### PR TITLE
fix: auto-propagate custom table names and use Web Crypto for edge runtime compatibility

### DIFF
--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -20,10 +20,11 @@
  * const backend = createPostgresBackend(db, { tables });
  * ```
  */
-import type { SQL } from "drizzle-orm";
+import { getTableName,type SQL } from "drizzle-orm";
 import { type PgDatabase } from "drizzle-orm/pg-core";
 
 import { UniquenessError } from "../../errors";
+import type { SqlTableNames } from "../../query/compiler/schema";
 import {
   type BackendCapabilities,
   type CheckUniqueParams,
@@ -271,6 +272,12 @@ export function createPostgresBackend(
 ): GraphBackend {
   const tables = options.tables ?? defaultTables;
 
+  const tableNames: SqlTableNames = {
+    nodes: getTableName(tables.nodes),
+    edges: getTableName(tables.edges),
+    embeddings: getTableName(tables.embeddings),
+  };
+
   /**
    * Execute a query and return all rows.
    */
@@ -300,6 +307,7 @@ export function createPostgresBackend(
   const backend: GraphBackend = {
     dialect: "postgres",
     capabilities: POSTGRES_VECTOR_CAPABILITIES,
+    tableNames,
 
     // === Node Operations ===
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -20,10 +20,11 @@
  * const backend = createSqliteBackend(db, { tables });
  * ```
  */
-import { type SQL,sql } from "drizzle-orm";
+import { getTableName, type SQL, sql } from "drizzle-orm";
 import { type BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
 import { ConfigurationError, UniquenessError } from "../../errors";
+import type { SqlTableNames } from "../../query/compiler/schema";
 import {
   type CheckUniqueParams,
   type CountEdgesByKindParams,
@@ -235,6 +236,12 @@ export function createSqliteBackend(
   const isD1 = isD1Database(db);
   const isSync = isSyncDatabase(db);
 
+  const tableNames: SqlTableNames = {
+    nodes: getTableName(tables.nodes),
+    edges: getTableName(tables.edges),
+    embeddings: getTableName(tables.embeddings),
+  };
+
   /**
    * Helper to execute a query and handle sync/async uniformly.
    */
@@ -257,6 +264,7 @@ export function createSqliteBackend(
   const backend: GraphBackend = {
     dialect: "sqlite",
     capabilities: isD1 ? D1_CAPABILITIES : SQLITE_CAPABILITIES,
+    tableNames,
 
     // === Node Operations ===
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -6,6 +6,8 @@
  */
 import { type SQL } from "drizzle-orm";
 
+import { type SqlTableNames } from "../query/compiler/schema";
+
 // ============================================================
 // Vector Search Types
 // ============================================================
@@ -348,6 +350,8 @@ export type GraphBackend = Readonly<{
   dialect: Dialect;
   /** Backend capabilities */
   capabilities: BackendCapabilities;
+  /** Table names used by this backend (for query schema auto-derivation) */
+  tableNames?: SqlTableNames | undefined;
 
   // === Node Operations ===
   insertNode: (params: InsertNodeParams) => Promise<NodeRow>;

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -257,6 +257,8 @@ export type {
   SelectContext,
   SortDirection,
   SqlDialect,
+  SqlSchema,
+  SqlTableNames,
   StreamOptions,
 } from "./query";
 
@@ -270,6 +272,9 @@ export {
   countDistinct,
   createFragment,
   createQueryBuilder,
+  // SQL schema configuration
+  createSqlSchema,
+  DEFAULT_SQL_SCHEMA,
   ExecutableAggregateQuery,
   ExecutableQuery,
   // Subquery predicates

--- a/packages/typegraph/src/query/index.ts
+++ b/packages/typegraph/src/query/index.ts
@@ -114,3 +114,11 @@ export { type DialectAdapter, getDialect, type SqlDialect } from "./dialect";
 
 // Compiler constants
 export { MAX_RECURSIVE_DEPTH } from "./compiler/index";
+
+// SQL schema configuration
+export {
+  createSqlSchema,
+  DEFAULT_SQL_SCHEMA,
+  type SqlSchema,
+  type SqlTableNames,
+} from "./compiler/schema";

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -91,7 +91,7 @@ export async function ensureSchema<G extends GraphDef>(
 
   // Quick hash check - if hashes match, schemas are identical
   const storedHash = activeSchema.schema_hash;
-  const currentHash = computeSchemaHash(currentSchema);
+  const currentHash = await computeSchemaHash(currentSchema);
 
   if (storedHash === currentHash) {
     return { status: "unchanged", version: activeSchema.version };
@@ -163,7 +163,7 @@ export async function initializeSchema<G extends GraphDef>(
   graph: G,
 ): Promise<SchemaVersionRow> {
   const schema = serializeSchema(graph, 1);
-  const hash = computeSchemaHash(schema);
+  const hash = await computeSchemaHash(schema);
 
   return backend.insertSchema({
     graphId: graph.id,
@@ -192,7 +192,7 @@ export async function migrateSchema<G extends GraphDef>(
 ): Promise<number> {
   const newVersion = currentVersion + 1;
   const schema = serializeSchema(graph, newVersion);
-  const hash = computeSchemaHash(schema);
+  const hash = await computeSchemaHash(schema);
 
   // Insert new version (not active yet)
   await backend.insertSchema({

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -11,6 +11,7 @@
 import { type GraphBackend } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
 import { createQueryBuilder, type QueryBuilder } from "../query/builder";
+import { createSqlSchema } from "../query/compiler/schema";
 import { buildKindRegistry, type KindRegistry } from "../registry";
 import { nowIso } from "../utils/date";
 import { generateId } from "../utils/id";
@@ -98,7 +99,9 @@ export class Store<G extends GraphDef> {
     this.#backend = backend;
     this.#registry = buildKindRegistry(graph);
     this.#hooks = options?.hooks ?? {};
-    this.#schema = options?.schema;
+    this.#schema =
+      options?.schema ??
+      (backend.tableNames ? createSqlSchema(backend.tableNames) : undefined);
   }
 
   // === Accessors ===

--- a/packages/typegraph/tests/custom-table-names.test.ts
+++ b/packages/typegraph/tests/custom-table-names.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Custom Table Names Regression Tests
+ *
+ * Verifies that custom table names configured on a backend propagate
+ * through to store.query() without requiring an explicit schema option.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createSqliteTables } from "../src/backend/drizzle/schema/sqlite";
+import type { GraphBackend } from "../src/backend/types";
+import { defineEdge, defineGraph, defineNode } from "../src/core";
+import { createSqlSchema } from "../src/query/compiler/schema";
+import { createStore } from "../src/store";
+import { createTestBackend } from "./test-utils";
+
+// ============================================================
+// Test Schema
+// ============================================================
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "custom_tables_test",
+  nodes: { Person: { type: Person } },
+  edges: {
+    knows: {
+      type: knows,
+      from: [Person],
+      to: [Person],
+      cardinality: "many",
+    },
+  },
+});
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("custom table names", () => {
+  const CUSTOM_NAMES = {
+    nodes: "app_nodes",
+    edges: "app_edges",
+    embeddings: "app_embeddings",
+  } as const;
+
+  let backend: GraphBackend;
+
+  beforeEach(() => {
+    const tables = createSqliteTables({
+      nodes: CUSTOM_NAMES.nodes,
+      edges: CUSTOM_NAMES.edges,
+      embeddings: CUSTOM_NAMES.embeddings,
+    });
+    backend = createTestBackend(tables);
+  });
+
+  it("exposes tableNames on the backend", () => {
+    expect(backend.tableNames).toEqual(CUSTOM_NAMES);
+  });
+
+  it("round-trips nodes through collection API and query builder", async () => {
+    const store = createStore(graph, backend);
+
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const bob = await store.nodes.Person.create({ name: "Bob" });
+
+    const results = await store
+      .query()
+      .from("Person", "p")
+      .select((context) => context.p)
+      .execute();
+
+    const names = results.map((r) => r.name).toSorted();
+    expect(names).toEqual(["Alice", "Bob"]);
+    expect(results).toHaveLength(2);
+
+    // Verify we can find specific nodes by ID
+    const aliceResult = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.id.eq(alice.id))
+      .select((context) => context.p)
+      .execute();
+
+    expect(aliceResult).toHaveLength(1);
+    expect(aliceResult[0]!.name).toBe("Alice");
+
+    void bob;
+  });
+
+  it("round-trips edges through collection API and query builder", async () => {
+    const store = createStore(graph, backend);
+
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const bob = await store.nodes.Person.create({ name: "Bob" });
+
+    await store.edges.knows.create(
+      { kind: "Person", id: alice.id },
+      { kind: "Person", id: bob.id },
+      { since: "2024" },
+    );
+
+    const results = await store
+      .query()
+      .from("Person", "p")
+      .traverse("knows", "e")
+      .to("Person", "friend")
+      .whereNode("p", (p) => p.id.eq(alice.id))
+      .select((context) => ({
+        person: context.p,
+        edge: context.e,
+        friend: context.friend,
+      }))
+      .execute();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.person.name).toBe("Alice");
+    expect(results[0]!.friend.name).toBe("Bob");
+    expect(results[0]!.edge.since).toBe("2024");
+  });
+
+  it("explicit schema option takes precedence over backend.tableNames", () => {
+    const explicitSchema = createSqlSchema({
+      nodes: "override_nodes",
+      edges: "override_edges",
+      embeddings: "override_embeddings",
+    });
+
+    const store = createStore(graph, backend, { schema: explicitSchema });
+
+    // The store's query builder should use the explicit schema, not the backend's tableNames.
+    // Backend retains its own tableNames.
+    expect(backend.tableNames).toEqual(CUSTOM_NAMES);
+
+    void store;
+  });
+
+  it("default table names propagate when no custom tables are specified", () => {
+    const defaultBackend = createTestBackend();
+
+    expect(defaultBackend.tableNames).toEqual({
+      nodes: "typegraph_nodes",
+      edges: "typegraph_edges",
+      embeddings: "typegraph_node_embeddings",
+    });
+  });
+});

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -459,14 +459,14 @@ describe("Schema Serialization Properties", () => {
   });
 
   describe("hash properties", () => {
-    it("hash is deterministic (same input produces same hash)", () => {
-      fc.assert(
-        fc.property(graphDefArb, versionArb, (graph, version) => {
+    it("hash is deterministic (same input produces same hash)", async () => {
+      await fc.assert(
+        fc.asyncProperty(graphDefArb, versionArb, async (graph, version) => {
           const serialized1 = serializeSchema(graph, version);
           const serialized2 = serializeSchema(graph, version);
 
-          const hash1 = computeSchemaHash(serialized1);
-          const hash2 = computeSchemaHash(serialized2);
+          const hash1 = await computeSchemaHash(serialized1);
+          const hash2 = await computeSchemaHash(serialized2);
 
           expect(hash1).toBe(hash2);
         }),
@@ -474,20 +474,20 @@ describe("Schema Serialization Properties", () => {
       );
     });
 
-    it("hash ignores version (only structure matters)", () => {
-      fc.assert(
-        fc.property(
+    it("hash ignores version (only structure matters)", async () => {
+      await fc.assert(
+        fc.asyncProperty(
           graphDefArb,
           versionArb,
           versionArb,
-          (graph, version1, version2) => {
+          async (graph, version1, version2) => {
             fc.pre(version1 !== version2);
 
             const serialized1 = serializeSchema(graph, version1);
             const serialized2 = serializeSchema(graph, version2);
 
-            const hash1 = computeSchemaHash(serialized1);
-            const hash2 = computeSchemaHash(serialized2);
+            const hash1 = await computeSchemaHash(serialized1);
+            const hash2 = await computeSchemaHash(serialized2);
 
             expect(hash1).toBe(hash2);
           },
@@ -496,13 +496,13 @@ describe("Schema Serialization Properties", () => {
       );
     });
 
-    it("hash changes when nodes are added", () => {
-      fc.assert(
-        fc.property(
+    it("hash changes when nodes are added", async () => {
+      await fc.assert(
+        fc.asyncProperty(
           graphDefArb,
           identifierArb,
           versionArb,
-          (graph, newNodeName, version) => {
+          async (graph, newNodeName, version) => {
             // Ensure new node name doesn't exist
             fc.pre(!Object.keys(graph.nodes).includes(newNodeName));
 
@@ -525,8 +525,8 @@ describe("Schema Serialization Properties", () => {
 
             const serialized2 = serializeSchema(extendedGraph, version);
 
-            const hash1 = computeSchemaHash(serialized1);
-            const hash2 = computeSchemaHash(serialized2);
+            const hash1 = await computeSchemaHash(serialized1);
+            const hash2 = await computeSchemaHash(serialized2);
 
             expect(hash1).not.toBe(hash2);
           },
@@ -535,11 +535,11 @@ describe("Schema Serialization Properties", () => {
       );
     });
 
-    it("hash is a 16-character hex string", () => {
-      fc.assert(
-        fc.property(graphDefArb, versionArb, (graph, version) => {
+    it("hash is a 16-character hex string", async () => {
+      await fc.assert(
+        fc.asyncProperty(graphDefArb, versionArb, async (graph, version) => {
           const serialized = serializeSchema(graph, version);
-          const hash = computeSchemaHash(serialized);
+          const hash = await computeSchemaHash(serialized);
 
           expect(hash).toMatch(/^[a-f0-9]{16}$/);
         }),

--- a/packages/typegraph/tests/schema-serialization.test.ts
+++ b/packages/typegraph/tests/schema-serialization.test.ts
@@ -291,7 +291,7 @@ describe("serializeSchema", () => {
 });
 
 describe("computeSchemaHash", () => {
-  it("produces consistent hashes for the same schema", () => {
+  it("produces consistent hashes for the same schema", async () => {
     const graph = defineGraph({
       id: "test_graph",
       nodes: { Person: { type: Person } },
@@ -301,13 +301,13 @@ describe("computeSchemaHash", () => {
     const serialized1 = serializeSchema(graph, 1);
     const serialized2 = serializeSchema(graph, 1);
 
-    const hash1 = computeSchemaHash(serialized1);
-    const hash2 = computeSchemaHash(serialized2);
+    const hash1 = await computeSchemaHash(serialized1);
+    const hash2 = await computeSchemaHash(serialized2);
 
     expect(hash1).toBe(hash2);
   });
 
-  it("ignores version and generatedAt for hashing", () => {
+  it("ignores version and generatedAt for hashing", async () => {
     const graph = defineGraph({
       id: "test_graph",
       nodes: { Person: { type: Person } },
@@ -317,13 +317,13 @@ describe("computeSchemaHash", () => {
     const serialized1 = serializeSchema(graph, 1);
     const serialized2 = serializeSchema(graph, 2);
 
-    const hash1 = computeSchemaHash(serialized1);
-    const hash2 = computeSchemaHash(serialized2);
+    const hash1 = await computeSchemaHash(serialized1);
+    const hash2 = await computeSchemaHash(serialized2);
 
     expect(hash1).toBe(hash2);
   });
 
-  it("produces different hashes for different schemas", () => {
+  it("produces different hashes for different schemas", async () => {
     const graph1 = defineGraph({
       id: "test_graph",
       nodes: { Person: { type: Person } },
@@ -336,8 +336,8 @@ describe("computeSchemaHash", () => {
       edges: {},
     });
 
-    const hash1 = computeSchemaHash(serializeSchema(graph1, 1));
-    const hash2 = computeSchemaHash(serializeSchema(graph2, 1));
+    const hash1 = await computeSchemaHash(serializeSchema(graph1, 1));
+    const hash2 = await computeSchemaHash(serializeSchema(graph2, 1));
 
     expect(hash1).not.toBe(hash2);
   });


### PR DESCRIPTION
- Add `tableNames` to `GraphBackend` interface so backends expose their configured table names to the query layer
- Auto-derive `SqlSchema` in Store constructor from `backend.tableNames` when no explicit `schema` option is provided, eliminating the need for users to manually keep backend tables and query schema in sync
- Replace `require("node:crypto")` in schema hashing with the Web Crypto API (`globalThis.crypto.subtle`), fixing "Dynamic require of crypto" errors in Cloudflare Workers and other edge runtimes
- Export `createSqlSchema`, `DEFAULT_SQL_SCHEMA`, `SqlSchema`, and `SqlTableNames` from the public API