### PR TITLE
Widen `AnyPgDatabase` schema generic to accept standard Drizzle instances

### DIFF
--- a/.changeset/fix-pg-schema-generic.md
+++ b/.changeset/fix-pg-schema-generic.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `AnyPgDatabase` type to accept standard Drizzle instances created without an explicit schema

--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -20,7 +20,7 @@ type PgClientCarrier = Readonly<{
   $client?: PgQueryClient;
 }>;
 
-export type AnyPgDatabase = PgDatabase<PgQueryResultHKT>;
+export type AnyPgDatabase = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 
 export type PostgresExecutionAdapter = SqlExecutionAdapter;
 


### PR DESCRIPTION
- Widens `AnyPgDatabase` type alias from `PgDatabase<PgQueryResultHKT>` (which defaults schema to `Record<string, never>`) to `PgDatabase<PgQueryResultHKT, Record<string, unknown>>`
  - Fixes TS2345 type error when passing a standard `drizzle()` instance (without explicit schema) to `createPostgresBackend`
  - Aligns Postgres type with the existing `AnySqliteDatabase` pattern in `sqlite-execution.ts`