### PR TITLE
feat: support unconstrained edges in defineGraph

### DIFF
--- a/.changeset/unconstrained-edges.md
+++ b/.changeset/unconstrained-edges.md
@@ -1,0 +1,11 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Support unconstrained edges in `defineGraph`.
+
+Edges defined without `from`/`to` constraints (e.g., `defineEdge("sameAs")`) can now be passed directly to `defineGraph` without an `EdgeRegistration` wrapper. They are automatically allowed to connect any node type in the graph to any other.
+
+- **`EdgeEntry` widened** — accepts any `EdgeType`, not just those with endpoints
+- **`NormalizedEdges`** — falls back to all graph node types when `from`/`to` are undefined
+- Constrained edges, `EdgeRegistration` wrappers, and narrowing validation are unchanged

--- a/apps/docs/src/content/docs/core-concepts.md
+++ b/apps/docs/src/content/docs/core-concepts.md
@@ -184,6 +184,40 @@ const knows = defineEdge("knows");
 // Equivalent to: defineEdge("knows", { schema: z.object({}) })
 ```
 
+#### Unconstrained Edges
+
+Edges defined without `from` and `to` are **unconstrained** — they can connect any
+node type to any node type. When used directly in `defineGraph`, they are automatically
+allowed for all node types in the graph:
+
+```typescript
+const sameAs = defineEdge("sameAs");
+const related = defineEdge("related", {
+  schema: z.object({ reason: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "my_graph",
+  nodes: {
+    Person: { type: Person },
+    Company: { type: Company },
+  },
+  edges: {
+    sameAs,     // any→any (Person↔Person, Person↔Company, Company↔Company)
+    related,    // any→any, with properties
+    worksAt: { type: worksAt, from: [Person], to: [Company] },  // constrained
+  },
+});
+
+// All of these work:
+await store.edges.sameAs.create(alice, bob, {});       // Person→Person
+await store.edges.sameAs.create(alice, acme, {});      // Person→Company
+await store.edges.sameAs.create(acme, alice, {});      // Company→Person
+```
+
+This is useful for semantic relationships like `sameAs`, `seeAlso`, `related`, or
+`tagged` that apply broadly across node types.
+
 #### Domain and Range Constraints
 
 Edges can include built-in domain (source types) and range (target types) constraints
@@ -207,13 +241,16 @@ const mentions = defineEdge("mentions", {
 });
 ```
 
-When an edge has `from` and `to` defined, you can use it directly in `defineGraph` without an `EdgeRegistration` wrapper:
+Any edge type can be used directly in `defineGraph` without an `EdgeRegistration`
+wrapper. Constrained edges use their built-in `from`/`to`; unconstrained edges
+allow all node types:
 
 ```typescript
 const graph = defineGraph({
   nodes: { Person: { type: Person }, Company: { type: Company } },
   edges: {
-    worksAt,  // Direct use - constraints come from the edge definition
+    worksAt,  // Constrained - uses built-in from/to
+    sameAs,   // Unconstrained - connects any node to any node
   },
 });
 ```

--- a/apps/docs/src/content/docs/getting-started.md
+++ b/apps/docs/src/content/docs/getting-started.md
@@ -204,6 +204,9 @@ const assignedTo = defineEdge("assignedTo", {
     assignedAt: z.string().optional(),
   }),
 });
+
+// Unconstrained edge — connects any node to any node
+const related = defineEdge("related");
 ```
 
 ### Step 3: Create the Graph Definition
@@ -224,6 +227,7 @@ const graph = defineGraph({
     worksOn: { type: worksOn, from: [Person], to: [Project] },
     hasTask: { type: hasTask, from: [Project], to: [Task] },
     assignedTo: { type: assignedTo, from: [Task], to: [Person] },
+    related,  // any→any
   },
   ontology: [
     // A Person cannot be a Project or Task

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -97,16 +97,35 @@ const worksAt = defineEdge("worksAt", {
   from: [Person],      // Domain: only Person can be the source
   to: [Company],       // Range: only Company can be the target
 });
+```
 
-// Edges with built-in constraints can be used directly in defineGraph
-const graph = defineGraph({
-  id: "my_graph",
-  nodes: { Person: { type: Person }, Company: { type: Company } },
-  edges: { worksAt },  // Direct use - no EdgeRegistration wrapper needed
+**Unconstrained Edges:**
+
+Edges without `from`/`to` are unconstrained — they can connect any node type to any node type:
+
+```typescript
+const sameAs = defineEdge("sameAs");
+const related = defineEdge("related", {
+  schema: z.object({ reason: z.string() }),
 });
 ```
 
-See [Schemas & Types](/core-concepts#domain-and-range-constraints) for detailed documentation on domain/range constraints.
+**Direct use in defineGraph:**
+
+Any edge type can be used directly in `defineGraph` without an `EdgeRegistration` wrapper:
+
+```typescript
+const graph = defineGraph({
+  id: "my_graph",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    worksAt,  // Constrained — uses built-in from/to
+    sameAs,   // Unconstrained — connects any node to any node
+  },
+});
+```
+
+See [Core Concepts](/core-concepts#domain-and-range-constraints) for detailed documentation on domain/range constraints.
 
 ### `embedding(dimensions)`
 
@@ -220,7 +239,7 @@ import { defineGraph } from "@nicia-ai/typegraph";
 function defineGraph<G extends GraphDef>(config: {
   id: string;
   nodes: Record<string, NodeRegistration>;
-  edges: Record<string, EdgeRegistration>;
+  edges: Record<string, EdgeRegistration | EdgeType>;
   ontology?: OntologyRelation[];
 }): G;
 ```
@@ -231,8 +250,14 @@ function defineGraph<G extends GraphDef>(config: {
 |-----------|------|-------------|
 | `id` | `string` | Unique identifier for this graph |
 | `nodes` | `Record<string, NodeRegistration>` | Node type registrations |
-| `edges` | `Record<string, EdgeRegistration>` | Edge type registrations with endpoint types |
+| `edges` | `Record<string, EdgeRegistration \| EdgeType>` | Edge registrations or edge types directly |
 | `ontology` | `OntologyRelation[]` | Optional semantic relationships |
+
+Edge entries can be:
+
+- **`EdgeRegistration`** — explicit `{ type, from, to }` with optional `cardinality`
+- **`EdgeType` with `from`/`to`** — uses built-in constraints
+- **`EdgeType` without `from`/`to`** — unconstrained, connects any node to any node
 
 **Example:**
 
@@ -250,6 +275,7 @@ const graph = defineGraph({
       to: [Company],
       cardinality: "many",
     },
+    sameAs,  // Unconstrained — any→any
   },
   ontology: [disjointWith(Person, Company)],
 });

--- a/packages/typegraph/src/core/define-graph.ts
+++ b/packages/typegraph/src/core/define-graph.ts
@@ -1,10 +1,12 @@
 import { ConfigurationError } from "../errors/index";
 import { type OntologyRelation } from "../ontology/types";
 import {
+  type AnyEdgeType,
   type DeleteBehavior,
   type EdgeRegistration,
   type EdgeTypeWithEndpoints,
   type GraphDefaults,
+  isEdgeType,
   isEdgeTypeWithEndpoints,
   type NodeRegistration,
   type NodeType,
@@ -25,21 +27,28 @@ const GRAPH_DEF_BRAND = "__graphDef" as const;
 /**
  * An edge entry in the graph definition.
  * Can be:
- * - EdgeType directly (if it has from/to defined)
+ * - EdgeType directly (constrained or unconstrained)
  * - EdgeRegistration object (always works, can override/narrow defaults)
  */
-type EdgeEntry = EdgeRegistration | EdgeTypeWithEndpoints;
+type EdgeEntry = EdgeRegistration | AnyEdgeType;
 
 /**
  * Normalized edge map type - all entries become EdgeRegistration.
+ * For bare EdgeTypes, constrained endpoints are extracted from the type;
+ * unconstrained edges fall back to all node types in the graph.
  */
-type NormalizedEdges<TEdges extends Record<string, EdgeEntry>> = {
+type NormalizedEdges<
+  TNodes extends Record<string, NodeRegistration>,
+  TEdges extends Record<string, EdgeEntry>,
+> = {
   [K in keyof TEdges]: TEdges[K] extends EdgeRegistration ? TEdges[K]
-  : TEdges[K] extends EdgeTypeWithEndpoints ?
+  : TEdges[K] extends AnyEdgeType ?
     EdgeRegistration<
       TEdges[K],
-      TEdges[K]["from"][number],
-      TEdges[K]["to"][number]
+      TEdges[K]["from"] extends readonly (infer N extends NodeType)[] ? N
+      : TNodes[keyof TNodes]["type"],
+      TEdges[K]["to"] extends readonly (infer N extends NodeType)[] ? N
+      : TNodes[keyof TNodes]["type"]
     >
   : never;
 };
@@ -97,17 +106,21 @@ function validateConstraintNarrowing(
 /**
  * Normalizes a single edge entry to EdgeRegistration.
  */
-function normalizeEdgeEntry(name: string, entry: EdgeEntry): EdgeRegistration {
-  if (isEdgeTypeWithEndpoints(entry)) {
-    // EdgeType with from/to - convert to EdgeRegistration
-    return {
-      type: entry,
-      from: entry.from,
-      to: entry.to,
-    };
+function normalizeEdgeEntry(
+  name: string,
+  entry: EdgeEntry,
+  allNodeTypes: readonly NodeType[],
+): EdgeRegistration {
+  if (isEdgeType(entry)) {
+    if (isEdgeTypeWithEndpoints(entry)) {
+      // EdgeType with from/to — convert to EdgeRegistration
+      return { type: entry, from: entry.from, to: entry.to };
+    }
+    // Unconstrained EdgeType — allow any→any
+    return { type: entry, from: allNodeTypes, to: allNodeTypes };
   }
 
-  // Already EdgeRegistration - validate narrowing if edge has built-in constraints
+  // Already EdgeRegistration — validate narrowing if edge has built-in constraints
   if (isEdgeTypeWithEndpoints(entry.type)) {
     validateConstraintNarrowing(name, entry.type, entry);
   }
@@ -120,10 +133,11 @@ function normalizeEdgeEntry(name: string, entry: EdgeEntry): EdgeRegistration {
  */
 function normalizeEdges(
   edges: Record<string, EdgeEntry>,
+  allNodeTypes: readonly NodeType[],
 ): Record<string, EdgeRegistration> {
   const result: Record<string, EdgeRegistration> = {};
   for (const [name, entry] of Object.entries(edges)) {
-    result[name] = normalizeEdgeEntry(name, entry);
+    result[name] = normalizeEdgeEntry(name, entry, allNodeTypes);
   }
   return result;
 }
@@ -271,13 +285,14 @@ export function defineGraph<
   const TOntology extends readonly OntologyRelation[],
 >(
   config: GraphDefConfig<TNodes, TEdges, TOntology>,
-): GraphDef<TNodes, NormalizedEdges<TEdges>, TOntology> {
+): GraphDef<TNodes, NormalizedEdges<TNodes, TEdges>, TOntology> {
   const defaults = {
     onNodeDelete: config.defaults?.onNodeDelete ?? "restrict",
     temporalMode: config.defaults?.temporalMode ?? "current",
   } as const;
 
-  const normalizedEdges = normalizeEdges(config.edges);
+  const allNodeTypes = Object.values(config.nodes).map((reg) => reg.type);
+  const normalizedEdges = normalizeEdges(config.edges, allNodeTypes);
 
   return Object.freeze({
     [GRAPH_DEF_BRAND]: true as const,
@@ -286,7 +301,7 @@ export function defineGraph<
     edges: normalizedEdges,
     ontology: config.ontology ?? ([] as unknown as TOntology),
     defaults,
-  }) as GraphDef<TNodes, NormalizedEdges<TEdges>, TOntology>;
+  }) as GraphDef<TNodes, NormalizedEdges<TNodes, TEdges>, TOntology>;
 }
 
 // ============================================================

--- a/packages/typegraph/tests/edge-domain-range.test.ts
+++ b/packages/typegraph/tests/edge-domain-range.test.ts
@@ -7,6 +7,8 @@ import {
   defineNode,
   isEdgeTypeWithEndpoints,
 } from "../src";
+import { createStore } from "../src/store";
+import { createTestBackend } from "./test-utils";
 
 describe("defineEdge() with domain/range", () => {
   const Person = defineNode("Person", {
@@ -240,6 +242,108 @@ describe("defineEdge() with domain/range", () => {
       });
 
       expect(graph.edges.worksAt.cardinality).toBe("one");
+    });
+  });
+
+  describe("unconstrained edges", () => {
+    it("allows bare EdgeType without from/to directly in defineGraph", () => {
+      const sameAs = defineEdge("sameAs");
+
+      const graph = defineGraph({
+        id: "test",
+        nodes: {
+          Person: { type: Person },
+          Company: { type: Company },
+        },
+        edges: { sameAs },
+      });
+
+      expect(graph.edges.sameAs.type).toBe(sameAs);
+      expect(graph.edges.sameAs.from).toContain(Person);
+      expect(graph.edges.sameAs.from).toContain(Company);
+      expect(graph.edges.sameAs.to).toContain(Person);
+      expect(graph.edges.sameAs.to).toContain(Company);
+    });
+
+    it("allows unconstrained edge with schema", () => {
+      const related = defineEdge("related", {
+        schema: z.object({ reason: z.string() }),
+      });
+
+      const graph = defineGraph({
+        id: "test",
+        nodes: {
+          Person: { type: Person },
+          Company: { type: Company },
+        },
+        edges: { related },
+      });
+
+      expect(graph.edges.related.type.schema).toBe(related.schema);
+      expect(graph.edges.related.from).toHaveLength(2);
+      expect(graph.edges.related.to).toHaveLength(2);
+    });
+
+    it("mixes constrained and unconstrained edges", () => {
+      const worksAt = defineEdge("worksAt", {
+        from: [Person],
+        to: [Company],
+      });
+      const sameAs = defineEdge("sameAs");
+
+      const graph = defineGraph({
+        id: "test",
+        nodes: {
+          Person: { type: Person },
+          Company: { type: Company },
+        },
+        edges: {
+          worksAt,
+          sameAs,
+        },
+      });
+
+      // Constrained edge: only Person→Company
+      expect(graph.edges.worksAt.from).toEqual([Person]);
+      expect(graph.edges.worksAt.to).toEqual([Company]);
+
+      // Unconstrained edge: any→any
+      expect(graph.edges.sameAs.from).toContain(Person);
+      expect(graph.edges.sameAs.from).toContain(Company);
+      expect(graph.edges.sameAs.to).toContain(Person);
+      expect(graph.edges.sameAs.to).toContain(Company);
+    });
+
+    it("works with store for cross-type edges", async () => {
+      const sameAs = defineEdge("sameAs");
+
+      const graph = defineGraph({
+        id: "test_unconstrained",
+        nodes: {
+          Person: { type: Person },
+          Company: { type: Company },
+        },
+        edges: { sameAs },
+      });
+
+      const backend = createTestBackend();
+      const store = createStore(graph, backend);
+
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+
+      // Person→Company
+      const edge1 = await store.edges.sameAs.create(alice, acme, {});
+      expect(edge1.id).toBeDefined();
+
+      // Company→Person
+      const edge2 = await store.edges.sameAs.create(acme, alice, {});
+      expect(edge2.id).toBeDefined();
+
+      // Person→Person
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const edge3 = await store.edges.sameAs.create(alice, bob, {});
+      expect(edge3.id).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
- Edges without `from`/`to` (e.g., `defineEdge("sameAs")`) can now be passed directly to `defineGraph` — they connect any node to any node
- `EdgeEntry` type widened from `EdgeRegistration | EdgeTypeWithEndpoints` to `EdgeRegistration | AnyEdgeType`
- `NormalizedEdges` falls back to all graph node types when `from`/`to` are undefined
- Constrained edges, `EdgeRegistration` wrappers, and narrowing validation are unchanged