### PR TITLE
feat!: add transactionMode to SQLite backend, fix Durable Object compatibility

### DIFF
--- a/.changeset/sqlite-transaction-mode.md
+++ b/.changeset/sqlite-transaction-mode.md
@@ -1,0 +1,17 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `transactionMode` to SQLite execution profile, fixing Cloudflare Durable Object compatibility.
+
+`createSqliteBackend` previously used raw `BEGIN`/`COMMIT`/`ROLLBACK` SQL for all sync SQLite drivers. This crashes on Cloudflare Durable Object SQLite (via `drizzle-orm/durable-sqlite`) because the driver does not support raw transaction SQL through `db.run()`.
+
+The new `transactionMode` option (`"sql"` | `"drizzle"` | `"none"`) controls how transactions are managed:
+
+- `"sql"` — TypeGraph issues `BEGIN`/`COMMIT`/`ROLLBACK` directly (default for better-sqlite3, bun:sqlite)
+- `"drizzle"` — delegates to Drizzle's `db.transaction()` (default for async drivers)
+- `"none"` — transactions disabled (default for D1 and Durable Objects)
+
+D1 and Durable Object sessions are auto-detected by Drizzle session name. Users can override via `executionProfile: { transactionMode: "..." }`.
+
+**Breaking:** `isD1` removed from `SqliteExecutionProfileHints` and `SqliteExecutionProfile`. Use `transactionMode: "none"` instead. `D1_CAPABILITIES` removed — capabilities are now derived from `transactionMode`.

--- a/packages/typegraph/src/backend/drizzle/execution/index.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/index.ts
@@ -9,6 +9,7 @@ export {
   type SqliteExecutionAdapter,
   type SqliteExecutionProfile,
   type SqliteExecutionProfileHints,
+  type SqliteTransactionMode,
 } from "./sqlite-execution";
 export {
   type CompiledSqlQuery,

--- a/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
@@ -35,9 +35,21 @@ type DatabaseWithSession = Readonly<{
   session?: SessionLike;
 }>;
 
+/**
+ * Controls how the backend manages SQLite transactions.
+ *
+ * - `"sql"`:     TypeGraph issues BEGIN / COMMIT / ROLLBACK SQL directly.
+ *                Default for sync drivers (better-sqlite3, bun:sqlite).
+ * - `"drizzle"`: Delegates to Drizzle's `db.transaction()` method.
+ *                Default for async drivers (libsql, sql.js).
+ * - `"none"`:    Transactions disabled.
+ *                Default for Cloudflare D1 and Durable Objects.
+ */
+export type SqliteTransactionMode = "sql" | "drizzle" | "none";
+
 export type SqliteExecutionProfileHints = Readonly<{
-  isD1?: boolean;
   isSync?: boolean;
+  transactionMode?: SqliteTransactionMode;
 }>;
 
 type SqliteExecutionAdapterOptions = Readonly<{
@@ -48,9 +60,9 @@ type SqliteExecutionAdapterOptions = Readonly<{
 export type AnySqliteDatabase = BaseSQLiteDatabase<"sync" | "async", unknown>;
 
 export type SqliteExecutionProfile = Readonly<{
-  isD1: boolean;
   isSync: boolean;
   supportsCompiledExecution: boolean;
+  transactionMode: SqliteTransactionMode;
 }>;
 
 export type SqliteExecutionAdapter = Readonly<
@@ -72,6 +84,11 @@ function getSessionName(db: AnySqliteDatabase): string | undefined {
 
 function isD1DatabaseBySessionName(db: AnySqliteDatabase): boolean {
   return getSessionName(db) === "SQLiteD1Session";
+}
+
+function isDurableObjectBySessionName(db: AnySqliteDatabase): boolean {
+  const sessionName = getSessionName(db);
+  return sessionName === "SQLiteDurableObjectSession";
 }
 
 function isSyncDatabaseBySessionName(db: AnySqliteDatabase): boolean {
@@ -105,15 +122,24 @@ function detectSyncProfile(
   }
 }
 
-function detectD1Profile(
+function detectTransactionMode(
   db: AnySqliteDatabase,
   profileHints: SqliteExecutionProfileHints,
-): boolean {
-  if (profileHints.isD1 !== undefined) {
-    return profileHints.isD1;
+  isSync: boolean,
+): SqliteTransactionMode {
+  if (profileHints.transactionMode !== undefined) {
+    return profileHints.transactionMode;
   }
-
-  return isD1DatabaseBySessionName(db);
+  // D1 and Durable Object SQLite do not support raw BEGIN/COMMIT SQL
+  // through Drizzle's db.run(). Default to "none" because async
+  // transaction callbacks are not reliably supported across sync
+  // Drizzle drivers. Users can opt in to "drizzle" mode explicitly if
+  // their runtime's db.transaction() handles async callbacks.
+  if (isD1DatabaseBySessionName(db) || isDurableObjectBySessionName(db)) {
+    return "none";
+  }
+  if (isSync) return "sql";
+  return "drizzle";
 }
 
 function resolveSqliteClient(
@@ -194,32 +220,21 @@ export function createSqliteExecutionAdapter(
     options.statementCacheMax ?? DEFAULT_PREPARED_STATEMENT_CACHE_MAX;
   const profileHints = options.profileHints ?? {};
 
-  const profileBase: Readonly<{
-    isD1: boolean;
-    isSync: boolean;
-    sqliteClient: SqliteClientWithPrepare | undefined;
-  }> = {
-    isD1: detectD1Profile(db, profileHints),
-    isSync: detectSyncProfile(db, profileHints),
-    sqliteClient: resolveSqliteClient(db),
-  };
-
-  const supportsCompiledExecution =
-    profileBase.isSync &&
-    !profileBase.isD1 &&
-    profileBase.sqliteClient !== undefined;
+  const isSync = detectSyncProfile(db, profileHints);
+  const sqliteClient = isSync ? resolveSqliteClient(db) : undefined;
+  const transactionMode = detectTransactionMode(db, profileHints, isSync);
 
   const profile: SqliteExecutionProfile = {
-    isD1: profileBase.isD1,
-    isSync: profileBase.isSync,
-    supportsCompiledExecution,
+    isSync,
+    supportsCompiledExecution: sqliteClient !== undefined,
+    transactionMode,
   };
 
   const compile = (query: SQL): CompiledSqlQuery =>
     compileQueryWithDialect(db, query, "SQLite");
 
-  if (supportsCompiledExecution) {
-    const sqliteClient = profileBase.sqliteClient;
+  if (sqliteClient !== undefined) {
+    const client = sqliteClient;
     const statementCache = new Map<string, PreparedAllStatement>();
 
     function executeCompiled<TRow>(
@@ -227,7 +242,7 @@ export function createSqliteExecutionAdapter(
     ): Promise<readonly TRow[]> {
       const preparedStatement = getOrCreatePreparedStatement(
         statementCache,
-        sqliteClient,
+        client,
         compiledQuery.sql,
         statementCacheMax,
       );
@@ -247,7 +262,7 @@ export function createSqliteExecutionAdapter(
       executeCompiled,
       prepare(sqlText: string): PreparedSqlStatement {
         return createPreparedStatementExecutor(
-          sqliteClient,
+          client,
           statementCache,
           sqlText,
           statementCacheMax,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -25,7 +25,6 @@ import { ConfigurationError } from "../../errors";
 import type { SqlTableNames } from "../../query/compiler/schema";
 import {
   type CreateVectorIndexParams,
-  D1_CAPABILITIES,
   type DropVectorIndexParams,
   type GraphBackend,
   SQLITE_CAPABILITIES,
@@ -38,6 +37,7 @@ import {
   type SqliteExecutionAdapter,
   type SqliteExecutionProfileHints,
 } from "./execution/sqlite-execution";
+export type { SqliteTransactionMode } from "./execution/sqlite-execution";
 import { createCommonOperationBackend } from "./operation-backend-core";
 import { createSqliteOperationStrategy } from "./operations/strategy";
 import {
@@ -70,7 +70,8 @@ export type SqliteBackendOptions = Readonly<{
   tables?: SqliteTables;
   /**
    * Optional execution profile hints used to avoid runtime driver reflection.
-   * Set `isD1: true` when using Cloudflare D1.
+   * Set `transactionMode: "none"` for drivers that do not support transactions
+   * (e.g. Cloudflare D1, Durable Objects).
    */
   executionProfile?: SqliteExecutionProfileHints;
 }>;
@@ -302,8 +303,11 @@ export function createSqliteBackend(
   const tables = options.tables ?? defaultTables;
   const profileHints = options.executionProfile ?? {};
   const executionAdapter = createSqliteExecutionAdapter(db, { profileHints });
-  const { isD1, isSync } = executionAdapter.profile;
-  const capabilities = isD1 ? D1_CAPABILITIES : SQLITE_CAPABILITIES;
+  const { isSync, transactionMode } = executionAdapter.profile;
+  const capabilities =
+    transactionMode === "none"
+      ? { ...SQLITE_CAPABILITIES, transactions: false }
+      : SQLITE_CAPABILITIES;
 
   const tableNames: SqlTableNames = {
     nodes: getTableName(tables.nodes),
@@ -334,28 +338,28 @@ export function createSqliteBackend(
       fn: (tx: TransactionBackend) => Promise<T>,
       _options?: TransactionOptions,
     ): Promise<T> {
-      if (isD1) {
+      if (transactionMode === "none") {
         throw new ConfigurationError(
-          "Cloudflare D1 does not support atomic transactions. " +
+          "This SQLite backend does not support atomic transactions. " +
             "Operations within a transaction are not rolled back on failure. " +
             "Use backend.capabilities.transactions to check for transaction support, " +
             "or use individual operations with manual error handling.",
           {
-            backend: "D1",
+            backend: "sqlite",
             capability: "transactions",
             supportsTransactions: false,
           },
         );
       }
 
-      if (isSync) {
+      if (transactionMode === "sql") {
         return runWithSerializedQueue(serializedQueue, async () => {
           const txBackend = createTransactionBackend({
             capabilities,
             db,
             executionAdapter,
             operationStrategy,
-            profileHints: { isD1: false, isSync: true },
+            profileHints: { isSync: true },
             tableNames,
           });
           db.run(sql`BEGIN`);
@@ -371,16 +375,19 @@ export function createSqliteBackend(
         });
       }
 
-      return db.transaction(async (tx) => {
-        const txBackend = createTransactionBackend({
-          capabilities,
-          db: tx as AnySqliteDatabase,
-          operationStrategy,
-          profileHints: { isD1: false, isSync: false },
-          tableNames,
-        });
-        return fn(txBackend);
-      }) as Promise<T>;
+      // transactionMode === "drizzle"
+      return runWithSerializedQueue(serializedQueue, async () =>
+        db.transaction(async (tx) => {
+          const txBackend = createTransactionBackend({
+            capabilities,
+            db: tx as AnySqliteDatabase,
+            operationStrategy,
+            profileHints: { isSync },
+            tableNames,
+          });
+          return fn(txBackend);
+        }) as Promise<T>,
+      );
     },
 
     async close(): Promise<void> {

--- a/packages/typegraph/src/backend/sqlite/index.ts
+++ b/packages/typegraph/src/backend/sqlite/index.ts
@@ -28,6 +28,7 @@ export {
   type SqliteBackendOptions,
   type SqliteTableNames,
   type SqliteTables,
+  type SqliteTransactionMode,
   tables,
 } from "../drizzle/sqlite";
 

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -175,7 +175,6 @@ export function createLocalSqliteBackend(
 
   const backend = createSqliteBackend(db, {
     executionProfile: {
-      isD1: false,
       isSync: true,
     },
     tables,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -664,16 +664,3 @@ export const POSTGRES_CAPABILITIES: BackendCapabilities = {
   returning: true,
   transactions: true, // PostgreSQL supports transactions
 };
-
-/**
- * Capabilities for Cloudflare D1.
- * D1 does NOT support atomic transactions - operations are auto-committed.
- */
-export const D1_CAPABILITIES: BackendCapabilities = {
-  jsonb: false, // D1 uses TEXT with json functions
-  partialIndexes: true,
-  ginIndexes: false,
-  cte: true,
-  returning: true,
-  transactions: false, // D1 does NOT support atomic transactions
-};

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -432,6 +432,73 @@ describe("Store with SQLite Backend", () => {
 });
 
 // ============================================================
+// Transaction Mode Tests
+// ============================================================
+
+describe("SQLite Backend - Transaction Modes", () => {
+  let db: BetterSQLite3Database;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+  });
+
+  it("defaults to 'raw' transaction mode for better-sqlite3", () => {
+    const backend = createSqliteBackend(db);
+    expect(backend.capabilities.transactions).toBe(true);
+  });
+
+  it("throws ConfigurationError when transactionMode is 'none'", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { transactionMode: "none" },
+    });
+    expect(backend.capabilities.transactions).toBe(false);
+
+    await expect(backend.transaction(() => Promise.resolve())).rejects.toThrow(
+      /does not support atomic transactions/,
+    );
+  });
+
+  it("includes backend label in 'none' mode error", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { transactionMode: "none" },
+    });
+
+    await expect(backend.transaction(() => Promise.resolve())).rejects.toThrow(
+      /This SQLite backend does not support/,
+    );
+  });
+
+  it("allows explicit transactionMode 'raw' to override auto-detection", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { transactionMode: "sql" },
+    });
+    expect(backend.capabilities.transactions).toBe(true);
+
+    const store = createStore(testGraph, backend);
+    const person = await store.transaction(async (tx) => {
+      return tx.nodes.Person.create({ name: "Bob" });
+    });
+    expect(person.name).toBe("Bob");
+  });
+
+  // Note: transactionMode "drizzle" cannot be tested with better-sqlite3 because
+  // its native .transaction() rejects async callbacks. The "drizzle" path is
+  // intended for async drivers (libsql, sql.js) and potentially Durable Objects.
+  it("attempts Drizzle transaction when transactionMode is 'drizzle'", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { transactionMode: "drizzle" },
+    });
+    expect(backend.capabilities.transactions).toBe(true);
+
+    // better-sqlite3 rejects async callbacks in db.transaction(), so this
+    // verifies the "drizzle" path is reached (not the "sql" BEGIN/COMMIT path).
+    await expect(backend.transaction(() => Promise.resolve())).rejects.toThrow(
+      /cannot return a promise/i,
+    );
+  });
+});
+
+// ============================================================
 // Vector Search Integration Tests (sqlite-vec)
 // ============================================================
 

--- a/packages/typegraph/tests/execution-adapter.test.ts
+++ b/packages/typegraph/tests/execution-adapter.test.ts
@@ -133,14 +133,47 @@ describe("sqlite execution adapter", () => {
     const db = createTestDatabase();
     const adapter = createSqliteExecutionAdapter(db as AnySqliteDatabase, {
       profileHints: {
-        isD1: true,
         isSync: false,
+        transactionMode: "none",
       },
     });
 
-    expect(adapter.profile.isD1).toBe(true);
     expect(adapter.profile.isSync).toBe(false);
     expect(adapter.profile.supportsCompiledExecution).toBe(false);
+    expect(adapter.profile.transactionMode).toBe("none");
+  });
+
+  describe("transactionMode detection", () => {
+    it("defaults to 'raw' for better-sqlite3", () => {
+      const db = createTestDatabase();
+      const adapter = createSqliteExecutionAdapter(db as AnySqliteDatabase);
+      expect(adapter.profile.transactionMode).toBe("sql");
+    });
+
+    it("respects explicit transactionMode hint", () => {
+      const db = createTestDatabase();
+      const adapter = createSqliteExecutionAdapter(db as AnySqliteDatabase, {
+        profileHints: { transactionMode: "drizzle" },
+      });
+      expect(adapter.profile.transactionMode).toBe("drizzle");
+    });
+
+    it("explicit transactionMode overrides session-based auto-detection", () => {
+      const db = createTestDatabase();
+      // better-sqlite3 would normally auto-detect as "sql", but explicit hint wins
+      const adapter = createSqliteExecutionAdapter(db as AnySqliteDatabase, {
+        profileHints: { transactionMode: "none" },
+      });
+      expect(adapter.profile.transactionMode).toBe("none");
+    });
+
+    it("defaults to 'drizzle' for async drivers", () => {
+      const db = createTestDatabase();
+      const adapter = createSqliteExecutionAdapter(db as AnySqliteDatabase, {
+        profileHints: { isSync: false },
+      });
+      expect(adapter.profile.transactionMode).toBe("drizzle");
+    });
   });
 });
 


### PR DESCRIPTION
- Fixes `createSqliteBackend` crashing with `DrizzleError: Failed to run the query 'BEGIN'` when used with `drizzle-orm/durable-sqlite` (Cloudflare Durable Objects)
- Replaces the `isD1` flag with `transactionMode: "sql" | "drizzle" | "none"` — an explicit, composable control over how the backend manages transactions
- Auto-detects D1 and Durable Object sessions by Drizzle session name; users can override via `executionProfile: { transactionMode: "..." }`

### Breaking changes

- `isD1` removed from `SqliteExecutionProfileHints` and `SqliteExecutionProfile` — use `transactionMode: "none"` instead
- `D1_CAPABILITIES` removed — capabilities are now derived from `transactionMode`