### PR TITLE
fix: chunk bulk constraint queries to respect SQL bind parameter limits

### DIFF
--- a/.changeset/fix-bulk-constraint-bind-limit.md
+++ b/.changeset/fix-bulk-constraint-bind-limit.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `checkUniqueBatch` exceeding SQL bind parameter limit on SQLite/D1/Durable Objects.
+
+Bulk constraint operations (`bulkGetOrCreateByConstraint`, `bulkFindByConstraint`) passed all keys in a single `IN (...)` clause. With hundreds of unique keys, this exceeded SQLite's 999 bind parameter limit, causing `SQLITE_ERROR: too many SQL variables`.
+
+The fix chunks the keys array in `checkUniqueBatch` using the same pattern already used by `getNodes`, `insertNodesBatch`, and other batch operations. SQLite chunks at 996 keys per query (999 max − 3 fixed params), PostgreSQL at 65,532.

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -76,6 +76,7 @@ type OperationBackendExecution = Readonly<{
 }>;
 
 type OperationBackendBatchConfig = Readonly<{
+  checkUniqueBatchChunkSize: number;
   edgeInsertBatchSize: number;
   getEdgesChunkSize: number;
   getNodesChunkSize: number;
@@ -390,9 +391,13 @@ export function createCommonOperationBackend(
       params: CheckUniqueBatchParams,
     ): Promise<readonly UniqueRow[]> {
       if (params.keys.length === 0) return [];
-      const query = operationStrategy.buildCheckUniqueBatch(params);
-      const rows = await execution.execAll<Record<string, unknown>>(query);
-      return rows.map((row) => rowMappers.toUniqueRow(row));
+      const allRows: UniqueRow[] = [];
+      for (const chunk of chunkArray(params.keys, batchConfig.checkUniqueBatchChunkSize)) {
+        const query = operationStrategy.buildCheckUniqueBatch({ ...params, keys: chunk });
+        const rows = await execution.execAll<Record<string, unknown>>(query);
+        allRows.push(...rows.map((row) => rowMappers.toUniqueRow(row)));
+      }
+      return allRows;
     },
 
     async getActiveSchema(

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -97,6 +97,11 @@ const POSTGRES_GET_EDGES_ID_CHUNK_SIZE = Math.max(
   1,
   POSTGRES_MAX_BIND_PARAMETERS - 1,
 );
+const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
+const POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE = Math.max(
+  1,
+  POSTGRES_MAX_BIND_PARAMETERS - CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT,
+);
 
 // ============================================================
 // Utilities
@@ -262,6 +267,7 @@ function createPostgresOperationBackend(
 
   const commonBackend = createCommonOperationBackend({
     batchConfig: {
+      checkUniqueBatchChunkSize: POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE,
       edgeInsertBatchSize: POSTGRES_EDGE_INSERT_BATCH_SIZE,
       getEdgesChunkSize: POSTGRES_GET_EDGES_ID_CHUNK_SIZE,
       getNodesChunkSize: POSTGRES_GET_NODES_ID_CHUNK_SIZE,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -95,6 +95,11 @@ const SQLITE_GET_EDGES_ID_CHUNK_SIZE = Math.max(
   1,
   SQLITE_MAX_BIND_PARAMETERS - 1,
 );
+const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
+const SQLITE_CHECK_UNIQUE_BATCH_CHUNK_SIZE = Math.max(
+  1,
+  SQLITE_MAX_BIND_PARAMETERS - CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT,
+);
 
 type SerializedExecutionQueue = Readonly<{
   runExclusive: <T>(task: () => Promise<T>) => Promise<T>;
@@ -199,6 +204,7 @@ function createSqliteOperationBackend(
 
   const commonBackend = createCommonOperationBackend({
     batchConfig: {
+      checkUniqueBatchChunkSize: SQLITE_CHECK_UNIQUE_BATCH_CHUNK_SIZE,
       edgeInsertBatchSize: SQLITE_EDGE_INSERT_BATCH_SIZE,
       getEdgesChunkSize: SQLITE_GET_EDGES_ID_CHUNK_SIZE,
       getNodesChunkSize: SQLITE_GET_NODES_ID_CHUNK_SIZE,

--- a/packages/typegraph/tests/find-by-constraint.test.ts
+++ b/packages/typegraph/tests/find-by-constraint.test.ts
@@ -174,6 +174,36 @@ describe("store.nodes.*.bulkFindByConstraint()", () => {
     expect(results[0]).toBeUndefined();
   });
 
+  it("handles batch larger than bind parameter limit", async () => {
+    const store = createStore(graph, backend);
+    const BATCH_SIZE = 1200;
+
+    const items = Array.from({ length: BATCH_SIZE }, (_, index) => ({
+      props: { email: `user${index}@example.com`, name: `User ${index}` },
+    }));
+
+    // Pre-create a subset so we get mixed found/not-found
+    const preCreated = await store.nodes.Person.bulkGetOrCreateByConstraint(
+      "email",
+      items.slice(0, 100),
+    );
+    expect(preCreated).toHaveLength(100);
+
+    const results = await store.nodes.Person.bulkFindByConstraint(
+      "email",
+      items,
+    );
+
+    expect(results).toHaveLength(BATCH_SIZE);
+    for (let index = 0; index < 100; index++) {
+      expect(results[index]).toBeDefined();
+      expect(results[index]!.email).toBe(`user${index}@example.com`);
+    }
+    for (let index = 100; index < BATCH_SIZE; index++) {
+      expect(results[index]).toBeUndefined();
+    }
+  });
+
   it("deduplicates within-batch lookups", async () => {
     const store = createStore(graph, backend);
     await store.nodes.Person.create({

--- a/packages/typegraph/tests/find-or-create.test.ts
+++ b/packages/typegraph/tests/find-or-create.test.ts
@@ -322,6 +322,37 @@ describe("store.nodes.*.bulkGetOrCreateByConstraint()", () => {
     expect(results[0]!.node.meta.deletedAt).toBeUndefined();
   });
 
+  it("handles batch larger than bind parameter limit", async () => {
+    const store = createStore(graph, backend);
+    const BATCH_SIZE = 1200;
+
+    const items = Array.from({ length: BATCH_SIZE }, (_, index) => ({
+      props: { entityType: "Person", name: `Entity ${index}` },
+    }));
+
+    const results = await store.nodes.Entity.bulkGetOrCreateByConstraint(
+      "entity_key",
+      items,
+    );
+
+    expect(results).toHaveLength(BATCH_SIZE);
+    for (const result of results) {
+      expect(result.action).toBe("created");
+    }
+
+    // Verify idempotency across the chunk boundary
+    const again = await store.nodes.Entity.bulkGetOrCreateByConstraint(
+      "entity_key",
+      items,
+    );
+
+    expect(again).toHaveLength(BATCH_SIZE);
+    for (let index = 0; index < BATCH_SIZE; index++) {
+      expect(again[index]!.action).toBe("found");
+      expect(again[index]!.node.id).toBe(results[index]!.node.id);
+    }
+  });
+
   it("throws NodeConstraintNotFoundError for invalid constraint name", async () => {
     const store = createStore(graph, backend);
 


### PR DESCRIPTION
- `checkUniqueBatch` passed all keys in a single `IN (...)` clause with no chunking, exceeding SQLite's 999 bind parameter limit with large batches
- Added chunking using the same `chunkArray` pattern already used by `getNodes`, `insertNodesBatch`, etc.
- SQLite: 996 keys per query (999 max − 3 fixed params), PostgreSQL: 65,532 keys per query

Closes #22 