### PR TITLE
fix: paginate drops id from selective queries, orderBy mishandles system fields

### DIFF
--- a/.changeset/fix-paginate-system-fields.md
+++ b/.changeset/fix-paginate-system-fields.md
@@ -1,0 +1,11 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `.paginate()` dropping `id` from selective query results and `orderBy()` mishandling system fields.
+
+- **Fix silent data loss in `.paginate()` + `.select()`**: `FieldAccessTracker.record()` no longer allows a system field (`id`, `kind`) to be downgraded to a props field, which caused the SQL projection to extract from `props->>'id'` (nonexistent) instead of the `id` column.
+- **Fix `orderBy()` for system fields**: `orderBy("alias", "id")` now emits `ORDER BY cte.alias_id` instead of `ORDER BY json_extract(cte.alias_props, '$.id')`.
+- **Add `gt`/`gte`/`lt`/`lte` to `StringFieldAccessor`**: Enables keyset cursor pagination via `whereNode("a", (a) => a.id.lt(cursor))`.
+
+Fixes #40.

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -32,6 +32,7 @@ import {
   mapResults,
   mapSelectiveResults,
   MissingSelectiveFieldError,
+  nullToUndefined,
   transformPathColumns,
 } from "../execution";
 import { jsonPointer, parseJsonPointer } from "../json-pointer";
@@ -777,6 +778,18 @@ export class ExecutableQuery<
   #recordOrderByFieldsForPagination(tracker: FieldAccessTracker): boolean {
     for (const spec of this.#state.orderBy) {
       const field = spec.field;
+
+      // System field (e.g., id, kind) — path is ["id"] or ["kind"]
+      if (
+        field.path.length === 1 &&
+        field.path[0] !== "props" &&
+        field.jsonPointer === undefined
+      ) {
+        tracker.record(field.alias, field.path[0]!, true);
+        continue;
+      }
+
+      // Props field — path is ["props"] with a JSON pointer
       if (field.path.length !== 1 || field.path[0] !== "props") {
         return false;
       }
@@ -832,8 +845,23 @@ export class ExecutableQuery<
     for (const spec of this.#state.orderBy) {
       const alias = spec.field.alias;
       const jsonPointer = spec.field.jsonPointer;
+
+      // System field order spec (e.g., path=["id"], no jsonPointer)
       if (jsonPointer === undefined) {
-        throw new MissingSelectiveFieldError(alias, "orderBy");
+        if (spec.field.path.length !== 1) {
+          throw new MissingSelectiveFieldError(alias, "orderBy");
+        }
+        const fieldName = spec.field.path[0]!;
+        const outputName = outputNameByAliasField.get(
+          `${alias}\u0000${fieldName}`,
+        );
+        if (outputName === undefined) {
+          throw new MissingSelectiveFieldError(alias, fieldName);
+        }
+
+        const aliasObject = this.#getOrCreateAliasObject(cursorContext, alias);
+        aliasObject[fieldName] = nullToUndefined(row[outputName]);
+        continue;
       }
 
       const segments = parseJsonPointer(jsonPointer);
@@ -860,14 +888,7 @@ export class ExecutableQuery<
         }
       }
 
-      let aliasObject: Record<string, unknown>;
-      const existing = cursorContext[alias];
-      if (typeof existing === "object" && existing !== null) {
-        aliasObject = existing as Record<string, unknown>;
-      } else {
-        aliasObject = {};
-        cursorContext[alias] = aliasObject;
-      }
+      const aliasObject = this.#getOrCreateAliasObject(cursorContext, alias);
 
       const kindNames = this.#getNodeKindNamesForAlias(alias);
       const typeInfo =
@@ -901,6 +922,19 @@ export class ExecutableQuery<
     }
 
     return cursorContext;
+  }
+
+  #getOrCreateAliasObject(
+    cursorContext: Record<string, unknown>,
+    alias: string,
+  ): Record<string, unknown> {
+    const existing = cursorContext[alias];
+    if (typeof existing === "object" && existing !== null) {
+      return existing as Record<string, unknown>;
+    }
+    const created: Record<string, unknown> = {};
+    cursorContext[alias] = created;
+    return created;
   }
 
   #getNodeKindNamesForAlias(alias: string): readonly string[] | undefined {

--- a/packages/typegraph/src/query/builder/query-builder.ts
+++ b/packages/typegraph/src/query/builder/query-builder.ts
@@ -633,20 +633,23 @@ export class QueryBuilder<
     field: string,
     direction: SortDirection = "asc",
   ): QueryBuilder<G, Aliases, EdgeAliases, RecursiveAliases> {
-    const kindNames = this.#getKindNamesForAlias(alias);
+    const isSystem = field === "id" || field === "kind";
     const typeInfo =
-      kindNames ?
-        this.#config.schemaIntrospector.getSharedFieldTypeInfo(kindNames, field)
-      : undefined;
-
-    const orderSpec: OrderSpec = {
-      field: fieldRef(alias, ["props"], {
-        jsonPointer: jsonPointer([field]),
-        valueType: typeInfo?.valueType,
-        elementType: typeInfo?.elementType,
-      }),
-      direction,
-    };
+      isSystem ? undefined : this.#getOrderByTypeInfo(alias, field);
+    const orderSpec: OrderSpec =
+      isSystem ?
+        {
+          field: fieldRef(alias, [field], { valueType: "string" }),
+          direction,
+        }
+      : {
+          field: fieldRef(alias, ["props"], {
+            jsonPointer: jsonPointer([field]),
+            valueType: typeInfo?.valueType,
+            elementType: typeInfo?.elementType,
+          }),
+          direction,
+        };
 
     const newState: QueryBuilderState = {
       ...this.#state,
@@ -654,6 +657,13 @@ export class QueryBuilder<
     };
 
     return new QueryBuilder(this.#config, newState);
+  }
+
+  #getOrderByTypeInfo(alias: string, field: string): FieldTypeInfo | undefined {
+    const kindNames = this.#getKindNamesForAlias(alias);
+    return kindNames ?
+        this.#config.schemaIntrospector.getSharedFieldTypeInfo(kindNames, field)
+      : undefined;
   }
 
   /**

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -205,6 +205,10 @@ export type BaseFieldAccessor = Readonly<{
 
 export type StringFieldAccessor = BaseFieldAccessor &
   Readonly<{
+    gt: (value: string | ParameterRef) => Predicate;
+    gte: (value: string | ParameterRef) => Predicate;
+    lt: (value: string | ParameterRef) => Predicate;
+    lte: (value: string | ParameterRef) => Predicate;
     contains: (pattern: string | ParameterRef) => Predicate;
     startsWith: (pattern: string | ParameterRef) => Predicate;
     endsWith: (pattern: string | ParameterRef) => Predicate;

--- a/packages/typegraph/src/query/execution/field-tracker.ts
+++ b/packages/typegraph/src/query/execution/field-tracker.ts
@@ -60,6 +60,13 @@ export class FieldAccessTracker {
 
   record(alias: string, field: string, isSystemField: boolean): void {
     const key = `${alias}\u0000${field}`;
+    const existing = this.#fields.get(key);
+    // System fields (id, kind) are dedicated columns — not in the props JSON.
+    // Never downgrade a system field to a props field, as that would cause the
+    // compiler to emit props->>'id' (nonexistent) instead of the id column.
+    if (existing !== undefined && existing.isSystemField && !isSystemField) {
+      return;
+    }
     this.#fields.set(key, { alias, field, isSystemField });
   }
 

--- a/packages/typegraph/src/query/predicates.ts
+++ b/packages/typegraph/src/query/predicates.ts
@@ -152,6 +152,10 @@ type BaseFieldBuilder = Readonly<{
  */
 type StringFieldBuilder = BaseFieldBuilder &
   Readonly<{
+    gt: (value: string | ParameterRef) => Predicate;
+    gte: (value: string | ParameterRef) => Predicate;
+    lt: (value: string | ParameterRef) => Predicate;
+    lte: (value: string | ParameterRef) => Predicate;
     contains: (pattern: string | ParameterRef) => Predicate;
     startsWith: (pattern: string | ParameterRef) => Predicate;
     endsWith: (pattern: string | ParameterRef) => Predicate;
@@ -515,6 +519,10 @@ function baseFieldBuilder(field: FieldRef): BaseFieldBuilder {
 export function stringField(field: FieldRef): StringFieldBuilder {
   return {
     ...baseFieldBuilder(field),
+    gt: (value) => comparison("gt", field, value),
+    gte: (value) => comparison("gte", field, value),
+    lt: (value) => comparison("lt", field, value),
+    lte: (value) => comparison("lte", field, value),
     contains: (pattern) => stringOp("contains", field, pattern),
     startsWith: (pattern) => stringOp("startsWith", field, pattern),
     endsWith: (pattern) => stringOp("endsWith", field, pattern),

--- a/packages/typegraph/tests/smart-select.test.ts
+++ b/packages/typegraph/tests/smart-select.test.ts
@@ -169,6 +169,34 @@ describe("FieldAccessTracker", () => {
       isSystemField: false,
     });
   });
+
+  it("preserves isSystemField when re-recorded as non-system", () => {
+    const tracker = new FieldAccessTracker();
+    tracker.record("a", "id", true);
+    tracker.record("a", "id", false);
+
+    const fields = tracker.getAccessedFields();
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toEqual({
+      alias: "a",
+      field: "id",
+      isSystemField: true,
+    });
+  });
+
+  it("upgrades non-system field to system field", () => {
+    const tracker = new FieldAccessTracker();
+    tracker.record("a", "id", false);
+    tracker.record("a", "id", true);
+
+    const fields = tracker.getAccessedFields();
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toEqual({
+      alias: "a",
+      field: "id",
+      isSystemField: true,
+    });
+  });
 });
 
 describe("createTrackingContext", () => {
@@ -511,5 +539,124 @@ describe("Smart Select Integration", () => {
     // Full fetch projection includes the props blob.
     const { sql } = sqlToStrings(getLastQuery()!);
     expect(sql).toContain('AS "p_props"');
+  });
+
+  it("preserves id system field in selective paginate results", async () => {
+    const page = await store
+      .query()
+      .from("Person", "p")
+      .orderBy("p", "name", "asc")
+      .select((ctx) => ({
+        id: ctx.p.id,
+        name: ctx.p.name,
+      }))
+      .paginate({ first: 10 });
+
+    expect(page.data).toHaveLength(2);
+    expect(page.data[0]!.name).toBe("Alice");
+    expect(page.data[0]!.id).toBe(aliceId);
+    expect(page.data[1]!.id).toBeDefined();
+    expect(typeof page.data[1]!.id).toBe("string");
+
+    const { sql } = sqlToStrings(getLastQuery()!);
+    expect(sql).toContain('AS "p_id"');
+    expect(sql).not.toContain('AS "p_props"');
+  });
+
+  it("orders by system field id correctly in paginate", async () => {
+    const page = await store
+      .query()
+      .from("Person", "p")
+      .orderBy("p", "id", "asc")
+      .select((ctx) => ({
+        id: ctx.p.id,
+        name: ctx.p.name,
+      }))
+      .paginate({ first: 10 });
+
+    expect(page.data).toHaveLength(2);
+    expect(page.data[0]!.id).toBeDefined();
+    expect(page.data[1]!.id).toBeDefined();
+    expect(page.data[0]!.id).not.toBe(page.data[1]!.id);
+
+    const { sql } = sqlToStrings(getLastQuery()!);
+    expect(sql).not.toContain('AS "p_props"');
+  });
+
+  it("orders by system field id correctly in execute", async () => {
+    const results = await store
+      .query()
+      .from("Person", "p")
+      .orderBy("p", "id", "asc")
+      .select((ctx) => ({
+        id: ctx.p.id,
+        name: ctx.p.name,
+      }))
+      .execute();
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.id).toBeDefined();
+    expect(results[1]!.id).toBeDefined();
+    // Verify ordering is by actual id column, not props->'id'
+    expect(results[0]!.id < results[1]!.id).toBe(true);
+  });
+
+  it("supports string comparison operators on id field", async () => {
+    const allResults = await store
+      .query()
+      .from("Person", "p")
+      .orderBy("p", "id", "asc")
+      .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
+      .execute();
+
+    expect(allResults).toHaveLength(2);
+    const firstId = allResults[0]!.id;
+
+    const gtResults = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.id.gt(firstId))
+      .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
+      .execute();
+
+    expect(gtResults).toHaveLength(1);
+    expect(gtResults[0]!.id > firstId).toBe(true);
+
+    const lteResults = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.id.lte(firstId))
+      .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
+      .execute();
+
+    expect(lteResults).toHaveLength(1);
+    expect(lteResults[0]!.id).toBe(firstId);
+  });
+
+  it("supports cursor pagination with orderBy id", async () => {
+    await store.nodes.Person.create({ name: "Charlie", age: 35 });
+
+    const page1 = await store
+      .query()
+      .from("Person", "p")
+      .orderBy("p", "id", "asc")
+      .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
+      .paginate({ first: 2 });
+
+    expect(page1.data).toHaveLength(2);
+    expect(page1.hasNextPage).toBe(true);
+    expect(page1.nextCursor).toBeDefined();
+
+    const page2 = await store
+      .query()
+      .from("Person", "p")
+      .orderBy("p", "id", "asc")
+      .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
+      .paginate({ first: 2, after: page1.nextCursor! });
+
+    expect(page2.data).toHaveLength(1);
+    expect(page2.hasNextPage).toBe(false);
+    // Page 2 id must be greater than all page 1 ids
+    expect(page2.data[0]!.id > page1.data[1]!.id).toBe(true);
   });
 });


### PR DESCRIPTION
- **Fix silent data loss in `.paginate()` + `.select()`**: `FieldAccessTracker.record()` no longer allows a system field (`id`, `kind`) to be downgraded to a props field when
  `#recordOrderByFieldsForPagination` re-records it, which caused the SQL projection to extract from `props->>'id'` (nonexistent) instead of the `id` column.
- **Fix `orderBy()` for system fields**: `orderBy("alias", "id")` now emits `ORDER BY cte.alias_id` instead of `ORDER BY json_extract(cte.alias_props, '$.id')`. Also updated
`#buildCursorContextFromSelectiveRow` to handle system field order specs for cursor construction.
- **Add `gt`/`gte`/`lt`/`lte` to `StringFieldAccessor`**: Enables keyset cursor pagination via `whereNode("a", (a) => a.id.lt(cursor))`.

Fixes #40