### PR TITLE
docs: query strategy guide for subgraph vs traversal

### DIFF
--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -309,6 +309,14 @@ Best for: API endpoints, hot loops, or any code path that runs the same query sh
 
 See [Prepared Queries](/queries/execute#prepared-queries) for usage details.
 
+### Subgraph extraction
+
+For the "load entity with all relationships" pattern, [`store.subgraph()`](/schemas-stores#subgraph-extraction)
+is the fastest strategy. It compiles to a single recursive CTE that fans out across all specified
+edge types in one round trip — no matter how many relationship kinds are involved. See
+[Choosing a query strategy](/schemas-stores#choosing-a-query-strategy) for guidance on when to use
+`subgraph()` vs the fluent query builder vs manual `findFrom` calls.
+
 ## Best Practices
 
 ### Filter early

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1145,6 +1145,27 @@ const neighborhood = await store.subgraph(skill.id, {
 });
 ```
 
+#### Choosing a query strategy
+
+TypeGraph offers several ways to load related data. The right choice depends on your access pattern:
+
+| Pattern | Best strategy | Why |
+|---------|--------------|-----|
+| Load entity with all relationships | `subgraph(maxDepth: 1)` | Single SQL round trip — fans out across all edge types in one recursive CTE |
+| Load entity with deep chain | `subgraph(maxDepth: N)` | Recursive CTE handles multi-hop in one query |
+| Filter/sort within a relationship | `.query().traverse()` | Fluent query supports WHERE/ORDER/LIMIT on target nodes |
+| Check if an edge exists | `edges.X.findFrom()` | Lightweight — no node resolution needed |
+| Traverse + resolve one edge type | `edges.X.findFrom()` + `nodes.X.getByIds()` | Two queries, simple and explicit |
+
+**Key insight:** `subgraph()` issues a single SQL statement regardless of how many edge types it
+traverses. Parallel `findFrom` calls scale linearly in round trips — one per edge type, plus
+additional queries for node resolution. The gap widens as relationship count grows.
+
+For the common "load an entity and everything it touches" pattern (detail pages, config hydration,
+template instantiation), `subgraph()` with `maxDepth: 1` is the fastest approach. Reserve the
+fluent query builder for cases where you need filtering, sorting, or pagination on the related
+nodes.
+
 ### Query Builder
 
 #### `store.query()`


### PR DESCRIPTION
- Adds a "Choosing a query strategy" section to the subgraph docs (`schemas-stores.md`) with a comparison table: subgraph vs fluent traversal vs manual findFrom, with guidance on when each is appropriate
- Adds a callout in the performance overview pointing users to subgraph as the preferred pattern for "load entity with all relationships"

Motivated by benchmarking that showed `subgraph()` is ~39% faster than parallel `findFrom` for multi-relationship loads due to single round-trip CTE compilation. The docs focus on the durable architectural insight (round-trip count) rather than hardware-specific numbers.