### PR TITLE
feat: add field-level projection to store.subgraph()

### DIFF
--- a/.changeset/feat-subgraph-projection.md
+++ b/.changeset/feat-subgraph-projection.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add field-level projection to `store.subgraph()` via a declarative `project` option.
+
+- **Declarative field selection**: Specify which properties to keep per node/edge kind. Projected nodes always retain `kind` and `id`; projected edges always retain structural endpoint fields. Kinds omitted from `project` remain fully hydrated.
+- **SQL-level extraction**: Projected property fields are extracted via `json_extract()` / JSONB path expressions directly in the query, avoiding full `props` blob transfer for projected kinds.
+- **All-or-nothing metadata**: Include `"meta"` in the field list for the full metadata object, or omit it entirely. No partial metadata selection — the struct is small enough that subsetting adds complexity without meaningful savings.
+- **`defineSubgraphProject()` helper**: Curried identity function that preserves literal types for reusable projection configs. Without it, storing a projection in a variable widens field arrays to `string[]`, defeating compile-time narrowing.
+- **Type-safe results**: Result types narrow per-kind based on the projection — accessing omitted fields is a compile-time error. Works through both inline literals and `defineSubgraphProject()`.
+
+```typescript
+const result = await store.subgraph(rootId, {
+  edges: ["has_task", "uses_skill"],
+  maxDepth: 2,
+  project: {
+    nodes: {
+      Task: ["title", "meta"],
+      Skill: ["name"],
+    },
+    edges: {
+      uses_skill: ["priority"],
+    },
+  },
+});
+// result.nodes — Task has { kind, id, title, meta }; Skill has { kind, id, name }
+// result.edges — uses_skill has { id, kind, fromKind, fromId, toKind, toId, priority }
+```
+
+Closes #46 (alternative implementation — declarative arrays instead of callbacks).

--- a/packages/benchmarks/src/config.ts
+++ b/packages/benchmarks/src/config.ts
@@ -2,6 +2,8 @@ export const BENCHMARK_CONFIG = {
   userCount: 1200,
   followsPerUser: 10,
   postsPerUser: 5,
+  userBioBytes: 1024,
+  postBodyBytes: 4096,
   batchSize: 250,
   warmupIterations: 2,
   sampleIterations: 15,
@@ -93,6 +95,12 @@ export type QueryMetrics = Readonly<{
   aggregateDistinctMs: number;
   cachedExecuteMs: number;
   preparedExecuteMs: number;
+  subgraphFullMs: number;
+  subgraphApplicationProjectionMs: number;
+  subgraphSqlProjectionMs: number;
+  subgraphStressFullMs: number;
+  subgraphStressApplicationProjectionMs: number;
+  subgraphStressSqlProjectionMs: number;
   tenHopMs: number;
   recursiveHundredHopMs: number;
   recursiveThousandHopMs: number;
@@ -102,12 +110,14 @@ export type UserSeed = Readonly<{
   id: string;
   name: string;
   city: string;
+  bio: string;
 }>;
 
 export type PostSeed = Readonly<{
   id: string;
   authorId: string;
   title: string;
+  body: string;
 }>;
 
 export type FollowSeed = Readonly<{

--- a/packages/benchmarks/src/graph.ts
+++ b/packages/benchmarks/src/graph.ts
@@ -11,12 +11,14 @@ const User = defineNode("User", {
   schema: z.object({
     name: z.string(),
     city: z.string(),
+    bio: z.string(),
   }),
 });
 
 const Post = defineNode("Post", {
   schema: z.object({
     title: z.string(),
+    body: z.string(),
   }),
 });
 

--- a/packages/benchmarks/src/guardrails.ts
+++ b/packages/benchmarks/src/guardrails.ts
@@ -184,6 +184,30 @@ export function printSummary(metrics: QueryMetrics): void {
     metrics.preparedExecuteMs,
     metrics.cachedExecuteMs,
   );
+  const subgraphApplicationToFull = safeRatio(
+    metrics.subgraphApplicationProjectionMs,
+    metrics.subgraphFullMs,
+  );
+  const subgraphSqlToFull = safeRatio(
+    metrics.subgraphSqlProjectionMs,
+    metrics.subgraphFullMs,
+  );
+  const subgraphSqlToApplication = safeRatio(
+    metrics.subgraphSqlProjectionMs,
+    metrics.subgraphApplicationProjectionMs,
+  );
+  const subgraphStressApplicationToFull = safeRatio(
+    metrics.subgraphStressApplicationProjectionMs,
+    metrics.subgraphStressFullMs,
+  );
+  const subgraphStressSqlToFull = safeRatio(
+    metrics.subgraphStressSqlProjectionMs,
+    metrics.subgraphStressFullMs,
+  );
+  const subgraphStressSqlToApplication = safeRatio(
+    metrics.subgraphStressSqlProjectionMs,
+    metrics.subgraphStressApplicationProjectionMs,
+  );
   const recursiveHundredToTenHop = safeRatio(
     metrics.recursiveHundredHopMs,
     metrics.tenHopMs,
@@ -200,6 +224,22 @@ export function printSummary(metrics: QueryMetrics): void {
     `aggregateDistinct/aggregate: ${aggregateDistinctToAggregate.toFixed(2)}x`,
   );
   console.log(`prepared/cached: ${preparedToCached.toFixed(2)}x`);
+  console.log(
+    `subgraph-app-projection/full: ${subgraphApplicationToFull.toFixed(2)}x`,
+  );
+  console.log(`subgraph-sql/full: ${subgraphSqlToFull.toFixed(2)}x`);
+  console.log(
+    `subgraph-sql/app-projection: ${subgraphSqlToApplication.toFixed(2)}x`,
+  );
+  console.log(
+    `subgraph-stress-app-projection/full: ${subgraphStressApplicationToFull.toFixed(2)}x`,
+  );
+  console.log(
+    `subgraph-stress-sql/full: ${subgraphStressSqlToFull.toFixed(2)}x`,
+  );
+  console.log(
+    `subgraph-stress-sql/app-projection: ${subgraphStressSqlToApplication.toFixed(2)}x`,
+  );
   console.log(
     `100-hop-recursive/10-hop-recursive: ${recursiveHundredToTenHop.toFixed(2)}x`,
   );

--- a/packages/benchmarks/src/measurements.ts
+++ b/packages/benchmarks/src/measurements.ts
@@ -4,6 +4,61 @@ import { BENCHMARK_CONFIG, type QueryMetrics } from "./config";
 import { type PerfStore } from "./graph";
 import { formatMs, median, nowMs } from "./utils";
 
+type FullSubgraphResult = Readonly<{
+  nodes: readonly (
+    | Readonly<{
+        kind: "User";
+        id: string;
+        name: string;
+        city: string;
+        bio: string;
+      }>
+    | Readonly<{
+        kind: "Post";
+        id: string;
+        title: string;
+        body: string;
+      }>
+  )[];
+  edges: readonly Readonly<{
+    id: string;
+    kind: "follows" | "authored";
+    fromId: string;
+    toId: string;
+  }>[];
+}>;
+
+type ProjectedSubgraphResult = Readonly<{
+  nodes: readonly (
+    | Readonly<{ kind: "User"; id: string; name: string }>
+    | Readonly<{ kind: "Post"; id: string; title: string }>
+  )[];
+  edges: readonly Readonly<{
+    id: string;
+    kind: "follows" | "authored";
+    fromId: string;
+    toId: string;
+  }>[];
+}>;
+
+type BenchmarkSubgraphOptions = Readonly<{
+  edges: readonly ("follows" | "authored")[];
+  maxDepth: number;
+  includeKinds: readonly ("User" | "Post")[];
+}>;
+
+const SUBGRAPH_BASELINE_OPTIONS = {
+  edges: ["follows", "authored"],
+  maxDepth: 2,
+  includeKinds: ["User", "Post"],
+} as const satisfies BenchmarkSubgraphOptions;
+
+const SUBGRAPH_STRESS_OPTIONS = {
+  edges: ["follows", "authored"],
+  maxDepth: 3,
+  includeKinds: ["User", "Post"],
+} as const satisfies BenchmarkSubgraphOptions;
+
 async function benchmarkQuery(
   label: string,
   fn: () => Promise<void>,
@@ -30,6 +85,82 @@ async function benchmarkQuery(
   const result = median(samples);
   console.log(`${label}: ${formatMs(result)}`);
   return result;
+}
+
+function consumeSubgraphCounts(
+  result: Readonly<{
+    nodes: readonly Readonly<{ kind: string; id: string }>[];
+    edges: readonly Readonly<{ id: string; fromId: string; toId: string }>[];
+  }>,
+): number {
+  let checksum = 0;
+
+  for (const node of result.nodes) {
+    checksum += node.id.length + node.kind.length;
+  }
+
+  for (const edge of result.edges) {
+    checksum += edge.id.length + edge.fromId.length + edge.toId.length;
+  }
+
+  return checksum;
+}
+
+function projectSubgraphInApplication(result: FullSubgraphResult): number {
+  let checksum = 0;
+
+  for (const node of result.nodes) {
+    if (node.kind === "User") {
+      checksum += node.id.length + node.name.length;
+      continue;
+    }
+
+    if (node.kind === "Post") {
+      checksum += node.id.length + node.title.length;
+    }
+  }
+
+  for (const edge of result.edges) {
+    checksum += edge.id.length + edge.fromId.length + edge.toId.length;
+  }
+
+  return checksum;
+}
+
+function consumeProjectedSubgraph(result: ProjectedSubgraphResult): number {
+  let checksum = 0;
+
+  for (const node of result.nodes) {
+    if (node.kind === "User") {
+      checksum += node.id.length + node.name.length;
+      continue;
+    }
+
+    checksum += node.id.length + node.title.length;
+  }
+
+  for (const edge of result.edges) {
+    checksum += edge.id.length + edge.fromId.length + edge.toId.length;
+  }
+
+  return checksum;
+}
+
+function assertNonEmptyChecksum(label: string, checksum: number): void {
+  if (checksum <= 0) {
+    throw new Error(`${label} produced an empty checksum`);
+  }
+}
+
+async function logSubgraphShape(
+  store: PerfStore,
+  label: string,
+  options: BenchmarkSubgraphOptions,
+): Promise<void> {
+  const result = await store.subgraph("user_0" as never, options);
+  console.log(
+    `${label}: ${result.nodes.length} nodes, ${result.edges.length} edges`,
+  );
 }
 
 export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
@@ -72,6 +203,126 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     "prepared execute",
     async () => {
       await preparedExecuteQuery.execute({ userId: "user_0" });
+    },
+  );
+
+  await logSubgraphShape(
+    store,
+    "subgraph baseline shape (wide payload, depth 2)",
+    SUBGRAPH_BASELINE_OPTIONS,
+  );
+
+  const subgraphFullMs = await benchmarkQuery(
+    "subgraph full hydration (wide payload, depth 2)",
+    async () => {
+      const result = await store.subgraph(
+        "user_0" as never,
+        SUBGRAPH_BASELINE_OPTIONS,
+      );
+
+      assertNonEmptyChecksum(
+        "subgraph full hydration",
+        consumeSubgraphCounts(result),
+      );
+    },
+  );
+
+  const subgraphApplicationProjectionMs = await benchmarkQuery(
+    "subgraph full hydration + app projection (wide payload, depth 2)",
+    async () => {
+      const result = await store.subgraph(
+        "user_0" as never,
+        SUBGRAPH_BASELINE_OPTIONS,
+      );
+
+      assertNonEmptyChecksum(
+        "subgraph app projection",
+        projectSubgraphInApplication(result),
+      );
+    },
+  );
+
+  const subgraphSqlProjectionMs = await benchmarkQuery(
+    "subgraph SQL projection (wide payload, depth 2)",
+    async () => {
+      const result = await store.subgraph("user_0" as never, {
+        ...SUBGRAPH_BASELINE_OPTIONS,
+        project: {
+          nodes: {
+            User: ["name"],
+            Post: ["title"],
+          },
+          edges: {
+            follows: [],
+            authored: [],
+          },
+        },
+      });
+
+      assertNonEmptyChecksum(
+        "subgraph SQL projection",
+        consumeProjectedSubgraph(result),
+      );
+    },
+  );
+
+  await logSubgraphShape(
+    store,
+    "subgraph stress shape (wide payload, depth 3)",
+    SUBGRAPH_STRESS_OPTIONS,
+  );
+
+  const subgraphStressFullMs = await benchmarkQuery(
+    "subgraph full hydration (wide payload, depth 3 stress)",
+    async () => {
+      const result = await store.subgraph(
+        "user_0" as never,
+        SUBGRAPH_STRESS_OPTIONS,
+      );
+
+      assertNonEmptyChecksum(
+        "subgraph stress full hydration",
+        consumeSubgraphCounts(result),
+      );
+    },
+  );
+
+  const subgraphStressApplicationProjectionMs = await benchmarkQuery(
+    "subgraph full hydration + app projection (wide payload, depth 3 stress)",
+    async () => {
+      const result = await store.subgraph(
+        "user_0" as never,
+        SUBGRAPH_STRESS_OPTIONS,
+      );
+
+      assertNonEmptyChecksum(
+        "subgraph stress app projection",
+        projectSubgraphInApplication(result),
+      );
+    },
+  );
+
+  const subgraphStressSqlProjectionMs = await benchmarkQuery(
+    "subgraph SQL projection (wide payload, depth 3 stress)",
+    async () => {
+      const result = await store.subgraph("user_0" as never, {
+        ...SUBGRAPH_STRESS_OPTIONS,
+        project: {
+          nodes: {
+            User: ["name"],
+            Post: ["title"],
+          },
+          edges: {
+            follows: [],
+            authored: [],
+          },
+        },
+      });
+
+      assertNonEmptyChecksum(
+        "subgraph stress SQL projection",
+        consumeProjectedSubgraph(result),
+      );
     },
   );
 
@@ -239,6 +490,12 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     aggregateDistinctMs,
     cachedExecuteMs,
     preparedExecuteMs,
+    subgraphFullMs,
+    subgraphApplicationProjectionMs,
+    subgraphSqlProjectionMs,
+    subgraphStressFullMs,
+    subgraphStressApplicationProjectionMs,
+    subgraphStressSqlProjectionMs,
     tenHopMs,
     recursiveHundredHopMs,
     recursiveThousandHopMs,

--- a/packages/benchmarks/src/seed.ts
+++ b/packages/benchmarks/src/seed.ts
@@ -18,11 +18,17 @@ function createRng(seed_: number): () => number {
   };
 }
 
+function buildPayload(prefix: string, bytes: number): string {
+  const chunk = `${prefix}|`;
+  return chunk.repeat(Math.ceil(bytes / chunk.length)).slice(0, bytes);
+}
+
 function buildUsers(): readonly UserSeed[] {
   return Array.from({ length: BENCHMARK_CONFIG.userCount }, (_, index) => ({
     id: `user_${index}`,
     name: `User ${index}`,
     city: index % 3 === 0 ? "San Francisco" : "New York",
+    bio: buildPayload(`bio_${index}`, BENCHMARK_CONFIG.userBioBytes),
   }));
 }
 
@@ -39,6 +45,10 @@ function buildPosts(users: readonly UserSeed[]): readonly PostSeed[] {
         id: `post_${user.id}_${postIndex}`,
         authorId: user.id,
         title: `Post ${user.id} ${postIndex}`,
+        body: buildPayload(
+          `body_${user.id}_${postIndex}`,
+          BENCHMARK_CONFIG.postBodyBytes,
+        ),
       });
     }
   }
@@ -113,6 +123,7 @@ async function ingestUsers(
         props: {
           name: user.name,
           city: user.city,
+          bio: user.bio,
         },
       })),
     );
@@ -135,6 +146,7 @@ async function ingestPosts(
         id: post.id,
         props: {
           title: post.title,
+          body: post.body,
         },
       })),
     );

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -202,6 +202,7 @@ export type {
   SubsetEdge,
   SubsetNode,
 } from "./store/subgraph";
+export { defineSubgraphProject } from "./store/subgraph";
 export type {
   ConstraintNames,
   CreateEdgeInput,

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -36,6 +36,7 @@ export type {
   SubsetEdge,
   SubsetNode,
 } from "./subgraph";
+export { defineSubgraphProject } from "./subgraph";
 
 // Store
 export type { SchemaManagerOptions, SchemaValidationResult } from "./store";

--- a/packages/typegraph/src/store/reserved-keys.ts
+++ b/packages/typegraph/src/store/reserved-keys.ts
@@ -1,0 +1,80 @@
+/**
+ * Reserved Keys for Store Entities
+ *
+ * Structural keys that cannot be overwritten by user-defined properties.
+ * Shared across row-mappers, subgraph projection, and schema validation.
+ */
+import { ConfigurationError } from "../errors";
+
+export const RESERVED_NODE_KEYS: ReadonlySet<string> = new Set([
+  "id",
+  "kind",
+  "meta",
+]);
+
+export const RESERVED_EDGE_KEYS: ReadonlySet<string> = new Set([
+  "id",
+  "kind",
+  "meta",
+  "fromKind",
+  "fromId",
+  "toKind",
+  "toId",
+]);
+
+const PROTOTYPE_POLLUTION_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+/**
+ * Validates that a projection field name is safe to assign onto a result object.
+ * Rejects reserved structural keys and prototype-pollution vectors.
+ *
+ * @throws ConfigurationError if the field is reserved or dangerous
+ */
+export function validateProjectionField(
+  field: string,
+  entityType: "node" | "edge",
+  kind: string,
+): void {
+  const reserved =
+    entityType === "node" ? RESERVED_NODE_KEYS : RESERVED_EDGE_KEYS;
+
+  if (reserved.has(field)) {
+    throw new ConfigurationError(
+      `Projection field "${field}" on ${entityType} kind "${kind}" conflicts with a reserved structural key`,
+      { field, kind, entityType, reservedKeys: [...reserved] },
+      {
+        suggestion: `Remove "${field}" from the projection. Structural fields (${[...reserved].join(", ")}) are included automatically when relevant.`,
+      },
+    );
+  }
+
+  if (PROTOTYPE_POLLUTION_KEYS.has(field)) {
+    throw new ConfigurationError(
+      `Projection field "${field}" on ${entityType} kind "${kind}" is not allowed`,
+      { field, kind, entityType },
+      {
+        suggestion: `"${field}" cannot be used as a projection field name.`,
+      },
+    );
+  }
+}
+
+/**
+ * Filters out reserved keys from a props object to prevent runtime collisions.
+ */
+export function filterReservedKeys(
+  props: Record<string, unknown>,
+  reservedKeys: ReadonlySet<string>,
+): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (!reservedKeys.has(key)) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+}

--- a/packages/typegraph/src/store/row-mappers.ts
+++ b/packages/typegraph/src/store/row-mappers.ts
@@ -7,7 +7,12 @@ import {
   type EdgeRow as BackendEdgeRow,
   type NodeRow as BackendNodeRow,
 } from "../backend/types";
-import { type Edge, type Node } from "./types";
+import {
+  filterReservedKeys,
+  RESERVED_EDGE_KEYS,
+  RESERVED_NODE_KEYS,
+} from "./reserved-keys";
+import { type Edge, type EdgeMeta, type Node, type NodeMeta } from "./types";
 
 /**
  * Raw node row from database (without graph_id).
@@ -21,31 +26,12 @@ export type NodeRow = Omit<BackendNodeRow, "graph_id">;
  */
 export type EdgeRow = Omit<BackendEdgeRow, "graph_id">;
 
-// Reserved keys that cannot be overwritten by user props
-const RESERVED_NODE_KEYS = new Set(["id", "kind", "meta"]);
-
 /**
  * Converts null to undefined for consistent typing.
  * Database backends return null for missing values, but our types use undefined.
  */
 function nullToUndefined<T>(value: T | null | undefined): T | undefined {
   return value === null ? undefined : value;
-}
-
-/**
- * Filters out reserved keys from props to prevent runtime collisions.
- */
-function filterReservedKeys(
-  props: Record<string, unknown>,
-  reservedKeys: Set<string>,
-): Record<string, unknown> {
-  const filtered: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(props)) {
-    if (!reservedKeys.has(key)) {
-      filtered[key] = value;
-    }
-  }
-  return filtered;
 }
 
 /**
@@ -61,28 +47,31 @@ export function rowToNode(row: NodeRow): Node {
   return {
     kind: row.kind,
     id: row.id as Node["id"],
-    meta: {
-      version: row.version,
-      validFrom: nullToUndefined(row.valid_from),
-      validTo: nullToUndefined(row.valid_to),
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-      deletedAt: nullToUndefined(row.deleted_at),
-    },
+    meta: rowToNodeMeta(row),
     ...props,
   } as Node;
 }
 
-// Reserved keys that cannot be overwritten by user props on edges
-const RESERVED_EDGE_KEYS = new Set([
-  "id",
-  "kind",
-  "meta",
-  "fromKind",
-  "fromId",
-  "toKind",
-  "toId",
-]);
+export function rowToNodeMeta(
+  row: Pick<
+    NodeRow,
+    | "version"
+    | "valid_from"
+    | "valid_to"
+    | "created_at"
+    | "updated_at"
+    | "deleted_at"
+  >,
+): NodeMeta {
+  return {
+    version: row.version,
+    validFrom: nullToUndefined(row.valid_from),
+    validTo: nullToUndefined(row.valid_to),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: nullToUndefined(row.deleted_at),
+  };
+}
 
 /**
  * Transforms a database row into a typed Edge object.
@@ -101,13 +90,22 @@ export function rowToEdge(row: EdgeRow): Edge {
     fromId: row.from_id,
     toKind: row.to_kind,
     toId: row.to_id,
-    meta: {
-      validFrom: nullToUndefined(row.valid_from),
-      validTo: nullToUndefined(row.valid_to),
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-      deletedAt: nullToUndefined(row.deleted_at),
-    },
+    meta: rowToEdgeMeta(row),
     ...props,
   } as Edge;
+}
+
+export function rowToEdgeMeta(
+  row: Pick<
+    EdgeRow,
+    "valid_from" | "valid_to" | "created_at" | "updated_at" | "deleted_at"
+  >,
+): EdgeMeta {
+  return {
+    validFrom: nullToUndefined(row.valid_from),
+    validTo: nullToUndefined(row.valid_to),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: nullToUndefined(row.deleted_at),
+  };
 }

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -58,6 +58,7 @@ import { rowToEdge, rowToNode } from "./row-mappers";
 import {
   executeSubgraph,
   type SubgraphOptions,
+  type SubgraphProject,
   type SubgraphResult,
 } from "./subgraph";
 import {
@@ -422,11 +423,13 @@ export class Store<G extends GraphDef> {
   async subgraph<
     const EK extends EdgeKinds<G>,
     const NK extends NodeKinds<G> = NodeKinds<G>,
+    const P extends SubgraphProject<G, NK, EK> | undefined = undefined,
   >(
     rootId: NodeId<AllNodeTypes<G>>,
-    options: SubgraphOptions<G, EK, NK>,
-  ): Promise<SubgraphResult<G, NK, EK>> {
+    options: SubgraphOptions<G, EK, NK, P>,
+  ): Promise<SubgraphResult<G, NK, EK, P>> {
     return executeSubgraph({
+      graph: this.#graph,
       graphId: this.graphId,
       rootId,
       backend: this.#backend,

--- a/packages/typegraph/src/store/subgraph.ts
+++ b/packages/typegraph/src/store/subgraph.ts
@@ -14,25 +14,104 @@ import type {
   GraphDef,
   NodeKinds,
 } from "../core/define-graph";
-import type { NodeId } from "../core/types";
+import type { AnyEdgeType, NodeId, NodeType } from "../core/types";
 import type { RecursiveCyclePolicy } from "../query/ast";
 import { compileKindFilter } from "../query/compiler/predicate-utils";
 import { MAX_RECURSIVE_DEPTH } from "../query/compiler/recursive";
 import { DEFAULT_SQL_SCHEMA, type SqlSchema } from "../query/compiler/schema";
+import { compileTypedJsonExtract } from "../query/compiler/typed-json-extract";
+import { quoteIdentifier } from "../query/compiler/utils";
 import type { DialectAdapter } from "../query/dialect/types";
+import { decodeSelectedValue } from "../query/execution/value-decoder";
+import { jsonPointer } from "../query/json-pointer";
+import {
+  createSchemaIntrospector,
+  type FieldTypeInfo,
+  type SchemaIntrospector,
+} from "../query/schema-introspector";
+import { validateProjectionField } from "./reserved-keys";
 import {
   type EdgeRow,
   type NodeRow,
   rowToEdge,
+  rowToEdgeMeta,
   rowToNode,
+  rowToNodeMeta,
 } from "./row-mappers";
-import type { Edge, Node } from "./types";
+import type { Edge, EdgeMeta, Node, NodeMeta } from "./types";
 
 // ============================================================
 // Constants
 // ============================================================
 
 const DEFAULT_SUBGRAPH_MAX_DEPTH = 10;
+
+/**
+ * PostgreSQL truncates identifiers longer than 63 bytes.
+ * Column aliases must stay under this limit to avoid silent mismatches.
+ */
+const MAX_PG_IDENTIFIER_LENGTH = 63;
+
+/**
+ * FNV-1a hash, base-36 encoded. Deterministic and fast.
+ * Used to generate short, collision-resistant column aliases.
+ */
+function fnv1aBase36(input: string): string {
+  let hash = 0x81_1c_9d_c5;
+  for (const character of input) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined) continue;
+    hash ^= codePoint;
+    hash = Math.imul(hash, 0x01_00_01_93);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+const TEXT_ENCODER = new TextEncoder();
+
+/**
+ * Truncates a string so its UTF-8 byte length does not exceed maxBytes.
+ * Avoids splitting in the middle of a multi-byte character.
+ */
+function truncateToBytes(value: string, maxBytes: number): string {
+  const encoded = TEXT_ENCODER.encode(value);
+  if (encoded.byteLength <= maxBytes) return value;
+
+  // Walk backwards from the limit to find a clean character boundary.
+  // UTF-8 continuation bytes have the form 10xxxxxx (0x80..0xBF).
+  let end = maxBytes;
+  while (end > 0 && encoded[end]! >= 0x80 && encoded[end]! < 0xc0) {
+    end--;
+  }
+
+  return new TextDecoder().decode(encoded.slice(0, end));
+}
+
+/**
+ * Generates a short, deterministic column alias safe for PostgreSQL.
+ *
+ * Format: `sg_{n|e}_{truncatedKind}_{hash}`
+ * The hash is computed from the full `kind + field` to prevent collisions
+ * when truncation would make two different identifiers identical.
+ *
+ * PostgreSQL truncates identifiers at 63 *bytes*, not characters.
+ * The kind portion is truncated by byte length to stay under the limit
+ * even with multibyte characters.
+ */
+function projectionAlias(
+  entityPrefix: "node" | "edge",
+  kind: string,
+  field: string,
+): string {
+  const prefix = entityPrefix === "node" ? "sg_n" : "sg_e";
+  const hash = fnv1aBase36(`${kind}\0${field}`);
+  // prefix + "_" + kind_trunc + "_" + hash must fit in 63 bytes.
+  // prefix and hash are ASCII, so byte length === string length.
+  const fixedBytes = prefix.length + 1 + 1 + hash.length;
+  const maxKindBytes = MAX_PG_IDENTIFIER_LENGTH - fixedBytes;
+  const truncatedKind = truncateToBytes(kind, maxKindBytes);
+  return `${prefix}_${truncatedKind}_${hash}`;
+}
 
 /**
  * Normalizes a JSON column value to a string.
@@ -77,6 +156,169 @@ export type SubsetEdge<G extends GraphDef, K extends EdgeKinds<G>> = {
   [Kind in K]: Edge<G["edges"][Kind]["type"]>;
 }[K];
 
+type EmptyShape = Readonly<Record<never, never>>;
+
+type NodeProjectionPropertyKey<N extends NodeType> = Exclude<
+  keyof Node<N>,
+  "id" | "kind" | "meta"
+> &
+  string;
+
+type EdgeProjectionPropertyKey<E extends AnyEdgeType> = Exclude<
+  keyof Edge<E>,
+  "id" | "kind" | "fromKind" | "fromId" | "toKind" | "toId" | "meta"
+> &
+  string;
+
+type SubgraphNodeProjectionField<N extends NodeType = NodeType> =
+  | NodeProjectionPropertyKey<N>
+  | "meta";
+
+type SubgraphEdgeProjectionField<E extends AnyEdgeType = AnyEdgeType> =
+  | EdgeProjectionPropertyKey<E>
+  | "meta";
+
+type SubgraphNodeProjectionMap<
+  G extends GraphDef,
+  NK extends NodeKinds<G> = NodeKinds<G>,
+> = Readonly<{
+  [K in NodeKinds<G>]?: K extends NK ?
+    readonly SubgraphNodeProjectionField<G["nodes"][K]["type"]>[]
+  : never;
+}>;
+
+type SubgraphEdgeProjectionMap<
+  G extends GraphDef,
+  EK extends EdgeKinds<G> = EdgeKinds<G>,
+> = Readonly<{
+  [K in EdgeKinds<G>]?: K extends EK ?
+    readonly SubgraphEdgeProjectionField<G["edges"][K]["type"]>[]
+  : never;
+}>;
+
+export type SubgraphProject<
+  G extends GraphDef,
+  NK extends NodeKinds<G> = NodeKinds<G>,
+  EK extends EdgeKinds<G> = EdgeKinds<G>,
+> = Readonly<{
+  /**
+   * Node fields to keep per kind.
+   *
+   * Projected nodes always retain `kind` and `id`.
+   * Use `"meta"` to include the full metadata object; omit it to exclude metadata entirely.
+   * Only kinds present in `includeKinds` (or all node kinds when omitted) are valid keys.
+   */
+  nodes?: SubgraphNodeProjectionMap<G, NK>;
+  /**
+   * Edge fields to keep per kind.
+   *
+   * Projected edges always retain `id`, `kind`, `fromKind`, `fromId`,
+   * `toKind`, and `toId`.
+   * Use `"meta"` to include the full metadata object; omit it to exclude metadata entirely.
+   * Only edge kinds listed in `edges` are valid keys.
+   */
+  edges?: SubgraphEdgeProjectionMap<G, EK>;
+}>;
+
+/**
+ * Identity function that preserves literal types for reusable projection configs.
+ *
+ * Without this helper, storing a projection in a typed variable widens the
+ * field arrays to `string[]`, defeating compile-time narrowing on results.
+ *
+ * @example
+ * ```ts
+ * const project = defineSubgraphProject(graph)({
+ *   nodes: { Task: ["title", "meta"] },
+ *   edges: { uses_skill: [] },
+ * });
+ * const result = await store.subgraph(rootId, { edges: ["uses_skill"], project });
+ * // result.nodes narrowed correctly — task.status is a type error
+ * ```
+ */
+export function defineSubgraphProject<G extends GraphDef>(
+  _graph: G,
+): <const P extends SubgraphProject<G>>(project: P) => P {
+  return <const P extends SubgraphProject<G>>(project: P): P => project;
+}
+
+type HasMeta<Selection extends readonly string[] | undefined> =
+  Selection extends readonly string[] ?
+    "meta" extends Selection[number] ?
+      true
+    : false
+  : false;
+
+type SelectedNodeProps<
+  N extends NodeType,
+  Selection extends readonly string[] | undefined,
+> =
+  Selection extends readonly string[] ?
+    Pick<Node<N>, Extract<Selection[number], NodeProjectionPropertyKey<N>>>
+  : EmptyShape;
+
+type SelectedEdgeProps<
+  E extends AnyEdgeType,
+  Selection extends readonly string[] | undefined,
+> =
+  Selection extends readonly string[] ?
+    Pick<Edge<E>, Extract<Selection[number], EdgeProjectionPropertyKey<E>>>
+  : EmptyShape;
+
+type ProjectedNodeResult<
+  N extends NodeType,
+  Selection extends readonly string[] | undefined,
+> = Readonly<Pick<Node<N>, "id" | "kind">> &
+  Readonly<SelectedNodeProps<N, Selection>> &
+  (HasMeta<Selection> extends true ? Readonly<{ meta: NodeMeta }> : EmptyShape);
+
+type ProjectedEdgeResult<
+  E extends AnyEdgeType,
+  Selection extends readonly string[] | undefined,
+> = Readonly<
+  Pick<Edge<E>, "id" | "kind" | "fromKind" | "fromId" | "toKind" | "toId">
+> &
+  Readonly<SelectedEdgeProps<E, Selection>> &
+  (HasMeta<Selection> extends true ? Readonly<{ meta: EdgeMeta }> : EmptyShape);
+
+type ProjectionSelection<
+  P,
+  Key extends "nodes" | "edges",
+  Kind extends string,
+> =
+  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- mapped type needed for conditional inference on Key
+  P extends Readonly<{ [K in Key]?: infer Map }> ?
+    Map extends Readonly<Record<string, readonly string[] | undefined>> ?
+      Kind extends keyof Map ?
+        Map[Kind]
+      : undefined
+    : undefined
+  : undefined;
+
+type SubgraphNodeResultForKind<
+  G extends GraphDef,
+  Kind extends NodeKinds<G>,
+  P,
+> =
+  ProjectionSelection<P, "nodes", Kind> extends readonly string[] ?
+    ProjectedNodeResult<
+      G["nodes"][Kind]["type"],
+      ProjectionSelection<P, "nodes", Kind>
+    >
+  : Node<G["nodes"][Kind]["type"]>;
+
+type SubgraphEdgeResultForKind<
+  G extends GraphDef,
+  Kind extends EdgeKinds<G>,
+  P,
+> =
+  ProjectionSelection<P, "edges", Kind> extends readonly string[] ?
+    ProjectedEdgeResult<
+      G["edges"][Kind]["type"],
+      ProjectionSelection<P, "edges", Kind>
+    >
+  : Edge<G["edges"][Kind]["type"]>;
+
 // ============================================================
 // Options & Result Types
 // ============================================================
@@ -85,6 +327,7 @@ export type SubgraphOptions<
   G extends GraphDef,
   EK extends EdgeKinds<G>,
   NK extends NodeKinds<G>,
+  P extends SubgraphProject<G, NK, EK> | undefined = undefined,
 > = Readonly<{
   /** Edge kinds to follow during traversal. Edges not listed are not traversed. */
   edges: readonly EK[];
@@ -106,15 +349,31 @@ export type SubgraphOptions<
   direction?: "out" | "both";
   /** Cycle policy — reuse RecursiveCyclePolicy (default: "prevent"). */
   cyclePolicy?: RecursiveCyclePolicy;
+  /**
+   * Optional field-level projection per node/edge kind.
+   *
+   * Projected nodes keep `kind` and `id`; projected edges keep their structural
+   * endpoint fields. Kinds omitted from `project` remain fully hydrated.
+   * Projection applies to every returned entity, including the root node.
+   *
+   * Only kinds present in `includeKinds` (nodes) or `edges` (edges) are valid
+   * projection keys. Specifying a kind outside those sets is a compile-time error.
+   */
+  project?: P;
 }>;
 
 export type SubgraphResult<
   G extends GraphDef,
   NK extends NodeKinds<G> = NodeKinds<G>,
   EK extends EdgeKinds<G> = EdgeKinds<G>,
+  P extends SubgraphProject<G, NK, EK> | undefined = undefined,
 > = Readonly<{
-  nodes: readonly SubsetNode<G, NK>[];
-  edges: readonly SubsetEdge<G, EK>[];
+  nodes: readonly {
+    [Kind in NK]: SubgraphNodeResultForKind<G, Kind, P>;
+  }[NK][];
+  edges: readonly {
+    [Kind in EK]: SubgraphEdgeResultForKind<G, Kind, P>;
+  }[EK][];
 }>;
 
 // ============================================================
@@ -135,6 +394,30 @@ type SubgraphContext = Readonly<{
   backend: GraphBackend;
 }>;
 
+type SubgraphNodeFetchRow = Readonly<
+  Omit<NodeRow, "props"> & { props: unknown } & Record<string, unknown>
+>;
+
+type SubgraphEdgeFetchRow = Readonly<
+  Omit<EdgeRow, "props"> & { props: unknown } & Record<string, unknown>
+>;
+
+type ProjectionPropertyFieldPlan = Readonly<{
+  field: string;
+  outputName: string;
+  typeInfo: FieldTypeInfo | undefined;
+}>;
+
+type KindProjectionPlan = Readonly<{
+  includeMeta: boolean;
+  propertyFields: readonly ProjectionPropertyFieldPlan[];
+}>;
+
+type ProjectionPlan = Readonly<{
+  fullKinds: readonly string[];
+  projectedKinds: ReadonlyMap<string, KindProjectionPlan>;
+}>;
+
 // ============================================================
 // Public API
 // ============================================================
@@ -143,18 +426,20 @@ export async function executeSubgraph<
   G extends GraphDef,
   EK extends EdgeKinds<G>,
   NK extends NodeKinds<G>,
+  P extends SubgraphProject<G, NK, EK> | undefined = undefined,
 >(params: {
+  graph: G;
   graphId: string;
   rootId: NodeId<AllNodeTypes<G>>;
   backend: GraphBackend;
   dialect: DialectAdapter;
   schema: SqlSchema | undefined;
-  options: SubgraphOptions<G, EK, NK>;
-}): Promise<SubgraphResult<G, NK, EK>> {
+  options: SubgraphOptions<G, EK, NK, P>;
+}): Promise<SubgraphResult<G, NK, EK, P>> {
   const { options } = params;
 
   if (options.edges.length === 0) {
-    return { nodes: [], edges: [] } as SubgraphResult<G, NK, EK>;
+    return { nodes: [], edges: [] } as SubgraphResult<G, NK, EK, P>;
   }
 
   const maxDepth = Math.min(
@@ -176,25 +461,148 @@ export async function executeSubgraph<
     backend: params.backend,
   };
 
+  const schemaIntrospector = getSubgraphSchemaIntrospector(params.graph);
+  const nodeProjectionPlan = buildProjectionPlan(
+    getIncludedNodeKinds(params.graph, options.includeKinds),
+    options.project?.nodes,
+    (kind, field) => schemaIntrospector.getFieldTypeInfo(kind, field),
+    "node",
+  );
+  const edgeProjectionPlan = buildProjectionPlan(
+    dedupeStrings(options.edges),
+    options.project?.edges,
+    (kind, field) => schemaIntrospector.getEdgeFieldTypeInfo(kind, field),
+    "edge",
+  );
+
   const reachableCte = buildReachableCte(ctx);
   const includedIdsCte = buildIncludedIdsCte(ctx);
 
   const [nodeRows, edgeRows] = await Promise.all([
-    fetchSubgraphNodes(ctx, reachableCte, includedIdsCte),
-    fetchSubgraphEdges(ctx, reachableCte, includedIdsCte),
+    fetchSubgraphNodes(ctx, reachableCte, includedIdsCte, nodeProjectionPlan),
+    fetchSubgraphEdges(ctx, reachableCte, includedIdsCte, edgeProjectionPlan),
   ]);
 
   const nodes = nodeRows.map((row) =>
-    rowToNode({ ...row, props: normalizeProps(row.props) }),
+    mapSubgraphNodeRow(row, nodeProjectionPlan),
   );
   const edges = edgeRows.map((row) =>
-    rowToEdge({ ...row, props: normalizeProps(row.props) }),
+    mapSubgraphEdgeRow(row, edgeProjectionPlan),
   );
 
   return {
-    nodes: nodes as unknown as SubgraphResult<G, NK, EK>["nodes"],
-    edges: edges as unknown as SubgraphResult<G, NK, EK>["edges"],
+    nodes: nodes as unknown as SubgraphResult<G, NK, EK, P>["nodes"],
+    edges: edges as unknown as SubgraphResult<G, NK, EK, P>["edges"],
   };
+}
+
+// ============================================================
+// Projection Planning
+// ============================================================
+
+type FieldTypeResolver = (
+  kind: string,
+  field: string,
+) => FieldTypeInfo | undefined;
+
+const introspectorCache = new WeakMap<GraphDef, SchemaIntrospector>();
+
+function getSubgraphSchemaIntrospector<G extends GraphDef>(
+  graph: G,
+): SchemaIntrospector {
+  const cached = introspectorCache.get(graph);
+  if (cached !== undefined) return cached;
+
+  const nodeKinds = new Map(
+    Object.entries(graph.nodes).map(([kind, definition]) => [
+      kind,
+      { schema: definition.type.schema },
+    ]),
+  );
+  const edgeKinds = new Map(
+    Object.entries(graph.edges).map(([kind, definition]) => [
+      kind,
+      { schema: definition.type.schema },
+    ]),
+  );
+
+  const introspector = createSchemaIntrospector(nodeKinds, edgeKinds);
+  introspectorCache.set(graph, introspector);
+  return introspector;
+}
+
+function buildProjectionPlan(
+  kinds: readonly string[],
+  projectionMap:
+    | Readonly<Record<string, readonly string[] | undefined>>
+    | undefined,
+  resolveFieldType: FieldTypeResolver,
+  entityPrefix: "node" | "edge",
+): ProjectionPlan {
+  const projectedKinds = new Map<string, KindProjectionPlan>();
+  const fullKinds: string[] = [];
+
+  for (const kind of kinds) {
+    const selection = projectionMap?.[kind];
+    if (selection === undefined) {
+      fullKinds.push(kind);
+      continue;
+    }
+
+    projectedKinds.set(
+      kind,
+      buildKindProjectionPlan(kind, selection, resolveFieldType, entityPrefix),
+    );
+  }
+
+  return { fullKinds, projectedKinds };
+}
+
+function buildKindProjectionPlan(
+  kind: string,
+  selection: readonly string[],
+  resolveFieldType: FieldTypeResolver,
+  entityPrefix: "node" | "edge",
+): KindProjectionPlan {
+  const propertyFields = new Map<string, ProjectionPropertyFieldPlan>();
+  let includeMeta = false;
+
+  for (const field of selection) {
+    if (field === "meta") {
+      includeMeta = true;
+      continue;
+    }
+
+    validateProjectionField(field, entityPrefix, kind);
+
+    if (!propertyFields.has(field)) {
+      propertyFields.set(field, {
+        field,
+        outputName: projectionAlias(entityPrefix, kind, field),
+        typeInfo: resolveFieldType(kind, field),
+      });
+    }
+  }
+
+  return {
+    includeMeta,
+    propertyFields: [...propertyFields.values()],
+  };
+}
+
+function getIncludedNodeKinds<G extends GraphDef>(
+  graph: G,
+  includeKinds: readonly NodeKinds<G>[] | undefined,
+): readonly string[] {
+  if (includeKinds === undefined || includeKinds.length === 0) {
+    return Object.keys(graph.nodes);
+  }
+
+  return dedupeStrings(includeKinds);
+}
+
+function dedupeStrings(values: readonly string[]): readonly string[] {
+  return [...new Set(values)];
 }
 
 // ============================================================
@@ -348,20 +756,197 @@ async function fetchSubgraphNodes(
   ctx: SubgraphContext,
   reachableCte: SQL,
   includedIdsCte: SQL,
-): Promise<NodeRow[]> {
-  const query = sql`${reachableCte}${includedIdsCte} SELECT n.kind, n.id, n.props, n.version, n.valid_from, n.valid_to, n.created_at, n.updated_at, n.deleted_at FROM ${ctx.schema.nodesTable} n WHERE n.graph_id = ${ctx.graphId} AND n.id IN (SELECT id FROM included_ids)`;
+  projectionPlan: ProjectionPlan,
+): Promise<SubgraphNodeFetchRow[]> {
+  const columns: SQL[] = [
+    sql`n.kind`,
+    sql`n.id`,
+    buildFullPropsColumn("n", projectionPlan),
+    ...buildMetadataColumns("n", projectionPlan, [
+      "version",
+      "valid_from",
+      "valid_to",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]),
+    ...buildProjectedPropertyColumns("n", projectionPlan, ctx.dialect),
+  ];
 
-  return ctx.backend.execute<NodeRow>(query) as Promise<NodeRow[]>;
+  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.nodesTable} n WHERE n.graph_id = ${ctx.graphId} AND n.id IN (SELECT id FROM included_ids)`;
+
+  return ctx.backend.execute<SubgraphNodeFetchRow>(query) as Promise<
+    SubgraphNodeFetchRow[]
+  >;
 }
 
 async function fetchSubgraphEdges(
   ctx: SubgraphContext,
   reachableCte: SQL,
   includedIdsCte: SQL,
-): Promise<EdgeRow[]> {
+  projectionPlan: ProjectionPlan,
+): Promise<SubgraphEdgeFetchRow[]> {
   const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), ctx.edgeKinds);
+  const columns: SQL[] = [
+    sql`e.id`,
+    sql`e.kind`,
+    sql`e.from_kind`,
+    sql`e.from_id`,
+    sql`e.to_kind`,
+    sql`e.to_id`,
+    buildFullPropsColumn("e", projectionPlan),
+    ...buildMetadataColumns("e", projectionPlan, [
+      "valid_from",
+      "valid_to",
+      "created_at",
+      "updated_at",
+      "deleted_at",
+    ]),
+    ...buildProjectedPropertyColumns("e", projectionPlan, ctx.dialect),
+  ];
 
-  const query = sql`${reachableCte}${includedIdsCte} SELECT e.id, e.kind, e.from_kind, e.from_id, e.to_kind, e.to_id, e.props, e.valid_from, e.valid_to, e.created_at, e.updated_at, e.deleted_at FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND e.deleted_at IS NULL AND e.from_id IN (SELECT id FROM included_ids) AND e.to_id IN (SELECT id FROM included_ids)`;
+  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND e.deleted_at IS NULL AND e.from_id IN (SELECT id FROM included_ids) AND e.to_id IN (SELECT id FROM included_ids)`;
 
-  return ctx.backend.execute<EdgeRow>(query) as Promise<EdgeRow[]>;
+  return ctx.backend.execute<SubgraphEdgeFetchRow>(query) as Promise<
+    SubgraphEdgeFetchRow[]
+  >;
+}
+
+function buildMetadataColumns(
+  alias: "n" | "e",
+  plan: ProjectionPlan,
+  columns: readonly string[],
+): readonly SQL[] {
+  if (plan.projectedKinds.size === 0) {
+    return columns.map((col) => sql`${sql.raw(`${alias}.${col}`)}`);
+  }
+
+  const metaKinds: string[] = [...plan.fullKinds];
+  for (const [kind, kindPlan] of plan.projectedKinds) {
+    if (kindPlan.includeMeta) metaKinds.push(kind);
+  }
+
+  if (metaKinds.length === 0) {
+    return columns.map((col) => sql`NULL AS ${sql.raw(col)}`);
+  }
+
+  // All kinds need meta — no CASE needed
+  if (metaKinds.length === plan.fullKinds.length + plan.projectedKinds.size) {
+    return columns.map((col) => sql`${sql.raw(`${alias}.${col}`)}`);
+  }
+
+  const filter = compileKindFilter(sql.raw(`${alias}.kind`), metaKinds);
+  return columns.map(
+    (col) =>
+      sql`CASE WHEN ${filter} THEN ${sql.raw(`${alias}.${col}`)} ELSE NULL END AS ${sql.raw(col)}`,
+  );
+}
+
+function buildFullPropsColumn(alias: "n" | "e", plan: ProjectionPlan): SQL {
+  if (plan.projectedKinds.size === 0) {
+    return sql`${sql.raw(`${alias}.props`)} AS props`;
+  }
+
+  if (plan.fullKinds.length === 0) {
+    return sql`NULL AS props`;
+  }
+
+  const filter = compileKindFilter(sql.raw(`${alias}.kind`), plan.fullKinds);
+  return sql`CASE WHEN ${filter} THEN ${sql.raw(`${alias}.props`)} ELSE NULL END AS props`;
+}
+
+function buildProjectedPropertyColumns(
+  alias: "n" | "e",
+  plan: ProjectionPlan,
+  dialect: DialectAdapter,
+): readonly SQL[] {
+  const columns: SQL[] = [];
+
+  for (const [kind, kindPlan] of plan.projectedKinds.entries()) {
+    for (const fieldPlan of kindPlan.propertyFields) {
+      const extracted = compileTypedJsonExtract({
+        column: sql.raw(`${alias}.props`),
+        dialect,
+        pointer: jsonPointer([fieldPlan.field]),
+        valueType: fieldPlan.typeInfo?.valueType,
+      });
+
+      columns.push(
+        sql`CASE WHEN ${sql.raw(alias)}.kind = ${kind} THEN ${extracted} ELSE NULL END AS ${quoteIdentifier(fieldPlan.outputName)}`,
+      );
+    }
+  }
+
+  return columns;
+}
+
+// ============================================================
+// Result Mapping
+// ============================================================
+
+function applyProjectedFields(
+  target: Record<string, unknown>,
+  row: Readonly<Record<string, unknown>>,
+  kindPlan: KindProjectionPlan,
+): void {
+  for (const fieldPlan of kindPlan.propertyFields) {
+    target[fieldPlan.field] = decodeSelectedValue(
+      row[fieldPlan.outputName],
+      fieldPlan.typeInfo,
+    );
+  }
+}
+
+function mapSubgraphNodeRow(
+  row: SubgraphNodeFetchRow,
+  projectionPlan: ProjectionPlan,
+): Node {
+  const kindPlan = projectionPlan.projectedKinds.get(row.kind);
+  if (kindPlan === undefined) {
+    return rowToNode({
+      ...row,
+      props: normalizeProps(row.props),
+    });
+  }
+
+  const projectedNode: Record<string, unknown> = {
+    kind: row.kind,
+    id: row.id,
+  };
+
+  if (kindPlan.includeMeta) {
+    projectedNode.meta = rowToNodeMeta(row);
+  }
+
+  applyProjectedFields(projectedNode, row, kindPlan);
+  return projectedNode as Node;
+}
+
+function mapSubgraphEdgeRow(
+  row: SubgraphEdgeFetchRow,
+  projectionPlan: ProjectionPlan,
+): Edge {
+  const kindPlan = projectionPlan.projectedKinds.get(row.kind);
+  if (kindPlan === undefined) {
+    return rowToEdge({
+      ...row,
+      props: normalizeProps(row.props),
+    });
+  }
+
+  const projectedEdge: Record<string, unknown> = {
+    id: row.id,
+    kind: row.kind,
+    fromKind: row.from_kind,
+    fromId: row.from_id,
+    toKind: row.to_kind,
+    toId: row.to_id,
+  };
+
+  if (kindPlan.includeMeta) {
+    projectedEdge.meta = rowToEdgeMeta(row);
+  }
+
+  applyProjectedFields(projectedEdge, row, kindPlan);
+  return projectedEdge as Edge;
 }

--- a/packages/typegraph/tests/backends/integration/subgraph.ts
+++ b/packages/typegraph/tests/backends/integration/subgraph.ts
@@ -258,5 +258,70 @@ export function registerSubgraphIntegrationTests(
       expect(result.nodes).toHaveLength(0);
       expect(result.edges).toHaveLength(0);
     });
+
+    it("projects node and edge fields across backends", async () => {
+      const store = context.getStore();
+      const result = await store.subgraph(ids.aliceId as never, {
+        edges: ["knows", "worksAt"],
+        maxDepth: 1,
+        project: {
+          nodes: {
+            Person: ["name"],
+            Company: ["name", "meta"],
+          },
+          edges: {
+            knows: [],
+            worksAt: ["role"],
+          },
+        },
+      });
+
+      const people = result.nodes.filter((node) => node.kind === "Person");
+      const companies = result.nodes.filter((node) => node.kind === "Company");
+
+      expect(people.length).toBeGreaterThan(0);
+      for (const person of people) {
+        expect(person).toHaveProperty("id");
+        expect(person).toHaveProperty("name");
+        expect(person).not.toHaveProperty("age");
+        expect(person).not.toHaveProperty("meta");
+      }
+
+      expect(companies).toHaveLength(1);
+      expect(companies[0]).toHaveProperty("name", "Acme");
+      expect(companies[0]).toHaveProperty("meta.createdAt");
+      expect(companies[0]).toHaveProperty("meta.updatedAt");
+      expect(companies[0]).not.toHaveProperty("industry");
+
+      const worksAtEdges = result.edges.filter(
+        (
+          edge,
+        ): edge is Extract<
+          (typeof result.edges)[number],
+          { kind: "worksAt" }
+        > => edge.kind === "worksAt",
+      );
+      const knowsEdges = result.edges.filter(
+        (
+          edge,
+        ): edge is Extract<(typeof result.edges)[number], { kind: "knows" }> =>
+          edge.kind === "knows",
+      );
+
+      expect(worksAtEdges).toHaveLength(2);
+      expect(worksAtEdges.map((edge) => edge.role).toSorted()).toEqual([
+        "Engineer",
+        "Manager",
+      ]);
+      for (const edge of worksAtEdges) {
+        expect(edge).toHaveProperty("toId", ids.acmeId);
+        expect(edge).not.toHaveProperty("meta");
+      }
+
+      expect(knowsEdges).toHaveLength(1);
+      expect(knowsEdges[0]).toHaveProperty("fromId", ids.aliceId);
+      expect(knowsEdges[0]).toHaveProperty("toId", ids.bobId);
+      expect(knowsEdges[0]).not.toHaveProperty("meta");
+    });
   });
 }

--- a/packages/typegraph/tests/subgraph.test.ts
+++ b/packages/typegraph/tests/subgraph.test.ts
@@ -15,7 +15,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { defineEdge, defineGraph, defineNode } from "../src";
+import {
+  defineEdge,
+  defineGraph,
+  defineNode,
+  defineSubgraphProject,
+} from "../src";
 import type { GraphBackend } from "../src/backend/types";
 import type { NodeId } from "../src/core/types";
 import { createStore, type Store } from "../src/store";
@@ -55,7 +60,9 @@ const Orphan = defineNode("Orphan", {
 
 const hasTask = defineEdge("has_task", { schema: z.object({}) });
 const runsAgent = defineEdge("runs_agent", { schema: z.object({}) });
-const usesSkill = defineEdge("uses_skill", { schema: z.object({}) });
+const usesSkill = defineEdge("uses_skill", {
+  schema: z.object({ priority: z.number() }),
+});
 const hasAttempt = defineEdge("has_attempt", { schema: z.object({}) });
 const usedTool = defineEdge("used_tool", { schema: z.object({}) });
 const dependsOn = defineEdge("depends_on", { schema: z.object({}) });
@@ -124,8 +131,8 @@ async function seedTestGraph(store: Store<TestGraph>): Promise<TestIds> {
   await store.edges.has_task.create(run, task1);
   await store.edges.has_task.create(run, task2);
   await store.edges.runs_agent.create(run, agent1);
-  await store.edges.uses_skill.create(task1, skill1);
-  await store.edges.uses_skill.create(task2, skill1);
+  await store.edges.uses_skill.create(task1, skill1, { priority: 1 });
+  await store.edges.uses_skill.create(task2, skill1, { priority: 2 });
   await store.edges.has_attempt.create(task1, attempt1);
   await store.edges.used_tool.create(attempt1, tool1);
   await store.edges.depends_on.create(task1, task2);
@@ -650,6 +657,102 @@ describe("store.subgraph()", () => {
     });
   });
 
+  // ── Projection ─────────────────────────────────────────────
+
+  describe("projection", () => {
+    it("applies projection to the root node when its kind is projected", async () => {
+      const result = await store.subgraph(ids.runId as never, {
+        edges: ["has_task"],
+        maxDepth: 0,
+        project: {
+          nodes: {
+            Run: ["name"],
+          },
+        },
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0]).toMatchObject({
+        kind: "Run",
+        id: ids.runId,
+        name: "run-1",
+      });
+      expect(result.nodes[0]).not.toHaveProperty("meta");
+    });
+
+    it("projects node props and full metadata while preserving identity", async () => {
+      const result = await store.subgraph(ids.runId as never, {
+        edges: ["has_task"],
+        maxDepth: 1,
+        includeKinds: ["Task"],
+        project: {
+          nodes: {
+            Task: ["title", "meta"],
+          },
+        },
+      });
+
+      expect(result.nodes).toHaveLength(2);
+      for (const node of result.nodes) {
+        expect(node.kind).toBe("Task");
+        expect(node).toHaveProperty("id");
+        expect(node).toHaveProperty("title");
+        expect(node).not.toHaveProperty("status");
+        expect(node).toHaveProperty("meta.createdAt");
+        expect(node).toHaveProperty("meta.updatedAt");
+      }
+    });
+
+    it("keeps unprojected kinds fully hydrated", async () => {
+      const result = await store.subgraph(ids.runId as never, {
+        edges: ["has_task", "runs_agent"],
+        maxDepth: 1,
+        project: {
+          nodes: {
+            Task: ["title"],
+          },
+        },
+      });
+
+      const task = result.nodes.find((node) => node.kind === "Task");
+      const agent = result.nodes.find((node) => node.kind === "Agent");
+
+      expect(task).toBeDefined();
+      expect(task).toHaveProperty("title");
+      expect(task).not.toHaveProperty("status");
+      expect(task).not.toHaveProperty("meta");
+
+      expect(agent).toBeDefined();
+      expect(agent).toHaveProperty("model");
+      expect(agent).toHaveProperty("meta.createdAt");
+      expect(agent).toHaveProperty("meta.updatedAt");
+    });
+
+    it("projects edges while preserving structural endpoint fields", async () => {
+      const result = await store.subgraph(ids.task1Id as never, {
+        edges: ["uses_skill"],
+        maxDepth: 1,
+        project: {
+          edges: {
+            uses_skill: ["meta"],
+          },
+        },
+      });
+
+      expect(result.edges).toHaveLength(1);
+      const edge = result.edges[0]!;
+      expect(edge.kind).toBe("uses_skill");
+      expect(edge).toHaveProperty("id");
+      expect(edge).toHaveProperty("fromKind");
+      expect(edge).toHaveProperty("fromId");
+      expect(edge).toHaveProperty("toKind");
+      expect(edge).toHaveProperty("toId");
+      expect(edge).toHaveProperty("meta.createdAt");
+      expect(edge).toHaveProperty("meta.updatedAt");
+      expect(edge).not.toHaveProperty("priority");
+    });
+  });
+
   // ── Type-level tests ────────────────────────────────────────
 
   describe("compile-time type safety", () => {
@@ -676,6 +779,329 @@ describe("store.subgraph()", () => {
       expect(result.nodes.length).toBeGreaterThan(0);
       for (const node of result.nodes) {
         expect(["Task", "Agent"]).toContain(node.kind);
+      }
+    });
+
+    it("narrows projected node fields at compile time", async () => {
+      const result = await store.subgraph(ids.runId as never, {
+        edges: ["has_task", "runs_agent"],
+        maxDepth: 1,
+        includeKinds: ["Task", "Agent"],
+        project: {
+          nodes: {
+            Task: ["title"],
+            Agent: ["meta"],
+          },
+        },
+      });
+
+      for (const node of result.nodes) {
+        if (node.kind === "Task") {
+          const title: string = node.title;
+          void title;
+          // @ts-expect-error - projected Task omits status
+          const status = node.status;
+          void status;
+        }
+
+        if (node.kind === "Agent") {
+          const createdAt: string = node.meta.createdAt;
+          void createdAt;
+          // @ts-expect-error - projected Agent omits model
+          const model = node.model;
+          void model;
+        }
+      }
+    });
+
+    it("narrows projected edge fields at compile time", async () => {
+      const result = await store.subgraph(ids.task1Id as never, {
+        edges: ["uses_skill"],
+        maxDepth: 1,
+        project: {
+          edges: {
+            uses_skill: [],
+          },
+        },
+      });
+
+      const edge = result.edges[0]!;
+      const fromId: string = edge.fromId;
+      const toId: string = edge.toId;
+      void fromId;
+      void toId;
+      // @ts-expect-error - projected edge omits meta unless requested
+      const meta = edge.meta;
+      void meta;
+    });
+
+    it("rejects partial meta fields at compile time", async () => {
+      await store.subgraph(ids.runId as never, {
+        edges: ["has_task"],
+        maxDepth: 1,
+        project: {
+          nodes: {
+            // @ts-expect-error - "meta.createdAt" is not a valid projection field; use "meta" for all-or-nothing
+            Task: ["title", "meta.createdAt"],
+          },
+        },
+      });
+
+      await store.subgraph(ids.task1Id as never, {
+        edges: ["uses_skill"],
+        maxDepth: 1,
+        project: {
+          edges: {
+            // @ts-expect-error - "meta.updatedAt" is not a valid edge projection field; use "meta" for all-or-nothing
+            uses_skill: ["meta.updatedAt"],
+          },
+        },
+      });
+    });
+
+    it("rejects projection keys for kinds outside includeKinds/edges", async () => {
+      await store.subgraph(ids.runId as never, {
+        edges: ["has_task"],
+        maxDepth: 1,
+        includeKinds: ["Task"],
+        project: {
+          nodes: {
+            Task: ["title"],
+            // @ts-expect-error - Agent is not in includeKinds
+            Agent: ["model"],
+          },
+        },
+      });
+
+      await store.subgraph(ids.runId as never, {
+        edges: ["has_task"],
+        maxDepth: 1,
+        project: {
+          edges: {
+            // @ts-expect-error - runs_agent is not in edges
+            runs_agent: [],
+          },
+        },
+      });
+    });
+
+    it("projects correctly with very long kind and field names", async () => {
+      // Alias must stay under PostgreSQL's 63-byte identifier limit.
+      // This test creates a node kind with a long schema field and verifies
+      // projection round-trips the value correctly (alias wasn't truncated).
+      const LongKind = defineNode(
+        "VeryLongNodeKindNameThatExceedsNormalLength",
+        {
+          schema: z.object({
+            a_field_name_that_is_also_unreasonably_long_for_testing_purposes:
+              z.string(),
+          }),
+        },
+      );
+
+      const longEdge = defineEdge("very_long_edge", {
+        schema: z.object({}),
+      });
+
+      const longGraph = defineGraph({
+        id: "long_test",
+        nodes: {
+          VeryLongNodeKindNameThatExceedsNormalLength: { type: LongKind },
+        },
+        edges: {
+          very_long_edge: {
+            type: longEdge,
+            from: [LongKind],
+            to: [LongKind],
+          },
+        },
+      });
+
+      const longBackend = createTestBackend();
+      const longStore = createStore(longGraph, longBackend);
+
+      const root =
+        await longStore.nodes.VeryLongNodeKindNameThatExceedsNormalLength.create(
+          {
+            a_field_name_that_is_also_unreasonably_long_for_testing_purposes:
+              "hello",
+          },
+        );
+
+      const child =
+        await longStore.nodes.VeryLongNodeKindNameThatExceedsNormalLength.create(
+          {
+            a_field_name_that_is_also_unreasonably_long_for_testing_purposes:
+              "world",
+          },
+        );
+
+      await longStore.edges.very_long_edge.create(root, child);
+
+      const result = await longStore.subgraph(root.id, {
+        edges: ["very_long_edge"],
+        maxDepth: 1,
+        project: {
+          nodes: {
+            VeryLongNodeKindNameThatExceedsNormalLength: [
+              "a_field_name_that_is_also_unreasonably_long_for_testing_purposes",
+            ],
+          },
+        },
+      });
+
+      expect(result.nodes).toHaveLength(2);
+      for (const node of result.nodes) {
+        expect(
+          node.a_field_name_that_is_also_unreasonably_long_for_testing_purposes,
+        ).toBeDefined();
+      }
+    });
+
+    it("projects correctly with multibyte kind names", async () => {
+      // PostgreSQL truncates identifiers at 63 bytes, not characters.
+      // Multibyte kind names (e.g. emoji, CJK) can exceed the byte limit
+      // even when string.length looks safe. This test verifies round-trip
+      // projection works with a multibyte kind name.
+      const multibyteKindName = "データノード_" + "あ".repeat(20);
+      const MultibyteKind = defineNode(multibyteKindName, {
+        schema: z.object({ value: z.string() }),
+      });
+
+      const mbEdge = defineEdge("mb_link", { schema: z.object({}) });
+
+      const mbGraph = defineGraph({
+        id: "mb_test",
+        nodes: { [multibyteKindName]: { type: MultibyteKind } },
+        edges: {
+          mb_link: {
+            type: mbEdge,
+            from: [MultibyteKind],
+            to: [MultibyteKind],
+          },
+        },
+      });
+
+      const mbBackend = createTestBackend();
+      const mbStore = createStore(mbGraph, mbBackend);
+
+      const collection = mbStore.nodes[multibyteKindName]!;
+      const root = await collection.create({ value: "root" });
+      const child = await collection.create({ value: "child" });
+      await mbStore.edges.mb_link.create(root, child);
+
+      const result = await mbStore.subgraph(root.id as never, {
+        edges: ["mb_link"] as never,
+        maxDepth: 1,
+        project: {
+          nodes: { [multibyteKindName]: ["value"] } as never,
+        },
+      });
+
+      expect(result.nodes).toHaveLength(2);
+      for (const node of result.nodes) {
+        expect((node as Record<string, unknown>).value).toBeDefined();
+      }
+    });
+
+    it("rejects reserved node keys in projection", async () => {
+      // "meta" is excluded — it's a valid projection field handled separately
+      const reservedNodeKeys = ["id", "kind"];
+      for (const key of reservedNodeKeys) {
+        await expect(
+          store.subgraph(ids.runId as never, {
+            edges: ["has_task"],
+            maxDepth: 1,
+            project: {
+              nodes: {
+                Task: [key] as never,
+              },
+            },
+          }),
+        ).rejects.toThrow(/reserved structural key/);
+      }
+    });
+
+    it("rejects reserved edge keys in projection", async () => {
+      // "meta" is excluded — it's a valid projection field handled separately
+      const reservedEdgeKeys = [
+        "id",
+        "kind",
+        "fromKind",
+        "fromId",
+        "toKind",
+        "toId",
+      ];
+      for (const key of reservedEdgeKeys) {
+        await expect(
+          store.subgraph(ids.runId as never, {
+            edges: ["has_task"],
+            maxDepth: 1,
+            project: {
+              edges: {
+                has_task: [key] as never,
+              },
+            },
+          }),
+        ).rejects.toThrow(/reserved structural key/);
+      }
+    });
+
+    it("rejects prototype-pollution keys in projection", async () => {
+      const dangerousKeys = ["__proto__", "constructor", "prototype"];
+      for (const key of dangerousKeys) {
+        await expect(
+          store.subgraph(ids.runId as never, {
+            edges: ["has_task"],
+            maxDepth: 1,
+            project: {
+              nodes: {
+                Task: [key] as never,
+              },
+            },
+          }),
+        ).rejects.toThrow(/not allowed/);
+      }
+    });
+
+    it("narrows reusable projection configs via defineSubgraphProject", async () => {
+      const project = defineSubgraphProject(testGraph)({
+        nodes: {
+          Task: ["title"],
+        },
+        edges: {
+          uses_skill: ["priority"],
+        },
+      });
+
+      const result = await store.subgraph(ids.runId as never, {
+        edges: ["has_task", "uses_skill"],
+        maxDepth: 2,
+        includeKinds: ["Task", "Skill"],
+        project,
+      });
+
+      for (const node of result.nodes) {
+        if (node.kind === "Task") {
+          const title: string = node.title;
+          void title;
+          // @ts-expect-error - projected Task omits status even through reusable config
+          const status = node.status;
+          void status;
+          // @ts-expect-error - projected Task omits meta when not requested
+          const meta = node.meta;
+          void meta;
+        }
+      }
+
+      for (const edge of result.edges) {
+        if (edge.kind === "uses_skill") {
+          const priority: number = edge.priority;
+          void priority;
+          // @ts-expect-error - projected uses_skill omits meta when not requested
+          const meta = edge.meta;
+          void meta;
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary

Adds a declarative `project` option to `store.subgraph()` that specifies which fields to retain per node/edge kind, with SQL-level extraction and compile-time type narrowing.

- **Declarative field arrays** (`["title", "meta"]`) instead of callbacks — statically analyzable, no side effects, enables SQL pushdown
- **SQL-level projection** via `json_extract()` / JSONB paths — projected kinds skip full `props` blob transfer
- **Metadata column pushdown** — projected kinds that omit `"meta"` also skip metadata columns (`version`, `valid_from`, `valid_to`, `created_at`, `updated_at`, `deleted_at`) via CASE-based SQL pushdown, matching the props strategy
- **All-or-nothing metadata** — `"meta"` includes the full struct; omit it to exclude entirely (partial `meta.createdAt` was cut — disproportionate type complexity for a 5-field struct)
- **Projection key constraints** — node projection keys must be in `includeKinds` (or all node kinds when omitted); edge projection keys must be in `edges`. Out-of-scope keys are a compile-time error
- **`defineSubgraphProject()` helper** preserves literal types for reusable projection configs; `SubgraphProject` type deliberately not exported to prevent the annotation-widening footgun
- **Cached `SchemaIntrospector`** — per-graph `WeakMap` cache avoids repeated `Object.entries` + `Map` construction on every `subgraph()` call
- **Unified internals** — single `KindProjectionPlan`, `ProjectionPlan`, `buildProjectionPlan()` serve both nodes and edges; entry-point mappers stay separate (different base shapes)

```typescript
const result = await store.subgraph(rootId, {
  edges: ["has_task", "uses_skill"],
  maxDepth: 2,
  project: {
    nodes: { Task: ["title", "meta"], Skill: ["name"] },
    edges: { uses_skill: ["priority"] },
  },
});
// Task → { kind, id, title, meta }  — status omitted, compile-time error to access
// Skill → { kind, id, name }
// uses_skill → { id, kind, fromKind, fromId, toKind, toId, priority }
```

### Benchmarks (SQLite, 1109 nodes / 4513 edges)

| | full | app-projection | SQL-projection |
|---|---|---|---|
| baseline (depth 2) | 37.1ms | 37.4ms | 36.7ms |
| stress (depth 3) | 352.1ms | 349.6ms | 332.4ms |

SQL path shows modest win at scale from reduced decode/allocation. CASE-based pushdown kept as first strategy, not expanded further until payload-size benchmarks justify it.

### Why not issue #46 as written

The issue proposed callback-based `select`/`selectEdge`. Declarative arrays are better: statically analyzable for SQL pushdown, no side-effect risk, simpler type inference. The issue's app-layer-first approach also defers solving its own stated motivation (wire overhead). See discussion in #46.

Closes #46