### PR TITLE
feat: add batchFind* methods to edge collections for store.batch()

### DIFF
--- a/.changeset/feat-edge-batch-find.md
+++ b/.changeset/feat-edge-batch-find.md
@@ -1,0 +1,23 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `batchFindFrom`, `batchFindTo`, and `batchFindByEndpoints` to edge collections for use with `store.batch()`.
+
+Edge collection lookup methods (`findFrom`, `findTo`, `findByEndpoints`) execute immediately and cannot participate in `store.batch()`. The new `batchFind*` variants return a `BatchableQuery` instead, enabling edge lookups to share a single transactional connection alongside fluent queries.
+
+```typescript
+const [skills, employer, colleague] = await store.batch(
+  store.edges.hasSkill.batchFindFrom(alice),
+  store.edges.worksAt.batchFindFrom(alice),
+  store.edges.knows.batchFindByEndpoints(alice, bob),
+);
+```
+
+- **`batchFindFrom(from)`** — deferred variant of `findFrom`
+- **`batchFindTo(to)`** — deferred variant of `findTo`
+- **`batchFindByEndpoints(from, to, options?)`** — deferred variant of `findByEndpoints`, returns 0-or-1 element array
+
+All three preserve the same endpoint type constraints as their immediate counterparts.
+
+Closes #51.

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -162,6 +162,10 @@ const [activeUsers, recentOrders] = await store.batch(
 );
 ```
 
+Edge collection `batchFind*` methods (`batchFindFrom`, `batchFindTo`, `batchFindByEndpoints`) also
+participate in `store.batch()`, replacing N individual `findFrom`/`findTo` calls with a single
+transactional round-trip.
+
 :::note[Operation hooks]
 Bulk operations (`bulkCreate`, `bulkInsert`, `bulkUpsertById`) skip per-item operation hooks for
 throughput. Query hooks still fire normally. See [Schemas & Stores](/schemas-stores#hooks) for details.

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -268,6 +268,15 @@ const [people, companies] = await store.batch(
 Each query preserves its own projection, filtering, sorting, and pagination. Results are returned
 as a typed tuple matching the input order.
 
+Edge collection `batchFind*` methods also return `BatchableQuery` and can be mixed freely with fluent queries:
+
+```typescript
+const [skills, employer] = await store.batch(
+  store.edges.hasSkill.batchFindFrom(alice),
+  store.edges.worksAt.batchFindFrom(alice),
+);
+```
+
 **vs `Promise.all`**: `batch()` uses 1 connection instead of N and guarantees snapshot consistency.
 **vs `transaction()`**: Same consistency, but cleaner API — no callback, typed tuple return.
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -783,6 +783,32 @@ store.edges.worksAt.findTo(
 ): Promise<Edge<worksAt>[]>;
 ```
 
+#### `batchFindFrom(from)` / `batchFindTo(to)` / `batchFindByEndpoints(from, to, options?)`
+
+Deferred variants of `findFrom`, `findTo`, and `findByEndpoints` for use with
+[`store.batch()`](#batch-query-execution). These return a `BatchableQuery` instead of
+executing immediately.
+
+```typescript
+store.edges.worksAt.batchFindFrom(from: NodeRef<Person>): BatchableQuery<Edge<worksAt>>;
+store.edges.worksAt.batchFindTo(to: NodeRef<Company>): BatchableQuery<Edge<worksAt>>;
+store.edges.worksAt.batchFindByEndpoints(
+  from: NodeRef<Person>,
+  to: NodeRef<Company>,
+  options?: { matchOn?: readonly string[]; props?: Partial<{ role: string }> }
+): BatchableQuery<Edge<worksAt>>;
+```
+
+```typescript
+// Execute multiple edge lookups over a single connection
+const [skills, employer] = await store.batch(
+  store.edges.hasSkill.batchFindFrom(alice),
+  store.edges.worksAt.batchFindFrom(alice),
+);
+```
+
+`batchFindByEndpoints` returns a 0-or-1 element array (matching the at-most-one semantics of `findByEndpoints`).
+
 #### `find(options?)`
 
 Finds edges with endpoint filtering.
@@ -1057,8 +1083,8 @@ const person = await store.nodes.Person.create({ name: "Alice" });
 #### `store.batch(...queries)`
 
 Executes multiple independent queries over a single connection with snapshot consistency.
-Accepts two or more queries (from `.select()` or set operations) and returns a typed tuple
-of results preserving input order.
+Accepts two or more queries (from `.select()`, set operations, or edge collection `batchFind*` methods)
+and returns a typed tuple of results preserving input order.
 
 All queries run within an implicit transaction — they see the same database snapshot.
 This avoids connection pool pressure from `Promise.all` patterns (N connections → 1) while
@@ -1146,6 +1172,17 @@ const [combined, separate] = await store.batch(
     .query()
     .from("Company", "c")
     .select((ctx) => ({ id: ctx.c.id, name: ctx.c.name })),
+);
+```
+
+**Edge collection lookups:**
+
+```typescript
+// Edge batchFind* methods return BatchableQuery — mix freely with fluent queries
+const [skills, employer, colleague] = await store.batch(
+  store.edges.hasSkill.batchFindFrom(alice),
+  store.edges.worksAt.batchFindFrom(alice),
+  store.edges.knows.batchFindByEndpoints(alice, bob),
 );
 ```
 

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -13,6 +13,7 @@ import { type GraphDef } from "../../core/define-graph";
 import { type AnyEdgeType, type TemporalMode } from "../../core/types";
 import { UnsupportedPredicateError } from "../../errors";
 import { type QueryBuilder } from "../../query/builder";
+import type { BatchableQuery } from "../../query/builder/types";
 import { nowIso } from "../../utils/date";
 import { type EdgeRow } from "../row-mappers";
 import {
@@ -225,6 +226,54 @@ export function createEdgeCollection<
     matchesTemporalMode,
   } = config;
 
+  const mapRows = (rows: readonly EdgeRow[]): Edge<E>[] =>
+    rows.map((row) => narrowEdge<E>(rowToEdge(row)));
+
+  async function findEdgesFrom(
+    from: NodeRef,
+    target: GraphBackend | TransactionBackend,
+  ): Promise<Edge<E>[]> {
+    const rows = await target.findEdgesByKind({
+      graphId,
+      kind,
+      fromKind: from.kind,
+      fromId: from.id,
+      excludeDeleted: true,
+    });
+    return mapRows(rows);
+  }
+
+  async function findEdgesTo(
+    to: NodeRef,
+    target: GraphBackend | TransactionBackend,
+  ): Promise<Edge<E>[]> {
+    const rows = await target.findEdgesByKind({
+      graphId,
+      kind,
+      toKind: to.kind,
+      toId: to.id,
+      excludeDeleted: true,
+    });
+    return mapRows(rows);
+  }
+
+  function buildFindByEndpointsOptions(
+    options?: EdgeFindByEndpointsOptions<E>,
+  ): Readonly<{
+    matchOn?: readonly string[];
+    props?: Record<string, unknown>;
+  }> {
+    const result: {
+      matchOn?: readonly string[];
+      props?: Record<string, unknown>;
+    } = {};
+    if (options?.matchOn !== undefined)
+      result.matchOn = options.matchOn as readonly string[];
+    if (options?.props !== undefined)
+      result.props = options.props as Record<string, unknown>;
+    return result;
+  }
+
   return {
     async create(
       from: NodeRef,
@@ -301,25 +350,40 @@ export function createEdgeCollection<
     },
 
     async findFrom(from: NodeRef): Promise<Edge<E>[]> {
-      const rows = await backend.findEdgesByKind({
-        graphId,
-        kind,
-        fromKind: from.kind,
-        fromId: from.id,
-        excludeDeleted: true,
-      });
-      return rows.map((row) => narrowEdge<E>(rowToEdge(row)));
+      return findEdgesFrom(from, backend);
     },
 
     async findTo(to: NodeRef): Promise<Edge<E>[]> {
-      const rows = await backend.findEdgesByKind({
-        graphId,
-        kind,
-        toKind: to.kind,
-        toId: to.id,
-        excludeDeleted: true,
-      });
-      return rows.map((row) => narrowEdge<E>(rowToEdge(row)));
+      return findEdgesTo(to, backend);
+    },
+
+    batchFindFrom(from: NodeRef): BatchableQuery<Edge<E>> {
+      return { executeOn: (target) => findEdgesFrom(from, target) };
+    },
+
+    batchFindTo(to: NodeRef): BatchableQuery<Edge<E>> {
+      return { executeOn: (target) => findEdgesTo(to, target) };
+    },
+
+    batchFindByEndpoints(
+      from: NodeRef,
+      to: NodeRef,
+      options?: EdgeFindByEndpointsOptions<E>,
+    ): BatchableQuery<Edge<E>> {
+      return {
+        executeOn: async (target) => {
+          const result = await config.executeFindByEndpoints(
+            kind,
+            from.kind,
+            from.id,
+            to.kind,
+            to.id,
+            target,
+            buildFindByEndpointsOptions(options),
+          );
+          return result === undefined ? [] : [narrowEdge<E>(result)];
+        },
+      };
     },
 
     async delete(id: string): Promise<void> {
@@ -382,7 +446,7 @@ export function createEdgeCollection<
       if (options?.offset !== undefined) params.offset = options.offset;
 
       const rows = await backend.findEdgesByKind(params);
-      return rows.map((row) => narrowEdge<E>(rowToEdge(row)));
+      return mapRows(rows);
     },
 
     async count(
@@ -607,15 +671,6 @@ export function createEdgeCollection<
       to: NodeRef,
       options?: EdgeFindByEndpointsOptions<E>,
     ): Promise<Edge<E> | undefined> {
-      const findOptions: {
-        matchOn?: readonly string[];
-        props?: Record<string, unknown>;
-      } = {};
-      if (options?.matchOn !== undefined)
-        findOptions.matchOn = options.matchOn as readonly string[];
-      if (options?.props !== undefined)
-        findOptions.props = options.props as Record<string, unknown>;
-
       const result = await config.executeFindByEndpoints(
         kind,
         from.kind,
@@ -623,7 +678,7 @@ export function createEdgeCollection<
         to.kind,
         to.id,
         backend,
-        findOptions,
+        buildFindByEndpointsOptions(options),
       );
       return result === undefined ? undefined : narrowEdge<E>(result);
     },

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -15,7 +15,7 @@ import {
   type TemporalMode,
 } from "../core/types";
 import type { TraversalExpansion } from "../query/ast";
-import type { NodeAccessor } from "../query/builder/types";
+import type { BatchableQuery, NodeAccessor } from "../query/builder/types";
 import { type SqlSchema } from "../query/compiler/schema";
 import type { Predicate } from "../query/predicates";
 
@@ -640,6 +640,32 @@ export type EdgeCollection<
 
   /** Find edges to a specific node */
   findTo: (to: NodeRef<To>) => Promise<Edge<E, From, To>[]>;
+
+  /**
+   * Deferred variant of `findFrom` for use with `store.batch()`.
+   *
+   * Returns a `BatchableQuery` instead of executing immediately.
+   */
+  batchFindFrom: (from: NodeRef<From>) => BatchableQuery<Edge<E, From, To>>;
+
+  /**
+   * Deferred variant of `findTo` for use with `store.batch()`.
+   *
+   * Returns a `BatchableQuery` instead of executing immediately.
+   */
+  batchFindTo: (to: NodeRef<To>) => BatchableQuery<Edge<E, From, To>>;
+
+  /**
+   * Deferred variant of `findByEndpoints` for use with `store.batch()`.
+   *
+   * Returns a `BatchableQuery` that yields a 0-or-1 element array
+   * (matching `findByEndpoints`' at-most-one semantics).
+   */
+  batchFindByEndpoints: (
+    from: NodeRef<From>,
+    to: NodeRef<To>,
+    options?: EdgeFindByEndpointsOptions<E>,
+  ) => BatchableQuery<Edge<E, From, To>>;
 
   /** Delete an edge (soft delete - sets deletedAt timestamp) */
   delete: (id: EdgeId<E>) => Promise<void>;

--- a/packages/typegraph/test-d/public-api.test-d.ts
+++ b/packages/typegraph/test-d/public-api.test-d.ts
@@ -2,9 +2,11 @@ import { expectAssignable, expectError, expectType } from "tsd";
 import { z } from "zod";
 
 import {
+  type BatchableQuery,
   defineEdge,
   defineGraph,
   defineNode,
+  type Edge,
   type EdgeId,
   getEdgeKinds,
   getNodeKinds,
@@ -126,3 +128,28 @@ expectError(
     title: "Roadmap",
   }),
 );
+
+// ============================================================
+// Edge batchFind* — published .d.ts surface
+// ============================================================
+
+declare const personRef: NodeRef<typeof Person>;
+declare const companyRef: NodeRef<typeof Company>;
+
+// batchFindFrom / batchFindTo return BatchableQuery with correct edge type
+type WorksAtEdge = Edge<typeof worksAt, typeof Person, typeof Company>;
+
+expectType<BatchableQuery<WorksAtEdge>>(
+  store.edges.worksAt.batchFindFrom(personRef),
+);
+expectType<BatchableQuery<WorksAtEdge>>(
+  store.edges.worksAt.batchFindTo(companyRef),
+);
+expectType<BatchableQuery<WorksAtEdge>>(
+  store.edges.worksAt.batchFindByEndpoints(personRef, companyRef),
+);
+
+// Endpoint constraints are enforced on batchFind* methods
+expectError(store.edges.worksAt.batchFindFrom(companyRef));
+expectError(store.edges.worksAt.batchFindTo(personRef));
+expectError(store.edges.worksAt.batchFindByEndpoints(companyRef, personRef));

--- a/packages/typegraph/tests/batch.test.ts
+++ b/packages/typegraph/tests/batch.test.ts
@@ -16,6 +16,7 @@ import {
   type Store,
 } from "../src";
 import type { GraphBackend } from "../src/backend/types";
+import type { Node } from "../src/store/types";
 import { createTestBackend } from "./test-utils";
 
 // ============================================================
@@ -75,23 +76,28 @@ type TestGraph = typeof graph;
 describe("store.batch()", () => {
   let backend: GraphBackend;
   let store: Store<TestGraph>;
+  let alice: Node<typeof Person>;
+  let bob: Node<typeof Person>;
+  let acme: Node<typeof Company>;
+  let globex: Node<typeof Company>;
+  let ts: Node<typeof Skill>;
 
   beforeEach(async () => {
     backend = createTestBackend();
     store = createStore(graph, backend);
 
     // Seed data
-    const alice = await store.nodes.Person.create({ name: "Alice", age: 30 });
-    const bob = await store.nodes.Person.create({ name: "Bob", age: 25 });
-    const acme = await store.nodes.Company.create({
+    alice = await store.nodes.Person.create({ name: "Alice", age: 30 });
+    bob = await store.nodes.Person.create({ name: "Bob", age: 25 });
+    acme = await store.nodes.Company.create({
       name: "Acme",
       industry: "Tech",
     });
-    const globex = await store.nodes.Company.create({
+    globex = await store.nodes.Company.create({
       name: "Globex",
       industry: "Manufacturing",
     });
-    const ts = await store.nodes.Skill.create({
+    ts = await store.nodes.Skill.create({
       name: "TypeScript",
       level: 9,
     });
@@ -305,5 +311,126 @@ describe("store.batch()", () => {
 
     expect(page).toHaveLength(1);
     expect(page[0]!.name).toBe("Bob"); // Second person alphabetically
+  });
+
+  // ============================================================
+  // Edge collection batchFind*
+  // ============================================================
+
+  it("batches edge batchFindFrom with fluent queries", async () => {
+    const [skills, companies] = await store.batch(
+      store.edges.hasSkill.batchFindFrom(alice),
+      store.edges.worksAt.batchFindFrom(alice),
+    );
+
+    expect(skills).toHaveLength(2);
+    expect(companies).toHaveLength(1);
+    expect(companies[0]!.kind).toBe("worksAt");
+  });
+
+  it("batches edge batchFindTo lookups", async () => {
+    const [hasSkillEdges] = await store.batch(
+      store.edges.hasSkill.batchFindTo(ts),
+      store
+        .query()
+        .from("Skill", "s")
+        .select((ctx) => ({ name: ctx.s.name })),
+    );
+
+    // Alice and Bob both have TypeScript
+    expect(hasSkillEdges).toHaveLength(2);
+  });
+
+  it("batchFind returns empty array when no edges match", async () => {
+    const [toAcme, toGlobex] = await store.batch(
+      store.edges.worksAt.batchFindTo(acme),
+      store.edges.worksAt.batchFindTo(globex),
+    );
+
+    expect(toAcme).toHaveLength(1); // Alice works at Acme
+    expect(toGlobex).toHaveLength(1); // Bob works at Globex
+
+    // Create a company with no edges
+    const orphan = await store.nodes.Company.create({ name: "Orphan" });
+    const [noEdges] = await store.batch(
+      store.edges.worksAt.batchFindTo(orphan),
+      store.edges.worksAt.batchFindTo(acme),
+    );
+
+    expect(noEdges).toHaveLength(0);
+  });
+
+  it("mixes edge queries with fluent queries in a single batch", async () => {
+    const [bobEdges, allPeople, bobSkillEdges] = await store.batch(
+      store.edges.worksAt.batchFindFrom(bob),
+      store
+        .query()
+        .from("Person", "p")
+        .select((ctx) => ({ name: ctx.p.name })),
+      store.edges.hasSkill.batchFindFrom(bob),
+    );
+
+    expect(bobEdges).toHaveLength(1);
+    expect(bobEdges[0]!.role).toBe("Manager");
+    expect(allPeople).toHaveLength(2);
+    expect(bobSkillEdges).toHaveLength(1);
+  });
+
+  it("batchFindFrom excludes soft-deleted edges", async () => {
+    const aliceSkills = await store.edges.hasSkill.findFrom(alice);
+    await store.edges.hasSkill.delete(aliceSkills[0]!.id);
+
+    const [remaining] = await store.batch(
+      store.edges.hasSkill.batchFindFrom(alice),
+      store
+        .query()
+        .from("Skill", "s")
+        .select((ctx) => ({ name: ctx.s.name })),
+    );
+
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("batches batchFindByEndpoints lookups", async () => {
+    const [aliceAtAcme, bobAtAcme] = await store.batch(
+      store.edges.worksAt.batchFindByEndpoints(alice, acme),
+      store.edges.worksAt.batchFindByEndpoints(bob, acme),
+    );
+
+    // Alice works at Acme — 1 result
+    expect(aliceAtAcme).toHaveLength(1);
+    expect(aliceAtAcme[0]!.role).toBe("Engineer");
+
+    // Bob does not work at Acme — 0 results
+    expect(bobAtAcme).toHaveLength(0);
+  });
+
+  it("batchFindByEndpoints passes matchOn and props options", async () => {
+    const [matchingRole, wrongRole] = await store.batch(
+      store.edges.worksAt.batchFindByEndpoints(alice, acme, {
+        matchOn: ["role"],
+        props: { role: "Engineer" },
+      }),
+      store.edges.worksAt.batchFindByEndpoints(alice, acme, {
+        matchOn: ["role"],
+        props: { role: "CEO" },
+      }),
+    );
+
+    expect(matchingRole).toHaveLength(1);
+    expect(matchingRole[0]!.role).toBe("Engineer");
+    expect(wrongRole).toHaveLength(0);
+  });
+
+  it("batchFindByEndpoints excludes soft-deleted edges", async () => {
+    const aliceEdges = await store.edges.worksAt.findFrom(alice);
+    await store.edges.worksAt.delete(aliceEdges[0]!.id);
+
+    const [result] = await store.batch(
+      store.edges.worksAt.batchFindByEndpoints(alice, acme),
+      store.edges.worksAt.batchFindFrom(bob),
+    );
+
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/typegraph/tests/query-builder-types.test.ts
+++ b/packages/typegraph/tests/query-builder-types.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  type BatchableQuery,
   createQueryBuilder,
   defineEdge,
   defineGraph,
@@ -23,6 +24,7 @@ import {
   type TypedEdgeCollection,
 } from "../src";
 import { buildKindRegistry } from "../src/registry";
+import type { Edge } from "../src/store/types";
 
 // ============================================================
 // Test Graph Definition
@@ -534,6 +536,78 @@ describe("Edge Collection Type Safety", () => {
 
       expect(validTo.kind).toBe("Company");
       void invalidTo;
+    });
+
+    it("constrains batchFindFrom to accept only valid from types", () => {
+      type WorksAtCollection = StoreEdges["worksAt"];
+      type Param = Parameters<WorksAtCollection["batchFindFrom"]>[0];
+
+      const validFrom: Param = { kind: "Person", id: "test-id" };
+
+      // @ts-expect-error - Company is not a valid 'from' type for worksAt
+      const invalidFrom: Param = { kind: "Company", id: "test-id" };
+
+      expect(validFrom.kind).toBe("Person");
+      void invalidFrom;
+    });
+
+    it("constrains batchFindTo to accept only valid to types", () => {
+      type WorksAtCollection = StoreEdges["worksAt"];
+      type Param = Parameters<WorksAtCollection["batchFindTo"]>[0];
+
+      const validTo: Param = { kind: "Company", id: "test-id" };
+
+      // @ts-expect-error - Person is not a valid 'to' type for worksAt
+      const invalidTo: Param = { kind: "Person", id: "test-id" };
+
+      expect(validTo.kind).toBe("Company");
+      void invalidTo;
+    });
+
+    it("constrains batchFindByEndpoints to accept valid from/to types", () => {
+      type WorksAtCollection = StoreEdges["worksAt"];
+      type Params = Parameters<WorksAtCollection["batchFindByEndpoints"]>;
+      type FromParam = Params[0];
+      type ToParam = Params[1];
+
+      const validFrom: FromParam = { kind: "Person", id: "test-id" };
+      const validTo: ToParam = { kind: "Company", id: "test-id" };
+
+      // @ts-expect-error - Company is not a valid 'from' type for worksAt
+      const invalidFrom: FromParam = { kind: "Company", id: "test-id" };
+
+      // @ts-expect-error - Person is not a valid 'to' type for worksAt
+      const invalidTo: ToParam = { kind: "Person", id: "test-id" };
+
+      expect(validFrom.kind).toBe("Person");
+      expect(validTo.kind).toBe("Company");
+      void invalidFrom;
+      void invalidTo;
+    });
+
+    it("batchFind methods return BatchableQuery with correct edge type", () => {
+      type WorksAtCollection = StoreEdges["worksAt"];
+      type WorksAtEdge = Edge<typeof worksAt, typeof Person, typeof Company>;
+
+      // Verify return types satisfy BatchableQuery
+      type FromResult = ReturnType<WorksAtCollection["batchFindFrom"]>;
+      type ToResult = ReturnType<WorksAtCollection["batchFindTo"]>;
+      type ByEndpointsResult = ReturnType<
+        WorksAtCollection["batchFindByEndpoints"]
+      >;
+
+      // All three return BatchableQuery<WorksAtEdge>
+      const _checkFrom: BatchableQuery<WorksAtEdge> =
+        {} as unknown as FromResult;
+      const _checkTo: BatchableQuery<WorksAtEdge> = {} as unknown as ToResult;
+      const _checkByEndpoints: BatchableQuery<WorksAtEdge> =
+        {} as unknown as ByEndpointsResult;
+
+      void _checkFrom;
+      void _checkTo;
+      void _checkByEndpoints;
+
+      expect(true).toBe(true);
     });
   });
 });


### PR DESCRIPTION
- Add `batchFindFrom`, `batchFindTo`, and `batchFindByEndpoints` to edge collections, returning `BatchableQuery` for use with `store.batch()`
- Add compile-time type assertions (source-level `@ts-expect-error` + tsd declaration tests) verifying endpoint constraints and return types
- Update docs: schemas-stores, queries/execute, performance/overview

## Motivation

Edge collection lookups (`findFrom`, `findTo`, `findByEndpoints`) execute immediately and can't participate in `store.batch()`. This forces users to rewrite simple edge lookups as verbose fluent traverse queries to batch them. The new `batchFind*` variants close this gap.

```typescript
const [skills, employer] = await store.batch(
  store.edges.hasSkill.batchFindFrom(alice),
  store.edges.worksAt.batchFindFrom(alice),
);
```

Closes #51