### PR TITLE
fix: reject empty index fields at the type level

### DIFF
--- a/.changeset/edge-index-empty-fields-type.md
+++ b/.changeset/edge-index-empty-fields-type.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Reject empty `fields` arrays at the type level in `defineNodeIndex` and `defineEdgeIndex`. Previously, passing `fields: []` was accepted by TypeScript but threw at runtime. The `fields` property now requires a non-empty tuple, surfacing the error at compile time.

--- a/packages/typegraph/src/indexes/types.ts
+++ b/packages/typegraph/src/indexes/types.ts
@@ -169,7 +169,10 @@ export type IndexFieldInput<T> =
   | JsonPointer;
 
 export type NodeIndexConfig<N extends NodeType> = Readonly<{
-  fields: readonly IndexFieldInput<z.infer<N["schema"]>>[];
+  fields: readonly [
+    IndexFieldInput<z.infer<N["schema"]>>,
+    ...IndexFieldInput<z.infer<N["schema"]>>[],
+  ];
   coveringFields?: readonly IndexFieldInput<z.infer<N["schema"]>>[] | undefined;
   unique?: boolean | undefined;
   name?: string | undefined;
@@ -180,7 +183,10 @@ export type NodeIndexConfig<N extends NodeType> = Readonly<{
 export type EdgeIndexDirection = "out" | "in" | "none";
 
 export type EdgeIndexConfig<E extends AnyEdgeType> = Readonly<{
-  fields: readonly IndexFieldInput<z.infer<E["schema"]>>[];
+  fields: readonly [
+    IndexFieldInput<z.infer<E["schema"]>>,
+    ...IndexFieldInput<z.infer<E["schema"]>>[],
+  ];
   coveringFields?: readonly IndexFieldInput<z.infer<E["schema"]>>[] | undefined;
   unique?: boolean | undefined;
   name?: string | undefined;

--- a/packages/typegraph/tests/indexes.test.ts
+++ b/packages/typegraph/tests/indexes.test.ts
@@ -182,6 +182,7 @@ describe("indexes", () => {
   it("throws when fields array is empty", () => {
     expect(() => {
       defineNodeIndex(Person, {
+        // @ts-expect-error Empty fields should be a type error
         fields: [],
       });
     }).toThrow(/must not be empty/);


### PR DESCRIPTION
## Summary

- Changes `fields` from `readonly T[]` to `readonly [T, ...T[]]` in both `NodeIndexConfig` and `EdgeIndexConfig`, making `fields: []` a compile-time error
- Also applied the same fix to `NodeIndexConfig` which had the identical gap
- Runtime validation in `normalizeEdgeIndexFieldsOrThrow` / `normalizeNodeIndexFieldsOrThrow` remains as a safety net

Closes #58
