### PR TITLE
fix: export SchemaValidationResult from root package API

### DIFF
--- a/.changeset/export-schema-validation-result.md
+++ b/.changeset/export-schema-validation-result.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Export `SchemaValidationResult` and `SchemaManagerOptions` types from the root package entry point so users can type the return value of `createStoreWithSchema()` without reaching into internal subpaths.

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -192,7 +192,11 @@ export {
 // Store
 // ============================================================
 
-export type { Store } from "./store";
+export type {
+  SchemaManagerOptions,
+  SchemaValidationResult,
+  Store,
+} from "./store";
 export { createStore, createStoreWithSchema } from "./store";
 export type {
   AnyEdge,


### PR DESCRIPTION
## Summary

- Re-exports `SchemaValidationResult` and `SchemaManagerOptions` from the root `@nicia-ai/typegraph` entry point
- Users can now type `createStoreWithSchema()` return values without importing from internal subpaths

Closes #57