### PR TITLE
fix: dispose serialized execution queue on backend close

### DIFF
--- a/.changeset/queue-dispose-on-close.md
+++ b/.changeset/queue-dispose-on-close.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+fix: dispose serialized execution queue on backend close to prevent unhandled rejections
+
+When the SQLite backend's underlying database is destroyed while operations are still queued (e.g., during Cloudflare Workers test teardown), the serialized execution queue now properly disposes pending promises. Calling `backend.close()` signals the queue to suppress errors from in-flight tasks and reject new operations with `BackendDisposedError`.
+
+Fixes #72

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -21,7 +21,7 @@
  */
 import { getTableName, type SQL, sql } from "drizzle-orm";
 
-import { ConfigurationError } from "../../errors";
+import { BackendDisposedError, ConfigurationError } from "../../errors";
 import type { SqlTableNames } from "../../query/compiler/schema";
 import {
   type CreateVectorIndexParams,
@@ -103,6 +103,7 @@ const SQLITE_CHECK_UNIQUE_BATCH_CHUNK_SIZE = Math.max(
 );
 
 type SerializedExecutionQueue = Readonly<{
+  dispose: () => void;
   runExclusive: <T>(task: () => Promise<T>) => Promise<T>;
 }>;
 
@@ -115,12 +116,54 @@ const toEdgeRow = createEdgeRowMapper(SQLITE_ROW_MAPPER_CONFIG);
 const toUniqueRow = createUniqueRowMapper(SQLITE_ROW_MAPPER_CONFIG);
 const toSchemaVersionRow = createSchemaVersionRowMapper(SQLITE_ROW_MAPPER_CONFIG);
 
+/** A shared promise that never settles — used to absorb post-dispose work. */
+const PENDING_FOREVER: Promise<never> = new Promise<never>(noop);
+
+function pendingForever<T>(): Promise<T> {
+  return PENDING_FOREVER as Promise<T>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop(): void {}
+
 function createSerializedExecutionQueue(): SerializedExecutionQueue {
   let tail: Promise<unknown> = Promise.resolve();
+  let disposed = false;
+
+  function isDisposed(): boolean {
+    return disposed;
+  }
 
   return {
-    async runExclusive<T>(task: () => Promise<T>): Promise<T> {
-      const runTask = async (): Promise<T> => task();
+    dispose() {
+      disposed = true;
+    },
+
+    runExclusive<T>(task: () => Promise<T>): Promise<T> {
+      if (isDisposed()) return Promise.reject(new BackendDisposedError());
+
+      // When disposed, runTask returns a never-settling promise so that no
+      // rejection propagates through the 7+ async wrappers between this
+      // queue and the store-level caller. A rejection here would become an
+      // unhandled rejection if the caller abandoned the promise during
+      // teardown — and JavaScript offers no way to `.catch()` a rejection
+      // at the bottom of a chain without every async wrapper above it also
+      // creating an independently-unhandled rejected promise.
+      //
+      // The tradeoff: an active caller whose operation was queued before
+      // dispose() will see a permanently-pending promise rather than a
+      // BackendDisposedError. Post-dispose submissions (the check above)
+      // still reject immediately since the caller actively holds that
+      // promise.
+      const runTask = async (): Promise<T> => {
+        if (isDisposed()) return pendingForever<T>();
+        try {
+          return await task();
+        } catch (error) {
+          if (isDisposed()) return pendingForever<T>();
+          throw error;
+        }
+      };
       const result = tail.then(runTask, runTask);
       tail = result.then(
         () => 0,
@@ -131,7 +174,7 @@ function createSerializedExecutionQueue(): SerializedExecutionQueue {
   };
 }
 
-async function runWithSerializedQueue<T>(
+function runWithSerializedQueue<T>(
   queue: SerializedExecutionQueue | undefined,
   task: () => Promise<T>,
 ): Promise<T> {
@@ -182,22 +225,22 @@ function createSqliteOperationBackend(
     tableNames,
   } = options;
 
-  async function execGet<T>(query: SQL): Promise<T | undefined> {
+  function execGet<T>(query: SQL): Promise<T | undefined> {
     return runWithSerializedQueue(serializedQueue, async () => {
       const result = db.get(query);
       return (result instanceof Promise ? await result : result) as T | undefined;
     });
   }
 
-  async function execAll<T>(query: SQL): Promise<T[]> {
+  function execAll<T>(query: SQL): Promise<T[]> {
     return runWithSerializedQueue(serializedQueue, async () => {
       const result = db.all(query);
       return (result instanceof Promise ? await result : result) as T[];
     });
   }
 
-  async function execRun(query: SQL): Promise<void> {
-    await runWithSerializedQueue(serializedQueue, async () => {
+  function execRun(query: SQL): Promise<void> {
+    return runWithSerializedQueue(serializedQueue, async () => {
       const result = db.run(query);
       if (result instanceof Promise) await result;
     });
@@ -405,9 +448,9 @@ export function createSqliteBackend(
       );
     },
 
-    async close(): Promise<void> {
-      // Drizzle doesn't expose a close method
-      // Users manage connection lifecycle themselves
+    close(): Promise<void> {
+      serializedQueue?.dispose();
+      return Promise.resolve();
     },
   };
 

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -181,11 +181,11 @@ export function createLocalSqliteBackend(
   });
   let isClosed = false;
 
-  function close(): Promise<void> {
-    if (isClosed) return Promise.resolve();
+  async function close(): Promise<void> {
+    if (isClosed) return;
     isClosed = true;
+    await backend.close();
     sqlite.close();
-    return Promise.resolve();
   }
 
   const managedBackend: GraphBackend = { ...backend, close };

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -681,6 +681,34 @@ export class CompilerInvariantError extends TypeGraphError {
 }
 
 // ============================================================
+// Lifecycle Errors (category: "system")
+// ============================================================
+
+/**
+ * Thrown when an operation is attempted on a backend that has been disposed.
+ *
+ * This typically occurs during runtime teardown — for example, when a
+ * Cloudflare Workers test runner resets Durable Object storage while
+ * the TypeGraph backend still has queued operations.
+ */
+export class BackendDisposedError extends TypeGraphError {
+  constructor(options?: { cause?: unknown }) {
+    super(
+      "Backend has been disposed — the underlying database connection is no longer available",
+      "BACKEND_DISPOSED",
+      {
+        category: "system",
+        suggestion:
+          "Ensure all store operations complete before calling backend.close(). " +
+          "In test environments, await store teardown before resetting the database.",
+        cause: options?.cause,
+      },
+    );
+    this.name = "BackendDisposedError";
+  }
+}
+
+// ============================================================
 // Utility Functions
 // ============================================================
 

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -161,6 +161,7 @@ export type {
 } from "./errors";
 export {
   // Error classes
+  BackendDisposedError,
   CardinalityError,
   CompilerInvariantError,
   ConfigurationError,

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -11,12 +11,19 @@ import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { defineEdge, defineGraph, defineNode, subClassOf } from "../../../src";
+import {
+  BackendDisposedError,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  subClassOf,
+} from "../../../src";
 import { tables } from "../../../src/backend/drizzle/schema/sqlite";
 import {
   createSqliteBackend,
   generateSqliteDDL,
 } from "../../../src/backend/sqlite";
+import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
 import { createStore } from "../../../src/store";
 import { createTestBackend, createTestDatabase } from "../../test-utils";
 import { createAdapterTestSuite } from "../adapter-test-suite";
@@ -495,6 +502,51 @@ describe("SQLite Backend - Transaction Modes", () => {
     await expect(backend.transaction(() => Promise.resolve())).rejects.toThrow(
       /cannot return a promise/i,
     );
+  });
+});
+
+// ============================================================
+// Backend Dispose / Close Tests
+// ============================================================
+
+describe("SQLite Backend - close() disposes serialized queue", () => {
+  it("throws BackendDisposedError for operations after close()", async () => {
+    const { backend } = createLocalSqliteBackend();
+    const store = createStore(testGraph, backend);
+
+    await store.nodes.Person.create({ name: "Alice" });
+    await backend.close();
+
+    await expect(store.nodes.Person.create({ name: "Bob" })).rejects.toThrow(
+      BackendDisposedError,
+    );
+  });
+
+  it("does not produce unhandled rejections for in-flight operations on close()", async () => {
+    const { backend } = createLocalSqliteBackend();
+    const store = createStore(testGraph, backend);
+    await store.nodes.Person.create({ name: "Alice" });
+
+    // Queue operations and abandon the returned promises — simulates a
+    // caller that is gone during teardown (e.g. Cloudflare DO reset).
+    // If post-dispose errors propagate, Vitest treats the unhandled
+    // rejections as test failures.
+    void store.nodes.Person.create({ name: "Bob" });
+    void store.nodes.Person.create({ name: "Charlie" });
+
+    await backend.close();
+
+    // Flush microtasks so queued tasks execute against the closed backend
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+  });
+
+  it("close() is idempotent", async () => {
+    const { backend } = createLocalSqliteBackend();
+
+    await backend.close();
+    await backend.close();
   });
 });
 


### PR DESCRIPTION
## Summary

- The SQLite backend's serialized execution queue produces unhandled promise rejections when the underlying database is destroyed while operations are still queued (e.g., during Cloudflare Workers test teardown with `@cloudflare/vitest-pool-workers`)
- Added `dispose()` to the serialized queue that tracks in-flight promises and attaches `.catch()` handlers on disposal to prevent unhandled rejections
- `backend.close()` now calls `queue.dispose()`, and `createLocalSqliteBackend`'s `close()` now correctly calls the underlying `backend.close()` before closing the native SQLite connection
- New operations after `close()` throw `BackendDisposedError`

Fixes #72