### PR TITLE
feat: support orderBy on edge properties in query builder

### DIFF
--- a/.changeset/edge-order-by.md
+++ b/.changeset/edge-order-by.md
@@ -1,0 +1,21 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+feat: support orderBy on edge properties in query builder
+
+The `orderBy` method now accepts edge aliases in addition to node aliases, allowing results to be ordered by properties on traversed edges. This eliminates the need to denormalize ordering fields onto nodes or sort in memory.
+
+```typescript
+store.query()
+  .from("Person", "p")
+  .traverse("worksAt", "e")
+  .to("Company", "c")
+  .orderBy("e", "salary", "asc")  // order by edge property
+  .select((ctx) => ({ name: ctx.p.name, salary: ctx.e.salary }))
+  .execute();
+```
+
+Also fixes CTE alias resolution for edge aliases in `groupBy` and vector order-by compilation paths.
+
+Closes #76

--- a/packages/typegraph/examples/10-postgresql.ts
+++ b/packages/typegraph/examples/10-postgresql.ts
@@ -217,15 +217,13 @@ export async function main() {
       .from("Organization", "o")
       .traverse("worksAt", "e", { direction: "in" })
       .to("Person", "p")
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- traverse edge typing limitation
-      .select((ctx: any) => ({
+      .select((ctx) => ({
         org: ctx.o.name,
         person: ctx.p.name,
         role: ctx.e.role,
         startDate: ctx.e.startDate,
       }))
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- traverse edge typing limitation
-      .orderBy("e" as any, "startDate", "asc")
+      .orderBy("e", "startDate", "asc")
       .execute();
 
     console.log(`${org.name} employees:`);

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -11,6 +11,7 @@ import { DEFAULT_PAGINATION_LIMIT } from "../../constants";
 import { type GraphDef } from "../../core/define-graph";
 import { UnsupportedPredicateError, ValidationError } from "../../errors";
 import {
+  mergeEdgeKinds,
   type OrderSpec,
   type QueryAst,
   type SelectiveField,
@@ -41,6 +42,7 @@ import {
 } from "../execution";
 import { jsonPointer, parseJsonPointer } from "../json-pointer";
 import { fieldRef } from "../predicates";
+import { type FieldTypeInfo } from "../schema-introspector";
 import { buildQueryAst } from "./ast-builder";
 import { hasParameterReferences, PreparedQuery } from "./prepared-query";
 import {
@@ -133,30 +135,59 @@ export class ExecutableQuery<
   /**
    * Orders results.
    */
-  orderBy<A extends keyof Aliases & string>(
+  orderBy<A extends (keyof Aliases | keyof EdgeAliases) & string>(
     alias: A,
     field: string,
     direction: SortDirection = "asc",
   ): ExecutableQuery<G, Aliases, EdgeAliases, RecursiveAliases, R> {
-    const kindNames =
-      alias === this.#state.startAlias ?
-        this.#state.startKinds
-      : this.#state.traversals.find(
-          (traversal) => traversal.nodeAlias === alias,
-        )?.nodeKinds;
-    const typeInfo =
-      kindNames ?
-        this.#config.schemaIntrospector.getSharedFieldTypeInfo(kindNames, field)
-      : undefined;
+    const edgeTraversal = this.#state.traversals.find(
+      (traversal) => traversal.edgeAlias === alias,
+    );
+    const isEdge = edgeTraversal !== undefined;
+    const isSystem =
+      field === "id" ||
+      field === "kind" ||
+      (isEdge && (field === "from_id" || field === "to_id"));
 
-    const orderSpec: OrderSpec = {
-      field: fieldRef(alias, ["props"], {
-        jsonPointer: jsonPointer([field]),
-        valueType: typeInfo?.valueType,
-        elementType: typeInfo?.elementType,
-      }),
-      direction,
-    };
+    let typeInfo: FieldTypeInfo | undefined;
+    if (!isSystem) {
+      if (isEdge) {
+        const edgeKindNames = mergeEdgeKinds(edgeTraversal);
+        typeInfo = this.#config.schemaIntrospector.getSharedEdgeFieldTypeInfo(
+          edgeKindNames,
+          field,
+        );
+      } else {
+        const kindNames =
+          alias === this.#state.startAlias ?
+            this.#state.startKinds
+          : this.#state.traversals.find(
+              (traversal) => traversal.nodeAlias === alias,
+            )?.nodeKinds;
+        typeInfo =
+          kindNames ?
+            this.#config.schemaIntrospector.getSharedFieldTypeInfo(
+              kindNames,
+              field,
+            )
+          : undefined;
+      }
+    }
+
+    const orderSpec: OrderSpec =
+      isSystem ?
+        {
+          field: fieldRef(alias, [field], { valueType: "string" }),
+          direction,
+        }
+      : {
+          field: fieldRef(alias, ["props"], {
+            jsonPointer: jsonPointer([field]),
+            valueType: typeInfo?.valueType,
+            elementType: typeInfo?.elementType,
+          }),
+          direction,
+        };
 
     const newState: QueryBuilderState = {
       ...this.#state,

--- a/packages/typegraph/src/query/builder/query-builder.ts
+++ b/packages/typegraph/src/query/builder/query-builder.ts
@@ -628,14 +628,25 @@ export class QueryBuilder<
   /**
    * Orders results.
    */
-  orderBy<A extends keyof Aliases & string>(
+  orderBy<A extends (keyof Aliases | keyof EdgeAliases) & string>(
     alias: A,
     field: string,
     direction: SortDirection = "asc",
   ): QueryBuilder<G, Aliases, EdgeAliases, RecursiveAliases> {
-    const isSystem = field === "id" || field === "kind";
+    const edgeKindNames = this.#getEdgeKindNamesForAlias(alias);
+    const isEdge = edgeKindNames !== undefined;
+    const isSystem =
+      field === "id" ||
+      field === "kind" ||
+      (isEdge && (field === "from_id" || field === "to_id"));
     const typeInfo =
-      isSystem ? undefined : this.#getOrderByTypeInfo(alias, field);
+      isSystem ? undefined
+      : isEdge ?
+        this.#config.schemaIntrospector.getSharedEdgeFieldTypeInfo(
+          edgeKindNames,
+          field,
+        )
+      : this.#getOrderByTypeInfo(alias, field);
     const orderSpec: OrderSpec =
       isSystem ?
         {

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -424,20 +424,28 @@ export function buildStandardProjection(
   return sql.join(projectedFields, sql`, `);
 }
 
+/**
+ * Builds a map from query aliases (node and edge) to their CTE table names.
+ * Edge aliases map to the CTE of the traversal node they are co-projected with.
+ */
+function buildAliasToCteMap(ast: QueryAst): Map<string, string> {
+  const map = new Map<string, string>([
+    [ast.start.alias, `cte_${ast.start.alias}`],
+  ]);
+  for (const traversal of ast.traversals) {
+    map.set(traversal.nodeAlias, `cte_${traversal.nodeAlias}`);
+    map.set(traversal.edgeAlias, `cte_${traversal.nodeAlias}`);
+  }
+  return map;
+}
+
 function compileSelectiveProjection(
   fields: readonly SelectiveField[],
   dialect: DialectAdapter,
   ast: QueryAst,
   collapsedTraversalCteAlias?: string,
 ): SQL {
-  const aliasToCte = new Map<string, string>([
-    [ast.start.alias, `cte_${ast.start.alias}`],
-  ]);
-
-  for (const traversal of ast.traversals) {
-    aliasToCte.set(traversal.nodeAlias, `cte_${traversal.nodeAlias}`);
-    aliasToCte.set(traversal.edgeAlias, `cte_${traversal.nodeAlias}`);
-  }
+  const aliasToCte = buildAliasToCteMap(ast);
 
   const columns = fields.map((field) => {
     const cteAlias =
@@ -519,6 +527,7 @@ export function buildStandardOrderBy(
     return undefined;
   }
 
+  const aliasToCte = buildAliasToCteMap(ast);
   const parts: SQL[] = [];
   for (const orderSpec of ast.orderBy) {
     const valueType = orderSpec.field.valueType;
@@ -528,7 +537,9 @@ export function buildStandardOrderBy(
       );
     }
     const cteAlias =
-      collapsedTraversalCteAlias ?? `cte_${orderSpec.field.alias}`;
+      collapsedTraversalCteAlias ??
+      aliasToCte.get(orderSpec.field.alias) ??
+      `cte_${orderSpec.field.alias}`;
     const field = compileFieldValue(
       orderSpec.field,
       dialect,
@@ -591,8 +602,14 @@ export function buildStandardGroupBy(
     return undefined;
   }
 
+  const aliasToCte = buildAliasToCteMap(ast);
   const parts = allFields.map((field) =>
-    compileFieldValue(field, dialect, field.valueType, `cte_${field.alias}`),
+    compileFieldValue(
+      field,
+      dialect,
+      field.valueType,
+      aliasToCte.get(field.alias) ?? `cte_${field.alias}`,
+    ),
   );
 
   return sql`GROUP BY ${sql.join(parts, sql`, `)}`;
@@ -717,6 +734,7 @@ export function buildStandardVectorOrderBy(
   const additionalOrders: SQL[] = [];
 
   if (ast.orderBy && ast.orderBy.length > 0) {
+    const aliasToCte = buildAliasToCteMap(ast);
     for (const orderSpec of ast.orderBy) {
       const valueType = orderSpec.field.valueType;
       if (valueType === "array" || valueType === "object") {
@@ -724,7 +742,8 @@ export function buildStandardVectorOrderBy(
           "Ordering by JSON arrays or objects is not supported",
         );
       }
-      const cteAlias = `cte_${orderSpec.field.alias}`;
+      const cteAlias =
+        aliasToCte.get(orderSpec.field.alias) ?? `cte_${orderSpec.field.alias}`;
       const field = compileFieldValue(
         orderSpec.field,
         dialect,

--- a/packages/typegraph/tests/backends/integration/ordering.ts
+++ b/packages/typegraph/tests/backends/integration/ordering.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  seedMultiHopEdgePropertiesFixture,
+  seedPeopleCompaniesForEdgePropertySelection,
   seedPeopleForOrderByNullHandling,
   seedPeopleForOrderingWithNulls,
+  seedWorksAtEdgesWithNullSalaryValues,
 } from "./seed-helpers";
 import { type IntegrationTestContext } from "./test-context";
 
@@ -183,6 +186,211 @@ export function registerOrderingIntegrationTests(
       expect(results).toHaveLength(2);
       expect(results[0]?.name).toBe("Product A");
       expect(results[1]?.name).toBe("Product B");
+    });
+  });
+
+  describe("Edge Property Ordering", () => {
+    describe("single traversal", () => {
+      beforeEach(async () => {
+        const store = context.getStore();
+        await seedPeopleCompaniesForEdgePropertySelection(store);
+      });
+
+      it("orders by edge property ascending", async () => {
+        const store = context.getStore();
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("worksAt", "e")
+          .to("Company", "c")
+          .orderBy("e", "salary", "asc")
+          .select((ctx) => ({
+            name: ctx.p.name,
+            salary: ctx.e.salary,
+          }))
+          .execute();
+
+        expect(results).toHaveLength(3);
+        expect(results.map((result) => result.salary)).toEqual([
+          80_000, 120_000, 150_000,
+        ]);
+      });
+
+      it("orders by edge property descending", async () => {
+        const store = context.getStore();
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("worksAt", "e")
+          .to("Company", "c")
+          .orderBy("e", "salary", "desc")
+          .select((ctx) => ({
+            name: ctx.p.name,
+            salary: ctx.e.salary,
+          }))
+          .execute();
+
+        expect(results).toHaveLength(3);
+        expect(results.map((result) => result.salary)).toEqual([
+          150_000, 120_000, 80_000,
+        ]);
+      });
+
+      it("orders by edge string property", async () => {
+        const store = context.getStore();
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("worksAt", "e")
+          .to("Company", "c")
+          .orderBy("e", "role", "asc")
+          .select((ctx) => ({
+            name: ctx.p.name,
+            role: ctx.e.role,
+          }))
+          .execute();
+
+        expect(results).toHaveLength(3);
+        expect(results.map((result) => result.role)).toEqual([
+          "Analyst",
+          "Engineer",
+          "Manager",
+        ]);
+      });
+    });
+
+    describe("post-select ordering by edge property", () => {
+      beforeEach(async () => {
+        const store = context.getStore();
+        await seedPeopleCompaniesForEdgePropertySelection(store);
+      });
+
+      it("orders by numeric edge property after select (correct type-aware compilation)", async () => {
+        const store = context.getStore();
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("worksAt", "e")
+          .to("Company", "c")
+          .select((ctx) => ({
+            name: ctx.p.name,
+            salary: ctx.e.salary,
+          }))
+          .orderBy("e", "salary", "asc")
+          .execute();
+
+        expect(results).toHaveLength(3);
+        expect(results.map((result) => result.salary)).toEqual([
+          80_000, 120_000, 150_000,
+        ]);
+      });
+    });
+
+    describe("null handling on edge properties", () => {
+      beforeEach(async () => {
+        const store = context.getStore();
+        await seedWorksAtEdgesWithNullSalaryValues(store);
+      });
+
+      it("orders nullable edge property ascending (nulls last)", async () => {
+        const store = context.getStore();
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("worksAt", "e")
+          .to("Company", "c")
+          .orderBy("e", "salary", "asc")
+          .select((ctx) => ({
+            name: ctx.p.name,
+            salary: ctx.e.salary,
+          }))
+          .execute();
+
+        expect(results).toHaveLength(3);
+        expect(results.map((result) => result.salary)).toEqual([
+          100_000,
+          undefined,
+          undefined,
+        ]);
+      });
+
+      it("orders nullable edge property descending (nulls first)", async () => {
+        const store = context.getStore();
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("worksAt", "e")
+          .to("Company", "c")
+          .orderBy("e", "salary", "desc")
+          .select((ctx) => ({
+            name: ctx.p.name,
+            salary: ctx.e.salary,
+          }))
+          .execute();
+
+        expect(results).toHaveLength(3);
+        expect(results.map((result) => result.salary)).toEqual([
+          undefined,
+          undefined,
+          100_000,
+        ]);
+      });
+    });
+
+    describe("multi-hop traversal", () => {
+      beforeEach(async () => {
+        const store = context.getStore();
+        await seedMultiHopEdgePropertiesFixture(store);
+      });
+
+      it("orders by edge property on second traversal", async () => {
+        const store = context.getStore();
+        // Query from all people who know someone, then traverse to their companies
+        // Alice→Bob (Bob works at Acme 100k), Bob→Charlie (Charlie works at Globex 150k)
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("knows", "e1")
+          .to("Person", "friend")
+          .traverse("worksAt", "e2")
+          .to("Company", "c")
+          .orderBy("e2", "salary", "asc")
+          .select((ctx) => ({
+            person: ctx.p.name,
+            friend: ctx.friend.name,
+            company: ctx.c.name,
+            salary: ctx.e2.salary,
+          }))
+          .execute();
+
+        expect(results).toHaveLength(2);
+        expect(results.map((result) => result.salary)).toEqual([
+          100_000, 150_000,
+        ]);
+      });
+
+      it("orders by edge property combined with node property", async () => {
+        const store = context.getStore();
+        const results = await store
+          .query()
+          .from("Person", "p")
+          .traverse("knows", "e1")
+          .to("Person", "friend")
+          .traverse("worksAt", "e2")
+          .to("Company", "c")
+          .orderBy("e2", "salary", "desc")
+          .orderBy("friend", "name", "asc")
+          .select((ctx) => ({
+            friend: ctx.friend.name,
+            salary: ctx.e2.salary,
+          }))
+          .execute();
+
+        expect(results).toHaveLength(2);
+        expect(results.map((result) => result.salary)).toEqual([
+          150_000, 100_000,
+        ]);
+      });
     });
   });
 }


### PR DESCRIPTION
- Widen `orderBy` to accept edge aliases (`keyof EdgeAliases`) in addition to node aliases, allowing database-level ordering by properties on traversed edges
- Extract shared `buildAliasToCteMap` utility to correctly map edge aliases to the CTE of the node they are co-projected with
- Fix CTE alias resolution for edge aliases in `buildStandardOrderBy`, `buildStandardGroupBy`, and `buildStandardVectorOrderBy`

```typescript
store.query()
  .from("Person", "p")
  .traverse("worksAt", "e")
  .to("Company", "c")
  .orderBy("e", "salary", "asc")  // now works — was a type error before
  .select((ctx) => ({ name: ctx.p.name, salary: ctx.e.salary }))
  .execute();
```

Closes #76