### PR TITLE
feat!: return indexed subgraph result with adjacency maps

### DIFF
--- a/.changeset/indexed-subgraph-result.md
+++ b/.changeset/indexed-subgraph-result.md
@@ -1,0 +1,23 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+**BREAKING:** `store.subgraph()` now returns an indexed result instead of flat arrays.
+
+The result shape changes from `{ nodes: Node[], edges: Edge[] }` to:
+
+```typescript
+{
+  root: Node | undefined;
+  nodes: ReadonlyMap<string, Node>;
+  adjacency: ReadonlyMap<string, ReadonlyMap<EdgeKind, Edge[]>>;
+  reverseAdjacency: ReadonlyMap<string, ReadonlyMap<EdgeKind, Edge[]>>;
+}
+```
+
+This eliminates the indexing boilerplate every consumer had to write before traversing the subgraph. Nodes are keyed by ID for O(1) lookup, and edges are organized into forward/reverse adjacency maps keyed by `nodeId → edgeKind`.
+
+Migration:
+- `result.nodes` is now a `Map` — use `.size` instead of `.length`, `.values()` instead of direct iteration, `.has(id)` / `.get(id)` instead of `.find()`
+- `result.edges` is removed — access edges via `result.adjacency.get(fromId)?.get(edgeKind)` or `result.reverseAdjacency.get(toId)?.get(edgeKind)`
+- `result.root` provides the root node directly (no lookup needed)

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1238,7 +1238,8 @@ operations in a `store.transaction()`.
 #### `store.subgraph(rootId, options)`
 
 Extracts a typed subgraph by performing a BFS traversal from a root node, following
-the specified edge kinds. Returns all reachable nodes and the edges connecting them.
+the specified edge kinds. Returns an indexed result with adjacency maps for immediate
+traversal.
 
 Under the hood, this compiles to a single `WITH RECURSIVE` CTE — the traversal,
 filtering, and hydration all happen in the database.
@@ -1266,10 +1267,19 @@ store.subgraph<EK, NK>(
 
 ```typescript
 type SubgraphResult<G, NK, EK> = Readonly<{
-  nodes: readonly SubsetNode<G, NK>[];
-  edges: readonly SubsetEdge<G, EK>[];
+  root: SubgraphNodeResult<G, NK> | undefined;
+  nodes: ReadonlyMap<string, SubgraphNodeResult<G, NK>>;
+  adjacency: ReadonlyMap<string, ReadonlyMap<EK, readonly SubgraphEdgeResult<G, EK>[]>>;
+  reverseAdjacency: ReadonlyMap<string, ReadonlyMap<EK, readonly SubgraphEdgeResult<G, EK>[]>>;
 }>;
 ```
+
+| Field | Description |
+|-------|-------------|
+| `root` | The root node, or `undefined` if it was not found or `excludeRoot` is set |
+| `nodes` | All reachable nodes keyed by string ID |
+| `adjacency` | Forward adjacency: `fromId → edgeKind → edges[]` |
+| `reverseAdjacency` | Reverse adjacency: `toId → edgeKind → edges[]` |
 
 Edges are only included when **both** endpoints appear in the result set.
 Soft-deleted nodes and edges are automatically excluded. Duplicate nodes
@@ -1278,19 +1288,26 @@ Soft-deleted nodes and edges are automatically excluded. Duplicate nodes
 **Example:**
 
 ```typescript
-import type { AnyNode, SubgraphResult } from "@nicia-ai/typegraph";
-
-// Extract the full neighborhood of a run
-const result = await store.subgraph(run.id, {
+const sg = await store.subgraph(run.id, {
   edges: ["has_task", "runs_agent", "uses_skill"],
   maxDepth: 4,
 });
 
-// result.nodes — all reachable nodes (typed as a discriminated union)
-// result.edges — all connecting edges between those nodes
+// Root node (the traversal starting point)
+console.log(sg.root?.kind);
+
+// Lookup by ID
+const task = sg.nodes.get(taskId);
+
+// Forward adjacency: edges of a kind from a node
+const taskEdges = sg.adjacency.get(String(run.id))?.get("has_task") ?? [];
+const tasks = taskEdges.map((edge) => sg.nodes.get(String(edge.toId)));
+
+// Reverse adjacency: edges of a kind pointing to a node
+const parentEdges = sg.reverseAdjacency.get(taskId)?.get("has_task") ?? [];
 
 // Narrow by kind with a switch
-for (const node of result.nodes) {
+for (const node of sg.nodes.values()) {
   switch (node.kind) {
     case "Task": {
       console.log(node.title, node.status);
@@ -1313,7 +1330,7 @@ const tasksOnly = await store.subgraph(run.id, {
   excludeRoot: true,
 });
 
-// tasksOnly.nodes is typed as readonly Node<typeof Task>[]
+// tasksOnly.nodes values are typed as Node<typeof Task>
 ```
 
 **Bidirectional traversal:**
@@ -1368,7 +1385,7 @@ Result types narrow per-kind based on the projection. Accessing an omitted field
 compile-time error:
 
 ```typescript
-for (const node of result.nodes) {
+for (const node of result.nodes.values()) {
   if (node.kind === "Task") {
     console.log(node.title);  // OK
     console.log(node.status); // TypeScript error — status was not projected

--- a/apps/docs/src/content/docs/types.md
+++ b/apps/docs/src/content/docs/types.md
@@ -334,13 +334,15 @@ type SubgraphOptions<G, EK, NK> = Readonly<{
 
 ### `SubgraphResult<G, NK, EK>`
 
-The return type of `store.subgraph()`. Contains deduplicated nodes and the edges
-connecting them.
+The return type of `store.subgraph()`. Contains the root node, a node index, and
+forward/reverse adjacency maps for immediate traversal.
 
 ```typescript
 type SubgraphResult<G, NK, EK> = Readonly<{
-  nodes: readonly SubsetNode<G, NK>[];
-  edges: readonly SubsetEdge<G, EK>[];
+  root: SubgraphNodeResult<G, NK> | undefined;
+  nodes: ReadonlyMap<string, SubgraphNodeResult<G, NK>>;
+  adjacency: ReadonlyMap<string, ReadonlyMap<EK, readonly SubgraphEdgeResult<G, EK>[]>>;
+  reverseAdjacency: ReadonlyMap<string, ReadonlyMap<EK, readonly SubgraphEdgeResult<G, EK>[]>>;
 }>;
 ```
 

--- a/packages/benchmarks/src/measurements.ts
+++ b/packages/benchmarks/src/measurements.ts
@@ -4,8 +4,12 @@ import { BENCHMARK_CONFIG, type QueryMetrics } from "./config";
 import { type PerfStore } from "./graph";
 import { formatMs, median, nowMs } from "./utils";
 
+type SubgraphNode = Readonly<{ kind: string; id: string }>;
+type SubgraphEdge = Readonly<{ id: string; fromId: string; toId: string }>;
+
 type FullSubgraphResult = Readonly<{
-  nodes: readonly (
+  nodes: ReadonlyMap<
+    string,
     | Readonly<{
         kind: "User";
         id: string;
@@ -19,26 +23,17 @@ type FullSubgraphResult = Readonly<{
         title: string;
         body: string;
       }>
-  )[];
-  edges: readonly Readonly<{
-    id: string;
-    kind: "follows" | "authored";
-    fromId: string;
-    toId: string;
-  }>[];
+  >;
+  adjacency: ReadonlyMap<string, ReadonlyMap<string, readonly SubgraphEdge[]>>;
 }>;
 
 type ProjectedSubgraphResult = Readonly<{
-  nodes: readonly (
+  nodes: ReadonlyMap<
+    string,
     | Readonly<{ kind: "User"; id: string; name: string }>
     | Readonly<{ kind: "Post"; id: string; title: string }>
-  )[];
-  edges: readonly Readonly<{
-    id: string;
-    kind: "follows" | "authored";
-    fromId: string;
-    toId: string;
-  }>[];
+  >;
+  adjacency: ReadonlyMap<string, ReadonlyMap<string, readonly SubgraphEdge[]>>;
 }>;
 
 type BenchmarkSubgraphOptions = Readonly<{
@@ -87,29 +82,43 @@ async function benchmarkQuery(
   return result;
 }
 
+function sumEdgeChecksum(
+  adjacency: ReadonlyMap<string, ReadonlyMap<string, readonly SubgraphEdge[]>>,
+): number {
+  let checksum = 0;
+  for (const kindMap of adjacency.values()) {
+    for (const edges of kindMap.values()) {
+      for (const edge of edges) {
+        checksum += edge.id.length + edge.fromId.length + edge.toId.length;
+      }
+    }
+  }
+  return checksum;
+}
+
 function consumeSubgraphCounts(
   result: Readonly<{
-    nodes: readonly Readonly<{ kind: string; id: string }>[];
-    edges: readonly Readonly<{ id: string; fromId: string; toId: string }>[];
+    nodes: ReadonlyMap<string, SubgraphNode>;
+    adjacency: ReadonlyMap<
+      string,
+      ReadonlyMap<string, readonly SubgraphEdge[]>
+    >;
   }>,
 ): number {
   let checksum = 0;
 
-  for (const node of result.nodes) {
+  for (const node of result.nodes.values()) {
     checksum += node.id.length + node.kind.length;
   }
 
-  for (const edge of result.edges) {
-    checksum += edge.id.length + edge.fromId.length + edge.toId.length;
-  }
-
+  checksum += sumEdgeChecksum(result.adjacency);
   return checksum;
 }
 
 function projectSubgraphInApplication(result: FullSubgraphResult): number {
   let checksum = 0;
 
-  for (const node of result.nodes) {
+  for (const node of result.nodes.values()) {
     if (node.kind === "User") {
       checksum += node.id.length + node.name.length;
       continue;
@@ -120,17 +129,14 @@ function projectSubgraphInApplication(result: FullSubgraphResult): number {
     }
   }
 
-  for (const edge of result.edges) {
-    checksum += edge.id.length + edge.fromId.length + edge.toId.length;
-  }
-
+  checksum += sumEdgeChecksum(result.adjacency);
   return checksum;
 }
 
 function consumeProjectedSubgraph(result: ProjectedSubgraphResult): number {
   let checksum = 0;
 
-  for (const node of result.nodes) {
+  for (const node of result.nodes.values()) {
     if (node.kind === "User") {
       checksum += node.id.length + node.name.length;
       continue;
@@ -139,10 +145,7 @@ function consumeProjectedSubgraph(result: ProjectedSubgraphResult): number {
     checksum += node.id.length + node.title.length;
   }
 
-  for (const edge of result.edges) {
-    checksum += edge.id.length + edge.fromId.length + edge.toId.length;
-  }
-
+  checksum += sumEdgeChecksum(result.adjacency);
   return checksum;
 }
 
@@ -158,9 +161,13 @@ async function logSubgraphShape(
   options: BenchmarkSubgraphOptions,
 ): Promise<void> {
   const result = await store.subgraph("user_0" as never, options);
-  console.log(
-    `${label}: ${result.nodes.length} nodes, ${result.edges.length} edges`,
-  );
+  let edgeCount = 0;
+  for (const kindMap of result.adjacency.values()) {
+    for (const edges of kindMap.values()) {
+      edgeCount += edges.length;
+    }
+  }
+  console.log(`${label}: ${result.nodes.size} nodes, ${edgeCount} edges`);
 }
 
 export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -202,6 +202,8 @@ export { createStore, createStoreWithSchema } from "./store";
 export type {
   AnyEdge,
   AnyNode,
+  SubgraphEdgeResult,
+  SubgraphNodeResult,
   SubgraphOptions,
   SubgraphResult,
   SubsetEdge,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -469,22 +469,26 @@ export class Store<G extends GraphDef> {
    * Extracts a typed subgraph by traversing from a root node.
    *
    * Performs a BFS traversal from `rootId` following the specified edge kinds,
-   * then returns all reachable nodes and the edges connecting them.
+   * returning an indexed result with adjacency maps for immediate traversal.
    *
    * @example
    * ```typescript
-   * const result = await store.subgraph(run.id, {
+   * const sg = await store.subgraph(run.id, {
    *   edges: ["has_task", "runs_agent", "uses_skill"],
    *   maxDepth: 4,
-   *   includeKinds: ["Run", "Task", "Agent", "Skill"],
    * });
    *
-   * for (const node of result.nodes) {
-   *   switch (node.kind) {
-   *     case "Task": console.log(node.name); break;
-   *     case "Agent": console.log(node.model); break;
-   *   }
-   * }
+   * // Root node (the traversal starting point)
+   * console.log(sg.root?.kind);
+   *
+   * // Lookup by ID
+   * const task = sg.nodes.get(taskId);
+   *
+   * // Forward adjacency: edges of a kind from a node
+   * const taskEdges = sg.adjacency.get(run.id)?.get("has_task") ?? [];
+   *
+   * // Reverse adjacency: edges of a kind pointing to a node
+   * const parentEdges = sg.reverseAdjacency.get(taskId)?.get("has_task") ?? [];
    * ```
    */
   async subgraph<

--- a/packages/typegraph/src/store/subgraph.ts
+++ b/packages/typegraph/src/store/subgraph.ts
@@ -343,18 +343,47 @@ export type SubgraphOptions<
   project?: P;
 }>;
 
+/**
+ * Union of all node result types in a subgraph, respecting projection.
+ */
+export type SubgraphNodeResult<
+  G extends GraphDef,
+  NK extends NodeKinds<G> = NodeKinds<G>,
+  P = undefined,
+> = {
+  [Kind in NK]: SubgraphNodeResultForKind<G, Kind, P>;
+}[NK];
+
+/**
+ * Union of all edge result types in a subgraph, respecting projection.
+ */
+export type SubgraphEdgeResult<
+  G extends GraphDef,
+  EK extends EdgeKinds<G> = EdgeKinds<G>,
+  P = undefined,
+> = {
+  [Kind in EK]: SubgraphEdgeResultForKind<G, Kind, P>;
+}[EK];
+
 export type SubgraphResult<
   G extends GraphDef,
   NK extends NodeKinds<G> = NodeKinds<G>,
   EK extends EdgeKinds<G> = EdgeKinds<G>,
   P extends SubgraphProject<G, NK, EK> | undefined = undefined,
 > = Readonly<{
-  nodes: readonly {
-    [Kind in NK]: SubgraphNodeResultForKind<G, Kind, P>;
-  }[NK][];
-  edges: readonly {
-    [Kind in EK]: SubgraphEdgeResultForKind<G, Kind, P>;
-  }[EK][];
+  /** The root node, or undefined if the root was not found or excluded. */
+  root: SubgraphNodeResult<G, NK, P> | undefined;
+  nodes: ReadonlyMap<string, SubgraphNodeResult<G, NK, P>>;
+  /** Forward adjacency: fromId → edgeKind → edges to targets. */
+  adjacency: ReadonlyMap<
+    string,
+    ReadonlyMap<EK, readonly SubgraphEdgeResult<G, EK, P>[]>
+  >;
+  /** Reverse adjacency: toId → edgeKind → edges from sources. */
+  reverseAdjacency: ReadonlyMap<
+    string,
+    ReadonlyMap<EK, readonly SubgraphEdgeResult<G, EK, P>[]>
+  >;
 }>;
 
 // ============================================================
@@ -419,10 +448,6 @@ export async function executeSubgraph<
 }): Promise<SubgraphResult<G, NK, EK, P>> {
   const { options } = params;
 
-  if (options.edges.length === 0) {
-    return { nodes: [], edges: [] } as SubgraphResult<G, NK, EK, P>;
-  }
-
   const maxDepth = Math.min(
     options.maxDepth ?? DEFAULT_SUBGRAPH_MAX_DEPTH,
     MAX_EXPLICIT_RECURSIVE_DEPTH,
@@ -464,17 +489,33 @@ export async function executeSubgraph<
     fetchSubgraphEdges(ctx, reachableCte, includedIdsCte, edgeProjectionPlan),
   ]);
 
-  const nodes = nodeRows.map((row) =>
-    mapSubgraphNodeRow(row, nodeProjectionPlan),
-  );
-  const edges = edgeRows.map((row) =>
-    mapSubgraphEdgeRow(row, edgeProjectionPlan),
-  );
+  const nodesMap = new Map<string, Node>();
+  for (const row of nodeRows) {
+    const node = mapSubgraphNodeRow(row, nodeProjectionPlan);
+    nodesMap.set(node.id as string, node);
+  }
+
+  const adjacency = new Map<string, Map<string, Edge[]>>();
+  const reverseAdjacency = new Map<string, Map<string, Edge[]>>();
+  for (const row of edgeRows) {
+    const edge = mapSubgraphEdgeRow(row, edgeProjectionPlan);
+    insertAdjacencyEntry(adjacency, edge.fromId as string, edge.kind, edge);
+    insertAdjacencyEntry(
+      reverseAdjacency,
+      edge.toId as string,
+      edge.kind,
+      edge,
+    );
+  }
+
+  const root = nodesMap.get(ctx.rootId);
 
   return {
-    nodes: nodes as unknown as SubgraphResult<G, NK, EK, P>["nodes"],
-    edges: edges as unknown as SubgraphResult<G, NK, EK, P>["edges"],
-  };
+    root,
+    nodes: nodesMap,
+    adjacency,
+    reverseAdjacency,
+  } as unknown as SubgraphResult<G, NK, EK, P>;
 }
 
 // ============================================================
@@ -859,6 +900,29 @@ function buildProjectedPropertyColumns(
   }
 
   return columns;
+}
+
+// ============================================================
+// Adjacency Index Builder
+// ============================================================
+
+function insertAdjacencyEntry(
+  index: Map<string, Map<string, Edge[]>>,
+  nodeId: string,
+  edgeKind: string,
+  edge: Edge,
+): void {
+  let kindMap = index.get(nodeId);
+  if (kindMap === undefined) {
+    kindMap = new Map();
+    index.set(nodeId, kindMap);
+  }
+  const edges = kindMap.get(edgeKind);
+  if (edges === undefined) {
+    kindMap.set(edgeKind, [edge]);
+  } else {
+    edges.push(edge);
+  }
 }
 
 // ============================================================

--- a/packages/typegraph/tests/backends/integration/subgraph.ts
+++ b/packages/typegraph/tests/backends/integration/subgraph.ts
@@ -6,6 +6,7 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { collectAllEdges } from "../../test-utils";
 import { type IntegrationTestContext } from "./test-context";
 
 /**
@@ -81,7 +82,7 @@ export function registerSubgraphIntegrationTests(
         maxDepth: 1,
       });
 
-      const names = result.nodes
+      const names = [...result.nodes.values()]
         .map((n) => (n as { name: string }).name)
         .toSorted();
       expect(names).toContain("Alice");
@@ -96,10 +97,9 @@ export function registerSubgraphIntegrationTests(
         maxDepth: 2,
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      expect(nodeIds.has(ids.aliceId)).toBe(true);
-      expect(nodeIds.has(ids.bobId)).toBe(true);
-      expect(nodeIds.has(ids.charlieId)).toBe(true);
+      expect(result.nodes.has(ids.aliceId)).toBe(true);
+      expect(result.nodes.has(ids.bobId)).toBe(true);
+      expect(result.nodes.has(ids.charlieId)).toBe(true);
     });
 
     it("follows multiple edge kinds", async () => {
@@ -109,7 +109,7 @@ export function registerSubgraphIntegrationTests(
         maxDepth: 2,
       });
 
-      const kinds = new Set(result.nodes.map((n) => n.kind));
+      const kinds = new Set([...result.nodes.values()].map((n) => n.kind));
       expect(kinds.has("Person")).toBe(true);
       expect(kinds.has("Company")).toBe(true);
     });
@@ -122,7 +122,9 @@ export function registerSubgraphIntegrationTests(
         maxDepth: 3,
       });
 
-      const companyNodes = result.nodes.filter((n) => n.kind === "Company");
+      const companyNodes = [...result.nodes.values()].filter(
+        (n) => n.kind === "Company",
+      );
       expect(companyNodes).toHaveLength(1);
     });
 
@@ -134,10 +136,10 @@ export function registerSubgraphIntegrationTests(
         includeKinds: ["Company"],
       });
 
-      for (const node of result.nodes) {
+      for (const node of result.nodes.values()) {
         expect(node.kind).toBe("Company");
       }
-      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes.size).toBe(1);
     });
 
     it("excludes root", async () => {
@@ -148,8 +150,8 @@ export function registerSubgraphIntegrationTests(
         excludeRoot: true,
       });
 
-      expect(result.nodes.every((n) => n.id !== ids.aliceId)).toBe(true);
-      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes.has(ids.aliceId)).toBe(false);
+      expect(result.nodes.size).toBe(1);
     });
 
     it("handles bidirectional traversal", async () => {
@@ -161,11 +163,10 @@ export function registerSubgraphIntegrationTests(
         direction: "both",
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
       // Outbound: bob → charlie
-      expect(nodeIds.has(ids.charlieId)).toBe(true);
+      expect(result.nodes.has(ids.charlieId)).toBe(true);
       // Inbound: alice → bob (reversed)
-      expect(nodeIds.has(ids.aliceId)).toBe(true);
+      expect(result.nodes.has(ids.aliceId)).toBe(true);
     });
 
     it("returns edges only when both endpoints are in result", async () => {
@@ -176,16 +177,17 @@ export function registerSubgraphIntegrationTests(
         includeKinds: ["Person"],
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      for (const edge of result.edges) {
-        expect(nodeIds.has(edge.fromId as string)).toBe(true);
-        expect(nodeIds.has(edge.toId as string)).toBe(true);
+      const allEdges = collectAllEdges(result.adjacency);
+      for (const edge of allEdges) {
+        expect(result.nodes.has(edge.fromId as string)).toBe(true);
+        expect(result.nodes.has(edge.toId as string)).toBe(true);
       }
 
       // worksAt edges connect Person→Company, but Company is excluded
-      expect(result.edges.some((edge) => edge.kind === "worksAt")).toBe(false);
+      const edgeKinds = new Set(allEdges.map((edge) => edge.kind));
+      expect(edgeKinds.has("worksAt")).toBe(false);
       // knows edges connect Person→Person, both in result
-      expect(result.edges.some((edge) => edge.kind === "knows")).toBe(true);
+      expect(edgeKinds.has("knows")).toBe(true);
     });
 
     it("excludes soft-deleted nodes", async () => {
@@ -216,10 +218,9 @@ export function registerSubgraphIntegrationTests(
         maxDepth: 2,
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      expect(nodeIds.has(ids.bobId)).toBe(false);
+      expect(result.nodes.has(ids.bobId)).toBe(false);
       // charlie is unreachable since bob (the intermediate node) is deleted
-      expect(nodeIds.has(ids.charlieId)).toBe(false);
+      expect(result.nodes.has(ids.charlieId)).toBe(false);
     });
 
     it("returns empty for non-existent root", async () => {
@@ -229,8 +230,8 @@ export function registerSubgraphIntegrationTests(
         maxDepth: 1,
       });
 
-      expect(result.nodes).toHaveLength(0);
-      expect(result.edges).toHaveLength(0);
+      expect(result.root).toBeUndefined();
+      expect(result.nodes.size).toBe(0);
     });
 
     it("handles cycles without infinite loops", async () => {
@@ -246,17 +247,19 @@ export function registerSubgraphIntegrationTests(
       });
 
       // All three people reachable, each visited once
-      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes.size).toBe(3);
     });
 
-    it("returns empty edges when empty edges option", async () => {
+    it("returns only root when empty edges option", async () => {
       const store = context.getStore();
       const result = await store.subgraph(ids.aliceId as never, {
         edges: [],
       });
 
-      expect(result.nodes).toHaveLength(0);
-      expect(result.edges).toHaveLength(0);
+      expect(result.root).toBeDefined();
+      expect(result.root!.id).toBe(ids.aliceId);
+      expect(result.nodes.size).toBe(1);
+      expect(result.adjacency.size).toBe(0);
     });
 
     it("projects node and edge fields across backends", async () => {
@@ -276,8 +279,9 @@ export function registerSubgraphIntegrationTests(
         },
       });
 
-      const people = result.nodes.filter((node) => node.kind === "Person");
-      const companies = result.nodes.filter((node) => node.kind === "Company");
+      const nodes = [...result.nodes.values()];
+      const people = nodes.filter((node) => node.kind === "Person");
+      const companies = nodes.filter((node) => node.kind === "Company");
 
       expect(people.length).toBeGreaterThan(0);
       for (const person of people) {
@@ -293,18 +297,13 @@ export function registerSubgraphIntegrationTests(
       expect(companies[0]).toHaveProperty("meta.updatedAt");
       expect(companies[0]).not.toHaveProperty("industry");
 
-      const worksAtEdges = result.edges.filter(
-        (
-          edge,
-        ): edge is Extract<
-          (typeof result.edges)[number],
-          { kind: "worksAt" }
-        > => edge.kind === "worksAt",
+      const allEdges = collectAllEdges(result.adjacency);
+      const worksAtEdges = allEdges.filter(
+        (edge): edge is Extract<typeof edge, { kind: "worksAt" }> =>
+          edge.kind === "worksAt",
       );
-      const knowsEdges = result.edges.filter(
-        (
-          edge,
-        ): edge is Extract<(typeof result.edges)[number], { kind: "knows" }> =>
+      const knowsEdges = allEdges.filter(
+        (edge): edge is Extract<typeof edge, { kind: "knows" }> =>
           edge.kind === "knows",
       );
 

--- a/packages/typegraph/tests/property/subgraph.test.ts
+++ b/packages/typegraph/tests/property/subgraph.test.ts
@@ -108,7 +108,7 @@ describe("subgraph property tests", () => {
             });
 
             const expected = Math.min(maxDepth + 1, chainLength);
-            expect(result.nodes).toHaveLength(expected);
+            expect(result.nodes.size).toBe(expected);
           },
         ),
         { numRuns: 30 },
@@ -130,10 +130,13 @@ describe("subgraph property tests", () => {
               maxDepth,
             });
 
-            const nodeIdSet = new Set(result.nodes.map((n) => n.id as string));
-            for (const edge of result.edges) {
-              expect(nodeIdSet.has(edge.fromId as string)).toBe(true);
-              expect(nodeIdSet.has(edge.toId as string)).toBe(true);
+            for (const kindMap of result.adjacency.values()) {
+              for (const edges of kindMap.values()) {
+                for (const edge of edges) {
+                  expect(result.nodes.has(edge.fromId as string)).toBe(true);
+                  expect(result.nodes.has(edge.toId as string)).toBe(true);
+                }
+              }
             }
           },
         ),
@@ -157,9 +160,15 @@ describe("subgraph property tests", () => {
             });
 
             // In a chain, edges = nodes - 1 (when all nodes are connected)
-            // With maxDepth >= 1, root is always included so length > 0
-            expect(result.nodes.length).toBeGreaterThan(0);
-            expect(result.edges).toHaveLength(result.nodes.length - 1);
+            // With maxDepth >= 1, root is always included so size > 0
+            expect(result.nodes.size).toBeGreaterThan(0);
+            let edgeCount = 0;
+            for (const kindMap of result.adjacency.values()) {
+              for (const edges of kindMap.values()) {
+                edgeCount += edges.length;
+              }
+            }
+            expect(edgeCount).toBe(result.nodes.size - 1);
           },
         ),
         { numRuns: 30 },
@@ -183,7 +192,7 @@ describe("subgraph property tests", () => {
               maxDepth: 1,
             });
 
-            expect(result.nodes).toHaveLength(spokeCount + 1);
+            expect(result.nodes.size).toBe(spokeCount + 1);
           },
         ),
         { numRuns: 20 },
@@ -206,9 +215,9 @@ describe("subgraph property tests", () => {
               maxDepth,
             });
 
-            const ids = result.nodes.map((n) => n.id);
-            const uniqueIds = new Set(ids);
-            expect(ids).toHaveLength(uniqueIds.size);
+            // Map keys are inherently unique — just verify size matches
+            // the expected count (no silent overwrites from duplicate IDs)
+            expect(result.nodes.size).toBeLessThanOrEqual(spokeCount + 1);
           },
         ),
         { numRuns: 20 },
@@ -240,11 +249,9 @@ describe("subgraph property tests", () => {
             });
 
             // Without root should have exactly one fewer node
-            expect(withoutRoot.nodes).toHaveLength(withRoot.nodes.length - 1);
+            expect(withoutRoot.nodes.size).toBe(withRoot.nodes.size - 1);
             // And that missing node is the root
-            expect(withoutRoot.nodes.every((n) => n.id !== centerId)).toBe(
-              true,
-            );
+            expect(withoutRoot.nodes.has(centerId)).toBe(false);
           },
         ),
         { numRuns: 20 },
@@ -274,7 +281,7 @@ describe("subgraph property tests", () => {
             });
 
             // All nodes in the cycle should be reachable, each exactly once
-            expect(result.nodes).toHaveLength(chainLength);
+            expect(result.nodes.size).toBe(chainLength);
           },
         ),
         { numRuns: 20 },

--- a/packages/typegraph/tests/subgraph.test.ts
+++ b/packages/typegraph/tests/subgraph.test.ts
@@ -24,7 +24,7 @@ import {
 import type { GraphBackend } from "../src/backend/types";
 import type { NodeId } from "../src/core/types";
 import { createStore, type Store } from "../src/store";
-import { createTestBackend } from "./test-utils";
+import { collectAllEdges, createTestBackend } from "./test-utils";
 
 // ============================================================
 // Test Schema
@@ -166,13 +166,16 @@ describe("store.subgraph()", () => {
   // ── Empty / boundary cases ──────────────────────────────────
 
   describe("boundary conditions", () => {
-    it("returns empty result when edges array is empty", async () => {
+    it("returns only root when edges array is empty", async () => {
       const result = await store.subgraph(ids.runId as never, {
         edges: [],
       });
 
-      expect(result.nodes).toHaveLength(0);
-      expect(result.edges).toHaveLength(0);
+      expect(result.root).toBeDefined();
+      expect(result.root!.id).toBe(ids.runId);
+      expect(result.nodes.size).toBe(1);
+      expect(result.adjacency.size).toBe(0);
+      expect(result.reverseAdjacency.size).toBe(0);
     });
 
     it("returns empty result for non-existent root", async () => {
@@ -181,8 +184,8 @@ describe("store.subgraph()", () => {
         maxDepth: 1,
       });
 
-      expect(result.nodes).toHaveLength(0);
-      expect(result.edges).toHaveLength(0);
+      expect(result.root).toBeUndefined();
+      expect(result.nodes.size).toBe(0);
     });
 
     it("returns only the root when maxDepth is 0", async () => {
@@ -191,19 +194,21 @@ describe("store.subgraph()", () => {
         maxDepth: 0,
       });
 
-      expect(result.nodes).toHaveLength(1);
-      expect(result.nodes[0]!.id).toBe(ids.runId);
+      expect(result.nodes.size).toBe(1);
+      expect(result.root).toBeDefined();
+      expect(result.root!.id).toBe(ids.runId);
     });
 
-    it("returns empty nodes and edges when maxDepth 0 and excludeRoot", async () => {
+    it("returns empty result when maxDepth 0 and excludeRoot", async () => {
       const result = await store.subgraph(ids.runId as never, {
         edges: ["has_task"],
         maxDepth: 0,
         excludeRoot: true,
       });
 
-      expect(result.nodes).toHaveLength(0);
-      expect(result.edges).toHaveLength(0);
+      expect(result.root).toBeUndefined();
+      expect(result.nodes.size).toBe(0);
+      expect(result.adjacency.size).toBe(0);
     });
 
     it("returns root even when no outgoing edges of the specified kind exist", async () => {
@@ -213,9 +218,10 @@ describe("store.subgraph()", () => {
         maxDepth: 5,
       });
 
-      expect(result.nodes).toHaveLength(1);
-      expect(result.nodes[0]!.id).toBe(ids.agent1Id);
-      expect(result.edges).toHaveLength(0);
+      expect(result.nodes.size).toBe(1);
+      expect(result.root).toBeDefined();
+      expect(result.root!.id).toBe(ids.agent1Id);
+      expect(result.adjacency.size).toBe(0);
     });
   });
 
@@ -228,9 +234,11 @@ describe("store.subgraph()", () => {
         maxDepth: 1,
       });
 
-      const nodeKinds = result.nodes.map((n) => n.kind).toSorted();
+      const nodeKinds = [...result.nodes.values()]
+        .map((n) => n.kind)
+        .toSorted();
       expect(nodeKinds).toEqual(["Agent", "Run", "Task", "Task"]);
-      expect(result.nodes.some((n) => n.id === ids.runId)).toBe(true);
+      expect(result.nodes.has(ids.runId as string)).toBe(true);
     });
 
     it("follows multi-hop paths", async () => {
@@ -239,12 +247,11 @@ describe("store.subgraph()", () => {
         maxDepth: 4,
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      expect(nodeIds.has(ids.runId as string)).toBe(true);
-      expect(nodeIds.has(ids.task1Id as string)).toBe(true);
-      expect(nodeIds.has(ids.attempt1Id as string)).toBe(true);
-      expect(nodeIds.has(ids.tool1Id as string)).toBe(true);
-      expect(nodeIds.has(ids.task2Id as string)).toBe(true);
+      expect(result.nodes.has(ids.runId as string)).toBe(true);
+      expect(result.nodes.has(ids.task1Id as string)).toBe(true);
+      expect(result.nodes.has(ids.attempt1Id as string)).toBe(true);
+      expect(result.nodes.has(ids.tool1Id as string)).toBe(true);
+      expect(result.nodes.has(ids.task2Id as string)).toBe(true);
     });
 
     it("only follows specified edge kinds", async () => {
@@ -253,7 +260,7 @@ describe("store.subgraph()", () => {
         maxDepth: 3,
       });
 
-      const kinds = new Set(result.nodes.map((n) => n.kind));
+      const kinds = new Set([...result.nodes.values()].map((n) => n.kind));
       expect(kinds.has("Run")).toBe(true);
       expect(kinds.has("Task")).toBe(true);
       expect(kinds.has("Agent")).toBe(false);
@@ -268,7 +275,7 @@ describe("store.subgraph()", () => {
       });
 
       // Still works, just capped internally
-      expect(result.nodes.length).toBeGreaterThan(0);
+      expect(result.nodes.size).toBeGreaterThan(0);
     });
   });
 
@@ -283,8 +290,8 @@ describe("store.subgraph()", () => {
       });
 
       // Only task1 itself — has_task edges go FROM Run, not from Task
-      expect(result.nodes).toHaveLength(1);
-      expect(result.nodes[0]!.id).toBe(ids.task1Id);
+      expect(result.nodes.size).toBe(1);
+      expect(result.root!.id).toBe(ids.task1Id);
     });
 
     it("follows both directions with direction: both", async () => {
@@ -294,11 +301,10 @@ describe("store.subgraph()", () => {
         direction: "both",
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
       // Inbound: task1 ← has_task ← run
-      expect(nodeIds.has(ids.runId as string)).toBe(true);
+      expect(result.nodes.has(ids.runId as string)).toBe(true);
       // Then outbound from run: run → has_task → task2
-      expect(nodeIds.has(ids.task2Id as string)).toBe(true);
+      expect(result.nodes.has(ids.task2Id as string)).toBe(true);
     });
   });
 
@@ -312,11 +318,11 @@ describe("store.subgraph()", () => {
         includeKinds: ["Task", "ToolDef"],
       });
 
-      for (const node of result.nodes) {
+      for (const node of result.nodes.values()) {
         expect(["Task", "ToolDef"]).toContain(node.kind);
       }
 
-      const kinds = result.nodes.map((n) => n.kind as string);
+      const kinds = [...result.nodes.values()].map((n) => n.kind as string);
       expect(kinds).not.toContain("Attempt");
       expect(kinds).not.toContain("Run");
     });
@@ -330,8 +336,8 @@ describe("store.subgraph()", () => {
         includeKinds: ["ToolDef"],
       });
 
-      expect(result.nodes.length).toBeGreaterThan(0);
-      const kinds = result.nodes.map((n) => n.kind as string);
+      expect(result.nodes.size).toBeGreaterThan(0);
+      const kinds = [...result.nodes.values()].map((n) => n.kind as string);
       expect(kinds).toContain("ToolDef");
       expect(kinds).not.toContain("Attempt");
     });
@@ -347,10 +353,9 @@ describe("store.subgraph()", () => {
         excludeRoot: true,
       });
 
-      expect(result.nodes.every((n) => n.id !== (ids.runId as string))).toBe(
-        true,
-      );
-      expect(result.nodes).toHaveLength(2);
+      expect(result.root).toBeUndefined();
+      expect(result.nodes.has(ids.runId as string)).toBe(false);
+      expect(result.nodes.size).toBe(2);
     });
 
     it("excludes root but keeps edges that connect remaining nodes", async () => {
@@ -361,13 +366,11 @@ describe("store.subgraph()", () => {
         excludeRoot: true,
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      expect(nodeIds.has(ids.runId as string)).toBe(false);
+      expect(result.nodes.has(ids.runId as string)).toBe(false);
 
       // depends_on edge should still appear since both task1 and task2 are in the set
-      const depEdges = result.edges.filter(
-        (edge) => edge.kind === "depends_on",
-      );
+      const depEdges =
+        result.adjacency.get(ids.task1Id as string)?.get("depends_on") ?? [];
       expect(depEdges).toHaveLength(1);
     });
 
@@ -380,7 +383,7 @@ describe("store.subgraph()", () => {
 
       // has_task edges go from Run to Task — but Run is excluded,
       // so no has_task edges should appear (from endpoint missing)
-      expect(result.edges).toHaveLength(0);
+      expect(result.adjacency.size).toBe(0);
     });
   });
 
@@ -394,14 +397,14 @@ describe("store.subgraph()", () => {
         includeKinds: ["Task", "ToolDef"],
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      for (const edge of result.edges) {
-        expect(nodeIds.has(edge.fromId as string)).toBe(true);
-        expect(nodeIds.has(edge.toId as string)).toBe(true);
+      const allEdges = collectAllEdges(result.adjacency);
+      for (const edge of allEdges) {
+        expect(result.nodes.has(edge.fromId as string)).toBe(true);
+        expect(result.nodes.has(edge.toId as string)).toBe(true);
       }
 
       // has_attempt: Task→Attempt — Attempt excluded, so edge excluded
-      const edgeKinds = result.edges.map((edge) => edge.kind as string);
+      const edgeKinds = allEdges.map((edge) => edge.kind as string);
       expect(edgeKinds).not.toContain("has_attempt");
       // used_tool: Attempt→ToolDef — Attempt excluded, so edge excluded
       expect(edgeKinds).not.toContain("used_tool");
@@ -413,12 +416,13 @@ describe("store.subgraph()", () => {
         maxDepth: 2,
       });
 
-      for (const edge of result.edges) {
+      const allEdges = collectAllEdges(result.adjacency);
+      for (const edge of allEdges) {
         expect(edge.kind).toBe("has_task");
       }
 
       // runs_agent, uses_skill edges exist but are not in the edge filter
-      const edgeKinds = result.edges.map((edge) => edge.kind as string);
+      const edgeKinds = allEdges.map((edge) => edge.kind as string);
       expect(edgeKinds).not.toContain("runs_agent");
     });
   });
@@ -437,8 +441,7 @@ describe("store.subgraph()", () => {
         maxDepth: 10,
       });
 
-      const taskIds = result.nodes.map((n) => n.id);
-      expect(taskIds).toHaveLength(2); // task1, task2 — each visited once
+      expect(result.nodes.size).toBe(2); // task1, task2 — each visited once
     });
 
     it("allows revisiting with cyclePolicy: allow", async () => {
@@ -455,8 +458,7 @@ describe("store.subgraph()", () => {
       });
 
       // Nodes are still deduplicated in the result (DISTINCT in SQL)
-      const uniqueIds = new Set(result.nodes.map((n) => n.id));
-      expect(uniqueIds.size).toBe(2);
+      expect(result.nodes.size).toBe(2);
     });
   });
 
@@ -472,7 +474,9 @@ describe("store.subgraph()", () => {
         maxDepth: 3,
       });
 
-      const skillNodes = result.nodes.filter((n) => n.kind === "Skill");
+      const skillNodes = [...result.nodes.values()].filter(
+        (n) => n.kind === "Skill",
+      );
       expect(skillNodes).toHaveLength(1);
       expect(skillNodes[0]!.id).toBe(ids.skill1Id);
     });
@@ -514,12 +518,9 @@ describe("store.subgraph()", () => {
         maxDepth: 1,
       });
 
-      const taskIds = result.nodes
-        .filter((n) => n.kind === "Task")
-        .map((n) => n.id);
-      expect(taskIds).not.toContain(ids.task1Id);
+      expect(result.nodes.has(ids.task1Id as string)).toBe(false);
       // task2 is still alive
-      expect(taskIds).toContain(ids.task2Id as string);
+      expect(result.nodes.has(ids.task2Id as string)).toBe(true);
     });
 
     it("excludes soft-deleted edges from traversal", async () => {
@@ -538,8 +539,7 @@ describe("store.subgraph()", () => {
       });
 
       // task1 should not be reachable since the edge to it is deleted
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      expect(nodeIds.has(ids.task1Id as string)).toBe(false);
+      expect(result.nodes.has(ids.task1Id as string)).toBe(false);
     });
 
     it("does not traverse through soft-deleted intermediate nodes", async () => {
@@ -563,8 +563,7 @@ describe("store.subgraph()", () => {
         maxDepth: 4,
       });
 
-      const nodeIds = new Set(result.nodes.map((n) => n.id as string));
-      expect(nodeIds.has(ids.tool1Id as string)).toBe(false);
+      expect(result.nodes.has(ids.tool1Id as string)).toBe(false);
     });
 
     it("excludes soft-deleted edges from result set", async () => {
@@ -586,7 +585,8 @@ describe("store.subgraph()", () => {
       });
 
       // The deleted edge should not appear in results
-      const edgeToIds = result.edges.map((edge) => edge.toId);
+      const allEdges = collectAllEdges(result.adjacency);
+      const edgeToIds = allEdges.map((edge) => edge.toId);
       expect(edgeToIds).not.toContain(ids.task1Id);
     });
 
@@ -612,8 +612,9 @@ describe("store.subgraph()", () => {
       });
 
       // Root doesn't match base case (deleted_at IS NULL), so empty
-      expect(result.nodes).toHaveLength(0);
-      expect(result.edges).toHaveLength(0);
+      expect(result.root).toBeUndefined();
+      expect(result.nodes.size).toBe(0);
+      expect(result.adjacency.size).toBe(0);
     });
   });
 
@@ -627,8 +628,8 @@ describe("store.subgraph()", () => {
         includeKinds: ["Task"],
       });
 
-      expect(result.nodes).toHaveLength(2);
-      for (const node of result.nodes) {
+      expect(result.nodes.size).toBe(2);
+      for (const node of result.nodes.values()) {
         expect(node.kind).toBe("Task");
         expect(node).toHaveProperty("title");
         expect(node).toHaveProperty("status");
@@ -644,8 +645,9 @@ describe("store.subgraph()", () => {
         maxDepth: 1,
       });
 
-      expect(result.edges.length).toBeGreaterThan(0);
-      for (const edge of result.edges) {
+      const allEdges = collectAllEdges(result.adjacency);
+      expect(allEdges.length).toBeGreaterThan(0);
+      for (const edge of allEdges) {
         expect(edge).toHaveProperty("id");
         expect(edge).toHaveProperty("kind");
         expect(edge).toHaveProperty("fromKind");
@@ -671,13 +673,13 @@ describe("store.subgraph()", () => {
         },
       });
 
-      expect(result.nodes).toHaveLength(1);
-      expect(result.nodes[0]).toMatchObject({
+      expect(result.nodes.size).toBe(1);
+      expect(result.root).toMatchObject({
         kind: "Run",
         id: ids.runId,
         name: "run-1",
       });
-      expect(result.nodes[0]).not.toHaveProperty("meta");
+      expect(result.root).not.toHaveProperty("meta");
     });
 
     it("projects node props and full metadata while preserving identity", async () => {
@@ -692,8 +694,8 @@ describe("store.subgraph()", () => {
         },
       });
 
-      expect(result.nodes).toHaveLength(2);
-      for (const node of result.nodes) {
+      expect(result.nodes.size).toBe(2);
+      for (const node of result.nodes.values()) {
         expect(node.kind).toBe("Task");
         expect(node).toHaveProperty("id");
         expect(node).toHaveProperty("title");
@@ -714,8 +716,9 @@ describe("store.subgraph()", () => {
         },
       });
 
-      const task = result.nodes.find((node) => node.kind === "Task");
-      const agent = result.nodes.find((node) => node.kind === "Agent");
+      const nodes = [...result.nodes.values()];
+      const task = nodes.find((node) => node.kind === "Task");
+      const agent = nodes.find((node) => node.kind === "Agent");
 
       expect(task).toBeDefined();
       expect(task).toHaveProperty("title");
@@ -739,8 +742,9 @@ describe("store.subgraph()", () => {
         },
       });
 
-      expect(result.edges).toHaveLength(1);
-      const edge = result.edges[0]!;
+      const allEdges = collectAllEdges(result.adjacency);
+      expect(allEdges).toHaveLength(1);
+      const edge = allEdges[0]!;
       expect(edge.kind).toBe("uses_skill");
       expect(edge).toHaveProperty("id");
       expect(edge).toHaveProperty("fromKind");
@@ -776,8 +780,8 @@ describe("store.subgraph()", () => {
       });
 
       // Type narrowing should work — these are Task | Agent nodes
-      expect(result.nodes.length).toBeGreaterThan(0);
-      for (const node of result.nodes) {
+      expect(result.nodes.size).toBeGreaterThan(0);
+      for (const node of result.nodes.values()) {
         expect(["Task", "Agent"]).toContain(node.kind);
       }
     });
@@ -795,7 +799,7 @@ describe("store.subgraph()", () => {
         },
       });
 
-      for (const node of result.nodes) {
+      for (const node of result.nodes.values()) {
         if (node.kind === "Task") {
           const title: string = node.title;
           void title;
@@ -825,7 +829,8 @@ describe("store.subgraph()", () => {
         },
       });
 
-      const edge = result.edges[0]!;
+      const allEdges = collectAllEdges(result.adjacency);
+      const edge = allEdges[0]!;
       const fromId: string = edge.fromId;
       const toId: string = edge.toId;
       void fromId;
@@ -833,6 +838,64 @@ describe("store.subgraph()", () => {
       // @ts-expect-error - projected edge omits meta unless requested
       const meta = edge.meta;
       void meta;
+    });
+
+    it("narrows root type with kind discrimination", async () => {
+      const result = await store.subgraph(ids.runId as never, {
+        edges: ["has_task", "runs_agent"],
+        maxDepth: 1,
+        includeKinds: ["Run", "Task"],
+      });
+
+      // root is Run | Task | undefined — narrows via kind check
+      if (result.root?.kind === "Run") {
+        const name: string = result.root.name;
+        void name;
+      }
+
+      // nodes.get returns Run | Task | undefined
+      const node = result.nodes.get(ids.runId as string);
+      if (node?.kind === "Task") {
+        const title: string = node.title;
+        void title;
+      }
+    });
+
+    it("narrows edge types via adjacency map access", async () => {
+      const result = await store.subgraph(ids.runId as never, {
+        edges: ["has_task", "uses_skill"],
+        maxDepth: 2,
+        project: {
+          edges: {
+            uses_skill: ["priority"],
+          },
+        },
+      });
+
+      const edges =
+        result.adjacency.get(ids.task1Id as string)?.get("uses_skill") ?? [];
+      for (const edge of edges) {
+        // Structural fields are always present
+        const fromId: string = edge.fromId;
+        void fromId;
+        if (edge.kind === "uses_skill") {
+          const priority: number = edge.priority;
+          void priority;
+          // @ts-expect-error - projected uses_skill omits meta
+          const meta = edge.meta;
+          void meta;
+        }
+      }
+
+      // reverseAdjacency has the same type
+      const reverseEdges =
+        result.reverseAdjacency
+          .get(ids.skill1Id as string)
+          ?.get("uses_skill") ?? [];
+      for (const edge of reverseEdges) {
+        const toId: string = edge.toId;
+        void toId;
+      }
     });
 
     it("rejects partial meta fields at compile time", async () => {
@@ -950,8 +1013,8 @@ describe("store.subgraph()", () => {
         },
       });
 
-      expect(result.nodes).toHaveLength(2);
-      for (const node of result.nodes) {
+      expect(result.nodes.size).toBe(2);
+      for (const node of result.nodes.values()) {
         expect(
           node.a_field_name_that_is_also_unreasonably_long_for_testing_purposes,
         ).toBeDefined();
@@ -998,8 +1061,8 @@ describe("store.subgraph()", () => {
         },
       });
 
-      expect(result.nodes).toHaveLength(2);
-      for (const node of result.nodes) {
+      expect(result.nodes.size).toBe(2);
+      for (const node of result.nodes.values()) {
         expect((node as Record<string, unknown>).value).toBeDefined();
       }
     });
@@ -1081,7 +1144,7 @@ describe("store.subgraph()", () => {
         project,
       });
 
-      for (const node of result.nodes) {
+      for (const node of result.nodes.values()) {
         if (node.kind === "Task") {
           const title: string = node.title;
           void title;
@@ -1094,7 +1157,8 @@ describe("store.subgraph()", () => {
         }
       }
 
-      for (const edge of result.edges) {
+      const allEdges = collectAllEdges(result.adjacency);
+      for (const edge of allEdges) {
         if (edge.kind === "uses_skill") {
           const priority: number = edge.priority;
           void priority;

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -44,3 +44,18 @@ export function createTestDatabase(
 }
 
 export { generateSqliteDDL } from "../src/backend/drizzle/ddl";
+
+/**
+ * Flattens all edges from a subgraph adjacency map into a single array.
+ */
+export function collectAllEdges<E>(
+  adjacency: ReadonlyMap<string, ReadonlyMap<string, readonly E[]>>,
+): E[] {
+  const edges: E[] = [];
+  for (const kindMap of adjacency.values()) {
+    for (const edgeList of kindMap.values()) {
+      edges.push(...edgeList);
+    }
+  }
+  return edges;
+}


### PR DESCRIPTION
- **BREAKING:** `store.subgraph()` now returns `{ root, nodes: Map, adjacency, reverseAdjacency }` instead of `{ nodes: Node[], edges: Edge[] }`
- Eliminates the adjacency-index-rebuilding boilerplate every consumer writes before traversing a subgraph result
- Forward and reverse adjacency maps provide O(1) edge lookup by `nodeId → edgeKind`
- `root` provides direct access to the traversal starting point

## Migration

```typescript
// Before
const nodeById = new Map(sg.nodes.map(n => [String(n.id), n]));
const items = sg.edges.filter(e => e.kind === "has_item" && e.fromId === orderId);

// After
const item = sg.nodes.get(itemId);
const itemEdges = sg.adjacency.get(orderId)?.get("has_item") ?? [];
const parentEdges = sg.reverseAdjacency.get(itemId)?.get("has_item") ?? [];
```

Closes #82