### PR TITLE
feat!: add Tier 1 graph algorithms and honor temporal mode

### DIFF
--- a/.changeset/add-tier-1-graph-algorithms.md
+++ b/.changeset/add-tier-1-graph-algorithms.md
@@ -1,0 +1,35 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add Tier 1 graph algorithms on `store.algorithms.*`: `shortestPath`, `reachable`, `canReach`, `neighbors`, and `degree`.
+
+```typescript
+// Find the shortest path through a set of edge kinds
+const path = await store.algorithms.shortestPath(alice, bob, {
+  edges: ["knows"],
+  maxHops: 6,
+});
+
+// Enumerate reachable nodes within a depth bound
+const reachable = await store.algorithms.reachable(alice, {
+  edges: ["knows"],
+  maxHops: 3,
+});
+
+// Fast existence check
+const connected = await store.algorithms.canReach(alice, bob, {
+  edges: ["knows"],
+});
+
+// k-hop neighborhood (source always excluded)
+const twoHop = await store.algorithms.neighbors(alice, {
+  edges: ["knows"],
+  depth: 2,
+});
+
+// Count incident edges
+const total = await store.algorithms.degree(alice, { edges: ["knows"] });
+```
+
+All traversal algorithms compile to a single recursive-CTE query and share the dialect primitives used by `.recursive()` and `store.subgraph()`, so SQLite and PostgreSQL yield identical semantics. Node arguments accept either a raw ID string or any object with an `id` field — `Node`, `NodeRef`, and the lightweight records returned by the algorithms themselves all work. See `/graph-algorithms` for the full reference.

--- a/.changeset/algorithms-and-subgraph-temporal.md
+++ b/.changeset/algorithms-and-subgraph-temporal.md
@@ -1,0 +1,25 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Graph algorithms (`store.algorithms.*`) and `store.subgraph()` now honor the store's temporal model.
+
+**New:** Every algorithm and `store.subgraph()` accept `temporalMode` and `asOf` options, matching the shape already used by `store.query()` and collection reads. When neither is supplied, the resolved mode falls back to `graph.defaults.temporalMode` (typically `"current"`).
+
+```typescript
+// Snapshot at a point in time
+await store.algorithms.shortestPath(alice, bob, {
+  edges: ["knows"],
+  temporalMode: "asOf",
+  asOf: "2023-01-15T00:00:00Z",
+});
+
+await store.subgraph(rootId, {
+  edges: ["has_task"],
+  temporalMode: "includeEnded",
+});
+```
+
+The filter applies to both nodes and edges along the traversal, is orthogonal to `cyclePolicy`, and is honored by the shortest-path self-path short-circuit.
+
+**BREAKING:** `store.subgraph()` previously ignored graph temporal settings and filtered only by `deleted_at IS NULL` (equivalent to `"includeEnded"`). It now defaults to `graph.defaults.temporalMode`. Callers that relied on walking through validity-ended rows must pass `temporalMode: "includeEnded"` explicitly. Soft-delete filtering is unchanged under the default `"current"` mode, so most callers see no difference.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -39,6 +39,7 @@ const sidebar = [
       { label: "Schemas & Types", slug: "core-concepts" },
       { label: "Ontology & Reasoning", slug: "ontology" },
       { label: "Semantic Search", slug: "semantic-search" },
+      { label: "Graph Algorithms", slug: "graph-algorithms" },
       { label: "Backend Setup", slug: "backend-setup" },
       { label: "Schema Migrations", slug: "schema-management" },
       { label: "Evolving Schemas", slug: "schema-evolution" },

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -47,6 +47,8 @@ Every traversal algorithm takes the same base options:
 | `maxHops` | `number` | `10` | Maximum traversal depth (1 – 1000) |
 | `direction` | `"out" \| "in" \| "both"` | `"out"` | Edge direction |
 | `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Skip visited nodes per path |
+| `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to nodes and edges along the traversal — see [Temporal Behavior](#temporal-behavior) |
+| `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
 
 `direction: "both"` treats edges as undirected. `cyclePolicy: "allow"` skips
 cycle tracking and relies solely on `maxHops` to terminate — use it only
@@ -79,7 +81,8 @@ type ShortestPathResult = Readonly<{
 ```
 
 Source equal to target returns a zero-length path containing just that
-node. Missing or soft-deleted endpoints return `undefined`.
+node. Endpoints that don't pass the resolved temporal filter return
+`undefined` — see [Temporal Behavior](#temporal-behavior).
 
 ## reachable
 
@@ -134,8 +137,8 @@ but the name reads more naturally for neighborhood queries.
 
 ## degree
 
-Counts active edges incident to a node. Self-loops contribute once when
-`direction` is `"both"`.
+Counts edges incident to a node under the resolved temporal filter.
+Self-loops contribute once when `direction` is `"both"`.
 
 ```typescript
 const friends = await store.algorithms.degree(alice, {
@@ -156,6 +159,8 @@ const everything = await store.algorithms.degree(alice);
 |--------|------|---------|-------------|
 | `edges` | `readonly EdgeKinds<G>[]` | all kinds | Edge kinds to count (empty array returns 0) |
 | `direction` | `"out" \| "in" \| "both"` | `"both"` | Count outgoing, incoming, or either |
+| `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to the counted edges |
+| `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
 
 `degree` runs a single `COUNT` query, not a recursive CTE, so it's
 efficient even for hub nodes with thousands of edges.
@@ -202,6 +207,54 @@ terminates via `maxHops` alone.
 runaway queries. The default of 10 covers typical connectivity questions on
 most graphs. Graphs with branching factor *B* produce O(*B*^depth) rows
 before cycle detection can prune them, so raise `maxHops` deliberately.
+
+## Temporal Behavior
+
+Algorithms honor the same temporal model as the rest of the store. The
+default temporal mode is `graph.defaults.temporalMode` (typically
+`"current"`), and every algorithm accepts per-call `temporalMode` and
+`asOf` options.
+
+```typescript
+// Default: uses graph.defaults.temporalMode — typically "current".
+await store.algorithms.shortestPath(alice, bob, { edges: ["knows"] });
+
+// Snapshot at a specific point in time. Both nodes and edges must have
+// been valid at that timestamp to participate in the traversal.
+await store.algorithms.shortestPath(alice, bob, {
+  edges: ["knows"],
+  temporalMode: "asOf",
+  asOf: "2023-01-15T00:00:00Z",
+});
+
+// Include validity-ended (but not soft-deleted) rows — useful for
+// historical traversal without needing a specific timestamp.
+await store.algorithms.reachable(alice, {
+  edges: ["knows"],
+  temporalMode: "includeEnded",
+});
+
+// Include soft-deleted rows too. Traversal can cross through tombstones.
+await store.algorithms.canReach(alice, ghost, {
+  edges: ["knows"],
+  temporalMode: "includeTombstones",
+});
+```
+
+**Semantic rules:**
+
+- The temporal filter applies to **both nodes and edges** along the
+  traversal. An edge can only be traversed if it passes the filter *and*
+  its endpoint node passes too.
+- `asOf` is required when `temporalMode: "asOf"` and ignored in every
+  other mode.
+- Temporal filtering is orthogonal to `cyclePolicy` — cycle detection
+  operates on path membership, not on time. A node that was valid → ended
+  → re-valid is not treated as "visited" just because it appears in two
+  validity periods.
+- The shortest-path self-path short-circuit also respects the resolved
+  mode: calling `shortestPath(a, a, ...)` returns `undefined` if node `a`
+  does not pass the temporal filter, and a zero-hop result otherwise.
 
 ## End-to-End Example
 

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -1,0 +1,230 @@
+---
+title: Graph Algorithms
+description: Shortest path, reachability, neighborhoods, and degree on store.algorithms
+---
+
+Graph queries like "are Alice and Bob connected?" or "who is within two hops
+of this node?" are common enough that writing them as recursive CTEs by hand
+gets repetitive. TypeGraph exposes the high-utility algorithms as a small
+facade on the store:
+
+```typescript
+store.algorithms.shortestPath(alice, bob, { edges: ["knows"] });
+store.algorithms.reachable(alice, { edges: ["knows"] });
+store.algorithms.canReach(alice, bob, { edges: ["knows"] });
+store.algorithms.neighbors(alice, { edges: ["knows"], depth: 2 });
+store.algorithms.degree(alice, { edges: ["knows"] });
+```
+
+Each call compiles to a single `WITH RECURSIVE` CTE (or a plain `COUNT` for
+`degree`), using the same path-tracking and cycle-detection machinery as
+`.recursive()` and `store.subgraph()`. The algorithms work identically on
+SQLite and PostgreSQL.
+
+## When to Reach for Algorithms
+
+| You want to... | Use |
+|----------------|-----|
+| Find the fewest-hop route between two nodes | `shortestPath` |
+| List every node reachable from a source | `reachable` |
+| Check whether a node is reachable at all | `canReach` |
+| Get the k-hop neighborhood of a node | `neighbors` |
+| Count incident edges (in, out, or both) | `degree` |
+| Filter, sort, or project over traversal results | `.query().traverse()` / `.recursive()` |
+| Hydrate an entity plus all its relationships | `store.subgraph()` |
+
+The algorithms return lightweight `{ id, kind, depth }` records rather than
+fully hydrated nodes. Use `store.nodes.<Kind>.getByIds(...)` when you need
+the full node data.
+
+## Shared Options
+
+Every traversal algorithm takes the same base options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `edges` | `readonly EdgeKinds<G>[]` | *(required)* | Edge kinds to follow |
+| `maxHops` | `number` | `10` | Maximum traversal depth (1 – 1000) |
+| `direction` | `"out" \| "in" \| "both"` | `"out"` | Edge direction |
+| `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Skip visited nodes per path |
+
+`direction: "both"` treats edges as undirected. `cyclePolicy: "allow"` skips
+cycle tracking and relies solely on `maxHops` to terminate — use it only
+when you know the graph is acyclic or you want maximum raw performance.
+
+## shortestPath
+
+Finds the fewest-hop path from `from` to `to`. Returns `undefined` when no
+path exists within `maxHops`.
+
+```typescript
+const path = await store.algorithms.shortestPath(alice, bob, {
+  edges: ["knows"],
+  maxHops: 6,
+});
+
+if (path) {
+  console.log(`${path.depth} hops:`, path.nodes.map((n) => n.id));
+}
+```
+
+The result contains the ordered sequence of nodes (endpoints inclusive) and
+the hop count:
+
+```typescript
+type ShortestPathResult = Readonly<{
+  nodes: readonly Readonly<{ id: string; kind: string }>[];
+  depth: number;
+}>;
+```
+
+Source equal to target returns a zero-length path containing just that
+node. Missing or soft-deleted endpoints return `undefined`.
+
+## reachable
+
+Returns every node reachable from `from` within `maxHops`, annotated with
+the shortest depth at which it was discovered.
+
+```typescript
+const reachable = await store.algorithms.reachable(alice, {
+  edges: ["knows"],
+  maxHops: 3,
+});
+// [{ id, kind, depth: 0 }, { id, kind, depth: 1 }, ...]
+```
+
+Pass `excludeSource: true` to drop the zero-depth source entry. Results are
+sorted by ascending depth.
+
+## canReach
+
+Fast boolean check that short-circuits with `LIMIT 1` so the database stops
+traversing as soon as it finds the target.
+
+```typescript
+const connected = await store.algorithms.canReach(alice, bob, {
+  edges: ["knows"],
+  maxHops: 6,
+});
+```
+
+Use this when you only care whether a path exists — it's cheaper than
+`shortestPath` because it never decodes the path.
+
+## neighbors
+
+The k-hop neighborhood of a node, with the source always excluded. `depth`
+defaults to `1`, so `neighbors(alice)` returns Alice's immediate
+connections.
+
+```typescript
+const immediate = await store.algorithms.neighbors(alice, {
+  edges: ["knows"],
+});
+
+const twoHop = await store.algorithms.neighbors(alice, {
+  edges: ["knows"],
+  depth: 2,
+});
+```
+
+Semantically equivalent to `reachable({ maxHops: depth, excludeSource: true })`,
+but the name reads more naturally for neighborhood queries.
+
+## degree
+
+Counts active edges incident to a node. Self-loops contribute once when
+`direction` is `"both"`.
+
+```typescript
+const friends = await store.algorithms.degree(alice, {
+  edges: ["knows"],
+  direction: "out",
+});
+
+const connections = await store.algorithms.degree(alice, {
+  edges: ["knows"],
+  // direction: "both" is the default
+});
+
+const everything = await store.algorithms.degree(alice);
+// No `edges` option counts all edge kinds in the graph
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `edges` | `readonly EdgeKinds<G>[]` | all kinds | Edge kinds to count (empty array returns 0) |
+| `direction` | `"out" \| "in" \| "both"` | `"both"` | Count outgoing, incoming, or either |
+
+`degree` runs a single `COUNT` query, not a recursive CTE, so it's
+efficient even for hub nodes with thousands of edges.
+
+## Passing Nodes or IDs
+
+Every algorithm accepts either a raw ID string or any object with an
+`id: string` field — `Node`, `NodeRef`, the lightweight records returned by
+these algorithms, and `store.subgraph()` results all work:
+
+```typescript
+const alice = await store.nodes.Person.getById(aliceId);
+
+// All equivalent
+store.algorithms.canReach(alice, bobId, { edges: ["knows"] });
+store.algorithms.canReach(alice.id, bobId, { edges: ["knows"] });
+store.algorithms.canReach(aliceId, { kind: "Person", id: bobId }, {
+  edges: ["knows"],
+});
+```
+
+## Direction and Cycles
+
+`direction: "both"` lets you treat a directed edge kind as undirected for
+reachability questions:
+
+```typescript
+// Did Dave ever know Alice, regardless of who "added" whom first?
+const knew = await store.algorithms.canReach(dave, alice, {
+  edges: ["knows"],
+  direction: "both",
+});
+```
+
+Cycles are prevented by default. The underlying CTE tracks visited nodes
+per path (the same mechanism described in
+[Cycle Detection](/queries/recursive#cycle-detection) for `.recursive()`).
+Switch to `cyclePolicy: "allow"` only when you're confident the traversal
+terminates via `maxHops` alone.
+
+## Depth Limits
+
+`maxHops` is capped at `MAX_EXPLICIT_RECURSIVE_DEPTH` (1000) to prevent
+runaway queries. The default of 10 covers typical connectivity questions on
+most graphs. Graphs with branching factor *B* produce O(*B*^depth) rows
+before cycle detection can prune them, so raise `maxHops` deliberately.
+
+## End-to-End Example
+
+The runnable example
+[`examples/14-research-copilot.ts`](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/14-research-copilot.ts)
+combines every algorithm with semantic search and ontology-expanded topic
+matching over a corpus of landmark ML papers. It produces an
+explainable literature-review digest in one run against a single SQLite
+file — a good starting point for your own RAG + graph workloads.
+
+## What's Not Included
+
+These algorithms cover shortest path, reachability, neighborhoods, and
+degree. They do **not** cover:
+
+- Weighted shortest path (Dijkstra / A*)
+- Connected components or strongly connected components
+- Topological sort
+- Centrality measures beyond degree (betweenness, closeness, eigenvector)
+- PageRank or community detection
+
+For those, export edges via `.query().traverse()` or `store.subgraph()` and
+use a specialized library such as
+[graphology](https://graphology.github.io/) in memory. See
+[Limitations](/limitations#no-built-in-graph-analytics) for the full list
+of excluded analytics.

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -230,17 +230,26 @@ for (let i = 0; i < items.length; i += BATCH_SIZE) {
 }
 ```
 
-## No Built-in Graph Algorithms
+## No Built-in Graph Analytics
 
-TypeGraph deliberately excludes graph algorithms. The following are **not** provided:
+TypeGraph ships a small set of Tier 1 connectivity algorithms on
+`store.algorithms.*` — shortest path, reachability, k-hop neighborhoods,
+and degree. See [Graph Algorithms](/graph-algorithms) for the full API.
 
-- Shortest path (Dijkstra, A*)
+The following heavier analytics are **not** provided:
+
+- Weighted shortest path (Dijkstra, A*)
 - PageRank
 - Community detection
-- Centrality measures
+- Centrality measures beyond degree (betweenness, closeness, eigenvector)
+- Connected components / strongly connected components
+- Topological sort
 - Graph partitioning
 
-For these use cases, export your data to a specialized graph processing library or database.
+For these use cases, export your data via `.query().traverse()` or
+`store.subgraph()` and use a specialized library such as
+[graphology](https://graphology.github.io/) in memory, or move to a
+dedicated graph database.
 
 ## Single Database Deployment
 

--- a/apps/docs/src/content/docs/overview.md
+++ b/apps/docs/src/content/docs/overview.md
@@ -92,7 +92,8 @@ The same query code works with SQLite and PostgreSQL.
 
 TypeGraph deliberately excludes:
 
-- **Graph algorithms**: No built-in shortest path, PageRank, or community detection
+- **Advanced graph analytics**: No PageRank, community detection, weighted
+  shortest path, or centrality measures beyond degree
 - **Distributed storage**: Single-database deployment only
 
 These exclusions keep TypeGraph focused and maintainable.
@@ -104,6 +105,10 @@ Note: TypeGraph does support **variable-length paths** via `.recursive()` with
 configurable depth limits, optional path/depth projection, and explicit cycle
 policy. Cycle prevention is the default.
 See [Recursive Traversals](/queries/recursive) for details.
+
+Note: TypeGraph ships **Tier 1 graph algorithms** (shortest path, reachability,
+neighborhoods, and degree) on `store.algorithms.*`. Each call compiles to a
+single recursive CTE. See [Graph Algorithms](/graph-algorithms) for details.
 
 ## Why TypeGraph?
 
@@ -117,7 +122,7 @@ Graph databases are powerful but come with operational overhead:
 | **Network** | Additional latency for every query | In-process, no network hop |
 | **Transactions** | Separate transaction scope from your SQL data | Same ACID transaction as your other data |
 | **Learning curve** | New query language (Cypher, Gremlin) | TypeScript you already know |
-| **Graph algorithms** | Built-in (PageRank, shortest path) | Not included |
+| **Graph algorithms** | Built-in (PageRank, shortest path, community detection) | Tier 1 only (shortest path, reachability, neighborhoods, degree) |
 | **Scale** | Optimized for billions of nodes | Best for thousands to millions |
 
 **Choose TypeGraph** when your graph is part of your application domain (knowledge bases, org
@@ -178,4 +183,6 @@ TypeGraph is not ideal for:
 - Large-scale graph analytics requiring distributed processing
 - Social networks with billions of edges
 - Real-time streaming graph data
-- Applications requiring graph algorithms (use Neo4j or a graph library)
+- Applications requiring advanced graph algorithms such as PageRank,
+  community detection, or weighted shortest path (use Neo4j or a graph
+  library; Tier 1 connectivity algorithms ship on `store.algorithms.*`)

--- a/apps/docs/src/content/docs/queries/temporal.md
+++ b/apps/docs/src/content/docs/queries/temporal.md
@@ -206,6 +206,12 @@ const pastEmployees = await store
   .execute();
 ```
 
+`store.subgraph()` and `store.algorithms.*` accept the same `temporalMode`
+and `asOf` options, defaulting to `graph.defaults.temporalMode`. See
+[Temporal Behavior](/graph-algorithms#temporal-behavior) for the algorithm
+surface and [`store.subgraph()` options](/schemas-stores#storesubgraphrootid-options)
+for subgraph.
+
 ## Real-World Examples
 
 ### Version Comparison

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1430,6 +1430,7 @@ TypeGraph offers several ways to load related data. The right choice depends on 
 | Multiple independent queries with per-query control | `store.batch()` | Single connection, snapshot consistency, typed tuple results |
 | Check if an edge exists | `edges.X.findFrom()` | Lightweight — no node resolution needed |
 | Traverse + resolve one edge type | `edges.X.findFrom()` + `nodes.X.getByIds()` | Two queries, simple and explicit |
+| Shortest path, reachability, neighborhoods, degree | `store.algorithms.*` | Single recursive CTE or `COUNT` per call — see [Graph Algorithms](/graph-algorithms) |
 
 **Key insight:** `subgraph()` issues a single SQL statement regardless of how many edge types it
 traverses. Parallel `findFrom` calls scale linearly in round trips — one per edge type, plus
@@ -1440,6 +1441,50 @@ template instantiation), `subgraph()` with `maxDepth: 1` is the fastest approach
 per-query filtering, sorting, or pagination across multiple independent queries, use
 [`store.batch()`](#batch-query-execution) to run them over a single connection with snapshot
 consistency. Reserve individual fluent queries for one-off operations.
+
+### Graph Algorithms
+
+#### `store.algorithms`
+
+Lazy-initialized facade exposing the Tier 1 graph algorithms —
+`shortestPath`, `reachable`, `canReach`, `neighbors`, and `degree`.
+See [Graph Algorithms](/graph-algorithms) for the full API; this section
+is a quick reference.
+
+```typescript
+// Shortest path between two nodes
+const path = await store.algorithms.shortestPath(alice, bob, {
+  edges: ["knows"],
+});
+
+// Every reachable node with its discovery depth
+const reachable = await store.algorithms.reachable(alice, {
+  edges: ["knows"],
+  maxHops: 5,
+});
+
+// Fast boolean reachability check
+const connected = await store.algorithms.canReach(alice, bob, {
+  edges: ["knows"],
+});
+
+// k-hop neighborhood (source excluded)
+const twoHop = await store.algorithms.neighbors(alice, {
+  edges: ["knows"],
+  depth: 2,
+});
+
+// Count incident edges
+const total = await store.algorithms.degree(alice, { edges: ["knows"] });
+```
+
+Every traversal algorithm accepts `edges`, `maxHops` (default 10),
+`direction` (`"out" | "in" | "both"`, default `"out"`), and `cyclePolicy`
+(`"prevent" | "allow"`, default `"prevent"`). Each call compiles to a
+single recursive CTE; `degree` compiles to a single `COUNT`. Node
+arguments accept either raw IDs or any object with an `id` field — `Node`,
+`NodeRef`, and the lightweight records returned by these algorithms all
+work.
 
 ### Query Builder
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1261,6 +1261,8 @@ store.subgraph<EK, NK>(
 | `excludeRoot` | `boolean` | `false` | Exclude the root node from the result |
 | `direction` | `"out" \| "both"` | `"out"` | `"out"` follows edges in their defined direction; `"both"` treats edges as undirected |
 | `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Whether to detect and skip cycles during traversal |
+| `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to both nodes and edges along the traversal — same semantics as `store.query()` and collection reads |
+| `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
 | `project` | `{ nodes?, edges? }` | *(none)* | Per-kind field projection — see [Projection](#subgraph-projection) below |
 
 **Result:**
@@ -1282,8 +1284,9 @@ type SubgraphResult<G, NK, EK> = Readonly<{
 | `reverseAdjacency` | Reverse adjacency: `toId → edgeKind → edges[]` |
 
 Edges are only included when **both** endpoints appear in the result set.
-Soft-deleted nodes and edges are automatically excluded. Duplicate nodes
-(reachable via multiple paths) are deduplicated.
+Nodes and edges are filtered by the resolved `temporalMode` — by default,
+only currently valid rows participate. Duplicate nodes (reachable via
+multiple paths) are deduplicated.
 
 **Example:**
 
@@ -1480,11 +1483,12 @@ const total = await store.algorithms.degree(alice, { edges: ["knows"] });
 
 Every traversal algorithm accepts `edges`, `maxHops` (default 10),
 `direction` (`"out" | "in" | "both"`, default `"out"`), and `cyclePolicy`
-(`"prevent" | "allow"`, default `"prevent"`). Each call compiles to a
-single recursive CTE; `degree` compiles to a single `COUNT`. Node
-arguments accept either raw IDs or any object with an `id` field — `Node`,
-`NodeRef`, and the lightweight records returned by these algorithms all
-work.
+(`"prevent" | "allow"`, default `"prevent"`), plus `temporalMode` / `asOf`
+for temporal filtering — see [Temporal Behavior](/graph-algorithms#temporal-behavior).
+Each call compiles to a single recursive CTE; `degree` compiles to a
+single `COUNT`. Node arguments accept either raw IDs or any object with
+an `id` field — `Node`, `NodeRef`, and the lightweight records returned
+by these algorithms all work.
 
 ### Query Builder
 

--- a/packages/typegraph/examples/14-research-copilot.ts
+++ b/packages/typegraph/examples/14-research-copilot.ts
@@ -470,6 +470,10 @@ export async function main(): Promise<void> {
   // In production you'd use `d.embedding.similarTo(queryEmbedding, k)` for
   // hardware-accelerated vector search via pgvector or sqlite-vec.
   const allPapers = await store.nodes.Paper.find();
+  type PaperNode = (typeof allPapers)[number];
+  const paperById = new Map<string, PaperNode>(
+    allPapers.map((paper) => [paper.id, paper]),
+  );
   const ranked = allPapers
     .map((paper) => ({
       paper,
@@ -504,9 +508,12 @@ export async function main(): Promise<void> {
   });
   for (const topic of topicAncestors) expandedTopicIds.add(topic.id);
 
-  const expandedTopics = [...expandedTopicIds]
-    .map((id) => [...topicByName.values()].find((topic) => topic.id === id)!)
-    .map((topic) => (topic as { name: string }).name);
+  const topicById = new Map<string, TopicNode>(
+    [...topicByName.values()].map((topic) => [topic.id, topic]),
+  );
+  const expandedTopics = [...expandedTopicIds].map(
+    (id) => topicById.get(id)!.name,
+  );
   console.log(`  Expanded to: ${expandedTopics.join(" → ")}\n`);
 
   // Papers covering ANY topic in the expanded set (one query via IN predicate)
@@ -532,7 +539,7 @@ export async function main(): Promise<void> {
 
   console.log(" Papers matching expanded topic set:");
   for (const [paperId, topics] of matchByPaper) {
-    const paper = allPapers.find((p) => p.id === paperId)!;
+    const paper = paperById.get(paperId)!;
     console.log(`   • ${paper.title}`);
     console.log(`       covers: [${[...topics].join(", ")}]`);
   }
@@ -552,14 +559,13 @@ export async function main(): Promise<void> {
 
   const hybridScored = await Promise.all(
     [...candidateIds].map(async (paperId) => {
-      const paper = allPapers.find((p) => p.id === paperId)!;
+      const paper = paperById.get(paperId)!;
       const citationCount = await store.algorithms.degree(paperId, {
         edges: ["cites"],
         direction: "in",
       });
       const similarity = cosine(queryEmbedding, paper.embedding);
       const topicBonus = (matchByPaper.get(paperId)?.size ?? 0) * 0.05;
-      // Blend: semantic similarity + topic coverage + log(citations + 1) / 10
       const authorityBoost = Math.log(citationCount + 1) / 10;
       const score = similarity + topicBonus + authorityBoost;
       return { paper, similarity, citationCount, score };
@@ -650,20 +656,32 @@ export async function main(): Promise<void> {
   });
 
   // For each CLIP author: 1-hop in along authored_by = all their papers,
-  // then 1-hop out = all collaborators. We do this via a single fan-out
-  // query to demonstrate how algorithms and the query builder compose.
+  // then 1-hop out = all collaborators. Issue each level in parallel so the
+  // full fan-out finishes in O(depth) round-trips instead of O(authors × papers).
   const collaboratorCounts = new Map<string, number>();
-  for (const clipAuthor of clipAuthors) {
-    const otherPapers = await store.algorithms.neighbors(clipAuthor.id, {
-      edges: ["authored_by"],
-      direction: "in",
-      depth: 1,
-    });
-    for (const other of otherPapers) {
-      const collaborators = await store.algorithms.neighbors(other.id, {
+  const perAuthorPapers = await Promise.all(
+    clipAuthors.map((author) =>
+      store.algorithms.neighbors(author.id, {
         edges: ["authored_by"],
+        direction: "in",
         depth: 1,
-      });
+      }),
+    ),
+  );
+  const perAuthorCollaborators = await Promise.all(
+    perAuthorPapers.map((papers) =>
+      Promise.all(
+        papers.map((paper) =>
+          store.algorithms.neighbors(paper.id, {
+            edges: ["authored_by"],
+            depth: 1,
+          }),
+        ),
+      ),
+    ),
+  );
+  for (const [authorIndex, clipAuthor] of clipAuthors.entries()) {
+    for (const collaborators of perAuthorCollaborators[authorIndex]!) {
       for (const collab of collaborators) {
         if (collab.id === clipAuthor.id) continue;
         collaboratorCounts.set(
@@ -702,25 +720,31 @@ export async function main(): Promise<void> {
     .slice(0, 5)
     .sort((a, b) => a.paper.year - b.paper.year);
 
-  for (const pick of topPicks) {
-    const paperAuthors = await store
-      .query()
-      .from("Paper", "p")
-      .whereNode("p", (p) => p.id.eq(pick.paper.id))
-      .traverse("authored_by", "e")
-      .to("Author", "a")
-      .select((ctx) => ctx.a.name)
-      .execute();
+  const picksWithMeta = await Promise.all(
+    topPicks.map(async (pick) => {
+      const [paperAuthors, paperTopics] = await Promise.all([
+        store
+          .query()
+          .from("Paper", "p")
+          .whereNode("p", (p) => p.id.eq(pick.paper.id))
+          .traverse("authored_by", "e")
+          .to("Author", "a")
+          .select((ctx) => ctx.a.name)
+          .execute(),
+        store
+          .query()
+          .from("Paper", "p")
+          .whereNode("p", (p) => p.id.eq(pick.paper.id))
+          .traverse("covers_topic", "e")
+          .to("Topic", "t")
+          .select((ctx) => ctx.t.name)
+          .execute(),
+      ]);
+      return { pick, paperAuthors, paperTopics };
+    }),
+  );
 
-    const paperTopics = await store
-      .query()
-      .from("Paper", "p")
-      .whereNode("p", (p) => p.id.eq(pick.paper.id))
-      .traverse("covers_topic", "e")
-      .to("Topic", "t")
-      .select((ctx) => ctx.t.name)
-      .execute();
-
+  for (const { pick, paperAuthors, paperTopics } of picksWithMeta) {
     const citationLabel = pick.citationCount === 1 ? "citation" : "citations";
     console.log(
       `  ${pick.paper.year}  ${pick.paper.title}  [${pick.citationCount} ${citationLabel}]`,

--- a/packages/typegraph/examples/14-research-copilot.ts
+++ b/packages/typegraph/examples/14-research-copilot.ts
@@ -1,0 +1,745 @@
+/**
+ * Example 14: Research Copilot (RAG + Citation Graph + Tier 1 Algorithms)
+ *
+ * A "fuck yeah" showcase that combines everything TypeGraph does:
+ *
+ *   • Typed schema with Zod            → compile-time guarantees
+ *   • Ontology (topic hierarchy)        → query expansion
+ *   • Vector embeddings                 → semantic retrieval
+ *   • Recursive CTE traversals          → subgraph extraction
+ *   • Tier 1 graph algorithms           → shortestPath / reachable /
+ *                                          canReach / neighbors / degree
+ *
+ * The scenario: a researcher asks natural-language questions over a corpus
+ * of landmark ML papers. The copilot combines semantic search, ontology-
+ * expanded topic matching, citation-authority ranking (degree), explainable
+ * recommendations (shortestPath), and co-author discovery (neighbors) — all
+ * over a single SQLite database with zero external services.
+ *
+ * Run with:
+ *   npx tsx examples/14-research-copilot.ts
+ */
+import { z } from "zod";
+
+import {
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  embedding,
+} from "@nicia-ai/typegraph";
+import { createExampleBackend } from "./_helpers";
+
+// ============================================================
+// Schema
+// ============================================================
+
+const Paper = defineNode("Paper", {
+  schema: z.object({
+    title: z.string(),
+    year: z.number().int(),
+    abstract: z.string(),
+    embedding: embedding(128),
+  }),
+});
+
+const Author = defineNode("Author", {
+  schema: z.object({
+    name: z.string(),
+  }),
+});
+
+const Topic = defineNode("Topic", {
+  schema: z.object({
+    name: z.string(),
+  }),
+});
+
+const cites = defineEdge("cites", { schema: z.object({}) });
+const authoredBy = defineEdge("authored_by", { schema: z.object({}) });
+const coversTopic = defineEdge("covers_topic", { schema: z.object({}) });
+/**
+ * Topic hierarchy edge: `CNN broader_than DL` reads "CNN is a more specific
+ * concept than DL". Recursive traversal over this edge expands narrow query
+ * terms into their ancestor concepts for higher recall.
+ */
+const broaderThan = defineEdge("broader_than", { schema: z.object({}) });
+
+const graph = defineGraph({
+  id: "research_copilot",
+  nodes: {
+    Paper: { type: Paper },
+    Author: { type: Author },
+    Topic: { type: Topic },
+  },
+  edges: {
+    cites: { type: cites, from: [Paper], to: [Paper] },
+    authored_by: { type: authoredBy, from: [Paper], to: [Author] },
+    covers_topic: { type: coversTopic, from: [Paper], to: [Topic] },
+    broader_than: { type: broaderThan, from: [Topic], to: [Topic] },
+  },
+});
+
+// ============================================================
+// Mock embedding helper
+// ============================================================
+//
+// Real deployments plug in OpenAI / sentence-transformers / etc. For the
+// demo we derive a deterministic 128-d vector from the text so similarity
+// rankings are reproducible without a network call.
+
+function mockEmbedding(text: string): number[] {
+  const dim = 128;
+  const vector = new Array<number>(dim).fill(0);
+  const tokens = text.toLowerCase().split(/\W+/).filter(Boolean);
+  for (const token of tokens) {
+    let hash = 0;
+    for (const char of token) hash = (hash * 31 + char.charCodeAt(0)) | 0;
+    for (let i = 0; i < dim; i++) {
+      vector[i]! += Math.sin(hash * (i + 1)) * 0.25 + Math.cos(hash + i) * 0.25;
+    }
+  }
+  const magnitude = Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0)) || 1;
+  return vector.map((v) => v / magnitude);
+}
+
+function cosine(a: readonly number[], b: readonly number[]): number {
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i]! * b[i]!;
+  return dot; // both vectors are unit-length
+}
+
+// ============================================================
+// Seed corpus: landmark ML papers with a realistic citation DAG
+// ============================================================
+
+type SeedPaper = Readonly<{
+  key: string;
+  title: string;
+  year: number;
+  abstract: string;
+  authors: readonly string[];
+  topics: readonly string[];
+  cites: readonly string[];
+}>;
+
+const PAPERS: readonly SeedPaper[] = [
+  {
+    key: "backprop",
+    title: "Learning representations by back-propagating errors",
+    year: 1986,
+    abstract:
+      "A procedure that adjusts the weights of hidden units in neural networks using gradients of the error. The backbone of modern deep learning optimization.",
+    authors: ["David Rumelhart", "Geoffrey Hinton", "Ronald Williams"],
+    topics: ["Optimization", "DeepLearning"],
+    cites: [],
+  },
+  {
+    key: "lenet",
+    title: "Gradient-Based Learning Applied to Document Recognition",
+    year: 1998,
+    abstract:
+      "Convolutional neural networks trained end-to-end outperform hand-engineered features on handwritten digit recognition.",
+    authors: ["Yann LeCun", "Leon Bottou", "Yoshua Bengio"],
+    topics: ["CNN", "ComputerVision"],
+    cites: ["backprop"],
+  },
+  {
+    key: "word2vec",
+    title: "Efficient Estimation of Word Representations in Vector Space",
+    year: 2013,
+    abstract:
+      "Dense vector representations of words learned from large unlabeled corpora via shallow neural networks; captures analogical semantic structure.",
+    authors: ["Tomas Mikolov", "Kai Chen", "Greg Corrado", "Jeffrey Dean"],
+    topics: ["Embeddings", "NLP"],
+    cites: ["backprop"],
+  },
+  {
+    key: "alexnet",
+    title: "ImageNet Classification with Deep Convolutional Neural Networks",
+    year: 2012,
+    abstract:
+      "A large deep CNN trained on ImageNet crushes prior benchmarks, launching the modern deep learning era of computer vision.",
+    authors: ["Alex Krizhevsky", "Ilya Sutskever", "Geoffrey Hinton"],
+    topics: ["CNN", "ComputerVision", "DeepLearning"],
+    cites: ["lenet", "backprop"],
+  },
+  {
+    key: "dropout",
+    title: "Dropout: A Simple Way to Prevent Neural Networks from Overfitting",
+    year: 2014,
+    abstract:
+      "Randomly zeroing unit activations during training prevents co-adaptation and dramatically improves generalization.",
+    authors: [
+      "Nitish Srivastava",
+      "Geoffrey Hinton",
+      "Alex Krizhevsky",
+      "Ilya Sutskever",
+    ],
+    topics: ["DeepLearning", "Optimization"],
+    cites: ["alexnet", "backprop"],
+  },
+  {
+    key: "adam",
+    title: "Adam: A Method for Stochastic Optimization",
+    year: 2014,
+    abstract:
+      "An adaptive moment estimation algorithm for first-order gradient-based optimization of stochastic objective functions; the default optimizer for modern deep learning.",
+    authors: ["Diederik Kingma", "Jimmy Ba"],
+    topics: ["Optimization"],
+    cites: ["backprop"],
+  },
+  {
+    key: "vgg",
+    title: "Very Deep Convolutional Networks for Large-Scale Image Recognition",
+    year: 2014,
+    abstract:
+      "Very deep architectures with small 3x3 filters achieve state-of-the-art on image classification.",
+    authors: ["Karen Simonyan", "Andrew Zisserman"],
+    topics: ["CNN", "ComputerVision"],
+    cites: ["alexnet"],
+  },
+  {
+    key: "resnet",
+    title: "Deep Residual Learning for Image Recognition",
+    year: 2015,
+    abstract:
+      "Residual connections let us train networks with hundreds of layers by reformulating layers as learning residual functions.",
+    authors: ["Kaiming He", "Xiangyu Zhang", "Shaoqing Ren", "Jian Sun"],
+    topics: ["CNN", "ComputerVision", "DeepLearning"],
+    cites: ["alexnet", "vgg", "dropout"],
+  },
+  {
+    key: "seq2seq",
+    title: "Sequence to Sequence Learning with Neural Networks",
+    year: 2014,
+    abstract:
+      "An encoder-decoder LSTM architecture that maps variable-length input sequences to variable-length output sequences end-to-end.",
+    authors: ["Ilya Sutskever", "Oriol Vinyals", "Quoc Le"],
+    topics: ["RNN", "NLP", "DeepLearning"],
+    cites: ["backprop", "word2vec"],
+  },
+  {
+    key: "transformer",
+    title: "Attention Is All You Need",
+    year: 2017,
+    abstract:
+      "A new sequence transduction architecture based solely on attention mechanisms, dispensing with recurrence and convolutions entirely.",
+    authors: [
+      "Ashish Vaswani",
+      "Noam Shazeer",
+      "Niki Parmar",
+      "Jakob Uszkoreit",
+    ],
+    topics: ["Transformer", "Attention", "NLP"],
+    cites: ["seq2seq", "adam", "dropout", "word2vec"],
+  },
+  {
+    key: "bert",
+    title:
+      "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
+    year: 2018,
+    abstract:
+      "Masked language modeling on bidirectional transformers produces representations that transfer to a wide range of NLP tasks via fine-tuning.",
+    authors: ["Jacob Devlin", "Ming-Wei Chang", "Kenton Lee", "Kristina Toutanova"],
+    topics: ["Transformer", "NLP", "SelfSupervised", "LanguageModel"],
+    cites: ["transformer", "word2vec"],
+  },
+  {
+    key: "gpt2",
+    title: "Language Models are Unsupervised Multitask Learners",
+    year: 2019,
+    abstract:
+      "A large transformer trained on diverse web text demonstrates strong zero-shot performance across many downstream NLP tasks.",
+    authors: [
+      "Alec Radford",
+      "Jeffrey Wu",
+      "Rewon Child",
+      "Ilya Sutskever",
+    ],
+    topics: ["Transformer", "NLP", "LanguageModel"],
+    cites: ["transformer", "bert"],
+  },
+  {
+    key: "moco",
+    title:
+      "Momentum Contrast for Unsupervised Visual Representation Learning",
+    year: 2019,
+    abstract:
+      "A contrastive learning framework that uses a momentum encoder and a dynamic queue of negatives to learn visual representations without labels.",
+    authors: ["Kaiming He", "Haoqi Fan", "Yuxin Wu", "Saining Xie"],
+    topics: ["Contrastive", "SelfSupervised", "ComputerVision"],
+    cites: ["resnet"],
+  },
+  {
+    key: "simclr",
+    title:
+      "A Simple Framework for Contrastive Learning of Visual Representations",
+    year: 2020,
+    abstract:
+      "A surprisingly simple contrastive framework—strong augmentation, a nonlinear projection head, large batch sizes—produces state-of-the-art self-supervised visual representations.",
+    authors: [
+      "Ting Chen",
+      "Simon Kornblith",
+      "Mohammad Norouzi",
+      "Geoffrey Hinton",
+    ],
+    topics: ["Contrastive", "SelfSupervised", "ComputerVision"],
+    cites: ["resnet", "moco", "dropout"],
+  },
+  {
+    key: "vit",
+    title:
+      "An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    year: 2020,
+    abstract:
+      "Applying a pure transformer directly to sequences of image patches achieves excellent results on image classification when pre-trained at scale.",
+    authors: [
+      "Alexey Dosovitskiy",
+      "Lucas Beyer",
+      "Alexander Kolesnikov",
+      "Dirk Weissenborn",
+    ],
+    topics: ["Transformer", "ComputerVision", "DeepLearning"],
+    cites: ["transformer", "resnet", "bert"],
+  },
+  {
+    key: "clip",
+    title:
+      "Learning Transferable Visual Models From Natural Language Supervision",
+    year: 2021,
+    abstract:
+      "Contrastive pre-training over 400M (image, text) pairs learns a joint embedding space that enables zero-shot image classification on dozens of benchmarks.",
+    authors: [
+      "Alec Radford",
+      "Jong Wook Kim",
+      "Chris Hallacy",
+      "Aditya Ramesh",
+      "Ilya Sutskever",
+    ],
+    topics: [
+      "Contrastive",
+      "MultiModal",
+      "ComputerVision",
+      "NLP",
+      "SelfSupervised",
+    ],
+    cites: ["vit", "simclr", "bert", "gpt2"],
+  },
+  {
+    key: "cot",
+    title: "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models",
+    year: 2022,
+    abstract:
+      "Prompting large language models to produce intermediate reasoning steps dramatically improves their performance on arithmetic, commonsense, and symbolic reasoning tasks.",
+    authors: [
+      "Jason Wei",
+      "Xuezhi Wang",
+      "Dale Schuurmans",
+      "Maarten Bosma",
+      "Ed Chi",
+      "Quoc Le",
+    ],
+    topics: ["LanguageModel", "Reasoning", "NLP"],
+    cites: ["gpt2", "bert"],
+  },
+  {
+    key: "llama",
+    title: "LLaMA: Open and Efficient Foundation Language Models",
+    year: 2023,
+    abstract:
+      "A collection of foundation language models ranging from 7B to 65B parameters trained exclusively on publicly available data, competitive with much larger closed models.",
+    authors: ["Hugo Touvron", "Thibaut Lavril", "Gautier Izacard"],
+    topics: ["Transformer", "LanguageModel", "NLP"],
+    cites: ["transformer", "gpt2", "cot"],
+  },
+];
+
+/**
+ * Topic hierarchy: narrow -> broader. Recursively expanding this edge lets
+ * a search for "Contrastive" also surface "SelfSupervised" and
+ * "DeepLearning" results.
+ */
+const TOPIC_HIERARCHY: readonly (readonly [string, string])[] = [
+  ["CNN", "DeepLearning"],
+  ["RNN", "DeepLearning"],
+  ["Transformer", "DeepLearning"],
+  ["Attention", "Transformer"],
+  ["Contrastive", "SelfSupervised"],
+  ["SelfSupervised", "DeepLearning"],
+  ["LanguageModel", "NLP"],
+  ["Reasoning", "LanguageModel"],
+  ["Embeddings", "NLP"],
+  ["MultiModal", "DeepLearning"],
+  ["Optimization", "DeepLearning"],
+  ["ComputerVision", "DeepLearning"],
+  ["NLP", "DeepLearning"],
+];
+
+// ============================================================
+// Main: build the graph, then run the copilot demo
+// ============================================================
+
+export async function main(): Promise<void> {
+  const store = createStore(graph, createExampleBackend());
+
+  console.log("━".repeat(68));
+  console.log(" Research Copilot — RAG + citation graph + Tier 1 algorithms");
+  console.log("━".repeat(68));
+
+  // ----------------------------------------------------------
+  // Seed the graph
+  // ----------------------------------------------------------
+
+  const paperByKey = new Map<string, { id: string; title: string }>();
+  type AuthorNode = Awaited<ReturnType<typeof store.nodes.Author.create>>;
+  type TopicNode = Awaited<ReturnType<typeof store.nodes.Topic.create>>;
+  const authorByName = new Map<string, AuthorNode>();
+  const topicByName = new Map<string, TopicNode>();
+
+  async function ensureAuthor(name: string): Promise<AuthorNode> {
+    const cached = authorByName.get(name);
+    if (cached) return cached;
+    const created = await store.nodes.Author.create({ name });
+    authorByName.set(name, created);
+    return created;
+  }
+
+  async function ensureTopic(name: string): Promise<TopicNode> {
+    const cached = topicByName.get(name);
+    if (cached) return cached;
+    const created = await store.nodes.Topic.create({ name });
+    topicByName.set(name, created);
+    return created;
+  }
+
+  for (const paper of PAPERS) {
+    const created = await store.nodes.Paper.create({
+      title: paper.title,
+      year: paper.year,
+      abstract: paper.abstract,
+      embedding: mockEmbedding(`${paper.title}. ${paper.abstract}`),
+    });
+    paperByKey.set(paper.key, { id: created.id, title: created.title });
+
+    for (const name of paper.authors) {
+      const author = await ensureAuthor(name);
+      await store.edges.authored_by.create(created, author, {});
+    }
+    for (const name of paper.topics) {
+      const topic = await ensureTopic(name);
+      await store.edges.covers_topic.create(created, topic, {});
+    }
+  }
+
+  for (const paper of PAPERS) {
+    const source = paperByKey.get(paper.key)!;
+    for (const citedKey of paper.cites) {
+      const target = paperByKey.get(citedKey)!;
+      await store.edges.cites.create(
+        { kind: "Paper", id: source.id },
+        { kind: "Paper", id: target.id },
+        {},
+      );
+    }
+  }
+
+  for (const [narrow, broad] of TOPIC_HIERARCHY) {
+    const narrowTopic = await ensureTopic(narrow);
+    const broadTopic = await ensureTopic(broad);
+    await store.edges.broader_than.create(narrowTopic, broadTopic, {});
+  }
+
+  console.log(
+    `\nIngested ${PAPERS.length} papers, ${authorByName.size} authors, ${topicByName.size} topics.\n`,
+  );
+
+  // ----------------------------------------------------------
+  // Scene 1: Semantic retrieval with ontology-expanded topics
+  // ----------------------------------------------------------
+
+  const query =
+    "contrastive self-supervised representation learning for vision";
+  console.log("━".repeat(68));
+  console.log(` [1] Semantic retrieval for: "${query}"`);
+  console.log("━".repeat(68));
+
+  const queryEmbedding = mockEmbedding(query);
+
+  // Fetch every paper + embedding once; rank by cosine similarity in JS.
+  // In production you'd use `d.embedding.similarTo(queryEmbedding, k)` for
+  // hardware-accelerated vector search via pgvector or sqlite-vec.
+  const allPapers = await store.nodes.Paper.find();
+  const ranked = allPapers
+    .map((paper) => ({
+      paper,
+      similarity: cosine(queryEmbedding, paper.embedding),
+    }))
+    .sort((a, b) => b.similarity - a.similarity);
+
+  console.log("\nTop semantic hits (vector similarity only):");
+  for (const hit of ranked.slice(0, 5)) {
+    const stars = "★".repeat(Math.max(1, Math.round(hit.similarity * 10)));
+    console.log(
+      `  ${hit.similarity.toFixed(3)} ${stars.padEnd(10)} ${hit.paper.title}`,
+    );
+  }
+
+  // ----------------------------------------------------------
+  // Scene 2: Ontology-expanded topic retrieval
+  // ----------------------------------------------------------
+
+  console.log("\n─── Ontology-expanded topic match ───");
+  console.log(
+    ' Query: "Contrastive" → recursively expand via broader_than → all',
+  );
+  console.log(" ancestor concepts matched too (SelfSupervised, DeepLearning).\n");
+
+  const contrastiveTopic = topicByName.get("Contrastive")!;
+  const expandedTopicIds = new Set<string>([contrastiveTopic.id]);
+  const topicAncestors = await store.algorithms.reachable(contrastiveTopic, {
+    edges: ["broader_than"],
+    maxHops: 10,
+    excludeSource: true,
+  });
+  for (const topic of topicAncestors) expandedTopicIds.add(topic.id);
+
+  const expandedTopics = [...expandedTopicIds]
+    .map((id) => [...topicByName.values()].find((topic) => topic.id === id)!)
+    .map((topic) => (topic as { name: string }).name);
+  console.log(`  Expanded to: ${expandedTopics.join(" → ")}\n`);
+
+  // Papers covering ANY topic in the expanded set (one query via IN predicate)
+  const topicMatches = await store
+    .query()
+    .from("Paper", "p")
+    .traverse("covers_topic", "e")
+    .to("Topic", "t")
+    .whereNode("t", (t) => t.id.in([...expandedTopicIds]))
+    .select((ctx) => ({
+      id: ctx.p.id,
+      title: ctx.p.title,
+      topic: ctx.t.name,
+    }))
+    .execute();
+
+  const matchByPaper = new Map<string, Set<string>>();
+  for (const row of topicMatches) {
+    const set = matchByPaper.get(row.id) ?? new Set();
+    set.add(row.topic);
+    matchByPaper.set(row.id, set);
+  }
+
+  console.log(" Papers matching expanded topic set:");
+  for (const [paperId, topics] of matchByPaper) {
+    const paper = allPapers.find((p) => p.id === paperId)!;
+    console.log(`   • ${paper.title}`);
+    console.log(`       covers: [${[...topics].join(", ")}]`);
+  }
+
+  // ----------------------------------------------------------
+  // Scene 3: Re-rank hybrid results by citation authority
+  // ----------------------------------------------------------
+
+  console.log("\n" + "━".repeat(68));
+  console.log(" [2] Citation-authority re-ranking (degree)");
+  console.log("━".repeat(68) + "\n");
+
+  const candidateIds = new Set<string>([
+    ...ranked.slice(0, 8).map((hit) => hit.paper.id),
+    ...matchByPaper.keys(),
+  ]);
+
+  const hybridScored = await Promise.all(
+    [...candidateIds].map(async (paperId) => {
+      const paper = allPapers.find((p) => p.id === paperId)!;
+      const citationCount = await store.algorithms.degree(paperId, {
+        edges: ["cites"],
+        direction: "in",
+      });
+      const similarity = cosine(queryEmbedding, paper.embedding);
+      const topicBonus = (matchByPaper.get(paperId)?.size ?? 0) * 0.05;
+      // Blend: semantic similarity + topic coverage + log(citations + 1) / 10
+      const authorityBoost = Math.log(citationCount + 1) / 10;
+      const score = similarity + topicBonus + authorityBoost;
+      return { paper, similarity, citationCount, score };
+    }),
+  );
+
+  hybridScored.sort((a, b) => b.score - a.score);
+
+  console.log(
+    " rank  score  sim    cites  title".padEnd(68) + "\n " + "─".repeat(67),
+  );
+  for (const [index, entry] of hybridScored.slice(0, 6).entries()) {
+    const rank = `  ${index + 1}`.padStart(4);
+    console.log(
+      `${rank}   ${entry.score.toFixed(3)}  ${entry.similarity.toFixed(3)}  ${String(entry.citationCount).padStart(5)}  ${entry.paper.title}`,
+    );
+  }
+
+  // ----------------------------------------------------------
+  // Scene 4: Explainable recommendations via shortestPath
+  // ----------------------------------------------------------
+
+  console.log("\n" + "━".repeat(68));
+  console.log(" [3] Explainable lineage (shortestPath)");
+  console.log("━".repeat(68));
+  console.log(
+    '\n "You\'ve read AlexNet — how does SimCLR trace back to it?"\n',
+  );
+
+  const alex = paperByKey.get("alexnet")!;
+  const simclr = paperByKey.get("simclr")!;
+
+  const lineage = await store.algorithms.shortestPath(simclr.id, alex.id, {
+    edges: ["cites"],
+    maxHops: 6,
+  });
+
+  const titleById = new Map(
+    [...paperByKey.values()].map((paper) => [paper.id, paper.title]),
+  );
+
+  if (lineage) {
+    console.log(`   ${lineage.depth}-hop citation lineage:\n`);
+    for (const [index, node] of lineage.nodes.entries()) {
+      const title = titleById.get(node.id) ?? node.id;
+      const prefix = index === 0 ? "   " : " ".repeat(3 + index * 2) + "└─▶ ";
+      console.log(`${prefix}${title}`);
+    }
+  } else {
+    console.log("   (no path)");
+  }
+
+  // ----------------------------------------------------------
+  // Scene 5: "Is this work grounded in backprop?"
+  // ----------------------------------------------------------
+
+  console.log("\n─── Heritage check (canReach) ───\n");
+
+  const backprop = paperByKey.get("backprop")!;
+  for (const key of ["llama", "clip", "cot", "simclr"] as const) {
+    const paper = paperByKey.get(key)!;
+    const reaches = await store.algorithms.canReach(paper.id, backprop.id, {
+      edges: ["cites"],
+      maxHops: 10,
+    });
+    console.log(
+      `   ${reaches ? "✓" : "✗"}  "${paper.title.slice(0, 55).padEnd(55)}"  ${reaches ? "traces to Rumelhart 1986" : "does not reach"}`,
+    );
+  }
+
+  // ----------------------------------------------------------
+  // Scene 6: Co-author discovery via 2-hop neighborhood
+  // ----------------------------------------------------------
+
+  console.log("\n" + "━".repeat(68));
+  console.log(" [4] Collaborator discovery (neighbors, 2 hops)");
+  console.log("━".repeat(68));
+  console.log(
+    '\n "If I write a paper citing CLIP, who are my natural co-authors?"\n',
+  );
+
+  const clip = paperByKey.get("clip")!;
+
+  // 1-hop out: CLIP → authors
+  const clipAuthors = await store.algorithms.neighbors(clip.id, {
+    edges: ["authored_by"],
+    depth: 1,
+  });
+
+  // For each CLIP author: 1-hop in along authored_by = all their papers,
+  // then 1-hop out = all collaborators. We do this via a single fan-out
+  // query to demonstrate how algorithms and the query builder compose.
+  const collaboratorCounts = new Map<string, number>();
+  for (const clipAuthor of clipAuthors) {
+    const otherPapers = await store.algorithms.neighbors(clipAuthor.id, {
+      edges: ["authored_by"],
+      direction: "in",
+      depth: 1,
+    });
+    for (const other of otherPapers) {
+      const collaborators = await store.algorithms.neighbors(other.id, {
+        edges: ["authored_by"],
+        depth: 1,
+      });
+      for (const collab of collaborators) {
+        if (collab.id === clipAuthor.id) continue;
+        collaboratorCounts.set(
+          collab.id,
+          (collaboratorCounts.get(collab.id) ?? 0) + 1,
+        );
+      }
+    }
+  }
+
+  const topCollaborators = [...collaboratorCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8);
+
+  const authorById = new Map<string, string>(
+    [...authorByName.values()].map((author) => [author.id, author.name]),
+  );
+  for (const [id, count] of topCollaborators) {
+    console.log(
+      `   ${count}× shared papers  ${authorById.get(id) ?? id}`,
+    );
+  }
+
+  // ----------------------------------------------------------
+  // Scene 7: Literature review digest
+  // ----------------------------------------------------------
+
+  console.log("\n" + "━".repeat(68));
+  console.log(" [5] One-shot literature review digest");
+  console.log("━".repeat(68) + "\n");
+
+  console.log(` Query: "${query}"\n`);
+  console.log(" Recommended reading order (chronological among top-ranked):\n");
+
+  const topPicks = hybridScored
+    .slice(0, 5)
+    .sort((a, b) => a.paper.year - b.paper.year);
+
+  for (const pick of topPicks) {
+    const paperAuthors = await store
+      .query()
+      .from("Paper", "p")
+      .whereNode("p", (p) => p.id.eq(pick.paper.id))
+      .traverse("authored_by", "e")
+      .to("Author", "a")
+      .select((ctx) => ctx.a.name)
+      .execute();
+
+    const paperTopics = await store
+      .query()
+      .from("Paper", "p")
+      .whereNode("p", (p) => p.id.eq(pick.paper.id))
+      .traverse("covers_topic", "e")
+      .to("Topic", "t")
+      .select((ctx) => ctx.t.name)
+      .execute();
+
+    const citationLabel = pick.citationCount === 1 ? "citation" : "citations";
+    console.log(
+      `  ${pick.paper.year}  ${pick.paper.title}  [${pick.citationCount} ${citationLabel}]`,
+    );
+    console.log(`        ${paperAuthors.slice(0, 3).join(", ")}${paperAuthors.length > 3 ? ", et al." : ""}`);
+    console.log(`        topics: ${paperTopics.join(", ")}`);
+  }
+
+  console.log("\n" + "━".repeat(68));
+  console.log(" Everything above ran against a single in-memory SQLite file.");
+  console.log(" Swap to Postgres by changing one import.");
+  console.log("━".repeat(68) + "\n");
+
+  await store.close();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/README.md
+++ b/packages/typegraph/examples/README.md
@@ -53,6 +53,7 @@ npx tsx examples/<example-name>.ts
 |---------|-------------|
 | [11-semantic-search.ts](./11-semantic-search.ts) | Vector embeddings and similarity search |
 | [12-knowledge-graph-rag.ts](./12-knowledge-graph-rag.ts) | Knowledge graph patterns for RAG applications |
+| [14-research-copilot.ts](./14-research-copilot.ts) | End-to-end showcase: semantic search + ontology-expanded topics + all five Tier 1 graph algorithms over a citation graph |
 
 ## Prerequisites
 

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -200,6 +200,20 @@ export type {
 } from "./store";
 export { createStore, createStoreWithSchema } from "./store";
 export type {
+  AlgorithmCyclePolicy,
+  BaseTraversalOptions,
+  DegreeOptions,
+  GraphAlgorithms,
+  NeighborsOptions,
+  NodeIdentifier,
+  PathNode,
+  ReachableNode,
+  ReachableOptions,
+  ShortestPathOptions,
+  ShortestPathResult,
+  TraversalDirection,
+} from "./store/algorithms";
+export type {
   AnyEdge,
   AnyNode,
   SubgraphEdgeResult,

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -211,6 +211,7 @@ export type {
   ReachableOptions,
   ShortestPathOptions,
   ShortestPathResult,
+  TemporalAlgorithmOptions,
   TraversalDirection,
 } from "./store/algorithms";
 export type {

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -1,0 +1,87 @@
+/**
+ * Resolved execution context shared by algorithm implementations.
+ *
+ * Algorithms are exposed as `store.algorithms.*` and share the same
+ * graph-id, backend, dialect, and schema as the hosting store. Bundling
+ * these into one value keeps the per-algorithm files focused on SQL
+ * generation and result decoding.
+ */
+import { type GraphBackend } from "../../backend/types";
+import { ConfigurationError } from "../../errors";
+import { MAX_EXPLICIT_RECURSIVE_DEPTH } from "../../query/compiler/recursive";
+import { type SqlSchema } from "../../query/compiler/schema";
+import { type DialectAdapter } from "../../query/dialect/types";
+import type { AlgorithmCyclePolicy, TraversalDirection } from "./types";
+
+export const DEFAULT_ALGORITHM_MAX_HOPS = 10;
+export const DEFAULT_NEIGHBOR_DEPTH = 1;
+
+export type AlgorithmContext = Readonly<{
+  graphId: string;
+  backend: GraphBackend;
+  dialect: DialectAdapter;
+  schema: SqlSchema;
+}>;
+
+/**
+ * Graph-agnostic shape of traversal options used by every recursive-CTE
+ * algorithm. Public wrappers in `./index.ts` narrow `edges` to
+ * `EdgeKinds<G>[]` for type safety; the runtime only sees raw kind strings.
+ */
+export type InternalTraversalOptions = Readonly<{
+  edges: readonly string[];
+  maxHops?: number;
+  direction?: TraversalDirection;
+  cyclePolicy?: AlgorithmCyclePolicy;
+}>;
+
+/**
+ * Normalizes and validates a `maxHops` option.
+ *
+ * Rejects zero, negative, non-finite, and over-limit values up-front so the
+ * compiled SQL always carries a sensible `r.depth < N` bound.
+ */
+export function resolveMaxHops(
+  rawMaxHops: number | undefined,
+  fallback: number,
+  optionName: "maxHops" | "depth",
+): number {
+  const value = rawMaxHops ?? fallback;
+
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new ConfigurationError(
+      `Graph algorithm ${optionName} must be a finite integer, got ${String(value)}.`,
+      { option: optionName, value },
+    );
+  }
+
+  if (value < 1) {
+    throw new ConfigurationError(
+      `Graph algorithm ${optionName} must be at least 1, got ${value}.`,
+      { option: optionName, value },
+    );
+  }
+
+  if (value > MAX_EXPLICIT_RECURSIVE_DEPTH) {
+    throw new ConfigurationError(
+      `Graph algorithm ${optionName} (${value}) exceeds the maximum of ${MAX_EXPLICIT_RECURSIVE_DEPTH}.`,
+      { option: optionName, value, limit: MAX_EXPLICIT_RECURSIVE_DEPTH },
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Validates that the caller supplied at least one edge kind. Zero-kind
+ * traversals always produce empty results, which almost always indicates a
+ * programming mistake (forgotten kind list, typo in a variable).
+ */
+export function assertEdgeKinds(edges: readonly string[]): void {
+  if (edges.length === 0) {
+    throw new ConfigurationError(
+      `Graph algorithms require at least one edge kind in 'edges'.`,
+      { edges },
+    );
+  }
+}

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -1,15 +1,12 @@
-/**
- * Resolved execution context shared by algorithm implementations.
- *
- * Algorithms are exposed as `store.algorithms.*` and share the same
- * graph-id, backend, dialect, and schema as the hosting store. Bundling
- * these into one value keeps the per-algorithm files focused on SQL
- * generation and result decoding.
- */
 import { type GraphBackend } from "../../backend/types";
+import { type TemporalMode } from "../../core/types";
 import { ConfigurationError } from "../../errors";
 import { MAX_EXPLICIT_RECURSIVE_DEPTH } from "../../query/compiler/recursive";
 import { type SqlSchema } from "../../query/compiler/schema";
+import {
+  compileTemporalFilter,
+  type TemporalFilterOptions,
+} from "../../query/compiler/temporal";
 import { type DialectAdapter } from "../../query/dialect/types";
 import type { AlgorithmCyclePolicy, TraversalDirection } from "./types";
 
@@ -21,26 +18,56 @@ export type AlgorithmContext = Readonly<{
   backend: GraphBackend;
   dialect: DialectAdapter;
   schema: SqlSchema;
+  defaultTemporalMode: TemporalMode;
 }>;
 
-/**
- * Graph-agnostic shape of traversal options used by every recursive-CTE
- * algorithm. Public wrappers in `./index.ts` narrow `edges` to
- * `EdgeKinds<G>[]` for type safety; the runtime only sees raw kind strings.
- */
-export type InternalTraversalOptions = Readonly<{
-  edges: readonly string[];
-  maxHops?: number;
-  direction?: TraversalDirection;
-  cyclePolicy?: AlgorithmCyclePolicy;
+export type InternalTemporalOptions = Readonly<{
+  temporalMode?: TemporalMode;
+  asOf?: string;
 }>;
 
+export type InternalTraversalOptions = InternalTemporalOptions &
+  Readonly<{
+    edges: readonly string[];
+    maxHops?: number;
+    direction?: TraversalDirection;
+    cyclePolicy?: AlgorithmCyclePolicy;
+  }>;
+
 /**
- * Normalizes and validates a `maxHops` option.
- *
- * Rejects zero, negative, non-finite, and over-limit values up-front so the
- * compiled SQL always carries a sensible `r.depth < N` bound.
+ * Resolves per-call temporal overrides against the graph's default mode into
+ * a plain `{ temporalMode, asOf? }` object. Shared by callers that forward
+ * the pair to `buildReachableCte`.
  */
+export function resolveTemporalOptions(
+  ctx: AlgorithmContext,
+  options: InternalTemporalOptions,
+): Readonly<{ temporalMode: TemporalMode; asOf?: string }> {
+  return {
+    temporalMode: options.temporalMode ?? ctx.defaultTemporalMode,
+    ...(options.asOf !== undefined && { asOf: options.asOf }),
+  };
+}
+
+/**
+ * Compiles the resolved temporal filter to SQL. `asOf` is only meaningful
+ * when the resolved mode is `"asOf"`; `compileTemporalFilter` ignores it in
+ * every other mode.
+ */
+export function resolveTemporalFilter(
+  ctx: AlgorithmContext,
+  options: InternalTemporalOptions,
+  tableAlias?: string,
+): ReturnType<typeof compileTemporalFilter> {
+  const resolved = resolveTemporalOptions(ctx, options);
+  const filterOptions: TemporalFilterOptions = {
+    mode: resolved.temporalMode,
+    asOf: resolved.asOf,
+    tableAlias,
+  };
+  return compileTemporalFilter(filterOptions);
+}
+
 export function resolveMaxHops(
   rawMaxHops: number | undefined,
   fallback: number,
@@ -72,11 +99,6 @@ export function resolveMaxHops(
   return value;
 }
 
-/**
- * Validates that the caller supplied at least one edge kind. Zero-kind
- * traversals always produce empty results, which almost always indicates a
- * programming mistake (forgotten kind list, typo in a variable).
- */
 export function assertEdgeKinds(edges: readonly string[]): void {
   if (edges.length === 0) {
     throw new ConfigurationError(

--- a/packages/typegraph/src/store/algorithms/degree.ts
+++ b/packages/typegraph/src/store/algorithms/degree.ts
@@ -1,0 +1,61 @@
+/**
+ * Degree algorithm.
+ *
+ * Counts the number of active edges incident to a node. Direction selects
+ * whether we count outgoing, incoming, or both. For `"both"` we count
+ * distinct edge IDs so that a self-loop (from === to === node) contributes
+ * exactly once rather than twice.
+ */
+import { sql } from "drizzle-orm";
+
+import { compileKindFilter } from "../../query/compiler/predicate-utils";
+import { type AlgorithmContext } from "./context";
+import type { TraversalDirection } from "./types";
+
+type InternalDegreeOptions = Readonly<{
+  edges?: readonly string[];
+  direction?: TraversalDirection;
+}>;
+
+export async function executeDegree(
+  ctx: AlgorithmContext,
+  nodeId: string,
+  options: InternalDegreeOptions = {},
+): Promise<number> {
+  const direction = options.direction ?? "both";
+
+  // An empty `edges: []` array is treated literally as "no kinds" — the
+  // caller explicitly asked to count nothing. Omitting the option entirely
+  // (`edges === undefined`) counts across every kind.
+  const kindFilter =
+    options.edges === undefined ?
+      sql`1 = 1`
+    : compileKindFilter(sql.raw("kind"), options.edges);
+
+  const directionFilter = compileDirectionFilter(direction, nodeId);
+  const countExpr =
+    direction === "both" ? sql`COUNT(DISTINCT id)` : sql`COUNT(*)`;
+
+  const query = sql`SELECT ${countExpr} AS count FROM ${ctx.schema.edgesTable} WHERE graph_id = ${ctx.graphId} AND deleted_at IS NULL AND ${kindFilter} AND ${directionFilter}`;
+
+  const rows =
+    await ctx.backend.execute<Readonly<{ count: number | string }>>(query);
+  return Number(rows[0]?.count ?? 0);
+}
+
+function compileDirectionFilter(
+  direction: TraversalDirection,
+  nodeId: string,
+): ReturnType<typeof sql> {
+  switch (direction) {
+    case "out": {
+      return sql`from_id = ${nodeId}`;
+    }
+    case "in": {
+      return sql`to_id = ${nodeId}`;
+    }
+    case "both": {
+      return sql`(from_id = ${nodeId} OR to_id = ${nodeId})`;
+    }
+  }
+}

--- a/packages/typegraph/src/store/algorithms/degree.ts
+++ b/packages/typegraph/src/store/algorithms/degree.ts
@@ -1,21 +1,18 @@
-/**
- * Degree algorithm.
- *
- * Counts the number of active edges incident to a node. Direction selects
- * whether we count outgoing, incoming, or both. For `"both"` we count
- * distinct edge IDs so that a self-loop (from === to === node) contributes
- * exactly once rather than twice.
- */
-import { sql } from "drizzle-orm";
+import { type SQL, sql } from "drizzle-orm";
 
 import { compileKindFilter } from "../../query/compiler/predicate-utils";
-import { type AlgorithmContext } from "./context";
+import {
+  type AlgorithmContext,
+  type InternalTemporalOptions,
+  resolveTemporalFilter,
+} from "./context";
 import type { TraversalDirection } from "./types";
 
-type InternalDegreeOptions = Readonly<{
-  edges?: readonly string[];
-  direction?: TraversalDirection;
-}>;
+type InternalDegreeOptions = InternalTemporalOptions &
+  Readonly<{
+    edges?: readonly string[];
+    direction?: TraversalDirection;
+  }>;
 
 export async function executeDegree(
   ctx: AlgorithmContext,
@@ -24,19 +21,21 @@ export async function executeDegree(
 ): Promise<number> {
   const direction = options.direction ?? "both";
 
-  // An empty `edges: []` array is treated literally as "no kinds" — the
-  // caller explicitly asked to count nothing. Omitting the option entirely
-  // (`edges === undefined`) counts across every kind.
-  const kindFilter =
-    options.edges === undefined ?
-      sql`1 = 1`
-    : compileKindFilter(sql.raw("kind"), options.edges);
+  const whereClauses: SQL[] = [
+    sql`graph_id = ${ctx.graphId}`,
+    resolveTemporalFilter(ctx, options),
+    compileDirectionFilter(direction, nodeId),
+  ];
+  if (options.edges !== undefined) {
+    whereClauses.push(compileKindFilter(sql.raw("kind"), options.edges));
+  }
 
-  const directionFilter = compileDirectionFilter(direction, nodeId);
+  // COUNT(DISTINCT id) collapses self-loops (from === to === nodeId) to a
+  // single edge so they don't double-count under `"both"`.
   const countExpr =
     direction === "both" ? sql`COUNT(DISTINCT id)` : sql`COUNT(*)`;
 
-  const query = sql`SELECT ${countExpr} AS count FROM ${ctx.schema.edgesTable} WHERE graph_id = ${ctx.graphId} AND deleted_at IS NULL AND ${kindFilter} AND ${directionFilter}`;
+  const query = sql`SELECT ${countExpr} AS count FROM ${ctx.schema.edgesTable} WHERE ${sql.join(whereClauses, sql` AND `)}`;
 
   const rows =
     await ctx.backend.execute<Readonly<{ count: number | string }>>(query);

--- a/packages/typegraph/src/store/algorithms/index.ts
+++ b/packages/typegraph/src/store/algorithms/index.ts
@@ -1,19 +1,6 @@
-/**
- * Tier 1 graph algorithms exposed as `store.algorithms.*`.
- *
- * Covers the high-utility primitives that the recursive-CTE machinery makes
- * cheap to implement:
- * - {@link GraphAlgorithms.shortestPath | shortestPath} — fewest-hop path
- * - {@link GraphAlgorithms.reachable | reachable} — all reachable nodes
- * - {@link GraphAlgorithms.canReach | canReach} — boolean reachability
- * - {@link GraphAlgorithms.neighbors | neighbors} — k-hop neighborhood
- * - {@link GraphAlgorithms.degree | degree} — edge-count centrality
- *
- * Heavier algorithms (connected components, topological sort, centrality)
- * live in Tier 2/3 and should follow once concrete user demand appears.
- */
 import { type GraphBackend } from "../../backend/types";
 import { type GraphDef } from "../../core/define-graph";
+import { type TemporalMode } from "../../core/types";
 import { createSqlSchema, type SqlSchema } from "../../query/compiler/schema";
 import { getDialect } from "../../query/dialect";
 import { type AlgorithmContext } from "./context";
@@ -35,9 +22,17 @@ import type {
 } from "./types";
 
 /**
- * Accepts either a raw node id or any object with an `id: string` field,
- * which covers `Node`, `NodeRef`, and the lightweight `ReachableNode` /
- * `PathNode` shapes returned by the algorithms themselves.
+ * Raw node id or any object with an `id: string` field. Covers `Node`,
+ * `NodeRef`, and the lightweight `ReachableNode` / `PathNode` shapes
+ * returned by the algorithms themselves.
+ *
+ * Deliberately kind-agnostic: graph algorithms don't constrain the source
+ * node's kind — you can start a traversal from any node reachable via the
+ * given edge kinds. `NodeRef<N>` exists for the edge-endpoint case where
+ * kind *is* load-bearing; using it here would paint a constraint onto a
+ * contract that doesn't need one and would reject common patterns like
+ * passing `ReachableNode` / cache entries / `{ id }` records straight
+ * through.
  */
 export type NodeIdentifier = string | Readonly<{ id: string }>;
 
@@ -45,9 +40,6 @@ function resolveNodeId(value: NodeIdentifier): string {
   return typeof value === "string" ? value : value.id;
 }
 
-/**
- * Public surface for Tier 1 graph algorithms.
- */
 export type GraphAlgorithms<G extends GraphDef> = Readonly<{
   /**
    * Finds the shortest directed path from `from` to `to` using the given
@@ -107,15 +99,11 @@ export type GraphAlgorithms<G extends GraphDef> = Readonly<{
   degree: (node: NodeIdentifier, options?: DegreeOptions<G>) => Promise<number>;
 }>;
 
-/**
- * Parameters supplied by the Store to construct an algorithms facade.
- * Using a factory keeps the Store constructor simple and lets us reuse the
- * same context for every algorithm call.
- */
 export type CreateGraphAlgorithmsParams = Readonly<{
   graphId: string;
   backend: GraphBackend;
   schema: SqlSchema | undefined;
+  defaultTemporalMode: TemporalMode;
 }>;
 
 export function createGraphAlgorithms<G extends GraphDef>(
@@ -130,12 +118,9 @@ export function createGraphAlgorithms<G extends GraphDef>(
       (params.backend.tableNames ?
         createSqlSchema(params.backend.tableNames)
       : createSqlSchema()),
+    defaultTemporalMode: params.defaultTemporalMode,
   };
 
-  // Public option shapes match the internal shapes by field name and
-  // optionality, so they forward unchanged. The cast drops `EdgeKinds<G>`
-  // branding to plain `string[]` for the SQL layer — public types exist
-  // purely for compile-time safety.
   return {
     shortestPath(from, to, options) {
       return executeShortestPath(
@@ -175,5 +160,6 @@ export type {
   ReachableOptions,
   ShortestPathOptions,
   ShortestPathResult,
+  TemporalAlgorithmOptions,
   TraversalDirection,
 } from "./types";

--- a/packages/typegraph/src/store/algorithms/index.ts
+++ b/packages/typegraph/src/store/algorithms/index.ts
@@ -1,0 +1,179 @@
+/**
+ * Tier 1 graph algorithms exposed as `store.algorithms.*`.
+ *
+ * Covers the high-utility primitives that the recursive-CTE machinery makes
+ * cheap to implement:
+ * - {@link GraphAlgorithms.shortestPath | shortestPath} — fewest-hop path
+ * - {@link GraphAlgorithms.reachable | reachable} — all reachable nodes
+ * - {@link GraphAlgorithms.canReach | canReach} — boolean reachability
+ * - {@link GraphAlgorithms.neighbors | neighbors} — k-hop neighborhood
+ * - {@link GraphAlgorithms.degree | degree} — edge-count centrality
+ *
+ * Heavier algorithms (connected components, topological sort, centrality)
+ * live in Tier 2/3 and should follow once concrete user demand appears.
+ */
+import { type GraphBackend } from "../../backend/types";
+import { type GraphDef } from "../../core/define-graph";
+import { createSqlSchema, type SqlSchema } from "../../query/compiler/schema";
+import { getDialect } from "../../query/dialect";
+import { type AlgorithmContext } from "./context";
+import { executeDegree } from "./degree";
+import {
+  executeCanReach,
+  executeNeighbors,
+  executeReachable,
+} from "./reachable";
+import { executeShortestPath } from "./shortest-path";
+import type {
+  BaseTraversalOptions,
+  DegreeOptions,
+  NeighborsOptions,
+  ReachableNode,
+  ReachableOptions,
+  ShortestPathOptions,
+  ShortestPathResult,
+} from "./types";
+
+/**
+ * Accepts either a raw node id or any object with an `id: string` field,
+ * which covers `Node`, `NodeRef`, and the lightweight `ReachableNode` /
+ * `PathNode` shapes returned by the algorithms themselves.
+ */
+export type NodeIdentifier = string | Readonly<{ id: string }>;
+
+function resolveNodeId(value: NodeIdentifier): string {
+  return typeof value === "string" ? value : value.id;
+}
+
+/**
+ * Public surface for Tier 1 graph algorithms.
+ */
+export type GraphAlgorithms<G extends GraphDef> = Readonly<{
+  /**
+   * Finds the shortest directed path from `from` to `to` using the given
+   * edge kinds. Returns `undefined` when no path exists within `maxHops`.
+   *
+   * @example
+   * ```typescript
+   * const path = await store.algorithms.shortestPath(alice, bob, {
+   *   edges: ["knows"],
+   *   maxHops: 6,
+   * });
+   * if (path) {
+   *   console.log(`${path.depth} hops via`, path.nodes.map((n) => n.id));
+   * }
+   * ```
+   */
+  shortestPath: (
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: ShortestPathOptions<G>,
+  ) => Promise<ShortestPathResult | undefined>;
+
+  /**
+   * Returns every node reachable from `from` within `maxHops` edges of the
+   * allowed kinds. Each node carries its minimum discovered depth.
+   */
+  reachable: (
+    from: NodeIdentifier,
+    options: ReachableOptions<G>,
+  ) => Promise<readonly ReachableNode[]>;
+
+  /**
+   * Fast boolean check: is `to` reachable from `from` within `maxHops`
+   * edges? Short-circuits the underlying recursive CTE with `LIMIT 1`.
+   */
+  canReach: (
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: BaseTraversalOptions<G>,
+  ) => Promise<boolean>;
+
+  /**
+   * Returns the k-hop neighborhood of a node. The source is always
+   * excluded. `depth` defaults to 1, matching the common "immediate
+   * neighbors" interpretation.
+   */
+  neighbors: (
+    node: NodeIdentifier,
+    options: NeighborsOptions<G>,
+  ) => Promise<readonly ReachableNode[]>;
+
+  /**
+   * Counts active edges incident to `node`.
+   *
+   * With `direction: "both"` (default), self-loops contribute once.
+   */
+  degree: (node: NodeIdentifier, options?: DegreeOptions<G>) => Promise<number>;
+}>;
+
+/**
+ * Parameters supplied by the Store to construct an algorithms facade.
+ * Using a factory keeps the Store constructor simple and lets us reuse the
+ * same context for every algorithm call.
+ */
+export type CreateGraphAlgorithmsParams = Readonly<{
+  graphId: string;
+  backend: GraphBackend;
+  schema: SqlSchema | undefined;
+}>;
+
+export function createGraphAlgorithms<G extends GraphDef>(
+  params: CreateGraphAlgorithmsParams,
+): GraphAlgorithms<G> {
+  const ctx: AlgorithmContext = {
+    graphId: params.graphId,
+    backend: params.backend,
+    dialect: getDialect(params.backend.dialect),
+    schema:
+      params.schema ??
+      (params.backend.tableNames ?
+        createSqlSchema(params.backend.tableNames)
+      : createSqlSchema()),
+  };
+
+  // Public option shapes match the internal shapes by field name and
+  // optionality, so they forward unchanged. The cast drops `EdgeKinds<G>`
+  // branding to plain `string[]` for the SQL layer — public types exist
+  // purely for compile-time safety.
+  return {
+    shortestPath(from, to, options) {
+      return executeShortestPath(
+        ctx,
+        resolveNodeId(from),
+        resolveNodeId(to),
+        options,
+      );
+    },
+    reachable(from, options) {
+      return executeReachable(ctx, resolveNodeId(from), options);
+    },
+    canReach(from, to, options) {
+      return executeCanReach(
+        ctx,
+        resolveNodeId(from),
+        resolveNodeId(to),
+        options,
+      );
+    },
+    neighbors(node, options) {
+      return executeNeighbors(ctx, resolveNodeId(node), options);
+    },
+    degree(node, options) {
+      return executeDegree(ctx, resolveNodeId(node), options ?? {});
+    },
+  };
+}
+
+export type {
+  AlgorithmCyclePolicy,
+  BaseTraversalOptions,
+  DegreeOptions,
+  NeighborsOptions,
+  PathNode,
+  ReachableNode,
+  ReachableOptions,
+  ShortestPathOptions,
+  ShortestPathResult,
+  TraversalDirection,
+} from "./types";

--- a/packages/typegraph/src/store/algorithms/reachable.ts
+++ b/packages/typegraph/src/store/algorithms/reachable.ts
@@ -1,11 +1,6 @@
-/**
- * Reachability algorithms: `reachable`, `canReach`, and `neighbors`.
- *
- * All three share the same recursive-CTE skeleton; they differ only in how
- * they aggregate the resulting rows.
- */
 import { sql } from "drizzle-orm";
 
+import { buildReachableCte } from "../recursive-cte";
 import {
   type AlgorithmContext,
   assertEdgeKinds,
@@ -13,8 +8,8 @@ import {
   DEFAULT_NEIGHBOR_DEPTH,
   type InternalTraversalOptions,
   resolveMaxHops,
+  resolveTemporalOptions,
 } from "./context";
-import { buildReachableCte } from "./recursive-cte";
 import type { ReachableNode } from "./types";
 
 type InternalReachableOptions = InternalTraversalOptions &
@@ -29,11 +24,6 @@ type ReachableRow = Readonly<{
   depth: number | string;
 }>;
 
-/**
- * Returns every node reachable from `sourceId` within `maxHops` edges of the
- * allowed kinds. Each node carries the shortest depth at which it was
- * discovered.
- */
 export async function executeReachable(
   ctx: AlgorithmContext,
   sourceId: string,
@@ -54,6 +44,7 @@ export async function executeReachable(
     direction: options.direction ?? "out",
     cyclePolicy: options.cyclePolicy ?? "prevent",
     includePath: false,
+    ...resolveTemporalOptions(ctx, options),
     dialect: ctx.dialect,
     schema: ctx.schema,
   });
@@ -61,9 +52,6 @@ export async function executeReachable(
   const sourceFilter =
     options.excludeSource === true ? sql` WHERE id != ${sourceId}` : sql``;
 
-  // GROUP BY id + kind to keep the shortest depth per distinct node. The
-  // recursive CTE may reach the same node via multiple paths, so MIN(depth)
-  // is required for stable output regardless of cycle policy.
   const query = sql`${cte} SELECT id, kind, MIN(depth) AS depth FROM reachable${sourceFilter} GROUP BY id, kind ORDER BY depth ASC, id ASC`;
 
   const rows = await ctx.backend.execute<ReachableRow>(query);
@@ -74,11 +62,6 @@ export async function executeReachable(
   }));
 }
 
-/**
- * Returns `true` iff `targetId` is reachable from `sourceId` within
- * `maxHops` edges. Short-circuits the query with `LIMIT 1` so the database
- * can stop traversing as soon as the first hit is found.
- */
 export async function executeCanReach(
   ctx: AlgorithmContext,
   sourceId: string,
@@ -87,14 +70,16 @@ export async function executeCanReach(
 ): Promise<boolean> {
   assertEdgeKinds(options.edges);
 
-  if (sourceId === targetId) return true;
-
   const maxHops = resolveMaxHops(
     options.maxHops,
     DEFAULT_ALGORITHM_MAX_HOPS,
     "maxHops",
   );
 
+  // Self-case (sourceId === targetId) is not short-circuited: the CTE base
+  // case emits the source row only if it passes the temporal filter, so
+  // `canReach(a, a)` correctly returns false when `a` is not visible under
+  // the resolved mode — consistent with `shortestPath(a, a)`.
   const cte = buildReachableCte({
     graphId: ctx.graphId,
     sourceId,
@@ -103,6 +88,7 @@ export async function executeCanReach(
     direction: options.direction ?? "out",
     cyclePolicy: options.cyclePolicy ?? "prevent",
     includePath: false,
+    ...resolveTemporalOptions(ctx, options),
     dialect: ctx.dialect,
     schema: ctx.schema,
   });
@@ -113,16 +99,11 @@ export async function executeCanReach(
   return rows.length > 0;
 }
 
-/**
- * Returns every node within `depth` hops of `sourceId`, excluding the
- * source itself.
- */
 export async function executeNeighbors(
   ctx: AlgorithmContext,
   sourceId: string,
   options: InternalNeighborsOptions,
 ): Promise<readonly ReachableNode[]> {
-  assertEdgeKinds(options.edges);
   const depth = resolveMaxHops(options.depth, DEFAULT_NEIGHBOR_DEPTH, "depth");
 
   return executeReachable(ctx, sourceId, {
@@ -130,6 +111,10 @@ export async function executeNeighbors(
     maxHops: depth,
     direction: options.direction ?? "out",
     cyclePolicy: options.cyclePolicy ?? "prevent",
+    ...(options.temporalMode !== undefined && {
+      temporalMode: options.temporalMode,
+    }),
+    ...(options.asOf !== undefined && { asOf: options.asOf }),
     excludeSource: true,
   });
 }

--- a/packages/typegraph/src/store/algorithms/reachable.ts
+++ b/packages/typegraph/src/store/algorithms/reachable.ts
@@ -1,0 +1,135 @@
+/**
+ * Reachability algorithms: `reachable`, `canReach`, and `neighbors`.
+ *
+ * All three share the same recursive-CTE skeleton; they differ only in how
+ * they aggregate the resulting rows.
+ */
+import { sql } from "drizzle-orm";
+
+import {
+  type AlgorithmContext,
+  assertEdgeKinds,
+  DEFAULT_ALGORITHM_MAX_HOPS,
+  DEFAULT_NEIGHBOR_DEPTH,
+  type InternalTraversalOptions,
+  resolveMaxHops,
+} from "./context";
+import { buildReachableCte } from "./recursive-cte";
+import type { ReachableNode } from "./types";
+
+type InternalReachableOptions = InternalTraversalOptions &
+  Readonly<{ excludeSource?: boolean }>;
+
+type InternalNeighborsOptions = Omit<InternalTraversalOptions, "maxHops"> &
+  Readonly<{ depth?: number }>;
+
+type ReachableRow = Readonly<{
+  id: string;
+  kind: string;
+  depth: number | string;
+}>;
+
+/**
+ * Returns every node reachable from `sourceId` within `maxHops` edges of the
+ * allowed kinds. Each node carries the shortest depth at which it was
+ * discovered.
+ */
+export async function executeReachable(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  options: InternalReachableOptions,
+): Promise<readonly ReachableNode[]> {
+  assertEdgeKinds(options.edges);
+  const maxHops = resolveMaxHops(
+    options.maxHops,
+    DEFAULT_ALGORITHM_MAX_HOPS,
+    "maxHops",
+  );
+
+  const cte = buildReachableCte({
+    graphId: ctx.graphId,
+    sourceId,
+    edgeKinds: options.edges,
+    maxHops,
+    direction: options.direction ?? "out",
+    cyclePolicy: options.cyclePolicy ?? "prevent",
+    includePath: false,
+    dialect: ctx.dialect,
+    schema: ctx.schema,
+  });
+
+  const sourceFilter =
+    options.excludeSource === true ? sql` WHERE id != ${sourceId}` : sql``;
+
+  // GROUP BY id + kind to keep the shortest depth per distinct node. The
+  // recursive CTE may reach the same node via multiple paths, so MIN(depth)
+  // is required for stable output regardless of cycle policy.
+  const query = sql`${cte} SELECT id, kind, MIN(depth) AS depth FROM reachable${sourceFilter} GROUP BY id, kind ORDER BY depth ASC, id ASC`;
+
+  const rows = await ctx.backend.execute<ReachableRow>(query);
+  return rows.map((row) => ({
+    id: row.id,
+    kind: row.kind,
+    depth: Number(row.depth),
+  }));
+}
+
+/**
+ * Returns `true` iff `targetId` is reachable from `sourceId` within
+ * `maxHops` edges. Short-circuits the query with `LIMIT 1` so the database
+ * can stop traversing as soon as the first hit is found.
+ */
+export async function executeCanReach(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  options: InternalTraversalOptions,
+): Promise<boolean> {
+  assertEdgeKinds(options.edges);
+
+  if (sourceId === targetId) return true;
+
+  const maxHops = resolveMaxHops(
+    options.maxHops,
+    DEFAULT_ALGORITHM_MAX_HOPS,
+    "maxHops",
+  );
+
+  const cte = buildReachableCte({
+    graphId: ctx.graphId,
+    sourceId,
+    edgeKinds: options.edges,
+    maxHops,
+    direction: options.direction ?? "out",
+    cyclePolicy: options.cyclePolicy ?? "prevent",
+    includePath: false,
+    dialect: ctx.dialect,
+    schema: ctx.schema,
+  });
+
+  const query = sql`${cte} SELECT 1 AS hit FROM reachable WHERE id = ${targetId} LIMIT 1`;
+
+  const rows = await ctx.backend.execute<Readonly<{ hit: number }>>(query);
+  return rows.length > 0;
+}
+
+/**
+ * Returns every node within `depth` hops of `sourceId`, excluding the
+ * source itself.
+ */
+export async function executeNeighbors(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  options: InternalNeighborsOptions,
+): Promise<readonly ReachableNode[]> {
+  assertEdgeKinds(options.edges);
+  const depth = resolveMaxHops(options.depth, DEFAULT_NEIGHBOR_DEPTH, "depth");
+
+  return executeReachable(ctx, sourceId, {
+    edges: options.edges,
+    maxHops: depth,
+    direction: options.direction ?? "out",
+    cyclePolicy: options.cyclePolicy ?? "prevent",
+    excludeSource: true,
+  });
+}

--- a/packages/typegraph/src/store/algorithms/recursive-cte.ts
+++ b/packages/typegraph/src/store/algorithms/recursive-cte.ts
@@ -1,0 +1,213 @@
+/**
+ * Shared recursive-CTE builder used by `reachable`, `shortestPath`,
+ * `neighbors`, and `canReach`.
+ *
+ * Produces a `reachable(id, kind, depth [, path])` CTE whose rows are every
+ * node discovered from `sourceId` in at most `maxHops` hops, following the
+ * configured edge kinds in the requested direction. Cycle prevention is
+ * delegated to the dialect's existing path-tracking primitives so the
+ * algorithms reuse the same semantics as subgraph extraction and the
+ * recursive query builder.
+ */
+import { type SQL, sql } from "drizzle-orm";
+
+import { compileKindFilter } from "../../query/compiler/predicate-utils";
+import { type SqlSchema } from "../../query/compiler/schema";
+import { type DialectAdapter } from "../../query/dialect/types";
+import { type AlgorithmCyclePolicy, type TraversalDirection } from "./types";
+
+export type BuildReachableCteOptions = Readonly<{
+  graphId: string;
+  sourceId: string;
+  edgeKinds: readonly string[];
+  maxHops: number;
+  direction: TraversalDirection;
+  cyclePolicy: AlgorithmCyclePolicy;
+  /**
+   * When `true`, the CTE selects a dialect-specific `path` column used for
+   * later decoding into an ordered list of node IDs.
+   */
+  includePath: boolean;
+  dialect: DialectAdapter;
+  schema: SqlSchema;
+}>;
+
+/**
+ * Compiles a `WITH RECURSIVE reachable(...) AS (...)` CTE.
+ *
+ * The caller concatenates this SQL fragment with a subsequent SELECT from
+ * the `reachable` CTE to project whatever columns they need.
+ */
+export function buildReachableCte(options: BuildReachableCteOptions): SQL {
+  const trackPath = options.cyclePolicy === "prevent" || options.includePath;
+  const edgeKindFilter = compileKindFilter(
+    sql.raw("e.kind"),
+    options.edgeKinds,
+  );
+
+  const initialPath =
+    trackPath ? options.dialect.initializePath(sql.raw("n.id")) : undefined;
+  const pathExtension =
+    trackPath ?
+      options.dialect.extendPath(sql.raw("r.path"), sql.raw("n.id"))
+    : undefined;
+  const cycleCheck =
+    options.cyclePolicy === "prevent" ?
+      options.dialect.cycleCheck(sql.raw("n.id"), sql.raw("r.path"))
+    : undefined;
+
+  const baseColumns: SQL[] = [sql`n.id`, sql`n.kind`, sql`0 AS depth`];
+  if (initialPath !== undefined) {
+    baseColumns.push(sql`${initialPath} AS path`);
+  }
+
+  const baseCase = sql`SELECT ${sql.join(baseColumns, sql`, `)} FROM ${options.schema.nodesTable} n WHERE n.graph_id = ${options.graphId} AND n.id = ${options.sourceId} AND n.deleted_at IS NULL`;
+
+  const recursiveColumns: SQL[] = [
+    sql`n.id`,
+    sql`n.kind`,
+    sql`r.depth + 1 AS depth`,
+  ];
+  if (pathExtension !== undefined) {
+    recursiveColumns.push(sql`${pathExtension} AS path`);
+  }
+
+  const recursiveWhere: SQL[] = [
+    sql`e.graph_id = ${options.graphId}`,
+    edgeKindFilter,
+    sql`e.deleted_at IS NULL`,
+    sql`n.deleted_at IS NULL`,
+    sql`r.depth < ${options.maxHops}`,
+  ];
+  if (cycleCheck !== undefined) recursiveWhere.push(cycleCheck);
+
+  const forceWorktableOuterJoinOrder =
+    options.dialect.capabilities.forceRecursiveWorktableOuterJoinOrder;
+
+  const recursiveCase = compileRecursiveBranch({
+    recursiveColumns,
+    whereClauses: recursiveWhere,
+    direction: options.direction,
+    forceWorktableOuterJoinOrder,
+    schema: options.schema,
+  });
+
+  return sql`WITH RECURSIVE reachable AS (${baseCase} UNION ALL ${recursiveCase})`;
+}
+
+type CompileRecursiveBranchOptions = Readonly<{
+  recursiveColumns: readonly SQL[];
+  whereClauses: readonly SQL[];
+  direction: TraversalDirection;
+  forceWorktableOuterJoinOrder: boolean;
+  schema: SqlSchema;
+}>;
+
+function compileRecursiveBranch(options: CompileRecursiveBranchOptions): SQL {
+  const selectClause = sql`SELECT ${sql.join([...options.recursiveColumns], sql`, `)}`;
+
+  switch (options.direction) {
+    case "out": {
+      return buildDirectionalBranch({
+        selectClause,
+        whereClauses: options.whereClauses,
+        joinField: "from_id",
+        targetField: "to_id",
+        targetKindField: "to_kind",
+        forceWorktableOuterJoinOrder: options.forceWorktableOuterJoinOrder,
+        schema: options.schema,
+      });
+    }
+    case "in": {
+      return buildDirectionalBranch({
+        selectClause,
+        whereClauses: options.whereClauses,
+        joinField: "to_id",
+        targetField: "from_id",
+        targetKindField: "from_kind",
+        forceWorktableOuterJoinOrder: options.forceWorktableOuterJoinOrder,
+        schema: options.schema,
+      });
+    }
+    case "both": {
+      return buildBidirectionalBranch({
+        selectClause,
+        whereClauses: options.whereClauses,
+        forceWorktableOuterJoinOrder: options.forceWorktableOuterJoinOrder,
+        schema: options.schema,
+      });
+    }
+  }
+}
+
+type DirectionalBranchOptions = Readonly<{
+  selectClause: SQL;
+  whereClauses: readonly SQL[];
+  joinField: "from_id" | "to_id";
+  targetField: "from_id" | "to_id";
+  targetKindField: "from_kind" | "to_kind";
+  forceWorktableOuterJoinOrder: boolean;
+  schema: SqlSchema;
+}>;
+
+function buildDirectionalBranch(options: DirectionalBranchOptions): SQL {
+  const nodeJoin = sql`JOIN ${options.schema.nodesTable} n ON n.graph_id = e.graph_id AND n.id = e.${sql.raw(options.targetField)} AND n.kind = e.${sql.raw(options.targetKindField)}`;
+
+  if (options.forceWorktableOuterJoinOrder) {
+    const allWhere = [
+      ...options.whereClauses,
+      sql`e.${sql.raw(options.joinField)} = r.id`,
+    ];
+    return sql`${options.selectClause} FROM reachable r CROSS JOIN ${options.schema.edgesTable} e ${nodeJoin} WHERE ${sql.join(allWhere, sql` AND `)}`;
+  }
+
+  return sql`${options.selectClause} FROM reachable r JOIN ${options.schema.edgesTable} e ON e.${sql.raw(options.joinField)} = r.id ${nodeJoin} WHERE ${sql.join([...options.whereClauses], sql` AND `)}`;
+}
+
+type BidirectionalBranchOptions = Readonly<{
+  selectClause: SQL;
+  whereClauses: readonly SQL[];
+  forceWorktableOuterJoinOrder: boolean;
+  schema: SqlSchema;
+}>;
+
+function buildBidirectionalBranch(options: BidirectionalBranchOptions): SQL {
+  // Match the node via either direction of the edge in a single UNION ALL
+  // branch, mirroring the approach used by subgraph extraction so PostgreSQL
+  // accepts the recursive CTE (it rejects multiple non-recursive terms).
+  const nodeJoin = sql`JOIN ${options.schema.nodesTable} n ON n.graph_id = e.graph_id AND ((e.to_id = r.id AND n.id = e.from_id AND n.kind = e.from_kind) OR (e.from_id = r.id AND n.id = e.to_id AND n.kind = e.to_kind))`;
+
+  if (options.forceWorktableOuterJoinOrder) {
+    const allWhere = [
+      ...options.whereClauses,
+      sql`(e.from_id = r.id OR e.to_id = r.id)`,
+    ];
+    return sql`${options.selectClause} FROM reachable r CROSS JOIN ${options.schema.edgesTable} e ${nodeJoin} WHERE ${sql.join(allWhere, sql` AND `)}`;
+  }
+
+  return sql`${options.selectClause} FROM reachable r JOIN ${options.schema.edgesTable} e ON (e.from_id = r.id OR e.to_id = r.id) ${nodeJoin} WHERE ${sql.join([...options.whereClauses], sql` AND `)}`;
+}
+
+/**
+ * Decodes a dialect-specific `path` column value into an ordered list of
+ * node IDs.
+ *
+ * PostgreSQL returns `text[]` arrays (already JavaScript arrays); SQLite
+ * returns a `'|id1|id2|...|id_n|'` delimited string. Empty or unknown values
+ * fall back to an empty list.
+ */
+export function decodePathColumn(value: unknown): readonly string[] {
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  if (typeof value === "string") {
+    if (value.length === 0) return [];
+    const trimmed = value.startsWith("|") ? value.slice(1) : value;
+    const withoutTail = trimmed.endsWith("|") ? trimmed.slice(0, -1) : trimmed;
+    if (withoutTail.length === 0) return [];
+    return withoutTail.split("|");
+  }
+
+  return [];
+}

--- a/packages/typegraph/src/store/algorithms/shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/shortest-path.ts
@@ -1,0 +1,109 @@
+/**
+ * Shortest-path algorithm.
+ *
+ * Runs the shared recursive CTE with path tracking, filters the frontier to
+ * the target row with the smallest depth, and decodes the dialect-encoded
+ * path column into an ordered list of node IDs. Node kinds for every hop
+ * are produced by the same CTE, so the full path is hydrated in a single
+ * round-trip by joining the hit row against the `reachable` CTE using the
+ * dialect's path-containment predicate.
+ */
+import { type SQL, sql } from "drizzle-orm";
+
+import {
+  type AlgorithmContext,
+  assertEdgeKinds,
+  DEFAULT_ALGORITHM_MAX_HOPS,
+  type InternalTraversalOptions,
+  resolveMaxHops,
+} from "./context";
+import { buildReachableCte, decodePathColumn } from "./recursive-cte";
+import type { PathNode, ShortestPathResult } from "./types";
+
+type ShortestPathRow = Readonly<{
+  hit_id: string;
+  hit_kind: string;
+  hit_depth: number | string;
+  hit_path: unknown;
+  node_id: string | undefined;
+  node_kind: string | undefined;
+}>;
+
+type NodeKindRow = Readonly<{ id: string; kind: string }>;
+
+export async function executeShortestPath(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  options: InternalTraversalOptions,
+): Promise<ShortestPathResult | undefined> {
+  assertEdgeKinds(options.edges);
+  const maxHops = resolveMaxHops(
+    options.maxHops,
+    DEFAULT_ALGORITHM_MAX_HOPS,
+    "maxHops",
+  );
+
+  // Self-path short-circuit: avoids the recursive CTE entirely while still
+  // honouring soft-delete semantics via a lightweight existence check.
+  if (sourceId === targetId) {
+    const source = await fetchNodeKind(ctx, sourceId);
+    if (source === undefined) return undefined;
+    return { nodes: [source], depth: 0 };
+  }
+
+  const cte = buildReachableCte({
+    graphId: ctx.graphId,
+    sourceId,
+    edgeKinds: options.edges,
+    maxHops,
+    direction: options.direction ?? "out",
+    cyclePolicy: options.cyclePolicy ?? "prevent",
+    includePath: true,
+    dialect: ctx.dialect,
+    schema: ctx.schema,
+  });
+
+  // `cycleCheck` returns TRUE when id is NOT in path, so its negation is the
+  // "id is in path" predicate we need to join every hop's kind in one query.
+  const pathContainsCheck = sql`NOT (${ctx.dialect.cycleCheck(sql.raw("r.id"), sql.raw("h.path"))})`;
+
+  const query = sql`${cte}, hit AS (SELECT id, kind, depth, path FROM reachable WHERE id = ${targetId} ORDER BY depth ASC LIMIT 1) SELECT h.id AS hit_id, h.kind AS hit_kind, h.depth AS hit_depth, h.path AS hit_path, r.id AS node_id, r.kind AS node_kind FROM hit h LEFT JOIN reachable r ON ${pathContainsCheck}`;
+
+  const rows = await ctx.backend.execute<ShortestPathRow>(query);
+  const first = rows[0];
+  if (first === undefined) return undefined;
+
+  const pathIds = decodePathColumn(first.hit_path);
+  const kindById = buildKindIndex(rows);
+
+  const pathNodes: PathNode[] = pathIds.map((id) => ({
+    id,
+    kind: kindById.get(id) ?? "",
+  }));
+
+  return { nodes: pathNodes, depth: Number(first.hit_depth) };
+}
+
+function buildKindIndex(
+  rows: readonly ShortestPathRow[],
+): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    if (row.node_id !== undefined && row.node_kind !== undefined) {
+      map.set(row.node_id, row.node_kind);
+    }
+  }
+  return map;
+}
+
+async function fetchNodeKind(
+  ctx: AlgorithmContext,
+  nodeId: string,
+): Promise<PathNode | undefined> {
+  const query: SQL = sql`SELECT id, kind FROM ${ctx.schema.nodesTable} WHERE graph_id = ${ctx.graphId} AND id = ${nodeId} AND deleted_at IS NULL LIMIT 1`;
+  const rows = await ctx.backend.execute<NodeKindRow>(query);
+  const row = rows[0];
+  if (row === undefined) return undefined;
+  return { id: row.id, kind: row.kind };
+}

--- a/packages/typegraph/src/store/algorithms/shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/shortest-path.ts
@@ -1,23 +1,16 @@
-/**
- * Shortest-path algorithm.
- *
- * Runs the shared recursive CTE with path tracking, filters the frontier to
- * the target row with the smallest depth, and decodes the dialect-encoded
- * path column into an ordered list of node IDs. Node kinds for every hop
- * are produced by the same CTE, so the full path is hydrated in a single
- * round-trip by joining the hit row against the `reachable` CTE using the
- * dialect's path-containment predicate.
- */
 import { type SQL, sql } from "drizzle-orm";
 
+import { normalizePath } from "../../utils";
+import { buildReachableCte } from "../recursive-cte";
 import {
   type AlgorithmContext,
   assertEdgeKinds,
   DEFAULT_ALGORITHM_MAX_HOPS,
   type InternalTraversalOptions,
   resolveMaxHops,
+  resolveTemporalFilter,
+  resolveTemporalOptions,
 } from "./context";
-import { buildReachableCte, decodePathColumn } from "./recursive-cte";
 import type { PathNode, ShortestPathResult } from "./types";
 
 type ShortestPathRow = Readonly<{
@@ -45,9 +38,9 @@ export async function executeShortestPath(
   );
 
   // Self-path short-circuit: avoids the recursive CTE entirely while still
-  // honouring soft-delete semantics via a lightweight existence check.
+  // honouring the configured temporal mode via a lightweight existence check.
   if (sourceId === targetId) {
-    const source = await fetchNodeKind(ctx, sourceId);
+    const source = await fetchNodeKind(ctx, sourceId, options);
     if (source === undefined) return undefined;
     return { nodes: [source], depth: 0 };
   }
@@ -60,12 +53,21 @@ export async function executeShortestPath(
     direction: options.direction ?? "out",
     cyclePolicy: options.cyclePolicy ?? "prevent",
     includePath: true,
+    ...resolveTemporalOptions(ctx, options),
     dialect: ctx.dialect,
     schema: ctx.schema,
   });
 
-  // `cycleCheck` returns TRUE when id is NOT in path, so its negation is the
-  // "id is in path" predicate we need to join every hop's kind in one query.
+  // `cycleCheck` returns TRUE when id is NOT in path; negating it yields the
+  // "id is in path" predicate needed to hydrate every hop's kind in one query.
+  //
+  // Cost model: the LEFT JOIN scans `reachable` with an O(path length) check
+  // per row. Under cyclePolicy: "prevent" (default), |reachable| ≤ V, so this
+  // is bounded by V × p. Under "allow" + high maxHops, |reachable| grows with
+  // the CTE itself (O(V × maxHops)) — but that cost is proportional to the
+  // CTE materialization the user already opted into, not a new asymptotic
+  // class. If this ever dominates in a real workload, the path-unpack +
+  // nodes-PK join variant is the likely next step.
   const pathContainsCheck = sql`NOT (${ctx.dialect.cycleCheck(sql.raw("r.id"), sql.raw("h.path"))})`;
 
   const query = sql`${cte}, hit AS (SELECT id, kind, depth, path FROM reachable WHERE id = ${targetId} ORDER BY depth ASC LIMIT 1) SELECT h.id AS hit_id, h.kind AS hit_kind, h.depth AS hit_depth, h.path AS hit_path, r.id AS node_id, r.kind AS node_kind FROM hit h LEFT JOIN reachable r ON ${pathContainsCheck}`;
@@ -74,7 +76,7 @@ export async function executeShortestPath(
   const first = rows[0];
   if (first === undefined) return undefined;
 
-  const pathIds = decodePathColumn(first.hit_path);
+  const pathIds = normalizePath(first.hit_path);
   const kindById = buildKindIndex(rows);
 
   const pathNodes: PathNode[] = pathIds.map((id) => ({
@@ -100,8 +102,10 @@ function buildKindIndex(
 async function fetchNodeKind(
   ctx: AlgorithmContext,
   nodeId: string,
+  options: InternalTraversalOptions,
 ): Promise<PathNode | undefined> {
-  const query: SQL = sql`SELECT id, kind FROM ${ctx.schema.nodesTable} WHERE graph_id = ${ctx.graphId} AND id = ${nodeId} AND deleted_at IS NULL LIMIT 1`;
+  const temporalFilter = resolveTemporalFilter(ctx, options);
+  const query: SQL = sql`SELECT id, kind FROM ${ctx.schema.nodesTable} WHERE graph_id = ${ctx.graphId} AND id = ${nodeId} AND ${temporalFilter} LIMIT 1`;
   const rows = await ctx.backend.execute<NodeKindRow>(query);
   const row = rows[0];
   if (row === undefined) return undefined;

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared types for Tier 1 graph algorithms.
+ *
+ * Algorithms operate over one or more edge kinds and may traverse edges
+ * in the forward direction ("out"), reverse ("in"), or undirected ("both").
+ */
+import type { EdgeKinds, GraphDef } from "../../core/define-graph";
+
+/**
+ * Direction of edge traversal.
+ *
+ * - `"out"` — follow edges from source to target (default)
+ * - `"in"` — follow edges from target back to source
+ * - `"both"` — undirected traversal over either endpoint
+ */
+export type TraversalDirection = "out" | "in" | "both";
+
+/**
+ * Cycle-handling strategy during recursive traversal.
+ *
+ * - `"prevent"` — skip any node already on the current path (default).
+ *   Guarantees termination even in cyclic graphs.
+ * - `"allow"` — permit revisiting nodes. Only safe with a bounded `maxHops`.
+ */
+export type AlgorithmCyclePolicy = "prevent" | "allow";
+
+/**
+ * Base options for traversal-style algorithms.
+ */
+export type BaseTraversalOptions<G extends GraphDef> = Readonly<{
+  /** Edge kinds to follow. At least one kind is required. */
+  edges: readonly EdgeKinds<G>[];
+  /**
+   * Maximum number of hops to traverse. Defaults to 10.
+   * Must be between 1 and 1000.
+   */
+  maxHops?: number;
+  /** Direction of traversal (default: `"out"`). */
+  direction?: TraversalDirection;
+  /** Cycle policy (default: `"prevent"`). */
+  cyclePolicy?: AlgorithmCyclePolicy;
+}>;
+
+/**
+ * A node reached during traversal, annotated with the shortest depth at which
+ * it was first discovered.
+ */
+export type ReachableNode = Readonly<{
+  id: string;
+  kind: string;
+  /** Number of edges traversed from the source. 0 for the source itself. */
+  depth: number;
+}>;
+
+/**
+ * A node along a shortest path. Endpoints are included.
+ */
+export type PathNode = Readonly<{
+  id: string;
+  kind: string;
+}>;
+
+/**
+ * Result of `shortestPath`: the ordered node sequence and its length in hops.
+ */
+export type ShortestPathResult = Readonly<{
+  /** Ordered nodes from source to target (inclusive). */
+  nodes: readonly PathNode[];
+  /** Number of edges traversed. Equals `nodes.length - 1`. */
+  depth: number;
+}>;
+
+/**
+ * Options for `shortestPath` and `canReach`. Reuses the base traversal
+ * options; cycle policy defaults to `"prevent"` since both algorithms only
+ * care about the first time a target is reached.
+ */
+export type ShortestPathOptions<G extends GraphDef> = BaseTraversalOptions<G>;
+
+/**
+ * Options for `reachable`.
+ *
+ * Returns every node reachable from the source within `maxHops`, each
+ * annotated with its minimum discovered depth. `depth: 0` refers to the
+ * source itself and is included unless `excludeSource` is `true`.
+ */
+export type ReachableOptions<G extends GraphDef> = BaseTraversalOptions<G> &
+  Readonly<{
+    /** Exclude the source node from the result set (default: `false`). */
+    excludeSource?: boolean;
+  }>;
+
+/**
+ * Options for `neighbors`.
+ *
+ * Like `reachable`, but the parameter is named `depth` for readability —
+ * "2-hop neighbors" reads more naturally than "reachable with maxHops=2".
+ * The source is always excluded.
+ */
+export type NeighborsOptions<G extends GraphDef> = Readonly<{
+  /** Edge kinds to follow. At least one kind is required. */
+  edges: readonly EdgeKinds<G>[];
+  /** Maximum neighborhood depth (default: 1). Must be between 1 and 1000. */
+  depth?: number;
+  /** Direction of traversal (default: `"out"`). */
+  direction?: TraversalDirection;
+  /** Cycle policy (default: `"prevent"`). */
+  cyclePolicy?: AlgorithmCyclePolicy;
+}>;
+
+/**
+ * Options for `degree`.
+ *
+ * Counts active edges incident to a node. With `direction: "both"`, an edge
+ * that happens to be a self-loop (from === to) is counted once, not twice.
+ */
+export type DegreeOptions<G extends GraphDef> = Readonly<{
+  /**
+   * Edge kinds to count. If omitted, counts across all edge kinds in the
+   * graph.
+   */
+  edges?: readonly EdgeKinds<G>[];
+  /** Direction (default: `"both"`). */
+  direction?: TraversalDirection;
+}>;

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -5,6 +5,8 @@
  * in the forward direction ("out"), reverse ("in"), or undirected ("both").
  */
 import type { EdgeKinds, GraphDef } from "../../core/define-graph";
+import type { TemporalMode } from "../../core/types";
+import type { RecursiveCyclePolicy } from "../../query/ast";
 
 /**
  * Direction of edge traversal.
@@ -21,25 +23,48 @@ export type TraversalDirection = "out" | "in" | "both";
  * - `"prevent"` — skip any node already on the current path (default).
  *   Guarantees termination even in cyclic graphs.
  * - `"allow"` — permit revisiting nodes. Only safe with a bounded `maxHops`.
+ *
+ * Aliased to `RecursiveCyclePolicy` so algorithms and query-builder traversals
+ * share a single canonical union.
  */
-export type AlgorithmCyclePolicy = "prevent" | "allow";
+export type AlgorithmCyclePolicy = RecursiveCyclePolicy;
+
+/**
+ * Temporal filter options shared by every algorithm.
+ *
+ * Algorithms honor the same temporal model as the rest of the store: both
+ * nodes and edges are filtered according to the resolved mode. `asOf` is
+ * only consulted when the resolved mode is `"asOf"`. If neither option is
+ * supplied, the algorithm falls back to `graph.defaults.temporalMode`.
+ */
+export type TemporalAlgorithmOptions = Readonly<{
+  /** Temporal mode. Defaults to the graph's configured default. */
+  temporalMode?: TemporalMode;
+  /**
+   * ISO-8601 timestamp used when `temporalMode` is `"asOf"`. Required in that
+   * mode; ignored in all others.
+   */
+  asOf?: string;
+}>;
 
 /**
  * Base options for traversal-style algorithms.
  */
-export type BaseTraversalOptions<G extends GraphDef> = Readonly<{
-  /** Edge kinds to follow. At least one kind is required. */
-  edges: readonly EdgeKinds<G>[];
-  /**
-   * Maximum number of hops to traverse. Defaults to 10.
-   * Must be between 1 and 1000.
-   */
-  maxHops?: number;
-  /** Direction of traversal (default: `"out"`). */
-  direction?: TraversalDirection;
-  /** Cycle policy (default: `"prevent"`). */
-  cyclePolicy?: AlgorithmCyclePolicy;
-}>;
+export type BaseTraversalOptions<G extends GraphDef> =
+  TemporalAlgorithmOptions &
+    Readonly<{
+      /** Edge kinds to follow. At least one kind is required. */
+      edges: readonly EdgeKinds<G>[];
+      /**
+       * Maximum number of hops to traverse. Defaults to 10.
+       * Must be between 1 and 1000.
+       */
+      maxHops?: number;
+      /** Direction of traversal (default: `"out"`). */
+      direction?: TraversalDirection;
+      /** Cycle policy (default: `"prevent"`). */
+      cyclePolicy?: AlgorithmCyclePolicy;
+    }>;
 
 /**
  * A node reached during traversal, annotated with the shortest depth at which
@@ -97,16 +122,17 @@ export type ReachableOptions<G extends GraphDef> = BaseTraversalOptions<G> &
  * "2-hop neighbors" reads more naturally than "reachable with maxHops=2".
  * The source is always excluded.
  */
-export type NeighborsOptions<G extends GraphDef> = Readonly<{
-  /** Edge kinds to follow. At least one kind is required. */
-  edges: readonly EdgeKinds<G>[];
-  /** Maximum neighborhood depth (default: 1). Must be between 1 and 1000. */
-  depth?: number;
-  /** Direction of traversal (default: `"out"`). */
-  direction?: TraversalDirection;
-  /** Cycle policy (default: `"prevent"`). */
-  cyclePolicy?: AlgorithmCyclePolicy;
-}>;
+export type NeighborsOptions<G extends GraphDef> = TemporalAlgorithmOptions &
+  Readonly<{
+    /** Edge kinds to follow. At least one kind is required. */
+    edges: readonly EdgeKinds<G>[];
+    /** Maximum neighborhood depth (default: 1). Must be between 1 and 1000. */
+    depth?: number;
+    /** Direction of traversal (default: `"out"`). */
+    direction?: TraversalDirection;
+    /** Cycle policy (default: `"prevent"`). */
+    cyclePolicy?: AlgorithmCyclePolicy;
+  }>;
 
 /**
  * Options for `degree`.
@@ -114,12 +140,13 @@ export type NeighborsOptions<G extends GraphDef> = Readonly<{
  * Counts active edges incident to a node. With `direction: "both"`, an edge
  * that happens to be a self-loop (from === to) is counted once, not twice.
  */
-export type DegreeOptions<G extends GraphDef> = Readonly<{
-  /**
-   * Edge kinds to count. If omitted, counts across all edge kinds in the
-   * graph.
-   */
-  edges?: readonly EdgeKinds<G>[];
-  /** Direction (default: `"both"`). */
-  direction?: TraversalDirection;
-}>;
+export type DegreeOptions<G extends GraphDef> = TemporalAlgorithmOptions &
+  Readonly<{
+    /**
+     * Edge kinds to count. If omitted, counts across all edge kinds in the
+     * graph.
+     */
+    edges?: readonly EdgeKinds<G>[];
+    /** Direction (default: `"both"`). */
+    direction?: TraversalDirection;
+  }>;

--- a/packages/typegraph/src/store/recursive-cte.ts
+++ b/packages/typegraph/src/store/recursive-cte.ts
@@ -1,49 +1,49 @@
-/**
- * Shared recursive-CTE builder used by `reachable`, `shortestPath`,
- * `neighbors`, and `canReach`.
- *
- * Produces a `reachable(id, kind, depth [, path])` CTE whose rows are every
- * node discovered from `sourceId` in at most `maxHops` hops, following the
- * configured edge kinds in the requested direction. Cycle prevention is
- * delegated to the dialect's existing path-tracking primitives so the
- * algorithms reuse the same semantics as subgraph extraction and the
- * recursive query builder.
- */
 import { type SQL, sql } from "drizzle-orm";
 
-import { compileKindFilter } from "../../query/compiler/predicate-utils";
-import { type SqlSchema } from "../../query/compiler/schema";
-import { type DialectAdapter } from "../../query/dialect/types";
-import { type AlgorithmCyclePolicy, type TraversalDirection } from "./types";
+import { type TemporalMode } from "../core/types";
+import { type RecursiveCyclePolicy } from "../query/ast";
+import { compileKindFilter } from "../query/compiler/predicate-utils";
+import { type SqlSchema } from "../query/compiler/schema";
+import { compileTemporalFilter } from "../query/compiler/temporal";
+import { type DialectAdapter } from "../query/dialect/types";
+import { type TraversalDirection } from "./algorithms/types";
 
-export type BuildReachableCteOptions = Readonly<{
+type BuildReachableCteOptions = Readonly<{
   graphId: string;
   sourceId: string;
   edgeKinds: readonly string[];
   maxHops: number;
   direction: TraversalDirection;
-  cyclePolicy: AlgorithmCyclePolicy;
-  /**
-   * When `true`, the CTE selects a dialect-specific `path` column used for
-   * later decoding into an ordered list of node IDs.
-   */
+  cyclePolicy: RecursiveCyclePolicy;
   includePath: boolean;
+  /**
+   * Temporal mode applied to both nodes and edges along the traversal.
+   * Callers that want the pre-temporal behavior (soft-delete only) should
+   * pass `"includeEnded"`.
+   */
+  temporalMode: TemporalMode;
+  /** ISO-8601 timestamp used when `temporalMode === "asOf"`. */
+  asOf?: string;
   dialect: DialectAdapter;
   schema: SqlSchema;
 }>;
 
-/**
- * Compiles a `WITH RECURSIVE reachable(...) AS (...)` CTE.
- *
- * The caller concatenates this SQL fragment with a subsequent SELECT from
- * the `reachable` CTE to project whatever columns they need.
- */
 export function buildReachableCte(options: BuildReachableCteOptions): SQL {
   const trackPath = options.cyclePolicy === "prevent" || options.includePath;
   const edgeKindFilter = compileKindFilter(
     sql.raw("e.kind"),
     options.edgeKinds,
   );
+  const nodeTemporalFilter = compileTemporalFilter({
+    mode: options.temporalMode,
+    asOf: options.asOf,
+    tableAlias: "n",
+  });
+  const edgeTemporalFilter = compileTemporalFilter({
+    mode: options.temporalMode,
+    asOf: options.asOf,
+    tableAlias: "e",
+  });
 
   const initialPath =
     trackPath ? options.dialect.initializePath(sql.raw("n.id")) : undefined;
@@ -61,7 +61,7 @@ export function buildReachableCte(options: BuildReachableCteOptions): SQL {
     baseColumns.push(sql`${initialPath} AS path`);
   }
 
-  const baseCase = sql`SELECT ${sql.join(baseColumns, sql`, `)} FROM ${options.schema.nodesTable} n WHERE n.graph_id = ${options.graphId} AND n.id = ${options.sourceId} AND n.deleted_at IS NULL`;
+  const baseCase = sql`SELECT ${sql.join(baseColumns, sql`, `)} FROM ${options.schema.nodesTable} n WHERE n.graph_id = ${options.graphId} AND n.id = ${options.sourceId} AND ${nodeTemporalFilter}`;
 
   const recursiveColumns: SQL[] = [
     sql`n.id`,
@@ -75,8 +75,8 @@ export function buildReachableCte(options: BuildReachableCteOptions): SQL {
   const recursiveWhere: SQL[] = [
     sql`e.graph_id = ${options.graphId}`,
     edgeKindFilter,
-    sql`e.deleted_at IS NULL`,
-    sql`n.deleted_at IS NULL`,
+    edgeTemporalFilter,
+    nodeTemporalFilter,
     sql`r.depth < ${options.maxHops}`,
   ];
   if (cycleCheck !== undefined) recursiveWhere.push(cycleCheck);
@@ -172,9 +172,8 @@ type BidirectionalBranchOptions = Readonly<{
 }>;
 
 function buildBidirectionalBranch(options: BidirectionalBranchOptions): SQL {
-  // Match the node via either direction of the edge in a single UNION ALL
-  // branch, mirroring the approach used by subgraph extraction so PostgreSQL
-  // accepts the recursive CTE (it rejects multiple non-recursive terms).
+  // PostgreSQL rejects multiple non-recursive terms, so both directions are
+  // folded into a single UNION ALL branch via an OR on the join condition.
   const nodeJoin = sql`JOIN ${options.schema.nodesTable} n ON n.graph_id = e.graph_id AND ((e.to_id = r.id AND n.id = e.from_id AND n.kind = e.from_kind) OR (e.from_id = r.id AND n.id = e.to_id AND n.kind = e.to_kind))`;
 
   if (options.forceWorktableOuterJoinOrder) {
@@ -186,28 +185,4 @@ function buildBidirectionalBranch(options: BidirectionalBranchOptions): SQL {
   }
 
   return sql`${options.selectClause} FROM reachable r JOIN ${options.schema.edgesTable} e ON (e.from_id = r.id OR e.to_id = r.id) ${nodeJoin} WHERE ${sql.join([...options.whereClauses], sql` AND `)}`;
-}
-
-/**
- * Decodes a dialect-specific `path` column value into an ordered list of
- * node IDs.
- *
- * PostgreSQL returns `text[]` arrays (already JavaScript arrays); SQLite
- * returns a `'|id1|id2|...|id_n|'` delimited string. Empty or unknown values
- * fall back to an empty list.
- */
-export function decodePathColumn(value: unknown): readonly string[] {
-  if (Array.isArray(value)) {
-    return value.map(String);
-  }
-
-  if (typeof value === "string") {
-    if (value.length === 0) return [];
-    const trimmed = value.startsWith("|") ? value.slice(1) : value;
-    const withoutTail = trimmed.endsWith("|") ? trimmed.slice(0, -1) : trimmed;
-    if (withoutTail.length === 0) return [];
-    return withoutTail.split("|");
-  }
-
-  return [];
 }

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -28,6 +28,7 @@ import { getDialect } from "../query/dialect";
 import { buildKindRegistry, type KindRegistry } from "../registry";
 import { nowIso } from "../utils/date";
 import { generateId } from "../utils/id";
+import { createGraphAlgorithms, type GraphAlgorithms } from "./algorithms";
 import {
   createEdgeCollectionsProxy,
   createNodeCollectionsProxy,
@@ -125,6 +126,7 @@ export class Store<G extends GraphDef> {
   readonly #defaultTraversalExpansion: TraversalExpansion;
   #nodeCollections: GraphNodeCollections<G> | undefined;
   #edgeCollections: GraphEdgeCollections<G> | undefined;
+  #algorithms: GraphAlgorithms<G> | undefined;
 
   constructor(graph: G, backend: GraphBackend, options?: StoreOptions) {
     this.#graph = graph;
@@ -219,6 +221,39 @@ export class Store<G extends GraphDef> {
     }
 
     return this.#edgeCollections;
+  }
+
+  // === Graph Algorithms ===
+
+  /**
+   * Tier 1 graph algorithms: shortest path, reachability, neighborhoods, and
+   * degree centrality.
+   *
+   * Each call compiles to a single recursive-CTE query against the backend.
+   * The facade is built lazily on first access and cached for the lifetime
+   * of the store.
+   *
+   * @example
+   * ```typescript
+   * const path = await store.algorithms.shortestPath(alice, bob, {
+   *   edges: ["knows"],
+   * });
+   *
+   * const friends = await store.algorithms.neighbors(alice, {
+   *   edges: ["knows"],
+   *   depth: 2,
+   * });
+   * ```
+   */
+  get algorithms(): GraphAlgorithms<G> {
+    if (this.#algorithms === undefined) {
+      this.#algorithms = createGraphAlgorithms<G>({
+        graphId: this.graphId,
+        backend: this.#backend,
+        schema: this.#schema,
+      });
+    }
+    return this.#algorithms;
   }
 
   // === Dynamic Collection Access ===
@@ -591,6 +626,7 @@ export class Store<G extends GraphDef> {
     // Reset lazy-initialized collection caches
     this.#nodeCollections = undefined;
     this.#edgeCollections = undefined;
+    this.#algorithms = undefined;
   }
 
   // === Lifecycle ===

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -251,6 +251,7 @@ export class Store<G extends GraphDef> {
         graphId: this.graphId,
         backend: this.#backend,
         schema: this.#schema,
+        defaultTemporalMode: this.#graph.defaults.temporalMode,
       });
     }
     return this.#algorithms;

--- a/packages/typegraph/src/store/subgraph.ts
+++ b/packages/typegraph/src/store/subgraph.ts
@@ -15,11 +15,17 @@ import type {
   GraphDef,
   NodeKinds,
 } from "../core/define-graph";
-import type { AnyEdgeType, NodeId, NodeType } from "../core/types";
+import type {
+  AnyEdgeType,
+  NodeId,
+  NodeType,
+  TemporalMode,
+} from "../core/types";
 import type { RecursiveCyclePolicy } from "../query/ast";
 import { compileKindFilter } from "../query/compiler/predicate-utils";
 import { MAX_EXPLICIT_RECURSIVE_DEPTH } from "../query/compiler/recursive";
 import { DEFAULT_SQL_SCHEMA, type SqlSchema } from "../query/compiler/schema";
+import { compileTemporalFilter } from "../query/compiler/temporal";
 import { compileTypedJsonExtract } from "../query/compiler/typed-json-extract";
 import { quoteIdentifier } from "../query/compiler/utils";
 import type { DialectAdapter } from "../query/dialect/types";
@@ -31,6 +37,7 @@ import {
   type SchemaIntrospector,
 } from "../query/schema-introspector";
 import { fnv1aBase36 } from "../utils/hash";
+import { buildReachableCte } from "./recursive-cte";
 import { validateProjectionField } from "./reserved-keys";
 import {
   type EdgeRow,
@@ -331,6 +338,13 @@ export type SubgraphOptions<
   /** Cycle policy — reuse RecursiveCyclePolicy (default: "prevent"). */
   cyclePolicy?: RecursiveCyclePolicy;
   /**
+   * Temporal mode applied to both nodes and edges along the traversal and in
+   * the hydrated result. Defaults to `graph.defaults.temporalMode`.
+   */
+  temporalMode?: TemporalMode;
+  /** ISO-8601 timestamp used when `temporalMode === "asOf"`. */
+  asOf?: string;
+  /**
    * Optional field-level projection per node/edge kind.
    *
    * Projected nodes keep `kind` and `id`; projected edges keep their structural
@@ -399,6 +413,8 @@ type SubgraphContext = Readonly<{
   excludeRoot: boolean;
   direction: "out" | "both";
   cyclePolicy: RecursiveCyclePolicy;
+  temporalMode: TemporalMode;
+  asOf: string | undefined;
   dialect: DialectAdapter;
   schema: SqlSchema;
   backend: GraphBackend;
@@ -462,6 +478,8 @@ export async function executeSubgraph<
     excludeRoot: options.excludeRoot ?? false,
     direction: options.direction ?? "out",
     cyclePolicy: options.cyclePolicy ?? "prevent",
+    temporalMode: options.temporalMode ?? params.graph.defaults.temporalMode,
+    asOf: options.asOf,
     dialect: params.dialect,
     schema: params.schema ?? DEFAULT_SQL_SCHEMA,
     backend: params.backend,
@@ -481,7 +499,19 @@ export async function executeSubgraph<
     "edge",
   );
 
-  const reachableCte = buildReachableCte(ctx);
+  const reachableCte = buildReachableCte({
+    graphId: ctx.graphId,
+    sourceId: ctx.rootId,
+    edgeKinds: ctx.edgeKinds,
+    maxHops: ctx.maxDepth,
+    direction: ctx.direction,
+    cyclePolicy: ctx.cyclePolicy,
+    includePath: false,
+    temporalMode: ctx.temporalMode,
+    ...(ctx.asOf !== undefined && { asOf: ctx.asOf }),
+    dialect: ctx.dialect,
+    schema: ctx.schema,
+  });
   const includedIdsCte = buildIncludedIdsCte(ctx);
 
   const [nodeRows, edgeRows] = await Promise.all([
@@ -631,132 +661,6 @@ function dedupeStrings(values: readonly string[]): readonly string[] {
 // SQL Generation
 // ============================================================
 
-function buildReachableCte(ctx: SubgraphContext): SQL {
-  const shouldTrackPath = ctx.cyclePolicy === "prevent";
-  const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), ctx.edgeKinds);
-
-  // Path operations for cycle detection
-  const initialPath =
-    shouldTrackPath ? ctx.dialect.initializePath(sql.raw("n.id")) : undefined;
-  const pathExtension =
-    shouldTrackPath ?
-      ctx.dialect.extendPath(sql.raw("r.path"), sql.raw("n.id"))
-    : undefined;
-  const cycleCheck =
-    shouldTrackPath ?
-      ctx.dialect.cycleCheck(sql.raw("n.id"), sql.raw("r.path"))
-    : undefined;
-
-  // Base case: the root node
-  const baseColumns: SQL[] = [sql`n.id`, sql`n.kind`, sql`0 AS depth`];
-  if (initialPath !== undefined) {
-    baseColumns.push(sql`${initialPath} AS path`);
-  }
-
-  const baseCase = sql`SELECT ${sql.join(baseColumns, sql`, `)} FROM ${ctx.schema.nodesTable} n WHERE n.graph_id = ${ctx.graphId} AND n.id = ${ctx.rootId} AND n.deleted_at IS NULL`;
-
-  // Recursive case columns
-  const recursiveColumns: SQL[] = [
-    sql`n.id`,
-    sql`n.kind`,
-    sql`r.depth + 1 AS depth`,
-  ];
-  if (pathExtension !== undefined) {
-    recursiveColumns.push(sql`${pathExtension} AS path`);
-  }
-
-  // Common WHERE clauses for recursive branches
-  const recursiveWhereClauses: SQL[] = [
-    sql`e.graph_id = ${ctx.graphId}`,
-    edgeKindFilter,
-    sql`e.deleted_at IS NULL`,
-    sql`n.deleted_at IS NULL`,
-    sql`r.depth < ${ctx.maxDepth}`,
-  ];
-  if (cycleCheck !== undefined) {
-    recursiveWhereClauses.push(cycleCheck);
-  }
-
-  const forceWorktableOuterJoinOrder =
-    ctx.dialect.capabilities.forceRecursiveWorktableOuterJoinOrder;
-
-  const recursiveCase =
-    ctx.direction === "both" ?
-      compileBidirectionalBranch({
-        recursiveColumns,
-        whereClauses: recursiveWhereClauses,
-        forceWorktableOuterJoinOrder,
-        schema: ctx.schema,
-      })
-    : compileRecursiveBranch({
-        recursiveColumns,
-        whereClauses: recursiveWhereClauses,
-        joinField: "from_id",
-        targetField: "to_id",
-        targetKindField: "to_kind",
-        forceWorktableOuterJoinOrder,
-        schema: ctx.schema,
-      });
-
-  return sql`WITH RECURSIVE reachable AS (${baseCase} UNION ALL ${recursiveCase})`;
-}
-
-function compileRecursiveBranch(params: {
-  recursiveColumns: readonly SQL[];
-  whereClauses: readonly SQL[];
-  joinField: "from_id" | "to_id";
-  targetField: "from_id" | "to_id";
-  targetKindField: "from_kind" | "to_kind";
-  forceWorktableOuterJoinOrder: boolean;
-  schema: SqlSchema;
-}): SQL {
-  const columns = [...params.recursiveColumns];
-  const selectClause = sql`SELECT ${sql.join(columns, sql`, `)}`;
-  const nodeJoin = sql`JOIN ${params.schema.nodesTable} n ON n.graph_id = e.graph_id AND n.id = e.${sql.raw(params.targetField)} AND n.kind = e.${sql.raw(params.targetKindField)}`;
-
-  if (params.forceWorktableOuterJoinOrder) {
-    // SQLite: worktable must be outer in the join — use CROSS JOIN + WHERE
-    const allWhere = [
-      ...params.whereClauses,
-      sql`e.${sql.raw(params.joinField)} = r.id`,
-    ];
-    return sql`${selectClause} FROM reachable r CROSS JOIN ${params.schema.edgesTable} e ${nodeJoin} WHERE ${sql.join(allWhere, sql` AND `)}`;
-  }
-
-  // PostgreSQL: standard JOIN ON
-  const where = [...params.whereClauses];
-  return sql`${selectClause} FROM reachable r JOIN ${params.schema.edgesTable} e ON e.${sql.raw(params.joinField)} = r.id ${nodeJoin} WHERE ${sql.join(where, sql` AND `)}`;
-}
-
-/**
- * Combines outbound and inbound traversal into a single recursive SELECT
- * using OR on the join condition. This avoids a second UNION ALL branch,
- * which PostgreSQL rejects because it treats the left side of a multi-part
- * UNION ALL as the non-recursive term.
- */
-function compileBidirectionalBranch(params: {
-  recursiveColumns: readonly SQL[];
-  whereClauses: readonly SQL[];
-  forceWorktableOuterJoinOrder: boolean;
-  schema: SqlSchema;
-}): SQL {
-  const columns = [...params.recursiveColumns];
-  const selectClause = sql`SELECT ${sql.join(columns, sql`, `)}`;
-
-  // Match node via either direction of the edge
-  const nodeJoin = sql`JOIN ${params.schema.nodesTable} n ON n.graph_id = e.graph_id AND ((e.to_id = r.id AND n.id = e.from_id AND n.kind = e.from_kind) OR (e.from_id = r.id AND n.id = e.to_id AND n.kind = e.to_kind))`;
-
-  if (params.forceWorktableOuterJoinOrder) {
-    const allWhere = [
-      ...params.whereClauses,
-      sql`(e.from_id = r.id OR e.to_id = r.id)`,
-    ];
-    return sql`${selectClause} FROM reachable r CROSS JOIN ${params.schema.edgesTable} e ${nodeJoin} WHERE ${sql.join(allWhere, sql` AND `)}`;
-  }
-
-  return sql`${selectClause} FROM reachable r JOIN ${params.schema.edgesTable} e ON (e.from_id = r.id OR e.to_id = r.id) ${nodeJoin} WHERE ${sql.join([...params.whereClauses], sql` AND `)}`;
-}
-
 function buildIncludedIdsCte(ctx: SubgraphContext): SQL {
   const filters: SQL[] = [];
 
@@ -809,6 +713,11 @@ async function fetchSubgraphEdges(
   projectionPlan: ProjectionPlan,
 ): Promise<SubgraphEdgeFetchRow[]> {
   const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), ctx.edgeKinds);
+  const edgeTemporalFilter = compileTemporalFilter({
+    mode: ctx.temporalMode,
+    asOf: ctx.asOf,
+    tableAlias: "e",
+  });
   const columns: SQL[] = [
     sql`e.id`,
     sql`e.kind`,
@@ -827,7 +736,7 @@ async function fetchSubgraphEdges(
     ...buildProjectedPropertyColumns("e", projectionPlan, ctx.dialect),
   ];
 
-  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND e.deleted_at IS NULL AND e.from_id IN (SELECT id FROM included_ids) AND e.to_id IN (SELECT id FROM included_ids)`;
+  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND ${edgeTemporalFilter} AND e.from_id IN (SELECT id FROM included_ids) AND e.to_id IN (SELECT id FROM included_ids)`;
 
   return ctx.backend.execute<SubgraphEdgeFetchRow>(query) as Promise<
     SubgraphEdgeFetchRow[]

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Graph algorithm tests.
+ *
+ * Exercises `store.algorithms.{shortestPath, reachable, canReach,
+ * neighbors, degree}` against the SQLite backend with a fixture that
+ * includes branching paths, cycles, self-loops, and disconnected regions.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineEdge, defineGraph, defineNode } from "../src";
+import type { GraphBackend } from "../src/backend/types";
+import type { NodeId } from "../src/core/types";
+import { ConfigurationError } from "../src/errors";
+import { createStore, type Store } from "../src/store";
+import { createTestBackend } from "./test-utils";
+
+// ============================================================
+// Test Schema
+// ============================================================
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Task = defineNode("Task", {
+  schema: z.object({ title: z.string() }),
+});
+
+const knows = defineEdge("knows", { schema: z.object({}) });
+const reportsTo = defineEdge("reports_to", { schema: z.object({}) });
+const dependsOn = defineEdge("depends_on", { schema: z.object({}) });
+
+const testGraph = defineGraph({
+  id: "algorithms_test",
+  nodes: {
+    Person: { type: Person },
+    Task: { type: Task },
+  },
+  edges: {
+    knows: { type: knows, from: [Person], to: [Person] },
+    reports_to: { type: reportsTo, from: [Person], to: [Person] },
+    depends_on: { type: dependsOn, from: [Task], to: [Task] },
+  },
+});
+
+type TestGraph = typeof testGraph;
+
+// ============================================================
+// Fixture
+// ============================================================
+//
+// People graph (directed "knows"):
+//   alice --> bob --> charlie --> dave
+//               \          ^
+//                \         |
+//                 +---> eve (knows charlie)
+//   frank (isolated — no edges)
+//
+// Cycle component:
+//   xavier <-> yves  (two-node cycle via "knows")
+//
+// Self-loop:
+//   narcissus --> narcissus (knows)
+//
+// Reports-to (different edge kind):
+//   bob reports_to alice
+//   charlie reports_to bob
+//
+// Task dependency DAG:
+//   t1 --> t2 --> t3
+//           \--> t4
+
+type Fixture = Readonly<{
+  alice: string;
+  bob: string;
+  charlie: string;
+  dave: string;
+  eve: string;
+  frank: string;
+  xavier: string;
+  yves: string;
+  narcissus: string;
+  t1: string;
+  t2: string;
+  t3: string;
+  t4: string;
+}>;
+
+async function seed(store: Store<TestGraph>): Promise<Fixture> {
+  const alice = await store.nodes.Person.create({ name: "Alice" });
+  const bob = await store.nodes.Person.create({ name: "Bob" });
+  const charlie = await store.nodes.Person.create({ name: "Charlie" });
+  const dave = await store.nodes.Person.create({ name: "Dave" });
+  const eve = await store.nodes.Person.create({ name: "Eve" });
+  const frank = await store.nodes.Person.create({ name: "Frank" });
+  const xavier = await store.nodes.Person.create({ name: "Xavier" });
+  const yves = await store.nodes.Person.create({ name: "Yves" });
+  const narcissus = await store.nodes.Person.create({ name: "Narcissus" });
+
+  await store.edges.knows.create(alice, bob, {});
+  await store.edges.knows.create(bob, charlie, {});
+  await store.edges.knows.create(charlie, dave, {});
+  await store.edges.knows.create(bob, eve, {});
+  await store.edges.knows.create(eve, charlie, {});
+
+  // Cycle component.
+  await store.edges.knows.create(xavier, yves, {});
+  await store.edges.knows.create(yves, xavier, {});
+
+  // Self-loop.
+  await store.edges.knows.create(narcissus, narcissus, {});
+
+  // Reports-to (different edge kind).
+  await store.edges.reports_to.create(bob, alice, {});
+  await store.edges.reports_to.create(charlie, bob, {});
+
+  // Task DAG.
+  const t1 = await store.nodes.Task.create({ title: "T1" });
+  const t2 = await store.nodes.Task.create({ title: "T2" });
+  const t3 = await store.nodes.Task.create({ title: "T3" });
+  const t4 = await store.nodes.Task.create({ title: "T4" });
+
+  await store.edges.depends_on.create(t1, t2, {});
+  await store.edges.depends_on.create(t2, t3, {});
+  await store.edges.depends_on.create(t2, t4, {});
+
+  return {
+    alice: alice.id,
+    bob: bob.id,
+    charlie: charlie.id,
+    dave: dave.id,
+    eve: eve.id,
+    frank: frank.id,
+    xavier: xavier.id,
+    yves: yves.id,
+    narcissus: narcissus.id,
+    t1: t1.id,
+    t2: t2.id,
+    t3: t3.id,
+    t4: t4.id,
+  };
+}
+
+// ============================================================
+// Test Setup
+// ============================================================
+
+describe("store.algorithms", () => {
+  let backend: GraphBackend;
+  let store: Store<TestGraph>;
+  let ids: Fixture;
+
+  beforeEach(async () => {
+    backend = createTestBackend();
+    store = createStore(testGraph, backend);
+    ids = await seed(store);
+  });
+
+  // --------------------------------------------------------------
+  // shortestPath
+  // --------------------------------------------------------------
+
+  describe("shortestPath", () => {
+    it("returns a direct single-hop path", async () => {
+      const path = await store.algorithms.shortestPath(ids.alice, ids.bob, {
+        edges: ["knows"],
+      });
+
+      expect(path).toBeDefined();
+      expect(path?.depth).toBe(1);
+      expect(path?.nodes.map((node) => node.id)).toEqual([ids.alice, ids.bob]);
+      expect(path?.nodes.every((node) => node.kind === "Person")).toBe(true);
+    });
+
+    it("prefers a shorter path when multiple routes exist", async () => {
+      // alice -> bob -> charlie is 2 hops.
+      // alice -> bob -> eve -> charlie is 3 hops.
+      const path = await store.algorithms.shortestPath(ids.alice, ids.charlie, {
+        edges: ["knows"],
+      });
+
+      expect(path?.depth).toBe(2);
+      expect(path?.nodes.map((node) => node.id)).toEqual([
+        ids.alice,
+        ids.bob,
+        ids.charlie,
+      ]);
+    });
+
+    it("returns undefined when the target is unreachable", async () => {
+      const path = await store.algorithms.shortestPath(ids.alice, ids.frank, {
+        edges: ["knows"],
+      });
+      expect(path).toBeUndefined();
+    });
+
+    it("returns a zero-length path when source equals target", async () => {
+      const path = await store.algorithms.shortestPath(ids.alice, ids.alice, {
+        edges: ["knows"],
+      });
+      expect(path).toEqual({
+        depth: 0,
+        nodes: [{ id: ids.alice, kind: "Person" }],
+      });
+    });
+
+    it("respects maxHops", async () => {
+      const shallow = await store.algorithms.shortestPath(ids.alice, ids.dave, {
+        edges: ["knows"],
+        maxHops: 2,
+      });
+      expect(shallow).toBeUndefined();
+
+      const deeper = await store.algorithms.shortestPath(ids.alice, ids.dave, {
+        edges: ["knows"],
+        maxHops: 3,
+      });
+      expect(deeper?.depth).toBe(3);
+    });
+
+    it("traverses reverse edges when direction is 'in'", async () => {
+      const path = await store.algorithms.shortestPath(ids.bob, ids.alice, {
+        edges: ["knows"],
+        direction: "in",
+      });
+      expect(path?.depth).toBe(1);
+      expect(path?.nodes.map((node) => node.id)).toEqual([ids.bob, ids.alice]);
+    });
+
+    it("treats edges as undirected when direction is 'both'", async () => {
+      const path = await store.algorithms.shortestPath(ids.dave, ids.alice, {
+        edges: ["knows"],
+        direction: "both",
+      });
+      expect(path?.depth).toBe(3);
+    });
+
+    it("tolerates cycles with the default cyclePolicy", async () => {
+      const path = await store.algorithms.shortestPath(ids.xavier, ids.yves, {
+        edges: ["knows"],
+      });
+      expect(path?.depth).toBe(1);
+    });
+
+    it("restricts traversal to the specified edge kinds", async () => {
+      const viaKnows = await store.algorithms.shortestPath(
+        ids.charlie,
+        ids.alice,
+        { edges: ["knows"] },
+      );
+      expect(viaKnows).toBeUndefined();
+
+      const viaReports = await store.algorithms.shortestPath(
+        ids.charlie,
+        ids.alice,
+        { edges: ["reports_to"] },
+      );
+      expect(viaReports?.depth).toBe(2);
+    });
+
+    it("accepts node objects in addition to raw ids", async () => {
+      const alice = await store.nodes.Person.getById(
+        ids.alice as NodeId<typeof Person>,
+      );
+      const bob = await store.nodes.Person.getById(
+        ids.bob as NodeId<typeof Person>,
+      );
+      const path = await store.algorithms.shortestPath(alice!, bob!, {
+        edges: ["knows"],
+      });
+      expect(path?.depth).toBe(1);
+    });
+  });
+
+  // --------------------------------------------------------------
+  // reachable
+  // --------------------------------------------------------------
+
+  describe("reachable", () => {
+    it("returns every reachable node with its shortest depth", async () => {
+      const reachable = await store.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+      });
+
+      const byId = new Map(reachable.map((row) => [row.id, row.depth]));
+      expect(byId.get(ids.alice)).toBe(0);
+      expect(byId.get(ids.bob)).toBe(1);
+      expect(byId.get(ids.eve)).toBe(2);
+      expect(byId.get(ids.charlie)).toBe(2);
+      expect(byId.get(ids.dave)).toBe(3);
+      expect(byId.has(ids.frank)).toBe(false);
+    });
+
+    it("excludes the source when requested", async () => {
+      const reachable = await store.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        excludeSource: true,
+      });
+      expect(reachable.some((row) => row.id === ids.alice)).toBe(false);
+    });
+
+    it("is bounded by maxHops", async () => {
+      const reachable = await store.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        maxHops: 1,
+      });
+      const ids1 = reachable.map((row) => row.id).toSorted();
+      expect(ids1).toEqual([ids.alice, ids.bob].toSorted());
+    });
+
+    it("returns only the source for disconnected nodes", async () => {
+      const reachable = await store.algorithms.reachable(ids.frank, {
+        edges: ["knows"],
+      });
+      expect(reachable).toEqual([{ id: ids.frank, kind: "Person", depth: 0 }]);
+    });
+
+    it("returns an ordering by ascending depth", async () => {
+      const reachable = await store.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+      });
+      for (let index = 1; index < reachable.length; index++) {
+        expect(reachable[index]!.depth).toBeGreaterThanOrEqual(
+          reachable[index - 1]!.depth,
+        );
+      }
+    });
+  });
+
+  // --------------------------------------------------------------
+  // canReach
+  // --------------------------------------------------------------
+
+  describe("canReach", () => {
+    it("returns true for reachable targets", async () => {
+      const reachable = await store.algorithms.canReach(
+        ids.alice,
+        ids.charlie,
+        { edges: ["knows"] },
+      );
+      expect(reachable).toBe(true);
+    });
+
+    it("returns false for unreachable targets", async () => {
+      const reachable = await store.algorithms.canReach(ids.alice, ids.frank, {
+        edges: ["knows"],
+      });
+      expect(reachable).toBe(false);
+    });
+
+    it("returns true when source equals target", async () => {
+      const reachable = await store.algorithms.canReach(ids.alice, ids.alice, {
+        edges: ["knows"],
+      });
+      expect(reachable).toBe(true);
+    });
+
+    it("respects maxHops", async () => {
+      const shallow = await store.algorithms.canReach(ids.alice, ids.dave, {
+        edges: ["knows"],
+        maxHops: 2,
+      });
+      expect(shallow).toBe(false);
+
+      const deeper = await store.algorithms.canReach(ids.alice, ids.dave, {
+        edges: ["knows"],
+        maxHops: 3,
+      });
+      expect(deeper).toBe(true);
+    });
+  });
+
+  // --------------------------------------------------------------
+  // neighbors
+  // --------------------------------------------------------------
+
+  describe("neighbors", () => {
+    it("returns direct neighbors at depth 1 by default", async () => {
+      const neighbors = await store.algorithms.neighbors(ids.alice, {
+        edges: ["knows"],
+      });
+      expect(neighbors.map((row) => row.id)).toEqual([ids.bob]);
+    });
+
+    it("returns k-hop neighborhood when depth > 1", async () => {
+      const neighbors = await store.algorithms.neighbors(ids.alice, {
+        edges: ["knows"],
+        depth: 2,
+      });
+      const neighborIds = neighbors.map((row) => row.id).toSorted();
+      expect(neighborIds).toEqual([ids.bob, ids.charlie, ids.eve].toSorted());
+      for (const neighbor of neighbors) {
+        expect(neighbor.id).not.toBe(ids.alice);
+      }
+    });
+
+    it("includes reverse neighbors with direction 'in'", async () => {
+      const reverse = await store.algorithms.neighbors(ids.bob, {
+        edges: ["knows"],
+        direction: "in",
+      });
+      expect(reverse.map((row) => row.id)).toEqual([ids.alice]);
+    });
+
+    it("handles cycles without infinite expansion", async () => {
+      const neighbors = await store.algorithms.neighbors(ids.xavier, {
+        edges: ["knows"],
+        depth: 5,
+      });
+      expect(neighbors.map((row) => row.id)).toEqual([ids.yves]);
+    });
+  });
+
+  // --------------------------------------------------------------
+  // degree
+  // --------------------------------------------------------------
+
+  describe("degree", () => {
+    it("counts outgoing edges for direction 'out'", async () => {
+      const outDegree = await store.algorithms.degree(ids.bob, {
+        edges: ["knows"],
+        direction: "out",
+      });
+      expect(outDegree).toBe(2);
+    });
+
+    it("counts incoming edges for direction 'in'", async () => {
+      const inDegree = await store.algorithms.degree(ids.charlie, {
+        edges: ["knows"],
+        direction: "in",
+      });
+      expect(inDegree).toBe(2);
+    });
+
+    it("counts both directions by default and deduplicates self-loops", async () => {
+      const selfDegree = await store.algorithms.degree(ids.narcissus, {
+        edges: ["knows"],
+      });
+      expect(selfDegree).toBe(1);
+
+      const bobDegree = await store.algorithms.degree(ids.bob, {
+        edges: ["knows"],
+      });
+      // bob: knows alice (in), knows charlie (out), knows eve (out)
+      expect(bobDegree).toBe(3);
+    });
+
+    it("aggregates across all edge kinds when edges is omitted", async () => {
+      // bob has 2 'knows' outgoing, 1 'knows' incoming, 1 'reports_to'
+      // outgoing, 1 'reports_to' incoming = 5 distinct edges.
+      const total = await store.algorithms.degree(ids.bob);
+      expect(total).toBe(5);
+    });
+
+    it("restricts to specific edge kinds", async () => {
+      const reports = await store.algorithms.degree(ids.bob, {
+        edges: ["reports_to"],
+      });
+      expect(reports).toBe(2);
+    });
+
+    it("returns 0 when edges is an empty list", async () => {
+      const none = await store.algorithms.degree(ids.bob, { edges: [] });
+      expect(none).toBe(0);
+    });
+
+    it("returns 0 for disconnected nodes", async () => {
+      const zero = await store.algorithms.degree(ids.frank, {
+        edges: ["knows"],
+      });
+      expect(zero).toBe(0);
+    });
+  });
+
+  // --------------------------------------------------------------
+  // validation
+  // --------------------------------------------------------------
+
+  describe("validation", () => {
+    it("rejects empty edge kinds for traversal algorithms", async () => {
+      await expect(
+        store.algorithms.shortestPath(ids.alice, ids.bob, { edges: [] }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(
+        store.algorithms.reachable(ids.alice, { edges: [] }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(
+        store.algorithms.canReach(ids.alice, ids.bob, { edges: [] }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(
+        store.algorithms.neighbors(ids.alice, { edges: [] }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+    });
+
+    it("rejects non-positive maxHops", async () => {
+      await expect(
+        store.algorithms.reachable(ids.alice, {
+          edges: ["knows"],
+          maxHops: 0,
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(
+        store.algorithms.neighbors(ids.alice, {
+          edges: ["knows"],
+          depth: -1,
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+    });
+
+    it("rejects maxHops over the explicit recursive limit", async () => {
+      await expect(
+        store.algorithms.reachable(ids.alice, {
+          edges: ["knows"],
+          maxHops: 10_000,
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+    });
+  });
+
+  // --------------------------------------------------------------
+  // task DAG sanity
+  // --------------------------------------------------------------
+
+  describe("task dependency DAG", () => {
+    it("finds the shortest path through a DAG", async () => {
+      const path = await store.algorithms.shortestPath(ids.t1, ids.t3, {
+        edges: ["depends_on"],
+      });
+      expect(path?.depth).toBe(2);
+      expect(path?.nodes.map((node) => node.id)).toEqual([
+        ids.t1,
+        ids.t2,
+        ids.t3,
+      ]);
+    });
+
+    it("reaches every dependent task", async () => {
+      const reachable = await store.algorithms.reachable(ids.t1, {
+        edges: ["depends_on"],
+        excludeSource: true,
+      });
+      const reached = reachable.map((row) => row.id).toSorted();
+      expect(reached).toEqual([ids.t2, ids.t3, ids.t4].toSorted());
+    });
+  });
+});

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -13,7 +13,7 @@ import type { GraphBackend } from "../src/backend/types";
 import type { NodeId } from "../src/core/types";
 import { ConfigurationError } from "../src/errors";
 import { createStore, type Store } from "../src/store";
-import { createTestBackend } from "./test-utils";
+import { createTestBackend, TEMPORAL_ANCHORS } from "./test-utils";
 
 // ============================================================
 // Test Schema
@@ -542,6 +542,428 @@ describe("store.algorithms", () => {
       });
       const reached = reachable.map((row) => row.id).toSorted();
       expect(reached).toEqual([ids.t2, ids.t3, ids.t4].toSorted());
+    });
+  });
+});
+
+// ============================================================
+// Temporal Behavior
+// ============================================================
+//
+// Algorithms honor the same temporal model as the rest of the store.
+// Default is graph.defaults.temporalMode ("current"), with per-call
+// overrides via `temporalMode` / `asOf`.
+//
+// Fixture (all nodes are Person, edges are "knows"):
+//
+//   alice  -- current edge -->  bob    (both always valid)
+//   bob    -- expired edge -->  david  (edge validTo = PAST)
+//   alice  -- current edge -->  eve    (eve validFrom = FUTURE)
+//   alice  -- current edge -->  ghost  (ghost soft-deleted)
+//
+// Time anchors:
+//   PAST   = 2020-01-01
+//   BEFORE = 2021-01-01   (before expired-edge ended)
+//   NOW    = 2025-06-01
+//   FUTURE = 2030-01-01
+
+describe("store.algorithms temporal behavior", () => {
+  const { PAST, BEFORE, EDGE_ENDED, FUTURE } = TEMPORAL_ANCHORS;
+
+  type TemporalFixture = Readonly<{
+    alice: string;
+    bob: string;
+    david: string;
+    eve: string;
+    ghost: string;
+  }>;
+
+  let backend: GraphBackend;
+  let store: Store<TestGraph>;
+  let temporalIds: TemporalFixture;
+
+  beforeEach(async () => {
+    backend = createTestBackend();
+    store = createStore(testGraph, backend);
+
+    // Alice/Bob/David valid from PAST so asOf: BEFORE sees them.
+    const [alice, bob, david, eve, ghost] = await Promise.all([
+      store.nodes.Person.create({ name: "Alice" }, { validFrom: PAST }),
+      store.nodes.Person.create({ name: "Bob" }, { validFrom: PAST }),
+      store.nodes.Person.create({ name: "David" }, { validFrom: PAST }),
+      store.nodes.Person.create({ name: "Eve" }, { validFrom: FUTURE }),
+      store.nodes.Person.create({ name: "Ghost" }),
+    ]);
+
+    // Edges: alice→bob (always valid), bob→david (ended), alice→eve (current),
+    // alice→ghost (soft-deleted along with ghost below, to exercise tombstone
+    // traversal). Edge must be deleted before ghost — node delete is restricted
+    // while live connected edges exist.
+    const edgeToGhostPromise = store.edges.knows.create(alice, ghost, {});
+    await Promise.all([
+      store.edges.knows.create(alice, bob, {}, { validFrom: PAST }),
+      store.edges.knows.create(
+        bob,
+        david,
+        {},
+        { validFrom: PAST, validTo: EDGE_ENDED },
+      ),
+      store.edges.knows.create(alice, eve, {}),
+      edgeToGhostPromise,
+    ]);
+    const edgeToGhost = await edgeToGhostPromise;
+    await store.edges.knows.delete(edgeToGhost.id);
+    await store.nodes.Person.delete(ghost.id);
+
+    temporalIds = {
+      alice: alice.id,
+      bob: bob.id,
+      david: david.id,
+      eve: eve.id,
+      ghost: ghost.id,
+    };
+  });
+
+  describe("reachable", () => {
+    it("defaults to current mode — excludes future and deleted nodes", async () => {
+      const reached = await store.algorithms.reachable(temporalIds.alice, {
+        edges: ["knows"],
+        excludeSource: true,
+      });
+      const reachedIds = reached.map((row) => row.id).toSorted();
+
+      expect(reachedIds).toEqual([temporalIds.bob].toSorted());
+    });
+
+    it("asOf = BEFORE sees the expired edge to david", async () => {
+      const reached = await store.algorithms.reachable(temporalIds.alice, {
+        edges: ["knows"],
+        excludeSource: true,
+        temporalMode: "asOf",
+        asOf: BEFORE,
+      });
+      const reachedIds = reached.map((row) => row.id).toSorted();
+
+      // Eve not yet valid (validFrom = FUTURE), Ghost not yet deleted but also
+      // its edge is current and asOf BEFORE is prior to the edge's implicit
+      // validFrom (ULID-based createdAt). Bob and David are reachable via the
+      // historical edge.
+      expect(reachedIds).toContain(temporalIds.bob);
+      expect(reachedIds).toContain(temporalIds.david);
+      expect(reachedIds).not.toContain(temporalIds.eve);
+    });
+
+    it("includeEnded traverses through the expired edge", async () => {
+      const reached = await store.algorithms.reachable(temporalIds.alice, {
+        edges: ["knows"],
+        excludeSource: true,
+        temporalMode: "includeEnded",
+      });
+      const reachedIds = reached.map((row) => row.id).toSorted();
+
+      // Ended edges included; deleted ghost excluded.
+      expect(reachedIds).toContain(temporalIds.bob);
+      expect(reachedIds).toContain(temporalIds.david);
+      expect(reachedIds).toContain(temporalIds.eve);
+      expect(reachedIds).not.toContain(temporalIds.ghost);
+    });
+
+    it("includeTombstones surfaces the deleted ghost node", async () => {
+      const reached = await store.algorithms.reachable(temporalIds.alice, {
+        edges: ["knows"],
+        excludeSource: true,
+        temporalMode: "includeTombstones",
+      });
+      const reachedIds = reached.map((row) => row.id).toSorted();
+
+      expect(reachedIds).toContain(temporalIds.ghost);
+    });
+  });
+
+  describe("canReach", () => {
+    it("self-path returns false when the node is not visible under current mode", async () => {
+      // Eve has validFrom = FUTURE — not current. The self-path short-circuit
+      // was removed so this honors the temporal filter like shortestPath does.
+      const reaches = await store.algorithms.canReach(
+        temporalIds.eve,
+        temporalIds.eve,
+        { edges: ["knows"] },
+      );
+      expect(reaches).toBe(false);
+    });
+
+    it("self-path returns true under includeEnded (ignores validity periods)", async () => {
+      const reaches = await store.algorithms.canReach(
+        temporalIds.eve,
+        temporalIds.eve,
+        { edges: ["knows"], temporalMode: "includeEnded" },
+      );
+      expect(reaches).toBe(true);
+    });
+
+    it("self-path returns true for ghost only under includeTombstones", async () => {
+      const currentReach = await store.algorithms.canReach(
+        temporalIds.ghost,
+        temporalIds.ghost,
+        { edges: ["knows"] },
+      );
+      expect(currentReach).toBe(false);
+
+      const tombstoneReach = await store.algorithms.canReach(
+        temporalIds.ghost,
+        temporalIds.ghost,
+        { edges: ["knows"], temporalMode: "includeTombstones" },
+      );
+      expect(tombstoneReach).toBe(true);
+    });
+
+    it("asOf finds a target through a historically-valid edge", async () => {
+      const reaches = await store.algorithms.canReach(
+        temporalIds.alice,
+        temporalIds.david,
+        { edges: ["knows"], temporalMode: "asOf", asOf: BEFORE },
+      );
+      expect(reaches).toBe(true);
+
+      // Default current mode: the bob→david edge is expired, so no path.
+      const currentReaches = await store.algorithms.canReach(
+        temporalIds.alice,
+        temporalIds.david,
+        { edges: ["knows"] },
+      );
+      expect(currentReaches).toBe(false);
+    });
+  });
+
+  describe("neighbors", () => {
+    it("forwards temporalMode through to the underlying reachable query", async () => {
+      // Alice's 1-hop current-mode neighbors: only bob (eve-future, ghost-deleted).
+      const current = await store.algorithms.neighbors(temporalIds.alice, {
+        edges: ["knows"],
+      });
+      expect(current.map((row) => row.id).toSorted()).toEqual(
+        [temporalIds.bob].toSorted(),
+      );
+
+      // Under includeEnded, eve becomes reachable too.
+      const ended = await store.algorithms.neighbors(temporalIds.alice, {
+        edges: ["knows"],
+        temporalMode: "includeEnded",
+      });
+      expect(ended.map((row) => row.id)).toContain(temporalIds.eve);
+
+      // Under includeTombstones, the deleted ghost surfaces.
+      const tombstones = await store.algorithms.neighbors(temporalIds.alice, {
+        edges: ["knows"],
+        temporalMode: "includeTombstones",
+      });
+      expect(tombstones.map((row) => row.id)).toContain(temporalIds.ghost);
+    });
+
+    it("forwards asOf through to the underlying reachable query", async () => {
+      // 2-hop at BEFORE: alice → bob → david via the historical edge.
+      const historical = await store.algorithms.neighbors(temporalIds.alice, {
+        edges: ["knows"],
+        depth: 2,
+        temporalMode: "asOf",
+        asOf: BEFORE,
+      });
+      expect(historical.map((row) => row.id)).toContain(temporalIds.david);
+    });
+  });
+
+  describe("shortestPath", () => {
+    it("defaults to current mode — no path to david through expired edge", async () => {
+      const path = await store.algorithms.shortestPath(
+        temporalIds.alice,
+        temporalIds.david,
+        { edges: ["knows"] },
+      );
+
+      expect(path).toBeUndefined();
+    });
+
+    it("asOf = BEFORE traverses the historical edge to david", async () => {
+      const path = await store.algorithms.shortestPath(
+        temporalIds.alice,
+        temporalIds.david,
+        { edges: ["knows"], temporalMode: "asOf", asOf: BEFORE },
+      );
+
+      expect(path?.depth).toBe(2);
+      expect(path?.nodes.map((node) => node.id)).toEqual([
+        temporalIds.alice,
+        temporalIds.bob,
+        temporalIds.david,
+      ]);
+    });
+
+    it("self-path short-circuit respects temporal mode", async () => {
+      // Eve is not yet valid under "current", so self-path returns undefined.
+      const currentSelf = await store.algorithms.shortestPath(
+        temporalIds.eve,
+        temporalIds.eve,
+        { edges: ["knows"] },
+      );
+      expect(currentSelf).toBeUndefined();
+
+      // Under "includeEnded", Eve exists regardless of validFrom — self-path succeeds.
+      const endedSelf = await store.algorithms.shortestPath(
+        temporalIds.eve,
+        temporalIds.eve,
+        { edges: ["knows"], temporalMode: "includeEnded" },
+      );
+      expect(endedSelf?.depth).toBe(0);
+      expect(endedSelf?.nodes[0]?.id).toBe(temporalIds.eve);
+    });
+
+    it("self-path under asOf honors the snapshot's validity window", async () => {
+      // Eve's validFrom is FUTURE — even at asOf BEFORE she isn't yet valid.
+      const beforeSelf = await store.algorithms.shortestPath(
+        temporalIds.eve,
+        temporalIds.eve,
+        { edges: ["knows"], temporalMode: "asOf", asOf: BEFORE },
+      );
+      expect(beforeSelf).toBeUndefined();
+
+      // Alice was valid from PAST, so asOf BEFORE sees her.
+      const aliceAtBefore = await store.algorithms.shortestPath(
+        temporalIds.alice,
+        temporalIds.alice,
+        { edges: ["knows"], temporalMode: "asOf", asOf: BEFORE },
+      );
+      expect(aliceAtBefore?.depth).toBe(0);
+      expect(aliceAtBefore?.nodes[0]?.id).toBe(temporalIds.alice);
+    });
+
+    it("self-path under includeTombstones resolves the deleted ghost", async () => {
+      // Ghost is soft-deleted. Under default current, self-path is undefined.
+      const currentSelf = await store.algorithms.shortestPath(
+        temporalIds.ghost,
+        temporalIds.ghost,
+        { edges: ["knows"] },
+      );
+      expect(currentSelf).toBeUndefined();
+
+      // includeTombstones surfaces the deleted node.
+      const tombstoneSelf = await store.algorithms.shortestPath(
+        temporalIds.ghost,
+        temporalIds.ghost,
+        { edges: ["knows"], temporalMode: "includeTombstones" },
+      );
+      expect(tombstoneSelf?.depth).toBe(0);
+      expect(tombstoneSelf?.nodes[0]?.id).toBe(temporalIds.ghost);
+    });
+  });
+
+  describe("degree", () => {
+    it("defaults to current mode — excludes expired edge", async () => {
+      // Bob has one outgoing edge (bob → david) but it's expired.
+      const currentDegree = await store.algorithms.degree(temporalIds.bob, {
+        edges: ["knows"],
+        direction: "out",
+      });
+      expect(currentDegree).toBe(0);
+    });
+
+    it("includeEnded counts the expired edge", async () => {
+      const degree = await store.algorithms.degree(temporalIds.bob, {
+        edges: ["knows"],
+        direction: "out",
+        temporalMode: "includeEnded",
+      });
+      expect(degree).toBe(1);
+    });
+
+    it("asOf counts edges that were valid at the snapshot", async () => {
+      // At BEFORE, the bob→david edge is still valid (ends at EDGE_ENDED).
+      const historical = await store.algorithms.degree(temporalIds.bob, {
+        edges: ["knows"],
+        direction: "out",
+        temporalMode: "asOf",
+        asOf: BEFORE,
+      });
+      expect(historical).toBe(1);
+    });
+
+    it("includeTombstones counts soft-deleted edges", async () => {
+      // Alice has one deleted edge (alice→ghost). Under default current,
+      // direction: "out" reports 2 (alice→bob, alice→eve — the alice→ghost
+      // edge is soft-deleted; eve's future validity doesn't matter for degree
+      // since degree only scans the edges table, not endpoint validity).
+      const current = await store.algorithms.degree(temporalIds.alice, {
+        edges: ["knows"],
+        direction: "out",
+      });
+      expect(current).toBe(2);
+
+      // With tombstones included, the alice→ghost edge surfaces too.
+      const tombstones = await store.algorithms.degree(temporalIds.alice, {
+        edges: ["knows"],
+        direction: "out",
+        temporalMode: "includeTombstones",
+      });
+      expect(tombstones).toBe(3);
+    });
+  });
+
+  describe("validation", () => {
+    it("throws when temporalMode is 'asOf' but asOf is not supplied", async () => {
+      // compileTemporalFilter enforces this at query compile time. Algorithms
+      // and subgraph should all surface the same error uniformly.
+      await expect(
+        store.algorithms.reachable(temporalIds.alice, {
+          edges: ["knows"],
+          temporalMode: "asOf",
+        }),
+      ).rejects.toThrow(/asOf/);
+
+      await expect(
+        store.algorithms.shortestPath(temporalIds.alice, temporalIds.bob, {
+          edges: ["knows"],
+          temporalMode: "asOf",
+        }),
+      ).rejects.toThrow(/asOf/);
+
+      await expect(
+        store.algorithms.canReach(temporalIds.alice, temporalIds.bob, {
+          edges: ["knows"],
+          temporalMode: "asOf",
+        }),
+      ).rejects.toThrow(/asOf/);
+
+      await expect(
+        store.algorithms.degree(temporalIds.alice, {
+          edges: ["knows"],
+          temporalMode: "asOf",
+        }),
+      ).rejects.toThrow(/asOf/);
+    });
+  });
+
+  describe("per-graph default temporal mode", () => {
+    it("respects graph.defaults.temporalMode when no per-call override", async () => {
+      // Build a separate graph with default "includeEnded" and verify algorithms
+      // pick it up without any per-call option.
+      const endedGraph = defineGraph({
+        id: "algorithms_temporal_ended",
+        nodes: { Person: { type: Person } },
+        edges: { knows: { type: knows, from: [Person], to: [Person] } },
+        defaults: { temporalMode: "includeEnded" },
+      });
+      const endedBackend = createTestBackend();
+      const endedStore = createStore(endedGraph, endedBackend);
+
+      const a = await endedStore.nodes.Person.create({ name: "A" });
+      const b = await endedStore.nodes.Person.create({ name: "B" });
+      await endedStore.edges.knows.create(a, b, {}, { validTo: EDGE_ENDED });
+
+      // Edge is ended, but graph default is "includeEnded" → b is reachable.
+      const reached = await endedStore.algorithms.reachable(a.id, {
+        edges: ["knows"],
+        excludeSource: true,
+      });
+      expect(reached.map((row) => row.id)).toContain(b.id);
     });
   });
 });

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -24,6 +24,7 @@ import {
   integrationTestGraph,
   registerAdvancedEdgePropertyIntegrationTests,
   registerAggregateIntegrationTests,
+  registerAlgorithmIntegrationTests,
   registerCrossBackendConsistencyTests,
   registerEdgeCaseIntegrationTests,
   registerEdgeOperationIntegrationTests,
@@ -116,6 +117,7 @@ export function createIntegrationTestSuite(
     registerEdgePropertyIntegrationTests(context);
     registerAdvancedEdgePropertyIntegrationTests(context);
     registerSubgraphIntegrationTests(context);
+    registerAlgorithmIntegrationTests(context);
     registerEdgeCaseIntegrationTests(context);
     registerCrossBackendConsistencyTests(context);
   });

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -1,0 +1,317 @@
+/**
+ * Graph Algorithms Integration Tests
+ *
+ * Tests `store.algorithms.*` and its temporal behavior against the shared
+ * integration test graph. Runs against both SQLite and PostgreSQL so the
+ * dialect-specific recursive-CTE path encoding (SQLite pipe-delimited
+ * strings vs Postgres text arrays), cycle detection, and temporal filter
+ * generation all get exercised on each backend.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { TEMPORAL_ANCHORS } from "../../test-utils";
+import { type IntegrationStore } from "./fixtures";
+import { seedKnowsChain } from "./seed-helpers";
+import { type IntegrationTestContext } from "./test-context";
+
+type AlgorithmFixture = Readonly<{
+  aliceId: string;
+  bobId: string;
+  charlieId: string;
+  dianaId: string;
+  eveId: string;
+}>;
+
+async function resolveAlgorithmFixture(
+  store: IntegrationStore,
+): Promise<AlgorithmFixture> {
+  const byName = new Map<string, string>();
+  const people = await store.nodes.Person.find();
+  for (const person of people) {
+    byName.set(person.name, person.id as string);
+  }
+  return {
+    aliceId: byName.get("Alice")!,
+    bobId: byName.get("Bob")!,
+    charlieId: byName.get("Charlie")!,
+    dianaId: byName.get("Diana")!,
+    eveId: byName.get("Eve")!,
+  };
+}
+
+type TemporalFixture = Readonly<{
+  rootId: string;
+  activeId: string;
+  endedId: string;
+  futureId: string;
+}>;
+
+async function seedTemporalGraph(
+  store: IntegrationStore,
+): Promise<TemporalFixture> {
+  const { PAST, EDGE_ENDED, FUTURE } = TEMPORAL_ANCHORS;
+
+  const [root, active, ended, future] = await Promise.all([
+    store.nodes.Person.create({ name: "Root" }, { validFrom: PAST }),
+    store.nodes.Person.create({ name: "Active" }, { validFrom: PAST }),
+    store.nodes.Person.create(
+      { name: "Ended" },
+      { validFrom: PAST, validTo: EDGE_ENDED },
+    ),
+    store.nodes.Person.create({ name: "Future" }, { validFrom: FUTURE }),
+  ]);
+
+  await Promise.all([
+    store.edges.knows.create(root, active, {}, { validFrom: PAST }),
+    store.edges.knows.create(
+      root,
+      ended,
+      {},
+      { validFrom: PAST, validTo: EDGE_ENDED },
+    ),
+    store.edges.knows.create(root, future, {}),
+  ]);
+
+  return {
+    rootId: root.id as string,
+    activeId: active.id as string,
+    endedId: ended.id as string,
+    futureId: future.id as string,
+  };
+}
+
+export function registerAlgorithmIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("Graph Algorithms", () => {
+    describe("core behaviors (seedKnowsChain: Alice→Bob→Charlie→Diana→Eve + Alice→Charlie)", () => {
+      let ids: AlgorithmFixture;
+
+      beforeEach(async () => {
+        const store = context.getStore();
+        await seedKnowsChain(store);
+        ids = await resolveAlgorithmFixture(store);
+      });
+
+      it("shortestPath finds the direct edge, not the longer route", async () => {
+        const store = context.getStore();
+        const path = await store.algorithms.shortestPath(
+          ids.aliceId,
+          ids.charlieId,
+          { edges: ["knows"] },
+        );
+        expect(path?.depth).toBe(1);
+        expect(path?.nodes.map((n) => n.id)).toEqual([
+          ids.aliceId,
+          ids.charlieId,
+        ]);
+      });
+
+      it("shortestPath finds a multi-hop path", async () => {
+        const store = context.getStore();
+        const path = await store.algorithms.shortestPath(
+          ids.aliceId,
+          ids.eveId,
+          { edges: ["knows"] },
+        );
+        expect(path?.depth).toBe(3);
+        expect(path?.nodes.at(0)?.id).toBe(ids.aliceId);
+        expect(path?.nodes.at(-1)?.id).toBe(ids.eveId);
+      });
+
+      it("shortestPath returns undefined for an unreachable target", async () => {
+        const store = context.getStore();
+        const path = await store.algorithms.shortestPath(
+          ids.eveId,
+          ids.aliceId,
+          { edges: ["knows"] },
+        );
+        expect(path).toBeUndefined();
+      });
+
+      it("reachable returns every node reachable from source", async () => {
+        const store = context.getStore();
+        const reached = await store.algorithms.reachable(ids.aliceId, {
+          edges: ["knows"],
+        });
+        const reachedIds = reached.map((r) => r.id).toSorted();
+        expect(reachedIds).toEqual(
+          [
+            ids.aliceId,
+            ids.bobId,
+            ids.charlieId,
+            ids.dianaId,
+            ids.eveId,
+          ].toSorted(),
+        );
+      });
+
+      it("reachable respects maxHops", async () => {
+        const store = context.getStore();
+        const reached = await store.algorithms.reachable(ids.aliceId, {
+          edges: ["knows"],
+          maxHops: 1,
+        });
+        const reachedIds = reached.map((r) => r.id).toSorted();
+        expect(reachedIds).toEqual(
+          [ids.aliceId, ids.bobId, ids.charlieId].toSorted(),
+        );
+      });
+
+      it("canReach returns true for a reachable target", async () => {
+        const store = context.getStore();
+        const reaches = await store.algorithms.canReach(
+          ids.aliceId,
+          ids.eveId,
+          { edges: ["knows"] },
+        );
+        expect(reaches).toBe(true);
+      });
+
+      it("canReach returns false when no path exists", async () => {
+        const store = context.getStore();
+        const reaches = await store.algorithms.canReach(
+          ids.eveId,
+          ids.aliceId,
+          { edges: ["knows"] },
+        );
+        expect(reaches).toBe(false);
+      });
+
+      it("neighbors returns the 1-hop neighborhood, source excluded", async () => {
+        const store = context.getStore();
+        const neighbors = await store.algorithms.neighbors(ids.aliceId, {
+          edges: ["knows"],
+        });
+        const neighborIds = neighbors.map((n) => n.id).toSorted();
+        expect(neighborIds).toEqual([ids.bobId, ids.charlieId].toSorted());
+      });
+
+      it("degree counts outgoing edges", async () => {
+        const store = context.getStore();
+        const degree = await store.algorithms.degree(ids.aliceId, {
+          edges: ["knows"],
+          direction: "out",
+        });
+        expect(degree).toBe(2);
+      });
+
+      it("degree counts edges in both directions (undirected)", async () => {
+        const store = context.getStore();
+        const degree = await store.algorithms.degree(ids.bobId, {
+          edges: ["knows"],
+          direction: "both",
+        });
+        // Alice→Bob (incoming), Bob→Charlie (outgoing)
+        expect(degree).toBe(2);
+      });
+    });
+
+    describe("temporal behavior", () => {
+      const { BEFORE } = TEMPORAL_ANCHORS;
+      let ids: TemporalFixture;
+
+      beforeEach(async () => {
+        const store = context.getStore();
+        ids = await seedTemporalGraph(store);
+      });
+
+      it("reachable defaults to current mode", async () => {
+        const store = context.getStore();
+        const reached = await store.algorithms.reachable(ids.rootId, {
+          edges: ["knows"],
+          excludeSource: true,
+        });
+        const reachedIds = reached.map((r) => r.id).toSorted();
+        expect(reachedIds).toEqual([ids.activeId].toSorted());
+      });
+
+      it("reachable under asOf surfaces historically-valid rows", async () => {
+        const store = context.getStore();
+        const reached = await store.algorithms.reachable(ids.rootId, {
+          edges: ["knows"],
+          excludeSource: true,
+          temporalMode: "asOf",
+          asOf: BEFORE,
+        });
+        const reachedIds = reached.map((r) => r.id);
+        expect(reachedIds).toContain(ids.activeId);
+        expect(reachedIds).toContain(ids.endedId);
+        expect(reachedIds).not.toContain(ids.futureId);
+      });
+
+      it("reachable under includeEnded includes validity-ended nodes and edges", async () => {
+        const store = context.getStore();
+        const reached = await store.algorithms.reachable(ids.rootId, {
+          edges: ["knows"],
+          excludeSource: true,
+          temporalMode: "includeEnded",
+        });
+        const reachedIds = reached.map((r) => r.id).toSorted();
+        expect(reachedIds).toEqual(
+          [ids.activeId, ids.endedId, ids.futureId].toSorted(),
+        );
+      });
+
+      it("shortestPath under asOf traverses the historical edge", async () => {
+        const store = context.getStore();
+        const path = await store.algorithms.shortestPath(
+          ids.rootId,
+          ids.endedId,
+          { edges: ["knows"], temporalMode: "asOf", asOf: BEFORE },
+        );
+        expect(path?.depth).toBe(1);
+        expect(path?.nodes.at(-1)?.id).toBe(ids.endedId);
+      });
+
+      it("canReach self-path honors the resolved temporal filter", async () => {
+        const store = context.getStore();
+        // Future node is not visible under current mode — canReach(a, a)
+        // should return false, matching shortestPath(a, a).
+        const currentSelf = await store.algorithms.canReach(
+          ids.futureId,
+          ids.futureId,
+          { edges: ["knows"] },
+        );
+        expect(currentSelf).toBe(false);
+
+        const endedSelf = await store.algorithms.canReach(
+          ids.futureId,
+          ids.futureId,
+          { edges: ["knows"], temporalMode: "includeEnded" },
+        );
+        expect(endedSelf).toBe(true);
+      });
+
+      it("degree honors temporalMode for the edge count", async () => {
+        const store = context.getStore();
+        // Current mode excludes only the expired root→ended edge. The
+        // root→future edge (no explicit validFrom) defaults to "now" at
+        // creation, so it's already valid.
+        const current = await store.algorithms.degree(ids.rootId, {
+          edges: ["knows"],
+          direction: "out",
+        });
+        expect(current).toBe(2);
+
+        // includeEnded lifts the validity filter and counts all three edges.
+        const ended = await store.algorithms.degree(ids.rootId, {
+          edges: ["knows"],
+          direction: "out",
+          temporalMode: "includeEnded",
+        });
+        expect(ended).toBe(3);
+      });
+
+      it("rejects temporalMode: 'asOf' without asOf timestamp", async () => {
+        const store = context.getStore();
+        await expect(
+          store.algorithms.reachable(ids.rootId, {
+            edges: ["knows"],
+            temporalMode: "asOf",
+          }),
+        ).rejects.toThrow(/asOf/);
+      });
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -1,4 +1,5 @@
 export { registerAggregateIntegrationTests } from "./aggregates";
+export { registerAlgorithmIntegrationTests } from "./algorithms";
 export { registerCrossBackendConsistencyTests } from "./cross-backend";
 export { registerEdgeCaseIntegrationTests } from "./edge-cases";
 export { registerEdgeOperationIntegrationTests } from "./edge-operations";

--- a/packages/typegraph/tests/examples.test.ts
+++ b/packages/typegraph/tests/examples.test.ts
@@ -18,6 +18,7 @@ import { main as deleteBehaviors } from "../examples/07-delete-behaviors";
 import { main as customOntology } from "../examples/08-custom-ontology";
 import { main as paginationStreaming } from "../examples/09-pagination-streaming";
 import { main as semanticSearch } from "../examples/11-semantic-search";
+import { main as researchCopilot } from "../examples/14-research-copilot";
 
 // Note: 10-postgresql.ts is excluded - it requires an external PostgreSQL database
 
@@ -32,6 +33,7 @@ const EXAMPLES = [
   { name: "08-custom-ontology", main: customOntology },
   { name: "09-pagination-streaming", main: paginationStreaming },
   { name: "11-semantic-search", main: semanticSearch },
+  { name: "14-research-copilot", main: researchCopilot },
 ] as const;
 
 describe("examples", () => {

--- a/packages/typegraph/tests/subgraph.test.ts
+++ b/packages/typegraph/tests/subgraph.test.ts
@@ -24,7 +24,11 @@ import {
 import type { GraphBackend } from "../src/backend/types";
 import type { NodeId } from "../src/core/types";
 import { createStore, type Store } from "../src/store";
-import { collectAllEdges, createTestBackend } from "./test-utils";
+import {
+  collectAllEdges,
+  createTestBackend,
+  TEMPORAL_ANCHORS,
+} from "./test-utils";
 
 // ============================================================
 // Test Schema
@@ -1168,5 +1172,207 @@ describe("store.subgraph()", () => {
         }
       }
     });
+  });
+});
+
+// ============================================================
+// Temporal Behavior
+// ============================================================
+//
+// subgraph() honors graph.defaults.temporalMode with per-call overrides.
+
+describe("store.subgraph temporal behavior", () => {
+  const { PAST, BEFORE, EDGE_ENDED, FUTURE } = TEMPORAL_ANCHORS;
+
+  type TemporalFixture = Readonly<{
+    runId: string;
+    activeTaskId: string;
+    endedTaskId: string;
+    futureTaskId: string;
+    tombstoneTaskId: string;
+    futureEdgeTargetId: string;
+  }>;
+
+  let backend: GraphBackend;
+  let store: Store<TestGraph>;
+  let ids: TemporalFixture;
+
+  beforeEach(async () => {
+    backend = createTestBackend();
+    store = createStore(testGraph, backend);
+
+    const [run, active, ended, future, tombstone, futureEdgeTarget] =
+      await Promise.all([
+        store.nodes.Run.create({ name: "r" }, { validFrom: PAST }),
+        store.nodes.Task.create(
+          { title: "active", status: "ok" },
+          { validFrom: PAST },
+        ),
+        store.nodes.Task.create(
+          { title: "ended", status: "done" },
+          { validFrom: PAST, validTo: EDGE_ENDED },
+        ),
+        store.nodes.Task.create(
+          { title: "future", status: "pending" },
+          { validFrom: FUTURE },
+        ),
+        store.nodes.Task.create(
+          { title: "tombstone", status: "done" },
+          { validFrom: PAST },
+        ),
+        // Currently-valid target node; we'll attach a future-only edge to it
+        // below to exercise the edge-validity path independent of node validity.
+        store.nodes.Task.create(
+          { title: "futureEdgeTarget", status: "ok" },
+          { validFrom: PAST },
+        ),
+      ]);
+
+    // Always-valid, ended, and node-future-only edges.
+    await Promise.all([
+      store.edges.has_task.create(run, active, {}, { validFrom: PAST }),
+      store.edges.has_task.create(
+        run,
+        ended,
+        {},
+        { validFrom: PAST, validTo: EDGE_ENDED },
+      ),
+      store.edges.has_task.create(run, future, {}),
+      // Edge has validFrom = FUTURE but target node is currently valid.
+      // Distinguishes edge-level validity from node-level validity.
+      store.edges.has_task.create(
+        run,
+        futureEdgeTarget,
+        {},
+        { validFrom: FUTURE },
+      ),
+    ]);
+
+    // Tombstone setup: create edge → delete edge → delete node so both
+    // the edge and the target surface only under includeTombstones.
+    const tombstoneEdge = await store.edges.has_task.create(
+      run,
+      tombstone,
+      {},
+      { validFrom: PAST },
+    );
+    await store.edges.has_task.delete(tombstoneEdge.id);
+    await store.nodes.Task.delete(tombstone.id);
+
+    ids = {
+      runId: run.id,
+      activeTaskId: active.id,
+      endedTaskId: ended.id,
+      futureTaskId: future.id,
+      tombstoneTaskId: tombstone.id,
+      futureEdgeTargetId: futureEdgeTarget.id,
+    };
+  });
+
+  it("defaults to current mode — excludes ended and future entities", async () => {
+    const result = await store.subgraph(ids.runId as never, {
+      edges: ["has_task"],
+      maxDepth: 1,
+    });
+
+    expect(result.nodes.has(ids.activeTaskId)).toBe(true);
+    expect(result.nodes.has(ids.endedTaskId)).toBe(false);
+    expect(result.nodes.has(ids.futureTaskId)).toBe(false);
+  });
+
+  it("asOf = BEFORE surfaces the historically-valid task and edge", async () => {
+    const result = await store.subgraph(ids.runId as never, {
+      edges: ["has_task"],
+      maxDepth: 1,
+      temporalMode: "asOf",
+      asOf: BEFORE,
+    });
+
+    // Active and ended were both valid at BEFORE; future was not.
+    expect(result.nodes.has(ids.activeTaskId)).toBe(true);
+    expect(result.nodes.has(ids.endedTaskId)).toBe(true);
+    expect(result.nodes.has(ids.futureTaskId)).toBe(false);
+  });
+
+  it("includeEnded traverses through validity-ended rows", async () => {
+    const result = await store.subgraph(ids.runId as never, {
+      edges: ["has_task"],
+      maxDepth: 1,
+      temporalMode: "includeEnded",
+    });
+
+    // Ended rows surface; deleted tombstone does not.
+    expect(result.nodes.has(ids.activeTaskId)).toBe(true);
+    expect(result.nodes.has(ids.endedTaskId)).toBe(true);
+    expect(result.nodes.has(ids.futureTaskId)).toBe(true);
+    expect(result.nodes.has(ids.tombstoneTaskId)).toBe(false);
+  });
+
+  it("includeTombstones surfaces soft-deleted nodes and edges", async () => {
+    const result = await store.subgraph(ids.runId as never, {
+      edges: ["has_task"],
+      maxDepth: 1,
+      temporalMode: "includeTombstones",
+    });
+
+    // Everything shows up under includeTombstones.
+    expect(result.nodes.has(ids.activeTaskId)).toBe(true);
+    expect(result.nodes.has(ids.endedTaskId)).toBe(true);
+    expect(result.nodes.has(ids.futureTaskId)).toBe(true);
+    expect(result.nodes.has(ids.tombstoneTaskId)).toBe(true);
+    expect(result.nodes.has(ids.futureEdgeTargetId)).toBe(true);
+  });
+
+  it("excludes edges with future validFrom under current mode", async () => {
+    // The edge run→futureEdgeTarget has validFrom: FUTURE even though the
+    // target node is currently valid. Under current mode, neither the edge
+    // nor (therefore) the target should appear in the traversal result.
+    const result = await store.subgraph(ids.runId as never, {
+      edges: ["has_task"],
+      maxDepth: 1,
+    });
+    expect(result.nodes.has(ids.futureEdgeTargetId)).toBe(false);
+  });
+
+  it("surfaces edges with future validFrom under includeEnded", async () => {
+    // `includeEnded` only filters `deleted_at IS NULL` — it ignores both
+    // ends of the validity window, so future-valid edges participate too.
+    const result = await store.subgraph(ids.runId as never, {
+      edges: ["has_task"],
+      maxDepth: 1,
+      temporalMode: "includeEnded",
+    });
+    expect(result.nodes.has(ids.futureEdgeTargetId)).toBe(true);
+  });
+
+  it("respects graph.defaults.temporalMode when no per-call override", async () => {
+    const endedDefaultsGraph = defineGraph({
+      id: "subgraph_temporal_ended_defaults",
+      nodes: { Run: { type: Run }, Task: { type: Task } },
+      edges: { has_task: { type: hasTask, from: [Run], to: [Task] } },
+      defaults: { temporalMode: "includeEnded" },
+    });
+    const altStore = createStore(endedDefaultsGraph, createTestBackend());
+
+    const [run, ended] = await Promise.all([
+      altStore.nodes.Run.create({ name: "r" }, { validFrom: PAST }),
+      altStore.nodes.Task.create(
+        { title: "ended", status: "done" },
+        { validFrom: PAST, validTo: EDGE_ENDED },
+      ),
+    ]);
+    await altStore.edges.has_task.create(
+      run,
+      ended,
+      {},
+      { validFrom: PAST, validTo: EDGE_ENDED },
+    );
+
+    // No per-call override — graph's includeEnded default applies.
+    const result = await altStore.subgraph(run.id as never, {
+      edges: ["has_task"],
+      maxDepth: 1,
+    });
+    expect(result.nodes.has(ended.id as string)).toBe(true);
   });
 });

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -59,3 +59,17 @@ export function collectAllEdges<E>(
   }
   return edges;
 }
+
+/**
+ * Shared time anchors for temporal-behavior tests.
+ *
+ * Use these to build fixtures that exercise `temporalMode` / `asOf` across
+ * the store. Spacing between anchors is intentional so individual tests can
+ * assert snapshot boundaries without coordinating timestamps.
+ */
+export const TEMPORAL_ANCHORS = {
+  PAST: "2020-01-01T00:00:00.000Z",
+  BEFORE: "2021-01-01T00:00:00.000Z",
+  EDGE_ENDED: "2022-01-01T00:00:00.000Z",
+  FUTURE: "2030-01-01T00:00:00.000Z",
+} as const;

--- a/packages/typegraph/type-smoke/consumer.ts
+++ b/packages/typegraph/type-smoke/consumer.ts
@@ -5,8 +5,13 @@ import {
   type EdgeId,
   getEdgeKinds,
   getNodeKinds,
+  type NodeId,
+  type NodeIdentifier,
   type NodeRef,
+  type PathNode,
+  type ReachableNode,
   type Store,
+  type TemporalAlgorithmOptions,
 } from "@nicia-ai/typegraph";
 import type { SqliteTables } from "@nicia-ai/typegraph/sqlite";
 import { z } from "zod";
@@ -96,3 +101,71 @@ void store.edges.knows.getById(worksAtId);
 void store.nodes.Project.findByConstraint("title_unique", {
   title: "Launch Plan",
 });
+
+// --- Graph algorithms: public surface shape checks ---
+
+declare const aliceId: string;
+declare const bobId: string;
+declare const aliceNodeId: NodeId<typeof Person>;
+declare const aliceNode: Awaited<ReturnType<typeof store.nodes.Person.getById>>;
+declare const reachableRow: ReachableNode;
+declare const pathNode: PathNode;
+
+// NodeIdentifier accepts bare strings, Node instances, and any {id} shape.
+const stringIdent: NodeIdentifier = aliceId;
+const objectIdent: NodeIdentifier = { id: aliceId };
+const reachableIdent: NodeIdentifier = reachableRow;
+const pathIdent: NodeIdentifier = pathNode;
+void stringIdent;
+void objectIdent;
+void reachableIdent;
+void pathIdent;
+
+// Every algorithm compiles with bare IDs, object identifiers, and Node values.
+void store.algorithms.shortestPath(aliceId, bobId, { edges: ["knows"] });
+void store.algorithms.shortestPath(
+  aliceNode ?? aliceId,
+  { id: bobId },
+  { edges: ["knows"], maxHops: 10, direction: "both", cyclePolicy: "allow" },
+);
+void store.algorithms.reachable(aliceId, { edges: ["knows"] });
+void store.algorithms.canReach(aliceId, bobId, { edges: ["knows"] });
+void store.algorithms.neighbors(aliceId, { edges: ["knows"], depth: 2 });
+
+// Degree accepts an options-less call and a specific edge-kind selection.
+void store.algorithms.degree(aliceId);
+void store.algorithms.degree(aliceId, { edges: ["knows"] });
+void store.algorithms.degree(aliceId, {});
+
+// TemporalAlgorithmOptions composes into every algorithm's option type.
+const temporal: TemporalAlgorithmOptions = {
+  temporalMode: "asOf",
+  asOf: "2024-01-01T00:00:00Z",
+};
+void store.algorithms.shortestPath(aliceId, bobId, {
+  edges: ["knows"],
+  ...temporal,
+});
+void store.algorithms.reachable(aliceId, { edges: ["knows"], ...temporal });
+void store.algorithms.neighbors(aliceId, { edges: ["knows"], ...temporal });
+void store.algorithms.degree(aliceId, { ...temporal });
+
+// Subgraph also accepts the temporal options (requires a branded NodeId).
+void store.subgraph(aliceNodeId, {
+  edges: ["knows"],
+  temporalMode: "includeEnded",
+});
+
+// --- Negative cases (must fail compile) ---
+
+// @ts-expect-error - "not_a_kind" isn't a registered edge kind
+void store.algorithms.reachable(aliceId, { edges: ["not_a_kind"] });
+
+void store.algorithms.reachable(aliceId, {
+  edges: ["knows"],
+  // @ts-expect-error - temporalMode literal must be a known TemporalMode
+  temporalMode: "bogus_mode",
+});
+
+// @ts-expect-error - subgraph edge kind must be registered on the graph
+void store.subgraph(aliceNodeId, { edges: ["not_a_kind"] });


### PR DESCRIPTION
- Adds **`store.algorithms.*`** with `shortestPath`, `reachable`, `canReach`, `neighbors`, and `degree` as a lazily-built facade on `Store`. All traversal algorithms compile to a single recursive-CTE query that shares the dialect's path-tracking primitives with `.recursive()` and `store.subgraph()`, so SQLite and PostgreSQL have identical semantics.
- Threads `temporalMode` / `asOf` through every algorithm and through `store.subgraph()`, defaulting to `graph.defaults.temporalMode`. Algorithms and subgraph previously used hardcoded filters (algorithms: `deleted_at IS NULL`; subgraph: effectively `"includeEnded"`) that diverged from `store.query()` and the collection APIs.
- Consolidates `buildReachableCte` into `src/store/recursive-cte.ts` (shared between algorithms and subgraph), aliases `AlgorithmCyclePolicy` to `RecursiveCyclePolicy`, and adds a `resolveTemporalOptions` helper to collapse duplicated fallback logic across call sites.
- **BREAKING:** `store.subgraph()` now follows `graph.defaults.temporalMode` (typically `"current"`) instead of hardcoded soft-delete-only filtering. Callers that relied on walking through validity-ended rows must pass `temporalMode: "includeEnded"` explicitly. Soft-delete handling under the default `"current"` mode is unchanged.
- Removes the `executeCanReach` self-path short-circuit so `canReach(a, a)` honors the temporal filter and matches `shortestPath(a, a)` when `a` isn't visible under the resolved mode.

## Docs

- New `/graph-algorithms` page with Shared Options table, per-algorithm reference, and a Temporal Behavior section.
- `schemas-stores.md` updated for the new subgraph options and algorithm quick-reference.
- `queries/temporal.md` cross-references the expanded surface.
- `14-research-copilot.ts` showcase example demonstrating all five algorithms alongside semantic search and ontology-expanded topic matching.
