### PR TITLE
fix: use dialect currentTimestamp in algorithm and subgraph temporal filters

### DIFF
--- a/.changeset/sqlite-current-timestamp-temporal.md
+++ b/.changeset/sqlite-current-timestamp-temporal.md
@@ -1,0 +1,19 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix SQLite temporal filter timestamp format in graph algorithms and subgraph.
+
+`buildReachableCte`, `resolveTemporalFilter`, and `fetchSubgraphEdges` compiled
+temporal filters without passing `dialect.currentTimestamp()`, so on SQLite they
+fell back to raw `CURRENT_TIMESTAMP` (`YYYY-MM-DD HH:MM:SS`). Stored
+`valid_from` / `valid_to` use ISO-8601 (`YYYY-MM-DDTHH:MM:SS.sssZ`), and because
+`T` sorts above space, same-day ISO timestamps compare incorrectly against raw
+`CURRENT_TIMESTAMP`. Under `temporalMode: "current"` this caused
+`reachable` / `canReach` / `neighbors` / `shortestPath` / `degree` and the
+`subgraph` edge hydration to misclassify rows whose `valid_from` or `valid_to`
+fell on today's date, disagreeing with `store.query()` and collection reads.
+
+All three call sites now inject the dialect-specific current timestamp
+(`strftime('%Y-%m-%dT%H:%M:%fZ','now')` on SQLite, `NOW()` on PostgreSQL),
+matching the query compiler.

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -64,6 +64,7 @@ export function resolveTemporalFilter(
     mode: resolved.temporalMode,
     asOf: resolved.asOf,
     tableAlias,
+    currentTimestamp: ctx.dialect.currentTimestamp(),
   };
   return compileTemporalFilter(filterOptions);
 }

--- a/packages/typegraph/src/store/recursive-cte.ts
+++ b/packages/typegraph/src/store/recursive-cte.ts
@@ -34,15 +34,18 @@ export function buildReachableCte(options: BuildReachableCteOptions): SQL {
     sql.raw("e.kind"),
     options.edgeKinds,
   );
+  const currentTimestamp = options.dialect.currentTimestamp();
   const nodeTemporalFilter = compileTemporalFilter({
     mode: options.temporalMode,
     asOf: options.asOf,
     tableAlias: "n",
+    currentTimestamp,
   });
   const edgeTemporalFilter = compileTemporalFilter({
     mode: options.temporalMode,
     asOf: options.asOf,
     tableAlias: "e",
+    currentTimestamp,
   });
 
   const initialPath =

--- a/packages/typegraph/src/store/subgraph.ts
+++ b/packages/typegraph/src/store/subgraph.ts
@@ -717,6 +717,7 @@ async function fetchSubgraphEdges(
     mode: ctx.temporalMode,
     asOf: ctx.asOf,
     tableAlias: "e",
+    currentTimestamp: ctx.dialect.currentTimestamp(),
   });
   const columns: SQL[] = [
     sql`e.id`,

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -13,7 +13,11 @@ import type { GraphBackend } from "../src/backend/types";
 import type { NodeId } from "../src/core/types";
 import { ConfigurationError } from "../src/errors";
 import { createStore, type Store } from "../src/store";
-import { createTestBackend, TEMPORAL_ANCHORS } from "./test-utils";
+import {
+  collectAllEdges,
+  createTestBackend,
+  TEMPORAL_ANCHORS,
+} from "./test-utils";
 
 // ============================================================
 // Test Schema
@@ -938,6 +942,95 @@ describe("store.algorithms temporal behavior", () => {
           temporalMode: "asOf",
         }),
       ).rejects.toThrow(/asOf/);
+    });
+  });
+
+  // Regression: SQLite's raw `CURRENT_TIMESTAMP` returns `YYYY-MM-DD HH:MM:SS`,
+  // while `valid_from` / `valid_to` are stored as ISO-8601 (`YYYY-MM-DDTHH:MM:SS.sssZ`).
+  // Because `T` > space lexicographically, same-day ISO timestamps sort *above*
+  // raw `CURRENT_TIMESTAMP`, so `valid_from <= CURRENT_TIMESTAMP` is spuriously
+  // false for rows that started earlier today. Every current-mode path must
+  // use the dialect's ISO-aligned timestamp instead.
+  describe("same-day current-mode boundary (SQLite format regression)", () => {
+    it("includes rows whose valid_from is earlier today across all algorithms", async () => {
+      const freshBackend = createTestBackend();
+      const freshStore = createStore(testGraph, freshBackend);
+
+      const recentValidFrom = new Date(Date.now() - 60_000).toISOString();
+      const [alice, bob] = await Promise.all([
+        freshStore.nodes.Person.create(
+          { name: "Alice" },
+          { validFrom: recentValidFrom },
+        ),
+        freshStore.nodes.Person.create(
+          { name: "Bob" },
+          { validFrom: recentValidFrom },
+        ),
+      ]);
+      await freshStore.edges.knows.create(
+        alice,
+        bob,
+        {},
+        { validFrom: recentValidFrom },
+      );
+
+      // buildReachableCte: reachable/canReach/neighbors/shortestPath all share
+      // the same CTE — one assertion exercises the recursive path.
+      const reached = await freshStore.algorithms.reachable(alice.id, {
+        edges: ["knows"],
+        excludeSource: true,
+      });
+      expect(reached.map((row) => row.id)).toContain(bob.id);
+
+      // resolveTemporalFilter: shortestPath(a, a) fast path.
+      const selfPath = await freshStore.algorithms.shortestPath(
+        alice.id,
+        alice.id,
+        { edges: ["knows"] },
+      );
+      expect(selfPath?.nodes[0]?.id).toBe(alice.id);
+
+      // resolveTemporalFilter: degree scans the edges table directly.
+      const outDegree = await freshStore.algorithms.degree(alice.id, {
+        edges: ["knows"],
+        direction: "out",
+      });
+      expect(outDegree).toBe(1);
+
+      // fetchSubgraphEdges: subgraph hydrates edges via compileTemporalFilter.
+      const sub = await freshStore.subgraph(alice.id, { edges: ["knows"] });
+      expect(collectAllEdges(sub.adjacency)).toHaveLength(1);
+    });
+
+    it("excludes rows whose valid_to was earlier today", async () => {
+      const freshBackend = createTestBackend();
+      const freshStore = createStore(testGraph, freshBackend);
+
+      const now = Date.now();
+      const earlierToday = new Date(now - 60_000).toISOString();
+      const muchEarlierToday = new Date(now - 120_000).toISOString();
+      const [alice, bob] = await Promise.all([
+        freshStore.nodes.Person.create({ name: "Alice" }),
+        freshStore.nodes.Person.create({ name: "Bob" }),
+      ]);
+      await freshStore.edges.knows.create(
+        alice,
+        bob,
+        {},
+        { validFrom: muchEarlierToday, validTo: earlierToday },
+      );
+
+      const reached = await freshStore.algorithms.reachable(alice.id, {
+        edges: ["knows"],
+        excludeSource: true,
+      });
+      expect(reached.map((row) => row.id)).not.toContain(bob.id);
+
+      const outDegree = await freshStore.algorithms.degree(alice.id, {
+        edges: ["knows"],
+        direction: "out",
+      });
+      expect(outDegree).toBe(0);
     });
   });
 


### PR DESCRIPTION
Fixes two P1 post-merge review findings against the Tier 1 graph algorithms
branch (#85) before we cut a release.

- `buildReachableCte`, `resolveTemporalFilter`, and `fetchSubgraphEdges`
  compiled temporal filters without a dialect-specific current timestamp.
- On SQLite, that meant falling back to raw `CURRENT_TIMESTAMP`
  (`YYYY-MM-DD HH:MM:SS`) while `valid_from` / `valid_to` are stored as
  ISO-8601 (`YYYY-MM-DDTHH:MM:SS.sssZ`).
- `'T' > ' '` lexicographically, so same-day ISO timestamps sort above raw
  `CURRENT_TIMESTAMP`, causing `reachable` / `canReach` / `neighbors` /
  `shortestPath` / `degree` and `subgraph` edge hydration to misclassify rows
  whose validity window fell on today's date — disagreeing with
  `store.query()` and collection reads under `temporalMode: "current"`.
- All three call sites now inject `ctx.dialect.currentTimestamp()`
  (`strftime('%Y-%m-%dT%H:%M:%fZ','now')` on SQLite, `NOW()` on PostgreSQL),
  matching how the query compiler already threads timestamps through.

Added a same-day-boundary regression test that fails on pre-fix code and
exercises every affected entry point: `reachable`, `shortestPath` self-path,
`degree`, and `subgraph`.