### PR TITLE
docs: add research copilot example and modernize existing examples

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -79,6 +79,10 @@ const sidebar = [
     label: "Examples",
     items: [
       {
+        label: "Research Copilot",
+        slug: "examples/research-copilot",
+      },
+      {
         label: "Knowledge Graph for RAG",
         slug: "examples/knowledge-graph-rag",
       },

--- a/apps/docs/src/content/docs/examples/audit-trail.md
+++ b/apps/docs/src/content/docs/examples/audit-trail.md
@@ -85,8 +85,28 @@ const hasSession = defineEdge("hasSession");
 const graph = defineGraph({
   id: "audit_trail",
   nodes: {
-    Setting: { type: Setting },
-    User: { type: User },
+    Setting: {
+      type: Setting,
+      unique: [
+        {
+          name: "setting_key",
+          fields: ["key"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    User: {
+      type: User,
+      unique: [
+        {
+          name: "user_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
     AuditEntry: { type: AuditEntry },
     Session: { type: Session },
   },

--- a/apps/docs/src/content/docs/examples/document-management.md
+++ b/apps/docs/src/content/docs/examples/document-management.md
@@ -87,9 +87,29 @@ const graph = defineGraph({
   id: "document_management",
   nodes: {
     Content: { type: Content },
-    Folder: { type: Folder },
+    Folder: {
+      type: Folder,
+      unique: [
+        {
+          name: "folder_path",
+          fields: ["path"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
     Document: { type: Document },
-    User: { type: User },
+    User: {
+      type: User,
+      unique: [
+        {
+          name: "user_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
     Permission: { type: Permission },
   },
   edges: {
@@ -142,28 +162,23 @@ async function createFolderPath(path: string, userId: string): Promise<Node<type
   for (const part of parts) {
     currentPath += `/${part}`;
 
-    // Check if folder exists
-    let folder = await store
-      .query()
-      .from("Folder", "f")
-      .whereNode("f", (f) => f.path.eq(currentPath))
-      .select((ctx) => ctx.f)
-      .first();
-
-    if (!folder) {
-      folder = await store.nodes.Folder.create({
+    // The `folder_path` unique constraint makes this atomic: concurrent
+    // callers converge on one folder instead of racing to create duplicates.
+    const result = await store.nodes.Folder.getOrCreateByConstraint(
+      "folder_path",
+      {
         title: part,
         path: currentPath,
         createdBy: userId,
         status: "published",
-      });
+      },
+    );
 
-      if (parentFolder) {
-        await store.edges.contains.create(parentFolder, folder, {});
-      }
+    if (result.action === "created" && parentFolder) {
+      await store.edges.contains.create(parentFolder, result.node, {});
     }
 
-    parentFolder = folder;
+    parentFolder = result.node;
   }
 
   return parentFolder!;
@@ -535,25 +550,40 @@ async function getFolderContents(folderId: string): Promise<FolderContents> {
 
 ### Get Breadcrumb Path
 
+`store.algorithms.reachable` walks `contains` edges in reverse to collect
+every ancestor folder, tagged with its depth from the starting content:
+
 ```typescript
 async function getBreadcrumb(
   contentId: string
 ): Promise<Array<{ id: string; title: string; path: string }>> {
-  return store
-    .query()
-    .from("Content", "c", { includeSubClasses: true })
-    .whereNode("c", (c) => c.id.eq(contentId))
-    .traverse("contains", "e", { direction: "in" })
-    .recursive()
-    .to("Folder", "ancestor")
-    .select((ctx) => ({
-      id: ctx.ancestor.id,
-      title: ctx.ancestor.title,
-      path: ctx.ancestor.path,
-    }))
-    .execute();
+  const ancestors = await store.algorithms.reachable(contentId, {
+    edges: ["contains"],
+    direction: "in",
+    excludeSource: true,
+  });
+
+  if (ancestors.length === 0) return [];
+
+  const folderIds = ancestors
+    .filter((node) => node.kind === "Folder")
+    .toSorted((a, b) => b.depth - a.depth) // root first
+    .map((node) => node.id);
+
+  const folders = await store.nodes.Folder.getByIds(folderIds);
+  return folders
+    .filter((folder): folder is NonNullable<typeof folder> => folder !== undefined)
+    .map((folder) => ({
+      id: folder.id,
+      title: folder.title,
+      path: folder.path,
+    }));
 }
 ```
+
+`reachable` returns `{ id, kind, depth }` — one recursive-CTE query returns
+the full ancestor chain, then a single batched `getByIds` hydrates the folder
+properties.
 
 ## Bulk Operations
 

--- a/apps/docs/src/content/docs/examples/multi-tenant.md
+++ b/apps/docs/src/content/docs/examples/multi-tenant.md
@@ -78,10 +78,33 @@ const memberOf = defineEdge("memberOf");
 const graph = defineGraph({
   id: "multi_tenant",
   nodes: {
-    Tenant: { type: Tenant },
+    Tenant: {
+      type: Tenant,
+      unique: [
+        {
+          name: "tenant_slug",
+          fields: ["slug"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
     Project: { type: Project },
     Task: { type: Task },
-    User: { type: User },
+    User: {
+      type: User,
+      unique: [
+        // Emails are scoped per tenant in the shared-tables strategy: the
+        // same address can be a member of more than one tenant, but not
+        // twice in the same one.
+        {
+          name: "user_tenant_email",
+          fields: ["tenantId", "email"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
   },
   edges: {
     hasProject: { type: hasProject, from: [Tenant], to: [Project] },
@@ -235,37 +258,33 @@ async function provisionTenant(
   plan: "free" | "starter" | "pro" | "enterprise" = "free"
 ): Promise<{ tenant: Node<typeof Tenant>; owner: Node<typeof User> }> {
   return store.transaction(async (tx) => {
-    // Check slug uniqueness
-    const existing = await tx
-      .query()
-      .from("Tenant", "t")
-      .whereNode("t", (t) => t.slug.eq(slug))
-      .first();
+    // Atomic uniqueness check — the `tenant_slug` constraint guarantees
+    // concurrent callers can't both succeed.
+    const tenantResult = await tx.nodes.Tenant.getOrCreateByConstraint(
+      "tenant_slug",
+      {
+        slug,
+        name,
+        plan,
+        status: "active",
+        createdAt: new Date().toISOString(),
+      },
+    );
 
-    if (existing) {
+    if (tenantResult.action !== "created") {
       throw new Error("Tenant slug already exists");
     }
 
-    // Create tenant
-    const tenant = await tx.nodes.Tenant.create({
-      slug,
-      name,
-      plan,
-      status: "active",
-      createdAt: new Date().toISOString(),
-    });
-
-    // Create owner user
     const owner = await tx.nodes.User.create({
-      tenantId: tenant.id,
+      tenantId: tenantResult.node.id,
       email: ownerEmail,
       name: ownerName,
       role: "owner",
     });
 
-    await tx.edges.memberOf.create(owner, tenant, {});
+    await tx.edges.memberOf.create(owner, tenantResult.node, {});
 
-    return { tenant, owner };
+    return { tenant: tenantResult.node, owner };
   });
 }
 ```

--- a/apps/docs/src/content/docs/examples/product-catalog.md
+++ b/apps/docs/src/content/docs/examples/product-catalog.md
@@ -96,10 +96,50 @@ const relatedProduct = defineEdge("relatedProduct", {
 const graph = defineGraph({
   id: "product_catalog",
   nodes: {
-    Category: { type: Category },
-    Product: { type: Product },
-    Variant: { type: Variant },
-    Warehouse: { type: Warehouse },
+    Category: {
+      type: Category,
+      unique: [
+        {
+          name: "category_slug",
+          fields: ["slug"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Product: {
+      type: Product,
+      unique: [
+        {
+          name: "product_sku",
+          fields: ["sku"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Variant: {
+      type: Variant,
+      unique: [
+        {
+          name: "variant_sku",
+          fields: ["sku"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Warehouse: {
+      type: Warehouse,
+      unique: [
+        {
+          name: "warehouse_code",
+          fields: ["code"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
     Inventory: { type: Inventory },
   },
   edges: {
@@ -128,26 +168,22 @@ async function createCategory(
   slug: string,
   parentSlug?: string
 ): Promise<Node<typeof Category>> {
-  const category = await store.nodes.Category.create({
-    name,
-    slug,
-    isActive: true,
-  });
+  const result = await store.nodes.Category.getOrCreateByConstraint(
+    "category_slug",
+    { name, slug, isActive: true },
+  );
 
-  if (parentSlug) {
-    const parent = await store
-      .query()
-      .from("Category", "c")
-      .whereNode("c", (c) => c.slug.eq(parentSlug))
-      .select((ctx) => ctx.c)
-      .first();
-
+  if (result.action === "created" && parentSlug) {
+    const parent = await store.nodes.Category.findByConstraint(
+      "category_slug",
+      { slug: parentSlug },
+    );
     if (parent) {
-      await store.edges.parentCategory.create(category, parent, {});
+      await store.edges.parentCategory.create(result.node, parent, {});
     }
   }
 
-  return category;
+  return result.node;
 }
 
 // Build initial category structure
@@ -169,35 +205,33 @@ interface CategoryWithPath {
 }
 
 async function getCategoryWithPath(slug: string): Promise<CategoryWithPath | undefined> {
-  const category = await store
-    .query()
-    .from("Category", "c")
-    .whereNode("c", (c) => c.slug.eq(slug))
-    .select((ctx) => ({
-      id: ctx.c.id,
-      name: ctx.c.name,
-      slug: ctx.c.slug,
-    }))
-    .first();
-
+  const category = await store.nodes.Category.findByConstraint(
+    "category_slug",
+    { slug },
+  );
   if (!category) return undefined;
 
-  const ancestors = await store
-    .query()
-    .from("Category", "c")
-    .whereNode("c", (c) => c.slug.eq(slug))
-    .traverse("parentCategory", "e")
-    .recursive()
-    .to("Category", "ancestor")
-    .select((ctx) => ({
-      name: ctx.ancestor.name,
-      slug: ctx.ancestor.slug,
-    }))
-    .execute();
+  // Walk `parentCategory` edges up to the root. `reachable` returns each
+  // ancestor with its depth from the starting node — sort by depth desc
+  // so the root comes first.
+  const ancestorIds = (
+    await store.algorithms.reachable(category.id, {
+      edges: ["parentCategory"],
+      excludeSource: true,
+    })
+  )
+    .toSorted((a, b) => b.depth - a.depth)
+    .map((node) => node.id);
+
+  const ancestors = await store.nodes.Category.getByIds(ancestorIds);
 
   return {
-    ...category,
-    path: ancestors.reverse(), // Root first
+    id: category.id,
+    name: category.name,
+    slug: category.slug,
+    path: ancestors
+      .filter((c): c is NonNullable<typeof c> => c !== undefined)
+      .map((c) => ({ name: c.name, slug: c.slug })),
   };
 }
 ```
@@ -209,27 +243,38 @@ async function getSubcategories(
   parentSlug: string,
   includeNested = false
 ): Promise<Array<{ id: string; name: string; slug: string; depth: number }>> {
-  let query = store
-    .query()
-    .from("Category", "parent")
-    .whereNode("parent", (c) => c.slug.eq(parentSlug))
-    .traverse("parentCategory", "e", { direction: "in" });
+  const parent = await store.nodes.Category.findByConstraint(
+    "category_slug",
+    { slug: parentSlug },
+  );
+  if (!parent) return [];
 
-  if (includeNested) {
-    query = query.recursive({ depth: "depth" });
-  }
+  // `reachable` returns descendants tagged with their depth. Cap at 1 for
+  // immediate children only, or let it run to the configured default
+  // (10 hops) for the full subtree.
+  const descendants = await store.algorithms.reachable(parent.id, {
+    edges: ["parentCategory"],
+    direction: "in",
+    excludeSource: true,
+    maxHops: includeNested ? undefined : 1,
+  });
 
-  return query
-    .to("Category", "child")
-    .whereNode("child", (c) => c.isActive.eq(true))
-    .select((ctx) => ({
-      id: ctx.child.id,
-      name: ctx.child.name,
-      slug: ctx.child.slug,
-      depth: ctx.depth ?? 1,
+  const children = (await store.nodes.Category.getByIds(
+    descendants.map((node) => node.id),
+  )).filter(
+    (category): category is NonNullable<typeof category> =>
+      category !== undefined && category.isActive,
+  );
+
+  const depthById = new Map(descendants.map((row) => [row.id, row.depth]));
+  return children
+    .map((category) => ({
+      id: category.id,
+      name: category.name,
+      slug: category.slug,
+      depth: depthById.get(category.id) ?? 1,
     }))
-    .orderBy((ctx) => ctx.child.displayOrder, "asc")
-    .execute();
+    .toSorted((a, b) => a.depth - b.depth);
 }
 ```
 
@@ -321,63 +366,57 @@ interface ProductDetails {
 }
 
 async function getProductDetails(sku: string): Promise<ProductDetails | undefined> {
-  const product = await store
-    .query()
-    .from("Product", "p")
-    .whereNode("p", (p) => p.sku.eq(sku))
-    .select((ctx) => ctx.p)
-    .first();
-
+  const product = await store.nodes.Product.findByConstraint(
+    "product_sku",
+    { sku },
+  );
   if (!product) return undefined;
 
-  // Get categories
-  const categories = await store
-    .query()
-    .from("Product", "p")
-    .whereNode("p", (p) => p.id.eq(product.id))
-    .traverse("inCategory", "e")
-    .to("Category", "c")
-    .select((ctx) => ({
-      name: ctx.c.name,
-      slug: ctx.c.slug,
-      isPrimary: ctx.e.isPrimary,
-    }))
-    .execute();
-
-  // Get variants with inventory
-  const variants = await store
-    .query()
-    .from("Product", "p")
-    .whereNode("p", (p) => p.id.eq(product.id))
-    .traverse("hasVariant", "e")
-    .to("Variant", "v")
-    .optionalTraverse("inventoryFor", "inv", { direction: "in" })
-    .to("Inventory", "i")
-    .select((ctx) => ({
-      id: ctx.v.id,
-      sku: ctx.v.sku,
-      name: ctx.v.name,
-      priceModifier: ctx.v.priceModifier,
-      attributes: ctx.v.attributes,
-      quantity: ctx.i?.quantity ?? 0,
-      reservedQuantity: ctx.i?.reservedQuantity ?? 0,
-    }))
-    .execute();
-
-  // Get related products
-  const related = await store
-    .query()
-    .from("Product", "p")
-    .whereNode("p", (p) => p.id.eq(product.id))
-    .traverse("relatedProduct", "e")
-    .to("Product", "r")
-    .select((ctx) => ({
-      id: ctx.r.id,
-      name: ctx.r.name,
-      type: ctx.e.type,
-    }))
-    .orderBy((ctx) => ctx.e.sortOrder, "asc")
-    .execute();
+  // `store.batch()` runs all three queries over a single connection with
+  // snapshot consistency — no interleaved writes between the category,
+  // variant, and related reads.
+  const [categories, variants, related] = await store.batch(
+    store
+      .query()
+      .from("Product", "p")
+      .whereNode("p", (p) => p.id.eq(product.id))
+      .traverse("inCategory", "e")
+      .to("Category", "c")
+      .select((ctx) => ({
+        name: ctx.c.name,
+        slug: ctx.c.slug,
+        isPrimary: ctx.e.isPrimary,
+      })),
+    store
+      .query()
+      .from("Product", "p")
+      .whereNode("p", (p) => p.id.eq(product.id))
+      .traverse("hasVariant", "e")
+      .to("Variant", "v")
+      .optionalTraverse("inventoryFor", "inv", { direction: "in" })
+      .to("Inventory", "i")
+      .select((ctx) => ({
+        id: ctx.v.id,
+        sku: ctx.v.sku,
+        name: ctx.v.name,
+        priceModifier: ctx.v.priceModifier,
+        attributes: ctx.v.attributes,
+        quantity: ctx.i?.quantity ?? 0,
+        reservedQuantity: ctx.i?.reservedQuantity ?? 0,
+      })),
+    store
+      .query()
+      .from("Product", "p")
+      .whereNode("p", (p) => p.id.eq(product.id))
+      .traverse("relatedProduct", "e")
+      .to("Product", "r")
+      .orderBy("e", "sortOrder", "asc")
+      .select((ctx) => ({
+        id: ctx.r.id,
+        name: ctx.r.name,
+        type: ctx.e.type,
+      })),
+  );
 
   return {
     id: product.id,
@@ -567,21 +606,22 @@ async function searchProducts(
 
   // Filter by category if specified
   if (categorySlug) {
-    // Get category and all subcategories
-    const categoryIds = await store
-      .query()
-      .from("Category", "c")
-      .whereNode("c", (c) => c.slug.eq(categorySlug))
-      .traverse("parentCategory", "e", { direction: "in" })
-      .recursive()
-      .to("Category", "sub")
-      .select((ctx) => ctx.sub.id)
-      .execute();
+    const root = await store.nodes.Category.findByConstraint(
+      "category_slug",
+      { slug: categorySlug },
+    );
+    if (!root) return [];
+
+    // Root + every descendant category (inbound traversal of parentCategory)
+    const subtree = await store.algorithms.reachable(root.id, {
+      edges: ["parentCategory"],
+      direction: "in",
+    });
 
     queryBuilder = queryBuilder
       .traverse("inCategory", "e")
       .to("Category", "c")
-      .whereNode("c", (c) => c.id.in([...categoryIds, categorySlug]));
+      .whereNode("c", (c) => c.id.in(subtree.map((node) => node.id)));
   }
 
   return queryBuilder
@@ -607,33 +647,20 @@ async function getProductsInCategory(
 ): Promise<{ products: ProductProps[]; total: number }> {
   const { includeSubcategories = true, page = 1, pageSize = 20, sortBy = "name" } = options;
 
-  // Build category ID list
-  let categoryIds: string[] = [];
+  const root = await store.nodes.Category.findByConstraint(
+    "category_slug",
+    { slug: categorySlug },
+  );
+  if (!root) return { products: [], total: 0 };
 
-  const rootCategory = await store
-    .query()
-    .from("Category", "c")
-    .whereNode("c", (c) => c.slug.eq(categorySlug))
-    .select((ctx) => ctx.c.id)
-    .first();
-
-  if (!rootCategory) return { products: [], total: 0 };
-
-  categoryIds.push(rootCategory);
-
-  if (includeSubcategories) {
-    const subIds = await store
-      .query()
-      .from("Category", "c")
-      .whereNode("c", (c) => c.slug.eq(categorySlug))
-      .traverse("parentCategory", "e", { direction: "in" })
-      .recursive()
-      .to("Category", "sub")
-      .select((ctx) => ctx.sub.id)
-      .execute();
-
-    categoryIds = [...categoryIds, ...subIds];
-  }
+  const categoryIds = includeSubcategories
+    ? (
+        await store.algorithms.reachable(root.id, {
+          edges: ["parentCategory"],
+          direction: "in",
+        })
+      ).map((node) => node.id)
+    : [root.id];
 
   const query = store
     .query()

--- a/apps/docs/src/content/docs/examples/research-copilot.md
+++ b/apps/docs/src/content/docs/examples/research-copilot.md
@@ -1,0 +1,294 @@
+---
+title: Research Copilot
+description: Semantic search, ontology expansion, and graph algorithms combined into an explainable literature-review digest over a citation graph
+---
+
+A single runnable example that exercises nearly every TypeGraph capability —
+typed schema, [ontology](/ontology), vector embeddings, recursive traversals,
+and the [graph algorithms](/graph-algorithms) — against a corpus of
+landmark ML papers. It produces an explainable literature-review digest in one
+run against a single SQLite file, with zero external services.
+
+:::tip[Just want the code?]
+Full source on GitHub: [`packages/typegraph/examples/14-research-copilot.ts`](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/14-research-copilot.ts)
+:::
+
+## What You Get
+
+A natural-language query comes in. The copilot returns a ranked, chronological
+reading list with citation counts, authors, and topics — all computed against
+a single in-memory SQLite database:
+
+```text
+ Query: "contrastive self-supervised representation learning for vision"
+
+ Recommended reading order (chronological among top-ranked):
+
+  2012  ImageNet Classification with Deep Convolutional Neural Networks  [3 citations]
+        Alex Krizhevsky, Ilya Sutskever, Geoffrey Hinton
+        topics: CNN, ComputerVision, DeepLearning
+        why: semantic 0.449 · topic match: DeepLearning · 3 incoming citations
+  2014  Adam: A Method for Stochastic Optimization  [1 citation]
+        Diederik Kingma, Jimmy Ba
+        topics: Optimization
+        why: semantic 0.429 · 1 incoming citation
+  2019  Momentum Contrast for Unsupervised Visual Representation Learning  [1 citation]
+        Kaiming He, Haoqi Fan, Yuxin Wu, et al.
+        topics: Contrastive, SelfSupervised, ComputerVision
+        why: semantic 0.523 · topic match: SelfSupervised, Contrastive · 1 incoming citation
+  2020  A Simple Framework for Contrastive Learning of Visual Representations  [1 citation]
+        Ting Chen, Simon Kornblith, Mohammad Norouzi, et al.
+        topics: Contrastive, SelfSupervised, ComputerVision
+        why: semantic 0.436 · topic match: SelfSupervised, Contrastive · 1 incoming citation
+  2020  An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale  [1 citation]
+        Alexey Dosovitskiy, Lucas Beyer, Alexander Kolesnikov, et al.
+        topics: Transformer, ComputerVision, DeepLearning
+        why: semantic 0.350 · topic match: DeepLearning · 1 incoming citation
+```
+
+## Architecture
+
+Each moving part maps to a single TypeGraph primitive:
+
+| Feature                              | TypeGraph capability                                        |
+| ------------------------------------ | ----------------------------------------------------------- |
+| Semantic paper retrieval             | `embedding()` fields + cosine similarity                    |
+| Topic hierarchy expansion            | [Ontology](/ontology) + `store.algorithms.reachable()`      |
+| Citation-authority ranking           | `store.algorithms.degree()` over `cites`                    |
+| Explainable paper lineage            | `store.algorithms.shortestPath()` over `cites`              |
+| "Does this trace back to X?"         | `store.algorithms.canReach()`                               |
+| Co-author discovery (2-hop)          | `store.algorithms.neighbors()`                              |
+| Reading-list assembly                | [Query builder](/queries/overview) with typed traversals    |
+
+## Schema
+
+Three node kinds and four edges model the citation graph plus a topic
+hierarchy that supports query expansion:
+
+```typescript
+const Paper = defineNode("Paper", {
+  schema: z.object({
+    title: z.string(),
+    year: z.number().int(),
+    abstract: z.string(),
+    embedding: embedding(128),
+  }),
+});
+
+const Author = defineNode("Author", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Topic = defineNode("Topic", {
+  schema: z.object({ name: z.string() }),
+});
+
+const cites = defineEdge("cites", { schema: z.object({}) });
+const authoredBy = defineEdge("authored_by", { schema: z.object({}) });
+const coversTopic = defineEdge("covers_topic", { schema: z.object({}) });
+
+// Topic hierarchy: `CNN broader_than DL` reads "CNN is a more specific
+// concept than DL". Recursive traversal expands narrow query terms into
+// their ancestor concepts for higher recall.
+const broaderThan = defineEdge("broader_than", { schema: z.object({}) });
+
+const graph = defineGraph({
+  id: "research_copilot",
+  nodes: { Paper: { type: Paper }, Author: { type: Author }, Topic: { type: Topic } },
+  edges: {
+    cites: { type: cites, from: [Paper], to: [Paper] },
+    authored_by: { type: authoredBy, from: [Paper], to: [Author] },
+    covers_topic: { type: coversTopic, from: [Paper], to: [Topic] },
+    broader_than: { type: broaderThan, from: [Topic], to: [Topic] },
+  },
+});
+```
+
+## Scene by Scene
+
+The example walks through five capabilities end-to-end. Each produces real
+console output against the seeded corpus of 18 landmark papers.
+
+### 1. Semantic retrieval
+
+Every paper has a 128-dimensional embedding. Rank the corpus against a
+query embedding and take the top hits:
+
+```typescript
+const queryEmbedding = mockEmbedding(query);
+const allPapers = await store.nodes.Paper.find();
+const ranked = allPapers
+  .map((paper) => ({
+    paper,
+    similarity: cosine(queryEmbedding, paper.embedding),
+  }))
+  .sort((a, b) => b.similarity - a.similarity);
+```
+
+In production, swap the in-JS ranking for `p.embedding.similarTo(queryEmbedding, k)`
+in a [query builder](/queries/overview) predicate — backed by pgvector or
+sqlite-vec — to do the scoring in SQL. See [Semantic Search](/semantic-search).
+
+### 2. Ontology-expanded topic matching
+
+A query for the narrow topic `Contrastive` should also return papers tagged
+with its ancestors (`SelfSupervised`, `DeepLearning`). `reachable()` walks
+the `broader_than` edge recursively and returns every ancestor topic:
+
+```typescript
+const topicAncestors = await store.algorithms.reachable(contrastiveTopic, {
+  edges: ["broader_than"],
+  maxHops: 10,
+  excludeSource: true,
+});
+```
+
+Then filter papers whose `covers_topic` edge lands in the expanded set:
+
+```typescript
+const topicMatches = await store
+  .query()
+  .from("Paper", "p")
+  .traverse("covers_topic", "e")
+  .to("Topic", "t")
+  .whereNode("t", (t) => t.id.in([...expandedTopicIds]))
+  .select((ctx) => ({ id: ctx.p.id, title: ctx.p.title, topic: ctx.t.name }))
+  .execute();
+```
+
+Output:
+
+```text
+  Expanded set: {Contrastive, SelfSupervised, DeepLearning}
+```
+
+### 3. Citation-authority re-ranking
+
+Pure vector similarity is noisy. Fuse it with in-degree on the `cites` edge
+so highly-cited papers bubble up:
+
+```typescript
+const citationCount = await store.algorithms.degree(paperId, {
+  edges: ["cites"],
+  direction: "in",
+});
+const score = similarity + topicBonus + Math.log(citationCount + 1) / 10;
+```
+
+Output:
+
+```text
+ score = similarity + 0.05 * topicMatches + log(1 + citations) / 10
+
+ rank  score  sim    topic  cites  title
+ ───────────────────────────────────────────────────────────────────
+   1   0.692  0.523      2      1  Momentum Contrast for Unsupervised Visual Representation Learning
+   2   0.638  0.449      1      3  ImageNet Classification with Deep Convolutional Neural Networks
+   3   0.606  0.436      2      1  A Simple Framework for Contrastive Learning of Visual Representations
+```
+
+### 4. Explainable lineage
+
+"You've read AlexNet — how does SimCLR trace back to it?" `shortestPath`
+returns an ordered list of nodes, which the example formats as a tree:
+
+```typescript
+const lineage = await store.algorithms.shortestPath(simclr.id, alex.id, {
+  edges: ["cites"],
+  maxHops: 6,
+});
+```
+
+```text
+   2-hop citation lineage:
+
+   A Simple Framework for Contrastive Learning of Visual Representations
+     └─▶ Deep Residual Learning for Image Recognition
+       └─▶ ImageNet Classification with Deep Convolutional Neural Networks
+```
+
+### 5. Heritage check
+
+`canReach` is the boolean sibling of `shortestPath` — useful when you don't
+need the path, just the answer. Here: "which of these modern papers still
+trace back to Rumelhart's 1986 backprop paper?"
+
+```typescript
+const reaches = await store.algorithms.canReach(paper.id, backprop.id, {
+  edges: ["cites"],
+  maxHops: 10,
+});
+```
+
+```text
+   ✓  "LLaMA: Open and Efficient Foundation Language Models"       traces to Rumelhart 1986
+   ✓  "Learning Transferable Visual Models From Natural Language"  traces to Rumelhart 1986
+   ✓  "Chain-of-Thought Prompting Elicits Reasoning in Large LMs"  traces to Rumelhart 1986
+   ✓  "A Simple Framework for Contrastive Learning of Visual Reps" traces to Rumelhart 1986
+```
+
+### 6. Collaborator discovery
+
+`neighbors` returns the direct neighborhood of a node. Compose it — authors
+of CLIP → their other papers → co-authors on those papers — to rank natural
+collaborators by shared-paper count:
+
+```typescript
+const clipAuthors = await store.algorithms.neighbors(clip.id, {
+  edges: ["authored_by"],
+  depth: 1,
+});
+
+// For each CLIP author: walk authored_by backwards to all their papers,
+// then forwards to all their co-authors.
+const perAuthorPapers = await Promise.all(
+  clipAuthors.map((author) =>
+    store.algorithms.neighbors(author.id, {
+      edges: ["authored_by"],
+      direction: "in",
+      depth: 1,
+    }),
+  ),
+);
+```
+
+Issuing each level in parallel keeps the fan-out at `O(depth)` round-trips
+instead of `O(authors × papers)`.
+
+```text
+ Seed paper authors: Ilya Sutskever, Jong Wook Kim, Aditya Ramesh, Alec Radford, Chris Hallacy
+
+ Nearby collaborators beyond the original CLIP paper:
+   2× shared papers with CLIP authors  Alex Krizhevsky
+   2× shared papers with CLIP authors  Geoffrey Hinton
+   2× shared papers with CLIP authors  Rewon Child
+   2× shared papers with CLIP authors  Jeffrey Wu
+   1× shared papers with CLIP authors  Nitish Srivastava
+```
+
+## Run It
+
+The full source lives at
+[`packages/typegraph/examples/14-research-copilot.ts`](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/14-research-copilot.ts).
+From a checkout of the repository:
+
+```bash
+pnpm install
+npx tsx packages/typegraph/examples/14-research-copilot.ts
+```
+
+The example builds the graph, runs every scene, and tears down — all
+against an in-memory SQLite database. To persist it, point
+`createExampleBackend()` at a file path. To run it on Postgres, swap the
+import to `createPostgresBackend` — see [Backend Setup](/backend-setup).
+
+## Next Steps
+
+- [Graph Algorithms](/graph-algorithms) — the full API for `shortestPath`,
+  `reachable`, `canReach`, `neighbors`, and `degree`
+- [Knowledge Graph for RAG](/examples/knowledge-graph-rag) — entity linking,
+  chunk traversal, and hybrid vector + fulltext retrieval
+- [Ontology & Reasoning](/ontology) — inverse edges, subclass hierarchies,
+  and other ontology primitives beyond `broader_than`
+- [Semantic Search](/semantic-search) — production vector search with
+  pgvector and sqlite-vec

--- a/apps/docs/src/content/docs/examples/workflow-engine.md
+++ b/apps/docs/src/content/docs/examples/workflow-engine.md
@@ -106,12 +106,32 @@ const reportsTo = defineEdge("reportsTo"); // For escalation chain
 const graph = defineGraph({
   id: "workflow_engine",
   nodes: {
-    WorkflowDefinition: { type: WorkflowDefinition },
+    WorkflowDefinition: {
+      type: WorkflowDefinition,
+      unique: [
+        {
+          name: "workflow_name_version",
+          fields: ["name", "version"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
     State: { type: State },
     Transition: { type: Transition },
     WorkflowInstance: { type: WorkflowInstance },
     Task: { type: Task },
-    User: { type: User },
+    User: {
+      type: User,
+      unique: [
+        {
+          name: "user_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
     Comment: { type: Comment },
   },
   edges: {
@@ -475,18 +495,22 @@ async function createApprovalTask(
     .select((ctx) => ctx.u)
     .first();
 
-  // If no direct match, find in reporting chain
+  // If no direct match, walk the reporting chain upward until we hit someone
+  // with the approver role. The recursive traversal tags each hop with its
+  // depth so we can pick the nearest matching manager.
   if (!approver) {
-    approver = await tx
+    const candidates = await tx
       .query()
       .from("User", "requester")
       .whereNode("requester", (u) => u.id.eq(requesterId))
       .traverse("reportsTo", "e")
-      .recursive()
+      .recursive({ depth: "depth" })
       .to("User", "manager")
       .whereNode("manager", (u) => u.role.eq(config.approverRole))
+      .orderBy("depth", "asc")
       .select((ctx) => ctx.manager)
-      .first();
+      .execute();
+    approver = candidates[0];
   }
 
   if (!approver) {
@@ -699,7 +723,7 @@ async function escalateTask(taskId: string): Promise<void> {
       throw new Error("Task has no assignee");
     }
 
-    // Find manager in reporting chain
+    // Single-hop traversal to the direct manager
     const manager = await tx
       .query()
       .from("User", "u")
@@ -770,20 +794,37 @@ interface TimelineEvent {
 async function getInstanceTimeline(instanceId: string): Promise<TimelineEvent[]> {
   const events: TimelineEvent[] = [];
 
-  // Get state change history using temporal queries
-  const stateHistory = await store
-    .query()
-    .from("WorkflowInstance", "i")
-    .temporal("includeEnded")
-    .whereNode("i", (i) => i.id.eq(instanceId))
-    .traverse("currentState", "e")
-    .to("State", "s")
-    .orderBy((ctx) => ctx.e.validFrom, "asc")
-    .select((ctx) => ({
-      stateName: ctx.s.name,
-      timestamp: ctx.e.validFrom,
-    }))
-    .execute();
+  // Run both history reads snapshot-consistent on a single connection so the
+  // state-change and task views can't observe interleaved writes.
+  const [stateHistory, tasks] = await store.batch(
+    store
+      .query()
+      .from("WorkflowInstance", "i")
+      .temporal("includeEnded")
+      .whereNode("i", (i) => i.id.eq(instanceId))
+      .traverse("currentState", "e")
+      .to("State", "s")
+      .orderBy("e", "validFrom", "asc")
+      .select((ctx) => ({
+        stateName: ctx.s.name,
+        timestamp: ctx.e.validFrom,
+      })),
+    store
+      .query()
+      .from("WorkflowInstance", "i")
+      .whereNode("i", (i) => i.id.eq(instanceId))
+      .traverse("hasTask", "e")
+      .to("Task", "t")
+      .optionalTraverse("assignedTo", "a")
+      .to("User", "u")
+      .select((ctx) => ({
+        title: ctx.t.title,
+        status: ctx.t.status,
+        createdAt: ctx.t.createdAt,
+        completedAt: ctx.t.completedAt,
+        assignee: ctx.u?.name,
+      })),
+  );
 
   for (const state of stateHistory) {
     events.push({
@@ -792,24 +833,6 @@ async function getInstanceTimeline(instanceId: string): Promise<TimelineEvent[]>
       description: `Entered state: ${state.stateName}`,
     });
   }
-
-  // Get task events
-  const tasks = await store
-    .query()
-    .from("WorkflowInstance", "i")
-    .whereNode("i", (i) => i.id.eq(instanceId))
-    .traverse("hasTask", "e")
-    .to("Task", "t")
-    .optionalTraverse("assignedTo", "a")
-    .to("User", "u")
-    .select((ctx) => ({
-      title: ctx.t.title,
-      status: ctx.t.status,
-      createdAt: ctx.t.createdAt,
-      completedAt: ctx.t.completedAt,
-      assignee: ctx.u?.name,
-    }))
-    .execute();
 
   for (const task of tasks) {
     events.push({

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1449,7 +1449,7 @@ consistency. Reserve individual fluent queries for one-off operations.
 
 #### `store.algorithms`
 
-Lazy-initialized facade exposing the Tier 1 graph algorithms —
+Lazy-initialized facade exposing the graph algorithms —
 `shortestPath`, `reachable`, `canReach`, `neighbors`, and `degree`.
 See [Graph Algorithms](/graph-algorithms) for the full API; this section
 is a quick reference.

--- a/packages/typegraph/examples/09-pagination-streaming.ts
+++ b/packages/typegraph/examples/09-pagination-streaming.ts
@@ -38,7 +38,17 @@ const authored = defineEdge("authored");
 const graph = defineGraph({
   id: "pagination_example",
   nodes: {
-    User: { type: User },
+    User: {
+      type: User,
+      unique: [
+        {
+          name: "user_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
     Post: { type: Post },
   },
   edges: {

--- a/packages/typegraph/examples/12-knowledge-graph-rag.ts
+++ b/packages/typegraph/examples/12-knowledge-graph-rag.ts
@@ -62,7 +62,17 @@ const graph = defineGraph({
   nodes: {
     Document: { type: Document },
     Chunk: { type: Chunk },
-    Entity: { type: Entity },
+    Entity: {
+      type: Entity,
+      unique: [
+        {
+          name: "entity_name_type",
+          fields: ["name", "type"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
   },
   edges: {
     containsChunk: { type: containsChunk, from: [Document], to: [Chunk] },
@@ -167,32 +177,24 @@ export async function main() {
     prevChunkNode = chunk;
   }
 
-  // Create entities
-  const samAltman = await store.nodes.Entity.create({
-    name: "Sam Altman",
-    type: "person",
-    embedding: mockEmbedding("Sam Altman"),
-  });
-  const elonMusk = await store.nodes.Entity.create({
-    name: "Elon Musk",
-    type: "person",
-    embedding: mockEmbedding("Elon Musk"),
-  });
-  const openai = await store.nodes.Entity.create({
-    name: "OpenAI",
-    type: "organization",
-    embedding: mockEmbedding("OpenAI"),
-  });
-  const tesla = await store.nodes.Entity.create({
-    name: "Tesla",
-    type: "organization",
-    embedding: mockEmbedding("Tesla"),
-  });
-  const gpt4 = await store.nodes.Entity.create({
-    name: "GPT-4",
-    type: "concept",
-    embedding: mockEmbedding("GPT-4"),
-  });
+  // Use getOrCreateByConstraint so re-running ingestion on overlapping
+  // corpora dedupes entities via the `entity_name_type` unique constraint.
+  async function ensureEntity(
+    name: string,
+    type: "person" | "organization" | "location" | "concept",
+  ) {
+    const result = await store.nodes.Entity.getOrCreateByConstraint(
+      "entity_name_type",
+      { name, type, embedding: mockEmbedding(name) },
+    );
+    return result.node;
+  }
+
+  const samAltman = await ensureEntity("Sam Altman", "person");
+  const elonMusk = await ensureEntity("Elon Musk", "person");
+  const openai = await ensureEntity("OpenAI", "organization");
+  const tesla = await ensureEntity("Tesla", "organization");
+  const gpt4 = await ensureEntity("GPT-4", "concept");
 
   // Link chunks to entities (mentions)
   await store.edges.mentions.create(doc1Chunks[0]!, samAltman, {});


### PR DESCRIPTION
- Add a dedicated **Research Copilot** example page as the headline entry in the Examples section, linking prominently to `packages/typegraph/examples/14-research-copilot.ts`.
- Sweep the five existing example pages (document management, product catalog, workflow engine, audit trail, multi-tenant SaaS) to use APIs added since they were first written.
- Keep the `.ts` examples in sync: `12-knowledge-graph-rag.ts` and `09-pagination-streaming.ts` pick up unique constraints and `getOrCreateByConstraint`.

### What changed per example page

| Page | Changes |
|---|---|
| research-copilot.md (new) | New page with architecture table, scene-by-scene walkthrough, and GitHub source link surfaced in three places |
| document-management.md | `folder_path`, `user_email` unique constraints; `createFolderPath` → `getOrCreateByConstraint`; `getBreadcrumb` → `store.algorithms.reachable(direction: "in")` + batched `getByIds` |
| product-catalog.md | `category_slug`, `product_sku`, `variant_sku`, `warehouse_code` constraints; `createCategory` → `getOrCreateByConstraint`; `getCategoryWithPath` / `getSubcategories` / two search-path category-subtree lookups → `reachable`; `getProductDetails` fuses three serial queries via `store.batch()` |
| workflow-engine.md | `workflow_name_version`, `user_email` constraints; approver lookup now walks `reportsTo` via recursive traversal with `orderBy("depth")`; `getInstanceTimeline` → `store.batch()` for snapshot-consistent state + task reads |
| audit-trail.md | `setting_key`, `user_email` constraints |
| multi-tenant.md | `tenant_slug` + composite `(tenantId, email)` constraints; `provisionTenant` → `getOrCreateByConstraint`, eliminating the pre-check race |
| schemas-stores.md | Terminology: drop "Tier 1" from `store.algorithms` reference (consistent with recent renames in `/graph-algorithms`) |

### Code-only examples

- `12-knowledge-graph-rag.ts` — add `entity_name_type` unique constraint (matches the doc page) and switch entity creation to `getOrCreateByConstraint` via an `ensureEntity` helper, so re-ingesting overlapping corpora dedupes correctly.
- `09-pagination-streaming.ts` — add `user_email` unique constraint for idiomatic consistency.