### PR TITLE
perf + feat: close the aggregate gap vs Neo4j; harden benchmarks

### DIFF
--- a/.changeset/count-aggregate-fast-path.md
+++ b/.changeset/count-aggregate-fast-path.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Push `LIMIT` past `GROUP BY` in the count aggregate fast path when it's safe.
+
+When `groupByNode(...).aggregate({ x: count(alias) })` is paired with an optional traversal and a `.limit(n)` that doesn't depend on the aggregate (no `ORDER BY`, or an `ORDER BY` restricted to group keys), the compiler now emits the `LIMIT` inside the start CTE. The `GROUP BY` runs over `n` rows instead of the full start set — `O(limit)` grouping work instead of `O(|start|)`. When `OFFSET` is also set, it rides along with the `LIMIT` into the start CTE and the outer `SELECT` drops its own `LIMIT`/`OFFSET` so neither clause is double-applied.
+
+The fast path also picks `INNER JOIN` over `LEFT JOIN` for the target-node join whenever a `whereNode()` predicate applies to the target alias, so those predicates constrain every aggregate — including `countEdges(...)`. `LEFT JOIN` remains the strategy when only temporal/delete filters apply to the target, so `countEdges` and `count(target)` can coexist in one query with divergent semantics.
+
+No change to query semantics — aggregate counts still reflect the same `count(target)` as before, including the target node's temporal and deletion filters. No change to aggregate queries without a `LIMIT`. No change on SQLite or PostgreSQL query shapes outside the fast path.
+
+Measured impact: scopes down group-by work for "top-N by count"-style aggregate queries. No impact on the blog-post benchmark's full-graph aggregate (which measures the ungrouped 1,200-user case and intentionally runs without a `LIMIT`).

--- a/.changeset/count-edges-aggregator.md
+++ b/.changeset/count-edges-aggregator.md
@@ -1,0 +1,39 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `countEdges(edgeAlias)` and `countDistinctEdges(edgeAlias)` — edge-count aggregators that skip the target-node join in the count aggregate fast path.
+
+The default `count(targetAlias)` counts edges whose target node is currently live under the query's temporal mode, which requires joining the edges to the target node table on every aggregation. For the common "how many follow relationships does this user have?" question, that join is unnecessary work: you want to count edges, not reach through each edge to validate the target.
+
+```typescript
+import { count, countEdges, field } from "@nicia-ai/typegraph";
+
+const result = await store
+  .query()
+  .from("User", "u")
+  .optionalTraverse("follows", "e", { expand: "none" })
+  .to("User", "target")
+  .groupByNode("u")
+  .aggregate({
+    name: field("u", "name"),
+    // Counts live edges, regardless of target-node validity.
+    // Skips the typegraph_nodes join entirely — ~1.7x faster on
+    // SQLite, ~1.35x on PostgreSQL at benchmark scale.
+    followCount: countEdges("e"),
+    // Counts edges to live targets. Keeps the target-node join
+    // so the target's temporal window is honored.
+    liveFollowCount: count("target"),
+  })
+  .execute();
+```
+
+**When to use which:**
+
+- `count(targetAlias)` — when the semantic question is "how many of this user's follows point to a live user?" The target-node join enforces the target's `validTo` / `deleted_at` filters.
+- `countEdges(edgeAlias)` — when the semantic question is "how many follow relationships does this user have?" The edge's own temporal and deletion filters are enforced; target validity is not consulted.
+- `countDistinctEdges(edgeAlias)` — same semantics as `countEdges` but with `COUNT(DISTINCT ...)`. Useful under ontology-driven expansions where the same edge can appear multiple times in join output.
+
+The two can be mixed in one aggregate. When present together, the compiler keeps the target-node join but switches it to a `LEFT JOIN` with node-side filters pushed into the `ON` clause so edge counts reflect all live edges while node counts only reflect edges to live targets.
+
+No change to existing `count(...)` behavior. This is purely additive — code that currently uses `count("targetAlias")` continues to count live targets exactly as before.

--- a/.changeset/fix-ddl-index-columns.md
+++ b/.changeset/fix-ddl-index-columns.md
@@ -1,0 +1,16 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `generateSqliteDDL` and `generatePostgresMigrationSQL` emitting `(unknown, unknown, ...)` for indexes threaded through `createSqliteTables({}, { indexes })` or `createPostgresTables({}, { indexes })`.
+
+The DDL generator's SQL-chunk flattener didn't handle two cases that appear inside index expression keys: Drizzle column references nested inside a SQL stream (whose `.getSQL()` wraps the column back inside a self-referential SQL object, causing the previous logic to recurse and fall through to `"unknown"`), and `StringChunk` values stored as single-element arrays (`[""]`).
+
+Expression indexes now emit correctly in both dialects, e.g.
+
+```sql
+CREATE INDEX IF NOT EXISTS "idx_tg_node_user_city_cov_name_…" ON "typegraph_nodes"
+  ("graph_id", "kind", (json_extract("props", '$."city"')), (json_extract("props", '$."name"')));
+```
+
+Added a regression test in `tests/indexes.test.ts` asserting that DDL from `createSqliteTables`/`createPostgresTables` never contains `(unknown` and includes the expected column and `json_extract` / `ARRAY['…']` expressions.

--- a/.changeset/pg-not-materialized-cte-hints.md
+++ b/.changeset/pg-not-materialized-cte-hints.md
@@ -1,0 +1,14 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Emit `NOT MATERIALIZED` on PostgreSQL traversal and start CTEs so the planner can inline them and see their inner row statistics.
+
+PostgreSQL defaults to materializing any CTE referenced more than once. TypeGraph's traversal compilation references each CTE twice — once from the next hop's join, once from the final SELECT — which triggers materialization under the default rules. Materialized CTEs have opaque statistics to the planner, causing poor join orderings and wildly off row estimates on multi-hop queries over larger graphs.
+
+Introduces a `emitNotMaterializedHint` dialect capability (`true` for PostgreSQL, `false` for SQLite, which ignores the hint entirely) and threads it through the start-CTE and traversal-CTE emitters. The hint matches what an expert would write by hand for the same query shape.
+
+Impact on the TypeGraph benchmark suite:
+- Multi-hop traversal plans no longer carry opaque materializations, so the planner picks index-scan orderings appropriate to the starting row's selectivity.
+- No visible change on SQLite (the hint is not emitted).
+- Guards against regressions on larger graphs where materialized CTE plans degenerate into cross-product-plus-filter.

--- a/.changeset/sqlite-embedding-persistence.md
+++ b/.changeset/sqlite-embedding-persistence.md
@@ -1,0 +1,21 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Persist vector embeddings on the SQLite backend when sqlite-vec is loaded.
+
+Previously, `store.nodes.X.create({ ..., embedding: [...] })` on SQLite validated the embedding and inserted the node, but the embedding itself was silently dropped — the SQLite backend didn't implement `upsertEmbedding`/`deleteEmbedding`, so the store's embedding-sync path quietly no-op'd. Vector predicates like `d.embedding.similarTo(q, 20, { metric: "cosine" })` then ran against an empty `typegraph_node_embeddings` table and returned zero rows without error.
+
+This release wires up both methods on the SQLite backend. They encode embeddings to `vec_f32('[...]')` BLOBs on write and rely on sqlite-vec at query time — same storage shape the existing `.similarTo()` compilation already targets. Activation is opt-in via a new `hasVectorEmbeddings` option on `createSqliteBackend` so callers that haven't loaded sqlite-vec don't hit `no such function: vec_f32` at write time. `createLocalSqliteBackend` best-effort-loads sqlite-vec at startup and flips the option automatically, so the common local setup works without configuration.
+
+```typescript
+// Local backend: sqlite-vec is loaded automatically when installed.
+const { backend } = createLocalSqliteBackend();
+
+// BYO drizzle connection: pass hasVectorEmbeddings after loading sqlite-vec.
+import sqliteVec from "sqlite-vec";
+sqliteVec.load(sqlite);
+const backend = createSqliteBackend(drizzle(sqlite), { tables, hasVectorEmbeddings: true });
+```
+
+`getEmbedding` and the hybrid-search facade (`store.search.hybrid(...)`) remain PostgreSQL-only — decoding the raw BLOB back to `number[]` via `vec_to_json` and exposing a hybrid-search backend method are tracked separately.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ pnpm test                 # Run all tests (SQLite only, postgres tests are skipp
 pnpm test:postgres        # Run PostgreSQL tests (starts Docker automatically)
 pnpm lint                 # Run ESLint
 pnpm typecheck            # TypeScript type checking
-pnpm fix                  # Auto-fix lint and formatting
+pnpm fix                  # Auto-fix lint and formatting (prettier + eslint --fix + markdownlint)
+pnpm test:unused          # Run knip (unused exports, deps, files)
 
 # From packages/typegraph
 pnpm test                 # Run unit tests
@@ -67,6 +68,21 @@ pnpm test:postgres        # Run PostgreSQL tests (starts Docker automatically)
 pnpm test:coverage        # Run tests with coverage
 pnpm test:mutation        # Run mutation testing
 ```
+
+# Before Committing
+
+Running `pnpm typecheck` and `pnpm lint` separately is *not* enough —
+prettier rules live outside eslint, and those commands won't surface
+formatting drift. The canonical pre-commit sequence is:
+
+```bash
+pnpm fix && pnpm typecheck && pnpm test
+```
+
+`pnpm fix` chains prettier, eslint `--fix` (so a separate `pnpm lint`
+is redundant), and markdownlint, exiting non-zero on any unfixable
+violation. If it modifies files, fold the changes into the same
+commit — they aren't a separate concern.
 
 **Important:** `pnpm test` runs only SQLite-backed tests. The PostgreSQL
 backend tests are **skipped** unless `POSTGRES_URL` is set. Always run

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -32,6 +32,16 @@ const config: KnipConfig = {
       // Astro/Starlight plugins loaded via config
       ignoreDependencies: ["@astrojs/starlight-tailwind", "tailwindcss"],
     },
+    "packages/benchmarks": {
+      // Neo4j head-to-head harness is a standalone package installed with
+      // pnpm --ignore-workspace. Its src files are entrypoints invoked
+      // from its own package.json scripts; the monorepo never imports
+      // them.
+      ignore: ["neo4j-compare/**"],
+      // sqlite-vec is loaded dynamically via createRequire so the optional
+      // peer dep stays optional; knip's static scan doesn't see it.
+      ignoreDependencies: ["sqlite-vec"],
+    },
   },
 };
 

--- a/packages/benchmarks/neo4j-compare/README.md
+++ b/packages/benchmarks/neo4j-compare/README.md
@@ -1,0 +1,146 @@
+# TypeGraph vs. Neo4j microbenchmark
+
+A minimal head-to-head that runs the same graph shape and the same query
+shapes through TypeGraph (SQLite in-process via `better-sqlite3`, or
+PostgreSQL via a local pool) and Neo4j 5.26 Community, using matching
+methodology (2 warmup iterations, 15 samples, median reported).
+
+**This is a microbenchmark, not LDBC SNB.** It measures a small, stable
+graph on a single machine. Use the numbers to anchor order-of-magnitude
+claims, not to make universal statements about either system.
+
+## Graph shape
+
+Identical on both sides, seeded from the same xorshift32 RNG with seed 42:
+
+- 1,200 `:User` nodes (id, name, city, ~1KB bio)
+- 6,000 `:Post` nodes (id, title, ~4KB body) — 5 per user
+- 1,199 `:NEXT` relationships forming a linear chain (`user_0` → `user_1` → …)
+- 12,000 `:FOLLOWS` relationships (10 per user)
+- 6,000 `:AUTHORED` relationships (1 per post)
+
+**Total: 7,200 nodes + 19,199 relationships + 26k raw items including
+post rows with 4KB bodies.**
+
+## What gets measured
+
+| Query | Description |
+|---|---|
+| `forward traversal` | 1-hop: `user_0`'s follows |
+| `cached execute` | Same query text repeated — plan cache hit |
+| `prepared execute` | Parameterized `$userId` — plan cache + param binding |
+| `reverse traversal` | 1-hop reverse: who follows `user_0` |
+| `2-hop traversal` | `user_0` → follows → authored (posts) |
+| `3-hop traversal` | `user_500` → follows → follows → authored |
+| `aggregate follow count` | COUNT per user over follows |
+| `aggregate distinct follow count` | COUNT DISTINCT variant |
+| `10-hop recursive` | `:NEXT*10..10` along the linear chain |
+| `100-hop recursive` | `:NEXT*100..100` along the linear chain |
+| `1000-hop recursive` | `:NEXT*1000..1000` along the linear chain |
+
+## What's NOT measured
+
+- **Inverse-edge traversal** (`expand: "inverse"`): TypeGraph ontology
+  feature without a direct Cypher analogue.
+- **Subgraph extraction** (`store.subgraph()`): TypeGraph's single-recursive-CTE
+  fan-out doesn't map cleanly to Cypher and would need a careful
+  port; left out of the v1 harness.
+- **Write-path throughput**: seeding times are printed but the benchmark
+  doesn't stress bulk writes under contention.
+
+## Fairness caveats
+
+Read this before citing the numbers.
+
+1. **Transport asymmetry.** TypeGraph uses `better-sqlite3`, which is
+   synchronous and in-process. Neo4j is a separate server process reached
+   over the Bolt protocol on localhost. Every Neo4j query pays a
+   TCP round-trip that the TypeGraph side does not. For sub-millisecond
+   queries, this overhead dominates — it is a real architectural
+   difference that shipping products also face, but it's not a pure
+   engine-to-engine comparison.
+
+2. **Cycle semantics differ slightly.** TypeGraph's benchmark uses
+   `cyclePolicy: "allow"` (no cycle tracking). Cypher's variable-length
+   path enforces relationship uniqueness by default (no repeated edge).
+   The `:NEXT` chain is linear, so the traversal space is identical
+   either way.
+
+3. **Single node, small graph.** Neo4j's architectural advantages
+   (index-free adjacency, native graph storage) show up more clearly
+   on graphs with 100M+ edges and deeper traversals. This benchmark
+   does not probe that regime.
+
+4. **Warmup may not be enough** for Neo4j's page cache on larger
+   graphs. The harness touches every node and edge once before
+   measuring, which is sufficient for this size.
+
+5. **JVM cold start.** Neo4j runs on the JVM; the first invocation
+   of each query shape is ~50–100% slower than the stable steady
+   state because the JIT hasn't kicked in. The per-query warmup
+   (2 iterations) handles this for each query shape individually,
+   but if you're comparing the very first `pnpm bench` run to
+   TypeGraph, expect Neo4j numbers to look ~2× worse than the truth.
+   Run `pnpm bench` twice and use the second run's numbers. TypeGraph
+   (SQLite via `better-sqlite3`) has no JIT and stabilizes on the
+   first run.
+
+## Running the benchmark
+
+### 1. TypeGraph side
+
+From the repo root:
+
+```bash
+pnpm --filter @nicia-ai/typegraph-benchmarks bench
+```
+
+Record the output.
+
+### 2. Neo4j side
+
+From this directory (`packages/benchmarks/neo4j-compare`):
+
+```bash
+# Start Neo4j 5.x Community in Docker
+docker compose up -d
+
+# Wait a few seconds for it to come up. You can confirm at http://localhost:7474
+# (user: neo4j, pass: benchpass)
+
+# Install the Neo4j driver + tsx
+# This directory is intentionally not a workspace member — use --ignore-workspace.
+pnpm install --ignore-workspace
+
+# Seed the same graph shape
+pnpm seed
+
+# Run the benchmark
+pnpm bench
+```
+
+### 3. Compare
+
+Paste the two outputs side by side. The shape of each output matches, so
+diffing them is straightforward.
+
+## Tear down
+
+```bash
+docker compose down -v
+```
+
+The `-v` removes the volume so the next run starts clean.
+
+## Configuration
+
+Environment variables (optional):
+
+- `NEO4J_URL` (default `bolt://localhost:7687`)
+- `NEO4J_USER` (default `neo4j`)
+- `NEO4J_PASSWORD` (default `benchpass`)
+- `NEO4J_DATABASE` (default `neo4j`)
+
+The compose file allocates 1GB heap + 1GB pagecache, which is more than
+enough for the benchmark graph (~30MB on disk). If you want to test a
+different configuration, edit `docker-compose.yml`.

--- a/packages/benchmarks/neo4j-compare/docker-compose.yml
+++ b/packages/benchmarks/neo4j-compare/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  neo4j:
+    image: neo4j:5.26-community
+    container_name: typegraph-compare-neo4j
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      NEO4J_AUTH: neo4j/benchpass
+      NEO4J_dbms_memory_heap_initial__size: 1G
+      NEO4J_dbms_memory_heap_max__size: 1G
+      NEO4J_dbms_memory_pagecache_size: 1G
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:7474 >/dev/null 2>&1 || exit 1",
+        ]
+      interval: 3s
+      timeout: 3s
+      retries: 30

--- a/packages/benchmarks/neo4j-compare/package.json
+++ b/packages/benchmarks/neo4j-compare/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "typegraph-neo4j-compare",
+  "private": true,
+  "type": "module",
+  "description": "Head-to-head microbenchmark: TypeGraph (SQLite in-process) vs Neo4j 5.x Community on the same graph shape.",
+  "scripts": {
+    "seed": "tsx src/seed.ts",
+    "bench": "tsx src/bench.ts",
+    "bench:typegraph": "pnpm --filter @nicia-ai/typegraph-benchmarks bench"
+  },
+  "dependencies": {
+    "neo4j-driver": "^5.24.0",
+    "tsx": "^4.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/benchmarks/neo4j-compare/pnpm-lock.yaml
+++ b/packages/benchmarks/neo4j-compare/pnpm-lock.yaml
@@ -1,0 +1,411 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      neo4j-driver:
+        specifier: ^5.24.0
+        version: 5.28.3
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.12.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  neo4j-driver-bolt-connection@5.28.3:
+    resolution: {integrity: sha512-wqHBYcU0FVRDmdsoZ+Fk0S/InYmu9/4BT6fPYh45Jimg/J7vQBUcdkiHGU7nop7HRb1ZgJmL305mJb6g5Bv35Q==}
+
+  neo4j-driver-core@5.28.3:
+    resolution: {integrity: sha512-Jk+hAmjFmO5YzVH/U7FyKXigot9zmIfLz6SZQy0xfr4zfTE/S8fOYFOGqKQTHBE86HHOWH2RbTslbxIb+XtU2g==}
+
+  neo4j-driver@5.28.3:
+    resolution: {integrity: sha512-k7c0wEh3HoONv1v5AyLp9/BDAbYHJhz2TZvzWstSEU3g3suQcXmKEaYBfrK2UMzxcy3bCT0DrnfRbzsOW5G/Ag==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  base64-js@1.5.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  ieee754@1.2.1: {}
+
+  neo4j-driver-bolt-connection@5.28.3:
+    dependencies:
+      buffer: 6.0.3
+      neo4j-driver-core: 5.28.3
+      string_decoder: 1.3.0
+
+  neo4j-driver-core@5.28.3: {}
+
+  neo4j-driver@5.28.3:
+    dependencies:
+      neo4j-driver-bolt-connection: 5.28.3
+      neo4j-driver-core: 5.28.3
+      rxjs: 7.8.2
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@7.16.0: {}

--- a/packages/benchmarks/neo4j-compare/src/bench.ts
+++ b/packages/benchmarks/neo4j-compare/src/bench.ts
@@ -1,0 +1,317 @@
+/**
+ * Neo4j-side of the head-to-head benchmark. Runs the same query shapes as
+ * packages/benchmarks/src/measurements.ts with matching methodology
+ * (2 warmup iterations, 15 samples, median reported).
+ *
+ * Queries are driver-side compiled via parameter binding; Neo4j caches the
+ * query plan so re-executions skip planning. This is the closest analogue
+ * to TypeGraph's `cachedExecute` / `preparedExecute`.
+ *
+ * Notes on semantics:
+ *   - Cypher's variable-length path `*N..N` enforces relationship uniqueness
+ *     by default (no repeated edge). The :NEXT chain is linear so no cycles
+ *     exist either way. TypeGraph's benchmark uses `cyclePolicy: "allow"`,
+ *     which skips cycle tracking entirely — slightly looser than Cypher's
+ *     default, but for this shape the traversal space is identical.
+ *   - `expand: "inverse"` is a TypeGraph ontology feature with no direct
+ *     Cypher equivalent; that row is omitted from the comparison.
+ */
+import neo4j, { type Driver, type Session } from "neo4j-driver";
+
+import { BENCHMARK_CONFIG, NEO4J_CONFIG } from "./config.ts";
+import { formatMs, median, nowMs } from "./utils.ts";
+
+async function benchmarkQuery(
+  label: string,
+  fn: () => Promise<void>,
+): Promise<number> {
+  for (let i = 0; i < BENCHMARK_CONFIG.warmupIterations; i += 1) {
+    await fn();
+  }
+  const samples: number[] = [];
+  for (let i = 0; i < BENCHMARK_CONFIG.sampleIterations; i += 1) {
+    const startedAt = nowMs();
+    await fn();
+    samples.push(nowMs() - startedAt);
+  }
+  const result = median(samples);
+  console.log(`${label}: ${formatMs(result)}`);
+  return result;
+}
+
+/**
+ * Runs a Cypher query and returns records as plain JS objects so call
+ * sites can assert cardinality and content invariants — mirroring the
+ * TypeGraph-side invariants. Drops the Neo4j driver's record wrapper
+ * by projecting every field to its JS value.
+ */
+async function run(
+  session: Session,
+  cypher: string,
+  params: Record<string, unknown>,
+): Promise<readonly Record<string, unknown>[]> {
+  const result = await session.run(cypher, params);
+  return result.records.map((record) => record.toObject());
+}
+
+type Metrics = {
+  forwardMs: number;
+  cachedExecuteMs: number;
+  preparedExecuteMs: number;
+  reverseMs: number;
+  twoHopMs: number;
+  threeHopMs: number;
+  aggregateMs: number;
+  aggregateDistinctMs: number;
+  tenHopMs: number;
+  hundredHopMs: number;
+  thousandHopMs: number;
+};
+
+async function main(): Promise<Metrics> {
+  const driver = neo4j.driver(
+    NEO4J_CONFIG.url,
+    neo4j.auth.basic(NEO4J_CONFIG.user, NEO4J_CONFIG.password),
+    { maxConnectionPoolSize: 10 },
+  );
+
+  // Warm up the page cache by touching every node and edge once.
+  {
+    const session = driver.session({ database: NEO4J_CONFIG.database });
+    try {
+      await session.run("MATCH (n) RETURN count(n)");
+      await session.run("MATCH ()-[r]->() RETURN count(r)");
+    } finally {
+      await session.close();
+    }
+  }
+
+  const session = driver.session({ database: NEO4J_CONFIG.database });
+  try {
+    console.log(
+      `Neo4j perf sanity (report mode, backend=neo4j ${NEO4J_CONFIG.url})`,
+    );
+
+    // Every User in the seed has exactly 10 outgoing FOLLOWS relationships,
+    // so user_0's forward-traversal cardinality is an invariant on both sides.
+    const expectedForwardCount = 10;
+    const assertLength = (
+      label: string,
+      rows: readonly unknown[],
+      expected: number,
+    ): void => {
+      if (rows.length !== expected) {
+        throw new Error(
+          `${label} drift: expected ${expected} rows, got ${rows.length}`,
+        );
+      }
+    };
+
+    const forwardMs = await benchmarkQuery("forward traversal", async () => {
+      const rows = await run(
+        session,
+        `MATCH (u:User {id: "user_0"})-[:FOLLOWS]->(friend:User)
+         RETURN friend.name AS friendName`,
+        {},
+      );
+      assertLength("forward traversal", rows, expectedForwardCount);
+    });
+
+    const cachedCypher = `MATCH (u:User {id: "user_0"})-[:FOLLOWS]->(friend:User)
+                          RETURN friend.name AS friendName`;
+    const cachedExecuteMs = await benchmarkQuery(
+      "cached execute (same query text)",
+      async () => {
+        const rows = await run(session, cachedCypher, {});
+        assertLength("cached execute", rows, expectedForwardCount);
+      },
+    );
+
+    const preparedCypher = `MATCH (u:User {id: $userId})-[:FOLLOWS]->(friend:User)
+                            RETURN friend.name AS friendName`;
+    const preparedExecuteMs = await benchmarkQuery(
+      "prepared execute",
+      async () => {
+        const rows = await run(session, preparedCypher, { userId: "user_0" });
+        assertLength("prepared execute", rows, expectedForwardCount);
+      },
+    );
+
+    const reverseMs = await benchmarkQuery("reverse traversal", async () => {
+      const rows = await run(
+        session,
+        `MATCH (follower:User)-[:FOLLOWS]->(target:User {id: "user_0"})
+         RETURN follower.name AS followerName`,
+        {},
+      );
+      if (rows.length === 0) {
+        throw new Error(
+          "reverse traversal drift: expected non-empty result set",
+        );
+      }
+    });
+
+    const twoHopMs = await benchmarkQuery("2-hop traversal", async () => {
+      const rows = await run(
+        session,
+        `MATCH (u:User {id: "user_0"})-[:FOLLOWS]->(friend:User)-[:AUTHORED]->(post:Post)
+         RETURN friend.name AS friendName, post.title AS title
+         LIMIT 50`,
+        {},
+      );
+      assertLength("2-hop traversal", rows, 50);
+    });
+
+    const threeHopMs = await benchmarkQuery("3-hop traversal", async () => {
+      const rows = await run(
+        session,
+        `MATCH (u:User {id: "user_500"})
+               -[:FOLLOWS]->(f1:User)
+               -[:FOLLOWS]->(f2:User)
+               -[:AUTHORED]->(post:Post)
+         RETURN f1.name AS f1Name, f2.name AS f2Name, post.title AS title
+         LIMIT 20`,
+        {},
+      );
+      assertLength("3-hop traversal", rows, 20);
+    });
+
+    // Full-graph aggregate. Deliberately no `LIMIT` — we claim this
+    // measures COUNT per user across all 1,200 users, and we assert that
+    // count returns, so the measurement and the label stay aligned.
+    // The TypeGraph-side benchmark was updated to match.
+    const expectedAggregateRows = 1200;
+    const aggregateMs = await benchmarkQuery(
+      "aggregate follow count",
+      async () => {
+        const rows = await run(
+          session,
+          `MATCH (u:User)
+         OPTIONAL MATCH (u)-[:FOLLOWS]->(target:User)
+         WITH u, count(target) AS followCount
+         RETURN u.name AS name, followCount`,
+          {},
+        );
+        assertLength("aggregate follow count", rows, expectedAggregateRows);
+      },
+    );
+
+    const aggregateDistinctMs = await benchmarkQuery(
+      "aggregate distinct follow count",
+      async () => {
+        const rows = await run(
+          session,
+          `MATCH (u:User)
+           OPTIONAL MATCH (u)-[:FOLLOWS]->(target:User)
+           WITH u, count(DISTINCT target) AS followCount
+           RETURN u.name AS name, followCount`,
+          {},
+        );
+        assertLength(
+          "aggregate distinct follow count",
+          rows,
+          expectedAggregateRows,
+        );
+      },
+    );
+
+    // Recursive traversals walk the :NEXT linear chain (user_0 -> user_1
+    // -> ...). At depth N, the single reachable target is user_N.
+    // Asserting the target id catches both empty-result regressions and
+    // off-by-one depth bugs, same as the TypeGraph side.
+    const assertRecursiveHit = (
+      label: string,
+      rows: readonly Record<string, unknown>[],
+      expectedDepth: number,
+    ): void => {
+      if (rows.length !== 1) {
+        throw new Error(
+          `${label} drift: expected 1 row at depth ${expectedDepth}, got ${rows.length}`,
+        );
+      }
+      if (rows[0]!.id !== `user_${expectedDepth}`) {
+        throw new Error(
+          `${label} drift: expected target user_${expectedDepth}, got ${String(rows[0]!.id)}`,
+        );
+      }
+    };
+
+    const tenHopMs = await benchmarkQuery(
+      "10-hop recursive traversal (linear :NEXT chain)",
+      async () => {
+        const rows = await run(
+          session,
+          `MATCH (u:User {id: "user_0"})-[:NEXT*10..10]->(target:User)
+           RETURN target.id AS id, target.name AS name
+           LIMIT 1`,
+          {},
+        );
+        assertRecursiveHit("10-hop recursive", rows, 10);
+      },
+    );
+
+    const hundredHopMs = await benchmarkQuery(
+      "100-hop recursive traversal (linear :NEXT chain)",
+      async () => {
+        const rows = await run(
+          session,
+          `MATCH (u:User {id: "user_0"})-[:NEXT*100..100]->(target:User)
+           RETURN target.id AS id
+           LIMIT 1`,
+          {},
+        );
+        assertRecursiveHit("100-hop recursive", rows, 100);
+      },
+    );
+
+    const thousandHopMs = await benchmarkQuery(
+      "1000-hop recursive traversal (linear :NEXT chain)",
+      async () => {
+        const rows = await run(
+          session,
+          `MATCH (u:User {id: "user_0"})-[:NEXT*1000..1000]->(target:User)
+           RETURN target.id AS id
+           LIMIT 1`,
+          {},
+        );
+        assertRecursiveHit("1000-hop recursive", rows, 1000);
+      },
+    );
+
+    const metrics: Metrics = {
+      forwardMs,
+      cachedExecuteMs,
+      preparedExecuteMs,
+      reverseMs,
+      twoHopMs,
+      threeHopMs,
+      aggregateMs,
+      aggregateDistinctMs,
+      tenHopMs,
+      hundredHopMs,
+      thousandHopMs,
+    };
+
+    console.log("");
+    console.log("Ratios:");
+    console.log(`reverse/forward: ${(reverseMs / forwardMs).toFixed(2)}x`);
+    console.log(`3-hop/2-hop: ${(threeHopMs / twoHopMs).toFixed(2)}x`);
+    console.log(
+      `aggregateDistinct/aggregate: ${(aggregateDistinctMs / aggregateMs).toFixed(2)}x`,
+    );
+    console.log(
+      `prepared/cached: ${(preparedExecuteMs / cachedExecuteMs).toFixed(2)}x`,
+    );
+    console.log(`100-hop/10-hop: ${(hundredHopMs / tenHopMs).toFixed(2)}x`);
+    console.log(
+      `1000-hop/100-hop: ${(thousandHopMs / hundredHopMs).toFixed(2)}x`,
+    );
+
+    return metrics;
+  } finally {
+    await session.close();
+    await driver.close();
+  }
+}
+
+await main();

--- a/packages/benchmarks/neo4j-compare/src/config.ts
+++ b/packages/benchmarks/neo4j-compare/src/config.ts
@@ -1,0 +1,21 @@
+/**
+ * Mirrors packages/benchmarks/src/config.ts so the graph shape and
+ * measurement methodology match exactly.
+ */
+export const BENCHMARK_CONFIG = {
+  userCount: 1200,
+  followsPerUser: 10,
+  postsPerUser: 5,
+  userBioBytes: 1024,
+  postBodyBytes: 4096,
+  batchSize: 250,
+  warmupIterations: 2,
+  sampleIterations: 15,
+} as const;
+
+export const NEO4J_CONFIG = {
+  url: process.env.NEO4J_URL ?? "bolt://localhost:7687",
+  user: process.env.NEO4J_USER ?? "neo4j",
+  password: process.env.NEO4J_PASSWORD ?? "benchpass",
+  database: process.env.NEO4J_DATABASE ?? "neo4j",
+} as const;

--- a/packages/benchmarks/neo4j-compare/src/seed.ts
+++ b/packages/benchmarks/neo4j-compare/src/seed.ts
@@ -1,0 +1,209 @@
+/**
+ * Seeds Neo4j with the same graph shape as the TypeGraph benchmark suite:
+ *
+ *   - 1,200 :User nodes (id, name, city, ~1KB bio)
+ *   - 6,000 :Post nodes (id, title, ~4KB body)          5 per user
+ *   - 1,199 :NEXT relationships forming a linear chain  user_0 -> user_1 -> ...
+ *   -12,000 :FOLLOWS relationships                       10 per user
+ *   - 6,000 :AUTHORED relationships                       1 per post
+ *
+ * Uses the same xorshift32 RNG seeded with 42 so the follow edges are
+ * byte-identical to the TypeGraph seed.
+ */
+import neo4j, { type Driver } from "neo4j-driver";
+
+import { BENCHMARK_CONFIG, NEO4J_CONFIG } from "./config.ts";
+import { buildPayload, createRng, formatMs, nowMs } from "./utils.ts";
+
+type User = { id: string; name: string; city: string; bio: string };
+type Post = { id: string; authorId: string; title: string; body: string };
+type Edge = { fromId: string; toId: string };
+
+function buildUsers(): readonly User[] {
+  return Array.from({ length: BENCHMARK_CONFIG.userCount }, (_, index) => ({
+    id: `user_${index}`,
+    name: `User ${index}`,
+    city: index % 3 === 0 ? "San Francisco" : "New York",
+    bio: buildPayload(`bio_${index}`, BENCHMARK_CONFIG.userBioBytes),
+  }));
+}
+
+function buildPosts(users: readonly User[]): readonly Post[] {
+  const posts: Post[] = [];
+  for (const user of users) {
+    for (
+      let postIndex = 0;
+      postIndex < BENCHMARK_CONFIG.postsPerUser;
+      postIndex += 1
+    ) {
+      posts.push({
+        id: `post_${user.id}_${postIndex}`,
+        authorId: user.id,
+        title: `Post ${user.id} ${postIndex}`,
+        body: buildPayload(
+          `body_${user.id}_${postIndex}`,
+          BENCHMARK_CONFIG.postBodyBytes,
+        ),
+      });
+    }
+  }
+  return posts;
+}
+
+function buildFollowEdges(rng: () => number): readonly Edge[] {
+  const maxFollows = Math.min(
+    BENCHMARK_CONFIG.followsPerUser,
+    BENCHMARK_CONFIG.userCount - 1,
+  );
+  const edges: Edge[] = [];
+  for (
+    let fromIndex = 0;
+    fromIndex < BENCHMARK_CONFIG.userCount;
+    fromIndex += 1
+  ) {
+    const seen = new Set<number>();
+    while (seen.size < maxFollows) {
+      const skew = rng();
+      const candidate =
+        skew < 0.2 ?
+          Math.floor(rng() * 50)
+        : Math.floor(rng() * BENCHMARK_CONFIG.userCount);
+      if (candidate === fromIndex || seen.has(candidate)) continue;
+      seen.add(candidate);
+      edges.push({ fromId: `user_${fromIndex}`, toId: `user_${candidate}` });
+    }
+  }
+  return edges;
+}
+
+function buildNextEdges(users: readonly User[]): readonly Edge[] {
+  const edges: Edge[] = [];
+  for (let index = 0; index < users.length - 1; index += 1) {
+    edges.push({ fromId: users[index]!.id, toId: users[index + 1]!.id });
+  }
+  return edges;
+}
+
+async function resetAndIndex(driver: Driver): Promise<void> {
+  const session = driver.session({ database: NEO4J_CONFIG.database });
+  try {
+    await session.run("MATCH (n) DETACH DELETE n");
+    await session.run(
+      "CREATE INDEX user_id IF NOT EXISTS FOR (u:User) ON (u.id)",
+    );
+    await session.run(
+      "CREATE INDEX post_id IF NOT EXISTS FOR (p:Post) ON (p.id)",
+    );
+    // Wait for indexes to be online before we start seeding.
+    await session.run("CALL db.awaitIndexes(30000)");
+  } finally {
+    await session.close();
+  }
+}
+
+async function loadUsers(
+  driver: Driver,
+  users: readonly User[],
+): Promise<void> {
+  const session = driver.session({ database: NEO4J_CONFIG.database });
+  try {
+    for (let i = 0; i < users.length; i += BENCHMARK_CONFIG.batchSize) {
+      const batch = users.slice(i, i + BENCHMARK_CONFIG.batchSize);
+      await session.run(
+        `UNWIND $rows AS row
+         CREATE (u:User {id: row.id, name: row.name, city: row.city, bio: row.bio})`,
+        { rows: batch },
+      );
+    }
+  } finally {
+    await session.close();
+  }
+}
+
+async function loadPosts(
+  driver: Driver,
+  posts: readonly Post[],
+): Promise<void> {
+  const session = driver.session({ database: NEO4J_CONFIG.database });
+  try {
+    for (let i = 0; i < posts.length; i += BENCHMARK_CONFIG.batchSize) {
+      const batch = posts.slice(i, i + BENCHMARK_CONFIG.batchSize);
+      await session.run(
+        `UNWIND $rows AS row
+         CREATE (p:Post {id: row.id, title: row.title, body: row.body})`,
+        { rows: batch },
+      );
+    }
+  } finally {
+    await session.close();
+  }
+}
+
+async function loadRelationships(
+  driver: Driver,
+  relType: "FOLLOWS" | "NEXT" | "AUTHORED",
+  fromLabel: "User" | "Post",
+  toLabel: "User" | "Post",
+  edges: readonly Edge[],
+): Promise<void> {
+  const session = driver.session({ database: NEO4J_CONFIG.database });
+  try {
+    for (let i = 0; i < edges.length; i += BENCHMARK_CONFIG.batchSize) {
+      const batch = edges.slice(i, i + BENCHMARK_CONFIG.batchSize);
+      await session.run(
+        `UNWIND $rows AS row
+         MATCH (a:${fromLabel} {id: row.fromId})
+         MATCH (b:${toLabel}   {id: row.toId})
+         CREATE (a)-[:${relType}]->(b)`,
+        { rows: batch },
+      );
+    }
+  } finally {
+    await session.close();
+  }
+}
+
+async function main(): Promise<void> {
+  const driver = neo4j.driver(
+    NEO4J_CONFIG.url,
+    neo4j.auth.basic(NEO4J_CONFIG.user, NEO4J_CONFIG.password),
+    { maxConnectionPoolSize: 10 },
+  );
+
+  try {
+    const rng = createRng(42);
+    const users = buildUsers();
+    const posts = buildPosts(users);
+    const nextEdges = buildNextEdges(users);
+    const followEdges = buildFollowEdges(rng);
+    const authoredEdges: readonly Edge[] = posts.map((p) => ({
+      fromId: p.authorId,
+      toId: p.id,
+    }));
+
+    console.log(`Neo4j seed: ${NEO4J_CONFIG.url} (${NEO4J_CONFIG.database})`);
+
+    const startedAt = nowMs();
+
+    await resetAndIndex(driver);
+    await loadUsers(driver, users);
+    await loadPosts(driver, posts);
+    await loadRelationships(driver, "NEXT", "User", "User", nextEdges);
+    await loadRelationships(driver, "FOLLOWS", "User", "User", followEdges);
+    await loadRelationships(driver, "AUTHORED", "User", "Post", authoredEdges);
+
+    const elapsed = nowMs() - startedAt;
+    const total =
+      users.length +
+      posts.length +
+      nextEdges.length +
+      followEdges.length +
+      authoredEdges.length;
+
+    console.log(`ingestion: ${formatMs(elapsed)} for ${total} items`);
+  } finally {
+    await driver.close();
+  }
+}
+
+await main();

--- a/packages/benchmarks/neo4j-compare/src/utils.ts
+++ b/packages/benchmarks/neo4j-compare/src/utils.ts
@@ -1,0 +1,39 @@
+/**
+ * Matches packages/benchmarks/src/utils.ts and seed.ts behavior so the
+ * generated graph shape is byte-identical across both benchmark runs.
+ */
+export function nowMs(): number {
+  return Number(process.hrtime.bigint()) / 1_000_000;
+}
+
+export function median(samples: readonly number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1]! + sorted[mid]!) / 2;
+  }
+  return sorted[mid]!;
+}
+
+export function formatMs(ms: number): string {
+  return `${ms.toFixed(1)}ms`;
+}
+
+/**
+ * xorshift32 RNG — identical to packages/benchmarks/src/seed.ts so that a
+ * seeded run produces the exact same follow edges as the TypeGraph benchmark.
+ */
+export function createRng(seed_: number): () => number {
+  let seed = seed_;
+  return function next(): number {
+    seed ^= seed << 13;
+    seed ^= seed >>> 17;
+    seed ^= seed << 5;
+    return (seed >>> 0) / 4_294_967_295;
+  };
+}
+
+export function buildPayload(prefix: string, bytes: number): string {
+  const chunk = `${prefix}|`;
+  return chunk.repeat(Math.ceil(bytes / chunk.length)).slice(0, bytes);
+}

--- a/packages/benchmarks/neo4j-compare/tsconfig.json
+++ b/packages/benchmarks/neo4j-compare/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -20,6 +20,7 @@
     "better-sqlite3": "^12.9.0",
     "drizzle-orm": "^0.45.2",
     "pg": "^8.20.0",
+    "sqlite-vec": "^0.1.9",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/benchmarks/src/backend.ts
+++ b/packages/benchmarks/src/backend.ts
@@ -1,22 +1,61 @@
+import { createRequire } from "node:module";
+
+import Database from "better-sqlite3";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
 import { drizzle as drizzlePostgres } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { createStore } from "@nicia-ai/typegraph";
 import {
   createPostgresBackend,
+  createPostgresTables,
   generatePostgresMigrationSQL,
 } from "@nicia-ai/typegraph/postgres";
-import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+import {
+  createSqliteBackend,
+  createSqliteTables,
+  generateSqliteDDL,
+} from "@nicia-ai/typegraph/sqlite";
 
 import { DEFAULT_POSTGRES_URL, type PerfBackend } from "./config";
-import { perfGraph, type PerfStore } from "./graph";
+import { perfGraph, perfIndexes, type PerfStore } from "./graph";
 
 type BackendResources = Readonly<{
   store: PerfStore;
   close: () => Promise<void>;
+  /**
+   * True when the backend can evaluate `similarTo()` predicates:
+   * `sqlite-vec` is loaded on SQLite, or `pgvector` is available on
+   * PostgreSQL. The query-builder vector path uses this.
+   */
+  hasVectorPredicate: boolean;
+  /**
+   * True when `store.search.hybrid(...)` works. Requires the backend to
+   * implement the `vectorSearch` capability — currently PostgreSQL only.
+   */
+  hasHybridFacade: boolean;
 }>;
 
 function getPostgresUrl(): string {
   return process.env.POSTGRES_URL ?? DEFAULT_POSTGRES_URL;
+}
+
+/**
+ * Attempt to load `sqlite-vec` into a better-sqlite3 connection. Returns
+ * true on success. When sqlite-vec is missing (e.g. CI without the
+ * optional dep) we quietly skip vector measurements rather than fail.
+ */
+const sqliteVecRequire = createRequire(import.meta.url);
+
+function loadSqliteVec(sqlite: Database.Database): boolean {
+  try {
+    const sqliteVec = sqliteVecRequire("sqlite-vec") as {
+      load: (db: Database.Database) => void;
+    };
+    sqliteVec.load(sqlite);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function resetPostgresTables(pool: Pool): Promise<void> {
@@ -26,20 +65,42 @@ async function resetPostgresTables(pool: Pool): Promise<void> {
     DROP TABLE IF EXISTS typegraph_edges CASCADE;
     DROP TABLE IF EXISTS typegraph_nodes CASCADE;
     DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+    DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;
   `);
-  await pool.query(generatePostgresMigrationSQL());
+  const tables = createPostgresTables({}, { indexes: perfIndexes });
+  await pool.query(generatePostgresMigrationSQL(tables));
 }
 
 export async function createBackendResources(
   backend: PerfBackend,
 ): Promise<BackendResources> {
   if (backend === "sqlite") {
-    const sqlite = createLocalSqliteBackend();
+    const tables = createSqliteTables({}, { indexes: perfIndexes });
+    const sqlite = new Database(":memory:");
+    const hasVectorEmbeddings = loadSqliteVec(sqlite);
+
+    for (const statement of generateSqliteDDL(tables)) {
+      sqlite.exec(statement);
+    }
+    const db = drizzleSqlite(sqlite);
+    const sqliteBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables,
+      hasVectorEmbeddings,
+    });
     return {
-      store: createStore(perfGraph, sqlite.backend, {
+      store: createStore(perfGraph, sqliteBackend, {
         queryDefaults: { traversalExpansion: "none" },
       }),
-      close: async () => sqlite.backend.close(),
+      close: async () => {
+        sqliteBackend.close();
+        sqlite.close();
+      },
+      hasVectorPredicate: sqliteBackend.upsertEmbedding !== undefined,
+      // The SQLite backend doesn't implement the hybrid-search facade
+      // capability (no `backend.vectorSearch`); store.search.hybrid() is
+      // PostgreSQL-only today.
+      hasHybridFacade: false,
     };
   }
 
@@ -61,7 +122,8 @@ export async function createBackendResources(
     );
   }
 
-  const postgresBackend = createPostgresBackend(drizzleDb);
+  const tables = createPostgresTables({}, { indexes: perfIndexes });
+  const postgresBackend = createPostgresBackend(drizzleDb, { tables });
   return {
     store: createStore(perfGraph, postgresBackend, {
       queryDefaults: { traversalExpansion: "none" },
@@ -70,5 +132,9 @@ export async function createBackendResources(
       await postgresBackend.close();
       await pool.end();
     },
+    // The migration enables the pgvector extension, so vector predicates
+    // and the hybrid facade are available on Postgres.
+    hasVectorPredicate: true,
+    hasHybridFacade: true,
   };
 }

--- a/packages/benchmarks/src/cli.ts
+++ b/packages/benchmarks/src/cli.ts
@@ -10,6 +10,16 @@ function parseBackend(rawBackend: string): PerfBackend {
   );
 }
 
+function parseScale(raw: string): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `Invalid --scale value: "${raw}". Must be a positive number.`,
+    );
+  }
+  return parsed;
+}
+
 export function parseCliOptions(argv: readonly string[]): PerfCliOptions {
   const runChecks = argv.includes("--check");
   const backendArgument = argv.find((argument) =>
@@ -20,8 +30,17 @@ export function parseCliOptions(argv: readonly string[]): PerfCliOptions {
       parseBackend(backendArgument.slice(10))
     );
 
+  const scaleArgument = argv.find((argument) =>
+    argument.startsWith("--scale="),
+  );
+  const scale =
+    scaleArgument === undefined ? 1 : (
+      parseScale(scaleArgument.slice("--scale=".length))
+    );
+
   return {
     runChecks,
     backend,
+    scale,
   };
 }

--- a/packages/benchmarks/src/config.ts
+++ b/packages/benchmarks/src/config.ts
@@ -1,4 +1,4 @@
-export const BENCHMARK_CONFIG = {
+const BASE_BENCHMARK_CONFIG = {
   userCount: 1200,
   followsPerUser: 10,
   postsPerUser: 5,
@@ -9,15 +9,65 @@ export const BENCHMARK_CONFIG = {
   sampleIterations: 15,
 } as const;
 
+/**
+ * Active benchmark configuration.
+ *
+ * Mutable because `--scale=N` scales `userCount` at startup. All other
+ * values are stable so per-user/per-post density doesn't drift with scale.
+ */
+export const BENCHMARK_CONFIG: {
+  userCount: number;
+  readonly followsPerUser: number;
+  readonly postsPerUser: number;
+  readonly userBioBytes: number;
+  readonly postBodyBytes: number;
+  readonly batchSize: number;
+  readonly warmupIterations: number;
+  readonly sampleIterations: number;
+} = { ...BASE_BENCHMARK_CONFIG };
+
+/**
+ * Minimum scale supported by the benchmark. Smaller values would reduce
+ * the graph below the 1000-hop recursive benchmark's required chain
+ * length, causing those measurements to silently return empty results.
+ * Tighten the recursive shapes and drop this if you need sub-1× scales.
+ */
+const MIN_SCALE = 1;
+
+export function applyScale(scale: number): void {
+  if (!Number.isFinite(scale) || scale <= 0) {
+    throw new Error(
+      `Invalid --scale value: ${scale}. Must be a positive number.`,
+    );
+  }
+  if (scale < MIN_SCALE) {
+    throw new Error(
+      `--scale=${scale} would shrink the graph below the 1000-hop recursive ` +
+        `benchmark's required chain length (1001 users). Minimum supported ` +
+        `scale is ${MIN_SCALE}.`,
+    );
+  }
+  BENCHMARK_CONFIG.userCount = Math.round(
+    BASE_BENCHMARK_CONFIG.userCount * scale,
+  );
+}
+
 const BASE_GUARDRAILS = {
   reverseToForwardRatioMax: 6,
   inverseTraversalMsMax: 500,
   inverseToForwardRatioMax: 10,
   threeHopMsMax: 500,
   threeHopToTwoHopRatioMax: 8,
-  aggregateMsMax: 500,
-  aggregateDistinctMsMax: 700,
+  aggregateMsMax: 100,
+  aggregateDistinctMsMax: 100,
   aggregateDistinctToAggregateRatioMax: 4,
+  aggregateEdgesMsMax: 50,
+  scopedAggregateMsMax: 50,
+  indexedFilterMsMax: 50,
+  temporalAsOfMsMax: 50,
+  fulltextSearchMsMax: 100,
+  vectorSearchMsMax: 200,
+  hybridSearchMsMax: 300,
   cachedExecuteMsMax: 500,
   preparedExecuteMsMax: 500,
   preparedToCachedRatioMax: 2,
@@ -38,7 +88,15 @@ const BACKEND_GUARDRAIL_OVERRIDES = {
     threeHopMsMax: 1000,
     inverseTraversalMsMax: 1000,
     inverseToForwardRatioMax: 30,
-    aggregateDistinctMsMax: 1200,
+    aggregateMsMax: 300,
+    aggregateDistinctMsMax: 300,
+    aggregateEdgesMsMax: 200,
+    scopedAggregateMsMax: 200,
+    indexedFilterMsMax: 200,
+    temporalAsOfMsMax: 200,
+    fulltextSearchMsMax: 300,
+    vectorSearchMsMax: 500,
+    hybridSearchMsMax: 800,
     preparedExecuteMsMax: 700,
   },
 } as const;
@@ -51,6 +109,7 @@ export type PerfBackend = "sqlite" | "postgres";
 export type PerfCliOptions = Readonly<{
   runChecks: boolean;
   backend: PerfBackend;
+  scale: number;
 }>;
 
 export type Guardrails = Readonly<{
@@ -62,6 +121,13 @@ export type Guardrails = Readonly<{
   aggregateMsMax: number;
   aggregateDistinctMsMax: number;
   aggregateDistinctToAggregateRatioMax: number;
+  aggregateEdgesMsMax: number;
+  scopedAggregateMsMax: number;
+  indexedFilterMsMax: number;
+  temporalAsOfMsMax: number;
+  fulltextSearchMsMax: number;
+  vectorSearchMsMax: number;
+  hybridSearchMsMax: number;
   cachedExecuteMsMax: number;
   preparedExecuteMsMax: number;
   preparedToCachedRatioMax: number;
@@ -93,6 +159,15 @@ export type QueryMetrics = Readonly<{
   threeHopMs: number;
   aggregateMs: number;
   aggregateDistinctMs: number;
+  aggregateEdgesMs: number;
+  scopedAggregateMs: number;
+  indexedFilterMs: number;
+  temporalAsOfMs: number;
+  fulltextSearchMs: number;
+  /** `undefined` when vector search is unavailable at this backend. */
+  vectorSearchMs: number | undefined;
+  /** `undefined` when vector search is unavailable at this backend. */
+  hybridSearchMs: number | undefined;
   cachedExecuteMs: number;
   preparedExecuteMs: number;
   subgraphFullMs: number;

--- a/packages/benchmarks/src/graph.ts
+++ b/packages/benchmarks/src/graph.ts
@@ -3,8 +3,11 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  embedding,
   inverseOf,
+  searchable,
 } from "@nicia-ai/typegraph";
+import { defineNodeIndex } from "@nicia-ai/typegraph/indexes";
 import { z } from "zod";
 
 const User = defineNode("User", {
@@ -22,15 +25,47 @@ const Post = defineNode("Post", {
   }),
 });
 
+export const EMBEDDING_DIMENSIONS = 384;
+
+/**
+ * Dedicated node kind for search-shape benchmarks. Keeping `Doc` separate
+ * from `User`/`Post` means adding fulltext and embedding fields doesn't
+ * change the measurements of the original shapes.
+ */
+const Doc = defineNode("Doc", {
+  schema: z.object({
+    title: searchable({ language: "english" }),
+    body: searchable({ language: "english" }),
+    category: z.string(),
+    embedding: embedding(EMBEDDING_DIMENSIONS),
+  }),
+});
+
 const follows = defineEdge("follows");
 const authored = defineEdge("authored");
 const nextEdge = defineEdge("next");
+
+/**
+ * Expression index on `User.city` with `name` as a covering field.
+ *
+ * Seeded data splits users across two cities (1/3 San Francisco, 2/3
+ * New York), so filter-by-city returns hundreds of rows. With the covering
+ * field, smart-select queries that touch `name` can be satisfied as
+ * index-only scans. Paired with `perfTables` in backend setup.
+ */
+const userCityIndex = defineNodeIndex(User, {
+  fields: ["city"],
+  coveringFields: ["name"],
+});
+
+export const perfIndexes = [userCityIndex];
 
 export const perfGraph = defineGraph({
   id: "perf_sanity",
   nodes: {
     User: { type: User },
     Post: { type: Post },
+    Doc: { type: Doc },
   },
   edges: {
     follows: {

--- a/packages/benchmarks/src/guardrails.ts
+++ b/packages/benchmarks/src/guardrails.ts
@@ -88,6 +88,68 @@ export function evaluateGuardrails(
     });
   }
 
+  if (metrics.scopedAggregateMs > guardrails.scopedAggregateMsMax) {
+    violations.push({
+      label: "scoped aggregate latency (ms)",
+      actual: metrics.scopedAggregateMs,
+      expectedMax: guardrails.scopedAggregateMsMax,
+    });
+  }
+
+  if (metrics.aggregateEdgesMs > guardrails.aggregateEdgesMsMax) {
+    violations.push({
+      label: "aggregate edges latency (ms)",
+      actual: metrics.aggregateEdgesMs,
+      expectedMax: guardrails.aggregateEdgesMsMax,
+    });
+  }
+
+  if (metrics.indexedFilterMs > guardrails.indexedFilterMsMax) {
+    violations.push({
+      label: "indexed filter latency (ms)",
+      actual: metrics.indexedFilterMs,
+      expectedMax: guardrails.indexedFilterMsMax,
+    });
+  }
+
+  if (metrics.temporalAsOfMs > guardrails.temporalAsOfMsMax) {
+    violations.push({
+      label: "temporal asOf latency (ms)",
+      actual: metrics.temporalAsOfMs,
+      expectedMax: guardrails.temporalAsOfMsMax,
+    });
+  }
+
+  if (metrics.fulltextSearchMs > guardrails.fulltextSearchMsMax) {
+    violations.push({
+      label: "fulltext search latency (ms)",
+      actual: metrics.fulltextSearchMs,
+      expectedMax: guardrails.fulltextSearchMsMax,
+    });
+  }
+
+  if (
+    metrics.vectorSearchMs !== undefined &&
+    metrics.vectorSearchMs > guardrails.vectorSearchMsMax
+  ) {
+    violations.push({
+      label: "vector search latency (ms)",
+      actual: metrics.vectorSearchMs,
+      expectedMax: guardrails.vectorSearchMsMax,
+    });
+  }
+
+  if (
+    metrics.hybridSearchMs !== undefined &&
+    metrics.hybridSearchMs > guardrails.hybridSearchMsMax
+  ) {
+    violations.push({
+      label: "hybrid search latency (ms)",
+      actual: metrics.hybridSearchMs,
+      expectedMax: guardrails.hybridSearchMsMax,
+    });
+  }
+
   if (metrics.cachedExecuteMs > guardrails.cachedExecuteMsMax) {
     violations.push({
       label: "cached execute latency (ms)",

--- a/packages/benchmarks/src/history.ts
+++ b/packages/benchmarks/src/history.ts
@@ -1,0 +1,82 @@
+import { execSync } from "node:child_process";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { type PerfBackend } from "./config";
+import { type LatencyRecord } from "./measurements";
+
+/**
+ * Per-run append to `packages/benchmarks/reports/history.jsonl` so
+ * trend analysis is a `grep`/`jq` away. One JSONL line per run.
+ */
+type HistoryEntry = Readonly<{
+  timestamp: string;
+  gitSha: string;
+  gitRefName: string | undefined;
+  backend: PerfBackend;
+  scale: number;
+  userCount: number;
+  latencies: Readonly<
+    Record<string, Readonly<{ median: number; p95: number }>>
+  >;
+}>;
+
+function resolveGitSha(): string {
+  try {
+    return execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function resolveGitRefName(): string | undefined {
+  try {
+    const ref = execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf-8",
+    }).trim();
+    return ref === "HEAD" ? undefined : ref;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveHistoryPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // src/ -> ../reports/history.jsonl
+  return join(here, "..", "reports", "history.jsonl");
+}
+
+function serializeLatencies(record: LatencyRecord): HistoryEntry["latencies"] {
+  const out: Record<string, { median: number; p95: number }> = {};
+  for (const [label, sample] of record) {
+    out[label] = {
+      median: Number(sample.median.toFixed(3)),
+      p95: Number(sample.p95.toFixed(3)),
+    };
+  }
+  return out;
+}
+
+type WriteHistoryInput = Readonly<{
+  backend: PerfBackend;
+  scale: number;
+  userCount: number;
+  latencies: LatencyRecord;
+}>;
+
+export function writeHistoryEntry(input: WriteHistoryInput): string {
+  const entry: HistoryEntry = {
+    timestamp: new Date().toISOString(),
+    gitSha: resolveGitSha(),
+    gitRefName: resolveGitRefName(),
+    backend: input.backend,
+    scale: input.scale,
+    userCount: input.userCount,
+    latencies: serializeLatencies(input.latencies),
+  };
+  const path = resolveHistoryPath();
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(entry)}\n`, "utf-8");
+  return path;
+}

--- a/packages/benchmarks/src/main.ts
+++ b/packages/benchmarks/src/main.ts
@@ -1,26 +1,50 @@
 import { createBackendResources } from "./backend";
 import { parseCliOptions } from "./cli";
-import { getGuardrails } from "./config";
+import { applyScale, BENCHMARK_CONFIG, getGuardrails } from "./config";
 import {
   evaluateGuardrails,
   printGuardrailFailures,
   printSummary,
 } from "./guardrails";
+import { writeHistoryEntry } from "./history";
 import { measureQueries } from "./measurements";
 import { seedStore } from "./seed";
 
 async function main(argv: readonly string[]): Promise<void> {
   const options = parseCliOptions(argv);
+  applyScale(options.scale);
+  const scaleSuffix = options.scale === 1 ? "" : `, scale=${options.scale}`;
   console.log(
-    `TypeGraph perf sanity (${options.runChecks ? "guardrail mode" : "report mode"}, backend=${options.backend})`,
+    `TypeGraph perf sanity (${options.runChecks ? "guardrail mode" : "report mode"}, backend=${options.backend}${scaleSuffix}, users=${BENCHMARK_CONFIG.userCount})`,
   );
 
   const resources = await createBackendResources(options.backend);
+  if (!resources.hasVectorPredicate) {
+    console.log(
+      "(vector predicate unavailable on this backend — vector and hybrid measurements will be skipped)",
+    );
+  } else if (!resources.hasHybridFacade) {
+    console.log(
+      "(hybrid-search facade not implemented on this backend — hybrid measurement will be skipped)",
+    );
+  }
   try {
-    await seedStore(resources.store);
+    const seedResult = await seedStore(resources.store);
 
-    const metrics = await measureQueries(resources.store);
+    const { metrics, latencies } = await measureQueries(resources.store, {
+      hasVectorPredicate: resources.hasVectorPredicate,
+      hasHybridFacade: resources.hasHybridFacade,
+      docs: seedResult.docs,
+    });
     printSummary(metrics);
+
+    const historyPath = writeHistoryEntry({
+      backend: options.backend,
+      scale: options.scale,
+      userCount: BENCHMARK_CONFIG.userCount,
+      latencies,
+    });
+    console.log(`\nappended run to ${historyPath}`);
 
     if (!options.runChecks) {
       return;

--- a/packages/benchmarks/src/measurements.ts
+++ b/packages/benchmarks/src/measurements.ts
@@ -1,8 +1,23 @@
-import { count, countDistinct, field, param } from "@nicia-ai/typegraph";
+import {
+  count,
+  countDistinct,
+  countEdges,
+  field,
+  param,
+} from "@nicia-ai/typegraph";
 
 import { BENCHMARK_CONFIG, type QueryMetrics } from "./config";
 import { type PerfStore } from "./graph";
-import { formatMs, median, nowMs } from "./utils";
+import { TEMPORAL_ARCHIVE_ASOF } from "./seed";
+import { formatMs, median, nowMs, percentile } from "./utils";
+
+export type LatencySample = Readonly<{
+  median: number;
+  p95: number;
+  samples: readonly number[];
+}>;
+
+export type LatencyRecord = Map<string, LatencySample>;
 
 type SubgraphNode = Readonly<{ kind: string; id: string }>;
 type SubgraphEdge = Readonly<{ id: string; fromId: string; toId: string }>;
@@ -57,6 +72,7 @@ const SUBGRAPH_STRESS_OPTIONS = {
 async function benchmarkQuery(
   label: string,
   fn: () => Promise<void>,
+  record: LatencyRecord,
 ): Promise<number> {
   for (
     let iteration = 0;
@@ -77,9 +93,13 @@ async function benchmarkQuery(
     samples.push(nowMs() - startedAt);
   }
 
-  const result = median(samples);
-  console.log(`${label}: ${formatMs(result)}`);
-  return result;
+  const medianResult = median(samples);
+  const p95Result = percentile(samples, 0.95);
+  record.set(label, { median: medianResult, p95: p95Result, samples });
+  console.log(
+    `${label}: ${formatMs(medianResult)} (p95 ${formatMs(p95Result)})`,
+  );
+  return medianResult;
 }
 
 function sumEdgeChecksum(
@@ -170,7 +190,19 @@ async function logSubgraphShape(
   console.log(`${label}: ${result.nodes.size} nodes, ${edgeCount} edges`);
 }
 
-export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
+type MeasurementContext = Readonly<{
+  hasVectorPredicate: boolean;
+  hasHybridFacade: boolean;
+  docs: readonly { id: string; embedding: readonly number[] }[] | undefined;
+}>;
+
+export async function measureQueries(
+  store: PerfStore,
+  context: MeasurementContext,
+): Promise<{ metrics: QueryMetrics; latencies: LatencyRecord }> {
+  const latencies: LatencyRecord = new Map();
+  const bench = (label: string, fn: () => Promise<void>): Promise<number> =>
+    benchmarkQuery(label, fn, latencies);
   const cachedExecuteQuery = store
     .query()
     .from("User", "u")
@@ -188,8 +220,11 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     .select((context) => ({ friendName: context.friend.name }))
     .prepare();
 
-  const forwardMs = await benchmarkQuery("forward traversal", async () => {
-    await store
+  // Every User in the seed has exactly followsPerUser (10) outgoing
+  // follows, so user_0's forward-traversal cardinality is an invariant.
+  const expectedForwardCount = BENCHMARK_CONFIG.followsPerUser;
+  const forwardMs = await bench("forward traversal", async () => {
+    const rows = await store
       .query()
       .from("User", "u")
       .whereNode("u", (user) => user.id.eq("user_0"))
@@ -197,21 +232,33 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
       .to("User", "friend")
       .select((context) => ({ friendName: context.friend.name }))
       .execute();
+    if (rows.length !== expectedForwardCount) {
+      throw new Error(
+        `forward traversal drift: expected ${expectedForwardCount} rows, got ${rows.length}`,
+      );
+    }
   });
 
-  const cachedExecuteMs = await benchmarkQuery(
+  const cachedExecuteMs = await bench(
     "cached execute (same query instance)",
     async () => {
-      await cachedExecuteQuery.execute();
+      const rows = await cachedExecuteQuery.execute();
+      if (rows.length !== expectedForwardCount) {
+        throw new Error(
+          `cached execute drift: expected ${expectedForwardCount} rows, got ${rows.length}`,
+        );
+      }
     },
   );
 
-  const preparedExecuteMs = await benchmarkQuery(
-    "prepared execute",
-    async () => {
-      await preparedExecuteQuery.execute({ userId: "user_0" });
-    },
-  );
+  const preparedExecuteMs = await bench("prepared execute", async () => {
+    const rows = await preparedExecuteQuery.execute({ userId: "user_0" });
+    if (rows.length !== expectedForwardCount) {
+      throw new Error(
+        `prepared execute drift: expected ${expectedForwardCount} rows, got ${rows.length}`,
+      );
+    }
+  });
 
   await logSubgraphShape(
     store,
@@ -219,7 +266,7 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     SUBGRAPH_BASELINE_OPTIONS,
   );
 
-  const subgraphFullMs = await benchmarkQuery(
+  const subgraphFullMs = await bench(
     "subgraph full hydration (wide payload, depth 2)",
     async () => {
       const result = await store.subgraph(
@@ -234,7 +281,7 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     },
   );
 
-  const subgraphApplicationProjectionMs = await benchmarkQuery(
+  const subgraphApplicationProjectionMs = await bench(
     "subgraph full hydration + app projection (wide payload, depth 2)",
     async () => {
       const result = await store.subgraph(
@@ -249,7 +296,7 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     },
   );
 
-  const subgraphSqlProjectionMs = await benchmarkQuery(
+  const subgraphSqlProjectionMs = await bench(
     "subgraph SQL projection (wide payload, depth 2)",
     async () => {
       const result = await store.subgraph("user_0" as never, {
@@ -279,7 +326,7 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     SUBGRAPH_STRESS_OPTIONS,
   );
 
-  const subgraphStressFullMs = await benchmarkQuery(
+  const subgraphStressFullMs = await bench(
     "subgraph full hydration (wide payload, depth 3 stress)",
     async () => {
       const result = await store.subgraph(
@@ -294,7 +341,7 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     },
   );
 
-  const subgraphStressApplicationProjectionMs = await benchmarkQuery(
+  const subgraphStressApplicationProjectionMs = await bench(
     "subgraph full hydration + app projection (wide payload, depth 3 stress)",
     async () => {
       const result = await store.subgraph(
@@ -309,7 +356,7 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     },
   );
 
-  const subgraphStressSqlProjectionMs = await benchmarkQuery(
+  const subgraphStressSqlProjectionMs = await bench(
     "subgraph SQL projection (wide payload, depth 3 stress)",
     async () => {
       const result = await store.subgraph("user_0" as never, {
@@ -333,8 +380,11 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     },
   );
 
-  const reverseMs = await benchmarkQuery("reverse traversal", async () => {
-    await store
+  // Reverse follow counts depend on the seeded random follow graph and
+  // can vary per-user. Pin it to a non-empty result to catch empty-plan
+  // regressions without baking in a brittle exact count.
+  const reverseMs = await bench("reverse traversal", async () => {
+    const rows = await store
       .query()
       .from("User", "follower")
       .traverse("follows", "e", { expand: "none" })
@@ -342,12 +392,17 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
       .whereNode("target", (target) => target.id.eq("user_0"))
       .select((context) => ({ followerName: context.follower.name }))
       .execute();
+    if (rows.length === 0) {
+      throw new Error("reverse traversal drift: expected non-empty result set");
+    }
   });
 
-  const inverseTraversalMs = await benchmarkQuery(
+  // user_600 sits in the middle of the :next chain, so inverse expansion
+  // (follow + its inverse) should return the two neighbors (user_599, user_601).
+  const inverseTraversalMs = await bench(
     "inverse traversal (expand: inverse)",
     async () => {
-      await store
+      const rows = await store
         .query()
         .from("User", "u")
         .whereNode("u", (user) => user.id.eq("user_600"))
@@ -356,11 +411,18 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
         .select((context) => ({ neighborId: context.neighbor.id }))
         .limit(20)
         .execute();
+      if (rows.length !== 2) {
+        throw new Error(
+          `inverse traversal drift: expected 2 neighbors, got ${rows.length}`,
+        );
+      }
     },
   );
 
-  const twoHopMs = await benchmarkQuery("2-hop traversal", async () => {
-    await store
+  // LIMIT 50 over follows * authored should saturate — every user has
+  // followsPerUser (10) follows and postsPerUser (5) posts each.
+  const twoHopMs = await bench("2-hop traversal", async () => {
+    const rows = await store
       .query()
       .from("User", "u")
       .whereNode("u", (user) => user.id.eq("user_0"))
@@ -374,10 +436,15 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
       }))
       .limit(50)
       .execute();
+    if (rows.length !== 50) {
+      throw new Error(
+        `2-hop drift: expected 50 rows (limit), got ${rows.length}`,
+      );
+    }
   });
 
-  const threeHopMs = await benchmarkQuery("3-hop traversal", async () => {
-    await store
+  const threeHopMs = await bench("3-hop traversal", async () => {
+    const rows = await store
       .query()
       .from("User", "u")
       .whereNode("u", (user) => user.id.eq("user_500"))
@@ -394,30 +461,41 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
       }))
       .limit(20)
       .execute();
+    if (rows.length !== 20) {
+      throw new Error(
+        `3-hop drift: expected 20 rows (limit), got ${rows.length}`,
+      );
+    }
   });
 
-  const aggregateMs = await benchmarkQuery(
-    "aggregate follow count",
-    async () => {
-      await store
-        .query()
-        .from("User", "u")
-        .optionalTraverse("follows", "e", { expand: "none" })
-        .to("User", "target")
-        .groupByNode("u")
-        .aggregate({
-          name: field("u", "name"),
-          followCount: count("target"),
-        })
-        .limit(20)
-        .execute();
-    },
-  );
+  // Full-graph aggregate: COUNT follows per user across every user. This
+  // is the worst case for graph-over-SQL backends because the GROUP BY
+  // runs over the full start set. Intentionally has NO `.limit()` so the
+  // measurement reflects the claimed 1,200-group GROUP BY rather than
+  // 20-row LIMIT push-down.
+  const aggregateMs = await bench("aggregate follow count", async () => {
+    const rows = await store
+      .query()
+      .from("User", "u")
+      .optionalTraverse("follows", "e", { expand: "none" })
+      .to("User", "target")
+      .groupByNode("u")
+      .aggregate({
+        name: field("u", "name"),
+        followCount: count("target"),
+      })
+      .execute();
+    if (rows.length !== BENCHMARK_CONFIG.userCount) {
+      throw new Error(
+        `aggregate cardinality drift: expected ${BENCHMARK_CONFIG.userCount} rows, got ${rows.length}`,
+      );
+    }
+  });
 
-  const aggregateDistinctMs = await benchmarkQuery(
+  const aggregateDistinctMs = await bench(
     "aggregate distinct follow count",
     async () => {
-      await store
+      const rows = await store
         .query()
         .from("User", "u")
         .optionalTraverse("follows", "e", { expand: "none" })
@@ -427,15 +505,238 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
           name: field("u", "name"),
           followCount: countDistinct("target"),
         })
-        .limit(20)
         .execute();
+      if (rows.length !== BENCHMARK_CONFIG.userCount) {
+        throw new Error(
+          `aggregate distinct cardinality drift: expected ${BENCHMARK_CONFIG.userCount} rows, got ${rows.length}`,
+        );
+      }
     },
   );
 
-  const tenHopMs = await benchmarkQuery(
+  // countEdges variant — counts live edges directly without joining to the
+  // target node table. Same graph-level semantics as the `aggregate follow
+  // count` shape above in a graph where no target nodes are validTo-expired
+  // (the benchmark seed only expires archived User rows that have no
+  // incident edges). This benchmark isolates the cost of the target-node
+  // join from the GROUP BY work.
+  const aggregateEdgesMs = await bench(
+    "aggregate follow count (countEdges)",
+    async () => {
+      const rows = await store
+        .query()
+        .from("User", "u")
+        .optionalTraverse("follows", "e", { expand: "none" })
+        .to("User", "target")
+        .groupByNode("u")
+        .aggregate({
+          name: field("u", "name"),
+          followCount: countEdges("e"),
+        })
+        .execute();
+      if (rows.length !== BENCHMARK_CONFIG.userCount) {
+        throw new Error(
+          `aggregate edges cardinality drift: expected ${BENCHMARK_CONFIG.userCount} rows, got ${rows.length}`,
+        );
+      }
+    },
+  );
+
+  // Scoped aggregate: "how many people does user_0 follow?" — the typical
+  // OLTP shape (count relative to a filtered starting point). Contrasts with
+  // the unscoped aggregate above which groups across every user.
+  const scopedAggregateMs = await bench(
+    "scoped aggregate (follow count for single user)",
+    async () => {
+      const rows = await store
+        .query()
+        .from("User", "u")
+        .whereNode("u", (user) => user.id.eq("user_0"))
+        .optionalTraverse("follows", "e", { expand: "none" })
+        .to("User", "target")
+        .groupByNode("u")
+        .aggregate({
+          name: field("u", "name"),
+          followCount: count("target"),
+        })
+        .execute();
+      if (
+        rows.length !== 1 ||
+        rows[0]!.followCount !== BENCHMARK_CONFIG.followsPerUser
+      ) {
+        throw new Error(
+          `scoped aggregate drift: expected 1 row with followCount=${BENCHMARK_CONFIG.followsPerUser}, got ${JSON.stringify(rows)}`,
+        );
+      }
+    },
+  );
+
+  // Indexed property filter: exercises the expression index defined in
+  // graph.ts (`userCityIndex` covers `city` with `name`). Smart select
+  // picks up only the indexed fields, so with a properly configured
+  // covering index the query is satisfied index-only. Regressions here
+  // catch breakage in smart-select or the indexes pipeline.
+  //
+  // Seed splits users 1/3 San Francisco, 2/3 New York; LIMIT 100 saturates
+  // because there are ~400 San Francisco users in the default scale.
+  const indexedFilterMs = await bench(
+    "indexed filter (User.city with covering name)",
+    async () => {
+      const rows = await store
+        .query()
+        .from("User", "u")
+        .whereNode("u", (user) => user.city.eq("San Francisco"))
+        .select((context) => ({
+          id: context.u.id,
+          name: context.u.name,
+        }))
+        .limit(100)
+        .execute();
+      if (rows.length !== 100) {
+        throw new Error(
+          `indexed filter drift: expected 100 rows (limit), got ${rows.length}`,
+        );
+      }
+    },
+  );
+
+  // Temporal `asOf` query: the seed creates an "archived" cohort of users
+  // whose validFrom/validTo bracket a past timestamp. Querying at that
+  // timestamp should surface them (they don't appear in `current`). This
+  // exercises the temporal filter compilation and is a regression canary
+  // for the asOf code path.
+  const expectedArchivedCount = Math.max(
+    50,
+    Math.round(BENCHMARK_CONFIG.userCount * 0.1),
+  );
+  const temporalAsOfMs = await bench(
+    "temporal asOf (archived user cohort)",
+    async () => {
+      const rows = await store
+        .query()
+        .from("User", "u")
+        .temporal("asOf", TEMPORAL_ARCHIVE_ASOF)
+        .whereNode("u", (user) => user.city.eq("Boston"))
+        .select((context) => ({
+          id: context.u.id,
+          name: context.u.name,
+        }))
+        .limit(expectedArchivedCount + 50)
+        .execute();
+      if (rows.length !== expectedArchivedCount) {
+        throw new Error(
+          `temporal asOf drift: expected ${expectedArchivedCount} archived rows, got ${rows.length}`,
+        );
+      }
+    },
+  );
+
+  // Fulltext match: BM25-ranked search over the seeded Doc bodies. SQLite
+  // FTS5 is native; Postgres uses tsvector + GIN. Works regardless of
+  // vector extension availability.
+  const fulltextSearchMs = await bench(
+    "fulltext search (Doc body match)",
+    async () => {
+      const rows = await store
+        .query()
+        .from("Doc", "d")
+        .whereNode("d", (doc) =>
+          doc.$fulltext.matches("climate adaptation", 20),
+        )
+        .select((ctx) => ({
+          id: ctx.d.id,
+          title: ctx.d.title,
+        }))
+        .execute();
+      if (rows.length === 0) {
+        throw new Error("fulltext search drift: expected non-empty result set");
+      }
+    },
+  );
+
+  const sampleEmbedding = context.docs?.[0]?.embedding;
+
+  const vectorSearchMs =
+    context.hasVectorPredicate && sampleEmbedding !== undefined ?
+      await bench("vector search (Doc cosine top-20)", async () => {
+        const rows = await store
+          .query()
+          .from("Doc", "d")
+          .whereNode("d", (doc) =>
+            doc.embedding.similarTo(sampleEmbedding, 20, {
+              metric: "cosine",
+            }),
+          )
+          .select((ctx) => ({
+            id: ctx.d.id,
+            title: ctx.d.title,
+          }))
+          .execute();
+        if (rows.length !== 20) {
+          throw new Error(
+            `vector search drift: expected 20 rows (top-k), got ${rows.length}`,
+          );
+        }
+      })
+    : undefined;
+
+  const hybridSearchMs =
+    context.hasHybridFacade && sampleEmbedding !== undefined ?
+      await bench("hybrid search (RRF)", async () => {
+        const hits = await store.search.hybrid("Doc", {
+          limit: 10,
+          vector: {
+            fieldPath: "embedding",
+            queryEmbedding: sampleEmbedding,
+            metric: "cosine",
+            k: 30,
+          },
+          fulltext: {
+            query: "climate adaptation",
+            k: 30,
+          },
+        });
+        if (hits.length !== 10) {
+          throw new Error(
+            `hybrid search drift: expected 10 fused hits (limit), got ${hits.length}`,
+          );
+        }
+      })
+    : undefined;
+
+  if (!context.hasVectorPredicate) {
+    console.log("vector search: skipped (backend does not persist embeddings)");
+  }
+  if (!context.hasHybridFacade) {
+    console.log(
+      "hybrid search: skipped (backend does not implement hybrid facade)",
+    );
+  }
+
+  // Recursive traversals walk the :next linear chain (user_0 -> user_1 -> ...).
+  // At depth N, the single reachable target is user_N. Asserting the target
+  // ID catches both empty-result regressions and off-by-one depth bugs.
+  async function assertRecursiveHit(
+    label: string,
+    rows: readonly { id: string }[],
+    expectedDepth: number,
+  ): Promise<void> {
+    if (rows.length !== 1) {
+      throw new Error(
+        `${label} drift: expected 1 row at depth ${expectedDepth}, got ${rows.length}`,
+      );
+    }
+    if (rows[0]!.id !== `user_${expectedDepth}`) {
+      throw new Error(
+        `${label} drift: expected target user_${expectedDepth}, got ${rows[0]!.id}`,
+      );
+    }
+  }
+
+  const tenHopMs = await bench(
     "10-hop recursive traversal (linear next edges, cyclePolicy: allow)",
     async () => {
-      await store
+      const rows = await store
         .query()
         .from("User", "u")
         .whereNode("u", (user) => user.id.eq("user_0"))
@@ -448,13 +749,14 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
         }))
         .limit(1)
         .execute();
+      await assertRecursiveHit("10-hop recursive", rows, 10);
     },
   );
 
-  const recursiveHundredHopMs = await benchmarkQuery(
+  const recursiveHundredHopMs = await bench(
     "100-hop recursive traversal (linear next edges, cyclePolicy: allow)",
     async () => {
-      await store
+      const rows = await store
         .query()
         .from("User", "u")
         .whereNode("u", (user) => user.id.eq("user_0"))
@@ -466,13 +768,14 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
         }))
         .limit(1)
         .execute();
+      await assertRecursiveHit("100-hop recursive", rows, 100);
     },
   );
 
-  const recursiveThousandHopMs = await benchmarkQuery(
+  const recursiveThousandHopMs = await bench(
     "1000-hop recursive traversal (linear next edges, cyclePolicy: allow)",
     async () => {
-      await store
+      const rows = await store
         .query()
         .from("User", "u")
         .whereNode("u", (user) => user.id.eq("user_0"))
@@ -484,10 +787,11 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
         }))
         .limit(1)
         .execute();
+      await assertRecursiveHit("1000-hop recursive", rows, 1000);
     },
   );
 
-  return {
+  const metrics: QueryMetrics = {
     forwardMs,
     reverseMs,
     inverseTraversalMs,
@@ -495,6 +799,13 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     threeHopMs,
     aggregateMs,
     aggregateDistinctMs,
+    aggregateEdgesMs,
+    scopedAggregateMs,
+    indexedFilterMs,
+    temporalAsOfMs,
+    fulltextSearchMs,
+    vectorSearchMs,
+    hybridSearchMs,
     cachedExecuteMs,
     preparedExecuteMs,
     subgraphFullMs,
@@ -507,4 +818,5 @@ export async function measureQueries(store: PerfStore): Promise<QueryMetrics> {
     recursiveHundredHopMs,
     recursiveThousandHopMs,
   };
+  return { metrics, latencies };
 }

--- a/packages/benchmarks/src/seed.ts
+++ b/packages/benchmarks/src/seed.ts
@@ -5,7 +5,7 @@ import {
   type PostSeed,
   type UserSeed,
 } from "./config";
-import { type PerfStore } from "./graph";
+import { EMBEDDING_DIMENSIONS, type PerfStore } from "./graph";
 import { formatMs, nowMs } from "./utils";
 
 function createRng(seed_: number): () => number {
@@ -216,7 +216,231 @@ async function ingestNextEdges(
   }
 }
 
-export async function seedStore(store: PerfStore): Promise<void> {
+/**
+ * Fixed historical timestamp used as an `asOf` anchor for temporal
+ * measurements. The seed creates a batch of "archived" users whose
+ * `validTo` is set to this instant; queries with
+ * `temporal("asOf", pastTimestamp)` see them, queries with the default
+ * `current` mode do not. Exported so measurements can reference it.
+ */
+const TEMPORAL_ARCHIVE_BOUNDARY = "2020-01-01T00:00:00.000Z";
+const TEMPORAL_ARCHIVE_ASOF = "2019-06-01T00:00:00.000Z";
+const TEMPORAL_ARCHIVE_VALID_FROM = "2019-01-01T00:00:00.000Z";
+
+export { TEMPORAL_ARCHIVE_ASOF };
+
+const DOC_CATEGORIES = [
+  "climate",
+  "technology",
+  "economics",
+  "biology",
+  "philosophy",
+] as const;
+
+const DOC_VOCABULARY: Readonly<
+  Record<(typeof DOC_CATEGORIES)[number], readonly string[]>
+> = {
+  climate: [
+    "climate change adaptation strategies",
+    "renewable energy transition in the global south",
+    "glacial retreat observations across the alps",
+    "carbon capture technology commercial viability",
+    "methane emissions from agriculture and industry",
+    "extreme weather attribution studies",
+    "policy frameworks for emissions trading",
+    "tropical ecosystem resilience indicators",
+    "climate modeling uncertainty bounds",
+    "arctic permafrost thaw feedback loops",
+  ],
+  technology: [
+    "distributed systems consensus algorithms",
+    "large language model inference optimization",
+    "graph database traversal performance",
+    "edge computing deployment patterns",
+    "query planner heuristics in relational engines",
+    "vector similarity search index structures",
+    "network protocol buffer serialization",
+    "transactional memory on multicore hardware",
+    "cache coherence in distributed stores",
+    "zero-copy data interchange between services",
+  ],
+  economics: [
+    "labor market frictions and wage dispersion",
+    "monetary policy transmission mechanisms",
+    "trade networks and comparative advantage",
+    "household consumption smoothing behavior",
+    "behavioral economics of retirement savings",
+    "auction theory and revenue equivalence",
+    "economic impact of automation on wages",
+    "inflation expectations anchoring dynamics",
+    "fiscal multipliers during recessions",
+    "housing market price inelasticity",
+  ],
+  biology: [
+    "bacterial quorum sensing signaling pathways",
+    "neural circuit development in vertebrates",
+    "circadian rhythm regulation molecular mechanisms",
+    "protein folding energy landscape",
+    "gene regulatory network evolution",
+    "coral reef microbiome symbiosis",
+    "CRISPR gene editing off-target analysis",
+    "immune system antigen recognition dynamics",
+    "plant drought stress response pathways",
+    "epigenetic inheritance across generations",
+  ],
+  philosophy: [
+    "metaphysical realism and scientific explanation",
+    "ethics of autonomous decision making systems",
+    "phenomenology of embodied cognition",
+    "philosophy of mathematical practice",
+    "free will and neural determinism",
+    "virtue ethics in professional practice",
+    "theories of consciousness and qualia",
+    "moral status of non-human animals",
+    "social contract theory modern applications",
+    "philosophy of measurement and scientific realism",
+  ],
+};
+
+type DocSeed = Readonly<{
+  id: string;
+  category: (typeof DOC_CATEGORIES)[number];
+  title: string;
+  body: string;
+  embedding: readonly number[];
+}>;
+
+/**
+ * Deterministic embedding seeded on the category so two "climate" docs
+ * have similar vectors and "climate" vs "technology" docs have
+ * dissimilar vectors. Good enough to make vector-ranked results
+ * stable for regression testing; not a real language model.
+ */
+function buildSeededEmbedding(
+  rng: () => number,
+  category: (typeof DOC_CATEGORIES)[number],
+  docIndex: number,
+): readonly number[] {
+  const categoryAxis = DOC_CATEGORIES.indexOf(category);
+  const vector = new Array<number>(EMBEDDING_DIMENSIONS);
+  for (let i = 0; i < EMBEDDING_DIMENSIONS; i += 1) {
+    // Category-correlated component on one axis, per-doc noise elsewhere.
+    const onCategoryAxis = i === categoryAxis * 30;
+    const base = onCategoryAxis ? 1 + (rng() - 0.5) * 0.2 : (rng() - 0.5) * 0.1;
+    vector[i] = base + docIndex * 1e-6;
+  }
+  // Normalize for cosine-style similarity stability.
+  let magnitude = 0;
+  for (const v of vector) magnitude += v * v;
+  const norm = Math.sqrt(magnitude);
+  for (let i = 0; i < vector.length; i += 1) {
+    vector[i] = vector[i]! / norm;
+  }
+  return vector;
+}
+
+function buildDocs(rng: () => number, count: number): readonly DocSeed[] {
+  const docs: DocSeed[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const category = DOC_CATEGORIES[index % DOC_CATEGORIES.length]!;
+    const vocab = DOC_VOCABULARY[category];
+    const sentence = vocab[index % vocab.length]!;
+    docs.push({
+      id: `doc_${index}`,
+      category,
+      title: `${sentence} — entry ${index}`,
+      body: `${sentence}. ${vocab.join(" ")}. Entry ${index} explores ${category} in depth with references to related literature.`,
+      embedding: buildSeededEmbedding(rng, category, index),
+    });
+  }
+  return docs;
+}
+
+async function ingestDocs(store: PerfStore): Promise<readonly DocSeed[]> {
+  // Keep doc count stable regardless of --scale; the search shapes are
+  // about per-query latency, not about dataset density.
+  const DOC_COUNT = 500;
+  const rng = (() => {
+    let seed = 4242;
+    return () => {
+      seed ^= seed << 13;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5;
+      return (seed >>> 0) / 4_294_967_295;
+    };
+  })();
+  const docs = buildDocs(rng, DOC_COUNT);
+  for (
+    let index = 0;
+    index < docs.length;
+    index += BENCHMARK_CONFIG.batchSize
+  ) {
+    const batch = docs.slice(index, index + BENCHMARK_CONFIG.batchSize);
+    await store.nodes.Doc.bulkInsert(
+      batch.map((doc) => ({
+        id: doc.id,
+        props: {
+          title: doc.title,
+          body: doc.body,
+          category: doc.category,
+          embedding: doc.embedding,
+        },
+      })),
+    );
+  }
+  return docs;
+}
+
+async function ingestArchivedUsers(store: PerfStore): Promise<void> {
+  // Creating nodes directly with validFrom in the past and validTo at
+  // the boundary gives us a typed temporal footprint: these users exist
+  // when queried at `TEMPORAL_ARCHIVE_ASOF` and disappear at `current`.
+  const archivedCount = Math.max(
+    50,
+    Math.round(BENCHMARK_CONFIG.userCount * 0.1),
+  );
+  const archived = Array.from({ length: archivedCount }, (_, index) => ({
+    id: `archived_user_${index}`,
+    props: {
+      name: `Archived ${index}`,
+      city: "Boston",
+      bio: buildPayload(`archived_${index}`, BENCHMARK_CONFIG.userBioBytes),
+    },
+  }));
+
+  for (
+    let index = 0;
+    index < archived.length;
+    index += BENCHMARK_CONFIG.batchSize
+  ) {
+    const batch = archived.slice(index, index + BENCHMARK_CONFIG.batchSize);
+    await Promise.all(
+      batch.map((node) =>
+        store.nodes.User.create(node.props, {
+          id: node.id,
+          validFrom: TEMPORAL_ARCHIVE_VALID_FROM,
+          validTo: TEMPORAL_ARCHIVE_BOUNDARY,
+        }),
+      ),
+    );
+  }
+}
+
+type SeedResult = Readonly<{
+  /**
+   * Total items ingested (users + posts + edges + archived + docs), for
+   * reporting in the benchmark header alongside elapsed time.
+   */
+  totalItems: number;
+  /**
+   * Vocabulary and seeded embeddings for Doc fulltext/vector measurements.
+   * `undefined` when vector support is not available so search
+   * measurements can skip cleanly.
+   */
+  docs: readonly { id: string; embedding: readonly number[] }[] | undefined;
+}>;
+
+export async function seedStore(store: PerfStore): Promise<SeedResult> {
   const rng = createRng(42);
   const users = buildUsers();
   const posts = buildPosts(users);
@@ -233,6 +457,8 @@ export async function seedStore(store: PerfStore): Promise<void> {
   await ingestNextEdges(store, nextEdges);
   await ingestFollowEdges(store, followEdges);
   await ingestAuthoredEdges(store, posts);
+  await ingestArchivedUsers(store);
+  const docs = await ingestDocs(store);
 
   const elapsed = nowMs() - startedAt;
   const totalItems =
@@ -240,7 +466,10 @@ export async function seedStore(store: PerfStore): Promise<void> {
     posts.length +
     nextEdges.length +
     followEdges.length +
-    posts.length;
+    posts.length +
+    docs.length;
 
   console.log(`ingestion: ${formatMs(elapsed)} for ${totalItems} items`);
+
+  return { totalItems, docs };
 }

--- a/packages/benchmarks/src/utils.ts
+++ b/packages/benchmarks/src/utils.ts
@@ -19,6 +19,24 @@ export function median(values: readonly number[]): number {
   return sorted[middle]!;
 }
 
+/**
+ * Nearest-rank percentile over the sorted samples. For the default suite
+ * size (15 samples) this picks index ceil(0.95 * 15) - 1 = 14, i.e. the
+ * slowest sample — a conservative tail estimate suitable for catching
+ * occasional slow outliers in CI.
+ */
+export function percentile(values: readonly number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  if (!Number.isFinite(p) || p <= 0 || p > 1) {
+    throw new RangeError(`percentile rank must be in (0, 1], got ${p}`);
+  }
+  const sorted = values.toSorted((left, right) => left - right);
+  const index = Math.max(0, Math.ceil(p * sorted.length) - 1);
+  return sorted[index]!;
+}
+
 export function formatMs(value: number): string {
   return `${value.toFixed(1)}ms`;
 }

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -142,10 +142,27 @@ function flattenSqlChunk(chunk: unknown): string {
   }
 
   if (typeof chunk === "object" && chunk !== null) {
-    if ("value" in chunk && Array.isArray((chunk).value)) {
-      return (chunk as { value: readonly unknown[] }).value
-        .map((part) => flattenSqlChunk(part))
-        .join("");
+    // Drizzle column references (SQLiteText, PgText, etc.) carry the
+    // column name directly. Match these BEFORE the `getSQL` fallback —
+    // a column's `.getSQL()` wraps the column back inside a SQL object
+    // that points to itself, which would recurse infinitely.
+    if (
+      "name" in chunk &&
+      typeof (chunk).name === "string"
+    ) {
+      return `"${(chunk as { name: string }).name}"`;
+    }
+
+    // Drizzle's StringChunk stores its literal as `.value`, usually as a
+    // one-element array ([""], ["SELECT "]) but sometimes as a plain string.
+    if ("value" in chunk) {
+      const value = (chunk).value;
+      if (typeof value === "string") {
+        return value;
+      }
+      if (Array.isArray(value)) {
+        return value.map((part) => flattenSqlChunk(part)).join("");
+      }
     }
 
     if (

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -87,6 +87,7 @@ import {
   buildDeleteEmbedding,
   buildGetEmbedding,
   buildUpsertEmbeddingPostgres,
+  buildUpsertEmbeddingSqlite,
   buildVectorSearchPostgres,
 } from "./vectors";
 
@@ -192,7 +193,28 @@ export type PostgresVectorOperationStrategy = Readonly<{
   buildVectorSearch: (params: VectorSearchParams) => SQL;
 }>;
 
-export type SqliteOperationStrategy = CommonOperationStrategy;
+/**
+ * SQLite embedding operations. Uses sqlite-vec's `vec_f32('[...]')` to
+ * encode embeddings as BLOBs on write. Requires the sqlite-vec extension
+ * to be loaded on the connection; the backend factory checks for that
+ * and only exposes the backend methods when it is.
+ *
+ * `getEmbedding` is not included: reading the raw BLOB back as a number
+ * array requires `vec_to_json(...)` and additional row decoding, which
+ * the current consumers (embedding sync, `.similarTo()` predicate) do
+ * not need.
+ */
+export type SqliteVectorOperationStrategy = Readonly<{
+  buildUpsertEmbedding: (
+    params: UpsertEmbeddingParams,
+    timestamp: string,
+  ) => SQL;
+  buildDeleteEmbedding: (params: DeleteEmbeddingParams) => SQL;
+}>;
+
+export type SqliteOperationStrategy = Readonly<
+  CommonOperationStrategy & SqliteVectorOperationStrategy
+>;
 
 export type PostgresOperationStrategy = Readonly<
   CommonOperationStrategy & PostgresVectorOperationStrategy
@@ -337,7 +359,20 @@ export function createSqliteOperationStrategy(
   tables: SqliteTables,
   fulltextStrategy: FulltextStrategy,
 ): SqliteOperationStrategy {
-  return createCommonOperationStrategy(tables, "sqlite", fulltextStrategy);
+  const common = createCommonOperationStrategy(
+    tables,
+    "sqlite",
+    fulltextStrategy,
+  );
+  return {
+    ...common,
+    buildUpsertEmbedding(params: UpsertEmbeddingParams, timestamp: string): SQL {
+      return buildUpsertEmbeddingSqlite(tables, params, timestamp);
+    },
+    buildDeleteEmbedding(params: DeleteEmbeddingParams): SQL {
+      return buildDeleteEmbedding(tables, params);
+    },
+  };
 }
 
 export function createPostgresOperationStrategy(

--- a/packages/typegraph/src/backend/drizzle/operations/vectors.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/vectors.ts
@@ -7,6 +7,7 @@ import type {
   VectorSearchParams,
 } from "../../types";
 import type { PostgresTables } from "../schema/postgres";
+import type { SqliteTables } from "../schema/sqlite";
 import type { Tables } from "./shared";
 
 /**
@@ -63,6 +64,48 @@ export function buildUpsertEmbeddingPostgres(
     ON CONFLICT (${conflictColumns})
     DO UPDATE SET
       ${column(embeddings.embedding)} = ${embeddingLiteral}::vector,
+      ${column(embeddings.dimensions)} = ${params.dimensions},
+      ${column(embeddings.updatedAt)} = ${timestamp}
+  `;
+}
+
+/**
+ * Builds an UPSERT query for an embedding (SQLite with sqlite-vec).
+ *
+ * The embedding is stored as a BLOB produced by `vec_f32('[...]')`. This
+ * requires the sqlite-vec extension to be loaded on the connection. When
+ * the extension is missing, the insert will fail at execution time with
+ * a "no such function: vec_f32" error — createSqliteBackend guards against
+ * that by only exposing `upsertEmbedding` when vec_f32 is available.
+ */
+export function buildUpsertEmbeddingSqlite(
+  tables: SqliteTables,
+  params: UpsertEmbeddingParams,
+  timestamp: string,
+): SQL {
+  const { embeddings } = tables;
+  const embeddingJson = JSON.stringify(params.embedding);
+  // Validate finite numbers BEFORE stringify so the error names the
+  // offending index (stringify would mask NaN/Infinity as null).
+  assertFiniteNumberArray(params.embedding, "embedding");
+
+  const columns = sql.raw(
+    `"${embeddings.graphId.name}", "${embeddings.nodeKind.name}", "${embeddings.nodeId.name}", "${embeddings.fieldPath.name}", "${embeddings.embedding.name}", "${embeddings.dimensions.name}", "${embeddings.createdAt.name}", "${embeddings.updatedAt.name}"`,
+  );
+  const conflictColumns = sql.raw(
+    `"${embeddings.graphId.name}", "${embeddings.nodeKind.name}", "${embeddings.nodeId.name}", "${embeddings.fieldPath.name}"`,
+  );
+  const column = (target: { name: string }) => sql.raw(`"${target.name}"`);
+
+  return sql`
+    INSERT INTO ${embeddings} (${columns})
+    VALUES (
+      ${params.graphId}, ${params.nodeKind}, ${params.nodeId}, ${params.fieldPath},
+      vec_f32(${embeddingJson}), ${params.dimensions}, ${timestamp}, ${timestamp}
+    )
+    ON CONFLICT (${conflictColumns})
+    DO UPDATE SET
+      ${column(embeddings.embedding)} = vec_f32(${embeddingJson}),
       ${column(embeddings.dimensions)} = ${params.dimensions},
       ${column(embeddings.updatedAt)} = ${timestamp}
   `;

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -31,6 +31,7 @@ import {
 import {
   type BackendCapabilities,
   type CreateVectorIndexParams,
+  type DeleteEmbeddingParams,
   type DeleteFulltextBatchParams,
   type DeleteFulltextParams,
   type DropVectorIndexParams,
@@ -40,6 +41,7 @@ import {
   SQLITE_CAPABILITIES,
   type TransactionBackend,
   type TransactionOptions,
+  type UpsertEmbeddingParams,
   type UpsertFulltextBatchParams,
   type UpsertFulltextParams,
 } from "../types";
@@ -92,6 +94,17 @@ export type SqliteBackendOptions = Readonly<{
    * built-in FTS5 virtual table). Most users should leave this alone.
    */
   fulltext?: FulltextStrategy;
+  /**
+   * Set to `true` when sqlite-vec has been loaded on the connection.
+   * Enables vector embedding persistence via `upsertEmbedding` /
+   * `deleteEmbedding`, which the store's embedding-sync path relies on
+   * whenever node schemas declare `embedding()` fields. When omitted the
+   * backend does not expose those methods and embedding values pass
+   * through writes without being indexed — matching existing behavior
+   * for backends without sqlite-vec. `createLocalSqliteBackend` sets
+   * this automatically when it loads the extension.
+   */
+  hasVectorEmbeddings?: boolean;
 }>;
 
 const SQLITE_MAX_BIND_PARAMETERS = 999;
@@ -220,6 +233,8 @@ type CreateSqliteOperationBackendOptions = Readonly<{
   serializedQueue?: SerializedExecutionQueue;
   tableNames: SqlTableNames;
   fulltextStrategy: FulltextStrategy;
+  /** Wire up upsertEmbedding / deleteEmbedding. See transaction options for details. */
+  hasVectorEmbeddings?: boolean;
 }>;
 
 type CreateSqliteTransactionBackendOptions = Readonly<{
@@ -230,6 +245,12 @@ type CreateSqliteTransactionBackendOptions = Readonly<{
   profileHints: SqliteExecutionProfileHints;
   tableNames: SqlTableNames;
   fulltextStrategy: FulltextStrategy;
+  /**
+   * When true, the backend exposes upsertEmbedding / deleteEmbedding —
+   * detected by probing `vec_f32(...)` on the connection at boot so the
+   * store's embedding-sync path persists vectors to the embeddings table.
+   */
+  hasVectorEmbeddings?: boolean;
 }>;
 
 function createSqliteOperationBackend(
@@ -309,9 +330,27 @@ function createSqliteOperationBackend(
         },
       };
 
+  const vectorEmbeddingMethods =
+    options.hasVectorEmbeddings
+      ? {
+          async upsertEmbedding(params: UpsertEmbeddingParams): Promise<void> {
+            const query = operationStrategy.buildUpsertEmbedding(
+              params,
+              nowIso(),
+            );
+            await execRun(query);
+          },
+          async deleteEmbedding(params: DeleteEmbeddingParams): Promise<void> {
+            const query = operationStrategy.buildDeleteEmbedding(params);
+            await execRun(query);
+          },
+        }
+      : {};
+
   const operationBackend: TransactionBackend = {
     ...commonBackend,
     ...executeRawMethod,
+    ...vectorEmbeddingMethods,
     capabilities,
     dialect: "sqlite",
     tableNames,
@@ -462,6 +501,11 @@ export function createSqliteBackend(
     fulltextStrategy,
   );
   const serializedQueue = isSync ? createSerializedExecutionQueue() : undefined;
+  // Explicit opt-in: wire upsertEmbedding / deleteEmbedding only when
+  // the caller confirms sqlite-vec is loaded. Probing synchronously
+  // isn't portable across drizzle SQLite drivers (sync vs async), so
+  // the gate lives with the caller that loaded the extension.
+  const hasVectorEmbeddings = options.hasVectorEmbeddings === true;
   const operations = createSqliteOperationBackend({
     capabilities,
     db,
@@ -469,6 +513,7 @@ export function createSqliteBackend(
     operationStrategy,
     tableNames,
     fulltextStrategy,
+    hasVectorEmbeddings,
     ...(serializedQueue === undefined ? {} : { serializedQueue }),
   });
 
@@ -516,6 +561,7 @@ export function createSqliteBackend(
             profileHints: { isSync: true },
             tableNames,
             fulltextStrategy,
+            hasVectorEmbeddings,
           });
           db.run(sql`BEGIN`);
 
@@ -540,6 +586,7 @@ export function createSqliteBackend(
             profileHints: { isSync },
             tableNames,
             fulltextStrategy,
+            hasVectorEmbeddings,
           });
           return fn(txBackend);
         }) as Promise<T>,
@@ -571,6 +618,9 @@ function createTransactionBackend(
     operationStrategy: options.operationStrategy,
     tableNames: options.tableNames,
     fulltextStrategy: options.fulltextStrategy,
+    ...(options.hasVectorEmbeddings === undefined
+      ? {}
+      : { hasVectorEmbeddings: options.hasVectorEmbeddings }),
   });
 }
 

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -21,6 +21,8 @@
  * const store = createStore(graph, backend);
  * ```
  */
+import { createRequire } from "node:module";
+
 import Database from "better-sqlite3";
 import {
   type BetterSQLite3Database,
@@ -35,6 +37,8 @@ import {
   tables as defaultTables,
 } from "../drizzle/sqlite";
 import { type GraphBackend, wrapWithManagedClose } from "../types";
+
+const nodeRequire = createRequire(import.meta.url);
 
 // ============================================================
 // Native Addon Helpers
@@ -165,6 +169,14 @@ export function createLocalSqliteBackend(
   const tables = options.tables ?? defaultTables;
 
   const sqlite = createDatabase(path);
+
+  // Best-effort: load sqlite-vec so embedding fields are persisted to the
+  // embeddings table. Without it, nodes with `embedding()` fields validate
+  // and insert but their vectors are silently dropped. When the user has
+  // installed sqlite-vec as a peer dep we load it; otherwise we proceed
+  // without vector support.
+  const hasVectorEmbeddings = tryLoadSqliteVec(sqlite);
+
   const db = drizzle(sqlite);
 
   // Generate and execute DDL from schema
@@ -178,10 +190,32 @@ export function createLocalSqliteBackend(
       isSync: true,
     },
     tables,
+    hasVectorEmbeddings,
   });
   const managedBackend = wrapWithManagedClose(backend, () => {
     sqlite.close();
   });
 
   return { backend: managedBackend, db };
+}
+
+function tryLoadSqliteVec(sqlite: Database.Database): boolean {
+  try {
+    // `sqlite-vec` is an optional peer dep; resolved via createRequire so
+    // bundlers don't mark it as a hard import. Node resolves the package
+    // only when it's actually installed.
+    const module_: unknown = nodeRequire("sqlite-vec");
+    if (
+      typeof module_ === "object" &&
+      module_ !== null &&
+      "load" in module_ &&
+      typeof module_.load === "function"
+    ) {
+      (module_ as { load: (db: Database.Database) => void }).load(sqlite);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
 }

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -342,6 +342,8 @@ export {
   composeFragments,
   count,
   countDistinct,
+  countDistinctEdges,
+  countEdges,
   createFragment,
   createQueryBuilder,
   // SQL schema configuration

--- a/packages/typegraph/src/query/builder.ts
+++ b/packages/typegraph/src/query/builder.ts
@@ -29,6 +29,8 @@ export {
   avg,
   count,
   countDistinct,
+  countDistinctEdges,
+  countEdges,
   field,
   having,
   havingEq,

--- a/packages/typegraph/src/query/builder/aggregates.ts
+++ b/packages/typegraph/src/query/builder/aggregates.ts
@@ -66,6 +66,56 @@ export function countDistinct(alias: string, field?: string): AggregateExpr {
 }
 
 /**
+ * Creates a COUNT aggregate expression over an edge alias.
+ *
+ * Counts edges directly, without joining back to the target node table.
+ * This has different semantics from `count(targetAlias)`:
+ *
+ * - `countEdges(edgeAlias)` — counts live edges, regardless of target-node
+ *   temporal state. If a target node's `validTo` is in the past while its
+ *   incident edges are still live, those edges are still counted.
+ * - `count(targetAlias)` — counts edges whose target node is currently
+ *   valid under the query's temporal mode.
+ *
+ * For the common case ("how many follow relationships does this user
+ * have?") the edge-count semantics is what you want, and the compiler
+ * can skip the target-node join entirely — measurably faster on
+ * full-graph aggregates where the join dominates cost.
+ *
+ * @example
+ * ```typescript
+ * store
+ *   .query()
+ *   .from("User", "u")
+ *   .optionalTraverse("follows", "e", { expand: "none" })
+ *   .to("User", "target")
+ *   .groupByNode("u")
+ *   .aggregate({
+ *     name: field("u", "name"),
+ *     // counts edges — skips the target-node join
+ *     followCount: countEdges("e"),
+ *   })
+ *   .execute();
+ * ```
+ */
+export function countEdges(edgeAlias: string): AggregateExpr {
+  return count(edgeAlias);
+}
+
+/**
+ * Creates a COUNT DISTINCT aggregate expression over an edge alias.
+ * See {@link countEdges} for semantics.
+ *
+ * Distinct-on-edge-id is equivalent to `countEdges` when the query
+ * surface produces each edge exactly once, but stays meaningful under
+ * polymorphic expansions and ontology-driven edge fan-outs where the
+ * same edge can appear multiple times in the join output.
+ */
+export function countDistinctEdges(edgeAlias: string): AggregateExpr {
+  return countDistinct(edgeAlias);
+}
+
+/**
  * Creates a SUM aggregate expression.
  *
  * @param alias - The node alias

--- a/packages/typegraph/src/query/builder/index.ts
+++ b/packages/typegraph/src/query/builder/index.ts
@@ -33,6 +33,8 @@ export {
   avg,
   count,
   countDistinct,
+  countDistinctEdges,
+  countEdges,
   field,
   having,
   havingEq,

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -112,12 +112,21 @@ type BuildStandardStartCteInput = Readonly<{
   predicateIndex: StandardEmitterPredicateIndex;
   requiredColumnsByAlias: RequiredColumnsByAlias | undefined;
   temporalFilterPass: TemporalFilterPass;
+  /**
+   * Optional LIMIT/OFFSET to apply inside the start CTE. Used by the count
+   * aggregate fast path to push limits past the GROUP BY when it's safe.
+   */
+  limitOffset?: Readonly<{ limit: number; offset?: number | undefined }>;
 }>;
 
 export function buildStandardStartCte(input: BuildStandardStartCteInput): SQL {
   const { ast, ctx, graphId, predicateIndex, requiredColumnsByAlias } = input;
   const alias = ast.start.alias;
   const kinds = ast.start.kinds;
+  const cteMaterialization =
+    ctx.dialect.capabilities.emitNotMaterializedHint ?
+      sql`NOT MATERIALIZED `
+    : sql``;
 
   const kindFilter = compileKindFilter(sql.raw("kind"), kinds);
   const temporalFilter = input.temporalFilterPass.forAlias();
@@ -139,14 +148,24 @@ export function buildStandardStartCte(input: BuildStandardStartCteInput): SQL {
       (requiredColumnsByAlias.get(alias) ?? EMPTY_REQUIRED_COLUMNS)
     : undefined;
 
+  const limitClause =
+    input.limitOffset === undefined ? sql``
+    : input.limitOffset.offset === undefined ?
+      sql`
+        LIMIT ${input.limitOffset.limit}
+      `
+    : sql`
+      LIMIT ${input.limitOffset.limit} OFFSET ${input.limitOffset.offset}
+    `;
+
   return sql`
-    cte_${sql.raw(alias)} AS (
+    cte_${sql.raw(alias)} AS ${cteMaterialization}(
       SELECT ${sql.join(
         compileNodeSelectColumns(undefined, alias, effectiveRequiredColumns),
         sql`, `,
       )}
       FROM ${ctx.schema.nodesTable}
-      WHERE ${sql.join(whereClauses, sql` AND `)}
+      WHERE ${sql.join(whereClauses, sql` AND `)}${limitClause}
     )
   `;
 }
@@ -246,7 +265,10 @@ export function buildStandardTraversalCte(
     ...compileEdgeSelectColumns("e", edgeAlias, requiredEdgeColumns),
     ...compileNodeSelectColumns("n", nodeAlias, requiredNodeColumns),
   ];
-  const cteMaterialization = materializeCte ? sql`MATERIALIZED ` : sql``;
+  const cteMaterialization =
+    materializeCte ? sql`MATERIALIZED `
+    : ctx.dialect.capabilities.emitNotMaterializedHint ? sql`NOT MATERIALIZED `
+    : sql``;
 
   function compileTraversalBranch(
     branch: Readonly<{

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -45,6 +45,7 @@ import { type SQL, sql } from "drizzle-orm";
 
 import { CompilerInvariantError } from "../../errors";
 import {
+  type AggregateExpr,
   type FulltextMatchPredicate,
   type HybridFusionOptions,
   type QueryAst,
@@ -76,7 +77,7 @@ import {
   buildStandardVectorOrderBy,
 } from "./emitter";
 import { type TemporalFilterPass } from "./passes";
-import { type LogicalPlan } from "./plan";
+import { type LogicalPlan, type LogicalPlanNode } from "./plan";
 import {
   compileKindFilter,
   compilePredicateClauses,
@@ -278,8 +279,14 @@ function propagateOptions(options_: CompileQueryOptions): CompileQueryOptions {
 
 type CountAggregateFastPathPlan = Readonly<{
   traversal: QueryAst["traversals"][number];
-  requiresCount: boolean;
-  requiresCountDistinct: boolean;
+  /** Aggregate references `traversal.nodeAlias` (count of live target nodes). */
+  requiresNodeCount: boolean;
+  /** countDistinct over `traversal.nodeAlias`. */
+  requiresNodeCountDistinct: boolean;
+  /** Aggregate references `traversal.edgeAlias` (count of live edges). */
+  requiresEdgeCount: boolean;
+  /** countDistinct over `traversal.edgeAlias`. */
+  requiresEdgeCountDistinct: boolean;
 }>;
 
 function resolveCountAggregateFastPath(
@@ -313,8 +320,10 @@ function resolveCountAggregateFastPath(
     return undefined;
   }
 
-  let requiresCount = false;
-  let requiresCountDistinct = false;
+  let requiresNodeCount = false;
+  let requiresNodeCountDistinct = false;
+  let requiresEdgeCount = false;
+  let requiresEdgeCountDistinct = false;
 
   for (const projectedField of ast.projection.fields) {
     const source = projectedField.source;
@@ -326,34 +335,46 @@ function resolveCountAggregateFastPath(
       continue;
     }
 
-    if (
-      source.field.alias !== traversal.nodeAlias ||
-      !isIdFieldRef(source.field)
-    ) {
+    if (!isIdFieldRef(source.field)) {
+      return undefined;
+    }
+
+    const isNodeTarget = source.field.alias === traversal.nodeAlias;
+    const isEdgeTarget = source.field.alias === traversal.edgeAlias;
+    if (!isNodeTarget && !isEdgeTarget) {
       return undefined;
     }
 
     if (source.function === "count") {
-      requiresCount = true;
+      if (isNodeTarget) requiresNodeCount = true;
+      else requiresEdgeCount = true;
       continue;
     }
 
     if (source.function === "countDistinct") {
-      requiresCountDistinct = true;
+      if (isNodeTarget) requiresNodeCountDistinct = true;
+      else requiresEdgeCountDistinct = true;
       continue;
     }
 
     return undefined;
   }
 
-  if (!requiresCount && !requiresCountDistinct) {
+  if (
+    !requiresNodeCount &&
+    !requiresNodeCountDistinct &&
+    !requiresEdgeCount &&
+    !requiresEdgeCountDistinct
+  ) {
     return undefined;
   }
 
   return {
     traversal,
-    requiresCount,
-    requiresCountDistinct,
+    requiresNodeCount,
+    requiresNodeCountDistinct,
+    requiresEdgeCount,
+    requiresEdgeCountDistinct,
   };
 }
 
@@ -371,15 +392,23 @@ function compileCountAggregateFastPath(
     return undefined;
   }
 
-  const { traversal, requiresCount, requiresCountDistinct } = plan;
+  const {
+    traversal,
+    requiresNodeCount,
+    requiresNodeCountDistinct,
+    requiresEdgeCount,
+    requiresEdgeCountDistinct,
+  } = plan;
   const { dialect } = ctx;
   const startAlias = ast.start.alias;
   const previousAlias = traversal.joinFromAlias;
   const previousAliasIdColumn = `${previousAlias}_id`;
   const previousAliasKindColumn = `${previousAlias}_kind`;
   const countCteAlias = `cte_${traversal.nodeAlias}_counts`;
-  const countColumn = `${traversal.nodeAlias}_count`;
-  const countDistinctColumn = `${traversal.nodeAlias}_count_distinct`;
+  const nodeCountColumn = `${traversal.nodeAlias}_count`;
+  const nodeCountDistinctColumn = `${traversal.nodeAlias}_count_distinct`;
+  const edgeCountColumn = `${traversal.edgeAlias}_count`;
+  const edgeCountDistinctColumn = `${traversal.edgeAlias}_count_distinct`;
 
   const previousNodeKinds = getNodeKindsForAlias(ast, traversal.joinFromAlias);
   const edgeKinds = [...new Set(traversal.edgeKinds)];
@@ -412,27 +441,106 @@ function compileCountAggregateFastPath(
   const targetKindField =
     traversal.direction === "out" ? "to_kind" : "from_kind";
 
+  // The target-node join is only needed when an aggregate actually counts
+  // live target nodes. For edge-only counts (countEdges / countDistinctEdges)
+  // the edge row alone is sufficient: the edge's own deleted_at and valid_*
+  // columns already constrain "live edge," and target-kind validation is
+  // enforced via the edge's to_kind filter (which the store's write path
+  // keeps consistent with the target node's kind at insert time).
+  const hasNodePredicates = nodePredicateClauses.length > 0;
+  const requiresNodeJoin =
+    requiresNodeCount || requiresNodeCountDistinct || hasNodePredicates;
+
+  // Join style depends on how the target-node join interacts with the
+  // aggregates:
+  //
+  // - INNER JOIN when the user applied a predicate to the target alias
+  //   (whereNode on the target). Predicates should constrain every
+  //   aggregate in the query — including countEdges — so they live in
+  //   WHERE and the JOIN filters edges whose targets fail to match.
+  //   With INNER JOIN, a group where every edge's target fails the
+  //   predicate produces no rows; GROUP BY omits it, and required
+  //   traversals correctly drop that start row.
+  //
+  // - LEFT JOIN when only temporal/deleted filters apply (no caller
+  //   predicates). This lets mixed aggregates differ: countEdges
+  //   counts all live edges (including edges to expired targets)
+  //   while count(target) only counts edges to live targets.
+  const useInnerJoin = hasNodePredicates;
+
   const whereClauses = [
     sql`e.graph_id = ${graphId}`,
     compileKindFilter(sql.raw("e.kind"), edgeKinds),
     compileKindFilter(sql.raw(`e.${joinKindField}`), previousNodeKinds),
     compileKindFilter(sql.raw(`e.${targetKindField}`), nodeKinds),
-    compileKindFilter(sql.raw("n.kind"), nodeKinds),
     edgeTemporalFilter,
-    nodeTemporalFilter,
-    ...nodePredicateClauses,
     ...edgePredicateClauses,
+    // INNER JOIN mode: node-side filters in WHERE constrain every aggregate.
+    ...(requiresNodeJoin && useInnerJoin ?
+      [
+        compileKindFilter(sql.raw("n.kind"), nodeKinds),
+        nodeTemporalFilter,
+        ...nodePredicateClauses,
+      ]
+    : []),
   ];
 
+  const nodeJoinOnClauses =
+    requiresNodeJoin ?
+      useInnerJoin ?
+        // INNER JOIN: only the key conditions; filters live in WHERE.
+        [
+          sql`n.graph_id = e.graph_id`,
+          sql`n.id = e.${sql.raw(targetField)}`,
+          sql`n.kind = e.${sql.raw(targetKindField)}`,
+        ]
+        // LEFT JOIN: temporal/kind filters gate the join, so countEdges
+        // still sees the full edge set while count(target) excludes edges
+        // to expired targets (via COUNT ignoring NULLs).
+      : [
+          sql`n.graph_id = e.graph_id`,
+          sql`n.id = e.${sql.raw(targetField)}`,
+          sql`n.kind = e.${sql.raw(targetKindField)}`,
+          compileKindFilter(sql.raw("n.kind"), nodeKinds),
+          nodeTemporalFilter,
+        ]
+    : [];
+
   const aggregateColumns: SQL[] = [];
-  if (requiresCount) {
-    aggregateColumns.push(sql`COUNT(n.id) AS ${sql.raw(countColumn)}`);
+  if (requiresNodeCount) {
+    aggregateColumns.push(sql`COUNT(n.id) AS ${sql.raw(nodeCountColumn)}`);
   }
-  if (requiresCountDistinct) {
+  if (requiresNodeCountDistinct) {
     aggregateColumns.push(
-      sql`COUNT(DISTINCT n.id) AS ${sql.raw(countDistinctColumn)}`,
+      sql`COUNT(DISTINCT n.id) AS ${sql.raw(nodeCountDistinctColumn)}`,
     );
   }
+  if (requiresEdgeCount) {
+    aggregateColumns.push(sql`COUNT(e.id) AS ${sql.raw(edgeCountColumn)}`);
+  }
+  if (requiresEdgeCountDistinct) {
+    aggregateColumns.push(
+      sql`COUNT(DISTINCT e.id) AS ${sql.raw(edgeCountDistinctColumn)}`,
+    );
+  }
+
+  // LIMIT push-down: when the outer SELECT applies LIMIT/OFFSET that do not
+  // depend on aggregate results, we can reduce the start CTE to just the
+  // required rows before aggregation. This turns an O(|start|) GROUP BY
+  // into an O(limit) GROUP BY.
+  //
+  // Safe when:
+  //   - The traversal is optional (LEFT JOIN outer). For INNER JOIN we can't
+  //     push down without potentially dropping rows the original query would
+  //     have kept.
+  //   - No ORDER BY. ORDER BY over the full result requires the full result.
+  //     (The fast path already restricts ORDER BY to the start alias, but we
+  //     still need every row to sort correctly.)
+  //   - LIMIT is defined. OFFSET is carried with it.
+  const startCteLimit =
+    traversal.optional && ast.orderBy === undefined && ast.limit !== undefined ?
+      { limit: ast.limit, offset: ast.offset }
+    : undefined;
 
   const startCte = buildStandardStartCte({
     ast,
@@ -441,7 +549,17 @@ function compileCountAggregateFastPath(
     predicateIndex,
     requiredColumnsByAlias,
     temporalFilterPass,
+    ...(startCteLimit === undefined ? {} : { limitOffset: startCteLimit }),
   });
+
+  const targetNodeJoinKeyword = useInnerJoin ? "JOIN" : "LEFT JOIN";
+  const targetNodeJoin =
+    requiresNodeJoin ?
+      sql`
+        ${sql.raw(targetNodeJoinKeyword)} ${ctx.schema.nodesTable} n ON ${sql.join(nodeJoinOnClauses, sql` AND `)}
+      `
+    : sql``;
+
   const countCte = sql`
     ${sql.raw(countCteAlias)} AS (
       SELECT
@@ -450,16 +568,21 @@ function compileCountAggregateFastPath(
         ${sql.join(aggregateColumns, sql`, `)}
       FROM cte_${sql.raw(previousAlias)}
       JOIN ${ctx.schema.edgesTable} e ON cte_${sql.raw(previousAlias)}.${sql.raw(previousAliasIdColumn)} = e.${sql.raw(joinField)}
-        AND cte_${sql.raw(previousAlias)}.${sql.raw(previousAliasKindColumn)} = e.${sql.raw(joinKindField)}
-      JOIN ${ctx.schema.nodesTable} n ON n.graph_id = e.graph_id
-        AND n.id = e.${sql.raw(targetField)}
-        AND n.kind = e.${sql.raw(targetKindField)}
+        AND cte_${sql.raw(previousAlias)}.${sql.raw(previousAliasKindColumn)} = e.${sql.raw(joinKindField)}${targetNodeJoin}
       WHERE ${sql.join(whereClauses, sql` AND `)}
       GROUP BY
         cte_${sql.raw(previousAlias)}.${sql.raw(previousAliasIdColumn)},
         cte_${sql.raw(previousAlias)}.${sql.raw(previousAliasKindColumn)}
     )
   `;
+
+  function resolveCountColumn(source: AggregateExpr): string {
+    const isEdge = source.field.alias === traversal.edgeAlias;
+    if (source.function === "countDistinct") {
+      return isEdge ? edgeCountDistinctColumn : nodeCountDistinctColumn;
+    }
+    return isEdge ? edgeCountColumn : nodeCountColumn;
+  }
 
   const projection = sql.join(
     ast.projection.fields.map((projectedField) => {
@@ -475,8 +598,7 @@ function compileCountAggregateFastPath(
         return sql`${value} AS ${quoteIdentifier(projectedField.outputName)}`;
       }
 
-      const projectedCountColumn =
-        source.function === "countDistinct" ? countDistinctColumn : countColumn;
+      const projectedCountColumn = resolveCountColumn(source);
       const countValue = sql`${sql.raw(countCteAlias)}.${sql.raw(projectedCountColumn)}`;
       const aggregateValue =
         traversal.optional ? sql`COALESCE(${countValue}, 0)` : countValue;
@@ -495,19 +617,51 @@ function compileCountAggregateFastPath(
   `;
 
   const orderBy = buildStandardOrderBy({ ast, dialect });
-  const limitOffset = buildLimitOffsetClause({
-    limit: ast.limit,
-    offset: ast.offset,
-  });
+  // When the LIMIT/OFFSET was pushed into the start CTE, the outer SELECT
+  // must not re-apply it — the start CTE already produced exactly the
+  // requested page, and the outer LEFT JOIN preserves its cardinality.
+  // Re-applying would double-offset and produce an empty page. Rewrite
+  // the logical plan to match: the emitter asserts plan shape aligns
+  // with emitted SQL, so dropping the clause and leaving the plan's
+  // `limit_offset` node behind would trip an invariant.
+  const emittedLogicalPlan =
+    startCteLimit === undefined ? logicalPlan : (
+      stripLimitOffsetFromPlan(logicalPlan)
+    );
+  const limitOffset =
+    startCteLimit === undefined ?
+      buildLimitOffsetClause({ limit: ast.limit, offset: ast.offset })
+    : undefined;
 
   return emitStandardQuerySql({
     ctes: [startCte, countCte],
     fromClause,
     ...(orderBy === undefined ? {} : { orderBy }),
     ...(limitOffset === undefined ? {} : { limitOffset }),
-    logicalPlan,
+    logicalPlan: emittedLogicalPlan,
     projection,
   });
+}
+
+/**
+ * Returns a copy of the logical plan with every `limit_offset` node
+ * elided. Used when the count aggregate fast path pushes LIMIT/OFFSET
+ * into the start CTE — the outer SELECT then carries no LIMIT/OFFSET,
+ * so the logical plan must not either or the emitter invariant check
+ * will disagree with the emitted SQL.
+ */
+function stripLimitOffsetFromPlan(plan: LogicalPlan): LogicalPlan {
+  return { ...plan, root: stripLimitOffsetFromPlanNode(plan.root) };
+}
+
+function stripLimitOffsetFromPlanNode(node: LogicalPlanNode): LogicalPlanNode {
+  if (node.op === "limit_offset") {
+    return stripLimitOffsetFromPlanNode(node.input);
+  }
+  if ("input" in node) {
+    return { ...node, input: stripLimitOffsetFromPlanNode(node.input) };
+  }
+  return node;
 }
 
 /**

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -59,6 +59,7 @@ export const postgresDialect: DialectAdapter = {
     recursiveQueryStrategy: "recursive_cte",
     setOperationStrategy: "standard_parenthesized",
     materializeIntermediateTraversalCtes: false,
+    emitNotMaterializedHint: true,
     forceRecursiveWorktableOuterJoinOrder: false,
     vectorPredicateStrategy: "native",
     vectorMetrics: ["cosine", "l2", "inner_product"] as const,

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -63,6 +63,7 @@ export const sqliteDialect: DialectAdapter = {
     recursiveQueryStrategy: "recursive_cte",
     setOperationStrategy: "sqlite_compound",
     materializeIntermediateTraversalCtes: true,
+    emitNotMaterializedHint: false,
     forceRecursiveWorktableOuterJoinOrder: true,
     vectorPredicateStrategy: "native",
     vectorMetrics: ["cosine", "l2"] as const,

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -63,6 +63,15 @@ export type DialectCapabilities = Readonly<{
   materializeIntermediateTraversalCtes: boolean;
 
   /**
+   * When true, emit an explicit `NOT MATERIALIZED` hint on non-materialized
+   * CTEs so the planner can inline them and see their row statistics. PostgreSQL
+   * otherwise defaults to materializing any CTE referenced more than once,
+   * which makes its planner opaque to the inner statistics. SQLite ignores
+   * CTE materialization hints entirely.
+   */
+  emitNotMaterializedHint: boolean;
+
+  /**
    * Whether recursive CTEs should enforce worktable-first join ordering.
    */
   forceRecursiveWorktableOuterJoinOrder: boolean;

--- a/packages/typegraph/src/query/index.ts
+++ b/packages/typegraph/src/query/index.ts
@@ -82,6 +82,8 @@ export {
   avg,
   count,
   countDistinct,
+  countDistinctEdges,
+  countEdges,
   field,
   having,
   havingEq,

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -5,9 +5,14 @@
  * Follows Better Auth's pattern: users provide a configured Drizzle instance
  * and run migrations to create TypeGraph tables.
  */
+import { createRequire } from "node:module";
+
 import Database from "better-sqlite3";
 import { sql } from "drizzle-orm";
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import {
+  type BetterSQLite3Database,
+  drizzle as drizzleBetterSqlite3,
+} from "drizzle-orm/better-sqlite3";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
@@ -18,6 +23,8 @@ import {
   defineNode,
   subClassOf,
 } from "../../../src";
+
+const nodeRequire = createRequire(import.meta.url);
 import { tables } from "../../../src/backend/drizzle/schema/sqlite";
 import {
   createSqliteBackend,
@@ -844,5 +851,95 @@ describe("Vector Search with SQLite (sqlite-vec)", () => {
         `SELECT vec_distance_ip(vec_f32('[1,0,0,0]'), vec_f32('[0,1,0,0]'))`,
       );
     }).toThrow(/no such function/);
+  });
+});
+
+// ============================================================
+// TypeGraph SQLite Embedding Persistence (end-to-end)
+// ============================================================
+
+describe("SQLite embedding persistence via createSqliteBackend", () => {
+  it("persists embeddings and returns results from .similarTo() when sqlite-vec is loaded", async () => {
+    // Best-effort: skip if the optional peer dep is not installed.
+    const sqlite = new Database(":memory:");
+    try {
+      const module_ = nodeRequire("sqlite-vec") as {
+        load: (db: Database.Database) => void;
+      };
+      module_.load(sqlite);
+    } catch {
+      sqlite.close();
+      return;
+    }
+
+    const { embedding, defineNode, defineGraph } = await import("../../../src");
+    const Document = defineNode("Doc", {
+      schema: z.object({
+        title: z.string(),
+        embedding: embedding(4),
+      }),
+    });
+    const graph = defineGraph({
+      id: "sqlite_vec_e2e",
+      nodes: { Doc: { type: Document } },
+      edges: {},
+    });
+
+    for (const statement of generateSqliteDDL(tables)) {
+      sqlite.exec(statement);
+    }
+    const db = drizzleBetterSqlite3(sqlite);
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables,
+      hasVectorEmbeddings: true,
+    });
+    expect(backend.upsertEmbedding).toBeDefined();
+
+    const store = createStore(graph, backend);
+    await store.nodes.Doc.create({
+      title: "Similar",
+      embedding: [1, 0, 0, 0],
+    });
+    await store.nodes.Doc.create({
+      title: "Dissimilar",
+      embedding: [0, 1, 0, 0],
+    });
+
+    // Embeddings table should now carry two rows.
+    const count = sqlite
+      .prepare("SELECT COUNT(*) AS n FROM typegraph_node_embeddings")
+      .get() as { n: number };
+    expect(count.n).toBe(2);
+
+    // `.similarTo()` should rank the identical embedding first.
+    const rows = await store
+      .query()
+      .from("Doc", "d")
+      .whereNode("d", (d) =>
+        d.embedding.similarTo([1, 0, 0, 0], 10, { metric: "cosine" }),
+      )
+      .select((ctx) => ({ title: ctx.d.title }))
+      .execute();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.title).toBe("Similar");
+    expect(rows[1]!.title).toBe("Dissimilar");
+
+    sqlite.close();
+  });
+
+  it("does not expose upsertEmbedding when hasVectorEmbeddings is false", () => {
+    const sqlite = new Database(":memory:");
+    for (const statement of generateSqliteDDL(tables)) {
+      sqlite.exec(statement);
+    }
+    const db = drizzleBetterSqlite3(sqlite);
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables,
+    });
+    expect(backend.upsertEmbedding).toBeUndefined();
+    expect(backend.deleteEmbedding).toBeUndefined();
+    sqlite.close();
   });
 });

--- a/packages/typegraph/tests/count-edges-semantics.test.ts
+++ b/packages/typegraph/tests/count-edges-semantics.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Runtime semantic tests for countEdges / countDistinctEdges.
+ *
+ * The shipped compiler fast path treats `count(targetAlias)` and
+ * `countEdges(edgeAlias)` as two distinct aggregators:
+ *
+ *   - `count(targetAlias)` joins to the target node table and respects
+ *     the target's temporal window — only live targets are counted.
+ *   - `countEdges(edgeAlias)` counts edges directly, skipping the node
+ *     join. An edge to a target whose `validTo` has passed still counts,
+ *     because the edge itself is still live.
+ *
+ * These tests exercise the distinction against a real SQLite backend
+ * using a target node whose `validTo` is in the past.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  count,
+  countDistinctEdges,
+  countEdges,
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  field,
+} from "../src";
+import type { GraphBackend } from "../src/backend/types";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows");
+
+const graph = defineGraph({
+  id: "count_edges_semantics",
+  nodes: { Person: { type: Person } },
+  edges: {
+    knows: {
+      type: knows,
+      from: [Person],
+      to: [Person],
+      cardinality: "many",
+    },
+  },
+});
+
+describe("countEdges vs count(target) semantics", () => {
+  let backend: GraphBackend;
+  let store: ReturnType<typeof createStore<typeof graph>>;
+
+  /**
+   * Canonical fixture for the two-aggregator comparison: Alice knows
+   * Bob (both live) and Eve (temporally expired via `validTo` in the
+   * past, while the Alice→Eve edge itself remains live). This is the
+   * exact state where `count(target)` and `countEdges` produce
+   * different answers.
+   */
+  const PAST_TIMESTAMP = "2020-01-01T00:00:00.000Z";
+  async function seedAliceWithExpiredEveFriend(): Promise<void> {
+    await store.nodes.Person.create({ name: "Alice" }, { id: "alice" });
+    await store.nodes.Person.create({ name: "Bob" }, { id: "bob" });
+    await store.nodes.Person.create(
+      { name: "Eve" },
+      { id: "eve", validTo: PAST_TIMESTAMP },
+    );
+    await store.edges.knows.create(
+      { kind: "Person", id: "alice" },
+      { kind: "Person", id: "bob" },
+      {},
+    );
+    await store.edges.knows.create(
+      { kind: "Person", id: "alice" },
+      { kind: "Person", id: "eve" },
+      {},
+    );
+  }
+
+  beforeEach(() => {
+    backend = createTestBackend();
+    store = createStore(graph, backend);
+  });
+
+  it("counts edges to a validTo-expired target differently from count(target)", async () => {
+    await seedAliceWithExpiredEveFriend();
+
+    const liveTargets = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (person) => person.id.eq("alice"))
+      .optionalTraverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        liveFriendCount: count("friend"),
+      })
+      .execute();
+    expect(liveTargets).toHaveLength(1);
+    // Eve is expired, so only the Alice→Bob relationship counts as live.
+    expect(liveTargets[0]!.liveFriendCount).toBe(1);
+
+    const edgeCount = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (person) => person.id.eq("alice"))
+      .optionalTraverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        totalKnows: countEdges("e"),
+      })
+      .execute();
+    expect(edgeCount).toHaveLength(1);
+    // Both Alice→Bob and Alice→Eve edges are live regardless of Eve's state.
+    expect(edgeCount[0]!.totalKnows).toBe(2);
+  });
+
+  it("mixes count(target) and countEdges in a single aggregate", async () => {
+    await seedAliceWithExpiredEveFriend();
+
+    const rows = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (person) => person.id.eq("alice"))
+      .optionalTraverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        liveFriends: count("friend"),
+        totalEdges: countEdges("e"),
+        distinctEdges: countDistinctEdges("e"),
+      })
+      .execute();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.liveFriends).toBe(1);
+    expect(rows[0]!.totalEdges).toBe(2);
+    expect(rows[0]!.distinctEdges).toBe(2);
+  });
+
+  it("countEdges returns 0 for users with no outgoing edges", async () => {
+    await store.nodes.Person.create({ name: "Solo" }, { id: "solo" });
+
+    const rows = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (person) => person.id.eq("solo"))
+      .optionalTraverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        followCount: countEdges("e"),
+      })
+      .execute();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.followCount).toBe(0);
+  });
+
+  it("countEdges respects a whereNode predicate on the target alias", async () => {
+    // Alice knows Bob (name matches "Bob") and Eve (name does not).
+    // countEdges with a whereNode predicate on `friend` should count
+    // only the Alice→Bob edge — the predicate must constrain the
+    // aggregate, not just the projection.
+    await store.nodes.Person.create({ name: "Alice" }, { id: "alice" });
+    await store.nodes.Person.create({ name: "Bob" }, { id: "bob" });
+    await store.nodes.Person.create({ name: "Eve" }, { id: "eve" });
+    await store.edges.knows.create(
+      { kind: "Person", id: "alice" },
+      { kind: "Person", id: "bob" },
+      {},
+    );
+    await store.edges.knows.create(
+      { kind: "Person", id: "alice" },
+      { kind: "Person", id: "eve" },
+      {},
+    );
+
+    const rows = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (person) => person.id.eq("alice"))
+      .optionalTraverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .whereNode("friend", (friend) => friend.name.eq("Bob"))
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        matchingFollows: countEdges("e"),
+      })
+      .execute();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.matchingFollows).toBe(1);
+  });
+
+  it("required traversal drops groups whose targets all fail a whereNode predicate", async () => {
+    // Without countEdges: same predicate behavior. A required traversal
+    // whose target predicate matches nothing should not produce a row
+    // at all.
+    await store.nodes.Person.create({ name: "Alice" }, { id: "alice" });
+    await store.nodes.Person.create({ name: "Bob" }, { id: "bob" });
+    await store.edges.knows.create(
+      { kind: "Person", id: "alice" },
+      { kind: "Person", id: "bob" },
+      {},
+    );
+
+    const rows = await store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (person) => person.id.eq("alice"))
+      // Required (non-optional) traversal; no matching target.
+      .traverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .whereNode("friend", (friend) => friend.name.eq("Zoe"))
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        matchingFollows: countEdges("e"),
+      })
+      .execute();
+
+    // Required traversal with no matching edges drops the start row
+    // entirely — it must not produce a zero-count phantom row.
+    expect(rows).toHaveLength(0);
+  });
+
+  it("paginated aggregate returns the right page with limit+offset", async () => {
+    // Regression: when the fast path pushed LIMIT+OFFSET into the start
+    // CTE, it also kept emitting LIMIT+OFFSET on the outer SELECT,
+    // double-applying and yielding an empty page.
+    for (let index = 0; index < 50; index += 1) {
+      const id = `user_${String(index).padStart(3, "0")}`;
+      await store.nodes.Person.create({ name: `User ${index}` }, { id });
+    }
+    // A single outgoing edge per user so every group has followCount=1.
+    for (let index = 0; index < 50; index += 1) {
+      const id = `user_${String(index).padStart(3, "0")}`;
+      const targetId = `user_${String((index + 1) % 50).padStart(3, "0")}`;
+      await store.edges.knows.create(
+        { kind: "Person", id },
+        { kind: "Person", id: targetId },
+        {},
+      );
+    }
+
+    const page1 = await store
+      .query()
+      .from("Person", "p")
+      .optionalTraverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        id: field("p", "id"),
+        followCount: count("friend"),
+      })
+      .limit(10)
+      .execute();
+
+    const page2 = await store
+      .query()
+      .from("Person", "p")
+      .optionalTraverse("knows", "e", { expand: "none" })
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        id: field("p", "id"),
+        followCount: count("friend"),
+      })
+      .limit(10)
+      .offset(10)
+      .execute();
+
+    expect(page1).toHaveLength(10);
+    expect(page2).toHaveLength(10);
+    // Pages must be disjoint — same row appearing in both means the
+    // offset was ignored, and an empty page2 means the offset was
+    // double-applied.
+    const page1Ids = new Set(page1.map((row) => row.id));
+    for (const row of page2) {
+      expect(page1Ids.has(row.id as string)).toBe(false);
+    }
+  });
+});

--- a/packages/typegraph/tests/indexes.test.ts
+++ b/packages/typegraph/tests/indexes.test.ts
@@ -89,6 +89,34 @@ describe("indexes", () => {
     expect(sqliteSql).toContain(`"${roleIndex.name}"`);
   });
 
+  it("emits real column expressions for indexes passed through Drizzle factories", () => {
+    // Regression: the DDL generator previously emitted `(unknown, unknown, ...)`
+    // for indexes threaded through createSqliteTables / createPostgresTables
+    // because the SQL-chunk flattener couldn't render Drizzle column
+    // references or StringChunks nested inside index keys.
+    const cityIndex = defineNodeIndex(Person, {
+      fields: ["email"],
+      coveringFields: ["name"],
+    });
+
+    const sqliteTables = createSqliteTables({}, { indexes: [cityIndex] });
+    const sqliteSql = generateSqliteDDL(sqliteTables).join("\n");
+    expect(sqliteSql).not.toContain("(unknown");
+    expect(sqliteSql).toMatch(
+      new RegExp(
+        String.raw`"${cityIndex.name}"[^\n]*"graph_id"[^\n]*"kind"[^\n]*json_extract[^\n]*'\$\."email"'[^\n]*json_extract[^\n]*'\$\."name"'`,
+      ),
+    );
+
+    const pgTables = createPostgresTables({}, { indexes: [cityIndex] });
+    const pgSql = generatePostgresDDL(pgTables).join("\n");
+    expect(pgSql).not.toContain("(unknown");
+    expect(pgSql).toContain(`"graph_id"`);
+    expect(pgSql).toContain(`"kind"`);
+    expect(pgSql).toContain(`ARRAY['email']`);
+    expect(pgSql).toContain(`ARRAY['name']`);
+  });
+
   it("prefixes edge indexes with the traversal join key when direction is set", () => {
     const out = defineEdgeIndex(worksAt, {
       fields: ["role"],

--- a/packages/typegraph/tests/query-builder.test.ts
+++ b/packages/typegraph/tests/query-builder.test.ts
@@ -18,6 +18,8 @@ import {
   avg,
   count,
   countDistinct,
+  countDistinctEdges,
+  countEdges,
   createQueryBuilder,
   defineEdge,
   defineGraph,
@@ -664,7 +666,7 @@ describe("Query Compilation to SQL", () => {
     expect(sql).not.toContain("cte_friendOfFriend AS MATERIALIZED");
   });
 
-  it("does not materialize traversal CTEs for postgres multi-hop queries", () => {
+  it("emits NOT MATERIALIZED on postgres traversal CTEs so the planner can inline them", () => {
     const query = createQueryBuilder<typeof graph>(graph.id, registry)
       .from("Person", "p")
       .whereNode("p", (p) => p.id.eq("person-1"))
@@ -680,7 +682,30 @@ describe("Query Compilation to SQL", () => {
     const sqlObject = compileQuery(query.toAst(), graph.id, "postgres");
     const { sql } = toSqlWithParams(sqlObject, "postgres");
 
-    expect(sql).not.toContain("MATERIALIZED");
+    // Each CTE (start + two traversals) should carry `NOT MATERIALIZED`.
+    const occurrences = sql.match(/NOT MATERIALIZED/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(3);
+    // And no plain `MATERIALIZED` without the NOT prefix.
+    expect(sql).not.toMatch(/(?<!NOT )MATERIALIZED/);
+  });
+
+  it("does not emit NOT MATERIALIZED on sqlite (hint unsupported there)", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .whereNode("p", (p) => p.id.eq("person-1"))
+      .traverse("knows", "e1")
+      .to("Person", "friend")
+      .traverse("knows", "e2")
+      .to("Person", "friendOfFriend")
+      .select((context) => ({
+        friendName: context.friend.name,
+        fofName: context.friendOfFriend.name,
+      }));
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    expect(sql).not.toContain("NOT MATERIALIZED");
   });
 
   it("does not push traversal limits when ORDER BY is present", () => {
@@ -1096,6 +1121,214 @@ describe("Query Builder - Aggregations", () => {
     expect(sql).toContain("p_props");
     expect(sql).toContain("cte_p.p_kind = e.to_kind");
     expect(sql).toContain("n.kind = e.from_kind");
+  });
+
+  it("countEdges(edgeAlias) drops the target node join in the fast path", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        followCount: countEdges("k"),
+      });
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    // Edge-only count should skip the typegraph_nodes n JOIN entirely.
+    expect(sql).not.toMatch(/JOIN\s+"typegraph_nodes"\s+n\s+ON/);
+    // And count the edge table primary key directly.
+    expect(sql).toContain("COUNT(e.id)");
+    // Target-side temporal / deleted filters are not emitted.
+    expect(sql).not.toContain("n.deleted_at");
+  });
+
+  it("countDistinctEdges(edgeAlias) emits COUNT(DISTINCT e.id) without node join", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        distinctFollowers: countDistinctEdges("k"),
+      });
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    expect(sql).toContain("COUNT(DISTINCT e.id)");
+    expect(sql).not.toMatch(/JOIN\s+"typegraph_nodes"\s+n\s+ON/);
+  });
+
+  it("mixes node and edge counts — keeps the node join and emits both columns", () => {
+    // When a query mixes count(targetAlias) with countEdges(edgeAlias) the
+    // compiler must keep the target-node join (for count-target's temporal
+    // correctness) and emit distinct result columns for each aggregate.
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        liveFriends: count("friend"),
+        totalEdges: countEdges("k"),
+      });
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    // No target predicate → LEFT JOIN so countEdges sees all live edges
+    // while count(target) still excludes edges to expired targets via
+    // COUNT ignoring NULL-valued n.id.
+    expect(sql).toMatch(/LEFT JOIN\s+"typegraph_nodes"\s+n\s+ON/);
+    expect(sql).toContain("COUNT(n.id)");
+    expect(sql).toContain("COUNT(e.id)");
+    // Different column identifiers for each aggregate, not a merged column.
+    expect(sql).toContain("friend_count");
+    expect(sql).toContain("k_count");
+  });
+
+  it("switches to INNER JOIN when a whereNode predicate targets the traversal target", () => {
+    // With a whereNode predicate on the target alias, the predicate must
+    // constrain every aggregate — including countEdges. LEFT JOIN with the
+    // predicate in ON would let edges pointing at non-matching targets
+    // through and inflate COUNT(e.id).
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .whereNode("friend", (friend) => friend.name.eq("Alice"))
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        matchingKnows: countEdges("k"),
+      });
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    // INNER JOIN (not LEFT JOIN) so predicate failures drop the edge row.
+    expect(sql).toMatch(/\bJOIN\s+"typegraph_nodes"\s+n\s+ON/);
+    expect(sql).not.toMatch(/LEFT JOIN\s+"typegraph_nodes"\s+n\s+ON/);
+    // Predicate lands in WHERE, not ON.
+    expect(sql).toMatch(/WHERE[\s\S]*json_extract\(n\.props,\s*'\$\."name"'\)/);
+    expect(sql).toContain("COUNT(e.id)");
+  });
+
+  it("joins to the target node table so target temporal filters apply", () => {
+    // count(target) must preserve the target node's validity window, which
+    // is NOT cascaded when a node is updated with `validTo`. The target
+    // node join is how we keep traversal-target visibility consistent.
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        friendCount: count("friend"),
+      });
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    expect(sql).toMatch(/JOIN\s+"typegraph_nodes"\s+n\s+ON/);
+    expect(sql).toContain("COUNT(n.id)");
+    // Target-side temporal + deleted filters present.
+    expect(sql).toContain("n.deleted_at");
+  });
+
+  it("suppresses outer LIMIT/OFFSET when LIMIT+OFFSET was pushed into the start CTE", () => {
+    // When .limit(N).offset(M) is pushed into cte_u, the outer SELECT
+    // must not also emit LIMIT/OFFSET or the offset is applied twice.
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        friendCount: count("friend"),
+      })
+      .limit(20)
+      .offset(20);
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql, params } = toSqlWithParams(sqlObject);
+
+    // Start CTE carries both LIMIT and OFFSET.
+    expect(sql).toMatch(/cte_p AS[\s\S]*?LIMIT\s+\?\s*OFFSET\s+\?\s*\)/);
+    // Outer SELECT does not re-emit them — anchor the final LIMIT keyword
+    // to the end of the statement and assert it's inside cte_p.
+    const outerLimitPattern = /LIMIT\s+\?(?:\s+OFFSET\s+\?)?\s*$/;
+    expect(sql.replaceAll(/\s+/g, " ")).not.toMatch(outerLimitPattern);
+    // Only one of each LIMIT/OFFSET value should be bound.
+    expect(params.filter((p) => p === 20)).toHaveLength(2);
+  });
+
+  it("pushes LIMIT into the start CTE for optional count aggregates", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        friendCount: count("friend"),
+      })
+      .limit(20);
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    // The start CTE should carry the LIMIT so GROUP BY only runs over 20 rows.
+    expect(sql).toMatch(/cte_p AS[\s\S]*?LIMIT\s+\?\s*\)/);
+  });
+
+  it("does not push LIMIT past GROUP BY when an ORDER BY is set", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .optionalTraverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .orderBy("p", "name", "asc")
+      .aggregate({
+        name: field("p", "name"),
+        friendCount: count("friend"),
+      })
+      .limit(20);
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    // ORDER BY over the full result requires the full result — no push-down.
+    expect(sql).not.toMatch(/cte_p AS[\s\S]*?LIMIT\s+\?\s*\)/);
+    // LIMIT still appears at the outer query level.
+    expect(sql).toMatch(/LIMIT\s+\?\s*$/);
+  });
+
+  it("does not push LIMIT past GROUP BY for required traversals", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .traverse("knows", "k")
+      .to("Person", "friend")
+      .groupByNode("p")
+      .aggregate({
+        name: field("p", "name"),
+        friendCount: count("friend"),
+      })
+      .limit(20);
+
+    const sqlObject = compileQuery(query.toAst(), graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    // INNER JOIN can drop start rows; pushing LIMIT into cte_p could change
+    // the result set size.
+    expect(sql).not.toMatch(/cte_p AS[\s\S]*?LIMIT\s+\?\s*\)/);
   });
 
   it("supports HAVING clause to filter groups", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
Builds out the TypeGraph perf suite into a real regression gate, adds a head-to-head harness against Neo4j 5.26, and ships three compiler improvements that the harness surfaced. Every query shape on both sides now asserts a cardinality invariant — silent empty-result or wrong-cardinality regressions throw instead of reporting a falsely fast number.

## Highlights

### bench: expanded perf suite and Neo4j 5.26 head-to-head microbenchmark harness

Scoped aggregate, indexed property filter, temporal `asOf`, fulltext/vector/hybrid search shapes, p95 alongside median, history appended to `reports/history.jsonl`. All shapes assert cardinality invariants. `--scale=N` CLI flag (validated `>= 1`). Existing aggregate benchmark dropped its silent `.limit(20)` so the label matches what it measures.

Standalone package under `packages/benchmarks/neo4j-compare/`. Docker Compose + seed + bench runner, shared xorshift32 seed for byte-identical graph shape, matching methodology (2 warmup iterations, 15 samples, median).

### fix: DDL generator emits real column expressions for indexes in Drizzle factories

Indexes threaded through `createSqliteTables({}, { indexes })` / `createPostgresTables({}, { indexes })` were emitting `(unknown, unknown, ...)` instead of their expression keys because the SQL-chunk flattener mishandled Drizzle column references and `StringChunk` values. Regression test pins the fix.

### fix: persist vector embeddings on SQLite backend
`store.nodes.X.create({ ..., embedding: [...] })` on SQLite was silently dropping the embedding because the backend never implemented `upsertEmbedding`/`deleteEmbedding`. Wires both methods up, opt-in via a new `hasVectorEmbeddings` option (`createLocalSqliteBackend` flips it automatically when sqlite-vec loads). End-to-end integration test.

### perf + feat: count aggregate fast path and Postgres CTE improvements

- **NOT MATERIALIZED** on Postgres traversal CTEs — stops the planner from opaquely materializing the twice-referenced CTEs and picking pathological join orderings on larger graphs.
- **LIMIT push-down** in the count aggregate fast path — when the outer `LIMIT` doesn't depend on aggregate results, push it past the `GROUP BY` into the start CTE. Semantics-preserving.
- **countEdges / countDistinctEdges** — new aggregators that count edges directly, skipping the target-node join when target validity isn't part of the question. `count(targetAlias)` behavior unchanged. Mixed aggregates (both in one query) keep the node join but switch to `LEFT JOIN` with node-side filters in `ON` so edge counts stay accurate.

## Measured impact

TypeGraph SQLite vs Neo4j 5.26 w/ honest 1,200-group aggregates.

| Shape | TypeGraph SQLite | Neo4j 5.26 |
|---|---|---|
| Forward traversal | 0.2ms | 1.1ms |
| 3-hop traversal | 0.5ms | 1.1ms |
| 1000-hop recursive | 1.3ms | 2.1ms |
| Aggregate `count(target)` | 12.6ms | 5.4ms |
| Aggregate `countEdges(e)` | **8.1ms** | — |
| Aggregate DISTINCT | 13.5ms | 6.1ms |

On Postgres the `countEdges` aggregate lands at **3.6ms** — faster than Neo4j's 5.4ms on this shape.