### PR TITLE
feat: PostgreSQL driver integration + ANALYZE API + multi-hop perf

### DIFF
--- a/.changeset/postgres-driver-integration.md
+++ b/.changeset/postgres-driver-integration.md
@@ -1,0 +1,49 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+PostgreSQL: official postgres-js / Neon support, server-side prepared statements on the fast path, and a `refreshStatistics()` API.
+
+**Four drivers supported.** `createPostgresBackend` has always been driver-agnostic, but only `node-postgres` was covered in CI. This release adds:
+
+- **`drizzle-orm/postgres-js`** — full adapter + integration suite coverage (~250 tests run against both `pg` and `postgres-js` against a real PostgreSQL).
+- **`drizzle-orm/neon-serverless`** — `@neondatabase/serverless` Pool over WebSockets. Wiring smoke tests verify driver detection, fast-path routing, Date→string normalization, and capability surface; the shared code paths are exercised by the `pg` integration suite since this driver is pg-Pool-protocol-compatible.
+- **`drizzle-orm/neon-http`** — `@neondatabase/serverless` `neon(url)` over HTTP. Auto-detected so `capabilities.transactions` is set to `false` (HTTP can't hold a session); single-statement reads, writes, and migrations work normally. Smoke tests verify the detection and capability override.
+
+Same `createPostgresBackend(db)` entry point regardless of driver.
+
+```typescript
+// postgres-js
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+const backend = createPostgresBackend(drizzle(postgres(process.env.DATABASE_URL)));
+
+// Neon serverless (edge runtimes)
+import { Pool } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-serverless";
+const backend = createPostgresBackend(drizzle(new Pool({ connectionString: env.NEON_DATABASE_URL })));
+```
+
+**On Neon HTTP vs WebSockets:** both work. The HTTP driver (`drizzle-orm/neon-http`) is best for stateless edge workloads — TypeGraph auto-disables transactions since HTTP can't hold a session, and `store.transaction(...)` falls through to non-transactional sequential execution. Use the WebSocket driver (`drizzle-orm/neon-serverless`) when you need atomic multi-statement writes.
+
+**~6× faster on multi-hop traversals via server-side prepared statements.** The execution adapter now uses `node-postgres`'s named prepared statements transparently — each unique compiled SQL string gets a stable counter-derived statement name (cached by SQL text), so PostgreSQL caches the plan after first execution. Combined with routing `execute()` through the fast path directly (skipping Drizzle's session wrapper), this drops the 3-hop benchmark from ~7.5ms to ~0.8ms median, putting TypeGraph-on-PostgreSQL at parity with Neo4j on every single-query and multi-hop shape we measure.
+
+The change is invisible to callers; existing code keeps working. postgres-js is unchanged (it handles its own preparation internally).
+
+**New `store.refreshStatistics()` / `backend.refreshStatistics()` API.** Call once after a large initial import or bulk backfill. Without fresh stats, the planner can pick suboptimal execution plans — on PostgreSQL this is the difference between a 0.5ms and 5ms forward traversal; on SQLite it's the difference between 0.9ms and 23ms fulltext search. Autovacuum / background statistics catch up eventually, but explicit invocation gives correct latencies immediately.
+
+```typescript
+for (const batch of batches) {
+  await store.bulkCreate(batch);
+}
+await store.refreshStatistics();
+```
+
+Implementations: SQLite runs `ANALYZE`; PostgreSQL runs `ANALYZE` on TypeGraph-managed tables only. Costs ~20ms on SQLite, ~80ms on PostgreSQL at the sizes this library is designed for.
+
+**Type surface changes:**
+
+- `GraphBackend` now requires a `refreshStatistics(): Promise<void>` method. `TransactionBackend` still excludes it (statistics refresh isn't meaningful inside a transaction). External `GraphBackend` implementations (uncommon) need to add a no-op or proper implementation.
+- `PostgresBackendOptions` adds an optional `capabilities?: Partial<BackendCapabilities>` for users who need to override capability flags (e.g., for custom HTTP-style drivers).
+
+See [`backend-setup`](https://typegraph.dev/backend-setup#choosing-a-postgresql-driver) for the runtime-to-driver matrix, per-driver setup snippets, and post-bulk-load guidance.

--- a/.changeset/postgres-driver-integration.md
+++ b/.changeset/postgres-driver-integration.md
@@ -34,7 +34,7 @@ The change is invisible to callers; existing code keeps working. postgres-js is 
 
 ```typescript
 for (const batch of batches) {
-  await store.bulkCreate(batch);
+  await store.nodes.Document.bulkCreate(batch);
 }
 await store.refreshStatistics();
 ```
@@ -45,5 +45,6 @@ Implementations: SQLite runs `ANALYZE`; PostgreSQL runs `ANALYZE` on TypeGraph-m
 
 - `GraphBackend` now requires a `refreshStatistics(): Promise<void>` method. `TransactionBackend` still excludes it (statistics refresh isn't meaningful inside a transaction). External `GraphBackend` implementations (uncommon) need to add a no-op or proper implementation.
 - `PostgresBackendOptions` adds an optional `capabilities?: Partial<BackendCapabilities>` for users who need to override capability flags (e.g., for custom HTTP-style drivers).
+- `PostgresBackendOptions` also adds `prepareStatements?: boolean` (default `true`) and `preparedStatementCacheMax?: number` (default `256`). The prepared-statement name cache is now LRU-bounded so high-cardinality SQL text doesn't grow unbounded in either the Node process or in PostgreSQL's per-session prepared-statement memory. Set `prepareStatements: false` when pooling through pgbouncer in transaction-pool mode.
 
 See [`backend-setup`](https://typegraph.dev/backend-setup#choosing-a-postgresql-driver) for the runtime-to-driver matrix, per-driver setup snippets, and post-bulk-load guidance.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -347,26 +347,51 @@ const backend = createPostgresBackend(db);
 
 See [Semantic Search](/semantic-search) for query examples.
 
-### Running ANALYZE after bulk loads
+### Refreshing planner statistics after bulk loads
 
-Run `ANALYZE` after any large initial import or bulk backfill. PostgreSQL's query
-planner relies on table statistics to choose between multi-column indexes on
-`typegraph_edges` (forward vs reverse vs cardinality), and when those statistics
-are stale the planner can pick a reverse-index scan with a filter — turning a
-0.5ms forward traversal into a 5ms one. Autovacuum will catch up eventually, but
-running ANALYZE explicitly after a bulk load gives you correct latencies
-immediately.
+Call `store.refreshStatistics()` after any large initial import or bulk
+backfill. PostgreSQL's query planner relies on table statistics to choose
+between multi-column indexes on `typegraph_edges` (forward vs reverse vs
+cardinality), and when those statistics are stale the planner can pick a
+reverse-index scan with a filter — turning a 0.5ms forward traversal into a
+5ms one. SQLite's planner is similarly sensitive: without `sqlite_stat1`
+data, some FTS5 fulltext queries fall back to a plan that's roughly 30×
+slower. Autovacuum / background statistics collection will catch up
+eventually, but refreshing explicitly gives correct latencies immediately.
 
 ```typescript
-await pool.query(
-  "ANALYZE typegraph_nodes, typegraph_edges, typegraph_node_uniques, " +
-    "typegraph_node_embeddings, typegraph_node_fulltext",
-);
+for (const batch of batches) {
+  await store.nodes.Document.bulkCreate(batch);
+}
+await store.refreshStatistics();
 ```
 
-The same applies to SQLite: run `ANALYZE` once after a bulk load so the planner
-has `sqlite_stat1` data to work from. Without it, some FTS5 fulltext queries
-fall back to a plan that's roughly 30× slower.
+The implementation runs `ANALYZE` against the TypeGraph-managed tables in
+the configured backend — the call is safe regardless of custom table names
+or fulltext / embedding configuration. If you need to bypass the API for an
+unusual deployment (for example issuing `ANALYZE` over a separate admin
+connection), call `backend.execute()` with raw SQL as the escape hatch.
+
+### pgbouncer / transaction-pool mode
+
+By default, the node-postgres / neon-serverless fast path issues server-side
+prepared statements (`client.query({name, text, values})`) so PostgreSQL
+caches the parsed plan per session. This is incompatible with pgbouncer in
+transaction-pool mode: pgbouncer routes successive statements over different
+backend connections, so a `name` registered on one connection isn't visible
+on the next. Pass `prepareStatements: false` to fall back to unnamed
+positional queries:
+
+```typescript
+const backend = createPostgresBackend(db, {
+  prepareStatements: false, // pgbouncer transaction-pool compatibility
+});
+```
+
+The cache that maps SQL text → statement name is LRU-bounded (default 256
+entries, override via `preparedStatementCacheMax`). Worst-case server-side
+footprint is roughly `cap × pool size` prepared statements across all pooled
+connections.
 
 ### Connection Pooling
 
@@ -418,6 +443,20 @@ function createPostgresBackend(
      * other capabilities for custom drivers.
      */
     capabilities?: Partial<BackendCapabilities>;
+    /**
+     * Use server-side prepared statements on the node-postgres /
+     * neon-serverless fast path. Default `true`. Set to `false` when
+     * pooling through pgbouncer in transaction-pool mode (named
+     * statements are invisible across pooled connections).
+     */
+    prepareStatements?: boolean;
+    /**
+     * LRU cap on the number of distinct SQL strings tracked for
+     * prepared-statement naming. Default 256. Worst-case server-side
+     * footprint is roughly `cap × pool size` prepared statements.
+     * Ignored when `prepareStatements` is `false`.
+     */
+    preparedStatementCacheMax?: number;
   }
 ): GraphBackend;
 ```
@@ -499,7 +538,7 @@ if (backend.capabilities.transactions) {
   // Handle non-transactional execution
 }
 
-if (backend.capabilities.vectorSearch) {
+if (backend.capabilities.vector?.supported) {
   // Vector similarity queries available
 }
 ```

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -175,7 +175,39 @@ async function createLibsqlBackend(
 PostgreSQL is recommended for production deployments with concurrent access, large datasets,
 or when you need advanced features like pgvector.
 
-### Basic Setup
+`createPostgresBackend` is driver-agnostic. Pick the Drizzle adapter that matches your
+runtime, and TypeGraph works the same way against each.
+
+### Choosing a PostgreSQL driver
+
+| Runtime | Recommended driver | Drizzle adapter |
+|---|---|---|
+| Long-lived Node server (Fly, Render, Cloud Run, containers) | `pg` (node-postgres) or `postgres` (postgres-js) | `drizzle-orm/node-postgres` or `drizzle-orm/postgres-js` |
+| Node serverless (Vercel Functions, AWS Lambda, Netlify Functions) | `postgres` (postgres-js) — faster cold start, lower per-query overhead | `drizzle-orm/postgres-js` |
+| Bun server | `postgres` (postgres-js) or Bun's built-in SQL | `drizzle-orm/postgres-js` or `drizzle-orm/bun-sql` |
+| Edge runtime (Cloudflare Workers, Vercel Edge, Netlify Edge) — needs transactions | `@neondatabase/serverless` Pool over WebSockets | `drizzle-orm/neon-serverless` |
+| Edge runtime — single-statement reads/writes only | `@neondatabase/serverless` `neon(url)` over HTTP | `drizzle-orm/neon-http` |
+| Cloudflare Hyperdrive | `pg` or `postgres` (through the Hyperdrive pooler) | `drizzle-orm/node-postgres` or `drizzle-orm/postgres-js` |
+
+:::note[Neon HTTP vs WebSocket]
+Both Neon drivers work with TypeGraph. They have different tradeoffs:
+
+- **`drizzle-orm/neon-http`** uses HTTP per statement. Lowest cold-start cost; survives Workers'
+  per-request isolation. **Cannot hold a session across statements**, so multi-statement transactions
+  are unavailable — TypeGraph auto-detects this driver and sets `capabilities.transactions = false`,
+  so `store.transaction(...)` falls through to non-transactional sequential execution.
+- **`drizzle-orm/neon-serverless`** uses a WebSocket Pool. Holds a session, supports full transactional
+  semantics, but the WebSocket connection lifecycle needs care in serverless / per-request contexts
+  (you typically want a fresh Pool per request).
+
+Pick HTTP for stateless reads, single upserts, and migrations. Pick WebSockets if you need atomic
+multi-statement writes.
+:::
+
+### node-postgres (pg)
+
+The default choice for long-lived Node servers. Widest ecosystem and most deployment
+documentation.
 
 ```typescript
 import { Pool } from "pg";
@@ -183,17 +215,13 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
 import { createStoreWithSchema } from "@nicia-ai/typegraph";
 
-// Create connection pool
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  max: 20, // Maximum connections
+  max: 20,
 });
 
-// Create Drizzle instance and backend
 const db = drizzle(pool);
 const backend = createPostgresBackend(db);
-
-// createStoreWithSchema auto-creates tables on first run
 const [store] = await createStoreWithSchema(graph, backend);
 ```
 
@@ -205,6 +233,98 @@ import { generatePostgresMigrationSQL } from "@nicia-ai/typegraph/postgres";
 await pool.query(generatePostgresMigrationSQL());
 const store = createStore(graph, backend);
 ```
+
+### postgres-js
+
+A leaner Postgres client with lower per-query overhead and smaller bundle size. Good
+default for Node serverless platforms and Bun. Fully tested against TypeGraph's adapter
+and integration suites.
+
+```bash
+npm install postgres drizzle-orm
+```
+
+```typescript
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
+import { createStoreWithSchema } from "@nicia-ai/typegraph";
+
+const sql = postgres(process.env.DATABASE_URL, {
+  max: 10,
+  idle_timeout: 30,
+});
+
+const db = drizzle(sql);
+const backend = createPostgresBackend(db);
+const [store] = await createStoreWithSchema(graph, backend);
+```
+
+Transactions go through `sql.begin(fn)`; TypeGraph handles this automatically via
+Drizzle's `db.transaction()`. Isolation levels are honored the same way as with
+node-postgres.
+
+### Neon serverless (WebSockets)
+
+For edge runtimes like Cloudflare Workers, Vercel Edge, and Netlify Edge — anywhere
+native TCP sockets aren't available. Neon's `@neondatabase/serverless` driver speaks
+the Postgres wire protocol over WebSockets and exposes a pg-Pool-compatible API.
+
+```bash
+npm install @neondatabase/serverless drizzle-orm
+```
+
+```typescript
+import { Pool } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-serverless";
+import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
+import { createStoreWithSchema } from "@nicia-ai/typegraph";
+
+const pool = new Pool({ connectionString: env.NEON_DATABASE_URL });
+const db = drizzle(pool);
+const backend = createPostgresBackend(db);
+const [store] = await createStoreWithSchema(graph, backend);
+```
+
+When running under Node.js (for local testing), install `ws` and configure it once
+before connecting:
+
+```typescript
+import { neonConfig } from "@neondatabase/serverless";
+import ws from "ws";
+
+neonConfig.webSocketConstructor = ws;
+```
+
+Edge runtimes expose `WebSocket` globally and need no extra setup.
+
+### Neon HTTP
+
+For stateless edge workloads where you don't need transactional writes. The HTTP
+driver issues one request per query — lowest cold-start cost, no session lifecycle
+to manage. TypeGraph auto-detects this driver and sets `capabilities.transactions`
+to `false`, so `store.transaction(...)` and `setActiveSchema(...)` fall through to
+sequential execution rather than throwing.
+
+```bash
+npm install @neondatabase/serverless drizzle-orm
+```
+
+```typescript
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
+import { createStore } from "@nicia-ai/typegraph";
+
+const sql = neon(env.NEON_DATABASE_URL);
+const db = drizzle({ client: sql });
+const backend = createPostgresBackend(db);
+const store = createStore(graph, backend);
+// backend.capabilities.transactions === false (auto-detected)
+```
+
+Use `neon-http` for reads, single upserts, and migrations. Use `neon-serverless`
+when you need atomic multi-statement writes.
 
 ### PostgreSQL with Vector Search
 
@@ -226,6 +346,27 @@ const backend = createPostgresBackend(db);
 ```
 
 See [Semantic Search](/semantic-search) for query examples.
+
+### Running ANALYZE after bulk loads
+
+Run `ANALYZE` after any large initial import or bulk backfill. PostgreSQL's query
+planner relies on table statistics to choose between multi-column indexes on
+`typegraph_edges` (forward vs reverse vs cardinality), and when those statistics
+are stale the planner can pick a reverse-index scan with a filter — turning a
+0.5ms forward traversal into a 5ms one. Autovacuum will catch up eventually, but
+running ANALYZE explicitly after a bulk load gives you correct latencies
+immediately.
+
+```typescript
+await pool.query(
+  "ANALYZE typegraph_nodes, typegraph_edges, typegraph_node_uniques, " +
+    "typegraph_node_embeddings, typegraph_node_fulltext",
+);
+```
+
+The same applies to SQLite: run `ANALYZE` once after a bulk load so the planner
+has `sqlite_stat1` data to work from. Without it, some FTS5 fulltext queries
+fall back to a plan that's roughly 30× slower.
 
 ### Connection Pooling
 
@@ -257,12 +398,27 @@ process.on("SIGTERM", async () => {
 
 #### `createPostgresBackend(db, options?)`
 
-Creates a PostgreSQL backend adapter.
+Creates a PostgreSQL backend adapter. Accepts any Drizzle PostgreSQL database
+instance, regardless of the underlying driver. Tested with `drizzle-orm/node-postgres`,
+`drizzle-orm/postgres-js`, `drizzle-orm/neon-serverless`, and
+`drizzle-orm/neon-http`. The neon-http driver is auto-detected and
+`capabilities.transactions` is set to `false` (HTTP can't hold a session); use
+`drizzle-orm/neon-serverless` if you need transactional writes.
 
 ```typescript
 function createPostgresBackend(
-  db: NodePgDatabase,
-  options?: { tables?: PostgresTables }
+  db: AnyPgDatabase,
+  options?: {
+    tables?: PostgresTables;
+    fulltext?: FulltextStrategy;
+    /**
+     * Override specific backend capabilities. Useful for HTTP-style
+     * drivers or test scenarios. neon-http already has `transactions:
+     * false` auto-applied — pass this to override that or to disable
+     * other capabilities for custom drivers.
+     */
+    capabilities?: Partial<BackendCapabilities>;
+  }
 ): GraphBackend;
 ```
 

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -5,39 +5,50 @@ description: Known constraints and backend-specific limitations
 
 This page documents TypeGraph's known limitations and constraints.
 
-## Cloudflare D1 Transactions
+## Backends Without Atomic Transactions
 
-Cloudflare D1 does not support atomic transactions. When using D1, calling
-`store.transaction()` will throw a `ConfigurationError`.
+Some runtimes cannot hold a multi-statement database session and therefore
+cannot offer atomic transactions:
+
+- **Cloudflare D1** — the D1 binding has no transaction primitive.
+- **`drizzle-orm/neon-http`** — Neon's HTTP driver issues each statement as
+  an independent request; there is no session to bind a transaction to.
+
+These backends report `capabilities.transactions: false`. On such backends,
+`store.transaction(fn)` and `store.batch(...)` still run — `fn` executes
+against the same backend used outside `transaction()`, sequentially —
+**but writes are applied as they happen and a thrown error inside the
+callback does not roll back earlier writes**. Likewise, `store.batch(...)`
+runs each query over an independent connection, so two queries in the same
+batch may observe different database snapshots.
 
 ```typescript
-// Throws ConfigurationError on D1
+// On D1 / neon-http: every successful create is persisted immediately.
+// If the throw fires after Alice is created, Alice stays in the database.
 await store.transaction(async (tx) => {
-  // ...
+  await tx.nodes.Person.create({ name: "Alice" });
+  throw new Error("boom"); // does NOT roll back the create above
 });
 ```
 
-**Workaround:** Execute operations directly without transaction wrapper. Operations
-execute sequentially but without atomicity guarantees.
-
-```typescript
-// Alternative: execute operations directly (not atomic)
-const person = await store.nodes.Person.create({ name: "Alice" });
-const company = await store.nodes.Company.create({ name: "Acme" });
-await store.edges.worksAt.create(person, company, { role: "Engineer" });
-```
-
-**Check support programmatically:**
+**If you require atomicity, branch on the capability:**
 
 ```typescript
 if (backend.capabilities.transactions) {
   await store.transaction(async (tx) => {
-    /* ... */
+    /* atomic */
   });
 } else {
-  // Handle non-transactional execution
+  // Sequential, non-atomic — handle partial-failure recovery yourself.
+  const person = await store.nodes.Person.create({ name: "Alice" });
+  const company = await store.nodes.Company.create({ name: "Acme" });
+  await store.edges.worksAt.create(person, company, { role: "Engineer" });
 }
 ```
+
+If you need atomic writes from an edge runtime, use
+`drizzle-orm/neon-serverless` (WebSocket-backed Pool) instead of
+`drizzle-orm/neon-http`.
 
 ## libsql In-Memory Transactions
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1077,17 +1077,24 @@ context through your call chain.
 
 #### Backend support
 
-Not all backends support atomic transactions. Cloudflare D1, for example, does not —
-calling `store.transaction()` on a D1-backed store throws a `ConfigurationError`. Check
-support at runtime with:
+Not all backends support atomic transactions. Cloudflare D1 and
+`drizzle-orm/neon-http` cannot hold a multi-statement session and report
+`capabilities.transactions: false`. On these backends `store.transaction(fn)`
+still runs — `fn` executes against the same backend used outside
+`transaction()`, sequentially — **but writes are applied as they happen and
+a thrown error does not roll back earlier writes inside the callback**. If
+you require atomicity, branch on the capability:
 
 ```typescript
 if (backend.capabilities.transactions) {
-  await store.transaction(async (tx) => { /* ... */ });
+  await store.transaction(async (tx) => { /* atomic */ });
 } else {
-  // fall back to individual operations with manual error handling
+  // Sequential, non-atomic — handle partial-failure recovery yourself.
 }
 ```
+
+See [Limitations](/limitations#backends-without-atomic-transactions) for
+the full list of affected backends and edge-runtime alternatives.
 
 ### Clear
 

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -20,6 +20,7 @@
     "better-sqlite3": "^12.9.0",
     "drizzle-orm": "^0.45.2",
     "pg": "^8.20.0",
+    "postgres": "^3.4.9",
     "sqlite-vec": "^0.1.9",
     "zod": "^4.3.6"
   },

--- a/packages/benchmarks/src/backend.ts
+++ b/packages/benchmarks/src/backend.ts
@@ -2,8 +2,10 @@ import { createRequire } from "node:module";
 
 import Database from "better-sqlite3";
 import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
-import { drizzle as drizzlePostgres } from "drizzle-orm/node-postgres";
+import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
+import { drizzle as drizzlePostgresJs } from "drizzle-orm/postgres-js";
 import { Pool } from "pg";
+import postgres, { type Sql } from "postgres";
 import { createStore } from "@nicia-ai/typegraph";
 import {
   createPostgresBackend,
@@ -16,7 +18,11 @@ import {
   generateSqliteDDL,
 } from "@nicia-ai/typegraph/sqlite";
 
-import { DEFAULT_POSTGRES_URL, type PerfBackend } from "./config";
+import {
+  DEFAULT_POSTGRES_URL,
+  type PerfBackend,
+  type PostgresDriver,
+} from "./config";
 import { perfGraph, perfIndexes, type PerfStore } from "./graph";
 
 type BackendResources = Readonly<{
@@ -58,21 +64,30 @@ function loadSqliteVec(sqlite: Database.Database): boolean {
   }
 }
 
-async function resetPostgresTables(pool: Pool): Promise<void> {
-  await pool.query(`
-    DROP TABLE IF EXISTS typegraph_node_embeddings CASCADE;
-    DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
-    DROP TABLE IF EXISTS typegraph_edges CASCADE;
-    DROP TABLE IF EXISTS typegraph_nodes CASCADE;
-    DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
-    DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;
-  `);
+const POSTGRES_RESET_DDL = `
+  DROP TABLE IF EXISTS typegraph_node_embeddings CASCADE;
+  DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
+  DROP TABLE IF EXISTS typegraph_edges CASCADE;
+  DROP TABLE IF EXISTS typegraph_nodes CASCADE;
+  DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+  DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;
+`;
+
+async function resetPostgresTablesViaPool(pool: Pool): Promise<void> {
+  await pool.query(POSTGRES_RESET_DDL);
   const tables = createPostgresTables({}, { indexes: perfIndexes });
   await pool.query(generatePostgresMigrationSQL(tables));
 }
 
+async function resetPostgresTablesViaSql(sql: Sql): Promise<void> {
+  await sql.unsafe(POSTGRES_RESET_DDL);
+  const tables = createPostgresTables({}, { indexes: perfIndexes });
+  await sql.unsafe(generatePostgresMigrationSQL(tables));
+}
+
 export async function createBackendResources(
   backend: PerfBackend,
+  postgresDriver: PostgresDriver = "pg",
 ): Promise<BackendResources> {
   if (backend === "sqlite") {
     const tables = createSqliteTables({}, { indexes: perfIndexes });
@@ -104,19 +119,60 @@ export async function createBackendResources(
     };
   }
 
-  const pool = new Pool({
-    connectionString: getPostgresUrl(),
+  if (postgresDriver === "pg") {
+    const pool = new Pool({
+      connectionString: getPostgresUrl(),
+    });
+    const drizzleDb = drizzleNodePostgres(pool);
+
+    try {
+      await resetPostgresTablesViaPool(pool);
+    } catch (error) {
+      await pool.end().catch(() => {
+        // Best effort cleanup after connection/init failures.
+      });
+      throw new Error(
+        `Failed to initialize PostgreSQL perf backend at ${getPostgresUrl()}. ` +
+          "Ensure POSTGRES_URL points to a reachable database.",
+        { cause: error },
+      );
+    }
+
+    const tables = createPostgresTables({}, { indexes: perfIndexes });
+    const postgresBackend = createPostgresBackend(drizzleDb, { tables });
+    return {
+      store: createStore(perfGraph, postgresBackend, {
+        queryDefaults: { traversalExpansion: "none" },
+      }),
+      close: async () => {
+        await postgresBackend.close();
+        await pool.end();
+      },
+      // The migration enables the pgvector extension, so vector predicates
+      // and the hybrid facade are available on Postgres.
+      hasVectorPredicate: true,
+      hasHybridFacade: true,
+    };
+  }
+
+  // postgres-js driver
+  const sql = postgres(getPostgresUrl(), {
+    max: 10,
+    onnotice: () => {
+      // Suppress NOTICE spam from IF NOT EXISTS DDL so the perf output
+      // stays readable.
+    },
   });
-  const drizzleDb = drizzlePostgres(pool);
+  const drizzleDb = drizzlePostgresJs(sql);
 
   try {
-    await resetPostgresTables(pool);
+    await resetPostgresTablesViaSql(sql);
   } catch (error) {
-    await pool.end().catch(() => {
+    await sql.end().catch(() => {
       // Best effort cleanup after connection/init failures.
     });
     throw new Error(
-      `Failed to initialize PostgreSQL perf backend at ${getPostgresUrl()}. ` +
+      `Failed to initialize PostgreSQL perf backend (postgres-js driver) at ${getPostgresUrl()}. ` +
         "Ensure POSTGRES_URL points to a reachable database.",
       { cause: error },
     );
@@ -130,10 +186,8 @@ export async function createBackendResources(
     }),
     close: async () => {
       await postgresBackend.close();
-      await pool.end();
+      await sql.end();
     },
-    // The migration enables the pgvector extension, so vector predicates
-    // and the hybrid facade are available on Postgres.
     hasVectorPredicate: true,
     hasHybridFacade: true,
   };

--- a/packages/benchmarks/src/cli.ts
+++ b/packages/benchmarks/src/cli.ts
@@ -1,4 +1,8 @@
-import { type PerfBackend, type PerfCliOptions } from "./config";
+import {
+  type PerfBackend,
+  type PerfCliOptions,
+  type PostgresDriver,
+} from "./config";
 
 function parseBackend(rawBackend: string): PerfBackend {
   if (rawBackend === "sqlite" || rawBackend === "postgres") {
@@ -7,6 +11,16 @@ function parseBackend(rawBackend: string): PerfBackend {
 
   throw new Error(
     `Unsupported backend: "${rawBackend}". Expected "sqlite" or "postgres".`,
+  );
+}
+
+function parsePostgresDriver(raw: string): PostgresDriver {
+  if (raw === "pg" || raw === "postgres-js") {
+    return raw;
+  }
+
+  throw new Error(
+    `Unsupported --postgres-driver value: "${raw}". Expected "pg" or "postgres-js".`,
   );
 }
 
@@ -38,9 +52,18 @@ export function parseCliOptions(argv: readonly string[]): PerfCliOptions {
       parseScale(scaleArgument.slice("--scale=".length))
     );
 
+  const driverArgument = argv.find((argument) =>
+    argument.startsWith("--postgres-driver="),
+  );
+  const postgresDriver: PostgresDriver =
+    driverArgument === undefined ? "pg" : (
+      parsePostgresDriver(driverArgument.slice("--postgres-driver=".length))
+    );
+
   return {
     runChecks,
     backend,
+    postgresDriver,
     scale,
   };
 }

--- a/packages/benchmarks/src/config.ts
+++ b/packages/benchmarks/src/config.ts
@@ -106,9 +106,12 @@ export const DEFAULT_POSTGRES_URL =
 
 export type PerfBackend = "sqlite" | "postgres";
 
+export type PostgresDriver = "pg" | "postgres-js";
+
 export type PerfCliOptions = Readonly<{
   runChecks: boolean;
   backend: PerfBackend;
+  postgresDriver: PostgresDriver;
   scale: number;
 }>;
 

--- a/packages/benchmarks/src/history.ts
+++ b/packages/benchmarks/src/history.ts
@@ -3,7 +3,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { type PerfBackend } from "./config";
+import { type PerfBackend, type PostgresDriver } from "./config";
 import { type LatencyRecord } from "./measurements";
 
 /**
@@ -15,6 +15,7 @@ type HistoryEntry = Readonly<{
   gitSha: string;
   gitRefName: string | undefined;
   backend: PerfBackend;
+  postgresDriver?: PostgresDriver;
   scale: number;
   userCount: number;
   latencies: Readonly<
@@ -60,6 +61,7 @@ function serializeLatencies(record: LatencyRecord): HistoryEntry["latencies"] {
 
 type WriteHistoryInput = Readonly<{
   backend: PerfBackend;
+  postgresDriver?: PostgresDriver;
   scale: number;
   userCount: number;
   latencies: LatencyRecord;
@@ -71,6 +73,9 @@ export function writeHistoryEntry(input: WriteHistoryInput): string {
     gitSha: resolveGitSha(),
     gitRefName: resolveGitRefName(),
     backend: input.backend,
+    ...(input.postgresDriver === undefined ?
+      {}
+    : { postgresDriver: input.postgresDriver }),
     scale: input.scale,
     userCount: input.userCount,
     latencies: serializeLatencies(input.latencies),

--- a/packages/benchmarks/src/main.ts
+++ b/packages/benchmarks/src/main.ts
@@ -9,16 +9,22 @@ import {
 import { writeHistoryEntry } from "./history";
 import { measureQueries } from "./measurements";
 import { seedStore } from "./seed";
+import { formatMs, nowMs } from "./utils";
 
 async function main(argv: readonly string[]): Promise<void> {
   const options = parseCliOptions(argv);
   applyScale(options.scale);
   const scaleSuffix = options.scale === 1 ? "" : `, scale=${options.scale}`;
+  const driverSuffix =
+    options.backend === "postgres" ? `, driver=${options.postgresDriver}` : "";
   console.log(
-    `TypeGraph perf sanity (${options.runChecks ? "guardrail mode" : "report mode"}, backend=${options.backend}${scaleSuffix}, users=${BENCHMARK_CONFIG.userCount})`,
+    `TypeGraph perf sanity (${options.runChecks ? "guardrail mode" : "report mode"}, backend=${options.backend}${driverSuffix}${scaleSuffix}, users=${BENCHMARK_CONFIG.userCount})`,
   );
 
-  const resources = await createBackendResources(options.backend);
+  const resources = await createBackendResources(
+    options.backend,
+    options.postgresDriver,
+  );
   if (!resources.hasVectorPredicate) {
     console.log(
       "(vector predicate unavailable on this backend — vector and hybrid measurements will be skipped)",
@@ -31,6 +37,14 @@ async function main(argv: readonly string[]): Promise<void> {
   try {
     const seedResult = await seedStore(resources.store);
 
+    // Without this, PostgreSQL keeps using stale row-count estimates
+    // until autovacuum runs, which drives the planner to pick the wrong
+    // index for 1-hop traversals. Real deployments run ANALYZE after
+    // bulk loads; we match that convention to measure steady state.
+    const analyzeStart = nowMs();
+    await resources.store.refreshStatistics();
+    console.log(`analyze: ${formatMs(nowMs() - analyzeStart)}`);
+
     const { metrics, latencies } = await measureQueries(resources.store, {
       hasVectorPredicate: resources.hasVectorPredicate,
       hasHybridFacade: resources.hasHybridFacade,
@@ -40,6 +54,9 @@ async function main(argv: readonly string[]): Promise<void> {
 
     const historyPath = writeHistoryEntry({
       backend: options.backend,
+      ...(options.backend === "postgres" ?
+        { postgresDriver: options.postgresDriver }
+      : {}),
       scale: options.scale,
       userCount: BENCHMARK_CONFIG.userCount,
       latencies,

--- a/packages/typegraph/examples/README.md
+++ b/packages/typegraph/examples/README.md
@@ -45,7 +45,13 @@ npx tsx examples/<example-name>.ts
 
 | Example | Description |
 |---------|-------------|
-| [10-postgresql.ts](./10-postgresql.ts) | PostgreSQL backend setup and usage |
+| [10-postgresql.ts](./10-postgresql.ts) | PostgreSQL backend setup, JSONB props, transactions, traversal queries |
+
+For wiring `createPostgresBackend` against `postgres-js`, `@neondatabase/serverless`
+(WebSockets), or `@neondatabase/serverless` (HTTP) instead of `node-postgres`, see the
+runtime-to-driver matrix and per-driver setup snippets in the
+[backend setup docs](https://typegraph.dev/backend-setup#choosing-a-postgresql-driver) —
+the only diff from example 10 is the import line and connection setup.
 
 ### Semantic Search & RAG
 
@@ -64,9 +70,10 @@ npx tsx examples/<example-name>.ts
 npm install @nicia-ai/typegraph zod drizzle-orm better-sqlite3
 ```
 
-### PostgreSQL Example (10-postgresql.ts)
+### PostgreSQL Example (10)
 
-Requires a running PostgreSQL instance:
+Requires a running PostgreSQL instance. Example 10 uses `node-postgres`; for other drivers
+(postgres-js, neon-serverless, neon-http), see the [backend setup docs](https://typegraph.dev/backend-setup#choosing-a-postgresql-driver).
 
 ```bash
 # Using Docker
@@ -75,10 +82,7 @@ docker run -d --name typegraph-pg \
   -p 5432:5432 \
   postgres:16
 
-# Set connection URL
 export POSTGRES_URL="postgresql://postgres:postgres@localhost:5432/postgres"
-
-# Run the example
 npx tsx examples/10-postgresql.ts
 ```
 

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -157,15 +157,27 @@
   },
   "peerDependencies": {
     "@libsql/client": ">=0.6.0",
+    "@neondatabase/serverless": ">=0.9.0 <2.0.0",
     "better-sqlite3": ">=9.0.0 <13.0.0",
     "drizzle-orm": ">=0.35.0 <1.0.0",
+    "pg": ">=8.0.0 <9.0.0",
+    "postgres": ">=3.4.0 <4.0.0",
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "@libsql/client": {
       "optional": true
     },
+    "@neondatabase/serverless": {
+      "optional": true
+    },
     "better-sqlite3": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    },
+    "postgres": {
       "optional": true
     }
   },
@@ -174,6 +186,7 @@
   },
   "devDependencies": {
     "@libsql/client": "^0.17.2",
+    "@neondatabase/serverless": "^1.1.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@typegraph/eslint-config": "workspace:*",
@@ -186,6 +199,7 @@
     "eslint": "^10.2.1",
     "fast-check": "^4.7.0",
     "pg": "^8.20.0",
+    "postgres": "^3.4.9",
     "sqlite-vec": "^0.1.9",
     "tsd": "^0.33.0",
     "tsup": "^8.5.1",

--- a/packages/typegraph/src/backend/drizzle/execution/lru.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/lru.ts
@@ -1,0 +1,29 @@
+/**
+ * Get-or-create with LRU eviction on a `Map`.
+ *
+ * Map insertion order is the LRU order: cache hits delete + reinsert
+ * the entry to promote it to most-recently-used; on miss, the oldest
+ * entry is evicted once the map exceeds `cacheMax`. Used by both the
+ * PostgreSQL prepared-statement-name cache and the SQLite prepared-
+ * statement cache.
+ */
+export function getOrCreateLru<K, V>(
+  cache: Map<K, V>,
+  key: K,
+  cacheMax: number,
+  create: () => V,
+): V {
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    cache.delete(key);
+    cache.set(key, cached);
+    return cached;
+  }
+  const value = create();
+  cache.set(key, value);
+  if (cache.size > cacheMax) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  return value;
+}

--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -8,39 +8,288 @@ import {
   type SqlExecutionAdapter,
 } from "./types";
 
+/**
+ * Edge-safe: this module is loaded on Cloudflare Workers / Vercel Edge
+ * via `@neondatabase/serverless`, so it must not statically import any
+ * `node:*` module. Use only platform-neutral primitives.
+ */
+
 type PgQueryResult = Readonly<{
   rows: readonly unknown[];
 }>;
 
+/**
+ * The wire-protocol-shaped client the fast path calls. Both the wrapped
+ * node-postgres and postgres-js clients normalize to this signature; what
+ * differs is whether the underlying driver gets a server-side prepared
+ * statement (node-postgres path) or relies on its own internal preparation
+ * (postgres-js).
+ */
 type PgQueryClient = Readonly<{
   query: (sqlText: string, params: readonly unknown[]) => Promise<PgQueryResult>;
 }>;
 
+/**
+ * Minimal shape of the node-postgres / @neondatabase/serverless client
+ * we rely on. Both accept either positional `query(text, values)`
+ * (unnamed) or the configuration-object form `query({name, text, values})`
+ * which uses a server-side prepared statement keyed by `name`.
+ */
+type NodePgQueryConfig = Readonly<{
+  name: string;
+  text: string;
+  values: readonly unknown[];
+}>;
+
+type NodePgClient = Readonly<{
+  query: ((
+    sqlText: string,
+    params?: readonly unknown[],
+  ) => Promise<PgQueryResult>) &
+    ((config: NodePgQueryConfig) => Promise<PgQueryResult>);
+}>;
+
+/**
+ * Minimal shape of the postgres-js tagged-template `Sql` client we rely on
+ * for the raw fast path. `unsafe(sqlText, params)` is postgres-js's
+ * parameterized-raw-SQL entry point and resolves to a row array.
+ */
+type PostgresJsClient = ((...args: readonly unknown[]) => unknown) &
+  Readonly<{
+    unsafe: (
+      sqlText: string,
+      params?: readonly unknown[],
+    ) => PromiseLike<readonly unknown[]>;
+  }>;
+
 type PgClientCarrier = Readonly<{
-  $client?: PgQueryClient;
+  $client?: unknown;
 }>;
 
 export type AnyPgDatabase = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 
 export type PostgresExecutionAdapter = SqlExecutionAdapter;
 
-function resolvePgClient(db: AnyPgDatabase): PgQueryClient | undefined {
-  const databaseWithClient = db as PgClientCarrier;
-  const pgClient = databaseWithClient.$client;
-  if (pgClient?.query === undefined) {
-    return undefined;
+function hasFunctionProperty<K extends string>(
+  value: unknown,
+  property: K,
+): value is Readonly<Record<K, (...args: readonly unknown[]) => unknown>> {
+  if (value === undefined || value === null) {
+    return false;
   }
-  return pgClient;
+  const candidate = value as Readonly<Record<K, unknown>>;
+  return typeof candidate[property] === "function";
 }
 
+function isPgNativeClient(candidate: unknown): candidate is NodePgClient {
+  // pg `Pool` / `Client` and @neondatabase/serverless `Pool` / `Client`
+  // are object instances with a `.query` method. We require non-callable
+  // here so we don't accidentally swallow the postgres-js or neon-http
+  // tagged-template clients (both callable, both also expose `.query`).
+  return typeof candidate === "object" && hasFunctionProperty(candidate, "query");
+}
+
+function isPostgresJsClient(candidate: unknown): candidate is PostgresJsClient {
+  // postgres-js's tagged-template Sql is callable, has `.unsafe` (raw
+  // parameterized executor), and has `.begin` (transaction starter).
+  // Neon HTTP is also callable + has `.unsafe`, but that `.unsafe` is a
+  // fragment builder rather than a query executor, so we discriminate
+  // on `.begin` (postgres-js only).
+  return (
+    typeof candidate === "function" &&
+    hasFunctionProperty(candidate, "unsafe") &&
+    hasFunctionProperty(candidate, "begin")
+  );
+}
+
+/**
+ * @neondatabase/serverless's `neon(url)` HTTP-only tagged-template
+ * function. Distinguishing markers vs postgres-js: `.transaction`
+ * (an HTTP-batch transaction submitter) instead of `.begin`. Its
+ * `.query`/`.unsafe` methods have different signatures from pg's, so
+ * the fast path can't drive them safely — Drizzle's neon-http session
+ * handles them correctly via the `db.execute` slow path.
+ *
+ * Exported so the backend factory can auto-disable the `transactions`
+ * capability when this driver is detected (HTTP can't hold a session,
+ * so multi-statement transactions are not available regardless).
+ */
+export function isNeonHttpClient(db: AnyPgDatabase): boolean {
+  const candidate = (db as PgClientCarrier).$client;
+  return (
+    typeof candidate === "function" &&
+    hasFunctionProperty(candidate, "transaction") &&
+    !hasFunctionProperty(candidate, "begin")
+  );
+}
+
+/**
+ * Module-scope cache mapping each unique SQL text to a stable
+ * prepared-statement name. PostgreSQL only requires statement names to
+ * be unique per session, so a monotonic counter is sufficient — and
+ * avoids depending on a hash primitive (`node:crypto` doesn't exist on
+ * Cloudflare Workers, Web Crypto's digest is async). Cache size is
+ * bounded by the number of distinct compiled SQL strings the
+ * application emits, typically dozens.
+ */
+const STATEMENT_NAME_CACHE = new Map<string, string>();
+
+function statementNameFor(sqlText: string): string {
+  const cached = STATEMENT_NAME_CACHE.get(sqlText);
+  if (cached !== undefined) return cached;
+  const name = `tg_${STATEMENT_NAME_CACHE.size}`;
+  STATEMENT_NAME_CACHE.set(sqlText, name);
+  return name;
+}
+
+/**
+ * Walks a row and replaces any `Date` instance with its ISO-string
+ * equivalent. Used to normalize node-postgres / neon-serverless output
+ * when we bypass Drizzle's session: pg's default type parsers return
+ * `Date` objects for `timestamptz` / `timestamp` / `date` columns, but
+ * TypeGraph's row contract everywhere downstream is "timestamps come
+ * back as ISO strings." Drizzle's session installs a per-query type
+ * override that does the same thing; this is the dependency-free,
+ * edge-safe equivalent.
+ *
+ * O(columns × rows) — negligible for the row counts TypeGraph queries
+ * return (typical: 1–100 rows × 5–30 columns).
+ */
+function normalizeRow(row: unknown): unknown {
+  if (row === null || typeof row !== "object") return row;
+  let mutated: Record<string, unknown> | undefined;
+  for (const key of Object.keys(row)) {
+    const value = (row as Record<string, unknown>)[key];
+    if (value instanceof Date) {
+      mutated ??= { ...(row as Record<string, unknown>) };
+      mutated[key] = value.toISOString();
+    }
+  }
+  return mutated ?? row;
+}
+
+function normalizeRows(
+  rows: readonly unknown[],
+): readonly unknown[] {
+  // Single-pass scan; only allocate a new array if any row contained a
+  // Date that needed normalizing. Most rows on most queries don't.
+  let mutated: unknown[] | undefined;
+  for (let index = 0; index < rows.length; index += 1) {
+    const original = rows[index];
+    const normalized = normalizeRow(original);
+    if (normalized !== original) {
+      mutated ??= [...rows] as unknown[];
+      mutated[index] = normalized;
+    }
+  }
+  return mutated ?? rows;
+}
+
+/**
+ * Wraps a node-postgres / neon-serverless client so every call goes
+ * through a server-side prepared statement keyed by a stable name. The
+ * first call on each connection parses + plans + executes; subsequent
+ * calls with the same statement name reuse the cached plan and skip
+ * both parse and plan phases. Measurable on multi-CTE TypeGraph
+ * queries: 3-hop drops from ~7-12ms (parse + plan + execute every call)
+ * to ~0.8ms median (execute only).
+ *
+ * Returned rows are normalized so that `Date` objects from default pg
+ * type parsers become ISO strings, matching the row shape Drizzle's
+ * session would produce. Without this, `ctx.<alias>.meta.createdAt`
+ * style accessors in the SELECT-result path return Date instances,
+ * breaking user code that expects strings.
+ */
+function wrapNodePgClient(client: NodePgClient): PgQueryClient {
+  return {
+    async query(
+      sqlText: string,
+      params: readonly unknown[],
+    ): Promise<PgQueryResult> {
+      const result = await client.query({
+        name: statementNameFor(sqlText),
+        text: sqlText,
+        values: params,
+      });
+      return { rows: normalizeRows(result.rows) };
+    },
+  };
+}
+
+function adaptPostgresJsClient(sql: PostgresJsClient): PgQueryClient {
+  return {
+    async query(
+      sqlText: string,
+      params: readonly unknown[],
+    ): Promise<PgQueryResult> {
+      // postgres-js handles its own statement preparation internally
+      // (controlled by the `prepare` connection option, default true),
+      // so we don't need to name statements here ourselves.
+      const rows = await sql.unsafe(sqlText, params);
+      return { rows };
+    },
+  };
+}
+
+/**
+ * Resolves a Drizzle-wrapped PostgreSQL client to a uniform `{query}` shape
+ * that the fast path can call. Supports:
+ *
+ * - `drizzle-orm/node-postgres` (pg Pool / Client) — wrapped to use
+ *   server-side prepared statements with stable counter-derived names
+ *   keyed by the SQL text (see `statementNameFor`)
+ * - `drizzle-orm/neon-serverless` (@neondatabase/serverless Pool) —
+ *   pg-Pool-compatible, takes the same wrapper as node-postgres
+ * - `drizzle-orm/postgres-js` (postgres-js tagged-template Sql) — adapted
+ *   via `.unsafe(sql, params)`. Safe because Drizzle installs transparent
+ *   parsers on the same client instance at `drizzle()` time, so direct
+ *   calls and Drizzle-routed calls produce identical row shapes.
+ *
+ * Returns `undefined` for `drizzle-orm/neon-http` and any other driver we
+ * don't recognize; callers fall back to `db.execute(sql)`, which goes
+ * through the Drizzle session and is always correct (just without the
+ * server-side prepared-statement perf win).
+ */
+function resolvePgClient(db: AnyPgDatabase): PgQueryClient | undefined {
+  // Order matters: neon-http and postgres-js are both callable + have
+  // `.unsafe`, but neon-http's `.unsafe` is a fragment builder (not a
+  // query executor) and its `.query` doesn't accept the {name, text,
+  // values} config form. Skip the fast path entirely for neon-http and
+  // let Drizzle's session route the call.
+  if (isNeonHttpClient(db)) {
+    return undefined;
+  }
+  const client = (db as PgClientCarrier).$client;
+  if (isPgNativeClient(client)) {
+    return wrapNodePgClient(client);
+  }
+  if (isPostgresJsClient(client)) {
+    return adaptPostgresJsClient(client);
+  }
+  return undefined;
+}
+
+/**
+ * Normalizes the result shape of `db.execute(sql)` across drivers.
+ *
+ * - `drizzle-orm/node-postgres` / `drizzle-orm/neon-serverless` return a
+ *   pg-style `{ rows, rowCount, ... }` object.
+ * - `drizzle-orm/postgres-js` returns the raw postgres-js result, which is
+ *   a plain array of rows (with extra non-enumerable properties like
+ *   `count` / `command`).
+ *
+ * The backend contract is "a row array." Normalize here so every caller
+ * downstream can assume the same shape.
+ */
 async function executeDrizzleQuery<TRow>(
   db: AnyPgDatabase,
   query: SQL,
 ): Promise<readonly TRow[]> {
-  const result = (await db.execute(query)) as Readonly<{
-    rows: readonly TRow[];
-  }>;
-  return result.rows;
+  const result = await db.execute(query);
+  if (Array.isArray(result)) {
+    return result as readonly TRow[];
+  }
+  return (result as Readonly<{ rows: readonly TRow[] }>).rows;
 }
 
 function createPgPreparedStatement(
@@ -88,7 +337,14 @@ export function createPostgresExecutionAdapter(
   return {
     compile,
     async execute<TRow>(query: SQL): Promise<readonly TRow[]> {
-      return executeDrizzleQuery<TRow>(db, query);
+      // Fast path: compile via Drizzle's dialect, then execute through
+      // the wrapped client directly. Bypasses Drizzle's session
+      // overhead (logging spans, plan-cache bookkeeping for typed
+      // queries we don't use), and on node-postgres this also enables
+      // the server-side prepared-statement path because the wrapped
+      // client assigns each unique SQL a stable statement name.
+      const compiled = compile(query);
+      return executeCompiled<TRow>(compiled);
     },
     executeCompiled,
     prepare(sqlText: string): PreparedSqlStatement {

--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -1,6 +1,7 @@
 import { type SQL } from "drizzle-orm";
 import { type PgDatabase, type PgQueryResultHKT } from "drizzle-orm/pg-core";
 
+import { getOrCreateLru } from "./lru";
 import {
   type CompiledSqlQuery,
   compileQueryWithDialect,
@@ -124,22 +125,53 @@ export function isNeonHttpClient(db: AnyPgDatabase): boolean {
 }
 
 /**
+ * Default cap on the number of distinct SQL strings tracked for
+ * server-side prepared statements. Mirrors the SQLite adapter's
+ * `DEFAULT_PREPARED_STATEMENT_CACHE_MAX`. High-cardinality SQL text —
+ * variable-length IN-list expansions, generated aliases, custom
+ * `backend.execute()` calls — would otherwise grow this map (and the
+ * matching per-session prepared-statement memory inside PostgreSQL)
+ * without bound.
+ */
+const DEFAULT_POSTGRES_STATEMENT_CACHE_MAX = 256;
+
+/**
  * Module-scope cache mapping each unique SQL text to a stable
  * prepared-statement name. PostgreSQL only requires statement names to
  * be unique per session, so a monotonic counter is sufficient — and
  * avoids depending on a hash primitive (`node:crypto` doesn't exist on
- * Cloudflare Workers, Web Crypto's digest is async). Cache size is
- * bounded by the number of distinct compiled SQL strings the
- * application emits, typically dozens.
+ * Cloudflare Workers, Web Crypto's digest is async).
+ *
+ * The cache is module-scope on purpose: pg `Pool` reuses connections,
+ * and the same SQL text needs the same statement name across every
+ * adapter that might end up driving the same connection. Without
+ * shared naming, two adapters could try to register two different
+ * statements under the same name on a recycled connection.
+ *
+ * Bounded by `cacheMax` per call (LRU eviction). The counter is
+ * deliberately independent of the cache size so eviction never
+ * recycles a name — a recycled name could collide with a still-cached
+ * statement on a long-lived pg connection ("prepared statement
+ * already exists" error with different text).
  */
 const STATEMENT_NAME_CACHE = new Map<string, string>();
+let nextStatementId = 0;
 
-function statementNameFor(sqlText: string): string {
-  const cached = STATEMENT_NAME_CACHE.get(sqlText);
-  if (cached !== undefined) return cached;
-  const name = `tg_${STATEMENT_NAME_CACHE.size}`;
-  STATEMENT_NAME_CACHE.set(sqlText, name);
-  return name;
+function statementNameFor(sqlText: string, cacheMax: number): string {
+  return getOrCreateLru(STATEMENT_NAME_CACHE, sqlText, cacheMax, () => {
+    const name = `tg_${nextStatementId}`;
+    nextStatementId += 1;
+    return name;
+  });
+}
+
+/**
+ * Test-only: reset the module-scope statement-name state. Used to
+ * isolate tests that assert on counter values or eviction behavior.
+ */
+export function resetStatementNameCacheForTests(): void {
+  STATEMENT_NAME_CACHE.clear();
+  nextStatementId = 0;
 }
 
 /**
@@ -200,17 +232,42 @@ function normalizeRows(
  * style accessors in the SELECT-result path return Date instances,
  * breaking user code that expects strings.
  */
-function wrapNodePgClient(client: NodePgClient): PgQueryClient {
+function wrapNodePgClient(
+  client: NodePgClient,
+  cacheMax: number,
+): PgQueryClient {
   return {
     async query(
       sqlText: string,
       params: readonly unknown[],
     ): Promise<PgQueryResult> {
       const result = await client.query({
-        name: statementNameFor(sqlText),
+        name: statementNameFor(sqlText, cacheMax),
         text: sqlText,
         values: params,
       });
+      return { rows: normalizeRows(result.rows) };
+    },
+  };
+}
+
+/**
+ * Variant that bypasses server-side prepared statements entirely.
+ * Required for pgbouncer in transaction-pool mode (named statements
+ * registered on one backend connection aren't visible on the next),
+ * and useful when memory-sensitive workloads can't afford to keep
+ * prepared statements warm across the pool.
+ *
+ * Same Date→ISO normalization as `wrapNodePgClient` so the row contract
+ * downstream stays identical.
+ */
+function wrapNodePgClientUnnamed(client: NodePgClient): PgQueryClient {
+  return {
+    async query(
+      sqlText: string,
+      params: readonly unknown[],
+    ): Promise<PgQueryResult> {
+      const result = await client.query(sqlText, params);
       return { rows: normalizeRows(result.rows) };
     },
   };
@@ -237,7 +294,10 @@ function adaptPostgresJsClient(sql: PostgresJsClient): PgQueryClient {
  *
  * - `drizzle-orm/node-postgres` (pg Pool / Client) — wrapped to use
  *   server-side prepared statements with stable counter-derived names
- *   keyed by the SQL text (see `statementNameFor`)
+ *   keyed by the SQL text (see `statementNameFor`). When
+ *   `prepareStatements` is `false`, falls back to unnamed
+ *   `client.query(text, values)` for pgbouncer transaction-pool
+ *   compatibility.
  * - `drizzle-orm/neon-serverless` (@neondatabase/serverless Pool) —
  *   pg-Pool-compatible, takes the same wrapper as node-postgres
  * - `drizzle-orm/postgres-js` (postgres-js tagged-template Sql) — adapted
@@ -250,7 +310,11 @@ function adaptPostgresJsClient(sql: PostgresJsClient): PgQueryClient {
  * through the Drizzle session and is always correct (just without the
  * server-side prepared-statement perf win).
  */
-function resolvePgClient(db: AnyPgDatabase): PgQueryClient | undefined {
+function resolvePgClient(
+  db: AnyPgDatabase,
+  prepareStatements: boolean,
+  cacheMax: number,
+): PgQueryClient | undefined {
   // Order matters: neon-http and postgres-js are both callable + have
   // `.unsafe`, but neon-http's `.unsafe` is a fragment builder (not a
   // query executor) and its `.query` doesn't accept the {name, text,
@@ -261,9 +325,15 @@ function resolvePgClient(db: AnyPgDatabase): PgQueryClient | undefined {
   }
   const client = (db as PgClientCarrier).$client;
   if (isPgNativeClient(client)) {
-    return wrapNodePgClient(client);
+    return prepareStatements
+      ? wrapNodePgClient(client, cacheMax)
+      : wrapNodePgClientUnnamed(client);
   }
   if (isPostgresJsClient(client)) {
+    // postgres-js handles its own preparation internally (controlled
+    // by the driver's own `prepare` connection option) — the
+    // `prepareStatements` flag here only affects the node-postgres
+    // path.
     return adaptPostgresJsClient(client);
   }
   return undefined;
@@ -304,10 +374,48 @@ function createPgPreparedStatement(
   };
 }
 
+/**
+ * Tuning options for the PostgreSQL execution fast path.
+ *
+ * Defaults are correct for `drizzle-orm/node-postgres` against a
+ * standalone PostgreSQL or session-pooled deployment. Override when:
+ *
+ * - **Pooling through pgbouncer in transaction-pool mode.** Set
+ *   `prepareStatements: false`. Named statements registered on one
+ *   pooled backend connection aren't visible to the next, so the
+ *   server-side prepared-statement cache must be off.
+ * - **High-cardinality SQL text.** If the application emits many
+ *   distinct compiled SQL strings (variable-length IN-list expansions,
+ *   custom `backend.execute()` calls, generated aliases), tune
+ *   `preparedStatementCacheMax` down to bound per-session memory more
+ *   aggressively, or up if memory is plentiful and you want fewer
+ *   re-PREPAREs.
+ */
+export type PostgresExecutionAdapterOptions = Readonly<{
+  /**
+   * When `true` (default), node-postgres / neon-serverless calls go
+   * through `client.query({name, text, values})` so PostgreSQL caches
+   * the parsed/planned statement per session. Set to `false` to issue
+   * unnamed `client.query(text, values)` calls — required for
+   * pgbouncer transaction-pool mode.
+   */
+  prepareStatements?: boolean;
+  /**
+   * Maximum number of distinct SQL strings tracked for prepared-
+   * statement naming. Defaults to `DEFAULT_POSTGRES_STATEMENT_CACHE_MAX`
+   * (256). Ignored when `prepareStatements` is `false`.
+   */
+  preparedStatementCacheMax?: number;
+}>;
+
 export function createPostgresExecutionAdapter(
   db: AnyPgDatabase,
+  options: PostgresExecutionAdapterOptions = {},
 ): PostgresExecutionAdapter {
-  const pgClient = resolvePgClient(db);
+  const prepareStatements = options.prepareStatements ?? true;
+  const cacheMax =
+    options.preparedStatementCacheMax ?? DEFAULT_POSTGRES_STATEMENT_CACHE_MAX;
+  const pgClient = resolvePgClient(db, prepareStatements, cacheMax);
 
   function compile(query: SQL): CompiledSqlQuery {
     return compileQueryWithDialect(db, query, "PostgreSQL");

--- a/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
@@ -1,6 +1,7 @@
 import { type SQL, sql } from "drizzle-orm";
 import { type BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
+import { getOrCreateLru } from "./lru";
 import {
   type CompiledSqlQuery,
   compileQueryWithDialect,
@@ -159,25 +160,9 @@ function getOrCreatePreparedStatement(
   sqlText: string,
   cacheMax: number,
 ): PreparedAllStatement {
-  const cachedStatement = cache.get(sqlText);
-  if (cachedStatement !== undefined) {
-    // Promote to most-recently-used position for LRU eviction
-    cache.delete(sqlText);
-    cache.set(sqlText, cachedStatement);
-    return cachedStatement;
-  }
-
-  const preparedStatement = sqliteClient.prepare(sqlText);
-  cache.set(sqlText, preparedStatement);
-
-  if (cache.size > cacheMax) {
-    const oldestSqlText = cache.keys().next().value;
-    if (typeof oldestSqlText === "string") {
-      cache.delete(oldestSqlText);
-    }
-  }
-
-  return preparedStatement;
+  return getOrCreateLru(cache, sqlText, cacheMax, () =>
+    sqliteClient.prepare(sqlText),
+  );
 }
 
 // Uses unconditional `await` because Drizzle returns SQLiteRaw thenables

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -1,12 +1,17 @@
 /**
  * PostgreSQL backend adapter for TypeGraph.
  *
- * Works with any Drizzle PostgreSQL database instance:
- * - node-postgres (pg)
- * - PGlite
- * - Neon
- * - Vercel Postgres
- * - Supabase
+ * Works with any Drizzle PostgreSQL database instance. Tested against:
+ * - `drizzle-orm/node-postgres` (pg Pool / Client)
+ * - `drizzle-orm/postgres-js` (postgres-js tagged-template client)
+ * - `drizzle-orm/neon-serverless` (@neondatabase/serverless Pool / Client)
+ * - `drizzle-orm/neon-http` (@neondatabase/serverless `neon(url)`) —
+ *   transactions are auto-disabled because HTTP can't hold a session;
+ *   use `drizzle-orm/neon-serverless` if you need transactional writes.
+ *
+ * Other pg-protocol Drizzle adapters (PGlite, Vercel Postgres, Supabase
+ * via pg) should work unchanged because they all expose a compatible
+ * `db.execute()` / `db.transaction()` surface.
  *
  * @example
  * ```typescript
@@ -22,6 +27,7 @@
 import { getTableName, type SQL, sql } from "drizzle-orm";
 
 import type { SqlTableNames } from "../../query/compiler/schema";
+import { quoteIdentifier } from "../../query/compiler/utils";
 import {
   buildFulltextCapabilities,
   type FulltextStrategy,
@@ -39,6 +45,7 @@ import {
   type FulltextSearchResult,
   type GraphBackend,
   POSTGRES_CAPABILITIES,
+  runOptionallyInTransaction,
   type TransactionBackend,
   type TransactionOptions,
   type UpsertEmbeddingParams,
@@ -51,6 +58,7 @@ import { generatePostgresDDL } from "./ddl";
 import {
   type AnyPgDatabase,
   createPostgresExecutionAdapter,
+  isNeonHttpClient,
   type PostgresExecutionAdapter,
 } from "./execution/postgres-execution";
 import { createCommonOperationBackend } from "./operation-backend-core";
@@ -97,6 +105,19 @@ export type PostgresBackendOptions = Readonly<{
    * pgroonga without forking TypeGraph.
    */
   fulltext?: FulltextStrategy;
+  /**
+   * Override specific backend capabilities. Useful when the underlying
+   * driver doesn't support a feature TypeGraph would otherwise assume —
+   * for example, an HTTP-only Postgres driver that can't hold a session
+   * across statements would need `{ transactions: false }` so
+   * TypeGraph falls through to non-transactional execution paths.
+   *
+   * `drizzle-orm/neon-http` is auto-detected and has `transactions`
+   * disabled without an explicit override; this option exists for
+   * other HTTP-style drivers and for tests that need to simulate a
+   * capability gap.
+   */
+  capabilities?: Partial<BackendCapabilities>;
 }>;
 
 const POSTGRES_MAX_BIND_PARAMETERS = 65_535;
@@ -206,7 +227,18 @@ export function createPostgresBackend(
 ): GraphBackend {
   const tables = options.tables ?? defaultTables;
   const fulltextStrategy = options.fulltext ?? tsvectorStrategy;
-  const capabilities = buildPostgresCapabilities(fulltextStrategy);
+  const baseCapabilities = buildPostgresCapabilities(fulltextStrategy);
+  // HTTP-only drivers (notably `drizzle-orm/neon-http`) can't hold a
+  // session across statements, so multi-statement transactions are
+  // unavailable regardless of what we declare. Auto-detect and downgrade
+  // the capability so callers get correct fallback behavior without
+  // having to remember to override it themselves.
+  const httpOnlyOverrides = isNeonHttpClient(db) ? { transactions: false } : {};
+  const capabilities: BackendCapabilities = {
+    ...baseCapabilities,
+    ...httpOnlyOverrides,
+    ...options.capabilities,
+  };
   const executionAdapter = createPostgresExecutionAdapter(db);
   const tableNames: SqlTableNames = {
     nodes: getTableName(tables.nodes),
@@ -214,6 +246,18 @@ export function createPostgresBackend(
     embeddings: getTableName(tables.embeddings),
     fulltext: tables.fulltextTableName,
   };
+  // Pre-quote identifiers so refreshStatistics() doesn't rebuild the
+  // ANALYZE statement on every call.
+  const analyzeStatement = sql`ANALYZE ${sql.join(
+    [
+      tableNames.nodes,
+      tableNames.edges,
+      getTableName(tables.uniques),
+      tableNames.embeddings,
+      tableNames.fulltext,
+    ].map((name) => quoteIdentifier(name)),
+    sql`, `,
+  )}`;
   const operationStrategy = createPostgresOperationStrategy(
     tables,
     fulltextStrategy,
@@ -237,10 +281,21 @@ export function createPostgresBackend(
       }
     },
 
+    async refreshStatistics(): Promise<void> {
+      // Scoped to TypeGraph-managed tables only — we don't touch
+      // unrelated tables in the same database. Without fresh stats
+      // after a bulk load the planner can pick a reverse-index scan
+      // with a filter (5ms forward traversal instead of 0.5ms) until
+      // autovacuum catches up.
+      await db.execute(analyzeStatement);
+    },
+
     async setActiveSchema(graphId: string, version: number): Promise<void> {
-      await backend.transaction(async (txBackend) => {
-        await txBackend.setActiveSchema(graphId, version);
-      });
+      await runOptionallyInTransaction(
+        backend,
+        (target) => target.setActiveSchema(graphId, version),
+        operations,
+      );
     },
 
     async transaction<T>(
@@ -308,22 +363,20 @@ function createPostgresOperationBackend(
     fulltextStrategy,
   } = options;
 
-  async function execAll<T>(query: SQL): Promise<T[]> {
-    const result = (await db.execute(query)) as Readonly<{
-      rows: T[];
-    }>;
-    return result.rows;
+  // Route through the execution adapter so driver-specific result shapes
+  // (`{rows}` for node-postgres / neon-serverless; bare array for
+  // postgres-js) are normalized in one place.
+  async function execAll<T>(query: SQL): Promise<readonly T[]> {
+    return executionAdapter.execute<T>(query);
   }
 
   async function execGet<T>(query: SQL): Promise<T | undefined> {
-    const result = (await db.execute(query)) as Readonly<{
-      rows: T[];
-    }>;
-    return result.rows[0];
+    const rows = await executionAdapter.execute<T>(query);
+    return rows[0];
   }
 
   async function execRun(query: SQL): Promise<void> {
-    await db.execute(query);
+    await executionAdapter.execute(query);
   }
 
   const commonBackend = createCommonOperationBackend({

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -60,6 +60,7 @@ import {
   createPostgresExecutionAdapter,
   isNeonHttpClient,
   type PostgresExecutionAdapter,
+  type PostgresExecutionAdapterOptions,
 } from "./execution/postgres-execution";
 import { createCommonOperationBackend } from "./operation-backend-core";
 import { createPostgresOperationStrategy } from "./operations/strategy";
@@ -118,6 +119,30 @@ export type PostgresBackendOptions = Readonly<{
    * capability gap.
    */
   capabilities?: Partial<BackendCapabilities>;
+  /**
+   * Use server-side prepared statements (named statements cached per
+   * pg connection) on the node-postgres / neon-serverless fast path.
+   * Defaults to `true`. Set to `false` when pooling through pgbouncer
+   * in transaction-pool mode — pgbouncer routes successive statements
+   * over different backend connections, and a `name` registered on one
+   * is invisible on the next.
+   *
+   * No effect on `drizzle-orm/postgres-js` (handles preparation
+   * internally) or `drizzle-orm/neon-http` (no fast path).
+   */
+  prepareStatements?: boolean;
+  /**
+   * Cap on the number of distinct SQL strings tracked for
+   * prepared-statement naming. Defaults to 256. The cache is LRU-
+   * bounded so high-cardinality SQL text (variable-length IN-lists,
+   * generated aliases, `backend.execute()` calls with one-off SQL)
+   * doesn't grow unbounded in either the Node process or in
+   * PostgreSQL's per-session prepared-statement memory. Worst-case
+   * server-side footprint is roughly `cap × pool size` statements
+   * across all pooled connections. Ignored when
+   * `prepareStatements` is `false`.
+   */
+  preparedStatementCacheMax?: number;
 }>;
 
 const POSTGRES_MAX_BIND_PARAMETERS = 65_535;
@@ -239,7 +264,15 @@ export function createPostgresBackend(
     ...httpOnlyOverrides,
     ...options.capabilities,
   };
-  const executionAdapter = createPostgresExecutionAdapter(db);
+  const adapterOptions: PostgresExecutionAdapterOptions = {
+    ...(options.prepareStatements === undefined
+      ? {}
+      : { prepareStatements: options.prepareStatements }),
+    ...(options.preparedStatementCacheMax === undefined
+      ? {}
+      : { preparedStatementCacheMax: options.preparedStatementCacheMax }),
+  };
+  const executionAdapter = createPostgresExecutionAdapter(db, adapterOptions);
   const tableNames: SqlTableNames = {
     nodes: getTableName(tables.nodes),
     edges: getTableName(tables.edges),
@@ -315,6 +348,7 @@ export function createPostgresBackend(
       return db.transaction(async (tx) => {
         const txBackend = createTransactionBackend({
           db: tx,
+          adapterOptions,
           operationStrategy,
           tableNames,
           capabilities,
@@ -345,6 +379,7 @@ type CreatePostgresOperationBackendOptions = Readonly<{
 type CreatePostgresTransactionBackendOptions = Readonly<{
   db: AnyPgDatabase;
   executionAdapter?: PostgresExecutionAdapter;
+  adapterOptions?: PostgresExecutionAdapterOptions;
   operationStrategy: ReturnType<typeof createPostgresOperationStrategy>;
   tableNames: SqlTableNames;
   capabilities: BackendCapabilities;
@@ -592,7 +627,8 @@ function createTransactionBackend(
   options: CreatePostgresTransactionBackendOptions,
 ): TransactionBackend {
   const txExecutionAdapter =
-    options.executionAdapter ?? createPostgresExecutionAdapter(options.db);
+    options.executionAdapter ??
+    createPostgresExecutionAdapter(options.db, options.adapterOptions);
 
   return createPostgresOperationBackend({
     db: options.db,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -38,6 +38,7 @@ import {
   type FulltextSearchParams,
   type FulltextSearchResult,
   type GraphBackend,
+  runOptionallyInTransaction,
   SQLITE_CAPABILITIES,
   type TransactionBackend,
   type TransactionOptions,
@@ -527,10 +528,21 @@ export function createSqliteBackend(
       }
     },
 
+    async refreshStatistics(): Promise<void> {
+      // `ANALYZE` populates `sqlite_stat1`. With no stat table, the
+      // planner falls back to heuristics that, at least for FTS5
+      // virtual-table queries and multi-column index selection, can be
+      // an order of magnitude slower. Running it explicitly makes the
+      // planner data-driven.
+      await db.run(sql`ANALYZE`);
+    },
+
     async setActiveSchema(graphId: string, version: number): Promise<void> {
-      await backend.transaction(async (txBackend) => {
-        await txBackend.setActiveSchema(graphId, version);
-      });
+      await runOptionallyInTransaction(
+        backend,
+        (target) => target.setActiveSchema(graphId, version),
+        operations,
+      );
     },
 
     async transaction<T>(

--- a/packages/typegraph/src/backend/postgres/index.ts
+++ b/packages/typegraph/src/backend/postgres/index.ts
@@ -5,7 +5,21 @@
  * Use `generatePostgresMigrationSQL()` to get the full DDL including
  * `CREATE EXTENSION IF NOT EXISTS vector` for pgvector support.
  *
- * @example
+ * `createPostgresBackend` is driver-agnostic. It accepts any Drizzle
+ * PostgreSQL database instance, so the same backend works across:
+ *
+ * - `drizzle-orm/node-postgres` (pg) — long-lived Node servers
+ * - `drizzle-orm/postgres-js` (postgres-js) — Node serverless, Bun,
+ *   lower per-query overhead
+ * - `drizzle-orm/neon-serverless` (@neondatabase/serverless Pool over
+ *   WebSockets) — edge runtimes; supports transactions
+ * - `drizzle-orm/neon-http` (@neondatabase/serverless `neon(url)` over
+ *   HTTP) — edge runtimes with no persistent session. Transactions are
+ *   auto-disabled (HTTP can't hold a session); single-statement reads,
+ *   writes, and migrations work normally. Use neon-serverless if you
+ *   need atomic multi-statement operations.
+ *
+ * @example node-postgres
  * ```typescript
  * import { drizzle } from "drizzle-orm/node-postgres";
  * import { Pool } from "pg";
@@ -14,6 +28,26 @@
  * const pool = new Pool({ connectionString: process.env.DATABASE_URL });
  * const db = drizzle(pool);
  * const backend = createPostgresBackend(db, { tables });
+ * ```
+ *
+ * @example postgres-js
+ * ```typescript
+ * import { drizzle } from "drizzle-orm/postgres-js";
+ * import postgres from "postgres";
+ * import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
+ *
+ * const sql = postgres(process.env.DATABASE_URL);
+ * const backend = createPostgresBackend(drizzle(sql));
+ * ```
+ *
+ * @example Neon serverless (edge runtimes)
+ * ```typescript
+ * import { Pool } from "@neondatabase/serverless";
+ * import { drizzle } from "drizzle-orm/neon-serverless";
+ * import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
+ *
+ * const pool = new Pool({ connectionString: env.NEON_DATABASE_URL });
+ * const backend = createPostgresBackend(drizzle(pool));
  * ```
  */
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -504,7 +504,10 @@ export type TransactionOptions = Readonly<{
 /**
  * Transaction backend - a backend scoped to a transaction.
  */
-export type TransactionBackend = Omit<GraphBackend, "transaction" | "close">;
+export type TransactionBackend = Omit<
+  GraphBackend,
+  "transaction" | "close" | "refreshStatistics"
+>;
 
 /**
  * The GraphBackend interface abstracts database operations.
@@ -652,6 +655,26 @@ export type GraphBackend = Readonly<{
    */
   bootstrapTables?: () => Promise<void>;
 
+  /**
+   * Refreshes the backend's query-planner statistics.
+   *
+   * Call this once after a large initial import or bulk backfill. Without
+   * up-to-date statistics, the planner can pick suboptimal execution plans
+   * — on PostgreSQL this is the difference between a 0.5ms and a 5ms
+   * forward traversal; on SQLite it's the difference between 0.9ms and
+   * 23ms fulltext search. Autovacuum / background statistics collection
+   * will catch up eventually, but calling this explicitly after a bulk
+   * load gives you correct latencies immediately.
+   *
+   * Implementations:
+   * - SQLite runs `ANALYZE`, which populates `sqlite_stat1`
+   * - PostgreSQL runs `ANALYZE` on the TypeGraph-managed tables
+   *
+   * Safe to call at any time; costs a few tens of milliseconds on the
+   * sizes this library is designed for.
+   */
+  refreshStatistics: () => Promise<void>;
+
   // === Query Execution ===
   execute: <T>(query: SQL) => Promise<readonly T[]>;
 
@@ -698,6 +721,30 @@ export function wrapWithManagedClose(
       await teardown();
     },
   };
+}
+
+/**
+ * Runs `fn` inside a transaction when the backend supports one, falling
+ * through to a direct invocation otherwise. Lets call sites benefit from
+ * atomicity on backends that have transactions while staying functional
+ * on backends that don't (Cloudflare D1, `drizzle-orm/neon-http` over
+ * HTTP). The single-statement race window is already implicit on any
+ * backend that reports `transactions: false`; callers that cannot
+ * tolerate it must branch on the capability themselves.
+ *
+ * Pass `fallback` only when the toplevel backend method would recurse
+ * — for example, when implementing `backend.setActiveSchema` itself,
+ * pass the operation-level backend so the no-tx path doesn't loop.
+ */
+export async function runOptionallyInTransaction<T>(
+  backend: GraphBackend,
+  fn: (target: GraphBackend | TransactionBackend) => Promise<T>,
+  fallback?: GraphBackend | TransactionBackend,
+): Promise<T> {
+  if (!backend.capabilities.transactions) {
+    return fn(fallback ?? backend);
+  }
+  return backend.transaction((tx) => fn(tx));
 }
 
 // ============================================================

--- a/packages/typegraph/src/store/fulltext-rebuild.ts
+++ b/packages/typegraph/src/store/fulltext-rebuild.ts
@@ -11,7 +11,12 @@
  */
 import { type z } from "zod";
 
-import type { GraphBackend, NodeRow } from "../backend/types";
+import {
+  type GraphBackend,
+  type NodeRow,
+  runOptionallyInTransaction,
+  type TransactionBackend,
+} from "../backend/types";
 import { ConfigurationError, ValidationError } from "../errors";
 import { type KindRegistry } from "../registry";
 import { computeFulltextContent, getSearchableFields } from "./fulltext-sync";
@@ -168,17 +173,19 @@ export async function rebuildFulltextIndex(
         skippedIds.push(...pageResult.skippedIds.slice(0, remaining));
       }
 
-      await backend.transaction(async (tx) => {
+      const writePage = async (
+        target: GraphBackend | TransactionBackend,
+      ): Promise<void> => {
         if (pageResult.toUpsert.length > 0) {
-          if (tx.upsertFulltextBatch) {
-            await tx.upsertFulltextBatch({
+          if (target.upsertFulltextBatch) {
+            await target.upsertFulltextBatch({
               graphId: ctx.graphId,
               nodeKind: kind,
               rows: pageResult.toUpsert,
             });
-          } else if (tx.upsertFulltext) {
+          } else if (target.upsertFulltext) {
             for (const item of pageResult.toUpsert) {
-              await tx.upsertFulltext({
+              await target.upsertFulltext({
                 graphId: ctx.graphId,
                 nodeKind: kind,
                 nodeId: item.nodeId,
@@ -189,15 +196,15 @@ export async function rebuildFulltextIndex(
           }
         }
         if (pageResult.toDelete.length > 0) {
-          if (tx.deleteFulltextBatch) {
-            await tx.deleteFulltextBatch({
+          if (target.deleteFulltextBatch) {
+            await target.deleteFulltextBatch({
               graphId: ctx.graphId,
               nodeKind: kind,
               nodeIds: pageResult.toDelete,
             });
-          } else if (tx.deleteFulltext) {
+          } else if (target.deleteFulltext) {
             for (const nodeId of pageResult.toDelete) {
-              await tx.deleteFulltext({
+              await target.deleteFulltext({
                 graphId: ctx.graphId,
                 nodeKind: kind,
                 nodeId,
@@ -205,7 +212,13 @@ export async function rebuildFulltextIndex(
             }
           }
         }
-      });
+      };
+
+      // Wrapped in a transaction when supported so a partial failure
+      // mid-page doesn't leave the index half-rebuilt. On backends without
+      // transactions, refusing to rebuild would be worse than the lost
+      // atomicity (the index would stay permanently stale).
+      await runOptionallyInTransaction(backend, writePage);
 
       processed += rows.length;
       upserted += pageResult.toUpsert.length;

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -500,12 +500,19 @@ export class Store<G extends GraphDef> {
   // === Batch Query Execution ===
 
   /**
-   * Executes multiple queries over a single connection with snapshot consistency.
+   * Executes multiple queries and returns a typed tuple of results.
    *
-   * Acquires one connection via an implicit transaction, executes each query
-   * sequentially on that connection, and returns a typed tuple of results.
-   * Each query preserves its own result type, projection, filtering,
-   * sorting, and pagination.
+   * Each query preserves its own result type, projection, filtering, sorting,
+   * and pagination.
+   *
+   * **Snapshot consistency is conditional.** When
+   * `backend.capabilities.transactions` is `true`, queries run sequentially
+   * on a single connection inside an implicit transaction and observe the
+   * same database snapshot. When transactions are unavailable
+   * (Cloudflare D1, `drizzle-orm/neon-http`), queries run sequentially over
+   * independent connections and may observe writes that landed between them.
+   * Branch on `backend.capabilities.transactions` if you need a guaranteed
+   * snapshot.
    *
    * Read-only — use `bulkCreate`, `bulkInsert`, etc. for write batching.
    *
@@ -613,6 +620,21 @@ export class Store<G extends GraphDef> {
    *   );
    * });
    * ```
+   *
+   * **Backends without transactions.** When `backend.capabilities.transactions`
+   * is `false` (Cloudflare D1, `drizzle-orm/neon-http`), this method runs the
+   * callback against the same backend used outside `transaction()` — writes
+   * are applied as they happen and a thrown error does **not** roll back
+   * earlier writes inside the callback. Branch on
+   * `backend.capabilities.transactions` if you require atomicity:
+   *
+   * ```typescript
+   * if (backend.capabilities.transactions) {
+   *   await store.transaction(async (tx) => { ... });
+   * } else {
+   *   // sequential, non-atomic — handle partial-failure recovery yourself
+   * }
+   * ```
    */
   async transaction<T>(
     fn: (tx: TransactionContext<G>) => Promise<T>,
@@ -707,7 +729,7 @@ export class Store<G extends GraphDef> {
    * ```typescript
    * // After a bulk import
    * for (const batch of batches) {
-   *   await store.bulkCreate(batch);
+   *   await store.nodes.Document.bulkCreate(batch);
    * }
    * await store.refreshStatistics();
    * ```

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -8,7 +8,11 @@
  * - Schema management
  * - Transaction handling
  */
-import { type GraphBackend, type TransactionBackend } from "../backend/types";
+import {
+  type GraphBackend,
+  runOptionallyInTransaction,
+  type TransactionBackend,
+} from "../backend/types";
 import {
   type AllNodeTypes,
   type EdgeKinds,
@@ -531,10 +535,10 @@ export class Store<G extends GraphDef> {
       ...BatchableQuery<unknown>[],
     ],
   >(...queries: Queries): Promise<BatchResults<Queries>> {
-    return this.#backend.transaction(async (txBackend) => {
+    return runOptionallyInTransaction(this.#backend, async (target) => {
       const results: unknown[] = [];
       for (const query of queries) {
-        const result = await query.executeOn(txBackend);
+        const result = await query.executeOn(target);
         results.push(result);
       }
       return results as BatchResults<Queries>;
@@ -613,6 +617,13 @@ export class Store<G extends GraphDef> {
   async transaction<T>(
     fn: (tx: TransactionContext<G>) => Promise<T>,
   ): Promise<T> {
+    // Without a real transaction the tx-scoped collections would be
+    // bound to the same backend as this.nodes/this.edges and exposing
+    // the cached versions avoids rebuilding the proxies on every call.
+    if (!this.#backend.capabilities.transactions) {
+      return fn({ nodes: this.nodes, edges: this.edges });
+    }
+
     return this.#backend.transaction(async (txBackend) => {
       const txNodeOperations: NodeOperations = {
         ...this.#nodeOperations,
@@ -623,7 +634,6 @@ export class Store<G extends GraphDef> {
         createQuery: () => this.#createQueryForBackend(txBackend),
       };
 
-      // Create collections using transaction backend
       const nodes = createNodeCollectionsProxy(
         this.#graph,
         this.graphId,
@@ -674,6 +684,37 @@ export class Store<G extends GraphDef> {
   }
 
   // === Lifecycle ===
+
+  /**
+   * Refreshes the backend's query-planner statistics.
+   *
+   * Call this once after a large initial import or bulk backfill. The
+   * planner uses table statistics to choose between TypeGraph's
+   * multi-column indexes; without fresh stats a forward traversal can
+   * pick a reverse index and run an order of magnitude slower than
+   * needed. Autovacuum / background statistics will catch up
+   * eventually, but calling this explicitly after a bulk load gives
+   * you correct latencies immediately.
+   *
+   * Implementations:
+   * - SQLite runs `ANALYZE`, populating `sqlite_stat1`
+   * - PostgreSQL runs `ANALYZE` on the TypeGraph-managed tables
+   *
+   * Costs a few tens of milliseconds at the sizes this library is
+   * designed for. Safe to call at any time.
+   *
+   * @example
+   * ```typescript
+   * // After a bulk import
+   * for (const batch of batches) {
+   *   await store.bulkCreate(batch);
+   * }
+   * await store.refreshStatistics();
+   * ```
+   */
+  async refreshStatistics(): Promise<void> {
+    await this.#backend.refreshStatistics();
+  }
 
   /**
    * Closes the store and releases underlying resources.

--- a/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Neon HTTP smoke test.
+ *
+ * `@neondatabase/serverless`'s `neon(url)` HTTP-only driver works in
+ * Cloudflare Workers and serves a real production deployment (Nicia).
+ * Distinct from the WebSocket `Pool` (covered in
+ * `neon-serverless-smoke.test.ts`), the HTTP driver:
+ *
+ *   - Cannot hold a session across statements, so multi-statement
+ *     transactions are unavailable.
+ *   - Has a `.unsafe()` that builds SQL fragments rather than executing
+ *     queries, and a `.query()` that doesn't accept the
+ *     `{name, text, values}` config object form. The fast path can't
+ *     drive it; we route through `db.execute` (Drizzle's neon-http
+ *     session) instead.
+ *
+ * This test verifies:
+ *
+ *   1. Driver detection identifies neon-http (callable + `.transaction`,
+ *      no `.begin`) and skips the broken pg fast path.
+ *   2. `capabilities.transactions` is auto-set to `false` so callers'
+ *      transaction-aware code paths fall through to non-transactional
+ *      execution rather than throwing.
+ *   3. The explicit `capabilities` override option still wins over the
+ *      auto-detection so users can opt back in (or further constrain).
+ */
+import { neon } from "@neondatabase/serverless";
+import { drizzle as drizzleNeonHttp } from "drizzle-orm/neon-http";
+import { describe, expect, it } from "vitest";
+
+import { createPostgresBackend } from "../../../src/backend/postgres";
+
+describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () => {
+  it("auto-disables transactions when neon-http is detected", () => {
+    // `neon()` doesn't validate the URL until the first request, so we
+    // can construct it safely. We never run a query, so no HTTP traffic
+    // happens.
+    const sql = neon("postgresql://test:test@invalid.neon.tech/test");
+    const db = drizzleNeonHttp({ client: sql });
+
+    const backend = createPostgresBackend(db);
+
+    expect(backend.dialect).toBe("postgres");
+    // The headline behavior: HTTP can't hold a session, so transactions
+    // are off. Callers like `setActiveSchema` and `store.transaction`
+    // check this capability and fall through to sequential execution
+    // when it's false.
+    expect(backend.capabilities.transactions).toBe(false);
+    // Other capabilities are unchanged.
+    expect(backend.capabilities.cte).toBe(true);
+    expect(backend.capabilities.jsonb).toBe(true);
+    expect(backend.capabilities.vector?.supported).toBe(true);
+  });
+
+  it("does not expose the executeRaw fast path for neon-http", () => {
+    // The fast path's prepared-statement `.query({name, text, values})`
+    // form is incompatible with neon-http. By skipping it, we route
+    // every query through Drizzle's neon-http session, which uses the
+    // correct HTTP request shape. `executeRaw` should be undefined,
+    // signaling to higher layers (like PreparedQuery) to use the slow
+    // path.
+    const sql = neon("postgresql://test:test@invalid.neon.tech/test");
+    const db = drizzleNeonHttp({ client: sql });
+    const backend = createPostgresBackend(db);
+
+    expect(backend.executeRaw).toBeUndefined();
+    // `execute` is always defined; it routes through db.execute for
+    // neon-http.
+    expect(typeof backend.execute).toBe("function");
+  });
+
+  it("respects an explicit capabilities override", () => {
+    // The auto-detection sets `transactions: false`, but if the user
+    // explicitly opts back in (e.g. via a wsproxy that does support
+    // sessions, or for testing), the override wins.
+    const sql = neon("postgresql://test:test@invalid.neon.tech/test");
+    const db = drizzleNeonHttp({ client: sql });
+    const backend = createPostgresBackend(db, {
+      capabilities: { transactions: true },
+    });
+
+    expect(backend.capabilities.transactions).toBe(true);
+  });
+});

--- a/packages/typegraph/tests/backends/postgres/neon-serverless-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-serverless-smoke.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Neon serverless smoke test.
+ *
+ * @neondatabase/serverless drives PostgreSQL over WebSockets, which is
+ * the only transport that works on Cloudflare Workers / Vercel Edge /
+ * Netlify Edge — runtimes without raw TCP sockets. We can't reach a
+ * real Neon database from CI without a live account, and we can't
+ * easily emulate the WebSocket protocol locally, so this test instead
+ * verifies the *integration shape*:
+ *
+ *   1. The `drizzle-orm/neon-serverless` package + `Pool` from
+ *      `@neondatabase/serverless` import without error (i.e. the path
+ *      we advertise in our docs is reachable from this codebase).
+ *   2. `createPostgresBackend` accepts a Drizzle db wrapped around the
+ *      Neon `Pool`, with no Node-only module imports failing.
+ *   3. The execution adapter's driver detection routes Neon's
+ *      pg-Pool-compatible `$client` through the wrapped node-postgres
+ *      fast path (named server-side prepared statements + Date→string
+ *      row normalization).
+ *   4. The resulting backend has the expected GraphBackend interface.
+ *
+ * That's enough to catch a refactor that would, e.g., introduce a
+ * static `node:` import that crashes in edge runtimes — which is what
+ * the original P1 review item was about.
+ */
+import { Pool as NeonPool } from "@neondatabase/serverless";
+import { drizzle as drizzleNeon } from "drizzle-orm/neon-serverless";
+import { describe, expect, it, vi } from "vitest";
+
+import { createPostgresBackend } from "../../../src/backend/postgres";
+
+describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless", () => {
+  it("wires drizzle-orm/neon-serverless through createPostgresBackend", () => {
+    // Construct a Neon Pool. We never .connect() so no WebSocket
+    // attempt happens; we just verify the constructor runs and the
+    // resulting db has the shape our adapter expects.
+    const pool = new NeonPool({
+      connectionString: "postgresql://test:test@invalid.neon.tech/test",
+    });
+    const db = drizzleNeon(pool);
+
+    const backend = createPostgresBackend(db);
+
+    expect(backend.dialect).toBe("postgres");
+    expect(backend.capabilities.cte).toBe(true);
+    expect(backend.capabilities.jsonb).toBe(true);
+    // Vector / pgvector capability is declared at backend-construction
+    // time and doesn't depend on a live connection. It's the same on
+    // every PostgreSQL driver we support.
+    expect(backend.capabilities.vector?.supported).toBe(true);
+    expect(backend.tableNames?.nodes).toBe("typegraph_nodes");
+
+    // Sanity: the fast path execute / prepare functions exist
+    // (i.e. driver detection succeeded). Under the hood this means
+    // the Neon `Pool.query({name, text, values})` shape is being
+    // routed through `wrapNodePgClient`.
+    expect(typeof backend.execute).toBe("function");
+    expect(typeof backend.executeRaw).toBe("function");
+    expect(typeof backend.refreshStatistics).toBe("function");
+  });
+
+  it("invokes neon Pool.query via the named-statement fast path", async () => {
+    // Replace the Pool's query method with a spy so we can observe
+    // exactly what shape the adapter sends. This confirms the
+    // server-side prepared-statement payload reaches the driver
+    // (named, with text + values), which is the perf-relevant
+    // optimization documented in this release.
+    const queryRows = [{ result: 1 }];
+    const queryFunction = vi.fn().mockResolvedValue({ rows: queryRows });
+
+    const pool = new NeonPool({
+      connectionString: "postgresql://test:test@invalid.neon.tech/test",
+    }) as unknown as { query: typeof queryFunction };
+    pool.query = queryFunction;
+
+    const db = drizzleNeon(pool as unknown as NeonPool);
+    const backend = createPostgresBackend(db);
+
+    if (backend.executeRaw === undefined) {
+      throw new Error(
+        "executeRaw should be available on Neon serverless backends",
+      );
+    }
+
+    const rows = await backend.executeRaw<{ result: number }>(
+      "SELECT $1::int AS result",
+      [1],
+    );
+    expect(rows).toEqual(queryRows);
+
+    expect(queryFunction).toHaveBeenCalledTimes(1);
+    expect(queryFunction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expect.stringMatching(/^tg_\d+$/) as unknown,
+        text: "SELECT $1::int AS result",
+        values: [1],
+      }),
+    );
+  });
+
+  it("normalizes Date columns to ISO strings on the way out", async () => {
+    // Neon (like node-postgres) returns timestamp columns as Date
+    // objects by default. The adapter's row normalizer converts them
+    // to ISO strings so downstream row mappers see the same shape
+    // they would through Drizzle's session.
+    const sampleDate = new Date("2026-04-25T12:00:00.000Z");
+    const queryFunction = vi.fn().mockResolvedValue({
+      rows: [{ created_at: sampleDate, name: "Alice" }],
+    });
+    const pool = new NeonPool({
+      connectionString: "postgresql://test:test@invalid.neon.tech/test",
+    }) as unknown as { query: typeof queryFunction };
+    pool.query = queryFunction;
+
+    const db = drizzleNeon(pool as unknown as NeonPool);
+    const backend = createPostgresBackend(db);
+
+    const rows = await backend.executeRaw!<{
+      created_at: string;
+      name: string;
+    }>("SELECT created_at, name FROM t WHERE id = $1", ["x"]);
+
+    expect(rows[0]?.created_at).toBe("2026-04-25T12:00:00.000Z");
+    expect(typeof rows[0]?.created_at).toBe("string");
+    expect(rows[0]?.name).toBe("Alice");
+  });
+});

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -25,7 +25,10 @@ import {
   generatePostgresDDL,
   generatePostgresMigrationSQL,
 } from "../../../src/backend/drizzle/ddl";
-import { createPostgresBackend } from "../../../src/backend/postgres";
+import {
+  createPostgresBackend,
+  createPostgresTables,
+} from "../../../src/backend/postgres";
 import { createStore } from "../../../src/store";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
@@ -147,6 +150,12 @@ async function clearTestData(): Promise<void> {
 // ============================================================
 
 beforeAll(async () => {
+  // Only attempt to connect when POSTGRES_URL is explicitly set (i.e. via
+  // `scripts/test-postgres.sh`). Without the gate, a developer with a
+  // stray Docker Postgres container running would trigger the
+  // DROP+CREATE schema setup below during `pnpm test:unit` and race with
+  // other postgres test files sharing the same database.
+  if (!process.env.POSTGRES_URL) return;
   isPostgresAvailable = await initializePostgres();
   if (isPostgresAvailable) {
     await setupTestDatabase();
@@ -399,6 +408,53 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
 
       const fetched = await backend.getNode("test_graph", "Person", "person-1");
       expect(fetched).toBeDefined();
+    });
+  });
+
+  describe("refreshStatistics()", () => {
+    it("runs ANALYZE on the default TypeGraph tables", async (ctx) => {
+      const { db } = requirePostgres(ctx);
+      const backend = createPostgresBackend(db);
+      await expect(backend.refreshStatistics()).resolves.toBeUndefined();
+    });
+
+    it("works against backends configured with non-default table names", async (ctx) => {
+      // Exercises the table-name parameterization path. Embedded-quote
+      // safety in the emitted SQL comes from routing through
+      // `quoteIdentifier`, which doubles `"` per the SQL spec — no
+      // additional integration coverage needed beyond verifying that
+      // custom names round-trip end-to-end.
+      const { pool } = requirePostgres(ctx);
+      const customTables = createPostgresTables({
+        nodes: "tg_custom_nodes",
+        edges: "tg_custom_edges",
+        uniques: "tg_custom_uniques",
+        embeddings: "tg_custom_embeddings",
+        fulltext: "tg_custom_fulltext",
+        schemaVersions: "tg_custom_schema_versions",
+      });
+
+      const customDdl = generatePostgresDDL(customTables);
+      try {
+        for (const statement of customDdl) {
+          await pool.query(statement);
+        }
+        const customBackend = createPostgresBackend(drizzle(pool), {
+          tables: customTables,
+        });
+        await expect(
+          customBackend.refreshStatistics(),
+        ).resolves.toBeUndefined();
+      } finally {
+        await pool.query(`
+          DROP TABLE IF EXISTS tg_custom_fulltext CASCADE;
+          DROP TABLE IF EXISTS tg_custom_embeddings CASCADE;
+          DROP TABLE IF EXISTS tg_custom_uniques CASCADE;
+          DROP TABLE IF EXISTS tg_custom_edges CASCADE;
+          DROP TABLE IF EXISTS tg_custom_nodes CASCADE;
+          DROP TABLE IF EXISTS tg_custom_schema_versions CASCADE;
+        `);
+      }
     });
   });
 });

--- a/packages/typegraph/tests/backends/postgres/postgres-fulltext.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-fulltext.test.ts
@@ -57,6 +57,10 @@ beforeAll(async () => {
   // generated migration SQL uses `CREATE TABLE IF NOT EXISTS` so it's
   // safe to run alongside; per-test isolation is handled by TRUNCATE in
   // `beforeEach` below.
+  //
+  // Gated on POSTGRES_URL so `pnpm test:unit` doesn't try to attach to a
+  // stray Docker Postgres and race other postgres files.
+  if (!process.env.POSTGRES_URL) return;
   try {
     pool = new Pool({ connectionString: TEST_DATABASE_URL });
     await pool.query("SELECT 1");

--- a/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
@@ -1,0 +1,389 @@
+/**
+ * PostgreSQL Backend Integration Tests — postgres-js driver.
+ *
+ * Mirrors `postgres-backend.test.ts` but wires the backend through
+ * `drizzle-orm/postgres-js` + the `postgres` (porsager) driver. We run
+ * the full adapter + integration suites against both drivers to prove
+ * driver-agnostic behavior end-to-end.
+ *
+ * Skipped automatically unless `POSTGRES_URL` is set (or the
+ * `scripts/test-postgres.sh` harness is used). Targets the same database
+ * as `postgres-backend.test.ts`; both files use `CREATE TABLE IF NOT
+ * EXISTS` DDL and per-test TRUNCATE, and the harness runs files
+ * serially.
+ */
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import postgres, { type Sql } from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { count, defineEdge, defineGraph, defineNode } from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { createStore } from "../../../src/store";
+import { createAdapterTestSuite } from "../adapter-test-suite";
+import { createIntegrationTestSuite } from "../integration-test-suite";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let sharedSql: Sql | undefined;
+let sharedDb: PostgresJsDatabase | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): {
+  sql: Sql;
+  db: PostgresJsDatabase;
+} {
+  if (!isPostgresAvailable || !sharedSql || !sharedDb) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return { sql: sharedSql, db: sharedDb };
+}
+
+function createConnection(): { sql: Sql; db: PostgresJsDatabase } {
+  const sql = postgres(TEST_DATABASE_URL, { max: 4 });
+  const db = drizzle(sql);
+  return { sql, db };
+}
+
+async function initializePostgres(): Promise<boolean> {
+  const maxRetries = 5;
+  const retryDelayMs = 1000;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const sql = postgres(TEST_DATABASE_URL, {
+      max: 4,
+      connect_timeout: 5,
+      onnotice: () => {
+        // Silence NOTICE messages from CREATE IF NOT EXISTS so test
+        // output stays readable.
+      },
+    });
+
+    try {
+      await sql`SELECT 1`;
+      sharedSql = sql;
+      sharedDb = drizzle(sql);
+      return true;
+    } catch {
+      await sql.end().catch(() => {
+        // Ignore cleanup errors
+      });
+      if (attempt < maxRetries) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  }
+
+  return false;
+}
+
+async function setupTestDatabase(): Promise<void> {
+  if (!sharedSql) return;
+  // Run the generated migration SQL. It uses CREATE TABLE IF NOT EXISTS
+  // and CREATE EXTENSION IF NOT EXISTS, so it's safe to run alongside the
+  // node-postgres test file — we don't drop tables here.
+  const migrationSql = generatePostgresMigrationSQL();
+  await sharedSql.unsafe(migrationSql);
+}
+
+async function clearTestData(): Promise<void> {
+  if (!sharedSql) return;
+  await sharedSql.unsafe(
+    `TRUNCATE typegraph_node_fulltext,
+              typegraph_node_embeddings,
+              typegraph_nodes,
+              typegraph_edges,
+              typegraph_node_uniques,
+              typegraph_schema_versions CASCADE`,
+  );
+}
+
+beforeAll(async () => {
+  // Gated on POSTGRES_URL (same pattern as postgres-backend.test.ts) so
+  // `pnpm test:unit` doesn't race with other postgres files when a stray
+  // Docker Postgres happens to be reachable.
+  if (!process.env.POSTGRES_URL) return;
+  isPostgresAvailable = await initializePostgres();
+  if (isPostgresAvailable) {
+    await setupTestDatabase();
+  }
+});
+
+afterAll(async () => {
+  if (sharedSql) {
+    await sharedSql.end();
+  }
+});
+
+// ============================================================
+// Shared Adapter + Integration Test Suites
+// ============================================================
+
+describe("PostgreSQL Adapter (postgres-js driver)", () => {
+  beforeEach(async () => {
+    if (!isPostgresAvailable) return;
+    await clearTestData();
+  });
+
+  it("is available for testing", (ctx) => {
+    requirePostgres(ctx);
+    expect(sharedSql).toBeDefined();
+    expect(sharedDb).toBeDefined();
+  });
+
+  describe.runIf(process.env.POSTGRES_URL)("Adapter Test Suite", () => {
+    beforeEach(async () => {
+      await clearTestData();
+    });
+
+    createAdapterTestSuite(
+      "PostgreSQL (postgres-js)",
+      () => {
+        const { db } = createConnection();
+        return createPostgresBackend(db);
+      },
+      { skipRawQueries: false },
+    );
+  });
+
+  describe.runIf(process.env.POSTGRES_URL)("Integration Test Suite", () => {
+    beforeEach(async () => {
+      await clearTestData();
+    });
+
+    createIntegrationTestSuite("PostgreSQL (postgres-js)", () => {
+      const { sql, db } = createConnection();
+      return {
+        backend: createPostgresBackend(db),
+        cleanup: async () => {
+          await sql.end();
+        },
+      };
+    });
+  });
+});
+
+// ============================================================
+// postgres-js-specific coercion sanity tests
+//
+// These guard the places postgres-js is known to diverge from
+// node-postgres: JSONB auto-parsing, numeric-as-string on aggregates,
+// pgvector string format, and transaction isolation levels.
+// ============================================================
+
+describe("postgres-js driver — coercion sanity", () => {
+  beforeEach(async () => {
+    if (!isPostgresAvailable) return;
+    await clearTestData();
+  });
+
+  it("round-trips complex JSONB props identically to node-postgres", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+
+    const complexProps = {
+      name: "Alice",
+      // `null` (not `undefined`) is part of the round-trip we need to
+      // verify: postgres-js auto-parses jsonb and must preserve nulls
+      // end-to-end through our row-mapper.
+      // eslint-disable-next-line unicorn/no-null
+      nested: { a: 1, b: [2, 3], deep: { x: "y", n: null } },
+      array: ["x", "y"],
+      unicode: "日本語",
+      zero: 0,
+      bool: true,
+    };
+
+    const inserted = await backend.insertNode({
+      graphId: "postgres_js_test",
+      kind: "Person",
+      id: "person-1",
+      props: complexProps,
+    });
+
+    // Backend's row contract stores `props` as a JSON string — drivers must
+    // agree on this wire-level representation so downstream JSON.parse is
+    // idempotent regardless of whether jsonb came back parsed or as text.
+    expect(typeof inserted.props).toBe("string");
+    const parsed = JSON.parse(inserted.props);
+    expect(parsed).toEqual(complexProps);
+
+    const fetched = await backend.getNode(
+      "postgres_js_test",
+      "Person",
+      "person-1",
+    );
+    expect(fetched).toBeDefined();
+    expect(typeof fetched!.props).toBe("string");
+    expect(JSON.parse(fetched!.props)).toEqual(complexProps);
+  });
+
+  it("returns aggregate counts as plain numbers (not BigInt)", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+
+    for (let index = 0; index < 5; index++) {
+      await backend.insertNode({
+        graphId: "postgres_js_test",
+        kind: "Person",
+        id: `person-count-${index}`,
+        props: { name: `Person ${index}` },
+      });
+    }
+
+    const Person = defineNode("Person", {
+      schema: z.object({ name: z.string() }),
+    });
+    const graph = defineGraph({
+      id: "postgres_js_test",
+      nodes: { Person: { type: Person } },
+      edges: {},
+    });
+    const store = createStore(graph, backend);
+
+    const result = await store
+      .query()
+      .from("Person", "p")
+      .aggregate({ total: count("p") })
+      .execute();
+
+    expect(result).toHaveLength(1);
+    // Postgres' `COUNT(*)` returns a `bigint`. node-postgres coerces to
+    // string; postgres-js coerces to native `BigInt` unless Drizzle's
+    // transparent-parser override catches OID 20. Assert we get a plain
+    // JS number at the store boundary — that's the contract.
+    expect(typeof result[0]!.total).toBe("number");
+    expect(result[0]!.total).toBe(5);
+  });
+
+  it("honors serializable isolation on db.transaction", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+
+    await backend.transaction(
+      async (tx) => {
+        await tx.insertNode({
+          graphId: "postgres_js_test",
+          kind: "Person",
+          id: "tx-1",
+          props: { name: "Alice" },
+        });
+      },
+      { isolationLevel: "serializable" },
+    );
+
+    const fetched = await backend.getNode("postgres_js_test", "Person", "tx-1");
+    expect(fetched).toBeDefined();
+    expect(JSON.parse(fetched!.props).name).toBe("Alice");
+  });
+});
+
+// ============================================================
+// Store smoke test — exercises the full CRUD surface once
+// through the postgres-js adapter, mirroring a tight subset of
+// what the node-postgres file asserts.
+// ============================================================
+
+const Person = defineNode("Person", {
+  schema: z.object({
+    name: z.string(),
+    email: z.email().optional(),
+    age: z.number().int().positive().optional(),
+  }),
+});
+
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string() }),
+});
+
+const smokeGraph = defineGraph({
+  id: "postgres_js_smoke",
+  nodes: {
+    Person: { type: Person },
+    Company: { type: Company },
+  },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "many",
+    },
+  },
+});
+
+describe("Store with PostgreSQL (postgres-js driver)", () => {
+  beforeEach(async () => {
+    if (!isPostgresAvailable) return;
+    await clearTestData();
+  });
+
+  it("creates, retrieves, updates, and soft-deletes nodes through postgres-js", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+    const store = createStore(smokeGraph, backend);
+
+    const person = await store.nodes.Person.create({
+      name: "Alice",
+      email: "alice@example.com",
+    });
+    expect(person.name).toBe("Alice");
+
+    const updated = await store.nodes.Person.update(person.id, {
+      name: "Alice Smith",
+      age: 30,
+    });
+    expect(updated.name).toBe("Alice Smith");
+    expect(updated.age).toBe(30);
+    expect(updated.meta.version).toBe(2);
+
+    await store.nodes.Person.delete(person.id);
+    const afterDelete = await store.nodes.Person.getById(person.id);
+    expect(afterDelete).toBeUndefined();
+  });
+
+  it("creates edges across the postgres-js driver", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+    const store = createStore(smokeGraph, backend);
+
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({ name: "Acme" });
+
+    const edge = await store.edges.worksAt.create(alice, acme, {
+      role: "Engineer",
+    });
+    expect(edge.fromId).toBe(alice.id);
+    expect(edge.toId).toBe(acme.id);
+    expect(edge.role).toBe("Engineer");
+  });
+
+  it("executes transactions atomically through postgres-js", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+    const store = createStore(smokeGraph, backend);
+
+    const result = await store.transaction(async (tx) => {
+      const alice = await tx.nodes.Person.create({ name: "Alice" });
+      const acme = await tx.nodes.Company.create({ name: "Acme" });
+      const edge = await tx.edges.worksAt.create(alice, acme, {
+        role: "Engineer",
+      });
+      return { alice, acme, edge };
+    });
+
+    expect(result.alice.id).toBeDefined();
+    expect(result.edge.role).toBe("Engineer");
+
+    const fetched = await store.nodes.Person.getById(result.alice.id);
+    expect(fetched).toBeDefined();
+  });
+});

--- a/packages/typegraph/tests/execution-adapter.test.ts
+++ b/packages/typegraph/tests/execution-adapter.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   type AnyPgDatabase,
   createPostgresExecutionAdapter,
+  resetStatementNameCacheForTests,
 } from "../src/backend/drizzle/execution/postgres-execution";
 import { createSqliteExecutionAdapter } from "../src/backend/drizzle/execution/sqlite-execution";
 import { createTestDatabase } from "./test-utils";
@@ -174,6 +175,48 @@ describe("sqlite execution adapter", () => {
   });
 });
 
+/**
+ * Builds a mock pg-style db whose `dialect.sqlToQuery()` echoes the
+ * SQL fragment built from a single placeholder, so each test can issue
+ * distinct queries via `sql\`q1\``, `sql\`q2\``, etc. and the adapter
+ * sees a different `compiled.sql` per query.
+ */
+type MockPgQueryFunction = ReturnType<
+  typeof vi.fn<
+    (
+      configOrSql: unknown,
+      params?: readonly unknown[],
+    ) => Promise<{ rows: readonly unknown[] }>
+  >
+>;
+
+function makeMockPgDb(): { db: AnyPgDatabase; query: MockPgQueryFunction } {
+  const query: MockPgQueryFunction = vi.fn(() => Promise.resolve({ rows: [] }));
+  // Compile each Drizzle SQL object to a stable SQL string keyed on
+  // object identity, so a query executed twice produces the same
+  // compiled text — matching the real dialect's behavior. A naive
+  // monotonic counter would assign a new SQL string per call and break
+  // any test that asserts on cache hits.
+  const compiled = new WeakMap<object, string>();
+  let counter = 0;
+  const db = {
+    $client: { query },
+    dialect: {
+      sqlToQuery(query: object) {
+        let sqlText = compiled.get(query);
+        if (sqlText === undefined) {
+          counter += 1;
+          sqlText = `SELECT ${counter} AS x`;
+          compiled.set(query, sqlText);
+        }
+        return { params: [] as readonly unknown[], sql: sqlText };
+      },
+    },
+    execute: vi.fn(() => Promise.resolve({ rows: [] as readonly unknown[] })),
+  } as unknown as AnyPgDatabase;
+  return { db, query };
+}
+
 describe("postgres execution adapter", () => {
   it("falls back to drizzle execution when raw client is unavailable", async () => {
     const execute = vi.fn(() =>
@@ -286,5 +329,100 @@ describe("postgres execution adapter", () => {
         values: ["abc"],
       }),
     );
+  });
+
+  describe("statement-name cache", () => {
+    it("evicts oldest entries when cache exceeds the configured cap", async () => {
+      resetStatementNameCacheForTests();
+      const { db, query } = makeMockPgDb();
+      const adapter = createPostgresExecutionAdapter(db, {
+        preparedStatementCacheMax: 2,
+      });
+
+      // Three distinct compiled SQL strings → cache exceeds cap by one,
+      // so the oldest entry must be evicted.
+      await adapter.execute(sql`q1`);
+      await adapter.execute(sql`q2`);
+      await adapter.execute(sql`q3`);
+
+      const namesUsed = query.mock.calls.map(
+        (call) => (call[0] as { name: string }).name,
+      );
+      expect(namesUsed).toHaveLength(3);
+      expect(new Set(namesUsed).size).toBe(3);
+    });
+
+    it("never recycles statement names after eviction", async () => {
+      resetStatementNameCacheForTests();
+      const { db, query } = makeMockPgDb();
+      const adapter = createPostgresExecutionAdapter(db, {
+        preparedStatementCacheMax: 2,
+      });
+
+      await adapter.execute(sql`q1`);
+      const firstName = (query.mock.calls[0]?.[0] as { name: string }).name;
+
+      await adapter.execute(sql`q2`);
+      await adapter.execute(sql`q3`); // evicts q1
+      await adapter.execute(sql`q4`); // evicts q2
+
+      const namesUsed = query.mock.calls.map(
+        (call) => (call[0] as { name: string }).name,
+      );
+      // After two evictions, four distinct names must have been issued —
+      // recycling firstName for q3 or q4 would collide with the still-
+      // prepared statement on a long-lived pg connection.
+      expect(new Set(namesUsed).size).toBe(4);
+      expect(namesUsed.slice(1)).not.toContain(firstName);
+    });
+
+    it("promotes recently-used entries so they are not evicted next", async () => {
+      resetStatementNameCacheForTests();
+      const { db, query } = makeMockPgDb();
+      const adapter = createPostgresExecutionAdapter(db, {
+        preparedStatementCacheMax: 2,
+      });
+
+      const queryA = sql`alpha`;
+      const queryB = sql`beta`;
+      const queryC = sql`gamma`;
+
+      await adapter.execute(queryA);
+      await adapter.execute(queryB);
+      const nameA = (query.mock.calls[0]?.[0] as { name: string }).name;
+      const nameB = (query.mock.calls[1]?.[0] as { name: string }).name;
+
+      // Touch queryA so queryB becomes the oldest entry.
+      await adapter.execute(queryA);
+      // Now queryC evicts queryB, not queryA.
+      await adapter.execute(queryC);
+      // Re-execute queryA: should reuse the existing name (no new entry).
+      await adapter.execute(queryA);
+
+      const namesUsed = query.mock.calls.map(
+        (call) => (call[0] as { name: string }).name,
+      );
+      // 5 calls total. queryA shows up 3× under nameA, queryB once under
+      // nameB (then evicted), queryC once under a fresh third name.
+      expect(namesUsed.filter((name) => name === nameA)).toHaveLength(3);
+      expect(namesUsed.filter((name) => name === nameB)).toHaveLength(1);
+      expect(new Set(namesUsed).size).toBe(3);
+    });
+
+    it("uses unnamed positional query when prepareStatements is false", async () => {
+      resetStatementNameCacheForTests();
+      const { db, query } = makeMockPgDb();
+      const adapter = createPostgresExecutionAdapter(db, {
+        prepareStatements: false,
+      });
+
+      await adapter.execute(sql`q1`);
+      await adapter.execute(sql`q2`);
+
+      for (const call of query.mock.calls) {
+        expect(typeof call[0]).toBe("string");
+        expect(Array.isArray(call[1])).toBe(true);
+      }
+    });
   });
 });

--- a/packages/typegraph/tests/execution-adapter.test.ts
+++ b/packages/typegraph/tests/execution-adapter.test.ts
@@ -207,10 +207,24 @@ describe("postgres execution adapter", () => {
   });
 
   it("exposes executeCompiled and prepare when raw client is available", async () => {
-    const query = vi.fn((sqlText: string, params: readonly unknown[]) =>
-      Promise.resolve({
-        rows: [{ params, sqlText }],
-      }),
+    // The fast path now wraps the node-postgres client to use named
+    // server-side prepared statements: it calls
+    // `client.query({name, text, values, types})` instead of
+    // `client.query(text, values)`. The mock accepts either shape so
+    // tests can assert on the meaningful payload (text, values).
+    type QueryArgument =
+      | string
+      | Readonly<{ name: string; text: string; values: readonly unknown[] }>;
+    const query = vi.fn(
+      (configOrSql: QueryArgument, paramsArgument?: readonly unknown[]) => {
+        const sqlText =
+          typeof configOrSql === "string" ? configOrSql : configOrSql.text;
+        const params =
+          typeof configOrSql === "string" ?
+            (paramsArgument ?? [])
+          : configOrSql.values;
+        return Promise.resolve({ rows: [{ params, sqlText }] });
+      },
     );
     const db = {
       $client: { query },
@@ -245,7 +259,13 @@ describe("postgres execution adapter", () => {
 
     expect(compiledRows[0]?.sqlText).toBe("SELECT $1");
     expect(compiledRows[0]?.params).toEqual([42]);
-    expect(query).toHaveBeenCalledWith("SELECT $1", [42]);
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expect.stringMatching(/^tg_\d+$/) as unknown,
+        text: "SELECT $1",
+        values: [42],
+      }),
+    );
 
     const prepare = adapter.prepare;
     if (prepare === undefined) {
@@ -260,6 +280,11 @@ describe("postgres execution adapter", () => {
     }>(["abc"]);
     expect(preparedRows[0]?.sqlText).toBe("SELECT $1");
     expect(preparedRows[0]?.params).toEqual(["abc"]);
-    expect(query).toHaveBeenCalledWith("SELECT $1", ["abc"]);
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "SELECT $1",
+        values: ["abc"],
+      }),
+    );
   });
 });

--- a/packages/typegraph/tests/no-transactions-fallthrough.test.ts
+++ b/packages/typegraph/tests/no-transactions-fallthrough.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Pins the contract for backends that report `transactions: false`
+ * (e.g. `drizzle-orm/neon-http`, Cloudflare D1).
+ *
+ * Wraps a real in-memory SQLite backend, flips `capabilities.transactions`
+ * off, and makes `backend.transaction(...)` throw — then walks every
+ * code path that historically wrapped its work in a transaction and
+ * asserts it now completes via the sequential fall-through instead of
+ * throwing. If a future change re-introduces an unconditional
+ * `backend.transaction(...)` in any of these paths, the corresponding
+ * test will fail with the synthetic transaction-disabled error.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+  searchable,
+} from "../src";
+import { computeSchemaHash, serializeSchema } from "../src/schema/serializer";
+import { createTestBackend } from "./test-utils";
+
+const TRANSACTIONS_DISABLED_MESSAGE =
+  "synthetic backend has transactions disabled";
+
+/**
+ * Wraps a real backend so any unconditional `transaction(...)` call
+ * throws — every other operation works normally. Mirrors the shape of
+ * `drizzle-orm/neon-http`'s session, which throws "No transactions
+ * support in neon-http driver" on `db.transaction(...)`.
+ */
+function disableTransactions(backend: GraphBackend): GraphBackend {
+  return {
+    ...backend,
+    capabilities: { ...backend.capabilities, transactions: false },
+    transaction: () => Promise.reject(new Error(TRANSACTIONS_DISABLED_MESSAGE)),
+  };
+}
+
+const Person = defineNode("Person", {
+  schema: z.object({
+    name: z.string(),
+    bio: z.string().optional(),
+  }),
+});
+
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "no_tx_fallthrough",
+  nodes: {
+    Person: { type: Person },
+    Company: { type: Company },
+  },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "many",
+    },
+  },
+});
+
+describe("backends with transactions: false fall through to sequential execution", () => {
+  let backend: GraphBackend;
+
+  beforeEach(() => {
+    backend = disableTransactions(createTestBackend());
+  });
+
+  it("synthetic backend rejects backend.transaction() (sanity)", async () => {
+    // If the wrapper ever stops throwing, the rest of this file becomes
+    // meaningless — assert the precondition explicitly.
+    await expect(
+      backend.transaction(() => Promise.resolve("unreachable")),
+    ).rejects.toThrow(TRANSACTIONS_DISABLED_MESSAGE);
+    expect(backend.capabilities.transactions).toBe(false);
+  });
+
+  it("setActiveSchema runs sequentially without throwing", async () => {
+    // Insert two real schema versions, then flip the active pointer.
+    // The toplevel backend used to wrap deactivate-all + activate in a
+    // transaction; the fall-through executes them as two sequential
+    // statements.
+    const v1 = serializeSchema(graph, 1);
+    const v2 = serializeSchema(graph, 2);
+
+    await backend.insertSchema({
+      graphId: graph.id,
+      version: 1,
+      schemaHash: await computeSchemaHash(v1),
+      schemaDoc: v1,
+      isActive: true,
+    });
+    await backend.insertSchema({
+      graphId: graph.id,
+      version: 2,
+      schemaHash: await computeSchemaHash(v2),
+      schemaDoc: v2,
+      isActive: false,
+    });
+
+    await expect(backend.setActiveSchema(graph.id, 2)).resolves.toBeUndefined();
+
+    const active = await backend.getActiveSchema(graph.id);
+    expect(active?.version).toBe(2);
+    expect(active?.is_active).toBe(true);
+  });
+
+  it("store.transaction(fn) executes fn against the main backend", async () => {
+    const store = createStore(graph, backend);
+
+    const result = await store.transaction(async (tx) => {
+      const person = await tx.nodes.Person.create({ name: "Alice" });
+      const company = await tx.nodes.Company.create({ name: "Acme" });
+      const edge = await tx.edges.worksAt.create(person, company, {
+        role: "Engineer",
+      });
+      return { personId: person.id, companyId: company.id, edgeId: edge.id };
+    });
+
+    // Writes are visible after the (non-atomic) callback returns.
+    const person = await store.nodes.Person.getById(result.personId);
+    expect(person?.name).toBe("Alice");
+    const company = await store.nodes.Company.getById(result.companyId);
+    expect(company?.name).toBe("Acme");
+  });
+
+  it("store.transaction errors propagate without rollback", async () => {
+    const store = createStore(graph, backend);
+    const persisted = await store.nodes.Person.create({ name: "Persisted" });
+
+    await expect(
+      store.transaction(async (tx) => {
+        await tx.nodes.Person.create({ name: "AlsoPersisted" });
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // Without transactions, prior writes inside the callback are NOT
+    // rolled back. This is the documented contract.
+    const allPeople = await store.nodes.Person.find();
+    expect(allPeople.map((person) => person.name).toSorted()).toEqual([
+      "AlsoPersisted",
+      "Persisted",
+    ]);
+    expect(persisted.id).toBeDefined();
+  });
+
+  it("store.batch returns per-query results without throwing", async () => {
+    const store = createStore(graph, backend);
+
+    await store.nodes.Person.create({ name: "Alice" });
+    await store.nodes.Person.create({ name: "Bob" });
+    await store.nodes.Company.create({ name: "Acme" });
+
+    const [people, companies] = await store.batch(
+      store
+        .query()
+        .from("Person", "p")
+        .select((ctx) => ({ name: ctx.p.name })),
+      store
+        .query()
+        .from("Company", "c")
+        .select((ctx) => ({ name: ctx.c.name })),
+    );
+
+    expect(people.map((p) => p.name).toSorted()).toEqual(["Alice", "Bob"]);
+    expect(companies.map((c) => c.name)).toEqual(["Acme"]);
+  });
+
+  it("store.search.rebuildFulltext completes via sequential page writes", async () => {
+    // The fulltext rebuild path used to wrap each page's upserts/deletes
+    // in backend.transaction(...). Verify it now runs the writes
+    // sequentially when the backend reports transactions: false.
+    const Document = defineNode("Document", {
+      schema: z.object({
+        title: searchable({ language: "english" }),
+        body: searchable({ language: "english" }),
+      }),
+    });
+    const documentGraph = defineGraph({
+      id: "no_tx_fallthrough_docs",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const store = createStore(documentGraph, backend);
+
+    await store.nodes.Document.create({
+      title: "First",
+      body: "alpha beta",
+    });
+    await store.nodes.Document.create({
+      title: "Second",
+      body: "gamma delta",
+    });
+
+    const result = await store.search.rebuildFulltext();
+    expect(result.kinds).toContain("Document");
+    expect(result.processed).toBe(2);
+    expect(result.upserted).toBe(2);
+    expect(result.skipped).toBe(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,10 +95,13 @@ importers:
         version: 12.9.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.2)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.2)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)(postgres@3.4.9)
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
       sqlite-vec:
         specifier: ^0.1.9
         version: 0.1.9
@@ -161,6 +164,9 @@ importers:
       '@libsql/client':
         specifier: ^0.17.2
         version: 0.17.2
+      '@neondatabase/serverless':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@stryker-mutator/core':
         specifier: ^9.6.1
         version: 9.6.1(@types/node@24.12.0)
@@ -187,7 +193,7 @@ importers:
         version: 12.9.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.2)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.2)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)(postgres@3.4.9)
       eslint:
         specifier: ^10.2.1
         version: 10.2.1(jiti@2.6.1)
@@ -197,6 +203,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
       sqlite-vec:
         specifier: ^0.1.9
         version: 0.1.9
@@ -1545,6 +1554,10 @@ packages:
 
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
+
+  '@neondatabase/serverless@1.1.0':
+    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
+    engines: {node: '>=19.0.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4828,6 +4841,10 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
+    engines: {node: '>=12'}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -7368,6 +7385,8 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
+  '@neondatabase/serverless@1.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8831,14 +8850,16 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.2)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.2)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)(postgres@3.4.9):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260307.1
       '@libsql/client': 0.17.2
+      '@neondatabase/serverless': 1.1.0
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.20.0
       better-sqlite3: 12.9.0
       pg: 8.20.0
+      postgres: 3.4.9
 
   dset@3.1.4: {}
 
@@ -11013,6 +11034,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres@3.4.9: {}
 
   prebuild-install@7.1.3:
     dependencies:


### PR DESCRIPTION
- **Four PostgreSQL drivers officially supported** via the same `createPostgresBackend(db)` entry point: `node-postgres`, `postgres-js`, `@neondatabase/serverless` (WebSocket Pool), and `@neondatabase/serverless` (HTTP). Driver detection, capability surface, and a fast-path execution adapter are all driver-aware. `neon-http` is auto-detected and `capabilities.transactions` is set to `false` so transactional code paths fall through to sequential execution rather than throwing.
- **~6× faster on multi-hop traversals** via server-side prepared statements on the node-postgres / neon-serverless fast path (3-hop: 7.5ms → 0.8ms median). Combined with bypassing Drizzle's session wrapper for raw SQL, this brings TypeGraph-on-PostgreSQL to parity with Neo4j 5.26 on every single-query and multi-hop shape we measure.
- **New `store.refreshStatistics()` / `backend.refreshStatistics()` API** that runs `ANALYZE` on the TypeGraph-managed tables. Without it the planner works from stale post-bulk-load stats — the difference between a 0.5ms and a 5ms forward traversal on PG, or a 0.9ms vs 23ms fulltext query on SQLite — until autovacuum catches up. Now a one-liner after any bulk import.
- **Edge-runtime safety**: the postgres execution adapter has zero static `node:*` imports, so `@nicia-ai/typegraph/postgres` loads cleanly on Cloudflare Workers / Vercel Edge.
- **Type surface change**: `GraphBackend` now requires `refreshStatistics(): Promise<void>`. `TransactionBackend` excludes it. External implementations (uncommon) need a no-op or proper implementation.
- **New options on `PostgresBackendOptions`**: `capabilities?: Partial<BackendCapabilities>` for explicit overrides on custom HTTP-style drivers.
- **Optional peer deps**: `pg`, `postgres`, and `@neondatabase/serverless` declared so installs surface the driver choice clearly.