### PR TITLE
feat: SQLite hybrid search via backend.vectorSearch facade

### DIFF
--- a/.changeset/sqlite-vector-search-facade.md
+++ b/.changeset/sqlite-vector-search-facade.md
@@ -1,0 +1,28 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+SQLite: implement `backend.vectorSearch`, unblocking `store.search.hybrid()` on SQLite.
+
+The hybrid retrieval facade has been Postgres-only since #88: SQLite shipped fulltext (`fulltextSearch`) and embedding persistence (`upsertEmbedding` / `deleteEmbedding`), but never the `vectorSearch` method that `executeHybridSearch` requires for RRF fusion. `.similarTo()` on SQLite still worked because the predicate path goes through the query compiler, not the backend facade — but anyone reaching for `store.search.hybrid()` on SQLite hit `ConfigurationError: Backend does not support vector search`.
+
+This release wires up the SQLite half of that contract:
+
+- `buildVectorSearchSqlite` issues `vec_distance_cosine` / `vec_distance_l2` against the embeddings BLOB column, mirroring the Postgres SQL shape (same WHERE / ORDER BY / score expression / minScore semantics).
+- `createSqliteBackend` exposes `vectorSearch` on the backend object whenever `hasVectorEmbeddings` is true (parallel to the existing `upsertEmbedding` gate).
+- `inner_product` is rejected — sqlite-vec has no `vec_distance_ip` function.
+
+```typescript
+import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+
+const { backend } = createLocalSqliteBackend(); // sqlite-vec auto-loaded
+const store = createStore(graph, backend);
+
+const ranked = await store.search.hybrid("Document", {
+  limit: 10,
+  vector: { fieldPath: "embedding", queryEmbedding },
+  fulltext: { query: "climate adaptation" },
+});
+```
+
+**Performance.** On the standard search-shapes bench (500 docs, 384-dim), SQLite hybrid clocks in at **0.8ms** — about 3× faster than PostgreSQL's 2.5ms on the same shape. The bench harness now measures it on both backends; the previously-blank SQLite cell in the search comparison table is filled in.

--- a/packages/benchmarks/src/backend.ts
+++ b/packages/benchmarks/src/backend.ts
@@ -34,10 +34,7 @@ type BackendResources = Readonly<{
    * PostgreSQL. The query-builder vector path uses this.
    */
   hasVectorPredicate: boolean;
-  /**
-   * True when `store.search.hybrid(...)` works. Requires the backend to
-   * implement the `vectorSearch` capability — currently PostgreSQL only.
-   */
+  /** True when `store.search.hybrid(...)` works. */
   hasHybridFacade: boolean;
 }>;
 
@@ -112,10 +109,7 @@ export async function createBackendResources(
         sqlite.close();
       },
       hasVectorPredicate: sqliteBackend.upsertEmbedding !== undefined,
-      // The SQLite backend doesn't implement the hybrid-search facade
-      // capability (no `backend.vectorSearch`); store.search.hybrid() is
-      // PostgreSQL-only today.
-      hasHybridFacade: false,
+      hasHybridFacade: sqliteBackend.vectorSearch !== undefined,
     };
   }
 

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -89,6 +89,7 @@ import {
   buildUpsertEmbeddingPostgres,
   buildUpsertEmbeddingSqlite,
   buildVectorSearchPostgres,
+  buildVectorSearchSqlite,
 } from "./vectors";
 
 export type CommonOperationStrategy = Readonly<{
@@ -194,15 +195,11 @@ export type PostgresVectorOperationStrategy = Readonly<{
 }>;
 
 /**
- * SQLite embedding operations. Uses sqlite-vec's `vec_f32('[...]')` to
- * encode embeddings as BLOBs on write. Requires the sqlite-vec extension
- * to be loaded on the connection; the backend factory checks for that
- * and only exposes the backend methods when it is.
+ * SQLite embedding operations.
  *
- * `getEmbedding` is not included: reading the raw BLOB back as a number
- * array requires `vec_to_json(...)` and additional row decoding, which
- * the current consumers (embedding sync, `.similarTo()` predicate) do
- * not need.
+ * `getEmbedding` is intentionally absent (asymmetry vs Postgres): reading
+ * the raw BLOB back as a number array requires `vec_to_json(...)` and
+ * additional row decoding, which no current consumer needs.
  */
 export type SqliteVectorOperationStrategy = Readonly<{
   buildUpsertEmbedding: (
@@ -210,6 +207,7 @@ export type SqliteVectorOperationStrategy = Readonly<{
     timestamp: string,
   ) => SQL;
   buildDeleteEmbedding: (params: DeleteEmbeddingParams) => SQL;
+  buildVectorSearch: (params: VectorSearchParams) => SQL;
 }>;
 
 export type SqliteOperationStrategy = Readonly<
@@ -371,6 +369,9 @@ export function createSqliteOperationStrategy(
     },
     buildDeleteEmbedding(params: DeleteEmbeddingParams): SQL {
       return buildDeleteEmbedding(tables, params);
+    },
+    buildVectorSearch(params: VectorSearchParams): SQL {
+      return buildVectorSearchSqlite(tables, params);
     },
   };
 }

--- a/packages/typegraph/src/backend/drizzle/operations/vectors.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/vectors.ts
@@ -221,6 +221,17 @@ function buildVectorSearchMinScoreCondition(
   }
 }
 
+function assertVectorSearchBounds(params: VectorSearchParams): void {
+  if (params.minScore !== undefined && !Number.isFinite(params.minScore)) {
+    throw new TypeError(
+      `minScore must be a finite number, got: ${params.minScore}`,
+    );
+  }
+  if (!Number.isInteger(params.limit) || params.limit <= 0) {
+    throw new Error(`limit must be a positive integer, got: ${params.limit}`);
+  }
+}
+
 /**
  * Builds a vector similarity search query (PostgreSQL).
  * Returns node IDs ordered by similarity (closest first).
@@ -231,21 +242,98 @@ export function buildVectorSearchPostgres(
 ): SQL {
   const { embeddings } = tables;
   const queryLiteral = formatEmbeddingLiteral(params.queryEmbedding);
-
-  if (params.minScore !== undefined && !Number.isFinite(params.minScore)) {
-    throw new TypeError(
-      `minScore must be a finite number, got: ${params.minScore}`,
-    );
-  }
-
-  if (!Number.isInteger(params.limit) || params.limit <= 0) {
-    throw new Error(`limit must be a positive integer, got: ${params.limit}`);
-  }
+  assertVectorSearchBounds(params);
 
   const embeddingColumn = sql`${embeddings.embedding}`;
   const distanceExpression = buildDistanceExpression(
     embeddingColumn,
     queryLiteral,
+    params.metric,
+  );
+
+  const conditions = [
+    sql`${embeddings.graphId} = ${params.graphId}`,
+    sql`${embeddings.nodeKind} = ${params.nodeKind}`,
+    sql`${embeddings.fieldPath} = ${params.fieldPath}`,
+  ];
+
+  if (params.minScore !== undefined) {
+    conditions.push(
+      buildVectorSearchMinScoreCondition(
+        distanceExpression,
+        params.metric,
+        params.minScore,
+      ),
+    );
+  }
+
+  const whereClause = sql.join(conditions, sql` AND `);
+  const scoreExpression = buildVectorSearchScoreExpression(
+    distanceExpression,
+    params.metric,
+  );
+
+  return sql`
+    SELECT
+      ${embeddings.nodeId} as node_id,
+      ${scoreExpression} as score
+    FROM ${embeddings}
+    WHERE ${whereClause}
+    ORDER BY ${distanceExpression} ASC
+    LIMIT ${params.limit}
+  `;
+}
+
+function buildSqliteDistanceExpression(
+  embeddingColumn: SQL,
+  embeddingJson: string,
+  metric: VectorMetric,
+): SQL {
+  switch (metric) {
+    case "cosine": {
+      return sql`vec_distance_cosine(${embeddingColumn}, vec_f32(${embeddingJson}))`;
+    }
+    case "l2": {
+      return sql`vec_distance_l2(${embeddingColumn}, vec_f32(${embeddingJson}))`;
+    }
+    case "inner_product": {
+      // sqlite-vec has no vec_distance_ip — see
+      // https://alexgarcia.xyz/sqlite-vec/api-reference.html.
+      throw new Error(
+        "Inner product distance is not supported by sqlite-vec. Use 'cosine' or 'l2' metrics instead.",
+      );
+    }
+    default: {
+      const _exhaustive: never = metric;
+      throw new Error(`Unsupported vector metric: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Builds a vector similarity search query (SQLite with sqlite-vec).
+ * Returns node IDs ordered by similarity (closest first).
+ *
+ * Requires sqlite-vec to be loaded on the connection; `createSqliteBackend`
+ * gates `vectorSearch` exposure on `hasVectorEmbeddings` so callers don't
+ * hit "no such function: vec_distance_cosine" at execution time.
+ */
+export function buildVectorSearchSqlite(
+  tables: SqliteTables,
+  params: VectorSearchParams,
+): SQL {
+  const { embeddings } = tables;
+
+  // Validate finite numbers BEFORE stringify so the error names the
+  // offending index (stringify would mask NaN/Infinity as null).
+  assertFiniteNumberArray(params.queryEmbedding, "queryEmbedding");
+  const embeddingJson = JSON.stringify(params.queryEmbedding);
+  assertVectorSearchBounds(params);
+
+  const embeddingColumn = sql`${embeddings.embedding}`;
+  const distanceExpression = buildSqliteDistanceExpression(
+    embeddingColumn,
+    embeddingJson,
     params.metric,
   );
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -45,6 +45,8 @@ import {
   type UpsertEmbeddingParams,
   type UpsertFulltextBatchParams,
   type UpsertFulltextParams,
+  type VectorSearchParams,
+  type VectorSearchResult,
 } from "../types";
 import {
   type AnySqliteDatabase,
@@ -213,6 +215,46 @@ function runWithSerializedQueue<T>(
   return queue.runExclusive(task);
 }
 
+// sqlite-vec exposes vec_distance_cosine and vec_distance_l2 but has no
+// vec_distance_ip — keep this list aligned with the SQLite dialect's
+// vectorMetrics so query compilation and capability advertising agree.
+const SQLITE_VECTOR_METRICS = ["cosine", "l2"] as const;
+// sqlite-vec doesn't expose explicit index types (vec0 manages indexing
+// internally); createSqliteVectorIndex is a no-op. "none" matches that
+// reality without claiming HNSW/IVFFlat support we don't have.
+const SQLITE_VECTOR_INDEX_TYPES = ["none"] as const;
+// sqlite-vec's vec_f32 has no documented hard cap, but practical ANN
+// performance degrades well before pgvector's 16k limit. 8000 is a
+// conservative ceiling consistent with the extension's typical use.
+const SQLITE_VECTOR_MAX_DIMENSIONS = 8000;
+
+function buildSqliteCapabilities(
+  options: Readonly<{
+    fulltextStrategy: FulltextStrategy;
+    hasVectorEmbeddings: boolean;
+    transactionMode: SqliteExecutionAdapter["profile"]["transactionMode"];
+  }>,
+): BackendCapabilities {
+  const base =
+    options.transactionMode === "none"
+      ? { ...SQLITE_CAPABILITIES, transactions: false }
+      : SQLITE_CAPABILITIES;
+  return {
+    ...base,
+    fulltext: buildFulltextCapabilities(options.fulltextStrategy),
+    ...(options.hasVectorEmbeddings
+      ? {
+          vector: {
+            supported: true,
+            metrics: SQLITE_VECTOR_METRICS,
+            indexTypes: SQLITE_VECTOR_INDEX_TYPES,
+            maxDimensions: SQLITE_VECTOR_MAX_DIMENSIONS,
+          },
+        }
+      : {}),
+  };
+}
+
 // ============================================================
 // Backend Factory
 // ============================================================
@@ -344,6 +386,18 @@ function createSqliteOperationBackend(
           async deleteEmbedding(params: DeleteEmbeddingParams): Promise<void> {
             const query = operationStrategy.buildDeleteEmbedding(params);
             await execRun(query);
+          },
+          async vectorSearch(
+            params: VectorSearchParams,
+          ): Promise<readonly VectorSearchResult[]> {
+            const query = operationStrategy.buildVectorSearch(params);
+            const rows = await execAll<{ node_id: string; score: number }>(
+              query,
+            );
+            return rows.map((row) => ({
+              nodeId: row.node_id,
+              score: row.score,
+            }));
           },
         }
       : {};
@@ -482,14 +536,16 @@ export function createSqliteBackend(
   const profileHints = options.executionProfile ?? {};
   const executionAdapter = createSqliteExecutionAdapter(db, { profileHints });
   const { isSync, transactionMode } = executionAdapter.profile;
-  const baseCapabilities: BackendCapabilities =
-    transactionMode === "none"
-      ? { ...SQLITE_CAPABILITIES, transactions: false }
-      : SQLITE_CAPABILITIES;
-  const capabilities: BackendCapabilities = {
-    ...baseCapabilities,
-    fulltext: buildFulltextCapabilities(fulltextStrategy),
-  };
+  // Explicit opt-in: wire upsertEmbedding / deleteEmbedding only when
+  // the caller confirms sqlite-vec is loaded. Probing synchronously
+  // isn't portable across drizzle SQLite drivers (sync vs async), so
+  // the gate lives with the caller that loaded the extension.
+  const hasVectorEmbeddings = options.hasVectorEmbeddings === true;
+  const capabilities: BackendCapabilities = buildSqliteCapabilities({
+    fulltextStrategy,
+    hasVectorEmbeddings,
+    transactionMode,
+  });
 
   const tableNames: SqlTableNames = {
     nodes: getTableName(tables.nodes),
@@ -502,11 +558,6 @@ export function createSqliteBackend(
     fulltextStrategy,
   );
   const serializedQueue = isSync ? createSerializedExecutionQueue() : undefined;
-  // Explicit opt-in: wire upsertEmbedding / deleteEmbedding only when
-  // the caller confirms sqlite-vec is loaded. Probing synchronously
-  // isn't portable across drizzle SQLite drivers (sync vs async), so
-  // the gate lives with the caller that loaded the extension.
-  const hasVectorEmbeddings = options.hasVectorEmbeddings === true;
   const operations = createSqliteOperationBackend({
     capabilities,
     db,

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -13,7 +13,7 @@ import {
   type BetterSQLite3Database,
   drizzle as drizzleBetterSqlite3,
 } from "drizzle-orm/better-sqlite3";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
@@ -940,6 +940,395 @@ describe("SQLite embedding persistence via createSqliteBackend", () => {
     });
     expect(backend.upsertEmbedding).toBeUndefined();
     expect(backend.deleteEmbedding).toBeUndefined();
+    expect(backend.vectorSearch).toBeUndefined();
+    expect(backend.capabilities.vector).toBeUndefined();
     sqlite.close();
+  });
+
+  it("advertises vector capabilities when hasVectorEmbeddings is true", () => {
+    const sqlite = new Database(":memory:");
+    for (const statement of generateSqliteDDL(tables)) {
+      sqlite.exec(statement);
+    }
+    const db = drizzleBetterSqlite3(sqlite);
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables,
+      hasVectorEmbeddings: true,
+    });
+    // Documented public capability check — consumers branch on this to
+    // decide whether to take SQLite vector/hybrid paths.
+    expect(backend.capabilities.vector?.supported).toBe(true);
+    expect(backend.capabilities.vector?.metrics).toEqual(["cosine", "l2"]);
+    expect(backend.capabilities.vector?.indexTypes).toEqual(["none"]);
+    expect(backend.capabilities.vector?.maxDimensions).toBeGreaterThan(0);
+    sqlite.close();
+  });
+});
+
+// ============================================================
+// SQLite backend.vectorSearch — facade for hybrid retrieval
+// ============================================================
+
+describe("SQLite backend.vectorSearch", () => {
+  type Harness = Readonly<{
+    backend: ReturnType<typeof createSqliteBackend>;
+    sqlite: Database.Database;
+    graphId: string;
+    nodeKind: string;
+    fieldPath: string;
+    seed: (
+      rows: readonly Readonly<{
+        nodeId: string;
+        embedding: readonly number[];
+      }>[],
+    ) => Promise<void>;
+    // Convenience: pre-narrowed methods so tests don't sprinkle non-null
+    // assertions. The harness only exists when sqlite-vec is loaded, which
+    // is exactly when these methods exist.
+    vectorSearch: NonNullable<
+      ReturnType<typeof createSqliteBackend>["vectorSearch"]
+    >;
+    upsertEmbedding: NonNullable<
+      ReturnType<typeof createSqliteBackend>["upsertEmbedding"]
+    >;
+  }>;
+
+  // `undefined` when sqlite-vec is not installed — tests early-return so
+  // the suite stays skip-friendly on platforms without the optional dep.
+  let harness: Harness | undefined;
+
+  beforeEach(() => {
+    const sqlite = new Database(":memory:");
+    try {
+      const module_ = nodeRequire("sqlite-vec") as {
+        load: (db: Database.Database) => void;
+      };
+      module_.load(sqlite);
+    } catch {
+      sqlite.close();
+      harness = undefined;
+      return;
+    }
+
+    for (const statement of generateSqliteDDL(tables)) {
+      sqlite.exec(statement);
+    }
+    const db = drizzleBetterSqlite3(sqlite);
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables,
+      hasVectorEmbeddings: true,
+    });
+
+    const graphId = "vector_search_facade";
+    const nodeKind = "Doc";
+    const fieldPath = "embedding";
+    const upsertEmbedding = backend.upsertEmbedding!;
+    const vectorSearch = backend.vectorSearch!;
+
+    async function seed(
+      rows: readonly Readonly<{
+        nodeId: string;
+        embedding: readonly number[];
+      }>[],
+    ): Promise<void> {
+      for (const row of rows) {
+        await upsertEmbedding({
+          graphId,
+          nodeKind,
+          nodeId: row.nodeId,
+          fieldPath,
+          embedding: row.embedding,
+          dimensions: row.embedding.length,
+        });
+      }
+    }
+
+    harness = {
+      backend,
+      sqlite,
+      graphId,
+      nodeKind,
+      fieldPath,
+      seed,
+      vectorSearch,
+      upsertEmbedding,
+    };
+  });
+
+  afterEach(() => {
+    harness?.sqlite.close();
+    harness = undefined;
+  });
+
+  it("exposes vectorSearch when sqlite-vec is loaded", () => {
+    if (!harness) return;
+    expect(harness.backend.vectorSearch).toBeDefined();
+  });
+
+  it("ranks identical embeddings first under cosine similarity", async () => {
+    if (!harness) return;
+
+    await harness.seed([
+      { nodeId: "doc-x", embedding: [1, 0, 0, 0] },
+      { nodeId: "doc-y", embedding: [0, 1, 0, 0] },
+      { nodeId: "doc-close", embedding: [0.9, 0.1, 0, 0] },
+    ]);
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "cosine",
+      limit: 3,
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results[0]!.nodeId).toBe("doc-x");
+    expect(results[0]!.score).toBeCloseTo(1, 5);
+    expect(results[1]!.nodeId).toBe("doc-close");
+    expect(results[2]!.nodeId).toBe("doc-y");
+    expect(results[2]!.score).toBeCloseTo(0, 5);
+  });
+
+  it("ranks identical embeddings first under L2 distance (lower score)", async () => {
+    if (!harness) return;
+
+    await harness.seed([
+      { nodeId: "doc-zero", embedding: [1, 0, 0, 0] },
+      { nodeId: "doc-near", embedding: [2, 0, 0, 0] },
+      { nodeId: "doc-far", embedding: [10, 0, 0, 0] },
+    ]);
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "l2",
+      limit: 3,
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results[0]!.nodeId).toBe("doc-zero");
+    expect(results[0]!.score).toBeCloseTo(0, 5);
+    expect(results[1]!.nodeId).toBe("doc-near");
+    expect(results[1]!.score).toBeCloseTo(1, 5);
+    expect(results[2]!.nodeId).toBe("doc-far");
+    expect(results[2]!.score).toBeGreaterThan(results[1]!.score);
+  });
+
+  it("rejects inner_product (sqlite-vec has no vec_distance_ip)", async () => {
+    if (!harness) return;
+
+    await harness.seed([{ nodeId: "doc-1", embedding: [1, 0, 0, 0] }]);
+
+    await expect(
+      harness.vectorSearch({
+        graphId: harness.graphId,
+        nodeKind: harness.nodeKind,
+        fieldPath: harness.fieldPath,
+        queryEmbedding: [1, 0, 0, 0],
+        metric: "inner_product",
+        limit: 5,
+      }),
+    ).rejects.toThrow(/inner product/i);
+  });
+
+  it("clips to limit when more rows match", async () => {
+    if (!harness) return;
+
+    const seed = Array.from({ length: 10 }, (_, index) => ({
+      nodeId: `doc-${index}`,
+      embedding: [Math.cos(index * 0.3), Math.sin(index * 0.3), 0, 0],
+    }));
+    await harness.seed(seed);
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "cosine",
+      limit: 3,
+    });
+
+    expect(results).toHaveLength(3);
+  });
+
+  it("filters out results below cosine minScore", async () => {
+    if (!harness) return;
+
+    await harness.seed([
+      { nodeId: "doc-identical", embedding: [1, 0, 0, 0] },
+      { nodeId: "doc-similar", embedding: [0.9, 0.1, 0, 0] },
+      { nodeId: "doc-orthogonal", embedding: [0, 1, 0, 0] },
+    ]);
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "cosine",
+      limit: 10,
+      minScore: 0.5,
+    });
+
+    const ids = results.map((row) => row.nodeId);
+    expect(ids).toContain("doc-identical");
+    expect(ids).toContain("doc-similar");
+    expect(ids).not.toContain("doc-orthogonal");
+    for (const row of results) {
+      expect(row.score).toBeGreaterThanOrEqual(0.5);
+    }
+  });
+
+  it("filters out results above L2 minScore (interpreted as max distance)", async () => {
+    if (!harness) return;
+
+    await harness.seed([
+      { nodeId: "doc-zero", embedding: [1, 0, 0, 0] },
+      { nodeId: "doc-near", embedding: [2, 0, 0, 0] },
+      { nodeId: "doc-far", embedding: [10, 0, 0, 0] },
+    ]);
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "l2",
+      limit: 10,
+      minScore: 2,
+    });
+
+    const ids = results.map((row) => row.nodeId);
+    expect(ids).toContain("doc-zero");
+    expect(ids).toContain("doc-near");
+    expect(ids).not.toContain("doc-far");
+  });
+
+  it("scopes results by graphId", async () => {
+    if (!harness) return;
+
+    await harness.seed([{ nodeId: "doc-here", embedding: [1, 0, 0, 0] }]);
+    await harness.upsertEmbedding({
+      graphId: "other_graph",
+      nodeKind: harness.nodeKind,
+      nodeId: "doc-elsewhere",
+      fieldPath: harness.fieldPath,
+      embedding: [1, 0, 0, 0],
+      dimensions: 4,
+    });
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "cosine",
+      limit: 10,
+    });
+
+    expect(results.map((row) => row.nodeId)).toEqual(["doc-here"]);
+  });
+
+  it("scopes results by nodeKind", async () => {
+    if (!harness) return;
+
+    await harness.seed([{ nodeId: "doc-here", embedding: [1, 0, 0, 0] }]);
+    await harness.upsertEmbedding({
+      graphId: harness.graphId,
+      nodeKind: "OtherKind",
+      nodeId: "other-node",
+      fieldPath: harness.fieldPath,
+      embedding: [1, 0, 0, 0],
+      dimensions: 4,
+    });
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "cosine",
+      limit: 10,
+    });
+
+    expect(results.map((row) => row.nodeId)).toEqual(["doc-here"]);
+  });
+
+  it("scopes results by fieldPath", async () => {
+    if (!harness) return;
+
+    await harness.seed([{ nodeId: "doc-here", embedding: [1, 0, 0, 0] }]);
+    await harness.upsertEmbedding({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      nodeId: "doc-here",
+      fieldPath: "secondary",
+      embedding: [1, 0, 0, 0],
+      dimensions: 4,
+    });
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "cosine",
+      limit: 10,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.nodeId).toBe("doc-here");
+  });
+
+  it("returns an empty array when no rows match", async () => {
+    if (!harness) return;
+
+    const results = await harness.vectorSearch({
+      graphId: harness.graphId,
+      nodeKind: harness.nodeKind,
+      fieldPath: harness.fieldPath,
+      queryEmbedding: [1, 0, 0, 0],
+      metric: "cosine",
+      limit: 10,
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it("rejects non-finite query embedding values", async () => {
+    if (!harness) return;
+
+    await expect(
+      harness.vectorSearch({
+        graphId: harness.graphId,
+        nodeKind: harness.nodeKind,
+        fieldPath: harness.fieldPath,
+        queryEmbedding: [1, Number.NaN, 0, 0],
+        metric: "cosine",
+        limit: 5,
+      }),
+    ).rejects.toThrow(/finite number/);
+  });
+
+  it("rejects non-positive limits", async () => {
+    if (!harness) return;
+
+    await expect(
+      harness.vectorSearch({
+        graphId: harness.graphId,
+        nodeKind: harness.nodeKind,
+        fieldPath: harness.fieldPath,
+        queryEmbedding: [1, 0, 0, 0],
+        metric: "cosine",
+        limit: 0,
+      }),
+    ).rejects.toThrow(/positive integer/);
   });
 });

--- a/packages/typegraph/tests/fulltext-search.test.ts
+++ b/packages/typegraph/tests/fulltext-search.test.ts
@@ -510,14 +510,28 @@ const HybridGraph = defineGraph({
 });
 
 describe("hybrid search (vector + FTS, RRF fusion)", () => {
-  it("throws clearly when vector search not supported (sqlite)", async () => {
-    // SQLite needs sqlite-vec to be loaded at runtime for vector ops; the
-    // test backend doesn't load it, so vectorSearch is missing. Our fusion
-    // helper should report this as a configuration error.
-    const backend = createTestBackend();
-    await backend.bootstrapTables?.();
-    const store = createStore(HybridGraph, backend);
+  it("throws clearly when vector search not supported (sqlite without sqlite-vec)", async () => {
+    // Construct the backend by hand without `hasVectorEmbeddings` so the
+    // no-extension case is exercised regardless of whether the test runner
+    // has sqlite-vec installed locally.
+    const drizzleModule = await import("drizzle-orm/better-sqlite3");
+    const betterSqlite3 = await import("better-sqlite3");
+    const Database = betterSqlite3.default;
+    const sqliteModule = await import("../src/backend/drizzle/sqlite");
+    const ddlModule = await import("../src/backend/drizzle/ddl");
 
+    const sqlite = new Database(":memory:");
+    for (const statement of ddlModule.generateSqliteDDL(sqliteModule.tables)) {
+      sqlite.exec(statement);
+    }
+    const db = drizzleModule.drizzle(sqlite);
+    const backend = sqliteModule.createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: sqliteModule.tables,
+    });
+    expect(backend.vectorSearch).toBeUndefined();
+
+    const store = createStore(HybridGraph, backend);
     await store.nodes.HybridDoc.create({
       title: "doc",
       body: "body",
@@ -534,6 +548,80 @@ describe("hybrid search (vector + FTS, RRF fusion)", () => {
         fulltext: { query: "doc" },
       }),
     ).rejects.toThrow(/vector search/);
+
+    sqlite.close();
+  });
+
+  it("fuses sqlite-vec and FTS5 results via RRF end-to-end", async () => {
+    const backend = createTestBackend();
+    if (backend.vectorSearch === undefined) return;
+    await backend.bootstrapTables?.();
+    const store = createStore(HybridGraph, backend);
+
+    const solar = await store.nodes.HybridDoc.create({
+      title: "Solar power",
+      body: "renewable energy from photovoltaics",
+      embedding: [1, 0, 0, 0],
+    });
+    const wind = await store.nodes.HybridDoc.create({
+      title: "Wind turbines",
+      body: "kinetic energy converted by rotors",
+      embedding: [0, 1, 0, 0],
+    });
+    const hydro = await store.nodes.HybridDoc.create({
+      title: "Hydroelectric dams",
+      body: "energy from controlled water flow",
+      embedding: [0, 0, 1, 0],
+    });
+
+    // Vector query targets `wind`; fulltext query targets `solar`. RRF
+    // should put one of those at the top, with `hydro` filling the
+    // long tail via the vector signal.
+    const results = await store.search.hybrid("HybridDoc", {
+      limit: 3,
+      vector: {
+        fieldPath: "embedding",
+        queryEmbedding: [0, 1, 0, 0],
+      },
+      fulltext: { query: "solar" },
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    const topId = results[0]!.node.id;
+    expect([solar.id, wind.id]).toContain(topId);
+
+    const fused = results.find(
+      (row) => row.vector !== undefined && row.fulltext !== undefined,
+    );
+    expect(fused).toBeDefined();
+
+    expect([solar.id, wind.id, hydro.id]).toContain(topId);
+  });
+
+  it("respects the limit on real SQLite hybrid fusion", async () => {
+    const backend = createTestBackend();
+    if (backend.vectorSearch === undefined) return;
+    await backend.bootstrapTables?.();
+    const store = createStore(HybridGraph, backend);
+
+    for (let index = 0; index < 5; index++) {
+      await store.nodes.HybridDoc.create({
+        title: `Doc ${index}`,
+        body: "shared keyword payload",
+        embedding: [Math.cos(index * 0.5), Math.sin(index * 0.5), 0, 0],
+      });
+    }
+
+    const results = await store.search.hybrid("HybridDoc", {
+      limit: 2,
+      vector: {
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+      },
+      fulltext: { query: "shared keyword" },
+    });
+
+    expect(results).toHaveLength(2);
   });
 
   it("RRF helper produces correct fused ordering for synthetic results", async () => {


### PR DESCRIPTION
`store.search.hybrid()` has been PostgreSQL-only since #88 — SQLite shipped fulltext (`fulltextSearch`) and embedding persistence (`upsertEmbedding` / `deleteEmbedding`) but never the `vectorSearch` method that `executeHybridSearch` needs for RRF fusion. `.similarTo()` worked through the predicate path; the hybrid facade threw `ConfigurationError: Backend does not support vector search`.

This PR wires up the SQLite half of that contract.

- `buildVectorSearchSqlite` issues `vec_distance_cosine` / `vec_distance_l2` against the embeddings BLOB column, mirroring the Postgres SQL shape (same WHERE / ORDER BY / score expression / minScore semantics).
- `createSqliteBackend` exposes `vectorSearch` whenever `hasVectorEmbeddings` is true (parallel to the existing `upsertEmbedding` / `deleteEmbedding` gate).
- `inner_product` is rejected — sqlite-vec has no `vec_distance_ip` function.
- Bench harness flips `hasHybridFacade` to track `sqliteBackend.vectorSearch`; the previously-blank SQLite cell in the search-comparison table is filled in.

## Performance

On the standard search-shapes bench (500 docs, 384-dim) on this machine:

| Query                           | SQLite | PostgreSQL |
| ------------------------------- | ------ | ---------- |
| Fulltext search (BM25-like)     | 0.7ms  | 1.6ms      |
| Vector search (cosine top-20)   | 0.8ms  | 1.1ms      |
| Hybrid (fulltext + vector, RRF) | **0.8ms**  | 2.5ms      |