### PR TITLE
feat: per-kind metadata on defineNode/defineEdge (#102)

### DIFF
--- a/.changeset/per-kind-annotations.md
+++ b/.changeset/per-kind-annotations.md
@@ -1,0 +1,41 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add optional `annotations` field to `defineNode` and `defineEdge` for consumer-owned per-kind structured data — UI hints, audit policy, provenance pointers, and other tooling labels that don't belong in the Zod schema.
+
+```typescript
+const Incident = defineNode("Incident", {
+  schema: z.object({
+    title: z.string(),
+    summary: z.string(),
+    occurredAt: z.string().datetime(),
+  }),
+  annotations: {
+    ui: {
+      titleField: "title",
+      temporalField: "occurredAt",
+      icon: "alert-triangle",
+    },
+    audit: {
+      pii: false,
+      retentionDays: 365,
+    },
+  },
+});
+
+const reportedBy = defineEdge("reportedBy", {
+  annotations: {
+    ui: { showInTimeline: true },
+  },
+});
+```
+
+**Contract:**
+
+- TypeGraph stores and versions `annotations` but never reads, validates, or interprets keys inside the field. Consumers own the entire namespace — no reserved prefixes, no `x-typegraph` extension convention. Future library-owned per-kind state, if needed, will use a separate sibling field rather than carving out keys here.
+- Annotations are included in `SerializedSchema.{nodes,edges}[*].annotations` and contribute to schema hashing with stable sorted-key ordering. Changes surface as `safe`-severity diffs through `getSchemaChanges()` / `SchemaManager`, so reformatting the annotations object doesn't bump the version, but value or structure changes do.
+- Graphs that never set `annotations` produce identical canonical-form hashes to today — adoption requires no migration. An explicit empty object (`{}`) is a structural opt-in and bumps the hash.
+- Values must be JSON-serializable. The `KindAnnotations` type is `Readonly<Record<string, JsonValue>>`, and at runtime `defineNode` / `defineEdge` reject `bigint`, `function`, `symbol`, `undefined`, `Date`, and other class instances with a `ConfigurationError` — so accidentally-non-JSON annotations can never silently break hashing or storage round-trips.
+
+Closes #102.

--- a/apps/docs/src/content/docs/schema-evolution.md
+++ b/apps/docs/src/content/docs/schema-evolution.md
@@ -29,6 +29,7 @@ These changes are backwards compatible and auto-migrate without intervention:
 - Adding new edge types
 - Adding optional properties (with defaults)
 - Adding ontology relations
+- Changing per-kind annotations (UI hints, audit policy, etc.)
 
 ### Adding an Optional Property
 
@@ -78,6 +79,62 @@ const graph = defineGraph({
 
 This is a single safe migration. New node and edge types don't affect existing
 data.
+
+### Changing Annotations
+
+The `annotations` field on `defineNode` and `defineEdge` is part of the canonical
+schema, so any change bumps the schema version. Changes are classified as
+`safe` — no data migration needed, only the schema document is updated.
+
+```typescript
+// Version 1
+const Incident = defineNode("Incident", {
+  schema: z.object({ title: z.string() }),
+  annotations: {
+    ui: { titleField: "title", icon: "alert-triangle" },
+  },
+});
+
+// Version 2 — swap the icon, add audit policy
+const Incident = defineNode("Incident", {
+  schema: z.object({ title: z.string() }),
+  annotations: {
+    ui: { titleField: "title", icon: "circle-alert" },
+    audit: { pii: false, retentionDays: 365 },
+  },
+});
+```
+
+`getSchemaChanges()` reports each annotations-only change per kind:
+
+```typescript
+import { getSchemaChanges } from "@nicia-ai/typegraph/schema";
+
+const diff = await getSchemaChanges(backend, graph);
+
+for (const change of diff?.nodes ?? []) {
+  if (change.details.includes("Annotations")) {
+    console.log(`${change.kind}: annotations changed (${change.severity})`);
+    // → "Incident: annotations changed (safe)"
+  }
+}
+```
+
+The hash is computed with stable sorted-key order at every depth, so
+re-formatting the annotations object — or swapping sibling key order — does
+not bump the version. Only structural or value changes do.
+
+A few things worth knowing:
+
+- Graphs that never set `annotations` produce identical canonical-form hashes
+  to graphs from before this field existed. Adoption requires no migration.
+- An explicit empty object (`annotations: {}`) is a structural opt-in and
+  bumps the hash — use the absent form to stay on the legacy hash.
+- Annotations values must be JSON-serializable (`bigint`, `function`, `Date`,
+  and other class instances are rejected at definition time).
+
+See the [schemas-stores reference](/schemas-stores#per-kind-annotations) for the
+full annotations contract.
 
 ## Breaking Changes
 
@@ -377,6 +434,7 @@ console.log("Current version:", active?.version);
 | Add edge type                  | Safe           | Yes            |
 | Add optional property          | Safe           | Yes            |
 | Add ontology relation          | Safe           | Yes            |
+| Change kind annotations           | Safe           | Yes            |
 | Add required property          | Breaking       | No             |
 | Remove property                | Breaking       | No             |
 | Remove node/edge type          | Breaking       | No             |
@@ -450,5 +508,5 @@ if (result.status === "migrated" && result.toVersion === 3) {
 - **Schema-level only.** Migrations operate on the graph definition, not on
   underlying database tables. TypeGraph's storage tables are
   schema-agnostic (nodes and edges are stored as JSON properties), so
-  "schema migration" means updating the metadata that TypeGraph tracks, not
-  running `ALTER TABLE`.
+  "schema migration" means updating the schema document that TypeGraph
+  tracks, not running `ALTER TABLE`.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -19,6 +19,7 @@ function defineNode<K extends string, S extends z.ZodObject<any>>(
   options: {
     schema: S;
     description?: string;
+    annotations?: Readonly<Record<string, JsonValue>>;
   },
 ): NodeType<K, S>;
 ```
@@ -30,6 +31,7 @@ function defineNode<K extends string, S extends z.ZodObject<any>>(
 | `name` | `string` | Unique name for this node type |
 | `options.schema` | `z.ZodObject` | Zod object schema for node properties |
 | `options.description` | `string` | Optional description |
+| `options.annotations` | `KindAnnotations` | Optional consumer-owned per-kind annotations. See [Per-kind annotations](#per-kind-annotations). |
 
 **Example:**
 
@@ -40,6 +42,29 @@ const Person = defineNode("Person", {
     email: z.string().email().optional(),
   }),
   description: "A person in the system",
+});
+```
+
+**With annotations:**
+
+```typescript
+const Incident = defineNode("Incident", {
+  schema: z.object({
+    title: z.string(),
+    summary: z.string(),
+    occurredAt: z.string().datetime(),
+  }),
+  annotations: {
+    ui: {
+      titleField: "title",
+      temporalField: "occurredAt",
+      icon: "alert-triangle",
+    },
+    audit: {
+      pii: false,
+      retentionDays: 365,
+    },
+  },
 });
 ```
 
@@ -55,6 +80,7 @@ function defineEdge<K extends string, S extends z.ZodObject<any>>(
   options?: {
     schema?: S;
     description?: string;
+    annotations?: Readonly<Record<string, JsonValue>>;
     from?: NodeType[];
     to?: NodeType[];
   },
@@ -68,6 +94,7 @@ function defineEdge<K extends string, S extends z.ZodObject<any>>(
 | `name` | `string` | Unique name for this edge type |
 | `options.schema` | `z.ZodObject` | Optional Zod object schema (defaults to empty object) |
 | `options.description` | `string` | Optional description |
+| `options.annotations` | `KindAnnotations` | Optional consumer-owned per-kind annotations. See [Per-kind annotations](#per-kind-annotations). |
 | `options.from` | `NodeType[]` | Optional domain constraint (valid source node types) |
 | `options.to` | `NodeType[]` | Optional range constraint (valid target node types) |
 
@@ -82,6 +109,19 @@ const worksAt = defineEdge("worksAt", {
 });
 
 const knows = defineEdge("knows"); // No schema needed
+```
+
+**With annotations:**
+
+```typescript
+const reportedBy = defineEdge("reportedBy", {
+  schema: z.object({ channel: z.string() }),
+  from: [Incident],
+  to: [Person],
+  annotations: {
+    ui: { showInTimeline: true, badge: "report" },
+  },
+});
 ```
 
 **With Domain/Range Constraints:**
@@ -126,6 +166,70 @@ const graph = defineGraph({
 ```
 
 See [Core Concepts](/core-concepts#domain-and-range-constraints) for detailed documentation on domain/range constraints.
+
+### Per-kind annotations
+
+Both `defineNode` and `defineEdge` accept an optional `annotations` field — a
+plain JSON object for consumer-owned, structured per-kind data that doesn't
+belong in the Zod schema. Common uses:
+
+- **Generic UI rendering.** Which property is the title for list views? Which
+  is the canonical date for sorting? Which icon represents the kind?
+- **Audit and compliance hints.** Mark a kind as PII, set retention windows,
+  attach data-classification labels.
+- **Tooling annotations.** Group kinds in catalogs, mark provenance
+  ("originated from agent run X"), attach feature-flag gates.
+
+```typescript
+const Incident = defineNode("Incident", {
+  schema: z.object({
+    title: z.string(),
+    occurredAt: z.string().datetime(),
+  }),
+  annotations: {
+    ui: { titleField: "title", temporalField: "occurredAt", icon: "alert-triangle" },
+    audit: { pii: false, retentionDays: 365 },
+  },
+});
+```
+
+Reading annotations back from a kind:
+
+```typescript
+const titleField = (Incident.annotations?.ui as { titleField?: string })?.titleField;
+```
+
+Or from a stored schema:
+
+```typescript
+import { getSchemaChanges, getActiveSchema } from "@nicia-ai/typegraph/schema";
+
+const stored = await getActiveSchema(backend, "my_graph");
+const incidentMeta = stored?.nodes.Incident?.annotations;
+```
+
+**Key guarantees and constraints:**
+
+- **TypeGraph never reads, validates, or interprets keys inside `annotations`.**
+  Consumers own the entire namespace — no reserved prefixes, no `x-typegraph`
+  extension convention. Future library-owned per-kind state, if needed, will
+  use a separate sibling field rather than carving out keys here.
+- **Annotations participate in schema hashing and migration diffs.** Changing
+  `annotations` bumps the schema version like any other structural change, and
+  the diff is reported as a `safe`-severity change per kind. See
+  [Schema Evolution](/schema-evolution#changing-annotations).
+- **Values must be JSON-serializable.** Strings, numbers, booleans, `null`,
+  arrays, and plain objects only. `bigint`, `function`, `symbol`, `undefined`,
+  `Date`, `Map`, `Set`, and other class instances are rejected at definition
+  time with a `ConfigurationError` so they can never silently break hashing or
+  storage round-trips.
+- **Default is `undefined`, not `{}`.** Graphs that never set `annotations`
+  produce identical canonical-form hashes to graphs from before this field
+  existed — adoption requires no migration. An explicit empty object (`{}`)
+  is a structural opt-in and bumps the hash.
+- **Annotations are not a typed contract.** TypeScript types them as
+  `Readonly<Record<string, JsonValue>>`. Wrap reads in your own typed
+  accessors at consumer boundaries if you need stronger guarantees.
 
 ### `embedding(dimensions)`
 

--- a/packages/typegraph/src/core/edge.ts
+++ b/packages/typegraph/src/core/edge.ts
@@ -4,7 +4,13 @@ import {
   assertSchemaKeysAreFree,
   RESERVED_EDGE_KEYS,
 } from "../store/reserved-keys";
-import { EDGE_TYPE_BRAND, type EdgeType, type NodeType } from "./types";
+import { assertJsonValue } from "./json-value";
+import {
+  EDGE_TYPE_BRAND,
+  type EdgeType,
+  type KindAnnotations,
+  type NodeType,
+} from "./types";
 
 // ============================================================
 // Edge Factory Options
@@ -22,6 +28,14 @@ export type DefineEdgeOptions<
   schema?: S;
   /** Optional description for documentation */
   description?: string;
+  /**
+   * Consumer-owned structured annotations for the kind.
+   *
+   * Stored in the canonical schema and **participates in schema hashing** —
+   * any change bumps the schema version and shows up as a `safe`-severity
+   * diff in `getSchemaChanges`. See `KindAnnotations` for the contract.
+   */
+  annotations?: KindAnnotations;
   /** Node types that can be the source of this edge (domain constraint) */
   from?: From;
   /** Node types that can be the target of this edge (range constraint) */
@@ -108,12 +122,16 @@ export function defineEdge<
 ): EdgeType<K, S, From, To> | EdgeType<K, EmptySchema> {
   const schema = options?.schema ?? EMPTY_SCHEMA;
   validateSchemaKeys(schema, name);
+  if (options?.annotations !== undefined) {
+    assertJsonValue(options.annotations, "annotations", `Edge "${name}"`);
+  }
 
   return Object.freeze({
     [EDGE_TYPE_BRAND]: true as const,
     kind: name,
     schema,
     description: options?.description,
+    annotations: options?.annotations,
     from: options?.from,
     to: options?.to,
   }) as EdgeType<K, S, From, To> | EdgeType<K, EmptySchema>;

--- a/packages/typegraph/src/core/index.ts
+++ b/packages/typegraph/src/core/index.ts
@@ -68,6 +68,8 @@ export {
   isEdgeType,
   isEdgeTypeWithEndpoints,
   isNodeType,
+  type JsonValue,
+  type KindAnnotations,
   type NodeId,
   type NodeProps,
   type NodeRegistration,

--- a/packages/typegraph/src/core/json-value.ts
+++ b/packages/typegraph/src/core/json-value.ts
@@ -1,0 +1,101 @@
+/**
+ * Runtime validation for JSON-serializable values.
+ *
+ * Used at definition-time boundaries (e.g., `defineNode`/`defineEdge` annotations)
+ * to reject values that would silently break `JSON.stringify` round-trips or
+ * throw at hash time. Catches accidental violations from untyped JS callers
+ * and `as any` escape hatches that bypass the `JsonValue` type.
+ */
+import { ConfigurationError } from "../errors";
+
+/**
+ * Asserts that `value` is JSON-serializable.
+ *
+ * Throws `ConfigurationError` with a dotted path identifying the offending
+ * field. Rejects `bigint`, `function`, `symbol`, `undefined`, and class
+ * instances such as `Date`, `Map`, `Set`, regex literals, and Buffers — all
+ * of which either throw or silently coerce under `JSON.stringify`.
+ *
+ * @param value - The value to validate
+ * @param rootLabel - Label for the root of the value (e.g., `"annotations"`)
+ *   used as the prefix of the error path
+ * @param ownerKind - Human-readable owner identifier for the error message
+ *   (e.g., `'Node "Person"'`)
+ */
+export function assertJsonValue(
+  value: unknown,
+  rootLabel: string,
+  ownerKind: string,
+): void {
+  walk(value, rootLabel, ownerKind);
+}
+
+function walk(value: unknown, path: string, ownerKind: string): void {
+  if (value === null) return;
+  const valueType = typeof value;
+  if (valueType === "number") {
+    // NaN/Infinity/-Infinity are not JSON values; JSON.stringify silently
+    // coerces them to `null`, which would change the canonical hash input
+    // without the consumer noticing.
+    if (!Number.isFinite(value)) {
+      throwInvalid(path, describeNonFinite(value as number), ownerKind);
+    }
+    return;
+  }
+  if (valueType === "string" || valueType === "boolean") return;
+  if (
+    valueType === "bigint" ||
+    valueType === "function" ||
+    valueType === "symbol" ||
+    valueType === "undefined"
+  ) {
+    throwInvalid(path, valueType, ownerKind);
+  }
+  if (Array.isArray(value)) {
+    for (const [index, element] of value.entries()) {
+      walk(element, `${path}[${index}]`, ownerKind);
+    }
+    return;
+  }
+  if (!isPlainObject(value)) {
+    throwInvalid(path, describeNonPlain(value), ownerKind);
+  }
+  for (const [key, nested] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    walk(nested, `${path}.${key}`, ownerKind);
+  }
+}
+
+function isPlainObject(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const prototype: unknown = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function describeNonFinite(value: number): string {
+  if (Number.isNaN(value)) return "NaN";
+  if (value === Number.POSITIVE_INFINITY) return "Infinity";
+  if (value === Number.NEGATIVE_INFINITY) return "-Infinity";
+  return "non-finite number";
+}
+
+function describeNonPlain(value: unknown): string {
+  const constructorName = (value as { constructor?: { name?: unknown } } | null)
+    ?.constructor?.name;
+  if (typeof constructorName === "string" && constructorName.length > 0) {
+    return `${constructorName} instance`;
+  }
+  return "non-plain object";
+}
+
+function throwInvalid(path: string, kind: string, ownerKind: string): never {
+  throw new ConfigurationError(
+    `${ownerKind} ${path} contains a non-JSON value (${kind}). Annotations must be JSON-serializable.`,
+    { path, valueKind: kind },
+    {
+      suggestion:
+        "Use only strings, numbers, booleans, null, arrays, and plain objects in annotations.",
+    },
+  );
+}

--- a/packages/typegraph/src/core/node.ts
+++ b/packages/typegraph/src/core/node.ts
@@ -4,7 +4,8 @@ import {
   assertSchemaKeysAreFree,
   RESERVED_NODE_KEYS,
 } from "../store/reserved-keys";
-import { NODE_TYPE_BRAND, type NodeType } from "./types";
+import { assertJsonValue } from "./json-value";
+import { type KindAnnotations, NODE_TYPE_BRAND, type NodeType } from "./types";
 
 // ============================================================
 // Node Factory Options
@@ -18,6 +19,14 @@ export type DefineNodeOptions<S extends z.ZodObject<z.ZodRawShape>> = Readonly<{
   schema: S;
   /** Optional description for documentation */
   description?: string;
+  /**
+   * Consumer-owned structured annotations for the kind.
+   *
+   * Stored in the canonical schema and **participates in schema hashing** —
+   * any change bumps the schema version and shows up as a `safe`-severity
+   * diff in `getSchemaChanges`. See `KindAnnotations` for the contract.
+   */
+  annotations?: KindAnnotations;
 }>;
 
 // ============================================================
@@ -55,11 +64,15 @@ export function defineNode<
   S extends z.ZodObject<z.ZodRawShape>,
 >(name: K, options: DefineNodeOptions<S>): NodeType<K, S> {
   validateSchemaKeys(options.schema, name);
+  if (options.annotations !== undefined) {
+    assertJsonValue(options.annotations, "annotations", `Node "${name}"`);
+  }
 
   return Object.freeze({
     [NODE_TYPE_BRAND]: true as const,
     kind: name,
     schema: options.schema,
     description: options.description,
+    annotations: options.annotations,
   });
 }

--- a/packages/typegraph/src/core/types.ts
+++ b/packages/typegraph/src/core/types.ts
@@ -21,6 +21,44 @@ declare const __edgeId: unique symbol;
 // ============================================================
 
 /**
+ * Any JSON-serializable value.
+ *
+ * Mirrors the JSON wire format: primitives, arrays, and string-keyed objects.
+ * `null` is included because the JSON spec requires it for "no value here";
+ * this is the one place in the public API that uses `null` over `undefined`.
+ */
+export type JsonValue =
+  | null
+  | string
+  | number
+  | boolean
+  | readonly JsonValue[]
+  | Readonly<{ [key: string]: JsonValue }>;
+
+/**
+ * Consumer-owned per-kind annotations.
+ *
+ * Stable labels attached to a node or edge kind at definition time — UI hints,
+ * audit policy, provenance pointers, tooling annotations.
+ *
+ * **Consumer-owned, fully.** TypeGraph never reads, validates, or interprets
+ * values in this field. Consumers own the entire namespace; there are no
+ * reserved keys or extension prefixes. Future library-owned per-kind state,
+ * if needed, will use a separate sibling field rather than carving out keys
+ * here.
+ *
+ * **Annotations participate in schema hashing.** Any change to an annotation
+ * value (or adding/removing an annotation key) bumps the canonical schema
+ * hash and is reported as a `safe`-severity diff by `getSchemaChanges`. If
+ * you don't want versioning for a piece of state, do not put it here.
+ *
+ * Values must be JSON-serializable — `bigint`, `function`, `symbol`, `undefined`,
+ * `Date`, and other class instances are rejected at definition time so they can
+ * never silently break schema hashing or storage round-trips.
+ */
+export type KindAnnotations = Readonly<Record<string, JsonValue>>;
+
+/**
  * A node type definition.
  *
  * Created via `defineNode()`. Represents a type of node in the graph
@@ -34,6 +72,7 @@ export type NodeType<
   kind: K;
   schema: S;
   description: string | undefined;
+  annotations: KindAnnotations | undefined;
 }>;
 
 /**
@@ -74,6 +113,7 @@ export type EdgeType<
   kind: K;
   schema: S;
   description: string | undefined;
+  annotations: KindAnnotations | undefined;
   from: From;
   to: To;
 }>;

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -134,6 +134,8 @@ export type {
   EdgeTypeWithEndpoints,
   EndpointExistence,
   GraphDefaults,
+  JsonValue,
+  KindAnnotations,
   MetaEdgeOptions,
   NodeId,
   NodeProps,

--- a/packages/typegraph/src/schema/canonical.ts
+++ b/packages/typegraph/src/schema/canonical.ts
@@ -1,0 +1,44 @@
+/**
+ * Canonical-form helpers for deterministic schema serialization.
+ *
+ * Used by both content-hashing (`computeSchemaHash`) and structural diffing
+ * (`computeSchemaDiff`) to ensure that semantically-equivalent objects with
+ * differently-ordered keys produce identical canonical strings.
+ */
+
+/**
+ * `JSON.stringify` replacer that sorts object keys recursively.
+ *
+ * Apply via `JSON.stringify(value, sortedReplacer)` to obtain output in
+ * which sibling keys at every depth appear in lexicographic order.
+ *
+ * Arrays are passed through unchanged — array order is semantically
+ * meaningful and must not be normalized.
+ */
+export function sortedReplacer(_key: string, value: unknown): unknown {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      sorted[key] = (value as Record<string, unknown>)[key];
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Compare two values for canonical-form equality.
+ *
+ * Returns `true` when both values produce identical JSON under `sortedReplacer`
+ * — i.e., they have the same JSON structure regardless of object key order.
+ * Used by diff machinery to detect semantic changes in JSON-shaped fields.
+ *
+ * Note: callers must handle `undefined` themselves — `JSON.stringify(undefined)`
+ * returns `undefined`, so two `undefined` inputs would compare equal here, which
+ * may or may not be the desired semantics depending on context.
+ */
+export function canonicalEqual(a: unknown, b: unknown): boolean {
+  return (
+    JSON.stringify(a, sortedReplacer) === JSON.stringify(b, sortedReplacer)
+  );
+}

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -4,6 +4,7 @@
  * Provides diff detection between schema versions to identify
  * what has changed and what migrations might be needed.
  */
+import { canonicalEqual } from "./canonical";
 import {
   type SerializedEdgeDef,
   type SerializedNodeDef,
@@ -275,6 +276,17 @@ function diffNodeDef(
     });
   }
 
+  if (annotationsChanged(before.annotations, after.annotations)) {
+    changes.push({
+      type: "modified",
+      kind: name,
+      severity: "safe",
+      details: `Annotations changed for "${name}"`,
+      before,
+      after,
+    });
+  }
+
   return changes;
 }
 
@@ -428,7 +440,24 @@ function diffEdgeDef(
     });
   }
 
+  if (annotationsChanged(before.annotations, after.annotations)) {
+    changes.push({
+      type: "modified",
+      kind: name,
+      severity: "safe",
+      details: `Annotations changed for "${name}"`,
+      before,
+      after,
+    });
+  }
+
   return changes;
+}
+
+function annotationsChanged(before: unknown, after: unknown): boolean {
+  if (before === undefined && after === undefined) return false;
+  if (before === undefined || after === undefined) return true;
+  return !canonicalEqual(before, after);
 }
 
 // ============================================================

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -23,6 +23,7 @@ import {
 } from "../ontology/types";
 import { computeClosuresFromOntology } from "../registry/kind-registry";
 import { nowIso } from "../utils/date";
+import { sortedReplacer } from "./canonical";
 import {
   type JsonSchema,
   type SchemaHash,
@@ -102,6 +103,9 @@ function serializeNodeDef(registration: NodeRegistration): SerializedNodeDef {
     uniqueConstraints: serializeUniqueConstraints(registration.unique ?? []),
     onDelete: registration.onDelete ?? "restrict",
     description: node.description,
+    ...(node.annotations === undefined ?
+      {}
+    : { annotations: node.annotations }),
   };
 }
 
@@ -257,6 +261,9 @@ function serializeEdgeDef(registration: EdgeRegistration): SerializedEdgeDef {
     cardinality: registration.cardinality ?? "many",
     endpointExistence: registration.endpointExistence ?? "notDeleted",
     description: edge.description,
+    ...(edge.annotations === undefined ?
+      {}
+    : { annotations: edge.annotations }),
   };
 }
 
@@ -439,20 +446,6 @@ export async function computeSchemaHash(
   // Serialize with sorted keys for deterministic output
   const json = JSON.stringify(hashable, sortedReplacer);
   return sha256Hash(json);
-}
-
-/**
- * JSON replacer that sorts object keys for deterministic serialization.
- */
-function sortedReplacer(_key: string, value: unknown): unknown {
-  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-    const sorted: Record<string, unknown> = {};
-    for (const key of Object.keys(value).toSorted()) {
-      sorted[key] = (value as Record<string, unknown>)[key];
-    }
-    return sorted;
-  }
-  return value;
 }
 
 /**

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -14,6 +14,7 @@ import {
   type Collation,
   type DeleteBehavior,
   type EndpointExistence,
+  type KindAnnotations,
   type TemporalMode,
   type UniquenessScope,
 } from "../core/types";
@@ -182,6 +183,7 @@ export type SerializedNodeDef = Readonly<{
   uniqueConstraints: readonly SerializedUniqueConstraint[];
   onDelete: DeleteBehavior;
   description: string | undefined;
+  annotations?: KindAnnotations;
 }>;
 
 // ============================================================
@@ -199,6 +201,7 @@ export type SerializedEdgeDef = Readonly<{
   cardinality: Cardinality;
   endpointExistence: EndpointExistence;
   description: string | undefined;
+  annotations?: KindAnnotations;
 }>;
 
 // ============================================================
@@ -265,6 +268,7 @@ export const serializedSchemaZod = z.object({
           ),
           onDelete: deleteBehaviorZod,
           description: z.string().optional(),
+          annotations: z.record(z.string(), z.json()).optional(),
         })
         .loose(),
     )
@@ -281,6 +285,7 @@ export const serializedSchemaZod = z.object({
           cardinality: cardinalityZod,
           endpointExistence: endpointExistenceZod,
           description: z.string().optional(),
+          annotations: z.record(z.string(), z.json()).optional(),
         })
         .loose(),
     )

--- a/packages/typegraph/test-d/public-api.test-d.ts
+++ b/packages/typegraph/test-d/public-api.test-d.ts
@@ -12,6 +12,7 @@ import {
   type EdgeId,
   getEdgeKinds,
   getNodeKinds,
+  type KindAnnotations,
   type NodeId,
   type NodeRef,
   type Store,
@@ -43,6 +44,58 @@ const worksAt = defineEdge("worksAt", {
 });
 
 const knows = defineEdge("knows");
+
+const Incident = defineNode("Incident", {
+  schema: z.object({
+    title: z.string(),
+  }),
+  annotations: {
+    ui: { titleField: "title" },
+  },
+});
+
+const reportedBy = defineEdge("reportedBy", {
+  annotations: {
+    ui: { showInTimeline: true },
+  },
+});
+
+// KindAnnotations rejects non-JSON values at the type level.
+expectError(
+  defineNode("BadBigInt", {
+    schema: z.object({ name: z.string() }),
+    annotations: { audit: { version: 1n } },
+  }),
+);
+expectError(
+  defineNode("BadFunction", {
+    schema: z.object({ name: z.string() }),
+    annotations: { onClick: () => undefined },
+  }),
+);
+expectError(
+  defineNode("BadSymbol", {
+    schema: z.object({ name: z.string() }),
+    annotations: { tag: Symbol("x") },
+  }),
+);
+expectError(
+  defineNode("BadUndefined", {
+    schema: z.object({ name: z.string() }),
+    annotations: { value: undefined },
+  }),
+);
+expectError(
+  defineNode("BadNested", {
+    schema: z.object({ name: z.string() }),
+    annotations: { audit: { handler: () => undefined } },
+  }),
+);
+expectError(
+  defineEdge("badEdgeBigInt", {
+    annotations: { count: 99n },
+  }),
+);
 
 const graph = defineGraph({
   id: "public_api_test_graph",
@@ -93,6 +146,8 @@ const edgeKinds = getEdgeKinds(graph);
 
 expectType<readonly ("Person" | "Company" | "Project")[]>(nodeKinds);
 expectType<readonly ("worksAt" | "knows")[]>(edgeKinds);
+expectType<KindAnnotations | undefined>(Incident.annotations);
+expectType<KindAnnotations | undefined>(reportedBy.annotations);
 
 expectAssignable<NodeRef>({ kind: "AnyKind", id: "node-id" });
 expectAssignable<Parameters<typeof store.edges.worksAt.create>[0]>({

--- a/packages/typegraph/tests/migration-diff.test.ts
+++ b/packages/typegraph/tests/migration-diff.test.ts
@@ -525,6 +525,97 @@ describe("computeSchemaDiff", () => {
       expect(diff.nodes).toHaveLength(1);
       expect(diff.nodes[0]!.type).toBe("modified");
     });
+
+    it("detects node annotations changes as safe", () => {
+      const before = createSchema({
+        version: 1,
+        nodes: {
+          Incident: {
+            kind: "Incident",
+            properties: {
+              type: "object",
+              properties: { title: { type: "string" } },
+            },
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+            annotations: {
+              ui: { titleField: "title", icon: "alert-triangle" },
+            },
+          },
+        },
+      });
+      const after = createSchema({
+        version: 2,
+        nodes: {
+          Incident: {
+            kind: "Incident",
+            properties: {
+              type: "object",
+              properties: { title: { type: "string" } },
+            },
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+            annotations: {
+              ui: { titleField: "title", icon: "circle-alert" },
+            },
+          },
+        },
+      });
+
+      const diff = computeSchemaDiff(before, after);
+
+      expect(diff.hasChanges).toBe(true);
+      expect(diff.hasBreakingChanges).toBe(false);
+      expect(diff.nodes).toHaveLength(1);
+      expect(diff.nodes[0]).toMatchObject({
+        type: "modified",
+        kind: "Incident",
+        severity: "safe",
+      });
+      expect(diff.nodes[0]!.details).toContain("Annotations");
+    });
+
+    it("ignores annotations object key order in node diffs", () => {
+      const before = createSchema({
+        version: 1,
+        nodes: {
+          Incident: {
+            kind: "Incident",
+            properties: { type: "object", properties: {} },
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+            annotations: {
+              ui: { titleField: "title", icon: "alert-triangle" },
+              audit: { pii: false },
+            },
+          },
+        },
+      });
+      const after = createSchema({
+        version: 2,
+        nodes: {
+          Incident: {
+            kind: "Incident",
+            properties: { type: "object", properties: {} },
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+            annotations: {
+              audit: { pii: false },
+              ui: { icon: "alert-triangle", titleField: "title" },
+            },
+          },
+        },
+      });
+
+      const diff = computeSchemaDiff(before, after);
+
+      expect(diff.hasChanges).toBe(false);
+      expect(diff.nodes).toHaveLength(0);
+    });
   });
 
   // ============================================================
@@ -755,6 +846,55 @@ describe("computeSchemaDiff", () => {
         severity: "safe",
       });
       expect(diff.edges[0]!.details).toContain("Properties");
+    });
+
+    it("detects edge annotations changes as safe", () => {
+      const before = createSchema({
+        version: 1,
+        edges: {
+          reportedBy: {
+            kind: "reportedBy",
+            fromKinds: ["Incident"],
+            toKinds: ["Person"],
+            properties: { type: "object", properties: {} },
+            cardinality: "many",
+            endpointExistence: "notDeleted",
+            description: undefined,
+            annotations: {
+              ui: { showInTimeline: true },
+            },
+          },
+        },
+      });
+      const after = createSchema({
+        version: 2,
+        edges: {
+          reportedBy: {
+            kind: "reportedBy",
+            fromKinds: ["Incident"],
+            toKinds: ["Person"],
+            properties: { type: "object", properties: {} },
+            cardinality: "many",
+            endpointExistence: "notDeleted",
+            description: undefined,
+            annotations: {
+              ui: { showInTimeline: false },
+            },
+          },
+        },
+      });
+
+      const diff = computeSchemaDiff(before, after);
+
+      expect(diff.hasChanges).toBe(true);
+      expect(diff.hasBreakingChanges).toBe(false);
+      expect(diff.edges).toHaveLength(1);
+      expect(diff.edges[0]).toMatchObject({
+        type: "modified",
+        kind: "reportedBy",
+        severity: "safe",
+      });
+      expect(diff.edges[0]!.details).toContain("Annotations");
     });
 
     it("handles multiple edge changes in single diff", () => {

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { defineGraph } from "../../src/core/define-graph";
-import { defineEdge } from "../../src/core/edge";
-import { defineNode } from "../../src/core/node";
+import { defineEdge, type DefineEdgeOptions } from "../../src/core/edge";
+import { defineNode, type DefineNodeOptions } from "../../src/core/node";
 import {
+  type AnyEdgeType,
   type Cardinality,
   type DeleteBehavior,
   type EndpointExistence,
+  type KindAnnotations,
   type TemporalMode,
 } from "../../src/core/types";
 import {
@@ -20,11 +22,13 @@ import {
   relatedTo,
   subClassOf,
 } from "../../src/ontology/core-meta-edges";
+import { sortedReplacer } from "../../src/schema/canonical";
 import { deserializeSchema } from "../../src/schema/deserializer";
 import {
   computeSchemaHash,
   serializeSchema,
 } from "../../src/schema/serializer";
+import { serializedSchemaZod } from "../../src/schema/types";
 
 // ============================================================
 // Arbitrary Generators
@@ -57,6 +61,25 @@ const graphIdArb = fc
 const descriptionArb = fc.option(fc.string({ minLength: 1, maxLength: 100 }), {
   nil: undefined,
 });
+
+/**
+ * Generate optional consumer-owned annotations (KindAnnotations).
+ *
+ * Uses arbitrary JSON values so the property tests cover deeply nested,
+ * heterogeneously-keyed shapes — exactly the kinds of structures consumers
+ * embed (UI hints, audit policy, provenance pointers, etc.).
+ */
+const annotationsKeyArb = fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9_]{0,7}$/);
+// fc.jsonValue() produces values that are valid JSON at runtime, but its
+// TypeScript type is wider than our KindAnnotations type. Cast the arbitrary
+// so the rest of the test sees the public type.
+const annotationsArb = fc.option(
+  fc.dictionary(annotationsKeyArb, fc.jsonValue(), {
+    minKeys: 0,
+    maxKeys: 4,
+  }),
+  { nil: undefined },
+) as fc.Arbitrary<KindAnnotations | undefined>;
 
 /**
  * Generate delete behaviors.
@@ -186,25 +209,38 @@ const nodeTypeArb = fc
     name: identifierArb,
     schema: simpleZodSchemaArb,
     description: descriptionArb,
+    annotations: annotationsArb,
   })
-  .map(({ name, schema, description }) =>
-    defineNode(name, description ? { schema, description } : { schema }),
+  .map(({ name, schema, description, annotations }) =>
+    defineNode(name, {
+      schema,
+      ...(description === undefined ? {} : { description }),
+      ...(annotations === undefined ? {} : { annotations }),
+    }),
   );
 
 /**
  * Generate an edge type with optional schema.
+ *
+ * Conditional spreads (instead of explicit `field: undefined`) keep us
+ * compatible with `exactOptionalPropertyTypes: true`.
  */
 const edgeTypeArb = fc
   .record({
     name: edgeIdentifierArb,
     schema: fc.option(simpleZodSchemaArb, { nil: undefined }),
     description: descriptionArb,
+    annotations: annotationsArb,
   })
-  .map(({ name, schema, description }) => {
-    if (schema && description) return defineEdge(name, { schema, description });
-    if (schema) return defineEdge(name, { schema });
-    if (description) return defineEdge(name, { description });
-    return defineEdge(name, {});
+  .map(({ name, schema, description, annotations }) => {
+    const annotationsPart = annotations === undefined ? {} : { annotations };
+    if (schema && description) {
+      return defineEdge(name, { schema, description, ...annotationsPart });
+    }
+    if (schema) return defineEdge(name, { schema, ...annotationsPart });
+    if (description)
+      return defineEdge(name, { description, ...annotationsPart });
+    return defineEdge(name, annotationsPart);
   });
 
 /**
@@ -399,7 +435,7 @@ describe("Schema Serialization Properties", () => {
           const serialized = serializeSchema(graph, version);
           const deserialized = deserializeSchema(serialized);
 
-          // Check metadata
+          // Check annotations
           expect(deserialized.graphId).toBe(graph.id);
           expect(deserialized.version).toBe(version);
 
@@ -452,6 +488,23 @@ describe("Schema Serialization Properties", () => {
           expect(Object.keys(raw.edges).toSorted()).toEqual(
             Object.keys(serialized.edges).toSorted(),
           );
+        }),
+        { numRuns: 50 },
+      );
+    });
+
+    it("serialize -> JSON -> Zod parse -> JSON is byte-identical", () => {
+      fc.assert(
+        fc.property(graphDefArb, versionArb, (graph, version) => {
+          const serialized = serializeSchema(graph, version);
+
+          const canonicalBefore = JSON.stringify(serialized, sortedReplacer);
+          const reparsed = serializedSchemaZod.parse(
+            JSON.parse(canonicalBefore),
+          );
+          const canonicalAfter = JSON.stringify(reparsed, sortedReplacer);
+
+          expect(canonicalAfter).toBe(canonicalBefore);
         }),
         { numRuns: 50 },
       );
@@ -545,6 +598,119 @@ describe("Schema Serialization Properties", () => {
         }),
         { numRuns: 50 },
       );
+    });
+
+    // Pins the load-bearing invariant from the issue: graphs that never set
+    // annotations produce identical canonical-form hashes to today, but an
+    // explicit empty object {} is a structural opt-in and bumps the hash.
+    //
+    // The "explicit-undefined" case uses a runtime cast to bypass
+    // exactOptionalPropertyTypes — that path can only originate from
+    // untyped JS callers or spread merges, but consumers can still hit it.
+    it("hash is invariant for absent vs explicit-undefined node annotations; differs for {}", async () => {
+      const baseSchema = z.object({ name: z.string() });
+      const withoutAnnotations = defineNode("Item", { schema: baseSchema });
+      const withUndefinedAnnotations = defineNode("Item", {
+        schema: baseSchema,
+        annotations: undefined,
+      } as unknown as DefineNodeOptions<typeof baseSchema>);
+      const withEmptyAnnotations = defineNode("Item", {
+        schema: baseSchema,
+        annotations: {},
+      });
+
+      const buildGraph = (node: typeof withoutAnnotations) =>
+        defineGraph({
+          id: "annotations_invariant_node",
+          nodes: { Item: { type: node } },
+          edges: {},
+        });
+
+      const hashAbsent = await computeSchemaHash(
+        serializeSchema(buildGraph(withoutAnnotations), 1),
+      );
+      const hashUndefined = await computeSchemaHash(
+        serializeSchema(buildGraph(withUndefinedAnnotations), 1),
+      );
+      const hashEmpty = await computeSchemaHash(
+        serializeSchema(buildGraph(withEmptyAnnotations), 1),
+      );
+
+      expect(hashUndefined).toBe(hashAbsent);
+      expect(hashEmpty).not.toBe(hashAbsent);
+    });
+
+    it("hash is invariant for absent vs explicit-undefined edge annotations; differs for {}", async () => {
+      const Source = defineNode("Source", {
+        schema: z.object({ name: z.string() }),
+      });
+      const Target = defineNode("Target", {
+        schema: z.object({ name: z.string() }),
+      });
+
+      const withoutAnnotations = defineEdge("links");
+      const withUndefinedAnnotations = defineEdge("links", {
+        annotations: undefined,
+      } as unknown as DefineEdgeOptions<z.ZodObject<z.ZodRawShape>>);
+      const withEmptyAnnotations = defineEdge("links", { annotations: {} });
+
+      const buildGraph = (edge: AnyEdgeType) =>
+        defineGraph({
+          id: "annotations_invariant_edge",
+          nodes: {
+            Source: { type: Source },
+            Target: { type: Target },
+          },
+          edges: {
+            links: { type: edge, from: [Source], to: [Target] },
+          },
+        });
+
+      const hashAbsent = await computeSchemaHash(
+        serializeSchema(buildGraph(withoutAnnotations), 1),
+      );
+      const hashUndefined = await computeSchemaHash(
+        serializeSchema(buildGraph(withUndefinedAnnotations), 1),
+      );
+      const hashEmpty = await computeSchemaHash(
+        serializeSchema(buildGraph(withEmptyAnnotations), 1),
+      );
+
+      expect(hashUndefined).toBe(hashAbsent);
+      expect(hashEmpty).not.toBe(hashAbsent);
+    });
+
+    // Hash compatibility for any deployment that existed before this field
+    // was added depends on the serialized schema_doc omitting `annotations`
+    // entirely when none are set — present-as-undefined would still appear
+    // in the canonical JSON and bump the hash.
+    it("graphs without annotations omit the field from canonical serialization", () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ name: z.string() }),
+      });
+      const knows = defineEdge("knows", {
+        schema: z.object({ since: z.string() }),
+      });
+
+      const graph = defineGraph({
+        id: "compat_test",
+        nodes: { Person: { type: Person } },
+        edges: {
+          knows: { type: knows, from: [Person], to: [Person] },
+        },
+      });
+
+      const serialized = serializeSchema(graph, 1);
+
+      for (const node of Object.values(serialized.nodes)) {
+        expect("annotations" in node).toBe(false);
+      }
+      for (const edge of Object.values(serialized.edges)) {
+        expect("annotations" in edge).toBe(false);
+      }
+
+      const canonical = JSON.stringify(serialized, sortedReplacer);
+      expect(canonical).not.toContain('"annotations"');
     });
   });
 

--- a/packages/typegraph/tests/schema-canonical.test.ts
+++ b/packages/typegraph/tests/schema-canonical.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for schema/canonical.ts (sortedReplacer + canonicalEqual).
+ */
+import { describe, expect, it } from "vitest";
+
+import { canonicalEqual, sortedReplacer } from "../src/schema/canonical";
+
+describe("sortedReplacer", () => {
+  it("sorts object keys lexicographically", () => {
+    const input = { z: 1, a: 2, m: 3 };
+    const output = JSON.stringify(input, sortedReplacer);
+    expect(output).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it("sorts nested object keys recursively", () => {
+    const input = { z: { y: 2, a: 1 }, a: 1 };
+    const output = JSON.stringify(input, sortedReplacer);
+    expect(output).toBe('{"a":1,"z":{"a":1,"y":2}}');
+  });
+
+  it("preserves array order", () => {
+    const input = { items: [3, 1, 2] };
+    const output = JSON.stringify(input, sortedReplacer);
+    expect(output).toBe('{"items":[3,1,2]}');
+  });
+
+  it("does not reorder objects nested inside arrays", () => {
+    // Object keys inside arrays still get sorted, but array order is preserved.
+    const input = { items: [{ z: 1, a: 2 }, { b: 3 }] };
+    const output = JSON.stringify(input, sortedReplacer);
+    expect(output).toBe('{"items":[{"a":2,"z":1},{"b":3}]}');
+  });
+});
+
+describe("canonicalEqual", () => {
+  it("returns true for equivalent objects with different key orders", () => {
+    const a = { ui: { icon: "x", title: "y" }, audit: { pii: false } };
+    const b = { audit: { pii: false }, ui: { title: "y", icon: "x" } };
+    expect(canonicalEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when values differ", () => {
+    const a = { count: 1 };
+    const b = { count: 2 };
+    expect(canonicalEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when arrays have different orders", () => {
+    expect(canonicalEqual([1, 2, 3], [3, 2, 1])).toBe(false);
+  });
+
+  it("treats two undefined inputs as equal", () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- testing undefined comparison
+    expect(canonicalEqual(undefined, undefined)).toBe(true);
+  });
+
+  it("compares primitives by value", () => {
+    expect(canonicalEqual("hello", "hello")).toBe(true);
+    expect(canonicalEqual(42, 42)).toBe(true);
+    expect(canonicalEqual(true, true)).toBe(true);
+  });
+});

--- a/packages/typegraph/tests/schema-definition.test.ts
+++ b/packages/typegraph/tests/schema-definition.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  ConfigurationError,
   defineEdge,
   defineGraph,
   defineNode,
@@ -18,6 +19,8 @@ import {
   getNodeKinds,
   subClassOf,
 } from "../src";
+import { type DefineEdgeOptions } from "../src/core/edge";
+import { type DefineNodeOptions } from "../src/core/node";
 
 describe("defineNode()", () => {
   it("creates a node kind with a name and schema", () => {
@@ -40,7 +43,129 @@ describe("defineNode()", () => {
 
     expect(Company.description).toBe("A legal business entity");
   });
+
+  it("accepts consumer-owned annotations", () => {
+    const Incident = defineNode("Incident", {
+      schema: z.object({ title: z.string() }),
+      annotations: {
+        ui: { titleField: "title", icon: "alert-triangle" },
+        audit: { pii: false },
+      },
+    });
+
+    expect(Incident.annotations).toEqual({
+      ui: { titleField: "title", icon: "alert-triangle" },
+      audit: { pii: false },
+    });
+  });
+
+  describe("annotations JSON validation", () => {
+    const baseSchema = z.object({ name: z.string() });
+
+    it("rejects bigint values", () => {
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ audit: { version: 1n } })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("rejects function values", () => {
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ onClick: noop })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("rejects symbol values", () => {
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ tag: Symbol("x") })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("rejects explicit undefined values", () => {
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ value: undefined })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("rejects Date instances", () => {
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ createdAt: new Date() })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("rejects Set and other class instances", () => {
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ tags: new Set(["a"]) })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("rejects non-JSON values nested inside arrays", () => {
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ items: [1, noop] })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("rejects NaN, Infinity, and -Infinity", () => {
+      // JSON.stringify silently coerces these to "null", which would
+      // change the canonical hash without the consumer noticing.
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ score: Number.NaN })),
+      ).toThrow(/NaN/);
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ score: Number.POSITIVE_INFINITY })),
+      ).toThrow(/Infinity/);
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ score: Number.NEGATIVE_INFINITY })),
+      ).toThrow(/-Infinity/);
+      expect(() =>
+        defineNode("Bad", badNodeOptions({ stats: { mean: Number.NaN } })),
+      ).toThrow(/annotations\.stats\.mean.*NaN/s);
+    });
+
+    it("error message includes the offending path and node kind", () => {
+      expect(() =>
+        defineNode("Incident", badNodeOptions({ audit: { version: 1n } })),
+      ).toThrow(/Node "Incident".*annotations\.audit\.version.*bigint/s);
+    });
+
+    it("accepts null, nested arrays, and deep plain objects", () => {
+      expect(() =>
+        defineNode("Good", {
+          schema: baseSchema,
+          annotations: {
+            // eslint-disable-next-line unicorn/no-null -- valid JSON value
+            placeholder: null,
+            tags: ["a", "b", ["nested"]],
+            nested: { deeper: { value: 42 } },
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
 });
+
+// Helpers hoisted outside any describe so they aren't recreated per test —
+// silences unicorn/consistent-function-scoping. Casts simulate untyped JS
+// callers or `as any` escape hatches that reach the runtime guard.
+function noop(): number {
+  return 0;
+}
+
+function badNodeOptions(
+  annotations: unknown,
+): DefineNodeOptions<z.ZodObject<{ name: z.ZodString }>> {
+  return {
+    schema: z.object({ name: z.string() }),
+    annotations,
+  } as unknown as DefineNodeOptions<z.ZodObject<{ name: z.ZodString }>>;
+}
+
+function badEdgeOptions(
+  annotations: unknown,
+): DefineEdgeOptions<z.ZodObject<z.ZodRawShape>> {
+  return { annotations } as unknown as DefineEdgeOptions<
+    z.ZodObject<z.ZodRawShape>
+  >;
+}
 
 describe("defineEdge()", () => {
   it("creates an edge kind with just a name (no properties)", () => {
@@ -61,6 +186,38 @@ describe("defineEdge()", () => {
 
     expect(worksAt.kind).toBe("worksAt");
     expect(worksAt.description).toBe("Employment relationship");
+  });
+
+  it("accepts consumer-owned annotations", () => {
+    const reportedBy = defineEdge("reportedBy", {
+      annotations: {
+        ui: { showInTimeline: true },
+      },
+    });
+
+    expect(reportedBy.annotations).toEqual({
+      ui: { showInTimeline: true },
+    });
+  });
+
+  describe("annotations JSON validation", () => {
+    it("rejects bigint values", () => {
+      expect(() => defineEdge("bad", badEdgeOptions({ count: 99n }))).toThrow(
+        ConfigurationError,
+      );
+    });
+
+    it("rejects function values", () => {
+      expect(() =>
+        defineEdge("bad", badEdgeOptions({ handler: noop })),
+      ).toThrow(ConfigurationError);
+    });
+
+    it("error message includes the offending path and edge kind", () => {
+      expect(() =>
+        defineEdge("reportedBy", badEdgeOptions({ ui: { onTap: noop } })),
+      ).toThrow(/Edge "reportedBy".*annotations\.ui\.onTap.*function/s);
+    });
   });
 });
 

--- a/packages/typegraph/tests/schema-migration.test.ts
+++ b/packages/typegraph/tests/schema-migration.test.ts
@@ -353,6 +353,90 @@ describe("Schema Changes Detection", () => {
 
     expect(diff).toBeUndefined();
   });
+
+  it("getSchemaChanges surfaces annotations-only node changes as safe", async () => {
+    const backend = createTestBackend();
+
+    const PersonWithUiHint = defineNode("Person", {
+      schema: z.object({ name: z.string() }),
+      annotations: { ui: { titleField: "name", icon: "user" } },
+    });
+    const graphV1 = defineGraph({
+      id: "annotations_diff_test",
+      nodes: { Person: { type: PersonWithUiHint } },
+      edges: {},
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    const PersonWithDifferentIcon = defineNode("Person", {
+      schema: z.object({ name: z.string() }),
+      annotations: { ui: { titleField: "name", icon: "user-circle" } },
+    });
+    const graphV2 = defineGraph({
+      id: "annotations_diff_test",
+      nodes: { Person: { type: PersonWithDifferentIcon } },
+      edges: {},
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+
+    expect(diff).toBeDefined();
+    expect(diff!.hasChanges).toBe(true);
+    expect(diff!.hasBreakingChanges).toBe(false);
+    expect(diff!.nodes).toHaveLength(1);
+    expect(diff!.nodes[0]).toMatchObject({
+      type: "modified",
+      kind: "Person",
+      severity: "safe",
+    });
+    expect(diff!.nodes[0]!.details).toContain("Annotations");
+  });
+
+  it("getSchemaChanges surfaces annotations-only edge changes as safe", async () => {
+    const backend = createTestBackend();
+
+    const reportedByV1 = defineEdge("reportedBy", {
+      annotations: { ui: { showInTimeline: true } },
+    });
+    const graphV1 = defineGraph({
+      id: "annotations_diff_edge_test",
+      nodes: {
+        Person: { type: PersonV1 },
+        Company: { type: Company },
+      },
+      edges: {
+        reportedBy: { type: reportedByV1, from: [PersonV1], to: [Company] },
+      },
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    const reportedByV2 = defineEdge("reportedBy", {
+      annotations: { ui: { showInTimeline: false } },
+    });
+    const graphV2 = defineGraph({
+      id: "annotations_diff_edge_test",
+      nodes: {
+        Person: { type: PersonV1 },
+        Company: { type: Company },
+      },
+      edges: {
+        reportedBy: { type: reportedByV2, from: [PersonV1], to: [Company] },
+      },
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+
+    expect(diff).toBeDefined();
+    expect(diff!.hasChanges).toBe(true);
+    expect(diff!.hasBreakingChanges).toBe(false);
+    expect(diff!.edges).toHaveLength(1);
+    expect(diff!.edges[0]).toMatchObject({
+      type: "modified",
+      kind: "reportedBy",
+      severity: "safe",
+    });
+    expect(diff!.edges[0]!.details).toContain("Annotations");
+  });
 });
 
 describe("Migration Options", () => {

--- a/packages/typegraph/tests/schema-parse-validation.test.ts
+++ b/packages/typegraph/tests/schema-parse-validation.test.ts
@@ -71,6 +71,9 @@ describe("serializedSchemaZod", () => {
             uniqueConstraints: [],
             onDelete: "restrict",
             description: undefined,
+            annotations: {
+              ui: { titleField: "name" },
+            },
           },
         },
         edges: {
@@ -82,6 +85,9 @@ describe("serializedSchemaZod", () => {
             cardinality: "many",
             endpointExistence: "notDeleted",
             description: undefined,
+            annotations: {
+              ui: { showInTimeline: true },
+            },
           },
         },
       };
@@ -486,6 +492,74 @@ describe("serializedSchemaZod", () => {
       };
       const result = serializedSchemaZod.safeParse(document);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("annotations JSON validation", () => {
+    it("accepts annotations containing nested plain JSON values", () => {
+      const document = {
+        ...createValidSchemaDocument(),
+        nodes: {
+          Person: {
+            kind: "Person",
+            properties: {},
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+            annotations: {
+              ui: { titleField: "name", icon: "user" },
+              audit: { pii: false, retentionDays: 365 },
+              // eslint-disable-next-line unicorn/no-null -- valid JSON value
+              tags: ["a", "b", null],
+            },
+          },
+        },
+      };
+      const result = serializedSchemaZod.safeParse(document);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects annotations containing non-JSON values at the parse boundary", () => {
+      const document = {
+        ...createValidSchemaDocument(),
+        nodes: {
+          Person: {
+            kind: "Person",
+            properties: {},
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+            annotations: {
+              audit: { handler: () => 1 },
+            },
+          },
+        },
+      };
+      const result = serializedSchemaZod.safeParse(document);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects annotations containing non-finite numbers at the parse boundary", () => {
+      for (const badValue of [
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+      ]) {
+        const document = {
+          ...createValidSchemaDocument(),
+          nodes: {
+            Person: {
+              kind: "Person",
+              properties: {},
+              uniqueConstraints: [],
+              onDelete: "restrict",
+              description: undefined,
+              annotations: { stats: { mean: badValue } },
+            },
+          },
+        };
+        expect(serializedSchemaZod.safeParse(document).success).toBe(false);
+      }
     });
   });
 });

--- a/packages/typegraph/tests/schema-serialization.test.ts
+++ b/packages/typegraph/tests/schema-serialization.test.ts
@@ -81,6 +81,42 @@ describe("serializeSchema", () => {
     expect(serialized.nodes.Person?.description).toBe("A person entity");
   });
 
+  it("includes node annotations only when provided", () => {
+    const Incident = defineNode("Incident", {
+      schema: z.object({
+        title: z.string(),
+        occurredAt: z.string(),
+      }),
+      annotations: {
+        ui: {
+          titleField: "title",
+          temporalField: "occurredAt",
+        },
+        audit: { pii: false },
+      },
+    });
+
+    const graph = defineGraph({
+      id: "test_graph",
+      nodes: {
+        Incident: { type: Incident },
+        Person: { type: Person },
+      },
+      edges: {},
+    });
+
+    const serialized = serializeSchema(graph, 1);
+
+    expect(serialized.nodes.Incident?.annotations).toEqual({
+      ui: {
+        titleField: "title",
+        temporalField: "occurredAt",
+      },
+      audit: { pii: false },
+    });
+    expect("annotations" in serialized.nodes.Person!).toBe(false);
+  });
+
   it("serializes node properties to JSON Schema", () => {
     const graph = defineGraph({
       id: "test_graph",
@@ -115,6 +151,36 @@ describe("serializeSchema", () => {
     expect(serialized.edges.worksAt?.fromKinds).toEqual(["Person"]);
     expect(serialized.edges.worksAt?.toKinds).toEqual(["Organization"]);
     expect(serialized.edges.worksAt?.cardinality).toBe("many");
+  });
+
+  it("includes edge annotations when provided", () => {
+    const reportedBy = defineEdge("reportedBy", {
+      schema: z.object({ channel: z.string() }),
+      annotations: {
+        ui: { showInTimeline: true },
+      },
+    });
+
+    const graph = defineGraph({
+      id: "test_graph",
+      nodes: {
+        Person: { type: Person },
+        Organization: { type: Organization },
+      },
+      edges: {
+        reportedBy: {
+          type: reportedBy,
+          from: [Person],
+          to: [Organization],
+        },
+      },
+    });
+
+    const serialized = serializeSchema(graph, 1);
+
+    expect(serialized.edges.reportedBy?.annotations).toEqual({
+      ui: { showInTimeline: true },
+    });
   });
 
   it("serializes ontology relations and computes closures", () => {
@@ -337,6 +403,53 @@ describe("computeSchemaHash", () => {
     const hash2 = await computeSchemaHash(serializeSchema(graph2, 1));
 
     expect(hash1).not.toBe(hash2);
+  });
+
+  it("includes annotations in hashes with stable key ordering", async () => {
+    const IncidentA = defineNode("Incident", {
+      schema: z.object({ title: z.string() }),
+      annotations: {
+        ui: { titleField: "title", icon: "alert-triangle" },
+        audit: { pii: false },
+      },
+    });
+    const IncidentB = defineNode("Incident", {
+      schema: z.object({ title: z.string() }),
+      annotations: {
+        audit: { pii: false },
+        ui: { icon: "alert-triangle", titleField: "title" },
+      },
+    });
+    const IncidentC = defineNode("Incident", {
+      schema: z.object({ title: z.string() }),
+      annotations: {
+        ui: { titleField: "title", icon: "circle-alert" },
+        audit: { pii: false },
+      },
+    });
+
+    const graphA = defineGraph({
+      id: "test_graph",
+      nodes: { Incident: { type: IncidentA } },
+      edges: {},
+    });
+    const graphB = defineGraph({
+      id: "test_graph",
+      nodes: { Incident: { type: IncidentB } },
+      edges: {},
+    });
+    const graphC = defineGraph({
+      id: "test_graph",
+      nodes: { Incident: { type: IncidentC } },
+      edges: {},
+    });
+
+    const hashA = await computeSchemaHash(serializeSchema(graphA, 1));
+    const hashB = await computeSchemaHash(serializeSchema(graphB, 1));
+    const hashC = await computeSchemaHash(serializeSchema(graphC, 1));
+
+    expect(hashA).toBe(hashB);
+    expect(hashA).not.toBe(hashC);
   });
 });
 


### PR DESCRIPTION
Adds an optional `metadata?: KindMetadata` field to `defineNode` and `defineEdge` for consumer-owned per-kind structured data (UI hints, audit policy, provenance pointers, etc.). TypeGraph stores and versions this value but never interprets keys inside it — consumers own the entire namespace.

Closes #102.

## What's in scope

- `KindMetadata = Readonly<Record<string, unknown>>` exported from the public API.
- Plumbed through `NodeType` / `EdgeType` value shape and `SerializedSchema.{nodes,edges}[*].metadata`.
- Included in `computeSchemaHash` with stable sorted-key order so equivalent metadata in different declaration order produces equal hashes.
- Surfaces as `safe`-severity changes in `computeSchemaDiff` / `SchemaManager.getSchemaChanges`.
- Forward-compat `serializedSchemaZod` parses both old (no metadata) and new documents.

## Load-bearing invariants pinned by tests

- Graphs that never set `metadata` produce **identical canonical-form hashes to today** — adoption requires no migration.
- An explicit empty `{}` is a structural opt-in and **does** bump the hash.
- Hash is invariant under metadata key reordering at any depth.
- Round-trip: `serialize → JSON → serializedSchemaZod.parse → JSON` is byte-identical.

## Notable refactors

- Extracted shared `sortedReplacer` from `serializer.ts` and `migration.ts` into a new `src/schema/canonical.ts` (was duplicated).
- Fixed `metadataChanged` undefined-sentinel: short-circuits on boolean `undefined` comparison instead of stringifying `undefined` as the literal `"undefined"`.