### PR TITLE
feat: atomic commitSchemaVersion backend primitive

### DIFF
--- a/.changeset/commit-schema-version.md
+++ b/.changeset/commit-schema-version.md
@@ -1,0 +1,41 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Replace the unwrapped `insertSchema` + `setActiveSchema` two-step migration flow with a single atomic `commitSchemaVersion` backend primitive (plus `setActiveVersion` for rollback). Fixes the orphan-row bug where a crash between insert and activate left the system wedged at the next `ensureSchema` call.
+
+**The bug.** `migrateSchema` called `backend.insertSchema(v=N+1, isActive=false)` then `backend.setActiveSchema(N+1)` as two independent operations with no surrounding transaction. A crash in between left an inactive `v=N+1` row that nothing referenced; the next migration attempt computed the same `newVersion=N+1` and hit a primary-key violation, requiring manual operator cleanup. Closes #104.
+
+**New primitives:**
+
+```typescript
+backend.commitSchemaVersion({
+  graphId,
+  expected: { kind: "initial" } | { kind: "active"; version: N },
+  version: N + 1,
+  schemaHash,
+  schemaDoc,
+});
+
+backend.setActiveVersion({ graphId, expected, version });
+```
+
+`commitSchemaVersion` inserts and activates as one transactional unit with optimistic compare-and-swap on the currently-active version, idempotency on same-hash retry (orphan reactivation), and explicit conflict detection. The CAS guard takes a tagged-union `expected` rather than a magic `version: 0` sentinel — initial commits have materially different semantics from successor commits and the type system reflects that.
+
+**New error types** (both extend `TypeGraphError`):
+
+- `StaleVersionError` — thrown when the caller's `expected` active version doesn't match what the database has. Includes `details.actual` so the caller knows what to refetch. Recovery: re-read with `getActiveSchema(graphId)` and retry against the new baseline.
+- `SchemaContentConflictError` — thrown when a row already exists at the target version with a different `schemaHash`. This is a content disagreement (two writers committed different schemas at the same version), not a stale-read race; recovery requires operator intervention, not retry.
+
+**Storage-layer invariant.** Adds a partial unique index `(graph_id) WHERE is_active = TRUE` on `typegraph_schema_versions`. Defense in depth: the database will refuse a corrupt "two active rows on one graph" state regardless of the application path that produced it.
+
+**Non-transactional backends refuse the primitive.** On Cloudflare D1, Cloudflare Durable Objects, `drizzle-orm/neon-http`, and any SQLite backend configured with `transactionMode: "none"`, `commitSchemaVersion` and `setActiveVersion` throw `ConfigurationError`. The orphan-row crash window cannot be eliminated without atomicity, so silent best-effort degradation would re-introduce the exact bug this primitive fixes. Run schema migrations from a process with a transactional driver; the edge worker can keep using its non-transactional driver for reads and ordinary writes once the schema is established.
+
+**Locking.**
+
+- SQLite: `BEGIN IMMEDIATE` (sync paths) or Drizzle's `behavior: "immediate"` (async paths) acquires a reserved write lock at the start of the transaction so the read-then-write CAS sequence is serialized.
+- Postgres: `pg_advisory_xact_lock(hashtext(graphId))` serializes commits per-graph, covering both the "active row exists" and "initial commit" cases under one mechanism.
+
+**Breaking changes for backend implementers.** `insertSchema` and `setActiveSchema` are removed from the `GraphBackend` interface; custom backend implementations must implement `commitSchemaVersion` and `setActiveVersion` instead. Callers using the public `initializeSchema`, `migrateSchema`, and `rollbackSchema` helpers from `@nicia-ai/typegraph/schema` need no changes — these now route through the new primitives transparently.
+
+Existing deployments need to add the partial unique index when they upgrade. `bootstrapTables` regenerates the full DDL set (idempotent; existing tables are unchanged); manually-managed schemas should run an additional `CREATE UNIQUE INDEX IF NOT EXISTS typegraph_schema_versions_one_active_per_graph_idx ON typegraph_schema_versions (graph_id) WHERE is_active = TRUE;` for Postgres or the equivalent `WHERE is_active = 1` for SQLite. Existing data that has only ever maintained one active row per graph will satisfy the constraint — the application path has always done so by convention; the index just makes the invariant structural.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -303,8 +303,16 @@ Edge runtimes expose `WebSocket` globally and need no extra setup.
 For stateless edge workloads where you don't need transactional writes. The HTTP
 driver issues one request per query — lowest cold-start cost, no session lifecycle
 to manage. TypeGraph auto-detects this driver and sets `capabilities.transactions`
-to `false`, so `store.transaction(...)` and `setActiveSchema(...)` fall through to
-sequential execution rather than throwing.
+to `false`, so `store.transaction(...)` falls through to sequential execution
+rather than throwing.
+
+Schema commits are the one exception: `commitSchemaVersion` and
+`setActiveVersion` require atomicity to eliminate the orphan-row crash window
+they exist to fix, so they refuse with a typed `ConfigurationError` on
+non-transactional backends. Run schema migrations from a process with a
+transactional driver (`drizzle-orm/neon-serverless`, regular `pg`, etc.); the
+edge worker can keep using neon-http for reads and writes once the schema is
+established.
 
 ```bash
 npm install @neondatabase/serverless drizzle-orm

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -38,12 +38,19 @@ import type {
 import { type CommonOperationStrategy } from "./operations/strategy";
 import { nowIso as defaultNowIso } from "./row-mappers";
 
-type CommonOperationBackend = Pick<
+/**
+ * The internal operation backend — what `createCommonOperationBackend`
+ * returns. Includes `commitSchemaVersion` and `setActiveVersion` so the
+ * top-level backend wrappers can call them on a fresh tx-scoped
+ * operation backend (created inside the dialect-specific
+ * write-locking transaction). These methods are deliberately NOT on
+ * the public `TransactionBackend` type — see the comment there.
+ */
+export type CommonOperationBackend = Pick<
   TransactionBackend,
   | "checkUnique"
   | "checkUniqueBatch"
   | "clearGraph"
-  | "commitSchemaVersion"
   | "countEdgesByKind"
   | "countEdgesFrom"
   | "countNodesByKind"
@@ -71,10 +78,15 @@ type CommonOperationBackend = Pick<
   | "insertNodesBatch"
   | "insertNodesBatchReturning"
   | "insertUnique"
-  | "setActiveVersion"
   | "updateEdge"
   | "updateNode"
->;
+> &
+  Readonly<{
+    commitSchemaVersion: (
+      params: CommitSchemaVersionParams,
+    ) => Promise<SchemaVersionRow>;
+    setActiveVersion: (params: SetActiveVersionParams) => Promise<void>;
+  }>;
 
 type OperationBackendExecution = Readonly<{
   execAll: <TRow>(query: SQL) => Promise<readonly TRow[]>;

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -1,9 +1,16 @@
 import { type SQL } from "drizzle-orm";
 
-import { DatabaseOperationError, UniquenessError } from "../../errors";
+import {
+  DatabaseOperationError,
+  MigrationError,
+  SchemaContentConflictError,
+  StaleVersionError,
+  UniquenessError,
+} from "../../errors";
 import type {
   CheckUniqueBatchParams,
   CheckUniqueParams,
+  CommitSchemaVersionParams,
   CountEdgesByKindParams,
   CountEdgesFromParams,
   CountNodesByKindParams,
@@ -19,10 +26,10 @@ import type {
   HardDeleteNodeParams,
   InsertEdgeParams,
   InsertNodeParams,
-  InsertSchemaParams,
   InsertUniqueParams,
   NodeRow,
   SchemaVersionRow,
+  SetActiveVersionParams,
   TransactionBackend,
   UniqueRow,
   UpdateEdgeParams,
@@ -36,6 +43,7 @@ type CommonOperationBackend = Pick<
   | "checkUnique"
   | "checkUniqueBatch"
   | "clearGraph"
+  | "commitSchemaVersion"
   | "countEdgesByKind"
   | "countEdgesFrom"
   | "countNodesByKind"
@@ -62,9 +70,8 @@ type CommonOperationBackend = Pick<
   | "insertNodeNoReturn"
   | "insertNodesBatch"
   | "insertNodesBatchReturning"
-  | "insertSchema"
   | "insertUnique"
-  | "setActiveSchema"
+  | "setActiveVersion"
   | "updateEdge"
   | "updateNode"
 >;
@@ -113,11 +120,35 @@ function chunkArray<T>(
   return chunks;
 }
 
+function verifyExpectedActiveVersion(
+  graphId: string,
+  expected: CommitSchemaVersionParams["expected"],
+  actualActiveVersion: number,
+): void {
+  const expectedVersion = expected.kind === "active" ? expected.version : 0;
+  if (actualActiveVersion !== expectedVersion) {
+    throw new StaleVersionError({
+      graphId,
+      expected: expectedVersion,
+      actual: actualActiveVersion,
+    });
+  }
+}
+
 export function createCommonOperationBackend(
   options: CreateCommonOperationBackendOptions,
 ): CommonOperationBackend {
   const { batchConfig, execution, operationStrategy, rowMappers } = options;
   const nowIso = options.nowIso ?? defaultNowIso;
+
+  // Returns 0 when no row is currently active — that's the sentinel
+  // `expected: { kind: "initial" }` matches against.
+  async function readActiveVersion(graphId: string): Promise<number> {
+    const row = await execution.execGet<Record<string, unknown>>(
+      operationStrategy.buildGetActiveSchema(graphId),
+    );
+    return row === undefined ? 0 : rowMappers.toSchemaVersionRow(row).version;
+  }
 
   return {
     async insertNode(params: InsertNodeParams): Promise<NodeRow> {
@@ -418,14 +449,6 @@ export function createCommonOperationBackend(
       return row ? rowMappers.toSchemaVersionRow(row) : undefined;
     },
 
-    async insertSchema(params: InsertSchemaParams): Promise<SchemaVersionRow> {
-      const timestamp = nowIso();
-      const query = operationStrategy.buildInsertSchema(params, timestamp);
-      const row = await execution.execGet<Record<string, unknown>>(query);
-      if (!row) throw new DatabaseOperationError("Insert schema failed: no row returned", { operation: "insert", entity: "schema" });
-      return rowMappers.toSchemaVersionRow(row);
-    },
-
     async getSchemaVersion(
       graphId: string,
       version: number,
@@ -435,8 +458,130 @@ export function createCommonOperationBackend(
       return row ? rowMappers.toSchemaVersionRow(row) : undefined;
     },
 
-    async setActiveSchema(graphId: string, version: number): Promise<void> {
-      const queries = operationStrategy.buildSetActiveSchema(graphId, version);
+    async commitSchemaVersion(
+      params: CommitSchemaVersionParams,
+    ): Promise<SchemaVersionRow> {
+      // The top-level backend wraps this method in a transaction with
+      // appropriate write-locking (BEGIN IMMEDIATE on SQLite,
+      // pg_advisory_xact_lock on Postgres) so the read-then-write
+      // sequence below is serialized against concurrent commits.
+
+      const existingRaw = await execution.execGet<Record<string, unknown>>(
+        operationStrategy.buildGetSchemaVersion(
+          params.graphId,
+          params.version,
+        ),
+      );
+      const actualActiveVersion = await readActiveVersion(params.graphId);
+
+      // Same-version-different-hash → content conflict. Always wins
+      // over CAS: a hash disagreement is operator-intervention
+      // territory regardless of which writer "got there first."
+      if (existingRaw !== undefined) {
+        const existing = rowMappers.toSchemaVersionRow(existingRaw);
+        if (existing.schema_hash !== params.schemaHash) {
+          throw new SchemaContentConflictError({
+            graphId: params.graphId,
+            version: params.version,
+            existingHash: existing.schema_hash,
+            incomingHash: params.schemaHash,
+          });
+        }
+        // Same-version-same-hash already active → idempotent success.
+        // Skips the CAS intentionally: same hash means identical
+        // content, so there's no disagreement for the caller to refetch.
+        if (existing.is_active) {
+          return existing;
+        }
+        // Same-version-same-hash but inactive: orphan row left by a
+        // crashed earlier commit. Reactivation requires CAS because
+        // we're about to flip the active pointer — fall through.
+        verifyExpectedActiveVersion(
+          params.graphId,
+          params.expected,
+          actualActiveVersion,
+        );
+        const reactivate = operationStrategy.buildSetActiveSchema(
+          params.graphId,
+          params.version,
+        );
+        await execution.execRun(reactivate.deactivateAll);
+        await execution.execRun(reactivate.activateVersion);
+        // Project the result instead of re-SELECTing: the partial
+        // unique index guarantees this is the only active row for the
+        // graph after the UPDATEs above.
+        return { ...existing, is_active: true };
+      }
+
+      verifyExpectedActiveVersion(
+        params.graphId,
+        params.expected,
+        actualActiveVersion,
+      );
+
+      // Fresh insert path. For the "active" expected case, deactivate
+      // the prior active row first so the partial unique index (one
+      // active per graph) is satisfied at every statement boundary.
+      // The "initial" case has no prior active, so skip.
+      if (params.expected.kind === "active") {
+        const flip = operationStrategy.buildSetActiveSchema(
+          params.graphId,
+          params.version,
+        );
+        await execution.execRun(flip.deactivateAll);
+      }
+
+      const timestamp = nowIso();
+      const insertQuery = operationStrategy.buildInsertSchema(
+        {
+          graphId: params.graphId,
+          version: params.version,
+          schemaHash: params.schemaHash,
+          schemaDoc: params.schemaDoc,
+          isActive: true,
+        },
+        timestamp,
+      );
+      const insertedRaw =
+        await execution.execGet<Record<string, unknown>>(insertQuery);
+      if (!insertedRaw) {
+        throw new DatabaseOperationError(
+          "Insert schema failed: no row returned",
+          { operation: "insert", entity: "schema" },
+        );
+      }
+      return rowMappers.toSchemaVersionRow(insertedRaw);
+    },
+
+    async setActiveVersion(params: SetActiveVersionParams): Promise<void> {
+      const actualActiveVersion = await readActiveVersion(params.graphId);
+      verifyExpectedActiveVersion(
+        params.graphId,
+        params.expected,
+        actualActiveVersion,
+      );
+
+      const targetRaw = await execution.execGet<Record<string, unknown>>(
+        operationStrategy.buildGetSchemaVersion(
+          params.graphId,
+          params.version,
+        ),
+      );
+      if (!targetRaw) {
+        throw new MigrationError(
+          `Cannot activate version ${params.version}: version does not exist for graph "${params.graphId}".`,
+          {
+            graphId: params.graphId,
+            fromVersion: actualActiveVersion,
+            toVersion: params.version,
+          },
+        );
+      }
+
+      const queries = operationStrategy.buildSetActiveSchema(
+        params.graphId,
+        params.version,
+      );
       await execution.execRun(queries.deactivateAll);
       await execution.execRun(queries.activateVersion);
     },

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -26,6 +26,7 @@
  */
 import { getTableName, type SQL, sql } from "drizzle-orm";
 
+import { ConfigurationError } from "../../errors";
 import type { SqlTableNames } from "../../query/compiler/schema";
 import { quoteIdentifier } from "../../query/compiler/utils";
 import {
@@ -35,6 +36,7 @@ import {
 } from "../../query/dialect/fulltext-strategy";
 import {
   type BackendCapabilities,
+  type CommitSchemaVersionParams,
   type CreateVectorIndexParams,
   type DeleteEmbeddingParams,
   type DeleteFulltextBatchParams,
@@ -45,7 +47,8 @@ import {
   type FulltextSearchResult,
   type GraphBackend,
   POSTGRES_CAPABILITIES,
-  runOptionallyInTransaction,
+  type SchemaVersionRow,
+  type SetActiveVersionParams,
   type TransactionBackend,
   type TransactionOptions,
   type UpsertEmbeddingParams,
@@ -304,6 +307,55 @@ export function createPostgresBackend(
     fulltextStrategy,
   });
 
+  /**
+   * Runs `fn` inside a Postgres transaction, holding an
+   * `pg_advisory_xact_lock` keyed on the graph id. The advisory lock
+   * serializes all schema commits per-graph: the read-then-write CAS in
+   * `commitSchemaVersion` is safe even for the initial-commit case
+   * where there is no row yet to `SELECT ... FOR UPDATE`.
+   *
+   * Refuses on backends that don't support transactions
+   * (`drizzle-orm/neon-http`). The orphan-row crash window cannot be
+   * eliminated without atomicity, so silent best-effort degradation is
+   * worse than a typed error.
+   */
+  function runSchemaWriteTransaction<T>(
+    graphId: string,
+    fn: (tx: TransactionBackend) => Promise<T>,
+  ): Promise<T> {
+    if (!capabilities.transactions) {
+      throw new ConfigurationError(
+        "commitSchemaVersion and setActiveVersion require atomic transactions, " +
+          "but this Postgres backend does not provide them. The drizzle-orm/neon-http " +
+          "driver communicates over HTTP and cannot hold a session across statements; " +
+          "use drizzle-orm/neon-serverless (websocket) for transactional writes.",
+        {
+          backend: "postgres",
+          capability: "transactions",
+          supportsTransactions: false,
+        },
+      );
+    }
+
+    return db.transaction(async (tx) => {
+      // Advisory lock: hashtext($graphId) is collision-tolerant for the
+      // size of an active graph set; collisions just serialize unrelated
+      // graphs which is harmless. Held until the transaction commits.
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${graphId}))`,
+      );
+      const txBackend = createTransactionBackend({
+        db: tx,
+        adapterOptions,
+        operationStrategy,
+        tableNames,
+        capabilities,
+        fulltextStrategy,
+      });
+      return fn(txBackend);
+    });
+  }
+
   const backend: GraphBackend = {
     ...operations,
 
@@ -323,11 +375,17 @@ export function createPostgresBackend(
       await db.execute(analyzeStatement);
     },
 
-    async setActiveSchema(graphId: string, version: number): Promise<void> {
-      await runOptionallyInTransaction(
-        backend,
-        (target) => target.setActiveSchema(graphId, version),
-        operations,
+    async commitSchemaVersion(
+      params: CommitSchemaVersionParams,
+    ): Promise<SchemaVersionRow> {
+      return runSchemaWriteTransaction(params.graphId, (target) =>
+        target.commitSchemaVersion(params),
+      );
+    },
+
+    async setActiveVersion(params: SetActiveVersionParams): Promise<void> {
+      await runSchemaWriteTransaction(params.graphId, (target) =>
+        target.setActiveVersion(params),
       );
     },
 

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -65,7 +65,10 @@ import {
   type PostgresExecutionAdapter,
   type PostgresExecutionAdapterOptions,
 } from "./execution/postgres-execution";
-import { createCommonOperationBackend } from "./operation-backend-core";
+import {
+  type CommonOperationBackend,
+  createCommonOperationBackend,
+} from "./operation-backend-core";
 import { createPostgresOperationStrategy } from "./operations/strategy";
 import {
   createEdgeRowMapper,
@@ -321,7 +324,7 @@ export function createPostgresBackend(
    */
   function runSchemaWriteTransaction<T>(
     graphId: string,
-    fn: (tx: TransactionBackend) => Promise<T>,
+    fn: (tx: CommonOperationBackend) => Promise<T>,
   ): Promise<T> {
     if (!capabilities.transactions) {
       throw new ConfigurationError(
@@ -344,6 +347,11 @@ export function createPostgresBackend(
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtext(${graphId}))`,
       );
+      // The runtime object always implements commitSchemaVersion /
+      // setActiveVersion (they live in operation-backend-core); the
+      // public TransactionBackend type omits them so user-supplied
+      // transaction() callbacks can't bypass the advisory lock. Cast
+      // back to the wider internal shape here, where the lock IS held.
       const txBackend = createTransactionBackend({
         db: tx,
         adapterOptions,
@@ -351,7 +359,7 @@ export function createPostgresBackend(
         tableNames,
         capabilities,
         fulltextStrategy,
-      });
+      }) as unknown as CommonOperationBackend;
       return fn(txBackend);
     });
   }

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -24,6 +24,7 @@
  * });
  * ```
  */
+import { sql } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -33,6 +34,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 import {
@@ -205,6 +207,14 @@ export function createPostgresTables(
     (t) => [
       primaryKey({ columns: [t.graphId, t.version] }),
       index(`${n.schemaVersions}_active_idx`).on(t.graphId, t.isActive),
+      // Partial unique index enforcing the "at most one active version
+      // per graph" invariant at the storage layer. Defense in depth
+      // against buggy backend implementations or out-of-band writes.
+      // Forces the deactivate-then-activate ordering used by
+      // `commitSchemaVersion` and `setActiveVersion`.
+      uniqueIndex(`${n.schemaVersions}_one_active_per_graph_idx`)
+        .on(t.graphId)
+        .where(sql`${t.isActive} = TRUE`),
     ],
   );
 

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -18,6 +18,7 @@
  * });
  * ```
  */
+import { sql } from "drizzle-orm";
 import {
   blob,
   index,
@@ -25,6 +26,7 @@ import {
   primaryKey,
   sqliteTable,
   text,
+  uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
 import {
@@ -198,6 +200,14 @@ export function createSqliteTables(
     (t) => [
       primaryKey({ columns: [t.graphId, t.version] }),
       index(`${n.schemaVersions}_active_idx`).on(t.graphId, t.isActive),
+      // Partial unique index enforcing the "at most one active version
+      // per graph" invariant at the storage layer. Defense in depth
+      // against buggy backend implementations or out-of-band writes.
+      // Forces the deactivate-then-activate ordering used by
+      // `commitSchemaVersion` and `setActiveVersion`.
+      uniqueIndex(`${n.schemaVersions}_one_active_per_graph_idx`)
+        .on(t.graphId)
+        .where(sql`${t.isActive} = 1`),
     ],
   );
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -58,7 +58,10 @@ import {
 } from "./execution/sqlite-execution";
 export type { SqliteTransactionMode } from "./execution/sqlite-execution";
 import { generateSqliteDDL } from "./ddl";
-import { createCommonOperationBackend } from "./operation-backend-core";
+import {
+  type CommonOperationBackend,
+  createCommonOperationBackend,
+} from "./operation-backend-core";
 import { createSqliteOperationStrategy } from "./operations/strategy";
 import {
   createEdgeRowMapper,
@@ -582,7 +585,7 @@ export function createSqliteBackend(
    * cannot be eliminated without atomicity.
    */
   function runSchemaWriteTransaction<T>(
-    fn: (tx: TransactionBackend) => Promise<T>,
+    fn: (tx: CommonOperationBackend) => Promise<T>,
   ): Promise<T> {
     if (transactionMode === "none") {
       throw new ConfigurationError(
@@ -600,6 +603,12 @@ export function createSqliteBackend(
 
     if (transactionMode === "sql") {
       return runWithSerializedQueue(serializedQueue, async () => {
+        // The runtime object returned by createTransactionBackend always
+        // implements commitSchemaVersion / setActiveVersion (they live in
+        // the operation-backend-core impl); the public TransactionBackend
+        // type omits them so user-supplied transaction() callbacks can't
+        // bypass the locking wrapper. Cast back to the wider internal
+        // shape here, where the locking IS being applied.
         const txBackend = createTransactionBackend({
           capabilities,
           db,
@@ -609,7 +618,7 @@ export function createSqliteBackend(
           tableNames,
           fulltextStrategy,
           hasVectorEmbeddings,
-        });
+        }) as unknown as CommonOperationBackend;
         db.run(sql`BEGIN IMMEDIATE`);
         try {
           const result = await fn(txBackend);
@@ -636,7 +645,7 @@ export function createSqliteBackend(
           tableNames,
           fulltextStrategy,
           hasVectorEmbeddings,
-        });
+        }) as unknown as CommonOperationBackend;
         return fn(txBackend);
       }, { behavior: "immediate" }) as Promise<T>,
     );

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -30,6 +30,7 @@ import {
 } from "../../query/dialect/fulltext-strategy";
 import {
   type BackendCapabilities,
+  type CommitSchemaVersionParams,
   type CreateVectorIndexParams,
   type DeleteEmbeddingParams,
   type DeleteFulltextBatchParams,
@@ -38,7 +39,8 @@ import {
   type FulltextSearchParams,
   type FulltextSearchResult,
   type GraphBackend,
-  runOptionallyInTransaction,
+  type SchemaVersionRow,
+  type SetActiveVersionParams,
   SQLITE_CAPABILITIES,
   type TransactionBackend,
   type TransactionOptions,
@@ -569,6 +571,77 @@ export function createSqliteBackend(
     ...(serializedQueue === undefined ? {} : { serializedQueue }),
   });
 
+  /**
+   * Runs `fn` inside a SQLite write transaction (BEGIN IMMEDIATE) so that
+   * the read-then-write inside `commitSchemaVersion` / `setActiveVersion`
+   * is serialized against concurrent writers — a deferred BEGIN would let
+   * two transactions race past the CAS read and one would later fail
+   * with SQLITE_BUSY instead of producing a clean StaleVersionError.
+   *
+   * Refuses on `transactionMode: "none"`. The orphan-row crash window
+   * cannot be eliminated without atomicity.
+   */
+  function runSchemaWriteTransaction<T>(
+    fn: (tx: TransactionBackend) => Promise<T>,
+  ): Promise<T> {
+    if (transactionMode === "none") {
+      throw new ConfigurationError(
+        "commitSchemaVersion and setActiveVersion require atomic transactions, " +
+          "but this SQLite backend has transactions disabled. Configure a " +
+          "driver that supports transactions (better-sqlite3, libsql, " +
+          "bun:sqlite) to use schema commits.",
+        {
+          backend: "sqlite",
+          capability: "transactions",
+          supportsTransactions: false,
+        },
+      );
+    }
+
+    if (transactionMode === "sql") {
+      return runWithSerializedQueue(serializedQueue, async () => {
+        const txBackend = createTransactionBackend({
+          capabilities,
+          db,
+          executionAdapter,
+          operationStrategy,
+          profileHints: { isSync: true },
+          tableNames,
+          fulltextStrategy,
+          hasVectorEmbeddings,
+        });
+        db.run(sql`BEGIN IMMEDIATE`);
+        try {
+          const result = await fn(txBackend);
+          db.run(sql`COMMIT`);
+          return result;
+        } catch (error) {
+          db.run(sql`ROLLBACK`);
+          throw error;
+        }
+      });
+    }
+
+    // transactionMode === "drizzle". Drizzle's sqlite-core transaction
+    // accepts a `behavior` option that maps to BEGIN / BEGIN IMMEDIATE /
+    // BEGIN EXCLUSIVE; "immediate" is what we need to acquire a reserved
+    // write lock at the start of the transaction.
+    return runWithSerializedQueue(serializedQueue, async () =>
+      db.transaction(async (tx) => {
+        const txBackend = createTransactionBackend({
+          capabilities,
+          db: tx,
+          operationStrategy,
+          profileHints: { isSync },
+          tableNames,
+          fulltextStrategy,
+          hasVectorEmbeddings,
+        });
+        return fn(txBackend);
+      }, { behavior: "immediate" }) as Promise<T>,
+    );
+  }
+
   const backend: GraphBackend = {
     ...operations,
 
@@ -588,11 +661,17 @@ export function createSqliteBackend(
       await db.run(sql`ANALYZE`);
     },
 
-    async setActiveSchema(graphId: string, version: number): Promise<void> {
-      await runOptionallyInTransaction(
-        backend,
-        (target) => target.setActiveSchema(graphId, version),
-        operations,
+    async commitSchemaVersion(
+      params: CommitSchemaVersionParams,
+    ): Promise<SchemaVersionRow> {
+      return runSchemaWriteTransaction((target) =>
+        target.commitSchemaVersion(params),
+      );
+    },
+
+    async setActiveVersion(params: SetActiveVersionParams): Promise<void> {
+      await runSchemaWriteTransaction((target) =>
+        target.setActiveVersion(params),
       );
     },
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -602,8 +602,39 @@ export type GraphBackend = Readonly<{
     graphId: string,
     version: number,
   ) => Promise<SchemaVersionRow | undefined>;
-  insertSchema: (params: InsertSchemaParams) => Promise<SchemaVersionRow>;
-  setActiveSchema: (graphId: string, version: number) => Promise<void>;
+  /**
+   * Atomically inserts a new schema version and activates it as a single
+   * transactional unit, with optimistic compare-and-swap on the currently
+   * active version.
+   *
+   * - If `expected.kind === "active"` and the actual active version
+   *   differs, throws `StaleVersionError` (caller should refetch and
+   *   retry).
+   * - If a row already exists at `params.version` with the same
+   *   `schemaHash`, returns it idempotently — reactivating it if it was
+   *   left inactive by an earlier crashed commit.
+   * - If a row already exists at `params.version` with a different
+   *   `schemaHash`, throws `SchemaContentConflictError`.
+   *
+   * Requires `capabilities.transactions === true`. On non-transactional
+   * backends (e.g. Cloudflare D1, drizzle-orm/neon-http) this method
+   * throws `ConfigurationError` rather than running with degraded
+   * atomicity that would silently re-introduce the orphan-row crash
+   * window the primitive exists to eliminate.
+   */
+  commitSchemaVersion: (
+    params: CommitSchemaVersionParams,
+  ) => Promise<SchemaVersionRow>;
+  /**
+   * Atomically flips the active schema pointer to an existing version,
+   * with optimistic compare-and-swap on the currently active version.
+   * Used by `rollbackSchema` and any other "promote/demote existing
+   * version" workflow. Throws `StaleVersionError` on CAS mismatch and
+   * `MigrationError` if the target version row does not exist.
+   *
+   * Same transactional requirements as `commitSchemaVersion`.
+   */
+  setActiveVersion: (params: SetActiveVersionParams) => Promise<void>;
 
   // === Embedding Operations (optional - depends on vector capabilities) ===
   upsertEmbedding?: (params: UpsertEmbeddingParams) => Promise<void>;
@@ -733,8 +764,8 @@ export function wrapWithManagedClose(
  * tolerate it must branch on the capability themselves.
  *
  * Pass `fallback` only when the toplevel backend method would recurse
- * — for example, when implementing `backend.setActiveSchema` itself,
- * pass the operation-level backend so the no-tx path doesn't loop.
+ * — pass the operation-level backend so the no-tx path doesn't loop
+ * back through the same toplevel method.
  */
 export async function runOptionallyInTransaction<T>(
   backend: GraphBackend,
@@ -799,6 +830,10 @@ export type CheckUniqueBatchParams = Readonly<{
 
 /**
  * Parameters for inserting a schema version.
+ *
+ * Used internally by backend implementations. Public callers go through
+ * `commitSchemaVersion`, which handles the insert + activate atomically
+ * with CAS guarantees.
  */
 export type InsertSchemaParams = Readonly<{
   graphId: string;
@@ -806,6 +841,53 @@ export type InsertSchemaParams = Readonly<{
   schemaHash: string;
   schemaDoc: SerializedSchema;
   isActive: boolean;
+}>;
+
+/**
+ * The caller's claim about the currently-active schema version, used as
+ * the optimistic compare-and-swap guard for `commitSchemaVersion`.
+ *
+ * - `{ kind: "initial" }` — caller is committing the first-ever version
+ *   for this graph and asserts no active version exists yet.
+ * - `{ kind: "active", version: N }` — caller observed version N as
+ *   active and is committing version N+1 against that baseline. The
+ *   commit fails with `StaleVersionError` if some other writer has
+ *   advanced or rolled back the pointer in the meantime.
+ *
+ * Tagged-union form (rather than a magic `version: 0` sentinel) because
+ * the two cases have materially different semantics: the initial path
+ * skips the "deactivate prior" UPDATE, and the no-active-row state is
+ * a *valid* expected state, not an out-of-band signal.
+ */
+export type CommitSchemaVersionExpected =
+  | Readonly<{ kind: "initial" }>
+  | Readonly<{ kind: "active"; version: number }>;
+
+/**
+ * Parameters for `commitSchemaVersion`.
+ */
+export type CommitSchemaVersionParams = Readonly<{
+  graphId: string;
+  /** CAS guard — see `CommitSchemaVersionExpected`. */
+  expected: CommitSchemaVersionExpected;
+  /** The new version to insert and activate. */
+  version: number;
+  schemaHash: string;
+  schemaDoc: SerializedSchema;
+}>;
+
+/**
+ * Parameters for `setActiveVersion`.
+ *
+ * Flips the active pointer from `expected` to `version` for an existing
+ * row. CAS prevents overwriting a concurrent rollback or commit.
+ */
+export type SetActiveVersionParams = Readonly<{
+  graphId: string;
+  /** CAS guard. Same semantics as `commitSchemaVersion.expected`. */
+  expected: CommitSchemaVersionExpected;
+  /** The version to mark active. Must already exist. */
+  version: number;
 }>;
 
 /**

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -502,11 +502,25 @@ export type TransactionOptions = Readonly<{
 // ============================================================
 
 /**
- * Transaction backend - a backend scoped to a transaction.
+ * Transaction backend — a backend scoped to a transaction.
+ *
+ * `commitSchemaVersion` and `setActiveVersion` are intentionally omitted:
+ * the atomicity / CAS guarantees of those primitives depend on
+ * dialect-specific write-locking (BEGIN IMMEDIATE on SQLite,
+ * `pg_advisory_xact_lock` on Postgres) acquired by the top-level
+ * backend wrappers, not the transaction itself. Calling them from a
+ * user-supplied `backend.transaction(...)` callback would bypass that
+ * locking and silently weaken the orphan-row crash window the primitive
+ * exists to eliminate. Schema commits go through the top-level backend
+ * methods only.
  */
 export type TransactionBackend = Omit<
   GraphBackend,
-  "transaction" | "close" | "refreshStatistics"
+  | "transaction"
+  | "close"
+  | "refreshStatistics"
+  | "commitSchemaVersion"
+  | "setActiveVersion"
 >;
 
 /**

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -576,6 +576,88 @@ export class MigrationError extends TypeGraphError {
   }
 }
 
+/**
+ * Thrown by `commitSchemaVersion` and `setActiveVersion` when the
+ * caller's view of the active schema version is out of date — another
+ * writer has already advanced it.
+ *
+ * Recovery: re-read the active version with `getActiveSchema(graphId)`,
+ * recompute against the new baseline, and retry. This is a routine
+ * concurrency signal, not a bug.
+ *
+ * `actual` is `0` when no active version exists yet (initial-commit race
+ * where another writer initialized first).
+ */
+export class StaleVersionError extends TypeGraphError {
+  declare readonly details: Readonly<{
+    graphId: string;
+    expected: number;
+    actual: number;
+  }>;
+
+  constructor(
+    details: Readonly<{
+      graphId: string;
+      expected: number;
+      actual: number;
+    }>,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `Schema version was advanced by another writer for graph "${details.graphId}": expected active version ${details.expected}, actual is ${details.actual}`,
+      "STALE_SCHEMA_VERSION",
+      {
+        details,
+        category: "system",
+        suggestion: `Re-read the active schema version, recompute the new version against that baseline, and retry the commit.`,
+        cause: options?.cause,
+      },
+    );
+    this.name = "StaleVersionError";
+  }
+}
+
+/**
+ * Thrown by `commitSchemaVersion` when a row already exists at the
+ * target version with a *different* schema hash — i.e. two writers
+ * committed materially different schemas at the same version number.
+ *
+ * Distinct from `StaleVersionError`: this is not a refetch-and-retry
+ * situation, it's a content disagreement that needs operator
+ * intervention. Typically caused by inconsistent application
+ * deployments writing schemas that hash differently.
+ */
+export class SchemaContentConflictError extends TypeGraphError {
+  declare readonly details: Readonly<{
+    graphId: string;
+    version: number;
+    existingHash: string;
+    incomingHash: string;
+  }>;
+
+  constructor(
+    details: Readonly<{
+      graphId: string;
+      version: number;
+      existingHash: string;
+      incomingHash: string;
+    }>,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `Schema content conflict for graph "${details.graphId}" at version ${details.version}: existing hash ${details.existingHash} differs from incoming hash ${details.incomingHash}`,
+      "SCHEMA_CONTENT_CONFLICT",
+      {
+        details,
+        category: "system",
+        suggestion: `Two writers committed different schemas at the same version. Reconcile the application deployments so they produce the same canonical schema, then retry.`,
+        cause: options?.cause,
+      },
+    );
+    this.name = "SchemaContentConflictError";
+  }
+}
+
 // ============================================================
 // Configuration Errors (category: "user")
 // ============================================================

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -99,6 +99,8 @@ export {
 
 export type {
   BackendCapabilities,
+  CommitSchemaVersionExpected,
+  CommitSchemaVersionParams,
   DeleteFulltextBatchParams,
   FulltextBatchRow,
   FulltextCapabilities,
@@ -106,6 +108,8 @@ export type {
   FulltextSearchParams,
   FulltextSearchResult,
   GraphBackend,
+  SchemaVersionRow,
+  SetActiveVersionParams,
   TransactionBackend,
   UpsertFulltextBatchParams,
   VectorCapabilities,
@@ -208,7 +212,9 @@ export {
   NodeConstraintNotFoundError,
   NodeNotFoundError,
   RestrictedDeleteError,
+  SchemaContentConflictError,
   SchemaMismatchError,
+  StaleVersionError,
   TypeGraphError,
   UniquenessError,
   UnsupportedPredicateError,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -240,7 +240,11 @@ export async function ensureSchema<G extends GraphDef>(
 /**
  * Initializes the schema for a new graph.
  *
- * Creates version 1 of the schema and marks it as active.
+ * Creates version 1 of the schema and marks it as active. Goes through
+ * the same `commitSchemaVersion` primitive as `migrateSchema` so the
+ * initial-commit race (two processes booting against an empty database
+ * simultaneously) resolves with `StaleVersionError` or idempotent
+ * success rather than a raw PK violation.
  *
  * @param backend - The database backend
  * @param graph - The graph definition
@@ -253,20 +257,24 @@ export async function initializeSchema<G extends GraphDef>(
   const schema = serializeSchema(graph, 1);
   const hash = await computeSchemaHash(schema);
 
-  return backend.insertSchema({
+  return backend.commitSchemaVersion({
     graphId: graph.id,
+    expected: { kind: "initial" },
     version: 1,
     schemaHash: hash,
     schemaDoc: schema,
-    isActive: true,
   });
 }
 
 /**
  * Migrates the schema to match the current graph definition.
  *
- * This creates a new schema version and marks it as active.
- * The old version is preserved for history/rollback.
+ * Creates a new schema version and atomically activates it via the
+ * `commitSchemaVersion` backend primitive — insert and activate happen
+ * in a single transactional unit with optimistic compare-and-swap on
+ * the currently-active version. If another writer has advanced the
+ * active version since `currentVersion` was read, this throws
+ * `StaleVersionError`; the caller should refetch and retry.
  *
  * @param backend - The database backend
  * @param graph - The current graph definition
@@ -282,17 +290,13 @@ export async function migrateSchema<G extends GraphDef>(
   const schema = serializeSchema(graph, newVersion);
   const hash = await computeSchemaHash(schema);
 
-  // Insert new version (not active yet)
-  await backend.insertSchema({
+  await backend.commitSchemaVersion({
     graphId: graph.id,
+    expected: { kind: "active", version: currentVersion },
     version: newVersion,
     schemaHash: hash,
     schemaDoc: schema,
-    isActive: false,
   });
-
-  // Atomically switch to the new version
-  await backend.setActiveSchema(graph.id, newVersion);
 
   return newVersion;
 }
@@ -303,24 +307,34 @@ export async function migrateSchema<G extends GraphDef>(
  * The target version must already exist in the version history.
  * This does not delete newer versions — it simply switches the active pointer.
  *
+ * Uses the `setActiveVersion` backend primitive, which performs the flip
+ * atomically with optimistic compare-and-swap on the currently-active
+ * version. Concurrent rollbacks or commits surface as
+ * `StaleVersionError`.
+ *
  * @param backend - The database backend
  * @param graphId - The graph ID
  * @param targetVersion - The version to roll back to
  * @throws MigrationError if the target version does not exist
+ * @throws StaleVersionError if another writer changed the active version concurrently
  */
 export async function rollbackSchema(
   backend: GraphBackend,
   graphId: string,
   targetVersion: number,
 ): Promise<void> {
-  const row = await backend.getSchemaVersion(graphId, targetVersion);
-  if (!row) {
+  const activeRow = await backend.getActiveSchema(graphId);
+  if (!activeRow) {
     throw new MigrationError(
-      `Cannot rollback to version ${targetVersion}: version does not exist.`,
-      { graphId, fromVersion: targetVersion, toVersion: targetVersion },
+      `Cannot rollback graph "${graphId}": no active schema version exists.`,
+      { graphId, fromVersion: 0, toVersion: targetVersion },
     );
   }
-  await backend.setActiveSchema(graphId, targetVersion);
+  await backend.setActiveVersion({
+    graphId,
+    expected: { kind: "active", version: activeRow.version },
+    version: targetVersion,
+  });
 }
 
 /**

--- a/packages/typegraph/tests/backends/adapter-test-suite.ts
+++ b/packages/typegraph/tests/backends/adapter-test-suite.ts
@@ -918,9 +918,10 @@ export function createAdapterTestSuite(
     // ============================================================
 
     describe("Schema Operations", () => {
-      it("inserts and retrieves active schema", async () => {
-        const inserted = await backend.insertSchema({
+      it("commits and retrieves the active schema", async () => {
+        const inserted = await backend.commitSchemaVersion({
           graphId: "test_graph",
+          expected: { kind: "initial" },
           version: 1,
           schemaHash: "abc123",
           schemaDoc: createTestSchemaDocument({
@@ -934,7 +935,6 @@ export function createAdapterTestSuite(
               },
             },
           }),
-          isActive: true,
         });
 
         expect(inserted.version).toBe(1);
@@ -956,34 +956,47 @@ export function createAdapterTestSuite(
         expect(active).toBeUndefined();
       });
 
-      it("inserts inactive schema", async () => {
-        await backend.insertSchema({
+      it("commits a successor version and deactivates the prior", async () => {
+        await backend.commitSchemaVersion({
           graphId: "test_graph",
+          expected: { kind: "initial" },
           version: 1,
-          schemaHash: "abc123",
+          schemaHash: "v1-hash",
           schemaDoc: createTestSchemaDocument(),
-          isActive: false,
         });
 
+        await backend.commitSchemaVersion({
+          graphId: "test_graph",
+          expected: { kind: "active", version: 1 },
+          version: 2,
+          schemaHash: "v2-hash",
+          schemaDoc: createTestSchemaDocument({ version: 2 }),
+        });
+
+        const v1 = await backend.getSchemaVersion("test_graph", 1);
+        const v2 = await backend.getSchemaVersion("test_graph", 2);
+        expect(v1!.is_active).toBe(false);
+        expect(v2!.is_active).toBe(true);
+
         const active = await backend.getActiveSchema("test_graph");
-        expect(active).toBeUndefined();
+        expect(active!.version).toBe(2);
       });
 
       it("handles schemas in different graphs", async () => {
-        await backend.insertSchema({
+        await backend.commitSchemaVersion({
           graphId: "graph_a",
+          expected: { kind: "initial" },
           version: 1,
           schemaHash: "hash-a",
           schemaDoc: createTestSchemaDocument({ graphId: "graph_a" }),
-          isActive: true,
         });
 
-        await backend.insertSchema({
+        await backend.commitSchemaVersion({
           graphId: "graph_b",
+          expected: { kind: "initial" },
           version: 1,
           schemaHash: "hash-b",
           schemaDoc: createTestSchemaDocument({ graphId: "graph_b" }),
-          isActive: true,
         });
 
         const activeA = await backend.getActiveSchema("graph_a");

--- a/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
@@ -42,9 +42,10 @@ describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () =
 
     expect(backend.dialect).toBe("postgres");
     // The headline behavior: HTTP can't hold a session, so transactions
-    // are off. Callers like `setActiveSchema` and `store.transaction`
-    // check this capability and fall through to sequential execution
-    // when it's false.
+    // are off. Callers like `store.transaction` check this capability
+    // and fall through to sequential execution when it's false.
+    // `commitSchemaVersion` is the exception — it requires atomicity
+    // and refuses with a typed ConfigurationError on this backend.
     expect(backend.capabilities.transactions).toBe(false);
     // Other capabilities are unchanged.
     expect(backend.capabilities.cte).toBe(true);

--- a/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
@@ -28,7 +28,36 @@ import { neon } from "@neondatabase/serverless";
 import { drizzle as drizzleNeonHttp } from "drizzle-orm/neon-http";
 import { describe, expect, it } from "vitest";
 
+import { ConfigurationError } from "../../../src";
 import { createPostgresBackend } from "../../../src/backend/postgres";
+import type { SerializedSchema } from "../../../src/schema/types";
+
+const STUB_SCHEMA_DOC: SerializedSchema = {
+  graphId: "neon_http_refusal",
+  version: 1,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  nodes: {},
+  edges: {},
+  ontology: {
+    metaEdges: {},
+    relations: [],
+    closures: {
+      subClassAncestors: {},
+      subClassDescendants: {},
+      broaderClosure: {},
+      narrowerClosure: {},
+      equivalenceSets: {},
+      disjointPairs: [],
+      partOfClosure: {},
+      hasPartClosure: {},
+      iriToKind: {},
+      edgeInverses: {},
+      edgeImplicationsClosure: {},
+      edgeImplyingClosure: {},
+    },
+  },
+  defaults: { onNodeDelete: "restrict", temporalMode: "current" },
+};
 
 describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () => {
   it("auto-disables transactions when neon-http is detected", () => {
@@ -68,6 +97,41 @@ describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () =
     // `execute` is always defined; it routes through db.execute for
     // neon-http.
     expect(typeof backend.execute).toBe("function");
+  });
+
+  it("refuses commitSchemaVersion before any HTTP traffic", async () => {
+    // The capability guard at the top of commitSchemaVersion fires
+    // synchronously, before any SQL is built or sent — so we can prove
+    // the refusal without hitting the invalid hostname. Documents the
+    // contract that schema migrations must run from a transactional
+    // driver (e.g. drizzle-orm/neon-serverless), not neon-http.
+    const sql = neon("postgresql://test:test@invalid.neon.tech/test");
+    const db = drizzleNeonHttp({ client: sql });
+    const backend = createPostgresBackend(db);
+
+    await expect(
+      backend.commitSchemaVersion({
+        graphId: "neon_http_refusal",
+        expected: { kind: "initial" },
+        version: 1,
+        schemaHash: "stub-hash",
+        schemaDoc: STUB_SCHEMA_DOC,
+      }),
+    ).rejects.toThrow(ConfigurationError);
+  });
+
+  it("refuses setActiveVersion before any HTTP traffic", async () => {
+    const sql = neon("postgresql://test:test@invalid.neon.tech/test");
+    const db = drizzleNeonHttp({ client: sql });
+    const backend = createPostgresBackend(db);
+
+    await expect(
+      backend.setActiveVersion({
+        graphId: "neon_http_refusal",
+        expected: { kind: "active", version: 1 },
+        version: 2,
+      }),
+    ).rejects.toThrow(ConfigurationError);
   });
 
   it("respects an explicit capabilities override", () => {

--- a/packages/typegraph/tests/commit-schema-version.test.ts
+++ b/packages/typegraph/tests/commit-schema-version.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Tests for the `commitSchemaVersion` and `setActiveVersion` backend
+ * primitives — the atomic insert-and-activate path that replaces the
+ * unwrapped `insertSchema` + `setActiveSchema` pair.
+ *
+ * Covered scenarios:
+ *   - Orphan-row reactivation (the original bug fix): an inactive row
+ *     left from a crashed earlier commit gets activated cleanly on retry.
+ *   - Same-hash idempotency (already active): re-running the same
+ *     commit returns the existing row without error.
+ *   - CAS guard: stale `expected.version` produces `StaleVersionError`
+ *     with the correct `actual` value populated.
+ *   - Initial-commit race: two callers both passing `{ kind: "initial" }`
+ *     resolve to the same active row (idempotent) when the schemas match,
+ *     and to `StaleVersionError` when they don't.
+ *   - Content conflict: same version, different hash → `SchemaContentConflictError`.
+ *   - Partial unique index: enforced at the storage layer.
+ *   - `setActiveVersion`: CAS guard + missing-target error path + rollback
+ *     happy path.
+ */
+import { sql } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+  MigrationError,
+  SchemaContentConflictError,
+  StaleVersionError,
+} from "../src";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
+import { computeSchemaHash, serializeSchema } from "../src/schema/serializer";
+import { createTestBackend, createTestDatabase } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Place = defineNode("Place", {
+  schema: z.object({ city: z.string() }),
+});
+
+function makeGraph(id: string) {
+  return defineGraph({
+    id,
+    nodes: { Person: { type: Person } },
+    edges: {},
+  });
+}
+
+function makeDivergentGraph(id: string) {
+  return defineGraph({
+    id,
+    nodes: { Person: { type: Person }, Place: { type: Place } },
+    edges: {},
+  });
+}
+
+async function buildCommitArguments(
+  graphId: string,
+  version: number,
+  graph = makeGraph(graphId),
+) {
+  const schema = serializeSchema(graph, version);
+  return {
+    schemaDoc: schema,
+    schemaHash: await computeSchemaHash(schema),
+  };
+}
+
+describe("commitSchemaVersion: initial commit", () => {
+  let backend: GraphBackend;
+
+  beforeEach(() => {
+    backend = createTestBackend();
+  });
+
+  it("inserts version 1 active when expected is initial", async () => {
+    const { schemaDoc, schemaHash } = await buildCommitArguments("g", 1);
+    const row = await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash,
+      schemaDoc,
+    });
+
+    expect(row.version).toBe(1);
+    expect(row.is_active).toBe(true);
+    expect(row.schema_hash).toBe(schemaHash);
+  });
+
+  it("is idempotent on re-run with the same hash", async () => {
+    const { schemaDoc, schemaHash } = await buildCommitArguments("g", 1);
+    const first = await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash,
+      schemaDoc,
+    });
+    const second = await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash,
+      schemaDoc,
+    });
+
+    // Same row, no errors. Idempotency lets two boot processes race
+    // through initial setup with the same compile-time graph.
+    expect(second.version).toBe(first.version);
+    expect(second.schema_hash).toBe(first.schema_hash);
+    expect(second.is_active).toBe(true);
+  });
+
+  it("throws StaleVersionError when expected initial but the target version is fresh and another version is active", async () => {
+    // First writer initializes at v=1.
+    const v1 = await buildCommitArguments("g", 1);
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash: v1.schemaHash,
+      schemaDoc: v1.schemaDoc,
+    });
+
+    // A second writer with stale code tries to initialize at v=2
+    // (claiming "initial" — i.e. it believes nothing is active yet).
+    // No row exists at v=2 so the same-version-conflict path doesn't
+    // fire; the CAS branch correctly surfaces it as stale.
+    const v2 = await buildCommitArguments("g", 2, makeDivergentGraph("g"));
+    let captured: unknown;
+    try {
+      await backend.commitSchemaVersion({
+        graphId: "g",
+        expected: { kind: "initial" },
+        version: 2,
+        schemaHash: v2.schemaHash,
+        schemaDoc: v2.schemaDoc,
+      });
+    } catch (error) {
+      captured = error;
+    }
+    expect(captured).toBeInstanceOf(StaleVersionError);
+    expect((captured as StaleVersionError).details.expected).toBe(0);
+    expect((captured as StaleVersionError).details.actual).toBe(1);
+  });
+
+  it("returns SchemaContentConflictError when two writers race initial with different schemas", async () => {
+    // The other half of the initial-commit race: same target version,
+    // different hashes. This is a content disagreement, not a stale
+    // read — different recovery action, different error type.
+    const a = await buildCommitArguments("g", 1);
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash: a.schemaHash,
+      schemaDoc: a.schemaDoc,
+    });
+
+    const b = await buildCommitArguments("g", 1, makeDivergentGraph("g"));
+    await expect(
+      backend.commitSchemaVersion({
+        graphId: "g",
+        expected: { kind: "initial" },
+        version: 1,
+        schemaHash: b.schemaHash,
+        schemaDoc: b.schemaDoc,
+      }),
+    ).rejects.toThrow(SchemaContentConflictError);
+  });
+});
+
+describe("commitSchemaVersion: successor commit (CAS guard)", () => {
+  let backend: GraphBackend;
+
+  beforeEach(async () => {
+    backend = createTestBackend();
+    const init = await buildCommitArguments("g", 1);
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash: init.schemaHash,
+      schemaDoc: init.schemaDoc,
+    });
+  });
+
+  it("commits v2 atomically and deactivates v1", async () => {
+    const next = await buildCommitArguments("g", 2, makeDivergentGraph("g"));
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "active", version: 1 },
+      version: 2,
+      schemaHash: next.schemaHash,
+      schemaDoc: next.schemaDoc,
+    });
+
+    const v1 = await backend.getSchemaVersion("g", 1);
+    const v2 = await backend.getSchemaVersion("g", 2);
+    expect(v1!.is_active).toBe(false);
+    expect(v2!.is_active).toBe(true);
+
+    const active = await backend.getActiveSchema("g");
+    expect(active!.version).toBe(2);
+  });
+
+  it("throws StaleVersionError with correct actual when expected is stale", async () => {
+    // Simulate another writer having already advanced to v2.
+    const next = await buildCommitArguments("g", 2, makeDivergentGraph("g"));
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "active", version: 1 },
+      version: 2,
+      schemaHash: next.schemaHash,
+      schemaDoc: next.schemaDoc,
+    });
+
+    // Now a stale caller tries to commit v3 against expected=v1.
+    // No row exists at v3, so the conflict-check short-circuit doesn't
+    // fire and the CAS branch surfaces the stale read with the actual
+    // version (2) populated.
+    const stale = await buildCommitArguments("g", 3);
+    let captured: unknown;
+    try {
+      await backend.commitSchemaVersion({
+        graphId: "g",
+        expected: { kind: "active", version: 1 },
+        version: 3,
+        schemaHash: stale.schemaHash,
+        schemaDoc: stale.schemaDoc,
+      });
+    } catch (error) {
+      captured = error;
+    }
+    expect(captured).toBeInstanceOf(StaleVersionError);
+    const error = captured as StaleVersionError;
+    expect(error.details.expected).toBe(1);
+    expect(error.details.actual).toBe(2);
+    expect(error.details.graphId).toBe("g");
+  });
+
+  it("reactivates an orphan inactive row left by a crashed prior commit", async () => {
+    // Reach into the underlying SQLite instance to simulate the crash:
+    // we already have v1 active, but the *previous* migration to v2
+    // crashed after the insert and before the activate, leaving v2 as
+    // an inactive orphan. The retry path should reactivate it cleanly.
+    const db = createTestDatabase();
+    // Create a fresh backend on top of the shared db so the test can
+    // both seed the orphan and exercise the primitive against the same
+    // storage. createTestDatabase already creates the DDL.
+    const orphanBackend = createSqliteBackend(db);
+
+    const init = await buildCommitArguments("orphan_g", 1);
+    await orphanBackend.commitSchemaVersion({
+      graphId: "orphan_g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash: init.schemaHash,
+      schemaDoc: init.schemaDoc,
+    });
+
+    // Inject an orphan inactive v2 row. Mirrors the post-crash state:
+    // insertSchema(v=2, isActive=false) succeeded, setActiveSchema never ran.
+    const orphan = await buildCommitArguments(
+      "orphan_g",
+      2,
+      makeDivergentGraph("orphan_g"),
+    );
+    db.run(sql`
+      INSERT INTO typegraph_schema_versions
+        (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+      VALUES (
+        'orphan_g', 2, ${orphan.schemaHash},
+        ${JSON.stringify(orphan.schemaDoc)},
+        '2026-01-01T00:00:00.000Z', 0
+      )
+    `);
+
+    // Retry the same commit. The new primitive detects the orphan
+    // (same hash, inactive) and activates it without trying to insert
+    // again — the bug that this issue fixes.
+    const reactivated = await orphanBackend.commitSchemaVersion({
+      graphId: "orphan_g",
+      expected: { kind: "active", version: 1 },
+      version: 2,
+      schemaHash: orphan.schemaHash,
+      schemaDoc: orphan.schemaDoc,
+    });
+    expect(reactivated.version).toBe(2);
+    expect(reactivated.is_active).toBe(true);
+
+    const active = await orphanBackend.getActiveSchema("orphan_g");
+    expect(active!.version).toBe(2);
+    const v1 = await orphanBackend.getSchemaVersion("orphan_g", 1);
+    expect(v1!.is_active).toBe(false);
+  });
+
+  it("throws SchemaContentConflictError when target version exists with a different hash", async () => {
+    // Commit v2 with one schema...
+    const a = await buildCommitArguments("g", 2, makeDivergentGraph("g"));
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "active", version: 1 },
+      version: 2,
+      schemaHash: a.schemaHash,
+      schemaDoc: a.schemaDoc,
+    });
+
+    // ...then re-attempt v2 with a *different* hash. Same-version
+    // conflict is not a stale-read race — it's a content disagreement
+    // that needs operator intervention, so it gets its own error type.
+    const conflicting = await buildCommitArguments("g", 2);
+    let captured: unknown;
+    try {
+      await backend.commitSchemaVersion({
+        graphId: "g",
+        expected: { kind: "active", version: 2 },
+        version: 2,
+        schemaHash: conflicting.schemaHash,
+        schemaDoc: conflicting.schemaDoc,
+      });
+    } catch (error) {
+      captured = error;
+    }
+    expect(captured).toBeInstanceOf(SchemaContentConflictError);
+    const error = captured as SchemaContentConflictError;
+    expect(error.details.version).toBe(2);
+    expect(error.details.existingHash).toBe(a.schemaHash);
+    expect(error.details.incomingHash).toBe(conflicting.schemaHash);
+  });
+});
+
+describe("partial unique index: at most one active version per graph", () => {
+  it("the storage layer rejects a second is_active=TRUE row on the same graph", () => {
+    const db = createTestDatabase();
+    // Seed two rows by raw DDL, both is_active=true. The partial unique
+    // index should refuse the second insert.
+    db.run(sql`
+      INSERT INTO typegraph_schema_versions
+        (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+      VALUES ('dup_g', 1, 'h1', '{}', 't', 1)
+    `);
+
+    let captured: unknown;
+    try {
+      db.run(sql`
+        INSERT INTO typegraph_schema_versions
+          (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+        VALUES ('dup_g', 2, 'h2', '{}', 't', 1)
+      `);
+    } catch (error) {
+      captured = error;
+    }
+    // Drizzle wraps the SQLITE_CONSTRAINT_UNIQUE error; assert via the
+    // cause chain rather than the wrapper's message.
+    expect(captured).toBeInstanceOf(Error);
+    const fullMessage = [
+      (captured as Error).message,
+      (captured as { cause?: { message?: string } }).cause?.message ?? "",
+    ].join("\n");
+    expect(fullMessage).toMatch(/UNIQUE/i);
+  });
+
+  it("allows multiple inactive rows alongside a single active row", () => {
+    const db = createTestDatabase();
+    db.run(sql`
+      INSERT INTO typegraph_schema_versions
+        (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+      VALUES ('multi_g', 1, 'h1', '{}', 't', 0)
+    `);
+    db.run(sql`
+      INSERT INTO typegraph_schema_versions
+        (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+      VALUES ('multi_g', 2, 'h2', '{}', 't', 0)
+    `);
+    db.run(sql`
+      INSERT INTO typegraph_schema_versions
+        (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+      VALUES ('multi_g', 3, 'h3', '{}', 't', 1)
+    `);
+    // No throw — three rows, only one with is_active=1.
+  });
+});
+
+describe("setActiveVersion", () => {
+  let backend: GraphBackend;
+
+  beforeEach(async () => {
+    backend = createTestBackend();
+    const v1 = await buildCommitArguments("g", 1);
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash: v1.schemaHash,
+      schemaDoc: v1.schemaDoc,
+    });
+    const v2 = await buildCommitArguments("g", 2, makeDivergentGraph("g"));
+    await backend.commitSchemaVersion({
+      graphId: "g",
+      expected: { kind: "active", version: 1 },
+      version: 2,
+      schemaHash: v2.schemaHash,
+      schemaDoc: v2.schemaDoc,
+    });
+  });
+
+  it("flips the active pointer to a prior version with matching CAS", async () => {
+    await backend.setActiveVersion({
+      graphId: "g",
+      expected: { kind: "active", version: 2 },
+      version: 1,
+    });
+
+    const active = await backend.getActiveSchema("g");
+    expect(active!.version).toBe(1);
+
+    const v2 = await backend.getSchemaVersion("g", 2);
+    expect(v2!.is_active).toBe(false);
+  });
+
+  it("throws StaleVersionError when expected does not match", async () => {
+    let captured: unknown;
+    try {
+      await backend.setActiveVersion({
+        graphId: "g",
+        expected: { kind: "active", version: 99 },
+        version: 1,
+      });
+    } catch (error) {
+      captured = error;
+    }
+    expect(captured).toBeInstanceOf(StaleVersionError);
+    expect((captured as StaleVersionError).details.actual).toBe(2);
+  });
+
+  it("throws MigrationError when target version does not exist", async () => {
+    await expect(
+      backend.setActiveVersion({
+        graphId: "g",
+        expected: { kind: "active", version: 2 },
+        version: 99,
+      }),
+    ).rejects.toThrow(MigrationError);
+  });
+});

--- a/packages/typegraph/tests/no-transactions-fallthrough.test.ts
+++ b/packages/typegraph/tests/no-transactions-fallthrough.test.ts
@@ -10,10 +10,13 @@
  * `backend.transaction(...)` in any of these paths, the corresponding
  * test will fail with the synthetic transaction-disabled error.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  ConfigurationError,
   createStore,
   defineEdge,
   defineGraph,
@@ -21,6 +24,8 @@ import {
   type GraphBackend,
   searchable,
 } from "../src";
+import { generateSqliteDDL } from "../src/backend/drizzle/ddl";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
 import { computeSchemaHash, serializeSchema } from "../src/schema/serializer";
 import { createTestBackend } from "./test-utils";
 
@@ -88,35 +93,12 @@ describe("backends with transactions: false fall through to sequential execution
     expect(backend.capabilities.transactions).toBe(false);
   });
 
-  it("setActiveSchema runs sequentially without throwing", async () => {
-    // Insert two real schema versions, then flip the active pointer.
-    // The toplevel backend used to wrap deactivate-all + activate in a
-    // transaction; the fall-through executes them as two sequential
-    // statements.
-    const v1 = serializeSchema(graph, 1);
-    const v2 = serializeSchema(graph, 2);
-
-    await backend.insertSchema({
-      graphId: graph.id,
-      version: 1,
-      schemaHash: await computeSchemaHash(v1),
-      schemaDoc: v1,
-      isActive: true,
-    });
-    await backend.insertSchema({
-      graphId: graph.id,
-      version: 2,
-      schemaHash: await computeSchemaHash(v2),
-      schemaDoc: v2,
-      isActive: false,
-    });
-
-    await expect(backend.setActiveSchema(graph.id, 2)).resolves.toBeUndefined();
-
-    const active = await backend.getActiveSchema(graph.id);
-    expect(active?.version).toBe(2);
-    expect(active?.is_active).toBe(true);
-  });
+  // Note: schema commits are NOT a fall-through path — they refuse on
+  // non-transactional backends. That contract is exercised below with a
+  // genuinely-non-transactional backend, since the synthetic disable
+  // wrapper used elsewhere in this file only overrides public methods
+  // and can't reach into the backend's closure-scoped transaction
+  // config.
 
   it("store.transaction(fn) executes fn against the main backend", async () => {
     const store = createStore(graph, backend);
@@ -211,5 +193,51 @@ describe("backends with transactions: false fall through to sequential execution
     expect(result.processed).toBe(2);
     expect(result.upserted).toBe(2);
     expect(result.skipped).toBe(0);
+  });
+});
+
+describe("backends with transactions: false refuse schema commits", () => {
+  // Genuine non-transactional configuration via the SQLite execution
+  // profile, so the closure-scoped transactionMode inside the backend
+  // observes "none" — the production code path for D1 / DurableObjects.
+  let nonTxBackend: GraphBackend;
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    for (const statement of generateSqliteDDL()) {
+      sqlite.exec(statement);
+    }
+    nonTxBackend = createSqliteBackend(db, {
+      executionProfile: { transactionMode: "none", isSync: true },
+    });
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("commitSchemaVersion throws ConfigurationError", async () => {
+    const v1 = serializeSchema(graph, 1);
+    await expect(
+      nonTxBackend.commitSchemaVersion({
+        graphId: graph.id,
+        expected: { kind: "initial" },
+        version: 1,
+        schemaHash: await computeSchemaHash(v1),
+        schemaDoc: v1,
+      }),
+    ).rejects.toThrow(ConfigurationError);
+  });
+
+  it("setActiveVersion throws ConfigurationError", async () => {
+    await expect(
+      nonTxBackend.setActiveVersion({
+        graphId: graph.id,
+        expected: { kind: "active", version: 1 },
+        version: 2,
+      }),
+    ).rejects.toThrow(ConfigurationError);
   });
 });

--- a/packages/typegraph/tests/schema-migration.test.ts
+++ b/packages/typegraph/tests/schema-migration.test.ts
@@ -246,11 +246,11 @@ describe("Safe Migration", () => {
     expect(v1).toBeDefined();
     expect(v2).toBeDefined();
     expect(v2?.is_active).toBe(true);
-    // Note: v1 should now be inactive after setActiveSchema was called for v2
+    // After commitSchemaVersion, v1 should be inactive in the same atomic step
     expect(v1?.is_active).toBe(false);
   });
 
-  it("setActiveSchema deactivates previous versions", async () => {
+  it("commitSchemaVersion deactivates previous versions", async () => {
     const backend = createTestBackend();
 
     // Initialize with v1


### PR DESCRIPTION
- Replace the unwrapped `insertSchema` + `setActiveSchema` two-step migration flow with a single atomic `commitSchemaVersion` backend primitive (plus `setActiveVersion` for rollback). Fixes the orphan-row bug where a crash between insert and activate left the system wedged at the next `ensureSchema` call.
- Adds optimistic compare-and-swap on the currently-active version with a tagged-union `expected` guard, idempotent retry on same-hash inputs (orphan reactivation), and a distinct `SchemaContentConflictError` for same-version-different-hash collisions.
- Adds a partial unique index `(graph_id) WHERE is_active = TRUE` on `typegraph_schema_versions` as defense in depth at the storage layer; refuses the primitive on non-transactional backends (D1, neon-http, `transactionMode: "none"`) with `ConfigurationError` rather than silently degrading.

Closes #104.

## How it works

- **SQLite locking**: `BEGIN IMMEDIATE` (sql mode) or Drizzle's `behavior: "immediate"` (drizzle mode) acquires a reserved write lock so the read-then-write CAS is serialized.
- **Postgres locking**: `pg_advisory_xact_lock(hashtext(graphId))` serializes commits per-graph, covering both the initial-commit and successor-commit cases under one mechanism.
- **Algorithm precedence**: same-version-different-hash → `SchemaContentConflictError` (always wins; content disagreements aren't a refetch-and-retry situation); same-version-same-hash + active → idempotent return; CAS guard; orphan reactivation; fresh insert.

## Breaking change for backend implementers

`insertSchema` and `setActiveSchema` are removed from the `GraphBackend` interface; custom implementations must implement `commitSchemaVersion` and `setActiveVersion` instead. Public callers (`initializeSchema`, `migrateSchema`, `rollbackSchema`) need no changes — they route through the new primitives transparently.

Existing deployments need to add the partial unique index on upgrade. `bootstrapTables` regenerates the full DDL set (idempotent); manually-managed schemas should run `CREATE UNIQUE INDEX IF NOT EXISTS typegraph_schema_versions_one_active_per_graph_idx ON typegraph_schema_versions (graph_id) WHERE is_active = TRUE`.