### PR TITLE
feat: RuntimeGraphDocument value layer and Zod compiler (#101 PR 3/6)

### DIFF
--- a/.changeset/runtime-extension-document.md
+++ b/.changeset/runtime-extension-document.md
@@ -1,0 +1,77 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `defineRuntimeExtension(...)` and `compileRuntimeExtension(...)` — a TypeGraph-native runtime graph document and a one-way compiler that turns it into Zod-bearing `NodeType` / `EdgeType` / `OntologyRelation` values. This is the value-layer foundation of the runtime-extension feature (issue #101 PR 3/6); persistence (`SerializedSchema.runtimeDocument`), the loader rewire, and `store.evolve()` land in PRs 4 and 5.
+
+```typescript
+import {
+  compileRuntimeExtension,
+  defineRuntimeExtension,
+} from "@nicia-ai/typegraph";
+
+const document = defineRuntimeExtension({
+  nodes: {
+    Paper: {
+      properties: {
+        doi: { type: "string" },
+        title: { type: "string", searchable: { language: "english" } },
+        abstract: {
+          type: "string",
+          searchable: { language: "english" },
+          optional: true,
+        },
+        publishedAt: { type: "string", format: "datetime" },
+        publicationType: {
+          type: "enum",
+          values: ["preprint", "conference", "journal", "workshop"],
+        },
+      },
+      unique: [{ name: "paper_doi", fields: ["doi"] }],
+    },
+    Author: {
+      properties: { name: { type: "string", minLength: 1 } },
+    },
+  },
+  edges: {
+    authoredBy: { from: ["Paper"], to: ["Author"], properties: {} },
+  },
+});
+
+const compiled = compileRuntimeExtension(document);
+// compiled.nodes[*].type is a NodeType, structurally indistinguishable from
+// the equivalent hand-written `defineNode(...)`.
+```
+
+**Why a TypeGraph-native document and not JSON Schema → Zod.** The existing `Zod → JSON Schema` path is one-way (`schema/deserializer.ts:5` documents the constraint). Running the loop in the other direction would lose `searchable()` markers, the `embedding()` brand, `.optional()` shape, and unique-constraint extraction — exactly the metadata the rest of TypeGraph reads at runtime. Owning both ends of the document → Zod path keeps the round-trip lossless. The runtime document is the canonical durable form; Zod is derived on each load. PR 4 will persist this document; PR 5 will let `store.evolve()` commit one and rebuild a `Store<ExtendedGraph>`.
+
+**v1 property-type subset is intentionally narrow** — it covers what LLM-induced schemas actually emit and nothing more. Anything outside the set fails synchronously at `defineRuntimeExtension(...)` with a JSON-pointer path to the offending node.
+
+| Type | Refinements |
+|---|---|
+| `string` | `minLength`, `maxLength`, `pattern`, `format: "datetime" \| "uri"` |
+| `number` | `min`, `max`, `int` |
+| `boolean` | — |
+| `enum` | `values: readonly string[]` |
+| `array` | `items: <any of these types>` (no nested arrays) |
+| `object` | `properties: { ... }` (single nesting level) |
+
+Plus per-property `optional`, `searchable: { language? }`, `embedding: { dimensions }`, and per-kind `unique: [{ name, fields, scope?, collation?, where? }]` where `where` is limited to `isNull` / `isNotNull` (matches the existing `serializeWherePredicate` capability). Adding refinements later is non-breaking; allowing the wrong shape now is forever.
+
+**Modifier combinations the v1 compiler can't honor are rejected at validation**, with an `INVALID_PROPERTY_REFINEMENT` issue and a JSON-pointer path:
+
+- `format` + `searchable` — the format-routed Zod schemas (`z.iso.datetime` / `z.url`) aren't `z.ZodString` and can't carry the searchable brand.
+- `format` + `minLength` / `maxLength` / `pattern` — same shape limitation; mixing them silently dropped the refinements before this fix.
+- `embedding` + item refinements — `embedding(dimensions)` replaces the array's item validator, so any `min` / `max` / `int` on the items would silently disappear.
+
+**Edge endpoints can reference unresolved kinds.** Endpoint names that don't match a kind declared in this same document are preserved as raw strings on `CompiledEdge.from` / `to` (typed `(NodeType | string)[]`) so the host-graph merge step can resolve them against compile-time kinds or treat them as external IRIs. Cross-graph resolution is intentionally out of scope for this PR.
+
+**Hierarchical-cycle detection normalizes inverse meta-edges before checking**, mirroring the registry's relation flattening: `narrower A→B` and `hasPart A→B` are treated as `broader B→A` and `partOf B→A` respectively. Mixed-direction cycles (e.g. `broader A→B` + `narrower A→B`) are now caught at validation instead of slipping through to runtime.
+
+**Round-trip parity is the load-bearing invariant.** For every type and modifier in the v1 subset, the test suite declares the same kind two ways — hand-written via `defineNode` / `defineEdge` and document-via-`defineRuntimeExtension` — and asserts that downstream introspection (`getSearchableMetadata`, `getEmbeddingDimensions`, unique-constraint extraction) returns identical results, that valid inputs parse to the same value, and that invalid inputs reject with the same issue paths. Property tests over the type subset further generate arbitrary documents and assert the compile pipeline always produces a Zod schema that accepts the document's own example values.
+
+**Two `validateRuntimeExtension` shapes.** Consumers that prefer `Result`-style get `validateRuntimeExtension(input)` returning `Result<RuntimeGraphDocument, RuntimeExtensionValidationError>`. The throw-on-error variant `defineRuntimeExtension(input)` is a thin wrapper that unwraps. Errors carry a structured `issues` array with stable `RuntimeExtensionIssueCode` values and JSON-pointer paths so callers can render field-level diagnostics without parsing message text.
+
+**Out of scope for this PR.** No `store.evolve()`. No `SerializedSchema` changes. No persistence. No DDL. No backend touches. The compiled output is a pure value the next PR will merge into a `GraphDef`.
+
+Closes part of #101.

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -402,6 +402,41 @@ export type {
 } from "./query";
 
 // ============================================================
+// Runtime Extension (issue #101)
+// ============================================================
+
+export type {
+  CompiledEdge,
+  CompiledExtension,
+  CompiledNode,
+  RuntimeArrayItemType,
+  RuntimeArrayProperty,
+  RuntimeBooleanProperty,
+  RuntimeEdgeDocument,
+  RuntimeEmbeddingModifier,
+  RuntimeEnumProperty,
+  RuntimeExtensionIssue,
+  RuntimeExtensionIssueCode,
+  RuntimeGraphDocument,
+  RuntimeNodeDocument,
+  RuntimeNumberProperty,
+  RuntimeObjectFieldProperty,
+  RuntimeObjectProperty,
+  RuntimeOntologyRelation,
+  RuntimePropertyType,
+  RuntimeSearchableModifier,
+  RuntimeStringProperty,
+  RuntimeUniqueConstraint,
+  RuntimeUniqueWhere,
+} from "./runtime";
+export {
+  compileRuntimeExtension,
+  defineRuntimeExtension,
+  RuntimeExtensionValidationError,
+  validateRuntimeExtension,
+} from "./runtime";
+
+// ============================================================
 // Utilities
 // ============================================================
 

--- a/packages/typegraph/src/runtime/compiler.ts
+++ b/packages/typegraph/src/runtime/compiler.ts
@@ -1,0 +1,400 @@
+/**
+ * One-way compiler from a validated `RuntimeGraphDocument` to Zod-bearing
+ * `NodeType` / `EdgeType` / `OntologyRelation` values.
+ *
+ * The output is structurally indistinguishable from equivalent
+ * compile-time `defineNode` / `defineEdge` declarations: `searchable()`
+ * and `embedding()` wrappers are reapplied so introspection helpers see
+ * the same metadata, optional properties use the standard `.optional()`
+ * chain, and unique-constraint `where` callbacks return the predicate
+ * shape `serializeWherePredicate` consumes.
+ */
+import { z, type ZodObject, type ZodRawShape, type ZodType } from "zod";
+
+import { defineEdge } from "../core/edge";
+import { embedding } from "../core/embedding";
+import { defineNode } from "../core/node";
+import { searchable } from "../core/searchable";
+import {
+  type EdgeType,
+  type NodeType,
+  type UniqueConstraint,
+} from "../core/types";
+import { ALL_META_EDGE_NAMES, type MetaEdgeName } from "../ontology/constants";
+import { core as coreOntology } from "../ontology/core-meta-edges";
+import { type MetaEdge, type OntologyRelation } from "../ontology/types";
+import {
+  type RuntimeArrayItemType,
+  type RuntimeArrayProperty,
+  type RuntimeEdgeDocument,
+  type RuntimeEnumProperty,
+  type RuntimeGraphDocument,
+  type RuntimeNodeDocument,
+  type RuntimeNumberProperty,
+  type RuntimeObjectProperty,
+  type RuntimeOntologyRelation,
+  type RuntimePropertyType,
+  type RuntimeStringProperty,
+  type RuntimeUniqueConstraint,
+} from "./document-types";
+import { compactUndefined } from "./internal";
+
+// ============================================================
+// Public types
+// ============================================================
+
+/**
+ * Compiled output of a runtime extension document, ready to merge into a
+ * host `GraphDef`. Each `OntologyRelation`'s `from` / `to` is a `NodeType`
+ * when the document name matches a declared kind, or the raw string
+ * (treated as an external IRI by downstream code) otherwise.
+ */
+export type CompiledExtension = Readonly<{
+  nodes: readonly CompiledNode[];
+  edges: readonly CompiledEdge[];
+  ontology: readonly OntologyRelation[];
+}>;
+
+export type CompiledNode = Readonly<{
+  type: NodeType;
+  unique: readonly UniqueConstraint[];
+}>;
+
+/**
+ * `from` / `to` carry one entry per endpoint name from the document — a
+ * `NodeType` when the name resolves to a kind declared in this same
+ * extension, or the raw string otherwise. Unresolved strings are
+ * preserved (not dropped) so the host-graph merge step can resolve them
+ * against compile-time kinds or treat them as external IRIs.
+ *
+ * The `type: EdgeType` is built with only the resolved `NodeType`
+ * references; merge-time reconstructs it once the full endpoint set is
+ * known.
+ */
+export type CompiledEdge = Readonly<{
+  type: EdgeType;
+  from: readonly (NodeType | string)[];
+  to: readonly (NodeType | string)[];
+}>;
+
+// ============================================================
+// Compilation entry point
+// ============================================================
+
+/**
+ * Compiles a validated runtime extension document into Zod-bearing kinds.
+ *
+ * Pure function with no I/O. Assumes the input has already passed
+ * `validateRuntimeExtension(...)` — invariant violations (e.g. unknown
+ * meta-edge name) are programming bugs and surface as plain `Error`s.
+ */
+export function compileRuntimeExtension(
+  document: RuntimeGraphDocument,
+): CompiledExtension {
+  const nodes: CompiledNode[] = [];
+  const nodeTypeByName = new Map<string, NodeType>();
+
+  for (const [kindName, nodeDocument] of Object.entries(document.nodes ?? {})) {
+    const compiled = compileNode(kindName, nodeDocument);
+    nodes.push(compiled);
+    nodeTypeByName.set(kindName, compiled.type);
+  }
+
+  const edges: CompiledEdge[] = [];
+  for (const [kindName, edgeDocument] of Object.entries(document.edges ?? {})) {
+    const compiled = compileEdge(kindName, edgeDocument, nodeTypeByName);
+    edges.push(compiled);
+  }
+
+  const ontology: OntologyRelation[] = [];
+  for (const relation of document.ontology ?? []) {
+    ontology.push(compileOntologyRelation(relation, nodeTypeByName));
+  }
+
+  return Object.freeze({
+    nodes: Object.freeze(nodes),
+    edges: Object.freeze(edges),
+    ontology: Object.freeze(ontology),
+  });
+}
+
+// ============================================================
+// Node compilation
+// ============================================================
+
+function compileNode(
+  kindName: string,
+  document: RuntimeNodeDocument,
+): CompiledNode {
+  const schema = buildObjectSchema(document.properties);
+
+  const type = defineNode(
+    kindName,
+    compactUndefined({
+      schema,
+      description: document.description,
+      annotations: document.annotations,
+    }),
+  );
+
+  const unique = (document.unique ?? []).map((constraint) =>
+    compileUniqueConstraint(constraint),
+  );
+
+  return Object.freeze({ type, unique: Object.freeze(unique) });
+}
+
+// ============================================================
+// Edge compilation
+// ============================================================
+
+function compileEdge(
+  kindName: string,
+  document: RuntimeEdgeDocument,
+  nodeTypeByName: ReadonlyMap<string, NodeType>,
+): CompiledEdge {
+  const schema = buildObjectSchema(document.properties ?? {});
+
+  const from = document.from.map(
+    (name): NodeType | string => nodeTypeByName.get(name) ?? name,
+  );
+  const to = document.to.map(
+    (name): NodeType | string => nodeTypeByName.get(name) ?? name,
+  );
+
+  const resolvedFrom = from.filter(
+    (entry): entry is NodeType => typeof entry !== "string",
+  );
+  const resolvedTo = to.filter(
+    (entry): entry is NodeType => typeof entry !== "string",
+  );
+
+  // Cast widens `defineEdge`'s narrowed overload return back to the
+  // generic public `EdgeType`. The constructed EdgeType only sees the
+  // resolved endpoints; merge-time rebuilds it with the full set.
+  const type = defineEdge(
+    kindName,
+    compactUndefined({
+      schema,
+      description: document.description,
+      annotations: document.annotations,
+      from: resolvedFrom,
+      to: resolvedTo,
+    }),
+  ) as unknown as EdgeType;
+
+  return Object.freeze({
+    type,
+    from: Object.freeze(from),
+    to: Object.freeze(to),
+  });
+}
+
+function buildObjectSchema(
+  properties: Readonly<Record<string, RuntimePropertyType>>,
+): ZodObject<ZodRawShape> {
+  const shape: Record<string, ZodType> = {};
+  for (const [propertyName, propertyType] of Object.entries(properties)) {
+    shape[propertyName] = applyOptional(
+      compileProperty(propertyType),
+      propertyType,
+    );
+  }
+  return z.object(shape);
+}
+
+// ============================================================
+// Property compilation (RuntimePropertyType -> z.ZodType)
+// ============================================================
+
+function compileProperty(property: RuntimePropertyType): ZodType {
+  switch (property.type) {
+    case "string": {
+      return compileStringProperty(property);
+    }
+    case "number": {
+      return compileNumberProperty(property);
+    }
+    case "boolean": {
+      return z.boolean();
+    }
+    case "enum": {
+      return compileEnumProperty(property);
+    }
+    case "array": {
+      return compileArrayProperty(property);
+    }
+    case "object": {
+      return compileObjectProperty(property);
+    }
+  }
+}
+
+function compileStringProperty(property: RuntimeStringProperty): ZodType {
+  // `searchable` and `format` are mutually exclusive (rejected by
+  // validation): the format-routed schemas (`z.iso.datetime` / `z.url`)
+  // are not z.ZodString subclasses we can chain `searchable()` through.
+  if (property.searchable !== undefined) {
+    return applyStringRefinements(searchable(property.searchable), property);
+  }
+  if (property.format === "datetime") {
+    return z.iso.datetime();
+  }
+  if (property.format === "uri") {
+    return z.url();
+  }
+  return applyStringRefinements(z.string(), property);
+}
+
+function applyStringRefinements(
+  base: z.ZodString,
+  property: RuntimeStringProperty,
+): z.ZodString {
+  let schema = base;
+  if (property.minLength !== undefined) schema = schema.min(property.minLength);
+  if (property.maxLength !== undefined) schema = schema.max(property.maxLength);
+  if (property.pattern !== undefined) {
+    schema = schema.regex(new RegExp(property.pattern));
+  }
+  return schema;
+}
+
+function compileNumberProperty(property: RuntimeNumberProperty): ZodType {
+  let schema: z.ZodNumber = z.number();
+  if (property.int === true) {
+    schema = schema.int();
+  }
+  if (property.min !== undefined) {
+    schema = schema.min(property.min);
+  }
+  if (property.max !== undefined) {
+    schema = schema.max(property.max);
+  }
+  return schema;
+}
+
+function compileEnumProperty(property: RuntimeEnumProperty): ZodType {
+  // `z.enum([...])` requires at least one value; validation guarantees
+  // this. The cast quiets the readonly-tuple check Zod's overload uses.
+  return z.enum(property.values as unknown as [string, ...string[]]);
+}
+
+function compileArrayProperty(property: RuntimeArrayProperty): ZodType {
+  if (property.embedding !== undefined) {
+    // The embedding modifier replaces the ordinary `z.array(z.number())`
+    // with the branded `embedding(dimensions)` schema so downstream
+    // vector-search code recognises it via `getEmbeddingDimensions`.
+    return embedding(property.embedding.dimensions);
+  }
+  const inner = compilePropertyForArrayItem(property.items);
+  return z.array(inner);
+}
+
+function compilePropertyForArrayItem(item: RuntimeArrayItemType): ZodType {
+  return applyOptional(compileProperty(item), item);
+}
+
+function compileObjectProperty(property: RuntimeObjectProperty): ZodType {
+  return buildObjectSchema(property.properties);
+}
+
+function applyOptional(
+  schema: ZodType,
+  property: { optional?: boolean },
+): ZodType {
+  return property.optional === true ? schema.optional() : schema;
+}
+
+// ============================================================
+// Unique constraint compilation
+// ============================================================
+
+function compileUniqueConstraint(
+  document: RuntimeUniqueConstraint,
+): UniqueConstraint {
+  const base = {
+    name: document.name,
+    fields: document.fields,
+    scope: document.scope ?? "kind",
+    collation: document.collation ?? "binary",
+  };
+  if (document.where === undefined) {
+    return base;
+  }
+  return {
+    ...base,
+    where: makeWherePredicate(document.where.field, document.where.op),
+  };
+}
+
+/**
+ * One-arg field-builder shape consumers pass into `where`. Exposed as
+ * its own type so the predicate factory can be typed without leaking
+ * the internal predicate-builder generic from `core/types.ts`.
+ */
+type UniquePredicateFieldBuilder = Readonly<{
+  isNull: () => unknown;
+  isNotNull: () => unknown;
+}>;
+
+type UniqueWhereCallback = (
+  props: Readonly<Record<string, UniquePredicateFieldBuilder>>,
+) => Readonly<{
+  __type: "unique_predicate";
+  field: string;
+  op: "isNull" | "isNotNull";
+}>;
+
+/**
+ * Builds the `where` callback `defineGraph`'s constraint plumbing
+ * expects. The callback receives a per-field predicate builder and must
+ * return `{ __type: "unique_predicate", field, op }`. Mirrors the shape
+ * `serializeWherePredicate` walks at persistence time.
+ */
+function makeWherePredicate(
+  field: string,
+  op: "isNull" | "isNotNull",
+): UniqueWhereCallback {
+  return (props) => {
+    const builder = props[field];
+    if (builder === undefined) {
+      // The runtime predicate object is the source of truth — even if the
+      // builder is missing (which validation should have prevented) the
+      // returned shape matches what consumers and serialization expect.
+      return { __type: "unique_predicate", field, op };
+    }
+    const result = op === "isNull" ? builder.isNull() : builder.isNotNull();
+    return result as ReturnType<UniqueWhereCallback>;
+  };
+}
+
+// ============================================================
+// Ontology compilation
+// ============================================================
+
+const META_EDGE_BY_NAME: Readonly<Record<MetaEdgeName, MetaEdge>> =
+  Object.fromEntries(
+    ALL_META_EDGE_NAMES.map((name) => [name, coreOntology[`${name}MetaEdge`]]),
+  ) as Readonly<Record<MetaEdgeName, MetaEdge>>;
+
+function compileOntologyRelation(
+  relation: RuntimeOntologyRelation,
+  nodeTypeByName: ReadonlyMap<string, NodeType>,
+): OntologyRelation {
+  // `relation.metaEdge` is typed as `MetaEdgeName` so the lookup is
+  // total. Validation rejects out-of-range names before they ever
+  // reach the compiler.
+  const metaEdge = META_EDGE_BY_NAME[relation.metaEdge];
+
+  const fromNode = nodeTypeByName.get(relation.from);
+  const toNode = nodeTypeByName.get(relation.to);
+
+  // Mirror the `OntologyRelation` shape used by compile-time relation
+  // factories: NodeType references when resolvable, raw string for
+  // external IRIs.
+  return {
+    metaEdge,
+    from: fromNode ?? relation.from,
+    to: toNode ?? relation.to,
+  };
+}

--- a/packages/typegraph/src/runtime/define-runtime-extension.ts
+++ b/packages/typegraph/src/runtime/define-runtime-extension.ts
@@ -1,0 +1,47 @@
+/**
+ * Public entry for declaring a runtime graph extension.
+ *
+ * Pure value: validates the input, deeply freezes the result, and returns
+ * a `RuntimeGraphDocument`. Invalid documents throw
+ * `RuntimeExtensionValidationError` carrying every issue with a
+ * JSON-pointer `path` to the offending field.
+ */
+import { unwrap } from "../utils/result";
+import { type RuntimeGraphDocument } from "./document-types";
+import { validateRuntimeExtension } from "./validation";
+
+/**
+ * Validates and freezes a runtime extension document.
+ *
+ * @param input - Plain object describing additional node kinds, edge
+ *   kinds, and ontology relations. Must satisfy the v1 property-type
+ *   subset documented in `RuntimePropertyType`.
+ *
+ * @returns The same document, deeply frozen and shape-checked.
+ *
+ * @throws {RuntimeExtensionValidationError} when the document violates
+ *   the v1 property-type subset, references undeclared kinds, contains
+ *   ontology cycles, etc. The thrown error's `details.issues` array
+ *   carries every failure with a JSON-pointer path.
+ *
+ * @example
+ * ```typescript
+ * const extension = defineRuntimeExtension({
+ *   nodes: {
+ *     Paper: {
+ *       properties: {
+ *         doi:   { type: "string" },
+ *         title: { type: "string", searchable: { language: "english" } },
+ *       },
+ *       unique: [{ name: "paper_doi", fields: ["doi"] }],
+ *     },
+ *   },
+ * });
+ *
+ * const compiled = compileRuntimeExtension(extension);
+ * // compiled.nodes[0].type is a NodeType ready to merge into a GraphDef.
+ * ```
+ */
+export function defineRuntimeExtension(input: unknown): RuntimeGraphDocument {
+  return unwrap(validateRuntimeExtension(input));
+}

--- a/packages/typegraph/src/runtime/document-types.ts
+++ b/packages/typegraph/src/runtime/document-types.ts
@@ -1,0 +1,268 @@
+/**
+ * Pure-value document format for runtime graph extensions.
+ *
+ * A `RuntimeGraphDocument` is a plain JSON-serializable description of
+ * additional node kinds, edge kinds, and ontology relations that should
+ * be merged into a graph at runtime. The document is the canonical
+ * artifact: every restart re-compiles it back to the same Zod-bearing
+ * `NodeType` / `EdgeType` / `OntologyRelation` shapes.
+ *
+ * The supported property-type subset is intentionally narrower than full
+ * JSON Schema — only what compiles cleanly to Zod and what real
+ * agent-induced schemas use in practice. Anything outside this set fails
+ * loudly at `defineRuntimeExtension(...)`.
+ */
+import { type KindAnnotations } from "../core/types";
+import { type MetaEdgeName } from "../ontology/constants";
+
+// ============================================================
+// Property Types
+// ============================================================
+
+/**
+ * Per-property modifier: tag the field as fulltext-searchable.
+ *
+ * Compiles to a `searchable({ language })`-wrapped Zod string when applied
+ * to a `string` property. Rejected on any other property type at validation
+ * time.
+ */
+export type RuntimeSearchableModifier = Readonly<{
+  language?: string;
+}>;
+
+/**
+ * Per-property modifier: declare a vector embedding with the given
+ * dimensionality. Compiles to `embedding(dimensions)` and is only valid on
+ * `array` properties whose item type is `number`. Rejected elsewhere.
+ */
+export type RuntimeEmbeddingModifier = Readonly<{
+  dimensions: number;
+}>;
+
+/**
+ * Modifiers shared by every runtime property type.
+ *
+ * `optional: true` flips the field from required-with-runtime-validation
+ * to `.optional()` and removes it from the parent object's `required`
+ * list. `searchable` and `embedding` only apply to specific underlying
+ * types — see the per-modifier docs.
+ */
+type RuntimePropertyModifiers = Readonly<{
+  optional?: boolean;
+  searchable?: RuntimeSearchableModifier;
+  embedding?: RuntimeEmbeddingModifier;
+  description?: string;
+}>;
+
+/**
+ * String property. Compiles to `z.string()` plus the requested refinements.
+ * `format` accepts the two formats motivated by induced schemas in
+ * practice — datetime strings (`z.iso.datetime()`) and URI strings
+ * (`z.url()`). Other JSON-Schema formats are deliberately not supported
+ * in v1.
+ */
+export type RuntimeStringProperty = Readonly<{
+  type: "string";
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: "datetime" | "uri";
+}> &
+  RuntimePropertyModifiers;
+
+/**
+ * Number property. `int: true` requires whole numbers; `min` / `max` are
+ * inclusive bounds. Compiles to `z.number().int()?.min(...)?.max(...)`.
+ */
+export type RuntimeNumberProperty = Readonly<{
+  type: "number";
+  min?: number;
+  max?: number;
+  int?: boolean;
+}> &
+  RuntimePropertyModifiers;
+
+/**
+ * Boolean property. Compiles to `z.boolean()`.
+ */
+export type RuntimeBooleanProperty = Readonly<{
+  type: "boolean";
+}> &
+  RuntimePropertyModifiers;
+
+/**
+ * Closed-set string enum. Compiles to `z.enum([...values])`. Must contain
+ * at least one value; duplicate values are rejected at validation time.
+ */
+export type RuntimeEnumProperty = Readonly<{
+  type: "enum";
+  values: readonly string[];
+}> &
+  RuntimePropertyModifiers;
+
+/**
+ * Array property. `items` is any of the scalar property types or an
+ * object property — nested arrays are forbidden in v1. Compiles to
+ * `z.array(<items>)`. The `embedding` modifier turns this into a
+ * vector embedding instead of a generic array.
+ */
+export type RuntimeArrayProperty = Readonly<{
+  type: "array";
+  items: RuntimeArrayItemType;
+}> &
+  RuntimePropertyModifiers;
+
+/**
+ * Element types allowed inside an array — every leaf property type plus
+ * single-level object. Nesting an array inside an array is rejected at
+ * validation time so the v1 surface stays a flat tree.
+ */
+export type RuntimeArrayItemType =
+  | RuntimeStringProperty
+  | RuntimeNumberProperty
+  | RuntimeBooleanProperty
+  | RuntimeEnumProperty
+  | RuntimeObjectProperty;
+
+/**
+ * Object property. `properties` is a single nesting level; deeper objects
+ * are rejected at validation time so the v1 surface is auditable at a
+ * glance.
+ */
+export type RuntimeObjectProperty = Readonly<{
+  type: "object";
+  properties: Readonly<Record<string, RuntimeObjectFieldProperty>>;
+}> &
+  RuntimePropertyModifiers;
+
+/**
+ * Property types allowed inside an `object`'s `properties` — leaf scalars
+ * and arrays only. Nested objects are blocked here to enforce the
+ * single-nesting-level rule.
+ */
+export type RuntimeObjectFieldProperty =
+  | RuntimeStringProperty
+  | RuntimeNumberProperty
+  | RuntimeBooleanProperty
+  | RuntimeEnumProperty
+  | RuntimeArrayProperty;
+
+/**
+ * Top-level property descriptor for a node or edge field.
+ *
+ * The discriminated union covers every type in the v1 subset; arbitrary
+ * `unknown` inputs are validated against this set at
+ * `defineRuntimeExtension(...)` time.
+ */
+export type RuntimePropertyType =
+  | RuntimeStringProperty
+  | RuntimeNumberProperty
+  | RuntimeBooleanProperty
+  | RuntimeEnumProperty
+  | RuntimeArrayProperty
+  | RuntimeObjectProperty;
+
+// ============================================================
+// Unique Constraints
+// ============================================================
+
+/**
+ * Document-side `where` clause for a unique constraint.
+ *
+ * Mirrors `serializeWherePredicate`'s capability — the only operations
+ * round-trippable through the persisted form are `isNull` and `isNotNull`.
+ * Anything richer (equality, `in`, etc.) is rejected at validation time.
+ */
+export type RuntimeUniqueWhere = Readonly<{
+  field: string;
+  op: "isNull" | "isNotNull";
+}>;
+
+/**
+ * Unique constraint declaration. `fields` must reference declared
+ * properties on the kind. Defaults match the existing `UniqueConstraint`:
+ * `scope: "kind"`, `collation: "binary"`.
+ */
+export type RuntimeUniqueConstraint = Readonly<{
+  name: string;
+  fields: readonly string[];
+  scope?: "kind" | "kindWithSubClasses";
+  collation?: "binary" | "caseInsensitive";
+  where?: RuntimeUniqueWhere;
+}>;
+
+// ============================================================
+// Node and Edge Documents
+// ============================================================
+
+/**
+ * Runtime declaration of a node kind.
+ *
+ * Property names follow the same reserved-key rules as compile-time
+ * `defineNode` (`id`, `kind`, `meta`, and the `$`-prefix accessor
+ * namespace are forbidden). Annotation values must be JSON.
+ */
+export type RuntimeNodeDocument = Readonly<{
+  description?: string;
+  annotations?: KindAnnotations;
+  properties: Readonly<Record<string, RuntimePropertyType>>;
+  unique?: readonly RuntimeUniqueConstraint[];
+}>;
+
+/**
+ * Runtime declaration of an edge kind.
+ *
+ * `from` / `to` reference node kind names — either kinds declared in this
+ * same document or compile-time kinds the document is being merged into.
+ * Endpoints that resolve to nothing within the document are flagged as
+ * soft references at validation time but not rejected; the final
+ * cross-graph check happens when the document is merged into a host
+ * `GraphDef`.
+ */
+export type RuntimeEdgeDocument = Readonly<{
+  description?: string;
+  annotations?: KindAnnotations;
+  from: readonly string[];
+  to: readonly string[];
+  properties?: Readonly<Record<string, RuntimePropertyType>>;
+}>;
+
+// ============================================================
+// Ontology
+// ============================================================
+
+/**
+ * Runtime ontology relation. `metaEdge` is one of the built-in
+ * meta-edge names (subClassOf, broader, disjointWith, etc.).
+ *
+ * `from` / `to` are either node-kind names declared in this document or
+ * external IRI strings. The pure-value document does not distinguish the
+ * two — the compiler treats endpoints that match a declared kind as
+ * `NodeType` references and falls back to passing the raw string for
+ * IRIs (matching the existing `OntologyRelation` shape, where
+ * `from`/`to` are `NodeType | EdgeType | string`).
+ */
+export type RuntimeOntologyRelation = Readonly<{
+  metaEdge: MetaEdgeName;
+  from: string;
+  to: string;
+}>;
+
+// ============================================================
+// Document
+// ============================================================
+
+/**
+ * The canonical pure-value runtime extension document.
+ *
+ * Frozen at construction. Round-trips losslessly through `JSON.stringify`
+ * / `JSON.parse`; the `RuntimeGraphDocument → CompiledExtension` direction
+ * is provided by `compileRuntimeExtension(...)`. There is no
+ * `Zod → RuntimeGraphDocument` direction because runtime kinds always
+ * originate as documents.
+ */
+export type RuntimeGraphDocument = Readonly<{
+  nodes?: Readonly<Record<string, RuntimeNodeDocument>>;
+  edges?: Readonly<Record<string, RuntimeEdgeDocument>>;
+  ontology?: readonly RuntimeOntologyRelation[];
+}>;

--- a/packages/typegraph/src/runtime/errors.ts
+++ b/packages/typegraph/src/runtime/errors.ts
@@ -1,0 +1,109 @@
+/**
+ * Errors raised while parsing and validating a `RuntimeGraphDocument`.
+ *
+ * Every issue carries a JSON-pointer-style `path` (e.g.
+ * `/nodes/Paper/properties/title/format`) so the caller can drop the
+ * pointer straight into the offending document and see the exact field
+ * that failed.
+ */
+import { TypeGraphError } from "../errors";
+
+/**
+ * One specific issue raised during runtime extension validation.
+ */
+export type RuntimeExtensionIssue = Readonly<{
+  /**
+   * JSON-pointer path to the offending value, rooted at the document
+   * (e.g. `/nodes/Paper/properties/title/pattern`). The empty string
+   * `""` means "the document itself".
+   */
+  path: string;
+  /** Human-readable explanation of the failure. */
+  message: string;
+  /**
+   * Stable machine-readable code so callers (and tests) can branch on
+   * specific failure modes without parsing messages. New codes are
+   * additive.
+   */
+  code: RuntimeExtensionIssueCode;
+}>;
+
+/**
+ * Stable machine codes for every validation failure produced by the
+ * document validator. New codes are additive — existing codes never
+ * change meaning.
+ */
+export type RuntimeExtensionIssueCode =
+  | "UNSUPPORTED_PROPERTY_TYPE"
+  | "INVALID_PROPERTY_REFINEMENT"
+  | "NESTED_ARRAY"
+  | "NESTED_OBJECT_TOO_DEEP"
+  | "INVALID_MODIFIER_TARGET"
+  | "INVALID_ENUM_VALUES"
+  | "INVALID_NUMBER_BOUNDS"
+  | "INVALID_LENGTH_BOUNDS"
+  | "INVALID_PATTERN"
+  | "INVALID_EMBEDDING_DIMENSIONS"
+  | "INVALID_SEARCHABLE_LANGUAGE"
+  | "RESERVED_PROPERTY_NAME"
+  | "INVALID_KIND_NAME"
+  | "DUPLICATE_KIND_NAME"
+  | "EMPTY_PROPERTIES"
+  | "EMPTY_FROM_OR_TO"
+  | "DUPLICATE_UNIQUE_CONSTRAINT"
+  | "EMPTY_UNIQUE_FIELDS"
+  | "DUPLICATE_UNIQUE_FIELD"
+  | "UNKNOWN_UNIQUE_FIELD"
+  | "INVALID_UNIQUE_WHERE_OP"
+  | "UNKNOWN_UNIQUE_WHERE_FIELD"
+  | "INVALID_ANNOTATION"
+  | "UNKNOWN_META_EDGE"
+  | "ONTOLOGY_CYCLE"
+  | "ONTOLOGY_SELF_LOOP"
+  | "DUPLICATE_ONTOLOGY_RELATION"
+  | "INVALID_DOCUMENT_SHAPE";
+
+/**
+ * Thrown when `defineRuntimeExtension(...)` rejects an input document.
+ *
+ * The `details.issues` array carries every failure with a JSON-pointer
+ * `path`, so callers presenting the document to a human reviewer can
+ * highlight the exact offending field.
+ */
+export class RuntimeExtensionValidationError extends TypeGraphError {
+  declare readonly details: Readonly<{
+    issues: readonly RuntimeExtensionIssue[];
+  }>;
+
+  constructor(issues: readonly RuntimeExtensionIssue[], cause?: unknown) {
+    const summary = summarizeIssues(issues);
+    super(
+      `Runtime extension document is invalid (${issues.length} issue${
+        issues.length === 1 ? "" : "s"
+      }): ${summary}`,
+      "RUNTIME_EXTENSION_INVALID",
+      {
+        details: { issues: Object.freeze([...issues]) },
+        category: "user",
+        suggestion: `Inspect error.details.issues for per-field paths and codes; each issue's "path" is a JSON pointer into the source document.`,
+        cause,
+      },
+    );
+    this.name = "RuntimeExtensionValidationError";
+  }
+}
+
+/**
+ * Builds the one-line summary the base `Error.message` shows. Keeps the
+ * full structured list available on `details.issues` for programmatic
+ * use.
+ */
+function summarizeIssues(issues: readonly RuntimeExtensionIssue[]): string {
+  if (issues.length === 0) return "no specific issues recorded";
+  const head = issues
+    .slice(0, 3)
+    .map((issue) => `${issue.path || "(root)"} — ${issue.message}`)
+    .join("; ");
+  const overflow = issues.length > 3 ? ` (+${issues.length - 3} more)` : "";
+  return `${head}${overflow}`;
+}

--- a/packages/typegraph/src/runtime/index.ts
+++ b/packages/typegraph/src/runtime/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Runtime graph extension — pure-value document layer and Zod compiler.
+ */
+
+// Public entry
+export { defineRuntimeExtension } from "./define-runtime-extension";
+
+// Compiler
+export {
+  type CompiledEdge,
+  type CompiledExtension,
+  type CompiledNode,
+  compileRuntimeExtension,
+} from "./compiler";
+
+// Document type surface
+export type {
+  RuntimeArrayItemType,
+  RuntimeArrayProperty,
+  RuntimeBooleanProperty,
+  RuntimeEdgeDocument,
+  RuntimeEmbeddingModifier,
+  RuntimeEnumProperty,
+  RuntimeGraphDocument,
+  RuntimeNodeDocument,
+  RuntimeNumberProperty,
+  RuntimeObjectFieldProperty,
+  RuntimeObjectProperty,
+  RuntimeOntologyRelation,
+  RuntimePropertyType,
+  RuntimeSearchableModifier,
+  RuntimeStringProperty,
+  RuntimeUniqueConstraint,
+  RuntimeUniqueWhere,
+} from "./document-types";
+
+// Errors
+export {
+  type RuntimeExtensionIssue,
+  type RuntimeExtensionIssueCode,
+  RuntimeExtensionValidationError,
+} from "./errors";
+
+// Result-returning validator (for callers that prefer Result-style)
+export { validateRuntimeExtension } from "./validation";

--- a/packages/typegraph/src/runtime/internal.ts
+++ b/packages/typegraph/src/runtime/internal.ts
@@ -1,0 +1,18 @@
+/**
+ * Builds an object dropping any keys whose value is `undefined`.
+ *
+ * Lets callers construct discriminated-union members and `defineNode` /
+ * `defineEdge` option objects without tripping over
+ * `exactOptionalPropertyTypes: true` — which forbids setting `optional:
+ * undefined` on a type that declares `optional?: boolean`. The cast keeps
+ * call sites readable; this helper is the single typed seam.
+ */
+export function compactUndefined<T extends object>(value: {
+  [K in keyof T]: T[K] | undefined;
+}): T {
+  const result: Record<string, unknown> = {};
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (fieldValue !== undefined) result[key] = fieldValue;
+  }
+  return result as T;
+}

--- a/packages/typegraph/src/runtime/validation.ts
+++ b/packages/typegraph/src/runtime/validation.ts
@@ -1,0 +1,1692 @@
+/**
+ * Pure structural validation for `RuntimeGraphDocument`.
+ *
+ * Walks the document and accumulates every issue (no fail-fast) so a
+ * caller showing the document to a human reviewer can surface all
+ * problems in one round. Cross-document references — edge endpoints,
+ * ontology endpoints — resolve only against this document; resolution
+ * against an existing compile-time graph happens later, when the
+ * document is merged into a host `GraphDef`.
+ */
+import { assertJsonValue } from "../core/json-value";
+import { type KindAnnotations } from "../core/types";
+import { ConfigurationError } from "../errors";
+import { computeTransitiveClosure } from "../ontology/closures";
+import { ALL_META_EDGE_NAMES, type MetaEdgeName } from "../ontology/constants";
+import { RESERVED_EDGE_KEYS, RESERVED_NODE_KEYS } from "../store/reserved-keys";
+import { err, ok, type Result } from "../utils/result";
+import {
+  type RuntimeArrayProperty,
+  type RuntimeBooleanProperty,
+  type RuntimeEdgeDocument,
+  type RuntimeEnumProperty,
+  type RuntimeGraphDocument,
+  type RuntimeNodeDocument,
+  type RuntimeNumberProperty,
+  type RuntimeObjectFieldProperty,
+  type RuntimeObjectProperty,
+  type RuntimeOntologyRelation,
+  type RuntimePropertyType,
+  type RuntimeStringProperty,
+  type RuntimeUniqueConstraint,
+} from "./document-types";
+import {
+  type RuntimeExtensionIssue,
+  type RuntimeExtensionIssueCode,
+  RuntimeExtensionValidationError,
+} from "./errors";
+import { compactUndefined } from "./internal";
+
+const META_EDGE_NAME_SET: ReadonlySet<string> = new Set(ALL_META_EDGE_NAMES);
+
+const SUPPORTED_PROPERTY_TYPES = new Set([
+  "string",
+  "number",
+  "boolean",
+  "enum",
+  "array",
+  "object",
+]);
+
+const STRING_REFINEMENT_KEYS = new Set([
+  "type",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "format",
+  "optional",
+  "searchable",
+  "embedding",
+  "description",
+]);
+
+const NUMBER_REFINEMENT_KEYS = new Set([
+  "type",
+  "min",
+  "max",
+  "int",
+  "optional",
+  "searchable",
+  "embedding",
+  "description",
+]);
+
+const BOOLEAN_REFINEMENT_KEYS = new Set([
+  "type",
+  "optional",
+  "searchable",
+  "embedding",
+  "description",
+]);
+
+const ENUM_REFINEMENT_KEYS = new Set([
+  "type",
+  "values",
+  "optional",
+  "searchable",
+  "embedding",
+  "description",
+]);
+
+const ARRAY_REFINEMENT_KEYS = new Set([
+  "type",
+  "items",
+  "optional",
+  "searchable",
+  "embedding",
+  "description",
+]);
+
+const OBJECT_REFINEMENT_KEYS = new Set([
+  "type",
+  "properties",
+  "optional",
+  "searchable",
+  "embedding",
+  "description",
+]);
+
+const SUPPORTED_STRING_FORMATS = new Set(["datetime", "uri"]);
+
+/**
+ * Validates a runtime extension document.
+ *
+ * Returns the (frozen, deeply normalized) document on success, or a
+ * `RuntimeExtensionValidationError` carrying every issue on failure. The
+ * function never throws — callers that prefer exceptions wrap with
+ * `unwrap()`.
+ */
+export function validateRuntimeExtension(
+  input: unknown,
+): Result<RuntimeGraphDocument, RuntimeExtensionValidationError> {
+  const issues: RuntimeExtensionIssue[] = [];
+
+  if (!isPlainObject(input)) {
+    issues.push({
+      path: "",
+      message: "Document must be a plain object.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return err(new RuntimeExtensionValidationError(issues));
+  }
+
+  const documentRecord = input;
+
+  const allowedTopLevelKeys = new Set(["nodes", "edges", "ontology"]);
+  for (const key of Object.keys(documentRecord)) {
+    if (!allowedTopLevelKeys.has(key)) {
+      issues.push({
+        path: `/${escapePointerSegment(key)}`,
+        message: `Unknown top-level key "${key}". Allowed keys: nodes, edges, ontology.`,
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+    }
+  }
+
+  const nodes = validateNodesSection(documentRecord.nodes, issues);
+  const edges = validateEdgesSection(documentRecord.edges, issues);
+
+  // Edge endpoints can reference (a) kinds declared in this same document,
+  // (b) compile-time host kinds resolved at merge time, or (c) external
+  // IRIs. The cross-graph resolution check happens at merge time, not
+  // here.
+
+  const ontology = validateOntologySection(documentRecord.ontology, issues);
+  if (ontology !== undefined) {
+    validateOntology(ontology, nodes, issues);
+  }
+
+  if (issues.length > 0) {
+    return err(new RuntimeExtensionValidationError(issues));
+  }
+
+  return ok(freezeDocument({ nodes, edges, ontology }));
+}
+
+// ============================================================
+// Section: nodes
+// ============================================================
+
+function validateNodesSection(
+  rawNodes: unknown,
+  issues: RuntimeExtensionIssue[],
+): Record<string, RuntimeNodeDocument> | undefined {
+  if (rawNodes === undefined) return undefined;
+
+  if (!isPlainObject(rawNodes)) {
+    issues.push({
+      path: "/nodes",
+      message: "`nodes` must be a plain object keyed by node-kind name.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const result: Record<string, RuntimeNodeDocument> = {};
+  const recorded = new Set<string>();
+
+  for (const [kindName, rawNode] of Object.entries(rawNodes)) {
+    const path = `/nodes/${escapePointerSegment(kindName)}`;
+
+    if (!isValidKindName(kindName)) {
+      issues.push({
+        path,
+        message: `Node kind name "${kindName}" must match /^[A-Za-z_][A-Za-z0-9_]*$/.`,
+        code: "INVALID_KIND_NAME",
+      });
+      continue;
+    }
+
+    if (recorded.has(kindName)) {
+      issues.push({
+        path,
+        message: `Duplicate node kind name "${kindName}".`,
+        code: "DUPLICATE_KIND_NAME",
+      });
+      continue;
+    }
+
+    const node = validateNodeDocument(kindName, rawNode, path, issues);
+    if (node === undefined) continue;
+    result[kindName] = node;
+    recorded.add(kindName);
+  }
+
+  return result;
+}
+
+function validateNodeDocument(
+  kindName: string,
+  raw: unknown,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): RuntimeNodeDocument | undefined {
+  if (!isPlainObject(raw)) {
+    issues.push({
+      path,
+      message: `Node "${kindName}" must be a plain object.`,
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const allowed = new Set([
+    "description",
+    "annotations",
+    "properties",
+    "unique",
+  ]);
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) {
+      issues.push({
+        path: `${path}/${escapePointerSegment(key)}`,
+        message: `Unknown node-level key "${key}". Allowed: description, annotations, properties, unique.`,
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+    }
+  }
+
+  const description = validateOptionalString(
+    raw.description,
+    `${path}/description`,
+    issues,
+  );
+
+  const annotations = validateAnnotations(
+    raw.annotations,
+    `${path}/annotations`,
+    `Node "${kindName}"`,
+    issues,
+  );
+
+  const propertiesRaw = raw.properties;
+  const properties = validatePropertiesMap(
+    propertiesRaw,
+    `${path}/properties`,
+    "node",
+    kindName,
+    issues,
+  );
+  if (properties === undefined) return undefined;
+
+  const uniqueRaw = raw.unique;
+  const unique = validateUniqueConstraints(
+    uniqueRaw,
+    `${path}/unique`,
+    properties,
+    issues,
+  );
+
+  return compactUndefined<RuntimeNodeDocument>({
+    description,
+    annotations,
+    properties,
+    unique,
+  });
+}
+
+// ============================================================
+// Section: edges
+// ============================================================
+
+function validateEdgesSection(
+  rawEdges: unknown,
+  issues: RuntimeExtensionIssue[],
+): Record<string, RuntimeEdgeDocument> | undefined {
+  if (rawEdges === undefined) return undefined;
+
+  if (!isPlainObject(rawEdges)) {
+    issues.push({
+      path: "/edges",
+      message: "`edges` must be a plain object keyed by edge-kind name.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const result: Record<string, RuntimeEdgeDocument> = {};
+  const recorded = new Set<string>();
+
+  for (const [kindName, rawEdge] of Object.entries(rawEdges)) {
+    const path = `/edges/${escapePointerSegment(kindName)}`;
+
+    if (!isValidKindName(kindName)) {
+      issues.push({
+        path,
+        message: `Edge kind name "${kindName}" must match /^[A-Za-z_][A-Za-z0-9_]*$/.`,
+        code: "INVALID_KIND_NAME",
+      });
+      continue;
+    }
+
+    if (recorded.has(kindName)) {
+      issues.push({
+        path,
+        message: `Duplicate edge kind name "${kindName}".`,
+        code: "DUPLICATE_KIND_NAME",
+      });
+      continue;
+    }
+
+    const edge = validateEdgeDocument(kindName, rawEdge, path, issues);
+    if (edge === undefined) continue;
+    result[kindName] = edge;
+    recorded.add(kindName);
+  }
+
+  return result;
+}
+
+function validateEdgeDocument(
+  kindName: string,
+  raw: unknown,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): RuntimeEdgeDocument | undefined {
+  if (!isPlainObject(raw)) {
+    issues.push({
+      path,
+      message: `Edge "${kindName}" must be a plain object.`,
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const allowed = new Set([
+    "description",
+    "annotations",
+    "from",
+    "to",
+    "properties",
+  ]);
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) {
+      issues.push({
+        path: `${path}/${escapePointerSegment(key)}`,
+        message: `Unknown edge-level key "${key}". Allowed: description, annotations, from, to, properties.`,
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+    }
+  }
+
+  const description = validateOptionalString(
+    raw.description,
+    `${path}/description`,
+    issues,
+  );
+
+  const annotations = validateAnnotations(
+    raw.annotations,
+    `${path}/annotations`,
+    `Edge "${kindName}"`,
+    issues,
+  );
+
+  const from = validateEndpointList(raw.from, `${path}/from`, issues);
+  const to = validateEndpointList(raw.to, `${path}/to`, issues);
+  if (from === undefined || to === undefined) return undefined;
+
+  const propertiesRaw = raw.properties;
+  const properties =
+    propertiesRaw === undefined ?
+      {}
+    : validatePropertiesMap(
+        propertiesRaw,
+        `${path}/properties`,
+        "edge",
+        kindName,
+        issues,
+      );
+  if (properties === undefined) return undefined;
+
+  return compactUndefined<RuntimeEdgeDocument>({
+    description,
+    annotations,
+    from,
+    to,
+    properties,
+  });
+}
+
+function validateEndpointList(
+  raw: unknown,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): readonly string[] | undefined {
+  if (!Array.isArray(raw)) {
+    issues.push({
+      path,
+      message: "Edge endpoint list must be an array of node-kind names.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+  if (raw.length === 0) {
+    issues.push({
+      path,
+      message: "Edge endpoint list must contain at least one node-kind name.",
+      code: "EMPTY_FROM_OR_TO",
+    });
+    return undefined;
+  }
+  const names: string[] = [];
+  for (const [index, value] of raw.entries()) {
+    if (typeof value !== "string" || value.length === 0) {
+      issues.push({
+        path: `${path}/${index}`,
+        message: "Edge endpoint must be a non-empty string node-kind name.",
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+      return undefined;
+    }
+    names.push(value);
+  }
+  return names;
+}
+
+// ============================================================
+// Section: ontology
+// ============================================================
+
+function validateOntologySection(
+  raw: unknown,
+  issues: RuntimeExtensionIssue[],
+): RuntimeOntologyRelation[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    issues.push({
+      path: "/ontology",
+      message: "`ontology` must be an array of relation objects.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const result: RuntimeOntologyRelation[] = [];
+  for (const [index, entry] of raw.entries()) {
+    const path = `/ontology/${index}`;
+    if (!isPlainObject(entry)) {
+      issues.push({
+        path,
+        message: "Ontology entry must be a plain object.",
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+      continue;
+    }
+    const allowed = new Set(["metaEdge", "from", "to"]);
+    for (const key of Object.keys(entry)) {
+      if (!allowed.has(key)) {
+        issues.push({
+          path: `${path}/${escapePointerSegment(key)}`,
+          message: `Unknown ontology-entry key "${key}". Allowed: metaEdge, from, to.`,
+          code: "INVALID_DOCUMENT_SHAPE",
+        });
+      }
+    }
+
+    const metaEdge = entry.metaEdge;
+    const from = entry.from;
+    const to = entry.to;
+
+    if (typeof metaEdge !== "string" || !META_EDGE_NAME_SET.has(metaEdge)) {
+      issues.push({
+        path: `${path}/metaEdge`,
+        message: `Unknown meta-edge ${describeUnknownValue(metaEdge)}. Allowed: ${[...ALL_META_EDGE_NAMES].join(", ")}.`,
+        code: "UNKNOWN_META_EDGE",
+      });
+      continue;
+    }
+    if (typeof from !== "string" || from.length === 0) {
+      issues.push({
+        path: `${path}/from`,
+        message: "Ontology relation `from` must be a non-empty string.",
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+      continue;
+    }
+    if (typeof to !== "string" || to.length === 0) {
+      issues.push({
+        path: `${path}/to`,
+        message: "Ontology relation `to` must be a non-empty string.",
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+      continue;
+    }
+
+    result.push({ metaEdge: metaEdge as MetaEdgeName, from, to });
+  }
+  return result;
+}
+
+function validateOntology(
+  ontology: readonly RuntimeOntologyRelation[],
+  _nodes: Record<string, RuntimeNodeDocument> | undefined,
+  issues: RuntimeExtensionIssue[],
+): void {
+  const seenKey = new Set<string>();
+
+  for (const [index, relation] of ontology.entries()) {
+    const path = `/ontology/${index}`;
+
+    if (
+      relation.from === relation.to &&
+      isStrictlyHierarchicalMetaEdge(relation.metaEdge)
+    ) {
+      issues.push({
+        path,
+        message: `Hierarchical meta-edge "${relation.metaEdge}" cannot be a self-loop ("${relation.from}" → "${relation.to}").`,
+        code: "ONTOLOGY_SELF_LOOP",
+      });
+    }
+
+    const key = `${relation.metaEdge}::${relation.from}->${relation.to}`;
+    if (seenKey.has(key)) {
+      issues.push({
+        path,
+        message: `Duplicate ontology relation "${relation.metaEdge}" (${relation.from} → ${relation.to}).`,
+        code: "DUPLICATE_ONTOLOGY_RELATION",
+      });
+      continue;
+    }
+    seenKey.add(key);
+  }
+
+  // Cycle detection on transitive hierarchical relations declared *within*
+  // this document. Cross-document cycles will be caught at evolve() time
+  // when the runtime extension is merged with the existing graph.
+  detectHierarchicalCycles(ontology, issues);
+}
+
+const STRICTLY_HIERARCHICAL: ReadonlySet<MetaEdgeName> = new Set([
+  "subClassOf",
+  "broader",
+  "narrower",
+  "partOf",
+  "hasPart",
+]);
+
+function isStrictlyHierarchicalMetaEdge(name: MetaEdgeName): boolean {
+  return STRICTLY_HIERARCHICAL.has(name);
+}
+
+/**
+ * Maps each hierarchical meta-edge to the canonical group it normalizes
+ * into, mirroring the registry's relation-table flattening
+ * (`computeClosuresFromOntology`). `narrower A→B` is the inverse of
+ * `broader A→B`; `hasPart A→B` is the inverse of `partOf A→B`. Cycle
+ * detection must run on the same normalized set the registry will, or
+ * mixed-direction cycles like `broader A→B` + `narrower A→B` slip
+ * through validation and surface only at runtime.
+ */
+const HIERARCHICAL_NORMALIZATION: ReadonlyMap<
+  MetaEdgeName,
+  Readonly<{ canonical: MetaEdgeName; flip: boolean }>
+> = new Map([
+  ["subClassOf", { canonical: "subClassOf", flip: false }],
+  ["broader", { canonical: "broader", flip: false }],
+  ["narrower", { canonical: "broader", flip: true }],
+  ["partOf", { canonical: "partOf", flip: false }],
+  ["hasPart", { canonical: "partOf", flip: true }],
+]);
+
+function detectHierarchicalCycles(
+  ontology: readonly RuntimeOntologyRelation[],
+  issues: RuntimeExtensionIssue[],
+): void {
+  type NormalizedEdge = Readonly<{
+    from: string;
+    to: string;
+    originalIndex: number;
+  }>;
+
+  const groups = new Map<MetaEdgeName, NormalizedEdge[]>();
+  for (const [index, relation] of ontology.entries()) {
+    const normalization = HIERARCHICAL_NORMALIZATION.get(relation.metaEdge);
+    if (normalization === undefined) continue;
+    if (relation.from === relation.to) continue; // already reported as self-loop
+
+    const from = normalization.flip ? relation.to : relation.from;
+    const to = normalization.flip ? relation.from : relation.to;
+
+    const list = groups.get(normalization.canonical) ?? [];
+    list.push({ from, to, originalIndex: index });
+    groups.set(normalization.canonical, list);
+  }
+
+  for (const [name, edges] of groups) {
+    const closure = computeTransitiveClosure(
+      edges.map((edge) => [edge.from, edge.to] as const),
+    );
+    const reportedNodes = new Set<string>();
+    for (const [from, reachable] of closure) {
+      if (!reachable.has(from) || reportedNodes.has(from)) continue;
+      reportedNodes.add(from);
+      const offendingEdge = edges.find((edge) => edge.from === from);
+      const path =
+        offendingEdge === undefined ? "/ontology" : (
+          `/ontology/${offendingEdge.originalIndex}`
+        );
+      issues.push({
+        path,
+        message: `Cycle detected in "${name}" relations involving "${from}".`,
+        code: "ONTOLOGY_CYCLE",
+      });
+    }
+  }
+}
+
+// ============================================================
+// Properties and refinements
+// ============================================================
+
+function validatePropertiesMap(
+  raw: unknown,
+  path: string,
+  ownerType: "node" | "edge",
+  ownerName: string,
+  issues: RuntimeExtensionIssue[],
+): Record<string, RuntimePropertyType> | undefined {
+  if (!isPlainObject(raw)) {
+    issues.push({
+      path,
+      message: `\`properties\` must be a plain object.`,
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const reserved =
+    ownerType === "node" ? RESERVED_NODE_KEYS : RESERVED_EDGE_KEYS;
+  const result: Record<string, RuntimePropertyType> = {};
+  for (const [propertyName, propertyValue] of Object.entries(raw)) {
+    const propertyPath = `${path}/${escapePointerSegment(propertyName)}`;
+    if (reserved.has(propertyName)) {
+      issues.push({
+        path: propertyPath,
+        message: `Property name "${propertyName}" is reserved for ${ownerType} "${ownerName}".`,
+        code: "RESERVED_PROPERTY_NAME",
+      });
+      continue;
+    }
+    if (propertyName.startsWith("$")) {
+      issues.push({
+        path: propertyPath,
+        message: `Property name "${propertyName}" uses the reserved "$" prefix.`,
+        code: "RESERVED_PROPERTY_NAME",
+      });
+      continue;
+    }
+    const validated = validateProperty(propertyValue, propertyPath, 0, issues);
+    if (validated === undefined) continue;
+    result[propertyName] = validated;
+  }
+
+  return result;
+}
+
+function validateProperty(
+  raw: unknown,
+  path: string,
+  depth: number,
+  issues: RuntimeExtensionIssue[],
+): RuntimePropertyType | undefined {
+  if (!isPlainObject(raw)) {
+    issues.push({
+      path,
+      message:
+        "Property descriptor must be a plain object with a `type` field.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+  const property = raw;
+  const type = property.type;
+  if (typeof type !== "string" || !SUPPORTED_PROPERTY_TYPES.has(type)) {
+    issues.push({
+      path: `${path}/type`,
+      message: `Unsupported property type ${describeUnknownValue(type)}. Supported: ${[...SUPPORTED_PROPERTY_TYPES].join(", ")}.`,
+      code: "UNSUPPORTED_PROPERTY_TYPE",
+    });
+    return undefined;
+  }
+
+  switch (type) {
+    case "string": {
+      return validateStringProperty(property, path, issues);
+    }
+    case "number": {
+      return validateNumberProperty(property, path, issues);
+    }
+    case "boolean": {
+      return validateBooleanProperty(property, path, issues);
+    }
+    case "enum": {
+      return validateEnumProperty(property, path, issues);
+    }
+    case "array": {
+      return validateArrayProperty(property, path, depth, issues);
+    }
+    case "object": {
+      return validateObjectProperty(property, path, depth, issues);
+    }
+  }
+  return undefined;
+}
+
+function validateStringProperty(
+  raw: Record<string, unknown>,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): RuntimeStringProperty | undefined {
+  rejectUnknownRefinements(raw, STRING_REFINEMENT_KEYS, path, "string", issues);
+
+  const minLength = validateNonNegativeInteger(
+    raw.minLength,
+    `${path}/minLength`,
+    "string.minLength",
+    "INVALID_LENGTH_BOUNDS",
+    issues,
+  );
+  const maxLength = validateNonNegativeInteger(
+    raw.maxLength,
+    `${path}/maxLength`,
+    "string.maxLength",
+    "INVALID_LENGTH_BOUNDS",
+    issues,
+  );
+  if (
+    minLength !== undefined &&
+    maxLength !== undefined &&
+    minLength > maxLength
+  ) {
+    issues.push({
+      path,
+      message: `string.minLength (${minLength}) cannot exceed string.maxLength (${maxLength}).`,
+      code: "INVALID_LENGTH_BOUNDS",
+    });
+  }
+
+  let pattern: string | undefined;
+  if (raw.pattern !== undefined) {
+    if (typeof raw.pattern === "string") {
+      try {
+        new RegExp(raw.pattern);
+        pattern = raw.pattern;
+      } catch (error) {
+        issues.push({
+          path: `${path}/pattern`,
+          message: `Pattern is not a valid regular expression: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          code: "INVALID_PATTERN",
+        });
+      }
+    } else {
+      issues.push({
+        path: `${path}/pattern`,
+        message: "`pattern` must be a string regular expression.",
+        code: "INVALID_PATTERN",
+      });
+    }
+  }
+
+  let format: "datetime" | "uri" | undefined;
+  if (raw.format !== undefined) {
+    if (
+      typeof raw.format !== "string" ||
+      !SUPPORTED_STRING_FORMATS.has(raw.format)
+    ) {
+      issues.push({
+        path: `${path}/format`,
+        message: `Unsupported string format ${describeUnknownValue(raw.format)}. Supported: ${[...SUPPORTED_STRING_FORMATS].join(", ")}.`,
+        code: "INVALID_PROPERTY_REFINEMENT",
+      });
+    } else {
+      format = raw.format as "datetime" | "uri";
+    }
+  }
+
+  const modifiers = validatePropertyModifiers(raw, path, "string", issues);
+  if (modifiers === undefined) return undefined;
+
+  if (format !== undefined && modifiers.searchable !== undefined) {
+    issues.push({
+      path,
+      message:
+        "`searchable` cannot be combined with `format` on a string property — the format-specific schema cannot carry the searchable brand. Drop one, or split into two fields.",
+      code: "INVALID_PROPERTY_REFINEMENT",
+    });
+    return undefined;
+  }
+
+  if (
+    format !== undefined &&
+    (minLength !== undefined ||
+      maxLength !== undefined ||
+      pattern !== undefined)
+  ) {
+    issues.push({
+      path,
+      message:
+        "`format` cannot be combined with `minLength`, `maxLength`, or `pattern` on a string property — the format-routed schema (`z.iso.datetime` / `z.url`) is not a `z.ZodString` and cannot carry length or pattern refinements. Drop the refinement, or drop the format and validate the shape with `pattern`.",
+      code: "INVALID_PROPERTY_REFINEMENT",
+    });
+    return undefined;
+  }
+
+  return compactUndefined<RuntimeStringProperty>({
+    type: "string",
+    minLength,
+    maxLength,
+    pattern,
+    format,
+    optional: modifiers.optional,
+    searchable: modifiers.searchable,
+    embedding: modifiers.embedding,
+    description: modifiers.description,
+  });
+}
+
+function validateNumberProperty(
+  raw: Record<string, unknown>,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): RuntimeNumberProperty | undefined {
+  rejectUnknownRefinements(raw, NUMBER_REFINEMENT_KEYS, path, "number", issues);
+
+  let min: number | undefined;
+  let max: number | undefined;
+  if (raw.min !== undefined) {
+    if (typeof raw.min !== "number" || !Number.isFinite(raw.min)) {
+      issues.push({
+        path: `${path}/min`,
+        message: "`min` must be a finite number.",
+        code: "INVALID_NUMBER_BOUNDS",
+      });
+    } else {
+      min = raw.min;
+    }
+  }
+  if (raw.max !== undefined) {
+    if (typeof raw.max !== "number" || !Number.isFinite(raw.max)) {
+      issues.push({
+        path: `${path}/max`,
+        message: "`max` must be a finite number.",
+        code: "INVALID_NUMBER_BOUNDS",
+      });
+    } else {
+      max = raw.max;
+    }
+  }
+  if (min !== undefined && max !== undefined && min > max) {
+    issues.push({
+      path,
+      message: `number.min (${min}) cannot exceed number.max (${max}).`,
+      code: "INVALID_NUMBER_BOUNDS",
+    });
+  }
+
+  let int: boolean | undefined;
+  if (raw.int !== undefined) {
+    if (typeof raw.int === "boolean") {
+      int = raw.int;
+    } else {
+      issues.push({
+        path: `${path}/int`,
+        message: "`int` must be a boolean.",
+        code: "INVALID_PROPERTY_REFINEMENT",
+      });
+    }
+  }
+
+  // Integer + non-integer bounds: reject early so the compiled Zod schema
+  // doesn't silently swallow values like `min: 1.5, int: true`.
+  if (int === true) {
+    if (min !== undefined && !Number.isInteger(min)) {
+      issues.push({
+        path: `${path}/min`,
+        message: "`min` must be an integer when `int: true`.",
+        code: "INVALID_NUMBER_BOUNDS",
+      });
+    }
+    if (max !== undefined && !Number.isInteger(max)) {
+      issues.push({
+        path: `${path}/max`,
+        message: "`max` must be an integer when `int: true`.",
+        code: "INVALID_NUMBER_BOUNDS",
+      });
+    }
+  }
+
+  const modifiers = validatePropertyModifiers(raw, path, "number", issues);
+  if (modifiers === undefined) return undefined;
+
+  return compactUndefined<RuntimeNumberProperty>({
+    type: "number",
+    min,
+    max,
+    int,
+    optional: modifiers.optional,
+    searchable: modifiers.searchable,
+    embedding: modifiers.embedding,
+    description: modifiers.description,
+  });
+}
+
+function validateBooleanProperty(
+  raw: Record<string, unknown>,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): RuntimeBooleanProperty | undefined {
+  rejectUnknownRefinements(
+    raw,
+    BOOLEAN_REFINEMENT_KEYS,
+    path,
+    "boolean",
+    issues,
+  );
+  const modifiers = validatePropertyModifiers(raw, path, "boolean", issues);
+  if (modifiers === undefined) return undefined;
+  return compactUndefined<RuntimeBooleanProperty>({
+    type: "boolean",
+    optional: modifiers.optional,
+    searchable: modifiers.searchable,
+    embedding: modifiers.embedding,
+    description: modifiers.description,
+  });
+}
+
+function validateEnumProperty(
+  raw: Record<string, unknown>,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): RuntimeEnumProperty | undefined {
+  rejectUnknownRefinements(raw, ENUM_REFINEMENT_KEYS, path, "enum", issues);
+
+  const valuesRaw = raw.values;
+  if (!Array.isArray(valuesRaw) || valuesRaw.length === 0) {
+    issues.push({
+      path: `${path}/values`,
+      message: "`enum.values` must be a non-empty array of strings.",
+      code: "INVALID_ENUM_VALUES",
+    });
+    return undefined;
+  }
+
+  const values: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, value] of valuesRaw.entries()) {
+    if (typeof value !== "string") {
+      issues.push({
+        path: `${path}/values/${index}`,
+        message: "`enum.values` entries must be strings.",
+        code: "INVALID_ENUM_VALUES",
+      });
+      return undefined;
+    }
+    if (seen.has(value)) {
+      issues.push({
+        path: `${path}/values/${index}`,
+        message: `Duplicate enum value "${value}".`,
+        code: "INVALID_ENUM_VALUES",
+      });
+      return undefined;
+    }
+    seen.add(value);
+    values.push(value);
+  }
+
+  const modifiers = validatePropertyModifiers(raw, path, "enum", issues);
+  if (modifiers === undefined) return undefined;
+
+  return compactUndefined<RuntimeEnumProperty>({
+    type: "enum",
+    values,
+    optional: modifiers.optional,
+    searchable: modifiers.searchable,
+    embedding: modifiers.embedding,
+    description: modifiers.description,
+  });
+}
+
+function validateArrayProperty(
+  raw: Record<string, unknown>,
+  path: string,
+  depth: number,
+  issues: RuntimeExtensionIssue[],
+): RuntimeArrayProperty | undefined {
+  rejectUnknownRefinements(raw, ARRAY_REFINEMENT_KEYS, path, "array", issues);
+
+  const itemsRaw = raw.items;
+  if (itemsRaw === undefined) {
+    issues.push({
+      path: `${path}/items`,
+      message: "`array.items` is required.",
+      code: "INVALID_PROPERTY_REFINEMENT",
+    });
+    return undefined;
+  }
+  if (!isPlainObject(itemsRaw)) {
+    issues.push({
+      path: `${path}/items`,
+      message: "`array.items` must be a plain property descriptor.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+  const itemType = itemsRaw.type;
+  if (itemType === "array") {
+    issues.push({
+      path: `${path}/items`,
+      message: "Nested arrays are not supported in v1.",
+      code: "NESTED_ARRAY",
+    });
+    return undefined;
+  }
+  const items = validateProperty(itemsRaw, `${path}/items`, depth + 1, issues);
+  if (items === undefined) return undefined;
+  if (items.type === "array") {
+    // Defensive: shouldn't be reachable because we checked above, but keeps
+    // the cast tight.
+    return undefined;
+  }
+
+  const modifiers = validatePropertyModifiers(raw, path, "array", issues);
+  if (modifiers === undefined) return undefined;
+
+  return compactUndefined<RuntimeArrayProperty>({
+    type: "array",
+    items: items,
+    optional: modifiers.optional,
+    searchable: modifiers.searchable,
+    embedding: modifiers.embedding,
+    description: modifiers.description,
+  });
+}
+
+function validateObjectProperty(
+  raw: Record<string, unknown>,
+  path: string,
+  depth: number,
+  issues: RuntimeExtensionIssue[],
+): RuntimeObjectProperty | undefined {
+  rejectUnknownRefinements(raw, OBJECT_REFINEMENT_KEYS, path, "object", issues);
+
+  if (depth >= 1) {
+    issues.push({
+      path,
+      message: "Nested objects are limited to a single level in v1.",
+      code: "NESTED_OBJECT_TOO_DEEP",
+    });
+    return undefined;
+  }
+
+  const propertiesRaw = raw.properties;
+  if (!isPlainObject(propertiesRaw)) {
+    issues.push({
+      path: `${path}/properties`,
+      message: "`object.properties` must be a plain object.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const propertiesEntries = Object.entries(propertiesRaw);
+  if (propertiesEntries.length === 0) {
+    issues.push({
+      path: `${path}/properties`,
+      message: "`object.properties` must declare at least one field.",
+      code: "EMPTY_PROPERTIES",
+    });
+    return undefined;
+  }
+
+  const fields: Record<string, RuntimeObjectFieldProperty> = {};
+  for (const [name, value] of propertiesEntries) {
+    const fieldPath = `${path}/properties/${escapePointerSegment(name)}`;
+    if (!isPlainObject(value)) {
+      issues.push({
+        path: fieldPath,
+        message: "Object field descriptor must be a plain object.",
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+      continue;
+    }
+    const fieldType = value.type;
+    if (fieldType === "object") {
+      issues.push({
+        path: fieldPath,
+        message: "Nested objects are limited to a single level in v1.",
+        code: "NESTED_OBJECT_TOO_DEEP",
+      });
+      continue;
+    }
+    const field = validateProperty(value, fieldPath, depth + 1, issues);
+    if (field === undefined) continue;
+    fields[name] = field as RuntimeObjectFieldProperty;
+  }
+
+  const modifiers = validatePropertyModifiers(raw, path, "object", issues);
+  if (modifiers === undefined) return undefined;
+
+  return compactUndefined<RuntimeObjectProperty>({
+    type: "object",
+    properties: fields,
+    optional: modifiers.optional,
+    searchable: modifiers.searchable,
+    embedding: modifiers.embedding,
+    description: modifiers.description,
+  });
+}
+
+// ============================================================
+// Modifiers
+// ============================================================
+
+type NormalizedModifiers = Readonly<{
+  optional?: boolean;
+  searchable?: { language?: string };
+  embedding?: { dimensions: number };
+  description?: string;
+}>;
+
+function validatePropertyModifiers(
+  raw: Record<string, unknown>,
+  path: string,
+  propertyType: RuntimePropertyType["type"],
+  issues: RuntimeExtensionIssue[],
+): NormalizedModifiers | undefined {
+  let valid = true;
+
+  let optional: boolean | undefined;
+  if (raw.optional !== undefined) {
+    if (typeof raw.optional === "boolean") {
+      optional = raw.optional;
+    } else {
+      issues.push({
+        path: `${path}/optional`,
+        message: "`optional` must be a boolean.",
+        code: "INVALID_PROPERTY_REFINEMENT",
+      });
+      valid = false;
+    }
+  }
+
+  let searchable: { language?: string } | undefined;
+  if (raw.searchable !== undefined) {
+    if (propertyType !== "string") {
+      issues.push({
+        path: `${path}/searchable`,
+        message: `\`searchable\` is only valid on string properties (got "${propertyType}").`,
+        code: "INVALID_MODIFIER_TARGET",
+      });
+      valid = false;
+    } else if (isPlainObject(raw.searchable)) {
+      const searchableRaw = raw.searchable;
+      const language = searchableRaw.language;
+      if (language === undefined) {
+        searchable = {};
+      } else {
+        if (typeof language !== "string" || language.length === 0) {
+          issues.push({
+            path: `${path}/searchable/language`,
+            message: "`searchable.language` must be a non-empty string.",
+            code: "INVALID_SEARCHABLE_LANGUAGE",
+          });
+          valid = false;
+        } else {
+          searchable = { language };
+        }
+      }
+    } else {
+      issues.push({
+        path: `${path}/searchable`,
+        message: "`searchable` must be a plain object (use `{}` for defaults).",
+        code: "INVALID_PROPERTY_REFINEMENT",
+      });
+      valid = false;
+    }
+  }
+
+  let embedding: { dimensions: number } | undefined;
+  if (raw.embedding !== undefined) {
+    if (propertyType === "array") {
+      const itemsRaw = raw.items;
+      const itemType = isPlainObject(itemsRaw) ? itemsRaw.type : undefined;
+      if (itemType !== "number") {
+        issues.push({
+          path: `${path}/embedding`,
+          message: '`embedding` requires `array.items.type === "number"`.',
+          code: "INVALID_MODIFIER_TARGET",
+        });
+        valid = false;
+      } else if (isPlainObject(raw.embedding)) {
+        const dim = raw.embedding.dimensions;
+        if (typeof dim !== "number" || !Number.isInteger(dim) || dim <= 0) {
+          issues.push({
+            path: `${path}/embedding/dimensions`,
+            message: "`embedding.dimensions` must be a positive integer.",
+            code: "INVALID_EMBEDDING_DIMENSIONS",
+          });
+          valid = false;
+        } else {
+          // `embedding(dimensions)` replaces the array's item validator with a
+          // length+finite-number check; any extra refinements on the items
+          // (min, max, int) would silently disappear at compile time.
+          const itemsObject = isPlainObject(itemsRaw) ? itemsRaw : {};
+          const extraneous = Object.keys(itemsObject).filter(
+            (key) => key !== "type",
+          );
+          if (extraneous.length > 0) {
+            issues.push({
+              path: `${path}/items`,
+              message: `\`embedding\` arrays must declare items as \`{ type: "number" }\` only — additional refinements (${extraneous.join(", ")}) are silently dropped by the embedding schema. Drop the refinements, or drop \`embedding\` and use a plain array.`,
+              code: "INVALID_PROPERTY_REFINEMENT",
+            });
+            valid = false;
+          } else {
+            embedding = { dimensions: dim };
+          }
+        }
+      } else {
+        issues.push({
+          path: `${path}/embedding`,
+          message:
+            "`embedding` must be a plain object with a `dimensions` field.",
+          code: "INVALID_PROPERTY_REFINEMENT",
+        });
+        valid = false;
+      }
+    } else {
+      issues.push({
+        path: `${path}/embedding`,
+        message: `\`embedding\` is only valid on array-of-number properties (got "${propertyType}").`,
+        code: "INVALID_MODIFIER_TARGET",
+      });
+      valid = false;
+    }
+  }
+
+  let description: string | undefined;
+  if (raw.description !== undefined) {
+    if (typeof raw.description === "string") {
+      description = raw.description;
+    } else {
+      issues.push({
+        path: `${path}/description`,
+        message: "`description` must be a string.",
+        code: "INVALID_PROPERTY_REFINEMENT",
+      });
+      valid = false;
+    }
+  }
+
+  if (!valid) return undefined;
+  return compactUndefined<NormalizedModifiers>({
+    optional,
+    searchable,
+    embedding,
+    description,
+  });
+}
+
+// ============================================================
+// Unique constraints
+// ============================================================
+
+function validateUniqueConstraints(
+  raw: unknown,
+  path: string,
+  properties: Record<string, RuntimePropertyType>,
+  issues: RuntimeExtensionIssue[],
+): readonly RuntimeUniqueConstraint[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    issues.push({
+      path,
+      message: "`unique` must be an array of constraint declarations.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+
+  const result: RuntimeUniqueConstraint[] = [];
+  const names = new Set<string>();
+  for (const [index, entry] of raw.entries()) {
+    const constraintPath = `${path}/${index}`;
+    if (!isPlainObject(entry)) {
+      issues.push({
+        path: constraintPath,
+        message: "Unique constraint must be a plain object.",
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+      continue;
+    }
+
+    const allowed = new Set(["name", "fields", "scope", "collation", "where"]);
+    for (const key of Object.keys(entry)) {
+      if (!allowed.has(key)) {
+        issues.push({
+          path: `${constraintPath}/${escapePointerSegment(key)}`,
+          message: `Unknown unique-constraint key "${key}". Allowed: name, fields, scope, collation, where.`,
+          code: "INVALID_DOCUMENT_SHAPE",
+        });
+      }
+    }
+
+    const constraint = entry;
+    const name = constraint.name;
+    if (typeof name !== "string" || name.length === 0) {
+      issues.push({
+        path: `${constraintPath}/name`,
+        message: "Unique constraint `name` must be a non-empty string.",
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+      continue;
+    }
+    if (names.has(name)) {
+      issues.push({
+        path: `${constraintPath}/name`,
+        message: `Duplicate unique constraint name "${name}".`,
+        code: "DUPLICATE_UNIQUE_CONSTRAINT",
+      });
+      continue;
+    }
+    names.add(name);
+
+    const fieldsRaw = constraint.fields;
+    if (!Array.isArray(fieldsRaw) || fieldsRaw.length === 0) {
+      issues.push({
+        path: `${constraintPath}/fields`,
+        message:
+          "Unique constraint `fields` must be a non-empty array of property names.",
+        code: "EMPTY_UNIQUE_FIELDS",
+      });
+      continue;
+    }
+
+    const fields: string[] = [];
+    const seenFields = new Set<string>();
+    let fieldsValid = true;
+    for (const [fieldIndex, field] of fieldsRaw.entries()) {
+      if (typeof field !== "string" || field.length === 0) {
+        issues.push({
+          path: `${constraintPath}/fields/${fieldIndex}`,
+          message: "Unique constraint field must be a non-empty string.",
+          code: "INVALID_DOCUMENT_SHAPE",
+        });
+        fieldsValid = false;
+        break;
+      }
+      if (seenFields.has(field)) {
+        issues.push({
+          path: `${constraintPath}/fields/${fieldIndex}`,
+          message: `Duplicate field "${field}" in unique constraint.`,
+          code: "DUPLICATE_UNIQUE_FIELD",
+        });
+        fieldsValid = false;
+        break;
+      }
+      if (!(field in properties)) {
+        issues.push({
+          path: `${constraintPath}/fields/${fieldIndex}`,
+          message: `Unique constraint field "${field}" is not declared on this kind.`,
+          code: "UNKNOWN_UNIQUE_FIELD",
+        });
+        fieldsValid = false;
+        break;
+      }
+      seenFields.add(field);
+      fields.push(field);
+    }
+    if (!fieldsValid) continue;
+
+    let scope: "kind" | "kindWithSubClasses" | undefined;
+    if (constraint.scope !== undefined) {
+      if (
+        constraint.scope !== "kind" &&
+        constraint.scope !== "kindWithSubClasses"
+      ) {
+        issues.push({
+          path: `${constraintPath}/scope`,
+          message: `Unique constraint scope must be "kind" or "kindWithSubClasses".`,
+          code: "INVALID_DOCUMENT_SHAPE",
+        });
+        continue;
+      }
+      scope = constraint.scope;
+    }
+
+    let collation: "binary" | "caseInsensitive" | undefined;
+    if (constraint.collation !== undefined) {
+      if (
+        constraint.collation !== "binary" &&
+        constraint.collation !== "caseInsensitive"
+      ) {
+        issues.push({
+          path: `${constraintPath}/collation`,
+          message: `Unique constraint collation must be "binary" or "caseInsensitive".`,
+          code: "INVALID_DOCUMENT_SHAPE",
+        });
+        continue;
+      }
+      collation = constraint.collation;
+    }
+
+    let where: { field: string; op: "isNull" | "isNotNull" } | undefined;
+    if (constraint.where !== undefined) {
+      const whereResult = validateUniqueWhere(
+        constraint.where,
+        `${constraintPath}/where`,
+        properties,
+        issues,
+      );
+      if (whereResult === undefined) continue;
+      where = whereResult;
+    }
+
+    result.push(
+      compactUndefined<RuntimeUniqueConstraint>({
+        name,
+        fields,
+        scope,
+        collation,
+        where,
+      }),
+    );
+  }
+
+  return result;
+}
+
+function validateUniqueWhere(
+  raw: unknown,
+  path: string,
+  properties: Record<string, RuntimePropertyType>,
+  issues: RuntimeExtensionIssue[],
+): { field: string; op: "isNull" | "isNotNull" } | undefined {
+  if (!isPlainObject(raw)) {
+    issues.push({
+      path,
+      message: "Unique constraint `where` must be `{ field, op }`.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+  const allowed = new Set(["field", "op"]);
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) {
+      issues.push({
+        path: `${path}/${escapePointerSegment(key)}`,
+        message: `Unknown where-clause key "${key}". Allowed: field, op.`,
+        code: "INVALID_DOCUMENT_SHAPE",
+      });
+    }
+  }
+  const field = raw.field;
+  const op = raw.op;
+  if (typeof field !== "string" || field.length === 0) {
+    issues.push({
+      path: `${path}/field`,
+      message: "Unique `where.field` must be a non-empty string.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+  if (!(field in properties)) {
+    issues.push({
+      path: `${path}/field`,
+      message: `Unique \`where.field\` "${field}" is not declared on this kind.`,
+      code: "UNKNOWN_UNIQUE_WHERE_FIELD",
+    });
+    return undefined;
+  }
+  if (op !== "isNull" && op !== "isNotNull") {
+    issues.push({
+      path: `${path}/op`,
+      message: `Unique \`where.op\` must be "isNull" or "isNotNull" (got ${describeUnknownValue(op)}).`,
+      code: "INVALID_UNIQUE_WHERE_OP",
+    });
+    return undefined;
+  }
+  return { field, op };
+}
+
+// ============================================================
+// Annotations
+// ============================================================
+
+function validateAnnotations(
+  raw: unknown,
+  path: string,
+  ownerLabel: string,
+  issues: RuntimeExtensionIssue[],
+): KindAnnotations | undefined {
+  if (raw === undefined) return undefined;
+  if (!isPlainObject(raw)) {
+    issues.push({
+      path,
+      message: `Annotations must be a plain JSON object.`,
+      code: "INVALID_ANNOTATION",
+    });
+    return undefined;
+  }
+
+  try {
+    assertJsonValue(raw, "annotations", ownerLabel);
+  } catch (error) {
+    if (error instanceof ConfigurationError) {
+      const detailPath = (error.details as Record<string, unknown>).path;
+      const annotationPath =
+        typeof detailPath === "string" ?
+          `${path}/${detailPath
+            .replace(/^annotations\.?/, "")
+            .replaceAll(".", "/")}`
+        : path;
+      issues.push({
+        path: annotationPath,
+        message: error.message,
+        code: "INVALID_ANNOTATION",
+      });
+      return undefined;
+    }
+    throw error;
+  }
+
+  return raw as KindAnnotations;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function rejectUnknownRefinements(
+  raw: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+  propertyType: RuntimePropertyType["type"],
+  issues: RuntimeExtensionIssue[],
+): void {
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) {
+      issues.push({
+        path: `${path}/${escapePointerSegment(key)}`,
+        message: `Refinement "${key}" is not supported on ${propertyType} properties.`,
+        code: "INVALID_PROPERTY_REFINEMENT",
+      });
+    }
+  }
+}
+
+function validateNonNegativeInteger(
+  value: unknown,
+  path: string,
+  label: string,
+  code: RuntimeExtensionIssueCode,
+  issues: RuntimeExtensionIssue[],
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    issues.push({
+      path,
+      message: `${label} must be a non-negative integer.`,
+      code,
+    });
+    return undefined;
+  }
+  return value;
+}
+
+function validateOptionalString(
+  value: unknown,
+  path: string,
+  issues: RuntimeExtensionIssue[],
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    issues.push({
+      path,
+      message: "`description` must be a string.",
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return undefined;
+  }
+  return value;
+}
+
+function isValidKindName(name: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+/**
+ * Renders an unknown value for inclusion in an error message without
+ * tripping `[object Object]` from a generic `String()` call. Strings
+ * are quoted; numbers, booleans, and null pass through; other values
+ * use `JSON.stringify` and fall back to `typeof` if that fails.
+ */
+function describeUnknownValue(value: unknown): string {
+  if (typeof value === "string") return `"${value}"`;
+  if (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return JSON.stringify(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return `(${typeof value})`;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const prototype: unknown = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Escapes a JSON-pointer reference segment per RFC 6901. `~` becomes
+ * `~0`, `/` becomes `~1`. The resulting segment is appended after the
+ * leading `/` separator.
+ */
+function escapePointerSegment(segment: string): string {
+  return segment.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+// ============================================================
+// Freezing
+// ============================================================
+
+function freezeDocument(input: {
+  nodes: Record<string, RuntimeNodeDocument> | undefined;
+  edges: Record<string, RuntimeEdgeDocument> | undefined;
+  ontology: readonly RuntimeOntologyRelation[] | undefined;
+}): RuntimeGraphDocument {
+  return Object.freeze(
+    compactUndefined<{
+      nodes?: Record<string, RuntimeNodeDocument>;
+      edges?: Record<string, RuntimeEdgeDocument>;
+      ontology?: readonly RuntimeOntologyRelation[];
+    }>({
+      nodes: input.nodes === undefined ? undefined : freezeDeep(input.nodes),
+      edges: input.edges === undefined ? undefined : freezeDeep(input.edges),
+      ontology:
+        input.ontology === undefined ?
+          undefined
+        : Object.freeze(
+            input.ontology.map((entry) => Object.freeze({ ...entry })),
+          ),
+    }),
+  );
+}
+
+function freezeDeep<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  if (Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value as Record<string, unknown>)) {
+    freezeDeep(nested);
+  }
+  return Object.freeze(value);
+}

--- a/packages/typegraph/tests/property/runtime-extension.test.ts
+++ b/packages/typegraph/tests/property/runtime-extension.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Property-based tests for the runtime extension document and compiler.
+ *
+ * fast-check generates arbitrary documents over the v1 property-type
+ * subset, and the suite asserts the load-bearing invariant from issue
+ * #101 PR 3:
+ *
+ * - `compileRuntimeExtension(defineRuntimeExtension(doc))` always
+ *   succeeds and produces a Zod schema that accepts the document's own
+ *   example values.
+ *
+ * The arbitraries don't try to cover *every* combination — that's the
+ * unit suite's job. They do cover enough of the cross-product
+ * (refinement + modifier + nesting) to catch surprising compositions
+ * where a refinement and a wrapper don't compose.
+ */
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { type z } from "zod";
+
+import { getEmbeddingDimensions } from "../../src/core/embedding";
+import { getSearchableMetadata } from "../../src/core/searchable";
+import {
+  compileRuntimeExtension,
+  defineRuntimeExtension,
+  type RuntimeArrayItemType,
+  type RuntimeObjectFieldProperty,
+  type RuntimePropertyType,
+} from "../../src/runtime";
+
+// ============================================================
+// Identifier arbitraries
+// ============================================================
+
+const propertyNameArb = fc.stringMatching(/^[a-z][a-zA-Z0-9]*$/).filter(
+  (s) =>
+    s.length > 0 &&
+    s.length <= 16 &&
+    // Stay clear of structural reserved keys: id, kind, meta. The validator
+    // would reject these and surface as a property-test failure.
+    !["id", "kind", "meta"].includes(s),
+);
+
+const nodeKindNameArb = fc
+  .stringMatching(/^[A-Z][a-zA-Z0-9]*$/)
+  .filter((s) => s.length >= 2 && s.length <= 16);
+
+const enumValueArb = fc
+  .stringMatching(/^[a-z]+$/)
+  .filter((s) => s.length > 0 && s.length <= 8);
+
+// ============================================================
+// Property type + example value arbitraries
+// ============================================================
+
+type PropertyAndExample = Readonly<{
+  property: RuntimePropertyType;
+  example: unknown;
+}>;
+
+const stringPropertyArb: fc.Arbitrary<PropertyAndExample> = fc
+  .record({
+    minLength: fc.option(fc.integer({ min: 0, max: 4 }), { nil: undefined }),
+    maxLength: fc.option(fc.integer({ min: 5, max: 32 }), { nil: undefined }),
+    optional: fc.boolean(),
+    wantSearchable: fc.boolean(),
+  })
+  .map(
+    ({
+      minLength,
+      maxLength,
+      optional,
+      wantSearchable,
+    }): PropertyAndExample => {
+      const property: Record<string, unknown> = { type: "string" };
+      if (minLength !== undefined) property.minLength = minLength;
+      if (maxLength !== undefined) property.maxLength = maxLength;
+      if (optional) property.optional = true;
+      if (wantSearchable) property.searchable = { language: "english" };
+      const example = "x".repeat(Math.max(minLength ?? 0, 1));
+      return {
+        property: property as unknown as RuntimePropertyType,
+        example,
+      };
+    },
+  );
+
+const numberPropertyArb: fc.Arbitrary<PropertyAndExample> = fc
+  .record({
+    int: fc.boolean(),
+    optional: fc.boolean(),
+  })
+  .map(({ int, optional }): PropertyAndExample => {
+    const property: Record<string, unknown> = { type: "number" };
+    if (int) property.int = true;
+    if (optional) property.optional = true;
+    return {
+      property: property as unknown as RuntimePropertyType,
+      example: int ? 7 : 1.5,
+    };
+  });
+
+const booleanPropertyArb: fc.Arbitrary<PropertyAndExample> = fc
+  .record({ optional: fc.boolean() })
+  .map(({ optional }): PropertyAndExample => {
+    const property: Record<string, unknown> = { type: "boolean" };
+    if (optional) property.optional = true;
+    return {
+      property: property as unknown as RuntimePropertyType,
+      example: true,
+    };
+  });
+
+const enumPropertyArb: fc.Arbitrary<PropertyAndExample> = fc
+  .uniqueArray(enumValueArb, { minLength: 1, maxLength: 5 })
+  .map((values): PropertyAndExample => {
+    return {
+      property: { type: "enum", values },
+      example: values[0],
+    };
+  });
+
+const leafPropertyArb: fc.Arbitrary<PropertyAndExample> = fc.oneof(
+  stringPropertyArb,
+  numberPropertyArb,
+  booleanPropertyArb,
+  enumPropertyArb,
+);
+
+const arrayPropertyArb: fc.Arbitrary<PropertyAndExample> = leafPropertyArb.map(
+  (leaf): PropertyAndExample => {
+    return {
+      property: {
+        type: "array",
+        items: leaf.property as RuntimeArrayItemType,
+      },
+      example: [leaf.example],
+    };
+  },
+);
+
+const objectPropertyArb: fc.Arbitrary<PropertyAndExample> = fc
+  .uniqueArray(fc.tuple(propertyNameArb, leafPropertyArb), {
+    minLength: 1,
+    maxLength: 4,
+    selector: ([name]) => name,
+  })
+  .map((entries): PropertyAndExample => {
+    const properties: Record<string, RuntimeObjectFieldProperty> = {};
+    const example: Record<string, unknown> = {};
+    for (const [name, leaf] of entries) {
+      properties[name] = leaf.property as RuntimeObjectFieldProperty;
+      example[name] = leaf.example;
+    }
+    return {
+      property: { type: "object", properties },
+      example,
+    };
+  });
+
+const propertyArb: fc.Arbitrary<PropertyAndExample> = fc.oneof(
+  leafPropertyArb,
+  arrayPropertyArb,
+  objectPropertyArb,
+);
+
+// ============================================================
+// Document + example payload arbitrary
+// ============================================================
+
+type NodeAndExample = Readonly<{
+  kindName: string;
+  properties: Record<string, RuntimePropertyType>;
+  example: Record<string, unknown>;
+}>;
+
+const nodeArb: fc.Arbitrary<NodeAndExample> = fc
+  .record({
+    kindName: nodeKindNameArb,
+    fields: fc.uniqueArray(
+      fc.tuple(propertyNameArb, propertyArb, fc.boolean()),
+      {
+        minLength: 1,
+        maxLength: 5,
+        selector: ([name]) => name,
+      },
+    ),
+  })
+  .map(({ kindName, fields }) => {
+    const properties: Record<string, RuntimePropertyType> = {};
+    const example: Record<string, unknown> = {};
+    for (const [name, propertyAndExample, includeOptional] of fields) {
+      properties[name] = propertyAndExample.property;
+      // Optional fields are present in the example payload only when the
+      // accompanying boolean from the arbitrary says so. Required fields
+      // are always present — that's what `optional !== true` enforces.
+      if (propertyAndExample.property.optional !== true || includeOptional) {
+        example[name] = propertyAndExample.example;
+      }
+    }
+    return { kindName, properties, example };
+  });
+
+// ============================================================
+// Property tests
+// ============================================================
+
+describe("runtime extension property tests", () => {
+  it("compiles every well-formed document and accepts the example payload", () => {
+    fc.assert(
+      fc.property(nodeArb, ({ kindName, properties, example }) => {
+        const document = defineRuntimeExtension({
+          nodes: { [kindName]: { properties } },
+        });
+        const compiled = compileRuntimeExtension(document);
+        expect(compiled.nodes).toHaveLength(1);
+        const node = compiled.nodes[0]!;
+        expect(node.type.kind).toBe(kindName);
+
+        const result = node.type.schema.safeParse(example);
+        expect(result.success).toBe(true);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("preserves searchable language metadata on string properties", () => {
+    const arb = fc.record({
+      kindName: nodeKindNameArb,
+      propertyName: propertyNameArb,
+      language: fc.constantFrom(
+        "english",
+        "spanish",
+        "german",
+        "french",
+        "simple",
+      ),
+    });
+    fc.assert(
+      fc.property(arb, ({ kindName, propertyName, language }) => {
+        const document = defineRuntimeExtension({
+          nodes: {
+            [kindName]: {
+              properties: {
+                [propertyName]: { type: "string", searchable: { language } },
+              },
+            },
+          },
+        });
+        const compiled = compileRuntimeExtension(document);
+        const schema = compiled.nodes[0]!.type.schema.shape[propertyName];
+        expect(schema).toBeDefined();
+        expect(getSearchableMetadata(schema! as z.ZodType)).toEqual({
+          language,
+        });
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  it("preserves embedding dimensions on array-of-number properties", () => {
+    const arb = fc.record({
+      kindName: nodeKindNameArb,
+      propertyName: propertyNameArb,
+      dimensions: fc.integer({ min: 1, max: 4096 }),
+    });
+    fc.assert(
+      fc.property(arb, ({ kindName, propertyName, dimensions }) => {
+        const document = defineRuntimeExtension({
+          nodes: {
+            [kindName]: {
+              properties: {
+                [propertyName]: {
+                  type: "array",
+                  items: { type: "number" },
+                  embedding: { dimensions },
+                },
+              },
+            },
+          },
+        });
+        const compiled = compileRuntimeExtension(document);
+        const schema = compiled.nodes[0]!.type.schema.shape[propertyName];
+        expect(schema).toBeDefined();
+        expect(getEmbeddingDimensions(schema! as z.ZodType)).toBe(dimensions);
+      }),
+      { numRuns: 30 },
+    );
+  });
+});

--- a/packages/typegraph/tests/runtime-extension.test.ts
+++ b/packages/typegraph/tests/runtime-extension.test.ts
@@ -1,0 +1,1193 @@
+/**
+ * Round-trip parity tests for `defineRuntimeExtension` /
+ * `compileRuntimeExtension`.
+ *
+ * For every type in the v1 property-type subset and every interesting
+ * modifier combination, this suite declares the same kind two ways:
+ *
+ *  (a) hand-written via `defineNode` / `defineEdge` with explicit Zod
+ *  (b) declared via `defineRuntimeExtension(...)` and compiled
+ *
+ * It then asserts structural equivalence between the two — same parsed
+ * output for valid inputs, equivalent error paths/counts for invalid
+ * ones, identical `getSearchableMetadata()` / `getEmbeddingDimensions()`
+ * results, and identical unique-constraint extraction.
+ *
+ * The compiler being one-way is what lets us hold this invariant: once a
+ * runtime-declared kind goes through the document → Zod path it must be
+ * indistinguishable from a compile-time declaration, since downstream
+ * code (introspection, fulltext sync, vector search, constraint
+ * enforcement) doesn't know — and shouldn't care — which declaration
+ * style produced it.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineEdge } from "../src/core/edge";
+import { embedding, getEmbeddingDimensions } from "../src/core/embedding";
+import { defineNode } from "../src/core/node";
+import { getSearchableMetadata, searchable } from "../src/core/searchable";
+import {
+  type EdgeType,
+  type NodeType,
+  type UniqueConstraint,
+} from "../src/core/types";
+import {
+  compileRuntimeExtension,
+  defineRuntimeExtension,
+  RuntimeExtensionValidationError,
+  type RuntimeGraphDocument,
+  validateRuntimeExtension,
+} from "../src/runtime";
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function compileSingleNode(document: RuntimeGraphDocument): NodeType {
+  const compiled = compileRuntimeExtension(document);
+  expect(compiled.nodes).toHaveLength(1);
+  return compiled.nodes[0]!.type;
+}
+
+function compileSingleEdge(document: RuntimeGraphDocument): EdgeType {
+  const compiled = compileRuntimeExtension(document);
+  expect(compiled.edges).toHaveLength(1);
+  return compiled.edges[0]!.type;
+}
+
+function endpointKind(endpoint: NodeType | string): string {
+  return typeof endpoint === "string" ? endpoint : endpoint.kind;
+}
+
+/**
+ * Asserts that two Zod schemas accept the same input and return the same
+ * parsed value. We don't compare schema internals directly — Zod's
+ * branded internal types vary by wrapper composition — but we compare
+ * what consumers actually observe: the parsed output.
+ */
+function assertParsedEqual<T>(
+  schemaA: z.ZodType,
+  schemaB: z.ZodType,
+  input: T,
+): void {
+  const a = schemaA.safeParse(input);
+  const b = schemaB.safeParse(input);
+  expect(a.success).toBe(true);
+  expect(b.success).toBe(true);
+  if (a.success && b.success) {
+    expect(b.data).toEqual(a.data);
+  }
+}
+
+/**
+ * Asserts that two Zod schemas reject the same input with the same set
+ * of issue paths. Message text varies between Zod versions; we compare
+ * structure instead.
+ */
+function assertRejectedEquivalently<T>(
+  schemaA: z.ZodType,
+  schemaB: z.ZodType,
+  input: T,
+): void {
+  const a = schemaA.safeParse(input);
+  const b = schemaB.safeParse(input);
+  expect(a.success).toBe(false);
+  expect(b.success).toBe(false);
+  if (!a.success && !b.success) {
+    const pathsA = new Set(a.error.issues.map((index) => index.path.join(".")));
+    const pathsB = new Set(b.error.issues.map((index) => index.path.join(".")));
+    expect(pathsB).toEqual(pathsA);
+  }
+}
+
+// ============================================================
+// String property parity
+// ============================================================
+
+describe("string property parity", () => {
+  it("plain string is structurally identical", () => {
+    const handwritten = defineNode("Plain", {
+      schema: z.object({ name: z.string() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: { Plain: { properties: { name: { type: "string" } } } },
+      }),
+    );
+    expect(compiled.kind).toBe(handwritten.kind);
+    assertParsedEqual(handwritten.schema, compiled.schema, { name: "alice" });
+  });
+
+  it("minLength + maxLength + pattern compile to equivalent refinements", () => {
+    const handwritten = defineNode("Sized", {
+      schema: z.object({
+        code: z
+          .string()
+          .min(2)
+          .max(8)
+          .regex(/^[A-Z]+$/),
+      }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Sized: {
+            properties: {
+              code: {
+                type: "string",
+                minLength: 2,
+                maxLength: 8,
+                pattern: "^[A-Z]+$",
+              },
+            },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, { code: "ABC" });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      code: "a",
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      code: "TOOLONGFIELD",
+    });
+  });
+
+  it("format: datetime parses ISO datetimes and rejects junk", () => {
+    const handwritten = defineNode("Stamp", {
+      schema: z.object({ at: z.iso.datetime() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Stamp: {
+            properties: { at: { type: "string", format: "datetime" } },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      at: "2025-01-02T03:04:05.000Z",
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      at: "not-a-date",
+    });
+  });
+
+  it("format: uri parses URLs and rejects non-URLs", () => {
+    const handwritten = defineNode("Link", {
+      schema: z.object({ href: z.url() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Link: {
+            properties: { href: { type: "string", format: "uri" } },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      href: "https://example.com",
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      href: "not a url",
+    });
+  });
+
+  it("optional string makes the field omittable on both sides", () => {
+    const handwritten = defineNode("Opt", {
+      schema: z.object({ note: z.string().optional() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Opt: {
+            properties: { note: { type: "string", optional: true } },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {});
+    assertParsedEqual(handwritten.schema, compiled.schema, { note: "hi" });
+  });
+
+  it("searchable string preserves metadata through wrappers", () => {
+    const handwritten = defineNode("Doc", {
+      schema: z.object({
+        title: searchable({ language: "english" }).min(1),
+      }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Doc: {
+            properties: {
+              title: {
+                type: "string",
+                searchable: { language: "english" },
+                minLength: 1,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const handwrittenMetadata = getSearchableMetadata(
+      handwritten.schema.shape.title,
+    );
+    const compiledMetadata = getSearchableMetadata(
+      compiled.schema.shape.title! as z.ZodType,
+    );
+    expect(compiledMetadata).toEqual(handwrittenMetadata);
+    expect(compiledMetadata).toEqual({ language: "english" });
+
+    // Also verify the marker survives `.optional()` in the compiled form.
+    const optionalCompiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Doc: {
+            properties: {
+              title: {
+                type: "string",
+                searchable: { language: "english" },
+                optional: true,
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(
+      getSearchableMetadata(optionalCompiled.schema.shape.title! as z.ZodType),
+    ).toEqual({
+      language: "english",
+    });
+  });
+
+  it("searchable defaults to language=english when omitted", () => {
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          D: {
+            properties: { body: { type: "string", searchable: {} } },
+          },
+        },
+      }),
+    );
+    expect(
+      getSearchableMetadata(compiled.schema.shape.body! as z.ZodType),
+    ).toEqual({
+      language: "english",
+    });
+  });
+});
+
+// ============================================================
+// Number property parity
+// ============================================================
+
+describe("number property parity", () => {
+  it("plain number accepts finite numbers on both sides", () => {
+    const handwritten = defineNode("N", {
+      schema: z.object({ score: z.number() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: { N: { properties: { score: { type: "number" } } } },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, { score: 1.5 });
+  });
+
+  it("int + min + max compose identically", () => {
+    const handwritten = defineNode("Bound", {
+      schema: z.object({ count: z.number().int().min(0).max(10) }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Bound: {
+            properties: {
+              count: { type: "number", int: true, min: 0, max: 10 },
+            },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, { count: 7 });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      count: 11,
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      count: 1.5,
+    });
+  });
+});
+
+// ============================================================
+// Boolean / enum parity
+// ============================================================
+
+describe("boolean and enum property parity", () => {
+  it("boolean parses truthy/falsy identically", () => {
+    const handwritten = defineNode("B", {
+      schema: z.object({ active: z.boolean() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: { B: { properties: { active: { type: "boolean" } } } },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, { active: true });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      active: "yes",
+    });
+  });
+
+  it("enum accepts members, rejects non-members", () => {
+    const handwritten = defineNode("E", {
+      schema: z.object({
+        status: z.enum(["draft", "published", "archived"]),
+      }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          E: {
+            properties: {
+              status: {
+                type: "enum",
+                values: ["draft", "published", "archived"],
+              },
+            },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      status: "draft",
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      status: "weird",
+    });
+  });
+});
+
+// ============================================================
+// Array / object / embedding parity
+// ============================================================
+
+describe("array and object property parity", () => {
+  it("array of strings parses identically", () => {
+    const handwritten = defineNode("A", {
+      schema: z.object({ tags: z.array(z.string()) }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          A: {
+            properties: {
+              tags: { type: "array", items: { type: "string" } },
+            },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      tags: ["a", "b"],
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      tags: ["a", 1],
+    });
+  });
+
+  it("single-level object property parses identically", () => {
+    const handwritten = defineNode("O", {
+      schema: z.object({
+        provenance: z.object({
+          createdBy: z.string(),
+          version: z.number().int(),
+        }),
+      }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          O: {
+            properties: {
+              provenance: {
+                type: "object",
+                properties: {
+                  createdBy: { type: "string" },
+                  version: { type: "number", int: true },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      provenance: { createdBy: "alice", version: 1 },
+    });
+  });
+
+  it("embedding(dimensions) is preserved in compiled output", () => {
+    const handwritten = defineNode("V", {
+      schema: z.object({ vector: embedding(384) }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          V: {
+            properties: {
+              vector: {
+                type: "array",
+                items: { type: "number" },
+                embedding: { dimensions: 384 },
+              },
+            },
+          },
+        },
+      }),
+    );
+    const compiledVector = compiled.schema.shape.vector! as z.ZodType;
+    expect(getEmbeddingDimensions(compiledVector)).toBe(384);
+    expect(getEmbeddingDimensions(compiledVector)).toBe(
+      getEmbeddingDimensions(handwritten.schema.shape.vector),
+    );
+
+    const goodVector = Array.from({ length: 384 }, () => 0.1);
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      vector: goodVector,
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      vector: [0.1, 0.2],
+    });
+  });
+});
+
+// ============================================================
+// Annotations passthrough
+// ============================================================
+
+describe("annotations passthrough", () => {
+  it("preserves consumer annotations on nodes", () => {
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          P: {
+            annotations: {
+              ui: { titleField: "name" },
+              audit: { pii: false, retentionDays: 30 },
+            },
+            properties: { name: { type: "string" } },
+          },
+        },
+      }),
+    );
+    expect(compiled.annotations).toEqual({
+      ui: { titleField: "name" },
+      audit: { pii: false, retentionDays: 30 },
+    });
+  });
+
+  it("preserves consumer annotations on edges", () => {
+    const compiled = compileSingleEdge(
+      defineRuntimeExtension({
+        nodes: { A: { properties: { x: { type: "string" } } } },
+        edges: {
+          link: {
+            from: ["A"],
+            to: ["A"],
+            annotations: { ui: { showInTimeline: true } },
+            properties: {},
+          },
+        },
+      }),
+    );
+    expect(compiled.annotations).toEqual({
+      ui: { showInTimeline: true },
+    });
+  });
+});
+
+// ============================================================
+// Edge endpoints + ontology references
+// ============================================================
+
+describe("edge compilation", () => {
+  it("resolves endpoint names to NodeType references", () => {
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: {
+          Paper: { properties: { doi: { type: "string" } } },
+          Author: { properties: { name: { type: "string" } } },
+        },
+        edges: {
+          authoredBy: { from: ["Paper"], to: ["Author"], properties: {} },
+        },
+      }),
+    );
+    expect(compiled.edges).toHaveLength(1);
+    const edge = compiled.edges[0]!;
+    expect(edge.from.map((endpoint) => endpointKind(endpoint))).toEqual([
+      "Paper",
+    ]);
+    expect(edge.to.map((endpoint) => endpointKind(endpoint))).toEqual([
+      "Author",
+    ]);
+  });
+
+  it("preserves unresolved endpoints as raw strings for host-graph merge", () => {
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: { Paper: { properties: { doi: { type: "string" } } } },
+        edges: {
+          authoredBy: {
+            from: ["Paper"],
+            to: ["Author"],
+            properties: {},
+          },
+        },
+      }),
+    );
+    const edge = compiled.edges[0]!;
+    expect(edge.from.map((endpoint) => endpointKind(endpoint))).toEqual([
+      "Paper",
+    ]);
+    expect(edge.to).toEqual(["Author"]);
+  });
+
+  it("compiles ontology relations referencing declared nodes", () => {
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: {
+          Podcast: { properties: { title: { type: "string" } } },
+          Media: { properties: { title: { type: "string" } } },
+        },
+        ontology: [{ metaEdge: "subClassOf", from: "Podcast", to: "Media" }],
+      }),
+    );
+    expect(compiled.ontology).toHaveLength(1);
+    const relation = compiled.ontology[0]!;
+    expect(relation.metaEdge.name).toBe("subClassOf");
+    // Resolved to NodeType references because both names are declared.
+    expect(typeof relation.from).toBe("object");
+    expect(typeof relation.to).toBe("object");
+  });
+
+  it("ontology endpoints that don't resolve fall through as IRI strings", () => {
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: { Podcast: { properties: { title: { type: "string" } } } },
+        ontology: [
+          {
+            metaEdge: "equivalentTo",
+            from: "Podcast",
+            to: "https://schema.org/PodcastSeries",
+          },
+        ],
+      }),
+    );
+    expect(compiled.ontology).toHaveLength(1);
+    const relation = compiled.ontology[0]!;
+    expect(typeof relation.to).toBe("string");
+    expect(relation.to).toBe("https://schema.org/PodcastSeries");
+  });
+});
+
+// ============================================================
+// Unique constraints
+// ============================================================
+
+describe("unique constraint compilation", () => {
+  it("compiles fields, scope, and collation defaults", () => {
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: {
+          Paper: {
+            properties: { doi: { type: "string" } },
+            unique: [{ name: "paper_doi", fields: ["doi"] }],
+          },
+        },
+      }),
+    );
+    expect(compiled.nodes).toHaveLength(1);
+    const constraint: UniqueConstraint = compiled.nodes[0]!.unique[0]!;
+    expect(constraint.name).toBe("paper_doi");
+    expect(constraint.fields).toEqual(["doi"]);
+    expect(constraint.scope).toBe("kind");
+    expect(constraint.collation).toBe("binary");
+    expect(constraint.where).toBeUndefined();
+  });
+
+  it("compiles where: isNull / isNotNull predicates round-trippable", () => {
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: {
+          Item: {
+            properties: {
+              code: { type: "string" },
+              archivedAt: { type: "string", optional: true },
+            },
+            unique: [
+              {
+                name: "active_code",
+                fields: ["code"],
+                where: { field: "archivedAt", op: "isNull" },
+              },
+            ],
+          },
+        },
+      }),
+    );
+    const constraint = compiled.nodes[0]!.unique[0]!;
+    expect(constraint.where).toBeDefined();
+    // The callback shape mirrors what `serializeWherePredicate` consumes:
+    // a per-field builder dict; calling builder.isNull() returns the
+    // predicate object.
+    const builder = {
+      archivedAt: {
+        isNull: () => ({
+          __type: "unique_predicate" as const,
+          field: "archivedAt",
+          op: "isNull" as const,
+        }),
+        isNotNull: () => ({
+          __type: "unique_predicate" as const,
+          field: "archivedAt",
+          op: "isNotNull" as const,
+        }),
+      },
+    };
+    const result = constraint.where!(builder);
+    expect(result).toEqual({
+      __type: "unique_predicate",
+      field: "archivedAt",
+      op: "isNull",
+    });
+  });
+
+  it("honours custom scope and collation when provided", () => {
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: {
+          Email: {
+            properties: { addr: { type: "string" } },
+            unique: [
+              {
+                name: "addr_ci",
+                fields: ["addr"],
+                scope: "kindWithSubClasses",
+                collation: "caseInsensitive",
+              },
+            ],
+          },
+        },
+      }),
+    );
+    const constraint = compiled.nodes[0]!.unique[0]!;
+    expect(constraint.scope).toBe("kindWithSubClasses");
+    expect(constraint.collation).toBe("caseInsensitive");
+  });
+});
+
+// ============================================================
+// Failure modes — must reject synchronously with a usable error
+// ============================================================
+
+function expectInvalid(
+  fn: () => unknown,
+  code: string,
+  pathFragment?: string,
+): RuntimeExtensionValidationError {
+  let caught: unknown;
+  try {
+    fn();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(RuntimeExtensionValidationError);
+  const error = caught as RuntimeExtensionValidationError;
+  const codes = error.details.issues.map((index) => index.code);
+  expect(codes).toContain(code);
+  if (pathFragment !== undefined) {
+    const matched = error.details.issues.some((issue) =>
+      issue.path.includes(pathFragment),
+    );
+    expect(matched).toBe(true);
+  }
+  return error;
+}
+
+describe("validation failures", () => {
+  it("rejects unsupported property types", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: { N: { properties: { x: { type: "bigint" } } } },
+        }),
+      "UNSUPPORTED_PROPERTY_TYPE",
+      "/nodes/N/properties/x/type",
+    );
+  });
+
+  it("rejects searchable + format on the same string property", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: {
+                at: {
+                  type: "string",
+                  format: "datetime",
+                  searchable: { language: "english" },
+                },
+              },
+            },
+          },
+        }),
+      "INVALID_PROPERTY_REFINEMENT",
+      "/nodes/N/properties/at",
+    );
+  });
+
+  it("rejects format combined with minLength/maxLength/pattern", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: {
+                href: { type: "string", format: "uri", maxLength: 10 },
+              },
+            },
+          },
+        }),
+      "INVALID_PROPERTY_REFINEMENT",
+      "/nodes/N/properties/href",
+    );
+  });
+
+  it("rejects embedding arrays whose items carry refinements", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: {
+                vector: {
+                  type: "array",
+                  items: { type: "number", min: 0, max: 1 },
+                  embedding: { dimensions: 8 },
+                },
+              },
+            },
+          },
+        }),
+      "INVALID_PROPERTY_REFINEMENT",
+      "/nodes/N/properties/vector/items",
+    );
+  });
+
+  it("detects mixed-direction hierarchical cycles after canonicalization", () => {
+    // `narrower A→B` normalizes to `broader B→A`; combined with `broader A→B`
+    // it forms a cycle in the normalized broader group.
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            A: { properties: { name: { type: "string" } } },
+            B: { properties: { name: { type: "string" } } },
+          },
+          ontology: [
+            { metaEdge: "broader", from: "A", to: "B" },
+            { metaEdge: "narrower", from: "A", to: "B" },
+          ],
+        }),
+      "ONTOLOGY_CYCLE",
+    );
+  });
+
+  it("detects hasPart/partOf cross-direction cycles", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            Whole: { properties: { name: { type: "string" } } },
+            Part: { properties: { name: { type: "string" } } },
+          },
+          ontology: [
+            { metaEdge: "partOf", from: "Whole", to: "Part" },
+            { metaEdge: "hasPart", from: "Whole", to: "Part" },
+          ],
+        }),
+      "ONTOLOGY_CYCLE",
+    );
+  });
+
+  it("rejects refinements on the wrong type (pattern on number)", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: { score: { type: "number", pattern: "abc" } },
+            },
+          },
+        }),
+      "INVALID_PROPERTY_REFINEMENT",
+      "/nodes/N/properties/score/pattern",
+    );
+  });
+
+  it("rejects nested arrays", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: {
+                grid: {
+                  type: "array",
+                  items: {
+                    type: "array",
+                    items: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      "NESTED_ARRAY",
+      "/nodes/N/properties/grid/items",
+    );
+  });
+
+  it("rejects two-level nested objects", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: {
+                outer: {
+                  type: "object",
+                  properties: {
+                    inner: {
+                      type: "object",
+                      properties: { x: { type: "string" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      "NESTED_OBJECT_TOO_DEEP",
+      "/nodes/N/properties/outer/properties/inner",
+    );
+  });
+
+  it("rejects ontology cycles", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            A: { properties: { x: { type: "string" } } },
+            B: { properties: { x: { type: "string" } } },
+            C: { properties: { x: { type: "string" } } },
+          },
+          ontology: [
+            { metaEdge: "subClassOf", from: "A", to: "B" },
+            { metaEdge: "subClassOf", from: "B", to: "C" },
+            { metaEdge: "subClassOf", from: "C", to: "A" },
+          ],
+        }),
+      "ONTOLOGY_CYCLE",
+    );
+  });
+
+  it("rejects ontology self-loops on hierarchical meta-edges", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: { A: { properties: { x: { type: "string" } } } },
+          ontology: [{ metaEdge: "subClassOf", from: "A", to: "A" }],
+        }),
+      "ONTOLOGY_SELF_LOOP",
+    );
+  });
+
+  it("accepts edge endpoints that don't resolve in-document (host-graph merge resolves)", () => {
+    // Endpoints can reference compile-time host kinds or external IRIs;
+    // cross-graph resolution happens at merge time, not here.
+    const compiled = compileRuntimeExtension(
+      defineRuntimeExtension({
+        nodes: { A: { properties: { x: { type: "string" } } } },
+        edges: {
+          partial: {
+            from: ["A"],
+            to: ["NotDeclaredLocally"],
+            properties: {},
+          },
+        },
+      }),
+    );
+    const edge = compiled.edges[0]!;
+    expect(edge.from.map((endpoint) => endpointKind(endpoint))).toEqual(["A"]);
+    expect(edge.to).toEqual(["NotDeclaredLocally"]);
+  });
+
+  it("rejects unknown meta-edge names", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: { A: { properties: { x: { type: "string" } } } },
+          ontology: [{ metaEdge: "notARealMetaEdge", from: "A", to: "A" }],
+        }),
+      "UNKNOWN_META_EDGE",
+    );
+  });
+
+  it("rejects unique constraint references to undeclared fields", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: { id: { type: "string" } },
+              unique: [{ name: "by_missing", fields: ["doesNotExist"] }],
+            },
+          },
+        }),
+      "UNKNOWN_UNIQUE_FIELD",
+    );
+  });
+
+  it("rejects unique where predicates with unsupported ops", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: { x: { type: "string" } },
+              unique: [
+                {
+                  name: "by_x",
+                  fields: ["x"],
+                  where: { field: "x", op: "equals" },
+                },
+              ],
+            },
+          },
+        }),
+      "INVALID_UNIQUE_WHERE_OP",
+    );
+  });
+
+  it("rejects searchable on non-string properties", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: {
+                count: {
+                  type: "number",
+                  searchable: { language: "english" },
+                },
+              },
+            },
+          },
+        }),
+      "INVALID_MODIFIER_TARGET",
+    );
+  });
+
+  it("rejects embedding on non-array-of-number properties", () => {
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            N: {
+              properties: {
+                vec: {
+                  type: "array",
+                  items: { type: "string" },
+                  embedding: { dimensions: 384 },
+                },
+              },
+            },
+          },
+        }),
+      "INVALID_MODIFIER_TARGET",
+    );
+  });
+
+  it("rejects duplicate kind names within the document", () => {
+    // Object literal duplicate keys are silently overwritten by JS, so
+    // we exercise the non-key-uniqueness duplicate-name path via the
+    // ontology validation: two ontology relations with the same
+    // (metaEdge, from, to) tuple.
+    expectInvalid(
+      () =>
+        defineRuntimeExtension({
+          nodes: {
+            A: { properties: { x: { type: "string" } } },
+            B: { properties: { x: { type: "string" } } },
+          },
+          ontology: [
+            { metaEdge: "subClassOf", from: "A", to: "B" },
+            { metaEdge: "subClassOf", from: "A", to: "B" },
+          ],
+        }),
+      "DUPLICATE_ONTOLOGY_RELATION",
+    );
+  });
+
+  it("collects multiple issues in a single error", () => {
+    let caught: unknown;
+    try {
+      defineRuntimeExtension({
+        nodes: {
+          N: {
+            properties: {
+              // unsupported type AND nested array
+              x: { type: "weird" } as never,
+              y: {
+                type: "array",
+                items: { type: "array", items: { type: "string" } },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(RuntimeExtensionValidationError);
+    const error = caught as RuntimeExtensionValidationError;
+    expect(error.details.issues.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("validateRuntimeExtension is the result-returning variant", () => {
+    const result = validateRuntimeExtension({
+      nodes: { N: { properties: { x: { type: "string" } } } },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================
+// Document is frozen
+// ============================================================
+
+describe("document immutability", () => {
+  it("returned document is deeply frozen", () => {
+    const document = defineRuntimeExtension({
+      nodes: {
+        N: {
+          properties: { x: { type: "string" } },
+          unique: [{ name: "by_x", fields: ["x"] }],
+        },
+      },
+    });
+    expect(Object.isFrozen(document)).toBe(true);
+    expect(Object.isFrozen(document.nodes!)).toBe(true);
+    expect(Object.isFrozen(document.nodes!.N!)).toBe(true);
+    expect(Object.isFrozen(document.nodes!.N!.properties)).toBe(true);
+  });
+});
+
+// ============================================================
+// Ontology cycle detection — additional cases
+// ============================================================
+
+describe("ontology cycle detection", () => {
+  it("ignores cycles across non-transitive meta-edges", () => {
+    // `relatedTo` is symmetric but not strictly hierarchical; cycles
+    // there are not domain errors. This document must succeed.
+    const document = defineRuntimeExtension({
+      nodes: {
+        A: { properties: { x: { type: "string" } } },
+        B: { properties: { x: { type: "string" } } },
+      },
+      ontology: [
+        { metaEdge: "relatedTo", from: "A", to: "B" },
+        { metaEdge: "relatedTo", from: "B", to: "A" },
+      ],
+    });
+    expect(document.ontology).toHaveLength(2);
+  });
+
+  it("rejects 2-cycle on broader/narrower", () => {
+    let caught: unknown;
+    try {
+      defineRuntimeExtension({
+        nodes: {
+          A: { properties: { x: { type: "string" } } },
+          B: { properties: { x: { type: "string" } } },
+        },
+        ontology: [
+          { metaEdge: "broader", from: "A", to: "B" },
+          { metaEdge: "broader", from: "B", to: "A" },
+        ],
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(RuntimeExtensionValidationError);
+    const codes = (
+      caught as RuntimeExtensionValidationError
+    ).details.issues.map((index) => index.code);
+    expect(codes).toContain("ONTOLOGY_CYCLE");
+  });
+});
+
+// ============================================================
+// Edge schema parity with defineEdge
+// ============================================================
+
+describe("edge schema parity", () => {
+  it("edge with no properties matches handwritten empty edge", () => {
+    const handwritten = defineEdge("emptyEdge");
+    const compiled = compileSingleEdge(
+      defineRuntimeExtension({
+        nodes: { A: { properties: { x: { type: "string" } } } },
+        edges: { emptyEdge: { from: ["A"], to: ["A"], properties: {} } },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {});
+  });
+
+  it("edge with properties parses identically", () => {
+    const handwritten = defineEdge("link", {
+      schema: z.object({ since: z.iso.datetime(), weight: z.number() }),
+    });
+    const compiled = compileSingleEdge(
+      defineRuntimeExtension({
+        nodes: { A: { properties: { x: { type: "string" } } } },
+        edges: {
+          link: {
+            from: ["A"],
+            to: ["A"],
+            properties: {
+              since: { type: "string", format: "datetime" },
+              weight: { type: "number" },
+            },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      since: "2025-01-02T03:04:05.000Z",
+      weight: 1.5,
+    });
+  });
+});


### PR DESCRIPTION
PR 3 of the runtime-extension feature (issue #101). Ships the pure-value `RuntimeGraphDocument` format and a one-way compiler that turns it into Zod-bearing `NodeType` / `EdgeType` / `OntologyRelation` values. No I/O, no `Store` changes, no schema persistence — those live in PRs 4 and 5.

```typescript
import {
  compileRuntimeExtension,
  defineRuntimeExtension,
} from "@nicia-ai/typegraph";

const document = defineRuntimeExtension({
  nodes: {
    Paper: {
      properties: {
        doi: { type: "string" },
        title: { type: "string", searchable: { language: "english" } },
        publishedAt: { type: "string", format: "datetime" },
        publicationType: {
          type: "enum",
          values: ["preprint", "conference", "journal", "workshop"],
        },
      },
      unique: [{ name: "paper_doi", fields: ["doi"] }],
    },
    Author: { properties: { name: { type: "string", minLength: 1 } } },
  },
  edges: {
    authoredBy: { from: ["Paper"], to: ["Author"], properties: {} },
  },
});

const compiled = compileRuntimeExtension(document);
// compiled.nodes[*].type is structurally indistinguishable from
// the equivalent hand-written `defineNode(...)`.
```

## Why a TypeGraph-native document and not JSON Schema → Zod

The existing `Zod → JSON Schema` path is one-way (`schema/deserializer.ts:5` documents the constraint). Going the other direction would lose `searchable()` markers, the `embedding()` brand, `.optional()` shape, and unique-constraint extraction — exactly the metadata the rest of TypeGraph reads at runtime. Owning both ends of the document → Zod path keeps the round-trip lossless. The runtime document is the canonical durable form; Zod is derived on each load. PR 4 will persist this document into `SerializedSchema.runtimeDocument`; PR 5 will let `store.evolve()` commit one and rebuild a `Store<ExtendedGraph>`.

## v1 property-type subset (pinned)

Intentionally narrow — covers what LLM-induced schemas actually emit and nothing more. Anything outside fails synchronously at `defineRuntimeExtension(...)` with a JSON-pointer path to the offending node.

| Type | Refinements |
|---|---|
| `string` | `minLength`, `maxLength`, `pattern`, `format: "datetime" \| "uri"` |
| `number` | `min`, `max`, `int` |
| `boolean` | — |
| `enum` | `values: readonly string[]` |
| `array` | `items: <any of these types>` (no nested arrays) |
| `object` | `properties: { ... }` (single nesting level) |

Plus per-property `optional`, `searchable: { language? }`, `embedding: { dimensions }`, and per-kind `unique: [{ name, fields, scope?, collation?, where? }]` where `where` is limited to `isNull` / `isNotNull` (matches the existing `serializeWherePredicate` capability). Adding refinements later is non-breaking; allowing the wrong shape now is forever.

## Round-trip parity is the load-bearing invariant

For every type and modifier in the v1 subset, the test suite declares the same kind two ways — hand-written via `defineNode` / `defineEdge` and document-via-`defineRuntimeExtension` — and asserts:

- `getSearchableMetadata` and `getEmbeddingDimensions` return identical results.
- Unique-constraint extraction matches.
- Valid inputs parse to the same value.
- Invalid inputs reject with the same issue paths (text varies between Zod versions; structure doesn't).

Property tests over the type subset additionally generate arbitrary documents and assert the compile pipeline always produces a Zod schema that accepts the document's own example values.

## API surface

- `defineRuntimeExtension(input)` — throw-on-error variant, returns a frozen `RuntimeGraphDocument`.
- `validateRuntimeExtension(input)` — `Result`-style variant returning `Result<RuntimeGraphDocument, RuntimeExtensionValidationError>` for callers that prefer to thread errors.
- `compileRuntimeExtension(document)` — pure function returning `CompiledExtension { nodes, edges, ontology }` ready to merge into a `GraphDef`.
- `RuntimeExtensionValidationError` carries a structured `issues` array with stable `RuntimeExtensionIssueCode` values and JSON-pointer paths so callers can render field-level diagnostics without parsing message text.
- All document type aliases (`RuntimeGraphDocument`, `RuntimePropertyType`, etc.) and the compiler output types (`CompiledNode`, `CompiledEdge`, `CompiledExtension`) are exported from the package root.

## Out of scope for this PR

No `store.evolve()`. No `SerializedSchema` changes. No persistence. No DDL. No backend touches. The compiled output is a pure value the next PR will merge into a `GraphDef`.

Closes part of #101.