### PR TITLE
feat: persist RuntimeGraphDocument and rewire schema-aware loader (#101 PR 4/6)

### DIFF
--- a/.changeset/runtime-document-persistence.md
+++ b/.changeset/runtime-document-persistence.md
@@ -1,0 +1,47 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Persist `RuntimeGraphDocument` in `SerializedSchema` and rewire the schema-aware loader (`createStoreWithSchema`) so a `Store` is built against a graph that already has the persisted runtime extension merged in. This is the durable-storage half of the runtime-extension feature (issue #101 PR 4/6); `store.evolve()` and `StoreRef` ship in PR 5, `materializeIndexes()` in PR 6.
+
+```typescript
+// Process A (PR 5 will turn this into store.evolve(...) — for PR 4 we
+// invoke the pieces directly):
+const merged = mergeRuntimeExtension(graph, runtimeExtension);
+const evolvedSchema = serializeSchema(merged, activeVersion + 1);
+await backend.commitSchemaVersion({
+  graphId: graph.id,
+  expected: { kind: "active", version: activeVersion },
+  version: activeVersion + 1,
+  schemaHash: await computeSchemaHash(evolvedSchema),
+  schemaDoc: evolvedSchema,
+});
+
+// Process B (different process, possibly different machine), boots
+// against the same backend with the original compile-time graph:
+const [store] = await createStoreWithSchema(graph, backend);
+// store.registry.hasNodeType("RuntimeKindFromExtensionA") === true
+```
+
+**The load-bearing constraint** (`schema/deserializer.ts:5`): the existing `Zod → JSON Schema` path is one-way, so `SerializedSchema.{nodes,edges,ontology}` cannot reconstruct runtime Zod validators on its own. The persisted `runtimeDocument` is the only durable source the loader uses to rebuild them — the merged maps remain useful for diff machinery and human-readable schema reporting but never for validator reconstruction.
+
+**Public-API additions:**
+
+- `GraphDef.runtimeDocument: RuntimeGraphDocument | undefined` — set by the loader (and by `store.evolve()` in PR 5), never by `defineGraph` directly. Serializes through to the canonical document so re-serializing the merged graph reproduces the same hash.
+- `SerializedSchema.runtimeDocument?: RuntimeGraphDocument` — the persisted slice. Omitted on graphs that have never been runtime-extended; legacy schemas hash byte-identically.
+- `mergeRuntimeExtension(graph, document)` — pure function: structurally validates the document, compiles it, validates that every edge endpoint resolves either to a runtime kind in the same document or to a compile-time kind in the host graph, throws `ConfigurationError` on collisions or unresolvable references (or `RuntimeExtensionValidationError` for malformed documents), and returns the merge applied to `graph`.
+- `loadAndMergeRuntimeDocument(backend, graph)` — schema-layer helper that reads the active row, parses it, folds any persisted runtime extension into the supplied graph, and returns the merged graph alongside the prefetched row + parsed schema. The loader passes those through to `ensureSchema` via a new `preloaded` option so each Store boot pays for one `getActiveSchema` round trip and one `serializedSchemaZod` walk, not two.
+- `loadActiveSchemaWithBootstrap(backend, graphId)` and `parseSerializedSchema(json)` — factored out of `ensureSchema` for the load-and-merge helper; both surface from `@nicia-ai/typegraph/schema`.
+- `RuntimeDocumentChange` and `SchemaDiff.runtimeDocument` — the diff classifies runtime-document changes as `safe`-severity (v1 runtime extensions are additive only; per-kind effects already surface in the node/edge/ontology change arrays).
+
+**Loader rewire.** `createStoreWithSchema` now reads the active schema row before constructing the `Store`. If the row's `runtimeDocument` is present, the loader compiles + merges it into the application's compile-time `GraphDef` and constructs the `Store` against the merged graph; `ensureSchema` then runs against the merged form. The prefetched row and parsed schema thread through a new `preloaded` option on `ensureSchema`, so legacy graphs (no runtime extension persisted) still pay for exactly one `getActiveSchema` round trip and one Zod parse at startup.
+
+**Startup-conflict behavior.** If application code has been updated such that a compile-time kind referenced by `runtimeDocument` (via an edge endpoint) no longer exists, `mergeRuntimeExtension` throws `ConfigurationError` with `code: "RUNTIME_EXTENSION_UNRESOLVED_ENDPOINT"`. Operators handle this by reverting the application change or evolving the runtime extension to drop the reference. Ontology endpoints remain permissive (unresolved strings pass through as external IRIs, matching the existing runtime-compiler behavior).
+
+**Load-bearing canonical-form invariants** (verified by tests in `tests/property/schema-serialization.test.ts` and `tests/runtime-document-persistence.test.ts`):
+
+- Graphs that have never been runtime-extended produce identical canonical-form hashes to today — adoption requires no migration.
+- A graph merged with a runtime extension serializes to a hash that round-trips: re-merging the same extension on top of the same compile-time graph in a different process yields the same hash, so `ensureSchema` returns `unchanged` on restart instead of triggering a spurious migration.
+- The diff distinguishes "runtime document added" / "modified" / "removed" as a single `RuntimeDocumentChange` alongside the per-kind node/edge/ontology changes the merge produces.
+
+**Forward compatibility.** `runtimeDocumentZod` uses `.loose()` on every nested object so future v2 property-type extensions don't fail older readers; the runtime/validation.ts validator is the authoritative shape check on the way back up.

--- a/packages/typegraph/src/core/define-graph.ts
+++ b/packages/typegraph/src/core/define-graph.ts
@@ -1,6 +1,7 @@
 import { ConfigurationError } from "../errors/index";
 import { type IndexDeclaration } from "../indexes/types";
 import { type OntologyRelation } from "../ontology/types";
+import { type RuntimeGraphDocument } from "../runtime/document-types";
 import {
   type AnyEdgeType,
   type DeleteBehavior,
@@ -226,6 +227,15 @@ export type GraphDef<
    * that an absent slice doesn't.
    */
   indexes: readonly IndexDeclaration[] | undefined;
+  /**
+   * Runtime extension document this graph was merged with, if any. Set
+   * by `mergeRuntimeExtension`; never set by `defineGraph` directly.
+   * Exists solely so re-serialization is stable — the rest of the
+   * system reads the merged kinds through `nodes` / `edges` /
+   * `ontology` and never inspects this field. Absent on graphs that
+   * have never been runtime-extended; legacy graphs hash byte-identically.
+   */
+  runtimeDocument: RuntimeGraphDocument | undefined;
 }>;
 
 // ============================================================
@@ -336,6 +346,7 @@ export function defineGraph<
     ontology: config.ontology ?? ([] as unknown as TOntology),
     defaults,
     indexes,
+    runtimeDocument: undefined,
   }) as GraphDef<TNodes, NormalizedEdges<TNodes, TEdges>, TOntology>;
 }
 

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -457,6 +457,7 @@ export type {
 export {
   compileRuntimeExtension,
   defineRuntimeExtension,
+  mergeRuntimeExtension,
   RuntimeExtensionValidationError,
   validateRuntimeExtension,
 } from "./runtime";

--- a/packages/typegraph/src/runtime/index.ts
+++ b/packages/typegraph/src/runtime/index.ts
@@ -43,3 +43,7 @@ export {
 
 // Result-returning validator (for callers that prefer Result-style)
 export { validateRuntimeExtension } from "./validation";
+
+// Merge: compile a runtime extension and fold it into a host GraphDef.
+// Used by the schema-aware loader at startup and by `store.evolve()`.
+export { mergeRuntimeExtension } from "./merge";

--- a/packages/typegraph/src/runtime/merge.ts
+++ b/packages/typegraph/src/runtime/merge.ts
@@ -1,0 +1,156 @@
+import { type GraphDef } from "../core/define-graph";
+import {
+  type EdgeRegistration,
+  type NodeRegistration,
+  type NodeType,
+} from "../core/types";
+import { ConfigurationError } from "../errors";
+import { type OntologyRelation } from "../ontology/types";
+import { unwrap } from "../utils/result";
+import { compileRuntimeExtension } from "./compiler";
+import { type RuntimeGraphDocument } from "./document-types";
+import { validateRuntimeExtension } from "./validation";
+
+/**
+ * Compiles a runtime extension document and merges the result into a
+ * host compile-time `GraphDef`. Throws `ConfigurationError` on
+ * kind-name collisions or on edge endpoints that don't resolve against
+ * either the runtime extension or the host graph (the startup-conflict
+ * case for stale persisted documents). The returned graph carries
+ * `runtimeDocument` so re-serialization is stable across restarts.
+ *
+ * Validates the document structurally before compiling — every load
+ * path goes through here, so persisted documents that drift from the
+ * v1 subset surface as `RuntimeExtensionValidationError` rather than
+ * raw compiler crashes.
+ */
+export function mergeRuntimeExtension<G extends GraphDef>(
+  graph: G,
+  document: RuntimeGraphDocument,
+): G {
+  const validated = unwrap(validateRuntimeExtension(document));
+  const compiled = compileRuntimeExtension(validated);
+
+  const nodeKinds = new Map<string, NodeType>();
+  for (const registration of Object.values(graph.nodes)) {
+    nodeKinds.set(registration.type.kind, registration.type);
+  }
+  for (const node of compiled.nodes) {
+    assertNoCollision(
+      node.type.kind,
+      "node",
+      nodeKinds.has(node.type.kind),
+      graph.id,
+    );
+    nodeKinds.set(node.type.kind, node.type);
+  }
+
+  const mergedNodes: Record<string, NodeRegistration> = { ...graph.nodes };
+  for (const node of compiled.nodes) {
+    mergedNodes[node.type.kind] = {
+      type: node.type,
+      ...(node.unique.length === 0 ? {} : { unique: [...node.unique] }),
+    };
+  }
+
+  const mergedEdges: Record<string, EdgeRegistration> = { ...graph.edges };
+  for (const edge of compiled.edges) {
+    assertNoCollision(
+      edge.type.kind,
+      "edge",
+      mergedEdges[edge.type.kind] !== undefined,
+      graph.id,
+    );
+    const from = resolveEndpoints(edge.from, nodeKinds, {
+      graphId: graph.id,
+      edgeKind: edge.type.kind,
+      side: "from",
+    });
+    const to = resolveEndpoints(edge.to, nodeKinds, {
+      graphId: graph.id,
+      edgeKind: edge.type.kind,
+      side: "to",
+    });
+    // Rebuild the EdgeType with the cross-graph-resolved endpoints —
+    // the compiler only saw the runtime document, so its
+    // `edge.type.from/to` covers in-document kinds only. Registry
+    // introspection (`registry.getEdgeType(name).to`) reads off the
+    // EdgeType, not the registration's parallel arrays, so the two
+    // must agree.
+    const resolvedType = Object.freeze({
+      ...edge.type,
+      from,
+      to,
+    }) as unknown as typeof edge.type;
+    mergedEdges[edge.type.kind] = { type: resolvedType, from, to };
+  }
+
+  const mergedOntology: readonly OntologyRelation[] = [
+    ...graph.ontology,
+    ...compiled.ontology.map((relation) =>
+      resolveOntologyEndpoints(relation, nodeKinds),
+    ),
+  ];
+
+  // The cast widens the merged graph back to `G`. Additional runtime
+  // kinds aren't visible to the type system; consumers that need them
+  // reach through the runtime registry. The lie is consolidated here so
+  // call sites don't repeat it.
+  return Object.freeze({
+    ...graph,
+    nodes: mergedNodes,
+    edges: mergedEdges,
+    ontology: mergedOntology,
+    runtimeDocument: validated,
+  });
+}
+
+function assertNoCollision(
+  kindName: string,
+  entity: "node" | "edge",
+  collides: boolean,
+  graphId: string,
+): void {
+  if (!collides) return;
+  throw new ConfigurationError(
+    `Runtime extension declares ${entity} kind "${kindName}" which already exists as a compile-time kind in graph "${graphId}". Kind-name collisions are not allowed; rename the runtime ${entity}.`,
+    { code: "RUNTIME_KIND_NAME_COLLISION" },
+  );
+}
+
+function resolveEndpoints(
+  entries: readonly (NodeType | string)[],
+  nodeKinds: ReadonlyMap<string, NodeType>,
+  context: Readonly<{ graphId: string; edgeKind: string; side: "from" | "to" }>,
+): readonly NodeType[] {
+  return entries.map((entry) => {
+    if (typeof entry !== "string") return entry;
+    const resolved = nodeKinds.get(entry);
+    if (resolved === undefined) {
+      throw new ConfigurationError(
+        `Runtime extension on graph "${context.graphId}" references undeclared node kind "${entry}" as the ${context.side} endpoint of edge "${context.edgeKind}". The kind may have been removed from the application's compile-time graph; revert the removal or evolve the runtime extension to drop the reference.`,
+        { code: "RUNTIME_EXTENSION_UNRESOLVED_ENDPOINT" },
+      );
+    }
+    return resolved;
+  });
+}
+
+function resolveOntologyEndpoints(
+  relation: OntologyRelation,
+  nodeKinds: ReadonlyMap<string, NodeType>,
+): OntologyRelation {
+  // Ontology endpoints are intentionally permissive — unresolved strings
+  // pass through as external IRIs (matching the existing runtime
+  // compiler behavior). Cross-graph kind validation only fires for edge
+  // endpoints, which require a NodeType reference.
+  const from =
+    typeof relation.from === "string" ?
+      (nodeKinds.get(relation.from) ?? relation.from)
+    : relation.from;
+  const to =
+    typeof relation.to === "string" ?
+      (nodeKinds.get(relation.to) ?? relation.to)
+    : relation.to;
+  return { ...relation, from, to };
+}

--- a/packages/typegraph/src/schema/index.ts
+++ b/packages/typegraph/src/schema/index.ts
@@ -40,8 +40,11 @@ export {
   getSchemaChanges,
   initializeSchema,
   isSchemaInitialized,
+  loadActiveSchemaWithBootstrap,
+  loadAndMergeRuntimeDocument,
   migrateSchema,
   type MigrationHookContext,
+  parseSerializedSchema,
   rollbackSchema,
   type SchemaManagerOptions,
   type SchemaValidationResult,
@@ -61,6 +64,7 @@ export {
   isBackwardsCompatible,
   type NodeChange,
   type OntologyChange,
+  type RuntimeDocumentChange,
   type SchemaDiff,
 } from "./migration";
 

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -10,6 +10,7 @@
 import { type GraphBackend, type SchemaVersionRow } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
 import { DatabaseOperationError, MigrationError } from "../errors";
+import { mergeRuntimeExtension } from "../runtime/merge";
 import {
   computeSchemaDiff,
   getMigrationActions,
@@ -26,7 +27,7 @@ import { type SerializedSchema, serializedSchemaZod } from "./types";
  * corruption, incompatible schema versions, or truncated JSON at the
  * parse boundary rather than letting invalid data propagate silently.
  */
-function parseSerializedSchema(json: string): SerializedSchema {
+export function parseSerializedSchema(json: string): SerializedSchema {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
@@ -68,6 +69,62 @@ const MISSING_TABLE_PATTERNS = [
 function isMissingTableError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return MISSING_TABLE_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+/**
+ * Reads the active schema row, bootstrapping the base tables on the
+ * first call against an empty database.
+ */
+export async function loadActiveSchemaWithBootstrap(
+  backend: GraphBackend,
+  graphId: string,
+): Promise<SchemaVersionRow | undefined> {
+  try {
+    return await backend.getActiveSchema(graphId);
+  } catch (error) {
+    if (backend.bootstrapTables && isMissingTableError(error)) {
+      await backend.bootstrapTables();
+      return await backend.getActiveSchema(graphId);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Reads the active schema, parses it, and folds any persisted runtime
+ * extension document into the supplied compile-time graph. Returns the
+ * merged graph alongside the prefetched row + parsed schema so the
+ * caller can pass them through to `ensureSchema` without paying for a
+ * second `getActiveSchema` round trip or a second
+ * `serializedSchemaZod` walk.
+ *
+ * Throws `ConfigurationError` if the persisted runtime document
+ * references a compile-time kind that no longer exists (the
+ * startup-conflict case).
+ */
+export async function loadAndMergeRuntimeDocument<G extends GraphDef>(
+  backend: GraphBackend,
+  graph: G,
+): Promise<
+  Readonly<{
+    graph: G;
+    activeRow: SchemaVersionRow | undefined;
+    storedSchema: SerializedSchema | undefined;
+  }>
+> {
+  const activeRow = await loadActiveSchemaWithBootstrap(backend, graph.id);
+  if (activeRow === undefined) {
+    return { graph, activeRow: undefined, storedSchema: undefined };
+  }
+  const storedSchema = parseSerializedSchema(activeRow.schema_doc);
+  if (storedSchema.runtimeDocument === undefined) {
+    return { graph, activeRow, storedSchema };
+  }
+  return {
+    graph: mergeRuntimeExtension(graph, storedSchema.runtimeDocument),
+    activeRow,
+    storedSchema,
+  };
 }
 
 // ============================================================
@@ -139,25 +196,37 @@ export type SchemaManagerOptions = Readonly<{
 export async function ensureSchema<G extends GraphDef>(
   backend: GraphBackend,
   graph: G,
-  options?: SchemaManagerOptions,
+  options?: SchemaManagerOptions & {
+    /**
+     * Pre-fetched active row + parsed stored schema. When the loader
+     * (`createStoreWithSchema`) has already paid for `getActiveSchema`
+     * and `parseSerializedSchema` to peek at `runtimeDocument`, it
+     * passes the results through here so `ensureSchema` doesn't repeat
+     * the round trip + Zod walk on every Store boot.
+     */
+    preloaded?: Readonly<{
+      activeRow: SchemaVersionRow | undefined;
+      storedSchema: SerializedSchema | undefined;
+    }>;
+  },
 ): Promise<SchemaValidationResult> {
   const autoMigrate = options?.autoMigrate ?? true;
   const throwOnBreaking = options?.throwOnBreaking ?? true;
 
-  // Get the active schema from the database.
-  // On a fresh database the base tables may not exist yet. If
-  // bootstrapTables is available, create them and retry.
-  let activeSchema: SchemaVersionRow | undefined;
-  try {
-    activeSchema = await backend.getActiveSchema(graph.id);
-  } catch (error) {
-    if (backend.bootstrapTables && isMissingTableError(error)) {
-      await backend.bootstrapTables();
-      activeSchema = await backend.getActiveSchema(graph.id);
-    } else {
-      throw error;
-    }
-  }
+  // When `preloaded` is supplied we trust both fields verbatim, even
+  // when `activeRow` is undefined — that means the loader explicitly
+  // checked and saw no schema yet. Falling back to `??` would refetch
+  // and could observe a row that another process committed in the
+  // race window between the loader's read and this point; ensureSchema
+  // would then diff a runtime-extended persisted schema against the
+  // unmerged graph and throw a misleading MigrationError. With the
+  // sentinel check the race surfaces as a clean `StaleVersionError`
+  // from `commitSchemaVersion` inside `initializeSchema` instead.
+  const preloaded = options?.preloaded;
+  const activeSchema =
+    preloaded === undefined ?
+      await loadActiveSchemaWithBootstrap(backend, graph.id)
+    : preloaded.activeRow;
 
   if (!activeSchema) {
     // No schema exists - initialize with version 1
@@ -165,8 +234,9 @@ export async function ensureSchema<G extends GraphDef>(
     return { status: "initialized", version: result.version };
   }
 
-  // Parse the stored schema
-  const storedSchema = parseSerializedSchema(activeSchema.schema_doc);
+  // Reuse the loader's parsed schema when supplied; otherwise parse now.
+  const storedSchema =
+    preloaded?.storedSchema ?? parseSerializedSchema(activeSchema.schema_doc);
 
   // Serialize the current graph for comparison
   const currentSchema = serializeSchema(graph, activeSchema.version + 1);

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -103,6 +103,25 @@ export type IndexChange = Readonly<{
 }>;
 
 // ============================================================
+// Runtime Document Changes
+// ============================================================
+
+/**
+ * A change to the persisted runtime extension document.
+ *
+ * v1 runtime extensions are additive only (kind-name collisions are
+ * rejected at evolve time; removal of runtime kinds is out of scope), so
+ * a `runtimeDocument` change is always `safe`-severity. The detailed
+ * per-kind effect is captured in the corresponding node/edge/ontology
+ * changes the merged document produced.
+ */
+export type RuntimeDocumentChange = Readonly<{
+  type: ChangeType;
+  severity: ChangeSeverity;
+  details: string;
+}>;
+
+// ============================================================
 // Schema Diff
 // ============================================================
 
@@ -124,6 +143,12 @@ export type SchemaDiff = Readonly<{
 
   /** Changes to index declarations */
   indexes: readonly IndexChange[];
+
+  /**
+   * Change to the runtime extension document, if any. `undefined` when
+   * the slice is unchanged on both sides (the common case).
+   */
+  runtimeDocument?: RuntimeDocumentChange;
 
   /** Whether any breaking changes exist */
   hasBreakingChanges: boolean;
@@ -157,6 +182,10 @@ export function computeSchemaDiff(
   const edgeChanges = diffEdges(before.edges, after.edges);
   const ontologyChanges = diffOntology(before.ontology, after.ontology);
   const indexChanges = diffIndexes(before.indexes, after.indexes);
+  const runtimeDocumentChange = diffRuntimeDocument(
+    before.runtimeDocument,
+    after.runtimeDocument,
+  );
 
   const allChanges = [
     ...nodeChanges,
@@ -167,7 +196,8 @@ export function computeSchemaDiff(
   const hasBreakingChanges = allChanges.some(
     (change) => change.severity === "breaking",
   );
-  const hasChanges = allChanges.length > 0;
+  const hasChanges =
+    allChanges.length > 0 || runtimeDocumentChange !== undefined;
 
   const summary = generateSummary(
     nodeChanges,
@@ -183,6 +213,9 @@ export function computeSchemaDiff(
     edges: edgeChanges,
     ontology: ontologyChanges,
     indexes: indexChanges,
+    ...(runtimeDocumentChange === undefined ?
+      {}
+    : { runtimeDocument: runtimeDocumentChange }),
     hasBreakingChanges,
     isBackwardsCompatible: !hasBreakingChanges,
     hasChanges,
@@ -651,6 +684,48 @@ function diffIndexes(
   }
 
   return changes;
+}
+
+// ============================================================
+// Runtime Document Diff
+// ============================================================
+
+/**
+ * Computes the change to the runtime extension document, if any. v1
+ * runtime extensions are additive only (collisions rejected at evolve
+ * time, removal out of scope), so the change severity is always `safe` —
+ * the per-kind effects of the merged document already surface as
+ * node/edge/ontology changes.
+ */
+function diffRuntimeDocument(
+  before: SerializedSchema["runtimeDocument"],
+  after: SerializedSchema["runtimeDocument"],
+): RuntimeDocumentChange | undefined {
+  // Reference-equality short-circuit: when the loader threads the same
+  // persisted document reference into the merged graph (the common
+  // restart-with-no-evolve case), we avoid stringifying potentially
+  // large agent-generated documents on every ensureSchema call.
+  if (before === after) return undefined;
+  if (before === undefined) {
+    return {
+      type: "added",
+      severity: "safe",
+      details: "Runtime extension document was added",
+    };
+  }
+  if (after === undefined) {
+    return {
+      type: "removed",
+      severity: "safe",
+      details: "Runtime extension document was removed",
+    };
+  }
+  if (canonicalEqual(before, after)) return undefined;
+  return {
+    type: "modified",
+    severity: "safe",
+    details: "Runtime extension document was modified",
+  };
 }
 
 // ============================================================

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -61,6 +61,7 @@ export function serializeSchema<G extends GraphDef>(
   const edges = serializeEdges(graph);
   const ontology = serializeOntology(graph.ontology);
   const indexes = serializeIndexes(graph.indexes);
+  const runtimeDocument = graph.runtimeDocument;
 
   return {
     graphId: graph.id,
@@ -78,6 +79,11 @@ export function serializeSchema<G extends GraphDef>(
     // in that case so legacy graphs hash byte-identically to the
     // pre-`indexes` form.
     ...(indexes === undefined ? {} : { indexes }),
+    // The runtime extension document is the durable source the loader
+    // uses to rebuild runtime Zod validators on restart. Omitted on
+    // graphs that have never been runtime-extended so legacy schemas
+    // hash byte-identically.
+    ...(runtimeDocument === undefined ? {} : { runtimeDocument }),
   };
 }
 

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -21,6 +21,7 @@ import {
 import { type IndexDeclaration } from "../indexes/types";
 import { type InferenceType } from "../ontology/types";
 import { type JsonPointer } from "../query/json-pointer";
+import { type RuntimeGraphDocument } from "../runtime/document-types";
 
 // ============================================================
 // Enum Zod Schemas
@@ -215,6 +216,56 @@ const indexDeclarationZod = z.discriminatedUnion("entity", [
   nodeIndexDeclarationZod,
   edgeIndexDeclarationZod,
 ]);
+
+// ============================================================
+// RuntimeGraphDocument Zod schema
+// ============================================================
+
+// Boundary parser for the persisted runtime extension document. The
+// pure-value validator in `runtime/validation.ts` is the authoritative
+// shape check (re-run on every load via the runtime compiler); this
+// schema's job is only to confirm the JSON shape is round-trippable
+// and to keep `SerializedSchema.runtimeDocument` typed.
+//
+// `.loose()` on every nested object accepts forward-compatible
+// extensions without breaking older readers — same posture as the rest
+// of the schema document.
+const runtimePropertyZod = z.record(z.string(), z.unknown());
+
+const runtimeNodeDocumentZod = z
+  .object({
+    description: z.string().optional(),
+    annotations: z.record(z.string(), z.json()).optional(),
+    properties: z.record(z.string(), runtimePropertyZod),
+    unique: z.array(z.object({}).loose()).optional(),
+  })
+  .loose();
+
+const runtimeEdgeDocumentZod = z
+  .object({
+    description: z.string().optional(),
+    annotations: z.record(z.string(), z.json()).optional(),
+    from: z.array(z.string()),
+    to: z.array(z.string()),
+    properties: z.record(z.string(), runtimePropertyZod).optional(),
+  })
+  .loose();
+
+const runtimeOntologyRelationZod = z
+  .object({
+    metaEdge: z.string(),
+    from: z.string(),
+    to: z.string(),
+  })
+  .loose();
+
+const runtimeGraphDocumentZod = z
+  .object({
+    nodes: z.record(z.string(), runtimeNodeDocumentZod).optional(),
+    edges: z.record(z.string(), runtimeEdgeDocumentZod).optional(),
+    ontology: z.array(runtimeOntologyRelationZod).optional(),
+  })
+  .loose() as unknown as z.ZodType<RuntimeGraphDocument>;
 
 // ============================================================
 // JSON Schema Types (from Zod)
@@ -508,6 +559,17 @@ export const serializedSchemaZod = z.object({
    * authored before `indexes` existed.
    */
   indexes: z.array(indexDeclarationZod).optional(),
+  /**
+   * Runtime extension document persisted alongside the compiled
+   * `nodes` / `edges` / `ontology` slices. The loader rebuilds runtime
+   * Zod validators from this document (the only durable source);
+   * legacy graphs omit the field and hash byte-identically to before
+   * runtime extensions existed.
+   *
+   * `.loose()` on the inner shape accepts forward-compatible extensions
+   * without breaking older readers.
+   */
+  runtimeDocument: runtimeGraphDocumentZod.optional(),
 });
 
 /**
@@ -540,6 +602,19 @@ export type SerializedSchema = Readonly<{
    * only `"runtime"` is emitted explicitly.
    */
   indexes?: readonly IndexDeclaration[];
+  /**
+   * Runtime extension document, when this schema was produced from a
+   * graph that had been merged with a runtime extension. The loader
+   * uses this document (and only this document) to rebuild runtime
+   * Zod validators on restart — the merged `nodes` / `edges` /
+   * `ontology` maps above carry the JSON-Schema-shaped views for diff
+   * machinery and human-readable reporting, but they cannot
+   * reconstruct Zod alone.
+   *
+   * Omitted entirely on graphs that have never been runtime-extended
+   * — legacy schemas hash byte-identically.
+   */
+  runtimeDocument?: RuntimeGraphDocument;
 }>;
 
 // ============================================================

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -923,6 +923,7 @@ export type {
 
 import {
   ensureSchema as ensureSchemaImpl,
+  loadAndMergeRuntimeDocument,
   type SchemaManagerOptions,
   type SchemaValidationResult,
 } from "../schema/manager";
@@ -960,7 +961,22 @@ export async function createStoreWithSchema<G extends GraphDef>(
   backend: GraphBackend,
   options?: StoreOptions & SchemaManagerOptions,
 ): Promise<[Store<G>, SchemaValidationResult]> {
-  const store = createStore(graph, backend, options);
-  const result = await ensureSchemaImpl(backend, graph, options);
+  // Fold any persisted runtime extension document into the graph
+  // BEFORE constructing the Store. The prefetched row + parsed schema
+  // thread through to ensureSchema so each Store boot pays for one DB
+  // round trip and one Zod parse, not two. Additional runtime kinds
+  // are reachable through the registry but invisible to the type
+  // system — see `mergeRuntimeExtension`.
+  const {
+    graph: merged,
+    activeRow,
+    storedSchema,
+  } = await loadAndMergeRuntimeDocument(backend, graph);
+
+  const store = createStore(merged, backend, options);
+  const result = await ensureSchemaImpl(backend, merged, {
+    ...options,
+    preloaded: { activeRow, storedSchema },
+  });
   return [store, result];
 }

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -27,6 +27,8 @@ import {
   relatedTo,
   subClassOf,
 } from "../../src/ontology/core-meta-edges";
+import { defineRuntimeExtension } from "../../src/runtime";
+import { mergeRuntimeExtension } from "../../src/runtime/merge";
 import { sortedReplacer } from "../../src/schema/canonical";
 import { deserializeSchema } from "../../src/schema/deserializer";
 import {
@@ -790,6 +792,54 @@ describe("Schema Serialization Properties", () => {
       const hashBA = await computeSchemaHash(serializeSchema(graphBA, 1));
 
       expect(hashAB).toBe(hashBA);
+    });
+
+    // The persisted runtime extension document is the durable source the
+    // loader uses to rebuild runtime Zod validators. Graphs that have
+    // never been runtime-extended must omit the slice entirely so legacy
+    // schemas hash byte-identically.
+    it("graphs without runtimeDocument omit the field from canonical serialization", () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ name: z.string() }),
+      });
+
+      const graph = defineGraph({
+        id: "runtime_doc_omit_compat",
+        nodes: { Person: { type: Person } },
+        edges: {},
+      });
+
+      const serialized = serializeSchema(graph, 1);
+      expect("runtimeDocument" in serialized).toBe(false);
+
+      const canonical = JSON.stringify(serialized, sortedReplacer);
+      expect(canonical).not.toContain('"runtimeDocument"');
+    });
+
+    it("hash differs when a runtimeDocument is present", async () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ name: z.string() }),
+      });
+
+      const baseGraph = defineGraph({
+        id: "runtime_doc_hash",
+        nodes: { Person: { type: Person } },
+        edges: {},
+      });
+
+      const baseHash = await computeSchemaHash(serializeSchema(baseGraph, 1));
+
+      const extension = defineRuntimeExtension({
+        nodes: {
+          Tag: { properties: { name: { type: "string" } } },
+        },
+      });
+      const extendedGraph = mergeRuntimeExtension(baseGraph, extension);
+      const extendedHash = await computeSchemaHash(
+        serializeSchema(extendedGraph, 1),
+      );
+
+      expect(extendedHash).not.toBe(baseHash);
     });
 
     it("graphs without indexes omit the field from canonical serialization", () => {

--- a/packages/typegraph/tests/runtime-document-persistence.test.ts
+++ b/packages/typegraph/tests/runtime-document-persistence.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Restart parity, cross-process visibility, and startup-conflict tests
+ * for the persisted runtime extension document.
+ *
+ * Simulates "an earlier process persisted a runtime extension" by
+ * composing `mergeRuntimeExtension(...)` + `serializeSchema(...)` +
+ * `backend.commitSchemaVersion(...)` directly, then verifies that a
+ * fresh `createStoreWithSchema(graph, backend)` reconstructs an
+ * identical `Store` — same kinds, same query behavior.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph } from "../src/core/define-graph";
+import { defineNode } from "../src/core/node";
+import { ConfigurationError } from "../src/errors";
+import { defineRuntimeExtension } from "../src/runtime";
+import { mergeRuntimeExtension } from "../src/runtime/merge";
+import { ensureSchema } from "../src/schema/manager";
+import { computeSchemaHash, serializeSchema } from "../src/schema/serializer";
+import { createStoreWithSchema } from "../src/store/store";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const baseGraph = defineGraph({
+  id: "runtime_doc_persistence",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+async function persistEvolvedSchema(
+  backend: ReturnType<typeof createTestBackend>,
+  document: Parameters<typeof mergeRuntimeExtension>[1],
+): Promise<void> {
+  // Bring the backend to a baseline at version 1 with the unmerged
+  // graph, then commit a v2 carrying the merged runtime document.
+  const [, initial] = await createStoreWithSchema(baseGraph, backend);
+  expect(initial.status).toBe("initialized");
+
+  const merged = mergeRuntimeExtension(baseGraph, document);
+  const evolvedSchema = serializeSchema(merged, 2);
+  const evolvedHash = await computeSchemaHash(evolvedSchema);
+  await backend.commitSchemaVersion({
+    graphId: baseGraph.id,
+    expected: { kind: "active", version: 1 },
+    version: 2,
+    schemaHash: evolvedHash,
+    schemaDoc: evolvedSchema,
+  });
+}
+
+describe("runtime document persistence — loader rewire", () => {
+  it("restart parity: a fresh Store sees runtime kinds persisted by an earlier process", async () => {
+    const backend = createTestBackend();
+    const tagExtension = defineRuntimeExtension({
+      nodes: {
+        Tag: { properties: { name: { type: "string" } } },
+      },
+    });
+    await persistEvolvedSchema(backend, tagExtension);
+
+    // "Process B" boots against the same backend with the original
+    // compile-time graph; the loader must read the persisted
+    // runtimeDocument and merge it before constructing the Store.
+    const [restoredStore, restoredResult] = await createStoreWithSchema(
+      baseGraph,
+      backend,
+    );
+    expect(restoredResult.status).toBe("unchanged");
+
+    const registry = restoredStore.registry;
+    expect(registry.hasNodeType("Person")).toBe(true);
+    expect(registry.hasNodeType("Tag")).toBe(true);
+    const tagType = registry.getNodeType("Tag");
+    expect(tagType?.schema.shape.name).toBeDefined();
+  });
+
+  it("re-serializing the merged graph reproduces the same canonical hash", async () => {
+    const backend = createTestBackend();
+    const extension = defineRuntimeExtension({
+      nodes: {
+        Tag: { properties: { name: { type: "string" } } },
+      },
+    });
+    await persistEvolvedSchema(backend, extension);
+
+    const persistedRow = await backend.getActiveSchema(baseGraph.id);
+    expect(persistedRow).toBeDefined();
+
+    // The merged graph the loader reconstructs must serialize to the
+    // same hash that was persisted — this is what makes ensureSchema's
+    // hash-equality check return "unchanged" rather than triggering a
+    // spurious migration on every boot.
+    const merged = mergeRuntimeExtension(baseGraph, extension);
+    const reSerialized = serializeSchema(merged, persistedRow!.version);
+    const reHash = await computeSchemaHash(reSerialized);
+    expect(reHash).toBe(persistedRow!.schema_hash);
+  });
+
+  it("runtime edges referencing host kinds expose resolved endpoints through the registry", async () => {
+    const backend = createTestBackend();
+    const extension = defineRuntimeExtension({
+      nodes: {
+        Tag: { properties: { name: { type: "string" } } },
+      },
+      edges: {
+        appliesTo: {
+          from: ["Tag"],
+          to: ["Person"],
+          properties: {},
+        },
+      },
+    });
+    await persistEvolvedSchema(backend, extension);
+
+    const [restored] = await createStoreWithSchema(baseGraph, backend);
+    const edgeType = restored.registry.getEdgeType("appliesTo");
+    expect(edgeType).toBeDefined();
+    expect(edgeType?.from?.map((node) => node.kind)).toEqual(["Tag"]);
+    expect(edgeType?.to?.map((node) => node.kind)).toEqual(["Person"]);
+  });
+
+  it("startup conflict: missing compile-time kind referenced by an edge endpoint fails store construction", async () => {
+    const backend = createTestBackend();
+
+    // Persist an extension whose runtime edge points at a host kind
+    // that DOES exist at extension time — succeeds.
+    const extension = defineRuntimeExtension({
+      nodes: {
+        Tag: { properties: { name: { type: "string" } } },
+      },
+      edges: {
+        appliesTo: {
+          from: ["Tag"],
+          to: ["Person"],
+          properties: {},
+        },
+      },
+    });
+    await persistEvolvedSchema(backend, extension);
+
+    // Now "Process C" boots with a graph that no longer declares Person
+    // — the runtime extension's edge endpoint is unresolvable. Store
+    // construction must fail with a clear error rather than silently
+    // dropping the reference.
+    const Other = defineNode("Other", {
+      schema: z.object({ value: z.number() }),
+    });
+    const conflictingGraph = defineGraph({
+      id: baseGraph.id,
+      nodes: { Other: { type: Other } },
+      edges: {},
+    });
+
+    await expect(
+      createStoreWithSchema(conflictingGraph, backend),
+    ).rejects.toBeInstanceOf(ConfigurationError);
+  });
+
+  it("ensureSchema's preloaded option is respected even when activeRow is undefined", async () => {
+    // Regression: an explicit `preloaded: { activeRow: undefined }`
+    // means "the loader checked and saw no schema yet". The legacy
+    // `??` coalesce treated that as "preloaded not supplied" and
+    // refetched, opening a race window where a concurrent commit could
+    // surface to ensureSchema as a misleading MigrationError. With the
+    // sentinel check, ensureSchema now follows the initialize path and
+    // any race surfaces as a clean StaleVersionError from
+    // commitSchemaVersion.
+    const backend = createTestBackend();
+    // Pre-seed the backend with a *different* v1 schema (simulates the
+    // racing committer that landed something between the loader's
+    // read and ensureSchema's would-be refetch).
+    const Other = defineNode("Other", {
+      schema: z.object({ value: z.number() }),
+    });
+    const racingGraph = defineGraph({
+      id: baseGraph.id,
+      nodes: { Other: { type: Other } },
+      edges: {},
+    });
+    const seed = serializeSchema(racingGraph, 1);
+    const seedHash = await computeSchemaHash(seed);
+    await backend.commitSchemaVersion({
+      graphId: baseGraph.id,
+      expected: { kind: "initial" },
+      version: 1,
+      schemaHash: seedHash,
+      schemaDoc: seed,
+    });
+
+    // Call ensureSchema with the loader's empty snapshot. With the
+    // sentinel honored, the function heads straight into
+    // initializeSchema, which conflicts at the commit boundary with
+    // the racing v1 — a precise concurrent-commit signal rather than
+    // a phantom MigrationError. Without the sentinel, the `??` would
+    // refetch, parse the racing schema, and diff it against the
+    // baseGraph (which lacks `Other`), classifying the missing kind
+    // as a breaking removal and throwing MigrationError instead.
+    await expect(
+      ensureSchema(backend, baseGraph, {
+        preloaded: { activeRow: undefined, storedSchema: undefined },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("legacy graphs (no runtimeDocument persisted) load without invoking the merge path", async () => {
+    const backend = createTestBackend();
+    const [, initial] = await createStoreWithSchema(baseGraph, backend);
+    expect(initial.status).toBe("initialized");
+
+    // Re-boot — no runtime extension was ever persisted, so the loader's
+    // fast path should return the original graph reference unchanged.
+    const [restored, restoredResult] = await createStoreWithSchema(
+      baseGraph,
+      backend,
+    );
+    expect(restoredResult.status).toBe("unchanged");
+    expect(restored.registry.hasNodeType("Person")).toBe(true);
+  });
+});


### PR DESCRIPTION
PR 4 of the runtime-extension feature (issue #101). Adds the durable storage half: a `runtimeDocument` slice on `SerializedSchema`, a `mergeRuntimeExtension` helper that compiles a document into a host `GraphDef`, and a rewire of `createStoreWithSchema` so the `Store` is built against a graph that already has any persisted runtime extension merged in. `store.evolve()` and `StoreRef` ship in PR 5; this PR exercises the persistence path by composing `mergeRuntimeExtension` + `commitSchemaVersion` directly in tests.

```typescript
// (PR 5 will encapsulate this as `store.evolve(extension)`.)
const merged = mergeRuntimeExtension(graph, runtimeExtension);
const evolvedSchema = serializeSchema(merged, activeVersion + 1);
await backend.commitSchemaVersion({
  graphId: graph.id,
  expected: { kind: "active", version: activeVersion },
  version: activeVersion + 1,
  schemaHash: await computeSchemaHash(evolvedSchema),
  schemaDoc: evolvedSchema,
});

// Different process boots against the same backend with the original
// compile-time graph:
const [store] = await createStoreWithSchema(graph, backend);
// store.registry.hasNodeType("RuntimeKindFromExtensionA") === true
```

## Why the document is the durable artifact

The existing \`Zod → JSON Schema\` path is one-way (\`schema/deserializer.ts:5\` documents the constraint). The merged \`nodes\`/\`edges\`/\`ontology\` maps in \`SerializedSchema\` carry useful JSON-Schema-shaped views for diff machinery and human-readable schema reporting, but they cannot reconstruct \`searchable()\` markers, the \`embedding()\` brand, \`.optional()\` shape, or unique-constraint extraction. Owning both ends of the document → Zod path keeps the round-trip lossless. The loader uses \`runtimeDocument\` (and only \`runtimeDocument\`) to rebuild runtime validators on every restart.

## Public API additions

- \`GraphDef.runtimeDocument: RuntimeGraphDocument | undefined\` — set by the loader (and by \`store.evolve()\` in PR 5), never by \`defineGraph\` directly. Re-serializing a merged graph reproduces the same canonical document including this slice.
- \`SerializedSchema.runtimeDocument?: RuntimeGraphDocument\` — the persisted slice. Omitted on graphs that have never been runtime-extended; legacy schemas hash byte-identically.
- \`mergeRuntimeExtension(graph, document)\` — pure function: compiles the document, validates that every edge endpoint resolves either to a runtime kind in the same document or to a compile-time kind in the host graph, throws \`ConfigurationError\` on collisions or unresolvable references, and returns a frozen \`GraphDef\` with the merge applied.
- \`loadActiveSchemaWithBootstrap(backend, graphId)\` and \`parseSerializedSchema(json)\` — factored out of \`ensureSchema\` so the loader's pre-\`ensureSchema\` peek at \`runtimeDocument\` doesn't duplicate the bootstrap-and-retry pattern.
- \`RuntimeDocumentChange\` and \`SchemaDiff.runtimeDocument\` — the diff classifies runtime-document changes as \`safe\`-severity (v1 runtime extensions are additive only; per-kind effects already surface in the node/edge/ontology change arrays).

## Loader rewire

\`createStoreWithSchema\` now reads the active schema row before constructing the \`Store\`. If the row's \`runtimeDocument\` is present, the loader compiles + merges it into the application's compile-time \`GraphDef\` and constructs the \`Store\` against the merged graph; \`ensureSchema\` then runs against the merged form. Backward-compatible: graphs without a persisted \`runtimeDocument\` short-circuit to today's behavior with one extra \`getActiveSchema\` round trip at startup.

## Startup-conflict behavior

If application code has been updated such that a compile-time kind referenced by \`runtimeDocument\` (via an edge endpoint) no longer exists, \`mergeRuntimeExtension\` throws \`ConfigurationError\` with \`code: "RUNTIME_EXTENSION_UNRESOLVED_ENDPOINT"\`. Operators handle this by reverting the application change or evolving the runtime extension to drop the reference. Ontology endpoints remain permissive (unresolved strings pass through as external IRIs, matching the existing runtime-compiler behavior).

## Load-bearing invariants

Verified by tests in \`tests/property/schema-serialization.test.ts\` and \`tests/runtime-document-persistence.test.ts\`:

- Graphs that have never been runtime-extended produce identical canonical-form hashes to today.
- A graph merged with a runtime extension serializes to a hash that round-trips: re-merging the same extension on top of the same compile-time graph in a different process yields the same hash, so \`ensureSchema\` returns \`unchanged\` on restart instead of triggering a spurious migration.
- The diff distinguishes "runtime document added" / "modified" / "removed" as a single \`RuntimeDocumentChange\` alongside the per-kind node/edge/ontology changes the merge produces.
- Startup conflict (missing compile-time kind referenced by an extension edge) fails fast with a clear error.

## Out of scope

No \`store.evolve()\`, no \`StoreRef\`, no \`materializeIndexes()\`. Those are PRs 5 and 6.


Closes part of #101.