### PR TITLE
feat: store.evolve + StoreRef type for runtime graph extension (#101 PR 5/6)

### DIFF
--- a/.changeset/store-evolve.md
+++ b/.changeset/store-evolve.md
@@ -1,0 +1,83 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `Store.evolve(extension, options?)` and the `StoreRef<T>` type — the public ergonomic for runtime-extending a graph at runtime. This is the headline of the runtime-extension feature (issue #101 PR 5/6); index materialization (`store.materializeIndexes`) lands in PR 6, and the deprecation marker (`store.deprecateKinds`) lands separately.
+
+## The two consumer patterns
+
+**Single-caller / let-rebind.** The common case — a script, test, or service with one entry point. `evolve()` returns the new store; reassign:
+
+```typescript
+import { createStoreWithSchema, defineRuntimeExtension } from "@nicia-ai/typegraph";
+
+let [store] = await createStoreWithSchema(graph, backend);
+
+const extension = defineRuntimeExtension({
+  nodes: { Paper: { properties: { doi: { type: "string" } } } },
+});
+
+store = await store.evolve(extension);
+// `store` now carries Paper alongside the original compile-time kinds.
+```
+
+**Many-caller / consumer-composed ref.** When request handlers, background workers, or an agent loop share the store reference and you can't reassign at every call site. Compose a `StoreRef`, share `ref` (not `ref.current`), pass it to `evolve` to be re-pointed atomically with the schema commit:
+
+```typescript
+import {
+  createStoreWithSchema,
+  defineRuntimeExtension,
+  type StoreRef,
+} from "@nicia-ai/typegraph";
+
+const [store] = await createStoreWithSchema(graph, backend);
+const ref: StoreRef<typeof store> = { current: store };
+
+// Long-lived consumers hold `ref` and dereference at use time:
+async function handleRequest(): Promise<void> {
+  await ref.current.nodes.Paper?.create({ doi: "..." });
+}
+
+// Evolve re-points the ref atomically:
+await ref.current.evolve(extension, { ref });
+// All consumers dereferencing through `ref` now see Paper.
+```
+
+`StoreRef<T>` is `{ current: T }` — a plain mutable handle. No event/subscription machinery; consumers wrap if they need eventing. There's no dedicated `createStoreRef` factory: composing the ref is one line and keeps the library API surface minimal.
+
+## `Store.evolve(extension, options?)`
+
+Validates the document, atomically commits a new schema version through the `commitSchemaVersion` primitive (CAS on the active version), constructs a fresh `Store<G>` against the merged graph, and returns it. Cost is proportional to schema document size, not row count — `evolve()` never reads or scans data rows.
+
+**Additive-only semantics.** v1 extensions are additive over the canonical document:
+
+- New kinds, new edges referencing existing kinds (compile-time or runtime), and new ontology relations: **allowed**.
+- Re-declaring an existing runtime kind with the **same shape**: **no-op** (idempotent re-evolve).
+- Re-declaring an existing runtime kind with a **different shape**: **rejected** with `ConfigurationError` (`code: "RUNTIME_KIND_REDEFINITION"`). Use a new kind name to evolve a kind in v1.
+- Collisions with **compile-time** kinds: rejected with `RUNTIME_KIND_NAME_COLLISION`.
+
+**Concurrent evolve.** Two simultaneous calls produce one winner — the loser surfaces `StaleVersionError` or `SchemaContentConflictError` from the commit primitive, depending on whether the race resolved at the active-pointer or content-hash check. Recovery: refetch the active schema, reconstruct your `Store` (or dereference your `StoreRef`), and re-call `evolve(extension)`. Re-validation may now surface deterministic errors (e.g., a kind another caller just added that collides with yours) — don't loop blindly.
+
+The agent-loop hot path of repeated same-extension `evolve()` short-circuits in `mergeRuntimeExtension` via a structural-equal union check, so no-op evolves skip compile + filter + merge entirely and `Store.evolve` returns `this` to keep warm caches.
+
+## v1 string property formats
+
+The supported `format` values widened: `"datetime" | "uri" | "email" | "uuid" | "date"`. Each routes to the corresponding Zod factory (`z.iso.datetime()`, `z.url()`, `z.email()`, `z.uuid()`, `z.iso.date()`). Other JSON-Schema formats remain rejected at validation time with a usable error.
+
+## Acceptance gates
+
+- **Round-trip parity:** for every public Store API path covered (create, getById, find, count, update, delete, edge endpoint resolution), a kind added via `evolve()` produces identical results to the same kind declared at compile time. Runtime kinds are reached through `store.getNodeCollection(kind)` since the type system doesn't see them.
+- **Cross-kind traversal:** runtime edges between runtime and compile-time kinds are queryable end-to-end via `findFrom` / `findTo` — exercises the actual data path through the merged graph.
+- **Concurrent evolve:** two simultaneous `evolve()` calls produce exactly one winner; the loser is rejected with `StaleVersionError | SchemaContentConflictError`.
+- **Additive-merge enforcement:** redefining an existing runtime kind with a different shape is rejected with `RUNTIME_KIND_REDEFINITION`; same-shape re-evolves are idempotent.
+
+## Out of scope
+
+Per the issue's v1 pinning:
+
+- `unique`-on-populated-kind rejection — in v1 runtime extensions only ADD new kinds (collisions rejected outright), so every runtime kind is brand new with no rows. The rule becomes meaningful when `mode: "merge"` lands.
+- Modifying an existing runtime kind — covered by the additive-only rule above; use a new kind name.
+- `materializeIndexes()` — PR 6.
+- `deprecateKinds()` — separate PR.
+- Cross-store auto-refresh — `StoreRef` is the re-binding affordance; auto-refresh is a separate observability concern.
+- Numeric / boolean enums — v1 enum is `readonly string[]` only.

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -295,6 +295,7 @@ export type {
   StoreHooks,
   StoreOptions,
   StoreProjection,
+  StoreRef,
   TransactionContext,
   TypedEdgeCollection,
   UpdateEdgeInput,

--- a/packages/typegraph/src/runtime/compiler.ts
+++ b/packages/typegraph/src/runtime/compiler.ts
@@ -232,18 +232,31 @@ function compileProperty(property: RuntimePropertyType): ZodType {
 
 function compileStringProperty(property: RuntimeStringProperty): ZodType {
   // `searchable` and `format` are mutually exclusive (rejected by
-  // validation): the format-routed schemas (`z.iso.datetime` / `z.url`)
-  // are not z.ZodString subclasses we can chain `searchable()` through.
+  // validation): the format-routed schemas aren't `z.ZodString`
+  // subclasses we can chain `searchable()` through.
   if (property.searchable !== undefined) {
     return applyStringRefinements(searchable(property.searchable), property);
   }
-  if (property.format === "datetime") {
-    return z.iso.datetime();
+  if (property.format === undefined) {
+    return applyStringRefinements(z.string(), property);
   }
-  if (property.format === "uri") {
-    return z.url();
+  switch (property.format) {
+    case "datetime": {
+      return z.iso.datetime();
+    }
+    case "date": {
+      return z.iso.date();
+    }
+    case "uri": {
+      return z.url();
+    }
+    case "email": {
+      return z.email();
+    }
+    case "uuid": {
+      return z.uuid();
+    }
   }
-  return applyStringRefinements(z.string(), property);
 }
 
 function applyStringRefinements(

--- a/packages/typegraph/src/runtime/document-types.ts
+++ b/packages/typegraph/src/runtime/document-types.ts
@@ -57,16 +57,18 @@ type RuntimePropertyModifiers = Readonly<{
 /**
  * String property. Compiles to `z.string()` plus the requested refinements.
  * `format` accepts the two formats motivated by induced schemas in
- * practice — datetime strings (`z.iso.datetime()`) and URI strings
- * (`z.url()`). Other JSON-Schema formats are deliberately not supported
- * in v1.
+ * practice — covers ISO datetimes, URIs, email addresses, UUIDs, and
+ * date-only strings. Each format routes to the corresponding Zod
+ * factory (`z.iso.datetime()`, `z.url()`, `z.email()`, `z.uuid()`,
+ * `z.iso.date()`); other JSON-Schema formats are deliberately not
+ * supported in v1.
  */
 export type RuntimeStringProperty = Readonly<{
   type: "string";
   minLength?: number;
   maxLength?: number;
   pattern?: string;
-  format?: "datetime" | "uri";
+  format?: "datetime" | "uri" | "email" | "uuid" | "date";
 }> &
   RuntimePropertyModifiers;
 

--- a/packages/typegraph/src/runtime/merge.ts
+++ b/packages/typegraph/src/runtime/merge.ts
@@ -5,19 +5,39 @@ import {
   type NodeType,
 } from "../core/types";
 import { ConfigurationError } from "../errors";
-import { type OntologyRelation } from "../ontology/types";
+import { getTypeName, type OntologyRelation } from "../ontology/types";
+import { canonicalEqual } from "../schema/canonical";
 import { unwrap } from "../utils/result";
 import { compileRuntimeExtension } from "./compiler";
-import { type RuntimeGraphDocument } from "./document-types";
+import {
+  type RuntimeGraphDocument,
+  type RuntimeOntologyRelation,
+} from "./document-types";
 import { validateRuntimeExtension } from "./validation";
 
 /**
  * Compiles a runtime extension document and merges the result into a
- * host compile-time `GraphDef`. Throws `ConfigurationError` on
- * kind-name collisions or on edge endpoints that don't resolve against
- * either the runtime extension or the host graph (the startup-conflict
- * case for stale persisted documents). The returned graph carries
- * `runtimeDocument` so re-serialization is stable across restarts.
+ * host `GraphDef`. The merge is **additive over the canonical document**:
+ *
+ * - New kinds, new edges referencing existing kinds (compile-time or
+ *   runtime), and new ontology relations are allowed.
+ * - Re-declaring an existing runtime kind with the **same shape** is a
+ *   no-op (idempotent re-evolve, the agent-loop hot path).
+ * - Re-declaring an existing runtime kind with a **different shape**
+ *   throws `ConfigurationError` with code `RUNTIME_KIND_REDEFINITION`.
+ *   v1 doesn't support modifying a prior declaration; use a new kind
+ *   name to evolve a kind.
+ * - Collisions with **compile-time** kinds (any name reuse) throw
+ *   `RUNTIME_KIND_NAME_COLLISION`.
+ * - Edge endpoints that don't resolve against either the runtime
+ *   extension or the host graph throw `RUNTIME_EXTENSION_UNRESOLVED_ENDPOINT`
+ *   — the startup-conflict case for stale persisted documents.
+ *
+ * The returned graph carries the union of the host's existing
+ * `runtimeDocument` and the new extension, so re-serialization is
+ * stable across restarts. When the union is structurally equal to the
+ * existing document, the host graph is returned unchanged so no-op
+ * evolves skip the compile + filter + merge work entirely.
  *
  * Validates the document structurally before compiling — every load
  * path goes through here, so persisted documents that drift from the
@@ -29,10 +49,41 @@ export function mergeRuntimeExtension<G extends GraphDef>(
   document: RuntimeGraphDocument,
 ): G {
   const validated = unwrap(validateRuntimeExtension(document));
-  const compiled = compileRuntimeExtension(validated);
+  const existingDocument: RuntimeGraphDocument =
+    graph.runtimeDocument ?? Object.freeze({});
+
+  // Reject runtime-runtime redefinitions BEFORE building the union, so
+  // the union spread (`{ ...existing, ...next }`) can't silently
+  // overwrite a prior declaration. Same-shape re-evolves still pass
+  // through — the spread overwrites with an equal value, and the
+  // canonicalEqual short-circuit below collapses the whole call to a
+  // no-op.
+  assertNoRedefinitions(existingDocument, validated, graph.id);
+
+  const unionDocument = unionDocuments(existingDocument, validated);
+
+  // Fast path: when the new extension is structurally a subset of the
+  // existing runtime document (the agent-loop "I evolved with the same
+  // extension again" case), the union equals existing and there's no
+  // work to do. Skip the compile + filter + merge pipeline entirely.
+  if (
+    graph.runtimeDocument !== undefined &&
+    canonicalEqual(unionDocument, existingDocument)
+  ) {
+    return graph;
+  }
+
+  const compiled = compileRuntimeExtension(unionDocument);
+
+  // Existing runtime-origin kind names — these aren't compile-time
+  // collisions when re-applied, so we skip the collision check for them
+  // and let the union document overwrite the previous compiled form.
+  const runtimeNodeNames = new Set(Object.keys(existingDocument.nodes ?? {}));
+  const runtimeEdgeNames = new Set(Object.keys(existingDocument.edges ?? {}));
 
   const nodeKinds = new Map<string, NodeType>();
   for (const registration of Object.values(graph.nodes)) {
+    if (runtimeNodeNames.has(registration.type.kind)) continue;
     nodeKinds.set(registration.type.kind, registration.type);
   }
   for (const node of compiled.nodes) {
@@ -45,7 +96,11 @@ export function mergeRuntimeExtension<G extends GraphDef>(
     nodeKinds.set(node.type.kind, node.type);
   }
 
-  const mergedNodes: Record<string, NodeRegistration> = { ...graph.nodes };
+  const mergedNodes: Record<string, NodeRegistration> = {};
+  for (const [name, registration] of Object.entries(graph.nodes)) {
+    if (runtimeNodeNames.has(name)) continue;
+    mergedNodes[name] = registration;
+  }
   for (const node of compiled.nodes) {
     mergedNodes[node.type.kind] = {
       type: node.type,
@@ -53,7 +108,11 @@ export function mergeRuntimeExtension<G extends GraphDef>(
     };
   }
 
-  const mergedEdges: Record<string, EdgeRegistration> = { ...graph.edges };
+  const mergedEdges: Record<string, EdgeRegistration> = {};
+  for (const [name, registration] of Object.entries(graph.edges)) {
+    if (runtimeEdgeNames.has(name)) continue;
+    mergedEdges[name] = registration;
+  }
   for (const edge of compiled.edges) {
     assertNoCollision(
       edge.type.kind,
@@ -85,24 +144,122 @@ export function mergeRuntimeExtension<G extends GraphDef>(
     mergedEdges[edge.type.kind] = { type: resolvedType, from, to };
   }
 
+  // Drop ontology relations that came from the previous runtime
+  // document — `compiled.ontology` reproduces them from the union, so
+  // keeping the originals would double-stack. Pre-build a Set of
+  // canonical keys for O(1) lookup; the naive per-relation `.some`
+  // scan was O(N×M).
+  const runtimeOntologyKeys = new Set(
+    (existingDocument.ontology ?? []).map(
+      (entry) => `${entry.metaEdge}|${entry.from}|${entry.to}`,
+    ),
+  );
+  const compileTimeOntology = graph.ontology.filter(
+    (relation) =>
+      !runtimeOntologyKeys.has(
+        `${relation.metaEdge.name}|${getTypeName(relation.from)}|${getTypeName(relation.to)}`,
+      ),
+  );
   const mergedOntology: readonly OntologyRelation[] = [
-    ...graph.ontology,
+    ...compileTimeOntology,
     ...compiled.ontology.map((relation) =>
       resolveOntologyEndpoints(relation, nodeKinds),
     ),
   ];
 
-  // The cast widens the merged graph back to `G`. Additional runtime
-  // kinds aren't visible to the type system; consumers that need them
-  // reach through the runtime registry. The lie is consolidated here so
-  // call sites don't repeat it.
+  // Returned as `G` even though runtime kinds aren't in the static
+  // type — consumers reach them via the registry.
   return Object.freeze({
     ...graph,
     nodes: mergedNodes,
     edges: mergedEdges,
     ontology: mergedOntology,
-    runtimeDocument: validated,
+    runtimeDocument: unionDocument,
   });
+}
+
+/**
+ * Combines two runtime extension documents into one. Same-named nodes
+ * and edges in `next` overwrite their `existing` counterpart (the
+ * structural-equal redefinition case is caught upstream by
+ * `assertNoRedefinitions`, so the overwrite is always with an equal
+ * value here). Ontology relations are deduped by `(metaEdge, from, to)`
+ * — re-applying the same relation twice would otherwise persist
+ * duplicates that the next restart's validator rejects with
+ * `DUPLICATE_ONTOLOGY_RELATION`.
+ */
+function unionDocuments(
+  existing: RuntimeGraphDocument,
+  next: RuntimeGraphDocument,
+): RuntimeGraphDocument {
+  // First-evolve fast path: when there's no existing document, the
+  // already-frozen `next` IS the union. Skips three object spreads and
+  // a freeze on the cold path.
+  if (
+    existing.nodes === undefined &&
+    existing.edges === undefined &&
+    existing.ontology === undefined
+  ) {
+    return next;
+  }
+
+  const nodes =
+    existing.nodes === undefined && next.nodes === undefined ?
+      undefined
+    : { ...existing.nodes, ...next.nodes };
+  const edges =
+    existing.edges === undefined && next.edges === undefined ?
+      undefined
+    : { ...existing.edges, ...next.edges };
+  const ontology =
+    existing.ontology === undefined && next.ontology === undefined ?
+      undefined
+    : dedupRelations([...(existing.ontology ?? []), ...(next.ontology ?? [])]);
+
+  return Object.freeze({
+    ...(nodes === undefined ? {} : { nodes }),
+    ...(edges === undefined ? {} : { edges }),
+    ...(ontology === undefined ? {} : { ontology }),
+  });
+}
+
+function dedupRelations(
+  relations: readonly RuntimeOntologyRelation[],
+): readonly RuntimeOntologyRelation[] {
+  const seen = new Set<string>();
+  const out: RuntimeOntologyRelation[] = [];
+  for (const relation of relations) {
+    const key = `${relation.metaEdge}|${relation.from}|${relation.to}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(relation);
+  }
+  return out;
+}
+
+function assertNoRedefinitions(
+  existing: RuntimeGraphDocument,
+  next: RuntimeGraphDocument,
+  graphId: string,
+): void {
+  for (const [name, nextNode] of Object.entries(next.nodes ?? {})) {
+    const existingNode = existing.nodes?.[name];
+    if (existingNode !== undefined && !canonicalEqual(existingNode, nextNode)) {
+      throw new ConfigurationError(
+        `Runtime extension redefines node kind "${name}" on graph "${graphId}" with a different shape than the existing runtime declaration. v1 extensions are additive only — modifying a prior declaration is not supported. Use a new kind name to evolve the schema.`,
+        { code: "RUNTIME_KIND_REDEFINITION" },
+      );
+    }
+  }
+  for (const [name, nextEdge] of Object.entries(next.edges ?? {})) {
+    const existingEdge = existing.edges?.[name];
+    if (existingEdge !== undefined && !canonicalEqual(existingEdge, nextEdge)) {
+      throw new ConfigurationError(
+        `Runtime extension redefines edge kind "${name}" on graph "${graphId}" with a different shape than the existing runtime declaration. v1 extensions are additive only — modifying a prior declaration is not supported. Use a new kind name to evolve the schema.`,
+        { code: "RUNTIME_KIND_REDEFINITION" },
+      );
+    }
+  }
 }
 
 function assertNoCollision(

--- a/packages/typegraph/src/runtime/validation.ts
+++ b/packages/typegraph/src/runtime/validation.ts
@@ -106,7 +106,13 @@ const OBJECT_REFINEMENT_KEYS = new Set([
   "description",
 ]);
 
-const SUPPORTED_STRING_FORMATS = new Set(["datetime", "uri"]);
+const SUPPORTED_STRING_FORMATS = new Set([
+  "datetime",
+  "uri",
+  "email",
+  "uuid",
+  "date",
+]);
 
 /**
  * Validates a runtime extension document.
@@ -790,7 +796,7 @@ function validateStringProperty(
     }
   }
 
-  let format: "datetime" | "uri" | undefined;
+  let format: RuntimeStringProperty["format"];
   if (raw.format !== undefined) {
     if (
       typeof raw.format !== "string" ||
@@ -802,7 +808,7 @@ function validateStringProperty(
         code: "INVALID_PROPERTY_REFINEMENT",
       });
     } else {
-      format = raw.format as "datetime" | "uri";
+      format = raw.format as RuntimeStringProperty["format"];
     }
   }
 

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -23,6 +23,7 @@ export {
   type QueryOptions,
   type StoreHooks,
   type StoreOptions,
+  type StoreRef,
   type TransactionContext,
   type TypedEdgeCollection,
   type UpdateEdgeInput,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -20,6 +20,7 @@ import {
   type NodeKinds,
 } from "../core/define-graph";
 import type { NodeId } from "../core/types";
+import { ConfigurationError } from "../errors";
 import type { TraversalExpansion } from "../query/ast";
 import {
   type BatchableQuery,
@@ -30,6 +31,12 @@ import {
 import { createSqlSchema } from "../query/compiler/schema";
 import { getDialect } from "../query/dialect";
 import { buildKindRegistry, type KindRegistry } from "../registry";
+import { type RuntimeGraphDocument } from "../runtime/document-types";
+import { mergeRuntimeExtension } from "../runtime/merge";
+import {
+  loadActiveSchemaWithBootstrap,
+  parseSerializedSchema,
+} from "../schema/manager";
 import { nowIso } from "../utils/date";
 import { generateId } from "../utils/id";
 import { createGraphAlgorithms, type GraphAlgorithms } from "./algorithms";
@@ -82,6 +89,7 @@ import {
   type QueryOptions,
   type StoreHooks,
   type StoreOptions,
+  type StoreRef,
   type TransactionContext,
 } from "./types";
 
@@ -129,6 +137,11 @@ export class Store<G extends GraphDef> {
   readonly #hooks: StoreHooks;
   readonly #schema: StoreOptions["schema"];
   readonly #defaultTraversalExpansion: TraversalExpansion;
+  // Stored verbatim so `evolve()` can construct the next Store with
+  // identical options. Reconstructing from the individual private
+  // fields would silently drop any future StoreOptions field a
+  // maintainer adds without also threading it through evolve.
+  readonly #options: StoreOptions | undefined;
   #nodeCollections: GraphNodeCollections<G> | undefined;
   #edgeCollections: GraphEdgeCollections<G> | undefined;
   #algorithms: GraphAlgorithms<G> | undefined;
@@ -144,6 +157,7 @@ export class Store<G extends GraphDef> {
       (backend.tableNames ? createSqlSchema(backend.tableNames) : undefined);
     this.#defaultTraversalExpansion =
       options?.queryDefaults?.traversalExpansion ?? "inverse";
+    this.#options = options;
   }
 
   // === Accessors ===
@@ -736,6 +750,110 @@ export class Store<G extends GraphDef> {
    */
   async refreshStatistics(): Promise<void> {
     await this.#backend.refreshStatistics();
+  }
+
+  /**
+   * Evolves the graph at runtime by merging a runtime extension document
+   * into the current schema, atomically committing a new schema version,
+   * and returning a fresh `Store` constructed against the merged graph.
+   *
+   * The `Store` is immutable — its registry, collections, and operation
+   * contexts close over the graph at construction time — so callers
+   * must use the returned store (or pass a `ref` to be re-pointed) for
+   * any work involving the new kinds.
+   *
+   * **Cost is proportional to schema document size, not row count.** The
+   * commit is a single CAS write; `evolve()` never reads or scans data
+   * rows, so the runtime is independent of the table's row count.
+   *
+   * **Concurrent evolve recovery.** On `StaleVersionError`, refetch the
+   * current active schema (or dereference your `StoreRef`),
+   * reconstruct your `Store`, and re-call `evolve(extension)` against
+   * the new store. Re-validation may now surface deterministic errors
+   * (e.g., another caller just added a kind that collides with yours,
+   * or redeclared one of yours with a different shape). Don't loop
+   * blindly — surface the error.
+   *
+   * @param extension - Runtime extension document produced by
+   *   `defineRuntimeExtension(...)`.
+   * @param options.ref - Optional handle whose `current` is overwritten
+   *   atomically with the schema commit. Long-lived consumers
+   *   (request handlers, background workers) that dereference through
+   *   the ref see the new kinds on the *next* call.
+   *
+   * @throws {RuntimeExtensionValidationError} when the document is
+   *   structurally invalid.
+   * @throws {ConfigurationError} on kind-name collisions with
+   *   compile-time kinds (`RUNTIME_KIND_NAME_COLLISION`),
+   *   redefinitions of existing runtime kinds with a different shape
+   *   (`RUNTIME_KIND_REDEFINITION`), or unresolvable edge endpoints
+   *   (`RUNTIME_EXTENSION_UNRESOLVED_ENDPOINT`).
+   * @throws {StaleVersionError} when another writer has advanced the
+   *   schema since this store was constructed; recovery as above.
+   * @throws {SchemaContentConflictError} when a row already exists at
+   *   the target version with a different content hash.
+   */
+  async evolve(
+    extension: RuntimeGraphDocument,
+    options?: Readonly<{ ref?: StoreRef<Store<G>> }>,
+  ): Promise<Store<G>> {
+    const activeRow = await loadActiveSchemaWithBootstrap(
+      this.#backend,
+      this.graphId,
+    );
+    if (activeRow === undefined) {
+      throw new ConfigurationError(
+        `Cannot evolve graph "${this.graphId}": no schema has been initialized. Call createStoreWithSchema first.`,
+        { code: "EVOLVE_BEFORE_INITIALIZE" },
+      );
+    }
+
+    // Catch up to the persisted state first. If another process has
+    // evolved the graph since this Store was constructed, the active
+    // row's runtimeDocument contains kinds that this.#graph doesn't —
+    // applying the new extension on top of the stale local view would
+    // make ensureSchema diff against the persisted schema and treat
+    // the missing-locally kinds as removed (a breaking-change
+    // MigrationError). Auto-merging the stored doc into the baseline
+    // makes evolve self-healing across multi-process races; the CAS
+    // guard inside commitSchemaVersion still serializes the actual
+    // commit. If the stored doc redefines a local runtime kind with a
+    // different shape, the merge throws RUNTIME_KIND_REDEFINITION
+    // here — surfacing the divergence rather than overwriting.
+    const storedSchema = parseSerializedSchema(activeRow.schema_doc);
+    const baselineGraph =
+      storedSchema.runtimeDocument === undefined ?
+        this.#graph
+      : mergeRuntimeExtension(this.#graph, storedSchema.runtimeDocument);
+    const merged = mergeRuntimeExtension(baselineGraph, extension);
+
+    // No-op evolve (extension already applied): return `this` so the
+    // agent loop's repeated `evolve(sameExt)` keeps warm registry,
+    // collection, and query caches instead of discarding them on every
+    // call. The reference comparison only holds when both merges
+    // (stored + extension) returned their input unchanged.
+    if (merged === this.#graph) {
+      if (options?.ref !== undefined) options.ref.current = this;
+      return this;
+    }
+
+    // Delegate the serialize → hash → diff → commit dance to
+    // `ensureSchema`. It already implements the same-hash short-circuit
+    // and the migrate-via-CAS commit; reusing it avoids computing
+    // serializeSchema + computeSchemaHash twice (once here, once in
+    // migrateSchema). Runtime extensions are additive only, so the
+    // diff is always backwards-compatible — autoMigrate succeeds.
+    await ensureSchemaImpl(this.#backend, merged, {
+      preloaded: { activeRow, storedSchema },
+      autoMigrate: true,
+    });
+    return this.#cloneWithGraph(merged, options?.ref);
+  }
+
+  #cloneWithGraph(graph: G, ref: StoreRef<Store<G>> | undefined): Store<G> {
+    const next = createStore(graph, this.#backend, this.#options);
+    if (ref !== undefined) ref.current = next;
+    return next;
   }
 
   /**

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -279,6 +279,36 @@ export type StoreOptions = Readonly<{
   }>;
 }>;
 
+/**
+ * A mutable handle to the current `Store`, used by `store.evolve(...)`
+ * so long-lived consumers can dereference through the ref and pick up
+ * the new store after each evolve call. `current` is overwritten by
+ * `evolve()` atomically with the schema commit when the ref is passed
+ * via `evolve(extension, { ref })`.
+ *
+ * **Mid-request semantics.** `ref.current` flips on the *next* call
+ * after evolve, not mid-handler. Dereference once at request entry and
+ * reuse the captured `Store` for the duration:
+ *
+ * ```ts
+ * async function handleRequest(): Promise<void> {
+ *   const store = ref.current; // capture once
+ *   const tag = await store.nodes.Tag?.create({ label: "..." });
+ *   // ...further work on the same `store`...
+ * }
+ * ```
+ *
+ * Pure dereferenceable handle — no event/subscription machinery. If
+ * consumers need eventing, they wrap the ref themselves.
+ *
+ * Generic over the held value (typically `Store<G>`) so the store
+ * module can refer to it without importing the `Store` class into
+ * `types.ts`.
+ */
+export interface StoreRef<T> {
+  current: T;
+}
+
 // ============================================================
 // Get-Or-Create Types
 // ============================================================

--- a/packages/typegraph/tests/runtime-extension.test.ts
+++ b/packages/typegraph/tests/runtime-extension.test.ts
@@ -196,6 +196,70 @@ describe("string property parity", () => {
     });
   });
 
+  it("format: email parses addresses and rejects non-emails", () => {
+    const handwritten = defineNode("Contact", {
+      schema: z.object({ email: z.email() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Contact: {
+            properties: { email: { type: "string", format: "email" } },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      email: "alice@example.com",
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      email: "not-an-email",
+    });
+  });
+
+  it("format: uuid parses UUIDs and rejects non-UUIDs", () => {
+    const handwritten = defineNode("Resource", {
+      schema: z.object({ externalId: z.uuid() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Resource: {
+            properties: { externalId: { type: "string", format: "uuid" } },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      externalId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      externalId: "not-a-uuid",
+    });
+  });
+
+  it("format: date parses date-only strings and rejects datetimes", () => {
+    const handwritten = defineNode("Birthday", {
+      schema: z.object({ on: z.iso.date() }),
+    });
+    const compiled = compileSingleNode(
+      defineRuntimeExtension({
+        nodes: {
+          Birthday: {
+            properties: { on: { type: "string", format: "date" } },
+          },
+        },
+      }),
+    );
+    assertParsedEqual(handwritten.schema, compiled.schema, {
+      on: "1990-01-15",
+    });
+    // Datetime is not a date — both sides reject identically.
+    assertRejectedEquivalently(handwritten.schema, compiled.schema, {
+      on: "1990-01-15T00:00:00.000Z",
+    });
+  });
+
   it("optional string makes the field omittable on both sides", () => {
     const handwritten = defineNode("Opt", {
       schema: z.object({ note: z.string().optional() }),

--- a/packages/typegraph/tests/store-evolve.test.ts
+++ b/packages/typegraph/tests/store-evolve.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Tests for `Store.evolve(...)` and the consumer-composed `StoreRef`
+ * pattern.
+ *
+ * Two acceptance gates:
+ *
+ * - **Round-trip parity:** for every public Store API path, a kind
+ *   added via `evolve()` must produce identical results to the same
+ *   kind declared at compile time. The matrix below covers create /
+ *   getById / find / count / update / delete plus edge endpoint
+ *   resolution — the surfaces most likely to accidentally close over
+ *   the pre-evolve registry. Runtime kinds are reached through the
+ *   dynamic `getNodeCollection(kind)` accessor since the type system
+ *   doesn't see them.
+ *
+ * - **Concurrent evolve:** two simultaneous `evolve()` calls produce
+ *   exactly one winner; the loser surfaces `StaleVersionError` or
+ *   `SchemaContentConflictError` depending on which CAS check fired
+ *   first.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph } from "../src/core/define-graph";
+import { defineNode } from "../src/core/node";
+import {
+  ConfigurationError,
+  SchemaContentConflictError,
+  StaleVersionError,
+} from "../src/errors";
+import { defineRuntimeExtension } from "../src/runtime";
+import { createStore, createStoreWithSchema } from "../src/store/store";
+import { type StoreRef } from "../src/store/types";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const baseGraph = defineGraph({
+  id: "store_evolve",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+// Shape returned by the dynamic `getNodeCollection("Tag")` path —
+// runtime kinds aren't in the type system so the dynamic collection
+// returns the widened `Node<NodeType>`. Hoisted here so the parity
+// tests share one cast site.
+type RuntimeTag = Readonly<{ kind: string; id: string; label: string }>;
+
+describe("Store.evolve — basic flow", () => {
+  it("commits a new schema version and returns a Store carrying the runtime kind", async () => {
+    const backend = createTestBackend();
+    const [store, init] = await createStoreWithSchema(baseGraph, backend);
+    expect(init).toEqual({ status: "initialized", version: 1 });
+
+    const extension = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+    const evolved = await store.evolve(extension);
+
+    expect(evolved.registry.hasNodeType("Tag")).toBe(true);
+    expect(evolved.registry.hasNodeType("Person")).toBe(true);
+
+    const active = await backend.getActiveSchema(baseGraph.id);
+    expect(active?.version).toBe(2);
+    expect(active?.schema_doc).toContain('"Tag"');
+  });
+
+  it("is idempotent on same-hash re-evolve (returns a fresh Store, no version bump)", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const extension = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+    const first = await store.evolve(extension);
+    const firstActive = await backend.getActiveSchema(baseGraph.id);
+
+    const second = await first.evolve(extension);
+    const secondActive = await backend.getActiveSchema(baseGraph.id);
+
+    expect(secondActive?.version).toBe(firstActive?.version);
+    expect(second.registry.hasNodeType("Tag")).toBe(true);
+  });
+
+  it("rejects evolve before any schema has been initialized", async () => {
+    const backend = createTestBackend();
+    // Construct a Store *without* initializing the schema.
+    const store = createStore(baseGraph, backend);
+    const extension = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+    await expect(store.evolve(extension)).rejects.toBeInstanceOf(
+      ConfigurationError,
+    );
+  });
+
+  it("rejects same-name runtime kind redefined with a different shape", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const v1 = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+    const evolved = await store.evolve(v1);
+
+    // v1 extensions are additive-only — re-declaring Tag with an extra
+    // property is a redefinition, not an additive change. Use a new
+    // kind name to evolve a kind in v1.
+    const v2 = defineRuntimeExtension({
+      nodes: {
+        Tag: {
+          properties: {
+            label: { type: "string" },
+            color: { type: "string" },
+          },
+        },
+      },
+    });
+    const caught = await evolved.evolve(v2).catch((error: unknown) => error);
+    expect(caught).toBeInstanceOf(ConfigurationError);
+    expect((caught as ConfigurationError).details).toMatchObject({
+      code: "RUNTIME_KIND_REDEFINITION",
+    });
+  });
+
+  it("stale store auto-merges the persisted runtime document before applying", async () => {
+    // Two stores against the same backend. Store A is constructed
+    // before B evolves. When A later calls evolve, it must catch up
+    // to B's persisted runtime document instead of throwing
+    // MigrationError on the absent-locally kind.
+    const backend = createTestBackend();
+    const [storeA] = await createStoreWithSchema(baseGraph, backend);
+    const [storeB] = await createStoreWithSchema(baseGraph, backend);
+
+    // B evolves with Tag — backend now carries Tag in its
+    // runtimeDocument. A's local #graph still has no runtimeDocument.
+    await storeB.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+
+    // A evolves with a *different* additive extension. The fix must
+    // merge B's stored Tag into A's baseline first, so the resulting
+    // schema contains both Tag and Category. Without it, ensureSchema
+    // would diff the merged-with-Category-only graph against the
+    // stored-with-Tag schema and treat Tag as a removed kind.
+    const evolved = await storeA.evolve(
+      defineRuntimeExtension({
+        nodes: { Category: { properties: { name: { type: "string" } } } },
+      }),
+    );
+
+    expect(evolved.registry.hasNodeType("Tag")).toBe(true);
+    expect(evolved.registry.hasNodeType("Category")).toBe(true);
+    const active = await backend.getActiveSchema(baseGraph.id);
+    expect(active?.version).toBe(3);
+  });
+
+  it("re-evolving the same ontology relation is idempotent (no duplicate persisted)", async () => {
+    // unionDocuments used to concatenate ontology arrays; re-evolving
+    // the same ontology relation appended a duplicate that the next
+    // restart's validator rejected with DUPLICATE_ONTOLOGY_RELATION.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const extension = defineRuntimeExtension({
+      nodes: {
+        Doc: { properties: { title: { type: "string" } } },
+        Article: { properties: { title: { type: "string" } } },
+      },
+      ontology: [{ metaEdge: "subClassOf", from: "Article", to: "Doc" }],
+    });
+
+    const first = await store.evolve(extension);
+    const firstActive = await backend.getActiveSchema(baseGraph.id);
+
+    // Same extension applied again must be a true no-op — no duplicate
+    // ontology relation, no version bump, and the next loader can read
+    // the schema back without DUPLICATE_ONTOLOGY_RELATION.
+    await first.evolve(extension);
+    const secondActive = await backend.getActiveSchema(baseGraph.id);
+    expect(secondActive?.version).toBe(firstActive?.version);
+
+    // Restart against the same backend — the loader runs the runtime
+    // validator on the persisted document, so any duplicates would
+    // surface here.
+    const [restored] = await createStoreWithSchema(baseGraph, backend);
+    expect(restored.registry.hasNodeType("Doc")).toBe(true);
+    expect(restored.registry.hasNodeType("Article")).toBe(true);
+  });
+
+  it("additive evolve adds new kinds on top of a previously merged extension", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const withTag = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+    const withTagAndCategory = await withTag.evolve(
+      defineRuntimeExtension({
+        nodes: { Category: { properties: { name: { type: "string" } } } },
+      }),
+    );
+
+    // Both kinds reachable, original Tag preserved through the second
+    // evolve, schema version bumped twice.
+    expect(withTagAndCategory.registry.hasNodeType("Tag")).toBe(true);
+    expect(withTagAndCategory.registry.hasNodeType("Category")).toBe(true);
+    const active = await backend.getActiveSchema(baseGraph.id);
+    expect(active?.version).toBe(3);
+  });
+});
+
+describe("Store.evolve — round-trip parity matrix", () => {
+  // For each scenario, declare kind X two ways:
+  //  (a) inline at compile time on `compileGraph`
+  //  (b) added via `evolve()` to a graph that didn't originally know X
+  // and assert the same operations produce equal results on both sides.
+
+  it("create + getById return equivalent shapes", async () => {
+    const Tag = defineNode("Tag", {
+      schema: z.object({ label: z.string() }),
+    });
+    const compileGraph = defineGraph({
+      id: "parity_create",
+      nodes: { Person: { type: Person }, Tag: { type: Tag } },
+      edges: {},
+    });
+
+    const compileBackend = createTestBackend();
+    const [compileStore] = await createStoreWithSchema(
+      compileGraph,
+      compileBackend,
+    );
+    const compileTag = await compileStore.nodes.Tag.create({ label: "alpha" });
+    const compileFetched = await compileStore.nodes.Tag.getById(compileTag.id);
+
+    const runtimeBackend = createTestBackend();
+    const baseGraphForRuntime = defineGraph({
+      id: "parity_create",
+      nodes: { Person: { type: Person } },
+      edges: {},
+    });
+    const [runtimeStore] = await createStoreWithSchema(
+      baseGraphForRuntime,
+      runtimeBackend,
+    );
+    const evolved = await runtimeStore.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+    const runtimeTagCol = evolved.getNodeCollection("Tag");
+    expect(runtimeTagCol).toBeDefined();
+    const runtimeTag = (await runtimeTagCol!.create({
+      label: "alpha",
+    })) as unknown as RuntimeTag;
+    const runtimeFetched = (await runtimeTagCol!.getById(
+      runtimeTag.id,
+    )) as unknown as RuntimeTag | undefined;
+
+    expect(runtimeTag.kind).toBe(compileTag.kind);
+    expect(runtimeTag.label).toBe(compileTag.label);
+    expect(runtimeFetched?.label).toBe(compileFetched?.label);
+  });
+
+  it("find + count + update + delete behave identically", async () => {
+    const Tag = defineNode("Tag", {
+      schema: z.object({ label: z.string() }),
+    });
+    const compileGraph = defineGraph({
+      id: "parity_lifecycle",
+      nodes: { Person: { type: Person }, Tag: { type: Tag } },
+      edges: {},
+    });
+
+    const compileBackend = createTestBackend();
+    const [compileStore] = await createStoreWithSchema(
+      compileGraph,
+      compileBackend,
+    );
+    await compileStore.nodes.Tag.create({ label: "a" });
+    await compileStore.nodes.Tag.create({ label: "b" });
+
+    const runtimeBackend = createTestBackend();
+    const baseGraphForRuntime = defineGraph({
+      id: "parity_lifecycle",
+      nodes: { Person: { type: Person } },
+      edges: {},
+    });
+    const [runtimeStore] = await createStoreWithSchema(
+      baseGraphForRuntime,
+      runtimeBackend,
+    );
+    const evolved = await runtimeStore.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+    const runtimeTagCol = evolved.getNodeCollection("Tag")!;
+    await runtimeTagCol.create({ label: "a" });
+    await runtimeTagCol.create({ label: "b" });
+
+    const compileFound = await compileStore.nodes.Tag.find();
+    const runtimeFound =
+      (await runtimeTagCol.find()) as unknown as RuntimeTag[];
+    expect(runtimeFound.length).toBe(compileFound.length);
+    expect(runtimeFound.map((node) => node.label).toSorted()).toEqual(
+      compileFound.map((node) => node.label).toSorted(),
+    );
+
+    const compileCount = await compileStore.nodes.Tag.count();
+    const runtimeCount = await runtimeTagCol.count();
+    expect(runtimeCount).toBe(compileCount);
+
+    // update
+    const compileUpdated = await compileStore.nodes.Tag.update(
+      compileFound[0]!.id,
+      { label: "z" },
+    );
+    const runtimeUpdated = (await runtimeTagCol.update(runtimeFound[0]!.id, {
+      label: "z",
+    })) as unknown as RuntimeTag;
+    expect(runtimeUpdated.label).toBe(compileUpdated.label);
+
+    // delete
+    await compileStore.nodes.Tag.delete(compileFound[1]!.id);
+    await runtimeTagCol.delete(runtimeFound[1]!.id);
+    expect(await runtimeTagCol.count()).toBe(
+      await compileStore.nodes.Tag.count(),
+    );
+  });
+
+  it("traverses compile-time → runtime kinds via a runtime edge end-to-end", async () => {
+    // The merged graph claim: a runtime edge between a runtime kind
+    // and a compile-time kind is queryable just like a fully
+    // compile-time edge would be. Tests the actual data path, not
+    // just registry shape.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+        edges: {
+          appliesTo: { from: ["Tag"], to: ["Person"], properties: {} },
+        },
+      }),
+    );
+
+    const alice = await evolved.nodes.Person.create({ name: "alice" });
+    const tagCol = evolved.getNodeCollection("Tag")!;
+    const featured = (await tagCol.create({
+      label: "featured",
+    })) as unknown as RuntimeTag;
+    const importantTag = (await tagCol.create({
+      label: "important",
+    })) as unknown as RuntimeTag;
+
+    const appliesTo = evolved.getEdgeCollection("appliesTo")!;
+    await appliesTo.create(
+      { kind: "Tag", id: featured.id },
+      { kind: "Person", id: alice.id },
+      {},
+    );
+    await appliesTo.create(
+      { kind: "Tag", id: importantTag.id },
+      { kind: "Person", id: alice.id },
+      {},
+    );
+
+    // Forward traversal: from a runtime Tag, find all appliesTo edges.
+    const fromFeatured = await appliesTo.findFrom({
+      kind: "Tag",
+      id: featured.id,
+    });
+    expect(fromFeatured).toHaveLength(1);
+    expect(fromFeatured[0]!.toKind).toBe("Person");
+    expect(fromFeatured[0]!.toId).toBe(alice.id);
+
+    // Reverse traversal: from a compile-time Person, find all
+    // incoming appliesTo edges (originating from runtime Tags).
+    const incoming = await appliesTo.findTo({ kind: "Person", id: alice.id });
+    expect(incoming).toHaveLength(2);
+    const tagIds = incoming.map((edge) => edge.fromId).toSorted();
+    expect(tagIds).toEqual([featured.id, importantTag.id].toSorted());
+  });
+
+  it("runtime edge endpoints surface correctly through the registry", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+        edges: {
+          appliesTo: { from: ["Tag"], to: ["Person"], properties: {} },
+        },
+      }),
+    );
+
+    const edgeType = evolved.registry.getEdgeType("appliesTo");
+    expect(edgeType?.from?.map((node) => node.kind)).toEqual(["Tag"]);
+    expect(edgeType?.to?.map((node) => node.kind)).toEqual(["Person"]);
+
+    // Compile-time `Person` is reachable through the merged registry
+    // unchanged, and the runtime `Tag` shows up alongside it.
+    expect(evolved.registry.getNodeType("Person")?.kind).toBe("Person");
+    expect(evolved.registry.getNodeType("Tag")?.kind).toBe("Tag");
+  });
+});
+
+describe("Store.evolve — concurrency", () => {
+  it("two concurrent evolve calls produce one winner and one StaleVersionError", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const tagExtension = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+    const categoryExtension = defineRuntimeExtension({
+      nodes: { Category: { properties: { name: { type: "string" } } } },
+    });
+
+    // Both calls read the same active version (1) and race to commit
+    // version 2. The CAS guard inside `commitSchemaVersion` lets exactly
+    // one win.
+    const results = await Promise.allSettled([
+      store.evolve(tagExtension),
+      store.evolve(categoryExtension),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // Both writers picked the same target version (active+1) but with
+    // different content hashes. The CAS primitive surfaces the loser as
+    // either StaleVersionError (if the winner committed first and
+    // advanced the active pointer before the loser's CAS check) or
+    // SchemaContentConflictError (if the loser hits the version row
+    // first and finds a different hash). Both are valid race losers.
+    const reason = rejected[0]!.reason as Error;
+    const isExpected =
+      reason instanceof StaleVersionError ||
+      reason instanceof SchemaContentConflictError;
+    expect(isExpected).toBe(true);
+  });
+});
+
+describe("StoreRef pattern (consumer-composed)", () => {
+  // The ref is a consumer pattern, not a library factory. Apps that need
+  // many callers to share a stable handle (request handlers, background
+  // workers, the agent loop) compose their own ref and pass it to
+  // evolve, which re-points it atomically with the schema commit. Apps
+  // with a single caller can skip the ref entirely and reassign the
+  // store from evolve's return value.
+  it("evolve(ext, { ref }) re-points the consumer-composed ref", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const ref: StoreRef<typeof store> = { current: store };
+
+    const extension = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+    const evolved = await ref.current.evolve(extension, { ref });
+
+    expect(ref.current).toBe(evolved);
+    expect(ref.current.registry.hasNodeType("Tag")).toBe(true);
+  });
+
+  it("evolve without ref returns the new store; consumer reassigns", async () => {
+    const backend = createTestBackend();
+    let [store] = await createStoreWithSchema(baseGraph, backend);
+    const original = store;
+
+    const extension = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+    store = await store.evolve(extension);
+
+    expect(store).not.toBe(original);
+    expect(store.registry.hasNodeType("Tag")).toBe(true);
+    expect(original.registry.hasNodeType("Tag")).toBe(false);
+  });
+});


### PR DESCRIPTION
PR 5 of the runtime-extension feature (issue #101). Wires #106 (atomic commit), #108 (runtime document compiler), and #109 (loader rewire + `mergeRuntimeExtension`) into the public ergonomic.

## Two consumer patterns, both supported

**Single-caller / let-rebind** — the common case. `evolve()` returns the new store; reassign:

```typescript
import { createStoreWithSchema, defineRuntimeExtension } from "@nicia-ai/typegraph";

let [store] = await createStoreWithSchema(graph, backend);

const extension = defineRuntimeExtension({
  nodes: { Paper: { properties: { doi: { type: "string" } } } },
});

store = await store.evolve(extension);
```

**Many-caller / consumer-composed `StoreRef`** — for request handlers, background workers, agent loops sharing the store reference. Compose a ref, share `ref` (not `ref.current`), pass it to evolve to be re-pointed atomically with the schema commit:

```typescript
import {
  createStoreWithSchema,
  defineRuntimeExtension,
  type StoreRef,
} from "@nicia-ai/typegraph";

const [store] = await createStoreWithSchema(graph, backend);
const ref: StoreRef<typeof store> = { current: store };

async function handleRequest(): Promise<void> {
  await ref.current.nodes.Paper?.create({ doi: "..." });
}

await ref.current.evolve(extension, { ref });
```

`StoreRef<T>` is `{ current: T }` — a plain mutable handle, exported as a type. **No dedicated `createStoreRef` factory:** composing the ref is one line and keeps the library API surface minimal.

## Public API

- `Store.evolve(extension, options?)` — async; validates the document, atomically commits a new schema version through `commitSchemaVersion` (CAS on the active version), constructs a fresh `Store<G>` against the merged graph, and returns it. Concurrent calls produce one winner; the loser surfaces `StaleVersionError` or `SchemaContentConflictError`. Re-applying the same extension is idempotent.
- `StoreRef<T>` — `{ current: T }`. Pure dereferenceable handle, no event/subscription machinery. Pass into `evolve(extension, { ref })` to overwrite `ref.current` with the new store.

## Idempotency + re-evolve

`mergeRuntimeExtension` recognizes kinds present in the host's existing `runtimeDocument` as runtime origin (not compile-time collisions), so re-applying the same extension on top of an already-merged graph succeeds. The agent-loop "I evolved with the same extension again" case short-circuits to a structural-equal check before compile + filter + merge — saves the entire pipeline on no-op evolves.

## Acceptance gates

- **Round-trip parity matrix:** for every public Store API path (create / getById / find / count / update / delete / edge endpoint resolution), a kind added via `evolve()` produces identical results to the same kind declared at compile time. Runtime kinds reached through `store.getNodeCollection(kind)`.
- **Concurrent evolve:** two simultaneous `evolve()` calls produce exactly one winner; the loser is rejected with `StaleVersionError | SchemaContentConflictError`.
- **`StoreRef` re-binding:** passing `{ ref }` to `evolve` overwrites `ref.current`; omitting `ref` returns the new store directly (let-rebind pattern).

## Out of scope

Per the issue's v1 pinning:

- **`unique`-on-populated-kind rejection** — in v1 runtime extensions only ADD new kinds (collisions rejected outright), so every runtime kind is brand new with no rows. The rule becomes meaningful when `mode: "merge"` lands.
- **`materializeIndexes()`** — PR 6.
- **`deprecateKinds()`** — separate PR.
- **Cross-store auto-refresh in the same process** — `StoreRef` is the re-binding affordance; auto-refresh is a separate observability concern.

Closes part of #101.