### PR TITLE
feat: store.deprecateKinds + undeprecateKinds soft-deprecation signal

### DIFF
--- a/.changeset/deprecate-kinds.md
+++ b/.changeset/deprecate-kinds.md
@@ -1,0 +1,48 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `store.deprecateKinds(names)` and `store.undeprecateKinds(names)` — the soft-deprecation signal for runtime extension's PR series. Library-owned per-graph kind set persisted in `schema_doc.deprecatedKinds`, surfaces in `store.deprecatedKinds` for introspection, does not affect reads, writes, or queries. Bumps the schema version like any other change. Originally folded into `store.evolve()` design; pulled into its own PR for review focus.
+
+```typescript
+const [store] = await createStoreWithSchema(graph, backend);
+
+// Mark a kind as deprecated. Surfaces in introspection (codegen, UI
+// tooling, lints) but reads/writes still work normally.
+const evolved = await store.deprecateKinds(["LegacyDocument"]);
+console.log([...evolved.deprecatedKinds]); // ["LegacyDocument"]
+
+// Reverse it.
+const restored = await evolved.undeprecateKinds(["LegacyDocument"]);
+
+// Works on both compile-time and runtime kinds. The standard StoreRef
+// re-binding pattern applies; pass `{ ref }` to be re-pointed
+// atomically with the schema commit.
+```
+
+## Public API
+
+- `Store.deprecateKinds(names: readonly string[], options?: { ref?: StoreRef<Store<G>> })` — async, atomically commits a new schema version with `names` added to the persisted set. Idempotent: re-deprecating an already-deprecated kind is a no-op (no version bump). Throws `ConfigurationError` (`code: "DEPRECATE_UNKNOWN_KIND"`) if any name doesn't match a known compile-time or runtime kind on the catchup-merged baseline.
+- `Store.undeprecateKinds(names: readonly string[], options?)` — symmetric reverse.
+- `Store.deprecatedKinds: ReadonlySet<string>` — getter for introspection.
+- `SchemaDiff.deprecatedKinds?: DeprecatedKindsChange` — diff classification (always `safe`-severity); `added` / `removed` arrays carry the per-name deltas.
+- `applyDeprecatedKinds(graph, names)` — exported from `@nicia-ai/typegraph/schema` for advanced consumers; same API the loader uses to fold persisted deprecations onto a fresh `GraphDef`.
+
+## Storage
+
+- New top-level slice on `SerializedSchema`: `deprecatedKinds?: readonly string[]` (sorted for canonical-form stability).
+- Omitted entirely when empty so legacy schemas hash byte-identically to before this PR landed.
+- Loader (`loadAndMergeRuntimeDocument`) applies the persisted set onto the merged graph alongside the runtime extension document.
+
+## Bug fix included
+
+`computeSchemaHash` was building its hashable subset by enumerating fields explicitly and was missing `runtimeDocument` and `deprecatedKinds`. For runtime extensions the missing field didn't matter in practice because the merged graph's `nodes` / `edges` always changed on `evolve()` — but for deprecation (which is metadata only), the missing `deprecatedKinds` slot meant the hash stayed identical and `ensureSchema` returned `unchanged` instead of migrating. Fixed: both slices are now part of the hashable subset, with the same omit-when-empty rule.
+
+## Concurrency + multi-process safety
+
+Same primitive as `Store.evolve()`: `commitSchemaVersion` CAS on the active version. Concurrent deprecate/evolve calls produce one winner; the loser surfaces `StaleVersionError` or `SchemaContentConflictError` from the commit primitive. The internal `#catchUpToStored` helper folds the persisted runtime document AND deprecated set into the local baseline before computing the next state, so a stale store's deprecate call doesn't trample another writer's runtime extension (the same auto-merge approach `evolve()` uses).
+
+## Out of scope
+
+- **Removal of runtime-declared kinds.** Deprecation is the soft-signal alternative; full runtime-kind removal remains its own future design.
+- **Hard-blocking reads/writes on deprecated kinds.** Deprecation is informational; if consumers want to refuse operations on deprecated kinds, they wrap the collection access themselves.

--- a/packages/typegraph/src/core/define-graph.ts
+++ b/packages/typegraph/src/core/define-graph.ts
@@ -236,6 +236,14 @@ export type GraphDef<
    * have never been runtime-extended; legacy graphs hash byte-identically.
    */
   runtimeDocument: RuntimeGraphDocument | undefined;
+  /**
+   * Soft-deprecated kind names attached to this graph. Set by the
+   * loader from the persisted schema and by `store.deprecateKinds(...)`
+   * / `store.undeprecateKinds(...)`. A purely informational signal
+   * surfaced for introspection — does not gate reads, writes, or
+   * queries. Defaults to the empty set on freshly-defined graphs.
+   */
+  deprecatedKinds: ReadonlySet<string>;
 }>;
 
 // ============================================================
@@ -347,8 +355,15 @@ export function defineGraph<
     defaults,
     indexes,
     runtimeDocument: undefined,
+    deprecatedKinds: EMPTY_DEPRECATED_KINDS,
   }) as GraphDef<TNodes, NormalizedEdges<TNodes, TEdges>, TOntology>;
 }
+
+// Sharing one frozen empty Set keeps the canonical-form hash stable
+// across graphs that never deprecate any kinds.
+const EMPTY_DEPRECATED_KINDS: ReadonlySet<string> = Object.freeze(
+  new Set<string>(),
+);
 
 // ============================================================
 // Index Normalization

--- a/packages/typegraph/src/schema/index.ts
+++ b/packages/typegraph/src/schema/index.ts
@@ -35,6 +35,7 @@ export {
 // ============================================================
 
 export {
+  applyDeprecatedKinds,
   ensureSchema,
   getActiveSchema,
   getSchemaChanges,
@@ -58,6 +59,7 @@ export {
   type ChangeSeverity,
   type ChangeType,
   computeSchemaDiff,
+  type DeprecatedKindsChange,
   type EdgeChange,
   getMigrationActions,
   type IndexChange,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -117,14 +117,46 @@ export async function loadAndMergeRuntimeDocument<G extends GraphDef>(
     return { graph, activeRow: undefined, storedSchema: undefined };
   }
   const storedSchema = parseSerializedSchema(activeRow.schema_doc);
-  if (storedSchema.runtimeDocument === undefined) {
-    return { graph, activeRow, storedSchema };
-  }
+  const merged =
+    storedSchema.runtimeDocument === undefined ?
+      graph
+    : mergeRuntimeExtension(graph, storedSchema.runtimeDocument);
   return {
-    graph: mergeRuntimeExtension(graph, storedSchema.runtimeDocument),
+    graph: applyDeprecatedKinds(merged, storedSchema.deprecatedKinds),
     activeRow,
     storedSchema,
   };
+}
+
+/**
+ * Returns a graph carrying the supplied deprecated-kind names. Used by
+ * the loader to propagate `SerializedSchema.deprecatedKinds` onto the
+ * `GraphDef` that the Store sees, and by `Store.deprecateKinds` /
+ * `Store.undeprecateKinds` to construct the next graph.
+ *
+ * Returns the original graph reference when the desired set already
+ * matches `graph.deprecatedKinds` — covers both the no-deprecations
+ * load path (empty equals empty) and the loader's restart-with-same-
+ * persisted-set hot path. Skips a Set allocation + spread + freeze.
+ */
+export function applyDeprecatedKinds<G extends GraphDef>(
+  graph: G,
+  names: readonly string[] | undefined,
+): G {
+  const empty = names === undefined || names.length === 0;
+  const current = graph.deprecatedKinds;
+  if (empty && current.size === 0) return graph;
+  if (
+    !empty &&
+    names.length === current.size &&
+    names.every((name) => current.has(name))
+  ) {
+    return graph;
+  }
+  return Object.freeze({
+    ...graph,
+    deprecatedKinds: Object.freeze(empty ? new Set<string>() : new Set(names)),
+  });
 }
 
 // ============================================================

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -122,6 +122,23 @@ export type RuntimeDocumentChange = Readonly<{
 }>;
 
 // ============================================================
+// Deprecated Kinds Changes
+// ============================================================
+
+/**
+ * Change to the soft-deprecated kind set. `safe`-severity by
+ * construction — deprecation is a metadata signal that doesn't gate
+ * reads, writes, or queries. The `added` and `removed` arrays carry
+ * the per-name deltas so consumers can render granular diffs.
+ */
+export type DeprecatedKindsChange = Readonly<{
+  added: readonly string[];
+  removed: readonly string[];
+  severity: ChangeSeverity;
+  details: string;
+}>;
+
+// ============================================================
 // Schema Diff
 // ============================================================
 
@@ -149,6 +166,12 @@ export type SchemaDiff = Readonly<{
    * the slice is unchanged on both sides (the common case).
    */
   runtimeDocument?: RuntimeDocumentChange;
+
+  /**
+   * Change to the soft-deprecated kind set, if any. `undefined` when
+   * the set is unchanged on both sides.
+   */
+  deprecatedKinds?: DeprecatedKindsChange;
 
   /** Whether any breaking changes exist */
   hasBreakingChanges: boolean;
@@ -186,6 +209,10 @@ export function computeSchemaDiff(
     before.runtimeDocument,
     after.runtimeDocument,
   );
+  const deprecatedKindsChange = diffDeprecatedKinds(
+    before.deprecatedKinds,
+    after.deprecatedKinds,
+  );
 
   const allChanges = [
     ...nodeChanges,
@@ -197,13 +224,17 @@ export function computeSchemaDiff(
     (change) => change.severity === "breaking",
   );
   const hasChanges =
-    allChanges.length > 0 || runtimeDocumentChange !== undefined;
+    allChanges.length > 0 ||
+    runtimeDocumentChange !== undefined ||
+    deprecatedKindsChange !== undefined;
 
   const summary = generateSummary(
     nodeChanges,
     edgeChanges,
     ontologyChanges,
     indexChanges,
+    runtimeDocumentChange,
+    deprecatedKindsChange,
   );
 
   return {
@@ -216,6 +247,9 @@ export function computeSchemaDiff(
     ...(runtimeDocumentChange === undefined ?
       {}
     : { runtimeDocument: runtimeDocumentChange }),
+    ...(deprecatedKindsChange === undefined ?
+      {}
+    : { deprecatedKinds: deprecatedKindsChange }),
     hasBreakingChanges,
     isBackwardsCompatible: !hasBreakingChanges,
     hasChanges,
@@ -729,6 +763,47 @@ function diffRuntimeDocument(
 }
 
 // ============================================================
+// Deprecated Kinds Diff
+// ============================================================
+
+/**
+ * Computes the change to the soft-deprecated kind set, if any.
+ * `safe`-severity by construction; the per-name `added` / `removed`
+ * deltas let consumers render granular diffs without re-comparing the
+ * whole set.
+ */
+function diffDeprecatedKinds(
+  before: SerializedSchema["deprecatedKinds"],
+  after: SerializedSchema["deprecatedKinds"],
+): DeprecatedKindsChange | undefined {
+  // Both inputs come from independent `parseSerializedSchema` calls,
+  // so reference equality only fires for the `undefined`/`undefined`
+  // case — covered by the empty-set comparison below.
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  const added: string[] = [];
+  const removed: string[] = [];
+  for (const name of afterSet) {
+    if (!beforeSet.has(name)) added.push(name);
+  }
+  for (const name of beforeSet) {
+    if (!afterSet.has(name)) removed.push(name);
+  }
+  if (added.length === 0 && removed.length === 0) return undefined;
+  added.sort();
+  removed.sort();
+  const parts: string[] = [];
+  if (added.length > 0) parts.push(`added ${added.join(", ")}`);
+  if (removed.length > 0) parts.push(`removed ${removed.join(", ")}`);
+  return {
+    added,
+    removed,
+    severity: "safe",
+    details: `Deprecated kinds: ${parts.join("; ")}`,
+  };
+}
+
+// ============================================================
 // Summary Generation
 // ============================================================
 
@@ -740,6 +815,8 @@ function generateSummary(
   edgeChanges: readonly EdgeChange[],
   ontologyChanges: readonly OntologyChange[],
   indexChanges: readonly IndexChange[],
+  runtimeDocumentChange: RuntimeDocumentChange | undefined,
+  deprecatedKindsChange: DeprecatedKindsChange | undefined,
 ): string {
   const parts: string[] = [];
 
@@ -783,6 +860,17 @@ function generateSummary(
   if (indexAdded > 0 || indexRemoved > 0 || indexModified > 0) {
     parts.push(
       `Indexes: ${indexAdded} added, ${indexRemoved} removed, ${indexModified} modified`,
+    );
+  }
+
+  if (runtimeDocumentChange !== undefined) {
+    parts.push(`Runtime document: ${runtimeDocumentChange.type}`);
+  }
+
+  if (deprecatedKindsChange !== undefined) {
+    const { added, removed } = deprecatedKindsChange;
+    parts.push(
+      `Deprecated kinds: ${added.length} added, ${removed.length} removed`,
     );
   }
 

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -62,6 +62,7 @@ export function serializeSchema<G extends GraphDef>(
   const ontology = serializeOntology(graph.ontology);
   const indexes = serializeIndexes(graph.indexes);
   const runtimeDocument = graph.runtimeDocument;
+  const deprecatedKinds = serializeDeprecatedKinds(graph.deprecatedKinds);
 
   return {
     graphId: graph.id,
@@ -84,7 +85,18 @@ export function serializeSchema<G extends GraphDef>(
     // graphs that have never been runtime-extended so legacy schemas
     // hash byte-identically.
     ...(runtimeDocument === undefined ? {} : { runtimeDocument }),
+    // Soft-deprecated kind names. Omitted when empty so legacy
+    // schemas hash byte-identically; sorted for canonical-form
+    // stability across insertion-order differences.
+    ...(deprecatedKinds === undefined ? {} : { deprecatedKinds }),
   };
+}
+
+function serializeDeprecatedKinds(
+  set: ReadonlySet<string> | undefined,
+): readonly string[] | undefined {
+  if (set === undefined || set.size === 0) return undefined;
+  return [...set].toSorted();
 }
 
 // ============================================================
@@ -534,10 +546,11 @@ function serializeZodSchema(schema: z.ZodType): JsonSchema {
 export async function computeSchemaHash(
   schema: SerializedSchema,
 ): Promise<SchemaHash> {
-  // Create a hashable representation excluding dynamic fields. `indexes`
-  // is included only when set so legacy schemas without the slice hash
-  // identically (the slice's canonical-form rules — including
-  // `origin: "compile-time"` omission — are applied at serialize time).
+  // Create a hashable representation excluding dynamic fields
+  // (version, generatedAt). Optional slices are included only when
+  // set so legacy schemas without them hash byte-identically — the
+  // per-slice canonical-form rules (e.g., `indexes` sort + origin
+  // omission, `deprecatedKinds` sort) are applied at serialize time.
   const hashable = {
     graphId: schema.graphId,
     nodes: schema.nodes,
@@ -545,6 +558,12 @@ export async function computeSchemaHash(
     ontology: schema.ontology,
     defaults: schema.defaults,
     ...(schema.indexes === undefined ? {} : { indexes: schema.indexes }),
+    ...(schema.runtimeDocument === undefined ?
+      {}
+    : { runtimeDocument: schema.runtimeDocument }),
+    ...(schema.deprecatedKinds === undefined ?
+      {}
+    : { deprecatedKinds: schema.deprecatedKinds }),
   };
 
   // Serialize with sorted keys for deterministic output

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -570,6 +570,15 @@ export const serializedSchemaZod = z.object({
    * without breaking older readers.
    */
   runtimeDocument: runtimeGraphDocumentZod.optional(),
+  /**
+   * Names of node and edge kinds the operator has soft-deprecated via
+   * `store.deprecateKinds(...)`. Surfaces in introspection so consumers
+   * (codegen, UI tooling, lints) can route around them. Does not affect
+   * reads, writes, or queries.
+   *
+   * Omitted when empty so legacy schemas hash byte-identically.
+   */
+  deprecatedKinds: z.array(z.string()).optional(),
 });
 
 /**
@@ -615,6 +624,14 @@ export type SerializedSchema = Readonly<{
    * — legacy schemas hash byte-identically.
    */
   runtimeDocument?: RuntimeGraphDocument;
+  /**
+   * Soft-deprecated node and edge kind names. Set by
+   * `store.deprecateKinds(...)`; cleared by `store.undeprecateKinds(...)`.
+   * Surfaces in introspection but does not affect reads, writes, or
+   * queries. Omitted entirely when empty so legacy schemas hash
+   * byte-identically.
+   */
+  deprecatedKinds?: readonly string[];
 }>;
 
 // ============================================================

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -34,9 +34,11 @@ import { buildKindRegistry, type KindRegistry } from "../registry";
 import { type RuntimeGraphDocument } from "../runtime/document-types";
 import { mergeRuntimeExtension } from "../runtime/merge";
 import {
+  applyDeprecatedKinds,
   loadActiveSchemaWithBootstrap,
   parseSerializedSchema,
 } from "../schema/manager";
+import { type SerializedSchema } from "../schema/types";
 import { nowIso } from "../utils/date";
 import { generateId } from "../utils/id";
 import { createGraphAlgorithms, type GraphAlgorithms } from "./algorithms";
@@ -175,6 +177,16 @@ export class Store<G extends GraphDef> {
   /** The kind registry for ontology lookups */
   get registry(): KindRegistry {
     return this.#registry;
+  }
+
+  /**
+   * Names of node and edge kinds the operator has soft-deprecated via
+   * `store.deprecateKinds(...)`. Surfaces in introspection so consumers
+   * (codegen, UI tooling, lints) can route around them. Reads, writes,
+   * and queries are unaffected — deprecation is a signal, not a gate.
+   */
+  get deprecatedKinds(): ReadonlySet<string> {
+    return this.#graph.deprecatedKinds;
   }
 
   /** The database backend */
@@ -808,23 +820,19 @@ export class Store<G extends GraphDef> {
       );
     }
 
-    // Catch up to the persisted state first. If another process has
-    // evolved the graph since this Store was constructed, the active
-    // row's runtimeDocument contains kinds that this.#graph doesn't —
-    // applying the new extension on top of the stale local view would
-    // make ensureSchema diff against the persisted schema and treat
-    // the missing-locally kinds as removed (a breaking-change
-    // MigrationError). Auto-merging the stored doc into the baseline
-    // makes evolve self-healing across multi-process races; the CAS
-    // guard inside commitSchemaVersion still serializes the actual
-    // commit. If the stored doc redefines a local runtime kind with a
-    // different shape, the merge throws RUNTIME_KIND_REDEFINITION
-    // here — surfacing the divergence rather than overwriting.
+    // Catch up to the persisted state first (runtime document AND
+    // deprecated set). Without this, a stale store applying an
+    // extension on top of an out-of-date baseline would make
+    // ensureSchema diff against the persisted schema and either treat
+    // missing-locally kinds as removed (breaking MigrationError) or
+    // silently drop another writer's deprecation flags. The CAS guard
+    // inside commitSchemaVersion still serializes the actual commit.
+    // If the stored doc redefines a local runtime kind with a
+    // different shape, the runtime merge throws
+    // RUNTIME_KIND_REDEFINITION here — surfacing the divergence
+    // rather than overwriting.
     const storedSchema = parseSerializedSchema(activeRow.schema_doc);
-    const baselineGraph =
-      storedSchema.runtimeDocument === undefined ?
-        this.#graph
-      : mergeRuntimeExtension(this.#graph, storedSchema.runtimeDocument);
+    const baselineGraph = this.#catchUpToStored(storedSchema);
     const merged = mergeRuntimeExtension(baselineGraph, extension);
 
     // No-op evolve (extension already applied): return `this` so the
@@ -848,6 +856,124 @@ export class Store<G extends GraphDef> {
       autoMigrate: true,
     });
     return this.#cloneWithGraph(merged, options?.ref);
+  }
+
+  /**
+   * Marks the named node and edge kinds as soft-deprecated. Surfaces in
+   * `store.deprecatedKinds` for introspection (codegen, UI tooling,
+   * lints) but does not gate reads, writes, or queries — deprecation
+   * is a signal, not a removal.
+   *
+   * Atomically commits a new schema version through the same primitive
+   * `evolve()` uses, so concurrent deprecate/evolve calls produce
+   * `StaleVersionError | SchemaContentConflictError` race losers that
+   * the caller refetches and retries. Idempotent: re-deprecating a
+   * kind that's already marked is a no-op (no version bump).
+   *
+   * @param names - Node or edge kind names to mark as deprecated.
+   * @param options.ref - Optional handle to be re-pointed atomically
+   *   with the schema commit, mirroring `evolve()`.
+   *
+   * @throws {ConfigurationError} on `DEPRECATE_BEFORE_INITIALIZE` (no
+   *   schema yet) or `DEPRECATE_UNKNOWN_KIND` (name not on the graph).
+   * @throws {StaleVersionError} when another writer has advanced the
+   *   schema since this store was constructed; refetch and retry per
+   *   the same recipe `evolve()` documents.
+   * @throws {SchemaContentConflictError} when a row already exists at
+   *   the target version with a different content hash.
+   */
+  async deprecateKinds(
+    names: readonly string[],
+    options?: Readonly<{ ref?: StoreRef<Store<G>> }>,
+  ): Promise<Store<G>> {
+    return this.#updateDeprecatedKinds("add", names, options);
+  }
+
+  /**
+   * Reverses `deprecateKinds(...)` for the named kinds. Same race +
+   * idempotency semantics: removing a name that isn't currently
+   * deprecated is a no-op for that name (the call as a whole is a
+   * no-op only if every name was already absent).
+   *
+   * @param names - Node or edge kind names to remove from the
+   *   deprecated set.
+   * @param options.ref - Optional handle to be re-pointed atomically
+   *   with the schema commit.
+   *
+   * @throws {ConfigurationError} on `DEPRECATE_BEFORE_INITIALIZE`.
+   * @throws {StaleVersionError} on a CAS race with another writer.
+   * @throws {SchemaContentConflictError} on a same-version content
+   *   conflict.
+   */
+  async undeprecateKinds(
+    names: readonly string[],
+    options?: Readonly<{ ref?: StoreRef<Store<G>> }>,
+  ): Promise<Store<G>> {
+    return this.#updateDeprecatedKinds("remove", names, options);
+  }
+
+  async #updateDeprecatedKinds(
+    direction: "add" | "remove",
+    names: readonly string[],
+    options: Readonly<{ ref?: StoreRef<Store<G>> }> | undefined,
+  ): Promise<Store<G>> {
+    const verb = direction === "add" ? "deprecate" : "undeprecate";
+    const activeRow = await loadActiveSchemaWithBootstrap(
+      this.#backend,
+      this.graphId,
+    );
+    if (activeRow === undefined) {
+      throw new ConfigurationError(
+        `Cannot ${verb} kinds on graph "${this.graphId}": no schema has been initialized. Call createStoreWithSchema first.`,
+        { code: "DEPRECATE_BEFORE_INITIALIZE" },
+      );
+    }
+
+    const storedSchema = parseSerializedSchema(activeRow.schema_doc);
+    const baseline = this.#catchUpToStored(storedSchema);
+    const nextSet = new Set(baseline.deprecatedKinds);
+
+    if (direction === "add") {
+      for (const name of names) {
+        if (!isKnownKind(baseline, name)) {
+          throw new ConfigurationError(
+            `Cannot deprecate unknown kind "${name}" on graph "${this.graphId}". Only kinds declared on the graph (compile-time or runtime) can be deprecated.`,
+            { code: "DEPRECATE_UNKNOWN_KIND" },
+          );
+        }
+        nextSet.add(name);
+      }
+    } else {
+      for (const name of names) nextSet.delete(name);
+    }
+
+    if (setsEqual(nextSet, baseline.deprecatedKinds)) {
+      // True no-op only when the catch-up didn't change anything
+      // either. Otherwise the caller's `this` reference is stale
+      // relative to the persisted state — return a clone of the
+      // caught-up baseline so they pick up another writer's
+      // runtime kinds and deprecation flags.
+      if (baseline === this.#graph) {
+        if (options?.ref !== undefined) options.ref.current = this;
+        return this;
+      }
+      return this.#cloneWithGraph(baseline, options?.ref);
+    }
+
+    const merged = applyDeprecatedKinds(baseline, [...nextSet]);
+    await ensureSchemaImpl(this.#backend, merged, {
+      preloaded: { activeRow, storedSchema },
+      autoMigrate: true,
+    });
+    return this.#cloneWithGraph(merged, options?.ref);
+  }
+
+  #catchUpToStored(storedSchema: SerializedSchema): G {
+    const withRuntime =
+      storedSchema.runtimeDocument === undefined ?
+        this.#graph
+      : mergeRuntimeExtension(this.#graph, storedSchema.runtimeDocument);
+    return applyDeprecatedKinds(withRuntime, storedSchema.deprecatedKinds);
   }
 
   #cloneWithGraph(graph: G, ref: StoreRef<Store<G>> | undefined): Store<G> {
@@ -1027,6 +1153,16 @@ export function createStore<G extends GraphDef>(
   options?: StoreOptions,
 ): Store<G> {
   return new Store(graph, backend, options);
+}
+
+function isKnownKind(graph: GraphDef, name: string): boolean {
+  return Object.hasOwn(graph.nodes, name) || Object.hasOwn(graph.edges, name);
+}
+
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) if (!b.has(value)) return false;
+  return true;
 }
 
 // ============================================================

--- a/packages/typegraph/tests/migration-diff.test.ts
+++ b/packages/typegraph/tests/migration-diff.test.ts
@@ -1201,6 +1201,36 @@ describe("computeSchemaDiff", () => {
       expect(diff.summary).toContain("1 removed");
       expect(diff.summary).toContain("Edges:");
     });
+
+    it("includes deprecated kinds in the summary when only deprecation changed", () => {
+      const before = createSchema({ version: 1 });
+      const after = createSchema({
+        version: 2,
+        deprecatedKinds: ["Person", "Company"],
+      });
+
+      const diff = computeSchemaDiff(before, after);
+
+      expect(diff.hasChanges).toBe(true);
+      expect(diff.summary).toContain("Deprecated kinds");
+      expect(diff.summary).toContain("2 added");
+      expect(diff.summary).toContain("0 removed");
+    });
+
+    it("includes runtime document in the summary when only it changed", () => {
+      const before = createSchema({ version: 1 });
+      const after = createSchema({
+        version: 2,
+        runtimeDocument: {
+          nodes: { Tag: { properties: { label: { type: "string" } } } },
+        },
+      });
+
+      const diff = computeSchemaDiff(before, after);
+
+      expect(diff.hasChanges).toBe(true);
+      expect(diff.summary).toContain("Runtime document");
+    });
   });
 
   // ============================================================

--- a/packages/typegraph/tests/store-deprecate-kinds.test.ts
+++ b/packages/typegraph/tests/store-deprecate-kinds.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for `store.deprecateKinds(...)` and `store.undeprecateKinds(...)`.
+ *
+ * Deprecation is a soft signal: the kind set surfaces in
+ * `store.deprecatedKinds` for introspection but doesn't gate reads,
+ * writes, or queries. Persistence round-trips through the schema
+ * document; restart parity verified by re-loading via
+ * `createStoreWithSchema`.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph } from "../src/core/define-graph";
+import { defineNode } from "../src/core/node";
+import {
+  ConfigurationError,
+  SchemaContentConflictError,
+  StaleVersionError,
+} from "../src/errors";
+import { defineRuntimeExtension } from "../src/runtime";
+import { createStore, createStoreWithSchema } from "../src/store/store";
+import { type StoreRef } from "../src/store/types";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const baseGraph = defineGraph({
+  id: "deprecate_kinds",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+describe("Store.deprecateKinds — basic flow", () => {
+  it("marks a compile-time kind deprecated and bumps schema version", async () => {
+    const backend = createTestBackend();
+    const [store, init] = await createStoreWithSchema(baseGraph, backend);
+    expect(init).toEqual({ status: "initialized", version: 1 });
+
+    expect(store.deprecatedKinds.size).toBe(0);
+
+    const evolved = await store.deprecateKinds(["Person"]);
+    expect(evolved.deprecatedKinds.has("Person")).toBe(true);
+
+    const active = await backend.getActiveSchema(baseGraph.id);
+    expect(active?.version).toBe(2);
+    expect(active?.schema_doc).toContain('"deprecatedKinds"');
+  });
+
+  it("marks runtime kinds deprecated alongside compile-time kinds", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const withTag = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+    const deprecated = await withTag.deprecateKinds(["Tag"]);
+
+    expect(deprecated.deprecatedKinds.has("Tag")).toBe(true);
+    expect(deprecated.deprecatedKinds.has("Person")).toBe(false);
+  });
+
+  it("is idempotent on re-deprecating an already-deprecated kind (no version bump)", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const first = await store.deprecateKinds(["Person"]);
+    const firstActive = await backend.getActiveSchema(baseGraph.id);
+
+    const second = await first.deprecateKinds(["Person"]);
+    const secondActive = await backend.getActiveSchema(baseGraph.id);
+
+    expect(secondActive?.version).toBe(firstActive?.version);
+    expect(second.deprecatedKinds.has("Person")).toBe(true);
+  });
+
+  it("rejects deprecating an unknown kind", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const caught = await store
+      .deprecateKinds(["NotAKind"])
+      .catch((error: unknown) => error);
+    expect(caught).toBeInstanceOf(ConfigurationError);
+    expect((caught as ConfigurationError).details).toMatchObject({
+      code: "DEPRECATE_UNKNOWN_KIND",
+    });
+  });
+
+  it("rejects deprecate before any schema has been initialized", async () => {
+    const backend = createTestBackend();
+    const store = createStore(baseGraph, backend);
+    await expect(store.deprecateKinds(["Person"])).rejects.toBeInstanceOf(
+      ConfigurationError,
+    );
+  });
+
+  it("does not affect reads or writes on the deprecated kind", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const deprecated = await store.deprecateKinds(["Person"]);
+
+    const alice = await deprecated.nodes.Person.create({ name: "alice" });
+    const fetched = await deprecated.nodes.Person.getById(alice.id);
+    expect(fetched?.name).toBe("alice");
+    expect(deprecated.deprecatedKinds.has("Person")).toBe(true);
+  });
+});
+
+describe("Store.undeprecateKinds", () => {
+  it("removes a kind from the deprecated set and bumps version", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    const deprecated = await store.deprecateKinds(["Person"]);
+    expect(deprecated.deprecatedKinds.has("Person")).toBe(true);
+
+    const restored = await deprecated.undeprecateKinds(["Person"]);
+    expect(restored.deprecatedKinds.has("Person")).toBe(false);
+
+    const active = await backend.getActiveSchema(baseGraph.id);
+    expect(active?.version).toBe(3);
+  });
+
+  it("is a no-op when the kind isn't currently deprecated", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    // Person isn't deprecated; undeprecating is a no-op.
+    const same = await store.undeprecateKinds(["Person"]);
+    const active = await backend.getActiveSchema(baseGraph.id);
+
+    expect(same.deprecatedKinds.size).toBe(0);
+    expect(active?.version).toBe(1);
+  });
+});
+
+describe("Store.deprecateKinds — concurrency + StoreRef", () => {
+  it("two concurrent deprecate calls produce one winner and one race-loser", async () => {
+    const backend = createTestBackend();
+    const [storeA] = await createStoreWithSchema(baseGraph, backend);
+    const [storeB] = await createStoreWithSchema(baseGraph, backend);
+
+    const Tag = await storeA.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+    const [storeBevolved] = await createStoreWithSchema(baseGraph, backend);
+    void storeB;
+
+    const results = await Promise.allSettled([
+      Tag.deprecateKinds(["Person"]),
+      storeBevolved.deprecateKinds(["Tag"]),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const reason = rejected[0]!.reason as Error;
+    const isExpected =
+      reason instanceof StaleVersionError ||
+      reason instanceof SchemaContentConflictError;
+    expect(isExpected).toBe(true);
+  });
+
+  it("deprecateKinds(names, { ref }) re-points the consumer-composed ref", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const ref: StoreRef<typeof store> = { current: store };
+
+    const evolved = await ref.current.deprecateKinds(["Person"], { ref });
+
+    expect(ref.current).toBe(evolved);
+    expect(ref.current.deprecatedKinds.has("Person")).toBe(true);
+  });
+});
+
+describe("Cross-flow safety: deprecate × evolve", () => {
+  // The bug this guards against: a stale store's evolve dropped
+  // another writer's deprecation set because evolve's catch-up only
+  // merged the runtime document, not the deprecated set. Without the
+  // fix, this test would commit a v3 schema with deprecatedKinds
+  // empty — silently rolling back B's deprecation.
+  it("stale evolve preserves another writer's persisted deprecations", async () => {
+    const backend = createTestBackend();
+    const [storeA] = await createStoreWithSchema(baseGraph, backend);
+    const [storeB] = await createStoreWithSchema(baseGraph, backend);
+
+    // B deprecates Person (v2). A is now stale.
+    await storeB.deprecateKinds(["Person"]);
+
+    // A evolves with a new Tag kind. The catch-up MUST include B's
+    // deprecation set, otherwise the resulting schema would lose the
+    // "Person is deprecated" signal.
+    const evolved = await storeA.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+
+    expect(evolved.deprecatedKinds.has("Person")).toBe(true);
+    expect(evolved.registry.hasNodeType("Tag")).toBe(true);
+
+    // Persisted form carries both — verifiable via fresh restart.
+    const [restored] = await createStoreWithSchema(baseGraph, backend);
+    expect(restored.deprecatedKinds.has("Person")).toBe(true);
+    expect(restored.registry.hasNodeType("Tag")).toBe(true);
+  });
+
+  it("idempotent deprecate against an already-persisted set still surfaces stored runtime kinds", async () => {
+    // Bug guarded: a stale store calling deprecateKinds with a name
+    // that's already in the persisted set was returning `this`
+    // unchanged, so the caller never saw runtime kinds another writer
+    // had added. The fix returns a clone of the caught-up baseline
+    // even on the no-op path.
+    const backend = createTestBackend();
+    const [storeA] = await createStoreWithSchema(baseGraph, backend);
+    const [storeB] = await createStoreWithSchema(baseGraph, backend);
+
+    // B evolves with Tag and deprecates Person.
+    const evolvedB = await storeB.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+    await evolvedB.deprecateKinds(["Person"]);
+
+    // A is stale. Calling deprecateKinds(["Person"]) is a no-op
+    // against the persisted set — but A must still pick up Tag from
+    // B's evolve. Without the catch-up clone, A would return its
+    // stale `this` and the caller would never see Tag.
+    const result = await storeA.deprecateKinds(["Person"]);
+
+    expect(result.deprecatedKinds.has("Person")).toBe(true);
+    expect(result.registry.hasNodeType("Tag")).toBe(true);
+    expect(result).not.toBe(storeA);
+  });
+});
+
+describe("Persistence + restart parity", () => {
+  it("deprecation survives a fresh createStoreWithSchema", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    await store.deprecateKinds(["Person"]);
+
+    // Different process / store instance reads the schema back. The
+    // loader (`loadAndMergeRuntimeDocument`) applies persisted
+    // deprecations to the merged graph.
+    const [restored, restoredResult] = await createStoreWithSchema(
+      baseGraph,
+      backend,
+    );
+    expect(restoredResult.status).toBe("unchanged");
+    expect(restored.deprecatedKinds.has("Person")).toBe(true);
+  });
+
+  it("graphs that never deprecated anything hash byte-identically to legacy", async () => {
+    // The deprecatedKinds slice must be omitted entirely when empty,
+    // so hashing a freshly-defined graph produces no `deprecatedKinds`
+    // key in the canonical document.
+    const { computeSchemaHash, serializeSchema } =
+      await import("../src/schema/serializer");
+    const { sortedReplacer } = await import("../src/schema/canonical");
+
+    const serialized = serializeSchema(baseGraph, 1);
+    expect("deprecatedKinds" in serialized).toBe(false);
+    const canonical = JSON.stringify(serialized, sortedReplacer);
+    expect(canonical).not.toContain('"deprecatedKinds"');
+
+    // Sanity: hash is non-empty and stable on this graph.
+    const hash = await computeSchemaHash(serialized);
+    expect(hash).toMatch(/^[a-f0-9]+$/);
+  });
+});


### PR DESCRIPTION
Adds the soft-deprecation primitive folded out of PR #110. Library-owned per-graph kind set persisted in `schema_doc.deprecatedKinds`, surfaces in `store.deprecatedKinds` for introspection, does not affect reads, writes, or queries. Bumps the schema version like any other change.

```typescript
const [store] = await createStoreWithSchema(graph, backend);

// Mark a kind as deprecated. Surfaces in introspection (codegen, UI
// tooling, lints) but reads/writes still work normally.
const evolved = await store.deprecateKinds(["LegacyDocument"]);
console.log([...evolved.deprecatedKinds]); // ["LegacyDocument"]

// Reverse it.
const restored = await evolved.undeprecateKinds(["LegacyDocument"]);

// Works on both compile-time and runtime kinds. Pass `{ ref }` for
// the standard StoreRef re-binding pattern, same as `evolve()`.
```

## Public API

- `Store.deprecateKinds(names, options?: { ref?: StoreRef<Store<G>> })` — async, atomically commits a new schema version with `names` added to the persisted set. Idempotent: re-deprecating an already-deprecated kind is a no-op (no version bump). Throws `ConfigurationError` (`code: "DEPRECATE_UNKNOWN_KIND"`) if any name doesn't match a known compile-time or runtime kind on the catchup-merged baseline.
- `Store.undeprecateKinds(names, options?)` — symmetric reverse.
- `Store.deprecatedKinds: ReadonlySet<string>` — getter for introspection.
- `SchemaDiff.deprecatedKinds?: DeprecatedKindsChange` — diff classification (always `safe`-severity); `added` / `removed` arrays carry the per-name deltas.
- `applyDeprecatedKinds(graph, names)` exported from `@nicia-ai/typegraph/schema` for advanced consumers.

## Storage

- New top-level slice on `SerializedSchema`: `deprecatedKinds?: readonly string[]` (sorted for canonical-form stability).
- Omitted entirely when empty so legacy schemas hash byte-identically.
- Loader (`loadAndMergeRuntimeDocument`) applies the persisted set onto the merged graph alongside the runtime extension document.

## Bug fix included

`computeSchemaHash` was building its hashable subset by enumerating fields and was missing both `runtimeDocument` and `deprecatedKinds`. For runtime extensions the omission didn't matter in practice (the merged graph's `nodes`/`edges` always changed on `evolve()`), but for deprecation (metadata only), the missing slot meant the hash stayed identical and `ensureSchema` returned `unchanged` instead of migrating. Fixed: both slices are now part of the hashable subset, with the same omit-when-empty rule.

## Concurrency + multi-process safety

Same primitive as `Store.evolve()`: `commitSchemaVersion` CAS on the active version. Concurrent deprecate/evolve calls produce one winner; the loser surfaces `StaleVersionError` or `SchemaContentConflictError`. The internal `#catchUpToStored` helper folds the persisted runtime document AND deprecated set into the local baseline before computing the next state — same auto-merge approach `evolve()` uses.

## Out of scope

- **Removal of runtime-declared kinds.** Deprecation is the soft-signal alternative; full runtime-kind removal remains its own future design.
- **Hard-blocking reads/writes on deprecated kinds.** Deprecation is informational; consumers wrap collection access if they want strict enforcement.

Closes the originally-folded `deprecateKinds` scope from #110 / issue #101.
