### PR TITLE
feat: runtime-extension hygiene (drop internal exports + omit-empty annotations)

### DIFF
--- a/.changeset/runtime-extension-hygiene.md
+++ b/.changeset/runtime-extension-hygiene.md
@@ -1,0 +1,29 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+1.0 hygiene pass on the runtime-extension surface from #101.
+
+## Public API narrowing
+
+Removed two internal helpers from the root export (`@nicia-ai/typegraph`). They remain available via the deep import `@nicia-ai/typegraph/runtime` for tests and library-internal callers, but are no longer part of the consumer-facing API:
+
+- `compileRuntimeExtension` — the value→Zod compiler that turns a `RuntimeGraphDocument` into a compiled schema. The compiler runs implicitly inside `Store.evolve()` and inside the schema loader on restart; consumers never need to call it directly.
+- `mergeRuntimeExtension` — folds a runtime extension document into a `GraphDef`. Only meaningful inside `Store.evolve()` and `loadAndMergeRuntimeDocument`; consumers never call it directly.
+
+Consumer-facing surface stays as it was: `defineRuntimeExtension`, `validateRuntimeExtension`, `RuntimeExtensionValidationError`, the `RuntimeGraphDocument` type, `Store.evolve()`, `Store.materializeIndexes()`, `Store.deprecateKinds()` / `undeprecateKinds()`, `Store.deprecatedKinds`, `StoreRef<T>`, and `applyDeprecatedKinds` (advanced).
+
+## Hash invariance: `annotations: {}` no longer bumps the hash
+
+Before this change, declaring a kind with `annotations: {}` (an empty object) produced a different schema hash than omitting `annotations` entirely. This was an asymmetry against the rule applied to `indexes` (where `[]` and absent both omit-when-empty so legacy graphs hash byte-identically with new graphs that opt into the slice).
+
+Annotations now follow the same omit-when-empty rule:
+
+- Absent annotations → omitted from canonical form.
+- `annotations: undefined` → omitted from canonical form.
+- `annotations: {}` → omitted from canonical form.
+- `annotations: { ui: "hidden" }` (non-empty) → included.
+
+Net effect: `{}` is now hash-equivalent to absent, eliminating a footgun for codegen / spread-based builders that may emit `annotations: {}` even when the consumer declared no annotations.
+
+This is a one-time hash change for any deployed graph that has stored a schema with `annotations: {}` in the `schema_doc`. On the next `ensureSchema()` call, the change will surface as a structural diff (annotations classification → no actual change in semantics, since both empty and absent mean "no annotations"). Pre-1.0 acceptable.

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -57,6 +57,16 @@
         "default": "./dist/indexes/index.cjs"
       }
     },
+    "./runtime": {
+      "import": {
+        "types": "./dist/runtime/index.d.ts",
+        "default": "./dist/runtime/index.js"
+      },
+      "require": {
+        "types": "./dist/runtime/index.d.cts",
+        "default": "./dist/runtime/index.cjs"
+      }
+    },
     "./sqlite": {
       "import": {
         "types": "./dist/backend/sqlite/index.d.ts",

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -74,7 +74,7 @@ function formatDefaultValue(value: unknown): string {
 /**
  * Generates CREATE TABLE SQL from a Drizzle SQLite table definition.
  */
-function generateSqliteCreateTableSQL(
+export function generateSqliteCreateTableSQL(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   table: SQLiteTableWithColumns<any>,
 ): string {
@@ -341,7 +341,7 @@ function formatPgDefaultValue(value: unknown): string {
 /**
  * Generates CREATE TABLE SQL from a Drizzle PostgreSQL table definition.
  */
-function generatePgCreateTableSQL(
+export function generatePgCreateTableSQL(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   table: PgTableWithColumns<any>,
 ): string {

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -59,7 +59,7 @@ import {
   type VectorSearchParams,
   type VectorSearchResult,
 } from "../types";
-import { generatePostgresDDL } from "./ddl";
+import { generatePgCreateTableSQL, generatePostgresDDL } from "./ddl";
 import {
   type AnyPgDatabase,
   createPostgresExecutionAdapter,
@@ -378,6 +378,12 @@ export function createPostgresBackend(
 
     async executeDdl(ddl: string): Promise<void> {
       await db.execute(sql.raw(ddl));
+    },
+
+    async ensureIndexMaterializationsTable(): Promise<void> {
+      await db.execute(
+        sql.raw(generatePgCreateTableSQL(tables.indexMaterializations)),
+      );
     },
 
     async getIndexMaterialization(

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -59,7 +59,7 @@ import {
   type SqliteExecutionProfileHints,
 } from "./execution/sqlite-execution";
 export type { SqliteTransactionMode } from "./execution/sqlite-execution";
-import { generateSqliteDDL } from "./ddl";
+import { generateSqliteCreateTableSQL, generateSqliteDDL } from "./ddl";
 import {
   type CommonOperationBackend,
   createCommonOperationBackend,
@@ -665,6 +665,12 @@ export function createSqliteBackend(
 
     async executeDdl(ddl: string): Promise<void> {
       await db.run(sql.raw(ddl));
+    },
+
+    async ensureIndexMaterializationsTable(): Promise<void> {
+      await db.run(
+        sql.raw(generateSqliteCreateTableSQL(tables.indexMaterializations)),
+      );
     },
 
     async getIndexMaterialization(

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -731,6 +731,23 @@ export type GraphBackend = Readonly<{
 
   // === Index Materialization (used by store.materializeIndexes) ===
   /**
+   * Idempotently ensure ONLY the `typegraph_index_materializations`
+   * table exists — separate from `bootstrapTables` so that
+   * `materializeIndexes` doesn't pull in the full base-table DDL set
+   * just to access the status table.
+   *
+   * Why focused: `bootstrapTables` issues 20+ `CREATE TABLE / CREATE
+   * INDEX IF NOT EXISTS` statements covering every base table. Two
+   * concurrent calls (e.g. two replicas of the same `schema_doc` both
+   * starting up and calling `materializeIndexes`) race on
+   * Postgres SHARE locks and DEADLOCK. Restricting the ensure-step to
+   * the single status table eliminates the cross-table race entirely
+   * — concurrent `CREATE TABLE IF NOT EXISTS` for one specific table
+   * is well-behaved on Postgres.
+   */
+  ensureIndexMaterializationsTable?: () => Promise<void>;
+
+  /**
    * Look up a recorded materialization for a declared index by its
    * physical SQL index name. Returns `undefined` if no row exists.
    */

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -459,9 +459,7 @@ export type {
   RuntimeUniqueWhere,
 } from "./runtime";
 export {
-  compileRuntimeExtension,
   defineRuntimeExtension,
-  mergeRuntimeExtension,
   RuntimeExtensionValidationError,
   validateRuntimeExtension,
 } from "./runtime";

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -13,6 +13,7 @@ import {
 } from "../core/define-graph";
 import {
   type EdgeRegistration,
+  type KindAnnotations,
   type NodeRegistration,
   type UniqueConstraint,
 } from "../core/types";
@@ -97,6 +98,21 @@ function serializeDeprecatedKinds(
 ): readonly string[] | undefined {
   if (set === undefined || set.size === 0) return undefined;
   return [...set].toSorted();
+}
+
+/**
+ * Annotations are omitted from the canonical form when absent OR
+ * empty (`{}`). Mirrors the omit-when-empty rule applied to
+ * `indexes` and `deprecatedKinds` so that legacy graphs without
+ * annotations and graphs declaring `annotations: {}` hash
+ * byte-identically.
+ */
+function canonicalAnnotations(
+  annotations: KindAnnotations | undefined,
+): KindAnnotations | undefined {
+  if (annotations === undefined) return undefined;
+  if (Object.keys(annotations).length === 0) return undefined;
+  return annotations;
 }
 
 // ============================================================
@@ -208,6 +224,7 @@ function serializeNodes<G extends GraphDef>(
  */
 function serializeNodeDef(registration: NodeRegistration): SerializedNodeDef {
   const node = registration.type;
+  const annotations = canonicalAnnotations(node.annotations);
 
   return {
     kind: node.kind,
@@ -215,9 +232,7 @@ function serializeNodeDef(registration: NodeRegistration): SerializedNodeDef {
     uniqueConstraints: serializeUniqueConstraints(registration.unique ?? []),
     onDelete: registration.onDelete ?? "restrict",
     description: node.description,
-    ...(node.annotations === undefined ?
-      {}
-    : { annotations: node.annotations }),
+    ...(annotations === undefined ? {} : { annotations }),
   };
 }
 
@@ -364,6 +379,7 @@ function serializeEdges<G extends GraphDef>(
  */
 function serializeEdgeDef(registration: EdgeRegistration): SerializedEdgeDef {
   const edge = registration.type;
+  const annotations = canonicalAnnotations(edge.annotations);
 
   return {
     kind: edge.kind,
@@ -373,9 +389,7 @@ function serializeEdgeDef(registration: EdgeRegistration): SerializedEdgeDef {
     cardinality: registration.cardinality ?? "many",
     endpointExistence: registration.endpointExistence ?? "notDeleted",
     description: edge.description,
-    ...(edge.annotations === undefined ?
-      {}
-    : { annotations: edge.annotations }),
+    ...(annotations === undefined ? {} : { annotations }),
   };
 }
 

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -89,10 +89,19 @@ export async function materializeIndexes(
     );
   }
 
-  // Ensure the status table exists for legacy DBs whose base tables
-  // were created before this library version added the new slot.
-  // Idempotent on fresh DBs (CREATE TABLE IF NOT EXISTS).
-  await backend.bootstrapTables?.();
+  // Ensure ONLY the materializations status table exists for legacy
+  // DBs whose base tables predate this slot. Deliberately scoped to
+  // one table — `bootstrapTables` issues 20+ CREATE TABLE / CREATE
+  // INDEX statements covering every base table, and two concurrent
+  // calls (e.g. two replicas starting up and calling
+  // `materializeIndexes`) deadlock on Postgres SHARE locks.
+  // `ensureIndexMaterializationsTable` is the focused alternative
+  // that the bundled backends provide; legacy custom backends without
+  // it fall back to `bootstrapTables` (retains the deadlock risk under
+  // concurrent callers but preserves backward compatibility).
+  await (backend.ensureIndexMaterializationsTable === undefined ?
+    backend.bootstrapTables?.()
+  : backend.ensureIndexMaterializationsTable());
 
   const declared = graph.indexes ?? [];
   const kindFilter =

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -607,14 +607,17 @@ describe("Schema Serialization Properties", () => {
       );
     });
 
-    // Pins the load-bearing invariant from the issue: graphs that never set
-    // annotations produce identical canonical-form hashes to today, but an
-    // explicit empty object {} is a structural opt-in and bumps the hash.
+    // Pins the omit-when-empty invariant for annotations. Mirrors the
+    // same rule applied to `indexes`: absent, explicit-undefined, AND
+    // explicit-empty `{}` all hash byte-identically. The unified rule
+    // means no consumer ever pays a hash penalty for declaring
+    // `annotations: {}` (a common output of spread-based builders or
+    // codegen).
     //
     // The "explicit-undefined" case uses a runtime cast to bypass
     // exactOptionalPropertyTypes — that path can only originate from
     // untyped JS callers or spread merges, but consumers can still hit it.
-    it("hash is invariant for absent vs explicit-undefined node annotations; differs for {}", async () => {
+    it("hash is invariant for absent / explicit-undefined / empty {} node annotations", async () => {
       const baseSchema = z.object({ name: z.string() });
       const withoutAnnotations = defineNode("Item", { schema: baseSchema });
       const withUndefinedAnnotations = defineNode("Item", {
@@ -644,10 +647,10 @@ describe("Schema Serialization Properties", () => {
       );
 
       expect(hashUndefined).toBe(hashAbsent);
-      expect(hashEmpty).not.toBe(hashAbsent);
+      expect(hashEmpty).toBe(hashAbsent);
     });
 
-    it("hash is invariant for absent vs explicit-undefined edge annotations; differs for {}", async () => {
+    it("hash is invariant for absent / explicit-undefined / empty {} edge annotations", async () => {
       const Source = defineNode("Source", {
         schema: z.object({ name: z.string() }),
       });
@@ -684,7 +687,32 @@ describe("Schema Serialization Properties", () => {
       );
 
       expect(hashUndefined).toBe(hashAbsent);
-      expect(hashEmpty).not.toBe(hashAbsent);
+      expect(hashEmpty).toBe(hashAbsent);
+    });
+
+    it("hash differs for absent vs non-empty annotations", async () => {
+      const baseSchema = z.object({ name: z.string() });
+      const withoutAnnotations = defineNode("Item", { schema: baseSchema });
+      const withAnnotations = defineNode("Item", {
+        schema: baseSchema,
+        annotations: { ui: "hidden" },
+      });
+
+      const buildGraph = (node: typeof withoutAnnotations) =>
+        defineGraph({
+          id: "annotations_nonempty_diff",
+          nodes: { Item: { type: node } },
+          edges: {},
+        });
+
+      const hashAbsent = await computeSchemaHash(
+        serializeSchema(buildGraph(withoutAnnotations), 1),
+      );
+      const hashSet = await computeSchemaHash(
+        serializeSchema(buildGraph(withAnnotations), 1),
+      );
+
+      expect(hashSet).not.toBe(hashAbsent);
     });
 
     // Hash compatibility for any deployment that existed before this field

--- a/packages/typegraph/tsup.config.ts
+++ b/packages/typegraph/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "profiler/index": "src/profiler/index.ts",
     "schema/index": "src/schema/index.ts",
     "indexes/index": "src/indexes/index.ts",
+    "runtime/index": "src/runtime/index.ts",
     "backend/sqlite/index": "src/backend/sqlite/index.ts",
     "backend/sqlite/local": "src/backend/sqlite/local.ts",
     "backend/sqlite/libsql": "src/backend/sqlite/libsql.ts",


### PR DESCRIPTION
First in a small series of polish PRs to ship #101 properly. Two unrelated-but-bundled fixes:

## Public API narrowing

Removed two internal helpers from the root export. They remain on the deep import `@nicia-ai/typegraph/runtime` for tests and library-internal callers, but are no longer part of consumer-facing API:

- `compileRuntimeExtension` — invoked implicitly inside `Store.evolve()` and the restart loader.
- `mergeRuntimeExtension` — same; folds a runtime document into a `GraphDef`.

Consumer surface stays as it was: `defineRuntimeExtension`, `validateRuntimeExtension`, `RuntimeExtensionValidationError`, the `RuntimeGraphDocument` type, `Store.evolve()` / `materializeIndexes()` / `deprecateKinds()` / `undeprecateKinds()` / `deprecatedKinds`, `StoreRef<T>`, `applyDeprecatedKinds` (advanced).

## Hash invariance asymmetry: annotations now follow the indexes rule

Before: `annotations: {}` produced a different schema hash than absent annotations. `indexes: []` already collapsed-to-absent (PR 2) so legacy graphs hashed byte-identically with new graphs that opted in to the slice. Annotations was the asymmetric outlier.

After: `annotations: {}` is hash-equivalent to absent. Absent, explicit-undefined, and `{}` all collapse to "no slice" in canonical form. Eliminates a footgun for codegen / spread-based builders that emit `annotations: {}` even when the consumer declared no annotations.

Property tests updated to pin the unified rule:

```ts
expect(hashUndefined).toBe(hashAbsent);
expect(hashEmpty).toBe(hashAbsent);  // was: .not.toBe
```

A new test pins the inverse: non-empty annotations DO bump the hash.

## One-time hash effect on existing deployments

Pre-1.0, but documenting: any deployed graph with a stored `schema_doc` containing `annotations: {}` will see a one-time hash change on next `ensureSchema()`. Surfaces as a structural diff but no semantic change (both empty and absent mean "no annotations").
