### PR TITLE
feat: eager flag on Store.evolve() for one-call schema-commit + materialize

### DIFF
--- a/.changeset/evolve-eager-materialize.md
+++ b/.changeset/evolve-eager-materialize.md
@@ -1,0 +1,52 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `eager` option to `Store.evolve()` for one-call schema-commit + index-materialize. Closes the eager-mode follow-up from #101 / PR 6.
+
+```typescript
+// All-in-one: commit the schema and materialize all declared indexes.
+const evolved = await store.evolve(extension, { eager: true });
+
+// Pass through MaterializeIndexesOptions for finer control. v1
+// runtime extensions don't carry relational indexes, so the kinds
+// filter only meaningfully restricts to compile-time kinds.
+const evolved = await store.evolve(extension, {
+  eager: { kinds: ["Document"], stopOnError: true },
+});
+```
+
+## Semantics
+
+- Eager mode runs `materializeIndexes()` AFTER the schema commit succeeds. The schema-version write is **not** rolled back if materialization produces failed entries — eager is a convenience, not a transaction.
+- On per-index failure, `evolve()` throws `EagerMaterializationError` AFTER the new `Store` is constructed and `ref.current` is updated. The caller can recover via the ref handle:
+
+```typescript
+const ref = { current: store };
+try {
+  await store.evolve(extension, { ref, eager: true });
+} catch (error) {
+  if (error instanceof EagerMaterializationError) {
+    // Schema is committed; ref.current is the new store.
+    log.warn(
+      { failed: error.failedIndexNames },
+      "indexes did not materialize; will retry",
+    );
+    await ref.current.materializeIndexes();
+  } else {
+    throw error;
+  }
+}
+```
+
+- `eager: false` (the default) preserves the existing behavior — `evolve()` returns the new `Store` immediately and the consumer calls `materializeIndexes()` separately if they need to.
+- `eager` accepts `boolean | MaterializeIndexesOptions`. Passing an object lets you scope to specific kinds or set `stopOnError`.
+
+## API additions
+
+- `Store.evolve(extension, options?)` — `options.eager?: boolean | MaterializeIndexesOptions`.
+- `EagerMaterializationError` — new error class exported from `@nicia-ai/typegraph`. Carries `materialization: MaterializeIndexesResult` (full result) and `failedIndexNames: readonly string[]` (convenience). `code: "EAGER_MATERIALIZATION_FAILED"`.
+
+## When to use eager
+
+The flag is dev-loop convenience and one-off scripts. Production code that wants nuanced failure handling (per-index retries, alerting on specific failures, deferred materialization) should keep the explicit two-call pattern: `await store.evolve(ext)` then `await store.materializeIndexes()` separately. The single-call shape pays for itself when the surrounding code doesn't care about distinguishing schema commits from index materializations — a single throw / no-throw signal is enough.

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -22,6 +22,11 @@
  * ```
  */
 
+// Type-only import: `materialize-indexes.ts` value-imports
+// `ConfigurationError` from this file, but type-only imports are erased
+// at runtime so this back-edge does not create a value cycle.
+import type { MaterializeIndexesResult } from "../store/materialize-indexes";
+
 // ============================================================
 // Types
 // ============================================================
@@ -574,6 +579,77 @@ export class MigrationError extends TypeGraphError {
     });
     this.name = "MigrationError";
   }
+}
+
+/**
+ * Thrown by `Store.evolve(extension, { eager: true })` when the schema
+ * commit succeeded but the follow-on `materializeIndexes()` produced
+ * one or more failed entries.
+ *
+ * Recovery: the schema commit is NOT rolled back. The new `Store` is
+ * fully constructed and (when `options.ref` was supplied) `ref.current`
+ * already points to it — the caller can read the new store via the ref
+ * and decide how to handle the failed indexes (retry, skip, alert).
+ * The full `MaterializeIndexesResult` is attached as `.materialization`.
+ *
+ * @example
+ * ```ts
+ * const ref = { current: store };
+ * try {
+ *   await store.evolve(extension, { ref, eager: true });
+ * } catch (error) {
+ *   if (error instanceof EagerMaterializationError) {
+ *     // schema is committed; ref.current is the new store
+ *     log.warn(
+ *       { failed: error.failedIndexNames },
+ *       "indexes did not materialize; will retry",
+ *     );
+ *     await ref.current.materializeIndexes();
+ *   } else {
+ *     throw error;
+ *   }
+ * }
+ * ```
+ */
+export class EagerMaterializationError extends TypeGraphError {
+  /**
+   * The full materialization result, including successful and failed
+   * entries. Same shape as `Store.materializeIndexes()` returns.
+   */
+  readonly materialization: MaterializeIndexesResult;
+
+  constructor(materialization: MaterializeIndexesResult, graphId: string) {
+    const names = collectFailedIndexNames(materialization);
+    super(
+      `Eager materialization failed for ${names.length} index(es) on graph "${graphId}": ${names.join(", ")}. The schema commit succeeded; the new Store is available via the ref handle (when supplied) and the failed indexes can be retried via store.materializeIndexes().`,
+      "EAGER_MATERIALIZATION_FAILED",
+      {
+        details: { graphId, failedIndexNames: names },
+        category: "system",
+        suggestion: `Inspect error.materialization for per-index errors. Each failure preserves any prior successful materialization timestamp; the schema is committed regardless.`,
+      },
+    );
+    this.name = "EagerMaterializationError";
+    this.materialization = materialization;
+  }
+
+  /**
+   * Names of just the indexes that failed — derived from
+   * `materialization.results` so the two views can never disagree.
+   */
+  get failedIndexNames(): readonly string[] {
+    return collectFailedIndexNames(this.materialization);
+  }
+}
+
+function collectFailedIndexNames(
+  materialization: MaterializeIndexesResult,
+): readonly string[] {
+  const names: string[] = [];
+  for (const entry of materialization.results) {
+    if (entry.status === "failed") names.push(entry.indexName);
+  }
+  return names;
 }
 
 /**

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -198,6 +198,7 @@ export {
   ConfigurationError,
   DatabaseOperationError,
   DisjointError,
+  EagerMaterializationError,
   EdgeNotFoundError,
   EndpointError,
   EndpointNotFoundError,

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -89,20 +89,6 @@ export async function materializeIndexes(
     );
   }
 
-  // Ensure ONLY the materializations status table exists for legacy
-  // DBs whose base tables predate this slot. Deliberately scoped to
-  // one table — `bootstrapTables` issues 20+ CREATE TABLE / CREATE
-  // INDEX statements covering every base table, and two concurrent
-  // calls (e.g. two replicas starting up and calling
-  // `materializeIndexes`) deadlock on Postgres SHARE locks.
-  // `ensureIndexMaterializationsTable` is the focused alternative
-  // that the bundled backends provide; legacy custom backends without
-  // it fall back to `bootstrapTables` (retains the deadlock risk under
-  // concurrent callers but preserves backward compatibility).
-  await (backend.ensureIndexMaterializationsTable === undefined ?
-    backend.bootstrapTables?.()
-  : backend.ensureIndexMaterializationsTable());
-
   const declared = graph.indexes ?? [];
   const kindFilter =
     options.kinds === undefined ? undefined : new Set(options.kinds);
@@ -121,6 +107,29 @@ export async function materializeIndexes(
   const candidates = declared.filter((index) =>
     kindFilter === undefined ? true : kindFilter.has(index.kind),
   );
+
+  // Short-circuit before any I/O when there's nothing to do. The
+  // ensure-step below issues a CREATE TABLE statement — paying that
+  // cost only to return an empty result is wasteful, especially on
+  // the agent-loop pattern where `evolve(sameExt, { eager: true })`
+  // is repeated.
+  if (candidates.length === 0) {
+    return { results: [] };
+  }
+
+  // Ensure ONLY the materializations status table exists for legacy
+  // DBs whose base tables predate this slot. Deliberately scoped to
+  // one table — `bootstrapTables` issues 20+ CREATE TABLE / CREATE
+  // INDEX statements covering every base table, and two concurrent
+  // calls (e.g. two replicas starting up and calling
+  // `materializeIndexes`) deadlock on Postgres SHARE locks.
+  // `ensureIndexMaterializationsTable` is the focused alternative
+  // that the bundled backends provide; legacy custom backends without
+  // it fall back to `bootstrapTables` (retains the deadlock risk under
+  // concurrent callers but preserves backward compatibility).
+  await (backend.ensureIndexMaterializationsTable === undefined ?
+    backend.bootstrapTables?.()
+  : backend.ensureIndexMaterializationsTable());
 
   const dialect = backend.dialect;
   const tableNames = backend.tableNames;

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -20,7 +20,7 @@ import {
   type NodeKinds,
 } from "../core/define-graph";
 import type { NodeId } from "../core/types";
-import { ConfigurationError } from "../errors";
+import { ConfigurationError, EagerMaterializationError } from "../errors";
 import type { TraversalExpansion } from "../query/ast";
 import {
   type BatchableQuery,
@@ -812,7 +812,21 @@ export class Store<G extends GraphDef> {
    */
   async evolve(
     extension: RuntimeGraphDocument,
-    options?: Readonly<{ ref?: StoreRef<Store<G>> }>,
+    options?: Readonly<{
+      ref?: StoreRef<Store<G>>;
+      /**
+       * After the schema commit succeeds, automatically run
+       * `materializeIndexes()` on the new Store. The schema-version
+       * write is NOT rolled back if materialization produces failed
+       * entries — failure surfaces as `EagerMaterializationError` thrown
+       * AFTER the new Store is constructed and `ref.current` is updated,
+       * so the caller can recover via the ref handle.
+       *
+       * Pass `true` for default behavior (all declared indexes,
+       * best-effort) or an options object for finer control.
+       */
+      eager?: boolean | MaterializeIndexesOptions;
+    }>,
   ): Promise<Store<G>> {
     const activeRow = await loadActiveSchemaWithBootstrap(
       this.#backend,
@@ -840,13 +854,19 @@ export class Store<G extends GraphDef> {
     const baselineGraph = this.#catchUpToStored(storedSchema);
     const merged = mergeRuntimeExtension(baselineGraph, extension);
 
-    // No-op evolve (extension already applied): return `this` so the
+    // No-op evolve (extension already applied): reuse `this` so the
     // agent loop's repeated `evolve(sameExt)` keeps warm registry,
     // collection, and query caches instead of discarding them on every
     // call. The reference comparison only holds when both merges
-    // (stored + extension) returned their input unchanged.
+    // (stored + extension) returned their input unchanged. Eager still
+    // runs because the contract is "schema committed AND indexes
+    // materialized" — the local DB may have unmaterialized indexes
+    // even when the local graph hasn't changed (restart-parity flow,
+    // prior failed materialize). `materializeIndexes` is idempotent
+    // so the verification is cheap.
     if (merged === this.#graph) {
       if (options?.ref !== undefined) options.ref.current = this;
+      if (options?.eager) await this.#runEagerOrThrow(this, options.eager);
       return this;
     }
 
@@ -860,7 +880,19 @@ export class Store<G extends GraphDef> {
       preloaded: { activeRow, storedSchema },
       autoMigrate: true,
     });
-    return this.#cloneWithGraph(merged, options?.ref);
+    const evolved = this.#cloneWithGraph(merged, options?.ref);
+    if (options?.eager) await this.#runEagerOrThrow(evolved, options.eager);
+    return evolved;
+  }
+
+  async #runEagerOrThrow(
+    store: Store<G>,
+    eager: true | MaterializeIndexesOptions,
+  ): Promise<void> {
+    const result = await store.materializeIndexes(eager === true ? {} : eager);
+    if (result.results.some((entry) => entry.status === "failed")) {
+      throw new EagerMaterializationError(result, this.graphId);
+    }
   }
 
   /**

--- a/packages/typegraph/tests/store-evolve-eager.test.ts
+++ b/packages/typegraph/tests/store-evolve-eager.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for `Store.evolve(extension, { eager: true })`.
+ *
+ * Eager mode runs `materializeIndexes()` immediately after the
+ * schema commit succeeds. Failures throw `EagerMaterializationError`
+ * AFTER the new Store is constructed and `ref.current` is updated, so
+ * the caller can recover via the ref handle and retry.
+ *
+ * The schema commit is not rolled back on materialization failure —
+ * that's a deliberate design choice (eager is a convenience, not a
+ * transaction). The caller decides what to do with the failed indexes.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph } from "../src/core/define-graph";
+import { defineNode } from "../src/core/node";
+import { EagerMaterializationError } from "../src/errors";
+import { defineNodeIndex } from "../src/indexes";
+import { defineRuntimeExtension } from "../src/runtime";
+import type { Store } from "../src/store/store";
+import { createStoreWithSchema } from "../src/store/store";
+import { type StoreRef } from "../src/store/types";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), email: z.email() }),
+});
+
+function buildGraphWithIndexes() {
+  return defineGraph({
+    id: "evolve_eager",
+    nodes: { Person: { type: Person } },
+    edges: {},
+    indexes: [defineNodeIndex(Person, { fields: ["email"] })],
+  });
+}
+
+function buildGraphWithoutIndexes() {
+  return defineGraph({
+    id: "evolve_eager_no_indexes",
+    nodes: { Person: { type: Person } },
+    edges: {},
+  });
+}
+
+/**
+ * Pre-record a status row with a deliberately wrong signature so the
+ * next materialize call surfaces signature drift as `failed`. With
+ * eager: true on evolve, this becomes EagerMaterializationError.
+ */
+async function forceSignatureDrift(
+  backend: ReturnType<typeof createTestBackend>,
+  declared: { name: string; entity: "node" | "edge"; kind: string },
+  overrides: { signature?: string; graphId?: string } = {},
+) {
+  await backend.recordIndexMaterialization!({
+    indexName: declared.name,
+    graphId: overrides.graphId ?? "some_other_graph",
+    entity: declared.entity,
+    kind: declared.kind,
+    signature: overrides.signature ?? "00000000deadbeef",
+    schemaVersion: 1,
+    attemptedAt: new Date().toISOString(),
+    materializedAt: new Date().toISOString(),
+    error: undefined,
+  });
+}
+
+describe("Store.evolve — eager materialization", () => {
+  it("eager: true materializes declared indexes after the schema commit", async () => {
+    const backend = createTestBackend();
+    const graph = buildGraphWithIndexes();
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const ref: StoreRef<Store<typeof graph>> = { current: store };
+
+    const evolved = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+      { ref, eager: true },
+    );
+
+    // The new Store is returned and the ref points to it.
+    expect(evolved).toBe(ref.current);
+    expect(evolved.registry.hasNodeType("Tag")).toBe(true);
+
+    // A subsequent materialize call sees alreadyMaterialized — proves
+    // eager mode actually ran the DDL.
+    const second = await evolved.materializeIndexes();
+    for (const entry of second.results) {
+      expect(entry.status).toBe("alreadyMaterialized");
+    }
+  });
+
+  it("eager: true on a graph with no declared indexes is a no-op", async () => {
+    const backend = createTestBackend();
+    const graph = buildGraphWithoutIndexes();
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const evolved = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+      { eager: true },
+    );
+
+    expect(evolved.registry.hasNodeType("Tag")).toBe(true);
+    const result = await evolved.materializeIndexes();
+    expect(result.results).toEqual([]);
+  });
+
+  it("eager accepts an options object — kind filter and stopOnError pass through", async () => {
+    const backend = createTestBackend();
+    const graph = buildGraphWithIndexes();
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    // Filter to just Person — same set as default since the runtime
+    // extension adds Tag (no indexes). This proves the options pass
+    // through without throwing on a known kind.
+    const evolved = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+      { eager: { kinds: ["Person"], stopOnError: true } },
+    );
+
+    expect(evolved.registry.hasNodeType("Tag")).toBe(true);
+    const second = await evolved.materializeIndexes();
+    for (const entry of second.results) {
+      expect(entry.status).toBe("alreadyMaterialized");
+    }
+  });
+
+  it("eager: true still materializes when the merge is a no-op (restart-parity contract)", async () => {
+    // A second store wraps a database whose schema already includes
+    // the runtime kind (e.g. another writer committed it, or this
+    // process restarted from a persisted runtimeDocument). Evolving
+    // with the same extension produces a no-op merge — but the local
+    // database may still have unmaterialized indexes (the prior
+    // writer never called materializeIndexes, or a previous attempt
+    // failed). The contract of `eager: true` is "schema committed AND
+    // indexes materialized" — skipping materialize on the no-op
+    // branch would return false success.
+    const backend = createTestBackend();
+    const graph = buildGraphWithIndexes();
+    const extension = defineRuntimeExtension({
+      nodes: { Tag: { properties: { label: { type: "string" } } } },
+    });
+
+    // First writer commits the runtime extension WITHOUT materializing
+    // (no eager, no explicit materializeIndexes).
+    const [storeA] = await createStoreWithSchema(graph, backend);
+    await storeA.evolve(extension);
+
+    // Second writer (fresh store) sees the persisted runtimeDocument
+    // via createStoreWithSchema's catch-up. Evolving with the same
+    // extension is a no-op merge.
+    const [storeB] = await createStoreWithSchema(graph, backend);
+    expect(storeB.registry.hasNodeType("Tag")).toBe(true);
+
+    // Eager must materialize even though the merge is a no-op.
+    const evolved = await storeB.evolve(extension, { eager: true });
+    const result = await evolved.materializeIndexes();
+    // After eager, every declared index reports alreadyMaterialized
+    // — proving eager actually ran the DDL on the no-op branch.
+    expect(result.results.length).toBeGreaterThan(0);
+    for (const entry of result.results) {
+      expect(entry.status).toBe("alreadyMaterialized");
+    }
+  });
+
+  it("eager: false (the default) does not materialize", async () => {
+    const backend = createTestBackend();
+    const graph = buildGraphWithIndexes();
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const evolved = await store.evolve(
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+      { eager: false },
+    );
+
+    // No prior materialize; first call should report `created` for the
+    // Person email index.
+    const result = await evolved.materializeIndexes();
+    const personEmail = result.results.find((entry) => entry.kind === "Person");
+    expect(personEmail?.status).toBe("created");
+  });
+
+  it("eager: true throws EagerMaterializationError on per-index failure; ref is updated before throw", async () => {
+    const backend = createTestBackend();
+    const graph = buildGraphWithIndexes();
+    const [store] = await createStoreWithSchema(graph, backend);
+    const declared = graph.indexes![0]!;
+    await forceSignatureDrift(backend, declared);
+
+    const ref: StoreRef<Store<typeof graph>> = { current: store };
+    const caught = await store
+      .evolve(
+        defineRuntimeExtension({
+          nodes: { Tag: { properties: { label: { type: "string" } } } },
+        }),
+        { ref, eager: true },
+      )
+      .catch((error: unknown) => error);
+
+    expect(caught).toBeInstanceOf(EagerMaterializationError);
+    expect(caught).not.toBe(store);
+    const error = caught as EagerMaterializationError;
+    expect(error.failedIndexNames).toEqual([declared.name]);
+    expect(error.materialization.results).toHaveLength(1);
+    expect(error.materialization.results[0]!.status).toBe("failed");
+
+    // ref was updated to the new Store BEFORE the throw — the recovery
+    // path is to read ref.current and decide what to do with the failures.
+    expect(ref.current).not.toBe(store);
+    expect(ref.current.registry.hasNodeType("Tag")).toBe(true);
+  });
+
+  it("schema commit is not rolled back when eager materialization fails", async () => {
+    const backend = createTestBackend();
+    const graph = buildGraphWithIndexes();
+    const [store] = await createStoreWithSchema(graph, backend);
+    await forceSignatureDrift(backend, graph.indexes![0]!);
+
+    await store
+      .evolve(
+        defineRuntimeExtension({
+          nodes: { Tag: { properties: { label: { type: "string" } } } },
+        }),
+        { eager: true },
+      )
+      .catch((error: unknown) => error);
+
+    // A fresh restart sees the runtime kind at version 2 despite the
+    // materialization throw — proving the schema commit survived.
+    const [restored] = await createStoreWithSchema(graph, backend);
+    expect(restored.registry.hasNodeType("Tag")).toBe(true);
+    const active = await backend.getActiveSchema(graph.id);
+    expect(active?.version).toBe(2);
+  });
+
+  it("EagerMaterializationError extends TypeGraphError with code", async () => {
+    const backend = createTestBackend();
+    const graph = buildGraphWithIndexes();
+    const [store] = await createStoreWithSchema(graph, backend);
+    await forceSignatureDrift(backend, graph.indexes![0]!);
+
+    const caught = await store
+      .evolve(
+        defineRuntimeExtension({
+          nodes: { Tag: { properties: { label: { type: "string" } } } },
+        }),
+        { eager: true },
+      )
+      .catch((error: unknown) => error);
+
+    expect(caught).toBeInstanceOf(EagerMaterializationError);
+    expect((caught as EagerMaterializationError).code).toBe(
+      "EAGER_MATERIALIZATION_FAILED",
+    );
+  });
+});


### PR DESCRIPTION
Second in the polish series for #101. Adds the eager-materialization flag deferred from PR 6.

```typescript
// All-in-one: commit schema and materialize all declared indexes.
const evolved = await store.evolve(extension, { eager: true });

// With per-call options. v1 runtime extensions don't carry
// relational indexes, so the kinds filter only meaningfully
// restricts to compile-time kinds.
const evolved = await store.evolve(extension, {
  eager: { kinds: ["Document"], stopOnError: true },
});
```

## Semantics

- Eager mode runs `materializeIndexes()` AFTER the schema commit succeeds. The schema-version write is **not** rolled back if materialization produces failed entries — eager is convenience, not a transaction.
- On per-index failure, `evolve()` throws `EagerMaterializationError` AFTER the new `Store` is constructed and `ref.current` is updated. The caller recovers via the ref handle:

```typescript
const ref = { current: store };
try {
  await store.evolve(extension, { ref, eager: true });
} catch (error) {
  if (error instanceof EagerMaterializationError) {
    // Schema is committed; ref.current is the new store.
    log.warn(
      { failed: error.failedIndexNames },
      "indexes did not materialize; will retry",
    );
    await ref.current.materializeIndexes();
  } else {
    throw error;
  }
}
```

- `eager: false` (the default) preserves existing behavior — `evolve()` returns the new `Store` immediately and the consumer calls `materializeIndexes()` separately.
- `eager` accepts `boolean | MaterializeIndexesOptions`. Object form lets you scope to specific kinds or set `stopOnError`.
- **Eager runs on no-op merge too.** When the local merge is a no-op (extension already applied via catch-up to a persisted runtimeDocument), eager still calls `materializeIndexes`. The contract is "schema committed AND indexes materialized" — skipping on no-op would hide unmaterialized state in restart-parity flows where another writer committed the schema but never materialized. `materializeIndexes` is idempotent, so the verification is cheap.

## Why throw, not tuple-return

Spec called for "separate diagnostic" on materialization failure. Two shapes considered:

1. **Tuple return** (mirroring `createStoreWithSchema`): every `evolve()` call site pays a destructure tax (`const [evolved] = await store.evolve(ext)`) for a slot that's `undefined` unless eager is set. ~20 internal call sites would need updating.
2. **Throw on failure** (chosen): existing `await store.evolve(ext)` call sites unchanged. Eager opt-in adds the failure semantics. Recovery uses the standard ref pattern that `evolve()` already documents.

Throwing on failure matches the "convenience, not transaction" framing — the consumer who opted in to eager mode is signaling they want a single throw / no-throw signal. Production code that wants finer control stays on the two-call pattern.

## API additions

- `Store.evolve(extension, options?)` — `options.eager?: boolean | MaterializeIndexesOptions`.
- `EagerMaterializationError` — new error class, exported from root. Carries `materialization: MaterializeIndexesResult` and `failedIndexNames: readonly string[]` (now a getter so it can never drift from `materialization.results`). Code `EAGER_MATERIALIZATION_FAILED`.

## Bonus: deadlock fix in `materializeIndexes`

Bundled because both PR A and PR B's CI hit the same failure. The previous `materializeIndexes` call invoked `bootstrapTables` (~20 `CREATE TABLE / CREATE INDEX IF NOT EXISTS` statements covering every base table). Two concurrent callers race on Postgres SHARE locks and deadlock — real production behavior, not a test artifact. Fix: new focused `backend.ensureIndexMaterializationsTable()` primitive that emits `CREATE TABLE IF NOT EXISTS` for ONLY the materializations status table. Concurrent execution of one `CREATE TABLE IF NOT EXISTS` for a single table is well-behaved on Postgres. Custom backends without the new method fall back to `bootstrapTables` for backward compatibility.

