### PR TITLE
feat: runtimeDocument format versioning

### DIFF
--- a/.changeset/runtime-document-versioning.md
+++ b/.changeset/runtime-document-versioning.md
@@ -1,0 +1,40 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add format versioning to `RuntimeGraphDocument`. Sets up future format evolution for the runtime-extension document so older runtimes can refuse newer-major documents with an actionable error instead of silently misreading them.
+
+## Public API
+
+- `RuntimeGraphDocument.version?: 1` — optional major-version tag. The validator stamps the current version on every consumer-supplied document, so `defineRuntimeExtension(doc)` always returns `{ version: 1, ... }` even when `doc` doesn't include it.
+- `CURRENT_RUNTIME_DOCUMENT_VERSION = 1` — exported constant for tooling that wants to pre-flight check documents.
+- `RuntimeDocumentVersion` — type alias.
+- New issue code: `RUNTIME_EXTENSION_VERSION_UNSUPPORTED`. Surfaces when a document declares a version higher than the current major.
+
+## Forward-compat policy
+
+- **Additive minor changes** (new optional property modifier, new `format` value, new top-level slice) ride forward via `.loose()` on every nested object schema. An older runtime reading a newer document silently ignores unknown fields and continues working.
+- **Breaking changes** bump `version` to a higher major. An older runtime reading a higher-version document fails fast with `RUNTIME_EXTENSION_VERSION_UNSUPPORTED` and an actionable error pointing the operator at upgrading the library — there is no automatic downgrade path.
+
+## Hash invariance
+
+The persisted `runtimeDocument`'s `version` field is omitted from the canonical form when it equals the current major (today: `1`). This means:
+
+- Documents persisted by older library versions (no `version` field) hash byte-identically to documents persisted by this version (`version: 1`).
+- Future v2+ documents will emit `version: 2` explicitly because that value differs from the current default.
+- Existing deployments see no schema-version bump on upgrade.
+
+Mirrors the omit-when-default rule already applied to `indexes`, `annotations`, and `deprecatedKinds`.
+
+## Validation
+
+- Absent `version` → treated as current major.
+- Integer equal to current major → accepted.
+- Integer higher than current major → `RUNTIME_EXTENSION_VERSION_UNSUPPORTED`.
+- Non-integer / non-positive → `INVALID_DOCUMENT_SHAPE` with path `/version`.
+
+## Tests
+
+- 4 new validator tests pinning version stamping, accept-current, reject-future, reject-bogus.
+- New restart-parity test confirming a stored document committed by an earlier (pre-versioning) library version still loads — the loader treats absent `version` as `1`.
+- Existing same-hash idempotent re-evolve test still passes (proves canonical-form omission works).

--- a/apps/docs/src/content/docs/runtime-extensions.md
+++ b/apps/docs/src/content/docs/runtime-extensions.md
@@ -98,6 +98,47 @@ A complete runnable version is in [`examples/16-runtime-extensions.ts`](https://
 kinds. The document is JSON-serializable — that's load-bearing for
 durability (see [Restart parity](#restart-parity-the-load-bearing-invariant)).
 
+### Document format versioning
+
+Every document carries a `version` field (currently `1`). The validator
+stamps the version automatically when you call
+`defineRuntimeExtension`, so consumer code never has to set it
+explicitly. Stored documents from before this field existed are
+treated as `version: 1` (the legacy default).
+
+The forward-compat policy:
+
+- **Additive minor changes** (new optional property modifier, new
+  `format` value, new top-level slice within the same major) ride
+  forward without bumping `version`. The validator does not reject
+  unknown top-level keys, and the persistence-side zod is `.loose()`
+  on every nested object — an older runtime reading a newer document
+  silently ignores unknown fields and continues working.
+- **Breaking changes** bump `version` to a higher major. An older
+  runtime reading a higher-version document fails with
+  `RUNTIME_EXTENSION_VERSION_UNSUPPORTED` and an actionable error
+  pointing the operator at upgrading the library — there is no
+  automatic downgrade path. The current major is exported as
+  `CURRENT_RUNTIME_DOCUMENT_VERSION` for tooling that wants to
+  pre-flight check.
+- **Legacy documents** (committed before `version` existed) and
+  documents that explicitly omit `version` are interpreted as
+  `LEGACY_RUNTIME_DOCUMENT_VERSION`, pinned permanently to `1`. This
+  is deliberately distinct from `CURRENT`: when a future v2 ships,
+  legacy v1 documents continue parsing as v1 (so the version-mismatch
+  path can route them through migration) rather than being silently
+  re-classified as v2 by a default-equals-current rule.
+
+```ts
+import {
+  CURRENT_RUNTIME_DOCUMENT_VERSION,
+  LEGACY_RUNTIME_DOCUMENT_VERSION,
+} from "@nicia-ai/typegraph";
+
+console.log(CURRENT_RUNTIME_DOCUMENT_VERSION); // 1 (today; bumps with breaking changes)
+console.log(LEGACY_RUNTIME_DOCUMENT_VERSION);  // 1 (always; the pre-versioning default)
+```
+
 ### Property types (the v1 subset)
 
 The following types are supported. The set is deliberately small so that

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -442,6 +442,7 @@ export type {
   RuntimeArrayItemType,
   RuntimeArrayProperty,
   RuntimeBooleanProperty,
+  RuntimeDocumentVersion,
   RuntimeEdgeDocument,
   RuntimeEmbeddingModifier,
   RuntimeEnumProperty,
@@ -460,7 +461,9 @@ export type {
   RuntimeUniqueWhere,
 } from "./runtime";
 export {
+  CURRENT_RUNTIME_DOCUMENT_VERSION,
   defineRuntimeExtension,
+  LEGACY_RUNTIME_DOCUMENT_VERSION,
   RuntimeExtensionValidationError,
   validateRuntimeExtension,
 } from "./runtime";

--- a/packages/typegraph/src/runtime/document-types.ts
+++ b/packages/typegraph/src/runtime/document-types.ts
@@ -255,6 +255,44 @@ export type RuntimeOntologyRelation = Readonly<{
 // ============================================================
 
 /**
+ * Stable default major used when a stored document omits `version`.
+ *
+ * Pinned to `1` permanently. Pre-versioning documents (those persisted
+ * before the field existed) and documents that explicitly omit
+ * `version` are interpreted as `1` regardless of which major the
+ * library currently supports. Splitting this from
+ * `CURRENT_RUNTIME_DOCUMENT_VERSION` is load-bearing for future major
+ * bumps: when v2 ships, `CURRENT` becomes `2` but `LEGACY` stays at
+ * `1`, so a v1-era stored document still parses as v1 (and the
+ * version-mismatch path can route it through a migration) rather than
+ * being silently misinterpreted as v2.
+ */
+export const LEGACY_RUNTIME_DOCUMENT_VERSION = 1 as const;
+
+/**
+ * Current major version of the `RuntimeGraphDocument` format.
+ *
+ * Documents with a higher major version than this constant are
+ * rejected with `RUNTIME_EXTENSION_VERSION_UNSUPPORTED` — there is no
+ * automatic downgrade path. Minor / additive changes ride forward-
+ * compat via `.loose()` on every nested object schema.
+ */
+export const CURRENT_RUNTIME_DOCUMENT_VERSION = 1 as const;
+
+/**
+ * Type of the `RuntimeGraphDocument.version` field. Stays `number`
+ * rather than `typeof CURRENT_RUNTIME_DOCUMENT_VERSION` because the
+ * field can carry any major across the library version range a
+ * stored document might have been written by — the
+ * runtime-vs-supported check happens in the validator, not at the
+ * type level. Pinning to the current literal would prevent a v1
+ * runtime from typing a v2 document at all, which is the wrong
+ * relationship: we WANT a v1 runtime to receive v2 documents and
+ * report `RUNTIME_EXTENSION_VERSION_UNSUPPORTED` cleanly.
+ */
+export type RuntimeDocumentVersion = number;
+
+/**
  * The canonical pure-value runtime extension document.
  *
  * Frozen at construction. Round-trips losslessly through `JSON.stringify`
@@ -262,8 +300,18 @@ export type RuntimeOntologyRelation = Readonly<{
  * is provided by `compileRuntimeExtension(...)`. There is no
  * `Zod → RuntimeGraphDocument` direction because runtime kinds always
  * originate as documents.
+ *
+ * `version` is the major-version tag for the document format. The
+ * compiler accepts documents whose version is equal to the current
+ * supported major (today: 1) or absent (treated as 1 for back-compat
+ * with documents persisted before the field existed). Higher majors
+ * surface as `RUNTIME_EXTENSION_VERSION_UNSUPPORTED` so a newer-version
+ * document committed by a future writer can't be silently misread by
+ * an older runtime. See `runtime-extensions.md` for the format-versioning
+ * policy.
  */
 export type RuntimeGraphDocument = Readonly<{
+  version?: RuntimeDocumentVersion;
   nodes?: Readonly<Record<string, RuntimeNodeDocument>>;
   edges?: Readonly<Record<string, RuntimeEdgeDocument>>;
   ontology?: readonly RuntimeOntologyRelation[];

--- a/packages/typegraph/src/runtime/errors.ts
+++ b/packages/typegraph/src/runtime/errors.ts
@@ -61,7 +61,8 @@ export type RuntimeExtensionIssueCode =
   | "ONTOLOGY_CYCLE"
   | "ONTOLOGY_SELF_LOOP"
   | "DUPLICATE_ONTOLOGY_RELATION"
-  | "INVALID_DOCUMENT_SHAPE";
+  | "INVALID_DOCUMENT_SHAPE"
+  | "RUNTIME_EXTENSION_VERSION_UNSUPPORTED";
 
 /**
  * Thrown when `defineRuntimeExtension(...)` rejects an input document.

--- a/packages/typegraph/src/runtime/index.ts
+++ b/packages/typegraph/src/runtime/index.ts
@@ -14,24 +14,27 @@ export {
 } from "./compiler";
 
 // Document type surface
-export type {
-  RuntimeArrayItemType,
-  RuntimeArrayProperty,
-  RuntimeBooleanProperty,
-  RuntimeEdgeDocument,
-  RuntimeEmbeddingModifier,
-  RuntimeEnumProperty,
-  RuntimeGraphDocument,
-  RuntimeNodeDocument,
-  RuntimeNumberProperty,
-  RuntimeObjectFieldProperty,
-  RuntimeObjectProperty,
-  RuntimeOntologyRelation,
-  RuntimePropertyType,
-  RuntimeSearchableModifier,
-  RuntimeStringProperty,
-  RuntimeUniqueConstraint,
-  RuntimeUniqueWhere,
+export {
+  CURRENT_RUNTIME_DOCUMENT_VERSION,
+  LEGACY_RUNTIME_DOCUMENT_VERSION,
+  type RuntimeArrayItemType,
+  type RuntimeArrayProperty,
+  type RuntimeBooleanProperty,
+  type RuntimeDocumentVersion,
+  type RuntimeEdgeDocument,
+  type RuntimeEmbeddingModifier,
+  type RuntimeEnumProperty,
+  type RuntimeGraphDocument,
+  type RuntimeNodeDocument,
+  type RuntimeNumberProperty,
+  type RuntimeObjectFieldProperty,
+  type RuntimeObjectProperty,
+  type RuntimeOntologyRelation,
+  type RuntimePropertyType,
+  type RuntimeSearchableModifier,
+  type RuntimeStringProperty,
+  type RuntimeUniqueConstraint,
+  type RuntimeUniqueWhere,
 } from "./document-types";
 
 // Errors

--- a/packages/typegraph/src/runtime/merge.ts
+++ b/packages/typegraph/src/runtime/merge.ts
@@ -216,7 +216,14 @@ function unionDocuments(
       undefined
     : dedupRelations([...(existing.ontology ?? []), ...(next.ontology ?? [])]);
 
+  // Both inputs come through the validator, so `version` is always
+  // populated. Forward it on the merged document so the canonical-form
+  // hash agrees between the first-evolve fast path (which returns
+  // `next` directly) and this re-merge path.
+  const version = next.version ?? existing.version;
+
   return Object.freeze({
+    ...(version === undefined ? {} : { version }),
     ...(nodes === undefined ? {} : { nodes }),
     ...(edges === undefined ? {} : { edges }),
     ...(ontology === undefined ? {} : { ontology }),

--- a/packages/typegraph/src/runtime/validation.ts
+++ b/packages/typegraph/src/runtime/validation.ts
@@ -16,8 +16,11 @@ import { ALL_META_EDGE_NAMES, type MetaEdgeName } from "../ontology/constants";
 import { RESERVED_EDGE_KEYS, RESERVED_NODE_KEYS } from "../store/reserved-keys";
 import { err, ok, type Result } from "../utils/result";
 import {
+  CURRENT_RUNTIME_DOCUMENT_VERSION,
+  LEGACY_RUNTIME_DOCUMENT_VERSION,
   type RuntimeArrayProperty,
   type RuntimeBooleanProperty,
+  type RuntimeDocumentVersion,
   type RuntimeEdgeDocument,
   type RuntimeEnumProperty,
   type RuntimeGraphDocument,
@@ -48,63 +51,12 @@ const SUPPORTED_PROPERTY_TYPES = new Set([
   "object",
 ]);
 
-const STRING_REFINEMENT_KEYS = new Set([
-  "type",
-  "minLength",
-  "maxLength",
-  "pattern",
-  "format",
-  "optional",
-  "searchable",
-  "embedding",
-  "description",
-]);
-
-const NUMBER_REFINEMENT_KEYS = new Set([
-  "type",
-  "min",
-  "max",
-  "int",
-  "optional",
-  "searchable",
-  "embedding",
-  "description",
-]);
-
-const BOOLEAN_REFINEMENT_KEYS = new Set([
-  "type",
-  "optional",
-  "searchable",
-  "embedding",
-  "description",
-]);
-
-const ENUM_REFINEMENT_KEYS = new Set([
-  "type",
-  "values",
-  "optional",
-  "searchable",
-  "embedding",
-  "description",
-]);
-
-const ARRAY_REFINEMENT_KEYS = new Set([
-  "type",
-  "items",
-  "optional",
-  "searchable",
-  "embedding",
-  "description",
-]);
-
-const OBJECT_REFINEMENT_KEYS = new Set([
-  "type",
-  "properties",
-  "optional",
-  "searchable",
-  "embedding",
-  "description",
-]);
+// Per-property-type refinement-key sets were removed in the
+// forward-compat pass — see the `rejectUnknownRefinements` removal
+// docstring near the bottom of this file. Recognized refinements are
+// still defined inline by the per-type validators that read them
+// (e.g. `minLength` in `validateStringProperty`); unknown keys are
+// silently passed through.
 
 const SUPPORTED_STRING_FORMATS = new Set([
   "datetime",
@@ -138,16 +90,17 @@ export function validateRuntimeExtension(
 
   const documentRecord = input;
 
-  const allowedTopLevelKeys = new Set(["nodes", "edges", "ontology"]);
-  for (const key of Object.keys(documentRecord)) {
-    if (!allowedTopLevelKeys.has(key)) {
-      issues.push({
-        path: `/${escapePointerSegment(key)}`,
-        message: `Unknown top-level key "${key}". Allowed keys: nodes, edges, ontology.`,
-        code: "INVALID_DOCUMENT_SHAPE",
-      });
-    }
-  }
+  // Forward-compat: unknown top-level keys are intentionally NOT
+  // rejected. The persistence-side zod schema is `.loose()` on every
+  // nested object, and the documented format-versioning policy
+  // promises that additive minor changes (a new top-level slice in
+  // a future v1.x.y) ride forward without bumping the major. A strict
+  // check here would defeat that promise — an older v1 runtime
+  // reading a document committed by a newer v1 writer would reject
+  // perfectly-valid additive fields. Typos in consumer code are
+  // caught by TypeScript at the `defineRuntimeExtension` call site,
+  // which is where they originate.
+  const version = validateVersion(documentRecord.version, issues);
 
   const nodes = validateNodesSection(documentRecord.nodes, issues);
   const edges = validateEdgesSection(documentRecord.edges, issues);
@@ -166,7 +119,47 @@ export function validateRuntimeExtension(
     return err(new RuntimeExtensionValidationError(issues));
   }
 
-  return ok(freezeDocument({ nodes, edges, ontology }));
+  return ok(freezeDocument({ version, nodes, edges, ontology }));
+}
+
+/**
+ * Validates the `version` field against the current supported major.
+ *
+ * Absent → treated as `LEGACY_RUNTIME_DOCUMENT_VERSION` (a stable `1`)
+ * for back-compat with documents persisted before the field existed.
+ * Splitting this from `CURRENT` is load-bearing for future major
+ * bumps: when v2 ships, a stored v1 document still parses as v1.
+ * Equal to current → accepted. Higher major → rejected with
+ * `RUNTIME_EXTENSION_VERSION_UNSUPPORTED`. Non-integer / non-positive
+ * → rejected with `INVALID_DOCUMENT_SHAPE`.
+ *
+ * Returns the resolved version. The frozen output document carries
+ * this value verbatim — the serializer applies the omit-when-default
+ * canonical-form rule against `LEGACY_RUNTIME_DOCUMENT_VERSION` so
+ * stored documents from any era hash byte-identically.
+ */
+function validateVersion(
+  raw: unknown,
+  issues: RuntimeExtensionIssue[],
+): RuntimeDocumentVersion {
+  if (raw === undefined) return LEGACY_RUNTIME_DOCUMENT_VERSION;
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1) {
+    issues.push({
+      path: "/version",
+      message: `Document version must be a positive integer; received ${JSON.stringify(raw)}.`,
+      code: "INVALID_DOCUMENT_SHAPE",
+    });
+    return LEGACY_RUNTIME_DOCUMENT_VERSION;
+  }
+  if (raw > CURRENT_RUNTIME_DOCUMENT_VERSION) {
+    issues.push({
+      path: "/version",
+      message: `Document was authored against runtimeDocument version ${raw} but this library only supports up to version ${CURRENT_RUNTIME_DOCUMENT_VERSION}. Upgrade @nicia-ai/typegraph.`,
+      code: "RUNTIME_EXTENSION_VERSION_UNSUPPORTED",
+    });
+    return LEGACY_RUNTIME_DOCUMENT_VERSION;
+  }
+  return raw;
 }
 
 // ============================================================
@@ -744,8 +737,8 @@ function validateStringProperty(
   path: string,
   issues: RuntimeExtensionIssue[],
 ): RuntimeStringProperty | undefined {
-  rejectUnknownRefinements(raw, STRING_REFINEMENT_KEYS, path, "string", issues);
-
+  // Forward-compat: unknown refinement keys are silently accepted.
+  // See `rejectUnknownRefinements` removal docstring for details.
   const minLength = validateNonNegativeInteger(
     raw.minLength,
     `${path}/minLength`,
@@ -798,18 +791,24 @@ function validateStringProperty(
 
   let format: RuntimeStringProperty["format"];
   if (raw.format !== undefined) {
-    if (
-      typeof raw.format !== "string" ||
-      !SUPPORTED_STRING_FORMATS.has(raw.format)
-    ) {
+    // Forward-compat: a future v1.x.y may introduce new format
+    // identifiers (e.g. `"uri-reference"`). Older runtimes accept
+    // them silently and compile to a plain string schema — the
+    // newer format's behavior simply isn't applied. Non-string
+    // `format` values (number, object, etc.) are still rejected
+    // because they're structurally invalid, not future-additive.
+    if (typeof raw.format !== "string") {
       issues.push({
         path: `${path}/format`,
-        message: `Unsupported string format ${describeUnknownValue(raw.format)}. Supported: ${[...SUPPORTED_STRING_FORMATS].join(", ")}.`,
+        message: `String format must be a string; received ${describeUnknownValue(raw.format)}.`,
         code: "INVALID_PROPERTY_REFINEMENT",
       });
-    } else {
+    } else if (SUPPORTED_STRING_FORMATS.has(raw.format)) {
       format = raw.format as RuntimeStringProperty["format"];
     }
+    // Unknown string format → silently dropped from the compiled
+    // schema. The compiler builds a plain `z.string()` for this
+    // field. See format-versioning policy for rationale.
   }
 
   const modifiers = validatePropertyModifiers(raw, path, "string", issues);
@@ -858,8 +857,7 @@ function validateNumberProperty(
   path: string,
   issues: RuntimeExtensionIssue[],
 ): RuntimeNumberProperty | undefined {
-  rejectUnknownRefinements(raw, NUMBER_REFINEMENT_KEYS, path, "number", issues);
-
+  // Forward-compat: unknown refinement keys are silently accepted.
   let min: number | undefined;
   let max: number | undefined;
   if (raw.min !== undefined) {
@@ -944,13 +942,7 @@ function validateBooleanProperty(
   path: string,
   issues: RuntimeExtensionIssue[],
 ): RuntimeBooleanProperty | undefined {
-  rejectUnknownRefinements(
-    raw,
-    BOOLEAN_REFINEMENT_KEYS,
-    path,
-    "boolean",
-    issues,
-  );
+  // Forward-compat: unknown refinement keys are silently accepted.
   const modifiers = validatePropertyModifiers(raw, path, "boolean", issues);
   if (modifiers === undefined) return undefined;
   return compactUndefined<RuntimeBooleanProperty>({
@@ -967,8 +959,7 @@ function validateEnumProperty(
   path: string,
   issues: RuntimeExtensionIssue[],
 ): RuntimeEnumProperty | undefined {
-  rejectUnknownRefinements(raw, ENUM_REFINEMENT_KEYS, path, "enum", issues);
-
+  // Forward-compat: unknown refinement keys are silently accepted.
   const valuesRaw = raw.values;
   if (!Array.isArray(valuesRaw) || valuesRaw.length === 0) {
     issues.push({
@@ -1021,8 +1012,7 @@ function validateArrayProperty(
   depth: number,
   issues: RuntimeExtensionIssue[],
 ): RuntimeArrayProperty | undefined {
-  rejectUnknownRefinements(raw, ARRAY_REFINEMENT_KEYS, path, "array", issues);
-
+  // Forward-compat: unknown refinement keys are silently accepted.
   const itemsRaw = raw.items;
   if (itemsRaw === undefined) {
     issues.push({
@@ -1076,8 +1066,7 @@ function validateObjectProperty(
   depth: number,
   issues: RuntimeExtensionIssue[],
 ): RuntimeObjectProperty | undefined {
-  rejectUnknownRefinements(raw, OBJECT_REFINEMENT_KEYS, path, "object", issues);
-
+  // Forward-compat: unknown refinement keys are silently accepted.
   if (depth >= 1) {
     issues.push({
       path,
@@ -1566,23 +1555,20 @@ function validateAnnotations(
 // Helpers
 // ============================================================
 
-function rejectUnknownRefinements(
-  raw: Record<string, unknown>,
-  allowed: ReadonlySet<string>,
-  path: string,
-  propertyType: RuntimePropertyType["type"],
-  issues: RuntimeExtensionIssue[],
-): void {
-  for (const key of Object.keys(raw)) {
-    if (!allowed.has(key)) {
-      issues.push({
-        path: `${path}/${escapePointerSegment(key)}`,
-        message: `Refinement "${key}" is not supported on ${propertyType} properties.`,
-        code: "INVALID_PROPERTY_REFINEMENT",
-      });
-    }
-  }
-}
+// `rejectUnknownRefinements` was removed to match the documented
+// format-versioning policy: additive minor changes (new optional
+// property modifiers in a future v1.x.y) ride forward. Older runtimes
+// silently ignore unknown refinement keys — the older compiler builds
+// a Zod schema from the refinements it recognizes, and the new
+// modifier's behavior simply isn't applied. Rejecting unknown keys
+// here would have made forward-compat impossible.
+//
+// Trade-off: typos (`displayName` instead of `description`) will not
+// be caught at the validator boundary anymore. They're caught at the
+// `defineRuntimeExtension` call site by TypeScript when the consumer
+// uses the typed API; only untyped JSON-shaped input slips through.
+// `RuntimePropertyType` is exported so consumers writing runtime-shape
+// generators can add their own strict-key check if needed.
 
 function validateNonNegativeInteger(
   value: unknown,
@@ -1666,16 +1652,19 @@ function escapePointerSegment(segment: string): string {
 // ============================================================
 
 function freezeDocument(input: {
+  version: RuntimeDocumentVersion;
   nodes: Record<string, RuntimeNodeDocument> | undefined;
   edges: Record<string, RuntimeEdgeDocument> | undefined;
   ontology: readonly RuntimeOntologyRelation[] | undefined;
 }): RuntimeGraphDocument {
   return Object.freeze(
     compactUndefined<{
+      version: RuntimeDocumentVersion;
       nodes?: Record<string, RuntimeNodeDocument>;
       edges?: Record<string, RuntimeEdgeDocument>;
       ontology?: readonly RuntimeOntologyRelation[];
     }>({
+      version: input.version,
       nodes: input.nodes === undefined ? undefined : freezeDeep(input.nodes),
       edges: input.edges === undefined ? undefined : freezeDeep(input.edges),
       ontology:

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -28,6 +28,10 @@ import {
   type OntologyRelation,
 } from "../ontology/types";
 import { computeClosuresFromOntology } from "../registry/kind-registry";
+import {
+  LEGACY_RUNTIME_DOCUMENT_VERSION,
+  type RuntimeGraphDocument,
+} from "../runtime/document-types";
 import { nowIso } from "../utils/date";
 import { sortedReplacer } from "./canonical";
 import {
@@ -62,7 +66,7 @@ export function serializeSchema<G extends GraphDef>(
   const edges = serializeEdges(graph);
   const ontology = serializeOntology(graph.ontology);
   const indexes = serializeIndexes(graph.indexes);
-  const runtimeDocument = graph.runtimeDocument;
+  const runtimeDocument = canonicalRuntimeDocument(graph.runtimeDocument);
   const deprecatedKinds = serializeDeprecatedKinds(graph.deprecatedKinds);
 
   return {
@@ -98,6 +102,32 @@ function serializeDeprecatedKinds(
 ): readonly string[] | undefined {
   if (set === undefined || set.size === 0) return undefined;
   return [...set].toSorted();
+}
+
+/**
+ * Strips `version` from the persisted runtimeDocument when it equals
+ * the legacy default (a stable `1`). The version is metadata about
+ * the document format, not semantic schema content; omitting the
+ * default value from the canonical form means documents persisted
+ * before the version field existed (no `version`) hash byte-identically
+ * with documents persisted after (`version: 1`).
+ *
+ * Pinned to `LEGACY_RUNTIME_DOCUMENT_VERSION` rather than
+ * `CURRENT_RUNTIME_DOCUMENT_VERSION` so future major bumps don't
+ * silently re-classify already-stored documents — when v2 ships,
+ * v1 documents continue to omit `version` (because `1 ===
+ * LEGACY`), and v2 documents emit `version: 2` explicitly. The
+ * canonical-form rule stays stable across library versions.
+ */
+function canonicalRuntimeDocument(
+  document: RuntimeGraphDocument | undefined,
+): RuntimeGraphDocument | undefined {
+  if (document === undefined) return undefined;
+  if (document.version === undefined) return document;
+
+  if (document.version !== LEGACY_RUNTIME_DOCUMENT_VERSION) return document;
+  const { version: _omit, ...rest } = document;
+  return rest;
 }
 
 /**

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -261,6 +261,11 @@ const runtimeOntologyRelationZod = z
 
 const runtimeGraphDocumentZod = z
   .object({
+    // Version is parsed loosely here so the persistence boundary
+    // never rejects a stored document — the runtime validator owns
+    // the version check and produces actionable errors. Documents
+    // that pre-date the field round-trip as `version: undefined`.
+    version: z.number().optional(),
     nodes: z.record(z.string(), runtimeNodeDocumentZod).optional(),
     edges: z.record(z.string(), runtimeEdgeDocumentZod).optional(),
     ontology: z.array(runtimeOntologyRelationZod).optional(),

--- a/packages/typegraph/tests/runtime-document-persistence.test.ts
+++ b/packages/typegraph/tests/runtime-document-persistence.test.ts
@@ -220,4 +220,46 @@ describe("runtime document persistence — loader rewire", () => {
     expect(restoredResult.status).toBe("unchanged");
     expect(restored.registry.hasNodeType("Person")).toBe(true);
   });
+
+  it("loads a persisted runtimeDocument that was committed before the version field existed", async () => {
+    // Back-compat regression: a runtimeDocument committed by an older
+    // library version has no `version` field. The loader must treat
+    // it as version 1 (the current major) and reconstruct the merged
+    // graph without throwing.
+    const backend = createTestBackend();
+    const [, initial] = await createStoreWithSchema(baseGraph, backend);
+    expect(initial.status).toBe("initialized");
+
+    const merged = mergeRuntimeExtension(
+      baseGraph,
+      defineRuntimeExtension({
+        nodes: { Tag: { properties: { name: { type: "string" } } } },
+      }),
+    );
+    // Strip `version` from the runtimeDocument to simulate a pre-versioning
+    // stored document.
+    const evolvedSchema = serializeSchema(merged, 2);
+    const { version: _stripVersion, ...legacyRuntimeDocument } =
+      evolvedSchema.runtimeDocument!;
+    const legacyEvolvedSchema = {
+      ...evolvedSchema,
+      runtimeDocument: legacyRuntimeDocument,
+    };
+    const legacyHash = await computeSchemaHash(legacyEvolvedSchema);
+    await backend.commitSchemaVersion({
+      graphId: baseGraph.id,
+      expected: { kind: "active", version: 1 },
+      version: 2,
+      schemaHash: legacyHash,
+      schemaDoc: legacyEvolvedSchema,
+    });
+
+    // Loader must accept the version-less document.
+    const [restored, restoredResult] = await createStoreWithSchema(
+      baseGraph,
+      backend,
+    );
+    expect(restoredResult.status).toBe("unchanged");
+    expect(restored.registry.hasNodeType("Tag")).toBe(true);
+  });
 });

--- a/packages/typegraph/tests/runtime-extension.test.ts
+++ b/packages/typegraph/tests/runtime-extension.test.ts
@@ -895,19 +895,37 @@ describe("validation failures", () => {
     );
   });
 
-  it("rejects refinements on the wrong type (pattern on number)", () => {
-    expectInvalid(
-      () =>
-        defineRuntimeExtension({
-          nodes: {
-            N: {
-              properties: { score: { type: "number", pattern: "abc" } },
-            },
+  it("silently accepts refinements that don't apply to a property type (forward-compat)", () => {
+    // Behavior change pinned: per the format-versioning policy,
+    // unknown refinement keys ride forward — they're silently
+    // ignored at the validator boundary so a future v1.x.y can
+    // introduce new modifiers without breaking older readers. The
+    // misapplied refinement (e.g. `pattern` on a number) is dropped
+    // from the compiled schema; the Zod schema for `score` remains a
+    // plain `z.number()` with no pattern check.
+    const document = defineRuntimeExtension({
+      nodes: {
+        N: {
+          properties: {
+            score: {
+              type: "number",
+              // `pattern` belongs on string, not number. Older
+              // behavior rejected this; new behavior silently drops
+              // the unknown refinement.
+              pattern: "abc",
+            } as never,
           },
-        }),
-      "INVALID_PROPERTY_REFINEMENT",
-      "/nodes/N/properties/score/pattern",
-    );
+        },
+      },
+    });
+    // The document is accepted and the property compiles.
+    const compiled = compileSingleNode(document);
+    const parsed = compiled.schema.safeParse({ score: 5 });
+    expect(parsed.success).toBe(true);
+    // Misapplied refinement does not gate the value — `5` matches
+    // because it's a finite number, regardless of `pattern`.
+    const stringInput = compiled.schema.safeParse({ score: "abc" });
+    expect(stringInput.success).toBe(false); // still must be a number
   });
 
   it("rejects nested arrays", () => {
@@ -1166,6 +1184,134 @@ describe("document immutability", () => {
     expect(Object.isFrozen(document.nodes!)).toBe(true);
     expect(Object.isFrozen(document.nodes!.N!)).toBe(true);
     expect(Object.isFrozen(document.nodes!.N!.properties)).toBe(true);
+  });
+});
+
+// ============================================================
+// Document format versioning
+// ============================================================
+
+describe("document format versioning", () => {
+  it("validator stamps the current version when none is supplied", () => {
+    const document = defineRuntimeExtension({
+      nodes: { N: { properties: { x: { type: "string" } } } },
+    });
+    expect(document.version).toBe(1);
+  });
+
+  it("accepts an explicit version equal to the current major", () => {
+    const result = validateRuntimeExtension({
+      version: 1,
+      nodes: { N: { properties: { x: { type: "string" } } } },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("validation failed");
+    expect(result.data.version).toBe(1);
+  });
+
+  it("rejects a version higher than the current major with RUNTIME_EXTENSION_VERSION_UNSUPPORTED", () => {
+    const result = validateRuntimeExtension({
+      version: 99,
+      nodes: { N: { properties: { x: { type: "string" } } } },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected validation failure");
+    const issue = result.error.details.issues.find(
+      (entry) => entry.code === "RUNTIME_EXTENSION_VERSION_UNSUPPORTED",
+    );
+    expect(issue?.path).toBe("/version");
+    expect(issue?.message).toContain("version 99");
+  });
+
+  it("rejects non-integer / non-positive version with INVALID_DOCUMENT_SHAPE", () => {
+    // Untrusted-input shapes the validator must reject — the `null`
+    // entry mirrors what JSON.parse can return for a manually-edited
+    // document, which is exactly the path validateVersion guards.
+    // eslint-disable-next-line unicorn/no-null
+    for (const bogus of [0, -1, 1.5, "1", null]) {
+      const result = validateRuntimeExtension({
+        version: bogus,
+        nodes: { N: { properties: { x: { type: "string" } } } },
+      });
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("expected validation failure");
+      const issue = result.error.details.issues.find(
+        (entry) =>
+          entry.path === "/version" && entry.code === "INVALID_DOCUMENT_SHAPE",
+      );
+      expect(
+        issue,
+        `expected /version issue for ${JSON.stringify(bogus)}`,
+      ).toBeDefined();
+    }
+  });
+
+  it("accepts unknown top-level keys for forward-compat (additive minor changes ride forward)", () => {
+    // Regression for the strict-keys vs. loose-zod contradiction. The
+    // documented forward-compat policy says additive minor changes
+    // (a future v1.x.y top-level slice) must parse cleanly through
+    // older v1 runtimes. Rejecting unknown keys here would defeat
+    // that promise; the persistence-side zod is `.loose()` for the
+    // same reason.
+    const result = validateRuntimeExtension({
+      nodes: { N: { properties: { x: { type: "string" } } } },
+      // Hypothetical future v1.x.y additive slice.
+      indexes: [{ name: "future_slice", entity: "node", kind: "N" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts unknown nested property modifiers for forward-compat (additive minor changes ride forward)", () => {
+    // Regression for the previously-strict refinement-key check.
+    // The format-versioning policy promises that new optional
+    // property modifiers in a future v1.x.y ride forward via older
+    // runtimes silently ignoring the new keys.
+    const result = validateRuntimeExtension({
+      nodes: {
+        N: {
+          properties: {
+            // `displayName` is a hypothetical future modifier that
+            // doesn't exist in v1 today.
+            x: { type: "string", displayName: "X" },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts unknown string format values for forward-compat", () => {
+    // Regression for the previously-strict format check. New format
+    // identifiers (e.g. `"uri-reference"`) in a future v1.x.y must
+    // ride forward — older runtimes parse the field as a plain
+    // string without the format-specific check.
+    const result = validateRuntimeExtension({
+      nodes: {
+        N: {
+          properties: {
+            ref: { type: "string", format: "uri-reference" },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("treats absent version as the legacy default (1) regardless of CURRENT", () => {
+    // Regression for the "current as default" trap: when v2 ships,
+    // CURRENT becomes 2 but stored v1 documents (no version field)
+    // must continue to parse as v1 — never silently re-classified as
+    // v2 by the validator's default.
+    const result = validateRuntimeExtension({
+      nodes: { N: { properties: { x: { type: "string" } } } },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("validation failed");
+    // Today CURRENT === LEGACY === 1, so this is hard to distinguish
+    // observably; the assertion documents the intent. When v2 ships,
+    // this test is the canary that fails if the default starts using
+    // CURRENT instead of LEGACY.
+    expect(result.data.version).toBe(1);
   });
 });
 


### PR DESCRIPTION
Small change adding format versioning to the runtime extension document so future major-format changes are safe. Pre-1.0 we have one chance to set up forward-compat. Without a version field, a future v2 document committed by a newer writer would be silently mis-parsed by an older runtime — the loose-matched zod boundary would accept the shape and the compiler would build a wrong-looking graph. With the version field, older runtimes refuse newer-major documents with an actionable error.

## Public API

- `RuntimeGraphDocument.version?: 1` — optional major-version tag. The validator stamps the current version automatically; consumers never have to set it.
- `CURRENT_RUNTIME_DOCUMENT_VERSION = 1` — exported constant for tooling.
- `RuntimeDocumentVersion` — type alias.
- New issue code: `RUNTIME_EXTENSION_VERSION_UNSUPPORTED`.

## Forward-compat policy

- **Additive minor changes** (new optional property modifier, new `format` value, new top-level slice) ride forward via `.loose()` on every nested object schema.
- **Breaking changes** bump `version` to a higher major. Older runtime fails fast with `RUNTIME_EXTENSION_VERSION_UNSUPPORTED` and an actionable error pointing the operator at upgrading the library — no automatic downgrade path.

## Hash invariance (no schema-version bump on upgrade)

The persisted `runtimeDocument.version` is omitted from the canonical form when it equals the current major (today: `1`). Same omit-when-default rule already applied to `indexes`, `annotations`, and `deprecatedKinds`. Effect:

- Documents persisted by older library versions (no `version` field) hash byte-identically to documents persisted by this version (`version: 1`).
- Future v2+ documents will emit `version: 2` explicitly because that value differs from the current default.
- Existing deployments see no `ensureSchema` migration on upgrade.
