### PR TITLE
feat: vector index unification — embedding() brands flow through materializeIndexes

### DIFF
--- a/.changeset/vector-index-unification.md
+++ b/.changeset/vector-index-unification.md
@@ -1,0 +1,121 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Unify vector indexes through the same declaration channel as relational indexes. Vector indexes are now auto-derived from `embedding()` brands at `defineGraph()` time and flow through `Store.materializeIndexes()` like any other index. Closes the second of two PRs needed to ship #101 properly.
+
+## What changed
+
+```typescript
+const Document = defineNode("Document", {
+  schema: z.object({
+    title: z.string(),
+    // Auto-derives a cosine HNSW vector index with pgvector defaults.
+    embedding: embedding(384),
+  }),
+});
+
+// Override the auto-derived defaults at the brand site.
+const Image = defineNode("Image", {
+  schema: z.object({
+    embedding: embedding(512, { metric: "l2", m: 32, efConstruction: 100 }),
+  }),
+});
+
+// Opt out of automatic materialization while keeping the embedding column.
+const Manual = defineNode("Manual", {
+  schema: z.object({
+    embedding: embedding(384, { indexType: "none" }),
+  }),
+});
+
+const [store] = await createStoreWithSchema(graph, backend);
+const result = await store.materializeIndexes();
+// Postgres+pgvector → status: "created"
+// SQLite (or `indexType: "none"`) → status: "skipped" with reason
+```
+
+## API additions
+
+- `embedding(dimensions, options?)` — `options` is the new
+  `EmbeddingIndexOptions` carrying `metric`, `indexType`, HNSW `m` /
+  `efConstruction`, and IVFFlat `lists`. Defaults: `cosine` /
+  `hnsw` / `m=16` / `efConstruction=64` (pgvector defaults).
+- `EmbeddingMetric`, `EmbeddingIndexType`, `EmbeddingIndexOptions`,
+  `ResolvedEmbeddingIndex` — exported types.
+- `getEmbeddingIndex(schema)` — read the resolved index config from
+  an embedding brand.
+- `IndexDeclaration` — now a discriminated union of
+  `NodeIndexDeclaration | EdgeIndexDeclaration | VectorIndexDeclaration`.
+- `RelationalIndexDeclaration` — alias for the relational subset
+  (the variants `generateIndexDDL` consumes).
+- `VectorIndexDeclaration`, `VectorIndexMetric`,
+  `VectorIndexImplementation`, `VectorIndexParams` — exported types.
+- `MaterializeIndexesEntry.entity` — extended to include `"vector"`.
+- `MaterializeIndexesEntry.status` — new variant `"skipped"` with a
+  `reason` field. Surfaces when the backend recognizes the
+  declaration but can't act on it (vector indexes against SQLite
+  without `sqlite-vec`, or `indexType: "none"`).
+
+## Auto-derivation
+
+At `defineGraph()` time, every top-level node field declared with
+`embedding()` produces one `VectorIndexDeclaration`. The declarations
+flow through `GraphDef.indexes` and `SerializedSchema.indexes` like
+relational indexes. v1 limits:
+
+- One vector index per (kind, fieldPath). To use a different metric
+  for the same field, use a different field name or wait for v2.
+- Top-level fields only. Embeddings nested inside object properties
+  are not auto-derived (pgvector's column-based indexes don't address
+  sub-paths cleanly).
+
+Explicit `VectorIndexDeclaration` entries passed via
+`defineGraph({ indexes })` win on (kind, fieldPath) collisions, so
+consumers can override defaults without losing auto-derivation for
+other fields.
+
+## Materialization dispatch
+
+`materializeIndexes()` reads `IndexDeclaration.entity` and dispatches:
+
+- `node` / `edge` → existing path: `generateIndexDDL` →
+  `executeDdl`.
+- `vector` → calls `backend.createVectorIndex(params)` with the
+  resolved metric, indexType, dimensions, and HNSW / IVFFlat params.
+
+Status tracking goes through the existing
+`typegraph_index_materializations` table; the `entity` column was
+widened to accept `"vector"`. Signature includes vector params for
+drift detection.
+
+## Capability checks
+
+`materializeIndexes()` checks `backend.capabilities.vector?.supported`
+and `backend.capabilities.vector.indexTypes` before dispatching. When
+the backend can't handle the requested vector indexType, the entry
+reports `status: "skipped"` with a clear reason rather than silently
+returning `"created"` for a no-op.
+
+## Backend interface cleanup
+
+Removed dead code from `GraphBackend`:
+
+- `createFulltextIndex?` — never called from anywhere in the store
+  layer; the fulltext table's canonical index is created with the
+  table itself by `bootstrapTables`.
+- `dropFulltextIndex?` — same.
+
+Custom backends implementing these methods will need to remove them.
+Pre-1.0 acceptable.
+
+## Out of scope (still deferred)
+
+- **Fulltext index unification.** Fulltext stays per-strategy in v1;
+  the GIN / FTS5 index is created with the fulltext table at
+  `bootstrapTables` time.
+- **Multiple vector indexes per (kind, field).** v1 allows at most
+  one. Use a different field name for now.
+- **Vector indexes for runtime-declared kinds.** Auto-derivation
+  walks compile-time node schemas. Runtime-extension documents can't
+  yet declare embeddings — coming in a follow-up.

--- a/apps/docs/src/content/docs/runtime-extensions.md
+++ b/apps/docs/src/content/docs/runtime-extensions.md
@@ -293,14 +293,83 @@ on the merged graph and tracks per-deployment status in
   `stopOnError: true` to halt on the first failure.
 
 The returned `MaterializeIndexesResult` has one entry per declared
-index with `status: "created" | "alreadyMaterialized" | "failed"`.
+index with `status: "created" | "alreadyMaterialized" | "failed" | "skipped"`.
+The `skipped` status surfaces when the backend recognizes the
+declaration but can't act on it in its current configuration — e.g.
+vector indexes against SQLite without the `sqlite-vec` extension, or
+`embedding(dims, { indexType: "none" })` opting out of automatic
+materialization.
 
-### v1 scope
+### Vector indexes
 
-PR 6 covers **relational indexes only**. Vector and fulltext indexes
-continue to use the existing per-kind imperative APIs
-(`backend.createVectorIndex` / `createFulltextIndex`); lifting them
-into the unified declaration channel is a future PR.
+Vector indexes are **auto-derived** from `embedding()` brands at
+`defineGraph()` time. Every top-level node field declared with
+`embedding(dims, opts?)` produces one `VectorIndexDeclaration` that
+flows through `materializeIndexes()` like any relational index. No
+extra wiring required.
+
+```ts
+const Document = defineNode("Document", {
+  schema: z.object({
+    title: z.string(),
+    // Auto-derives a cosine HNSW vector index with pgvector
+    // defaults (m=16, ef_construction=64).
+    embedding: embedding(384),
+  }),
+});
+
+// Customize the auto-derived index by passing options at the brand.
+const Image = defineNode("Image", {
+  schema: z.object({
+    embedding: embedding(512, { metric: "l2", m: 32, efConstruction: 100 }),
+  }),
+});
+
+// Opt out of automatic materialization while keeping the embedding.
+const Manual = defineNode("Manual", {
+  schema: z.object({
+    embedding: embedding(384, { indexType: "none" }),
+  }),
+});
+```
+
+On `materializeIndexes()`:
+
+- Postgres with pgvector: emits `CREATE INDEX ... USING hnsw ...` (or
+  `ivfflat`) on `typegraph_node_embeddings` and reports `created`.
+- SQLite with `sqlite-vec`: vectors are stored but the brute-force
+  scan IS the "index"; declarations report `skipped` because
+  HNSW/IVFFlat aren't available natively on SQLite.
+- SQLite without `sqlite-vec`: declarations report `skipped` with a
+  reason indicating the backend lacks vector support.
+
+The vector declaration's identity key within a single graph is
+`(kind, fieldPath)` — v1 allows at most one vector index per
+(kind, field) pair. The auto-derived deterministic declaration
+name is `tg_vec_{kind}_{field}_{metric}` — clean and scannable for
+inspection in `pg_indexes` and result entries. Changing the metric
+requires a different declaration name and explicit
+re-materialization.
+
+Cross-graph disambiguation lives at the materialization boundary,
+not in the declaration name. Vector status rows in
+`typegraph_index_materializations` are keyed on the compound
+`{graphId}::{declaration.name}` for both auto-derived and explicit
+`VectorIndexDeclaration` entries — so two graphs reusing the same
+declaration name (whether auto-derived from the same kind/field or
+constructed explicitly via `defineGraph({ indexes: [...] })`) don't
+collide in the status table. Each graph's `materializeIndexes()`
+call creates its own physical pgvector index (which is itself
+partial-by-graph_id) and records its own status row.
+
+### Fulltext indexes (out of scope for v1)
+
+Fulltext indexes are NOT in the unified declaration channel for v1.
+The fulltext table's canonical index (Postgres GIN on `tsv`, SQLite
+FTS5 virtual table) is created with the table itself by
+`bootstrapTables` per the active `FulltextStrategy`. Per-kind fulltext
+indexes are an "advanced strategy" surface that doesn't fit the
+relational-style declaration model and is reserved for future work.
 
 ### Caveats (Postgres)
 
@@ -434,10 +503,17 @@ as untrusted data. Specifically:
   signal; a hard-removal verb has a long edge-case tail (existing
   rows, edges referencing the kind, ontology references, fulltext /
   embedding rows, tombstoned rows) and deserves its own design pass.
-- **Vector and fulltext index unification.** `materializeIndexes`
-  covers relational indexes only. Vector / fulltext continue to use
-  the existing per-kind imperative APIs. Lifting them into the unified
-  declaration channel is future work.
+- **Fulltext index unification.** Vector indexes flow through the
+  unified channel (auto-derived from `embedding()` brands). Fulltext
+  is still per-strategy: the GIN / FTS5 index is created with the
+  fulltext table at `bootstrapTables` time. Per-kind fulltext indexes
+  are reserved for future work.
+- **Multiple vector indexes per (kind, field).** v1 allows at most
+  one. To use a different metric for the same field, use a different
+  field name or wait for v2.
+- **Vector index for runtime-declared kinds.** Auto-derivation walks
+  compile-time node schemas. Runtime-extension documents cannot yet
+  declare embeddings — coming in a follow-up.
 - **Hard-blocking reads/writes on deprecated kinds.** Deprecation is
   informational. If you want strict enforcement, wrap collection
   access yourself.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -231,25 +231,48 @@ const incidentMeta = stored?.nodes.Incident?.annotations;
   `Readonly<Record<string, JsonValue>>`. Wrap reads in your own typed
   accessors at consumer boundaries if you need stronger guarantees.
 
-### `embedding(dimensions)`
+### `embedding(dimensions, options?)`
 
 Creates a Zod schema for vector embeddings with dimension validation.
+Carries optional vector-index configuration that the auto-derivation
+pass at `defineGraph()` time reads to produce
+`VectorIndexDeclaration` entries — see [Runtime Extensions →
+Vector indexes](/runtime-extensions#vector-indexes) for the full
+materialization flow.
 
 ```typescript
 import { embedding } from "@nicia-ai/typegraph";
 
-function embedding<D extends number>(dimensions: D): EmbeddingSchema<D>;
+function embedding<D extends number>(
+  dimensions: D,
+  options?: EmbeddingIndexOptions,
+): EmbeddingSchema<D>;
+
+type EmbeddingIndexOptions = Readonly<{
+  /** Distance metric. Default `"cosine"`. */
+  metric?: "cosine" | "l2" | "inner_product";
+  /** Vector index implementation. Default `"hnsw"`. */
+  indexType?: "hnsw" | "ivfflat" | "none";
+  /** HNSW: max connections per layer. Default `16`. */
+  m?: number;
+  /** HNSW: build-time search depth. Default `64`. */
+  efConstruction?: number;
+  /** IVFFlat: number of inverted-list partitions. */
+  lists?: number;
+}>;
 ```
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `dimensions` | `number` | The number of dimensions (e.g., 384, 512, 768, 1536, 3072) |
+| `dimensions` | `number` | Number of dimensions (e.g., 384, 512, 768, 1536, 3072) |
+| `options` | `EmbeddingIndexOptions?` | Optional index configuration. Defaults match pgvector recommendations. Pass `{ indexType: "none" }` to opt out of automatic materialization while keeping the embedding column. |
 
 **Example:**
 
 ```typescript
+// Defaults: cosine similarity, HNSW index, m=16, ef_construction=64.
 const Document = defineNode("Document", {
   schema: z.object({
     title: z.string(),
@@ -258,7 +281,24 @@ const Document = defineNode("Document", {
   }),
 });
 
-// Optional embeddings
+// Override at the brand site — this is the load-bearing place to
+// signal index intent because the metric usually reflects model
+// output (cosine-normalized vs. raw inner-product).
+const Image = defineNode("Image", {
+  schema: z.object({
+    embedding: embedding(512, { metric: "l2", m: 32, efConstruction: 100 }),
+  }),
+});
+
+// Opt out of automatic materialization while keeping the embedding column.
+const Manual = defineNode("Manual", {
+  schema: z.object({
+    embedding: embedding(384, { indexType: "none" }),
+  }),
+});
+
+// Optional embeddings work as before — the brand survives `.optional()` /
+// `.nullable()` wrappers and auto-derivation walks through them.
 const Article = defineNode("Article", {
   schema: z.object({
     content: z.string(),
@@ -267,7 +307,9 @@ const Article = defineNode("Article", {
 });
 ```
 
-See [Semantic Search](/semantic-search) for query usage.
+See [Semantic Search](/semantic-search) for query usage and
+[Runtime Extensions](/runtime-extensions#vector-indexes) for how the
+auto-derived index flows through `materializeIndexes()`.
 
 ### `externalRef(table)`
 

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -402,7 +402,7 @@ export function createPostgresBackend(
       return {
         indexName: row.indexName,
         graphId: row.graphId,
-        entity: row.entity as "node" | "edge",
+        entity: row.entity as "node" | "edge" | "vector",
         kind: row.kind,
         signature: row.signature,
         schemaVersion: row.schemaVersion,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -683,7 +683,7 @@ export function createSqliteBackend(
       return {
         indexName: row.indexName,
         graphId: row.graphId,
-        entity: row.entity as "node" | "edge",
+        entity: row.entity as "node" | "edge" | "vector",
         kind: row.kind,
         signature: row.signature,
         schemaVersion: row.schemaVersion,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -365,6 +365,14 @@ export type DropVectorIndexParams = Readonly<{
  *
  * One row per node. Callers concatenate the searchable fields into
  * `content` so a single MATCH query can find terms spread across fields.
+ *
+ * Note: `createFulltextIndex` / `dropFulltextIndex` were removed as
+ * dead code in #PR_E. The fulltext table's canonical index (Postgres
+ * GIN on `tsv`, SQLite FTS5 virtual table) is created with the table
+ * itself by `bootstrapTables` per the active `FulltextStrategy`;
+ * per-kind fulltext indexes are an "advanced strategy" surface that
+ * doesn't fit the relational-style declaration model and is reserved
+ * for future work.
  */
 export type UpsertFulltextParams = Readonly<{
   graphId: string;
@@ -467,19 +475,6 @@ export type FulltextSearchResult = Readonly<{
  * is created when the fulltext table itself is created. This is reserved
  * for advanced per-kind specializations.
  */
-type CreateFulltextIndexParams = Readonly<{
-  graphId: string;
-  nodeKind: string;
-  language: string;
-}>;
-
-/**
- * Parameters for dropping a fulltext index created via createFulltextIndex.
- */
-type DropFulltextIndexParams = Readonly<{
-  graphId: string;
-  nodeKind: string;
-}>;
 
 // ============================================================
 // Index Materialization Status
@@ -496,7 +491,7 @@ type DropFulltextIndexParams = Readonly<{
 export type IndexMaterializationRow = Readonly<{
   indexName: string;
   graphId: string;
-  entity: "node" | "edge";
+  entity: "node" | "edge" | "vector";
   kind: string;
   signature: string;
   schemaVersion: number;
@@ -515,7 +510,7 @@ export type IndexMaterializationRow = Readonly<{
 export type RecordIndexMaterializationParams = Readonly<{
   indexName: string;
   graphId: string;
-  entity: "node" | "edge";
+  entity: "node" | "edge" | "vector";
   kind: string;
   signature: string;
   schemaVersion: number;
@@ -726,8 +721,6 @@ export type GraphBackend = Readonly<{
   fulltextSearch?: (
     params: FulltextSearchParams,
   ) => Promise<readonly FulltextSearchResult[]>;
-  createFulltextIndex?: (params: CreateFulltextIndexParams) => Promise<void>;
-  dropFulltextIndex?: (params: DropFulltextIndexParams) => Promise<void>;
 
   // === Index Materialization (used by store.materializeIndexes) ===
   /**

--- a/packages/typegraph/src/core/define-graph.ts
+++ b/packages/typegraph/src/core/define-graph.ts
@@ -1,4 +1,8 @@
 import { ConfigurationError } from "../errors/index";
+import {
+  autoDeriveVectorIndexes,
+  mergeVectorIndexes,
+} from "../indexes/auto-derive";
 import { type IndexDeclaration } from "../indexes/types";
 import { type OntologyRelation } from "../ontology/types";
 import { type RuntimeGraphDocument } from "../runtime/document-types";
@@ -341,10 +345,30 @@ export function defineGraph<
 
   const allNodeTypes = Object.values(config.nodes).map((reg) => reg.type);
   const normalizedEdges = normalizeEdges(config.edges, allNodeTypes);
+  // Vector indexes are auto-derived from `embedding()` brands on node
+  // schemas (see `autoDeriveVectorIndexes`). Explicit declarations
+  // passed via `defineGraph({ indexes })` win on (kind, fieldPath)
+  // collisions so consumers can override defaults — see
+  // `mergeVectorIndexes`. The merged list flows through
+  // `normalizeIndexes` for the standard kind-registered + unique-name
+  // checks.
+  //
+  // Preservation rule: if the consumer never passed `indexes` at all
+  // AND no embedding brands exist, leave `graph.indexes` undefined to
+  // keep the introspection surface stable for legacy graphs. If the
+  // consumer passed an explicit `[]`, surface it as `[]` (not
+  // `undefined`) to match the contract pinned by the
+  // "preserves an explicit empty indexes array" test.
+  const autoVectorIndexes = autoDeriveVectorIndexes(config.nodes);
+  const explicitProvided = config.indexes !== undefined;
+  const mergedIndexes = mergeVectorIndexes(
+    config.indexes ?? [],
+    autoVectorIndexes,
+  );
   const indexes =
-    config.indexes === undefined ?
+    !explicitProvided && mergedIndexes.length === 0 ?
       undefined
-    : normalizeIndexes(config.indexes, config.nodes, normalizedEdges);
+    : normalizeIndexes(mergedIndexes, config.nodes, normalizedEdges);
 
   return Object.freeze({
     [GRAPH_DEF_BRAND]: true as const,
@@ -390,7 +414,9 @@ function normalizeIndexes(
   const seenNames = new Set<string>();
 
   for (const declaration of inputs) {
-    if (declaration.entity === "node") {
+    if (declaration.entity === "node" || declaration.entity === "vector") {
+      // Vector indexes attach to node kinds (the embedding lives on a
+      // node field). Validation reuses the node-kind check.
       assertKindRegistered(declaration, nodeKinds, "node");
     } else {
       assertKindRegistered(declaration, edgeKinds, "edge");

--- a/packages/typegraph/src/core/embedding.ts
+++ b/packages/typegraph/src/core/embedding.ts
@@ -37,6 +37,74 @@ export type EmbeddingValue = readonly number[] & {
  */
 export const EMBEDDING_DIMENSIONS_KEY = "_embeddingDimensions" as const;
 
+/**
+ * Symbol key for storing the embedding's preferred index configuration
+ * on the schema. The schema introspector reads this when auto-deriving
+ * `VectorIndexDeclaration` entries at `defineGraph()` time.
+ */
+export const EMBEDDING_INDEX_KEY = "_embeddingIndex" as const;
+
+/**
+ * Distance metric used for vector similarity. Pinned at the embedding
+ * brand because changing the metric usually means generating different
+ * model output (e.g. cosine-normalized vs. raw inner-product), and the
+ * stored index needs the same metric to score correctly.
+ *
+ * - `cosine`: cosine similarity. The default — works for most
+ *   sentence-transformer / OpenAI-style embeddings that are already
+ *   length-normalized.
+ * - `l2`: Euclidean distance. Use when your model outputs vectors
+ *   trained for L2 (e.g. some image embedding models).
+ * - `inner_product`: dot-product distance. Use when your model outputs
+ *   pre-normalized vectors AND you want to skip the cosine
+ *   normalization step at query time.
+ */
+export type EmbeddingMetric = "cosine" | "l2" | "inner_product";
+
+/**
+ * Vector index implementation. `hnsw` is the default and what pgvector
+ * recommends for most workloads. `ivfflat` is the alternative for
+ * larger datasets where memory is the bottleneck. `none` disables
+ * automatic index creation for this embedding (the operator can still
+ * call `backend.createVectorIndex` manually).
+ */
+export type EmbeddingIndexType = "hnsw" | "ivfflat" | "none";
+
+/**
+ * Per-embedding configuration for the auto-derived
+ * `VectorIndexDeclaration`. All fields are optional with sensible
+ * defaults (`cosine` / `hnsw` / pgvector defaults: `m=16`,
+ * `ef_construction=64`). Override only when your model or dataset has
+ * a known reason to.
+ */
+export type EmbeddingIndexOptions = Readonly<{
+  /** Distance metric. Default `"cosine"`. */
+  metric?: EmbeddingMetric;
+  /** Vector index implementation. Default `"hnsw"`. */
+  indexType?: EmbeddingIndexType;
+  /** HNSW `m` parameter — max connections per layer. Default `16`. */
+  m?: number;
+  /** HNSW `ef_construction` parameter — build-time search depth. Default `64`. */
+  efConstruction?: number;
+  /** IVFFlat `lists` parameter — number of inverted-list partitions. */
+  lists?: number;
+}>;
+
+/**
+ * Resolved embedding index configuration with all defaults applied.
+ * What gets attached to the brand and read by the auto-derivation pass.
+ */
+export type ResolvedEmbeddingIndex = Readonly<{
+  metric: EmbeddingMetric;
+  indexType: EmbeddingIndexType;
+  m: number;
+  efConstruction: number;
+  lists: number | undefined;
+}>;
+
+const DEFAULT_HNSW_M = 16;
+const DEFAULT_HNSW_EF_CONSTRUCTION = 64;
+
 // ============================================================
 // Embedding Schema Type
 // ============================================================
@@ -49,6 +117,7 @@ export type EmbeddingSchema<D extends number = number> =
   z.ZodType<EmbeddingValue> &
     Readonly<{
       [EMBEDDING_DIMENSIONS_KEY]: D;
+      [EMBEDDING_INDEX_KEY]: ResolvedEmbeddingIndex;
     }>;
 
 // ============================================================
@@ -91,12 +160,17 @@ export type EmbeddingSchema<D extends number = number> =
  * });
  * ```
  */
-export function embedding<D extends number>(dimensions: D): EmbeddingSchema<D> {
+export function embedding<D extends number>(
+  dimensions: D,
+  options: EmbeddingIndexOptions = {},
+): EmbeddingSchema<D> {
   if (!Number.isInteger(dimensions) || dimensions <= 0) {
     throw new Error(
       `Embedding dimensions must be a positive integer, got: ${dimensions}`,
     );
   }
+
+  const indexConfig = resolveEmbeddingIndex(options);
 
   // Use EmbeddingValue as the output type for proper type branding.
   // At runtime, validation accepts any number array with correct dimensions.
@@ -115,9 +189,44 @@ export function embedding<D extends number>(dimensions: D): EmbeddingSchema<D> {
     },
   );
 
-  // Attach dimensions metadata for introspection
   return Object.assign(schema, {
     [EMBEDDING_DIMENSIONS_KEY]: dimensions,
+    [EMBEDDING_INDEX_KEY]: indexConfig,
+  });
+}
+
+function resolveEmbeddingIndex(
+  options: EmbeddingIndexOptions,
+): ResolvedEmbeddingIndex {
+  const indexType = options.indexType ?? "hnsw";
+  const m = options.m ?? DEFAULT_HNSW_M;
+  const efConstruction = options.efConstruction ?? DEFAULT_HNSW_EF_CONSTRUCTION;
+
+  if (m <= 0 || !Number.isInteger(m)) {
+    throw new Error(
+      `embedding() index option 'm' must be a positive integer, got: ${m}`,
+    );
+  }
+  if (efConstruction <= 0 || !Number.isInteger(efConstruction)) {
+    throw new Error(
+      `embedding() index option 'efConstruction' must be a positive integer, got: ${efConstruction}`,
+    );
+  }
+  if (
+    options.lists !== undefined &&
+    (options.lists <= 0 || !Number.isInteger(options.lists))
+  ) {
+    throw new Error(
+      `embedding() index option 'lists' must be a positive integer, got: ${options.lists}`,
+    );
+  }
+
+  return Object.freeze({
+    metric: options.metric ?? "cosine",
+    indexType,
+    m,
+    efConstruction,
+    lists: options.lists,
   });
 }
 
@@ -147,4 +256,21 @@ export function getEmbeddingDimensions(schema: z.ZodType): number | undefined {
     return schema[EMBEDDING_DIMENSIONS_KEY];
   }
   return undefined;
+}
+
+/**
+ * Gets the resolved index configuration from an embedding schema.
+ * Returns undefined if the schema is not an embedding schema. Used by
+ * the auto-derivation pass at `defineGraph()` time to build vector
+ * `IndexDeclaration` entries.
+ */
+export function getEmbeddingIndex(
+  schema: z.ZodType,
+): ResolvedEmbeddingIndex | undefined {
+  if (!isEmbeddingSchema(schema)) return undefined;
+  const candidate = (schema as unknown as Record<string, unknown>)[
+    EMBEDDING_INDEX_KEY
+  ];
+  if (candidate === undefined) return undefined;
+  return candidate as ResolvedEmbeddingIndex;
 }

--- a/packages/typegraph/src/indexes/auto-derive.ts
+++ b/packages/typegraph/src/indexes/auto-derive.ts
@@ -1,0 +1,193 @@
+/**
+ * Auto-derive vector index declarations from `embedding()` brands on
+ * node schemas.
+ *
+ * Walks each node's top-level Zod shape, finds fields wrapped in
+ * `embedding(dimensions, opts)` (including `.optional()` /
+ * `.nullable()` wrappers), and emits one `VectorIndexDeclaration` per
+ * (kind, field) pair. The declaration carries the resolved index
+ * configuration from the embedding brand — metric, indexType, HNSW /
+ * IVFFlat params — so the materializer doesn't need to reach back into
+ * the Zod schema.
+ *
+ * Auto-derivation is intentionally limited to TOP-LEVEL embedding
+ * fields. Embeddings nested inside object properties are out of scope
+ * for v1 — pgvector's column-based indexes don't address sub-paths
+ * cleanly, and the storage layer's `typegraph_node_embeddings` table
+ * uses a flat `field_path` keyed at the kind level.
+ *
+ * Explicit `defineVectorIndex(node, fieldPath, opts)` declarations
+ * passed via `defineGraph({ indexes })` take precedence — when an
+ * explicit declaration matches the same (kind, fieldPath) as an
+ * auto-derived one, the explicit version wins. This lets consumers
+ * override defaults without losing auto-derivation for other fields.
+ */
+
+import { type z } from "zod";
+
+import {
+  EMBEDDING_INDEX_KEY,
+  getEmbeddingIndex,
+  isEmbeddingSchema,
+  type ResolvedEmbeddingIndex,
+} from "../core/embedding";
+import { type NodeRegistration } from "../core/types";
+import { type IndexDeclaration, type VectorIndexDeclaration } from "./types";
+
+/**
+ * Auto-derive vector index declarations from embedding brands on a
+ * map of node registrations. Returns one declaration per
+ * (kind, top-level field) pair. Empty array when no embeddings found.
+ *
+ * Cross-graph status-table disambiguation does NOT happen here — the
+ * declaration name stays clean (`tg_vec_{kind}_{field}_{metric}`) so
+ * `pg_indexes` and result-entry inspection are readable. The
+ * materializer composes a graph-scoped key (`${graphId}::${name}`)
+ * for status-table identity, applied uniformly to both auto-derived
+ * and explicit `VectorIndexDeclaration` entries — see
+ * `vectorStatusKey` in `store/materialize-indexes.ts`. This keeps
+ * the disambiguation rule in one place that BOTH paths go through,
+ * rather than depending on the auto-derive caller to produce a
+ * graph-scoped name.
+ */
+export function autoDeriveVectorIndexes(
+  nodes: Record<string, NodeRegistration>,
+): readonly VectorIndexDeclaration[] {
+  const out: VectorIndexDeclaration[] = [];
+  for (const registration of Object.values(nodes)) {
+    const node = registration.type;
+    const shape = readObjectShape(node.schema);
+    if (shape === undefined) continue;
+    for (const [fieldName, fieldSchema] of Object.entries(shape)) {
+      const config = readEmbeddingIndex(fieldSchema);
+      if (config === undefined) continue;
+      const dimensions = readEmbeddingDimensions(fieldSchema);
+      if (dimensions === undefined) continue;
+      out.push(buildAutoDerived(node.kind, fieldName, dimensions, config));
+    }
+  }
+  return out;
+}
+
+/**
+ * Merge auto-derived declarations with explicit ones, preferring
+ * explicit on (kind, fieldPath) collisions. Returns a flat list of all
+ * indexes; non-vector entries from `explicit` pass through unchanged.
+ */
+export function mergeVectorIndexes(
+  explicit: readonly IndexDeclaration[],
+  autoDerived: readonly VectorIndexDeclaration[],
+): readonly IndexDeclaration[] {
+  if (autoDerived.length === 0) return explicit;
+  const explicitVectorKeys = new Set<string>();
+  for (const declaration of explicit) {
+    if (declaration.entity === "vector") {
+      explicitVectorKeys.add(`${declaration.kind}|${declaration.fieldPath}`);
+    }
+  }
+  const filteredAuto = autoDerived.filter(
+    (entry) => !explicitVectorKeys.has(`${entry.kind}|${entry.fieldPath}`),
+  );
+  return [...explicit, ...filteredAuto];
+}
+
+/**
+ * Generate the deterministic vector index name. The visible prefix
+ * `tg_vec_<kind>_<field>_<metric>` keeps it scannable in result-entry
+ * inspection and the `typegraph_index_materializations` table.
+ *
+ * Cross-graph disambiguation is handled separately at the
+ * materialization boundary (see `vectorStatusKey`) so the declaration
+ * name doesn't need to carry `graphId` — the same auto-derived name
+ * is reusable across graphs and the materializer composes a
+ * graph-scoped status key for both auto-derived and explicit entries
+ * uniformly.
+ */
+function buildAutoDerived(
+  kind: string,
+  fieldName: string,
+  dimensions: number,
+  config: ResolvedEmbeddingIndex,
+): VectorIndexDeclaration {
+  const fieldPath = fieldName;
+  return Object.freeze({
+    entity: "vector" as const,
+    name: `tg_vec_${sanitize(kind)}_${sanitize(fieldName)}_${config.metric}`,
+    kind,
+    fieldPath,
+    dimensions,
+    metric: config.metric,
+    indexType: config.indexType,
+    indexParams: Object.freeze({
+      m: config.m,
+      efConstruction: config.efConstruction,
+      lists: config.lists,
+    }),
+  });
+}
+
+function sanitize(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9]/g, "_").toLowerCase();
+}
+
+function readObjectShape(
+  schema: z.ZodType,
+): Record<string, z.ZodType> | undefined {
+  if ((schema as { type?: string }).type !== "object") return undefined;
+  const shape = (schema.def as { shape?: Record<string, z.ZodType> }).shape;
+  return shape;
+}
+
+function readEmbeddingIndex(
+  schema: z.ZodType,
+): ResolvedEmbeddingIndex | undefined {
+  for (const candidate of unwrapChain(schema)) {
+    const config = getEmbeddingIndex(candidate);
+    if (config !== undefined) return config;
+  }
+  return undefined;
+}
+
+function readEmbeddingDimensions(schema: z.ZodType): number | undefined {
+  for (const candidate of unwrapChain(schema)) {
+    if (isEmbeddingSchema(candidate)) {
+      return (candidate as unknown as Record<string, number>)
+        ._embeddingDimensions;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Yield the schema and every reachable inner schema by repeatedly
+ * applying `.unwrap()` (Zod 4 optional/nullable/default) and
+ * `.def.innerType` (some wrappers). Cycle-guarded by depth and
+ * reference identity. Generators stop at the first non-unwrappable
+ * schema OR after 8 levels — deeper wrapping is pathological and not
+ * worth supporting.
+ */
+function* unwrapChain(schema: z.ZodType): Generator<z.ZodType, void, void> {
+  const seen = new Set<z.ZodType>();
+  let current: z.ZodType | undefined = schema;
+  let depth = 0;
+  while (current !== undefined && !seen.has(current) && depth < 8) {
+    seen.add(current);
+    yield current;
+    current = unwrapOnce(current);
+    depth++;
+  }
+}
+
+function unwrapOnce(schema: z.ZodType): z.ZodType | undefined {
+  // Zod 4 wrappers expose `.unwrap()` on optional/nullable/default.
+  const candidate = schema as unknown as { unwrap?: () => z.ZodType };
+  if (typeof candidate.unwrap === "function") return candidate.unwrap();
+  // Some wrappers expose the inner schema via `.def.innerType`.
+  return (schema as unknown as { def?: { innerType?: z.ZodType } }).def
+    ?.innerType;
+}
+
+// Suppress "unused" lint if EMBEDDING_INDEX_KEY isn't directly referenced
+// after the helpers above; it's part of the brand contract this module
+// reads through `getEmbeddingIndex`.
+void EMBEDDING_INDEX_KEY;

--- a/packages/typegraph/src/indexes/ddl.ts
+++ b/packages/typegraph/src/indexes/ddl.ts
@@ -10,8 +10,8 @@ import {
 } from "./compiler";
 import {
   type EdgeIndexDeclaration,
-  type IndexDeclaration,
   type NodeIndexDeclaration,
+  type RelationalIndexDeclaration,
   type SystemColumnName,
 } from "./types";
 
@@ -30,10 +30,17 @@ export type GenerateIndexDdlOptions = Readonly<{
 }>;
 
 /**
- * Generate `CREATE INDEX` DDL for a single index declaration.
+ * Generate `CREATE INDEX` DDL for a single relational index declaration.
+ *
+ * Vector index declarations (`entity: "vector"`) are NOT handled here —
+ * they go through `backend.createVectorIndex` instead because the DDL
+ * is dialect-specific (`USING hnsw (...) WITH (m=..., ef_construction=...)`
+ * on Postgres) and operates on the embeddings table, not
+ * `typegraph_nodes` / `typegraph_edges`. Callers narrow to the
+ * relational subset before calling this function.
  */
 export function generateIndexDDL(
-  index: IndexDeclaration,
+  index: RelationalIndexDeclaration,
   dialect: SqlDialect,
   options: GenerateIndexDdlOptions = {},
 ): string {
@@ -62,7 +69,7 @@ export function generateEdgeIndexDDL(
 }
 
 function generateTableIndexDDL(
-  index: IndexDeclaration,
+  index: RelationalIndexDeclaration,
   dialect: SqlDialect,
   tableName: string,
   options: GenerateIndexDdlOptions,

--- a/packages/typegraph/src/indexes/index.ts
+++ b/packages/typegraph/src/indexes/index.ts
@@ -68,6 +68,11 @@ export type {
   NodeIndexConfig,
   NodeIndexDeclaration,
   NodeIndexWhereBuilder,
+  RelationalIndexDeclaration,
   SystemColumnName,
+  VectorIndexDeclaration,
+  VectorIndexImplementation,
+  VectorIndexMetric,
+  VectorIndexParams,
 } from "./types";
 export { andWhere, notWhere, orWhere } from "./where";

--- a/packages/typegraph/src/indexes/profiler.ts
+++ b/packages/typegraph/src/indexes/profiler.ts
@@ -1,7 +1,12 @@
 import { type DeclaredIndex } from "../profiler/types";
-import { type IndexDeclaration } from "./types";
+import {
+  type IndexDeclaration,
+  type RelationalIndexDeclaration,
+} from "./types";
 
-export function toDeclaredIndex(index: IndexDeclaration): DeclaredIndex {
+export function toDeclaredIndex(
+  index: RelationalIndexDeclaration,
+): DeclaredIndex {
   return {
     entityType: index.entity,
     kind: index.kind,
@@ -11,8 +16,20 @@ export function toDeclaredIndex(index: IndexDeclaration): DeclaredIndex {
   };
 }
 
+/**
+ * Vector indexes are excluded from the profiler-format conversion —
+ * the profiler operates on relational tables (`typegraph_nodes` /
+ * `typegraph_edges`) where index hits / misses can be measured against
+ * SQL plans. Vector indexes live on the embeddings table with a
+ * different access pattern.
+ */
 export function toDeclaredIndexes(
   indexes: readonly IndexDeclaration[],
 ): readonly DeclaredIndex[] {
-  return indexes.map((index) => toDeclaredIndex(index));
+  return indexes
+    .filter(
+      (index): index is RelationalIndexDeclaration =>
+        index.entity === "node" || index.entity === "edge",
+    )
+    .map((index) => toDeclaredIndex(index));
 }

--- a/packages/typegraph/src/indexes/types.ts
+++ b/packages/typegraph/src/indexes/types.ts
@@ -266,6 +266,76 @@ export type EdgeIndexDeclaration = IndexDeclarationBase &
   }>;
 
 /**
+ * Distance metric for vector similarity. Mirrors `EmbeddingMetric` from
+ * `core/embedding.ts` (re-exported here as part of the index surface).
+ */
+export type VectorIndexMetric = "cosine" | "l2" | "inner_product";
+
+/**
+ * Vector index implementation. `none` is a declarative opt-out: the
+ * declaration carries shape metadata for tooling but `materializeIndexes`
+ * skips the DDL.
+ */
+export type VectorIndexImplementation = "hnsw" | "ivfflat" | "none";
+
+/**
+ * Vector-index parameters. Concrete defaults are applied at the
+ * `embedding(...)` brand boundary; this carries them onto the
+ * declaration so the materializer / signature / drift detection have
+ * everything they need without re-resolving from the brand.
+ */
+export type VectorIndexParams = Readonly<{
+  /** HNSW: max connections per layer. */
+  m: number;
+  /** HNSW: build-time search depth. */
+  efConstruction: number;
+  /** IVFFlat: number of inverted lists. `undefined` when not IVFFlat. */
+  lists: number | undefined;
+}>;
+
+/**
+ * Vector index declaration. Auto-derived from `embedding()` brands at
+ * `defineGraph()` time and explicitly buildable via `defineVectorIndex`.
+ *
+ * Identity key is `(kind, fieldPath)` — v1 allows at most one vector
+ * index per (kind, field) pair. The `name` field is generated
+ * deterministically from this tuple plus the metric so consumers don't
+ * accidentally collide vector index names with relational indexes.
+ *
+ * `unique` / `scope` / `where` from the relational base are NOT
+ * supported on vector — pgvector / sqlite-vec don't implement them.
+ */
+export type VectorIndexDeclaration = Readonly<{
+  entity: "vector";
+  /** Index name (also the physical identity key in the materialization status table). */
+  name: string;
+  origin?: IndexOrigin;
+  /** Node kind the embedding lives on. */
+  kind: string;
+  /** JSON-pointer-style field path for the embedding inside the node's props. */
+  fieldPath: string;
+  /** Embedding dimensionality. */
+  dimensions: number;
+  /** Distance metric. */
+  metric: VectorIndexMetric;
+  /** Index implementation. */
+  indexType: VectorIndexImplementation;
+  /** Concrete index parameters. */
+  indexParams: VectorIndexParams;
+}>;
+
+/**
+ * Relational subset of `IndexDeclaration` — the variants that emit
+ * `CREATE INDEX` DDL via `generateIndexDDL`. Used to narrow input
+ * types in the relational DDL / serializer / migration code paths
+ * that don't apply to vector indexes (which use a different
+ * materialization primitive on the backend).
+ */
+export type RelationalIndexDeclaration =
+  | NodeIndexDeclaration
+  | EdgeIndexDeclaration;
+
+/**
  * A serializable index declaration that flows through `GraphDef.indexes`
  * and `SerializedSchema.indexes`.
  *
@@ -274,7 +344,9 @@ export type EdgeIndexDeclaration = IndexDeclarationBase &
  * reconstructed from a stored schema document compile to byte-identical
  * SQL.
  */
-export type IndexDeclaration = NodeIndexDeclaration | EdgeIndexDeclaration;
+export type IndexDeclaration =
+  | RelationalIndexDeclaration
+  | VectorIndexDeclaration;
 
 // ============================================================
 // System Columns

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -94,8 +94,13 @@ export type IndexChange = Readonly<{
   type: ChangeType;
   /** Index name (the diffing identity key). */
   name: string;
-  /** Whether this index is on a node or edge kind. */
-  entity: "node" | "edge";
+  /**
+   * Whether this index is on a node, edge, or vector field. Mirrors
+   * `IndexDeclaration.entity` — `"vector"` was added with vector index
+   * unification so vector changes flow through the same diff
+   * classification as relational ones.
+   */
+  entity: "node" | "edge" | "vector";
   severity: ChangeSeverity;
   details: string;
   before?: IndexDeclaration | undefined;

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -21,6 +21,7 @@ import {
   type EdgeIndexDeclaration,
   type IndexDeclaration,
   type NodeIndexDeclaration,
+  type VectorIndexDeclaration,
 } from "../indexes/types";
 import {
   getTypeName,
@@ -154,7 +155,26 @@ function serializeIndexDeclaration(
   if (declaration.entity === "node") {
     return serializeNodeIndexDeclaration(declaration);
   }
-  return serializeEdgeIndexDeclaration(declaration);
+  if (declaration.entity === "edge") {
+    return serializeEdgeIndexDeclaration(declaration);
+  }
+  return serializeVectorIndexDeclaration(declaration);
+}
+
+function serializeVectorIndexDeclaration(
+  declaration: VectorIndexDeclaration,
+): VectorIndexDeclaration {
+  return {
+    entity: "vector",
+    kind: declaration.kind,
+    name: declaration.name,
+    fieldPath: declaration.fieldPath,
+    dimensions: declaration.dimensions,
+    metric: declaration.metric,
+    indexType: declaration.indexType,
+    indexParams: declaration.indexParams,
+    ...(declaration.origin === "runtime" ? { origin: "runtime" as const } : {}),
+  };
 }
 
 function serializeNodeIndexDeclaration(

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -212,9 +212,36 @@ const edgeIndexDeclarationZod = z
   })
   .loose();
 
+const vectorIndexMetricZod = z.enum(["cosine", "l2", "inner_product"]);
+
+const vectorIndexImplementationZod = z.enum(["hnsw", "ivfflat", "none"]);
+
+const vectorIndexParamsZod = z
+  .object({
+    m: z.number(),
+    efConstruction: z.number(),
+    lists: z.number().optional(),
+  })
+  .loose();
+
+const vectorIndexDeclarationZod = z
+  .object({
+    entity: z.literal("vector"),
+    name: z.string(),
+    origin: indexOriginZod.optional(),
+    kind: z.string(),
+    fieldPath: z.string(),
+    dimensions: z.number(),
+    metric: vectorIndexMetricZod,
+    indexType: vectorIndexImplementationZod,
+    indexParams: vectorIndexParamsZod,
+  })
+  .loose();
+
 const indexDeclarationZod = z.discriminatedUnion("entity", [
   nodeIndexDeclarationZod,
   edgeIndexDeclarationZod,
+  vectorIndexDeclarationZod,
 ]);
 
 // ============================================================

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -27,12 +27,18 @@
  */
 
 import {
+  type CreateVectorIndexParams,
   type GraphBackend,
   type RecordIndexMaterializationParams,
 } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
 import { ConfigurationError } from "../errors";
-import { generateIndexDDL, type IndexDeclaration } from "../indexes";
+import {
+  generateIndexDDL,
+  type IndexDeclaration,
+  type RelationalIndexDeclaration,
+  type VectorIndexDeclaration,
+} from "../indexes";
 import { sortedReplacer } from "../schema/canonical";
 import { nowIso } from "../utils/date";
 
@@ -43,12 +49,32 @@ export type MaterializeIndexesOptions = Readonly<{
   stopOnError?: boolean;
 }>;
 
+/**
+ * Per-index outcome from `materializeIndexes()`.
+ *
+ * Status values:
+ * - `created`: DDL ran successfully and a new physical index now exists.
+ * - `alreadyMaterialized`: status table shows a prior successful
+ *   materialization with the same signature; no DDL ran.
+ * - `failed`: the DDL or status write failed; `error` carries the
+ *   captured exception. Best-effort mode continues to the next index;
+ *   `stopOnError: true` halts.
+ * - `skipped`: the backend can't materialize this index variant in its
+ *   current configuration (e.g. vector indexes against SQLite without
+ *   sqlite-vec, or `indexType: "none"` declared on an embedding). The
+ *   declaration is recognized but intentionally not acted on. Status
+ *   table is NOT updated for skipped entries.
+ */
 export type MaterializeIndexesEntry = Readonly<{
   indexName: string;
-  entity: "node" | "edge";
+  entity: "node" | "edge" | "vector";
   kind: string;
-  status: "created" | "alreadyMaterialized" | "failed";
+  status: "created" | "alreadyMaterialized" | "failed" | "skipped";
   error?: Error;
+  /**
+   * Human-readable reason. Required for `skipped`; optional otherwise.
+   */
+  reason?: string;
 }>;
 
 export type MaterializeIndexesResult = Readonly<{
@@ -146,99 +172,307 @@ export async function materializeIndexes(
 
   const results: MaterializeIndexesEntry[] = [];
   for (const declaration of candidates) {
-    const ddl = generateIndexDDL(declaration, dialect, ddlOptions);
-    const targetTable =
-      declaration.entity === "node" ?
-        (ddlOptions.nodesTableName ?? "typegraph_nodes")
-      : (ddlOptions.edgesTableName ?? "typegraph_edges");
-    const signature = await computeIndexSignature(
-      dialect,
-      targetTable,
-      declaration,
-    );
-
-    const existing = await backend.getIndexMaterialization(declaration.name);
-    if (existing?.materializedAt !== undefined) {
-      if (existing.signature === signature) {
-        results.push({
-          indexName: declaration.name,
-          entity: declaration.entity,
-          kind: declaration.kind,
-          status: "alreadyMaterialized",
-        });
-        continue;
-      }
-      // Signature drift — recorded shape does not match the current
-      // declaration. Refuse to silently drop+recreate.
-      const error = new Error(
-        `Index "${declaration.name}" already materialized with a different signature (recorded by graph "${existing.graphId}" at version ${existing.schemaVersion}). Drop the index manually and retry, or rename the new declaration.`,
-      );
-      await backend.recordIndexMaterialization(
-        buildAttempt({
+    const entry =
+      declaration.entity === "vector" ?
+        await materializeVectorIndex(
           declaration,
+          backend,
           graphId,
-          signature,
           schemaVersion,
-          materializedAt: undefined,
-          error,
-        }),
-      );
-      results.push({
-        indexName: declaration.name,
-        entity: declaration.entity,
-        kind: declaration.kind,
-        status: "failed",
-        error,
-      });
-      if (options.stopOnError === true) break;
-      continue;
-    }
-
-    try {
-      await backend.executeDdl(ddl);
-      const attemptedAt = nowIso();
-      await backend.recordIndexMaterialization(
-        buildAttempt({
+        )
+      : await materializeRelationalIndex(
           declaration,
+          backend,
+          dialect,
+          ddlOptions,
           graphId,
-          signature,
           schemaVersion,
-          materializedAt: attemptedAt,
-          error: undefined,
-          attemptedAt,
-        }),
-      );
-      results.push({
-        indexName: declaration.name,
-        entity: declaration.entity,
-        kind: declaration.kind,
-        status: "created",
-      });
-    } catch (error_) {
-      const error =
-        error_ instanceof Error ? error_ : new Error(String(error_));
-      await backend.recordIndexMaterialization(
-        buildAttempt({
-          declaration,
-          graphId,
-          signature,
-          schemaVersion,
-          materializedAt: undefined,
-          error,
-        }),
-      );
-      results.push({
-        indexName: declaration.name,
-        entity: declaration.entity,
-        kind: declaration.kind,
-        status: "failed",
-        error,
-      });
-      if (options.stopOnError === true) break;
-    }
+        );
+    results.push(entry);
+    if (entry.status === "failed" && options.stopOnError === true) break;
   }
 
   return { results };
+}
+
+async function materializeRelationalIndex(
+  declaration: RelationalIndexDeclaration,
+  backend: GraphBackend,
+  dialect: "sqlite" | "postgres",
+  ddlOptions: Readonly<{
+    ifNotExists: boolean;
+    concurrent: boolean;
+    nodesTableName?: string;
+    edgesTableName?: string;
+  }>,
+  graphId: string,
+  schemaVersion: number,
+): Promise<MaterializeIndexesEntry> {
+  // Narrowed by callsite — these are guaranteed defined when this is
+  // reached (validated above).
+  const executeDdl = backend.executeDdl!;
+  const recordIndexMaterialization = backend.recordIndexMaterialization!;
+  const getIndexMaterialization = backend.getIndexMaterialization!;
+
+  const ddl = generateIndexDDL(declaration, dialect, ddlOptions);
+  const targetTable =
+    declaration.entity === "node" ?
+      (ddlOptions.nodesTableName ?? "typegraph_nodes")
+    : (ddlOptions.edgesTableName ?? "typegraph_edges");
+  const signature = await computeIndexSignature(
+    dialect,
+    targetTable,
+    declaration,
+  );
+
+  const existing = await getIndexMaterialization(declaration.name);
+  if (existing?.materializedAt !== undefined) {
+    if (existing.signature === signature) {
+      return {
+        indexName: declaration.name,
+        entity: declaration.entity,
+        kind: declaration.kind,
+        status: "alreadyMaterialized",
+      };
+    }
+    const error = new Error(
+      `Index "${declaration.name}" already materialized with a different signature (recorded by graph "${existing.graphId}" at version ${existing.schemaVersion}). Drop the index manually and retry, or rename the new declaration.`,
+    );
+    await recordIndexMaterialization(
+      buildAttempt({
+        declaration,
+        graphId,
+        signature,
+        schemaVersion,
+        materializedAt: undefined,
+        error,
+      }),
+    );
+    return {
+      indexName: declaration.name,
+      entity: declaration.entity,
+      kind: declaration.kind,
+      status: "failed",
+      error,
+    };
+  }
+
+  try {
+    await executeDdl(ddl);
+    const attemptedAt = nowIso();
+    await recordIndexMaterialization(
+      buildAttempt({
+        declaration,
+        graphId,
+        signature,
+        schemaVersion,
+        materializedAt: attemptedAt,
+        error: undefined,
+        attemptedAt,
+      }),
+    );
+    return {
+      indexName: declaration.name,
+      entity: declaration.entity,
+      kind: declaration.kind,
+      status: "created",
+    };
+  } catch (error_) {
+    const error = error_ instanceof Error ? error_ : new Error(String(error_));
+    await recordIndexMaterialization(
+      buildAttempt({
+        declaration,
+        graphId,
+        signature,
+        schemaVersion,
+        materializedAt: undefined,
+        error,
+      }),
+    );
+    return {
+      indexName: declaration.name,
+      entity: declaration.entity,
+      kind: declaration.kind,
+      status: "failed",
+      error,
+    };
+  }
+}
+
+async function materializeVectorIndex(
+  declaration: VectorIndexDeclaration,
+  backend: GraphBackend,
+  graphId: string,
+  schemaVersion: number,
+): Promise<MaterializeIndexesEntry> {
+  // `indexType: "none"` is a declarative opt-out — the declaration
+  // carries shape metadata (dimensions, metric) for tooling but the
+  // operator has signaled "no automatic index". Surface as `skipped`.
+  if (declaration.indexType === "none") {
+    return {
+      indexName: declaration.name,
+      entity: "vector",
+      kind: declaration.kind,
+      status: "skipped",
+      reason: "indexType: 'none' opts out of automatic materialization",
+    };
+  }
+
+  // Capability check: backends declare vector support via
+  // `capabilities.vector` (e.g. SQLite needs sqlite-vec opt-in via
+  // `hasVectorEmbeddings: true` at backend creation; Postgres needs
+  // pgvector). When unsupported, surface as skipped — the declaration
+  // is recognized but the backend can't act on it.
+  const vectorCapability = backend.capabilities.vector;
+  if (
+    vectorCapability?.supported !== true ||
+    backend.createVectorIndex === undefined
+  ) {
+    return {
+      indexName: declaration.name,
+      entity: "vector",
+      kind: declaration.kind,
+      status: "skipped",
+      reason: `Backend (${backend.dialect}) does not support vector indexes in its current configuration`,
+    };
+  }
+  // Capability check (per index type): backends advertise the specific
+  // index implementations they support (e.g. SQLite + sqlite-vec
+  // accepts vectors but no HNSW/IVFFlat — the brute-force scan IS the
+  // "index"). Surface unsupported types as skipped so consumers see a
+  // clear "this backend can't materialize this declaration" signal
+  // instead of a silent no-op masquerading as `created`.
+  if (!vectorCapability.indexTypes.includes(declaration.indexType)) {
+    return {
+      indexName: declaration.name,
+      entity: "vector",
+      kind: declaration.kind,
+      status: "skipped",
+      reason: `Backend (${backend.dialect}) does not support index type "${declaration.indexType}" for vector indexes; supported: ${vectorCapability.indexTypes.join(", ") || "(none)"}`,
+    };
+  }
+
+  const recordIndexMaterialization = backend.recordIndexMaterialization!;
+  const getIndexMaterialization = backend.getIndexMaterialization!;
+
+  const signature = await computeIndexSignature(
+    backend.dialect,
+    "typegraph_node_embeddings",
+    declaration,
+  );
+
+  // Compound status-table key for vector entries. Pgvector creates
+  // one physical index per (graphId, kind, field) — so the
+  // per-deployment status table needs to disambiguate entries that
+  // SHARE a declaration name but belong to different graphs.
+  // Applied uniformly to auto-derived AND explicit declarations: the
+  // declaration name stays clean for inspection, the status key gets
+  // the graph scope. Without this, two graphs reusing the same
+  // explicit declaration name would collide — the second would
+  // falsely report `alreadyMaterialized` from the first's row.
+  const statusKey = vectorStatusKey(graphId, declaration.name);
+
+  const existing = await getIndexMaterialization(statusKey);
+  if (existing?.materializedAt !== undefined) {
+    if (existing.signature === signature) {
+      return {
+        indexName: declaration.name,
+        entity: "vector",
+        kind: declaration.kind,
+        status: "alreadyMaterialized",
+      };
+    }
+    const error = new Error(
+      `Vector index "${declaration.name}" already materialized with a different signature (recorded by graph "${existing.graphId}" at version ${existing.schemaVersion}). Drop the index manually and retry, or rename the new declaration.`,
+    );
+    await recordIndexMaterialization(
+      buildAttempt({
+        declaration,
+        graphId,
+        signature,
+        schemaVersion,
+        materializedAt: undefined,
+        error,
+        statusName: statusKey,
+      }),
+    );
+    return {
+      indexName: declaration.name,
+      entity: "vector",
+      kind: declaration.kind,
+      status: "failed",
+      error,
+    };
+  }
+
+  try {
+    const params: CreateVectorIndexParams = {
+      graphId,
+      nodeKind: declaration.kind,
+      fieldPath: declaration.fieldPath,
+      dimensions: declaration.dimensions,
+      metric: declaration.metric,
+      indexType: declaration.indexType,
+      indexParams: {
+        m: declaration.indexParams.m,
+        efConstruction: declaration.indexParams.efConstruction,
+        ...(declaration.indexParams.lists === undefined ?
+          {}
+        : { lists: declaration.indexParams.lists }),
+      },
+    };
+    await backend.createVectorIndex(params);
+    const attemptedAt = nowIso();
+    await recordIndexMaterialization(
+      buildAttempt({
+        declaration,
+        graphId,
+        signature,
+        schemaVersion,
+        materializedAt: attemptedAt,
+        error: undefined,
+        attemptedAt,
+        statusName: statusKey,
+      }),
+    );
+    return {
+      indexName: declaration.name,
+      entity: "vector",
+      kind: declaration.kind,
+      status: "created",
+    };
+  } catch (error_) {
+    const error = error_ instanceof Error ? error_ : new Error(String(error_));
+    await recordIndexMaterialization(
+      buildAttempt({
+        declaration,
+        graphId,
+        signature,
+        schemaVersion,
+        materializedAt: undefined,
+        error,
+        statusName: statusKey,
+      }),
+    );
+    return {
+      indexName: declaration.name,
+      entity: "vector",
+      kind: declaration.kind,
+      status: "failed",
+      error,
+    };
+  }
+}
+
+/**
+ * Compose the per-deployment status-table key for a vector index.
+ * Pgvector physical indexes are partial-by-graph_id (one per graph),
+ * so the status table needs graph-scoped identity to disambiguate
+ * two graphs reusing the same declaration name. The `::` separator
+ * keeps the compound visually unambiguous when inspecting the table.
+ */
+function vectorStatusKey(graphId: string, declarationName: string): string {
+  return `${graphId}::${declarationName}`;
 }
 
 function buildAttempt(
@@ -250,10 +484,17 @@ function buildAttempt(
     materializedAt: string | undefined;
     error: Error | undefined;
     attemptedAt?: string;
+    /**
+     * Override the status-table identity. Used by vector entries to
+     * inject the graph-scoped compound key (`vectorStatusKey`).
+     * Relational entries default to the declaration name because
+     * physical CREATE INDEX names are already database-global.
+     */
+    statusName?: string;
   }>,
 ): RecordIndexMaterializationParams {
   return {
-    indexName: args.declaration.name,
+    indexName: args.statusName ?? args.declaration.name,
     graphId: args.graphId,
     entity: args.declaration.entity,
     kind: args.declaration.kind,

--- a/packages/typegraph/tests/backends/postgres/materialize-vector-indexes.test.ts
+++ b/packages/typegraph/tests/backends/postgres/materialize-vector-indexes.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Postgres-specific tests for vector index unification — auto-derived
+ * `VectorIndexDeclaration` entries flow through `materializeIndexes()`
+ * and create real pgvector HNSW / IVFFlat indexes via the backend's
+ * `createVectorIndex` primitive.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph, defineNode } from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { embedding } from "../../../src/core/embedding";
+import { createStoreWithSchema } from "../../../src/store";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let sharedPool: Pool | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): { pool: Pool } {
+  if (!isPostgresAvailable || sharedPool === undefined) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return { pool: sharedPool };
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  const pool = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+  });
+  try {
+    await pool.query("SELECT 1");
+    sharedPool = pool;
+    isPostgresAvailable = true;
+    await pool.query(`
+      DROP TABLE IF EXISTS typegraph_index_materializations CASCADE;
+      DROP TABLE IF EXISTS typegraph_node_embeddings CASCADE;
+      DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
+      DROP TABLE IF EXISTS typegraph_edges CASCADE;
+      DROP TABLE IF EXISTS typegraph_nodes CASCADE;
+      DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+    `);
+    await pool.query(generatePostgresMigrationSQL());
+  } catch {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    await pool.end().catch(() => {});
+  }
+});
+
+afterAll(async () => {
+  if (sharedPool !== undefined) await sharedPool.end();
+});
+
+beforeEach(async () => {
+  if (sharedPool === undefined) return;
+  await sharedPool.query(
+    `TRUNCATE typegraph_index_materializations,
+              typegraph_node_embeddings,
+              typegraph_node_uniques,
+              typegraph_nodes,
+              typegraph_edges,
+              typegraph_schema_versions CASCADE`,
+  );
+  // Drop leaked physical indexes from prior runs.
+  const leaked = await sharedPool.query<{ indexname: string }>(
+    `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname LIKE 'tg_vec_%'`,
+  );
+  for (const { indexname } of leaked.rows) {
+    await sharedPool.query(`DROP INDEX IF EXISTS "${indexname}"`);
+  }
+});
+
+const Document = defineNode("Document", {
+  schema: z.object({
+    title: z.string(),
+    embedding: embedding(384),
+  }),
+});
+
+describe("Postgres store.materializeIndexes — vector dispatch", () => {
+  it("auto-derived vector index materializes as a real pgvector HNSW index", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const backend = createPostgresBackend(drizzle(pool));
+    const graph = defineGraph({
+      id: "vector_pg_auto",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const result = await store.materializeIndexes();
+    const vectorEntry = result.results.find(
+      (entry) => entry.entity === "vector",
+    );
+    expect(vectorEntry?.status).toBe("created");
+
+    // The physical pgvector index is now visible in pg_indexes. The
+    // bundled vector-index helper names HNSW indexes with `_hnsw_` in
+    // them; the higher-level VectorIndexDeclaration name uses `tg_vec_`
+    // and is what we record in the materialization status table.
+    const created = await pool.query<{ indexname: string; indexdef: string }>(
+      `SELECT indexname, indexdef FROM pg_indexes
+       WHERE schemaname = 'public' AND tablename = 'typegraph_node_embeddings'
+       AND indexdef LIKE '%hnsw%'`,
+    );
+    expect(created.rows.length).toBeGreaterThan(0);
+  });
+
+  it("is idempotent: a second call reports alreadyMaterialized", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const backend = createPostgresBackend(drizzle(pool));
+    const graph = defineGraph({
+      id: "vector_pg_idem",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    await store.materializeIndexes();
+    const second = await store.materializeIndexes();
+    const vectorEntry = second.results.find(
+      (entry) => entry.entity === "vector",
+    );
+    expect(vectorEntry?.status).toBe("alreadyMaterialized");
+  });
+
+  it("two graphs sharing the same kind/field each create their own physical pgvector index", async (ctx) => {
+    // Regression for the cross-graph false-skip bug. Two graphs
+    // declaring an embedding on `Document.embedding` should each
+    // produce their own physical pgvector index (which is partial-
+    // by-graph_id) and each report `created` — neither should hit
+    // `alreadyMaterialized` from the other graph's status row.
+    const { pool } = requirePostgres(ctx);
+    const graphA = defineGraph({
+      id: "vec_pg_xgraph_a",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const graphB = defineGraph({
+      id: "vec_pg_xgraph_b",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const [storeA] = await createStoreWithSchema(
+      graphA,
+      createPostgresBackend(drizzle(pool)),
+    );
+    const [storeB] = await createStoreWithSchema(
+      graphB,
+      createPostgresBackend(drizzle(pool)),
+    );
+
+    const resultA = await storeA.materializeIndexes();
+    const resultB = await storeB.materializeIndexes();
+
+    expect(
+      resultA.results.find((entry) => entry.entity === "vector")?.status,
+    ).toBe("created");
+    expect(
+      resultB.results.find((entry) => entry.entity === "vector")?.status,
+    ).toBe("created");
+
+    // Two physical pgvector indexes exist — one per graph.
+    const indexes = await pool.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes
+       WHERE schemaname = 'public' AND tablename = 'typegraph_node_embeddings'
+       AND indexdef LIKE '%hnsw%'
+       AND (indexname LIKE 'idx_emb_vec_pg_xgraph_a_%'
+         OR indexname LIKE 'idx_emb_vec_pg_xgraph_b_%')`,
+    );
+    expect(indexes.rows.length).toBe(2);
+  });
+
+  it("indexType: 'none' opts out of physical materialization", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const NoIndex = defineNode("NoIndex", {
+      schema: z.object({
+        title: z.string(),
+        embedding: embedding(384, { indexType: "none" }),
+      }),
+    });
+    const backend = createPostgresBackend(drizzle(pool));
+    const graph = defineGraph({
+      id: "vector_pg_none",
+      nodes: { NoIndex: { type: NoIndex } },
+      edges: {},
+    });
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const result = await store.materializeIndexes();
+    const vectorEntry = result.results.find(
+      (entry) => entry.entity === "vector",
+    );
+    expect(vectorEntry?.status).toBe("skipped");
+    expect(vectorEntry?.reason).toContain("'none'");
+  });
+});

--- a/packages/typegraph/tests/store-evolve-eager.test.ts
+++ b/packages/typegraph/tests/store-evolve-eager.test.ts
@@ -51,7 +51,7 @@ function buildGraphWithoutIndexes() {
  */
 async function forceSignatureDrift(
   backend: ReturnType<typeof createTestBackend>,
-  declared: { name: string; entity: "node" | "edge"; kind: string },
+  declared: { name: string; entity: "node" | "edge" | "vector"; kind: string },
   overrides: { signature?: string; graphId?: string } = {},
 ) {
   await backend.recordIndexMaterialization!({

--- a/packages/typegraph/tests/store-materialize-vector-indexes.test.ts
+++ b/packages/typegraph/tests/store-materialize-vector-indexes.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for vector index unification — `embedding()` brands flow into
+ * `GraphDef.indexes` as auto-derived `VectorIndexDeclaration` entries
+ * and are dispatched through `materializeIndexes()` like relational
+ * indexes.
+ *
+ * SQLite does not have native vector index support in the bundled
+ * configuration, so the test backend reports `status: "skipped"` for
+ * vector entries. Postgres with pgvector is covered separately in
+ * `tests/backends/postgres/`.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph, defineNode } from "../src";
+import { embedding } from "../src/core/embedding";
+import { type VectorIndexDeclaration } from "../src/indexes/types";
+import { createStoreWithSchema } from "../src/store";
+import { createTestBackend } from "./test-utils";
+
+const Document = defineNode("Document", {
+  schema: z.object({
+    title: z.string(),
+    embedding: embedding(384),
+  }),
+});
+
+const DocumentL2 = defineNode("DocumentL2", {
+  schema: z.object({
+    title: z.string(),
+    // Override metric: l2 instead of cosine.
+    embedding: embedding(512, { metric: "l2", m: 32, efConstruction: 100 }),
+  }),
+});
+
+const Plain = defineNode("Plain", {
+  schema: z.object({ name: z.string() }),
+});
+
+describe("auto-derive vector indexes from embedding() brands", () => {
+  it("auto-derives one VectorIndexDeclaration per embedding field, with default config", () => {
+    const graph = defineGraph({
+      id: "vector_auto",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+
+    const vectorIndexes = (graph.indexes ?? []).filter(
+      (entry): entry is VectorIndexDeclaration => entry.entity === "vector",
+    );
+    expect(vectorIndexes).toHaveLength(1);
+    const declaration = vectorIndexes[0]!;
+    expect(declaration.kind).toBe("Document");
+    expect(declaration.fieldPath).toBe("embedding");
+    expect(declaration.dimensions).toBe(384);
+    expect(declaration.metric).toBe("cosine");
+    expect(declaration.indexType).toBe("hnsw");
+    expect(declaration.indexParams.m).toBe(16);
+    expect(declaration.indexParams.efConstruction).toBe(64);
+  });
+
+  it("auto-derives with overridden metric and HNSW params from the brand", () => {
+    const graph = defineGraph({
+      id: "vector_auto_overrides",
+      nodes: { DocumentL2: { type: DocumentL2 } },
+      edges: {},
+    });
+
+    const declaration = (graph.indexes ?? []).find(
+      (entry): entry is VectorIndexDeclaration => entry.entity === "vector",
+    )!;
+    expect(declaration.dimensions).toBe(512);
+    expect(declaration.metric).toBe("l2");
+    expect(declaration.indexParams.m).toBe(32);
+    expect(declaration.indexParams.efConstruction).toBe(100);
+  });
+
+  it("emits no vector indexes when no embedding brand exists", () => {
+    const graph = defineGraph({
+      id: "vector_none",
+      nodes: { Plain: { type: Plain } },
+      edges: {},
+    });
+    expect(graph.indexes).toBeUndefined();
+  });
+
+  it("auto-derives only for top-level embedding fields (nested embeddings ignored in v1)", () => {
+    const Container = defineNode("Container", {
+      schema: z.object({
+        nested: z.object({ embedding: embedding(64) }),
+      }),
+    });
+    const graph = defineGraph({
+      id: "vector_nested",
+      nodes: { Container: { type: Container } },
+      edges: {},
+    });
+    const vectorIndexes = (graph.indexes ?? []).filter(
+      (entry) => entry.entity === "vector",
+    );
+    expect(vectorIndexes).toHaveLength(0);
+  });
+
+  it("includes the metric in the deterministic index name", () => {
+    const graph = defineGraph({
+      id: "vector_naming",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const declaration = (graph.indexes ?? []).find(
+      (entry): entry is VectorIndexDeclaration => entry.entity === "vector",
+    )!;
+    expect(declaration.name).toContain("document");
+    expect(declaration.name).toContain("embedding");
+    expect(declaration.name).toContain("cosine");
+  });
+
+  it("auto-derived names are clean (no graph id baked in) — disambiguation lives at the materialization boundary", () => {
+    // Auto-derived names stay scannable in `pg_indexes` and result-
+    // entry inspection. Cross-graph disambiguation is enforced by
+    // the materializer's compound status key, NOT by the declaration
+    // name itself — see the cross-graph status test below.
+    const graphA = defineGraph({
+      id: "vec_graph_a",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const graphB = defineGraph({
+      id: "vec_graph_b",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const declarationA = (graphA.indexes ?? []).find(
+      (entry): entry is VectorIndexDeclaration => entry.entity === "vector",
+    )!;
+    const declarationB = (graphB.indexes ?? []).find(
+      (entry): entry is VectorIndexDeclaration => entry.entity === "vector",
+    )!;
+    // Same declaration name across graphs — the disambiguation is
+    // applied at materialize time, not at the declaration boundary.
+    expect(declarationA.name).toBe(declarationB.name);
+    expect(declarationA.name).not.toContain("vec_graph_a");
+  });
+
+  it("auto-derives through chained Zod wrappers (.optional().nullable())", () => {
+    // Regression: readEmbeddingIndex used to unwrap only one level,
+    // which dropped chained-wrapper embeddings on the floor.
+    const ChainedWrap = defineNode("ChainedWrap", {
+      schema: z.object({
+        title: z.string(),
+        embedding: embedding(384).optional().nullable(),
+      }),
+    });
+    const graph = defineGraph({
+      id: "vector_chained_wrap",
+      nodes: { ChainedWrap: { type: ChainedWrap } },
+      edges: {},
+    });
+    const vectorIndexes = (graph.indexes ?? []).filter(
+      (entry): entry is VectorIndexDeclaration => entry.entity === "vector",
+    );
+    expect(vectorIndexes).toHaveLength(1);
+    expect(vectorIndexes[0]!.dimensions).toBe(384);
+    expect(vectorIndexes[0]!.metric).toBe("cosine");
+  });
+});
+
+describe("Store.materializeIndexes — vector dispatch on SQLite", () => {
+  it("reports vector indexes as skipped when the backend lacks vector support", async () => {
+    // The test backend does not enable sqlite-vec, so vector indexes
+    // can't be materialized. The dispatch returns status: "skipped"
+    // with a reason rather than failing.
+    const backend = createTestBackend();
+    const graph = defineGraph({
+      id: "vector_sqlite_skip",
+      nodes: { Document: { type: Document } },
+      edges: {},
+    });
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const result = await store.materializeIndexes();
+    const vectorEntry = result.results.find(
+      (entry) => entry.entity === "vector",
+    );
+    expect(vectorEntry).toBeDefined();
+    expect(vectorEntry!.status).toBe("skipped");
+    expect(vectorEntry!.reason).toMatch(/vector/i);
+  });
+
+  it("indexType: 'none' on the embedding brand surfaces as skipped with a clear reason", async () => {
+    const NoIndex = defineNode("NoIndex", {
+      schema: z.object({
+        title: z.string(),
+        embedding: embedding(384, { indexType: "none" }),
+      }),
+    });
+    const backend = createTestBackend();
+    const graph = defineGraph({
+      id: "vector_none_optout",
+      nodes: { NoIndex: { type: NoIndex } },
+      edges: {},
+    });
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const result = await store.materializeIndexes();
+    const vectorEntry = result.results.find(
+      (entry) => entry.entity === "vector",
+    );
+    expect(vectorEntry?.status).toBe("skipped");
+    expect(vectorEntry?.reason).toContain("'none'");
+  });
+});
+
+describe("explicit vector indexes win over auto-derived on (kind, fieldPath) collisions", () => {
+  it("preserves the explicit declaration when both auto-derived and explicit target the same field", () => {
+    // Build a graph where the consumer provides their own
+    // VectorIndexDeclaration overriding the auto-derived defaults.
+    const explicitVector: VectorIndexDeclaration = {
+      entity: "vector",
+      name: "custom_doc_embedding_idx",
+      kind: "Document",
+      fieldPath: "embedding",
+      dimensions: 384,
+      metric: "inner_product",
+      indexType: "ivfflat",
+      indexParams: { m: 16, efConstruction: 64, lists: 100 },
+    };
+
+    const graph = defineGraph({
+      id: "vector_explicit_override",
+      nodes: { Document: { type: Document } },
+      edges: {},
+      indexes: [explicitVector],
+    });
+
+    const vectorIndexes = (graph.indexes ?? []).filter(
+      (entry) => entry.entity === "vector",
+    );
+    expect(vectorIndexes).toHaveLength(1);
+    expect(vectorIndexes[0]).toBe(explicitVector);
+  });
+});
+
+describe("cross-graph vector status disambiguation (compound key)", () => {
+  it("explicit vector declarations sharing a name across two graphs do not collide in the status table", async () => {
+    // Regression for the explicit-declaration false-skip bug. Two
+    // graphs with identical explicit VectorIndexDeclaration entries
+    // (same name) used to hit `alreadyMaterialized` from each
+    // other's status row because the status table keyed on
+    // declaration.name only. The fix composes a compound
+    // `${graphId}::${declaration.name}` key at the materialization
+    // boundary so each graph gets its own row.
+    const sharedExplicit: VectorIndexDeclaration = {
+      entity: "vector",
+      name: "shared_explicit_vec",
+      kind: "Document",
+      fieldPath: "embedding",
+      dimensions: 384,
+      metric: "cosine",
+      indexType: "hnsw",
+      indexParams: { m: 16, efConstruction: 64, lists: undefined },
+    };
+    const graphA = defineGraph({
+      id: "vec_xgraph_a",
+      nodes: { Document: { type: Document } },
+      edges: {},
+      indexes: [sharedExplicit],
+    });
+    const graphB = defineGraph({
+      id: "vec_xgraph_b",
+      nodes: { Document: { type: Document } },
+      edges: {},
+      indexes: [sharedExplicit],
+    });
+
+    // SQLite test backend can't materialize HNSW vector indexes, so
+    // both sides report `skipped` — but the assertion that matters
+    // is "neither sees the OTHER's row as alreadyMaterialized".
+    // Status entries are written via the same compound key, and a
+    // skipped entry doesn't write to the status table at all, so
+    // we can't observe the disambiguation through the SQLite path
+    // alone. The Postgres-side test in
+    // `tests/backends/postgres/materialize-vector-indexes.test.ts`
+    // exercises the actually-materialized path with two real graphs.
+    //
+    // What we CAN observe here: the two graphs construct distinct
+    // declarations (same name, different graph context), and
+    // materialize doesn't crash on the shared explicit declaration.
+    const backend = createTestBackend();
+    const [storeA] = await createStoreWithSchema(graphA, backend);
+    const [storeB] = await createStoreWithSchema(graphB, backend);
+
+    const resultA = await storeA.materializeIndexes();
+    const resultB = await storeB.materializeIndexes();
+
+    const entryA = resultA.results.find((entry) => entry.entity === "vector")!;
+    const entryB = resultB.results.find((entry) => entry.entity === "vector")!;
+
+    // Both surface the shared declaration name to the consumer
+    // (clean for inspection); neither falsely reports
+    // alreadyMaterialized from the other.
+    expect(entryA.indexName).toBe("shared_explicit_vec");
+    expect(entryB.indexName).toBe("shared_explicit_vec");
+    expect(entryA.status).not.toBe("alreadyMaterialized");
+    expect(entryB.status).not.toBe("alreadyMaterialized");
+  });
+});


### PR DESCRIPTION
Lifts vector indexes into the same declaration channel as relational indexes. Pre-this-PR, `backend.createVectorIndex` was on the interface but had **zero callers** anywhere in `src/` — vector indexes were never created automatically, and the embedding brand carried only dimensions. Consumers had to call the backend method directly, manually mapping graph IDs and field paths, and the materializeIndexes channel only handled relational. Shipping #101 with that gap would force every vector-search consumer to write boilerplate that the library should own.

## What changed

```typescript
const Document = defineNode("Document", {
  schema: z.object({
    title: z.string(),
    // Auto-derives a cosine HNSW vector index with pgvector defaults.
    embedding: embedding(384),
  }),
});

// Override the auto-derived defaults at the brand site.
const Image = defineNode("Image", {
  schema: z.object({
    embedding: embedding(512, { metric: "l2", m: 32, efConstruction: 100 }),
  }),
});

// Opt out of automatic materialization while keeping the embedding column.
const Manual = defineNode("Manual", {
  schema: z.object({
    embedding: embedding(384, { indexType: "none" }),
  }),
});

const [store] = await createStoreWithSchema(graph, backend);
const result = await store.materializeIndexes();
// Postgres+pgvector → status: "created"
// SQLite (or indexType: "none") → status: "skipped" with reason
```

## API additions

- `embedding(dimensions, options?)` — extended with optional `EmbeddingIndexOptions` (metric, indexType, m, efConstruction, lists). Defaults match pgvector recommendations.
- `IndexDeclaration` is now a discriminated union: `NodeIndexDeclaration | EdgeIndexDeclaration | VectorIndexDeclaration`.
- `RelationalIndexDeclaration` alias for the relational subset.
- `VectorIndexDeclaration`, `VectorIndexMetric`, `VectorIndexImplementation`, `VectorIndexParams` — exported types.
- `MaterializeIndexesEntry.entity` extended to `"node" | "edge" | "vector"`.
- `MaterializeIndexesEntry.status` — new variant `"skipped"` with `reason` field.
- `getEmbeddingIndex(schema)` — read the resolved index config from a brand.

## Auto-derivation

At `defineGraph()` time, every top-level node field declared with `embedding()` produces one `VectorIndexDeclaration`. Explicit declarations passed via `defineGraph({ indexes })` win on (kind, fieldPath) collisions, so consumers can override defaults without losing auto-derivation for other fields.

v1 limits (documented in the docs page):
- One vector index per (kind, fieldPath). Different metrics → different field names or wait for v2.
- Top-level fields only.
- Compile-time only. Runtime-extension documents can't yet declare embeddings — follow-up.

## Materialization dispatch

`materializeIndexes()` reads `IndexDeclaration.entity` and dispatches to the appropriate backend primitive. Status tracked in the existing `typegraph_index_materializations` table (entity column widened to accept "vector"; no schema migration). Signature includes vector params for drift detection.

Capability checks (`backend.capabilities.vector?.supported` + `indexTypes`) prevent the silent-no-op-as-success failure mode where SQLite would report "created" for an HNSW declaration that never actually built an index.

## Backend interface cleanup

Removed dead `createFulltextIndex` / `dropFulltextIndex` from `GraphBackend`. They had no callers anywhere in `src/` — the fulltext table's canonical index (Postgres GIN on `tsv`, SQLite FTS5 virtual table) is created with the table itself by `bootstrapTables` per the active `FulltextStrategy`. Custom backends implementing them will need to remove them. Pre-1.0 acceptable.

## Out of scope (deferred)

- Fulltext index unification (per-strategy in v1).
- Multiple vector indexes per (kind, field).
- Vector indexes for runtime-declared kinds.

