### PR TITLE
docs: tighten graph-extensions release notes

### DIFF
--- a/.changeset/graph-extensions.md
+++ b/.changeset/graph-extensions.md
@@ -12,7 +12,7 @@ Public API:
 - `GraphExtension`, `ExtensionNodeDef`, `ExtensionEdgeDef`, `ExtensionPropertyType`, `ExtensionIndex`, version constants, and graph-extension error classes are exported for tool builders.
 - `Store.evolve(extension, { ref?, eager? })` atomically commits the merged schema with CAS and returns a fresh store carrying the graph-extension-declared kinds.
 - Graph-extension-declared kinds are reached through `getNodeCollection(kind)`, `getNodeCollectionOrThrow(kind)`, `getEdgeCollection(kind)`, and `getEdgeCollectionOrThrow(kind)`.
-- `store.introspect()` returns the merged schema, origin markers, persisted extension, deprecation set, and known schema version/hash.
+- `store.introspect()` returns the merged schema (`kinds`, `edges`, `ontology`), the persisted extension document on `extension`, the soft-deprecation set on `deprecatedKinds`, and the active schema version and hash on `schemaVersion` / `schemaHash` (both `undefined` until the first commit).
 - `store.materializeIndexes()` materializes compile-time and graph-extension relational/vector indexes per deployment.
 - `store.deprecateKinds()`, `store.undeprecateKinds()`, `store.removeKinds()`, and `store.materializeRemovals()` manage graph-extension-kind lifecycle after induction.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ deployment.
 - Model richer semantics with `subClassOf`, `implies`, `inverseOf`, and `disjointWith`
 - Traverse relationships with compile-time type safety
 - Start with SQLite, move to PostgreSQL without changing your graph definition
+- Evolve the schema at runtime from agent-proposed JSON — no redeploy
+  ([Graph Extensions](https://typegraph.dev/graph-extensions))
 
 ## Best fit
 

--- a/apps/docs/src/content/docs/graph-extensions.md
+++ b/apps/docs/src/content/docs/graph-extensions.md
@@ -16,6 +16,7 @@ This guide covers the core verbs:
 | ------------------------------------------------ | ----------------------------------------------------------------- |
 | `defineGraphExtension`                           | Build a typed extension (pure value, no I/O)                      |
 | `store.evolve(extension)`                        | Atomically commit a new schema version with the extension applied |
+| `store.introspect()`                             | Snapshot the merged schema, persisted extension, version, and hash |
 | `store.materializeIndexes()`                     | Run declared `CREATE INDEX` DDL against the live database         |
 | `store.deprecateKinds(...)` / `undeprecateKinds` | Soft-deprecate kinds for codegen / lint signaling                 |
 | `store.removeKinds(...)`                         | Remove graph-extension-declared kinds from the active schema      |
@@ -333,6 +334,13 @@ await papers.create({ title: "...", doi: "...", year: 2024 });
 const all = await papers.find({});
 ```
 
+The throwing variants `getNodeCollectionOrThrow(kind)` /
+`getEdgeCollectionOrThrow(kind)` are the right call when the caller
+already knows the kind has been evolved onto the store — they raise
+`KindNotFoundError` with the offending `kindName`, `entity`, and host
+`graphId` instead of returning `undefined`, so a typo fails loudly at
+the call site rather than crashing later on `papers!.create(...)`.
+
 `DynamicNodeCollection` exposes the same CRUD surface as
 `store.nodes.X` — `create`, `getById`, `find`, `update`, `delete`,
 etc. — but with widened `Node<NodeType>` element types since the
@@ -355,7 +363,7 @@ The `store.search` facade — `fulltext`, `vector`, `hybrid`, and
 runtime, with no type cast. The hit's `node` type narrows to the
 concrete typed node only when the kind literal is statically known
 in `Store<G>`; extension kinds widen to the base `Node`. Misspelled
-kind names throw a `ConfigurationError` at the call site instead of
+kind names throw `KindNotFoundError` at the call site instead of
 returning empty results.
 
 ```ts
@@ -372,6 +380,33 @@ const runtimeHits = await store.search.fulltext("Paper", {
   limit: 10,
 });
 ```
+
+## `store.introspect()`
+
+`introspect()` returns a frozen snapshot of the merged schema and the
+durable-state metadata the store has loaded so far. Its shape:
+
+| Field                  | Type                                  | Notes                                                                                          |
+| ---------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `graphId`              | `string`                              | The graph's stable id.                                                                         |
+| `kinds`                | `readonly KindIntrospection[]`        | Merged node kinds with `origin: "compile-time" \| "runtime"`, description, annotations, etc.   |
+| `edges`                | `readonly EdgeIntrospection[]`        | Merged edge kinds with the same origin discriminator and endpoint information.                 |
+| `ontology`             | `readonly OntologyIntrospection[]`    | Ontology relations declared on either tier.                                                    |
+| `deprecatedKinds`      | `ReadonlySet<string>`                 | Kinds flagged via `deprecateKinds(...)`. Informational, not a gate.                            |
+| `extension`            | `GraphExtension \| undefined`         | The persisted graph-extension document, or `undefined` when no extensions have been committed. |
+| `schemaVersion`        | `number \| undefined`                 | Active schema version on the backend. `undefined` until the first commit.                      |
+| `schemaHash`           | `string \| undefined`                 | Hash of the active schema document. `undefined` under the same condition.                      |
+
+```ts
+const intro = store.introspect();
+console.log(intro.schemaVersion); // e.g. 2
+console.log(intro.extension?.nodes?.Paper); // ExtensionNodeDef or undefined
+console.log([...intro.deprecatedKinds]);    // ["LegacyDocument"]
+```
+
+The `extension` field round-trips: passing it back through
+`defineGraphExtension(intro.extension!)` and `evolve()` against an
+empty graph reconstructs the same extension kinds.
 
 ## `store.materializeIndexes(options?)`
 

--- a/apps/docs/src/content/docs/overview.md
+++ b/apps/docs/src/content/docs/overview.md
@@ -116,6 +116,13 @@ Note: TypeGraph ships **Tier 1 graph algorithms** (shortest path, reachability,
 neighborhoods, and degree) on `store.algorithms.*`. Each call compiles to a
 single recursive CTE. See [Graph Algorithms](/graph-algorithms) for details.
 
+Note: TypeGraph supports **runtime schema induction** via graph
+extensions. An LLM or ingestion agent can propose a typed schema as a
+JSON-serializable document, an operator approves it, and `store.evolve()`
+atomically commits a new schema version — no redeploy, full Zod
+validation, restart parity. See [Graph Extensions](/graph-extensions)
+for the agent-driven workflow.
+
 ## Why TypeGraph?
 
 ### Compared to Graph Databases (Neo4j, Amazon Neptune)


### PR DESCRIPTION
Polish: an independent doc-driven review of issue #101 (closed by #118) surfaced four inaccuracies in the graph-extensions guide and changeset that would trip a fresh consumer following the docs verbatim, plus two missing cross-links to the headline feature.

## Changes

### Doc-vs-API mismatches (prose corrections, no API changes)

- **`.changeset/graph-extensions.md`** — prose called the introspect field "persisted extension" while the API exposes it as `extension`. Re-stated to enumerate the actual fields and to call out that `schemaVersion` / `schemaHash` are `undefined` until the first commit.
- **`apps/docs/src/content/docs/graph-extensions.md`**:
  - Added a `store.introspect()` reference subsection with a field-by-field table (the guide previously only mentioned `deprecatedKinds`).
  - Added a row for `store.introspect()` to the top-level verb-summary table.
  - Documented `getNodeCollectionOrThrow` / `getEdgeCollectionOrThrow` next to the `getNodeCollection` snippet, including the `KindNotFoundError` they actually raise.
  - Fixed an incorrect error name: misspelled kinds in `store.search.fulltext` throw `KindNotFoundError`, not `ConfigurationError`.

### Discovery-surface cross-links

- **`README.md`** — added one bullet under "Why teams use it" linking to the Graph Extensions guide.
- **`apps/docs/src/content/docs/overview.md`** — added a Note paragraph in the existing "Note: TypeGraph also supports..." sequence introducing runtime schema induction and linking to the guide.

## Notes

No code changes. Field names, error classes, and invariants in the rewritten prose were verified against `packages/typegraph/src/store/introspect.ts`, `src/store/store.ts:376-409`, and `src/store/search-facade.ts:202`.