### PR TITLE
fix: stale-store kind resurrection + concurrent pgvector index DDL

### DIFF
--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -684,6 +684,7 @@ function createPostgresOperationBackend(
         ...(params.indexParams?.lists === undefined
           ? {}
           : { ivfflatLists: params.indexParams.lists }),
+        ...(params.concurrent === true ? { concurrent: true } : {}),
       };
 
       const result = await createPostgresVectorIndex(db, indexOptions);

--- a/packages/typegraph/src/backend/drizzle/vector-index.ts
+++ b/packages/typegraph/src/backend/drizzle/vector-index.ts
@@ -62,6 +62,8 @@ export type VectorIndexOptions = Readonly<{
   ivfflatLists?: number;
   /** Embeddings table name. Defaults to typegraph_node_embeddings. */
   embeddingsTableName?: string;
+  /** Emit `CREATE INDEX CONCURRENTLY`. See `CreateVectorIndexParams.concurrent`. */
+  concurrent?: boolean;
 }>;
 
 /**
@@ -237,13 +239,14 @@ export async function createPostgresVectorIndex(
 
   // Build the CREATE INDEX statement
   let indexSql: SQL;
+  const concurrentClause = options.concurrent === true ? "CONCURRENTLY " : "";
 
   if (indexType === "hnsw") {
     // HNSW index with optional parameters
     // Column is native VECTOR type, but we still specify dimensions in the
     // index expression to ensure consistent index behavior
     indexSql = sql.raw(`
-      CREATE INDEX IF NOT EXISTS ${indexName}
+      CREATE INDEX ${concurrentClause}IF NOT EXISTS ${indexName}
       ON ${quotedEmbeddingsTableName}
       USING hnsw ((embedding::vector(${dimensions})) ${operatorClass})
       WITH (m = ${hnswM}, ef_construction = ${hnswEfConstruction})
@@ -256,7 +259,7 @@ export async function createPostgresVectorIndex(
     // Column is native VECTOR type, but we still specify dimensions in the
     // index expression to ensure consistent index behavior
     indexSql = sql.raw(`
-      CREATE INDEX IF NOT EXISTS ${indexName}
+      CREATE INDEX ${concurrentClause}IF NOT EXISTS ${indexName}
       ON ${quotedEmbeddingsTableName}
       USING ivfflat ((embedding::vector(${dimensions})) ${operatorClass})
       WITH (lists = ${ivfflatLists})

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -345,6 +345,15 @@ export type CreateVectorIndexParams = Readonly<{
     /** IVFFlat: number of lists */
     lists?: number;
   }>;
+  /**
+   * Build the index without taking an `AccessExclusiveLock` on live
+   * tables (Postgres `CREATE INDEX CONCURRENTLY`). Mirrors the
+   * `concurrent` flag the relational DDL path uses inside
+   * `materializeIndexes()`. Cannot be set inside a transaction —
+   * callers (`materializeIndexes()`) run at top level. Backends that
+   * don't have a CONCURRENTLY equivalent (SQLite) ignore this flag.
+   */
+  concurrent?: boolean;
 }>;
 
 /**

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -344,6 +344,7 @@ async function materializeVectorIndex(
         {}
       : { lists: declaration.indexParams.lists }),
     },
+    concurrent: backend.dialect === "postgres",
   };
   return materializeOne(declaration, backend, graphId, schemaVersion, {
     // Compound status-table key for vector entries. Pgvector creates

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1358,10 +1358,18 @@ export class Store<G extends GraphDef> {
   }
 
   #catchUpToStored(storedSchema: SerializedSchema): G {
+    // Strip the local extension slice before re-applying the persisted
+    // extension. Otherwise a stale store whose `this.#graph` carries
+    // extension kinds another writer has since removed would resurrect
+    // them: `unionDocuments` unions local extension nodes/edges back in,
+    // and the absent-from-stored kinds win the spread. Stripping first
+    // makes the merge a function of the persisted document alone, so
+    // removeKinds on one store cannot be silently undone by a stale peer.
+    const compileTimeGraph = stripGraphExtension(this.#graph);
     const withGraphExtension =
       storedSchema.extension === undefined ?
-        this.#graph
-      : mergeGraphExtension(this.#graph, storedSchema.extension);
+        compileTimeGraph
+      : mergeGraphExtension(compileTimeGraph, storedSchema.extension);
     return applyDeprecatedKinds(
       withGraphExtension,
       storedSchema.deprecatedKinds,

--- a/packages/typegraph/tests/store-remove-kinds.test.ts
+++ b/packages/typegraph/tests/store-remove-kinds.test.ts
@@ -519,6 +519,45 @@ describe("Store.removeKinds — re-add and re-remove cycle", () => {
   });
 });
 
+describe("Store.removeKinds — stale-store recovery", () => {
+  // Without stripping the local extension first, `#catchUpToStored`'s
+  // merge unions stale local extension nodes back on top of the
+  // persisted document, resurrecting kinds another writer has removed.
+  it("a stale store evolving with a new kind does NOT resurrect a removed kind", async () => {
+    const backend = createTestBackend();
+    const [storeA] = await createStoreWithSchema(baseGraph, backend);
+    const staleWithTag = await storeA.evolve(
+      defineGraphExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+
+    const [storeB] = await createStoreWithSchema(baseGraph, backend);
+    const evolvedB = await storeB.evolve(
+      defineGraphExtension({
+        nodes: { Tag: { properties: { label: { type: "string" } } } },
+      }),
+    );
+    await evolvedB.removeKinds(["Tag"]);
+
+    const evolved = await staleWithTag.evolve(
+      defineGraphExtension({
+        nodes: { Category: { properties: { name: { type: "string" } } } },
+      }),
+    );
+
+    expect(evolved.registry.hasNodeType("Tag")).toBe(false);
+    expect(
+      evolved.introspect().kinds.find((k) => k.name === "Tag"),
+    ).toBeUndefined();
+    expect(evolved.registry.hasNodeType("Category")).toBe(true);
+
+    const [restored] = await createStoreWithSchema(baseGraph, backend);
+    expect(restored.registry.hasNodeType("Tag")).toBe(false);
+    expect(restored.registry.hasNodeType("Category")).toBe(true);
+  });
+});
+
 describe("Store.removeKinds — restart parity", () => {
   it("a fresh store reading the same database does not see the removed kind", async () => {
     const backend = createTestBackend();

--- a/packages/typegraph/tests/vector-index.test.ts
+++ b/packages/typegraph/tests/vector-index.test.ts
@@ -218,6 +218,57 @@ describe("createPostgresVectorIndex", () => {
     expect(sqlText).toContain('ON "custom_embeddings"');
     expect(sqlText).not.toContain("ON typegraph_node_embeddings");
   });
+
+  it("emits CREATE INDEX CONCURRENTLY when concurrent: true", async () => {
+    const execute = vi.fn((_query: unknown) =>
+      Promise.resolve({ rows: [] as const }),
+    );
+    const db = {
+      execute,
+    } as unknown as Parameters<typeof createPostgresVectorIndex>[0];
+
+    for (const indexType of ["hnsw", "ivfflat"] as const) {
+      execute.mockClear();
+      const result = await createPostgresVectorIndex(db, {
+        graphId: "g",
+        nodeKind: "Doc",
+        fieldPath: "embedding",
+        dimensions: 8,
+        indexType,
+        concurrent: true,
+      });
+      expect(result.success).toBe(true);
+      const sqlInput = execute.mock.calls[0]?.[0];
+      if (sqlInput === undefined) {
+        throw new Error("Expected SQL input to be captured");
+      }
+      const sqlText = flattenSql(sqlInput);
+      expect(sqlText).toMatch(/CREATE INDEX\s+CONCURRENTLY\s+IF NOT EXISTS/);
+    }
+  });
+
+  it("omits CONCURRENTLY by default to preserve transaction-safe callers", async () => {
+    const execute = vi.fn((_query: unknown) =>
+      Promise.resolve({ rows: [] as const }),
+    );
+    const db = {
+      execute,
+    } as unknown as Parameters<typeof createPostgresVectorIndex>[0];
+
+    const result = await createPostgresVectorIndex(db, {
+      graphId: "g",
+      nodeKind: "Doc",
+      fieldPath: "embedding",
+      dimensions: 8,
+    });
+    expect(result.success).toBe(true);
+    const sqlInput = execute.mock.calls[0]?.[0];
+    if (sqlInput === undefined) {
+      throw new Error("Expected SQL input to be captured");
+    }
+    const sqlText = flattenSql(sqlInput);
+    expect(sqlText).not.toMatch(/CONCURRENTLY/);
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
Two pre-release-review issues addressed.

### P1 — stale stores can resurrect removed graph-extension kinds

`Store.#catchUpToStored` merged the persisted extension on top of `this.#graph`. When a peer had since removed an extension kind, the stale local graph still carried it; `unionDocuments` would union it back in, silently undoing the removal on the next `evolve()`.

**Fix:** strip the local extension before re-applying the persisted document, so the merge is a function of the persisted state alone (`packages/typegraph/src/store/store.ts`).

### P2 — pgvector index DDL not concurrent

`materializeIndexes()` documents that Postgres uses `CREATE INDEX CONCURRENTLY` so live tables never take an `AccessExclusiveLock`. The relational path honored that; the pgvector path emitted plain `CREATE INDEX`.

**Fix:** plumb a `concurrent` flag through `VectorIndexOptions` and `CreateVectorIndexParams`, request it from `materializeIndexes` for Postgres, and emit the modifier in the pgvector DDL. Direct callers of `createPostgresVectorIndex` default to non-concurrent so transaction-bound use keeps working.