### PR TITLE
docs(changeset): drop stale deferred claims for graph extensions in 0.25.0

### DIFF
--- a/.changeset/graphdef-indexes.md
+++ b/.changeset/graphdef-indexes.md
@@ -2,7 +2,7 @@
 "@nicia-ai/typegraph": minor
 ---
 
-Bring compile-time indexes into `defineGraph` and `SerializedSchema` so they flow through the canonical schema document uniformly with future graph-extension-declared indexes.
+Bring compile-time indexes into `defineGraph` and `SerializedSchema` so they flow through the canonical schema document uniformly with graph-extension-declared indexes.
 
 ```typescript
 const personEmail = defineNodeIndex(Person, {
@@ -37,6 +37,6 @@ const graph = defineGraph({
 - Graphs that never declare indexes produce identical canonical-form hashes to today — adoption requires no migration.
 - The serialized slice is order-canonicalized (sorted by `name`) and treats `undefined` and `[]` as the same "no slice" form. Indexes are an unordered set keyed by name; an empty list carries no semantic meaning that an absent slice doesn't, so the hash and the diff agree on both points (reorders are a no-op, opting in with `[]` doesn't bump the hash). The in-memory `GraphDef.indexes` still preserves whatever the caller passed for introspection.
 - A populated `indexes` array bumps the hash. Round-trip (`serialize → JSON → serializedSchemaZod.parse → JSON`) is byte-identical after the canonical sort.
-- `origin: "compile-time"` is the default and is omitted from canonical form. Only `origin: "runtime"` is emitted explicitly. Absence-as-default keeps compile-only graphs hashing identically while leaving the discriminator ready for graph extensions.
+- `origin: "compile-time"` is the default and is omitted from canonical form. Only `origin: "runtime"` is emitted explicitly. Absence-as-default keeps compile-only graphs hashing identically; the graph-extension loader emits the explicit `"runtime"` discriminator on extension-declared indexes.
 
 **Forward compatibility.** `serializedSchemaZod` parses both old (no `indexes`) and new documents, with extras-allowed (`.loose()`) on each declaration so future fields don't break older readers.

--- a/.changeset/vector-index-unification.md
+++ b/.changeset/vector-index-unification.md
@@ -116,6 +116,3 @@ Pre-1.0 acceptable.
   `bootstrapTables` time.
 - **Multiple vector indexes per (kind, field).** v1 allows at most
   one. Use a different field name for now.
-- **Vector indexes for graph-extension-declared kinds.** Auto-derivation
-  walks compile-time node schemas. Graph-extension documents can't
-  yet declare embeddings — coming in a follow-up.


### PR DESCRIPTION
Two of the consolidated 0.25.0 changesets contain "deferred / future" framing that became stale once #118 (graph extensions) merged after #117 and #107. Both will land in the same release, so the contradictions surface directly in #105's body and the generated `CHANGELOG.md`.

- **`.changeset/vector-index-unification.md`**: Removes the "Out of scope (still deferred)" bullet that said graph-extension documents can't yet declare embeddings — they can, and `packages/typegraph/src/graph-extension/merge.ts` auto-derives vector indexes from extension-declared `embedding()` brands.
- **`.changeset/graphdef-indexes.md`**: Drops "future" from the intro line about graph-extension-declared indexes, and rewords the canonical-form bullet from "leaving the discriminator ready for graph extensions" to "the graph-extension loader emits the explicit `\"runtime\"` discriminator on extension-declared indexes" — present-tense, since the loader ships in this release.

No behavior change. After merge, the Changesets action will regenerate #105 with the corrected body and `CHANGELOG.md` content.
