### PR TITLE
feat: getNodePropsSchema / getEdgePropsSchema accessors (closes #122)

### DIFF
--- a/.changeset/props-schema-accessors.md
+++ b/.changeset/props-schema-accessors.md
@@ -1,0 +1,19 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `getNodePropsSchema` / `getEdgePropsSchema` (plus `…OrThrow` siblings) on `Store` for runtime access to the compiled Zod props schema.
+
+Compile-time and graph-extension kinds both store their props schema as a real `z.ZodObject` — `defineNode` / `defineEdge` for the typed surface, `compileGraphExtension` for the runtime surface — and the store validates `.create()` / `.update()` against those objects. Until now those Zod instances weren't reachable through the public API, so MCP servers, tool wrappers, and agent loops that wanted to validate inputs with the same schema as the store had to either reach into private fields or round-trip `introspect().properties` JSON Schema → Zod (lossy on refinements, formats, branded `searchable()` / `embedding()` types).
+
+The new accessors return the exact Zod object the store uses. Closes #122.
+
+```ts
+const schema = store.getNodePropsSchemaOrThrow("Paper");
+const parsed = schema.parse(input);            // same parsed output as papers.create(input)
+const json = z.toJSONSchema(schema);            // for MCP tool descriptions / agent prompts
+```
+
+Lookup is `Object.hasOwn`-gated, matching `getNodeCollection` / `getEdgeCollection` (no prototype-name leakage). The `OrThrow` variants throw `KindNotFoundError` on unknown kinds. Identity holds for compile-time kinds: `store.getNodePropsSchema("Person") === Person.schema`.
+
+These return only the props validator. Operation-level checks — uniqueness, endpoint resolution (edges validate endpoints before props), temporal validity, backend constraints — still run only through `collection.create` / `update`. Failed `parse()` throws `ZodError`; failed `create()` wraps the same underlying issues in `ValidationError`.

--- a/apps/docs/src/content/docs/graph-extensions.md
+++ b/apps/docs/src/content/docs/graph-extensions.md
@@ -346,6 +346,29 @@ the call site rather than crashing later on `papers!.create(...)`.
 etc. — but with widened `Node<NodeType>` element types since the
 specific Zod schema isn't visible to TypeScript at the call site.
 
+For consumers that need the live Zod schema itself — MCP tool wrappers
+that validate inputs before forwarding to `collection.create`, or
+agent prompts that want richer JSON Schema than `introspect()`
+exposes — `store.getNodePropsSchema(kind)` /
+`getNodePropsSchemaOrThrow(kind)` (and the edge counterparts) return
+the exact `z.ZodObject` the store uses internally. Identity holds:
+`evolved.getNodePropsSchema("Paper")` is the same instance the store
+parses against on `papers.create(...)`.
+
+```ts
+import { z } from "zod";
+
+const schema = evolved.getNodePropsSchemaOrThrow("Paper");
+const parsed = schema.parse(input); // same Zod issues as papers.create surfaces
+const jsonSchema = z.toJSONSchema(schema); // for MCP tool descriptions
+```
+
+These accessors return only the props validator. Operation-level
+checks — uniqueness, endpoint resolution, temporal validity, backend
+constraints — still run only through `collection.create` / `update`.
+See [Dynamic Props Schema Access](/schemas-stores#dynamic-props-schema-access)
+for the full reference.
+
 For codegen consumers, the kind set is reachable by iterating the
 registry's `nodeKinds` and `edgeKinds` maps:
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1733,6 +1733,45 @@ The returned collections expose the full API (`create`, `getById`, `find`, `coun
 [`DynamicNodeCollection`](/types#dynamicnodecollection) and
 [`DynamicEdgeCollection`](/types#dynamicedgecollection).
 
+### Dynamic Props Schema Access
+
+Returns the live `z.ZodObject` the store uses internally to validate `.create()` /
+`.update()` props. Same accessor for compile-time and graph-extension kinds. Useful
+for MCP tool wrappers that want to validate inputs against the same schema as the
+store, and for producing richer JSON Schema (refinements, formats, branded
+`searchable()` / `embedding()` types) than `introspect().properties` exposes.
+
+```typescript
+store.getNodePropsSchema(kind: string): z.ZodObject<z.ZodRawShape> | undefined;
+store.getNodePropsSchemaOrThrow(kind: string): z.ZodObject<z.ZodRawShape>;
+store.getEdgePropsSchema(kind: string): z.ZodObject<z.ZodRawShape> | undefined;
+store.getEdgePropsSchemaOrThrow(kind: string): z.ZodObject<z.ZodRawShape>;
+```
+
+`Object.hasOwn`-gated lookup matches `getNodeCollection` (no prototype-name leakage).
+The `OrThrow` variants throw `KindNotFoundError` with `kindName`, `entity`, and host
+`graphId` when the kind is not registered. Identity holds for compile-time kinds:
+`store.getNodePropsSchema("Person") === Person.schema`.
+
+```typescript
+import { z } from "zod";
+
+const schema = store.getNodePropsSchemaOrThrow("Paper");
+
+// Validate tool input with the same schema the store uses.
+const parsed = schema.parse(input);
+await store.getNodeCollectionOrThrow("Paper").create(parsed);
+
+// Produce JSON Schema for an MCP tool description.
+const jsonSchema = z.toJSONSchema(schema);
+```
+
+**Props-only contract.** These accessors return only the props validator. Failed
+`schema.parse()` throws `ZodError`; failed `collection.create()` wraps the same
+underlying issues in `ValidationError`. Operation-level checks — uniqueness,
+endpoint resolution (edges validate endpoints before props), temporal validity,
+backend constraints — still run only through `collection.create` / `update`.
+
 ### Registry Access
 
 #### `store.registry`

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -8,6 +8,8 @@
  * - Schema management
  * - Transaction handling
  */
+import type { z } from "zod";
+
 import {
   type GraphBackend,
   runOptionallyInTransaction,
@@ -409,6 +411,58 @@ export class Store<G extends GraphDef> {
       });
     }
     return collection;
+  }
+
+  // === Dynamic Props Schema Access ===
+
+  /**
+   * Returns the Zod props schema for the given node kind, or `undefined`
+   * if the kind is not registered. Identity-preserving: returns the
+   * exact instance used by `.create()` / `.update()`, so a `parse()`
+   * surfaces the same underlying Zod issues that `ValidationError`
+   * wraps (operation-level checks like uniqueness and endpoints stay
+   * in `collection.create`).
+   */
+  getNodePropsSchema(kind: string): z.ZodObject<z.ZodRawShape> | undefined {
+    if (!Object.hasOwn(this.#graph.nodes, kind)) return undefined;
+    return this.#graph.nodes[kind]!.type.schema;
+  }
+
+  /**
+   * Returns the Zod props schema for the given node kind. Throws
+   * `KindNotFoundError` when the kind is not registered.
+   */
+  getNodePropsSchemaOrThrow(kind: string): z.ZodObject<z.ZodRawShape> {
+    const schema = this.getNodePropsSchema(kind);
+    if (schema === undefined) {
+      throw new KindNotFoundError(kind, "node", {
+        graphId: this.graphId,
+      });
+    }
+    return schema;
+  }
+
+  /**
+   * Returns the Zod props schema for the given edge kind, or `undefined`
+   * if the kind is not registered. Symmetric with `getNodePropsSchema`.
+   */
+  getEdgePropsSchema(kind: string): z.ZodObject<z.ZodRawShape> | undefined {
+    if (!Object.hasOwn(this.#graph.edges, kind)) return undefined;
+    return this.#graph.edges[kind]!.type.schema;
+  }
+
+  /**
+   * Returns the Zod props schema for the given edge kind. Throws
+   * `KindNotFoundError` when the kind is not registered.
+   */
+  getEdgePropsSchemaOrThrow(kind: string): z.ZodObject<z.ZodRawShape> {
+    const schema = this.getEdgePropsSchema(kind);
+    if (schema === undefined) {
+      throw new KindNotFoundError(kind, "edge", {
+        graphId: this.graphId,
+      });
+    }
+    return schema;
   }
 
   /**

--- a/packages/typegraph/tests/props-schema-accessors.test.ts
+++ b/packages/typegraph/tests/props-schema-accessors.test.ts
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineEdge, defineGraph, defineNode, type Store } from "../src";
+import { KindNotFoundError, ValidationError } from "../src/errors";
+import { defineGraphExtension } from "../src/graph-extension";
+import { createStore, createStoreWithSchema } from "../src/store/store";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({
+    name: z.string().min(1),
+    email: z.email().optional(),
+  }),
+});
+
+const Company = defineNode("Company", {
+  schema: z.object({
+    name: z.string(),
+    industry: z.string(),
+  }),
+});
+
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string().min(1) }),
+  from: [Person],
+  to: [Company],
+});
+
+const baseGraph = defineGraph({
+  id: "props_schema_accessors",
+  nodes: {
+    Person: { type: Person },
+    Company: { type: Company },
+  },
+  edges: {
+    worksAt: { type: worksAt, from: [Person], to: [Company] },
+  },
+});
+
+function paperExtension() {
+  return defineGraphExtension({
+    nodes: {
+      Paper: {
+        properties: {
+          title: { type: "string", minLength: 1 },
+          year: { type: "number", int: true, min: 1900 },
+        },
+      },
+    },
+  });
+}
+
+function paperWithCitesExtension() {
+  return defineGraphExtension({
+    nodes: {
+      Paper: { properties: { title: { type: "string", minLength: 1 } } },
+    },
+    edges: {
+      cites: {
+        from: ["Paper"],
+        to: ["Paper"],
+        properties: {
+          note: { type: "string", maxLength: 200 },
+        },
+      },
+    },
+  });
+}
+
+describe("getNodePropsSchema / getEdgePropsSchema (compile-time kinds)", () => {
+  let store: Store<typeof baseGraph>;
+
+  beforeEach(() => {
+    store = createStore(baseGraph, createTestBackend());
+  });
+
+  it("returns the same Zod object instance as defineNode", () => {
+    expect(store.getNodePropsSchema("Person")).toBe(Person.schema);
+    expect(store.getNodePropsSchema("Company")).toBe(Company.schema);
+  });
+
+  it("returns the same Zod object instance as defineEdge", () => {
+    expect(store.getEdgePropsSchema("worksAt")).toBe(worksAt.schema);
+  });
+
+  it("returns undefined for an unregistered node kind", () => {
+    expect(store.getNodePropsSchema("Ghost")).toBeUndefined();
+  });
+
+  it("returns undefined for an unregistered edge kind", () => {
+    expect(store.getEdgePropsSchema("hasPet")).toBeUndefined();
+  });
+
+  it("returns undefined for inherited prototype keys (node)", () => {
+    expect(store.getNodePropsSchema("toString")).toBeUndefined();
+    expect(store.getNodePropsSchema("constructor")).toBeUndefined();
+    expect(store.getNodePropsSchema("hasOwnProperty")).toBeUndefined();
+  });
+
+  it("returns undefined for inherited prototype keys (edge)", () => {
+    expect(store.getEdgePropsSchema("toString")).toBeUndefined();
+    expect(store.getEdgePropsSchema("constructor")).toBeUndefined();
+    expect(store.getEdgePropsSchema("hasOwnProperty")).toBeUndefined();
+  });
+});
+
+describe("getNodePropsSchemaOrThrow / getEdgePropsSchemaOrThrow", () => {
+  let store: Store<typeof baseGraph>;
+
+  beforeEach(() => {
+    store = createStore(baseGraph, createTestBackend());
+  });
+
+  it("returns the schema when the kind is registered", () => {
+    expect(store.getNodePropsSchemaOrThrow("Person")).toBe(Person.schema);
+    expect(store.getEdgePropsSchemaOrThrow("worksAt")).toBe(worksAt.schema);
+  });
+
+  it("throws KindNotFoundError with entity=node for unknown node kind", () => {
+    let caught: unknown;
+    try {
+      store.getNodePropsSchemaOrThrow("Ghost");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(KindNotFoundError);
+    const error = caught as KindNotFoundError;
+    expect(error.kindName).toBe("Ghost");
+    expect(error.entity).toBe("node");
+    expect(error.details.graphId).toBe(baseGraph.id);
+  });
+
+  it("throws KindNotFoundError with entity=edge for unknown edge kind", () => {
+    let caught: unknown;
+    try {
+      store.getEdgePropsSchemaOrThrow("hasPet");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(KindNotFoundError);
+    const error = caught as KindNotFoundError;
+    expect(error.kindName).toBe("hasPet");
+    expect(error.entity).toBe("edge");
+  });
+
+  it("throws KindNotFoundError for prototype-leak keys", () => {
+    expect(() => store.getNodePropsSchemaOrThrow("toString")).toThrow(
+      KindNotFoundError,
+    );
+    expect(() => store.getEdgePropsSchemaOrThrow("toString")).toThrow(
+      KindNotFoundError,
+    );
+  });
+});
+
+describe("parse parity with collection.create — node", () => {
+  let store: Store<typeof baseGraph>;
+
+  beforeEach(() => {
+    store = createStore(baseGraph, createTestBackend());
+  });
+
+  it("valid props produce the same parsed output as create persists", async () => {
+    const schema = store.getNodePropsSchemaOrThrow("Person");
+
+    const input = { name: "Alice", email: "alice@example.com" };
+    const parsed = schema.parse(input);
+    const created = await store.nodes.Person.create(input);
+
+    expect(parsed).toEqual({ name: "Alice", email: "alice@example.com" });
+    expect(created.name).toBe(parsed.name);
+    expect(created.email).toBe(parsed.email);
+  });
+
+  it("invalid props produce the same underlying Zod issues as create surfaces", async () => {
+    const schema = store.getNodePropsSchemaOrThrow("Person");
+
+    const input = { name: "", email: "not-an-email" };
+
+    const parseResult = schema.safeParse(input);
+    expect(parseResult.success).toBe(false);
+    if (parseResult.success) return;
+    const parseIssues = parseResult.error.issues.map((issue) => ({
+      path: issue.path.join("."),
+      code: issue.code,
+    }));
+
+    let caught: unknown;
+    try {
+      await store.nodes.Person.create(input);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ValidationError);
+    const error = caught as ValidationError;
+    const createIssues = error.details.issues.map((issue) => ({
+      path: issue.path,
+      code: issue.code,
+    }));
+
+    expect(createIssues).toEqual(parseIssues);
+  });
+});
+
+describe("parse parity with collection.create — edge", () => {
+  let store: Store<typeof baseGraph>;
+
+  beforeEach(() => {
+    store = createStore(baseGraph, createTestBackend());
+  });
+
+  it("valid edge props produce the same parsed output as create persists", async () => {
+    const schema = store.getEdgePropsSchemaOrThrow("worksAt");
+
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({
+      name: "Acme",
+      industry: "Tech",
+    });
+
+    const input = { role: "Engineer" };
+    const parsed = schema.parse(input);
+    const edge = await store.edges.worksAt.create(alice, acme, input);
+
+    expect(parsed).toEqual({ role: "Engineer" });
+    expect(edge.role).toBe(parsed.role);
+  });
+
+  it("invalid edge props produce the same underlying Zod issues as create surfaces", async () => {
+    const schema = store.getEdgePropsSchemaOrThrow("worksAt");
+
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({
+      name: "Acme",
+      industry: "Tech",
+    });
+
+    const input = { role: "" };
+
+    const parseResult = schema.safeParse(input);
+    expect(parseResult.success).toBe(false);
+    if (parseResult.success) return;
+    const parseIssues = parseResult.error.issues.map((issue) => ({
+      path: issue.path.join("."),
+      code: issue.code,
+    }));
+
+    let caught: unknown;
+    try {
+      await store.edges.worksAt.create(alice, acme, input);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ValidationError);
+    const error = caught as ValidationError;
+    const createIssues = error.details.issues.map((issue) => ({
+      path: issue.path,
+      code: issue.code,
+    }));
+
+    expect(createIssues).toEqual(parseIssues);
+  });
+});
+
+describe("graph-extension (runtime) kinds after evolve", () => {
+  it("returns the compiled Zod schema for an extension node kind", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(paperExtension());
+
+    const schema = evolved.getNodePropsSchemaOrThrow("Paper");
+    expect(schema).toBeDefined();
+
+    const valid = { title: "On Computable Numbers", year: 1936 };
+    expect(schema.parse(valid)).toEqual(valid);
+
+    const papers = evolved.getNodeCollectionOrThrow("Paper");
+    const created = (await papers.create(valid)) as unknown as {
+      title: string;
+      year: number;
+    };
+    expect(created.title).toBe(valid.title);
+    expect(created.year).toBe(valid.year);
+  });
+
+  it("invalid extension-kind props surface identical Zod issues from parse and create", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(paperExtension());
+    const schema = evolved.getNodePropsSchemaOrThrow("Paper");
+
+    const invalid = { title: "", year: 1936.5 };
+    const parseResult = schema.safeParse(invalid);
+    expect(parseResult.success).toBe(false);
+    if (parseResult.success) return;
+    const parseIssues = parseResult.error.issues.map((issue) => ({
+      path: issue.path.join("."),
+      code: issue.code,
+    }));
+
+    const papers = evolved.getNodeCollectionOrThrow("Paper");
+    let caught: unknown;
+    try {
+      await papers.create(invalid);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ValidationError);
+    const error = caught as ValidationError;
+    const createIssues = error.details.issues.map((issue) => ({
+      path: issue.path,
+      code: issue.code,
+    }));
+
+    expect(createIssues).toEqual(parseIssues);
+  });
+
+  it("returns undefined for an extension kind not yet evolved into the store", () => {
+    const store = createStore(baseGraph, createTestBackend());
+
+    expect(store.getNodePropsSchema("Paper")).toBeUndefined();
+    expect(() => store.getNodePropsSchemaOrThrow("Paper")).toThrow(
+      KindNotFoundError,
+    );
+  });
+
+  it("returns the compiled Zod schema for an extension edge kind", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(paperWithCitesExtension());
+
+    const schema = evolved.getEdgePropsSchemaOrThrow("cites");
+    expect(schema).toBeDefined();
+
+    const valid = { note: "follow-up" };
+    expect(schema.parse(valid)).toEqual(valid);
+
+    const tooLong = "x".repeat(201);
+    const result = schema.safeParse({ note: tooLong });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("z.toJSONSchema interop (doc snippet sanity)", () => {
+  it("produces a JSON Schema object for a compile-time node kind", () => {
+    const store = createStore(baseGraph, createTestBackend());
+
+    const jsonSchema = z.toJSONSchema(
+      store.getNodePropsSchemaOrThrow("Person"),
+    ) as Record<string, unknown>;
+
+    expect(jsonSchema).toBeTypeOf("object");
+    expect(jsonSchema.type).toBe("object");
+    expect(jsonSchema.properties).toBeTypeOf("object");
+  });
+
+  it("produces a JSON Schema object for an extension node kind", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(paperExtension());
+
+    const jsonSchema = z.toJSONSchema(
+      evolved.getNodePropsSchemaOrThrow("Paper"),
+    ) as Record<string, unknown>;
+
+    expect(jsonSchema).toBeTypeOf("object");
+    expect(jsonSchema.type).toBe("object");
+    const properties = jsonSchema.properties as Record<string, unknown>;
+    expect(properties.title).toBeDefined();
+  });
+});


### PR DESCRIPTION
- Adds `store.getNodePropsSchema` / `getNodePropsSchemaOrThrow` / `getEdgePropsSchema` / `getEdgePropsSchemaOrThrow` for runtime access to the compiled Zod props schema. Closes #122.
- Returns the exact `z.ZodObject` instance the store uses internally for `.create()` / `.update()`. Identity holds for compile-time kinds: `store.getNodePropsSchema("Person") === Person.schema`.
- Works uniformly for compile-time and graph-extension kinds. `Object.hasOwn`-gated lookup matches `getNodeCollection` (no prototype-name leakage); `OrThrow` variants throw `KindNotFoundError`.

## Why

Compile-time and runtime kinds both store their props schema as a real `z.ZodObject` (`defineNode` / `defineEdge` for compile-time, `compileGraphExtension` for runtime), but those instances weren't reachable through the public API. MCP servers, tool wrappers, and agent loops that wanted to validate inputs with the same schema as the store had to either reach into private fields or round-trip `introspect().properties` JSON Schema → Zod (lossy on refinements, formats, branded `searchable()` / `embedding()` types).

The accessors return only the props validator. Operation-level checks — uniqueness, endpoint resolution (edges validate endpoints before props), temporal validity, backend constraints — still run only through `collection.create` / `update`. Failed `parse()` throws `ZodError`; failed `create()` wraps the same underlying issues in `ValidationError`.

```ts
const schema = store.getNodePropsSchemaOrThrow("Paper");
const parsed = schema.parse(input);             // same parsed output as papers.create(input)
const json = z.toJSONSchema(schema);             // for MCP tool descriptions / agent prompts
```