### PR TITLE
fix: drizzle-kit-managed fulltext bootstrap gap

### DIFF
--- a/.changeset/fulltext-bootstrap-gap.md
+++ b/.changeset/fulltext-bootstrap-gap.md
@@ -1,0 +1,67 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix drizzle-kit-managed fulltext bootstrap gap on both Postgres and SQLite (#128).
+
+Consumers managing typegraph storage via `drizzle-kit push` /
+`drizzle-kit generate` (`export * from "@nicia-ai/typegraph/postgres"`
+or `…/sqlite"`) got every typegraph table EXCEPT
+`typegraph_node_fulltext`. The fulltext table was strategy-owned raw
+DDL — the schema modules exposed only `fulltextTableName: string`,
+not a Drizzle table — so drizzle-kit silently skipped it. The
+`bootstrapTables` fallback in `loadActiveSchemaWithBootstrap` only
+fires on a missing-table error from `getActiveSchema`; once
+drizzle-kit had created `typegraph_schema_versions`, that branch
+stopped triggering and `searchable()` writes failed at runtime with
+`relation/table "typegraph_node_fulltext" does not exist`.
+
+Two fixes ship together:
+
+- **`backend.ensureFulltextTable()` (both backends).** A focused
+  narrow-ensure that mirrors the existing
+  `ensureIndexMaterializationsTable` /
+  `ensureKindRemovalsTable` /
+  `ensureReconciliationMarkersTable` idiom — single-table
+  `CREATE … IF NOT EXISTS`, no Postgres SHARE-lock deadlock under
+  concurrent replica startup. The backend wraps every method that
+  emits fulltext SQL (`upsertFulltext` / `deleteFulltext` and their
+  batch variants, `fulltextSearch`, and `hardDeleteNode` whose
+  cascade unconditionally deletes from the fulltext table) to call
+  the ensure first. A per-backend latch makes the per-call cost a
+  single boolean check after the first invocation, so the wrapping
+  is safe on the hot path. `loadActiveSchemaWithBootstrap` also
+  calls the ensure as a belt-and-suspenders for the
+  `createStoreWithSchema` path. Together these cover both async
+  schema-aware boot AND the sync `createStore` path — the bare
+  bootstrap-load probe alone would miss the latter. This is the
+  canonical fix and the **only** viable one for SQLite (FTS5
+  virtual tables aren't drizzle-kit-modelable).
+
+- **Typed Drizzle pg-core table for `tsvectorStrategy` (Postgres
+  only).** `createPostgresTables()` now returns
+  `tables.fulltext` — a typed `pgTable` for the default
+  `tsvector` + GIN stack — alongside `tables.fulltextTableName`.
+  The new `fulltext` named export is included in
+  `@nicia-ai/typegraph/postgres`, so `export *` lets drizzle-kit
+  generate migrations for the fulltext table the same way it does
+  for `nodes`/`edges`/etc. Custom `tsvector`/`regconfig` column
+  types are exported alongside the existing `vector` column.
+
+  `generatePostgresDDL` deliberately skips the typed Drizzle table
+  (the column-walker can't reproduce the `GENERATED ALWAYS AS (…)
+  STORED` clause) and continues to defer to
+  `tsvectorStrategy.generateDdl()` for the runtime DDL emit. The
+  two paths agree byte-for-byte; a drift sentinel test catches any
+  divergence.
+
+  Alternate Postgres fulltext strategies (pg_trgm, ParadeDB,
+  pgroonga) still own their own DDL via
+  `FulltextStrategy.generateDdl()` and the bootstrap probe runs it.
+  Drizzle-kit consumers using a non-default strategy must override
+  `tables.fulltext` in their schema barrel with their strategy's
+  own table.
+
+Documented the SQLite FTS5 virtual-table caveat and the new
+Postgres `tables.fulltext` export in
+`apps/docs/src/content/docs/integration.md`.

--- a/apps/docs/src/content/docs/integration.md
+++ b/apps/docs/src/content/docs/integration.md
@@ -160,9 +160,45 @@ export const {
   reconciliationMarkers: myappGraphReconciliationMarkers,
 } = typegraphTables;
 
+// SQLite fulltext is an FTS5 virtual table — drizzle-kit can't model
+// virtual tables, so this name is exposed as a string. The backend
+// creates the FTS5 table on first store boot via a focused
+// `ensureFulltextTable()` ensure (idempotent CREATE VIRTUAL TABLE
+// IF NOT EXISTS), so drizzle-kit-managed setups work without an
+// extra manual step.
 export const myappGraphFulltextTableName =
   typegraphTables.fulltextTableName;
 ```
+
+For PostgreSQL with the default `tsvectorStrategy`, the factory
+**does** return a typed Drizzle table — `tables.fulltext` — alongside
+the others, so drizzle-kit-managed setups pick up the fulltext table
+automatically:
+
+```typescript
+// schema.ts (PostgreSQL)
+import { createPostgresTables } from "@nicia-ai/typegraph/postgres";
+
+export const typegraphTables = createPostgresTables({
+  // …same names as above…
+});
+
+export const {
+  nodes: myappGraphNodes,
+  edges: myappGraphEdges,
+  // …
+  fulltext: myappGraphFulltext,
+  indexMaterializations: myappGraphIndexMaterializations,
+  // …
+} = typegraphTables;
+```
+
+If you swap in an alternate Postgres fulltext strategy (pg_trgm,
+ParadeDB / pg_search, pgroonga), the typed `tsvector`-shaped table
+won't match what your strategy needs. Override `tables.fulltext` in
+your schema barrel with your strategy's own Drizzle table, or skip
+the typed export and rely on the backend's runtime
+`ensureFulltextTable()` ensure to bootstrap your strategy's DDL.
 
 Then pass the same tables to the backend:
 

--- a/packages/typegraph/src/backend/drizzle/columns/fulltext.ts
+++ b/packages/typegraph/src/backend/drizzle/columns/fulltext.ts
@@ -1,0 +1,40 @@
+/**
+ * Custom Drizzle column types for the PostgreSQL `tsvectorStrategy`
+ * fulltext table (`tsvector` + `regconfig`). Lets drizzle-kit
+ * introspect the typed fulltext table the same way it introspects
+ * `nodes`, `edges`, etc. Alternate strategies (pg_trgm, ParadeDB,
+ * pgroonga) carry their own DDL via `FulltextStrategy.generateDdl()`
+ * and don't use these columns.
+ */
+import { customType } from "drizzle-orm/pg-core";
+
+/**
+ * PostgreSQL `regconfig` column type — a registered text-search
+ * configuration name (e.g. `'english'::regconfig`). Identical wire
+ * format to `text`, but the `regconfig` SQL type lets a generated
+ * column reference it inside `to_tsvector("language", "content")`
+ * as an immutable expression.
+ */
+export const regconfig = customType<{
+  data: string;
+  driverData: string;
+}>({
+  dataType: () => "regconfig",
+});
+
+/**
+ * PostgreSQL `tsvector` column type. Represents a parsed,
+ * dictionary-normalized document; the GIN index that
+ * `tsvectorFulltextTable` declares makes `@@ tsquery` lookups cheap.
+ *
+ * The on-the-wire driver representation is the canonical text form
+ * (`'word1':1 'word2':2`); this type is read-only in practice — the
+ * value is computed by a `GENERATED ALWAYS AS (...) STORED` clause —
+ * so no `toDriver` mapping is provided.
+ */
+export const tsvector = customType<{
+  data: string;
+  driverData: string;
+}>({
+  dataType: () => "tsvector",
+});

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -422,6 +422,10 @@ function isPgTable(
 
 /**
  * Generates all DDL statements for the given PostgreSQL tables.
+ *
+ * The typed `tables.fulltext` is excluded from the column-walker
+ * pass (it can't reproduce `GENERATED ALWAYS AS … STORED`); the
+ * strategy emits the canonical fulltext DDL last.
  */
 export function generatePostgresDDL(
   tables: PostgresTables = postgresTables,
@@ -429,14 +433,16 @@ export function generatePostgresDDL(
 ): string[] {
   const statements: string[] = [];
 
-  // Generate in dependency order (tables first, then indexes)
+  // Reference identity sidesteps the per-iter `getPgTableConfig` walk
+  // a name lookup would add, and stays correct under custom names.
   for (const table of Object.values(tables)) {
     if (!isPgTable(table)) continue;
+    if (table === tables.fulltext) continue;
     statements.push(generatePgCreateTableSQL(table));
   }
-
   for (const table of Object.values(tables)) {
     if (!isPgTable(table)) continue;
+    if (table === tables.fulltext) continue;
     statements.push(...generatePgCreateIndexSQL(table));
   }
 

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -389,6 +389,22 @@ export function createPostgresBackend(
     });
   }
 
+  // Per-backend latch for fulltext-table DDL. The wrappers below
+  // guard every method that touches the fulltext table — fulltext
+  // writes can fire from any code path (sync `createStore`, hard-
+  // delete cascade, batched index sync), so the bootstrap-load
+  // probe alone doesn't cover all surfaces.
+  let fulltextEnsured = false;
+  async function ensureFulltextDdl(): Promise<void> {
+    if (fulltextEnsured) return;
+    for (const statement of fulltextStrategy.generateDdl(
+      tables.fulltextTableName,
+    )) {
+      await db.execute(sql.raw(statement));
+    }
+    fulltextEnsured = true;
+  }
+
   const backend: GraphBackend = {
     ...operations,
 
@@ -397,6 +413,39 @@ export function createPostgresBackend(
       for (const statement of statements) {
         await db.execute(sql.raw(statement));
       }
+      fulltextEnsured = true;
+    },
+
+    async upsertFulltext(params): Promise<void> {
+      await ensureFulltextDdl();
+      await operations.upsertFulltext!(params);
+    },
+    async deleteFulltext(params): Promise<void> {
+      await ensureFulltextDdl();
+      await operations.deleteFulltext!(params);
+    },
+    async upsertFulltextBatch(params): Promise<void> {
+      // Mirror the inner-method empty-input guard so a no-op call
+      // on a cold backend doesn't materialize the table.
+      if (params.rows.length === 0) return;
+      await ensureFulltextDdl();
+      await operations.upsertFulltextBatch!(params);
+    },
+    async deleteFulltextBatch(params): Promise<void> {
+      if (params.nodeIds.length === 0) return;
+      await ensureFulltextDdl();
+      await operations.deleteFulltextBatch!(params);
+    },
+    async fulltextSearch(params) {
+      await ensureFulltextDdl();
+      return operations.fulltextSearch!(params);
+    },
+    // hardDeleteNode is wrapped because the operation-backend-core
+    // cascade unconditionally deletes from the fulltext table — it
+    // would fail even on graphs that declare no searchable() fields.
+    async hardDeleteNode(params): Promise<void> {
+      await ensureFulltextDdl();
+      await operations.hardDeleteNode(params);
     },
 
     async executeDdl(ddl: string): Promise<void> {
@@ -505,6 +554,10 @@ export function createPostgresBackend(
       );
     },
 
+    async ensureFulltextTable(): Promise<void> {
+      await ensureFulltextDdl();
+    },
+
     async getReconciliationMarker(
       graphId: string,
     ): Promise<number | undefined> {
@@ -554,6 +607,14 @@ export function createPostgresBackend(
       fn: (tx: TransactionBackend) => Promise<T>,
       options?: TransactionOptions,
     ): Promise<T> {
+      // The tx-scoped backend exposes raw fulltext methods without
+      // the outer self-ensure wrappers — so we do the ensure here,
+      // before db.transaction() opens BEGIN. Outside-the-tx avoids
+      // CREATE-INDEX-inside-tx SHARE-lock contention with concurrent
+      // replicas and keeps the DDL durable if the user's tx rolls
+      // back.
+      await ensureFulltextDdl();
+
       const txConfig = options?.isolationLevel
         ? {
             isolationLevel: options.isolationLevel.replace("_", " ") as

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -42,6 +42,7 @@ import {
   buildPostgresNodeIndexBuilders,
   type IndexDeclaration,
 } from "../../../indexes";
+import { regconfig, tsvector } from "../columns/fulltext";
 import { vector } from "../columns/vector";
 
 /**
@@ -347,6 +348,44 @@ export function createPostgresTables(
     (t) => [primaryKey({ columns: [t.graphId] })],
   );
 
+  /**
+   * Drizzle pg-core table for the default `tsvectorStrategy` so
+   * drizzle-kit can introspect the fulltext table alongside the
+   * others. Mirrors `tsvectorStrategy.generateDdl()` — the typed
+   * shape and the strategy DDL must stay in sync (drift sentinel
+   * lives in `tests/typed-fulltext-table.test.ts`).
+   *
+   * Why `regconfig` + GENERATED: `to_tsvector("language", "content")`
+   * needs an immutable language to qualify for use inside a
+   * `STORED` generated column, so Postgres can own the
+   * `content → tsv` invariant.
+   *
+   * Alternate strategies (pg_trgm, ParadeDB, pgroonga) bring their
+   * own DDL; `generatePostgresDDL` skips this typed table for them
+   * and defers to `FulltextStrategy.generateDdl()`. Drizzle-kit
+   * consumers on non-default strategies must override
+   * `tables.fulltext` in their schema barrel.
+   */
+  const fulltext = pgTable(
+    n.fulltext,
+    {
+      graphId: text("graph_id").notNull(),
+      nodeKind: text("node_kind").notNull(),
+      nodeId: text("node_id").notNull(),
+      content: text("content").notNull(),
+      language: regconfig("language").notNull(),
+      tsv: tsvector("tsv")
+        .generatedAlwaysAs(sql`to_tsvector("language", "content")`)
+        .notNull(),
+      updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+    },
+    (t) => [
+      primaryKey({ columns: [t.graphId, t.nodeKind, t.nodeId] }),
+      index(`${n.fulltext}_tsv_idx`).using("gin", t.tsv),
+      index(`${n.fulltext}_kind_idx`).on(t.graphId, t.nodeKind),
+    ],
+  );
+
   return {
     nodes,
     edges,
@@ -356,15 +395,7 @@ export function createPostgresTables(
     indexMaterializations,
     kindRemovals,
     reconciliationMarkers,
-    /**
-     * The fulltext storage table is owned by the active `FulltextStrategy`,
-     * not Drizzle. Shapes vary across strategies — the default `tsvectorStrategy`
-     * uses a `regconfig` language column, a GENERATED STORED `tsv` column,
-     * and a GIN index; alternate strategies (ParadeDB, pg_trgm, pgroonga)
-     * pick their own column types and index methods. DDL is emitted as
-     * raw SQL via `strategy.generateDdl()`; reads and writes are composed
-     * from the strategy's fragment helpers.
-     */
+    fulltext,
     fulltextTableName: n.fulltext,
   } as const;
 }
@@ -377,7 +408,14 @@ export const tables = createPostgresTables();
 /**
  * Convenience exports for default tables.
  */
-export const { nodes, edges, uniques, schemaVersions, embeddings } = tables;
+export const {
+  nodes,
+  edges,
+  uniques,
+  schemaVersions,
+  embeddings,
+  fulltext,
+} = tables;
 
 /**
  * Type representing the tables object returned by createPostgresTables.

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -676,6 +676,22 @@ export function createSqliteBackend(
     );
   }
 
+  // Per-backend latch for fulltext-table DDL. The wrappers below
+  // guard every method that touches the fulltext table — fulltext
+  // writes can fire from any code path (sync `createStore`, hard-
+  // delete cascade, batched index sync), so the bootstrap-load
+  // probe alone doesn't cover all surfaces.
+  let fulltextEnsured = false;
+  async function ensureFulltextDdl(): Promise<void> {
+    if (fulltextEnsured) return;
+    for (const statement of fulltextStrategy.generateDdl(
+      tables.fulltextTableName,
+    )) {
+      await db.run(sql.raw(statement));
+    }
+    fulltextEnsured = true;
+  }
+
   const backend: GraphBackend = {
     ...operations,
 
@@ -684,6 +700,39 @@ export function createSqliteBackend(
       for (const statement of statements) {
         await db.run(sql.raw(statement));
       }
+      fulltextEnsured = true;
+    },
+
+    async upsertFulltext(params): Promise<void> {
+      await ensureFulltextDdl();
+      await operations.upsertFulltext!(params);
+    },
+    async deleteFulltext(params): Promise<void> {
+      await ensureFulltextDdl();
+      await operations.deleteFulltext!(params);
+    },
+    async upsertFulltextBatch(params): Promise<void> {
+      // Mirror the inner-method empty-input guard so a no-op call
+      // on a cold backend doesn't materialize the table.
+      if (params.rows.length === 0) return;
+      await ensureFulltextDdl();
+      await operations.upsertFulltextBatch!(params);
+    },
+    async deleteFulltextBatch(params): Promise<void> {
+      if (params.nodeIds.length === 0) return;
+      await ensureFulltextDdl();
+      await operations.deleteFulltextBatch!(params);
+    },
+    async fulltextSearch(params) {
+      await ensureFulltextDdl();
+      return operations.fulltextSearch!(params);
+    },
+    // hardDeleteNode is wrapped because the operation-backend-core
+    // cascade unconditionally deletes from the fulltext table — it
+    // would fail even on graphs that declare no searchable() fields.
+    async hardDeleteNode(params): Promise<void> {
+      await ensureFulltextDdl();
+      await operations.hardDeleteNode(params);
     },
 
     async executeDdl(ddl: string): Promise<void> {
@@ -790,6 +839,10 @@ export function createSqliteBackend(
       );
     },
 
+    async ensureFulltextTable(): Promise<void> {
+      await ensureFulltextDdl();
+    },
+
     async getReconciliationMarker(
       graphId: string,
     ): Promise<number | undefined> {
@@ -852,6 +905,13 @@ export function createSqliteBackend(
           },
         );
       }
+
+      // The tx-scoped backend exposes raw fulltext methods without
+      // the outer self-ensure wrappers — so we do the ensure here,
+      // before BEGIN runs. Outside-the-tx avoids
+      // CREATE-INDEX-inside-tx lock contention and keeps the DDL
+      // durable if the user's tx rolls back.
+      await ensureFulltextDdl();
 
       if (transactionMode === "sql") {
         return runWithSerializedQueue(serializedQueue, async () => {

--- a/packages/typegraph/src/backend/postgres/index.ts
+++ b/packages/typegraph/src/backend/postgres/index.ts
@@ -66,6 +66,7 @@ export {
   type CreatePostgresTablesOptions,
   edges,
   embeddings,
+  fulltext,
   nodes,
   schemaVersions,
   uniques,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -872,6 +872,18 @@ export type GraphBackend = Readonly<{
    */
   ensureReconciliationMarkersTable?: () => Promise<void>;
 
+  // === Fulltext Storage ===
+
+  /**
+   * Bootstraps the fulltext storage table the active `FulltextStrategy`
+   * owns — the strategy owns this DDL because shapes diverge across
+   * stacks (`tsvector` + GIN, FTS5 virtual table, pg_trgm, …) and
+   * the SQLite case can't be Drizzle-modeled at all. Same focused-
+   * bootstrap rationale as the other `ensure*Table` methods:
+   * idempotent and concurrency-safe under replica startup.
+   */
+  ensureFulltextTable?: () => Promise<void>;
+
   /**
    * Read the high-water mark schema version for which
    * `materializeRemovals` reconciliation has already verified history

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -106,14 +106,21 @@ function isMissingTableError(error: unknown): boolean {
 
 /**
  * Reads the active schema row, bootstrapping the base tables on the
- * first call against an empty database.
+ * first call against an empty database. Also runs
+ * `ensureFulltextTable` on the success path: drizzle-kit-managed
+ * setups create every base table EXCEPT the strategy-owned fulltext
+ * table, and the missing-table-error fallback below doesn't trigger
+ * once `schema_versions` exists. The focused ensure closes that gap
+ * before any `searchable()` write runs.
  */
 export async function loadActiveSchemaWithBootstrap(
   backend: GraphBackend,
   graphId: string,
 ): Promise<SchemaVersionRow | undefined> {
   try {
-    return await backend.getActiveSchema(graphId);
+    const row = await backend.getActiveSchema(graphId);
+    await backend.ensureFulltextTable?.();
+    return row;
   } catch (error) {
     if (backend.bootstrapTables && isMissingTableError(error)) {
       await backend.bootstrapTables();

--- a/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Regression tests for the drizzle-kit-managed fulltext bootstrap
+ * gap on PostgreSQL — SQLite mirror at
+ * `tests/fulltext-bootstrap.test.ts`. The strategy owns the
+ * fulltext DDL (alternate Postgres stacks carry incompatible
+ * schemas), so the `bootstrapTables` shortcut bypasses it once
+ * `schema_versions` exists. `ensureFulltextTable` closes the gap.
+ *
+ * Skipped unless `POSTGRES_URL` is set (or `scripts/test-postgres.sh`).
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { z } from "zod";
+
+import {
+  createStore,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  searchable,
+  tsvectorStrategy,
+} from "../../../src";
+import {
+  generatePostgresDDL,
+  generatePostgresMigrationSQL,
+} from "../../../src/backend/drizzle/ddl";
+import {
+  createPostgresBackend,
+  tables as defaultTables,
+} from "../../../src/backend/postgres";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let pool: Pool | undefined;
+let postgresAvailable = false;
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    title: searchable({ language: "english" }),
+  }),
+});
+
+const FtGraph = defineGraph({
+  // Distinct graph id so this file can run alongside other postgres
+  // suites without colliding on the shared schema_versions table.
+  id: "pg_fulltext_bootstrap_gap",
+  nodes: { Doc: { type: Document } },
+  edges: {},
+});
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  try {
+    pool = new Pool({ connectionString: TEST_DATABASE_URL });
+    await pool.query("SELECT 1");
+    // Run the full migration once so other typegraph_* tables exist
+    // for the full test database (other postgres suites share these
+    // tables — see `postgres-fulltext.test.ts`).
+    await pool.query(generatePostgresMigrationSQL());
+    postgresAvailable = true;
+  } catch {
+    postgresAvailable = false;
+  }
+});
+
+afterAll(async () => {
+  // Safety net for downstream postgres test files that share this
+  // database (postgres-fulltext.test.ts truncates `typegraph_node_fulltext`
+  // and assumes it exists). If a test in this file fails between
+  // dropping the table and the bootstrap probe restoring it,
+  // `--no-file-parallelism` carries that broken state into the next
+  // file. Replaying the migration SQL (idempotent: every CREATE
+  // uses `IF NOT EXISTS`) leaves the database in a known good state.
+  if (pool && postgresAvailable) {
+    await pool.query(generatePostgresMigrationSQL());
+  }
+  if (pool) await pool.end();
+});
+
+/**
+ * Drops `typegraph_node_fulltext` to mimic the post-`drizzle-kit push`
+ * state where every other typegraph table exists but the fulltext
+ * table does not. This is the exact partial-bootstrap state the bug
+ * report describes.
+ */
+async function dropFulltextTable(p: Pool): Promise<void> {
+  await p.query(`DROP TABLE IF EXISTS ${defaultTables.fulltextTableName}`);
+}
+
+/**
+ * Confirms `dropFulltextTable` actually left the table missing.
+ * Each test calls this first so a silently-failing drop can't
+ * mask a regression — the bug under test only reproduces when
+ * the fulltext table is genuinely absent.
+ */
+async function expectFulltextTableMissing(): Promise<void> {
+  if (!pool) throw new Error("postgres pool not initialized");
+  const exists = await pool.query<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM pg_tables
+       WHERE schemaname = 'public' AND tablename = $1
+     ) AS exists`,
+    [defaultTables.fulltextTableName],
+  );
+  expect(exists.rows[0]?.exists).toBe(false);
+}
+
+describe.runIf(process.env.POSTGRES_URL)(
+  "PostgreSQL fulltext bootstrap gap",
+  () => {
+    const transientPools: Pool[] = [];
+
+    function pooledBackend(): ReturnType<typeof createPostgresBackend> {
+      const transientPool = new Pool({ connectionString: TEST_DATABASE_URL });
+      transientPools.push(transientPool);
+      return createPostgresBackend(drizzle(transientPool));
+    }
+
+    /**
+     * Bootstraps a real schema row (so `createStore` CRUD passes
+     * the no-schema gate) then drops the fulltext table again,
+     * restoring the drizzle-kit-only state.
+     */
+    async function seedSchemaThenDropFulltext(): Promise<void> {
+      await createStoreWithSchema(FtGraph, pooledBackend());
+      await dropFulltextTable(pool!);
+    }
+
+    beforeEach(async () => {
+      if (!postgresAvailable || !pool) return;
+      await dropFulltextTable(pool);
+    });
+
+    afterEach(async () => {
+      // Per-test pools (one per pooledBackend() call) — flush them
+      // so repeated suite runs don't accumulate Postgres backends.
+      while (transientPools.length > 0) {
+        const transientPool = transientPools.pop()!;
+        await transientPool.end();
+      }
+    });
+
+    it("createStoreWithSchema bootstrap restores the missing fulltext table", async () => {
+      await expectFulltextTableMissing();
+
+      const [store] = await createStoreWithSchema(FtGraph, pooledBackend());
+
+      // The bootstrap probe should have created the table.
+      const exists = await pool!.query<{ exists: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM pg_tables
+           WHERE schemaname = 'public' AND tablename = $1
+         ) AS exists`,
+        [defaultTables.fulltextTableName],
+      );
+      expect(exists.rows[0]?.exists).toBe(true);
+
+      await store.nodes.Doc.create({ title: "renewable energy" });
+
+      const rows = await pool!.query<{ content: string }>(
+        `SELECT content FROM ${defaultTables.fulltextTableName} WHERE graph_id = $1`,
+        [FtGraph.id],
+      );
+      expect(rows.rows).toHaveLength(1);
+      expect(rows.rows[0]?.content).toBe("renewable energy");
+    });
+
+    it("sync createStore path materializes the fulltext table on first write", async () => {
+      // createStore is sync and skips loadActiveSchemaWithBootstrap,
+      // so the bootstrap-load probe can't help here — the backend's
+      // wrapped write methods must self-ensure.
+      await seedSchemaThenDropFulltext();
+      const store = createStore(FtGraph, pooledBackend());
+      await store.nodes.Doc.create({ title: "sync path works" });
+
+      const rows = await pool!.query<{ content: string }>(
+        `SELECT content FROM ${defaultTables.fulltextTableName} WHERE graph_id = $1`,
+        [FtGraph.id],
+      );
+      expect(rows.rows).toHaveLength(1);
+      expect(rows.rows[0]?.content).toBe("sync path works");
+    });
+
+    it("store.transaction() materializes the fulltext table before BEGIN", async () => {
+      // The tx-scoped backend exposes raw fulltext methods, so
+      // transaction() itself ensures the table BEFORE BEGIN runs
+      // (avoiding CREATE-INDEX-inside-tx SHARE-lock contention and
+      // keeping the table durable on rollback).
+      await seedSchemaThenDropFulltext();
+      const store = createStore(FtGraph, pooledBackend());
+      await store.transaction(async (tx) => {
+        await tx.nodes.Doc.create({ title: "tx path works" });
+      });
+
+      const rows = await pool!.query<{ content: string }>(
+        `SELECT content FROM ${defaultTables.fulltextTableName} WHERE graph_id = $1`,
+        [FtGraph.id],
+      );
+      expect(rows.rows).toHaveLength(1);
+      expect(rows.rows[0]?.content).toBe("tx path works");
+    });
+
+    it("ensureFulltextTable is idempotent across repeat calls", async () => {
+      await expectFulltextTableMissing();
+
+      const backend = pooledBackend();
+
+      expect(backend.ensureFulltextTable).toBeTypeOf("function");
+
+      await backend.ensureFulltextTable!();
+      await backend.ensureFulltextTable!();
+      await backend.ensureFulltextTable!();
+
+      // Sanity: the GIN index the strategy declares is also present
+      // and idempotent (CREATE INDEX IF NOT EXISTS).
+      const indexes = await pool!.query<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes WHERE tablename = $1`,
+        [defaultTables.fulltextTableName],
+      );
+      const names = indexes.rows.map((row) => row.indexname);
+      expect(names).toContain(`${defaultTables.fulltextTableName}_tsv_idx`);
+      expect(names).toContain(`${defaultTables.fulltextTableName}_kind_idx`);
+    });
+
+    it("DDL generated by tsvectorStrategy matches the bootstrap probe DDL", () => {
+      // Drift sentinel: the strategy DDL and `generatePostgresDDL`
+      // must agree on the trailing fulltext block. The typed Drizzle
+      // table at `tables.fulltext` is intentionally skipped by
+      // `generatePostgresDDL` (the column-walker can't reproduce the
+      // GENERATED clause), so the strategy DDL should be the only
+      // source of fulltext CREATE TABLE.
+      const allDdl = generatePostgresDDL(defaultTables, tsvectorStrategy);
+      const strategyDdl = tsvectorStrategy.generateDdl(
+        defaultTables.fulltextTableName,
+      );
+      const tail = allDdl.slice(allDdl.length - strategyDdl.length);
+      expect(tail).toEqual(strategyDdl);
+    });
+
+    it("bootstrapTables is safe to run multiple times against the typed-fulltext schema", async () => {
+      // Smoke: with the typed Drizzle fulltext table now part of
+      // `createPostgresTables`, the DDL generator must not double-
+      // emit the fulltext CREATE TABLE (the strategy DDL would IF
+      // NOT EXISTS no-op, but the column-walked emit would produce
+      // a column-incompatible CREATE without GENERATED). This
+      // exercises the full bootstrap flow back-to-back.
+      const backend = pooledBackend();
+
+      await backend.bootstrapTables!();
+      await backend.bootstrapTables!();
+      await backend.bootstrapTables!();
+
+      // Confirm the GENERATED column landed (would be missing if the
+      // typed Drizzle table's CREATE had won the race).
+      const generated = await pool!.query<{ generation_expression: string }>(
+        `SELECT generation_expression
+           FROM information_schema.columns
+          WHERE table_name = $1 AND column_name = 'tsv'`,
+        [defaultTables.fulltextTableName],
+      );
+      expect(generated.rows[0]?.generation_expression).toMatch(/to_tsvector/i);
+    });
+  },
+);

--- a/packages/typegraph/tests/fulltext-bootstrap.test.ts
+++ b/packages/typegraph/tests/fulltext-bootstrap.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression tests for the drizzle-kit-managed fulltext bootstrap
+ * gap on SQLite. drizzle-kit can't model FTS5 virtual tables, so
+ * consumers driving migrations through `drizzle-kit push` land here
+ * with every typegraph table EXCEPT `typegraph_node_fulltext`. The
+ * fix is `backend.ensureFulltextTable()`, called from
+ * `loadActiveSchemaWithBootstrap` on the success path.
+ */
+import Database from "better-sqlite3";
+import {
+  type BetterSQLite3Database,
+  drizzle,
+} from "drizzle-orm/better-sqlite3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  createStore,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  fts5Strategy,
+  searchable,
+} from "../src";
+import { generateSqliteDDL } from "../src/backend/drizzle/ddl";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
+import { tables as defaultTables } from "../src/backend/sqlite";
+
+/**
+ * Builds an in-memory SQLite database that has every typegraph table
+ * EXCEPT the FTS5 fulltext virtual table — the post-`drizzle-kit
+ * push` state where drizzle-kit creates the Drizzle-modeled tables
+ * but skips the strategy-owned FTS5 virtual table.
+ */
+function createDrizzleKitOnlySqlite(): {
+  sqlite: Database.Database;
+  db: BetterSQLite3Database;
+} {
+  const sqlite = new Database(":memory:");
+  const drizzleOnlyDdl = generateSqliteDDL(defaultTables, fts5Strategy).filter(
+    (statement) => !statement.includes(defaultTables.fulltextTableName),
+  );
+  for (const statement of drizzleOnlyDdl) {
+    sqlite.exec(statement);
+  }
+  return { sqlite, db: drizzle(sqlite) };
+}
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    title: searchable({ language: "english" }),
+  }),
+});
+
+const FtGraph = defineGraph({
+  id: "fulltext-bootstrap-gap",
+  nodes: { Doc: { type: Document } },
+  edges: {},
+});
+
+describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database;
+
+  beforeEach(() => {
+    ({ sqlite, db } = createDrizzleKitOnlySqlite());
+  });
+
+  /**
+   * Bootstraps a real schema row (so subsequent `createStore` CRUD
+   * passes the no-schema gate) then drops the fulltext table again,
+   * restoring the drizzle-kit-only state. Mirrors what a consumer
+   * who ran `drizzle-kit push` + an external schema migration would
+   * leave on disk.
+   */
+  async function seedSchemaThenDropFulltext(): Promise<void> {
+    const seederBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    await createStoreWithSchema(FtGraph, seederBackend);
+    sqlite.exec(`DROP TABLE IF EXISTS ${defaultTables.fulltextTableName}`);
+  }
+
+  it("starts with the fulltext virtual table missing", () => {
+    expect(() =>
+      sqlite.prepare(`SELECT * FROM ${defaultTables.fulltextTableName}`).all(),
+    ).toThrow(/no such table/);
+    sqlite.close();
+  });
+
+  it("creates the fulltext table during createStoreWithSchema bootstrap", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+
+    const [store] = await createStoreWithSchema(FtGraph, backend);
+
+    // The bootstrap probe should have created the table.
+    const rows = sqlite
+      .prepare(`SELECT * FROM ${defaultTables.fulltextTableName}`)
+      .all();
+    expect(rows).toEqual([]);
+
+    // And the searchable() write should land without error.
+    await store.nodes.Doc.create({ title: "hello world" });
+
+    const fulltext = sqlite
+      .prepare(`SELECT content FROM ${defaultTables.fulltextTableName}`)
+      .all() as readonly { content: string }[];
+    expect(fulltext).toHaveLength(1);
+    expect(fulltext[0]?.content).toBe("hello world");
+
+    sqlite.close();
+  });
+
+  it("sync createStore path materializes the fulltext table on first write", async () => {
+    // createStore is sync and skips loadActiveSchemaWithBootstrap, so
+    // the bootstrap-load probe can't help here — the backend's
+    // wrapped write methods must self-ensure.
+    await seedSchemaThenDropFulltext();
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    const store = createStore(FtGraph, backend);
+    await store.nodes.Doc.create({ title: "sync path works" });
+
+    const rows = sqlite
+      .prepare(`SELECT content FROM ${defaultTables.fulltextTableName}`)
+      .all() as readonly { content: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.content).toBe("sync path works");
+
+    sqlite.close();
+  });
+
+  it("store.transaction() materializes the fulltext table before BEGIN", async () => {
+    // The tx-scoped backend exposes raw fulltext methods without
+    // the outer wrappers, so transaction() itself ensures the
+    // table BEFORE BEGIN runs (avoiding CREATE-inside-tx and
+    // keeping the table durable on rollback).
+    await seedSchemaThenDropFulltext();
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    const store = createStore(FtGraph, backend);
+    await store.transaction(async (tx) => {
+      await tx.nodes.Doc.create({ title: "tx path works" });
+    });
+
+    const rows = sqlite
+      .prepare(`SELECT content FROM ${defaultTables.fulltextTableName}`)
+      .all() as readonly { content: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.content).toBe("tx path works");
+
+    sqlite.close();
+  });
+
+  it("transaction() with transactionMode 'none' rejects without side effects", async () => {
+    // The early-rejection must fire before the ensure runs —
+    // otherwise a backend configured without transactions would
+    // materialize the fulltext table from a call that's about to
+    // throw.
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true, transactionMode: "none" },
+      tables: defaultTables,
+    });
+
+    const callback = vi.fn(() => Promise.resolve("unreached"));
+    await expect(backend.transaction(callback)).rejects.toThrow(
+      /does not support atomic transactions/,
+    );
+    expect(callback).not.toHaveBeenCalled();
+    expect(() =>
+      sqlite.prepare(`SELECT * FROM ${defaultTables.fulltextTableName}`).all(),
+    ).toThrow(/no such table/);
+
+    sqlite.close();
+  });
+
+  it("ensureFulltextTable is idempotent across repeat calls", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+
+    expect(backend.ensureFulltextTable).toBeTypeOf("function");
+
+    await backend.ensureFulltextTable!();
+    await backend.ensureFulltextTable!();
+    await backend.ensureFulltextTable!();
+
+    // Inserts still work after multiple ensure calls — no double-create
+    // surprise from FTS5. Using raw `sqlite.exec` (rather than the
+    // drizzle wrapper) sidesteps the sync/async return-type juggling
+    // for a one-off insert in a sync-mode test.
+    sqlite.exec(
+      `INSERT INTO ${defaultTables.fulltextTableName} ` +
+        `(graph_id, node_kind, node_id, content, language, updated_at) ` +
+        `VALUES ('g', 'Doc', 'n', 'body', 'english', '2026-01-01T00:00:00.000Z')`,
+    );
+
+    const rows = sqlite
+      .prepare(
+        `SELECT graph_id, node_id FROM ${defaultTables.fulltextTableName}`,
+      )
+      .all() as readonly { graph_id: string; node_id: string }[];
+    expect(rows).toEqual([{ graph_id: "g", node_id: "n" }]);
+
+    sqlite.close();
+  });
+});

--- a/packages/typegraph/tests/typed-fulltext-table.test.ts
+++ b/packages/typegraph/tests/typed-fulltext-table.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Drift sentinel for the typed Drizzle pg-core fulltext table
+ * (`tables.fulltext`). The typed table's introspectable shape must
+ * match `tsvectorStrategy.generateDdl()` — same columns + types,
+ * primary key, indexes, and GENERATED expression. If either side
+ * diverges, drizzle-kit will emit spurious migrations on every run.
+ */
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { createPostgresTables } from "../src/backend/drizzle/schema/postgres";
+import { tsvectorStrategy } from "../src/query/dialect";
+
+describe("typed Drizzle fulltext table (tsvectorStrategy)", () => {
+  const tables = createPostgresTables();
+  const config = getTableConfig(tables.fulltext);
+
+  it("table name matches the strategy's expected target", () => {
+    expect(config.name).toBe(tables.fulltextTableName);
+    expect(config.name).toBe("typegraph_node_fulltext");
+  });
+
+  it("declares the columns the strategy expects", () => {
+    const columns = Object.fromEntries(
+      config.columns.map((column) => [column.name, column.getSQLType()]),
+    );
+
+    expect(columns).toEqual({
+      graph_id: "text",
+      node_kind: "text",
+      node_id: "text",
+      content: "text",
+      language: "regconfig",
+      tsv: "tsvector",
+      updated_at: "timestamp with time zone",
+    });
+
+    // All seven columns must be NOT NULL — no implicit nulls allowed
+    // in the fulltext index.
+    for (const column of config.columns) {
+      expect(column.notNull).toBe(true);
+    }
+  });
+
+  it("declares the (graph_id, node_kind, node_id) composite primary key", () => {
+    const [pk] = config.primaryKeys;
+    expect(pk).toBeDefined();
+    expect(pk?.columns.map((column) => column.name)).toEqual([
+      "graph_id",
+      "node_kind",
+      "node_id",
+    ]);
+  });
+
+  it("declares the GIN index on tsv that the strategy creates", () => {
+    const ginIndex = config.indexes.find(
+      (index) => index.config.name === `${tables.fulltextTableName}_tsv_idx`,
+    );
+    expect(ginIndex).toBeDefined();
+    expect(ginIndex?.config.method).toBe("gin");
+    expect(ginIndex?.config.columns).toHaveLength(1);
+  });
+
+  it("declares the B-tree (graph_id, node_kind) lookup index", () => {
+    const kindIndex = config.indexes.find(
+      (index) => index.config.name === `${tables.fulltextTableName}_kind_idx`,
+    );
+    expect(kindIndex).toBeDefined();
+    // No explicit method = B-tree (the Postgres default).
+    expect(kindIndex?.config.method ?? "btree").toBe("btree");
+    expect(
+      kindIndex?.config.columns.map((column) =>
+        "name" in column ? column.name : undefined,
+      ),
+    ).toEqual(["graph_id", "node_kind"]);
+  });
+
+  it("declares the GENERATED ALWAYS AS expression on tsv", () => {
+    const tsvColumn = config.columns.find((column) => column.name === "tsv");
+    expect(tsvColumn).toBeDefined();
+    // Drizzle stores the generation config under `generated`. Type cast
+    // through unknown because the runtime field isn't on the public
+    // PgColumn type (it's a `HasGenerated` mixin tracked structurally).
+    const generated = (
+      tsvColumn as unknown as {
+        generated?: { type: string; as: unknown };
+      }
+    ).generated;
+    expect(generated).toBeDefined();
+    expect(generated?.type).toBe("always");
+  });
+
+  it("matches the strategy DDL for the same table name", () => {
+    // The strategy's own DDL is the source of truth at runtime
+    // (bootstrap probe + raw `generatePostgresDDL` both call into it).
+    // This sentinel just confirms the strategy still emits the table
+    // shape we modeled in Drizzle — if either side diverges, this
+    // test catches it before a consumer hits drizzle-kit drift.
+    const strategyDdl = tsvectorStrategy.generateDdl(tables.fulltextTableName);
+    const ddlText = strategyDdl.join("\n");
+
+    expect(ddlText).toContain(`"${tables.fulltextTableName}"`);
+    expect(ddlText).toMatch(/"language" regconfig NOT NULL/);
+    expect(ddlText).toMatch(
+      /"tsv" tsvector NOT NULL\s+GENERATED ALWAYS AS \(to_tsvector\("language", "content"\)\) STORED/,
+    );
+    expect(ddlText).toContain(
+      `PRIMARY KEY ("graph_id", "node_kind", "node_id")`,
+    );
+    expect(ddlText).toContain(
+      `CREATE INDEX IF NOT EXISTS "${tables.fulltextTableName}_tsv_idx"`,
+    );
+    expect(ddlText).toContain(`USING GIN ("tsv")`);
+    expect(ddlText).toContain(
+      `CREATE INDEX IF NOT EXISTS "${tables.fulltextTableName}_kind_idx"`,
+    );
+  });
+
+  it("respects custom table names from the factory", () => {
+    const customTables = createPostgresTables({
+      fulltext: "myapp_search_index",
+    });
+    const customConfig = getTableConfig(customTables.fulltext);
+
+    expect(customConfig.name).toBe("myapp_search_index");
+    expect(
+      customConfig.indexes.find(
+        (index) => index.config.name === "myapp_search_index_tsv_idx",
+      ),
+    ).toBeDefined();
+    expect(
+      customConfig.indexes.find(
+        (index) => index.config.name === "myapp_search_index_kind_idx",
+      ),
+    ).toBeDefined();
+  });
+
+  it("is included in the @nicia-ai/typegraph/postgres named exports", async () => {
+    // `export *` from "@nicia-ai/typegraph/postgres" is only complete
+    // if `fulltext` is named — drizzle-kit picks up named exports.
+    const postgresPublic = await import("../src/backend/postgres");
+    expect(postgresPublic.fulltext).toBeDefined();
+    expect(getTableConfig(postgresPublic.fulltext).name).toBe(
+      "typegraph_node_fulltext",
+    );
+  });
+});
+
+describe("generatePostgresDDL skips the typed fulltext table", () => {
+  it("does not emit a column-walked CREATE TABLE for typegraph_node_fulltext", async () => {
+    // Walking the typed table with `generatePgCreateTableSQL` would
+    // skip the GENERATED clause entirely (the column-walker has no
+    // generated-column branch), producing a non-equivalent table.
+    // The strategy's `generateDdl` owns CREATE TABLE for the
+    // fulltext table and is what we want to see in the output.
+    const { generatePostgresDDL } = await import("../src/backend/drizzle/ddl");
+    const tables = createPostgresTables();
+    const ddl = generatePostgresDDL(tables, tsvectorStrategy);
+
+    const fulltextCreateTables = ddl.filter(
+      (statement) =>
+        statement.includes(`"${tables.fulltextTableName}"`) &&
+        statement.startsWith("CREATE TABLE"),
+    );
+
+    // Exactly one CREATE TABLE for the fulltext name — the
+    // strategy's, which has the GENERATED clause.
+    expect(fulltextCreateTables).toHaveLength(1);
+    expect(fulltextCreateTables[0]).toMatch(/GENERATED ALWAYS AS/);
+  });
+});


### PR DESCRIPTION
Fixes the silent fulltext-table gap consumers hit when managing typegraph storage via `drizzle-kit push` / `drizzle-kit generate` (closes #128).

drizzle-kit-managed setups create every `typegraph_*` table EXCEPT `typegraph_node_fulltext` because the fulltext DDL is owned by `FulltextStrategy.generateDdl()` (alternate stacks — tsvector + GIN, FTS5 virtual table, pg_trgm, ParadeDB, pgroonga — carry incompatible schemas, and the SQLite case can't be Drizzle-modeled at all). `loadActiveSchemaWithBootstrap` only fires `bootstrapTables` on a missing-table error from `getActiveSchema`, which stops triggering once `schema_versions` exists, so the first `searchable()` write fails at runtime with `relation/table … does not exist` deep in user code.

Two fixes ship together:

- **`backend.ensureFulltextTable()` (both backends).** Focused narrow-ensure mirroring the existing `ensureIndexMaterializationsTable` / `ensureKindRemovalsTable` / `ensureReconciliationMarkersTable` idiom — same SHARE-lock-deadlock-safe rationale documented in `materialize-shared.ts`. `loadActiveSchemaWithBootstrap` calls it after `getActiveSchema` succeeds, so the gap is closed before any user write runs. Latched per-backend so the hot path (every store boot AND every schema verb — `evolve`, `materializeIndexes`, `(un)deprecateKinds`, `removeKinds`) only pays the DDL round-trip once per backend instance.
- **Typed Drizzle pg-core `tables.fulltext` for `tsvectorStrategy`.** New `regconfig` and `tsvector` `customType` columns (parallel to the existing `vector.ts`), with `GENERATED ALWAYS AS (to_tsvector("language", "content")) STORED` on the `tsv` column. `fulltext` is a named export from `@nicia-ai/typegraph/postgres` so `export *` lets drizzle-kit emit migrations for the fulltext table the same way it does for `nodes`/`edges`/etc. `generatePostgresDDL` deliberately defers to the strategy's raw DDL emit (the column-walker can't reproduce GENERATED) — drift sentinel test asserts the typed shape matches strategy DDL byte-for-byte so consumers don't see spurious `drizzle-kit generate` migrations on subsequent runs.

The deeper `TableContribution` refactor that would prevent this trap from recurring with the next strategy-owned table is filed as #129.

## Why two arms

- **SQLite needs Arm 2 (focused ensure):** drizzle-kit doesn't model FTS5 virtual tables; there's no Arm 1 equivalent.
- **Postgres benefits from both:** Arm 1 makes the table visible in drizzle-kit migrations (auditable schema in source control); Arm 2 catches the upgrade case AND covers consumers using non-default Postgres strategies (pg_trgm, ParadeDB, pgroonga) where Arm 1 doesn't apply.

## Out of scope

- The `TableContribution` abstraction proposed in #129 (would unify "what tables does TypeGraph need" across Drizzle exports + tables-factory recursion + strategy-owned raw DDL). Larger refactor; deferred to a minor release.