### PR TITLE
refactor: unified TableContribution contract for strategy-owned tables (closes #129)

### DIFF
--- a/.changeset/table-contribution-contract.md
+++ b/.changeset/table-contribution-contract.md
@@ -1,0 +1,61 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Unified `TableContribution` contract for strategy-owned tables (#129).
+
+"What tables does TypeGraph own?" was previously split across four
+uncoordinated surfaces (Drizzle named exports, tables-factory
+recursion, strategy raw DDL, per-table `ensureXTable` methods). Adding
+a new strategy- or backend-owned table without also wiring an
+`ensureXTable` + bootstrap probe re-opened the gap #128 closed. This
+refactor routes every owned table through one shape.
+
+**Breaking (custom `FulltextStrategy` implementers only):**
+`FulltextStrategy.generateDdl(tableName): string[]` is replaced by
+`ownedTables(primaryTableName): readonly StrategyTableContribution[]`.
+A strategy now *declares* its tables (Drizzle-free: `logicalName`,
+`owner`, resolved `tableName`, idempotent `createDdl` for the table
+**and its supporting indexes**, and a `drizzleModel` discriminant);
+the schema factory resolves those declarations into authoritative
+`TableContribution`s. The two shipped strategies (`tsvectorStrategy`,
+`fts5Strategy`) and all internal callers are migrated; consumers using
+only the shipped strategies need no changes.
+
+**What ships:**
+
+- New `@nicia-ai/typegraph` export: `TableContribution`,
+  `TableContributionSource`, `StrategyTableContribution`,
+  `StrategyDrizzleModel`, `isDrizzleContribution`. Each contribution
+  carries a stable, deployment-independent `logicalName` plus the
+  resolved physical `tableName` (distinct identity vs. drift-signature
+  inputs) — the prerequisite that lets #135 make fulltext
+  materialization a durable, decidable fact instead of an in-memory
+  per-backend latch.
+- `postgresContributions()` / `sqliteContributions()` are the single
+  source of truth for DDL generation, the bootstrap ensure, and
+  drizzle-kit visibility. The Postgres `tables.fulltext` pgTable is
+  created once by the factory and that **exact** object is attached to
+  the fulltext contribution — never a second object for the same
+  physical table. `generatePostgresDDL` / `generateSqliteDDL` iterate
+  contributions; the `table === tables.fulltext` reference-identity
+  hack is gone. drizzle-kit visibility is now declarative
+  (`source.kind`) rather than structural.
+- New backend methods `ensureContribution(logicalName)` and
+  `ensureRuntimeContributions()`. `ensureContribution` runs a
+  contribution's full idempotent `createDdl` (table + supporting
+  indexes), so a partial state (table present, index missing)
+  self-heals — it is not a probe-and-skip.
+  `loadActiveSchemaWithBootstrap` now calls
+  `ensureRuntimeContributions()`, scoped to `runtimeEnsure`
+  contributions only (the strategy-owned fulltext table today), so
+  startup does not regress into broad DDL/probing across every table.
+  `ensureFulltextTable` is retained as a thin back-compat wrapper.
+
+DDL statement ordering changes from "all CREATE TABLE, then all CREATE
+INDEX, then fulltext" to per-contribution "table then its own
+indexes". Safe because TypeGraph's tables carry no cross-table foreign
+keys; raw migration SQL byte output differs accordingly.
+
+Prerequisite for #135 (durable fulltext materialization), which is in
+turn the prerequisite for #134 (cross-store transaction adoption).

--- a/apps/docs/src/content/docs/fulltext-search.md
+++ b/apps/docs/src/content/docs/fulltext-search.md
@@ -626,20 +626,35 @@ export const pgTrgmStrategy: FulltextStrategy = {
     return sql`NULL`;
   },
 
-  generateDdl(table) {
+  // Declares the table(s) this strategy owns. The schema factory
+  // resolves these into TableContributions. `drizzleModel: "raw-ddl"`
+  // because pg_trgm brings its own table (not the typed Drizzle
+  // `tables.fulltext`), so it is emitted verbatim and is invisible to
+  // drizzle-kit. `runtimeEnsure: true` because no drizzle-kit-managed
+  // setup can create it.
+  ownedTables(primaryTableName) {
     return [
-      `CREATE EXTENSION IF NOT EXISTS pg_trgm;`,
-      `CREATE TABLE IF NOT EXISTS "${table}" (
-         "graph_id" TEXT NOT NULL,
-         "node_kind" TEXT NOT NULL,
-         "node_id" TEXT NOT NULL,
-         "content" TEXT NOT NULL,
-         "language" TEXT NOT NULL,
-         "updated_at" TIMESTAMPTZ NOT NULL,
-         PRIMARY KEY ("graph_id", "node_kind", "node_id")
-       );`,
-      `CREATE INDEX IF NOT EXISTS "${table}_trgm_idx"
-         ON "${table}" USING GIN ("content" gin_trgm_ops);`,
+      {
+        logicalName: "fulltext",
+        owner: "pg_trgm",
+        tableName: primaryTableName,
+        createDdl: [
+          `CREATE EXTENSION IF NOT EXISTS pg_trgm;`,
+          `CREATE TABLE IF NOT EXISTS "${primaryTableName}" (
+             "graph_id" TEXT NOT NULL,
+             "node_kind" TEXT NOT NULL,
+             "node_id" TEXT NOT NULL,
+             "content" TEXT NOT NULL,
+             "language" TEXT NOT NULL,
+             "updated_at" TIMESTAMPTZ NOT NULL,
+             PRIMARY KEY ("graph_id", "node_kind", "node_id")
+           );`,
+          `CREATE INDEX IF NOT EXISTS "${primaryTableName}_trgm_idx"
+             ON "${primaryTableName}" USING GIN ("content" gin_trgm_ops);`,
+        ],
+        runtimeEnsure: true,
+        drizzleModel: "raw-ddl",
+      },
     ];
   },
 

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -20,6 +20,11 @@ import {
   type FulltextStrategy,
   tsvectorStrategy,
 } from "../../query/dialect";
+import {
+  BASE_CONTRIBUTION_OWNER,
+  type StrategyTableContribution,
+  type TableContribution,
+} from "../table-contribution";
 import { type PostgresTables, tables as postgresTables } from "./schema/postgres";
 import { type SqliteTables, tables as sqliteTables } from "./schema/sqlite";
 
@@ -248,29 +253,132 @@ function isSqliteTable(
 }
 
 /**
+ * Resolves a strategy's Drizzle-free table *declarations* into
+ * authoritative {@link TableContribution}s, attaching the exact
+ * factory-built Drizzle table object for `drizzle-*` models. A strategy
+ * never constructs a Drizzle table itself, so there is never a second
+ * object for the same physical table (#129).
+ */
+function resolveStrategyContribution(
+  declared: StrategyTableContribution,
+  drizzleTable?: TableContribution["source"],
+): TableContribution {
+  const base = {
+    logicalName: declared.logicalName,
+    owner: declared.owner,
+    tableName: declared.tableName,
+    createDdl: declared.createDdl,
+    runtimeEnsure: declared.runtimeEnsure,
+  };
+  if (declared.drizzleModel === "raw-ddl") {
+    return { ...base, source: { kind: "raw-ddl" } };
+  }
+  if (drizzleTable?.kind !== declared.drizzleModel) {
+    throw new Error(
+      `Strategy declared drizzleModel "${declared.drizzleModel}" for ` +
+        `contribution "${declared.logicalName}" but the schema factory ` +
+        `did not supply a matching Drizzle table object.`,
+    );
+  }
+  return { ...base, source: drizzleTable };
+}
+
+/**
+ * The idempotent DDL a strategy declares for one logical slot (table +
+ * supporting indexes). O(1) in the number of base tables: it asks the
+ * strategy directly and never walks or regenerates base-table DDL —
+ * this is what keeps the latched fulltext ensure and the per-boot
+ * runtime ensure off the base-table DDL-generation path.
+ *
+ * Throws when the strategy declares no contribution under
+ * `logicalName` (caller typo / strategy↔backend disagreement) rather
+ * than silently emitting nothing.
+ */
+export function strategyContributionDdl(
+  fulltextStrategy: FulltextStrategy,
+  fulltextTableName: string,
+  logicalName: string,
+): readonly string[] {
+  const declared = fulltextStrategy
+    .ownedTables(fulltextTableName)
+    .find((contribution) => contribution.logicalName === logicalName);
+  if (declared === undefined) {
+    throw new Error(
+      `No strategy table contribution named "${logicalName}" ` +
+        `(strategy "${fulltextStrategy.name}").`,
+    );
+  }
+  return declared.createDdl;
+}
+
+/**
+ * Strategy-declared contributions flagged `runtimeEnsure`. Per the
+ * `runtimeEnsure` invariant only strategy contributions can be runtime
+ * (base tables never are), so this is the complete runtime set without
+ * walking base tables.
+ */
+export function runtimeStrategyContributions(
+  fulltextStrategy: FulltextStrategy,
+  fulltextTableName: string,
+): readonly StrategyTableContribution[] {
+  return fulltextStrategy
+    .ownedTables(fulltextTableName)
+    .filter((contribution) => contribution.runtimeEnsure);
+}
+
+/**
+ * The authoritative set of tables the SQLite backend owns: every
+ * base/status Drizzle table plus the resolved fulltext-strategy
+ * contribution(s). Single source of truth for DDL generation, the
+ * bootstrap ensure, and drizzle-kit visibility (#129).
+ */
+export function sqliteContributions(
+  tables: SqliteTables = sqliteTables,
+  fulltextStrategy: FulltextStrategy = fts5Strategy,
+): readonly TableContribution[] {
+  const contributions: TableContribution[] = [];
+  for (const [key, table] of Object.entries(tables)) {
+    if (!isSqliteTable(table)) continue;
+    // Stable factory key (`nodes`, `edges`, …) is the logicalName so
+    // the #135 materialization identity survives custom table-name
+    // overrides; the resolved SQL name is only the physical tableName.
+    contributions.push({
+      logicalName: key,
+      owner: BASE_CONTRIBUTION_OWNER,
+      tableName: getSqliteTableConfig(table).name,
+      createDdl: [
+        generateSqliteCreateTableSQL(table),
+        ...generateSqliteCreateIndexSQL(table),
+      ],
+      runtimeEnsure: false,
+      source: { kind: "drizzle-sqlite", table },
+    });
+  }
+  // FTS5 is raw-ddl (virtual table, not Drizzle-modelable) so no table
+  // object is supplied; emitted last (after base tables).
+  for (const declared of fulltextStrategy.ownedTables(
+    tables.fulltextTableName,
+  )) {
+    contributions.push(resolveStrategyContribution(declared));
+  }
+  return contributions;
+}
+
+/**
  * Generates all DDL statements for the given SQLite tables.
+ *
+ * Iterates the unified contribution set (#129) — base tables first,
+ * then strategy-owned tables. Per-contribution ordering is
+ * table-then-its-own-indexes; safe because TypeGraph's tables carry no
+ * cross-table foreign keys.
  */
 export function generateSqliteDDL(
   tables: SqliteTables = sqliteTables,
   fulltextStrategy: FulltextStrategy = fts5Strategy,
 ): string[] {
-  const statements: string[] = [];
-
-  // Generate in dependency order (tables first, then indexes)
-  for (const table of Object.values(tables)) {
-    if (!isSqliteTable(table)) continue;
-    statements.push(generateSqliteCreateTableSQL(table));
-  }
-
-  for (const table of Object.values(tables)) {
-    if (!isSqliteTable(table)) continue;
-    statements.push(...generateSqliteCreateIndexSQL(table));
-  }
-
-  // Fulltext table is a virtual table; emit its DDL last.
-  statements.push(...fulltextStrategy.generateDdl(tables.fulltextTableName));
-
-  return statements;
+  return sqliteContributions(tables, fulltextStrategy).flatMap((
+    contribution,
+  ) => [...contribution.createDdl]);
 }
 
 /**
@@ -421,34 +529,73 @@ function isPgTable(
 }
 
 /**
+ * The authoritative set of tables the PostgreSQL backend owns: every
+ * base/status Drizzle table plus the resolved fulltext-strategy
+ * contribution(s). Single source of truth for DDL generation, the
+ * bootstrap ensure, and drizzle-kit visibility (#129).
+ *
+ * The typed `tables.fulltext` object is **not** emitted via the
+ * column-walker (it can't reproduce `GENERATED ALWAYS AS … STORED`);
+ * instead the strategy's canonical DDL is carried as the fulltext
+ * contribution's `createDdl`, while that same `tables.fulltext` object
+ * is attached as its `source` for drizzle-kit visibility — one object,
+ * not two.
+ */
+export function postgresContributions(
+  tables: PostgresTables = postgresTables,
+  fulltextStrategy: FulltextStrategy = tsvectorStrategy,
+): readonly TableContribution[] {
+  const contributions: TableContribution[] = [];
+  for (const [key, table] of Object.entries(tables)) {
+    if (!isPgTable(table)) continue;
+    // The strategy owns the fulltext slot's DDL; skip the typed object
+    // here and re-attach it to the strategy contribution below.
+    if (table === tables.fulltext) continue;
+    // Stable factory key (`nodes`, `edges`, …) is the logicalName so
+    // the #135 materialization identity survives custom table-name
+    // overrides; the resolved SQL name is only the physical tableName.
+    contributions.push({
+      logicalName: key,
+      owner: BASE_CONTRIBUTION_OWNER,
+      tableName: getPgTableConfig(table).name,
+      createDdl: [
+        generatePgCreateTableSQL(table),
+        ...generatePgCreateIndexSQL(table),
+      ],
+      runtimeEnsure: false,
+      source: { kind: "drizzle-pg", table },
+    });
+  }
+  for (const declared of fulltextStrategy.ownedTables(
+    tables.fulltextTableName,
+  )) {
+    contributions.push(
+      resolveStrategyContribution(
+        declared,
+        declared.drizzleModel === "drizzle-pg"
+          ? { kind: "drizzle-pg", table: tables.fulltext }
+          : undefined,
+      ),
+    );
+  }
+  return contributions;
+}
+
+/**
  * Generates all DDL statements for the given PostgreSQL tables.
  *
- * The typed `tables.fulltext` is excluded from the column-walker
- * pass (it can't reproduce `GENERATED ALWAYS AS … STORED`); the
- * strategy emits the canonical fulltext DDL last.
+ * Iterates the unified contribution set (#129) — base tables first,
+ * then strategy-owned tables. Per-contribution ordering is
+ * table-then-its-own-indexes; safe because TypeGraph's tables carry no
+ * cross-table foreign keys.
  */
 export function generatePostgresDDL(
   tables: PostgresTables = postgresTables,
   fulltextStrategy: FulltextStrategy = tsvectorStrategy,
 ): string[] {
-  const statements: string[] = [];
-
-  // Reference identity sidesteps the per-iter `getPgTableConfig` walk
-  // a name lookup would add, and stays correct under custom names.
-  for (const table of Object.values(tables)) {
-    if (!isPgTable(table)) continue;
-    if (table === tables.fulltext) continue;
-    statements.push(generatePgCreateTableSQL(table));
-  }
-  for (const table of Object.values(tables)) {
-    if (!isPgTable(table)) continue;
-    if (table === tables.fulltext) continue;
-    statements.push(...generatePgCreateIndexSQL(table));
-  }
-
-  statements.push(...fulltextStrategy.generateDdl(tables.fulltextTableName));
-
-  return statements;
+  return postgresContributions(tables, fulltextStrategy).flatMap((
+    contribution,
+  ) => [...contribution.createDdl]);
 }
 
 /**

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -42,6 +42,7 @@ import {
   type FulltextStrategy,
   tsvectorStrategy,
 } from "../../query/dialect/fulltext-strategy";
+import { FULLTEXT_CONTRIBUTION_NAME } from "../table-contribution";
 import {
   type BackendCapabilities,
   type CommitSchemaVersionParams,
@@ -69,7 +70,12 @@ import {
   type VectorSearchParams,
   type VectorSearchResult,
 } from "../types";
-import { generatePgCreateTableSQL, generatePostgresDDL } from "./ddl";
+import {
+  generatePgCreateTableSQL,
+  generatePostgresDDL,
+  runtimeStrategyContributions,
+  strategyContributionDdl,
+} from "./ddl";
 import {
   type AnyPgDatabase,
   createPostgresExecutionAdapter,
@@ -393,13 +399,17 @@ export function createPostgresBackend(
   // guard every method that touches the fulltext table — fulltext
   // writes can fire from any code path (sync `createStore`, hard-
   // delete cascade, batched index sync), so the bootstrap-load
-  // probe alone doesn't cover all surfaces.
+  // probe alone doesn't cover all surfaces. (#135 replaces this
+  // in-memory latch with a durable materialization marker.)
   let fulltextEnsured = false;
   async function ensureFulltextDdl(): Promise<void> {
     if (fulltextEnsured) return;
-    for (const statement of fulltextStrategy.generateDdl(
+    const statements = strategyContributionDdl(
+      fulltextStrategy,
       tables.fulltextTableName,
-    )) {
+      FULLTEXT_CONTRIBUTION_NAME,
+    );
+    for (const statement of statements) {
       await db.execute(sql.raw(statement));
     }
     fulltextEnsured = true;
@@ -554,6 +564,47 @@ export function createPostgresBackend(
       );
     },
 
+    async ensureContribution(logicalName: string): Promise<void> {
+      if (logicalName === FULLTEXT_CONTRIBUTION_NAME) {
+        // Route the fulltext slot through the latched path so the
+        // in-memory short-circuit (and, post-#135, the durable marker)
+        // stays the single gate for it.
+        await ensureFulltextDdl();
+        return;
+      }
+      const statements = strategyContributionDdl(
+        fulltextStrategy,
+        tables.fulltextTableName,
+        logicalName,
+      );
+      for (const statement of statements) {
+        await db.execute(sql.raw(statement));
+      }
+    },
+
+    async ensureRuntimeContributions(): Promise<void> {
+      // Runtime contributions are strategy-owned by invariant (base
+      // tables are never `runtimeEnsure`), so this asks the strategy
+      // directly — no base-table walk on the per-boot path.
+      for (const contribution of runtimeStrategyContributions(
+        fulltextStrategy,
+        tables.fulltextTableName,
+      )) {
+        if (contribution.logicalName === FULLTEXT_CONTRIBUTION_NAME) {
+          await ensureFulltextDdl();
+          continue;
+        }
+        for (const statement of contribution.createDdl) {
+          await db.execute(sql.raw(statement));
+        }
+      }
+    },
+
+    /**
+     * Superseded by `ensureContribution("fulltext")` /
+     * `ensureRuntimeContributions()` (#129). Retained as a thin
+     * back-compat wrapper; #135 removes the remaining hot-path callers.
+     */
     async ensureFulltextTable(): Promise<void> {
       await ensureFulltextDdl();
     },

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -69,7 +69,13 @@ import {
   type SqliteExecutionProfileHints,
 } from "./execution/sqlite-execution";
 export type { SqliteTransactionMode } from "./execution/sqlite-execution";
-import { generateSqliteCreateTableSQL, generateSqliteDDL } from "./ddl";
+import { FULLTEXT_CONTRIBUTION_NAME } from "../table-contribution";
+import {
+  generateSqliteCreateTableSQL,
+  generateSqliteDDL,
+  runtimeStrategyContributions,
+  strategyContributionDdl,
+} from "./ddl";
 import {
   buildMaterializationInsertValues,
   buildMaterializationOnConflictSet,
@@ -680,13 +686,17 @@ export function createSqliteBackend(
   // guard every method that touches the fulltext table — fulltext
   // writes can fire from any code path (sync `createStore`, hard-
   // delete cascade, batched index sync), so the bootstrap-load
-  // probe alone doesn't cover all surfaces.
+  // probe alone doesn't cover all surfaces. (#135 replaces this
+  // in-memory latch with a durable materialization marker.)
   let fulltextEnsured = false;
   async function ensureFulltextDdl(): Promise<void> {
     if (fulltextEnsured) return;
-    for (const statement of fulltextStrategy.generateDdl(
+    const statements = strategyContributionDdl(
+      fulltextStrategy,
       tables.fulltextTableName,
-    )) {
+      FULLTEXT_CONTRIBUTION_NAME,
+    );
+    for (const statement of statements) {
       await db.run(sql.raw(statement));
     }
     fulltextEnsured = true;
@@ -839,6 +849,44 @@ export function createSqliteBackend(
       );
     },
 
+    async ensureContribution(logicalName: string): Promise<void> {
+      if (logicalName === FULLTEXT_CONTRIBUTION_NAME) {
+        await ensureFulltextDdl();
+        return;
+      }
+      const statements = strategyContributionDdl(
+        fulltextStrategy,
+        tables.fulltextTableName,
+        logicalName,
+      );
+      for (const statement of statements) {
+        await db.run(sql.raw(statement));
+      }
+    },
+
+    async ensureRuntimeContributions(): Promise<void> {
+      // Runtime contributions are strategy-owned by invariant (base
+      // tables are never `runtimeEnsure`), so this asks the strategy
+      // directly — no base-table walk on the per-boot path.
+      for (const contribution of runtimeStrategyContributions(
+        fulltextStrategy,
+        tables.fulltextTableName,
+      )) {
+        if (contribution.logicalName === FULLTEXT_CONTRIBUTION_NAME) {
+          await ensureFulltextDdl();
+          continue;
+        }
+        for (const statement of contribution.createDdl) {
+          await db.run(sql.raw(statement));
+        }
+      }
+    },
+
+    /**
+     * Superseded by `ensureContribution("fulltext")` /
+     * `ensureRuntimeContributions()` (#129). Retained as a thin
+     * back-compat wrapper; #135 removes the remaining hot-path callers.
+     */
     async ensureFulltextTable(): Promise<void> {
       await ensureFulltextDdl();
     },

--- a/packages/typegraph/src/backend/table-contribution.ts
+++ b/packages/typegraph/src/backend/table-contribution.ts
@@ -1,0 +1,183 @@
+/**
+ * Unified table-contribution contract (#129).
+ *
+ * Every table TypeGraph owns — whether modeled as a Drizzle table or
+ * emitted as strategy-owned raw DDL — is described by a single
+ * {@link TableContribution} shape. This is the one place that answers
+ * "what tables does this backend/strategy own?", replacing the
+ * previously split surfaces (Drizzle named exports, tables-factory
+ * recursion, strategy raw DDL, per-table `ensureXTable` methods).
+ *
+ * Lives in the neutral `backend/` layer (sibling of `backend/types.ts`,
+ * which `query/dialect` already depends on) with **type-only** Drizzle
+ * imports, so declaring contributions does not pull the concrete
+ * Drizzle backend runtime into the query/dialect layer.
+ *
+ * ## Identity vs. signature (prerequisite for #135)
+ *
+ * #135 (durable fulltext/contribution materialization) needs to make
+ * "not materialized" vs. "materialized but stale" a decidable, durable
+ * fact instead of an in-memory per-backend latch. That requires two
+ * conceptually separate things, and #129's job is only to make both
+ * *derivable* from the contract:
+ *
+ * - **Materialization identity** — `owner` + `logicalName` +
+ *   resolved physical `tableName`. Keying on `logicalName` alone is
+ *   insufficient: custom per-deployment table names must be
+ *   distinguishable, otherwise two deployments with different physical
+ *   names would collide on one durable marker. (#135 additionally
+ *   scopes this by `graphId` at persistence time.)
+ * - **Drift signature** — a hash of the strategy identity/version,
+ *   the resolved table name(s), and the normalized `createDdl`. #129
+ *   guarantees `createDdl` is deterministic for a given resolved
+ *   configuration so the hash #135 computes is meaningful.
+ *
+ * The signature is intentionally **not** eagerly carried on the
+ * contribution: hashing is async (Web Crypto, see `utils/hash`) and
+ * #135 already owns signature persistence the same way
+ * `materializeIndexes` does for declared indexes.
+ */
+import type { PgTableWithColumns } from "drizzle-orm/pg-core";
+import type { SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";
+
+/**
+ * `logicalName` of the strategy-owned fulltext slot. Used as a logic
+ * discriminant (latch routing, runtime-ensure) across the strategies
+ * and both backends — a shared constant so a strategy declaring a
+ * different name fails loudly at the call site instead of silently
+ * skipping the latched fulltext path.
+ */
+export const FULLTEXT_CONTRIBUTION_NAME = "fulltext";
+
+/** `owner` of core/base schema tables (not strategy-owned). */
+export const BASE_CONTRIBUTION_OWNER = "base";
+
+/**
+ * Where a contribution's storage comes from. Drives two otherwise
+ * structural decisions declaratively:
+ *
+ * - **drizzle-kit visibility**: only `drizzle-*` contributions are
+ *   re-exported for drizzle-kit introspection. Previously decided by
+ *   scattered `table === tables.fulltext` reference-identity checks in
+ *   the DDL generators.
+ * - **DDL-generation routing**: `drizzle-*` contributions can flow
+ *   through the column-walker; `raw-ddl` contributions (SQLite FTS5
+ *   virtual tables, future pg_trgm / ParadeDB / pgroonga stacks) are
+ *   emitted verbatim from `createDdl`.
+ *
+ * The `drizzle-*` variants reference the **exact** table object the
+ * schema factory created and exports — never a second `pgTable`
+ * constructed elsewhere for the same physical table.
+ */
+export type TableContributionSource =
+  | {
+      readonly kind: "drizzle-pg";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      readonly table: PgTableWithColumns<any>;
+    }
+  | {
+      readonly kind: "drizzle-sqlite";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      readonly table: SQLiteTableWithColumns<any>;
+    }
+  | { readonly kind: "raw-ddl" };
+
+/**
+ * A single table TypeGraph owns.
+ */
+export type TableContribution = Readonly<{
+  /**
+   * Stable, graph- and deployment-independent identity for the logical
+   * slot this contribution fills (e.g. `"fulltext"`). NOT the physical
+   * table name. Stable across table-name overrides and across strategy
+   * swaps of the *same* logical slot, so #135's durable marker can
+   * survive both.
+   */
+  logicalName: string;
+  /**
+   * Identifies the producer of this contribution (e.g. a strategy id
+   * like `"tsvector"` / `"fts5"`, or `"base"` for core schema tables).
+   * Part of the #135 materialization identity and an input to the
+   * drift signature — a strategy swap on the same `logicalName` is a
+   * legitimate, detectable drift, not a silent reuse.
+   */
+  owner: string;
+  /**
+   * Resolved physical table name after any per-deployment name
+   * override. Part of the #135 materialization identity (custom names
+   * must be distinguishable) and used by diagnostics / the focused
+   * bootstrap ensure.
+   */
+  tableName: string;
+  /**
+   * Idempotent (`CREATE ... IF NOT EXISTS`) statements that
+   * materialize this contribution's table **and its supporting
+   * indexes**. Running the full list is how `ensureContribution`
+   * self-heals partial states (table present, index missing) — it is
+   * not a probe-and-skip. Deterministic for a given resolved
+   * configuration: the canonical normalized input to #135's drift
+   * signature.
+   */
+  createDdl: readonly string[];
+  /**
+   * When `true`, the post-schema-load focused ensure
+   * (`loadActiveSchemaWithBootstrap`) materializes this contribution
+   * on every successful schema load.
+   *
+   * **Invariant: only strategy-declared contributions may set this.**
+   * Core/base tables are always `false` — they are created by
+   * drizzle-kit / `bootstrapTables`. This is what lets the boot path
+   * derive runtime contributions straight from the strategy
+   * (`fulltextStrategy.ownedTables`) without walking — and generating
+   * DDL for — every base table.
+   */
+  runtimeEnsure: boolean;
+  /** Storage origin — see {@link TableContributionSource}. */
+  source: TableContributionSource;
+}>;
+
+/**
+ * Whether a contribution should be visible to drizzle-kit (i.e. is
+ * backed by a Drizzle table object, not strategy-owned raw DDL).
+ */
+export function isDrizzleContribution(
+  contribution: TableContribution,
+): boolean {
+  return contribution.source.kind !== "raw-ddl";
+}
+
+/**
+ * How the schema factory should source a strategy-declared table.
+ *
+ * - `"raw-ddl"` — emit `createDdl` verbatim; not drizzle-kit visible
+ *   (SQLite FTS5 virtual tables, raw-DDL Postgres stacks).
+ * - `"drizzle-pg"` — the Postgres factory attaches the **exact**
+ *   `tables.fulltext` pgTable object it already created and exports;
+ *   the strategy never constructs a Drizzle table itself, so there is
+ *   never a second object for the same physical table.
+ *
+ * There is intentionally no `"drizzle-sqlite"`: the SQLite factory has
+ * no strategy-owned Drizzle table slot to attach (FTS5 virtual tables
+ * aren't Drizzle-modelable, so SQLite strategies are `"raw-ddl"`).
+ * `TableContributionSource` still carries a `drizzle-sqlite` kind for
+ * *resolved* base/core tables — that path is unaffected.
+ */
+export type StrategyDrizzleModel = "raw-ddl" | "drizzle-pg";
+
+/**
+ * A table a {@link FulltextStrategy} declares it owns. This is the
+ * strategy's *declaration*; the schema factory resolves it into the
+ * authoritative {@link TableContribution} — attaching the real Drizzle
+ * table object for `drizzle-*` models (see {@link StrategyDrizzleModel}).
+ *
+ * Deliberately Drizzle-free so implementing a custom strategy never
+ * requires a `drizzle-orm` dependency.
+ */
+export type StrategyTableContribution = Readonly<{
+  logicalName: string;
+  owner: string;
+  tableName: string;
+  createDdl: readonly string[];
+  runtimeEnsure: boolean;
+  drizzleModel: StrategyDrizzleModel;
+}>;

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -872,15 +872,44 @@ export type GraphBackend = Readonly<{
    */
   ensureReconciliationMarkersTable?: () => Promise<void>;
 
-  // === Fulltext Storage ===
+  // === Table Contributions (#129) ===
+
+  /**
+   * Materializes a single **strategy-declared** contribution by
+   * `logicalName` (e.g. `"fulltext"`) — running its full idempotent
+   * `createDdl` (table + supporting indexes), so a partial state
+   * (table present, index missing) self-heals. Concurrency-safe under
+   * replica startup.
+   *
+   * Scope is intentionally the strategy-owned slots only (the set
+   * `FulltextStrategy.ownedTables` declares); it is **not** a generic
+   * "materialize any table" entrypoint. Base/core tables come from
+   * drizzle-kit or `bootstrapTables`, never here. Throws on a
+   * `logicalName` no active strategy declares, rather than silently
+   * doing nothing.
+   */
+  ensureContribution?: (logicalName: string) => Promise<void>;
+
+  /**
+   * Materializes every contribution flagged `runtimeEnsure` — the
+   * strategy-owned runtime tables (fulltext today) that drizzle-kit-
+   * managed setups don't create. Called once after a successful schema
+   * load. Deliberately scoped: base/drizzle-visible tables are
+   * `runtimeEnsure: false`, so this does not regress startup into
+   * broad DDL/probing across every table.
+   */
+  ensureRuntimeContributions?: () => Promise<void>;
 
   /**
    * Bootstraps the fulltext storage table the active `FulltextStrategy`
-   * owns — the strategy owns this DDL because shapes diverge across
-   * stacks (`tsvector` + GIN, FTS5 virtual table, pg_trgm, …) and
-   * the SQLite case can't be Drizzle-modeled at all. Same focused-
-   * bootstrap rationale as the other `ensure*Table` methods:
-   * idempotent and concurrency-safe under replica startup.
+   * owns. Same focused-bootstrap rationale as the other `ensure*Table`
+   * methods: idempotent and concurrency-safe under replica startup.
+   *
+   * Superseded by `ensureContribution("fulltext")` /
+   * `ensureRuntimeContributions()` (#129); retained as a thin
+   * back-compat wrapper for backends/callers predating #129. Not
+   * machine-`@deprecated` because the manager still calls it as the
+   * pre-#129 fallback. #135 removes the remaining hot-path callers.
    */
   ensureFulltextTable?: () => Promise<void>;
 

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -98,6 +98,13 @@ export {
 // ============================================================
 
 export type {
+  StrategyDrizzleModel,
+  StrategyTableContribution,
+  TableContribution,
+  TableContributionSource,
+} from "./backend/table-contribution";
+export { isDrizzleContribution } from "./backend/table-contribution";
+export type {
   BackendCapabilities,
   CommitSchemaVersionExpected,
   CommitSchemaVersionParams,

--- a/packages/typegraph/src/query/dialect/fulltext-strategy.ts
+++ b/packages/typegraph/src/query/dialect/fulltext-strategy.ts
@@ -13,6 +13,10 @@ import { type SQL, sql } from "drizzle-orm";
 
 import { quotedTableName } from "../../backend/drizzle/operations/shared";
 import {
+  FULLTEXT_CONTRIBUTION_NAME,
+  type StrategyTableContribution,
+} from "../../backend/table-contribution";
+import {
   type DeleteFulltextBatchParams,
   type DeleteFulltextParams,
   type FulltextBatchRow,
@@ -135,11 +139,19 @@ export interface FulltextStrategy {
   ): SQL;
 
   /**
-   * DDL statements to create the backing table and any supporting
-   * indexes. Idempotent (`CREATE ... IF NOT EXISTS`). Called once from
-   * `bootstrapTables()` on a fresh database.
+   * The tables this strategy owns, as Drizzle-free *declarations*
+   * (`logicalName`, `owner`, resolved `tableName`, idempotent
+   * `createDdl` for the table **and its supporting indexes**, and the
+   * `drizzleModel` telling the schema factory how to source it). The
+   * factory resolves these into authoritative `TableContribution`s,
+   * attaching the exact Drizzle table object for `drizzle-*` models —
+   * a strategy never constructs a Drizzle table itself.
+   *
+   * Replaces the former `generateDdl(tableName)`: DDL is now one field
+   * of a contribution rather than the strategy's whole storage
+   * surface. (Public API change — see #129.)
    */
-  generateDdl(tableName: string): readonly string[];
+  ownedTables(primaryTableName: string): readonly StrategyTableContribution[];
 
   /**
    * Emits the statements that upsert a single fulltext row. Returns one
@@ -311,17 +323,17 @@ export const tsvectorStrategy: FulltextStrategy = {
     return sql`ts_headline(${langExpr}, "content", ${q}, 'StartSel=<mark>,StopSel=</mark>,MaxFragments=1,MinWords=5,MaxWords=30,ShortWord=3')`;
   },
 
-  generateDdl(tableName) {
-    const name = quoteIdentifier(tableName);
-    const gin = quoteIdentifier(`${tableName}_tsv_idx`);
-    const kind = quoteIdentifier(`${tableName}_kind_idx`);
+  ownedTables(primaryTableName) {
+    const name = quoteIdentifier(primaryTableName);
+    const gin = quoteIdentifier(`${primaryTableName}_tsv_idx`);
+    const kind = quoteIdentifier(`${primaryTableName}_kind_idx`);
     // `language` is `regconfig` so `to_tsvector("language", "content")`
     // is an immutable expression — Postgres can then compute `tsv` as a
     // GENERATED STORED column and own the `content → tsv` invariant.
     // (The text→regconfig cast happens once at INSERT time against the
     // bound parameter, which is fine because it's not inside the
     // generated expression.)
-    return [
+    const createDdl = [
       `CREATE TABLE IF NOT EXISTS ${name} (
   "graph_id" TEXT NOT NULL,
   "node_kind" TEXT NOT NULL,
@@ -335,6 +347,20 @@ export const tsvectorStrategy: FulltextStrategy = {
 );`,
       `CREATE INDEX IF NOT EXISTS ${gin} ON ${name} USING GIN ("tsv");`,
       `CREATE INDEX IF NOT EXISTS ${kind} ON ${name} ("graph_id", "node_kind");`,
+    ];
+    // Drizzle-modelable on Postgres: the schema factory attaches the
+    // exact `tables.fulltext` pgTable object (no second object for the
+    // same physical table). `runtimeEnsure` because drizzle-kit-managed
+    // setups create every base table except this strategy-owned one.
+    return [
+      {
+        logicalName: FULLTEXT_CONTRIBUTION_NAME,
+        owner: "tsvector",
+        tableName: primaryTableName,
+        createDdl,
+        runtimeEnsure: true,
+        drizzleModel: "drizzle-pg",
+      },
     ];
   },
 
@@ -524,10 +550,19 @@ export const fts5Strategy: FulltextStrategy = {
     return sql`snippet(${quotedTableName(tableName)}, -1, '<mark>', '</mark>', '…', 20)`;
   },
 
-  generateDdl(tableName) {
-    const name = quoteIdentifier(tableName);
+  ownedTables(primaryTableName) {
+    const name = quoteIdentifier(primaryTableName);
+    // FTS5 virtual tables cannot be modeled as a Drizzle table, so this
+    // contribution is raw-ddl: emitted verbatim and invisible to
+    // drizzle-kit. `runtimeEnsure` because no drizzle-kit-managed setup
+    // can create it.
     return [
-      `CREATE VIRTUAL TABLE IF NOT EXISTS ${name} USING fts5(
+      {
+        logicalName: FULLTEXT_CONTRIBUTION_NAME,
+        owner: "fts5",
+        tableName: primaryTableName,
+        createDdl: [
+          `CREATE VIRTUAL TABLE IF NOT EXISTS ${name} USING fts5(
   graph_id UNINDEXED,
   node_kind UNINDEXED,
   node_id UNINDEXED,
@@ -536,6 +571,10 @@ export const fts5Strategy: FulltextStrategy = {
   content,
   tokenize='porter unicode61 remove_diacritics 2'
 );`,
+        ],
+        runtimeEnsure: true,
+        drizzleModel: "raw-ddl",
+      },
     ];
   },
 

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -106,12 +106,15 @@ function isMissingTableError(error: unknown): boolean {
 
 /**
  * Reads the active schema row, bootstrapping the base tables on the
- * first call against an empty database. Also runs
- * `ensureFulltextTable` on the success path: drizzle-kit-managed
- * setups create every base table EXCEPT the strategy-owned fulltext
- * table, and the missing-table-error fallback below doesn't trigger
- * once `schema_versions` exists. The focused ensure closes that gap
- * before any `searchable()` write runs.
+ * first call against an empty database. Also runs the focused
+ * runtime-contribution ensure on the success path: drizzle-kit-managed
+ * setups create every base table EXCEPT strategy-owned runtime tables
+ * (fulltext), and the missing-table-error fallback below doesn't
+ * trigger once `schema_versions` exists. `ensureRuntimeContributions`
+ * closes that gap before any `searchable()` write runs — scoped to
+ * `runtimeEnsure` contributions only, so this stays a focused ensure
+ * rather than broad startup DDL (#129). Falls back to the deprecated
+ * `ensureFulltextTable` for backends predating #129.
  */
 export async function loadActiveSchemaWithBootstrap(
   backend: GraphBackend,
@@ -119,7 +122,9 @@ export async function loadActiveSchemaWithBootstrap(
 ): Promise<SchemaVersionRow | undefined> {
   try {
     const row = await backend.getActiveSchema(graphId);
-    await backend.ensureFulltextTable?.();
+    await (backend.ensureRuntimeContributions ?
+      backend.ensureRuntimeContributions()
+    : backend.ensureFulltextTable?.());
     return row;
   } catch (error) {
     if (backend.bootstrapTables && isMissingTableError(error)) {

--- a/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
@@ -241,9 +241,9 @@ describe.runIf(process.env.POSTGRES_URL)(
       // GENERATED clause), so the strategy DDL should be the only
       // source of fulltext CREATE TABLE.
       const allDdl = generatePostgresDDL(defaultTables, tsvectorStrategy);
-      const strategyDdl = tsvectorStrategy.generateDdl(
-        defaultTables.fulltextTableName,
-      );
+      const strategyDdl = tsvectorStrategy
+        .ownedTables(defaultTables.fulltextTableName)
+        .flatMap((contribution) => contribution.createDdl);
       const tail = allDdl.slice(allDdl.length - strategyDdl.length);
       expect(tail).toEqual(strategyDdl);
     });

--- a/packages/typegraph/tests/fulltext-search.test.ts
+++ b/packages/typegraph/tests/fulltext-search.test.ts
@@ -706,7 +706,7 @@ describe("custom FulltextStrategy plumbing", () => {
     const Database = betterSqlite3.default;
 
     const calls = {
-      generateDdl: 0,
+      ownedTables: 0,
       buildUpsert: 0,
       buildBatchUpsert: 0,
       buildDelete: 0,
@@ -717,9 +717,9 @@ describe("custom FulltextStrategy plumbing", () => {
     };
     const spyStrategy = {
       ...fts5Strategy,
-      generateDdl: (tableName: string) => {
-        calls.generateDdl += 1;
-        return fts5Strategy.generateDdl(tableName);
+      ownedTables: (tableName: string) => {
+        calls.ownedTables += 1;
+        return fts5Strategy.ownedTables(tableName);
       },
       buildUpsert: (...args: Parameters<typeof fts5Strategy.buildUpsert>) => {
         calls.buildUpsert += 1;
@@ -767,8 +767,8 @@ describe("custom FulltextStrategy plumbing", () => {
     await backend.bootstrapTables?.();
     const store = createStore(HybridGraph, backend);
 
-    // generateDdl called during bootstrap.
-    expect(calls.generateDdl).toBeGreaterThanOrEqual(1);
+    // ownedTables consulted during bootstrap (DDL derives from it).
+    expect(calls.ownedTables).toBeGreaterThanOrEqual(1);
 
     const node = await store.nodes.HybridDoc.create({
       title: "strategy plumbing",

--- a/packages/typegraph/tests/table-contribution.test.ts
+++ b/packages/typegraph/tests/table-contribution.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Contract tests for the unified `TableContribution` surface (#129).
+ *
+ * Covers the invariants the refactor must hold and that #135 (durable
+ * materialization) will build on: a single Drizzle table object for the
+ * Postgres fulltext slot (no duplicate), custom table names reflected
+ * in contribution identity, FTS5 staying raw-ddl, tsvector staying
+ * drizzle-visible, supporting indexes still emitted, and a custom
+ * strategy plugging in through the new `ownedTables` public API.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  generatePostgresDDL,
+  postgresContributions,
+  sqliteContributions,
+} from "../src/backend/drizzle/ddl";
+import { createPostgresTables } from "../src/backend/drizzle/schema/postgres";
+import { createSqliteTables } from "../src/backend/drizzle/schema/sqlite";
+import { isDrizzleContribution } from "../src/backend/table-contribution";
+import { type FulltextStrategy, tsvectorStrategy } from "../src/query/dialect";
+
+function fulltextContribution(
+  contributions: ReturnType<typeof postgresContributions>,
+) {
+  const found = contributions.find(
+    (contribution) => contribution.logicalName === "fulltext",
+  );
+  if (found === undefined) throw new Error("no fulltext contribution");
+  return found;
+}
+
+describe("TableContribution — Postgres (tsvectorStrategy)", () => {
+  it("attaches the exact factory pgTable object — no duplicate", () => {
+    const tables = createPostgresTables();
+    const contribution = fulltextContribution(postgresContributions(tables));
+
+    expect(contribution.source.kind).toBe("drizzle-pg");
+    if (contribution.source.kind !== "drizzle-pg") return;
+    // Reference identity: the contribution must carry the SAME object
+    // the factory created and exports, never a second pgTable for the
+    // same physical table.
+    expect(contribution.source.table).toBe(tables.fulltext);
+  });
+
+  it("stays drizzle-kit visible", () => {
+    const contribution = fulltextContribution(
+      postgresContributions(createPostgresTables()),
+    );
+    expect(isDrizzleContribution(contribution)).toBe(true);
+  });
+
+  it("reflects custom table names in contribution identity", () => {
+    const tables = createPostgresTables({ fulltext: "myapp_search_index" });
+    const contribution = fulltextContribution(postgresContributions(tables));
+
+    expect(contribution.logicalName).toBe("fulltext"); // stable slot
+    expect(contribution.tableName).toBe("myapp_search_index"); // physical
+    expect(contribution.createDdl.join("\n")).toContain("myapp_search_index");
+  });
+
+  it("still emits the supporting GIN + kind indexes", () => {
+    const ddl = generatePostgresDDL(
+      createPostgresTables(),
+      tsvectorStrategy,
+    ).join("\n");
+    expect(ddl).toContain("typegraph_node_fulltext_tsv_idx");
+    expect(ddl).toContain('USING GIN ("tsv")');
+    expect(ddl).toContain("typegraph_node_fulltext_kind_idx");
+  });
+
+  it("keeps base-table logicalName stable across custom table names", () => {
+    const tables = createPostgresTables({
+      nodes: "myapp_nodes",
+      edges: "myapp_edges",
+    });
+    const contributions = postgresContributions(tables);
+
+    const nodes = contributions.find((c) => c.logicalName === "nodes");
+    const edges = contributions.find((c) => c.logicalName === "edges");
+    if (nodes === undefined || edges === undefined) {
+      throw new Error("base contributions missing");
+    }
+    // logicalName is the stable factory key — the #135 materialization
+    // identity must not move when the physical name is overridden.
+    expect(nodes.tableName).toBe("myapp_nodes");
+    expect(edges.tableName).toBe("myapp_edges");
+    expect(nodes.createDdl.join("\n")).toContain("myapp_nodes");
+    // The physical name must NOT have leaked into logicalName.
+    expect(contributions.some((c) => c.logicalName === "myapp_nodes")).toBe(
+      false,
+    );
+  });
+
+  it("marks the fulltext slot runtimeEnsure but base tables not", () => {
+    const contributions = postgresContributions(createPostgresTables());
+    expect(fulltextContribution(contributions).runtimeEnsure).toBe(true);
+    const base = contributions.filter(
+      (contribution) => contribution.owner === "base",
+    );
+    expect(base.length).toBeGreaterThan(0);
+    expect(base.every((contribution) => !contribution.runtimeEnsure)).toBe(
+      true,
+    );
+  });
+});
+
+describe("TableContribution — SQLite (fts5Strategy)", () => {
+  it("is raw-ddl, not drizzle-visible, and emits the FTS5 virtual table", () => {
+    const contributions = sqliteContributions(createSqliteTables());
+    const fulltext = contributions.find(
+      (contribution) => contribution.logicalName === "fulltext",
+    );
+    if (fulltext === undefined) throw new Error("no fulltext contribution");
+
+    expect(fulltext.source.kind).toBe("raw-ddl");
+    expect(isDrizzleContribution(fulltext)).toBe(false);
+    expect(fulltext.createDdl.join("\n")).toContain(
+      "CREATE VIRTUAL TABLE IF NOT EXISTS",
+    );
+    expect(fulltext.createDdl.join("\n")).toContain("USING fts5(");
+  });
+});
+
+describe("TableContribution — custom strategy via the ownedTables API", () => {
+  it("a custom strategy's ownedTables flows into generated DDL", () => {
+    // Exercises the new public API shape: a strategy declares its
+    // storage through `ownedTables` (Drizzle-free) and the resolver
+    // turns it into emitted DDL.
+    const customStrategy: FulltextStrategy = {
+      ...tsvectorStrategy,
+      ownedTables(primaryTableName) {
+        return [
+          {
+            logicalName: "fulltext",
+            owner: "custom-pg-trgm",
+            tableName: primaryTableName,
+            createDdl: [
+              `CREATE TABLE IF NOT EXISTS "${primaryTableName}" (id TEXT);`,
+            ],
+            runtimeEnsure: true,
+            drizzleModel: "raw-ddl",
+          },
+        ];
+      },
+    };
+
+    const contribution = fulltextContribution(
+      postgresContributions(createPostgresTables(), customStrategy),
+    );
+    expect(contribution.owner).toBe("custom-pg-trgm");
+    expect(contribution.source.kind).toBe("raw-ddl");
+
+    const ddl = generatePostgresDDL(
+      createPostgresTables(),
+      customStrategy,
+    ).join("\n");
+    expect(ddl).toContain(
+      'CREATE TABLE IF NOT EXISTS "typegraph_node_fulltext" (id TEXT);',
+    );
+  });
+});

--- a/packages/typegraph/tests/typed-fulltext-table.test.ts
+++ b/packages/typegraph/tests/typed-fulltext-table.test.ts
@@ -96,7 +96,9 @@ describe("typed Drizzle fulltext table (tsvectorStrategy)", () => {
     // This sentinel just confirms the strategy still emits the table
     // shape we modeled in Drizzle — if either side diverges, this
     // test catches it before a consumer hits drizzle-kit drift.
-    const strategyDdl = tsvectorStrategy.generateDdl(tables.fulltextTableName);
+    const strategyDdl = tsvectorStrategy
+      .ownedTables(tables.fulltextTableName)
+      .flatMap((contribution) => contribution.createDdl);
     const ddlText = strategyDdl.join("\n");
 
     expect(ddlText).toContain(`"${tables.fulltextTableName}"`);


### PR DESCRIPTION
Closes #129.

Unified `TableContribution` contract for strategy-owned tables. "What tables does TypeGraph own?" was split across four uncoordinated surfaces (Drizzle named exports, tables-factory recursion, strategy raw DDL, per-table `ensureXTable` methods); adding a new strategy/backend table without also wiring an `ensureXTable` + bootstrap probe re-opened the gap #128 closed. Everything now flows through one shape.

This is the **blocking prerequisite for #135** (durable fulltext materialization), which is in turn the prerequisite for #134 (cross-store transaction adoption). It deliberately stops short of #135's scope: it makes the materialization identity/signature *exist and be stable*; durable persistence + latch removal is #135.

## Breaking change (custom `FulltextStrategy` implementers only)

`FulltextStrategy.generateDdl(tableName): string[]` → `ownedTables(primaryTableName): readonly StrategyTableContribution[]`. Strategies now *declare* their tables Drizzle-free (`logicalName`, `owner`, resolved `tableName`, idempotent `createDdl` for table **+ supporting indexes**, `drizzleModel` discriminant); the schema factory resolves declarations into authoritative `TableContribution`s. Shipped strategies (`tsvectorStrategy`, `fts5Strategy`) and all internal callers are migrated — **consumers using only the shipped strategies need no changes**. Versioned `minor`.

## What ships

- **New exports**: `TableContribution`, `TableContributionSource`, `StrategyTableContribution`, `StrategyDrizzleModel`, `isDrizzleContribution`. Stable `logicalName` + resolved physical `tableName` are distinct identity vs. drift-signature inputs (the prerequisite #135 needs).
- **Single source of truth**: `postgresContributions()` / `sqliteContributions()` drive DDL generation, the bootstrap ensure, and drizzle-kit visibility. The Postgres `tables.fulltext` pgTable is created once by the factory and that **exact object** is attached to the fulltext contribution — never a duplicate (reference-identity test enforces this). The `table === tables.fulltext` hack is gone; drizzle-kit visibility is now declarative (`source.kind`).
- **Lifecycle**: `ensureContribution(logicalName)` materializes a single **strategy-declared** contribution (the slots `FulltextStrategy.ownedTables` declares — `"fulltext"` today), running its full idempotent `createDdl` (table + indexes) so partial state self-heals — not probe-and-skip. It is intentionally **not** a generic "materialize any table" entrypoint: base/core tables come from drizzle-kit or `bootstrapTables`, and an unknown `logicalName` throws rather than silently no-ops. `loadActiveSchemaWithBootstrap` calls `ensureRuntimeContributions()`, scoped to `runtimeEnsure` (strategy-owned) contributions only, so startup does not regress into broad DDL/probing. `ensureFulltextTable` retained as a back-compat wrapper.

## Two deliberate deviations from the issue text (defended in-code)

1. **Contribution resolver lives in `ddl.ts`, not the factory `as const` return** — baking it into `createPostgresTables` would create a `schema → ddl` import cycle *and* freeze contributions against the default strategy even when a backend overrides it. Same intent, cleaner seam.
2. **Shim is prose-"superseded", not machine-`@deprecated`** — `@typescript-eslint/no-deprecated` failed the build on the manager's own legitimate back-compat fallback and the shim's tests. A machine-deprecation on a shim the codebase must still call is wrong.

## Behavioural note

DDL statement ordering changes from "all CREATE TABLE → all CREATE INDEX → fulltext" to per-contribution "table then its own indexes". Safe — TypeGraph's tables carry no cross-table foreign keys — but raw migration SQL byte output differs accordingly.

## Verification

- `pnpm fix` — clean
- `pnpm typecheck` — clean
- `pnpm test` (SQLite) — **3092 passed**, 0 failed
- PostgreSQL suite (`tests/backends/postgres/` + `tests/backends/integration/`) — **594 passed**, 0 failed (incl. `postgres-fulltext-bootstrap`, `postgres-fulltext`)

New contract test (`tests/table-contribution.test.ts`) covers: no duplicate pg table object, custom table names in contribution identity, FTS5 raw-ddl, tsvector drizzle-visible, supporting indexes still emitted, `runtimeEnsure` classification, and a custom strategy plugging in via the new `ownedTables` API.

