### PR TITLE
feat: durable, enforced fulltext materialization (closes #135)

### DIFF
--- a/.changeset/durable-fulltext-materialization.md
+++ b/.changeset/durable-fulltext-materialization.md
@@ -1,0 +1,60 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Durable, enforced fulltext materialization (#135).
+
+Strategy-owned fulltext table/index DDL was materialized lazily, guarded by an
+**in-memory, per-backend-instance boolean latch** (`fulltextEnsured`), and
+interleaved into the read/write data path. That was correct only by accident
+(idempotent DDL + a warm process) and at the wrong durability scope; it was
+inconsistent with how vector indexes are tracked and it blocked cross-store
+transaction adoption (#134). "Is this graph's fulltext storage materialized?"
+is now a **durable, queryable database fact** instead of a process boolean.
+
+**Breaking (behavioral): fulltext now requires an explicit boot step.**
+`createStore()` is a synchronous, zero-I/O *attach* — it never creates tables,
+repairs DDL, or writes materialization markers. The durable marker is written
+exclusively by the async boot path, `createStoreWithSchema(graph, backend)`,
+which must run once at application startup (outside request handlers and
+adopted transactions). A fulltext read/write — or a transaction that touches
+fulltext — against a database with no valid marker now throws the new
+`StoreNotInitializedError` instead of lazily emitting DDL on the hot path.
+Consumers already using `createStoreWithSchema` need no changes; consumers
+relying on lazy fulltext creation via bare `createStore()` must add a
+`createStoreWithSchema` call at boot.
+
+**What ships:**
+
+- New `@nicia-ai/typegraph` exports: `StoreNotInitializedError` and the
+  `StoreNotInitializedReason` (`"missing" | "stale" | "failed"`) it carries in
+  `details.reason`.
+- New per-deployment table `typegraph_contribution_materializations`, a
+  sibling of `typegraph_index_materializations` (the declared-index status
+  table is deliberately left unchanged). Keyed by #129 contribution identity
+  `(graph_id, logical_name, owner, table_name)`; `signature` is a separate
+  content-hash column, so a same-identity row with a drifted signature is a
+  loud error, never a silent re-materialize. Failed re-attempts preserve the
+  prior success timestamp via the same COALESCE rule as index
+  materializations.
+- New backend primitives (SQLite + Postgres):
+  `ensureContributionMaterializationsTable`, `getContributionMaterialization`,
+  `recordContributionMaterialization`, and
+  `assertRuntimeContributionsInitialized`. `ensureRuntimeContributions`,
+  `ensureContribution`, and `ensureFulltextTable` now take a `graphId` and
+  route through the durable-marker writer (short-circuiting when the recorded
+  signature already matches). `createStoreWithSchema` records the marker after
+  the schema version is resolved, covering the cold-initialize path.
+- The six fulltext-touching methods (`upsertFulltext`, `deleteFulltext`,
+  `upsertFulltextBatch`, `deleteFulltextBatch`, `fulltextSearch`,
+  `hardDeleteNode`) stop ensuring and instead assert the durable marker
+  (resolved once per backend instance, cached). The transaction path performs
+  zero DDL: the tx-scoped backend's fulltext methods assert the cached marker
+  at point of use (a `SELECT`, never `CREATE`), so a transaction that never
+  touches fulltext requires no fulltext initialization and one that does runs
+  pure DML on the adopted transaction.
+
+This makes #134 (cross-store transaction adoption) sound by construction: a
+transaction-adopting primitive consults the durable fact and refuses with a
+clear `StoreNotInitializedError` if the store was never initialized, instead
+of emitting `CREATE INDEX` inside the caller's business transaction.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -32,6 +32,14 @@ const { backend, db } = createLocalSqliteBackend({ path: "./app.db" });
 const store = createStore(graph, backend);
 ```
 
+:::caution[Fulltext requires `createStoreWithSchema`]
+`createLocalSqliteBackend` creates the tables but does not durably
+materialize fulltext storage. If your graph has `searchable()` fields,
+boot with `const [store] = await createStoreWithSchema(graph, backend);`
+instead of bare `createStore()` — otherwise the first fulltext operation
+throws `StoreNotInitializedError`.
+:::
+
 ### Manual Setup
 
 For full control over the database connection:

--- a/apps/docs/src/content/docs/examples/document-management.md
+++ b/apps/docs/src/content/docs/examples/document-management.md
@@ -142,7 +142,7 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
 import { createSqliteBackend, generateSqliteMigrationSQL } from "@nicia-ai/typegraph/sqlite";
-import { createStore } from "@nicia-ai/typegraph";
+import { createStoreWithSchema } from "@nicia-ai/typegraph";
 
 // Initialize database with vector extension
 const sqlite = new Database("documents.db");
@@ -151,7 +151,12 @@ sqlite.exec(generateSqliteMigrationSQL());
 
 const db = drizzle(sqlite);
 const backend = createSqliteBackend(db);
-const store = createStore(graph, backend);
+
+// `searchable()` fields require the durable fulltext-materialization
+// step that `createStoreWithSchema` performs at boot. Bare
+// `createStore()` is an attach-only path and would throw
+// `StoreNotInitializedError` on the first fulltext write.
+const [store] = await createStoreWithSchema(graph, backend);
 ```
 
 ## Core Operations

--- a/apps/docs/src/content/docs/examples/multi-tenant.md
+++ b/apps/docs/src/content/docs/examples/multi-tenant.md
@@ -329,7 +329,11 @@ async function getTenantStore(tenantId: string): Promise<Store> {
   const db = drizzle(client);
   const backend = createPostgresBackend(db);
 
-  return createStore(graph, backend);
+  // `searchable()` fields require the durable fulltext-materialization
+  // step `createStoreWithSchema` performs at boot; bare `createStore()`
+  // would throw `StoreNotInitializedError` on the first fulltext op.
+  const [store] = await createStoreWithSchema(graph, backend);
+  return store;
 }
 ```
 
@@ -451,7 +455,7 @@ class TenantDatabaseManager {
     const pool = new Pool({ connectionString: config.databaseUrl, max: 5 });
     const db = drizzle(pool);
     const backend = createPostgresBackend(db);
-    const store = createStore(graph, backend);
+    const [store] = await createStoreWithSchema(graph, backend);
 
     this.connections.set(tenantId, { pool, store });
 
@@ -519,7 +523,7 @@ async function provisionTenantDatabase(
   // Create initial data
   const db = drizzle(tenantPool);
   const backend = createPostgresBackend(db);
-  const store = createStore(graph, backend);
+  const [store] = await createStoreWithSchema(graph, backend);
 
   await store.nodes.User.create({
     email: ownerEmail,

--- a/apps/docs/src/content/docs/fulltext-search.md
+++ b/apps/docs/src/content/docs/fulltext-search.md
@@ -165,13 +165,34 @@ Also useful for:
 
 ## Database Setup
 
+### Initialization is required (boot via `createStoreWithSchema`)
+
+Fulltext storage is **durably materialized once, at application boot**,
+by `createStoreWithSchema`:
+
+```typescript
+// Run this once at startup — outside request handlers and transactions.
+const [store] = await createStoreWithSchema(graph, backend);
+```
+
+`createStore(graph, backend)` is a synchronous, zero-I/O *attach*: it
+does not create tables, repair DDL, or record that fulltext storage is
+materialized. A fulltext read or write — a `searchable()` field write,
+`store.search.fulltext()`, `store.search.hybrid()`,
+`n.$fulltext.matches()`, `store.search.rebuildFulltext()`, or a
+transaction that touches fulltext — against a database that was never
+initialized throws `StoreNotInitializedError`. Use `createStore()` only
+to attach to a database a prior `createStoreWithSchema` boot already
+initialized. Graphs with no `searchable()` fields are unaffected.
+
 ### PostgreSQL
 
 No extensions required. The built-in `tsvector` type and GIN indexes
 work on every managed Postgres (RDS, Supabase, Neon, Cloud SQL, Aiven).
 
-The fulltext table is created automatically by `bootstrapTables()` or the
-migration SQL:
+The fulltext table's DDL ships in `bootstrapTables()` and the migration
+SQL; `createStoreWithSchema` is what then records the durable
+materialization marker that fulltext operations check (see above):
 
 ```typescript
 import { generatePostgresMigrationSQL } from "@nicia-ai/typegraph/postgres";
@@ -715,6 +736,23 @@ Capabilities (`phraseQueries`, `prefixQueries`, `highlighting`,
 `supportedModes` is the source of truth.
 
 ## Troubleshooting
+
+### `StoreNotInitializedError: fulltext storage … is not initialized`
+
+The database was never booted through `createStoreWithSchema`, so the
+durable fulltext-materialization marker is missing (or it is `stale` —
+the strategy/DDL changed since it was recorded, or `failed` — the last
+boot-time attempt errored). Bare `createStore()` deliberately does **not**
+self-heal this on the hot path.
+
+Fix: call `createStoreWithSchema(graph, backend)` once at application
+startup — outside request handlers and adopted transactions — before any
+fulltext operation. If you previously relied on fulltext tables being
+created lazily on first write via `createStore()`, that path was removed;
+move the initialization to an explicit boot step. A `stale` reason means
+the recorded shape no longer matches the active strategy/DDL: migrate or
+drop the fulltext table and re-run the boot, or restore the original
+strategy.
 
 ### `Cannot call .$fulltext.matches() on alias "x"`
 

--- a/apps/docs/src/content/docs/getting-started.md
+++ b/apps/docs/src/content/docs/getting-started.md
@@ -274,6 +274,14 @@ const store = createStore(graph, backend);
 | `createStore` + manual migration | None | When you manage migrations externally |
 | `createStoreWithSchema` | Auto-creates tables, validates & auto-migrates | **Recommended for production** |
 
+:::caution[Fulltext requires `createStoreWithSchema`]
+If your graph has any `searchable()` fields, you must boot through
+`createStoreWithSchema` once at startup. It durably materializes the
+fulltext storage; bare `createStore()` is an attach-only path and throws
+`StoreNotInitializedError` on the first fulltext operation. Graphs
+without `searchable()` fields are unaffected.
+:::
+
 For production, use `createStoreWithSchema` to validate and auto-apply safe schema changes:
 
 ```typescript

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -82,6 +82,13 @@ const store = createStore(graph, backend);
 // No schema versioning - you handle migrations manually
 ```
 
+:::caution[Fulltext requires the managed store]
+`createStore()` is attach-only. If the graph has `searchable()` fields,
+use `createStoreWithSchema()` (below) at boot — it durably materializes
+the fulltext storage. Bare `createStore()` throws
+`StoreNotInitializedError` on the first fulltext operation.
+:::
+
 ### Managed Store (Automatic Schema Management)
 
 Use `createStoreWithSchema()` for automatic version tracking:

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -475,7 +475,11 @@ const store = createStore(graph, backend, {
 ### `createStoreWithSchema(graph, backend, options?)`
 
 Creates a store and ensures the database schema is initialized or migrated.
-This is the recommended factory for production use.
+This is the recommended factory for production use, and it is **required**
+for any graph with `searchable()` fields: it durably materializes the
+fulltext storage. Bare `createStore()` does not, and the first fulltext
+operation against an uninitialized database throws
+`StoreNotInitializedError`.
 
 ```typescript
 import { createStoreWithSchema } from "@nicia-ai/typegraph";

--- a/apps/docs/src/content/docs/testing.md
+++ b/apps/docs/src/content/docs/testing.md
@@ -79,11 +79,15 @@ describe("Person", () => {
 
 | Factory | Sync? | Schema management | Use for |
 |---------|-------|-------------------|---------|
-| `createStore(graph, backend)` | Yes | None | Tests, local dev |
-| `createStoreWithSchema(graph, backend)` | No | Auto-init, auto-migrate | Production, schema evolution tests |
+| `createStore(graph, backend)` | Yes | None | Tests, local dev (no `searchable()` fields) |
+| `createStoreWithSchema(graph, backend)` | No | Auto-init, auto-migrate | Production, fulltext, schema evolution tests |
 
 Use `createStore` for most tests — it's synchronous and avoids async setup. Use
-`createStoreWithSchema` when you're specifically testing schema migrations or evolution:
+`createStoreWithSchema` when you're specifically testing schema migrations or
+evolution, **or whenever the graph under test has `searchable()` fields**: a
+fulltext write/search through a bare `createStore()` test throws
+`StoreNotInitializedError` because the durable fulltext marker was never
+written.
 
 ```typescript
 import { createStoreWithSchema } from "@nicia-ai/typegraph";

--- a/packages/benchmarks/src/backend.ts
+++ b/packages/benchmarks/src/backend.ts
@@ -100,6 +100,10 @@ export async function createBackendResources(
       tables,
       hasVectorEmbeddings,
     });
+    // #135: the harness builds the schema via raw DDL and uses the sync
+    // createStore, so it writes the durable fulltext-materialization
+    // marker itself — the boot step createStoreWithSchema performs.
+    await sqliteBackend.ensureRuntimeContributions?.(perfGraph.id);
     return {
       store: createStore(perfGraph, sqliteBackend, {
         queryDefaults: { traversalExpansion: "none" },
@@ -134,6 +138,7 @@ export async function createBackendResources(
 
     const tables = createPostgresTables({}, { indexes: perfIndexes });
     const postgresBackend = createPostgresBackend(drizzleDb, { tables });
+    await postgresBackend.ensureRuntimeContributions?.(perfGraph.id);
     return {
       store: createStore(perfGraph, postgresBackend, {
         queryDefaults: { traversalExpansion: "none" },
@@ -174,6 +179,7 @@ export async function createBackendResources(
 
   const tables = createPostgresTables({}, { indexes: perfIndexes });
   const postgresBackend = createPostgresBackend(drizzleDb, { tables });
+  await postgresBackend.ensureRuntimeContributions?.(perfGraph.id);
   return {
     store: createStore(perfGraph, postgresBackend, {
       queryDefaults: { traversalExpansion: "none" },

--- a/packages/typegraph/examples/14-research-copilot.ts
+++ b/packages/typegraph/examples/14-research-copilot.ts
@@ -22,7 +22,7 @@
 import { z } from "zod";
 
 import {
-  createStore,
+  createStoreWithSchema,
   defineEdge,
   defineGraph,
   defineNode,
@@ -388,7 +388,11 @@ const TOPIC_HIERARCHY: readonly (readonly [string, string])[] = [
 // ============================================================
 
 export async function main(): Promise<void> {
-  const store = createStore(graph, createExampleBackend());
+  // Fulltext storage is materialized once, at boot, via the async
+  // createStoreWithSchema path — the canonical, durable initialization
+  // step. (Sync createStore() is an attach-only, zero-I/O path and
+  // would throw StoreNotInitializedError on the first searchable write.)
+  const [store] = await createStoreWithSchema(graph, createExampleBackend());
 
   console.log("━".repeat(68));
   console.log(" Research Copilot — RAG + citation graph + graph algorithms");

--- a/packages/typegraph/examples/15-fulltext-hybrid-search.ts
+++ b/packages/typegraph/examples/15-fulltext-hybrid-search.ts
@@ -32,7 +32,7 @@
 import { z } from "zod";
 
 import {
-  createStore,
+  createStoreWithSchema,
   defineGraph,
   defineNode,
   embedding,
@@ -247,10 +247,12 @@ export async function main(): Promise<void> {
   console.log("=== Fulltext & Hybrid Search Example ===");
 
   // Fulltext is backed by SQLite FTS5 — no extra extension required.
-  // `createExampleBackend()` runs the DDL on startup, so the fulltext
-  // virtual table is already in place.
+  // createStoreWithSchema is the canonical boot path: it materializes
+  // the fulltext storage and writes the durable marker. (Sync
+  // createStore() is an attach-only path and would throw
+  // StoreNotInitializedError on the first searchable write.)
   const backend = createExampleBackend();
-  const store = createStore(graph, backend);
+  const [store] = await createStoreWithSchema(graph, backend);
 
   // ============================================================
   // Part 1: Seed the catalog

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -1,0 +1,500 @@
+/**
+ * Shared building blocks for the
+ * `typegraph_contribution_materializations` durable-marker table on
+ * both SQLite and Postgres backends (#135).
+ *
+ * Independent sibling of `index-materializations.ts`. It deliberately
+ * mirrors that module's shape — dialect timestamp adapter, raw-row
+ * mapper, insert/upsert value builders, the `materialized_at` COALESCE
+ * preservation rule for failed re-attempts — but stays a separate
+ * module because the two status tables have different identities:
+ * declared indexes key on a database-global physical index name,
+ * #129 contributions key on `(graph_id, logical_name, owner,
+ * table_name)`. The declared-index path is untouched by #135; a future
+ * PR may migrate it onto this contribution model.
+ */
+
+import { sql } from "drizzle-orm";
+
+import {
+  StoreNotInitializedError,
+  type StoreNotInitializedReason,
+} from "../../errors";
+import { type SqlDialect } from "../../query/dialect";
+import { type FulltextStrategy } from "../../query/dialect/fulltext-strategy";
+import { sortedReplacer } from "../../schema/canonical";
+import { sha256Hex } from "../../utils/hash";
+import { isMissingTableError } from "../../utils/sql-errors";
+import type { StrategyTableContribution } from "../table-contribution";
+import type {
+  ContributionMaterializationIdentity,
+  ContributionMaterializationRow,
+  RecordContributionMaterializationParams,
+  TransactionBackend,
+} from "../types";
+import { findStrategyContribution, runtimeStrategyContributions } from "./ddl";
+import { formatPostgresTimestamp, nowIso } from "./row-mappers";
+
+/**
+ * Bridges the dialect-specific timestamp column representation to the
+ * canonical ISO-8601 strings used by the row/param types. `string` for
+ * SQLite TEXT, `Date` for Postgres TIMESTAMPTZ — identical contract to
+ * the index-materialization adapter, kept separate so the two status
+ * subsystems stay independent.
+ */
+type ContributionMaterializationTimestampAdapter<TEncoded> = Readonly<{
+  /** Convert a stored column value to ISO-8601 (or `undefined`). */
+  decode(value: unknown): string | undefined;
+  /** Convert an ISO-8601 string to the value Drizzle expects on insert. */
+  encode(value: string): TEncoded;
+}>;
+
+export const SQLITE_CONTRIBUTION_MAT_TIMESTAMPS: ContributionMaterializationTimestampAdapter<string> =
+  {
+    decode: (value) => (typeof value === "string" ? value : undefined),
+    encode: (value) => value,
+  };
+
+export const POSTGRES_CONTRIBUTION_MAT_TIMESTAMPS: ContributionMaterializationTimestampAdapter<Date> =
+  {
+    decode: formatPostgresTimestamp,
+    encode: (value) => new Date(value),
+  };
+
+/**
+ * Raw shape Drizzle returns for one row of
+ * `typegraph_contribution_materializations`. The caller has already
+ * narrowed via the typed table query; this just spells out the
+ * dialect-shared field set so `mapContributionMaterializationRow` can
+ * decode it.
+ */
+type RawContributionMaterializationRow = Readonly<{
+  graphId: string;
+  logicalName: string;
+  owner: string;
+  tableName: string;
+  signature: string;
+  materializedAt: unknown;
+  lastAttemptedAt: unknown;
+  lastError: string | null;
+}>;
+
+export function mapContributionMaterializationRow(
+  row: RawContributionMaterializationRow,
+  decode: (value: unknown) => string | undefined,
+): ContributionMaterializationRow {
+  const lastAttemptedAt = decode(row.lastAttemptedAt);
+  if (lastAttemptedAt === undefined) {
+    throw new Error(
+      `contribution materialization row missing required ` +
+        `last_attempted_at: ${row.graphId}/${row.logicalName}`,
+    );
+  }
+  return {
+    graphId: row.graphId,
+    logicalName: row.logicalName,
+    owner: row.owner,
+    tableName: row.tableName,
+    signature: row.signature,
+    materializedAt: decode(row.materializedAt),
+    lastAttemptedAt,
+    lastError: row.lastError ?? undefined,
+  };
+}
+
+/**
+ * Build the column values for the upsert. Timestamp columns are encoded
+ * through the adapter so the dialect's Drizzle column type gets the
+ * value-shape it expects.
+ */
+export function buildContributionInsertValues<TEncoded>(
+  params: RecordContributionMaterializationParams,
+  encode: (value: string) => TEncoded,
+): Readonly<{
+  graphId: string;
+  logicalName: string;
+  owner: string;
+  tableName: string;
+  signature: string;
+  materializedAt: TEncoded | undefined;
+  lastAttemptedAt: TEncoded;
+  lastError: string | undefined;
+}> {
+  return {
+    graphId: params.graphId,
+    logicalName: params.logicalName,
+    owner: params.owner,
+    tableName: params.tableName,
+    signature: params.signature,
+    materializedAt:
+      params.materializedAt === undefined ?
+        undefined
+      : encode(params.materializedAt),
+    lastAttemptedAt: encode(params.attemptedAt),
+    lastError: params.error,
+  };
+}
+
+/**
+ * Build the `set` clause for the upsert's ON CONFLICT DO UPDATE.
+ *
+ * The identity columns are the conflict target (composite primary key)
+ * so they are never in the set clause. `materializedAt` uses `COALESCE`
+ * to preserve any prior successful timestamp when this attempt failed
+ * (`materializedAt === undefined`); on success the new timestamp wins.
+ * Identical preservation rule to `buildMaterializationOnConflictSet`,
+ * keeping a stale/failed boot retry from erasing the historical
+ * success another replica recorded.
+ */
+export function buildContributionOnConflictSet(
+  materializedAtColumn: unknown,
+  paramsMaterializedAt: string | undefined,
+): Readonly<Record<string, ReturnType<typeof sql>>> {
+  const materializedAtSet =
+    paramsMaterializedAt === undefined ?
+      sql`COALESCE(excluded.${sql.identifier("materialized_at")}, ${materializedAtColumn})`
+    : sql`excluded.${sql.identifier("materialized_at")}`;
+  return {
+    signature: sql`excluded.${sql.identifier("signature")}`,
+    materializedAt: materializedAtSet,
+    lastAttemptedAt: sql`excluded.${sql.identifier("last_attempted_at")}`,
+    lastError: sql`excluded.${sql.identifier("last_error")}`,
+  };
+}
+
+/**
+ * Canonical hash of a resolved contribution's drift surface:
+ * `{ dialect, owner, logicalName, tableName, createDdl }`. #129
+ * guarantees `createDdl` is deterministic for a given resolved
+ * configuration, so this hash is a meaningful staleness discriminant.
+ * A strategy swap (different `owner`) or a DDL change on the same
+ * logical slot changes the signature → detectable drift. 32 hex chars
+ * because it is compared against an externally-stored signature.
+ */
+async function computeContributionSignature(
+  dialect: SqlDialect,
+  identity: Readonly<{
+    owner: string;
+    logicalName: string;
+    tableName: string;
+  }>,
+  createDdl: readonly string[],
+): Promise<string> {
+  const hashable = {
+    dialect,
+    owner: identity.owner,
+    logicalName: identity.logicalName,
+    tableName: identity.tableName,
+    createDdl,
+  };
+  return sha256Hex(JSON.stringify(hashable, sortedReplacer), 16);
+}
+
+/**
+ * Whether a contribution is usable on the current connection, derived
+ * from its durable marker row and the freshly-computed signature.
+ *
+ * - `missing`: no row — never initialized.
+ * - `failed`: the last recorded attempt errored. Boot may retry; the
+ *   hot path must refuse.
+ * - `stale`: a row exists but its recorded signature no longer matches
+ *   (strategy swap / DDL drift). Refuse rather than silently
+ *   re-materialize on a hot path.
+ * - `initialized`: signature matches, a successful `materializedAt` is
+ *   recorded, and the last attempt did not error.
+ */
+// The non-initialized states are exactly `StoreNotInitializedError`'s
+// reasons — derive the union so the two cannot drift apart and the
+// assert can pass the state straight through as the error reason.
+type ContributionMaterializationState =
+  | "initialized"
+  | StoreNotInitializedReason;
+
+function evaluateContributionState(
+  row: ContributionMaterializationRow | undefined,
+  signature: string,
+): ContributionMaterializationState {
+  if (row === undefined) return "missing";
+  if (row.lastError !== undefined) return "failed";
+  if (row.signature !== signature) return "stale";
+  if (row.materializedAt === undefined) return "missing";
+  return "initialized";
+}
+
+function identityOf(
+  graphId: string,
+  contribution: StrategyTableContribution,
+): ContributionMaterializationIdentity {
+  return {
+    graphId,
+    logicalName: contribution.logicalName,
+    owner: contribution.owner,
+    tableName: contribution.tableName,
+  };
+}
+
+/**
+ * Wrap a transaction-scoped backend so every fulltext-touching method
+ * asserts the durable contribution marker before delegating — the
+ * point-of-use gate (#135) for the transaction path, mirroring the
+ * non-tx wrappers.
+ *
+ * The tx-scoped backend exposes RAW fulltext methods (no self-ensure);
+ * `assert` is the outer backend's cached durable-marker resolver. A
+ * transaction that never touches fulltext never asserts, so non-
+ * fulltext transactions stay free of any fulltext-init requirement.
+ * `assert` performs only a (cached) SELECT — never DDL — so it is safe
+ * inside the caller's open transaction (#134).
+ *
+ * `hardDeleteNode` is gated because the cascade unconditionally deletes
+ * from the fulltext table even for graphs with no `searchable()`
+ * fields. Empty-input batch calls skip the assert, matching the
+ * "a genuine no-op is harmless" contract of the non-tx wrappers.
+ */
+export function gateFulltext(
+  tx: TransactionBackend,
+  assert: (graphId: string) => Promise<void>,
+): TransactionBackend {
+  // Mutable local so each override is only assigned when the raw method
+  // exists; the "only wrap when defined" rule stays obvious instead of
+  // hiding behind conditional spreads.
+  const gated: { -readonly [K in keyof TransactionBackend]: TransactionBackend[K] } =
+    { ...tx };
+
+  if (tx.upsertFulltext) {
+    const raw = tx.upsertFulltext;
+    gated.upsertFulltext = async (params) => {
+      await assert(params.graphId);
+      await raw(params);
+    };
+  }
+  if (tx.deleteFulltext) {
+    const raw = tx.deleteFulltext;
+    gated.deleteFulltext = async (params) => {
+      await assert(params.graphId);
+      await raw(params);
+    };
+  }
+  if (tx.upsertFulltextBatch) {
+    const raw = tx.upsertFulltextBatch;
+    gated.upsertFulltextBatch = async (params) => {
+      // A genuine no-op call asserts nothing, matching the non-tx
+      // wrappers' "empty input is harmless" contract.
+      if (params.rows.length === 0) return;
+      await assert(params.graphId);
+      await raw(params);
+    };
+  }
+  if (tx.deleteFulltextBatch) {
+    const raw = tx.deleteFulltextBatch;
+    gated.deleteFulltextBatch = async (params) => {
+      if (params.nodeIds.length === 0) return;
+      await assert(params.graphId);
+      await raw(params);
+    };
+  }
+  if (tx.fulltextSearch) {
+    const raw = tx.fulltextSearch;
+    gated.fulltextSearch = async (params) => {
+      await assert(params.graphId);
+      return raw(params);
+    };
+  }
+  // Unconditional: the hard-delete cascade deletes from the fulltext
+  // table even for graphs that declare no `searchable()` fields.
+  const rawHardDelete = tx.hardDeleteNode;
+  gated.hardDeleteNode = async (params) => {
+    await assert(params.graphId);
+    await rawHardDelete(params);
+  };
+  return gated;
+}
+
+// ============================================================
+// Materializer (#135) — the one place orchestration lives
+// ============================================================
+
+/**
+ * The dialect-specific seams the materializer needs. Mirrors how the
+ * index-materialization subsystem keeps orchestration dialect-agnostic
+ * (`store/materialize-indexes.ts`) and leaves only thin primitives in
+ * each backend.
+ */
+export type ContributionMaterializerDeps = Readonly<{
+  dialect: SqlDialect;
+  fulltextStrategy: FulltextStrategy;
+  fulltextTableName: string;
+  /** Run one raw DDL statement (dialect's `execute`/`run` of `sql.raw`). */
+  execDdl: (statement: string) => Promise<void>;
+  /** Idempotently create the `contribution_materializations` table. */
+  ensureMarkerTable: () => Promise<void>;
+  getMarker: (
+    identity: ContributionMaterializationIdentity,
+  ) => Promise<ContributionMaterializationRow | undefined>;
+  recordMarker: (
+    params: RecordContributionMaterializationParams,
+  ) => Promise<void>;
+}>;
+
+export type ContributionMaterializer = Readonly<{
+  /** Materialize one declared contribution by `logicalName` + record it. */
+  ensureContribution: (logicalName: string, graphId: string) => Promise<void>;
+  /** Canonical durable-marker writer: every `runtimeEnsure` contribution. */
+  ensureRuntimeContributions: (graphId: string) => Promise<void>;
+  /**
+   * Hot-path / transaction gate: resolve the durable markers once per
+   * backend instance (cached) and throw `StoreNotInitializedError` on
+   * the first missing/stale/failed contribution. Zero DDL, zero writes.
+   */
+  assertInitialized: (graphId: string) => Promise<void>;
+}>;
+
+export function createContributionMaterializer(
+  deps: ContributionMaterializerDeps,
+): ContributionMaterializer {
+  const { dialect, fulltextStrategy, fulltextTableName } = deps;
+
+  // Positive-only cache: a graph id lands here once every runtime
+  // contribution's durable marker has been observed materialized for
+  // it. Missing/stale/failed verdicts are never cached, so a concurrent
+  // boot that fixes the state is picked up on the next call.
+  const initializedGraphIds = new Set<string>();
+
+  function runtimeContributions(): readonly StrategyTableContribution[] {
+    return runtimeStrategyContributions(fulltextStrategy, fulltextTableName);
+  }
+
+  async function materializeOne(
+    graphId: string,
+    contribution: StrategyTableContribution,
+  ): Promise<void> {
+    const signature = await computeContributionSignature(
+      dialect,
+      contribution,
+      contribution.createDdl,
+    );
+    const identity = identityOf(graphId, contribution);
+    const existing = await deps.getMarker(identity);
+    const priorSuccess = existing?.materializedAt !== undefined;
+
+    // Already materialized at this exact shape — nothing to do.
+    if (
+      priorSuccess &&
+      existing.signature === signature &&
+      existing.lastError === undefined
+    ) {
+      return;
+    }
+
+    // Drift after a *recorded success*: the table physically exists with
+    // the OLD shape, so the idempotent `CREATE ... IF NOT EXISTS` would
+    // no-op and we'd silently bless the new signature against a stale
+    // table. Refuse loudly instead — mirrors the index materializer's
+    // signature-drift handling. (A row with no prior success, or one
+    // whose last attempt errored, falls through and re-runs the DDL.)
+    if (priorSuccess && existing.signature !== signature) {
+      const error = new Error(
+        `Contribution "${contribution.logicalName}" (owner ` +
+          `"${contribution.owner}", table "${contribution.tableName}") was ` +
+          `already materialized with a different signature. The recorded ` +
+          `physical shape is stale relative to the current strategy/DDL — ` +
+          `migrate or drop the table and retry, or restore the original ` +
+          `strategy.`,
+      );
+      await deps.recordMarker({
+        ...identity,
+        signature,
+        attemptedAt: nowIso(),
+        materializedAt: undefined,
+        error: error.message,
+      });
+      throw error;
+    }
+
+    const attemptedAt = nowIso();
+    try {
+      for (const statement of contribution.createDdl) {
+        await deps.execDdl(statement);
+      }
+    } catch (error) {
+      await deps.recordMarker({
+        ...identity,
+        signature,
+        attemptedAt,
+        materializedAt: undefined,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+    await deps.recordMarker({
+      ...identity,
+      signature,
+      attemptedAt,
+      materializedAt: attemptedAt,
+      error: undefined,
+    });
+  }
+
+  async function ensureRuntimeContributions(graphId: string): Promise<void> {
+    // Cache guard so a redundant boot call (the warm path materializes
+    // via loadActiveSchemaWithBootstrap, then createStoreWithSchema
+    // calls again) is a true O(1) no-op rather than a re-SELECT.
+    if (initializedGraphIds.has(graphId)) return;
+    const contributions = runtimeContributions();
+    if (contributions.length > 0) {
+      await deps.ensureMarkerTable();
+      for (const contribution of contributions) {
+        await materializeOne(graphId, contribution);
+      }
+    }
+    initializedGraphIds.add(graphId);
+  }
+
+  async function ensureContribution(
+    logicalName: string,
+    graphId: string,
+  ): Promise<void> {
+    const declared = findStrategyContribution(
+      fulltextStrategy,
+      fulltextTableName,
+      logicalName,
+    );
+    await deps.ensureMarkerTable();
+    await materializeOne(graphId, declared);
+  }
+
+  async function assertInitialized(graphId: string): Promise<void> {
+    if (initializedGraphIds.has(graphId)) return;
+    for (const contribution of runtimeContributions()) {
+      const signature = await computeContributionSignature(
+        dialect,
+        contribution,
+        contribution.createDdl,
+      );
+      const identity = identityOf(graphId, contribution);
+      let existing: ContributionMaterializationRow | undefined;
+      try {
+        existing = await deps.getMarker(identity);
+      } catch (error) {
+        // A never-bootstrapped database has no marker table — that is
+        // precisely "not initialized". Any other failure (connection,
+        // permission, driver) is a real system fault and must surface
+        // as-is rather than be masked as a user init error.
+        if (!isMissingTableError(error)) throw error;
+        throw new StoreNotInitializedError(graphId, "missing", {
+          cause: error,
+          details: { logicalName: contribution.logicalName },
+        });
+      }
+      const state = evaluateContributionState(existing, signature);
+      if (state !== "initialized") {
+        throw new StoreNotInitializedError(graphId, state, {
+          details: { logicalName: contribution.logicalName },
+        });
+      }
+    }
+    initializedGraphIds.add(graphId);
+  }
+
+  return { ensureContribution, ensureRuntimeContributions, assertInitialized };
+}

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -284,21 +284,20 @@ function resolveStrategyContribution(
 }
 
 /**
- * The idempotent DDL a strategy declares for one logical slot (table +
- * supporting indexes). O(1) in the number of base tables: it asks the
- * strategy directly and never walks or regenerates base-table DDL —
- * this is what keeps the latched fulltext ensure and the per-boot
- * runtime ensure off the base-table DDL-generation path.
+ * The strategy's declaration for one logical slot. O(1) in the number
+ * of base tables: it asks the strategy directly and never walks or
+ * regenerates base-table DDL — this is what keeps the per-boot runtime
+ * ensure off the base-table DDL-generation path.
  *
  * Throws when the strategy declares no contribution under
  * `logicalName` (caller typo / strategy↔backend disagreement) rather
- * than silently emitting nothing.
+ * than silently doing nothing.
  */
-export function strategyContributionDdl(
+export function findStrategyContribution(
   fulltextStrategy: FulltextStrategy,
   fulltextTableName: string,
   logicalName: string,
-): readonly string[] {
+): StrategyTableContribution {
   const declared = fulltextStrategy
     .ownedTables(fulltextTableName)
     .find((contribution) => contribution.logicalName === logicalName);
@@ -308,7 +307,7 @@ export function strategyContributionDdl(
         `(strategy "${fulltextStrategy.name}").`,
     );
   }
-  return declared.createDdl;
+  return declared;
 }
 
 /**

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -42,10 +42,11 @@ import {
   type FulltextStrategy,
   tsvectorStrategy,
 } from "../../query/dialect/fulltext-strategy";
-import { FULLTEXT_CONTRIBUTION_NAME } from "../table-contribution";
 import {
   type BackendCapabilities,
   type CommitSchemaVersionParams,
+  type ContributionMaterializationIdentity,
+  type ContributionMaterializationRow,
   type CreateVectorIndexParams,
   type DeleteEmbeddingParams,
   type DeleteFulltextBatchParams,
@@ -58,6 +59,7 @@ import {
   type IndexMaterializationRow,
   type KindRemovalRow,
   POSTGRES_CAPABILITIES,
+  type RecordContributionMaterializationParams,
   type RecordIndexMaterializationParams,
   type RecordKindRemovalParams,
   type SchemaVersionRow,
@@ -71,11 +73,14 @@ import {
   type VectorSearchResult,
 } from "../types";
 import {
-  generatePgCreateTableSQL,
-  generatePostgresDDL,
-  runtimeStrategyContributions,
-  strategyContributionDdl,
-} from "./ddl";
+  buildContributionInsertValues,
+  buildContributionOnConflictSet,
+  createContributionMaterializer,
+  gateFulltext,
+  mapContributionMaterializationRow,
+  POSTGRES_CONTRIBUTION_MAT_TIMESTAMPS,
+} from "./contribution-materializations";
+import { generatePgCreateTableSQL, generatePostgresDDL } from "./ddl";
 import {
   type AnyPgDatabase,
   createPostgresExecutionAdapter,
@@ -395,25 +400,73 @@ export function createPostgresBackend(
     });
   }
 
-  // Per-backend latch for fulltext-table DDL. The wrappers below
-  // guard every method that touches the fulltext table — fulltext
-  // writes can fire from any code path (sync `createStore`, hard-
-  // delete cascade, batched index sync), so the bootstrap-load
-  // probe alone doesn't cover all surfaces. (#135 replaces this
-  // in-memory latch with a durable materialization marker.)
-  let fulltextEnsured = false;
-  async function ensureFulltextDdl(): Promise<void> {
-    if (fulltextEnsured) return;
-    const statements = strategyContributionDdl(
-      fulltextStrategy,
-      tables.fulltextTableName,
-      FULLTEXT_CONTRIBUTION_NAME,
-    );
-    for (const statement of statements) {
-      await db.execute(sql.raw(statement));
-    }
-    fulltextEnsured = true;
+  // Durable fulltext materialization (#135): the dialect-specific
+  // marker-table primitives. Orchestration (materialize / assert /
+  // per-instance cache) lives once in `createContributionMaterializer`.
+  const matTable = tables.contributionMaterializations;
+
+  async function ensureContributionMaterializationsTableImpl(): Promise<void> {
+    await db.execute(sql.raw(generatePgCreateTableSQL(matTable)));
   }
+
+  async function getContributionMaterializationRow(
+    identity: ContributionMaterializationIdentity,
+  ): Promise<ContributionMaterializationRow | undefined> {
+    const rows = await db
+      .select()
+      .from(matTable)
+      .where(
+        and(
+          eq(matTable.graphId, identity.graphId),
+          eq(matTable.logicalName, identity.logicalName),
+          eq(matTable.owner, identity.owner),
+          eq(matTable.tableName, identity.tableName),
+        ),
+      );
+    const row = rows[0];
+    if (row === undefined) return undefined;
+    return mapContributionMaterializationRow(
+      row,
+      POSTGRES_CONTRIBUTION_MAT_TIMESTAMPS.decode,
+    );
+  }
+
+  async function recordContributionMaterializationRow(
+    params: RecordContributionMaterializationParams,
+  ): Promise<void> {
+    await db
+      .insert(matTable)
+      .values(
+        buildContributionInsertValues(
+          params,
+          POSTGRES_CONTRIBUTION_MAT_TIMESTAMPS.encode,
+        ),
+      )
+      .onConflictDoUpdate({
+        target: [
+          matTable.graphId,
+          matTable.logicalName,
+          matTable.owner,
+          matTable.tableName,
+        ],
+        set: buildContributionOnConflictSet(
+          matTable.materializedAt,
+          params.materializedAt,
+        ),
+      });
+  }
+
+  const contributionMaterializer = createContributionMaterializer({
+    dialect: "postgres",
+    fulltextStrategy,
+    fulltextTableName: tables.fulltextTableName,
+    execDdl: async (statement) => {
+      await db.execute(sql.raw(statement));
+    },
+    ensureMarkerTable: ensureContributionMaterializationsTableImpl,
+    getMarker: getContributionMaterializationRow,
+    recordMarker: recordContributionMaterializationRow,
+  });
 
   const backend: GraphBackend = {
     ...operations,
@@ -423,38 +476,41 @@ export function createPostgresBackend(
       for (const statement of statements) {
         await db.execute(sql.raw(statement));
       }
-      fulltextEnsured = true;
     },
 
+    // Every fulltext-touching method now asserts the durable marker
+    // instead of lazily emitting DDL. Steady state performs zero
+    // ensure; an uninitialized database throws `StoreNotInitializedError`
+    // loudly rather than self-healing on a read/write path (#135).
     async upsertFulltext(params): Promise<void> {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.upsertFulltext!(params);
     },
     async deleteFulltext(params): Promise<void> {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.deleteFulltext!(params);
     },
     async upsertFulltextBatch(params): Promise<void> {
-      // Mirror the inner-method empty-input guard so a no-op call
-      // on a cold backend doesn't materialize the table.
+      // A genuine no-op call asserts nothing — preserves the prior
+      // "empty input on any backend is harmless" contract.
       if (params.rows.length === 0) return;
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.upsertFulltextBatch!(params);
     },
     async deleteFulltextBatch(params): Promise<void> {
       if (params.nodeIds.length === 0) return;
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.deleteFulltextBatch!(params);
     },
     async fulltextSearch(params) {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       return operations.fulltextSearch!(params);
     },
     // hardDeleteNode is wrapped because the operation-backend-core
     // cascade unconditionally deletes from the fulltext table — it
     // would fail even on graphs that declare no searchable() fields.
     async hardDeleteNode(params): Promise<void> {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.hardDeleteNode(params);
     },
 
@@ -513,6 +569,28 @@ export function createPostgresBackend(
         });
     },
 
+    async ensureContributionMaterializationsTable(): Promise<void> {
+      await ensureContributionMaterializationsTableImpl();
+    },
+
+    async getContributionMaterialization(
+      identity: ContributionMaterializationIdentity,
+    ): Promise<ContributionMaterializationRow | undefined> {
+      return getContributionMaterializationRow(identity);
+    },
+
+    async recordContributionMaterialization(
+      params: RecordContributionMaterializationParams,
+    ): Promise<void> {
+      await recordContributionMaterializationRow(params);
+    },
+
+    async assertRuntimeContributionsInitialized(
+      graphId: string,
+    ): Promise<void> {
+      await contributionMaterializer.assertInitialized(graphId);
+    },
+
     async ensureKindRemovalsTable(): Promise<void> {
       await db.execute(
         sql.raw(generatePgCreateTableSQL(tables.kindRemovals)),
@@ -564,49 +642,25 @@ export function createPostgresBackend(
       );
     },
 
-    async ensureContribution(logicalName: string): Promise<void> {
-      if (logicalName === FULLTEXT_CONTRIBUTION_NAME) {
-        // Route the fulltext slot through the latched path so the
-        // in-memory short-circuit (and, post-#135, the durable marker)
-        // stays the single gate for it.
-        await ensureFulltextDdl();
-        return;
-      }
-      const statements = strategyContributionDdl(
-        fulltextStrategy,
-        tables.fulltextTableName,
-        logicalName,
-      );
-      for (const statement of statements) {
-        await db.execute(sql.raw(statement));
-      }
+    async ensureContribution(
+      logicalName: string,
+      graphId: string,
+    ): Promise<void> {
+      await contributionMaterializer.ensureContribution(logicalName, graphId);
     },
 
-    async ensureRuntimeContributions(): Promise<void> {
-      // Runtime contributions are strategy-owned by invariant (base
-      // tables are never `runtimeEnsure`), so this asks the strategy
-      // directly — no base-table walk on the per-boot path.
-      for (const contribution of runtimeStrategyContributions(
-        fulltextStrategy,
-        tables.fulltextTableName,
-      )) {
-        if (contribution.logicalName === FULLTEXT_CONTRIBUTION_NAME) {
-          await ensureFulltextDdl();
-          continue;
-        }
-        for (const statement of contribution.createDdl) {
-          await db.execute(sql.raw(statement));
-        }
-      }
+    async ensureRuntimeContributions(graphId: string): Promise<void> {
+      await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
     /**
-     * Superseded by `ensureContribution("fulltext")` /
-     * `ensureRuntimeContributions()` (#129). Retained as a thin
-     * back-compat wrapper; #135 removes the remaining hot-path callers.
+     * Superseded by `ensureContribution("fulltext", graphId)` /
+     * `ensureRuntimeContributions(graphId)` (#129). Retained as a thin
+     * back-compat wrapper for callers predating #129; #135 routed it
+     * through the durable-marker writer.
      */
-    async ensureFulltextTable(): Promise<void> {
-      await ensureFulltextDdl();
+    async ensureFulltextTable(graphId: string): Promise<void> {
+      await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
     async getReconciliationMarker(
@@ -658,14 +712,13 @@ export function createPostgresBackend(
       fn: (tx: TransactionBackend) => Promise<T>,
       options?: TransactionOptions,
     ): Promise<T> {
-      // The tx-scoped backend exposes raw fulltext methods without
-      // the outer self-ensure wrappers — so we do the ensure here,
-      // before db.transaction() opens BEGIN. Outside-the-tx avoids
-      // CREATE-INDEX-inside-tx SHARE-lock contention with concurrent
-      // replicas and keeps the DDL durable if the user's tx rolls
-      // back.
-      await ensureFulltextDdl();
-
+      // #134/#135: NO DDL or ensure here. The tx-scoped backend's
+      // fulltext-touching methods assert the durable contribution
+      // marker (one cached SELECT — never DDL) at point of use, exactly
+      // like the non-tx wrappers. A transaction that never touches
+      // fulltext never asserts; one that does runs pure DML against an
+      // already-materialized table, with the "no DDL in the business
+      // transaction" guarantee backed by the durable fact.
       const txConfig = options?.isolationLevel
         ? {
             isolationLevel: options.isolationLevel.replace("_", " ") as
@@ -685,7 +738,7 @@ export function createPostgresBackend(
           capabilities,
           fulltextStrategy,
         });
-        return fn(txBackend);
+        return fn(gateFulltext(txBackend, contributionMaterializer.assertInitialized));
       }, txConfig);
     },
 

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -56,6 +56,7 @@ export type PostgresTableNames = Readonly<{
   embeddings: string;
   fulltext: string;
   indexMaterializations: string;
+  contributionMaterializations: string;
   kindRemovals: string;
   reconciliationMarkers: string;
 }>;
@@ -78,6 +79,7 @@ const DEFAULT_TABLE_NAMES: PostgresTableNames = {
   embeddings: "typegraph_node_embeddings",
   fulltext: "typegraph_node_fulltext",
   indexMaterializations: "typegraph_index_materializations",
+  contributionMaterializations: "typegraph_contribution_materializations",
   kindRemovals: "typegraph_kind_removals",
   reconciliationMarkers: "typegraph_reconciliation_markers",
 };
@@ -349,6 +351,46 @@ export function createPostgresTables(
   );
 
   /**
+   * Per-deployment durable marker that a strategy-owned table
+   * contribution (#129 — fulltext today) has been materialized against
+   * this database (#135). The single source of truth replacing the old
+   * in-memory per-backend `fulltextEnsured` latch: "is fulltext storage
+   * materialized?" is now a queryable database fact, written only by
+   * the async boot path and read (cached) by the fulltext hot-path
+   * gate.
+   *
+   * Keyed on `(graph_id, logical_name, owner, table_name)` — unlike
+   * `indexMaterializations` (physical index name is database-global),
+   * a contribution's identity is graph-scoped: two graphs can each own
+   * a logically-identical fulltext table. `signature` is deliberately
+   * NOT in the key: a same-identity row with a different signature is
+   * detectable drift, surfaced as a loud error rather than a silent
+   * re-materialize. `materialized_at` is null until the first success;
+   * the COALESCE-on-failure rule preserves it across failed retries,
+   * mirroring `indexMaterializations`.
+   */
+  const contributionMaterializations = pgTable(
+    n.contributionMaterializations,
+    {
+      graphId: text("graph_id").notNull(),
+      logicalName: text("logical_name").notNull(),
+      owner: text("owner").notNull(),
+      tableName: text("table_name").notNull(),
+      signature: text("signature").notNull(),
+      materializedAt: timestamp("materialized_at", { withTimezone: true }),
+      lastAttemptedAt: timestamp("last_attempted_at", {
+        withTimezone: true,
+      }).notNull(),
+      lastError: text("last_error"),
+    },
+    (t) => [
+      primaryKey({
+        columns: [t.graphId, t.logicalName, t.owner, t.tableName],
+      }),
+    ],
+  );
+
+  /**
    * Drizzle pg-core table for the default `tsvectorStrategy` so
    * drizzle-kit can introspect the fulltext table alongside the
    * others. Mirrors `tsvectorStrategy.generateDdl()` — the typed
@@ -393,6 +435,7 @@ export function createPostgresTables(
     schemaVersions,
     embeddings,
     indexMaterializations,
+    contributionMaterializations,
     kindRemovals,
     reconciliationMarkers,
     fulltext,

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -46,6 +46,7 @@ export type SqliteTableNames = Readonly<{
   embeddings: string;
   fulltext: string;
   indexMaterializations: string;
+  contributionMaterializations: string;
   kindRemovals: string;
   reconciliationMarkers: string;
 }>;
@@ -68,6 +69,7 @@ const DEFAULT_TABLE_NAMES: SqliteTableNames = {
   embeddings: "typegraph_node_embeddings",
   fulltext: "typegraph_node_fulltext",
   indexMaterializations: "typegraph_index_materializations",
+  contributionMaterializations: "typegraph_contribution_materializations",
   kindRemovals: "typegraph_kind_removals",
   reconciliationMarkers: "typegraph_reconciliation_markers",
 };
@@ -332,6 +334,35 @@ export function createSqliteTables(
     (t) => [primaryKey({ columns: [t.graphId] })],
   );
 
+  /**
+   * Per-deployment durable marker that a strategy-owned table
+   * contribution (#129 — the FTS5 virtual table today) has been
+   * materialized against this database (#135). Replaces the in-memory
+   * per-backend `fulltextEnsured` latch with a queryable database fact.
+   * Keyed on `(graph_id, logical_name, owner, table_name)`; `signature`
+   * stays out of the key so same-identity drift is a loud error, not a
+   * silent re-materialize. Same COALESCE-on-failure preservation rule
+   * as `indexMaterializations`.
+   */
+  const contributionMaterializations = sqliteTable(
+    n.contributionMaterializations,
+    {
+      graphId: text("graph_id").notNull(),
+      logicalName: text("logical_name").notNull(),
+      owner: text("owner").notNull(),
+      tableName: text("table_name").notNull(),
+      signature: text("signature").notNull(),
+      materializedAt: text("materialized_at"),
+      lastAttemptedAt: text("last_attempted_at").notNull(),
+      lastError: text("last_error"),
+    },
+    (t) => [
+      primaryKey({
+        columns: [t.graphId, t.logicalName, t.owner, t.tableName],
+      }),
+    ],
+  );
+
   return {
     nodes,
     edges,
@@ -339,6 +370,7 @@ export function createSqliteTables(
     schemaVersions,
     embeddings,
     indexMaterializations,
+    contributionMaterializations,
     kindRemovals,
     reconciliationMarkers,
     /**

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -39,6 +39,8 @@ import {
 import {
   type BackendCapabilities,
   type CommitSchemaVersionParams,
+  type ContributionMaterializationIdentity,
+  type ContributionMaterializationRow,
   type CreateVectorIndexParams,
   type DeleteEmbeddingParams,
   type DeleteFulltextBatchParams,
@@ -49,6 +51,7 @@ import {
   type GraphBackend,
   type IndexMaterializationRow,
   type KindRemovalRow,
+  type RecordContributionMaterializationParams,
   type RecordIndexMaterializationParams,
   type RecordKindRemovalParams,
   type SchemaVersionRow,
@@ -69,13 +72,15 @@ import {
   type SqliteExecutionProfileHints,
 } from "./execution/sqlite-execution";
 export type { SqliteTransactionMode } from "./execution/sqlite-execution";
-import { FULLTEXT_CONTRIBUTION_NAME } from "../table-contribution";
 import {
-  generateSqliteCreateTableSQL,
-  generateSqliteDDL,
-  runtimeStrategyContributions,
-  strategyContributionDdl,
-} from "./ddl";
+  buildContributionInsertValues,
+  buildContributionOnConflictSet,
+  createContributionMaterializer,
+  gateFulltext,
+  mapContributionMaterializationRow,
+  SQLITE_CONTRIBUTION_MAT_TIMESTAMPS,
+} from "./contribution-materializations";
+import { generateSqliteCreateTableSQL, generateSqliteDDL } from "./ddl";
 import {
   buildMaterializationInsertValues,
   buildMaterializationOnConflictSet,
@@ -682,25 +687,73 @@ export function createSqliteBackend(
     );
   }
 
-  // Per-backend latch for fulltext-table DDL. The wrappers below
-  // guard every method that touches the fulltext table — fulltext
-  // writes can fire from any code path (sync `createStore`, hard-
-  // delete cascade, batched index sync), so the bootstrap-load
-  // probe alone doesn't cover all surfaces. (#135 replaces this
-  // in-memory latch with a durable materialization marker.)
-  let fulltextEnsured = false;
-  async function ensureFulltextDdl(): Promise<void> {
-    if (fulltextEnsured) return;
-    const statements = strategyContributionDdl(
-      fulltextStrategy,
-      tables.fulltextTableName,
-      FULLTEXT_CONTRIBUTION_NAME,
-    );
-    for (const statement of statements) {
-      await db.run(sql.raw(statement));
-    }
-    fulltextEnsured = true;
+  // Durable fulltext materialization (#135): the dialect-specific
+  // marker-table primitives. Orchestration (materialize / assert /
+  // per-instance cache) lives once in `createContributionMaterializer`.
+  const matTable = tables.contributionMaterializations;
+
+  async function ensureContributionMaterializationsTableImpl(): Promise<void> {
+    await db.run(sql.raw(generateSqliteCreateTableSQL(matTable)));
   }
+
+  async function getContributionMaterializationRow(
+    identity: ContributionMaterializationIdentity,
+  ): Promise<ContributionMaterializationRow | undefined> {
+    const rows = await db
+      .select()
+      .from(matTable)
+      .where(
+        and(
+          eq(matTable.graphId, identity.graphId),
+          eq(matTable.logicalName, identity.logicalName),
+          eq(matTable.owner, identity.owner),
+          eq(matTable.tableName, identity.tableName),
+        ),
+      );
+    const row = rows[0];
+    if (row === undefined) return undefined;
+    return mapContributionMaterializationRow(
+      row,
+      SQLITE_CONTRIBUTION_MAT_TIMESTAMPS.decode,
+    );
+  }
+
+  async function recordContributionMaterializationRow(
+    params: RecordContributionMaterializationParams,
+  ): Promise<void> {
+    await db
+      .insert(matTable)
+      .values(
+        buildContributionInsertValues(
+          params,
+          SQLITE_CONTRIBUTION_MAT_TIMESTAMPS.encode,
+        ),
+      )
+      .onConflictDoUpdate({
+        target: [
+          matTable.graphId,
+          matTable.logicalName,
+          matTable.owner,
+          matTable.tableName,
+        ],
+        set: buildContributionOnConflictSet(
+          matTable.materializedAt,
+          params.materializedAt,
+        ),
+      });
+  }
+
+  const contributionMaterializer = createContributionMaterializer({
+    dialect: "sqlite",
+    fulltextStrategy,
+    fulltextTableName: tables.fulltextTableName,
+    execDdl: async (statement) => {
+      await db.run(sql.raw(statement));
+    },
+    ensureMarkerTable: ensureContributionMaterializationsTableImpl,
+    getMarker: getContributionMaterializationRow,
+    recordMarker: recordContributionMaterializationRow,
+  });
 
   const backend: GraphBackend = {
     ...operations,
@@ -710,38 +763,41 @@ export function createSqliteBackend(
       for (const statement of statements) {
         await db.run(sql.raw(statement));
       }
-      fulltextEnsured = true;
     },
 
+    // Every fulltext-touching method asserts the durable marker
+    // instead of lazily emitting DDL. Steady state performs zero
+    // ensure; an uninitialized database throws
+    // `StoreNotInitializedError` rather than self-healing (#135).
     async upsertFulltext(params): Promise<void> {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.upsertFulltext!(params);
     },
     async deleteFulltext(params): Promise<void> {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.deleteFulltext!(params);
     },
     async upsertFulltextBatch(params): Promise<void> {
-      // Mirror the inner-method empty-input guard so a no-op call
-      // on a cold backend doesn't materialize the table.
+      // A genuine no-op call asserts nothing — preserves the prior
+      // "empty input on any backend is harmless" contract.
       if (params.rows.length === 0) return;
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.upsertFulltextBatch!(params);
     },
     async deleteFulltextBatch(params): Promise<void> {
       if (params.nodeIds.length === 0) return;
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.deleteFulltextBatch!(params);
     },
     async fulltextSearch(params) {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       return operations.fulltextSearch!(params);
     },
     // hardDeleteNode is wrapped because the operation-backend-core
     // cascade unconditionally deletes from the fulltext table — it
     // would fail even on graphs that declare no searchable() fields.
     async hardDeleteNode(params): Promise<void> {
-      await ensureFulltextDdl();
+      await contributionMaterializer.assertInitialized(params.graphId);
       await operations.hardDeleteNode(params);
     },
 
@@ -800,6 +856,28 @@ export function createSqliteBackend(
         });
     },
 
+    async ensureContributionMaterializationsTable(): Promise<void> {
+      await ensureContributionMaterializationsTableImpl();
+    },
+
+    async getContributionMaterialization(
+      identity: ContributionMaterializationIdentity,
+    ): Promise<ContributionMaterializationRow | undefined> {
+      return getContributionMaterializationRow(identity);
+    },
+
+    async recordContributionMaterialization(
+      params: RecordContributionMaterializationParams,
+    ): Promise<void> {
+      await recordContributionMaterializationRow(params);
+    },
+
+    async assertRuntimeContributionsInitialized(
+      graphId: string,
+    ): Promise<void> {
+      await contributionMaterializer.assertInitialized(graphId);
+    },
+
     async ensureKindRemovalsTable(): Promise<void> {
       await db.run(sql.raw(generateSqliteCreateTableSQL(tables.kindRemovals)));
     },
@@ -849,46 +927,25 @@ export function createSqliteBackend(
       );
     },
 
-    async ensureContribution(logicalName: string): Promise<void> {
-      if (logicalName === FULLTEXT_CONTRIBUTION_NAME) {
-        await ensureFulltextDdl();
-        return;
-      }
-      const statements = strategyContributionDdl(
-        fulltextStrategy,
-        tables.fulltextTableName,
-        logicalName,
-      );
-      for (const statement of statements) {
-        await db.run(sql.raw(statement));
-      }
+    async ensureContribution(
+      logicalName: string,
+      graphId: string,
+    ): Promise<void> {
+      await contributionMaterializer.ensureContribution(logicalName, graphId);
     },
 
-    async ensureRuntimeContributions(): Promise<void> {
-      // Runtime contributions are strategy-owned by invariant (base
-      // tables are never `runtimeEnsure`), so this asks the strategy
-      // directly — no base-table walk on the per-boot path.
-      for (const contribution of runtimeStrategyContributions(
-        fulltextStrategy,
-        tables.fulltextTableName,
-      )) {
-        if (contribution.logicalName === FULLTEXT_CONTRIBUTION_NAME) {
-          await ensureFulltextDdl();
-          continue;
-        }
-        for (const statement of contribution.createDdl) {
-          await db.run(sql.raw(statement));
-        }
-      }
+    async ensureRuntimeContributions(graphId: string): Promise<void> {
+      await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
     /**
-     * Superseded by `ensureContribution("fulltext")` /
-     * `ensureRuntimeContributions()` (#129). Retained as a thin
-     * back-compat wrapper; #135 removes the remaining hot-path callers.
+     * Superseded by `ensureContribution("fulltext", graphId)` /
+     * `ensureRuntimeContributions(graphId)` (#129). Retained as a thin
+     * back-compat wrapper for callers predating #129; #135 routed it
+     * through the durable-marker writer.
      */
-    async ensureFulltextTable(): Promise<void> {
-      await ensureFulltextDdl();
+    async ensureFulltextTable(graphId: string): Promise<void> {
+      await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
     async getReconciliationMarker(
@@ -954,13 +1011,11 @@ export function createSqliteBackend(
         );
       }
 
-      // The tx-scoped backend exposes raw fulltext methods without
-      // the outer self-ensure wrappers — so we do the ensure here,
-      // before BEGIN runs. Outside-the-tx avoids
-      // CREATE-INDEX-inside-tx lock contention and keeps the DDL
-      // durable if the user's tx rolls back.
-      await ensureFulltextDdl();
-
+      // #134/#135: NO DDL or ensure here. The tx-scoped backend
+      // exposes raw fulltext methods without self-ensure wrappers; the
+      // single gate is `Store.transaction()`, which asserts the durable
+      // contribution marker (one cached SELECT) before this method is
+      // reached. The caller's BEGIN never carries CREATE statements.
       if (transactionMode === "sql") {
         return runWithSerializedQueue(serializedQueue, async () => {
           const txBackend = createTransactionBackend({
@@ -976,7 +1031,9 @@ export function createSqliteBackend(
           db.run(sql`BEGIN`);
 
           try {
-            const result = await fn(txBackend);
+            const result = await fn(
+              gateFulltext(txBackend, contributionMaterializer.assertInitialized),
+            );
             db.run(sql`COMMIT`);
             return result;
           } catch (error) {
@@ -998,7 +1055,9 @@ export function createSqliteBackend(
             fulltextStrategy,
             hasVectorEmbeddings,
           });
-          return fn(txBackend);
+          return fn(
+            gateFulltext(txBackend, contributionMaterializer.assertInitialized),
+          );
         }) as Promise<T>,
       );
     },

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -535,6 +535,71 @@ export type RecordIndexMaterializationParams = Readonly<{
 }>;
 
 // ============================================================
+// Contribution Materializations (#135 — durable strategy-owned
+// storage marker, sibling of index materializations)
+// ============================================================
+
+/**
+ * Durable identity of a strategy-owned table contribution (#129),
+ * scoped to a graph. This is the primary key of
+ * `typegraph_contribution_materializations`.
+ *
+ * `logicalName` is the stable slot ("fulltext"); `owner` is the
+ * producing strategy ("tsvector" / "fts5"); `tableName` is the resolved
+ * physical name (custom per-deployment names must be distinguishable).
+ * `graphId` is part of identity here — unlike the index status table
+ * where the physical index name is database-global, two graphs can each
+ * own a logically-identical fulltext contribution.
+ */
+export type ContributionMaterializationIdentity = Readonly<{
+  graphId: string;
+  logicalName: string;
+  owner: string;
+  tableName: string;
+}>;
+
+/**
+ * Per-deployment record that a strategy-owned contribution has been
+ * durably materialized against this database.
+ *
+ * `signature` is intentionally NOT part of the identity: a row with the
+ * same identity but a different signature means "materialized artifact
+ * is stale/drifted" — a loud error on the hot path, never a silent
+ * re-materialize. `materializedAt` is undefined until the first
+ * successful materialization; `lastAttemptedAt` is always set.
+ */
+export type ContributionMaterializationRow = Readonly<{
+  graphId: string;
+  logicalName: string;
+  owner: string;
+  tableName: string;
+  signature: string;
+  materializedAt: string | undefined;
+  lastAttemptedAt: string;
+  lastError: string | undefined;
+}>;
+
+/**
+ * Parameters for upserting a contribution-materialization attempt.
+ * Same success/failure contract as
+ * {@link RecordIndexMaterializationParams}: on failure pass undefined
+ * `materializedAt` so a prior successful timestamp is preserved via
+ * COALESCE, and the error message.
+ */
+export type RecordContributionMaterializationParams = Readonly<{
+  graphId: string;
+  logicalName: string;
+  owner: string;
+  tableName: string;
+  signature: string;
+  attemptedAt: string;
+  /** ISO timestamp on success; undefined on failure (preserves existing). */
+  materializedAt: string | undefined;
+  /** Error message on failure; undefined on success (clears existing). */
+  error: string | undefined;
+}>;
+
+// ============================================================
 // Kind Removals (data-cleanup status)
 // ============================================================
 
@@ -819,6 +884,51 @@ export type GraphBackend = Readonly<{
     params: RecordIndexMaterializationParams,
   ) => Promise<void>;
 
+  // === Contribution Materialization (#135 — durable strategy-owned
+  // storage marker, sibling of the index status table) ===
+
+  /**
+   * Idempotently ensure ONLY the
+   * `typegraph_contribution_materializations` table exists. Same
+   * focused-bootstrap rationale as `ensureIndexMaterializationsTable`:
+   * a single `CREATE TABLE IF NOT EXISTS` is concurrency-safe under
+   * replica startup, where the full `bootstrapTables` set risks a
+   * Postgres SHARE-lock deadlock.
+   */
+  ensureContributionMaterializationsTable?: () => Promise<void>;
+
+  /**
+   * Look up the durable materialization marker for one strategy-owned
+   * contribution identity. Returns `undefined` when no row exists
+   * ("never initialized").
+   */
+  getContributionMaterialization?: (
+    identity: ContributionMaterializationIdentity,
+  ) => Promise<ContributionMaterializationRow | undefined>;
+
+  /**
+   * Upsert a contribution-materialization attempt — success or failure.
+   * Failure rows preserve any prior `materializedAt` via COALESCE so a
+   * later failed re-attempt doesn't erase the historical success.
+   */
+  recordContributionMaterialization?: (
+    params: RecordContributionMaterializationParams,
+  ) => Promise<void>;
+
+  /**
+   * Resolve (once per backend instance, cached) and assert the durable
+   * materialization markers for every `runtimeEnsure` contribution this
+   * backend's strategy declares, for `graphId`. Throws
+   * `StoreNotInitializedError` when a marker is missing, stale
+   * (signature drift), or recorded a failed last attempt.
+   *
+   * This is the single read-side gate the fulltext hot-path wrappers
+   * and `store.transaction()` consult. It performs ZERO DDL and ZERO
+   * marker writes — initialization is the exclusive job of the async
+   * boot path (`createStoreWithSchema` → `ensureRuntimeContributions`).
+   */
+  assertRuntimeContributionsInitialized?: (graphId: string) => Promise<void>;
+
   // === Kind Removal Status ===
 
   /**
@@ -887,8 +997,13 @@ export type GraphBackend = Readonly<{
    * drizzle-kit or `bootstrapTables`, never here. Throws on a
    * `logicalName` no active strategy declares, rather than silently
    * doing nothing.
+   *
+   * Writes the durable materialization marker for the contribution
+   * (success or failure) keyed by `graphId` + contribution identity
+   * (#135), so the hot-path gate can later answer "initialized?"
+   * without re-running DDL.
    */
-  ensureContribution?: (logicalName: string) => Promise<void>;
+  ensureContribution?: (logicalName: string, graphId: string) => Promise<void>;
 
   /**
    * Materializes every contribution flagged `runtimeEnsure` — the
@@ -897,8 +1012,13 @@ export type GraphBackend = Readonly<{
    * load. Deliberately scoped: base/drizzle-visible tables are
    * `runtimeEnsure: false`, so this does not regress startup into
    * broad DDL/probing across every table.
+   *
+   * The canonical durable-marker writer (#135): for each runtime
+   * contribution it short-circuits when the marker already records a
+   * matching signature, otherwise runs the idempotent `createDdl` and
+   * records the marker (success or failure) keyed by `graphId`.
    */
-  ensureRuntimeContributions?: () => Promise<void>;
+  ensureRuntimeContributions?: (graphId: string) => Promise<void>;
 
   /**
    * Bootstraps the fulltext storage table the active `FulltextStrategy`
@@ -909,9 +1029,10 @@ export type GraphBackend = Readonly<{
    * `ensureRuntimeContributions()` (#129); retained as a thin
    * back-compat wrapper for backends/callers predating #129. Not
    * machine-`@deprecated` because the manager still calls it as the
-   * pre-#129 fallback. #135 removes the remaining hot-path callers.
+   * pre-#129 fallback. #135 removed the remaining hot-path callers and
+   * routed this through the durable-marker writer.
    */
-  ensureFulltextTable?: () => Promise<void>;
+  ensureFulltextTable?: (graphId: string) => Promise<void>;
 
   /**
    * Read the high-water mark schema version for which

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -787,6 +787,65 @@ export class ConfigurationError extends TypeGraphError {
   }
 }
 
+/**
+ * Why a store's strategy-owned storage is not usable on the current
+ * connection. Drives the {@link StoreNotInitializedError} message and
+ * is surfaced in `details.reason` for programmatic handling.
+ *
+ * - `missing`: no durable materialization marker exists — the database
+ *   was never initialized for this graph's runtime contributions.
+ * - `stale`: a marker exists but its recorded signature no longer
+ *   matches the resolved contribution DDL (strategy swap or DDL drift).
+ *   The hot path refuses rather than silently re-materializing.
+ * - `failed`: the most recent boot-time materialization attempt
+ *   recorded an error. Boot may retry; the hot path refuses.
+ */
+export type StoreNotInitializedReason = "missing" | "stale" | "failed";
+
+const STORE_NOT_INITIALIZED_REASON_PHRASE: Readonly<
+  Record<StoreNotInitializedReason, string>
+> = {
+  missing: "is not initialized",
+  stale: "is stale (recorded materialization signature no longer matches)",
+  failed: "failed its last initialization attempt",
+};
+
+/**
+ * Thrown when a fulltext-dependent operation runs against a connection
+ * whose strategy-owned storage has not been durably materialized.
+ *
+ * `createStore()` is a synchronous, zero-I/O attach: it never creates
+ * tables, repairs DDL, or writes materialization markers. The durable
+ * marker is written exclusively by the async boot path
+ * (`createStoreWithSchema`). When a fulltext read/write — or an
+ * adopted/business transaction — observes no valid marker, it refuses
+ * loudly here instead of lazily emitting DDL on the hot path.
+ */
+export class StoreNotInitializedError extends TypeGraphError {
+  constructor(
+    graphId: string,
+    reason: StoreNotInitializedReason,
+    options?: { cause?: unknown; details?: Record<string, unknown> },
+  ) {
+    super(
+      `fulltext storage for graph "${graphId}" ${STORE_NOT_INITIALIZED_REASON_PHRASE[reason]}. ` +
+        `Run createStoreWithSchema(graph, backend) during application boot, ` +
+        `outside request handlers and adopted transactions, before using createStore().`,
+      "STORE_NOT_INITIALIZED",
+      {
+        details: { graphId, reason, ...options?.details },
+        category: "user",
+        suggestion:
+          "Call createStoreWithSchema(graph, backend) once at application " +
+          "startup. createStore() attaches to an already-initialized " +
+          "database and does not materialize storage itself.",
+        cause: options?.cause,
+      },
+    );
+    this.name = "StoreNotInitializedError";
+  }
+}
+
 // ============================================================
 // Database Errors (category: "system")
 // ============================================================

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -193,6 +193,7 @@ export {
 
 export type {
   ErrorCategory,
+  StoreNotInitializedReason,
   TypeGraphErrorOptions,
   ValidationErrorDetails,
   ValidationIssue,
@@ -223,6 +224,7 @@ export {
   SchemaContentConflictError,
   SchemaMismatchError,
   StaleVersionError,
+  StoreNotInitializedError,
   TypeGraphError,
   UniquenessError,
   UnsupportedPredicateError,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -12,6 +12,7 @@ import { type GraphDef } from "../core/define-graph";
 import { DatabaseOperationError, MigrationError } from "../errors";
 import { mergeGraphExtension } from "../graph-extension/merge";
 import { freezeDeep } from "../utils/object";
+import { isMissingTableError } from "../utils/sql-errors";
 import {
   computeSchemaDiff,
   getMigrationActions,
@@ -93,17 +94,6 @@ export function parseSerializedSchema(json: string): SerializedSchema {
 // Helpers
 // ============================================================
 
-const MISSING_TABLE_PATTERNS = [
-  "no such table", // SQLite
-  "does not exist", // PostgreSQL ("relation ... does not exist")
-  "SQLITE_ERROR", // D1 / Durable Objects error code
-];
-
-function isMissingTableError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return MISSING_TABLE_PATTERNS.some((pattern) => message.includes(pattern));
-}
-
 /**
  * Reads the active schema row, bootstrapping the base tables on the
  * first call against an empty database. Also runs the focused
@@ -123,8 +113,8 @@ export async function loadActiveSchemaWithBootstrap(
   try {
     const row = await backend.getActiveSchema(graphId);
     await (backend.ensureRuntimeContributions ?
-      backend.ensureRuntimeContributions()
-    : backend.ensureFulltextTable?.());
+      backend.ensureRuntimeContributions(graphId)
+    : backend.ensureFulltextTable?.(graphId));
     return row;
   } catch (error) {
     if (backend.bootstrapTables && isMissingTableError(error)) {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -847,6 +847,10 @@ export class Store<G extends GraphDef> {
       return fn({ nodes: this.nodes, edges: this.edges });
     }
 
+    // #134/#135: no gate here. The backend's transaction() wraps the
+    // tx-scoped fulltext methods so the durable-marker assert fires at
+    // point of use (a cached SELECT, never DDL). A transaction that
+    // never touches fulltext requires no fulltext initialization.
     return this.#backend.transaction(async (txBackend) => {
       const txNodeOperations: NodeOperations = {
         ...this.#nodeOperations,
@@ -1791,6 +1795,18 @@ export async function createStoreWithSchema<G extends GraphDef>(
     ...options,
     preloaded: { activeRow, storedSchema },
   });
+
+  // #135: createStoreWithSchema is the single canonical durable-marker
+  // writer. The warm path already materialized runtime contributions
+  // inside loadActiveSchemaWithBootstrap, but the COLD path returns
+  // before that success branch (bootstrapTables runs, no active schema
+  // yet) — ensureSchemaImpl then initializes the schema. This explicit
+  // post-init call closes that gap: it writes the durable contribution
+  // marker AFTER the schema version is resolved, for cold and warm
+  // boots alike. Idempotent and cheap (the per-instance cache and the
+  // recorded-signature short-circuit make a warm re-call a no-op).
+  await backend.ensureRuntimeContributions?.(merged.id);
+
   const store = new Store(
     merged,
     backend,

--- a/packages/typegraph/src/utils/index.ts
+++ b/packages/typegraph/src/utils/index.ts
@@ -16,3 +16,4 @@ export {
   unwrap,
   unwrapOr,
 } from "./result";
+export { isMissingTableError } from "./sql-errors";

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Cross-dialect detection of "this relation does not exist yet" errors.
+ *
+ * Shared so the schema bootstrap (`loadActiveSchemaWithBootstrap`) and
+ * the durable contribution-materialization gate (#135) agree on what a
+ * missing-table failure looks like, and — critically — so neither one
+ * swallows a genuine system fault (connection/permission/driver error)
+ * as a benign "not bootstrapped yet".
+ */
+
+const MISSING_TABLE_PATTERNS = [
+  "no such table", // SQLite
+  "does not exist", // PostgreSQL ("relation ... does not exist")
+  "SQLITE_ERROR", // D1 / Durable Objects error code
+] as const;
+
+export function isMissingTableError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return MISSING_TABLE_PATTERNS.some((pattern) => message.includes(pattern));
+}

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -17,7 +17,7 @@
  */
 import { afterEach, beforeEach, describe } from "vitest";
 
-import { createStore } from "../../src";
+import { createStoreWithSchema } from "../../src";
 import type { GraphBackend } from "../../src/backend/types";
 import type { IntegrationStore, IntegrationTestContext } from "./integration";
 import {
@@ -95,7 +95,13 @@ export function createIntegrationTestSuite(
 
     beforeEach(async () => {
       const result = await createBackend();
-      store = createStore(integrationTestGraph, result.backend);
+      // #135: createStoreWithSchema is the canonical durable-marker
+      // writer. The shared fulltext suite exercises fulltext ops, which
+      // now (correctly) require materialization at boot.
+      [store] = await createStoreWithSchema(
+        integrationTestGraph,
+        result.backend,
+      );
       cleanup = result.cleanup;
     });
 

--- a/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
@@ -1,13 +1,20 @@
 /**
- * Regression tests for the drizzle-kit-managed fulltext bootstrap
- * gap on PostgreSQL — SQLite mirror at
- * `tests/fulltext-bootstrap.test.ts`. The strategy owns the
- * fulltext DDL (alternate Postgres stacks carry incompatible
- * schemas), so the `bootstrapTables` shortcut bypasses it once
- * `schema_versions` exists. `ensureFulltextTable` closes the gap.
+ * #135: durable, enforced fulltext materialization on PostgreSQL —
+ * SQLite mirror at `tests/fulltext-bootstrap.test.ts`.
+ *
+ * `createStoreWithSchema` is the single canonical writer of the durable
+ * `typegraph_contribution_materializations` marker. The sync
+ * `createStore` path is attach-only: it never lazily materializes the
+ * strategy-owned fulltext table. A fulltext read/write — or an adopted
+ * transaction — against a database with no valid marker throws
+ * `StoreNotInitializedError` rather than emitting DDL on the hot path
+ * (the pre-#135 behavior). This also closes the drizzle-kit gap: the
+ * strategy owns the fulltext DDL, so `bootstrapTables` bypasses it once
+ * `schema_versions` exists; the durable boot step covers it.
  *
  * Skipped unless `POSTGRES_URL` is set (or `scripts/test-postgres.sh`).
  */
+import { getTableName } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import {
@@ -27,6 +34,7 @@ import {
   defineGraph,
   defineNode,
   searchable,
+  StoreNotInitializedError,
   tsvectorStrategy,
 } from "../../../src";
 import {
@@ -58,6 +66,10 @@ const FtGraph = defineGraph({
   nodes: { Doc: { type: Document } },
   edges: {},
 });
+
+const CONTRIB_MAT_TABLE = getTableName(
+  defaultTables.contributionMaterializations,
+);
 
 beforeAll(async () => {
   if (!process.env.POSTGRES_URL) return;
@@ -127,19 +139,15 @@ describe.runIf(process.env.POSTGRES_URL)(
       return createPostgresBackend(drizzle(transientPool));
     }
 
-    /**
-     * Bootstraps a real schema row (so `createStore` CRUD passes
-     * the no-schema gate) then drops the fulltext table again,
-     * restoring the drizzle-kit-only state.
-     */
-    async function seedSchemaThenDropFulltext(): Promise<void> {
-      await createStoreWithSchema(FtGraph, pooledBackend());
-      await dropFulltextTable(pool!);
-    }
-
     beforeEach(async () => {
       if (!postgresAvailable || !pool) return;
       await dropFulltextTable(pool);
+      // Each test starts genuinely uninitialized: drop the durable
+      // marker a prior test's createStoreWithSchema may have written.
+      await pool.query(
+        `DELETE FROM ${CONTRIB_MAT_TABLE} ` + `WHERE graph_id = $1`,
+        [FtGraph.id],
+      );
     });
 
     afterEach(async () => {
@@ -151,12 +159,12 @@ describe.runIf(process.env.POSTGRES_URL)(
       }
     });
 
-    it("createStoreWithSchema bootstrap restores the missing fulltext table", async () => {
+    it("createStoreWithSchema materializes the fulltext table and writes the durable marker", async () => {
       await expectFulltextTableMissing();
 
       const [store] = await createStoreWithSchema(FtGraph, pooledBackend());
 
-      // The bootstrap probe should have created the table.
+      // The canonical boot path created the table.
       const exists = await pool!.query<{ exists: boolean }>(
         `SELECT EXISTS (
            SELECT 1 FROM pg_tables
@@ -165,6 +173,22 @@ describe.runIf(process.env.POSTGRES_URL)(
         [defaultTables.fulltextTableName],
       );
       expect(exists.rows[0]?.exists).toBe(true);
+
+      // The durable marker was recorded for this graph.
+      const markers = await pool!.query<{
+        owner: string;
+        materialized_at: string | null;
+        last_error: string | null;
+      }>(
+        `SELECT owner, materialized_at, last_error
+           FROM ${CONTRIB_MAT_TABLE}
+          WHERE graph_id = $1 AND logical_name = 'fulltext'`,
+        [FtGraph.id],
+      );
+      expect(markers.rows).toHaveLength(1);
+      expect(markers.rows[0]?.owner).toBe(tsvectorStrategy.name);
+      expect(markers.rows[0]?.materialized_at).not.toBeNull();
+      expect(markers.rows[0]?.last_error).toBeNull();
 
       await store.nodes.Doc.create({ title: "renewable energy" });
 
@@ -176,51 +200,69 @@ describe.runIf(process.env.POSTGRES_URL)(
       expect(rows.rows[0]?.content).toBe("renewable energy");
     });
 
-    it("sync createStore path materializes the fulltext table on first write", async () => {
-      // createStore is sync and skips loadActiveSchemaWithBootstrap,
-      // so the bootstrap-load probe can't help here — the backend's
-      // wrapped write methods must self-ensure.
-      await seedSchemaThenDropFulltext();
+    it("sync createStore path throws StoreNotInitializedError on a fulltext write", async () => {
+      // createStore is attach-only and skips
+      // loadActiveSchemaWithBootstrap. Against a database with no
+      // durable marker the fulltext write refuses loudly rather than
+      // self-healing.
       const store = createStore(FtGraph, pooledBackend());
-      await store.nodes.Doc.create({ title: "sync path works" });
+      await expect(
+        store.nodes.Doc.create({ title: "should not persist" }),
+      ).rejects.toBeInstanceOf(StoreNotInitializedError);
+
+      await expectFulltextTableMissing();
+    });
+
+    it("a fulltext write inside store.transaction() throws StoreNotInitializedError (no DDL in the business tx)", async () => {
+      // The tx-scoped backend's fulltext methods assert the durable
+      // marker at point of use — a cached SELECT, never DDL. The
+      // uninitialized database makes the write refuse and roll back.
+      const store = createStore(FtGraph, pooledBackend());
+      await expect(
+        store.transaction(async (tx) => {
+          await tx.nodes.Doc.create({ title: "tx" });
+        }),
+      ).rejects.toBeInstanceOf(StoreNotInitializedError);
+
+      await expectFulltextTableMissing();
+    });
+
+    it("createStore against an already-initialized database works without re-running boot", async () => {
+      await createStoreWithSchema(FtGraph, pooledBackend());
+
+      // A fresh backend instance (cold latch) attaches via the sync
+      // createStore — the durable marker, not an in-memory boolean, is
+      // what lets the hot path proceed DML-only.
+      const store = createStore(FtGraph, pooledBackend());
+      await store.nodes.Doc.create({ title: "attach path works" });
 
       const rows = await pool!.query<{ content: string }>(
         `SELECT content FROM ${defaultTables.fulltextTableName} WHERE graph_id = $1`,
         [FtGraph.id],
       );
       expect(rows.rows).toHaveLength(1);
-      expect(rows.rows[0]?.content).toBe("sync path works");
+      expect(rows.rows[0]?.content).toBe("attach path works");
     });
 
-    it("store.transaction() materializes the fulltext table before BEGIN", async () => {
-      // The tx-scoped backend exposes raw fulltext methods, so
-      // transaction() itself ensures the table BEFORE BEGIN runs
-      // (avoiding CREATE-INDEX-inside-tx SHARE-lock contention and
-      // keeping the table durable on rollback).
-      await seedSchemaThenDropFulltext();
-      const store = createStore(FtGraph, pooledBackend());
-      await store.transaction(async (tx) => {
-        await tx.nodes.Doc.create({ title: "tx path works" });
-      });
-
-      const rows = await pool!.query<{ content: string }>(
-        `SELECT content FROM ${defaultTables.fulltextTableName} WHERE graph_id = $1`,
-        [FtGraph.id],
-      );
-      expect(rows.rows).toHaveLength(1);
-      expect(rows.rows[0]?.content).toBe("tx path works");
-    });
-
-    it("ensureFulltextTable is idempotent across repeat calls", async () => {
+    it("ensureFulltextTable(graphId) is the durable-marker writer and is idempotent", async () => {
       await expectFulltextTableMissing();
 
       const backend = pooledBackend();
 
       expect(backend.ensureFulltextTable).toBeTypeOf("function");
 
-      await backend.ensureFulltextTable!();
-      await backend.ensureFulltextTable!();
-      await backend.ensureFulltextTable!();
+      await backend.ensureFulltextTable!(FtGraph.id);
+      await backend.ensureFulltextTable!(FtGraph.id);
+      await backend.ensureFulltextTable!(FtGraph.id);
+
+      // Exactly one durable marker row, no error recorded.
+      const markers = await pool!.query<{ last_error: string | null }>(
+        `SELECT last_error FROM ${CONTRIB_MAT_TABLE}
+          WHERE graph_id = $1`,
+        [FtGraph.id],
+      );
+      expect(markers.rows).toHaveLength(1);
+      expect(markers.rows[0]?.last_error).toBeNull();
 
       // Sanity: the GIN index the strategy declares is also present
       // and idempotent (CREATE INDEX IF NOT EXISTS).

--- a/packages/typegraph/tests/backends/postgres/postgres-fulltext.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-fulltext.test.ts
@@ -12,7 +12,8 @@ import { z } from "zod";
 import { defineGraph, defineNode, embedding, searchable } from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
-import { createStore } from "../../../src/store";
+import type { createStore } from "../../../src/store";
+import { createStoreWithSchema } from "../../../src/store";
 import { type FulltextSearchHit } from "../../../src/store/search";
 
 const TEST_DATABASE_URL =
@@ -84,7 +85,9 @@ describe.runIf(process.env.POSTGRES_URL)("PostgreSQL fulltext search", () => {
     await pool.query("TRUNCATE typegraph_nodes CASCADE");
     const db = drizzle(new Pool({ connectionString: TEST_DATABASE_URL }));
     const backend = createPostgresBackend(db);
-    store = createStore(SearchGraph, backend);
+    // #135: createStoreWithSchema is the canonical durable-marker
+    // writer; fulltext ops require materialization at boot.
+    [store] = await createStoreWithSchema(SearchGraph, backend);
   });
 
   it("declares fulltext capability with stemmer languages", () => {

--- a/packages/typegraph/tests/fulltext-bootstrap.test.ts
+++ b/packages/typegraph/tests/fulltext-bootstrap.test.ts
@@ -1,12 +1,21 @@
 /**
- * Regression tests for the drizzle-kit-managed fulltext bootstrap
- * gap on SQLite. drizzle-kit can't model FTS5 virtual tables, so
- * consumers driving migrations through `drizzle-kit push` land here
- * with every typegraph table EXCEPT `typegraph_node_fulltext`. The
- * fix is `backend.ensureFulltextTable()`, called from
- * `loadActiveSchemaWithBootstrap` on the success path.
+ * #135: durable, enforced fulltext materialization on SQLite.
+ *
+ * `createStoreWithSchema` is the single canonical writer of the durable
+ * `typegraph_contribution_materializations` marker. The sync
+ * `createStore` path is attach-only and zero-I/O: it never lazily
+ * materializes the FTS5 virtual table. A fulltext read/write — or an
+ * adopted transaction — against a database with no valid marker throws
+ * `StoreNotInitializedError` instead of silently emitting DDL on the
+ * hot path (the pre-#135 behavior).
+ *
+ * Also covers the drizzle-kit gap (drizzle-kit can't model FTS5 virtual
+ * tables, so `drizzle-kit push` leaves every typegraph table EXCEPT
+ * `typegraph_node_fulltext`): `createStoreWithSchema` closes it as part
+ * of the same durable-materialization step.
  */
 import Database from "better-sqlite3";
+import { getTableName } from "drizzle-orm";
 import {
   type BetterSQLite3Database,
   drizzle,
@@ -21,6 +30,7 @@ import {
   defineNode,
   fts5Strategy,
   searchable,
+  StoreNotInitializedError,
 } from "../src";
 import { generateSqliteDDL } from "../src/backend/drizzle/ddl";
 import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
@@ -58,29 +68,17 @@ const FtGraph = defineGraph({
   edges: {},
 });
 
-describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
+const CONTRIB_MAT_TABLE = getTableName(
+  defaultTables.contributionMaterializations,
+);
+
+describe("#135 durable fulltext materialization (SQLite)", () => {
   let sqlite: Database.Database;
   let db: BetterSQLite3Database;
 
   beforeEach(() => {
     ({ sqlite, db } = createDrizzleKitOnlySqlite());
   });
-
-  /**
-   * Bootstraps a real schema row (so subsequent `createStore` CRUD
-   * passes the no-schema gate) then drops the fulltext table again,
-   * restoring the drizzle-kit-only state. Mirrors what a consumer
-   * who ran `drizzle-kit push` + an external schema migration would
-   * leave on disk.
-   */
-  async function seedSchemaThenDropFulltext(): Promise<void> {
-    const seederBackend = createSqliteBackend(db, {
-      executionProfile: { isSync: true },
-      tables: defaultTables,
-    });
-    await createStoreWithSchema(FtGraph, seederBackend);
-    sqlite.exec(`DROP TABLE IF EXISTS ${defaultTables.fulltextTableName}`);
-  }
 
   it("starts with the fulltext virtual table missing", () => {
     expect(() =>
@@ -89,7 +87,7 @@ describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
     sqlite.close();
   });
 
-  it("creates the fulltext table during createStoreWithSchema bootstrap", async () => {
+  it("createStoreWithSchema materializes the fulltext table and writes the durable marker", async () => {
     const backend = createSqliteBackend(db, {
       executionProfile: { isSync: true },
       tables: defaultTables,
@@ -97,13 +95,33 @@ describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
 
     const [store] = await createStoreWithSchema(FtGraph, backend);
 
-    // The bootstrap probe should have created the table.
+    // The canonical boot path created the FTS5 table.
     const rows = sqlite
       .prepare(`SELECT * FROM ${defaultTables.fulltextTableName}`)
       .all();
     expect(rows).toEqual([]);
 
-    // And the searchable() write should land without error.
+    // The durable marker was recorded for this graph.
+    const markers = sqlite
+      .prepare(
+        `SELECT graph_id, logical_name, owner, materialized_at, last_error ` +
+          `FROM ${CONTRIB_MAT_TABLE}`,
+      )
+      .all() as readonly {
+      graph_id: string;
+      logical_name: string;
+      owner: string;
+      materialized_at: string | null;
+      last_error: string | null;
+    }[];
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.graph_id).toBe(FtGraph.id);
+    expect(markers[0]?.logical_name).toBe("fulltext");
+    expect(markers[0]?.owner).toBe(fts5Strategy.name);
+    expect(markers[0]?.materialized_at).not.toBeNull();
+    expect(markers[0]?.last_error).toBeNull();
+
+    // And the searchable() write lands without error.
     await store.nodes.Doc.create({ title: "hello world" });
 
     const fulltext = sqlite
@@ -115,56 +133,83 @@ describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
     sqlite.close();
   });
 
-  it("sync createStore path materializes the fulltext table on first write", async () => {
-    // createStore is sync and skips loadActiveSchemaWithBootstrap, so
-    // the bootstrap-load probe can't help here — the backend's
-    // wrapped write methods must self-ensure.
-    await seedSchemaThenDropFulltext();
+  it("sync createStore path throws StoreNotInitializedError on a fulltext write (no lazy materialization)", async () => {
+    // createStore is sync, attach-only, and skips
+    // loadActiveSchemaWithBootstrap. Against an uninitialized database
+    // the fulltext write must refuse loudly instead of self-healing.
     const backend = createSqliteBackend(db, {
       executionProfile: { isSync: true },
       tables: defaultTables,
     });
     const store = createStore(FtGraph, backend);
-    await store.nodes.Doc.create({ title: "sync path works" });
 
-    const rows = sqlite
-      .prepare(`SELECT content FROM ${defaultTables.fulltextTableName}`)
-      .all() as readonly { content: string }[];
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.content).toBe("sync path works");
+    await expect(
+      store.nodes.Doc.create({ title: "should not persist" }),
+    ).rejects.toBeInstanceOf(StoreNotInitializedError);
+
+    // No table was lazily created on the hot path.
+    expect(() =>
+      sqlite.prepare(`SELECT * FROM ${defaultTables.fulltextTableName}`).all(),
+    ).toThrow(/no such table/);
 
     sqlite.close();
   });
 
-  it("store.transaction() materializes the fulltext table before BEGIN", async () => {
-    // The tx-scoped backend exposes raw fulltext methods without
-    // the outer wrappers, so transaction() itself ensures the
-    // table BEFORE BEGIN runs (avoiding CREATE-inside-tx and
-    // keeping the table durable on rollback).
-    await seedSchemaThenDropFulltext();
+  it("a fulltext write inside store.transaction() throws StoreNotInitializedError (no DDL in the business tx)", async () => {
+    // The tx-scoped backend's fulltext methods assert the durable
+    // marker at point of use — a cached SELECT, never DDL. The
+    // uninitialized database makes the fulltext write refuse, so the
+    // transaction rolls back and nothing is created.
     const backend = createSqliteBackend(db, {
       executionProfile: { isSync: true },
       tables: defaultTables,
     });
     const store = createStore(FtGraph, backend);
-    await store.transaction(async (tx) => {
-      await tx.nodes.Doc.create({ title: "tx path works" });
+
+    await expect(
+      store.transaction(async (tx) => {
+        await tx.nodes.Doc.create({ title: "tx" });
+      }),
+    ).rejects.toBeInstanceOf(StoreNotInitializedError);
+
+    // The gate emitted no DDL: the FTS5 table was never created.
+    expect(() =>
+      sqlite.prepare(`SELECT * FROM ${defaultTables.fulltextTableName}`).all(),
+    ).toThrow(/no such table/);
+
+    sqlite.close();
+  });
+
+  it("createStore against an already-initialized database works without re-running boot", async () => {
+    // First process boots the database via the canonical writer.
+    const bootBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
     });
+    await createStoreWithSchema(FtGraph, bootBackend);
+
+    // A subsequent fresh backend instance (cold latch) attaches via the
+    // sync createStore — the durable marker, not an in-memory boolean,
+    // is what lets the hot path proceed DML-only.
+    const attachBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    const store = createStore(FtGraph, attachBackend);
+    await store.nodes.Doc.create({ title: "attach path works" });
 
     const rows = sqlite
       .prepare(`SELECT content FROM ${defaultTables.fulltextTableName}`)
       .all() as readonly { content: string }[];
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.content).toBe("tx path works");
+    expect(rows[0]?.content).toBe("attach path works");
 
     sqlite.close();
   });
 
   it("transaction() with transactionMode 'none' rejects without side effects", async () => {
-    // The early-rejection must fire before the ensure runs —
-    // otherwise a backend configured without transactions would
-    // materialize the fulltext table from a call that's about to
-    // throw.
+    // The early-rejection fires before any work — a backend configured
+    // without transactions never touches the fulltext or marker tables.
     const backend = createSqliteBackend(db, {
       executionProfile: { isSync: true, transactionMode: "none" },
       tables: defaultTables,
@@ -182,7 +227,7 @@ describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
     sqlite.close();
   });
 
-  it("ensureFulltextTable is idempotent across repeat calls", async () => {
+  it("ensureFulltextTable(graphId) is the durable-marker writer and is idempotent", async () => {
     const backend = createSqliteBackend(db, {
       executionProfile: { isSync: true },
       tables: defaultTables,
@@ -190,14 +235,22 @@ describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
 
     expect(backend.ensureFulltextTable).toBeTypeOf("function");
 
-    await backend.ensureFulltextTable!();
-    await backend.ensureFulltextTable!();
-    await backend.ensureFulltextTable!();
+    await backend.ensureFulltextTable!(FtGraph.id);
+    await backend.ensureFulltextTable!(FtGraph.id);
+    await backend.ensureFulltextTable!(FtGraph.id);
+
+    // Exactly one durable marker row, no error recorded.
+    const markers = sqlite
+      .prepare(
+        `SELECT last_error FROM ${CONTRIB_MAT_TABLE} ` +
+          `WHERE graph_id = '${FtGraph.id}'`,
+      )
+      .all() as readonly { last_error: string | null }[];
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.last_error).toBeNull();
 
     // Inserts still work after multiple ensure calls — no double-create
-    // surprise from FTS5. Using raw `sqlite.exec` (rather than the
-    // drizzle wrapper) sidesteps the sync/async return-type juggling
-    // for a one-off insert in a sync-mode test.
+    // surprise from FTS5.
     sqlite.exec(
       `INSERT INTO ${defaultTables.fulltextTableName} ` +
         `(graph_id, node_kind, node_id, content, language, updated_at) ` +
@@ -210,6 +263,95 @@ describe("drizzle-kit-managed setup: fulltext bootstrap gap", () => {
       )
       .all() as readonly { graph_id: string; node_id: string }[];
     expect(rows).toEqual([{ graph_id: "g", node_id: "n" }]);
+
+    sqlite.close();
+  });
+});
+
+describe("#135 signature drift is a loud error, never silently re-blessed", () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    for (const statement of generateSqliteDDL(defaultTables, fts5Strategy)) {
+      sqlite.exec(statement);
+    }
+    db = drizzle(sqlite);
+  });
+
+  // Same contribution identity (graph/logicalName/owner/tableName) but a
+  // changed `createDdl` — the exact shape #129's drift signature exists
+  // to detect. The extra statement is idempotent so the FTS5 table is
+  // unaffected; only the recorded signature would differ.
+  const driftStrategy: typeof fts5Strategy = {
+    ...fts5Strategy,
+    ownedTables(primaryTableName) {
+      return fts5Strategy.ownedTables(primaryTableName).map((contribution) => ({
+        ...contribution,
+        createDdl: [
+          ...contribution.createDdl,
+          "CREATE TABLE IF NOT EXISTS typegraph_drift_probe (x)",
+        ],
+      }));
+    },
+  };
+
+  it("ensureRuntimeContributions refuses a post-success signature change", async () => {
+    const bootBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    await createStoreWithSchema(FtGraph, bootBackend);
+
+    const driftBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+      fulltext: driftStrategy,
+    });
+
+    await expect(
+      driftBackend.ensureRuntimeContributions!(FtGraph.id),
+    ).rejects.toThrow(/already materialized with a different signature/);
+
+    // The recorded marker still reflects the original successful
+    // materialization — the drift attempt did not overwrite it as success.
+    const markers = sqlite
+      .prepare(
+        `SELECT materialized_at, last_error FROM ${CONTRIB_MAT_TABLE} ` +
+          `WHERE graph_id = '${FtGraph.id}'`,
+      )
+      .all() as readonly {
+      materialized_at: string | null;
+      last_error: string | null;
+    }[];
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.materialized_at).not.toBeNull();
+    expect(markers[0]?.last_error).not.toBeNull();
+
+    sqlite.close();
+  });
+
+  it("the hot path reports drift as StoreNotInitializedError(stale)", async () => {
+    const bootBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    await createStoreWithSchema(FtGraph, bootBackend);
+
+    const driftBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+      fulltext: driftStrategy,
+    });
+    const store = createStore(FtGraph, driftBackend);
+
+    await expect(
+      store.nodes.Doc.create({ title: "drifted" }),
+    ).rejects.toMatchObject({
+      name: "StoreNotInitializedError",
+      details: { reason: "stale" },
+    });
 
     sqlite.close();
   });

--- a/packages/typegraph/tests/fulltext-rebuild.test.ts
+++ b/packages/typegraph/tests/fulltext-rebuild.test.ts
@@ -11,7 +11,8 @@ import { KindNotFoundError } from "../src";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import { type GraphBackend } from "../src/backend/types";
 import { ConfigurationError, ValidationError } from "../src/errors";
-import { createStore } from "../src/store";
+import type { createStore } from "../src/store";
+import { createInitializedStore } from "./test-utils";
 
 const Document = defineNode("Document", {
   schema: z.object({
@@ -46,7 +47,7 @@ describe("store.search.rebuildFulltext", () => {
     backend = result.backend;
     db = result.db;
     await backend.bootstrapTables?.();
-    store = createStore(TestGraph, backend);
+    store = await createInitializedStore(TestGraph, backend);
   });
 
   it("restores fulltext results after the fulltext table is truncated", async () => {
@@ -175,7 +176,10 @@ describe("store.search.rebuildFulltext", () => {
       ...rest
     } = backend;
     const backendNoFulltext = rest as GraphBackend;
-    const storeNoFulltext = createStore(TestGraph, backendNoFulltext);
+    const storeNoFulltext = await createInitializedStore(
+      TestGraph,
+      backendNoFulltext,
+    );
 
     await expect(storeNoFulltext.search.rebuildFulltext()).rejects.toThrow(
       ConfigurationError,

--- a/packages/typegraph/tests/fulltext-search.test.ts
+++ b/packages/typegraph/tests/fulltext-search.test.ts
@@ -23,10 +23,10 @@ import {
   searchable,
 } from "../src/core/searchable";
 import { createSchemaIntrospector } from "../src/query/schema-introspector";
-import { createStore } from "../src/store";
+import type { createStore } from "../src/store";
 import { getSearchableFields } from "../src/store/fulltext-sync";
 import { type FulltextSearchHit } from "../src/store/search";
-import { createTestBackend } from "./test-utils";
+import { createInitializedStore, createTestBackend } from "./test-utils";
 
 type DocumentProps = Readonly<{ title: string; body: string; plain?: string }>;
 function documentProps(hit: FulltextSearchHit): DocumentProps {
@@ -196,7 +196,7 @@ describe("end-to-end fulltext search (SQLite FTS5)", () => {
   beforeEach(async () => {
     backend = createTestBackend();
     await backend.bootstrapTables?.();
-    store = createStore(SearchableGraph, backend);
+    store = await createInitializedStore(SearchableGraph, backend);
   });
 
   it("declares fulltext capability", () => {
@@ -473,7 +473,10 @@ describe("end-to-end fulltext search (SQLite FTS5)", () => {
     });
     const chainedBackend = createTestBackend();
     await chainedBackend.bootstrapTables?.();
-    const chainedStore = createStore(ChainedGraph, chainedBackend);
+    const chainedStore = await createInitializedStore(
+      ChainedGraph,
+      chainedBackend,
+    );
 
     await chainedStore.nodes.ChainedDocument.create({
       title: "Climate report",
@@ -531,7 +534,7 @@ describe("hybrid search (vector + FTS, RRF fusion)", () => {
     });
     expect(backend.vectorSearch).toBeUndefined();
 
-    const store = createStore(HybridGraph, backend);
+    const store = await createInitializedStore(HybridGraph, backend);
     await store.nodes.HybridDoc.create({
       title: "doc",
       body: "body",
@@ -556,7 +559,7 @@ describe("hybrid search (vector + FTS, RRF fusion)", () => {
     const backend = createTestBackend();
     if (backend.vectorSearch === undefined) return;
     await backend.bootstrapTables?.();
-    const store = createStore(HybridGraph, backend);
+    const store = await createInitializedStore(HybridGraph, backend);
 
     const solar = await store.nodes.HybridDoc.create({
       title: "Solar power",
@@ -602,7 +605,7 @@ describe("hybrid search (vector + FTS, RRF fusion)", () => {
     const backend = createTestBackend();
     if (backend.vectorSearch === undefined) return;
     await backend.bootstrapTables?.();
-    const store = createStore(HybridGraph, backend);
+    const store = await createInitializedStore(HybridGraph, backend);
 
     for (let index = 0; index < 5; index++) {
       await store.nodes.HybridDoc.create({
@@ -630,7 +633,7 @@ describe("hybrid search (vector + FTS, RRF fusion)", () => {
     // tests. Here we exercise the RRF math by stubbing backend methods.
     const backend = createTestBackend();
     await backend.bootstrapTables?.();
-    const store = createStore(HybridGraph, backend);
+    const store = await createInitializedStore(HybridGraph, backend);
 
     // Insert three nodes so getNodes can resolve them by id.
     const a = await store.nodes.HybridDoc.create({
@@ -765,7 +768,7 @@ describe("custom FulltextStrategy plumbing", () => {
     const db = drizzle(sqlite);
     const backend = createSqliteBackend(db, { fulltext: spyStrategy });
     await backend.bootstrapTables?.();
-    const store = createStore(HybridGraph, backend);
+    const store = await createInitializedStore(HybridGraph, backend);
 
     // ownedTables consulted during bootstrap (DDL derives from it).
     expect(calls.ownedTables).toBeGreaterThanOrEqual(1);

--- a/packages/typegraph/tests/matches-predicate.test.ts
+++ b/packages/typegraph/tests/matches-predicate.test.ts
@@ -20,9 +20,9 @@ import { type PropsAccessor } from "../src/query/builder/types";
 import { compileQuery } from "../src/query/compiler";
 import { type FulltextAccessor } from "../src/query/predicates";
 import { buildKindRegistry } from "../src/registry";
-import { createStore } from "../src/store";
+import type { createStore } from "../src/store";
 import { toSqlString, toSqlWithParams } from "./sql-test-utils";
-import { createTestBackend } from "./test-utils";
+import { createInitializedStore, createTestBackend } from "./test-utils";
 
 // ============================================================
 // Fixture schemas
@@ -83,7 +83,7 @@ describe(".matches() predicate", () => {
   beforeEach(async () => {
     backend = createTestBackend();
     await backend.bootstrapTables?.();
-    store = createStore(DocumentGraph, backend);
+    store = await createInitializedStore(DocumentGraph, backend);
   });
 
   // ================================================================
@@ -365,7 +365,10 @@ describe(".matches() predicate", () => {
 
     const hybridBackend = createTestBackend();
     await hybridBackend.bootstrapTables?.();
-    const hybridStore = createStore(HybridGraph, hybridBackend);
+    const hybridStore = await createInitializedStore(
+      HybridGraph,
+      hybridBackend,
+    );
 
     const solar = await hybridStore.nodes.HybridDoc.create({
       title: "Solar power",
@@ -508,7 +511,7 @@ describe(".matches() with polymorphic alias", () => {
   beforeEach(async () => {
     backend = createTestBackend();
     await backend.bootstrapTables?.();
-    store = createStore(PolymorphicGraph, backend);
+    store = await createInitializedStore(PolymorphicGraph, backend);
   });
 
   it("searches every concrete kind that the alias resolves to via subClassOf", async () => {
@@ -571,7 +574,7 @@ describe(".matches() with polymorphic alias", () => {
 
     const mixedBackend = createTestBackend();
     await mixedBackend.bootstrapTables?.();
-    const mixedStore = createStore(MixedGraph, mixedBackend);
+    const mixedStore = await createInitializedStore(MixedGraph, mixedBackend);
 
     await mixedStore.nodes.TextMedia.create({ title: "searchable one" });
     await mixedStore.nodes.BinaryMedia.create({ title: "opaque one" });

--- a/packages/typegraph/tests/no-transactions-fallthrough.test.ts
+++ b/packages/typegraph/tests/no-transactions-fallthrough.test.ts
@@ -17,7 +17,6 @@ import { z } from "zod";
 
 import {
   ConfigurationError,
-  createStore,
   defineEdge,
   defineGraph,
   defineNode,
@@ -27,7 +26,7 @@ import {
 import { generateSqliteDDL } from "../src/backend/drizzle/ddl";
 import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
 import { computeSchemaHash, serializeSchema } from "../src/schema/serializer";
-import { createTestBackend } from "./test-utils";
+import { createInitializedStore, createTestBackend } from "./test-utils";
 
 const TRANSACTIONS_DISABLED_MESSAGE =
   "synthetic backend has transactions disabled";
@@ -101,7 +100,7 @@ describe("backends with transactions: false fall through to sequential execution
   // config.
 
   it("store.transaction(fn) executes fn against the main backend", async () => {
-    const store = createStore(graph, backend);
+    const store = await createInitializedStore(graph, backend);
 
     const result = await store.transaction(async (tx) => {
       const person = await tx.nodes.Person.create({ name: "Alice" });
@@ -120,7 +119,7 @@ describe("backends with transactions: false fall through to sequential execution
   });
 
   it("store.transaction errors propagate without rollback", async () => {
-    const store = createStore(graph, backend);
+    const store = await createInitializedStore(graph, backend);
     const persisted = await store.nodes.Person.create({ name: "Persisted" });
 
     await expect(
@@ -141,7 +140,7 @@ describe("backends with transactions: false fall through to sequential execution
   });
 
   it("store.batch returns per-query results without throwing", async () => {
-    const store = createStore(graph, backend);
+    const store = await createInitializedStore(graph, backend);
 
     await store.nodes.Person.create({ name: "Alice" });
     await store.nodes.Person.create({ name: "Bob" });
@@ -177,7 +176,7 @@ describe("backends with transactions: false fall through to sequential execution
       nodes: { Document: { type: Document } },
       edges: {},
     });
-    const store = createStore(documentGraph, backend);
+    const store = await createInitializedStore(documentGraph, backend);
 
     await store.nodes.Document.create({
       title: "First",

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -6,6 +6,8 @@
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { afterEach } from "vitest";
 
+import type { GraphDef } from "../src";
+import { createStoreWithSchema, type Store } from "../src";
 import type { SqliteTables } from "../src/backend/sqlite";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import type { GraphBackend } from "../src/backend/types";
@@ -41,6 +43,26 @@ export function createTestDatabase(
   const { backend, db } = createLocalSqliteBackend(options);
   backendsToClose.push(backend);
   return db;
+}
+
+/**
+ * Boots a store through the canonical async path
+ * (`createStoreWithSchema`) and returns just the `Store`.
+ *
+ * Post-#135 this is the test idiom for any suite exercising fulltext
+ * (or transactions that touch it): `createStoreWithSchema` is the
+ * single durable-materialization writer, so a sync `createStore`
+ * against an unmaterialized in-memory backend now (correctly) throws
+ * `StoreNotInitializedError` on the first fulltext op. Tests that are
+ * NOT asserting the init contract use this helper to get an
+ * already-initialized store with minimal call-site churn.
+ */
+export async function createInitializedStore<G extends GraphDef>(
+  graph: G,
+  backend: GraphBackend,
+): Promise<Store<G>> {
+  const [store] = await createStoreWithSchema(graph, backend);
+  return store;
 }
 
 export { generateSqliteDDL } from "../src/backend/drizzle/ddl";


### PR DESCRIPTION
Closes #135. Unblocks #134. Builds on #136 (#129 `TableContribution`).

## Problem

Strategy-owned fulltext DDL was materialized lazily behind an in-memory, per-backend-instance boolean latch (`fulltextEnsured`), interleaved into the read/write hot path. Correct only by accident (idempotent DDL + a warm process), at the wrong durability scope, inconsistent with how vector indexes are tracked, and a hard blocker for cross-store transaction adoption (#134).

## Approach

"Is this graph's fulltext storage materialized?" becomes a **durable, queryable database fact**.

- **New `typegraph_contribution_materializations` table** — a sibling of `typegraph_index_materializations` (the declared-index status table is deliberately left untouched; a future PR may migrate it onto this model). Keyed by #129 contribution identity `(graph_id, logical_name, owner, table_name)`; `signature` is a separate content-hash column so same-identity drift is a loud error, not a silent re-materialize. Failed re-attempts preserve the prior success timestamp via the same COALESCE rule as index materializations. New sibling module `contribution-materializations.ts` mirrors the `index-materializations.ts` helper pattern.
- **`createStoreWithSchema()` is the single canonical writer.** It records the marker after the schema version is resolved, covering the cold-initialize path (not just `loadActiveSchemaWithBootstrap`'s active-schema branch). Sync `createStore()` stays a zero-I/O *attach*: it never creates tables, repairs DDL, or writes markers. No new `store.initialize()` API.
- **Hot paths stop ensuring.** The six fulltext-touching methods assert the durable marker (resolved once per backend instance, cached) and throw the new **`StoreNotInitializedError`** (`reason: missing | stale | failed`) instead of lazily emitting DDL.
- **Transaction path: zero DDL by construction.** The tx-scoped backend's fulltext methods assert the cached marker at point of use (a `SELECT`, never `CREATE`). A transaction that never touches fulltext requires no fulltext init; one that does runs pure DML on the adopted transaction — exactly the guarantee #134 needs.
- Same treatment applied to **both** SQLite and Postgres backends.

## Breaking (behavioral)

Fulltext now requires an explicit boot step. Consumers relying on lazy fulltext creation via bare `createStore()` must call `createStoreWithSchema(graph, backend)` once at application startup (outside request handlers / adopted transactions). Consumers already using `createStoreWithSchema` need no changes. Documented in the changeset (`minor`, matching the #136 convention for strategy-breaking changes pre-1.0).

## Verification

- `pnpm fix` clean; `pnpm typecheck` clean
- SQLite: **3094 passed**, 0 failed
- PostgreSQL: **595 passed**, 0 failed (run against a local test container; `pnpm test:postgres`'s default port 5432 is occupied on this machine — environmental, unrelated)
- Fulltext/transaction tests that relied on lazy creation were migrated to the canonical boot path via a `createInitializedStore` test helper / the integration-suite chokepoint; the two `*-fulltext-bootstrap` suites were rewritten to assert the new contract.

Pre-existing and out of scope: `pnpm test:unused` (knip) is already red on `main` (stale `vector-index.ts` ignore in `knip.config.ts`); verified by stashing.