### PR TITLE
feat: cross-store transaction adoption (closes #134)

### DIFF
--- a/.changeset/cross-store-transaction-adoption.md
+++ b/.changeset/cross-store-transaction-adoption.md
@@ -1,0 +1,56 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Cross-store atomicity: share one transaction across the TypeGraph store and an
+external Drizzle connection (#134).
+
+Applications that persist into the same database through two layers — Drizzle
+for relational rows and TypeGraph for graph nodes/edges — previously had no way
+to make a write that spans both layers all-or-nothing. `store.transaction()`
+and `db.transaction()` each opened a *separate* transaction on a *separate*
+connection, so a failure between the two writes left either a stray relational
+row or a committed graph node with a dangling foreign reference.
+
+**What ships (additive — no breaking changes):**
+
+- New `Store.withTransaction(externalTx): TransactionContext<G>`. The caller
+  owns the transaction; `store.withTransaction(sqlTx)` returns a
+  transaction-scoped `{ nodes, edges }` bound to that *exact* connection, so
+  both layers commit or roll back together. It is driver-agnostic; how you
+  open the transaction is not.
+
+  Async drivers (node-postgres, `neon-serverless` Pool, libsql):
+
+  ```ts
+  await db.transaction(async (sqlTx) => {
+    const connector = await createConnectorRow(sqlTx, input); // Drizzle
+    const txStore = store.withTransaction(sqlTx);
+    await txStore.nodes.ArtifactSource.create({                // TypeGraph
+      connectorId: connector.id,
+    });
+  }); // one COMMIT / ROLLBACK
+  ```
+
+  Synchronous `better-sqlite3` cannot use `db.transaction(async …)` (its
+  driver rejects an `async` callback); open the transaction with explicit
+  `BEGIN`/`COMMIT`/`ROLLBACK` instead and pass the connection to
+  `withTransaction`. See the "Cross-Store Transactions" recipe for both
+  shapes.
+
+- New optional `GraphBackend.adoptTransaction(externalTx)` member, implemented
+  by the Drizzle Postgres and SQLite backends, plus the new `AdoptedTransaction`
+  type.
+
+**Guarantees.** The adopted context reuses the parent store's already-resolved
+schema: it runs no `createStoreWithSchema` / `evolve` / `migrateSchema` and
+emits **no DDL inside the caller's business transaction**. Building on #135,
+fulltext operations assert the durable materialization marker (a cached
+`SELECT`, never DDL) and throw `StoreNotInitializedError` on a
+missing/stale/failed marker rather than migrating mid-transaction — so boot the
+parent store via `createStoreWithSchema` once at startup. When the backend
+cannot provide real rollback (`backend.capabilities.transactions === false`:
+`drizzle-orm/neon-http`, Cloudflare D1, SQLite `transactionMode: "none"`),
+`withTransaction` throws `ConfigurationError` rather than silently degrading —
+a non-atomic fallback is safe for graph-only writes but dangerous for
+cross-store flows, where the caller's relational write *would* still commit.

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ yarn-error.log
 # Stryker mutation testing
 .stryker-cache/
 reports/
+.gstack/

--- a/apps/docs/src/content/docs/recipes.md
+++ b/apps/docs/src/content/docs/recipes.md
@@ -574,6 +574,84 @@ async function cascadeDelete(documentId: string): Promise<void> {
 }
 ```
 
+### Cross-Store Transactions (Drizzle + TypeGraph)
+
+When your app writes to the **same database** through both a directly-owned
+Drizzle connection (relational rows) and a TypeGraph `Store`, use
+`store.withTransaction(sqlTx)` to enlist both layers in **one** transaction.
+The caller owns the transaction boundary; TypeGraph adopts that exact
+connection, so a failure rolls back both layers — no stray relational row, no
+graph node with a dangling foreign reference.
+
+How you open the transaction depends on whether your driver is async or
+synchronous. `withTransaction` itself is driver-agnostic — it adopts whatever
+connection you hand it.
+
+**Async drivers** — node-postgres, `neon-serverless` (Pool/WebSocket), libsql.
+Use Drizzle's `db.transaction(async …)`:
+
+```typescript
+await db.transaction(async (sqlTx) => {
+  const [connector] = await sqlTx
+    .insert(connectors)
+    .values({ name: "github" })
+    .returning({ id: connectors.id });
+
+  const txStore = store.withTransaction(sqlTx);
+  await txStore.nodes.ArtifactSource.create({
+    connectorId: connector.id,
+    label: "primary",
+  });
+}); // one COMMIT / ROLLBACK across both layers
+```
+
+**Synchronous `better-sqlite3`.** better-sqlite3 is a synchronous driver:
+Drizzle's `db.transaction()` rejects an `async` callback (`Transaction
+function cannot return a promise`), and the async continuation would then run
+*outside* the rolled-back transaction. Open the transaction with explicit
+`BEGIN`/`COMMIT`/`ROLLBACK` on the single connection instead, and pass that
+connection to `withTransaction`:
+
+```typescript
+db.run(sql`BEGIN`);
+try {
+  const [connector] = db
+    .insert(connectors)
+    .values({ name: "github" })
+    .returning({ id: connectors.id })
+    .all();
+
+  const txStore = store.withTransaction(db);
+  await txStore.nodes.ArtifactSource.create({
+    connectorId: connector.id,
+    label: "primary",
+  });
+  db.run(sql`COMMIT`);
+} catch (error) {
+  db.run(sql`ROLLBACK`);
+  throw error;
+}
+```
+
+This is safe because better-sqlite3 is a single, single-threaded connection:
+the `await` between statements only yields the microtask queue, and nothing
+else touches the connection between `BEGIN` and `COMMIT`/`ROLLBACK`. Do not
+interleave other async work that writes to the same connection inside the
+`try`.
+
+The adopted context exposes the `{ nodes, edges }` surface (same as
+`store.transaction`) and reuses the parent store's resolved schema — it runs
+no migration and emits no DDL inside your transaction. Boot the parent store
+once at startup with `createStoreWithSchema(graph, backend)` so fulltext-backed
+writes find their durable materialization marker; an uninitialized store
+throws `StoreNotInitializedError` instead of migrating mid-transaction.
+
+`withTransaction` throws `ConfigurationError` on backends that cannot provide
+real rollback (`backend.capabilities.transactions === false`:
+`drizzle-orm/neon-http`, Cloudflare D1, SQLite `transactionMode: "none"`) —
+it never silently degrades to a non-atomic fallback, because the relational
+write would still commit.
+
 ## Enforcing Unique Constraints
 
 Prevent duplicate nodes or relationships.

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -43,6 +43,7 @@ import {
   tsvectorStrategy,
 } from "../../query/dialect/fulltext-strategy";
 import {
+  type AdoptedTransaction,
   type BackendCapabilities,
   type CommitSchemaVersionParams,
   type ContributionMaterializationIdentity,
@@ -468,6 +469,22 @@ export function createPostgresBackend(
     recordMarker: recordContributionMaterializationRow,
   });
 
+  // Shared by `transaction()` (TypeGraph opens the tx) and
+  // `adoptTransaction()` (#134 — the caller already opened it): bind a
+  // tx-scoped backend to the *literal* `tx` client and gate fulltext on
+  // the durable marker (a cached SELECT, never DDL).
+  function bindTransactionBackend(tx: AnyPgDatabase): TransactionBackend {
+    const txBackend = createTransactionBackend({
+      db: tx,
+      adapterOptions,
+      operationStrategy,
+      tableNames,
+      capabilities,
+      fulltextStrategy,
+    });
+    return gateFulltext(txBackend, contributionMaterializer.assertInitialized);
+  }
+
   const backend: GraphBackend = {
     ...operations,
 
@@ -729,17 +746,37 @@ export function createPostgresBackend(
           }
         : undefined;
 
-      return db.transaction(async (tx) => {
-        const txBackend = createTransactionBackend({
-          db: tx,
-          adapterOptions,
-          operationStrategy,
-          tableNames,
-          capabilities,
-          fulltextStrategy,
-        });
-        return fn(gateFulltext(txBackend, contributionMaterializer.assertInitialized));
-      }, txConfig);
+      return db.transaction(
+        async (tx) => fn(bindTransactionBackend(tx)),
+        txConfig,
+      );
+    },
+
+    adoptTransaction(externalTx: AdoptedTransaction): TransactionBackend {
+      // #134: cross-store atomicity is unsafe without real rollback —
+      // the caller's relational write on `externalTx` *would* still
+      // commit even though the graph write could not be undone. Refuse
+      // loudly rather than silently degrade.
+      if (!capabilities.transactions) {
+        throw new ConfigurationError(
+          "Cross-store atomicity is unavailable on this Postgres backend: " +
+            "its driver does not support transactions (drizzle-orm/neon-http, " +
+            "Cloudflare D1). Adopting an external transaction here would let " +
+            "the caller's relational write commit with no way to roll back " +
+            "the graph write. Use a node-postgres or neon-serverless " +
+            "(Pool/WebSocket) connection for cross-store transactions.",
+          {
+            backend: "postgres",
+            capability: "transactions",
+            supportsTransactions: false,
+          },
+        );
+      }
+      // The caller owns BEGIN/COMMIT/ROLLBACK via its own
+      // `db.transaction(...)`. We adopt the literal `tx` client and run
+      // pure DML on it — no transaction is opened or closed here, and no
+      // DDL is emitted inside the caller's business transaction.
+      return bindTransactionBackend(externalTx as AnyPgDatabase);
     },
 
     async close(): Promise<void> {

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -37,6 +37,7 @@ import {
   type FulltextStrategy,
 } from "../../query/dialect/fulltext-strategy";
 import {
+  type AdoptedTransaction,
   type BackendCapabilities,
   type CommitSchemaVersionParams,
   type ContributionMaterializationIdentity,
@@ -755,6 +756,25 @@ export function createSqliteBackend(
     recordMarker: recordContributionMaterializationRow,
   });
 
+  // Shared by the "drizzle" branch of `transaction()` (TypeGraph opens
+  // the tx) and `adoptTransaction()` (#134 — the caller already opened
+  // it): bind a tx-scoped backend to the *literal* `tx` client and gate
+  // fulltext on the durable marker (a cached SELECT, never DDL).
+  function bindTransactionBackend(
+    tx: AnySqliteDatabase,
+  ): TransactionBackend {
+    const txBackend = createTransactionBackend({
+      capabilities,
+      db: tx,
+      operationStrategy,
+      profileHints: { isSync },
+      tableNames,
+      fulltextStrategy,
+      hasVectorEmbeddings,
+    });
+    return gateFulltext(txBackend, contributionMaterializer.assertInitialized);
+  }
+
   const backend: GraphBackend = {
     ...operations,
 
@@ -1045,21 +1065,40 @@ export function createSqliteBackend(
 
       // transactionMode === "drizzle"
       return runWithSerializedQueue(serializedQueue, async () =>
-        db.transaction(async (tx) => {
-          const txBackend = createTransactionBackend({
-            capabilities,
-            db: tx,
-            operationStrategy,
-            profileHints: { isSync },
-            tableNames,
-            fulltextStrategy,
-            hasVectorEmbeddings,
-          });
-          return fn(
-            gateFulltext(txBackend, contributionMaterializer.assertInitialized),
-          );
-        }) as Promise<T>,
+        db.transaction(
+          async (tx) => fn(bindTransactionBackend(tx)),
+        ) as Promise<T>,
       );
+    },
+
+    adoptTransaction(externalTx: AdoptedTransaction): TransactionBackend {
+      // #134: parity with Postgres. Cross-store atomicity needs real
+      // rollback; on a "none" driver the caller's relational write
+      // would commit with no way to undo the graph write. Refuse
+      // loudly rather than silently degrade.
+      if (transactionMode === "none") {
+        throw new ConfigurationError(
+          "Cross-store atomicity is unavailable on this SQLite backend: " +
+            "transactions are disabled (transactionMode: 'none'). Adopting " +
+            "an external transaction here would let the caller's relational " +
+            "write commit with no way to roll back the graph write. " +
+            "Configure a driver that supports transactions (better-sqlite3, " +
+            "libsql, bun:sqlite).",
+          {
+            backend: "sqlite",
+            capability: "transactions",
+            supportsTransactions: false,
+          },
+        );
+      }
+      // The caller owns the transaction *and* the connection's
+      // serialization: a sync better-sqlite3 driver runs the adopted
+      // statements on the caller's stack, so the backend's own
+      // `serializedQueue` is deliberately not applied here — wrapping a
+      // caller-driven tx in our queue could deadlock against the
+      // caller's outer `db.transaction(...)`. We bind the literal `tx`
+      // and run pure DML; no transaction is opened or closed here.
+      return bindTransactionBackend(externalTx as AnySqliteDatabase);
     },
 
     close(): Promise<void> {

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -14,6 +14,10 @@ import {
 import { type SqlTableNames } from "../query/compiler/schema";
 import { type FulltextStrategy } from "../query/dialect/fulltext-strategy";
 import { type SerializedSchema } from "../schema/types";
+import {
+  type AnyPgDatabase,
+  type AnySqliteDatabase,
+} from "./drizzle/execution";
 
 // ============================================================
 // Vector Search Types
@@ -655,6 +659,22 @@ export type TransactionOptions = Readonly<{
     | "serializable";
 }>;
 
+/**
+ * A caller-owned, already-open Drizzle transaction handle that a
+ * TypeGraph store can adopt so both layers commit/rollback together.
+ *
+ * The literal client the caller's transaction runs on — a `PgDatabase`
+ * transaction (node-postgres / `neon-serverless` Pool) or a
+ * `BaseSQLiteDatabase` connection. Async drivers obtain it from
+ * `db.transaction(async (tx) => …)`; synchronous `better-sqlite3` (whose
+ * driver rejects an `async` transaction callback) passes the connection
+ * itself under an explicit `BEGIN`/`COMMIT`/`ROLLBACK`. Passing it to
+ * {@link GraphBackend.adoptTransaction} threads that *literal* client
+ * through TypeGraph's SQL, so graph writes and the caller's own
+ * relational writes share one Postgres/SQLite transaction (#134).
+ */
+export type AdoptedTransaction = AnyPgDatabase | AnySqliteDatabase;
+
 // ============================================================
 // Backend Interface
 // ============================================================
@@ -675,6 +695,7 @@ export type TransactionOptions = Readonly<{
 export type TransactionBackend = Omit<
   GraphBackend,
   | "transaction"
+  | "adoptTransaction"
   | "close"
   | "refreshStatistics"
   | "commitSchemaVersion"
@@ -1119,6 +1140,36 @@ export type GraphBackend = Readonly<{
     fn: (tx: TransactionBackend) => Promise<T>,
     options?: TransactionOptions,
   ) => Promise<T>;
+
+  /**
+   * Adopt a caller-owned, already-open transaction (#134).
+   *
+   * Returns a transaction-scoped backend bound to the *exact*
+   * `externalTx` client, reusing this backend's already-resolved
+   * schema/strategy config — no `createStoreWithSchema` / `evolve` /
+   * `migrateSchema`, and **no DDL inside the caller's business
+   * transaction**. The caller owns `BEGIN`/`COMMIT`/`ROLLBACK`; this
+   * method neither opens nor closes a transaction. Async drivers
+   * (node-postgres, `neon-serverless` Pool, libsql) wrap with
+   * `db.transaction(async …)`; synchronous `better-sqlite3` must instead
+   * issue explicit `BEGIN`/`COMMIT`/`ROLLBACK` (its driver rejects an
+   * `async` transaction callback).
+   *
+   * Optional and presence-detected like the other capability-scoped
+   * members: only the Drizzle Postgres/SQLite backends provide it.
+   * Implementations MUST throw (not silently degrade) when
+   * `capabilities.transactions` is `false` — a non-atomic fallback is
+   * safe for graph-only writes but dangerous for cross-store flows,
+   * where the caller's relational write *would* still commit.
+   *
+   * Fulltext stays safe by construction: the returned backend's
+   * fulltext methods assert the durable materialization marker (a
+   * cached SELECT, never DDL) at point of use and throw
+   * `StoreNotInitializedError` on a missing/stale/failed marker rather
+   * than migrating mid-transaction. Prefer booting the parent store via
+   * `createStoreWithSchema` so that assertion is a warm-cache no-op.
+   */
+  adoptTransaction?: (externalTx: AdoptedTransaction) => TransactionBackend;
 
   // === Lifecycle ===
   close: () => Promise<void>;

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -105,6 +105,7 @@ export type {
 } from "./backend/table-contribution";
 export { isDrizzleContribution } from "./backend/table-contribution";
 export type {
+  AdoptedTransaction,
   BackendCapabilities,
   CommitSchemaVersionExpected,
   CommitSchemaVersionParams,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -11,6 +11,7 @@
 import type { z } from "zod";
 
 import {
+  type AdoptedTransaction,
   type GraphBackend,
   runOptionallyInTransaction,
   type SchemaVersionRow,
@@ -851,34 +852,112 @@ export class Store<G extends GraphDef> {
     // tx-scoped fulltext methods so the durable-marker assert fires at
     // point of use (a cached SELECT, never DDL). A transaction that
     // never touches fulltext requires no fulltext initialization.
-    return this.#backend.transaction(async (txBackend) => {
-      const txNodeOperations: NodeOperations = {
-        ...this.#nodeOperations,
-        createQuery: () => this.#createQueryForBackend(txBackend),
-      };
-      const txEdgeOperations: EdgeOperations = {
-        ...this.#edgeOperations,
-        createQuery: () => this.#createQueryForBackend(txBackend),
-      };
+    return this.#backend.transaction(async (txBackend) =>
+      fn(this.#buildTransactionContext(txBackend)),
+    );
+  }
 
-      const nodes = createNodeCollectionsProxy(
-        this.#graph,
-        this.graphId,
-        this.#registry,
-        txBackend,
-        txNodeOperations,
+  /**
+   * Adopts a caller-owned, already-open Drizzle transaction so the graph
+   * store and the caller's relational writes commit or roll back as one
+   * Postgres/SQLite transaction (#134).
+   *
+   * Use this when the **relational layer owns the transaction**: the
+   * caller has opened a transaction and needs TypeGraph writes enlisted
+   * on the *same* connection. Unlike {@link transaction}, this opens no
+   * transaction — the caller's transaction is the single commit/rollback
+   * boundary.
+   *
+   * `withTransaction` is driver-agnostic; how the caller opens the
+   * transaction is not. **Async drivers** (node-postgres,
+   * `neon-serverless` Pool, libsql) use `db.transaction(async …)`.
+   * **Synchronous `better-sqlite3`** cannot — its driver rejects an
+   * `async` transaction callback (`Transaction function cannot return a
+   * promise`) and the async continuation would run outside the
+   * rolled-back transaction — so the caller opens the transaction with
+   * explicit `BEGIN`/`COMMIT`/`ROLLBACK` on the single connection
+   * instead. See the "Cross-Store Transactions" recipe for both shapes.
+   *
+   * The returned context reuses this store's already-resolved
+   * schema/registry: it runs **no** schema bootstrap, `evolve`, or
+   * migration, and emits **no DDL** inside the caller's transaction.
+   * Fulltext operations assert the durable materialization marker (a
+   * cached SELECT) and throw {@link StoreNotInitializedError} on a
+   * missing/stale/failed marker rather than migrating mid-transaction —
+   * so boot the parent store via `createStoreWithSchema` once at
+   * startup.
+   *
+   * @example
+   * ```typescript
+   * // Async driver (Postgres / libsql):
+   * await db.transaction(async (sqlTx) => {
+   *   const connector = await createConnectorRow(sqlTx, input); // Drizzle
+   *   const txStore = store.withTransaction(sqlTx);
+   *   await txStore.nodes.ArtifactSource.create({              // TypeGraph
+   *     connectorId: connector.id,
+   *   });
+   * }); // one COMMIT / ROLLBACK across both layers
+   * ```
+   *
+   * @throws {ConfigurationError} when the backend cannot adopt an
+   *   external transaction — either it is not a Drizzle Postgres/SQLite
+   *   backend, or `backend.capabilities.transactions` is `false`
+   *   (`drizzle-orm/neon-http`, Cloudflare D1, SQLite
+   *   `transactionMode: "none"`). A non-atomic fallback is deliberately
+   *   not offered here: the caller's relational write *would* still
+   *   commit, defeating the purpose of cross-store atomicity.
+   */
+  withTransaction(externalTx: AdoptedTransaction): TransactionContext<G> {
+    const adopt = this.#backend.adoptTransaction;
+    if (!adopt) {
+      throw new ConfigurationError(
+        "This backend cannot adopt an external transaction for cross-store " +
+          "atomicity. adoptTransaction is provided only by the Drizzle " +
+          "Postgres/SQLite backends with transaction support. Check " +
+          "backend.capabilities.transactions, or run the relational and " +
+          "graph writes as separate transactions with manual compensation.",
+        { capability: "adoptTransaction" },
       );
+    }
+    return this.#buildTransactionContext(adopt(externalTx));
+  }
 
-      const edges = createEdgeCollectionsProxy(
-        this.#graph,
-        this.graphId,
-        this.#registry,
-        txBackend,
-        txEdgeOperations,
-      );
+  /**
+   * Builds the `{ nodes, edges }` projection bound to a transaction-
+   * scoped backend. Shared verbatim by {@link transaction} (TypeGraph
+   * opens the tx) and {@link withTransaction} (#134 — the caller opened
+   * it) so both surfaces resolve collections, query factories, and the
+   * reused graph/registry identically.
+   */
+  #buildTransactionContext(
+    txBackend: TransactionBackend,
+  ): TransactionContext<G> {
+    const txNodeOperations: NodeOperations = {
+      ...this.#nodeOperations,
+      createQuery: () => this.#createQueryForBackend(txBackend),
+    };
+    const txEdgeOperations: EdgeOperations = {
+      ...this.#edgeOperations,
+      createQuery: () => this.#createQueryForBackend(txBackend),
+    };
 
-      return fn({ nodes, edges });
-    });
+    const nodes = createNodeCollectionsProxy(
+      this.#graph,
+      this.graphId,
+      this.#registry,
+      txBackend,
+      txNodeOperations,
+    );
+
+    const edges = createEdgeCollectionsProxy(
+      this.#graph,
+      this.graphId,
+      this.#registry,
+      txBackend,
+      txEdgeOperations,
+    );
+
+    return { nodes, edges };
   }
 
   // === Graph Lifecycle ===

--- a/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
@@ -1,0 +1,238 @@
+/**
+ * #134: cross-store atomicity on PostgreSQL — a TypeGraph store and a
+ * caller-owned node-postgres Drizzle connection sharing ONE Postgres
+ * transaction via `store.withTransaction(externalTx)`.
+ *
+ * This is the canonical Direction-A shape from the issue: the caller
+ * owns `db.transaction(async (sqlTx) => …)`, writes a relational row,
+ * then enlists a TypeGraph node on the *same* connection. SQLite mirror
+ * at `tests/cross-store-transaction.test.ts`.
+ *
+ * Skipped unless `POSTGRES_URL` is set (or `scripts/test-postgres.sh`).
+ */
+import { getTableName } from "drizzle-orm";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { pgTable, serial, text } from "drizzle-orm/pg-core";
+import { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  ConfigurationError,
+  createStore,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  searchable,
+  StoreNotInitializedError,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import {
+  createPostgresBackend,
+  tables as defaultTables,
+} from "../../../src/backend/postgres";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let pool: Pool | undefined;
+let db: NodePgDatabase | undefined;
+let postgresAvailable = false;
+
+// The caller's own relational table (Drizzle-owned, NOT a TypeGraph
+// table). Distinct name so this suite does not collide with others
+// sharing the test database.
+const connectors = pgTable("cross_store_connectors", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+});
+
+const ArtifactSource = defineNode("ArtifactSource", {
+  schema: z.object({
+    connectorId: z.number().int(),
+    label: z.string(),
+  }),
+});
+
+const PlainGraph = defineGraph({
+  id: "pg_cross_store_plain",
+  nodes: { ArtifactSource: { type: ArtifactSource } },
+  edges: {},
+});
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    connectorId: z.number().int(),
+    title: searchable({ language: "english" }),
+  }),
+});
+
+const FtGraph = defineGraph({
+  id: "pg_cross_store_fulltext",
+  nodes: { Doc: { type: Document } },
+  edges: {},
+});
+
+const CONTRIB_MAT_TABLE = getTableName(
+  defaultTables.contributionMaterializations,
+);
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  try {
+    pool = new Pool({ connectionString: TEST_DATABASE_URL });
+    await pool.query("SELECT 1");
+    await pool.query(generatePostgresMigrationSQL());
+    await pool.query(
+      `CREATE TABLE IF NOT EXISTS cross_store_connectors (
+         id SERIAL PRIMARY KEY, name TEXT NOT NULL)`,
+    );
+    db = drizzle(pool);
+    postgresAvailable = true;
+  } catch {
+    postgresAvailable = false;
+  }
+});
+
+afterAll(async () => {
+  if (pool && postgresAvailable) {
+    await pool.query(generatePostgresMigrationSQL());
+  }
+  if (pool) await pool.end();
+});
+
+describe.runIf(process.env.POSTGRES_URL)(
+  "PostgreSQL cross-store atomicity (#134)",
+  () => {
+    beforeEach(async () => {
+      if (!postgresAvailable || !pool) return;
+      await pool.query("TRUNCATE cross_store_connectors RESTART IDENTITY");
+      await pool.query(
+        `TRUNCATE typegraph_nodes, typegraph_edges,
+                  typegraph_node_uniques, typegraph_node_fulltext,
+                  typegraph_schema_versions CASCADE`,
+      );
+      await pool.query(`DELETE FROM ${CONTRIB_MAT_TABLE} WHERE graph_id = $1`, [
+        FtGraph.id,
+      ]);
+    });
+
+    it("commits a relational row and a graph node in one transaction", async () => {
+      const backend = createPostgresBackend(db!);
+      const store = createStore(PlainGraph, backend);
+
+      const sourceId = await db!.transaction(async (sqlTx) => {
+        const insertedConnectors = await sqlTx
+          .insert(connectors)
+          .values({ name: "github" })
+          .returning({ id: connectors.id });
+        const connectorId = insertedConnectors[0]!.id;
+        const txStore = store.withTransaction(sqlTx);
+        const source = await txStore.nodes.ArtifactSource.create({
+          connectorId,
+          label: "primary",
+        });
+        return source.id;
+      });
+
+      const rows = await db!.select().from(connectors);
+      expect(rows).toEqual([{ id: 1, name: "github" }]);
+      const fetched = await store.nodes.ArtifactSource.getById(sourceId);
+      expect(fetched?.connectorId).toBe(1);
+    });
+
+    it("rolls back BOTH layers when the caller's transaction throws", async () => {
+      const backend = createPostgresBackend(db!);
+      const store = createStore(PlainGraph, backend);
+
+      await expect(
+        db!.transaction(async (sqlTx) => {
+          await sqlTx.insert(connectors).values({ name: "orphan" });
+          const txStore = store.withTransaction(sqlTx);
+          await txStore.nodes.ArtifactSource.create({
+            connectorId: 999,
+            label: "doomed",
+          });
+          throw new Error("business failure after both writes");
+        }),
+      ).rejects.toThrow("business failure after both writes");
+
+      expect(await db!.select().from(connectors)).toEqual([]);
+      expect(await store.nodes.ArtifactSource.find()).toEqual([]);
+    });
+
+    it("commits a fulltext write with a relational row when the store is booted", async () => {
+      const [store] = await createStoreWithSchema(
+        FtGraph,
+        createPostgresBackend(db!),
+      );
+
+      const documentId = await db!.transaction(async (sqlTx) => {
+        const insertedConnectors = await sqlTx
+          .insert(connectors)
+          .values({ name: "drive" })
+          .returning({ id: connectors.id });
+        const connectorId = insertedConnectors[0]!.id;
+        const txStore = store.withTransaction(sqlTx);
+        const document = await txStore.nodes.Doc.create({
+          connectorId,
+          title: "quarterly revenue report",
+        });
+        return document.id;
+      });
+
+      expect(await db!.select().from(connectors)).toHaveLength(1);
+      const hits = await store.search.fulltext("Doc", {
+        query: "revenue",
+        limit: 10,
+      });
+      expect(hits.map((hit) => hit.node.id)).toEqual([documentId]);
+    });
+
+    it("refuses loudly (and rolls back the relational write) when the store is not booted", async () => {
+      // Strategy-owned fulltext table dropped + no durable marker: the
+      // exact uninitialized state the gate must refuse on.
+      await pool!.query(
+        `DROP TABLE IF EXISTS ${defaultTables.fulltextTableName}`,
+      );
+      const backend = createPostgresBackend(db!);
+      const store = createStore(FtGraph, backend);
+
+      await expect(
+        db!.transaction(async (sqlTx) => {
+          await sqlTx.insert(connectors).values({ name: "premature" });
+          const txStore = store.withTransaction(sqlTx);
+          await txStore.nodes.Doc.create({
+            connectorId: 1,
+            title: "should not persist",
+          });
+        }),
+      ).rejects.toBeInstanceOf(StoreNotInitializedError);
+
+      // The caller's relational write rolled back with the refusal.
+      expect(await db!.select().from(connectors)).toEqual([]);
+      // Restore the shared fulltext table for downstream suites.
+      await pool!.query(generatePostgresMigrationSQL());
+    });
+
+    it("exposes adoptTransaction with transactions capability", () => {
+      const backend = createPostgresBackend(db!);
+      expect(backend.capabilities.transactions).toBe(true);
+      expect(backend.adoptTransaction).toBeTypeOf("function");
+    });
+
+    it("rejects withTransaction when the backend cannot adopt a transaction", () => {
+      // A backend whose driver reports no transaction support must not
+      // silently degrade — the relational write would still commit.
+      const backend = createPostgresBackend(db!, {
+        capabilities: { transactions: false },
+      });
+      const store = createStore(PlainGraph, backend);
+      expect(() => store.withTransaction(db!)).toThrow(ConfigurationError);
+      expect(() => store.withTransaction(db!)).toThrow(
+        /Cross-store atomicity is unavailable/,
+      );
+    });
+  },
+);

--- a/packages/typegraph/tests/backends/sqlite/libsql-cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/libsql-cross-store-transaction.test.ts
@@ -1,0 +1,121 @@
+/**
+ * #134: cross-store atomicity on libsql — proves the *documented async*
+ * shape `db.transaction(async (sqlTx) => store.withTransaction(sqlTx))`
+ * works for a sqlite-family async driver, not just Postgres.
+ *
+ * better-sqlite3 (synchronous) uses the raw BEGIN/COMMIT shape instead;
+ * that path is covered in `tests/cross-store-transaction.test.ts`.
+ *
+ * libsql opens transactions on a separate connection, so in-memory
+ * databases break (tursodatabase/libsql-client-ts#229) — use a temp
+ * file, mirroring `libsql-backend.test.ts`.
+ */
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createClient } from "@libsql/client";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStore, defineGraph, defineNode } from "../../../src";
+import { createLibsqlBackend } from "../../../src/backend/sqlite/libsql";
+
+const temporaryFiles: string[] = [];
+
+function createTemporaryDbPath(): string {
+  const dbPath = path.join(
+    tmpdir(),
+    `typegraph-libsql-xstore-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}.db`,
+  );
+  temporaryFiles.push(dbPath);
+  return dbPath;
+}
+
+afterEach(() => {
+  for (const dbPath of temporaryFiles.splice(0)) {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      const filePath = dbPath + suffix;
+      if (existsSync(filePath)) unlinkSync(filePath);
+    }
+  }
+});
+
+const connectors = sqliteTable("connectors", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+});
+
+const ArtifactSource = defineNode("ArtifactSource", {
+  schema: z.object({
+    connectorId: z.number().int(),
+    label: z.string(),
+  }),
+});
+
+const PlainGraph = defineGraph({
+  id: "libsql-cross-store",
+  nodes: { ArtifactSource: { type: ArtifactSource } },
+  edges: {},
+});
+
+describe("#134 cross-store atomicity (libsql, documented async shape)", () => {
+  it("commits a relational row and a graph node in one db.transaction()", async () => {
+    const client = createClient({ url: `file:${createTemporaryDbPath()}` });
+    const { backend, db } = await createLibsqlBackend(client);
+    await client.execute(
+      "CREATE TABLE connectors (" +
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+    );
+    const store = createStore(PlainGraph, backend);
+
+    const sourceId = await db.transaction(async (sqlTx) => {
+      const inserted = await sqlTx
+        .insert(connectors)
+        .values({ name: "github" })
+        .returning({ id: connectors.id });
+      const txStore = store.withTransaction(sqlTx);
+      const source = await txStore.nodes.ArtifactSource.create({
+        connectorId: inserted[0]!.id,
+        label: "primary",
+      });
+      return source.id;
+    });
+
+    expect(await db.select().from(connectors)).toEqual([
+      { id: 1, name: "github" },
+    ]);
+    const fetched = await store.nodes.ArtifactSource.getById(sourceId);
+    expect(fetched?.connectorId).toBe(1);
+    client.close();
+  });
+
+  it("rolls back BOTH layers when the async callback throws", async () => {
+    const client = createClient({ url: `file:${createTemporaryDbPath()}` });
+    const { backend, db } = await createLibsqlBackend(client);
+    await client.execute(
+      "CREATE TABLE connectors (" +
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+    );
+    const store = createStore(PlainGraph, backend);
+
+    await expect(
+      db.transaction(async (sqlTx) => {
+        await sqlTx.insert(connectors).values({ name: "orphan" });
+        const txStore = store.withTransaction(sqlTx);
+        await txStore.nodes.ArtifactSource.create({
+          connectorId: 999,
+          label: "doomed",
+        });
+        throw new Error("business failure after both writes");
+      }),
+    ).rejects.toThrow("business failure after both writes");
+
+    expect(await db.select().from(connectors)).toEqual([]);
+    expect(await store.nodes.ArtifactSource.find()).toEqual([]);
+    client.close();
+  });
+});

--- a/packages/typegraph/tests/cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/cross-store-transaction.test.ts
@@ -1,0 +1,250 @@
+/**
+ * #134: cross-store atomicity — a TypeGraph store and a caller-owned
+ * Drizzle connection sharing ONE SQLite transaction via
+ * `store.withTransaction(externalTx)`.
+ *
+ * The canonical shape: the caller opens a transaction, writes a
+ * relational row, then a TypeGraph node that references it — and both
+ * commit or roll back as one unit. `withTransaction` adopts the
+ * caller's literal connection (no nested transaction, no schema
+ * bootstrap, no DDL in the business transaction).
+ *
+ * Postgres parity lives in
+ * `tests/backends/postgres/postgres-cross-store-transaction.test.ts`.
+ */
+import Database from "better-sqlite3";
+import {
+  type BetterSQLite3Database,
+  drizzle,
+} from "drizzle-orm/better-sqlite3";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  ConfigurationError,
+  createStore,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  searchable,
+  StoreNotInitializedError,
+} from "../src";
+import { generateSqliteDDL } from "../src/backend/drizzle/ddl";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
+import { tables as defaultTables } from "../src/backend/sqlite";
+
+// The caller's own relational table (Drizzle-owned, NOT a TypeGraph
+// table) — the "Connector" row a graph node will point at.
+const connectors = sqliteTable("connectors", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+});
+
+// Graph-dominant, no searchable fields: a node create is a pure INSERT,
+// so the adopted-tx path never touches fulltext and needs no boot.
+const ArtifactSource = defineNode("ArtifactSource", {
+  schema: z.object({
+    connectorId: z.number().int(),
+    label: z.string(),
+  }),
+});
+
+const PlainGraph = defineGraph({
+  id: "cross-store-plain",
+  nodes: { ArtifactSource: { type: ArtifactSource } },
+  edges: {},
+});
+
+// Fulltext-bearing variant: a node create also writes the FTS5 table,
+// so the adopted-tx path asserts the durable materialization marker.
+const Document = defineNode("Doc", {
+  schema: z.object({
+    connectorId: z.number().int(),
+    title: searchable({ language: "english" }),
+  }),
+});
+
+const FtGraph = defineGraph({
+  id: "cross-store-fulltext",
+  nodes: { Doc: { type: Document } },
+  edges: {},
+});
+
+function createSqlite(): {
+  sqlite: Database.Database;
+  db: BetterSQLite3Database;
+} {
+  const sqlite = new Database(":memory:");
+  // Base TypeGraph tables only — the FTS5 virtual table is filtered out
+  // (the post-`drizzle-kit push` state). createStoreWithSchema is the
+  // single writer that materializes it; the not-booted test relies on
+  // it being absent to prove the gate emits no DDL.
+  const baseDdl = generateSqliteDDL(defaultTables).filter(
+    (statement) => !statement.includes(defaultTables.fulltextTableName),
+  );
+  for (const statement of baseDdl) {
+    sqlite.exec(statement);
+  }
+  // The caller's own relational table.
+  sqlite.exec(
+    "CREATE TABLE connectors (" +
+      "id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+  );
+  return { sqlite, db: drizzle(sqlite) };
+}
+
+describe("#134 cross-store atomicity (SQLite)", () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database;
+
+  beforeEach(() => {
+    ({ sqlite, db } = createSqlite());
+  });
+
+  it("commits a relational row and a graph node in one transaction", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    // No createStoreWithSchema: a non-fulltext adopted-tx flow needs no
+    // boot — proving "a transaction that never touches fulltext requires
+    // no fulltext initialization".
+    const store = createStore(PlainGraph, backend);
+
+    // The caller owns BEGIN / COMMIT on its own connection.
+    sqlite.exec("BEGIN");
+    const txStore = store.withTransaction(db);
+    const connectorId = db
+      .insert(connectors)
+      .values({ name: "github" })
+      .returning({ id: connectors.id })
+      .all()[0]!.id;
+    const source = await txStore.nodes.ArtifactSource.create({
+      connectorId,
+      label: "primary",
+    });
+    sqlite.exec("COMMIT");
+
+    expect(db.select().from(connectors).all()).toEqual([
+      { id: connectorId, name: "github" },
+    ]);
+    const fetched = await store.nodes.ArtifactSource.getById(source.id);
+    expect(fetched?.connectorId).toBe(connectorId);
+    sqlite.close();
+  });
+
+  it("rolls back BOTH layers when the caller's transaction fails (no dangling reference)", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    const store = createStore(PlainGraph, backend);
+
+    sqlite.exec("BEGIN");
+    let caught: unknown;
+    try {
+      const txStore = store.withTransaction(db);
+      db.insert(connectors).values({ name: "orphan" }).run();
+      await txStore.nodes.ArtifactSource.create({
+        connectorId: 999,
+        label: "doomed",
+      });
+      throw new Error("business failure after both writes");
+    } catch (error) {
+      caught = error;
+    }
+    sqlite.exec("ROLLBACK");
+
+    expect((caught as Error).message).toBe(
+      "business failure after both writes",
+    );
+    // Neither layer persisted: no stray relational row, no graph node
+    // with a dangling connector reference.
+    expect(db.select().from(connectors).all()).toEqual([]);
+    expect(await store.nodes.ArtifactSource.find()).toEqual([]);
+    sqlite.close();
+  });
+
+  it("commits a fulltext write with a relational row when the store is booted", async () => {
+    const bootBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    // Canonical boot path: materializes the FTS5 table and warms the
+    // durable marker so the adopted-tx assert is a cache hit (no DDL).
+    const [store] = await createStoreWithSchema(FtGraph, bootBackend);
+
+    sqlite.exec("BEGIN");
+    const txStore = store.withTransaction(db);
+    const connectorId = db
+      .insert(connectors)
+      .values({ name: "drive" })
+      .returning({ id: connectors.id })
+      .all()[0]!.id;
+    const document = await txStore.nodes.Doc.create({
+      connectorId,
+      title: "quarterly revenue report",
+    });
+    sqlite.exec("COMMIT");
+
+    // The relational row, the graph node, AND the FTS5 row all landed.
+    expect(db.select().from(connectors).all()).toEqual([
+      { id: connectorId, name: "drive" },
+    ]);
+    const hits = await store.search.fulltext("Doc", {
+      query: "revenue",
+      limit: 10,
+    });
+    expect(hits.map((hit) => hit.node.id)).toEqual([document.id]);
+    sqlite.close();
+  });
+
+  it("refuses loudly (and rolls back the relational write) when the store is not booted", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    // Bare createStore against an unmaterialized FTS5 table.
+    const store = createStore(FtGraph, backend);
+
+    sqlite.exec("BEGIN");
+    let thrown: unknown;
+    try {
+      const txStore = store.withTransaction(db);
+      db.insert(connectors).values({ name: "premature" }).run();
+      await txStore.nodes.Doc.create({
+        connectorId: 1,
+        title: "should not persist",
+      });
+    } catch (error) {
+      thrown = error;
+      sqlite.exec("ROLLBACK");
+    }
+
+    expect(thrown).toBeInstanceOf(StoreNotInitializedError);
+    // The gate emitted no DDL: the FTS5 table was never created...
+    expect(() =>
+      sqlite.prepare(`SELECT * FROM ${defaultTables.fulltextTableName}`).all(),
+    ).toThrow(/no such table/);
+    // ...and the caller's relational write rolled back with it.
+    expect(db.select().from(connectors).all()).toEqual([]);
+    sqlite.close();
+  });
+
+  it("rejects withTransaction when the backend cannot adopt a transaction", () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true, transactionMode: "none" },
+      tables: defaultTables,
+    });
+    const store = createStore(PlainGraph, backend);
+
+    expect(() => store.withTransaction(db)).toThrow(ConfigurationError);
+    expect(() => store.withTransaction(db)).toThrow(
+      /Cross-store atomicity is unavailable/,
+    );
+    // The rejection fired before any work — no side effects.
+    expect(db.select().from(connectors).all()).toEqual([]);
+    sqlite.close();
+  });
+});


### PR DESCRIPTION
Closes #134. Builds on #138 (durable fulltext materialization) and #136 (TableContribution), both merged.

## Summary

Applications that persist into the same database through **both** a directly-owned Drizzle connection (relational rows) and a TypeGraph `Store` (graph nodes/edges) had no way to make a cross-layer write all-or-nothing — `store.transaction()` and `db.transaction()` each opened a *separate* transaction on a *separate* connection.

This adds **Direction A** from the issue (the preferred, sufficient shape):

- **`Store.withTransaction(externalTx): TransactionContext<G>`** — synchronous accessor. Inside your own `db.transaction(async (sqlTx) => …)`, `store.withTransaction(sqlTx)` returns a tx-scoped `{ nodes, edges }` bound to that *exact* connection. The caller's `db.transaction(...)` is the single commit/rollback boundary.
- **`GraphBackend.adoptTransaction?(externalTx): TransactionBackend`** — optional member (presence = feature detection, consistent with the other optional backend members), implemented by the Drizzle Postgres and SQLite backends. Added to `TransactionBackend`'s `Omit` so a tx-scoped backend can't recursively adopt.
- **`AdoptedTransaction`** type, exported publicly.
- Shared `#buildTransactionContext` helper extracted so `transaction()` and `withTransaction()` resolve collections identically (no duplication).

Mechanically this is `backend.transaction()`'s body **minus** the `db.transaction()` wrapper.

## Effect of the prerequisites (#136/#138)

The issue's "Blocking prerequisite" section was written pre-#138 and is now obsolete. #138 replaced the in-memory `fulltextEnsured` latch with a durable marker + the `gateFulltext`/`assertInitialized` seam (cached SELECT, never DDL). That makes the issue's hardest constraint hold **by construction**: an adopted-tx fulltext op hits the warm marker cache (zero I/O) on a store booted via `createStoreWithSchema`, and throws `StoreNotInitializedError` otherwise — a loud error, never an implicit mid-transaction migrate. One deviation from the issue's feasibility note: it suggested typing `adoptTransaction` on "concrete drizzle backends," but `createPostgresBackend` returns the dialect-agnostic `GraphBackend`, so it's an optional `GraphBackend` member instead.

`ConfigurationError` (never silent degrade) when `capabilities.transactions === false` (`neon-http`, D1, SQLite `transactionMode:"none"`) — a non-atomic fallback is safe for graph-only writes but dangerous cross-store, where the relational write *would* still commit.

## Test Coverage

New `tests/cross-store-transaction.test.ts` (SQLite, 5) + `tests/backends/postgres/postgres-cross-store-transaction.test.ts` (Postgres, 6):

- Atomic commit across a Drizzle row + a TypeGraph node
- Rollback prevents the dangling reference (neither layer persists)
- Booted fulltext write commits with the relational row
- `StoreNotInitializedError` rolls back the relational write when not booted (no DDL emitted)
- `ConfigurationError` on capability-false backends
- Postgres: also asserts `adoptTransaction` presence + `capabilities.transactions`
- libsql (async sqlite driver): documented `db.transaction(async sqlTx => store.withTransaction(sqlTx))` commit + rollback

**Driver contract** (review follow-up): `better-sqlite3` is synchronous — Drizzle rejects an `async` `db.transaction()` callback, so the documented better-sqlite3 pattern is explicit `BEGIN`/`COMMIT`/`ROLLBACK` (what the better-sqlite3 tests exercise). Async drivers (node-postgres, `neon-serverless` Pool, libsql) use `db.transaction(async …)` (Postgres + new libsql tests exercise this). Recipe doc + `withTransaction`/`adoptTransaction` JSDoc split by driver. No implementation change — the primitive is driver-agnostic.

All new code paths covered. 13 cross-store tests: better-sqlite3 (5), Postgres (6), libsql (2).

## Pre-Landing Review

Self-reviewed: additive, no raw SQL string interpolation, no LLM trust boundary, capability guard throws before any side effect (test-verified). No issues.
