### PR TITLE
refactor: simplify transaction-handling churn (post-#136/#138/#139)

### DIFF
--- a/.changeset/durable-fulltext-materialization.md
+++ b/.changeset/durable-fulltext-materialization.md
@@ -40,8 +40,8 @@ relying on lazy fulltext creation via bare `createStore()` must add a
 - New backend primitives (SQLite + Postgres):
   `ensureContributionMaterializationsTable`, `getContributionMaterialization`,
   `recordContributionMaterialization`, and
-  `assertRuntimeContributionsInitialized`. `ensureRuntimeContributions`,
-  `ensureContribution`, and `ensureFulltextTable` now take a `graphId` and
+  `assertRuntimeContributionsInitialized`. `ensureRuntimeContributions`
+  and `ensureFulltextTable` now take a `graphId` and
   route through the durable-marker writer (short-circuiting when the recorded
   signature already matches). `createStoreWithSchema` records the marker after
   the schema version is resolved, covering the cold-initialize path.

--- a/.changeset/table-contribution-contract.md
+++ b/.changeset/table-contribution-contract.md
@@ -14,40 +14,35 @@ refactor routes every owned table through one shape.
 **Breaking (custom `FulltextStrategy` implementers only):**
 `FulltextStrategy.generateDdl(tableName): string[]` is replaced by
 `ownedTables(primaryTableName): readonly StrategyTableContribution[]`.
-A strategy now *declares* its tables (Drizzle-free: `logicalName`,
-`owner`, resolved `tableName`, idempotent `createDdl` for the table
-**and its supporting indexes**, and a `drizzleModel` discriminant);
-the schema factory resolves those declarations into authoritative
-`TableContribution`s. The two shipped strategies (`tsvectorStrategy`,
-`fts5Strategy`) and all internal callers are migrated; consumers using
-only the shipped strategies need no changes.
+A strategy now *declares* its tables, Drizzle-free, as already
+authoritative contributions (`logicalName`, `owner`, resolved
+`tableName`, idempotent `createDdl` for the table **and its supporting
+indexes**, `runtimeEnsure`). The two shipped strategies
+(`tsvectorStrategy`, `fts5Strategy`) and all internal callers are
+migrated; consumers using only the shipped strategies need no changes.
 
 **What ships:**
 
-- New `@nicia-ai/typegraph` export: `TableContribution`,
-  `TableContributionSource`, `StrategyTableContribution`,
-  `StrategyDrizzleModel`, `isDrizzleContribution`. Each contribution
-  carries a stable, deployment-independent `logicalName` plus the
-  resolved physical `tableName` (distinct identity vs. drift-signature
-  inputs) — the prerequisite that lets #135 make fulltext
-  materialization a durable, decidable fact instead of an in-memory
-  per-backend latch.
+- New `@nicia-ai/typegraph` export: `TableContribution` and
+  `StrategyTableContribution` (its strategy-declaration alias). Each
+  contribution carries a stable, deployment-independent `logicalName`
+  plus the resolved physical `tableName` (distinct identity vs.
+  drift-signature inputs) — the prerequisite that lets #135 make
+  fulltext materialization a durable, decidable fact instead of an
+  in-memory per-backend latch.
 - `postgresContributions()` / `sqliteContributions()` are the single
-  source of truth for DDL generation, the bootstrap ensure, and
-  drizzle-kit visibility. The Postgres `tables.fulltext` pgTable is
-  created once by the factory and that **exact** object is attached to
-  the fulltext contribution — never a second object for the same
-  physical table. `generatePostgresDDL` / `generateSqliteDDL` iterate
-  contributions; the `table === tables.fulltext` reference-identity
-  hack is gone. drizzle-kit visibility is now declarative
-  (`source.kind`) rather than structural.
-- New backend methods `ensureContribution(logicalName)` and
-  `ensureRuntimeContributions()`. `ensureContribution` runs a
-  contribution's full idempotent `createDdl` (table + supporting
-  indexes), so a partial state (table present, index missing)
-  self-heals — it is not a probe-and-skip.
-  `loadActiveSchemaWithBootstrap` now calls
-  `ensureRuntimeContributions()`, scoped to `runtimeEnsure`
+  source of truth for DDL generation and the bootstrap ensure.
+  `generatePostgresDDL` / `generateSqliteDDL` iterate contributions;
+  the `table === tables.fulltext` reference-identity hack is gone from
+  DDL generation. drizzle-kit visibility for the default Postgres
+  strategy comes from the schema barrel exporting the matching
+  `tables.fulltext` object (one object, not two); a non-default
+  strategy exports its own.
+- New backend method `ensureRuntimeContributions()`, which runs each
+  `runtimeEnsure` contribution's full idempotent `createDdl` (table +
+  supporting indexes) so a partial state (table present, index
+  missing) self-heals — not a probe-and-skip.
+  `loadActiveSchemaWithBootstrap` calls it scoped to `runtimeEnsure`
   contributions only (the strategy-owned fulltext table today), so
   startup does not regress into broad DDL/probing across every table.
   `ensureFulltextTable` is retained as a thin back-compat wrapper.

--- a/apps/docs/src/content/docs/fulltext-search.md
+++ b/apps/docs/src/content/docs/fulltext-search.md
@@ -647,12 +647,12 @@ export const pgTrgmStrategy: FulltextStrategy = {
     return sql`NULL`;
   },
 
-  // Declares the table(s) this strategy owns. The schema factory
-  // resolves these into TableContributions. `drizzleModel: "raw-ddl"`
-  // because pg_trgm brings its own table (not the typed Drizzle
-  // `tables.fulltext`), so it is emitted verbatim and is invisible to
-  // drizzle-kit. `runtimeEnsure: true` because no drizzle-kit-managed
-  // setup can create it.
+  // Declares the table(s) this strategy owns as authoritative
+  // TableContributions. pg_trgm brings its own table (not the typed
+  // Drizzle `tables.fulltext`), so it is emitted verbatim from
+  // `createDdl` and is invisible to drizzle-kit unless you export your
+  // own table object. `runtimeEnsure: true` because no
+  // drizzle-kit-managed setup can create it.
   ownedTables(primaryTableName) {
     return [
       {
@@ -674,7 +674,6 @@ export const pgTrgmStrategy: FulltextStrategy = {
              ON "${primaryTableName}" USING GIN ("content" gin_trgm_ops);`,
         ],
         runtimeEnsure: true,
-        drizzleModel: "raw-ddl",
       },
     ];
   },

--- a/packages/typegraph/src/backend/drizzle/columns/fulltext.ts
+++ b/packages/typegraph/src/backend/drizzle/columns/fulltext.ts
@@ -3,7 +3,7 @@
  * fulltext table (`tsvector` + `regconfig`). Lets drizzle-kit
  * introspect the typed fulltext table the same way it introspects
  * `nodes`, `edges`, etc. Alternate strategies (pg_trgm, ParadeDB,
- * pgroonga) carry their own DDL via `FulltextStrategy.generateDdl()`
+ * pgroonga) carry their own DDL via `FulltextStrategy.ownedTables()`
  * and don't use these columns.
  */
 import { customType } from "drizzle-orm/pg-core";

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -32,7 +32,7 @@ import type {
   RecordContributionMaterializationParams,
   TransactionBackend,
 } from "../types";
-import { findStrategyContribution, runtimeStrategyContributions } from "./ddl";
+import { runtimeStrategyContributions } from "./ddl";
 import { formatPostgresTimestamp, nowIso } from "./row-mappers";
 
 /**
@@ -234,67 +234,74 @@ function identityOf(
 }
 
 /**
- * Wrap a transaction-scoped backend so every fulltext-touching method
- * asserts the durable contribution marker before delegating — the
- * point-of-use gate (#135) for the transaction path, mirroring the
- * non-tx wrappers.
- *
- * The tx-scoped backend exposes RAW fulltext methods (no self-ensure);
- * `assert` is the outer backend's cached durable-marker resolver. A
- * transaction that never touches fulltext never asserts, so non-
- * fulltext transactions stay free of any fulltext-init requirement.
- * `assert` performs only a (cached) SELECT — never DDL — so it is safe
- * inside the caller's open transaction (#134).
- *
- * `hardDeleteNode` is gated because the cascade unconditionally deletes
- * from the fulltext table even for graphs with no `searchable()`
- * fields. Empty-input batch calls skip the assert, matching the
- * "a genuine no-op is harmless" contract of the non-tx wrappers.
+ * The fulltext-touching methods the durable-marker gate wraps. The five
+ * `upsert*`/`delete*`/`fulltextSearch` are optional (a graph with no
+ * `searchable()` fields has none); `hardDeleteNode` is always present
+ * because its cascade unconditionally deletes from the fulltext table.
  */
-export function gateFulltext(
-  tx: TransactionBackend,
-  assert: (graphId: string) => Promise<void>,
-): TransactionBackend {
-  // Mutable local so each override is only assigned when the raw method
-  // exists; the "only wrap when defined" rule stays obvious instead of
-  // hiding behind conditional spreads.
-  const gated: { -readonly [K in keyof TransactionBackend]: TransactionBackend[K] } =
-    { ...tx };
+export type GatableFulltextBackend = Pick<
+  TransactionBackend,
+  | "upsertFulltext"
+  | "deleteFulltext"
+  | "upsertFulltextBatch"
+  | "deleteFulltextBatch"
+  | "fulltextSearch"
+  | "hardDeleteNode"
+>;
 
-  if (tx.upsertFulltext) {
-    const raw = tx.upsertFulltext;
+/**
+ * The fulltext point-of-use gate, as the wrapped overrides only. Each
+ * method asserts the durable contribution marker before delegating; an
+ * optional method is wrapped only when present. `assert` performs only
+ * a (cached) SELECT — never DDL — so it is safe inside an open
+ * transaction. The single source of the gating contract: both the
+ * non-tx backend and the tx-scoped {@link gateFulltext} consume it.
+ */
+export function gateFulltextMethods(
+  source: GatableFulltextBackend,
+  assert: (graphId: string) => Promise<void>,
+): Partial<GatableFulltextBackend> {
+  // Only assign an override when the raw method exists, so the "wrap
+  // only what's defined" rule stays obvious instead of hiding behind
+  // conditional spreads.
+  const gated: {
+    -readonly [K in keyof GatableFulltextBackend]?: GatableFulltextBackend[K];
+  } = {};
+
+  if (source.upsertFulltext) {
+    const raw = source.upsertFulltext;
     gated.upsertFulltext = async (params) => {
       await assert(params.graphId);
       await raw(params);
     };
   }
-  if (tx.deleteFulltext) {
-    const raw = tx.deleteFulltext;
+  if (source.deleteFulltext) {
+    const raw = source.deleteFulltext;
     gated.deleteFulltext = async (params) => {
       await assert(params.graphId);
       await raw(params);
     };
   }
-  if (tx.upsertFulltextBatch) {
-    const raw = tx.upsertFulltextBatch;
+  if (source.upsertFulltextBatch) {
+    const raw = source.upsertFulltextBatch;
     gated.upsertFulltextBatch = async (params) => {
-      // A genuine no-op call asserts nothing, matching the non-tx
-      // wrappers' "empty input is harmless" contract.
+      // A genuine no-op call asserts nothing — the "empty input is
+      // harmless" contract.
       if (params.rows.length === 0) return;
       await assert(params.graphId);
       await raw(params);
     };
   }
-  if (tx.deleteFulltextBatch) {
-    const raw = tx.deleteFulltextBatch;
+  if (source.deleteFulltextBatch) {
+    const raw = source.deleteFulltextBatch;
     gated.deleteFulltextBatch = async (params) => {
       if (params.nodeIds.length === 0) return;
       await assert(params.graphId);
       await raw(params);
     };
   }
-  if (tx.fulltextSearch) {
-    const raw = tx.fulltextSearch;
+  if (source.fulltextSearch) {
+    const raw = source.fulltextSearch;
     gated.fulltextSearch = async (params) => {
       await assert(params.graphId);
       return raw(params);
@@ -302,12 +309,26 @@ export function gateFulltext(
   }
   // Unconditional: the hard-delete cascade deletes from the fulltext
   // table even for graphs that declare no `searchable()` fields.
-  const rawHardDelete = tx.hardDeleteNode;
+  const rawHardDelete = source.hardDeleteNode;
   gated.hardDeleteNode = async (params) => {
     await assert(params.graphId);
     await rawHardDelete(params);
   };
   return gated;
+}
+
+/**
+ * Tx-scoped variant: a {@link TransactionBackend} with its fulltext
+ * methods gated. The tx-scoped backend exposes RAW fulltext methods (no
+ * self-ensure); a transaction that never touches fulltext never
+ * asserts, so non-fulltext transactions stay free of any fulltext-init
+ * requirement.
+ */
+export function gateFulltext(
+  tx: TransactionBackend,
+  assert: (graphId: string) => Promise<void>,
+): TransactionBackend {
+  return { ...tx, ...gateFulltextMethods(tx, assert) };
 }
 
 // ============================================================
@@ -337,8 +358,6 @@ export type ContributionMaterializerDeps = Readonly<{
 }>;
 
 export type ContributionMaterializer = Readonly<{
-  /** Materialize one declared contribution by `logicalName` + record it. */
-  ensureContribution: (logicalName: string, graphId: string) => Promise<void>;
   /** Canonical durable-marker writer: every `runtimeEnsure` contribution. */
   ensureRuntimeContributions: (graphId: string) => Promise<void>;
   /**
@@ -375,16 +394,12 @@ export function createContributionMaterializer(
     );
     const identity = identityOf(graphId, contribution);
     const existing = await deps.getMarker(identity);
-    const priorSuccess = existing?.materializedAt !== undefined;
 
     // Already materialized at this exact shape — nothing to do.
-    if (
-      priorSuccess &&
-      existing.signature === signature &&
-      existing.lastError === undefined
-    ) {
+    if (evaluateContributionState(existing, signature) === "initialized") {
       return;
     }
+    const priorSuccess = existing?.materializedAt !== undefined;
 
     // Drift after a *recorded success*: the table physically exists with
     // the OLD shape, so the idempotent `CREATE ... IF NOT EXISTS` would
@@ -450,19 +465,6 @@ export function createContributionMaterializer(
     initializedGraphIds.add(graphId);
   }
 
-  async function ensureContribution(
-    logicalName: string,
-    graphId: string,
-  ): Promise<void> {
-    const declared = findStrategyContribution(
-      fulltextStrategy,
-      fulltextTableName,
-      logicalName,
-    );
-    await deps.ensureMarkerTable();
-    await materializeOne(graphId, declared);
-  }
-
   async function assertInitialized(graphId: string): Promise<void> {
     if (initializedGraphIds.has(graphId)) return;
     for (const contribution of runtimeContributions()) {
@@ -496,5 +498,5 @@ export function createContributionMaterializer(
     initializedGraphIds.add(graphId);
   }
 
-  return { ensureContribution, ensureRuntimeContributions, assertInitialized };
+  return { ensureRuntimeContributions, assertInitialized };
 }

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -4,14 +4,17 @@
  * Provides utilities for generating DDL statements from Drizzle
  * table definitions. This ensures migrations match production schema.
  */
+import { is } from "drizzle-orm";
 import {
   getTableConfig as getPgTableConfig,
   type PgColumn,
+  PgTable,
   type PgTableWithColumns,
 } from "drizzle-orm/pg-core";
 import {
   getTableConfig as getSqliteTableConfig,
   type SQLiteColumn,
+  SQLiteTable,
   type SQLiteTableWithColumns,
 } from "drizzle-orm/sqlite-core";
 
@@ -236,78 +239,17 @@ function generateSqliteCreateIndexSQL(
 }
 
 /**
- * Returns true for a value that looks like a Drizzle SQLite table.
- * The schema module exposes non-table values (e.g. `fulltextTableName: string`)
- * alongside the Drizzle tables, and the DDL generators must skip them.
+ * Whether a schema-barrel value is a Drizzle SQLite table. The barrel
+ * exposes non-table values (e.g. `fulltextTableName: string`) the DDL
+ * generators must skip — and a contribution's barrel key is its
+ * materialization identity, so a misclassified non-table would corrupt
+ * that identity, not just emit stray DDL.
  */
 function isSqliteTable(
   value: unknown,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): value is SQLiteTableWithColumns<any> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    // Drizzle tables are always objects; strings are our escape hatch.
-    typeof value !== "string"
-  );
-}
-
-/**
- * Resolves a strategy's Drizzle-free table *declarations* into
- * authoritative {@link TableContribution}s, attaching the exact
- * factory-built Drizzle table object for `drizzle-*` models. A strategy
- * never constructs a Drizzle table itself, so there is never a second
- * object for the same physical table (#129).
- */
-function resolveStrategyContribution(
-  declared: StrategyTableContribution,
-  drizzleTable?: TableContribution["source"],
-): TableContribution {
-  const base = {
-    logicalName: declared.logicalName,
-    owner: declared.owner,
-    tableName: declared.tableName,
-    createDdl: declared.createDdl,
-    runtimeEnsure: declared.runtimeEnsure,
-  };
-  if (declared.drizzleModel === "raw-ddl") {
-    return { ...base, source: { kind: "raw-ddl" } };
-  }
-  if (drizzleTable?.kind !== declared.drizzleModel) {
-    throw new Error(
-      `Strategy declared drizzleModel "${declared.drizzleModel}" for ` +
-        `contribution "${declared.logicalName}" but the schema factory ` +
-        `did not supply a matching Drizzle table object.`,
-    );
-  }
-  return { ...base, source: drizzleTable };
-}
-
-/**
- * The strategy's declaration for one logical slot. O(1) in the number
- * of base tables: it asks the strategy directly and never walks or
- * regenerates base-table DDL — this is what keeps the per-boot runtime
- * ensure off the base-table DDL-generation path.
- *
- * Throws when the strategy declares no contribution under
- * `logicalName` (caller typo / strategy↔backend disagreement) rather
- * than silently doing nothing.
- */
-export function findStrategyContribution(
-  fulltextStrategy: FulltextStrategy,
-  fulltextTableName: string,
-  logicalName: string,
-): StrategyTableContribution {
-  const declared = fulltextStrategy
-    .ownedTables(fulltextTableName)
-    .find((contribution) => contribution.logicalName === logicalName);
-  if (declared === undefined) {
-    throw new Error(
-      `No strategy table contribution named "${logicalName}" ` +
-        `(strategy "${fulltextStrategy.name}").`,
-    );
-  }
-  return declared;
+  return is(value, SQLiteTable);
 }
 
 /**
@@ -350,15 +292,14 @@ export function sqliteContributions(
         ...generateSqliteCreateIndexSQL(table),
       ],
       runtimeEnsure: false,
-      source: { kind: "drizzle-sqlite", table },
     });
   }
-  // FTS5 is raw-ddl (virtual table, not Drizzle-modelable) so no table
-  // object is supplied; emitted last (after base tables).
+  // Strategy declarations are already authoritative contributions;
+  // emitted last (after base tables).
   for (const declared of fulltextStrategy.ownedTables(
     tables.fulltextTableName,
   )) {
-    contributions.push(resolveStrategyContribution(declared));
+    contributions.push(declared);
   }
   return contributions;
 }
@@ -516,15 +457,15 @@ function generatePgCreateIndexSQL(
   return statements;
 }
 
+/**
+ * Whether a schema-barrel value is a Drizzle Postgres table. See
+ * {@link isSqliteTable} for why this uses Drizzle's brand check.
+ */
 function isPgTable(
   value: unknown,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): value is PgTableWithColumns<any> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof value !== "string"
-  );
+  return is(value, PgTable);
 }
 
 /**
@@ -536,9 +477,11 @@ function isPgTable(
  * The typed `tables.fulltext` object is **not** emitted via the
  * column-walker (it can't reproduce `GENERATED ALWAYS AS … STORED`);
  * instead the strategy's canonical DDL is carried as the fulltext
- * contribution's `createDdl`, while that same `tables.fulltext` object
- * is attached as its `source` for drizzle-kit visibility — one object,
- * not two.
+ * contribution's `createDdl`. drizzle-kit visibility for the default
+ * tsvector strategy comes from `schema/postgres.ts` exporting that
+ * same `tables.fulltext` object through the barrel — one object, not
+ * two. (Non-default Postgres strategies must export their own table
+ * for drizzle-kit; see `FulltextStrategy.ownedTables`.)
  */
 export function postgresContributions(
   tables: PostgresTables = postgresTables,
@@ -547,8 +490,9 @@ export function postgresContributions(
   const contributions: TableContribution[] = [];
   for (const [key, table] of Object.entries(tables)) {
     if (!isPgTable(table)) continue;
-    // The strategy owns the fulltext slot's DDL; skip the typed object
-    // here and re-attach it to the strategy contribution below.
+    // The strategy owns the fulltext slot's DDL (the column-walker
+    // can't reproduce its generated tsvector column); the strategy
+    // declaration below is the authoritative fulltext contribution.
     if (table === tables.fulltext) continue;
     // Stable factory key (`nodes`, `edges`, …) is the logicalName so
     // the #135 materialization identity survives custom table-name
@@ -562,20 +506,12 @@ export function postgresContributions(
         ...generatePgCreateIndexSQL(table),
       ],
       runtimeEnsure: false,
-      source: { kind: "drizzle-pg", table },
     });
   }
   for (const declared of fulltextStrategy.ownedTables(
     tables.fulltextTableName,
   )) {
-    contributions.push(
-      resolveStrategyContribution(
-        declared,
-        declared.drizzleModel === "drizzle-pg"
-          ? { kind: "drizzle-pg", table: tables.fulltext }
-          : undefined,
-      ),
-    );
+    contributions.push(declared);
   }
   return contributions;
 }

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -1,6 +1,7 @@
-import { type SQL } from "drizzle-orm";
+import { is, type SQL } from "drizzle-orm";
 
 import {
+  ConfigurationError,
   DatabaseOperationError,
   MigrationError,
   SchemaContentConflictError,
@@ -87,6 +88,39 @@ export type CommonOperationBackend = Pick<
     ) => Promise<SchemaVersionRow>;
     setActiveVersion: (params: SetActiveVersionParams) => Promise<void>;
   }>;
+
+/**
+ * The full internal shape the dialect operation-backend factories
+ * build: a {@link TransactionBackend} that also exposes the schema-write
+ * methods ({@link CommonOperationBackend}). Internal callers holding the
+ * dialect's write-lock (`runSchemaWriteTransaction`) use it directly;
+ * the public `transaction()` / `adoptTransaction()` boundary narrows it
+ * to `TransactionBackend` so user callbacks can't reach
+ * `commitSchemaVersion` / `setActiveVersion` and bypass the lock.
+ */
+export type InternalOperationBackend = TransactionBackend &
+  CommonOperationBackend;
+
+/**
+ * Assert an externally-supplied transaction handle is the expected
+ * Drizzle dialect, narrowing it for `adoptTransaction`. A wrong-dialect
+ * handle would otherwise surface as an opaque driver error mid-
+ * transaction; this fails it loudly at the boundary instead.
+ */
+export function assertAdoptedDialect<T>(
+  externalTx: unknown,
+  brand: Parameters<typeof is>[1],
+  backend: "postgres" | "sqlite",
+): asserts externalTx is T {
+  if (is(externalTx, brand)) return;
+  const label = backend === "postgres" ? "Postgres" : "SQLite";
+  throw new ConfigurationError(
+    `adoptTransaction received a handle that is not a ${label} Drizzle ` +
+      `transaction. Pass the \`tx\` from a ${label} ` +
+      `\`db.transaction(...)\` opened on this backend's connection.`,
+    { backend, capability: "adoptTransaction" },
+  );
+}
 
 type OperationBackendExecution = Readonly<{
   execAll: <TRow>(query: SQL) => Promise<readonly TRow[]>;

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -33,6 +33,7 @@ import {
   type SQL,
   sql,
 } from "drizzle-orm";
+import { PgDatabase } from "drizzle-orm/pg-core";
 
 import { ConfigurationError } from "../../errors";
 import type { SqlTableNames } from "../../query/compiler/schema";
@@ -78,6 +79,7 @@ import {
   buildContributionOnConflictSet,
   createContributionMaterializer,
   gateFulltext,
+  gateFulltextMethods,
   mapContributionMaterializationRow,
   POSTGRES_CONTRIBUTION_MAT_TIMESTAMPS,
 } from "./contribution-materializations";
@@ -102,11 +104,14 @@ import {
   POSTGRES_KIND_REMOVAL_TIMESTAMPS,
 } from "./kind-removals";
 import {
+  assertAdoptedDialect,
   type CommonOperationBackend,
   createCommonOperationBackend,
+  type InternalOperationBackend,
 } from "./operation-backend-core";
 import { createPostgresOperationStrategy } from "./operations/strategy";
 import {
+  coerceNumericScore,
   createEdgeRowMapper,
   createNodeRowMapper,
   createSchemaVersionRowMapper,
@@ -249,16 +254,6 @@ function toEmbeddingRow(row: Record<string, unknown>): EmbeddingRow {
   };
 }
 
-function coerceNumericScore(value: number | string): number {
-  if (typeof value === "number") return value;
-  const parsed = Number.parseFloat(value);
-  if (Number.isNaN(parsed)) {
-    throw new TypeError(
-      `Backend returned non-numeric fulltext score: ${JSON.stringify(value)}`,
-    );
-  }
-  return parsed;
-}
 
 function buildPostgresCapabilities(
   strategy: FulltextStrategy,
@@ -384,11 +379,8 @@ export function createPostgresBackend(
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtext(${graphId}))`,
       );
-      // The runtime object always implements commitSchemaVersion /
-      // setActiveVersion (they live in operation-backend-core); the
-      // public TransactionBackend type omits them so user-supplied
-      // transaction() callbacks can't bypass the advisory lock. Cast
-      // back to the wider internal shape here, where the lock IS held.
+      // Advisory lock is held here, so the schema-write-capable
+      // InternalOperationBackend is used intentionally (see its type).
       const txBackend = createTransactionBackend({
         db: tx,
         adapterOptions,
@@ -396,7 +388,7 @@ export function createPostgresBackend(
         tableNames,
         capabilities,
         fulltextStrategy,
-      }) as unknown as CommonOperationBackend;
+      });
       return fn(txBackend);
     });
   }
@@ -495,41 +487,15 @@ export function createPostgresBackend(
       }
     },
 
-    // Every fulltext-touching method now asserts the durable marker
-    // instead of lazily emitting DDL. Steady state performs zero
-    // ensure; an uninitialized database throws `StoreNotInitializedError`
-    // loudly rather than self-healing on a read/write path (#135).
-    async upsertFulltext(params): Promise<void> {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.upsertFulltext!(params);
-    },
-    async deleteFulltext(params): Promise<void> {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.deleteFulltext!(params);
-    },
-    async upsertFulltextBatch(params): Promise<void> {
-      // A genuine no-op call asserts nothing — preserves the prior
-      // "empty input on any backend is harmless" contract.
-      if (params.rows.length === 0) return;
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.upsertFulltextBatch!(params);
-    },
-    async deleteFulltextBatch(params): Promise<void> {
-      if (params.nodeIds.length === 0) return;
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.deleteFulltextBatch!(params);
-    },
-    async fulltextSearch(params) {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      return operations.fulltextSearch!(params);
-    },
-    // hardDeleteNode is wrapped because the operation-backend-core
-    // cascade unconditionally deletes from the fulltext table — it
-    // would fail even on graphs that declare no searchable() fields.
-    async hardDeleteNode(params): Promise<void> {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.hardDeleteNode(params);
-    },
+    // Every fulltext-touching method asserts the durable marker instead
+    // of lazily emitting DDL. Steady state performs zero ensure; an
+    // uninitialized database throws `StoreNotInitializedError` loudly
+    // rather than self-healing on a read/write path (#135). Shared
+    // verbatim with the tx-scoped gate via `gateFulltextMethods`.
+    ...gateFulltextMethods(
+      operations,
+      contributionMaterializer.assertInitialized,
+    ),
 
     async executeDdl(ddl: string): Promise<void> {
       await db.execute(sql.raw(ddl));
@@ -659,22 +625,14 @@ export function createPostgresBackend(
       );
     },
 
-    async ensureContribution(
-      logicalName: string,
-      graphId: string,
-    ): Promise<void> {
-      await contributionMaterializer.ensureContribution(logicalName, graphId);
-    },
-
     async ensureRuntimeContributions(graphId: string): Promise<void> {
       await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
     /**
-     * Superseded by `ensureContribution("fulltext", graphId)` /
-     * `ensureRuntimeContributions(graphId)` (#129). Retained as a thin
-     * back-compat wrapper for callers predating #129; #135 routed it
-     * through the durable-marker writer.
+     * Superseded by `ensureRuntimeContributions(graphId)` (#129).
+     * Retained as a thin back-compat wrapper for callers predating
+     * #129; #135 routed it through the durable-marker writer.
      */
     async ensureFulltextTable(graphId: string): Promise<void> {
       await contributionMaterializer.ensureRuntimeContributions(graphId);
@@ -772,11 +730,12 @@ export function createPostgresBackend(
           },
         );
       }
+      assertAdoptedDialect<AnyPgDatabase>(externalTx, PgDatabase, "postgres");
       // The caller owns BEGIN/COMMIT/ROLLBACK via its own
       // `db.transaction(...)`. We adopt the literal `tx` client and run
       // pure DML on it — no transaction is opened or closed here, and no
       // DDL is emitted inside the caller's business transaction.
-      return bindTransactionBackend(externalTx as AnyPgDatabase);
+      return bindTransactionBackend(externalTx);
     },
 
     async close(): Promise<void> {
@@ -809,7 +768,7 @@ type CreatePostgresTransactionBackendOptions = Readonly<{
 
 function createPostgresOperationBackend(
   options: CreatePostgresOperationBackendOptions,
-): TransactionBackend {
+): InternalOperationBackend {
   const {
     db,
     executionAdapter,
@@ -871,7 +830,7 @@ function createPostgresOperationBackend(
         },
       };
 
-  const operationBackend: TransactionBackend = {
+  const operationBackend: InternalOperationBackend = {
     ...commonBackend,
     ...executeRawMethod,
     capabilities,
@@ -1050,7 +1009,7 @@ function createPostgresOperationBackend(
 
 function createTransactionBackend(
   options: CreatePostgresTransactionBackendOptions,
-): TransactionBackend {
+): InternalOperationBackend {
   const txExecutionAdapter =
     options.executionAdapter ??
     createPostgresExecutionAdapter(options.db, options.adapterOptions);

--- a/packages/typegraph/src/backend/drizzle/row-mappers.ts
+++ b/packages/typegraph/src/backend/drizzle/row-mappers.ts
@@ -60,6 +60,25 @@ export function formatPostgresTimestamp(value: unknown): string | undefined {
 }
 
 /**
+ * Coerce a fulltext relevance score to `number` at the backend
+ * boundary. Postgres returns `numeric` as a string to preserve
+ * precision; a custom `FulltextStrategy` on either dialect could
+ * likewise yield a string. Shared so both backends enforce the same
+ * `FulltextSearchResult.score: number` contract and reject garbage
+ * loudly instead of propagating `NaN`.
+ */
+export function coerceNumericScore(value: number | string): number {
+  if (typeof value === "number") return value;
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) {
+    throw new TypeError(
+      `Backend returned non-numeric fulltext score: ${JSON.stringify(value)}`,
+    );
+  }
+  return parsed;
+}
+
+/**
  * Normalizes a JSON column that may be returned as a parsed object (JSONB) or string.
  */
 function normalizeJsonColumn(value: unknown): string {

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -393,9 +393,9 @@ export function createPostgresTables(
   /**
    * Drizzle pg-core table for the default `tsvectorStrategy` so
    * drizzle-kit can introspect the fulltext table alongside the
-   * others. Mirrors `tsvectorStrategy.generateDdl()` — the typed
-   * shape and the strategy DDL must stay in sync (drift sentinel
-   * lives in `tests/typed-fulltext-table.test.ts`).
+   * others. Mirrors `tsvectorStrategy.ownedTables(...).createDdl` —
+   * the typed shape and the strategy DDL must stay in sync (drift
+   * sentinel lives in `tests/typed-fulltext-table.test.ts`).
    *
    * Why `regconfig` + GENERATED: `to_tsvector("language", "content")`
    * needs an immutable language to qualify for use inside a
@@ -404,8 +404,8 @@ export function createPostgresTables(
    *
    * Alternate strategies (pg_trgm, ParadeDB, pgroonga) bring their
    * own DDL; `generatePostgresDDL` skips this typed table for them
-   * and defers to `FulltextStrategy.generateDdl()`. Drizzle-kit
-   * consumers on non-default strategies must override
+   * and defers to the active strategy's `ownedTables(...).createDdl`.
+   * Drizzle-kit consumers on non-default strategies must override
    * `tables.fulltext` in their schema barrel.
    */
   const fulltext = pgTable(

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -28,6 +28,7 @@ import {
   type SQL,
   sql,
 } from "drizzle-orm";
+import { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
 import { BackendDisposedError, ConfigurationError } from "../../errors";
 import type { SqlTableNames } from "../../query/compiler/schema";
@@ -78,6 +79,7 @@ import {
   buildContributionOnConflictSet,
   createContributionMaterializer,
   gateFulltext,
+  gateFulltextMethods,
   mapContributionMaterializationRow,
   SQLITE_CONTRIBUTION_MAT_TIMESTAMPS,
 } from "./contribution-materializations";
@@ -95,11 +97,14 @@ import {
   SQLITE_KIND_REMOVAL_TIMESTAMPS,
 } from "./kind-removals";
 import {
+  assertAdoptedDialect,
   type CommonOperationBackend,
   createCommonOperationBackend,
+  type InternalOperationBackend,
 } from "./operation-backend-core";
 import { createSqliteOperationStrategy } from "./operations/strategy";
 import {
+  coerceNumericScore,
   createEdgeRowMapper,
   createNodeRowMapper,
   createSchemaVersionRowMapper,
@@ -339,7 +344,7 @@ type CreateSqliteTransactionBackendOptions = Readonly<{
 
 function createSqliteOperationBackend(
   options: CreateSqliteOperationBackendOptions,
-): TransactionBackend {
+): InternalOperationBackend {
   const {
     capabilities,
     db,
@@ -443,7 +448,7 @@ function createSqliteOperationBackend(
         }
       : {};
 
-  const operationBackend: TransactionBackend = {
+  const operationBackend: InternalOperationBackend = {
     ...commonBackend,
     ...executeRawMethod,
     ...vectorEmbeddingMethods,
@@ -541,12 +546,12 @@ function createSqliteOperationBackend(
       const query = operationStrategy.buildFulltextSearch(params);
       const rows = await execAll<{
         node_id: string;
-        score: number;
+        score: number | string;
         snippet: string | null;
       }>(query);
       return rows.map((row, index) => ({
         nodeId: row.node_id,
-        score: row.score,
+        score: coerceNumericScore(row.score),
         rank: index + 1,
         ...(row.snippet === null ? {} : { snippet: row.snippet }),
       }));
@@ -640,12 +645,8 @@ export function createSqliteBackend(
 
     if (transactionMode === "sql") {
       return runWithSerializedQueue(serializedQueue, async () => {
-        // The runtime object returned by createTransactionBackend always
-        // implements commitSchemaVersion / setActiveVersion (they live in
-        // the operation-backend-core impl); the public TransactionBackend
-        // type omits them so user-supplied transaction() callbacks can't
-        // bypass the locking wrapper. Cast back to the wider internal
-        // shape here, where the locking IS being applied.
+        // Write-lock is held here, so the schema-write-capable
+        // InternalOperationBackend is used intentionally (see its type).
         const txBackend = createTransactionBackend({
           capabilities,
           db,
@@ -655,7 +656,7 @@ export function createSqliteBackend(
           tableNames,
           fulltextStrategy,
           hasVectorEmbeddings,
-        }) as unknown as CommonOperationBackend;
+        });
         db.run(sql`BEGIN IMMEDIATE`);
         try {
           const result = await fn(txBackend);
@@ -682,7 +683,7 @@ export function createSqliteBackend(
           tableNames,
           fulltextStrategy,
           hasVectorEmbeddings,
-        }) as unknown as CommonOperationBackend;
+        });
         return fn(txBackend);
       }, { behavior: "immediate" }) as Promise<T>,
     );
@@ -785,41 +786,15 @@ export function createSqliteBackend(
       }
     },
 
-    // Every fulltext-touching method asserts the durable marker
-    // instead of lazily emitting DDL. Steady state performs zero
-    // ensure; an uninitialized database throws
-    // `StoreNotInitializedError` rather than self-healing (#135).
-    async upsertFulltext(params): Promise<void> {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.upsertFulltext!(params);
-    },
-    async deleteFulltext(params): Promise<void> {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.deleteFulltext!(params);
-    },
-    async upsertFulltextBatch(params): Promise<void> {
-      // A genuine no-op call asserts nothing — preserves the prior
-      // "empty input on any backend is harmless" contract.
-      if (params.rows.length === 0) return;
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.upsertFulltextBatch!(params);
-    },
-    async deleteFulltextBatch(params): Promise<void> {
-      if (params.nodeIds.length === 0) return;
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.deleteFulltextBatch!(params);
-    },
-    async fulltextSearch(params) {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      return operations.fulltextSearch!(params);
-    },
-    // hardDeleteNode is wrapped because the operation-backend-core
-    // cascade unconditionally deletes from the fulltext table — it
-    // would fail even on graphs that declare no searchable() fields.
-    async hardDeleteNode(params): Promise<void> {
-      await contributionMaterializer.assertInitialized(params.graphId);
-      await operations.hardDeleteNode(params);
-    },
+    // Every fulltext-touching method asserts the durable marker instead
+    // of lazily emitting DDL. Steady state performs zero ensure; an
+    // uninitialized database throws `StoreNotInitializedError` rather
+    // than self-healing (#135). Shared verbatim with the tx-scoped gate
+    // via `gateFulltextMethods`.
+    ...gateFulltextMethods(
+      operations,
+      contributionMaterializer.assertInitialized,
+    ),
 
     async executeDdl(ddl: string): Promise<void> {
       await db.run(sql.raw(ddl));
@@ -947,22 +922,14 @@ export function createSqliteBackend(
       );
     },
 
-    async ensureContribution(
-      logicalName: string,
-      graphId: string,
-    ): Promise<void> {
-      await contributionMaterializer.ensureContribution(logicalName, graphId);
-    },
-
     async ensureRuntimeContributions(graphId: string): Promise<void> {
       await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
     /**
-     * Superseded by `ensureContribution("fulltext", graphId)` /
-     * `ensureRuntimeContributions(graphId)` (#129). Retained as a thin
-     * back-compat wrapper for callers predating #129; #135 routed it
-     * through the durable-marker writer.
+     * Superseded by `ensureRuntimeContributions(graphId)` (#129).
+     * Retained as a thin back-compat wrapper for callers predating
+     * #129; #135 routed it through the durable-marker writer.
      */
     async ensureFulltextTable(graphId: string): Promise<void> {
       await contributionMaterializer.ensureRuntimeContributions(graphId);
@@ -1038,6 +1005,10 @@ export function createSqliteBackend(
       // reached. The caller's BEGIN never carries CREATE statements.
       if (transactionMode === "sql") {
         return runWithSerializedQueue(serializedQueue, async () => {
+          // Not `bindTransactionBackend(...)`: this path frames the tx
+          // with manual BEGIN/COMMIT on the *outer* `db`, so it must
+          // reuse that connection's already-built `executionAdapter`
+          // rather than synthesize a fresh one for a distinct handle.
           const txBackend = createTransactionBackend({
             capabilities,
             db,
@@ -1091,14 +1062,16 @@ export function createSqliteBackend(
           },
         );
       }
-      // The caller owns the transaction *and* the connection's
-      // serialization: a sync better-sqlite3 driver runs the adopted
-      // statements on the caller's stack, so the backend's own
-      // `serializedQueue` is deliberately not applied here — wrapping a
-      // caller-driven tx in our queue could deadlock against the
-      // caller's outer `db.transaction(...)`. We bind the literal `tx`
-      // and run pure DML; no transaction is opened or closed here.
-      return bindTransactionBackend(externalTx as AnySqliteDatabase);
+      assertAdoptedDialect<AnySqliteDatabase>(
+        externalTx,
+        BaseSQLiteDatabase,
+        "sqlite",
+      );
+      // serializedQueue is deliberately NOT applied to an adopted tx: a
+      // sync better-sqlite3 driver runs the adopted statements on the
+      // caller's stack, so wrapping a caller-driven tx in our queue
+      // could deadlock against the caller's outer `db.transaction(...)`.
+      return bindTransactionBackend(externalTx);
     },
 
     close(): Promise<void> {
@@ -1112,7 +1085,7 @@ export function createSqliteBackend(
 
 function createTransactionBackend(
   options: CreateSqliteTransactionBackendOptions,
-): TransactionBackend {
+): InternalOperationBackend {
   const txExecutionAdapter =
     options.executionAdapter ??
     createSqliteExecutionAdapter(options.db, {

--- a/packages/typegraph/src/backend/table-contribution.ts
+++ b/packages/typegraph/src/backend/table-contribution.ts
@@ -9,8 +9,8 @@
  * recursion, strategy raw DDL, per-table `ensureXTable` methods).
  *
  * Lives in the neutral `backend/` layer (sibling of `backend/types.ts`,
- * which `query/dialect` already depends on) with **type-only** Drizzle
- * imports, so declaring contributions does not pull the concrete
+ * which `query/dialect` already depends on) and is deliberately
+ * Drizzle-free, so declaring contributions does not pull the concrete
  * Drizzle backend runtime into the query/dialect layer.
  *
  * ## Identity vs. signature (prerequisite for #135)
@@ -37,8 +37,6 @@
  * #135 already owns signature persistence the same way
  * `materializeIndexes` does for declared indexes.
  */
-import type { PgTableWithColumns } from "drizzle-orm/pg-core";
-import type { SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";
 
 /**
  * `logicalName` of the strategy-owned fulltext slot. Used as a logic
@@ -51,36 +49,6 @@ export const FULLTEXT_CONTRIBUTION_NAME = "fulltext";
 
 /** `owner` of core/base schema tables (not strategy-owned). */
 export const BASE_CONTRIBUTION_OWNER = "base";
-
-/**
- * Where a contribution's storage comes from. Drives two otherwise
- * structural decisions declaratively:
- *
- * - **drizzle-kit visibility**: only `drizzle-*` contributions are
- *   re-exported for drizzle-kit introspection. Previously decided by
- *   scattered `table === tables.fulltext` reference-identity checks in
- *   the DDL generators.
- * - **DDL-generation routing**: `drizzle-*` contributions can flow
- *   through the column-walker; `raw-ddl` contributions (SQLite FTS5
- *   virtual tables, future pg_trgm / ParadeDB / pgroonga stacks) are
- *   emitted verbatim from `createDdl`.
- *
- * The `drizzle-*` variants reference the **exact** table object the
- * schema factory created and exports — never a second `pgTable`
- * constructed elsewhere for the same physical table.
- */
-export type TableContributionSource =
-  | {
-      readonly kind: "drizzle-pg";
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      readonly table: PgTableWithColumns<any>;
-    }
-  | {
-      readonly kind: "drizzle-sqlite";
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      readonly table: SQLiteTableWithColumns<any>;
-    }
-  | { readonly kind: "raw-ddl" };
 
 /**
  * A single table TypeGraph owns.
@@ -112,7 +80,7 @@ export type TableContribution = Readonly<{
   /**
    * Idempotent (`CREATE ... IF NOT EXISTS`) statements that
    * materialize this contribution's table **and its supporting
-   * indexes**. Running the full list is how `ensureContribution`
+   * indexes**. Running the full list is how the runtime ensure
    * self-heals partial states (table present, index missing) — it is
    * not a probe-and-skip. Deterministic for a given resolved
    * configuration: the canonical normalized input to #135's drift
@@ -132,52 +100,11 @@ export type TableContribution = Readonly<{
    * DDL for — every base table.
    */
   runtimeEnsure: boolean;
-  /** Storage origin — see {@link TableContributionSource}. */
-  source: TableContributionSource;
 }>;
 
 /**
- * Whether a contribution should be visible to drizzle-kit (i.e. is
- * backed by a Drizzle table object, not strategy-owned raw DDL).
+ * A table a {@link FulltextStrategy} declares it owns. An alias, not a
+ * distinct shape: a strategy's declaration is already authoritative
+ * (no resolution step). The name documents the producer role.
  */
-export function isDrizzleContribution(
-  contribution: TableContribution,
-): boolean {
-  return contribution.source.kind !== "raw-ddl";
-}
-
-/**
- * How the schema factory should source a strategy-declared table.
- *
- * - `"raw-ddl"` — emit `createDdl` verbatim; not drizzle-kit visible
- *   (SQLite FTS5 virtual tables, raw-DDL Postgres stacks).
- * - `"drizzle-pg"` — the Postgres factory attaches the **exact**
- *   `tables.fulltext` pgTable object it already created and exports;
- *   the strategy never constructs a Drizzle table itself, so there is
- *   never a second object for the same physical table.
- *
- * There is intentionally no `"drizzle-sqlite"`: the SQLite factory has
- * no strategy-owned Drizzle table slot to attach (FTS5 virtual tables
- * aren't Drizzle-modelable, so SQLite strategies are `"raw-ddl"`).
- * `TableContributionSource` still carries a `drizzle-sqlite` kind for
- * *resolved* base/core tables — that path is unaffected.
- */
-export type StrategyDrizzleModel = "raw-ddl" | "drizzle-pg";
-
-/**
- * A table a {@link FulltextStrategy} declares it owns. This is the
- * strategy's *declaration*; the schema factory resolves it into the
- * authoritative {@link TableContribution} — attaching the real Drizzle
- * table object for `drizzle-*` models (see {@link StrategyDrizzleModel}).
- *
- * Deliberately Drizzle-free so implementing a custom strategy never
- * requires a `drizzle-orm` dependency.
- */
-export type StrategyTableContribution = Readonly<{
-  logicalName: string;
-  owner: string;
-  tableName: string;
-  createDdl: readonly string[];
-  runtimeEnsure: boolean;
-  drizzleModel: StrategyDrizzleModel;
-}>;
+export type StrategyTableContribution = TableContribution;

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1006,27 +1006,6 @@ export type GraphBackend = Readonly<{
   // === Table Contributions (#129) ===
 
   /**
-   * Materializes a single **strategy-declared** contribution by
-   * `logicalName` (e.g. `"fulltext"`) — running its full idempotent
-   * `createDdl` (table + supporting indexes), so a partial state
-   * (table present, index missing) self-heals. Concurrency-safe under
-   * replica startup.
-   *
-   * Scope is intentionally the strategy-owned slots only (the set
-   * `FulltextStrategy.ownedTables` declares); it is **not** a generic
-   * "materialize any table" entrypoint. Base/core tables come from
-   * drizzle-kit or `bootstrapTables`, never here. Throws on a
-   * `logicalName` no active strategy declares, rather than silently
-   * doing nothing.
-   *
-   * Writes the durable materialization marker for the contribution
-   * (success or failure) keyed by `graphId` + contribution identity
-   * (#135), so the hot-path gate can later answer "initialized?"
-   * without re-running DDL.
-   */
-  ensureContribution?: (logicalName: string, graphId: string) => Promise<void>;
-
-  /**
    * Materializes every contribution flagged `runtimeEnsure` — the
    * strategy-owned runtime tables (fulltext today) that drizzle-kit-
    * managed setups don't create. Called once after a successful schema
@@ -1046,9 +1025,8 @@ export type GraphBackend = Readonly<{
    * owns. Same focused-bootstrap rationale as the other `ensure*Table`
    * methods: idempotent and concurrency-safe under replica startup.
    *
-   * Superseded by `ensureContribution("fulltext")` /
-   * `ensureRuntimeContributions()` (#129); retained as a thin
-   * back-compat wrapper for backends/callers predating #129. Not
+   * Superseded by `ensureRuntimeContributions()` (#129); retained as
+   * a thin back-compat wrapper for backends/callers predating #129. Not
    * machine-`@deprecated` because the manager still calls it as the
    * pre-#129 fallback. #135 removed the remaining hot-path callers and
    * routed this through the durable-marker writer.

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -822,6 +822,9 @@ const STORE_NOT_INITIALIZED_REASON_PHRASE: Readonly<
  * loudly here instead of lazily emitting DDL on the hot path.
  */
 export class StoreNotInitializedError extends TypeGraphError {
+  // `graphId`/`reason` are positional and required: both are
+  // load-bearing for the message and for programmatic handling via
+  // `details.reason`. Caller `details` merge on top.
   constructor(
     graphId: string,
     reason: StoreNotInitializedReason,

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -98,12 +98,9 @@ export {
 // ============================================================
 
 export type {
-  StrategyDrizzleModel,
   StrategyTableContribution,
   TableContribution,
-  TableContributionSource,
 } from "./backend/table-contribution";
-export { isDrizzleContribution } from "./backend/table-contribution";
 export type {
   AdoptedTransaction,
   BackendCapabilities,

--- a/packages/typegraph/src/query/dialect/fulltext-strategy.ts
+++ b/packages/typegraph/src/query/dialect/fulltext-strategy.ts
@@ -139,13 +139,14 @@ export interface FulltextStrategy {
   ): SQL;
 
   /**
-   * The tables this strategy owns, as Drizzle-free *declarations*
-   * (`logicalName`, `owner`, resolved `tableName`, idempotent
-   * `createDdl` for the table **and its supporting indexes**, and the
-   * `drizzleModel` telling the schema factory how to source it). The
-   * factory resolves these into authoritative `TableContribution`s,
-   * attaching the exact Drizzle table object for `drizzle-*` models —
-   * a strategy never constructs a Drizzle table itself.
+   * The tables this strategy owns, as Drizzle-free, already
+   * authoritative `TableContribution`s (`logicalName`, `owner`,
+   * resolved `tableName`, idempotent `createDdl` for the table **and
+   * its supporting indexes**, `runtimeEnsure`). A strategy never
+   * constructs a Drizzle table itself; drizzle-kit visibility, when
+   * applicable, is the schema barrel's responsibility (the default
+   * Postgres strategy's `schema/postgres.ts` exports a matching
+   * `tables.fulltext` — a non-default strategy must export its own).
    *
    * Replaces the former `generateDdl(tableName)`: DDL is now one field
    * of a contribution rather than the strategy's whole storage
@@ -348,10 +349,11 @@ export const tsvectorStrategy: FulltextStrategy = {
       `CREATE INDEX IF NOT EXISTS ${gin} ON ${name} USING GIN ("tsv");`,
       `CREATE INDEX IF NOT EXISTS ${kind} ON ${name} ("graph_id", "node_kind");`,
     ];
-    // Drizzle-modelable on Postgres: the schema factory attaches the
-    // exact `tables.fulltext` pgTable object (no second object for the
-    // same physical table). `runtimeEnsure` because drizzle-kit-managed
-    // setups create every base table except this strategy-owned one.
+    // drizzle-kit visibility for this default strategy comes from
+    // `schema/postgres.ts` exporting the matching `tables.fulltext`
+    // pgTable through the barrel — one object, not two. `runtimeEnsure`
+    // because drizzle-kit-managed setups create every base table except
+    // this strategy-owned one.
     return [
       {
         logicalName: FULLTEXT_CONTRIBUTION_NAME,
@@ -359,7 +361,6 @@ export const tsvectorStrategy: FulltextStrategy = {
         tableName: primaryTableName,
         createDdl,
         runtimeEnsure: true,
-        drizzleModel: "drizzle-pg",
       },
     ];
   },
@@ -573,7 +574,6 @@ export const fts5Strategy: FulltextStrategy = {
 );`,
         ],
         runtimeEnsure: true,
-        drizzleModel: "raw-ddl",
       },
     ];
   },

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -112,9 +112,13 @@ export async function loadActiveSchemaWithBootstrap(
 ): Promise<SchemaVersionRow | undefined> {
   try {
     const row = await backend.getActiveSchema(graphId);
-    await (backend.ensureRuntimeContributions ?
-      backend.ensureRuntimeContributions(graphId)
-    : backend.ensureFulltextTable?.(graphId));
+    // Prefer the #129 contribution path; fall back to the pre-#129
+    // `ensureFulltextTable` for backends that predate it.
+    const ensureRuntime =
+      backend.ensureRuntimeContributions ?
+        backend.ensureRuntimeContributions(graphId)
+      : backend.ensureFulltextTable?.(graphId);
+    await ensureRuntime;
     return row;
   } catch (error) {
     if (backend.bootstrapTables && isMissingTableError(error)) {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -906,6 +906,11 @@ export class Store<G extends GraphDef> {
    *   `transactionMode: "none"`). A non-atomic fallback is deliberately
    *   not offered here: the caller's relational write *would* still
    *   commit, defeating the purpose of cross-store atomicity.
+   * @throws {StoreNotInitializedError} at point of use, when a fulltext
+   *   operation on the returned context observes a missing/stale/failed
+   *   durable materialization marker (parent store not booted via
+   *   `createStoreWithSchema`). Rolls back the caller's transaction
+   *   without emitting any DDL.
    */
   withTransaction(externalTx: AdoptedTransaction): TransactionContext<G> {
     const adopt = this.#backend.adoptTransaction;

--- a/packages/typegraph/tests/table-contribution.test.ts
+++ b/packages/typegraph/tests/table-contribution.test.ts
@@ -2,11 +2,11 @@
  * Contract tests for the unified `TableContribution` surface (#129).
  *
  * Covers the invariants the refactor must hold and that #135 (durable
- * materialization) will build on: a single Drizzle table object for the
- * Postgres fulltext slot (no duplicate), custom table names reflected
- * in contribution identity, FTS5 staying raw-ddl, tsvector staying
- * drizzle-visible, supporting indexes still emitted, and a custom
- * strategy plugging in through the new `ownedTables` public API.
+ * materialization) builds on: the Postgres fulltext slot emitted once
+ * (strategy-owned, never duplicated by the column-walker), custom table
+ * names reflected in contribution identity, FTS5 staying raw-ddl,
+ * supporting indexes still emitted, and a custom strategy plugging in
+ * through the `ownedTables` public API.
  */
 import { describe, expect, it } from "vitest";
 
@@ -17,7 +17,6 @@ import {
 } from "../src/backend/drizzle/ddl";
 import { createPostgresTables } from "../src/backend/drizzle/schema/postgres";
 import { createSqliteTables } from "../src/backend/drizzle/schema/sqlite";
-import { isDrizzleContribution } from "../src/backend/table-contribution";
 import { type FulltextStrategy, tsvectorStrategy } from "../src/query/dialect";
 
 function fulltextContribution(
@@ -31,23 +30,18 @@ function fulltextContribution(
 }
 
 describe("TableContribution — Postgres (tsvectorStrategy)", () => {
-  it("attaches the exact factory pgTable object — no duplicate", () => {
+  it("emits the strategy-owned fulltext table exactly once", () => {
     const tables = createPostgresTables();
-    const contribution = fulltextContribution(postgresContributions(tables));
-
-    expect(contribution.source.kind).toBe("drizzle-pg");
-    if (contribution.source.kind !== "drizzle-pg") return;
-    // Reference identity: the contribution must carry the SAME object
-    // the factory created and exports, never a second pgTable for the
-    // same physical table.
-    expect(contribution.source.table).toBe(tables.fulltext);
-  });
-
-  it("stays drizzle-kit visible", () => {
-    const contribution = fulltextContribution(
-      postgresContributions(createPostgresTables()),
+    const ddl = generatePostgresDDL(tables, tsvectorStrategy);
+    // The column-walker skips `tables.fulltext` (the strategy owns its
+    // generated tsvector DDL); it must not also emit a second CREATE
+    // TABLE for the same physical name.
+    const creates = ddl.filter((statement) =>
+      statement.includes(
+        'CREATE TABLE IF NOT EXISTS "typegraph_node_fulltext"',
+      ),
     );
-    expect(isDrizzleContribution(contribution)).toBe(true);
+    expect(creates).toHaveLength(1);
   });
 
   it("reflects custom table names in contribution identity", () => {
@@ -106,15 +100,14 @@ describe("TableContribution — Postgres (tsvectorStrategy)", () => {
 });
 
 describe("TableContribution — SQLite (fts5Strategy)", () => {
-  it("is raw-ddl, not drizzle-visible, and emits the FTS5 virtual table", () => {
+  it("emits the FTS5 virtual table as raw DDL", () => {
     const contributions = sqliteContributions(createSqliteTables());
     const fulltext = contributions.find(
       (contribution) => contribution.logicalName === "fulltext",
     );
     if (fulltext === undefined) throw new Error("no fulltext contribution");
 
-    expect(fulltext.source.kind).toBe("raw-ddl");
-    expect(isDrizzleContribution(fulltext)).toBe(false);
+    expect(fulltext.owner).toBe("fts5");
     expect(fulltext.createDdl.join("\n")).toContain(
       "CREATE VIRTUAL TABLE IF NOT EXISTS",
     );
@@ -124,9 +117,8 @@ describe("TableContribution — SQLite (fts5Strategy)", () => {
 
 describe("TableContribution — custom strategy via the ownedTables API", () => {
   it("a custom strategy's ownedTables flows into generated DDL", () => {
-    // Exercises the new public API shape: a strategy declares its
-    // storage through `ownedTables` (Drizzle-free) and the resolver
-    // turns it into emitted DDL.
+    // Exercises the public API shape: a strategy declares its storage
+    // through `ownedTables` (Drizzle-free) and it flows into emitted DDL.
     const customStrategy: FulltextStrategy = {
       ...tsvectorStrategy,
       ownedTables(primaryTableName) {
@@ -139,7 +131,6 @@ describe("TableContribution — custom strategy via the ownedTables API", () => 
               `CREATE TABLE IF NOT EXISTS "${primaryTableName}" (id TEXT);`,
             ],
             runtimeEnsure: true,
-            drizzleModel: "raw-ddl",
           },
         ];
       },
@@ -149,7 +140,6 @@ describe("TableContribution — custom strategy via the ownedTables API", () => 
       postgresContributions(createPostgresTables(), customStrategy),
     );
     expect(contribution.owner).toBe("custom-pg-trgm");
-    expect(contribution.source.kind).toBe("raw-ddl");
 
     const ddl = generatePostgresDDL(
       createPostgresTables(),


### PR DESCRIPTION
Comprehensive code-quality pass over the surface that churned across the three stacked transaction PRs (#136 TableContribution, #138 durable fulltext, #139 cross-store transactions).


## What changed

**Structural**
- **Cut the speculative `source` abstraction.** `TableContributionSource`, `source`, `isDrizzleContribution`, `StrategyDrizzleModel`/`drizzleModel`, and `resolveStrategyContribution` had zero production consumers (only re-exports + tests). `StrategyTableContribution` is now a `TableContribution` alias. Removed both `eslint-disable no-explicit-any` escapes; `isPgTable`/`isSqliteTable` now use Drizzle's real `is()` brand check instead of "any non-string object".
- **Deleted the fully-dead `ensureContribution` API** across all four layers (materializer, `GraphBackend`, both backends) + `findStrategyContribution` that only served it. Never called anywhere.
- **Collapsed the 3-way-duplicated fulltext gate** (`gateFulltext` + both backends' hand-coded non-tx wrappers) into one shared `gateFulltextMethods` — the gating contract now lives once.
- **Removed the tx-adoption type-safety escapes.** New `InternalOperationBackend` intersection lets the factories return their true shape — all three `as unknown as CommonOperationBackend` double-casts gone. Shared `assertAdoptedDialect` guard fails a wrong-dialect handle loudly at the boundary and eliminated the last `as Any*Database` casts (zero adoption casts remain).
- **Shared `coerceNumericScore`** so SQLite enforces the same `FulltextSearchResult.score: number` contract as Postgres.

**Readability**
- `withTransaction` `@throws {StoreNotInitializedError}` documented; `manager.ts` ensure-path; `materializeOne` shares the one state classifier with `assertInitialized`; `StoreNotInitializedError` constructor-shape rationale; comment-bloat trim.

**Docs/changesets**
- The pending (unreleased) changesets for #136/#138 and the fulltext-search doc updated to describe the final trimmed API. No new changeset — every changed API was added by those three unreleased PRs, so editing their changesets is correct (a new one would double-count).

## Deliberately *not* done (flagged, not forced)

- **Marker-store plumbing extraction:** the sibling subsystems (`index-materializations.ts`, `kind-removals.ts`) deliberately share only value-builders/adapters and keep thin per-backend Drizzle plumbing. Extracting only contribution markers would make them *inconsistent* with three siblings.
- **sqlite "sql"-branch / `bindTransactionBackend` unification:** the divergence is legitimate (manual BEGIN/COMMIT on the outer connection vs a distinct `tx` handle). Documented the deliberate divergence rather than risk an unverifiable transaction regression.
