### PR TITLE
feat: atomic transactions for Cloudflare Durable Objects SQLite + tx.sql (#140)

### DIFF
--- a/.changeset/do-sqlite-transactions.md
+++ b/.changeset/do-sqlite-transactions.md
@@ -1,0 +1,69 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Transactional writes for Cloudflare Durable Objects SQLite (`do-sqlite`)
+(#140).
+
+A store backed by `drizzle(ctx.storage)` previously fell back to
+non-transactional behavior, so TypeGraph mutations could not be composed
+atomically with a product's own relational ledger tables (e.g.
+`document_versions`, `change_events`) inside a Durable Object.
+
+**What ships (additive — no breaking changes):**
+
+- New SQLite `transactionMode: "do-sqlite"`, **auto-detected** for
+  `drizzle(ctx.storage)`. Such backends now advertise
+  `capabilities.transactions: true`.
+
+- `store.transaction(async (tx) => …)` and the caller-owned
+  `store.withTransaction(db)` shape both work on Durable Objects. TypeGraph
+  delegates to the async storage runner `ctx.storage.transaction(async …)`
+  (surfaced by Drizzle as `db.$client.transaction`), which rolls back SQL
+  writes across `await`. Drizzle's own `db.transaction()` on DO is
+  `ctx.storage.transactionSync` and cannot span an `await`, so it is
+  deliberately not used. There is no Drizzle transaction handle on DO — the
+  storage transaction is ambient on the object — so the tx-scoped backend
+  binds the outer `db`.
+
+  ```ts
+  await ctx.storage.transaction(async () => {
+    const txStore = store.withTransaction(db);
+    await txStore.nodes.Document.update(documentId, props);
+    await db.insert(documentVersions).values(versionRow);
+    await db.insert(changeEvents).values(eventRow);
+  }); // one storage-transaction COMMIT / ROLLBACK across both layers
+  ```
+
+- A latent detection bug is fixed: drizzle's Durable Objects session class is
+  `SQLiteDOSession` (not the previously-checked `SQLiteDurableObjectSession`),
+  so a real `drizzle(ctx.storage)` store was misclassified.
+
+- New `TransactionContext.sql` — the raw Drizzle handle bound to the same
+  transaction — for graph-owned cross-store writes across **all**
+  transactional backends (Postgres, libsql, better-sqlite3, do-sqlite):
+
+  ```ts
+  await store.transaction(async (tx) => {
+    await tx.nodes.Document.update(documentId, props);
+    await tx.sql.insert(documentVersions).values(versionRow);
+    await tx.sql.insert(changeEvents).values(eventRow);
+  });
+  ```
+
+  This is the graph-owned counterpart of `store.withTransaction` (where the
+  caller owns the boundary). On Postgres/libsql it is a correctness
+  requirement — the outer `db` would write on a different connection and
+  escape the transaction. `tx.sql` is `undefined` only on the
+  non-transactional fallback. Its static type is the `AdoptedTransaction`
+  union; cast to your concrete Drizzle database type at the call site.
+
+**Guarantees.** Building on #135, no schema/bootstrap/fulltext DDL ever runs
+inside the business transaction: `bootstrapTables` and the durable
+materialization marker run outside any storage transaction, while the
+schema-version commit uses the `do-sqlite` runner (data only). Boot the parent
+store via `createStoreWithSchema` once at object startup.
+
+**Out of scope.** Cloudflare D1 stays `transactionMode: "none"`:
+`D1Database.batch(...)` is transactional but not an interactive runner. A
+batch-only D1 mode is tracked separately.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,28 @@ jobs:
           # Use 127.0.0.1 instead of localhost to avoid IPv6 resolution issues
           POSTGRES_URL: postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test
 
+  test-durable-objects:
+    name: Test (Durable Objects SQLite)
+    runs-on: ubuntu-24.04
+    needs: [detect-release-metadata-push]
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Durable Objects SQLite tests (workerd)
+        run: pnpm --filter @nicia-ai/typegraph test:do
+
   build:
     name: Build
     runs-on: ubuntu-24.04
@@ -240,6 +262,7 @@ jobs:
       - test-coverage
       - test-typescript-compat
       - test-postgres
+      - test-durable-objects
     if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ npm install @nicia-ai/typegraph zod drizzle-orm better-sqlite3
 npm install -D @types/better-sqlite3
 ```
 
-For edge/serverless environments (D1, libsql, bun:sqlite), see the docs:
+For edge/serverless environments (Cloudflare Durable Objects, D1, libsql,
+bun:sqlite), see the docs:
 [Edge and Serverless](https://typegraph.dev/integration#edge-and-serverless).
 
 ## Quick Start

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -539,7 +539,53 @@ export default {
 If you prefer to manage DDL yourself, use `createStore()` with manual migrations
 instead.
 
-**Important:** D1 does not support transactions. See [Limitations](/limitations) for details.
+**Important:** D1 has no interactive transaction primitive
+(`D1Database.batch(...)` is transactional, but batch-only — not an
+interactive runner), so `store.transaction()` is non-atomic on D1. See
+[Limitations](/limitations) for details. For a transactional Cloudflare
+SQLite store, use **Durable Objects** (below) instead.
+
+## Cloudflare Durable Objects (SQLite)
+
+A store backed by `drizzle(ctx.storage)` inside a Durable Object is
+**auto-detected** as `transactionMode: "do-sqlite"` and reports
+`capabilities.transactions: true` — no `executionProfile` hint needed.
+Unlike D1, Durable Objects expose an interactive storage transaction runner,
+so `store.transaction()` and `store.withTransaction()` are fully atomic.
+
+```typescript
+import { drizzle } from "drizzle-orm/durable-sqlite";
+import { createStoreWithSchema } from "@nicia-ai/typegraph";
+import { createSqliteBackend } from "@nicia-ai/typegraph/sqlite";
+
+export class MyObject {
+  constructor(private ctx: DurableObjectState) {}
+
+  async handle() {
+    const db = drizzle(this.ctx.storage);
+    const backend = createSqliteBackend(db);
+    // Boots schema/DDL outside any storage transaction (no DDL in the
+    // business transaction); the schema-version commit uses the
+    // do-sqlite runner.
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    // Atomic across TypeGraph + the product's own relational tables:
+    await store.transaction(async (tx) => {
+      await tx.nodes.Document.update(documentId, props);
+      // tx.sql is the AdoptedTransaction union — cast to your db type.
+      const sqlTx = tx.sql as typeof db;
+      await sqlTx.insert(documentVersions).values(versionRow);
+    });
+  }
+}
+```
+
+TypeGraph delegates to the async storage runner
+`ctx.storage.transaction(async …)` (Drizzle's own `db.transaction()` on
+Durable Objects is `ctx.storage.transactionSync` and cannot span an
+`await`, so it is not used). See the
+[Cross-Store Transactions recipe](/recipes#cross-store-transactions-drizzle--typegraph)
+for the caller-owned (`withTransaction`) and graph-owned (`tx.sql`) shapes.
 
 ## Backend Capabilities
 

--- a/apps/docs/src/content/docs/integration.md
+++ b/apps/docs/src/content/docs/integration.md
@@ -609,9 +609,43 @@ see the dedicated [Testing](/testing) guide.
 
 Deploy TypeGraph at the edge using SQLite-compatible runtimes.
 
-> **Note:** Edge environments cannot use `@nicia-ai/typegraph/sqlite` because it
-> depends on `better-sqlite3`, a native Node.js addon. Instead, use
+> **Note:** Edge environments cannot use `@nicia-ai/typegraph/sqlite/local`
+> because it depends on `better-sqlite3`, a native Node.js addon. Instead, use
 > `@nicia-ai/typegraph/sqlite` which is driver-agnostic.
+
+**Cloudflare Durable Objects (SQLite) — transactional:**
+
+```typescript
+import { drizzle } from "drizzle-orm/durable-sqlite";
+import { createStoreWithSchema } from "@nicia-ai/typegraph";
+import { createSqliteBackend } from "@nicia-ai/typegraph/sqlite";
+
+export class GraphObject {
+  constructor(private ctx: DurableObjectState) {}
+
+  async fetch(): Promise<Response> {
+    const db = drizzle(this.ctx.storage);
+    const backend = createSqliteBackend(db); // auto-detects "do-sqlite"
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    // Atomic across TypeGraph + the caller's own relational tables:
+    await store.transaction(async (tx) => {
+      await tx.nodes.Document.update(documentId, props);
+      // tx.sql is the AdoptedTransaction union — cast to your db type.
+      const sqlTx = tx.sql as typeof db;
+      await sqlTx.insert(documentVersions).values(versionRow);
+    });
+
+    return new Response("ok");
+  }
+}
+```
+
+Unlike D1, Durable Objects expose an interactive storage transaction runner,
+so `store.transaction()` / `store.withTransaction()` are fully atomic
+(`capabilities.transactions: true`). See
+[Backend Setup](/backend-setup#cloudflare-durable-objects-sqlite) and the
+[Cross-Store Transactions recipe](/recipes#cross-store-transactions-drizzle--typegraph).
 
 **Cloudflare Workers with D1:**
 

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -10,9 +10,16 @@ This page documents TypeGraph's known limitations and constraints.
 Some runtimes cannot hold a multi-statement database session and therefore
 cannot offer atomic transactions:
 
-- **Cloudflare D1** — the D1 binding has no transaction primitive.
+- **Cloudflare D1** — the D1 binding has no interactive transaction
+  primitive (`D1Database.batch(...)` is transactional but batch-only).
 - **`drizzle-orm/neon-http`** — Neon's HTTP driver issues each statement as
   an independent request; there is no session to bind a transaction to.
+
+Cloudflare **Durable Objects** SQLite is *not* in this list: a store backed
+by `drizzle(ctx.storage)` is auto-detected as `transactionMode: "do-sqlite"`,
+reports `capabilities.transactions: true`, and is fully atomic (including
+`store.withTransaction` and `tx.sql`). See
+[Backend Setup](/backend-setup#cloudflare-durable-objects-sqlite).
 
 These backends report `capabilities.transactions: false`. On such backends,
 `store.transaction(fn)` and `store.batch(...)` still run — `fn` executes

--- a/apps/docs/src/content/docs/recipes.md
+++ b/apps/docs/src/content/docs/recipes.md
@@ -639,6 +639,35 @@ else touches the connection between `BEGIN` and `COMMIT`/`ROLLBACK`. Do not
 interleave other async work that writes to the same connection inside the
 `try`.
 
+**Cloudflare Durable Objects (`do-sqlite`).** A store backed by
+`drizzle(ctx.storage)` is auto-detected as `transactionMode: "do-sqlite"`
+and advertises `capabilities.transactions: true`. Drizzle's own
+`db.transaction()` here is `ctx.storage.transactionSync` and cannot span an
+`await`; TypeGraph instead delegates to the async storage runner
+`ctx.storage.transaction(async …)` (surfaced by Drizzle as
+`db.$client.transaction`), which rolls back SQL writes across `await`. There
+is no Drizzle transaction handle on Durable Objects — the storage
+transaction is ambient on the object — so the caller hands `withTransaction`
+the same `db`:
+
+```typescript
+await ctx.storage.transaction(async () => {
+  const txStore = store.withTransaction(db);
+  await txStore.nodes.Document.update(documentId, props);
+  await db.insert(documentVersions).values(versionRow);
+  await db.insert(changeEvents).values(eventRow);
+}); // one storage-transaction COMMIT / ROLLBACK across both layers
+```
+
+`store.transaction(async (tx) => …)` works the same way (TypeGraph opens the
+storage transaction for you). Boot the parent store with
+`createStoreWithSchema` at object startup: bootstrap DDL and the durable
+materialization marker run *outside* any storage transaction (no DDL is ever
+emitted inside the business transaction), while the schema-version commit
+uses the `do-sqlite` runner. Cloudflare D1 is **not** `do-sqlite`:
+`D1Database.batch(...)` is transactional but not an interactive runner, so
+D1-backed stores stay `transactionMode: "none"` pending separate work.
+
 The adopted context exposes the `{ nodes, edges }` surface (same as
 `store.transaction`) and reuses the parent store's resolved schema — it runs
 no migration and emits no DDL inside your transaction. Boot the parent store
@@ -651,6 +680,35 @@ real rollback (`backend.capabilities.transactions === false`:
 `drizzle-orm/neon-http`, Cloudflare D1, SQLite `transactionMode: "none"`) —
 it never silently degrades to a non-atomic fallback, because the relational
 write would still commit.
+
+#### Graph-owned: `store.transaction` + `tx.sql`
+
+`withTransaction` is for when the **caller** owns the transaction boundary.
+When **TypeGraph** should own it, use `store.transaction(async (tx) => …)` and
+write your own relational tables through `tx.sql` — the raw Drizzle handle
+bound to that same transaction:
+
+```typescript
+await store.transaction(async (tx) => {
+  await tx.nodes.Document.update(documentId, props);
+  // tx.sql is the AdoptedTransaction union — cast to your concrete
+  // Drizzle database type at the call site.
+  const sqlTx = tx.sql as NodePgDatabase;
+  await sqlTx.insert(documentVersions).values(versionRow);
+  await sqlTx.insert(changeEvents).values(eventRow);
+}); // one COMMIT / ROLLBACK across both layers
+```
+
+`tx.sql`'s static type is the `AdoptedTransaction` union; cast it to your
+concrete Drizzle database type at the call site (as above).
+On **Postgres / libsql** this is mandatory for correctness — using the outer
+`db` would write on a *different* connection and silently escape the
+transaction. On **better-sqlite3** it is the single connection framed by
+TypeGraph's `BEGIN`/`COMMIT`/`ROLLBACK`; on **Durable Objects**
+(`do-sqlite`) it is the bound handle (the storage transaction is ambient).
+`tx.sql` is `undefined` only on the non-transactional fallback
+(`capabilities.transactions === false`), where `store.transaction` runs the
+callback with no atomicity and there is no transaction to join.
 
 ## Enforcing Unique Constraints
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,7 +8,13 @@ const config: KnipConfig = {
         "examples/*.ts",
         "test-d/**/*.test-d.ts",
         "type-smoke/**/*.ts",
+        // workerd entry for the do-sqlite test lane: its default export
+        // is loaded by @cloudflare/vitest-pool-workers, not imported.
+        "tests/do-sqlite/worker.ts",
       ],
+      // `cloudflare:test` / `cloudflare:workers` are workerd virtual
+      // modules provided by the pool at runtime, not npm packages.
+      ignoreDependencies: ["cloudflare"],
       project: [
         "src/**/*.ts",
         "tests/**/*.ts",

--- a/packages/typegraph/eslint.config.mjs
+++ b/packages/typegraph/eslint.config.mjs
@@ -3,5 +3,14 @@
 import { createLibraryConfig } from "@typegraph/eslint-config/library";
 
 export default createLibraryConfig(import.meta.dirname, {
-  ignores: ["examples/**", "test-d/**", "type-smoke/**", "tmp/**"],
+  ignores: [
+    "examples/**",
+    "test-d/**",
+    "type-smoke/**",
+    "tmp/**",
+    // #140: workerd-only do-sqlite suite (cloudflare:test). Runs via
+    // its own `test:do` lane, not the Node lanes which cannot resolve
+    // the `cloudflare:test` / worker ambient types.
+    "tests/do-sqlite/**",
+  ],
 });

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -85,6 +85,7 @@
     "test:perf:postgres": "pnpm --filter @nicia-ai/typegraph-benchmarks perf:check:postgres",
     "bench:perf:postgres": "pnpm --filter @nicia-ai/typegraph-benchmarks perf:postgres",
     "test:postgres": "./scripts/test-postgres.sh",
+    "test:do": "vitest run --config vitest.workers.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:mutation": "stryker run"
   },
@@ -145,6 +146,7 @@
     "nanoid": "^5.1.11"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.6",
     "@libsql/client": "^0.17.3",
     "@neondatabase/serverless": "^1.1.0",
     "@stryker-mutator/core": "^9.6.1",

--- a/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
@@ -43,10 +43,18 @@ type DatabaseWithSession = Readonly<{
  *                Default for sync drivers (better-sqlite3, bun:sqlite).
  * - `"drizzle"`: Delegates to Drizzle's `db.transaction()` method.
  *                Default for async drivers (libsql, sql.js).
- * - `"none"`:    Transactions disabled.
- *                Default for Cloudflare D1 and Durable Objects.
+ * - `"do-sqlite"`: Delegates to the Cloudflare Durable Objects async
+ *                storage transaction runner (`db.$client.transaction`,
+ *                i.e. `ctx.storage.transaction(async ...)`). Drizzle's
+ *                own `db.transaction()` on DO is
+ *                `ctx.storage.transactionSync` and cannot span `await`,
+ *                so it is deliberately not used. Auto-detected for
+ *                `drizzle(ctx.storage)` (#140).
+ * - `"none"`:    Transactions disabled. Default for Cloudflare D1
+ *                (`D1Database.batch` is transactional but not an
+ *                interactive runner — tracked separately).
  */
-export type SqliteTransactionMode = "sql" | "drizzle" | "none";
+export type SqliteTransactionMode = "sql" | "drizzle" | "none" | "do-sqlite";
 
 export type SqliteExecutionProfileHints = Readonly<{
   isSync?: boolean;
@@ -89,7 +97,13 @@ function isD1DatabaseBySessionName(db: AnySqliteDatabase): boolean {
 
 function isDurableObjectBySessionName(db: AnySqliteDatabase): boolean {
   const sessionName = getSessionName(db);
-  return sessionName === "SQLiteDurableObjectSession";
+  // drizzle-orm/durable-sqlite's session class is `SQLiteDOSession`
+  // (verified drizzle 0.45.x). `SQLiteDurableObjectSession` is kept as
+  // a defensive alias against future drizzle renames.
+  return (
+    sessionName === "SQLiteDOSession" ||
+    sessionName === "SQLiteDurableObjectSession"
+  );
 }
 
 function isSyncDatabaseBySessionName(db: AnySqliteDatabase): boolean {
@@ -109,6 +123,11 @@ function detectSyncProfile(
 
   const sessionName = getSessionName(db);
   if (sessionName === "BetterSQLiteSession" || sessionName === "BunSQLiteSession") {
+    return true;
+  }
+  // Durable Objects SQLite is synchronous (`ctx.storage` exec /
+  // `transactionSync`); detect it by name rather than the SQL probe.
+  if (isDurableObjectBySessionName(db)) {
     return true;
   }
   if (sessionName === "SQLiteD1Session") {
@@ -131,12 +150,18 @@ function detectTransactionMode(
   if (profileHints.transactionMode !== undefined) {
     return profileHints.transactionMode;
   }
-  // D1 and Durable Object SQLite do not support raw BEGIN/COMMIT SQL
-  // through Drizzle's db.run(). Default to "none" because async
-  // transaction callbacks are not reliably supported across sync
-  // Drizzle drivers. Users can opt in to "drizzle" mode explicitly if
-  // their runtime's db.transaction() handles async callbacks.
-  if (isD1DatabaseBySessionName(db) || isDurableObjectBySessionName(db)) {
+  // Neither D1 nor Durable Object SQLite supports raw BEGIN/COMMIT SQL
+  // through Drizzle's db.run(), and Drizzle's own db.transaction() on
+  // Durable Objects is `ctx.storage.transactionSync` (cannot span an
+  // await). Durable Objects expose an async storage transaction runner
+  // (`ctx.storage.transaction(async ...)`, surfaced by Drizzle as
+  // `db.$client.transaction`) — route those through "do-sqlite" (#140).
+  // D1 has no equivalent interactive runner (only batch); it stays
+  // "none" pending a separate batch-mode investigation.
+  if (isDurableObjectBySessionName(db)) {
+    return "do-sqlite";
+  }
+  if (isD1DatabaseBySessionName(db)) {
     return "none";
   }
   if (isSync) return "sql";

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -684,7 +684,7 @@ export function createPostgresBackend(
     },
 
     async transaction<T>(
-      fn: (tx: TransactionBackend) => Promise<T>,
+      fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
       options?: TransactionOptions,
     ): Promise<T> {
       // #134/#135: NO DDL or ensure here. The tx-scoped backend's
@@ -705,7 +705,7 @@ export function createPostgresBackend(
         : undefined;
 
       return db.transaction(
-        async (tx) => fn(bindTransactionBackend(tx)),
+        async (tx) => fn(bindTransactionBackend(tx), tx),
         txConfig,
       );
     },

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -134,8 +134,9 @@ export type SqliteBackendOptions = Readonly<{
   tables?: SqliteTables;
   /**
    * Optional execution profile hints used to avoid runtime driver reflection.
-   * Set `transactionMode: "none"` for drivers that do not support transactions
-   * (e.g. Cloudflare D1, Durable Objects).
+   * Set `transactionMode: "none"` for drivers without transactions (e.g.
+   * Cloudflare D1). Durable Objects (`drizzle(ctx.storage)`) auto-detect
+   * `transactionMode: "do-sqlite"` and do not need a hint.
    */
   executionProfile?: SqliteExecutionProfileHints;
   /**
@@ -273,6 +274,24 @@ const SQLITE_VECTOR_INDEX_TYPES = ["none"] as const;
 // performance degrades well before pgvector's 16k limit. 8000 is a
 // conservative ceiling consistent with the extension's typical use.
 const SQLITE_VECTOR_MAX_DIMENSIONS = 8000;
+
+/**
+ * The async storage transaction runner Drizzle's durable-sqlite driver
+ * exposes as `db.$client` (`ctx.storage.transaction(async () => ...)`).
+ * Structural because drizzle-orm does not export the DO `$client` type.
+ */
+interface DurableObjectStorageClient {
+  transaction?: <R>(closure: () => Promise<R>) => Promise<R>;
+}
+
+/** Every SQLite "atomic transactions unavailable" refusal shares this shape. */
+function throwSqliteTransactionsDisabled(message: string): never {
+  throw new ConfigurationError(message, {
+    backend: "sqlite",
+    capability: "transactions",
+    supportsTransactions: false,
+  });
+}
 
 function buildSqliteCapabilities(
   options: Readonly<{
@@ -617,6 +636,38 @@ export function createSqliteBackend(
   });
 
   /**
+   * #140: the `transactionMode: "do-sqlite"` primitive. Cloudflare
+   * Durable Objects expose an async storage transaction runner —
+   * `ctx.storage.transaction(async () => ...)`, surfaced by Drizzle as
+   * `db.$client.transaction` — that rolls back SQL writes across
+   * `await`. There is no Drizzle tx handle on DO: the storage
+   * transaction is ambient on the object, so callers bind the *outer*
+   * `db` (as the "sql" path binds the outer connection). Drizzle's own
+   * `db.transaction()` here is `ctx.storage.transactionSync` and cannot
+   * span an await, so it is deliberately not used. Shared by
+   * `transaction()` (business writes) and `runSchemaWriteTransaction()`
+   * (schema-version commits — data only, never DDL: the #135 invariant
+   * holds because `bootstrapTables` runs outside any transaction).
+   */
+  function runDoSqliteStorageTransaction<T>(
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const storage = (db as { $client?: DurableObjectStorageClient }).$client;
+    const storageTransaction = storage?.transaction;
+    if (typeof storageTransaction !== "function") {
+      throwSqliteTransactionsDisabled(
+        "transactionMode 'do-sqlite' requires a Drizzle Durable Objects " +
+          "database (drizzle(ctx.storage)) whose `$client` exposes the " +
+          "async storage `transaction(async () => ...)` runner.",
+      );
+    }
+    return runWithSerializedQueue(
+      serializedQueue,
+      async () => storageTransaction.call(storage, run) as Promise<T>,
+    );
+  }
+
+  /**
    * Runs `fn` inside a SQLite write transaction (BEGIN IMMEDIATE) so that
    * the read-then-write inside `commitSchemaVersion` / `setActiveVersion`
    * is serialized against concurrent writers — a deferred BEGIN would let
@@ -630,16 +681,11 @@ export function createSqliteBackend(
     fn: (tx: CommonOperationBackend) => Promise<T>,
   ): Promise<T> {
     if (transactionMode === "none") {
-      throw new ConfigurationError(
+      throwSqliteTransactionsDisabled(
         "commitSchemaVersion and setActiveVersion require atomic transactions, " +
           "but this SQLite backend has transactions disabled. Configure a " +
           "driver that supports transactions (better-sqlite3, libsql, " +
           "bun:sqlite) to use schema commits.",
-        {
-          backend: "sqlite",
-          capability: "transactions",
-          supportsTransactions: false,
-        },
       );
     }
 
@@ -666,6 +712,28 @@ export function createSqliteBackend(
           db.run(sql`ROLLBACK`);
           throw error;
         }
+      });
+    }
+
+    if (transactionMode === "do-sqlite") {
+      // No interactive lock-mode control on the DO storage runner; the
+      // serialized queue (always present — DO is sync) provides the
+      // single-writer ordering that "immediate" gives the other paths.
+      // Raw txBackend (no `gateFulltext`, unlike the business
+      // `transaction()` do-sqlite branch): schema-version commits are
+      // data-only and never touch fulltext (#135), matching the "sql"
+      // and "drizzle" schema-write branches.
+      return runDoSqliteStorageTransaction(async () => {
+        const txBackend = createTransactionBackend({
+          capabilities,
+          db,
+          operationStrategy,
+          profileHints: { isSync },
+          tableNames,
+          fulltextStrategy,
+          hasVectorEmbeddings,
+        });
+        return fn(txBackend);
       });
     }
 
@@ -981,20 +1049,15 @@ export function createSqliteBackend(
     },
 
     async transaction<T>(
-      fn: (tx: TransactionBackend) => Promise<T>,
+      fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
       _options?: TransactionOptions,
     ): Promise<T> {
       if (transactionMode === "none") {
-        throw new ConfigurationError(
+        throwSqliteTransactionsDisabled(
           "This SQLite backend does not support atomic transactions. " +
             "Operations within a transaction are not rolled back on failure. " +
             "Use backend.capabilities.transactions to check for transaction support, " +
             "or use individual operations with manual error handling.",
-          {
-            backend: "sqlite",
-            capability: "transactions",
-            supportsTransactions: false,
-          },
         );
       }
 
@@ -1023,7 +1086,11 @@ export function createSqliteBackend(
 
           try {
             const result = await fn(
-              gateFulltext(txBackend, contributionMaterializer.assertInitialized),
+              gateFulltext(
+                txBackend,
+                contributionMaterializer.assertInitialized,
+              ),
+              db,
             );
             db.run(sql`COMMIT`);
             return result;
@@ -1034,10 +1101,16 @@ export function createSqliteBackend(
         });
       }
 
+      if (transactionMode === "do-sqlite") {
+        return runDoSqliteStorageTransaction(async () =>
+          fn(bindTransactionBackend(db), db),
+        );
+      }
+
       // transactionMode === "drizzle"
       return runWithSerializedQueue(serializedQueue, async () =>
         db.transaction(
-          async (tx) => fn(bindTransactionBackend(tx)),
+          async (tx) => fn(bindTransactionBackend(tx), tx),
         ) as Promise<T>,
       );
     },
@@ -1048,18 +1121,13 @@ export function createSqliteBackend(
       // would commit with no way to undo the graph write. Refuse
       // loudly rather than silently degrade.
       if (transactionMode === "none") {
-        throw new ConfigurationError(
+        throwSqliteTransactionsDisabled(
           "Cross-store atomicity is unavailable on this SQLite backend: " +
             "transactions are disabled (transactionMode: 'none'). Adopting " +
             "an external transaction here would let the caller's relational " +
             "write commit with no way to roll back the graph write. " +
             "Configure a driver that supports transactions (better-sqlite3, " +
             "libsql, bun:sqlite).",
-          {
-            backend: "sqlite",
-            capability: "transactions",
-            supportsTransactions: false,
-          },
         );
       }
       assertAdoptedDialect<AnySqliteDatabase>(

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1114,8 +1114,18 @@ export type GraphBackend = Readonly<{
   executeDdl?: (ddl: string) => Promise<void>;
 
   // === Transaction ===
+  /**
+   * `fn` receives the tx-scoped backend and the raw Drizzle handle
+   * **bound to that same transaction** (`AdoptedTransaction`). The
+   * store surfaces the second argument as `TransactionContext.sql` so
+   * callers can write their own relational tables inside the
+   * graph-owned transaction. Implementations MUST pass the *exact*
+   * handle the tx-scoped backend writes through (the Postgres/libsql
+   * tx handle; for better-sqlite3 / do-sqlite the bound connection),
+   * never a fresh one.
+   */
   transaction: <T>(
-    fn: (tx: TransactionBackend) => Promise<T>,
+    fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
     options?: TransactionOptions,
   ) => Promise<T>;
 

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -809,6 +809,12 @@ export class Store<G extends GraphDef> {
    * The transaction context provides the same collection API as the Store:
    * - `tx.nodes.Person.create(...)` - Create a node
    * - `tx.edges.worksAt.create(...)` - Create an edge
+   * - `tx.sql` - the raw Drizzle handle **bound to this same
+   *   transaction**, for writing the caller's own relational tables in
+   *   the same atomic boundary (the graph-owned counterpart of
+   *   {@link Store.withTransaction}). See {@link TransactionContext}
+   *   for per-backend semantics; it is `undefined` only on the
+   *   non-transactional fallback.
    *
    * @example
    * ```typescript
@@ -820,6 +826,16 @@ export class Store<G extends GraphDef> {
    *     { kind: "Company", id: company.id },
    *     { role: "Engineer" }
    *   );
+   * });
+   * ```
+   *
+   * @example Cross-store write via `tx.sql` (graph-owned boundary):
+   * ```typescript
+   * await store.transaction(async (tx) => {
+   *   await tx.nodes.Document.update(documentId, props);
+   *   // cast `tx.sql` to your concrete Drizzle database type
+   *   const sqlTx = tx.sql as NodePgDatabase;
+   *   await sqlTx.insert(documentVersions).values(versionRow);
    * });
    * ```
    *
@@ -852,8 +868,8 @@ export class Store<G extends GraphDef> {
     // tx-scoped fulltext methods so the durable-marker assert fires at
     // point of use (a cached SELECT, never DDL). A transaction that
     // never touches fulltext requires no fulltext initialization.
-    return this.#backend.transaction(async (txBackend) =>
-      fn(this.#buildTransactionContext(txBackend)),
+    return this.#backend.transaction(async (txBackend, sql) =>
+      fn(this.#buildTransactionContext(txBackend, sql)),
     );
   }
 
@@ -924,18 +940,24 @@ export class Store<G extends GraphDef> {
         { capability: "adoptTransaction" },
       );
     }
-    return this.#buildTransactionContext(adopt(externalTx));
+    // The caller already owns the boundary, so `externalTx` *is* the
+    // bound handle — surface it as `tx.sql` for symmetry with the
+    // graph-owned `transaction()` path.
+    return this.#buildTransactionContext(adopt(externalTx), externalTx);
   }
 
   /**
-   * Builds the `{ nodes, edges }` projection bound to a transaction-
-   * scoped backend. Shared verbatim by {@link transaction} (TypeGraph
-   * opens the tx) and {@link withTransaction} (#134 — the caller opened
-   * it) so both surfaces resolve collections, query factories, and the
-   * reused graph/registry identically.
+   * Builds the `{ nodes, edges, sql }` projection bound to a
+   * transaction-scoped backend. Shared verbatim by {@link transaction}
+   * (TypeGraph opens the tx) and {@link withTransaction} (#134 — the
+   * caller opened it) so both surfaces resolve collections, query
+   * factories, and the reused graph/registry identically. `sql` is the
+   * raw Drizzle handle bound to the same transaction (#140);
+   * `undefined` only on the non-transactional fallback.
    */
   #buildTransactionContext(
     txBackend: TransactionBackend,
+    sql?: AdoptedTransaction,
   ): TransactionContext<G> {
     const txNodeOperations: NodeOperations = {
       ...this.#nodeOperations,
@@ -962,7 +984,7 @@ export class Store<G extends GraphDef> {
       txEdgeOperations,
     );
 
-    return { nodes, edges };
+    return sql === undefined ? { nodes, edges } : { nodes, edges, sql };
   }
 
   // === Graph Lifecycle ===

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -3,7 +3,11 @@
  */
 import { type z } from "zod";
 
-import { type EdgeRow, type NodeRow } from "../backend/types";
+import {
+  type AdoptedTransaction,
+  type EdgeRow,
+  type NodeRow,
+} from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
 import {
   type AnyEdgeType,
@@ -946,6 +950,41 @@ export type GraphEdgeCollections<G extends GraphDef> = {
  * Provides the same `tx.nodes.*` and `tx.edges.*` API as the Store,
  * but operations are executed within the transaction scope.
  *
+ * `tx.sql` is the raw Drizzle handle **bound to this same
+ * transaction** — use it to write the caller's own relational tables
+ * inside the graph-owned transaction so both layers commit or roll
+ * back together (the graph-owned counterpart of
+ * {@link Store.withTransaction}, where the caller owns the boundary):
+ *
+ * ```typescript
+ * await store.transaction(async (tx) => {
+ *   await tx.nodes.Document.update(documentId, props);
+ *   // `tx.sql` is the `AdoptedTransaction` union — cast to your
+ *   // concrete Drizzle database type at the call site.
+ *   const sqlTx = tx.sql as NodePgDatabase;
+ *   await sqlTx.insert(documentVersions).values(versionRow);
+ *   await sqlTx.insert(changeEvents).values(eventRow);
+ * });
+ * ```
+ *
+ * Per-backend semantics:
+ * - **Postgres / libsql** (async drivers): `tx.sql` is the Drizzle
+ *   transaction handle. Using the outer `db` instead would write on a
+ *   *different* connection and silently escape the transaction — so
+ *   `tx.sql` is a correctness requirement there.
+ * - **better-sqlite3**: the single connection, framed by TypeGraph's
+ *   `BEGIN`/`COMMIT`/`ROLLBACK`.
+ * - **Durable Objects (`do-sqlite`)**: the bound Drizzle handle; the
+ *   storage transaction is ambient, so writing the outer `db` also
+ *   enlists — `tx.sql` is the explicit, portable form.
+ *
+ * It is `undefined` only on the non-transactional fallback
+ * (`backend.capabilities.transactions === false` — e.g. Cloudflare
+ * D1, `drizzle-orm/neon-http`), where `store.transaction()` runs the
+ * callback with no atomicity and there is no transaction to enlist.
+ * Its type is the `AdoptedTransaction` union; cast to your concrete
+ * Drizzle database type at the call site.
+ *
  * @example
  * ```typescript
  * await store.transaction(async (tx) => {
@@ -958,6 +997,7 @@ export type GraphEdgeCollections<G extends GraphDef> = {
 export type TransactionContext<G extends GraphDef> = Readonly<{
   nodes: GraphNodeCollections<G>;
   edges: GraphEdgeCollections<G>;
+  sql?: AdoptedTransaction;
 }>;
 
 // ============================================================

--- a/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
@@ -234,5 +234,52 @@ describe.runIf(process.env.POSTGRES_URL)(
         /Cross-store atomicity is unavailable/,
       );
     });
+
+    // #140 — graph-owned: TypeGraph opens the tx, `tx.sql` is
+    // the bound pg transaction handle. Using the outer `db` instead
+    // would write on a different connection and escape the tx, so
+    // `tx.sql` is a correctness requirement here.
+    it("commits a graph node and a tx.sql relational row in one store.transaction", async () => {
+      const backend = createPostgresBackend(db!);
+      const store = createStore(PlainGraph, backend);
+
+      const source = await store.transaction(async (tx) => {
+        const sqlTx = tx.sql as NodePgDatabase;
+        const inserted = await sqlTx
+          .insert(connectors)
+          .values({ name: "github" })
+          .returning({ id: connectors.id });
+        return tx.nodes.ArtifactSource.create({
+          connectorId: inserted[0]!.id,
+          label: "primary",
+        });
+      });
+
+      expect(await db!.select().from(connectors)).toEqual([
+        { id: 1, name: "github" },
+      ]);
+      const fetched = await store.nodes.ArtifactSource.getById(source.id);
+      expect(fetched?.connectorId).toBe(1);
+    });
+
+    it("rolls back BOTH the graph node and the tx.sql relational row when the callback throws", async () => {
+      const backend = createPostgresBackend(db!);
+      const store = createStore(PlainGraph, backend);
+
+      await expect(
+        store.transaction(async (tx) => {
+          const sqlTx = tx.sql as NodePgDatabase;
+          await sqlTx.insert(connectors).values({ name: "orphan" });
+          await tx.nodes.ArtifactSource.create({
+            connectorId: 999,
+            label: "doomed",
+          });
+          throw new Error("phase2-pg-rollback");
+        }),
+      ).rejects.toThrow("phase2-pg-rollback");
+
+      expect(await db!.select().from(connectors)).toEqual([]);
+      expect(await store.nodes.ArtifactSource.find()).toEqual([]);
+    });
   },
 );

--- a/packages/typegraph/tests/backends/sqlite/libsql-cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/libsql-cross-store-transaction.test.ts
@@ -118,4 +118,52 @@ describe("#134 cross-store atomicity (libsql, documented async shape)", () => {
     expect(await store.nodes.ArtifactSource.find()).toEqual([]);
     client.close();
   });
+
+  // #140 — graph-owned: TypeGraph opens the tx, `tx.sql` is
+  // the bound libsql transaction handle (the "drizzle" SQLite mode).
+  it("commits/rolls back a tx.sql relational row with the graph node in one store.transaction", async () => {
+    const client = createClient({ url: `file:${createTemporaryDbPath()}` });
+    const { backend, db } = await createLibsqlBackend(client);
+    await client.execute(
+      "CREATE TABLE connectors (" +
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+    );
+    const store = createStore(PlainGraph, backend);
+
+    const source = await store.transaction(async (tx) => {
+      const sqlTx = tx.sql as typeof db;
+      const inserted = await sqlTx
+        .insert(connectors)
+        .values({ name: "github" })
+        .returning({ id: connectors.id });
+      return tx.nodes.ArtifactSource.create({
+        connectorId: inserted[0]!.id,
+        label: "primary",
+      });
+    });
+
+    expect(await db.select().from(connectors)).toEqual([
+      { id: 1, name: "github" },
+    ]);
+    const fetched = await store.nodes.ArtifactSource.getById(source.id);
+    expect(fetched?.connectorId).toBe(1);
+
+    await expect(
+      store.transaction(async (tx) => {
+        const sqlTx = tx.sql as typeof db;
+        await sqlTx.insert(connectors).values({ name: "orphan" });
+        await tx.nodes.ArtifactSource.create({
+          connectorId: 999,
+          label: "doomed",
+        });
+        throw new Error("phase2-libsql-rollback");
+      }),
+    ).rejects.toThrow("phase2-libsql-rollback");
+
+    expect(await db.select().from(connectors)).toEqual([
+      { id: 1, name: "github" },
+    ]);
+    expect(await store.nodes.ArtifactSource.find()).toHaveLength(1);
+    client.close();
+  });
 });

--- a/packages/typegraph/tests/collection-api.test.ts
+++ b/packages/typegraph/tests/collection-api.test.ts
@@ -9,7 +9,11 @@ import { z } from "zod";
 
 import { defineEdge, defineGraph, defineNode, type EdgeId } from "../src";
 import { createSqliteBackend } from "../src/backend/sqlite";
-import type { GraphBackend, TransactionBackend } from "../src/backend/types";
+import type {
+  AdoptedTransaction,
+  GraphBackend,
+  TransactionBackend,
+} from "../src/backend/types";
 import { createStore } from "../src/store";
 import { createTestBackend, createTestDatabase } from "./test-utils";
 
@@ -233,10 +237,10 @@ describe("Node Collections (SQLite)", () => {
           return baseBackend.execute<T>(query);
         },
         async transaction<T>(
-          fn: (tx: TransactionBackend) => Promise<T>,
+          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
           options?: Parameters<GraphBackend["transaction"]>[1],
         ): Promise<T> {
-          return baseBackend.transaction(async (txBackend) => {
+          return baseBackend.transaction(async (txBackend, sql) => {
             const observedTxBackend: TransactionBackend = {
               ...txBackend,
               async execute<T>(
@@ -246,7 +250,7 @@ describe("Node Collections (SQLite)", () => {
                 return txBackend.execute<T>(query);
               },
             };
-            return fn(observedTxBackend);
+            return fn(observedTxBackend, sql);
           }, options);
         },
       };
@@ -791,7 +795,7 @@ describe("Bulk Operations (SQLite)", () => {
           await insertNodesBatchWithFallback(baseBackend, params);
         },
         async transaction(fn, options) {
-          return baseBackend.transaction(async (tx) => {
+          return baseBackend.transaction(async (tx, sql) => {
             const wrappedTx: TransactionBackend = {
               ...tx,
               async insertNodeNoReturn(params) {
@@ -803,7 +807,7 @@ describe("Bulk Operations (SQLite)", () => {
                 await insertNodesBatchWithFallback(tx, params);
               },
             };
-            return fn(wrappedTx);
+            return fn(wrappedTx, sql);
           }, options);
         },
       };
@@ -988,7 +992,7 @@ describe("Bulk Operations (SQLite)", () => {
           await insertEdgesBatchWithFallback(baseBackend, params);
         },
         async transaction(fn, options) {
-          return baseBackend.transaction(async (tx) => {
+          return baseBackend.transaction(async (tx, sql) => {
             const wrappedTx: TransactionBackend = {
               ...tx,
               async insertEdgeNoReturn(params) {
@@ -1000,7 +1004,7 @@ describe("Bulk Operations (SQLite)", () => {
                 await insertEdgesBatchWithFallback(tx, params);
               },
             };
-            return fn(wrappedTx);
+            return fn(wrappedTx, sql);
           }, options);
         },
       };
@@ -1053,7 +1057,7 @@ describe("Bulk Operations (SQLite)", () => {
           return baseBackend.getNode(graphId, kind, id);
         },
         async transaction(fn, options) {
-          return baseBackend.transaction(async (tx) => {
+          return baseBackend.transaction(async (tx, sql) => {
             const wrappedTx = {
               ...tx,
               async getNode(graphId: string, kind: string, id: string) {
@@ -1061,7 +1065,7 @@ describe("Bulk Operations (SQLite)", () => {
                 return tx.getNode(graphId, kind, id);
               },
             };
-            return fn(wrappedTx);
+            return fn(wrappedTx, sql);
           }, options);
         },
       };

--- a/packages/typegraph/tests/cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/cross-store-transaction.test.ts
@@ -248,3 +248,64 @@ describe("#134 cross-store atomicity (SQLite)", () => {
     sqlite.close();
   });
 });
+
+// #140: the graph-owned counterpart of withTransaction.
+// TypeGraph opens the transaction; `tx.sql` is the same connection,
+// so the caller's relational write joins the same atomic boundary.
+describe("#140 graph-owned cross-store via tx.sql (SQLite)", () => {
+  let sqlite: Database.Database;
+  let db: BetterSQLite3Database;
+
+  beforeEach(() => {
+    ({ sqlite, db } = createSqlite());
+  });
+
+  it("commits a graph node and a tx.sql relational row in one store.transaction", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    const store = createStore(PlainGraph, backend);
+
+    const source = await store.transaction(async (tx) => {
+      const sqlTx = tx.sql as typeof db;
+      const connectorId = sqlTx
+        .insert(connectors)
+        .values({ name: "github" })
+        .returning({ id: connectors.id })
+        .all()[0]!.id;
+      return tx.nodes.ArtifactSource.create({ connectorId, label: "primary" });
+    });
+
+    expect(db.select().from(connectors).all()).toEqual([
+      { id: 1, name: "github" },
+    ]);
+    const fetched = await store.nodes.ArtifactSource.getById(source.id);
+    expect(fetched?.connectorId).toBe(1);
+    sqlite.close();
+  });
+
+  it("rolls back BOTH the graph node and the tx.sql relational row when the callback throws", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    const store = createStore(PlainGraph, backend);
+
+    await expect(
+      store.transaction(async (tx) => {
+        const sqlTx = tx.sql as typeof db;
+        sqlTx.insert(connectors).values({ name: "orphan" }).run();
+        await tx.nodes.ArtifactSource.create({
+          connectorId: 1,
+          label: "doomed",
+        });
+        throw new Error("phase2-rollback");
+      }),
+    ).rejects.toThrow("phase2-rollback");
+
+    expect(db.select().from(connectors).all()).toEqual([]);
+    expect(await store.nodes.ArtifactSource.find()).toEqual([]);
+    sqlite.close();
+  });
+});

--- a/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
+++ b/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
@@ -1,0 +1,271 @@
+/**
+ * #140 — `transactionMode: "do-sqlite"` integration suite.
+ *
+ * Runs against a real Cloudflare `workerd` Durable Object with SQLite
+ * storage (not a Node fake), exercising the ACTUAL auto-detected
+ * `backend.transaction()` / `adoptTransaction()` paths — no
+ * `executionProfile` hint. `drizzle(ctx.storage)` must be detected as
+ * `transactionMode: "do-sqlite"` and advertise
+ * `capabilities.transactions: true`.
+ *
+ * The async storage runner `ctx.storage.transaction(async () => ...)`
+ * (surfaced by Drizzle as `db.$client.transaction`) rolls back SQL
+ * writes across `await`. There is no Drizzle tx handle on DO: the
+ * storage transaction is ambient on the object, so TypeGraph binds the
+ * outer `db`.
+ *
+ * Boot uses `createStoreWithSchema` (the real path): `bootstrapTables`
+ * DDL and the durable contribution marker run OUTSIDE any storage
+ * transaction (the #135 invariant); the schema-version commit runs
+ * through the `do-sqlite` storage runner (data only, never DDL).
+ *
+ * Each `it` runs in its OWN Durable Object instance (unique
+ * `idFromName`) so storage is isolated. The graph node has no
+ * `searchable` field, so a create is a pure INSERT and the fulltext
+ * gate is never reached. Store reads return the flattened node shape
+ * (`node.title`, `node.meta`) — there is no `node.props`.
+ */
+import { env, runInDurableObject } from "cloudflare:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/durable-sqlite";
+import {
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+} from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
+import { createSqliteBackend } from "../../src/backend/drizzle/sqlite";
+import { tables as defaultTables } from "../../src/backend/sqlite";
+
+import { SpikeDO } from "./worker";
+
+// The product's own relational ledger — NOT a TypeGraph table. The
+// composite PK is the racing-save anti-divergence mechanic: a stale
+// writer targeting an already-written (slug, version) is rejected.
+const docVersions = sqliteTable(
+  "doc_versions",
+  {
+    documentSlug: text("document_slug").notNull(),
+    docVersion: integer("doc_version").notNull(),
+    payload: text("payload").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.documentSlug, table.docVersion] })],
+);
+
+const Doc = defineNode("Doc", { schema: z.object({ title: z.string() }) });
+
+const DocGraph = defineGraph({
+  id: "do-sqlite",
+  nodes: { Doc: { type: Doc } },
+  edges: {},
+});
+
+async function bootInsideDurableObject(storage: DurableObjectStorage) {
+  // No executionProfile hint: detection must classify drizzle(ctx.storage)
+  // as `do-sqlite` on its own.
+  const db = drizzle(storage);
+  const backend = createSqliteBackend(db, { tables: defaultTables });
+
+  // Real boot path: bootstrap DDL + durable marker run OUTSIDE any
+  // storage transaction; the schema-version commit runs through the
+  // do-sqlite storage runner (data only).
+  const [store] = await createStoreWithSchema(DocGraph, backend);
+
+  // The caller's own relational table (created outside any business
+  // transaction, like the TypeGraph base tables).
+  db.run(
+    sql.raw(
+      "CREATE TABLE doc_versions (" +
+        "document_slug TEXT NOT NULL, doc_version INTEGER NOT NULL, " +
+        "payload TEXT NOT NULL, PRIMARY KEY (document_slug, doc_version))",
+    ),
+  );
+
+  return { db, backend, store };
+}
+
+function inObject<T>(
+  name: string,
+  body: (
+    ctx: Awaited<ReturnType<typeof bootInsideDurableObject>>,
+    storage: DurableObjectStorage,
+  ) => Promise<T>,
+): Promise<T> {
+  const stub = env.SPIKE_DO.get(env.SPIKE_DO.idFromName(name));
+  return runInDurableObject(
+    stub,
+    async (_instance: SpikeDO, state: DurableObjectState) =>
+      body(await bootInsideDurableObject(state.storage), state.storage),
+  );
+}
+
+describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
+  it("auto-detects do-sqlite and advertises capabilities.transactions:true", async () => {
+    await inObject("detect", async ({ db, backend }, storage) => {
+      expect(db.$client).toBe(storage);
+      expect(typeof storage.transaction).toBe("function");
+      expect(backend.capabilities.transactions).toBe(true);
+    });
+  });
+
+  it("A) graph-owned store.transaction(): throw-after-await rolls back BOTH TypeGraph and product writes", async () => {
+    await inObject("A-rollback", async ({ db, store }) => {
+      await expect(
+        store.transaction(async (tx) => {
+          await tx.nodes.Doc.create({ title: "rollback-A" });
+          await db
+            .insert(docVersions)
+            .values({ documentSlug: "A", docVersion: 1, payload: "x" });
+          throw new Error("do-sqlite-A-rollback");
+        }),
+      ).rejects.toThrow("do-sqlite-A-rollback");
+
+      expect(await store.nodes.Doc.count()).toBe(0);
+      expect((await db.select().from(docVersions)).length).toBe(0);
+    });
+  });
+
+  it("A) graph-owned store.transaction(): normal return commits BOTH", async () => {
+    await inObject("A-commit", async ({ db, store }) => {
+      await store.transaction(async (tx) => {
+        await tx.nodes.Doc.create({ title: "commit-A" });
+        await db
+          .insert(docVersions)
+          .values({ documentSlug: "A", docVersion: 2, payload: "y" });
+      });
+
+      expect(await store.nodes.Doc.count()).toBe(1);
+      expect((await db.select().from(docVersions)).length).toBe(1);
+    });
+  });
+
+  it("B) caller-owned ctx.storage.transaction()+withTransaction(): throw rolls back BOTH; prior committed work survives", async () => {
+    await inObject("B-rollback", async ({ db, store }, storage) => {
+      const seeded = await store.transaction(async (tx) =>
+        tx.nodes.Doc.create({ title: "seed" }),
+      );
+      expect(await store.nodes.Doc.count()).toBe(1);
+
+      await expect(
+        storage.transaction(async () => {
+          const txStore = store.withTransaction(db);
+          await txStore.nodes.Doc.update(seeded.id, { title: "MUTATED" });
+          await db
+            .insert(docVersions)
+            .values({ documentSlug: "B", docVersion: 1, payload: "z" });
+          throw new Error("do-sqlite-B-rollback");
+        }),
+      ).rejects.toThrow("do-sqlite-B-rollback");
+
+      const after = await store.nodes.Doc.getById(seeded.id);
+      expect(after?.title).toBe("seed");
+      expect(await store.nodes.Doc.count()).toBe(1);
+      expect((await db.select().from(docVersions)).length).toBe(0);
+    });
+  });
+
+  it("B) caller-owned ctx.storage.transaction()+withTransaction(): normal return commits BOTH", async () => {
+    await inObject("B-commit", async ({ db, store }, storage) => {
+      const seeded = await store.transaction(async (tx) =>
+        tx.nodes.Doc.create({ title: "seed" }),
+      );
+
+      await storage.transaction(async () => {
+        const txStore = store.withTransaction(db);
+        await txStore.nodes.Doc.update(seeded.id, { title: "committed" });
+        await db
+          .insert(docVersions)
+          .values({ documentSlug: "B", docVersion: 2, payload: "ok" });
+      });
+
+      const after = await store.nodes.Doc.getById(seeded.id);
+      expect(after?.title).toBe("committed");
+      expect((await db.select().from(docVersions)).length).toBe(1);
+    });
+  });
+
+  it("a product-table PK violation surfaces as a catchable error and rolls back the earlier TypeGraph mutation", async () => {
+    await inObject("pk-violation", async ({ db, store }) => {
+      await expect(
+        store.transaction(async (tx) => {
+          await tx.nodes.Doc.create({ title: "pk-victim" });
+          await db
+            .insert(docVersions)
+            .values({ documentSlug: "P", docVersion: 1, payload: "a" });
+          // Same composite PK — the stale-writer rejection.
+          await db
+            .insert(docVersions)
+            .values({ documentSlug: "P", docVersion: 1, payload: "b" });
+        }),
+      ).rejects.toThrow();
+
+      expect(await store.nodes.Doc.count()).toBe(0);
+      expect((await db.select().from(docVersions)).length).toBe(0);
+    });
+  });
+
+  it("same-document contention: two concurrent saves race for one (slug, version); only the winner persists", async () => {
+    await inObject("contention", async ({ db, store }) => {
+      const save = (title: string) =>
+        store.transaction(async (tx) => {
+          await tx.nodes.Doc.create({ title });
+          await db
+            .insert(docVersions)
+            .values({ documentSlug: "HEAD", docVersion: 1, payload: title });
+        });
+
+      const results = await Promise.allSettled([
+        save("writer-1"),
+        save("writer-2"),
+      ]);
+      const fulfilled = results.filter(
+        (result) => result.status === "fulfilled",
+      );
+      const rejected = results.filter((result) => result.status === "rejected");
+
+      // Exactly one writer wins the (HEAD, 1) ledger row; the loser's
+      // PK conflict rolls back its TypeGraph node mutation too.
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect(await store.nodes.Doc.count()).toBe(1);
+
+      const ledger = await db.select().from(docVersions);
+      expect(ledger).toHaveLength(1);
+      expect(ledger[0]?.documentSlug).toBe("HEAD");
+    });
+  });
+
+  it("graph-owned tx.sql: product write via tx.sql commits/rolls back with the TypeGraph mutation", async () => {
+    await inObject("tx-sql", async ({ db, store }) => {
+      // tx.sql is the bound do-sqlite Drizzle handle.
+      await store.transaction(async (tx) => {
+        await tx.nodes.Doc.create({ title: "via-tx-sql" });
+        const sqlTx = tx.sql as typeof db;
+        await sqlTx
+          .insert(docVersions)
+          .values({ documentSlug: "S", docVersion: 1, payload: "ok" });
+      });
+      expect(await store.nodes.Doc.count()).toBe(1);
+      expect((await db.select().from(docVersions)).length).toBe(1);
+
+      await expect(
+        store.transaction(async (tx) => {
+          await tx.nodes.Doc.create({ title: "doomed" });
+          const sqlTx = tx.sql as typeof db;
+          await sqlTx
+            .insert(docVersions)
+            .values({ documentSlug: "S", docVersion: 2, payload: "z" });
+          throw new Error("phase2-do-sqlite-rollback");
+        }),
+      ).rejects.toThrow("phase2-do-sqlite-rollback");
+
+      // Rolled back: still one Doc, still one ledger row.
+      expect(await store.nodes.Doc.count()).toBe(1);
+      expect((await db.select().from(docVersions)).length).toBe(1);
+    });
+  });
+});

--- a/packages/typegraph/tests/do-sqlite/worker.ts
+++ b/packages/typegraph/tests/do-sqlite/worker.ts
@@ -1,0 +1,22 @@
+/**
+ * #140 do-sqlite test harness worker.
+ *
+ * A minimal Durable Object whose only job is to expose a real
+ * `ctx.storage` (SQLite-backed) to the test suite via
+ * `runInDurableObject`. All assertions run inside the DO context where
+ * `state.storage` is a genuine `DurableObjectStorage` with the async
+ * `transaction(async () => ...)` runner.
+ */
+import { DurableObject } from "cloudflare:workers";
+
+export class SpikeDO extends DurableObject {
+  async ping(): Promise<string> {
+    return "ok";
+  }
+}
+
+export default {
+  fetch(): Response {
+    return new Response("typegraph do-sqlite test worker");
+  },
+};

--- a/packages/typegraph/tests/do-sqlite/wrangler.jsonc
+++ b/packages/typegraph/tests/do-sqlite/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "name": "typegraph-do-sqlite",
+  "main": "worker.ts",
+  "compatibility_date": "2025-05-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [{ "name": "SPIKE_DO", "class_name": "SpikeDO" }],
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["SpikeDO"] }],
+}

--- a/packages/typegraph/tsconfig.json
+++ b/packages/typegraph/tsconfig.json
@@ -15,5 +15,6 @@
       "@nicia-ai/typegraph/postgres": ["./src/backend/postgres/index.ts"]
     }
   },
-  "include": ["src", "tests", "examples", "scripts", "tsup.config.ts"]
+  "include": ["src", "tests", "examples", "scripts", "tsup.config.ts"],
+  "exclude": ["tests/do-sqlite"]
 }

--- a/packages/typegraph/vitest.config.ts
+++ b/packages/typegraph/vitest.config.ts
@@ -33,6 +33,9 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     exclude: [
       ...configDefaults.exclude,
+      // #140: workerd-only do-sqlite suite — runs via `test:do`
+      // (vitest.workers.config.ts), not the Node suite.
+      "tests/do-sqlite/**",
       "**/dist/**",
       "**/.{idea,git,cache,output,temp}/**",
       "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc}.config.*",

--- a/packages/typegraph/vitest.workers.config.ts
+++ b/packages/typegraph/vitest.workers.config.ts
@@ -1,0 +1,40 @@
+import { resolve } from "node:path";
+
+import {
+  cloudflarePool,
+  cloudflareTest,
+} from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+/**
+ * #140: Cloudflare Durable Objects SQLite (`do-sqlite`) test harness.
+ *
+ * Runs in a real `workerd` runtime via `@cloudflare/vitest-pool-workers`
+ * (0.16.x Vitest-4 pool architecture: a Vite plugin + a pool runner
+ * initializer fed the same options) so the suite exercises genuine
+ * `ctx.storage` transaction semantics — not a Node fake. Separate from
+ * `vitest.config.ts` because the workers pool is incompatible with the
+ * Node-environment suite; invoked through the `test:do` script,
+ * mirroring how `test:postgres` is its own lane.
+ */
+const workersOptions = {
+  main: "./tests/do-sqlite/worker.ts",
+  wrangler: { configPath: "./tests/do-sqlite/wrangler.jsonc" },
+};
+
+export default defineConfig({
+  plugins: [cloudflareTest(workersOptions)],
+  resolve: {
+    alias: {
+      "@nicia-ai/typegraph/sqlite": resolve(
+        __dirname,
+        "src/backend/sqlite/index.ts",
+      ),
+      "@nicia-ai/typegraph": resolve(__dirname, "src/index.ts"),
+    },
+  },
+  test: {
+    include: ["tests/do-sqlite/**/*.test.ts"],
+    pool: cloudflarePool(workersOptions),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
         specifier: ^5.1.11
         version: 5.1.11
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.16.6
+        version: 0.16.6(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5)
       '@libsql/client':
         specifier: ^0.17.3
         version: 0.17.3
@@ -553,8 +556,21 @@ packages:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.90.0
 
+  '@cloudflare/vitest-pool-workers@0.16.6':
+    resolution: {integrity: sha512-dt8LyDZCqJe95orS0eVmFnKFk7qkUTn1XjM2ppcTJJe67PJK9gt2VzBGk4gS64cxPk7uKoJ201kVtHPq5rQnNQ==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
+
   '@cloudflare/workerd-darwin-64@1.20260507.1':
     resolution: {integrity: sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
+    resolution: {integrity: sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -565,8 +581,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    resolution: {integrity: sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@cloudflare/workerd-linux-64@1.20260507.1':
     resolution: {integrity: sha512-QlrKEBdgA3uVc0Ok0Q3+0/CW0CTjgj5ySir1i1YY5FXVv0X6GpwtnB5umjunjF2MFprss+L+iFGZzxcSvMC1nA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260515.1':
+    resolution: {integrity: sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -577,8 +605,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    resolution: {integrity: sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260507.1':
     resolution: {integrity: sha512-dmClJ/E0BAcuDetQIZFqbeAXejWrG5pysGRMQ6T83Y0IW/7IAamY2zFEkAJ10I5xwZsdHuYsZtzlOxpEXpJs7A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260515.1':
+    resolution: {integrity: sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2901,6 +2941,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
@@ -4414,6 +4457,11 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@4.20260515.0:
+    resolution: {integrity: sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -5899,12 +5947,27 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260515.1:
+    resolution: {integrity: sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@4.90.0:
     resolution: {integrity: sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260507.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.92.0:
+    resolution: {integrity: sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260515.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -5997,6 +6060,9 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -6589,6 +6655,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260507.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260515.1
+
   '@cloudflare/vite-plugin@1.36.3(vite@7.3.3(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.4))(workerd@1.20260507.1)(wrangler@4.90.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260507.1)
@@ -6602,19 +6674,49 @@ snapshots:
       - utf-8-validate
       - workerd
 
+  '@cloudflare/vitest-pool-workers@0.16.6(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5)':
+    dependencies:
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      cjs-module-lexer: 1.4.3
+      esbuild: 0.27.3
+      miniflare: 4.20260515.0
+      vitest: 4.1.5(@types/node@24.12.0)(@vitest/coverage-v8@4.1.5)(vite@7.3.3(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.4))
+      wrangler: 4.92.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
   '@cloudflare/workerd-darwin-64@1.20260507.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260507.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20260507.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260515.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260507.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260507.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260515.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260307.1':
@@ -8598,6 +8700,8 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cjs-module-lexer@1.4.3: {}
+
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -10508,6 +10612,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@4.20260515.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260515.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
@@ -12146,6 +12262,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260507.1
       '@cloudflare/workerd-windows-64': 1.20260507.1
 
+  workerd@1.20260515.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260515.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260515.1
+      '@cloudflare/workerd-linux-64': 1.20260515.1
+      '@cloudflare/workerd-linux-arm64': 1.20260515.1
+      '@cloudflare/workerd-windows-64': 1.20260515.1
+
   wrangler@4.90.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
@@ -12156,6 +12280,22 @@ snapshots:
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260507.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.92.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260515.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260515.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
@@ -12236,6 +12376,8 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
Closes #140.

## What ships

**Cloudflare Durable Objects SQLite is now fully transactional.** A store backed by `drizzle(ctx.storage)` is auto-detected as a new SQLite `transactionMode: "do-sqlite"` and reports `capabilities.transactions: true` (previously `false`). `store.transaction()` and `store.withTransaction()` roll back and commit atomically by delegating to the async `ctx.storage.transaction(async …)` runner (Drizzle's `db.$client.transaction`), which rolls back across `await`. Drizzle's own `db.transaction()` on DO is `ctx.storage.transactionSync` and cannot span an `await`, so it is deliberately not used.

This also fixes a **latent detection bug**: drizzle's Durable Objects session class is `SQLiteDOSession`, not the previously-checked `SQLiteDurableObjectSession`, so a real `drizzle(ctx.storage)` store was silently misclassified.

**`TransactionContext.sql` — graph-owned cross-store writes (all transactional backends).** `store.transaction(async (tx) => …)` now exposes `tx.sql`, the raw Drizzle handle bound to the same transaction, so the caller's own relational tables join the same atomic boundary — the graph-owned counterpart of `store.withTransaction`. On Postgres/libsql this is a correctness requirement (the outer `db` is a different connection and would escape the transaction); `undefined` only on non-transactional backends.

```ts
await store.transaction(async (tx) => {
  await tx.nodes.Document.update(documentId, props);
  await tx.sql.insert(documentVersions).values(versionRow);
});
```

## Invariants preserved

Schema bootstrap/DDL and the durable fulltext materialization marker run **outside** any storage transaction; only the data-only schema-version commit uses the storage runner — "no DDL in the business transaction" holds.

## Testing

- New `pnpm test:do` lane (`@cloudflare/vitest-pool-workers`) driving a **real Durable Object** in `workerd`: cross-store commit/rollback, product-key-conflict rollback, same-document contention.
- Graph-owned `tx.sql` commit/rollback coverage on better-sqlite3, libsql, Postgres, and do-sqlite.
- Full SQLite suite (3105) + do-sqlite (8) + Postgres cross-store (8) green; typecheck/lint/format clean.

## Out of scope

Cloudflare D1 stays `transactionMode: "none"`: `D1Database.batch(...)` is transactional but batch-only, not an interactive runner. A batch-mode D1 path is tracked separately (per the issue's own scoping).