### PR TITLE
feat: createVerifiedStore + assertSchemaCurrent runtime attach; fix #143 contribution-DDL ordering

### DIFF
--- a/.changeset/migration-error-before-contribution-ddl.md
+++ b/.changeset/migration-error-before-contribution-ddl.md
@@ -1,0 +1,28 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Surface `MigrationError` before runtime-contribution DDL on a pending
+breaking migration (#143).
+
+`loadActiveSchemaWithBootstrap` ran `ensureRuntimeContributions` (fulltext
+contribution DDL) **before** `ensureSchema` computed the schema diff and
+threw `MigrationError`. Contribution DDL is derived from the current code
+graph, so against a database still on the old schema version it was applied
+to a stale table shape. On Postgres the first failing statement aborts the
+surrounding transaction, and the error that escaped was the idempotent
+marker-table `CREATE TABLE IF NOT EXISTS
+"typegraph_contribution_materializations"` (collateral damage), not a clean
+`MigrationError`. Consumers using the documented migrate-on-`MigrationError`
+recovery pattern never saw a `MigrationError`, so the first request after
+every breaking schema change 500'd until a concurrent boot won the migration
+race.
+
+`loadActiveSchemaWithBootstrap` no longer materializes runtime
+contributions. `createStoreWithSchema` remains the single canonical
+durable-marker writer and runs the materialization step **after**
+`ensureSchema`, so the breaking-change gate is always reached first and a
+pending breaking migration throws `MigrationError` on the first request —
+making the migrate-then-retry recovery path work as documented. The pre-#129
+`ensureFulltextTable` fallback is preserved at the canonical writer. No API
+changes.

--- a/.changeset/verified-store-runtime-attach.md
+++ b/.changeset/verified-store-runtime-attach.md
@@ -1,0 +1,58 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `createVerifiedStore` and `assertSchemaCurrent` — the runtime
+counterparts of `createStoreWithSchema` for the least-privilege
+deployment model.
+
+`createStoreWithSchema()` runs DDL (bootstrap, safe auto-migrations,
+durable contribution materialization) and must run under a role with
+`CREATE` privileges. For applications that want their runtime under a
+least-privilege, DML-only role, the previous options were `createStore`
+(zero-DDL attach with no schema gate — drift goes undetected until a
+hot-path operation trips) or hand-rolling a SELECT-only verification
+dance from `getActiveSchema` + `getSchemaChanges`.
+
+This release adds two cleanly named entrypoints that share the same
+zero-DDL verification path:
+
+- **`createVerifiedStore(graph, backend, options?)`** — a SELECT-only
+  attach (zero DDL) with a verification gate. Reads the active schema
+  row and contribution markers, folds the persisted graph extension,
+  and refuses to construct the Store unless the database is at the
+  same schema version as the code graph. Returns
+  `Promise<[Store<G>, SchemaValidationResult]>` mirroring
+  `createStoreWithSchema`. Throws `MigrationError` on any drift (safe
+  or breaking — the least-privilege runtime cannot migrate),
+  `ConfigurationError` when no schema has been initialized, and
+  `StoreNotInitializedError` when the schema is current but
+  runtime-contribution markers (e.g. fulltext) are missing/stale.
+
+- **`assertSchemaCurrent(backend, graph)`** — the same verification gate
+  exposed as a standalone predicate for readiness probes / healthchecks.
+  Returns the `SchemaValidationResult` or throws the same errors.
+
+The recommended deployment shape is now:
+
+1. **Migration step** (privileged role with DDL/`CREATE`): run
+   `createStoreWithSchema()` once at startup, or apply
+   `generatePostgresMigrationSQL` / `generateSqliteMigrationSQL` plus a
+   one-shot `createStoreWithSchema()` to materialize runtime
+   contributions.
+2. **Runtime** (least-privilege, DML-only role): attach with
+   `createVerifiedStore()`. Zero DDL on the runtime path; schema drift
+   fails fast with a clean `MigrationError` instead of leaking into
+   hot-path operations or 500ing on a permission error.
+
+Internal: factored a pure `mergeStoredGraphExtension` helper out of
+`loadAndMergeGraphExtensionDocument` so the SELECT-only verifier reuses
+the same parse + extension-merge + deprecated-kind logic without going
+through the bootstrap-capable loader. No behavior change for the
+existing schema entrypoints.
+
+Documentation: "Database roles & least privilege" in `backend-setup.md`
+now folds in `createVerifiedStore` as the canonical runtime attach;
+`schema-management.md` covers Basic / Managed / Verified stores side by
+side; `troubleshooting.md` adds entries for `MigrationError` from a
+verifying attach and `ConfigurationError` on uninitialized databases.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -142,7 +142,7 @@ Creates a SQLite backend with automatic database and schema setup.
 
 ```typescript
 function createLocalSqliteBackend(options?: {
-  path?: string;       // Database path, defaults to ":memory:"
+  path?: string; // Database path, defaults to ":memory:"
   tables?: SqliteTables;
 }): { backend: GraphBackend; db: BetterSQLite3Database };
 ```
@@ -152,10 +152,7 @@ function createLocalSqliteBackend(options?: {
 Creates a SQLite backend from an existing Drizzle database instance.
 
 ```typescript
-function createSqliteBackend(
-  db: BetterSQLite3Database,
-  options?: { tables?: SqliteTables }
-): GraphBackend;
+function createSqliteBackend(db: BetterSQLite3Database, options?: { tables?: SqliteTables }): GraphBackend;
 ```
 
 #### `generateSqliteMigrationSQL()`
@@ -172,10 +169,7 @@ Creates a SQLite backend from a `@libsql/client` instance. Runs DDL automaticall
 The caller retains ownership of the client and is responsible for closing it.
 
 ```typescript
-async function createLibsqlBackend(
-  client: Client,
-  options?: { tables?: SqliteTables }
-): Promise<{ backend: GraphBackend; db: LibSQLDatabase }>;
+async function createLibsqlBackend(client: Client, options?: { tables?: SqliteTables }): Promise<{ backend: GraphBackend; db: LibSQLDatabase }>;
 ```
 
 ## PostgreSQL
@@ -188,14 +182,14 @@ runtime, and TypeGraph works the same way against each.
 
 ### Choosing a PostgreSQL driver
 
-| Runtime | Recommended driver | Drizzle adapter |
-|---|---|---|
-| Long-lived Node server (Fly, Render, Cloud Run, containers) | `pg` (node-postgres) or `postgres` (postgres-js) | `drizzle-orm/node-postgres` or `drizzle-orm/postgres-js` |
-| Node serverless (Vercel Functions, AWS Lambda, Netlify Functions) | `postgres` (postgres-js) — faster cold start, lower per-query overhead | `drizzle-orm/postgres-js` |
-| Bun server | `postgres` (postgres-js) or Bun's built-in SQL | `drizzle-orm/postgres-js` or `drizzle-orm/bun-sql` |
-| Edge runtime (Cloudflare Workers, Vercel Edge, Netlify Edge) — needs transactions | `@neondatabase/serverless` Pool over WebSockets | `drizzle-orm/neon-serverless` |
-| Edge runtime — single-statement reads/writes only | `@neondatabase/serverless` `neon(url)` over HTTP | `drizzle-orm/neon-http` |
-| Cloudflare Hyperdrive | `pg` or `postgres` (through the Hyperdrive pooler) | `drizzle-orm/node-postgres` or `drizzle-orm/postgres-js` |
+| Runtime                                                                           | Recommended driver                                                     | Drizzle adapter                                          |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------- |
+| Long-lived Node server (Fly, Render, Cloud Run, containers)                       | `pg` (node-postgres) or `postgres` (postgres-js)                       | `drizzle-orm/node-postgres` or `drizzle-orm/postgres-js` |
+| Node serverless (Vercel Functions, AWS Lambda, Netlify Functions)                 | `postgres` (postgres-js) — faster cold start, lower per-query overhead | `drizzle-orm/postgres-js`                                |
+| Bun server                                                                        | `postgres` (postgres-js) or Bun's built-in SQL                         | `drizzle-orm/postgres-js` or `drizzle-orm/bun-sql`       |
+| Edge runtime (Cloudflare Workers, Vercel Edge, Netlify Edge) — needs transactions | `@neondatabase/serverless` Pool over WebSockets                        | `drizzle-orm/neon-serverless`                            |
+| Edge runtime — single-statement reads/writes only                                 | `@neondatabase/serverless` `neon(url)` over HTTP                       | `drizzle-orm/neon-http`                                  |
+| Cloudflare Hyperdrive                                                             | `pg` or `postgres` (through the Hyperdrive pooler)                     | `drizzle-orm/node-postgres` or `drizzle-orm/postgres-js` |
 
 :::note[Neon HTTP vs WebSocket]
 Both Neon drivers work with TypeGraph. They have different tradeoffs:
@@ -418,8 +412,8 @@ import { Pool } from "pg";
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  max: 20,                    // Maximum pool size
-  idleTimeoutMillis: 30000,   // Close idle connections after 30s
+  max: 20, // Maximum pool size
+  idleTimeoutMillis: 30000, // Close idle connections after 30s
   connectionTimeoutMillis: 2000, // Timeout for new connections
 });
 
@@ -473,7 +467,7 @@ function createPostgresBackend(
      * Ignored when `prepareStatements` is `false`.
      */
     preparedStatementCacheMax?: number;
-  }
+  },
 ): GraphBackend;
 ```
 
@@ -595,7 +589,9 @@ Check what features a backend supports:
 const backend = createSqliteBackend(db);
 
 if (backend.capabilities.transactions) {
-  await store.transaction(async (tx) => { /* ... */ });
+  await store.transaction(async (tx) => {
+    /* ... */
+  });
 } else {
   // Handle non-transactional execution
 }
@@ -628,6 +624,80 @@ process.on("exit", () => {
 
 The `store.close()` method is a no-op—cleanup is your responsibility.
 
+## Database roles & least privilege
+
+`createStoreWithSchema()` and `createStore()` divide cleanly along DDL
+privilege, so a production deployment can run its application under a
+least-privilege, DML-only database role.
+
+- **`createStoreWithSchema(graph, backend)` runs DDL.** It bootstraps the
+  base tables on a fresh database, applies safe auto-migrations, and
+  durably materializes strategy-owned runtime storage (e.g. fulltext). It
+  re-issues idempotent DDL on every cold boot — at minimum a
+  `CREATE TABLE IF NOT EXISTS` for the contribution-marker table — so the
+  role it runs under **must hold `CREATE` / DDL privileges**. Run it once
+  at startup, outside request handlers and transactions.
+
+- **`createStore(graph, backend)` is a synchronous, zero-I/O attach.**
+  It does not create tables, repair DDL, or record that runtime storage
+  is materialized — it issues **no DDL ever**. Use it only to attach to a
+  database a prior `createStoreWithSchema` boot already initialized. A
+  fulltext read or write against a database that was never initialized
+  throws `StoreNotInitializedError` rather than silently emitting DDL on
+  the hot path. Graphs with no `searchable()` fields are unaffected.
+
+- **`createVerifiedStore(graph, backend)` is the same zero-DDL attach
+  with a verification gate.** It reads the active schema row, folds the
+  persisted graph extension, and refuses to construct the Store unless
+  the database is at the same schema version as the code graph. Throws
+  `MigrationError` on drift (safe or breaking), `ConfigurationError`
+  when no schema has been initialized, and `StoreNotInitializedError`
+  when the schema is current but runtime-contribution markers are
+  missing. The runtime-side counterpart of `createStoreWithSchema` for
+  least-privilege deployments. If you only need the gate without
+  building a Store (e.g. a readiness probe), call `assertSchemaCurrent`.
+
+### Recommended deployment shape
+
+Run schema/DDL changes as a **privileged, one-time migration step**, then
+run the application under a **least-privilege runtime role** that holds
+only `SELECT` / `INSERT` / `UPDATE` / `DELETE`:
+
+```typescript
+// 1. Migration step — privileged role with DDL/CREATE.
+//
+//    createStoreWithSchema is mandatory here: it bootstraps tables,
+//    applies safe auto-migrations, commits the schema_versions row,
+//    and writes the durable contribution markers. The runtime gate
+//    checks all of those.
+const [
+  /* store */
+] = await createStoreWithSchema(graph, adminBackend);
+
+//    Optional prerequisite if you manage DDL externally with
+//    drizzle-kit. Generated SQL creates the tables but does NOT
+//    initialize the schema row or contribution markers — still run
+//    createStoreWithSchema afterwards (it skips bootstrap when tables
+//    already exist and commits the row + markers):
+//
+//    import { generatePostgresMigrationSQL } from "@nicia-ai/typegraph/postgres";
+//    await adminPool.query(generatePostgresMigrationSQL());
+//    await createStoreWithSchema(graph, adminBackend);
+```
+
+```typescript
+// 2. Runtime — least-privilege, DML-only role. Zero DDL.
+// createVerifiedStore fails fast if the privileged migrator is behind.
+const runtimePool = new Pool({ connectionString: process.env.APP_DATABASE_URL });
+const backend = createPostgresBackend(drizzle(runtimePool));
+const [store] = await createVerifiedStore(graph, backend);
+```
+
+If the runtime role has no DDL privileges and you boot it with
+`createStoreWithSchema()` anyway, the first cold boot fails with a
+permission error on the bootstrap or contribution-marker DDL — see
+[Troubleshooting](/troubleshooting).
+
 ## Environment-Specific Setup
 
 ### Development
@@ -652,6 +722,11 @@ beforeEach(() => {
 
 ### Production
 
+Single-role setup — `createStoreWithSchema` bootstraps and migrates on
+boot, so the role needs DDL privileges. To run the application under a
+least-privilege, DML-only role instead, split the migration step out as
+described in [Database roles & least privilege](#database-roles--least-privilege).
+
 ```typescript
 // PostgreSQL with pooling
 const pool = new Pool({
@@ -660,7 +735,6 @@ const pool = new Pool({
   ssl: { rejectUnauthorized: false }, // For managed databases
 });
 
-await pool.query(generatePostgresMigrationSQL());
 const db = drizzle(pool);
 const backend = createPostgresBackend(db);
 const [store] = await createStoreWithSchema(graph, backend);

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -67,9 +67,10 @@ switch (result.status) {
 }
 ```
 
-## Basic vs Managed Store
+## Basic vs Managed vs Verified Store
 
-TypeGraph provides two ways to create a store:
+TypeGraph provides three ways to create a store, each suited to a
+different deployment role:
 
 ### Basic Store (No Schema Management)
 
@@ -107,6 +108,49 @@ const [store, result] = await createStoreWithSchema(graph, backend, {
   },
 });
 ```
+
+### Verified Store (Zero-DDL Attach With Verification Gate)
+
+Use `createVerifiedStore()` at runtime when the application runs under a
+least-privilege, DML-only database role and a separate privileged step
+has already advanced the schema. It is the runtime counterpart of
+`createStoreWithSchema()`: a synchronous-semantics attach that **issues
+no DDL** and fails fast if the database is not at the same schema
+version as the code graph.
+
+```typescript
+import { createVerifiedStore } from "@nicia-ai/typegraph";
+
+// Runtime — least-privilege, DML-only role. Zero DDL.
+const [store, result] = await createVerifiedStore(graph, backend);
+// result.status === "unchanged" on success.
+```
+
+It throws:
+
+- `ConfigurationError` if no schema has been initialized (run the
+  privileged migration step first).
+- `MigrationError` if the persisted schema is behind the code graph by
+  **any** pending change (safe or breaking) — the least-privilege
+  runtime cannot migrate.
+- `StoreNotInitializedError` if the schema is current but the
+  runtime-contribution markers (e.g. fulltext) are missing/stale.
+
+If you only need the check without building a Store (e.g. a readiness
+probe), call `assertSchemaCurrent(backend, graph)` directly — it returns
+the same `SchemaValidationResult` or throws the same errors.
+
+:::note[Database privileges]
+Only `createStoreWithSchema()` runs DDL. `createStore()` is a
+synchronous zero-I/O attach; `createVerifiedStore()` is a SELECT-only
+attach (zero DDL — reads the active schema row and contribution
+markers, nothing else). To run the application under a least-privilege,
+DML-only role, do the privileged migration step once with
+`createStoreWithSchema(graph, adminBackend)` and use
+`createVerifiedStore()` at runtime. See
+[Database roles & least privilege](/backend-setup#database-roles--least-privilege)
+for the canonical breakdown.
+:::
 
 ## Schema Validation Results
 
@@ -204,12 +248,7 @@ if (diff?.hasChanges) {
 For full control over migrations:
 
 ```typescript
-import {
-  initializeSchema,
-  migrateSchema,
-  rollbackSchema,
-  ensureSchema,
-} from "@nicia-ai/typegraph/schema";
+import { initializeSchema, migrateSchema, rollbackSchema, ensureSchema } from "@nicia-ai/typegraph/schema";
 
 // Initialize schema (first run only)
 const row = await initializeSchema(backend, graph);

--- a/apps/docs/src/content/docs/troubleshooting.md
+++ b/apps/docs/src/content/docs/troubleshooting.md
@@ -203,16 +203,10 @@ await store.nodes.Organization.create({ name: "Acme" });
 
 ```typescript
 // Bad
-store.query()
-  .from("Person", "p")
-  .traverse("knows", "e")
-  .to("Person", "p") // Error! 'p' already used
+store.query().from("Person", "p").traverse("knows", "e").to("Person", "p"); // Error! 'p' already used
 
 // Good
-store.query()
-  .from("Person", "p1")
-  .traverse("knows", "e")
-  .to("Person", "p2")
+store.query().from("Person", "p1").traverse("knows", "e").to("Person", "p2");
 ```
 
 ### Empty results when expecting data
@@ -236,7 +230,11 @@ store.query()
 
    ```typescript
    // Debug by removing filters temporarily
-   const all = await store.query().from("Person", "p").select((c) => c.p).execute();
+   const all = await store
+     .query()
+     .from("Person", "p")
+     .select((c) => c.p)
+     .execute();
    console.log(all.length); // How many total?
    ```
 
@@ -319,6 +317,65 @@ import { generateSqliteMigrationSQL } from "@nicia-ai/typegraph/sqlite";
 sqlite.exec(generateSqliteMigrationSQL());
 ```
 
+### "permission denied" / cannot create relation on boot
+
+**Cause:** `createStoreWithSchema()` runs DDL on every cold boot
+(bootstrap, safe auto-migrations, and the contribution-marker
+`CREATE TABLE IF NOT EXISTS`). If it runs under a least-privilege,
+DML-only database role, that DDL fails with a permission error.
+
+**Solution:** Run schema/DDL changes as a privileged one-time migration
+step, then attach at runtime with the zero-DDL
+`createVerifiedStore()` (or `createStore()`) under the least-privilege
+role. See
+[Database roles & least privilege](/backend-setup#database-roles--least-privilege).
+
+### `MigrationError` from `createVerifiedStore` / `assertSchemaCurrent`
+
+**Cause:** The runtime is using a code graph whose schema is ahead of
+the database. The least-privilege runtime cannot migrate — by design,
+it fails fast so requests don't run against a stale schema.
+
+**Solution:** Run `createStoreWithSchema(graph, adminBackend)` under
+the privileged role before promoting the new runtime build (apply any
+generated migration SQL first if you manage DDL externally), then
+restart the runtime. The thrown `MigrationError.message` includes the
+diff summary and migration actions to apply.
+
+### `ConfigurationError`: "no schema has been initialized"
+
+**Cause:** A verifying attach (`createVerifiedStore` /
+`assertSchemaCurrent`) ran before any privileged
+`createStoreWithSchema()` boot — the database has no `schema_versions`
+row (or no typegraph tables at all). The runtime deliberately refuses
+to bootstrap under a least-privilege role. **Note:** running only the
+generated migration SQL is not sufficient — it creates the tables but
+does not write the schema row or contribution markers.
+
+**Solution:** Run `createStoreWithSchema(graph, adminBackend)` once
+under the privileged role. If you manage DDL externally with
+drizzle-kit / `generatePostgresMigrationSQL()` /
+`generateSqliteMigrationSQL()`, apply that first, then still run
+`createStoreWithSchema()` to commit the schema row and contribution
+markers. See
+[Database roles & least privilege](/backend-setup#database-roles--least-privilege).
+
+### `StoreNotInitializedError` on the first operation
+
+**Cause:** The store was created with `createStore()` (a zero-I/O attach
+that never materializes runtime storage) against a database that no
+`createStoreWithSchema()` boot has initialized — commonly the runtime
+started before the privileged migration step ran, or the wrong role/
+database is configured. `createVerifiedStore()` catches this case at
+boot rather than at first hot-path operation.
+
+**Solution:** Run `createStoreWithSchema(graph, adminBackend)` once
+under the privileged role before the runtime attaches (it writes the
+contribution markers that `createStore` / `createVerifiedStore` only
+check), and prefer `createVerifiedStore()` over bare `createStore()` so
+drift fails fast. See
+[Database roles & least privilege](/backend-setup#database-roles--least-privilege).
+
 ## Semantic Search Issues
 
 ### "Extension not found" / "vector type not available"
@@ -365,10 +422,10 @@ console.log(queryEmbedding.length); // Should be 1536
 
 ```typescript
 // Instead of:
-d.embedding.similarTo(query, 10, { metric: "inner_product" })
+d.embedding.similarTo(query, 10, { metric: "inner_product" });
 
 // Use:
-d.embedding.similarTo(query, 10, { metric: "cosine" })
+d.embedding.similarTo(query, 10, { metric: "cosine" });
 ```
 
 ## TypeScript Issues
@@ -389,7 +446,7 @@ const Person = defineNode("Person", {
 
 // Now both properties are available with correct types
 const person = await store.nodes.Person.getById(id);
-person?.name;  // string
+person?.name; // string
 person?.email; // string | undefined
 ```
 

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -261,7 +261,12 @@ export type {
   VectorSearchHit,
   VectorSearchOptions,
 } from "./store";
-export { createStore, createStoreWithSchema, StoreSearch } from "./store";
+export {
+  createStore,
+  createStoreWithSchema,
+  createVerifiedStore,
+  StoreSearch,
+} from "./store";
 export type {
   AlgorithmCyclePolicy,
   BaseTraversalOptions,

--- a/packages/typegraph/src/schema/index.ts
+++ b/packages/typegraph/src/schema/index.ts
@@ -36,6 +36,7 @@ export {
 
 export {
   applyDeprecatedKinds,
+  assertSchemaCurrent,
   ensureSchema,
   getActiveSchema,
   getSchemaChanges,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -9,7 +9,11 @@
  */
 import { type GraphBackend, type SchemaVersionRow } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
-import { DatabaseOperationError, MigrationError } from "../errors";
+import {
+  ConfigurationError,
+  DatabaseOperationError,
+  MigrationError,
+} from "../errors";
 import { mergeGraphExtension } from "../graph-extension/merge";
 import { freezeDeep } from "../utils/object";
 import { isMissingTableError } from "../utils/sql-errors";
@@ -96,30 +100,28 @@ export function parseSerializedSchema(json: string): SerializedSchema {
 
 /**
  * Reads the active schema row, bootstrapping the base tables on the
- * first call against an empty database. Also runs the focused
- * runtime-contribution ensure on the success path: drizzle-kit-managed
- * setups create every base table EXCEPT strategy-owned runtime tables
- * (fulltext), and the missing-table-error fallback below doesn't
- * trigger once `schema_versions` exists. `ensureRuntimeContributions`
- * closes that gap before any `searchable()` write runs — scoped to
- * `runtimeEnsure` contributions only, so this stays a focused ensure
- * rather than broad startup DDL (#129). Falls back to the deprecated
- * `ensureFulltextTable` for backends predating #129.
+ * first call against an empty database.
+ *
+ * Deliberately does NOT materialize runtime contributions (fulltext)
+ * here. Contribution DDL is derived from the *current code graph*; when
+ * the persisted schema is behind by a breaking change, running it here
+ * would apply vN+1 DDL against the vN table shape before `ensureSchema`
+ * computes the diff and throws `MigrationError`. On Postgres the first
+ * failing statement poisons the surrounding transaction, so the error
+ * that escapes is the idempotent marker-table
+ * `CREATE TABLE IF NOT EXISTS` (collateral damage) rather than a clean
+ * `MigrationError` — breaking the documented migrate-on-`MigrationError`
+ * recovery path (#143). `createStoreWithSchema` is the single canonical
+ * durable-marker writer (#135) and materializes runtime contributions
+ * only AFTER the schema gate has run, so the breaking-change check is
+ * always reached first.
  */
 export async function loadActiveSchemaWithBootstrap(
   backend: GraphBackend,
   graphId: string,
 ): Promise<SchemaVersionRow | undefined> {
   try {
-    const row = await backend.getActiveSchema(graphId);
-    // Prefer the #129 contribution path; fall back to the pre-#129
-    // `ensureFulltextTable` for backends that predate it.
-    const ensureRuntime =
-      backend.ensureRuntimeContributions ?
-        backend.ensureRuntimeContributions(graphId)
-      : backend.ensureFulltextTable?.(graphId);
-    await ensureRuntime;
-    return row;
+    return await backend.getActiveSchema(graphId);
   } catch (error) {
     if (backend.bootstrapTables && isMissingTableError(error)) {
       await backend.bootstrapTables();
@@ -155,6 +157,24 @@ export async function loadAndMergeGraphExtensionDocument<G extends GraphDef>(
   if (activeRow === undefined) {
     return { graph, activeRow: undefined, storedSchema: undefined };
   }
+  const { graph: merged, storedSchema } = mergeStoredGraphExtension(
+    graph,
+    activeRow,
+  );
+  return { graph: merged, activeRow, storedSchema };
+}
+
+/**
+ * Pure parse + extension-merge + deprecated-kind application. Factored
+ * out so the SELECT-only verifier (`assertSchemaCurrent`) can fold the
+ * persisted graph extension into the supplied graph without paying for a
+ * second `getActiveSchema` round trip or going through the
+ * bootstrap-capable loader.
+ */
+function mergeStoredGraphExtension<G extends GraphDef>(
+  graph: G,
+  activeRow: SchemaVersionRow,
+): Readonly<{ graph: G; storedSchema: SerializedSchema }> {
   const storedSchema = parseSerializedSchema(activeRow.schema_doc);
   const merged =
     storedSchema.extension === undefined ?
@@ -162,7 +182,6 @@ export async function loadAndMergeGraphExtensionDocument<G extends GraphDef>(
     : mergeGraphExtension(graph, storedSchema.extension);
   return {
     graph: applyDeprecatedKinds(merged, storedSchema.deprecatedKinds),
-    activeRow,
     storedSchema,
   };
 }
@@ -398,6 +417,164 @@ export async function ensureSchema<G extends GraphDef>(
   }
 
   return { status: "breaking", diff, actions };
+}
+
+// ============================================================
+// SELECT-only schema verification (least-privilege runtime)
+// ============================================================
+
+/**
+ * SELECT-only sibling of `loadAndMergeGraphExtensionDocument` for the
+ * least-privilege runtime path: reads the active schema row, folds any
+ * persisted graph extension into the supplied graph, and classifies
+ * whether the database is current relative to that merged graph — all
+ * **without DDL, bootstrap, or writes**. Returns the merged graph
+ * alongside the active row and the validation result so a caller can
+ * build a `Store` on the correct graph without paying for a second
+ * `getActiveSchema` round trip or re-merging.
+ *
+ * @throws ConfigurationError if no schema has been initialized for
+ *   `graph.id` (the privileged migration step has not run, or the base
+ *   tables do not exist on this connection).
+ * @throws MigrationError if the persisted schema is behind the code
+ *   graph — for **any** pending change, safe or breaking. The
+ *   least-privilege runtime cannot migrate; "behind" means the
+ *   privileged migrator has not yet caught up.
+ */
+export async function loadAndVerifyGraph<G extends GraphDef>(
+  backend: GraphBackend,
+  graph: G,
+): Promise<
+  Readonly<{
+    graph: G;
+    activeRow: SchemaVersionRow;
+    result: SchemaValidationResult;
+  }>
+> {
+  const activeRow = await readActiveSchemaPure(backend, graph.id);
+  const { graph: merged, storedSchema } = mergeStoredGraphExtension(
+    graph,
+    activeRow,
+  );
+
+  // Hash short-circuit avoids the serialize + diff walk on the steady-
+  // state warm path. A semantic no-op (hash differs but `hasChanges` is
+  // false) takes the same return path.
+  const storedHash = activeRow.schema_hash;
+  const currentHash = await getSchemaHash(merged, activeRow.version + 1);
+  if (storedHash !== currentHash) {
+    const currentSchema = serializeSchema(merged, activeRow.version + 1);
+    const diff = computeSchemaDiff(storedSchema, currentSchema);
+    if (diff.hasChanges) {
+      throw schemaBehindError(merged.id, activeRow.version, diff);
+    }
+  }
+
+  await backend.assertRuntimeContributionsInitialized?.(merged.id);
+  return {
+    graph: merged,
+    activeRow,
+    result: { status: "unchanged", version: activeRow.version },
+  };
+}
+
+function schemaBehindError(
+  graphId: string,
+  fromVersion: number,
+  diff: SchemaDiff,
+): MigrationError {
+  const actions = getMigrationActions(diff);
+  const qualifier =
+    isBackwardsCompatible(diff) ? "safe auto-migration" : "breaking change";
+  return new MigrationError(
+    `Schema verification failed for graph "${graphId}": ${diff.summary} ` +
+      `(${qualifier}). ${actions.length} migration action(s) needed. ` +
+      `The least-privilege runtime cannot migrate — run ` +
+      `createStoreWithSchema(graph, adminBackend) under a privileged role ` +
+      `(after any generated migration SQL, if you manage DDL externally) ` +
+      `before attaching with createStore() / createVerifiedStore().`,
+    {
+      graphId,
+      fromVersion,
+      toVersion: fromVersion + 1,
+    },
+  );
+}
+
+/**
+ * Verifies the database is at the same schema version as the code
+ * graph, **without** running DDL, bootstrapping tables, or writing
+ * markers. The runtime-side counterpart of `ensureSchema` for the
+ * least-privilege deployment model documented in "Database roles &
+ * least privilege": `createStoreWithSchema` (run once under a privileged
+ * role, optionally after applying generated migration SQL externally) is
+ * responsible for advancing the schema; runtimes assert it.
+ *
+ * @throws ConfigurationError if no schema has been initialized.
+ * @throws MigrationError if the persisted schema is behind the code
+ *   graph by any change (safe or breaking).
+ * @throws StoreNotInitializedError if the schema is current but the
+ *   runtime-contribution markers are missing/stale/failed (the
+ *   privileged migrator has not materialized strategy-owned storage for
+ *   this graph on this connection).
+ */
+export async function assertSchemaCurrent<G extends GraphDef>(
+  backend: GraphBackend,
+  graph: G,
+): Promise<SchemaValidationResult> {
+  const { result } = await loadAndVerifyGraph(backend, graph);
+  return result;
+}
+
+/**
+ * Strict SELECT-only read of the active schema row. Unlike
+ * `loadActiveSchemaWithBootstrap`, this never calls `bootstrapTables` —
+ * a missing-table error or an absent row both surface as
+ * `ConfigurationError` so a least-privilege runtime never attempts DDL
+ * it can't run. Real system faults (connection, permission, driver)
+ * still propagate as themselves.
+ */
+async function readActiveSchemaPure(
+  backend: GraphBackend,
+  graphId: string,
+): Promise<SchemaVersionRow> {
+  let activeRow: SchemaVersionRow | undefined;
+  try {
+    activeRow = await backend.getActiveSchema(graphId);
+  } catch (error) {
+    if (isMissingTableError(error)) {
+      throw schemaNotInitializedError(graphId, error);
+    }
+    throw error;
+  }
+  if (activeRow === undefined) {
+    throw schemaNotInitializedError(graphId);
+  }
+  return activeRow;
+}
+
+function schemaNotInitializedError(
+  graphId: string,
+  cause?: unknown,
+): ConfigurationError {
+  return new ConfigurationError(
+    `Cannot verify graph "${graphId}": no schema has been initialized. ` +
+      `Run createStoreWithSchema(graph, adminBackend) once under a ` +
+      `privileged role (which commits the schema_versions row and ` +
+      `materializes contribution markers) before attaching with ` +
+      `createStore() / createVerifiedStore(). Generated migration SQL ` +
+      `creates the tables but does not initialize the schema row.`,
+    { graphId },
+    {
+      cause,
+      suggestion:
+        "Run createStoreWithSchema(graph, adminBackend) once under a " +
+        "privileged role. If you manage DDL externally with drizzle-kit / " +
+        "generatePostgresMigrationSQL / generateSqliteMigrationSQL, apply " +
+        "that first, then still run createStoreWithSchema to commit the " +
+        "schema row and contribution markers.",
+    },
+  );
 }
 
 /**

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -54,7 +54,11 @@ export type {
 } from "./materialize-removals";
 export type { SchemaManagerOptions, SchemaValidationResult } from "./store";
 export type { Store } from "./store";
-export { createStore, createStoreWithSchema } from "./store";
+export {
+  createStore,
+  createStoreWithSchema,
+  createVerifiedStore,
+} from "./store";
 
 // Search facade and option / result types
 export type {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -55,6 +55,7 @@ import {
   ensureSchema as ensureSchemaImpl,
   loadActiveSchemaWithBootstrap,
   loadAndMergeGraphExtensionDocument,
+  loadAndVerifyGraph,
   parseSerializedSchema,
   type SchemaManagerOptions,
   type SchemaValidationResult,
@@ -1842,6 +1843,23 @@ function schemaMetadataForResult(
   return schemaMetadataFromRow(activeRow);
 }
 
+/**
+ * Prefer the #129 contribution path; fall back to the pre-#129
+ * `ensureFulltextTable` for backends that predate it. Idempotent and
+ * cheap on a warm re-call (per-instance cache + recorded-signature
+ * short-circuit).
+ */
+async function materializeRuntimeContributions(
+  backend: GraphBackend,
+  graphId: string,
+): Promise<void> {
+  if (backend.ensureRuntimeContributions) {
+    await backend.ensureRuntimeContributions(graphId);
+    return;
+  }
+  await backend.ensureFulltextTable?.(graphId);
+}
+
 // ============================================================
 // Async Factory with Schema Management
 // ============================================================
@@ -1902,22 +1920,77 @@ export async function createStoreWithSchema<G extends GraphDef>(
     preloaded: { activeRow, storedSchema },
   });
 
-  // #135: createStoreWithSchema is the single canonical durable-marker
-  // writer. The warm path already materialized runtime contributions
-  // inside loadActiveSchemaWithBootstrap, but the COLD path returns
-  // before that success branch (bootstrapTables runs, no active schema
-  // yet) — ensureSchemaImpl then initializes the schema. This explicit
-  // post-init call closes that gap: it writes the durable contribution
-  // marker AFTER the schema version is resolved, for cold and warm
-  // boots alike. Idempotent and cheap (the per-instance cache and the
-  // recorded-signature short-circuit make a warm re-call a no-op).
-  await backend.ensureRuntimeContributions?.(merged.id);
+  // #135/#143: this is the single durable-marker writer, and it MUST
+  // run after ensureSchemaImpl so the breaking-change gate is reached
+  // first — otherwise contribution DDL derived from the new code graph
+  // would hit a stale table shape and mask `MigrationError`.
+  await materializeRuntimeContributions(backend, merged.id);
 
   const store = new Store(
     merged,
     backend,
     options,
     schemaMetadataForResult(activeRow, result),
+  );
+  return [store, result];
+}
+
+/**
+ * Creates a Store after **verifying** that the database is at the same
+ * schema version as the code graph — without running any DDL, bootstrap,
+ * or marker writes. The runtime counterpart of `createStoreWithSchema`
+ * for the deployment model in "Database roles & least privilege":
+ *
+ * - **`createStoreWithSchema(graph, backend)`** runs DDL (bootstrap,
+ *   safe auto-migrations, durable contribution materialization). Run it
+ *   once at startup under a privileged role that holds `CREATE` / DDL.
+ * - **`createVerifiedStore(graph, backend)`** is the zero-DDL runtime
+ *   attach with a verification gate. Throws `MigrationError` when the
+ *   persisted schema is behind the code graph (any pending change, safe
+ *   or breaking), `ConfigurationError` when no schema has been
+ *   initialized, or `StoreNotInitializedError` when the schema is
+ *   current but the runtime-contribution markers are missing/stale.
+ *   The runtime can use a least-privilege, DML-only database role.
+ * - **`createStore(graph, backend)`** is the same zero-DDL attach
+ *   *without* the verification gate — fastest, but schema drift goes
+ *   undetected until a hot-path operation trips.
+ *
+ * Folds any persisted graph-extension document into the supplied graph
+ * before building the Store, just like `createStoreWithSchema`.
+ *
+ * @param graph - The graph definition
+ * @param backend - The database backend
+ * @param options - Optional store configuration
+ * @returns A tuple of [store, validationResult] — `result.status` is
+ *   always `"unchanged"` on success
+ *
+ * @example
+ * ```typescript
+ * // Runtime — least-privilege, DML-only role. Zero DDL.
+ * const [store, result] = await createVerifiedStore(graph, backend);
+ * // result.status === "unchanged" — the privileged migrator is current.
+ * ```
+ *
+ * @throws ConfigurationError if no schema has been initialized.
+ * @throws MigrationError if the persisted schema is behind the code graph.
+ * @throws StoreNotInitializedError if runtime-contribution markers are
+ *   missing/stale/failed for this graph on this connection.
+ */
+export async function createVerifiedStore<G extends GraphDef>(
+  graph: G,
+  backend: GraphBackend,
+  options?: StoreOptions,
+): Promise<[Store<G>, SchemaValidationResult]> {
+  const {
+    graph: merged,
+    activeRow,
+    result,
+  } = await loadAndVerifyGraph(backend, graph);
+  const store = new Store(
+    merged,
+    backend,
+    options,
+    schemaMetadataFromRow(activeRow),
   );
   return [store, result];
 }

--- a/packages/typegraph/tests/fulltext-bootstrap.test.ts
+++ b/packages/typegraph/tests/fulltext-bootstrap.test.ts
@@ -29,6 +29,7 @@ import {
   defineGraph,
   defineNode,
   fts5Strategy,
+  MigrationError,
   searchable,
   StoreNotInitializedError,
 } from "../src";
@@ -354,5 +355,60 @@ describe("#135 signature drift is a loud error, never silently re-blessed", () =
     });
 
     sqlite.close();
+  });
+});
+
+/**
+ * #143: `loadActiveSchemaWithBootstrap` used to materialize runtime
+ * contributions BEFORE `ensureSchema` computed the diff. On a database
+ * pending a breaking migration that applied vN+1 fulltext DDL against
+ * the vN table shape; on Postgres the aborted transaction surfaced as a
+ * wrapped `CREATE TABLE IF NOT EXISTS` query error instead of a clean
+ * `MigrationError`, breaking the documented migrate-on-`MigrationError`
+ * recovery path. The breaking-change gate must run first.
+ */
+describe("#143 breaking-change gate precedes contribution materialization", () => {
+  const DocumentV2Breaking = defineNode("Doc", {
+    schema: z.object({
+      // Required-field rename: a breaking change relative to `title`.
+      headline: searchable({ language: "english" }),
+    }),
+  });
+
+  const FtGraphV2Breaking = defineGraph({
+    id: FtGraph.id,
+    nodes: { Doc: { type: DocumentV2Breaking } },
+    edges: {},
+  });
+
+  it("throws MigrationError and never runs contribution DDL on a pending breaking migration", async () => {
+    const { sqlite: freshSqlite, db: freshDb } = createDrizzleKitOnlySqlite();
+
+    // v1 boots and materializes the fulltext contribution.
+    const v1Backend = createSqliteBackend(freshDb, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    await createStoreWithSchema(FtGraph, v1Backend);
+
+    // A second backend instance models a cold boot of the new code
+    // graph against the still-v1 database — its per-instance
+    // contribution cache is empty, so the pre-#143 loader would have
+    // emitted contribution DDL before the breaking-change check.
+    const coldBackend = createSqliteBackend(freshDb, {
+      executionProfile: { isSync: true },
+      tables: defaultTables,
+    });
+    const ensureSpy = vi.spyOn(coldBackend, "ensureRuntimeContributions");
+
+    await expect(
+      createStoreWithSchema(FtGraphV2Breaking, coldBackend),
+    ).rejects.toThrow(MigrationError);
+
+    // The breaking-change gate ran first: no contribution DDL was
+    // attempted against the stale v1 table shape.
+    expect(ensureSpy).not.toHaveBeenCalled();
+
+    freshSqlite.close();
   });
 });

--- a/packages/typegraph/tests/store-verified.test.ts
+++ b/packages/typegraph/tests/store-verified.test.ts
@@ -1,0 +1,233 @@
+/**
+ * `createVerifiedStore` / `assertSchemaCurrent` — the runtime
+ * counterpart of `createStoreWithSchema` for the "Database roles &
+ * least privilege" deployment model. SELECT-only attach with a
+ * verification gate: throws `ConfigurationError` when no schema has
+ * been initialized, `MigrationError` when the persisted schema is
+ * behind the code graph by **any** change (safe or breaking), and
+ * `StoreNotInitializedError` when the schema is current but the
+ * runtime-contribution markers are missing.
+ */
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  ConfigurationError,
+  createStore,
+  createStoreWithSchema,
+  createVerifiedStore,
+  defineGraph,
+  defineNode,
+  MigrationError,
+  searchable,
+  StoreNotInitializedError,
+} from "../src";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
+import { tables as defaultTables } from "../src/backend/sqlite";
+import { assertSchemaCurrent } from "../src/schema";
+
+const PersonV1 = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const PersonV2 = defineNode("Person", {
+  schema: z.object({
+    name: z.string(),
+    email: z.string().optional(), // additive — safe auto-migration
+  }),
+});
+
+const PersonV3Breaking = defineNode("Person", {
+  schema: z.object({
+    fullName: z.string(), // required-field rename — breaking
+  }),
+});
+
+const GRAPH_ID = "store-verified-test";
+
+function graphV1() {
+  return defineGraph({
+    id: GRAPH_ID,
+    nodes: { Person: { type: PersonV1 } },
+    edges: {},
+  });
+}
+
+function graphV2Safe() {
+  return defineGraph({
+    id: GRAPH_ID,
+    nodes: { Person: { type: PersonV2 } },
+    edges: {},
+  });
+}
+
+function graphV3Breaking() {
+  return defineGraph({
+    id: GRAPH_ID,
+    nodes: { Person: { type: PersonV3Breaking } },
+    edges: {},
+  });
+}
+
+function freshBackend(sqlite: Database.Database) {
+  return createSqliteBackend(drizzle(sqlite), {
+    executionProfile: { isSync: true },
+    tables: defaultTables,
+  });
+}
+
+describe("createVerifiedStore", () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("attaches and returns unchanged when the database is current", async () => {
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(graphV1(), bootBackend);
+
+    const runtimeBackend = freshBackend(sqlite);
+    const [store, result] = await createVerifiedStore(
+      graphV1(),
+      runtimeBackend,
+    );
+
+    expect(result.status).toBe("unchanged");
+    expect(store.graphId).toBe(GRAPH_ID);
+  });
+
+  it("throws ConfigurationError on a fresh database without bootstrapping tables", async () => {
+    const backend = freshBackend(sqlite);
+    const bootstrapSpy = vi.spyOn(backend, "bootstrapTables");
+    const ensureRuntimeSpy = vi.spyOn(backend, "ensureRuntimeContributions");
+
+    await expect(createVerifiedStore(graphV1(), backend)).rejects.toThrow(
+      ConfigurationError,
+    );
+
+    // Zero-DDL: the runtime path must not bootstrap or materialize.
+    expect(bootstrapSpy).not.toHaveBeenCalled();
+    expect(ensureRuntimeSpy).not.toHaveBeenCalled();
+
+    // And it really did not run DDL: schema_versions does not exist.
+    expect(() => sqlite.prepare(`SELECT 1 FROM schema_versions`).all()).toThrow(
+      /no such table/,
+    );
+  });
+
+  it("throws MigrationError when the database is behind by a safe pending change", async () => {
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(graphV1(), bootBackend);
+
+    const runtimeBackend = freshBackend(sqlite);
+    await expect(
+      createVerifiedStore(graphV2Safe(), runtimeBackend),
+    ).rejects.toMatchObject({
+      name: "MigrationError",
+      message: expect.stringMatching(/safe auto-migration/),
+    });
+  });
+
+  it("throws MigrationError when the database is behind by a breaking change", async () => {
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(graphV1(), bootBackend);
+
+    const runtimeBackend = freshBackend(sqlite);
+    await expect(
+      createVerifiedStore(graphV3Breaking(), runtimeBackend),
+    ).rejects.toMatchObject({
+      name: "MigrationError",
+      message: expect.stringMatching(/breaking change/),
+    });
+  });
+
+  it("throws StoreNotInitializedError when schema is current but contribution markers are absent", async () => {
+    const FtNode = defineNode("Doc", {
+      schema: z.object({ title: searchable({ language: "english" }) }),
+    });
+    const ftGraph = defineGraph({
+      id: GRAPH_ID,
+      nodes: { Doc: { type: FtNode } },
+      edges: {},
+    });
+
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(ftGraph, bootBackend);
+
+    // Drop the durable contribution marker — schema row stays current.
+    sqlite.exec(`DELETE FROM typegraph_contribution_materializations`);
+
+    const runtimeBackend = freshBackend(sqlite);
+    await expect(
+      createVerifiedStore(ftGraph, runtimeBackend),
+    ).rejects.toBeInstanceOf(StoreNotInitializedError);
+  });
+
+  it("does not invoke any DDL/materialization backend method on a successful verify", async () => {
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(graphV1(), bootBackend);
+
+    const runtimeBackend = freshBackend(sqlite);
+    const bootstrapSpy = vi.spyOn(runtimeBackend, "bootstrapTables");
+    const ensureRuntimeSpy = vi.spyOn(
+      runtimeBackend,
+      "ensureRuntimeContributions",
+    );
+    const ensureFulltextSpy = vi.spyOn(runtimeBackend, "ensureFulltextTable");
+
+    await createVerifiedStore(graphV1(), runtimeBackend);
+
+    expect(bootstrapSpy).not.toHaveBeenCalled();
+    expect(ensureRuntimeSpy).not.toHaveBeenCalled();
+    expect(ensureFulltextSpy).not.toHaveBeenCalled();
+  });
+
+  it("createStore (no verification) silently attaches against a behind database", async () => {
+    // Sanity check that the verification gate is what catches drift —
+    // createStore itself does not, by design.
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(graphV1(), bootBackend);
+
+    const runtimeBackend = freshBackend(sqlite);
+    const store = createStore(graphV2Safe(), runtimeBackend);
+    expect(store.graphId).toBe(GRAPH_ID);
+  });
+});
+
+describe("assertSchemaCurrent", () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("returns unchanged when the database is current", async () => {
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(graphV1(), bootBackend);
+
+    const runtimeBackend = freshBackend(sqlite);
+    const result = await assertSchemaCurrent(runtimeBackend, graphV1());
+    expect(result).toMatchObject({ status: "unchanged", version: 1 });
+  });
+
+  it("throws MigrationError on drift", async () => {
+    const bootBackend = freshBackend(sqlite);
+    await createStoreWithSchema(graphV1(), bootBackend);
+
+    const runtimeBackend = freshBackend(sqlite);
+    await expect(
+      assertSchemaCurrent(runtimeBackend, graphV2Safe()),
+    ).rejects.toThrow(MigrationError);
+  });
+});


### PR DESCRIPTION
Two related changes that together unlock running the TypeGraph runtime under a least-privilege, DML-only database role.

Closes #143.

## #143 — `MigrationError` masked by wrapped contribution DDL (patch)

**Symptom.** On a Postgres DB pending a breaking migration, `createStoreWithSchema` 500'd with a `DrizzleQueryError` wrapping a no-op `CREATE TABLE IF NOT EXISTS typegraph_contribution_materializations` instead of a clean `MigrationError`. Consumers using the documented migrate-on-`MigrationError` recovery path never saw it; only a concurrent migration race healed it.

**Cause.** `loadActiveSchemaWithBootstrap` called `ensureRuntimeContributions` (fulltext contribution DDL, derived from the new code graph) **before** `ensureSchema` computed the diff. Against a stale schema the new DDL hit the old table shape, poisoning the surrounding transaction; the error that escaped was the next idempotent statement (the marker-table CREATE), not the originating one.

**Fix.** The loader is now strictly read+bootstrap. `createStoreWithSchema` remains the single canonical durable-marker writer and runs that step **after** `ensureSchemaImpl`, so the breaking-change gate is reached first. Pre-#129 `ensureFulltextTable` fallback is preserved at the canonical writer (factored into `materializeRuntimeContributions`).

**Test.** New regression in `tests/fulltext-bootstrap.test.ts` spies on `ensureRuntimeContributions` across a v1 → v2-breaking cold boot and asserts `MigrationError` is thrown without contribution DDL being attempted.

## `createVerifiedStore` + `assertSchemaCurrent` (minor)

New SELECT-only entrypoints — the runtime counterparts of `createStoreWithSchema` for the least-privilege deployment model:

- **`createVerifiedStore(graph, backend, options?)`** returns `Promise<[Store<G>, SchemaValidationResult]>`. Zero DDL. Throws `MigrationError` on any drift (safe or breaking — the least-privilege runtime cannot migrate), `ConfigurationError` when no schema has been initialized, `StoreNotInitializedError` when the schema is current but runtime-contribution markers are missing/stale.
- **`assertSchemaCurrent(backend, graph)`** — the same gate as a standalone predicate for readiness probes / healthchecks.

Recommended deployment shape is now:

1. **Migration step** (privileged role, DDL/CREATE): `createStoreWithSchema()` once, or `generate*MigrationSQL()` + a one-shot `createStoreWithSchema()`.
2. **Runtime** (least-privilege, DML-only role): attach with `createVerifiedStore()`. Schema drift fails fast with a clean `MigrationError` instead of leaking into hot-path operations or 500'ing on a permission error.

Internal: factored a pure `mergeStoredGraphExtension` helper out of `loadAndMergeGraphExtensionDocument` so the SELECT-only verifier reuses the same parse + extension-merge + deprecated-kind logic without going through the bootstrap-capable loader. `loadAndVerifyGraph` is module-internal; `assertSchemaCurrent` is the sole public verifying primitive in the schema barrel.

**Tests** in `tests/store-verified.test.ts` cover: success returns `unchanged`; fresh DB → `ConfigurationError` without bootstrapping tables (spy-asserted); safe-pending and breaking drift both → `MigrationError` (qualifier in message); missing contribution markers → `StoreNotInitializedError`; zero DDL backend methods on successful verify (spy-asserted); bare `createStore` does **not** catch drift (proves the gate does the work).

## Docs

- `backend-setup.md` — new "Database roles & least privilege" section folds in all three entrypoints; Production example updated.
- `schema-management.md` — "Basic vs Managed vs Verified Store" with a short cross-reference for the role split.
- `troubleshooting.md` — entries for permission-denied-on-boot, `MigrationError` from a verifying attach, `ConfigurationError` on uninitialized DBs, and `StoreNotInitializedError` on the first op.


## Notes for reviewers

- API surface is strictly additive. `createStore` / `createStoreWithSchema` are unchanged.
- `assertRuntimeContributionsInitialized` (already on the backend type) is reused as the zero-DDL marker gate inside `loadAndVerifyGraph`.
- Honest open item out of scope here: `loadAndVerifyGraph` (and `ensureSchema`) compute `getSchemaHash` and, on hash miss, re-`serializeSchema` for the diff. Pre-existing in `ensureSchema`; only affects the drift/failure path. Worth a follow-up to extend the hash cache to also store the `SerializedSchema`, not part of this PR.
- The other unimplemented item from the #143 discussion — unwrapping Postgres SQLSTATE `25P02` ("current transaction is aborted") in `sql-errors.ts` so a poisoned-tx surfaces the originating statement instead of a downstream idempotent no-op — is also out of scope here. The #143 fix already defused the acute recovery-breaking case; the masking is now an operator-ergonomics wart on the privileged migration path, worth a follow-up.