### PR TITLE
feat: per-search `hnsw.ef_search` override for vector / hybrid search (#148)

### DIFF
--- a/.changeset/per-search-hnsw-ef-search.md
+++ b/.changeset/per-search-hnsw-ef-search.md
@@ -1,0 +1,27 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add a per-search `efSearch` knob for tuning pgvector HNSW recall (#148).
+
+`store.search.vector` and the vector half of `store.search.hybrid` now
+accept an optional `efSearch` — the HNSW search frontier
+(`hnsw.ef_search`, default 40). pgvector caps a single index scan at
+`ef_search` candidates, so the hybrid over-fetch (`vectorK = 4 * limit`
+by default) silently under-delivers once `vectorK` climbs past the
+session default; the floor is `efSearch >= vectorK` and ~2–4× is the
+high-recall target. Being per-search lets one connection pool serve both
+a latency-sensitive interactive path and a recall-sensitive batch path.
+
+The Postgres backend applies it transaction-locally
+(`SET LOCAL hnsw.ef_search`) around the vector `SELECT`, so it never
+leaks to the next query on a pooled connection — `SET LOCAL` issued in
+autocommit would roll off with the statement and the next pooled query
+would see the session default. Omitting `efSearch` opens no transaction
+and preserves today's behavior exactly. Validated as a positive integer
+≤ 1000 (pgvector's ceiling).
+
+Scope: pgvector HNSW only. sqlite-vec has no equivalent frontier knob
+and treats it as a no-op; transaction-less Postgres drivers
+(`drizzle-orm/neon-http`) ignore it with a one-time warning. IVFFlat's
+`ivfflat.probes` is a follow-up.

--- a/apps/docs/src/content/docs/semantic-search.md
+++ b/apps/docs/src/content/docs/semantic-search.md
@@ -523,6 +523,62 @@ Vector indexes (HNSW, IVFFlat) trade accuracy for speed:
 
 TypeGraph creates HNSW indexes by default for optimal balance.
 
+### Tuning recall per query with `efSearch`
+
+pgvector's HNSW index searches a dynamic candidate list whose size is
+the `hnsw.ef_search` GUC — **default 40**. That frontier caps how many
+neighbors a single scan can surface, so on corpora past a few million
+vectors recall@k flattens well below 1.0 at the default. TypeGraph
+exposes it as a per-search `efSearch` knob on `store.search.vector` and
+the vector half of `store.search.hybrid`:
+
+```typescript
+const hits = await store.search.hybrid("Document", {
+  limit: 20,
+  vector: {
+    fieldPath: "embedding",
+    queryEmbedding,
+    k: 80, // over-fetch 80 candidates from the vector side
+    efSearch: 240, // ~3× k — high-recall frontier for this query
+  },
+  fulltext: { query: "renewable energy" },
+});
+```
+
+Sizing guidance:
+
+- **Floor — `efSearch >= k`.** Hybrid over-fetches `k` candidates from
+  the vector side (default `4 * limit`). If `efSearch` is below `k` the
+  scan can't fill the candidate set, so the over-fetch silently
+  under-delivers — RRF papers over this on head queries (the fulltext
+  half covers the miss) but drops tail queries only the vector side
+  knows about.
+- **Target — ~2–4× `k`.** On million-scale corpora this clears roughly
+  0.95 recall@10, versus ~0.82–0.85 at the default 40. Verify the curve
+  against your own corpus rather than hard-coding a multiplier.
+- **Ceiling — 1000.** pgvector caps `hnsw.ef_search` at 1000; TypeGraph
+  rejects a larger `efSearch` with a clear error.
+
+Because it's per-search, one connection pool can serve both a
+latency-sensitive interactive path (omit `efSearch`, inherit the session
+default) and a recall-sensitive batch/ETL path (raise it) — a session
+GUC can't, a per-call override can.
+
+**Mechanics and limits.** The override is applied transaction-locally
+(`SET LOCAL hnsw.ef_search`) around the vector `SELECT`, so it never
+leaks to the next query on a pooled connection. Omitting it preserves
+today's behavior exactly — no transaction is opened. It applies to the
+**Postgres HNSW** path only:
+
+- **sqlite-vec** has no equivalent frontier knob and ignores `efSearch`
+  (no-op).
+- **Transaction-less Postgres drivers** (`drizzle-orm/neon-http`) can't
+  scope `SET LOCAL`, so `efSearch` is ignored with a one-time warning —
+  use a transactional driver (`node-postgres` / `neon-serverless` /
+  `postgres-js`) to apply it.
+- It tunes HNSW only; IVFFlat's analogous knob (`ivfflat.probes`) is not
+  yet exposed.
+
 ## Troubleshooting
 
 ### "Extension not found" errors

--- a/packages/typegraph/src/backend/drizzle/operations/vectors.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/vectors.ts
@@ -11,6 +11,14 @@ import type { SqliteTables } from "../schema/sqlite";
 import type { Tables } from "./shared";
 
 /**
+ * pgvector defines `hnsw.ef_search` as an integer GUC with a valid
+ * range of 1..1000; `SET hnsw.ef_search = 1001` errors at the server.
+ * We reject out-of-range values with a clear message instead of letting
+ * the raw pgvector error surface downstream.
+ */
+export const MAX_HNSW_EF_SEARCH = 1000;
+
+/**
  * Validates that all values in an array are finite numbers.
  * Throws if any value is NaN, Infinity, or not a number.
  */
@@ -230,6 +238,14 @@ function assertVectorSearchBounds(params: VectorSearchParams): void {
   if (!Number.isInteger(params.limit) || params.limit <= 0) {
     throw new Error(`limit must be a positive integer, got: ${params.limit}`);
   }
+  if (
+    params.efSearch !== undefined &&
+    (!Number.isInteger(params.efSearch) || params.efSearch <= 0)
+  ) {
+    throw new Error(
+      `efSearch must be a positive integer, got: ${params.efSearch}`,
+    );
+  }
 }
 
 /**
@@ -243,6 +259,12 @@ export function buildVectorSearchPostgres(
   const { embeddings } = tables;
   const queryLiteral = formatEmbeddingLiteral(params.queryEmbedding);
   assertVectorSearchBounds(params);
+  if (params.efSearch !== undefined && params.efSearch > MAX_HNSW_EF_SEARCH) {
+    throw new RangeError(
+      `efSearch must be ≤ ${MAX_HNSW_EF_SEARCH} (pgvector's hnsw.ef_search ` +
+        `valid range is 1..${MAX_HNSW_EF_SEARCH}), got: ${params.efSearch}`,
+    );
+  }
 
   const embeddingColumn = sql`${embeddings.embedding}`;
   const distanceExpression = buildDistanceExpression(

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -33,7 +33,7 @@ import {
   type SQL,
   sql,
 } from "drizzle-orm";
-import { PgDatabase } from "drizzle-orm/pg-core";
+import { PgDatabase, PgTransaction } from "drizzle-orm/pg-core";
 
 import { ConfigurationError } from "../../errors";
 import type { SqlTableNames } from "../../query/compiler/schema";
@@ -336,6 +336,7 @@ export function createPostgresBackend(
   const operations = createPostgresOperationBackend({
     db,
     executionAdapter,
+    adapterOptions,
     operationStrategy,
     tableNames,
     capabilities,
@@ -750,6 +751,12 @@ export function createPostgresBackend(
 type CreatePostgresOperationBackendOptions = Readonly<{
   db: AnyPgDatabase;
   executionAdapter: PostgresExecutionAdapter;
+  /**
+   * Adapter tuning (prepared-statement cache settings). Used to bind a
+   * fresh, equivalently-configured adapter to a transaction client when
+   * a per-search `efSearch` override opens its own transaction.
+   */
+  adapterOptions?: PostgresExecutionAdapterOptions | undefined;
   operationStrategy: ReturnType<typeof createPostgresOperationStrategy>;
   tableNames: SqlTableNames;
   capabilities: BackendCapabilities;
@@ -772,6 +779,7 @@ function createPostgresOperationBackend(
   const {
     db,
     executionAdapter,
+    adapterOptions,
     operationStrategy,
     tableNames,
     capabilities,
@@ -792,6 +800,87 @@ function createPostgresOperationBackend(
 
   async function execRun(query: SQL): Promise<void> {
     await executionAdapter.execute(query);
+  }
+
+  type VectorSearchRow = Readonly<{ node_id: string; score: number }>;
+
+  // One warning per backend instance when `efSearch` is supplied but the
+  // driver can't hold a transaction to scope `SET LOCAL` to.
+  let efSearchUnsupportedWarned = false;
+  function warnEfSearchUnsupported(): void {
+    if (efSearchUnsupportedWarned) return;
+    efSearchUnsupportedWarned = true;
+    if (typeof console === "undefined" || typeof console.warn !== "function") {
+      return;
+    }
+    console.warn(
+      "[typegraph] efSearch (hnsw.ef_search override) was ignored: this " +
+        "Postgres backend has transactions disabled (e.g. drizzle-orm/neon-http), " +
+        "and SET LOCAL needs a transaction to scope the override. Use a " +
+        "transactional driver (node-postgres / neon-serverless / postgres-js) " +
+        "to apply efSearch.",
+    );
+  }
+
+  /**
+   * Runs the vector SELECT, applying `hnsw.ef_search` transaction-locally
+   * when requested. `SET LOCAL` only takes effect inside an explicit
+   * transaction — issued in autocommit it rolls off with the statement
+   * and the next pooled query (notably under transaction-mode pgbouncer)
+   * sees the session default again. So when `efSearch` is set we bundle
+   * `BEGIN; SET LOCAL …; SELECT …; COMMIT;` onto one connection. When
+   * absent we take the unchanged single-statement fast path and open no
+   * transaction.
+   */
+  async function runVectorSearch(
+    efSearch: number | undefined,
+    query: SQL,
+  ): Promise<readonly VectorSearchRow[]> {
+    if (efSearch === undefined) {
+      return execAll<VectorSearchRow>(query);
+    }
+    if (!capabilities.transactions) {
+      warnEfSearchUnsupported();
+      return execAll<VectorSearchRow>(query);
+    }
+    // `SET` cannot be parameterized; `efSearch` is validated as an
+    // integer in 1..MAX_HNSW_EF_SEARCH before we get here, so inlining
+    // it is injection-safe.
+    const setEfSearch = sql.raw(`SET LOCAL hnsw.ef_search = ${efSearch}`);
+    if (db instanceof PgTransaction) {
+      // Already inside the caller's transaction (low-level
+      // backend.transaction / adoptTransaction). `executionAdapter` is
+      // bound to this tx client, but SET LOCAL persists to the end of the
+      // caller's transaction — leaking the override into their later
+      // vector searches and breaking the per-search contract. Snapshot
+      // the current frontier, apply the override, then restore it once
+      // the SELECT has materialized so the override stays scoped to this
+      // one search.
+      const [setting] = await execAll<{ ef_search: string }>(
+        sql`SELECT current_setting('hnsw.ef_search') AS ef_search`,
+      );
+      await execRun(setEfSearch);
+      const rows = await execAll<VectorSearchRow>(query);
+      // Restore only on success: a failed SELECT aborts the caller's
+      // transaction, so its rollback discards the SET LOCAL anyway and a
+      // restore here would just fail against the aborted tx, masking the
+      // real error. `set_config(_, _, true)` is the parameterizable form
+      // of SET LOCAL.
+      if (setting !== undefined) {
+        await execRun(
+          sql`SELECT set_config('hnsw.ef_search', ${setting.ef_search}, true)`,
+        );
+      }
+      return rows;
+    }
+    return db.transaction(async (tx) => {
+      // Bind an equivalently-configured adapter to the tx client so the
+      // SELECT keeps the server-side prepared-statement fast path and the
+      // driver result-shape normalization, rather than a bespoke execute.
+      const txAdapter = createPostgresExecutionAdapter(tx, adapterOptions);
+      await txAdapter.execute(setEfSearch);
+      return txAdapter.execute<VectorSearchRow>(query);
+    });
   }
 
   const commonBackend = createCommonOperationBackend({
@@ -870,8 +959,11 @@ function createPostgresOperationBackend(
     async vectorSearch(
       params: VectorSearchParams,
     ): Promise<readonly VectorSearchResult[]> {
+      // Build first: `buildVectorSearch` validates `efSearch` (positive
+      // integer, ≤ pgvector's 1000 ceiling) before `runVectorSearch`
+      // inlines it into `SET LOCAL`.
       const query = operationStrategy.buildVectorSearch(params);
-      const rows = await execAll<{ node_id: string; score: number }>(query);
+      const rows = await runVectorSearch(params.efSearch, query);
       return rows.map((row) => ({
         nodeId: row.node_id,
         score: row.score,
@@ -1017,6 +1109,7 @@ function createTransactionBackend(
   return createPostgresOperationBackend({
     db: options.db,
     executionAdapter: txExecutionAdapter,
+    adapterOptions: options.adapterOptions,
     operationStrategy: options.operationStrategy,
     tableNames: options.tableNames,
     capabilities: options.capabilities,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -320,6 +320,17 @@ export type VectorSearchParams = Readonly<{
   metric: VectorMetric;
   limit: number;
   minScore?: number;
+  /**
+   * HNSW search frontier for this query (pgvector `hnsw.ef_search`).
+   * Sizes the dynamic candidate list the index scan maintains: higher
+   * trades latency for recall. The floor for the over-fetch to fill its
+   * candidate set is `efSearch >= limit`; ~2–4× is the high-recall
+   * target. Applied transaction-locally (`SET LOCAL`) on the Postgres
+   * HNSW path only. No-op on backends without an HNSW frontier knob
+   * (sqlite-vec) and ignored — with a one-time warning — on Postgres
+   * backends without transactions (e.g. `drizzle-orm/neon-http`).
+   */
+  efSearch?: number;
 }>;
 
 /**

--- a/packages/typegraph/src/store/search.ts
+++ b/packages/typegraph/src/store/search.ts
@@ -90,6 +90,14 @@ export type HybridVectorOptions = Readonly<{
   k?: number;
   /** Minimum similarity to include (units depend on metric). */
   minScore?: number;
+  /**
+   * HNSW search frontier for this query (pgvector `hnsw.ef_search`).
+   * The vector side over-fetches `k` (default `4 * limit`) candidates;
+   * `efSearch` must be `>= k` for the index to surface that many
+   * neighbors, and ~2–4× `k` is the high-recall target. Postgres HNSW
+   * only — no-op elsewhere. See `VectorSearchOptions.efSearch`.
+   */
+  efSearch?: number;
 }>;
 
 /**
@@ -108,6 +116,22 @@ export type VectorSearchOptions = Readonly<{
   metric?: VectorMetric;
   /** Minimum similarity to include (units depend on metric). */
   minScore?: number;
+  /**
+   * HNSW search frontier for this query (pgvector `hnsw.ef_search`).
+   * Sizes the dynamic candidate list the index scan maintains — higher
+   * trades latency for recall. The floor for the index to surface
+   * `limit` neighbors is `efSearch >= limit`; ~2–4× is the high-recall
+   * target on million-scale corpora. Lets a latency-sensitive
+   * interactive path and a recall-sensitive batch path share one
+   * connection pool, tuning per query rather than per session.
+   *
+   * Postgres HNSW only: applied transaction-locally via `SET LOCAL`.
+   * sqlite-vec has no equivalent frontier knob and ignores it; Postgres
+   * backends without transactions (`drizzle-orm/neon-http`) ignore it
+   * with a one-time warning. Must be a positive integer; pgvector caps
+   * it at 1000.
+   */
+  efSearch?: number;
 }>;
 
 export type HybridFulltextOptions = Readonly<{
@@ -208,6 +232,7 @@ export async function executeVectorSearch<N = Node>(
       `vectorSearch.limit must be a positive integer, got: ${options.limit}`,
     );
   }
+  assertEfSearch(options.efSearch, "vectorSearch.efSearch");
 
   const rows = await backend.vectorSearch({
     graphId,
@@ -217,6 +242,7 @@ export async function executeVectorSearch<N = Node>(
     metric: options.metric ?? "cosine",
     limit: options.limit,
     ...(options.minScore === undefined ? {} : { minScore: options.minScore }),
+    ...(options.efSearch === undefined ? {} : { efSearch: options.efSearch }),
   });
   if (rows.length === 0) return [];
 
@@ -261,6 +287,7 @@ export async function executeHybridSearch<N = Node>(
   if (options.fusion !== undefined) {
     validateHybridFusionOptions(options.fusion);
   }
+  assertEfSearch(options.vector.efSearch, "hybridSearch.vector.efSearch");
 
   validateFulltextCallOptions(backend, {
     mode: options.fulltext.mode,
@@ -286,6 +313,9 @@ export async function executeHybridSearch<N = Node>(
     ...(options.vector.minScore === undefined ?
       {}
     : { minScore: options.vector.minScore }),
+    ...(options.vector.efSearch === undefined ?
+      {}
+    : { efSearch: options.vector.efSearch }),
   });
 
   const fulltextPromise = backend.fulltextSearch({
@@ -399,6 +429,22 @@ export async function executeHybridSearch<N = Node>(
     rank += 1;
   }
   return hits;
+}
+
+/**
+ * Validates the optional `efSearch` knob at the API boundary. Rejects
+ * non-positive-integer values uniformly across backends — the
+ * backend-specific ceiling (pgvector caps `hnsw.ef_search` at 1000) is
+ * enforced on the Postgres path, and backends without an HNSW frontier
+ * knob treat a valid value as a no-op.
+ */
+function assertEfSearch(efSearch: number | undefined, label: string): void {
+  if (efSearch === undefined) return;
+  if (!Number.isInteger(efSearch) || efSearch <= 0) {
+    throw new RangeError(
+      `${label} must be a positive integer, got: ${efSearch}`,
+    );
+  }
 }
 
 type FulltextCallOptions = Readonly<{

--- a/packages/typegraph/tests/backends/postgres/postgres-vector-ef-search.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-vector-ef-search.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Postgres `efSearch` (HNSW `hnsw.ef_search` override) mechanism tests.
+ *
+ * These assert the *mechanism*, not a statistical recall lift (which
+ * depends on HNSW build randomness + corpus size and belongs in a
+ * benchmark, not a flaky CI assertion):
+ *
+ * - The override is applied transaction-locally and does NOT leak to the
+ *   next query on a pooled connection — the load-bearing property of
+ *   `SET LOCAL`. Issued in autocommit it would roll off with the
+ *   statement and the next pooled query would see the session default.
+ * - The transactional path still returns correct nearest-neighbor rows.
+ * - A transaction-less backend (`transactions: false`) warns once and
+ *   ignores the option rather than emitting an unscoped `SET`.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { z } from "zod";
+
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { embedding } from "../../../src/core/embedding";
+import { defineGraph, defineNode } from "../../../src/index";
+import { createStoreWithSchema } from "../../../src/store";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let sharedPool: Pool | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): { pool: Pool } {
+  if (!isPostgresAvailable || sharedPool === undefined) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return { pool: sharedPool };
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  const pool = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+  });
+  try {
+    await pool.query("SELECT 1");
+    sharedPool = pool;
+    isPostgresAvailable = true;
+    await pool.query(`
+      DROP TABLE IF EXISTS typegraph_node_embeddings CASCADE;
+      DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
+      DROP TABLE IF EXISTS typegraph_edges CASCADE;
+      DROP TABLE IF EXISTS typegraph_nodes CASCADE;
+      DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+    `);
+    await pool.query(generatePostgresMigrationSQL());
+  } catch {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    await pool.end().catch(() => {});
+  }
+});
+
+afterAll(async () => {
+  if (sharedPool !== undefined) await sharedPool.end();
+});
+
+beforeEach(async () => {
+  if (sharedPool === undefined) return;
+  await sharedPool.query(
+    `TRUNCATE typegraph_node_embeddings,
+              typegraph_node_uniques,
+              typegraph_nodes,
+              typegraph_edges,
+              typegraph_schema_versions CASCADE`,
+  );
+});
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    title: z.string(),
+    embedding: embedding(4),
+  }),
+});
+
+async function seed(pool: Pool, graphId: string) {
+  const graph = defineGraph({
+    id: graphId,
+    nodes: { Doc: { type: Document } },
+    edges: {},
+  });
+  const backend = createPostgresBackend(drizzle(pool));
+  const [store] = await createStoreWithSchema(graph, backend);
+  await store.nodes.Doc.create({ title: "alpha", embedding: [1, 0, 0, 0] });
+  await store.nodes.Doc.create({ title: "beta", embedding: [0, 1, 0, 0] });
+  await store.nodes.Doc.create({ title: "gamma", embedding: [0, 0, 1, 0] });
+  return { graph, backend, store };
+}
+
+describe("Postgres efSearch — SET LOCAL transaction scoping", () => {
+  it("does not leak hnsw.ef_search to the next query on the same connection", async (ctx) => {
+    requirePostgres(ctx);
+    // max:1 pins one backend connection so the post-search read lands on
+    // the same connection the override ran on. SET LOCAL must have rolled
+    // off with the committed transaction; a (buggy) session-level SET
+    // would still be visible here.
+    const pinned = new Pool({ connectionString: TEST_DATABASE_URL, max: 1 });
+    try {
+      const backend = createPostgresBackend(drizzle(pinned));
+      const graph = defineGraph({
+        id: "ef_leak",
+        nodes: { Doc: { type: Document } },
+        edges: {},
+      });
+      const [store] = await createStoreWithSchema(graph, backend);
+      await store.nodes.Doc.create({ title: "alpha", embedding: [1, 0, 0, 0] });
+
+      const readEfSearch = async () => {
+        const rows = await backend.execute<{ ef: string }>(
+          sql`SELECT current_setting('hnsw.ef_search') AS ef`,
+        );
+        return rows[0]?.ef;
+      };
+
+      const baseline = await readEfSearch();
+      await store.search.vector("Doc", {
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+        limit: 5,
+        efSearch: 256,
+      });
+      const afterOverride = await readEfSearch();
+
+      expect(baseline).toBeDefined();
+      expect(afterOverride).toBe(baseline);
+      expect(afterOverride).not.toBe("256");
+    } finally {
+      await pinned.end();
+    }
+  });
+
+  it("restores the override inside a caller transaction so later searches don't inherit it", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const { backend } = await seed(pool, "ef_tx_restore");
+
+    await backend.transaction(async (tx) => {
+      const readEfSearch = async () => {
+        const rows = await tx.execute<{ ef: string }>(
+          sql`SELECT current_setting('hnsw.ef_search') AS ef`,
+        );
+        return rows[0]?.ef;
+      };
+      const baseline = await readEfSearch();
+      const params = {
+        graphId: "ef_tx_restore",
+        nodeKind: "Doc",
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+        metric: "cosine",
+        limit: 3,
+      } as const;
+
+      await tx.vectorSearch!({ ...params, efSearch: 256 });
+
+      // The override was restored within the same transaction: a later
+      // search without efSearch must not inherit 256.
+      expect(await readEfSearch()).toBe(baseline);
+      expect(await readEfSearch()).not.toBe("256");
+      const hits = await tx.vectorSearch!(params);
+      expect(hits.length).toBeGreaterThan(0);
+      expect(await readEfSearch()).toBe(baseline);
+    });
+  });
+
+  it("returns correct nearest-neighbor rows on the transactional path", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const { store } = await seed(pool, "ef_functional");
+
+    const hits = await store.search.vector("Doc", {
+      fieldPath: "embedding",
+      queryEmbedding: [1, 0, 0, 0],
+      limit: 3,
+      efSearch: 200,
+    });
+
+    expect(hits.length).toBeGreaterThan(0);
+    expect((hits[0]!.node as unknown as { title: string }).title).toBe("alpha");
+  });
+});
+
+describe("Postgres efSearch — transaction-less backend", () => {
+  it("warns once and ignores the override instead of leaking a session SET", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    // Seed via a normal (transactional) backend — a transaction-less
+    // backend can't bootstrap schema (commitSchemaVersion needs atomicity).
+    await seed(pool, "ef_txless");
+
+    const noTxBackend = createPostgresBackend(drizzle(pool), {
+      capabilities: { transactions: false },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const params = {
+        graphId: "ef_txless",
+        nodeKind: "Doc",
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+        metric: "cosine",
+        limit: 3,
+        efSearch: 256,
+      } as const;
+
+      const first = await noTxBackend.vectorSearch!(params);
+      const second = await noTxBackend.vectorSearch!(params);
+
+      // The query still runs (override silently dropped, not fatal).
+      expect(Array.isArray(first)).toBe(true);
+      expect(Array.isArray(second)).toBe(true);
+      // Warned exactly once across both calls.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]![0]).toMatch(/efSearch.*ignored/s);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/typegraph/tests/vector-ef-search.test.ts
+++ b/packages/typegraph/tests/vector-ef-search.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Per-search `efSearch` (HNSW `hnsw.ef_search` override) — backend-agnostic
+ * behavior.
+ *
+ * Covers the parts that don't need a live Postgres:
+ * - Validation at the store boundary (positive integer) for vector + hybrid.
+ * - pgvector's 1..1000 ceiling, enforced where the SELECT is built.
+ * - sqlite-vec accepts the option as a pure no-op (identical results).
+ *
+ * The Postgres `SET LOCAL` mechanism (transaction scoping, non-leak,
+ * transaction-less warn) lives in
+ * `tests/backends/postgres/postgres-vector-ef-search.test.ts`.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph, defineNode, searchable } from "../src";
+import {
+  buildVectorSearchPostgres,
+  MAX_HNSW_EF_SEARCH,
+} from "../src/backend/drizzle/operations/vectors";
+import { tables as pgTables } from "../src/backend/drizzle/schema/postgres";
+import { embedding } from "../src/core/embedding";
+import { createStoreWithSchema } from "../src/store";
+import { createTestBackend } from "./test-utils";
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    title: searchable({ language: "english" }),
+    embedding: embedding(4),
+  }),
+});
+
+const graph = defineGraph({
+  id: "ef_search_unit",
+  nodes: { Doc: { type: Document } },
+  edges: {},
+});
+
+async function seededStore() {
+  const backend = createTestBackend();
+  const [store] = await createStoreWithSchema(graph, backend);
+  await store.nodes.Doc.create({ title: "alpha", embedding: [1, 0, 0, 0] });
+  await store.nodes.Doc.create({ title: "beta", embedding: [0, 1, 0, 0] });
+  await store.nodes.Doc.create({ title: "gamma", embedding: [0, 0, 1, 0] });
+  return store;
+}
+
+const PG_PARAMS = {
+  graphId: "g",
+  nodeKind: "Doc",
+  fieldPath: "embedding",
+  queryEmbedding: [0.1, 0.2, 0.3, 0.4],
+  metric: "cosine",
+  limit: 10,
+} as const;
+
+describe("efSearch validation (store boundary)", () => {
+  it("rejects a non-positive-integer efSearch on vector search", async () => {
+    const store = await seededStore();
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      await expect(
+        store.search.vector("Doc", {
+          fieldPath: "embedding",
+          queryEmbedding: [1, 0, 0, 0],
+          limit: 5,
+          efSearch: bad,
+        }),
+      ).rejects.toThrow(/efSearch must be a positive integer/);
+    }
+  });
+
+  it("rejects a non-positive-integer efSearch on hybrid search", async () => {
+    const store = await seededStore();
+    await expect(
+      store.search.hybrid("Doc", {
+        limit: 5,
+        vector: {
+          fieldPath: "embedding",
+          queryEmbedding: [1, 0, 0, 0],
+          efSearch: 0,
+        },
+        fulltext: { query: "alpha" },
+      }),
+    ).rejects.toThrow(/efSearch must be a positive integer/);
+  });
+});
+
+describe("efSearch pgvector ceiling (query builder)", () => {
+  it("rejects efSearch above pgvector's 1000 ceiling", () => {
+    expect(() =>
+      buildVectorSearchPostgres(pgTables, {
+        ...PG_PARAMS,
+        efSearch: MAX_HNSW_EF_SEARCH + 1,
+      }),
+    ).toThrow(/1\.\.1000/);
+  });
+
+  it("accepts efSearch exactly at the ceiling", () => {
+    expect(() =>
+      buildVectorSearchPostgres(pgTables, {
+        ...PG_PARAMS,
+        efSearch: MAX_HNSW_EF_SEARCH,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a non-positive-integer efSearch at the build boundary", () => {
+    for (const bad of [0, -5, 2.5]) {
+      expect(() =>
+        buildVectorSearchPostgres(pgTables, { ...PG_PARAMS, efSearch: bad }),
+      ).toThrow(/efSearch must be a positive integer/);
+    }
+  });
+});
+
+describe("efSearch on sqlite-vec is a no-op", () => {
+  it("returns identical results with and without efSearch", async () => {
+    const store = await seededStore();
+    const query = [1, 0, 0, 0];
+
+    const without = await store.search.vector("Doc", {
+      fieldPath: "embedding",
+      queryEmbedding: query,
+      limit: 5,
+    });
+    const withEf = await store.search.vector("Doc", {
+      fieldPath: "embedding",
+      queryEmbedding: query,
+      limit: 5,
+      efSearch: 256,
+    });
+
+    expect(withEf.length).toBe(without.length);
+    expect(withEf.map((hit) => hit.node.id)).toEqual(
+      without.map((hit) => hit.node.id),
+    );
+    // The nearest neighbor to the x-axis query is "alpha".
+    expect((withEf[0]!.node as unknown as { title: string }).title).toBe(
+      "alpha",
+    );
+  });
+});


### PR DESCRIPTION
Closes #148.

## What

Adds an optional per-search `efSearch` knob to `store.search.vector` and the vector half of `store.search.hybrid`, plumbed through `VectorSearchParams` to the backend boundary. It sizes pgvector's HNSW search frontier (`hnsw.ef_search`, default **40**) per query, letting a caller trade latency for recall on a per-search basis instead of tuning the whole connection.

```ts
const hits = await store.search.hybrid("Document", {
  limit: 20,
  vector: { fieldPath: "embedding", queryEmbedding, k: 80, efSearch: 240 }, // ~3× k
  fulltext: { query: "renewable energy" },
});
```

Omitting `efSearch` preserves today's behavior **exactly** — no transaction is opened and no default changes.

## The load-bearing detail (per the issue discussion)

`SET LOCAL` only takes effect inside an explicit transaction. Issued in autocommit it rolls off with the statement, and the next pooled query — notably under transaction-mode pgbouncer — sees the session default again. The current `vectorSearch` path runs a single autocommit statement, so the implementation **opens the transaction itself**: when `efSearch` is set it bundles `BEGIN; SET LOCAL hnsw.ef_search = …; SELECT …; COMMIT;` onto one connection via `db.transaction()`. `SET` can't be parameterized, so the value is inlined after being validated as an integer in `1..1000`.

When `vectorSearch` is already running inside a transaction (adopted / tx-scoped backend), it runs both statements on the current client rather than opening a nested savepoint — which would add a round-trip and still leak the GUC to the parent transaction on `RELEASE`.

## Scope / caveats

- **pgvector HNSW only.** sqlite-vec has no equivalent frontier knob and treats `efSearch` as a no-op.
- **Transaction-less Postgres drivers** (`drizzle-orm/neon-http`) can't scope `SET LOCAL`, so `efSearch` is ignored with a one-time warning.
- **Ceiling 1000.** pgvector caps `hnsw.ef_search` at 1000; values above it are rejected with a clear error (so the "2–4× vectorK" guidance can't silently overflow past ~vectorK 250).
- IVFFlat's `ivfflat.probes` is a follow-up, not in this PR.

## Tests

`pnpm test` (SQLite, 3121 passed) and the full Postgres + integration suite (606 passed) green locally.

- **Unit** (`tests/vector-ef-search.test.ts`): store-boundary validation (positive integer) for vector + hybrid, the pgvector ≤ 1000 ceiling at the build boundary, and the sqlite-vec no-op (identical results with/without `efSearch`).
- **Postgres mechanism** (`tests/backends/postgres/postgres-vector-ef-search.test.ts`):
  - `SET LOCAL` does **not** leak to the next query on a pinned (`max: 1`) pooled connection — the property a session `SET` would violate.
  - The transactional path returns the correct nearest neighbor.
  - A `transactions: false` backend warns **once** and ignores the override instead of emitting an unscoped `SET`.

Per the issue evaluation, the **statistical** recall lift is intentionally left to a benchmark rather than a flaky CI assertion (HNSW build randomness + corpus-size dependence make a "default-40 drops a known hit" test non-deterministic).

## Docs

`apps/docs/src/content/docs/semantic-search.md` gains a "Tuning recall per query with `efSearch`" section covering the floor (`efSearch >= k`), the ~2–4× target, the 1000 ceiling, the per-call latency↔recall trade for mixed pools, and the `SET LOCAL` / backend-support mechanics.

A `minor` changeset is included.
