### PR TITLE
fix: ensureRuntimeContributions read-only no-op when already materialized (#149)

### DIFF
--- a/.changeset/ensure-contributions-readonly.md
+++ b/.changeset/ensure-contributions-readonly.md
@@ -1,0 +1,32 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `ensureRuntimeContributions` running marker-table DDL on every store
+open (#149).
+
+`createStoreWithSchema` → `ensureRuntimeContributions` previously ran the
+`typegraph_contribution_materializations` marker DDL
+(`ensureMarkerTable()` → `CREATE TABLE IF NOT EXISTS …`) on **every** open
+for any graph with runtime contributions (e.g. `searchable()` fields),
+even when every contribution was already materialized. The per-materializer
+`initializedGraphIds` cache is per-instance, so a deployment that builds a
+fresh backend per request (the norm on serverless Postgres) got an empty
+cache each time and re-ran the DDL on every open — which intermittently
+fails on connections that can't run it (observed on Cloudflare Workers +
+the Neon serverless driver) and surfaces as a wrapped `DrizzleQueryError`
+rather than a clean `MigrationError`.
+
+`ensureRuntimeContributions` now does a read-only pre-check first, mirroring
+the SELECT-only `assertInitialized`: when every runtime contribution is
+already materialized (marker present, signature matches, no recorded error)
+it returns without `ensureMarkerTable()` / `materializeOne`. A missing
+marker table, or any missing/stale/failed contribution, still falls through
+to the unchanged privileged first-materialization path. Warm per-request
+opens are now DDL-free.
+
+Note: the canonical runtime attach for the least-privilege / per-request
+deployment model remains `createVerifiedStore` (zero DDL by construction);
+`createStoreWithSchema` also runs bootstrap and auto-migration DDL and is
+still intended to run once under a privileged role. This change is
+defense-in-depth for the marker DDL specifically.

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -450,17 +450,82 @@ export function createContributionMaterializer(
     });
   }
 
+  /**
+   * Durable state of a single contribution on the current connection:
+   * its freshly-computed signature read back against the marker row. A
+   * missing marker *table* (never bootstrapped) is reported as its own
+   * variant so each caller decides what it means — `assertInitialized`
+   * treats it as "not initialized" and throws; `ensureRuntimeContributions`
+   * treats it as "needs first materialization" and falls through to DDL.
+   * Any non-missing-table read fault (connection/permission/driver) is a
+   * real system error and propagates as-is rather than being masked.
+   */
+  async function readContributionState(
+    graphId: string,
+    contribution: StrategyTableContribution,
+  ): Promise<
+    | Readonly<{ kind: "state"; state: ContributionMaterializationState }>
+    | Readonly<{ kind: "missing-table"; error: unknown }>
+  > {
+    const signature = await computeContributionSignature(
+      dialect,
+      contribution,
+      contribution.createDdl,
+    );
+    const identity = identityOf(graphId, contribution);
+    try {
+      const existing = await deps.getMarker(identity);
+      return {
+        kind: "state",
+        state: evaluateContributionState(existing, signature),
+      };
+    } catch (error) {
+      if (!isMissingTableError(error)) throw error;
+      return { kind: "missing-table", error };
+    }
+  }
+
+  /**
+   * SELECT-only verdict over every runtime contribution: `true` only when
+   * each one is already materialized at its current signature. Short-
+   * circuits on the first non-initialized read — a missing marker table
+   * or any missing/stale/failed contribution. Never runs DDL.
+   */
+  async function allContributionsInitialized(
+    graphId: string,
+    contributions: readonly StrategyTableContribution[],
+  ): Promise<boolean> {
+    for (const contribution of contributions) {
+      const read = await readContributionState(graphId, contribution);
+      if (read.kind !== "state" || read.state !== "initialized") return false;
+    }
+    return true;
+  }
+
   async function ensureRuntimeContributions(graphId: string): Promise<void> {
     // Cache guard so a redundant boot call (the warm path materializes
     // via loadActiveSchemaWithBootstrap, then createStoreWithSchema
     // calls again) is a true O(1) no-op rather than a re-SELECT.
     if (initializedGraphIds.has(graphId)) return;
     const contributions = runtimeContributions();
-    if (contributions.length > 0) {
-      await deps.ensureMarkerTable();
-      for (const contribution of contributions) {
-        await materializeOne(graphId, contribution);
-      }
+
+    // Read-only pre-check mirroring `assertInitialized` (#149): when every
+    // contribution is already materialized at its current signature, this
+    // open needs no DDL — skip `ensureMarkerTable()` / `materializeOne`
+    // entirely. A consumer that builds a fresh backend per request (empty
+    // per-instance cache) therefore stays DDL-free on a warm graph instead
+    // of re-running the marker `CREATE TABLE IF NOT EXISTS` on every open,
+    // which fails on connections that can't run it. A missing marker table
+    // or any missing/stale/failed contribution falls through to the
+    // privileged first-materialization path below, unchanged.
+    if (await allContributionsInitialized(graphId, contributions)) {
+      initializedGraphIds.add(graphId);
+      return;
+    }
+
+    await deps.ensureMarkerTable();
+    for (const contribution of contributions) {
+      await materializeOne(graphId, contribution);
     }
     initializedGraphIds.add(graphId);
   }
@@ -468,29 +533,20 @@ export function createContributionMaterializer(
   async function assertInitialized(graphId: string): Promise<void> {
     if (initializedGraphIds.has(graphId)) return;
     for (const contribution of runtimeContributions()) {
-      const signature = await computeContributionSignature(
-        dialect,
-        contribution,
-        contribution.createDdl,
-      );
-      const identity = identityOf(graphId, contribution);
-      let existing: ContributionMaterializationRow | undefined;
-      try {
-        existing = await deps.getMarker(identity);
-      } catch (error) {
-        // A never-bootstrapped database has no marker table — that is
-        // precisely "not initialized". Any other failure (connection,
-        // permission, driver) is a real system fault and must surface
-        // as-is rather than be masked as a user init error.
-        if (!isMissingTableError(error)) throw error;
+      const read = await readContributionState(graphId, contribution);
+      // A never-bootstrapped database has no marker table — that is
+      // precisely "not initialized". `readContributionState` has already
+      // rethrown any non-missing-table fault (connection, permission,
+      // driver), so a real system error never surfaces here masked as a
+      // user init error.
+      if (read.kind === "missing-table") {
         throw new StoreNotInitializedError(graphId, "missing", {
-          cause: error,
+          cause: read.error,
           details: { logicalName: contribution.logicalName },
         });
       }
-      const state = evaluateContributionState(existing, signature);
-      if (state !== "initialized") {
-        throw new StoreNotInitializedError(graphId, state, {
+      if (read.state !== "initialized") {
+        throw new StoreNotInitializedError(graphId, read.state, {
           details: { logicalName: contribution.logicalName },
         });
       }

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -1,0 +1,258 @@
+/**
+ * #149: `ensureRuntimeContributions` must be a read-only no-op when every
+ * runtime contribution is already materialized — no marker `CREATE TABLE`,
+ * no per-contribution DDL — mirroring the SELECT-only `assertInitialized`.
+ *
+ * These exercise `createContributionMaterializer` directly with mock deps
+ * so the DDL seams (`ensureMarkerTable`, `execDdl`) are observable: a fresh
+ * materializer instance (the per-request "fresh backend, empty cache" case)
+ * opening an already-materialized graph must touch neither. The signature
+ * value stays internal — both sides run the real `computeContributionSignature`
+ * over the same contribution, so a recorded marker reads back as `initialized`
+ * without the test hard-coding the hash.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { fts5Strategy, StoreNotInitializedError } from "../src";
+import {
+  type ContributionMaterializerDeps,
+  createContributionMaterializer,
+} from "../src/backend/drizzle/contribution-materializations";
+import type {
+  ContributionMaterializationIdentity,
+  ContributionMaterializationRow,
+  RecordContributionMaterializationParams,
+} from "../src/backend/types";
+
+const GRAPH_ID = "contrib-mat-unit";
+const FULLTEXT_TABLE = "typegraph_node_fulltext";
+
+// SQLite's missing-relation message — what `isMissingTableError` keys on
+// for a never-bootstrapped marker table.
+const MISSING_MARKER_TABLE_ERROR = new Error(
+  "no such table: typegraph_contribution_materializations",
+);
+
+function markerKey(identity: ContributionMaterializationIdentity): string {
+  return [
+    identity.graphId,
+    identity.logicalName,
+    identity.owner,
+    identity.tableName,
+  ].join("\0");
+}
+
+/**
+ * Upsert a recorded attempt into the in-memory marker store, preserving a
+ * prior success when this attempt failed (`materializedAt` undefined) —
+ * the same COALESCE rule the real `buildContributionOnConflictSet` applies.
+ */
+function recordMarkerInto(
+  markers: Map<string, ContributionMaterializationRow>,
+  params: RecordContributionMaterializationParams,
+): void {
+  const key = markerKey(params);
+  const prior = markers.get(key);
+  markers.set(key, {
+    graphId: params.graphId,
+    logicalName: params.logicalName,
+    owner: params.owner,
+    tableName: params.tableName,
+    signature: params.signature,
+    materializedAt: params.materializedAt ?? prior?.materializedAt,
+    lastAttemptedAt: params.attemptedAt,
+    lastError: params.error,
+  });
+}
+
+/**
+ * A materializer wired to an in-memory marker store with spied DDL seams.
+ * `getMarker` defaults to a map lookup; pass an override to simulate a
+ * missing marker table or a hard read fault.
+ */
+function createMockMaterializer(
+  markers: Map<string, ContributionMaterializationRow>,
+  getMarkerOverride?: (
+    identity: ContributionMaterializationIdentity,
+  ) => Promise<ContributionMaterializationRow | undefined>,
+) {
+  const ensureMarkerTable = vi.fn((): Promise<void> => Promise.resolve());
+  const execDdl = vi.fn(
+    (_statement: string): Promise<void> => Promise.resolve(),
+  );
+  const getMarker = vi.fn(
+    getMarkerOverride ??
+      ((
+        identity: ContributionMaterializationIdentity,
+      ): Promise<ContributionMaterializationRow | undefined> =>
+        Promise.resolve(markers.get(markerKey(identity)))),
+  );
+  const recordMarker = vi.fn(
+    (params: RecordContributionMaterializationParams): Promise<void> => {
+      recordMarkerInto(markers, params);
+      return Promise.resolve();
+    },
+  );
+
+  const deps = {
+    dialect: "sqlite",
+    fulltextStrategy: fts5Strategy,
+    fulltextTableName: FULLTEXT_TABLE,
+    execDdl,
+    ensureMarkerTable,
+    getMarker,
+    recordMarker,
+  } satisfies ContributionMaterializerDeps;
+
+  return {
+    materializer: createContributionMaterializer(deps),
+    spies: { ensureMarkerTable, execDdl, getMarker, recordMarker },
+  };
+}
+
+describe("#149 ensureRuntimeContributions is read-only when already materialized", () => {
+  it("a fresh materializer over an already-materialized graph runs zero DDL", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+
+    // Cold boot: empty markers → the full materialization path runs DDL
+    // and records the durable marker.
+    const cold = createMockMaterializer(markers);
+    await cold.materializer.ensureRuntimeContributions(GRAPH_ID);
+    expect(cold.spies.ensureMarkerTable).toHaveBeenCalledTimes(1);
+    expect(cold.spies.execDdl).toHaveBeenCalled();
+    expect(markers.size).toBe(1);
+
+    // Warm reopen with a FRESH materializer instance — the per-request
+    // "new backend, empty per-instance cache" case the issue is about.
+    const warm = createMockMaterializer(markers);
+    await warm.materializer.ensureRuntimeContributions(GRAPH_ID);
+
+    // #149: no marker `CREATE TABLE`, no contribution DDL, no marker write.
+    expect(warm.spies.ensureMarkerTable).not.toHaveBeenCalled();
+    expect(warm.spies.execDdl).not.toHaveBeenCalled();
+    expect(warm.spies.recordMarker).not.toHaveBeenCalled();
+    // It did consult the durable marker — a SELECT-only pre-check.
+    expect(warm.spies.getMarker).toHaveBeenCalled();
+  });
+
+  it("the per-materializer cache makes a redundant warm call a true no-op", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    await createMockMaterializer(
+      markers,
+    ).materializer.ensureRuntimeContributions(GRAPH_ID);
+
+    const warm = createMockMaterializer(markers);
+    await warm.materializer.ensureRuntimeContributions(GRAPH_ID);
+    warm.spies.getMarker.mockClear();
+
+    // Second call on the same instance hits the cache before any read.
+    await warm.materializer.ensureRuntimeContributions(GRAPH_ID);
+    expect(warm.spies.getMarker).not.toHaveBeenCalled();
+  });
+
+  it("still materializes (with DDL) when the marker table is missing", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    let tableExists = false;
+    const ensureMarkerTable = vi.fn((): Promise<void> => {
+      tableExists = true;
+      return Promise.resolve();
+    });
+    const execDdl = vi.fn(
+      (_statement: string): Promise<void> => Promise.resolve(),
+    );
+    // Faithful to the real backend: the marker SELECT throws until
+    // `ensureMarkerTable` has created the table.
+    const getMarker = vi.fn(
+      (
+        identity: ContributionMaterializationIdentity,
+      ): Promise<ContributionMaterializationRow | undefined> => {
+        if (!tableExists) return Promise.reject(MISSING_MARKER_TABLE_ERROR);
+        return Promise.resolve(markers.get(markerKey(identity)));
+      },
+    );
+    const recordMarker = vi.fn(
+      (params: RecordContributionMaterializationParams): Promise<void> => {
+        recordMarkerInto(markers, params);
+        return Promise.resolve();
+      },
+    );
+    const deps = {
+      dialect: "sqlite",
+      fulltextStrategy: fts5Strategy,
+      fulltextTableName: FULLTEXT_TABLE,
+      execDdl,
+      ensureMarkerTable,
+      getMarker,
+      recordMarker,
+    } satisfies ContributionMaterializerDeps;
+
+    await createContributionMaterializer(deps).ensureRuntimeContributions(
+      GRAPH_ID,
+    );
+
+    // The pre-check saw a missing marker table → fell through to the
+    // privileged first-materialization path: create marker table, run DDL,
+    // record the marker.
+    expect(ensureMarkerTable).toHaveBeenCalledTimes(1);
+    expect(execDdl).toHaveBeenCalled();
+    expect(recordMarker).toHaveBeenCalled();
+    expect(markers.size).toBe(1);
+  });
+
+  it("propagates a non-missing-table read fault without attempting DDL", async () => {
+    const fault = new Error("connection terminated unexpectedly");
+    const { materializer, spies } = createMockMaterializer(new Map(), () =>
+      Promise.reject(fault),
+    );
+
+    // The read-first pre-check must not swallow a genuine system fault and
+    // proceed to DDL — it surfaces as-is.
+    await expect(
+      materializer.ensureRuntimeContributions(GRAPH_ID),
+    ).rejects.toBe(fault);
+    expect(spies.ensureMarkerTable).not.toHaveBeenCalled();
+    expect(spies.execDdl).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertInitialized verdicts after the readContributionState refactor", () => {
+  it("resolves without DDL when every contribution is materialized", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    await createMockMaterializer(
+      markers,
+    ).materializer.ensureRuntimeContributions(GRAPH_ID);
+
+    const warm = createMockMaterializer(markers);
+    await expect(
+      warm.materializer.assertInitialized(GRAPH_ID),
+    ).resolves.toBeUndefined();
+    expect(warm.spies.ensureMarkerTable).not.toHaveBeenCalled();
+    expect(warm.spies.execDdl).not.toHaveBeenCalled();
+  });
+
+  it("throws StoreNotInitializedError(missing) when the marker table is missing", async () => {
+    const { materializer } = createMockMaterializer(new Map(), () =>
+      Promise.reject(MISSING_MARKER_TABLE_ERROR),
+    );
+
+    await expect(
+      materializer.assertInitialized(GRAPH_ID),
+    ).rejects.toMatchObject({
+      name: "StoreNotInitializedError",
+      details: { reason: "missing" },
+    });
+  });
+
+  it("propagates a non-missing-table read fault as-is (not masked as missing)", async () => {
+    const fault = new Error("permission denied for relation");
+    const { materializer } = createMockMaterializer(new Map(), () =>
+      Promise.reject(fault),
+    );
+
+    const rejection = await materializer
+      .assertInitialized(GRAPH_ID)
+      .catch((error: unknown) => error);
+    expect(rejection).toBe(fault);
+    expect(rejection).not.toBeInstanceOf(StoreNotInitializedError);
+  });
+});


### PR DESCRIPTION
Closes #149.

## Problem

`createStoreWithSchema` → `ensureRuntimeContributions` ran the `typegraph_contribution_materializations` marker DDL (`ensureMarkerTable()` → `CREATE TABLE IF NOT EXISTS …`) on **every** store open for any graph with runtime contributions (e.g. `searchable()` fields), even when every contribution was already materialized.

`initializedGraphIds` is a per-materializer-instance cache, so a consumer that builds a fresh backend per request (the norm on serverless Postgres) gets an empty cache each open and re-runs the DDL every time. On a connection that can't run that DDL — or where concurrent opens race it — the open throws. Observed on **Cloudflare Workers + the Neon serverless driver**: the marker `CREATE TABLE IF NOT EXISTS` is the first statement, so it's what escapes, surfacing as a wrapped `DrizzleQueryError` instead of a clean `MigrationError` — which breaks the documented migrate-on-`MigrationError` recovery and 500s.

On a warm open the marker DDL is in fact the *sole* remaining DDL in `createStoreWithSchema` (`loadActiveSchemaWithBootstrap` only bootstraps on a missing-table error; `ensureSchemaImpl` returns `unchanged` without DDL), so removing it makes a warm open genuinely DDL-free.

## Fix

`ensureRuntimeContributions` now does a read-only pre-check first, mirroring the SELECT-only `assertInitialized`: when every runtime contribution reads back as `initialized` (marker present, signature matches, no recorded error), it caches and returns **without** `ensureMarkerTable()` / `materializeOne`. A missing marker table, or any missing/stale/failed contribution, falls through to the **unchanged** privileged first-materialization path — so the #135 self-heal and #143 drift-refusal/boot-ordering behavior are untouched.

- Extract **`readContributionState`** (signature + `getMarker` + evaluate) returning a `state` / `missing-table` discriminated union, rethrowing any non-missing-table fault as-is (connection/permission/driver errors are never masked). Both `ensureRuntimeContributions` and `assertInitialized` consume it; the missing-table → action mapping stays per-caller (assert throws `StoreNotInitializedError("missing")`; ensure falls through to DDL). This is the shareable piece — *not* `assertInitialized` itself.
- Add **`allContributionsInitialized`** — the short-circuiting SELECT-only predicate the ensure path gates on.

## Scope / non-goals

`createVerifiedStore` (added in 0.27.0) remains the canonical **zero-DDL** runtime attach for the least-privilege / per-request deployment model, and is the recommended fix for the reported consumer scenario. `createStoreWithSchema` still runs bootstrap + auto-migration DDL and is intended to run once under a privileged role. This change is **defense-in-depth** for the marker DDL specifically and does not re-position `createStoreWithSchema` as runtime-safe.

## Tests

New `tests/contribution-materializer.test.ts` unit-tests `createContributionMaterializer` with mock deps so the DDL seams (`ensureMarkerTable`, `execDdl`) are observable:

- a fresh materializer instance over an already-materialized graph runs **zero DDL** (the #149 regression);
- a missing marker table still materializes with DDL;
- a non-missing-table read fault propagates instead of falling through to DDL;
- `assertInitialized` verdicts (initialized / missing / non-missing-table fault) hold after the refactor.

## Verification

- `pnpm typecheck` — clean
- eslint + prettier (changed files) — clean
- `pnpm test` (SQLite) — 3128 passed
- `pnpm test:postgres` — 607 passed (incl. `postgres-fulltext-bootstrap`)