### PR TITLE
fix: walk error.cause chain in isMissingTableError for wrapped Postgres errors (#153)

### DIFF
--- a/.changeset/missing-table-error-cause-chain.md
+++ b/.changeset/missing-table-error-cause-chain.md
@@ -1,0 +1,34 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `isMissingTableError` missing DrizzleQueryError-wrapped Postgres
+"relation does not exist" errors, breaking fresh/partial Postgres boot (#153).
+
+`isMissingTableError` (the shared "relation not bootstrapped yet"
+discriminant for `loadActiveSchemaWithBootstrap`, `readActiveSchemaPure`,
+and the #135 durable-marker gate) classified failures by inspecting only
+`error.message`. On Postgres, drizzle-orm wraps every query-builder call
+(`db.select()`, `db.insert()`, …) in a `DrizzleQueryError` whose `.message`
+is the failed SQL text; the real driver error — carrying both
+`relation "…" does not exist` and SQLSTATE `42P01` — is preserved on
+`error.cause`, which the helper never walked. So the helper returned
+`false` and a benign "not bootstrapped yet" surfaced as a hard fault.
+
+This regressed `createStoreWithSchema` after the #149/#152 read-only
+pre-check: `ensureRuntimeContributions` now calls `getMarker` (a
+query-builder read) on the possibly-absent
+`typegraph_contribution_materializations` table *before* `ensureMarkerTable()`.
+On Postgres that read throws a `DrizzleQueryError`, the helper missed it,
+and the open rethrew instead of materializing — breaking seed, first boot,
+and test global-setup on any fresh or partial Postgres database (base
+tables present, marker table absent — e.g. drizzle-kit-managed schemas).
+SQLite was unaffected because better-sqlite3 throws a raw error whose
+`.message` literally contains `no such table`.
+
+`isMissingTableError` now walks the `error.cause` chain (cycle-safe) and
+additionally keys on the locale-independent SQLSTATE `42P01`, rather than
+matching only the outermost `.message`. Existing message patterns are
+retained, so all prior matches still hold; the fix applies uniformly to
+all three call sites, including the latent slow-path blind spot in
+`loadActiveSchemaWithBootstrap` / `readActiveSchemaPure`.

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -6,6 +6,17 @@
  * missing-table failure looks like, and — critically — so neither one
  * swallows a genuine system fault (connection/permission/driver error)
  * as a benign "not bootstrapped yet".
+ *
+ * Detection walks the error's `cause` chain because Drizzle (>= the
+ * `DrizzleQueryError` era, drizzle-orm ≥ 0.36) wraps every failure from a
+ * query-builder call (`db.select()`, `db.insert()`, …): the wrapper's
+ * `.message` becomes the failed query text and the real driver error —
+ * which carries both the missing-relation text and the SQLSTATE — is
+ * preserved on `.cause`. node-postgres / postgres-js nest the pg error
+ * one link deep; better-sqlite3 throws it unwrapped; raw `client.query()`
+ * fast paths surface it directly. Walking the chain makes the check
+ * wrapper- and driver-agnostic instead of only matching the outermost
+ * `.message`, which on Postgres is just the SQL string.
  */
 
 const MISSING_TABLE_PATTERNS = [
@@ -14,7 +25,51 @@ const MISSING_TABLE_PATTERNS = [
   "SQLITE_ERROR", // D1 / Durable Objects error code
 ] as const;
 
+/**
+ * SQLSTATE for PostgreSQL `undefined_table`. Preferred over the
+ * human-readable message: it is locale-independent (the "... does not
+ * exist" text is translated under a non-English `lc_messages`) and is
+ * preserved on the underlying driver error even when Drizzle overwrites
+ * `.message` with the query text.
+ */
+const POSTGRES_UNDEFINED_TABLE_CODE = "42P01";
+
+/**
+ * Yields an error and each error reachable by following `.cause`,
+ * outermost first. `seen` guards the pathological cyclic-cause case so a
+ * self-referential chain can't spin forever.
+ */
+function* errorChain(error: unknown): Generator<unknown, void, void> {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    yield current;
+    current = current instanceof Error ? current.cause : undefined;
+  }
+}
+
+/**
+ * Whether a single chain link is a PostgreSQL `undefined_table` failure,
+ * identified by its SQLSTATE rather than a message substring.
+ */
+function isPostgresUndefinedTable(link: unknown): boolean {
+  return (
+    typeof link === "object" &&
+    link !== null &&
+    "code" in link &&
+    (link as Readonly<{ code?: unknown }>).code ===
+      POSTGRES_UNDEFINED_TABLE_CODE
+  );
+}
+
 export function isMissingTableError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return MISSING_TABLE_PATTERNS.some((pattern) => message.includes(pattern));
+  for (const link of errorChain(error)) {
+    if (isPostgresUndefinedTable(link)) return true;
+    const message = link instanceof Error ? link.message : String(link);
+    if (MISSING_TABLE_PATTERNS.some((pattern) => message.includes(pattern))) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -33,6 +33,26 @@ const MISSING_MARKER_TABLE_ERROR = new Error(
   "no such table: typegraph_contribution_materializations",
 );
 
+// Postgres' missing-relation failure as it actually reaches the gate:
+// drizzle-orm wraps the query-builder `getMarker` SELECT in a
+// `DrizzleQueryError` whose `.message` is the SQL text, with the real pg
+// error (`relation ... does not exist` / SQLSTATE 42P01) on `.cause`.
+// This is the #152 regression shape — the pre-check must still recognize
+// it as a missing table and fall through to first materialization.
+const POSTGRES_MISSING_MARKER_TABLE_ERROR = Object.assign(
+  new Error(
+    'Failed query: select * from "typegraph_contribution_materializations"\nparams: ',
+  ),
+  {
+    cause: Object.assign(
+      new Error(
+        'relation "typegraph_contribution_materializations" does not exist',
+      ),
+      { code: "42P01" },
+    ),
+  },
+);
+
 function markerKey(identity: ContributionMaterializationIdentity): string {
   return [
     identity.graphId,
@@ -196,6 +216,51 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
     expect(ensureMarkerTable).toHaveBeenCalledTimes(1);
     expect(execDdl).toHaveBeenCalled();
     expect(recordMarker).toHaveBeenCalled();
+    expect(markers.size).toBe(1);
+  });
+
+  it("falls through to DDL when the marker table is missing behind a DrizzleQueryError (Postgres)", async () => {
+    // The #152 regression: on Postgres the pre-check `getMarker` SELECT
+    // fails wrapped, so the missing-table signal lives on `.cause`. Before
+    // the cause-walking fix this rethrew and broke first boot.
+    let tableExists = false;
+    const ensureMarkerTable = vi.fn((): Promise<void> => {
+      tableExists = true;
+      return Promise.resolve();
+    });
+    const execDdl = vi.fn(
+      (_statement: string): Promise<void> => Promise.resolve(),
+    );
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const getMarker = vi.fn(
+      (
+        identity: ContributionMaterializationIdentity,
+      ): Promise<ContributionMaterializationRow | undefined> =>
+        tableExists ?
+          Promise.resolve(markers.get(markerKey(identity)))
+        : Promise.reject(POSTGRES_MISSING_MARKER_TABLE_ERROR),
+    );
+    const recordMarker = vi.fn(
+      (params: RecordContributionMaterializationParams): Promise<void> => {
+        recordMarkerInto(markers, params);
+        return Promise.resolve();
+      },
+    );
+    const deps = {
+      dialect: "postgres",
+      fulltextStrategy: fts5Strategy,
+      fulltextTableName: FULLTEXT_TABLE,
+      execDdl,
+      ensureMarkerTable,
+      getMarker,
+      recordMarker,
+    } satisfies ContributionMaterializerDeps;
+
+    await expect(
+      createContributionMaterializer(deps).ensureRuntimeContributions(GRAPH_ID),
+    ).resolves.toBeUndefined();
+    expect(ensureMarkerTable).toHaveBeenCalledTimes(1);
+    expect(execDdl).toHaveBeenCalled();
     expect(markers.size).toBe(1);
   });
 

--- a/packages/typegraph/tests/sql-errors.test.ts
+++ b/packages/typegraph/tests/sql-errors.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `isMissingTableError` is the single cross-dialect "relation not
+ * bootstrapped yet" discriminant for both the schema bootstrap
+ * (`loadActiveSchemaWithBootstrap`) and the durable-marker gate (#135).
+ *
+ * The regression these tests pin: drizzle-orm (≥ the `DrizzleQueryError`
+ * era) wraps query-builder failures so the wrapper's `.message` is the
+ * failed SQL text and the real driver error lives on `.cause`. On
+ * Postgres that real error carries `relation ... does not exist` /
+ * SQLSTATE `42P01`. A helper that reads only the outermost `.message`
+ * sees only the SQL string and reports a fresh Postgres database as a
+ * hard fault — breaking first boot. The helper must walk the cause chain
+ * (and key on the locale-independent SQLSTATE) without ever swallowing a
+ * genuine system fault as "missing table".
+ */
+import { describe, expect, it } from "vitest";
+
+import { isMissingTableError } from "../src/utils/sql-errors";
+
+/**
+ * Mirrors drizzle-orm's `DrizzleQueryError`: `.message` is the query
+ * text, the driver error is attached on `.cause`.
+ */
+function drizzleQueryError(query: string, cause: Error): Error {
+  const wrapper = new Error(`Failed query: ${query}\nparams: `);
+  (wrapper as { cause?: unknown }).cause = cause;
+  return wrapper;
+}
+
+/** Mirrors a node-postgres `DatabaseError`: real message + SQLSTATE code. */
+function pgError(message: string, code: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+describe("isMissingTableError", () => {
+  it("detects the native SQLite missing-table message", () => {
+    expect(
+      isMissingTableError(new Error("no such table: typegraph_node_fulltext")),
+    ).toBe(true);
+  });
+
+  it("detects the native Postgres fast-path error (message + code)", () => {
+    expect(
+      isMissingTableError(
+        pgError('relation "typegraph_node_fulltext" does not exist', "42P01"),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a Postgres error wrapped in DrizzleQueryError via .cause", () => {
+    const wrapped = drizzleQueryError(
+      'select * from "typegraph_contribution_materializations"',
+      pgError(
+        'relation "typegraph_contribution_materializations" does not exist',
+        "42P01",
+      ),
+    );
+    // The outermost message is only the SQL text — the missing-table
+    // signal is reachable solely through the cause chain.
+    expect(wrapped.message).not.toContain("does not exist");
+    expect(isMissingTableError(wrapped)).toBe(true);
+  });
+
+  it("keys on the SQLSTATE even when the message is non-English", () => {
+    const wrapped = drizzleQueryError(
+      'select * from "typegraph_node_fulltext"',
+      // Localized lc_messages: text no longer contains "does not exist".
+      pgError("la relación «typegraph_node_fulltext» no existe", "42P01"),
+    );
+    expect(isMissingTableError(wrapped)).toBe(true);
+  });
+
+  it("detects the D1 / Durable Objects SQLITE_ERROR marker", () => {
+    expect(isMissingTableError(new Error("SQLITE_ERROR: no such table"))).toBe(
+      true,
+    );
+  });
+
+  it("handles a non-Error value", () => {
+    expect(isMissingTableError("no such table: foo")).toBe(true);
+    expect(isMissingTableError("connection refused")).toBe(false);
+  });
+
+  it("does NOT treat a genuine system fault as a missing table", () => {
+    expect(
+      isMissingTableError(new Error("connection terminated unexpectedly")),
+    ).toBe(false);
+    expect(
+      isMissingTableError(
+        pgError("permission denied for relation foo", "42501"),
+      ),
+    ).toBe(false);
+    // A connection fault wrapped by Drizzle must still surface as a fault.
+    expect(
+      isMissingTableError(
+        drizzleQueryError(
+          "select 1",
+          pgError(
+            "terminating connection due to administrator command",
+            "57P01",
+          ),
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("survives a cyclic cause chain without spinning", () => {
+    const a = new Error("connection reset");
+    const b = new Error("downstream failure");
+    (a as { cause?: unknown }).cause = b;
+    (b as { cause?: unknown }).cause = a;
+    expect(isMissingTableError(a)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #153.

## Problem

`isMissingTableError` (`src/utils/sql-errors.ts`) — the shared "relation not bootstrapped yet" discriminant for `loadActiveSchemaWithBootstrap`, `readActiveSchemaPure`, and the #135 durable-marker gate — classified failures by inspecting only `error.message`.

On Postgres, drizzle-orm (0.45.2) wraps every query-builder call (`db.select()`, `db.insert()`, …) in a `DrizzleQueryError` whose `.message` is the failed **query text**; the real driver error — carrying both `relation "…" does not exist` and SQLSTATE `42P01` — is preserved on `.cause`, which the helper never walked. So it returned `false` and a benign "not bootstrapped yet" surfaced as a hard fault.

This regressed `createStoreWithSchema` after the #149/#152 read-only pre-check: `ensureRuntimeContributions` now calls `getMarker` (a query-builder read) on the possibly-absent `typegraph_contribution_materializations` table *before* `ensureMarkerTable()`. On Postgres that read throws a `DrizzleQueryError`, the helper missed it, and the open **rethrew instead of materializing** — breaking seed, first boot, and the test global-setup (`DROP SCHEMA public CASCADE` → `createStoreWithSchema`) on any fresh or partial Postgres database. SQLite was unaffected (better-sqlite3 throws a raw error whose `.message` contains `no such table`).

### Why partial-state, not fully-empty

The two read paths use different execution surfaces:

| Path | Mechanism | Error shape | Detected (pre-fix) |
|---|---|---|---|
| `getActiveSchema` (bootstrap, first) | adapter **fast path** `client.query()` | native pg error, `.message` has "does not exist" | ✅ |
| `getMarker` (#152 pre-check) | **Drizzle query builder** `db.select()` | `DrizzleQueryError`, real error on `.cause` (`42P01`) | ❌ |

A fully empty DB still boots (`bootstrapTables()` creates the marker table). The break needs base tables present but the marker table absent — exactly what drizzle-kit-managed schemas and seed/first-boot produce. The same latent blind spot also affected `loadActiveSchemaWithBootstrap` / `readActiveSchemaPure` on any driver/config routing `getActiveSchema` through Drizzle's slow path.

## Fix

`isMissingTableError` now walks the `error.cause` chain (cycle-safe) and additionally keys on the locale-independent SQLSTATE `42P01`, rather than matching only the outermost `.message`. Existing message patterns are retained (no prior match changes); the fix applies uniformly to all three call sites.
