### PR TITLE
feat: export ontology transitive-closure utilities from package root

### DIFF
--- a/.changeset/public-ontology-closures.md
+++ b/.changeset/public-ontology-closures.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Export the ontology transitive-closure utilities (`computeTransitiveClosure`, `invertClosure`, `isReachable`) from the package root. These were previously internal-only. Exposing them lets consumers reason over `subClassOf` / `equivalentTo` hierarchies — e.g. reconciling node types when merging graphs from independent sources.

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -168,6 +168,8 @@ export type {
 export {
   // Individual relation factories (for convenience)
   broader,
+  // Transitive-closure utilities (reason over subClassOf/equivalentTo hierarchies)
+  computeTransitiveClosure,
   // Core ontology module
   core,
   differentFrom,
@@ -176,8 +178,10 @@ export {
   hasPart,
   implies,
   inverseOf,
+  invertClosure,
   // Type guards
   isMetaEdge,
+  isReachable,
   narrower,
   partOf,
   relatedTo,


### PR DESCRIPTION
Surface the ontology transitive-closure utilities from the package root barrel:

- `computeTransitiveClosure`
- `invertClosure`
- `isReachable`

These were exported from `src/ontology/index.ts` but omitted from the public root entrypoint (`src/index.ts`), and there is no `/ontology` subpath — so they were unreachable from any public import. They are general-purpose, well-tested pure functions for reasoning over `subClassOf` / `equivalentTo` hierarchies which should be accessible to outside consumers.