### PR TITLE
feat: allow disabling the vector stack on the Postgres backend (vector: false)

### DIFF
--- a/.changeset/postgres-disable-vector.md
+++ b/.changeset/postgres-disable-vector.md
@@ -1,0 +1,16 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `vector: false` to `createPostgresBackend` to disable the vector stack.
+
+The Postgres backend wires `pgvectorStrategy` by default, assuming a standalone
+Postgres server has the pgvector extension installed. An in-process Postgres
+(PGlite) built without that extension can't honor it — the default strategy's
+`vector(N)` DDL hard-fails the moment an embedding is written or
+`CREATE EXTENSION vector` runs. Passing `vector: false` turns the stack off:
+the backend advertises no `capabilities.vector` and omits the
+embedding/search methods, mirroring a SQLite connection without sqlite-vec, so
+the store never routes vector work to it.
+
+Real-Postgres behavior is unchanged — the default remains `pgvectorStrategy`.

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -172,8 +172,16 @@ export type PostgresBackendOptions = Readonly<{
    * `capabilities.vector`. Pass a custom strategy to swap the entire
    * vector stack for an alternate Postgres extension without forking
    * TypeGraph.
+   *
+   * Pass `false` to disable vector support entirely. The backend then
+   * advertises no `capabilities.vector` and omits the embedding/search
+   * methods, mirroring a SQLite connection without sqlite-vec. Required
+   * for an in-process Postgres (e.g. PGlite) built without the pgvector
+   * extension: the default `pgvectorStrategy` assumes `vector(N)` exists,
+   * so any embedding write or `CREATE EXTENSION vector` would otherwise
+   * hard-fail at runtime.
    */
-  vector?: VectorStrategy;
+  vector?: VectorStrategy | false;
   /**
    * Override specific backend capabilities. Useful when the underlying
    * driver doesn't support a feature TypeGraph would otherwise assume —
@@ -251,11 +259,13 @@ const toSchemaVersionRow = createSchemaVersionRowMapper(
 
 function buildPostgresCapabilities(
   fulltextStrategy: FulltextStrategy,
-  vectorStrategy: VectorStrategy,
+  vectorStrategy: VectorStrategy | undefined,
 ): BackendCapabilities {
   return {
     ...POSTGRES_CAPABILITIES,
-    vector: buildVectorCapabilities(vectorStrategy),
+    ...(vectorStrategy === undefined ?
+      {}
+    : { vector: buildVectorCapabilities(vectorStrategy) }),
     fulltext: buildFulltextCapabilities(fulltextStrategy),
   };
 }
@@ -279,12 +289,18 @@ export function createPostgresBackend(
 ): GraphBackend {
   const tables = options.tables ?? defaultTables;
   const fulltextStrategy = options.fulltext ?? tsvectorStrategy;
-  // pgvector is compiled in via the extension, so it is wired
-  // unconditionally (overridable for alternate Postgres vector stacks).
-  const vectorStrategy = options.vector ?? pgvectorStrategy;
+  // pgvector is compiled into a standalone Postgres server, so it is wired
+  // unconditionally by default (overridable for alternate Postgres vector
+  // stacks). `vector: false` disables it — required for an in-process
+  // Postgres (PGlite) built without the pgvector extension, where the
+  // default strategy's `vector(N)` DDL would hard-fail.
+  const vectorStrategy =
+    options.vector === false ? undefined : (options.vector ?? pgvectorStrategy);
   // One latch per backend instance, shared with every transaction-scoped
   // backend so a slot's per-field table is created at most once per process.
-  const vectorSlotLatch = createVectorSlotLatch();
+  // Absent when vector support is disabled.
+  const vectorSlotLatch =
+    vectorStrategy === undefined ? undefined : createVectorSlotLatch();
   const baseCapabilities = buildPostgresCapabilities(
     fulltextStrategy,
     vectorStrategy,
@@ -762,10 +778,16 @@ type CreatePostgresOperationBackendOptions = Readonly<{
   tableNames: SqlTableNames;
   capabilities: BackendCapabilities;
   fulltextStrategy: FulltextStrategy;
-  /** Active vector strategy (always `pgvectorStrategy` unless overridden). */
-  vectorStrategy: VectorStrategy;
-  /** Shared per-`(kind, field)` storage-ensure latch. */
-  vectorSlotLatch: VectorSlotLatch;
+  /**
+   * Active vector strategy (`pgvectorStrategy` unless overridden), or
+   * `undefined` when vector support is disabled (`vector: false`).
+   */
+  vectorStrategy: VectorStrategy | undefined;
+  /**
+   * Shared per-`(kind, field)` storage-ensure latch. Paired with
+   * `vectorStrategy`: both present, or both `undefined`.
+   */
+  vectorSlotLatch: VectorSlotLatch | undefined;
 }>;
 
 type CreatePostgresTransactionBackendOptions = Readonly<{
@@ -777,9 +799,9 @@ type CreatePostgresTransactionBackendOptions = Readonly<{
   capabilities: BackendCapabilities;
   fulltextStrategy: FulltextStrategy;
   /** Active vector strategy. See {@link CreatePostgresOperationBackendOptions}. */
-  vectorStrategy: VectorStrategy;
+  vectorStrategy: VectorStrategy | undefined;
   /** Shared storage-ensure latch. See {@link CreatePostgresOperationBackendOptions}. */
-  vectorSlotLatch: VectorSlotLatch;
+  vectorSlotLatch: VectorSlotLatch | undefined;
 }>;
 
 function createPostgresOperationBackend(
@@ -898,6 +920,7 @@ function createPostgresOperationBackend(
   // client for a transaction-scoped backend) so a slot's table exists
   // before the first write/search hits it.
   async function ensureVectorSlotStorage(slot: VectorSlot): Promise<void> {
+    if (vectorStrategy === undefined || vectorSlotLatch === undefined) return;
     await vectorSlotLatch.ensure(vectorStrategy, slot, async (statement) => {
       await execRun(sql.raw(statement));
     });
@@ -939,71 +962,82 @@ function createPostgresOperationBackend(
         },
       };
 
+  // Embedding write/search methods are present only when a vector strategy
+  // is wired. With `vector: false` (e.g. PGlite without pgvector) they are
+  // omitted, so `capabilities.vector` is absent and the store never routes
+  // embedding work here — mirroring a SQLite connection without sqlite-vec.
+  const vectorEmbeddingMethods =
+    vectorStrategy === undefined ?
+      {}
+    : {
+        async upsertEmbedding(params: UpsertEmbeddingParams): Promise<void> {
+          const slot = vectorSlotFromParams(params);
+          await ensureVectorSlotStorage(slot);
+          const statements = vectorStrategy.buildUpsert(slot, params, nowIso());
+          try {
+            for (const statement of statements) {
+              await execRun(statement);
+            }
+          } catch (error) {
+            throw mapVectorWriteError(error, params);
+          }
+        },
+
+        async deleteEmbedding(params: DeleteEmbeddingParams): Promise<void> {
+          // Ensure the per-field table exists before deleting. A delete can
+          // run before any embedding was ever written for the field (e.g. a
+          // node hard-deleted having never carried one), and on Postgres a
+          // DELETE against a missing relation INSIDE a transaction aborts the
+          // whole transaction — swallowing the JS error can't un-abort it.
+          // The idempotent ensure makes the DELETE target an existing
+          // (possibly empty) table, so it's always a clean no-op.
+          const slot = vectorSlotFromParams(params);
+          await ensureVectorSlotStorage(slot);
+          const statements = vectorStrategy.buildDelete(slot, params);
+          for (const statement of statements) {
+            await execRun(statement);
+          }
+        },
+
+        async vectorSearch(
+          params: VectorSearchParams,
+        ): Promise<readonly VectorSearchResult[]> {
+          assertVectorSearchLimit(params.limit);
+          // Validate `efSearch` against pgvector's `hnsw.ef_search` ceiling
+          // before `runVectorSearch` inlines it into `SET LOCAL`.
+          assertPgvectorEfSearch(params.efSearch);
+          const slot = vectorSlotFromParams(params);
+          await ensureVectorSlotStorage(slot);
+          const query = vectorStrategy.buildSearch(slot, params);
+          let rows: readonly { node_id: string; score: number }[];
+          try {
+            rows = await runVectorSearch(params.efSearch, query);
+          } catch (error) {
+            // A query vector whose dimension no longer matches the stored
+            // column surfaces the same typed error as the write path.
+            throw mapVectorWriteError(error, params);
+          }
+          return rows.map((row) => ({
+            nodeId: row.node_id,
+            score: row.score,
+          }));
+        },
+      };
+
   const operationBackend: InternalOperationBackend = {
     ...commonBackend,
     ...executeRawMethod,
+    ...vectorEmbeddingMethods,
     capabilities,
     fulltextStrategy,
-    vectorStrategy,
+    ...(vectorStrategy === undefined ? {} : { vectorStrategy }),
     dialect: "postgres",
     tableNames,
 
-    // === Embedding Operations ===
-
-    async upsertEmbedding(params: UpsertEmbeddingParams): Promise<void> {
-      const slot = vectorSlotFromParams(params);
-      await ensureVectorSlotStorage(slot);
-      const statements = vectorStrategy.buildUpsert(slot, params, nowIso());
-      try {
-        for (const statement of statements) {
-          await execRun(statement);
-        }
-      } catch (error) {
-        throw mapVectorWriteError(error, params);
-      }
-    },
-
-    async deleteEmbedding(params: DeleteEmbeddingParams): Promise<void> {
-      // Ensure the per-field table exists before deleting. A delete can
-      // run before any embedding was ever written for the field (e.g. a
-      // node hard-deleted having never carried one), and on Postgres a
-      // DELETE against a missing relation INSIDE a transaction aborts the
-      // whole transaction — swallowing the JS error can't un-abort it.
-      // The idempotent ensure makes the DELETE target an existing
-      // (possibly empty) table, so it's always a clean no-op.
-      const slot = vectorSlotFromParams(params);
-      await ensureVectorSlotStorage(slot);
-      const statements = vectorStrategy.buildDelete(slot, params);
-      for (const statement of statements) {
-        await execRun(statement);
-      }
-    },
-
-    async vectorSearch(
-      params: VectorSearchParams,
-    ): Promise<readonly VectorSearchResult[]> {
-      assertVectorSearchLimit(params.limit);
-      // Validate `efSearch` against pgvector's `hnsw.ef_search` ceiling
-      // before `runVectorSearch` inlines it into `SET LOCAL`.
-      assertPgvectorEfSearch(params.efSearch);
-      const slot = vectorSlotFromParams(params);
-      await ensureVectorSlotStorage(slot);
-      const query = vectorStrategy.buildSearch(slot, params);
-      let rows: readonly { node_id: string; score: number }[];
-      try {
-        rows = await runVectorSearch(params.efSearch, query);
-      } catch (error) {
-        // A query vector whose dimension no longer matches the stored column
-        // surfaces the same typed error as the write path.
-        throw mapVectorWriteError(error, params);
-      }
-      return rows.map((row) => ({
-        nodeId: row.node_id,
-        score: row.score,
-      }));
-    },
+    // === Vector Index Operations ===
 
     async createVectorIndex(params: CreateVectorIndexParams): Promise<void> {
+      if (vectorStrategy === undefined) return;
       const slot = vectorSlotFromCreateIndexParams(params);
       // Ensure the per-field table exists first (idempotent), then create its
       // ANN index. pgvector's `ownedTables` builds the table only — the HNSW/
@@ -1086,6 +1120,7 @@ function createPostgresOperationBackend(
     },
 
     async dropVectorIndex(params: DropVectorIndexParams): Promise<void> {
+      if (vectorStrategy === undefined) return;
       const slot = vectorSlotFromDropIndexParams(params);
       const dropStatement = vectorStrategy.buildDropIndex?.(slot);
       if (dropStatement === undefined) return;
@@ -1127,6 +1162,7 @@ function createTransactionBackend(
   // marking the slot "ensured" (which would skip the re-CREATE and make every
   // later write fail with "relation does not exist"). The fresh latch is
   // discarded with the transaction, so the next write re-ensures idempotently.
+  // No latch when vector support is disabled (`vector: false`).
   return createPostgresOperationBackend({
     db: options.db,
     executionAdapter: txExecutionAdapter,
@@ -1136,7 +1172,8 @@ function createTransactionBackend(
     capabilities: options.capabilities,
     fulltextStrategy: options.fulltextStrategy,
     vectorStrategy: options.vectorStrategy,
-    vectorSlotLatch: createVectorSlotLatch(),
+    vectorSlotLatch:
+      options.vectorStrategy === undefined ? undefined : createVectorSlotLatch(),
   });
 }
 

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -347,6 +347,26 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
       expect(backend.capabilities.jsonb).toBe(true);
       expect(backend.capabilities.ginIndexes).toBe(true);
     });
+
+    it("runs non-vector CRUD with vector disabled (vector: false)", async (ctx) => {
+      const { db } = requirePostgres(ctx);
+      // A PGlite instance built without pgvector takes this path: the
+      // backend must work end-to-end for ordinary graph operations — store
+      // creation (schema commit + index materialization), writes, reads —
+      // while advertising no vector support.
+      const backend = createPostgresBackend(db, { vector: false });
+      expect(backend.capabilities.vector).toBeUndefined();
+
+      const store = createStore(testGraph, backend);
+      const person = await store.nodes.Person.create({
+        name: "Alice",
+        email: "alice@example.com",
+      });
+      const fetched = await store.nodes.Person.getById(person.id);
+
+      expect(fetched).toBeDefined();
+      expect(fetched!.name).toBe("Alice");
+    });
   });
 
   describe("generatePostgresDDL()", () => {

--- a/packages/typegraph/tests/backends/postgres/postgres-disable-vector.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-disable-vector.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `createPostgresBackend(db, { vector: false })` — disabling the vector stack.
+ *
+ * The Postgres backend wires `pgvectorStrategy` by default, on the assumption
+ * that a standalone Postgres server has the pgvector extension installed. An
+ * in-process Postgres (PGlite) built without that extension can't honor it:
+ * the default strategy's `vector(N)` DDL would hard-fail. `vector: false`
+ * turns the stack off, mirroring a SQLite connection without sqlite-vec — the
+ * backend advertises no `capabilities.vector` and omits the embedding/search
+ * methods, so the store never routes vector work to it.
+ *
+ * These assertions inspect the constructed backend's shape only and issue no
+ * SQL, so they run in plain `pnpm test` without a database. See
+ * `postgres-backend.test.ts` for the Docker-gated end-to-end check that
+ * non-vector CRUD works under `vector: false`.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createPostgresBackend } from "../../../src/backend/postgres";
+
+// A pool is lazy — it opens no connection until the first query — and
+// `createPostgresBackend` issues none at construction, so this never touches a
+// real database.
+const PLACEHOLDER_URL = "postgresql://placeholder@127.0.0.1:5432/placeholder";
+
+describe("createPostgresBackend({ vector: false })", () => {
+  let pool: Pool | undefined;
+
+  function backendWith(disableVector = false) {
+    pool = new Pool({ connectionString: PLACEHOLDER_URL });
+    const db = drizzle(pool);
+    return createPostgresBackend(db, disableVector ? { vector: false } : {});
+  }
+
+  afterEach(async () => {
+    await pool?.end();
+    pool = undefined;
+  });
+
+  it("advertises no vector capability and omits embedding methods", () => {
+    const backend = backendWith(true);
+
+    expect(backend.capabilities.vector).toBeUndefined();
+    expect(backend.upsertEmbedding).toBeUndefined();
+    expect(backend.deleteEmbedding).toBeUndefined();
+    expect(backend.vectorSearch).toBeUndefined();
+  });
+
+  it("advertises pgvector capability by default (no override)", () => {
+    const backend = backendWith();
+
+    expect(backend.capabilities.vector?.supported).toBe(true);
+    expect(backend.capabilities.vector?.metrics).toContain("cosine");
+    expect(backend.capabilities.vector?.indexTypes).toContain("hnsw");
+    expect(backend.capabilities.vector?.maxDimensions).toBeGreaterThan(0);
+    expect(backend.upsertEmbedding).toBeDefined();
+    expect(backend.vectorSearch).toBeDefined();
+  });
+
+  it("retains non-vector capabilities when vector is disabled", () => {
+    const backend = backendWith(true);
+
+    // Disabling vector must not disturb the rest of the capability surface.
+    expect(backend.capabilities.transactions).toBe(true);
+    expect(backend.capabilities.fulltext?.supported).toBe(true);
+    expect(backend.capabilities.jsonb).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Prerequisite for PGlite backend support (#160). `createPostgresBackend` wires `pgvectorStrategy` **unconditionally** (added in #161), on the assumption that a standalone Postgres server has the pgvector extension installed. An in-process Postgres (PGlite) built without that extension can't honor it: the default strategy's `vector(N)` DDL **hard-fails** the moment an embedding is written or `CREATE EXTENSION vector` runs, and there was no way to turn the stack off.

This adds **`vector: false`** to `PostgresBackendOptions`, mirroring SQLite's existing no-vector mode (when sqlite-vec isn't loaded). When disabled, the backend:

- advertises no `capabilities.vector`,
- omits `upsertEmbedding` / `deleteEmbedding` / `vectorSearch`,
- creates no vector-slot latch, and no-ops `createVectorIndex` / `dropVectorIndex`,

so the store never routes vector work to it. The default remains `pgvectorStrategy` — **real-Postgres behavior is unchanged**.

## Why this and not auto-detection

SQLite degrades to no-vector by the *absence* of a strategy; the Postgres factory instead forced one. The type layer already supports a no-vector backend (`vectorStrategy?`, `upsertEmbedding?`, etc. are all optional in `backend/types.ts`) — SQLite exploits it today. This change just lets `createPostgresBackend` produce that shape. Auto-detecting pgvector would mean an async probe in a synchronous factory; an explicit opt-out is simpler and matches the user-facing `vector: false` ergonomics.

## Implementation

Mirrors `sqlite.ts`'s conditional structure into `postgres.ts`:

- `vector: false` → internal `undefined` strategy + `undefined` latch.
- `buildPostgresCapabilities` omits `vector` when the strategy is absent.
- Embedding write/search methods hoisted into a conditional `vectorEmbeddingMethods` (the large diff is a move, not new logic); `ensureVectorSlotStorage` and the index methods early-return.
- `createTransactionBackend` creates a fresh per-tx latch only when a strategy is present.

## Tests

- `postgres-disable-vector.test.ts` (**ungated**, runs in plain `pnpm test`, no Docker): asserts the no-vector backend advertises no `capabilities.vector` and omits the embedding methods, that the default still advertises pgvector, and that non-vector capabilities are untouched. Construction does no I/O, so a lazy `pg.Pool` that never connects suffices.
- `postgres-backend.test.ts` (**Docker-gated**): end-to-end non-vector CRUD against real Postgres with `vector: false`, proving the store lifecycle (schema commit + index materialization) works with vector disabled.

## Verification

- `pnpm typecheck` ✅ (full repo)
- `pnpm test` (SQLite) ✅ — 3189 passed
- Full Postgres lane against pgvector/pgvector:pg18 ✅ — 14 files / 631 passed, incl. the pgvector strategy suite (no regression) and both new tests
- `pnpm fix`: prettier + eslint clean. `fix:docs` (markdownlint) fails only on pre-existing **git-ignored** scratch files under `packages/typegraph/tmp/` — unrelated to this change.

Closes the pgvector / API-gap items raised in #160.
