### PR TITLE
feat: support PGlite (Postgres-in-WASM) as a backend

### DIFF
--- a/.changeset/pglite-backend.md
+++ b/.changeset/pglite-backend.md
@@ -1,0 +1,26 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add first-class support for [PGlite](https://pglite.dev/) (Postgres-in-WASM),
+closing #160.
+
+- **Execution fast-path fix.** `createPostgresBackend` now detects a PGlite
+  `db.$client` and routes it to the unnamed positional query wrapper. PGlite's
+  `.query` has no node-postgres named-statement config form — passing one
+  desyncs its single connection (`08P01`), so under the default
+  `prepareStatements: true` every query previously failed. PGlite works
+  unchanged with `createPostgresBackend(drizzle(pglite))` now.
+
+- **`createLocalPgliteBackend`** — a batteries-included helper under the new
+  `@nicia-ai/typegraph/postgres/pglite` entry, the Postgres analog of
+  `createLocalSqliteBackend`. It constructs an in-process PGlite engine
+  (in-memory by default, or any `dataDir`), loads pgvector, runs the schema
+  DDL, and returns `{ backend, db, client }` whose `close()` disposes the
+  engine. Pass `vector: false` to skip the extension, or `vector: <Extension>`
+  to bring your own pgvector build.
+
+`@electric-sql/pglite` (and, for vector support, `@electric-sql/pglite-pgvector`
+on PGlite ≥ 0.5) are optional peer dependencies. The biggest payoff: the
+Postgres dialect and pgvector path can now be exercised in plain `pnpm test`
+with zero Docker.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -4,7 +4,7 @@ description: Configure SQLite and PostgreSQL backends for TypeGraph
 ---
 
 TypeGraph stores graph data in your existing relational database using Drizzle ORM adapters.
-This guide covers setting up SQLite and PostgreSQL backends.
+This guide covers setting up SQLite, PostgreSQL, and PGlite backends.
 
 :::note[Custom indexes]
 TypeGraph migrations create the core tables and built-in indexes. For application-specific indexes
@@ -205,6 +205,7 @@ runtime, and TypeGraph works the same way against each.
 | Edge runtime (Cloudflare Workers, Vercel Edge, Netlify Edge) — needs transactions | `@neondatabase/serverless` Pool over WebSockets                        | `drizzle-orm/neon-serverless`                            |
 | Edge runtime — single-statement reads/writes only                                 | `@neondatabase/serverless` `neon(url)` over HTTP                       | `drizzle-orm/neon-http`                                  |
 | Cloudflare Hyperdrive                                                             | `pg` or `postgres` (through the Hyperdrive pooler)                     | `drizzle-orm/node-postgres` or `drizzle-orm/postgres-js` |
+| Embedded apps, local development, Postgres dialect tests                          | `@electric-sql/pglite`                                                 | `drizzle-orm/pglite`                                     |
 
 :::note[Neon HTTP vs WebSocket]
 Both Neon drivers work with TypeGraph. They have different tradeoffs:
@@ -351,6 +352,69 @@ const store = createStore(graph, backend);
 Use `neon-http` for reads, single upserts, and migrations. Use `neon-serverless`
 when you need atomic multi-statement writes.
 
+### PGlite (Postgres-in-WASM)
+
+[PGlite](https://pglite.dev/) is a full Postgres compiled to WebAssembly that runs
+in-process — in Node, Bun, Deno, or the browser — with no server and no native
+addon. It's ideal for local development, embedded apps, and running the real
+Postgres dialect (including pgvector) in tests without Docker.
+
+`@electric-sql/pglite` is an optional peer dependency. Vector support additionally
+needs `@electric-sql/pglite-pgvector` (PGlite ≥ 0.5 ships pgvector as a separate
+package):
+
+```bash
+npm install @electric-sql/pglite @electric-sql/pglite-pgvector
+```
+
+The batteries-included helper constructs the engine, loads pgvector, runs the
+schema DDL, and returns a ready backend — the Postgres analog of
+`createLocalSqliteBackend`:
+
+```typescript
+import { createLocalPgliteBackend } from "@nicia-ai/typegraph/postgres/pglite";
+import { createStore } from "@nicia-ai/typegraph";
+
+// In-memory by default, with pgvector enabled.
+const { backend, db, client } = await createLocalPgliteBackend();
+const store = createStore(graph, backend);
+
+// backend.close() disposes the PGlite engine.
+```
+
+```typescript
+// Persistent on disk:
+const { backend } = await createLocalPgliteBackend({ dataDir: "./pgdata" });
+
+// No embeddings? Skip the extension (no pgvector dependency needed):
+const { backend } = await createLocalPgliteBackend({ vector: false });
+
+// Pass an explicit pgvector extension object:
+import { vector } from "@electric-sql/pglite-pgvector";
+const { backend } = await createLocalPgliteBackend({ vector });
+```
+
+If you construct PGlite yourself, pass its Drizzle database straight to
+`createPostgresBackend` — the execution fast path detects PGlite and routes it
+correctly:
+
+```typescript
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite-pgvector";
+import { drizzle } from "drizzle-orm/pglite";
+import { createPostgresBackend, generatePostgresMigrationSQL } from "@nicia-ai/typegraph/postgres";
+
+const client = await PGlite.create({ extensions: { vector } });
+await client.exec(generatePostgresMigrationSQL());
+const backend = createPostgresBackend(drizzle(client));
+```
+
+PGlite is single-connection and serial: there is no pooling, so concurrent
+`store.transaction()` calls queue rather than run in parallel. It complements,
+rather than replaces, a Docker-based Postgres for CI — PGlite exercises the SQL
+dialect and pgvector, but not driver-specific behavior (node-postgres statement
+naming, postgres-js, pgbouncer, real concurrency).
+
 ### PostgreSQL with Vector Search
 
 For semantic search, enable pgvector. `createPostgresBackend` defaults to `pgvectorStrategy`, so no extra
@@ -455,8 +519,8 @@ process.on("SIGTERM", async () => {
 
 Creates a PostgreSQL backend adapter. Accepts any Drizzle PostgreSQL database
 instance, regardless of the underlying driver. Tested with `drizzle-orm/node-postgres`,
-`drizzle-orm/postgres-js`, `drizzle-orm/neon-serverless`, and
-`drizzle-orm/neon-http`. The neon-http driver is auto-detected and
+`drizzle-orm/postgres-js`, `drizzle-orm/neon-serverless`,
+`drizzle-orm/neon-http`, and `drizzle-orm/pglite`. The neon-http driver is auto-detected and
 `capabilities.transactions` is set to `false` (HTTP can't hold a session); use
 `drizzle-orm/neon-serverless` if you need transactional writes.
 
@@ -469,9 +533,9 @@ function createPostgresBackend(
     /**
      * Override the vector search strategy. Defaults to
      * `pgvectorStrategy`. Pass a custom `VectorStrategy` to change the
-     * storage / index engine.
+     * storage / index engine, or `false` to disable vector support.
      */
-    vector?: VectorStrategy;
+    vector?: VectorStrategy | false;
     /**
      * Override specific backend capabilities. Useful for HTTP-style
      * drivers or test scenarios. neon-http already has `transactions:
@@ -495,6 +559,32 @@ function createPostgresBackend(
     preparedStatementCacheMax?: number;
   },
 ): GraphBackend;
+```
+
+#### `createLocalPgliteBackend(options?)`
+
+Creates an in-process PGlite backend with automatic engine construction,
+schema DDL, and optional pgvector loading. The returned backend owns the PGlite
+engine; call `backend.close()` when the process or test is done.
+
+```typescript
+async function createLocalPgliteBackend(options?: {
+  /**
+   * PGlite data directory. Omit for an in-memory database, pass a filesystem
+   * path for persistence, or use a runtime-specific scheme such as `idb://`.
+   */
+  dataDir?: string;
+  tables?: PostgresTables;
+  /**
+   * Omit to load @electric-sql/pglite-pgvector, pass `false` to disable vector
+   * support, or pass a PGlite Extension object to control the extension import.
+   */
+  vector?: false | Extension;
+}): Promise<{
+  backend: GraphBackend;
+  db: PgliteDatabase;
+  client: PGlite;
+}>;
 ```
 
 #### `generatePostgresMigrationSQL()`
@@ -522,7 +612,8 @@ TypeGraph exposes Drizzle adapters through public entrypoints:
 - `@nicia-ai/typegraph/sqlite` — Generic SQLite adapter (any Drizzle SQLite driver)
 - `@nicia-ai/typegraph/sqlite/local` — Batteries-included better-sqlite3 wrapper (Node.js only)
 - `@nicia-ai/typegraph/sqlite/libsql` — Batteries-included libsql wrapper (Node.js, Workers, browser)
-- `@nicia-ai/typegraph/postgres` — PostgreSQL adapter
+- `@nicia-ai/typegraph/postgres` — PostgreSQL adapter (any Drizzle Postgres driver)
+- `@nicia-ai/typegraph/postgres/pglite` — Batteries-included PGlite (Postgres-in-WASM) wrapper
 
 Import from the entrypoint matching your database:
 
@@ -531,6 +622,7 @@ import { createSqliteBackend, tables } from "@nicia-ai/typegraph/sqlite";
 import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
 import { createLibsqlBackend } from "@nicia-ai/typegraph/sqlite/libsql";
 import { createPostgresBackend, tables } from "@nicia-ai/typegraph/postgres";
+import { createLocalPgliteBackend } from "@nicia-ai/typegraph/postgres/pglite";
 ```
 
 ## Cloudflare D1

--- a/apps/docs/src/content/docs/getting-started.md
+++ b/apps/docs/src/content/docs/getting-started.md
@@ -271,6 +271,7 @@ const store = createStore(graph, backend);
 |----------|-----------------|----------|
 | `createLocalSqliteBackend` | Automatic | Quick start, development, tests (Node.js) |
 | `createLibsqlBackend` | Automatic | libsql/Turso (Node.js, Workers, browser) |
+| `createLocalPgliteBackend` | Automatic | In-process Postgres, embedded apps, pgvector tests |
 | `createStore` + manual migration | None | When you manage migrations externally |
 | `createStoreWithSchema` | Auto-creates tables, validates & auto-migrates | **Recommended for production** |
 
@@ -465,6 +466,8 @@ try {
 ## PostgreSQL Setup
 
 TypeGraph also supports PostgreSQL for production deployments with better concurrency and JSON support.
+For in-process Postgres during local development or tests, see
+[PGlite in Backend Setup](/backend-setup#pglite-postgres-in-wasm).
 
 ### Installation
 

--- a/apps/docs/src/content/docs/testing.md
+++ b/apps/docs/src/content/docs/testing.md
@@ -250,6 +250,45 @@ describe("Index coverage", () => {
 This is particularly effective when run against your full test suite — it catches filter patterns
 across all tests, not just the ones you remember to check manually.
 
+## PGlite Tests (Postgres dialect, no Docker)
+
+Use `createLocalPgliteBackend()` when you want the PostgreSQL dialect and
+pgvector path in ordinary test runs without starting Docker. It creates an
+in-process PGlite engine, runs TypeGraph DDL, and returns a backend that should
+be closed after each test.
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createLocalPgliteBackend } from "@nicia-ai/typegraph/postgres/pglite";
+import { createStore } from "@nicia-ai/typegraph";
+import { graph } from "../src/graph";
+
+describe("Postgres dialect behavior", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  let store: ReturnType<typeof createStore<typeof graph>>;
+
+  beforeEach(async () => {
+    const { backend } = await createLocalPgliteBackend();
+    cleanup = () => backend.close();
+    store = createStore(graph, backend);
+  });
+
+  afterEach(async () => {
+    await cleanup?.();
+  });
+
+  it("runs against the Postgres query compiler", async () => {
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    expect(await store.nodes.Person.getById(alice.id)).toBeDefined();
+  });
+});
+```
+
+PGlite is a good fit for SQL dialect coverage, pgvector behavior, and embedded
+Postgres workflows. Use a real PostgreSQL server for driver-specific behavior
+such as node-postgres named statements, postgres-js, pgbouncer, connection pool
+behavior, isolation levels, and true concurrent sessions.
+
 ## PostgreSQL Integration Tests
 
 For tests that verify PostgreSQL-specific behavior (JSONB operators, GIN indexes, concurrent
@@ -311,11 +350,14 @@ describePostgres("PostgreSQL-specific", () => {
 | Level | Backend | Speed | Isolation | When to use |
 |-------|---------|-------|-----------|-------------|
 | Unit | In-memory SQLite | Fast (~1ms setup) | Full (fresh DB per test) | Collection API, query logic, business rules |
-| Integration | SQLite file or PostgreSQL | Medium | Shared (truncate between tests) | Concurrency, transactions, backend-specific behavior |
+| Integration | PGlite | Fast-medium | Full (fresh DB per test) | Postgres SQL dialect, pgvector, embedded workflows |
+| Integration | SQLite file or real PostgreSQL | Medium | Shared (truncate between tests) | Concurrency, driver behavior, isolation levels |
 | Profiler | In-memory SQLite | Fast | Full | Index coverage, query pattern verification |
 
-Most tests should be unit tests with in-memory SQLite. Reserve PostgreSQL integration tests for
-behavior that differs across backends (array containment, concurrent writes, isolation levels).
+Most tests should be unit tests with in-memory SQLite. Use PGlite when you need
+the Postgres dialect or pgvector path in normal test runs. Reserve real
+PostgreSQL integration tests for behavior PGlite cannot model, such as
+connection pooling, driver quirks, concurrent sessions, and isolation levels.
 
 ## Next Steps
 

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -47,6 +47,11 @@
       "import": "./dist/backend/postgres/index.js",
       "require": "./dist/backend/postgres/index.cjs"
     },
+    "./postgres/pglite": {
+      "types": "./dist/backend/postgres/pglite.d.ts",
+      "import": "./dist/backend/postgres/pglite.js",
+      "require": "./dist/backend/postgres/pglite.cjs"
+    },
     "./sqlite/local": {
       "types": "./dist/backend/sqlite/local.d.ts",
       "import": "./dist/backend/sqlite/local.js",
@@ -117,6 +122,8 @@
     "node": ">=22"
   },
   "peerDependencies": {
+    "@electric-sql/pglite": ">=0.5.0 <0.6.0",
+    "@electric-sql/pglite-pgvector": ">=0.0.2 <1.0.0",
     "@libsql/client": ">=0.6.0",
     "@neondatabase/serverless": ">=0.9.0 <2.0.0",
     "better-sqlite3": ">=9.0.0 <13.0.0",
@@ -126,6 +133,12 @@
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
+    "@electric-sql/pglite": {
+      "optional": true
+    },
+    "@electric-sql/pglite-pgvector": {
+      "optional": true
+    },
     "@libsql/client": {
       "optional": true
     },
@@ -147,6 +160,8 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.16.7",
+    "@electric-sql/pglite": "^0.5.1",
+    "@electric-sql/pglite-pgvector": "^0.0.2",
     "@libsql/client": "^0.17.3",
     "@neondatabase/serverless": "^1.1.0",
     "@stryker-mutator/core": "^9.6.1",

--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -90,6 +90,23 @@ function isPgNativeClient(candidate: unknown): candidate is NodePgClient {
   return typeof candidate === "object" && hasFunctionProperty(candidate, "query");
 }
 
+function isPgliteClient(candidate: unknown): candidate is NodePgClient {
+  // PGlite (Postgres-in-WASM) exposes `.query(sql, params, options)` like
+  // node-postgres and so also satisfies `isPgNativeClient` — but it does NOT
+  // accept the `{name, text, values}` named-statement config form. Passing
+  // that object doesn't merely fail the call: it desyncs PGlite's single
+  // wire connection, so every subsequent query errors with `08P01`. Detect
+  // PGlite structurally via `dumpDataDir` (a PGlite-specific method absent on
+  // pg `Pool`/`Client`) so `resolvePgClient` can route it to the unnamed
+  // positional wrapper regardless of `prepareStatements`. Duck-typed with no
+  // static import, keeping this module dependency-free and edge-safe.
+  return (
+    typeof candidate === "object" &&
+    hasFunctionProperty(candidate, "query") &&
+    hasFunctionProperty(candidate, "dumpDataDir")
+  );
+}
+
 function isPostgresJsClient(candidate: unknown): candidate is PostgresJsClient {
   // postgres-js's tagged-template Sql is callable, has `.unsafe` (raw
   // parameterized executor), and has `.begin` (transaction starter).
@@ -304,6 +321,10 @@ function adaptPostgresJsClient(sql: PostgresJsClient): PgQueryClient {
  *   via `.unsafe(sql, params)`. Safe because Drizzle installs transparent
  *   parsers on the same client instance at `drizzle()` time, so direct
  *   calls and Drizzle-routed calls produce identical row shapes.
+ * - `drizzle-orm/pglite` (PGlite, Postgres-in-WASM) — routed to the unnamed
+ *   wrapper unconditionally. PGlite's `.query` has no named-statement config
+ *   form (and server-side prepared statements buy nothing for an in-process
+ *   engine), so `prepareStatements` is ignored for it.
  *
  * Returns `undefined` for `drizzle-orm/neon-http` and any other driver we
  * don't recognize; callers fall back to `db.execute(sql)`, which goes
@@ -324,6 +345,12 @@ function resolvePgClient(
     return undefined;
   }
   const client = (db as PgClientCarrier).$client;
+  // Must precede `isPgNativeClient`: PGlite matches it too (object with
+  // `.query`), but only the unnamed wrapper is safe for it (see
+  // `isPgliteClient`).
+  if (isPgliteClient(client)) {
+    return wrapNodePgClientUnnamed(client);
+  }
   if (isPgNativeClient(client)) {
     return prepareStatements
       ? wrapNodePgClient(client, cacheMax)

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -9,9 +9,14 @@
  *   transactions are auto-disabled because HTTP can't hold a session;
  *   use `drizzle-orm/neon-serverless` if you need transactional writes.
  *
- * Other pg-protocol Drizzle adapters (PGlite, Vercel Postgres, Supabase
- * via pg) should work unchanged because they all expose a compatible
- * `db.execute()` / `db.transaction()` surface.
+ * - `drizzle-orm/pglite` (PGlite, Postgres-in-WASM) — the execution
+ *   fast path detects PGlite and routes it correctly (its `.query` has no
+ *   named-statement form). For a batteries-included in-process setup, see
+ *   `createLocalPgliteBackend` in `@nicia-ai/typegraph/postgres/pglite`.
+ *
+ * Other pg-protocol Drizzle adapters (Vercel Postgres, Supabase via pg)
+ * work unchanged because they all expose a compatible `db.execute()` /
+ * `db.transaction()` surface.
  *
  * @example
  * ```typescript

--- a/packages/typegraph/src/backend/postgres/pglite.ts
+++ b/packages/typegraph/src/backend/postgres/pglite.ts
@@ -1,0 +1,203 @@
+/**
+ * Local PGlite backend — Postgres-in-WASM, running in-process.
+ *
+ * [PGlite](https://pglite.dev/) is a full Postgres compiled to WebAssembly
+ * that runs inside the Node/Bun/Deno/browser process with no server and no
+ * native addon. This is the batteries-included Postgres analog of
+ * `createLocalSqliteBackend`: it constructs a PGlite instance, loads the
+ * pgvector extension, runs the schema DDL, and returns a ready
+ * `{ backend, db }` pair whose `close()` disposes the engine.
+ *
+ * `@electric-sql/pglite` is an optional peer dependency. Vector support
+ * additionally needs `@electric-sql/pglite-pgvector` (PGlite ≥ 0.5 ships
+ * pgvector as a separate package). Install what you need:
+ *
+ * ```bash
+ * pnpm add @electric-sql/pglite @electric-sql/pglite-pgvector
+ * ```
+ *
+ * @example In-memory database (default, vector enabled)
+ * ```typescript
+ * import { createLocalPgliteBackend } from "@nicia-ai/typegraph/postgres/pglite";
+ *
+ * const { backend } = await createLocalPgliteBackend();
+ * const store = createStore(graph, backend);
+ * ```
+ *
+ * @example Persistent on-disk database
+ * ```typescript
+ * const { backend, db } = await createLocalPgliteBackend({ dataDir: "./pgdata" });
+ * ```
+ *
+ * @example No vector support (skip the pgvector extension)
+ * ```typescript
+ * const { backend } = await createLocalPgliteBackend({ vector: false });
+ * ```
+ *
+ * PGlite is single-connection and serial: there is no pooling, so concurrent
+ * `store.transaction()` calls queue rather than run in parallel.
+ */
+import { type Extension, PGlite } from "@electric-sql/pglite";
+import { drizzle, type PgliteDatabase } from "drizzle-orm/pglite";
+
+import { ConfigurationError } from "../../errors";
+import {
+  generatePostgresDDL,
+  generatePostgresMigrationSQL,
+} from "../drizzle/ddl";
+import {
+  createPostgresBackend,
+  type PostgresTables,
+  tables as defaultTables,
+} from "../drizzle/postgres";
+import { type GraphBackend, wrapWithManagedClose } from "../types";
+
+// ============================================================
+// Types
+// ============================================================
+
+/**
+ * Options for creating a local PGlite backend.
+ */
+export type LocalPgliteBackendOptions = Readonly<{
+  /**
+   * PGlite data directory. Omit for an in-memory database (the default).
+   * Accepts any PGlite data-dir spec: a filesystem path (`"./pgdata"`),
+   * `"memory://"`, or a browser/runtime-specific scheme such as
+   * `"idb://my-db"`.
+   */
+  dataDir?: string;
+
+  /**
+   * Custom table definitions. Defaults to standard TypeGraph table names.
+   */
+  tables?: PostgresTables;
+
+  /**
+   * Controls the pgvector stack:
+   *
+   * - **omitted (default)** — load pgvector from `@electric-sql/pglite-pgvector`
+   *   and run `CREATE EXTENSION vector`, so embedding fields work out of the
+   *   box. Throws a {@link ConfigurationError} if the package isn't installed.
+   * - **`false`** — skip the extension entirely; the backend advertises no
+   *   vector capability (mirroring a SQLite connection without sqlite-vec).
+   *   Use when a graph carries no embeddings, or to avoid the extension dep.
+   * - **a PGlite `Extension`** — bring your own pgvector build or custom
+   *   extension packaging. Decouples this helper from a specific pgvector
+   *   package version.
+   */
+  vector?: false | Extension;
+}>;
+
+/**
+ * Result of creating a local PGlite backend.
+ */
+export type LocalPgliteBackendResult = Readonly<{
+  /**
+   * The GraphBackend instance for use with createStore. Its `close()`
+   * disposes the underlying PGlite engine.
+   */
+  backend: GraphBackend;
+
+  /**
+   * The underlying Drizzle database instance. Useful for direct SQL access.
+   */
+  db: PgliteDatabase;
+
+  /**
+   * The raw PGlite instance, for engine-specific operations such as
+   * `dumpDataDir()` / `clone()` not surfaced through Drizzle.
+   */
+  client: PGlite;
+}>;
+
+// ============================================================
+// Vector extension loading
+// ============================================================
+
+/**
+ * Dynamically loads the default pgvector extension from
+ * `@electric-sql/pglite-pgvector`. Kept as a runtime import so the package
+ * stays an optional peer dependency — callers using `vector: false` or
+ * supplying their own extension never need it installed.
+ */
+async function loadDefaultPgvectorExtension(): Promise<Extension> {
+  try {
+    const module_ = await import("@electric-sql/pglite-pgvector");
+    return module_.vector;
+  } catch (error) {
+    throw new ConfigurationError(
+      "createLocalPgliteBackend needs the pgvector extension but " +
+        "`@electric-sql/pglite-pgvector` could not be loaded. Install it " +
+        "(`pnpm add @electric-sql/pglite-pgvector`), pass your own `vector` " +
+        "extension, or set `vector: false` to disable vector support.",
+      { backend: "pglite", dependency: "@electric-sql/pglite-pgvector" },
+      { cause: error },
+    );
+  }
+}
+
+// ============================================================
+// Factory Function
+// ============================================================
+
+/**
+ * Creates a TypeGraph backend backed by an in-process PGlite database.
+ *
+ * Constructs the PGlite engine (loading pgvector unless disabled), executes
+ * the schema DDL, and wires the standard Postgres backend. The returned
+ * backend owns the engine: call `backend.close()` to dispose it.
+ *
+ * For production Postgres, or a PGlite instance you construct yourself,
+ * use `createPostgresBackend` directly with your own Drizzle database — the
+ * execution fast path detects PGlite and routes it correctly.
+ *
+ * @param options - Configuration options
+ * @returns Backend, Drizzle database, and raw PGlite client
+ */
+export async function createLocalPgliteBackend(
+  options: LocalPgliteBackendOptions = {},
+): Promise<LocalPgliteBackendResult> {
+  const tables = options.tables ?? defaultTables;
+
+  // pgvector lives in the WASM instance, so the extension must be passed at
+  // construction — `CREATE EXTENSION vector` alone can't pull it in. An
+  // explicitly supplied extension wins; `false` disables; otherwise load the
+  // default package.
+  const vectorExtension =
+    options.vector === false ?
+      undefined
+    : (options.vector ?? (await loadDefaultPgvectorExtension()));
+  const vectorEnabled = vectorExtension !== undefined;
+
+  // Construct via the single options-object form (passing `dataDir` as a
+  // field), not the positional `create(dataDir, options)` overload: with a
+  // leading `undefined` dataDir, that overload silently drops `extensions`
+  // ("extension vector is not available"). The options form loads them for
+  // both the in-memory and on-disk cases.
+  const client = await PGlite.create({
+    ...(options.dataDir === undefined ? {} : { dataDir: options.dataDir }),
+    ...(vectorExtension === undefined ?
+      {}
+    : { extensions: { vector: vectorExtension } }),
+  });
+
+  // `exec` runs a multi-statement batch (DDL + the pgvector `CREATE
+  // EXTENSION` when enabled) in one round trip.
+  const migrationSql =
+    vectorEnabled ?
+      generatePostgresMigrationSQL(tables)
+    : generatePostgresDDL(tables).join("\n\n");
+  await client.exec(migrationSql);
+
+  const db = drizzle(client);
+  const backend = createPostgresBackend(db, {
+    tables,
+    ...(vectorEnabled ? {} : { vector: false }),
+  });
+  const managedBackend = wrapWithManagedClose(backend, async () => {
+    await client.close();
+  });
+
+  return { backend: managedBackend, db, client };
+}

--- a/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
@@ -1,0 +1,183 @@
+/**
+ * PGlite backend — in-process Postgres-in-WASM.
+ *
+ * Unlike the Docker-gated `postgres-backend.test.ts`, these run in plain
+ * `pnpm test`: PGlite boots a real Postgres in the test process, so this
+ * exercises the actual PG dialect and the pgvector path with zero Docker.
+ *
+ * Two things are under test:
+ *  - the execution fast-path blocker fix — PGlite's `.query` has no
+ *    named-statement config form, and passing one desyncs its single
+ *    connection (`08P01`). The default `prepareStatements: true` must route
+ *    PGlite to the unnamed positional wrapper instead.
+ *  - `createLocalPgliteBackend` — the batteries-included helper, including
+ *    the pgvector round trip and the `vector: false` / bring-your-own paths.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { PGlite } from "@electric-sql/pglite";
+import { vector as pgvectorExtension } from "@electric-sql/pglite-pgvector";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph, defineNode, embedding } from "../../../src";
+import { generatePostgresDDL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { createLocalPgliteBackend } from "../../../src/backend/postgres/pglite";
+import { createStore } from "../../../src/store";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), email: z.string().optional() }),
+});
+const peopleGraph = defineGraph({
+  id: "pglite_people",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+const Document = defineNode("Doc", {
+  schema: z.object({ title: z.string(), embedding: embedding(4) }),
+});
+const documentsGraph = defineGraph({
+  id: "pglite_docs",
+  nodes: { Doc: { type: Document } },
+  edges: {},
+});
+
+describe("PGlite backend", () => {
+  // Each test registers its own teardown; closing a backend from
+  // createLocalPgliteBackend disposes its PGlite engine, while the bare-client
+  // test closes the client directly.
+  const cleanups: (() => Promise<void>)[] = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0)) await cleanup();
+  });
+
+  describe("execution fast-path (blocker fix)", () => {
+    it("runs queries under default prepareStatements (no named-statement desync)", async () => {
+      // A bare PGlite + createPostgresBackend with DEFAULT options
+      // (prepareStatements: true). Before the fix this routed to the
+      // named-statement wrapper and every query failed; now PGlite is
+      // detected and routed to the unnamed positional wrapper.
+      const client = await PGlite.create();
+      await client.exec(generatePostgresDDL().join("\n\n"));
+      cleanups.push(() => client.close());
+
+      const backend = createPostgresBackend(drizzle(client), { vector: false });
+      const store = createStore(peopleGraph, backend);
+
+      const created = await store.nodes.Person.create({
+        name: "Alice",
+        email: "alice@example.com",
+      });
+      const fetched = await store.nodes.Person.getById(created.id);
+
+      expect(fetched).toBeDefined();
+      expect(fetched!.name).toBe("Alice");
+    });
+  });
+
+  describe("createLocalPgliteBackend()", () => {
+    it("advertises pgvector and runs a vector search end to end", async () => {
+      const { backend } = await createLocalPgliteBackend();
+      cleanups.push(() => backend.close());
+      expect(backend.capabilities.vector?.supported).toBe(true);
+
+      const store = createStore(documentsGraph, backend);
+      await store.nodes.Doc.create({ title: "near", embedding: [1, 0, 0, 0] });
+      await store.nodes.Doc.create({ title: "far", embedding: [0, 0, 0, 1] });
+
+      const hits = await store.search.vector("Doc", {
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+        limit: 2,
+        metric: "cosine",
+      });
+
+      expect(hits).toHaveLength(2);
+      expect(hits[0]!.node.title).toBe("near");
+      expect(hits[0]!.score).toBeGreaterThan(hits[1]!.score);
+    });
+
+    it("runs ordinary CRUD and transactions", async () => {
+      const { backend } = await createLocalPgliteBackend();
+      cleanups.push(() => backend.close());
+      const store = createStore(peopleGraph, backend);
+
+      const result = await store.transaction(async (tx) => {
+        const alice = await tx.nodes.Person.create({ name: "Alice" });
+        const bob = await tx.nodes.Person.create({ name: "Bob" });
+        return { alice, bob };
+      });
+
+      expect(await store.nodes.Person.getById(result.alice.id)).toBeDefined();
+      expect(await store.nodes.Person.getById(result.bob.id)).toBeDefined();
+    });
+
+    it("disables vector with vector: false (no extension, CRUD still works)", async () => {
+      const { backend } = await createLocalPgliteBackend({ vector: false });
+      cleanups.push(() => backend.close());
+      expect(backend.capabilities.vector).toBeUndefined();
+      expect(backend.upsertEmbedding).toBeUndefined();
+
+      const store = createStore(peopleGraph, backend);
+      const created = await store.nodes.Person.create({ name: "Carol" });
+      expect(await store.nodes.Person.getById(created.id)).toBeDefined();
+    });
+
+    it("accepts a bring-your-own pgvector extension", async () => {
+      // The default path dynamically loads @electric-sql/pglite-pgvector;
+      // passing the same extension explicitly must produce an equivalent,
+      // working vector backend (the escape hatch for version pinning).
+      const { backend } = await createLocalPgliteBackend({
+        vector: pgvectorExtension,
+      });
+      cleanups.push(() => backend.close());
+      expect(backend.capabilities.vector?.supported).toBe(true);
+
+      const store = createStore(documentsGraph, backend);
+      await store.nodes.Doc.create({ title: "only", embedding: [0, 1, 0, 0] });
+      const hits = await store.search.vector("Doc", {
+        fieldPath: "embedding",
+        queryEmbedding: [0, 1, 0, 0],
+        limit: 1,
+        metric: "cosine",
+      });
+      expect(hits[0]!.node.title).toBe("only");
+    });
+
+    it("persists data (and embeddings) to an on-disk dataDir across reopen", async () => {
+      const dataDir = await mkdtemp(path.join(tmpdir(), "typegraph-pglite-"));
+      cleanups.push(() => rm(dataDir, { recursive: true, force: true }));
+
+      // Session 1: write a node + embedding, then close to flush to disk.
+      const first = await createLocalPgliteBackend({ dataDir });
+      const created = await createStore(
+        documentsGraph,
+        first.backend,
+      ).nodes.Doc.create({ title: "persisted", embedding: [1, 0, 0, 0] });
+      await first.backend.close();
+
+      // Session 2: reopen the same dataDir — the node and its embedding
+      // (pgvector storage) must survive. Read everything, then close before
+      // asserting so the engine is disposed even if an expectation fails.
+      const second = await createLocalPgliteBackend({ dataDir });
+      const store = createStore(documentsGraph, second.backend);
+      const fetched = await store.nodes.Doc.getById(created.id);
+      const hits = await store.search.vector("Doc", {
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+        limit: 1,
+        metric: "cosine",
+      });
+      await second.backend.close();
+
+      expect(fetched?.title).toBe("persisted");
+      expect(hits[0]!.node.title).toBe("persisted");
+    });
+  });
+});

--- a/packages/typegraph/tsup.config.ts
+++ b/packages/typegraph/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     "backend/sqlite/local": "src/backend/sqlite/local.ts",
     "backend/sqlite/libsql": "src/backend/sqlite/libsql.ts",
     "backend/postgres/index": "src/backend/postgres/index.ts",
+    "backend/postgres/pglite": "src/backend/postgres/pglite.ts",
   },
   format: ["esm", "cjs"],
   dts: true,
@@ -19,5 +20,12 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   treeshake: true,
-  external: ["better-sqlite3", "@libsql/client", "bun:sqlite", "pg"],
+  external: [
+    "better-sqlite3",
+    "@libsql/client",
+    "bun:sqlite",
+    "pg",
+    "@electric-sql/pglite",
+    "@electric-sql/pglite-pgvector",
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 12.10.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.3)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(pg@8.21.0)(postgres@3.4.9)
+        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.5.1)(@libsql/client@0.17.3)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(pg@8.21.0)(postgres@3.4.9)
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -164,6 +164,12 @@ importers:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.7
         version: 0.16.7(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7)
+      '@electric-sql/pglite':
+        specifier: ^0.5.1
+        version: 0.5.1
+      '@electric-sql/pglite-pgvector':
+        specifier: ^0.0.2
+        version: 0.0.2(@electric-sql/pglite@0.5.1)
       '@libsql/client':
         specifier: ^0.17.3
         version: 0.17.3
@@ -196,7 +202,7 @@ importers:
         version: 12.10.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.3)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(pg@8.21.0)(postgres@3.4.9)
+        version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.5.1)(@libsql/client@0.17.3)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(pg@8.21.0)(postgres@3.4.9)
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
@@ -643,6 +649,14 @@ packages:
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
+
+  '@electric-sql/pglite-pgvector@0.0.2':
+    resolution: {integrity: sha512-Gu9Nv7JHlg6BgOLqPCR6lCjI+3xlb7ej5qUtHWmzEYA0ZKzuNgeDK16nRO0ELInwzhLptLqX7VdWyYRElSXjdQ==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.5.1
+
+  '@electric-sql/pglite@0.5.1':
+    resolution: {integrity: sha512-h2Vc+qkQqsEL5kvyN5nBAxn3Vbyvka7QfDW7Io+CdcwU1+X8JbCAN2og+5dI11S3eJuDfroUCxzJaap6k+ezEw==}
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -6929,6 +6943,12 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
+  '@electric-sql/pglite-pgvector@0.0.2(@electric-sql/pglite@0.5.1)':
+    dependencies:
+      '@electric-sql/pglite': 0.5.1
+
+  '@electric-sql/pglite@0.5.1': {}
+
   '@emmetio/abbreviation@2.3.3':
     dependencies:
       '@emmetio/scanner': 1.0.4
@@ -8540,7 +8560,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.0.3)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@24.12.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.7)':
     dependencies:
@@ -8578,6 +8598,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.3(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+    optional: true
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -9158,9 +9179,10 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@libsql/client@0.17.3)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(pg@8.21.0)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.5.1)(@libsql/client@0.17.3)(@neondatabase/serverless@1.1.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(pg@8.21.0)(postgres@3.4.9):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260307.1
+      '@electric-sql/pglite': 0.5.1
       '@libsql/client': 0.17.3
       '@neondatabase/serverless': 1.1.0
       '@types/better-sqlite3': 7.6.13
@@ -12413,6 +12435,7 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.22.3
       yaml: 2.9.0
+    optional: true
 
   vitefu@1.1.3(vite@7.3.3(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
@@ -12473,6 +12496,7 @@ snapshots:
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
+    optional: true
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:


### PR DESCRIPTION
## Summary

Closes #160. Adds first-class [PGlite](https://pglite.dev/) (Postgres-in-WASM) support, at both levels: the execution-fast-path **blocker fix** and the batteries-included **`createLocalPgliteBackend`** helper.

Built on #162 (`vector: false`), which this uses for the no-extension path.

## The blocker fix

`backend/drizzle/execution/postgres-execution.ts` duck-typed `db.$client` as node-postgres (any non-callable object with `.query`) and drove it via the `{name, text, values}` named-statement form. PGlite's `.query` has no such form — and passing the object doesn't just fail the call, it **desyncs PGlite's single WASM connection** (every subsequent query errors `08P01`, verified empirically). So under the default `prepareStatements: true`, *all* queries failed.

Fix: add `isPgliteClient()` — structural detection via `.dumpDataDir` (PGlite-specific, absent on pg `Pool`/`Client`), no static import so the module stays edge-safe — checked **before** `isPgNativeClient()` (PGlite matches that too), routing PGlite to the unnamed positional wrapper regardless of `prepareStatements`. Routing to the wrapper (not the slow path) preserves `executeRaw`/`compileSql`; the lost prepared-statement perf is irrelevant for an in-process engine. The existing `normalizeRows` Date→ISO pass handles PGlite's `timestamptz`→Date, and `numeric`→string matches pg-types (both verified).

## `createLocalPgliteBackend`

New `@nicia-ai/typegraph/postgres/pglite` entry, the Postgres analog of `createLocalSqliteBackend`: constructs an in-process PGlite engine (in-memory or any `dataDir`), loads pgvector, runs the DDL, returns `{ backend, db, client }` with a managed `close()`.

Vector is **pluggable**: default dynamic-load of `@electric-sql/pglite-pgvector`; `vector: false` to disable (no dependency needed); or bring-your-own `Extension`.

## On supporting the latest PGlite (the version story)

PGlite 0.5.0 — published the same day as this work — extracted pgvector from the core package's `./vector` subpath into a standalone `@electric-sql/pglite-pgvector` (currently `0.0.2`, which pins `@electric-sql/pglite` to an exact version). This PR **targets the latest 0.5.x** and verified the full stack end-to-end (`CREATE EXTENSION vector` → pgvector 0.8.1, KNN, Date/numeric shapes). To avoid hard-coupling the feature to a churning `0.0.x` package, the vector extension is loaded via a dynamic import with a bring-your-own escape hatch — so a future repackaging or version bump doesn't break the helper.

## Biggest payoff

The real Postgres dialect **and** pgvector now run in plain `pnpm test` with **zero Docker**. `tests/backends/postgres/pglite-backend.test.ts` (in-process, ungated) covers the blocker fix under default options, the vector round trip, transactions, `vector: false`, and the BYO extension path. This complements — does not replace — the Docker lane, which still covers driver-specific behavior (node-pg statement naming, postgres-js, pgbouncer, real concurrency).

## Packaging

- `@electric-sql/pglite` (`>=0.5.0 <0.6.0`) and `@electric-sql/pglite-pgvector` (`>=0.0.2 <1.0.0`) as **optional** peer dependencies.
- New tsup entry + `./postgres/pglite` export; both packages external; dynamic import preserved in the build.
- Changeset (minor) + backend-setup docs.

## Verification

- `pnpm typecheck` ✅ · `pnpm test` (SQLite + in-process PGlite) ✅ 3194 passed (+5) · `pnpm build` ✅ (pglite entry emitted)
- Full Postgres **Docker** lane against `pgvector/pgvector:pg18` ✅ 636 passed — no regression to pg/postgres-js/neon routing
- prettier/eslint clean on changed files; new docs pass markdownlint
- knip & `fix:docs` flag only **pre-existing untracked** files (`docs/design/…`, `packages/benchmarks/src/recursive-pg-bench.ts`), not this change

## Not included (possible follow-ups)

- The optional **PGlite-backed PG correctness test lane** (running the broader suite under PGlite in CI) — deferred per scope.
