### PR TITLE
test: zero-Docker PGlite Postgres correctness lane

### DIFF
--- a/packages/typegraph/tests/backends/postgres/pglite-adapter-suite.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-adapter-suite.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Adapter contract suite, run against in-process PGlite (Postgres-in-WASM).
+ *
+ * Part of the PGlite correctness lane: unlike the Docker-gated
+ * `postgres-backend.test.ts`, this runs in plain `pnpm test` with zero Docker,
+ * so the real PG dialect gets adapter-contract coverage on every CI run. It is
+ * the same `createAdapterTestSuite` the Docker lane uses — driver/concurrency
+ * behavior stays Docker-only (see `pglite-correctness-harness.ts`).
+ *
+ * One shared engine is booted per file; data is reset between tests rather than
+ * re-booting WASM. `makeBackend()` is a plain backend whose `close()` (called by
+ * the suite's `afterEach`) is a client no-op, so the shared engine survives.
+ */
+import { afterAll, beforeAll, beforeEach } from "vitest";
+
+import { createAdapterTestSuite } from "../adapter-test-suite";
+import {
+  setupSharedPgliteEngine,
+  type SharedPgliteEngine,
+} from "./pglite-correctness-harness";
+
+let engine: SharedPgliteEngine;
+
+beforeAll(async () => {
+  engine = await setupSharedPgliteEngine();
+});
+
+afterAll(async () => {
+  await engine.dispose();
+});
+
+// Root-level reset runs before the suite's own per-test `beforeEach`
+// (which builds the backend), giving every test a clean, migrated schema.
+// `truncateVectorTables` is defensive completeness: the adapter contract
+// writes no embeddings today, but the reset stays correct if it ever does.
+beforeEach(async () => {
+  await engine.resetData();
+  await engine.truncateVectorTables();
+});
+
+createAdapterTestSuite("PGlite", () => engine.makeBackend(), {
+  skipRawQueries: false,
+});

--- a/packages/typegraph/tests/backends/postgres/pglite-correctness-harness.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-correctness-harness.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared harness for the PGlite Postgres correctness lane.
+ *
+ * Boots ONE in-process PGlite engine (Postgres-in-WASM, pgvector loaded) per
+ * importing test file and resets state between tests instead of re-booting —
+ * the same shared-connection + reset strategy the Docker lane uses
+ * (`postgres-backend.test.ts`). A per-test WASM boot would cost ~0.5 s, and the
+ * reused adapter + integration suites run ~250 tests; one boot per file plus a
+ * truncate keeps the lane inside the default `pnpm test` budget.
+ *
+ * The engine is owned solely by this harness. `setupSharedPgliteEngine` keeps
+ * `createLocalPgliteBackend`'s `{ db, client }` and **discards its managed
+ * `backend`** — whose `close()` disposes the engine. `makeBackend()` hands out a
+ * plain `createPostgresBackend(db)` whose `close()` is a client no-op
+ * (`backend/drizzle/postgres.ts`), so the suites' per-test `backend.close()` can
+ * never kill the shared engine. Disposal happens exactly once, in `dispose()`.
+ */
+import { type PGlite } from "@electric-sql/pglite";
+import { getTableName, is, Table } from "drizzle-orm";
+
+import {
+  createPostgresBackend,
+  tables as defaultTables,
+} from "../../../src/backend/postgres";
+import { createLocalPgliteBackend } from "../../../src/backend/postgres/pglite";
+import { type GraphBackend } from "../../../src/backend/types";
+
+/**
+ * Every TypeGraph-managed table name, derived from the schema module rather
+ * than hand-copied from an older `clearTestData`. Postgres has grown past the
+ * original five (it now also owns `index_materializations`,
+ * `contribution_materializations`, `kind_removals`, `reconciliation_markers`);
+ * deriving the list via `getTableName` over the default tables means a future
+ * table can't silently leak across tests.
+ */
+const MANAGED_TABLE_NAMES: readonly string[] = Object.values(defaultTables)
+  .filter((value) => is(value, Table))
+  .map((table) => getTableName(table));
+
+/** Single TRUNCATE over every managed table — built once from the static list. */
+const TRUNCATE_MANAGED_SQL = `TRUNCATE ${MANAGED_TABLE_NAMES.map(
+  (name) => `"${name}"`,
+).join(", ")} CASCADE`;
+
+/**
+ * A booted PGlite engine shared across one test file, with the reset
+ * primitives the reused suites and the vector-paths tests need.
+ */
+export type SharedPgliteEngine = Readonly<{
+  /** Raw PGlite client, for strategy-level SQL driven directly. */
+  client: PGlite;
+  /**
+   * A fresh plain backend over the shared engine. Its `close()` is a client
+   * no-op, so the adapter suite's per-test close never disposes the engine.
+   */
+  makeBackend: () => GraphBackend;
+  /** TRUNCATE all managed metadata/data tables — default per-test isolation. */
+  resetData: () => Promise<void>;
+  /**
+   * TRUNCATE the lazily-created per-field vector tables (`tg_vec_*`). Keeps the
+   * `vector(N)` column type, so it is row isolation only.
+   */
+  truncateVectorTables: () => Promise<void>;
+  /**
+   * DROP the per-field vector tables (`tg_vec_*`). Structural reset for tests
+   * that change a field's dimension or reclaim storage, where a leftover
+   * `vector(3)` table would reject a later `vector(4)` insert.
+   */
+  dropVectorTables: () => Promise<void>;
+  /** Dispose the underlying PGlite engine. Call once in `afterAll`. */
+  dispose: () => Promise<void>;
+}>;
+
+/**
+ * Boots a shared PGlite engine with pgvector and the schema migrated. Call in
+ * `beforeAll`; call the returned `dispose()` in `afterAll`.
+ */
+export async function setupSharedPgliteEngine(): Promise<SharedPgliteEngine> {
+  // Keep only the engine handles; the managed backend (engine-closing) is
+  // deliberately discarded — see the module doc comment.
+  const { db, client } = await createLocalPgliteBackend();
+
+  return {
+    client,
+    makeBackend: () => createPostgresBackend(db),
+    resetData: async () => {
+      await client.exec(TRUNCATE_MANAGED_SQL);
+    },
+    truncateVectorTables: async () => {
+      for (const name of await listVectorTables(client)) {
+        await client.exec(`TRUNCATE "${name}" CASCADE`);
+      }
+    },
+    dropVectorTables: async () => {
+      for (const name of await listVectorTables(client)) {
+        await client.exec(`DROP TABLE IF EXISTS "${name}" CASCADE`);
+      }
+    },
+    dispose: async () => {
+      await client.close();
+    },
+  };
+}
+
+/**
+ * Names of the strategy-owned per-field vector tables (`tg_vec_*`) currently
+ * present. They are materialized lazily, so there is no single shared table to
+ * reset.
+ */
+async function listVectorTables(client: PGlite): Promise<readonly string[]> {
+  const result = await client.query<{ tablename: string }>(
+    String.raw`SELECT tablename FROM pg_tables
+      WHERE schemaname = 'public' AND tablename LIKE 'tg_vec\_%'`,
+  );
+  return result.rows.map((row) => row.tablename);
+}

--- a/packages/typegraph/tests/backends/postgres/pglite-integration-suite.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-integration-suite.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Integration / SQL-correctness suite, run against in-process PGlite.
+ *
+ * Part of the PGlite correctness lane: the same `createIntegrationTestSuite` the
+ * Docker lane runs (predicates, aggregates, ordering, traversals, recursive
+ * CTEs, fulltext/tsvector, cross-backend consistency, …), now exercising the
+ * real PG dialect on every `pnpm test` with zero Docker. Driver/concurrency
+ * behavior stays Docker-only (see `pglite-correctness-harness.ts`).
+ *
+ * Split from the adapter suite into its own file so the two heaviest reused
+ * suites run on separate vitest workers (parallel files) rather than one serial
+ * long-pole. One shared engine per file; data is reset between tests.
+ */
+import { afterAll, beforeAll, beforeEach } from "vitest";
+
+import { createIntegrationTestSuite } from "../integration-test-suite";
+import {
+  setupSharedPgliteEngine,
+  type SharedPgliteEngine,
+} from "./pglite-correctness-harness";
+
+let engine: SharedPgliteEngine;
+
+beforeAll(async () => {
+  engine = await setupSharedPgliteEngine();
+});
+
+afterAll(async () => {
+  await engine.dispose();
+});
+
+// The integration suite builds the store in its own `beforeEach`, so the
+// root-level reset here is the correct lifecycle: clear state first, then the
+// suite bootstraps the schema on the shared engine. `truncateVectorTables`
+// keeps the reset complete for the shared fixture's vector-capable `Article`
+// embedding field, which a future hybrid-search test could exercise.
+beforeEach(async () => {
+  await engine.resetData();
+  await engine.truncateVectorTables();
+});
+
+// No `cleanup` is returned: closing per test would dispose nothing useful (the
+// backend close is a no-op) and the engine must survive for the next test.
+createIntegrationTestSuite("PGlite", () => ({ backend: engine.makeBackend() }));

--- a/packages/typegraph/tests/backends/postgres/pglite-vector-paths.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-vector-paths.test.ts
@@ -1,0 +1,384 @@
+/**
+ * pgvector paths against in-process PGlite (Postgres-in-WASM).
+ *
+ * Part of the PGlite correctness lane (runs in plain `pnpm test`, zero Docker).
+ * This file is intentionally a **representative** slice of the pgvector surface,
+ * not a re-run of the Docker pgvector suite: enough to prove pgvector works
+ * end-to-end under PGlite's bundled extension (pgvector 0.8.1), while deeper
+ * behavior (full metric matrices, statistical recall, idempotency edge cases)
+ * stays in the Docker files.
+ *
+ * Two layers:
+ *  - strategy-level SQL driven directly through PGlite's `client.query` (the
+ *    same shape `pgvector-strategy.test.ts` drives through `pool.query`);
+ *  - store/backend-level paths: `SET LOCAL hnsw.ef_search` and removed-field
+ *    storage reclamation. (Legacy shared-table migration is deliberately out of
+ *    scope: PGlite is new this release and never had the legacy embeddings
+ *    table, which is being dropped in the same release.)
+ *
+ * One shared engine per file; `beforeEach` drops vector tables (dimension- and
+ * reclaim-sensitive) and truncates base tables.
+ */
+import { type SQL, sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph, defineNode, embedding } from "../../../src";
+import { type VectorSearchParams } from "../../../src/backend/types";
+import { defineGraphExtension } from "../../../src/graph-extension";
+import { pgvectorStrategy } from "../../../src/query/dialect/vector/pgvector-strategy";
+import { type VectorSlot } from "../../../src/query/dialect/vector-strategy";
+import { createStoreWithSchema } from "../../../src/store";
+import {
+  setupSharedPgliteEngine,
+  type SharedPgliteEngine,
+} from "./pglite-correctness-harness";
+
+// ============================================================
+// Strategy-level SQL helpers (driven through PGlite's client.query, which
+// matches pg's `query(sql, params) -> { rows }` shape).
+// ============================================================
+
+const dialect = new PgDialect();
+const GRAPH = "g1";
+const TS = "2026-06-01T00:00:00.000Z";
+
+let engine: SharedPgliteEngine;
+
+async function run(query: SQL): Promise<readonly Record<string, unknown>[]> {
+  const compiled = dialect.sqlToQuery(query);
+  const result = await engine.client.query<Record<string, unknown>>(
+    compiled.sql,
+    compiled.params,
+  );
+  return result.rows;
+}
+
+async function execAll(queries: readonly SQL[]): Promise<void> {
+  for (const query of queries) {
+    const compiled = dialect.sqlToQuery(query);
+    await engine.client.query(compiled.sql, compiled.params);
+  }
+}
+
+function slot(
+  indexType: VectorSlot["indexType"],
+  metric: VectorSlot["metric"] = "cosine",
+): VectorSlot {
+  return {
+    graphId: GRAPH,
+    nodeKind: "Document",
+    fieldPath: "embedding",
+    dimensions: 3,
+    metric,
+    indexType,
+  };
+}
+
+function searchParams(
+  queryEmbedding: readonly number[],
+  overrides: Partial<VectorSearchParams> = {},
+): VectorSearchParams {
+  return {
+    graphId: GRAPH,
+    nodeKind: "Document",
+    fieldPath: "embedding",
+    queryEmbedding,
+    metric: "cosine",
+    dimensions: 3,
+    indexType: "none",
+    limit: 10,
+    ...overrides,
+  };
+}
+
+async function createStorage(s: VectorSlot): Promise<void> {
+  for (const contribution of pgvectorStrategy.ownedTables(s)) {
+    for (const ddl of contribution.createDdl) {
+      await engine.client.exec(ddl);
+    }
+  }
+}
+
+async function upsert(
+  s: VectorSlot,
+  nodeId: string,
+  vec: readonly number[],
+  graphId = GRAPH,
+): Promise<void> {
+  await execAll(
+    pgvectorStrategy.buildUpsert(
+      s,
+      {
+        graphId,
+        nodeKind: s.nodeKind,
+        nodeId,
+        fieldPath: s.fieldPath,
+        embedding: vec,
+        dimensions: s.dimensions,
+        metric: s.metric,
+        indexType: s.indexType,
+      },
+      TS,
+    ),
+  );
+}
+
+beforeAll(async () => {
+  engine = await setupSharedPgliteEngine();
+});
+
+afterAll(async () => {
+  await engine.dispose();
+});
+
+beforeEach(async () => {
+  // Drop (not truncate) per-field vector tables: these tests intentionally vary
+  // dimensions and reclaim storage, so a leftover `vector(3)` table must not
+  // outlive the test that created it.
+  await engine.dropVectorTables();
+  await engine.resetData();
+});
+
+// ============================================================
+// Strategy-level pgvector SQL
+// ============================================================
+
+describe("pgvectorStrategy under PGlite (executed against bundled pgvector)", () => {
+  it("ranks by cosine similarity (closest first)", async () => {
+    const s = slot("none");
+    await createStorage(s);
+    await upsert(s, "d1", [1, 0, 0]);
+    await upsert(s, "d2", [0, 1, 0]);
+    await upsert(s, "d3", [0.9, 0.1, 0]);
+
+    const rows = await run(
+      pgvectorStrategy.buildSearch(s, searchParams([1, 0, 0])),
+    );
+    expect(rows.map((row) => row.node_id)).toEqual(["d1", "d3", "d2"]);
+    expect(Number(rows[0]?.score)).toBeCloseTo(1, 5);
+  });
+
+  it("ranks by l2 (euclidean) distance", async () => {
+    const s = slot("none", "l2");
+    await createStorage(s);
+    await upsert(s, "d1", [1, 0, 0]);
+    await upsert(s, "d2", [0, 5, 0]);
+    await upsert(s, "d3", [0.9, 0.1, 0]);
+
+    const rows = await run(
+      pgvectorStrategy.buildSearch(
+        s,
+        searchParams([1, 0, 0], { metric: "l2" }),
+      ),
+    );
+    expect(rows.map((row) => row.node_id)).toEqual(["d1", "d3", "d2"]);
+  });
+
+  it("ranks by inner_product (pgvector-only metric)", async () => {
+    const s = slot("none", "inner_product");
+    await createStorage(s);
+    await upsert(s, "d1", [1, 0, 0]);
+    await upsert(s, "d2", [2, 0, 0]);
+    await upsert(s, "d3", [0, 1, 0]);
+
+    const rows = await run(
+      pgvectorStrategy.buildSearch(
+        s,
+        searchParams([1, 0, 0], { metric: "inner_product" }),
+      ),
+    );
+    expect(rows.map((row) => row.node_id)).toEqual(["d2", "d1", "d3"]);
+  });
+
+  it("filters dissimilar rows with minScore and replaces on re-upsert", async () => {
+    const s = slot("none");
+    await createStorage(s);
+    await upsert(s, "d1", [0, 1, 0]); // will be replaced
+    await upsert(s, "d1", [1, 0, 0]);
+    await upsert(s, "d2", [0, 1, 0]); // orthogonal → cosine 0
+
+    const rows = await run(
+      pgvectorStrategy.buildSearch(
+        s,
+        searchParams([1, 0, 0], { minScore: 0.5 }),
+      ),
+    );
+    expect(rows.map((row) => row.node_id)).toEqual(["d1"]);
+  });
+
+  it("deletes a node's embedding", async () => {
+    const s = slot("none");
+    await createStorage(s);
+    await upsert(s, "d1", [1, 0, 0]);
+    await execAll(
+      pgvectorStrategy.buildDelete(s, {
+        graphId: GRAPH,
+        nodeKind: s.nodeKind,
+        nodeId: "d1",
+        fieldPath: s.fieldPath,
+        dimensions: s.dimensions,
+        metric: s.metric,
+        indexType: s.indexType,
+      }),
+    );
+    const rows = await run(
+      pgvectorStrategy.buildSearch(s, searchParams([1, 0, 0])),
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("partitions by graph: another graph's identical vector does not leak", async () => {
+    const s = slot("none");
+    await createStorage(s);
+    await upsert(s, "d1", [1, 0, 0], GRAPH);
+    await upsert(s, "other", [1, 0, 0], "g2");
+
+    const rows = await run(
+      pgvectorStrategy.buildSearch(s, searchParams([1, 0, 0])),
+    );
+    expect(rows.map((row) => row.node_id)).toEqual(["d1"]);
+  });
+
+  it("builds an HNSW index that executes and still ranks", async () => {
+    const s = slot("hnsw");
+    await createStorage(s);
+    const indexDdl = pgvectorStrategy.buildCreateIndex?.(s);
+    expect(indexDdl).toBeDefined();
+    await execAll([indexDdl!]);
+    await upsert(s, "d1", [1, 0, 0]);
+    await upsert(s, "d2", [0, 1, 0]);
+
+    const rows = await run(
+      pgvectorStrategy.buildSearch(s, searchParams([1, 0, 0], { limit: 1 })),
+    );
+    expect(rows.map((row) => row.node_id)).toEqual(["d1"]);
+  });
+
+  it("builds an IVFFlat index that executes", async () => {
+    const s = slot("ivfflat");
+    await createStorage(s);
+    const indexDdl = pgvectorStrategy.buildCreateIndex?.(s);
+    expect(indexDdl).toBeDefined();
+    await execAll([indexDdl!]);
+    await upsert(s, "d1", [1, 0, 0]);
+
+    const rows = await run(
+      pgvectorStrategy.buildSearch(s, searchParams([1, 0, 0], { limit: 1 })),
+    );
+    expect(rows.map((row) => row.node_id)).toEqual(["d1"]);
+  });
+});
+
+// ============================================================
+// Store / backend-level vector paths
+// ============================================================
+
+const Document = defineNode("Doc", {
+  schema: z.object({ title: z.string(), embedding: embedding(4) }),
+});
+
+function documentGraph(id: string) {
+  return defineGraph({ id, nodes: { Doc: { type: Document } }, edges: {} });
+}
+
+describe("Store-level vector paths under PGlite", () => {
+  it("applies hnsw.ef_search transaction-locally without leaking it", async () => {
+    const backend = engine.makeBackend();
+    const [store] = await createStoreWithSchema(
+      documentGraph("ef_pglite"),
+      backend,
+    );
+    await store.nodes.Doc.create({ title: "alpha", embedding: [1, 0, 0, 0] });
+    await store.nodes.Doc.create({ title: "beta", embedding: [0, 1, 0, 0] });
+
+    const readEfSearch = async () => {
+      // missing_ok=true: returns NULL rather than erroring if the GUC is unset.
+      const rows = await backend.execute<{ ef: string }>(
+        sql`SELECT current_setting('hnsw.ef_search', true) AS ef`,
+      );
+      return rows[0]?.ef;
+    };
+
+    const baseline = await readEfSearch();
+    const hits = await store.search.vector("Doc", {
+      fieldPath: "embedding",
+      queryEmbedding: [1, 0, 0, 0],
+      limit: 2,
+      efSearch: 256,
+    });
+
+    // Correct nearest neighbor returned via the efSearch path...
+    expect(hits[0]!.node.title).toBe("alpha");
+    // ...and the SET LOCAL rolled off — single-connection PGlite makes any leak
+    // immediately visible on the next read.
+    expect(await readEfSearch()).toBe(baseline);
+    expect(await readEfSearch()).not.toBe("256");
+  });
+
+  it("reclaims the orphaned vector table when an embedding field is removed", async () => {
+    const backend = engine.makeBackend();
+    const table = backend.vectorStrategy!.tableName(
+      "reclaim_pglite",
+      "Document",
+      "embedding",
+    );
+
+    const [store] = await createStoreWithSchema(
+      defineGraph({ id: "reclaim_pglite", nodes: {}, edges: {} }),
+      backend,
+    );
+    const withField = await store.evolve(addDocumentWithEmbedding);
+    await withField
+      .getNodeCollectionOrThrow("Document")
+      .create({ title: "a", embedding: [1, 0, 0] });
+    expect(await vectorTableExists(table)).toBe(true);
+
+    const dropped = await withField.evolve(dropEmbeddingModifier);
+    const result = await dropped.materializeRemovals();
+
+    expect(result.reclaimedVectorFields).toEqual([
+      { kind: "Document", fieldPath: "embedding", status: "reclaimed" },
+    ]);
+    expect(await vectorTableExists(table)).toBe(false);
+  });
+});
+
+// ============================================================
+// Store-level helpers
+// ============================================================
+
+async function vectorTableExists(name: string): Promise<boolean> {
+  const result = await engine.client.query(
+    "SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = $1",
+    [name],
+  );
+  return result.rows.length > 0;
+}
+
+const addDocumentWithEmbedding = defineGraphExtension({
+  nodes: {
+    Document: {
+      properties: {
+        title: { type: "string" },
+        embedding: {
+          type: "array",
+          items: { type: "number" },
+          embedding: { dimensions: 3 },
+        },
+      },
+    },
+  },
+});
+
+const dropEmbeddingModifier = defineGraphExtension({
+  nodes: {
+    Document: {
+      properties: {
+        title: { type: "string" },
+        embedding: { type: "array", items: { type: "number" } },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

The optional **PGlite-backed PG correctness test lane** deferred from #160 / #163. Reruns the existing backend-agnostic suites plus representative pgvector paths against in-process PGlite (Postgres-in-WASM) in plain `pnpm test` — so PG dialect + SQL correctness + pgvector get verified on every CI run with **zero Docker**. Complements, does not replace, the Docker lane (driver/concurrency behavior stays Docker-only).

Constrained scope, agreed up front: **PG dialect + SQL correctness + pgvector paths**, explicitly **excluding** driver-specific and concurrency behavior (node-pg named statements, postgres-js, neon-http, pgbouncer, real pooling/parallel transactions) — PGlite is single-connection WASM and can't exercise them.

Added four files under `packages/typegraph/tests/backends/postgres/` (all ungated, run in `pnpm test`):

## Design notes

- **One shared PGlite engine per file + reset between tests**, not per-test WASM boot (~0.5s each × ~250 tests ≈ 2 min). Mirrors the Docker lane's shared-connection + clear-data strategy.
- **Reset is schema-derived**: `resetData()` truncates all managed tables via `getTableName` over the exported `tables` object (single source of truth), so it can't silently drift when a table is added — unlike the Docker lane's hardcoded list.
- **No managed-close footgun**: the harness keeps only `{ db, client }` from `createLocalPgliteBackend()` and hands out plain `createPostgresBackend(db)` (no-op `close()`), so the shared engine survives the suites' per-test `backend.close()`.
- **Self-contained**: the working Docker pgvector files are untouched (zero regression risk). Legacy-embedding migration is deliberately out of scope — PGlite is new this release and never had the legacy table.

## Performance

Per-file wall-clock ~1.6s / 4.3s / 1.7s — well under a 30s/file budget; aggregate ~7.6s, no meaningful impact on default `pnpm test`. No new CI job, script, or changeset needed (test-only).
