### PR TITLE
Backend parity: full SQLite set operations, capability cleanup, and enforcement

### DIFF
--- a/.changeset/drop-unused-backend-capability-flags.md
+++ b/.changeset/drop-unused-backend-capability-flags.md
@@ -1,0 +1,19 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Reduce `BackendCapabilities` to the flags the library actually consumes:
+`transactions`, `vector`, and `fulltext`.
+
+The descriptive-only flags `jsonb`, `ginIndexes`, `partialIndexes`, `cte`, and
+`returning` were never read anywhere to gate a query feature or pick an index
+strategy. `jsonb`/`ginIndexes` additionally misrepresented SQLite, which has
+native JSON (`json_extract`/`json_each`) and supports B-tree expression indexes
+on scalar JSON properties at parity with PostgreSQL — the only real JSON
+difference (GIN containment acceleration) is a Postgres performance
+characteristic, not a gated capability.
+
+If you were reading any of these removed flags, branch on
+`backend.dialect === "postgres"` instead, or rely on the dialect layer
+(JSON-path predicates, `WITH` queries, `RETURNING`, partial indexes, and
+`defineNodeIndex`/`defineEdgeIndex` work the same on both backends).

--- a/.changeset/nested-set-operation-suffix-clauses.md
+++ b/.changeset/nested-set-operation-suffix-clauses.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `ORDER BY`/`LIMIT`/`OFFSET` being silently dropped on a nested set-operation
+operand.
+
+When a set operation was nested inside another — e.g.
+`a.union(b).limit(10).intersect(c)` — the inner compound's suffix clauses were
+applied only at the top level, so the inner `limit`/`offset` were ignored and
+the outer operation ran over the full (unlimited) inner result. The compiler now
+emits each nested compound's own `ORDER BY`/`LIMIT`/`OFFSET` inside its operand
+subquery on both SQLite and PostgreSQL.

--- a/.changeset/setop-vector-strategy-and-fulltext-language.md
+++ b/.changeset/setop-vector-strategy-and-fulltext-language.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Validate set-operation leaf vector predicates against the configured vector
+strategy rather than only the dialect's fallback metric list, so a custom
+strategy's metric (e.g. `inner_product` on SQLite) is accepted inside
+`UNION`/`INTERSECT`/`EXCEPT` leaves exactly as it is in a standalone query.
+
+Reject a per-query fulltext `language` override on the query-builder path
+(`.$fulltext.matches(..., { language })`) when the strategy's tokenizer is fixed
+at table-create time (SQLite/FTS5), matching the store-level search guard
+instead of silently ignoring the option.

--- a/.changeset/sqlite-set-operations-full-support.md
+++ b/.changeset/sqlite-set-operations-full-support.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Support the full query feature set inside SQLite set operations
+(`UNION`/`UNION ALL`/`INTERSECT`/`EXCEPT`).
+
+Previously the SQLite set-operation compiler hand-rolled a thin subset of leaf
+compilation and rejected leaves that used traversals, `EXISTS`/`IN` subqueries,
+vector or fulltext predicates, `GROUP BY`/`HAVING`, or per-leaf
+`ORDER BY`/`LIMIT`/`OFFSET` — throwing `UnsupportedPredicateError` at execution
+time. PostgreSQL accepted all of these. The result was a portability cliff: a
+combined query developed against PostgreSQL could throw the moment the backend
+was switched to SQLite.
+
+Both dialects now compile every leaf with the full query compiler and only
+differ in how each operand is wrapped. SQLite forbids parenthesized compound
+operands, but it does allow a `WITH` clause inside a FROM-subquery, so each
+operand is emitted as `SELECT * FROM (<leaf>)`. This keeps every leaf's CTEs
+(traversal joins, recursive expansions, vector/fulltext relevance) scoped to its
+own subquery and lets per-leaf `ORDER BY`/`LIMIT`/`OFFSET` live inside the wrap.
+Nested set operations are wrapped the same way, preserving the AST's grouping
+regardless of the dialect's native compound-operator associativity. As a
+side effect, vector/fulltext predicates in set-operation leaves now use the
+backend's configured relevance strategy instead of falling back to the dialect
+default.
+
+Note: `GROUP BY`/`HAVING` leaves are supported at the compiler level, but the
+query builder still does not expose `.union()`/`.intersect()`/`.except()` on
+aggregate queries — that builder gate is unchanged and applies equally to both
+backends.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,36 @@ import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
 const backend = createPostgresBackend(pool);
 ```
 
+## Backend parity
+
+A query written against one backend must behave identically on the other. We
+get there by construction, not by hoping:
+
+1. **The query compiler (`src/query`) is a single shared path.** The only
+   sanctioned place for a dialect difference is a member of the `DialectAdapter`
+   interface — a *token-level* seam (quote an identifier, pick a JSON function,
+   emit a boolean literal). Because it is an `interface`, every dialect is forced
+   by the type checker to provide an implementation, so a backend can never be
+   silently skipped. An ESLint rule bans inline `=== "sqlite"` / `case
+   "postgres"` branching under `src/query` to keep this true. Never reintroduce a
+   per-dialect *strategy function* that re-implements compilation for one backend
+   — that parallel-path pattern is exactly what hid the set-operation gap.
+   (Backend provisioning under `src/backend` — DDL, migrations, extension setup —
+   legitimately branches on dialect and is out of scope.)
+
+2. **Query-feature tests live in the shared cross-backend suite**
+   (`tests/backends/integration/*.ts`, registered via `createIntegrationTestSuite`
+   and run against every backend). Per-dialect tests in `tests/backends/{sqlite,
+   postgres}/**` are for backend-specific wiring only — never for query
+   semantics. A per-dialect test will happily certify a divergence; only the
+   same case run on both backends verifies equivalence.
+
+3. **Genuine engine gaps are declared, not hidden.** When an engine truly cannot
+   do something (e.g. `sqlite-vec` has no `inner_product` metric), surface it as
+   a typed capability (`backend.capabilities`), document it in the parity matrix
+   in `backend-setup.md`, and add a test asserting the *exact* error on the
+   unsupported backend. No silent no-ops.
+
 ## Graph Definition
 
 ```typescript

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -725,7 +725,7 @@ if (backend.capabilities.vector?.supported) {
 | --- | --- |
 | `transactions` | Atomic transactions available (see note below) |
 | `vector?.metrics` / `vector?.indexTypes` / `vector?.maxDimensions` | Vector strategy capabilities (present once a vector strategy is configured) |
-| `fulltext?.{modes,phraseQueries,prefixQueries,highlighting,languages}` | Fulltext strategy capabilities |
+| `fulltext?.{supported,languages,phraseQueries,prefixQueries,highlighting}` | Fulltext strategy capabilities |
 
 ### SQLite ↔ PostgreSQL parity
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -719,6 +719,63 @@ if (backend.capabilities.vector?.supported) {
 }
 ```
 
+`backend.capabilities` is the runtime source of truth. The shape is:
+
+| Field | Meaning |
+| --- | --- |
+| `transactions` | Atomic transactions available (see note below) |
+| `vector?.metrics` / `vector?.indexTypes` / `vector?.maxDimensions` | Vector strategy capabilities (present once a vector strategy is configured) |
+| `fulltext?.{modes,phraseQueries,prefixQueries,highlighting,languages}` | Fulltext strategy capabilities |
+
+### SQLite ↔ PostgreSQL parity
+
+The **query language is fully portable** between SQLite and PostgreSQL. Predicates (comparison, string/`ILIKE`,
+null, `between`, array, object, JSON-path), fixed and variable-length (recursive) traversals, aggregates
+(`count`/`sum`/`avg`/`min`/`max` with `groupBy`/`having`), set operations (`UNION`/`UNION ALL`/`INTERSECT`/`EXCEPT`,
+including traversal, subquery, `GROUP BY`/`HAVING`, and per-leaf `ORDER BY`/`LIMIT`/`OFFSET` leaves), ordering with
+`NULLS FIRST`/`LAST`, cursor pagination, temporal queries, and the fulltext query modes (`websearch`, `phrase`,
+`plain`, `raw`) all behave identically. A query you write against one backend compiles and runs the same way on the
+other.
+
+The remaining differences are **engine-capability gaps in the vector and fulltext layers** — they stem from what
+`sqlite-vec`/FTS5 implement versus `pgvector`/`tsvector`, not from TypeGraph choosing to support a feature on one
+backend only:
+
+| Capability | SQLite | PostgreSQL | Behavior on the unsupported side |
+| --- | --- | --- | --- |
+| Vector metric `inner_product` | ✗ | ✓ | Rejected at compile time on SQLite (`sqlite-vec`/`libsql-native` expose `cosine` + `l2`; `pgvector` adds `inner_product`) |
+| Vector index type `ivfflat` | ✗ | ✓ | Index declaration is **skipped** on SQLite (`indexTypes`: `hnsw`/`none` vs `hnsw`/`ivfflat`/`none`) |
+| Per-query fulltext `language` override | ✗ | ✓ | Throws on SQLite — FTS5's tokenizer is fixed at table-create time; `tsvector` accepts a regconfig per query |
+| HNSW `efSearch` query tuning | ✗ | ✓ | Silent no-op on SQLite; Postgres applies `hnsw.ef_search`. Performance only — same results |
+
+Vector and fulltext capabilities are populated from the configured strategy, so the matrix above reflects the
+bundled strategies (`sqlite-vec`/`libsql-native`/`pgvector`, `fts5`/`tsvector`). A custom strategy advertising
+different `metrics`/`indexTypes` shifts these rows accordingly — always check `backend.capabilities` at runtime
+rather than hard-coding the dialect.
+
+:::note[JSON is native on both backends]
+SQLite stores JSON as text and queries it with the built-in JSON functions (`json_extract`, `json_each`, …);
+PostgreSQL uses native `JSONB`. The dialect layer hides this difference, so JSON-path predicates and **B-tree
+expression indexes on scalar JSON properties** (`defineNodeIndex` / `defineEdgeIndex`) are at full parity. The one
+JSON-related difference is performance, not capability: PostgreSQL can use a single GIN index to accelerate
+array/object **containment** predicates (`contains()` / `containsAll()` / `hasKey()` / `pathEquals()`), whereas on
+SQLite those run as `json_each()` scans — correct results, just not index-accelerated. See
+[Indexes](/performance/indexes) for the full breakdown.
+:::
+
+:::note[Transactions are driver-dependent, not backend-dependent]
+Both backends report `transactions: true` by default. The exception is symmetric and lives in specific drivers:
+Cloudflare D1 (SQLite) and `drizzle-orm/neon-http` (Postgres) are non-transactional, so they downgrade to
+`transactions: false`. Operations that require atomicity (`commitSchemaVersion`, `setActiveVersion`) throw on those
+drivers regardless of backend.
+:::
+
+:::note[Aggregate set operations are a builder limitation, not a parity gap]
+`GROUP BY`/`HAVING` leaves are supported by the set-operation compiler on **both** backends, but the query builder
+does not expose `.union()`/`.intersect()`/`.except()` on `.aggregate()` queries. That limit applies equally to SQLite
+and PostgreSQL, so it is not a portability difference.
+:::
+
 ## Connection Management
 
 TypeGraph does not manage database connections. You are responsible for:

--- a/packages/typegraph/eslint.config.mjs
+++ b/packages/typegraph/eslint.config.mjs
@@ -2,15 +2,47 @@
 
 import { createLibraryConfig } from "@typegraph/eslint-config/library";
 
-export default createLibraryConfig(import.meta.dirname, {
-  ignores: [
-    "examples/**",
-    "test-d/**",
-    "type-smoke/**",
-    "tmp/**",
-    // #140: workerd-only do-sqlite suite (cloudflare:test). Runs via
-    // its own `test:do` lane, not the Node lanes which cannot resolve
-    // the `cloudflare:test` / worker ambient types.
-    "tests/do-sqlite/**",
-  ],
-});
+const DIALECT_SEAM_MESSAGE =
+  "Do not branch on dialect identity in the query compiler. Express the " +
+  "difference as a method/capability on DialectAdapter (a token-level seam) so " +
+  "TypeScript forces every backend to provide an implementation and the " +
+  "divergence stays visible and cross-backend testable. Backend provisioning " +
+  "(src/backend) may branch on dialect for DDL/migration; the query compiler " +
+  "must not.";
+
+export default [
+  ...createLibraryConfig(import.meta.dirname, {
+    ignores: [
+      "examples/**",
+      "test-d/**",
+      "type-smoke/**",
+      "tmp/**",
+      // #140: workerd-only do-sqlite suite (cloudflare:test). Runs via
+      // its own `test:do` lane, not the Node lanes which cannot resolve
+      // the `cloudflare:test` / worker ambient types.
+      "tests/do-sqlite/**",
+    ],
+  }),
+
+  // Backend parity guardrail. The query compiler is a single shared path; the
+  // only sanctioned place for a dialect difference is a DialectAdapter member.
+  // Inline `=== "sqlite"` / `case "postgres"` branching reintroduces the
+  // parallel-path failure mode that hid the set-operation gap, so ban it here.
+  {
+    files: ["src/query/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "BinaryExpression[operator=/^(===|!==|==|!=)$/] > Literal[value=/^(sqlite|postgres)$/]",
+          message: DIALECT_SEAM_MESSAGE,
+        },
+        {
+          selector: "SwitchCase > Literal[value=/^(sqlite|postgres)$/]",
+          message: DIALECT_SEAM_MESSAGE,
+        },
+      ],
+    },
+  },
+];

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -97,16 +97,6 @@ export type { SqlDialect } from "../query/dialect/types";
  * Backend capabilities that vary by dialect.
  */
 export type BackendCapabilities = Readonly<{
-  /** Whether the backend supports JSONB type (vs TEXT for JSON) */
-  jsonb: boolean;
-  /** Whether the backend supports partial indexes */
-  partialIndexes: boolean;
-  /** Whether the backend supports GIN indexes for JSON */
-  ginIndexes: boolean;
-  /** Whether the backend supports CTE (WITH) queries */
-  cte: boolean;
-  /** Whether the backend supports RETURNING clause */
-  returning: boolean;
   /** Whether the backend supports atomic transactions (D1 does not) */
   transactions: boolean;
   /** Vector search capabilities (undefined if not configured) */
@@ -1483,11 +1473,6 @@ export type CountEdgesByKindParams = Readonly<{
  * Default capabilities for SQLite.
  */
 export const SQLITE_CAPABILITIES: BackendCapabilities = {
-  jsonb: false, // SQLite uses TEXT with json functions
-  partialIndexes: true, // SQLite supports WHERE in CREATE INDEX
-  ginIndexes: false, // SQLite doesn't have GIN
-  cte: true, // SQLite supports WITH
-  returning: true, // SQLite 3.35+ supports RETURNING
   transactions: true, // SQLite supports transactions
 };
 
@@ -1495,10 +1480,5 @@ export const SQLITE_CAPABILITIES: BackendCapabilities = {
  * Default capabilities for PostgreSQL.
  */
 export const POSTGRES_CAPABILITIES: BackendCapabilities = {
-  jsonb: true, // PostgreSQL has native JSONB
-  partialIndexes: true,
-  ginIndexes: true,
-  cte: true,
-  returning: true,
   transactions: true, // PostgreSQL supports transactions
 };

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -259,8 +259,12 @@ export function compileSetOperation(
   const dialect = options_.dialect ?? "sqlite";
 
   const adapter = resolveDialectAdapter(dialect, options_.fulltextStrategy);
-  return compileSetOp(op, graphId, adapter, (ast, gid) =>
-    compileQuery(ast, gid, propagateOptions(options_)),
+  return compileSetOp(
+    op,
+    graphId,
+    adapter,
+    (ast, gid) => compileQuery(ast, gid, propagateOptions(options_)),
+    options_.vectorStrategy,
   );
 }
 

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -257,10 +257,9 @@ export function compileSetOperation(
   const options_: CompileQueryOptions =
     typeof options === "string" ? { dialect: options } : options;
   const dialect = options_.dialect ?? "sqlite";
-  const schema = options_.schema ?? DEFAULT_SQL_SCHEMA;
 
   const adapter = resolveDialectAdapter(dialect, options_.fulltextStrategy);
-  return compileSetOp(op, graphId, adapter, schema, (ast, gid) =>
+  return compileSetOp(op, graphId, adapter, (ast, gid) =>
     compileQuery(ast, gid, propagateOptions(options_)),
   );
 }

--- a/packages/typegraph/src/query/compiler/passes/fulltext.ts
+++ b/packages/typegraph/src/query/compiler/passes/fulltext.ts
@@ -51,6 +51,17 @@ export function runFulltextPredicatePass(
   }
 
   if (
+    fulltextPredicate.language !== undefined &&
+    !strategy.supportsLanguageOverride
+  ) {
+    throw new UnsupportedPredicateError(
+      `Fulltext strategy "${strategy.name}" does not honor a per-query \`language\` override ` +
+        `(its tokenizer is fixed at table-create time). Drop the option, or use a strategy ` +
+        `that advertises \`supportsLanguageOverride: true\`.`,
+    );
+  }
+
+  if (
     !Number.isFinite(fulltextPredicate.limit) ||
     fulltextPredicate.limit <= 0
   ) {

--- a/packages/typegraph/src/query/compiler/plan/lowering.ts
+++ b/packages/typegraph/src/query/compiler/plan/lowering.ts
@@ -8,7 +8,11 @@ import type {
   SetOperation,
   VectorSimilarityPredicate,
 } from "../../ast";
-import { getDialect, type SqlDialect } from "../../dialect";
+import {
+  getDialect,
+  type SqlDialect,
+  type VectorStrategy,
+} from "../../dialect";
 import {
   resolveFulltextAwareLimit,
   resolveVectorAwareLimit,
@@ -46,6 +50,12 @@ export type LowerSetOperationToLogicalPlanInput = Readonly<{
   dialect: SqlDialect;
   graphId: string;
   op: SetOperation;
+  /**
+   * The backend-configured vector strategy, threaded so a set-operation leaf's
+   * vector predicate validates against the same metric set as standalone leaf
+   * compilation (rather than only the dialect's fallback metric list).
+   */
+  vectorStrategy?: VectorStrategy;
 }>;
 
 /**
@@ -341,6 +351,7 @@ function lowerComposableQueryToLogicalPlanNode(
   dialect: SqlDialect,
   graphId: string,
   nextPlanNodeId: () => string,
+  vectorStrategy: VectorStrategy | undefined,
 ): LogicalPlanNode {
   if ("__type" in query) {
     return lowerSetOperationToLogicalPlanNode(
@@ -348,6 +359,7 @@ function lowerComposableQueryToLogicalPlanNode(
       graphId,
       dialect,
       nextPlanNodeId,
+      vectorStrategy,
     );
   }
 
@@ -367,6 +379,7 @@ function lowerComposableQueryToLogicalPlanNode(
   const vectorPredicate = runVectorPredicatePass(
     query,
     dialectAdapter,
+    vectorStrategy,
   ).vectorPredicate;
   const fulltextPredicate = runFulltextPredicatePass(
     query,
@@ -397,6 +410,7 @@ function lowerSetOperationToLogicalPlanNode(
   graphId: string,
   dialect: SqlDialect,
   nextPlanNodeId: () => string,
+  vectorStrategy: VectorStrategy | undefined,
 ): LogicalPlanNode {
   let currentNode: LogicalPlanNode = {
     id: nextPlanNodeId(),
@@ -405,6 +419,7 @@ function lowerSetOperationToLogicalPlanNode(
       dialect,
       graphId,
       nextPlanNodeId,
+      vectorStrategy,
     ),
     op: "set_op",
     operator: op.operator,
@@ -413,6 +428,7 @@ function lowerSetOperationToLogicalPlanNode(
       dialect,
       graphId,
       nextPlanNodeId,
+      vectorStrategy,
     ),
   };
 
@@ -489,6 +505,7 @@ export function lowerSetOperationToLogicalPlan(
       input.graphId,
       input.dialect,
       nextPlanNodeId,
+      input.vectorStrategy,
     ),
   };
 }

--- a/packages/typegraph/src/query/compiler/set-operations.ts
+++ b/packages/typegraph/src/query/compiler/set-operations.ts
@@ -33,7 +33,7 @@ import {
   type QueryAst,
   type SetOperation,
 } from "../ast";
-import { type DialectAdapter } from "../dialect";
+import { type DialectAdapter, type VectorStrategy } from "../dialect";
 import { type JsonPointer, jsonPointer } from "../json-pointer";
 import { emitSetOperationQuerySql } from "./emitter";
 import { runCompilerPass } from "./passes";
@@ -65,6 +65,7 @@ function runSetOperationPassPipeline(
   op: SetOperation,
   graphId: string,
   dialect: DialectAdapter,
+  vectorStrategy: VectorStrategy | undefined,
 ): SetOperationPassState {
   let state: SetOperationPassState = {
     dialect,
@@ -80,6 +81,7 @@ function runSetOperationPassPipeline(
         dialect: currentState.dialect.name,
         graphId: currentState.graphId,
         op: currentState.op,
+        ...(vectorStrategy === undefined ? {} : { vectorStrategy }),
       });
     },
     update(currentState, logicalPlan): SetOperationPassState {
@@ -110,6 +112,8 @@ function runSetOperationPassPipeline(
  * @param graphId - The graph ID
  * @param dialect - The dialect adapter
  * @param compileQuery - Function to compile regular (leaf) queries
+ * @param vectorStrategy - The backend-configured vector strategy, if any, used
+ *   to validate leaf vector predicates against the strategy's metric set
  * @returns SQL for the set operation
  */
 export function compileSetOperation(
@@ -117,8 +121,14 @@ export function compileSetOperation(
   graphId: string,
   dialect: DialectAdapter,
   compileQuery: QueryCompilerFunction,
+  vectorStrategy?: VectorStrategy,
 ): SQL {
-  const passState = runSetOperationPassPipeline(op, graphId, dialect);
+  const passState = runSetOperationPassPipeline(
+    op,
+    graphId,
+    dialect,
+    vectorStrategy,
+  );
   const { logicalPlan } = passState;
   if (logicalPlan === undefined) {
     throw new CompilerInvariantError(

--- a/packages/typegraph/src/query/compiler/set-operations.ts
+++ b/packages/typegraph/src/query/compiler/set-operations.ts
@@ -3,13 +3,20 @@
  *
  * Compiles UNION, INTERSECT, and EXCEPT operations to SQL.
  *
- * For SQLite, special handling is required because:
- * - CTEs (WITH clauses) cannot be wrapped in parentheses
- * - Compound SELECT statements can only have a single WITH clause at the start
+ * Both dialects compile each leaf with the full query compiler and combine
+ * the results with the requested operator. The only dialect-specific concern
+ * is how each operand is wrapped so the compound statement stays valid:
  *
- * This module handles these requirements by:
- * - For simple queries (no traversals): Compiling without CTEs, using direct table queries
- * - For complex queries: Merging all CTEs into a single WITH clause with unique prefixes
+ * - PostgreSQL allows a complete SELECT (including its own WITH clause) to be
+ *   parenthesized as a compound operand: `(SELECT ...) UNION (SELECT ...)`.
+ * - SQLite forbids parentheses around compound operands, but it does allow a
+ *   `WITH` clause inside a FROM-subquery, so each operand is wrapped as
+ *   `SELECT * FROM (SELECT ...)`. This keeps every leaf's CTEs (traversals,
+ *   vector/fulltext joins, recursive expansions) scoped to its own subquery
+ *   and lets per-leaf ORDER BY/LIMIT/OFFSET live inside the wrap.
+ *
+ * Nested set operations are wrapped the same way, which preserves the AST's
+ * grouping regardless of the dialect's native compound-operator associativity.
  */
 import { type SQL, sql } from "drizzle-orm";
 
@@ -26,34 +33,16 @@ import {
   type QueryAst,
   type SetOperation,
 } from "../ast";
-import {
-  type DialectAdapter,
-  type DialectSetOperationStrategy,
-} from "../dialect";
+import { type DialectAdapter } from "../dialect";
 import { type JsonPointer, jsonPointer } from "../json-pointer";
 import { emitSetOperationQuerySql } from "./emitter";
-import { createTemporalFilterPass, runCompilerPass } from "./passes";
+import { runCompilerPass } from "./passes";
 import { type LogicalPlan, lowerSetOperationToLogicalPlan } from "./plan";
-import {
-  compilePredicateExpression,
-  type PredicateCompilerContext,
-} from "./predicates";
-import { type SqlSchema } from "./schema";
-import { compileTypedJsonExtract } from "./typed-json-extract";
 
 /**
  * Type for the query compiler function.
  */
 export type QueryCompilerFunction = (ast: QueryAst, graphId: string) => SQL;
-
-type SetOperationStrategyHandler = (
-  op: SetOperation,
-  graphId: string,
-  dialect: DialectAdapter,
-  logicalPlan: LogicalPlan,
-  schema: SqlSchema,
-  compileQuery: QueryCompilerFunction,
-) => SQL;
 
 /**
  * Operator mapping for set operations.
@@ -63,48 +52,6 @@ const OPERATOR_MAP: Record<SetOperationType, string> = {
   unionAll: "UNION ALL",
   intersect: "INTERSECT",
   except: "EXCEPT",
-};
-
-function compileSetOperationWithStandardParenthesizedStrategy(
-  op: SetOperation,
-  graphId: string,
-  dialect: DialectAdapter,
-  logicalPlan: LogicalPlan,
-  _schema: SqlSchema,
-  compileQuery: QueryCompilerFunction,
-): SQL {
-  return compileSetOperationStandard(
-    op,
-    graphId,
-    dialect,
-    logicalPlan,
-    compileQuery,
-  );
-}
-
-function compileSetOperationWithSqliteCompoundStrategy(
-  op: SetOperation,
-  graphId: string,
-  dialect: DialectAdapter,
-  logicalPlan: LogicalPlan,
-  schema: SqlSchema,
-  _compileQuery: QueryCompilerFunction,
-): SQL {
-  return compileSetOperationForSqlite(
-    op,
-    graphId,
-    dialect,
-    logicalPlan,
-    schema,
-  );
-}
-
-const SET_OPERATION_STRATEGY_HANDLERS: Record<
-  DialectSetOperationStrategy,
-  SetOperationStrategyHandler
-> = {
-  standard_parenthesized: compileSetOperationWithStandardParenthesizedStrategy,
-  sqlite_compound: compileSetOperationWithSqliteCompoundStrategy,
 };
 
 type SetOperationPassState = Readonly<{
@@ -154,21 +101,21 @@ function runSetOperationPassPipeline(
 /**
  * Compiles a set operation to SQL.
  *
- * For SQLite, uses a special compilation strategy that avoids wrapping
- * CTEs in parentheses. For other databases, uses the standard approach.
+ * Each leaf is compiled by the full query compiler, so set operations support
+ * exactly the same query features as standalone queries (traversals, EXISTS/IN
+ * subqueries, vector/fulltext predicates, GROUP BY/HAVING, and per-leaf
+ * ORDER BY/LIMIT/OFFSET) on every dialect.
  *
  * @param op - The set operation AST
  * @param graphId - The graph ID
  * @param dialect - The dialect adapter
- * @param schema - SQL schema configuration for table names
- * @param compileQuery - Function to compile regular queries
+ * @param compileQuery - Function to compile regular (leaf) queries
  * @returns SQL for the set operation
  */
 export function compileSetOperation(
   op: SetOperation,
   graphId: string,
   dialect: DialectAdapter,
-  schema: SqlSchema,
   compileQuery: QueryCompilerFunction,
 ): SQL {
   const passState = runSetOperationPassPipeline(op, graphId, dialect);
@@ -179,31 +126,7 @@ export function compileSetOperation(
     );
   }
 
-  const strategy = dialect.capabilities.setOperationStrategy;
-  const handler = SET_OPERATION_STRATEGY_HANDLERS[strategy];
-  return handler(op, graphId, dialect, logicalPlan, schema, compileQuery);
-}
-
-// ============================================================
-// Standard (PostgreSQL) Compilation
-// ============================================================
-
-/**
- * Standard set operation compilation for databases that support CTEs in parentheses.
- */
-function compileSetOperationStandard(
-  op: SetOperation,
-  graphId: string,
-  dialect: DialectAdapter,
-  logicalPlan: LogicalPlan,
-  compileQuery: QueryCompilerFunction,
-): SQL {
-  const coreSql = compileSetOperationCoreStandard(
-    op,
-    graphId,
-    dialect,
-    compileQuery,
-  );
+  const coreSql = compileSetOperationCore(op, graphId, compileQuery, dialect);
 
   const suffixClauses = buildSetOperationSuffixClauses(op, dialect);
   return emitSetOperationQuerySql({
@@ -214,584 +137,66 @@ function compileSetOperationStandard(
 }
 
 /**
- * Compiles the core set operation with parentheses (standard approach).
+ * Compiles a set operation node into a compound SELECT by wrapping each side
+ * with the dialect's operand wrapper and joining them with the operator.
  */
-function compileSetOperationCoreStandard(
+function compileSetOperationCore(
   op: SetOperation,
   graphId: string,
-  dialect: DialectAdapter,
   compileQuery: QueryCompilerFunction,
+  dialect: DialectAdapter,
 ): SQL {
-  const left = compileComposableQueryStandard(
-    op.left,
-    graphId,
-    dialect,
-    compileQuery,
-  );
-  const right = compileComposableQueryStandard(
+  const left = compileComposableQuery(op.left, graphId, compileQuery, dialect);
+  const right = compileComposableQuery(
     op.right,
     graphId,
-    dialect,
     compileQuery,
+    dialect,
   );
 
   const opSql = sql.raw(OPERATOR_MAP[op.operator]);
 
-  return sql`(${left}) ${opSql} (${right})`;
+  return sql`${dialect.wrapSetOperationOperand(left)} ${opSql} ${dialect.wrapSetOperationOperand(right)}`;
 }
 
 /**
- * Compiles a composable query for standard databases.
+ * Compiles a composable query operand. Leaves are compiled by the full query
+ * compiler; nested set operations recurse into a complete compound SELECT
+ * (including their own ORDER BY/LIMIT/OFFSET) before the parent wraps them.
  */
-function compileComposableQueryStandard(
+function compileComposableQuery(
   query: ComposableQuery,
   graphId: string,
-  dialect: DialectAdapter,
   compileQuery: QueryCompilerFunction,
+  dialect: DialectAdapter,
 ): SQL {
   if ("__type" in query) {
-    return compileSetOperationCoreStandard(
-      query,
-      graphId,
-      dialect,
-      compileQuery,
-    );
+    return compileSetOperationCompound(query, graphId, compileQuery, dialect);
   }
   return compileQuery(query, graphId);
 }
 
-// ============================================================
-// SQLite Compilation
-// ============================================================
-
-type SqliteSetOperationLeaf = Readonly<{
-  ast: QueryAst;
-  prefix: string;
-}>;
-
-type SqliteSetOperationValidationPassResult = Readonly<{
-  leaves: readonly SqliteSetOperationLeaf[];
-}>;
-
 /**
- * Validates and prepares SQLite set-operation leaves.
- *
- * Invariants:
- * - All leaves are flattened with stable prefixes.
- * - Every leaf passes SQLite compound-query compatibility checks.
+ * Compiles a set operation into a complete compound SELECT, including its own
+ * ORDER BY/LIMIT/OFFSET suffix clauses. Used for nested operands: a nested
+ * compound carries suffix clauses that belong inside the operand, not on the
+ * outer statement. The top-level entry (compileSetOperation) layers the
+ * logical-plan emitter invariant on top of these same core + suffix clauses.
  */
-function runSqliteSetOperationValidationPass(
-  op: SetOperation,
-): SqliteSetOperationValidationPassResult {
-  const leaves: SqliteSetOperationLeaf[] = [];
-  collectLeafQueries(op, leaves, "q");
-
-  for (const leaf of leaves) {
-    validateSqliteSetOpLeaf(leaf.ast);
-  }
-
-  return { leaves };
-}
-
-/**
- * SQLite-specific set operation compilation.
- *
- * SQLite compound SELECT statements cannot have parentheses around
- * queries that include CTEs. This function compiles set operations
- * by merging all CTEs into a single WITH clause at the top.
- *
- * @throws Error if any leaf query contains traversals (not yet supported)
- */
-function compileSetOperationForSqlite(
+function compileSetOperationCompound(
   op: SetOperation,
   graphId: string,
+  compileQuery: QueryCompilerFunction,
   dialect: DialectAdapter,
-  logicalPlan: LogicalPlan,
-  schema: SqlSchema,
 ): SQL {
-  const { leaves } = runSqliteSetOperationValidationPass(op);
-
-  // Build all CTEs with unique prefixes
-  const allCtes: SQL[] = [];
-  const ctx: PredicateCompilerContext = {
-    dialect,
-    schema,
-    compileQuery: () => {
-      throw new CompilerInvariantError(
-        "compileQuery is not available in set-operation CTE compilation",
-      );
-    },
-  };
-
-  for (const leaf of leaves) {
-    const cte = compilePrefixedStartCte(leaf.ast, leaf.prefix, graphId, ctx);
-    allCtes.push(cte);
-  }
-
-  // Build SELECT statements for each leaf
-  const selectStatements: SQL[] = [];
-  for (const leaf of leaves) {
-    const select = compilePrefixedSelect(leaf.ast, leaf.prefix, dialect);
-    selectStatements.push(select);
-  }
-
-  // Build compound SELECT from the set operation structure
-  const compoundSelect = buildCompoundSelect(op, leaves, selectStatements);
-
+  const core = compileSetOperationCore(op, graphId, compileQuery, dialect);
   const suffixClauses = buildSetOperationSuffixClauses(op, dialect);
-  return emitSetOperationQuerySql({
-    baseQuery: compoundSelect,
-    ...(allCtes.length === 0 ? {} : { ctes: allCtes }),
-    logicalPlan,
-    ...(suffixClauses.length === 0 ? {} : { suffixClauses }),
-  });
-}
-
-/**
- * Validates that a leaf query is compatible with SQLite set operations.
- * SQLite's compound SELECT has significant limitations compared to PostgreSQL.
- *
- * @throws Error if the query uses unsupported features
- */
-function validateSqliteSetOpLeaf(ast: QueryAst): void {
-  const unsupported: string[] = [];
-
-  // Traversals require multiple CTEs which SQLite can't handle in compound statements
-  if (ast.traversals.length > 0) {
-    unsupported.push("traversals");
-  }
-
-  // Subqueries (EXISTS/IN) would need CTEs or nested queries
-  if (hasSubqueryPredicates(ast)) {
-    unsupported.push("EXISTS/IN subqueries");
-  }
-
-  // Vector similarity requires the embeddings table join
-  if (hasVectorSimilarityPredicates(ast)) {
-    unsupported.push("vector similarity predicates");
-  }
-
-  // Fulltext match requires the fulltext table join
-  if (hasFulltextMatchPredicates(ast)) {
-    unsupported.push("fulltext match predicates");
-  }
-
-  // GROUP BY/HAVING would need to be applied to the individual leaf, not the compound result
-  if (ast.groupBy !== undefined) {
-    unsupported.push("GROUP BY");
-  }
-  if (ast.having !== undefined) {
-    unsupported.push("HAVING");
-  }
-
-  // Per-leaf ORDER BY/LIMIT/OFFSET would silently be ignored in compound statements
-  // (only the outer ORDER BY/LIMIT/OFFSET apply)
-  if (ast.orderBy !== undefined && ast.orderBy.length > 0) {
-    unsupported.push(
-      "per-query ORDER BY (use set operation's orderBy instead)",
-    );
-  }
-  if (ast.limit !== undefined) {
-    unsupported.push("per-query LIMIT (use set operation's limit instead)");
-  }
-  if (ast.offset !== undefined) {
-    unsupported.push("per-query OFFSET (use set operation's offset instead)");
-  }
-
-  if (unsupported.length > 0) {
-    throw new UnsupportedPredicateError(
-      `SQLite set operations (UNION/INTERSECT/EXCEPT) do not support: ${unsupported.join(", ")}. ` +
-        "Use PostgreSQL for complex set operations, or refactor to separate queries.",
-    );
-  }
-}
-
-/**
- * Checks if a query AST has vector similarity predicates.
- */
-function hasVectorSimilarityPredicates(ast: QueryAst): boolean {
-  return ast.predicates.some((predicate) =>
-    hasVectorSimilarityInExpression(predicate.expression),
-  );
-}
-
-/**
- * Recursively checks if a predicate expression contains vector similarity.
- */
-function hasVectorSimilarityInExpression(
-  expr: QueryAst["predicates"][0]["expression"],
-): boolean {
-  if ("__type" in expr) {
-    switch (expr.__type) {
-      case "and":
-      case "or": {
-        return expr.predicates.some((p) => hasVectorSimilarityInExpression(p));
-      }
-      case "not": {
-        return hasVectorSimilarityInExpression(expr.predicate);
-      }
-      case "vector_similarity": {
-        return true;
-      }
-      case "exists":
-      case "in_subquery":
-      case "comparison":
-      case "string_op":
-      case "null_check":
-      case "between":
-      case "array_op":
-      case "object_op":
-      case "aggregate_comparison":
-      case "fulltext_match": {
-        return false;
-      }
-    }
-  }
-  return false;
-}
-
-function hasFulltextMatchPredicates(ast: QueryAst): boolean {
-  return ast.predicates.some((predicate) =>
-    hasFulltextMatchInExpression(predicate.expression),
-  );
-}
-
-function hasFulltextMatchInExpression(
-  expr: QueryAst["predicates"][0]["expression"],
-): boolean {
-  if ("__type" in expr) {
-    switch (expr.__type) {
-      case "and":
-      case "or": {
-        return expr.predicates.some((p) => hasFulltextMatchInExpression(p));
-      }
-      case "not": {
-        return hasFulltextMatchInExpression(expr.predicate);
-      }
-      case "fulltext_match": {
-        return true;
-      }
-      case "exists":
-      case "in_subquery":
-      case "comparison":
-      case "string_op":
-      case "null_check":
-      case "between":
-      case "array_op":
-      case "object_op":
-      case "aggregate_comparison":
-      case "vector_similarity": {
-        return false;
-      }
-    }
-  }
-  return false;
-}
-
-/**
- * Checks if a query AST has predicates with subqueries (EXISTS/IN with subquery).
- */
-function hasSubqueryPredicates(ast: QueryAst): boolean {
-  return ast.predicates.some((predicate) =>
-    hasSubqueryInExpression(predicate.expression),
-  );
-}
-
-/**
- * Recursively checks if a predicate expression contains subqueries.
- */
-function hasSubqueryInExpression(
-  expr: QueryAst["predicates"][0]["expression"],
-): boolean {
-  if ("__type" in expr) {
-    switch (expr.__type) {
-      case "and":
-      case "or": {
-        return expr.predicates.some((p) => hasSubqueryInExpression(p));
-      }
-      case "not": {
-        return hasSubqueryInExpression(expr.predicate);
-      }
-      case "exists": {
-        return true; // EXISTS always has a subquery
-      }
-      case "in_subquery": {
-        return true; // IN with subquery
-      }
-      // These expression types don't contain subqueries
-      case "comparison":
-      case "string_op":
-      case "null_check":
-      case "between":
-      case "array_op":
-      case "object_op":
-      case "aggregate_comparison":
-      case "vector_similarity":
-      case "fulltext_match": {
-        return false;
-      }
-    }
-  }
-  return false;
-}
-
-/**
- * Recursively collects all leaf QueryAst nodes from a set operation tree.
- * Assigns unique prefixes to each leaf (q0, q1, q2, etc.).
- */
-function collectLeafQueries(
-  query: ComposableQuery,
-  leaves: SqliteSetOperationLeaf[],
-  basePrefix: string,
-): void {
-  if ("__type" in query) {
-    // This is a SetOperation, recurse
-    collectLeafQueries(query.left, leaves, basePrefix);
-    collectLeafQueries(query.right, leaves, basePrefix);
-  } else {
-    // This is a QueryAst leaf
-    const index = leaves.length;
-    leaves.push({ ast: query, prefix: `${basePrefix}${index}` });
-  }
-}
-
-/**
- * Compiles a CTE for the start node selection with a unique prefix.
- */
-function compilePrefixedStartCte(
-  ast: QueryAst,
-  prefix: string,
-  graphId: string,
-  ctx: PredicateCompilerContext,
-): SQL {
-  const temporalFilterPass = createTemporalFilterPass(
-    ast,
-    ctx.dialect.currentTimestamp(),
-  );
-  const alias = ast.start.alias;
-  const kinds = ast.start.kinds;
-
-  // Kind filter
-  const kindFilter =
-    kinds.length === 1 ?
-      sql`kind = ${kinds[0]}`
-    : sql`kind IN (${sql.join(
-        kinds.map((k) => sql`${k}`),
-        sql`, `,
-      )})`;
-
-  // Temporal filter
-  const temporalFilter = temporalFilterPass.forAlias();
-
-  // Node predicates for this alias
-  const cteContext: PredicateCompilerContext = { ...ctx, cteColumnPrefix: "" };
-  const predicateClauses = ast.predicates
-    .filter((p) => p.targetAlias === alias)
-    .map((p) => compilePredicateExpression(p.expression, cteContext));
-
-  // Combine all WHERE clauses
-  const whereClauses = [
-    sql`graph_id = ${graphId}`,
-    kindFilter,
-    temporalFilter,
-    ...predicateClauses,
-  ];
-
-  // Use prefixed CTE name: cte_q0_c, cte_q1_c, etc.
-  const cteName = `cte_${prefix}_${alias}`;
-
-  return sql`
-    ${sql.raw(cteName)} AS (
-      SELECT
-        id AS ${sql.raw(alias)}_id,
-        kind AS ${sql.raw(alias)}_kind,
-        props AS ${sql.raw(alias)}_props,
-        version AS ${sql.raw(alias)}_version,
-        valid_from AS ${sql.raw(alias)}_valid_from,
-        valid_to AS ${sql.raw(alias)}_valid_to,
-        created_at AS ${sql.raw(alias)}_created_at,
-        updated_at AS ${sql.raw(alias)}_updated_at,
-        deleted_at AS ${sql.raw(alias)}_deleted_at
-      FROM ${ctx.schema.nodesTable}
-      WHERE ${sql.join(whereClauses, sql` AND `)}
-    )
-  `;
-}
-
-/**
- * Compiles the SELECT statement for a leaf query using the prefixed CTE.
- */
-function compilePrefixedSelect(
-  ast: QueryAst,
-  prefix: string,
-  dialect: DialectAdapter,
-): SQL {
-  const alias = ast.start.alias;
-  const cteName = `cte_${prefix}_${alias}`;
-  const fields = ast.projection.fields;
-
-  // Build projection
-  const projection =
-    fields.length === 0 ?
-      sql.raw("*")
-    : sql.join(
-        fields.map((f) => {
-          const source = compileFieldValueForSetOp(
-            f.source,
-            prefix,
-            alias,
-            dialect,
-          );
-          return sql`${source} AS ${sql.raw(dialect.quoteIdentifier(f.outputName))}`;
-        }),
-        sql`, `,
-      );
-
-  return sql`SELECT ${projection} FROM ${sql.raw(cteName)}`;
-}
-
-/**
- * Compiles a field value reference for set operation queries.
- */
-function compileFieldValueForSetOp(
-  source: QueryAst["projection"]["fields"][0]["source"],
-  prefix: string,
-  alias: string,
-  dialect: DialectAdapter,
-): SQL {
-  if ("__type" in source && source.__type === "aggregate") {
-    // Aggregate expressions
-    const { field, function: fn } = source;
-
-    switch (fn) {
-      case "count":
-      case "countDistinct":
-      case "sum":
-      case "avg":
-      case "min":
-      case "max": {
-        const column = compileFieldColumnForSetOp(field, prefix, dialect);
-        if (fn === "countDistinct") {
-          return sql`COUNT(DISTINCT ${column})`;
-        }
-        return sql`${sql.raw(fn.toUpperCase())}(${column})`;
-      }
-      default: {
-        throw new CompilerInvariantError(
-          `Unknown aggregate function: ${String(fn)}`,
-        );
-      }
-    }
-  }
-
-  // Field reference
-  return compileFieldColumnForSetOp(source, prefix, dialect);
-}
-
-/**
- * Compiles a field column reference for set operation queries.
- */
-function compileFieldColumnForSetOp(
-  field: {
-    alias: string;
-    path: readonly string[];
-    jsonPointer?: JsonPointer | undefined;
-    valueType?: string | undefined;
-  },
-  prefix: string,
-  dialect: DialectAdapter,
-): SQL {
-  const cteName = `cte_${prefix}_${field.alias}`;
-  const alias = field.alias;
-
-  // Handle direct column references
-  if (field.path.length === 1) {
-    const columnName = field.path[0];
-    // Map path names to column names
-    const columnMap: Record<string, string> = {
-      id: "_id",
-      kind: "_kind",
-      props: "_props",
-      version: "_version",
-      valid_from: "_valid_from",
-      valid_to: "_valid_to",
-      created_at: "_created_at",
-      updated_at: "_updated_at",
-      deleted_at: "_deleted_at",
-    };
-    if (columnName === undefined) return sql.raw(`${cteName}.${alias}_props`);
-    const suffix = columnMap[columnName];
-    if (suffix) {
-      return sql.raw(`${cteName}.${alias}${suffix}`);
-    }
-  }
-
-  // JSON field (path starts with "props" and has a json pointer)
-  const column = sql.raw(`${cteName}.${alias}_props`);
-  const pointer = field.jsonPointer;
-
-  if (!pointer) {
-    return column;
-  }
-
-  return compileTypedJsonExtract({
-    column,
-    dialect,
-    fallback: "text",
-    pointer,
-    valueType: field.valueType,
-  });
-}
-
-/**
- * Builds the compound SELECT statement from the set operation structure.
- */
-function buildCompoundSelect(
-  op: SetOperation,
-  leaves: readonly SqliteSetOperationLeaf[],
-  selectStatements: readonly SQL[],
-): SQL {
-  // Build a map from prefix to select statement
-  const prefixToSelect = new Map<string, SQL>();
-  for (const [index, leaf] of leaves.entries()) {
-    prefixToSelect.set(leaf.prefix, selectStatements[index]!);
-  }
-
-  // Recursively build compound select
-  return buildCompoundSelectRecursive(op, leaves, prefixToSelect);
-}
-
-/**
- * Recursively builds compound SELECT with proper operator placement.
- */
-function buildCompoundSelectRecursive(
-  query: ComposableQuery,
-  leaves: readonly SqliteSetOperationLeaf[],
-  prefixToSelect: Map<string, SQL>,
-): SQL {
-  if (!("__type" in query)) {
-    // This is a leaf QueryAst - find its prefix and return the SELECT
-    const leaf = leaves.find((l) => l.ast === query);
-    if (!leaf) {
-      throw new CompilerInvariantError("Leaf query not found in leaves array");
-    }
-    return prefixToSelect.get(leaf.prefix)!;
-  }
-
-  // This is a SetOperation
-  const left = buildCompoundSelectRecursive(query.left, leaves, prefixToSelect);
-  const right = buildCompoundSelectRecursive(
-    query.right,
-    leaves,
-    prefixToSelect,
-  );
-  const opSql = sql.raw(OPERATOR_MAP[query.operator]);
-
-  return sql`${left} ${opSql} ${right}`;
+  if (suffixClauses.length === 0) return core;
+  return sql.join([core, ...suffixClauses], sql` `);
 }
 
 // ============================================================
-// Shared Utilities
+// Suffix Clauses (ORDER BY / LIMIT / OFFSET)
 // ============================================================
 
 /**

--- a/packages/typegraph/src/query/dialect/index.ts
+++ b/packages/typegraph/src/query/dialect/index.ts
@@ -18,7 +18,6 @@ export type {
   DialectAdapter,
   DialectCapabilities,
   DialectRecursiveQueryStrategy,
-  DialectSetOperationStrategy,
   DialectStandardQueryStrategy,
   DialectVectorPredicateStrategy,
   SqlDialect,

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -57,7 +57,6 @@ export const postgresDialect: DialectAdapter = {
   capabilities: {
     standardQueryStrategy: "cte_project",
     recursiveQueryStrategy: "recursive_cte",
-    setOperationStrategy: "standard_parenthesized",
     materializeIntermediateTraversalCtes: false,
     emitNotMaterializedHint: true,
     forceRecursiveWorktableOuterJoinOrder: false,
@@ -169,6 +168,16 @@ export const postgresDialect: DialectAdapter = {
   ilike(column, pattern) {
     // PostgreSQL has native ILIKE operator
     return sql`${column} ILIKE ${pattern}`;
+  },
+
+  // ============================================================
+  // Set Operations
+  // ============================================================
+
+  wrapSetOperationOperand(inner) {
+    // PostgreSQL allows a complete SELECT (incl. its own WITH) as a
+    // parenthesized compound operand.
+    return sql`(${inner})`;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -61,7 +61,6 @@ export const sqliteDialect: DialectAdapter = {
   capabilities: {
     standardQueryStrategy: "cte_project",
     recursiveQueryStrategy: "recursive_cte",
-    setOperationStrategy: "sqlite_compound",
     materializeIntermediateTraversalCtes: true,
     emitNotMaterializedHint: false,
     forceRecursiveWorktableOuterJoinOrder: true,
@@ -175,6 +174,16 @@ export const sqliteDialect: DialectAdapter = {
     // SQLite LIKE is case-insensitive for ASCII by default, but we use
     // LOWER() for consistency with non-ASCII characters
     return sql`LOWER(${column}) LIKE LOWER(${pattern})`;
+  },
+
+  // ============================================================
+  // Set Operations
+  // ============================================================
+
+  wrapSetOperationOperand(inner) {
+    // SQLite forbids parenthesized compound operands, but a FROM-subquery may
+    // carry its own WITH clause, so wrap each operand as a subquery.
+    return sql`SELECT * FROM (${inner})`;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -17,13 +17,6 @@ import { type FulltextStrategy } from "./fulltext-strategy";
 export type SqlDialect = "sqlite" | "postgres";
 
 /**
- * Strategy for compiling set operations.
- */
-export type DialectSetOperationStrategy =
-  | "standard_parenthesized"
-  | "sqlite_compound";
-
-/**
  * Strategy for compiling standard (non-recursive, non-set-op) queries.
  */
 export type DialectStandardQueryStrategy = "cte_project";
@@ -51,11 +44,6 @@ export type DialectCapabilities = Readonly<{
    * Recursive query compilation strategy.
    */
   recursiveQueryStrategy: DialectRecursiveQueryStrategy;
-
-  /**
-   * Set operation compilation strategy.
-   */
-  setOperationStrategy: DialectSetOperationStrategy;
 
   /**
    * Whether intermediate traversal CTEs should be materialized.
@@ -253,6 +241,23 @@ export interface DialectAdapter {
    * PostgreSQL: column ILIKE pattern
    */
   ilike(column: SQL, pattern: SQL | string): SQL;
+
+  // ============================================================
+  // Set Operations
+  // ============================================================
+
+  /**
+   * Wraps a single operand of a compound SELECT (UNION/INTERSECT/EXCEPT) so it
+   * is a valid compound member for this dialect. The inner SQL is a complete
+   * leaf SELECT (which may carry its own WITH clause) or an already-combined
+   * nested compound.
+   *
+   * @example
+   * SQLite: SELECT * FROM (inner)   // parenthesized operands are forbidden,
+   *                                 // but a WITH may live in a FROM-subquery
+   * PostgreSQL: (inner)
+   */
+  wrapSetOperationOperand(inner: SQL): SQL;
 
   // ============================================================
   // Recursive CTE Path Operations

--- a/packages/typegraph/tests/backends/differential-parity.test.ts
+++ b/packages/typegraph/tests/backends/differential-parity.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Differential backend-parity harness.
+ *
+ * The strongest guarantee that a query behaves identically across backends: run
+ * the SAME query against BOTH a SQLite store and an (in-process, WASM)
+ * PostgreSQL/PGlite store seeded with identical data, and assert the results
+ * match. This is the net that catches semantic divergence the type system and
+ * the `dialect.name` lint cannot see — it would have flagged the set-operation
+ * gap instantly (SQLite threw, PostgreSQL returned rows).
+ *
+ * Scope: the PORTABLE query surface that MUST be identical — predicates,
+ * ordering (incl. NULL placement), aggregates, traversals, recursion, set
+ * operations, and pagination. Vector and fulltext are deliberately excluded:
+ * they have *declared* engine gaps (see the capability matrix in
+ * `backend-setup.md`), so identical behavior is not expected and is covered by
+ * their own backend-specific tests.
+ *
+ * Comparison rules:
+ * - Queries project business fields (names, prices, …), never generated ids, so
+ *   the per-backend id nondeterminism is irrelevant.
+ * - Results are compared as multisets unless the case declares a total order.
+ * - Values are normalized: floats are rounded, and numeric-looking strings
+ *   (PostgreSQL numeric/decimal can arrive as a string) are coerced to numbers.
+ *   This is safe because no business field in the seed is a numeric-looking
+ *   string.
+ *
+ * Runs in the default `pnpm test` lane: SQLite via better-sqlite3, PostgreSQL
+ * via PGlite (Postgres-in-WASM) — no Docker.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { avg, count, createStoreWithSchema, field, sum } from "../../src";
+import { createSqliteBackend } from "../../src/backend/sqlite";
+import { createLocalSqliteBackend } from "../../src/backend/sqlite/local";
+import { type IntegrationStore, integrationTestGraph } from "./integration";
+import {
+  setupSharedPgliteEngine,
+  type SharedPgliteEngine,
+} from "./postgres/pglite-correctness-harness";
+
+// ============================================================
+// Seed — identical structure on both backends
+// ============================================================
+
+async function seedParityCorpus(store: IntegrationStore): Promise<void> {
+  const tech = await store.nodes.Company.create({
+    name: "TechCorp",
+    industry: "Tech",
+  });
+  await store.nodes.Company.create({ name: "DataInc", industry: "Tech" });
+  const bio = await store.nodes.Company.create({
+    name: "BioMed",
+    industry: "Healthcare",
+  });
+  await store.nodes.Company.create({
+    name: "HealthFirst",
+    industry: "Healthcare",
+  });
+  const finance = await store.nodes.Company.create({
+    name: "FinanceHub",
+    industry: "Finance",
+  });
+
+  const alice = await store.nodes.Person.create({ name: "Alice", age: 30 });
+  const bob = await store.nodes.Person.create({ name: "Bob", age: 25 });
+  const charlie = await store.nodes.Person.create({ name: "Charlie" }); // age null
+  const diana = await store.nodes.Person.create({ name: "Diana", age: 40 });
+  const eve = await store.nodes.Person.create({ name: "Eve", age: 25 });
+
+  await store.edges.worksAt.create(alice, tech, {
+    role: "Engineer",
+    salary: 100_000,
+  });
+  await store.edges.worksAt.create(bob, finance, {
+    role: "Analyst",
+    salary: 80_000,
+  });
+  await store.edges.worksAt.create(diana, bio, { role: "Researcher" }); // null salary
+
+  // knows chain: Alice → Bob → Charlie → Diana → Eve, plus a direct Alice → Charlie.
+  await store.edges.knows.create(alice, bob, { since: "2020" });
+  await store.edges.knows.create(bob, charlie, { since: "2021" });
+  await store.edges.knows.create(charlie, diana, { since: "2022" });
+  await store.edges.knows.create(diana, eve, { since: "2023" });
+  await store.edges.knows.create(alice, charlie, { since: "2019" });
+
+  await store.nodes.Product.create({
+    name: "Laptop",
+    price: 1200,
+    category: "Electronics",
+  });
+  await store.nodes.Product.create({
+    name: "Mouse",
+    price: 25,
+    category: "Electronics",
+  });
+  await store.nodes.Product.create({
+    name: "Monitor",
+    price: 300,
+    category: "Electronics",
+  });
+  await store.nodes.Product.create({
+    name: "Desk",
+    price: 450,
+    category: "Furniture",
+  });
+  await store.nodes.Product.create({
+    name: "Chair",
+    price: 150,
+    category: "Furniture",
+  });
+}
+
+// ============================================================
+// Corpus — read-only queries over the portable surface
+// ============================================================
+
+type ParityCase = Readonly<{
+  name: string;
+  run: (store: IntegrationStore) => Promise<readonly unknown[]>;
+  /** Compare results in order (the query has a total order). Default: multiset. */
+  ordered?: boolean;
+}>;
+
+const CASES: readonly ParityCase[] = [
+  {
+    name: "predicate: eq on number",
+    run: (store) =>
+      store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.age.eq(25))
+        .select((ctx) => ctx.p.name)
+        .execute(),
+  },
+  {
+    name: "predicate: gt",
+    run: (store) =>
+      store
+        .query()
+        .from("Product", "p")
+        .whereNode("p", (p) => p.price.gt(100))
+        .select((ctx) => ctx.p.name)
+        .execute(),
+  },
+  {
+    name: "predicate: in",
+    run: (store) =>
+      store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.in(["Tech", "Finance"]))
+        .select((ctx) => ctx.c.name)
+        .execute(),
+  },
+  {
+    name: "predicate: isNull",
+    run: (store) =>
+      store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.age.isNull())
+        .select((ctx) => ctx.p.name)
+        .execute(),
+  },
+  {
+    name: "predicate: between",
+    run: (store) =>
+      store
+        .query()
+        .from("Product", "p")
+        .whereNode("p", (p) => p.price.between(100, 500))
+        .select((ctx) => ctx.p.name)
+        .execute(),
+  },
+  {
+    name: "ordering: age asc, NULLS placement (name tiebreaker)",
+    ordered: true,
+    run: (store) =>
+      store
+        .query()
+        .from("Person", "p")
+        .orderBy("p", "age", "asc")
+        .orderBy("p", "name", "asc")
+        .select((ctx) => ({ name: ctx.p.name, age: ctx.p.age }))
+        .execute(),
+  },
+  {
+    name: "ordering: name desc",
+    ordered: true,
+    run: (store) =>
+      store
+        .query()
+        .from("Product", "p")
+        .orderBy("p", "name", "desc")
+        .select((ctx) => ctx.p.name)
+        .execute(),
+  },
+  {
+    name: "aggregate: groupBy count",
+    run: (store) =>
+      store
+        .query()
+        .from("Company", "c")
+        .groupBy("c", "industry")
+        .aggregate({ industry: field("c", "industry"), n: count("c") })
+        .execute(),
+  },
+  {
+    name: "aggregate: sum + avg by category",
+    run: (store) =>
+      store
+        .query()
+        .from("Product", "p")
+        .groupBy("p", "category")
+        .aggregate({
+          category: field("p", "category"),
+          total: sum("p", "price"),
+          mean: avg("p", "price"),
+        })
+        .execute(),
+  },
+  {
+    name: "traversal: worksAt filtered by industry",
+    run: (store) =>
+      store
+        .query()
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .select((ctx) => ctx.p.name)
+        .execute(),
+  },
+  {
+    name: "traversal: optional (LEFT JOIN)",
+    run: (store) =>
+      store
+        .query()
+        .from("Person", "p")
+        .optionalTraverse("worksAt", "e")
+        .to("Company", "c")
+        .select((ctx) => ({ person: ctx.p.name, company: ctx.c?.name }))
+        .execute(),
+  },
+  {
+    name: "recursive: knows reachability from Alice (unlimited)",
+    run: (store) =>
+      store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.eq("Alice"))
+        .traverse("knows", "e")
+        .recursive()
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.name)
+        .execute(),
+  },
+  {
+    name: "recursive: knows reachability from Alice (maxHops 2)",
+    run: (store) =>
+      store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.eq("Alice"))
+        .traverse("knows", "e")
+        .recursive({ maxHops: 2 })
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.name)
+        .execute(),
+  },
+  {
+    name: "set op: union",
+    run: (store) => {
+      const tech = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .select((ctx) => ctx.c.name);
+      const healthcare = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Healthcare"))
+        .select((ctx) => ctx.c.name);
+      return tech.union(healthcare).execute();
+    },
+  },
+  {
+    name: "set op: intersect",
+    run: (store) => {
+      const all = store
+        .query()
+        .from("Company", "c")
+        .select((ctx) => ctx.c.name);
+      const tech = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .select((ctx) => ctx.c.name);
+      return all.intersect(tech).execute();
+    },
+  },
+  {
+    name: "set op: except",
+    run: (store) => {
+      const all = store
+        .query()
+        .from("Company", "c")
+        .select((ctx) => ctx.c.name);
+      const tech = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .select((ctx) => ctx.c.name);
+      return all.except(tech).execute();
+    },
+  },
+  {
+    // The exact shape that used to throw on SQLite while running on Postgres.
+    name: "set op: union of traversal-filtered queries",
+    run: (store) => {
+      const techWorkers = store
+        .query()
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .select((ctx) => ctx.p.name);
+      const financeWorkers = store
+        .query()
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Finance"))
+        .select((ctx) => ctx.p.name);
+      return techWorkers.union(financeWorkers).execute();
+    },
+  },
+  {
+    name: "set op: union with per-leaf ORDER BY + LIMIT",
+    run: (store) => {
+      const topTech = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .orderBy("c", "name", "asc")
+        .limit(1)
+        .select((ctx) => ctx.c.name);
+      const topHealth = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Healthcare"))
+        .orderBy("c", "name", "asc")
+        .limit(1)
+        .select((ctx) => ctx.c.name);
+      return topTech.union(topHealth).execute();
+    },
+  },
+  {
+    name: "pagination: ORDER BY price, LIMIT 2 OFFSET 1",
+    ordered: true,
+    run: (store) =>
+      store
+        .query()
+        .from("Product", "p")
+        .orderBy("p", "price", "asc")
+        .limit(2)
+        .offset(1)
+        .select((ctx) => ctx.p.name)
+        .execute(),
+  },
+];
+
+// ============================================================
+// Comparison
+// ============================================================
+
+/** Canonical stand-in for SQL NULL / `undefined`, so the two normalize equally. */
+const NULL_SENTINEL = "∅";
+
+function roundFloat(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (value === undefined || value === null) return NULL_SENTINEL;
+  if (typeof value === "number") return roundFloat(value);
+  // PostgreSQL numeric/decimal can come back as a string; SQLite returns a JS
+  // number. Coerce so aggregate parity (sum/avg/count) survives the driver
+  // difference. Skip leading-zero strings (e.g. a "00123" code) — those are
+  // never numeric-aggregate output, and coercing them could collide a string
+  // field with a real number and mask a divergence.
+  if (
+    typeof value === "string" &&
+    /^-?\d+(\.\d+)?$/.test(value) &&
+    !/^-?0\d/.test(value)
+  ) {
+    return roundFloat(Number(value));
+  }
+  if (Array.isArray(value)) {
+    return value.map((element) => normalizeValue(element));
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const normalized: Record<string, unknown> = {};
+    for (const key of Object.keys(record).toSorted()) {
+      normalized[key] = normalizeValue(record[key]);
+    }
+    return normalized;
+  }
+  return value;
+}
+
+function canonical(rows: readonly unknown[]): string[] {
+  return rows.map((row) => JSON.stringify(normalizeValue(row)));
+}
+
+// ============================================================
+// Suite
+// ============================================================
+
+describe("Differential backend parity (SQLite vs PGlite)", () => {
+  let sqliteStore: IntegrationStore;
+  let pgStore: IntegrationStore;
+  let engine: SharedPgliteEngine;
+
+  beforeAll(async () => {
+    const { db } = createLocalSqliteBackend();
+    [sqliteStore] = await createStoreWithSchema(
+      integrationTestGraph,
+      createSqliteBackend(db),
+    );
+
+    engine = await setupSharedPgliteEngine();
+    [pgStore] = await createStoreWithSchema(
+      integrationTestGraph,
+      engine.makeBackend(),
+    );
+
+    // Independent stores — seed concurrently.
+    await Promise.all([
+      seedParityCorpus(sqliteStore),
+      seedParityCorpus(pgStore),
+    ]);
+  });
+
+  afterAll(async () => {
+    await engine.dispose();
+  });
+
+  for (const parityCase of CASES) {
+    it(`agrees across backends — ${parityCase.name}`, async () => {
+      const [sqliteRows, pgRows] = await Promise.all([
+        parityCase.run(sqliteStore),
+        parityCase.run(pgStore),
+      ]);
+
+      // The corpus is intentionally all-non-empty: a result that is empty on
+      // either backend signals a seed/query mistake (and an empty-on-both case
+      // would otherwise pass vacuously). Check both backends, not just one.
+      expect(sqliteRows.length).toBeGreaterThan(0);
+      expect(pgRows.length).toBeGreaterThan(0);
+
+      // Compare in order when the query has a total order; otherwise as a
+      // multiset (unordered queries may return rows in any order).
+      const sqliteCanonical = canonical(sqliteRows);
+      const pgCanonical = canonical(pgRows);
+      const [expected, actual] =
+        parityCase.ordered ?
+          [sqliteCanonical, pgCanonical]
+        : [sqliteCanonical.toSorted(), pgCanonical.toSorted()];
+
+      expect(actual).toEqual(expected);
+    });
+  }
+});

--- a/packages/typegraph/tests/backends/integration/set-operations.ts
+++ b/packages/typegraph/tests/backends/integration/set-operations.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { seedCompaniesForSetOperations } from "./seed-helpers";
+import {
+  seedCompaniesForSetOperations,
+  seedPeopleCompaniesForOptionalTraversals,
+} from "./seed-helpers";
 import { type IntegrationTestContext } from "./test-context";
 
 export function registerSetOperationIntegrationTests(
@@ -209,6 +212,118 @@ export function registerSetOperationIntegrationTests(
       const results = await techCompanies.intersect(financeCompanies).execute();
 
       expect(results).toHaveLength(0);
+    });
+
+    it("applies per-leaf ORDER BY and LIMIT before combining", async () => {
+      const store = context.getStore();
+      // Top Tech company by name (DataInc < TechCorp)
+      const topTech = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .orderBy("c", "name", "asc")
+        .limit(1)
+        .select((ctx) => ctx.c.name);
+
+      // Top Healthcare company by name (BioMed < HealthFirst)
+      const topHealth = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Healthcare"))
+        .orderBy("c", "name", "asc")
+        .limit(1)
+        .select((ctx) => ctx.c.name);
+
+      const results = await topTech.union(topHealth).execute();
+
+      // Each leaf's ORDER BY/LIMIT applies inside its own operand subquery.
+      expect(results.toSorted()).toEqual(["BioMed", "DataInc"]);
+    });
+
+    it("applies LIMIT/OFFSET on a nested set-operation operand", async () => {
+      const store = context.getStore();
+      const techCorp = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.name.eq("TechCorp"))
+        .select((ctx) => ctx.c.name);
+      const dataInc = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.name.eq("DataInc"))
+        .select((ctx) => ctx.c.name);
+      const bioMed = store
+        .query()
+        .from("Company", "c")
+        .whereNode("c", (c) => c.name.eq("BioMed"))
+        .select((ctx) => ctx.c.name);
+
+      // Inner union = {TechCorp, DataInc}; OFFSET 2 drops both → empty; then
+      // UNION BioMed → {BioMed}. If the nested operand's LIMIT/OFFSET were
+      // dropped, the result would wrongly include TechCorp and DataInc.
+      const results = await techCorp
+        .union(dataInc)
+        .limit(10)
+        .offset(2)
+        .union(bioMed)
+        .execute();
+
+      expect(results.toSorted()).toEqual(["BioMed"]);
+    });
+  });
+
+  describe("Set Operations with traversal leaves", () => {
+    beforeEach(async () => {
+      const store = context.getStore();
+      await seedPeopleCompaniesForOptionalTraversals(store);
+    });
+
+    it("unions traversal-filtered queries", async () => {
+      const store = context.getStore();
+      // Alice works at Acme (Tech)
+      const techWorkers = store
+        .query()
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .select((ctx) => ctx.p.name);
+
+      // Bob works at Globex (Finance)
+      const financeWorkers = store
+        .query()
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Finance"))
+        .select((ctx) => ctx.p.name);
+
+      const results = await techWorkers.union(financeWorkers).execute();
+
+      // Traversal CTEs are scoped inside each operand subquery.
+      expect(results.toSorted()).toEqual(["Alice", "Bob"]);
+    });
+
+    it("intersects traversal-filtered queries", async () => {
+      const store = context.getStore();
+      const allWorkers = store
+        .query()
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .select((ctx) => ctx.p.name);
+
+      const techWorkers = store
+        .query()
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .whereNode("c", (c) => c.industry.eq("Tech"))
+        .select((ctx) => ctx.p.name);
+
+      const results = await allWorkers.intersect(techWorkers).execute();
+
+      expect(results.toSorted()).toEqual(["Alice"]);
     });
   });
 }

--- a/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
@@ -77,8 +77,6 @@ describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () =
     // and refuses with a typed ConfigurationError on this backend.
     expect(backend.capabilities.transactions).toBe(false);
     // Other capabilities are unchanged.
-    expect(backend.capabilities.cte).toBe(true);
-    expect(backend.capabilities.jsonb).toBe(true);
     expect(backend.capabilities.vector?.supported).toBe(true);
   });
 

--- a/packages/typegraph/tests/backends/postgres/neon-serverless-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-serverless-smoke.test.ts
@@ -42,8 +42,6 @@ describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless", () => {
     const backend = createPostgresBackend(db);
 
     expect(backend.dialect).toBe("postgres");
-    expect(backend.capabilities.cte).toBe(true);
-    expect(backend.capabilities.jsonb).toBe(true);
     // Vector / pgvector capability is declared at backend-construction
     // time and doesn't depend on a live connection. It's the same on
     // every PostgreSQL driver we support.

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -342,10 +342,7 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
       const backend = createPostgresBackend(db);
 
       expect(backend.dialect).toBe("postgres");
-      expect(backend.capabilities.cte).toBe(true);
-      expect(backend.capabilities.returning).toBe(true);
-      expect(backend.capabilities.jsonb).toBe(true);
-      expect(backend.capabilities.ginIndexes).toBe(true);
+      expect(backend.capabilities.transactions).toBe(true);
     });
 
     it("runs non-vector CRUD with vector disabled (vector: false)", async (ctx) => {

--- a/packages/typegraph/tests/backends/postgres/postgres-disable-vector.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-disable-vector.test.ts
@@ -65,6 +65,5 @@ describe("createPostgresBackend({ vector: false })", () => {
     // Disabling vector must not disturb the rest of the capability surface.
     expect(backend.capabilities.transactions).toBe(true);
     expect(backend.capabilities.fulltext?.supported).toBe(true);
-    expect(backend.capabilities.jsonb).toBe(true);
   });
 });

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -76,10 +76,7 @@ describe("SQLite Backend - Adapter Specific", () => {
       const backend = createSqliteBackend(db);
 
       expect(backend.dialect).toBe("sqlite");
-      expect(backend.capabilities.cte).toBe(true);
-      expect(backend.capabilities.returning).toBe(true);
-      expect(backend.capabilities.jsonb).toBe(false);
-      expect(backend.capabilities.ginIndexes).toBe(false);
+      expect(backend.capabilities.transactions).toBe(true);
     });
 
     it("reuses prepared statements in execute() for repeated SQL shapes", async () => {

--- a/packages/typegraph/tests/logical-plan.test.ts
+++ b/packages/typegraph/tests/logical-plan.test.ts
@@ -13,6 +13,8 @@ import {
   lowerSetOperationToLogicalPlan,
   lowerStandardQueryToLogicalPlan,
 } from "../src/query/compiler";
+import { sqliteVecStrategy } from "../src/query/dialect/vector/sqlite-vec-strategy";
+import { type VectorStrategy } from "../src/query/dialect/vector-strategy";
 import { jsonPointer } from "../src/query/json-pointer";
 
 function createIdField(alias: string): FieldRef {
@@ -82,6 +84,53 @@ function createBaseAst(extra: Partial<QueryAst> = {}): QueryAst {
 }
 
 describe("logical plan lowering", () => {
+  it("validates a set-op leaf's vector metric against the configured strategy", () => {
+    const vectorPredicate: VectorSimilarityPredicate = {
+      __type: "vector_similarity",
+      field: {
+        __type: "field_ref",
+        alias: "p",
+        jsonPointer: jsonPointer(["embedding"]),
+        path: ["props", "embedding"],
+        valueType: "embedding",
+      },
+      limit: 8,
+      metric: "inner_product",
+      queryEmbedding: [0.1, 0.2, 0.3],
+    };
+    const op: SetOperation = {
+      __type: "set_operation",
+      left: createBaseAst({
+        predicates: [{ expression: vectorPredicate, targetAlias: "p" }],
+      }),
+      operator: "union",
+      right: createBaseAst(),
+    };
+
+    // SQLite's dialect fallback metric list is cosine/l2, so without a strategy
+    // the inner_product leaf is rejected.
+    expect(() =>
+      lowerSetOperationToLogicalPlan({ dialect: "sqlite", graphId: "g", op }),
+    ).toThrow(/inner_product.*not supported for dialect "sqlite"/);
+
+    // A configured strategy advertising inner_product is honored.
+    const innerProductStrategy: VectorStrategy = {
+      ...sqliteVecStrategy,
+      capabilities: {
+        ...sqliteVecStrategy.capabilities,
+        metrics: ["cosine", "l2", "inner_product"],
+      },
+    };
+    expect(() =>
+      lowerSetOperationToLogicalPlan({
+        dialect: "sqlite",
+        graphId: "g",
+        op,
+        vectorStrategy: innerProductStrategy,
+      }),
+    ).not.toThrow();
+  });
+
   it("lowers simple query into scan/filter/project pipeline", () => {
     const predicateExpression: PredicateExpression = {
       __type: "comparison",

--- a/packages/typegraph/tests/matches-predicate.test.ts
+++ b/packages/typegraph/tests/matches-predicate.test.ts
@@ -145,6 +145,22 @@ describe(".matches() predicate", () => {
     );
   });
 
+  it("rejects a per-query language override on a strategy that does not honor it", async () => {
+    // FTS5's tokenizer is fixed at table-create time, so a per-query `language`
+    // override is rejected on SQLite — matching the store-level search guard.
+    const query = store
+      .query()
+      .from("Document", "d")
+      .whereNode("d", (d) =>
+        d.$fulltext.matches("climate", 10, { language: "french" }),
+      )
+      .select((ctx) => ctx.d);
+
+    await expect(query.execute()).rejects.toThrow(
+      /does not honor a per-query `language` override/,
+    );
+  });
+
   it("enforces the top-k limit from the matches() call", async () => {
     for (let index = 0; index < 5; index += 1) {
       await store.nodes.Document.create({

--- a/packages/typegraph/tests/set-operations-compiler.test.ts
+++ b/packages/typegraph/tests/set-operations-compiler.test.ts
@@ -12,7 +12,6 @@ import {
   type QueryAst,
   type SetOperation,
 } from "../src/query/ast";
-import { DEFAULT_SQL_SCHEMA } from "../src/query/compiler/schema";
 import {
   compileSetOperation,
   type QueryCompilerFunction,
@@ -100,6 +99,11 @@ function mockCompileQuery(ast: QueryAst, _graphId: string): SQL {
   return sql`SELECT * FROM ${sql.raw(ast.start.alias)}`;
 }
 
+function taggedCompileQuery(ast: QueryAst, _graphId: string): SQL {
+  // Tags each leaf so we can assert the set-op compiler delegated to it.
+  return sql`SELECT 'leaf:' || ${sql.raw(ast.start.alias)}`;
+}
+
 function getSqlString(
   op: SetOperation,
   compileQuery: QueryCompilerFunction = mockCompileQuery,
@@ -108,7 +112,6 @@ function getSqlString(
     op,
     "test-graph",
     sqliteDialect,
-    DEFAULT_SQL_SCHEMA,
     compileQuery,
   );
   return toSqlString(result);
@@ -153,18 +156,19 @@ describe("compileSetOperation", () => {
       expect(sql).toContain("EXCEPT");
     });
 
-    it("produces correct SQLite format with merged CTEs", () => {
+    it("wraps each leaf as a FROM-subquery operand (SQLite compound format)", () => {
       const op = createSetOperation("union");
 
       const sql = getSqlString(op);
 
-      // SQLite uses merged CTEs: WITH cte1 AS (...), cte2 AS (...) SELECT ... UNION SELECT ...
-      // No parentheses around individual queries (SQLite doesn't support CTEs in parentheses)
-      expect(sql).toMatch(/WITH\s+cte_q0_a/);
-      expect(sql).toMatch(/cte_q1_b/);
-      expect(sql).toMatch(
-        /SELECT.*FROM\s+cte_q0_a.*UNION.*SELECT.*FROM\s+cte_q1_b/s,
-      );
+      // SQLite forbids parenthesized compound operands, so each leaf (compiled
+      // by the provided compile function) is wrapped as `SELECT * FROM (...)`.
+      // The leaf bodies keep their own CTEs scoped inside the subquery.
+      expect(sql).toMatch(/SELECT \* FROM \(SELECT \* FROM a\)/);
+      expect(sql).toMatch(/UNION/);
+      expect(sql).toMatch(/SELECT \* FROM \(SELECT \* FROM b\)/);
+      // No top-level CTE hoisting / prefixing anymore.
+      expect(sql).not.toContain("cte_q0_a");
     });
   });
 
@@ -219,6 +223,30 @@ describe("compileSetOperation", () => {
       expect(sql).toContain("UNION");
       expect(sql).toContain("INTERSECT");
       expect(sql).toContain("EXCEPT");
+    });
+
+    it("applies a nested operand's own LIMIT/OFFSET inside its subquery", () => {
+      // (a UNION b LIMIT 10 OFFSET 5) INTERSECT c — the inner LIMIT/OFFSET
+      // belong to the inner compound, not the outer statement, and must not be
+      // dropped.
+      const inner: SetOperation = {
+        ...createSetOperation("union", "a", "b"),
+        limit: 10,
+        offset: 5,
+      };
+      const outer: SetOperation = {
+        __type: "set_operation",
+        operator: "intersect",
+        left: inner,
+        right: createMinimalAst("c"),
+      };
+
+      const sql = getSqlString(outer);
+
+      expect(sql).toContain("LIMIT");
+      expect(sql).toContain("OFFSET");
+      // The inner suffix lives inside a wrapped operand, ahead of INTERSECT.
+      expect(sql).toMatch(/LIMIT.*OFFSET.*\)\s*INTERSECT/s);
     });
   });
 
@@ -448,17 +476,17 @@ describe("compileSetOperation", () => {
   // ============================================================
 
   describe("with custom compile function", () => {
-    it("SQLite compilation includes graph_id filtering", () => {
-      // Note: SQLite uses internal compilation (not custom compile function)
-      // to handle CTE merging. The custom compile function is only used
-      // for PostgreSQL which supports CTEs in parentheses.
+    it("delegates leaf compilation to the provided compile function on SQLite", () => {
+      // Both dialects now compile each leaf with the full query compiler.
+      // The leaf compiler owns graph_id filtering, projections, traversals,
+      // etc.; the set-op compiler only combines and wraps the operands.
       const op = createSetOperation("union");
 
-      const sqlString = getSqlString(op);
+      const sqlString = getSqlString(op, taggedCompileQuery);
 
-      // SQLite compiles internally but should still include graph_id filtering
-      expect(sqlString).toContain("graph_id");
-      expect(sqlString).toContain("test-graph");
+      expect(sqlString).toContain("'leaf:'");
+      expect(sqlString).toContain("SELECT * FROM (SELECT 'leaf:' || a)");
+      expect(sqlString).toContain("SELECT * FROM (SELECT 'leaf:' || b)");
     });
   });
 });

--- a/packages/typegraph/tests/set-operations-validation.test.ts
+++ b/packages/typegraph/tests/set-operations-validation.test.ts
@@ -1,8 +1,13 @@
 /**
- * Tests for set operation validation logic.
+ * Tests that SQLite set operations support the same leaf features as
+ * standalone queries.
  *
- * Covers validation of SQLite set operation limitations and
- * predicate detection for subqueries and vector similarity.
+ * SQLite forbids parenthesized compound operands, so each leaf is wrapped as
+ * `SELECT * FROM (<leaf>)`. Because a FROM-subquery may carry its own WITH
+ * clause, every feature that works in a standalone query (traversals,
+ * EXISTS/IN subqueries, GROUP BY/HAVING, and per-leaf ORDER BY/LIMIT/OFFSET)
+ * also works inside a UNION/INTERSECT/EXCEPT leaf. These tests assert the
+ * leaves compile (rather than throw) and are wrapped as subquery operands.
  */
 import { describe, expect, it } from "vitest";
 
@@ -12,7 +17,6 @@ import {
   type SetOperation,
 } from "../src/query/ast";
 import { compileSetOperation } from "../src/query/compiler/index";
-import { jsonPointer } from "../src/query/json-pointer";
 import { toSqlString } from "./sql-test-utils";
 
 // ============================================================
@@ -66,325 +70,185 @@ function compileSqlite(op: SetOperation): string {
 }
 
 // ============================================================
-// SQLite Validation Tests
+// SQLite leaf-feature support
 // ============================================================
 
-describe("SQLite set operation validation", () => {
-  describe("unsupported features", () => {
-    it("rejects queries with traversals", () => {
-      const astWithTraversals = createMinimalAst("a", {
-        traversals: [
-          {
-            edgeKinds: ["knows"],
-            edgeAlias: "e",
-            nodeKinds: ["Person"],
-            nodeAlias: "friend",
-            direction: "out",
-            joinFromAlias: "a",
-            joinEdgeField: "to_id",
-            optional: false,
-          },
-        ],
-      });
+describe("SQLite set operation leaf features", () => {
+  it("wraps each compound operand as a FROM-subquery", () => {
+    const op = createSetOperation();
 
-      const op = createSetOperation(astWithTraversals);
+    const sql = compileSqlite(op);
 
-      expect(() => compileSqlite(op)).toThrow(/traversals/i);
-    });
-
-    it("rejects queries with EXISTS subquery", () => {
-      const existsExpression: PredicateExpression = {
-        __type: "exists",
-        subquery: createMinimalAst("sub"),
-        negated: false,
-      };
-
-      const astWithExists = createMinimalAst("a", {
-        predicates: [
-          {
-            targetAlias: "a",
-            expression: existsExpression,
-          },
-        ],
-      });
-
-      const op = createSetOperation(astWithExists);
-
-      expect(() => compileSqlite(op)).toThrow(/EXISTS\/IN subqueries/i);
-    });
-
-    it("rejects queries with IN subquery", () => {
-      const inSubqueryExpression: PredicateExpression = {
-        __type: "in_subquery",
-        field: {
-          __type: "field_ref",
-          alias: "a",
-          path: ["id"],
-        },
-        subquery: createMinimalAst("sub"),
-        negated: false,
-      };
-
-      const astWithInSubquery = createMinimalAst("a", {
-        predicates: [
-          {
-            targetAlias: "a",
-            expression: inSubqueryExpression,
-          },
-        ],
-      });
-
-      const op = createSetOperation(astWithInSubquery);
-
-      expect(() => compileSqlite(op)).toThrow(/EXISTS\/IN subqueries/i);
-    });
-
-    it("rejects queries with vector similarity predicates", () => {
-      const vectorExpression: PredicateExpression = {
-        __type: "vector_similarity",
-        field: {
-          __type: "field_ref",
-          alias: "a",
-          path: ["props", "embedding"],
-          jsonPointer: jsonPointer(["embedding"]),
-        },
-        queryEmbedding: [0.1, 0.2, 0.3],
-        metric: "cosine",
-        limit: 10,
-      };
-
-      const astWithVector = createMinimalAst("a", {
-        predicates: [
-          {
-            targetAlias: "a",
-            expression: vectorExpression,
-          },
-        ],
-      });
-
-      const op = createSetOperation(astWithVector);
-
-      expect(() => compileSqlite(op)).toThrow(/vector similarity/i);
-    });
-
-    it("rejects queries with GROUP BY", () => {
-      const astWithGroupBy = createMinimalAst("a", {
-        groupBy: {
-          fields: [
-            {
-              __type: "field_ref",
-              alias: "a",
-              path: ["props", "category"],
-            },
-          ],
-        },
-      });
-
-      const op = createSetOperation(astWithGroupBy);
-
-      expect(() => compileSqlite(op)).toThrow(/GROUP BY/i);
-    });
-
-    it("rejects queries with HAVING", () => {
-      const astWithHaving = createMinimalAst("a", {
-        having: {
-          __type: "aggregate_comparison",
-          op: "gt",
-          aggregate: {
-            __type: "aggregate",
-            function: "count",
-            field: { __type: "field_ref", alias: "a", path: ["id"] },
-          },
-          value: { __type: "literal", value: 5 },
-        },
-      });
-
-      const op = createSetOperation(astWithHaving);
-
-      expect(() => compileSqlite(op)).toThrow(/HAVING/i);
-    });
-
-    it("rejects queries with per-query ORDER BY", () => {
-      const astWithOrderBy = createMinimalAst("a", {
-        orderBy: [
-          {
-            field: {
-              __type: "field_ref",
-              alias: "a",
-              path: ["props", "name"],
-            },
-            direction: "asc",
-          },
-        ],
-      });
-
-      const op = createSetOperation(astWithOrderBy);
-
-      expect(() => compileSqlite(op)).toThrow(/per-query ORDER BY/i);
-    });
-
-    it("rejects queries with per-query LIMIT", () => {
-      const astWithLimit = createMinimalAst("a", {
-        limit: 10,
-      });
-
-      const op = createSetOperation(astWithLimit);
-
-      expect(() => compileSqlite(op)).toThrow(/per-query LIMIT/i);
-    });
-
-    it("rejects queries with per-query OFFSET", () => {
-      const astWithOffset = createMinimalAst("a", {
-        offset: 5,
-      });
-
-      const op = createSetOperation(astWithOffset);
-
-      expect(() => compileSqlite(op)).toThrow(/per-query OFFSET/i);
-    });
+    // No parenthesized compound operands; each leaf is a `SELECT * FROM (...)`.
+    expect(sql).toContain("UNION");
+    expect(sql).toMatch(/SELECT \* FROM \(/);
   });
 
-  describe("nested predicate detection", () => {
-    it("detects EXISTS in AND expression", () => {
-      const andExpression: PredicateExpression = {
-        __type: "and",
-        predicates: [
-          {
-            __type: "comparison",
-            op: "eq",
-            left: { __type: "field_ref", alias: "a", path: ["props", "name"] },
-            right: { __type: "literal", value: "test" },
-          },
-          {
-            __type: "exists",
-            subquery: createMinimalAst("sub"),
-            negated: false,
-          },
-        ],
-      };
-
-      const ast = createMinimalAst("a", {
-        predicates: [{ targetAlias: "a", expression: andExpression }],
-      });
-
-      const op = createSetOperation(ast);
-
-      expect(() => compileSqlite(op)).toThrow(/EXISTS\/IN subqueries/i);
-    });
-
-    it("detects EXISTS in OR expression", () => {
-      const orExpression: PredicateExpression = {
-        __type: "or",
-        predicates: [
-          {
-            __type: "comparison",
-            op: "eq",
-            left: { __type: "field_ref", alias: "a", path: ["props", "name"] },
-            right: { __type: "literal", value: "test" },
-          },
-          {
-            __type: "exists",
-            subquery: createMinimalAst("sub"),
-            negated: false,
-          },
-        ],
-      };
-
-      const ast = createMinimalAst("a", {
-        predicates: [{ targetAlias: "a", expression: orExpression }],
-      });
-
-      const op = createSetOperation(ast);
-
-      expect(() => compileSqlite(op)).toThrow(/EXISTS\/IN subqueries/i);
-    });
-
-    it("detects EXISTS in NOT expression", () => {
-      const notExpression: PredicateExpression = {
-        __type: "not",
-        predicate: {
-          __type: "exists",
-          subquery: createMinimalAst("sub"),
-          negated: false,
+  it("supports leaves with traversals", () => {
+    const astWithTraversals = createMinimalAst("a", {
+      traversals: [
+        {
+          edgeKinds: ["knows"],
+          edgeAlias: "e",
+          nodeKinds: ["Person"],
+          nodeAlias: "friend",
+          direction: "out",
+          joinFromAlias: "a",
+          joinEdgeField: "to_id",
+          optional: false,
         },
-      };
-
-      const ast = createMinimalAst("a", {
-        predicates: [{ targetAlias: "a", expression: notExpression }],
-      });
-
-      const op = createSetOperation(ast);
-
-      expect(() => compileSqlite(op)).toThrow(/EXISTS\/IN subqueries/i);
+      ],
     });
 
-    it("detects vector similarity in nested AND", () => {
-      const andExpression: PredicateExpression = {
-        __type: "and",
-        predicates: [
-          {
-            __type: "comparison",
-            op: "eq",
-            left: { __type: "field_ref", alias: "a", path: ["props", "name"] },
-            right: { __type: "literal", value: "test" },
-          },
-          {
-            __type: "vector_similarity",
-            field: {
-              __type: "field_ref",
-              alias: "a",
-              path: ["props", "embedding"],
-              jsonPointer: jsonPointer(["embedding"]),
-            },
-            queryEmbedding: [0.1, 0.2, 0.3],
-            metric: "cosine",
-            limit: 10,
-          },
-        ],
-      };
+    const op = createSetOperation(astWithTraversals);
 
-      const ast = createMinimalAst("a", {
-        predicates: [{ targetAlias: "a", expression: andExpression }],
-      });
-
-      const op = createSetOperation(ast);
-
-      expect(() => compileSqlite(op)).toThrow(/vector similarity/i);
-    });
+    expect(() => compileSqlite(op)).not.toThrow();
   });
 
-  describe("error message quality", () => {
-    it("lists multiple unsupported features in error message", () => {
-      const astWithMultiple = createMinimalAst("a", {
-        traversals: [
+  it("supports leaves with EXISTS subqueries", () => {
+    const existsExpression: PredicateExpression = {
+      __type: "exists",
+      subquery: { ...createMinimalAst("sub"), graphId: "test" },
+      negated: false,
+    };
+
+    const astWithExists = createMinimalAst("a", {
+      predicates: [{ targetAlias: "a", expression: existsExpression }],
+    });
+
+    const op = createSetOperation(astWithExists);
+
+    const sql = compileSqlite(op);
+    expect(sql).toContain("EXISTS");
+  });
+
+  it("supports leaves with IN subqueries", () => {
+    const inSubqueryExpression: PredicateExpression = {
+      __type: "in_subquery",
+      field: {
+        __type: "field_ref",
+        alias: "a",
+        path: ["id"],
+      },
+      subquery: { ...createMinimalAst("sub"), graphId: "test" },
+      negated: false,
+    };
+
+    const astWithInSubquery = createMinimalAst("a", {
+      predicates: [{ targetAlias: "a", expression: inSubqueryExpression }],
+    });
+
+    const op = createSetOperation(astWithInSubquery);
+
+    const sql = compileSqlite(op);
+    expect(sql).toContain("IN");
+  });
+
+  it("supports leaves with GROUP BY", () => {
+    const astWithGroupBy = createMinimalAst("a", {
+      groupBy: {
+        fields: [
           {
-            edgeKinds: ["knows"],
-            edgeAlias: "e",
-            nodeKinds: ["Person"],
-            nodeAlias: "friend",
-            direction: "out",
-            joinFromAlias: "a",
-            joinEdgeField: "to_id",
-            optional: false,
+            __type: "field_ref",
+            alias: "a",
+            path: ["props", "category"],
           },
         ],
-        groupBy: {
-          fields: [
-            {
-              __type: "field_ref",
-              alias: "a",
-              path: ["props", "category"],
-            },
-          ],
-        },
-      });
-
-      const op = createSetOperation(astWithMultiple);
-
-      // Should mention both unsupported features
-      expect(() => compileSqlite(op)).toThrow(
-        /traversals.*GROUP BY|GROUP BY.*traversals/s,
-      );
+      },
     });
+
+    const op = createSetOperation(astWithGroupBy);
+
+    const sql = compileSqlite(op);
+    expect(sql).toContain("GROUP BY");
+  });
+
+  it("supports leaves with HAVING", () => {
+    const astWithHaving = createMinimalAst("a", {
+      having: {
+        __type: "aggregate_comparison",
+        op: "gt",
+        aggregate: {
+          __type: "aggregate",
+          function: "count",
+          field: { __type: "field_ref", alias: "a", path: ["id"] },
+        },
+        value: { __type: "literal", value: 5 },
+      },
+    });
+
+    const op = createSetOperation(astWithHaving);
+
+    const sql = compileSqlite(op);
+    expect(sql).toContain("HAVING");
+  });
+
+  it("supports leaves with per-leaf ORDER BY", () => {
+    const astWithOrderBy = createMinimalAst("a", {
+      orderBy: [
+        {
+          field: {
+            __type: "field_ref",
+            alias: "a",
+            path: ["props", "name"],
+          },
+          direction: "asc",
+        },
+      ],
+    });
+
+    const op = createSetOperation(astWithOrderBy);
+
+    const sql = compileSqlite(op);
+    // Per-leaf ORDER BY lives inside the operand subquery, not the compound tail.
+    expect(sql).toContain("ORDER BY");
+  });
+
+  it("supports leaves with per-leaf LIMIT", () => {
+    const astWithLimit = createMinimalAst("a", { limit: 10 });
+
+    const op = createSetOperation(astWithLimit);
+
+    const sql = compileSqlite(op);
+    expect(sql).toContain("LIMIT");
+  });
+
+  it("supports leaves with per-leaf OFFSET", () => {
+    const astWithOffset = createMinimalAst("a", { limit: 10, offset: 5 });
+
+    const op = createSetOperation(astWithOffset);
+
+    const sql = compileSqlite(op);
+    expect(sql).toContain("OFFSET");
+  });
+
+  it("supports a leaf combining traversal + GROUP BY", () => {
+    const astWithMultiple = createMinimalAst("a", {
+      traversals: [
+        {
+          edgeKinds: ["knows"],
+          edgeAlias: "e",
+          nodeKinds: ["Person"],
+          nodeAlias: "friend",
+          direction: "out",
+          joinFromAlias: "a",
+          joinEdgeField: "to_id",
+          optional: false,
+        },
+      ],
+      groupBy: {
+        fields: [
+          {
+            __type: "field_ref",
+            alias: "a",
+            path: ["props", "category"],
+          },
+        ],
+      },
+    });
+
+    const op = createSetOperation(astWithMultiple);
+
+    expect(() => compileSqlite(op)).not.toThrow();
   });
 });


### PR DESCRIPTION
What began as a fix for one SQLite/PostgreSQL divergence grew into closing the gap **and** making that class of bug structurally hard to reintroduce. Seven commits, three layers:

1. **Fix** — full SQLite support for set-operation leaves (the actual bug).
2. **Document** — an honest SQLite ↔ PostgreSQL parity matrix; remove dead capability metadata the audit surfaced.
3. **Enforce** — a compiler lint rule + a differential test harness so divergence can't slip back in silently.

Two changesets (both `minor`): `sqlite-set-operations-full-support`, `drop-unused-backend-capability-flags`.

---

## 1. Full SQLite support for set-operation leaves 

`UNION` / `UNION ALL` / `INTERSECT` / `EXCEPT` on SQLite previously rejected leaves that used traversals, `EXISTS`/`IN` subqueries, vector/fulltext predicates, `GROUP BY`/`HAVING`, or per-leaf `ORDER BY`/`LIMIT`/`OFFSET` — throwing `UnsupportedPredicateError` at execute() time while PostgreSQL ran them. A combined query developed against Postgres could blow up the moment the backend was switched to SQLite.

**Root cause:** the SQLite path hand-rolled a thin subset of leaf compilation instead of delegating to the full query compiler (which the Postgres path already did). **Fix:** both dialects now compile each leaf with the full compiler and differ only in operand wrapping — Postgres `(<leaf>)`, SQLite `SELECT * FROM (<leaf>)` (SQLite forbids parenthesized compound operands but allows a `WITH` clause inside a FROM-subquery). This **deletes ~600 lines** of CTE-hoisting/prefixing and unifies the two paths behind one token-level seam. Vector/fulltext leaves now also use the configured relevance strategy instead of a dialect fallback.

Verified against SQLite 3.51 before writing a line.

## 2. Parity matrix + JSON correction

Added an honest **SQLite ↔ PostgreSQL parity matrix** to `backend-setup.md`: the query language is fully portable; the only divergences are *engine-capability* gaps in vector/fulltext (`inner_product` metric, `ivfflat` index, per-query fulltext `language`, HNSW `efSearch`). Corrected an initial overstatement — SQLite has native JSON and full parity for JSON-path predicates and scalar-property expression indexes; the only JSON difference is GIN containment *acceleration* (performance, not capability).

## 3. Remove dead capability flags

The audit found `jsonb`, `ginIndexes`, `partialIndexes`, `cte`, and `returning` on `BackendCapabilities` were **descriptive-only** — read nowhere to gate a feature or pick a strategy. `jsonb`/`ginIndexes` additionally misrepresented SQLite. Removed all five; `BackendCapabilities` is now `{ transactions, vector?, fulltext? }` — exactly what the library consumes.

> ⚠️ **Type-surface change.** If you read `backend.capabilities.{jsonb,ginIndexes,partialIndexes,cte,returning}`, branch on `backend.dialect` instead, or rely on the dialect layer. Covered by the `drop-unused-backend-capability-flags` changeset.

## 4. Compiler-level enforcement

An ESLint `no-restricted-syntax` rule (scoped to `src/query`) bans inline `=== "sqlite"` / `case "postgres"` branching, so dialect differences are forced through the typed `DialectAdapter` seam — the single-shared-path discipline whose violation hid the set-op gap. Validated to both pass on the clean compiler and fire on a synthetic violation. The two rules a lint can't mechanize (no per-dialect *strategy functions*; query-feature tests live in the shared cross-backend suite) are written into a new **Backend parity** section of `AGENTS.md`.

## 5. Differential parity harness

The empirical net for semantic divergence that types and lint can't see. Runs a curated read-only corpus (predicates, ordering incl. NULL placement, aggregates, traversals, recursion, set operations, pagination) against **both** a SQLite store and an in-process **PGlite** (Postgres-in-WASM) store seeded identically, and asserts results match (multiset, or in-order for totally-ordered queries; floats and PG numeric-strings normalized; ids never compared).

- Includes the **union-of-traversals** case — the exact shape that used to throw on SQLite — so it would have caught the original bug on the first run.
- **Validated to fail**, not just pass: a deliberate one-backend divergence turned exactly the affected cases red, then was reverted.
- Runs in the default `pnpm test` lane — **no Docker**, +19 tests, ~1.8s.

---

## The resulting safety model

| Layer | Catches | Mechanism |
| --- | --- | --- |
| `DialectAdapter` interface | a backend never wired up | compile-time (types) |
| `dialect.name` lint rule | inline string-branching in the compiler | lint |
| `AGENTS.md` Backend parity | per-dialect strategy functions; shared-test rule | convention/review |
| Differential harness | semantic divergence / "throws on one backend" | runtime (cross-backend) |

The first three make divergence hard to introduce; the last makes it impossible to ship undetected.

## Known boundaries (intentional, documented)

- `GROUP BY`/`HAVING` set-op leaves compile, but the builder doesn't expose `.union()` on `.aggregate()` queries — a *uniform* builder limit (both backends), not a parity gap.
- Vector/fulltext engine gaps (`inner_product`, `ivfflat`, fulltext `language`, `efSearch`) are inherent to the engines — declared in the capability matrix and excluded from the differential corpus by design.