### PR TITLE
Add window function backend capability

### DIFF
--- a/.changeset/few-windows-notice.md
+++ b/.changeset/few-windows-notice.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add the `backend.capabilities.windowFunctions` capability and reject relevance-ranking queries before SQL generation when a custom backend profile disables SQL window functions.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -166,7 +166,11 @@ Creates a SQLite backend from an existing Drizzle database instance. Pass `vecto
 ```typescript
 function createSqliteBackend(
   db: BetterSQLite3Database,
-  options?: { tables?: SqliteTables; vector?: VectorStrategy },
+  options?: {
+    tables?: SqliteTables;
+    vector?: VectorStrategy;
+    capabilities?: Partial<BackendCapabilities>;
+  },
 ): GraphBackend;
 ```
 
@@ -724,6 +728,7 @@ if (backend.capabilities.vector?.supported) {
 | Field | Meaning |
 | --- | --- |
 | `transactions` | Atomic transactions available (see note below) |
+| `windowFunctions` | SQL window functions such as `ROW_NUMBER()` are available |
 | `vector?.metrics` / `vector?.indexTypes` / `vector?.maxDimensions` | Vector strategy capabilities (present once a vector strategy is configured) |
 | `fulltext?.{supported,languages,phraseQueries,prefixQueries,highlighting}` | Fulltext strategy capabilities |
 
@@ -752,6 +757,10 @@ Vector and fulltext capabilities are populated from the configured strategy, so 
 bundled strategies (`sqlite-vec`/`libsql-native`/`pgvector`, `fts5`/`tsvector`). A custom strategy advertising
 different `metrics`/`indexTypes` shifts these rows accordingly — always check `backend.capabilities` at runtime
 rather than hard-coding the dialect.
+
+Both bundled backends advertise `windowFunctions: true`. Vector, fulltext, and hybrid relevance-ranking
+queries use `ROW_NUMBER()` internally and throw `ConfigurationError` before SQL generation if a custom backend profile
+sets `windowFunctions: false`.
 
 :::note[JSON is native on both backends]
 SQLite stores JSON as text and queries it with the built-in JSON functions (`json_extract`, `json_each`, …);

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -166,6 +166,11 @@ export type SqliteBackendOptions = Readonly<{
    * connections without a vector extension.
    */
   vector?: VectorStrategy;
+  /**
+   * Override specific backend capabilities. Useful for custom SQLite builds
+   * or tests that need to simulate an engine-level capability gap.
+   */
+  capabilities?: Partial<BackendCapabilities>;
 }>;
 
 const SQLITE_MAX_BIND_PARAMETERS = 999;
@@ -643,11 +648,14 @@ export function createSqliteBackend(
   // backend so a slot's per-field table is created at most once per process.
   const vectorSlotLatch =
     vectorStrategy === undefined ? undefined : createVectorSlotLatch();
-  const capabilities: BackendCapabilities = buildSqliteCapabilities({
-    fulltextStrategy,
-    vectorStrategy,
-    transactionMode,
-  });
+  const capabilities: BackendCapabilities = {
+    ...buildSqliteCapabilities({
+      fulltextStrategy,
+      vectorStrategy,
+      transactionMode,
+    }),
+    ...options.capabilities,
+  };
 
   const tableNames: SqlTableNames = {
     nodes: getTableName(tables.nodes),

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -99,6 +99,8 @@ export type { SqlDialect } from "../query/dialect/types";
 export type BackendCapabilities = Readonly<{
   /** Whether the backend supports atomic transactions (D1 does not) */
   transactions: boolean;
+  /** Whether the backend supports SQL window functions such as ROW_NUMBER() */
+  windowFunctions: boolean;
   /** Vector search capabilities (undefined if not configured) */
   vector?: VectorCapabilities | undefined;
   /** Fulltext search capabilities (undefined if not configured) */
@@ -1474,6 +1476,7 @@ export type CountEdgesByKindParams = Readonly<{
  */
 export const SQLITE_CAPABILITIES: BackendCapabilities = {
   transactions: true, // SQLite supports transactions
+  windowFunctions: true, // SQLite has supported window functions since 3.25.0
 };
 
 /**
@@ -1481,4 +1484,5 @@ export const SQLITE_CAPABILITIES: BackendCapabilities = {
  */
 export const POSTGRES_CAPABILITIES: BackendCapabilities = {
   transactions: true, // PostgreSQL supports transactions
+  windowFunctions: true, // PostgreSQL supports ROW_NUMBER() and related windows
 };

--- a/packages/typegraph/src/query/builder/compile-options.ts
+++ b/packages/typegraph/src/query/builder/compile-options.ts
@@ -21,6 +21,7 @@ export function buildCompileOptions(
   return {
     dialect: config.dialect ?? "sqlite",
     schema: config.schema,
+    windowFunctions: config.backend?.capabilities.windowFunctions ?? true,
     ...(fulltextStrategy === undefined ? {} : { fulltextStrategy }),
     ...(vectorStrategy === undefined ?
       {}

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -43,7 +43,7 @@ export { type DialectAdapter, getDialect, type SqlDialect } from "../dialect";
 
 import { type SQL, sql } from "drizzle-orm";
 
-import { CompilerInvariantError } from "../../errors";
+import { CompilerInvariantError, ConfigurationError } from "../../errors";
 import {
   type AggregateExpr,
   type FulltextMatchPredicate,
@@ -138,6 +138,11 @@ export type CompileQueryOptions = Readonly<{
    */
   vectorStrategy?: VectorStrategy | undefined;
   /**
+   * Whether the active backend supports SQL window functions such as
+   * `ROW_NUMBER()`. Defaults to true for direct compiler callers.
+   */
+  windowFunctions?: boolean | undefined;
+  /**
    * Declared embedding slots `(kind, fieldPath) -> descriptor` used by
    * the `field.similarTo(...)` CTE to know which kinds in an alias
    * declare the field. Callers build it from the graph's node schemas.
@@ -191,6 +196,7 @@ export function compileQuery(
     ...(options_.vectorStrategy === undefined ?
       {}
     : { vectorStrategy: options_.vectorStrategy }),
+    windowFunctions: options_.windowFunctions ?? true,
     ...(options_.vectorSlots === undefined ?
       {}
     : { vectorSlots: options_.vectorSlots }),
@@ -301,6 +307,7 @@ function propagateOptions(options_: CompileQueryOptions): CompileQueryOptions {
     ...(options_.vectorStrategy === undefined ?
       {}
     : { vectorStrategy: options_.vectorStrategy }),
+    windowFunctions: options_.windowFunctions ?? true,
     ...(options_.vectorSlots === undefined ?
       {}
     : { vectorSlots: options_.vectorSlots }),
@@ -762,6 +769,37 @@ function selectStandardOrderBy(
   });
 }
 
+function selectWindowFunctionOperation(
+  vectorPredicate: VectorSimilarityPredicate | undefined,
+  fulltextPredicate: FulltextMatchPredicate | undefined,
+): string {
+  if (vectorPredicate !== undefined && fulltextPredicate !== undefined) {
+    return "hybrid relevance ranking";
+  }
+  if (vectorPredicate !== undefined) return "vector relevance ranking";
+  return "fulltext relevance ranking";
+}
+
+function assertWindowFunctionsSupported(
+  ctx: PredicateCompilerContext,
+  operation: string,
+): void {
+  if (ctx.windowFunctions) return;
+
+  throw new ConfigurationError(
+    `${operation} requires SQL window functions, but this backend profile declares windowFunctions: false.`,
+    {
+      capability: "windowFunctions",
+      operation,
+      windowFunctions: false,
+    },
+    {
+      suggestion:
+        "Use a backend profile that supports SQL window functions, or avoid this query shape.",
+    },
+  );
+}
+
 function compileStandardQueryWithCteStrategy(
   ast: QueryAst,
   graphId: string,
@@ -792,6 +830,13 @@ function compileStandardQueryWithCteStrategy(
     throw new CompilerInvariantError(
       "Logical plan pass did not initialize plan state",
       { phase: "standard-pass-pipeline" },
+    );
+  }
+
+  if (vectorPredicate !== undefined || fulltextPredicate !== undefined) {
+    assertWindowFunctionsSupported(
+      ctx,
+      selectWindowFunctionOperation(vectorPredicate, fulltextPredicate),
     );
   }
 

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -405,6 +405,11 @@ export type PredicateCompilerContext = Readonly<{
    */
   vectorStrategy?: VectorStrategy;
   /**
+   * Whether the active backend supports SQL window functions such as
+   * `ROW_NUMBER()`.
+   */
+  windowFunctions: boolean;
+  /**
    * Declared embedding slots `(kind, fieldPath) -> {dimensions, metric,
    * indexType}`. The embeddings CTE consults it to know which kinds in
    * an alias actually declare the field — only those get a per-field

--- a/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
@@ -77,6 +77,7 @@ describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () =
     // and refuses with a typed ConfigurationError on this backend.
     expect(backend.capabilities.transactions).toBe(false);
     // Other capabilities are unchanged.
+    expect(backend.capabilities.windowFunctions).toBe(true);
     expect(backend.capabilities.vector?.supported).toBe(true);
   });
 
@@ -139,9 +140,10 @@ describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () =
     const sql = neon("postgresql://test:test@invalid.neon.tech/test");
     const db = drizzleNeonHttp({ client: sql });
     const backend = createPostgresBackend(db, {
-      capabilities: { transactions: true },
+      capabilities: { transactions: true, windowFunctions: false },
     });
 
     expect(backend.capabilities.transactions).toBe(true);
+    expect(backend.capabilities.windowFunctions).toBe(false);
   });
 });

--- a/packages/typegraph/tests/executable-aggregate-query.test.ts
+++ b/packages/typegraph/tests/executable-aggregate-query.test.ts
@@ -39,6 +39,10 @@ const graph = defineGraph({
 });
 
 const registry = buildKindRegistry(graph);
+const MOCK_BACKEND_CAPABILITIES = {
+  transactions: true,
+  windowFunctions: true,
+} as const;
 
 // ============================================================
 // ExecutableAggregateQuery toAst
@@ -256,6 +260,7 @@ describe("ExecutableAggregateQuery.execute", () => {
 
   it("executes query with mock backend", async () => {
     const mockBackend = {
+      capabilities: MOCK_BACKEND_CAPABILITIES,
       execute: vi.fn().mockResolvedValue([
         { category: "Electronics", count: 10 },
         { category: "Books", count: 25 },
@@ -282,6 +287,7 @@ describe("ExecutableAggregateQuery.execute", () => {
 
   it("maps only requested fields from results", async () => {
     const mockBackend = {
+      capabilities: MOCK_BACKEND_CAPABILITIES,
       execute: vi
         .fn()
         .mockResolvedValue([
@@ -308,6 +314,7 @@ describe("ExecutableAggregateQuery.execute", () => {
 
   it("handles empty result set", async () => {
     const mockBackend = {
+      capabilities: MOCK_BACKEND_CAPABILITIES,
       execute: vi.fn().mockResolvedValue([]),
     };
 

--- a/packages/typegraph/tests/fulltext-search.test.ts
+++ b/packages/typegraph/tests/fulltext-search.test.ts
@@ -15,6 +15,7 @@ import {
   defineGraph,
   defineNode,
 } from "../src";
+import { createSqliteBackend } from "../src/backend/sqlite";
 import { type GraphBackend } from "../src/backend/types";
 import { embedding } from "../src/core/embedding";
 import {
@@ -26,7 +27,11 @@ import { createSchemaIntrospector } from "../src/query/schema-introspector";
 import type { createStore } from "../src/store";
 import { getSearchableFields } from "../src/store/fulltext-sync";
 import { type FulltextSearchHit } from "../src/store/search";
-import { createInitializedStore, createTestBackend } from "./test-utils";
+import {
+  createInitializedStore,
+  createTestBackend,
+  createTestDatabase,
+} from "./test-utils";
 
 type DocumentProps = Readonly<{ title: string; body: string; plain?: string }>;
 function documentProps(hit: FulltextSearchHit): DocumentProps {
@@ -203,6 +208,44 @@ describe("end-to-end fulltext search (SQLite FTS5)", () => {
     expect(backend.capabilities.fulltext?.supported).toBe(true);
     expect(backend.capabilities.fulltext?.phraseQueries).toBe(true);
     expect(backend.capabilities.fulltext?.prefixQueries).toBe(true);
+  });
+
+  it("rejects relevance ranking when the backend disables window functions", async () => {
+    const db = createTestDatabase();
+    const backendWithoutWindows = createSqliteBackend(db, {
+      capabilities: { windowFunctions: false },
+    });
+
+    try {
+      await backendWithoutWindows.bootstrapTables?.();
+      const storeWithoutWindows = await createInitializedStore(
+        SearchableGraph,
+        backendWithoutWindows,
+      );
+
+      let caught: unknown;
+      try {
+        await storeWithoutWindows
+          .query()
+          .from("Document", "d")
+          .whereNode("d", (d) => d.$fulltext.matches("climate", 10))
+          .select((ctx) => ctx.d)
+          .execute();
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(ConfigurationError);
+      expect(caught).toMatchObject({
+        details: {
+          capability: "windowFunctions",
+          operation: "fulltext relevance ranking",
+          windowFunctions: false,
+        },
+      });
+    } finally {
+      await backendWithoutWindows.close();
+    }
   });
 
   it("indexes searchable fields on create and surfaces them in search", async () => {

--- a/packages/typegraph/tests/fuse-with.test.ts
+++ b/packages/typegraph/tests/fuse-with.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  ConfigurationError,
   defineGraph,
   defineNode,
   embedding,
@@ -103,6 +104,66 @@ describe(".fuseWith()", () => {
     const sqlText = toSqlString(compiled);
     expect(sqlText).toMatch(/1\.3 \/ \(42 \+ cte_embeddings\.ord\)/);
     expect(sqlText).toMatch(/0\.7 \/ \(42 \+ cte_fulltext\.ord\)/);
+  });
+
+  it("rejects hybrid relevance ranking when window functions are unavailable", () => {
+    const builder = makeBuilder();
+    const ast = builder
+      .from("HybridDoc", "d")
+      .whereNode("d", (d) =>
+        d.$fulltext
+          .matches("anything", 50)
+          .and(d.embedding.similarTo([0.1, 0.2, 0.3, 0.4], 50)),
+      )
+      .select((ctx) => ctx.d)
+      .toAst();
+
+    let caught: unknown;
+    try {
+      compileQuery(ast, HybridGraph.id, {
+        ...PG_VECTOR_OPTIONS,
+        windowFunctions: false,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ConfigurationError);
+    expect(caught).toMatchObject({
+      details: {
+        capability: "windowFunctions",
+        operation: "hybrid relevance ranking",
+        windowFunctions: false,
+      },
+    });
+  });
+
+  it("rejects fulltext relevance ranking when window functions are unavailable", () => {
+    const builder = makeBuilder();
+    const ast = builder
+      .from("HybridDoc", "d")
+      .whereNode("d", (d) => d.$fulltext.matches("anything", 50))
+      .select((ctx) => ctx.d)
+      .toAst();
+
+    let caught: unknown;
+    try {
+      compileQuery(ast, HybridGraph.id, {
+        dialect: "postgres",
+        windowFunctions: false,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ConfigurationError);
+    expect(caught).toMatchObject({
+      details: {
+        capability: "windowFunctions",
+        operation: "fulltext relevance ranking",
+        windowFunctions: false,
+      },
+    });
   });
 
   it("rejects invalid k values via validateHybridFusionOptions", () => {

--- a/packages/typegraph/tests/predicate-compiler.test.ts
+++ b/packages/typegraph/tests/predicate-compiler.test.ts
@@ -106,6 +106,7 @@ function createContext(cteColumnPrefix?: string): PredicateCompilerContext {
     dialect: sqliteDialect,
     schema: DEFAULT_SQL_SCHEMA,
     compileQuery: () => sql`SELECT 1`,
+    windowFunctions: true,
   };
   if (cteColumnPrefix !== undefined) {
     return { ...base, cteColumnPrefix };
@@ -1237,6 +1238,7 @@ describe("subquery predicates", () => {
       dialect: sqliteDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT 1 FROM users WHERE active = 1`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1253,6 +1255,7 @@ describe("subquery predicates", () => {
       dialect: sqliteDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT 1 FROM deleted_users`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1269,6 +1272,7 @@ describe("subquery predicates", () => {
       dialect: sqliteDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT user_id FROM admins`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1286,6 +1290,7 @@ describe("subquery predicates", () => {
       dialect: postgresDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT score FROM scores`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1316,6 +1321,7 @@ describe("subquery predicates", () => {
       dialect: sqliteDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT blocked_id FROM blocklist`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1333,6 +1339,7 @@ describe("subquery predicates", () => {
       dialect: sqliteDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT user_id, role FROM admins`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1366,6 +1373,7 @@ describe("subquery predicates", () => {
       dialect: postgresDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT name FROM people`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1395,6 +1403,7 @@ describe("subquery predicates", () => {
       dialect: sqliteDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT profile FROM people`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {
@@ -1426,6 +1435,7 @@ describe("subquery predicates", () => {
       dialect: sqliteDialect,
       schema: DEFAULT_SQL_SCHEMA,
       compileQuery: () => sql`SELECT 1`,
+      windowFunctions: true,
     };
 
     const expr: PredicateExpression = {

--- a/packages/typegraph/tests/recursive-compiler.test.ts
+++ b/packages/typegraph/tests/recursive-compiler.test.ts
@@ -91,6 +91,7 @@ function createContext(
     dialect,
     schema: DEFAULT_SQL_SCHEMA,
     compileQuery: () => sql`SELECT 1`,
+    windowFunctions: true,
   };
 }
 

--- a/packages/typegraph/tests/standard-pass-pipeline.test.ts
+++ b/packages/typegraph/tests/standard-pass-pipeline.test.ts
@@ -128,6 +128,7 @@ function makePipelineContext(
     dialect,
     schema: DEFAULT_SQL_SCHEMA,
     compileQuery: () => sql`SELECT 1`,
+    windowFunctions: true,
   };
 }
 

--- a/packages/typegraph/tests/unionable-query-state.test.ts
+++ b/packages/typegraph/tests/unionable-query-state.test.ts
@@ -54,6 +54,10 @@ const graph = defineGraph({
 });
 
 const registry = buildKindRegistry(graph);
+const MOCK_BACKEND_CAPABILITIES = {
+  transactions: true,
+  windowFunctions: true,
+} as const;
 
 // ============================================================
 // State Preservation Tests
@@ -223,6 +227,7 @@ describe("UnionableQuery state preservation", () => {
   describe("result transformation", () => {
     it("applies select function when executing with mock backend", async () => {
       const mockBackend = {
+        capabilities: MOCK_BACKEND_CAPABILITIES,
         execute: vi.fn().mockResolvedValue([
           {
             p_id: "person-1",
@@ -267,6 +272,7 @@ describe("UnionableQuery state preservation", () => {
 
     it("returns raw rows when no select function is set", async () => {
       const mockBackend = {
+        capabilities: MOCK_BACKEND_CAPABILITIES,
         execute: vi
           .fn()
           .mockResolvedValue([

--- a/packages/typegraph/tests/unionable-query.test.ts
+++ b/packages/typegraph/tests/unionable-query.test.ts
@@ -54,6 +54,11 @@ const User = defineNode("User", {
   }),
 });
 
+const MOCK_BACKEND_CAPABILITIES = {
+  transactions: true,
+  windowFunctions: true,
+} as const;
+
 const Admin = defineNode("Admin", {
   schema: z.object({
     name: z.string(),
@@ -514,6 +519,7 @@ describe("UnionableQuery.execute", () => {
   it("executes query with mock backend", async () => {
     // Mock returns database-style rows with prefixed columns
     const mockBackend = {
+      capabilities: MOCK_BACKEND_CAPABILITIES,
       execute: vi.fn().mockResolvedValue([
         {
           u_id: "user-1",
@@ -572,6 +578,7 @@ describe("UnionableQuery.execute", () => {
 
   it("handles empty result set", async () => {
     const mockBackend = {
+      capabilities: MOCK_BACKEND_CAPABILITIES,
       execute: vi.fn().mockResolvedValue([]),
     };
 
@@ -641,6 +648,7 @@ describe("UnionableQuery complex scenarios", () => {
 
   it("rejects execute() when any leaf query contains param() references", async () => {
     const mockBackend = {
+      capabilities: MOCK_BACKEND_CAPABILITIES,
       dialect: "sqlite" as const,
       execute: vi.fn(),
     };

--- a/packages/typegraph/tests/vector-compiler.test.ts
+++ b/packages/typegraph/tests/vector-compiler.test.ts
@@ -1,6 +1,7 @@
 import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 
+import { ConfigurationError } from "../src/errors";
 import { type QueryAst, type VectorMetricType } from "../src/query/ast";
 import { compileQuery, type CompileQueryOptions } from "../src/query/compiler";
 import {
@@ -114,6 +115,27 @@ describe("vector compilation semantics", () => {
     expect(sql).toMatch(/ROW_NUMBER\(\) OVER \(ORDER BY distance ASC\) AS ord/);
     // The inner k-cutoff bounds the ranked set to the predicate's limit.
     expect(sql).toMatch(/ORDER BY distance ASC\s+LIMIT 10/);
+  });
+
+  it("rejects vector relevance ranking when window functions are unavailable", () => {
+    let caught: unknown;
+    try {
+      compileQuery(buildVectorAst("cosine", 0.5), "graph_1", {
+        ...pgVectorOptions(),
+        windowFunctions: false,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ConfigurationError);
+    expect(caught).toMatchObject({
+      details: {
+        capability: "windowFunctions",
+        operation: "vector relevance ranking",
+        windowFunctions: false,
+      },
+    });
   });
 
   it("unions per-(kind, field) tables across kinds the alias resolves to (includeSubClasses)", () => {


### PR DESCRIPTION
## Summary
- Adds required `windowFunctions` backend capability for SQLite and PostgreSQL profiles.
- Propagates the capability into query compilation and rejects vector, fulltext, and hybrid relevance-ranking SQL before generation when a backend profile declares it unavailable.
- Allows SQLite backend capability overrides for synthetic/custom backend profiles and documents the new capability.
- Tightens internal compiler context types and test backend doubles so missing capability wiring is a type/test failure instead of a fallback.
- Adds a store-level SQLite wiring test proving `backend.capabilities.windowFunctions` flows through `buildCompileOptions`.
- Adds a minor changeset for the new public capability/custom-backend type contract change.

## Relationship to #171
When `bulkFindByIndex({ limitPerInput })` rebases on this, it should gate the windowed branch on `backend.capabilities.windowFunctions` and throw the same typed `ConfigurationError` rather than emitting unsupported SQL.
