### PR TITLE
docs: bulkFindByIndex windowless behavior, add example, and integration cross-ref

### DIFF
--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -760,7 +760,13 @@ rather than hard-coding the dialect.
 
 Both bundled backends advertise `windowFunctions: true`. Vector, fulltext, and hybrid relevance-ranking
 queries use `ROW_NUMBER()` internally and throw `ConfigurationError` before SQL generation if a custom backend profile
-sets `windowFunctions: false`.
+sets `windowFunctions: false` — there the window output *is* the result (the relevance k-cutoff / rank ordinal), so
+there is no correct fallback.
+
+`bulkFindByIndex({ limitPerInput })` also uses `ROW_NUMBER()` when available, but it does **not** throw on a
+windowless profile: the per-input cap is a transfer optimization with identical row semantics either way, so it
+degrades gracefully — fetching all matching ids and capping per group in application code. The unbounded
+`bulkFindByIndex` path needs no window and is always available.
 
 :::note[JSON is native on both backends]
 SQLite stores JSON as text and queries it with the built-in JSON functions (`json_extract`, `json_each`, …);

--- a/apps/docs/src/content/docs/integration.md
+++ b/apps/docs/src/content/docs/integration.md
@@ -228,6 +228,13 @@ export const typegraphTables = createSqliteTables({}, { indexes: [personEmail] }
 For PostgreSQL, use `createPostgresTables` from `@nicia-ai/typegraph/postgres`.
 See [Indexes](/performance/indexes) for covering fields, partial indexes, and profiler integration.
 
+Beyond accelerating queries, a declared index powers `store.nodes.<Kind>.bulkFindByIndex(indexName, items)` — a
+batched lookup that returns, for each incoming record, the live nodes sharing its index key. This is the primitive for
+**import reconciliation** and **dedup-candidate discovery**: probe an entire import batch against the graph in one
+query to decide create-vs-merge per record (the key may be non-unique, so each record yields its own candidate list).
+See the [batched index lookup reference](/performance/indexes#batched-index-lookup-bulkfindbyindex) and the runnable
+[`examples/17-bulk-find-by-index.ts`](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/17-bulk-find-by-index.ts).
+
 If you only need PostgreSQL adapter exports, import from `@nicia-ai/typegraph/postgres`:
 
 ```typescript

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -17,12 +17,12 @@ const version = package_.version;
         <a
           href="/changelog"
           class="inline-flex items-center gap-2 px-3 py-1 mb-6 rounded-full border border-primary/30 bg-primary/10 text-sm font-mono text-primary hover:bg-primary/15 hover:border-primary/50 transition-colors no-underline"
-          aria-label={`Version ${version} — Runtime schema evolution. See changelog.`}
+          aria-label={`Version ${version} — Batched index lookup. See changelog.`}
         >
           <span
             class="inline-block w-2 h-2 rounded-full bg-primary"
             aria-hidden="true"></span>
-          v{version} · Runtime schema evolution
+          v{version} · Batched index lookup
           <span class="opacity-70" aria-hidden="true">→</span>
         </a>
         <h1 class="text-5xl font-extrabold leading-[1.1] mb-6 tracking-tight">

--- a/packages/typegraph/examples/17-bulk-find-by-index.ts
+++ b/packages/typegraph/examples/17-bulk-find-by-index.ts
@@ -1,0 +1,170 @@
+/**
+ * Example 17: Batched Index Lookup — Import Reconciliation
+ *
+ * `store.nodes.<Kind>.bulkFindByIndex(indexName, items, options?)` takes many
+ * in-memory records and, for each one, returns the live nodes that share its
+ * declared index key. It is the batched primitive for:
+ *
+ * - import reconciliation (decide create-new vs. merge for each incoming row)
+ * - dedup-candidate discovery (find rows that might be the same entity)
+ * - joining incoming records against the graph by a declared composite key
+ *
+ * The index may be non-unique, so each input yields its own (possibly empty)
+ * array of candidates — this is candidate retrieval, not a uniqueness
+ * guarantee. For unique lookups use `bulkFindByConstraint` instead.
+ *
+ * This example demonstrates:
+ * - composite, non-unique keys and org-scoped matching
+ * - the empty bucket → "create new" reconciliation decision
+ * - null-safe equality (a missing key field matches a stored NULL)
+ * - `limitPerInput` to cap each candidate bucket
+ */
+import { z } from "zod";
+
+import { createStore, defineGraph, defineNode } from "@nicia-ai/typegraph";
+import { defineNodeIndex } from "@nicia-ai/typegraph/indexes";
+import { createExampleBackend } from "./_helpers";
+
+// ============================================================
+// Schema Definition
+// ============================================================
+
+const Contact = defineNode("Contact", {
+  schema: z.object({
+    orgId: z.string(),
+    fullName: z.string(),
+    email: z.string().optional(),
+    sourceSystem: z.string(),
+  }),
+});
+
+// Reconciliation key: many contacts can share (orgId, fullName) — duplicates
+// imported from different source systems — so this index is non-unique.
+const contactByOrgName = defineNodeIndex(Contact, {
+  name: "contact_by_org_name",
+  fields: ["orgId", "fullName"],
+});
+
+// Email key: `email` is optional, so stored rows without one carry NULL.
+// Probing with no email matches those NULL rows via null-safe equality.
+const contactByOrgEmail = defineNodeIndex(Contact, {
+  name: "contact_by_org_email",
+  fields: ["orgId", "email"],
+});
+
+const graph = defineGraph({
+  id: "crm_import",
+  nodes: { Contact: { type: Contact } },
+  edges: {},
+  indexes: [contactByOrgName, contactByOrgEmail],
+});
+
+// ============================================================
+// Demonstrate Batched Index Lookup
+// ============================================================
+
+export async function main() {
+  const backend = createExampleBackend();
+  const store = createStore(graph, backend);
+
+  console.log("=== Batched Index Lookup (bulkFindByIndex) ===\n");
+
+  // Existing graph state: contacts already imported from various systems.
+  // Note the deliberate duplicates and the email-less rows.
+  console.log("Seeding the existing contact graph...\n");
+  const seed = [
+    { orgId: "acme", fullName: "Jane Doe", email: "jane@acme.com", sourceSystem: "salesforce" },
+    { orgId: "acme", fullName: "Jane Doe", email: "jane.doe@acme.com", sourceSystem: "hubspot" },
+    { orgId: "acme", fullName: "John Smith", email: "john@acme.com", sourceSystem: "salesforce" },
+    { orgId: "acme", fullName: "Mystery Contact", sourceSystem: "manual" }, // no email → NULL
+    { orgId: "acme", fullName: "Walk-in Lead", sourceSystem: "manual" }, // no email → NULL
+    { orgId: "globex", fullName: "Jane Doe", email: "jane@globex.com", sourceSystem: "salesforce" },
+  ];
+  for (const record of seed) {
+    await store.nodes.Contact.create(record);
+  }
+  console.log(`  Seeded ${seed.length} contacts across 2 orgs\n`);
+
+  // ============================================================
+  // Reconcile an incoming import batch by (orgId, fullName)
+  // ============================================================
+
+  console.log("=== Reconcile incoming batch by (orgId, fullName) ===\n");
+
+  const incoming = [
+    { orgId: "acme", fullName: "Jane Doe" }, // 2 candidates → needs merge review
+    { orgId: "acme", fullName: "John Smith" }, // 1 candidate → likely the same person
+    { orgId: "acme", fullName: "Grace Hopper" }, // 0 candidates → create new
+    { orgId: "globex", fullName: "Jane Doe" }, // 1 candidate → org-scoped, not acme's Janes
+  ];
+
+  // bulkFindByIndex takes records shaped as { props }, one per input. Each
+  // input's candidates come back in the same position, ordered by node id.
+  const candidates = await store.nodes.Contact.bulkFindByIndex(
+    "contact_by_org_name",
+    incoming.map((record) => ({ props: record })),
+  );
+
+  for (const [index, record] of incoming.entries()) {
+    const bucket = candidates[index] ?? [];
+    const decision = bucket.length === 0 ? "CREATE NEW" : `REVIEW (${bucket.length} candidate(s))`;
+    console.log(`  ${record.orgId}/${record.fullName} → ${decision}`);
+    for (const candidate of bucket) {
+      console.log(`      ↳ ${candidate.id} via ${candidate.sourceSystem}`);
+    }
+  }
+
+  // ============================================================
+  // Null-safe matching by (orgId, email)
+  // ============================================================
+
+  console.log("\n=== Null-safe matching by (orgId, email) ===\n");
+
+  // A probe that omits `email` matches stored rows whose email is NULL —
+  // not every acme row. A probe with a concrete email matches that value.
+  const emailProbes = [
+    { orgId: "acme" }, // email omitted → matches the two NULL-email rows
+    { orgId: "acme", email: "jane@acme.com" }, // matches the one salesforce Jane
+  ];
+  const emailMatches = await store.nodes.Contact.bulkFindByIndex(
+    "contact_by_org_email",
+    emailProbes.map((record) => ({ props: record })),
+  );
+
+  console.log("  acme / (no email) →");
+  for (const match of emailMatches[0] ?? []) {
+    console.log(`      ↳ ${match.fullName} (email: ${match.email ?? "none"})`);
+  }
+  console.log("  acme / jane@acme.com →");
+  for (const match of emailMatches[1] ?? []) {
+    console.log(`      ↳ ${match.fullName} (${match.sourceSystem})`);
+  }
+
+  // ============================================================
+  // Capping candidates with limitPerInput
+  // ============================================================
+
+  console.log("\n=== Capping candidates with limitPerInput ===\n");
+
+  // Low-selectivity keys can return many candidates. `limitPerInput` caps each
+  // bucket (lowest node ids kept). On backends with SQL window functions the
+  // cap runs in-database via ROW_NUMBER(); otherwise it is applied in memory
+  // with the same result.
+  const [capped] = await store.nodes.Contact.bulkFindByIndex(
+    "contact_by_org_name",
+    [{ props: { orgId: "acme", fullName: "Jane Doe" } }],
+    { limitPerInput: 1 },
+  );
+  console.log(`  acme/Jane Doe with limitPerInput: 1 → ${capped?.length ?? 0} candidate (of 2)`);
+
+  console.log("\n=== Batched index lookup example complete ===");
+
+  await backend.close();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/README.md
+++ b/packages/typegraph/examples/README.md
@@ -40,6 +40,7 @@ npx tsx examples/<example-name>.ts
 | [07-delete-behaviors.ts](./07-delete-behaviors.ts) | Cascade, restrict, and disconnect on delete |
 | [09-pagination-streaming.ts](./09-pagination-streaming.ts) | Cursor pagination and result streaming |
 | [13-aggregates.ts](./13-aggregates.ts) | GROUP BY, COUNT, SUM, AVG, MIN, MAX, and HAVING |
+| [17-bulk-find-by-index.ts](./17-bulk-find-by-index.ts) | Batched candidate lookup by declared index for import reconciliation and dedup, with null-safe matching and `limitPerInput` |
 
 ### Backend Configuration
 
@@ -61,6 +62,12 @@ the only diff from example 10 is the import line and connection setup.
 | [12-knowledge-graph-rag.ts](./12-knowledge-graph-rag.ts) | Knowledge graph patterns for RAG applications |
 | [14-research-copilot.ts](./14-research-copilot.ts) | End-to-end showcase: semantic search + ontology-expanded topics + all five Tier 1 graph algorithms over a citation graph |
 | [15-fulltext-hybrid-search.ts](./15-fulltext-hybrid-search.ts) | BM25 fulltext + hybrid (vector + fulltext) retrieval with RRF, query modes, and index rebuild |
+
+### Runtime Schema & Application Showcases
+
+| Example | Description |
+|---------|-------------|
+| [16-graph-extensions.ts](./16-graph-extensions.ts) | Runtime schema evolution with operator-approved graph extensions, dynamic kinds, fulltext, indexes, and removal |
 
 ## Prerequisites
 
@@ -121,5 +128,7 @@ Each example follows a consistent pattern:
 4. Understand data lifecycle with **07-delete-behaviors**
 5. Learn efficient data access with **09-pagination-streaming**
 6. Learn aggregate queries with **13-aggregates**
-7. For production, see **10-postgresql** for backend configuration
-8. For AI/ML applications, see **11-semantic-search** and **12-knowledge-graph-rag**
+7. Reconcile imports and find dedup candidates with **17-bulk-find-by-index**
+8. For production, see **10-postgresql** for backend configuration
+9. For AI/ML applications, see **11-semantic-search** and **12-knowledge-graph-rag**
+10. For end-to-end application demos, see **14-research-copilot**


### PR DESCRIPTION
Documentation follow-up to the 0.30.0 `bulkFindByIndex` (#171) / `windowFunctions` (#173) work, from a doc-sync sweep. No source/runtime changes.

- **`backend-setup.md` parity matrix** — documents that `bulkFindByIndex({ limitPerInput })` does *not* throw on a `windowFunctions: false` backend; it degrades gracefully to in-memory per-group capping (identical results), unlike vector/fulltext/hybrid relevance ranking where the window output *is* the result and a `ConfigurationError` is thrown. Closes the last open item from #172.
- **New runnable example `examples/17-bulk-find-by-index.ts`** — import-reconciliation walkthrough covering composite non-unique keys, org-scoped matching, the empty-bucket → create-new decision, null-safe matching (omitted key field matches stored `NULL`), and `limitPerInput` capping. Wired into the examples README under Data Management.
- **`integration.md` cross-reference** — adds a `bulkFindByIndex` note to the "Adding TypeGraph Indexes" section linking the batched-lookup reference and the new example.
- **Homepage release badge** — the badge tracked `v{version}` dynamically but the highlight phrase was still "Runtime schema evolution" from a prior release; updated to "Batched index lookup" (0.30.0 headline) in both the visible text and aria-label.