### PR TITLE
chore(docs): format .astro files with prettier-plugin-astro

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,11 @@ src/routeTree.gen.ts
 worker-configuration.d.ts
 dist/
 node_modules
+
+# Vendor analytics bootstrap: minified is:inline snippet that prettier-plugin-astro cannot parse
+apps/docs/src/components/Analytics.astro
+
+# Hand-authored SVG illustrations: prettier-plugin-astro expands self-closing SVG tags and
+# wraps every attribute, bloating these write-once art files with no readability gain
+apps/docs/src/components/landing/HeroIllustration.astro
+apps/docs/src/components/landing/FeatureIcon.astro

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,5 @@
 {
-  "experimentalTernaries": true
+  "experimentalTernaries": true,
+  "plugins": ["prettier-plugin-astro"],
+  "overrides": [{ "files": "*.astro", "options": { "parser": "astro" } }]
 }

--- a/apps/docs/src/components/landing/NewsletterSignup.astro
+++ b/apps/docs/src/components/landing/NewsletterSignup.astro
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 <section class="py-24 text-center">
@@ -84,8 +85,9 @@
       return;
     }
 
-    messageEl.textContent = data.alreadySubscribed
-      ? "You\u2019re already subscribed!"
+    messageEl.textContent =
+      data.alreadySubscribed ?
+        "You\u2019re already subscribed!"
       : "You\u2019re in. Thanks for subscribing!";
     messageEl.className = "mt-4 text-sm text-primary";
     emailInput.disabled = true;

--- a/apps/docs/src/components/starlight/ThemeProvider.astro
+++ b/apps/docs/src/components/starlight/ThemeProvider.astro
@@ -11,34 +11,41 @@
 
 {/* Intentionally inlined to avoid FOUC. */}
 <script is:inline>
-	window.StarlightThemeProvider = (() => {
-		const storedTheme =
-			typeof localStorage !== 'undefined' && localStorage.getItem('starlight-theme');
-		const theme =
-			storedTheme ||
-			(window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-		document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark';
+  window.StarlightThemeProvider = (() => {
+    const storedTheme =
+      typeof localStorage !== "undefined" &&
+      localStorage.getItem("starlight-theme");
+    const theme =
+      storedTheme ||
+      (window.matchMedia("(prefers-color-scheme: light)").matches ?
+        "light"
+      : "dark");
+    document.documentElement.dataset.theme =
+      theme === "light" ? "light" : "dark";
 
-		const iconSvgs = {
-			light: '<path d="M5 12a1 1 0 0 0-1-1H3a1 1 0 0 0 0 2h1a1 1 0 0 0 1-1Zm.64 5-.71.71a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l.71-.71A1 1 0 0 0 5.64 17ZM12 5a1 1 0 0 0 1-1V3a1 1 0 0 0-2 0v1a1 1 0 0 0 1 1Zm5.66 2.34a1 1 0 0 0 .7-.29l.71-.71a1 1 0 1 0-1.41-1.41l-.66.71a1 1 0 0 0 0 1.41 1 1 0 0 0 .66.29Zm-12-.29a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.71-.71a1.004 1.004 0 1 0-1.43 1.41l.73.71ZM21 11h-1a1 1 0 0 0 0 2h1a1 1 0 0 0 0-2Zm-2.64 6A1 1 0 0 0 17 18.36l.71.71a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.76-.66ZM12 6.5a5.5 5.5 0 1 0 5.5 5.5A5.51 5.51 0 0 0 12 6.5Zm0 9a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0 3.5a1 1 0 0 0-1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 0-1-1Z"/>',
-			dark: '<path d="M21.64 13a1 1 0 0 0-1.05-.14 8.049 8.049 0 0 1-3.37.73 8.15 8.15 0 0 1-8.14-8.1 8.59 8.59 0 0 1 .25-2A1 1 0 0 0 8 2.36a10.14 10.14 0 1 0 14 11.69 1 1 0 0 0-.36-1.05Zm-9.5 6.69A8.14 8.14 0 0 1 7.08 5.22v.27a10.15 10.15 0 0 0 10.14 10.14 9.784 9.784 0 0 0 2.1-.22 8.11 8.11 0 0 1-7.18 4.32v-.04Z"/>',
-			auto: '<path d="M21 14h-1V7a3 3 0 0 0-3-3H7a3 3 0 0 0-3 3v7H3a1 1 0 0 0-1 1v2a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-2a1 1 0 0 0-1-1ZM6 7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7H6V7Zm14 10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1h16v1Z"/>',
-		};
+    const iconSvgs = {
+      light:
+        '<path d="M5 12a1 1 0 0 0-1-1H3a1 1 0 0 0 0 2h1a1 1 0 0 0 1-1Zm.64 5-.71.71a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l.71-.71A1 1 0 0 0 5.64 17ZM12 5a1 1 0 0 0 1-1V3a1 1 0 0 0-2 0v1a1 1 0 0 0 1 1Zm5.66 2.34a1 1 0 0 0 .7-.29l.71-.71a1 1 0 1 0-1.41-1.41l-.66.71a1 1 0 0 0 0 1.41 1 1 0 0 0 .66.29Zm-12-.29a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.71-.71a1.004 1.004 0 1 0-1.43 1.41l.73.71ZM21 11h-1a1 1 0 0 0 0 2h1a1 1 0 0 0 0-2Zm-2.64 6A1 1 0 0 0 17 18.36l.71.71a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.76-.66ZM12 6.5a5.5 5.5 0 1 0 5.5 5.5A5.51 5.51 0 0 0 12 6.5Zm0 9a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0 3.5a1 1 0 0 0-1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 0-1-1Z"/>',
+      dark: '<path d="M21.64 13a1 1 0 0 0-1.05-.14 8.049 8.049 0 0 1-3.37.73 8.15 8.15 0 0 1-8.14-8.1 8.59 8.59 0 0 1 .25-2A1 1 0 0 0 8 2.36a10.14 10.14 0 1 0 14 11.69 1 1 0 0 0-.36-1.05Zm-9.5 6.69A8.14 8.14 0 0 1 7.08 5.22v.27a10.15 10.15 0 0 0 10.14 10.14 9.784 9.784 0 0 0 2.1-.22 8.11 8.11 0 0 1-7.18 4.32v-.04Z"/>',
+      auto: '<path d="M21 14h-1V7a3 3 0 0 0-3-3H7a3 3 0 0 0-3 3v7H3a1 1 0 0 0-1 1v2a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-2a1 1 0 0 0-1-1ZM6 7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7H6V7Zm14 10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1h16v1Z"/>',
+    };
 
-		return {
-			updatePickers(theme = storedTheme || 'auto') {
-				document.querySelectorAll('starlight-theme-select').forEach((picker) => {
-					const select = picker.querySelector('select');
-					if (select) select.value = theme;
-					const svg = iconSvgs[theme];
-					if (svg) {
-						const oldIcon = picker.querySelector('svg.label-icon');
-						if (oldIcon) {
-							oldIcon.innerHTML = svg;
-						}
-					}
-				});
-			},
-		};
-	})();
+    return {
+      updatePickers(theme = storedTheme || "auto") {
+        document
+          .querySelectorAll("starlight-theme-select")
+          .forEach((picker) => {
+            const select = picker.querySelector("select");
+            if (select) select.value = theme;
+            const svg = iconSvgs[theme];
+            if (svg) {
+              const oldIcon = picker.querySelector("svg.label-icon");
+              if (oldIcon) {
+                oldIcon.innerHTML = svg;
+              }
+            }
+          });
+      },
+    };
+  })();
 </script>

--- a/apps/docs/src/layouts/Landing.astro
+++ b/apps/docs/src/layouts/Landing.astro
@@ -54,15 +54,32 @@ const ogImageAlt =
     <Analytics />
   </head>
   <body>
-    <nav class="flex justify-between items-center py-6 px-8 max-w-[1200px] mx-auto">
-      <a href="/" class="text-2xl font-extrabold text-text-main no-underline flex items-center gap-3">
+    <nav
+      class="flex justify-between items-center py-6 px-8 max-w-[1200px] mx-auto"
+    >
+      <a
+        href="/"
+        class="text-2xl font-extrabold text-text-main no-underline flex items-center gap-3"
+      >
         <img src="/favicon.svg" alt="" class="w-14 h-14" />
         TypeGraph
       </a>
       <div class="flex gap-8">
-        <a href="/overview" class="text-text-muted font-semibold hover:text-primary transition-colors">Docs</a>
-        <a href="/getting-started" class="text-text-muted font-semibold hover:text-primary transition-colors">Get Started</a>
-        <a href="https://github.com/nicia-ai/typegraph" class="text-text-muted font-semibold hover:text-primary transition-colors">GitHub</a>
+        <a
+          href="/overview"
+          class="text-text-muted font-semibold hover:text-primary transition-colors"
+          >Docs</a
+        >
+        <a
+          href="/getting-started"
+          class="text-text-muted font-semibold hover:text-primary transition-colors"
+          >Get Started</a
+        >
+        <a
+          href="https://github.com/nicia-ai/typegraph"
+          class="text-text-muted font-semibold hover:text-primary transition-colors"
+          >GitHub</a
+        >
       </div>
     </nav>
     <slot />

--- a/apps/docs/src/pages/404.astro
+++ b/apps/docs/src/pages/404.astro
@@ -13,11 +13,13 @@ import Layout from "../layouts/Landing.astro";
       <a
         href="/"
         class="inline-flex items-center justify-center px-6 py-3 rounded-lg text-white bg-primary font-semibold hover:bg-primary-dark hover:-translate-y-px transition-all duration-200"
-      >Home</a>
+        >Home</a
+      >
       <a
         href="/overview"
         class="inline-flex items-center justify-center px-6 py-3 rounded-lg text-text-main border border-border bg-transparent font-semibold hover:border-primary hover:text-primary transition-all duration-200"
-      >Documentation</a>
+        >Documentation</a
+      >
     </div>
   </main>
 </Layout>

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -54,15 +54,33 @@ const version = package_.version;
     </section>
 
     <section class="py-16 text-center">
-      <h2 class="text-4xl font-extrabold mb-4">Define. Connect. Query. Evolve.</h2>
+      <h2 class="text-4xl font-extrabold mb-4">
+        Define. Connect. Query. Evolve.
+      </h2>
       <p class="text-xl text-text-muted mb-12">
         Your schema is your database. Your types are your queries.
       </p>
 
       <div class="code-tabs max-w-[900px] mx-auto text-left">
-        <input type="radio" name="ctab" id="ctab-basic" checked aria-label="Basic example" />
-        <input type="radio" name="ctab" id="ctab-hybrid" aria-label="Hybrid search example" />
-        <input type="radio" name="ctab" id="ctab-evolve" aria-label="Runtime evolution example" />
+        <input
+          type="radio"
+          name="ctab"
+          id="ctab-basic"
+          checked
+          aria-label="Basic example"
+        />
+        <input
+          type="radio"
+          name="ctab"
+          id="ctab-hybrid"
+          aria-label="Hybrid search example"
+        />
+        <input
+          type="radio"
+          name="ctab"
+          id="ctab-evolve"
+          aria-label="Runtime evolution example"
+        />
 
         <div
           class="code-tab-labels flex gap-1 border-b border-[#333] bg-[#252526] rounded-t-xl overflow-x-auto"
@@ -73,9 +91,12 @@ const version = package_.version;
           <label for="ctab-evolve">Runtime Evolution</label>
         </div>
 
-        <div class="code-tab-panels bg-[#1e1e1e] border border-t-0 border-[#333] rounded-b-xl shadow-2xl overflow-hidden">
+        <div
+          class="code-tab-panels bg-[#1e1e1e] border border-t-0 border-[#333] rounded-b-xl shadow-2xl overflow-hidden"
+        >
           <div class="code-panel code-panel-basic p-6 overflow-x-auto">
-            <pre class="m-0 font-mono text-sm leading-relaxed text-[#d4d4d4]"><code is:raw><span class="hl-keyword">import</span> { defineNode, defineEdge, defineGraph, createStore } <span class="hl-keyword">from</span> <span class="hl-string">"@nicia-ai/typegraph"</span>;
+            <pre
+              class="m-0 font-mono text-sm leading-relaxed text-[#d4d4d4]"><code is:raw><span class="hl-keyword">import</span> { defineNode, defineEdge, defineGraph, createStore } <span class="hl-keyword">from</span> <span class="hl-string">"@nicia-ai/typegraph"</span>;
 <span class="hl-keyword">import</span> { z } <span class="hl-keyword">from</span> <span class="hl-string">"zod"</span>;
 
 <span class="hl-comment">// 1. Define your ontology</span>
@@ -104,7 +125,8 @@ const version = package_.version;
           </div>
 
           <div class="code-panel code-panel-hybrid p-6 overflow-x-auto">
-            <pre class="m-0 font-mono text-sm leading-relaxed text-[#d4d4d4]"><code is:raw><span class="hl-keyword">import</span> { defineNode, searchable, embedding } <span class="hl-keyword">from</span> <span class="hl-string">"@nicia-ai/typegraph"</span>;
+            <pre
+              class="m-0 font-mono text-sm leading-relaxed text-[#d4d4d4]"><code is:raw><span class="hl-keyword">import</span> { defineNode, searchable, embedding } <span class="hl-keyword">from</span> <span class="hl-string">"@nicia-ai/typegraph"</span>;
 <span class="hl-keyword">import</span> { z } <span class="hl-keyword">from</span> <span class="hl-string">"zod"</span>;
 
 <span class="hl-comment">// 1. Declare semantic + fulltext fields right in the Zod schema</span>
@@ -133,7 +155,8 @@ const version = package_.version;
           </div>
 
           <div class="code-panel code-panel-evolve p-6 overflow-x-auto">
-            <pre class="m-0 font-mono text-sm leading-relaxed text-[#d4d4d4]"><code is:raw><span class="hl-keyword">import</span> { defineGraphExtension } <span class="hl-keyword">from</span> <span class="hl-string">"@nicia-ai/typegraph"</span>;
+            <pre
+              class="m-0 font-mono text-sm leading-relaxed text-[#d4d4d4]"><code is:raw><span class="hl-keyword">import</span> { defineGraphExtension } <span class="hl-keyword">from</span> <span class="hl-string">"@nicia-ai/typegraph"</span>;
 
 <span class="hl-comment">// 1. An agent proposes a typed kind from observed data.</span>
 <span class="hl-keyword">const</span> <span class="hl-type">proposal</span> = defineGraphExtension({
@@ -196,8 +219,8 @@ const version = package_.version;
           </h3>
           <p class="text-text-muted">
             Built for RAG and agentic systems. Hybrid retrieval blends BM25
-            fulltext with vector similarity in a single query, and your
-            ontology gives LLMs the structured context they need.
+            fulltext with vector similarity in a single query, and your ontology
+            gives LLMs the structured context they need.
           </p>
         </div>
         <div
@@ -283,9 +306,9 @@ const version = package_.version;
             </h3>
             <p class="text-text-muted mb-6 grow">
               Feed your LLMs high-fidelity, structured context. Map documents to
-              concepts, authors, and entities — then retrieve with hybrid
-              search (vector + fulltext) and let agents extend the ontology
-              when they encounter new types.
+              concepts, authors, and entities — then retrieve with hybrid search
+              (vector + fulltext) and let agents extend the ontology when they
+              encounter new types.
             </p>
             <a
               href="/examples/knowledge-graph-rag/"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "markdownlint-cli2": "^0.22.1",
     "npm-run-all2": "^9.0.1",
     "prettier": "^3.8.3",
+    "prettier-plugin-astro": "^0.14.1",
     "tsx": "^4.22.4",
     "turbo": "^2.9.16",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      prettier-plugin-astro:
+        specifier: ^0.14.1
+        version: 0.14.1
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -40,7 +43,7 @@ importers:
     dependencies:
       '@astrojs/check':
         specifier: ^0.9.9
-        version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
+        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)
       '@astrojs/cloudflare':
         specifier: ^13.6.1
         version: 13.6.1(@types/node@24.12.0)(astro@6.4.3(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(workerd@1.20260601.1)(wrangler@4.97.0)(yaml@2.9.0)
@@ -5092,6 +5095,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-astro@0.14.1:
+    resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
+    engines: {node: ^14.15.0 || >=16.0.0}
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -5335,11 +5342,17 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  s.color@0.0.15:
+    resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass-formatter@0.7.9:
+    resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -5573,6 +5586,9 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  suf-log@2.5.3:
+    resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -6300,9 +6316,9 @@ packages:
 
 snapshots:
 
-  '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)':
+  '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.7(prettier@3.8.3)(typescript@5.9.3)
+      '@astrojs/language-server': 2.16.7(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 5.9.3
@@ -6362,7 +6378,7 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
-  '@astrojs/language-server@2.16.7(prettier@3.8.3)(typescript@5.9.3)':
+  '@astrojs/language-server@2.16.7(prettier-plugin-astro@0.14.1)(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.3
@@ -6384,6 +6400,7 @@ snapshots:
       vscode-uri: 3.1.0
     optionalDependencies:
       prettier: 3.8.3
+      prettier-plugin-astro: 0.14.1
     transitivePeerDependencies:
       - typescript
 
@@ -11509,6 +11526,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier-plugin-astro@0.14.1:
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      prettier: 3.8.3
+      sass-formatter: 0.7.9
+
   prettier@2.8.8: {}
 
   prettier@3.8.3: {}
@@ -11877,9 +11900,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  s.color@0.0.15: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sass-formatter@0.7.9:
+    dependencies:
+      suf-log: 2.5.3
 
   sax@1.6.0: {}
 
@@ -12145,6 +12174,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  suf-log@2.5.3:
+    dependencies:
+      s.color: 0.0.15
 
   supports-color@10.2.2: {}
 


### PR DESCRIPTION
Register `prettier-plugin-astro` so `.astro` files are actually covered by `prettier --check .` (the CI "Prettier" step) and `pnpm fix`. Today no Astro parser is registered, so prettier silently skips all `.astro` files — they fall outside the formatting net the repo's tooling otherwise applies tree-wide.

## What changed

- **Dependency:** `prettier-plugin-astro` added to root devDependencies.
- **`.prettierrc`:** registers the plugin + an `*.astro` parser override.
- **`.prettierignore`:** three deliberate exclusions —
  - `Analytics.astro` — minified vendor `is:inline` PostHog snippet the plugin **cannot parse** (would make `prettier --check .` error → CI red).
  - `HeroIllustration.astro`, `FeatureIcon.astro` — hand-authored SVG illustrations. The plugin expands self-closing SVG tags (`<circle/>` → `<circle></circle>`) and wraps every attribute, bloating these write-once art files with no readability gain.
- **Reformatted 5 files** (the pages/layouts/components people actually edit): `index.astro`, `404.astro`, `Landing.astro`, `ThemeProvider.astro`, `NewsletterSignup.astro`. Markup/whitespace only — no render changes.

## Why scoped, not all-in

Adopting the plugin across all 9 files produced +327/−127, ~226 of which was SVG self-closing/attribute noise in the two illustration files. Scoping to the genuine markup keeps this to +95/−40 of useful formatting and avoids churning write-once art.

## Note

`prettier-plugin-tailwindcss` was intentionally **not** added — it would reorder every Tailwind `class="…"` string across all components (large, opinionated churn). Out of scope here.
