### PR TITLE
Add graph merge

### DIFF
--- a/.changeset/add-graph-merge-subpath.md
+++ b/.changeset/add-graph-merge-subpath.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `@nicia-ai/typegraph/graph-merge`, a TypeGraph-native branch and semantic merge subpath for deterministic entity-resolution merges across graph forks.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -13,6 +13,7 @@ const LLMS_SMALL_PAGES = new Set([
   "schema-management",
   "schema-evolution",
   "graph-extensions",
+  "graph-merge",
   "integration",
   "multiple-graphs",
   "queries/overview",
@@ -47,6 +48,7 @@ const sidebar = [
       { label: "Schema Migrations", slug: "schema-management" },
       { label: "Evolving Schemas", slug: "schema-evolution" },
       { label: "Graph Extensions", slug: "graph-extensions" },
+      { label: "Graph Merge", slug: "graph-merge" },
       { label: "Multiple Graphs", slug: "multiple-graphs" },
       { label: "Import/export", slug: "interchange" },
       { label: "Testing", slug: "testing" },
@@ -82,6 +84,14 @@ const sidebar = [
   {
     label: "Examples",
     items: [
+      {
+        label: "FHIR Graph Merge",
+        slug: "examples/fhir-graph-merge",
+      },
+      {
+        label: "Incremental Merge",
+        slug: "examples/incremental-merge",
+      },
       {
         label: "Agent-Driven Schema",
         slug: "examples/agent-driven-schema",

--- a/apps/docs/src/content/docs/examples/fhir-graph-merge.md
+++ b/apps/docs/src/content/docs/examples/fhir-graph-merge.md
@@ -1,0 +1,188 @@
+---
+title: FHIR Graph Merge
+description: Reconcile overlapping FHIR-style records from independent branches into one canonical patient care graph.
+---
+
+This example shows TypeGraph's graph-merge primitive on a concrete healthcare
+interoperability problem: two independent ingestion agents extract overlapping
+FHIR-style records, disagree on patient spelling, and produce separate care
+context. TypeGraph branches isolate those writes. `merge()` folds them into one
+base graph, resolves the duplicate patient, repoints each branch's clinical
+edges, and reports the conflict/provenance trail.
+
+:::tip[Just want the code?]
+Full source on GitHub:
+[`packages/typegraph/examples/18-fhir-graph-merge.ts`](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/18-fhir-graph-merge.ts)
+:::
+
+:::caution[Synthetic demo data only]
+This is an interoperability and data-exploration example. It is not clinical
+decision support and should not be run on protected health information as-is.
+The bundled patient record is synthetic and intentionally small.
+:::
+
+## What It Demonstrates
+
+- `branch()` creates isolated working copies over fresh local SQLite backends.
+- Two patient pairs are reconciled by **two different mechanisms**, so you can
+  see exact identity and fuzzy resolution side by side:
+  - **`Anna Rivera` / `Ana Rivera`** share a unique MRN. The unique constraint
+    forces this merge by **exact identity** — fuzzy scoring is bypassed, so the
+    similarity threshold is irrelevant to their collapse.
+  - **`Mohammed Ali` / `Mohamed Ali`** have **different** MRNs, so nothing forces
+    them. Only the in-memory fulltext name similarity clearing the threshold
+    collapses them — this is the case where similarity is actually decisive.
+- Care-context edges from both branches are repointed onto each canonical
+  patient. The output proves this by reading context through `forPatient` edges
+  *into* the survivor, not via a blanket `.find()`.
+- The merge report surfaces every spelling / identifier disagreement (name,
+  MRN, FHIR id) instead of silently choosing a winner.
+- Report provenance shows which branch contributed the canonical nodes and
+  edges.
+
+## Run It
+
+From the repository root:
+
+```bash
+pnpm --filter @nicia-ai/typegraph exec tsx examples/18-fhir-graph-merge.ts
+```
+
+Or from `packages/typegraph`:
+
+```bash
+npx tsx examples/18-fhir-graph-merge.ts
+```
+
+The example uses in-memory SQLite backends, so it does not require Docker, a
+FHIR server, or external services.
+
+## Sample Output
+
+```text
+=== FHIR Graph Merge ===
+
+Before merge:
+  base patients: 0
+  EHR branch patients: 2
+  claims branch patients: 2
+
+After merge:
+  merged nodes: 9
+  merged edges: 10
+  entity resolutions: 2
+  conflicts:
+    - Patient.fhirId on patient-ana: claims-agent="Patient/claims-ana", ehr-agent="Patient/ehr-anna"
+    - Patient.name on patient-ana: claims-agent="Ana Rivera", ehr-agent="Anna Rivera"
+    - Patient.fhirId on patient-mohamed: claims-agent="Patient/claims-mohamed", ehr-agent="Patient/ehr-mohammed"
+    - Patient.mrn on patient-mohamed: claims-agent="MRN-205", ehr-agent="MRN-204"
+    - Patient.name on patient-mohamed: claims-agent="Mohamed Ali", ehr-agent="Mohammed Ali"
+  provenance:
+    - ehr-agent: 6 node(s), 6 edge(s)
+    - claims-agent: 5 node(s), 4 edge(s)
+
+Canonical patients and their repointed care context:
+  Ana Rivera (MRN-001, 1974-03-09)
+    - Encounter: Hypertension follow-up (2026-04-11T09:30:00-07:00)
+    - Encounter: Kidney function review (2026-04-14T10:00:00-07:00)
+    - MedicationRequest: Lisinopril 10 MG Oral Tablet - Take one tablet by mouth daily
+    - Observation: Blood pressure panel = 152/96 mmHg (high)
+    - Observation: Estimated glomerular filtration rate = 54 mL/min/1.73m2 (low)
+  Mohamed Ali (MRN-205, 1990-08-21)
+    - Encounter: Cardiology consult (2026-05-02T13:00:00-07:00)
+    - Observation: LDL cholesterol = 168 mg/dL (high)
+```
+
+The `Mohamed Ali` line is the proof that fuzzy resolution and edge repointing
+both work: the two spellings carried **different** MRNs (so no exact match
+forced them), yet they collapsed to one patient — and that patient now owns the
+EHR branch's cardiology encounter *and* the claims branch's lab observation,
+each repointed from its origin branch.
+
+## Graph Model
+
+The example keeps the schema intentionally small:
+
+| TypeGraph kind | FHIR-ish source | Purpose |
+| -------------- | --------------- | ------- |
+| `Patient` | `Patient` | The canonical person being reconciled |
+| `Encounter` | `Encounter` | Clinical visit context |
+| `Observation` | `Observation` | Vitals and lab evidence |
+| `MedicationRequest` | `MedicationRequest` | Medication order |
+| `forPatient` | `subject` references | Connects clinical resources to the patient |
+| `duringEncounter` | `encounter` references | Connects observations/orders to visits |
+| `reasonFor` | `reasonReference` | Connects an order to supporting evidence |
+
+The `Patient` kind declares a unique MRN constraint:
+
+```typescript
+const careGraph = defineGraph({
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "patient_mrn",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
+  },
+});
+```
+
+A shared unique value is a **definitional** identity source: when two staged
+nodes share all of a constraint's fields, they are forced to merge and fuzzy
+scoring is bypassed entirely. That is what collapses `Anna Rivera` / `Ana Rivera`
+(both `MRN-001`) — the similarity threshold never enters into it. The merge still
+reports their property disagreements (`name`, `fhirId`).
+
+## Merge Configuration
+
+The example configures entity resolution only for `Patient`; other kinds merge
+by ID and keep their branch-specific clinical context.
+
+```typescript
+const mergeOptions = {
+  resolve: {
+    Patient: {
+      // Block by shared birth date. The unique MRN constraint forces exact
+      // matches in its own bucket, so blocking does not need the MRN — and using
+      // it would split the different-MRN fuzzy pair apart.
+      block: (node) => node.birthDate,
+      similarity: { kind: "fulltext", fields: ["name"] },
+      threshold: 0.78,
+    },
+  },
+  onPropertyConflict: "flag",
+  branchOrder: [EHR_BRANCH, CLAIMS_BRANCH],
+  provenance: true,
+};
+```
+
+The `fulltext` strategy is an in-memory trigram scorer. It does not require
+embeddings, database fulltext indexes, or a specific backend, which makes it a
+good default for bounded candidate dedup during merge. It is the **decisive**
+signal for `Mohammed Ali` / `Mohamed Ali`: those records carry different MRNs,
+so no unique match forces them — only the name score clearing `threshold`
+collapses them.
+
+## Why This Matters
+
+FHIR imports often arrive from multiple systems: EHR exports, claims feeds,
+lab feeds, patient-reported questionnaires, and agent-produced extraction
+passes. Each source can be useful, but naive append-only ingestion leaves
+duplicates and broken care context.
+
+Graph merge gives you a deterministic reconciliation step:
+
+1. Run each extractor in an isolated branch.
+2. Keep all writes type-checked by the same TypeGraph schema.
+3. Resolve entities by exact identity, blocking keys, and similarity.
+4. Preserve branch-specific context by repointing edges.
+5. Return a merge report that callers can inspect, persist, or route for human
+   review.
+
+See [Graph Merge](/graph-merge) for the API reference and option semantics.

--- a/apps/docs/src/content/docs/examples/incremental-merge.md
+++ b/apps/docs/src/content/docs/examples/incremental-merge.md
@@ -1,0 +1,129 @@
+---
+title: Incremental Merge
+description: Ingest into a live graph in waves — mergeIncremental() folds a new source onto an already-committed graph without creating duplicates, and persists a queryable provenance trail.
+---
+
+This example shows TypeGraph's **incremental** merge path. Where the snapshot
+[`merge()`](/examples/fhir-graph-merge) reconciles branches that all forked from
+the *current* base, `mergeIncremental()` folds a new source's branch into a
+`target` that has **already advanced** — re-discovering an entity that was
+committed in an earlier wave and merging onto it instead of creating a duplicate.
+
+It is the primitive for **continuous ingestion**: every new feed, crawl, or
+agent batch lands on the live graph, deduplicated against what is already there.
+
+:::tip[Just want the code?]
+Full source on GitHub:
+[`packages/typegraph/examples/19-incremental-merge.ts`](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/19-incremental-merge.ts)
+:::
+
+## What It Demonstrates
+
+- A `target` graph that already holds one committed `Company` ("Acme Corp").
+- A new provider branch (forked from an empty fork-point in this example) that
+  re-reports the same company under a different spelling
+  ("ACME Corporation", same `acme.com` domain) and adds a genuinely new one
+  ("Globex").
+- `mergeIncremental()` recalls the committed company via its unique `domain` and
+  merges the new spelling **onto** it — the target keeps one Acme, not two.
+- The name disagreement is flagged in the report instead of silently overwriting
+  the committed value.
+- Provenance is persisted to a sidecar graph and queried back: "which canonical
+  entities did this provider contribute to?"
+
+## Run It
+
+From the repository root:
+
+```bash
+pnpm --filter @nicia-ai/typegraph exec tsx examples/19-incremental-merge.ts
+```
+
+Or from `packages/typegraph`:
+
+```bash
+npx tsx examples/19-incremental-merge.ts
+```
+
+It uses in-memory SQLite backends, so it needs no Docker or external services.
+
+## Sample Output
+
+```text
+=== Incremental Graph Merge ===
+
+Target before: [ 'Acme Corp (acme.com)' ]
+Target after:  [ 'Acme Corp (acme.com)', 'Globex (globex.io)' ]
+
+No duplicate was created: the provider's "ACME Corporation" merged onto the
+committed "Acme Corp" via the shared domain.
+
+Merged nodes: 2
+Entity resolutions: 1
+Conflict on Company.name @ acme: provider-crunchbase="ACME Corporation"
+
+Provenance persisted: 3 row(s) in sidecar "company_kb::merge-provenance"
+
+Provenance — canonical entities this provider contributed to:
+  - Company "cb-globex" (from source "cb-globex")
+  - Company "acme" (from source "cb-acme")
+```
+
+## How It Works
+
+```typescript
+const result = await mergeIncremental({
+  forkPoint, // the frozen ancestor the provider branch forked from
+  target, // the live committed graph (already holds "Acme Corp")
+  branches: [provider],
+  options: {
+    resolve: {
+      Company: {
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.9,
+      },
+    },
+    onPropertyConflict: "flag",
+    onBasePropertyConflict: "flag", // required by mergeIncremental (keep-base)
+    branchOrder: [PROVIDER],
+    persistProvenance: true,
+  },
+});
+```
+
+Two ideas do the work:
+
+1. **Unique `domain` as definitional identity.** The `Company` kind declares a
+   unique constraint on `domain`. The new-vs-base recall queries the target for
+   committed companies that share a staged company's domain, so "ACME
+   Corporation" (`acme.com`) is matched to the committed "Acme Corp" regardless
+   of the name spelling — no similarity threshold needs to be cleared.
+2. **Keep-base conflict handling.** `onBasePropertyConflict: "flag"` guarantees
+   a stale branch value can never overwrite a newer committed one: the committed
+   `name` is kept and the provider's spelling is recorded as a conflict for
+   review.
+
+The genuinely-new "Globex" has no committed match, so it is created. After the
+commit, `persistProvenance` writes one row per contribution to a sidecar graph
+on the target's backend, which `readProvenance` reads back later.
+
+## Why This Matters
+
+Real ingestion is never one-shot. Feeds arrive continuously, crawls re-run, and
+agents produce overlapping batches. Append-only ingestion turns that into a pile
+of duplicates; a full re-merge from scratch does not scale.
+
+`mergeIncremental()` gives you a **steady-state ingestion loop**:
+
+1. Take each new source as a branch off a known fork-point.
+2. Merge it into the live target; already-known entities are recalled and
+   updated in place, inherited modifications/deletions propagate, and new ones
+   are created.
+3. Keep concurrently changed committed data authoritative
+   (`onBasePropertyConflict: "flag"`).
+4. Persist provenance so every canonical entity carries the trail of which
+   source contributed it.
+
+See [Graph Merge](/graph-merge) for the full API reference, and
+[FHIR Graph Merge](/examples/fhir-graph-merge) for the snapshot-merge
+counterpart.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -1,0 +1,483 @@
+---
+title: Graph Merge
+description: Branch a TypeGraph store, let many writers edit it independently, and fold their work back into one canonical graph with deterministic entity resolution, conflict reporting, edge repointing, and provenance.
+---
+
+Graph Merge turns a TypeGraph store into something you can **fork, edit in
+parallel, and reconcile** — the way you already fork, branch, and merge code.
+Several writers (agents, importers, reviewers, background workers) each build
+graph changes in isolation, and a single deterministic step folds them back into
+one canonical graph: duplicate entities are resolved, edges are repointed onto
+the survivors, disagreements are surfaced (never silently overwritten), and you
+get a full report of what happened and who contributed it.
+
+It ships as a core package subpath:
+
+```typescript
+import { branch, merge } from "@nicia-ai/typegraph/graph-merge";
+```
+
+Everything here is defined over ordinary TypeGraph stores, schemas, indexes,
+backends, and ontology semantics — there is no separate service to run.
+
+## What you can build
+
+Graph Merge exists because "append everything" is the wrong default for graphs:
+it produces duplicate entities and dangling relationships. With a real merge
+primitive you can build:
+
+- **Multi-agent knowledge-graph construction.** Run N extraction agents in
+  parallel, each on its own branch, then merge. The same real-world entity
+  discovered by three agents collapses to one canonical node; every agent's
+  edges follow it; disagreements come back as conflicts to adjudicate.
+- **Parallel ETL / import reconciliation.** Ingest an EHR export, a claims
+  feed, and a lab feed as independent branches and reconcile them into one
+  patient-care graph — by exact identifier, blocking key, or fuzzy name match.
+- **Master-data / entity dedup (CRM, FHIR, catalogs).** Use declared `unique`
+  constraints as definitional identity and similarity scoring for the rest.
+- **Human-in-the-loop review queues.** `merge()` returns a report, not just a
+  mutation. Auto-apply the clean parts, route the conflicts to a reviewer, and
+  keep a provenance trail of every decision.
+- **Incremental ingestion against a live graph.** `mergeIncremental()` lets new
+  batches land on a target that has *advanced* since the branch was taken,
+  re-discovering already-committed entities instead of duplicating them.
+- **Semantic deduplication.** Plug in an embedder for `vector` or `hybrid`
+  similarity to collapse near-duplicates that exact and trigram matching miss.
+
+The throughline: **isolation while writing, determinism while merging, and a
+report you can act on.**
+
+## How it works
+
+The mental model is a three-act lifecycle:
+
+1. **`branch()`** stamps the base store's `base@V` (a hash of its schema *and*
+   live content) and materializes an isolated, independently-mutable working
+   copy. Writers edit the working copy with the normal store API; the base is
+   never touched.
+2. Writers do whatever they want — create nodes/edges, modify inherited rows,
+   delete inherited rows.
+3. **`merge()`** diffs every branch against the base, then runs a fixed
+   pipeline to fold them into the target:
+
+   ```text
+   stage (diff every branch)
+     → generate candidates (exact unique · blocking key · similarity)
+       → cluster (group nodes that are the same entity)
+         → canonicalize (pick a survivor, union properties, resolve conflicts)
+           → repoint + dedupe edges onto survivors
+             → reconcile delete/modify and types
+               → commit transactionally + build the report
+   ```
+
+The pipeline is **deterministic by construction**: candidate sets are sorted,
+clusters resolve by stable keys, and every conflict is decided on an explicit
+`branchOrder` (or lexicographic branch id) — *never* wall-clock arrival. Merging
+the same branches in any order yields the same committed graph and the same
+normalized report. That property is what makes a merge safe to retry, cache, and
+reason about.
+
+## Quick start
+
+Create a base store, fork one branch per writer, write to the branch stores,
+then merge them back into the target.
+
+```typescript
+import { createStoreWithSchema } from "@nicia-ai/typegraph";
+import { asBranchId, branch, isOk, merge, unwrap } from "@nicia-ai/typegraph/graph-merge";
+
+const [base] = await createStoreWithSchema(graph, baseBackend);
+
+// branch() is backend-agnostic: you supply a factory for each branch's backend.
+const makeBranchBackend = async () => createFreshBackend();
+
+const sourceA = unwrap(await branch(base, makeBranchBackend, { id: asBranchId("source-a") }));
+const sourceB = unwrap(await branch(base, makeBranchBackend, { id: asBranchId("source-b") }));
+
+await sourceA.store.nodes.Patient.create({ name: "Anna Rivera", birthDate: "1974-03-09", mrn: "MRN-001" });
+await sourceB.store.nodes.Patient.create({ name: "Ana Rivera", birthDate: "1974-03-09", mrn: "MRN-001" });
+
+const result = await merge(base, [sourceA, sourceB], {
+  resolve: {
+    Patient: {
+      block: (node) => node.mrn ?? node.birthDate,
+      similarity: { kind: "fulltext", fields: ["name"] },
+      threshold: 0.78,
+    },
+  },
+  onPropertyConflict: "flag",
+  branchOrder: [sourceA.id, sourceB.id],
+});
+
+if (!isOk(result)) throw result.error;
+console.log(result.data.resolutions); // the two patients collapsed to one
+console.log(result.data.conflicts); // the "Anna" vs "Ana" spelling disagreement
+```
+
+`branch()` returns a `Result`; `unwrap` throws on failure (or branch on
+`isOk`). The default working-copy strategy clones the base through TypeGraph's
+export/import, so each branch gets a fresh backend from your factory.
+
+## Entity resolution
+
+Resolution is configured **per node kind** in `resolve`. A kind that is omitted
+merges *by id only*: its new nodes and edges are copied through, but no fuzzy
+matching runs. Each configured kind composes up to three candidate sources, all
+feeding one shared scorer:
+
+| Source | What it matches | Configured by |
+| ------ | --------------- | ------------- |
+| Exact unique | Two staged nodes sharing all of a declared `unique` constraint's values — a *definitional* match that bypasses scoring | the graph's `unique` constraints |
+| Blocking key | Cheap pre-grouping so similarity only compares plausibly-related nodes | `block` (staged) / `blockIndex` (vs. committed base) |
+| Similarity | Fuzzy scoring of candidate pairs against a `threshold` | `similarity` + `threshold` |
+
+```typescript
+resolve: {
+  Patient: {
+    block: (node) => node.mrn ?? node.birthDate, // cheap candidate grouping
+    similarity: { kind: "fulltext", fields: ["name"] },
+    threshold: 0.78, // pairs scoring >= 0.78 merge
+  },
+}
+```
+
+### Blocking: `block` vs `blockIndex`
+
+Blocking bounds the otherwise-`O(n²)` pairwise comparison by only comparing
+nodes that share a cheap key.
+
+- **`block(node) => string | undefined`** is an arbitrary function over staged
+  nodes — a normalized email, a tenant id, a birth date, a `soundex(name)`.
+  Returning `undefined` puts the node in the shared *unblocked* bucket.
+- **`blockIndex`** names a declared `defineNodeIndex` and is the **new-vs-base**
+  block key: it lets the merge query *already-committed* nodes that share a
+  staged node's index key and propose them as candidates. It powers incremental
+  ingestion (see [Snapshot vs incremental](#snapshot-vs-incremental)) and is
+  ignored on the snapshot `merge()` path.
+
+```typescript
+import { defineNodeIndex } from "@nicia-ai/typegraph";
+
+const patientCohort = defineNodeIndex(Patient, { name: "patient_cohort_idx", fields: ["cohort"] });
+const graph = defineGraph({ /* ... */ indexes: [patientCohort] });
+
+// In resolve, recall committed patients in the same cohort:
+resolve: { Patient: { blockIndex: "patient_cohort_idx", similarity: { kind: "fulltext", fields: ["name"] }, threshold: 0.85 } }
+```
+
+### Keyless windows
+
+A node with no block key and no unique signature lands in the *unblocked*
+bucket, which is otherwise compared all-vs-all. For large unblocked sets, set
+`keyless` to switch to bounded single-pass **sorted-neighbourhood**: nodes are
+sorted by their similarity text and each is compared only to its next `window`
+neighbours — `O(n·window)` instead of `O(n²)`, still fully deterministic.
+
+```typescript
+resolve: {
+  Article: {
+    similarity: { kind: "fulltext", fields: ["title"] },
+    threshold: 0.8,
+    keyless: { window: 20 }, // compare each unblocked article to its 20 nearest neighbours
+  },
+}
+```
+
+### Similarity strategies
+
+Four strategies cover the spectrum from zero-dependency to embedding-powered:
+
+| Strategy | Needs embedder? | Use case |
+| -------- | --------------- | -------- |
+| `fulltext` | No | Portable in-memory Sørensen–Dice trigram score over one or more fields (e.g. `name`). The cross-backend default. |
+| `custom` | No | Your own deterministic `score(a, b) => number` — domain rules, weighted field blends, edit distance. |
+| `vector` | Yes | Cosine similarity over one field's embedding. Catches semantic near-duplicates. |
+| `hybrid` | Yes | Blend `vector` and `fulltext` by `weights` (default 0.5 / 0.5). |
+
+The `fulltext` scorer runs **in memory** over the staged candidate text — it
+deliberately does not consult database fulltext indexes, because branch
+candidates are staged working-copy rows, not indexed search results. That keeps
+scoring deterministic and identical across SQLite and Postgres.
+
+For `vector` / `hybrid`, supply an `embedder` (batched, async, deterministic —
+the same text must always map to the same vector):
+
+```typescript
+const result = await merge(base, branches, {
+  embedder: async (texts) => texts.map((text) => embedModel(text)), // text[] -> Float32Array[]
+  resolve: {
+    Article: {
+      similarity: { kind: "hybrid", fields: ["title", "summary"], weights: { vector: 0.7, fulltext: 0.3 } },
+      threshold: 0.84,
+    },
+  },
+});
+```
+
+A `vector`/`hybrid` strategy with no embedder configured fails with a typed
+`SimilarityUnavailableError`, never a silent no-op.
+
+## Conflicts
+
+When merged contributors disagree on a property value, Graph Merge **resolves by
+an explicit, deterministic policy and records what it did** — it never lets
+arrival order decide.
+
+### Property conflicts
+
+| Policy | Behavior |
+| ------ | -------- |
+| `flag` (default) | Commit the deterministic survivor value (or the committed base value, for base-vs-branch) and record a `PropertyConflict` for review. The graph still gets a value; the disagreement is surfaced rather than resolved toward another branch. |
+| `lastWriteWins` | Pick the value from the highest-priority branch (earliest in `branchOrder`) — *logical* order, never wall-clock. |
+| `provenanceWeighted` | Pick the value from the highest-weight branch (see `provenanceWeights`). Ties fall back to branch order. |
+| function | Delegate: `(conflict) => JsonValue` lets application code decide per conflict. |
+
+There are **two** property-conflict knobs, deliberately separate so a fuzzy
+branch match can never silently overwrite committed data:
+
+- `onPropertyConflict` — staged branch vs. staged branch.
+- `onBasePropertyConflict` — committed base vs. a branch (new-vs-base merges).
+  Defaults to `flag` independently, and does **not** inherit `onPropertyConflict`.
+
+`provenanceWeighted` reads per-branch trust weights you supply:
+
+```typescript
+const result = await merge(base, branches, {
+  onPropertyConflict: "provenanceWeighted",
+  provenanceWeights: new Map([
+    [authoritativeFeed.id, 1.0], // the system of record wins ties of value
+    [bestEffortAgent.id, 0.2],
+  ]),
+});
+```
+
+### Delete / modify conflicts
+
+An inherited node or edge that one branch **deletes** while another **modifies**
+is neither a pure delete nor a pure modify. `onDeleteModifyConflict` governs it
+for both nodes and edges:
+
+| Policy | Behavior |
+| ------ | -------- |
+| `flag` (default) | The modification survives **and** an unresolved `DeleteModifyConflict` is recorded — a merge must never silently destroy the only branch still carrying data. |
+| `deleteWins` | Honor the delete; discard the modification; record the conflict. |
+| `modifyWins` | Resurrect the row; keep the modification; record the conflict. |
+
+Independent edits to the *same* inherited row by different branches are
+**three-way merged against the base**: a field only one branch changed takes
+that change with no conflict; only fields multiple branches changed to differing
+values become conflicts. This holds for node *and* edge properties, so disjoint
+edits compose instead of clobbering each other.
+
+## Edges follow their entities
+
+When nodes collapse, their edges must too. After clustering, Graph Merge:
+
+1. **Repoints** every edge endpoint onto its cluster's canonical survivor.
+2. **Drops** any edge whose endpoint was finally deleted (recorded in `dropped`).
+3. **Dedupes** edges as a pure set keyed by `(from, type, to, props)`, so two
+   branches' "same" edge collapses to one.
+4. **Reconciles** edges that collapse to the same `(from, type, to)` but
+   disagree on properties, via the same conflict policy as nodes.
+
+Inherited edges that a branch **deleted** are removed from the target, and
+inherited edges **modified** by multiple branches go through the same base-aware
+three-way merge as nodes — so an edge's `since` edited by one branch and `note`
+edited by another keep *both* edits.
+
+## Ontology type reconciliation
+
+With `reconcileTypes: "ontology"`, two staged nodes that share an id but carry
+subtype-compatible kinds (via the graph's `subClassOf` closure) are collapsed to
+the **most-specific** common type, recorded as a `TypeReconciliation`. A base
+`Doctor` and a branch `SpecialistDoctor` reconcile to `SpecialistDoctor` instead
+of being dropped as incompatible. The default `"off"` keeps identity strictly
+`(kind, id)`.
+
+```typescript
+const graph = defineGraph({ /* ... */ ontology: [subClassOf(SpecialistDoctor, Doctor)] });
+const result = await merge(base, branches, { reconcileTypes: "ontology" });
+```
+
+## Choosing the survivor
+
+By default a cluster's canonical survivor is the member with the
+lexicographically-minimal id (and, on new-vs-base merges, a committed base
+member always wins so its committed identity stays stable). Override the
+staged-vs-staged choice with `canonical`:
+
+```typescript
+const result = await merge(base, branches, {
+  canonical: (cluster) => preferGoldenSource(cluster.members), // pick which id survives
+});
+```
+
+## Scaling & safety
+
+Two guards keep a merge bounded and predictable on large or pathological inputs:
+
+- **`maxComparisonsPerKind`** caps fuzzy comparisons per kind. On overflow,
+  `onComparisonCeiling` decides: `"error"` (default) fails with a typed error,
+  or `"mergeByIdOnly"` skips similarity for that kind (still honoring exact
+  unique matches) and records a warning. Tighten your `block` to shrink buckets
+  rather than raising the ceiling blindly.
+- **`clusterMaxDiameter`** optionally splits over-broad clusters: if a cluster's
+  single-link diameter exceeds the bound, the weakest edges are dropped
+  deterministically until every sub-cluster fits. This stops a chain of
+  near-matches (`a~b~c~…`) from fusing genuinely-distinct entities.
+
+```typescript
+const result = await merge(base, branches, {
+  maxComparisonsPerKind: 50_000,
+  onComparisonCeiling: "mergeByIdOnly",
+  clusterMaxDiameter: 2,
+});
+```
+
+## The merge report
+
+`merge()` returns `Result<MergeReport, MergeError>`. The report is the
+**application boundary** — show conflicts to an operator, write a review record,
+persist provenance, or feed a downstream step.
+
+```typescript
+type MergeReport = {
+  merged: { nodes: number; edges: number }; // counts committed
+  resolutions: EntityResolution[]; // which fork ids collapsed into each canonical
+  conflicts: PropertyConflict[]; // per-property disagreements + how they resolved
+  deleteModifyConflicts: DeleteModifyConflict[]; // node/edge delete-vs-modify cases
+  typeReconciliations: TypeReconciliation[]; // ontology kind collapses
+  dropped: DroppedItem[]; // edges to deleted endpoints, incompatible members
+  baseAmbiguities: BaseAmbiguity[]; // new-vs-base matches that spanned >= 2 committed entities
+  provenance: ProvenanceIndex; // byBranch(id) -> { nodeIds, edgeIds }
+  warnings: string[]; // non-fatal advisories (ceiling skips, provenance-persist failures)
+  provenancePersisted?: { graphId: string; count: number }; // when persistProvenance ran
+};
+```
+
+A typical operator loop: auto-apply when `conflicts` and
+`deleteModifyConflicts` are empty; otherwise enqueue them for review alongside
+`resolutions` so the reviewer sees what merged and why.
+
+## Provenance
+
+Provenance answers *which branch contributed each merged node and edge*.
+
+- **Report-only (default, `provenance: true`)** — `report.provenance.byBranch(id)`
+  returns the `{ nodeIds, edgeIds }` that branch contributed. In-memory; it
+  evaporates after the call.
+- **Durable (`persistProvenance: true`)** — after the commit, one
+  `{branch, sourceId} → canonical` row per contribution is upserted into a
+  *sidecar* graph on the target's backend (its own namespaced tables; your
+  domain schema is untouched). It is best-effort and post-commit: a persistence
+  failure surfaces as a `warnings` entry, never a failed merge. Re-running the
+  same merge upserts (deterministic ids), never duplicates.
+
+Query persisted provenance back later:
+
+```typescript
+import { openProvenanceStore, readProvenance } from "@nicia-ai/typegraph/graph-merge";
+
+const store = await openProvenanceStore(target.backend, target.graphId);
+const fromAgentA = await readProvenance(store, { branchId: "agent-a" }); // what did agent A contribute?
+const whoMadeX = await readProvenance(store, { canonicalId: "patient-123" }); // who contributed node X?
+```
+
+## Snapshot vs incremental
+
+A branch is forked from a `base@V` — a token combining the base's schema hash
+and a fingerprint of its live content. The two merge entry points differ in how
+they treat that token.
+
+**`merge()` is a snapshot merge.** Every branch must have forked from the
+target's *current* `base@V`. If the target advanced since the branch was taken,
+`merge()` returns a `BaseVersionMismatchError` rather than risk clobbering newer
+data. This is the right model for "fork, do work, merge back" within one round.
+
+**`mergeIncremental()` is a fork-point merge into a live target.** It merges
+branches that forked from a frozen `forkPoint` into a `target` that may have
+*moved on*. Additions are re-discovered against already-committed entities (via
+`blockIndex` / unique constraints) so a re-seen entity updates the committed row
+instead of duplicating it. Inherited node and edge modifications/deletions are
+also propagated through the same three-way planner, with the live target kept
+authoritative when it changed concurrently.
+
+```typescript
+import { mergeIncremental } from "@nicia-ai/typegraph/graph-merge";
+
+const result = await mergeIncremental({
+  forkPoint, // the frozen ancestor the branches forked from
+  target, // the live committed graph (may have advanced)
+  branches,
+  options: {
+    resolve: { Patient: { blockIndex: "patient_cohort_idx", similarity: { kind: "fulltext", fields: ["name"] }, threshold: 0.85 } },
+    onBasePropertyConflict: "flag", // required: never overwrite a newer committed value
+  },
+});
+```
+
+`mergeIncremental()` requires `onBasePropertyConflict: "flag"` so a stale branch
+value can never overwrite a newer committed value during new-vs-base recall.
+If both the branch and the live target changed the same inherited row, the target
+value/deletion wins and the conflict is reported. Both `merge()` and
+`mergeIncremental()` commit **transactionally** and require a
+transaction-capable target backend.
+
+## Working copies
+
+`branch()` is backend-agnostic. The default `cloneWorkingCopyStrategy` exports
+the base through TypeGraph's interchange and imports it into a fresh store on a
+backend your factory provides — so it works identically across SQLite, Postgres,
+and in-process PGlite, and needs no schema changes.
+
+```typescript
+// Each branch gets its own in-memory SQLite backend:
+import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+const makeBackend = async () => createLocalSqliteBackend().backend;
+const fork = unwrap(await branch(base, makeBackend, { id: asBranchId("worker-1") }));
+```
+
+For a custom isolation mechanism (e.g. a future copy-on-write namespace), pass a
+`WorkingCopyStrategy` as the fourth argument to `branch()` — its single `create`
+method returns an independently-mutable store over the same graph definition.
+
+## Determinism
+
+Graph Merge is built to be reproducible, which is what lets you retry, cache,
+diff, and test a merge with confidence:
+
+- Candidate sets are sorted before clustering; clusters resolve by stable keys.
+- Conflict resolution consults only the captured `branchOrder` (or lexicographic
+  branch id) — never wall-clock.
+- The committed graph and the normalized report are a pure function of the
+  *unordered* branch set.
+
+Use `branchOrder` to make preference explicit wherever a policy needs ordering:
+
+```typescript
+const branchOrder = [systemOfRecord.id, agentA.id, agentB.id];
+const result = await merge(base, [agentB, systemOfRecord, agentA], {
+  branchOrder,
+  onPropertyConflict: "lastWriteWins", // systemOfRecord wins, regardless of input order
+});
+```
+
+## Errors
+
+All entry points return a `Result`; the error arm is a typed `TypeGraphError`
+subclass you can branch on:
+
+| Error | When |
+| ----- | ---- |
+| `BranchError` | `branch()` could not materialize a working copy. |
+| `BaseVersionMismatchError` | A branch forked from a different `base@V` than the target now has (snapshot `merge()`). |
+| `SimilarityUnavailableError` | A `vector`/`hybrid` strategy was requested with no `embedder`. |
+| `MergeConflictError` | A conflict could not be resolved under the configured policy. |
+| `MergeError` | Any other merge failure (e.g. comparison-ceiling `"error"`, a non-transactional target). `MERGE_ERROR_CODES` enumerates the codes. |
+
+## Example
+
+See [FHIR Graph Merge](/examples/fhir-graph-merge) for a complete runnable
+snapshot merge that reconciles two independently-extracted patient-care branches,
+and [Incremental Merge](/examples/incremental-merge) for live-target ingestion
+against an advancing base with persisted, queryable provenance.

--- a/apps/docs/src/content/docs/overview.md
+++ b/apps/docs/src/content/docs/overview.md
@@ -125,6 +125,15 @@ atomically commits a new schema version — no redeploy, full Zod
 validation, restart parity. See [Graph Extensions](/graph-extensions)
 for the agent-driven workflow.
 
+Note: TypeGraph ships **graph merge** — fork a store into isolated working
+copies, let many writers (parallel agents, importers, reviewers) edit
+independently, then reconcile them into one canonical graph with deterministic
+entity resolution (exact / blocking / fulltext / vector / hybrid), edge
+repointing, conflict reporting, and provenance. `mergeIncremental()` folds new
+sources into a *live* graph without creating duplicates — the primitive for
+multi-agent knowledge-graph construction and continuous ingestion. See
+[Graph Merge](/graph-merge) for the full guide.
+
 ## Why TypeGraph?
 
 ### Compared to Graph Databases (Neo4j, Amazon Neptune)
@@ -192,6 +201,8 @@ TypeGraph is ideal for:
 - **Content graphs** with topics, articles, and references
 - **Domain models** requiring semantic constraints
 - **RAG applications** combining graph traversal with vector search
+- **Multi-source ingestion & entity resolution** — reconcile parallel agent or
+  importer outputs into one canonical graph with [graph merge](/graph-merge)
 
 TypeGraph is not ideal for:
 

--- a/packages/typegraph/README.md
+++ b/packages/typegraph/README.md
@@ -46,6 +46,45 @@ See the repo README for more.
 
 Examples: [github.com/nicia-ai/typegraph/tree/main/packages/typegraph/examples](https://github.com/nicia-ai/typegraph/tree/main/packages/typegraph/examples)
 
+## Graph Merge
+
+TypeGraph ships semantic graph merge as a dedicated subpath:
+
+```ts
+import { branch, merge } from "@nicia-ai/typegraph/graph-merge";
+```
+
+`branch()` creates isolated working copies over caller-provided backends, stamped
+with the base graph's schema and content version. `merge()` reconciles those
+branches back into a target graph with deterministic entity resolution, conflict
+reporting, edge repointing, optional ontology type reconciliation, and provenance
+reporting.
+
+Use it when several agents, importers, reviewers, or local workers edit graph
+state independently and the application needs one canonical result instead of an
+append-only pile of duplicates. The merge pipeline can:
+
+- resolve duplicate entities by exact unique constraints, blocking keys,
+  fulltext/custom similarity, or vector/hybrid similarity;
+- preserve branch-specific context by repointing edges to canonical nodes;
+- surface property and delete/modify conflicts (for nodes and edges) in a
+  `MergeReport`, three-way merged against base so disjoint edits compose;
+- expose report-only provenance, with optional sidecar persistence you can query.
+
+`merge()` is a snapshot merge (all branches forked from the current base);
+`mergeIncremental()` additively folds a new source into a target that has already
+advanced, re-discovering committed entities instead of duplicating them — the
+primitive for continuous ingestion.
+
+It lives in the core package because the primitive is defined over TypeGraph
+stores, schemas, indexes, backends, and ontology semantics rather than as a
+separate product surface.
+
+Docs: [Graph Merge](https://typegraph.dev/graph-merge)
+
+Examples: [FHIR Graph Merge](https://typegraph.dev/examples/fhir-graph-merge)
+· [Incremental Merge](https://typegraph.dev/examples/incremental-merge)
+
 ## Performance Smoke Check
 
 The perf harness lives in `@nicia-ai/typegraph-benchmarks`; these commands delegate to it.

--- a/packages/typegraph/eslint.config.mjs
+++ b/packages/typegraph/eslint.config.mjs
@@ -27,6 +27,48 @@ export default [
     ],
   }),
 
+  // graph-merge is intentionally heavy on deterministic ordering helpers plus
+  // branch-dependent assertions. Relax only STYLE-ONLY Unicorn/Vitest
+  // preferences for the subsystem. The type-safety rules
+  // (no-unnecessary-condition, prefer-nullish-coalescing, require-await) stay ON
+  // for the SOURCE — this is the most algorithmically complex code in the
+  // package and exactly where a dead guard or a value-dropping `||` must be
+  // caught.
+  {
+    files: [
+      "src/graph-merge/**/*.ts",
+      "tests/graph-merge/**/*.ts",
+      "tests/property/graph-merge/**/*.ts",
+    ],
+    rules: {
+      "@typescript-eslint/no-confusing-void-expression": "off",
+      "unicorn/consistent-function-scoping": "off",
+      "unicorn/no-array-callback-reference": "off",
+      "unicorn/no-array-reduce": "off",
+      "unicorn/no-array-reverse": "off",
+      "unicorn/no-array-sort": "off",
+      "unicorn/no-await-expression-member": "off",
+      "unicorn/no-for-loop": "off",
+      "unicorn/no-null": "off",
+      "unicorn/prefer-code-point": "off",
+      "unicorn/prefer-structured-clone": "off",
+      "unicorn/prevent-abbreviations": "off",
+      "vitest/no-conditional-expect": "off",
+    },
+  },
+
+  // Merge TESTS additionally relax two rules that are pure noise in test code:
+  // `no-unnecessary-condition` (defensive `cleanups ?? []` harness idioms,
+  // tautological narrowing after an `expect(x).toBe(...)`) and `require-await`
+  // (uniform `async` test/callback signatures). These stay ON for the source.
+  {
+    files: ["tests/graph-merge/**/*.ts", "tests/property/graph-merge/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-unnecessary-condition": "off",
+      "@typescript-eslint/require-await": "off",
+    },
+  },
+
   // Backend parity guardrail. The query compiler is a single shared path; the
   // only sanctioned place for a dialect difference is a DialectAdapter member.
   // Inline `=== "sqlite"` / `case "postgres"` branching reintroduces the

--- a/packages/typegraph/examples/18-fhir-graph-merge.ts
+++ b/packages/typegraph/examples/18-fhir-graph-merge.ts
@@ -1,0 +1,438 @@
+/**
+ * Example 18: FHIR Graph Merge
+ *
+ * Two independent ingestion agents extract overlapping FHIR-style records into
+ * isolated TypeGraph branches. `merge()` folds both branches back into the base
+ * graph, resolves the duplicate patient, repoints each branch's care-context
+ * edges onto the canonical patient, and reports the conflict/provenance trail.
+ *
+ * Run with:
+ *   npx tsx examples/18-fhir-graph-merge.ts
+ */
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  searchable,
+  type GraphBackend,
+  type Node,
+  type Store,
+} from "@nicia-ai/typegraph";
+import {
+  asBranchId,
+  branch,
+  isOk,
+  merge,
+  unwrap,
+  type GraphBranch,
+  type MergeOptions,
+  type MergeReport,
+  type SimilarityStrategy,
+} from "@nicia-ai/typegraph/graph-merge";
+import { createExampleBackend } from "./_helpers";
+
+// ============================================================
+// FHIR-flavored schema
+// ============================================================
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    fhirId: z.string(),
+    name: searchable({ language: "english" }),
+    birthDate: z.string(),
+    mrn: z.string(),
+  }),
+});
+
+const Encounter = defineNode("Encounter", {
+  schema: z.object({
+    fhirId: z.string(),
+    reason: searchable({ language: "english" }),
+    startedAt: z.string(),
+  }),
+});
+
+const Observation = defineNode("Observation", {
+  schema: z.object({
+    fhirId: z.string(),
+    display: searchable({ language: "english" }),
+    value: z.string(),
+    interpretation: z.enum(["normal", "high", "low"]),
+  }),
+});
+
+const MedicationRequest = defineNode("MedicationRequest", {
+  schema: z.object({
+    fhirId: z.string(),
+    medication: searchable({ language: "english" }),
+    dosage: z.string(),
+  }),
+});
+
+const forPatient = defineEdge("forPatient", {
+  schema: z.object({ sourcePath: z.string() }),
+});
+
+const duringEncounter = defineEdge("duringEncounter", {
+  schema: z.object({ sourcePath: z.string() }),
+});
+
+const reasonFor = defineEdge("reasonFor", {
+  schema: z.object({ sourcePath: z.string() }),
+});
+
+const careGraph = defineGraph({
+  id: "fhir_merge_demo",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "patient_mrn",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
+    Encounter: { type: Encounter },
+    Observation: { type: Observation },
+    MedicationRequest: { type: MedicationRequest },
+  },
+  edges: {
+    forPatient,
+    duringEncounter,
+    reasonFor,
+  },
+});
+
+type CareGraph = typeof careGraph;
+type CareStore = Store<CareGraph>;
+
+const EHR_BRANCH = asBranchId("ehr-agent");
+const CLAIMS_BRANCH = asBranchId("claims-agent");
+
+async function makeExampleBackend(): Promise<GraphBackend> {
+  return createExampleBackend();
+}
+
+const patientSimilarity: SimilarityStrategy<CareGraph> = {
+  kind: "fulltext",
+  fields: ["name"],
+};
+
+function blockPatient(node: Node): string | undefined {
+  const patient = node as unknown as { birthDate?: string };
+  // Block by shared birth date. The unique MRN constraint forces exact-identity
+  // matches in its own bucket independently of blocking, so blocking does not
+  // need the MRN — and using it would split the different-MRN fuzzy pair apart.
+  return patient.birthDate;
+}
+
+const mergeOptions: MergeOptions<CareGraph> = {
+  resolve: {
+    Patient: {
+      block: blockPatient,
+      similarity: patientSimilarity,
+      // This demo exercises BOTH resolution paths:
+      //   - Anna/Ana share MRN-001, so the unique constraint forces that merge
+      //     (definitional identity — fuzzy scoring is bypassed for them). The
+      //     threshold is irrelevant to their collapse.
+      //   - Mohammed/Mohamed have DIFFERENT MRNs, so nothing forces them; only
+      //     the fulltext name similarity clearing this threshold collapses them.
+      //     This is the case where the threshold is actually decisive.
+      threshold: 0.78,
+    },
+  },
+  onPropertyConflict: "flag",
+  branchOrder: [EHR_BRANCH, CLAIMS_BRANCH],
+  provenance: true,
+};
+
+// ============================================================
+// Branch seeding
+// ============================================================
+
+async function createBranch(
+  base: CareStore,
+  id: typeof EHR_BRANCH | typeof CLAIMS_BRANCH,
+): Promise<GraphBranch<CareGraph>> {
+  return unwrap(await branch(base, makeExampleBackend, { id }));
+}
+
+async function seedEhrBranch(branchStore: CareStore): Promise<void> {
+  const patient = await branchStore.nodes.Patient.create({
+    fhirId: "Patient/ehr-anna",
+    name: "Anna Rivera",
+    birthDate: "1974-03-09",
+    mrn: "MRN-001",
+  }, {
+    id: "patient-anna",
+  });
+  const encounter = await branchStore.nodes.Encounter.create({
+    fhirId: "Encounter/ehr-follow-up",
+    reason: "Hypertension follow-up",
+    startedAt: "2026-04-11T09:30:00-07:00",
+  }, {
+    id: "encounter-follow-up",
+  });
+  const bloodPressure = await branchStore.nodes.Observation.create({
+    fhirId: "Observation/ehr-bp",
+    display: "Blood pressure panel",
+    value: "152/96 mmHg",
+    interpretation: "high",
+  }, {
+    id: "observation-blood-pressure",
+  });
+  const medication = await branchStore.nodes.MedicationRequest.create({
+    fhirId: "MedicationRequest/ehr-lisinopril",
+    medication: "Lisinopril 10 MG Oral Tablet",
+    dosage: "Take one tablet by mouth daily",
+  }, {
+    id: "medication-lisinopril",
+  });
+
+  await branchStore.edges.forPatient.create(encounter, patient, {
+    sourcePath: "Encounter.subject",
+  });
+  await branchStore.edges.forPatient.create(bloodPressure, patient, {
+    sourcePath: "Observation.subject",
+  });
+  await branchStore.edges.forPatient.create(medication, patient, {
+    sourcePath: "MedicationRequest.subject",
+  });
+  await branchStore.edges.duringEncounter.create(medication, encounter, {
+    sourcePath: "MedicationRequest.encounter",
+  });
+  await branchStore.edges.reasonFor.create(medication, bloodPressure, {
+    sourcePath: "MedicationRequest.reasonReference",
+  });
+
+  // A SECOND patient whose MRN differs from the claims branch's, so the unique
+  // constraint can NOT force a match — only the fulltext name similarity can
+  // collapse "Mohammed Ali" / "Mohamed Ali".
+  const mohammed = await branchStore.nodes.Patient.create(
+    {
+      fhirId: "Patient/ehr-mohammed",
+      name: "Mohammed Ali",
+      birthDate: "1990-08-21",
+      mrn: "MRN-204",
+    },
+    { id: "patient-mohammed" },
+  );
+  const cardiology = await branchStore.nodes.Encounter.create(
+    {
+      fhirId: "Encounter/ehr-cardiology",
+      reason: "Cardiology consult",
+      startedAt: "2026-05-02T13:00:00-07:00",
+    },
+    { id: "encounter-cardiology" },
+  );
+  await branchStore.edges.forPatient.create(cardiology, mohammed, {
+    sourcePath: "Encounter.subject",
+  });
+}
+
+async function seedClaimsBranch(branchStore: CareStore): Promise<void> {
+  const patient = await branchStore.nodes.Patient.create({
+    fhirId: "Patient/claims-ana",
+    name: "Ana Rivera",
+    birthDate: "1974-03-09",
+    mrn: "MRN-001",
+  }, {
+    id: "patient-ana",
+  });
+  const encounter = await branchStore.nodes.Encounter.create({
+    fhirId: "Encounter/claims-kidney-review",
+    reason: "Kidney function review",
+    startedAt: "2026-04-14T10:00:00-07:00",
+  }, {
+    id: "encounter-kidney-review",
+  });
+  const kidneyLab = await branchStore.nodes.Observation.create({
+    fhirId: "Observation/claims-egfr",
+    display: "Estimated glomerular filtration rate",
+    value: "54 mL/min/1.73m2",
+    interpretation: "low",
+  }, {
+    id: "observation-egfr",
+  });
+
+  await branchStore.edges.forPatient.create(encounter, patient, {
+    sourcePath: "Encounter.subject",
+  });
+  await branchStore.edges.forPatient.create(kidneyLab, patient, {
+    sourcePath: "Observation.subject",
+  });
+  await branchStore.edges.duringEncounter.create(kidneyLab, encounter, {
+    sourcePath: "Observation.encounter",
+  });
+
+  // The claims-side spelling of the second patient, with a DIFFERENT MRN. Same
+  // birth date (so they block together), close name (so fulltext collapses them).
+  const mohamed = await branchStore.nodes.Patient.create(
+    {
+      fhirId: "Patient/claims-mohamed",
+      name: "Mohamed Ali",
+      birthDate: "1990-08-21",
+      mrn: "MRN-205",
+    },
+    { id: "patient-mohamed" },
+  );
+  const ldl = await branchStore.nodes.Observation.create(
+    {
+      fhirId: "Observation/claims-ldl",
+      display: "LDL cholesterol",
+      value: "168 mg/dL",
+      interpretation: "high",
+    },
+    { id: "observation-ldl" },
+  );
+  await branchStore.edges.forPatient.create(ldl, mohamed, {
+    sourcePath: "Observation.subject",
+  });
+}
+
+// ============================================================
+// Reporting helpers
+// ============================================================
+
+function summarizePatient(node: Node<typeof Patient>): string {
+  return `${node.name} (${node.mrn}, ${node.birthDate})`;
+}
+
+/** An `id -> human-readable label` map for every clinical resource in the store. */
+async function resourceDisplays(store: CareStore): Promise<Map<string, string>> {
+  const displays = new Map<string, string>();
+  for (const encounter of await store.nodes.Encounter.find()) {
+    displays.set(
+      encounter.id,
+      `Encounter: ${encounter.reason} (${encounter.startedAt})`,
+    );
+  }
+  for (const observation of await store.nodes.Observation.find()) {
+    displays.set(
+      observation.id,
+      `Observation: ${observation.display} = ${observation.value} (${observation.interpretation})`,
+    );
+  }
+  for (const medication of await store.nodes.MedicationRequest.find()) {
+    displays.set(
+      medication.id,
+      `MedicationRequest: ${medication.medication} - ${medication.dosage}`,
+    );
+  }
+  return displays;
+}
+
+/**
+ * The resources linked to a canonical patient, found by FOLLOWING `forPatient`
+ * edges INTO that patient. Membership comes from the edges (not a blanket
+ * `.find()`), so this proves edge repointing: a resource appears under a patient
+ * only because its `forPatient` edge now points at the canonical survivor. A
+ * mis-repointed edge would simply not show up here.
+ */
+async function careContextFor(
+  store: CareStore,
+  patient: Node<typeof Patient>,
+  displays: ReadonlyMap<string, string>,
+): Promise<readonly string[]> {
+  const edges = await store.edges.forPatient.findTo(patient);
+  return edges
+    .map((edge) => displays.get(edge.fromId) ?? `${edge.fromKind} ${edge.fromId}`)
+    .sort((left, right) =>
+      left < right ? -1
+      : left > right ? 1
+      : 0,
+    );
+}
+
+function printConflicts(report: MergeReport<CareGraph>): void {
+  if (report.conflicts.length === 0) {
+    console.log("  conflicts: none");
+    return;
+  }
+
+  console.log("  conflicts:");
+  for (const conflict of report.conflicts) {
+    const values = conflict.values
+      .map((value) => `${value.branchId}=${JSON.stringify(value.value)}`)
+      .join(", ");
+    console.log(
+      `    - ${conflict.kind}.${conflict.property} on ${conflict.entityId}: ${values}`,
+    );
+  }
+}
+
+function printProvenance(report: MergeReport<CareGraph>): void {
+  console.log("  provenance:");
+  for (const branchId of [EHR_BRANCH, CLAIMS_BRANCH]) {
+    const contribution = report.provenance.byBranch(branchId);
+    console.log(
+      `    - ${branchId}: ${contribution.nodeIds.length} node(s), ${contribution.edgeIds.length} edge(s)`,
+    );
+  }
+}
+
+// ============================================================
+// Demo
+// ============================================================
+
+async function main() {
+  const backend = await makeExampleBackend();
+  const [base] = await createStoreWithSchema(careGraph, backend);
+
+  const ehr = await createBranch(base, EHR_BRANCH);
+  const claims = await createBranch(base, CLAIMS_BRANCH);
+
+  await seedEhrBranch(ehr.store);
+  await seedClaimsBranch(claims.store);
+
+  console.log("=== FHIR Graph Merge ===\n");
+  console.log("Before merge:");
+  console.log("  base patients:", (await base.nodes.Patient.find()).length);
+  console.log("  EHR branch patients:", (await ehr.store.nodes.Patient.find()).length);
+  console.log(
+    "  claims branch patients:",
+    (await claims.store.nodes.Patient.find()).length,
+  );
+
+  const result = await merge(base, [ehr, claims], mergeOptions);
+  if (!isOk(result)) {
+    throw result.error;
+  }
+  const report = result.data;
+
+  console.log("\nAfter merge:");
+  console.log(`  merged nodes: ${report.merged.nodes}`);
+  console.log(`  merged edges: ${report.merged.edges}`);
+  console.log(`  entity resolutions: ${report.resolutions.length}`);
+  printConflicts(report);
+  printProvenance(report);
+
+  // Two patients collapsed by two different mechanisms — Anna/Ana by the shared
+  // MRN (exact identity), Mohammed/Mohamed by fulltext name similarity. The care
+  // context below is read by following `forPatient` edges INTO each survivor, so
+  // it proves both branches' edges were repointed onto the canonical patient.
+  const patients = (await base.nodes.Patient.find()).sort((left, right) =>
+    left.name < right.name ? -1
+    : left.name > right.name ? 1
+    : 0,
+  );
+  const displays = await resourceDisplays(base);
+  console.log("\nCanonical patients and their repointed care context:");
+  for (const patient of patients) {
+    console.log(`  ${summarizePatient(patient)}`);
+    for (const line of await careContextFor(base, patient, displays)) {
+      console.log(`    - ${line}`);
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/typegraph/examples/19-incremental-merge.ts
+++ b/packages/typegraph/examples/19-incremental-merge.ts
@@ -1,0 +1,188 @@
+/**
+ * Example 19: Incremental Graph Merge
+ *
+ * Ingest into a LIVE graph in waves. Unlike the snapshot `merge()` (example 18),
+ * `mergeIncremental()` folds a new source's branch into a `target` that already
+ * holds committed entities: it re-discovers an already-committed company (by its
+ * unique `domain`) and merges the new spelling ONTO it instead of creating a
+ * duplicate, commits the genuinely-new company, handles inherited edits against
+ * the fork-point, flags the name disagreement, and persists a queryable
+ * provenance trail.
+ *
+ * Run with:
+ *   npx tsx examples/19-incremental-merge.ts
+ */
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  searchable,
+  type GraphBackend,
+  type Store,
+} from "@nicia-ai/typegraph";
+import {
+  asBranchId,
+  branch,
+  isOk,
+  mergeIncremental,
+  openProvenanceStore,
+  readProvenance,
+  unwrap,
+  type MergeIncrementalArgs,
+} from "@nicia-ai/typegraph/graph-merge";
+
+import { createExampleBackend } from "./_helpers";
+
+// ============================================================
+// A tiny company knowledge base, deduplicated by domain
+// ============================================================
+
+const Company = defineNode("Company", {
+  schema: z.object({
+    name: searchable({ language: "english" }),
+    domain: z.string(),
+  }),
+});
+
+const kbGraph = defineGraph({
+  id: "company_kb",
+  nodes: {
+    Company: {
+      type: Company,
+      // A shared domain is a DEFINITIONAL identity: the new-vs-base recall uses it
+      // to find the already-committed company regardless of name spelling.
+      unique: [
+        {
+          name: "company_domain",
+          fields: ["domain"],
+          scope: "kind",
+          collation: "caseInsensitive",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+
+type KbGraph = typeof kbGraph;
+type KbStore = Store<KbGraph>;
+
+async function makeBackend(): Promise<GraphBackend> {
+  return createExampleBackend();
+}
+
+const PROVIDER = asBranchId("provider-crunchbase");
+
+async function listCompanies(store: KbStore): Promise<readonly string[]> {
+  const companies = await store.nodes.Company.find();
+  return companies
+    .map((company) => `${company.name} (${company.domain})`)
+    .sort((left, right) =>
+      left < right ? -1
+      : left > right ? 1
+      : 0,
+    );
+}
+
+async function main(): Promise<void> {
+  // The LIVE target graph, already holding one canonical company from an earlier
+  // ingestion wave. This is the "base that has advanced" mergeIncremental targets.
+  const [target] = await createStoreWithSchema(kbGraph, await makeBackend());
+  await target.nodes.Company.create(
+    { name: "Acme Corp", domain: "acme.com" },
+    { id: "acme" },
+  );
+
+  // The frozen fork-point a new provider's branch forks from. This example keeps
+  // it empty so the provider's company rows are additions, but mergeIncremental()
+  // also propagates inherited modifications and deletions relative to this store.
+  const [forkPoint] = await createStoreWithSchema(kbGraph, await makeBackend());
+  const provider = unwrap(await branch(forkPoint, makeBackend, { id: PROVIDER }));
+
+  // The provider re-reports Acme (same domain, different spelling) and adds a
+  // genuinely new company.
+  await provider.store.nodes.Company.create(
+    { name: "ACME Corporation", domain: "acme.com" },
+    { id: "cb-acme" },
+  );
+  await provider.store.nodes.Company.create(
+    { name: "Globex", domain: "globex.io" },
+    { id: "cb-globex" },
+  );
+
+  console.log("=== Incremental Graph Merge ===\n");
+  console.log("Target before:", await listCompanies(target));
+
+  const args: MergeIncrementalArgs<KbGraph> = {
+    forkPoint,
+    target,
+    branches: [provider],
+    options: {
+      resolve: {
+        Company: {
+          // `similarity` is required, but the unique `domain` constraint forces the
+          // new-vs-base match here regardless of the name-spelling difference.
+          similarity: { kind: "fulltext", fields: ["name"] },
+          threshold: 0.9,
+        },
+      },
+      onPropertyConflict: "flag",
+      onBasePropertyConflict: "flag", // required by mergeIncremental (keep-base)
+      branchOrder: [PROVIDER],
+      persistProvenance: true,
+    },
+  };
+
+  const result = await mergeIncremental(args);
+  if (!isOk(result)) {
+    throw result.error;
+  }
+  const report = result.data;
+
+  console.log("Target after: ", await listCompanies(target));
+  console.log(
+    `\nNo duplicate was created: the provider's "ACME Corporation" merged onto the`,
+  );
+  console.log(`committed "Acme Corp" via the shared domain.\n`);
+  console.log(`Merged nodes: ${report.merged.nodes}`);
+  console.log(`Entity resolutions: ${report.resolutions.length}`);
+  if (report.conflicts.length === 0) {
+    console.log("Conflicts: none");
+  } else {
+    for (const conflict of report.conflicts) {
+      const values = conflict.values
+        .map((value) => `${value.branchId}=${JSON.stringify(value.value)}`)
+        .join(", ");
+      console.log(
+        `Conflict on ${conflict.kind}.${conflict.property} @ ${conflict.entityId}: ${values}`,
+      );
+    }
+  }
+  if (report.provenancePersisted !== undefined) {
+    console.log(
+      `\nProvenance persisted: ${report.provenancePersisted.count} row(s) in sidecar "${report.provenancePersisted.graphId}"`,
+    );
+  }
+
+  // Query the DURABLE provenance back later: "what did this provider contribute?"
+  const provenanceStore = await openProvenanceStore(
+    target.backend,
+    target.graphId,
+  );
+  const contributed = await readProvenance(provenanceStore, {
+    branchId: PROVIDER,
+  });
+  console.log("\nProvenance — canonical entities this provider contributed to:");
+  for (const node of contributed) {
+    console.log(
+      `  - ${node.canonicalKind} "${node.canonicalId}" (from source "${node.sourceId}")`,
+    );
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/typegraph/examples/README.md
+++ b/packages/typegraph/examples/README.md
@@ -41,6 +41,8 @@ npx tsx examples/<example-name>.ts
 | [09-pagination-streaming.ts](./09-pagination-streaming.ts) | Cursor pagination and result streaming |
 | [13-aggregates.ts](./13-aggregates.ts) | GROUP BY, COUNT, SUM, AVG, MIN, MAX, and HAVING |
 | [17-bulk-find-by-index.ts](./17-bulk-find-by-index.ts) | Batched candidate lookup by declared index for import reconciliation and dedup, with null-safe matching and `limitPerInput` |
+| [18-fhir-graph-merge.ts](./18-fhir-graph-merge.ts) | Branch and merge overlapping FHIR-style records into a canonical patient care graph with conflict and provenance reporting |
+| [19-incremental-merge.ts](./19-incremental-merge.ts) | Incrementally ingest a new source into a live graph with `mergeIncremental()` — recall an already-committed entity by its unique key (no duplicate), flag the conflict, and persist queryable provenance |
 
 ### Backend Configuration
 
@@ -129,6 +131,8 @@ Each example follows a consistent pattern:
 5. Learn efficient data access with **09-pagination-streaming**
 6. Learn aggregate queries with **13-aggregates**
 7. Reconcile imports and find dedup candidates with **17-bulk-find-by-index**
-8. For production, see **10-postgresql** for backend configuration
-9. For AI/ML applications, see **11-semantic-search** and **12-knowledge-graph-rag**
-10. For end-to-end application demos, see **14-research-copilot**
+8. Merge independently edited graph branches with **18-fhir-graph-merge**, then
+   ingest into a live graph in waves with **19-incremental-merge**
+9. For production, see **10-postgresql** for backend configuration
+10. For AI/ML applications, see **11-semantic-search** and **12-knowledge-graph-rag**
+11. For end-to-end application demos, see **14-research-copilot**

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/graph-extension/index.js",
       "require": "./dist/graph-extension/index.cjs"
     },
+    "./graph-merge": {
+      "types": "./dist/graph-merge/index.d.ts",
+      "import": "./dist/graph-merge/index.js",
+      "require": "./dist/graph-merge/index.cjs"
+    },
     "./sqlite": {
       "types": "./dist/backend/sqlite/index.d.ts",
       "import": "./dist/backend/sqlite/index.js",

--- a/packages/typegraph/scripts/smoke-exports.mjs
+++ b/packages/typegraph/scripts/smoke-exports.mjs
@@ -31,6 +31,7 @@ const PUBLIC_SUBPATHS = [
   { subpath: "/schema", expectedExport: "deserializeSchema" },
   { subpath: "/indexes", expectedExport: "defineNodeIndex" },
   { subpath: "/graph-extension", expectedExport: "defineGraphExtension" },
+  { subpath: "/graph-merge", expectedExport: "branch" },
   { subpath: "/sqlite", expectedExport: "createSqliteBackend" },
   { subpath: "/postgres", expectedExport: "createPostgresBackend" },
   { subpath: "/sqlite/local", expectedExport: "createLocalSqliteBackend" },

--- a/packages/typegraph/src/backend/drizzle/operations/collections.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/collections.ts
@@ -133,6 +133,14 @@ export function buildCountNodesByKind(
 
 /**
  * Builds a query to find edges by kind with optional endpoint filters.
+ *
+ * Pagination mirrors {@link buildFindNodesByKind}:
+ * - Offset pagination (`limit` + `offset`): keeps the historical
+ *   `ORDER BY created_at DESC` and adds `id DESC` as a deterministic tiebreaker
+ *   so a non-unique `created_at` can no longer shuffle rows across pages.
+ * - Keyset pagination (`orderBy: "id"` + optional `after`): iterates by `id ASC`
+ *   over the unique `id`, a TOTAL order, so a full enumeration can neither skip
+ *   nor duplicate a row even when many edges share a `created_at`.
  */
 export function buildFindEdgesByKind(
   tables: Tables,
@@ -162,13 +170,22 @@ export function buildFindEdgesByKind(
     conditions.push(sql`${edges.toId} = ${params.toId}`);
   }
 
+  if (params.orderBy === "id" && params.after !== undefined) {
+    conditions.push(sql`${edges.id} > ${params.after}`);
+  }
+
   const whereClause = sql.join(conditions, sql` AND `);
+
+  const orderByClause =
+    params.orderBy === "id"
+      ? sql`${edges.id} ASC`
+      : sql`${edges.createdAt} DESC, ${edges.id} DESC`;
 
   if (params.limit !== undefined && params.offset !== undefined) {
     return sql`
       SELECT * FROM ${edges}
       WHERE ${whereClause}
-      ORDER BY ${edges.createdAt} DESC
+      ORDER BY ${orderByClause}
       LIMIT ${params.limit} OFFSET ${params.offset}
     `;
   }
@@ -177,7 +194,7 @@ export function buildFindEdgesByKind(
     return sql`
       SELECT * FROM ${edges}
       WHERE ${whereClause}
-      ORDER BY ${edges.createdAt} DESC
+      ORDER BY ${orderByClause}
       LIMIT ${params.limit}
     `;
   }
@@ -185,7 +202,7 @@ export function buildFindEdgesByKind(
   return sql`
     SELECT * FROM ${edges}
     WHERE ${whereClause}
-    ORDER BY ${edges.createdAt} DESC
+    ORDER BY ${orderByClause}
   `;
 }
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1447,6 +1447,20 @@ export type FindEdgesByKindParams = Readonly<{
   temporalMode?: TemporalMode;
   /** Timestamp for "current" and "asOf" temporal modes. */
   asOf?: string;
+  /**
+   * Stable ordering for keyset pagination. Default: "created_at" (existing
+   * behavior). Use "id" for iteration that is stable under shared `created_at`
+   * timestamps — the offset path orders by the NON-unique `created_at`, so a
+   * full enumeration must page by the unique `id` to avoid skipping a row at a
+   * page boundary. Mirrors {@link FindNodesByKindParams.orderBy}.
+   */
+  orderBy?: "id" | "created_at";
+  /**
+   * Keyset cursor. Returns rows strictly greater (by `orderBy`) than this value.
+   * When `orderBy: "id"`, compared lexicographically. Mutually exclusive with
+   * `offset` — callers pick one. Mirrors {@link FindNodesByKindParams.after}.
+   */
+  after?: string;
 }>;
 
 /**

--- a/packages/typegraph/src/graph-merge/base-version.ts
+++ b/packages/typegraph/src/graph-merge/base-version.ts
@@ -1,0 +1,210 @@
+/**
+ * `base@V` stamping.
+ *
+ * A {@link BaseVersion} is the immutable token a branch is forked from. It must
+ * change whenever either the schema OR the live content of the base store
+ * changes, so that `merge()`'s precondition check (T11) can reject a branch that
+ * forked from a divergent base.
+ *
+ * The token is two stable components joined by a separator:
+ *
+ *   1. A **schema hash** — `computeSchemaHash(serializeSchema(graph, version))`.
+ *      This is content-addressed (the public `computeSchemaHash` deliberately
+ *      excludes the version number and `generatedAt`, so it is stable across
+ *      re-saves of the same schema).
+ *   2. A **content fingerprint** — a SHA-256 digest (truncated to a fixed-width
+ *      hex string) of every LIVE node and edge over the base store (`id`,
+ *      `updated_at`, the bitemporal `valid_from`/`valid_to`, and canonicalized
+ *      `props`; edges also carry their endpoint ids), sorted by id, so two stores
+ *      with identical live content fingerprint identically regardless of row
+ *      enumeration order or insertion order. Props AND validity are folded in so
+ *      the token changes on a content or validity edit even when `updated_at` ties
+ *      at millisecond granularity. Hashing keeps the token fixed-width instead of
+ *      growing linearly with store size.
+ *
+ * The token MUST be computed off the ORIGINAL base store, never off a clone:
+ * `exportGraph`/`importGraph` regenerate `created_at`/`updated_at`, so a clone's
+ * fingerprint would not match its source. (See the working-copy fidelity note in
+ * T4.)
+ *
+ * `computeBaseVersion` is async because schema hashing and live-content
+ * enumeration go through async TypeGraph internals. The design's synchronous
+ * illustrative signature does not survive contact with the real store surface.
+ */
+
+import { canonicalizeProps, parseRowProps } from "./canonical-props";
+import { compareStrings } from "./node-key";
+import { enumerateAllEdges, enumerateAllNodes } from "./state-diff";
+import type { GraphBackend, GraphDef, Store } from "./typegraph-internal";
+import { getEdgeKinds, getNodeKinds, sha256Hex } from "./typegraph-internal";
+import { computeSchemaHash, serializeSchema } from "./typegraph-internal";
+import type { BaseVersion } from "./types";
+import { asBaseVersion } from "./types";
+
+/**
+ * Separator between the schema-hash and content-fingerprint token components.
+ * Both components are fixed-width hex digests (no NUL byte), so a single NUL
+ * unambiguously delimits the two components.
+ */
+const TOKEN_SEPARATOR = "\0";
+
+/**
+ * Falls back to schema version `1` when the backend has not recorded an active
+ * schema version. `serializeSchema` only uses the version for the serialized
+ * doc; the hash deliberately excludes it, so the exact value never affects the
+ * resulting `BaseVersion`.
+ */
+const FALLBACK_SCHEMA_VERSION = 1;
+
+/**
+ * Reads the active schema version from the backend, defaulting when absent. The
+ * value is informational for `serializeSchema`; `computeSchemaHash` excludes the
+ * version, so this never destabilizes the token.
+ */
+async function readActiveSchemaVersion(
+  backend: GraphBackend,
+  graphId: string,
+): Promise<number> {
+  const active = await backend.getActiveSchema(graphId);
+  return active?.version ?? FALLBACK_SCHEMA_VERSION;
+}
+
+/**
+ * Computes the schema-hash component of the base version token — the SCHEMA half of
+ * `base@V`, independent of live content. Exported so `mergeIncremental()` can assert
+ * `forkPoint` and `target` share a schema (the hard half of its precondition) without
+ * re-parsing the token separator or recomputing the content fingerprint (§6.6).
+ */
+export async function computeSchemaComponent<G extends GraphDef>(
+  store: Store<G>,
+): Promise<string> {
+  const version = await readActiveSchemaVersion(store.backend, store.graphId);
+  return computeSchemaHash(serializeSchema(store.graph, version));
+}
+
+/**
+ * Stable TOTAL comparator over `{ kind, id }` digest entries. Keyed on `(kind, id)`
+ * because the node primary key is `(graph_id, kind, id)` — two nodes of different
+ * kinds may legitimately share an `id` (e.g. `Person:x` and `Company:x`), so an
+ * id-only comparator is non-total and would leave same-id/different-kind entries at
+ * the mercy of sort stability. `(kind, id)` makes the digest order fully canonical.
+ */
+function byDigestEntry(
+  left: Readonly<{ kind: string; id: string }>,
+  right: Readonly<{ kind: string; id: string }>,
+): number {
+  const byKind = compareStrings(left.kind, right.kind);
+  return byKind === 0 ? compareStrings(left.id, right.id) : byKind;
+}
+
+/**
+ * Number of SHA-256 bytes retained for the content fingerprint. 16 bytes (128
+ * bits) makes an accidental collision — which would let a divergent base pass
+ * the merge precondition — negligible, while keeping the token fixed-width
+ * regardless of store size.
+ */
+const CONTENT_FINGERPRINT_BYTES = 16;
+
+/**
+ * Builds the deterministic content fingerprint over the base store's LIVE rows.
+ *
+ * Each live node contributes `(id, updatedAt, validFrom, validTo, props)` and
+ * each live edge contributes `(id, updatedAt, validFrom, validTo, endpoints,
+ * props)`; both lists are sorted by id before serialization so the fingerprint is
+ * independent of enumeration order. Props are canonicalized so the token changes
+ * whenever live content changes even when two writes land on the same millisecond
+ * `updated_at` (timestamp granularity must never be the sole change signal). The
+ * bitemporal `valid_from`/`valid_to` are folded in for the same reason — they are
+ * user-mutable row content, so a validity-only edit that leaves `updated_at`
+ * unchanged must still move the token. Soft-deleted rows are intentionally
+ * excluded — the fingerprint describes the live base a branch forks from.
+ */
+async function computeContentFingerprint<G extends GraphDef>(
+  store: Store<G>,
+): Promise<string> {
+  const backend = store.backend;
+  const graphId = store.graphId;
+  const graph = store.graph;
+
+  const nodeKinds = getNodeKinds(graph);
+  const edgeKinds = getEdgeKinds(graph);
+
+  const nodeDigest: Readonly<{
+    id: string;
+    kind: string;
+    updatedAt: string;
+    validFrom: string | undefined;
+    validTo: string | undefined;
+    props: string;
+  }>[] = [];
+  for (const kind of nodeKinds) {
+    const rows = await enumerateAllNodes(backend, graphId, kind);
+    for (const row of rows) {
+      if (row.deleted_at === undefined) {
+        nodeDigest.push({
+          id: row.id,
+          kind: row.kind,
+          updatedAt: row.updated_at,
+          validFrom: row.valid_from,
+          validTo: row.valid_to,
+          props: canonicalizeProps(parseRowProps(row.props)),
+        });
+      }
+    }
+  }
+
+  const edgeDigest: Readonly<{
+    id: string;
+    kind: string;
+    fromId: string;
+    toId: string;
+    updatedAt: string;
+    validFrom: string | undefined;
+    validTo: string | undefined;
+    props: string;
+  }>[] = [];
+  for (const kind of edgeKinds) {
+    const rows = await enumerateAllEdges(backend, graphId, kind);
+    for (const row of rows) {
+      if (row.deleted_at === undefined) {
+        edgeDigest.push({
+          id: row.id,
+          kind: row.kind,
+          fromId: row.from_id,
+          toId: row.to_id,
+          updatedAt: row.updated_at,
+          validFrom: row.valid_from,
+          validTo: row.valid_to,
+          props: canonicalizeProps(parseRowProps(row.props)),
+        });
+      }
+    }
+  }
+
+  return sha256Hex(
+    canonicalizeProps({
+      nodes: nodeDigest.sort((left, right) => byDigestEntry(left, right)),
+      edges: edgeDigest.sort((left, right) => byDigestEntry(left, right)),
+    }),
+    CONTENT_FINGERPRINT_BYTES,
+  );
+}
+
+/**
+ * Computes the immutable `base@V` token for a store. Combines the schema hash
+ * with a live-content fingerprint into a single branded {@link BaseVersion}.
+ *
+ * MUST be called on the ORIGINAL base store, not a clone (clones regenerate
+ * timestamps and would fingerprint differently).
+ */
+export async function computeBaseVersion<G extends GraphDef>(
+  store: Store<G>,
+): Promise<BaseVersion> {
+  const [schemaComponent, contentComponent] = await Promise.all([
+    computeSchemaComponent(store),
+    computeContentFingerprint(store),
+  ]);
+  return asBaseVersion(
+    `${schemaComponent}${TOKEN_SEPARATOR}${contentComponent}`,
+  );
+}

--- a/packages/typegraph/src/graph-merge/blocking.ts
+++ b/packages/typegraph/src/graph-merge/blocking.ts
@@ -1,0 +1,202 @@
+/**
+ * Per-kind blocking (design §9 phase 2): bucket a kind's NEW nodes by a cheap
+ * exact-equality key so candidate-gen (T6) only compares pairs that could
+ * plausibly be the same entity, bounding the otherwise-O(n²) work.
+ *
+ * A node is placed into a bucket for EACH key it produces, so it can belong to
+ * MULTIPLE buckets — two key sources combined as a UNION (not a composite key):
+ *
+ *   1. The caller's `ResolveConfig.block(node)` — an application-defined cheap
+ *      pre-filter (e.g. a Patient's `birthDate`) → its ONE block bucket.
+ *   2. The kind's declared `unique` constraints, read from the PUBLIC
+ *      `store.introspect().kinds[k].unique` → ONE bucket per constraint the node
+ *      fully satisfies. A unique constraint is an exact-match short-circuit: two
+ *      nodes sharing all of a constraint's field values are definitionally the
+ *      same entity, so they co-bucket THERE regardless of their block keys or any
+ *      OTHER constraint.
+ *
+ * Composing the two sources into a single key (the old behavior) was a bug: a
+ * differing `block()` key — or a differing EARLIER constraint — split two nodes
+ * that share a unique value into separate buckets, so candidate-gen never compared
+ * them and a real duplicate survived the merge. The UNION fixes this: a shared
+ * unique value always co-buckets, independent of `block()`.
+ *
+ * candidate-gen compares pairs within each bucket and DEDUPS pairs across buckets,
+ * so a node in several buckets is compared against the UNION of its bucket-mates,
+ * each pair scored exactly once.
+ *
+ * Determinism is load-bearing — candidate-gen order must never leak into merge
+ * results — so bucket keys are emitted sorted lexicographically, each bucket's
+ * member list is sorted by `node.id`, and each unique signature is built in the
+ * constraint's declared field order.
+ *
+ * A node that produces NO key (no `block()`, no satisfied constraint) lands in the
+ * shared {@link UNBLOCKED_BUCKET_KEY} bucket, compared all-vs-all within its kind.
+ * This is the safe (no false-negative) fallback: blocking only ever prunes pairs
+ * that are guaranteed non-matches.
+ *
+ * This module is a PURE function over its inputs (the introspection snapshot is
+ * read synchronously by the caller and passed in); it performs no I/O.
+ */
+
+import { compareStrings } from "./node-key";
+import type { Node, NodeType, UniqueIntrospection } from "./typegraph-internal";
+import { computeUniqueKey } from "./typegraph-internal";
+import type { ResolveConfig } from "./types";
+
+/**
+ * Bucket key for nodes that produced no blocking key from either `block()` or a
+ * unique constraint. Members of this bucket are compared all-vs-all within their
+ * kind by candidate-gen.
+ */
+export const UNBLOCKED_BUCKET_KEY = "unblocked";
+
+/**
+ * Separator joining the parts of a bucket key (its prefix, and a unique
+ * signature's constraint name + field values). Chosen as a control character so it
+ * cannot collide with ordinary stringified property values.
+ */
+const KEY_PART_SEPARATOR = "\0";
+
+/**
+ * Prefix marking a `block()`-key bucket, so a `block()` value can never be confused
+ * with a unique-constraint value that happens to stringify the same.
+ */
+const BLOCK_KEY_PREFIX = "b";
+
+/** Prefix marking a unique-constraint bucket. See {@link BLOCK_KEY_PREFIX}. */
+const UNIQUE_KEY_PREFIX = "u";
+
+/**
+ * True when a bucket key denotes a UNIQUE-constraint bucket (vs. a `block()` or the
+ * unblocked bucket). candidate-gen FORCE-MERGES every pair in such a bucket: a
+ * shared unique value is definitionally the same entity (the exact-match
+ * short-circuit), so the pair is a GUARANTEED merge candidate regardless of the
+ * similarity threshold — differing properties are then reported as conflicts
+ * normally. This also keeps the merged graph from violating its own uniqueness:
+ * two unmerged same-unique rows could never commit.
+ */
+export function isUniqueBucketKey(key: string): boolean {
+  return key.startsWith(`${UNIQUE_KEY_PREFIX}${KEY_PART_SEPARATOR}`);
+}
+
+/**
+ * Builds the exact-match signature for one unique constraint from a node's
+ * field values, or `undefined` when ANY of the constraint's fields is `null` /
+ * `undefined` (a partial key cannot establish exact-match equality, and — since
+ * the introspection snapshot does not expose a constraint's `where` predicate —
+ * skipping absent values keeps a partial unique constraint from silently
+ * over-merging two distinct rows that the database would treat as a non-match;
+ * a genuine non-partial null collision still surfaces loudly at commit).
+ *
+ * The signature delegates to {@link computeUniqueKey} — the SAME key the store
+ * enforces uniqueness with — so a blocking bucket co-buckets EXACTLY the values
+ * the commit-time uniqueness check treats as equal. Hand-rolling a separate
+ * canonical encoding here drifted from enforcement: it distinguished the number
+ * `1` from the string `"1"` (which `computeUniqueKey` collapses, so the merge
+ * aborted with a `UniquenessError`) and key-sorted object values (which
+ * `computeUniqueKey` does not, so distinct rows were silently over-merged).
+ */
+function constraintSignature(
+  node: Node<NodeType>,
+  constraint: UniqueIntrospection,
+): string | undefined {
+  const props = node as unknown as Record<string, unknown>;
+  for (const field of constraint.fields) {
+    const value = props[field];
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+  }
+  return `${constraint.name}${KEY_PART_SEPARATOR}${computeUniqueKey(
+    props,
+    constraint.fields,
+    constraint.collation,
+  )}`;
+}
+
+/**
+ * Computes the SET of bucket keys a node belongs to: its `block()` key bucket (if
+ * `block()` returned a key) PLUS one bucket per unique constraint the node fully
+ * satisfies. Because a shared unique value gets its OWN bucket — never intersected
+ * with the block key or other constraints — two nodes sharing it always co-bucket.
+ * Returns `[UNBLOCKED_BUCKET_KEY]` when the node produces no key at all.
+ *
+ * Each unique signature already embeds its constraint name, so distinct constraints
+ * yield distinct keys; the `b`/`u` prefixes keep block and unique keyspaces
+ * disjoint. No constraint ordering is needed — each is an independent bucket.
+ */
+function bucketKeysFor(
+  node: Node<NodeType>,
+  block: ResolveConfig["block"],
+  constraints: readonly UniqueIntrospection[],
+): readonly string[] {
+  const keys: string[] = [];
+
+  const blockKey = block?.(node);
+  if (blockKey !== undefined) {
+    keys.push(`${BLOCK_KEY_PREFIX}${KEY_PART_SEPARATOR}${blockKey}`);
+  }
+
+  for (const constraint of constraints) {
+    const signature = constraintSignature(node, constraint);
+    if (signature !== undefined) {
+      keys.push(`${UNIQUE_KEY_PREFIX}${KEY_PART_SEPARATOR}${signature}`);
+    }
+  }
+
+  return keys.length === 0 ? [UNBLOCKED_BUCKET_KEY] : keys;
+}
+
+/**
+ * Buckets a kind's NEW nodes by their blocking key(s). A node may land in MORE
+ * THAN ONE bucket — its `block()` bucket plus a bucket for each unique constraint
+ * it satisfies — so two nodes sharing any blocking key co-bucket and are compared.
+ *
+ * @param newNodes The kind's new (fork-introduced) nodes. All nodes SHOULD be of
+ *   one kind; the caller invokes `blockNodes` once per resolved kind.
+ * @param resolveConfig The kind's resolution config; its optional `block`
+ *   function supplies the application blocking key.
+ * @param uniqueConstraints The kind's `unique` constraints from
+ *   `store.introspect().kinds[k].unique`. Pass an empty array when blocking
+ *   should rely on `block()` alone.
+ * @returns A map from bucket key → that bucket's nodes. Iteration order of the
+ *   returned map is the lexicographic order of bucket keys, and each bucket's
+ *   node list is sorted by `node.id`, so the result is a pure, order-independent
+ *   function of the input node SET. A node may appear in several buckets;
+ *   candidate-gen dedups pairs so each is scored once.
+ */
+export function blockNodes<K extends NodeType>(
+  newNodes: readonly Node<K>[],
+  resolveConfig: Pick<ResolveConfig, "block">,
+  uniqueConstraints: readonly UniqueIntrospection[] = [],
+): Map<string, Node<K>[]> {
+  const buckets = new Map<string, Node<K>[]>();
+
+  for (const node of newNodes) {
+    for (const key of bucketKeysFor(
+      node,
+      resolveConfig.block,
+      uniqueConstraints,
+    )) {
+      const bucket = buckets.get(key);
+      if (bucket === undefined) {
+        buckets.set(key, [node]);
+      } else {
+        bucket.push(node);
+      }
+    }
+  }
+
+  const sortedKeys = [...buckets.keys()].sort((left, right) =>
+    compareStrings(left, right),
+  );
+  const ordered = new Map<string, Node<K>[]>();
+  for (const key of sortedKeys) {
+    const members = [...buckets.get(key)!].sort((left, right) =>
+      compareStrings(left.id, right.id),
+    );
+    ordered.set(key, members);
+  }
+  return ordered;
+}

--- a/packages/typegraph/src/graph-merge/branch.ts
+++ b/packages/typegraph/src/graph-merge/branch.ts
@@ -1,0 +1,69 @@
+/**
+ * `branch()` — fork an isolated, independently-mutable working copy of a base
+ * store (design §7.1).
+ *
+ * A branch is a {@link GraphBranch}: a fresh {@link BranchId}, the immutable
+ * `base@V` token the copy forked from (computed off the ORIGINAL base store via
+ * {@link computeBaseVersion}, never off the clone), and a {@link Store} over the
+ * branch's own backend seeded with the base's live state.
+ *
+ * The copy mechanism is pluggable behind {@link WorkingCopyStrategy}. The P0
+ * default is the faithful export/import clone ({@link cloneWorkingCopyStrategy}),
+ * which keeps this primitive backend-agnostic: the caller supplies a
+ * `makeBackend` factory, and `branch()` never names a concrete backend.
+ */
+
+import { computeBaseVersion } from "./base-version";
+import { BranchError } from "./errors";
+import type { Result } from "./result";
+import { err, ok } from "./result";
+import type { GraphDef } from "./typegraph-internal";
+import { generateId } from "./typegraph-internal";
+import type { BranchOptions, GraphBranch } from "./types";
+import { asBranchId } from "./types";
+import type { MakeBackend, WorkingCopyStrategy } from "./working-copy";
+import { cloneWorkingCopyStrategy } from "./working-copy";
+
+/**
+ * Creates an isolated working-copy branch of `baseStore`.
+ *
+ * Stamps the `base@V` token off the original base store, mints (or accepts) a
+ * {@link BranchId}, and materializes the working copy via the resolved strategy.
+ * The default strategy is a faithful clone over a fresh backend produced by
+ * `makeBackend`; pass an explicit `strategy` to override (e.g. a future
+ * logical-namespace copy-on-write).
+ *
+ * Returns a {@link Result}: success yields the {@link GraphBranch}; any failure
+ * (base-version stamping, backend construction, export/import) is wrapped in a
+ * {@link BranchError} with the underlying cause attached. Errors are returned,
+ * never thrown — this is internal-logic surface (the caller converts to a thrown
+ * error at the framework boundary).
+ *
+ * @param baseStore - The store to fork. Remains untouched.
+ * @param makeBackend - Factory for the working copy's backend (keeps the
+ *   primitive backend-agnostic). Used only by the default clone strategy; ignored
+ *   when an explicit `strategy` is supplied.
+ * @param options - Optional `{ id }` to set an explicit branch id.
+ * @param strategy - Optional working-copy strategy override.
+ */
+export async function branch<G extends GraphDef>(
+  baseStore: GraphBranch<G>["store"],
+  makeBackend: MakeBackend,
+  options?: BranchOptions,
+  strategy?: WorkingCopyStrategy<G>,
+): Promise<Result<GraphBranch<G>, BranchError>> {
+  try {
+    const base = await computeBaseVersion(baseStore);
+    const id = options?.id ?? asBranchId(generateId());
+    const workingCopyStrategy =
+      strategy ?? cloneWorkingCopyStrategy<G>(makeBackend);
+    const store = await workingCopyStrategy.create(baseStore);
+    return ok({ id, base, store });
+  } catch (error) {
+    return err(
+      new BranchError("Failed to create working-copy branch of base store", {
+        cause: error,
+      }),
+    );
+  }
+}

--- a/packages/typegraph/src/graph-merge/candidate-gen.ts
+++ b/packages/typegraph/src/graph-merge/candidate-gen.ts
@@ -1,0 +1,65 @@
+/**
+ * Candidate generation over a kind's pre-blocked nodes (design §9 phase 3, T6).
+ *
+ * Since the §4 three-layer split this is a thin COMPOSITION of the two layers it
+ * used to fuse: the bucket SOURCES (`sources.ts`) that turn the blocked buckets
+ * into proposals, and the shared SCORING stage (`scoring.ts`) that turns those
+ * proposals into the {@link CandidateEdge} set. `block()` / `unblocked` buckets
+ * become fuzzy pairs (scored against the threshold); unique-constraint buckets
+ * become FORCED edges (definitional, max score, never bounded by the comparison
+ * ceiling). The two layers — not this function — own the behaviour; `merge()` drives
+ * the same sources + scoring directly off the staged nodes (`merge.ts`).
+ *
+ * The edge / warning / result types live in `scoring.ts` (the layer that produces
+ * them) and are re-exported here so existing importers keep their import path.
+ */
+
+import type { MergeError } from "./errors";
+import type { Result } from "./result";
+import type { CandidateGenResult } from "./scoring";
+import { scoreCandidates } from "./scoring";
+import type { SimilarityContext } from "./similarity";
+import {
+  forcedEdgesFromBlocks,
+  keylessConfigFor,
+  pairsFromBlocks,
+} from "./sources";
+import type { Node, NodeType } from "./typegraph-internal";
+import type { ComparisonCeilingPolicy, ResolveConfig } from "./types";
+
+export type { CandidateEdge, CandidateGenResult } from "./scoring";
+
+/**
+ * Generates candidate-merge edges for a single kind's blocked nodes by running the
+ * bucket sources over the shared scoring stage.
+ *
+ * @param blocks The kind's nodes bucketed by `blockNodes` (T5) — the UNION of the
+ *   `block()` key and the unique-constraint signatures. A node may appear in
+ *   SEVERAL buckets; the scoring stage dedups pairs so each is scored once.
+ * @param resolveConfig The kind's resolution config (similarity strategy + threshold).
+ * @param ctx Ambient context (the backend, for vector-capability gating).
+ * @param ceilingPolicy Behavior when `maxComparisonsPerKind` is exceeded.
+ * @param maxComparisonsPerKind Optional per-kind FUZZY-comparison ceiling.
+ *   `undefined` means unbounded.
+ * @returns `ok({ edges, warnings })`, or `err(...)` when the `"error"` ceiling
+ *   fires or a `vector`/`hybrid` guard trips.
+ */
+export function generateCandidates<K extends NodeType>(
+  blocks: ReadonlyMap<string, readonly Node<K>[]>,
+  resolveConfig: ResolveConfig,
+  ctx: SimilarityContext,
+  ceilingPolicy: ComparisonCeilingPolicy,
+  maxComparisonsPerKind?: number,
+): Result<CandidateGenResult, MergeError> {
+  const widened = blocks as ReadonlyMap<string, readonly Node<NodeType>[]>;
+  return scoreCandidates(
+    {
+      pairs: pairsFromBlocks(widened, keylessConfigFor(resolveConfig)),
+      forcedEdges: forcedEdgesFromBlocks(widened),
+    },
+    resolveConfig,
+    ctx,
+    ceilingPolicy,
+    maxComparisonsPerKind,
+  );
+}

--- a/packages/typegraph/src/graph-merge/canonical-props.ts
+++ b/packages/typegraph/src/graph-merge/canonical-props.ts
@@ -1,0 +1,95 @@
+/**
+ * The single canonical property serializer for the merge primitive.
+ *
+ * Hoisted to T2 (rather than living next to the clustering code) because three
+ * separate phases must agree byte-for-byte on the serialized form of a property
+ * bag:
+ *
+ *   - state-diff (T3) — to detect whether an inherited node's props changed,
+ *   - clustering / property union (T8) — to compare member values,
+ *   - edge repoint + dedupe (T9) — to key the `(from|type|to|propsKey)` tuple.
+ *
+ * {@link canonicalValueKey} is the SINGLE-VALUE sibling: the same recursive
+ * key-sort over an arbitrary {@link JsonValue} (scalar / array / object), so the
+ * conflict-resolution layer (T8 / `conflict-policy.ts`) decides value equality and
+ * tie-breaks on the canonical form too — two branches that wrote a logically-equal
+ * nested object with different key order must NOT register as a conflict.
+ *
+ * Determinism rules:
+ *   - Object keys are sorted lexicographically at every nesting level, so two
+ *     objects that differ only by key insertion order serialize identically.
+ *   - Arrays preserve order (order is semantically meaningful in a list).
+ *   - `undefined` keys are dropped (JSON has no `undefined`; an absent key and a
+ *     key set to `undefined` are treated as the same absence).
+ *   - All other JSON-representable values serialize via their natural form.
+ *
+ * IMPORTANT contract for callers: the input MUST be a PARSED plain object, never
+ * a JSON string. Backend rows store `props` as a JSON string; callers MUST
+ * `JSON.parse` first. Passing a string would serialize the string literal (with
+ * its own incidental key order) rather than the canonical structure, so the
+ * `propsKey` would NOT be stable across staged-vs-committed representations.
+ */
+
+import type { JsonValue } from "./typegraph-internal";
+import { sortedReplacer } from "./typegraph-internal";
+
+/**
+ * Produces a deterministic, recursively key-sorted JSON serialization of a
+ * parsed property object.
+ *
+ * Delegates to the schema layer's {@link sortedReplacer} — the single canonical
+ * JSON serializer in the codebase (also used by `computeSchemaHash` /
+ * `computeSchemaDiff`) — so the merge primitive and the schema layer can never
+ * drift on what "canonical form" means. The replacer sorts object keys at every
+ * depth while preserving array order; `JSON.stringify` omits `undefined`-valued
+ * keys, matching the "an absent key and a key set to `undefined` are the same
+ * absence" rule in the module docs.
+ *
+ * @param props A PARSED plain object (NOT a JSON string). See module docs.
+ * @returns A canonical JSON string suitable for equality comparison / dedupe
+ *   keying. Equivalent objects (key order aside) yield identical strings;
+ *   objects differing in any value yield differing strings.
+ */
+export function canonicalizeProps(
+  props: Readonly<Record<string, unknown>>,
+): string {
+  return JSON.stringify(props, sortedReplacer);
+}
+
+/**
+ * Produces a deterministic, recursively key-sorted JSON serialization of a single
+ * {@link JsonValue} — the per-value analogue of {@link canonicalizeProps}.
+ *
+ * Used by the conflict layer to compare candidate values, dedupe them, and
+ * tie-break, so a nested object's incidental key order can never make two
+ * logically-equal values look different (which would surface a spurious conflict).
+ *
+ * @param value Any parsed JSON value (scalar, array, or object). Not a JSON string.
+ * @returns A canonical JSON string suitable for equality / dedupe / ordering.
+ */
+export function canonicalValueKey(value: JsonValue): string {
+  return JSON.stringify(value, sortedReplacer);
+}
+
+/**
+ * Parses a stored row's JSON `props` string into the PARSED plain object that
+ * {@link canonicalizeProps} requires. Malformed JSON, a non-object, or an array
+ * all collapse to `{}` — a parse error never escapes. Backend-written rows hold
+ * valid JSON, but an external / legacy / truncated `props` value must not crash a
+ * state diff or a base-version fingerprint. Centralized so the diff and the
+ * fingerprint can never disagree on what a malformed row parses to.
+ */
+export function parseRowProps(
+  props: string,
+): Readonly<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(props);
+  } catch {
+    return {};
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {};
+  }
+  return parsed as Record<string, unknown>;
+}

--- a/packages/typegraph/src/graph-merge/canonicalize.ts
+++ b/packages/typegraph/src/graph-merge/canonicalize.ts
@@ -1,0 +1,421 @@
+/**
+ * Canonical survivor selection + commutative property union (design §6.4 rule 3
+ * & rule 4 / §7.3, T8).
+ *
+ * Given a {@link ClusterResult} (member ids) and the per-member, per-branch
+ * property contributions, this module:
+ *
+ *   1. Picks the CANONICAL survivor — by default the member with the
+ *      lexicographically-minimal node id (`MergeOptions.canonical` overrides).
+ *      Because `generateId()` is nanoid (random, NOT time-prefixed), min-id is
+ *      independent of creation order — the canonical choice cannot leak the
+ *      order nodes were created or branches were merged in.
+ *   2. UNIONS properties across all members: per property, collect every
+ *      `(branchId, value)`; if all agree → that value; if they differ → defer to
+ *      the conflict policy on a STABLE non-wall-clock branch order (T8 /
+ *      `conflict-policy.ts`), recording a {@link PropertyConflict}.
+ *
+ * The result is a pure function of the (unordered) member set + the captured
+ * branch order, so shuffling members or branches yields an identical resolution.
+ */
+
+import type { ClusterResult } from "./clustering";
+import type { ProvenanceWeights, ResolutionContext } from "./conflict-policy";
+import {
+  collectConflictingValues,
+  resolvePropertyUnion,
+} from "./conflict-policy";
+import { compareMergeKeys, compareStrings, idOf, mergeKeyOf } from "./node-key";
+import type {
+  GraphDef,
+  JsonValue,
+  NodeId,
+  NodeType,
+} from "./typegraph-internal";
+import type {
+  BranchId,
+  ConflictingValue,
+  EntityResolution,
+  PropertyConflict,
+  PropertyConflictPolicy,
+  ResolvedCluster,
+} from "./types";
+import { asBranchId } from "./types";
+
+/**
+ * Reserved provenance "branch" for a BASE contribution (§6.4-D). A committed base
+ * member has no real branch; this BranchId-shaped sentinel is the key its
+ * contributions carry through the value union and the provenance records, so those
+ * paths tolerate a base member without a separate code path. It is NOT a real branch
+ * id — it is EXCLUDED from the public {@link EntityResolution.branchOrigins} (which
+ * lists only real contributing branches), and callers must never mint a branch with
+ * this reserved value (rejected at the merge boundary; kept NUL-free so it round-trips
+ * through `persistProvenance` on every backend).
+ */
+export const BASE_PROVENANCE_BRANCH: BranchId =
+  asBranchId("__committed_base__");
+
+/** A node id in its untyped (`NodeType`-default) branded form. */
+type AnyNodeId = NodeId<NodeType>;
+
+/**
+ * Where a {@link ClusterMember}'s contribution originated: a branch's STAGED diff,
+ * or a committed BASE node a base source pulled into the cluster (design §6.4-C).
+ * The mandatory `branchId` cannot represent a base member, so this discriminator is
+ * what lets the reconciler tell the two apart — it enforces base-id-wins (§6.4-C: a
+ * base member is the canonical survivor, see {@link pickClusterSurvivor}) and tags
+ * base provenance with {@link BASE_PROVENANCE_BRANCH} (§6.4-D). The new-vs-base
+ * sources (`baseUnique`) emit `"base"` members; the public snapshot `merge()` path
+ * stays staged-only, so every member there is `"staged"`.
+ */
+type MemberOrigin = "staged" | "base";
+
+/**
+ * One member of a cluster, with the parsed props the contributing branch staged
+ * for it. A node that appears in several branches contributes several
+ * {@link ClusterMember} entries (one per branch), so property differences across
+ * branches surface as conflicts.
+ */
+export type ClusterMember = Readonly<{
+  origin: MemberOrigin;
+  id: AnyNodeId;
+  kind: string;
+  branchId: BranchId;
+  props: Readonly<Record<string, JsonValue>>;
+}>;
+
+/**
+ * The fully-resolved canonical entity for one cluster: the survivor id, the
+ * unioned property bag, the {@link EntityResolution} record, and any
+ * {@link PropertyConflict}s the union surfaced.
+ */
+export type CanonicalEntity = Readonly<{
+  canonicalId: AnyNodeId;
+  kind: string;
+  props: Readonly<Record<string, JsonValue>>;
+  resolution: EntityResolution;
+  conflicts: readonly PropertyConflict[];
+}>;
+
+/**
+ * Bare-id reference selector over a PUBLIC {@link ResolvedCluster}: the member with
+ * the lexicographically-minimal node id, or the caller's override. It is NOT the
+ * live survivor selector — the merge path selects survivors via
+ * {@link pickClusterSurvivor}, which is cross-kind-aware (composite `(kind, id)`
+ * keys), enforces base-id-wins, and is where the {@link MergeOptions.canonical} hook
+ * is actually consulted. Kept as the documented bare-id default a `canonical` hook
+ * mirrors; do not wire new phases onto this helper.
+ */
+export function pickCanonical(
+  cluster: ResolvedCluster,
+  override?: (cluster: ResolvedCluster) => AnyNodeId,
+): AnyNodeId {
+  if (override !== undefined) {
+    return override(cluster);
+  }
+  return [...cluster.members].sort((left, right) =>
+    compareStrings(left, right),
+  )[0]!;
+}
+
+/**
+ * Selects a cluster's canonical survivor MEMBER, enforcing BASE-ID-WINS (§6.4-C)
+ * UPSTREAM of the `MergeOptions.canonical` hook. Returning the member (not just its
+ * id) carries the survivor's KIND alongside its id, so the canonical entity's kind is
+ * the survivor's own kind — never a different-kind member that merely shares the id
+ * string (the cross-kind identity hazard).
+ *
+ *   - if the cluster contains a BASE member, the committed base identity is the
+ *     survivor and the hook is BYPASSED — the committed identity (and everything
+ *     pointing at it) must stay stable, so this is a commit-correctness invariant,
+ *     not a survivor preference. By §6.4-A a merged cluster holds ≤1 base member; the
+ *     min base `(id, kind)` is taken defensively so selection is deterministic even
+ *     before that guard lands.
+ *   - otherwise the cluster is pure staged-vs-staged and the hook (mapped over the
+ *     bare-id view of the cluster) or the min-`(id, kind)` default applies.
+ */
+function pickClusterSurvivor(
+  members: readonly ClusterMember[],
+  cluster: ClusterResult,
+  canonicalOverride?: (cluster: ResolvedCluster) => AnyNodeId,
+  preferKind?: (kinds: readonly string[]) => string | undefined,
+): ClusterMember {
+  const byKey = (left: ClusterMember, right: ClusterMember): number =>
+    compareMergeKeys(mergeKeyOf(left), mergeKeyOf(right));
+
+  // base-id-wins (§6.4-C): the committed identity is the survivor outright. By the
+  // staged-only ontology-retype rule, a base member never shares an id with a
+  // different-kind member, so no cross-kind kind choice arises here.
+  const baseMembers = members
+    .filter((member) => member.origin === "base")
+    .sort(byKey);
+  if (baseMembers.length > 0) {
+    return baseMembers[0]!;
+  }
+
+  // The survivor's bare id: the override's pick (mapped over the bare-id view of the
+  // cluster) when it names a real member, else the minimum identity's id.
+  let canonicalId: AnyNodeId | undefined;
+  if (canonicalOverride !== undefined) {
+    const chosen = canonicalOverride({ members: cluster.members.map(idOf) });
+    if (members.some((member) => member.id === chosen)) {
+      canonicalId = chosen;
+    }
+  }
+  if (canonicalId === undefined) {
+    const minIdentity = [...cluster.members].sort((left, right) =>
+      compareMergeKeys(left, right),
+    )[0];
+    canonicalId =
+      minIdentity === undefined ? members[0]!.id : idOf(minIdentity);
+  }
+
+  // Among the members AT that id, choose the KIND. An ontology-retype cluster carries
+  // several subtype-compatible kinds under one id; `preferKind` selects the
+  // MOST-SPECIFIC one, BYPASSING the bare-id hook (which cannot tell `Doctor:x` from
+  // `SpecialistDoctor:x`). Otherwise the id has a single kind and the min `(id, kind)`
+  // member is taken.
+  const membersAtId = members.filter((member) => member.id === canonicalId);
+  if (membersAtId.length === 0) {
+    return [...members].sort(byKey)[0]!;
+  }
+  const kinds = [...new Set(membersAtId.map((member) => member.kind))];
+  const chosenKind =
+    preferKind !== undefined && kinds.length > 1 ?
+      preferKind(kinds)
+    : undefined;
+  return (
+    (chosenKind === undefined ? undefined : (
+      membersAtId.find((member) => member.kind === chosenKind)
+    )) ?? [...membersAtId].sort(byKey)[0]!
+  );
+}
+
+function findPreferredMember(
+  members: readonly ClusterMember[],
+  property: string,
+  preferredBranchId: BranchId | undefined,
+): ClusterMember | undefined {
+  if (preferredBranchId === undefined) {
+    return undefined;
+  }
+  return members.find(
+    (member) =>
+      member.branchId === preferredBranchId && property in member.props,
+  );
+}
+
+function memberPropertyValue(
+  member: ClusterMember,
+  property: string,
+): JsonValue | undefined {
+  if (!(property in member.props)) {
+    return undefined;
+  }
+  return member.props[property];
+}
+
+function pickCanonicalPropertyValue(
+  canonicalMember: ClusterMember,
+  members: readonly ClusterMember[],
+  property: string,
+  values: readonly ConflictingValue[],
+  preferredBranchId: BranchId | undefined,
+): JsonValue {
+  const preferredMember = findPreferredMember(
+    members,
+    property,
+    preferredBranchId,
+  );
+  const preferredValue =
+    preferredMember === undefined ? undefined : (
+      memberPropertyValue(preferredMember, property)
+    );
+  if (preferredValue !== undefined) {
+    return preferredValue;
+  }
+
+  const canonicalValue = memberPropertyValue(canonicalMember, property);
+  return canonicalValue === undefined ? values[0]!.value : canonicalValue;
+}
+
+/**
+ * Unions the properties of a cluster's members into a single canonical property
+ * bag, resolving any per-property disagreement via the conflict policy on a
+ * stable branch order. Returns the merged props plus a {@link PropertyConflict}
+ * for every property that genuinely differed.
+ *
+ * @param canonicalId The survivor id (from {@link pickClusterSurvivor}); the entity id
+ *   on every recorded conflict.
+ * @param kind The canonical entity's kind, recorded on each conflict.
+ * @param members Every `(branchId, props)` contribution for this cluster.
+ * @param context The captured policy + stable branch order + optional weights.
+ * @param branchRank The branch rank lookup (built once, shared across clusters).
+ */
+function unionProperties(
+  canonicalMember: ClusterMember,
+  members: readonly ClusterMember[],
+  context: ResolutionContext<GraphDef>,
+  baseContext: ResolutionContext<GraphDef>,
+  branchRank: ReadonlyMap<BranchId, number>,
+  preferredBranchId?: BranchId,
+): Readonly<{
+  props: Record<string, JsonValue>;
+  conflicts: PropertyConflict[];
+}> {
+  const canonicalId = canonicalMember.id;
+  const kind = canonicalMember.kind;
+  const hasBaseMember = members.some((member) => member.origin === "base");
+
+  const propertyNames = new Set<string>();
+  for (const member of members) {
+    for (const name of Object.keys(member.props)) {
+      propertyNames.add(name);
+    }
+  }
+
+  const props: Record<string, JsonValue> = {};
+  const conflicts: PropertyConflict[] = [];
+
+  for (const property of [...propertyNames].sort((left, right) =>
+    compareStrings(left, right),
+  )) {
+    const values = collectConflictingValues(property, members);
+    if (values.length === 0) {
+      continue;
+    }
+    const canonicalValue = pickCanonicalPropertyValue(
+      canonicalMember,
+      members,
+      property,
+      values,
+      preferredBranchId,
+    );
+
+    // A disagreement that involves a committed BASE value is governed by the
+    // SEPARATE onBasePropertyConflict policy (§6.4-C) — it must not inherit the
+    // staged policy, which could let a branch overwrite committed data. Because
+    // base-id-wins makes the base member canonical, `canonicalValue` is already the
+    // committed value, so `"flag"` keeps it. A property the base lacks is a pure
+    // gap-fill / staged-vs-staged conflict and uses the staged policy.
+    const baseInvolved =
+      hasBaseMember &&
+      members.some(
+        (member) => member.origin === "base" && property in member.props,
+      );
+
+    // Resolution math sees the FULL contributions (including the base value, so the
+    // disagreement is detected and base-id-wins resolves it). But the reserved
+    // {@link BASE_PROVENANCE_BRANCH} sentinel is NOT a real branch, so it is excluded
+    // from the PUBLIC conflict's `values` — exactly as it is from `branchOrigins`. The
+    // committed value the base contributed still surfaces as the conflict `resolution`.
+    const reportedValues = values.filter(
+      (value) =>
+        value.branchId !== BASE_PROVENANCE_BRANCH &&
+        value.branchId !== preferredBranchId,
+    );
+    const { value, conflict } = resolvePropertyUnion(
+      {
+        entityId: canonicalId,
+        kind,
+        property,
+        values,
+        reportedValues,
+        canonicalValue,
+      },
+      baseInvolved ? baseContext : context,
+      branchRank,
+    );
+    props[property] = value;
+    if (conflict !== undefined) {
+      conflicts.push(conflict);
+    }
+  }
+
+  return { props, conflicts };
+}
+
+/**
+ * Resolves a single cluster into its {@link CanonicalEntity}: picks the survivor,
+ * unions properties under the conflict policy, and assembles the
+ * {@link EntityResolution} record.
+ *
+ * @param cluster The cluster's member ids (id-sorted from T8 clustering).
+ * @param members The per-branch property contributions for those member ids.
+ * @param policy The staged-vs-staged property-conflict policy.
+ * @param branchRank The captured stable branch rank (built once).
+ * @param weights Optional per-branch trust weights for `"provenanceWeighted"`.
+ * @param canonicalOverride Optional `MergeOptions.canonical` survivor selector.
+ * @param basePolicy The SEPARATE base↔branch policy (§6.4-C, `onBasePropertyConflict`)
+ *   governing conflicts that involve a committed base value. Defaults to `"flag"`
+ *   (keep committed value) — it never inherits `policy`.
+ */
+export function canonicalizeCluster(
+  cluster: ClusterResult,
+  members: readonly ClusterMember[],
+  policy: PropertyConflictPolicy,
+  branchRank: ReadonlyMap<BranchId, number>,
+  weights?: ProvenanceWeights,
+  canonicalOverride?: (cluster: ResolvedCluster) => AnyNodeId,
+  basePolicy: PropertyConflictPolicy = "flag",
+  preferKind?: (kinds: readonly string[]) => string | undefined,
+  preferredBranchId?: BranchId,
+): CanonicalEntity {
+  const survivor = pickClusterSurvivor(
+    members,
+    cluster,
+    canonicalOverride,
+    preferKind,
+  );
+  const canonicalId = survivor.id;
+  const kind = survivor.kind;
+
+  const context: ResolutionContext<GraphDef> = {
+    policy,
+    ...(weights === undefined ? {} : { weights }),
+  };
+  const baseContext: ResolutionContext<GraphDef> = {
+    policy: basePolicy,
+    ...(weights === undefined ? {} : { weights }),
+  };
+
+  const { props, conflicts } = unionProperties(
+    survivor,
+    members,
+    context,
+    baseContext,
+    branchRank,
+    preferredBranchId,
+  );
+
+  // The public resolution reports the DISTINCT bare member ids; the cluster carries
+  // composite `(kind, id)` keys, so project each to its id and dedup (an ontology
+  // retype puts several kinds under one id, which collapses to a single member id).
+  const memberIds = [
+    ...new Set(cluster.members.map((member) => idOf(member))),
+  ].sort((left, right) => compareStrings(left, right));
+  // `branchOrigins` lists the REAL contributing branches; the reserved
+  // {@link BASE_PROVENANCE_BRANCH} sentinel a base member carries is NOT a branch, so
+  // it is excluded from this public field (it still flows through the value union and
+  // the provenance records, which is where a base contribution is tracked).
+  const branchOrigins = [
+    ...new Set(
+      members
+        .map((member) => member.branchId)
+        .filter(
+          (branchId) =>
+            branchId !== BASE_PROVENANCE_BRANCH &&
+            branchId !== preferredBranchId,
+        ),
+    ),
+  ].sort((left, right) => compareStrings(left, right));
+
+  const resolution: EntityResolution = {
+    canonicalId,
+    memberIds,
+    kind,
+    branchOrigins,
+  };
+
+  return { canonicalId, kind, props, resolution, conflicts };
+}

--- a/packages/typegraph/src/graph-merge/closures.ts
+++ b/packages/typegraph/src/graph-merge/closures.ts
@@ -1,0 +1,154 @@
+/**
+ * Ontology subclass-closure glue over TypeGraph's PUBLIC closure utilities.
+ *
+ * TypeGraph 0.29.0 exports `computeTransitiveClosure` / `invertClosure` /
+ * `isReachable` from the package root, and `store.introspect().ontology` exposes
+ * the declared meta-edges as `{ metaEdge, from, to, origin }` records. This
+ * module is therefore THIN GLUE: it projects the introspected ontology onto the
+ * `[child, parent]` relation pairs the public closure builder expects, folds in
+ * `equivalentTo` equivalence classes, and exposes the {@link isReachable}
+ * accessor reconcileTypes (T10) consumes. There is deliberately NO local Warshall
+ * reimplementation — the transitive work is done entirely by the public
+ * `computeTransitiveClosure`.
+ *
+ * Direction convention (verified against `store.introspect()` at runtime):
+ * `subClassOf(Child, Parent)` introspects as `{ metaEdge: "subClassOf",
+ * from: "Child", to: "Parent" }`. So `from` is the more-specific (child) type
+ * and `to` is the more-general (parent) type, matching the `[child, parent]`
+ * relation pairs `computeTransitiveClosure` consumes, where `isReachable(closure,
+ * child, ancestor)` answers "is `child` a (transitive) subclass of `ancestor`?".
+ */
+import { compareStrings } from "./node-key";
+import type { OntologyIntrospection } from "./typegraph-internal";
+import {
+  computeTransitiveClosure,
+  isReachable as isReachablePublic,
+} from "./typegraph-internal";
+import { UnionFind } from "./union-find";
+
+/**
+ * The meta-edge name identifying a subclass relation in `introspect().ontology`.
+ */
+export const SUB_CLASS_OF_META_EDGE = "subClassOf";
+
+/**
+ * The meta-edge name identifying an equivalence relation in
+ * `introspect().ontology`. `equivalentTo` edges are folded into symmetric
+ * equivalence classes so that equivalent types share each other's ancestors and
+ * descendants.
+ */
+const EQUIVALENT_TO_META_EDGE = "equivalentTo";
+
+/**
+ * An immutable subclass closure plus the equivalence-class canonicalization used
+ * to fold `equivalentTo` relations.
+ *
+ * - `closure` maps each (canonicalized) child type to the set of all its
+ *   (canonicalized) transitive ancestors, as produced by the public
+ *   `computeTransitiveClosure`.
+ * - `canonicalOf` maps every type seen in the ontology to its equivalence-class
+ *   representative (the lexicographically-smallest member). Types not involved
+ *   in any `equivalentTo` relation map to themselves.
+ */
+export type SubClassClosure = Readonly<{
+  closure: ReadonlyMap<string, ReadonlySet<string>>;
+  canonicalOf: ReadonlyMap<string, string>;
+}>;
+
+/**
+ * Builds the subclass closure from an introspected ontology.
+ *
+ * Steps:
+ *   1. Fold every `equivalentTo` relation into a union-find so equivalent types
+ *      collapse to a single deterministic representative.
+ *   2. Project every `subClassOf` relation onto a `[childRep, parentRep]` pair
+ *      (each endpoint canonicalized to its equivalence representative). Self
+ *      loops introduced by equivalence are dropped — a type is never its own
+ *      strict subclass.
+ *   3. Hand the relation pairs to the PUBLIC `computeTransitiveClosure`. No local
+ *      transitive-closure logic exists here.
+ *
+ * @param ontology The `store.introspect().ontology` array.
+ * @returns A `SubClassClosure` queryable via `isReachable` (which canonicalizes
+ *   its inputs through the equivalence map).
+ */
+export function buildSubClassClosure(
+  ontology: readonly OntologyIntrospection[],
+): SubClassClosure {
+  // Union by lexicographically-smaller representative, so each equivalence class's
+  // canonical is its lex-min member, independent of relation insertion order.
+  const unionFind = new UnionFind<string>(compareStrings);
+
+  for (const relation of ontology) {
+    unionFind.add(relation.from);
+    unionFind.add(relation.to);
+    if (relation.metaEdge === EQUIVALENT_TO_META_EDGE) {
+      unionFind.union(relation.from, relation.to);
+    }
+  }
+
+  const canonicalOf = new Map<string, string>();
+  for (const value of unionFind.members()) {
+    canonicalOf.set(value, unionFind.find(value));
+  }
+
+  const relationKeys = new Set<string>();
+  const relations: (readonly [string, string])[] = [];
+  for (const relation of ontology) {
+    if (relation.metaEdge !== SUB_CLASS_OF_META_EDGE) {
+      continue;
+    }
+    const child = canonicalOf.get(relation.from) ?? relation.from;
+    const parent = canonicalOf.get(relation.to) ?? relation.to;
+    if (child === parent) {
+      continue;
+    }
+    const key = `${child}\0${parent}`;
+    if (relationKeys.has(key)) {
+      continue;
+    }
+    relationKeys.add(key);
+    relations.push([child, parent]);
+  }
+
+  return {
+    closure: computeTransitiveClosure(relations),
+    canonicalOf,
+  };
+}
+
+/**
+ * Resolves a type name to its equivalence-class representative, falling back to
+ * the name itself when the type was never seen in the ontology.
+ */
+function canonicalType(closure: SubClassClosure, type: string): string {
+  return closure.canonicalOf.get(type) ?? type;
+}
+
+/**
+ * Reports whether `from` is a (transitive) subclass of `to`.
+ *
+ * Both arguments are canonicalized through the equivalence map first, then the
+ * PUBLIC `isReachable` is consulted. Equivalent-but-distinct types (e.g.
+ * `equivalentTo(Physician, Doctor)`) are treated as mutually reachable. A type
+ * is NOT considered a subclass of itself (the relation is strict / irreflexive),
+ * matching the public closure's non-reflexive semantics.
+ *
+ * @param closure The closure produced by `buildSubClassClosure`.
+ * @param from The candidate descendant (more-specific) type.
+ * @param to The candidate ancestor (more-general) type.
+ */
+export function isReachable(
+  closure: SubClassClosure,
+  from: string,
+  to: string,
+): boolean {
+  const fromRep = canonicalType(closure, from);
+  const toRep = canonicalType(closure, to);
+  if (fromRep === toRep) {
+    // Distinct names that fold to the same equivalence class are mutually
+    // reachable; identical names are NOT (strict subclass relation).
+    return from !== to;
+  }
+  return isReachablePublic(closure.closure, fromRep, toRep);
+}

--- a/packages/typegraph/src/graph-merge/clustering.ts
+++ b/packages/typegraph/src/graph-merge/clustering.ts
@@ -1,0 +1,439 @@
+/**
+ * Connected-components clustering over the candidate-edge graph (design §6.4
+ * rule 2, T8).
+ *
+ * Two staged nodes are merged into the same cluster iff they are connected
+ * (transitively) by a chain of candidate-merge edges. This is the SINGLE-LINK
+ * rule: A~B and B~C cluster {A,B,C} even when A≁C directly, because each hop
+ * cleared the similarity threshold. The frozen v1 default is single-link with NO
+ * guard; the optional diameter guard (below) is the only deviation.
+ *
+ * Determinism:
+ *   - The component assignment is computed via union-find over the candidate
+ *     edge SET (a pure function of the edges, never their arrival order). We
+ *     additionally order edge consumption by `(a, b)` and union with a
+ *     min-id-as-root tie-break, so even the internal forest is identical across
+ *     shuffled inputs — not merely the resulting partition.
+ *   - Every cluster's `members` array is sorted by node id, and the cluster list
+ *     is sorted by each cluster's minimum member id. So the output is fully
+ *     canonical regardless of the order edges or seed node ids are supplied in.
+ *
+ * Diameter guard (optional, design §6.4 / T8):
+ *   When `clusterMaxDiameter` is set, a formed component must satisfy a single
+ *   bound: the maximum pairwise graph distance (in candidate-edge hops) between
+ *   any two members must not exceed the guard. A component that violates the
+ *   bound is split by the deterministic DROP-WEAKEST single-link rule: remove the
+ *   lowest-scoring candidate edge (ties broken by `(a, b)` id order) and
+ *   recompute components on the survivors, repeating until every sub-component
+ *   satisfies the bound. This is the frozen v1 behavior — no correlation
+ *   clustering in P0.
+ */
+
+import type { CandidateEdge } from "./candidate-gen";
+import { compareMergeKeys, type MergeKey } from "./node-key";
+import { compareCandidateEdges } from "./scoring";
+import { UnionFind } from "./union-find";
+
+/**
+ * The node IDENTITY the cluster graph is built over: the composite `(kind, id)`
+ * {@link MergeKey}, NOT a bare node id. Two different-kind nodes that share an id
+ * string are DISTINCT identities here, so single-link clustering never fuses them
+ * into one component (the base guard would otherwise be silently bypassed).
+ */
+type AnyNodeId = MergeKey;
+
+/**
+ * A resolved cluster of node identities that the merge collapses into one canonical
+ * survivor. `members` is always sorted (by id, then kind) and never empty.
+ */
+export type ClusterResult = Readonly<{
+  members: readonly AnyNodeId[];
+}>;
+
+/**
+ * Builds connected components from a candidate-edge set plus an explicit seed
+ * set of all node ids in scope. Seed ids with no incident edge become singleton
+ * components, so the result partitions the ENTIRE node set, not just edge
+ * endpoints.
+ */
+function buildComponents(
+  edges: readonly CandidateEdge[],
+  nodeIds: readonly AnyNodeId[],
+  edgesSorted = false,
+): ClusterResult[] {
+  const forest = new UnionFind<AnyNodeId>(compareMergeKeys);
+  const seed = new Set<AnyNodeId>(nodeIds);
+  for (const id of nodeIds) {
+    forest.add(id);
+  }
+  // Consume edges in canonical order so the forest is identical across shuffles.
+  // An edge whose endpoint is NOT in the seed set is out of scope and skipped, so
+  // the partition is a function of exactly the supplied node set — a candidate
+  // edge can never inject a phantom member never passed in `nodeIds`.
+  // `edgesSorted` lets a caller that already holds the edges in canonical order
+  // (the drop-weakest loop) skip the redundant re-sort on every iteration.
+  const orderedEdges =
+    edgesSorted ? edges : (
+      [...edges].sort((left, right) => compareCandidateEdges(left, right))
+    );
+  for (const edge of orderedEdges) {
+    if (!seed.has(edge.a) || !seed.has(edge.b)) {
+      continue;
+    }
+    forest.union(edge.a, edge.b);
+  }
+
+  const byRoot = new Map<AnyNodeId, AnyNodeId[]>();
+  for (const id of forest.members()) {
+    const root = forest.find(id);
+    const bucket = byRoot.get(root);
+    if (bucket === undefined) {
+      byRoot.set(root, [id]);
+    } else {
+      bucket.push(id);
+    }
+  }
+
+  const clusters: ClusterResult[] = [];
+  for (const members of byRoot.values()) {
+    clusters.push({
+      members: [...members].sort((left, right) =>
+        compareMergeKeys(left, right),
+      ),
+    });
+  }
+  // Order clusters by their (sorted) first member, which is the minimum id.
+  clusters.sort((left, right) =>
+    compareMergeKeys(left.members[0]!, right.members[0]!),
+  );
+  return clusters;
+}
+
+/**
+ * Builds the undirected adjacency (member id → set of neighbor ids) for one
+ * component's members, restricted to candidate edges whose BOTH endpoints are in
+ * the component.
+ */
+function adjacencyOf(
+  members: readonly AnyNodeId[],
+  edges: readonly CandidateEdge[],
+): Map<AnyNodeId, Set<AnyNodeId>> {
+  const memberSet = new Set(members);
+  const adjacency = new Map<AnyNodeId, Set<AnyNodeId>>();
+  for (const id of members) {
+    adjacency.set(id, new Set());
+  }
+  for (const edge of edges) {
+    if (memberSet.has(edge.a) && memberSet.has(edge.b)) {
+      adjacency.get(edge.a)!.add(edge.b);
+      adjacency.get(edge.b)!.add(edge.a);
+    }
+  }
+  return adjacency;
+}
+
+/**
+ * Whether one component's pairwise graph diameter (in candidate-edge hops) EXCEEDS
+ * `maxDiameter`. Runs a BFS from each member but EARLY-EXITS the moment it reaches
+ * a node beyond `maxDiameter` (or finds the component disconnected), so a check
+ * costs `O(members + edges-within-the-bound)` rather than the full all-pairs
+ * `O(V·(V+E))` exact diameter — the guard only needs the threshold answer, never
+ * the exact value. Equivalent to `componentDiameter(...) > maxDiameter`.
+ */
+function exceedsDiameter(
+  members: readonly AnyNodeId[],
+  edges: readonly CandidateEdge[],
+  maxDiameter: number,
+): boolean {
+  if (members.length <= 1) {
+    return false;
+  }
+  const adjacency = adjacencyOf(members, edges);
+  for (const source of members) {
+    const distance = new Map<AnyNodeId, number>([[source, 0]]);
+    const queue: AnyNodeId[] = [source];
+    let head = 0;
+    while (head < queue.length) {
+      const current = queue[head]!;
+      head += 1;
+      const currentDistance = distance.get(current)!;
+      for (const neighbor of adjacency.get(current)!) {
+        if (!distance.has(neighbor)) {
+          const neighborDistance = currentDistance + 1;
+          if (neighborDistance > maxDiameter) {
+            return true; // a pair already exceeds the bound — stop early
+          }
+          distance.set(neighbor, neighborDistance);
+          queue.push(neighbor);
+        }
+      }
+    }
+    if (distance.size < members.length) {
+      return true; // disconnected from `source` → diameter is infinite
+    }
+  }
+  return false;
+}
+
+/**
+ * The candidate edges internal to a single component (both endpoints inside it),
+ * in canonical `(a, b)` order.
+ */
+function internalEdges(
+  members: readonly AnyNodeId[],
+  edges: readonly CandidateEdge[],
+): CandidateEdge[] {
+  const memberSet = new Set(members);
+  return edges
+    .filter((edge) => memberSet.has(edge.a) && memberSet.has(edge.b))
+    .sort((left, right) => compareCandidateEdges(left, right));
+}
+
+/**
+ * The single weakest edge of a set: lowest score, ties broken by `(a, b)` id
+ * order. The deterministic edge the drop-weakest splits remove first.
+ */
+function weakestEdge(edges: readonly CandidateEdge[]): CandidateEdge {
+  return edges.reduce((current, candidate) => {
+    if (candidate.score !== current.score) {
+      return candidate.score < current.score ? candidate : current;
+    }
+    return compareCandidateEdges(candidate, current) < 0 ? candidate : current;
+  });
+}
+
+/**
+ * The shared DROP-WEAKEST splitter (design §6.4 / §6.4-A). Repeatedly removes the
+ * lowest-scoring internal candidate edge (ties broken by `(a, b)` id order) and
+ * recomputes components until NO sub-component is still `isOffending`, then returns
+ * the satisfying sub-components. `isOffending` receives the current surviving edge
+ * set so a predicate like the diameter check can measure against it.
+ *
+ * The degenerate "still offending but no internal edge left to drop" case — only
+ * reachable if a future caller passes a ≥2-member component with no internal edge —
+ * degrades EVERY such offending component to singletons (keeping every satisfying
+ * sibling intact), so the partition is never silently truncated. It first exhausts the
+ * splittable offending components (those with an edge to drop), so an edgeless
+ * offending sibling can never leave another offending component unsplit.
+ */
+function splitUntil(
+  members: readonly AnyNodeId[],
+  edges: readonly CandidateEdge[],
+  isOffending: (
+    members: readonly AnyNodeId[],
+    surviving: readonly CandidateEdge[],
+  ) => boolean,
+): ClusterResult[] {
+  // `surviving` starts in canonical `(a, b)` order and `.filter` preserves it, so
+  // every iteration can pass it to `buildComponents` pre-sorted.
+  let surviving = internalEdges(members, edges);
+
+  for (;;) {
+    const components = buildComponents(surviving, members, true);
+    const offending = components.filter((component) =>
+      isOffending(component.members, surviving),
+    );
+    if (offending.length === 0) {
+      return components;
+    }
+    // Prefer to keep dropping the weakest edge of an offending component that still has
+    // one; only when EVERY offending component is edgeless do we degrade them all.
+    // Scan lazily — stop at the first offending component that still has an internal
+    // edge instead of materializing internalEdges for every offending component.
+    let splittable: CandidateEdge[] | undefined;
+    for (const component of offending) {
+      const componentEdges = internalEdges(component.members, surviving);
+      if (componentEdges.length > 0) {
+        splittable = componentEdges;
+        break;
+      }
+    }
+    if (splittable === undefined) {
+      const offendingSet = new Set(offending);
+      return components.flatMap((component) =>
+        offendingSet.has(component) ?
+          component.members.map((id) => ({ members: [id] }))
+        : [component],
+      );
+    }
+    const weakest = weakestEdge(splittable);
+    surviving = surviving.filter((edge) => edge !== weakest);
+  }
+}
+
+/**
+ * Splits a single over-diameter component by the deterministic DROP-WEAKEST
+ * single-link rule until every resulting sub-component satisfies `maxDiameter`.
+ */
+function splitByDropWeakest(
+  members: readonly AnyNodeId[],
+  edges: readonly CandidateEdge[],
+  maxDiameter: number,
+): ClusterResult[] {
+  return splitUntil(members, edges, (componentMembers, surviving) =>
+    exceedsDiameter(componentMembers, surviving, maxDiameter),
+  );
+}
+
+/**
+ * Computes the connected components of the candidate-edge graph over `nodeIds`,
+ * applying the optional single-link diameter guard.
+ *
+ * @param candidateEdges Undirected candidate-merge edges (from T6). Order does
+ *   not affect the result.
+ * @param nodeIds Every node id in scope. Ids with no incident candidate edge
+ *   become singleton clusters, so the output partitions the full set.
+ * @returns Clusters with id-sorted members, sorted by minimum member id. Pure
+ *   over the input edge/node SETS.
+ *
+ * The diameter guard is deliberately NOT applied here: {@link enforceBaseGuard}
+ * (§6.4-A) must run on these RAW components FIRST, and only then may a caller run
+ * {@link enforceDiameter}. Folding the diameter split back in would let it sever a
+ * base↔base bridge before base multiplicity is detected.
+ */
+export function connectedComponents(
+  candidateEdges: readonly CandidateEdge[],
+  nodeIds: readonly AnyNodeId[],
+): readonly ClusterResult[] {
+  return buildComponents(candidateEdges, nodeIds);
+}
+
+/**
+ * Applies the single-link DIAMETER guard to already-formed clusters: any cluster
+ * whose pairwise diameter exceeds `clusterMaxDiameter` is split by the deterministic
+ * drop-weakest rule. Separated from {@link connectedComponents} so the base guard
+ * (§6.4-A) can run on the RAW pre-diameter components FIRST — a diameter split must
+ * never sever a base↔base bridge before base-multiplicity is detected.
+ */
+export function enforceDiameter(
+  clusters: readonly ClusterResult[],
+  candidateEdges: readonly CandidateEdge[],
+  clusterMaxDiameter: number,
+): readonly ClusterResult[] {
+  const guarded: ClusterResult[] = [];
+  for (const component of clusters) {
+    if (
+      exceedsDiameter(component.members, candidateEdges, clusterMaxDiameter)
+    ) {
+      guarded.push(
+        ...splitByDropWeakest(
+          component.members,
+          candidateEdges,
+          clusterMaxDiameter,
+        ),
+      );
+    } else {
+      guarded.push(component);
+    }
+  }
+  guarded.sort((left, right) =>
+    compareMergeKeys(left.members[0]!, right.members[0]!),
+  );
+  return guarded;
+}
+
+/** Count of a component's members that are committed BASE nodes. */
+function countBaseMembers(
+  members: readonly AnyNodeId[],
+  baseIds: ReadonlySet<AnyNodeId>,
+): number {
+  let count = 0;
+  for (const id of members) {
+    if (baseIds.has(id)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Splits a component holding ≥2 base members by the deterministic DROP-WEAKEST rule
+ * until NO surviving sub-component holds two base members. This is CONTAINMENT, not
+ * resolution: it removes the lowest-scoring BRIDGING edges (forced new↔base edges,
+ * at max score, are dropped last), so the distinct committed entities land in
+ * separate clusters and BOTH survive — it never "picks" which base wins (§6.4-A).
+ */
+function splitByBaseMultiplicity(
+  members: readonly AnyNodeId[],
+  edges: readonly CandidateEdge[],
+  baseIds: ReadonlySet<AnyNodeId>,
+): ClusterResult[] {
+  return splitUntil(
+    members,
+    edges,
+    (componentMembers) => countBaseMembers(componentMembers, baseIds) >= 2,
+  );
+}
+
+/**
+ * A connected component that spanned ≥2 distinct committed base entities — an
+ * AMBIGUOUS match (§6.4-A). Reported regardless of how the component was split:
+ * any component that EVER bridged two base identities is an ambiguity event.
+ */
+export type BaseMultiplicityEvent = Readonly<{
+  baseIds: readonly AnyNodeId[];
+  memberIds: readonly AnyNodeId[];
+}>;
+
+/**
+ * Component-level BASE GUARD (§6.4-A). Single-link clustering is transitive, so two
+ * committed entities fuse whenever ANY chain links them (`baseA ~ new ~ baseB`, or
+ * through staged hops `baseA ~ new1 ~ new2 ~ baseB` where no single new node spans
+ * both). A node-level guard misses the chain case; this guard is COMPONENT-level.
+ *
+ * MUST run on the RAW connected components, BEFORE any diameter split — otherwise a
+ * diameter guard could sever a base↔base bridge into single-base pieces and the
+ * ambiguity would go unreported (§6.4-A: reported regardless of how it split).
+ *
+ * Any component containing ≥2 distinct base members is an ambiguous match and is
+ * reported as a {@link BaseMultiplicityEvent}. The committed entities are ALWAYS kept
+ * SEPARATE — the base↔base collapse is REFUSED by splitting the component
+ * (drop-weakest, containment only) until no sub-component holds two base members.
+ * Splitting never downgrades the event from ambiguous, and never silently picks which
+ * base wins. (A deliberate-collapse trust path is deferred until committed-entity
+ * re-keying + edge repoint exist; §6.4-C.)
+ *
+ * A no-op fast path when there are no base members (the public snapshot path).
+ *
+ * @returns the guarded clusters (id-sorted members, sorted by min member id) and
+ *   one event per component that spanned ≥2 base entities.
+ */
+export function enforceBaseGuard(
+  clusters: readonly ClusterResult[],
+  candidateEdges: readonly CandidateEdge[],
+  baseIds: ReadonlySet<AnyNodeId>,
+): Readonly<{
+  clusters: readonly ClusterResult[];
+  events: readonly BaseMultiplicityEvent[];
+}> {
+  if (baseIds.size === 0) {
+    return { clusters, events: [] };
+  }
+
+  const result: ClusterResult[] = [];
+  const events: BaseMultiplicityEvent[] = [];
+  for (const cluster of clusters) {
+    const clusterBaseIds = cluster.members.filter((id) => baseIds.has(id));
+    if (clusterBaseIds.length < 2) {
+      result.push(cluster);
+      continue;
+    }
+    events.push({
+      baseIds: [...clusterBaseIds].sort((left, right) =>
+        compareMergeKeys(left, right),
+      ),
+      memberIds: [...cluster.members].sort((left, right) =>
+        compareMergeKeys(left, right),
+      ),
+    });
+    // Always REFUSE the base↔base collapse: split for containment so both committed
+    // entities survive separately (§6.4-A). A deliberate collapse is deferred (§6.4-C).
+    result.push(
+      ...splitByBaseMultiplicity(cluster.members, candidateEdges, baseIds),
+    );
+  }
+  result.sort((left, right) =>
+    compareMergeKeys(left.members[0]!, right.members[0]!),
+  );
+  return { clusters: result, events };
+}

--- a/packages/typegraph/src/graph-merge/conflict-policy.ts
+++ b/packages/typegraph/src/graph-merge/conflict-policy.ts
@@ -1,0 +1,347 @@
+/**
+ * The centralized property-conflict resolution rule (design §6.4 rule 4 / §7.3,
+ * T8). Shared by canonical node-property union (T8 / `canonicalize.ts`) and edge
+ * property-collision resolution (T9), so the determinism contract lives in
+ * exactly one place.
+ *
+ * DETERMINISM CONTRACT — the single most important invariant of the merge:
+ *   Conflict resolution NEVER consults wall-clock arrival time. When a value
+ *   must be chosen among differing per-branch candidates, the choice is made on
+ *   a STABLE branch total order — either the caller-supplied
+ *   `MergeOptions.branchOrder`, or branch ids sorted lexicographically — captured
+ *   ONCE before any resolution runs. Two merges of the same branch set in any
+ *   order therefore resolve every conflict identically.
+ */
+
+import { canonicalValueKey } from "./canonical-props";
+import { compareStrings } from "./node-key";
+import type {
+  EdgeId,
+  GraphDef,
+  JsonValue,
+  NodeId,
+  NodeType,
+} from "./typegraph-internal";
+import type {
+  BranchId,
+  ConflictingValue,
+  PropertyConflict,
+  PropertyConflictPolicy,
+} from "./types";
+
+/**
+ * The candidate values for one conflicted property, each tagged with the branch
+ * that contributed it. Built by the union phases (node/edge) before delegating
+ * to {@link resolveConflictValue}.
+ */
+type ConflictInput = Readonly<{
+  /** The property name in conflict. */
+  property: string;
+  /** Every distinct contributing `(branchId, value)`, one per source. */
+  values: readonly ConflictingValue[];
+  /** The canonical survivor's own value — kept under the `"flag"` policy. */
+  canonicalValue: JsonValue;
+}>;
+
+/**
+ * Per-branch trust weights for the `"provenanceWeighted"` policy. Branches absent
+ * from the map default to weight `0`. Ties are broken by the stable branch order.
+ */
+export type ProvenanceWeights = ReadonlyMap<BranchId, number>;
+
+/**
+ * The captured, immutable resolution context. The stable branch order is passed
+ * separately as a precomputed `branchRank` (built once via {@link buildBranchRank}
+ * and shared across every conflict), so this context carries only the policy and
+ * the optional `"provenanceWeighted"` weights.
+ *
+ * BRANCH ORDER IS A PRIORITY ORDER: the branch appearing EARLIER in
+ * `MergeOptions.branchOrder` (lower rank) has higher precedence. `"lastWriteWins"`
+ * therefore picks the value of the HIGHEST-PRIORITY branch (lowest rank / first
+ * in the order) — the "winning write" is defined by the stable order, NOT by
+ * wall-clock arrival. There is no wall-clock anywhere in this module.
+ */
+export type ResolutionContext<G extends GraphDef = GraphDef> = Readonly<{
+  policy: PropertyConflictPolicy<G>;
+  weights?: ProvenanceWeights;
+}>;
+
+/**
+ * The outcome of resolving one property conflict: the surviving value and
+ * whether the values actually differed (so callers know whether to record a
+ * {@link PropertyConflict}).
+ */
+type ConflictResolution = Readonly<{
+  value: JsonValue;
+  conflicted: boolean;
+}>;
+
+/**
+ * Builds the rank lookup for a stable branch order. Branch ids not present in
+ * the supplied order are appended in lexicographic order after the explicit
+ * ones, so an incomplete `branchOrder` is still total and deterministic.
+ */
+export function buildBranchRank(
+  branchOrder: readonly BranchId[],
+  allBranchIds: readonly BranchId[],
+): ReadonlyMap<BranchId, number> {
+  const rank = new Map<BranchId, number>();
+  let next = 0;
+  for (const branchId of branchOrder) {
+    if (!rank.has(branchId)) {
+      rank.set(branchId, next);
+      next += 1;
+    }
+  }
+  const remaining = allBranchIds
+    .filter((branchId) => !rank.has(branchId))
+    .sort((left, right) => compareStrings(left, right));
+  for (const branchId of remaining) {
+    if (!rank.has(branchId)) {
+      rank.set(branchId, next);
+      next += 1;
+    }
+  }
+  return rank;
+}
+
+/**
+ * Returns the value contributed by the HIGHEST-PRIORITY branch — the one with
+ * the lowest rank (earliest in the stable branch order). Ties (two contributions
+ * sharing a rank, e.g. when the same branch staged two values) are broken by the
+ * canonical serialization of the value, so the choice is fully deterministic.
+ */
+function pickByPriority(
+  values: readonly ConflictingValue[],
+  branchRank: ReadonlyMap<BranchId, number>,
+): JsonValue {
+  let chosen = values[0]!;
+  let chosenRank = branchRank.get(chosen.branchId) ?? Number.MAX_SAFE_INTEGER;
+  for (const candidate of values.slice(1)) {
+    const candidateRank =
+      branchRank.get(candidate.branchId) ?? Number.MAX_SAFE_INTEGER;
+    if (candidateRank < chosenRank) {
+      chosen = candidate;
+      chosenRank = candidateRank;
+    } else if (
+      candidateRank === chosenRank &&
+      canonicalValueKey(candidate.value) < canonicalValueKey(chosen.value)
+    ) {
+      chosen = candidate;
+    }
+  }
+  return chosen.value;
+}
+
+/**
+ * Picks the value contributed by the highest-weight branch under
+ * `"provenanceWeighted"`. Ties on weight fall back to the stable branch order
+ * (highest-priority / lowest rank wins), then to canonical value order — never
+ * wall-clock.
+ */
+function pickByWeight(
+  values: readonly ConflictingValue[],
+  weights: ProvenanceWeights,
+  branchRank: ReadonlyMap<BranchId, number>,
+): JsonValue {
+  let chosen = values[0]!;
+  let chosenWeight = weights.get(chosen.branchId) ?? 0;
+  let chosenRank = branchRank.get(chosen.branchId) ?? Number.MAX_SAFE_INTEGER;
+  for (const candidate of values.slice(1)) {
+    const candidateWeight = weights.get(candidate.branchId) ?? 0;
+    const candidateRank =
+      branchRank.get(candidate.branchId) ?? Number.MAX_SAFE_INTEGER;
+    if (candidateWeight > chosenWeight) {
+      chosen = candidate;
+      chosenWeight = candidateWeight;
+      chosenRank = candidateRank;
+      continue;
+    }
+    if (candidateWeight === chosenWeight) {
+      if (candidateRank < chosenRank) {
+        chosen = candidate;
+        chosenRank = candidateRank;
+      } else if (
+        candidateRank === chosenRank &&
+        canonicalValueKey(candidate.value) < canonicalValueKey(chosen.value)
+      ) {
+        chosen = candidate;
+      }
+    }
+  }
+  return chosen.value;
+}
+
+/**
+ * Returns whether every contributing value is deeply equal (so there is no real
+ * conflict). Compares the {@link canonicalValueKey} (recursively key-sorted) form
+ * so two branches that wrote a logically-equal object with different key order do
+ * NOT register as a conflict.
+ */
+function allValuesEqual(values: readonly ConflictingValue[]): boolean {
+  if (values.length <= 1) {
+    return true;
+  }
+  const first = canonicalValueKey(values[0]!.value);
+  return values.every(
+    (candidate) => canonicalValueKey(candidate.value) === first,
+  );
+}
+
+/**
+ * A single `(branchId, props)` contribution to a property union — a cluster
+ * member (node) or a collision-group member (edge's staged record). The union
+ * phases differ in their surrounding base/survivor logic but agree on HOW to
+ * gather a property's candidate values, so they share {@link collectConflictingValues}.
+ */
+type Contribution = Readonly<{
+  branchId: BranchId;
+  props: Readonly<Record<string, JsonValue>>;
+}>;
+
+/**
+ * Collects the distinct `(branchId, value)` contributions for one property across
+ * a set of contributions, in stable `(branchId, canonical-value)` order. Distinct
+ * on `(branchId, value)`: two contributions from the same branch carrying the same
+ * value collapse to one entry, but the same branch contributing two different
+ * values is preserved (so an intra-branch contradiction stays visible).
+ *
+ * Shared by the node property union (T8) and the edge property union (T9) so the
+ * determinism-critical dedupe + sort is defined exactly once and node/edge conflict
+ * records are shaped identically.
+ */
+export function collectConflictingValues(
+  property: string,
+  contributions: readonly Contribution[],
+): readonly ConflictingValue[] {
+  const seen = new Set<string>();
+  const values: ConflictingValue[] = [];
+  for (const { branchId, props } of contributions) {
+    if (!(property in props)) {
+      continue;
+    }
+    const value = props[property] as JsonValue;
+    const dedupeKey = `${branchId}\0${canonicalValueKey(value)}`;
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+    seen.add(dedupeKey);
+    values.push({ branchId, value });
+  }
+  return [...values].sort((left, right) => {
+    const byBranch = compareStrings(left.branchId, right.branchId);
+    return byBranch === 0 ?
+        compareStrings(
+          canonicalValueKey(left.value),
+          canonicalValueKey(right.value),
+        )
+      : byBranch;
+  });
+}
+
+/**
+ * Resolves one property conflict under the captured {@link ResolutionContext}.
+ *
+ * - If all contributing values are equal → that value, `conflicted: false`.
+ * - `"flag"` → keep the canonical's value, `conflicted: true` (caller records a
+ *   {@link PropertyConflict}; no auto-resolution).
+ * - `"lastWriteWins"` → the value of the HIGHEST-PRIORITY branch (earliest in the
+ *   stable order / lowest rank). NEVER wall-clock.
+ * - `"provenanceWeighted"` → the value of the highest-weight branch (ties →
+ *   highest-priority branch → canonical value order).
+ * - function policy → the value returned by the delegate.
+ *
+ * @param input The conflicted property, its tagged candidate values, and the
+ *   canonical survivor's own value.
+ * @param context The captured policy + stable branch order + optional weights.
+ * @param makeConflict Builds the {@link PropertyConflict}-shaped record passed to
+ *   a function policy. Kept as a callback so this module needs no knowledge of
+ *   the node-vs-edge entity shape.
+ * @returns The surviving value and whether the values genuinely differed.
+ */
+function resolveConflictValue<G extends GraphDef = GraphDef>(
+  input: ConflictInput,
+  context: ResolutionContext<G>,
+  branchRank: ReadonlyMap<BranchId, number>,
+  makeConflict: (
+    resolution: JsonValue,
+  ) => Parameters<
+    Extract<PropertyConflictPolicy<G>, (...args: never[]) => unknown>
+  >[0],
+): ConflictResolution {
+  if (allValuesEqual(input.values)) {
+    return {
+      value: input.values[0]?.value ?? input.canonicalValue,
+      conflicted: false,
+    };
+  }
+
+  const { policy } = context;
+
+  if (policy === "flag") {
+    return { value: input.canonicalValue, conflicted: true };
+  }
+  if (policy === "lastWriteWins") {
+    return {
+      value: pickByPriority(input.values, branchRank),
+      conflicted: true,
+    };
+  }
+  if (policy === "provenanceWeighted") {
+    const weights = context.weights ?? new Map<BranchId, number>();
+    return {
+      value: pickByWeight(input.values, weights, branchRank),
+      conflicted: true,
+    };
+  }
+  // Function policy: delegate, but first resolve a stable provisional value so
+  // the conflict record handed to the delegate is itself deterministic.
+  const provisional = pickByPriority(input.values, branchRank);
+  const resolved = policy(makeConflict(provisional));
+  return { value: resolved, conflicted: true };
+}
+
+/**
+ * The resolve-and-record tail every property union shares (node cluster union T8,
+ * edge collision union T9, inherited 3-way merge T8a): resolve the conflict, then —
+ * if the values genuinely differed — build the public {@link PropertyConflict}. The
+ * SINGLE place the conflict record is shaped, so the value the function policy sees
+ * and the value recorded can never drift.
+ *
+ * `values` is the FULL contributing set the policy resolves over; `reportedValues`
+ * is the PUBLIC subset (synthetic sentinels excluded) recorded on the conflict.
+ */
+export function resolvePropertyUnion<G extends GraphDef = GraphDef>(
+  input: Readonly<{
+    entityId: NodeId<NodeType> | EdgeId;
+    kind: string;
+    property: string;
+    values: readonly ConflictingValue[];
+    reportedValues: readonly ConflictingValue[];
+    canonicalValue: JsonValue;
+  }>,
+  context: ResolutionContext<G>,
+  branchRank: ReadonlyMap<BranchId, number>,
+): Readonly<{ value: JsonValue; conflict: PropertyConflict<G> | undefined }> {
+  const makeRecord = (resolution: JsonValue): PropertyConflict<G> => ({
+    entityId: input.entityId,
+    kind: input.kind,
+    property: input.property,
+    values: input.reportedValues,
+    resolution,
+  });
+  const resolved = resolveConflictValue(
+    {
+      property: input.property,
+      values: input.values,
+      canonicalValue: input.canonicalValue,
+    },
+    context,
+    branchRank,
+    (resolution) => makeRecord(resolution),
+  );
+  return {
+    value: resolved.value,
+    conflict: resolved.conflicted ? makeRecord(resolved.value) : undefined,
+  };
+}

--- a/packages/typegraph/src/graph-merge/delete-modify.ts
+++ b/packages/typegraph/src/graph-merge/delete-modify.ts
@@ -1,0 +1,673 @@
+/**
+ * Node-level delete/modify conflict resolution (design §6.2, T8a).
+ *
+ * The §6.2 case the draft omitted: an INHERITED node that one fork DELETES while
+ * another fork MODIFIES is neither a pure deletion nor a pure modification — it
+ * is a delete/modify conflict whose outcome is governed by the
+ * {@link DeleteModifyPolicy} (`"deleteWins"` | `"modifyWins"` | `"flag"`) and
+ * surfaced in the {@link MergeReport}.
+ *
+ * This module is a PURE decision function over the staging set (T7) plus the
+ * captured stable branch order (T8). It runs BEFORE clustering/canonicalize feed
+ * the surviving modifications into the property union, and BEFORE edge repoint
+ * (T9), to which it hands the authoritative FINAL LIVENESS of every inherited
+ * endpoint:
+ *
+ *   - a node finally deleted (`"deleteWins"`) → it is in {@link nodeDeletions};
+ *     T9 drops every edge touching it.
+ *   - a node kept/resurrected (`"modifyWins"` / `"flag"`, or never deleted) →
+ *     its modifications are in {@link survivingModifications}; T9 keeps its edges.
+ *
+ * DETERMINISM CONTRACT (inherited from the merge-wide invariant):
+ *   The keep-vs-delete decision is a function ONLY of the policy and the
+ *   (unordered) set of contributing branches — it NEVER consults wall-clock
+ *   arrival. The captured `branchRank` is used solely to TIE-BREAK which
+ *   modification survives under `"modifyWins"` / `"flag"` (and which branch ids
+ *   are recorded as `deletedBy` / `modifiedBy`), so two merges of the same branch
+ *   set in any order resolve every delete/modify conflict identically.
+ */
+
+import { canonicalValueKey } from "./canonical-props";
+import type { ProvenanceWeights, ResolutionContext } from "./conflict-policy";
+import {
+  collectConflictingValues,
+  resolvePropertyUnion,
+} from "./conflict-policy";
+import { compareStrings, type MergeKey, mergeKey } from "./node-key";
+import type {
+  StagedModifiedEdge,
+  StagedModifiedNode,
+  StagingSet,
+} from "./staging";
+import type { DeletedEdge, DeletedNode } from "./state-diff";
+import type {
+  EdgeId,
+  GraphDef,
+  JsonValue,
+  NodeId,
+  NodeType,
+} from "./typegraph-internal";
+import type {
+  BranchId,
+  DeleteModifyConflict,
+  DeleteModifyPolicy,
+  DroppedItem,
+  PropertyConflict,
+  PropertyConflictPolicy,
+} from "./types";
+
+/** A node id in its untyped (`NodeType`-default) branded form. */
+type AnyNodeId = NodeId<NodeType>;
+type BranchTagged = Readonly<{ branchId: BranchId }>;
+
+/** Reason recorded on a {@link DroppedItem} for a finally-deleted node. */
+export const DELETED_NODE_DROP_REASON = "delete-modify:deleteWins" as const;
+
+/**
+ * The outcome of delete/modify resolution over the whole staging set.
+ *
+ * - `survivingModifications`: every staged inherited-node modification that the
+ *   merge will still apply — i.e. all modifications NOT overridden by a
+ *   `"deleteWins"` resolution. A node modified by several branches contributes
+ *   several entries here (one per branch), so T8's property union still sees the
+ *   full cross-branch disagreement.
+ * - `nodeDeletions`: the AUTHORITATIVE set of inherited nodes that are finally
+ *   deleted — pure deletions (no branch modified them) plus delete/modify
+ *   conflicts resolved `"deleteWins"`. T9 reads this as the endpoint liveness.
+ * - `conflicts`: one {@link DeleteModifyConflict} per inherited node that was
+ *   both deleted and modified.
+ * - `dropped`: a `{ kind: "node" }` {@link DroppedItem} for every finally-deleted
+ *   node, so the report can enumerate exactly what left the merged graph.
+ */
+export type DeleteModifyResolution = Readonly<{
+  survivingModifications: readonly StagedModifiedNode[];
+  nodeDeletions: readonly DeletedNode[];
+  conflicts: readonly DeleteModifyConflict[];
+  dropped: readonly DroppedItem[];
+}>;
+
+/**
+ * Picks the HIGHEST-PRIORITY branch from a set — the one with the lowest
+ * `branchRank` (earliest in the captured stable order). Ties on rank fall back to
+ * lexicographic branch-id order, so the choice is total and deterministic. Used
+ * to record `deletedBy` / `modifiedBy` and to select which modification survives.
+ */
+function pickHighestPriorityBranch(
+  branchIds: readonly BranchId[],
+  branchRank: ReadonlyMap<BranchId, number>,
+): BranchId {
+  let chosen = branchIds[0]!;
+  let chosenRank = branchRank.get(chosen) ?? Number.MAX_SAFE_INTEGER;
+  for (const candidate of branchIds.slice(1)) {
+    const candidateRank = branchRank.get(candidate) ?? Number.MAX_SAFE_INTEGER;
+    if (
+      candidateRank < chosenRank ||
+      (candidateRank === chosenRank && compareStrings(candidate, chosen) < 0)
+    ) {
+      chosen = candidate;
+      chosenRank = candidateRank;
+    }
+  }
+  return chosen;
+}
+
+function effectiveDeleteModifyPolicy(
+  policy: DeleteModifyPolicy,
+  deletions: readonly BranchTagged[],
+  modifications: readonly BranchTagged[],
+  preferredBranchId: BranchId | undefined,
+): DeleteModifyPolicy {
+  if (
+    preferredBranchId !== undefined &&
+    deletions.some((deletion) => deletion.branchId === preferredBranchId)
+  ) {
+    return "deleteWins";
+  }
+  if (
+    policy === "deleteWins" &&
+    preferredBranchId !== undefined &&
+    modifications.some(
+      (modification) => modification.branchId === preferredBranchId,
+    )
+  ) {
+    return "modifyWins";
+  }
+  return policy;
+}
+
+/**
+ * Groups staged items by the `(kind, id)` IDENTITY of the entity `entityOf` extracts
+ * (a node or an edge), preserving the per-identity arrays so callers can inspect every
+ * contributing branch. Keying on the composite identity (not bare id) keeps an
+ * inherited `Patient` and an inherited `Encounter` that share an id string from being
+ * reconciled/deleted as if they were one entity.
+ */
+function groupByEntity<T>(
+  items: readonly T[],
+  entityOf: (item: T) => Readonly<{ id: string; kind: string }>,
+): ReadonlyMap<MergeKey, readonly T[]> {
+  const grouped = new Map<MergeKey, T[]>();
+  for (const item of items) {
+    const entity = entityOf(item);
+    const key = mergeKey(entity.kind, entity.id);
+    const bucket = grouped.get(key);
+    if (bucket === undefined) {
+      grouped.set(key, [item]);
+    } else {
+      bucket.push(item);
+    }
+  }
+  return grouped;
+}
+
+/**
+ * The shared node/edge DELETE-MODIFY resolver — the single control flow behind
+ * {@link resolveDeleteModify} (nodes) and {@link resolveEdgeDeleteModify} (edges).
+ * `modifiedEntity`/`deletedEntity` extract each staged item's `(id, kind)` (its
+ * `.node` or `.edge`), and `droppedKind` tags the {@link DroppedItem}; everything
+ * else — conflict detection, policy application, pure-deletion/pure-modification
+ * passthrough, and the canonical output sort — is identical for both.
+ */
+function resolveDeleteModifyOver<
+  ModifiedItem extends BranchTagged,
+  DeletedItem extends BranchTagged,
+  Id extends AnyNodeId | EdgeId,
+>(
+  modified: readonly ModifiedItem[],
+  deleted: readonly DeletedItem[],
+  modifiedEntity: (item: ModifiedItem) => Readonly<{ id: Id; kind: string }>,
+  deletedEntity: (item: DeletedItem) => Readonly<{ id: Id; kind: string }>,
+  droppedKind: "node" | "edge",
+  policy: DeleteModifyPolicy,
+  branchRank: ReadonlyMap<BranchId, number>,
+  preferredBranchId: BranchId | undefined,
+): Readonly<{
+  survivingModifications: readonly ModifiedItem[];
+  deletions: readonly Readonly<{ id: Id; kind: string }>[];
+  conflicts: readonly DeleteModifyConflict[];
+  dropped: readonly DroppedItem[];
+}> {
+  const modifiedByKey = groupByEntity(modified, modifiedEntity);
+  const deletedByKey = groupByEntity(deleted, deletedEntity);
+
+  const survivingModifications: ModifiedItem[] = [];
+  const deletions: Readonly<{ id: Id; kind: string }>[] = [];
+  const conflicts: DeleteModifyConflict[] = [];
+  const dropped: DroppedItem[] = [];
+
+  const conflictedKeys = new Set<MergeKey>();
+  for (const key of deletedByKey.keys()) {
+    if (modifiedByKey.has(key)) {
+      conflictedKeys.add(key);
+    }
+  }
+
+  for (const [key, modifications] of modifiedByKey) {
+    if (!conflictedKeys.has(key)) {
+      for (const modification of modifications) {
+        survivingModifications.push(modification);
+      }
+      continue;
+    }
+
+    const deletionsForKey = deletedByKey.get(key)!;
+    const { id, kind } = modifiedEntity(modifications[0]!);
+    const deletedBy = pickHighestPriorityBranch(
+      deletionsForKey.map((deletion) => deletion.branchId),
+      branchRank,
+    );
+    const modifiedBy = pickHighestPriorityBranch(
+      modifications.map((modification) => modification.branchId),
+      branchRank,
+    );
+    const effectivePolicy = effectiveDeleteModifyPolicy(
+      policy,
+      deletionsForKey,
+      modifications,
+      preferredBranchId,
+    );
+
+    conflicts.push({
+      entityId: id,
+      kind,
+      deletedBy,
+      modifiedBy,
+      resolution: effectivePolicy,
+    });
+
+    if (effectivePolicy === "deleteWins") {
+      deletions.push({ id, kind });
+      dropped.push({ kind: droppedKind, id, reason: DELETED_NODE_DROP_REASON });
+      continue;
+    }
+
+    // "modifyWins" and "flag" both KEEP the modification (resurrect the entity);
+    // "flag" additionally leaves the recorded conflict unresolved for review.
+    for (const modification of modifications) {
+      survivingModifications.push(modification);
+    }
+  }
+
+  for (const [key, deletionsForKey] of deletedByKey) {
+    if (conflictedKeys.has(key)) {
+      continue;
+    }
+    const { id, kind } = deletedEntity(deletionsForKey[0]!);
+    deletions.push({ id, kind });
+  }
+
+  return {
+    survivingModifications: [...survivingModifications].sort((left, right) => {
+      const byId = compareStrings(
+        modifiedEntity(left).id,
+        modifiedEntity(right).id,
+      );
+      return byId === 0 ? compareStrings(left.branchId, right.branchId) : byId;
+    }),
+    deletions: [...deletions].sort((left, right) =>
+      compareStrings(left.id, right.id),
+    ),
+    conflicts: [...conflicts].sort((left, right) =>
+      compareStrings(left.entityId, right.entityId),
+    ),
+    dropped: [...dropped].sort((left, right) =>
+      compareStrings(left.id, right.id),
+    ),
+  };
+}
+
+/**
+ * The shared node/edge MODIFICATION reconciler — the single control flow behind
+ * {@link reconcileModifications} (nodes) and {@link reconcileEdgeModifications}
+ * (edges). Groups by `(kind, id)`, 3-way merges every multi-branch modification via
+ * {@link threeWayMergeProps}, and rebuilds ONE surviving record per id via `rebuild`
+ * (carrying the highest-priority contributor's branch + the merged props).
+ */
+function reconcileOver<Item extends BranchTagged>(
+  survivingModifications: readonly Item[],
+  entityOf: (item: Item) => Readonly<{
+    id: AnyNodeId | EdgeId;
+    kind: string;
+    baseProps: Readonly<Record<string, unknown>>;
+    forkProps: Readonly<Record<string, unknown>>;
+  }>,
+  rebuild: (
+    representative: Item,
+    chosenBranch: BranchId,
+    mergedProps: Record<string, JsonValue>,
+  ) => Item,
+  policy: PropertyConflictPolicy,
+  branchRank: ReadonlyMap<BranchId, number>,
+  weights: ProvenanceWeights | undefined,
+  preferredBranchId: BranchId | undefined,
+): Readonly<{
+  survivingModifications: readonly Item[];
+  conflicts: readonly PropertyConflict[];
+}> {
+  const context: ResolutionContext<GraphDef> = {
+    policy,
+    ...(weights === undefined ? {} : { weights }),
+  };
+
+  const grouped = groupByEntity(survivingModifications, entityOf);
+  const out: Item[] = [];
+  const conflicts: PropertyConflict[] = [];
+
+  for (const modifications of grouped.values()) {
+    if (modifications.length === 1) {
+      out.push(modifications[0]!);
+      continue;
+    }
+    const first = entityOf(modifications[0]!);
+    const { props, conflicts: propertyConflicts } = threeWayMergeProps(
+      first.id,
+      first.kind,
+      first.baseProps as Readonly<Record<string, JsonValue>>,
+      modifications.map((modification) => ({
+        branchId: modification.branchId,
+        forkProps: entityOf(modification).forkProps as Readonly<
+          Record<string, JsonValue>
+        >,
+      })),
+      context,
+      branchRank,
+      preferredBranchId,
+    );
+    const chosenBranch = pickHighestPriorityBranch(
+      modifications.map((modification) => modification.branchId),
+      branchRank,
+    );
+    const representative =
+      modifications.find(
+        (modification) => modification.branchId === chosenBranch,
+      ) ?? modifications[0]!;
+    out.push(rebuild(representative, chosenBranch, props));
+    for (const conflict of propertyConflicts) {
+      conflicts.push(conflict);
+    }
+  }
+
+  return {
+    survivingModifications: [...out].sort((left, right) => {
+      const byId = compareStrings(entityOf(left).id, entityOf(right).id);
+      return byId === 0 ? compareStrings(left.branchId, right.branchId) : byId;
+    }),
+    conflicts: conflicts.sort((left, right) =>
+      compareStrings(
+        `${left.entityId}|${left.property}`,
+        `${right.entityId}|${right.property}`,
+      ),
+    ),
+  };
+}
+
+/**
+ * Resolves every inherited node that is simultaneously DELETED by one or more
+ * branches and MODIFIED by one or more (other) branches, per the
+ * {@link DeleteModifyPolicy}:
+ *
+ *   - `"deleteWins"` → the node is finally deleted (its modifications are
+ *     discarded). A {@link DeleteModifyConflict} with `resolution: "deleteWins"`
+ *     is recorded and a `{ kind: "node" }` {@link DroppedItem} is emitted.
+ *   - `"modifyWins"` → the node is RESURRECTED: its modifications survive (the
+ *     deletion is ignored). A conflict with `resolution: "modifyWins"` is
+ *     recorded; the node is NOT deleted.
+ *   - `"flag"` → the modifications survive (as with `"modifyWins"`) but the
+ *     conflict is recorded UNRESOLVED (`resolution: "flag"`) for human review.
+ *
+ * Pure deletions (no branch modified the node) pass straight through to
+ * {@link nodeDeletions}; pure modifications (no branch deleted the node) pass
+ * straight through to {@link survivingModifications}. Both unconflicted paths
+ * carry NO {@link DeleteModifyConflict}.
+ *
+ * The result is order-independent: the keep-vs-delete decision depends only on
+ * the policy and the contributing branch SET; `branchRank` is consulted solely to
+ * tie-break which modification survives and which branch ids are recorded.
+ *
+ * @param staging The provenance-tagged union staging set (T7).
+ * @param policy The delete/modify-conflict policy.
+ * @param branchRank The captured stable branch rank (built once via
+ *   `buildBranchRank`, shared across phases). Used ONLY for deterministic
+ *   tie-breaking — never for the keep-vs-delete decision itself.
+ */
+export function resolveDeleteModify(
+  staging: StagingSet,
+  policy: DeleteModifyPolicy,
+  branchRank: ReadonlyMap<BranchId, number>,
+  preferredBranchId?: BranchId,
+): DeleteModifyResolution {
+  const resolved = resolveDeleteModifyOver(
+    staging.modifiedNodes,
+    staging.deletedNodes,
+    (item) => item.node,
+    (item) => item.node,
+    "node",
+    policy,
+    branchRank,
+    preferredBranchId,
+  );
+  return {
+    survivingModifications: resolved.survivingModifications,
+    nodeDeletions: resolved.deletions,
+    conflicts: resolved.conflicts,
+    dropped: resolved.dropped,
+  };
+}
+
+/**
+ * The outcome of reconciling the surviving inherited modifications: ONE merged
+ * record per node id (carrying the 3-way-merged props the commit applies) plus
+ * every {@link PropertyConflict} that a multi-branch modification surfaced.
+ */
+export type ModificationReconciliation = Readonly<{
+  survivingModifications: readonly StagedModifiedNode[];
+  conflicts: readonly PropertyConflict[];
+}>;
+
+/** A single branch's full fork props for an inherited entity (node or edge). */
+type ForkContribution = Readonly<{
+  branchId: BranchId;
+  forkProps: Readonly<Record<string, JsonValue>>;
+}>;
+
+/**
+ * 3-WAY merges one inherited entity (node OR edge) modified by 2+ branches against
+ * the SHARED base.
+ *
+ * Per property: a branch whose fork value equals base contributed no change; a
+ * property exactly one branch changed takes that change; a property multiple
+ * branches changed to DIFFERING values is a genuine conflict, resolved by the
+ * captured policy on the stable `branchRank` and recorded as a
+ * {@link PropertyConflict}. Property DELETIONS (a base key absent from a fork) are
+ * treated conservatively as "unchanged" so an unrelated branch's edit is never
+ * lost. `baseProps` is identical across the contributions (same base, same id).
+ *
+ * Shared by node modification reconciliation ({@link reconcileModifications}) and
+ * edge modification reconciliation ({@link reconcileEdgeModifications}), so both
+ * apply identical base-aware semantics — without this, disjoint edits to the same
+ * entity by different branches would false-conflict and one edit could be lost.
+ */
+function threeWayMergeProps(
+  entityId: AnyNodeId | EdgeId,
+  kind: string,
+  baseProps: Readonly<Record<string, JsonValue>>,
+  contributions: readonly ForkContribution[],
+  context: ResolutionContext<GraphDef>,
+  branchRank: ReadonlyMap<BranchId, number>,
+  preferredBranchId?: BranchId,
+): Readonly<{
+  props: Record<string, JsonValue>;
+  conflicts: PropertyConflict[];
+}> {
+  const merged: Record<string, JsonValue> = {};
+  const conflicts: PropertyConflict[] = [];
+
+  // Every property the base OR any fork carries. Base keys are included so a key
+  // that EVERY fork dropped is still seen here (a fork's `forkProps` is its full
+  // bag, so a missing base key is an intentional deletion, not an omission).
+  const propertyNames = new Set<string>(Object.keys(baseProps));
+  for (const contribution of contributions) {
+    for (const name of Object.keys(contribution.forkProps)) {
+      propertyNames.add(name);
+    }
+  }
+
+  for (const property of [...propertyNames].sort(compareStrings)) {
+    const baseHas = property in baseProps;
+    const baseKey =
+      baseHas ? canonicalValueKey(baseProps[property]!) : undefined;
+
+    // Contributions from branches that actually CHANGED this property (present and
+    // differing from base). Reuse the shared collector so the distinct-(branch,value)
+    // dedupe + ordering match the node/edge property unions exactly — one definition
+    // of conflict gathering, with the canonical NUL-separated dedupe key.
+    const changed = contributions
+      .filter((contribution) => {
+        if (!(property in contribution.forkProps)) {
+          return false; // absent — a deletion (handled below), never a change
+        }
+        const value = contribution.forkProps[property] as JsonValue;
+        return !baseHas || canonicalValueKey(value) !== baseKey;
+      })
+      .map((contribution) => ({
+        branchId: contribution.branchId,
+        props: contribution.forkProps,
+      }));
+    const values = collectConflictingValues(property, changed);
+
+    if (values.length === 0) {
+      // No fork CHANGED the value. A fork's `forkProps` is its FULL bag, so a base
+      // property a fork OMITS was DELETED by it; honor that deletion by leaving the
+      // key out of `merged`. Otherwise every fork kept the base value, so it stands.
+      const deletedByFork =
+        baseHas &&
+        contributions.some(
+          (contribution) => !(property in contribution.forkProps),
+        );
+      if (baseHas && !deletedByFork) {
+        merged[property] = baseProps[property]!;
+      }
+      continue;
+    }
+
+    const distinctValues = new Set(
+      values.map((candidate) => canonicalValueKey(candidate.value)),
+    );
+    if (distinctValues.size === 1) {
+      merged[property] = values[0]!.value; // a single, agreed-upon change
+      continue;
+    }
+
+    const preferredValue = values.find(
+      (value) => value.branchId === preferredBranchId,
+    )?.value;
+    const canonicalValue =
+      preferredValue ?? (baseHas ? baseProps[property]! : values[0]!.value);
+    const reportedValues =
+      preferredBranchId === undefined ? values : (
+        values.filter((value) => value.branchId !== preferredBranchId)
+      );
+    const { value, conflict } = resolvePropertyUnion(
+      { entityId, kind, property, values, reportedValues, canonicalValue },
+      context,
+      branchRank,
+    );
+    merged[property] = value;
+    if (conflict !== undefined) {
+      conflicts.push(conflict);
+    }
+  }
+
+  return { props: merged, conflicts };
+}
+
+/**
+ * Reconciles the post-delete/modify surviving modifications into the records the
+ * commit applies. An inherited node modified by a SINGLE branch passes through
+ * unchanged; a node modified by TWO OR MORE branches is 3-way merged against the
+ * base ({@link mergeModifiedProps}) into one record carrying the merged props,
+ * surfacing any genuine cross-branch disagreement as a {@link PropertyConflict}.
+ *
+ * Without this, each per-branch modification was committed by id in turn, so the
+ * lexicographically-largest branchId silently overwrote the others with NO
+ * conflict recorded and the configured `onPropertyConflict` / `branchOrder`
+ * bypassed (the §6.2 gap). The synthetic record's `branchId` is the highest
+ * -priority contributor — cosmetic, since the commit reads only `node.id` / kind /
+ * `forkProps`, and provenance for every contributing branch is recorded upstream.
+ *
+ * Order-independent: groups by id (the staging input is already `(id, branchId)`
+ * sorted), merges per the stable `branchRank`, and sorts both outputs by stable
+ * keys, so shuffling the branch set yields an identical result.
+ *
+ * @param survivingModifications The surviving modifications from
+ *   {@link resolveDeleteModify} (one entry per `(id, branch)`).
+ * @param policy The property-conflict policy (shared with the cluster union, T8).
+ * @param branchRank The captured stable branch rank.
+ * @param weights Optional per-branch weights for `"provenanceWeighted"`.
+ */
+export function reconcileModifications(
+  survivingModifications: readonly StagedModifiedNode[],
+  policy: PropertyConflictPolicy,
+  branchRank: ReadonlyMap<BranchId, number>,
+  weights?: ProvenanceWeights,
+  preferredBranchId?: BranchId,
+): ModificationReconciliation {
+  return reconcileOver(
+    survivingModifications,
+    (item) => item.node,
+    (representative, chosenBranch, mergedProps) => ({
+      branchId: chosenBranch,
+      node: { ...representative.node, forkProps: mergedProps },
+    }),
+    policy,
+    branchRank,
+    weights,
+    preferredBranchId,
+  );
+}
+
+// ============================================================
+// Inherited EDGE delete/modify resolution (the edge analogue of the node path
+// above). Edges carry fixed endpoints, so a "modified" edge only changes props;
+// the delete/modify and 3-way merge logic is otherwise identical to nodes, and
+// reuses the same {@link pickHighestPriorityBranch} + {@link threeWayMergeProps}
+// cores so node and edge behavior can never drift.
+// ============================================================
+
+/**
+ * The outcome of delete/modify resolution over the staged inherited EDGES.
+ * Mirrors {@link DeleteModifyResolution}: `edgeDeletions` is the authoritative set
+ * of finally-deleted inherited edges (pure deletions plus `"deleteWins"` conflict
+ * resolutions); `survivingModifications` is every modification the merge still
+ * applies; `conflicts`/`dropped` mirror the node fields.
+ */
+export type EdgeDeleteModifyResolution = Readonly<{
+  survivingModifications: readonly StagedModifiedEdge[];
+  edgeDeletions: readonly DeletedEdge[];
+  conflicts: readonly DeleteModifyConflict[];
+  dropped: readonly DroppedItem[];
+}>;
+
+/**
+ * Resolves every inherited EDGE simultaneously deleted by one+ branches and
+ * modified by one+ (other) branches, per the {@link DeleteModifyPolicy} — the
+ * edge analogue of {@link resolveDeleteModify}. Pure deletions flow to
+ * `edgeDeletions`; pure modifications flow to `survivingModifications`. Without
+ * this, inherited edge deletions were staged but never applied, so a branch's
+ * edge deletion was silently dropped and the edge stayed live. Shares
+ * {@link resolveDeleteModifyOver} with the node path so the two can never drift.
+ */
+export function resolveEdgeDeleteModify(
+  staging: StagingSet,
+  policy: DeleteModifyPolicy,
+  branchRank: ReadonlyMap<BranchId, number>,
+  preferredBranchId?: BranchId,
+): EdgeDeleteModifyResolution {
+  const resolved = resolveDeleteModifyOver(
+    staging.modifiedEdges,
+    staging.deletedEdges,
+    (item) => item.edge,
+    (item) => item.edge,
+    "edge",
+    policy,
+    branchRank,
+    preferredBranchId,
+  );
+  return {
+    survivingModifications: resolved.survivingModifications,
+    edgeDeletions: resolved.deletions,
+    conflicts: resolved.conflicts,
+    dropped: resolved.dropped,
+  };
+}
+
+/**
+ * The edge analogue of {@link reconcileModifications}: ONE merged record per edge
+ * id, carrying the 3-way-merged props the commit applies, plus every
+ * {@link PropertyConflict} a multi-branch edge modification surfaced. Edge
+ * endpoints are immutable, so only props are merged; the representative's
+ * endpoints/kind are kept.
+ */
+export function reconcileEdgeModifications(
+  survivingModifications: readonly StagedModifiedEdge[],
+  policy: PropertyConflictPolicy,
+  branchRank: ReadonlyMap<BranchId, number>,
+  weights?: ProvenanceWeights,
+  preferredBranchId?: BranchId,
+): Readonly<{
+  survivingModifications: readonly StagedModifiedEdge[];
+  conflicts: readonly PropertyConflict[];
+}> {
+  return reconcileOver(
+    survivingModifications,
+    (item) => item.edge,
+    (representative, chosenBranch, mergedProps) => ({
+      branchId: chosenBranch,
+      edge: { ...representative.edge, forkProps: mergedProps },
+    }),
+    policy,
+    branchRank,
+    weights,
+    preferredBranchId,
+  );
+}

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -1,0 +1,484 @@
+/**
+ * Edge repoint to canonical + set-dedupe cascade (design §6.3 / §6.4 rule 5, T9).
+ *
+ * After clustering (T8) collapses fork nodes into canonical survivors and
+ * delete/modify resolution (T8a) fixes the FINAL LIVENESS of every endpoint, the
+ * inherited and new edges of the merge must be:
+ *
+ *   1. REPOINTED — each endpoint mapped to its cluster's canonical id. An edge
+ *      `x → a` where `{a, b}` collapsed to canonical `c*` becomes `x → c*`.
+ *   2. DROPPED — any edge whose (repointed) `from` or `to` is a finally-deleted
+ *      node (per T8a, NOT resurrected) is removed, recorded as a
+ *      {@link DroppedItem} with reason {@link ENDPOINT_DELETED_DROP_REASON}.
+ *   3. DEDUPED — repointing can make two distinct edges identical. Edges are
+ *      collapsed as a pure SET operation keyed by
+ *      `(fromCanonical | type | toCanonical | propsKey)`, where `propsKey` is the
+ *      T2 canonical serializer over PARSED props. So `x → a` and `x → b` (both
+ *      repointed to `x → c*`) with equal props yield a SINGLE `x → c*`.
+ *   4. RECONCILED — when two edges collapse to the same `(from, type, to)` but
+ *      carry DIFFERING props, the per-property disagreement is resolved by the
+ *      shared T8 conflict policy ({@link resolvePropertyUnion}) on the captured,
+ *      non-wall-clock branch order, recording an edge-level {@link PropertyConflict}
+ *      whose `entityId` is the surviving edge's id.
+ *
+ * Determinism: the dedupe is a pure function of the (unordered) staged-edge SET.
+ * Within a collision group the surviving edge id is the lexicographically-minimal
+ * member id, property resolution uses only the captured `branchRank`, and the
+ * output is sorted by dedupe key — so shuffling the input edges yields an
+ * identical result. Clusters are computed once upstream (T8) and passed in as
+ * {@link canonicalOf}; this module never re-clusters.
+ */
+
+import { canonicalizeProps } from "./canonical-props";
+import type { ClusterResult } from "./clustering";
+import type { ProvenanceWeights, ResolutionContext } from "./conflict-policy";
+import {
+  collectConflictingValues,
+  resolvePropertyUnion,
+} from "./conflict-policy";
+import {
+  compareStrings,
+  idOf,
+  kindOf,
+  type MergeKey,
+  mergeKey,
+} from "./node-key";
+import type {
+  EdgeId,
+  GraphDef,
+  JsonValue,
+  NodeId,
+  NodeType,
+} from "./typegraph-internal";
+import type {
+  BranchId,
+  PropertyConflict,
+  PropertyConflictPolicy,
+} from "./types";
+
+/** A node id in its untyped (`NodeType`-default) branded form. */
+type AnyNodeId = NodeId<NodeType>;
+
+/** Reason recorded on a {@link DroppedItem} for an edge to a deleted endpoint. */
+export const ENDPOINT_DELETED_DROP_REASON = "edge:endpoint-deleted" as const;
+
+/**
+ * A `{ kind: "edge" }` dropped item. Mirrors the public {@link DroppedItem} but is
+ * narrowed to edges so this module's output is precisely typed. Structurally
+ * assignable to {@link DroppedItem}.
+ */
+type DroppedEdge = Readonly<{
+  kind: "edge";
+  id: EdgeId;
+  reason: string;
+}>;
+
+/**
+ * One staged edge fed into the repoint phase: a new fork edge or a surviving
+ * inherited edge. Carries the parsed props (NOT a JSON string) so the dedupe key
+ * and the conflict union both operate on the canonical structure, and the
+ * {@link BranchId} that contributed it so edge-property conflicts resolve on the
+ * same stable branch order as node-property conflicts.
+ *
+ * The orchestrator (T11) builds these from `StagedNewEdge` / surviving
+ * `StagedModifiedEdge` items (T7); this module needs no knowledge of the diff
+ * shape beyond these fields.
+ */
+export type StagedEdge = Readonly<{
+  id: EdgeId;
+  kind: string;
+  fromId: AnyNodeId;
+  toId: AnyNodeId;
+  fromKind: string;
+  toKind: string;
+  props: Readonly<Record<string, JsonValue>>;
+  branchId: BranchId;
+}>;
+
+/**
+ * A surviving merged edge after repoint + dedupe. `id` is the canonical survivor
+ * of its collision group (the lexicographically-minimal contributing edge id);
+ * `mergedIds` is every staged edge id that collapsed into it (always includes
+ * `id`), so the commit phase (T11) knows which inherited edges to fold away.
+ */
+export type MergedEdge = Readonly<{
+  id: EdgeId;
+  kind: string;
+  fromId: AnyNodeId;
+  toId: AnyNodeId;
+  fromKind: string;
+  toKind: string;
+  props: Readonly<Record<string, JsonValue>>;
+  mergedIds: readonly EdgeId[];
+}>;
+
+/**
+ * The outcome of the repoint + dedupe cascade: the surviving merged edges, every
+ * edge dropped for a deleted endpoint, and every edge-level property conflict the
+ * dedupe surfaced.
+ */
+export type EdgeRepointResult<G extends GraphDef = GraphDef> = Readonly<{
+  edges: readonly MergedEdge[];
+  dropped: readonly DroppedEdge[];
+  conflicts: readonly PropertyConflict<G>[];
+}>;
+
+/**
+ * Builds the endpoint → canonical map from the resolved clusters. Every member of
+ * a cluster maps to that cluster's canonical id; ids absent from the map (cluster
+ * singletons / nodes never compared) are treated as their own canonical by the
+ * `?? id` fallback at lookup time, so the map need only carry the rewrites.
+ *
+ * @param clusters Resolved clusters (T8). Each must be non-empty.
+ * @param canonicalOf A `cluster → canonicalId` selector returning the cluster's
+ *   canonical survivor (as chosen by T8 `pickClusterSurvivor`), threaded so this
+ *   module reuses the merge-wide canonical choice rather than re-deriving it.
+ */
+export function buildCanonicalMap(
+  clusters: readonly ClusterResult[],
+  canonicalOf: (cluster: ClusterResult) => MergeKey,
+): ReadonlyMap<MergeKey, MergeKey> {
+  const map = new Map<MergeKey, MergeKey>();
+  for (const cluster of clusters) {
+    const canonical = canonicalOf(cluster);
+    for (const member of cluster.members) {
+      map.set(member, canonical);
+    }
+  }
+  return map;
+}
+
+/**
+ * Resolves an endpoint IDENTITY (`(kind, id)` key) to its cluster canonical,
+ * defaulting to itself. Keying on the composite identity is what stops an edge from
+ * a `Patient` and an edge from an `Encounter` that share an endpoint id from being
+ * repointed onto the same survivor.
+ */
+function repoint(
+  key: MergeKey,
+  canonicalOf: ReadonlyMap<MergeKey, MergeKey>,
+): MergeKey {
+  return canonicalOf.get(key) ?? key;
+}
+
+/**
+ * The dedupe key for a repointed edge: a JSON-encoded `[from', type, to',
+ * propsKey]` tuple. The `propsKey` is the T2 canonical serializer over the PARSED
+ * props, so two edges that agree on endpoints, type, AND every property collapse to
+ * one regardless of property key order. JSON-encoding the tuple (rather than
+ * concatenating with a literal separator) keeps the key unambiguous even when an
+ * edge `type` — a user-defined schema string — or a caller-supplied endpoint id
+ * contains the separator character.
+ */
+function dedupeKey(
+  fromKey: MergeKey,
+  type: string,
+  toKey: MergeKey,
+  props: Readonly<Record<string, JsonValue>>,
+): string {
+  return JSON.stringify([fromKey, type, toKey, canonicalizeProps(props)]);
+}
+
+/**
+ * The key identifying a collision GROUP — edges sharing `(from', type, to')`
+ * regardless of props. Edges in the same group but with differing props are the
+ * ones whose properties must be reconciled by the conflict policy. JSON-encoded
+ * (see {@link dedupeKey}) so a `|`-bearing type/id can never fuse two distinct
+ * groups.
+ */
+function groupKey(fromKey: MergeKey, type: string, toKey: MergeKey): string {
+  return JSON.stringify([fromKey, type, toKey]);
+}
+
+/**
+ * A repointed staged edge plus both endpoints already mapped to their canonical
+ * IDENTITY key (`(kind, id)`). The composite keys carry the canonical node's kind, so
+ * the surviving edge's bare `fromId`/`toId` and `fromKind`/`toKind` are read off
+ * `idOf`/`kindOf` of these keys — never the (possibly different-kind) staged endpoint.
+ */
+type RepointedEdge = Readonly<{
+  staged: StagedEdge;
+  fromKey: MergeKey;
+  toKey: MergeKey;
+}>;
+
+/**
+ * Picks the canonical survivor edge of a collision group: the member with the
+ * lexicographically-minimal edge id. Mirrors the node min-id canonical rule (T8)
+ * so the surviving id is independent of input edge order. (`generateId()` is
+ * nanoid — random, not time-prefixed — so min-id never leaks creation order.)
+ */
+function pickSurvivor(
+  edges: readonly RepointedEdge[],
+  preferredBranchId?: BranchId,
+): RepointedEdge {
+  const preferred =
+    preferredBranchId === undefined ?
+      []
+    : edges.filter((edge) => edge.staged.branchId === preferredBranchId);
+  const candidates = preferred.length > 0 ? preferred : edges;
+  let survivor = candidates[0]!;
+  for (const candidate of candidates.slice(1)) {
+    if (candidate.staged.id < survivor.staged.id) {
+      survivor = candidate;
+    }
+  }
+  return survivor;
+}
+
+/**
+ * Unions the props of one collision group's edges, resolving any per-property
+ * disagreement via the shared T8 conflict policy. Returns the surviving prop bag
+ * plus an edge-level {@link PropertyConflict} for every property that genuinely
+ * differed (its `entityId` is the surviving edge id).
+ */
+function unionEdgeProps(
+  survivorId: EdgeId,
+  kind: string,
+  survivor: RepointedEdge,
+  edges: readonly RepointedEdge[],
+  context: ResolutionContext<GraphDef>,
+  branchRank: ReadonlyMap<BranchId, number>,
+  preferredBranchId?: BranchId,
+): Readonly<{
+  props: Record<string, JsonValue>;
+  conflicts: PropertyConflict[];
+}> {
+  const propertyNames = new Set<string>();
+  for (const edge of edges) {
+    for (const name of Object.keys(edge.staged.props)) {
+      propertyNames.add(name);
+    }
+  }
+
+  const props: Record<string, JsonValue> = {};
+  const conflicts: PropertyConflict[] = [];
+
+  // The staged record of each edge IS a `(branchId, props)` contribution, so the
+  // shared node/edge collector consumes it directly.
+  const contributions = edges.map((edge) => edge.staged);
+
+  for (const property of [...propertyNames].sort((left, right) =>
+    compareStrings(left, right),
+  )) {
+    const values = collectConflictingValues(property, contributions);
+    if (values.length === 0) {
+      continue;
+    }
+    const survivorValue =
+      property in survivor.staged.props ?
+        (survivor.staged.props[property] as JsonValue)
+      : values[0]!.value;
+    const canonicalValue: JsonValue =
+      values.find((value) => value.branchId === preferredBranchId)?.value ??
+      survivorValue;
+    const reportedValues =
+      preferredBranchId === undefined ? values : (
+        values.filter((value) => value.branchId !== preferredBranchId)
+      );
+
+    const { value, conflict } = resolvePropertyUnion(
+      {
+        entityId: survivorId,
+        kind,
+        property,
+        values,
+        reportedValues,
+        canonicalValue,
+      },
+      context,
+      branchRank,
+    );
+    props[property] = value;
+    if (conflict !== undefined) {
+      conflicts.push(conflict);
+    }
+  }
+
+  return { props, conflicts };
+}
+
+/**
+ * Repoints every staged edge onto its cluster canonical, drops edges whose
+ * (repointed) endpoints are finally deleted, and dedupes the survivors as a pure
+ * set operation keyed by `(from' | type | to' | propsKey)`.
+ *
+ * Within a collision group sharing `(from', type, to')`:
+ *   - identical props collapse silently to one edge,
+ *   - DIFFERING props are reconciled by `policy` on the captured `branchRank`,
+ *     recording one edge-level {@link PropertyConflict} per disagreeing property.
+ *
+ * The surviving edge of every group is the lexicographically-minimal contributing
+ * edge id; its `mergedIds` lists every collapsed edge id. Output is sorted by the
+ * full dedupe key, so the result is a pure function of the unordered input set.
+ *
+ * @param stagedEdges The new + surviving-inherited edges to merge. Order does not
+ *   affect the result. Props MUST already be parsed objects.
+ * @param canonicalOf The endpoint → canonical map (from {@link buildCanonicalMap}).
+ *   Endpoints absent from it map to themselves.
+ * @param deletedNodeIds The AUTHORITATIVE finally-deleted node id set (T8a). Any
+ *   edge whose repointed `from`/`to` is in this set is dropped.
+ * @param policy The property-conflict policy (shared with node union, T8).
+ * @param branchRank The captured stable branch rank (built once via
+ *   `buildBranchRank`). Used only for deterministic conflict resolution — never
+ *   wall-clock.
+ * @param weights Optional per-branch weights for the `"provenanceWeighted"` policy.
+ */
+export function repointEdges<G extends GraphDef = GraphDef>(
+  stagedEdges: readonly StagedEdge[],
+  canonicalOf: ReadonlyMap<MergeKey, MergeKey>,
+  deletedNodeIds: ReadonlySet<MergeKey>,
+  policy: PropertyConflictPolicy<G>,
+  branchRank: ReadonlyMap<BranchId, number>,
+  weights?: ProvenanceWeights,
+  preferredBranchId?: BranchId,
+): EdgeRepointResult<G> {
+  const dropped: DroppedEdge[] = [];
+  const liveByDedupeKey = new Map<string, RepointedEdge[]>();
+  // Per `(from', type, to')` group → the SET of distinct dedupe keys seen for it.
+  // Insertion order is irrelevant: Phase 2 re-derives the survivor and sorts the
+  // output explicitly, so the set carries membership only.
+  const dedupeKeyByGroup = new Map<string, Set<string>>();
+
+  // Phase 1: repoint endpoints (by their `(kind, id)` identity, so a cross-kind id
+  // collision can never repoint two unrelated edges onto one survivor), drop edges to
+  // deleted nodes, and bucket the survivors by their full dedupe key.
+  for (const staged of stagedEdges) {
+    const fromKey = repoint(
+      mergeKey(staged.fromKind, staged.fromId),
+      canonicalOf,
+    );
+    const toKey = repoint(mergeKey(staged.toKind, staged.toId), canonicalOf);
+
+    if (deletedNodeIds.has(fromKey) || deletedNodeIds.has(toKey)) {
+      dropped.push({
+        kind: "edge",
+        id: staged.id,
+        reason: ENDPOINT_DELETED_DROP_REASON,
+      });
+      continue;
+    }
+
+    const repointed: RepointedEdge = { staged, fromKey, toKey };
+    const key = dedupeKey(fromKey, staged.kind, toKey, staged.props);
+    const bucket = liveByDedupeKey.get(key);
+    if (bucket === undefined) {
+      liveByDedupeKey.set(key, [repointed]);
+    } else {
+      bucket.push(repointed);
+    }
+
+    const group = groupKey(fromKey, staged.kind, toKey);
+    const keysForGroup = dedupeKeyByGroup.get(group);
+    if (keysForGroup === undefined) {
+      dedupeKeyByGroup.set(group, new Set([key]));
+    } else {
+      keysForGroup.add(key);
+    }
+  }
+
+  // Phase 2: per `(from', type, to')` group, fold the per-dedupe-key buckets into
+  // one survivor. A group with a single dedupe key is an exact-equal collapse (no
+  // conflict); a group with several dedupe keys means props differ, so the union
+  // runs the conflict policy.
+  const context: ResolutionContext<GraphDef> = {
+    policy: policy as PropertyConflictPolicy<GraphDef>,
+    ...(weights === undefined ? {} : { weights }),
+  };
+
+  const merged: MergedEdge[] = [];
+  const conflicts: PropertyConflict<G>[] = [];
+
+  const sortedGroups = [...dedupeKeyByGroup.keys()].sort((left, right) =>
+    compareStrings(left, right),
+  );
+
+  for (const group of sortedGroups) {
+    const dedupeKeys = [...dedupeKeyByGroup.get(group)!];
+    const groupEdges: RepointedEdge[] = [];
+    for (const key of dedupeKeys) {
+      for (const edge of liveByDedupeKey.get(key)!) {
+        groupEdges.push(edge);
+      }
+    }
+
+    const survivor = pickSurvivor(groupEdges, preferredBranchId);
+    const survivorId = survivor.staged.id;
+    const mergedIds = [...groupEdges]
+      .map((edge) => edge.staged.id)
+      .sort((left, right) => compareStrings(left, right));
+
+    // Endpoint ids AND kinds come from the canonical IDENTITY keys, so a repointed
+    // edge always names the canonical node's own kind (the commit then applies any
+    // retype cascade), never a staged endpoint that merely shared the id string.
+    const fromId = idOf(survivor.fromKey);
+    const fromKind = kindOf(survivor.fromKey);
+    const toId = idOf(survivor.toKey);
+    const toKind = kindOf(survivor.toKey);
+
+    if (dedupeKeys.length === 1) {
+      // Exact-equal collapse: every member shares identical props, so no
+      // conflict is possible — keep the survivor's props verbatim.
+      merged.push({
+        id: survivorId,
+        kind: survivor.staged.kind,
+        fromId,
+        toId,
+        fromKind,
+        toKind,
+        props: survivor.staged.props,
+        mergedIds,
+      });
+      continue;
+    }
+
+    const { props, conflicts: groupConflicts } = unionEdgeProps(
+      survivorId,
+      survivor.staged.kind,
+      survivor,
+      groupEdges,
+      context,
+      branchRank,
+      preferredBranchId,
+    );
+    for (const conflict of groupConflicts) {
+      conflicts.push(conflict as PropertyConflict<G>);
+    }
+    merged.push({
+      id: survivorId,
+      kind: survivor.staged.kind,
+      fromId,
+      toId,
+      fromKind,
+      toKind,
+      props,
+      mergedIds,
+    });
+  }
+
+  // Sort on a PRECOMPUTED dedupe key per edge (Schwartzian) so `canonicalizeProps` +
+  // serialization run once per edge, not twice on every comparison.
+  const sortedEdges = merged
+    .map((edge) => ({
+      edge,
+      sortKey: dedupeKey(
+        mergeKey(edge.fromKind, edge.fromId),
+        edge.kind,
+        mergeKey(edge.toKind, edge.toId),
+        edge.props,
+      ),
+    }))
+    .sort((left, right) => compareStrings(left.sortKey, right.sortKey))
+    .map(({ edge }) => edge);
+
+  return {
+    edges: sortedEdges,
+    dropped: dropped.sort((left, right) => compareStrings(left.id, right.id)),
+    conflicts: conflicts.sort((left, right) =>
+      compareStrings(
+        `${left.entityId}|${left.property}`,
+        `${right.entityId}|${right.property}`,
+      ),
+    ),
+  };
+}

--- a/packages/typegraph/src/graph-merge/errors.ts
+++ b/packages/typegraph/src/graph-merge/errors.ts
@@ -1,0 +1,136 @@
+import type { TypeGraphErrorOptions } from "./typegraph-internal";
+import { TypeGraphError } from "./typegraph-internal";
+
+/**
+ * Error hierarchy for the graph-merge primitive.
+ *
+ * Every error extends the publicly-exported {@link TypeGraphError}, so consumers
+ * can use the same `isTypeGraphError`/category machinery they already use for
+ * TypeGraph itself. Each subclass carries a stable machine-readable `code`, a
+ * fixed `ErrorCategory`, and a cause chain for debugging.
+ */
+
+/**
+ * Machine-readable error codes for the merge primitive. Stable identifiers so
+ * callers can branch on `error.code` without string-matching messages.
+ */
+export const MERGE_ERROR_CODES = {
+  merge: "GRAPH_MERGE_ERROR",
+  branch: "GRAPH_MERGE_BRANCH_ERROR",
+  similarityUnavailable: "GRAPH_MERGE_SIMILARITY_UNAVAILABLE",
+  conflict: "GRAPH_MERGE_CONFLICT",
+  baseVersionMismatch: "GRAPH_MERGE_BASE_VERSION_MISMATCH",
+} as const;
+
+/**
+ * Options shared by every merge error. Mirrors the relevant subset of
+ * TypeGraphError's options while making `cause`/`details`/`suggestion`
+ * uniformly optional at the merge-error boundary.
+ */
+export type MergeErrorOptions = Readonly<{
+  details?: Record<string, unknown>;
+  suggestion?: string;
+  cause?: unknown;
+}>;
+
+/**
+ * Builds a {@link TypeGraphErrorOptions} for a fixed category, threading only
+ * the optional fields that are actually present. Omitting undefined keys (rather
+ * than assigning `undefined`) keeps the result valid under
+ * `exactOptionalPropertyTypes`.
+ */
+function toTypeGraphErrorOptions(
+  category: TypeGraphErrorOptions["category"],
+  options: MergeErrorOptions,
+): TypeGraphErrorOptions {
+  return {
+    category,
+    ...(options.details === undefined ? {} : { details: options.details }),
+    ...(options.suggestion === undefined ?
+      {}
+    : { suggestion: options.suggestion }),
+    ...(options.cause === undefined ? {} : { cause: options.cause }),
+  };
+}
+
+/**
+ * Generic failure raised while computing or committing a merge. The catch-all
+ * for the orchestrator (comparison-ceiling overruns, commit failures, etc.).
+ */
+export class MergeError extends TypeGraphError {
+  constructor(message: string, options: MergeErrorOptions = {}) {
+    super(
+      message,
+      MERGE_ERROR_CODES.merge,
+      toTypeGraphErrorOptions("system", options),
+    );
+    this.name = "MergeError";
+  }
+}
+
+/**
+ * Failure raised while creating a working-copy branch of a base store
+ * (clone/export/import failures, backend construction failures).
+ */
+export class BranchError extends TypeGraphError {
+  constructor(message: string, options: MergeErrorOptions = {}) {
+    super(
+      message,
+      MERGE_ERROR_CODES.branch,
+      toTypeGraphErrorOptions("system", options),
+    );
+    this.name = "BranchError";
+  }
+}
+
+/**
+ * Raised when a `vector`/`hybrid` similarity strategy is requested but no
+ * {@link import("./types").Embedder} was configured (`MergeOptions.embedder` is
+ * absent). The `vector`/`hybrid` scorers compute cosine over real embeddings in
+ * memory, so an embedder is mandatory for them; `fulltext`/`custom` need none.
+ */
+export class SimilarityUnavailableError extends MergeError {
+  override readonly code = MERGE_ERROR_CODES.similarityUnavailable;
+
+  constructor(message: string, options: MergeErrorOptions = {}) {
+    super(message, {
+      ...options,
+      suggestion:
+        options.suggestion ??
+        "Pass MergeOptions.embedder (a local model), or use a fulltext/custom similarity strategy.",
+    });
+    this.name = "SimilarityUnavailableError";
+  }
+}
+
+/**
+ * Raised when a conflict cannot be resolved by the configured policy and the
+ * caller has opted into hard-failing rather than flagging.
+ */
+export class MergeConflictError extends MergeError {
+  override readonly code = MERGE_ERROR_CODES.conflict;
+
+  constructor(message: string, options: MergeErrorOptions = {}) {
+    super(message, options);
+    this.name = "MergeConflictError";
+  }
+}
+
+/**
+ * Raised by the `merge()` precondition check when a branch's `base@V` token
+ * does not match the merge target's current base version (the branch forked
+ * from a divergent schema or content fingerprint).
+ */
+export class BaseVersionMismatchError extends MergeError {
+  override readonly code = MERGE_ERROR_CODES.baseVersionMismatch;
+
+  constructor(message: string, options: MergeErrorOptions = {}) {
+    super(message, {
+      ...options,
+      suggestion:
+        options.suggestion ??
+        "Re-branch from the current target so the branch base matches before merging.",
+    });
+    this.name = "BaseVersionMismatchError";
+  }
+}

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -1,0 +1,69 @@
+// Public barrel for @nicia-ai/typegraph/graph-merge.
+//
+// Keep this surface deliberately narrower than the implementation modules:
+// branch()/merge(), the stable option/report types, working-copy extension
+// points, typed errors, and durable provenance helpers. The phase-level
+// algorithms stay internal and are covered through relative test imports.
+export { computeBaseVersion } from "./base-version";
+export { branch } from "./branch";
+export {
+  BaseVersionMismatchError,
+  BranchError,
+  MERGE_ERROR_CODES,
+  MergeConflictError,
+  MergeError,
+  SimilarityUnavailableError,
+} from "./errors";
+export { merge, mergeIncremental } from "./merge";
+export type { NormalizedMergeOptions } from "./options";
+export { MERGE_OPTION_DEFAULTS, normalizeMergeOptions } from "./options";
+export type {
+  ProvenanceGraph,
+  ProvenanceNode,
+  ProvenanceQuery,
+} from "./provenance-store";
+export {
+  openProvenanceStore,
+  persistProvenanceRecords,
+  provenanceGraphId,
+  readProvenance,
+} from "./provenance-store";
+export type { Result } from "./result";
+export { isErr, isOk, unwrap } from "./result";
+export type {
+  BaseNodeLookup,
+  CandidateSource,
+  KeylessConfig,
+  SourceScope,
+} from "./sources";
+export type {
+  BaseAmbiguity,
+  BaseVersion,
+  BranchId,
+  BranchOptions,
+  BranchProvenance,
+  ComparisonCeilingPolicy,
+  ConflictingValue,
+  DeleteModifyConflict,
+  DeleteModifyPolicy,
+  DroppedItem,
+  Embedder,
+  EntityResolution,
+  GraphBranch,
+  MergeIncrementalArgs,
+  MergeOptions,
+  MergeReport,
+  PropertyConflict,
+  PropertyConflictPolicy,
+  ProvenanceIndex,
+  ProvenanceRecord,
+  ReconcileTypesMode,
+  ResolveConfig,
+  ResolvedCluster,
+  ResolveMap,
+  SimilarityStrategy,
+  TypeReconciliation,
+} from "./types";
+export { asBaseVersion, asBranchId } from "./types";
+export type { MakeBackend, WorkingCopyStrategy } from "./working-copy";
+export { cloneWorkingCopyStrategy } from "./working-copy";

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -1,0 +1,2253 @@
+/**
+ * `merge()` orchestrator (design §7.2, T11).
+ *
+ * Composes every phase built in T3–T10 into one DB-agnostic primitive:
+ *
+ *   1. PRECONDITION — compute the target's `base@V` and reject any branch whose
+ *      `base` token does not match it (`BaseVersionMismatchError`). A branch
+ *      forked from a divergent schema or content fingerprint cannot be merged
+ *      safely (design §5.2 / §13.6).
+ *   2. STAGE — `stageBranches` (T7): the provenance-tagged UNION of every
+ *      branch's state-diff against the immutable base.
+ *   3. CANDIDATE-GEN — per resolved kind: build node-shaped objects from the
+ *      staged NEW nodes, `blockNodes` (T5, folding in unique constraints from
+ *      `introspect()`), `generateCandidates` (T6, fulltext Dice + custom; vector/
+ *      hybrid guarded). Kinds NOT in `options.resolve` merge by id only.
+ *   4. CLUSTER — `connectedComponents` (T8) over the accumulated candidate edges
+ *      and every staged new-node id, with the optional diameter guard.
+ *   5. CANONICALIZE — `canonicalizeCluster` (T8): min-id survivor + commutative
+ *      property union under the stable, non-wall-clock conflict policy.
+ *   6. DELETE/MODIFY — `resolveDeleteModify` (T8a): the authoritative final
+ *      liveness of every inherited node + the delete/modify conflicts.
+ *   7. TYPE-RECONCILE — `reconcileTypes` (T10) over the public-closure glue when
+ *      `reconcileTypes: "ontology"`; otherwise a no-op.
+ *   8. EDGE REPOINT — `repointEdges` (T9): repoint every staged edge onto its
+ *      cluster canonical, drop edges to finally-deleted endpoints, dedupe + union
+ *      edge props under the same conflict policy.
+ *   9. COMMIT — apply everything to `target` (default = base store) in a single
+ *      `store.transaction` when the backend is transactional, else non-atomically
+ *      with a report warning (out of the P0 acceptance path — SQLite + Postgres
+ *      are both transactional).
+ *  10. REPORT — assemble the {@link MergeReport} with merged counts, every
+ *      resolution / conflict / reconciliation / drop, and the in-memory
+ *      {@link ProvenanceIndex}. With `persistProvenance`, ALSO upsert the
+ *      `{branch, sourceId}` records to a sidecar provenance graph (post-commit,
+ *      best-effort — a failure surfaces as a report warning, never a failed merge).
+ *
+ * DETERMINISM: every phase is order-independent (pure functions over the
+ * unordered branch / staged sets, with a branch order captured ONCE for
+ * conflict resolution), so shuffling `branches` yields a deep-equal report and an
+ * identical committed graph. T12 proves this with a fast-check shuffle property.
+ */
+
+import { computeBaseVersion, computeSchemaComponent } from "./base-version";
+import { blockNodes } from "./blocking";
+import { canonicalizeProps } from "./canonical-props";
+import type { CanonicalEntity, ClusterMember } from "./canonicalize";
+import { BASE_PROVENANCE_BRANCH, canonicalizeCluster } from "./canonicalize";
+import { buildSubClassClosure } from "./closures";
+import type { ClusterResult } from "./clustering";
+import {
+  connectedComponents,
+  enforceBaseGuard,
+  enforceDiameter,
+} from "./clustering";
+import type { ProvenanceWeights } from "./conflict-policy";
+import { buildBranchRank } from "./conflict-policy";
+import {
+  reconcileEdgeModifications,
+  reconcileModifications,
+  resolveDeleteModify,
+  resolveEdgeDeleteModify,
+} from "./delete-modify";
+import type { MergedEdge, StagedEdge } from "./edge-repoint";
+import { buildCanonicalMap, repointEdges } from "./edge-repoint";
+import { BaseVersionMismatchError, MergeError } from "./errors";
+import {
+  compareMergeKeys,
+  compareStrings,
+  idOf,
+  kindOf,
+  type MergeKey,
+  mergeKey,
+  mergeKeyOf,
+} from "./node-key";
+import type { NormalizedMergeOptions } from "./options";
+import { normalizeMergeOptions } from "./options";
+import {
+  openProvenanceStore,
+  persistProvenanceRecords,
+  provenanceGraphId,
+} from "./provenance-store";
+import type { Result } from "./result";
+import { err, isErr, ok } from "./result";
+import type { CandidateEdge, CandidatePair } from "./scoring";
+import { compareCandidateEdges, scoreCandidates } from "./scoring";
+import type { SimilarityContext } from "./similarity";
+import { embeddingFields, fieldText } from "./similarity";
+import type { BaseLookupStore, BaseMember, SourceScope } from "./sources";
+import {
+  baseKeySource,
+  baseUniqueSource,
+  CANDIDATE_SOURCES,
+  keylessConfigFor,
+  ontologyRetypeEdges,
+} from "./sources";
+import type {
+  StagedModifiedEdge,
+  StagedModifiedNode,
+  StagedNewEdge,
+  StagedNewNode,
+  StagingSet,
+} from "./staging";
+import { stageBranches } from "./staging";
+import type { ReconcileClusterInput } from "./type-reconcile";
+import { mostSpecificCommonKind, reconcileTypes } from "./type-reconcile";
+import type {
+  Edge,
+  EdgeId,
+  GraphDef,
+  JsonValue,
+  Node,
+  NodeId,
+  NodeType,
+  Store,
+  UniqueIntrospection,
+} from "./typegraph-internal";
+import type {
+  BaseAmbiguity,
+  BaseVersion,
+  BranchId,
+  BranchProvenance,
+  DeleteModifyConflict,
+  DroppedItem,
+  Embedder,
+  EntityResolution,
+  GraphBranch,
+  MergeIncrementalArgs as MergeIncrementalArguments,
+  MergeOptions,
+  MergeReport,
+  PropertyConflict,
+  PropertyConflictPolicy,
+  ProvenanceIndex,
+  ProvenanceRecord,
+  SimilarityStrategy,
+  TypeReconciliation,
+} from "./types";
+import { asBranchId } from "./types";
+
+/** A node id in its untyped (`NodeType`-default) branded form. */
+type AnyNodeId = NodeId<NodeType>;
+
+/** Reserved synthetic branch id for the live target in `mergeIncremental()`. */
+const COMMITTED_TARGET_BRANCH: BranchId = asBranchId("__committed_target__");
+
+/**
+ * Materializes a {@link Node}-shaped object from a staged new node's parsed
+ * props. The blocking (T5) and similarity (T6) phases read schema fields directly
+ * off the node (`node.name`), so the props must be spread at the top level with
+ * `kind`/`id` alongside — exactly the runtime shape `Node<NodeType>` carries.
+ */
+function asNode(staged: StagedNewNode): Node<NodeType> {
+  return {
+    kind: staged.node.kind,
+    id: staged.node.id,
+    ...staged.node.props,
+  } as unknown as Node<NodeType>;
+}
+
+/**
+ * Collects, per kind, every staged new node tagged by branch, in deterministic
+ * `(id, branchId)` order. The staging set already buckets new nodes by kind in
+ * lexicographic order; this re-sorts each bucket defensively so candidate-gen is
+ * correct for any caller.
+ */
+function newNodesByKind(
+  staging: StagingSet,
+): ReadonlyMap<string, readonly StagedNewNode[]> {
+  const ordered = new Map<string, readonly StagedNewNode[]>();
+  for (const [kind, items] of staging.newNodesByKind) {
+    ordered.set(
+      kind,
+      [...items].sort((left, right) => {
+        const byId = compareStrings(left.node.id, right.node.id);
+        return byId === 0 ?
+            compareStrings(left.branchId, right.branchId)
+          : byId;
+      }),
+    );
+  }
+  return ordered;
+}
+
+/**
+ * Looks up a kind's declared unique constraints from the store introspection, so
+ * blocking can short-circuit exact-match duplicates. Returns an empty array for a
+ * kind with no constraints (or an unknown kind).
+ */
+function uniqueConstraintsFor(
+  introspectionKinds: ReadonlyMap<string, readonly UniqueIntrospection[]>,
+  kind: string,
+): readonly UniqueIntrospection[] {
+  return introspectionKinds.get(kind) ?? [];
+}
+
+/**
+ * Precomputes the text→vector lookup the `vector`/`hybrid` scorers read.
+ *
+ * Runs the injected {@link Embedder} ONCE over the deduplicated, non-empty field
+ * texts of every staged new node belonging to a `vector`/`hybrid` kind, in sorted
+ * order. Embedding is per-text independent and the lookup is keyed by text, so the
+ * map — and therefore every pairwise cosine — is a pure function of the staged node
+ * SET, independent of branch/arrival order (the determinism contract). The text of
+ * each node is taken via the SAME {@link fieldText} the scorer uses, so the
+ * embedded key and the looked-up key always match.
+ *
+ * Returns an EMPTY map when no kind needs embeddings (or every text is empty). The
+ * caller passes the map (vs. `undefined`) to {@link SimilarityContext} only when an
+ * embedder was configured — that presence is what lets `scorePair` distinguish
+ * "embedder configured" from "vector/hybrid requested with no embedder".
+ *
+ * This covers only STAGED node texts. COMMITTED base nodes pulled into staged↔base
+ * candidate pairs by the base sources are not known until candidate generation
+ * runs, so their texts are embedded there via {@link embedMissingPairTexts}.
+ */
+async function precomputeEmbeddings<G extends GraphDef>(
+  byKind: ReadonlyMap<string, readonly StagedNewNode[]>,
+  resolve: NormalizedMergeOptions<G>["resolve"],
+  embedder: Embedder,
+): Promise<ReadonlyMap<string, Float32Array>> {
+  const texts = new Set<string>();
+  for (const [kind, items] of byKind) {
+    const config = resolve[kind];
+    if (config === undefined) {
+      continue;
+    }
+    const fields = embeddingFields(config.similarity);
+    if (fields === undefined) {
+      continue;
+    }
+    for (const staged of items) {
+      const text = fieldText(asNode(staged), fields);
+      if (text.length > 0) {
+        texts.add(text);
+      }
+    }
+  }
+
+  const lookup = new Map<string, Float32Array>();
+  if (texts.size === 0) {
+    return lookup;
+  }
+  const orderedTexts = [...texts].sort((left, right) =>
+    compareStrings(left, right),
+  );
+  const vectors = await embedder(orderedTexts);
+  if (vectors.length !== orderedTexts.length) {
+    throw new MergeError(
+      `Embedder returned ${vectors.length} vectors for ${orderedTexts.length} texts; expected exactly one per text.`,
+      {
+        details: { texts: orderedTexts.length, vectors: vectors.length },
+        suggestion:
+          "Ensure MergeOptions.embedder returns one vector per input text, in order.",
+      },
+    );
+  }
+  for (const [index, text] of orderedTexts.entries()) {
+    lookup.set(text, vectors[index]!);
+  }
+  return lookup;
+}
+
+/**
+ * Ensures every text scored for a `vector`/`hybrid` kind is in the embeddings
+ * lookup. {@link precomputeEmbeddings} embeds only STAGED node texts; the base
+ * sources (`baseKeySource`/`baseUniqueSource`) pull COMMITTED nodes into
+ * staged↔base candidate pairs whose texts were never embedded — without this they
+ * would score MIN_SCORE and a staged node would commit as a DUPLICATE instead of
+ * merging onto its committed entity. Embeds any pair-endpoint text missing from
+ * `base` and returns the augmented map (the original when nothing is missing).
+ * Keyed by text and embedded in sorted order, so the result stays a pure function
+ * of the node set (the determinism contract). Non-embedding strategies
+ * (`fulltext`/`custom`) return `base` unchanged.
+ */
+async function embedMissingPairTexts(
+  base: ReadonlyMap<string, Float32Array> | undefined,
+  pairs: readonly CandidatePair[],
+  strategy: SimilarityStrategy,
+  embedder: Embedder,
+): Promise<ReadonlyMap<string, Float32Array>> {
+  const existing = base ?? new Map<string, Float32Array>();
+  const fields = embeddingFields(strategy);
+  if (fields === undefined) {
+    return existing;
+  }
+  const missing = new Set<string>();
+  for (const pair of pairs) {
+    for (const node of [pair.left, pair.right]) {
+      const text = fieldText(node, fields);
+      if (text.length > 0 && !existing.has(text)) {
+        missing.add(text);
+      }
+    }
+  }
+  if (missing.size === 0) {
+    return existing;
+  }
+  const orderedTexts = [...missing].sort((left, right) =>
+    compareStrings(left, right),
+  );
+  const vectors = await embedder(orderedTexts);
+  if (vectors.length !== orderedTexts.length) {
+    throw new MergeError(
+      `Embedder returned ${vectors.length} vectors for ${orderedTexts.length} texts; expected exactly one per text.`,
+      {
+        details: { texts: orderedTexts.length, vectors: vectors.length },
+        suggestion:
+          "Ensure MergeOptions.embedder returns one vector per input text, in order.",
+      },
+    );
+  }
+  const augmented = new Map(existing);
+  for (const [index, text] of orderedTexts.entries()) {
+    augmented.set(text, vectors[index]!);
+  }
+  return augmented;
+}
+
+/**
+ * Runs candidate generation for every kind that has a {@link ResolveConfig} by
+ * driving the candidate SOURCES (`sources.ts`) over the shared SCORING stage
+ * (`scoring.ts`, §4): per kind, each source proposes pairs + forced edges off the
+ * scope, and the scoring stage turns them into the kind's candidate edges.
+ * Accumulates edges + any base members across kinds and records comparison-ceiling
+ * warnings. Kinds NOT in `resolve` (or with no staged new nodes) contribute no
+ * candidate edges — they merge by id only.
+ *
+ * `useBaseSources` selects the resolution DIRECTION. The public snapshot `merge()`
+ * passes `false` — only the staged sources (`exactKey`, `unique`) run, so no
+ * committed node is pulled into scope (`baseMembers` is empty) and the path stays
+ * staged-vs-staged. The synthetic new-vs-base scope passes `true`, adding
+ * {@link baseUniqueSource} (which queries `target`) so a staged node re-discovering
+ * a committed entity surfaces as a forced new↔base edge + a base member.
+ *
+ * Returns `err` when a kind's `onComparisonCeiling: "error"` ceiling trips or a
+ * `vector`/`hybrid` strategy hits the no-embedder guard.
+ */
+async function generateAllCandidates<G extends GraphDef>(
+  target: Store<G>,
+  staging: StagingSet,
+  options: NormalizedMergeOptions<G>,
+  introspectionKinds: ReadonlyMap<string, readonly UniqueIntrospection[]>,
+  ctx: SimilarityContext,
+  useBaseSources: boolean,
+  embedder: Embedder | undefined,
+): Promise<
+  Result<
+    Readonly<{
+      edges: readonly CandidateEdge[];
+      warnings: readonly string[];
+      baseMembers: readonly BaseMember[];
+    }>,
+    MergeError
+  >
+> {
+  const allEdges: CandidateEdge[] = [];
+  const warnings: string[] = [];
+  const baseMembers: BaseMember[] = [];
+  const byKind = newNodesByKind(staging);
+  const sources =
+    useBaseSources ?
+      [...CANDIDATE_SOURCES, baseUniqueSource, baseKeySource]
+    : CANDIDATE_SOURCES;
+  // Base sources resolve staged nodes against the COMMITTED graph — the merge
+  // TARGET, where prior runs' canonicals live — NOT the (possibly older) diff
+  // reference. They coincide under the public snapshot path (target defaults to
+  // store); they differ under the synthetic new-vs-base scope.
+  const baseStore = target as unknown as BaseLookupStore;
+
+  // Each kind's candidate generation is independent (results are concatenated, then
+  // globally re-sorted below), so run them concurrently — under the base-source path
+  // each kind's `bulkFindByConstraint` round-trip would otherwise serialise.
+  const perKind = await Promise.all(
+    [...byKind].map(
+      async ([kind, items]): Promise<
+        Result<
+          Readonly<{
+            edges: readonly CandidateEdge[];
+            warnings: readonly string[];
+            baseMembers: readonly BaseMember[];
+          }>,
+          MergeError
+        >
+      > => {
+        const resolveConfig = options.resolve[kind];
+        if (resolveConfig === undefined) {
+          // No resolution config for this kind: merge by id only (no candidate
+          // edges, so every new node stays a singleton cluster).
+          return ok({ edges: [], warnings: [], baseMembers: [] });
+        }
+
+        const nodes = items.map((staged) => asNode(staged));
+        const uniqueConstraints = uniqueConstraintsFor(
+          introspectionKinds,
+          kind,
+        );
+        const blocks = blockNodes(nodes, resolveConfig, uniqueConstraints);
+        const keylessConfig = keylessConfigFor(resolveConfig);
+        const scope: SourceScope = {
+          kind,
+          blocks,
+          nodes,
+          uniqueConstraints,
+          store: baseStore,
+          ...(resolveConfig.blockIndex === undefined ?
+            {}
+          : { blockIndex: resolveConfig.blockIndex }),
+          ...(keylessConfig === undefined ? {} : { keyless: keylessConfig }),
+        };
+
+        const pairs: CandidatePair[] = [];
+        const forcedEdges: CandidateEdge[] = [];
+        const kindBaseMembers: BaseMember[] = [];
+        for (const source of sources) {
+          const produced = await source.generate(scope);
+          pairs.push(...produced.pairs);
+          forcedEdges.push(...produced.forcedEdges);
+          kindBaseMembers.push(...produced.baseMembers);
+        }
+
+        // Base sources pull committed nodes into staged↔base pairs whose texts
+        // were not in the staged-only precompute; embed them now so vector/hybrid
+        // scoring can actually find them (otherwise the pair scores MIN_SCORE and
+        // the staged node duplicates instead of merging onto the committed entity).
+        const kindCtx =
+          embedder === undefined ? ctx : (
+            {
+              ...ctx,
+              embeddings: await embedMissingPairTexts(
+                ctx.embeddings,
+                pairs,
+                resolveConfig.similarity,
+                embedder,
+              ),
+            }
+          );
+
+        const scored = scoreCandidates(
+          { pairs, forcedEdges },
+          resolveConfig,
+          kindCtx,
+          options.onComparisonCeiling,
+          options.maxComparisonsPerKind,
+        );
+        if (isErr(scored)) {
+          return err(scored.error);
+        }
+        return ok({
+          edges: scored.data.edges,
+          warnings: scored.data.warnings.map(
+            (warning) => `[${kind}] ${warning.message}`,
+          ),
+          baseMembers: kindBaseMembers,
+        });
+      },
+    ),
+  );
+
+  for (const result of perKind) {
+    if (isErr(result)) {
+      return err(result.error);
+    }
+    allEdges.push(...result.data.edges);
+    warnings.push(...result.data.warnings);
+    baseMembers.push(...result.data.baseMembers);
+  }
+
+  return ok({
+    // The ONE shared `(a, b)` edge comparator (id-first `(kind, id)` order), so this
+    // stage emits edges in exactly the order clustering consumes them.
+    edges: allEdges.sort((left, right) => compareCandidateEdges(left, right)),
+    warnings,
+    // Total order over the composite `(kind, id)` identity (two same-id/different-kind
+    // base members would tie under a bare-id compare).
+    baseMembers: baseMembers.sort((left, right) =>
+      compareMergeKeys(mergeKeyOf(left), mergeKeyOf(right)),
+    ),
+  });
+}
+
+/**
+ * Builds, per cluster, the {@link ClusterMember} contributions. A staged new node
+ * contributes one member per branch that staged it (so a cross-branch property
+ * disagreement surfaces as a conflict in the union, T8); a committed BASE node the
+ * cluster pulled in contributes one `origin: "base"` member, carrying the reserved
+ * {@link BASE_PROVENANCE_BRANCH} so it gap-fills the property union and survivor
+ * selection can enforce base-id-wins (§6.4-C).
+ */
+function clusterMembersFor(
+  cluster: ClusterResult,
+  newNodesById: ReadonlyMap<MergeKey, readonly StagedNewNode[]>,
+  baseMembersById: ReadonlyMap<MergeKey, BaseMember>,
+): readonly ClusterMember[] {
+  const members: ClusterMember[] = [];
+  for (const key of cluster.members) {
+    for (const staged of newNodesById.get(key) ?? []) {
+      members.push({
+        origin: "staged",
+        id: staged.node.id,
+        kind: staged.node.kind,
+        branchId: staged.branchId,
+        props: staged.node.props as Readonly<Record<string, JsonValue>>,
+      });
+    }
+    const base = baseMembersById.get(key);
+    if (base !== undefined) {
+      members.push({
+        origin: "base",
+        id: base.id,
+        kind: base.kind,
+        branchId: BASE_PROVENANCE_BRANCH,
+        props: base.props,
+      });
+    }
+  }
+  return members;
+}
+
+/**
+ * Indexes the staged new nodes by id (preserving the per-id branch list), so
+ * clustering / canonicalization can pull every branch's contribution for a node.
+ */
+function indexNewNodesById(
+  staging: StagingSet,
+): ReadonlyMap<MergeKey, readonly StagedNewNode[]> {
+  const index = new Map<MergeKey, StagedNewNode[]>();
+  for (const items of staging.newNodesByKind.values()) {
+    for (const staged of items) {
+      const key = mergeKeyOf(staged.node);
+      const bucket = index.get(key);
+      if (bucket === undefined) {
+        index.set(key, [staged]);
+      } else {
+        bucket.push(staged);
+      }
+    }
+  }
+  return index;
+}
+
+/**
+ * Flattens the staged NEW edges plus the surviving inherited MODIFIED edges into
+ * the {@link StagedEdge} shape the repoint phase (T9) consumes (parsed props +
+ * branch tag). Inherited edges that were not modified by any branch are unchanged
+ * in the base and need no re-commit, so only modified inherited edges are folded
+ * in here alongside the new edges.
+ *
+ * The modified inherited edges are the RECONCILED ones (one per id, 3-way merged
+ * against base by {@link reconcileEdgeModifications}) — NOT the raw per-branch
+ * `staging.modifiedEdges`. Staging each branch's full fork props separately would
+ * make the repoint union treat unchanged-from-base fields as conflicts, dropping a
+ * disjoint edit by another branch.
+ */
+function buildStagedEdges(
+  staging: StagingSet,
+  modifiedEdges: readonly StagedModifiedEdge[],
+): readonly StagedEdge[] {
+  const staged: StagedEdge[] = [];
+  for (const items of staging.newEdgesByKind.values()) {
+    for (const item of items) {
+      staged.push(toStagedEdge(item.branchId, item));
+    }
+  }
+  for (const item of modifiedEdges) {
+    staged.push({
+      id: item.edge.id,
+      kind: item.edge.kind,
+      fromId: item.edge.fromId,
+      toId: item.edge.toId,
+      fromKind: item.edge.fromKind,
+      toKind: item.edge.toKind,
+      props: item.edge.forkProps as Readonly<Record<string, JsonValue>>,
+      branchId: item.branchId,
+    });
+  }
+  return staged;
+}
+
+/** Projects a {@link StagedNewEdge} onto the repoint-phase {@link StagedEdge}. */
+function toStagedEdge(branchId: BranchId, item: StagedNewEdge): StagedEdge {
+  return {
+    id: item.edge.id,
+    kind: item.edge.kind,
+    fromId: item.edge.fromId,
+    toId: item.edge.toId,
+    fromKind: item.edge.fromKind,
+    toKind: item.edge.toKind,
+    props: item.edge.props as Readonly<Record<string, JsonValue>>,
+    branchId,
+  };
+}
+
+/**
+ * Builds the report-only, in-memory provenance index from the full record list.
+ * `byBranch(id)` answers which merged node / edge ids that branch contributed to:
+ * a node id when the branch staged a new node that survived into a cluster's
+ * canonical (or a surviving modification), an edge id when the branch staged an
+ * edge that survived the repoint/dedupe. Collapses the records — which ALSO carry
+ * each contribution's `sourceId` for the persisted sidecar — to deduped, sorted id
+ * sets per branch (the unchanged report-only shape).
+ */
+function buildProvenanceIndex(
+  records: readonly ProvenanceRecord[],
+): ProvenanceIndex {
+  const byBranch = new Map<
+    BranchId,
+    Readonly<{ nodeIds: Set<AnyNodeId>; edgeIds: Set<string> }>
+  >();
+  for (const record of records) {
+    let entry = byBranch.get(record.branchId);
+    if (entry === undefined) {
+      entry = { nodeIds: new Set(), edgeIds: new Set() };
+      byBranch.set(record.branchId, entry);
+    }
+    if (record.role === "node") {
+      entry.nodeIds.add(record.canonicalId as AnyNodeId);
+    } else {
+      entry.edgeIds.add(record.canonicalId);
+    }
+  }
+
+  const frozen = new Map<BranchId, BranchProvenance>();
+  for (const [branchId, sets] of byBranch) {
+    frozen.set(branchId, {
+      nodeIds: [...sets.nodeIds].sort((left, right) =>
+        compareStrings(left, right),
+      ),
+      edgeIds: [...sets.edgeIds]
+        .sort((left, right) => compareStrings(left, right))
+        .map((id) => id as Edge["id"]),
+    });
+  }
+  return {
+    byBranch: (branchId: BranchId): BranchProvenance =>
+      frozen.get(branchId) ?? { nodeIds: [], edgeIds: [] },
+  };
+}
+
+/**
+ * Appends a branch's contribution of a CANONICAL node id (`role: "node"`) or a
+ * SURVIVING edge id (`role: "edge"`), keeping its source.
+ */
+function pushProvenance(
+  records: ProvenanceRecord[],
+  role: ProvenanceRecord["role"],
+  branchId: BranchId,
+  canonicalId: string,
+  canonicalKind: string,
+  sourceId: string,
+): void {
+  records.push({ role, canonicalId, canonicalKind, branchId, sourceId });
+}
+
+/**
+ * Empty per-branch trust weights — the fallback when the caller supplies no
+ * {@link MergeOptions.provenanceWeights}. With empty weights the
+ * `"provenanceWeighted"` policy degrades to the stable branch order (its
+ * documented tie-break), i.e. `"lastWriteWins"` semantics.
+ */
+const EMPTY_WEIGHTS: ProvenanceWeights = new Map<BranchId, number>();
+
+/**
+ * The fully-resolved (pre-commit) merge plan: everything the commit applies plus
+ * everything the report records. Separated from the commit so the commit body is
+ * a thin, mechanical application of an already-decided plan.
+ *
+ * Exported so the commit path can be unit-tested in isolation (e.g. proving that a
+ * canonical entity whose id is an already-committed base node UPDATES that row and
+ * repoints edges onto it, rather than inserting a duplicate — §6.2).
+ */
+export type MergePlan<G extends GraphDef> = Readonly<{
+  canonicalEntities: readonly CanonicalEntity[];
+  survivingModifications: readonly StagedModifiedNode[];
+  nodeDeletions: ReadonlyMap<MergeKey, string>;
+  edgeDeletions: ReadonlyMap<MergeKey, string>;
+  mergedEdges: readonly MergedEdge[];
+  // Base props of every inherited edge a fork MODIFIED, keyed by edge id. The
+  // commit drops props a fork removed (a base key absent from the merged edge's
+  // props) via {@link commitModificationProps} — edges, like nodes, are written
+  // with PATCH semantics, so a removed key would otherwise survive. New edges
+  // (never inherited) are absent from this map and need no deletion handling.
+  inheritedEdgeBaseProps: ReadonlyMap<
+    EdgeId,
+    Readonly<Record<string, unknown>>
+  >;
+  retypeMap: ReadonlyMap<MergeKey, string>;
+  resolutions: readonly EntityResolution[];
+  propertyConflicts: readonly PropertyConflict<G>[];
+  deleteModifyConflicts: readonly DeleteModifyConflict[];
+  typeReconciliations: readonly TypeReconciliation[];
+  dropped: readonly DroppedItem[];
+  baseAmbiguities: readonly BaseAmbiguity[];
+  provenanceRecords: readonly ProvenanceRecord[];
+  warnings: readonly string[];
+}>;
+
+/**
+ * Resolves the entire merge into a {@link MergePlan} WITHOUT touching the target.
+ * Pure composition of the T3–T10 phases over the staged union; every step is
+ * order-independent given the captured `branchRank`.
+ */
+function planMerge<G extends GraphDef>(
+  staging: StagingSet,
+  candidateEdges: readonly CandidateEdge[],
+  candidateWarnings: readonly string[],
+  baseMembers: readonly BaseMember[],
+  options: NormalizedMergeOptions<G>,
+  branchRank: ReadonlyMap<BranchId, number>,
+  subClassClosure: ReturnType<typeof buildSubClassClosure>,
+  preferredBranchId?: BranchId,
+): MergePlan<G> {
+  const provenanceRecords: ProvenanceRecord[] = [];
+  // Per-branch trust weights for the `"provenanceWeighted"` policy, or empty when
+  // the caller supplied none (then the policy falls back to the stable branch order).
+  const weights = options.provenanceWeights ?? EMPTY_WEIGHTS;
+  const recordProvenance = (
+    role: ProvenanceRecord["role"],
+    branchId: BranchId,
+    canonicalId: string,
+    canonicalKind: string,
+    sourceId: string,
+  ): void => {
+    if (branchId === preferredBranchId) {
+      return;
+    }
+    pushProvenance(
+      provenanceRecords,
+      role,
+      branchId,
+      canonicalId,
+      canonicalKind,
+      sourceId,
+    );
+  };
+
+  // (4) cluster over every staged new-node id + every base member id (so a forced
+  // new↔base edge is not dropped as out-of-scope, clustering.ts:134) + the
+  // candidate edges. Base members come only from base sources, so this set is
+  // exactly the staged universe under the public snapshot path.
+  const newNodesById = indexNewNodesById(staging);
+  // A base member only belongs in the cluster universe if it actually PARTICIPATES:
+  // it got an ACCEPTED candidate edge to a staged node (a forced `baseUnique` edge, or a
+  // `baseKey`/fuzzy pair that cleared the threshold), or it shares a key with a staged
+  // node (a same-(kind, id) rediscovery, which joins by key without an edge). A `baseKey`
+  // hit whose fuzzy pair was REJECTED below threshold would otherwise be seeded as a
+  // singleton cluster and re-committed — rewriting an unrelated committed row, inflating
+  // `merged.nodes`, and recording spurious provenance under the base sentinel. Drop those
+  // orphans here, now that scoring has decided which pairs survived.
+  const acceptedEndpointKeys = new Set<MergeKey>();
+  for (const edge of candidateEdges) {
+    acceptedEndpointKeys.add(edge.a);
+    acceptedEndpointKeys.add(edge.b);
+  }
+  const baseMembersById = new Map<MergeKey, BaseMember>();
+  for (const member of baseMembers) {
+    const key = mergeKeyOf(member);
+    if (acceptedEndpointKeys.has(key) || newNodesById.has(key)) {
+      baseMembersById.set(key, member);
+    }
+  }
+  const newNodeIds = [...newNodesById.keys(), ...baseMembersById.keys()];
+
+  // (3b) ONTOLOGY RETYPE edges (T10 input): identity stays strictly `(kind, id)`, but
+  // under `reconcileTypes: "ontology"` two STAGED-new nodes sharing a bare id with
+  // subtype-compatible kinds are the same entity at a refined type, so they are forced
+  // into one cluster for the reconciler to collapse. Same most-specific-common-kind
+  // test the reconciler uses (so a set fuses here iff it would collapse later);
+  // staged-only (base members excluded — a committed-base retype is an inherited
+  // mutation v1 refuses); `"off"` emits nothing, leaving identity strictly `(kind,id)`.
+  const isOntology = options.reconcileTypes === "ontology";
+  const preferKind =
+    isOntology ?
+      (kinds: readonly string[]): string | undefined =>
+        mostSpecificCommonKind(subClassClosure, kinds)
+    : undefined;
+  const clusterEdges =
+    isOntology ?
+      [
+        ...candidateEdges,
+        ...ontologyRetypeEdges(
+          newNodesById.keys(),
+          (kinds) =>
+            mostSpecificCommonKind(subClassClosure, kinds) !== undefined,
+        ),
+      ]
+    : candidateEdges;
+
+  // (4) component-level BASE GUARD (§6.4-A) runs on the RAW components, BEFORE the
+  // diameter split — so a diameter guard can never sever a base↔base bridge into
+  // single-base pieces and leave the ambiguity unreported. The committed entities are
+  // always kept separate (the collapse is refused; a deliberate collapse is deferred,
+  // §6.4-C), then the optional diameter guard splits the base-contained clusters.
+  const baseIds = new Set<MergeKey>(baseMembersById.keys());
+  const guard = enforceBaseGuard(
+    connectedComponents(clusterEdges, newNodeIds),
+    clusterEdges,
+    baseIds,
+  );
+  const clusters =
+    options.clusterMaxDiameter === undefined ?
+      guard.clusters
+    : enforceDiameter(guard.clusters, clusterEdges, options.clusterMaxDiameter);
+  // The guard keys on composite `(kind, id)` identities; the public BaseAmbiguity
+  // carries them in full, so a component spanning two same-id/different-kind committed
+  // entities stays distinguishable in the report.
+  const baseAmbiguities: BaseAmbiguity[] = guard.events.map((event) => ({
+    baseIds: event.baseIds.map((key) => ({ kind: kindOf(key), id: idOf(key) })),
+    memberIds: event.memberIds.map((key) => ({
+      kind: kindOf(key),
+      id: idOf(key),
+    })),
+  }));
+
+  // (5) canonicalize each cluster: min-id survivor + commutative prop union.
+  const canonicalEntities: CanonicalEntity[] = [];
+  const resolutions: EntityResolution[] = [];
+  const propertyConflicts: PropertyConflict<G>[] = [];
+  // (7-input) the distinct member kinds per cluster, collected here so a committed
+  // BASE member's kind is part of type reconciliation — a base↔staged kind divergence
+  // (e.g. base `Doctor` vs staged `SpecialistDoctor`) must be reconciled/flagged, not
+  // dropped because base members live outside `newNodesById`.
+  const reconcileInputs: ReconcileClusterInput[] = [];
+  for (const cluster of clusters) {
+    const members = clusterMembersFor(cluster, newNodesById, baseMembersById);
+    if (members.length === 0) {
+      continue;
+    }
+    const entity = canonicalizeCluster(
+      cluster,
+      members,
+      options.onPropertyConflict as PropertyConflictPolicy,
+      branchRank,
+      weights,
+      options.canonical,
+      options.onBasePropertyConflict as PropertyConflictPolicy,
+      preferKind,
+      preferredBranchId,
+    );
+    canonicalEntities.push(entity);
+    reconcileInputs.push({
+      canonicalId: mergeKey(entity.kind, entity.canonicalId),
+      memberKinds: members.map((member) => member.kind),
+    });
+    // An EntityResolution records an actual MERGE — two or more distinct fork node
+    // IDS collapsing into one canonical. Counted by distinct BARE id (not composite
+    // identity): an ontology-retype cluster is several `(kind, id)` identities at ONE
+    // id, which is a type reconciliation (recorded separately), not an id merge. A
+    // singleton cluster records no resolution.
+    const distinctMergedIds = new Set(
+      cluster.members.map((member) => idOf(member)),
+    );
+    if (distinctMergedIds.size > 1) {
+      resolutions.push(entity.resolution);
+    }
+    // Conflicts are recorded REGARDLESS of distinct-id count: two branches can
+    // stage a new node under the SAME id with differing props, producing a genuine
+    // cross-branch conflict inside a single-id cluster. `entity.conflicts` is
+    // already gated by `resolved.conflicted`, so an agreeing single-member cluster
+    // contributes none — but a real disagreement must not be silently auto-resolved
+    // without a report entry.
+    for (const conflict of entity.conflicts) {
+      propertyConflicts.push(conflict as PropertyConflict<G>);
+    }
+    for (const member of members) {
+      recordProvenance(
+        "node",
+        member.branchId,
+        entity.canonicalId,
+        entity.kind,
+        member.id,
+      );
+    }
+  }
+
+  // (6) delete/modify resolution → authoritative final endpoint liveness.
+  const deleteModify = resolveDeleteModify(
+    staging,
+    options.onDeleteModifyConflict,
+    branchRank,
+    preferredBranchId,
+  );
+  const nodeDeletions = new Map<MergeKey, string>();
+  for (const deletion of deleteModify.nodeDeletions) {
+    nodeDeletions.set(mergeKey(deletion.kind, deletion.id), deletion.kind);
+  }
+  for (const modification of deleteModify.survivingModifications) {
+    recordProvenance(
+      "node",
+      modification.branchId,
+      modification.node.id,
+      modification.node.kind,
+      modification.node.id,
+    );
+  }
+
+  // Reconcile inherited nodes modified by 2+ branches into one merged record per
+  // id (3-way against base), surfacing genuine disagreements as PropertyConflicts
+  // instead of silently letting the last-committed branch win. Provenance above
+  // already credited every contributing branch.
+  const reconciledModifications = reconcileModifications(
+    deleteModify.survivingModifications,
+    options.onPropertyConflict as PropertyConflictPolicy,
+    branchRank,
+    weights,
+    preferredBranchId,
+  );
+  for (const conflict of reconciledModifications.conflicts) {
+    propertyConflicts.push(conflict as PropertyConflict<G>);
+  }
+
+  // (6-edge) the EDGE analogue of node delete/modify + reconcile. Inherited edge
+  // deletions are applied (previously staged but never committed, so the edge
+  // stayed live), and edges modified by 2+ branches are 3-way merged against base
+  // so disjoint edits do not false-conflict (previously each branch's full fork
+  // props were unioned, dropping a branch's independent edit). Provenance credits
+  // every modifying branch (mirrors the node push), before reconcile collapses
+  // them to one record per id.
+  const edgeDeleteModify = resolveEdgeDeleteModify(
+    staging,
+    options.onDeleteModifyConflict,
+    branchRank,
+    preferredBranchId,
+  );
+  const edgeDeletions = new Map<MergeKey, string>();
+  for (const deletion of edgeDeleteModify.edgeDeletions) {
+    edgeDeletions.set(mergeKey(deletion.kind, deletion.id), deletion.kind);
+  }
+  for (const modification of edgeDeleteModify.survivingModifications) {
+    recordProvenance(
+      "edge",
+      modification.branchId,
+      modification.edge.id,
+      modification.edge.kind,
+      modification.edge.id,
+    );
+  }
+  const reconciledEdgeModifications = reconcileEdgeModifications(
+    edgeDeleteModify.survivingModifications,
+    options.onPropertyConflict as PropertyConflictPolicy,
+    branchRank,
+    weights,
+    preferredBranchId,
+  );
+  for (const conflict of reconciledEdgeModifications.conflicts) {
+    propertyConflicts.push(conflict as PropertyConflict<G>);
+  }
+
+  // (7) opt-in ontology type reconciliation over the public-closure glue. Inputs
+  // (incl. base member kinds) were collected per cluster in the canonicalize loop.
+  const reconciliation = reconcileTypes(
+    reconcileInputs,
+    subClassClosure,
+    options.reconcileTypes,
+  );
+
+  // (8) repoint every staged edge onto its cluster canonical + dedupe. Index the
+  // canonical entities by their `(kind, id)` ONCE so the per-cluster survivor
+  // lookup is O(1) — a linear scan per cluster would make the map build
+  // O(clusters × entities), quadratic over the merged-node universe.
+  const entityByIdentity = new Map<MergeKey, CanonicalEntity>();
+  for (const entity of canonicalEntities) {
+    entityByIdentity.set(mergeKey(entity.kind, entity.canonicalId), entity);
+  }
+  const canonicalOf = buildCanonicalMap(clusters, (cluster) =>
+    pickClusterCanonical(cluster, entityByIdentity),
+  );
+  const stagedEdges = buildStagedEdges(
+    staging,
+    reconciledEdgeModifications.survivingModifications,
+  );
+  // An edge id can be staged by MORE THAN ONE branch (e.g. an inherited edge
+  // modified by two branches), so map each id to the SET of contributing branches.
+  // A plain last-write Map would credit only one branch's provenance.
+  const stagedEdgeBranches = new Map<string, Set<BranchId>>();
+  for (const staged of stagedEdges) {
+    const branches = stagedEdgeBranches.get(staged.id);
+    if (branches === undefined) {
+      stagedEdgeBranches.set(staged.id, new Set([staged.branchId]));
+    } else {
+      branches.add(staged.branchId);
+    }
+  }
+  const deletedNodeIdSet = new Set<MergeKey>(nodeDeletions.keys());
+  const repoint = repointEdges<G>(
+    stagedEdges,
+    canonicalOf,
+    deletedNodeIdSet,
+    options.onPropertyConflict,
+    branchRank,
+    weights,
+    preferredBranchId,
+  );
+  for (const merged of repoint.edges) {
+    for (const sourceId of merged.mergedIds) {
+      for (const branchId of stagedEdgeBranches.get(sourceId) ?? []) {
+        recordProvenance("edge", branchId, merged.id, merged.kind, sourceId);
+      }
+    }
+  }
+
+  const dropped: DroppedItem[] = [
+    ...deleteModify.dropped,
+    ...edgeDeleteModify.dropped,
+    ...repoint.dropped,
+    ...reconciliation.dropped,
+  ].sort((left, right) =>
+    compareStrings(`${left.kind}|${left.id}`, `${right.kind}|${right.id}`),
+  );
+
+  return {
+    canonicalEntities,
+    survivingModifications: reconciledModifications.survivingModifications,
+    nodeDeletions,
+    edgeDeletions,
+    mergedEdges: repoint.edges,
+    inheritedEdgeBaseProps: new Map(
+      reconciledEdgeModifications.survivingModifications.map((modification) => [
+        modification.edge.id,
+        modification.edge.baseProps,
+      ]),
+    ),
+    retypeMap: reconciliation.retypeMap,
+    // Order report arrays by the composite (kind, id) identity — never a bare id
+    // or a `|`-joined string. A bare id ties two different-kind entities that
+    // share an id, and a `|` separator collides on caller-supplied ids/property
+    // names that contain `|`; either makes the comparator non-total, so the
+    // returned order would depend on stable-sort + insertion order and break the
+    // order-independence the whole subsystem guarantees.
+    resolutions: resolutions.sort((left, right) =>
+      compareMergeKeys(
+        mergeKey(left.kind, left.canonicalId),
+        mergeKey(right.kind, right.canonicalId),
+      ),
+    ),
+    propertyConflicts: [...propertyConflicts, ...repoint.conflicts].sort(
+      (left, right) => {
+        const byEntity = compareMergeKeys(
+          mergeKey(left.kind, left.entityId),
+          mergeKey(right.kind, right.entityId),
+        );
+        return byEntity === 0 ?
+            compareStrings(left.property, right.property)
+          : byEntity;
+      },
+    ),
+    deleteModifyConflicts: [
+      ...deleteModify.conflicts,
+      ...edgeDeleteModify.conflicts,
+    ].sort((left, right) =>
+      compareMergeKeys(
+        mergeKey(left.kind, left.entityId),
+        mergeKey(right.kind, right.entityId),
+      ),
+    ),
+    typeReconciliations: reconciliation.reconciliations,
+    dropped,
+    baseAmbiguities: baseAmbiguities.sort((left, right) =>
+      compareMergeKeys(
+        mergeKey(left.baseIds[0]!.kind, left.baseIds[0]!.id),
+        mergeKey(right.baseIds[0]!.kind, right.baseIds[0]!.id),
+      ),
+    ),
+    provenanceRecords,
+    warnings: candidateWarnings,
+  };
+}
+
+/**
+ * The canonical survivor identity of a cluster, taken DIRECTLY from its already-resolved
+ * {@link CanonicalEntity} so edge repoint reuses the exact survivor `canonicalizeCluster`
+ * chose (base-id-wins, the `options.canonical` hook, and the most-specific-kind pick all
+ * already applied there). This is the SINGLE survivor-selection point: re-deriving it
+ * here by a second rule could split the canonical between the node write and the edge
+ * repoint, so this never re-runs the hook.
+ *
+ * Every non-empty cluster yields exactly one canonical entity whose `(kind, id)` is one
+ * of its members (the survivor is always a cluster member), so the lookup always hits;
+ * a miss is an internal invariant violation, not a fallback.
+ *
+ * `entityByIdentity` maps each canonical entity's `(kind, id)` → entity, built once by
+ * the caller, so finding a cluster's survivor is O(cluster.members) rather than a scan
+ * of every canonical entity.
+ */
+function pickClusterCanonical(
+  cluster: ClusterResult,
+  entityByIdentity: ReadonlyMap<MergeKey, CanonicalEntity>,
+): MergeKey {
+  for (const member of cluster.members) {
+    if (entityByIdentity.has(member)) {
+      return member;
+    }
+  }
+  throw new MergeError(
+    "Internal invariant: cluster has no canonical entity in pickClusterCanonical.",
+    { details: { members: cluster.members.map((member) => idOf(member)) } },
+  );
+}
+
+/**
+ * Builds the prop bag to COMMIT for an inherited modification, HONORING property
+ * deletions. A fork's `forkProps` is its full intended state, so a base property
+ * ABSENT from it was removed by that fork. The commit upsert shallow-merges the
+ * written props onto the existing (base) row, so a removed key would otherwise
+ * survive; writing it as `undefined` makes the row write drop it (the props column
+ * is JSON-serialized, which omits `undefined`), so the fork's deletion is applied
+ * instead of being silently reverted to the base value.
+ */
+function commitModificationProps(
+  baseProps: Readonly<Record<string, unknown>>,
+  forkProps: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const props: Record<string, unknown> = { ...forkProps };
+  for (const key of Object.keys(baseProps)) {
+    if (!(key in forkProps)) {
+      props[key] = undefined;
+    }
+  }
+  return props;
+}
+
+/**
+ * Applies a resolved {@link MergePlan} through a transaction's collection API.
+ * Shared by `commitPlan()` and the guarded `mergeIncremental()` commit path so
+ * both modes execute the same resolved semantics.
+ */
+async function applyMergePlan<G extends GraphDef>(
+  plan: MergePlan<G>,
+  nodesApi: TxNodes,
+  edgesApi: TxEdges,
+): Promise<Readonly<{ nodes: number; edges: number }>> {
+  // Counted by composite `(kind, id)` identity, so two different-kind nodes that
+  // share an id string each count once (and never collide in the dedupe set).
+  const committedNodeIds = new Set<MergeKey>();
+
+  // Identities written as canonical cluster entities, and the fork props of every
+  // surviving inherited modification keyed by identity. On the new-vs-base path a
+  // committed node can be BOTH a base-member cluster survivor AND an inherited
+  // modification; without coordinating the two writes the canonical upsert (built
+  // from the cluster union, which carries the OLDER base props) would clobber the
+  // modification's fork edit. We therefore fold the fork props into the canonical
+  // write and skip the standalone modification write for that identity.
+  const canonicalIdentities = new Set<MergeKey>();
+  for (const entity of plan.canonicalEntities) {
+    canonicalIdentities.add(mergeKey(entity.kind, entity.canonicalId));
+  }
+  const survivingModProps = new Map<
+    MergeKey,
+    Readonly<{
+      baseProps: Readonly<Record<string, unknown>>;
+      forkProps: Readonly<Record<string, unknown>>;
+    }>
+  >();
+  for (const modification of plan.survivingModifications) {
+    survivingModProps.set(mergeKeyOf(modification.node), {
+      baseProps: modification.node.baseProps,
+      forkProps: modification.node.forkProps,
+    });
+  }
+
+  // Surviving inherited modifications, skipping any node finally deleted OR folded
+  // into a canonical cluster write below. Property deletions the fork made are
+  // honored via {@link commitModificationProps}.
+  for (const modification of plan.survivingModifications) {
+    const identity = mergeKeyOf(modification.node);
+    if (plan.nodeDeletions.has(identity) || canonicalIdentities.has(identity)) {
+      continue;
+    }
+    const collection = nodeCollection(nodesApi, modification.node.kind);
+    await collection.upsertByIdFromRecord(
+      modification.node.id,
+      commitModificationProps(
+        modification.node.baseProps,
+        modification.node.forkProps,
+      ),
+    );
+    committedNodeIds.add(identity);
+  }
+
+  // New canonical cluster nodes (survivors), with retype cascade. When the survivor
+  // is also an inherited modification, merge the fork edit's props ON TOP of the
+  // cluster union so the explicit fork edit is not lost to the (older) base props
+  // the union carried.
+  for (const entity of plan.canonicalEntities) {
+    const identity = mergeKey(entity.kind, entity.canonicalId);
+    if (plan.nodeDeletions.has(identity)) {
+      continue;
+    }
+    const kind = plan.retypeMap.get(identity) ?? entity.kind;
+    const modification = survivingModProps.get(identity);
+    // Fold the fork edit ON TOP of the cluster union, honoring the fork's property
+    // deletions (which surface as `undefined` and so override the union's value).
+    const props =
+      modification === undefined ?
+        entity.props
+      : {
+          ...entity.props,
+          ...commitModificationProps(
+            modification.baseProps,
+            modification.forkProps,
+          ),
+        };
+    const collection = nodeCollection(nodesApi, kind);
+    await collection.upsertByIdFromRecord(entity.canonicalId, props);
+    committedNodeIds.add(mergeKey(kind, entity.canonicalId));
+  }
+
+  // Soft-delete every finally-deleted node (key encodes the kind; the value repeats
+  // it for the collection lookup).
+  for (const [identity, kind] of plan.nodeDeletions) {
+    const collection = nodeCollection(nodesApi, kind);
+    await collection.delete(idOf(identity));
+  }
+
+  // Soft-delete every finally-deleted inherited edge. These ids are disjoint from
+  // the merged-edge upserts below (deleted edges are not staged), so order is
+  // immaterial. Without this an inherited edge deleted in a branch stayed live.
+  for (const [identity, kind] of plan.edgeDeletions) {
+    await edgeCollection(edgesApi, kind).delete(idOf(identity));
+  }
+
+  // Repointed + deduped edges, grouped by kind so each kind is one batched
+  // round-trip (upsert-by-id is order-independent). The retype cascade keys on
+  // each endpoint's full `(kind, id)` identity.
+  const edgesByKind = new Map<string, EdgeUpsert[]>();
+  for (const edge of plan.mergedEdges) {
+    const fromKind = plan.retypeMap.get(mergeKey(edge.fromKind, edge.fromId));
+    const toKind = plan.retypeMap.get(mergeKey(edge.toKind, edge.toId));
+    // Honor a fork's property deletion on an inherited edge: drop base keys absent
+    // from the merged props (the edge upsert PATCH-merges, so a removed key would
+    // otherwise survive). New edges have no base entry, so their props pass through.
+    const edgeBaseProps = plan.inheritedEdgeBaseProps.get(edge.id);
+    const props =
+      edgeBaseProps === undefined ?
+        edge.props
+      : commitModificationProps(edgeBaseProps, edge.props);
+    const item: EdgeUpsert = {
+      id: edge.id,
+      from: { kind: fromKind ?? edge.fromKind, id: edge.fromId },
+      to: { kind: toKind ?? edge.toKind, id: edge.toId },
+      props,
+    };
+    const existing = edgesByKind.get(edge.kind);
+    if (existing === undefined) {
+      edgesByKind.set(edge.kind, [item]);
+    } else {
+      existing.push(item);
+    }
+  }
+  let committedEdges = 0;
+  for (const [kind, items] of edgesByKind) {
+    await edgeCollection(edgesApi, kind).bulkUpsertById(items);
+    committedEdges += items.length;
+  }
+
+  return { nodes: committedNodeIds.size, edges: committedEdges };
+}
+
+/**
+ * Applies a resolved {@link MergePlan} to the target via the typed transaction
+ * collection API. Surviving inherited modifications are upserted by id, canonical
+ * cluster nodes are upserted by id with their unioned + (optionally) retyped
+ * props, finally-deleted nodes are soft-deleted, and repointed/deduped edges are
+ * upserted by id. Returns the merged node / edge counts.
+ *
+ * UPDATE-NOT-INSERT (§6.2): every node write is an `upsertById`, so a canonical
+ * entity whose id is an ALREADY-COMMITTED base node UPDATES that committed row in
+ * place — the committed identity is stable and every edge repointed onto it (the
+ * merged edges already carry the canonical endpoint) attaches to the surviving
+ * row, never a duplicate insert. This is what lets a base member be the canonical
+ * survivor once base sources land. Exported for isolated commit-path testing.
+ */
+export async function commitPlan<G extends GraphDef>(
+  target: Store<G>,
+  plan: MergePlan<G>,
+): Promise<Readonly<{ nodes: number; edges: number }>> {
+  if (!target.backend.capabilities.transactions) {
+    throw new MergeError(
+      "merge() requires a transaction-capable target backend. The merged plan (canonical upserts, soft-deletes, edge upserts) must commit atomically; a non-transactional fallback would leave a partially-merged graph on a mid-commit failure. (mergeIncremental() enforces the same requirement.)",
+      { details: { capability: "transactions" } },
+    );
+  }
+  return target.transaction((tx) =>
+    applyMergePlan(
+      plan,
+      tx.nodes as unknown as TxNodes,
+      tx.edges as unknown as TxEdges,
+    ),
+  );
+}
+
+/**
+ * Runtime-keyed view of the transaction's node collections. The typed
+ * `tx.nodes` is keyed by the graph's concrete kinds; the orchestrator dispatches
+ * on kind STRINGS, so it indexes through this widened record. Each entry exposes
+ * the subset of the collection API the commit uses.
+ */
+type TxNodes = Record<string, NodeCollectionLike>;
+
+/** Runtime-keyed view of the transaction's edge collections. See {@link TxNodes}. */
+type TxEdges = Record<string, EdgeCollectionLike>;
+
+/** The node-collection surface the commit uses (runtime, kind-string keyed). */
+type NodeCollectionLike = Readonly<{
+  getById: (
+    id: string,
+    options?: Readonly<{ temporalMode?: "includeTombstones" }>,
+  ) => Promise<Node | undefined>;
+  getByIds: (
+    ids: readonly string[],
+    options?: Readonly<{ temporalMode?: "includeTombstones" }>,
+  ) => Promise<readonly (Node | undefined)[]>;
+  bulkCreate: (
+    items: readonly Readonly<{
+      id?: string;
+      props: Record<string, unknown>;
+    }>[],
+  ) => Promise<unknown>;
+  update: (id: string, props: Record<string, unknown>) => Promise<unknown>;
+  upsertByIdFromRecord: (
+    id: string,
+    data: Record<string, unknown>,
+  ) => Promise<unknown>;
+  delete: (id: string) => Promise<void>;
+}>;
+
+/** The edge-collection surface the commit uses (runtime, kind-string keyed). */
+type EdgeCollectionLike = Readonly<{
+  getById: (
+    id: string,
+    options?: Readonly<{ temporalMode?: "includeTombstones" }>,
+  ) => Promise<Edge | undefined>;
+  getByIds: (
+    ids: readonly string[],
+    options?: Readonly<{ temporalMode?: "includeTombstones" }>,
+  ) => Promise<readonly (Edge | undefined)[]>;
+  bulkCreate: (
+    items: readonly Readonly<{
+      id?: string;
+      from: Readonly<{ kind: string; id: string }>;
+      to: Readonly<{ kind: string; id: string }>;
+      props?: Record<string, unknown>;
+    }>[],
+  ) => Promise<unknown>;
+  bulkUpsertById: (
+    items: readonly Readonly<{
+      id: string;
+      from: Readonly<{ kind: string; id: string }>;
+      to: Readonly<{ kind: string; id: string }>;
+      props?: Record<string, unknown>;
+    }>[],
+  ) => Promise<unknown>;
+  delete: (id: string) => Promise<void>;
+}>;
+
+/** A single edge upsert payload (the element of a {@link EdgeCollectionLike} batch). */
+type EdgeUpsert = Parameters<EdgeCollectionLike["bulkUpsertById"]>[0][number];
+
+/** Resolves a node collection by kind, failing loudly on an unknown kind. */
+function nodeCollection(nodes: TxNodes, kind: string): NodeCollectionLike {
+  const collection = nodes[kind];
+  if (collection === undefined) {
+    throw new MergeError(`No node collection for kind "${kind}".`, {
+      details: { kind },
+    });
+  }
+  return collection;
+}
+
+/** Resolves an edge collection by kind, failing loudly on an unknown kind. */
+function edgeCollection(edges: TxEdges, kind: string): EdgeCollectionLike {
+  const collection = edges[kind];
+  if (collection === undefined) {
+    throw new MergeError(`No edge collection for kind "${kind}".`, {
+      details: { kind },
+    });
+  }
+  return collection;
+}
+
+/**
+ * Validates the `base@V` precondition: every branch's `base` token MUST equal the
+ * target's current base version. A mismatch means the branch forked from a
+ * divergent schema or content fingerprint, which cannot be merged safely.
+ */
+async function validateBaseVersions<G extends GraphDef>(
+  target: Store<G>,
+  branches: readonly GraphBranch<G>[],
+): Promise<Result<undefined, BaseVersionMismatchError>> {
+  const targetVersion = await computeBaseVersion(target);
+  for (const branch of branches) {
+    if (branch.base !== targetVersion) {
+      return err(
+        new BaseVersionMismatchError(
+          `Branch "${branch.id}" forked from base@V "${branch.base}", which does not match the merge target's current base@V "${targetVersion}".`,
+          {
+            details: {
+              branchId: branch.id,
+              branchBase: branch.base,
+              targetBase: targetVersion,
+            },
+          },
+        ),
+      );
+    }
+  }
+  return ok();
+}
+
+/** Normalizes options, converting an invalid-option throw into a typed result. */
+function tryNormalize<G extends GraphDef>(
+  optionsInput: MergeOptions<G>,
+): Result<NormalizedMergeOptions<G>, MergeError> {
+  try {
+    return ok(normalizeMergeOptions(optionsInput));
+  } catch (error) {
+    return err(new MergeError("Invalid merge options.", { cause: error }));
+  }
+}
+
+/**
+ * The shared resolve→commit→report pipeline behind both `merge()` (snapshot,
+ * staged-vs-staged) and `mergeAgainstBase()` (synthetic new-vs-base). It stages the
+ * union of branch diffs, generates candidates (with or without the base sources per
+ * `useBaseSources`), resolves the plan, commits, and assembles the report. The
+ * `base@V` precondition is the CALLER's responsibility — `merge()` enforces it,
+ * the synthetic scope deliberately bypasses it (§6.4-B).
+ */
+async function resolveMerge<G extends GraphDef>(
+  store: Store<G>,
+  target: Store<G>,
+  branches: readonly GraphBranch<G>[],
+  options: NormalizedMergeOptions<G>,
+  useBaseSources: boolean,
+  incremental?: IncrementalConfig,
+): Promise<Result<MergeReport<G>, MergeError>> {
+  // Reserved BranchIds are used for non-user contributions. Reject real branches
+  // that try to mint them rather than silently corrupting conflict/provenance state.
+  let targetBranchSeen = false;
+  for (const branch of branches) {
+    if (branch.id === BASE_PROVENANCE_BRANCH) {
+      return err(
+        new MergeError(
+          `Branch id "${BASE_PROVENANCE_BRANCH}" is reserved for committed-base provenance and cannot be used as a branch id.`,
+          { details: { branchId: branch.id } },
+        ),
+      );
+    }
+    if (branch.id === COMMITTED_TARGET_BRANCH) {
+      if (
+        incremental?.targetBranchId !== COMMITTED_TARGET_BRANCH ||
+        targetBranchSeen
+      ) {
+        return err(
+          new MergeError(
+            `Branch id "${COMMITTED_TARGET_BRANCH}" is reserved for the committed incremental target and cannot be used as a branch id.`,
+            { details: { branchId: branch.id } },
+          ),
+        );
+      }
+      targetBranchSeen = true;
+    }
+  }
+
+  try {
+    // (2) stage the provenance-tagged union of every branch's diff.
+    const staging = await stageBranches(store, branches);
+
+    // Capture the stable branch order ONCE (never wall-clock).
+    const preferredBranchId = incremental?.targetBranchId;
+    const branchIds = branches.map((branch) => branch.id);
+    const branchOrder =
+      preferredBranchId === undefined ?
+        (options.branchOrder ?? [])
+      : [
+          preferredBranchId,
+          ...(options.branchOrder ?? []).filter(
+            (branchId) => branchId !== preferredBranchId,
+          ),
+        ];
+    const branchRank = buildBranchRank(branchOrder, branchIds);
+
+    // Introspection snapshot: unique constraints for blocking + ontology closure.
+    const introspection = store.introspect();
+    const introspectionKinds = new Map<
+      string,
+      readonly UniqueIntrospection[]
+    >();
+    for (const kind of introspection.kinds) {
+      introspectionKinds.set(kind.name, kind.unique);
+    }
+    const subClassClosure = buildSubClassClosure(introspection.ontology);
+
+    // (3) candidate generation across every resolved kind. When an embedder is
+    // configured, precompute the STAGED texts' vectors ONCE (a batched step) so
+    // the per-pair `vector`/`hybrid` scoring is a pure in-memory cosine; base-node
+    // texts pulled into staged↔base pairs are embedded inside generateAllCandidates
+    // (they are not known until the base sources run). With no embedder,
+    // `embeddings` stays absent and a vector/hybrid kind surfaces
+    // SimilarityUnavailableError in candidate generation.
+    const embeddings =
+      options.embedder === undefined ?
+        undefined
+      : await precomputeEmbeddings(
+          newNodesByKind(staging),
+          options.resolve,
+          options.embedder,
+        );
+    const ctx: SimilarityContext = {
+      backend: store.backend,
+      ...(embeddings === undefined ? {} : { embeddings }),
+    };
+    const candidates = await generateAllCandidates(
+      target,
+      staging,
+      options,
+      introspectionKinds,
+      ctx,
+      useBaseSources,
+      options.embedder,
+    );
+    if (isErr(candidates)) {
+      return err(candidates.error);
+    }
+
+    // (4–8) resolve the whole merge into a commit-ready plan.
+    const plan = planMerge(
+      staging,
+      candidates.data.edges,
+      candidates.data.warnings,
+      candidates.data.baseMembers,
+      options,
+      branchRank,
+      subClassClosure,
+      preferredBranchId,
+    );
+
+    // (9) commit to the target. Incremental mode commits through the guarded path
+    // (the existing-target-id write guard, §6.6); snapshot mode commits directly.
+    const merged =
+      incremental === undefined ?
+        await commitPlan(target, plan)
+      : await commitIncrementalPlan(target, plan);
+
+    // (10) assemble the report. The full provenance records are always built in the
+    // plan; the in-memory index is gated by `provenance`, and on-graph persistence
+    // by `persistProvenance`.
+    const provenance: ProvenanceIndex =
+      options.provenance ?
+        buildProvenanceIndex(plan.provenanceRecords)
+      : { byBranch: () => ({ nodeIds: [], edgeIds: [] }) };
+
+    const warnings = [...plan.warnings];
+    let provenancePersisted: MergeReport<G>["provenancePersisted"];
+    if (options.persistProvenance) {
+      // POST-COMMIT, best-effort: the graph is already committed, so a provenance
+      // write failure must NOT fail the merge — it surfaces as a warning. The
+      // sidecar node ids are deterministic, so this UPSERTS (idempotent re-runs).
+      try {
+        const provenanceStore = await openProvenanceStore(
+          target.backend,
+          target.graphId,
+        );
+        const count = await persistProvenanceRecords(
+          provenanceStore,
+          target.graphId,
+          plan.provenanceRecords,
+        );
+        provenancePersisted = {
+          graphId: provenanceGraphId(target.graphId),
+          count,
+        };
+      } catch (error) {
+        warnings.push(
+          "provenance persistence failed (graph committed; provenance not persisted): " +
+            (error instanceof Error ? error.message : String(error)),
+        );
+      }
+    }
+
+    const report: MergeReport<G> = {
+      merged,
+      resolutions: plan.resolutions,
+      conflicts: plan.propertyConflicts,
+      deleteModifyConflicts: plan.deleteModifyConflicts,
+      typeReconciliations: plan.typeReconciliations,
+      dropped: plan.dropped,
+      baseAmbiguities: plan.baseAmbiguities,
+      provenance,
+      warnings,
+      ...(provenancePersisted === undefined ? {} : { provenancePersisted }),
+    };
+    return ok(report);
+  } catch (error) {
+    // A typed MergeError thrown deeper (e.g. the incremental guard's stale-overwrite
+    // refusal) carries its own precise message — surface it directly rather than
+    // masking it behind the generic wrapper, which is reserved for opaque failures
+    // (a backend error, a malformed row).
+    if (error instanceof MergeError) {
+      return err(error);
+    }
+    return err(
+      new MergeError(
+        `Merge failed while staging or committing: ${describeCause(error)}`,
+        { cause: error },
+      ),
+    );
+  }
+}
+
+/**
+ * Merges a set of branches back into a target store (design §7.2).
+ *
+ * Validates that every branch forked from the target's current `base@V`, stages
+ * the union of their diffs, resolves entities / conflicts / types through the
+ * T3–T10 phases, and commits the merged result to `target` (default: the base
+ * `store`) in a single transaction. Returns a {@link MergeReport} on success.
+ *
+ * This is the SNAPSHOT entry point: candidate generation runs the staged sources
+ * only (`exactKey`, `unique`) — it never resolves a staged node against the
+ * committed base. New-vs-base resolution is the separate {@link mergeAgainstBase}
+ * scope, which has a weaker `base@V` contract.
+ *
+ * Errors are RETURNED (never thrown) as a typed {@link MergeError} subclass:
+ * `BaseVersionMismatchError` for the precondition, `MergeError` for a
+ * comparison-ceiling overrun / commit failure, `SimilarityUnavailableError` for a
+ * `vector`/`hybrid` strategy with no configured vector strategy.
+ *
+ * @param store The base store the branches forked from. Used as the default merge
+ *   target and as the immutable diff reference.
+ * @param branches The branches to merge. ORDER DOES NOT AFFECT THE RESULT — the
+ *   report and committed graph are identical across any permutation.
+ * @param optionsInput Caller-facing {@link MergeOptions}; normalized internally.
+ */
+export async function merge<G extends GraphDef>(
+  store: Store<G>,
+  branches: readonly GraphBranch<G>[],
+  optionsInput: MergeOptions<G> = {},
+): Promise<Result<MergeReport<G>, MergeError>> {
+  const normalized = tryNormalize(optionsInput);
+  if (isErr(normalized)) {
+    return err(normalized.error);
+  }
+  const options = normalized.data;
+  const target = options.target ?? store;
+
+  // (1) base@V precondition — the snapshot contract.
+  const precondition = await validateBaseVersions(target, branches);
+  if (isErr(precondition)) {
+    return err(precondition.error);
+  }
+
+  return resolveMerge(store, target, branches, options, false);
+}
+
+/**
+ * SYNTHETIC new-vs-base merge scope (design §8 "Slice 1"). Runs the full
+ * candidate-source + scoring + reconciler pipeline WITH the base sources active —
+ * so a staged node re-discovering a committed entity resolves against it
+ * (base-id-wins, update-not-insert) — while DELIBERATELY bypassing the `base@V`
+ * snapshot precondition (§6.4-B) rather than fighting it.
+ *
+ * This is the lower-level scope the slice's mechanism is built and exercised behind
+ * (the fixed-point + determinism gates drive it directly), and it is intentionally
+ * NOT re-exported from the package barrel. The public incremental surface over it
+ * is {@link mergeIncremental} (§6.6), which adds the fork-point precondition, the
+ * keep-base pin, and the transaction-scoped existing-row guard. `merge()` and its
+ * snapshot precondition are unchanged.
+ */
+export async function mergeAgainstBase<G extends GraphDef>(
+  store: Store<G>,
+  branches: readonly GraphBranch<G>[],
+  optionsInput: MergeOptions<G> = {},
+): Promise<Result<MergeReport<G>, MergeError>> {
+  const normalized = tryNormalize(optionsInput);
+  if (isErr(normalized)) {
+    return err(normalized.error);
+  }
+  const options = normalized.data;
+  const target = options.target ?? store;
+  return resolveMerge(store, target, branches, options, true);
+}
+
+// --- mergeIncremental: full fork-point-vs-live-target entry point (§6.6) -------
+
+/** Internal config carried into {@link resolveMerge} for incremental mode. */
+type IncrementalConfig = Readonly<{
+  targetBranchId: BranchId;
+}>;
+
+/**
+ * Incremental precondition: every branch must have forked from THIS fork-point, so
+ * the fork-point diff (fork-point → branch) is honest. The analogue of
+ * {@link validateBaseVersions}, repointed from `target` to `forkPoint` (§6.6).
+ */
+async function validateForkPointVersions<G extends GraphDef>(
+  forkPoint: Store<G>,
+  branches: readonly GraphBranch<G>[],
+): Promise<Result<BaseVersion, BaseVersionMismatchError>> {
+  const forkVersion = await computeBaseVersion(forkPoint);
+  for (const branch of branches) {
+    if (branch.base !== forkVersion) {
+      return err(
+        new BaseVersionMismatchError(
+          `Branch "${branch.id}" forked from base@V "${branch.base}", which does not match the fork-point's base@V "${forkVersion}". mergeIncremental() requires every branch to have forked from the supplied forkPoint.`,
+          {
+            details: {
+              branchId: branch.id,
+              branchBase: branch.base,
+              forkPointBase: forkVersion,
+            },
+          },
+        ),
+      );
+    }
+  }
+  return ok(forkVersion);
+}
+
+/**
+ * The minimal schema surface the write guards need: a kind's Zod schema, called the
+ * SAME way the commit calls it (`safeParse`). Structural so the guard couples to the
+ * parse behaviour, not a zod version.
+ */
+type PropsSchema = Readonly<{
+  safeParse: (
+    value: unknown,
+  ) => { success: true; data: unknown } | { success: false };
+}>;
+
+type RevalidatingWriteAnalysis =
+  | Readonly<{
+      status: "valid";
+      /** Whether TypeGraph's re-validating write would change persisted bytes. */
+      storageWouldChange: boolean;
+      /** Whether declared schema fields would change, ignoring unknown stored keys. */
+      schemaWouldChange: boolean;
+      /** Whether the write would drop current props not preserved by the schema. */
+      stripsCurrentProps: boolean;
+    }>
+  | Readonly<{ status: "invalid" }>;
+
+/** The declared schema for a node kind off the public `GraphDef` registry (or none). */
+function nodeSchemaFor<G extends GraphDef>(
+  target: Store<G>,
+  kind: string,
+): PropsSchema | undefined {
+  const registry = target.graph.nodes as Record<
+    string,
+    Readonly<{ type?: Readonly<{ schema?: PropsSchema }> }> | undefined
+  >;
+  return registry[kind]?.type?.schema;
+}
+
+/** The declared schema for an edge kind off the public `GraphDef` registry (or none). */
+function edgeSchemaFor<G extends GraphDef>(
+  target: Store<G>,
+  kind: string,
+): PropsSchema | undefined {
+  const registry = target.graph.edges as Record<
+    string,
+    Readonly<{ type?: Readonly<{ schema?: PropsSchema }> }> | undefined
+  >;
+  return registry[kind]?.type?.schema;
+}
+
+/**
+ * Models TypeGraph's re-validating update semantics for one row:
+ * `schema.safeParse({...current, ...planned})`, then storing the parsed result. This
+ * is NOT used as a pre-transaction write guard anymore; `mergeIncremental()` calls it
+ * inside the target transaction to decide between create/update/skip/error.
+ */
+function analyzeRevalidatingWrite(
+  schema: PropsSchema | undefined,
+  current: Readonly<Record<string, unknown>>,
+  planned: Readonly<Record<string, unknown>>,
+): RevalidatingWriteAnalysis {
+  const merged = { ...current, ...planned };
+  if (schema === undefined) {
+    const storageWouldChange =
+      canonicalizeProps(merged) !== canonicalizeProps(current);
+    return {
+      status: "valid",
+      storageWouldChange,
+      schemaWouldChange: storageWouldChange,
+      stripsCurrentProps: false,
+    };
+  }
+
+  const currentParsed = schema.safeParse(current);
+  const mergedParsed = schema.safeParse(merged);
+  if (!currentParsed.success || !mergedParsed.success) {
+    return { status: "invalid" };
+  }
+  const normalizedCurrent = currentParsed.data as Record<string, unknown>;
+  const normalizedMerged = mergedParsed.data as Record<string, unknown>;
+  return {
+    status: "valid",
+    storageWouldChange:
+      canonicalizeProps(normalizedMerged) !== canonicalizeProps(current),
+    schemaWouldChange:
+      canonicalizeProps(normalizedMerged) !==
+      canonicalizeProps(normalizedCurrent),
+    stripsCurrentProps:
+      canonicalizeProps(normalizedCurrent) !== canonicalizeProps(current),
+  };
+}
+
+export function writeWouldChangeRow(
+  schema: PropsSchema | undefined,
+  committed: Readonly<Record<string, unknown>>,
+  planned: Readonly<Record<string, unknown>>,
+): boolean {
+  const analysis = analyzeRevalidatingWrite(schema, committed, planned);
+  return analysis.status === "valid" ? analysis.storageWouldChange : false;
+}
+
+/**
+ * Public node objects spread props at top-level. Strip TypeGraph structural keys so
+ * write comparisons operate on the persisted props bag only.
+ */
+function nodeProps(node: Node): Record<string, unknown> {
+  const props: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "id" || key === "kind" || key === "meta") continue;
+    props[key] = value;
+  }
+  return props;
+}
+
+/**
+ * Public edge objects spread props at top-level. Strip TypeGraph structural keys so
+ * write comparisons operate on the persisted props bag only.
+ */
+function edgeProps(edge: Edge): Record<string, unknown> {
+  const props: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(edge)) {
+    if (
+      key === "id" ||
+      key === "kind" ||
+      key === "fromKind" ||
+      key === "fromId" ||
+      key === "toKind" ||
+      key === "toId" ||
+      key === "meta"
+    ) {
+      continue;
+    }
+    props[key] = value;
+  }
+  return props;
+}
+
+const INCLUDE_TOMBSTONES = { temporalMode: "includeTombstones" as const };
+
+function finalEdgeFrom<G extends GraphDef>(
+  edge: MergedEdge,
+  plan: MergePlan<G>,
+) {
+  return {
+    kind:
+      plan.retypeMap.get(mergeKey(edge.fromKind, edge.fromId)) ?? edge.fromKind,
+    id: edge.fromId,
+  };
+}
+
+function finalEdgeTo<G extends GraphDef>(edge: MergedEdge, plan: MergePlan<G>) {
+  return {
+    kind: plan.retypeMap.get(mergeKey(edge.toKind, edge.toId)) ?? edge.toKind,
+    id: edge.toId,
+  };
+}
+
+function assertValidRevalidatingWrite(
+  analysis: RevalidatingWriteAnalysis,
+  message: string,
+  details: Record<string, unknown>,
+): asserts analysis is Extract<RevalidatingWriteAnalysis, { status: "valid" }> {
+  if (analysis.status === "invalid") {
+    throw new MergeError(message, { details });
+  }
+}
+
+function describeCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+type PlannedNodeWrite = Readonly<{
+  identity: MergeKey;
+  kind: string;
+  id: AnyNodeId;
+  props: Readonly<Record<string, unknown>>;
+}>;
+
+function plannedNodeWrites<G extends GraphDef>(
+  plan: MergePlan<G>,
+): readonly PlannedNodeWrite[] {
+  const canonicalIdentities = new Set<MergeKey>();
+  for (const entity of plan.canonicalEntities) {
+    canonicalIdentities.add(mergeKey(entity.kind, entity.canonicalId));
+  }
+  const survivingModProps = new Map<
+    MergeKey,
+    Readonly<Record<string, unknown>>
+  >();
+  for (const modification of plan.survivingModifications) {
+    survivingModProps.set(
+      mergeKeyOf(modification.node),
+      modification.node.forkProps,
+    );
+  }
+
+  const writes: PlannedNodeWrite[] = [];
+  for (const modification of plan.survivingModifications) {
+    const identity = mergeKeyOf(modification.node);
+    if (plan.nodeDeletions.has(identity) || canonicalIdentities.has(identity)) {
+      continue;
+    }
+    writes.push({
+      identity,
+      kind: modification.node.kind,
+      id: modification.node.id,
+      props: modification.node.forkProps,
+    });
+  }
+  for (const entity of plan.canonicalEntities) {
+    const sourceIdentity = mergeKey(entity.kind, entity.canonicalId);
+    if (plan.nodeDeletions.has(sourceIdentity)) {
+      continue;
+    }
+    const kind = plan.retypeMap.get(sourceIdentity) ?? entity.kind;
+    const forkProps = survivingModProps.get(sourceIdentity);
+    writes.push({
+      identity: mergeKey(kind, entity.canonicalId),
+      kind,
+      id: entity.canonicalId,
+      props:
+        forkProps === undefined ?
+          entity.props
+        : { ...entity.props, ...forkProps },
+    });
+  }
+  return writes;
+}
+
+function edgeWriteSignature<G extends GraphDef>(
+  edge: MergedEdge,
+  plan: MergePlan<G>,
+): string {
+  const from = finalEdgeFrom(edge, plan);
+  const to = finalEdgeTo(edge, plan);
+  return JSON.stringify([
+    edge.kind,
+    from.kind,
+    from.id,
+    to.kind,
+    to.id,
+    canonicalizeProps(edge.props),
+  ]);
+}
+
+async function validateIncrementalNodeWrites<G extends GraphDef>(
+  target: Store<G>,
+  nodesApi: TxNodes,
+  plan: MergePlan<G>,
+): Promise<void> {
+  const writes = plannedNodeWrites(plan);
+  const nodeIdsByKind = new Map<string, AnyNodeId[]>();
+  for (const write of writes) {
+    const bucket = nodeIdsByKind.get(write.kind) ?? [];
+    bucket.push(write.id);
+    nodeIdsByKind.set(write.kind, bucket);
+  }
+
+  const currentByIdentity = new Map<MergeKey, Node | undefined>();
+  for (const [kind, ids] of nodeIdsByKind) {
+    const rows = await nodeCollection(nodesApi, kind).getByIds(
+      ids,
+      INCLUDE_TOMBSTONES,
+    );
+    for (const [index, id] of ids.entries()) {
+      currentByIdentity.set(mergeKey(kind, id), rows[index]);
+    }
+  }
+
+  for (const write of writes) {
+    const current = currentByIdentity.get(write.identity);
+    if (current === undefined) {
+      continue;
+    }
+    if (current.meta.deletedAt !== undefined) {
+      throw new MergeError(
+        `mergeIncremental() would resurrect soft-deleted committed node "${write.id}" (kind "${write.kind}").`,
+        { details: { id: write.id, kind: write.kind } },
+      );
+    }
+    const analysis = analyzeRevalidatingWrite(
+      nodeSchemaFor(target, write.kind),
+      nodeProps(current),
+      write.props,
+    );
+    assertValidRevalidatingWrite(
+      analysis,
+      `mergeIncremental() found an existing committed node "${write.id}" (kind "${write.kind}") whose current props do not validate against the active schema.`,
+      { id: write.id, kind: write.kind },
+    );
+    if (analysis.stripsCurrentProps && analysis.schemaWouldChange) {
+      throw new MergeError(
+        `mergeIncremental() would update committed node "${write.id}" (kind "${write.kind}") but the write would strip existing props outside the active schema (lossy base update).`,
+        { details: { id: write.id, kind: write.kind } },
+      );
+    }
+  }
+}
+
+async function validateIncrementalEdgeWrites<G extends GraphDef>(
+  target: Store<G>,
+  edgesApi: TxEdges,
+  plan: MergePlan<G>,
+): Promise<void> {
+  const signatureById = new Map<EdgeId, string>();
+  for (const edge of plan.mergedEdges) {
+    const signature = edgeWriteSignature(edge, plan);
+    const existing = signatureById.get(edge.id);
+    if (existing !== undefined && existing !== signature) {
+      throw new MergeError(
+        `mergeIncremental() would overwrite committed edge "${edge.id}" with multiple planned endpoint/prop shapes (edge.id collision).`,
+        { details: { id: edge.id } },
+      );
+    }
+    signatureById.set(edge.id, signature);
+  }
+
+  // Bucket the planned edges by their PLANNED kind and fetch each kind's ids in a
+  // single round-trip. An edge belongs to exactly one kind, so this does O(edges)
+  // lookups instead of scanning EVERY schema edge kind for every id (the old
+  // O(edgeKinds × edges) fan-out that held the write lock far longer than needed).
+  const plannedKindById = new Map<EdgeId, string>();
+  const idsByKind = new Map<string, EdgeId[]>();
+  for (const edge of plan.mergedEdges) {
+    if (plannedKindById.has(edge.id)) {
+      continue; // shape already deduped by the signature guard above
+    }
+    plannedKindById.set(edge.id, edge.kind);
+    const bucket = idsByKind.get(edge.kind) ?? [];
+    bucket.push(edge.id);
+    idsByKind.set(edge.kind, bucket);
+  }
+  const existingById = new Map<string, Edge>();
+  for (const [kind, ids] of idsByKind) {
+    const rows = await edgeCollection(edgesApi, kind).getByIds(
+      ids,
+      INCLUDE_TOMBSTONES,
+    );
+    for (const [index, id] of ids.entries()) {
+      const row = rows[index];
+      if (row !== undefined) {
+        existingById.set(id, row);
+      }
+    }
+  }
+
+  // Cross-kind collision guard: edge ids are GLOBALLY unique, so an id NOT found
+  // under its planned kind may still be committed under a DIFFERENT kind — a silent
+  // overwrite hazard. Scan the schema's edge kinds for ONLY those not-found ids,
+  // through the transaction's collections (never `target.backend`, whose separate
+  // connection would deadlock against the tx-held one). An update-only merge finds
+  // every edge in the bucketed pass above, so this fallback is empty.
+  const notFound = [...plannedKindById.keys()]
+    .filter((id) => !existingById.has(id))
+    .sort((left, right) => compareStrings(left, right));
+  if (notFound.length > 0) {
+    const perKind = await Promise.all(
+      Object.keys(target.graph.edges).map((kind) =>
+        edgeCollection(edgesApi, kind).getByIds(notFound, INCLUDE_TOMBSTONES),
+      ),
+    );
+    const crossKindById = new Map<string, Edge>();
+    for (const rows of perKind) {
+      for (const [index, id] of notFound.entries()) {
+        const row = rows[index];
+        if (row !== undefined && !crossKindById.has(id)) {
+          crossKindById.set(id, row);
+        }
+      }
+    }
+    for (const id of notFound) {
+      const row = crossKindById.get(id);
+      if (row === undefined) {
+        continue;
+      }
+      if (row.meta.deletedAt !== undefined) {
+        throw new MergeError(
+          `mergeIncremental() would resurrect soft-deleted committed edge "${id}" (kind "${row.kind}").`,
+          { details: { id, committedKind: row.kind } },
+        );
+      }
+      throw new MergeError(
+        `mergeIncremental() would overwrite committed edge "${id}" (kind "${row.kind}") with a different-kind edge "${plannedKindById.get(id)!}" of the same id.`,
+        {
+          details: {
+            id,
+            committedKind: row.kind,
+            plannedKind: plannedKindById.get(id)!,
+          },
+        },
+      );
+    }
+  }
+
+  for (const edge of plan.mergedEdges) {
+    const current = existingById.get(edge.id);
+    if (current === undefined) {
+      continue;
+    }
+    // `current` was fetched under `edge.kind`, so its kind matches by construction;
+    // a different committed kind for this id is caught by the cross-kind guard above.
+    if (current.meta.deletedAt !== undefined) {
+      throw new MergeError(
+        `mergeIncremental() would resurrect soft-deleted committed edge "${edge.id}" (kind "${current.kind}").`,
+        { details: { id: edge.id, committedKind: current.kind } },
+      );
+    }
+
+    const from = finalEdgeFrom(edge, plan);
+    const to = finalEdgeTo(edge, plan);
+    if (
+      current.fromId !== from.id ||
+      current.fromKind !== from.kind ||
+      current.toId !== to.id ||
+      current.toKind !== to.kind
+    ) {
+      throw new MergeError(
+        `mergeIncremental() would overwrite committed edge "${edge.id}" (kind "${edge.kind}") with different endpoints.`,
+        { details: { id: edge.id, kind: edge.kind } },
+      );
+    }
+
+    const analysis = analyzeRevalidatingWrite(
+      edgeSchemaFor(target, edge.kind),
+      edgeProps(current),
+      edge.props,
+    );
+    assertValidRevalidatingWrite(
+      analysis,
+      `mergeIncremental() found an existing committed edge "${edge.id}" (kind "${edge.kind}") whose current props do not validate against the active schema.`,
+      { id: edge.id, kind: edge.kind },
+    );
+    if (analysis.stripsCurrentProps && analysis.schemaWouldChange) {
+      throw new MergeError(
+        `mergeIncremental() would update committed edge "${edge.id}" (kind "${edge.kind}") but the write would strip existing props outside the active schema.`,
+        { details: { id: edge.id, kind: edge.kind } },
+      );
+    }
+  }
+}
+
+/**
+ * The full incremental commit path (§6.6). The planner has already folded the live
+ * target in as a preferred synthetic branch, so this path preflights destructive
+ * row hazards inside the target transaction and then applies the normal merge plan.
+ */
+async function commitIncrementalPlan<G extends GraphDef>(
+  target: Store<G>,
+  plan: MergePlan<G>,
+): Promise<Readonly<{ nodes: number; edges: number }>> {
+  if (!target.backend.capabilities.transactions) {
+    throw new MergeError(
+      "mergeIncremental() requires a transaction-capable target backend. Incremental writes must preflight existing rows and commit atomically; non-transactional fallback would allow partial graph writes.",
+      { details: { capability: "transactions" } },
+    );
+  }
+
+  return target.transaction(async (tx) => {
+    const nodesApi = tx.nodes as unknown as TxNodes;
+    const edgesApi = tx.edges as unknown as TxEdges;
+    await validateIncrementalNodeWrites(target, nodesApi, plan);
+    await validateIncrementalEdgeWrites(target, edgesApi, plan);
+    return applyMergePlan(plan, nodesApi, edgesApi);
+  });
+}
+
+/**
+ * Incremental merge — the public fork-point-vs-live-target entry point (design
+ * §6.4-B / §6.6). It treats `forkPoint` as the immutable ancestor, folds the live
+ * `target` in as a preferred committed branch, resolves branch additions against
+ * committed rows, and propagates inherited node/edge modifications and deletions
+ * through the same three-way merge planner.
+ *
+ * Object-form args so the two same-typed stores (`forkPoint`, `target`) cannot be
+ * swapped. `options.target` is ignored — `target` is the explicit arg.
+ *
+ * Preconditions (typed errors): every branch forked from `forkPoint`
+ * (`branch.base === computeBaseVersion(forkPoint)`); `forkPoint` and `target` share a
+ * schema hash (schema drift is fatal; target CONTENT may have advanced); and
+ * `onBasePropertyConflict` is `"flag"` (keep-base for committed-row conflicts).
+ */
+export async function mergeIncremental<G extends GraphDef>(
+  args: MergeIncrementalArguments<G>,
+): Promise<Result<MergeReport<G>, MergeError>> {
+  const { forkPoint, target, branches } = args;
+
+  const normalized = tryNormalize(args.options ?? {});
+  if (isErr(normalized)) {
+    return err(normalized.error);
+  }
+  const options = normalized.data;
+
+  // Keep-base pin: committed rows remain authoritative under unresolved base
+  // conflicts. A non-keep-base policy would let a stale branch value overwrite a
+  // newer committed value.
+  if (options.onBasePropertyConflict !== "flag") {
+    return err(
+      new MergeError(
+        'mergeIncremental() requires onBasePropertyConflict: "flag" (keep-base); a non-keep-base policy could overwrite a newer committed base value with a stale branch value.',
+        { details: {} },
+      ),
+    );
+  }
+
+  // Every branch must have forked from THIS fork-point (honest diff).
+  const forkPrecondition = await validateForkPointVersions(forkPoint, branches);
+  if (isErr(forkPrecondition)) {
+    return err(forkPrecondition.error);
+  }
+  const forkVersion = forkPrecondition.data;
+
+  // Schema half of base@V stays a hard precondition; target CONTENT may advance.
+  const [forkSchema, targetSchema] = await Promise.all([
+    computeSchemaComponent(forkPoint),
+    computeSchemaComponent(target),
+  ]);
+  if (forkSchema !== targetSchema) {
+    return err(
+      new MergeError(
+        "mergeIncremental() requires target and forkPoint to share a schema; schema drift is not supported (the target content may differ — only the schema must match).",
+        { details: {} },
+      ),
+    );
+  }
+
+  const targetBranch: GraphBranch<G> = {
+    id: COMMITTED_TARGET_BRANCH,
+    base: forkVersion,
+    store: target,
+  };
+  return resolveMerge(
+    forkPoint,
+    target,
+    [targetBranch, ...branches],
+    options,
+    true,
+    { targetBranchId: COMMITTED_TARGET_BRANCH },
+  );
+}

--- a/packages/typegraph/src/graph-merge/node-key.ts
+++ b/packages/typegraph/src/graph-merge/node-key.ts
@@ -1,0 +1,105 @@
+/**
+ * The composite MERGE IDENTITY key for a node: the pair `(kind, id)`.
+ *
+ * TypeGraph node identity is the PAIR `(kind, id)` — a bare id string is NOT unique
+ * on its own (a `Patient` and an `Encounter` may both carry the id "x" as two
+ * DISTINCT committed nodes; ids are caller-supplied). Every place the merge pipeline
+ * groups, clusters, de-dupes, repoints, retypes, or deletes BY NODE IDENTITY must
+ * key on this pair — never the bare id — or two different-kind nodes that happen to
+ * share an id string silently fuse into one cluster (wrong merge, dropped node,
+ * incoherent commit) and the §6.4-A base guard is bypassed.
+ *
+ * Represented as a NUL-joined string (a branded {@link MergeKey}) so it doubles as a
+ * `Map`/`Set` key and a deterministic ordering key. `kind` is a schema identifier
+ * (NUL-free), so the FIRST NUL unambiguously delimits kind from id even when a
+ * caller-supplied id itself contains a NUL byte. This matches the `(kind, id)`
+ * separator the commit-time write guard already uses.
+ *
+ * {@link compareMergeKeys} orders by the bare id FIRST (kind only breaks a same-id
+ * tie), so the merge's "minimum-id survivor" / id-sorted-members semantics are
+ * preserved unchanged for the common single-kind cluster — the composite key changes
+ * WHICH nodes share an identity, never the ordering among genuinely distinct ids.
+ */
+
+import type { NodeId, NodeType } from "./typegraph-internal";
+
+/** The `(kind, id)` separator: a NUL byte (0x00), absent from schema kind names. */
+const SEPARATOR = String.fromCharCode(0);
+
+/** A node id in its untyped (`NodeType`-default) branded form. */
+type AnyNodeId = NodeId<NodeType>;
+
+/**
+ * A composite `(kind, id)` node-identity key. Branded so it cannot be confused with
+ * a bare {@link NodeId} at the type level — the whole point is that the two are NOT
+ * interchangeable as identities.
+ */
+export type MergeKey = string & { readonly __mergeKey: unique symbol };
+
+/** Builds the composite identity key for a `(kind, id)` pair. */
+export function mergeKey(kind: string, id: string): MergeKey {
+  // `kindOf`/`idOf` split on the FIRST NUL, so a NUL in `kind` would alias distinct
+  // identities (`mergeKey("a\0b","c") === mergeKey("a","b\0c")`), silently fusing
+  // unrelated nodes into one cluster and bypassing the §6.4-A base guard this composite
+  // key exists to protect. Kinds are NUL-free schema identifiers; fail loud if not.
+  if (kind.includes(SEPARATOR)) {
+    throw new Error(
+      `Node kind ${JSON.stringify(kind)} contains a NUL byte, which collides the (kind, id) merge-identity separator.`,
+    );
+  }
+  return `${kind}${SEPARATOR}${id}` as MergeKey;
+}
+
+/**
+ * Lexicographic comparator over two strings (node/edge ids, kinds, property names,
+ * bucket keys, branches). The single shared total-order primitive the merge pipeline's
+ * deterministic sorts are built on.
+ */
+export function compareStrings(left: string, right: string): number {
+  return (
+    left < right ? -1
+    : left > right ? 1
+    : 0
+  );
+}
+
+/** Builds the composite identity key for any object carrying a `kind` and `id`. */
+export function mergeKeyOf(
+  node: Readonly<{ kind: string; id: string }>,
+): MergeKey {
+  return mergeKey(node.kind, node.id);
+}
+
+/** The kind component of a {@link MergeKey}. */
+export function kindOf(key: MergeKey): string {
+  const separator = key.indexOf(SEPARATOR);
+  return separator === -1 ? key : key.slice(0, separator);
+}
+
+/** The bare node id component of a {@link MergeKey}. */
+export function idOf(key: MergeKey): AnyNodeId {
+  const separator = key.indexOf(SEPARATOR);
+  return (separator === -1 ? key : key.slice(separator + 1)) as AnyNodeId;
+}
+
+/**
+ * Deterministic comparator over two merge keys, BARE ID first and kind only as a
+ * same-id tie-break. This keeps the merge's minimum-id survivor selection and
+ * id-sorted member order identical to the pre-composite behaviour for any pair of
+ * genuinely distinct ids (the overwhelmingly common case), so the re-key changes
+ * identity grouping without perturbing deterministic ordering.
+ */
+export function compareMergeKeys(left: MergeKey, right: MergeKey): number {
+  const leftId = idOf(left);
+  const rightId = idOf(right);
+  if (leftId !== rightId) {
+    return leftId < rightId ? -1 : 1;
+  }
+  const leftKind = kindOf(left);
+  const rightKind = kindOf(right);
+  return (
+    leftKind < rightKind ? -1
+    : leftKind > rightKind ? 1
+    : 0
+  );
+}

--- a/packages/typegraph/src/graph-merge/options.ts
+++ b/packages/typegraph/src/graph-merge/options.ts
@@ -1,0 +1,305 @@
+/**
+ * Validation + default-application for {@link MergeOptions}.
+ *
+ * The zod schema validates the scalar / enum surface (thresholds, ceilings,
+ * enums) and applies the frozen P0 defaults. Function- and store-valued fields
+ * (`canonical`, a function `onPropertyConflict`, `target`, per-kind `block` /
+ * `custom.score`, `branchOrder`) are not meaningfully validatable by zod, so they
+ * are threaded through unchanged after the scalar surface validates.
+ *
+ * `normalizeMergeOptions` is the single entry point: it returns a
+ * {@link NormalizedMergeOptions} with every default resolved, so downstream
+ * phases never branch on `undefined`.
+ */
+
+import { z } from "zod";
+
+import type { GraphDef } from "./typegraph-internal";
+import type {
+  BranchId,
+  ComparisonCeilingPolicy,
+  DeleteModifyPolicy,
+  Embedder,
+  MergeOptions,
+  PropertyConflictPolicy,
+  ReconcileTypesMode,
+  ResolveConfig,
+  ResolvedCluster,
+  ResolveMap,
+} from "./types";
+
+/**
+ * Frozen P0 defaults. Exported so tests and downstream phases assert against the
+ * same constants rather than re-typing literals.
+ */
+export const MERGE_OPTION_DEFAULTS = {
+  reconcileTypes: "off",
+  onPropertyConflict: "flag",
+  onBasePropertyConflict: "flag",
+  onDeleteModifyConflict: "flag",
+  onComparisonCeiling: "error",
+  provenance: true,
+  persistProvenance: false,
+} as const satisfies Readonly<{
+  reconcileTypes: ReconcileTypesMode;
+  onPropertyConflict: "flag";
+  onBasePropertyConflict: "flag";
+  onDeleteModifyConflict: DeleteModifyPolicy;
+  onComparisonCeiling: ComparisonCeilingPolicy;
+  provenance: boolean;
+  persistProvenance: boolean;
+}>;
+
+/**
+ * zod schema for the STRING arm of `onPropertyConflict`. The field is a union of
+ * this enum and a function; the function arm is not validatable by zod, but the
+ * string arm is — and validating it here keeps `onPropertyConflict` consistent with
+ * every other enum option, so a bad string fails with a clean option error rather
+ * than an opaque `TypeError` deep inside conflict resolution.
+ */
+const propertyConflictPolicySchema = z.enum([
+  "flag",
+  "lastWriteWins",
+  "provenanceWeighted",
+]);
+
+/** zod schema for a single resolve config's scalar surface (the threshold). */
+const resolveConfigScalarSchema = z.object({
+  threshold: z
+    .number()
+    .min(0, { message: "threshold must be >= 0" })
+    .max(1, { message: "threshold must be <= 1" }),
+});
+
+/**
+ * zod schema for the scalar / enum surface of {@link MergeOptions}. Function- and
+ * store-valued fields are deliberately omitted (validated structurally by the
+ * type system, not at runtime) and re-attached after parsing.
+ */
+const mergeOptionsScalarSchema = z.object({
+  reconcileTypes: z
+    .enum(["ontology", "off"])
+    .default(MERGE_OPTION_DEFAULTS.reconcileTypes),
+  onDeleteModifyConflict: z
+    .enum(["deleteWins", "modifyWins", "flag"])
+    .default(MERGE_OPTION_DEFAULTS.onDeleteModifyConflict),
+  onComparisonCeiling: z
+    .enum(["error", "mergeByIdOnly"])
+    .default(MERGE_OPTION_DEFAULTS.onComparisonCeiling),
+  provenance: z.boolean().default(MERGE_OPTION_DEFAULTS.provenance),
+  persistProvenance: z
+    .boolean()
+    .default(MERGE_OPTION_DEFAULTS.persistProvenance),
+  maxComparisonsPerKind: z
+    .number()
+    .int({ message: "maxComparisonsPerKind must be an integer" })
+    .min(0, { message: "maxComparisonsPerKind must be >= 0" })
+    .optional(),
+  clusterMaxDiameter: z
+    .number()
+    .positive({ message: "clusterMaxDiameter must be positive" })
+    .optional(),
+});
+
+/**
+ * Fully-normalized merge options: every default resolved, the (validated)
+ * pass-through fields attached. Downstream phases consume this, never the raw
+ * {@link MergeOptions}.
+ */
+export type NormalizedMergeOptions<G extends GraphDef = GraphDef> = Readonly<{
+  // Internal kind-agnostic view: the public {@link ResolveMap} is keyed per-kind,
+  // but downstream phases index it by a runtime kind STRING, so the normalized
+  // form widens to a plain record. Unknown keys were already validated away.
+  resolve: Readonly<Record<string, ResolveConfig<G>>>;
+  reconcileTypes: ReconcileTypesMode;
+  onPropertyConflict: PropertyConflictPolicy<G>;
+  onBasePropertyConflict: PropertyConflictPolicy<G>;
+  onDeleteModifyConflict: DeleteModifyPolicy;
+  onComparisonCeiling: ComparisonCeilingPolicy;
+  provenance: boolean;
+  persistProvenance: boolean;
+  canonical?: (
+    cluster: ResolvedCluster,
+  ) => ReturnType<NonNullable<MergeOptions<G>["canonical"]>>;
+  embedder?: Embedder;
+  target?: MergeOptions<G>["target"];
+  maxComparisonsPerKind?: number;
+  clusterMaxDiameter?: number;
+  branchOrder?: readonly BranchId[];
+  provenanceWeights?: ReadonlyMap<BranchId, number>;
+}>;
+
+/**
+ * Validates the STRING arm of a property-conflict policy (the function arm is not
+ * validatable by zod), throwing a clean option error for an unknown enum value.
+ * Shared by `onPropertyConflict` and the separate `onBasePropertyConflict`.
+ */
+function validatePropertyConflictPolicy<G extends GraphDef>(
+  policy: PropertyConflictPolicy<G>,
+  label: string,
+): PropertyConflictPolicy<G> {
+  if (
+    typeof policy === "string" &&
+    !propertyConflictPolicySchema.safeParse(policy).success
+  ) {
+    throw new Error(
+      `Invalid ${label} "${policy}": expected "flag", "lastWriteWins", "provenanceWeighted", or a function.`,
+    );
+  }
+  return policy;
+}
+
+/**
+ * Validates each per-kind resolve config's threshold, leaving the strategy and
+ * `block` function untouched. Returns the same map shape (resolve configs are
+ * passed through; only their scalar surface is validated).
+ */
+function validateResolveMap<G extends GraphDef>(
+  resolve: ResolveMap<G> | undefined,
+): Readonly<Record<string, ResolveConfig<G>>> {
+  if (resolve === undefined) {
+    return {};
+  }
+  // The public ResolveMap binds each kind's config to that kind's NodeType;
+  // validation only reads the kind-agnostic scalar surface, so widen to a plain
+  // record (the per-kind block/similarity types are sound at every call site).
+  const configs = resolve as unknown as Readonly<
+    Record<string, ResolveConfig<G>>
+  >;
+  const validated: Record<string, ResolveConfig<G>> = {};
+  for (const [kind, config] of Object.entries(configs)) {
+    const parsed = resolveConfigScalarSchema.safeParse({
+      threshold: config.threshold,
+    });
+    if (!parsed.success) {
+      throw new Error(
+        `Invalid resolve config for kind "${kind}": ${parsed.error.message}`,
+      );
+    }
+    if (
+      config.keyless !== undefined &&
+      (!Number.isInteger(config.keyless.window) || config.keyless.window < 1)
+    ) {
+      throw new Error(
+        `Invalid resolve config for kind "${kind}": keyless.window must be a positive integer, got ${config.keyless.window}.`,
+      );
+    }
+    const strategy = config.similarity;
+    if (strategy.kind === "hybrid") {
+      for (const component of ["vector", "fulltext"] as const) {
+        const weight = strategy.weights?.[component];
+        if (weight !== undefined && (!Number.isFinite(weight) || weight < 0)) {
+          throw new Error(
+            `Invalid resolve config for kind "${kind}": similarity.weights.${component} must be a finite number >= 0, got ${String(weight)}.`,
+          );
+        }
+      }
+    }
+    validated[kind] = config;
+  }
+  return validated;
+}
+
+/**
+ * Validates the optional `"provenanceWeighted"` trust weights: every weight must
+ * be a finite number `>= 0`, since a NaN / negative weight would corrupt the
+ * highest-weight pick. Returns the same map.
+ */
+function validateProvenanceWeights(
+  weights: ReadonlyMap<BranchId, number>,
+): ReadonlyMap<BranchId, number> {
+  for (const [branchId, weight] of weights) {
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new Error(
+        `Invalid provenanceWeights for branch "${branchId}": weight must be a finite number >= 0, got ${String(weight)}.`,
+      );
+    }
+  }
+  return weights;
+}
+
+/**
+ * Validates and normalizes {@link MergeOptions}, applying every P0 default.
+ *
+ * Throws (not a `Result`) on invalid scalar input — option validation is a
+ * caller-boundary concern, surfaced as a thrown error per project conventions;
+ * `merge()` converts it back to a typed `MergeError` at its own boundary.
+ *
+ * @throws if a threshold is outside `[0, 1]`, `maxComparisonsPerKind` is
+ *   negative/non-integer, or `clusterMaxDiameter` is non-positive.
+ */
+export function normalizeMergeOptions<G extends GraphDef>(
+  options: MergeOptions<G> = {},
+): NormalizedMergeOptions<G> {
+  const scalar = mergeOptionsScalarSchema.parse({
+    reconcileTypes: options.reconcileTypes,
+    onDeleteModifyConflict: options.onDeleteModifyConflict,
+    onComparisonCeiling: options.onComparisonCeiling,
+    provenance: options.provenance,
+    persistProvenance: options.persistProvenance,
+    ...(options.maxComparisonsPerKind === undefined ?
+      {}
+    : { maxComparisonsPerKind: options.maxComparisonsPerKind }),
+    ...(options.clusterMaxDiameter === undefined ?
+      {}
+    : { clusterMaxDiameter: options.clusterMaxDiameter }),
+  });
+
+  const onPropertyConflict = validatePropertyConflictPolicy(
+    options.onPropertyConflict ?? MERGE_OPTION_DEFAULTS.onPropertyConflict,
+    "onPropertyConflict",
+  );
+  // DELIBERATELY does not fall back to `onPropertyConflict` — base↔branch conflicts
+  // must not silently inherit a staged policy that could overwrite committed data.
+  const onBasePropertyConflict = validatePropertyConflictPolicy(
+    options.onBasePropertyConflict ??
+      MERGE_OPTION_DEFAULTS.onBasePropertyConflict,
+    "onBasePropertyConflict",
+  );
+
+  const provenanceWeights =
+    options.provenanceWeights === undefined ?
+      undefined
+    : validateProvenanceWeights(options.provenanceWeights);
+
+  // "provenanceWeighted" without weights would silently degrade to a
+  // stable-branch-order (lastWriteWins) resolution and quietly commit a
+  // different graph. Fail loudly instead so the misconfiguration is visible.
+  const usesProvenanceWeighting =
+    onPropertyConflict === "provenanceWeighted" ||
+    onBasePropertyConflict === "provenanceWeighted";
+  if (
+    usesProvenanceWeighting &&
+    (provenanceWeights === undefined || provenanceWeights.size === 0)
+  ) {
+    throw new Error(
+      'A "provenanceWeighted" property-conflict policy requires a non-empty provenanceWeights map.',
+    );
+  }
+
+  return {
+    resolve: validateResolveMap(options.resolve),
+    reconcileTypes: scalar.reconcileTypes,
+    onPropertyConflict,
+    onBasePropertyConflict,
+    onDeleteModifyConflict: scalar.onDeleteModifyConflict,
+    onComparisonCeiling: scalar.onComparisonCeiling,
+    provenance: scalar.provenance,
+    persistProvenance: scalar.persistProvenance,
+    ...(options.canonical === undefined ?
+      {}
+    : { canonical: options.canonical }),
+    ...(options.embedder === undefined ? {} : { embedder: options.embedder }),
+    ...(options.target === undefined ? {} : { target: options.target }),
+    ...(scalar.maxComparisonsPerKind === undefined ?
+      {}
+    : { maxComparisonsPerKind: scalar.maxComparisonsPerKind }),
+    ...(scalar.clusterMaxDiameter === undefined ?
+      {}
+    : { clusterMaxDiameter: scalar.clusterMaxDiameter }),
+    ...(options.branchOrder === undefined ?
+      {}
+    : { branchOrder: options.branchOrder }),
+    ...(provenanceWeights === undefined ? {} : { provenanceWeights }),
+  };
+}

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -1,0 +1,178 @@
+/**
+ * Sidecar provenance graph — durable, queryable `{branch, sourceId}` → canonical
+ * tagging for a merge (open-item #5: "on-graph provenance persistence").
+ *
+ * The merge's in-memory {@link import("./types").ProvenanceIndex}
+ * (`report.provenance.byBranch`) evaporates after the call. This module persists the
+ * same contributions as TYPED nodes in a SIDECAR graph on the SAME backend as the
+ * merge target — a separate graph (its own `graphId`-namespaced tables), so the
+ * user's domain schema is untouched. It is a faithful prototype of a future
+ * first-class TypeGraph `annotations` primitive (see `docs/design/annotations.md`).
+ *
+ * Persistence is POST-COMMIT and best-effort, by design: the merge's commit path is
+ * unchanged and stays on the same public store/backend contracts. Provenance is derived and
+ * re-runnable, and the node ids are DETERMINISTIC (a hash of `{targetGraphId, role,
+ * canonicalKind, canonicalId, branchId, sourceId}`), so re-merging the same forks UPSERTS rather
+ * than duplicating. Atomic-in-the-merge-transaction is a possible upgrade later
+ * (TypeGraph's cross-store `withTransaction`), deliberately deferred for v1.
+ */
+
+import { z } from "zod";
+
+import { compareStrings } from "./node-key";
+import type { GraphBackend, Node, Store } from "./typegraph-internal";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  sha256Hex,
+} from "./typegraph-internal";
+import type { BranchId, ProvenanceRecord } from "./types";
+
+/** The Provenance node: one row per `{branch, sourceId}` → canonical contribution. */
+const Provenance = defineNode("Provenance", {
+  schema: z.object({
+    targetGraphId: z.string(),
+    role: z.enum(["node", "edge"]),
+    canonicalId: z.string(),
+    canonicalKind: z.string(),
+    branchId: z.string(),
+    sourceId: z.string(),
+  }),
+});
+
+/**
+ * Derives the sidecar graph id for a target graph. Suffixing the target's own id
+ * keeps each target graph's provenance in its own `graphId`-namespaced tables on a
+ * shared backend, while a single `Provenance` schema serves all of them.
+ */
+export function provenanceGraphId(targetGraphId: string): string {
+  return `${targetGraphId}::merge-provenance`;
+}
+
+/** Builds the sidecar provenance graph definition for a target graph. */
+function buildProvenanceGraph(targetGraphId: string) {
+  return defineGraph({
+    id: provenanceGraphId(targetGraphId),
+    nodes: { Provenance: { type: Provenance } },
+    edges: {},
+  });
+}
+
+/** The concrete sidecar provenance graph type. */
+export type ProvenanceGraph = ReturnType<typeof buildProvenanceGraph>;
+
+/** A persisted provenance node (the queryable record). */
+export type ProvenanceNode = Node<typeof Provenance>;
+
+/**
+ * Opens — materializing the schema if needed — the provenance store for a target
+ * graph on the given backend. Idempotent: safe to call before every persist/query,
+ * and shares the backend with the target (so the caller must NOT close it
+ * separately — closing the shared backend is the target owner's job).
+ */
+export async function openProvenanceStore(
+  backend: GraphBackend,
+  targetGraphId: string,
+): Promise<Store<ProvenanceGraph>> {
+  const [store] = await createStoreWithSchema(
+    buildProvenanceGraph(targetGraphId),
+    backend,
+  );
+  return store;
+}
+
+/** Null byte — cannot occur in a normal id, so an unambiguous tuple separator. */
+const ID_SEPARATOR = "\0";
+
+/** Bytes of the SHA-256 digest kept (128 bits — collision-safe for provenance). */
+const ID_DIGEST_BYTES = 16;
+
+/**
+ * Deterministic provenance node id: a hash of the contribution tuple, so
+ * re-persisting the same contribution UPSERTS the same row (idempotent re-runs).
+ *
+ * Uses the shared {@link sha256Hex} (Web Crypto) instead of `node:crypto` so the
+ * `graph-merge` entry point stays importable on every runtime the library
+ * targets (Cloudflare Workers, Deno, browsers) — `base-version.ts` already hashes
+ * its content fingerprint the same way.
+ */
+export async function provenanceNodeId(
+  targetGraphId: string,
+  record: ProvenanceRecord,
+): Promise<string> {
+  const tuple = [
+    targetGraphId,
+    record.role,
+    // canonicalKind is part of node identity: two contributions to different-kind
+    // canonicals that share a bare id (e.g. base Patient:x and Encounter:x) must NOT
+    // hash to the same sidecar row and clobber each other (the (kind,id) identity model).
+    record.canonicalKind,
+    record.canonicalId,
+    record.branchId,
+    record.sourceId,
+  ].join(ID_SEPARATOR);
+  const digest = await sha256Hex(tuple, ID_DIGEST_BYTES);
+  return `prov_${digest}`;
+}
+
+/**
+ * Upserts one `Provenance` node per record into the sidecar store, keyed by the
+ * deterministic id (re-running the same merge is a no-op upsert, never a
+ * duplicate). Returns the row count written. The caller wraps this for best-effort
+ * behavior — a failure here must not fail an already-committed merge.
+ */
+export async function persistProvenanceRecords(
+  store: Store<ProvenanceGraph>,
+  targetGraphId: string,
+  records: readonly ProvenanceRecord[],
+): Promise<number> {
+  if (records.length === 0) {
+    return 0;
+  }
+  const items = await Promise.all(
+    records.map(async (record) => ({
+      id: await provenanceNodeId(targetGraphId, record),
+      props: {
+        targetGraphId,
+        role: record.role,
+        canonicalId: record.canonicalId,
+        canonicalKind: record.canonicalKind,
+        branchId: record.branchId,
+        sourceId: record.sourceId,
+      },
+    })),
+  );
+  await store.nodes.Provenance.bulkUpsertById(items);
+  return items.length;
+}
+
+/** Filter for {@link readProvenance}. Each field, when set, narrows the result. */
+export type ProvenanceQuery = Readonly<{
+  branchId?: BranchId | string;
+  canonicalId?: string;
+  role?: "node" | "edge";
+}>;
+
+/**
+ * Reads persisted provenance back, filtered and stably ordered. The sidecar is a
+ * normal typed graph, so this is a thin ergonomic wrapper over
+ * `store.nodes.Provenance.find()` (filtered in memory — provenance volumes are
+ * modest; a query-builder `where` is the scale path). Answers "which canonical
+ * entities did branch X contribute to?" and "who contributed canonical Y?".
+ */
+export async function readProvenance(
+  store: Store<ProvenanceGraph>,
+  query: ProvenanceQuery = {},
+): Promise<readonly ProvenanceNode[]> {
+  const all = await store.nodes.Provenance.find();
+  return all
+    .filter(
+      (node) =>
+        (query.branchId === undefined || node.branchId === query.branchId) &&
+        (query.canonicalId === undefined ||
+          node.canonicalId === query.canonicalId) &&
+        (query.role === undefined || node.role === query.role),
+    )
+    .sort((left, right) => compareStrings(left.id, right.id));
+}

--- a/packages/typegraph/src/graph-merge/result.ts
+++ b/packages/typegraph/src/graph-merge/result.ts
@@ -1,0 +1,1 @@
+export { err, isErr, isOk, ok, type Result, unwrap } from "../utils/result";

--- a/packages/typegraph/src/graph-merge/scoring.ts
+++ b/packages/typegraph/src/graph-merge/scoring.ts
@@ -1,0 +1,236 @@
+/**
+ * The shared SCORING stage (design §4, the single match-decision point).
+ *
+ * Candidate generation is three layers — sources → scoring → reconciler (§4).
+ * This module is the MIDDLE layer: it turns the candidate PROPOSALS every source
+ * emits into the {@link CandidateEdge} set the reconciler consumes, applying the
+ * EXACT same scorer + threshold regardless of which source proposed a pair. A
+ * source proposes (recall); scoring disposes (the match decision).
+ *
+ * Two proposal kinds enter:
+ *
+ *   - {@link CandidatePair}s — unscored `(a, b)` node pairs from any source. They
+ *     are deduped by canonical `(a, b)` and each scored EXACTLY ONCE by
+ *     {@link scorePair}; only pairs clearing the kind's threshold become edges.
+ *   - FORCED {@link CandidateEdge}s — DEFINITIONAL matches (a shared unique value)
+ *     that BYPASS scoring entirely, emitted at {@link FORCED_MATCH_SCORE}. A forced
+ *     pair is never also fuzzy-scored: forced `(a, b)` keys are reserved first, so
+ *     a fuzzy pair proposing the same endpoints is dropped before scoring.
+ *
+ * This was previously fused into `candidate-gen.ts`'s `generateCandidates` (which
+ * scored AND thresholded inline); naming scoring as its own stage is what makes
+ * "the scorer — not a source — decides matches" concrete (§4). `generateCandidates`
+ * now composes the bucket sources over this stage.
+ *
+ * Determinism: the emitted edge set is a pure function of the proposal SETS — pairs
+ * are deduped by canonical `(a, b)`, scored by the symmetric {@link scorePair}, and
+ * the final list is sorted by `(a, b)`, so neither the order proposals arrive in
+ * nor the directionality of a pair affects the result.
+ *
+ * The {@link ComparisonCeilingPolicy} bounds only the FUZZY scoring work (the
+ * embedder step for vector/hybrid); FORCED edges are definitional, not
+ * similarity-based, so they are emitted regardless of the ceiling:
+ *
+ *   - `"error"`         — exceeding the ceiling fails with a typed {@link MergeError}.
+ *   - `"mergeByIdOnly"` — fuzzy similarity is SKIPPED for the kind (no
+ *                         threshold-scored edges), FORCED edges are still emitted,
+ *                         and a {@link CandidateWarning} is recorded.
+ */
+
+import { MergeError } from "./errors";
+import { compareMergeKeys, type MergeKey } from "./node-key";
+import type { Result } from "./result";
+import { err, isErr, ok } from "./result";
+import type { SimilarityContext } from "./similarity";
+import { createPairScorer } from "./similarity";
+import type { Node, NodeType } from "./typegraph-internal";
+import type { ComparisonCeilingPolicy, ResolveConfig } from "./types";
+
+/**
+ * An undirected candidate-merge edge between two nodes that should merge.
+ * Endpoints are stored in ascending id order (`a < b`) so the edge has a single
+ * canonical representation. Fuzzy edges carry their similarity score; FORCED
+ * (definitional) edges carry {@link FORCED_MATCH_SCORE}.
+ */
+export type CandidateEdge = Readonly<{
+  a: MergeKey;
+  b: MergeKey;
+  score: number;
+}>;
+
+/**
+ * A non-fatal advisory raised during scoring — currently only the
+ * `"mergeByIdOnly"` comparison-ceiling skip. Surfaced in the merge report.
+ */
+type CandidateWarning = Readonly<{
+  kind: "comparisonCeiling";
+  comparisons: number;
+  limit: number;
+  message: string;
+}>;
+
+/**
+ * The scoring result for one kind: the emitted edges plus any advisories.
+ * Returned inside a {@link Result} so the `vector`/`hybrid` guard and the
+ * `"error"` ceiling path can fail without throwing.
+ */
+export type CandidateGenResult = Readonly<{
+  edges: readonly CandidateEdge[];
+  warnings: readonly CandidateWarning[];
+}>;
+
+/**
+ * An unscored candidate pair a source proposes for scoring: the canonical
+ * endpoint ids `(a, b)` (`a < b`) plus the two node objects the scorer reads
+ * fields off of. `left`/`right` carry the nodes whose ids are `a`/`b`
+ * respectively, but {@link scorePair} is symmetric so their roles are
+ * interchangeable for scoring.
+ */
+export type CandidatePair<K extends NodeType = NodeType> = Readonly<{
+  a: MergeKey;
+  b: MergeKey;
+  left: Node<K>;
+  right: Node<K>;
+}>;
+
+/**
+ * The proposals the scoring stage consumes for one kind: the fuzzy pairs to score
+ * and the forced (definitional) edges to pass through unscored.
+ */
+export type ScoringInput<K extends NodeType = NodeType> = Readonly<{
+  pairs: readonly CandidatePair<K>[];
+  forcedEdges: readonly CandidateEdge[];
+}>;
+
+/**
+ * Score for a FORCED (definitional, unique-match) edge — the maximum, so the pair
+ * always clears any threshold and is never the weakest edge a diameter guard would
+ * drop. Sources that emit forced edges stamp this score; scoring passes it through.
+ */
+export const FORCED_MATCH_SCORE = 1;
+
+/**
+ * Stable `(a, b)` ascending comparator over {@link CandidateEdge}. Endpoints are
+ * `(kind, id)` MergeKeys, so ordering uses the SAME id-first {@link compareMergeKeys}
+ * the clustering stage uses — never raw kind-first string order. The SINGLE shared
+ * definition: clustering and `merge()`'s candidate generation import this instead of
+ * re-deriving it, so every stage orders the edge set identically by construction.
+ */
+export function compareCandidateEdges(
+  left: CandidateEdge,
+  right: CandidateEdge,
+): number {
+  const byA = compareMergeKeys(left.a, right.a);
+  return byA === 0 ? compareMergeKeys(left.b, right.b) : byA;
+}
+
+/** The canonical dedup key for a pair / edge's ordered endpoints. */
+function endpointKey(a: MergeKey, b: MergeKey): string {
+  return JSON.stringify([a, b]);
+}
+
+/**
+ * Scores the proposed candidates for a single kind into a {@link CandidateEdge}
+ * set, applying the kind's threshold and the comparison-ceiling policy.
+ *
+ * FORCED endpoint keys are reserved FIRST, so a fuzzy pair proposing the same
+ * `(a, b)` is dropped before scoring — a forced (definitional) match is never also
+ * fuzzy-scored. The remaining fuzzy pairs are deduped by canonical `(a, b)` and
+ * scored exactly once; only those clearing `threshold` become edges. The combined
+ * forced + passing-fuzzy edge list is sorted by `(a, b)`.
+ *
+ * @param input The fuzzy pairs + forced edges every source proposed for the kind.
+ * @param resolveConfig The kind's resolution config (similarity strategy + threshold).
+ * @param ctx Ambient context (the backend, for vector-capability gating).
+ * @param ceilingPolicy Behavior when `maxComparisonsPerKind` is exceeded.
+ * @param maxComparisonsPerKind Optional per-kind FUZZY-comparison ceiling.
+ *   `undefined` means unbounded. Forced edges are never bounded by it.
+ * @returns `ok({ edges, warnings })`, or `err(...)` when the `"error"` ceiling
+ *   fires or a `vector`/`hybrid` guard trips.
+ */
+export function scoreCandidates<K extends NodeType>(
+  input: ScoringInput<K>,
+  resolveConfig: ResolveConfig,
+  ctx: SimilarityContext,
+  ceilingPolicy: ComparisonCeilingPolicy,
+  maxComparisonsPerKind?: number,
+): Result<CandidateGenResult, MergeError> {
+  const { similarity, threshold } = resolveConfig;
+
+  // Reserve forced endpoint keys FIRST so a fuzzy pair proposing the same pair is
+  // dropped — a definitional match is never also fuzzy-scored (the old Phase-1
+  // before Phase-2 dedup, now source-agnostic).
+  const seen = new Set<string>();
+  const forced: CandidateEdge[] = [];
+  for (const edge of input.forcedEdges) {
+    const key = endpointKey(edge.a, edge.b);
+    if (!seen.has(key)) {
+      seen.add(key);
+      forced.push(edge);
+    }
+  }
+
+  const fuzzy: CandidatePair<K>[] = [];
+  for (const pair of input.pairs) {
+    const key = endpointKey(pair.a, pair.b);
+    if (!seen.has(key)) {
+      seen.add(key);
+      fuzzy.push(pair);
+    }
+  }
+
+  if (
+    maxComparisonsPerKind !== undefined &&
+    fuzzy.length > maxComparisonsPerKind
+  ) {
+    if (ceilingPolicy === "error") {
+      return err(
+        new MergeError(
+          `Comparison ceiling exceeded: ${fuzzy.length} candidate pairs > maxComparisonsPerKind ${maxComparisonsPerKind}.`,
+          {
+            details: {
+              comparisons: fuzzy.length,
+              limit: maxComparisonsPerKind,
+            },
+            suggestion:
+              'Tighten the kind\'s block() to shrink buckets, or set onComparisonCeiling: "mergeByIdOnly".',
+          },
+        ),
+      );
+    }
+    // "mergeByIdOnly": skip FUZZY similarity for this kind, but KEEP the forced
+    // edges — those are definitional, not similarity-based.
+    return ok({
+      edges: [...forced].sort((left, right) =>
+        compareCandidateEdges(left, right),
+      ),
+      warnings: [
+        {
+          kind: "comparisonCeiling",
+          comparisons: fuzzy.length,
+          limit: maxComparisonsPerKind,
+          message: `Skipped similarity for this kind: ${fuzzy.length} candidate pairs exceeded maxComparisonsPerKind ${maxComparisonsPerKind}; nodes will merge by id and exact unique match only.`,
+        },
+      ],
+    });
+  }
+
+  // One memoized scorer per kind so each node's text + trigram multiset is built
+  // once, not once per pair it joins (the within-bucket pair count is ~O(n²)).
+  const scorer = createPairScorer<K>(similarity, ctx);
+  const edges: CandidateEdge[] = [...forced];
+  for (const { left, right, a, b } of fuzzy) {
+    const scored = scorer(a, left, b, right);
+    if (isErr(scored)) {
+      return err(scored.error);
+    }
+    if (scored.data >= threshold) {
+      edges.push({ a, b, score: scored.data });
+    }
+  }
+
+  return ok({
+    edges: edges.sort((left, right) => compareCandidateEdges(left, right)),
+    warnings: [],
+  });
+}

--- a/packages/typegraph/src/graph-merge/similarity.ts
+++ b/packages/typegraph/src/graph-merge/similarity.ts
@@ -1,0 +1,570 @@
+/**
+ * Pluggable, symmetric candidate-pair similarity scoring (design §8, T6).
+ *
+ * Four strategy kinds, two of which are the ZERO-EMBEDDING P0 default:
+ *
+ *   - `custom`   — the caller's own `score(a, b)` function, clamped to `[0, 1]`.
+ *   - `fulltext` — an IN-MEMORY Sørensen–Dice trigram coefficient over the
+ *                  configured `fields` of the two staged nodes. No embeddings,
+ *                  no DB round-trips, identical across every backend. This is
+ *                  the portable scorer the FHIR demo runs on.
+ *   - `vector` / `hybrid` — REAL embeddings scored IN MEMORY. An injected
+ *                  {@link import("./types").Embedder} (precomputed by `merge()`
+ *                  into `ctx.embeddings`, a text→vector lookup) turns each node's
+ *                  configured field text into a vector; the pair is scored by
+ *                  cosine. `vector` is pure cosine over one field; `hybrid` blends
+ *                  cosine with the Dice trigram by `weights` (default 0.5 / 0.5).
+ *                  Staged candidate rows are unindexed, so a backend ANN index
+ *                  cannot score them pairwise — exact in-memory cosine is the right
+ *                  tool at candidate-dedup scale AND is deterministic (the merge
+ *                  contract). With NO embedder configured (`ctx.embeddings`
+ *                  absent), scoring fails with a typed
+ *                  {@link SimilarityUnavailableError}.
+ *
+ * IMPORTANT: this module never touches `store.search.fulltext`. Staged candidate
+ * nodes are unindexed in the working copy, so the DB fulltext index cannot score
+ * them; the in-memory Dice scorer is the only correct option for staged
+ * candidate generation. `store.search.fulltext` is reserved for the T11 parity
+ * probe.
+ *
+ * Symmetry is a load-bearing invariant: clustering treats candidate edges as
+ * undirected, so `scorePair(a, b)` MUST equal `scorePair(b, a)`. The Dice
+ * coefficient is symmetric by construction; the `custom` branch documents the
+ * requirement and the caller is responsible for honoring it.
+ */
+
+import { canonicalValueKey } from "./canonical-props";
+import { SimilarityUnavailableError } from "./errors";
+import type { MergeKey } from "./node-key";
+import type { Result } from "./result";
+import { err, ok } from "./result";
+import type {
+  GraphBackend,
+  JsonValue,
+  Node,
+  NodeType,
+} from "./typegraph-internal";
+import type { SimilarityStrategy } from "./types";
+
+/**
+ * Ambient context a scorer needs beyond the two nodes.
+ *
+ * - `backend` is carried for diagnostics (the dialect in error details).
+ * - `embeddings` is the precomputed text→vector lookup `merge()` builds by running
+ *   the injected {@link import("./types").Embedder} over every staged field text of
+ *   the `vector`/`hybrid` kinds. Its PRESENCE means an embedder was configured;
+ *   its ABSENCE makes a `vector`/`hybrid` strategy fail with
+ *   {@link SimilarityUnavailableError}. `fulltext`/`custom` never read it.
+ */
+export type SimilarityContext = Readonly<{
+  backend: GraphBackend;
+  embeddings?: ReadonlyMap<string, Float32Array>;
+}>;
+
+/** Lower bound of the similarity codomain. */
+const MIN_SCORE = 0;
+
+/** Upper bound of the similarity codomain. */
+const MAX_SCORE = 1;
+
+/**
+ * Sub-threshold sentinel returned by {@link scorePrepared} for a pair with NO
+ * comparable text (one side has no value in the scoring field). It is BELOW
+ * {@link MIN_SCORE}, and the kind's `threshold` is validated to `[0, 1]`, so a
+ * textless pair can never clear ANY threshold — including `threshold: 0`, where
+ * a `MIN_SCORE` (0) return would otherwise pass `score >= threshold` and merge two
+ * distinct entities that share no evidence. The standalone {@link scorePair}
+ * surfaces this as `MIN_SCORE` to keep its `[0, 1]` contract; only candidate-gen
+ * (via {@link createPairScorer} + the threshold gate) treats it as "never a match".
+ */
+const NO_EVIDENCE_SCORE = -1;
+
+/** Trigram window length for the Sørensen–Dice coefficient. */
+const TRIGRAM_LENGTH = 3;
+
+/**
+ * Padding character framing a normalized string before trigram extraction, so
+ * leading/trailing characters are weighted like interior ones and very short
+ * strings still produce trigrams. A space is conventional and cannot appear in a
+ * trigram alongside itself for non-trivial inputs.
+ */
+const TRIGRAM_PAD = " ";
+
+/**
+ * Clamps an arbitrary number into the `[0, 1]` similarity codomain. `NaN`
+ * collapses to {@link MIN_SCORE} so a misbehaving custom scorer can never inject
+ * a non-comparable score into clustering.
+ */
+function clampScore(value: number): number {
+  if (Number.isNaN(value)) {
+    return MIN_SCORE;
+  }
+  if (value < MIN_SCORE) {
+    return MIN_SCORE;
+  }
+  if (value > MAX_SCORE) {
+    return MAX_SCORE;
+  }
+  return value;
+}
+
+/**
+ * Reads a single schema field off a node. `Node<N>` spreads its schema
+ * properties at the top level (e.g. `node.name`, not `node.props.name`), so a
+ * field is indexed directly on the node.
+ */
+function readField(node: Node<NodeType>, field: string): unknown {
+  return (node as unknown as Record<string, unknown>)[field];
+}
+
+/**
+ * Concatenates a node's configured `fields` into a single lowercase comparison
+ * string. Non-string field values are coerced via `String(...)`; absent /
+ * `undefined` fields contribute nothing. Fields are joined with a space so two
+ * adjacent fields cannot fuse into a spurious cross-field trigram.
+ *
+ * Exported so `merge()`'s embedding precompute keys the text→vector lookup by the
+ * EXACT same text `scorePair` looks up — there is a single source of truth for "the
+ * text of a node under a strategy's fields", so the precompute and the scorer can
+ * never disagree on what to embed.
+ */
+export function fieldText(
+  node: Node<NodeType>,
+  fields: readonly string[],
+): string {
+  const parts: string[] = [];
+  for (const field of fields) {
+    const value = readField(node, field);
+    if (value === undefined || value === null) {
+      continue;
+    }
+    parts.push(stringifyFieldValue(value));
+  }
+  return parts.join(TRIGRAM_PAD).toLowerCase();
+}
+
+function stringifyFieldValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  // Objects/arrays: canonical (recursively key-sorted) JSON so two
+  // logically-equal values written with different key order yield the same
+  // comparison text — matching canonicalValueKey used everywhere else.
+  return canonicalValueKey(value as JsonValue);
+}
+
+/**
+ * Extracts the trigram MULTISET of a normalized string as a count map. A
+ * multiset (not a set) is required so repeated trigrams contribute their full
+ * multiplicity to the Dice intersection, matching the standard Sørensen–Dice
+ * formulation `2·|A∩B| / (|A|+|B|)` over bags.
+ */
+function trigramMultiset(text: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  if (text.length === 0) {
+    return counts;
+  }
+  const padded = `${TRIGRAM_PAD}${text}${TRIGRAM_PAD}`;
+  for (let index = 0; index + TRIGRAM_LENGTH <= padded.length; index += 1) {
+    const gram = padded.slice(index, index + TRIGRAM_LENGTH);
+    counts.set(gram, (counts.get(gram) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Total cardinality (with multiplicity) of a trigram multiset. */
+function multisetSize(counts: Map<string, number>): number {
+  let total = 0;
+  for (const count of counts.values()) {
+    total += count;
+  }
+  return total;
+}
+
+/**
+ * Multiset intersection cardinality: for every shared trigram, the lesser of
+ * the two multiplicities.
+ */
+function multisetIntersectionSize(
+  left: Map<string, number>,
+  right: Map<string, number>,
+): number {
+  let shared = 0;
+  for (const [gram, leftCount] of left) {
+    const rightCount = right.get(gram);
+    if (rightCount !== undefined) {
+      shared += Math.min(leftCount, rightCount);
+    }
+  }
+  return shared;
+}
+
+/**
+ * Computes the symmetric Sørensen–Dice trigram coefficient of two raw strings:
+ * lowercase, pad, extract trigram multisets, then `2·|A∩B| / (|A|+|B|)`.
+ *
+ * Edge cases:
+ *   - Two empty strings score {@link MAX_SCORE} (vacuously identical).
+ *   - One empty and one non-empty score {@link MIN_SCORE}.
+ *
+ * Exported so the determinism / acceptance tests can assert the metric directly.
+ */
+/**
+ * Sørensen–Dice coefficient over two PRECOMPUTED trigram multisets — the metric
+ * core, with the same empty-input rules as {@link diceTrigramSimilarity}. The
+ * candidate scorer prepares each node's multiset ONCE and calls this directly, so
+ * a node's trigrams are built once rather than rebuilt for every pair it joins.
+ */
+function diceFromMultisets(
+  left: Map<string, number>,
+  right: Map<string, number>,
+): number {
+  const leftSize = multisetSize(left);
+  const rightSize = multisetSize(right);
+  if (leftSize === 0 && rightSize === 0) {
+    return MAX_SCORE;
+  }
+  if (leftSize === 0 || rightSize === 0) {
+    return MIN_SCORE;
+  }
+  const shared = multisetIntersectionSize(left, right);
+  return (2 * shared) / (leftSize + rightSize);
+}
+
+export function diceTrigramSimilarity(left: string, right: string): number {
+  return diceFromMultisets(
+    trigramMultiset(left.toLowerCase()),
+    trigramMultiset(right.toLowerCase()),
+  );
+}
+
+/**
+ * The field(s) whose text a `vector`/`hybrid` strategy embeds, or `undefined` for
+ * the zero-embedding strategies (`fulltext`/`custom`). `merge()`'s precompute uses
+ * this to decide which staged texts to embed; `scorePair` uses the SAME selection
+ * implicitly via {@link fieldText}, so the embedded text and the looked-up text
+ * match exactly.
+ */
+export function embeddingFields(
+  strategy: SimilarityStrategy,
+): readonly string[] | undefined {
+  switch (strategy.kind) {
+    case "vector": {
+      return [strategy.field];
+    }
+    case "hybrid": {
+      return strategy.fields;
+    }
+    case "fulltext":
+    case "custom": {
+      return undefined;
+    }
+    default: {
+      const exhaustive: never = strategy;
+      throw new Error(
+        `Unhandled similarity strategy: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Cosine similarity of two equal-length vectors, in `[-1, 1]`. Computed in a fixed
+ * index order so it is deterministic. Returns {@link MIN_SCORE} for a dimension
+ * mismatch or a zero-magnitude vector (no comparable direction → no evidence),
+ * never `NaN`. `scorePair` clamps the result into the `[0, 1]` similarity codomain.
+ *
+ */
+function cosineSimilarity(left: Float32Array, right: Float32Array): number {
+  if (left.length !== right.length || left.length === 0) {
+    return MIN_SCORE;
+  }
+  let dot = 0;
+  let leftMagnitude = 0;
+  let rightMagnitude = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftComponent = left[index]!;
+    const rightComponent = right[index]!;
+    dot += leftComponent * rightComponent;
+    leftMagnitude += leftComponent * leftComponent;
+    rightMagnitude += rightComponent * rightComponent;
+  }
+  if (leftMagnitude === 0 || rightMagnitude === 0) {
+    return MIN_SCORE;
+  }
+  return dot / (Math.sqrt(leftMagnitude) * Math.sqrt(rightMagnitude));
+}
+
+/**
+ * Cosine of the two field texts' precomputed vectors. A text whose vector is
+ * absent from the lookup (only possible if the precompute and scorer disagreed —
+ * they cannot, since both go through {@link fieldText}) scores {@link MIN_SCORE}
+ * defensively rather than throwing.
+ */
+function cosineFromLookup(
+  embeddings: ReadonlyMap<string, Float32Array>,
+  leftText: string,
+  rightText: string,
+): number {
+  const leftVector = embeddings.get(leftText);
+  const rightVector = embeddings.get(rightText);
+  if (leftVector === undefined || rightVector === undefined) {
+    return MIN_SCORE;
+  }
+  return cosineSimilarity(leftVector, rightVector);
+}
+
+/** Default hybrid blend: equal weight to the vector and fulltext components. */
+const DEFAULT_HYBRID_WEIGHT = 0.5;
+
+/**
+ * Coerces a raw weight into the non-negative finite domain. A non-finite value
+ * (`NaN`/`±Infinity`) contributes `0` rather than poisoning the whole blend —
+ * `Math.max(0, NaN)` is `NaN`, which would survive the `total === 0` guard and
+ * collapse every hybrid score to 0. Valid weights are rejected earlier at the
+ * options boundary (`normalizeMergeOptions`); this is the defensive backstop.
+ */
+function nonNegativeFinite(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+/**
+ * Normalizes a hybrid strategy's `weights` so the vector and fulltext components
+ * sum to 1, defaulting either omitted side to {@link DEFAULT_HYBRID_WEIGHT}. A
+ * degenerate `{0, 0}` (or negative / non-finite) total falls back to an even
+ * 0.5/0.5 split so the blend can never divide by zero, invert, or produce `NaN`.
+ */
+function normalizeHybridWeights(
+  weights: Readonly<{ vector?: number; fulltext?: number }> | undefined,
+): Readonly<{ vector: number; fulltext: number }> {
+  const vector = nonNegativeFinite(weights?.vector ?? DEFAULT_HYBRID_WEIGHT);
+  const fulltext = nonNegativeFinite(
+    weights?.fulltext ?? DEFAULT_HYBRID_WEIGHT,
+  );
+  const total = vector + fulltext;
+  if (total === 0) {
+    return { vector: DEFAULT_HYBRID_WEIGHT, fulltext: DEFAULT_HYBRID_WEIGHT };
+  }
+  return { vector: vector / total, fulltext: fulltext / total };
+}
+
+/**
+ * Builds the {@link SimilarityUnavailableError} for a `vector`/`hybrid` strategy
+ * requested with no configured embedder.
+ */
+function embedderUnavailable(
+  kind: "vector" | "hybrid",
+  ctx: SimilarityContext,
+): SimilarityUnavailableError {
+  return new SimilarityUnavailableError(
+    `Similarity strategy "${kind}" requires a configured embedder (MergeOptions.embedder); none was provided.`,
+    { details: { strategy: kind, dialect: ctx.backend.dialect } },
+  );
+}
+
+/**
+ * The field(s) a strategy reads off a node to form its comparison text: the
+ * embedded field(s) for `vector`/`hybrid`, the configured `fields` for `fulltext`,
+ * and none for `custom` (which scores the node objects directly).
+ */
+function scoringFields(strategy: SimilarityStrategy): readonly string[] {
+  switch (strategy.kind) {
+    case "fulltext":
+    case "hybrid": {
+      return strategy.fields;
+    }
+    case "vector": {
+      return [strategy.field];
+    }
+    case "custom": {
+      return [];
+    }
+    default: {
+      const exhaustive: never = strategy;
+      throw new Error(
+        `Unhandled similarity strategy: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+}
+
+/**
+ * A node's per-strategy comparison inputs, computed ONCE and reused across every
+ * pair the node joins: its lowercase {@link fieldText} (looked up in the embedding
+ * map for `vector`/`hybrid`) and, for the trigram strategies, its trigram multiset.
+ * The original `node` is retained for the `custom` strategy, which scores nodes
+ * directly. {@link createPairScorer} memoizes one of these per node.
+ */
+type PreparedNode<K extends NodeType = NodeType> = Readonly<{
+  node: Node<K>;
+  text: string;
+  grams: Map<string, number>;
+}>;
+
+/** Empty trigram multiset shared by strategies that never consult grams. */
+const NO_GRAMS: Map<string, number> = new Map<string, number>();
+
+/** Computes a node's {@link PreparedNode} for a strategy (trigrams only when used). */
+function prepareNode<K extends NodeType>(
+  node: Node<K>,
+  strategy: SimilarityStrategy,
+): PreparedNode<K> {
+  const text = fieldText(node, scoringFields(strategy));
+  const grams =
+    strategy.kind === "fulltext" || strategy.kind === "hybrid" ?
+      trigramMultiset(text)
+    : NO_GRAMS;
+  return { node, text, grams };
+}
+
+/**
+ * Scores a candidate pair from its two {@link PreparedNode}s under a
+ * {@link SimilarityStrategy}, returning a value in `[0, 1]` (guaranteed symmetric
+ * for the built-in strategies). This is the single match-decision switch;
+ * {@link scorePair} and {@link createPairScorer} both feed it prepared nodes.
+ *
+ * @returns `ok(score)` on success, or `err(SimilarityUnavailableError)` when a
+ *   `vector`/`hybrid` strategy is requested with no configured embedder.
+ */
+function scorePrepared<K extends NodeType>(
+  left: PreparedNode<K>,
+  right: PreparedNode<K>,
+  strategy: SimilarityStrategy,
+  ctx: SimilarityContext,
+): Result<number, SimilarityUnavailableError> {
+  switch (strategy.kind) {
+    case "custom": {
+      // The caller owns symmetry here; we only clamp into the codomain so a
+      // stray out-of-range or NaN score cannot corrupt clustering.
+      const raw = strategy.score(left.node, right.node);
+      return ok(clampScore(raw));
+    }
+    case "fulltext": {
+      // A node with NO text in the configured fields offers no evidence of a
+      // match. Comparing two such nodes must NOT collapse two distinct entities,
+      // NOT even at threshold 0 — so it returns the sub-threshold
+      // {@link NO_EVIDENCE_SCORE}, never the vacuous diceTrigramSimilarity("","")
+      // === 1. The metric itself keeps empty==empty==1 for direct callers / the
+      // acceptance tests; this guard is candidate-gen's policy.
+      if (left.text.length === 0 || right.text.length === 0) {
+        return ok(NO_EVIDENCE_SCORE);
+      }
+      return ok(clampScore(diceFromMultisets(left.grams, right.grams)));
+    }
+    case "vector": {
+      // Presence of `ctx.embeddings` == an embedder was configured. Absent → the
+      // caller asked for vector similarity without supplying MergeOptions.embedder.
+      if (ctx.embeddings === undefined) {
+        return err(embedderUnavailable("vector", ctx));
+      }
+      // A node with no text in the field offers no evidence of a match —
+      // NO_EVIDENCE_SCORE, not the cosine of two zero/absent vectors (mirrors the
+      // fulltext guard, and excludes the pair even at threshold 0).
+      if (left.text.length === 0 || right.text.length === 0) {
+        return ok(NO_EVIDENCE_SCORE);
+      }
+      const cosine = cosineFromLookup(ctx.embeddings, left.text, right.text);
+      return ok(clampScore(cosine));
+    }
+    case "hybrid": {
+      if (ctx.embeddings === undefined) {
+        return err(embedderUnavailable("hybrid", ctx));
+      }
+      if (left.text.length === 0 || right.text.length === 0) {
+        return ok(NO_EVIDENCE_SCORE);
+      }
+      // Blend exact in-memory cosine (semantic/spelling proximity) with the Dice
+      // trigram (literal character overlap) by the normalized weights. Both
+      // components are symmetric, so the blend is too.
+      const vectorScore = clampScore(
+        cosineFromLookup(ctx.embeddings, left.text, right.text),
+      );
+      const fulltextScore = diceFromMultisets(left.grams, right.grams);
+      const weights = normalizeHybridWeights(strategy.weights);
+      return ok(
+        clampScore(
+          weights.vector * vectorScore + weights.fulltext * fulltextScore,
+        ),
+      );
+    }
+    default: {
+      // Exhaustiveness guard: a new strategy kind must add a branch above, or
+      // this assignment fails to compile.
+      const exhaustive: never = strategy;
+      throw new Error(
+        `Unhandled similarity strategy: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Scores a candidate pair under a {@link SimilarityStrategy}, returning a value
+ * in `[0, 1]` (guaranteed symmetric for the built-in strategies). A single-pair
+ * convenience over {@link scorePrepared}; the candidate loop uses
+ * {@link createPairScorer} instead so per-node work is not repeated across pairs.
+ *
+ * @param a   First staged node.
+ * @param b   Second staged node.
+ * @param strategy The per-kind similarity strategy from the kind's `ResolveConfig`.
+ * @param ctx Ambient context (the backend, for vector-capability gating).
+ * @returns `ok(score)` on success, or `err(SimilarityUnavailableError)` when a
+ *   `vector`/`hybrid` strategy is requested with no configured embedder.
+ */
+export function scorePair<K extends NodeType>(
+  a: Node<K>,
+  b: Node<K>,
+  strategy: SimilarityStrategy,
+  ctx: SimilarityContext,
+): Result<number, SimilarityUnavailableError> {
+  const result = scorePrepared(
+    prepareNode(a, strategy),
+    prepareNode(b, strategy),
+    strategy,
+    ctx,
+  );
+  // The standalone scorer's contract is a [0, 1] score; the internal
+  // NO_EVIDENCE_SCORE sentinel (a textless pair) surfaces here as MIN_SCORE. Only
+  // candidate-gen needs the sub-threshold value to exclude the pair at threshold 0.
+  if (result.success && result.data === NO_EVIDENCE_SCORE) {
+    return ok(MIN_SCORE);
+  }
+  return result;
+}
+
+/**
+ * Builds a memoized pair scorer for one kind. Each node's {@link PreparedNode} is
+ * computed once, keyed by its `(kind, id)` {@link MergeKey}, so a node appearing in
+ * m candidate pairs has its text + trigram multiset built once, not m times — the
+ * per-bucket cost drops from O(pairs · text) trigram builds to O(nodes · text).
+ * Pair-for-pair equivalent to {@link scorePair}.
+ */
+export function createPairScorer<K extends NodeType>(
+  strategy: SimilarityStrategy,
+  ctx: SimilarityContext,
+): (
+  a: MergeKey,
+  left: Node<K>,
+  b: MergeKey,
+  right: Node<K>,
+) => Result<number, SimilarityUnavailableError> {
+  const prepared = new Map<MergeKey, PreparedNode<K>>();
+  const prepare = (key: MergeKey, node: Node<K>): PreparedNode<K> => {
+    const cached = prepared.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const fresh = prepareNode(node, strategy);
+    prepared.set(key, fresh);
+    return fresh;
+  };
+  return (a, left, b, right) =>
+    scorePrepared(prepare(a, left), prepare(b, right), strategy, ctx);
+}

--- a/packages/typegraph/src/graph-merge/sources.ts
+++ b/packages/typegraph/src/graph-merge/sources.ts
@@ -1,0 +1,720 @@
+/**
+ * Candidate SOURCES (design §4 / §6.1) — the RECALL layer of candidate generation.
+ *
+ * Candidate generation is three layers — sources → scoring → reconciler (§4). This
+ * module is the FIRST layer: each source PROPOSES candidates and decides nothing
+ * about a fuzzy match. A source emits three things:
+ *
+ *   - `pairs`       — unscored `(a, b)` node pairs handed to the shared scoring
+ *                     stage (`scoring.ts`), which makes every fuzzy match decision.
+ *   - `forcedEdges` — DEFINITIONAL matches (a shared unique value) that bypass
+ *                     scoring at {@link FORCED_MATCH_SCORE}.
+ *   - `baseMembers` — committed base nodes the source pulled into scope, so the
+ *                     reconciler can seed + canonicalize a base endpoint without
+ *                     re-querying the backend. EMPTY for staged-only sources.
+ *
+ * Two sources ship here — today's two blocking strategies (`blocking.ts`),
+ * refactored behind the source interface:
+ *
+ *   - {@link exactKeySource} (`exactKey`, §6.1) — the `block(node) => string`
+ *     bucket: same-bucket node pairs become fuzzy `pairs`. Staged-vs-staged.
+ *   - {@link uniqueSource} (`unique`, §6.1) — the unique-constraint signature
+ *     buckets: every same-signature pair is a FORCED edge (a shared unique value
+ *     is definitionally the same entity). Staged-vs-staged.
+ *
+ * Both read the SAME pre-computed `blockNodes` map off the scope (the UNION of the
+ * `block()` key and the per-constraint signatures, `blocking.ts`), filtering it by
+ * {@link isUniqueBucketKey}: `exactKey` owns the non-unique buckets, `unique` owns
+ * the unique buckets. Sharing one blocked map (vs. re-blocking per source) keeps the
+ * source split byte-identical to the old fused `generateCandidates` — a node with a
+ * unique signature but no `block()` key lands ONLY in its unique bucket, never the
+ * all-vs-all `unblocked` bucket.
+ *
+ * Determinism: the extraction visits buckets in sorted-key order over id-sorted
+ * members and enumerates `i < j`, so proposals are emitted in a canonical order;
+ * the scoring stage additionally dedups + sorts, so neither source's emission order
+ * leaks into the merge result.
+ */
+
+import { isUniqueBucketKey, UNBLOCKED_BUCKET_KEY } from "./blocking";
+import { MergeError } from "./errors";
+import {
+  compareMergeKeys,
+  compareStrings,
+  idOf,
+  kindOf,
+  type MergeKey,
+  mergeKey,
+  mergeKeyOf,
+} from "./node-key";
+import type { CandidateEdge, CandidatePair } from "./scoring";
+import { FORCED_MATCH_SCORE } from "./scoring";
+import { fieldText } from "./similarity";
+import type {
+  GraphDef,
+  JsonValue,
+  Node,
+  NodeId,
+  NodeType,
+  UniqueIntrospection,
+} from "./typegraph-internal";
+import type { ResolveConfig } from "./types";
+import { UnionFind } from "./union-find";
+
+/**
+ * A committed BASE node a source pulled into the cluster universe (design §4
+ * member contribution / §6.4-D). It carries the same `(id, kind, props)` a staged
+ * member does, plus a reserved `"base"` origin so the reconciler can enforce
+ * base-id-wins (§6.4-C) and tag provenance with the base sentinel (§6.4-D). EMPTY
+ * for staged-only sources (`exactKey`, `unique`).
+ */
+export type BaseMember = Readonly<{
+  id: NodeId<NodeType>;
+  kind: string;
+  props: Readonly<Record<string, JsonValue>>;
+  origin: "base";
+}>;
+
+/**
+ * What a candidate source emits for one kind: fuzzy `pairs` to score, FORCED
+ * (definitional) edges to pass through unscored, and the committed `baseMembers`
+ * it pulled into scope.
+ */
+type SourceResult = Readonly<{
+  pairs: readonly CandidatePair[];
+  forcedEdges: readonly CandidateEdge[];
+  baseMembers: readonly BaseMember[];
+}>;
+
+/**
+ * The minimal node-collection surface a base-querying source needs: the public
+ * `bulkFindByConstraint` (typegraph 0.29.0). It computes each item's constraint key
+ * from its props, returns the live committed match per item in INPUT ORDER
+ * (`undefined` for misses, soft-deleted excluded), and is indexed by the `uniques`
+ * table PK — so graph-merge never reconstructs constraint keys itself. A runtime,
+ * kind-string-keyed view (like the commit's `TxNodes`) so a source can dispatch on
+ * a kind string without threading the caller's concrete `Store<G>` generic.
+ */
+export type BaseNodeLookup = Readonly<{
+  bulkFindByConstraint: (
+    constraintName: string,
+    items: readonly Readonly<{ props: Record<string, unknown> }>[],
+  ) => Promise<readonly (Node<NodeType> | undefined)[]>;
+  /**
+   * The non-unique sibling (typegraph 0.30): for each item, the live committed nodes
+   * sharing its declared-INDEX key (computed from props), returned per item in input
+   * order, each inner array id-sorted, soft-deleted excluded. `limitPerInput` bounds
+   * per-item fan-out (id-ordered, so the cap is deterministic). Candidate retrieval —
+   * NOT a uniqueness/identity guarantee — so `baseKey` emits scored pairs, not forced
+   * edges.
+   */
+  bulkFindByIndex: (
+    indexName: string,
+    items: readonly Readonly<{ props: Record<string, unknown> }>[],
+    options?: Readonly<{ limitPerInput?: number }>,
+  ) => Promise<readonly (readonly Node<NodeType>[])[]>;
+}>;
+
+/** Runtime, kind-string-keyed view of a store's node collections for base lookups. */
+export type BaseLookupStore = Readonly<{
+  nodes: Readonly<Record<string, BaseNodeLookup>>;
+}>;
+
+/**
+ * The per-kind input a source generates over. `blocks` is the UNION `blockNodes`
+ * result (`block()` key + per-constraint signatures) the staged sources read.
+ *
+ * The remaining fields are present only when a BASE-querying source (`baseUnique` /
+ * `baseKey`, §6.2) is driven: the kind's materialized staged new `nodes` (the lookup
+ * items), its `uniqueConstraints` (for `baseUnique`), the declared `blockIndex` name
+ * (for `baseKey`, when the kind configured one), and the committed `store` to query
+ * against. Staged-only sources (`exactKey`, `unique`) ignore them, so the public
+ * `merge()` candidate path leaves them unset.
+ */
+export type SourceScope = Readonly<{
+  kind: string;
+  blocks: ReadonlyMap<string, readonly Node<NodeType>[]>;
+  nodes?: readonly Node<NodeType>[];
+  uniqueConstraints?: readonly UniqueIntrospection[];
+  blockIndex?: string;
+  /** When set, `exactKey` bounds the no-key (`"unblocked"`) bucket by sorted-
+   * neighbourhood instead of all-vs-all (the `keyless` source, §6.2). */
+  keyless?: KeylessConfig;
+  store?: BaseLookupStore;
+}>;
+
+/**
+ * A candidate source (design §4): proposes pairs (recall) + definitional forced
+ * edges, and supplies the base members it pulled into scope. The `id` attributes
+ * a source in reports and pins its determinism level (§7).
+ */
+export type CandidateSource = Readonly<{
+  readonly id: string;
+  generate(scope: SourceScope): Promise<SourceResult>;
+}>;
+
+/**
+ * Orders a pair's two node IDENTITY keys (`(kind, id)`, not bare id) so the smaller
+ * is `a`, with the matching node objects in `left`/`right`. Keying on the composite
+ * identity is what keeps a `Patient` and an `Encounter` that share an id string from
+ * being proposed as the same endpoint. Guarantees every proposal has a single
+ * canonical `(a, b)` representation regardless of enumeration order.
+ */
+function orderEndpoints<K extends NodeType>(
+  left: Node<K>,
+  right: Node<K>,
+): CandidatePair<K> {
+  const leftKey = mergeKeyOf(left);
+  const rightKey = mergeKeyOf(right);
+  return compareMergeKeys(leftKey, rightKey) <= 0 ?
+      { a: leftKey, b: rightKey, left, right }
+    : { a: rightKey, b: leftKey, left: right, right: left };
+}
+
+/** Sorts a bucket's members by ascending node id (defensive — blocking already does). */
+function sortMembersById<K extends NodeType>(
+  members: readonly Node<K>[],
+): readonly Node<K>[] {
+  return [...members].sort((left, right) => compareStrings(left.id, right.id));
+}
+
+/** Visits the blocked buckets in sorted-key order. */
+function sortedBucketKeys(
+  blocks: ReadonlyMap<string, readonly Node<NodeType>[]>,
+): readonly string[] {
+  return [...blocks.keys()].sort((left, right) => compareStrings(left, right));
+}
+
+/** The system fields a {@link Node} carries alongside its schema props. */
+const NODE_SYSTEM_FIELDS: ReadonlySet<string> = new Set(["id", "kind", "meta"]);
+
+/**
+ * Extracts a node's schema PROPS from its spread runtime shape (`Node` spreads its
+ * schema fields at the top level alongside `id` / `kind` / `meta`). Used to build a
+ * base lookup's props from a staged node and a {@link BaseMember}'s props from the
+ * returned committed node — without a second fetch or any knowledge of the schema.
+ */
+function nodeProps(node: Node<NodeType>): Record<string, JsonValue> {
+  const props: Record<string, JsonValue> = {};
+  for (const [key, value] of Object.entries(
+    node as unknown as Record<string, unknown>,
+  )) {
+    if (!NODE_SYSTEM_FIELDS.has(key)) {
+      props[key] = value as JsonValue;
+    }
+  }
+  return props;
+}
+
+/**
+ * The bounded coarse source for the NO-KEY case (design §6.2, `keyless`): which
+ * unblocked nodes to compare, and how far. `window` is the forward-neighbour count;
+ * `sortFields` is the kind's similarity text fields, so the SORTED-NEIGHBOURHOOD sort
+ * groups lexically-similar values adjacently (the same text the scorer reads).
+ */
+export type KeylessConfig = Readonly<{
+  window: number;
+  sortFields: readonly string[];
+}>;
+
+/**
+ * Builds the {@link KeylessConfig} for a kind's resolve config (its `keyless.window`
+ * plus the similarity text fields the sorted-neighbourhood pass sorts on), or
+ * `undefined` when `keyless` is unset. The sort fields are the kind's similarity text
+ * (so adjacency tracks the scorer's text); `custom` similarity exposes none → sort by
+ * id only (bounded but semantically weak — a no-key custom kind wants `stagedVector`,
+ * deferred §8).
+ *
+ * Shared by `merge()`'s source path AND the back-compat `generateCandidates()` helper,
+ * so both honour `ResolveConfig.keyless` identically rather than the helper silently
+ * ignoring it.
+ */
+export function keylessConfigFor<G extends GraphDef, K extends NodeType>(
+  resolveConfig: ResolveConfig<G, K>,
+): KeylessConfig | undefined {
+  if (resolveConfig.keyless === undefined) {
+    return undefined;
+  }
+  const strategy = resolveConfig.similarity;
+  const sortFields =
+    strategy.kind === "fulltext" || strategy.kind === "hybrid" ? strategy.fields
+    : strategy.kind === "vector" ? [strategy.field]
+    : [];
+  return { window: resolveConfig.keyless.window, sortFields };
+}
+
+/**
+ * Single-pass SORTED-NEIGHBOURHOOD pairs over one bucket's members: sort by the
+ * similarity-field text (tie-broken by id — a total order, so the output is a pure
+ * function of the member SET), then propose each node only against its next `window`
+ * neighbours. O(n·window) instead of O(n²); `window ≥ n-1` degenerates to all-vs-all.
+ */
+function windowedPairs(
+  members: readonly Node<NodeType>[],
+  config: KeylessConfig,
+): readonly CandidatePair[] {
+  const keyed = members.map((node) => ({
+    node,
+    key: fieldText(node, config.sortFields),
+  }));
+  keyed.sort((left, right) =>
+    left.key === right.key ?
+      compareStrings(left.node.id, right.node.id)
+    : compareStrings(left.key, right.key),
+  );
+  const pairs: CandidatePair[] = [];
+  for (let index = 0; index < keyed.length; index += 1) {
+    const last = Math.min(index + config.window, keyed.length - 1);
+    for (let index_ = index + 1; index_ <= last; index_ += 1) {
+      pairs.push(orderEndpoints(keyed[index]!.node, keyed[index_]!.node));
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Extracts the FUZZY candidate pairs from the NON-unique (block / unblocked)
+ * buckets: every `i < j` pair of a bucket's id-sorted members, in sorted-key
+ * order. Cross-bucket duplicates are left for the scoring stage to dedup.
+ *
+ * When `keyless` is set, the shared `"unblocked"` (no-key) bucket is bounded by
+ * single-pass sorted-neighbourhood ({@link windowedPairs}) instead of all-vs-all —
+ * closing the O(n²) cliff (design §6.2). Keyed `block()` buckets are unaffected
+ * (they are already bounded by the key). Unset preserves all-vs-all for every bucket.
+ */
+export function pairsFromBlocks(
+  blocks: ReadonlyMap<string, readonly Node<NodeType>[]>,
+  keyless?: KeylessConfig,
+): readonly CandidatePair[] {
+  const pairs: CandidatePair[] = [];
+  for (const bucketKey of sortedBucketKeys(blocks)) {
+    if (isUniqueBucketKey(bucketKey)) {
+      continue;
+    }
+    const members = sortMembersById(blocks.get(bucketKey) ?? []);
+    if (keyless !== undefined && bucketKey === UNBLOCKED_BUCKET_KEY) {
+      pairs.push(...windowedPairs(members, keyless));
+      continue;
+    }
+    for (let index = 0; index < members.length; index += 1) {
+      for (let index_ = index + 1; index_ < members.length; index_ += 1) {
+        pairs.push(orderEndpoints(members[index]!, members[index_]!));
+      }
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Extracts the FORCED (definitional) edges from the UNIQUE-constraint buckets:
+ * every `i < j` pair of a bucket's id-sorted members, at {@link FORCED_MATCH_SCORE}.
+ * Cross-bucket / cross-constraint duplicates are left for the scoring stage to dedup.
+ */
+export function forcedEdgesFromBlocks(
+  blocks: ReadonlyMap<string, readonly Node<NodeType>[]>,
+): readonly CandidateEdge[] {
+  const edges: CandidateEdge[] = [];
+  for (const bucketKey of sortedBucketKeys(blocks)) {
+    if (!isUniqueBucketKey(bucketKey)) {
+      continue;
+    }
+    const members = sortMembersById(blocks.get(bucketKey) ?? []);
+    for (let index = 0; index < members.length; index += 1) {
+      for (let index_ = index + 1; index_ < members.length; index_ += 1) {
+        const { a, b } = orderEndpoints(members[index]!, members[index_]!);
+        edges.push({ a, b, score: FORCED_MATCH_SCORE });
+      }
+    }
+  }
+  return edges;
+}
+
+/**
+ * Ontology RETYPE candidate edges (the cross-kind STAGED source, §6.4 / T10).
+ *
+ * Node identity is strictly `(kind, id)`, so a `Patient` and an `Encounter` that
+ * share an id string are DISTINCT and never fuse. But under `reconcileTypes:
+ * "ontology"`, two STAGED-NEW nodes that share a bare id AND carry subtype-compatible
+ * kinds are "the same entity at a refined type" (one branch staged `Doctor:x`,
+ * another `SpecialistDoctor:x`). This source forces those distinct identities into one
+ * cluster so the reconciler can collapse it to the most-specific kind. The same-id
+ * identities are PARTITIONED into maximal subtype-comparable groups first, so an
+ * unrelated kind sharing the id (`Encounter:x` beside `Doctor:x` / `SpecialistDoctor:x`)
+ * is split into its own group and does NOT suppress the valid retype; a group only
+ * fuses when its kinds still collapse to a single most-specific kind.
+ *
+ * `isRetypeCompatible` MUST be the same most-specific-common-kind test the reconciler
+ * uses ({@link import("./type-reconcile").mostSpecificCommonKind}), so a kind set
+ * fuses here iff the reconciler would later collapse it. The caller passes STAGED
+ * identities only; committed-base members stay outside this staged retype source.
+ *
+ * Deterministic: ids are visited in sorted order, the identities at each id are sorted
+ * + deduped, and a star of forced edges from the minimum identity makes the fusion
+ * transitive (the scoring stage dedups the forced set).
+ */
+export function ontologyRetypeEdges(
+  stagedIdentities: Iterable<MergeKey>,
+  isRetypeCompatible: (kinds: readonly string[]) => boolean,
+): readonly CandidateEdge[] {
+  const identitiesById = new Map<string, MergeKey[]>();
+  for (const identity of stagedIdentities) {
+    const id = idOf(identity);
+    const bucket = identitiesById.get(id);
+    if (bucket === undefined) {
+      identitiesById.set(id, [identity]);
+    } else {
+      bucket.push(identity);
+    }
+  }
+
+  const edges: CandidateEdge[] = [];
+  for (const id of [...identitiesById.keys()].sort(compareStrings)) {
+    const identities = [...new Set(identitiesById.get(id))].sort(
+      compareMergeKeys,
+    );
+    if (identities.length < 2) {
+      continue; // a single kind at this id — nothing cross-kind to reconcile.
+    }
+    // Partition the same-id identities into maximal subtype-comparable GROUPS, so an
+    // UNRELATED kind sharing the id (e.g. an `Encounter:x` next to a `Doctor:x` /
+    // `SpecialistDoctor:x` refinement) does not suppress the valid retype: two
+    // identities join a group when their kinds are pairwise retype-compatible, and the
+    // relation is unioned transitively.
+    const group = unionByCompatibility(identities, isRetypeCompatible);
+    for (const members of groupsOf(identities, group)) {
+      // Only fuse a group that still collapses to ONE most-specific kind (a single
+      // minimum). Incompatible siblings linked only through a shared subtype do not —
+      // fusing them would force the reconciler to flag the cluster and pick a kind.
+      if (
+        members.length < 2 ||
+        !isRetypeCompatible(members.map((identity) => kindOf(identity)))
+      ) {
+        continue;
+      }
+      for (let index = 1; index < members.length; index += 1) {
+        edges.push({
+          a: members[0]!,
+          b: members[index]!,
+          score: FORCED_MATCH_SCORE,
+        });
+      }
+    }
+  }
+  return edges;
+}
+
+/**
+ * Union-find over a same-id identity set: `identity → group representative`, where two
+ * identities share a representative iff their kinds are (transitively) pairwise
+ * {@link isRetypeCompatible}. Pure over the identity SET (the representative chosen is
+ * irrelevant — only the partition matters, and callers re-sort each group).
+ */
+function unionByCompatibility(
+  identities: readonly MergeKey[],
+  isRetypeCompatible: (kinds: readonly string[]) => boolean,
+): ReadonlyMap<MergeKey, MergeKey> {
+  // Partition only — the representative chosen is irrelevant (callers re-sort each
+  // group), so any total order works; `compareMergeKeys` keeps it deterministic.
+  const forest = new UnionFind<MergeKey>(compareMergeKeys);
+  for (const identity of identities) {
+    forest.add(identity);
+  }
+  for (let index = 0; index < identities.length; index += 1) {
+    for (let index_ = index + 1; index_ < identities.length; index_ += 1) {
+      if (
+        isRetypeCompatible([
+          kindOf(identities[index]!),
+          kindOf(identities[index_]!),
+        ])
+      ) {
+        forest.union(identities[index]!, identities[index_]!);
+      }
+    }
+  }
+  return new Map(
+    identities.map((identity) => [identity, forest.find(identity)]),
+  );
+}
+
+/** Buckets identities by their union-find representative, each group id-sorted. */
+function groupsOf(
+  identities: readonly MergeKey[],
+  representativeOf: ReadonlyMap<MergeKey, MergeKey>,
+): readonly (readonly MergeKey[])[] {
+  const byRoot = new Map<MergeKey, MergeKey[]>();
+  for (const identity of identities) {
+    const root = representativeOf.get(identity)!;
+    const bucket = byRoot.get(root);
+    if (bucket === undefined) {
+      byRoot.set(root, [identity]);
+    } else {
+      bucket.push(identity);
+    }
+  }
+  return [...byRoot.values()].map((group) => [...group].sort(compareMergeKeys));
+}
+
+/**
+ * `exactKey` source (§6.1) — today's `block(node) => string` bucketing. Same-bucket
+ * node pairs become fuzzy `pairs` for the scoring stage to decide. Staged-vs-staged,
+ * fully deterministic, no base members.
+ *
+ * Also hosts the `keyless` source (§6.2): when `scope.keyless` is set, the no-key
+ * (`"unblocked"`) bucket is bounded by sorted-neighbourhood rather than all-vs-all.
+ * It rides `exactKey` rather than a parallel source because both operate on the same
+ * staged blocked map and would otherwise double-emit the unblocked bucket.
+ */
+export const exactKeySource: CandidateSource = {
+  id: "exactKey",
+  generate(scope) {
+    return Promise.resolve({
+      pairs: pairsFromBlocks(scope.blocks, scope.keyless),
+      forcedEdges: [],
+      baseMembers: [],
+    });
+  },
+};
+
+/**
+ * `unique` source (§6.1) — today's unique-constraint short-circuit. Every pair
+ * sharing a unique signature is a FORCED edge: a shared unique value is
+ * definitionally the same entity, so it merges regardless of similarity (differing
+ * properties are reported as conflicts downstream, and the merged graph never
+ * violates its own uniqueness). Staged-vs-staged, fully deterministic, no base
+ * members.
+ */
+export const uniqueSource: CandidateSource = {
+  id: "unique",
+  generate(scope) {
+    return Promise.resolve({
+      pairs: [],
+      forcedEdges: forcedEdgesFromBlocks(scope.blocks),
+      baseMembers: [],
+    });
+  },
+};
+
+/**
+ * `baseUnique` source (§6.2) — the first NEW-vs-BASE source. For each declared
+ * unique constraint, it issues ONE batched `bulkFindByConstraint` over the staged
+ * new nodes against the committed base store (TypeGraph's own constraint API,
+ * indexed by the `uniques` PK; key computed from props, soft-deleted excluded). Each
+ * hit is a DEFINITIONAL match — a staged node sharing a committed node's unique
+ * value is the same entity — so it emits:
+ *
+ *   - a FORCED edge between the staged node and the committed base node, and
+ *   - a {@link BaseMember} built from the returned committed node (no second fetch),
+ *     so the reconciler can seed + canonicalize the base endpoint (§4).
+ *
+ * Grouped by `(kind, constraint)` — one batched call per constraint — so each
+ * constraint's own `fields` / `where` / `scope` / `collation` semantics are honoured
+ * by construction; graph-merge never rebuilds keys. Deterministic: constraints are
+ * visited in sorted name order, base members are deduped by id and id-sorted, and
+ * the scoring stage dedups + sorts the forced edges.
+ *
+ * NOT part of {@link CANDIDATE_SOURCES}: the public `merge()` snapshot path stays
+ * staged-vs-staged. This source is driven only by the synthetic new-vs-base scope
+ * (later slice steps), which supplies the `nodes` / `uniqueConstraints` / `store`
+ * the staged sources omit.
+ */
+export const baseUniqueSource: CandidateSource = {
+  id: "baseUnique",
+  async generate(scope) {
+    const { kind, nodes, uniqueConstraints, store } = scope;
+    if (
+      nodes === undefined ||
+      uniqueConstraints === undefined ||
+      store === undefined
+    ) {
+      throw new MergeError(
+        "baseUniqueSource requires nodes, uniqueConstraints, and store in the source scope.",
+        { details: { kind, source: "baseUnique" } },
+      );
+    }
+
+    const collection = store.nodes[kind];
+    if (collection === undefined || nodes.length === 0) {
+      return { pairs: [], forcedEdges: [], baseMembers: [] };
+    }
+
+    const forcedEdges: CandidateEdge[] = [];
+    const baseMembers = new Map<string, BaseMember>();
+
+    // The lookup items are the SAME for every constraint (one props bag per staged
+    // node), so build them ONCE rather than per constraint, and fire the independent
+    // per-constraint lookups concurrently. Results are consumed in sorted-constraint
+    // order below, so the dedup-by-id keeps determinism despite the parallel I/O.
+    const constraints = [...uniqueConstraints].sort((left, right) =>
+      compareStrings(left.name, right.name),
+    );
+    const items = nodes.map((node) => ({ props: nodeProps(node) }));
+    // `bulkFindByConstraint` re-validates each item's FULL props against the kind's
+    // CREATE schema to compute the constraint key, so a non-idempotent create schema
+    // (a transform/default/coercion) — or a staged node that otherwise fails the
+    // schema — throws a typegraph error. Surface it as a typed MergeError carrying the
+    // kind + constraint, rather than letting an opaque throw be masked as the generic
+    // "Merge failed while staging or committing" wrapper downstream.
+    const matchesByConstraint = await Promise.all(
+      constraints.map(async (constraint) => {
+        try {
+          return await collection.bulkFindByConstraint(constraint.name, items);
+        } catch (error) {
+          throw new MergeError(
+            `baseUniqueSource: new-vs-base lookup for constraint "${constraint.name}" on kind "${kind}" failed — a staged node's props could not be validated against the kind's schema for constraint-key computation.`,
+            { details: { kind, constraint: constraint.name }, cause: error },
+          );
+        }
+      }),
+    );
+    for (const matches of matchesByConstraint) {
+      for (const [index, node] of nodes.entries()) {
+        const base = matches[index];
+        if (base === undefined) {
+          continue;
+        }
+        const stagedNode = node;
+        const stagedKey = mergeKey(stagedNode.kind, stagedNode.id);
+        const baseKey = mergeKey(base.kind, base.id);
+        // ALWAYS pull the committed node in as a base member, so the reconciler seeds +
+        // canonicalizes it and enforces base-id-wins (§6.4-C) — including for a
+        // same-(kind,id) re-discovery, where the committed value must still win over a
+        // divergent staged prop. (Dropping the base member here is what made a same-id
+        // re-add ERROR in the stale-overwrite guard instead of resolving onto the base.)
+        if (!baseMembers.has(baseKey)) {
+          baseMembers.set(baseKey, {
+            origin: "base",
+            id: base.id,
+            kind: base.kind,
+            props: nodeProps(base),
+          });
+        }
+        // A same-(kind,id) re-discovery is already ONE identity (the base member lands
+        // in the staged node's own cluster by key), so it needs no linking edge — a
+        // self-loop would be a degenerate no-op. Skip ONLY the forced edge, not the
+        // base member above.
+        if (stagedKey === baseKey) {
+          continue;
+        }
+        const { a, b } =
+          compareMergeKeys(stagedKey, baseKey) <= 0 ?
+            { a: stagedKey, b: baseKey }
+          : { a: baseKey, b: stagedKey };
+        forcedEdges.push({ a, b, score: FORCED_MATCH_SCORE });
+      }
+    }
+
+    return {
+      pairs: [],
+      forcedEdges,
+      baseMembers: [...baseMembers.values()].sort((left, right) =>
+        compareStrings(left.id, right.id),
+      ),
+    };
+  },
+};
+
+/**
+ * `baseKey` source (§6.2, descriptor-backed block key) — the second NEW-vs-BASE
+ * source. For the kind's declared block INDEX (named by `ResolveConfig.blockIndex`,
+ * threaded onto the scope), it issues ONE batched `bulkFindByIndex` over the staged
+ * new nodes against the committed base store (typegraph 0.30's non-unique index
+ * lookup; key computed from props, soft-deleted excluded, fan-out bounded by
+ * `limitPerInput`). Unlike {@link baseUniqueSource}, a shared block key is NOT
+ * definitional — it is a candidate — so each new↔base hit emits:
+ *
+ *   - a {@link CandidatePair} (staged ↔ base) handed to the shared scoring stage (it
+ *     becomes an edge only if it clears the kind's threshold), and
+ *   - a {@link BaseMember} built from the returned committed node (no second fetch).
+ *
+ * A same-(kind, id) hit needs no pair — the base member joins the staged node's own
+ * cluster by key — so only its base member is emitted. graph-merge never reconstructs
+ * the index key (typegraph owns `fields`/`scope`/`where`/collation), mirroring
+ * `baseUnique`. Deterministic: typegraph returns matches per item in input order,
+ * id-sorted; base members are deduped by id and id-sorted; the scoring stage dedups +
+ * sorts the pairs. Field-set index keys only — a transform block key stays on the
+ * staged-only opaque `block()` (§6.2).
+ *
+ * NOT part of {@link CANDIDATE_SOURCES}: the public `merge()` snapshot path stays
+ * staged-vs-staged; this source runs only under the synthetic new-vs-base scope.
+ */
+export const baseKeySource: CandidateSource = {
+  id: "baseKey",
+  async generate(scope) {
+    const { kind, nodes, blockIndex, store } = scope;
+    // No declared block index for this kind → baseKey contributes nothing (a kind opts
+    // into new-vs-base block-key recall by declaring an index + setting blockIndex).
+    if (blockIndex === undefined) {
+      return { pairs: [], forcedEdges: [], baseMembers: [] };
+    }
+    if (nodes === undefined || store === undefined) {
+      throw new MergeError(
+        "baseKeySource requires nodes and store in the source scope.",
+        { details: { kind, source: "baseKey" } },
+      );
+    }
+
+    const collection = store.nodes[kind];
+    if (collection === undefined || nodes.length === 0) {
+      return { pairs: [], forcedEdges: [], baseMembers: [] };
+    }
+
+    const items = nodes.map((node) => ({ props: nodeProps(node) }));
+    // Like `bulkFindByConstraint`, an unknown index name / type-incompatible field
+    // throws a typegraph error; surface it as a typed MergeError carrying the index +
+    // kind rather than letting it be masked as the generic "Merge failed" wrapper.
+    let matchesByNode: readonly (readonly Node<NodeType>[])[];
+    try {
+      matchesByNode = await collection.bulkFindByIndex(blockIndex, items);
+    } catch (error) {
+      throw new MergeError(
+        `baseKeySource: new-vs-base lookup on index "${blockIndex}" for kind "${kind}" failed — the index is undeclared or a staged node's props are incompatible with its indexed fields.`,
+        { details: { kind, index: blockIndex }, cause: error },
+      );
+    }
+
+    const pairs: CandidatePair[] = [];
+    const baseMembers = new Map<string, BaseMember>();
+    for (const [index, node] of nodes.entries()) {
+      const stagedNode = node;
+      const stagedKey = mergeKey(stagedNode.kind, stagedNode.id);
+      for (const base of matchesByNode[index] ?? []) {
+        const baseKey = mergeKey(base.kind, base.id);
+        if (!baseMembers.has(baseKey)) {
+          baseMembers.set(baseKey, {
+            origin: "base",
+            id: base.id,
+            kind: base.kind,
+            props: nodeProps(base),
+          });
+        }
+        // A same-(kind, id) re-discovery is already ONE identity; the base member lands
+        // in the staged node's own cluster by key, so it needs no candidate pair.
+        if (stagedKey === baseKey) {
+          continue;
+        }
+        pairs.push(orderEndpoints(stagedNode, base));
+      }
+    }
+
+    return {
+      pairs,
+      forcedEdges: [],
+      baseMembers: [...baseMembers.values()].sort((left, right) =>
+        compareStrings(left.id, right.id),
+      ),
+    };
+  },
+};
+
+/**
+ * The STAGED candidate sources the public `merge()` drives, in a fixed order (§6.1
+ * "phase: now"). The scoring stage dedups + sorts the union, so this order does not
+ * affect the merge result; it is fixed only for stable report attribution. The
+ * new-vs-base {@link baseUniqueSource} / {@link baseKeySource} are deliberately NOT
+ * here — they run only under the synthetic new-vs-base scope so the public snapshot
+ * path stays staged-vs-staged.
+ */
+export const CANDIDATE_SOURCES: readonly CandidateSource[] = [
+  exactKeySource,
+  uniqueSource,
+];

--- a/packages/typegraph/src/graph-merge/staging.ts
+++ b/packages/typegraph/src/graph-merge/staging.ts
@@ -1,0 +1,226 @@
+/**
+ * Staging (design §6.4 rule 1, T7): run the state-diff (T3) for EVERY branch,
+ * tag each diff item with its origin {@link BranchId}, and assemble the UNION
+ * of all branches' diffs into a single {@link StagingSet}.
+ *
+ * Why union (not incremental):
+ *   Downstream candidate-generation (T6) and clustering (T8) must be
+ *   order-independent — shuffling the branch order MUST yield an identical
+ *   merge. If staging folded branches one-at-a-time into a mutating cumulative
+ *   state, the result could depend on fold order. Instead we COLLECT every
+ *   branch's tagged items into flat arrays, then GROUP and SORT once at the end,
+ *   so the {@link StagingSet} is a pure function of the unordered branch SET.
+ *
+ * Provenance tagging:
+ *   Every staged item carries the {@link BranchId} of the branch whose diff
+ *   produced it. An inherited node modified differently by two branches appears
+ *   once per branch (each tagged), which is exactly what the conflict-detection
+ *   phases (T8 / T8a) need. A new node introduced by one branch appears once,
+ *   tagged by that branch.
+ *
+ * Determinism:
+ *   - New nodes/edges are grouped by kind; the per-kind arrays are sorted by
+ *     `(id, branchId)`.
+ *   - Flat collections (modified / deleted) are sorted by `(kind, id, branchId)`.
+ *   - Bucket maps iterate in lexicographic kind order.
+ *   The `(…, branchId)` tail breaks ties when the same id is contributed by more
+ *   than one branch, so the ordering is total and stable.
+ */
+
+import { compareStrings } from "./node-key";
+import type {
+  ChangedEdge,
+  ChangedNode,
+  DeletedEdge,
+  DeletedNode,
+  ModifiedEdge,
+  ModifiedNode,
+} from "./state-diff";
+import { diffAgainstBase } from "./state-diff";
+import type { GraphDef, Store } from "./typegraph-internal";
+import type { BranchId, GraphBranch } from "./types";
+
+/** A new fork node tagged with the branch that introduced it. */
+export type StagedNewNode = Readonly<{
+  branchId: BranchId;
+  node: ChangedNode;
+}>;
+
+/** A modified inherited node tagged with the branch that modified it. */
+export type StagedModifiedNode = Readonly<{
+  branchId: BranchId;
+  node: ModifiedNode;
+}>;
+
+/** A deleted inherited node tagged with the branch that deleted it. */
+type StagedDeletedNode = Readonly<{
+  branchId: BranchId;
+  node: DeletedNode;
+}>;
+
+/** A new fork edge tagged with the branch that introduced it. */
+export type StagedNewEdge = Readonly<{
+  branchId: BranchId;
+  edge: ChangedEdge;
+}>;
+
+/** A modified inherited edge tagged with the branch that modified it. */
+export type StagedModifiedEdge = Readonly<{
+  branchId: BranchId;
+  edge: ModifiedEdge;
+}>;
+
+/** A deleted inherited edge tagged with the branch that deleted it. */
+type StagedDeletedEdge = Readonly<{
+  branchId: BranchId;
+  edge: DeletedEdge;
+}>;
+
+/**
+ * The provenance-tagged union of every branch's state-diff against the base.
+ *
+ * New items are bucketed by kind so downstream blocking/candidate-gen (T5/T6)
+ * can iterate one kind at a time. Modified and deleted items are kept as flat,
+ * fully-sorted arrays — conflict detection (T8/T8a) groups them by id itself.
+ */
+export type StagingSet = Readonly<{
+  /** New fork nodes, bucketed by kind. Map iterates in lexicographic kind order. */
+  newNodesByKind: ReadonlyMap<string, readonly StagedNewNode[]>;
+  /** Modified inherited nodes (one entry per (id, branch) modification). */
+  modifiedNodes: readonly StagedModifiedNode[];
+  /** Deleted inherited nodes (one entry per (id, branch) deletion). */
+  deletedNodes: readonly StagedDeletedNode[];
+  /** New fork edges, bucketed by kind. Map iterates in lexicographic kind order. */
+  newEdgesByKind: ReadonlyMap<string, readonly StagedNewEdge[]>;
+  /** Modified inherited edges (one entry per (id, branch) modification). */
+  modifiedEdges: readonly StagedModifiedEdge[];
+  /** Deleted inherited edges (one entry per (id, branch) deletion). */
+  deletedEdges: readonly StagedDeletedEdge[];
+}>;
+
+/**
+ * Total order over `(id, branchId)`. Used for the new-node/new-edge per-kind
+ * buckets, where every member already shares a kind so kind need not be keyed.
+ */
+function compareByIdThenBranch(
+  left: Readonly<{ id: string; branchId: BranchId }>,
+  right: Readonly<{ id: string; branchId: BranchId }>,
+): number {
+  const byId = compareStrings(left.id, right.id);
+  return byId === 0 ? compareStrings(left.branchId, right.branchId) : byId;
+}
+
+/**
+ * Total order over `(kind, id, branchId)`. Used for the flat modified/deleted
+ * collections, which mix kinds.
+ */
+function compareByKindIdBranch(
+  left: Readonly<{ kind: string; id: string; branchId: BranchId }>,
+  right: Readonly<{ kind: string; id: string; branchId: BranchId }>,
+): number {
+  const byKind = compareStrings(left.kind, right.kind);
+  if (byKind !== 0) {
+    return byKind;
+  }
+  const byId = compareStrings(left.id, right.id);
+  return byId === 0 ? compareStrings(left.branchId, right.branchId) : byId;
+}
+
+/**
+ * Groups items carrying a `kind` into a kind-keyed map whose iteration order is
+ * lexicographic by kind and whose per-kind lists are sorted by `(id, branchId)`.
+ */
+function groupByKind<
+  T extends Readonly<{ kind: string; id: string; branchId: BranchId }>,
+>(items: readonly T[]): ReadonlyMap<string, readonly T[]> {
+  const buckets = new Map<string, T[]>();
+  for (const item of items) {
+    const bucket = buckets.get(item.kind);
+    if (bucket === undefined) {
+      buckets.set(item.kind, [item]);
+    } else {
+      bucket.push(item);
+    }
+  }
+  const ordered = new Map<string, readonly T[]>();
+  for (const kind of [...buckets.keys()].sort((left, right) =>
+    compareStrings(left, right),
+  )) {
+    ordered.set(
+      kind,
+      [...buckets.get(kind)!].sort((left, right) =>
+        compareByIdThenBranch(left, right),
+      ),
+    );
+  }
+  return ordered;
+}
+
+/**
+ * Stages the UNION of all branches' diffs against the base, provenance-tagged.
+ *
+ * Each branch is diffed against `baseStore` (the immutable reference — NEVER a
+ * clone, per the Interchange `deletedAt` fidelity limitation), and every diff
+ * item is tagged with that branch's id. All branches' tagged items are then
+ * collected into flat arrays and grouped/sorted ONCE, so the result is a pure
+ * function of the unordered branch set: passing the branches in any order yields
+ * a structurally identical {@link StagingSet}.
+ *
+ * @param baseStore The immutable base store every branch is diffed against.
+ * @param branches The branches to stage. Order does not affect the result.
+ * @returns The provenance-tagged union staging set.
+ */
+export async function stageBranches<G extends GraphDef>(
+  baseStore: Store<G>,
+  branches: readonly GraphBranch<G>[],
+): Promise<StagingSet> {
+  const newNodes: (StagedNewNode & { kind: string; id: string })[] = [];
+  const modifiedNodes: (StagedModifiedNode & { kind: string; id: string })[] =
+    [];
+  const deletedNodes: (StagedDeletedNode & { kind: string; id: string })[] = [];
+  const newEdges: (StagedNewEdge & { kind: string; id: string })[] = [];
+  const modifiedEdges: (StagedModifiedEdge & { kind: string; id: string })[] =
+    [];
+  const deletedEdges: (StagedDeletedEdge & { kind: string; id: string })[] = [];
+
+  for (const branch of branches) {
+    const diff = await diffAgainstBase(baseStore, branch.store);
+    const branchId = branch.id;
+
+    for (const node of diff.nodes.new) {
+      newNodes.push({ branchId, node, kind: node.kind, id: node.id });
+    }
+    for (const node of diff.nodes.modified) {
+      modifiedNodes.push({ branchId, node, kind: node.kind, id: node.id });
+    }
+    for (const node of diff.nodes.deleted) {
+      deletedNodes.push({ branchId, node, kind: node.kind, id: node.id });
+    }
+    for (const edge of diff.edges.new) {
+      newEdges.push({ branchId, edge, kind: edge.kind, id: edge.id });
+    }
+    for (const edge of diff.edges.modified) {
+      modifiedEdges.push({ branchId, edge, kind: edge.kind, id: edge.id });
+    }
+    for (const edge of diff.edges.deleted) {
+      deletedEdges.push({ branchId, edge, kind: edge.kind, id: edge.id });
+    }
+  }
+
+  return {
+    newNodesByKind: groupByKind(newNodes),
+    modifiedNodes: [...modifiedNodes].sort((left, right) =>
+      compareByKindIdBranch(left, right),
+    ),
+    deletedNodes: [...deletedNodes].sort((left, right) =>
+      compareByKindIdBranch(left, right),
+    ),
+    newEdgesByKind: groupByKind(newEdges),
+    modifiedEdges: [...modifiedEdges].sort((left, right) =>
+      compareByKindIdBranch(left, right),
+    ),
+    deletedEdges: [...deletedEdges].sort((left, right) =>
+      compareByKindIdBranch(left, right),
+    ),
+  };
+}

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -1,0 +1,452 @@
+/**
+ * State-diff engine: compute the per-fork delta (new / modified / deleted nodes
+ * and edges) of a working copy against the IMMUTABLE original base store.
+ *
+ * Why backend-level enumeration (not `Store.find()`): the collection API
+ * silently hides soft-deleted rows, so a node deleted in a fork would be
+ * invisible and the diff could never report a deletion. We therefore go through
+ * the backend with `excludeDeleted: false` and read the raw `NodeRow`/`EdgeRow`.
+ *
+ * Row representation contract (verified against `NodeRow`/`EdgeRow`):
+ *   - `props` is a JSON STRING — every comparison `JSON.parse`s it before
+ *     `canonicalizeProps`, never feeding the raw string to the serializer (that
+ *     would key on incidental string-literal order, not canonical structure).
+ *   - `deleted_at` is a field, `undefined` for live rows. Liveness is
+ *     `row.deleted_at === undefined`.
+ *
+ * Enumeration ordering: both nodes AND edges use KEYSET pagination
+ * (`orderBy: "id"` + `after` cursor) over the unique `id`, a TOTAL order, so
+ * paging can neither skip nor duplicate a row even when many rows share a
+ * `created_at`. (Edges previously had only offset paging over the non-unique
+ * `created_at`, which could skip a boundary row under a reordering query plan.)
+ *
+ * Concurrency: P0 assumes quiesced (non-concurrent) forks per design §10.
+ * Concurrent-write enumeration is a P1 concern.
+ */
+
+import { canonicalizeProps, parseRowProps } from "./canonical-props";
+import { compareStrings } from "./node-key";
+import type {
+  EdgeId,
+  GraphBackend,
+  GraphDef,
+  NodeId,
+  NodeType,
+  Store,
+} from "./typegraph-internal";
+import { getEdgeKinds, getNodeKinds } from "./typegraph-internal";
+
+/**
+ * Local structural mirror of TypeGraph's internal `NodeRow`. 0.29.0 does NOT
+ * re-export `NodeRow`/`EdgeRow` from any public entrypoint, but `GraphBackend`
+ * (public) returns rows of exactly this shape from `findNodesByKind`, so the
+ * runtime values are structurally assignable. Keep this local mirror until using
+ * the backend row type directly buys enough clarity to justify the coupling.
+ */
+export type NodeRow = Readonly<{
+  graph_id: string;
+  kind: string;
+  id: string;
+  props: string;
+  version: number;
+  valid_from: string | undefined;
+  valid_to: string | undefined;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | undefined;
+}>;
+
+/** Local structural mirror of TypeGraph's internal `EdgeRow`. See {@link NodeRow}. */
+export type EdgeRow = Readonly<{
+  graph_id: string;
+  id: string;
+  kind: string;
+  from_kind: string;
+  from_id: string;
+  to_kind: string;
+  to_id: string;
+  props: string;
+  valid_from: string | undefined;
+  valid_to: string | undefined;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | undefined;
+}>;
+
+/**
+ * Page size for keyset/offset enumeration. Large enough to keep round-trips low
+ * on demo-scale graphs; the algorithm is correct for any positive value.
+ */
+const ENUMERATION_PAGE_SIZE = 1000;
+
+/**
+ * A node that exists in both base and fork but whose canonicalized props differ.
+ * Carries the parsed fork props so downstream phases (staging, conflict) avoid
+ * re-parsing.
+ */
+export type ModifiedNode = Readonly<{
+  id: NodeId<NodeType>;
+  kind: string;
+  baseProps: Readonly<Record<string, unknown>>;
+  forkProps: Readonly<Record<string, unknown>>;
+  row: NodeRow;
+}>;
+
+/** A node present and live only on one side of the diff. */
+export type ChangedNode = Readonly<{
+  id: NodeId<NodeType>;
+  kind: string;
+  props: Readonly<Record<string, unknown>>;
+  row: NodeRow;
+}>;
+
+/** Identifier of a node that the fork removed (live in base, gone in fork). */
+export type DeletedNode = Readonly<{
+  id: NodeId<NodeType>;
+  kind: string;
+}>;
+
+/** An edge present and live only on one side of the diff. */
+export type ChangedEdge = Readonly<{
+  id: EdgeId;
+  kind: string;
+  fromId: NodeId<NodeType>;
+  toId: NodeId<NodeType>;
+  fromKind: string;
+  toKind: string;
+  props: Readonly<Record<string, unknown>>;
+  row: EdgeRow;
+}>;
+
+/** An edge present in both base and fork but whose canonicalized props differ. */
+export type ModifiedEdge = Readonly<{
+  id: EdgeId;
+  kind: string;
+  fromId: NodeId<NodeType>;
+  toId: NodeId<NodeType>;
+  fromKind: string;
+  toKind: string;
+  baseProps: Readonly<Record<string, unknown>>;
+  forkProps: Readonly<Record<string, unknown>>;
+  row: EdgeRow;
+}>;
+
+/** Identifier of an edge the fork removed (live in base, gone in fork). */
+export type DeletedEdge = Readonly<{
+  id: EdgeId;
+  kind: string;
+}>;
+
+/**
+ * The complete delta of a fork against the original base store.
+ */
+export type StateDiff = Readonly<{
+  nodes: Readonly<{
+    new: readonly ChangedNode[];
+    modified: readonly ModifiedNode[];
+    deleted: readonly DeletedNode[];
+  }>;
+  edges: Readonly<{
+    new: readonly ChangedEdge[];
+    modified: readonly ModifiedEdge[];
+    deleted: readonly DeletedEdge[];
+  }>;
+}>;
+
+/**
+ * Enumerates EVERY node of `kind` for `graphId` (live and soft-deleted) via
+ * keyset pagination on `id`. Returns rows in ascending `id` order.
+ */
+export async function enumerateAllNodes(
+  backend: GraphBackend,
+  graphId: string,
+  kind: string,
+): Promise<readonly NodeRow[]> {
+  const collected: NodeRow[] = [];
+  let after: string | undefined = undefined;
+  for (;;) {
+    const page: readonly NodeRow[] = await backend.findNodesByKind({
+      graphId,
+      kind,
+      excludeDeleted: false,
+      orderBy: "id",
+      limit: ENUMERATION_PAGE_SIZE,
+      ...(after === undefined ? {} : { after }),
+    });
+    for (const row of page) {
+      collected.push(row);
+    }
+    if (page.length < ENUMERATION_PAGE_SIZE) {
+      break;
+    }
+    after = page.at(-1)!.id;
+  }
+  return collected;
+}
+
+/**
+ * Enumerates EVERY edge of `kind` for `graphId` (live and soft-deleted) via
+ * keyset pagination on the unique `id` (a TOTAL order), so paging can neither
+ * skip nor duplicate a row regardless of how many edges share a `created_at`.
+ * Returns rows in ascending `id` order. Mirrors {@link enumerateAllNodes}.
+ */
+export async function enumerateAllEdges(
+  backend: GraphBackend,
+  graphId: string,
+  kind: string,
+): Promise<readonly EdgeRow[]> {
+  const collected: EdgeRow[] = [];
+  let after: string | undefined = undefined;
+  for (;;) {
+    const page: readonly EdgeRow[] = await backend.findEdgesByKind({
+      graphId,
+      kind,
+      excludeDeleted: false,
+      orderBy: "id",
+      limit: ENUMERATION_PAGE_SIZE,
+      ...(after === undefined ? {} : { after }),
+    });
+    for (const row of page) {
+      collected.push(row);
+    }
+    if (page.length < ENUMERATION_PAGE_SIZE) {
+      break;
+    }
+    after = page.at(-1)!.id;
+  }
+  return collected;
+}
+
+/** True when the row is live (not soft-deleted). */
+function isLive(row: Readonly<{ deleted_at: string | undefined }>): boolean {
+  return row.deleted_at === undefined;
+}
+
+/** Indexes rows by id for O(1) base-vs-fork lookup. */
+function indexById<T extends Readonly<{ id: string }>>(
+  rows: readonly T[],
+): ReadonlyMap<string, T> {
+  const index = new Map<string, T>();
+  for (const row of rows) {
+    index.set(row.id, row);
+  }
+  return index;
+}
+
+/**
+ * Diffs the node sets of one kind. `new` = absent-in-base, live-in-fork;
+ * `deleted` = live-in-base, absent-or-soft-deleted-in-fork; `modified` =
+ * live in both with differing canonicalized props.
+ */
+function diffNodeKind(
+  kind: string,
+  baseRows: readonly NodeRow[],
+  forkRows: readonly NodeRow[],
+): Readonly<{
+  new: ChangedNode[];
+  modified: ModifiedNode[];
+  deleted: DeletedNode[];
+}> {
+  const baseIndex = indexById(baseRows);
+  const forkIndex = indexById(forkRows);
+
+  const created: ChangedNode[] = [];
+  const modified: ModifiedNode[] = [];
+  const deleted: DeletedNode[] = [];
+
+  for (const forkRow of forkRows) {
+    if (!isLive(forkRow)) {
+      continue;
+    }
+    const baseRow = baseIndex.get(forkRow.id);
+    const forkProps = parseRowProps(forkRow.props);
+    if (baseRow === undefined || !isLive(baseRow)) {
+      created.push({
+        id: forkRow.id as NodeId<NodeType>,
+        kind,
+        props: forkProps,
+        row: forkRow,
+      });
+      continue;
+    }
+    const baseProps = parseRowProps(baseRow.props);
+    if (canonicalizeProps(baseProps) !== canonicalizeProps(forkProps)) {
+      modified.push({
+        id: forkRow.id as NodeId<NodeType>,
+        kind,
+        baseProps,
+        forkProps,
+        row: forkRow,
+      });
+    }
+  }
+
+  for (const baseRow of baseRows) {
+    if (!isLive(baseRow)) {
+      continue;
+    }
+    const forkRow = forkIndex.get(baseRow.id);
+    if (forkRow === undefined || !isLive(forkRow)) {
+      deleted.push({ id: baseRow.id as NodeId<NodeType>, kind });
+    }
+  }
+
+  return { new: created, modified, deleted };
+}
+
+/**
+ * Diffs the edge sets of one kind. Same liveness/modification rules as nodes,
+ * carrying endpoint ids/kinds for the downstream repoint phase.
+ */
+function diffEdgeKind(
+  kind: string,
+  baseRows: readonly EdgeRow[],
+  forkRows: readonly EdgeRow[],
+): Readonly<{
+  new: ChangedEdge[];
+  modified: ModifiedEdge[];
+  deleted: DeletedEdge[];
+}> {
+  const baseIndex = indexById(baseRows);
+  const forkIndex = indexById(forkRows);
+
+  const created: ChangedEdge[] = [];
+  const modified: ModifiedEdge[] = [];
+  const deleted: DeletedEdge[] = [];
+
+  for (const forkRow of forkRows) {
+    if (!isLive(forkRow)) {
+      continue;
+    }
+    const baseRow = baseIndex.get(forkRow.id);
+    const forkProps = parseRowProps(forkRow.props);
+    if (baseRow === undefined || !isLive(baseRow)) {
+      created.push({
+        id: forkRow.id as EdgeId,
+        kind,
+        fromId: forkRow.from_id as NodeId<NodeType>,
+        toId: forkRow.to_id as NodeId<NodeType>,
+        fromKind: forkRow.from_kind,
+        toKind: forkRow.to_kind,
+        props: forkProps,
+        row: forkRow,
+      });
+      continue;
+    }
+    const baseProps = parseRowProps(baseRow.props);
+    if (canonicalizeProps(baseProps) !== canonicalizeProps(forkProps)) {
+      modified.push({
+        id: forkRow.id as EdgeId,
+        kind,
+        fromId: forkRow.from_id as NodeId<NodeType>,
+        toId: forkRow.to_id as NodeId<NodeType>,
+        fromKind: forkRow.from_kind,
+        toKind: forkRow.to_kind,
+        baseProps,
+        forkProps,
+        row: forkRow,
+      });
+    }
+  }
+
+  for (const baseRow of baseRows) {
+    if (!isLive(baseRow)) {
+      continue;
+    }
+    const forkRow = forkIndex.get(baseRow.id);
+    if (forkRow === undefined || !isLive(forkRow)) {
+      deleted.push({ id: baseRow.id as EdgeId, kind });
+    }
+  }
+
+  return { new: created, modified, deleted };
+}
+
+/** Stable id-ascending comparator over any `{ id: string }`. */
+function byId<T extends Readonly<{ id: string }>>(left: T, right: T): number {
+  return compareStrings(left.id, right.id);
+}
+
+/**
+ * Computes the full {@link StateDiff} of `forkStore` against `baseStore`.
+ *
+ * Both stores MUST share the same graph definition (the fork is a clone of the
+ * base). The diff is keyed by id and sorted by `(kind, id)` so its shape is a
+ * pure function of the stores' content, independent of enumeration order. No
+ * branch tag is attached here — provenance tagging happens in T7 (staging).
+ */
+export async function diffAgainstBase<G extends GraphDef>(
+  baseStore: Store<G>,
+  forkStore: Store<G>,
+): Promise<StateDiff> {
+  const graph = baseStore.graph;
+  const nodeKinds = getNodeKinds(graph);
+  const edgeKinds = getEdgeKinds(graph);
+
+  const newNodes: ChangedNode[] = [];
+  const modifiedNodes: ModifiedNode[] = [];
+  const deletedNodes: DeletedNode[] = [];
+
+  for (const kind of nodeKinds) {
+    const baseRows = await enumerateAllNodes(
+      baseStore.backend,
+      baseStore.graphId,
+      kind,
+    );
+    const forkRows = await enumerateAllNodes(
+      forkStore.backend,
+      forkStore.graphId,
+      kind,
+    );
+    const delta = diffNodeKind(kind, baseRows, forkRows);
+    for (const entry of delta.new) {
+      newNodes.push(entry);
+    }
+    for (const entry of delta.modified) {
+      modifiedNodes.push(entry);
+    }
+    for (const entry of delta.deleted) {
+      deletedNodes.push(entry);
+    }
+  }
+
+  const newEdges: ChangedEdge[] = [];
+  const modifiedEdges: ModifiedEdge[] = [];
+  const deletedEdges: DeletedEdge[] = [];
+
+  for (const kind of edgeKinds) {
+    const baseRows = await enumerateAllEdges(
+      baseStore.backend,
+      baseStore.graphId,
+      kind,
+    );
+    const forkRows = await enumerateAllEdges(
+      forkStore.backend,
+      forkStore.graphId,
+      kind,
+    );
+    const delta = diffEdgeKind(kind, baseRows, forkRows);
+    for (const entry of delta.new) {
+      newEdges.push(entry);
+    }
+    for (const entry of delta.modified) {
+      modifiedEdges.push(entry);
+    }
+    for (const entry of delta.deleted) {
+      deletedEdges.push(entry);
+    }
+  }
+
+  return {
+    nodes: {
+      new: newNodes.sort((left, right) => byId(left, right)),
+      modified: modifiedNodes.sort((left, right) => byId(left, right)),
+      deleted: deletedNodes.sort((left, right) => byId(left, right)),
+    },
+    edges: {
+      new: newEdges.sort((left, right) => byId(left, right)),
+      modified: modifiedEdges.sort((left, right) => byId(left, right)),
+      deleted: deletedEdges.sort((left, right) => byId(left, right)),
+    },
+  };
+}

--- a/packages/typegraph/src/graph-merge/type-reconcile.ts
+++ b/packages/typegraph/src/graph-merge/type-reconcile.ts
@@ -1,0 +1,231 @@
+/**
+ * Opt-in ontology type reconciliation (design §6 / §7, T10).
+ *
+ * When entity resolution (T8) collapses fork nodes into one cluster, those nodes
+ * may carry DIFFERING `node.kind` values across branches — e.g. one branch staged
+ * a `Doctor` while another staged the more-specific `SpecialistDoctor` for what is
+ * really the same person. With `reconcileTypes: "ontology"` enabled, this module
+ * uses the PUBLIC-closure glue (T2a, `closures.ts`) to decide whether those kinds
+ * are subClassOf-compatible and, if so, collapses the cluster to the
+ * MOST-SPECIFIC common type, recording a {@link TypeReconciliation}. Genuinely
+ * incompatible kinds (siblings, disjoint trees) are FLAGGED — never silently
+ * collapsed — and surfaced as a {@link DroppedItem}.
+ *
+ * MOST-SPECIFIC = the unique minimum of the subclass partial order restricted to
+ * the cluster's distinct kinds: the kind `T` such that every OTHER kind in the
+ * cluster is a (transitive) ancestor of `T` (`isReachable(closure, T, other)`),
+ * or is EQUIVALENT to `T` (mutual reachability, from folded `equivalentTo`
+ * relations). If several mutually-equivalent kinds tie for the minimum, the
+ * lexicographically-smallest representative is chosen so the outcome is
+ * deterministic. If no single minimum exists, the kinds are incompatible.
+ *
+ * This module is a PURE decision function — no I/O, no store access. The
+ * orchestrator (T11) builds the {@link ReconcileClusterInput}s from the resolved
+ * clusters + the staged nodes' kinds, then applies the returned
+ * {@link TypeReconcileResult.retypeMap} to the canonical node's `kind` and to the
+ * repointed edges' `fromKind` / `toKind` annotations while keeping endpoint ids
+ * stable (the cascade described in step 2). `mode: "off"` is a guaranteed no-op.
+ */
+
+import type { SubClassClosure } from "./closures";
+import { isReachable } from "./closures";
+import { compareStrings, idOf, type MergeKey } from "./node-key";
+import type {
+  DroppedItem,
+  ReconcileTypesMode,
+  TypeReconciliation,
+} from "./types";
+
+/**
+ * Reason recorded on a {@link DroppedItem} when a cluster's mixed kinds are
+ * neither subClassOf-comparable nor equivalent and therefore CANNOT be collapsed.
+ * The cluster is left untouched (its members keep their original kinds); this
+ * record only flags the incompatibility for the {@link MergeReport}.
+ */
+export const INCOMPATIBLE_TYPES_FLAG_REASON =
+  "type-reconcile:incompatible-kinds" as const;
+
+/**
+ * One resolved cluster fed into type reconciliation: the canonical survivor id
+ * (from T8 `pickClusterSurvivor`) and the DISTINCT kinds present across the cluster's
+ * members. Single-kind clusters (one distinct kind) are no-ops and may be omitted
+ * by the caller, but are handled defensively here too.
+ */
+export type ReconcileClusterInput = Readonly<{
+  /** The canonical survivor IDENTITY (`(kind, id)`), so the retype keys on the same
+   * composite identity the commit looks it up by — never a bare id shared across
+   * kinds. */
+  canonicalId: MergeKey;
+  /** The distinct member kinds in the cluster. Order does not affect the result. */
+  memberKinds: readonly string[];
+}>;
+
+/**
+ * The outcome of reconciling every cluster's kinds.
+ *
+ * - `reconciliations`: one {@link TypeReconciliation} per multi-kind cluster that
+ *   collapsed to a single most-specific type.
+ * - `retypeMap`: `canonicalId → toType` for exactly those reconciled clusters, so
+ *   the commit (T11) can cascade the retype onto the canonical node and the
+ *   repointed edges' endpoint-kind annotations.
+ * - `dropped`: one `{ kind: "node" }` {@link DroppedItem} per cluster whose kinds
+ *   were incompatible (flagged, NOT collapsed) — its `id` is the canonical id and
+ *   its `reason` is {@link INCOMPATIBLE_TYPES_FLAG_REASON}.
+ */
+export type TypeReconcileResult = Readonly<{
+  reconciliations: readonly TypeReconciliation[];
+  /** `canonical (kind, id) → toType` for each reconciled cluster, keyed by the
+   * composite identity so the commit cascade resolves a retype unambiguously even
+   * when an id is shared across kinds. */
+  retypeMap: ReadonlyMap<MergeKey, string>;
+  dropped: readonly DroppedItem[];
+}>;
+
+/** Distinct, lexicographically-sorted kinds — the canonical kind set. */
+function distinctKinds(kinds: readonly string[]): readonly string[] {
+  return [...new Set(kinds)].sort((left, right) => compareStrings(left, right));
+}
+
+/**
+ * Reports whether two kinds are EQUIVALENT under the closure — distinct names
+ * that fold to the same `equivalentTo` class, hence mutually reachable. (A kind is
+ * not equivalent to itself here; identical names are handled by the caller.)
+ */
+function areEquivalent(
+  closure: SubClassClosure,
+  left: string,
+  right: string,
+): boolean {
+  return (
+    left !== right &&
+    isReachable(closure, left, right) &&
+    isReachable(closure, right, left)
+  );
+}
+
+/**
+ * Reports whether `candidate` is "at or below" `other` in the subclass order:
+ * either it is a (transitive) subclass of `other`, or the two are equivalent. This
+ * is the predicate the most-specific kind must satisfy against every OTHER kind in
+ * the cluster.
+ */
+function isAtOrBelow(
+  closure: SubClassClosure,
+  candidate: string,
+  other: string,
+): boolean {
+  if (candidate === other) {
+    return true;
+  }
+  return (
+    isReachable(closure, candidate, other) ||
+    areEquivalent(closure, candidate, other)
+  );
+}
+
+/**
+ * Finds the MOST-SPECIFIC common kind among `kinds`, or `undefined` if the kinds
+ * are incompatible (no single minimum of the subclass order).
+ *
+ * A kind qualifies as the minimum when every OTHER kind is at-or-above it
+ * ({@link isAtOrBelow}). Several mutually-equivalent kinds can all qualify; the
+ * lexicographically-smallest qualifier is returned so the choice is deterministic.
+ * Siblings (e.g. two leaves under a shared parent) and disjoint trees yield no
+ * qualifier → `undefined` (incompatible).
+ */
+export function mostSpecificCommonKind(
+  closure: SubClassClosure,
+  kinds: readonly string[],
+): string | undefined {
+  const qualifiers = kinds.filter((candidate) =>
+    kinds.every((other) => isAtOrBelow(closure, candidate, other)),
+  );
+  if (qualifiers.length === 0) {
+    return undefined;
+  }
+  return [...qualifiers].sort((left, right) => compareStrings(left, right))[0]!;
+}
+
+/**
+ * Reconciles the differing kinds of each resolved cluster against the subClassOf
+ * closure.
+ *
+ * For `mode: "off"` (the default) this is a guaranteed no-op: it returns zero
+ * reconciliations, an empty retype map, and zero dropped items, regardless of the
+ * clusters.
+ *
+ * For `mode: "ontology"`, each cluster with more than one distinct kind is
+ * reconciled:
+ *
+ *   - a single MOST-SPECIFIC common kind exists → the cluster collapses to it; a
+ *     {@link TypeReconciliation} is recorded (`fromTypes` = the distinct kinds,
+ *     `toType` = the chosen kind) and `canonicalId → toType` is added to
+ *     `retypeMap`. When the most-specific kind already equals the cluster's full
+ *     (single-element-after-collapse) intent — i.e. all kinds were equivalent and
+ *     fold to the same chosen representative — the reconciliation is still
+ *     recorded so the cascade can normalize the canonical node's kind.
+ *   - no single most-specific kind (siblings / disjoint trees) → the cluster is
+ *     FLAGGED incompatible: a `{ kind: "node" }` {@link DroppedItem} with reason
+ *     {@link INCOMPATIBLE_TYPES_FLAG_REASON} is recorded and the cluster is NOT
+ *     collapsed (no retype entry).
+ *
+ * Single-kind clusters never appear in the output. All output collections are
+ * sorted by stable keys (`canonicalId`) so the result is a pure function of the
+ * unordered cluster set.
+ *
+ * @param clusters The resolved clusters with their distinct member kinds.
+ * @param closure The subClassOf closure from {@link buildSubClassClosure} (T2a).
+ * @param mode `"off"` (no-op) or `"ontology"` (reconcile).
+ */
+export function reconcileTypes(
+  clusters: readonly ReconcileClusterInput[],
+  closure: SubClassClosure,
+  mode: ReconcileTypesMode,
+): TypeReconcileResult {
+  if (mode === "off") {
+    return {
+      reconciliations: [],
+      retypeMap: new Map<MergeKey, string>(),
+      dropped: [],
+    };
+  }
+
+  const reconciliations: TypeReconciliation[] = [];
+  const retypeMap = new Map<MergeKey, string>();
+  const dropped: DroppedItem[] = [];
+
+  for (const cluster of clusters) {
+    const kinds = distinctKinds(cluster.memberKinds);
+    if (kinds.length <= 1) {
+      continue;
+    }
+
+    // The PUBLIC report fields (`entityId`, dropped `id`) carry the bare node id;
+    // the internal retype keys on the full `(kind, id)` identity.
+    const entityId = idOf(cluster.canonicalId);
+    const toType = mostSpecificCommonKind(closure, kinds);
+    if (toType === undefined) {
+      dropped.push({
+        kind: "node",
+        id: entityId,
+        reason: INCOMPATIBLE_TYPES_FLAG_REASON,
+      });
+      continue;
+    }
+
+    reconciliations.push({
+      entityId,
+      fromTypes: kinds,
+      toType,
+    });
+    retypeMap.set(cluster.canonicalId, toType);
+  }
+
+  return {
+    reconciliations: reconciliations.sort((left, right) =>
+      compareStrings(left.entityId, right.entityId),
+    ),
+    retypeMap,
+    dropped: dropped.sort((left, right) => compareStrings(left.id, right.id)),
+  };
+}

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -1,0 +1,27 @@
+export type { GraphBackend } from "../backend/types";
+export { computeUniqueKey } from "../constraints";
+export {
+  defineGraph,
+  getEdgeKinds,
+  getNodeKinds,
+  type GetNodeType,
+  type GraphDef,
+  type NodeKinds,
+} from "../core/define-graph";
+export { defineNode } from "../core/node";
+export type { EdgeId, JsonValue, NodeId, NodeType } from "../core/types";
+export { TypeGraphError, type TypeGraphErrorOptions } from "../errors";
+export { exportGraph } from "../interchange/export";
+export { importGraph } from "../interchange/import";
+export { computeTransitiveClosure, isReachable } from "../ontology/closures";
+export { sortedReplacer } from "../schema/canonical";
+export { computeSchemaHash, serializeSchema } from "../schema/serializer";
+export {
+  type OntologyIntrospection,
+  type UniqueIntrospection,
+} from "../store/introspect";
+export type { Store } from "../store/store";
+export { createStoreWithSchema } from "../store/store";
+export type { Edge, Node } from "../store/types";
+export { sha256Hex } from "../utils/hash";
+export { generateId } from "../utils/id";

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -1,0 +1,510 @@
+/**
+ * Core type model for the graph-merge primitive.
+ *
+ * Finalized against TypeGraph's real generic machinery: the design's illustrative
+ * `Node<G, K>` / `NodeId<NodeKinds<G>>` collapse onto TypeGraph's public
+ * `Node` / `Edge` / `NodeId<NodeType>` / `EdgeId` (which are themselves branded
+ * over `NodeType` / `EdgeType`). The merge surface is parameterized over
+ * `G extends GraphDef` so `Store<G>` and `GraphBranch<G>` thread the caller's
+ * concrete graph definition end-to-end.
+ *
+ * This module is pure type declarations plus the two branding helpers — no
+ * runtime merge logic.
+ */
+
+import type {
+  EdgeId,
+  GetNodeType,
+  GraphDef,
+  JsonValue,
+  Node,
+  NodeId,
+  NodeKinds,
+  NodeType,
+  Store,
+} from "./typegraph-internal";
+
+/**
+ * Opaque identifier for a branch (working copy) of a base store. Branded so a
+ * raw string cannot be passed where a deliberately-minted branch id is required.
+ */
+export type BranchId = string & Readonly<{ readonly __brand: "BranchId" }>;
+
+/**
+ * Opaque token identifying the immutable `base@V` a branch was forked from.
+ * Combines a schema hash with a content fingerprint (computed in T3). Branded so
+ * it cannot be confused with an arbitrary string.
+ */
+export type BaseVersion = string &
+  Readonly<{ readonly __brand: "BaseVersion" }>;
+
+/**
+ * Mints a {@link BranchId} from a raw string. Centralizes the brand cast so the
+ * unsafe assertion lives in exactly one place.
+ */
+export function asBranchId(value: string): BranchId {
+  return value as BranchId;
+}
+
+/**
+ * Mints a {@link BaseVersion} from a raw string. Centralizes the brand cast so
+ * the unsafe assertion lives in exactly one place.
+ */
+export function asBaseVersion(value: string): BaseVersion {
+  return value as BaseVersion;
+}
+
+/**
+ * A working-copy handle for one branch: its id, the `base@V` it forked from, and
+ * a {@link Store} over the branch's own backend.
+ */
+export type GraphBranch<G extends GraphDef> = Readonly<{
+  id: BranchId;
+  base: BaseVersion;
+  store: Store<G>;
+}>;
+
+/**
+ * Options for {@link GraphBranch} creation. `id` is optional — when omitted a
+ * fresh id is generated.
+ */
+export type BranchOptions = Readonly<{
+  id?: BranchId;
+}>;
+
+/**
+ * Turns text into an embedding vector. Injected via {@link MergeOptions.embedder}
+ * and used by the `vector` / `hybrid` similarity strategies to score candidate
+ * pairs by cosine IN MEMORY — the staged candidate nodes are unindexed in the
+ * working copy, so a backend ANN index cannot score them pairwise (see
+ * `scorePair`). Exact in-memory cosine over real model vectors is both the right
+ * scale for bounded candidate dedup and deterministic, which the merge contract
+ * requires.
+ *
+ * Batched and async: given N texts it returns N vectors in the SAME order, each a
+ * fixed-dimension `Float32Array` (every vector a given embedder returns shares one
+ * length — the model's embedding dimension). The function MUST be deterministic —
+ * the same text always yields the same vector — because the whole merge is
+ * order-independent and reproducible. Vectors need NOT be pre-normalized; cosine
+ * scoring normalizes internally.
+ *
+ * The concrete local model lives in the CONSUMER (the harness ships an
+ * all-MiniLM-L6-v2 embedder); this package depends only on the function shape, so
+ * it stays model-agnostic and lean inside the TypeGraph core package.
+ */
+export type Embedder = (
+  texts: readonly string[],
+) => Promise<readonly Float32Array[]>;
+
+/**
+ * Pluggable per-kind similarity strategy (design §8).
+ *
+ * - `vector` / `hybrid` score candidate pairs by cosine over an injected
+ *   {@link Embedder} ({@link MergeOptions.embedder}), computed in memory; they
+ *   fail with `SimilarityUnavailableError` when no embedder is configured.
+ * - `fulltext` and `custom` run with ZERO embeddings — the cross-DB-safe
+ *   default. `fulltext` uses an in-memory Sørensen–Dice trigram scorer (T6).
+ *
+ * The generic mirrors the design's `SimilarityStrategy<G, K>`: `K` constrains the
+ * `custom` score function's node arguments to the resolved kind.
+ */
+export type SimilarityStrategy<
+  G extends GraphDef = GraphDef,
+  K extends NodeType = NodeType,
+> =
+  | Readonly<{
+      kind: "hybrid";
+      fields: readonly string[];
+      weights?: Readonly<{ vector?: number; fulltext?: number }>;
+      // Phantom binding to the caller's graph, matching the design's
+      // `SimilarityStrategy<G, K>` two-parameter shape. Never set at runtime.
+      readonly __graph?: G;
+    }>
+  | Readonly<{ kind: "vector"; field: string; readonly __graph?: G }>
+  | Readonly<{
+      kind: "fulltext";
+      fields: readonly string[];
+      readonly __graph?: G;
+    }>
+  | Readonly<{
+      kind: "custom";
+      score: (a: Node<K>, b: Node<K>) => number;
+      readonly __graph?: G;
+    }>;
+
+/**
+ * Per-kind entity-resolution configuration.
+ */
+export type ResolveConfig<
+  G extends GraphDef = GraphDef,
+  K extends NodeType = NodeType,
+> = Readonly<{
+  /**
+   * Cheap exact-equality blocking key, evaluated before similarity to bound the
+   * O(n²) candidate comparisons. Returning `undefined` places the node in the
+   * shared `"unblocked"` bucket (compared all-vs-all within its kind).
+   *
+   * STAGED-vs-staged only: it is an arbitrary JS function, so it cannot be queried
+   * against the committed base. To recall committed entities by a block key
+   * (new-vs-base, the `baseKey` source §6.2), declare the key as a TypeGraph node
+   * index and name it via {@link ResolveConfig.blockIndex} instead.
+   */
+  block?: (node: Node<K>) => string | undefined;
+  /**
+   * Name of a declared TypeGraph node index (`defineNodeIndex`) whose key is this
+   * kind's NEW-vs-BASE block key (design §6.2). When set and the new-vs-base scope is
+   * driven, the `baseKey` source issues an indexed `bulkFindByIndex` lookup of
+   * committed nodes sharing each staged node's index key and proposes them as scored
+   * candidate pairs (a shared block key is a candidate, not a definitional match).
+   *
+   * The index keys on real fields (a field-set + scope + optional partial-`where`), so
+   * only a FIELD-SET block key migrates here; a transform key (`slice`/`soundex`/…)
+   * stays on the staged-only {@link block}. Unused on the public snapshot `merge()`
+   * path. An undeclared name surfaces a typed error at lookup time.
+   */
+  blockIndex?: string;
+  /**
+   * Bounded coarse candidate generation for the NO-KEY case (design §6.2, the
+   * `keyless` source). A node whose {@link block} returns `undefined` (and has no
+   * unique signature) lands in the shared `"unblocked"` bucket, which is otherwise
+   * compared ALL-vs-all — an O(n²) cliff that `maxComparisonsPerKind` then truncates
+   * to id-only. Set `keyless` to bound that bucket by single-pass SORTED-NEIGHBOURHOOD
+   * instead: the unblocked nodes are sorted by their similarity-field text (tie-broken
+   * by id) and each is proposed only against its next `window` neighbours — O(n·window),
+   * deterministic. Unset preserves today's all-vs-all behaviour. Only the `"unblocked"`
+   * bucket is affected; keyed `block()` buckets are unchanged.
+   */
+  keyless?: Readonly<{
+    /** Forward-neighbour window: each unblocked node is paired with its next `window`
+     * neighbours in the sort. Must be a positive integer. Larger → more recall, more
+     * comparisons (→ all-vs-all as `window` ≥ bucket size). */
+    window: number;
+  }>;
+  /** Similarity strategy (design §8). */
+  similarity: SimilarityStrategy<G, K>;
+  /** Candidate-merge threshold in `[0, 1]`. */
+  threshold: number;
+}>;
+
+/**
+ * A resolved cluster of node ids that the merge collapses into one canonical
+ * survivor.
+ */
+export type ResolvedCluster = Readonly<{
+  members: readonly NodeId<NodeType>[];
+}>;
+
+/**
+ * Policy for resolving conflicting property values across cluster members.
+ *
+ * - `"flag"` keeps the canonical's value and records a {@link PropertyConflict}
+ *   without auto-resolving.
+ * - `"lastWriteWins"` picks by the stable branch/logical total order — NEVER
+ *   wall-clock arrival.
+ * - `"provenanceWeighted"` picks by per-branch trust weight.
+ * - A function delegates the decision, returning the surviving {@link JsonValue}.
+ */
+export type PropertyConflictPolicy<G extends GraphDef = GraphDef> =
+  | "flag"
+  | "lastWriteWins"
+  | "provenanceWeighted"
+  | ((conflict: PropertyConflict<G>) => JsonValue);
+
+/**
+ * Policy for resolving an inherited node that is deleted by one branch and
+ * modified by another (design §6.2).
+ *
+ * - `"deleteWins"` — the node is finally DELETED; the modification is discarded.
+ * - `"modifyWins"` — the node is RESURRECTED; the modification survives.
+ * - `"flag"` (default) — the **modification SURVIVES in the merged output** (as
+ *   with `"modifyWins"`) AND an **unresolved {@link DeleteModifyConflict} is
+ *   recorded** in `report.deleteModifyConflicts` for human review. `"flag"` is
+ *   therefore NOT neutral — it keeps data and surfaces the disagreement, on the
+ *   posture that a merge must never silently destroy the only branch still
+ *   carrying data. Choose `"deleteWins"` to honor the delete by default instead.
+ */
+export type DeleteModifyPolicy = "deleteWins" | "modifyWins" | "flag";
+
+/**
+ * Behavior when `maxComparisonsPerKind` is exceeded for a kind.
+ *
+ * - `"error"` fails the merge with a typed error (default).
+ * - `"mergeByIdOnly"` skips similarity for that kind, emits no candidate edges,
+ *   and records a report warning.
+ */
+export type ComparisonCeilingPolicy = "error" | "mergeByIdOnly";
+
+/**
+ * Ontology type-reconciliation mode. `"off"` is a no-op (default); `"ontology"`
+ * collapses compatible types to the most-specific via the public subClassOf
+ * closure (T2a / T10).
+ */
+export type ReconcileTypesMode = "ontology" | "off";
+
+/**
+ * Map of node kind name → its {@link ResolveConfig}. Keys are constrained to the
+ * graph's node kinds (`keyof G["nodes"]`), so a typo or a kind that does not
+ * belong to the graph is a COMPILE error rather than a silently-ignored config
+ * (which would let those nodes merge by id only without warning). Each kind's
+ * config is bound to that kind's concrete `NodeType`, so `block(node)` and the
+ * `custom` scorer see the right node shape. All keys are optional: kinds omitted
+ * from this map merge by ID only (new fork nodes added as-is, no fuzzy
+ * resolution). For the default unparameterized `GraphDef` the keys widen back to
+ * `string`.
+ */
+export type ResolveMap<G extends GraphDef = GraphDef> = Readonly<
+  Partial<{
+    [K in NodeKinds<G>]: ResolveConfig<G, GetNodeType<G, K>>;
+  }>
+>;
+
+/**
+ * Caller-facing options for {@link merge}. All fields are optional with frozen
+ * defaults applied by `normalizeMergeOptions` (see `options.ts`).
+ */
+export type MergeOptions<G extends GraphDef = GraphDef> = Readonly<{
+  /** Per-kind entity resolution. Omitted kinds merge by ID only. */
+  resolve?: ResolveMap<G>;
+  /** Reconcile differing types across forks. Default `"off"`. */
+  reconcileTypes?: ReconcileTypesMode;
+  /** Property-conflict policy for staged-vs-staged disagreements. Default `"flag"`. */
+  onPropertyConflict?: PropertyConflictPolicy<G>;
+  /**
+   * Property-conflict policy for BASE↔branch disagreements in a new-vs-base merge
+   * (§6.4-C). DISTINCT from {@link onPropertyConflict} and DOES NOT inherit it:
+   * `onPropertyConflict` can be `"lastWriteWins"` / `"provenanceWeighted"` / a
+   * function, any of which would let a fuzzy branch match silently OVERWRITE
+   * committed data. Default `"flag"` keeps the committed base value (and records the
+   * conflict). Mirrors how `onDeleteModifyConflict` is kept separate. Only consulted
+   * when a cluster contains a base member; the staged path never uses it.
+   */
+  onBasePropertyConflict?: PropertyConflictPolicy<G>;
+  /** Delete/modify-conflict policy. Default `"flag"`. */
+  onDeleteModifyConflict?: DeleteModifyPolicy;
+  /** Comparison-ceiling behavior. Default `"error"`. */
+  onComparisonCeiling?: ComparisonCeilingPolicy;
+  /**
+   * Deterministic survivor selection within a cluster. Default: the member with
+   * the lexicographically-minimal node id.
+   */
+  canonical?: (cluster: ResolvedCluster) => NodeId<NodeType>;
+  /** Populate the report-only provenance index. Default `true`. */
+  provenance?: boolean;
+  /**
+   * Persist provenance ON-GRAPH: after the commit, upsert one `{branch, sourceId}`
+   * row per contribution into a sidecar provenance graph on the target's backend
+   * (queryable via `openProvenanceStore` / `readProvenance`). Default `false`
+   * (report-only). Best-effort and post-commit — a persistence failure surfaces as
+   * a {@link MergeReport.warnings} entry, never a failed merge.
+   */
+  persistProvenance?: boolean;
+  /**
+   * Local embedder for `vector` / `hybrid` similarity (in-memory cosine over the
+   * staged candidate pairs). Required ONLY when a kind's resolve strategy is
+   * `vector` or `hybrid`; `fulltext` / `custom` ignore it. A vector/hybrid
+   * strategy with no embedder configured fails with a typed
+   * {@link import("./errors").SimilarityUnavailableError}.
+   */
+  embedder?: Embedder;
+  /** Merge receiver. Default: the base `store`, written transactionally. */
+  target?: Store<G>;
+  /** Safety ceiling on candidate comparisons per kind. Default: unbounded. */
+  maxComparisonsPerKind?: number;
+  /**
+   * Optional single-link diameter guard. When set, clusters whose pairwise
+   * distance exceeds it are split by the deterministic drop-weakest rule (T8).
+   */
+  clusterMaxDiameter?: number;
+  /**
+   * Explicit stable branch order used by `lastWriteWins` / tie-breaking. When
+   * omitted, branch ids sorted lexicographically are used. NEVER wall-clock.
+   */
+  branchOrder?: readonly BranchId[];
+  /**
+   * Per-branch trust weights consulted ONLY by the `"provenanceWeighted"`
+   * property-conflict policy ({@link onPropertyConflict} /
+   * {@link onBasePropertyConflict}): when branches disagree on a property value,
+   * the value contributed by the highest-weight branch wins. Ties fall back to
+   * {@link branchOrder} (then canonical value order); branches absent from the map
+   * default to weight `0`. Ignored by every other policy. Keyed by
+   * {@link BranchId}, like {@link branchOrder}. Without this map,
+   * `"provenanceWeighted"` has no weights to consult and degrades to
+   * `"lastWriteWins"` semantics.
+   */
+  provenanceWeights?: ReadonlyMap<BranchId, number>;
+}>;
+
+/**
+ * Object-form arguments for {@link mergeIncremental} (§6.6). The two same-typed
+ * stores are NAMED so `forkPoint` (the frozen ancestor the branches forked from, the
+ * diff reference) and `target` (the live committed graph that base lookups and the
+ * commit land on) cannot be swapped. `options.target` is ignored — `target` is the
+ * explicit arg.
+ */
+export type MergeIncrementalArgs<G extends GraphDef = GraphDef> = Readonly<{
+  forkPoint: Store<G>;
+  target: Store<G>;
+  branches: readonly GraphBranch<G>[];
+  options?: MergeOptions<G>;
+}>;
+
+/**
+ * Records that a set of fork node ids resolved to a single canonical survivor.
+ */
+export type EntityResolution = Readonly<{
+  canonicalId: NodeId<NodeType>;
+  memberIds: readonly NodeId<NodeType>[];
+  kind: string;
+  branchOrigins: readonly BranchId[];
+}>;
+
+/**
+ * One candidate value contributing to a property conflict, tagged by its origin
+ * branch.
+ */
+export type ConflictingValue = Readonly<{
+  branchId: BranchId;
+  value: JsonValue;
+}>;
+
+/**
+ * A property whose value differed across cluster members (or across the two
+ * collapsed edges for an edge conflict). `resolution` records the value the
+ * policy selected.
+ */
+export type PropertyConflict<G extends GraphDef = GraphDef> = Readonly<{
+  entityId: NodeId<NodeType> | EdgeId;
+  kind: string;
+  property: string;
+  values: readonly ConflictingValue[];
+  resolution: JsonValue;
+  // `G` keeps the public conflict type parameterized by the caller's graph
+  // (matching the design's `PropertyConflict<G>`); it carries no runtime field.
+  readonly __graph?: G;
+}>;
+
+/**
+ * An inherited node OR edge deleted by one branch and modified by another, with
+ * the resolution the {@link DeleteModifyPolicy} produced. `entityId` is a
+ * {@link NodeId} for a node conflict and an {@link EdgeId} for an edge conflict.
+ */
+export type DeleteModifyConflict = Readonly<{
+  entityId: NodeId<NodeType> | EdgeId;
+  kind: string;
+  deletedBy: BranchId;
+  modifiedBy: BranchId;
+  resolution: DeleteModifyPolicy;
+}>;
+
+/**
+ * Records that a cluster's mixed member kinds were collapsed to a single
+ * canonical (most-specific) type via ontology reconciliation.
+ */
+export type TypeReconciliation = Readonly<{
+  entityId: NodeId<NodeType>;
+  fromTypes: readonly string[];
+  toType: string;
+}>;
+
+/**
+ * An item omitted from the merged result (e.g. an edge whose endpoint was
+ * deleted, or an incompatible-typed cluster member).
+ */
+export type DroppedItem = Readonly<{
+  kind: "edge" | "node";
+  id: NodeId<NodeType> | EdgeId;
+  reason: string;
+}>;
+
+/**
+ * A `(kind, id)` node identity as surfaced in the merge report. Node identity is the
+ * PAIR, never the bare id (a `Doctor` and a `SpecialistDoctor` can share an id string),
+ * so report shapes that name nodes carry both halves.
+ */
+type ReportNodeIdentity = Readonly<{
+  kind: string;
+  id: NodeId<NodeType>;
+}>;
+
+/**
+ * An AMBIGUOUS new-vs-base match (design §6.4-A): a connected component that
+ * bridged ≥2 distinct committed base entities (directly, `baseA ~ new ~ baseB`, or
+ * through staged hops, `baseA ~ new1 ~ new2 ~ baseB`). `baseIds` are the committed
+ * entities the component spanned; `memberIds` are all of its members. Both are full
+ * `(kind, id)` identities — the guard keys on the composite identity, so a component
+ * spanning two SAME-id/different-kind bases stays distinguishable in the report. The
+ * base↔base collapse is ALWAYS REFUSED — the component is split so the committed
+ * entities stay separate. Reported regardless of how the component split. (A
+ * deliberate-collapse trust path is deferred until committed-entity re-keying + edge
+ * repoint exist; §6.4-C.)
+ */
+export type BaseAmbiguity = Readonly<{
+  baseIds: readonly ReportNodeIdentity[];
+  memberIds: readonly ReportNodeIdentity[];
+}>;
+
+/**
+ * The contribution one branch made to the merged result. Returned by
+ * {@link ProvenanceIndex.byBranch}. EXPLICITLY in-memory / report-only for P0 —
+ * no on-graph prop tagging (deferred to the AgentFS phase).
+ */
+export type BranchProvenance = Readonly<{
+  nodeIds: readonly NodeId<NodeType>[];
+  edgeIds: readonly EdgeId[];
+}>;
+
+/**
+ * Report-only, in-memory provenance index. `byBranch` answers "which
+ * nodes/edges did this branch contribute to the merged result?".
+ */
+export type ProvenanceIndex = Readonly<{
+  byBranch: (branchId: BranchId) => BranchProvenance;
+}>;
+
+/**
+ * One `{branch, sourceId}` → canonical contribution — the unit of provenance.
+ *
+ * The in-memory {@link ProvenanceIndex} collapses these to `branch → {canonical
+ * ids}`; the full record (which keeps the contributing `sourceId` and kind) is what
+ * `persistProvenance` writes to the sidecar provenance graph. `sourceId` is the
+ * fork-local id the contribution had in its branch BEFORE the merge collapsed it to
+ * `canonicalId` (equal to `canonicalId` for an in-place modification).
+ */
+export type ProvenanceRecord = Readonly<{
+  role: "node" | "edge";
+  canonicalId: string;
+  canonicalKind: string;
+  branchId: BranchId;
+  sourceId: string;
+}>;
+
+/**
+ * The full result of a {@link merge}: counts, every resolution/conflict/
+ * reconciliation/drop, and the report-only provenance index.
+ */
+export type MergeReport<G extends GraphDef = GraphDef> = Readonly<{
+  merged: Readonly<{ nodes: number; edges: number }>;
+  resolutions: readonly EntityResolution[];
+  conflicts: readonly PropertyConflict<G>[];
+  deleteModifyConflicts: readonly DeleteModifyConflict[];
+  typeReconciliations: readonly TypeReconciliation[];
+  dropped: readonly DroppedItem[];
+  /**
+   * Ambiguous new-vs-base matches (§6.4-A): components that bridged ≥2 committed
+   * base entities. Empty on the staged-vs-staged snapshot path.
+   */
+  baseAmbiguities: readonly BaseAmbiguity[];
+  provenance: ProvenanceIndex;
+  /**
+   * Non-fatal advisories from the merge — comparison-ceiling skips and, when
+   * `persistProvenance` is set, a best-effort provenance-persistence failure (the
+   * graph still committed). Empty on a clean merge.
+   */
+  warnings: readonly string[];
+  /**
+   * Present only when `persistProvenance` ran and SUCCEEDED: the sidecar provenance
+   * graph id and how many `{branch, sourceId}` rows were upserted. Absent when
+   * persistence was off or failed (a failure adds a {@link MergeReport.warnings}).
+   */
+  provenancePersisted?: Readonly<{ graphId: string; count: number }>;
+}>;

--- a/packages/typegraph/src/graph-merge/union-find.ts
+++ b/packages/typegraph/src/graph-merge/union-find.ts
@@ -1,0 +1,64 @@
+/**
+ * A deterministic disjoint-set forest (union-find), shared by every merge phase
+ * that folds a set of items into equivalence classes — ontology equivalence
+ * (`closures.ts`), candidate clustering (`clustering.ts`), and cross-kind identity
+ * grouping (`sources.ts`).
+ *
+ * Determinism is the load-bearing property: path compression keeps `find` flat,
+ * and the union rule makes the chosen representative a pure function of the union
+ * SET, not the union order — the item that compares LEAST (by the `compare`
+ * supplied at construction) always becomes the root. Two runs that union the same
+ * pairs in any order therefore produce identical roots, which is what lets the
+ * merge's partitions be order-independent. Callers that only need the partition
+ * (and re-sort each group) may pass any total order; callers that expose the
+ * representative (e.g. an equivalence-class canonical) pass the comparator whose
+ * minimum they want as the representative.
+ */
+export class UnionFind<T> {
+  private readonly parent = new Map<T, T>();
+
+  constructor(private readonly compare: (left: T, right: T) => number) {}
+
+  /** Adds `value` as its own singleton set if it is not already present. */
+  add(value: T): void {
+    if (!this.parent.has(value)) {
+      this.parent.set(value, value);
+    }
+  }
+
+  /** Returns the representative of `value`'s set, compressing the path to it. */
+  find(value: T): T {
+    this.add(value);
+    let root = value;
+    while (this.parent.get(root) !== root) {
+      root = this.parent.get(root)!;
+    }
+    // Path compression: point every node on the walk straight at the root.
+    let cursor = value;
+    while (cursor !== root) {
+      const next = this.parent.get(cursor)!;
+      this.parent.set(cursor, root);
+      cursor = next;
+    }
+    return root;
+  }
+
+  /** Merges the sets of `left` and `right`; the `compare`-minimal root wins. */
+  union(left: T, right: T): void {
+    const leftRoot = this.find(left);
+    const rightRoot = this.find(right);
+    if (leftRoot === rightRoot) {
+      return;
+    }
+    if (this.compare(leftRoot, rightRoot) <= 0) {
+      this.parent.set(rightRoot, leftRoot);
+    } else {
+      this.parent.set(leftRoot, rightRoot);
+    }
+  }
+
+  /** Every value seen by {@link add}/{@link find}/{@link union}, insertion order. */
+  members(): readonly T[] {
+    return [...this.parent.keys()];
+  }
+}

--- a/packages/typegraph/src/graph-merge/working-copy.ts
+++ b/packages/typegraph/src/graph-merge/working-copy.ts
@@ -1,0 +1,139 @@
+/**
+ * Pluggable working-copy strategy: how `branch()` produces an isolated,
+ * independently-mutable copy of a base store.
+ *
+ * The P0 default is a faithful CLONE via the public interchange API
+ * ({@link cloneWorkingCopyStrategy}): `exportGraph` the base, then `importGraph`
+ * into a fresh store on a caller-provided backend. IDs are preserved by
+ * interchange, so the diff engine (T3) can key on stable ids across base and
+ * fork. This leverages public entrypoints only, needs zero schema changes, and
+ * behaves identically across SQLite and Postgres.
+ *
+ * INTERCHANGE FIDELITY LIMITATION (verified, design §13.x): the interchange
+ * `meta` schema has no `deletedAt` field, so a base row that is already
+ * soft-deleted would round-trip into the clone as LIVE (its tombstone lost). A
+ * resurrected row would then read as a spurious `new` node in the fork's diff —
+ * the base row is non-live, so `diffNodeKind` takes its `!isLive(base)` branch and
+ * reports the (live, clone-resurrected) row as an addition — silently re-creating a
+ * deleted node on commit. We therefore export with `includeDeleted: false`: the
+ * clone carries only the base's LIVE state, exactly what `branch()` needs. The
+ * merge state-diff is still computed against the ORIGINAL base store (live rows
+ * only) as the immutable reference, never against the clone (clones regenerate
+ * `created_at`/`updated_at`, which would otherwise destabilize `base@V`).
+ *
+ * Logical-namespace (copy-on-write within one backend, no full data copy) is a
+ * future strategy slot — see the `WorkingCopyStrategy` interface — deferred past
+ * P0.
+ */
+
+import { BranchError } from "./errors";
+import type { GraphBackend, GraphDef, Store } from "./typegraph-internal";
+import { createStoreWithSchema } from "./typegraph-internal";
+import { exportGraph, importGraph } from "./typegraph-internal";
+
+/**
+ * Batch size for the clone's `importGraph` pass. Large enough to keep
+ * round-trips low on demo-scale graphs; correctness is independent of the value.
+ */
+const CLONE_IMPORT_BATCH_SIZE = 1000;
+
+/**
+ * How `branch()` materializes a working copy of a base store.
+ *
+ * `create` receives the live base store and returns a fresh, independently
+ * mutable {@link Store} over the SAME graph definition, seeded with the base's
+ * current state. Mutating the returned store MUST NOT affect the base.
+ *
+ * The single method is the only extension point: alternative strategies
+ * (e.g. a future logical-namespace copy-on-write within one backend) implement
+ * the same contract.
+ */
+export type WorkingCopyStrategy<G extends GraphDef> = Readonly<{
+  create: (baseStore: Store<G>) => Promise<Store<G>>;
+}>;
+
+/**
+ * Factory for a caller-provided backend. `branch()` stays backend-agnostic by
+ * delegating backend construction to the caller: the clone strategy calls this
+ * once per `create()` to obtain the fresh backend that backs the working copy.
+ *
+ * Returning a promise lets async backends (e.g. PGlite, which boots an
+ * in-process Postgres engine) be constructed lazily at branch time.
+ *
+ * The returned backend MUST be EMPTY (no rows for the base graph): the clone
+ * seeds it from the base via `importGraph` with `onConflict: "error"`, so a
+ * pre-existing row is surfaced as a {@link BranchError} rather than silently
+ * skipped (which would leave the working copy diverging from the base).
+ */
+export type MakeBackend = () => Promise<GraphBackend>;
+
+/**
+ * The P0 default working-copy strategy: faithful clone via export/import.
+ *
+ * On each `create(baseStore)`:
+ *   1. `exportGraph(baseStore, { includeMeta: true, includeDeleted: false })` —
+ *      `includeMeta: true` carries `created_at`/`updated_at`; `includeDeleted:
+ *      false` keeps the clone to LIVE rows only. Shipping soft-deleted rows is
+ *      unsafe: the meta schema has no `deletedAt`, so they would import as live and
+ *      resurrect on the fork's diff (see the fidelity note above). `branch()` only
+ *      needs the base's live state.
+ *   2. Create a fresh store over the caller-provided backend with the SAME graph
+ *      definition via `createStoreWithSchema`.
+ *   3. `importGraph(freshStore, data, { onConflict: "error", ... })` — ids are
+ *      preserved so the diff engine can key on them. `onConflict: "error"`
+ *      requires the backend to be EMPTY: a pre-existing row is a contract
+ *      violation that must surface loudly, never be silently skipped (a skipped
+ *      row would leave the clone diverging from the base, so the fork's diff would
+ *      report phantom modifications/deletions). `importGraph` RETURNS
+ *      `{ success, errors }` rather than throwing on a per-row rejection, so its
+ *      result is checked and any failure fails the branch.
+ *
+ * The backend `makeBackend()` returns is opened here, so any failure AFTER it is
+ * created closes it before rethrowing — only the success path hands the backend
+ * (via the returned store) to the caller, who then owns its lifecycle.
+ *
+ * @param makeBackend - Constructs the fresh, EMPTY backend the working copy is
+ *   built on.
+ */
+export function cloneWorkingCopyStrategy<G extends GraphDef>(
+  makeBackend: MakeBackend,
+): WorkingCopyStrategy<G> {
+  return {
+    create: async (baseStore: Store<G>): Promise<Store<G>> => {
+      const data = await exportGraph(baseStore, {
+        includeMeta: true,
+        includeDeleted: false,
+      });
+      const backend = await makeBackend();
+      try {
+        const [freshStore] = await createStoreWithSchema(
+          baseStore.graph,
+          backend,
+        );
+        const result = await importGraph(freshStore, data, {
+          onConflict: "error",
+          onUnknownProperty: "error",
+          validateReferences: true,
+          batchSize: CLONE_IMPORT_BATCH_SIZE,
+        });
+        if (!result.success) {
+          throw new BranchError(
+            "Clone import failed: the working copy could not be seeded from the base store. The backend returned by makeBackend() must be empty.",
+            { details: { errors: result.errors } },
+          );
+        }
+        return freshStore;
+      } catch (error) {
+        // The backend was opened above; close it on any failure so its
+        // connection / file handle / in-process engine cannot leak. A close
+        // failure must not mask the original error.
+        try {
+          await backend.close();
+        } catch {
+          // Intentionally ignored — surface the original branch failure.
+        }
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/typegraph/src/utils/result.ts
+++ b/packages/typegraph/src/utils/result.ts
@@ -42,19 +42,25 @@ export function unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T {
 
 /**
  * Type guard to check if result is successful.
+ *
+ * Narrows to the `Readonly<{...}>` success arm so that an early-return on the
+ * negative branch (`if (isErr(x)) return; x.data`) leaves the success arm
+ * reachable — the union members are themselves `Readonly`, so a mutable
+ * predicate target would subtract nothing and break narrowing for callers.
  */
 export function isOk<T, E>(
   result: Result<T, E>,
-): result is { success: true; data: T } {
+): result is Readonly<{ success: true; data: T }> {
   return result.success;
 }
 
 /**
- * Type guard to check if result is an error.
+ * Type guard to check if result is an error. See {@link isOk} for why the
+ * predicate narrows to the `Readonly<{...}>` arm.
  */
 export function isErr<T, E>(
   result: Result<T, E>,
-): result is { success: false; error: E } {
+): result is Readonly<{ success: false; error: E }> {
   return !result.success;
 }
 

--- a/packages/typegraph/test-d/graph-merge.test-d.ts
+++ b/packages/typegraph/test-d/graph-merge.test-d.ts
@@ -1,0 +1,86 @@
+import { expectAssignable, expectError, expectType } from "tsd";
+import { z } from "zod";
+
+import { type GraphBackend, defineGraph, defineNode, type Store } from "..";
+import {
+  BranchError,
+  type GraphBranch,
+  type MakeBackend,
+  type MergeOptions,
+  MergeError,
+  type MergeReport,
+  type ReconcileTypesMode,
+  type Result,
+  type WorkingCopyStrategy,
+  branch,
+  cloneWorkingCopyStrategy,
+  isErr,
+  isOk,
+  merge,
+  normalizeMergeOptions,
+  unwrap,
+} from "../dist/graph-merge";
+
+const Person = defineNode("Person", {
+  schema: z.object({
+    birthDate: z.string(),
+    name: z.string(),
+  }),
+});
+
+const graph = defineGraph({
+  id: "graph_merge_typetest",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+declare const backend: GraphBackend;
+declare const store: Store<typeof graph>;
+declare const branches: readonly GraphBranch<typeof graph>[];
+
+const makeBackend: MakeBackend = () => Promise.resolve(backend);
+const strategy = cloneWorkingCopyStrategy<typeof graph>(makeBackend);
+expectAssignable<MakeBackend>(makeBackend);
+expectAssignable<WorkingCopyStrategy<typeof graph>>(strategy);
+
+const options: MergeOptions<typeof graph> = {
+  resolve: {
+    Person: {
+      block: () => "same-day",
+      similarity: { kind: "fulltext", fields: ["name"] },
+      threshold: 0.85,
+    },
+  },
+  reconcileTypes: "ontology",
+  onPropertyConflict: "flag",
+};
+
+// A resolve key that is not a node kind of `graph` is a COMPILE error, not a
+// silently-ignored config that would let those nodes merge by id only (#6 / B2).
+expectError<MergeOptions<typeof graph>>({
+  resolve: {
+    Patient: {
+      similarity: { kind: "fulltext", fields: ["name"] },
+      threshold: 0.85,
+    },
+  },
+});
+
+const normalized = normalizeMergeOptions(options);
+expectType<ReconcileTypesMode>(normalized.reconcileTypes);
+
+expectType<Promise<Result<GraphBranch<typeof graph>, BranchError>>>(
+  branch(store, makeBackend),
+);
+expectType<Promise<Result<MergeReport<typeof graph>, MergeError>>>(
+  merge(store, branches, options),
+);
+
+declare const mergeResult: Result<MergeReport<typeof graph>, MergeError>;
+if (isOk(mergeResult)) {
+  expectAssignable<MergeReport<typeof graph>>(mergeResult.data);
+}
+if (isErr(mergeResult)) {
+  expectAssignable<MergeError>(mergeResult.error);
+}
+expectAssignable<MergeReport<typeof graph>>(unwrap(mergeResult));

--- a/packages/typegraph/tests/graph-merge/base-guard.test.ts
+++ b/packages/typegraph/tests/graph-merge/base-guard.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Step 5 contract: the component-level BASE GUARD (design §6.4-A).
+ *
+ * Single-link clustering is transitive, so two committed base entities fuse through
+ * ANY chain — even one where no single new node spans both:
+ *
+ *     base-a ~ new-1 ~ new-2 ~ base-b
+ *       (forced)  (fuzzy)  (forced)
+ *
+ * new-1 matches base-a by unique value, new-2 matches base-b, and new-1 ~ new-2 is a
+ * staged fuzzy edge — so the component bridges TWO committed entities. The guard:
+ *
+ *   - DEFAULT: refuses the base↔base collapse — drop-weakest splits the component
+ *     (containment) so base-a and base-b stay SEPARATE — and reports the ambiguity.
+ *   - clusterMaxDiameter: even when the diameter guard splits the chain first, the
+ *     base guard (run on the raw components) still reports the ambiguity (§6.4-A).
+ *
+ * Runs on BOTH backends (new-vs-base semantics parity).
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { mergeAgainstBase } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    mrn: z.string(),
+    cohort: z.string(),
+  }),
+});
+
+const careGraph = defineGraph({
+  id: "base-guard-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+type CareGraph = typeof careGraph;
+
+const BRANCH = asBranchId("provider-x");
+
+/** Block by the shared cohort so the two new nodes co-block and fuzzy-match. */
+function options(
+  target: GraphBranch<CareGraph>["store"],
+  clusterMaxDiameter?: number,
+): MergeOptions<CareGraph> {
+  return {
+    target,
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { cohort?: string }).cohort,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH],
+    ...(clusterMaxDiameter === undefined ? {} : { clusterMaxDiameter }),
+  };
+}
+
+describe.each(backendMatrix())("component base guard [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  /**
+   * Builds the `base-a ~ new-1 ~ new-2 ~ base-b` chain: an empty fork-point, a
+   * branch with two near-duplicate new patients (co-blocked by cohort, each keyed to
+   * a different committed base mrn), and a target holding the two committed bases.
+   */
+  async function buildChain(): Promise<{
+    forkBase: GraphBranch<CareGraph>["store"];
+    provider: GraphBranch<CareGraph>;
+    target: GraphBranch<CareGraph>["store"];
+  }> {
+    const [forkBase] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const provider = unwrap(
+      await branch<CareGraph>(forkBase, () => makeBackend(), { id: BRANCH }),
+    );
+    // Near-duplicate names (Dice ≈ 0.857 ≥ 0.85) so new-1 ~ new-2 is a fuzzy edge
+    // STRICTLY weaker than the forced (max-score) new↔base edges — so drop-weakest
+    // severs the bridge, not a forced edge.
+    await provider.store.nodes.Patient.bulkCreate([
+      {
+        id: "new-1",
+        props: { name: "Anna Rivera", mrn: "MRN-A", cohort: "C1" },
+      },
+      {
+        id: "new-2",
+        props: { name: "Ana Rivera", mrn: "MRN-B", cohort: "C1" },
+      },
+    ]);
+    const [target] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    await target.nodes.Patient.bulkCreate([
+      { id: "base-a", props: { name: "Anna R.", mrn: "MRN-A", cohort: "C0" } },
+      { id: "base-b", props: { name: "Ana R.", mrn: "MRN-B", cohort: "C0" } },
+    ]);
+    return { forkBase, provider, target };
+  }
+
+  it("DEFAULT: refuses base↔base collapse — splits to keep both committed entities, reports ambiguity", async () => {
+    cleanups = [];
+    const { forkBase, provider, target } = await buildChain();
+
+    const result = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [provider],
+      options(target),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+    console.info(
+      `[${entry.name}] baseAmbiguities:`,
+      JSON.stringify(result.data.baseAmbiguities),
+    );
+
+    // BOTH committed entities survive, separate — the collapse was refused.
+    const patients = await target.nodes.Patient.find();
+    const ids = patients.map((p) => p.id).sort();
+    console.info(`[${entry.name}] patients:`, ids);
+    expect(ids).toEqual(["base-a", "base-b"]);
+
+    // The ambiguity is reported, spanning both base ids.
+    expect(result.data.baseAmbiguities).toHaveLength(1);
+    const ambiguity = result.data.baseAmbiguities[0]!;
+    expect(ambiguity.baseIds.map((identity) => identity.id)).toEqual([
+      "base-a",
+      "base-b",
+    ]);
+    // The report carries the full (kind, id) identity, not a bare id.
+    expect(ambiguity.baseIds.every((index) => index.kind === "Patient")).toBe(
+      true,
+    );
+    expect(ambiguity.memberIds.map((identity) => identity.id).sort()).toEqual([
+      "base-a",
+      "base-b",
+      "new-1",
+      "new-2",
+    ]);
+    expect(ambiguity.memberIds.every((index) => index.kind === "Patient")).toBe(
+      true,
+    );
+
+    // Each base absorbed its OWN matching new node — never the other base's.
+    const resolutionTargets = result.data.resolutions
+      .map((r) => r.canonicalId)
+      .sort();
+    expect(resolutionTargets).toEqual(["base-a", "base-b"]);
+  });
+
+  it("reports the ambiguity even when clusterMaxDiameter splits the chain first (§6.4-A on raw components)", async () => {
+    cleanups = [];
+    const { forkBase, provider, target } = await buildChain();
+
+    // clusterMaxDiameter: 1 forces the diameter guard to split the 3-hop chain. The
+    // base guard runs on the RAW component FIRST, so the base↔base bridge is still
+    // detected and the ambiguity reported — the diameter split cannot hide it.
+    const result = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [provider],
+      options(target, 1),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    // Ambiguity still reported despite the diameter split.
+    expect(result.data.baseAmbiguities).toHaveLength(1);
+    expect(
+      result.data.baseAmbiguities[0]!.baseIds.map((identity) => identity.id),
+    ).toEqual(["base-a", "base-b"]);
+
+    // Both committed entities still survive, separate.
+    const patients = await target.nodes.Patient.find();
+    expect(patients.map((p) => p.id).sort()).toEqual(["base-a", "base-b"]);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/base-key-source.test.ts
+++ b/packages/typegraph/tests/graph-merge/base-key-source.test.ts
@@ -1,0 +1,205 @@
+/**
+ * `baseKey` source contract (design §6.2, descriptor-backed block key). Drives
+ * `mergeAgainstBase` end-to-end over a kind whose NEW-vs-BASE block key is a declared
+ * TypeGraph node index (`defineNodeIndex`), named via `ResolveConfig.blockIndex`, and
+ * proves the source's defining behaviours:
+ *
+ *   - a staged node sharing a committed node's INDEX key becomes a SCORED candidate
+ *     pair — it merges (base-id-wins) only when it CLEARS the kind's threshold;
+ *   - a shared index key is NOT definitional: a same-key pair BELOW threshold does
+ *     NOT merge (the contrast with `baseUnique`'s forced edge);
+ *   - a different index key is never even compared (the blocking reduction holds
+ *     against the base, not just staged-vs-staged).
+ *
+ * The kind has NO unique constraint, so `baseUnique` contributes nothing and `baseKey`
+ * is the only base source doing work. The branch forks from an EMPTY fork-point; the
+ * committed base lives in a separate TARGET (the evolved-base shape). Both backends.
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  defineNodeIndex,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { mergeAgainstBase } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), cohort: z.string() }),
+});
+// The NEW-vs-BASE block key: a declared, indexed field-set (here `cohort`). This is
+// the queryable surface `baseKey` looks committed nodes up against.
+const patientCohort = defineNodeIndex(Patient, {
+  name: "patient_cohort_idx",
+  fields: ["cohort"],
+});
+
+const careGraph = defineGraph({
+  id: "base-key-care",
+  // No unique constraint on Patient — so `baseUnique` is a no-op and `baseKey` owns
+  // new-vs-base recall for this kind.
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+  indexes: [patientCohort],
+});
+type CareGraph = typeof careGraph;
+type CareStore = GraphBranch<CareGraph>["store"];
+
+const BRANCH = asBranchId("provider-x");
+
+function mergeOptions(target: CareStore): MergeOptions<CareGraph> {
+  return {
+    target,
+    resolve: {
+      Patient: {
+        // No staged-vs-staged `block`; the new-vs-base key is the declared index.
+        blockIndex: "patient_cohort_idx",
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH],
+  };
+}
+
+describe.each(backendMatrix())("baseKey source [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function emptyStore(): Promise<CareStore> {
+    const [store] = await createStoreWithSchema(careGraph, await makeBackend());
+    return store;
+  }
+
+  async function forkOf(forkBase: CareStore): Promise<GraphBranch<CareGraph>> {
+    return unwrap(
+      await branch<CareGraph>(forkBase, () => makeBackend(), { id: BRANCH }),
+    );
+  }
+
+  /** Seeds the target with one committed base patient and returns it. */
+  async function targetWithBase(
+    id: string,
+    props: { name: string; cohort: string },
+  ): Promise<CareStore> {
+    const target = await emptyStore();
+    await target.nodes.Patient.bulkCreate([{ id, props }]);
+    return target;
+  }
+
+  it("MERGES a staged node sharing the index key when it clears the threshold (base-id-wins)", async () => {
+    cleanups = [];
+    const forkBase = await emptyStore();
+    const provider = await forkOf(forkBase);
+    // Same cohort as the committed base, near-duplicate name (Dice ≈ 0.857 ≥ 0.85).
+    await provider.store.nodes.Patient.bulkCreate([
+      { id: "new-1", props: { name: "Anna Rivera", cohort: "C1" } },
+    ]);
+    const target = await targetWithBase("base-1", {
+      name: "Ana Rivera",
+      cohort: "C1",
+    });
+
+    const result = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [provider],
+      mergeOptions(target),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+    // Absorbed onto the committed base id (no duplicate), base value kept (keep-base).
+    const patients = await target.nodes.Patient.find();
+    expect(patients.map((patient) => patient.id)).toEqual(["base-1"]);
+    expect(patients[0]!.name).toBe("Ana Rivera");
+    expect(result.data.resolutions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT merge a same-index-key pair below threshold (a block key is a candidate, not a forced match)", async () => {
+    cleanups = [];
+    const forkBase = await emptyStore();
+    const provider = await forkOf(forkBase);
+    // Same cohort (so it IS proposed as a pair) but a dissimilar name (below 0.85).
+    await provider.store.nodes.Patient.bulkCreate([
+      { id: "new-2", props: { name: "Zachary Quux", cohort: "C1" } },
+    ]);
+    const target = await targetWithBase("base-1", {
+      name: "Ana Rivera",
+      cohort: "C1",
+    });
+
+    const result = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [provider],
+      mergeOptions(target),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+    // Both survive: the shared block key was scored and REJECTED, not force-merged.
+    const ids = (await target.nodes.Patient.find())
+      .map((patient) => patient.id)
+      .sort();
+    expect(ids).toEqual(["base-1", "new-2"]);
+    expect(result.data.resolutions).toHaveLength(0);
+    // The rejected hit must NOT pull the committed base row back into the write set:
+    // exactly ONE node is committed (`new-2`); `base-1` is left untouched — no re-commit,
+    // no spurious provenance under the base sentinel. (Before the fix this was 2: the
+    // orphan base member was seeded as a singleton cluster and re-upserted.)
+    expect(result.data.merged.nodes).toBe(1);
+  });
+
+  it("never compares a staged node with a DIFFERENT index key (blocking holds vs base)", async () => {
+    cleanups = [];
+    const forkBase = await emptyStore();
+    const provider = await forkOf(forkBase);
+    // Near-duplicate name to the base, but a DIFFERENT cohort — so the index lookup
+    // never surfaces the base, and the pair is never even proposed.
+    await provider.store.nodes.Patient.bulkCreate([
+      { id: "new-3", props: { name: "Ana Rivera", cohort: "C2" } },
+    ]);
+    const target = await targetWithBase("base-1", {
+      name: "Ana Rivera",
+      cohort: "C1",
+    });
+
+    const result = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [provider],
+      mergeOptions(target),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+    const ids = (await target.nodes.Patient.find())
+      .map((patient) => patient.id)
+      .sort();
+    expect(ids).toEqual(["base-1", "new-3"]);
+    expect(result.data.resolutions).toHaveLength(0);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/base-property-conflict.test.ts
+++ b/packages/typegraph/tests/graph-merge/base-property-conflict.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Step 6 contract: onBasePropertyConflict (§6.4-C) + the provenance base sentinel
+ * (§6.4-D).
+ *
+ *   - A BASE↔branch property disagreement is governed by `onBasePropertyConflict`,
+ *     which is SEPARATE from `onPropertyConflict` and does NOT inherit it: with
+ *     `onPropertyConflict: "lastWriteWins"`, the default base policy ("flag") still
+ *     keeps the committed value — a fuzzy branch match cannot silently overwrite
+ *     committed data — while an explicit `onBasePropertyConflict` is honoured.
+ *   - A base contribution carries the reserved BASE_PROVENANCE_BRANCH sentinel and
+ *     round-trips through `persistProvenance` (NUL-free, so it persists on every
+ *     backend) and `readProvenance`.
+ *
+ * Runs on BOTH backends (new-vs-base semantics parity).
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { BASE_PROVENANCE_BRANCH } from "../../src/graph-merge/canonicalize";
+import { mergeAgainstBase } from "../../src/graph-merge/merge";
+import {
+  openProvenanceStore,
+  readProvenance,
+} from "../../src/graph-merge/provenance-store";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), mrn: z.string() }),
+});
+
+const careGraph = defineGraph({
+  id: "base-prop-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+type CareGraph = typeof careGraph;
+
+const BRANCH = asBranchId("provider-x");
+
+describe.each(backendMatrix())(
+  "base property conflict + provenance [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) {
+        await cleanup();
+      }
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    /** A branch whose new patient duplicates a committed base patient by mrn, but
+     * with a DIFFERENT name (the base↔branch conflict). */
+    async function scenario(): Promise<{
+      forkBase: GraphBranch<CareGraph>["store"];
+      provider: GraphBranch<CareGraph>;
+      target: GraphBranch<CareGraph>["store"];
+    }> {
+      const [forkBase] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      const provider = unwrap(
+        await branch<CareGraph>(forkBase, () => makeBackend(), { id: BRANCH }),
+      );
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "new-ana", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+      ]);
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      return { forkBase, provider, target };
+    }
+
+    function baseOptions(
+      target: GraphBranch<CareGraph>["store"],
+    ): MergeOptions<CareGraph> {
+      return {
+        target,
+        resolve: {
+          Patient: {
+            block: (node) => (node as unknown as { mrn?: string }).mrn,
+            similarity: { kind: "fulltext", fields: ["name"] },
+            threshold: 0.85,
+          },
+        },
+        branchOrder: [BRANCH],
+      };
+    }
+
+    it("default onBasePropertyConflict keeps the committed value even when onPropertyConflict=lastWriteWins", async () => {
+      cleanups = [];
+      const { forkBase, provider, target } = await scenario();
+
+      const result = await mergeAgainstBase<CareGraph>(forkBase, [provider], {
+        ...baseOptions(target),
+        // A staged policy that WOULD overwrite the committed value if it leaked into
+        // the base↔branch decision. onBasePropertyConflict defaults to "flag".
+        onPropertyConflict: "lastWriteWins",
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      const patients = await target.nodes.Patient.find();
+      console.info(
+        `[${entry.name}] name after merge:`,
+        patients.map((p) => p.name),
+      );
+      // The committed base value survives — the branch did NOT overwrite it.
+      expect(patients).toHaveLength(1);
+      expect(patients[0]?.name).toBe("Anna Rivera");
+
+      // The disagreement is still REPORTED (flag does not suppress it).
+      const nameConflict = result.data.conflicts.find(
+        (c) => c.property === "name" && `${c.entityId}` === "base-ana",
+      );
+      expect(nameConflict).toBeDefined();
+      expect(nameConflict?.resolution).toBe("Anna Rivera");
+    });
+
+    it("honours an explicit onBasePropertyConflict (separate from onPropertyConflict)", async () => {
+      cleanups = [];
+      const { forkBase, provider, target } = await scenario();
+
+      const result = await mergeAgainstBase<CareGraph>(forkBase, [provider], {
+        ...baseOptions(target),
+        onPropertyConflict: "flag",
+        // Explicitly let the highest-priority branch win the base↔branch conflict.
+        onBasePropertyConflict: "lastWriteWins",
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      const patients = await target.nodes.Patient.find();
+      // branch BRANCH (rank 0) outranks the base sentinel, so its value wins now.
+      expect(patients).toHaveLength(1);
+      expect(patients[0]?.name).toBe("Ana Rivera");
+    });
+
+    it("persists the base contribution under the reserved sentinel and reads it back", async () => {
+      cleanups = [];
+      const { forkBase, provider, target } = await scenario();
+
+      const result = await mergeAgainstBase<CareGraph>(forkBase, [provider], {
+        ...baseOptions(target),
+        persistProvenance: true,
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      expect(result.data.provenancePersisted).toBeDefined();
+
+      const provenanceStore = await openProvenanceStore(
+        target.backend,
+        target.graphId,
+      );
+      const baseRecords = await readProvenance(provenanceStore, {
+        branchId: BASE_PROVENANCE_BRANCH,
+      });
+      console.info(
+        `[${entry.name}] base provenance:`,
+        baseRecords.map((r) => `${r.branchId}->${r.canonicalId}`),
+      );
+      // The base contribution round-tripped: the sentinel branch credits the
+      // committed base id as the canonical it contributed to.
+      const baseContribution = baseRecords.find(
+        (r) => r.canonicalId === "base-ana",
+      );
+      expect(baseContribution).toBeDefined();
+      expect(baseContribution?.branchId).toBe(BASE_PROVENANCE_BRANCH);
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/base-unique-source.test.ts
+++ b/packages/typegraph/tests/graph-merge/base-unique-source.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Step 3 contract: the `baseUnique` candidate source (design §6.2) — the first
+ * NEW-vs-BASE source.
+ *
+ * Against a committed base store, for each declared unique constraint, it batch-looks
+ * up the staged new nodes via `bulkFindByConstraint` and, per hit, emits:
+ *
+ *   - a FORCED edge between the staged node and the committed base node
+ *     (definitional — a shared unique value is the same entity), and
+ *   - a BASE MEMBER built from the returned committed node (props stripped of the
+ *     system fields, origin "base"), with no second fetch.
+ *
+ * Misses emit nothing; a base node matched by several staged nodes yields ONE
+ * deduped base member. Runs on BOTH backends (new-vs-base semantics parity).
+ */
+
+import type { GraphBackend, Node, NodeType } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { idOf, type MergeKey } from "../../src/graph-merge/node-key";
+import { FORCED_MATCH_SCORE } from "../../src/graph-merge/scoring";
+import type {
+  BaseLookupStore,
+  SourceScope,
+} from "../../src/graph-merge/sources";
+import { baseUniqueSource } from "../../src/graph-merge/sources";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), mrn: z.string() }),
+});
+
+const careGraph = defineGraph({
+  id: "base-unique-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+
+/** A staged NEW node in its spread runtime shape (props at the top level). */
+function stagedPatient(id: string, name: string, mrn: string): Node<NodeType> {
+  return { kind: "Patient", id, name, mrn } as unknown as Node<NodeType>;
+}
+
+/**
+ * Sorts bare `a|b` edge keys for stable comparison. `idOf` projects a composite
+ * `(kind, id)` endpoint to its bare id and is a no-op on a plain id, so this accepts
+ * both the produced forced edges and the bare-id expectation literals below.
+ */
+function edgeKeys(
+  edges: readonly Readonly<{ a: string; b: string }>[],
+): string[] {
+  return edges
+    .map((edge) => `${idOf(edge.a as MergeKey)}|${idOf(edge.b as MergeKey)}`)
+    .sort();
+}
+
+describe.each(backendMatrix())("baseUnique source [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function scopeOver(
+    nodes: readonly Node<NodeType>[],
+  ): Promise<SourceScope> {
+    const [base] = await createStoreWithSchema(careGraph, await makeBackend());
+    // The committed base: two distinct patients keyed by mrn.
+    await base.nodes.Patient.bulkCreate([
+      { id: "base-anna", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      { id: "base-bob", props: { name: "Bob Lee", mrn: "MRN-2" } },
+    ]);
+    const introspection = base.introspect();
+    const uniqueConstraints =
+      introspection.kinds.find((kind) => kind.name === "Patient")?.unique ?? [];
+    return {
+      kind: "Patient",
+      blocks: new Map(),
+      nodes,
+      uniqueConstraints,
+      store: base as unknown as BaseLookupStore,
+    };
+  }
+
+  it("emits a forced edge + a base member for each unique-constraint hit", async () => {
+    cleanups = [];
+    const newAna = stagedPatient("new-ana", "Ana Rivera", "MRN-1"); // hits base-anna
+    const newBob = stagedPatient("new-bobby", "Bobby L.", "MRN-2"); // hits base-bob
+    const newCarol = stagedPatient("new-carol", "Carol King", "MRN-9"); // miss
+
+    const scope = await scopeOver([newAna, newBob, newCarol]);
+    const produced = await baseUniqueSource.generate(scope);
+
+    console.info(
+      `[${entry.name}] forced:`,
+      produced.forcedEdges.map((e) => `${idOf(e.a)}|${idOf(e.b)}@${e.score}`),
+    );
+    console.info(
+      `[${entry.name}] baseMembers:`,
+      produced.baseMembers.map(
+        (m) => `${m.id}:${m.origin}:${JSON.stringify(m.props)}`,
+      ),
+    );
+
+    // One forced edge per hit (Carol misses), endpoints id-ordered.
+    expect(edgeKeys(produced.forcedEdges)).toEqual(
+      edgeKeys([
+        { a: "base-anna", b: "new-ana" },
+        { a: "base-bob", b: "new-bobby" },
+      ]),
+    );
+    expect(
+      produced.forcedEdges.every((e) => e.score === FORCED_MATCH_SCORE),
+    ).toBe(true);
+    expect(produced.pairs).toEqual([]);
+
+    // One base member per matched committed node, origin "base", props stripped
+    // of system fields (id/kind/meta) — proving no leak from the spread Node shape.
+    const membersById = new Map(
+      produced.baseMembers.map((m) => [m.id as string, m]),
+    );
+    expect([...membersById.keys()].sort()).toEqual(["base-anna", "base-bob"]);
+    const anna = membersById.get("base-anna")!;
+    expect(anna.origin).toBe("base");
+    expect(anna.kind).toBe("Patient");
+    expect(Object.keys(anna.props).sort()).toEqual(["mrn", "name"]);
+    expect(anna.props).toEqual({ name: "Anna Rivera", mrn: "MRN-1" });
+  });
+
+  it("dedups a base node matched by several staged nodes into one base member", async () => {
+    cleanups = [];
+    // Two staged nodes share MRN-1 → both match base-anna.
+    const dupA = stagedPatient("new-1", "Ana Rivera", "MRN-1");
+    const dupB = stagedPatient("new-2", "A. Rivera", "MRN-1");
+
+    const scope = await scopeOver([dupA, dupB]);
+    const produced = await baseUniqueSource.generate(scope);
+
+    // Two forced edges (each staged node ↔ base-anna), one deduped base member.
+    expect(edgeKeys(produced.forcedEdges)).toEqual(
+      edgeKeys([
+        { a: "base-anna", b: "new-1" },
+        { a: "base-anna", b: "new-2" },
+      ]),
+    );
+    expect(produced.baseMembers).toHaveLength(1);
+    expect(`${produced.baseMembers[0]?.id}`).toBe("base-anna");
+  });
+
+  it("emits nothing when no staged node matches a committed unique value", async () => {
+    cleanups = [];
+    const miss = stagedPatient("new-x", "Zoe Adams", "MRN-404");
+    const scope = await scopeOver([miss]);
+    const produced = await baseUniqueSource.generate(scope);
+    expect(produced.forcedEdges).toEqual([]);
+    expect(produced.baseMembers).toEqual([]);
+  });
+
+  it("throws if driven without the base-query scope inputs", async () => {
+    cleanups = [];
+    await expect(
+      baseUniqueSource.generate({ kind: "Patient", blocks: new Map() }),
+    ).rejects.toThrow(/requires nodes, uniqueConstraints, and store/);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/blocking.test.ts
+++ b/packages/typegraph/tests/graph-merge/blocking.test.ts
@@ -1,0 +1,520 @@
+import type { Node, UniqueIntrospection } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  blockNodes,
+  isUniqueBucketKey,
+  UNBLOCKED_BUCKET_KEY,
+} from "../../src/graph-merge/blocking";
+import type { ResolveConfig } from "../../src/graph-merge/types";
+import { createSqliteMergeBackend } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string().optional(),
+    mrn: z.string().optional(),
+  }),
+});
+
+/**
+ * Plain Patient graph with NO unique constraint. Used for the `block()`,
+ * unblocked-fallback, and determinism tests, which freely create nodes with
+ * absent `mrn` — a unique constraint over an optional field would (correctly)
+ * reject two such rows in the same store.
+ */
+const patientGraph = defineGraph({
+  id: "blocking-patient",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+
+/**
+ * Patient graph WITH an `mrn` unique constraint. Used only for the
+ * unique-constraint short-circuit tests, where every node in a given store
+ * carries a distinct `mrn`.
+ */
+const patientGraphWithUnique = defineGraph({
+  id: "blocking-patient-unique",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+
+type PatientNode = Node<typeof Patient>;
+
+type StoreHarness<
+  G extends typeof patientGraph | typeof patientGraphWithUnique,
+> = Readonly<{
+  store: Awaited<ReturnType<typeof createStoreWithSchema<G>>>[0];
+  uniqueConstraints: readonly UniqueIntrospection[];
+  cleanup: () => Promise<void>;
+}>;
+
+/**
+ * Boots a real Patient store on an in-memory SQLite backend and returns it
+ * alongside the kind's introspected unique constraints. Using a real store keeps
+ * the test honest about the public `Node` runtime shape (props spread at the top
+ * level) and the public `store.introspect().kinds[k].unique` surface that the
+ * production caller reads.
+ */
+async function makePatientStore<
+  G extends typeof patientGraph | typeof patientGraphWithUnique,
+>(graph: G): Promise<StoreHarness<G>> {
+  const fixture = createSqliteMergeBackend();
+  const [store] = await createStoreWithSchema(graph, fixture.backend);
+  const patientKind = store
+    .introspect()
+    .kinds.find((kind) => kind.name === "Patient");
+  return {
+    store,
+    uniqueConstraints: patientKind?.unique ?? [],
+    cleanup: fixture.cleanup,
+  };
+}
+
+/** Returns a stable, comparable view of a bucket map: key -> ordered ids. */
+function bucketShape(
+  buckets: Map<string, PatientNode[]>,
+): Record<string, string[]> {
+  const shape: Record<string, string[]> = {};
+  for (const [key, members] of buckets) {
+    shape[key] = members.map((node) => node.id);
+  }
+  return shape;
+}
+
+/** Bucket keys in their actual map-iteration order (must be sorted). */
+function keyOrder(buckets: Map<string, PatientNode[]>): string[] {
+  return [...buckets.keys()];
+}
+
+const blockByBirthDate: Pick<ResolveConfig, "block"> = {
+  block: (node) => (node as unknown as { birthDate?: string }).birthDate,
+};
+
+describe("blockNodes grouping by block()", () => {
+  it("groups Patient nodes by their birthDate block key", async () => {
+    const harness = await makePatientStore(patientGraph);
+    try {
+      const alice = await harness.store.nodes.Patient.create({
+        name: "Alice",
+        birthDate: "1974-03-09",
+      });
+      const anna = await harness.store.nodes.Patient.create({
+        name: "Anna",
+        birthDate: "1974-03-09",
+      });
+      const bob = await harness.store.nodes.Patient.create({
+        name: "Bob",
+        birthDate: "1990-01-01",
+      });
+
+      const buckets = blockNodes([alice, anna, bob], blockByBirthDate);
+
+      // Two birthDate buckets; the 1974 cohort holds both Alice and Anna.
+      expect(keyOrder(buckets)).toHaveLength(2);
+      const cohort1974 = [...buckets.entries()].find(([key]) =>
+        key.includes("1974-03-09"),
+      );
+      const cohort1990 = [...buckets.entries()].find(([key]) =>
+        key.includes("1990-01-01"),
+      );
+      expect(cohort1974?.[1].map((node) => node.id).sort()).toEqual(
+        [alice.id, anna.id].sort(),
+      );
+      expect(cohort1990?.[1].map((node) => node.id)).toEqual([bob.id]);
+      // No node fell through to the all-vs-all fallback.
+      expect(buckets.has(UNBLOCKED_BUCKET_KEY)).toBe(false);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("places nodes whose block() returns undefined into the unblocked bucket", async () => {
+    const harness = await makePatientStore(patientGraph);
+    try {
+      // No birthDate -> block() is undefined; no unique constraint on this graph.
+      const noKeyA = await harness.store.nodes.Patient.create({ name: "X" });
+      const noKeyB = await harness.store.nodes.Patient.create({ name: "Y" });
+      const dated = await harness.store.nodes.Patient.create({
+        name: "Z",
+        birthDate: "2000-12-31",
+      });
+
+      const buckets = blockNodes([noKeyA, noKeyB, dated], blockByBirthDate);
+
+      expect(buckets.has(UNBLOCKED_BUCKET_KEY)).toBe(true);
+      expect(
+        buckets
+          .get(UNBLOCKED_BUCKET_KEY)!
+          .map((node) => node.id)
+          .sort(),
+      ).toEqual([noKeyA.id, noKeyB.id].sort());
+      // The dated node is in its own birthDate bucket, not unblocked.
+      const datedBucket = [...buckets.entries()].find(([key]) =>
+        key.includes("2000-12-31"),
+      );
+      expect(datedBucket?.[1].map((node) => node.id)).toEqual([dated.id]);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});
+
+describe("blockNodes unique-constraint short-circuit", () => {
+  it("co-buckets nodes sharing a unique-constraint value even without a block()", async () => {
+    const harness = await makePatientStore(patientGraphWithUnique);
+    try {
+      // No block() configured at all; rely entirely on the mrn unique constraint.
+      const noBlock: Pick<ResolveConfig, "block"> = {};
+      const shareMrnA = await harness.store.nodes.Patient.create({
+        name: "Dup A",
+        mrn: "MRN-100",
+      });
+      const distinctMrn = await harness.store.nodes.Patient.create({
+        name: "Other",
+        mrn: "MRN-200",
+      });
+
+      // A second node with the SAME mrn cannot be created in this store (the
+      // unique constraint forbids it), so model the second branch's duplicate as
+      // a node from a separate store sharing the mrn value.
+      const otherHarness = await makePatientStore(patientGraphWithUnique);
+      const shareMrnB = await otherHarness.store.nodes.Patient.create({
+        name: "Dup B",
+        mrn: "MRN-100",
+      });
+
+      const buckets = blockNodes(
+        [shareMrnA, shareMrnB, distinctMrn],
+        noBlock,
+        harness.uniqueConstraints,
+      );
+
+      // shareMrnA and shareMrnB co-bucket on MRN-100; distinctMrn is separate.
+      const mrn100 = [...buckets.entries()].find(([key]) =>
+        key.includes("MRN-100"),
+      );
+      const mrn200 = [...buckets.entries()].find(([key]) =>
+        key.includes("MRN-200"),
+      );
+      expect(mrn100?.[1].map((node) => node.id).sort()).toEqual(
+        [shareMrnA.id, shareMrnB.id].sort(),
+      );
+      expect(mrn200?.[1].map((node) => node.id)).toEqual([distinctMrn.id]);
+      expect(buckets.has(UNBLOCKED_BUCKET_KEY)).toBe(false);
+
+      await otherHarness.cleanup();
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("places a node in BOTH its block bucket and its unique bucket (union, not composite)", async () => {
+    const harness = await makePatientStore(patientGraphWithUnique);
+    try {
+      // Same birthDate, different mrn. They MUST still co-bucket on birthDate (the
+      // block key) — the old composite key wrongly intersected mrn into the block
+      // bucket and split two same-birthDate nodes so they were never compared.
+      const sameDate1 = await harness.store.nodes.Patient.create({
+        name: "P1",
+        birthDate: "1980-05-05",
+        mrn: "A-1",
+      });
+      const sameDate2 = await harness.store.nodes.Patient.create({
+        name: "P2",
+        birthDate: "1980-05-05",
+        mrn: "A-2",
+      });
+
+      const buckets = blockNodes(
+        [sameDate1, sameDate2],
+        blockByBirthDate,
+        harness.uniqueConstraints,
+      );
+
+      // The birthDate block bucket co-buckets BOTH (so candidate-gen compares them).
+      const blockBucket = [...buckets.entries()].find(([key]) =>
+        key.includes("1980-05-05"),
+      );
+      expect(blockBucket?.[1].map((node) => node.id).sort()).toEqual(
+        [sameDate1.id, sameDate2.id].sort(),
+      );
+      // PLUS a distinct mrn bucket per node (each a singleton): the union, not a
+      // composite. So there are three buckets total.
+      expect(keyOrder(buckets)).toHaveLength(3);
+      const a1 = [...buckets.entries()].find(([key]) => key.includes("A-1"));
+      const a2 = [...buckets.entries()].find(([key]) => key.includes("A-2"));
+      expect(a1?.[1].map((node) => node.id)).toEqual([sameDate1.id]);
+      expect(a2?.[1].map((node) => node.id)).toEqual([sameDate2.id]);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("co-buckets nodes sharing a unique value even when their block() keys DIFFER (P1 regression)", async () => {
+    const harness = await makePatientStore(patientGraphWithUnique);
+    try {
+      // The exact reported bug: two nodes share mrn but have DIFFERENT birthDate
+      // block keys. The old composite key split them, so entity resolution never
+      // compared them and the duplicate survived. They must co-bucket on the mrn.
+      const dupA = await harness.store.nodes.Patient.create({
+        name: "Dup A",
+        birthDate: "1974-03-09",
+        mrn: "MRN-100",
+      });
+      const otherHarness = await makePatientStore(patientGraphWithUnique);
+      const dupB = await otherHarness.store.nodes.Patient.create({
+        name: "Dup B",
+        birthDate: "1990-01-01",
+        mrn: "MRN-100",
+      });
+
+      const buckets = blockNodes(
+        [dupA, dupB],
+        blockByBirthDate,
+        harness.uniqueConstraints,
+      );
+
+      // Despite different birthDate buckets, they co-bucket on the shared mrn, so
+      // candidate-gen WILL compare them — the duplicate is no longer missed.
+      const mrnBucket = [...buckets.entries()].find(([key]) =>
+        key.includes("MRN-100"),
+      );
+      expect(mrnBucket?.[1].map((node) => node.id).sort()).toEqual(
+        [dupA.id, dupB.id].sort(),
+      );
+      await otherHarness.cleanup();
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});
+
+describe("blockNodes caseInsensitive collation (F6)", () => {
+  const patientGraphCaseInsensitive = defineGraph({
+    id: "blocking-patient-ci",
+    nodes: {
+      Patient: {
+        type: Patient,
+        unique: [
+          {
+            name: "mrn_ci",
+            fields: ["mrn"],
+            scope: "kind",
+            collation: "caseInsensitive",
+          },
+        ],
+      },
+    },
+    edges: {},
+  });
+
+  it("co-buckets case-variant unique values under a caseInsensitive constraint", async () => {
+    // Two case-variant mrn values are the SAME entity under caseInsensitive
+    // collation, so they MUST co-bucket — formerly the raw JSON encoding put them
+    // in different buckets and candidate-gen never compared them, so the real
+    // duplicate survived the merge. Distinct stores because one store's own
+    // constraint forbids two case-equal rows.
+    const fixtureA = createSqliteMergeBackend();
+    const fixtureB = createSqliteMergeBackend();
+    try {
+      const [storeA] = await createStoreWithSchema(
+        patientGraphCaseInsensitive,
+        fixtureA.backend,
+      );
+      const [storeB] = await createStoreWithSchema(
+        patientGraphCaseInsensitive,
+        fixtureB.backend,
+      );
+      const constraints =
+        storeA.introspect().kinds.find((kind) => kind.name === "Patient")
+          ?.unique ?? [];
+
+      const upper = await storeA.nodes.Patient.create({
+        name: "Upper",
+        mrn: "MRN-100",
+      });
+      const lower = await storeB.nodes.Patient.create({
+        name: "Lower",
+        mrn: "mrn-100",
+      });
+
+      const buckets = blockNodes([upper, lower], {}, constraints);
+
+      expect(keyOrder(buckets)).toHaveLength(1);
+      const [, members] = [...buckets.entries()][0]!;
+      expect(members.map((node) => node.id).sort()).toEqual(
+        [upper.id, lower.id].sort(),
+      );
+      expect(buckets.has(UNBLOCKED_BUCKET_KEY)).toBe(false);
+    } finally {
+      await fixtureA.cleanup();
+      await fixtureB.cleanup();
+    }
+  });
+});
+
+describe("blockNodes unique key matches enforcement (#1)", () => {
+  const Account = defineNode("Account", {
+    schema: z.object({
+      name: z.string(),
+      ref: z.union([z.string(), z.number()]).nullable().optional(),
+    }),
+  });
+  const accountGraph = defineGraph({
+    id: "blocking-account-unique",
+    nodes: {
+      Account: {
+        type: Account,
+        unique: [
+          {
+            name: "ref_unique",
+            fields: ["ref"],
+            scope: "kind",
+            collation: "binary",
+          },
+        ],
+      },
+    },
+    edges: {},
+  });
+
+  async function makeAccountStore() {
+    const fixture = createSqliteMergeBackend();
+    const [store] = await createStoreWithSchema(accountGraph, fixture.backend);
+    const constraints =
+      store.introspect().kinds.find((kind) => kind.name === "Account")
+        ?.unique ?? [];
+    return { store, constraints, cleanup: fixture.cleanup };
+  }
+
+  /** Unique bucket keys are the ones candidate-gen FORCE-merges. */
+  function uniqueBucketKeys(buckets: Map<string, Node<typeof Account>[]>) {
+    return [...buckets.keys()].filter((key) => isUniqueBucketKey(key));
+  }
+
+  it('co-buckets the number 1 and the string "1" (the DB unique key collapses them)', async () => {
+    // computeUniqueKey maps both to "1", so committing them as two rows trips a
+    // UniquenessError. Blocking MUST co-bucket them so the merge resolves the
+    // duplicate instead of aborting — the old hand-rolled encoding split them.
+    const storeA = await makeAccountStore();
+    const storeB = await makeAccountStore();
+    try {
+      const numeric = await storeA.store.nodes.Account.create({
+        name: "Num",
+        ref: 1,
+      });
+      const stringy = await storeB.store.nodes.Account.create({
+        name: "Str",
+        ref: "1",
+      });
+
+      const buckets = blockNodes([numeric, stringy], {}, storeA.constraints);
+
+      const unique = uniqueBucketKeys(buckets);
+      expect(unique).toHaveLength(1);
+      expect(
+        buckets
+          .get(unique[0]!)!
+          .map((node) => node.id)
+          .sort(),
+      ).toEqual([numeric.id, stringy.id].sort());
+    } finally {
+      await storeA.cleanup();
+      await storeB.cleanup();
+    }
+  });
+
+  it("never force-merges two null unique values (no silent over-merge of distinct rows)", async () => {
+    // Two distinct entities that both happen to carry a null unique value must
+    // not be definitionally fused: with no `where` predicate visible, a partial
+    // unique constraint would treat them as a non-match. They land in the
+    // all-vs-all unblocked bucket (compared, never forced).
+    const storeA = await makeAccountStore();
+    const storeB = await makeAccountStore();
+    try {
+      const nullA = await storeA.store.nodes.Account.create({
+        name: "A",
+        ref: null,
+      });
+      const nullB = await storeB.store.nodes.Account.create({
+        name: "B",
+        ref: null,
+      });
+
+      const buckets = blockNodes([nullA, nullB], {}, storeA.constraints);
+
+      expect(uniqueBucketKeys(buckets)).toEqual([]);
+      expect(
+        buckets
+          .get(UNBLOCKED_BUCKET_KEY)
+          ?.map((node) => node.id)
+          .sort(),
+      ).toEqual([nullA.id, nullB.id].sort());
+    } finally {
+      await storeA.cleanup();
+      await storeB.cleanup();
+    }
+  });
+});
+
+describe("blockNodes deterministic ordering", () => {
+  it("yields identical bucket structure and member order across shuffled inputs", async () => {
+    const harness = await makePatientStore(patientGraph);
+    try {
+      const nodes: PatientNode[] = [];
+      for (let index = 0; index < 8; index += 1) {
+        // Half on 1974, half on 1990, in deliberately non-sorted name order.
+        const birthDate = index % 2 === 0 ? "1974-03-09" : "1990-01-01";
+        nodes.push(
+          await harness.store.nodes.Patient.create({
+            name: `Patient-${7 - index}`,
+            birthDate,
+          }),
+        );
+      }
+
+      const forward = blockNodes(nodes, blockByBirthDate);
+      const reversed = blockNodes([...nodes].reverse(), blockByBirthDate);
+      const rotated = blockNodes(
+        [...nodes.slice(3), ...nodes.slice(0, 3)],
+        blockByBirthDate,
+      );
+
+      // Identical key iteration order (lexicographically sorted).
+      expect(keyOrder(reversed)).toEqual(keyOrder(forward));
+      expect(keyOrder(rotated)).toEqual(keyOrder(forward));
+      // Key order is genuinely sorted, not just stable.
+      expect(keyOrder(forward)).toEqual([...keyOrder(forward)].sort());
+      // Identical per-bucket member id ordering.
+      expect(bucketShape(reversed)).toEqual(bucketShape(forward));
+      expect(bucketShape(rotated)).toEqual(bucketShape(forward));
+      // Member ids within each bucket are sorted ascending.
+      for (const [, members] of forward) {
+        const ids = members.map((node) => node.id);
+        expect(ids).toEqual([...ids].sort());
+      }
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -1,0 +1,244 @@
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import {
+  enumerateAllEdges,
+  enumerateAllNodes,
+} from "../../src/graph-merge/state-diff";
+import { asBranchId } from "../../src/graph-merge/types";
+import { cloneWorkingCopyStrategy } from "../../src/graph-merge/working-copy";
+import { backendMatrix } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+  from: [Person],
+  to: [Person],
+});
+
+const graph = defineGraph({
+  id: "branch-test",
+  nodes: { Person: { type: Person } },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+type G = typeof graph;
+
+/** Live `{ id, name }` snapshot of every Person node in a store, sorted by id. */
+async function snapshotPeople(
+  store: Store<G>,
+): Promise<readonly Readonly<{ id: string; name: unknown }>[]> {
+  const rows = await enumerateAllNodes(store.backend, store.graphId, "Person");
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => ({
+      id: row.id,
+      name: (JSON.parse(row.props) as Record<string, unknown>).name,
+    }))
+    .sort((left, right) =>
+      left.id < right.id ? -1
+      : left.id > right.id ? 1
+      : 0,
+    );
+}
+
+/** Live `{ id, from, to, since }` snapshot of every knows edge, sorted by id. */
+async function snapshotEdges(
+  store: Store<G>,
+): Promise<
+  readonly Readonly<{ id: string; from: string; to: string; since: unknown }>[]
+> {
+  const rows = await enumerateAllEdges(store.backend, store.graphId, "knows");
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => ({
+      id: row.id,
+      from: row.from_id,
+      to: row.to_id,
+      since: (JSON.parse(row.props) as Record<string, unknown>).since,
+    }))
+    .sort((left, right) =>
+      left.id < right.id ? -1
+      : left.id > right.id ? 1
+      : 0,
+    );
+}
+
+describe.each(backendMatrix())("branch [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function seedBase() {
+    const [baseStore] = await createStoreWithSchema(graph, await makeBackend());
+    const alice = await baseStore.nodes.Person.create({ name: "Alice" });
+    const bob = await baseStore.nodes.Person.create({ name: "Bob" });
+    const edge = await baseStore.edges.knows.create(alice, bob, {
+      since: "2020",
+    });
+    return {
+      baseStore,
+      aliceId: alice.id,
+      bobId: bob.id,
+      edgeId: edge.id,
+    };
+  }
+
+  it("identical base tokens, deep-copies base data, and isolates mutations", async () => {
+    const { baseStore, aliceId, bobId, edgeId } = await seedBase();
+
+    const baseBefore = await snapshotPeople(baseStore);
+    const baseEdgesBefore = await snapshotEdges(baseStore);
+
+    const branchAResult = await branch<G>(baseStore, () => makeBackend());
+    const branchBResult = await branch<G>(baseStore, () => makeBackend());
+    expect(isOk(branchAResult)).toBe(true);
+    expect(isOk(branchBResult)).toBe(true);
+    const branchA = unwrap(branchAResult);
+    const branchB = unwrap(branchBResult);
+
+    // (a) Both branches forked from the same immutable base@V.
+    expect(branchA.base).toBe(branchB.base);
+
+    // Distinct branch ids and distinct backing stores.
+    expect(branchA.id).not.toBe(branchB.id);
+    expect(branchA.store).not.toBe(branchB.store);
+    expect(branchA.store.backend).not.toBe(branchB.store.backend);
+    expect(branchA.store.backend).not.toBe(baseStore.backend);
+
+    // (b) Each branch.store is a deep, id-preserving copy of base data.
+    expect(await snapshotPeople(branchA.store)).toEqual(baseBefore);
+    expect(await snapshotPeople(branchB.store)).toEqual(baseBefore);
+    expect(await snapshotEdges(branchA.store)).toEqual(baseEdgesBefore);
+    expect(await snapshotEdges(branchB.store)).toEqual(baseEdgesBefore);
+    // Spot-check ID preservation through the clone.
+    expect((await branchA.store.nodes.Person.getById(aliceId))?.name).toBe(
+      "Alice",
+    );
+    expect((await branchB.store.nodes.Person.getById(aliceId))?.name).toBe(
+      "Alice",
+    );
+
+    // (c) Mutating branchA affects neither base nor branchB.
+    await branchA.store.nodes.Person.update(aliceId, { name: "Alice (A)" });
+    await branchA.store.nodes.Person.create({ name: "Dave (A only)" });
+    await branchA.store.edges.knows.delete(edgeId);
+    await branchA.store.nodes.Person.delete(bobId);
+
+    // Base unchanged.
+    expect(await snapshotPeople(baseStore)).toEqual(baseBefore);
+    expect(await snapshotEdges(baseStore)).toEqual(baseEdgesBefore);
+    // branchB unchanged.
+    expect(await snapshotPeople(branchB.store)).toEqual(baseBefore);
+    expect(await snapshotEdges(branchB.store)).toEqual(baseEdgesBefore);
+
+    // branchA reflects its own mutations.
+    const branchAPeople = await snapshotPeople(branchA.store);
+    expect(branchAPeople.map((person) => person.name).sort()).toEqual([
+      "Alice (A)",
+      "Dave (A only)",
+    ]);
+    expect(await snapshotEdges(branchA.store)).toHaveLength(0);
+  });
+
+  it("honors an explicit branch id from options", async () => {
+    const { baseStore } = await seedBase();
+    const explicitId = asBranchId("branch-explicit-id");
+    const result = await branch<G>(baseStore, () => makeBackend(), {
+      id: explicitId,
+    });
+    expect(isOk(result)).toBe(true);
+    expect(unwrap(result).id).toBe(explicitId);
+  });
+
+  it("wraps clone failures in a BranchError with cause", async () => {
+    const { baseStore } = await seedBase();
+    const failure = new Error("backend boom");
+    const result = await branch<G>(baseStore, () => Promise.reject(failure));
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.name).toBe("BranchError");
+      expect(result.error.cause).toBe(failure);
+    }
+  });
+
+  it("fails loudly on a non-empty backend and closes it (no silent skip, no leak)", async () => {
+    const { baseStore } = await seedBase();
+
+    // A close-tracking wrapper so we can assert the failure path released the
+    // backend it opened (rather than leaking the handle).
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    let closeCount = 0;
+    const tracked: GraphBackend = new Proxy(fixture.backend, {
+      get(target, property, receiver) {
+        if (property === "close") {
+          return async () => {
+            closeCount += 1;
+            await target.close();
+          };
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    // First branch onto the empty backend succeeds and SEEDS it with base rows.
+    const first = await branch<G>(baseStore, () => Promise.resolve(tracked));
+    expect(isOk(first)).toBe(true);
+
+    // Second branch onto the now-NON-EMPTY backend must fail loudly (onConflict
+    // "error", never a silent skip) AND close the backend it was handed.
+    const closesBefore = closeCount;
+    const second = await branch<G>(baseStore, () => Promise.resolve(tracked));
+    expect(isErr(second)).toBe(true);
+    if (isErr(second)) {
+      expect(second.error.name).toBe("BranchError");
+    }
+    expect(closeCount).toBe(closesBefore + 1);
+  });
+
+  it("accepts an explicit working-copy strategy override", async () => {
+    const { baseStore, aliceId } = await seedBase();
+    const strategy = cloneWorkingCopyStrategy<G>(() => makeBackend());
+    const result = await branch<G>(
+      baseStore,
+      // makeBackend here is ignored because an explicit strategy is supplied;
+      // it must never be invoked, so reject to prove the override path is taken.
+      () => Promise.reject(new Error("default factory must not run")),
+      undefined,
+      strategy,
+    );
+    expect(isOk(result)).toBe(true);
+    const created = unwrap(result);
+    expect((await created.store.nodes.Person.getById(aliceId))?.name).toBe(
+      "Alice",
+    );
+  });
+});

--- a/packages/typegraph/tests/graph-merge/candidate-gen.test.ts
+++ b/packages/typegraph/tests/graph-merge/candidate-gen.test.ts
@@ -1,0 +1,423 @@
+import type { GraphBackend, Node } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { blockNodes } from "../../src/graph-merge/blocking";
+import type { CandidateEdge } from "../../src/graph-merge/candidate-gen";
+import { generateCandidates } from "../../src/graph-merge/candidate-gen";
+import {
+  MergeError,
+  SimilarityUnavailableError,
+} from "../../src/graph-merge/errors";
+import { idOf } from "../../src/graph-merge/node-key";
+import { isErr, isOk } from "../../src/graph-merge/result";
+import type { SimilarityContext } from "../../src/graph-merge/similarity";
+import type {
+  ResolveConfig,
+  SimilarityStrategy,
+} from "../../src/graph-merge/types";
+import { backendMatrix, fakeEmbeddings } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string().optional(),
+  }),
+});
+
+const patientGraph = defineGraph({
+  id: "candidate-gen-patient",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+
+type PatientNode = Node<typeof Patient>;
+
+const DEMO_THRESHOLD = 0.85;
+
+const fulltextName: SimilarityStrategy = {
+  kind: "fulltext",
+  fields: ["name"],
+};
+
+const blockByBirthDate: Pick<ResolveConfig, "block"> = {
+  block: (node) => (node as unknown as { birthDate?: string }).birthDate,
+};
+
+/**
+ * A stable, comparable view of an edge set: bare `a|b` id keys (drops the float
+ * score). Endpoints are composite `(kind, id)` keys; project them to bare ids so the
+ * single-kind expectations read in plain ids.
+ */
+function edgeKeys(edges: readonly CandidateEdge[]): string[] {
+  return edges.map((edge) => `${idOf(edge.a)}|${idOf(edge.b)}`);
+}
+
+async function makeHarness(backend: GraphBackend): Promise<
+  Readonly<{
+    create: (name: string, birthDate?: string) => Promise<PatientNode>;
+    ctx: SimilarityContext;
+  }>
+> {
+  const [store] = await createStoreWithSchema(patientGraph, backend);
+  return {
+    create: (name, birthDate) =>
+      store.nodes.Patient.create(
+        birthDate === undefined ? { name } : { name, birthDate },
+      ),
+    ctx: { backend },
+  };
+}
+
+describe.each(backendMatrix())("generateCandidates on $name", (entry) => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup !== undefined) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("only pairs nodes that share a block", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    // A near-duplicate PAIR co-located in the 1974 block — this pair SHOULD emit
+    // ("Anna Rivera" ~ "Ana Rivera" = 0.857, above the 0.85 threshold).
+    const anna1974 = await harness.create("Anna Rivera", "1974-03-09");
+    const ana1974 = await harness.create("Ana Rivera", "1974-03-09");
+    // An IDENTICAL-named node in a DIFFERENT block. A perfect-score match, but it
+    // shares no block with the 1974 cohort, so it must never be compared.
+    const annaOther = await harness.create("Anna Rivera", "1990-01-01");
+
+    const blocks = blockNodes([anna1974, ana1974, annaOther], blockByBirthDate);
+    const config: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: fulltextName,
+      threshold: DEMO_THRESHOLD,
+    };
+
+    const result = generateCandidates(blocks, config, harness.ctx, "error");
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      // Exactly one edge, within the 1974 block, never crossing blocks — even
+      // though annaOther is a perfect name match for anna1974.
+      const expected = [anna1974.id, ana1974.id].sort();
+      expect(edgeKeys(result.data.edges)).toEqual([
+        `${expected[0]}|${expected[1]}`,
+      ]);
+      expect(result.data.warnings).toEqual([]);
+    }
+  });
+
+  it("emits an identical edge set regardless of input node ordering", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera", "1974-03-09");
+    const ana = await harness.create("Ana Rivera", "1974-03-09");
+    const annah = await harness.create("Annah Rivera", "1974-03-09");
+    const bob = await harness.create("Bob Lee", "1974-03-09");
+    const nodes = [anna, ana, annah, bob];
+
+    const config: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: fulltextName,
+      threshold: DEMO_THRESHOLD,
+    };
+
+    const forward = generateCandidates(
+      blockNodes(nodes, blockByBirthDate),
+      config,
+      harness.ctx,
+      "error",
+    );
+    const reversed = generateCandidates(
+      blockNodes([...nodes].reverse(), blockByBirthDate),
+      config,
+      harness.ctx,
+      "error",
+    );
+    const rotated = generateCandidates(
+      blockNodes(
+        [nodes[2]!, nodes[0]!, nodes[3]!, nodes[1]!],
+        blockByBirthDate,
+      ),
+      config,
+      harness.ctx,
+      "error",
+    );
+
+    expect(isOk(forward) && isOk(reversed) && isOk(rotated)).toBe(true);
+    if (isOk(forward) && isOk(reversed) && isOk(rotated)) {
+      expect(edgeKeys(reversed.data.edges)).toEqual(
+        edgeKeys(forward.data.edges),
+      );
+      expect(edgeKeys(rotated.data.edges)).toEqual(
+        edgeKeys(forward.data.edges),
+      );
+      // The output is genuinely sorted by (a, b), not merely stable.
+      expect(edgeKeys(forward.data.edges)).toEqual(
+        [...edgeKeys(forward.data.edges)].sort(),
+      );
+      // Only the Anna~Ana pair clears 0.85; Annah (<=0.783) and Bob (0) do not.
+      const expected = [anna.id, ana.id].sort();
+      expect(edgeKeys(forward.data.edges)).toEqual([
+        `${expected[0]}|${expected[1]}`,
+      ]);
+      for (const edge of forward.data.edges) {
+        expect(idOf(edge.a)).not.toBe(bob.id);
+        expect(idOf(edge.b)).not.toBe(bob.id);
+        expect(idOf(edge.a)).not.toBe(annah.id);
+        expect(idOf(edge.b)).not.toBe(annah.id);
+      }
+    }
+  });
+
+  it("respects the threshold boundary (>= emits, just-below drops)", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera", "1974-03-09");
+    const ana = await harness.create("Ana Rivera", "1974-03-09");
+    const blocks = blockNodes([anna, ana], blockByBirthDate);
+
+    const baseConfig: Omit<ResolveConfig, "threshold"> = {
+      ...blockByBirthDate,
+      similarity: fulltextName,
+    };
+
+    // At a threshold the pair clears, the edge is emitted.
+    const clears = generateCandidates(
+      blocks,
+      { ...baseConfig, threshold: DEMO_THRESHOLD },
+      harness.ctx,
+      "error",
+    );
+    expect(isOk(clears)).toBe(true);
+    const emittedScore =
+      isOk(clears) && clears.data.edges.length === 1 ?
+        clears.data.edges[0]!.score
+      : undefined;
+    expect(emittedScore).toBeDefined();
+
+    if (emittedScore !== undefined) {
+      // A threshold exactly at the score still emits (>= is inclusive).
+      const inclusive = generateCandidates(
+        blocks,
+        { ...baseConfig, threshold: emittedScore },
+        harness.ctx,
+        "error",
+      );
+      expect(isOk(inclusive) && inclusive.data.edges.length === 1).toBe(true);
+
+      // A threshold just ABOVE the score drops the pair.
+      const justAbove = generateCandidates(
+        blocks,
+        { ...baseConfig, threshold: Math.min(1, emittedScore + 1e-9) },
+        harness.ctx,
+        "error",
+      );
+      expect(isOk(justAbove) && justAbove.data.edges.length === 0).toBe(true);
+
+      // A threshold of 1 drops any non-identical pair.
+      const exactlyOne = generateCandidates(
+        blocks,
+        { ...baseConfig, threshold: 1 },
+        harness.ctx,
+        "error",
+      );
+      expect(isOk(exactlyOne) && exactlyOne.data.edges.length === 0).toBe(true);
+    }
+  });
+
+  it('maxComparisonsPerKind with "error" fails the merge', async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    // Three nodes in one block => 3 unordered pairs > a ceiling of 2.
+    const a = await harness.create("Anna Rivera", "1974-03-09");
+    const b = await harness.create("Ana Rivera", "1974-03-09");
+    const c = await harness.create("Annah Rivera", "1974-03-09");
+    const blocks = blockNodes([a, b, c], blockByBirthDate);
+    const config: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: fulltextName,
+      threshold: DEMO_THRESHOLD,
+    };
+
+    const result = generateCandidates(blocks, config, harness.ctx, "error", 2);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error).toBeInstanceOf(MergeError);
+    }
+  });
+
+  it("honours ResolveConfig.keyless: windowing the no-key bucket avoids the all-vs-all ceiling (review #3)", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    // Four nodes with NO block key (undefined birthDate) → all in the "unblocked"
+    // bucket. Sorted by name they are: "ana rivera", "anna rivera", "bob lee",
+    // "carol king" — the two Riveras adjacent (Dice ≈ 0.857 ≥ 0.85).
+    const ana = await harness.create("Ana Rivera");
+    const anna = await harness.create("Anna Rivera");
+    const bob = await harness.create("Bob Lee");
+    const carol = await harness.create("Carol King");
+    const blocks = blockNodes([ana, anna, bob, carol], blockByBirthDate);
+    const baseConfig: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: fulltextName,
+      threshold: DEMO_THRESHOLD,
+    };
+
+    // Without keyless: 6 all-vs-all pairs > ceiling 3 → the helper errors.
+    const cliff = generateCandidates(
+      blocks,
+      baseConfig,
+      harness.ctx,
+      "error",
+      3,
+    );
+    expect(isErr(cliff)).toBe(true);
+
+    // With keyless window=1: 3 windowed pairs (≤ 3) → no ceiling, and only the adjacent
+    // Riveras clear the threshold. Proves generateCandidates threads keyless (before the
+    // fix it ignored it and still errored).
+    const windowed = generateCandidates(
+      blocks,
+      { ...baseConfig, keyless: { window: 1 } },
+      harness.ctx,
+      "error",
+      3,
+    );
+    expect(isOk(windowed)).toBe(true);
+    if (isOk(windowed)) {
+      expect(windowed.data.edges).toHaveLength(1);
+      const edge = windowed.data.edges[0]!;
+      expect(new Set([idOf(edge.a), idOf(edge.b)])).toEqual(
+        new Set([ana.id, anna.id]),
+      );
+    }
+  });
+
+  it('maxComparisonsPerKind with "mergeByIdOnly" skips similarity and warns', async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const a = await harness.create("Anna Rivera", "1974-03-09");
+    const b = await harness.create("Ana Rivera", "1974-03-09");
+    const c = await harness.create("Annah Rivera", "1974-03-09");
+    const blocks = blockNodes([a, b, c], blockByBirthDate);
+    const config: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: fulltextName,
+      threshold: DEMO_THRESHOLD,
+    };
+
+    const result = generateCandidates(
+      blocks,
+      config,
+      harness.ctx,
+      "mergeByIdOnly",
+      2,
+    );
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      // No candidate edges: the kind merges by id only downstream.
+      expect(result.data.edges).toEqual([]);
+      expect(result.data.warnings).toHaveLength(1);
+      expect(result.data.warnings[0]!.kind).toBe("comparisonCeiling");
+      expect(result.data.warnings[0]!.comparisons).toBe(3);
+      expect(result.data.warnings[0]!.limit).toBe(2);
+    }
+  });
+
+  it("does not fire the ceiling when comparisons equal the limit", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    // Two nodes => exactly 1 pair; a ceiling of 1 must NOT trip.
+    const a = await harness.create("Anna Rivera", "1974-03-09");
+    const b = await harness.create("Ana Rivera", "1974-03-09");
+    const blocks = blockNodes([a, b], blockByBirthDate);
+    const config: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: fulltextName,
+      threshold: DEMO_THRESHOLD,
+    };
+
+    const result = generateCandidates(blocks, config, harness.ctx, "error", 1);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data.edges).toHaveLength(1);
+      expect(result.data.warnings).toEqual([]);
+    }
+  });
+
+  it("propagates SimilarityUnavailableError from a vector strategy with no configured embedder", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const a = await harness.create("Anna Rivera", "1974-03-09");
+    const b = await harness.create("Ana Rivera", "1974-03-09");
+    const blocks = blockNodes([a, b], blockByBirthDate);
+    const vectorConfig: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: { kind: "vector", field: "name" },
+      threshold: DEMO_THRESHOLD,
+    };
+
+    // harness.ctx carries no embeddings -> vector scoring is unavailable.
+    const result = generateCandidates(
+      blocks,
+      vectorConfig,
+      harness.ctx,
+      "error",
+    );
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error).toBeInstanceOf(SimilarityUnavailableError);
+    }
+  });
+
+  it("emits a candidate edge for a vector strategy WITH an embedder", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const a = await harness.create("Anna Rivera", "1974-03-09");
+    const b = await harness.create("Ana Rivera", "1974-03-09");
+    const blocks = blockNodes([a, b], blockByBirthDate);
+    const vectorConfig: ResolveConfig = {
+      ...blockByBirthDate,
+      similarity: { kind: "vector", field: "name" },
+      threshold: 0.5,
+    };
+    const ctx: SimilarityContext = {
+      backend: fixture.backend,
+      embeddings: await fakeEmbeddings(["Anna Rivera", "Ana Rivera"]),
+    };
+
+    const result = generateCandidates(blocks, vectorConfig, ctx, "error");
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      // The near-duplicate pair clears the threshold under fake-embedding cosine.
+      expect(result.data.edges).toHaveLength(1);
+    }
+  });
+});

--- a/packages/typegraph/tests/graph-merge/canonicalize.test.ts
+++ b/packages/typegraph/tests/graph-merge/canonicalize.test.ts
@@ -1,0 +1,355 @@
+import type { JsonValue, NodeId, NodeType } from "@nicia-ai/typegraph";
+import { generateId } from "@nicia-ai/typegraph";
+import { describe, expect, it } from "vitest";
+
+import type { ClusterMember } from "../../src/graph-merge/canonicalize";
+import {
+  BASE_PROVENANCE_BRANCH,
+  canonicalizeCluster,
+  pickCanonical,
+} from "../../src/graph-merge/canonicalize";
+import type { ClusterResult } from "../../src/graph-merge/clustering";
+import { buildBranchRank } from "../../src/graph-merge/conflict-policy";
+import {
+  compareMergeKeys,
+  type MergeKey,
+  mergeKey,
+} from "../../src/graph-merge/node-key";
+import type {
+  BranchId,
+  PropertyConflictPolicy,
+  ResolvedCluster,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+
+type AnyNodeId = NodeId<NodeType>;
+
+/** A bare node id — for ClusterMember ids and the public bare-id ResolvedCluster. */
+function nodeId(value: string): AnyNodeId {
+  return value as AnyNodeId;
+}
+
+/** A composite `(kind, id)` cluster key; every member in these tests is a `Patient`. */
+function memberKey(id: string): MergeKey {
+  return mergeKey("Patient", id);
+}
+
+function lexicographic(left: string, right: string): number {
+  return (
+    left < right ? -1
+    : left > right ? 1
+    : 0
+  );
+}
+
+/** The INTERNAL composite-key cluster shape T8 emits (members are `(kind, id)` keys). */
+function clusterOf(...ids: readonly string[]): ClusterResult {
+  return {
+    members: [...ids]
+      .map((value) => memberKey(value))
+      .sort((left, right) => compareMergeKeys(left, right)),
+  };
+}
+
+/** The PUBLIC bare-id cluster shape the `pickCanonical` / `canonical` hook sees. */
+function bareCluster(...ids: readonly string[]): ResolvedCluster {
+  return {
+    members: [...ids]
+      .map((value) => nodeId(value))
+      .sort((left, right) => lexicographic(left, right)),
+  };
+}
+
+function member(
+  id: string,
+  branchId: BranchId,
+  props: Readonly<Record<string, JsonValue>>,
+): ClusterMember {
+  return { origin: "staged", id: nodeId(id), kind: "Patient", branchId, props };
+}
+
+/** Deterministically shuffles a copy of an array via a seeded LCG. */
+function shuffled<T>(items: readonly T[], seed: number): T[] {
+  const copy = [...items];
+  let state = seed;
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    state = (state * 1_103_515_245 + 12_345) & 0x7f_ff_ff_ff;
+    const swapWith = state % (index + 1);
+    const temporary = copy[index]!;
+    copy[index] = copy[swapWith]!;
+    copy[swapWith] = temporary;
+  }
+  return copy;
+}
+
+const b1 = asBranchId("branch-1");
+const b2 = asBranchId("branch-2");
+const b3 = asBranchId("branch-3");
+
+describe("pickCanonical", () => {
+  it("defaults to the lexicographically-minimal member id", () => {
+    expect(pickCanonical(bareCluster("c", "a", "b"))).toBe("a");
+  });
+
+  it("honors an explicit canonical override", () => {
+    const last = (cluster: ResolvedCluster): AnyNodeId =>
+      [...cluster.members].sort((left, right) =>
+        lexicographic(right, left),
+      )[0]!;
+    expect(pickCanonical(bareCluster("a", "b", "c"), last)).toBe("c");
+  });
+});
+
+describe("canonicalizeCluster", () => {
+  // A 3-node cluster, one member per branch, agreeing on birthDate but
+  // disagreeing on name — the classic entity-resolution property conflict.
+  const cluster = clusterOf("node-a", "node-b", "node-c");
+  const members: readonly ClusterMember[] = [
+    member("node-a", b1, { name: "Anna Rivera", birthDate: "1990-01-01" }),
+    member("node-b", b2, { name: "Ana Rivera", birthDate: "1990-01-01" }),
+    member("node-c", b3, { name: "A. Rivera", birthDate: "1990-01-01" }),
+  ];
+
+  function rank(order: readonly BranchId[]): ReadonlyMap<BranchId, number> {
+    return buildBranchRank(order, [b1, b2, b3]);
+  }
+
+  it('"flag" keeps the canonical member value and records the conflict', () => {
+    const entity = canonicalizeCluster(cluster, members, "flag", rank([]));
+
+    // Canonical is node-a (min id), whose name is "Anna Rivera".
+    expect(entity.canonicalId).toBe("node-a");
+    expect(entity.props.name).toBe("Anna Rivera");
+    // birthDate agreed → unioned, no conflict.
+    expect(entity.props.birthDate).toBe("1990-01-01");
+
+    expect(entity.conflicts).toHaveLength(1);
+    const conflict = entity.conflicts[0]!;
+    expect(conflict.property).toBe("name");
+    expect(`${conflict.entityId}`).toBe("node-a");
+    expect(conflict.resolution).toBe("Anna Rivera");
+    expect(conflict.values.map((value) => value.value).sort()).toEqual([
+      "A. Rivera",
+      "Ana Rivera",
+      "Anna Rivera",
+    ]);
+  });
+
+  it('"lastWriteWins" with branchOrder [b3,b1,b2] picks b3\'s value regardless of member array order', () => {
+    const order = [b3, b1, b2];
+
+    const natural = canonicalizeCluster(
+      cluster,
+      members,
+      "lastWriteWins",
+      rank(order),
+    );
+    expect(natural.props.name).toBe("A. Rivera");
+
+    // Shuffling the member array must not change the resolution.
+    for (let seed = 1; seed <= 5; seed += 1) {
+      const reordered = canonicalizeCluster(
+        cluster,
+        shuffled(members, seed),
+        "lastWriteWins",
+        rank(order),
+      );
+      expect(reordered.props.name).toBe("A. Rivera");
+      // The canonical id is still the min member id, independent of order.
+      expect(reordered.canonicalId).toBe("node-a");
+    }
+  });
+
+  it('"lastWriteWins" picks a different branch when the order is reversed', () => {
+    const entity = canonicalizeCluster(
+      cluster,
+      members,
+      "lastWriteWins",
+      rank([b2, b1, b3]),
+    );
+    // b2 is now highest priority → "Ana Rivera".
+    expect(entity.props.name).toBe("Ana Rivera");
+  });
+
+  it('"provenanceWeighted" picks the highest-weight branch', () => {
+    const weights = new Map<BranchId, number>([
+      [b1, 1],
+      [b2, 5],
+      [b3, 2],
+    ]);
+    const entity = canonicalizeCluster(
+      cluster,
+      members,
+      "provenanceWeighted",
+      rank([]),
+      weights,
+    );
+    expect(entity.props.name).toBe("Ana Rivera");
+  });
+
+  it("delegates to a function policy with a deterministic conflict record", () => {
+    const longest: PropertyConflictPolicy = (conflict) => {
+      const candidates = conflict.values.map((entry) => entry.value as string);
+      return candidates.reduce((current, candidate) =>
+        candidate.length > current.length ? candidate : current,
+      );
+    };
+    const entity = canonicalizeCluster(cluster, members, longest, rank([]));
+    expect(entity.props.name).toBe("Anna Rivera");
+  });
+
+  it("records no conflict when every member agrees on a property", () => {
+    const agreeing = clusterOf("x", "y");
+    const agreeingMembers: readonly ClusterMember[] = [
+      member("x", b1, { name: "Same Name" }),
+      member("y", b2, { name: "Same Name" }),
+    ];
+    const entity = canonicalizeCluster(
+      agreeing,
+      agreeingMembers,
+      "flag",
+      rank([]),
+    );
+    expect(entity.conflicts).toHaveLength(0);
+    expect(entity.props.name).toBe("Same Name");
+  });
+
+  it("reports the full EntityResolution (canonical, sorted members, branch origins)", () => {
+    const entity = canonicalizeCluster(cluster, members, "flag", rank([]));
+    expect(entity.resolution.canonicalId).toBe("node-a");
+    expect(entity.resolution.memberIds.map((id) => id)).toEqual([
+      "node-a",
+      "node-b",
+      "node-c",
+    ]);
+    expect(entity.resolution.kind).toBe("Patient");
+    expect(entity.resolution.branchOrigins).toEqual([b1, b2, b3]);
+  });
+
+  it("min-nodeId canonical selection is independent of creation order (nanoid ids)", () => {
+    // generateId() is nanoid (random, NOT time-prefixed), so the min id is NOT
+    // the first-created id. Create three, build a cluster, assert the canonical
+    // is the lexicographic minimum — proving creation order does not leak in.
+    const created = [generateId(), generateId(), generateId()];
+    const sortedMin = [...created].sort((left, right) =>
+      lexicographic(left, right),
+    )[0]!;
+
+    const nanoidCluster = clusterOf(...created);
+    const nanoidMembers = created.map((id, index) =>
+      member(id, [b1, b2, b3][index]!, { name: "Shared" }),
+    );
+
+    const entity = canonicalizeCluster(
+      nanoidCluster,
+      nanoidMembers,
+      "flag",
+      rank([]),
+    );
+    expect(entity.canonicalId).toBe(sortedMin);
+  });
+});
+
+describe("ClusterMember origin discriminator (step 1)", () => {
+  function rank(order: readonly BranchId[]): ReadonlyMap<BranchId, number> {
+    return buildBranchRank(order, [b1, b2]);
+  }
+
+  it("tags staged contributions with origin 'staged'", () => {
+    const staged = member("node-a", b1, { name: "Anna Rivera" });
+    expect(staged.origin).toBe("staged");
+  });
+
+  it("makes a base-origin member the survivor even when its id is NOT the minimum (base-id-wins)", () => {
+    // base-id-wins (§6.4-C): whenever a cluster holds a base member, the committed
+    // identity is the canonical survivor regardless of the min-id rule. The base id
+    // here ("z-base") is the lexicographic MAXIMUM, so this fails if survivor selection
+    // ever regressed to plain min-id (the old fixture used a min base id and could not
+    // catch that). The base member's extra property still gap-fills the union.
+    const cluster = clusterOf("a-new", "z-base");
+    const members: readonly ClusterMember[] = [
+      {
+        origin: "base",
+        id: nodeId("z-base"),
+        kind: "Patient",
+        branchId: b1,
+        props: { name: "Anna Rivera", mrn: "MRN-1" },
+      },
+      member("a-new", b2, { name: "Anna Rivera" }),
+    ];
+
+    const entity = canonicalizeCluster(
+      cluster,
+      members,
+      "flag",
+      rank([b1, b2]),
+    );
+    console.info(
+      "[origin] survivor:",
+      entity.canonicalId,
+      "from",
+      members.map((m) => `${m.id}:${m.origin}`),
+    );
+    expect(entity.canonicalId).toBe("z-base");
+    expect(entity.resolution.canonicalId).toBe(nodeId("z-base"));
+    expect(entity.props.name).toBe("Anna Rivera");
+    expect(entity.props.mrn).toBe("MRN-1");
+  });
+
+  it("keeps the committed base VALUE under the default 'flag' base policy (#4)", () => {
+    // base-id-wins governs IDENTITY; the base VALUE is governed by
+    // onBasePropertyConflict. The default 'flag' keeps the committed value and the
+    // base sentinel is NOT a real branch, so it never appears in `values`.
+    const cluster = clusterOf("a-new", "z-base");
+    const members: readonly ClusterMember[] = [
+      {
+        origin: "base",
+        id: nodeId("z-base"),
+        kind: "Patient",
+        branchId: BASE_PROVENANCE_BRANCH,
+        props: { name: "Committed" },
+      },
+      member("a-new", b1, { name: "Branch" }),
+    ];
+
+    const entity = canonicalizeCluster(cluster, members, "flag", rank([b1]));
+
+    expect(entity.canonicalId).toBe("z-base");
+    expect(entity.props.name).toBe("Committed");
+    expect(entity.conflicts).toHaveLength(1);
+    // The sentinel base branch is excluded from the public values; the staged
+    // branch's competing value is shown.
+    const reported = entity.conflicts[0]!.values.map((value) => value.value);
+    expect(reported).toEqual(["Branch"]);
+  });
+
+  it("lets an explicit non-flag base policy overwrite the base VALUE while keeping its identity (#4 opt-in)", () => {
+    // onBasePropertyConflict:'lastWriteWins' is the documented opt-in to let a
+    // branch overwrite committed data. The committed IDENTITY (base-id-wins) is
+    // still preserved; only the conflicting property value is overwritten.
+    const cluster = clusterOf("a-new", "z-base");
+    const members: readonly ClusterMember[] = [
+      {
+        origin: "base",
+        id: nodeId("z-base"),
+        kind: "Patient",
+        branchId: BASE_PROVENANCE_BRANCH,
+        props: { name: "Committed" },
+      },
+      member("a-new", b1, { name: "Branch" }),
+    ];
+
+    const entity = canonicalizeCluster(
+      cluster,
+      members,
+      "flag",
+      rank([b1]),
+      undefined, // weights
+      undefined, // canonicalOverride
+      "lastWriteWins", // basePolicy — explicit opt-in to overwrite the base value
+    );
+
+    expect(entity.canonicalId).toBe("z-base"); // identity invariant intact
+    expect(entity.props.name).toBe("Branch"); // value overwritten by opt-in
+  });
+});

--- a/packages/typegraph/tests/graph-merge/closures.test.ts
+++ b/packages/typegraph/tests/graph-merge/closures.test.ts
@@ -1,0 +1,241 @@
+import type { OntologyIntrospection } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  equivalentTo,
+  subClassOf,
+} from "@nicia-ai/typegraph";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  buildSubClassClosure,
+  isReachable,
+  SUB_CLASS_OF_META_EDGE,
+} from "../../src/graph-merge/closures";
+import { createSqliteMergeBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const Doctor = defineNode("Doctor", {
+  schema: z.object({ name: z.string() }),
+});
+const SpecialistDoctor = defineNode("SpecialistDoctor", {
+  schema: z.object({ name: z.string() }),
+});
+const Physician = defineNode("Physician", {
+  schema: z.object({ name: z.string() }),
+});
+const Animal = defineNode("Animal", {
+  schema: z.object({ name: z.string() }),
+});
+
+/**
+ * Builds a real store from `graph`, then projects its public
+ * `store.introspect().ontology` into a closure — exercising the genuine public
+ * surface (introspection + `computeTransitiveClosure`) end to end rather than a
+ * hand-rolled ontology array.
+ */
+async function closureFromGraph(
+  graph: Parameters<typeof createStoreWithSchema>[0],
+): Promise<ReturnType<typeof buildSubClassClosure>> {
+  const fixture = createSqliteMergeBackend();
+  try {
+    const [store] = await createStoreWithSchema(graph, fixture.backend);
+    return buildSubClassClosure(store.introspect().ontology);
+  } finally {
+    await fixture.cleanup();
+  }
+}
+
+const taxonomyGraph = defineGraph({
+  id: "closures-taxonomy",
+  nodes: {
+    Person: { type: Person },
+    Doctor: { type: Doctor },
+    SpecialistDoctor: { type: SpecialistDoctor },
+    Animal: { type: Animal },
+  },
+  edges: {},
+  ontology: [subClassOf(SpecialistDoctor, Doctor), subClassOf(Doctor, Person)],
+});
+
+describe("buildSubClassClosure over public introspection", () => {
+  it("exposes the introspected subClassOf relations", async () => {
+    const fixture = createSqliteMergeBackend();
+    try {
+      const [store] = await createStoreWithSchema(
+        taxonomyGraph,
+        fixture.backend,
+      );
+      const ontology = store.introspect().ontology;
+      const subClassPairs = ontology
+        .filter((entry) => entry.metaEdge === SUB_CLASS_OF_META_EDGE)
+        .map((entry) => [entry.from, entry.to] as const);
+      expect(subClassPairs).toContainEqual(["SpecialistDoctor", "Doctor"]);
+      expect(subClassPairs).toContainEqual(["Doctor", "Person"]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("is reachable transitively (SpecialistDoctor -> Person)", async () => {
+    const closure = await closureFromGraph(taxonomyGraph);
+    expect(isReachable(closure, "SpecialistDoctor", "Doctor")).toBe(true);
+    expect(isReachable(closure, "Doctor", "Person")).toBe(true);
+    expect(isReachable(closure, "SpecialistDoctor", "Person")).toBe(true);
+  });
+
+  it("is not reachable in the reverse (superclass -> subclass) direction", async () => {
+    const closure = await closureFromGraph(taxonomyGraph);
+    expect(isReachable(closure, "Person", "SpecialistDoctor")).toBe(false);
+    expect(isReachable(closure, "Person", "Doctor")).toBe(false);
+    expect(isReachable(closure, "Doctor", "SpecialistDoctor")).toBe(false);
+  });
+
+  it("treats the subclass relation as strict (irreflexive)", async () => {
+    const closure = await closureFromGraph(taxonomyGraph);
+    expect(isReachable(closure, "Doctor", "Doctor")).toBe(false);
+    expect(isReachable(closure, "SpecialistDoctor", "SpecialistDoctor")).toBe(
+      false,
+    );
+  });
+
+  it("reports unrelated types as mutually unreachable", async () => {
+    const graph = defineGraph({
+      id: "closures-disjoint",
+      nodes: {
+        Person: { type: Person },
+        Doctor: { type: Doctor },
+        Animal: { type: Animal },
+      },
+      edges: {},
+      ontology: [subClassOf(Doctor, Person)],
+    });
+    const closure = await closureFromGraph(graph);
+    expect(isReachable(closure, "Animal", "Person")).toBe(false);
+    expect(isReachable(closure, "Person", "Animal")).toBe(false);
+    expect(isReachable(closure, "Doctor", "Animal")).toBe(false);
+    expect(isReachable(closure, "Animal", "Doctor")).toBe(false);
+  });
+
+  it("returns false for types absent from the ontology", async () => {
+    const closure = await closureFromGraph(taxonomyGraph);
+    expect(isReachable(closure, "Nurse", "Person")).toBe(false);
+    expect(isReachable(closure, "Person", "Nurse")).toBe(false);
+  });
+});
+
+describe("closure is independent of input pair ordering", () => {
+  const forward: readonly OntologyIntrospection[] = [
+    {
+      metaEdge: SUB_CLASS_OF_META_EDGE,
+      from: "SpecialistDoctor",
+      to: "Doctor",
+      origin: "compile-time",
+    },
+    {
+      metaEdge: SUB_CLASS_OF_META_EDGE,
+      from: "Doctor",
+      to: "Person",
+      origin: "compile-time",
+    },
+  ];
+  const reversed: readonly OntologyIntrospection[] = [...forward].reverse();
+
+  it("yields identical reachability regardless of relation order", () => {
+    const a = buildSubClassClosure(forward);
+    const b = buildSubClassClosure(reversed);
+    expect(isReachable(a, "SpecialistDoctor", "Person")).toBe(true);
+    expect(isReachable(b, "SpecialistDoctor", "Person")).toBe(true);
+    expect(isReachable(a, "Person", "SpecialistDoctor")).toBe(
+      isReachable(b, "Person", "SpecialistDoctor"),
+    );
+  });
+
+  it("produces byte-identical closures after normalization", () => {
+    const normalize = (
+      closure: ReturnType<typeof buildSubClassClosure>,
+    ): Record<string, string[]> => {
+      const out: Record<string, string[]> = {};
+      for (const [child, ancestors] of closure.closure) {
+        out[child] = [...ancestors].sort();
+      }
+      return out;
+    };
+    expect(normalize(buildSubClassClosure(forward))).toEqual(
+      normalize(buildSubClassClosure(reversed)),
+    );
+  });
+});
+
+describe("equivalentTo folding", () => {
+  const equivalenceGraph = defineGraph({
+    id: "closures-equivalence",
+    nodes: {
+      Person: { type: Person },
+      Doctor: { type: Doctor },
+      Physician: { type: Physician },
+      SpecialistDoctor: { type: SpecialistDoctor },
+    },
+    edges: {},
+    ontology: [
+      subClassOf(SpecialistDoctor, Doctor),
+      subClassOf(Doctor, Person),
+      equivalentTo(Physician, Doctor),
+    ],
+  });
+
+  it("makes equivalent types mutually reachable", async () => {
+    const closure = await closureFromGraph(equivalenceGraph);
+    expect(isReachable(closure, "Physician", "Doctor")).toBe(true);
+    expect(isReachable(closure, "Doctor", "Physician")).toBe(true);
+  });
+
+  it("shares ancestors across an equivalence class", async () => {
+    const closure = await closureFromGraph(equivalenceGraph);
+    // Physician ≡ Doctor, and Doctor ⊑ Person, so Physician ⊑ Person too.
+    expect(isReachable(closure, "Physician", "Person")).toBe(true);
+    // SpecialistDoctor ⊑ Doctor ≡ Physician, so SpecialistDoctor ⊑ Physician.
+    expect(isReachable(closure, "SpecialistDoctor", "Physician")).toBe(true);
+  });
+
+  it("is order-independent for equivalentTo and subClassOf interleaving", () => {
+    const base: readonly OntologyIntrospection[] = [
+      {
+        metaEdge: SUB_CLASS_OF_META_EDGE,
+        from: "SpecialistDoctor",
+        to: "Doctor",
+        origin: "compile-time",
+      },
+      {
+        metaEdge: SUB_CLASS_OF_META_EDGE,
+        from: "Doctor",
+        to: "Person",
+        origin: "compile-time",
+      },
+      {
+        metaEdge: "equivalentTo",
+        from: "Physician",
+        to: "Doctor",
+        origin: "compile-time",
+      },
+    ];
+    const shuffled: readonly OntologyIntrospection[] = [
+      base[2]!,
+      base[0]!,
+      base[1]!,
+    ];
+    const a = buildSubClassClosure(base);
+    const b = buildSubClassClosure(shuffled);
+    expect(isReachable(a, "Physician", "Person")).toBe(
+      isReachable(b, "Physician", "Person"),
+    );
+    expect(isReachable(a, "SpecialistDoctor", "Physician")).toBe(
+      isReachable(b, "SpecialistDoctor", "Physician"),
+    );
+    expect(isReachable(a, "Physician", "Person")).toBe(true);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/clustering.test.ts
+++ b/packages/typegraph/tests/graph-merge/clustering.test.ts
@@ -1,0 +1,188 @@
+import { generateId } from "@nicia-ai/typegraph";
+import { describe, expect, it } from "vitest";
+
+import type { CandidateEdge } from "../../src/graph-merge/candidate-gen";
+import type { ClusterResult } from "../../src/graph-merge/clustering";
+import {
+  connectedComponents,
+  enforceDiameter,
+} from "../../src/graph-merge/clustering";
+import type { MergeKey } from "../../src/graph-merge/node-key";
+
+/**
+ * Brands a plain string as a node-identity key for pure clustering tests. These tests
+ * exercise the generic key-graph logic over opaque ids; a NUL-free string compares
+ * id-first identically to a real `(kind, id)` key, so the single-token form is exact.
+ */
+function nodeId(value: string): MergeKey {
+  return value as MergeKey;
+}
+
+/** Builds an undirected candidate edge with endpoints in canonical `(a, b)` order. */
+function edge(a: string, b: string, score: number): CandidateEdge {
+  const left = nodeId(a);
+  const right = nodeId(b);
+  return left < right ?
+      { a: left, b: right, score }
+    : { a: right, b: left, score };
+}
+
+/** A stable, comparable view of a cluster partition for deep-equal assertions. */
+function partitionOf(clusters: readonly ClusterResult[]): string[][] {
+  return clusters.map((cluster) => [...cluster.members].map((id) => id));
+}
+
+/** Deterministically shuffles a copy of an array via a seeded LCG. */
+function shuffled<T>(items: readonly T[], seed: number): T[] {
+  const copy = [...items];
+  let state = seed;
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    state = (state * 1_103_515_245 + 12_345) & 0x7f_ff_ff_ff;
+    const swapWith = state % (index + 1);
+    const temporary = copy[index]!;
+    copy[index] = copy[swapWith]!;
+    copy[swapWith] = temporary;
+  }
+  return copy;
+}
+
+describe("connectedComponents", () => {
+  const ids = ["A", "B", "C"].map((value) => nodeId(value));
+
+  it("single-link clusters A~B, B~C into {A,B,C} even though A and C are not directly similar", () => {
+    const edges: CandidateEdge[] = [edge("A", "B", 0.9), edge("B", "C", 0.88)];
+
+    const clusters = connectedComponents(edges, ids);
+
+    expect(partitionOf(clusters)).toEqual([["A", "B", "C"]]);
+  });
+
+  it("places nodes with no incident candidate edge into singleton clusters", () => {
+    const edges: CandidateEdge[] = [edge("A", "B", 0.9)];
+    const withIsolated = [...ids, nodeId("Z")];
+
+    const clusters = connectedComponents(edges, withIsolated);
+
+    expect(partitionOf(clusters)).toEqual([["A", "B"], ["C"], ["Z"]]);
+  });
+
+  it("is identical across shuffled edge-input order", () => {
+    const edges: CandidateEdge[] = [
+      edge("A", "B", 0.9),
+      edge("B", "C", 0.88),
+      edge("D", "E", 0.91),
+    ];
+    const allIds = ["A", "B", "C", "D", "E"].map((value) => nodeId(value));
+
+    const natural = partitionOf(connectedComponents(edges, allIds));
+
+    for (let seed = 1; seed <= 5; seed += 1) {
+      const reordered = partitionOf(
+        connectedComponents(shuffled(edges, seed), shuffled(allIds, seed * 7)),
+      );
+      expect(reordered).toEqual(natural);
+    }
+  });
+
+  describe("diameter guard", () => {
+    // The diameter guard is intentionally separate from connectedComponents (the
+    // base guard must run on the raw components first), so callers compose
+    // enforceDiameter over connectedComponents explicitly.
+    it("keeps a within-bound chain intact (diameter 2 <= guard 2)", () => {
+      // A-B-C chain has diameter 2; guard of 2 must NOT split it.
+      const edges: CandidateEdge[] = [
+        edge("A", "B", 0.9),
+        edge("B", "C", 0.88),
+      ];
+
+      const clusters = enforceDiameter(
+        connectedComponents(edges, ids),
+        edges,
+        2,
+      );
+
+      expect(partitionOf(clusters)).toEqual([["A", "B", "C"]]);
+    });
+
+    it("splits an over-diameter chain by dropping the weakest edge deterministically", () => {
+      // A-B-C chain has diameter 2 > guard 1. The weakest edge (B-C, 0.86) is
+      // dropped, leaving {A,B} (diameter 1) and {C} (singleton).
+      const edges: CandidateEdge[] = [
+        edge("A", "B", 0.95),
+        edge("B", "C", 0.86),
+      ];
+
+      const clusters = enforceDiameter(
+        connectedComponents(edges, ids),
+        edges,
+        1,
+      );
+
+      expect(partitionOf(clusters)).toEqual([["A", "B"], ["C"]]);
+    });
+
+    it("drop-weakest split is independent of edge-input order", () => {
+      const edges: CandidateEdge[] = [
+        edge("A", "B", 0.95),
+        edge("B", "C", 0.86),
+        edge("C", "D", 0.97),
+      ];
+      const allIds = ["A", "B", "C", "D"].map((value) => nodeId(value));
+
+      const natural = partitionOf(
+        enforceDiameter(connectedComponents(edges, allIds), edges, 1),
+      );
+
+      for (let seed = 1; seed <= 5; seed += 1) {
+        const shuffledEdges = shuffled(edges, seed);
+        const reordered = partitionOf(
+          enforceDiameter(
+            connectedComponents(shuffledEdges, allIds),
+            shuffledEdges,
+            1,
+          ),
+        );
+        expect(reordered).toEqual(natural);
+      }
+    });
+
+    it("drops the lowest-score edge (not the lowest-id edge) when scores differ", () => {
+      // Both A-B (0.99) and B-C (0.80) exceed the chain's guard of 1, but only
+      // the weaker B-C edge must be removed, isolating C.
+      const edges: CandidateEdge[] = [
+        edge("A", "B", 0.99),
+        edge("B", "C", 0.8),
+      ];
+
+      const clusters = enforceDiameter(
+        connectedComponents(edges, ids),
+        edges,
+        1,
+      );
+
+      expect(partitionOf(clusters)).toEqual([["A", "B"], ["C"]]);
+    });
+  });
+
+  it("treats real generated nanoid ids consistently regardless of creation order", () => {
+    const first = generateId();
+    const second = generateId();
+    const third = generateId();
+    const idList = [first, second, third].map((value) => nodeId(value));
+    const edges: CandidateEdge[] = [
+      edge(first, second, 0.9),
+      edge(second, third, 0.9),
+    ];
+
+    const clusters = connectedComponents(edges, idList);
+
+    expect(clusters).toHaveLength(1);
+    expect([...clusters[0]!.members].map((id) => id)).toEqual(
+      [first, second, third].sort((left, right) =>
+        left < right ? -1
+        : left > right ? 1
+        : 0,
+      ),
+    );
+  });
+});

--- a/packages/typegraph/tests/graph-merge/commit.test.ts
+++ b/packages/typegraph/tests/graph-merge/commit.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Step 2 spike: the commit path, in isolation, when a cluster's canonical survivor
+ * is an ALREADY-COMMITTED base node (design §6.2 — the riskiest core mutation,
+ * pulled ahead of `baseUnique`).
+ *
+ * Proves, against a HAND-BUILT {@link MergePlan} (no clustering / candidate-gen
+ * yet), that a canonical entity whose id is an existing committed node:
+ *
+ *   - UPDATES that committed row in place — not a duplicate insert (the committed
+ *     identity is stable, so external references survive);
+ *   - has the merged edges repointed onto it land on the surviving row;
+ *   - absorbs the non-canonical cluster member (it is never separately inserted).
+ *
+ * Runs on BOTH backends (the backend-parity invariant for new-vs-base semantics).
+ */
+
+import type {
+  EdgeId,
+  GraphBackend,
+  NodeId,
+  NodeType,
+} from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { CanonicalEntity } from "../../src/graph-merge/canonicalize";
+import type { MergedEdge } from "../../src/graph-merge/edge-repoint";
+import type { MergePlan } from "../../src/graph-merge/merge";
+import { commitPlan } from "../../src/graph-merge/merge";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), mrn: z.string().optional() }),
+});
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const careGraph = defineGraph({
+  id: "commit-care",
+  nodes: { Patient: { type: Patient }, Encounter: { type: Encounter } },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+});
+type CareGraph = typeof careGraph;
+
+function nodeId(value: string): NodeId<NodeType> {
+  return value as NodeId<NodeType>;
+}
+function edgeId(value: string): EdgeId {
+  return value as EdgeId;
+}
+
+/** An empty plan; tests override only the slices they exercise. */
+function emptyPlan(): MergePlan<CareGraph> {
+  return {
+    canonicalEntities: [],
+    survivingModifications: [],
+    nodeDeletions: new Map(),
+    edgeDeletions: new Map(),
+    mergedEdges: [],
+    inheritedEdgeBaseProps: new Map(),
+    retypeMap: new Map(),
+    resolutions: [],
+    propertyConflicts: [],
+    deleteModifyConflicts: [],
+    typeReconciliations: [],
+    dropped: [],
+    baseAmbiguities: [],
+    provenanceRecords: [],
+    warnings: [],
+  };
+}
+
+describe.each(backendMatrix())(
+  "commit update-not-insert onto a base id [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) {
+        await cleanup();
+      }
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    it("updates the committed base row in place and repoints an edge onto it", async () => {
+      cleanups = [];
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+
+      // The committed base graph: one Patient (base-1) and one Encounter (enc-1).
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-1", props: { name: "Anna R.", mrn: "MRN-1" } },
+      ]);
+      await target.nodes.Encounter.bulkCreate([
+        { id: "enc-1", props: { reason: "checkup" } },
+      ]);
+
+      // A merge resolved {base-1 (committed), new-2 (a branch duplicate)} to the
+      // base id base-1, unioning the branch's fuller name + a new edge from new-2
+      // repointed onto base-1.
+      const canonical: CanonicalEntity = {
+        canonicalId: nodeId("base-1"),
+        kind: "Patient",
+        props: { name: "Anna Rivera", mrn: "MRN-1" },
+        resolution: {
+          canonicalId: nodeId("base-1"),
+          memberIds: [nodeId("base-1"), nodeId("new-2")],
+          kind: "Patient",
+          branchOrigins: [],
+        },
+        conflicts: [],
+      };
+      const edge: MergedEdge = {
+        id: edgeId("edge-new"),
+        kind: "hadEncounter",
+        fromId: nodeId("base-1"),
+        toId: nodeId("enc-1"),
+        fromKind: "Patient",
+        toKind: "Encounter",
+        props: { on: "2026-06-04" },
+        mergedIds: [edgeId("edge-from-new-2")],
+      };
+
+      const plan: MergePlan<CareGraph> = {
+        ...emptyPlan(),
+        canonicalEntities: [canonical],
+        mergedEdges: [edge],
+      };
+
+      const merged = await commitPlan(target, plan);
+      console.info(`[${entry.name}] merged counts:`, merged);
+
+      // UPDATE-NOT-INSERT: still exactly one Patient — base-1 — with the unioned
+      // name. new-2 was absorbed (never inserted as its own row).
+      const patients = await target.nodes.Patient.find();
+      console.info(
+        `[${entry.name}] patients after commit:`,
+        patients.map((p) => `${p.id}:${p.name}`),
+      );
+      // The committed identity is stable: the SAME base-1 id carries the updated
+      // props (a fresh insert would have minted a new id and left two rows).
+      expect(patients).toHaveLength(1);
+      expect(`${patients[0]?.id}`).toBe("base-1");
+      expect(patients[0]?.name).toBe("Anna Rivera");
+
+      // The repointed edge landed on the surviving base row.
+      const edges = await target.edges.hadEncounter.find();
+      console.info(
+        `[${entry.name}] edges after commit:`,
+        edges.map((e) => `${e.id}:${e.fromId}->${e.toId}`),
+      );
+      const repointed = edges.find((e) => e.id === "edge-new");
+      expect(repointed).toBeDefined();
+      expect(`${repointed?.fromId}`).toBe("base-1");
+      expect(`${repointed?.toId}`).toBe("enc-1");
+
+      expect(merged.nodes).toBe(1);
+      expect(merged.edges).toBe(1);
+    });
+
+    it("a second commit of the same base canonical is idempotent (no duplicate)", async () => {
+      cleanups = [];
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-1", props: { name: "Anna R.", mrn: "MRN-1" } },
+      ]);
+
+      const canonical: CanonicalEntity = {
+        canonicalId: nodeId("base-1"),
+        kind: "Patient",
+        props: { name: "Anna Rivera", mrn: "MRN-1" },
+        resolution: {
+          canonicalId: nodeId("base-1"),
+          memberIds: [nodeId("base-1")],
+          kind: "Patient",
+          branchOrigins: [],
+        },
+        conflicts: [],
+      };
+      const plan: MergePlan<CareGraph> = {
+        ...emptyPlan(),
+        canonicalEntities: [canonical],
+      };
+
+      await commitPlan(target, plan);
+      await commitPlan(target, plan);
+
+      const patients = await target.nodes.Patient.find();
+      expect(patients).toHaveLength(1);
+      expect(patients[0]?.name).toBe("Anna Rivera");
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/cross-kind-identity.test.ts
+++ b/packages/typegraph/tests/graph-merge/cross-kind-identity.test.ts
@@ -1,0 +1,221 @@
+/**
+ * End-to-end regression for the `(kind, id)` identity re-key (design §6.4 / §7 T10).
+ *
+ * Node identity is the PAIR `(kind, id)`, and ids are caller-supplied, so two nodes of
+ * DIFFERENT kinds may share an id string. The pre-re-key clustering keyed on the bare
+ * id, silently FUSING such nodes into one cluster — a wrong merge that dropped a node,
+ * mixed cross-kind props, and bypassed the §6.4-A base guard. These tests pin the
+ * fixed behaviour from the public `merge()` surface:
+ *
+ *   1. unrelated kinds sharing an id (`Patient:x` / `Encounter:x`) NEVER fuse;
+ *   2. under `reconcileTypes: "ontology"`, subtype-compatible kinds sharing an id
+ *      (`Doctor:x` / `SpecialistDoctor:x`) ARE a cross-kind merge candidate — the same
+ *      entity at a refined type — and collapse to the most-specific kind (the ontology
+ *      retype is a candidate-EDGE rule, not an identity rule);
+ *   3. with `reconcileTypes: "off"`, that same pair stays two distinct nodes — strict
+ *      `(kind, id)` identity wins.
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  subClassOf,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type {
+  GraphBranch,
+  MergeOptions,
+  ReconcileTypesMode,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string() }),
+});
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+const Doctor = defineNode("Doctor", {
+  schema: z.object({ name: z.string() }),
+});
+const SpecialistDoctor = defineNode("SpecialistDoctor", {
+  schema: z.object({ name: z.string() }),
+});
+
+// SpecialistDoctor ⊑ Doctor; Patient and Encounter are disjoint from each other.
+const careGraph = defineGraph({
+  id: "cross-kind-identity",
+  nodes: {
+    Patient: { type: Patient },
+    Encounter: { type: Encounter },
+    Doctor: { type: Doctor },
+    SpecialistDoctor: { type: SpecialistDoctor },
+  },
+  edges: {},
+  ontology: [subClassOf(SpecialistDoctor, Doctor)],
+});
+type CareGraph = typeof careGraph;
+
+const BRANCH_A = asBranchId("provider-a");
+const BRANCH_B = asBranchId("provider-b");
+
+function mergeOptions(
+  reconcileTypes: ReconcileTypesMode,
+): MergeOptions<CareGraph> {
+  return {
+    resolve: {},
+    reconcileTypes,
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH_A, BRANCH_B],
+  };
+}
+
+describe.each(backendMatrix())("cross-kind identity merge [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function forkedBranches(): Promise<
+    Readonly<{
+      base: Awaited<ReturnType<typeof createStoreWithSchema<CareGraph>>>[0];
+      branches: readonly GraphBranch<CareGraph>[];
+    }>
+  > {
+    const [base] = await createStoreWithSchema(careGraph, await makeBackend());
+    const branchA = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_A }),
+    );
+    const branchB = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_B }),
+    );
+    return { base, branches: [branchA, branchB] };
+  }
+
+  it("does NOT fuse a Patient and an Encounter that share an id string", async () => {
+    cleanups = [];
+    const { base, branches } = await forkedBranches();
+    const [branchA, branchB] = branches;
+
+    // Same id "shared", UNRELATED kinds, staged on different branches.
+    await branchA!.store.nodes.Patient.bulkCreate([
+      { id: "shared", props: { name: "Anna Rivera" } },
+    ]);
+    await branchB!.store.nodes.Encounter.bulkCreate([
+      { id: "shared", props: { reason: "annual checkup" } },
+    ]);
+
+    // Even with ontology ON, disjoint kinds are not retype-compatible → no fusion.
+    const result = await merge<CareGraph>(
+      base,
+      branches,
+      mergeOptions("ontology"),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    // Two DISTINCT nodes survive, each with its own props intact.
+    const patients = await base.nodes.Patient.find();
+    const encounters = await base.nodes.Encounter.find();
+    expect(patients).toHaveLength(1);
+    expect(`${patients[0]?.id}`).toBe("shared");
+    expect(patients[0]?.name).toBe("Anna Rivera");
+    expect(encounters).toHaveLength(1);
+    expect(`${encounters[0]?.id}`).toBe("shared");
+    expect(encounters[0]?.reason).toBe("annual checkup");
+
+    // No cross-kind id-merge, no spurious cross-kind property conflict, no reconcile.
+    expect(result.data.resolutions).toEqual([]);
+    expect(result.data.conflicts).toEqual([]);
+    expect(result.data.typeReconciliations).toEqual([]);
+  });
+
+  it('reconciles a same-id Doctor / SpecialistDoctor pair under reconcileTypes:"ontology"', async () => {
+    cleanups = [];
+    const { base, branches } = await forkedBranches();
+    const [branchA, branchB] = branches;
+
+    // Same id "doc-1", SUBTYPE-compatible kinds — the same entity at a refined type.
+    await branchA!.store.nodes.Doctor.bulkCreate([
+      { id: "doc-1", props: { name: "Helen Park" } },
+    ]);
+    await branchB!.store.nodes.SpecialistDoctor.bulkCreate([
+      { id: "doc-1", props: { name: "Helen Park" } },
+    ]);
+
+    const result = await merge<CareGraph>(
+      base,
+      branches,
+      mergeOptions("ontology"),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    // Collapsed to the MOST-SPECIFIC kind: one SpecialistDoctor, no leftover Doctor.
+    const doctors = await base.nodes.Doctor.find();
+    const specialists = await base.nodes.SpecialistDoctor.find();
+    expect(doctors).toHaveLength(0);
+    expect(specialists).toHaveLength(1);
+    expect(`${specialists[0]?.id}`).toBe("doc-1");
+    expect(specialists[0]?.name).toBe("Helen Park");
+
+    // Reported as a type reconciliation (Doctor → SpecialistDoctor), keyed on the id.
+    expect(result.data.typeReconciliations).toHaveLength(1);
+    const reconciliation = result.data.typeReconciliations[0]!;
+    expect(reconciliation.entityId).toBe("doc-1");
+    expect(reconciliation.toType).toBe("SpecialistDoctor");
+    expect([...reconciliation.fromTypes].sort()).toEqual([
+      "Doctor",
+      "SpecialistDoctor",
+    ]);
+  });
+
+  it('keeps a same-id Doctor / SpecialistDoctor pair distinct under reconcileTypes:"off"', async () => {
+    cleanups = [];
+    const { base, branches } = await forkedBranches();
+    const [branchA, branchB] = branches;
+
+    await branchA!.store.nodes.Doctor.bulkCreate([
+      { id: "doc-1", props: { name: "Helen Park" } },
+    ]);
+    await branchB!.store.nodes.SpecialistDoctor.bulkCreate([
+      { id: "doc-1", props: { name: "Helen Park" } },
+    ]);
+
+    // "off": the ontology retype source emits nothing — strict (kind, id) identity.
+    const result = await merge<CareGraph>(base, branches, mergeOptions("off"));
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    const doctors = await base.nodes.Doctor.find();
+    const specialists = await base.nodes.SpecialistDoctor.find();
+    expect(doctors).toHaveLength(1);
+    expect(specialists).toHaveLength(1);
+    expect(result.data.typeReconciliations).toEqual([]);
+    expect(result.data.resolutions).toEqual([]);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/delete-modify.test.ts
+++ b/packages/typegraph/tests/graph-merge/delete-modify.test.ts
@@ -1,0 +1,316 @@
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { buildBranchRank } from "../../src/graph-merge/conflict-policy";
+import type { DeleteModifyResolution } from "../../src/graph-merge/delete-modify";
+import {
+  DELETED_NODE_DROP_REASON,
+  resolveDeleteModify,
+} from "../../src/graph-merge/delete-modify";
+import { unwrap } from "../../src/graph-merge/result";
+import { stageBranches } from "../../src/graph-merge/staging";
+import type {
+  BranchId,
+  DeleteModifyPolicy,
+  GraphBranch,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "delete-modify-test",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+type G = typeof graph;
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+/**
+ * A plain, fully-comparable projection of a {@link DeleteModifyResolution} so two
+ * resolutions can be deep-equality compared independent of input branch order.
+ * Surviving modifications carry non-deterministic row meta, so we keep only the
+ * load-bearing fields.
+ */
+type ResolutionShape = Readonly<{
+  survivingModifications: readonly Readonly<{
+    id: string;
+    branchId: string;
+    name: unknown;
+  }>[];
+  nodeDeletions: readonly Readonly<{ id: string; kind: string }>[];
+  conflicts: readonly Readonly<{
+    entityId: string;
+    kind: string;
+    deletedBy: string;
+    modifiedBy: string;
+    resolution: DeleteModifyPolicy;
+  }>[];
+  dropped: readonly Readonly<{ kind: string; id: string; reason: string }>[];
+}>;
+
+function projectResolution(
+  resolution: DeleteModifyResolution,
+): ResolutionShape {
+  return {
+    survivingModifications: resolution.survivingModifications.map(
+      (modification) => ({
+        id: modification.node.id,
+        branchId: modification.branchId,
+        name: modification.node.forkProps.name,
+      }),
+    ),
+    nodeDeletions: resolution.nodeDeletions.map((deletion) => ({
+      id: deletion.id,
+      kind: deletion.kind,
+    })),
+    conflicts: resolution.conflicts.map((conflict) => ({
+      entityId: conflict.entityId,
+      kind: conflict.kind,
+      deletedBy: conflict.deletedBy,
+      modifiedBy: conflict.modifiedBy,
+      resolution: conflict.resolution,
+    })),
+    dropped: resolution.dropped.map((item) => ({
+      kind: item.kind,
+      id: item.id,
+      reason: item.reason,
+    })),
+  };
+}
+
+describe.each(backendMatrix())("delete/modify resolution [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function makeBranch(
+    baseStore: Store<G>,
+    id: BranchId,
+  ): Promise<GraphBranch<G>> {
+    return unwrap(await branch<G>(baseStore, () => makeBackend(), { id }));
+  }
+
+  /**
+   * Scenario shared by every policy: branchA DELETES inherited node N, branchB
+   * MODIFIES N's name. Returns the staging set, the conflicted node id, and the
+   * captured stable branch rank ([branchA, branchB]).
+   */
+  async function stageDeleteVsModify(): Promise<
+    Readonly<{
+      nodeId: string;
+      staging: Awaited<ReturnType<typeof stageBranches<G>>>;
+      branchRank: ReadonlyMap<BranchId, number>;
+      branchA: GraphBranch<G>;
+      branchB: GraphBranch<G>;
+    }>
+  > {
+    const [baseStore] = await createStoreWithSchema(graph, await makeBackend());
+    const inherited = await baseStore.nodes.Person.create({ name: "Origin" });
+
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    await branchA.store.nodes.Person.delete(inherited.id);
+    await branchB.store.nodes.Person.update(inherited.id, { name: "Modified" });
+
+    const staging = await stageBranches(baseStore, [branchA, branchB]);
+    const branchRank = buildBranchRank(
+      [BRANCH_A, BRANCH_B],
+      [branchA.id, branchB.id],
+    );
+
+    // The scenario must actually stage exactly one delete + one modify of N.
+    expect(staging.deletedNodes).toHaveLength(1);
+    expect(staging.modifiedNodes).toHaveLength(1);
+    expect(staging.deletedNodes[0]?.node.id).toBe(inherited.id);
+    expect(staging.modifiedNodes[0]?.node.id).toBe(inherited.id);
+
+    return { nodeId: inherited.id, staging, branchRank, branchA, branchB };
+  }
+
+  it("'deleteWins' deletes N, records the conflict, and drops the node", async () => {
+    const { nodeId, staging, branchRank } = await stageDeleteVsModify();
+
+    const resolution = resolveDeleteModify(staging, "deleteWins", branchRank);
+
+    // N is finally deleted; its modification does NOT survive.
+    expect(resolution.survivingModifications).toHaveLength(0);
+    expect(resolution.nodeDeletions).toHaveLength(1);
+    expect(resolution.nodeDeletions[0]).toEqual({
+      id: nodeId,
+      kind: "Person",
+    });
+
+    // The conflict is recorded with the correct provenance + resolution.
+    expect(resolution.conflicts).toHaveLength(1);
+    expect(resolution.conflicts[0]).toEqual({
+      entityId: nodeId,
+      kind: "Person",
+      deletedBy: BRANCH_A,
+      modifiedBy: BRANCH_B,
+      resolution: "deleteWins",
+    });
+
+    // The deleted node is enumerated as dropped from the merged graph.
+    expect(resolution.dropped).toEqual([
+      { kind: "node", id: nodeId, reason: DELETED_NODE_DROP_REASON },
+    ]);
+  });
+
+  it("'modifyWins' resurrects N with branchB's props and records the conflict", async () => {
+    const { nodeId, staging, branchRank } = await stageDeleteVsModify();
+
+    const resolution = resolveDeleteModify(staging, "modifyWins", branchRank);
+
+    // N is kept: branchB's modification survives, nothing is deleted/dropped.
+    expect(resolution.nodeDeletions).toHaveLength(0);
+    expect(resolution.dropped).toHaveLength(0);
+    expect(resolution.survivingModifications).toHaveLength(1);
+    const survivor = resolution.survivingModifications[0]!;
+    expect(survivor.node.id).toBe(nodeId);
+    expect(survivor.branchId).toBe(BRANCH_B);
+    expect(survivor.node.forkProps).toMatchObject({ name: "Modified" });
+
+    // The conflict is still recorded (resolved as modifyWins).
+    expect(resolution.conflicts).toHaveLength(1);
+    expect(resolution.conflicts[0]).toEqual({
+      entityId: nodeId,
+      kind: "Person",
+      deletedBy: BRANCH_A,
+      modifiedBy: BRANCH_B,
+      resolution: "modifyWins",
+    });
+  });
+
+  it("'flag' keeps the modification but surfaces the conflict UNRESOLVED", async () => {
+    const { nodeId, staging, branchRank } = await stageDeleteVsModify();
+
+    const resolution = resolveDeleteModify(staging, "flag", branchRank);
+
+    // Like modifyWins, the modification is kept and nothing is deleted...
+    expect(resolution.nodeDeletions).toHaveLength(0);
+    expect(resolution.dropped).toHaveLength(0);
+    expect(resolution.survivingModifications).toHaveLength(1);
+    expect(resolution.survivingModifications[0]?.node.id).toBe(nodeId);
+    expect(resolution.survivingModifications[0]?.node.forkProps).toMatchObject({
+      name: "Modified",
+    });
+
+    // ...but the conflict is recorded as UNRESOLVED ("flag") for human review.
+    expect(resolution.conflicts).toHaveLength(1);
+    expect(resolution.conflicts[0]?.resolution).toBe("flag");
+    expect(resolution.conflicts[0]).toEqual({
+      entityId: nodeId,
+      kind: "Person",
+      deletedBy: BRANCH_A,
+      modifiedBy: BRANCH_B,
+      resolution: "flag",
+    });
+  });
+
+  it.each<DeleteModifyPolicy>(["deleteWins", "modifyWins", "flag"])(
+    "resolves identically across reversed branch order under '%s'",
+    async (policy) => {
+      const [baseStore] = await createStoreWithSchema(
+        graph,
+        await makeBackend(),
+      );
+      const inherited = await baseStore.nodes.Person.create({ name: "Origin" });
+
+      const branchA = await makeBranch(baseStore, BRANCH_A);
+      const branchB = await makeBranch(baseStore, BRANCH_B);
+
+      await branchA.store.nodes.Person.delete(inherited.id);
+      await branchB.store.nodes.Person.update(inherited.id, {
+        name: "Modified",
+      });
+
+      // Stage + rank the branches FORWARD ([A, B]) and REVERSED ([B, A]). Both
+      // staging (T7) and the captured branch rank (T8) are pure functions of the
+      // unordered set, so the delete/modify resolution must be identical.
+      const forwardStaging = await stageBranches(baseStore, [branchA, branchB]);
+      const reversedStaging = await stageBranches(baseStore, [
+        branchB,
+        branchA,
+      ]);
+      const forwardRank = buildBranchRank(
+        [BRANCH_A, BRANCH_B],
+        [branchA.id, branchB.id],
+      );
+      const reversedRank = buildBranchRank(
+        [BRANCH_A, BRANCH_B],
+        [branchB.id, branchA.id],
+      );
+
+      const forward = resolveDeleteModify(forwardStaging, policy, forwardRank);
+      const reversed = resolveDeleteModify(
+        reversedStaging,
+        policy,
+        reversedRank,
+      );
+
+      expect(projectResolution(reversed)).toEqual(projectResolution(forward));
+    },
+  );
+
+  it("passes pure deletions and pure modifications through unconflicted", async () => {
+    const [baseStore] = await createStoreWithSchema(graph, await makeBackend());
+    const toDelete = await baseStore.nodes.Person.create({ name: "Doomed" });
+    const toModify = await baseStore.nodes.Person.create({ name: "Mutable" });
+
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    // branchA deletes one node; branchB modifies a DIFFERENT node. No overlap →
+    // no delete/modify conflict.
+    await branchA.store.nodes.Person.delete(toDelete.id);
+    await branchB.store.nodes.Person.update(toModify.id, { name: "Changed" });
+
+    const staging = await stageBranches(baseStore, [branchA, branchB]);
+    const branchRank = buildBranchRank(
+      [BRANCH_A, BRANCH_B],
+      [branchA.id, branchB.id],
+    );
+
+    const resolution = resolveDeleteModify(staging, "flag", branchRank);
+
+    expect(resolution.conflicts).toHaveLength(0);
+    expect(resolution.dropped).toHaveLength(0);
+    expect(resolution.nodeDeletions).toEqual([
+      { id: toDelete.id, kind: "Person" },
+    ]);
+    expect(resolution.survivingModifications).toHaveLength(1);
+    expect(resolution.survivingModifications[0]?.node.id).toBe(toModify.id);
+    expect(resolution.survivingModifications[0]?.node.forkProps).toMatchObject({
+      name: "Changed",
+    });
+  });
+});

--- a/packages/typegraph/tests/graph-merge/edge-delete-modify.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-delete-modify.test.ts
@@ -1,0 +1,188 @@
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import { enumerateAllEdges } from "../../src/graph-merge/state-diff";
+import type {
+  BranchId,
+  GraphBranch,
+  MergeOptions,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+/**
+ * Regression coverage for inherited-EDGE delete/modify handling (parity with the
+ * node path):
+ *   - an inherited edge deleted in a branch is actually removed from the merged
+ *     target (previously staged but never applied — the edge stayed live);
+ *   - disjoint edits to the same inherited edge by different branches 3-way merge
+ *     against base instead of false-conflicting and dropping one edit;
+ *   - a genuine same-field edge disagreement still surfaces as a conflict.
+ *
+ * The `link` edge carries TWO independent fields (`since`, `note`) so a per-field
+ * disjoint edit is expressible.
+ */
+const Thing = defineNode("Thing", {
+  schema: z.object({ name: z.string() }),
+});
+
+const link = defineEdge("link", {
+  schema: z.object({ since: z.string(), note: z.string() }),
+  from: [Thing],
+  to: [Thing],
+});
+
+const graph = defineGraph({
+  id: "edge-delete-modify-graph",
+  nodes: { Thing: { type: Thing } },
+  edges: { link: { type: link, from: [Thing], to: [Thing] } },
+});
+
+type EdgeGraph = typeof graph;
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+function mergeOptions(): MergeOptions<EdgeGraph> {
+  return { onPropertyConflict: "flag", branchOrder: [BRANCH_A, BRANCH_B] };
+}
+
+async function liveLinks(
+  store: Store<EdgeGraph>,
+): Promise<
+  readonly Readonly<{ id: string; props: Record<string, unknown> }>[]
+> {
+  const rows = await enumerateAllEdges(store.backend, store.graphId, "link");
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => ({
+      id: row.id,
+      props: JSON.parse(row.props) as Record<string, unknown>,
+    }));
+}
+
+describe.each(backendMatrix())("edge delete/modify [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function makeBranch(
+    baseStore: Store<EdgeGraph>,
+    id: BranchId,
+  ): Promise<GraphBranch<EdgeGraph>> {
+    return unwrap(
+      await branch<EdgeGraph>(baseStore, () => makeBackend(), { id }),
+    );
+  }
+
+  /** Base: two Things joined by one `link` edge, so every branch inherits it. */
+  async function seed() {
+    const [baseStore] = await createStoreWithSchema(graph, await makeBackend());
+    const a = await baseStore.nodes.Thing.create({ name: "a" });
+    const b = await baseStore.nodes.Thing.create({ name: "b" });
+    const edge = await baseStore.edges.link.create(a, b, {
+      since: "base",
+      note: "base",
+    });
+    return { baseStore, edgeId: edge.id };
+  }
+
+  it("propagates an inherited edge deletion to the merged target", async () => {
+    const { baseStore, edgeId } = await seed();
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    await branchA.store.edges.link.delete(edgeId);
+
+    const result = await merge<EdgeGraph>(baseStore, [branchA], mergeOptions());
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+
+    // The branch's deletion is honored: the edge is gone from the target.
+    expect(await liveLinks(baseStore)).toHaveLength(0);
+    expect(result.data.deleteModifyConflicts).toHaveLength(0);
+  });
+
+  it("3-way merges disjoint edge edits without false conflicts or lost edits", async () => {
+    const { baseStore, edgeId } = await seed();
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    // Disjoint edits: A changes `since` only, B changes `note` only.
+    await branchA.store.edges.link.update(edgeId, { since: "2025" });
+    await branchB.store.edges.link.update(edgeId, { note: "B" });
+
+    const result = await merge<EdgeGraph>(
+      baseStore,
+      [branchA, branchB],
+      mergeOptions(),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+
+    // Both independent edits survive; neither is dropped and nothing false-conflicts.
+    const links = await liveLinks(baseStore);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.props).toMatchObject({ since: "2025", note: "B" });
+    expect(result.data.conflicts).toHaveLength(0);
+  });
+
+  it("flags a genuine same-field edge conflict (both branches change `since`)", async () => {
+    const { baseStore, edgeId } = await seed();
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    await branchA.store.edges.link.update(edgeId, { since: "2025-A" });
+    await branchB.store.edges.link.update(edgeId, { since: "2025-B" });
+
+    const result = await merge<EdgeGraph>(
+      baseStore,
+      [branchA, branchB],
+      mergeOptions(),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+
+    const sinceConflict = result.data.conflicts.find(
+      (conflict) => conflict.property === "since",
+    );
+    expect(sinceConflict).toBeDefined();
+    expect(sinceConflict!.entityId).toBe(edgeId);
+    expect(sinceConflict!.values.map((value) => value.value).sort()).toEqual([
+      "2025-A",
+      "2025-B",
+    ]);
+    // `note` was untouched by both branches → no spurious conflict on it.
+    expect(
+      result.data.conflicts.some((conflict) => conflict.property === "note"),
+    ).toBe(false);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -1,0 +1,456 @@
+import type { EdgeId, JsonValue, NodeId, NodeType } from "@nicia-ai/typegraph";
+import { describe, expect, it } from "vitest";
+
+import type { ClusterResult } from "../../src/graph-merge/clustering";
+import { buildBranchRank } from "../../src/graph-merge/conflict-policy";
+import type {
+  MergedEdge,
+  StagedEdge,
+} from "../../src/graph-merge/edge-repoint";
+import {
+  buildCanonicalMap,
+  ENDPOINT_DELETED_DROP_REASON,
+  repointEdges,
+} from "../../src/graph-merge/edge-repoint";
+import {
+  compareMergeKeys,
+  type MergeKey,
+  mergeKey,
+} from "../../src/graph-merge/node-key";
+import { asBranchId } from "../../src/graph-merge/types";
+
+type AnyNodeId = NodeId<NodeType>;
+
+function nodeId(value: string): AnyNodeId {
+  return value as AnyNodeId;
+}
+
+/**
+ * The composite `(kind, id)` identity of a test node. Every edge endpoint in this
+ * suite is kind "Doc", so the cluster keys and the canonical map key on that pair —
+ * matching what `repointEdges` derives from each staged edge's `fromKind`/`toKind`.
+ */
+function key(id: string): MergeKey {
+  return mergeKey("Doc", id);
+}
+
+function edgeId(value: string): EdgeId {
+  return value as EdgeId;
+}
+
+function lexicographic(left: string, right: string): number {
+  return (
+    left < right ? -1
+    : left > right ? 1
+    : 0
+  );
+}
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+/** The fixed graph-wide branch order for these tests: [branchA, branchB]. */
+function rank(): ReadonlyMap<typeof BRANCH_A, number> {
+  return buildBranchRank([BRANCH_A, BRANCH_B], [BRANCH_A, BRANCH_B]);
+}
+
+/** Builds a staged edge with parsed props; defaults keep the call sites terse. */
+function stagedEdge(
+  args: Readonly<{
+    id: string;
+    from: string;
+    to: string;
+    kind?: string;
+    props?: Readonly<Record<string, JsonValue>>;
+    branchId?: typeof BRANCH_A;
+  }>,
+): StagedEdge {
+  return {
+    id: edgeId(args.id),
+    kind: args.kind ?? "references",
+    fromId: nodeId(args.from),
+    toId: nodeId(args.to),
+    fromKind: "Doc",
+    toKind: "Doc",
+    props: args.props ?? {},
+    branchId: args.branchId ?? BRANCH_A,
+  };
+}
+
+/** A cluster whose composite-key members are id-sorted, mirroring what T8 emits. */
+function clusterOf(...ids: readonly string[]): ClusterResult {
+  return {
+    members: [...ids]
+      .map((value) => key(value))
+      .sort((left, right) => compareMergeKeys(left, right)),
+  };
+}
+
+/** Min-id canonical selector — the merge-wide default — over composite keys. */
+function minIdCanonical(cluster: ClusterResult): MergeKey {
+  return [...cluster.members].sort((left, right) =>
+    compareMergeKeys(left, right),
+  )[0]!;
+}
+
+/** Deterministically shuffles a copy of an array via a seeded LCG. */
+function shuffled<T>(items: readonly T[], seed: number): T[] {
+  const copy = [...items];
+  let state = seed;
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    state = (state * 1_103_515_245 + 12_345) & 0x7f_ff_ff_ff;
+    const swapWith = state % (index + 1);
+    const temporary = copy[index]!;
+    copy[index] = copy[swapWith]!;
+    copy[swapWith] = temporary;
+  }
+  return copy;
+}
+
+/**
+ * A plain, fully-comparable projection of a merged edge (drops `props` key order
+ * by canonicalizing via JSON over a sorted shape is unnecessary here since props
+ * are simple) used to deep-equal compare results across shuffled input order.
+ */
+type MergedEdgeShape = Readonly<{
+  id: string;
+  kind: string;
+  fromId: string;
+  toId: string;
+  props: Readonly<Record<string, JsonValue>>;
+  mergedIds: readonly string[];
+}>;
+
+function projectEdges(
+  edges: readonly MergedEdge[],
+): readonly MergedEdgeShape[] {
+  return edges.map((edge) => ({
+    id: edge.id,
+    kind: edge.kind,
+    fromId: edge.fromId,
+    toId: edge.toId,
+    props: edge.props,
+    mergedIds: edge.mergedIds.map((id) => id as string),
+  }));
+}
+
+describe("buildCanonicalMap", () => {
+  it("maps every cluster member to its canonical and omits singletons", () => {
+    const map = buildCanonicalMap(
+      [clusterOf("node-a", "node-b"), clusterOf("node-x")],
+      (cluster) => minIdCanonical(cluster),
+    );
+
+    // {a, b} collapse to a (min id); both members rewrite to its composite key.
+    expect(map.get(key("node-a"))).toBe(key("node-a"));
+    expect(map.get(key("node-b"))).toBe(key("node-a"));
+    // Singleton x maps to itself.
+    expect(map.get(key("node-x"))).toBe(key("node-x"));
+    // An identity in no cluster is simply absent (callers default it to itself).
+    expect(map.has(key("node-z"))).toBe(false);
+  });
+});
+
+describe("repointEdges", () => {
+  // The headline §6.3 case: a and b collapse to canonical c* (= "a", min id).
+  // Two distinct edges x→a and x→b both repoint to x→a and, with equal props,
+  // must dedupe to a SINGLE merged edge.
+  const collapse = buildCanonicalMap([clusterOf("a", "b")], (cluster) =>
+    minIdCanonical(cluster),
+  );
+
+  it("dedupes x→a and x→b to a single x→c* when {a,b} collapse", () => {
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "a" }),
+      stagedEdge({ id: "edge-2", from: "x", to: "b" }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(1);
+    const edge = result.edges[0]!;
+    expect(edge.fromId).toBe("x");
+    // Canonical of {a, b} is "a" (lexicographic min).
+    expect(edge.toId).toBe("a");
+    // Survivor id is the lexicographically-minimal contributing edge id, and
+    // BOTH source ids are recorded as merged.
+    expect(edge.id).toBe("edge-1");
+    expect(edge.mergedIds.map((id) => id).sort()).toEqual(["edge-1", "edge-2"]);
+    // Equal props → no conflict.
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  it("surfaces an edge PropertyConflict when collapsed edges carry differing props", () => {
+    const staged = [
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "a",
+        props: { weight: 1 },
+        branchId: BRANCH_A,
+      }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    // Still a single edge (same from'/type/to'), but props differ → conflict.
+    expect(result.edges).toHaveLength(1);
+    const edge = result.edges[0]!;
+    expect(edge.id).toBe("edge-1");
+
+    expect(result.conflicts).toHaveLength(1);
+    const conflict = result.conflicts[0]!;
+    expect(`${conflict.entityId}`).toBe("edge-1");
+    expect(conflict.property).toBe("weight");
+    // "flag" keeps the survivor's (edge-1, branchA) value.
+    expect(conflict.resolution).toBe(1);
+    expect(edge.props.weight).toBe(1);
+    // Both contributing values are recorded, tagged by branch.
+    expect(
+      conflict.values
+        .map((value) => ({
+          branchId: value.branchId,
+          value: value.value,
+        }))
+        .sort((left, right) => lexicographic(left.branchId, right.branchId)),
+    ).toEqual([
+      { branchId: "branch-a", value: 1 },
+      { branchId: "branch-b", value: 2 },
+    ]);
+  });
+
+  it("resolves an edge property conflict via lastWriteWins on the stable branch order", () => {
+    const staged = [
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "a",
+        props: { weight: 1 },
+        branchId: BRANCH_A,
+      }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    // branchOrder [branchB, branchA] makes branchB highest-priority → weight 2.
+    const branchRank = buildBranchRank(
+      [BRANCH_B, BRANCH_A],
+      [BRANCH_A, BRANCH_B],
+    );
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "lastWriteWins",
+      branchRank,
+    );
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]?.props.weight).toBe(2);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.resolution).toBe(2);
+  });
+
+  it("drops an edge whose repointed endpoint is finally deleted", () => {
+    // a and b collapse to a; node a is then finally deleted (T8a deleteWins).
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "a" }),
+      stagedEdge({ id: "edge-2", from: "y", to: "b" }),
+      stagedEdge({ id: "edge-3", from: "x", to: "y" }),
+    ];
+    const deleted = new Set<MergeKey>([key("a")]);
+
+    const result = repointEdges(staged, collapse, deleted, "flag", rank());
+
+    // edge-1 (x→a) and edge-2 (y→b, repointed to y→a) both touch the deleted a.
+    expect(result.dropped.map((item) => item.id).sort()).toEqual([
+      "edge-1",
+      "edge-2",
+    ]);
+    for (const item of result.dropped) {
+      expect(item.kind).toBe("edge");
+      expect(item.reason).toBe(ENDPOINT_DELETED_DROP_REASON);
+    }
+    // edge-3 (x→y) survives untouched.
+    expect(result.edges).toHaveLength(1);
+    expect(`${result.edges[0]?.id}`).toBe("edge-3");
+  });
+
+  it("drops an edge whose repointed SOURCE is finally deleted", () => {
+    const staged = [stagedEdge({ id: "edge-1", from: "a", to: "x" })];
+    const deleted = new Set<MergeKey>([key("a")]);
+
+    const result = repointEdges(staged, collapse, deleted, "flag", rank());
+
+    expect(result.edges).toHaveLength(0);
+    expect(result.dropped).toHaveLength(1);
+    expect(`${result.dropped[0]?.id}`).toBe("edge-1");
+    expect(result.dropped[0]?.reason).toBe(ENDPOINT_DELETED_DROP_REASON);
+  });
+
+  it("does NOT dedupe edges of differing type or differing endpoints", () => {
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "a", kind: "references" }),
+      // Same repointed endpoints but a DIFFERENT type → distinct edge.
+      stagedEdge({ id: "edge-2", from: "x", to: "b", kind: "cites" }),
+      // Different source → distinct edge.
+      stagedEdge({ id: "edge-3", from: "y", to: "a", kind: "references" }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(3);
+    expect(result.conflicts).toHaveLength(0);
+    expect(
+      result.edges
+        .map((edge) => `${edge.fromId}|${edge.kind}|${edge.toId}`)
+        .sort(),
+    ).toEqual(["x|cites|a", "x|references|a", "y|references|a"]);
+  });
+
+  it("collapses three edges x→a, x→b, x→a' into one with all three merged ids", () => {
+    // a, b, and a-prime all collapse to canonical "a".
+    const triple = buildCanonicalMap(
+      [clusterOf("a", "a-prime", "b")],
+      (cluster) => minIdCanonical(cluster),
+    );
+    const staged = [
+      stagedEdge({ id: "edge-3", from: "x", to: "b" }),
+      stagedEdge({ id: "edge-1", from: "x", to: "a" }),
+      stagedEdge({ id: "edge-2", from: "x", to: "a-prime" }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      triple,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(1);
+    const edge = result.edges[0]!;
+    expect(edge.toId).toBe("a");
+    expect(edge.id).toBe("edge-1");
+    expect(edge.mergedIds.map((id) => id)).toEqual([
+      "edge-1",
+      "edge-2",
+      "edge-3",
+    ]);
+  });
+
+  it("produces an identical result across shuffled input-edge order", () => {
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "a", props: { weight: 1 } }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+      stagedEdge({ id: "edge-3", from: "y", to: "x" }),
+      stagedEdge({ id: "edge-4", from: "a", to: "x" }),
+      stagedEdge({ id: "edge-5", from: "b", to: "x" }),
+    ];
+
+    const reference = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+    const referenceShape = {
+      edges: projectEdges(reference.edges),
+      dropped: reference.dropped.map((item) => ({
+        id: item.id,
+        reason: item.reason,
+      })),
+      conflicts: reference.conflicts.map((conflict) => ({
+        entityId: conflict.entityId,
+        property: conflict.property,
+        resolution: conflict.resolution,
+      })),
+    };
+
+    for (let seed = 1; seed <= 6; seed += 1) {
+      const result = repointEdges(
+        shuffled(staged, seed),
+        collapse,
+        new Set<MergeKey>(),
+        "flag",
+        rank(),
+      );
+      const shape = {
+        edges: projectEdges(result.edges),
+        dropped: result.dropped.map((item) => ({
+          id: item.id,
+          reason: item.reason,
+        })),
+        conflicts: result.conflicts.map((conflict) => ({
+          entityId: conflict.entityId,
+          property: conflict.property,
+          resolution: conflict.resolution,
+        })),
+      };
+      expect(shape).toEqual(referenceShape);
+    }
+  });
+});
+
+describe("repointEdges dedupe-key delimiter safety (F13)", () => {
+  it("does not collapse distinct edges whose type/endpoint contains the separator", () => {
+    // Under the old `${from}|${type}|${to}|${props}` key, BOTH of these produced
+    // the ambiguous string "x|a|b|c|{}" and one edge was silently dropped. The
+    // JSON-encoded key keeps them distinct.
+    const edges = [
+      stagedEdge({ id: "e1", from: "x", to: "c", kind: "a|b" }),
+      stagedEdge({ id: "e2", from: "x", to: "b|c", kind: "a" }),
+    ];
+    const result = repointEdges(
+      edges,
+      new Map(), // no repointing — endpoints map to themselves
+      new Set(), // no deleted endpoints
+      "flag",
+      rank(),
+    );
+    expect(result.edges).toHaveLength(2);
+    expect(result.edges.map((edge) => edge.id as string).sort()).toEqual([
+      "e1",
+      "e2",
+    ]);
+    expect(result.dropped).toEqual([]);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/keyless-source.test.ts
+++ b/packages/typegraph/tests/graph-merge/keyless-source.test.ts
@@ -1,0 +1,188 @@
+/**
+ * `keyless` source contract (design §6.2): the bounded coarse source for the NO-KEY
+ * case. A kind whose `block()` returns `undefined` for every node lands them all in the
+ * shared `"unblocked"` bucket — otherwise compared ALL-vs-all (O(n²)) and then
+ * TRUNCATED to id-only by `maxComparisonsPerKind`. Setting `keyless: { window }` bounds
+ * that bucket by single-pass sorted-neighbourhood instead.
+ *
+ * The headline test proves it CLOSES THE CLIFF: a node set whose all-vs-all pair count
+ * exceeds the ceiling (so the default path errors) merges cleanly under a small window,
+ * because windowing keeps the comparison count under the budget — and the near-
+ * duplicates that are adjacent in the similarity-text sort still merge. Plus a
+ * determinism check (shuffled creation order → identical committed graph). Both backends.
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+// No unique constraint, no block key → every node falls into the "unblocked" bucket.
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string() }),
+});
+const careGraph = defineGraph({
+  id: "keyless-care",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+type CareGraph = typeof careGraph;
+type CareStore = GraphBranch<CareGraph>["store"];
+
+const BRANCH = asBranchId("provider-x");
+
+// Six unblocked patients; sorted by lowercased name they are:
+//   "ana rivera", "anna rivera", "bob lee", "carol king", "dave poe", "eve stone".
+// The two Riveras are ADJACENT (and Dice ≈ 0.857 ≥ 0.85), so even window=1 compares —
+// and merges — them, while nothing else is similar.
+const PATIENTS: readonly { id: string; name: string }[] = [
+  { id: "p-ana", name: "Ana Rivera" },
+  { id: "p-anna", name: "Anna Rivera" },
+  { id: "p-bob", name: "Bob Lee" },
+  { id: "p-carol", name: "Carol King" },
+  { id: "p-dave", name: "Dave Poe" },
+  { id: "p-eve", name: "Eve Stone" },
+];
+// All-vs-all over 6 nodes = 15 pairs; a ceiling of 10 truncates it. window=1 over the
+// 6 sorted nodes = 5 pairs, comfortably under the ceiling.
+const CEILING = 10;
+
+function options(
+  overrides: Partial<MergeOptions<CareGraph>> = {},
+): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        // No `block` → every node is unblocked.
+        keyless: { window: 1 },
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    maxComparisonsPerKind: CEILING,
+    onComparisonCeiling: "error",
+    branchOrder: [BRANCH],
+    ...overrides,
+  };
+}
+
+describe.each(backendMatrix())("keyless source [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function emptyStore(): Promise<CareStore> {
+    const [store] = await createStoreWithSchema(careGraph, await makeBackend());
+    return store;
+  }
+
+  /** A branch off `base` that stages `patients` as new Patient nodes (in `order`). */
+  async function branchWith(
+    base: CareStore,
+    order: readonly { id: string; name: string }[],
+  ): Promise<GraphBranch<CareGraph>> {
+    const provider = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH }),
+    );
+    await provider.store.nodes.Patient.bulkCreate(
+      order.map((patient) => ({
+        id: patient.id,
+        props: { name: patient.name },
+      })),
+    );
+    return provider;
+  }
+
+  it("CLOSES THE CLIFF: all-vs-all would exceed the ceiling, but windowing merges under it", async () => {
+    cleanups = [];
+
+    // Default path (no keyless): 15 all-vs-all pairs > ceiling 10 → the configured
+    // "error" ceiling fires. This is the quadratic cliff keyless exists to close.
+    const cliffBase = await emptyStore();
+    const cliffProvider = await branchWith(cliffBase, PATIENTS);
+    const cliff = await merge<CareGraph>(cliffBase, [cliffProvider], {
+      resolve: {
+        Patient: {
+          similarity: { kind: "fulltext", fields: ["name"] },
+          threshold: 0.85,
+        },
+      },
+      maxComparisonsPerKind: CEILING,
+      onComparisonCeiling: "error",
+      branchOrder: [BRANCH],
+    });
+    expect(isErr(cliff)).toBe(true);
+    if (isErr(cliff)) {
+      expect(cliff.error.message).toMatch(/ceiling/i);
+    }
+
+    // Keyless path: window=1 over the same 6 nodes = 5 pairs < 10 → no ceiling, and the
+    // adjacent Riveras still merge.
+    const base = await emptyStore();
+    const provider = await branchWith(base, PATIENTS);
+    const result = await merge<CareGraph>(base, [provider], options());
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+    const names = (await base.nodes.Patient.find())
+      .map((patient) => patient.name)
+      .sort();
+    // 6 staged → 5 committed (the two Riveras collapsed into one).
+    expect(names).toHaveLength(5);
+    expect(names.filter((name) => name.includes("Rivera"))).toHaveLength(1);
+    expect(result.data.resolutions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("is DETERMINISTIC: shuffled creation order yields the same committed graph", async () => {
+    cleanups = [];
+    const shuffled = [
+      PATIENTS[3]!,
+      PATIENTS[0]!,
+      PATIENTS[5]!,
+      PATIENTS[1]!,
+      PATIENTS[4]!,
+      PATIENTS[2]!,
+    ];
+
+    const baseNatural = await emptyStore();
+    const natural = await merge<CareGraph>(
+      baseNatural,
+      [await branchWith(baseNatural, PATIENTS)],
+      options(),
+    );
+    const baseShuffled = await emptyStore();
+    const reordered = await merge<CareGraph>(
+      baseShuffled,
+      [await branchWith(baseShuffled, shuffled)],
+      options(),
+    );
+    expect(isOk(natural) && isOk(reordered)).toBe(true);
+
+    const namesOf = async (store: CareStore): Promise<readonly string[]> =>
+      (await store.nodes.Patient.find()).map((patient) => patient.name).sort();
+    expect(await namesOf(baseShuffled)).toEqual(await namesOf(baseNatural));
+  });
+});

--- a/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
@@ -1,0 +1,983 @@
+/**
+ * Acceptance gate for the public new-vs-live-target entry point `mergeIncremental()`
+ * (design §6.4-B / §6.6). It commits branch additions, resolves them against the
+ * committed `target` (base-id-wins), propagates inherited modifications/deletions,
+ * and refuses row hazards that would resurrect tombstones or corrupt edge identity.
+ *
+ * Covers, on BOTH backends (new-vs-base semantics parity):
+ *   - happy path: additive resolution against an ADVANCED target (target content the
+ *     fork-point never had) — the deliberately-relaxed half of base@V;
+ *   - idempotent re-run: a second merge against the now-evolved target does not churn;
+ *   - inherited modify / delete propagate when the live target did not conflict;
+ *   - live target modify/delete wins over stale branch delete/modify conflicts;
+ *   - a non-keep-base `onBasePropertyConflict` is REJECTED;
+ *   - the existing-target-id write guard fires for a colliding NODE and a colliding EDGE;
+ *   - a branch that did not fork from `forkPoint` is REJECTED.
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { mergeIncremental } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { normalizeGraph } from "../property/graph-merge/normalize";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    mrn: z.string(),
+    tag: z.string().optional(),
+  }),
+});
+const Encounter = defineNode("Encounter", {
+  // `tag` is OPTIONAL so a target row can carry a field a branch's add omits — the
+  // subset/patch-no-op case the stale-overwrite guard must NOT falsely refuse.
+  schema: z.object({ reason: z.string(), tag: z.string().optional() }),
+});
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+// A SECOND edge kind over the same endpoints, so a test can collide two different-kind
+// edges on one (globally-unique) edge id.
+const flaggedEncounter = defineEdge("flaggedEncounter", {
+  schema: z.object({ reason: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+const primaryEncounter = defineEdge("primaryEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const careGraph = defineGraph({
+  id: "merge-incremental-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Encounter: { type: Encounter },
+  },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+    flaggedEncounter: {
+      type: flaggedEncounter,
+      from: [Patient],
+      to: [Encounter],
+    },
+    primaryEncounter: {
+      type: primaryEncounter,
+      from: [Patient],
+      to: [Encounter],
+      cardinality: "one",
+    },
+  },
+});
+type CareGraph = typeof careGraph;
+type CareStore = GraphBranch<CareGraph>["store"];
+
+const A = asBranchId("provider-a");
+
+function options(
+  overrides: Partial<MergeOptions<CareGraph>> = {},
+): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { mrn?: string }).mrn,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [A],
+    ...overrides,
+  };
+}
+
+describe.each(backendMatrix())(
+  "mergeIncremental new-vs-live-target [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) {
+        await cleanup();
+      }
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function emptyStore(): Promise<CareStore> {
+      const [store] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      return store;
+    }
+
+    async function forkOf(
+      forkPoint: CareStore,
+    ): Promise<GraphBranch<CareGraph>> {
+      return unwrap(
+        await branch<CareGraph>(forkPoint, () => makeBackend(), { id: A }),
+      );
+    }
+
+    async function seedCarePath(store: CareStore) {
+      await store.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      await store.nodes.Encounter.bulkCreate([
+        { id: "enc-1", props: { reason: "checkup" } },
+      ]);
+      const [edge] = await store.edges.hadEncounter.bulkCreate([
+        {
+          id: "edge-1",
+          from: { kind: "Patient", id: "base-ana" },
+          to: { kind: "Encounter", id: "enc-1" },
+          props: { on: "2026-06-01" },
+        },
+      ]);
+      return edge!;
+    }
+
+    it("HAPPY PATH: resolves a branch addition onto an advanced target's base entity", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // A re-discovered patient (different spelling, same mrn) + an encounter edge.
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "new-ana", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+      ]);
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "enc-1", props: { reason: "checkup" } },
+      ]);
+      await provider.store.edges.hadEncounter.bulkCreate([
+        {
+          id: "edge-1",
+          from: { kind: "Patient", id: "new-ana" },
+          to: { kind: "Encounter", id: "enc-1" },
+          props: { on: "2026-06-04" },
+        },
+      ]);
+
+      // Target is ADVANCED beyond the (empty) fork-point: it already holds the base.
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      // The new patient absorbed onto the committed base id (base-id-wins), and the
+      // encounter + edge repointed onto it. Base name preserved (keep-base).
+      const patients = await target.nodes.Patient.find();
+      expect(patients.map((patient) => patient.id)).toEqual(["base-ana"]);
+      expect(patients[0]!.name).toBe("Anna Rivera");
+      const encounters = await target.nodes.Encounter.find();
+      expect(encounters.map((enc) => enc.id)).toEqual(["enc-1"]);
+      expect(result.data.resolutions.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("IDEMPOTENT: re-merging the same branch against the evolved target does not churn", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "new-ana", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+        // A novel patient with NO base match — exercises the idempotency of a
+        // non-resolved branch addition (committed under its own id, then re-seen).
+        { id: "new-cara", props: { name: "Cara Diaz", mrn: "MRN-9" } },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      const first = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(first)).toBe(true);
+      const afterFirst = await normalizeGraph(target);
+
+      const second = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(second)).toBe(true);
+      const afterSecond = await normalizeGraph(target);
+
+      expect(afterSecond).toEqual(afterFirst);
+    });
+
+    it("APPLIES an inherited node modification when the target is unchanged", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const [base] = await forkPoint.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.update(base!.id, { name: "Anna R." });
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      const [patient] = await target.nodes.Patient.find();
+      expect(patient?.name).toBe("Anna R.");
+    });
+
+    it("APPLIES an inherited node deletion when the target is unchanged", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const [base] = await forkPoint.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.delete(base!.id);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      expect(await target.nodes.Patient.find()).toEqual([]);
+    });
+
+    it("APPLIES an inherited edge modification when the target is unchanged", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const baseEdge = await seedCarePath(forkPoint);
+      const provider = await forkOf(forkPoint);
+      await provider.store.edges.hadEncounter.update(baseEdge.id, {
+        on: "2026-06-15",
+      });
+      const target = await emptyStore();
+      await seedCarePath(target);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      const [edge] = await target.edges.hadEncounter.find();
+      expect(edge?.on).toBe("2026-06-15");
+    });
+
+    it("APPLIES an inherited edge deletion when the target is unchanged", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const baseEdge = await seedCarePath(forkPoint);
+      const provider = await forkOf(forkPoint);
+      await provider.store.edges.hadEncounter.delete(baseEdge.id);
+      const target = await emptyStore();
+      await seedCarePath(target);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      expect(await target.edges.hadEncounter.find()).toEqual([]);
+    });
+
+    it("TARGET WINS: target modification survives a branch deletion", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const [base] = await forkPoint.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.delete(base!.id);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      await target.nodes.Patient.update(base!.id, { tag: "target-live" });
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options({ onDeleteModifyConflict: "deleteWins" }),
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      const [patient] = await target.nodes.Patient.find();
+      expect(patient?.tag).toBe("target-live");
+      expect(result.data.deleteModifyConflicts[0]?.resolution).toBe(
+        "modifyWins",
+      );
+    });
+
+    it("TARGET WINS: target deletion is not resurrected by a branch modification", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const [base] = await forkPoint.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.update(base!.id, { name: "Anna R." });
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      await target.nodes.Patient.delete(base!.id);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      expect(await target.nodes.Patient.find()).toEqual([]);
+      expect(result.data.deleteModifyConflicts[0]?.resolution).toBe(
+        "deleteWins",
+      );
+    });
+
+    it("REJECTS a non-keep-base onBasePropertyConflict policy", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      const target = await emptyStore();
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options({ onBasePropertyConflict: "lastWriteWins" }),
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(/onBasePropertyConflict/);
+      }
+    });
+
+    it("TARGET WINS: preserves a colliding committed NODE id", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // A novel patient (mrn has no base match) under an id that the live target
+      // already owns. Same `(kind,id)` is one identity; target props win.
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "shared-id", props: { name: "Branch Person", mrn: "MRN-NEW" } },
+      ]);
+      const target = await emptyStore();
+      // Same id, DIFFERENT entity (different mrn → no new-vs-base resolution).
+      await target.nodes.Patient.bulkCreate([
+        {
+          id: "shared-id",
+          props: { name: "Committed Person", mrn: "MRN-OTHER" },
+        },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      const [patient] = await target.nodes.Patient.find();
+      expect(patient?.name).toBe("Committed Person");
+      expect(patient?.mrn).toBe("MRN-OTHER");
+      const conflictProperties = result.data.conflicts
+        .map((conflict) => conflict.property)
+        .sort();
+      expect(conflictProperties).toEqual(["mrn", "name"]);
+    });
+
+    it("SAME-ID re-discovery: resolves onto the base (base-id-wins), does not error", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // The branch re-creates the entity under its REAL committed id (same id, same mrn,
+      // a divergent name) — a node whose unique value re-discovers the committed base
+      // AT THE SAME (kind, id). It must resolve via base-id-wins, not trip the guard.
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      // Single committed row, base name kept (keep-base), no duplicate insert.
+      const patients = await target.nodes.Patient.find();
+      expect(patients.map((patient) => patient.id)).toEqual(["base-ana"]);
+      expect(patients[0]!.name).toBe("Anna Rivera");
+      // The base↔branch name divergence is FLAGGED, and the reserved base-provenance
+      // sentinel never leaks into the public conflict's contributing-branch values.
+      const nameConflict = result.data.conflicts.find(
+        (conflict) => conflict.property === "name",
+      );
+      expect(nameConflict).toBeDefined();
+      for (const value of nameConflict?.values ?? []) {
+        expect(value.branchId).toBe(A);
+      }
+    });
+
+    it("PATCH no-op: a subset re-add of a committed row is allowed (not a stale overwrite)", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // A new Encounter (no unique constraint → never a base member) under an id the
+      // target already holds, whose props are a SUBSET of (and agree with) the committed
+      // row. The commit PATCH-merges, so this is a no-op, not a stale overwrite.
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "enc-sub", props: { reason: "checkup" } },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Encounter.bulkCreate([
+        { id: "enc-sub", props: { reason: "checkup", tag: "vip" } },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isOk(result)).toBe(true);
+      // The patch preserved the committed-only field — a true no-op.
+      const [encounter] = await target.nodes.Encounter.find();
+      expect(encounter?.reason).toBe("checkup");
+      expect((encounter as { tag?: string } | undefined)?.tag).toBe("vip");
+    });
+
+    it("GUARD: refuses to overwrite a colliding committed EDGE id", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // Branch addition: novel patient + encounter + edge "shared-edge".
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "branch-pat", props: { name: "Branch Person", mrn: "MRN-NEW" } },
+      ]);
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "branch-enc", props: { reason: "branch" } },
+      ]);
+      await provider.store.edges.hadEncounter.bulkCreate([
+        {
+          id: "shared-edge",
+          from: { kind: "Patient", id: "branch-pat" },
+          to: { kind: "Encounter", id: "branch-enc" },
+          props: { on: "2026-06-04" },
+        },
+      ]);
+      const target = await emptyStore();
+      // Same edge id, DIFFERENT endpoints already committed.
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-pat", props: { name: "Committed", mrn: "MRN-OTHER" } },
+      ]);
+      await target.nodes.Encounter.bulkCreate([
+        { id: "base-enc", props: { reason: "committed" } },
+      ]);
+      await target.edges.hadEncounter.bulkCreate([
+        {
+          id: "shared-edge",
+          from: { kind: "Patient", id: "base-pat" },
+          to: { kind: "Encounter", id: "base-enc" },
+          props: { on: "2000-01-01" },
+        },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(/overwrite committed edge/i);
+      }
+    });
+
+    it("GUARD (cross-kind): refuses a same-id edge of a DIFFERENT kind than the committed edge", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // Branch additively creates a patient + encounter + a flaggedEncounter edge that
+      // reuses an id the target holds under a DIFFERENT edge kind.
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "branch-pat", props: { name: "Branch", mrn: "MRN-NEW" } },
+      ]);
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "branch-enc", props: { reason: "branch" } },
+      ]);
+      await provider.store.edges.flaggedEncounter.bulkCreate([
+        {
+          id: "shared-edge",
+          from: { kind: "Patient", id: "branch-pat" },
+          to: { kind: "Encounter", id: "branch-enc" },
+          props: { reason: "flag" },
+        },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-pat", props: { name: "Committed", mrn: "MRN-OTHER" } },
+      ]);
+      await target.nodes.Encounter.bulkCreate([
+        { id: "base-enc", props: { reason: "committed" } },
+      ]);
+      // SAME edge id, committed as a DIFFERENT kind (hadEncounter).
+      await target.edges.hadEncounter.bulkCreate([
+        {
+          id: "shared-edge",
+          from: { kind: "Patient", id: "base-pat" },
+          to: { kind: "Encounter", id: "base-enc" },
+          props: { on: "2000-01-01" },
+        },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      // Edge ids are globally unique (PK is (graph_id, id)); committing the
+      // flaggedEncounter edge would resolve the committed hadEncounter row by id and
+      // overwrite it in place. Must be refused (was silently allowed + corrupting).
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(
+          /edge.id collision|different-kind/i,
+        );
+      }
+      // The committed edge is untouched: still hadEncounter, original props (the guard
+      // aborts before any write, so nothing was committed).
+      const committed = await target.edges.hadEncounter.find();
+      expect(committed.map((edge) => edge.id)).toEqual(["shared-edge"]);
+      expect(committed[0]!.on).toBe("2000-01-01");
+    });
+
+    it("GUARD (soft-delete): refuses to resurrect a soft-deleted committed EDGE", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "branch-pat", props: { name: "Branch", mrn: "MRN-NEW" } },
+      ]);
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "branch-enc", props: { reason: "branch" } },
+      ]);
+      await provider.store.edges.hadEncounter.bulkCreate([
+        {
+          id: "sd-edge",
+          from: { kind: "Patient", id: "branch-pat" },
+          to: { kind: "Encounter", id: "branch-enc" },
+          props: { on: "2026-06-06" },
+        },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-pat", props: { name: "Committed", mrn: "MRN-OTHER" } },
+      ]);
+      await target.nodes.Encounter.bulkCreate([
+        { id: "base-enc", props: { reason: "committed" } },
+      ]);
+      const [sdEdge] = await target.edges.hadEncounter.bulkCreate([
+        {
+          id: "sd-edge",
+          from: { kind: "Patient", id: "base-pat" },
+          to: { kind: "Encounter", id: "base-enc" },
+          props: { on: "2000-01-01" },
+        },
+      ]);
+      // Soft-delete the committed edge. The commit's upsert resolves by id and would
+      // RESURRECT this tombstone (dropping the branch's new edge) — a silent data loss.
+      await target.edges.hadEncounter.delete(sdEdge!.id);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(
+          /resurrect soft-deleted committed edge/i,
+        );
+      }
+    });
+
+    it("GUARD (soft-delete): refuses to resurrect a soft-deleted committed NODE", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // A novel patient (different mrn → no base match) reusing a soft-deleted id.
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "sd-pat", props: { name: "Fresh", mrn: "MRN-NEW" } },
+      ]);
+      const target = await emptyStore();
+      const [sdPat] = await target.nodes.Patient.bulkCreate([
+        { id: "sd-pat", props: { name: "OldStale", mrn: "MRN-OTHER" } },
+      ]);
+      // Soft-delete it; the commit's upsert would resurrect the tombstone and merge its
+      // stale props forward into what the branch staged as a fresh insert.
+      await target.nodes.Patient.delete(sdPat!.id);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(
+          /resurrect soft-deleted committed node/i,
+        );
+      }
+    });
+
+    it("GUARD (kind-aware): a base member does NOT exempt a same-id node of another kind", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      // A new Patient resolves onto base Patient:shared (so "shared" is a base member)...
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "new-pat", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+      ]);
+      // ...and a NEW Encounter reuses the id "shared" — a DIFFERENT kind, same id.
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "shared", props: { reason: "branch" } },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "shared", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      await target.nodes.Encounter.bulkCreate([
+        { id: "shared", props: { reason: "committed" } },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      // Patient:shared is the base member; Encounter:shared is a separate same-id
+      // target identity and must be preserved rather than overwritten by the branch.
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      const encounter = (await target.nodes.Encounter.find()).find(
+        (item) => item.id === "shared",
+      );
+      expect(encounter?.reason).toBe("committed");
+    });
+
+    it("TRANSACTION: TypeGraph edge-cardinality failure rolls back prior node creates", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.bulkCreate([
+        {
+          id: "new-ana",
+          props: { name: "Ana Rivera", mrn: "MRN-1" },
+        },
+      ]);
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "branch-enc", props: { reason: "branch" } },
+      ]);
+      await provider.store.edges.primaryEncounter.bulkCreate([
+        {
+          id: "branch-primary",
+          from: { kind: "Patient", id: "new-ana" },
+          to: { kind: "Encounter", id: "branch-enc" },
+          props: { on: "2026-06-06" },
+        },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      await target.nodes.Encounter.bulkCreate([
+        { id: "base-enc", props: { reason: "committed" } },
+      ]);
+      await target.edges.primaryEncounter.bulkCreate([
+        {
+          id: "base-primary",
+          from: { kind: "Patient", id: "base-ana" },
+          to: { kind: "Encounter", id: "base-enc" },
+          props: { on: "2026-06-01" },
+        },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(/cardinality/i);
+      }
+
+      expect(
+        (await target.nodes.Patient.find()).map((patient) => patient.id),
+      ).toEqual(["base-ana"]);
+      expect(
+        (await target.nodes.Encounter.find()).map((encounter) => encounter.id),
+      ).toEqual(["base-enc"]);
+      expect(
+        (await target.edges.primaryEncounter.find()).map((edge) => edge.id),
+      ).toEqual(["base-primary"]);
+    });
+
+    it("GUARD (base update): refuses to strip heterogeneous committed props while gap-filling base fields", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.bulkCreate([
+        {
+          id: "new-ana",
+          props: { name: "Ana Rivera", mrn: "MRN-1", tag: "branch-gap" },
+        },
+      ]);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      // Public create keeps the unique index coherent; this raw backend update then
+      // simulates an older/heterogeneous committed row the active schema would strip.
+      await target.backend.updateNode({
+        graphId: target.graphId,
+        kind: "Patient",
+        id: "base-ana",
+        props: {
+          name: "Anna Rivera",
+          mrn: "MRN-1",
+          legacyCode: "KEEP-ME",
+        },
+        incrementVersion: true,
+      });
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(/strip existing props/i);
+        expect(result.error.message).toMatch(/lossy base update/i);
+      }
+
+      const row = await target.backend.getNode(
+        target.graphId,
+        "Patient",
+        "base-ana",
+      );
+      expect(row).toBeDefined();
+      const props = JSON.parse(row!.props) as Record<string, unknown>;
+      expect(props.legacyCode).toBe("KEEP-ME");
+      expect(props.tag).toBeUndefined();
+    });
+
+    it("REJECTS a branch that did not fork from forkPoint (base@V mismatch)", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "new-ana", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+      ]);
+      // Mutate the fork-point AFTER forking → its base@V no longer matches the branch.
+      await forkPoint.nodes.Patient.bulkCreate([
+        { id: "drift", props: { name: "Drift", mrn: "MRN-DRIFT" } },
+      ]);
+      const target = await emptyStore();
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(/forkPoint|fork-point/i);
+      }
+    });
+  },
+);
+
+// A graph whose edge type allows MULTIPLE endpoint kinds, so an edge's identity
+// includes `(fromKind, toKind)` — the edge guard must compare them.
+const Thing = defineNode("Thing", { schema: z.object({ name: z.string() }) });
+const Other = defineNode("Other", { schema: z.object({ name: z.string() }) });
+const relatesTo = defineEdge("relatesTo", {
+  schema: z.object({ note: z.string() }),
+  from: [Thing, Other],
+  to: [Thing, Other],
+});
+const polyGraph = defineGraph({
+  id: "merge-incremental-poly",
+  nodes: { Thing: { type: Thing }, Other: { type: Other } },
+  edges: {
+    relatesTo: { type: relatesTo, from: [Thing, Other], to: [Thing, Other] },
+  },
+});
+type PolyGraph = typeof polyGraph;
+
+describe.each(backendMatrix())(
+  "mergeIncremental edge endpoint-kind guard [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) {
+        await cleanup();
+      }
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function emptyPoly(): Promise<GraphBranch<PolyGraph>["store"]> {
+      const [store] = await createStoreWithSchema(
+        polyGraph,
+        await makeBackend(),
+      );
+      return store;
+    }
+
+    it("refuses an edge differing ONLY by endpoint kind (same id / endpoint ids / props)", async () => {
+      cleanups = [];
+      const forkPoint = await emptyPoly();
+      const provider = unwrap(
+        await branch<PolyGraph>(forkPoint, () => makeBackend(), { id: A }),
+      );
+      // Branch edge "e": Other:x -> Other:y, note "same".
+      await provider.store.nodes.Other.bulkCreate([
+        { id: "x", props: { name: "X" } },
+        { id: "y", props: { name: "Y" } },
+      ]);
+      await provider.store.edges.relatesTo.bulkCreate([
+        {
+          id: "e",
+          from: { kind: "Other", id: "x" },
+          to: { kind: "Other", id: "y" },
+          props: { note: "same" },
+        },
+      ]);
+      const target = await emptyPoly();
+      // Committed edge "e": Thing:x -> Thing:y, note "same" — same id, same endpoint
+      // ids, same props, DIFFERENT endpoint kinds.
+      await target.nodes.Thing.bulkCreate([
+        { id: "x", props: { name: "X" } },
+        { id: "y", props: { name: "Y" } },
+      ]);
+      await target.edges.relatesTo.bulkCreate([
+        {
+          id: "e",
+          from: { kind: "Thing", id: "x" },
+          to: { kind: "Thing", id: "y" },
+          props: { note: "same" },
+        },
+      ]);
+
+      const result = await mergeIncremental<PolyGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: { branchOrder: [A] },
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toMatch(/overwrite committed edge/i);
+      }
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge.test.ts
@@ -1,0 +1,741 @@
+import type { GraphBackend, Node, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  subClassOf,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
+import { merge } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import {
+  enumerateAllEdges,
+  enumerateAllNodes,
+} from "../../src/graph-merge/state-diff";
+import type {
+  BranchId,
+  GraphBranch,
+  MergeOptions,
+  SimilarityStrategy,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+/**
+ * A small FHIR-flavored care graph (design §14): patients linked to encounters
+ * and conditions. The `Patient.name` field drives entity resolution; `Doctor` /
+ * `SpecialistDoctor` give the graph a real subclass ontology so
+ * `reconcileTypes: "ontology"` is exercised end-to-end.
+ */
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string(),
+    mrn: z.string().optional(),
+  }),
+});
+
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+
+const Condition = defineNode("Condition", {
+  schema: z.object({ code: z.string() }),
+});
+
+const Doctor = defineNode("Doctor", {
+  schema: z.object({ name: z.string() }),
+});
+
+const SpecialistDoctor = defineNode("SpecialistDoctor", {
+  schema: z.object({ name: z.string() }),
+});
+
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const hasCondition = defineEdge("hasCondition", {
+  schema: z.object({ since: z.string() }),
+  from: [Patient],
+  to: [Condition],
+});
+
+const careGraph = defineGraph({
+  id: "fhir-care-graph",
+  nodes: {
+    Patient: { type: Patient },
+    Encounter: { type: Encounter },
+    Condition: { type: Condition },
+    Doctor: { type: Doctor },
+    SpecialistDoctor: { type: SpecialistDoctor },
+  },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+    hasCondition: { type: hasCondition, from: [Patient], to: [Condition] },
+  },
+  ontology: [subClassOf(SpecialistDoctor, Doctor)],
+});
+
+type CareGraph = typeof careGraph;
+
+const DEMO_THRESHOLD = 0.85;
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+/** The FHIR demo similarity: in-memory Dice trigram over Patient.name (no embeddings). */
+const patientNameSimilarity: SimilarityStrategy<CareGraph> = {
+  kind: "fulltext",
+  fields: ["name"],
+};
+
+/** Blocks patients by shared birthDate, bounding the O(n²) comparisons. */
+function blockByBirthDate(node: Node): string | undefined {
+  return (node as unknown as { birthDate?: string }).birthDate;
+}
+
+/** The merge options shared by the FHIR scenario. */
+function fhirMergeOptions(): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => blockByBirthDate(node),
+        similarity: patientNameSimilarity,
+        threshold: DEMO_THRESHOLD,
+      },
+    },
+    reconcileTypes: "ontology",
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH_A, BRANCH_B],
+  };
+}
+
+function lexicographicMin(left: string, right: string): string {
+  return left < right ? left : right;
+}
+
+/** Live `{ id, name, mrn }` for every Patient in a store, sorted by id. */
+async function livePatients(
+  store: Store<CareGraph>,
+): Promise<readonly Readonly<{ id: string; name: unknown; mrn: unknown }>[]> {
+  const rows = await enumerateAllNodes(store.backend, store.graphId, "Patient");
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => {
+      const props = JSON.parse(row.props) as Record<string, unknown>;
+      return { id: row.id, name: props.name, mrn: props.mrn };
+    })
+    .sort((left, right) =>
+      left.id < right.id ? -1
+      : left.id > right.id ? 1
+      : 0,
+    );
+}
+
+/** Live `{ id, from, to }` for every edge of `kind`, sorted by id. */
+async function liveEdges(
+  store: Store<CareGraph>,
+  kind: string,
+): Promise<readonly Readonly<{ id: string; from: string; to: string }>[]> {
+  const rows = await enumerateAllEdges(store.backend, store.graphId, kind);
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => ({ id: row.id, from: row.from_id, to: row.to_id }))
+    .sort((left, right) =>
+      left.id < right.id ? -1
+      : left.id > right.id ? 1
+      : 0,
+    );
+}
+
+describe.each(backendMatrix())("merge — FHIR care graph [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function makeBranch(
+    baseStore: Store<CareGraph>,
+    id: BranchId,
+  ): Promise<GraphBranch<CareGraph>> {
+    return unwrap(
+      await branch<CareGraph>(baseStore, () => makeBackend(), { id }),
+    );
+  }
+
+  /**
+   * The §14 scenario: an empty base (so both branches' patients are NEW and must
+   * be resolved). Branch A adds "Anna Rivera" with an encounter; branch B adds
+   * "Ana Rivera" (same birthDate, a near-duplicate spelling) with a condition.
+   * Branch A also carries an `mrn` that branch B leaves blank, and the two name
+   * spellings disagree — both surface as property conflicts under `"flag"`.
+   */
+  async function seedScenario(): Promise<
+    Readonly<{
+      baseStore: Store<CareGraph>;
+      branchA: GraphBranch<CareGraph>;
+      branchB: GraphBranch<CareGraph>;
+      annaId: string;
+      anaId: string;
+    }>
+  > {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    // Branch A: "Anna Rivera" + an encounter edge onto her.
+    const anna = await branchA.store.nodes.Patient.create({
+      name: "Anna Rivera",
+      birthDate: "1974-03-09",
+      mrn: "MRN-001",
+    });
+    const encounter = await branchA.store.nodes.Encounter.create({
+      reason: "annual checkup",
+    });
+    await branchA.store.edges.hadEncounter.create(anna, encounter, {
+      on: "2024-01-15",
+    });
+
+    // Branch B: "Ana Rivera" (same birthDate) + a condition edge onto her.
+    const ana = await branchB.store.nodes.Patient.create({
+      name: "Ana Rivera",
+      birthDate: "1974-03-09",
+    });
+    const condition = await branchB.store.nodes.Condition.create({
+      code: "E11.9",
+    });
+    await branchB.store.edges.hasCondition.create(ana, condition, {
+      since: "2023-06-01",
+    });
+
+    return {
+      baseStore,
+      branchA,
+      branchB,
+      annaId: anna.id,
+      anaId: ana.id,
+    };
+  }
+
+  it("honors a branch's property deletion on an inherited node (#2)", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const alice = await baseStore.nodes.Patient.create({
+      name: "Alice",
+      birthDate: "1974-03-09",
+      mrn: "MRN-1",
+    });
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    // The branch removes the optional `mrn` on the inherited node.
+    await branchA.store.nodes.Patient.update(alice.id, { mrn: undefined });
+
+    const result = await merge<CareGraph>(baseStore, [branchA], {
+      branchOrder: [BRANCH_A],
+    });
+    expect(isOk(result)).toBe(true);
+
+    const patients = await livePatients(baseStore);
+    expect(patients).toHaveLength(1);
+    expect(patients[0]!.name).toBe("Alice");
+    expect(patients[0]!.mrn).toBeUndefined();
+  });
+
+  it("honors a deletion while a concurrent branch edits a different property (#2)", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const alice = await baseStore.nodes.Patient.create({
+      name: "Alice",
+      birthDate: "1974-03-09",
+      mrn: "MRN-1",
+    });
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+    await branchA.store.nodes.Patient.update(alice.id, { mrn: undefined });
+    await branchB.store.nodes.Patient.update(alice.id, { name: "Alicia" });
+
+    const result = await merge<CareGraph>(baseStore, [branchA, branchB], {
+      branchOrder: [BRANCH_A, BRANCH_B],
+    });
+    expect(isOk(result)).toBe(true);
+
+    const patients = await livePatients(baseStore);
+    expect(patients).toHaveLength(1);
+    // Branch B's name edit survives; branch A's mrn deletion is honored, not
+    // reverted to the base value.
+    expect(patients[0]!.name).toBe("Alicia");
+    expect(patients[0]!.mrn).toBeUndefined();
+  });
+
+  it("resolves the duplicate Patient, repoints both branches' edges, and flags the name conflict", async () => {
+    const { baseStore, branchA, branchB, annaId, anaId } = await seedScenario();
+
+    const result = await merge<CareGraph>(
+      baseStore,
+      [branchA, branchB],
+      fhirMergeOptions(),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+    const report = result.data;
+
+    // Exactly ONE canonical Patient survives in the merged base. The canonical
+    // id is the lexicographically-minimal of the two duplicate ids.
+    const patients = await livePatients(baseStore);
+    expect(patients).toHaveLength(1);
+    const expectedCanonical = lexicographicMin(annaId, anaId);
+    expect(patients[0]!.id).toBe(expectedCanonical);
+
+    // One entity resolution recording the two-member cluster.
+    expect(report.resolutions).toHaveLength(1);
+    const resolution = report.resolutions[0]!;
+    expect(resolution.canonicalId).toBe(expectedCanonical);
+    expect(resolution.kind).toBe("Patient");
+    expect([...resolution.memberIds].sort()).toEqual([annaId, anaId].sort());
+    expect([...resolution.branchOrigins].sort()).toEqual(
+      [BRANCH_A, BRANCH_B].sort(),
+    );
+
+    // Both branches' edges are repointed onto the SINGLE canonical patient.
+    const encounters = await liveEdges(baseStore, "hadEncounter");
+    const conditions = await liveEdges(baseStore, "hasCondition");
+    expect(encounters).toHaveLength(1);
+    expect(conditions).toHaveLength(1);
+    expect(encounters[0]!.from).toBe(expectedCanonical);
+    expect(conditions[0]!.from).toBe(expectedCanonical);
+
+    // The name-spelling disagreement surfaces as a property conflict on the
+    // canonical patient. The two contributing branch values are recorded.
+    const nameConflict = report.conflicts.find(
+      (conflict) => conflict.property === "name",
+    );
+    expect(nameConflict).toBeDefined();
+    expect(nameConflict!.entityId).toBe(expectedCanonical);
+    expect(nameConflict!.kind).toBe("Patient");
+    const conflictNames = nameConflict!.values
+      .map((value) => value.value)
+      .sort();
+    expect(conflictNames).toEqual(["Ana Rivera", "Anna Rivera"]);
+    // Under "flag" the canonical's own value is retained (no auto-resolution).
+    expect(nameConflict!.resolution).toBe(
+      expectedCanonical === annaId ? "Anna Rivera" : "Ana Rivera",
+    );
+
+    // The merged counts reflect the single patient + both repointed edges, plus
+    // the two non-duplicate satellite nodes (encounter, condition).
+    expect(report.merged.nodes).toBeGreaterThanOrEqual(1);
+    expect(report.merged.edges).toBe(2);
+
+    // Same-kind cluster: ontology reconciliation is a no-op here (both members
+    // are Patient), so no type reconciliation is recorded.
+    expect(report.typeReconciliations).toEqual([]);
+
+    // Report-only provenance: each branch contributed the canonical patient and
+    // its own edge into the merged graph.
+    const provA = report.provenance.byBranch(BRANCH_A);
+    const provB = report.provenance.byBranch(BRANCH_B);
+    expect(provA.nodeIds).toContain(expectedCanonical);
+    expect(provB.nodeIds).toContain(expectedCanonical);
+    expect(provA.edgeIds).toContain(encounters[0]!.id);
+    expect(provB.edgeIds).toContain(conditions[0]!.id);
+  });
+
+  it("produces an identical merged graph regardless of branch order", async () => {
+    const forward = await seedScenario();
+    const forwardResult = await merge<CareGraph>(
+      forward.baseStore,
+      [forward.branchA, forward.branchB],
+      fhirMergeOptions(),
+    );
+
+    const reversed = await seedScenario();
+    const reversedResult = await merge<CareGraph>(
+      reversed.baseStore,
+      [reversed.branchB, reversed.branchA],
+      fhirMergeOptions(),
+    );
+
+    expect(isOk(forwardResult) && isOk(reversedResult)).toBe(true);
+    if (!isOk(forwardResult) || !isOk(reversedResult)) {
+      return;
+    }
+
+    // The two scenarios mint distinct ids, so compare structural shape: one
+    // patient, one of each edge, one resolution, one name conflict.
+    expect(forwardResult.data.resolutions).toHaveLength(1);
+    expect(reversedResult.data.resolutions).toHaveLength(1);
+    expect(forwardResult.data.merged.edges).toBe(
+      reversedResult.data.merged.edges,
+    );
+    expect(
+      forwardResult.data.conflicts.filter(
+        (conflict) => conflict.property === "name",
+      ),
+    ).toHaveLength(1);
+    expect(
+      reversedResult.data.conflicts.filter(
+        (conflict) => conflict.property === "name",
+      ),
+    ).toHaveLength(1);
+
+    // A within-scenario order swap (forward.* merged in reversed order) must
+    // commit the SAME canonical patient set as the forward order.
+    const orderSwap = await seedScenario();
+    const swapForward = await merge<CareGraph>(
+      orderSwap.baseStore,
+      [orderSwap.branchA, orderSwap.branchB],
+      fhirMergeOptions(),
+    );
+    const swapPatients = await livePatients(orderSwap.baseStore);
+    expect(isOk(swapForward)).toBe(true);
+    expect(swapPatients).toHaveLength(1);
+    const expectedCanonical = lexicographicMin(
+      orderSwap.annaId,
+      orderSwap.anaId,
+    );
+    expect(swapPatients[0]!.id).toBe(expectedCanonical);
+  });
+
+  it("merges distinct (non-duplicate) patients without collapsing them", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    await branchA.store.nodes.Patient.create({
+      name: "Anna Rivera",
+      birthDate: "1974-03-09",
+    });
+    // Same birthDate (so they co-block) but a completely different name —
+    // below threshold, so they must NOT merge.
+    await branchB.store.nodes.Patient.create({
+      name: "Robert Smith",
+      birthDate: "1974-03-09",
+    });
+
+    const result = await merge<CareGraph>(
+      baseStore,
+      [branchA, branchB],
+      fhirMergeOptions(),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+
+    const patients = await livePatients(baseStore);
+    expect(patients).toHaveLength(2);
+    // Each new patient is its own singleton cluster: no multi-member resolution.
+    for (const resolution of result.data.resolutions) {
+      expect(resolution.memberIds).toHaveLength(1);
+    }
+    expect(
+      result.data.conflicts.filter((conflict) => conflict.property === "name"),
+    ).toHaveLength(0);
+  });
+
+  it("rejects a branch whose base@V does not match the target", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+
+    // Fork a branch FIRST (captures base@V over the empty base)...
+    const staleBranch = await makeBranch(baseStore, BRANCH_A);
+
+    // ...then MUTATE the base so its content fingerprint (and thus base@V)
+    // diverges from what the branch forked from.
+    await baseStore.nodes.Patient.create({
+      name: "Drift Patient",
+      birthDate: "2000-01-01",
+    });
+
+    const result = await merge<CareGraph>(
+      baseStore,
+      [staleBranch],
+      fhirMergeOptions(),
+    );
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+      expect(result.error.code).toBe("GRAPH_MERGE_BASE_VERSION_MISMATCH");
+    }
+  });
+
+  // Regression (F20): a base row soft-deleted BEFORE branching must not come back
+  // to life. The clone formerly exported `includeDeleted: true`, but interchange's
+  // meta schema has no `deletedAt`, so the tombstone was lost and the row imported
+  // LIVE — then the fork diff reported it as a new node and the merge re-created it.
+  it("does not resurrect a soft-deleted base row as a new node (F20)", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+
+    const ghost = await baseStore.nodes.Patient.create({
+      name: "Ghost",
+      birthDate: "1900-01-01",
+    });
+    await baseStore.nodes.Patient.delete(ghost.id); // soft-delete IN THE BASE
+    const keeper = await baseStore.nodes.Patient.create({
+      name: "Keeper",
+      birthDate: "1990-05-05",
+    });
+
+    // Fork (clone) and merge straight back with no branch-side edits.
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const result = await merge<CareGraph>(
+      baseStore,
+      [branchA],
+      fhirMergeOptions(),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+
+    // Only Keeper is live; Ghost stays deleted and is never re-introduced.
+    const patients = await livePatients(baseStore);
+    expect(patients.map((patient) => patient.id)).toEqual([keeper.id]);
+    expect(patients.map((patient) => patient.name)).toEqual(["Keeper"]);
+    expect(result.data.resolutions).toEqual([]);
+  });
+
+  // Regression (F1): two branches create a node under the SAME explicit id with
+  // differing props. The committed node is policy-resolved, but the cross-branch
+  // disagreement must be REPORTED — formerly it was silently dropped because the
+  // cluster had a single distinct id.
+  it("reports a conflict for a node both branches create under one id (F1)", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    const sharedId = "shared-patient-1";
+    await branchA.store.nodes.Patient.bulkCreate([
+      { id: sharedId, props: { name: "Anna Rivera", birthDate: "1974-03-09" } },
+    ]);
+    await branchB.store.nodes.Patient.bulkCreate([
+      { id: sharedId, props: { name: "Ana Rivera", birthDate: "1974-03-09" } },
+    ]);
+
+    const result = await merge<CareGraph>(baseStore, [branchA, branchB], {
+      onPropertyConflict: "flag",
+      branchOrder: [BRANCH_A, BRANCH_B],
+    });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+    const report = result.data;
+
+    const patients = await livePatients(baseStore);
+    expect(patients.map((patient) => patient.id)).toEqual([sharedId]);
+
+    const nameConflict = report.conflicts.find(
+      (conflict) => conflict.property === "name",
+    );
+    expect(nameConflict).toBeDefined();
+    expect(nameConflict!.entityId).toBe(sharedId);
+    expect(nameConflict!.values.map((value) => value.value).sort()).toEqual([
+      "Ana Rivera",
+      "Anna Rivera",
+    ]);
+    // A single distinct id is not a multi-id MERGE, so no EntityResolution.
+    expect(report.resolutions).toEqual([]);
+  });
+
+  // Regression (F11): an inherited node modified by two branches on DIFFERENT
+  // fields must 3-way merge — neither edit silently overwrites the other (formerly
+  // the lexicographically-largest branchId's full prop bag won).
+  it("3-way merges an inherited node edited on disjoint fields (F11)", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const origin = await baseStore.nodes.Patient.create({
+      name: "Origin",
+      birthDate: "1980-01-01",
+      mrn: "MRN-ORIG",
+    });
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    await branchA.store.nodes.Patient.update(origin.id, { name: "Renamed" });
+    await branchB.store.nodes.Patient.update(origin.id, {
+      birthDate: "2000-12-31",
+    });
+
+    const result = await merge<CareGraph>(baseStore, [branchA, branchB], {
+      onPropertyConflict: "flag",
+      branchOrder: [BRANCH_A, BRANCH_B],
+    });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+
+    const patients = await livePatients(baseStore);
+    expect(patients).toHaveLength(1);
+    expect(patients[0]!.id).toBe(origin.id);
+    expect(patients[0]!.name).toBe("Renamed"); // A's edit survived
+    expect(result.data.conflicts).toEqual([]); // disjoint fields → no conflict
+
+    const rows = await enumerateAllNodes(
+      baseStore.backend,
+      baseStore.graphId,
+      "Patient",
+    );
+    const merged = rows.find((row) => row.id === origin.id)!;
+    expect((JSON.parse(merged.props) as { birthDate: string }).birthDate).toBe(
+      "2000-12-31", // B's edit survived too
+    );
+  });
+
+  // Regression (F11): two branches modifying the SAME inherited field surface a
+  // PropertyConflict instead of one silently overwriting the other.
+  it("surfaces a conflict when two branches edit the same inherited field (F11)", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const origin = await baseStore.nodes.Patient.create({
+      name: "Origin",
+      birthDate: "1980-01-01",
+    });
+    const branchA = await makeBranch(baseStore, BRANCH_A);
+    const branchB = await makeBranch(baseStore, BRANCH_B);
+
+    await branchA.store.nodes.Patient.update(origin.id, { name: "Alpha" });
+    await branchB.store.nodes.Patient.update(origin.id, { name: "Beta" });
+
+    const result = await merge<CareGraph>(baseStore, [branchA, branchB], {
+      onPropertyConflict: "flag",
+      branchOrder: [BRANCH_A, BRANCH_B],
+    });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+
+    const nameConflict = result.data.conflicts.find(
+      (conflict) => conflict.property === "name",
+    );
+    expect(nameConflict).toBeDefined();
+    expect(nameConflict!.entityId).toBe(origin.id);
+    expect(nameConflict!.values.map((value) => value.value).sort()).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+    // Under "flag" the base value is retained — not silently overwritten.
+    const patients = await livePatients(baseStore);
+    expect(patients[0]!.name).toBe("Origin");
+  });
+});
+
+describe.each(backendMatrix())(
+  "merge edge property deletion [$name]",
+  (entry) => {
+    const Person = defineNode("Person", {
+      schema: z.object({ name: z.string() }),
+    });
+    // `note` is optional so a fork can remove it; `since` is required.
+    const linked = defineEdge("linked", {
+      schema: z.object({ since: z.string(), note: z.string().optional() }),
+      from: [Person],
+      to: [Person],
+    });
+    const linkGraph = defineGraph({
+      id: "merge-edge-deletion",
+      nodes: { Person: { type: Person } },
+      edges: { linked: { type: linked, from: [Person], to: [Person] } },
+    });
+    type LinkGraph = typeof linkGraph;
+
+    let cleanups: (() => Promise<void>)[];
+    beforeEach(() => {
+      cleanups = [];
+    });
+    afterEach(async () => {
+      for (const cleanup of cleanups) {
+        await cleanup();
+      }
+    });
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    it("honors a fork's deletion of an optional edge property (#2 edges)", async () => {
+      const [baseStore] = await createStoreWithSchema(
+        linkGraph,
+        await makeBackend(),
+      );
+      const alice = await baseStore.nodes.Person.create({ name: "Alice" });
+      const bob = await baseStore.nodes.Person.create({ name: "Bob" });
+      const edge = await baseStore.edges.linked.create(alice, bob, {
+        since: "2020",
+        note: "temporary",
+      });
+
+      const branchA = unwrap(
+        await branch<LinkGraph>(baseStore, () => makeBackend(), {
+          id: BRANCH_A,
+        }),
+      );
+      // The branch removes the optional `note` on the inherited edge.
+      await branchA.store.edges.linked.update(edge.id, { note: undefined });
+
+      const result = await merge<LinkGraph>(baseStore, [branchA], {
+        branchOrder: [BRANCH_A],
+      });
+      expect(isOk(result)).toBe(true);
+
+      const rows = await enumerateAllEdges(
+        baseStore.backend,
+        baseStore.graphId,
+        "linked",
+      );
+      const live = rows.filter((row) => row.deleted_at === undefined);
+      expect(live).toHaveLength(1);
+      const props = JSON.parse(live[0]!.props) as Record<string, unknown>;
+      expect(props.since).toBe("2020");
+      expect(props.note).toBeUndefined();
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/new-vs-base-determinism.test.ts
+++ b/packages/typegraph/tests/graph-merge/new-vs-base-determinism.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Step 7: the new-vs-base invariant gates at the SYNTHETIC scope (design §6.4-B,
+ * §7), exercising the candidate-source + scoring + reconciler pipeline via
+ * `mergeAgainstBase` — bypassing the public-`merge()` snapshot precondition rather
+ * than fighting it.
+ *
+ *   1. FIXED POINT (§6.4-B): re-merging the SAME branch against an already-absorbed,
+ *      consistent evolved base is a no-op — the committed graph does not churn.
+ *   2. PERMUTATION-INVARIANCE (§7): with base sources ACTIVE, shuffling branch order
+ *      yields a deep-equal committed graph and normalized report. This is the
+ *      new-axis analogue of the branch-permutation gate; it must hold unconditionally.
+ *
+ * Both run on BOTH backends. Comparison uses the same canonical `normalizeGraph` /
+ * `normalizeReport` the headline determinism gate uses — `normalizeGraph` strips the
+ * non-deterministic META (version / timestamps), so an idempotent re-commit (which
+ * bumps `version`) still compares equal when the logical graph is unchanged.
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { mergeAgainstBase } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type {
+  BranchId,
+  GraphBranch,
+  MergeOptions,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import {
+  normalizeGraph,
+  normalizeReport,
+} from "../property/graph-merge/normalize";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    mrn: z.string(),
+    cohort: z.string().optional(),
+  }),
+});
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const careGraph = defineGraph({
+  id: "nvb-determinism-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Encounter: { type: Encounter },
+  },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+});
+type CareGraph = typeof careGraph;
+
+const A = asBranchId("provider-a");
+const B = asBranchId("provider-b");
+const FIXED_ORDER: readonly BranchId[] = [A, B];
+
+function options(
+  target: GraphBranch<CareGraph>["store"],
+): MergeOptions<CareGraph> {
+  return {
+    target,
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { mrn?: string }).mrn,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: FIXED_ORDER,
+  };
+}
+
+function cohortOptions(
+  target: GraphBranch<CareGraph>["store"],
+): MergeOptions<CareGraph> {
+  return {
+    target,
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { cohort?: string }).cohort,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: FIXED_ORDER,
+  };
+}
+
+describe.each(backendMatrix())("new-vs-base invariants [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  it("FIXED POINT: re-merging the same branch against the evolved base does not churn", async () => {
+    cleanups = [];
+    const [forkBase] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const provider = unwrap(
+      await branch<CareGraph>(forkBase, () => makeBackend(), { id: A }),
+    );
+    // Consistent with the base (same name) + an encounter edge to exercise repoint
+    // idempotency across the re-merge.
+    await provider.store.nodes.Patient.bulkCreate([
+      { id: "new-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+    ]);
+    await provider.store.nodes.Encounter.bulkCreate([
+      { id: "enc-1", props: { reason: "checkup" } },
+    ]);
+    await provider.store.edges.hadEncounter.bulkCreate([
+      {
+        id: "edge-1",
+        from: { kind: "Patient", id: "new-ana" },
+        to: { kind: "Encounter", id: "enc-1" },
+        props: { on: "2026-06-04" },
+      },
+    ]);
+
+    const [target] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    await target.nodes.Patient.bulkCreate([
+      { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+    ]);
+
+    // First merge: absorb new-ana into base-ana, commit enc + repointed edge.
+    const first = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [provider],
+      options(target),
+    );
+    expect(isOk(first)).toBe(true);
+    const afterFirst = await normalizeGraph(target);
+
+    // Second merge of the SAME branch against the now-evolved base.
+    const second = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [provider],
+      options(target),
+    );
+    expect(isOk(second)).toBe(true);
+    const afterSecond = await normalizeGraph(target);
+
+    // No churn: the committed graph is byte-identical after the re-merge.
+    expect(afterSecond).toEqual(afterFirst);
+    // And it really did absorb (one Patient, the committed base id).
+    const patients = await target.nodes.Patient.find();
+    expect(patients.map((p) => p.id)).toEqual(["base-ana"]);
+  });
+
+  it("PERMUTATION-INVARIANCE: shuffling branch order is identical with base sources active", async () => {
+    cleanups = [];
+    // One fork-point + two read-only branches, each re-discovering a DIFFERENT
+    // committed base entity. Merged into two identically-seeded targets in opposite
+    // orders.
+    const [forkBase] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const branchA = unwrap(
+      await branch<CareGraph>(forkBase, () => makeBackend(), { id: A }),
+    );
+    await branchA.store.nodes.Patient.bulkCreate([
+      { id: "new-ana", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+    ]);
+    const branchB = unwrap(
+      await branch<CareGraph>(forkBase, () => makeBackend(), { id: B }),
+    );
+    await branchB.store.nodes.Patient.bulkCreate([
+      { id: "new-bob", props: { name: "Bobby Lee", mrn: "MRN-2" } },
+    ]);
+
+    async function seededTarget(): Promise<GraphBranch<CareGraph>["store"]> {
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+        { id: "base-bob", props: { name: "Bob Lee", mrn: "MRN-2" } },
+      ]);
+      return target;
+    }
+
+    const targetNatural = await seededTarget();
+    const targetReversed = await seededTarget();
+
+    const natural = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [branchA, branchB],
+      options(targetNatural),
+    );
+    const reversed = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [branchB, branchA],
+      options(targetReversed),
+    );
+    expect(isOk(natural) && isOk(reversed)).toBe(true);
+    if (!isOk(natural) || !isOk(reversed)) {
+      return;
+    }
+
+    // Deep-equal normalized report AND committed graph across the two orderings.
+    expect(normalizeReport(reversed.data, FIXED_ORDER)).toEqual(
+      normalizeReport(natural.data, FIXED_ORDER),
+    );
+    expect(await normalizeGraph(targetReversed)).toEqual(
+      await normalizeGraph(targetNatural),
+    );
+
+    // The run actually exercised base resolution (both new nodes absorbed).
+    expect(natural.data.resolutions.length).toBeGreaterThanOrEqual(2);
+    const ids = (await targetNatural.nodes.Patient.find())
+      .map((p) => p.id)
+      .sort();
+    expect(ids).toEqual(["base-ana", "base-bob"]);
+  });
+
+  it("PERMUTATION-INVARIANCE: reports non-empty base ambiguities deterministically", async () => {
+    cleanups = [];
+    // Same `base-a ~ new-1 ~ new-2 ~ base-b` chain as the base-guard contract,
+    // but split across two branches so the determinism reducer sees a real,
+    // non-empty baseAmbiguities report under branch-order permutation.
+    const [forkBase] = await createStoreWithSchema(
+      careGraph,
+      await makeBackend(),
+    );
+    const branchA = unwrap(
+      await branch<CareGraph>(forkBase, () => makeBackend(), { id: A }),
+    );
+    await branchA.store.nodes.Patient.bulkCreate([
+      {
+        id: "new-1",
+        props: { name: "Anna Rivera", mrn: "MRN-A", cohort: "C1" },
+      },
+    ]);
+    const branchB = unwrap(
+      await branch<CareGraph>(forkBase, () => makeBackend(), { id: B }),
+    );
+    await branchB.store.nodes.Patient.bulkCreate([
+      {
+        id: "new-2",
+        props: { name: "Ana Rivera", mrn: "MRN-B", cohort: "C1" },
+      },
+    ]);
+
+    async function seededTarget(): Promise<GraphBranch<CareGraph>["store"]> {
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      await target.nodes.Patient.bulkCreate([
+        {
+          id: "base-a",
+          props: { name: "Anna R.", mrn: "MRN-A", cohort: "C0" },
+        },
+        {
+          id: "base-b",
+          props: { name: "Ana R.", mrn: "MRN-B", cohort: "C0" },
+        },
+      ]);
+      return target;
+    }
+
+    const targetNatural = await seededTarget();
+    const targetReversed = await seededTarget();
+
+    const natural = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [branchA, branchB],
+      cohortOptions(targetNatural),
+    );
+    const reversed = await mergeAgainstBase<CareGraph>(
+      forkBase,
+      [branchB, branchA],
+      cohortOptions(targetReversed),
+    );
+    expect(isOk(natural) && isOk(reversed)).toBe(true);
+    if (!isOk(natural) || !isOk(reversed)) {
+      return;
+    }
+
+    expect(natural.data.baseAmbiguities).toHaveLength(1);
+    expect(reversed.data.baseAmbiguities).toHaveLength(1);
+    expect(normalizeReport(reversed.data, FIXED_ORDER)).toEqual(
+      normalizeReport(natural.data, FIXED_ORDER),
+    );
+    expect(await normalizeGraph(targetReversed)).toEqual(
+      await normalizeGraph(targetNatural),
+    );
+
+    const ambiguity = natural.data.baseAmbiguities[0]!;
+    expect(
+      ambiguity.baseIds
+        .map((identity) => `${identity.kind}:${identity.id}`)
+        .sort(),
+    ).toEqual(["Patient:base-a", "Patient:base-b"]);
+    expect(
+      ambiguity.memberIds
+        .map((identity) => `${identity.kind}:${identity.id}`)
+        .sort(),
+    ).toEqual([
+      "Patient:base-a",
+      "Patient:base-b",
+      "Patient:new-1",
+      "Patient:new-2",
+    ]);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/new-vs-base-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/new-vs-base-merge.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Step 4 contract: reconciler wiring for the synthetic NEW-vs-BASE scope
+ * (design §6.4-C). Drives `mergeAgainstBase` end-to-end and proves:
+ *
+ *   - a staged node re-discovering a committed entity (shared unique value)
+ *     resolves AGAINST it — BASE-ID-WINS: the committed base id is the canonical
+ *     survivor, the new node is absorbed (never inserted as a duplicate);
+ *   - branch edges onto the new node REPOINT onto the surviving base id;
+ *   - base props gap-fill / keep the committed value under the default policy.
+ *
+ * The branch forks from an EMPTY fork-point (so its new node does not collide with
+ * the committed base's unique value and the diff sees no spurious deletion), while
+ * the committed base lives in a separate TARGET — the evolved-base shape the
+ * synthetic scope models. Runs on BOTH backends (new-vs-base semantics parity).
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { mergeAgainstBase } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), mrn: z.string() }),
+});
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const careGraph = defineGraph({
+  id: "new-vs-base-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Encounter: { type: Encounter },
+  },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+});
+type CareGraph = typeof careGraph;
+
+const BRANCH = asBranchId("provider-x");
+
+function mergeOptions(
+  target: GraphBranch<CareGraph>["store"],
+): MergeOptions<CareGraph> {
+  return {
+    target,
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { mrn?: string }).mrn,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH],
+  };
+}
+
+describe.each(backendMatrix())(
+  "mergeAgainstBase new-vs-base [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) {
+        await cleanup();
+      }
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    it("resolves a staged duplicate onto the committed base id; edges follow", async () => {
+      cleanups = [];
+
+      // Fork-point base: EMPTY (so the branch's new patient does not collide with the
+      // committed unique value, and the diff sees no spurious deletion).
+      const [forkBase] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+
+      // The branch adds a duplicate patient (same mrn as the committed base) + an
+      // encounter edge onto her.
+      const provider = unwrap(
+        await branch<CareGraph>(forkBase, () => makeBackend(), { id: BRANCH }),
+      );
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "new-ana", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+      ]);
+      await provider.store.nodes.Encounter.bulkCreate([
+        { id: "enc-1", props: { reason: "checkup" } },
+      ]);
+      await provider.store.edges.hadEncounter.bulkCreate([
+        {
+          id: "edge-1",
+          from: { kind: "Patient", id: "new-ana" },
+          to: { kind: "Encounter", id: "enc-1" },
+          props: { on: "2026-06-04" },
+        },
+      ]);
+
+      // The committed (evolved) base, in a SEPARATE target: already holds the entity.
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      const result = await mergeAgainstBase<CareGraph>(
+        forkBase,
+        [provider],
+        mergeOptions(target),
+      );
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+      console.info(
+        `[${entry.name}] resolutions:`,
+        result.data.resolutions.map(
+          (r) => `${r.canonicalId}<-[${r.memberIds.join(",")}]`,
+        ),
+      );
+
+      // BASE-ID-WINS: exactly one Patient in the target — the committed base-ana —
+      // carrying its committed value (flag keeps the canonical/base value). new-ana
+      // was absorbed, never inserted as a second row.
+      const patients = await target.nodes.Patient.find();
+      console.info(
+        `[${entry.name}] patients:`,
+        patients.map((p) => `${p.id}:${p.name}`),
+      );
+      expect(patients).toHaveLength(1);
+      expect(`${patients[0]?.id}`).toBe("base-ana");
+      expect(patients[0]?.name).toBe("Anna Rivera");
+
+      // The branch's new encounter committed, and its edge REPOINTED onto base-ana.
+      const encounters = await target.nodes.Encounter.find();
+      expect(encounters).toHaveLength(1);
+      const edges = await target.edges.hadEncounter.find();
+      console.info(
+        `[${entry.name}] edges:`,
+        edges.map((e) => `${e.fromId}->${e.toId}`),
+      );
+      expect(edges).toHaveLength(1);
+      expect(`${edges[0]?.fromId}`).toBe("base-ana");
+      expect(`${edges[0]?.toId}`).toBe("enc-1");
+
+      // The resolution records the base id as canonical, spanning both ids.
+      const resolution = result.data.resolutions.find(
+        (r) => r.canonicalId === "base-ana",
+      );
+      expect(resolution).toBeDefined();
+      expect(resolution?.memberIds.map((id) => id).sort()).toEqual([
+        "base-ana",
+        "new-ana",
+      ]);
+    });
+
+    it("base-id-wins overrides a MergeOptions.canonical hook (hook bypassed for base clusters)", async () => {
+      cleanups = [];
+      const [forkBase] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      const provider = unwrap(
+        await branch<CareGraph>(forkBase, () => makeBackend(), { id: BRANCH }),
+      );
+      await provider.store.nodes.Patient.bulkCreate([
+        { id: "zzz-new", props: { name: "Ana Rivera", mrn: "MRN-1" } },
+      ]);
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      await target.nodes.Patient.bulkCreate([
+        { id: "aaa-base", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      // A canonical hook that would pick the lexicographically-LAST member id. For a
+      // base cluster it must be BYPASSED — the committed base id wins regardless.
+      const result = await mergeAgainstBase<CareGraph>(forkBase, [provider], {
+        ...mergeOptions(target),
+        canonical: (cluster) =>
+          [...cluster.members].sort((l, r) => (l < r ? 1 : -1))[0]!,
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      const patients = await target.nodes.Patient.find();
+      // Hook would have chosen "zzz-new"; base-id-wins forces the committed "aaa-base".
+      expect(patients).toHaveLength(1);
+      expect(`${patients[0]?.id}`).toBe("aaa-base");
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/provenance-store.test.ts
+++ b/packages/typegraph/tests/graph-merge/provenance-store.test.ts
@@ -1,0 +1,248 @@
+/**
+ * On-graph provenance persistence — the sidecar provenance graph (open-item #5).
+ *
+ * With `persistProvenance: true`, the merge upserts one `{branch, sourceId}` row
+ * per contribution into a sidecar graph on the SAME backend, queryable AFTER the
+ * merge via `openProvenanceStore` / `readProvenance`. Asserted on BOTH backends:
+ *
+ *   1. the persisted rows match the in-memory `report.provenance.byBranch` index;
+ *   2. a resolved canonical carries provenance from BOTH contributing branches
+ *      (with the original fork-local `sourceId`s);
+ *   3. edges are tagged too (`role: "edge"`);
+ *   4. re-persisting is idempotent (deterministic ids → upsert, no duplicates);
+ *   5. it is OFF by default (no `provenancePersisted`, no rows).
+ */
+
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import {
+  openProvenanceStore,
+  persistProvenanceRecords,
+  provenanceGraphId,
+} from "../../src/graph-merge/provenance-store";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), birthDate: z.string() }),
+});
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const careGraph = defineGraph({
+  id: "provenance-test-care",
+  nodes: { Patient: { type: Patient }, Encounter: { type: Encounter } },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+});
+type CareGraph = typeof careGraph;
+
+const BRANCH_A = asBranchId("provider-a");
+const BRANCH_B = asBranchId("provider-b");
+
+/** Fulltext name match (no embedder): "Anna Rivera" ~ "Ana Rivera" clears 0.85. */
+function provMergeOptions(persistProvenance: boolean): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { birthDate?: string }).birthDate,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH_A, BRANCH_B],
+    persistProvenance,
+  };
+}
+
+type Fixture = Readonly<{
+  base: Store<CareGraph>;
+  branches: readonly GraphBranch<CareGraph>[];
+}>;
+
+describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  /**
+   * Base + two branches: each adds a near-duplicate Patient (same birthDate) plus
+   * its own Encounter joined by a hadEncounter edge. The merge resolves the two
+   * Patients into one canonical and repoints both edges onto it.
+   */
+  async function materialize(): Promise<Fixture> {
+    const [base] = await createStoreWithSchema(careGraph, await makeBackend());
+    const branchA = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_A }),
+    );
+    const branchB = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_B }),
+    );
+
+    await branchA.store.nodes.Patient.bulkCreate([
+      {
+        id: "pat-anna",
+        props: { name: "Anna Rivera", birthDate: "1974-03-09" },
+      },
+    ]);
+    await branchA.store.nodes.Encounter.bulkCreate([
+      { id: "enc-a", props: { reason: "checkup" } },
+    ]);
+    await branchA.store.edges.hadEncounter.bulkCreate([
+      {
+        id: "edge-a",
+        from: { kind: "Patient", id: "pat-anna" },
+        to: { kind: "Encounter", id: "enc-a" },
+        props: { on: "1974-03-09" },
+      },
+    ]);
+
+    await branchB.store.nodes.Patient.bulkCreate([
+      { id: "pat-ana", props: { name: "Ana Rivera", birthDate: "1974-03-09" } },
+    ]);
+    await branchB.store.nodes.Encounter.bulkCreate([
+      { id: "enc-b", props: { reason: "referral" } },
+    ]);
+    await branchB.store.edges.hadEncounter.bulkCreate([
+      {
+        id: "edge-b",
+        from: { kind: "Patient", id: "pat-ana" },
+        to: { kind: "Encounter", id: "enc-b" },
+        props: { on: "1974-03-09" },
+      },
+    ]);
+
+    return { base, branches: [branchA, branchB] };
+  }
+
+  it("persists {branch, sourceId} rows that match the report index", async () => {
+    cleanups = [];
+    const { base, branches } = await materialize();
+
+    const result = await merge<CareGraph>(
+      base,
+      branches,
+      provMergeOptions(true),
+    );
+    expect(isOk(result)).toBe(true);
+    const report = unwrap(result);
+
+    // The report announces the sidecar graph + the row count.
+    expect(report.provenancePersisted?.graphId).toBe(
+      provenanceGraphId(base.graphId),
+    );
+    expect(report.provenancePersisted?.count).toBeGreaterThan(0);
+    expect(report.warnings).toEqual([]);
+
+    const provStore = await openProvenanceStore(base.backend, base.graphId);
+
+    // Every node id the in-memory index credits to a branch is persisted for it.
+    for (const branchId of [BRANCH_A, BRANCH_B]) {
+      const reported = report.provenance.byBranch(branchId);
+      const persisted = await provStore.nodes.Provenance.find();
+      const persistedNodeIds = new Set(
+        persisted
+          .filter((p) => p.branchId === branchId && p.role === "node")
+          .map((p) => p.canonicalId),
+      );
+      for (const nodeId of reported.nodeIds) {
+        expect(persistedNodeIds.has(nodeId)).toBe(true);
+      }
+    }
+  });
+
+  it("tags the resolved canonical with BOTH branches and keeps each source id", async () => {
+    cleanups = [];
+    const { base, branches } = await materialize();
+    unwrap(await merge<CareGraph>(base, branches, provMergeOptions(true)));
+
+    const patients = await base.nodes.Patient.find();
+    expect(patients).toHaveLength(1);
+    const canonicalId = patients[0]!.id;
+
+    const provStore = await openProvenanceStore(base.backend, base.graphId);
+    const forCanonical = (await provStore.nodes.Provenance.find()).filter(
+      (p) => p.canonicalId === canonicalId,
+    );
+
+    // Two contributions — one per branch — each keeping the fork-local source id.
+    expect(new Set(forCanonical.map((p) => p.branchId))).toEqual(
+      new Set([BRANCH_A, BRANCH_B]),
+    );
+    expect(new Set(forCanonical.map((p) => p.sourceId))).toEqual(
+      new Set(["pat-anna", "pat-ana"]),
+    );
+
+    // Edges are tagged too.
+    const edges = (await provStore.nodes.Provenance.find()).filter(
+      (p) => p.role === "edge",
+    );
+    expect(edges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("is idempotent: re-persisting the same records upserts (no duplicates)", async () => {
+    cleanups = [];
+    const { base, branches } = await materialize();
+    unwrap(await merge<CareGraph>(base, branches, provMergeOptions(true)));
+
+    const provStore = await openProvenanceStore(base.backend, base.graphId);
+    const firstCount = (await provStore.nodes.Provenance.find()).length;
+
+    // Re-persist the SAME records (as a re-run would): deterministic ids → upsert.
+    const records = (await provStore.nodes.Provenance.find()).map((p) => ({
+      role: p.role,
+      canonicalId: p.canonicalId,
+      canonicalKind: p.canonicalKind,
+      branchId: asBranchId(p.branchId),
+      sourceId: p.sourceId,
+    }));
+    await persistProvenanceRecords(provStore, base.graphId, records);
+
+    const secondCount = (await provStore.nodes.Provenance.find()).length;
+    expect(secondCount).toBe(firstCount);
+  });
+
+  it("is OFF by default: no provenancePersisted, no rows", async () => {
+    cleanups = [];
+    const { base, branches } = await materialize();
+
+    const report = unwrap(
+      await merge<CareGraph>(base, branches, provMergeOptions(false)),
+    );
+    expect(report.provenancePersisted).toBeUndefined();
+
+    const provStore = await openProvenanceStore(base.backend, base.graphId);
+    expect(await provStore.nodes.Provenance.find()).toHaveLength(0);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/search-parity.test.ts
+++ b/packages/typegraph/tests/graph-merge/search-parity.test.ts
@@ -1,0 +1,155 @@
+import type { GraphBackend, Node } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  searchable,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { SimilarityUnavailableError } from "../../src/graph-merge/errors";
+import { isErr } from "../../src/graph-merge/result";
+import type { SimilarityContext } from "../../src/graph-merge/similarity";
+import { scorePair } from "../../src/graph-merge/similarity";
+import type { SimilarityStrategy } from "../../src/graph-merge/types";
+import {
+  createPgliteMergeBackend,
+  createSqliteMergeBackend,
+} from "./test-utils";
+
+/**
+ * Search-parity probe (design §13 Open-Q#1, mostly resolved by TypeGraph 0.29.0).
+ *
+ * Three properties, asserted across the dual backend matrix:
+ *
+ *   1. `store.search.fulltext` returns hits on BOTH SQLite (FTS5) and PGlite
+ *      (tsvector + GIN) — full parity, no extension beyond the batteries-included
+ *      local backends, no embeddings.
+ *   2. A `vector` / `hybrid` similarity strategy with NO configured embedder
+ *      yields a typed {@link SimilarityUnavailableError}, INDEPENDENT of the
+ *      backend's own vector capability: merge scoring uses an injected in-memory
+ *      embedder (exact cosine over staged candidate pairs), never the backend ANN
+ *      index (the staged candidate rows are unindexed).
+ *   3. `backend.capabilities.vector?.supported` is `true` on the default PGlite
+ *      backend (pgvector loaded). That index is available for RETRIEVAL at scale;
+ *      it is deliberately NOT on the merge candidate-scoring path, so the
+ *      capability and the merge embedder are orthogonal.
+ */
+
+const Document = defineNode("Document", {
+  schema: z.object({
+    title: searchable(),
+    body: z.string(),
+  }),
+});
+
+const searchGraph = defineGraph({
+  id: "search-parity",
+  nodes: { Document: { type: Document } },
+  edges: {},
+});
+
+/** Seeds three documents whose titles share a discriminating term. */
+async function seedDocuments(backend: GraphBackend) {
+  const [store] = await createStoreWithSchema(searchGraph, backend);
+  await store.nodes.Document.create({
+    title: "Climate warming trends",
+    body: "rising global temperatures",
+  });
+  await store.nodes.Document.create({
+    title: "Climate policy review",
+    body: "carbon pricing mechanisms",
+  });
+  await store.nodes.Document.create({
+    title: "Local bakery openings",
+    body: "fresh bread daily",
+  });
+  return store;
+}
+
+describe("search-parity probe (Open-Q#1)", () => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  it("fulltext returns hits on SQLite (FTS5)", async () => {
+    const fixture = createSqliteMergeBackend();
+    cleanups = [fixture.cleanup];
+    const store = await seedDocuments(fixture.backend);
+
+    const hits = await store.search.fulltext("Document", {
+      query: "climate",
+      limit: 10,
+    });
+
+    // Both "Climate" titles match; the bakery doc does not.
+    expect(hits.length).toBe(2);
+    const titles = hits.map((hit) => hit.node.title).sort();
+    expect(titles).toEqual(["Climate policy review", "Climate warming trends"]);
+    for (const hit of hits) {
+      expect(hit.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("fulltext returns hits on PGlite (tsvector + GIN)", async () => {
+    const fixture = await createPgliteMergeBackend();
+    cleanups = [fixture.cleanup];
+    const store = await seedDocuments(fixture.backend);
+
+    const hits = await store.search.fulltext("Document", {
+      query: "climate",
+      limit: 10,
+    });
+
+    expect(hits.length).toBe(2);
+    const titles = hits.map((hit) => hit.node.title).sort();
+    expect(titles).toEqual(["Climate policy review", "Climate warming trends"]);
+    for (const hit of hits) {
+      expect(hit.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("yields SimilarityUnavailableError for vector/hybrid with no configured embedder", async () => {
+    const fixture = createSqliteMergeBackend();
+    cleanups = [fixture.cleanup];
+
+    const a = { kind: "Document", id: "a", title: "x" } as unknown as Node;
+    const b = { kind: "Document", id: "b", title: "y" } as unknown as Node;
+    // No `embeddings` on the context == MergeOptions.embedder was not configured.
+    // The error fires regardless of the backend's own vector capability.
+    const ctx: SimilarityContext = { backend: fixture.backend };
+
+    for (const kind of ["vector", "hybrid"] as const) {
+      const strategy: SimilarityStrategy =
+        kind === "vector" ?
+          { kind: "vector", field: "title" }
+        : { kind: "hybrid", fields: ["title"] };
+      const result = scorePair(a, b, strategy, ctx);
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(SimilarityUnavailableError);
+        expect(result.error.code).toBe("GRAPH_MERGE_SIMILARITY_UNAVAILABLE");
+      }
+    }
+  });
+
+  it("advertises vector capability on the default PGlite backend (pgvector) — orthogonal to merge scoring", async () => {
+    const fixture = await createPgliteMergeBackend();
+    cleanups = [fixture.cleanup];
+
+    // The default PGlite backend loads pgvector, so it advertises vector support
+    // for RETRIEVAL. Merge candidate scoring does NOT use this index (staged rows
+    // are unindexed) — it uses the injected in-memory embedder — so this is
+    // asserted as an independent backend fact, not a merge gate.
+    expect(fixture.backend.capabilities.vector?.supported).toBe(true);
+    expect(
+      fixture.backend.capabilities.vector?.metrics.length ?? 0,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/similarity.test.ts
+++ b/packages/typegraph/tests/graph-merge/similarity.test.ts
@@ -1,0 +1,308 @@
+import type { GraphBackend, Node } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { SimilarityUnavailableError } from "../../src/graph-merge/errors";
+import { isErr, isOk } from "../../src/graph-merge/result";
+import type { SimilarityContext } from "../../src/graph-merge/similarity";
+import {
+  diceTrigramSimilarity,
+  scorePair,
+} from "../../src/graph-merge/similarity";
+import type { SimilarityStrategy } from "../../src/graph-merge/types";
+import {
+  backendMatrix,
+  createSqliteMergeBackend,
+  fakeEmbeddings,
+} from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string().optional(),
+  }),
+});
+
+const patientGraph = defineGraph({
+  id: "similarity-patient",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+
+type PatientNode = Node<typeof Patient>;
+
+/** Demo merge threshold frozen by the plan: Sørensen–Dice trigram @ 0.85. */
+const DEMO_THRESHOLD = 0.85;
+
+/**
+ * Boots a real Patient store on a given backend and yields a node factory plus a
+ * {@link SimilarityContext} over that backend. Using a real store keeps the test
+ * honest about the public `Node` runtime shape (schema props spread at the top
+ * level) the production scorer reads.
+ */
+async function makeHarness(backend: GraphBackend): Promise<
+  Readonly<{
+    create: (name: string, birthDate?: string) => Promise<PatientNode>;
+    ctx: SimilarityContext;
+  }>
+> {
+  const [store] = await createStoreWithSchema(patientGraph, backend);
+  return {
+    create: (name, birthDate) =>
+      store.nodes.Patient.create(
+        birthDate === undefined ? { name } : { name, birthDate },
+      ),
+    ctx: { backend },
+  };
+}
+
+describe("diceTrigramSimilarity (pure metric)", () => {
+  it("is symmetric and bounded in [0, 1]", () => {
+    const left = diceTrigramSimilarity("Anna Rivera", "Ana Rivera");
+    const right = diceTrigramSimilarity("Ana Rivera", "Anna Rivera");
+    expect(left).toBe(right);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left).toBeLessThanOrEqual(1);
+  });
+
+  it("scores an identical string at 1 and a fully-disjoint pair at 0", () => {
+    expect(diceTrigramSimilarity("Anna Rivera", "Anna Rivera")).toBe(1);
+    // No shared trigrams between these two short, disjoint tokens.
+    expect(diceTrigramSimilarity("xyz", "qpw")).toBe(0);
+  });
+
+  it("ranks a near-duplicate name above an unrelated one and clears 0.85", () => {
+    const close = diceTrigramSimilarity("Anna Rivera", "Ana Rivera");
+    const far = diceTrigramSimilarity("Anna Rivera", "Bob Lee");
+    expect(close).toBeGreaterThan(far);
+    expect(close).toBeGreaterThanOrEqual(DEMO_THRESHOLD);
+  });
+});
+
+describe.each(backendMatrix())("scorePair on $name", (entry) => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup !== undefined) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("custom strategy is symmetric and clamped into [0, 1]", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera", "1974-03-09");
+    const ana = await harness.create("Ana Rivera", "1974-03-09");
+
+    // An asymmetric raw scorer (depends on first arg) that also returns
+    // out-of-range values, to prove clamping AND that scorePair forwards the
+    // caller's value (the caller owns symmetry).
+    const asymmetric: SimilarityStrategy = {
+      kind: "custom",
+      score: (a) =>
+        (a as unknown as { name: string }).name === "Anna Rivera" ? 1.5 : -0.5,
+    };
+
+    const forward = scorePair(anna, ana, asymmetric, harness.ctx);
+    const reverse = scorePair(ana, anna, asymmetric, harness.ctx);
+    expect(isOk(forward)).toBe(true);
+    expect(isOk(reverse)).toBe(true);
+    if (isOk(forward) && isOk(reverse)) {
+      // 1.5 clamps to 1, -0.5 clamps to 0 — both inside the codomain.
+      expect(forward.data).toBe(1);
+      expect(reverse.data).toBe(0);
+    }
+
+    // A genuinely symmetric custom scorer round-trips identically.
+    const symmetric: SimilarityStrategy = {
+      kind: "custom",
+      score: (a, b) =>
+        diceTrigramSimilarity(
+          (a as unknown as { name: string }).name,
+          (b as unknown as { name: string }).name,
+        ),
+    };
+    const sForward = scorePair(anna, ana, symmetric, harness.ctx);
+    const sReverse = scorePair(ana, anna, symmetric, harness.ctx);
+    expect(isOk(sForward) && isOk(sReverse)).toBe(true);
+    if (isOk(sForward) && isOk(sReverse)) {
+      expect(sForward.data).toBe(sReverse.data);
+    }
+  });
+
+  it("fulltext ranks Anna~Ana above Anna~Bob and clears 0.85", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera");
+    const ana = await harness.create("Ana Rivera");
+    const bob = await harness.create("Bob Lee");
+
+    const strategy: SimilarityStrategy = {
+      kind: "fulltext",
+      fields: ["name"],
+    };
+
+    const close = scorePair(anna, ana, strategy, harness.ctx);
+    const far = scorePair(anna, bob, strategy, harness.ctx);
+    expect(isOk(close) && isOk(far)).toBe(true);
+    if (isOk(close) && isOk(far)) {
+      // Relative behavior (per the plan): near-duplicate beats unrelated.
+      expect(close.data).toBeGreaterThan(far.data);
+      // Absolute behavior: the near-duplicate clears the demo threshold.
+      expect(close.data).toBeGreaterThanOrEqual(DEMO_THRESHOLD);
+      // And the unrelated pair does NOT clear it.
+      expect(far.data).toBeLessThan(DEMO_THRESHOLD);
+    }
+  });
+
+  it("fulltext scoring is symmetric across multiple fields", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera", "1974-03-09");
+    const ana = await harness.create("Ana Rivera", "1974-03-09");
+
+    const strategy: SimilarityStrategy = {
+      kind: "fulltext",
+      fields: ["name", "birthDate"],
+    };
+    const forward = scorePair(anna, ana, strategy, harness.ctx);
+    const reverse = scorePair(ana, anna, strategy, harness.ctx);
+    expect(isOk(forward) && isOk(reverse)).toBe(true);
+    if (isOk(forward) && isOk(reverse)) {
+      expect(forward.data).toBe(reverse.data);
+    }
+  });
+
+  it("vector/hybrid with NO embedder configured yields SimilarityUnavailableError", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera");
+    const ana = await harness.create("Ana Rivera");
+
+    // harness.ctx carries no `embeddings` — i.e. MergeOptions.embedder was not
+    // configured. vector/hybrid then fail with a typed error REGARDLESS of the
+    // backend's own vector capability: merge scoring uses an injected in-memory
+    // embedder, not the backend's index.
+    for (const strategy of [
+      { kind: "vector", field: "name" },
+      { kind: "hybrid", fields: ["name"] },
+    ] as const) {
+      const result = scorePair(anna, ana, strategy, harness.ctx);
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(SimilarityUnavailableError);
+      }
+    }
+  });
+
+  it("vector strategy WITH an embedder ranks Anna~Ana above Anna~Bob", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera");
+    const ana = await harness.create("Ana Rivera");
+    const bob = await harness.create("Bob Lee");
+
+    const ctx: SimilarityContext = {
+      backend: fixture.backend,
+      embeddings: await fakeEmbeddings([
+        "Anna Rivera",
+        "Ana Rivera",
+        "Bob Lee",
+      ]),
+    };
+    const strategy: SimilarityStrategy = { kind: "vector", field: "name" };
+
+    const close = scorePair(anna, ana, strategy, ctx);
+    const far = scorePair(anna, bob, strategy, ctx);
+    expect(isOk(close) && isOk(far)).toBe(true);
+    if (isOk(close) && isOk(far)) {
+      // Cosine is symmetric, in [0, 1], and the near-duplicate beats the
+      // unrelated pair (the determinism/relative contract the demo relies on).
+      expect(close.data).toBeGreaterThan(far.data);
+      expect(close.data).toBeLessThanOrEqual(1);
+      expect(far.data).toBeGreaterThanOrEqual(0);
+      const reverse = scorePair(ana, anna, strategy, ctx);
+      if (isOk(reverse)) {
+        expect(reverse.data).toBe(close.data);
+      }
+    }
+  });
+
+  it("hybrid strategy WITH an embedder blends cosine + trigram and ranks Anna~Ana above Anna~Bob", async () => {
+    const fixture = await entry.make();
+    cleanup = fixture.cleanup;
+    const harness = await makeHarness(fixture.backend);
+
+    const anna = await harness.create("Anna Rivera");
+    const ana = await harness.create("Ana Rivera");
+    const bob = await harness.create("Bob Lee");
+
+    const ctx: SimilarityContext = {
+      backend: fixture.backend,
+      embeddings: await fakeEmbeddings([
+        "Anna Rivera",
+        "Ana Rivera",
+        "Bob Lee",
+      ]),
+    };
+    const strategy: SimilarityStrategy = { kind: "hybrid", fields: ["name"] };
+
+    const close = scorePair(anna, ana, strategy, ctx);
+    const far = scorePair(anna, bob, strategy, ctx);
+    expect(isOk(close) && isOk(far)).toBe(true);
+    if (isOk(close) && isOk(far)) {
+      expect(close.data).toBeGreaterThan(far.data);
+      expect(close.data).toBeLessThanOrEqual(1);
+      // Symmetric blend.
+      const reverse = scorePair(ana, anna, strategy, ctx);
+      if (isOk(reverse)) {
+        expect(reverse.data).toBe(close.data);
+      }
+    }
+  });
+});
+
+describe("scorePair fulltext empty-field guard (F7)", () => {
+  const birthDateSimilarity: SimilarityStrategy = {
+    kind: "fulltext",
+    fields: ["birthDate"],
+  };
+
+  it("scores two nodes both missing the configured field as MIN_SCORE, not 1.0", async () => {
+    const fixture = createSqliteMergeBackend();
+    try {
+      const harness = await makeHarness(fixture.backend);
+      // Neither patient carries a birthDate, so the configured fulltext field is
+      // empty on both. They share NO comparable text — that must NOT score a
+      // perfect 1.0 (which would emit a candidate edge and merge two distinct
+      // entities). The pure metric still treats empty==empty as vacuously identical.
+      const alice = await harness.create("Alice");
+      const bob = await harness.create("Bob");
+      const score = scorePair(alice, bob, birthDateSimilarity, harness.ctx);
+      expect(isOk(score)).toBe(true);
+      if (!isOk(score)) {
+        return;
+      }
+      expect(score.data).toBe(0);
+      expect(diceTrigramSimilarity("", "")).toBe(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});

--- a/packages/typegraph/tests/graph-merge/smoke.test.ts
+++ b/packages/typegraph/tests/graph-merge/smoke.test.ts
@@ -1,0 +1,27 @@
+import { defineEdge, defineGraph, defineNode } from "@nicia-ai/typegraph";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+});
+
+describe("graph-merge scaffold smoke", () => {
+  it("constructs a trivial graph from @nicia-ai/typegraph", () => {
+    const graph = defineGraph({
+      id: "social",
+      nodes: { Person: { type: Person } },
+      edges: {
+        knows: { type: knows, from: [Person], to: [Person] },
+      },
+    });
+
+    expect(graph.id).toBe("social");
+    expect(Object.keys(graph.nodes)).toContain("Person");
+    expect(Object.keys(graph.edges)).toContain("knows");
+  });
+});

--- a/packages/typegraph/tests/graph-merge/sources.test.ts
+++ b/packages/typegraph/tests/graph-merge/sources.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Step 0 contract: the candidate-SOURCE layer + the shared SCORING stage (§4).
+ *
+ * Proves the three-layer split (sources → scoring → reconciler) for the two staged
+ * sources refactored out of the old fused `generateCandidates`:
+ *
+ *   - `exactKeySource` PROPOSES fuzzy pairs from the `block()` / unblocked buckets
+ *     and decides no match itself (no forced edges, no base members).
+ *   - `uniqueSource` PROPOSES forced (definitional) edges from the unique-constraint
+ *     buckets and no fuzzy pairs.
+ *   - the scoring stage is the single match-decision point: it thresholds fuzzy
+ *     pairs, passes forced edges through unscored, and a forced pair is never also
+ *     fuzzy-scored.
+ *
+ * Plus the behaviour-preserving guard: driving the sources through scoring yields
+ * the BYTE-IDENTICAL edge set the back-compat `generateCandidates(blocks, …)`
+ * composition produces over the same blocked input.
+ */
+
+import type { Node, UniqueIntrospection } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { blockNodes } from "../../src/graph-merge/blocking";
+import { generateCandidates } from "../../src/graph-merge/candidate-gen";
+import {
+  compareMergeKeys,
+  idOf,
+  kindOf,
+  mergeKey,
+  mergeKeyOf,
+} from "../../src/graph-merge/node-key";
+import { isOk } from "../../src/graph-merge/result";
+import type { CandidateEdge } from "../../src/graph-merge/scoring";
+import {
+  FORCED_MATCH_SCORE,
+  scoreCandidates,
+} from "../../src/graph-merge/scoring";
+import type { SimilarityContext } from "../../src/graph-merge/similarity";
+import {
+  exactKeySource,
+  forcedEdgesFromBlocks,
+  ontologyRetypeEdges,
+  pairsFromBlocks,
+  uniqueSource,
+} from "../../src/graph-merge/sources";
+import type {
+  ResolveConfig,
+  SimilarityStrategy,
+} from "../../src/graph-merge/types";
+import { createSqliteMergeBackend } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string().optional(),
+    mrn: z.string().optional(),
+  }),
+});
+
+// The store deliberately does NOT declare the `mrn` unique constraint: this suite
+// exercises the SIGNATURE-blocking + scoring logic in isolation, hand-feeding the
+// constraint to `blockNodes` via {@link MRN_CONSTRAINT}. (In a real merge the
+// same-mrn duplicates live in separate branch stores, so no single store enforces
+// uniqueness across them.)
+const patientGraph = defineGraph({
+  id: "sources-patient",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+
+type PatientNode = Node<typeof Patient>;
+
+const DEMO_THRESHOLD = 0.85;
+
+const fulltextName: SimilarityStrategy = { kind: "fulltext", fields: ["name"] };
+
+const blockByBirthDate: ResolveConfig = {
+  block: (node) => (node as unknown as { birthDate?: string }).birthDate,
+  similarity: fulltextName,
+  threshold: DEMO_THRESHOLD,
+};
+
+/** The kind's `mrn` unique constraint, as `store.introspect()` would surface it. */
+const MRN_CONSTRAINT: readonly UniqueIntrospection[] = [
+  { name: "mrn_unique", fields: ["mrn"], scope: "kind", collation: "binary" },
+];
+
+/**
+ * A stable, comparable view of an edge set: bare `a|b` id keys (drops the float
+ * score). Endpoints are composite `(kind, id)` keys; this projects them back to bare
+ * ids so the single-kind expectations read in plain ids.
+ */
+function edgeKeys(edges: readonly CandidateEdge[]): string[] {
+  return edges.map((edge) => `${idOf(edge.a)}|${idOf(edge.b)}`);
+}
+
+describe("candidate sources + scoring stage (step 0)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup !== undefined) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  async function makeFixture(): Promise<
+    Readonly<{
+      create: (
+        props: Readonly<{ name: string; birthDate?: string; mrn?: string }>,
+      ) => Promise<PatientNode>;
+      ctx: SimilarityContext;
+    }>
+  > {
+    const fixture = createSqliteMergeBackend();
+    cleanup = fixture.cleanup;
+    const [store] = await createStoreWithSchema(patientGraph, fixture.backend);
+    return {
+      create: (props) => store.nodes.Patient.create(props),
+      ctx: { backend: fixture.backend },
+    };
+  }
+
+  it("exactKeySource proposes fuzzy pairs from block buckets; nothing forced or base", async () => {
+    const { create } = await makeFixture();
+    const anna = await create({ name: "Anna Rivera", birthDate: "1974-03-09" });
+    const ana = await create({ name: "Ana Rivera", birthDate: "1974-03-09" });
+    const other = await create({ name: "Bob Lee", birthDate: "1990-01-01" });
+
+    const blocks = blockNodes([anna, ana, other], blockByBirthDate);
+    const produced = await exactKeySource.generate({ kind: "Patient", blocks });
+
+    const proposed = produced.pairs
+      .map((pair) => `${idOf(pair.a)}|${idOf(pair.b)}`)
+      .sort();
+    console.info("[exactKey] proposed pairs:", proposed);
+    console.info("[exactKey] forcedEdges:", produced.forcedEdges.length);
+    console.info("[exactKey] baseMembers:", produced.baseMembers.length);
+
+    // Only the same-birthDate cohort co-blocks: {anna, ana}. `other` is alone in
+    // its block, so no pair references it.
+    const expected = [anna.id, ana.id].sort();
+    expect(proposed).toEqual([`${expected[0]}|${expected[1]}`]);
+    expect(produced.forcedEdges).toEqual([]);
+    expect(produced.baseMembers).toEqual([]);
+  });
+
+  it("uniqueSource proposes forced (definitional) edges from unique buckets; nothing fuzzy or base", async () => {
+    const { create } = await makeFixture();
+    // Same mrn, different birthDate, dissimilar names — a definitional match.
+    const annaA = await create({
+      name: "Anna Rivera",
+      birthDate: "1974-03-09",
+      mrn: "MRN-1",
+    });
+    const robertB = await create({
+      name: "Robert Smith",
+      birthDate: "1990-01-01",
+      mrn: "MRN-1",
+    });
+    const distinct = await create({
+      name: "Carol King",
+      birthDate: "1980-05-05",
+      mrn: "MRN-2",
+    });
+
+    const blocks = blockNodes(
+      [annaA, robertB, distinct],
+      blockByBirthDate,
+      MRN_CONSTRAINT,
+    );
+    const produced = await uniqueSource.generate({ kind: "Patient", blocks });
+
+    console.info(
+      "[unique] forced edges:",
+      produced.forcedEdges.map((e) => `${idOf(e.a)}|${idOf(e.b)}@${e.score}`),
+    );
+
+    const expected = [annaA.id, robertB.id].sort();
+    expect(edgeKeys(produced.forcedEdges)).toEqual([
+      `${expected[0]}|${expected[1]}`,
+    ]);
+    expect(produced.forcedEdges[0]?.score).toBe(FORCED_MATCH_SCORE);
+    expect(produced.pairs).toEqual([]);
+    expect(produced.baseMembers).toEqual([]);
+  });
+
+  it("scoring decides fuzzy pairs by threshold and passes forced edges through unscored", async () => {
+    const { create, ctx } = await makeFixture();
+    const anna = await create({ name: "Anna Rivera", birthDate: "1974-03-09" });
+    const ana = await create({ name: "Ana Rivera", birthDate: "1974-03-09" });
+    // A second cohort whose names are far apart (~0) and below threshold.
+    const x = await create({ name: "Zoe Adams", birthDate: "2000-01-01" });
+    const y = await create({ name: "Quinn Webb", birthDate: "2000-01-01" });
+
+    const blocks = blockNodes([anna, ana, x, y], blockByBirthDate);
+    const pairs = pairsFromBlocks(blocks);
+    const xKey = mergeKeyOf(x);
+    const yKey = mergeKeyOf(y);
+    const forced: readonly CandidateEdge[] = [
+      {
+        a: compareMergeKeys(xKey, yKey) <= 0 ? xKey : yKey,
+        b: compareMergeKeys(xKey, yKey) <= 0 ? yKey : xKey,
+        score: FORCED_MATCH_SCORE,
+      },
+    ];
+
+    const scored = scoreCandidates(
+      { pairs, forcedEdges: forced },
+      blockByBirthDate,
+      ctx,
+      "error",
+    );
+    expect(isOk(scored)).toBe(true);
+    if (!isOk(scored)) {
+      return;
+    }
+    console.info(
+      "[scoring] edges:",
+      scored.data.edges.map((e) => `${e.a}|${e.b}@${e.score.toFixed(3)}`),
+    );
+
+    // anna~ana clears 0.85 → a scored fuzzy edge. x~y would NOT clear the
+    // threshold on similarity, but it was FORCED, so it survives at max score.
+    const annaAna = [anna.id, ana.id].sort();
+    const xy = [x.id, y.id].sort();
+    expect(edgeKeys(scored.data.edges).sort()).toEqual(
+      [`${annaAna[0]}|${annaAna[1]}`, `${xy[0]}|${xy[1]}`].sort(),
+    );
+    const forcedEdge = scored.data.edges.find(
+      (e) => `${idOf(e.a)}|${idOf(e.b)}` === `${xy[0]}|${xy[1]}`,
+    );
+    expect(forcedEdge?.score).toBe(FORCED_MATCH_SCORE);
+  });
+
+  it("a forced (definitional) pair is never also fuzzy-scored (forced wins dedup)", async () => {
+    const { create, ctx } = await makeFixture();
+    // The SAME pair appears both as a fuzzy proposal (co-blocked) and forced.
+    const anna = await create({ name: "Anna Rivera", birthDate: "1974-03-09" });
+    const ana = await create({ name: "Ana Rivera", birthDate: "1974-03-09" });
+
+    const blocks = blockNodes([anna, ana], blockByBirthDate);
+    const pairs = pairsFromBlocks(blocks);
+    expect(pairs).toHaveLength(1);
+    const forced: readonly CandidateEdge[] = [
+      { a: pairs[0]!.a, b: pairs[0]!.b, score: FORCED_MATCH_SCORE },
+    ];
+
+    const scored = scoreCandidates(
+      { pairs, forcedEdges: forced },
+      blockByBirthDate,
+      ctx,
+      "error",
+    );
+    expect(isOk(scored)).toBe(true);
+    if (!isOk(scored)) {
+      return;
+    }
+    // Exactly ONE edge — the forced one — not a forced AND a separate fuzzy edge.
+    expect(scored.data.edges).toHaveLength(1);
+    expect(scored.data.edges[0]?.score).toBe(FORCED_MATCH_SCORE);
+  });
+
+  it("never merges two textless fuzzy pairs, even at threshold 0 (#8)", async () => {
+    const { create, ctx } = await makeFixture();
+    // Two DISTINCT patients with no value in the scoring field (mrn) — their
+    // comparison text is empty on both, so there is no evidence they match.
+    const alice = await create({ name: "Alice", birthDate: "1974-03-09" });
+    const bob = await create({ name: "Bob", birthDate: "1974-03-09" });
+
+    // threshold 0 would let a MIN_SCORE (0) pair pass `score >= threshold`; the
+    // empty-text guard must still exclude the pair (no comparable text).
+    const textlessAtZero: ResolveConfig = {
+      similarity: { kind: "fulltext", fields: ["mrn"] },
+      threshold: 0,
+    };
+
+    const blocks = blockNodes([alice, bob], textlessAtZero);
+    const pairs = pairsFromBlocks(blocks);
+    expect(pairs).toHaveLength(1); // both unblocked → compared all-vs-all
+
+    const scored = scoreCandidates(
+      { pairs, forcedEdges: [] },
+      textlessAtZero,
+      ctx,
+      "error",
+    );
+    expect(isOk(scored)).toBe(true);
+    if (!isOk(scored)) {
+      return;
+    }
+    expect(scored.data.edges).toEqual([]);
+  });
+
+  it("driving the sources through scoring equals generateCandidates over the same blocks", async () => {
+    const { create, ctx } = await makeFixture();
+    const annaA = await create({
+      name: "Anna Rivera",
+      birthDate: "1974-03-09",
+      mrn: "MRN-1",
+    });
+    const robertB = await create({
+      name: "Robert Smith",
+      birthDate: "1990-01-01",
+      mrn: "MRN-1",
+    });
+    const ana = await create({ name: "Ana Rivera", birthDate: "1974-03-09" });
+    const distinct = await create({
+      name: "Carol King",
+      birthDate: "1980-05-05",
+    });
+
+    const nodes = [annaA, robertB, ana, distinct];
+    const blocks = blockNodes(nodes, blockByBirthDate, MRN_CONSTRAINT);
+
+    // Path A: drive the sources, then score.
+    const fromSources = scoreCandidates(
+      {
+        pairs: pairsFromBlocks(blocks),
+        forcedEdges: forcedEdgesFromBlocks(blocks),
+      },
+      blockByBirthDate,
+      ctx,
+      "error",
+    );
+    // Path B: the back-compat composition.
+    const fromGenerate = generateCandidates(
+      blocks,
+      blockByBirthDate,
+      ctx,
+      "error",
+    );
+
+    expect(isOk(fromSources) && isOk(fromGenerate)).toBe(true);
+    if (!isOk(fromSources) || !isOk(fromGenerate)) {
+      return;
+    }
+    console.info("[equivalence] edges:", edgeKeys(fromSources.data.edges));
+    expect(fromSources.data.edges).toEqual(fromGenerate.data.edges);
+    expect(fromSources.data.warnings).toEqual(fromGenerate.data.warnings);
+  });
+});
+
+describe("ontologyRetypeEdges (cross-kind ontology retype source)", () => {
+  // Stands in for the reconciler's most-specific-common-kind test: only
+  // {Doctor, SpecialistDoctor} is subtype-compatible; any set touching another kind
+  // (Patient/Encounter siblings) is not.
+  const isRetypeCompatible = (kinds: readonly string[]): boolean =>
+    [...new Set(kinds)].every(
+      (kind) => kind === "Doctor" || kind === "SpecialistDoctor",
+    );
+
+  it("fuses same-id subtype-compatible identities; leaves unrelated kinds and single kinds apart", () => {
+    const identities = [
+      mergeKey("Doctor", "x"),
+      mergeKey("SpecialistDoctor", "x"), // compatible at id x → ONE forced edge
+      mergeKey("Patient", "y"),
+      mergeKey("Encounter", "y"), // unrelated kinds at id y → no edge (no corruption)
+      mergeKey("Doctor", "z"), // single kind at id z → no edge
+    ];
+
+    const edges = ontologyRetypeEdges(identities, isRetypeCompatible);
+
+    expect(edges).toHaveLength(1);
+    const edge = edges[0]!;
+    expect(idOf(edge.a)).toBe("x");
+    expect(idOf(edge.b)).toBe("x");
+    expect(new Set([kindOf(edge.a), kindOf(edge.b)])).toEqual(
+      new Set(["Doctor", "SpecialistDoctor"]),
+    );
+    expect(edge.score).toBe(FORCED_MATCH_SCORE);
+  });
+
+  it("partitions a mixed bucket: an unrelated kind at the id does NOT suppress the valid retype pair", () => {
+    // Doctor:x / SpecialistDoctor:x are a valid refinement; the unrelated Encounter:x
+    // shares the bare id but is its own group, so the Doctor↔SpecialistDoctor edge is
+    // still emitted (and Encounter:x stays a separate identity — no corruption).
+    const identities = [
+      mergeKey("Doctor", "x"),
+      mergeKey("SpecialistDoctor", "x"),
+      mergeKey("Encounter", "x"),
+    ];
+
+    const edges = ontologyRetypeEdges(identities, isRetypeCompatible);
+
+    expect(edges).toHaveLength(1);
+    expect(new Set([kindOf(edges[0]!.a), kindOf(edges[0]!.b)])).toEqual(
+      new Set(["Doctor", "SpecialistDoctor"]),
+    );
+    // No edge touches the unrelated Encounter identity.
+    const touched = edges.flatMap((edge) => [kindOf(edge.a), kindOf(edge.b)]);
+    expect(touched).not.toContain("Encounter");
+  });
+
+  it("connects N compatible identities at one id with an (N-1)-edge star anchored at the min", () => {
+    const identities = [
+      mergeKey("Gamma", "x"),
+      mergeKey("Alpha", "x"),
+      mergeKey("Beta", "x"),
+    ];
+
+    const edges = ontologyRetypeEdges(identities, () => true);
+
+    expect(edges).toHaveLength(2); // 3 identities → star of 2 edges → one cluster
+    const min = [...identities].sort(compareMergeKeys)[0]!;
+    expect(edges.every((edge) => edge.a === min)).toBe(true);
+  });
+
+  it("dedups a repeated identity (same kind+id from two branches) before counting", () => {
+    const identities = [
+      mergeKey("Doctor", "x"),
+      mergeKey("Doctor", "x"), // duplicate identity — one kind at x, not a retype
+    ];
+    expect(ontologyRetypeEdges(identities, () => true)).toEqual([]);
+  });
+
+  it("emits nothing for an empty set or all-distinct ids", () => {
+    expect(ontologyRetypeEdges([], () => true)).toEqual([]);
+    expect(
+      ontologyRetypeEdges(
+        [mergeKey("Doctor", "a"), mergeKey("Patient", "b")],
+        () => true,
+      ),
+    ).toEqual([]);
+  });
+
+  // A REAL subtype lattice (not the monotone set-membership stand-in above): the
+  // set-membership mock is monotone over subsets and so can never model a group that is
+  // pairwise-compatible yet whole-group-incompatible — the exact case the whole-group
+  // recheck in `ontologyRetypeEdges` exists for. This closure mirrors
+  // `mostSpecificCommonKind`: a kind set collapses iff one of its kinds is at-or-below
+  // every other (a single most-specific kind).
+  const subtypeParent: Readonly<Record<string, string | undefined>> = {
+    SpecialistDoctor: "Doctor", // Doctor > SpecialistDoctor
+    Surgeon: "Doctor", //          Doctor > Surgeon  (sibling of SpecialistDoctor)
+    PediatricSpecialist: "SpecialistDoctor", // SpecialistDoctor > PediatricSpecialist
+  };
+  const isAtOrBelow = (lower: string, upper: string): boolean => {
+    let cursor: string | undefined = lower;
+    while (cursor !== undefined) {
+      if (cursor === upper) {
+        return true;
+      }
+      cursor = subtypeParent[cursor];
+    }
+    return false;
+  };
+  const collapsesToOneKind = (kinds: readonly string[]): boolean => {
+    const distinct = [...new Set(kinds)];
+    return distinct.some((candidate) =>
+      distinct.every((other) => isAtOrBelow(candidate, other)),
+    );
+  };
+
+  it("does NOT fuse a DIAMOND: pairwise-compatible siblings with no single most-specific kind stay apart", () => {
+    // {Doctor, SpecialistDoctor} and {Doctor, Surgeon} each collapse, so union-find
+    // pulls all three into one group THROUGH Doctor — but {SpecialistDoctor, Surgeon}
+    // are siblings and the whole trio has no single most-specific kind, so the
+    // reconciler would FLAG it. The source must refuse to force-fuse it.
+    const identities = [
+      mergeKey("Doctor", "x"),
+      mergeKey("SpecialistDoctor", "x"),
+      mergeKey("Surgeon", "x"),
+    ];
+    expect(ontologyRetypeEdges(identities, collapsesToOneKind)).toEqual([]);
+  });
+
+  it("fuses a CHAIN: A<B<C collapses to the single most-specific kind", () => {
+    // A genuine chain (each kind below the next) DOES have a single most-specific kind
+    // (PediatricSpecialist), so it must still fuse — guarding the whole-group recheck
+    // against over-rejecting a valid multi-kind refinement.
+    const identities = [
+      mergeKey("Doctor", "x"),
+      mergeKey("SpecialistDoctor", "x"),
+      mergeKey("PediatricSpecialist", "x"),
+    ];
+    const edges = ontologyRetypeEdges(identities, collapsesToOneKind);
+    expect(edges).toHaveLength(2); // 3 identities → star of 2 edges → one cluster
+    const min = [...identities].sort(compareMergeKeys)[0]!;
+    expect(edges.every((edge) => edge.a === min)).toBe(true);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/staging.test.ts
+++ b/packages/typegraph/tests/graph-merge/staging.test.ts
@@ -1,0 +1,255 @@
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { unwrap } from "../../src/graph-merge/result";
+import type { StagingSet } from "../../src/graph-merge/staging";
+import { stageBranches } from "../../src/graph-merge/staging";
+import type { BranchId, GraphBranch } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+  from: [Person],
+  to: [Person],
+});
+
+const graph = defineGraph({
+  id: "staging-test",
+  nodes: { Person: { type: Person } },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+type G = typeof graph;
+
+/**
+ * A comparable, fully-sorted plain projection of a {@link StagingSet} so two
+ * sets can be deep-equality compared independent of branch ordering. Raw rows
+ * carry non-deterministic meta (timestamps), so we project only the load-bearing
+ * fields: ids, kinds, branch tags, and parsed props.
+ */
+type StagingShape = Readonly<{
+  newNodes: readonly Readonly<{
+    kind: string;
+    id: string;
+    branchId: string;
+    name: unknown;
+  }>[];
+  modifiedNodes: readonly Readonly<{
+    kind: string;
+    id: string;
+    branchId: string;
+    name: unknown;
+  }>[];
+  deletedNodes: readonly Readonly<{
+    kind: string;
+    id: string;
+    branchId: string;
+  }>[];
+  newEdges: readonly Readonly<{
+    kind: string;
+    id: string;
+    branchId: string;
+    from: string;
+    to: string;
+  }>[];
+  modifiedEdges: readonly Readonly<{
+    kind: string;
+    id: string;
+    branchId: string;
+  }>[];
+  deletedEdges: readonly Readonly<{
+    kind: string;
+    id: string;
+    branchId: string;
+  }>[];
+}>;
+
+function projectStaging(staging: StagingSet): StagingShape {
+  const newNodes = [...staging.newNodesByKind.entries()].flatMap(
+    ([kind, members]) =>
+      members.map((member) => ({
+        kind,
+        id: member.node.id,
+        branchId: member.branchId,
+        name: member.node.props.name,
+      })),
+  );
+  const newEdges = [...staging.newEdgesByKind.entries()].flatMap(
+    ([kind, members]) =>
+      members.map((member) => ({
+        kind,
+        id: member.edge.id,
+        branchId: member.branchId,
+        from: member.edge.fromId,
+        to: member.edge.toId,
+      })),
+  );
+  return {
+    newNodes,
+    modifiedNodes: staging.modifiedNodes.map((member) => ({
+      kind: member.node.kind,
+      id: member.node.id,
+      branchId: member.branchId,
+      name: member.node.forkProps.name,
+    })),
+    deletedNodes: staging.deletedNodes.map((member) => ({
+      kind: member.node.kind,
+      id: member.node.id,
+      branchId: member.branchId,
+    })),
+    newEdges,
+    modifiedEdges: staging.modifiedEdges.map((member) => ({
+      kind: member.edge.kind,
+      id: member.edge.id,
+      branchId: member.branchId,
+    })),
+    deletedEdges: staging.deletedEdges.map((member) => ({
+      kind: member.edge.kind,
+      id: member.edge.id,
+      branchId: member.branchId,
+    })),
+  };
+}
+
+describe.each(backendMatrix())("staging [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  async function makeBranch(baseStore: Store<G>): Promise<GraphBranch<G>> {
+    return unwrap(await branch<G>(baseStore, () => makeBackend()));
+  }
+
+  it("unions both branches' diffs, tags provenance, surfaces the inherited node once per branch", async () => {
+    const [baseStore] = await createStoreWithSchema(graph, await makeBackend());
+    const inherited = await baseStore.nodes.Person.create({ name: "Origin" });
+
+    const branchA = await makeBranch(baseStore);
+    const branchB = await makeBranch(baseStore);
+
+    // Each branch modifies the SAME inherited node differently...
+    await branchA.store.nodes.Person.update(inherited.id, { name: "From A" });
+    await branchB.store.nodes.Person.update(inherited.id, { name: "From B" });
+    // ...and each adds a DISTINCT new node.
+    const newA = await branchA.store.nodes.Person.create({ name: "Alpha" });
+    const newB = await branchB.store.nodes.Person.create({ name: "Beta" });
+
+    const staging = await stageBranches(baseStore, [branchA, branchB]);
+
+    // Both new nodes present and tagged by their origin branch.
+    const personNew = staging.newNodesByKind.get("Person") ?? [];
+    const newById = new Map(
+      personNew.map((member) => [member.node.id as string, member] as const),
+    );
+    expect(newById.size).toBe(2);
+    expect(newById.get(newA.id)?.branchId).toBe(branchA.id);
+    expect(newById.get(newA.id)?.node.props).toMatchObject({ name: "Alpha" });
+    expect(newById.get(newB.id)?.branchId).toBe(branchB.id);
+    expect(newById.get(newB.id)?.node.props).toMatchObject({ name: "Beta" });
+
+    // The inherited node appears ONCE PER BRANCH (ready for conflict detection),
+    // each entry tagged + carrying that branch's divergent props.
+    const inheritedMods = staging.modifiedNodes.filter(
+      (member) => (member.node.id as string) === inherited.id,
+    );
+    expect(inheritedMods).toHaveLength(2);
+    const moduleByBranch = new Map<BranchId, (typeof inheritedMods)[number]>(
+      inheritedMods.map((member) => [member.branchId, member] as const),
+    );
+    expect(moduleByBranch.get(branchA.id)?.node.forkProps).toMatchObject({
+      name: "From A",
+    });
+    expect(moduleByBranch.get(branchB.id)?.node.forkProps).toMatchObject({
+      name: "From B",
+    });
+
+    // No spurious deletes / edge churn for this scenario.
+    expect(staging.deletedNodes).toHaveLength(0);
+    expect(staging.modifiedEdges).toHaveLength(0);
+    expect(staging.deletedEdges).toHaveLength(0);
+  });
+
+  it("produces a structurally identical StagingSet for reversed branch order", async () => {
+    const [baseStore] = await createStoreWithSchema(graph, await makeBackend());
+    const inherited = await baseStore.nodes.Person.create({ name: "Origin" });
+    const peer = await baseStore.nodes.Person.create({ name: "Peer" });
+    const inheritedEdge = await baseStore.edges.knows.create(inherited, peer, {
+      since: "2020",
+    });
+
+    const branchA = await makeBranch(baseStore);
+    const branchB = await makeBranch(baseStore);
+
+    // branchA: modify inherited node + edge, add a new node, delete peer's edge? No —
+    // exercise a deletion: branchA deletes the inherited edge then peer.
+    await branchA.store.nodes.Person.update(inherited.id, { name: "From A" });
+    await branchA.store.nodes.Person.create({ name: "Alpha" });
+    await branchA.store.edges.knows.update(inheritedEdge.id, { since: "2021" });
+
+    // branchB: modify the same inherited node differently, add a new node,
+    // delete the inherited edge then peer (so a deletion is staged too).
+    await branchB.store.nodes.Person.update(inherited.id, { name: "From B" });
+    await branchB.store.nodes.Person.create({ name: "Beta" });
+    await branchB.store.edges.knows.delete(inheritedEdge.id);
+    await branchB.store.nodes.Person.delete(peer.id);
+
+    const forward = await stageBranches(baseStore, [branchA, branchB]);
+    const reversed = await stageBranches(baseStore, [branchB, branchA]);
+
+    // The union staging set is a pure function of the unordered branch SET, so
+    // its canonical projection must be byte-identical across input orderings.
+    expect(projectStaging(reversed)).toEqual(projectStaging(forward));
+
+    // Sanity: the scenario actually produced cross-branch churn worth ordering.
+    expect(forward.modifiedNodes.length).toBeGreaterThanOrEqual(2);
+    expect(forward.deletedNodes.length).toBeGreaterThanOrEqual(1);
+    expect(forward.deletedEdges.length).toBeGreaterThanOrEqual(1);
+    expect(forward.modifiedEdges.length).toBeGreaterThanOrEqual(1);
+    expect(
+      (forward.newNodesByKind.get("Person") ?? []).length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("stages an empty union when no branch diverges from base", async () => {
+    const [baseStore] = await createStoreWithSchema(graph, await makeBackend());
+    await baseStore.nodes.Person.create({ name: "Untouched" });
+
+    const branchA = await makeBranch(baseStore);
+    const branchB = await makeBranch(baseStore);
+
+    const staging = await stageBranches(baseStore, [branchA, branchB]);
+
+    expect(staging.newNodesByKind.size).toBe(0);
+    expect(staging.modifiedNodes).toHaveLength(0);
+    expect(staging.deletedNodes).toHaveLength(0);
+    expect(staging.newEdgesByKind.size).toBe(0);
+    expect(staging.modifiedEdges).toHaveLength(0);
+    expect(staging.deletedEdges).toHaveLength(0);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/state-diff.test.ts
+++ b/packages/typegraph/tests/graph-merge/state-diff.test.ts
@@ -1,0 +1,265 @@
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { exportGraph, importGraph } from "@nicia-ai/typegraph/interchange";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { computeBaseVersion } from "../../src/graph-merge/base-version";
+import {
+  diffAgainstBase,
+  enumerateAllEdges,
+  enumerateAllNodes,
+} from "../../src/graph-merge/state-diff";
+import { backendMatrix } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+  from: [Person],
+  to: [Person],
+});
+
+const graph = defineGraph({
+  id: "state-diff-test",
+  nodes: { Person: { type: Person } },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+type G = typeof graph;
+
+/**
+ * Clones a base store into a fresh store on a new backend via the public
+ * interchange API, preserving ids. This stands in for T4's `branch()` clone:
+ * the diff reference remains the ORIGINAL base store (the Interchange meta schema
+ * has no `deletedAt`, so soft-deletes do not survive a round-trip — exactly the
+ * fidelity limitation that mandates diffing against the original base).
+ */
+async function cloneToFork(
+  baseStore: Store<G>,
+  forkBackend: GraphBackend,
+): Promise<Store<G>> {
+  const data = await exportGraph(baseStore, {
+    includeMeta: true,
+    includeDeleted: true,
+  });
+  const [forkStore] = await createStoreWithSchema(baseStore.graph, forkBackend);
+  await importGraph(forkStore, data, {
+    onConflict: "skip",
+    onUnknownProperty: "error",
+    validateReferences: true,
+    batchSize: 1000,
+  });
+  return forkStore;
+}
+
+describe.each(backendMatrix())("state-diff [$name]", (entry) => {
+  let baseBackend: GraphBackend;
+  let forkBackend: GraphBackend;
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  it("reports new / modified / deleted nodes and edges of a fork", async () => {
+    baseBackend = await makeBackend();
+    forkBackend = await makeBackend();
+
+    const [baseStore] = await createStoreWithSchema(graph, baseBackend);
+
+    // Seed base: nodes A, B and edge A -> B.
+    const nodeA = await baseStore.nodes.Person.create({ name: "Alice" });
+    const nodeB = await baseStore.nodes.Person.create({ name: "Bob" });
+    const edgeAB = await baseStore.edges.knows.create(nodeA, nodeB, {
+      since: "2020",
+    });
+
+    const forkStore = await cloneToFork(baseStore, forkBackend);
+
+    // Mutate fork: modify A, delete edge A->B then soft-delete B, add C and
+    // edge A -> C. (The default restrict delete behavior requires removing the
+    // incident edge before the node — exercising both edge AND node deletion.)
+    await forkStore.nodes.Person.update(nodeA.id, { name: "Alice Updated" });
+    await forkStore.edges.knows.delete(edgeAB.id);
+    await forkStore.nodes.Person.delete(nodeB.id);
+    const nodeC = await forkStore.nodes.Person.create({ name: "Carol" });
+    const edgeAC = await forkStore.edges.knows.create(
+      { kind: "Person", id: nodeA.id },
+      nodeC,
+      { since: "2024" },
+    );
+
+    const diff = await diffAgainstBase(baseStore, forkStore);
+
+    // Node A modified.
+    expect(diff.nodes.modified).toHaveLength(1);
+    expect(diff.nodes.modified[0]!.id).toBe(nodeA.id);
+    expect(diff.nodes.modified[0]!.forkProps).toMatchObject({
+      name: "Alice Updated",
+    });
+    expect(diff.nodes.modified[0]!.baseProps).toMatchObject({ name: "Alice" });
+
+    // Node B deleted.
+    expect(diff.nodes.deleted.map((entry) => entry.id)).toEqual([nodeB.id]);
+
+    // Node C new.
+    expect(diff.nodes.new).toHaveLength(1);
+    expect(diff.nodes.new[0]!.id).toBe(nodeC.id);
+    expect(diff.nodes.new[0]!.props).toMatchObject({ name: "Carol" });
+
+    // Edge A -> C new.
+    expect(diff.edges.new.map((entry) => entry.id)).toEqual([edgeAC.id]);
+    expect(diff.edges.new[0]!.fromId).toBe(nodeA.id);
+    expect(diff.edges.new[0]!.toId).toBe(nodeC.id);
+
+    // Edge A -> B deleted.
+    expect(diff.edges.deleted.map((entry) => entry.id)).toEqual([edgeAB.id]);
+    expect(diff.edges.modified).toHaveLength(0);
+  });
+
+  it("enumerates soft-deleted rows with excludeDeleted:false on both backends", async () => {
+    baseBackend = await makeBackend();
+    const [store] = await createStoreWithSchema(graph, baseBackend);
+
+    const live = await store.nodes.Person.create({ name: "Live" });
+    const gone = await store.nodes.Person.create({ name: "Gone" });
+    await store.nodes.Person.delete(gone.id);
+
+    const rows = await enumerateAllNodes(
+      store.backend,
+      store.graphId,
+      "Person",
+    );
+    const byId = new Map(rows.map((row) => [row.id, row] as const));
+
+    expect(byId.get(live.id)?.deleted_at).toBeUndefined();
+    expect(byId.get(gone.id)?.deleted_at).not.toBeUndefined();
+    // Both rows are visible — Store.find() would have hidden the deleted one.
+    expect(rows).toHaveLength(2);
+  });
+
+  it("enumerates edges in stable id order independent of insertion order", async () => {
+    baseBackend = await makeBackend();
+    const [store] = await createStoreWithSchema(graph, baseBackend);
+
+    const a = await store.nodes.Person.create({ name: "A" });
+    const b = await store.nodes.Person.create({ name: "B" });
+    const c = await store.nodes.Person.create({ name: "C" });
+    await store.edges.knows.create(a, b, { since: "1" });
+    await store.edges.knows.create(b, c, { since: "2" });
+    await store.edges.knows.create(c, a, { since: "3" });
+
+    const rows = await enumerateAllEdges(store.backend, store.graphId, "knows");
+    const ids = rows.map((row) => row.id);
+    expect(ids).toEqual([...ids].sort());
+    expect(ids).toHaveLength(3);
+  });
+
+  it("detects no changes between a base and its faithful clone", async () => {
+    baseBackend = await makeBackend();
+    forkBackend = await makeBackend();
+    const [baseStore] = await createStoreWithSchema(graph, baseBackend);
+    const a = await baseStore.nodes.Person.create({ name: "A" });
+    const b = await baseStore.nodes.Person.create({ name: "B" });
+    await baseStore.edges.knows.create(a, b, { since: "x" });
+
+    const forkStore = await cloneToFork(baseStore, forkBackend);
+    const diff = await diffAgainstBase(baseStore, forkStore);
+
+    expect(diff.nodes.new).toHaveLength(0);
+    expect(diff.nodes.modified).toHaveLength(0);
+    expect(diff.nodes.deleted).toHaveLength(0);
+    expect(diff.edges.new).toHaveLength(0);
+    expect(diff.edges.modified).toHaveLength(0);
+    expect(diff.edges.deleted).toHaveLength(0);
+  });
+
+  it("reports an edge whose props were modified in the fork", async () => {
+    baseBackend = await makeBackend();
+    forkBackend = await makeBackend();
+    const [baseStore] = await createStoreWithSchema(graph, baseBackend);
+    const a = await baseStore.nodes.Person.create({ name: "A" });
+    const b = await baseStore.nodes.Person.create({ name: "B" });
+    const edge = await baseStore.edges.knows.create(a, b, { since: "2020" });
+
+    const forkStore = await cloneToFork(baseStore, forkBackend);
+    await forkStore.edges.knows.update(edge.id, { since: "2025" });
+
+    const diff = await diffAgainstBase(baseStore, forkStore);
+    expect(diff.edges.modified).toHaveLength(1);
+    expect(diff.edges.modified[0]!.id).toBe(edge.id);
+    expect(diff.edges.modified[0]!.forkProps).toMatchObject({ since: "2025" });
+    expect(diff.edges.modified[0]!.baseProps).toMatchObject({ since: "2020" });
+    expect(diff.edges.new).toHaveLength(0);
+    expect(diff.edges.deleted).toHaveLength(0);
+  });
+});
+
+describe.each(backendMatrix())("computeBaseVersion [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  it("is stable for identical content and changes when content changes", async () => {
+    const [store] = await createStoreWithSchema(graph, await makeBackend());
+    const before = await computeBaseVersion(store);
+    const again = await computeBaseVersion(store);
+    expect(again).toBe(before);
+
+    const node = await store.nodes.Person.create({ name: "Alice" });
+    const afterAdd = await computeBaseVersion(store);
+    expect(afterAdd).not.toBe(before);
+
+    await store.nodes.Person.update(node.id, { name: "Alice Renamed" });
+    const afterModify = await computeBaseVersion(store);
+    expect(afterModify).not.toBe(afterAdd);
+  });
+
+  it("ignores soft-deleted rows in the live-content fingerprint", async () => {
+    const [store] = await createStoreWithSchema(graph, await makeBackend());
+    const keep = await store.nodes.Person.create({ name: "Keep" });
+    const baseline = await computeBaseVersion(store);
+
+    const transient = await store.nodes.Person.create({ name: "Transient" });
+    expect(await computeBaseVersion(store)).not.toBe(baseline);
+
+    await store.nodes.Person.delete(transient.id);
+    // Live content is back to just `keep`, so the fingerprint returns to baseline.
+    expect(await computeBaseVersion(store)).toBe(baseline);
+    expect(keep.id).toBeDefined();
+  });
+});

--- a/packages/typegraph/tests/graph-merge/test-utils.test.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.test.ts
@@ -1,0 +1,197 @@
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  generateId,
+  TypeGraphError,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  BaseVersionMismatchError,
+  BranchError,
+  MergeConflictError,
+  MergeError,
+  SimilarityUnavailableError,
+} from "../../src/graph-merge/errors";
+import type { Result } from "../../src/graph-merge/result";
+import { err, isErr, isOk, ok, unwrap } from "../../src/graph-merge/result";
+import type { BackendMatrixEntry, MergeBackendFixture } from "./test-utils";
+import { backendMatrix, createSqliteMergeBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "merge-test-utils",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+describe("graph-merge Result module", () => {
+  it("round-trips ok() and reads its data", () => {
+    const result = ok(42);
+    expect(isOk(result)).toBe(true);
+    expect(isErr(result)).toBe(false);
+    expect(unwrap(result)).toBe(42);
+  });
+
+  it("round-trips err() and surfaces its error", () => {
+    const cause = new Error("boom");
+    const result = err(cause);
+    expect(isErr(result)).toBe(true);
+    expect(isOk(result)).toBe(false);
+    if (isErr(result)) {
+      expect(result.error).toBe(cause);
+    }
+    expect(() => unwrap(result)).toThrow(cause);
+  });
+
+  it("ok() defaults to undefined data when called with no argument", () => {
+    const result = ok();
+    expect(isOk(result)).toBe(true);
+    expect(unwrap(result)).toBeUndefined();
+  });
+
+  it("narrows the discriminated union via the type guards", () => {
+    const value: Result<number, Error> =
+      Math.random() < 2 ? ok(1) : err(new Error("never"));
+    if (isOk(value)) {
+      const widened: number = value.data;
+      expect(widened).toBe(1);
+    } else {
+      throw new Error("expected ok branch");
+    }
+  });
+});
+
+describe("graph-merge Result structural compatibility with TypeGraph", () => {
+  it("is assignable to TypeGraph's Result shape (type-level drift guard)", () => {
+    // The graph-merge subpath intentionally re-exports TypeGraph's internal
+    // Result shape. If that shape drifts, the assignments below stop compiling.
+    type TypeGraphResult<T, E = Error> =
+      | Readonly<{ success: true; data: T }>
+      | Readonly<{ success: false; error: E }>;
+
+    const localOk: Result<number, Error> = ok(7);
+    const localErr: Result<number, Error> = err(new Error("x"));
+
+    const asPublicOk: TypeGraphResult<number, Error> = localOk;
+    const asPublicErr: TypeGraphResult<number, Error> = localErr;
+
+    // And the reverse direction: a value typed as the canonical shape must be
+    // assignable back to our local Result.
+    const publicValue: TypeGraphResult<number, Error> = {
+      success: true,
+      data: 9,
+    };
+    const backToLocal: Result<number, Error> = publicValue;
+
+    expect(isOk(asPublicOk)).toBe(true);
+    expect(isErr(asPublicErr)).toBe(true);
+    expect(unwrap(backToLocal)).toBe(9);
+  });
+});
+
+describe("MergeError hierarchy", () => {
+  it("MergeError is a TypeGraphError with a stable code and cause chain", () => {
+    const cause = new Error("underlying");
+    const error = new MergeError("merge failed", { cause });
+    expect(error).toBeInstanceOf(TypeGraphError);
+    expect(error).toBeInstanceOf(MergeError);
+    expect(error.name).toBe("MergeError");
+    expect(error.code).toBe("GRAPH_MERGE_ERROR");
+    expect(error.category).toBe("system");
+    expect(error.cause).toBe(cause);
+  });
+
+  it("BranchError is a distinct TypeGraphError subclass", () => {
+    const error = new BranchError("branch failed");
+    expect(error).toBeInstanceOf(TypeGraphError);
+    expect(error).toBeInstanceOf(BranchError);
+    expect(error).not.toBeInstanceOf(MergeError);
+    expect(error.code).toBe("GRAPH_MERGE_BRANCH_ERROR");
+  });
+
+  it("SimilarityUnavailableError discriminates from generic MergeError", () => {
+    const error = new SimilarityUnavailableError("no embedder configured");
+    expect(error).toBeInstanceOf(TypeGraphError);
+    expect(error).toBeInstanceOf(MergeError);
+    expect(error).toBeInstanceOf(SimilarityUnavailableError);
+    expect(error.code).toBe("GRAPH_MERGE_SIMILARITY_UNAVAILABLE");
+    expect(error.suggestion).toContain("embedder");
+  });
+
+  it("MergeConflictError discriminates and carries details", () => {
+    const error = new MergeConflictError("unresolved conflict", {
+      details: { entityId: "n1", property: "name" },
+    });
+    expect(error).toBeInstanceOf(MergeError);
+    expect(error.code).toBe("GRAPH_MERGE_CONFLICT");
+    expect(error.details).toEqual({ entityId: "n1", property: "name" });
+  });
+
+  it("BaseVersionMismatchError discriminates with its own code", () => {
+    const error = new BaseVersionMismatchError(
+      "branch base@V differs from target",
+    );
+    expect(error).toBeInstanceOf(MergeError);
+    expect(error).toBeInstanceOf(BaseVersionMismatchError);
+    expect(error.code).toBe("GRAPH_MERGE_BASE_VERSION_MISMATCH");
+    expect(error.suggestion).toContain("Re-branch");
+  });
+
+  it("error codes are mutually distinct", () => {
+    const codes = [
+      new MergeError("a").code,
+      new BranchError("b").code,
+      new SimilarityUnavailableError("c").code,
+      new MergeConflictError("d").code,
+      new BaseVersionMismatchError("e").code,
+    ];
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});
+
+describe.each(backendMatrix())(
+  "dual-backend fixtures: $name",
+  (entry: BackendMatrixEntry) => {
+    let fixture: MergeBackendFixture;
+
+    afterEach(async () => {
+      await fixture.cleanup();
+    });
+
+    it("yields a usable store via createStoreWithSchema", async () => {
+      fixture = await entry.make();
+      const [store, validation] = await createStoreWithSchema(
+        graph,
+        fixture.backend,
+      );
+
+      expect(validation).toBeDefined();
+      expect(store.graphId).toBe("merge-test-utils");
+      expect(store.backend).toBe(fixture.backend);
+
+      const name = `Person-${generateId()}`;
+      const created = await store.nodes.Person.create({ name });
+      expect(created.id).toBeDefined();
+      expect(created.name).toBe(name);
+
+      const fetched = await store.nodes.Person.getById(created.id);
+      expect(fetched?.name).toBe(name);
+    });
+  },
+);
+
+describe("createSqliteMergeBackend (direct)", () => {
+  it("constructs and cleans up an in-memory SQLite backend", async () => {
+    const fixture = createSqliteMergeBackend();
+    expect(fixture.backend).toBeDefined();
+    const [store] = await createStoreWithSchema(graph, fixture.backend);
+    expect(store.graphId).toBe("merge-test-utils");
+    await fixture.cleanup();
+  });
+});

--- a/packages/typegraph/tests/graph-merge/test-utils.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.ts
@@ -1,0 +1,123 @@
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import { createLocalPgliteBackend } from "@nicia-ai/typegraph/postgres/pglite";
+import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+
+import type { Embedder } from "../../src/graph-merge/types";
+
+/**
+ * Dual-backend test fixtures for the graph-merge suite.
+ *
+ * Both backends run fully in-process: SQLite via better-sqlite3
+ * (`createLocalSqliteBackend`) and Postgres via PGlite + pgvector
+ * (`createLocalPgliteBackend`). There is NO Docker, NO `POSTGRES_URL`, and no
+ * 5432 dependency — `backendMatrix()` returns both backends and both ALWAYS
+ * run under plain `pnpm test`.
+ */
+
+/**
+ * A constructed backend paired with a disposer. Callers MUST invoke `cleanup`
+ * (typically in an `afterEach`) so the underlying engine — including PGlite's
+ * in-process Postgres — is released.
+ */
+export type MergeBackendFixture = Readonly<{
+  backend: GraphBackend;
+  cleanup: () => Promise<void>;
+}>;
+
+/**
+ * Creates an in-memory SQLite backend fixture.
+ */
+export function createSqliteMergeBackend(): MergeBackendFixture {
+  const { backend } = createLocalSqliteBackend();
+  return {
+    backend,
+    cleanup: async () => {
+      await backend.close();
+    },
+  };
+}
+
+/**
+ * Creates an in-process PGlite (Postgres + pgvector) backend fixture.
+ *
+ * `createLocalPgliteBackend` is async because it boots the WASM Postgres
+ * engine and loads the pgvector extension before returning a ready backend.
+ */
+export async function createPgliteMergeBackend(): Promise<MergeBackendFixture> {
+  const { backend } = await createLocalPgliteBackend();
+  return {
+    backend,
+    cleanup: async () => {
+      await backend.close();
+    },
+  };
+}
+
+/** Fixed alphabet for {@link fakeEmbedder}: a–z plus space (27 dims). */
+const EMBEDDER_ALPHABET = "abcdefghijklmnopqrstuvwxyz ";
+
+/** Maps a text to its 27-dim lowercase character-frequency vector. */
+function charFrequencyVector(text: string): Float32Array {
+  const vector = new Float32Array(EMBEDDER_ALPHABET.length);
+  for (const char of text.toLowerCase()) {
+    const index = EMBEDDER_ALPHABET.indexOf(char);
+    if (index !== -1) {
+      vector[index] = (vector[index] ?? 0) + 1;
+    }
+  }
+  return vector;
+}
+
+/**
+ * A deterministic, OFFLINE stand-in for a real sentence embedder, for exercising
+ * the `vector`/`hybrid` plumbing without downloading a model. Each text maps to a
+ * 27-dim character-frequency vector, so cosine over the vectors correlates with
+ * character overlap: a near-duplicate name ("anna rivera" ≈ "ana rivera") scores
+ * far above an unrelated one ("bob lee") — enough to assert RELATIVE behavior and
+ * determinism. It is a PURE function of the text, so the merge stays
+ * order-independent. NOT a quality model — production injects the real
+ * all-MiniLM-L6-v2 embedder from the harness.
+ */
+export const fakeEmbedder: Embedder = (texts) =>
+  Promise.resolve(texts.map((text) => charFrequencyVector(text)));
+
+/**
+ * Builds the precomputed `text→vector` lookup `scorePair` reads, from the
+ * lowercased field texts, using {@link fakeEmbedder}. Mirrors what `merge()`
+ * precomputes, so a unit test can score a `vector`/`hybrid` pair directly.
+ */
+export async function fakeEmbeddings(
+  texts: readonly string[],
+): Promise<ReadonlyMap<string, Float32Array>> {
+  const keys = texts.map((text) => text.toLowerCase());
+  const vectors = await fakeEmbedder(keys);
+  const lookup = new Map<string, Float32Array>();
+  for (const [index, key] of keys.entries()) lookup.set(key, vectors[index]!);
+  return lookup;
+}
+
+/**
+ * A named backend factory used to parameterize `describe.each` suites.
+ */
+export type BackendMatrixEntry = Readonly<{
+  name: string;
+  make: () => Promise<MergeBackendFixture>;
+}>;
+
+/**
+ * Returns the full dual-backend matrix. Both entries always run — there is no
+ * environment gating. SQLite's synchronous factory is wrapped so every entry
+ * shares the async `make()` signature.
+ */
+export function backendMatrix(): readonly BackendMatrixEntry[] {
+  return [
+    {
+      name: "SQLite",
+      make: () => Promise.resolve(createSqliteMergeBackend()),
+    },
+    {
+      name: "PGlite",
+      make: () => createPgliteMergeBackend(),
+    },
+  ];
+}

--- a/packages/typegraph/tests/graph-merge/type-reconcile.test.ts
+++ b/packages/typegraph/tests/graph-merge/type-reconcile.test.ts
@@ -1,0 +1,284 @@
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  equivalentTo,
+  generateId,
+  subClassOf,
+} from "@nicia-ai/typegraph";
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { SubClassClosure } from "../../src/graph-merge/closures";
+import { buildSubClassClosure } from "../../src/graph-merge/closures";
+import type { MergeKey } from "../../src/graph-merge/node-key";
+import type { ReconcileClusterInput } from "../../src/graph-merge/type-reconcile";
+import {
+  INCOMPATIBLE_TYPES_FLAG_REASON,
+  reconcileTypes,
+} from "../../src/graph-merge/type-reconcile";
+import { createSqliteMergeBackend } from "./test-utils";
+
+/**
+ * Brands a plain string as a canonical identity key for the pure reconciliation
+ * tests. The bare reports (`entityId`, dropped `id`) project this back via `idOf`,
+ * which on a single-token (NUL-free) key returns the token unchanged — so these
+ * assertions read identically to the bare-id form.
+ */
+function nodeId(value: string): MergeKey {
+  return value as MergeKey;
+}
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const Doctor = defineNode("Doctor", {
+  schema: z.object({ name: z.string() }),
+});
+const SpecialistDoctor = defineNode("SpecialistDoctor", {
+  schema: z.object({ name: z.string() }),
+});
+const Physician = defineNode("Physician", {
+  schema: z.object({ name: z.string() }),
+});
+const Animal = defineNode("Animal", {
+  schema: z.object({ name: z.string() }),
+});
+
+/**
+ * A taxonomy with a two-level subclass chain plus disjoint and equivalent types:
+ *
+ *   SpecialistDoctor ⊑ Doctor ⊑ Person
+ *   Physician ≡ Doctor
+ *   Animal     (disjoint from the Person tree)
+ */
+const taxonomyGraph = defineGraph({
+  id: "type-reconcile-taxonomy",
+  nodes: {
+    Person: { type: Person },
+    Doctor: { type: Doctor },
+    SpecialistDoctor: { type: SpecialistDoctor },
+    Physician: { type: Physician },
+    Animal: { type: Animal },
+  },
+  edges: {},
+  ontology: [
+    subClassOf(SpecialistDoctor, Doctor),
+    subClassOf(Doctor, Person),
+    equivalentTo(Physician, Doctor),
+  ],
+});
+
+describe("reconcileTypes over the public-closure glue (T10)", () => {
+  let closure: SubClassClosure;
+
+  beforeEach(async () => {
+    const fixture = createSqliteMergeBackend();
+    try {
+      const [store] = await createStoreWithSchema(
+        taxonomyGraph,
+        fixture.backend,
+      );
+      closure = buildSubClassClosure(store.introspect().ontology);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  describe('mode "off" is a guaranteed no-op', () => {
+    it("returns zero reconciliations even for a multi-kind cluster", () => {
+      const clusters: readonly ReconcileClusterInput[] = [
+        {
+          canonicalId: nodeId("n1"),
+          memberKinds: ["Doctor", "SpecialistDoctor"],
+        },
+      ];
+      const result = reconcileTypes(clusters, closure, "off");
+      expect(result.reconciliations).toEqual([]);
+      expect(result.dropped).toEqual([]);
+      expect(result.retypeMap.size).toBe(0);
+    });
+  });
+
+  describe("subsumption collapse to the most-specific type", () => {
+    it("collapses {Doctor, SpecialistDoctor} to SpecialistDoctor with a recorded reconciliation", () => {
+      const canonicalId = nodeId("patient-1");
+      const clusters: readonly ReconcileClusterInput[] = [
+        { canonicalId, memberKinds: ["Doctor", "SpecialistDoctor"] },
+      ];
+      const result = reconcileTypes(clusters, closure, "ontology");
+
+      expect(result.reconciliations).toHaveLength(1);
+      const reconciliation = result.reconciliations[0]!;
+      expect(reconciliation.entityId).toBe(canonicalId);
+      expect(reconciliation.toType).toBe("SpecialistDoctor");
+      expect([...reconciliation.fromTypes].sort()).toEqual([
+        "Doctor",
+        "SpecialistDoctor",
+      ]);
+      expect(result.retypeMap.get(canonicalId)).toBe("SpecialistDoctor");
+      expect(result.dropped).toEqual([]);
+    });
+
+    it("collapses a full three-kind chain to the deepest descendant", () => {
+      const canonicalId = nodeId("patient-2");
+      const clusters: readonly ReconcileClusterInput[] = [
+        {
+          canonicalId,
+          memberKinds: ["Person", "Doctor", "SpecialistDoctor"],
+        },
+      ];
+      const result = reconcileTypes(clusters, closure, "ontology");
+
+      expect(result.reconciliations).toHaveLength(1);
+      expect(result.reconciliations[0]!.toType).toBe("SpecialistDoctor");
+      expect(result.retypeMap.get(canonicalId)).toBe("SpecialistDoctor");
+      expect(result.dropped).toEqual([]);
+    });
+
+    it("is independent of memberKinds ordering", () => {
+      const canonicalId = nodeId("patient-3");
+      const forward = reconcileTypes(
+        [
+          {
+            canonicalId,
+            memberKinds: ["Doctor", "SpecialistDoctor", "Person"],
+          },
+        ],
+        closure,
+        "ontology",
+      );
+      const reversed = reconcileTypes(
+        [
+          {
+            canonicalId,
+            memberKinds: ["Person", "SpecialistDoctor", "Doctor"],
+          },
+        ],
+        closure,
+        "ontology",
+      );
+      expect(forward.reconciliations[0]!.toType).toBe(
+        reversed.reconciliations[0]!.toType,
+      );
+      expect(forward.reconciliations[0]!.toType).toBe("SpecialistDoctor");
+    });
+  });
+
+  describe("equivalentTo handling", () => {
+    it("collapses an equivalent pair to a single deterministic representative", () => {
+      const canonicalId = nodeId("patient-4");
+      const result = reconcileTypes(
+        [{ canonicalId, memberKinds: ["Physician", "Doctor"] }],
+        closure,
+        "ontology",
+      );
+
+      expect(result.dropped).toEqual([]);
+      expect(result.reconciliations).toHaveLength(1);
+      // Physician ≡ Doctor: either qualifies as the minimum, so the
+      // lexicographically-smallest representative ("Doctor") is chosen
+      // deterministically — never flagged as incompatible.
+      expect(result.reconciliations[0]!.toType).toBe("Doctor");
+      expect(result.retypeMap.get(canonicalId)).toBe("Doctor");
+    });
+
+    it("collapses a subclass mixed with an equivalent parent to the subclass", () => {
+      const canonicalId = nodeId("patient-5");
+      // SpecialistDoctor ⊑ Doctor ≡ Physician, so SpecialistDoctor is below both.
+      const result = reconcileTypes(
+        [{ canonicalId, memberKinds: ["SpecialistDoctor", "Physician"] }],
+        closure,
+        "ontology",
+      );
+      expect(result.dropped).toEqual([]);
+      expect(result.reconciliations[0]!.toType).toBe("SpecialistDoctor");
+      expect(result.retypeMap.get(canonicalId)).toBe("SpecialistDoctor");
+    });
+  });
+
+  describe("incompatible kinds are flagged, not collapsed", () => {
+    it("flags a disjoint pair (Animal, Person) without collapsing", () => {
+      const canonicalId = nodeId("mixed-1");
+      const result = reconcileTypes(
+        [{ canonicalId, memberKinds: ["Animal", "Person"] }],
+        closure,
+        "ontology",
+      );
+
+      expect(result.reconciliations).toEqual([]);
+      expect(result.retypeMap.size).toBe(0);
+      expect(result.dropped).toEqual([
+        {
+          kind: "node",
+          id: canonicalId,
+          reason: INCOMPATIBLE_TYPES_FLAG_REASON,
+        },
+      ]);
+    });
+
+    it("flags two siblings under a shared parent without collapsing", () => {
+      // SpecialistDoctor and Animal share no common descendant; neither is
+      // reachable from the other, so there is no single most-specific kind.
+      const canonicalId = nodeId("mixed-2");
+      const result = reconcileTypes(
+        [{ canonicalId, memberKinds: ["SpecialistDoctor", "Animal"] }],
+        closure,
+        "ontology",
+      );
+      expect(result.reconciliations).toEqual([]);
+      expect(result.dropped[0]!.reason).toBe(INCOMPATIBLE_TYPES_FLAG_REASON);
+    });
+  });
+
+  describe("single-kind and mixed cluster sets", () => {
+    it("ignores single-kind clusters entirely", () => {
+      const result = reconcileTypes(
+        [
+          { canonicalId: nodeId("a"), memberKinds: ["Doctor"] },
+          { canonicalId: nodeId("b"), memberKinds: ["Doctor", "Doctor"] },
+        ],
+        closure,
+        "ontology",
+      );
+      expect(result.reconciliations).toEqual([]);
+      expect(result.dropped).toEqual([]);
+      expect(result.retypeMap.size).toBe(0);
+    });
+
+    it("partitions a batch into reconciled and flagged clusters, sorted by canonical id", () => {
+      const compatible = nodeId("zzz-compatible");
+      const incompatible = nodeId("aaa-incompatible");
+      const result = reconcileTypes(
+        [
+          {
+            canonicalId: compatible,
+            memberKinds: ["Doctor", "SpecialistDoctor"],
+          },
+          { canonicalId: incompatible, memberKinds: ["Animal", "Person"] },
+        ],
+        closure,
+        "ontology",
+      );
+
+      expect(result.reconciliations).toHaveLength(1);
+      expect(result.reconciliations[0]!.entityId).toBe(compatible);
+      expect(result.reconciliations[0]!.toType).toBe("SpecialistDoctor");
+
+      expect(result.dropped).toHaveLength(1);
+      expect(result.dropped[0]!.id).toBe(incompatible);
+      expect(result.retypeMap.get(compatible)).toBe("SpecialistDoctor");
+      expect(result.retypeMap.has(incompatible)).toBe(false);
+    });
+
+    it("produces a retype map keyed by canonical id usable by the T11 cascade", () => {
+      const canonicalId = generateId() as MergeKey;
+      const result = reconcileTypes(
+        [{ canonicalId, memberKinds: ["Person", "SpecialistDoctor"] }],
+        closure,
+        "ontology",
+      );
+      expect(result.retypeMap.get(canonicalId)).toBe("SpecialistDoctor");
+    });
+  });
+});

--- a/packages/typegraph/tests/graph-merge/types.test.ts
+++ b/packages/typegraph/tests/graph-merge/types.test.ts
@@ -1,0 +1,322 @@
+import { defineEdge, defineGraph, defineNode } from "@nicia-ai/typegraph";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { canonicalizeProps } from "../../src/graph-merge/canonical-props";
+import {
+  MERGE_OPTION_DEFAULTS,
+  normalizeMergeOptions,
+} from "../../src/graph-merge/options";
+import type {
+  BranchId,
+  MergeOptions,
+  ResolveConfig,
+  ResolvedCluster,
+  SimilarityStrategy,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+
+// A real 2-kind graph so the merge generics resolve against actual TypeGraph
+// type machinery (not a stub) — this is the "generics resolve against a real
+// defineGraph" acceptance gate.
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), birthDate: z.string() }),
+});
+
+const Provider = defineNode("Provider", {
+  schema: z.object({ organization: z.string() }),
+});
+
+const treats = defineEdge("treats", {
+  schema: z.object({ since: z.string() }),
+  from: [Provider],
+  to: [Patient],
+});
+
+const graph = defineGraph({
+  id: "merge-types-test",
+  nodes: { Patient: { type: Patient }, Provider: { type: Provider } },
+  edges: { treats: { type: treats, from: [Provider], to: [Patient] } },
+});
+
+type G = typeof graph;
+
+describe("sample graph", () => {
+  it("constructs a real 2-kind graph the merge generics bind against", () => {
+    expect(graph.id).toBe("merge-types-test");
+    expect(Object.keys(graph.nodes).sort()).toEqual(["Patient", "Provider"]);
+    expect(Object.keys(graph.edges)).toEqual(["treats"]);
+  });
+});
+
+describe("canonicalizeProps", () => {
+  it("is identical for key-shuffled equivalent objects", () => {
+    const a = canonicalizeProps({ name: "Anna", birthDate: "1990-01-02" });
+    const b = canonicalizeProps({ birthDate: "1990-01-02", name: "Anna" });
+    expect(a).toBe(b);
+  });
+
+  it("recursively sorts nested object keys", () => {
+    const a = canonicalizeProps({
+      outer: { z: 1, a: 2 },
+      first: { nested: { y: 3, x: 4 } },
+    });
+    const b = canonicalizeProps({
+      first: { nested: { x: 4, y: 3 } },
+      outer: { a: 2, z: 1 },
+    });
+    expect(a).toBe(b);
+  });
+
+  it("differs when any value differs", () => {
+    const a = canonicalizeProps({ name: "Anna", birthDate: "1990-01-02" });
+    const b = canonicalizeProps({ name: "Ana", birthDate: "1990-01-02" });
+    expect(a).not.toBe(b);
+  });
+
+  it("preserves array order (order is semantically meaningful)", () => {
+    const a = canonicalizeProps({ tags: ["x", "y"] });
+    const b = canonicalizeProps({ tags: ["y", "x"] });
+    expect(a).not.toBe(b);
+  });
+
+  it("treats an undefined-valued key as absent", () => {
+    const withKey = canonicalizeProps({ name: "Anna", note: undefined });
+    const withoutKey = canonicalizeProps({ name: "Anna" });
+    expect(withKey).toBe(withoutKey);
+  });
+
+  it("operates on the parsed object, not its JSON string form", () => {
+    // The contract: callers pass parsed objects. A round-trip through JSON must
+    // therefore be a no-op on the canonical output.
+    const parsed = { birthDate: "2000-12-31", name: "Bob" };
+    const fromParsed = canonicalizeProps(parsed);
+    const fromReparsed = canonicalizeProps(
+      JSON.parse(JSON.stringify(parsed)) as Record<string, unknown>,
+    );
+    expect(fromParsed).toBe(fromReparsed);
+  });
+});
+
+describe("normalizeMergeOptions defaults", () => {
+  it("applies every frozen default when given no options", () => {
+    const normalized = normalizeMergeOptions<G>();
+    expect(normalized.reconcileTypes).toBe(
+      MERGE_OPTION_DEFAULTS.reconcileTypes,
+    );
+    expect(normalized.onPropertyConflict).toBe(
+      MERGE_OPTION_DEFAULTS.onPropertyConflict,
+    );
+    expect(normalized.onDeleteModifyConflict).toBe(
+      MERGE_OPTION_DEFAULTS.onDeleteModifyConflict,
+    );
+    expect(normalized.onComparisonCeiling).toBe(
+      MERGE_OPTION_DEFAULTS.onComparisonCeiling,
+    );
+    expect(normalized.provenance).toBe(MERGE_OPTION_DEFAULTS.provenance);
+    expect(normalized.resolve).toEqual({});
+    expect(normalized.maxComparisonsPerKind).toBeUndefined();
+    expect(normalized.clusterMaxDiameter).toBeUndefined();
+    expect(normalized.canonical).toBeUndefined();
+    expect(normalized.target).toBeUndefined();
+    expect(normalized.branchOrder).toBeUndefined();
+  });
+
+  it("preserves explicitly-provided scalar options over defaults", () => {
+    const branchOrder: readonly BranchId[] = [
+      asBranchId("b3"),
+      asBranchId("b1"),
+    ];
+    const normalized = normalizeMergeOptions<G>({
+      reconcileTypes: "ontology",
+      onDeleteModifyConflict: "deleteWins",
+      onComparisonCeiling: "mergeByIdOnly",
+      provenance: false,
+      maxComparisonsPerKind: 100,
+      clusterMaxDiameter: 0.5,
+      branchOrder,
+    });
+    expect(normalized.reconcileTypes).toBe("ontology");
+    expect(normalized.onDeleteModifyConflict).toBe("deleteWins");
+    expect(normalized.onComparisonCeiling).toBe("mergeByIdOnly");
+    expect(normalized.provenance).toBe(false);
+    expect(normalized.maxComparisonsPerKind).toBe(100);
+    expect(normalized.clusterMaxDiameter).toBe(0.5);
+    expect(normalized.branchOrder).toEqual(branchOrder);
+  });
+
+  it("threads a function onPropertyConflict and canonical selector through", () => {
+    const canonical = (cluster: ResolvedCluster) => cluster.members[0]!;
+    const normalized = normalizeMergeOptions<G>({
+      onPropertyConflict: (conflict) => conflict.resolution,
+      canonical,
+    });
+    expect(typeof normalized.onPropertyConflict).toBe("function");
+    expect(normalized.canonical).toBe(canonical);
+  });
+});
+
+describe("normalizeMergeOptions validation", () => {
+  it("rejects a per-kind threshold above 1", () => {
+    expect(() =>
+      normalizeMergeOptions<G>({
+        resolve: {
+          Patient: {
+            similarity: { kind: "fulltext", fields: ["name"] },
+            threshold: 1.5,
+          },
+        },
+      }),
+    ).toThrow(/threshold/);
+  });
+
+  it("rejects a per-kind threshold below 0", () => {
+    expect(() =>
+      normalizeMergeOptions<G>({
+        resolve: {
+          Patient: {
+            similarity: { kind: "fulltext", fields: ["name"] },
+            threshold: -0.1,
+          },
+        },
+      }),
+    ).toThrow(/threshold/);
+  });
+
+  it("accepts threshold boundaries 0 and 1", () => {
+    expect(() =>
+      normalizeMergeOptions<G>({
+        resolve: {
+          Patient: {
+            similarity: { kind: "fulltext", fields: ["name"] },
+            threshold: 0,
+          },
+          Provider: {
+            similarity: { kind: "fulltext", fields: ["organization"] },
+            threshold: 1,
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a negative maxComparisonsPerKind", () => {
+    expect(() =>
+      normalizeMergeOptions<G>({ maxComparisonsPerKind: -1 }),
+    ).toThrow(/maxComparisonsPerKind/);
+  });
+
+  it("rejects a non-integer maxComparisonsPerKind", () => {
+    expect(() =>
+      normalizeMergeOptions<G>({ maxComparisonsPerKind: 2.5 }),
+    ).toThrow(/maxComparisonsPerKind/);
+  });
+
+  it("rejects a non-positive clusterMaxDiameter", () => {
+    expect(() => normalizeMergeOptions<G>({ clusterMaxDiameter: 0 })).toThrow(
+      /clusterMaxDiameter/,
+    );
+  });
+
+  it('rejects "provenanceWeighted" with no provenanceWeights', () => {
+    expect(() =>
+      normalizeMergeOptions<G>({ onPropertyConflict: "provenanceWeighted" }),
+    ).toThrow(/provenanceWeights/);
+  });
+
+  it('rejects "provenanceWeighted" with an empty provenanceWeights map', () => {
+    expect(() =>
+      normalizeMergeOptions<G>({
+        onBasePropertyConflict: "provenanceWeighted",
+        provenanceWeights: new Map(),
+      }),
+    ).toThrow(/provenanceWeights/);
+  });
+
+  it('accepts "provenanceWeighted" when weights are provided', () => {
+    expect(() =>
+      normalizeMergeOptions<G>({
+        onPropertyConflict: "provenanceWeighted",
+        provenanceWeights: new Map([[asBranchId("b1"), 1]]),
+      }),
+    ).not.toThrow();
+  });
+
+  it("keeps the validated resolve map intact", () => {
+    const normalized = normalizeMergeOptions<G>({
+      resolve: {
+        Patient: {
+          similarity: { kind: "fulltext", fields: ["name"] },
+          threshold: 0.85,
+        },
+      },
+    });
+    expect(normalized.resolve.Patient?.threshold).toBe(0.85);
+    expect(normalized.resolve.Patient?.similarity.kind).toBe("fulltext");
+  });
+});
+
+describe("strategy + option types resolve against a real defineGraph", () => {
+  it("typechecks a custom score strategy bound to the Patient kind", () => {
+    // The custom score function receives Node<Patient> instances; accessing
+    // schema fields proves the generic binding is real, not erased.
+    const custom: SimilarityStrategy<G, typeof Patient> = {
+      kind: "custom",
+      score: (a, b) =>
+        a.name === b.name && a.birthDate === b.birthDate ? 1 : 0,
+    };
+    expect(custom.kind).toBe("custom");
+    if (custom.kind === "custom") {
+      const left = {
+        kind: "Patient" as const,
+        id: "n1",
+        name: "Anna",
+        birthDate: "1990-01-02",
+        meta: {},
+      } as unknown as Parameters<typeof custom.score>[0];
+      const right = {
+        kind: "Patient" as const,
+        id: "n2",
+        name: "Anna",
+        birthDate: "1990-01-02",
+        meta: {},
+      } as unknown as Parameters<typeof custom.score>[1];
+      expect(custom.score(left, right)).toBe(1);
+    }
+  });
+
+  it("typechecks a fulltext strategy in a ResolveConfig", () => {
+    const config: ResolveConfig<G, typeof Patient> = {
+      block: (node) => node.birthDate,
+      similarity: { kind: "fulltext", fields: ["name"] },
+      threshold: 0.85,
+    };
+    expect(config.similarity.kind).toBe("fulltext");
+    expect(config.threshold).toBe(0.85);
+  });
+
+  it("accepts a fulltext + custom resolve map as MergeOptions", () => {
+    const options: MergeOptions<G> = {
+      resolve: {
+        Patient: {
+          similarity: { kind: "fulltext", fields: ["name", "birthDate"] },
+          threshold: 0.85,
+        },
+        Provider: {
+          similarity: {
+            kind: "custom",
+            score: (a, b) => (a.organization === b.organization ? 1 : 0),
+          },
+          threshold: 0.9,
+        },
+      },
+      reconcileTypes: "ontology",
+      onPropertyConflict: "flag",
+    };
+    const normalized = normalizeMergeOptions(options);
+    expect(Object.keys(normalized.resolve).sort()).toEqual([
+      "Patient",
+      "Provider",
+    ]);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/unique-blocking-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/unique-blocking-merge.test.ts
@@ -1,0 +1,198 @@
+/**
+ * End-to-end regression for the unique-constraint blocking + force-merge fix.
+ *
+ * Two branches each add a Patient sharing an `mrn` (a unique constraint) but with a
+ * DIFFERENT `birthDate` (the block key). The old composite-key blocking split them
+ * into different buckets, so entity resolution NEVER compared them — the duplicate
+ * survived (and committing two same-mrn rows would even violate the merged graph's
+ * own uniqueness). Two cases:
+ *
+ *   1. near-duplicate names — they co-bucket on the shared mrn and resolve into ONE
+ *      canonical;
+ *   2. DISSIMILAR names (fuzzy score ~0) — an exact unique match is definitional, so
+ *      they are FORCE-merged regardless of similarity, with the name disagreement
+ *      reported as a property conflict (never a silent commit-time uniqueness fail).
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string(),
+    mrn: z.string(),
+  }),
+});
+
+const careGraph = defineGraph({
+  id: "unique-blocking-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+type CareGraph = typeof careGraph;
+
+const BRANCH_A = asBranchId("provider-a");
+const BRANCH_B = asBranchId("provider-b");
+
+/** Block by birthDate; fuzzy-match names. The mrn unique constraint is folded in
+ * automatically by `merge()` via `store.introspect()`. */
+function mergeOptions(): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { birthDate?: string }).birthDate,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH_A, BRANCH_B],
+  };
+}
+
+describe.each(backendMatrix())(
+  "unique-constraint blocking merge [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) {
+        await cleanup();
+      }
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    it("resolves a same-mrn duplicate whose birthDate (block key) differs", async () => {
+      cleanups = [];
+      const [base] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      const branchA = unwrap(
+        await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_A }),
+      );
+      const branchB = unwrap(
+        await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_B }),
+      );
+
+      // Same mrn, DIFFERENT birthDate, near-duplicate name.
+      await branchA.store.nodes.Patient.bulkCreate([
+        {
+          id: "pat-a",
+          props: { name: "Anna Rivera", birthDate: "1974-03-09", mrn: "MRN-1" },
+        },
+      ]);
+      await branchB.store.nodes.Patient.bulkCreate([
+        {
+          id: "pat-b",
+          props: { name: "Ana Rivera", birthDate: "1990-01-01", mrn: "MRN-1" },
+        },
+      ]);
+
+      const branches: readonly GraphBranch<CareGraph>[] = [branchA, branchB];
+      const result = await merge<CareGraph>(base, branches, mergeOptions());
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      // One canonical Patient (the duplicate resolved) spanning BOTH branches — and
+      // the commit did not trip the mrn unique constraint.
+      const patients = await base.nodes.Patient.find();
+      expect(patients).toHaveLength(1);
+      expect(patients[0]?.mrn).toBe("MRN-1");
+      expect(result.data.resolutions).toHaveLength(1);
+      expect(new Set(result.data.resolutions[0]?.branchOrigins).size).toBe(2);
+    });
+
+    it("FORCE-merges an exact unique match even when names are dissimilar", async () => {
+      cleanups = [];
+      const [base] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      const branchA = unwrap(
+        await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_A }),
+      );
+      const branchB = unwrap(
+        await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_B }),
+      );
+
+      // Same mrn, but WILDLY different names (fuzzy score ~0, far below 0.85) and
+      // different birthDate. A unique match is definitional, so they MUST merge —
+      // never fall through to a commit-time uniqueness failure.
+      await branchA.store.nodes.Patient.bulkCreate([
+        {
+          id: "pat-a",
+          props: { name: "Anna Rivera", birthDate: "1974-03-09", mrn: "MRN-9" },
+        },
+      ]);
+      await branchB.store.nodes.Patient.bulkCreate([
+        {
+          id: "pat-b",
+          props: {
+            name: "Robert Smith",
+            birthDate: "1990-01-01",
+            mrn: "MRN-9",
+          },
+        },
+      ]);
+
+      const branches: readonly GraphBranch<CareGraph>[] = [branchA, branchB];
+      const result = await merge<CareGraph>(base, branches, mergeOptions());
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      // Forced into ONE canonical despite the dissimilar names.
+      const patients = await base.nodes.Patient.find();
+      expect(patients).toHaveLength(1);
+      expect(patients[0]?.mrn).toBe("MRN-9");
+      expect(result.data.resolutions).toHaveLength(1);
+
+      // The name disagreement is REPORTED as a property conflict, not suppressed.
+      const nameConflict = result.data.conflicts.find(
+        (conflict) => conflict.property === "name",
+      );
+      expect(nameConflict).toBeDefined();
+      const values = new Set(
+        (nameConflict?.values ?? []).map((value) => value.value),
+      );
+      expect(values.has("Anna Rivera")).toBe(true);
+      expect(values.has("Robert Smith")).toBe(true);
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/vector-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/vector-merge.test.ts
@@ -1,0 +1,196 @@
+/**
+ * End-to-end vector/hybrid similarity through `merge()` (real embeddings path).
+ *
+ * Exercises the whole injected-embedder flow — precompute the staged texts'
+ * vectors, score candidate pairs by in-memory cosine, cluster, canonicalize — on
+ * BOTH backends, using the deterministic offline {@link fakeEmbedder} (no model
+ * download). Three properties:
+ *
+ *   1. a `hybrid` strategy WITH an embedder resolves the near-duplicate patient
+ *      pair into ONE canonical survivor (the duplicate the fulltext demo resolves,
+ *      now via real cosine + trigram blend);
+ *   2. the result is ORDER-INDEPENDENT — merging the two branches in either order
+ *      yields an identical committed graph (the embedding precompute is keyed by
+ *      text and sorted, so it adds no order dependence to the merge contract);
+ *   3. a `vector`/`hybrid` strategy with NO embedder configured fails with a typed
+ *      error surfaced as a `MergeError`.
+ */
+
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import type {
+  Embedder,
+  GraphBranch,
+  MergeOptions,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix, fakeEmbedder } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string(),
+    mrn: z.string().optional(),
+  }),
+});
+
+const careGraph = defineGraph({
+  id: "vector-merge-patient",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+
+type CareGraph = typeof careGraph;
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+/** Explicit ids so the two materializations are id-for-id comparable across runs. */
+const LEFT_PATIENT_ID = "pat-anna";
+const RIGHT_PATIENT_ID = "pat-ana";
+
+/**
+ * Hybrid (cosine + trigram) over `name`, blocked by birthDate. Threshold 0.7 is
+ * cleared by the near-duplicate under the fake character-frequency embedding.
+ */
+function hybridMergeOptions(embedder?: Embedder): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { birthDate?: string }).birthDate,
+        similarity: { kind: "hybrid", fields: ["name"] },
+        threshold: 0.7,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH_A, BRANCH_B],
+    ...(embedder === undefined ? {} : { embedder }),
+  };
+}
+
+type Fixture = Readonly<{
+  base: Store<CareGraph>;
+  branches: readonly GraphBranch<CareGraph>[];
+}>;
+
+describe.each(backendMatrix())("merge vector/hybrid path [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups ?? []) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  /**
+   * Base + two branches: branch A adds "Anna Rivera" (with an mrn), branch B adds
+   * "Ana Rivera" — same birthDate (same block), near-duplicate name. Explicit ids
+   * make two materializations id-for-id identical.
+   */
+  async function materialize(): Promise<Fixture> {
+    const [base] = await createStoreWithSchema(careGraph, await makeBackend());
+    const branchA = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_A }),
+    );
+    const branchB = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_B }),
+    );
+    await branchA.store.nodes.Patient.bulkCreate([
+      {
+        id: LEFT_PATIENT_ID,
+        props: { name: "Anna Rivera", birthDate: "1974-03-09", mrn: "MRN-001" },
+      },
+    ]);
+    await branchB.store.nodes.Patient.bulkCreate([
+      {
+        id: RIGHT_PATIENT_ID,
+        props: { name: "Ana Rivera", birthDate: "1974-03-09" },
+      },
+    ]);
+    return { base, branches: [branchA, branchB] };
+  }
+
+  it("hybrid + embedder resolves the near-duplicate into ONE canonical Patient", async () => {
+    cleanups = [];
+    const { base, branches } = await materialize();
+
+    const result = await merge<CareGraph>(
+      base,
+      branches,
+      hybridMergeOptions(fakeEmbedder),
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    // Exactly one resolution, spanning BOTH branches.
+    expect(result.data.resolutions).toHaveLength(1);
+    expect(new Set(result.data.resolutions[0]?.branchOrigins).size).toBe(2);
+
+    // The committed base holds ONE canonical Patient — the default canonical rule
+    // keeps the lexicographically-minimal member id.
+    const expectedCanonical = [LEFT_PATIENT_ID, RIGHT_PATIENT_ID].sort(
+      (left, right) =>
+        left < right ? -1
+        : left > right ? 1
+        : 0,
+    )[0];
+    const patients = await base.nodes.Patient.find();
+    expect(patients).toHaveLength(1);
+    expect(patients[0]?.id).toBe(expectedCanonical);
+  });
+
+  it("is order-independent: natural vs reversed branch order commit the same graph", async () => {
+    cleanups = [];
+    const natural = await materialize();
+    const shuffled = await materialize();
+
+    const naturalResult = await merge<CareGraph>(
+      natural.base,
+      natural.branches,
+      hybridMergeOptions(fakeEmbedder),
+    );
+    const shuffledResult = await merge<CareGraph>(
+      shuffled.base,
+      [...shuffled.branches].reverse(),
+      hybridMergeOptions(fakeEmbedder),
+    );
+    expect(isOk(naturalResult) && isOk(shuffledResult)).toBe(true);
+
+    const naturalPatients = await natural.base.nodes.Patient.find();
+    const shuffledPatients = await shuffled.base.nodes.Patient.find();
+    // Same single survivor, same id, same retained props — independent of order.
+    expect(naturalPatients).toHaveLength(1);
+    expect(shuffledPatients).toHaveLength(1);
+    expect(shuffledPatients[0]?.id).toBe(naturalPatients[0]?.id);
+    expect(shuffledPatients[0]?.name).toBe(naturalPatients[0]?.name);
+    expect(shuffledPatients[0]?.mrn).toBe(naturalPatients[0]?.mrn);
+  });
+
+  it("hybrid with NO embedder configured fails the merge", async () => {
+    cleanups = [];
+    const { base, branches } = await materialize();
+
+    const result = await merge<CareGraph>(base, branches, hybridMergeOptions());
+    // The SimilarityUnavailableError from candidate-gen surfaces as a MergeError.
+    expect(isErr(result)).toBe(true);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/write-guards.test.ts
+++ b/packages/typegraph/tests/graph-merge/write-guards.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit regression guards for two adversarial-review findings (core-readiness pass):
+ *
+ *   #2 — `writeWouldChangeRow` must model the commit's RE-VALIDATING write, not a raw
+ *        structural merge. The real node/edge update stores `schema.safeParse({...
+ *        committed, ...planned})`, which STRIPS undeclared keys + applies defaults. A
+ *        heterogeneous committed row (a key the current schema strips — which
+ *        `mergeIncremental` permits via "advanced target content") must be seen as
+ *        CHANGED, not a silent no-op (the data-loss hole).
+ *
+ *   #3 — `provenanceNodeId` must include `canonicalKind`, so two different-kind
+ *        contributions that share a bare id (e.g. base `Patient:x` and `Encounter:x`)
+ *        get DISTINCT sidecar rows instead of clobbering each other.
+ *
+ * Pure unit tests — no backend.
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { writeWouldChangeRow } from "../../src/graph-merge/merge";
+import { provenanceNodeId } from "../../src/graph-merge/provenance-store";
+import type { ProvenanceRecord } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+
+describe("writeWouldChangeRow (faithful to the re-validating write)", () => {
+  const schema = z.object({ name: z.string(), mrn: z.string() });
+
+  it("DATA-LOSS GUARD: a committed-only key the schema strips counts as a CHANGE", () => {
+    // The committed row carries `legacy`, which the current schema does not declare.
+    // The real write re-validates {...committed, ...planned} -> strips `legacy` -> the
+    // stored row changes. A structural merge would wrongly call this a no-op.
+    expect(
+      writeWouldChangeRow(
+        schema,
+        { name: "Alice", mrn: "M1", legacy: "KEEP-ME" },
+        { name: "Alice", mrn: "M1" },
+      ),
+    ).toBe(true);
+  });
+
+  it("no-op: an exactly-equal re-add does not change the row", () => {
+    expect(
+      writeWouldChangeRow(
+        schema,
+        { name: "Alice", mrn: "M1" },
+        { name: "Alice", mrn: "M1" },
+      ),
+    ).toBe(false);
+  });
+
+  it("no-op: a subset re-add (planned ⊆ committed, schema-normalized) is preserved", () => {
+    // committed is already in current-schema form; the patch validates back to the same
+    // bytes, so this stays the allowed idempotent re-run (the E3/E5 behaviour).
+    const optional = z.object({ name: z.string(), tag: z.string().optional() });
+    expect(
+      writeWouldChangeRow(
+        optional,
+        { name: "Alice", tag: "vip" },
+        { name: "Alice" },
+      ),
+    ).toBe(false);
+  });
+
+  it("CHANGE: overwriting an existing committed value", () => {
+    expect(
+      writeWouldChangeRow(
+        schema,
+        { name: "Alice", mrn: "M1" },
+        { name: "Bob", mrn: "M1" },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not mask a validation error: an unvalidatable merge is reported as no-change", () => {
+    // {...{name}, ...{}} = {name} is missing required `mrn` -> the real write would THROW
+    // a ValidationError at commit; the guard returns false so it never masks that with a
+    // stale-overwrite error.
+    expect(writeWouldChangeRow(schema, { name: "Alice" }, {})).toBe(false);
+  });
+
+  it("falls back to the structural comparison when no schema is reachable", () => {
+    expect(writeWouldChangeRow(undefined, { a: 1 }, { a: 1 })).toBe(false);
+    expect(writeWouldChangeRow(undefined, { a: 1 }, { a: 2 })).toBe(true);
+  });
+});
+
+describe("provenanceNodeId (cross-kind identity)", () => {
+  const base = (kind: string): ProvenanceRecord => ({
+    role: "node",
+    canonicalId: "x",
+    canonicalKind: kind,
+    branchId: asBranchId("provider-a"),
+    sourceId: "x",
+  });
+
+  it("distinguishes two different-kind contributions that share a bare id", async () => {
+    const patient = await provenanceNodeId("g", base("Patient"));
+    const encounter = await provenanceNodeId("g", base("Encounter"));
+    expect(patient).not.toBe(encounter);
+  });
+
+  it("is stable for the same record (deterministic upsert key)", async () => {
+    expect(await provenanceNodeId("g", base("Patient"))).toBe(
+      await provenanceNodeId("g", base("Patient")),
+    );
+  });
+});

--- a/packages/typegraph/tests/property/graph-merge/arbitraries.ts
+++ b/packages/typegraph/tests/property/graph-merge/arbitraries.ts
@@ -1,0 +1,143 @@
+/**
+ * Bounded fast-check arbitraries for the determinism property test (T12).
+ *
+ * The arbitrary produces a PURE DATA scenario spec — never a live store. The
+ * property body materializes it twice (a base + N branches) and merges a natural
+ * and a permuted branch order onto two fresh target clones, so the same logical
+ * scenario drives both runs with identical node/edge ids (deep-equal is only
+ * meaningful when both merges see the SAME ids).
+ *
+ * The scenario deliberately exercises every order-sensitive merge path the gate
+ * must prove commutative:
+ *
+ *   - DUPLICATE NEW NODES — two branches add patients whose names collide under
+ *     the Dice-trigram threshold (`"Anna Rivera"` / `"Ana Rivera"`), so they
+ *     cluster into one canonical (pure canonical selection + property union).
+ *   - MODIFIED INHERITED PROPS — branches re-set props on a base patient, so the
+ *     property union surfaces a cross-branch conflict.
+ *   - DELETE/MODIFY — a base patient is DELETED by one branch and MODIFIED by
+ *     another on the same scenario (hits T8a).
+ *   - COLLAPSING EDGES — each duplicate patient carries an edge; after the
+ *     cluster collapses, the edges repoint onto the single canonical and dedupe.
+ *   - ONTOLOGY — a cluster mixes `Doctor` and `SpecialistDoctor` so
+ *     `reconcileTypes: "ontology"` collapses to the most-specific type.
+ */
+
+import fc from "fast-check";
+
+/** A near-duplicate patient-name pair that clears the Dice-trigram 0.85 threshold. */
+type DuplicateNamePair = Readonly<{ left: string; right: string }>;
+
+/**
+ * Name pairs chosen so the in-memory Sørensen–Dice trigram scorer rates them
+ * STRICTLY ABOVE the demo threshold of 0.85 (they MUST cluster). Each is a real
+ * near-duplicate spelling, mirroring the FHIR `"Anna Rivera"` / `"Ana Rivera"`
+ * case; the scores below were measured against `diceTrigramSimilarity` so the
+ * duplicate pair always produces an entity resolution.
+ */
+const DUPLICATE_NAME_PAIRS: readonly DuplicateNamePair[] = [
+  { left: "Anna Rivera", right: "Ana Rivera" }, // 0.857
+  { left: "Catherine Brooks", right: "Katherine Brooks" }, // 0.875
+  { left: "Gabriella Stone", right: "Gabriela Stone" }, // 0.897
+  { left: "Maximilian Cross", right: "Maximillian Cross" }, // 0.909
+];
+
+/** A distinct (non-duplicate) name that must NOT cluster with the duplicate pair. */
+const DISTINCT_NAMES: readonly string[] = [
+  "Robert Smith",
+  "Maria Gonzalez",
+  "Wei Chen",
+  "Olu Adeyemi",
+];
+
+/** Birth dates used to co-block duplicate patients (same date → same block). */
+const BIRTH_DATES: readonly string[] = [
+  "1974-03-09",
+  "1988-11-21",
+  "1965-07-02",
+  "1991-02-14",
+];
+
+/** A doctor-name pair whose two members are added under different kinds. */
+const DOCTOR_NAME_PAIRS: readonly DuplicateNamePair[] = [
+  { left: "Helen Park", right: "Helen Park" },
+  { left: "Marcus Webb", right: "Marcus Webb" },
+];
+
+/**
+ * The full scenario the property materializes. Every field is pure data; the
+ * property body turns it into a base store + branches with concrete ids.
+ */
+export type DeterminismScenario = Readonly<{
+  /**
+   * A base patient both branches inherit. One branch DELETES it while the other
+   * MODIFIES its `mrn` — a delete/modify conflict (T8a). The boolean chooses
+   * which branch deletes (branch 0) vs modifies (branch 1).
+   */
+  inherited: Readonly<{
+    name: string;
+    birthDate: string;
+    baseMrn: string;
+    modifiedMrn: string;
+  }>;
+  /**
+   * The duplicate patient pair: branch 0 adds `pair.left` + an encounter edge,
+   * branch 1 adds `pair.right` + a condition edge, both on `birthDate`. They
+   * cluster into one canonical; the two edges collapse onto it.
+   */
+  duplicate: Readonly<{
+    pair: DuplicateNamePair;
+    birthDate: string;
+    leftMrn: string;
+    encounterReason: string;
+  }>;
+  /** A distinct patient one branch adds that must remain its own singleton. */
+  distinct: Readonly<{ name: string; birthDate: string }>;
+  /**
+   * The ontology pair: branch 0 adds the name as a `Doctor`, branch 1 adds the
+   * same name as a `SpecialistDoctor`, on a shared block key. They cluster and
+   * `reconcileTypes: "ontology"` collapses them to `SpecialistDoctor`.
+   */
+  ontology: Readonly<{ pair: DuplicateNamePair }>;
+}>;
+
+/** A non-empty alphanumeric token usable as an mrn / reason / code value. */
+const tokenArb = fc
+  .string({ minLength: 3, maxLength: 8, unit: "binary-ascii" })
+  .map((value) => value.replaceAll(/[^A-Za-z0-9]/g, "") || "x")
+  .map((value) => value.toUpperCase());
+
+/**
+ * The bounded scenario arbitrary. Constrained so `numRuns ~ 30` stays fast on
+ * both backends (PGlite boots an in-process Postgres per fixture) while still
+ * covering the full cross-product of name pairs, birth dates, and value tokens.
+ */
+export const determinismScenarioArb: fc.Arbitrary<DeterminismScenario> =
+  fc.record({
+    // `modifiedMrn` is DERIVED from `baseMrn` so it is GUARANTEED distinct — the
+    // delete/modify conflict (T8a) only arises if the "modify" actually changes
+    // the canonicalized props, so an equal value would silently skip that path.
+    inherited: fc
+      .record({
+        name: fc.constantFrom(...DISTINCT_NAMES),
+        birthDate: fc.constantFrom(...BIRTH_DATES),
+        baseMrn: tokenArb,
+      })
+      .map((inherited) => ({
+        ...inherited,
+        modifiedMrn: `${inherited.baseMrn}-MOD`,
+      })),
+    duplicate: fc.record({
+      pair: fc.constantFrom(...DUPLICATE_NAME_PAIRS),
+      birthDate: fc.constantFrom(...BIRTH_DATES),
+      leftMrn: tokenArb,
+      encounterReason: tokenArb,
+    }),
+    distinct: fc.record({
+      name: fc.constantFrom(...DISTINCT_NAMES),
+      birthDate: fc.constantFrom(...BIRTH_DATES),
+    }),
+    ontology: fc.record({
+      pair: fc.constantFrom(...DOCTOR_NAME_PAIRS),
+    }),
+  });

--- a/packages/typegraph/tests/property/graph-merge/determinism.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/determinism.test.ts
@@ -1,0 +1,429 @@
+/**
+ * The headline P0 determinism gate (design §12 / §6.4, T12).
+ *
+ * For randomly-generated base + branch fixtures, `merge()` MUST be commutative in
+ * the branch order: shuffling `branches` yields a deep-equal normalized
+ * {@link MergeReport} AND a deep-equal committed graph — on BOTH backends.
+ *
+ * Why a SHARED base + branches built once:
+ *   Each merge run mints no new ids (the duplicate / inherited / ontology nodes
+ *   carry ids fixed when the branches are seeded), so the two runs are comparable
+ *   id-for-id. We build the base + N branches ONCE, then merge the SAME branch
+ *   objects in two orders — the natural order onto a fresh target clone, and a
+ *   shuffled order onto a SECOND fresh target clone. `merge()` only READS the
+ *   branch stores and WRITES the target, so reusing the branch objects across the
+ *   two runs is safe and keeps every id identical between runs.
+ *
+ *   The `branchOrder` option is held FIXED across both runs — it is the stable,
+ *   non-wall-clock tie-break anchor; only the `branches` ARRAY order is shuffled.
+ *   If determinism depended on arrival order, the two normalized results would
+ *   diverge and the property would fail.
+ *
+ * Coverage (every order-sensitive path the gate must prove commutative):
+ *   - canonical selection + commutative property union (duplicate patient pair),
+ *   - set-dedupe edges (both branches' collapsing edges onto one canonical),
+ *   - node delete/modify conflicts (T8a — one branch deletes, another modifies),
+ *   - ontology type reconciliation (T10 — a shared id staged under Doctor and
+ *     SpecialistDoctor collapses to the most-specific kind).
+ */
+
+import type { GraphBackend, Node, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  subClassOf,
+} from "@nicia-ai/typegraph";
+import fc from "fast-check";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../../src/graph-merge/branch";
+import { merge } from "../../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../../src/graph-merge/result";
+import type {
+  BranchId,
+  GraphBranch,
+  MergeOptions,
+  SimilarityStrategy,
+} from "../../../src/graph-merge/types";
+import { asBranchId } from "../../../src/graph-merge/types";
+import { backendMatrix } from "../../graph-merge/test-utils";
+import type { DeterminismScenario } from "./arbitraries";
+import { determinismScenarioArb } from "./arbitraries";
+import { normalizeGraph, normalizeReport } from "./normalize";
+
+/**
+ * The same FHIR-flavored care graph the T11 merge suite uses: patients with
+ * encounters/conditions, plus a `Doctor ⊐ SpecialistDoctor` ontology so
+ * `reconcileTypes: "ontology"` is exercised end-to-end.
+ */
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string(),
+    mrn: z.string().optional(),
+  }),
+});
+
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+
+const Doctor = defineNode("Doctor", {
+  schema: z.object({ name: z.string() }),
+});
+
+const SpecialistDoctor = defineNode("SpecialistDoctor", {
+  schema: z.object({ name: z.string() }),
+});
+
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const careGraph = defineGraph({
+  id: "fhir-care-graph",
+  nodes: {
+    Patient: { type: Patient },
+    Encounter: { type: Encounter },
+    Doctor: { type: Doctor },
+    SpecialistDoctor: { type: SpecialistDoctor },
+  },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+  ontology: [subClassOf(SpecialistDoctor, Doctor)],
+});
+
+type CareGraph = typeof careGraph;
+
+const DEMO_THRESHOLD = 0.85;
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+/** Stable, non-wall-clock branch order — held FIXED across both merge runs. */
+const FIXED_BRANCH_ORDER: readonly BranchId[] = [BRANCH_A, BRANCH_B];
+
+/**
+ * fast-check iterations. Each run boots ~6 in-process PGlite (WASM Postgres)
+ * engines (two materializations × base + two branches), which is markedly slower
+ * on CI runners — 30 runs there blow past any sane timeout. So CI runs fewer
+ * iterations (still meaningful, and the order-independence property is ALSO pinned
+ * by the deterministic, non-property tests on both backends); a dev box runs the
+ * full set. (A shared-PGlite-engine fixture would let CI run the full count.)
+ */
+const DETERMINISM_RUNS = process.env.CI ? 12 : 30;
+
+/** In-memory Dice trigram over the `name` field (no embeddings). */
+const nameSimilarity: SimilarityStrategy<CareGraph> = {
+  kind: "fulltext",
+  fields: ["name"],
+};
+
+/** Blocks patients by `birthDate`, bounding the O(n²) comparisons. */
+function blockByBirthDate(node: Node): string | undefined {
+  return (node as unknown as { birthDate?: string }).birthDate;
+}
+
+/** Blocks doctors by name so same-name members co-block and can cluster. */
+function blockByName(node: Node): string | undefined {
+  return (node as unknown as { name?: string }).name;
+}
+
+/**
+ * The merge options shared by every property run. `reconcileTypes: "ontology"`
+ * collapses the Doctor/SpecialistDoctor pair; `onPropertyConflict: "flag"` and
+ * `onDeleteModifyConflict: "flag"` surface (not auto-resolve) every conflict; the
+ * branch order is FIXED so determinism cannot leak through arrival order.
+ */
+function determinismMergeOptions(): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => blockByBirthDate(node),
+        similarity: nameSimilarity,
+        threshold: DEMO_THRESHOLD,
+      },
+      Doctor: {
+        block: (node) => blockByName(node),
+        similarity: nameSimilarity,
+        threshold: DEMO_THRESHOLD,
+      },
+      SpecialistDoctor: {
+        block: (node) => blockByName(node),
+        similarity: nameSimilarity,
+        threshold: DEMO_THRESHOLD,
+      },
+    },
+    reconcileTypes: "ontology",
+    onPropertyConflict: "flag",
+    onDeleteModifyConflict: "flag",
+    branchOrder: FIXED_BRANCH_ORDER,
+  };
+}
+
+/** The materialized fixture for one property run: a base + its two branches. */
+type Fixture = Readonly<{
+  base: Store<CareGraph>;
+  branches: readonly GraphBranch<CareGraph>[];
+}>;
+
+describe.each(backendMatrix())(
+  "determinism property — shuffled branch order [$name]",
+  (entry) => {
+    // Disposers for backends still open at test end (belt-and-suspenders — the
+    // property body also disposes each iteration's backends inline so PGlite's
+    // in-process engines never accumulate across the 30 runs).
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups) {
+        await cleanup();
+      }
+    });
+
+    async function makeBackend(
+      disposers: (() => Promise<void>)[],
+    ): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      disposers.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    /**
+     * Materializes a {@link DeterminismScenario} into a fresh base store + two
+     * branches. EVERY node and edge is seeded with an EXPLICIT, scenario-derived
+     * id (via `bulkCreate`) — never a random nanoid — so two independent
+     * materializations of the same scenario produce id-for-id identical graphs.
+     * That is what makes the natural-order vs shuffled-order committed graphs
+     * deep-comparable: each run merges into its OWN base store, and the two base
+     * stores start from identical content.
+     *
+     * The base carries the inherited patient both branches diverge on; each
+     * branch then stages its half of the scenario:
+     *
+     *   - branch A DELETES the inherited patient, adds the LEFT duplicate name
+     *     (with a shared-id encounter edge), a distinct patient, and the ontology
+     *     member as a `Doctor`.
+     *   - branch B MODIFIES the inherited patient's mrn, adds the RIGHT duplicate
+     *     name (with the same shared-id encounter edge + identical props →
+     *     set-dedupe), and the ontology member as a `SpecialistDoctor` UNDER THE
+     *     SAME id (so the cluster has mixed kinds → reconciliation collapses it).
+     */
+    async function materialize(
+      scenario: DeterminismScenario,
+      disposers: (() => Promise<void>)[],
+    ): Promise<Fixture> {
+      const [base] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(disposers),
+      );
+
+      // Explicit, scenario-stable ids. The two duplicate patients are DISTINCT
+      // ids that cluster; the encounter and ontology member are SHARED ids so the
+      // branches' contributions co-locate.
+      const inheritedId = "pat-inherited";
+      const leftPatientId = "pat-left";
+      const rightPatientId = "pat-right";
+      const distinctPatientId = "pat-distinct";
+      const sharedEncounterId = "enc-shared";
+      const sharedOntologyId = "doc-shared";
+      const encounterEdgeAId = "edge-enc-a";
+      const encounterEdgeBId = "edge-enc-b";
+
+      // Inherited patient both branches will diverge on (delete vs modify, T8a).
+      // Capture the created node so its BRANDED id can drive `delete`/`update` in
+      // the branch clones (the id value is identical across clones).
+      const [inherited] = await base.nodes.Patient.bulkCreate([
+        {
+          id: inheritedId,
+          props: {
+            name: scenario.inherited.name,
+            birthDate: scenario.inherited.birthDate,
+            mrn: scenario.inherited.baseMrn,
+          },
+        },
+      ]);
+      const inheritedNodeId = inherited!.id;
+
+      const branchA = unwrap(
+        await branch<CareGraph>(base, () => makeBackend(disposers), {
+          id: BRANCH_A,
+        }),
+      );
+      const branchB = unwrap(
+        await branch<CareGraph>(base, () => makeBackend(disposers), {
+          id: BRANCH_B,
+        }),
+      );
+
+      // --- branch A ---------------------------------------------------------
+      // Delete the inherited patient (the delete side of the delete/modify pair).
+      await branchA.store.nodes.Patient.delete(inheritedNodeId);
+      // The LEFT duplicate patient + a shared-id encounter edge onto her.
+      await branchA.store.nodes.Patient.bulkCreate([
+        {
+          id: leftPatientId,
+          props: {
+            name: scenario.duplicate.pair.left,
+            birthDate: scenario.duplicate.birthDate,
+            mrn: scenario.duplicate.leftMrn,
+          },
+        },
+      ]);
+      await branchA.store.nodes.Encounter.bulkCreate([
+        {
+          id: sharedEncounterId,
+          props: { reason: scenario.duplicate.encounterReason },
+        },
+      ]);
+      await branchA.store.edges.hadEncounter.bulkCreate([
+        {
+          id: encounterEdgeAId,
+          from: { kind: "Patient", id: leftPatientId },
+          to: { kind: "Encounter", id: sharedEncounterId },
+          props: { on: scenario.duplicate.birthDate },
+        },
+      ]);
+      // A distinct patient that must remain its own singleton (no over-merge).
+      await branchA.store.nodes.Patient.bulkCreate([
+        {
+          id: distinctPatientId,
+          props: {
+            name: scenario.distinct.name,
+            birthDate: scenario.distinct.birthDate,
+          },
+        },
+      ]);
+      // The ontology member as a Doctor under the shared id.
+      await branchA.store.nodes.Doctor.bulkCreate([
+        { id: sharedOntologyId, props: { name: scenario.ontology.pair.left } },
+      ]);
+
+      // --- branch B ---------------------------------------------------------
+      // Modify the inherited patient's mrn (the modify side of the pair).
+      await branchB.store.nodes.Patient.update(inheritedNodeId, {
+        mrn: scenario.inherited.modifiedMrn,
+      });
+      // The RIGHT duplicate patient + the SAME shared-id encounter edge with
+      // identical props, so after repoint the two edges set-dedupe to one.
+      await branchB.store.nodes.Patient.bulkCreate([
+        {
+          id: rightPatientId,
+          props: {
+            name: scenario.duplicate.pair.right,
+            birthDate: scenario.duplicate.birthDate,
+          },
+        },
+      ]);
+      await branchB.store.nodes.Encounter.bulkCreate([
+        {
+          id: sharedEncounterId,
+          props: { reason: scenario.duplicate.encounterReason },
+        },
+      ]);
+      await branchB.store.edges.hadEncounter.bulkCreate([
+        {
+          id: encounterEdgeBId,
+          from: { kind: "Patient", id: rightPatientId },
+          to: { kind: "Encounter", id: sharedEncounterId },
+          props: { on: scenario.duplicate.birthDate },
+        },
+      ]);
+      // The ontology member as a SpecialistDoctor UNDER THE SAME id → the cluster
+      // has mixed kinds, so reconcileTypes: "ontology" collapses it to the
+      // most-specific kind (SpecialistDoctor).
+      await branchB.store.nodes.SpecialistDoctor.bulkCreate([
+        { id: sharedOntologyId, props: { name: scenario.ontology.pair.right } },
+      ]);
+
+      return { base, branches: [branchA, branchB] };
+    }
+
+    it(
+      "yields a deep-equal normalized report + graph for any branch ordering",
+      { timeout: 300_000 },
+      async () => {
+        cleanups = [];
+        await fc.assert(
+          fc.asyncProperty(
+            determinismScenarioArb,
+            fc.boolean(),
+            async (scenario, reverse) => {
+              // Each property iteration owns its backends and disposes them inline,
+              // so PGlite's in-process engines never accumulate across the 30 runs.
+              const disposers: (() => Promise<void>)[] = [];
+              try {
+                // TWO independent materializations of the SAME scenario. Because
+                // every node/edge carries an explicit, scenario-derived id, the two
+                // base stores start id-for-id identical — so their committed graphs
+                // are deep-comparable after merging in different orders.
+                const natural = await materialize(scenario, disposers);
+                const shuffled = await materialize(scenario, disposers);
+
+                const naturalResult = await merge<CareGraph>(
+                  natural.base,
+                  natural.branches,
+                  determinismMergeOptions(),
+                );
+                const shuffledBranches =
+                  reverse ?
+                    [...shuffled.branches].reverse()
+                  : shuffled.branches;
+                const shuffledResult = await merge<CareGraph>(
+                  shuffled.base,
+                  shuffledBranches,
+                  determinismMergeOptions(),
+                );
+
+                expect(isOk(naturalResult)).toBe(true);
+                expect(isOk(shuffledResult)).toBe(true);
+                if (!isOk(naturalResult) || !isOk(shuffledResult)) {
+                  return;
+                }
+
+                const branchIds = FIXED_BRANCH_ORDER;
+                const naturalReport = normalizeReport(
+                  naturalResult.data,
+                  branchIds,
+                );
+                const shuffledReport = normalizeReport(
+                  shuffledResult.data,
+                  branchIds,
+                );
+                expect(shuffledReport).toEqual(naturalReport);
+
+                const naturalGraph = await normalizeGraph(natural.base);
+                const shuffledGraph = await normalizeGraph(shuffled.base);
+                expect(shuffledGraph).toEqual(naturalGraph);
+
+                // The scenario actually exercised the order-sensitive paths: an
+                // entity resolution (the duplicate pair), an edge set-dedupe (one
+                // surviving hadEncounter), a delete/modify conflict (the inherited
+                // patient), and an ontology reconciliation (Doctor → Specialist).
+                expect(naturalReport.resolutions.length).toBeGreaterThanOrEqual(
+                  1,
+                );
+                expect(
+                  naturalReport.deleteModifyConflicts.length,
+                ).toBeGreaterThanOrEqual(1);
+                expect(
+                  naturalReport.typeReconciliations.length,
+                ).toBeGreaterThanOrEqual(1);
+              } finally {
+                for (const dispose of disposers) {
+                  await dispose();
+                }
+              }
+            },
+          ),
+          { numRuns: DETERMINISM_RUNS },
+        );
+      },
+    );
+  },
+);

--- a/packages/typegraph/tests/property/graph-merge/new-vs-base-determinism.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/new-vs-base-determinism.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Fuzzed new-vs-base permutation-invariance gate (review #5; design §6.4-B / §7).
+ *
+ * The headline determinism property (`determinism.test.ts`) drives the public
+ * `merge()` snapshot path, where base sources are never active. The single-scenario
+ * `new-vs-base-determinism.test.ts` proves permutation-invariance for ONE fixed
+ * 2-branch case with DISTINCT base entities. Neither fuzzes the new-vs-base axis, and
+ * the path most likely to leak emission order — MULTIPLE branches re-discovering the
+ * SAME committed base entity (same unique value) — was untested.
+ *
+ * This gate closes that gap: a fast-check scenario seeds a target with committed base
+ * patients and two read-only branches whose new patients:
+ *
+ *   - collide on `mrn` with the base (forced new↔base merges),
+ *   - sometimes collide on `mrn` with each other across branches (same-base
+ *     re-discovery),
+ *   - sometimes share an independent `cohort` despite DIFFERENT `mrn`s
+ *     (base-a ~ new-1 ~ new-2 ~ base-b ambiguity).
+ *
+ * Shuffling the branch order MUST yield a deep-equal normalized report and a
+ * deep-equal committed graph, with base sources active, on BOTH backends. The
+ * property also asserts that at least one run produces non-empty `baseAmbiguities`,
+ * so the base-guard portion cannot silently regress to vacuous coverage.
+ *
+ * forkBase + branches are READ-ONLY under `mergeAgainstBase` (it diffs against them
+ * and commits to `target`), so they are built ONCE and reused across the two orders;
+ * only the two `target`s are independent so their committed graphs are comparable.
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../../src/graph-merge/branch";
+import { mergeAgainstBase } from "../../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../../src/graph-merge/result";
+import type {
+  BranchId,
+  GraphBranch,
+  MergeOptions,
+} from "../../../src/graph-merge/types";
+import { asBranchId } from "../../../src/graph-merge/types";
+import { backendMatrix } from "../../graph-merge/test-utils";
+import { normalizeGraph, normalizeReport } from "./normalize";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), mrn: z.string(), cohort: z.string() }),
+});
+
+const careGraph = defineGraph({
+  id: "nvb-prop-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+type CareGraph = typeof careGraph;
+
+const A = asBranchId("provider-a");
+const B = asBranchId("provider-b");
+const FIXED_ORDER: readonly BranchId[] = [A, B];
+
+/**
+ * fast-check iterations. Each run boots 5 backends (forkBase + two branches + two
+ * targets); PGlite (in-process WASM Postgres) makes that the slow axis, so CI runs
+ * fewer (still meaningful — the deterministic new-vs-base tests pin the same paths on
+ * both backends). A dev box runs the full set.
+ */
+const RUNS = process.env.CI ? 8 : 16;
+
+/**
+ * A new patient a branch stages: keyed by `mrn` for forced unique matches, and
+ * separately blocked by `cohort` so the fuzzer can generate different-mrn fuzzy
+ * bridges across committed base identities.
+ */
+type NewPatient = Readonly<{ mrn: string; name: string; cohort: string }>;
+
+/** Committed-base mrn pool. `MN` is deliberately ABSENT — a novel cross-branch key. */
+const BASE_POOL = ["M0", "M1", "M2", "M3", "MA", "MB"] as const;
+const BRIDGE_A: NewPatient = {
+  mrn: "MA",
+  name: "Anna Rivera",
+  cohort: "C-BRIDGE",
+};
+const BRIDGE_B: NewPatient = {
+  mrn: "MB",
+  name: "Ana Rivera",
+  cohort: "C-BRIDGE",
+};
+
+/**
+ * Per-branch candidate patients with UNIQUE mrns within each list (so a `subarray`
+ * is always a valid single-branch store under the `mrn` unique constraint). The
+ * overlapping mrns across A and B (`M0`, `M2`, `MN`) are where two branches
+ * re-discover the same entity at once.
+ */
+const A_CANDIDATES: readonly NewPatient[] = [
+  { mrn: "M0", name: "Anna Rivera", cohort: "C-M0" },
+  { mrn: "M1", name: "Bob Lee", cohort: "C-M1" },
+  { mrn: "M2", name: "Cara Diaz", cohort: "C-M2" },
+  { mrn: "MN", name: "Dora Vale", cohort: "C-MN" },
+  BRIDGE_A,
+];
+const B_CANDIDATES: readonly NewPatient[] = [
+  { mrn: "M0", name: "Ana Rivera", cohort: "C-M0" },
+  { mrn: "M2", name: "Cora Diaz", cohort: "C-M2" },
+  { mrn: "M3", name: "Evan Poe", cohort: "C-M3" },
+  { mrn: "MN", name: "Dara Vale", cohort: "C-MN" },
+  BRIDGE_B,
+];
+
+type NvbScenario = Readonly<{
+  baseMrns: readonly string[];
+  branchA: readonly NewPatient[];
+  branchB: readonly NewPatient[];
+}>;
+
+const BRIDGE_EXAMPLE: NvbScenario = {
+  baseMrns: ["MA", "MB"],
+  branchA: [BRIDGE_A],
+  branchB: [BRIDGE_B],
+};
+
+/**
+ * The general scenario arbitrary. `subarray` over unique-mrn sources guarantees
+ * every single-branch store is valid, while the shared mrns produce the same-base
+ * multi-branch collisions (base + A + B onto one entity) and novel new↔new
+ * collisions (`MN`, never in base).
+ */
+const generalScenarioArb: fc.Arbitrary<NvbScenario> = fc.record({
+  baseMrns: fc.subarray([...BASE_POOL], { minLength: 0, maxLength: 6 }),
+  branchA: fc.subarray([...A_CANDIDATES], { minLength: 0, maxLength: 5 }),
+  branchB: fc.subarray([...B_CANDIDATES], { minLength: 0, maxLength: 5 }),
+});
+
+const A_NON_BRIDGE = A_CANDIDATES.filter((patient) => patient !== BRIDGE_A);
+const B_NON_BRIDGE = B_CANDIDATES.filter((patient) => patient !== BRIDGE_B);
+const NON_BRIDGE_BASE_POOL = BASE_POOL.filter(
+  (mrn) => mrn !== BRIDGE_A.mrn && mrn !== BRIDGE_B.mrn,
+);
+
+/**
+ * A biased bridge arbitrary: every generated value contains two different-mrn
+ * staged nodes sharing one cohort, plus both matching base mrns. That creates the
+ * base-a ~ new-1 ~ new-2 ~ base-b component shape the general arbitrary only hits
+ * by chance.
+ */
+const bridgeScenarioArb: fc.Arbitrary<NvbScenario> = fc
+  .record({
+    extraBaseMrns: fc.subarray([...NON_BRIDGE_BASE_POOL], {
+      minLength: 0,
+      maxLength: 4,
+    }),
+    branchAExtras: fc.subarray([...A_NON_BRIDGE], {
+      minLength: 0,
+      maxLength: 4,
+    }),
+    branchBExtras: fc.subarray([...B_NON_BRIDGE], {
+      minLength: 0,
+      maxLength: 4,
+    }),
+  })
+  .map(({ extraBaseMrns, branchAExtras, branchBExtras }) => ({
+    baseMrns: [BRIDGE_A.mrn, BRIDGE_B.mrn, ...extraBaseMrns],
+    branchA: [BRIDGE_A, ...branchAExtras],
+    branchB: [BRIDGE_B, ...branchBExtras],
+  }));
+
+const nvbScenarioArb: fc.Arbitrary<NvbScenario> = fc.oneof(
+  generalScenarioArb,
+  bridgeScenarioArb,
+);
+
+function options(
+  target: GraphBranch<CareGraph>["store"],
+): MergeOptions<CareGraph> {
+  return {
+    target,
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { cohort?: string }).cohort,
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: FIXED_ORDER,
+  };
+}
+
+describe.each(backendMatrix())(
+  "new-vs-base determinism property — shuffled branch order [$name]",
+  (entry) => {
+    async function makeBackend(
+      disposers: (() => Promise<void>)[],
+    ): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      disposers.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    /** Seeds a branch's new patients under stable `${label}-${mrn}` ids. */
+    async function seedBranch(
+      target: GraphBranch<CareGraph>,
+      label: string,
+      news: readonly NewPatient[],
+    ): Promise<void> {
+      if (news.length === 0) {
+        return;
+      }
+      await target.store.nodes.Patient.bulkCreate(
+        news.map((patient) => ({
+          id: `${label}-${patient.mrn}`,
+          props: {
+            name: patient.name,
+            mrn: patient.mrn,
+            cohort: patient.cohort,
+          },
+        })),
+      );
+    }
+
+    /** A fresh target seeded with the committed base patients under `base-${mrn}` ids. */
+    async function seededTarget(
+      disposers: (() => Promise<void>)[],
+      baseMrns: readonly string[],
+    ): Promise<GraphBranch<CareGraph>["store"]> {
+      const [target] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(disposers),
+      );
+      if (baseMrns.length > 0) {
+        await target.nodes.Patient.bulkCreate(
+          baseMrns.map((mrn) => ({
+            id: `base-${mrn}`,
+            props: { name: `Base-${mrn}`, mrn, cohort: `BASE-${mrn}` },
+          })),
+        );
+      }
+      return target;
+    }
+
+    it(
+      "yields a deep-equal normalized report + committed graph for either branch order",
+      { timeout: 300_000 },
+      async () => {
+        let nonEmptyBaseAmbiguityRuns = 0;
+        await fc.assert(
+          fc.asyncProperty(nvbScenarioArb, async (scenario) => {
+            const disposers: (() => Promise<void>)[] = [];
+            try {
+              // forkBase + branches are read-only across both runs; reuse them.
+              const [forkBase] = await createStoreWithSchema(
+                careGraph,
+                await makeBackend(disposers),
+              );
+              const branchA = unwrap(
+                await branch<CareGraph>(
+                  forkBase,
+                  () => makeBackend(disposers),
+                  { id: A },
+                ),
+              );
+              const branchB = unwrap(
+                await branch<CareGraph>(
+                  forkBase,
+                  () => makeBackend(disposers),
+                  { id: B },
+                ),
+              );
+              await seedBranch(branchA, "a", scenario.branchA);
+              await seedBranch(branchB, "b", scenario.branchB);
+
+              const targetNatural = await seededTarget(
+                disposers,
+                scenario.baseMrns,
+              );
+              const targetShuffled = await seededTarget(
+                disposers,
+                scenario.baseMrns,
+              );
+
+              const naturalResult = await mergeAgainstBase<CareGraph>(
+                forkBase,
+                [branchA, branchB],
+                options(targetNatural),
+              );
+              // Always the REVERSED order — with two branches that is the only
+              // non-trivial permutation, so every run actually exercises order
+              // independence (the prior `reverse` boolean made ~half the runs
+              // re-run the natural order and assert nothing).
+              const shuffledResult = await mergeAgainstBase<CareGraph>(
+                forkBase,
+                [branchB, branchA],
+                options(targetShuffled),
+              );
+
+              expect(isOk(naturalResult)).toBe(true);
+              expect(isOk(shuffledResult)).toBe(true);
+              if (!isOk(naturalResult) || !isOk(shuffledResult)) {
+                return;
+              }
+
+              expect(shuffledResult.data.baseAmbiguities.length).toBe(
+                naturalResult.data.baseAmbiguities.length,
+              );
+              if (naturalResult.data.baseAmbiguities.length > 0) {
+                nonEmptyBaseAmbiguityRuns += 1;
+              }
+
+              expect(normalizeReport(shuffledResult.data, FIXED_ORDER)).toEqual(
+                normalizeReport(naturalResult.data, FIXED_ORDER),
+              );
+              expect(await normalizeGraph(targetShuffled)).toEqual(
+                await normalizeGraph(targetNatural),
+              );
+            } finally {
+              for (const dispose of disposers) {
+                await dispose();
+              }
+            }
+          }),
+          { numRuns: RUNS, examples: [[BRIDGE_EXAMPLE]] },
+        );
+        expect(nonEmptyBaseAmbiguityRuns).toBeGreaterThan(0);
+      },
+    );
+  },
+);

--- a/packages/typegraph/tests/property/graph-merge/normalize.ts
+++ b/packages/typegraph/tests/property/graph-merge/normalize.ts
@@ -1,0 +1,338 @@
+/**
+ * The SINGLE normalization comparator for the determinism property test (T12).
+ *
+ * Determinism is meaningful only against a canonical representation: two merges
+ * of the same branch set in different orders must produce the same {@link
+ * MergeReport} and the same committed graph — but the raw values carry
+ * order-/time-sensitive noise that would defeat a naive `deepEqual`:
+ *
+ *   - The {@link MergeReport.provenance} field is a CLOSURE
+ *     (`byBranch(id) => …`), not data, so it cannot be structurally compared; it
+ *     is replaced by a materialized, sorted map keyed by the branches under test.
+ *   - Committed rows carry non-deterministic META — `created_at` / `updated_at`
+ *     (wall-clock) and `version` (write counter) — which differ between two
+ *     independent commits even when the logical result is identical. These are
+ *     STRIPPED, and every props bag is re-serialized through the same canonical,
+ *     recursively key-sorted JSON form so key-ordering noise cannot leak in.
+ *   - Every array in the report and the graph is sorted by a stable key so two
+ *     orderings that produce the same SET produce the same SEQUENCE.
+ *
+ * Centralizing both `normalizeReport` and `normalizeGraph` here avoids the
+ * inconsistent-equality smell of ad-hoc per-test comparators: the determinism
+ * gate asserts deep-equality over exactly these two canonical forms and nothing
+ * else.
+ */
+
+import type { GraphDef, Store } from "@nicia-ai/typegraph";
+import { getEdgeKinds, getNodeKinds } from "@nicia-ai/typegraph";
+
+import { canonicalizeProps } from "../../../src/graph-merge/canonical-props";
+import {
+  enumerateAllEdges,
+  enumerateAllNodes,
+} from "../../../src/graph-merge/state-diff";
+import type { BranchId, MergeReport } from "../../../src/graph-merge/types";
+
+/** Lexicographic comparator over two strings (ids, kinds, properties). */
+function compareStrings(left: string, right: string): number {
+  return (
+    left < right ? -1
+    : left > right ? 1
+    : 0
+  );
+}
+
+/**
+ * A property bag rendered to a canonical, recursively key-sorted JSON string, so
+ * two logically-equal bags compare equal regardless of key insertion order.
+ */
+function canonicalProps(props: Readonly<Record<string, unknown>>): string {
+  return canonicalizeProps(props);
+}
+
+/** One canonical conflicting value: branch id + its canonical-JSON value. */
+type NormalizedConflictValue = Readonly<{ branchId: string; value: string }>;
+
+/** A property/edge conflict reduced to its order-independent canonical fields. */
+type NormalizedConflict = Readonly<{
+  entityId: string;
+  kind: string;
+  property: string;
+  values: readonly NormalizedConflictValue[];
+  resolution: string;
+}>;
+
+/** An entity resolution reduced to its order-independent canonical fields. */
+type NormalizedResolution = Readonly<{
+  canonicalId: string;
+  kind: string;
+  memberIds: readonly string[];
+  branchOrigins: readonly string[];
+}>;
+
+/** A delete/modify conflict in canonical form. */
+type NormalizedDeleteModify = Readonly<{
+  entityId: string;
+  kind: string;
+  deletedBy: string;
+  modifiedBy: string;
+  resolution: string;
+}>;
+
+/** A type reconciliation in canonical form. */
+type NormalizedTypeReconciliation = Readonly<{
+  entityId: string;
+  fromTypes: readonly string[];
+  toType: string;
+}>;
+
+/** A dropped item in canonical form. */
+type NormalizedDropped = Readonly<{
+  kind: "edge" | "node";
+  id: string;
+  reason: string;
+}>;
+
+/** Per-branch provenance materialized from the report closure, sorted. */
+type NormalizedProvenance = Readonly<{
+  branchId: string;
+  nodeIds: readonly string[];
+  edgeIds: readonly string[];
+}>;
+
+/**
+ * A new-vs-base ambiguity event reduced to canonical `(kind, id)` identity strings,
+ * each list sorted, so a permutation-order-dependent base-guard report would surface
+ * as a determinism-gate failure (rather than being silently dropped from comparison).
+ */
+type NormalizedBaseAmbiguity = Readonly<{
+  baseIds: readonly string[];
+  memberIds: readonly string[];
+}>;
+
+/** The fully canonical, deep-equal-comparable form of a {@link MergeReport}. */
+export type NormalizedReport = Readonly<{
+  merged: Readonly<{ nodes: number; edges: number }>;
+  resolutions: readonly NormalizedResolution[];
+  conflicts: readonly NormalizedConflict[];
+  deleteModifyConflicts: readonly NormalizedDeleteModify[];
+  typeReconciliations: readonly NormalizedTypeReconciliation[];
+  dropped: readonly NormalizedDropped[];
+  baseAmbiguities: readonly NormalizedBaseAmbiguity[];
+  provenance: readonly NormalizedProvenance[];
+}>;
+
+/** A committed node reduced to id + kind + canonical props (meta stripped). */
+type NormalizedNode = Readonly<{
+  id: string;
+  kind: string;
+  props: string;
+}>;
+
+/** A committed edge reduced to its structural identity (meta stripped). */
+type NormalizedEdge = Readonly<{
+  id: string;
+  kind: string;
+  from: string;
+  to: string;
+  fromKind: string;
+  toKind: string;
+  props: string;
+}>;
+
+/** The fully canonical, deep-equal-comparable form of a committed graph. */
+export type NormalizedGraph = Readonly<{
+  nodes: readonly NormalizedNode[];
+  edges: readonly NormalizedEdge[];
+}>;
+
+/** Sorts conflicting values by `(branchId, value)`. */
+function normalizeConflictValues(
+  values: MergeReport["conflicts"][number]["values"],
+): readonly NormalizedConflictValue[] {
+  return values
+    .map((entry) => ({
+      branchId: entry.branchId,
+      value: JSON.stringify(entry.value),
+    }))
+    .sort((left, right) => {
+      const byBranch = compareStrings(left.branchId, right.branchId);
+      return byBranch === 0 ?
+          compareStrings(left.value, right.value)
+        : byBranch;
+    });
+}
+
+/**
+ * Reduces a {@link MergeReport} to a {@link NormalizedReport}: every array sorted
+ * by a stable key, the provenance closure materialized over the branches under
+ * test, and every conflicting value rendered to canonical JSON. Two merges of the
+ * same branch set in any order normalize to a deep-equal report.
+ *
+ * @param report The report returned by `merge`.
+ * @param branchIds The branch ids whose provenance to materialize (the branches
+ *   passed to `merge`). Sorted internally so order does not matter.
+ */
+export function normalizeReport<G extends GraphDef>(
+  report: MergeReport<G>,
+  branchIds: readonly BranchId[],
+): NormalizedReport {
+  const resolutions: readonly NormalizedResolution[] = report.resolutions
+    .map((resolution) => ({
+      canonicalId: resolution.canonicalId,
+      kind: resolution.kind,
+      memberIds: [...resolution.memberIds]
+        .map((id) => id as string)
+        .sort((left, right) => compareStrings(left, right)),
+      branchOrigins: [...resolution.branchOrigins]
+        .map((id) => id as string)
+        .sort((left, right) => compareStrings(left, right)),
+    }))
+    .sort((left, right) => compareStrings(left.canonicalId, right.canonicalId));
+
+  const conflicts: readonly NormalizedConflict[] = report.conflicts
+    .map((conflict) => ({
+      entityId: conflict.entityId,
+      kind: conflict.kind,
+      property: conflict.property,
+      values: normalizeConflictValues(conflict.values),
+      resolution: JSON.stringify(conflict.resolution),
+    }))
+    .sort((left, right) =>
+      compareStrings(
+        `${left.entityId}|${left.kind}|${left.property}`,
+        `${right.entityId}|${right.kind}|${right.property}`,
+      ),
+    );
+
+  const deleteModifyConflicts: readonly NormalizedDeleteModify[] =
+    report.deleteModifyConflicts
+      .map((conflict) => ({
+        entityId: conflict.entityId,
+        kind: conflict.kind,
+        deletedBy: conflict.deletedBy,
+        modifiedBy: conflict.modifiedBy,
+        resolution: conflict.resolution,
+      }))
+      .sort((left, right) =>
+        compareStrings(
+          `${left.entityId}|${left.kind}`,
+          `${right.entityId}|${right.kind}`,
+        ),
+      );
+
+  const typeReconciliations: readonly NormalizedTypeReconciliation[] =
+    report.typeReconciliations
+      .map((reconciliation) => ({
+        entityId: reconciliation.entityId,
+        fromTypes: [...reconciliation.fromTypes].sort((left, right) =>
+          compareStrings(left, right),
+        ),
+        toType: reconciliation.toType,
+      }))
+      .sort((left, right) => compareStrings(left.entityId, right.entityId));
+
+  const dropped: readonly NormalizedDropped[] = report.dropped
+    .map((item) => ({
+      kind: item.kind,
+      id: item.id,
+      reason: item.reason,
+    }))
+    .sort((left, right) =>
+      compareStrings(`${left.kind}|${left.id}`, `${right.kind}|${right.id}`),
+    );
+
+  const baseAmbiguities: readonly NormalizedBaseAmbiguity[] =
+    report.baseAmbiguities
+      .map((ambiguity) => ({
+        baseIds: ambiguity.baseIds
+          .map((identity) => `${identity.kind}|${identity.id as string}`)
+          .sort((left, right) => compareStrings(left, right)),
+        memberIds: ambiguity.memberIds
+          .map((identity) => `${identity.kind}|${identity.id as string}`)
+          .sort((left, right) => compareStrings(left, right)),
+      }))
+      .sort((left, right) =>
+        compareStrings(left.baseIds.join(","), right.baseIds.join(",")),
+      );
+
+  const provenance: readonly NormalizedProvenance[] = [...branchIds]
+    .sort((left, right) => compareStrings(left, right))
+    .map((branchId) => {
+      const contribution = report.provenance.byBranch(branchId);
+      return {
+        branchId: branchId,
+        nodeIds: [...contribution.nodeIds]
+          .map((id) => id as string)
+          .sort((left, right) => compareStrings(left, right)),
+        edgeIds: [...contribution.edgeIds]
+          .map((id) => id as string)
+          .sort((left, right) => compareStrings(left, right)),
+      };
+    });
+
+  return {
+    merged: { nodes: report.merged.nodes, edges: report.merged.edges },
+    resolutions,
+    conflicts,
+    deleteModifyConflicts,
+    typeReconciliations,
+    dropped,
+    baseAmbiguities,
+    provenance,
+  };
+}
+
+/**
+ * Reduces a committed store's LIVE graph to a {@link NormalizedGraph}: every live
+ * node/edge across every kind, with wall-clock / version meta stripped and props
+ * rendered to canonical JSON, sorted by id. Two merges of the same branch set in
+ * any order commit a deep-equal graph.
+ *
+ * Soft-deleted rows are excluded — a delete-wins outcome must compare equal to
+ * another delete-wins outcome whether the row physically exists (soft-deleted) or
+ * not, so the comparator looks only at the live projection.
+ */
+export async function normalizeGraph<G extends GraphDef>(
+  store: Store<G>,
+): Promise<NormalizedGraph> {
+  const nodeKinds = getNodeKinds(store.graph);
+  const edgeKinds = getEdgeKinds(store.graph);
+
+  const nodes: NormalizedNode[] = [];
+  for (const kind of nodeKinds) {
+    const rows = await enumerateAllNodes(store.backend, store.graphId, kind);
+    for (const row of rows) {
+      if (row.deleted_at !== undefined) {
+        continue;
+      }
+      const props = JSON.parse(row.props) as Record<string, unknown>;
+      nodes.push({ id: row.id, kind: row.kind, props: canonicalProps(props) });
+    }
+  }
+
+  const edges: NormalizedEdge[] = [];
+  for (const kind of edgeKinds) {
+    const rows = await enumerateAllEdges(store.backend, store.graphId, kind);
+    for (const row of rows) {
+      if (row.deleted_at !== undefined) {
+        continue;
+      }
+      const props = JSON.parse(row.props) as Record<string, unknown>;
+      edges.push({
+        id: row.id,
+        kind: row.kind,
+        from: row.from_id,
+        to: row.to_id,
+        fromKind: row.from_kind,
+        toKind: row.to_kind,
+        props: canonicalProps(props),
+      });
+    }
+  }
+
+  return {
+    nodes: nodes.sort((left, right) => compareStrings(left.id, right.id)),
+    edges: edges.sort((left, right) => compareStrings(left.id, right.id)),
+  };
+}

--- a/packages/typegraph/tsconfig.json
+++ b/packages/typegraph/tsconfig.json
@@ -9,10 +9,15 @@
       "@nicia-ai/typegraph": ["./src/index.ts"],
       "@nicia-ai/typegraph/interchange": ["./src/interchange/index.ts"],
       "@nicia-ai/typegraph/profiler": ["./src/profiler/index.ts"],
+      "@nicia-ai/typegraph/schema": ["./src/schema/index.ts"],
       "@nicia-ai/typegraph/indexes": ["./src/indexes/index.ts"],
+      "@nicia-ai/typegraph/graph-merge": ["./src/graph-merge/index.ts"],
       "@nicia-ai/typegraph/sqlite": ["./src/backend/sqlite/index.ts"],
       "@nicia-ai/typegraph/sqlite/local": ["./src/backend/sqlite/local.ts"],
-      "@nicia-ai/typegraph/postgres": ["./src/backend/postgres/index.ts"]
+      "@nicia-ai/typegraph/postgres": ["./src/backend/postgres/index.ts"],
+      "@nicia-ai/typegraph/postgres/pglite": [
+        "./src/backend/postgres/pglite.ts"
+      ]
     }
   },
   "include": ["src", "tests", "examples", "scripts", "tsup.config.ts"],

--- a/packages/typegraph/tsup.config.ts
+++ b/packages/typegraph/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "schema/index": "src/schema/index.ts",
     "indexes/index": "src/indexes/index.ts",
     "graph-extension/index": "src/graph-extension/index.ts",
+    "graph-merge/index": "src/graph-merge/index.ts",
     "backend/sqlite/index": "src/backend/sqlite/index.ts",
     "backend/sqlite/local": "src/backend/sqlite/local.ts",
     "backend/sqlite/libsql": "src/backend/sqlite/libsql.ts",

--- a/packages/typegraph/type-smoke/consumer.ts
+++ b/packages/typegraph/type-smoke/consumer.ts
@@ -13,6 +13,12 @@ import {
   type Store,
   type TemporalAlgorithmOptions,
 } from "@nicia-ai/typegraph";
+import type {
+  GraphBranch,
+  MakeBackend,
+  MergeOptions,
+} from "@nicia-ai/typegraph/graph-merge";
+import { branch, merge } from "@nicia-ai/typegraph/graph-merge";
 import type { SqliteTables } from "@nicia-ai/typegraph/sqlite";
 import { z } from "zod";
 
@@ -78,6 +84,8 @@ const graph = defineGraph({
 declare const store: Store<typeof graph>;
 declare const worksAtId: EdgeId<typeof worksAt>;
 declare const sqliteTables: SqliteTables;
+declare const makeBackend: MakeBackend;
+declare const branches: readonly GraphBranch<typeof graph>[];
 
 const nodeKinds = getNodeKinds(graph);
 const edgeKinds = getEdgeKinds(graph);
@@ -93,6 +101,19 @@ void store.nodes.Person.findByConstraint("email_unique", {
   email: "alice@example.com",
   name: "Alice",
 });
+
+const mergeOptions: MergeOptions<typeof graph> = {
+  resolve: {
+    Person: {
+      block: () => "person",
+      similarity: { kind: "fulltext", fields: ["name"] },
+      threshold: 0.8,
+    },
+  },
+};
+
+void branch(store, makeBackend);
+void merge(store, branches, mergeOptions);
 
 // @ts-expect-error - edge id brands cannot be mixed across edge kinds
 void store.edges.knows.getById(worksAtId);

--- a/packages/typegraph/vitest.config.ts
+++ b/packages/typegraph/vitest.config.ts
@@ -2,6 +2,27 @@ import { resolve } from "node:path";
 
 import { configDefaults, defineConfig } from "vitest/config";
 
+/**
+ * Test globs for the graph-merge subsystem. These suites boot an in-process
+ * PGlite (WASM Postgres) per fixture and run on BOTH backends, so they get their
+ * own project with file serialization + generous timeouts. The rest of the
+ * package keeps default parallelism and fast-fail timeouts.
+ */
+const GRAPH_MERGE_GLOBS = [
+  "tests/graph-merge/**/*.test.ts",
+  "tests/property/graph-merge/**/*.test.ts",
+];
+
+const SHARED_EXCLUDE = [
+  ...configDefaults.exclude,
+  // #140: workerd-only do-sqlite suite — runs via `test:do`
+  // (vitest.workers.config.ts), not the Node suite.
+  "tests/do-sqlite/**",
+  "**/dist/**",
+  "**/.{idea,git,cache,output,temp}/**",
+  "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc}.config.*",
+];
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -10,6 +31,10 @@ export default defineConfig({
         __dirname,
         "src/interchange/index.ts",
       ),
+      "@nicia-ai/typegraph/postgres/pglite": resolve(
+        __dirname,
+        "src/backend/postgres/pglite.ts",
+      ),
       "@nicia-ai/typegraph/postgres": resolve(
         __dirname,
         "src/backend/postgres/index.ts",
@@ -17,6 +42,11 @@ export default defineConfig({
       "@nicia-ai/typegraph/profiler": resolve(
         __dirname,
         "src/profiler/index.ts",
+      ),
+      "@nicia-ai/typegraph/schema": resolve(__dirname, "src/schema/index.ts"),
+      "@nicia-ai/typegraph/graph-merge": resolve(
+        __dirname,
+        "src/graph-merge/index.ts",
       ),
       "@nicia-ai/typegraph/sqlite/local": resolve(
         __dirname,
@@ -30,16 +60,6 @@ export default defineConfig({
     },
   },
   test: {
-    include: ["tests/**/*.test.ts"],
-    exclude: [
-      ...configDefaults.exclude,
-      // #140: workerd-only do-sqlite suite — runs via `test:do`
-      // (vitest.workers.config.ts), not the Node suite.
-      "tests/do-sqlite/**",
-      "**/dist/**",
-      "**/.{idea,git,cache,output,temp}/**",
-      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc}.config.*",
-    ],
     globals: false,
     coverage: {
       provider: "v8",
@@ -52,5 +72,31 @@ export default defineConfig({
         lines: 75,
       },
     },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "main",
+          include: ["tests/**/*.test.ts"],
+          // Graph-merge runs under its own (serialized) project below.
+          exclude: [...SHARED_EXCLUDE, ...GRAPH_MERGE_GLOBS],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "graph-merge",
+          include: GRAPH_MERGE_GLOBS,
+          exclude: SHARED_EXCLUDE,
+          // PGlite boots an in-process Postgres per fixture. Serialize files and
+          // use generous budgets so normal PGlite startup/cleanup latency does
+          // not masquerade as a correctness failure. Scoped to this project so
+          // the rest of the package keeps default parallelism + fast timeouts.
+          fileParallelism: false,
+          testTimeout: 60_000,
+          hookTimeout: 60_000,
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

TypeGraph gains a first-class **branch-and-merge** capability for graph state, shipped as the new `@nicia-ai/typegraph/graph-merge` subpath.

Real systems rarely edit one graph in one place. Multiple agents explore in parallel, importers ingest overlapping sources, reviewers stage changes, and offline/edge workers sync later. Each produces a divergent copy of the graph, and folding those copies back together is the hard part: the same real-world entity appears under different ids, relationships point at the now-duplicated copies, and concurrent edits disagree. Writing changes straight back accumulates duplicate entities and orphaned edges; reconciling by hand doesn't scale.

Graph Merge makes that reconciliation a primitive: **fork** a graph into an isolated working copy, **mutate** it freely, then **merge** it back into one canonical graph — with entity resolution, conflict handling, edge repointing, and provenance built in.

This belongs in TypeGraph core because correct reconciliation needs everything the store already owns: the schema and declared uniqueness constraints, indexes, ontology/subclass semantics, and backend transactions. A bolt-on layer would have to re-derive all of that and would inevitably drift from how the store actually enforces it.

## The workflow

```ts
import { branch, merge, unwrap } from "@nicia-ai/typegraph/graph-merge";

// 1. Fork the live graph into independent working copies.
const a = unwrap(await branch(store, makeBackend));
const b = unwrap(await branch(store, makeBackend));

// 2. Each copy is mutated in isolation (different agents, importers, reviewers…).
await a.store.nodes.Patient.create({ name: "Anna Rivera", mrn: "MRN-1" });
await b.store.nodes.Patient.create({ name: "Ana Rivera", mrn: "MRN-1" });

// 3. Merge them back. The two records resolve to one canonical patient,
//    their edges repoint onto it, and any disagreement is reported, not lost.
const report = unwrap(
  await merge(store, [a, b], {
    resolve: {
      Patient: {
        similarity: { kind: "fulltext", fields: ["name"] },
        threshold: 0.85,
      },
    },
  }),
);
```

## What ships

**Branching & isolation**

- `branch()` forks a base store into an independent, mutable working copy over a caller-provided backend; mutations never touch the base.
- Each branch is stamped with a `base@V` token (schema hash + live-content fingerprint) so a snapshot merge rejects a branch forked from a since-diverged base rather than committing against stale state.
- The working-copy strategy is pluggable (`WorkingCopyStrategy`); the default clones via TypeGraph's own export/import, so it stays backend-agnostic and preserves ids, props, and metadata.

**Merge & entity resolution**

- `merge()` folds one or more branches into a target graph (the base by default).
- Duplicate entities resolve by stable id, **declared unique constraints**, application **blocking keys**, and pluggable **similarity** — fulltext (trigram Dice), vector (embedding cosine), hybrid (weighted blend), or a custom scorer — gated by a per-kind threshold.
- Matched candidates cluster by single-link connected components (with an optional diameter guard and a per-kind comparison ceiling), collapse to one canonical survivor, and have their properties unioned.
- Kinds you don't configure under `resolve` still merge their new content by id — they simply skip fuzzy resolution.

**Conflicts & policies**

- Property disagreements surface in the merge report instead of being silently overwritten. Resolution is configurable: keep-and-flag (default), last-write-wins over a stable branch order, provenance-weighted, or a custom function.
- Base-vs-branch conflicts get a **separate** policy, so a fuzzy branch match can't quietly overwrite data that's already committed.
- Delete/modify conflicts — one branch deletes an inherited node/edge while another edits it — are detected and resolved by policy.
- A branch's intentional removal of an optional property is honored on both nodes and edges, not reverted to the base value.

**Edges & ontology**

- Edges of collapsed nodes are repointed onto the canonical survivor and deduped; edges to a finally-deleted endpoint are dropped and reported.
- Optional ontology type reconciliation merges subtype-compatible kinds through TypeGraph's subclass closure (e.g. a `SpecialistDoctor` and a `Doctor` referring to the same person).

**Incremental merge**

- `mergeIncremental()` handles the live-target case where the committed graph has advanced since a branch forked: it folds the live target in as a preferred committed branch (target-wins) and preflights destructive hazards — resurrecting a soft-deleted row, overwriting an edge's endpoints or kind, or a lossy base update.

**Provenance**

- The report records which branches contributed each merged node and edge; `persistProvenance` additionally upserts those contributions into a durable sidecar graph, queryable via `openProvenanceStore` / `readProvenance`.

**Guarantees**

- **Deterministic / order-independent** — merging the same branches in any order yields a deep-equal report and an identical committed graph. Resolution never consults wall-clock time; ties break on a stable branch order captured once.
- **Atomic** — the merge applies in a single store transaction.
- **Backend parity** — identical behavior on SQLite and PostgreSQL.

## Public surface

`@nicia-ai/typegraph/graph-merge` exports `branch()`, `merge()`, `mergeIncremental()`, the working-copy extension points, the durable-provenance helpers, the typed errors (`BaseVersionMismatchError`, `BranchError`, `MergeError`, …), and the stable option/report/strategy types. The phase-level algorithms stay internal.

## Docs & example

A guide (`graph-merge.md`) and a runnable FHIR reconciliation example (`examples/18-fhir-graph-merge.ts`) walk two independent ingestion agents writing overlapping patient/care records, then merge them into one canonical patient — resolving `Anna Rivera` / `Ana Rivera` via shared MRN plus name similarity, repointing their encounters and observations, and printing the conflict and provenance output.

## Notes

- Merge requires a transaction-capable backend (SQLite and PostgreSQL both qualify); it fails loudly rather than committing non-atomically.
- Vector and hybrid similarity require a configured embedder.
- `persistProvenance` is best-effort and post-commit — a persistence failure surfaces as a report warning, never a failed merge.
