### PR TITLE
Fix Rollup barrel import warnings

### DIFF
--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -20,8 +20,8 @@ import {
   StoreNotInitializedError,
   type StoreNotInitializedReason,
 } from "../../errors";
-import { type SqlDialect } from "../../query/dialect";
 import { type FulltextStrategy } from "../../query/dialect/fulltext-strategy";
+import { type SqlDialect } from "../../query/dialect/types";
 import { sortedReplacer } from "../../schema/canonical";
 import { sha256Hex } from "../../utils/hash";
 import { isMissingTableError } from "../../utils/sql-errors";

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -40,8 +40,8 @@ import {
 import {
   buildPostgresEdgeIndexBuilders,
   buildPostgresNodeIndexBuilders,
-  type IndexDeclaration,
-} from "../../../indexes";
+} from "../../../indexes/drizzle";
+import { type IndexDeclaration } from "../../../indexes/types";
 import { regconfig, tsvector } from "../columns/fulltext";
 
 /**

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -31,8 +31,8 @@ import {
 import {
   buildSqliteEdgeIndexBuilders,
   buildSqliteNodeIndexBuilders,
-  type IndexDeclaration,
-} from "../../../indexes";
+} from "../../../indexes/drizzle";
+import { type IndexDeclaration } from "../../../indexes/types";
 
 /**
  * Table name configuration.

--- a/packages/typegraph/src/indexes/compiler.ts
+++ b/packages/typegraph/src/indexes/compiler.ts
@@ -1,7 +1,8 @@
 import { type SQL, sql } from "drizzle-orm";
 
 import { type ValueType } from "../query/ast";
-import { getDialect, type SqlDialect } from "../query/dialect";
+import { getDialect } from "../query/dialect";
+import { type SqlDialect } from "../query/dialect/types";
 import { type JsonPointer, jsonPointer } from "../query/json-pointer";
 import {
   type EdgeIndexDeclaration,

--- a/packages/typegraph/src/indexes/ddl.ts
+++ b/packages/typegraph/src/indexes/ddl.ts
@@ -1,7 +1,8 @@
 import { type SQL, sql } from "drizzle-orm";
 import { CasingCache } from "drizzle-orm/casing";
 
-import { getDialect, type SqlDialect } from "../query/dialect";
+import { getDialect } from "../query/dialect";
+import { type SqlDialect } from "../query/dialect/types";
 import {
   compileEdgeIndexKeys,
   compileIndexWhere,

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -33,7 +33,8 @@ import {
   type TraversalDirection,
   type TraversalExpansion,
 } from "../ast";
-import { type SqlDialect, type SqlSchema } from "../compiler/index";
+import { type SqlSchema } from "../compiler/schema";
+import { type SqlDialect } from "../dialect/types";
 import { type JsonPointerInput } from "../json-pointer";
 import type {
   FulltextAccessor,

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -12,7 +12,7 @@ import {
   type SelectiveField,
   type VectorSimilarityPredicate,
 } from "../../ast";
-import { type DialectAdapter } from "../../dialect";
+import { type DialectAdapter } from "../../dialect/types";
 import {
   vectorMinScoreCondition,
   vectorScoreExpression,

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -38,8 +38,9 @@ export {
   type TemporalFilterOptions,
 } from "./temporal";
 
-// Re-export dialect types
-export { type DialectAdapter, getDialect, type SqlDialect } from "../dialect";
+// Re-export dialect helpers and types
+export { getDialect } from "../dialect";
+export { type DialectAdapter, type SqlDialect } from "../dialect/types";
 
 import { type SQL, sql } from "drizzle-orm";
 
@@ -52,14 +53,14 @@ import {
   type SetOperation,
   type VectorSimilarityPredicate,
 } from "../ast";
+import { getDialect } from "../dialect";
+import { type FulltextStrategy } from "../dialect/fulltext-strategy";
 import {
   type DialectAdapter,
   type DialectStandardQueryStrategy,
-  type FulltextStrategy,
-  getDialect,
   type SqlDialect,
-  type VectorStrategy,
-} from "../dialect";
+} from "../dialect/types";
+import { type VectorStrategy } from "../dialect/vector-strategy";
 import { emitStandardQuerySql } from "./emitter";
 import {
   buildLimitOffsetClause,

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -22,7 +22,8 @@ import {
   type ValueType,
   type VectorSimilarityPredicate,
 } from "../ast";
-import { type DialectAdapter, type VectorStrategy } from "../dialect";
+import { type DialectAdapter } from "../dialect/types";
+import { type VectorStrategy } from "../dialect/vector-strategy";
 import {
   joinJsonPointers,
   type JsonPointer,

--- a/packages/typegraph/src/query/compiler/set-operations.ts
+++ b/packages/typegraph/src/query/compiler/set-operations.ts
@@ -33,7 +33,8 @@ import {
   type QueryAst,
   type SetOperation,
 } from "../ast";
-import { type DialectAdapter, type VectorStrategy } from "../dialect";
+import { type DialectAdapter } from "../dialect/types";
+import { type VectorStrategy } from "../dialect/vector-strategy";
 import { type JsonPointer, jsonPointer } from "../json-pointer";
 import { emitSetOperationQuerySql } from "./emitter";
 import { runCompilerPass } from "./passes";

--- a/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
+++ b/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
@@ -5,7 +5,7 @@ import type {
   QueryAst,
   VectorSimilarityPredicate,
 } from "../ast";
-import { type DialectAdapter } from "../dialect";
+import { type DialectAdapter } from "../dialect/types";
 import {
   createTemporalFilterPass,
   resolveFulltextAwareLimit,

--- a/packages/typegraph/src/query/compiler/typed-json-extract.ts
+++ b/packages/typegraph/src/query/compiler/typed-json-extract.ts
@@ -1,6 +1,6 @@
 import { type SQL } from "drizzle-orm";
 
-import { type DialectAdapter } from "../dialect";
+import { type DialectAdapter } from "../dialect/types";
 import { type JsonPointer } from "../json-pointer";
 
 type JsonExtractFallback = "json" | "text";

--- a/packages/typegraph/src/query/execution/result-mapper.ts
+++ b/packages/typegraph/src/query/execution/result-mapper.ts
@@ -15,7 +15,7 @@ import type {
   SelectableNode,
   SelectContext,
 } from "../builder/types";
-import { type SqlDialect } from "../compiler/index";
+import { type SqlDialect } from "../dialect/types";
 
 /**
  * Transforms SQLite path columns from pipe-delimited strings to arrays.

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -35,13 +35,13 @@ import {
 import { type GraphDef, isKnownKind } from "../core/define-graph";
 import type { IndexEntity } from "../core/types";
 import { ConfigurationError, KindNotFoundError } from "../errors";
+import { generateIndexDDL } from "../indexes/ddl";
 import {
-  generateIndexDDL,
   type IndexDeclaration,
   type RelationalIndexDeclaration,
   type VectorIndexDeclaration,
-} from "../indexes";
-import { type SqlDialect } from "../query/dialect";
+} from "../indexes/types";
+import { type SqlDialect } from "../query/dialect/types";
 import { sortedReplacer } from "../schema/canonical";
 import { nowIso } from "../utils/date";
 import { sha256Hex } from "../utils/hash";


### PR DESCRIPTION
This PR removes the Rollup circular chunk warnings emitted during the TypeGraph build by replacing internal barrel imports with leaf-module imports.

The warnings were caused by internal files importing types through public barrels that also export runtime values and are separate tsup entrypoints. During declaration/chunk generation, Rollup saw those barrels and their source modules as dependencies of each other, then warned that the resulting chunks could have circular execution order.

## What Changed

- `backend/drizzle/schema/{sqlite,postgres}.ts` now import index builders from `indexes/drizzle` and `IndexDeclaration` from `indexes/types`.
- `indexes/{ddl,compiler}.ts` now import `SqlDialect` from `query/dialect/types` while keeping runtime `getDialect` from the dialect runtime barrel.
- Query compiler internals now import dialect types and vector/fulltext strategy types from their leaf modules instead of `query/dialect`.
- Query builder/execution types now import `SqlDialect`/`SqlSchema` from leaf modules instead of routing through `query/compiler/index`.
- Store index materialization now imports `generateIndexDDL` and index declaration types from leaf modules.

Public package exports remain unchanged; this only narrows internal dependency edges.
