### PR TITLE
Merge hardening: three-way law property tests, TOCTOU commit guards, real-Postgres lane.

### DIFF
--- a/.changeset/merge-commit-toctou-guard.md
+++ b/.changeset/merge-commit-toctou-guard.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Close the TOCTOU windows in graph-merge commits. A merge resolves its plan from reads taken before the commit transaction, so a write landing on the target in between could previously be committed over. Now, inside the commit transaction: `merge()` and `mergeAgainstBase()` re-validate the target's base@V content fingerprint, and `mergeIncremental()` re-runs its new-vs-base identity resolution (the unique-constraint and block-index probes). All three fail with `BaseVersionMismatchError` — instead of committing a stale plan or a duplicate entity — when the target changed in that window. Merge commits run at `SERIALIZABLE` isolation with bounded retry on serialization failures and deadlocks, making the guards race-free on multi-writer Postgres. `Store.transaction()` accepts optional `TransactionOptions` (isolation level) and `TransactionContext` exposes the transaction-scoped `backend`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,12 @@ jobs:
       - name: Unused code check
         run: pnpm test:unused
 
-  test-sqlite:
-    name: Test (SQLite, Node ${{ matrix.node-version }})
+  test-sqlite-unit:
+    name: Test Unit (SQLite, Node ${{ matrix.node-version }})
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
     if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -123,11 +123,48 @@ jobs:
       - name: Run unit tests
         run: pnpm turbo run test:unit
 
+  test-sqlite-property:
+    name: Test Property (SQLite, Node 24)
+    runs-on: ubuntu-24.04
+    needs: [detect-release-metadata-push]
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Run property tests
         run: pnpm turbo run test:property
 
+  test-sqlite-smoke:
+    name: Test Smoke (SQLite, Node 24)
+    runs-on: ubuntu-24.04
+    needs: [detect-release-metadata-push]
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Run SQLite perf sanity
-        if: ${{ matrix.node-version == 24 }}
         run: pnpm --filter @nicia-ai/typegraph-benchmarks perf:check
 
       - name: Run example smoke test
@@ -258,7 +295,9 @@ jobs:
     needs:
       - detect-release-metadata-push
       - lint-and-check
-      - test-sqlite
+      - test-sqlite-unit
+      - test-sqlite-property
+      - test-sqlite-smoke
       - test-coverage
       - test-typescript-compat
       - test-postgres

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -26,11 +26,17 @@ else
   POSTGRES_URL="$DEFAULT_POSTGRES_URL"
 fi
 
-# Run all postgres tests (backend-specific and integration).
+# Run all postgres tests (backend-specific, integration, and graph-merge).
 #
 # `--no-file-parallelism` serializes test-file execution: every PG test
 # suite targets the same `typegraph_test` database, and several files'
 # `beforeAll` hooks run schema-destructive DDL (DROP TABLE). Running
 # files in parallel is a recipe for flaky mid-test table disappearance.
+# (Graph-merge fixtures isolate per-fixture schemas, but they share the
+# serialized lane for the same connection-budget reasons.)
+#
+# With POSTGRES_URL set, the graph-merge backendMatrix() gains its
+# server-Postgres entry, so those suites run on SQLite, PGlite, AND the
+# production pg driver in this lane.
 echo "Running PostgreSQL tests..."
-POSTGRES_URL="$POSTGRES_URL" vitest run --no-file-parallelism tests/backends/postgres/ tests/backends/integration/
+POSTGRES_URL="$POSTGRES_URL" vitest run --no-file-parallelism tests/backends/postgres/ tests/backends/integration/ tests/graph-merge/ tests/property/graph-merge/

--- a/packages/typegraph/src/graph-merge/base-version.ts
+++ b/packages/typegraph/src/graph-merge/base-version.ts
@@ -35,7 +35,12 @@
 import { canonicalizeProps, parseRowProps } from "./canonical-props";
 import { compareStrings } from "./node-key";
 import { enumerateAllEdges, enumerateAllNodes } from "./state-diff";
-import type { GraphBackend, GraphDef, Store } from "./typegraph-internal";
+import type {
+  GraphBackend,
+  GraphDef,
+  Store,
+  TransactionBackend,
+} from "./typegraph-internal";
 import { getEdgeKinds, getNodeKinds, sha256Hex } from "./typegraph-internal";
 import { computeSchemaHash, serializeSchema } from "./typegraph-internal";
 import type { BaseVersion } from "./types";
@@ -118,14 +123,17 @@ const CONTENT_FINGERPRINT_BYTES = 16;
  * user-mutable row content, so a validity-only edit that leaves `updated_at`
  * unchanged must still move the token. Soft-deleted rows are intentionally
  * excluded — the fingerprint describes the live base a branch forks from.
+ *
+ * Takes the backend rather than a `Store` so the SAME fingerprint can be
+ * re-computed inside a commit transaction (via the tx-scoped backend) for the
+ * in-transaction `base@V` re-validation — the reads then observe the
+ * transaction's snapshot, not whatever a concurrent writer has since committed.
  */
-async function computeContentFingerprint<G extends GraphDef>(
-  store: Store<G>,
+export async function computeContentComponent<G extends GraphDef>(
+  backend: GraphBackend | TransactionBackend,
+  graphId: string,
+  graph: G,
 ): Promise<string> {
-  const backend = store.backend;
-  const graphId = store.graphId;
-  const graph = store.graph;
-
   const nodeKinds = getNodeKinds(graph);
   const edgeKinds = getEdgeKinds(graph);
 
@@ -202,9 +210,26 @@ export async function computeBaseVersion<G extends GraphDef>(
 ): Promise<BaseVersion> {
   const [schemaComponent, contentComponent] = await Promise.all([
     computeSchemaComponent(store),
-    computeContentFingerprint(store),
+    computeContentComponent(store.backend, store.graphId, store.graph),
   ]);
   return asBaseVersion(
     `${schemaComponent}${TOKEN_SEPARATOR}${contentComponent}`,
   );
+}
+
+/**
+ * Extracts the content-fingerprint component from a `base@V` token. The schema
+ * component is a fixed-width hex digest with no NUL byte, so the substring after
+ * the single NUL separator is exactly the content fingerprint.
+ *
+ * Used by the in-transaction re-validation: the SCHEMA component is a pure
+ * function of the in-memory graph definition (it cannot drift between the
+ * precondition check and the commit), so only the content component needs to be
+ * re-compared against live rows.
+ */
+export function contentComponentOf(version: BaseVersion): string {
+  const separatorIndex = (version as string).indexOf(TOKEN_SEPARATOR);
+  return separatorIndex === -1 ? version : (
+      (version as string).slice(separatorIndex + 1)
+    );
 }

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -2170,13 +2170,15 @@ async function validateIncrementalEdgeWrites<G extends GraphDef>(
     .filter((id) => !existingById.has(id))
     .sort((left, right) => compareStrings(left, right));
   if (notFound.length > 0) {
-    const perKind = await Promise.all(
-      Object.keys(target.graph.edges).map((kind) =>
-        edgeCollection(edgesApi, kind).getByIds(notFound, INCLUDE_TOMBSTONES),
-      ),
-    );
+    // Sequential: all queries share the same transaction client (a single
+    // pg PoolClient). Concurrent client.query() calls on a PoolClient queue
+    // with a deprecation warning in pg@8 and become an error in pg@9.
     const crossKindById = new Map<string, Edge>();
-    for (const rows of perKind) {
+    for (const kind of Object.keys(target.graph.edges)) {
+      const rows = await edgeCollection(edgesApi, kind).getByIds(
+        notFound,
+        INCLUDE_TOMBSTONES,
+      );
       for (const [index, id] of notFound.entries()) {
         const row = rows[index];
         if (row !== undefined && !crossKindById.has(id)) {

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -40,7 +40,12 @@
  * identical committed graph. T12 proves this with a fast-check shuffle property.
  */
 
-import { computeBaseVersion, computeSchemaComponent } from "./base-version";
+import {
+  computeBaseVersion,
+  computeContentComponent,
+  computeSchemaComponent,
+  contentComponentOf,
+} from "./base-version";
 import { blockNodes } from "./blocking";
 import { canonicalizeProps } from "./canonical-props";
 import type { CanonicalEntity, ClusterMember } from "./canonicalize";
@@ -101,6 +106,7 @@ import type {
   StagingSet,
 } from "./staging";
 import { stageBranches } from "./staging";
+import { withTxConflictRetry } from "./tx-retry";
 import type { ReconcileClusterInput } from "./type-reconcile";
 import { mostSpecificCommonKind, reconcileTypes } from "./type-reconcile";
 import type {
@@ -112,6 +118,8 @@ import type {
   NodeId,
   NodeType,
   Store,
+  TransactionBackend,
+  TransactionOptions,
   UniqueIntrospection,
 } from "./typegraph-internal";
 import type {
@@ -1271,6 +1279,7 @@ async function applyMergePlan<G extends GraphDef>(
 export async function commitPlan<G extends GraphDef>(
   target: Store<G>,
   plan: MergePlan<G>,
+  expectedBaseVersion?: BaseVersion,
 ): Promise<Readonly<{ nodes: number; edges: number }>> {
   if (!target.backend.capabilities.transactions) {
     throw new MergeError(
@@ -1278,13 +1287,70 @@ export async function commitPlan<G extends GraphDef>(
       { details: { capability: "transactions" } },
     );
   }
-  return target.transaction((tx) =>
-    applyMergePlan(
-      plan,
-      tx.nodes as unknown as TxNodes,
-      tx.edges as unknown as TxEdges,
-    ),
+  return withTxConflictRetry(() =>
+    target.transaction(async (tx) => {
+      // TOCTOU guard: the plan was resolved from reads taken OUTSIDE this
+      // transaction, so the target may have been written between the base@V
+      // precondition and this commit. Re-deriving the content fingerprint
+      // through the tx-scoped backend (this transaction's snapshot) and
+      // comparing it to the captured token proves the plan still describes the
+      // live target; SERIALIZABLE isolation makes the proof race-free — a
+      // concurrent write that invalidates these reads aborts one transaction
+      // with a retryable serialization failure instead of committing silently.
+      if (expectedBaseVersion !== undefined) {
+        await assertTargetUnchanged(tx.backend, target, expectedBaseVersion);
+      }
+      return applyMergePlan(
+        plan,
+        tx.nodes as unknown as TxNodes,
+        tx.edges as unknown as TxEdges,
+      );
+    }, MERGE_COMMIT_TX_OPTIONS),
   );
+}
+
+/**
+ * Isolation for the merge commit transaction. SERIALIZABLE closes the window
+ * between the in-transaction re-validation reads and COMMIT on multi-writer
+ * Postgres (SSI aborts a racing writer with SQLSTATE 40001, which
+ * {@link withTxConflictRetry} retries); SQLite and PGlite serialize writers by
+ * construction, and the SQLite backend ignores the option.
+ */
+const MERGE_COMMIT_TX_OPTIONS = {
+  isolationLevel: "serializable",
+} as const satisfies TransactionOptions;
+
+/**
+ * The in-transaction half of the base@V guard: recomputes the target's content
+ * fingerprint through the TRANSACTION-SCOPED backend and compares it to the
+ * token captured by the precondition (`merge()`) or at plan start
+ * (`mergeAgainstBase()`). The schema component cannot drift (it is a pure
+ * function of the in-memory graph definition), so only content is compared.
+ */
+async function assertTargetUnchanged<G extends GraphDef>(
+  txBackend: TransactionBackend,
+  target: Store<G>,
+  expectedBaseVersion: BaseVersion,
+): Promise<void> {
+  const liveContent = await computeContentComponent(
+    txBackend,
+    target.graphId,
+    target.graph,
+  );
+  const expectedContent = contentComponentOf(expectedBaseVersion);
+  if (liveContent !== expectedContent) {
+    throw new BaseVersionMismatchError(
+      "The merge target was modified between the base@V check and the commit transaction; the resolved plan no longer describes the live target and was not applied.",
+      {
+        details: {
+          expectedContentFingerprint: expectedContent,
+          liveContentFingerprint: liveContent,
+        },
+        suggestion:
+          "Re-run the merge (and re-branch if the divergence is real), or serialize writers against merges on this target.",
+      },
+    );
+  }
 }
 
 /**
@@ -1384,7 +1450,7 @@ function edgeCollection(edges: TxEdges, kind: string): EdgeCollectionLike {
 async function validateBaseVersions<G extends GraphDef>(
   target: Store<G>,
   branches: readonly GraphBranch<G>[],
-): Promise<Result<undefined, BaseVersionMismatchError>> {
+): Promise<Result<BaseVersion, BaseVersionMismatchError>> {
   const targetVersion = await computeBaseVersion(target);
   for (const branch of branches) {
     if (branch.base !== targetVersion) {
@@ -1402,7 +1468,7 @@ async function validateBaseVersions<G extends GraphDef>(
       );
     }
   }
-  return ok();
+  return ok(targetVersion);
 }
 
 /** Normalizes options, converting an invalid-option throw into a typed result. */
@@ -1431,6 +1497,7 @@ async function resolveMerge<G extends GraphDef>(
   options: NormalizedMergeOptions<G>,
   useBaseSources: boolean,
   incremental?: IncrementalConfig,
+  expectedBaseVersion?: BaseVersion,
 ): Promise<Result<MergeReport<G>, MergeError>> {
   // Reserved BranchIds are used for non-user contributions. Reject real branches
   // that try to mint them rather than silently corrupting conflict/provenance state.
@@ -1534,11 +1601,21 @@ async function resolveMerge<G extends GraphDef>(
     );
 
     // (9) commit to the target. Incremental mode commits through the guarded path
-    // (the existing-target-id write guard, §6.6); snapshot mode commits directly.
+    // (the existing-target-id write guard, §6.6); snapshot mode commits directly,
+    // re-validating the captured base@V inside the transaction (TOCTOU guard).
     const merged =
       incremental === undefined ?
-        await commitPlan(target, plan)
-      : await commitIncrementalPlan(target, plan);
+        await commitPlan(target, plan, expectedBaseVersion)
+      : await commitIncrementalPlan(target, plan, {
+          stagedNewByKind: newNodesByKind(staging),
+          options,
+          introspectionKinds,
+          // The committed (kind, id) keys the base sources matched at PLAN time;
+          // anything NEW the in-tx re-probe surfaces is a window write.
+          plannedBaseMatchKeys: new Set(
+            candidates.data.baseMembers.map((member) => mergeKeyOf(member)),
+          ),
+        });
 
     // (10) assemble the report. The full provenance records are always built in the
     // plan; the in-memory index is gated by `provenance`, and on-graph persistence
@@ -1642,13 +1719,24 @@ export async function merge<G extends GraphDef>(
   const options = normalized.data;
   const target = options.target ?? store;
 
-  // (1) base@V precondition — the snapshot contract.
+  // (1) base@V precondition — the snapshot contract. The validated token is
+  // re-checked INSIDE the commit transaction (see `commitPlan`), so a target
+  // write landing between this check and the commit fails typed instead of
+  // committing a stale plan.
   const precondition = await validateBaseVersions(target, branches);
   if (isErr(precondition)) {
     return err(precondition.error);
   }
 
-  return resolveMerge(store, target, branches, options, false);
+  return resolveMerge(
+    store,
+    target,
+    branches,
+    options,
+    false,
+    undefined,
+    precondition.data,
+  );
 }
 
 /**
@@ -1676,7 +1764,21 @@ export async function mergeAgainstBase<G extends GraphDef>(
   }
   const options = normalized.data;
   const target = options.target ?? store;
-  return resolveMerge(store, target, branches, options, true);
+
+  // No branch-level base@V precondition here (the synthetic scope's contract),
+  // but PLAN STABILITY still holds: the token captured before any planning
+  // read is re-validated inside the commit transaction, so the target must not
+  // move while THIS merge is in flight.
+  const expectedBaseVersion = await computeBaseVersion(target);
+  return resolveMerge(
+    store,
+    target,
+    branches,
+    options,
+    true,
+    undefined,
+    expectedBaseVersion,
+  );
 }
 
 // --- mergeIncremental: full fork-point-vs-live-target entry point (§6.6) -------
@@ -2154,6 +2256,123 @@ async function validateIncrementalEdgeWrites<G extends GraphDef>(
 }
 
 /**
+ * The reads `commitIncrementalPlan` needs to re-run the NEW-vs-BASE identity
+ * resolution INSIDE the commit transaction — the inputs to {@link
+ * collectBaseMatchKeys}, plus the set of committed `(kind, id)` keys those base
+ * sources matched at PLAN time. Comparing the two closes the identity-resolution
+ * TOCTOU window (see {@link assertBaseResolutionStable}).
+ */
+type IncrementalCommitGuard<G extends GraphDef> = Readonly<{
+  stagedNewByKind: ReadonlyMap<string, readonly StagedNewNode[]>;
+  options: NormalizedMergeOptions<G>;
+  introspectionKinds: ReadonlyMap<string, readonly UniqueIntrospection[]>;
+  plannedBaseMatchKeys: ReadonlySet<MergeKey>;
+}>;
+
+/**
+ * Re-runs the NEW-vs-BASE identity probes — each kind's unique constraints
+ * (`baseUnique`) and its declared block index (`baseKey`) — for the staged new
+ * nodes against `lookupStore`, returning the set of committed `(kind, id)` keys
+ * those probes surface. It computes the lookup keys from the SAME staged props
+ * the planner used (typegraph owns key derivation), so the result over the
+ * plan-time target reproduces `candidates.baseMembers`, and the result over the
+ * tx-snapshot target reveals any committed row that became a match in between.
+ *
+ * Probes are issued STRICTLY SEQUENTIALLY (one awaited query at a time): inside
+ * the commit transaction these run on the single tx-held client, where
+ * concurrent `client.query()` calls queue with a pg deprecation warning that
+ * becomes an error in pg@9.
+ */
+async function collectBaseMatchKeys<G extends GraphDef>(
+  lookupStore: BaseLookupStore,
+  guard: IncrementalCommitGuard<G>,
+): Promise<ReadonlySet<MergeKey>> {
+  const matched = new Set<MergeKey>();
+  for (const [kind, stagedNodes] of guard.stagedNewByKind) {
+    const resolveConfig = guard.options.resolve[kind];
+    // A kind with no resolve config has no base recall — it never pulls a
+    // committed row into scope, so it carries no identity-resolution TOCTOU.
+    if (resolveConfig === undefined) {
+      continue;
+    }
+    const collection = lookupStore.nodes[kind];
+    if (collection === undefined || stagedNodes.length === 0) {
+      continue;
+    }
+    const items = stagedNodes.map((staged) => ({ props: staged.node.props }));
+
+    for (const constraint of uniqueConstraintsFor(
+      guard.introspectionKinds,
+      kind,
+    )) {
+      const matches = await collection.bulkFindByConstraint(
+        constraint.name,
+        items,
+      );
+      for (const base of matches) {
+        if (base !== undefined) {
+          matched.add(mergeKeyOf(base));
+        }
+      }
+    }
+
+    if (resolveConfig.blockIndex !== undefined) {
+      const matchesByItem = await collection.bulkFindByIndex(
+        resolveConfig.blockIndex,
+        items,
+      );
+      for (const perItem of matchesByItem) {
+        for (const base of perItem) {
+          matched.add(mergeKeyOf(base));
+        }
+      }
+    }
+  }
+  return matched;
+}
+
+/**
+ * The identity-resolution half of the incremental TOCTOU guard. The planner
+ * resolves each branch addition against the target's committed rows from reads
+ * taken OUTSIDE this transaction (`baseUnique`/`baseKey` in candidate
+ * generation). A committed row sharing a branch addition's unique-constraint or
+ * block-index key that LANDS in the plan→commit window is invisible to the
+ * per-row write guards — they only re-fetch the plan's own write ids — so the
+ * stale plan would commit the addition under its own id, leaving a duplicate the
+ * base-source resolution would otherwise have collapsed. A unique-constraint
+ * collision is still caught at write time by the uniques side-table, but only as
+ * a late, opaque failure mid-apply; a non-unique BLOCK-INDEX collision has no
+ * such backstop and commits the duplicate SILENTLY. This guard refuses both
+ * early and typed, before any row is touched.
+ *
+ * Re-deriving the matched base keys through the TX-scoped store and comparing
+ * them to the plan-time set proves no new identity match appeared. SERIALIZABLE
+ * isolation makes the proof race-free on multi-writer Postgres: a concurrent
+ * insert that this read would have to see aborts one side with a retryable
+ * serialization failure; the retry re-runs this probe and fails typed.
+ */
+async function assertBaseResolutionStable<G extends GraphDef>(
+  lookupStore: BaseLookupStore,
+  guard: IncrementalCommitGuard<G>,
+): Promise<void> {
+  const liveKeys = await collectBaseMatchKeys(lookupStore, guard);
+  const appeared = [...liveKeys]
+    .filter((key) => !guard.plannedBaseMatchKeys.has(key))
+    .sort((left, right) => compareMergeKeys(left, right));
+  if (appeared.length === 0) {
+    return;
+  }
+  throw new BaseVersionMismatchError(
+    `mergeIncremental() resolved its branch additions against the target as of planning, but ${appeared.length} committed row(s) matching a branch addition's identity key (a unique constraint or block index) were inserted before the commit transaction. Committing the plan would create duplicate entities the base-source resolution would otherwise have collapsed.`,
+    {
+      details: { appeared },
+      suggestion:
+        "Re-run mergeIncremental(); the re-planned merge resolves the branch additions against the now-committed rows.",
+    },
+  );
+}
+
+/**
  * The full incremental commit path (§6.6). The planner has already folded the live
  * target in as a preferred synthetic branch, so this path preflights destructive
  * row hazards inside the target transaction and then applies the normal merge plan.
@@ -2161,6 +2380,7 @@ async function validateIncrementalEdgeWrites<G extends GraphDef>(
 async function commitIncrementalPlan<G extends GraphDef>(
   target: Store<G>,
   plan: MergePlan<G>,
+  guard: IncrementalCommitGuard<G>,
 ): Promise<Readonly<{ nodes: number; edges: number }>> {
   if (!target.backend.capabilities.transactions) {
     throw new MergeError(
@@ -2169,13 +2389,24 @@ async function commitIncrementalPlan<G extends GraphDef>(
     );
   }
 
-  return target.transaction(async (tx) => {
-    const nodesApi = tx.nodes as unknown as TxNodes;
-    const edgesApi = tx.edges as unknown as TxEdges;
-    await validateIncrementalNodeWrites(target, nodesApi, plan);
-    await validateIncrementalEdgeWrites(target, edgesApi, plan);
-    return applyMergePlan(plan, nodesApi, edgesApi);
-  });
+  // SERIALIZABLE + retry for the same reason as `commitPlan`: the per-row
+  // guards read inside this transaction, and SSI turns a concurrent write that
+  // invalidates those reads into a retryable abort instead of a lost update.
+  // Every retry re-runs the guards, so a real hazard fails typed, never stale.
+  return withTxConflictRetry(() =>
+    target.transaction(async (tx) => {
+      const nodesApi = tx.nodes as unknown as TxNodes;
+      const edgesApi = tx.edges as unknown as TxEdges;
+      // Identity-resolution TOCTOU guard: the base-source lookups ran OUTSIDE
+      // this transaction, so re-derive them here (tx snapshot) and refuse the
+      // plan if a matching committed row appeared in the window. `tx` exposes
+      // the same `.nodes` collection record a `BaseLookupStore` needs.
+      await assertBaseResolutionStable(tx as unknown as BaseLookupStore, guard);
+      await validateIncrementalNodeWrites(target, nodesApi, plan);
+      await validateIncrementalEdgeWrites(target, edgesApi, plan);
+      return applyMergePlan(plan, nodesApi, edgesApi);
+    }, MERGE_COMMIT_TX_OPTIONS),
+  );
 }
 
 /**

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -33,6 +33,7 @@ import type {
   NodeId,
   NodeType,
   Store,
+  TransactionBackend,
 } from "./typegraph-internal";
 import { getEdgeKinds, getNodeKinds } from "./typegraph-internal";
 
@@ -155,10 +156,16 @@ export type StateDiff = Readonly<{
 
 /**
  * Enumerates EVERY node of `kind` for `graphId` (live and soft-deleted) via
- * keyset pagination on `id`. Returns rows in ascending `id` order.
+ * keyset pagination on `id`. Returns rows ascending in the BACKEND's own id
+ * ordering — byte order on SQLite/PGlite, the database collation on server
+ * Postgres. That order is deterministic and pagination-consistent (the cursor
+ * comparison uses the same collation as ORDER BY), but it is NOT guaranteed to
+ * equal JS code-unit order for mixed-case ids; consumers needing a canonical
+ * cross-backend order sort in JS (as `stateDiff` and the base@V fingerprint
+ * do).
  */
 export async function enumerateAllNodes(
-  backend: GraphBackend,
+  backend: GraphBackend | TransactionBackend,
   graphId: string,
   kind: string,
 ): Promise<readonly NodeRow[]> {
@@ -188,10 +195,12 @@ export async function enumerateAllNodes(
  * Enumerates EVERY edge of `kind` for `graphId` (live and soft-deleted) via
  * keyset pagination on the unique `id` (a TOTAL order), so paging can neither
  * skip nor duplicate a row regardless of how many edges share a `created_at`.
- * Returns rows in ascending `id` order. Mirrors {@link enumerateAllNodes}.
+ * Returns rows ascending in the backend's own id ordering (see
+ * {@link enumerateAllNodes} for the collation caveat). Mirrors
+ * {@link enumerateAllNodes}.
  */
 export async function enumerateAllEdges(
-  backend: GraphBackend,
+  backend: GraphBackend | TransactionBackend,
   graphId: string,
   kind: string,
 ): Promise<readonly EdgeRow[]> {

--- a/packages/typegraph/src/graph-merge/tx-retry.ts
+++ b/packages/typegraph/src/graph-merge/tx-retry.ts
@@ -1,0 +1,102 @@
+/**
+ * Bounded retry for the merge commit transaction.
+ *
+ * The commit runs at `SERIALIZABLE` isolation (see `commitPlan` /
+ * `commitIncrementalPlan`): under Postgres SSI a concurrent write that
+ * invalidates the transaction's reads aborts one side with SQLSTATE 40001
+ * (serialization failure); lock ordering between concurrent merges can also
+ * surface 40P01 (deadlock). Both are TRANSIENT — the transaction did not
+ * commit, and re-running it is the documented client protocol — so the commit
+ * is retried a bounded number of times. The in-transaction `base@V`
+ * re-validation runs on every attempt, so a retry that lands after a REAL
+ * divergence fails deterministically with `BaseVersionMismatchError` instead
+ * of committing a stale plan.
+ *
+ * SQLite and PGlite serialize writers (single connection), so retryable
+ * conflicts cannot occur there and the wrapper is pass-through in practice.
+ */
+
+import { MergeError } from "./errors";
+
+/** SQLSTATEs that mean "transaction aborted, safe to re-run verbatim". */
+const RETRYABLE_SQLSTATES: ReadonlySet<string> = new Set(["40001", "40P01"]);
+
+/**
+ * Driver-message fallback for errors whose SQLSTATE was lost in wrapping.
+ * Matches the fixed Postgres texts for serialization failure and deadlock.
+ */
+const RETRYABLE_MESSAGE_PATTERN =
+  /could not serialize access|deadlock detected/i;
+
+/** Bounded number of commit attempts before giving up with a typed error. */
+export const MAX_COMMIT_ATTEMPTS = 3;
+
+/**
+ * Whether `error` (or anything in its cause chain) is a retryable transaction
+ * conflict — a Postgres serialization failure (40001) or deadlock (40P01).
+ * Walks the `cause` chain because drivers and wrappers (pg → Drizzle →
+ * TypeGraph) re-wrap the original error; a visited set guards against cyclic
+ * cause chains.
+ */
+export function isRetryableTxConflict(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (
+    current !== undefined &&
+    current !== null &&
+    typeof current === "object" &&
+    !seen.has(current)
+  ) {
+    seen.add(current);
+    const candidate = current as Readonly<{
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    }>;
+    if (
+      typeof candidate.code === "string" &&
+      RETRYABLE_SQLSTATES.has(candidate.code)
+    ) {
+      return true;
+    }
+    if (
+      typeof candidate.message === "string" &&
+      RETRYABLE_MESSAGE_PATTERN.test(candidate.message)
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
+/**
+ * Runs `commit` (a function that opens and completes ONE transaction attempt),
+ * retrying up to {@link MAX_COMMIT_ATTEMPTS} times on retryable conflicts.
+ * Non-retryable errors propagate immediately; exhaustion raises a
+ * {@link MergeError} carrying the final conflict as its cause.
+ */
+export async function withTxConflictRetry<T>(
+  commit: () => Promise<T>,
+): Promise<T> {
+  let lastConflict: unknown;
+  for (let attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt += 1) {
+    try {
+      return await commit();
+    } catch (error) {
+      if (!isRetryableTxConflict(error)) {
+        throw error;
+      }
+      lastConflict = error;
+    }
+  }
+  throw new MergeError(
+    `Merge commit aborted by transaction conflicts (serialization failure or deadlock) on ${MAX_COMMIT_ATTEMPTS} consecutive attempts; giving up.`,
+    {
+      cause: lastConflict,
+      details: { attempts: MAX_COMMIT_ATTEMPTS },
+      suggestion:
+        "Reduce concurrent writes to the merge target, or serialize merges against it.",
+    },
+  );
+}

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -1,4 +1,8 @@
-export type { GraphBackend } from "../backend/types";
+export type {
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../backend/types";
 export { computeUniqueKey } from "../constraints";
 export {
   defineGraph,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -16,6 +16,7 @@ import {
   runOptionallyInTransaction,
   type SchemaVersionRow,
   type TransactionBackend,
+  type TransactionOptions,
 } from "../backend/types";
 import {
   type AllNodeTypes,
@@ -912,23 +913,37 @@ export class Store<G extends GraphDef> {
    *   // sequential, non-atomic — handle partial-failure recovery yourself
    * }
    * ```
+   *
+   * @param fn The callback run inside the transaction boundary.
+   * @param options Optional {@link TransactionOptions} forwarded to the
+   *   backend (e.g. `isolationLevel: "serializable"` on Postgres). Backends
+   *   without isolation-level support ignore it; the non-transactional
+   *   fallback ignores it entirely.
    */
   async transaction<T>(
     fn: (tx: TransactionContext<G>) => Promise<T>,
+    options?: TransactionOptions,
   ): Promise<T> {
     // Without a real transaction the tx-scoped collections would be
     // bound to the same backend as this.nodes/this.edges and exposing
     // the cached versions avoids rebuilding the proxies on every call.
+    // An isolation-level request in `options` is equally meaningless here.
     if (!this.#backend.capabilities.transactions) {
-      return fn({ nodes: this.nodes, edges: this.edges });
+      return fn({
+        nodes: this.nodes,
+        edges: this.edges,
+        backend: this.#backend,
+      });
     }
 
     // #134/#135: no gate here. The backend's transaction() wraps the
     // tx-scoped fulltext methods so the durable-marker assert fires at
     // point of use (a cached SELECT, never DDL). A transaction that
     // never touches fulltext requires no fulltext initialization.
-    return this.#backend.transaction(async (txBackend, sql) =>
-      fn(this.#buildTransactionContext(txBackend, sql)),
+    return this.#backend.transaction(
+      async (txBackend, sql) =>
+        fn(this.#buildTransactionContext(txBackend, sql)),
+      options,
     );
   }
 
@@ -1043,7 +1058,9 @@ export class Store<G extends GraphDef> {
       txEdgeOperations,
     );
 
-    return sql === undefined ? { nodes, edges } : { nodes, edges, sql };
+    return sql === undefined ?
+        { nodes, edges, backend: txBackend }
+      : { nodes, edges, sql, backend: txBackend };
   }
 
   // === Graph Lifecycle ===

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -7,6 +7,7 @@ import {
   type AdoptedTransaction,
   type EdgeRow,
   type NodeRow,
+  type TransactionBackend,
 } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
 import {
@@ -1039,6 +1040,13 @@ export type TransactionContext<G extends GraphDef> = Readonly<{
   nodes: GraphNodeCollections<G>;
   edges: GraphEdgeCollections<G>;
   sql?: AdoptedTransaction;
+  /**
+   * The transaction-scoped backend the collections are bound to, for advanced
+   * raw reads that must observe the transaction's snapshot (e.g. graph-merge's
+   * in-transaction base@V re-validation). On the non-transactional fallback it
+   * is the store's plain backend — reads work, but there is no snapshot.
+   */
+  backend: TransactionBackend;
 }>;
 
 // ============================================================

--- a/packages/typegraph/tests/graph-merge/commit-revalidation.test.ts
+++ b/packages/typegraph/tests/graph-merge/commit-revalidation.test.ts
@@ -1,0 +1,235 @@
+/**
+ * In-transaction base@V re-validation (the TOCTOU guard).
+ *
+ * `merge()` validates the base@V precondition and resolves the whole plan from
+ * reads taken OUTSIDE the commit transaction. A write landing on the target in
+ * that window used to be invisible: the stale plan committed anyway. The guard
+ * re-derives the target's content fingerprint INSIDE the commit transaction and
+ * refuses to apply a plan whose captured token no longer matches.
+ *
+ * The drift is injected deterministically through the `embedder` callback: it
+ * runs after the precondition check and before the commit — exactly the window
+ * a concurrent writer would hit — and writes straight to the target store.
+ * `mergeAgainstBase()` (no branch-level precondition) gets the same
+ * plan-stability guard from a token captured at plan start, so it is covered
+ * here too. The serialization-retry half of the commit path is unit-tested in
+ * `tx-retry.test.ts`; true multi-session SSI races need concurrent server
+ * connections that in-process backends cannot produce.
+ */
+
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
+import { merge, mergeAgainstBase } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import { enumerateAllNodes } from "../../src/graph-merge/state-diff";
+import type {
+  BranchId,
+  Embedder,
+  GraphBranch,
+  MergeOptions,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix, fakeEmbedder } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string(),
+  }),
+});
+
+const driftGraph = defineGraph({
+  id: "commit-revalidation-graph",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+
+type DriftGraph = typeof driftGraph;
+
+const BRANCH_A = asBranchId("branch-a");
+
+/**
+ * Hybrid similarity so `merge()` invokes the embedder during planning — the
+ * deterministic stand-in for "a concurrent writer landed mid-merge". The high
+ * threshold keeps the two distinct branch patients from actually clustering;
+ * the guard under test is orthogonal to entity resolution.
+ */
+function revalidationMergeOptions(
+  embedder: Embedder,
+): MergeOptions<DriftGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => (node as unknown as { birthDate?: string }).birthDate,
+        similarity: { kind: "hybrid", fields: ["name"] },
+        threshold: 0.95,
+      },
+    },
+    embedder,
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH_A],
+  };
+}
+
+/** Live patient ids in the store, sorted. */
+async function livePatientIds(
+  store: Store<DriftGraph>,
+): Promise<readonly string[]> {
+  const rows = await enumerateAllNodes(store.backend, store.graphId, "Patient");
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => row.id)
+    .sort();
+}
+
+describe.each(backendMatrix())(
+  "merge — in-transaction base@V re-validation [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    beforeEach(() => {
+      cleanups = [];
+    });
+
+    afterEach(async () => {
+      for (const cleanup of cleanups) {
+        await cleanup();
+      }
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function makeBranch(
+      baseStore: Store<DriftGraph>,
+      id: BranchId,
+    ): Promise<GraphBranch<DriftGraph>> {
+      return unwrap(
+        await branch<DriftGraph>(baseStore, () => makeBackend(), { id }),
+      );
+    }
+
+    /** Base with one anchor patient plus a branch that adds two more. */
+    async function seedScenario(): Promise<
+      Readonly<{
+        baseStore: Store<DriftGraph>;
+        branchA: GraphBranch<DriftGraph>;
+      }>
+    > {
+      const [baseStore] = await createStoreWithSchema(
+        driftGraph,
+        await makeBackend(),
+      );
+      await baseStore.nodes.Patient.bulkCreate([
+        {
+          id: "pat-base",
+          props: { name: "Wei Chen", birthDate: "1965-07-02" },
+        },
+      ]);
+
+      const branchA = await makeBranch(baseStore, BRANCH_A);
+      await branchA.store.nodes.Patient.bulkCreate([
+        {
+          id: "pat-robert",
+          props: { name: "Robert Smith", birthDate: "1974-03-09" },
+        },
+        {
+          id: "pat-maria",
+          props: { name: "Maria Gonzalez", birthDate: "1974-03-09" },
+        },
+      ]);
+      return { baseStore, branchA };
+    }
+
+    /**
+     * Wraps {@link fakeEmbedder} so the FIRST invocation also writes a patient
+     * straight to `target` — a deterministic concurrent write inside the
+     * precondition→commit window.
+     */
+    function driftingEmbedder(target: Store<DriftGraph>): Embedder {
+      let driftInjected = false;
+      return async (texts) => {
+        if (!driftInjected) {
+          driftInjected = true;
+          await target.nodes.Patient.bulkCreate([
+            {
+              id: "pat-drift",
+              props: { name: "Olu Adeyemi", birthDate: "1991-02-14" },
+            },
+          ]);
+        }
+        return fakeEmbedder(texts);
+      };
+    }
+
+    it("rejects the commit when the target was written mid-merge, applying nothing", async () => {
+      const { baseStore, branchA } = await seedScenario();
+
+      const result = await merge<DriftGraph>(
+        baseStore,
+        [branchA],
+        revalidationMergeOptions(driftingEmbedder(baseStore)),
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+        expect(result.error.code).toBe("GRAPH_MERGE_BASE_VERSION_MISMATCH");
+      }
+
+      // The drift write survives; the stale plan committed NOTHING on top.
+      expect(await livePatientIds(baseStore)).toEqual([
+        "pat-base",
+        "pat-drift",
+      ]);
+    });
+
+    it("commits normally when no write lands in the window (control)", async () => {
+      const { baseStore, branchA } = await seedScenario();
+
+      const result = await merge<DriftGraph>(
+        baseStore,
+        [branchA],
+        revalidationMergeOptions(fakeEmbedder),
+      );
+
+      expect(isOk(result)).toBe(true);
+      expect(await livePatientIds(baseStore)).toEqual([
+        "pat-base",
+        "pat-maria",
+        "pat-robert",
+      ]);
+    });
+
+    it("guards mergeAgainstBase the same way via the plan-start token", async () => {
+      const { baseStore, branchA } = await seedScenario();
+
+      const result = await mergeAgainstBase<DriftGraph>(
+        baseStore,
+        [branchA],
+        revalidationMergeOptions(driftingEmbedder(baseStore)),
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+      }
+      expect(await livePatientIds(baseStore)).toEqual([
+        "pat-base",
+        "pat-drift",
+      ]);
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -370,6 +370,59 @@ describe("repointEdges", () => {
     ]);
   });
 
+  it("repoints an INTRA-cluster edge a→b to a kept self-edge c*→c*", () => {
+    // An edge BETWEEN two cluster members: both endpoints repoint to the same
+    // canonical, producing a self-edge. The contract is that the relationship
+    // SURVIVES as c*→c* — it is not dropped (only edges to finally-deleted
+    // endpoints drop), so no merged relationship silently vanishes.
+    const staged = [stagedEdge({ id: "edge-1", from: "a", to: "b" })];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.dropped).toEqual([]);
+    expect(result.edges).toHaveLength(1);
+    const edge = result.edges[0]!;
+    expect(edge.fromId).toBe("a");
+    expect(edge.toId).toBe("a");
+    expect(edge.id).toBe("edge-1");
+  });
+
+  it("dedupes the reversed intra-cluster pair a→b and b→a into ONE self-edge", () => {
+    // Once {a, b} collapse, BOTH directions repoint to the same (c*, type, c*)
+    // identity, so with equal props the pair dedupes to a single self-edge —
+    // the original direction is deliberately unrecoverable after the collapse.
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "a", to: "b", branchId: BRANCH_A }),
+      stagedEdge({ id: "edge-2", from: "b", to: "a", branchId: BRANCH_B }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.dropped).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+    expect(result.edges).toHaveLength(1);
+    const edge = result.edges[0]!;
+    expect(edge.fromId).toBe("a");
+    expect(edge.toId).toBe("a");
+    expect(edge.id).toBe("edge-1");
+    expect(edge.mergedIds.map((id) => id as string).sort()).toEqual([
+      "edge-1",
+      "edge-2",
+    ]);
+  });
+
   it("produces an identical result across shuffled input-edge order", () => {
     const staged = [
       stagedEdge({ id: "edge-1", from: "x", to: "a", props: { weight: 1 } }),

--- a/packages/typegraph/tests/graph-merge/incremental-toctou.test.ts
+++ b/packages/typegraph/tests/graph-merge/incremental-toctou.test.ts
@@ -1,0 +1,300 @@
+/**
+ * In-transaction NEW-vs-BASE identity re-resolution (the incremental TOCTOU guard).
+ *
+ * `mergeIncremental()` resolves each branch addition against the target's
+ * committed rows from `baseUnique`/`baseKey` lookups taken OUTSIDE the commit
+ * transaction. A committed row that shares a branch addition's identity key (a
+ * unique constraint or a declared block index) and LANDS in the plan→commit
+ * window is invisible to the per-row write guards — they only re-fetch the
+ * plan's own write ids — so the stale plan would commit the addition under its
+ * own id, leaving a duplicate the base-source resolution would otherwise have
+ * collapsed. Serializable isolation cannot catch a read taken before the
+ * transaction began, so the guard RE-DERIVES the matched base keys through the
+ * tx-scoped store and refuses any plan whose identity resolution drifted.
+ *
+ * The window write is injected deterministically by wrapping `target.transaction`
+ * (the seam the commit goes through): the first call writes the colliding row
+ * straight to the target, then delegates — exactly the window a concurrent
+ * writer would hit. The control case proves an UNRELATED advance (a row sharing
+ * neither identity key) is still tolerated: incremental merge is defined against
+ * an advancing target.
+ */
+
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  defineNodeIndex,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
+import { mergeIncremental } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), cohort: z.string(), mrn: z.string() }),
+});
+// The NEW-vs-BASE block key (`baseKey`): a declared, non-unique index.
+const patientCohort = defineNodeIndex(Patient, {
+  name: "patient_cohort_idx",
+  fields: ["cohort"],
+});
+
+const careGraph = defineGraph({
+  id: "incremental-toctou-care",
+  nodes: {
+    Patient: {
+      type: Patient,
+      // The definitional identity key (`baseUnique`). The uniques side-table
+      // would reject the duplicate WRITE late with an opaque error; the guard
+      // fires earlier and typed, before any row is touched.
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+  indexes: [patientCohort],
+});
+type CareGraph = typeof careGraph;
+type CareStore = GraphBranch<CareGraph>["store"];
+
+const BRANCH = asBranchId("provider-x");
+
+function mergeOptions(): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Patient: {
+        blockIndex: "patient_cohort_idx",
+        similarity: { kind: "fulltext", fields: ["name"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    onBasePropertyConflict: "flag",
+    branchOrder: [BRANCH],
+  };
+}
+
+/**
+ * Wraps `target.transaction` so the FIRST call writes `rows` straight to the
+ * target before delegating — a deterministic concurrent write inside the
+ * plan→commit window. Returns a restore fn so a re-run can commit cleanly.
+ * `injected` flips BEFORE the write so a transaction the write itself opens does
+ * not re-enter the injection.
+ */
+function injectWindowWrite(
+  target: CareStore,
+  rows: readonly Readonly<{
+    id: string;
+    props: { name: string; cohort: string; mrn: string };
+  }>[],
+): () => void {
+  const original = target.transaction.bind(target);
+  let injected = false;
+  (target as { transaction: unknown }).transaction = async (
+    fn: unknown,
+    options: unknown,
+  ) => {
+    if (!injected) {
+      injected = true;
+      await target.nodes.Patient.bulkCreate(rows);
+    }
+    return (original as (f: unknown, o: unknown) => unknown)(fn, options);
+  };
+  return () => {
+    (target as { transaction: unknown }).transaction = original;
+  };
+}
+
+async function patientIds(store: CareStore): Promise<readonly string[]> {
+  return (await store.nodes.Patient.find()).map((patient) => patient.id).sort();
+}
+
+describe.each(backendMatrix())(
+  "mergeIncremental — in-transaction identity re-resolution [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) {
+        await cleanup();
+      }
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function emptyStore(): Promise<CareStore> {
+      const [store] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+      );
+      return store;
+    }
+
+    async function forkWithAddition(
+      forkPoint: CareStore,
+      props: { name: string; cohort: string; mrn: string },
+    ): Promise<GraphBranch<CareGraph>> {
+      const provider = unwrap(
+        await branch<CareGraph>(forkPoint, () => makeBackend(), { id: BRANCH }),
+      );
+      await provider.store.nodes.Patient.bulkCreate([{ id: "new-1", props }]);
+      return provider;
+    }
+
+    it("REFUSES the commit when a same-block-index row appears in the window, applying nothing", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkWithAddition(forkPoint, {
+        name: "Anna Rivera",
+        cohort: "C1",
+        mrn: "MRN-1",
+      });
+      const target = await emptyStore();
+
+      // A near-duplicate-name, same-cohort row (a `baseKey` match the planner
+      // never saw), DIFFERENT mrn so only the block-index path is exercised.
+      const restore = injectWindowWrite(target, [
+        {
+          id: "drift-1",
+          props: { name: "Ana Rivera", cohort: "C1", mrn: "MRN-9" },
+        },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: mergeOptions(),
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+        expect(result.error.code).toBe("GRAPH_MERGE_BASE_VERSION_MISMATCH");
+      }
+      // The window write survives; the stale plan committed NOTHING — no duplicate.
+      expect(await patientIds(target)).toEqual(["drift-1"]);
+
+      // Re-running against the now-stable target re-plans WITH the row visible:
+      // the addition clusters onto it (base-id-wins), leaving a single Patient.
+      restore();
+      const rerun = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: mergeOptions(),
+      });
+      expect(isOk(rerun)).toBe(true);
+      expect(await patientIds(target)).toEqual(["drift-1"]);
+    });
+
+    // The uniques side-table PK would itself reject this duplicate at write
+    // time (an opaque late MergeError), so this case is not a SILENT duplicate
+    // like the block-index path. The guard's value here is a clean, early,
+    // typed refusal that touches no rows — and it unifies both paths.
+    it("REFUSES the commit when a same-unique-key row appears in the window", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkWithAddition(forkPoint, {
+        name: "Anna Rivera",
+        cohort: "C1",
+        mrn: "MRN-1",
+      });
+      const target = await emptyStore();
+
+      // Same mrn (the definitional `baseUnique` key) but a DIFFERENT cohort and
+      // an unrelated name, so ONLY the unique-constraint path is exercised.
+      injectWindowWrite(target, [
+        {
+          id: "drift-1",
+          props: { name: "Zachary Quux", cohort: "C9", mrn: "MRN-1" },
+        },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: mergeOptions(),
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+      }
+      // Nothing committed on top of the window write — no unique-key duplicate.
+      expect(await patientIds(target)).toEqual(["drift-1"]);
+    });
+
+    it("COMMITS normally when the window write shares NEITHER identity key (advancing target)", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkWithAddition(forkPoint, {
+        name: "Anna Rivera",
+        cohort: "C1",
+        mrn: "MRN-1",
+      });
+      const target = await emptyStore();
+
+      // An unrelated advance: different cohort AND different mrn. Incremental
+      // merge tolerates a target that moved on — only an identity-key MATCH trips.
+      injectWindowWrite(target, [
+        {
+          id: "drift-2",
+          props: { name: "Mara Lopez", cohort: "C9", mrn: "MRN-9" },
+        },
+      ]);
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: mergeOptions(),
+      });
+
+      expect(isOk(result)).toBe(true);
+      // Both survive: the addition committed under its own id, the advance kept.
+      expect(await patientIds(target)).toEqual(["drift-2", "new-1"]);
+    });
+
+    it("COMMITS normally when no write lands in the window (control)", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkWithAddition(forkPoint, {
+        name: "Anna Rivera",
+        cohort: "C1",
+        mrn: "MRN-1",
+      });
+      const target = await emptyStore();
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: mergeOptions(),
+      });
+
+      expect(isOk(result)).toBe(true);
+      expect(await patientIds(target)).toEqual(["new-1"]);
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/merge-rollback.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-rollback.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Atomicity contract for the SNAPSHOT `merge()` commit (the mergeIncremental
+ * counterpart lives in `merge-incremental.test.ts` "TRANSACTION: …").
+ *
+ * The merged plan commits inside a single `target.transaction(…)`: when a
+ * store-level constraint rejects a write mid-commit, EVERYTHING already applied
+ * in that transaction must roll back — a partially-merged graph (some branch
+ * nodes committed, their edges missing) is the failure mode the
+ * transaction-capability requirement exists to prevent.
+ *
+ * The forcing scenario: `primaryEncounter` carries cardinality "one". Each
+ * branch adds one primary encounter for the SAME inherited patient — valid in
+ * isolation, a cardinality violation in union. The commit writes the branch
+ * encounters first and only then the edge batch, so the constraint fires after
+ * real rows have been applied; the test proves those rows do not survive.
+ */
+
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { MergeError } from "../../src/graph-merge/errors";
+import { merge } from "../../src/graph-merge/merge";
+import { isErr, unwrap } from "../../src/graph-merge/result";
+import {
+  enumerateAllEdges,
+  enumerateAllNodes,
+} from "../../src/graph-merge/state-diff";
+import type { BranchId, GraphBranch } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+
+const primaryEncounter = defineEdge("primaryEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const rollbackGraph = defineGraph({
+  id: "merge-rollback-graph",
+  nodes: {
+    Patient: { type: Patient },
+    Encounter: { type: Encounter },
+  },
+  edges: {
+    primaryEncounter: {
+      type: primaryEncounter,
+      from: [Patient],
+      to: [Encounter],
+      cardinality: "one",
+    },
+  },
+});
+
+type RollbackGraph = typeof rollbackGraph;
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+/** Live row ids of `kind`, sorted, for asserting the post-rollback graph. */
+async function liveNodeIds(
+  store: Store<RollbackGraph>,
+  kind: string,
+): Promise<readonly string[]> {
+  const rows = await enumerateAllNodes(store.backend, store.graphId, kind);
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => row.id)
+    .sort();
+}
+
+async function liveEdgeIds(
+  store: Store<RollbackGraph>,
+  kind: string,
+): Promise<readonly string[]> {
+  const rows = await enumerateAllEdges(store.backend, store.graphId, kind);
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => row.id)
+    .sort();
+}
+
+describe.each(backendMatrix())(
+  "merge — mid-commit failure atomicity [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    beforeEach(() => {
+      cleanups = [];
+    });
+
+    afterEach(async () => {
+      for (const cleanup of cleanups) {
+        await cleanup();
+      }
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function makeBranch(
+      baseStore: Store<RollbackGraph>,
+      id: BranchId,
+    ): Promise<GraphBranch<RollbackGraph>> {
+      return unwrap(
+        await branch<RollbackGraph>(baseStore, () => makeBackend(), { id }),
+      );
+    }
+
+    it("TRANSACTION: a cardinality violation in the union rolls back every committed row", async () => {
+      const [baseStore] = await createStoreWithSchema(
+        rollbackGraph,
+        await makeBackend(),
+      );
+      await baseStore.nodes.Patient.bulkCreate([
+        { id: "pat-1", props: { name: "Robert Smith" } },
+      ]);
+
+      const branchA = await makeBranch(baseStore, BRANCH_A);
+      const branchB = await makeBranch(baseStore, BRANCH_B);
+
+      // Each branch adds ONE primary encounter for pat-1 — valid per branch
+      // (cardinality "one" holds inside each fork), violated by their union.
+      await branchA.store.nodes.Encounter.bulkCreate([
+        { id: "enc-a", props: { reason: "branch a" } },
+      ]);
+      await branchA.store.edges.primaryEncounter.bulkCreate([
+        {
+          id: "pe-a",
+          from: { kind: "Patient", id: "pat-1" },
+          to: { kind: "Encounter", id: "enc-a" },
+          props: { on: "2026-06-01" },
+        },
+      ]);
+      await branchB.store.nodes.Encounter.bulkCreate([
+        { id: "enc-b", props: { reason: "branch b" } },
+      ]);
+      await branchB.store.edges.primaryEncounter.bulkCreate([
+        {
+          id: "pe-b",
+          from: { kind: "Patient", id: "pat-1" },
+          to: { kind: "Encounter", id: "enc-b" },
+          props: { on: "2026-06-02" },
+        },
+      ]);
+
+      const result = await merge<RollbackGraph>(baseStore, [branchA, branchB], {
+        branchOrder: [BRANCH_A, BRANCH_B],
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(MergeError);
+        expect(result.error.message).toMatch(/cardinality/i);
+      }
+
+      // The commit had already upserted the branch encounters before the edge
+      // batch hit the constraint — the rollback must take them down with it.
+      expect(await liveNodeIds(baseStore, "Patient")).toEqual(["pat-1"]);
+      expect(await liveNodeIds(baseStore, "Encounter")).toEqual([]);
+      expect(await liveEdgeIds(baseStore, "primaryEncounter")).toEqual([]);
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge.test.ts
@@ -494,6 +494,42 @@ describe.each(backendMatrix())("merge — FHIR care graph [$name]", (entry) => {
     }
   });
 
+  it("rejects re-merging an already-merged branch — a successful merge advances base@V", async () => {
+    const { baseStore, branchA, branchB } = await seedScenario();
+
+    const first = await merge<CareGraph>(
+      baseStore,
+      [branchA],
+      fhirMergeOptions(),
+    );
+    expect(isOk(first)).toBe(true);
+
+    // The committed merge changed the target's content fingerprint, so the
+    // SAME branch cannot be merged twice (no double-application)...
+    const again = await merge<CareGraph>(
+      baseStore,
+      [branchA],
+      fhirMergeOptions(),
+    );
+    expect(isErr(again)).toBe(true);
+    if (isErr(again)) {
+      expect(again.error).toBeInstanceOf(BaseVersionMismatchError);
+    }
+
+    // ...and a SIBLING branch forked before the first merge landed is equally
+    // stale: sequential single-branch merges require a re-fork (or
+    // mergeIncremental). Merging siblings together is the snapshot contract.
+    const sibling = await merge<CareGraph>(
+      baseStore,
+      [branchB],
+      fhirMergeOptions(),
+    );
+    expect(isErr(sibling)).toBe(true);
+    if (isErr(sibling)) {
+      expect(sibling.error).toBeInstanceOf(BaseVersionMismatchError);
+    }
+  });
+
   // Regression (F20): a base row soft-deleted BEFORE branching must not come back
   // to life. The clone formerly exported `includeDeleted: true`, but interchange's
   // meta schema has no `deletedAt`, so the tombstone was lost and the row imported

--- a/packages/typegraph/tests/graph-merge/self-edge-collapse.test.ts
+++ b/packages/typegraph/tests/graph-merge/self-edge-collapse.test.ts
@@ -1,0 +1,261 @@
+/**
+ * End-to-end contract for INTRA-cluster edges: when entity resolution collapses
+ * two duplicates that are themselves connected by an edge, the edge survives as
+ * a SELF-EDGE on the canonical node — it is never dropped (only edges to
+ * finally-deleted endpoints drop), and a reversed pair dedupes to one edge.
+ *
+ * This pins the committed-graph shape for the importer-dedupe case: a source
+ * that records a relationship between two spellings of the same entity (e.g. a
+ * "knows"/"duplicateOf" link) keeps that relationship through the collapse
+ * rather than silently losing it. The unit-level repoint mechanics live in
+ * `edge-repoint.test.ts`; this suite proves the same contract through
+ * `merge()` and the committed store on both backends.
+ */
+
+import type { GraphBackend, Node, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import {
+  enumerateAllEdges,
+  enumerateAllNodes,
+} from "../../src/graph-merge/state-diff";
+import type {
+  BranchId,
+  GraphBranch,
+  MergeOptions,
+  SimilarityStrategy,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string(),
+  }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+  from: [Person],
+  to: [Person],
+});
+
+const socialGraph = defineGraph({
+  id: "self-edge-collapse-graph",
+  nodes: { Person: { type: Person } },
+  edges: {
+    knows: { type: knows, from: [Person], to: [Person] },
+  },
+});
+
+type SocialGraph = typeof socialGraph;
+
+const DEMO_THRESHOLD = 0.85;
+const BRANCH_A = asBranchId("branch-a");
+
+/** In-memory Dice trigram over `Person.name` (no embeddings). */
+const personNameSimilarity: SimilarityStrategy<SocialGraph> = {
+  kind: "fulltext",
+  fields: ["name"],
+};
+
+/** Blocks persons by shared birthDate, bounding the O(n²) comparisons. */
+function blockByBirthDate(node: Node): string | undefined {
+  return (node as unknown as { birthDate?: string }).birthDate;
+}
+
+function selfEdgeMergeOptions(): MergeOptions<SocialGraph> {
+  return {
+    resolve: {
+      Person: {
+        block: (node) => blockByBirthDate(node),
+        similarity: personNameSimilarity,
+        threshold: DEMO_THRESHOLD,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: [BRANCH_A],
+  };
+}
+
+/** Live `{ id, name }` for every Person, sorted by id. */
+async function livePersons(
+  store: Store<SocialGraph>,
+): Promise<readonly Readonly<{ id: string; name: unknown }>[]> {
+  const rows = await enumerateAllNodes(store.backend, store.graphId, "Person");
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => {
+      const props = JSON.parse(row.props) as Record<string, unknown>;
+      return { id: row.id, name: props.name };
+    })
+    .sort((left, right) =>
+      left.id < right.id ? -1
+      : left.id > right.id ? 1
+      : 0,
+    );
+}
+
+/** Live `{ id, from, to }` for every `knows` edge, sorted by id. */
+async function liveKnows(
+  store: Store<SocialGraph>,
+): Promise<readonly Readonly<{ id: string; from: string; to: string }>[]> {
+  const rows = await enumerateAllEdges(store.backend, store.graphId, "knows");
+  return rows
+    .filter((row) => row.deleted_at === undefined)
+    .map((row) => ({ id: row.id, from: row.from_id, to: row.to_id }))
+    .sort((left, right) =>
+      left.id < right.id ? -1
+      : left.id > right.id ? 1
+      : 0,
+    );
+}
+
+describe.each(backendMatrix())(
+  "merge — intra-cluster self-edge collapse [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    beforeEach(() => {
+      cleanups = [];
+    });
+
+    afterEach(async () => {
+      for (const cleanup of cleanups) {
+        await cleanup();
+      }
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function makeBranch(
+      baseStore: Store<SocialGraph>,
+      id: BranchId,
+    ): Promise<GraphBranch<SocialGraph>> {
+      return unwrap(
+        await branch<SocialGraph>(baseStore, () => makeBackend(), { id }),
+      );
+    }
+
+    /**
+     * One branch stages two near-duplicate persons ("Anna Rivera" / "Ana
+     * Rivera", same birthDate block, Dice 0.857 ≥ 0.85 → MUST cluster) plus the
+     * given `knows` edges between them. Canonical is the min id, "p-ana".
+     */
+    async function seedDuplicatesWithEdges(
+      edges: readonly Readonly<{
+        id: string;
+        from: string;
+        to: string;
+      }>[],
+    ): Promise<
+      Readonly<{
+        baseStore: Store<SocialGraph>;
+        branchA: GraphBranch<SocialGraph>;
+      }>
+    > {
+      const [baseStore] = await createStoreWithSchema(
+        socialGraph,
+        await makeBackend(),
+      );
+      const branchA = await makeBranch(baseStore, BRANCH_A);
+
+      await branchA.store.nodes.Person.bulkCreate([
+        {
+          id: "p-anna",
+          props: { name: "Anna Rivera", birthDate: "1974-03-09" },
+        },
+        {
+          id: "p-ana",
+          props: { name: "Ana Rivera", birthDate: "1974-03-09" },
+        },
+      ]);
+      await branchA.store.edges.knows.bulkCreate(
+        edges.map((edge) => ({
+          id: edge.id,
+          from: { kind: "Person", id: edge.from },
+          to: { kind: "Person", id: edge.to },
+          props: { since: "2020" },
+        })),
+      );
+
+      return { baseStore, branchA };
+    }
+
+    it("keeps an edge between two resolved duplicates as a self-edge on the canonical", async () => {
+      const { baseStore, branchA } = await seedDuplicatesWithEdges([
+        { id: "e-knows", from: "p-anna", to: "p-ana" },
+      ]);
+
+      const result = await merge<SocialGraph>(
+        baseStore,
+        [branchA],
+        selfEdgeMergeOptions(),
+      );
+
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      // The duplicates collapsed into the min-id canonical...
+      expect(result.data.resolutions).toHaveLength(1);
+      const resolution = result.data.resolutions[0]!;
+      expect(resolution.canonicalId).toBe("p-ana");
+      expect([...resolution.memberIds].sort()).toEqual(["p-ana", "p-anna"]);
+      expect(await livePersons(baseStore)).toEqual([
+        { id: "p-ana", name: "Ana Rivera" },
+      ]);
+
+      // ...and the edge BETWEEN them survives as a self-edge, never dropped.
+      expect(result.data.dropped).toEqual([]);
+      expect(await liveKnows(baseStore)).toEqual([
+        { id: "e-knows", from: "p-ana", to: "p-ana" },
+      ]);
+    });
+
+    it("dedupes a reversed equal-props edge pair between duplicates into ONE self-edge", async () => {
+      const { baseStore, branchA } = await seedDuplicatesWithEdges([
+        { id: "e-1", from: "p-anna", to: "p-ana" },
+        { id: "e-2", from: "p-ana", to: "p-anna" },
+      ]);
+
+      const result = await merge<SocialGraph>(
+        baseStore,
+        [branchA],
+        selfEdgeMergeOptions(),
+      );
+
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      // Both directions repoint to (p-ana, knows, p-ana) with equal props, so
+      // they dedupe to the min-id survivor: direction is unrecoverable once the
+      // endpoints collapse, and no edge-level conflict is recorded.
+      expect(result.data.dropped).toEqual([]);
+      expect(
+        result.data.conflicts.filter((conflict) => conflict.kind === "knows"),
+      ).toEqual([]);
+      expect(await liveKnows(baseStore)).toEqual([
+        { id: "e-1", from: "p-ana", to: "p-ana" },
+      ]);
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/state-diff.test.ts
+++ b/packages/typegraph/tests/graph-merge/state-diff.test.ts
@@ -165,14 +165,35 @@ describe.each(backendMatrix())("state-diff [$name]", (entry) => {
     const a = await store.nodes.Person.create({ name: "A" });
     const b = await store.nodes.Person.create({ name: "B" });
     const c = await store.nodes.Person.create({ name: "C" });
-    await store.edges.knows.create(a, b, { since: "1" });
-    await store.edges.knows.create(b, c, { since: "2" });
-    await store.edges.knows.create(c, a, { since: "3" });
+    // DELIBERATELY inserted out of id order, with explicit all-lowercase ids:
+    // every backend collation (SQLite byte order, PGlite "C", a server
+    // Postgres database under a linguistic/ICU collation) agrees on the
+    // ordering of same-shape lowercase ASCII ids, so the expected sequence is
+    // portable — mixed-case generated ids are NOT (e.g. "V" < "s" in code
+    // units but not under a case-insensitive linguistic collation).
+    await store.edges.knows.bulkCreate([
+      {
+        id: "e-ccc",
+        from: { kind: "Person", id: c.id },
+        to: { kind: "Person", id: a.id },
+        props: { since: "3" },
+      },
+      {
+        id: "e-aaa",
+        from: { kind: "Person", id: a.id },
+        to: { kind: "Person", id: b.id },
+        props: { since: "1" },
+      },
+      {
+        id: "e-bbb",
+        from: { kind: "Person", id: b.id },
+        to: { kind: "Person", id: c.id },
+        props: { since: "2" },
+      },
+    ]);
 
     const rows = await enumerateAllEdges(store.backend, store.graphId, "knows");
-    const ids = rows.map((row) => row.id);
-    expect(ids).toEqual([...ids].sort());
-    expect(ids).toHaveLength(3);
+    expect(rows.map((row) => row.id)).toEqual(["e-aaa", "e-bbb", "e-ccc"]);
   });
 
   it("detects no changes between a base and its faithful clone", async () => {

--- a/packages/typegraph/tests/graph-merge/test-utils.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.ts
@@ -1,17 +1,29 @@
+import { randomUUID } from "node:crypto";
+
 import type { GraphBackend } from "@nicia-ai/typegraph";
+import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
 import { createLocalPgliteBackend } from "@nicia-ai/typegraph/postgres/pglite";
 import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client, Pool } from "pg";
 
 import type { Embedder } from "../../src/graph-merge/types";
 
 /**
- * Dual-backend test fixtures for the graph-merge suite.
+ * Backend test fixtures for the graph-merge suite.
  *
- * Both backends run fully in-process: SQLite via better-sqlite3
- * (`createLocalSqliteBackend`) and Postgres via PGlite + pgvector
- * (`createLocalPgliteBackend`). There is NO Docker, NO `POSTGRES_URL`, and no
- * 5432 dependency — `backendMatrix()` returns both backends and both ALWAYS
- * run under plain `pnpm test`.
+ * Two backends run fully in-process and ALWAYS run under plain `pnpm test`:
+ * SQLite via better-sqlite3 (`createLocalSqliteBackend`) and Postgres via
+ * PGlite + pgvector (`createLocalPgliteBackend`) — no Docker, no
+ * `POSTGRES_URL`, no 5432 dependency.
+ *
+ * When `POSTGRES_URL` IS set (the `pnpm test:postgres` lane), a third entry
+ * runs every suite against the real server-Postgres backend (node-postgres
+ * `Pool` + Drizzle) — the production driver and transaction wiring PGlite
+ * cannot exercise. Each fixture gets its own throwaway schema on the shared
+ * server (merge fixtures must be EMPTY and several live simultaneously per
+ * test: a base plus its branches), created on `make()` and dropped by
+ * `cleanup()`.
  */
 
 /**
@@ -51,6 +63,83 @@ export async function createPgliteMergeBackend(): Promise<MergeBackendFixture> {
       await backend.close();
     },
   };
+}
+
+/**
+ * Creates a server-Postgres backend fixture on the shared `POSTGRES_URL`
+ * server, isolated in its own throwaway schema.
+ *
+ * The data pool pins `search_path` to the fixture schema (with `public` second
+ * so extension types like pgvector's `vector` still resolve); all TypeGraph
+ * DDL and DML are schema-relative, so every fixture sees an empty graph store.
+ * `backend.close()` ends the data pool; the one-connection admin pool drops
+ * the schema afterwards.
+ */
+export async function createServerPostgresMergeBackend(
+  postgresUrl: string,
+): Promise<MergeBackendFixture> {
+  const schemaName = `merge_test_${randomUUID().replaceAll("-", "")}`;
+  await runAdminQuery(postgresUrl, `CREATE SCHEMA "${schemaName}"`);
+
+  // `max: 2` keeps the shared server's connection budget intact: the property
+  // suites hold a base plus several branch fixtures alive at once, and a
+  // default-size pool (10) per fixture exhausts `max_connections` ("sorry,
+  // too many clients already"). Merge traffic is sequential — one connection
+  // serves it; the second is headroom so a transaction never self-starves.
+  const dataPool = new Pool({
+    connectionString: postgresUrl,
+    options: `-c search_path=${schemaName},public`,
+    max: 2,
+  });
+  const backend = createPostgresBackend(drizzle(dataPool));
+
+  // Force the DDL bootstrap NOW. The lazy bootstrap gate only fires when
+  // `typegraph_schema_versions` is missing — and on a shared server whose
+  // `public` schema already has the tables, search_path fall-through makes the
+  // probe SUCCEED against `public`, so no per-schema tables would ever be
+  // created and every fixture would silently share `public`'s data. Creating
+  // the full table set in the fixture schema up front shadows `public` for all
+  // subsequent unqualified references. (`public` stays second on the path so
+  // extension types — pgvector's `vector` — still resolve.)
+  if (backend.bootstrapTables === undefined) {
+    await backend.close();
+    throw new Error(
+      "createPostgresBackend() returned no bootstrapTables(); the schema-isolated merge fixture requires it.",
+    );
+  }
+  await backend.bootstrapTables();
+
+  return {
+    backend,
+    cleanup: async () => {
+      // `createPostgresBackend(db).close()` is deliberately a no-op — the
+      // caller owns the connection lifecycle — so the fixture must end its
+      // own pool or every fixture leaks its connections for the whole worker
+      // process (the shared server then hits "too many clients").
+      await backend.close();
+      await dataPool.end();
+      await runAdminQuery(postgresUrl, `DROP SCHEMA "${schemaName}" CASCADE`);
+    },
+  };
+}
+
+/**
+ * Runs one admin statement (schema create/drop) on a TRANSIENT connection.
+ * A per-fixture admin pool would hold an idle connection for the fixture's
+ * whole lifetime — multiplied across the property suites' simultaneous
+ * fixtures, enough to breach the shared server's connection limit.
+ */
+async function runAdminQuery(
+  postgresUrl: string,
+  statement: string,
+): Promise<void> {
+  const client = new Client({ connectionString: postgresUrl });
+  await client.connect();
+  try {
+    await client.query(statement);
+  } finally {
+    await client.end();
+  }
 }
 
 /** Fixed alphabet for {@link fakeEmbedder}: a–z plus space (27 dims). */
@@ -105,12 +194,14 @@ export type BackendMatrixEntry = Readonly<{
 }>;
 
 /**
- * Returns the full dual-backend matrix. Both entries always run — there is no
- * environment gating. SQLite's synchronous factory is wrapped so every entry
- * shares the async `make()` signature.
+ * Returns the backend matrix. The in-process SQLite and PGlite entries always
+ * run; the server-Postgres entry (production `pg` driver over Docker/CI
+ * Postgres) joins only when `POSTGRES_URL` is set — the `pnpm test:postgres`
+ * lane. SQLite's synchronous factory is wrapped so every entry shares the
+ * async `make()` signature.
  */
 export function backendMatrix(): readonly BackendMatrixEntry[] {
-  return [
+  const entries: BackendMatrixEntry[] = [
     {
       name: "SQLite",
       make: () => Promise.resolve(createSqliteMergeBackend()),
@@ -120,4 +211,12 @@ export function backendMatrix(): readonly BackendMatrixEntry[] {
       make: () => createPgliteMergeBackend(),
     },
   ];
+  const postgresUrl = process.env.POSTGRES_URL;
+  if (postgresUrl !== undefined && postgresUrl !== "") {
+    entries.push({
+      name: "Postgres",
+      make: () => createServerPostgresMergeBackend(postgresUrl),
+    });
+  }
+  return entries;
 }

--- a/packages/typegraph/tests/graph-merge/tx-retry.test.ts
+++ b/packages/typegraph/tests/graph-merge/tx-retry.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { MergeError } from "../../src/graph-merge/errors";
+import {
+  isRetryableTxConflict,
+  MAX_COMMIT_ATTEMPTS,
+  withTxConflictRetry,
+} from "../../src/graph-merge/tx-retry";
+
+/** A pg-driver-shaped error: `code` carries the SQLSTATE. */
+function pgError(code: string, message = "tx failed"): Error {
+  const error = new Error(message);
+  (error as Error & { code: string }).code = code;
+  return error;
+}
+
+describe("isRetryableTxConflict", () => {
+  it("detects a serialization failure (40001) by SQLSTATE", () => {
+    expect(isRetryableTxConflict(pgError("40001"))).toBe(true);
+  });
+
+  it("detects a deadlock (40P01) by SQLSTATE", () => {
+    expect(isRetryableTxConflict(pgError("40P01"))).toBe(true);
+  });
+
+  it("detects a conflict buried in a wrapped cause chain", () => {
+    const wrapped = new Error("Merge failed", {
+      cause: new Error("drizzle tx", { cause: pgError("40001") }),
+    });
+    expect(isRetryableTxConflict(wrapped)).toBe(true);
+  });
+
+  it("detects the fixed Postgres message when the SQLSTATE was lost", () => {
+    expect(
+      isRetryableTxConflict(
+        new Error(
+          "could not serialize access due to read/write dependencies among transactions",
+        ),
+      ),
+    ).toBe(true);
+    expect(isRetryableTxConflict(new Error("deadlock detected"))).toBe(true);
+  });
+
+  it("rejects non-conflict SQLSTATEs and plain errors", () => {
+    expect(isRetryableTxConflict(pgError("23505"))).toBe(false);
+    expect(isRetryableTxConflict(new Error("cardinality violation"))).toBe(
+      false,
+    );
+    expect(isRetryableTxConflict(null)).toBe(false);
+    expect(isRetryableTxConflict("40001")).toBe(false);
+  });
+
+  it("terminates on a cyclic cause chain", () => {
+    const first = new Error("a");
+    const second = new Error("b", { cause: first });
+    (first as Error & { cause: unknown }).cause = second;
+    expect(isRetryableTxConflict(first)).toBe(false);
+  });
+});
+
+describe("withTxConflictRetry", () => {
+  it("retries a retryable conflict and returns the eventual result", async () => {
+    let attempts = 0;
+    const result = await withTxConflictRetry(async () => {
+      attempts += 1;
+      if (attempts < MAX_COMMIT_ATTEMPTS) {
+        throw pgError("40001", "could not serialize access");
+      }
+      return "committed";
+    });
+    expect(result).toBe("committed");
+    expect(attempts).toBe(MAX_COMMIT_ATTEMPTS);
+  });
+
+  it("propagates a non-retryable error immediately, without retrying", async () => {
+    let attempts = 0;
+    await expect(
+      withTxConflictRetry(async () => {
+        attempts += 1;
+        throw pgError("23505", "unique violation");
+      }),
+    ).rejects.toThrow(/unique violation/);
+    expect(attempts).toBe(1);
+  });
+
+  it("gives up after the bounded attempts with a typed MergeError", async () => {
+    let attempts = 0;
+    const conflict = pgError("40001", "could not serialize access");
+    let caught: unknown;
+    try {
+      await withTxConflictRetry(async () => {
+        attempts += 1;
+        throw conflict;
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(attempts).toBe(MAX_COMMIT_ATTEMPTS);
+    expect(caught).toBeInstanceOf(MergeError);
+    const mergeError = caught as MergeError;
+    expect(mergeError.code).toBe("GRAPH_MERGE_ERROR");
+    expect(mergeError.cause).toBe(conflict);
+  });
+});

--- a/packages/typegraph/tests/property/graph-merge/arbitraries.ts
+++ b/packages/typegraph/tests/property/graph-merge/arbitraries.ts
@@ -1,11 +1,17 @@
 /**
- * Bounded fast-check arbitraries for the determinism property test (T12).
+ * Bounded fast-check arbitraries for the graph-merge property tests: the
+ * determinism gate (T12, {@link determinismScenarioArb}) and the three-way
+ * merge-law suite ({@link mergeLawScenarioArb}).
  *
- * The arbitrary produces a PURE DATA scenario spec — never a live store. The
- * property body materializes it twice (a base + N branches) and merges a natural
- * and a permuted branch order onto two fresh target clones, so the same logical
- * scenario drives both runs with identical node/edge ids (deep-equal is only
- * meaningful when both merges see the SAME ids).
+ * Every arbitrary produces a PURE DATA scenario spec — never a live store. The
+ * property body materializes it (a base + N branches) with EXPLICIT,
+ * scenario-derived ids, so independent materializations of the same scenario
+ * are id-for-id identical and their merge outcomes deep-comparable.
+ *
+ * For the determinism gate the body materializes the scenario twice and merges
+ * a natural and a permuted branch order onto two fresh target clones, so the
+ * same logical scenario drives both runs with identical node/edge ids
+ * (deep-equal is only meaningful when both merges see the SAME ids).
  *
  * The scenario deliberately exercises every order-sensitive merge path the gate
  * must prove commutative:
@@ -140,4 +146,97 @@ export const determinismScenarioArb: fc.Arbitrary<DeterminismScenario> =
     ontology: fc.record({
       pair: fc.constantFrom(...DOCTOR_NAME_PAIRS),
     }),
+  });
+
+/** What a law-scenario branch does to the inherited (edge-free) base patient. */
+export type InheritedAction = "delete" | "none" | "update";
+
+/**
+ * The scenario for the three-way merge-law properties (identity,
+ * diff-coherence, idempotence). Three patients drive it:
+ *
+ *   - INHERITED — an edge-free base patient the branch may leave alone, update
+ *     (mrn), or delete. Edge-free because the default `onDelete: "restrict"`
+ *     would reject deleting a node with live edges; the laws are about merge
+ *     semantics, not delete-behavior policy.
+ *   - ANCHOR — static base content (patient + encounter + edge) that must pass
+ *     through every merge untouched.
+ *   - ADDED — the branch's additions (patient + encounter + edge).
+ *
+ * The three names are drawn from {@link DISTINCT_NAMES} at pairwise-distinct
+ * indices, so no pair clears the 0.85 Dice threshold and NO entity resolution
+ * fires — the laws quantify over plain three-way diffs, where faithful
+ * application is the contract. (Resolution-triggering scenarios are the
+ * determinism gate's domain; ER merge is deliberately NOT claimed idempotent.)
+ */
+export type MergeLawScenario = Readonly<{
+  inherited: Readonly<{
+    name: string;
+    birthDate: string;
+    mrn: string;
+    updatedMrn: string;
+  }>;
+  anchor: Readonly<{
+    name: string;
+    birthDate: string;
+    encounterReason: string;
+    edgeOn: string;
+  }>;
+  added: Readonly<{
+    name: string;
+    birthDate: string;
+    mrn: string;
+    encounterReason: string;
+    edgeOn: string;
+  }>;
+  inheritedAction: InheritedAction;
+}>;
+
+/**
+ * The bounded merge-law scenario arbitrary. `updatedMrn` is DERIVED from the
+ * base mrn so an "update" action is GUARANTEED to change the canonicalized
+ * props (an equal value would silently turn the update path into a no-op).
+ */
+export const mergeLawScenarioArb: fc.Arbitrary<MergeLawScenario> = fc
+  .record({
+    nameOffset: fc.nat({ max: DISTINCT_NAMES.length - 1 }),
+    inheritedBirthDate: fc.constantFrom(...BIRTH_DATES),
+    anchorBirthDate: fc.constantFrom(...BIRTH_DATES),
+    addedBirthDate: fc.constantFrom(...BIRTH_DATES),
+    inheritedMrn: tokenArb,
+    addedMrn: tokenArb,
+    anchorReason: tokenArb,
+    addedReason: tokenArb,
+    edgeOn: fc.constantFrom(...BIRTH_DATES),
+    inheritedAction: fc.constantFrom<InheritedAction>(
+      "none",
+      "update",
+      "delete",
+    ),
+  })
+  .map((draw) => {
+    const nameAt = (offset: number): string =>
+      DISTINCT_NAMES[(draw.nameOffset + offset) % DISTINCT_NAMES.length]!;
+    return {
+      inherited: {
+        name: nameAt(0),
+        birthDate: draw.inheritedBirthDate,
+        mrn: draw.inheritedMrn,
+        updatedMrn: `${draw.inheritedMrn}-MOD`,
+      },
+      anchor: {
+        name: nameAt(1),
+        birthDate: draw.anchorBirthDate,
+        encounterReason: draw.anchorReason,
+        edgeOn: draw.edgeOn,
+      },
+      added: {
+        name: nameAt(2),
+        birthDate: draw.addedBirthDate,
+        mrn: draw.addedMrn,
+        encounterReason: draw.addedReason,
+        edgeOn: draw.edgeOn,
+      },
+      inheritedAction: draw.inheritedAction,
+    };
   });

--- a/packages/typegraph/tests/property/graph-merge/arbitraries.ts
+++ b/packages/typegraph/tests/property/graph-merge/arbitraries.ts
@@ -149,7 +149,7 @@ export const determinismScenarioArb: fc.Arbitrary<DeterminismScenario> =
   });
 
 /** What a law-scenario branch does to the inherited (edge-free) base patient. */
-export type InheritedAction = "delete" | "none" | "update";
+type InheritedAction = "delete" | "none" | "update";
 
 /**
  * The scenario for the three-way merge-law properties (identity,

--- a/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Three-way merge LAW properties (complements the T12 determinism gate).
+ *
+ * `merge()` claims Dolt-class deterministic THREE-WAY merge semantics — NOT
+ * CRDT semilattice (ACI) convergence. Entity-resolution merge is not
+ * associative or idempotent in general (similarity is not transitive), so the
+ * honest, checkable law set for an LCA-anchored merge `m(base, branches…)` is:
+ *
+ *   1. SYMMETRY        m(B, [a, b]) ≡ m(B, [b, a])
+ *      — covered by `determinism.test.ts` (shuffled branch order), including
+ *        the resolution-triggering paths.
+ *   2. IDENTITY        m(B, [ε]) ≡ B
+ *      — a branch that changed nothing merges as a no-op: the committed graph
+ *        is unchanged and the report is empty.
+ *   3. DIFF-COHERENCE  m(B, [B + d]) ≡ B + d
+ *      — a single branch's non-colliding diff is applied FAITHFULLY: the
+ *        target's live graph after merge equals the branch's live graph.
+ *   4. IDEMPOTENCE     m(B, [a, a′]) ≡ m(B, [a])
+ *      — merging an identical twin branch (same mutations under the same
+ *        explicit ids, forked from the same base) adds nothing.
+ *
+ * Laws 2–4 are asserted here over randomized base content and diffs
+ * ({@link mergeLawScenarioArb}), on both backends. The scenarios deliberately
+ * avoid similarity collisions (pairwise-distinct names below the Dice
+ * threshold) so the laws quantify over plain three-way diffs — the regime in
+ * which they are claimed to hold.
+ */
+
+import type { GraphBackend, Node, NodeId, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import fc from "fast-check";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../../src/graph-merge/branch";
+import { merge } from "../../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../../src/graph-merge/result";
+import type {
+  BranchId,
+  GraphBranch,
+  MergeOptions,
+  SimilarityStrategy,
+} from "../../../src/graph-merge/types";
+import { asBranchId } from "../../../src/graph-merge/types";
+import { backendMatrix } from "../../graph-merge/test-utils";
+import type { MergeLawScenario } from "./arbitraries";
+import { mergeLawScenarioArb } from "./arbitraries";
+import { normalizeGraph, normalizeReport } from "./normalize";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({
+    name: z.string(),
+    birthDate: z.string(),
+    mrn: z.string().optional(),
+  }),
+});
+
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const lawGraph = defineGraph({
+  id: "merge-law-graph",
+  nodes: {
+    Patient: { type: Patient },
+    Encounter: { type: Encounter },
+  },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+});
+
+type LawGraph = typeof lawGraph;
+
+const DEMO_THRESHOLD = 0.85;
+const BRANCH_A = asBranchId("law-branch-a");
+const BRANCH_B = asBranchId("law-branch-b");
+
+/**
+ * fast-check iterations. Each idempotence iteration boots up to 5 in-process
+ * backends (two bases + three branches), so CI runs fewer iterations — same
+ * rationale as the determinism gate's run budget.
+ */
+const LAW_RUNS = process.env.CI ? 8 : 16;
+
+/** In-memory Dice trigram over the `name` field (no embeddings). */
+const nameSimilarity: SimilarityStrategy<LawGraph> = {
+  kind: "fulltext",
+  fields: ["name"],
+};
+
+/** Blocks patients by `birthDate`, bounding the O(n²) comparisons. */
+function blockByBirthDate(node: Node): string | undefined {
+  return (node as unknown as { birthDate?: string }).birthDate;
+}
+
+/**
+ * Realistic merge options — resolution CONFIGURED (so the laws hold under the
+ * options real callers use), but the scenario data guarantees nothing clusters.
+ */
+function lawMergeOptions(
+  branchOrder: readonly BranchId[],
+): MergeOptions<LawGraph> {
+  return {
+    resolve: {
+      Patient: {
+        block: (node) => blockByBirthDate(node),
+        similarity: nameSimilarity,
+        threshold: DEMO_THRESHOLD,
+      },
+    },
+    onPropertyConflict: "flag",
+    onDeleteModifyConflict: "flag",
+    branchOrder,
+  };
+}
+
+/** Explicit, scenario-stable ids (never random — see arbitraries.ts header). */
+const INHERITED_ID = "pat-inherited";
+const ANCHOR_PATIENT_ID = "pat-anchor";
+const ANCHOR_ENCOUNTER_ID = "enc-anchor";
+const ANCHOR_EDGE_ID = "edge-anchor";
+const ADDED_PATIENT_ID = "pat-added";
+const ADDED_ENCOUNTER_ID = "enc-added";
+const ADDED_EDGE_ID = "edge-added";
+
+describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups) {
+      await cleanup();
+    }
+  });
+
+  async function makeBackend(
+    disposers: (() => Promise<void>)[],
+  ): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    disposers.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  /**
+   * Materializes the scenario's base store: the edge-free inherited patient
+   * plus the static anchor content (patient + encounter + edge) that every
+   * merge must pass through untouched. The inherited patient's BRANDED id is
+   * captured at creation (the id VALUE is identical across branch clones) so
+   * the diff can drive `update`/`delete` in any clone.
+   */
+  async function materializeBase(
+    scenario: MergeLawScenario,
+    disposers: (() => Promise<void>)[],
+  ): Promise<
+    Readonly<{
+      base: Store<LawGraph>;
+      inheritedNodeId: NodeId<typeof Patient>;
+    }>
+  > {
+    const [base] = await createStoreWithSchema(
+      lawGraph,
+      await makeBackend(disposers),
+    );
+
+    const [inherited] = await base.nodes.Patient.bulkCreate([
+      {
+        id: INHERITED_ID,
+        props: {
+          name: scenario.inherited.name,
+          birthDate: scenario.inherited.birthDate,
+          mrn: scenario.inherited.mrn,
+        },
+      },
+      {
+        id: ANCHOR_PATIENT_ID,
+        props: {
+          name: scenario.anchor.name,
+          birthDate: scenario.anchor.birthDate,
+        },
+      },
+    ]);
+    await base.nodes.Encounter.bulkCreate([
+      {
+        id: ANCHOR_ENCOUNTER_ID,
+        props: { reason: scenario.anchor.encounterReason },
+      },
+    ]);
+    await base.edges.hadEncounter.bulkCreate([
+      {
+        id: ANCHOR_EDGE_ID,
+        from: { kind: "Patient", id: ANCHOR_PATIENT_ID },
+        to: { kind: "Encounter", id: ANCHOR_ENCOUNTER_ID },
+        props: { on: scenario.anchor.edgeOn },
+      },
+    ]);
+
+    return { base, inheritedNodeId: inherited!.id };
+  }
+
+  /**
+   * Applies the scenario's diff `d` to a branch store: the inherited action
+   * (none / update / delete) plus the additions (patient + encounter + edge).
+   * Applied identically to twin branches so their staged diffs are id-for-id
+   * and prop-for-prop equal.
+   */
+  async function applyDiff(
+    store: Store<LawGraph>,
+    scenario: MergeLawScenario,
+    inheritedNodeId: NodeId<typeof Patient>,
+  ): Promise<void> {
+    switch (scenario.inheritedAction) {
+      case "update": {
+        await store.nodes.Patient.update(inheritedNodeId, {
+          mrn: scenario.inherited.updatedMrn,
+        });
+        break;
+      }
+      case "delete": {
+        await store.nodes.Patient.delete(inheritedNodeId);
+        break;
+      }
+      case "none": {
+        break;
+      }
+    }
+
+    await store.nodes.Patient.bulkCreate([
+      {
+        id: ADDED_PATIENT_ID,
+        props: {
+          name: scenario.added.name,
+          birthDate: scenario.added.birthDate,
+          mrn: scenario.added.mrn,
+        },
+      },
+    ]);
+    await store.nodes.Encounter.bulkCreate([
+      {
+        id: ADDED_ENCOUNTER_ID,
+        props: { reason: scenario.added.encounterReason },
+      },
+    ]);
+    await store.edges.hadEncounter.bulkCreate([
+      {
+        id: ADDED_EDGE_ID,
+        from: { kind: "Patient", id: ADDED_PATIENT_ID },
+        to: { kind: "Encounter", id: ADDED_ENCOUNTER_ID },
+        props: { on: scenario.added.edgeOn },
+      },
+    ]);
+  }
+
+  async function makeBranch(
+    base: Store<LawGraph>,
+    id: BranchId,
+    disposers: (() => Promise<void>)[],
+  ): Promise<GraphBranch<LawGraph>> {
+    return unwrap(
+      await branch<LawGraph>(base, () => makeBackend(disposers), { id }),
+    );
+  }
+
+  it(
+    "IDENTITY — an unchanged branch merges as a no-op",
+    { timeout: 300_000 },
+    async () => {
+      cleanups = [];
+      await fc.assert(
+        fc.asyncProperty(mergeLawScenarioArb, async (scenario) => {
+          const disposers: (() => Promise<void>)[] = [];
+          try {
+            const { base } = await materializeBase(scenario, disposers);
+            const before = await normalizeGraph(base);
+
+            const unchanged = await makeBranch(base, BRANCH_A, disposers);
+            const result = await merge<LawGraph>(
+              base,
+              [unchanged],
+              lawMergeOptions([BRANCH_A]),
+            );
+
+            expect(isOk(result)).toBe(true);
+            if (!isOk(result)) {
+              return;
+            }
+
+            const report = normalizeReport(result.data, [BRANCH_A]);
+            expect(report.merged).toEqual({ nodes: 0, edges: 0 });
+            expect(report.resolutions).toEqual([]);
+            expect(report.conflicts).toEqual([]);
+            expect(report.deleteModifyConflicts).toEqual([]);
+            expect(report.typeReconciliations).toEqual([]);
+            expect(report.dropped).toEqual([]);
+            expect(report.baseAmbiguities).toEqual([]);
+
+            const after = await normalizeGraph(base);
+            expect(after).toEqual(before);
+          } finally {
+            for (const dispose of disposers) {
+              await dispose();
+            }
+          }
+        }),
+        { numRuns: LAW_RUNS },
+      );
+    },
+  );
+
+  it(
+    "DIFF-COHERENCE — a single branch's non-colliding diff is applied faithfully",
+    { timeout: 300_000 },
+    async () => {
+      cleanups = [];
+      await fc.assert(
+        fc.asyncProperty(mergeLawScenarioArb, async (scenario) => {
+          const disposers: (() => Promise<void>)[] = [];
+          try {
+            const { base, inheritedNodeId } = await materializeBase(
+              scenario,
+              disposers,
+            );
+            const mutated = await makeBranch(base, BRANCH_A, disposers);
+            await applyDiff(mutated.store, scenario, inheritedNodeId);
+
+            const result = await merge<LawGraph>(
+              base,
+              [mutated],
+              lawMergeOptions([BRANCH_A]),
+            );
+
+            expect(isOk(result)).toBe(true);
+            if (!isOk(result)) {
+              return;
+            }
+
+            // The law itself: target's live graph == the branch's live graph.
+            const targetGraph = await normalizeGraph(base);
+            const branchGraph = await normalizeGraph(mutated.store);
+            expect(targetGraph).toEqual(branchGraph);
+
+            // With one branch and no similarity collisions, nothing may be
+            // resolved, conflicted, or dropped along the way.
+            const report = normalizeReport(result.data, [BRANCH_A]);
+            expect(report.resolutions).toEqual([]);
+            expect(report.conflicts).toEqual([]);
+            expect(report.deleteModifyConflicts).toEqual([]);
+            expect(report.dropped).toEqual([]);
+          } finally {
+            for (const dispose of disposers) {
+              await dispose();
+            }
+          }
+        }),
+        { numRuns: LAW_RUNS },
+      );
+    },
+  );
+
+  it(
+    "IDEMPOTENCE — merging an identical twin branch adds nothing",
+    { timeout: 300_000 },
+    async () => {
+      cleanups = [];
+      await fc.assert(
+        fc.asyncProperty(mergeLawScenarioArb, async (scenario) => {
+          const disposers: (() => Promise<void>)[] = [];
+          try {
+            // Twin run: two branches with the SAME diff under the SAME ids.
+            const twin = await materializeBase(scenario, disposers);
+            const twinA = await makeBranch(twin.base, BRANCH_A, disposers);
+            const twinB = await makeBranch(twin.base, BRANCH_B, disposers);
+            await applyDiff(twinA.store, scenario, twin.inheritedNodeId);
+            await applyDiff(twinB.store, scenario, twin.inheritedNodeId);
+
+            // Single run: one branch with the same diff, from an id-for-id
+            // identical second materialization of the same scenario.
+            const solo = await materializeBase(scenario, disposers);
+            const single = await makeBranch(solo.base, BRANCH_A, disposers);
+            await applyDiff(single.store, scenario, solo.inheritedNodeId);
+
+            const twinResult = await merge<LawGraph>(
+              twin.base,
+              [twinA, twinB],
+              lawMergeOptions([BRANCH_A, BRANCH_B]),
+            );
+            const singleResult = await merge<LawGraph>(
+              solo.base,
+              [single],
+              lawMergeOptions([BRANCH_A]),
+            );
+
+            expect(isOk(twinResult)).toBe(true);
+            expect(isOk(singleResult)).toBe(true);
+            if (!isOk(twinResult) || !isOk(singleResult)) {
+              return;
+            }
+
+            // The law itself: identical twins commit the same graph as one.
+            const twinGraph = await normalizeGraph(twin.base);
+            const singleGraph = await normalizeGraph(solo.base);
+            expect(twinGraph).toEqual(singleGraph);
+
+            // Identical props can never conflict, and identical diffs commit
+            // the same number of rows.
+            const twinReport = normalizeReport(twinResult.data, [
+              BRANCH_A,
+              BRANCH_B,
+            ]);
+            const singleReport = normalizeReport(singleResult.data, [BRANCH_A]);
+            expect(twinReport.conflicts).toEqual([]);
+            expect(singleReport.conflicts).toEqual([]);
+            expect(twinReport.deleteModifyConflicts).toEqual([]);
+            expect(twinReport.merged).toEqual(singleReport.merged);
+          } finally {
+            for (const dispose of disposers) {
+              await dispose();
+            }
+          }
+        }),
+        { numRuns: LAW_RUNS },
+      );
+    },
+  );
+});


### PR DESCRIPTION
Four pieces of merge hardening, each building on the last:

### 1. Three-way merge law property tests

Property-tests the LCA-anchored merge laws the determinism gate does not cover — **identity** (an unchanged branch merges as a no-op), **diff-coherence** (a single branch's non-colliding diff is applied faithfully), and **idempotence** (an identical twin branch adds nothing) — over randomized base content and diffs, on every backend. Symmetry stays covered by the existing determinism gate. These pin `merge()` to [Dolt](https://github.com/dolthub/dolt)-class deterministic three-way semantics, deliberately *not* CRDT semilattice claims (entity-resolution merge is not associative or idempotent in general).

### 2. Coverage-gap tests

Three previously-unpinned high-stakes behaviors:

- **Intra-cluster edges**: an edge between two duplicates that cluster survives as a *self-edge* on the canonical (never dropped); a reversed equal-props pair dedupes to one edge, direction unrecoverable. Unit + end-to-end.
- **Snapshot rollback**: a cardinality-`"one"` union violation proves plain `merge()` rolls back every row the commit had already applied (previously only tested on the `mergeIncremental` path).
- **Double-merge guard**: a successful merge advances base@V, so re-merging the same branch — or a stale sibling — fails with `BaseVersionMismatchError`.

### 3. TOCTOU-safe merge commits

A merge resolves its whole plan from reads taken *outside* the commit transaction, so a target write landing before `COMMIT` could be committed over. Two windows, both now closed inside the commit transaction:

- **base@V drift** (`merge()` / `mergeAgainstBase()`): re-derives the target's content fingerprint through the tx-scoped backend and fails typed (`BaseVersionMismatchError`, full rollback) when it no longer matches the captured token. (`merge()` previously committed the stale plan silently; `mergeAgainstBase()` had no protection at all.)
- **identity-resolution drift** (`mergeIncremental()`): re-runs its new-vs-base identity resolution — the unique-constraint and block-index probes — against the tx-scoped target and fails typed when a committed row matching a branch addition's identity key appeared after planning. Without it the stale plan committed the addition under its own id, leaving a duplicate the base-source resolution would otherwise have collapsed (silent for a block-index match; a late, opaque write error for a unique key).

Both run at **`SERIALIZABLE`** so a racing writer on multi-writer Postgres aborts retryably (SSI) instead of slipping between the re-read and `COMMIT`, with **bounded retry** on `40001`/`40P01` (cause-chain aware); every retry re-runs validation, so a real divergence fails deterministically. `mergeIncremental()` also keeps its per-row write guards (tombstone resurrection, lossy base update, cross-kind edge collision).

Plumbing: `Store.transaction()` accepts optional `TransactionOptions`; `TransactionContext` exposes the tx-scoped `backend`. Each guard is tested deterministically by injecting a concurrent write into the precondition→commit window — the base@V guard through the async embedder callback, the identity-resolution guard by wrapping `target.transaction()` — asserting typed rejection and zero stale writes on every backend.

### 4. Real-Postgres test lane

`backendMatrix()` gains an env-gated third entry (production `pg` Pool + Drizzle) when `POSTGRES_URL` is set; `test-postgres.sh` now runs the graph-merge suites. Schema-per-fixture isolation (merge needs several simultaneously-live empty stores per test), forced `bootstrapTables()` (the lazy missing-table probe resolves through to `public` on a shared server), capped + explicitly-ended pools (`createPostgresBackend(db).close()` is a deliberate no-op).

The lane immediately caught a real parity gap: under a linguistic database collation, Postgres `ORDER BY` over mixed-case ids ≠ JS code-unit order. Production code is unaffected (`stateDiff` and the base@V fingerprint re-sort in JS; keyset pagination is self-consistent); the over-asserting state-diff ordering test now uses collation-portable lowercase ids, and the `enumerateAll*` docs state the caveat.

The lane also surfaced a pg deprecation warning ("client.query() while already executing") in `validateIncrementalEdgeWrites`: the cross-kind collision guard was fanning out `getByIds` for every edge kind via `Promise.all` inside a `SERIALIZABLE` transaction, firing concurrent `client.query()` calls on the single `PoolClient` checked out for that transaction. Fixed by serializing the loop (harmless: this fallback only fires when a planned edge id is missing from its expected kind). The in-transaction identity re-resolution above follows the same single-client discipline.

## Notes for reviewers

- The self-edge semantics (keep, not drop; reversed pair collapses to one) were previously *unpinned silent behavior* — the new tests codify them as the contract. If dropping degenerate self-edges is preferred, those tests are the place to change.
