### PR TITLE
fix(schema): classify property type/removal changes as breaking migrations

### DIFF
--- a/.changeset/migration-breaking-classification.md
+++ b/.changeset/migration-breaking-classification.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Classify in-place property type changes and property removals as breaking schema
+migrations. The migration diff previously compared only added/removed property
+keys, so a changed property type (e.g. `string` → `number`) — the most common
+breaking change — auto-migrated silently, leaving stored rows that no longer
+satisfy the declared schema; edge property changes were unconditionally treated
+as safe. Node and edge property diffs now share one classifier: a removed
+property, an in-place type change, or a newly required property is breaking; a
+same-type constraint change is a non-blocking warning; only added optional
+properties stay safe.

--- a/.changeset/migration-breaking-classification.md
+++ b/.changeset/migration-breaking-classification.md
@@ -2,12 +2,17 @@
 "@nicia-ai/typegraph": patch
 ---
 
-Classify in-place property type changes and property removals as breaking schema
-migrations. The migration diff previously compared only added/removed property
-keys, so a changed property type (e.g. `string` → `number`) — the most common
-breaking change — auto-migrated silently, leaving stored rows that no longer
-satisfy the declared schema; edge property changes were unconditionally treated
-as safe. Node and edge property diffs now share one classifier: a removed
-property, an in-place type change, or a newly required property is breaking; a
-same-type constraint change is a non-blocking warning; only added optional
-properties stay safe.
+Classify incompatible property-schema changes as breaking schema migrations. The
+migration diff previously compared only the top-level JSON-Schema token of each
+property, so a changed property type (e.g. `string` → `number`), a changed array
+item type (`string[]` → `number[]`), a narrowed enum, or a type change nested
+inside an object all auto-migrated silently as a non-blocking warning, leaving
+stored rows that no longer satisfy the declared schema; edge property changes
+were unconditionally treated as safe. Node and edge property diffs now share one
+recursive, conservative classifier: a change is `safe` only when it can be proven
+non-breaking (a new optional property, a metadata-only edit, or an additive
+optional field nested inside an object). Everything else — a removed property, a
+newly required property, an in-place type change, a changed array item schema, an
+enum/const/composition change, a same-type constraint change, or a breaking
+change nested inside an object — is `breaking` and blocks auto-migration. The
+`warning` severity is no longer emitted for property changes.

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -395,24 +395,111 @@ function propertyTypeSignature(schema: JsonSchema): string {
 }
 
 /**
+ * Non-constraining JSON-Schema keywords: changing them cannot invalidate an
+ * existing stored value, so a diff limited to these is safe.
+ */
+const NON_CONSTRAINING_KEYWORDS = new Set([
+  "description",
+  "title",
+  "default",
+  "$schema",
+]);
+
+/** A copy of `schema` with the non-constraining keywords removed. */
+function stripSchemaMetadata(schema: JsonSchema): Record<string, unknown> {
+  const stripped: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (!NON_CONSTRAINING_KEYWORDS.has(key)) stripped[key] = value;
+  }
+  return stripped;
+}
+
+function isObjectSchema(schema: JsonSchema): boolean {
+  return schema.type === "object" || schema.properties !== undefined;
+}
+
+/**
+ * Whether replacing property schema `before` with `after` can invalidate an
+ * existing stored value — i.e. whether the change is breaking. Deliberately
+ * conservative: it returns `false` (safe) only for changes it can prove are
+ * non-breaking, and `true` for everything else.
+ *
+ * Provably safe: a metadata-only change; an object whose nested change is itself
+ * safe (recursively) with no removed or newly-required nested property (so
+ * adding an optional nested field stays safe). Everything else — a changed type
+ * token, an array whose items changed, an enum/const change, a composition
+ * change, or any constraint change on a scalar — is treated as breaking. This
+ * mirrors how the top-level property diff classifies node/edge properties, so a
+ * change nested inside an object, array, or enum is caught the same way a
+ * top-level one is (rather than passing as a non-blocking warning and
+ * auto-migrating over rows that no longer satisfy the schema).
+ */
+function isBreakingPropertyChange(
+  before: JsonSchema,
+  after: JsonSchema,
+): boolean {
+  if (canonicalEqual(stripSchemaMetadata(before), stripSchemaMetadata(after))) {
+    return false;
+  }
+  if (propertyTypeSignature(before) !== propertyTypeSignature(after)) {
+    return true;
+  }
+  if (isObjectSchema(before) && isObjectSchema(after)) {
+    return isBreakingObjectSchemaChange(before, after);
+  }
+  // Same top-level token, but a constraining change the recursion above does not
+  // model (array items, enum/const values, composition members, scalar bounds).
+  // Cannot prove it is a loosening, so treat it as breaking.
+  return true;
+}
+
+/** Recursive breaking-change check for two object JSON-Schemas. */
+function isBreakingObjectSchemaChange(
+  before: JsonSchema,
+  after: JsonSchema,
+): boolean {
+  const beforeProps = before.properties ?? {};
+  const afterProps = after.properties ?? {};
+  const beforeRequired = new Set(before.required);
+  const afterRequired = new Set(after.required);
+
+  for (const key of Object.keys(beforeProps)) {
+    if (!(key in afterProps)) return true; // nested property removed
+  }
+  for (const key of afterRequired) {
+    if (!beforeRequired.has(key)) return true; // nested property newly required
+  }
+  for (const [key, beforeChild] of Object.entries(beforeProps)) {
+    const afterChild = afterProps[key];
+    if (afterChild === undefined) continue; // removal already handled above
+    if (isBreakingPropertyChange(beforeChild, afterChild)) return true;
+  }
+  return false; // only additive optional / provably-safe nested changes
+}
+
+/**
  * Classifies a change to a node/edge's property JSON-Schema. Props are stored
  * as a single JSON column with no per-field DDL, so the schema is enforced only
  * at the application layer — a diff-based migration cannot rewrite existing
- * rows. A change is therefore:
+ * rows. A change is therefore only ever **breaking** or **safe**:
  *
- *  - **breaking** when existing rows can no longer satisfy the new schema and
- *    no data-free migration fixes it: a removed property, an in-place property
- *    *type* change, or a newly required property. `ensureSchema` refuses to
+ *  - **breaking** when existing rows can no longer be proven to satisfy the new
+ *    schema and no data-free migration fixes it: a removed property, a newly
+ *    required property, or a shared property whose schema changed in a way that
+ *    is not provably a loosening (a changed type token, a changed array item
+ *    schema, an enum/const/composition change, a scalar constraint change, or a
+ *    breaking change nested inside an object). `ensureSchema` refuses to
  *    auto-migrate these (throws `MigrationError` with the data actions).
- *  - **warning** when a shared property's constraints changed without a type
- *    change (a tightened bound may reject existing data). Surfaced in the diff
- *    but still auto-migrates, so legitimate loosening is not blocked.
- *  - **safe** when only new optional properties were added.
+ *  - **safe** when the only changes are new optional properties, metadata-only
+ *    edits, or additive optional fields nested inside an object.
  *
- * Conservative on the type axis: a scalar → union *widening* is reported
- * breaking (a false positive the operator acknowledges) rather than risk
- * misclassifying a genuine narrowing as safe. Constraint tightening within the
- * same type is the one residual that still auto-migrates as a warning.
+ * Deliberately conservative: a change is called safe only when
+ * {@link isBreakingPropertyChange} can prove it non-breaking, so an ambiguous
+ * change (e.g. a scalar → union *widening*, or a same-type constraint change)
+ * is reported breaking — a false positive the operator acknowledges — rather
+ * than risk auto-migrating over rows that no longer satisfy the schema. There
+ * is no "warning" bucket: an unproven change blocks rather than silently
+ * migrating.
  */
 function classifyPropertyChanges(
   kind: string,
@@ -428,16 +515,15 @@ function classifyPropertyChanges(
   const added = Object.keys(afterProps).filter((p) => !(p in beforeProps));
   const newRequired = [...afterRequired].filter((p) => !beforeRequired.has(p));
 
-  const typeChanged: string[] = [];
-  const constraintChanged: string[] = [];
+  // A shared property whose schema changed in a way that can invalidate existing
+  // rows (type/shape change, a breaking nested/array/enum/constraint change).
+  const breakingProps: string[] = [];
   for (const [property, beforeProperty] of Object.entries(beforeProps)) {
     const afterProperty = afterProps[property];
     if (afterProperty === undefined) continue; // removed — handled below
-    if (canonicalEqual(beforeProperty, afterProperty)) continue;
-    if (propertyTypeSignature(beforeProperty) === propertyTypeSignature(afterProperty)) {
-      constraintChanged.push(property);
-    } else {
-      typeChanged.push(property);
+    if (canonicalEqual(beforeProperty, afterProperty)) continue; // unchanged
+    if (isBreakingPropertyChange(beforeProperty, afterProperty)) {
+      breakingProps.push(property);
     }
   }
 
@@ -447,10 +533,10 @@ function classifyPropertyChanges(
       details: `Properties removed from "${kind}": ${removed.join(", ")}`,
     };
   }
-  if (typeChanged.length > 0) {
+  if (breakingProps.length > 0) {
     return {
       severity: "breaking",
-      details: `Property types changed in "${kind}": ${typeChanged.join(", ")}`,
+      details: `Property schemas changed incompatibly in "${kind}": ${breakingProps.join(", ")}`,
     };
   }
   if (newRequired.length > 0) {
@@ -459,18 +545,14 @@ function classifyPropertyChanges(
       details: `New required properties in "${kind}": ${newRequired.join(", ")}`,
     };
   }
-  if (constraintChanged.length > 0) {
-    return {
-      severity: "warning",
-      details: `Property constraints changed in "${kind}": ${constraintChanged.join(", ")}`,
-    };
-  }
   if (added.length > 0) {
     return {
       severity: "safe",
       details: `Properties added to "${kind}": ${added.join(", ")}`,
     };
   }
+  // Only provably non-breaking property changes remain (metadata, additive
+  // optional nested fields, a widened/loosened shape the checks above cleared).
   return { severity: "safe", details: `Properties changed in "${kind}"` };
 }
 

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -8,6 +8,7 @@ import { type IndexEntity } from "../core/types";
 import { type IndexDeclaration } from "../indexes/types";
 import { canonicalEqual } from "./canonical";
 import {
+  type JsonSchema,
   type SerializedEdgeDef,
   type SerializedNodeDef,
   type SerializedOntology,
@@ -323,27 +324,10 @@ function diffNodeDef(
 
   // Check property schema changes
   if (!canonicalEqual(before.properties, after.properties)) {
-    // Determine if properties were added or removed
-    const beforeProps = before.properties.properties ?? {};
-    const afterProps = after.properties.properties ?? {};
-    const beforeRequired = new Set(before.properties.required);
-    const afterRequired = new Set(after.properties.required);
-
-    const addedProps = Object.keys(afterProps).filter(
-      (p) => !(p in beforeProps),
-    );
-    const removedProps = Object.keys(beforeProps).filter(
-      (p) => !(p in afterProps),
-    );
-    const newRequired = [...afterRequired].filter(
-      (p) => !beforeRequired.has(p),
-    );
-
-    const { severity, details } = computePropertyChangeSeverity(
+    const { severity, details } = classifyPropertyChanges(
       name,
-      removedProps,
-      addedProps,
-      newRequired,
+      before.properties,
+      after.properties,
     );
 
     changes.push({
@@ -395,36 +379,99 @@ function diffNodeDef(
 }
 
 /**
- * Computes the severity and details message for property changes.
+ * A comparable token for a property's JSON-Schema type. A change here
+ * (`string` → `number`, or scalar → union / enum / const) means existing
+ * JSON-encoded props no longer satisfy the declared type, which no data-free
+ * migration can reconcile.
  */
-function computePropertyChangeSeverity(
-  name: string,
-  removedProps: readonly string[],
-  addedProps: readonly string[],
-  newRequired: readonly string[],
+function propertyTypeSignature(schema: JsonSchema): string {
+  if (schema.type !== undefined) return JSON.stringify(schema.type);
+  if (schema.const !== undefined) return "const";
+  if (schema.enum !== undefined) return "enum";
+  if (schema.anyOf !== undefined) return "anyOf";
+  if (schema.oneOf !== undefined) return "oneOf";
+  if (schema.allOf !== undefined) return "allOf";
+  return "unknown";
+}
+
+/**
+ * Classifies a change to a node/edge's property JSON-Schema. Props are stored
+ * as a single JSON column with no per-field DDL, so the schema is enforced only
+ * at the application layer — a diff-based migration cannot rewrite existing
+ * rows. A change is therefore:
+ *
+ *  - **breaking** when existing rows can no longer satisfy the new schema and
+ *    no data-free migration fixes it: a removed property, an in-place property
+ *    *type* change, or a newly required property. `ensureSchema` refuses to
+ *    auto-migrate these (throws `MigrationError` with the data actions).
+ *  - **warning** when a shared property's constraints changed without a type
+ *    change (a tightened bound may reject existing data). Surfaced in the diff
+ *    but still auto-migrates, so legitimate loosening is not blocked.
+ *  - **safe** when only new optional properties were added.
+ *
+ * Conservative on the type axis: a scalar → union *widening* is reported
+ * breaking (a false positive the operator acknowledges) rather than risk
+ * misclassifying a genuine narrowing as safe. Constraint tightening within the
+ * same type is the one residual that still auto-migrates as a warning.
+ */
+function classifyPropertyChanges(
+  kind: string,
+  before: JsonSchema,
+  after: JsonSchema,
 ): { severity: ChangeSeverity; details: string } {
-  if (removedProps.length > 0) {
+  const beforeProps = before.properties ?? {};
+  const afterProps = after.properties ?? {};
+  const beforeRequired = new Set(before.required);
+  const afterRequired = new Set(after.required);
+
+  const removed = Object.keys(beforeProps).filter((p) => !(p in afterProps));
+  const added = Object.keys(afterProps).filter((p) => !(p in beforeProps));
+  const newRequired = [...afterRequired].filter((p) => !beforeRequired.has(p));
+
+  const typeChanged: string[] = [];
+  const constraintChanged: string[] = [];
+  for (const [property, beforeProperty] of Object.entries(beforeProps)) {
+    const afterProperty = afterProps[property];
+    if (afterProperty === undefined) continue; // removed — handled below
+    if (canonicalEqual(beforeProperty, afterProperty)) continue;
+    if (propertyTypeSignature(beforeProperty) === propertyTypeSignature(afterProperty)) {
+      constraintChanged.push(property);
+    } else {
+      typeChanged.push(property);
+    }
+  }
+
+  if (removed.length > 0) {
     return {
       severity: "breaking",
-      details: `Properties removed from "${name}": ${removedProps.join(", ")}`,
+      details: `Properties removed from "${kind}": ${removed.join(", ")}`,
+    };
+  }
+  if (typeChanged.length > 0) {
+    return {
+      severity: "breaking",
+      details: `Property types changed in "${kind}": ${typeChanged.join(", ")}`,
     };
   }
   if (newRequired.length > 0) {
     return {
       severity: "breaking",
-      details: `New required properties in "${name}": ${newRequired.join(", ")}`,
+      details: `New required properties in "${kind}": ${newRequired.join(", ")}`,
     };
   }
-  if (addedProps.length > 0) {
+  if (constraintChanged.length > 0) {
+    return {
+      severity: "warning",
+      details: `Property constraints changed in "${kind}": ${constraintChanged.join(", ")}`,
+    };
+  }
+  if (added.length > 0) {
     return {
       severity: "safe",
-      details: `Properties added to "${name}": ${addedProps.join(", ")}`,
+      details: `Properties added to "${kind}": ${added.join(", ")}`,
     };
   }
-  return {
-    severity: "safe",
-    details: `Properties changed in "${name}"`,
-  };
+  return { severity: "safe", details: `Properties changed in "${kind}"` };
 }
 
 // ============================================================
@@ -528,11 +575,16 @@ function diffEdgeDef(
 
   // Check properties
   if (!canonicalEqual(before.properties, after.properties)) {
+    const { severity, details } = classifyPropertyChanges(
+      name,
+      before.properties,
+      after.properties,
+    );
     changes.push({
       type: "modified",
       kind: name,
-      severity: "safe",
-      details: `Properties changed for "${name}"`,
+      severity,
+      details,
       before,
       after,
     });

--- a/packages/typegraph/tests/schema-migration.test.ts
+++ b/packages/typegraph/tests/schema-migration.test.ts
@@ -707,3 +707,146 @@ describe("Auto-Bootstrap Tables", () => {
     expect(second.status).toBe("unchanged");
   });
 });
+
+describe("Property change classification", () => {
+  it("classifies an in-place node property type change as breaking", async () => {
+    const backend = createTestBackend();
+    const graphV1 = defineGraph({
+      id: "proptype_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", { schema: z.object({ age: z.string() }) }),
+        },
+      },
+      edges: {},
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    // Same key, changed type: existing JSON props are now the wrong type and no
+    // data-free migration reconciles them, so this must not auto-migrate.
+    const graphV2 = defineGraph({
+      id: "proptype_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", { schema: z.object({ age: z.number() }) }),
+        },
+      },
+      edges: {},
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(true);
+    expect(diff!.nodes[0]).toMatchObject({ kind: "Person", severity: "breaking" });
+    expect(diff!.nodes[0]!.details).toContain("type");
+
+    await expect(createStoreWithSchema(graphV2, backend)).rejects.toThrow(
+      MigrationError,
+    );
+  });
+
+  it("classifies a same-type constraint change as a non-blocking warning", async () => {
+    const backend = createTestBackend();
+    const graphV1 = defineGraph({
+      id: "propconstraint_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", { schema: z.object({ name: z.string() }) }),
+        },
+      },
+      edges: {},
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    // Tightened constraint, same type — surfaced as a warning but not blocked,
+    // so a legitimate loosening also stays auto-migratable.
+    const graphV2 = defineGraph({
+      id: "propconstraint_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ name: z.string().min(3) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(false);
+    expect(diff!.nodes[0]).toMatchObject({ kind: "Person", severity: "warning" });
+
+    const [, result] = await createStoreWithSchema(graphV2, backend);
+    expect(result.status).toBe("migrated");
+  });
+
+  it("classifies an edge property type change as breaking", async () => {
+    const backend = createTestBackend();
+    const PersonNode = defineNode("Person", {
+      schema: z.object({ name: z.string() }),
+    });
+    const graphV1 = defineGraph({
+      id: "edgeproptype_test",
+      nodes: { Person: { type: PersonNode } },
+      edges: {
+        worksAt: {
+          type: defineEdge("worksAt", { schema: z.object({ years: z.string() }) }),
+          from: [PersonNode],
+          to: [PersonNode],
+        },
+      },
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    const graphV2 = defineGraph({
+      id: "edgeproptype_test",
+      nodes: { Person: { type: PersonNode } },
+      edges: {
+        worksAt: {
+          type: defineEdge("worksAt", { schema: z.object({ years: z.number() }) }),
+          from: [PersonNode],
+          to: [PersonNode],
+        },
+      },
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(true);
+    expect(diff!.edges[0]).toMatchObject({ kind: "worksAt", severity: "breaking" });
+  });
+
+  it("classifies an edge property removal as breaking", async () => {
+    const backend = createTestBackend();
+    const PersonNode = defineNode("Person", {
+      schema: z.object({ name: z.string() }),
+    });
+    const graphV1 = defineGraph({
+      id: "edgeproprem_test",
+      nodes: { Person: { type: PersonNode } },
+      edges: {
+        worksAt: {
+          type: defineEdge("worksAt", { schema: z.object({ role: z.string() }) }),
+          from: [PersonNode],
+          to: [PersonNode],
+        },
+      },
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    // Edge property removal was previously misclassified as "safe".
+    const graphV2 = defineGraph({
+      id: "edgeproprem_test",
+      nodes: { Person: { type: PersonNode } },
+      edges: {
+        worksAt: {
+          type: defineEdge("worksAt", { schema: z.object({}) }),
+          from: [PersonNode],
+          to: [PersonNode],
+        },
+      },
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(true);
+    expect(diff!.edges[0]).toMatchObject({ kind: "worksAt", severity: "breaking" });
+  });
+});

--- a/packages/typegraph/tests/schema-migration.test.ts
+++ b/packages/typegraph/tests/schema-migration.test.ts
@@ -736,29 +736,34 @@ describe("Property change classification", () => {
 
     const diff = await getSchemaChanges(backend, graphV2);
     expect(diff!.hasBreakingChanges).toBe(true);
-    expect(diff!.nodes[0]).toMatchObject({ kind: "Person", severity: "breaking" });
-    expect(diff!.nodes[0]!.details).toContain("type");
+    expect(diff!.nodes[0]).toMatchObject({
+      kind: "Person",
+      severity: "breaking",
+    });
+    expect(diff!.nodes[0]!.details).toContain("age");
 
     await expect(createStoreWithSchema(graphV2, backend)).rejects.toThrow(
       MigrationError,
     );
   });
 
-  it("classifies a same-type constraint change as a non-blocking warning", async () => {
+  it("classifies a tightened same-type constraint as breaking", async () => {
     const backend = createTestBackend();
     const graphV1 = defineGraph({
       id: "propconstraint_test",
       nodes: {
         Person: {
-          type: defineNode("Person", { schema: z.object({ name: z.string() }) }),
+          type: defineNode("Person", {
+            schema: z.object({ name: z.string() }),
+          }),
         },
       },
       edges: {},
     });
     await createStoreWithSchema(graphV1, backend);
 
-    // Tightened constraint, same type — surfaced as a warning but not blocked,
-    // so a legitimate loosening also stays auto-migratable.
+    // Adding a minLength is a tightening: existing shorter strings no longer
+    // satisfy the schema. Must not auto-migrate.
     const graphV2 = defineGraph({
       id: "propconstraint_test",
       nodes: {
@@ -772,9 +777,169 @@ describe("Property change classification", () => {
     });
 
     const diff = await getSchemaChanges(backend, graphV2);
-    expect(diff!.hasBreakingChanges).toBe(false);
-    expect(diff!.nodes[0]).toMatchObject({ kind: "Person", severity: "warning" });
+    expect(diff!.hasBreakingChanges).toBe(true);
+    expect(diff!.nodes[0]).toMatchObject({
+      kind: "Person",
+      severity: "breaking",
+    });
+    await expect(createStoreWithSchema(graphV2, backend)).rejects.toThrow(
+      MigrationError,
+    );
+  });
 
+  it("classifies a NESTED object property type change as breaking", async () => {
+    const backend = createTestBackend();
+    const graphV1 = defineGraph({
+      id: "propnested_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ profile: z.object({ age: z.string() }) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    // Only the nested `profile.age` changes type; the top-level `profile` token
+    // stays "object". A shallow token comparison would miss this.
+    const graphV2 = defineGraph({
+      id: "propnested_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ profile: z.object({ age: z.number() }) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(true);
+    expect(diff!.nodes[0]).toMatchObject({
+      kind: "Person",
+      severity: "breaking",
+    });
+    await expect(createStoreWithSchema(graphV2, backend)).rejects.toThrow(
+      MigrationError,
+    );
+  });
+
+  it("classifies an array item type change as breaking", async () => {
+    const backend = createTestBackend();
+    const graphV1 = defineGraph({
+      id: "proparray_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ tags: z.array(z.string()) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    const graphV2 = defineGraph({
+      id: "proparray_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ tags: z.array(z.number()) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(true);
+    expect(diff!.nodes[0]).toMatchObject({
+      kind: "Person",
+      severity: "breaking",
+    });
+    await expect(createStoreWithSchema(graphV2, backend)).rejects.toThrow(
+      MigrationError,
+    );
+  });
+
+  it("classifies enum narrowing as breaking", async () => {
+    const backend = createTestBackend();
+    const graphV1 = defineGraph({
+      id: "propenum_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ role: z.enum(["admin", "user", "guest"]) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    // Dropping enum members: existing rows holding "guest" no longer validate.
+    const graphV2 = defineGraph({
+      id: "propenum_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ role: z.enum(["admin", "user"]) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(true);
+    expect(diff!.nodes[0]).toMatchObject({
+      kind: "Person",
+      severity: "breaking",
+    });
+    await expect(createStoreWithSchema(graphV2, backend)).rejects.toThrow(
+      MigrationError,
+    );
+  });
+
+  it("classifies an added OPTIONAL nested property as safe (not over-restrictive)", async () => {
+    const backend = createTestBackend();
+    const graphV1 = defineGraph({
+      id: "propnestedadd_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({ profile: z.object({ age: z.number() }) }),
+          }),
+        },
+      },
+      edges: {},
+    });
+    await createStoreWithSchema(graphV1, backend);
+
+    // Adding an optional field inside a nested object cannot invalidate existing
+    // rows, so it must remain auto-migratable.
+    const graphV2 = defineGraph({
+      id: "propnestedadd_test",
+      nodes: {
+        Person: {
+          type: defineNode("Person", {
+            schema: z.object({
+              profile: z.object({
+                age: z.number(),
+                nickname: z.string().optional(),
+              }),
+            }),
+          }),
+        },
+      },
+      edges: {},
+    });
+
+    const diff = await getSchemaChanges(backend, graphV2);
+    expect(diff!.hasBreakingChanges).toBe(false);
     const [, result] = await createStoreWithSchema(graphV2, backend);
     expect(result.status).toBe("migrated");
   });
@@ -789,7 +954,9 @@ describe("Property change classification", () => {
       nodes: { Person: { type: PersonNode } },
       edges: {
         worksAt: {
-          type: defineEdge("worksAt", { schema: z.object({ years: z.string() }) }),
+          type: defineEdge("worksAt", {
+            schema: z.object({ years: z.string() }),
+          }),
           from: [PersonNode],
           to: [PersonNode],
         },
@@ -802,7 +969,9 @@ describe("Property change classification", () => {
       nodes: { Person: { type: PersonNode } },
       edges: {
         worksAt: {
-          type: defineEdge("worksAt", { schema: z.object({ years: z.number() }) }),
+          type: defineEdge("worksAt", {
+            schema: z.object({ years: z.number() }),
+          }),
           from: [PersonNode],
           to: [PersonNode],
         },
@@ -811,7 +980,10 @@ describe("Property change classification", () => {
 
     const diff = await getSchemaChanges(backend, graphV2);
     expect(diff!.hasBreakingChanges).toBe(true);
-    expect(diff!.edges[0]).toMatchObject({ kind: "worksAt", severity: "breaking" });
+    expect(diff!.edges[0]).toMatchObject({
+      kind: "worksAt",
+      severity: "breaking",
+    });
   });
 
   it("classifies an edge property removal as breaking", async () => {
@@ -824,7 +996,9 @@ describe("Property change classification", () => {
       nodes: { Person: { type: PersonNode } },
       edges: {
         worksAt: {
-          type: defineEdge("worksAt", { schema: z.object({ role: z.string() }) }),
+          type: defineEdge("worksAt", {
+            schema: z.object({ role: z.string() }),
+          }),
           from: [PersonNode],
           to: [PersonNode],
         },
@@ -847,6 +1021,9 @@ describe("Property change classification", () => {
 
     const diff = await getSchemaChanges(backend, graphV2);
     expect(diff!.hasBreakingChanges).toBe(true);
-    expect(diff!.edges[0]).toMatchObject({ kind: "worksAt", severity: "breaking" });
+    expect(diff!.edges[0]).toMatchObject({
+      kind: "worksAt",
+      severity: "breaking",
+    });
   });
 });


### PR DESCRIPTION
The migration diff compared only the top-level JSON-Schema **token** of each property, so an in-place property type change (`age: string → number`), a changed array item type (`string[] → number[]`), enum narrowing, and any type change nested inside an object all classified as a non-blocking **warning** and auto-migrated silently — leaving stored rows that no longer satisfy the declared schema, the exact failure this classifier exists to prevent. Edge property changes were unconditionally classified `safe` (even removals).

Node and edge property diffs now share one **recursive, conservative** classifier. A change is `safe` only when it can be proven non-breaking: a new optional property, a metadata-only edit (`description`/`title`/`default`), or an additive optional field nested inside an object. Everything else is **breaking** and blocks auto-migration (`ensureSchema` throws `MigrationError` with the data actions):

- a removed or newly-required property (including nested);
- an in-place property type change;
- a changed array item schema;
- an enum / const / composition (`anyOf`/`oneOf`/`allOf`) change;
- a same-type constraint change (a tightened bound may reject existing rows, so it is conservatively breaking rather than an auto-migrating warning);
- any breaking change nested inside an object.

The property-schema **warning** bucket is removed — an unproven change blocks rather than silently migrating. (Non-property axes — `onDelete`, unique constraints, edge cardinality, ontology relations — keep their existing `warning` severity; they don't gate stored-row compatibility.)

Adds regression tests for the three reproduced cases (nested object type change, array item type change, enum narrowing → breaking), edge-property parity, and the safe additive-optional-nested case. SQLite + Postgres green.
