### PR TITLE
fix(query): keyset pagination tiebreaker + LIKE ESCAPE parity

### DIFF
--- a/.changeset/query-pagination-and-like-escape.md
+++ b/.changeset/query-pagination-and-like-escape.md
@@ -1,0 +1,10 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix two silent query-correctness bugs. Keyset pagination (`paginate`/`stream`)
+now appends a unique `id` tiebreaker to the ORDER BY so a non-unique sort no
+longer drops equal-key rows across pages. And every compiled `LIKE`/`ILIKE` now
+emits `ESCAPE '\'`, so escaped `%`/`_`/`\` in `contains`/`startsWith`/`endsWith`
+match literally on SQLite as they already did on PostgreSQL (previously SQLite
+had no default LIKE escape character, so the two backends diverged).

--- a/.changeset/query-pagination-and-like-escape.md
+++ b/.changeset/query-pagination-and-like-escape.md
@@ -5,6 +5,10 @@
 Fix two silent query-correctness bugs. Keyset pagination (`paginate`/`stream`)
 now appends a unique `id` tiebreaker to the ORDER BY so a non-unique sort no
 longer drops equal-key rows across pages. And every compiled `LIKE`/`ILIKE` now
-emits `ESCAPE '\'`, so escaped `%`/`_`/`\` in `contains`/`startsWith`/`endsWith`
-match literally on SQLite as they already did on PostgreSQL (previously SQLite
-had no default LIKE escape character, so the two backends diverged).
+emits `ESCAPE '\'` — including the case-sensitive `like` path, which previously
+omitted it — so escaped `%`/`_`/`\` match literally on SQLite as they already
+did on PostgreSQL, in both the auto-escaped operators
+(`contains`/`startsWith`/`endsWith`) and raw `like`/`ilike` patterns, and
+whether the pattern is a literal or a bound parameter (previously SQLite had no
+default LIKE escape character, so the two backends — and the direct vs prepared
+paths — diverged).

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -932,7 +932,7 @@ export class ExecutableQuery<
   }
 
   #recordOrderByFieldsForPagination(tracker: FieldAccessTracker): boolean {
-    for (const spec of this.#state.orderBy) {
+    for (const spec of this.#paginationOrderBy()) {
       const field = spec.field;
 
       // System field (e.g., id, kind) — path is ["id"] or ["kind"]
@@ -974,7 +974,7 @@ export class ExecutableQuery<
       row,
       selectiveFields,
     );
-    return buildCursorFromRow(contextRow, this.#state.orderBy, direction);
+    return buildCursorFromRow(contextRow, this.#paginationOrderBy(), direction);
   }
 
   #buildCursorContextFromSelectiveRow(
@@ -998,7 +998,7 @@ export class ExecutableQuery<
 
     const cursorContext: Record<string, unknown> = {};
 
-    for (const spec of this.#state.orderBy) {
+    for (const spec of this.#paginationOrderBy()) {
       const alias = spec.field.alias;
       const jsonPointer = spec.field.jsonPointer;
 
@@ -1101,6 +1101,37 @@ export class ExecutableQuery<
   }
 
   /**
+   * The ORDER BY used for keyset pagination: the caller's ORDER BY plus a final
+   * unique tiebreaker on the start alias's `id`. Without a unique final key, a
+   * non-unique sort (e.g. `orderBy("p", "age")` with many equal ages) makes the
+   * keyset predicate `age > lastAge` skip every not-yet-returned equal-age row,
+   * silently losing data across pages. The start node's `id` is unique and
+   * always projected, so appending it gives a total order that page boundaries
+   * can split cleanly. Skipped when the caller already orders by the start
+   * alias's `id` (the sort is already total). Every pagination read of ORDER BY
+   * — the emitted sort, the cursor predicate, cursor encoding, and cursor
+   * validation — routes through here so the extra column stays consistent across
+   * the standard and selective-field-optimized paths.
+   */
+  #paginationOrderBy(): readonly OrderSpec[] {
+    const orderBy = this.#state.orderBy;
+    const startAlias = this.#state.startAlias;
+    const alreadyTotal = orderBy.some(
+      (spec) =>
+        spec.field.alias === startAlias &&
+        spec.field.path.length === 1 &&
+        spec.field.path[0] === "id" &&
+        spec.field.jsonPointer === undefined,
+    );
+    if (alreadyTotal) return orderBy;
+    const tiebreaker: OrderSpec = {
+      field: { __type: "field_ref", alias: startAlias, path: ["id"] },
+      direction: "asc",
+    };
+    return [...orderBy, tiebreaker];
+  }
+
+  /**
    * Executes a paginated query using cursor-based keyset pagination.
    *
    * Cursor pagination is efficient for large datasets as it avoids OFFSET.
@@ -1146,7 +1177,7 @@ export class ExecutableQuery<
     let cursorData: CursorData | undefined;
     if (cursor) {
       cursorData = decodeCursor(cursor);
-      validateCursorColumns(cursorData, this.#state.orderBy);
+      validateCursorColumns(cursorData, this.#paginationOrderBy());
     }
 
     // Fetch limit + 1 to detect if there are more pages
@@ -1191,7 +1222,7 @@ export class ExecutableQuery<
     return buildPaginatedResult(
       data,
       orderedRows,
-      this.#state.orderBy,
+      this.#paginationOrderBy(),
       limit,
       hasMore,
       isBackward,
@@ -1248,7 +1279,7 @@ export class ExecutableQuery<
     const ast = this.toAst();
 
     // Adjust ORDER BY for backward pagination (reverse all directions)
-    let orderBy = this.#state.orderBy;
+    let orderBy = this.#paginationOrderBy();
     if (direction === "backward") {
       orderBy = orderBy.map((spec) => ({
         ...spec,
@@ -1262,7 +1293,7 @@ export class ExecutableQuery<
     if (cursorData) {
       const cursorPredicate = buildCursorPredicate(
         cursorData,
-        this.#state.orderBy,
+        this.#paginationOrderBy(),
         direction,
         this.#state.startAlias,
       );

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -22,6 +22,7 @@ import {
   type ValueType,
   type VectorSimilarityPredicate,
 } from "../ast";
+import { likeEscapeClause } from "../dialect/like-escape";
 import { type DialectAdapter } from "../dialect/types";
 import { type VectorStrategy } from "../dialect/vector-strategy";
 import {
@@ -321,7 +322,12 @@ function convertValueForSql(value: unknown, dialect: DialectAdapter): unknown {
  * Compiles a string pattern for LIKE operations.
  */
 function compileStringPattern(op: string, pattern: string): string {
+  // Escape the backslash first so the wildcards we prefix below aren't
+  // double-escaped, then neutralize the LIKE wildcards. Mirrors
+  // escapeLikePatternParameter for the parameterized path. The emitted
+  // LIKE/ILIKE declares backslash as its ESCAPE character (see likeEscapeClause).
   const escaped = pattern
+    .replaceAll("\\", String.raw`\\`)
     .replaceAll("%", String.raw`\%`)
     .replaceAll("_", String.raw`\_`);
 
@@ -455,7 +461,7 @@ export function compilePredicateExpression(
         ) {
           return dialect.ilike(field, pattern);
         }
-        return sql`${field} LIKE ${pattern}`;
+        return sql`${field} LIKE ${pattern} ${likeEscapeClause}`;
       }
 
       const pattern = compileStringPattern(expr.op, expr.pattern);

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -22,7 +22,10 @@ import {
   type ValueType,
   type VectorSimilarityPredicate,
 } from "../ast";
-import { likeEscapeClause } from "../dialect/like-escape";
+import {
+  LIKE_ESCAPE_CHARACTER,
+  likeEscapeClause,
+} from "../dialect/like-escape";
 import { type DialectAdapter } from "../dialect/types";
 import { type VectorStrategy } from "../dialect/vector-strategy";
 import {
@@ -322,14 +325,17 @@ function convertValueForSql(value: unknown, dialect: DialectAdapter): unknown {
  * Compiles a string pattern for LIKE operations.
  */
 function compileStringPattern(op: string, pattern: string): string {
-  // Escape the backslash first so the wildcards we prefix below aren't
+  // Escape the escape character first so the wildcards we prefix below aren't
   // double-escaped, then neutralize the LIKE wildcards. Mirrors
   // escapeLikePatternParameter for the parameterized path. The emitted
-  // LIKE/ILIKE declares backslash as its ESCAPE character (see likeEscapeClause).
+  // LIKE/ILIKE declares this same character as its ESCAPE (see likeEscapeClause).
   const escaped = pattern
-    .replaceAll("\\", String.raw`\\`)
-    .replaceAll("%", String.raw`\%`)
-    .replaceAll("_", String.raw`\_`);
+    .replaceAll(
+      LIKE_ESCAPE_CHARACTER,
+      `${LIKE_ESCAPE_CHARACTER}${LIKE_ESCAPE_CHARACTER}`,
+    )
+    .replaceAll("%", `${LIKE_ESCAPE_CHARACTER}%`)
+    .replaceAll("_", `${LIKE_ESCAPE_CHARACTER}_`);
 
   switch (op) {
     case "contains": {
@@ -476,8 +482,11 @@ export function compilePredicateExpression(
       ) {
         return dialect.ilike(field, pattern);
       }
-      // Use case-sensitive LIKE only for explicit 'like' operator
-      return sql`${field} LIKE ${pattern}`;
+      // Use case-sensitive LIKE only for explicit 'like' operator. The ESCAPE
+      // clause must match the parameterized path (above) and dialect.ilike so a
+      // raw '\%' / '\_' in a user pattern is a literal on SQLite too, not just
+      // on Postgres (whose default LIKE escape is already backslash).
+      return sql`${field} LIKE ${pattern} ${likeEscapeClause}`;
     }
 
     case "null_check": {

--- a/packages/typegraph/src/query/dialect/like-escape.ts
+++ b/packages/typegraph/src/query/dialect/like-escape.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared LIKE-escape clause for the query compiler.
+ *
+ * The compiler builds `contains` / `startsWith` / `endsWith` patterns by
+ * escaping the literal `%`, `_`, and `\` in user input with a backslash (see
+ * the pattern builders in `compiler/predicates.ts`). For that escaping to take
+ * effect the emitted `LIKE` / `ILIKE` must declare backslash as its escape
+ * character. PostgreSQL's default LIKE escape is already backslash, so this
+ * clause is a no-op there; SQLite has *no* default escape character, so without
+ * it an escaped `\%` matches a literal backslash followed by any character —
+ * silently diverging from Postgres. Emitting it on every compiled predicate
+ * makes the two backends match by construction.
+ */
+import { type SQL, sql } from "drizzle-orm";
+
+/**
+ * The backslash escape character shared by the pattern builders and the
+ * {@link likeEscapeClause}. They must stay in sync: the builders prefix
+ * wildcards with this character, and the clause tells SQL to treat it as an
+ * escape.
+ */
+export const LIKE_ESCAPE_CHARACTER = "\\";
+
+/**
+ * `ESCAPE '\'` clause appended to every compiled `LIKE` / `ILIKE` predicate.
+ * The single backslash inside the quotes is a literal in both PostgreSQL
+ * (with `standard_conforming_strings`, the default) and SQLite.
+ */
+export const likeEscapeClause: SQL = sql`ESCAPE '\\'`;

--- a/packages/typegraph/src/query/dialect/like-escape.ts
+++ b/packages/typegraph/src/query/dialect/like-escape.ts
@@ -14,16 +14,18 @@
 import { type SQL, sql } from "drizzle-orm";
 
 /**
- * The backslash escape character shared by the pattern builders and the
- * {@link likeEscapeClause}. They must stay in sync: the builders prefix
- * wildcards with this character, and the clause tells SQL to treat it as an
- * escape.
+ * The backslash escape character used by the JS pattern builder
+ * (`compileStringPattern` in `compiler/predicates.ts`) to prefix the literal
+ * `%`, `_`, and `\` in user input. It must match the character declared by
+ * {@link likeEscapeClause}: the builder prefixes wildcards with this character,
+ * and the clause tells SQL to treat it as the escape. Both are backslash.
  */
 export const LIKE_ESCAPE_CHARACTER = "\\";
 
 /**
- * `ESCAPE '\'` clause appended to every compiled `LIKE` / `ILIKE` predicate.
- * The single backslash inside the quotes is a literal in both PostgreSQL
- * (with `standard_conforming_strings`, the default) and SQLite.
+ * `ESCAPE '\'` clause appended to every compiled `LIKE` / `ILIKE` predicate,
+ * declaring {@link LIKE_ESCAPE_CHARACTER} as the escape character. The single
+ * backslash inside the quotes is a literal in both PostgreSQL (with
+ * `standard_conforming_strings`, the default) and SQLite.
  */
 export const likeEscapeClause: SQL = sql`ESCAPE '\\'`;

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -8,6 +8,7 @@ import { type SQL, sql } from "drizzle-orm";
 
 import { type JsonPointer, parseJsonPointer } from "../json-pointer";
 import { tsvectorStrategy } from "./fulltext-strategy";
+import { likeEscapeClause } from "./like-escape";
 import { type DialectAdapter } from "./types";
 
 /**
@@ -174,8 +175,10 @@ export const postgresDialect: DialectAdapter = {
   // ============================================================
 
   ilike(column, pattern) {
-    // PostgreSQL has native ILIKE operator
-    return sql`${column} ILIKE ${pattern}`;
+    // PostgreSQL has native ILIKE operator. Declaring backslash as the escape
+    // character is a no-op (it is the LIKE default) but keeps the emitted SQL
+    // identical in intent to SQLite, which has no default escape character.
+    return sql`${column} ILIKE ${pattern} ${likeEscapeClause}`;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -8,6 +8,7 @@ import { sql } from "drizzle-orm";
 
 import { type JsonPointer, parseJsonPointer } from "../json-pointer";
 import { fts5Strategy } from "./fulltext-strategy";
+import { likeEscapeClause } from "./like-escape";
 import { type DialectAdapter } from "./types";
 
 /**
@@ -182,8 +183,10 @@ export const sqliteDialect: DialectAdapter = {
 
   ilike(column, pattern) {
     // SQLite LIKE is case-insensitive for ASCII by default, but we use
-    // LOWER() for consistency with non-ASCII characters
-    return sql`LOWER(${column}) LIKE LOWER(${pattern})`;
+    // LOWER() for consistency with non-ASCII characters. SQLite has no default
+    // LIKE escape character, so declare backslash explicitly to honor the
+    // escaping the compiler applies to the pattern (parity with Postgres).
+    return sql`LOWER(${column}) LIKE LOWER(${pattern}) ${likeEscapeClause}`;
   },
 
   // ============================================================

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -272,7 +272,10 @@ export function registerPredicateIntegrationTests(
         email: "pctwild@test.com",
       });
       await store.nodes.Person.create({ name: "id_42", email: "us@test.com" });
-      await store.nodes.Person.create({ name: "idX42", email: "uswild@test.com" });
+      await store.nodes.Person.create({
+        name: "idX42",
+        email: "uswild@test.com",
+      });
       await store.nodes.Person.create({
         name: String.raw`path\to\file`,
         email: "bs@test.com",

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { param as parameter } from "../../../src";
 import {
   seedDocumentsForArrayPredicates,
   seedDocumentsForObjectPredicates,
@@ -308,6 +309,44 @@ export function registerPredicateIntegrationTests(
         .select((ctx) => ctx.p.name)
         .execute();
       expect(backslash.toSorted()).toEqual([String.raw`path\to\file`]);
+    });
+
+    it("honors backslash escapes in raw like/ilike patterns (direct/prepared parity)", async () => {
+      const store = context.getStore();
+      await store.nodes.Person.create({ name: "a_b", email: "und@test.com" });
+      await store.nodes.Person.create({ name: "axb", email: "wild@test.com" });
+
+      // Raw `like`: `\_` must be a literal underscore on every backend. Without
+      // the ESCAPE clause on SQLite (no default escape char) this matched
+      // nothing — diverging from Postgres and from the parameterized path.
+      const literal = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.like(String.raw`a\_b`))
+        .select((ctx) => ctx.p.name)
+        .execute();
+      expect(literal.toSorted()).toEqual(["a_b"]);
+
+      // Same pattern through a bound parameter must agree with the literal path.
+      const prepared = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.like(parameter("pattern")))
+        .select((ctx) => ctx.p.name)
+        .prepare();
+      const parameterized = await prepared.execute({
+        pattern: String.raw`a\_b`,
+      });
+      expect(parameterized.toSorted()).toEqual(["a_b"]);
+
+      // Case-insensitive `ilike` honors the same escape, case-folded.
+      const insensitive = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.ilike(String.raw`A\_B`))
+        .select((ctx) => ctx.p.name)
+        .execute();
+      expect(insensitive.toSorted()).toEqual(["a_b"]);
     });
   });
 

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -260,6 +260,52 @@ export function registerPredicateIntegrationTests(
 
       expect(results).toContain("Special User");
     });
+
+    it("treats %, _, and backslash as literals in contains/startsWith (LIKE escape parity)", async () => {
+      const store = context.getStore();
+      await store.nodes.Person.create({
+        name: "Discount 100% off",
+        email: "pct@test.com",
+      });
+      await store.nodes.Person.create({
+        name: "Discount 100X off",
+        email: "pctwild@test.com",
+      });
+      await store.nodes.Person.create({ name: "id_42", email: "us@test.com" });
+      await store.nodes.Person.create({ name: "idX42", email: "uswild@test.com" });
+      await store.nodes.Person.create({
+        name: String.raw`path\to\file`,
+        email: "bs@test.com",
+      });
+
+      // A literal % must not act as a multi-char wildcard. Before the ESCAPE
+      // fix this returned nothing on SQLite (no default LIKE escape char).
+      const percent = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.contains("100%"))
+        .select((ctx) => ctx.p.name)
+        .execute();
+      expect(percent.toSorted()).toEqual(["Discount 100% off"]);
+
+      // A literal _ must not act as a single-char wildcard.
+      const underscore = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.contains("id_"))
+        .select((ctx) => ctx.p.name)
+        .execute();
+      expect(underscore.toSorted()).toEqual(["id_42"]);
+
+      // A literal backslash must match a backslash, not act as an escape char.
+      const backslash = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.startsWith(String.raw`path\to`))
+        .select((ctx) => ctx.p.name)
+        .execute();
+      expect(backslash.toSorted()).toEqual([String.raw`path\to\file`]);
+    });
   });
 
   describe("Array Predicates", () => {

--- a/packages/typegraph/tests/query-pagination.test.ts
+++ b/packages/typegraph/tests/query-pagination.test.ts
@@ -386,3 +386,65 @@ describe("Streaming", () => {
     ).toThrow(ValidationError);
   });
 });
+
+describe("Pagination with a non-unique sort key", () => {
+  it("returns every row across pages when the sort column has ties", async () => {
+    const store = createTestStore();
+    // Every person shares one age: the sort key is non-unique, so a keyset
+    // predicate over `age` alone (`age > lastAge`) would skip every
+    // not-yet-returned equal-age row. The id tiebreaker must keep the page
+    // boundary total.
+    const created = [];
+    for (let index = 1; index <= 25; index++) {
+      created.push(
+        await store.nodes.Person.create({
+          name: `Person_${String(index).padStart(2, "0")}`,
+          age: 30,
+        }),
+      );
+    }
+
+    const seen = new Set<string>();
+    let cursor: string | undefined;
+    for (let page = 0; page < 50; page++) {
+      const result = await store
+        .query()
+        .from("Person", "p")
+        .orderBy("p", "age")
+        .select((ctx) => ctx.p)
+        .paginate({ first: 5, ...(cursor ? { after: cursor } : {}) });
+      for (const person of result.data) seen.add(person.id);
+      if (!result.hasNextPage) break;
+      cursor = result.nextCursor!;
+    }
+
+    expect([...seen].toSorted()).toEqual(
+      created.map((person) => person.id).toSorted(),
+    );
+  });
+
+  it("streams every row exactly once when the sort column has ties", async () => {
+    const store = createTestStore();
+    const created = [];
+    for (let index = 1; index <= 30; index++) {
+      created.push(
+        await store.nodes.Person.create({ name: `P${index}`, age: 40 }),
+      );
+    }
+
+    const seen: string[] = [];
+    for await (const person of store
+      .query()
+      .from("Person", "p")
+      .orderBy("p", "age")
+      .select((ctx) => ctx.p)
+      .stream({ batchSize: 7 })) {
+      seen.push(person.id);
+    }
+
+    expect(seen.length).toBe(30); // no rows dropped, none repeated
+    expect([...new Set(seen)].toSorted()).toEqual(
+      created.map((person) => person.id).toSorted(),
+    );
+  });
+});


### PR DESCRIPTION
Two silent query-correctness bugs, both in the shared compiler (no dialect branching).

**Keyset pagination has no unique tiebreaker.** `paginate()`/`stream()` built the keyset over exactly the caller's ORDER BY, so a non-unique sort (e.g. `orderBy("p","age")` with many equal ages) produced a page-2 predicate of `age > lastAge` that skips every not-yet-returned equal-age row — silent data loss across pages/streams. A start-alias `id` tiebreaker is now appended through every pagination read (emitted sort, cursor predicate, cursor encoding, validation, and the selective-optimized path). Caveat: pre-upgrade cursors carry one fewer column and fail validation with a clear column-mismatch error (re-fetch); cursors are opaque/per-session.

**SQLite LIKE emits no ESCAPE clause.** The wildcard-escaping operators (`contains`/`startsWith`/`endsWith`) backslash-escape `%`/`_`/`\`, but no compiled LIKE/ILIKE declared an escape character. Postgres defaults to backslash so it worked there; SQLite has no default, so an escaped `\%` matched a literal backslash-then-anything — the backends silently diverged. Every compiled LIKE/ILIKE now emits `ESCAPE '\'` via a shared clause — including the case-sensitive `like` path, which appended the clause on the parameterized branch and via `dialect.ilike` but **not** on the literal branch, leaving raw `.like()` patterns diverging on SQLite (and between the direct and prepared paths). `compileStringPattern` now derives its wildcard-prefixing from the shared `LIKE_ESCAPE_CHARACTER` constant (previously an unused export that failed `test:unused`/knip). Postgres unchanged; SQLite aligns.

Adds a pagination regression test (non-unique sort returns every row across pages/streams) and cross-backend integration tests: literal `%`/`_`/`\` match literally via the auto-escaped operators, and raw `like`/`ilike` plus a bound parameter all honor `\_` as a literal underscore (verified failing before the fix — the literal path returned `[]` on SQLite). SQLite + Postgres green.
