### PR TITLE
fix(graph-merge): guard mergeIncremental against inherited-row lost updates

### DIFF
--- a/.changeset/graph-merge-incremental-lost-update.md
+++ b/.changeset/graph-merge-incremental-lost-update.md
@@ -4,9 +4,12 @@
 
 Guard `mergeIncremental()` against inherited-row lost updates. The incremental
 commit path re-checked new-row identity resolution and per-row resurrect/strip
-hazards, but not whether a committed row the plan overwrites still held the value
+hazards, but not whether a committed row the plan mutates still held the value
 the plan merged against — so a concurrent write to an inherited row between
 planning (reads taken outside the transaction) and commit was silently
-discarded. The commit now re-reads each planned write's row in-transaction and
-aborts with a retryable `BaseVersionMismatchError` if its version advanced,
-matching the snapshot merge path's TOCTOU contract.
+discarded. The commit now re-reads, in-transaction, every committed target row
+the plan will change and aborts with a retryable `BaseVersionMismatchError` if it
+drifted, matching the snapshot merge path's TOCTOU contract. This covers all four
+mutating paths: node writes and node deletions (checked by `version`), and edge
+upserts and edge deletions (checked by a content signature over endpoints,
+liveness, and canonical props, since edges carry no version column).

--- a/.changeset/graph-merge-incremental-lost-update.md
+++ b/.changeset/graph-merge-incremental-lost-update.md
@@ -1,0 +1,12 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Guard `mergeIncremental()` against inherited-row lost updates. The incremental
+commit path re-checked new-row identity resolution and per-row resurrect/strip
+hazards, but not whether a committed row the plan overwrites still held the value
+the plan merged against — so a concurrent write to an inherited row between
+planning (reads taken outside the transaction) and commit was silently
+discarded. The commit now re-reads each planned write's row in-transaction and
+aborts with a retryable `BaseVersionMismatchError` if its version advanced,
+matching the snapshot merge path's TOCTOU contract.

--- a/packages/typegraph/src/graph-merge/canonical-props.ts
+++ b/packages/typegraph/src/graph-merge/canonical-props.ts
@@ -72,6 +72,38 @@ export function canonicalValueKey(value: JsonValue): string {
 }
 
 /**
+ * A stable fingerprint of a committed edge's mergeable state — its endpoints,
+ * liveness, and canonical props. The incremental lost-update guard captures this
+ * for every target edge at plan time and re-derives it inside the commit
+ * transaction; a mismatch means the committed edge drifted in the plan→commit
+ * window, so applying the plan (built from the plan-time value) would silently
+ * overwrite that change. Edges carry no `version` column, so this content
+ * fingerprint is the node-`version` analogue for the edge half of the guard.
+ *
+ * @param edge Endpoints, liveness, and PARSED props (never a JSON string).
+ * @returns A canonical string; equal iff the two edge states are mergeably equal.
+ */
+export function edgeStateSignature(
+  edge: Readonly<{
+    fromKind: string;
+    fromId: string;
+    toKind: string;
+    toId: string;
+    live: boolean;
+    props: Readonly<Record<string, unknown>>;
+  }>,
+): string {
+  return JSON.stringify([
+    edge.fromKind,
+    edge.fromId,
+    edge.toKind,
+    edge.toId,
+    edge.live,
+    canonicalizeProps(edge.props),
+  ]);
+}
+
+/**
  * Parses a stored row's JSON `props` string into the PARSED plain object that
  * {@link canonicalizeProps} requires. Malformed JSON, a non-object, or an array
  * all collapse to `{}` — a parse error never escapes. Backend-written rows hold

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -47,7 +47,7 @@ import {
   contentComponentOf,
 } from "./base-version";
 import { blockNodes } from "./blocking";
-import { canonicalizeProps } from "./canonical-props";
+import { canonicalizeProps, edgeStateSignature } from "./canonical-props";
 import type { CanonicalEntity, ClusterMember } from "./canonicalize";
 import { BASE_PROVENANCE_BRANCH, canonicalizeCluster } from "./canonicalize";
 import { buildSubClassClosure } from "./closures";
@@ -1623,6 +1623,7 @@ async function resolveMerge<G extends GraphDef>(
             candidates.data.baseMembers.map((member) => mergeKeyOf(member)),
           ),
           targetNodeVersions: staging.targetNodeVersions,
+          targetEdgeSignatures: staging.targetEdgeSignatures,
         });
 
     // (10) assemble the report. The full provenance records are always built in the
@@ -2280,11 +2281,19 @@ type IncrementalCommitGuard<G extends GraphDef> = Readonly<{
   /**
    * `(kind, id) -> version` for every committed target node observed while
    * planning (the target-branch diff enumeration). The commit-time guard
-   * re-reads the rows the plan writes and refuses if any inherited row's version
-   * advanced in the plan→commit window — a concurrent write the stale plan would
-   * otherwise overwrite (lost update).
+   * re-reads the rows the plan writes OR deletes and refuses if any inherited
+   * row's version advanced in the plan→commit window — a concurrent write the
+   * stale plan would otherwise overwrite (lost update).
    */
   targetNodeVersions: ReadonlyMap<MergeKey, number>;
+  /**
+   * `(kind, id) -> content signature` for every committed target edge observed
+   * while planning. The edge-half analogue of {@link targetNodeVersions}: edges
+   * have no version, so the guard fingerprints their mergeable content
+   * (endpoints, liveness, canonical props) and refuses if the fingerprint of an
+   * edge the plan upserts OR deletes drifted in the plan→commit window.
+   */
+  targetEdgeSignatures: ReadonlyMap<MergeKey, string>;
 }>;
 
 /**
@@ -2390,22 +2399,63 @@ async function assertBaseResolutionStable<G extends GraphDef>(
   );
 }
 
+/** A `(kind, id)` the plan will mutate whose identity was an observed target row. */
+type InheritedTargetRef = Readonly<{ kind: string; id: string }>;
+
+/**
+ * Buckets the plan's inherited-target mutations by kind, deduped by identity, for
+ * a single batched re-read per kind. `identities` filters to the rows observed at
+ * plan time (new rows the plan creates have no baseline and are skipped). Both a
+ * write and a delete of the same identity collapse to one entry — either way the
+ * row is re-checked once.
+ */
+function bucketInheritedRefsByKind(
+  refs: Iterable<InheritedTargetRef>,
+  identities: ReadonlySet<MergeKey>,
+): ReadonlyMap<string, readonly string[]> {
+  const seen = new Set<MergeKey>();
+  const idsByKind = new Map<string, string[]>();
+  for (const ref of refs) {
+    const identity = mergeKey(ref.kind, ref.id);
+    if (!identities.has(identity) || seen.has(identity)) {
+      continue;
+    }
+    seen.add(identity);
+    const bucket = idsByKind.get(ref.kind) ?? [];
+    bucket.push(ref.id);
+    idsByKind.set(ref.kind, bucket);
+  }
+  return idsByKind;
+}
+
 /**
  * The inherited-target-row half of the incremental TOCTOU guard. The plan folds
  * the live target in as a preferred branch and resolves inherited modifications
  * against the target rows it enumerated OUTSIDE this transaction. If a committed
- * row the plan overwrites was modified in the plan→commit window, applying the
- * plan would discard that write (a silent lost update) — the per-row write
- * guards only check resurrection / lossy strips, not that the row still holds
- * the value the plan merged from.
+ * row the plan mutates was changed in the plan→commit window, applying the plan
+ * would discard that write (a silent lost update) — the per-row write guards only
+ * check resurrection / lossy strips, not that the row still holds the value the
+ * plan merged from.
  *
- * For every planned node write whose id was an observed target row, this
- * re-reads the current committed version through the tx snapshot and refuses the
- * plan if it advanced (or the row vanished). SERIALIZABLE + retry then re-plans
- * against the now-committed value, exactly as the snapshot path's
- * {@link assertTargetUnchanged} does for full-graph drift.
+ * Covers every path that mutates a committed target row: node writes and node
+ * deletions (checked by `version`), and edge upserts and edge deletions (checked
+ * by content signature, since edges carry no version). For each, it re-reads the
+ * committed row through the tx snapshot and refuses if it drifted (or vanished).
+ * SERIALIZABLE + retry then re-plans against the now-committed value, exactly as
+ * the snapshot path's {@link assertTargetUnchanged} does for full-graph drift.
  */
 async function assertInheritedTargetUnchanged<G extends GraphDef>(
+  nodesApi: TxNodes,
+  edgesApi: TxEdges,
+  guard: IncrementalCommitGuard<G>,
+  plan: MergePlan<G>,
+): Promise<void> {
+  await assertInheritedNodesUnchanged(nodesApi, guard, plan);
+  await assertInheritedEdgesUnchanged(edgesApi, guard, plan);
+}
+
+/** Version-checks every committed target node the plan writes or deletes. */
+async function assertInheritedNodesUnchanged<G extends GraphDef>(
   nodesApi: TxNodes,
   guard: IncrementalCommitGuard<G>,
   plan: MergePlan<G>,
@@ -2414,15 +2464,16 @@ async function assertInheritedTargetUnchanged<G extends GraphDef>(
   if (targetNodeVersions.size === 0) {
     return;
   }
-  const idsByKind = new Map<string, AnyNodeId[]>();
-  for (const write of plannedNodeWrites(plan)) {
-    if (!targetNodeVersions.has(write.identity)) {
-      continue; // not a committed target row observed at plan time
-    }
-    const bucket = idsByKind.get(write.kind) ?? [];
-    bucket.push(write.id);
-    idsByKind.set(write.kind, bucket);
+  const nodeRefs: InheritedTargetRef[] = plannedNodeWrites(plan).map(
+    (write) => ({ kind: write.kind, id: write.id }),
+  );
+  for (const [identity, kind] of plan.nodeDeletions) {
+    nodeRefs.push({ kind, id: idOf(identity) });
   }
+  const idsByKind = bucketInheritedRefsByKind(
+    nodeRefs,
+    new Set(targetNodeVersions.keys()),
+  );
   for (const [kind, ids] of idsByKind) {
     const rows = await nodeCollection(nodesApi, kind).getByIds(
       ids,
@@ -2443,6 +2494,67 @@ async function assertInheritedTargetUnchanged<G extends GraphDef>(
             expectedVersion: expected,
             currentVersion: current?.meta.version,
           },
+          suggestion:
+            "Re-run mergeIncremental(); the re-planned merge resolves the inherited modifications against the now-committed rows.",
+        },
+      );
+    }
+  }
+}
+
+/**
+ * Signature-checks every committed target edge the plan upserts or deletes. Edges
+ * carry no `version`, so the plan-time baseline is a content fingerprint
+ * ({@link edgeStateSignature}) captured over the target's edge enumeration; a
+ * changed fingerprint means the committed edge's endpoints, liveness, or props
+ * drifted in the plan→commit window.
+ */
+async function assertInheritedEdgesUnchanged<G extends GraphDef>(
+  edgesApi: TxEdges,
+  guard: IncrementalCommitGuard<G>,
+  plan: MergePlan<G>,
+): Promise<void> {
+  const { targetEdgeSignatures } = guard;
+  if (targetEdgeSignatures.size === 0) {
+    return;
+  }
+  const edgeRefs: InheritedTargetRef[] = plan.mergedEdges.map((edge) => ({
+    kind: edge.kind,
+    id: edge.id,
+  }));
+  for (const [identity, kind] of plan.edgeDeletions) {
+    edgeRefs.push({ kind, id: idOf(identity) });
+  }
+  const idsByKind = bucketInheritedRefsByKind(
+    edgeRefs,
+    new Set(targetEdgeSignatures.keys()),
+  );
+  for (const [kind, ids] of idsByKind) {
+    const rows = await edgeCollection(edgesApi, kind).getByIds(
+      ids,
+      INCLUDE_TOMBSTONES,
+    );
+    for (const [index, id] of ids.entries()) {
+      const expected = targetEdgeSignatures.get(mergeKey(kind, id))!;
+      const current = rows[index];
+      const currentSignature =
+        current === undefined ? undefined : (
+          edgeStateSignature({
+            fromKind: current.fromKind,
+            fromId: current.fromId,
+            toKind: current.toKind,
+            toId: current.toId,
+            live: current.meta.deletedAt === undefined,
+            props: edgeProps(current),
+          })
+        );
+      if (currentSignature === expected) {
+        continue;
+      }
+      throw new BaseVersionMismatchError(
+        `mergeIncremental() observed committed edge "${id}" (kind "${kind}") while planning, but its endpoints, liveness, or props changed before the commit transaction; the resolved plan no longer describes the live target and was not applied.`,
+        {
+          details: { id, kind },
           suggestion:
             "Re-run mergeIncremental(); the re-planned merge resolves the inherited modifications against the now-committed rows.",
         },
@@ -2481,9 +2593,9 @@ async function commitIncrementalPlan<G extends GraphDef>(
       // plan if a matching committed row appeared in the window. `tx` exposes
       // the same `.nodes` collection record a `BaseLookupStore` needs.
       await assertBaseResolutionStable(tx as unknown as BaseLookupStore, guard);
-      // Inherited-row TOCTOU guard: refuse if a committed row the plan
-      // overwrites changed since it was observed at plan time (lost update).
-      await assertInheritedTargetUnchanged(nodesApi, guard, plan);
+      // Inherited-row TOCTOU guard: refuse if a committed node OR edge the plan
+      // writes or deletes changed since it was observed at plan time (lost update).
+      await assertInheritedTargetUnchanged(nodesApi, edgesApi, guard, plan);
       await validateIncrementalNodeWrites(target, nodesApi, plan);
       await validateIncrementalEdgeWrites(target, edgesApi, plan);
       return applyMergePlan(plan, nodesApi, edgesApi);

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -1528,8 +1528,15 @@ async function resolveMerge<G extends GraphDef>(
   }
 
   try {
-    // (2) stage the provenance-tagged union of every branch's diff.
-    const staging = await stageBranches(store, branches);
+    // (2) stage the provenance-tagged union of every branch's diff. For the
+    // incremental path, capture the committed target branch's node versions from
+    // its diff enumeration — the plan-time baseline for the commit-time
+    // lost-update guard (assertInheritedTargetUnchanged).
+    const staging = await stageBranches(
+      store,
+      branches,
+      incremental?.targetBranchId,
+    );
 
     // Capture the stable branch order ONCE (never wall-clock).
     const preferredBranchId = incremental?.targetBranchId;
@@ -1615,6 +1622,7 @@ async function resolveMerge<G extends GraphDef>(
           plannedBaseMatchKeys: new Set(
             candidates.data.baseMembers.map((member) => mergeKeyOf(member)),
           ),
+          targetNodeVersions: staging.targetNodeVersions,
         });
 
     // (10) assemble the report. The full provenance records are always built in the
@@ -2269,6 +2277,14 @@ type IncrementalCommitGuard<G extends GraphDef> = Readonly<{
   options: NormalizedMergeOptions<G>;
   introspectionKinds: ReadonlyMap<string, readonly UniqueIntrospection[]>;
   plannedBaseMatchKeys: ReadonlySet<MergeKey>;
+  /**
+   * `(kind, id) -> version` for every committed target node observed while
+   * planning (the target-branch diff enumeration). The commit-time guard
+   * re-reads the rows the plan writes and refuses if any inherited row's version
+   * advanced in the plan→commit window — a concurrent write the stale plan would
+   * otherwise overwrite (lost update).
+   */
+  targetNodeVersions: ReadonlyMap<MergeKey, number>;
 }>;
 
 /**
@@ -2375,6 +2391,67 @@ async function assertBaseResolutionStable<G extends GraphDef>(
 }
 
 /**
+ * The inherited-target-row half of the incremental TOCTOU guard. The plan folds
+ * the live target in as a preferred branch and resolves inherited modifications
+ * against the target rows it enumerated OUTSIDE this transaction. If a committed
+ * row the plan overwrites was modified in the plan→commit window, applying the
+ * plan would discard that write (a silent lost update) — the per-row write
+ * guards only check resurrection / lossy strips, not that the row still holds
+ * the value the plan merged from.
+ *
+ * For every planned node write whose id was an observed target row, this
+ * re-reads the current committed version through the tx snapshot and refuses the
+ * plan if it advanced (or the row vanished). SERIALIZABLE + retry then re-plans
+ * against the now-committed value, exactly as the snapshot path's
+ * {@link assertTargetUnchanged} does for full-graph drift.
+ */
+async function assertInheritedTargetUnchanged<G extends GraphDef>(
+  nodesApi: TxNodes,
+  guard: IncrementalCommitGuard<G>,
+  plan: MergePlan<G>,
+): Promise<void> {
+  const { targetNodeVersions } = guard;
+  if (targetNodeVersions.size === 0) {
+    return;
+  }
+  const idsByKind = new Map<string, AnyNodeId[]>();
+  for (const write of plannedNodeWrites(plan)) {
+    if (!targetNodeVersions.has(write.identity)) {
+      continue; // not a committed target row observed at plan time
+    }
+    const bucket = idsByKind.get(write.kind) ?? [];
+    bucket.push(write.id);
+    idsByKind.set(write.kind, bucket);
+  }
+  for (const [kind, ids] of idsByKind) {
+    const rows = await nodeCollection(nodesApi, kind).getByIds(
+      ids,
+      INCLUDE_TOMBSTONES,
+    );
+    for (const [index, id] of ids.entries()) {
+      const expected = targetNodeVersions.get(mergeKey(kind, id))!;
+      const current = rows[index];
+      if (current?.meta.version === expected) {
+        continue;
+      }
+      throw new BaseVersionMismatchError(
+        `mergeIncremental() observed committed node "${id}" (kind "${kind}") at version ${expected} while planning, but it changed before the commit transaction; the resolved plan no longer describes the live target and was not applied.`,
+        {
+          details: {
+            id,
+            kind,
+            expectedVersion: expected,
+            currentVersion: current?.meta.version,
+          },
+          suggestion:
+            "Re-run mergeIncremental(); the re-planned merge resolves the inherited modifications against the now-committed rows.",
+        },
+      );
+    }
+  }
+}
+
+/**
  * The full incremental commit path (§6.6). The planner has already folded the live
  * target in as a preferred synthetic branch, so this path preflights destructive
  * row hazards inside the target transaction and then applies the normal merge plan.
@@ -2404,6 +2481,9 @@ async function commitIncrementalPlan<G extends GraphDef>(
       // plan if a matching committed row appeared in the window. `tx` exposes
       // the same `.nodes` collection record a `BaseLookupStore` needs.
       await assertBaseResolutionStable(tx as unknown as BaseLookupStore, guard);
+      // Inherited-row TOCTOU guard: refuse if a committed row the plan
+      // overwrites changed since it was observed at plan time (lost update).
+      await assertInheritedTargetUnchanged(nodesApi, guard, plan);
       await validateIncrementalNodeWrites(target, nodesApi, plan);
       await validateIncrementalEdgeWrites(target, edgesApi, plan);
       return applyMergePlan(plan, nodesApi, edgesApi);

--- a/packages/typegraph/src/graph-merge/staging.ts
+++ b/packages/typegraph/src/graph-merge/staging.ts
@@ -27,7 +27,7 @@
  *   than one branch, so the ordering is total and stable.
  */
 
-import { compareStrings } from "./node-key";
+import { compareStrings, type MergeKey } from "./node-key";
 import type {
   ChangedEdge,
   ChangedNode,
@@ -96,6 +96,14 @@ export type StagingSet = Readonly<{
   modifiedEdges: readonly StagedModifiedEdge[];
   /** Deleted inherited edges (one entry per (id, branch) deletion). */
   deletedEdges: readonly StagedDeletedEdge[];
+  /**
+   * `(kind, id) -> version` for the nodes of the branch named by
+   * `stageBranches`' `captureNodeVersionsFor` argument, observed by that
+   * branch's diff enumeration. Empty when no branch was requested. The
+   * incremental merge captures the committed target branch here to use as the
+   * plan-time baseline for its commit-time lost-update guard.
+   */
+  targetNodeVersions: ReadonlyMap<MergeKey, number>;
 }>;
 
 /**
@@ -173,6 +181,7 @@ function groupByKind<
 export async function stageBranches<G extends GraphDef>(
   baseStore: Store<G>,
   branches: readonly GraphBranch<G>[],
+  captureNodeVersionsFor?: BranchId,
 ): Promise<StagingSet> {
   const newNodes: (StagedNewNode & { kind: string; id: string })[] = [];
   const modifiedNodes: (StagedModifiedNode & { kind: string; id: string })[] =
@@ -183,9 +192,13 @@ export async function stageBranches<G extends GraphDef>(
     [];
   const deletedEdges: (StagedDeletedEdge & { kind: string; id: string })[] = [];
 
+  let targetNodeVersions: ReadonlyMap<MergeKey, number> = new Map();
   for (const branch of branches) {
     const diff = await diffAgainstBase(baseStore, branch.store);
     const branchId = branch.id;
+    if (branchId === captureNodeVersionsFor) {
+      targetNodeVersions = diff.forkNodeVersions;
+    }
 
     for (const node of diff.nodes.new) {
       newNodes.push({ branchId, node, kind: node.kind, id: node.id });
@@ -222,5 +235,6 @@ export async function stageBranches<G extends GraphDef>(
     deletedEdges: [...deletedEdges].sort((left, right) =>
       compareByKindIdBranch(left, right),
     ),
+    targetNodeVersions,
   };
 }

--- a/packages/typegraph/src/graph-merge/staging.ts
+++ b/packages/typegraph/src/graph-merge/staging.ts
@@ -98,12 +98,19 @@ export type StagingSet = Readonly<{
   deletedEdges: readonly StagedDeletedEdge[];
   /**
    * `(kind, id) -> version` for the nodes of the branch named by
-   * `stageBranches`' `captureNodeVersionsFor` argument, observed by that
+   * `stageBranches`' `captureTargetStateFor` argument, observed by that
    * branch's diff enumeration. Empty when no branch was requested. The
    * incremental merge captures the committed target branch here to use as the
    * plan-time baseline for its commit-time lost-update guard.
    */
   targetNodeVersions: ReadonlyMap<MergeKey, number>;
+  /**
+   * `(kind, id) -> edge content signature` for the edges of the same captured
+   * branch. The edge-half analogue of {@link targetNodeVersions} (edges carry no
+   * version, so the guard fingerprints their content). Empty when no branch was
+   * requested.
+   */
+  targetEdgeSignatures: ReadonlyMap<MergeKey, string>;
 }>;
 
 /**
@@ -181,7 +188,7 @@ function groupByKind<
 export async function stageBranches<G extends GraphDef>(
   baseStore: Store<G>,
   branches: readonly GraphBranch<G>[],
-  captureNodeVersionsFor?: BranchId,
+  captureTargetStateFor?: BranchId,
 ): Promise<StagingSet> {
   const newNodes: (StagedNewNode & { kind: string; id: string })[] = [];
   const modifiedNodes: (StagedModifiedNode & { kind: string; id: string })[] =
@@ -193,11 +200,13 @@ export async function stageBranches<G extends GraphDef>(
   const deletedEdges: (StagedDeletedEdge & { kind: string; id: string })[] = [];
 
   let targetNodeVersions: ReadonlyMap<MergeKey, number> = new Map();
+  let targetEdgeSignatures: ReadonlyMap<MergeKey, string> = new Map();
   for (const branch of branches) {
     const diff = await diffAgainstBase(baseStore, branch.store);
     const branchId = branch.id;
-    if (branchId === captureNodeVersionsFor) {
+    if (branchId === captureTargetStateFor) {
       targetNodeVersions = diff.forkNodeVersions;
+      targetEdgeSignatures = diff.forkEdgeSignatures;
     }
 
     for (const node of diff.nodes.new) {
@@ -236,5 +245,6 @@ export async function stageBranches<G extends GraphDef>(
       compareByKindIdBranch(left, right),
     ),
     targetNodeVersions,
+    targetEdgeSignatures,
   };
 }

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -24,7 +24,11 @@
  * Concurrent-write enumeration is a P1 concern.
  */
 
-import { canonicalizeProps, parseRowProps } from "./canonical-props";
+import {
+  canonicalizeProps,
+  edgeStateSignature,
+  parseRowProps,
+} from "./canonical-props";
 import { compareStrings, type MergeKey, mergeKey } from "./node-key";
 import type {
   EdgeId,
@@ -160,6 +164,15 @@ export type StateDiff = Readonly<{
    * lost-update guard (see assertInheritedTargetUnchanged in merge.ts).
    */
   forkNodeVersions: ReadonlyMap<MergeKey, number>;
+  /**
+   * `(kind, id) -> {@link edgeStateSignature}` for every fork-store edge observed
+   * during this diff (live and soft-deleted). The edge-half analogue of
+   * {@link forkNodeVersions}: edges carry no `version` column, so the guard
+   * fingerprints their mergeable content (endpoints, liveness, canonical props)
+   * instead. The incremental merge uses the target branch's map as the plan-time
+   * baseline for the commit-time lost-update guard.
+   */
+  forkEdgeSignatures: ReadonlyMap<MergeKey, string>;
 }>;
 
 /**
@@ -436,6 +449,10 @@ export async function diffAgainstBase<G extends GraphDef>(
   const newEdges: ChangedEdge[] = [];
   const modifiedEdges: ModifiedEdge[] = [];
   const deletedEdges: DeletedEdge[] = [];
+  // Content fingerprint of the fork store's edges as observed by THIS diff's
+  // enumeration — the edge-half baseline for the commit-time lost-update guard
+  // (edges have no version, so we key on mergeable content instead).
+  const forkEdgeSignatures = new Map<MergeKey, string>();
 
   for (const kind of edgeKinds) {
     const baseRows = await enumerateAllEdges(
@@ -448,6 +465,19 @@ export async function diffAgainstBase<G extends GraphDef>(
       forkStore.graphId,
       kind,
     );
+    for (const row of forkRows) {
+      forkEdgeSignatures.set(
+        mergeKey(kind, row.id),
+        edgeStateSignature({
+          fromKind: row.from_kind,
+          fromId: row.from_id,
+          toKind: row.to_kind,
+          toId: row.to_id,
+          live: isLive(row),
+          props: parseRowProps(row.props),
+        }),
+      );
+    }
     const delta = diffEdgeKind(kind, baseRows, forkRows);
     for (const entry of delta.new) {
       newEdges.push(entry);
@@ -472,5 +502,6 @@ export async function diffAgainstBase<G extends GraphDef>(
       deleted: deletedEdges.sort((left, right) => byId(left, right)),
     },
     forkNodeVersions,
+    forkEdgeSignatures,
   };
 }

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -25,7 +25,7 @@
  */
 
 import { canonicalizeProps, parseRowProps } from "./canonical-props";
-import { compareStrings, type MergeKey,mergeKey } from "./node-key";
+import { compareStrings, type MergeKey, mergeKey } from "./node-key";
 import type {
   EdgeId,
   GraphBackend,

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -25,7 +25,7 @@
  */
 
 import { canonicalizeProps, parseRowProps } from "./canonical-props";
-import { compareStrings } from "./node-key";
+import { compareStrings, type MergeKey,mergeKey } from "./node-key";
 import type {
   EdgeId,
   GraphBackend,
@@ -152,6 +152,14 @@ export type StateDiff = Readonly<{
     modified: readonly ModifiedEdge[];
     deleted: readonly DeletedEdge[];
   }>;
+  /**
+   * `(kind, id) -> version` for every fork-store node observed during this diff
+   * (live and soft-deleted). Captured from the same enumeration the diff reads,
+   * so it is the fork's exact observed state — the incremental merge uses the
+   * target branch's map as the plan-time baseline for its commit-time
+   * lost-update guard (see assertInheritedTargetUnchanged in merge.ts).
+   */
+  forkNodeVersions: ReadonlyMap<MergeKey, number>;
 }>;
 
 /**
@@ -395,6 +403,9 @@ export async function diffAgainstBase<G extends GraphDef>(
   const newNodes: ChangedNode[] = [];
   const modifiedNodes: ModifiedNode[] = [];
   const deletedNodes: DeletedNode[] = [];
+  // Version snapshot of the fork store as observed by THIS diff's enumeration
+  // (the same read the plan resolves against), keyed by merge identity.
+  const forkNodeVersions = new Map<MergeKey, number>();
 
   for (const kind of nodeKinds) {
     const baseRows = await enumerateAllNodes(
@@ -407,6 +418,9 @@ export async function diffAgainstBase<G extends GraphDef>(
       forkStore.graphId,
       kind,
     );
+    for (const row of forkRows) {
+      forkNodeVersions.set(mergeKey(kind, row.id), row.version);
+    }
     const delta = diffNodeKind(kind, baseRows, forkRows);
     for (const entry of delta.new) {
       newNodes.push(entry);
@@ -457,5 +471,6 @@ export async function diffAgainstBase<G extends GraphDef>(
       modified: modifiedEdges.sort((left, right) => byId(left, right)),
       deleted: deletedEdges.sort((left, right) => byId(left, right)),
     },
+    forkNodeVersions,
   };
 }

--- a/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
@@ -443,6 +443,145 @@ describe.each(backendMatrix())(
       expect(await target.edges.hadEncounter.find()).toEqual([]);
     });
 
+    it("REFUSES an inherited node DELETION when the target row changed in the window", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const [base] = await forkPoint.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.delete(base!.id);
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      // Concurrent edit to the row the branch DELETES, inside the plan→commit
+      // window. The plan's node deletion is stale; applying it would discard the
+      // concurrent edit (a silent lost update the node-write guard missed because
+      // deletions are not planned writes).
+      const original = target.transaction.bind(target);
+      let injected = false;
+      (target as { transaction: unknown }).transaction = async (
+        fn: unknown,
+        opts: unknown,
+      ) => {
+        if (!injected) {
+          injected = true;
+          await target.nodes.Patient.update(base!.id, {
+            name: "Concurrent Edit",
+          });
+        }
+        return (original as (f: unknown, o: unknown) => unknown)(fn, opts);
+      };
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+      }
+      // The stale deletion applied nothing; the row is still live with the edit.
+      (target as { transaction: unknown }).transaction = original;
+      const [patient] = await target.nodes.Patient.find();
+      expect(patient?.name).toBe("Concurrent Edit");
+    });
+
+    it("REFUSES an inherited edge MODIFICATION when the target edge changed in the window", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const baseEdge = await seedCarePath(forkPoint);
+      const provider = await forkOf(forkPoint);
+      await provider.store.edges.hadEncounter.update(baseEdge.id, {
+        on: "2026-06-15",
+      });
+      const target = await emptyStore();
+      await seedCarePath(target);
+
+      // Concurrent edit to the SAME edge the branch modifies, inside the window.
+      // The plan would overwrite it with the stale "2026-06-15" — the exact edge
+      // lost update the node-only guard missed (edges have no version).
+      const original = target.transaction.bind(target);
+      let injected = false;
+      (target as { transaction: unknown }).transaction = async (
+        fn: unknown,
+        opts: unknown,
+      ) => {
+        if (!injected) {
+          injected = true;
+          await target.edges.hadEncounter.update(baseEdge.id, {
+            on: "2026-07-01",
+          });
+        }
+        return (original as (f: unknown, o: unknown) => unknown)(fn, opts);
+      };
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+      }
+      // The concurrent edge edit survives; the stale plan did not overwrite it.
+      (target as { transaction: unknown }).transaction = original;
+      const [edge] = await target.edges.hadEncounter.find();
+      expect(edge?.on).toBe("2026-07-01");
+    });
+
+    it("REFUSES an inherited edge DELETION when the target edge changed in the window", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const baseEdge = await seedCarePath(forkPoint);
+      const provider = await forkOf(forkPoint);
+      await provider.store.edges.hadEncounter.delete(baseEdge.id);
+      const target = await emptyStore();
+      await seedCarePath(target);
+
+      // Concurrent edit to the edge the branch DELETES, inside the window. The
+      // plan's edge deletion is stale; applying it would discard the concurrent
+      // edit (nothing guarded edge deletions before).
+      const original = target.transaction.bind(target);
+      let injected = false;
+      (target as { transaction: unknown }).transaction = async (
+        fn: unknown,
+        opts: unknown,
+      ) => {
+        if (!injected) {
+          injected = true;
+          await target.edges.hadEncounter.update(baseEdge.id, {
+            on: "2026-07-01",
+          });
+        }
+        return (original as (f: unknown, o: unknown) => unknown)(fn, opts);
+      };
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+      }
+      // The stale deletion applied nothing; the edge is still live with the edit.
+      (target as { transaction: unknown }).transaction = original;
+      const [edge] = await target.edges.hadEncounter.find();
+      expect(edge?.on).toBe("2026-07-01");
+    });
+
     it("TARGET WINS: target modification survives a branch deletion", async () => {
       cleanups = [];
       const forkPoint = await emptyStore();

--- a/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
@@ -26,6 +26,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { branch } from "../../src/graph-merge/branch";
+import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
 import { mergeIncremental } from "../../src/graph-merge/merge";
 import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
 import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
@@ -276,6 +277,103 @@ describe.each(backendMatrix())(
       }
       const [patient] = await target.nodes.Patient.find();
       expect(patient?.name).toBe("Anna R.");
+    });
+
+    it("REFUSES the commit when an inherited row the plan overwrites changed in the window", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const [base] = await forkPoint.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.update(base!.id, { name: "Anna R." });
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      // Concurrent write to the SAME inherited row inside the plan→commit
+      // window: it bumps the committed version, so the plan's merged value is
+      // stale. `injected` flips before the write so the transaction the write
+      // itself opens does not re-enter the injection.
+      const original = target.transaction.bind(target);
+      let injected = false;
+      (target as { transaction: unknown }).transaction = async (
+        fn: unknown,
+        opts: unknown,
+      ) => {
+        if (!injected) {
+          injected = true;
+          await target.nodes.Patient.update(base!.id, {
+            name: "Concurrent Edit",
+          });
+        }
+        return (original as (f: unknown, o: unknown) => unknown)(fn, opts);
+      };
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+      }
+
+      // The stale plan applied nothing; the concurrent edit survives (no lost
+      // update). Before this guard, the plan silently overwrote it with "Anna R.".
+      (target as { transaction: unknown }).transaction = original;
+      const [patient] = await target.nodes.Patient.find();
+      expect(patient?.name).toBe("Concurrent Edit");
+    });
+
+    it("TOLERATES a window write to an UNRELATED row the plan does not touch", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const [base] = await forkPoint.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.update(base!.id, { name: "Anna R." });
+      const target = await emptyStore();
+      await target.nodes.Patient.bulkCreate([
+        { id: "base-ana", props: { name: "Anna Rivera", mrn: "MRN-1" } },
+      ]);
+
+      // A window write that inserts a DIFFERENT patient the plan never observed
+      // or writes — incremental merge is defined against an advancing target, so
+      // this must commit cleanly.
+      const original = target.transaction.bind(target);
+      let injected = false;
+      (target as { transaction: unknown }).transaction = async (
+        fn: unknown,
+        opts: unknown,
+      ) => {
+        if (!injected) {
+          injected = true;
+          await target.nodes.Patient.bulkCreate([
+            { id: "unrelated-1", props: { name: "Someone Else", mrn: "MRN-2" } },
+          ]);
+        }
+        return (original as (f: unknown, o: unknown) => unknown)(fn, opts);
+      };
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+
+      expect(isOk(result)).toBe(true);
+      (target as { transaction: unknown }).transaction = original;
+      const ana = (await target.nodes.Patient.find()).find(
+        (patient) => patient.id === base!.id,
+      );
+      expect(ana?.name).toBe("Anna R.");
     });
 
     it("APPLIES an inherited node deletion when the target is unchanged", async () => {

--- a/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
@@ -355,7 +355,10 @@ describe.each(backendMatrix())(
         if (!injected) {
           injected = true;
           await target.nodes.Patient.bulkCreate([
-            { id: "unrelated-1", props: { name: "Someone Else", mrn: "MRN-2" } },
+            {
+              id: "unrelated-1",
+              props: { name: "Someone Else", mrn: "MRN-2" },
+            },
           ]);
         }
         return (original as (f: unknown, o: unknown) => unknown)(fn, opts);


### PR DESCRIPTION
The snapshot merge path re-derives the whole-target fingerprint inside its SERIALIZABLE commit and aborts on drift. The incremental path can't (it's defined against an advancing target) and its guards covered only new-row identity resolution and per-row resurrect/strip — not whether an **inherited** row the plan mutates still held the value the plan merged against. So a concurrent write to a committed row between planning (reads taken outside the tx) and commit was silently discarded: `applyMergePlan` upserted the stale 3-way-merged value or applied a stale deletion. SERIALIZABLE can't catch it because the plan's read predates the transaction.

The commit-time guard now re-reads, in-transaction, **every committed target row the plan will change** and throws a retryable `BaseVersionMismatchError` on drift (matching the snapshot path's contract). This covers all four mutating paths:

- **Node writes and node deletions** — `diffAgainstBase` captures `(kind,id) → version` for every fork-store node from the enumeration it already performs (no extra queries); the guard version-checks the rows the plan writes *and* the rows it deletes.
- **Edge upserts and edge deletions** — edges carry no `version` column, so `diffAgainstBase` captures a content signature over endpoints + liveness + canonical props (`edgeStateSignature`) for every fork-store edge; the guard re-derives it in-tx and refuses if an edge the plan upserts or deletes drifted.

`stageBranches` surfaces the committed target branch's node-version and edge-signature maps; the baselines are captured from the plan's own read, so there's no masking window and unrelated target advances stay tolerated.

Adds deterministic regression tests (wrapping `target.transaction` to inject a window write): concurrent edits to an inherited node the branch overwrites, a node the branch deletes, an edge the branch modifies, and an edge the branch deletes are each refused with the concurrent value preserved; a window write to an unrelated row still commits. The four lost-update races were verified failing on both SQLite and PGlite before the fix. Runs on every backend via the shared merge matrix, including production Postgres (the SERIALIZABLE path).
