### PR TITLE
refactor(store): type-check the remaining StoreView read-name arrays

### DIFF
--- a/.changeset/store-view-read-name-guard.md
+++ b/.changeset/store-view-read-name-guard.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Type-check the remaining StoreView read-name buckets. `CURRENT_ONLY_READ_NAMES`
+and `EDGE_BATCH_READ_NAMES` were plain `as const` arrays while every sibling
+bucket carried a `satisfies readonly (keyof Collection)[]` guard, so a renamed
+or mistyped method in those two would have gone uncaught at compile time. All
+six buckets are now checked against the live collection keys. Compile-time only.

--- a/packages/typegraph/src/store/collection-surface.ts
+++ b/packages/typegraph/src/store/collection-surface.ts
@@ -36,7 +36,7 @@ export const CURRENT_ONLY_READ_NAMES = [
   "findByConstraint",
   "bulkFindByConstraint",
   "bulkFindByIndex",
-] as const;
+] as const satisfies readonly (keyof NodeCollection<NodeType, string>)[];
 
 /** Node write method names: never available on a read-only StoreView. */
 export const NODE_WRITE_NAMES = [
@@ -75,7 +75,11 @@ export const EDGE_BATCH_READ_NAMES = [
   "batchFindFrom",
   "batchFindTo",
   "batchFindByEndpoints",
-] as const;
+] as const satisfies readonly (keyof EdgeCollection<
+  AnyEdgeType,
+  NodeType,
+  NodeType
+>)[];
 
 /** Edge write method names: never available on a read-only StoreView. */
 export const EDGE_WRITE_NAMES = [


### PR DESCRIPTION
`CURRENT_ONLY_READ_NAMES` and `EDGE_BATCH_READ_NAMES` were plain `as const` arrays while every sibling StoreView bucket (temporal reads, writes, search reads) carries a `satisfies readonly (keyof Collection)[]` guard. The file's own doc comment calls these arrays the type-level source of truth for the StoreView surface, so a renamed or mistyped method in those two would have gone uncaught at compile time (only the runtime partition test would catch it). All six buckets are now checked against the live collection keys.