### PR TITLE
perf: batch bulkCreate and importGraph round trips 

### DIFF
--- a/.changeset/bulk-create-batching.md
+++ b/.changeset/bulk-create-batching.md
@@ -1,0 +1,25 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+`bulkCreate` now batches its round trips end to end instead of degenerating
+into per-row statements around one multi-row INSERT.
+
+- Validation probes: per-row existence checks collapse into one `getNodes`
+  per kind, and per-row uniqueness pre-checks into one `checkUniqueBatch`
+  per (constraint, kind) — the batch validation caches are primed up front,
+  so the per-row checks run against memory. Validation now runs as a
+  synchronous first pass, so a later row's validation error can surface
+  before an earlier row's constraint error (both fail the whole batch).
+- Side effects: uniqueness entries write through a new `insertUniqueBatch`
+  (multi-row conditional upsert with the same per-entry `UniquenessError`
+  semantics), fulltext sync goes through the existing `upsertFulltextBatch`,
+  and embedding sync through a new `upsertEmbeddingBatch` per
+  (kind, field) — implemented for pgvector, sqlite-vec, and libSQL native
+  vectors via an optional `VectorStrategy.buildUpsertBatch` seam with a
+  per-row fallback for custom strategies.
+
+Measured on the write bench (in-memory SQLite, 100-row batches of nodes
+with searchable + embedding fields): ~1,600 → ~4,100 rows/s (~2.6×). The
+win compounds on per-statement-networked engines (Turso, D1, Neon), where
+each eliminated statement is a network round trip.

--- a/.changeset/import-batching.md
+++ b/.changeset/import-batching.md
@@ -1,0 +1,22 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+`importGraph` now processes each `batchSize` slice with batched round trips
+instead of fully single-row statements. Nodes: one `getNodes` per kind for
+existence, one `checkUniqueBatch` per (constraint, kind) for uniqueness
+pre-checks, one multi-row insert, and one batched side-effect pass
+(uniqueness entries, fulltext, embeddings) for the accepted creates.
+Edges: one `getNodes` per endpoint kind for reference liveness, one
+`getEdges` for existence, and one multi-row insert.
+
+Per-row semantics are unchanged: conflicts route by `onConflict`, a
+uniqueness conflict is recorded as a per-row error entry (the rest of the
+import proceeds), reference validation still rejects missing or tombstoned
+endpoints, and rows repeating an id within a slice fall back to the
+per-row path so they observe the first occurrence's row exactly as before.
+
+Measured on the write bench (in-memory SQLite, 500 nodes + 500 edges per
+import): ~26k → ~96k entities/s (~4×). The win compounds on
+per-statement-networked engines (Turso, D1, Neon), where the old path paid
+one round trip per row and the new one pays a handful per slice.

--- a/packages/benchmarks/src/write-bench.ts
+++ b/packages/benchmarks/src/write-bench.ts
@@ -187,6 +187,25 @@ const SHAPES: readonly WriteShape[] = [
     },
   },
   {
+    // Same rows as write:doc-create but through bulkCreate — the shape
+    // that exercises batched sidecar sync (fulltext + embeddings).
+    label: "write:bulk-doc-create",
+    ops: DOC_CREATE_OPS,
+    prepare: (store) => {
+      const inputs = Array.from({ length: DOC_CREATE_OPS }, () => ({
+        props: {
+          title: nextId("bulkdoc"),
+          body: DOC_BODY,
+          category: "bench",
+          embedding: buildEmbedding(),
+        },
+      }));
+      return async () => {
+        await store.nodes.Doc.bulkCreate(inputs);
+      };
+    },
+  },
+  {
     label: "write:import",
     ops: IMPORT_NODE_COUNT + IMPORT_EDGE_COUNT,
     prepare: (store) => {

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -85,6 +85,7 @@ export type CommonOperationBackend = Pick<
   | "insertNodesBatch"
   | "insertNodesBatchReturning"
   | "insertUnique"
+  | "insertUniqueBatch"
   | "updateEdge"
   | "updateNode"
 > &
@@ -140,6 +141,7 @@ type OperationBackendBatchConfig = Readonly<{
   getEdgesChunkSize: number;
   getNodesChunkSize: number;
   nodeInsertBatchSize: number;
+  uniqueInsertBatchSize: number;
 }>;
 
 type OperationBackendRowMappers = Readonly<{
@@ -485,6 +487,68 @@ export function createCommonOperationBackend(
           newId: params.nodeId,
           fields: [],
         });
+      }
+    },
+
+    async insertUniqueBatch(
+      entries: readonly InsertUniqueParams[],
+    ): Promise<void> {
+      if (entries.length === 0) return;
+
+      // A multi-row upsert cannot affect one row twice, so collapse exact
+      // duplicates and reject two entries claiming the same conflict target
+      // for different nodes up front. Batch validation pre-rejects real
+      // conflicts, so this is a defensive invariant, not a semantic path.
+      const targetKey = (entry: InsertUniqueParams): string =>
+        `${entry.nodeKind}\u0000${entry.constraintName}\u0000${entry.key}`;
+      const byTarget = new Map<string, InsertUniqueParams>();
+      for (const entry of entries) {
+        const existing = byTarget.get(targetKey(entry));
+        if (existing === undefined) {
+          byTarget.set(targetKey(entry), entry);
+          continue;
+        }
+        if (existing.nodeId !== entry.nodeId) {
+          throw new UniquenessError({
+            constraintName: entry.constraintName,
+            kind: entry.nodeKind,
+            existingId: existing.nodeId,
+            newId: entry.nodeId,
+            fields: [],
+          });
+        }
+      }
+      const deduped = [...byTarget.values()];
+
+      for (const chunk of chunkArray(
+        deduped,
+        batchConfig.uniqueInsertBatchSize,
+      )) {
+        const query = operationStrategy.buildInsertUniqueBatch(chunk);
+        const rows = await execution.execAll<{
+          node_kind: string;
+          constraint_name: string;
+          key: string;
+          node_id: string;
+        }>(query);
+        const ownerByTarget = new Map(
+          rows.map((row) => [
+            `${row.node_kind}\u0000${row.constraint_name}\u0000${row.key}`,
+            row.node_id,
+          ]),
+        );
+        for (const entry of chunk) {
+          const owner = ownerByTarget.get(targetKey(entry));
+          if (owner !== undefined && owner !== entry.nodeId) {
+            throw new UniquenessError({
+              constraintName: entry.constraintName,
+              kind: entry.nodeKind,
+              existingId: owner,
+              newId: entry.nodeId,
+              fields: [],
+            });
+          }
+        }
       }
     },
 

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -79,6 +79,7 @@ import {
   buildDeleteUnique,
   buildHardDeleteUniquesByNode,
   buildInsertUnique,
+  buildInsertUniqueBatch,
 } from "./uniques";
 
 export type CommonOperationStrategy = Readonly<{
@@ -149,6 +150,7 @@ export type CommonOperationStrategy = Readonly<{
   buildFindEdgesByKind: (params: FindEdgesByKindParams) => SQL;
   buildCountEdgesByKind: (params: CountEdgesByKindParams) => SQL;
   buildInsertUnique: (params: InsertUniqueParams) => SQL;
+  buildInsertUniqueBatch: (entries: readonly InsertUniqueParams[]) => SQL;
   buildDeleteUnique: (params: DeleteUniqueParams, timestamp: string) => SQL;
   buildHardDeleteUniquesByNode: (graphId: string, nodeId: string) => SQL;
   buildCheckUnique: (params: CheckUniqueParams) => SQL;
@@ -289,6 +291,9 @@ function createCommonOperationStrategy(
     ...fulltextBuilders,
     buildInsertUnique(params: InsertUniqueParams): SQL {
       return buildInsertUnique(tables, dialect, params);
+    },
+    buildInsertUniqueBatch(entries: readonly InsertUniqueParams[]): SQL {
+      return buildInsertUniqueBatch(tables, dialect, entries);
     },
     buildGetActiveSchema(graphId: string): SQL {
       return buildGetActiveSchema(tables, graphId, dialect);

--- a/packages/typegraph/src/backend/drizzle/operations/uniques.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/uniques.ts
@@ -129,6 +129,80 @@ export function buildInsertUnique(
 }
 
 /**
+ * Builds a multi-row INSERT for uniqueness entries with the same conflict
+ * semantics as {@link buildInsertUnique}, expressed against `excluded`
+ * (the proposed row) instead of per-statement bound values. RETURNING
+ * exposes `(node_kind, constraint_name, key, node_id)` for every row —
+ * ON CONFLICT DO UPDATE returns updated rows too — so the caller can
+ * attribute each entry's final owner and raise a uniqueness error for the
+ * ones a different live node holds.
+ *
+ * Callers must not pass two entries with the same conflict target
+ * (`node_kind`, `constraint_name`, `key`): a multi-row upsert cannot
+ * affect one row twice.
+ */
+export function buildInsertUniqueBatch(
+  tables: Tables,
+  dialect: SqlDialect,
+  entries: readonly InsertUniqueParams[],
+): SQL {
+  const { uniques } = tables;
+
+  const columns = sql.raw(
+    `"${uniques.graphId.name}", "${uniques.nodeKind.name}", "${uniques.constraintName.name}", "${uniques.key.name}", "${uniques.nodeId.name}", "${uniques.concreteKind.name}", "${uniques.deletedAt.name}"`,
+  );
+  const conflictColumns = sql.raw(
+    `"${uniques.graphId.name}", "${uniques.nodeKind.name}", "${uniques.constraintName.name}", "${uniques.key.name}"`,
+  );
+
+  // Mirror the single-row builders' dialect split for references to the
+  // EXISTING row inside DO UPDATE: Postgres qualifies with the table name,
+  // SQLite uses the bare quoted column.
+  const tableName = getTableName(uniques);
+  const existingColumn = (column: Readonly<{ name: string }>) =>
+    dialect === "postgres" ?
+      sql.raw(`"${tableName}"."${column.name}"`)
+    : sql.raw(`"${column.name}"`);
+  const excludedColumn = (column: Readonly<{ name: string }>) =>
+    sql.raw(`excluded."${column.name}"`);
+
+  const valueRows = sql.join(
+    entries.map(
+      (params) =>
+        sql`(${params.graphId}, ${params.nodeKind}, ${params.constraintName}, ${params.key}, ${params.nodeId}, ${params.concreteKind}, ${sql.raw("NULL")})`,
+    ),
+    sql`, `,
+  );
+
+  return sql`
+    INSERT INTO ${uniques} (${columns})
+    VALUES ${valueRows}
+    ON CONFLICT (${conflictColumns})
+    DO UPDATE SET
+      ${quotedColumn(uniques.nodeId)} = CASE
+        WHEN ${existingColumn(uniques.nodeId)} = ${excludedColumn(uniques.nodeId)} THEN ${excludedColumn(uniques.nodeId)}
+        WHEN ${existingColumn(uniques.deletedAt)} IS NOT NULL THEN ${excludedColumn(uniques.nodeId)}
+        ELSE ${existingColumn(uniques.nodeId)}
+      END,
+      ${quotedColumn(uniques.concreteKind)} = CASE
+        WHEN ${existingColumn(uniques.nodeId)} = ${excludedColumn(uniques.nodeId)} THEN ${excludedColumn(uniques.concreteKind)}
+        WHEN ${existingColumn(uniques.deletedAt)} IS NOT NULL THEN ${excludedColumn(uniques.concreteKind)}
+        ELSE ${existingColumn(uniques.concreteKind)}
+      END,
+      ${quotedColumn(uniques.deletedAt)} = CASE
+        WHEN ${existingColumn(uniques.nodeId)} = ${excludedColumn(uniques.nodeId)} THEN NULL
+        WHEN ${existingColumn(uniques.deletedAt)} IS NOT NULL THEN NULL
+        ELSE ${existingColumn(uniques.deletedAt)}
+      END
+    RETURNING
+      ${quotedColumn(uniques.nodeKind)} as node_kind,
+      ${quotedColumn(uniques.constraintName)} as constraint_name,
+      ${quotedColumn(uniques.key)} as key,
+      ${quotedColumn(uniques.nodeId)} as node_id
+  `;
+}
+
+/**
  * Builds a soft DELETE query for a uniqueness entry.
  * Uses raw column name in SET clause.
  */

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -58,6 +58,7 @@ import {
   type VectorSlot,
   type VectorStrategy,
 } from "../../query/dialect/vector-strategy";
+import { chunk as chunkArray } from "../../utils/array";
 import { isMissingTableError } from "../../utils/sql-errors";
 import {
   type AdoptedTransaction,
@@ -84,6 +85,7 @@ import {
   type SetActiveVersionParams,
   type TransactionBackend,
   type TransactionOptions,
+  type UpsertEmbeddingBatchParams,
   type UpsertEmbeddingParams,
   type UpsertFulltextBatchParams,
   type UpsertFulltextParams,
@@ -144,6 +146,7 @@ import {
 } from "./schema/postgres";
 import {
   createVectorSlotLatch,
+  EMBEDDING_UPSERT_PARAM_COUNT,
   mapVectorWriteError,
   vectorSlotFromCreateIndexParams,
   vectorSlotFromDropIndexParams,
@@ -252,6 +255,11 @@ const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
 const POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE = Math.max(
   1,
   POSTGRES_MAX_BIND_PARAMETERS - CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT,
+);
+const UNIQUE_INSERT_PARAM_COUNT = 6;
+const POSTGRES_UNIQUE_INSERT_BATCH_SIZE = Math.max(
+  1,
+  Math.floor(POSTGRES_MAX_BIND_PARAMETERS / UNIQUE_INSERT_PARAM_COUNT),
 );
 
 // ============================================================
@@ -996,6 +1004,7 @@ function createPostgresOperationBackend(
       getEdgesChunkSize: POSTGRES_GET_EDGES_ID_CHUNK_SIZE,
       getNodesChunkSize: POSTGRES_GET_NODES_ID_CHUNK_SIZE,
       nodeInsertBatchSize: POSTGRES_NODE_INSERT_BATCH_SIZE,
+      uniqueInsertBatchSize: POSTGRES_UNIQUE_INSERT_BATCH_SIZE,
     },
     execution: {
       execAll,
@@ -1041,6 +1050,60 @@ function createPostgresOperationBackend(
           try {
             for (const statement of statements) {
               await execRun(statement);
+            }
+          } catch (error) {
+            throw mapVectorWriteError(error, params);
+          }
+        },
+
+        async upsertEmbeddingBatch(
+          params: UpsertEmbeddingBatchParams,
+        ): Promise<void> {
+          if (params.rows.length === 0) return;
+          const slot = vectorSlotFromParams(params);
+          await ensureVectorSlotStorage(slot);
+          // Last-write-wins dedupe: a multi-row upsert cannot affect one
+          // row twice.
+          const rowsById = new Map(
+            params.rows.map((row) => [row.nodeId, row] as const),
+          );
+          const rows = [...rowsById.values()];
+          const chunkSize = Math.max(
+            1,
+            Math.floor(
+              (capabilities.maxBindParameters ??
+                POSTGRES_MAX_BIND_PARAMETERS) / EMBEDDING_UPSERT_PARAM_COUNT,
+            ),
+          );
+          const timestamp = nowIso();
+          try {
+            for (const chunk of chunkArray(rows, chunkSize)) {
+              const statements =
+                vectorStrategy.buildUpsertBatch === undefined ?
+                  chunk.flatMap((row) =>
+                    vectorStrategy.buildUpsert(
+                      slot,
+                      {
+                        graphId: params.graphId,
+                        nodeKind: params.nodeKind,
+                        nodeId: row.nodeId,
+                        fieldPath: params.fieldPath,
+                        embedding: row.embedding,
+                        dimensions: params.dimensions,
+                        metric: params.metric,
+                        indexType: params.indexType,
+                      },
+                      timestamp,
+                    ),
+                  )
+                : vectorStrategy.buildUpsertBatch(
+                    slot,
+                    { ...params, rows: chunk },
+                    timestamp,
+                  );
+              for (const statement of statements) {
+                await execRun(statement);
+              }
             }
           } catch (error) {
             throw mapVectorWriteError(error, params);

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -43,6 +43,7 @@ import {
   type VectorSlot,
   type VectorStrategy,
 } from "../../query/dialect/vector-strategy";
+import { chunk as chunkArray } from "../../utils/array";
 import { isMissingTableError } from "../../utils/sql-errors";
 import {
   type AdoptedTransaction,
@@ -69,6 +70,7 @@ import {
   SQLITE_MAX_BIND_PARAMETERS,
   type TransactionBackend,
   type TransactionOptions,
+  type UpsertEmbeddingBatchParams,
   type UpsertEmbeddingParams,
   type UpsertFulltextBatchParams,
   type UpsertFulltextParams,
@@ -83,6 +85,7 @@ import {
 } from "./execution/sqlite-execution";
 import {
   createVectorSlotLatch,
+  EMBEDDING_UPSERT_PARAM_COUNT,
   mapVectorWriteError,
   vectorSlotFromCreateIndexParams,
   vectorSlotFromDropIndexParams,
@@ -179,6 +182,7 @@ const EDGE_INSERT_PARAM_COUNT = 12;
 const GET_NODES_FIXED_PARAM_COUNT = 2;
 const GET_EDGES_FIXED_PARAM_COUNT = 1;
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
+const UNIQUE_INSERT_PARAM_COUNT = 6;
 
 /**
  * Batch chunk sizes for the SQLite operation backend, derived from the
@@ -191,6 +195,7 @@ export type SqliteBatchChunkSizes = Readonly<{
   getEdgesChunkSize: number;
   getNodesChunkSize: number;
   nodeInsertBatchSize: number;
+  uniqueInsertBatchSize: number;
 }>;
 
 /**
@@ -222,6 +227,10 @@ export function computeSqliteBatchChunkSizes(
     nodeInsertBatchSize: Math.max(
       1,
       Math.floor(maxBindParameters / NODE_INSERT_PARAM_COUNT),
+    ),
+    uniqueInsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / UNIQUE_INSERT_PARAM_COUNT),
     ),
   };
 }
@@ -553,6 +562,59 @@ function createSqliteOperationBackend(
           try {
             for (const statement of statements) {
               await execRun(statement);
+            }
+          } catch (error) {
+            throw mapVectorWriteError(error, params);
+          }
+        },
+        async upsertEmbeddingBatch(
+          params: UpsertEmbeddingBatchParams,
+        ): Promise<void> {
+          if (params.rows.length === 0) return;
+          const slot = vectorSlotFromParams(params);
+          await ensureVectorSlotStorage(slot);
+          // Last-write-wins dedupe: a multi-row upsert cannot affect one
+          // row twice.
+          const rowsById = new Map(
+            params.rows.map((row) => [row.nodeId, row] as const),
+          );
+          const rows = [...rowsById.values()];
+          const chunkSize = Math.max(
+            1,
+            Math.floor(
+              (capabilities.maxBindParameters ?? SQLITE_MAX_BIND_PARAMETERS) /
+                EMBEDDING_UPSERT_PARAM_COUNT,
+            ),
+          );
+          const timestamp = nowIso();
+          try {
+            for (const chunk of chunkArray(rows, chunkSize)) {
+              const statements =
+                vectorStrategy.buildUpsertBatch === undefined ?
+                  chunk.flatMap((row) =>
+                    vectorStrategy.buildUpsert(
+                      slot,
+                      {
+                        graphId: params.graphId,
+                        nodeKind: params.nodeKind,
+                        nodeId: row.nodeId,
+                        fieldPath: params.fieldPath,
+                        embedding: row.embedding,
+                        dimensions: params.dimensions,
+                        metric: params.metric,
+                        indexType: params.indexType,
+                      },
+                      timestamp,
+                    ),
+                  )
+                : vectorStrategy.buildUpsertBatch(
+                    slot,
+                    { ...params, rows: chunk },
+                    timestamp,
+                  );
+              for (const statement of statements) {
+                await execRun(statement);
+              }
             }
           } catch (error) {
             throw mapVectorWriteError(error, params);

--- a/packages/typegraph/src/backend/drizzle/vector-runtime.ts
+++ b/packages/typegraph/src/backend/drizzle/vector-runtime.ts
@@ -100,6 +100,15 @@ const VECTOR_SLOT_PLACEHOLDER_DIMENSIONS = 1;
  * just `(nodeKind, fieldPath)`) so the backend can idempotently ensure the
  * correctly-shaped per-field table before deleting.
  */
+/**
+ * Bound parameters per row in every strategy's embedding upsert SQL
+ * (graph_id, node_id, created_at, updated_at, embedding). Backends derive
+ * their batch chunk size from the connection's bound-parameter budget and
+ * this count. sqlite-vec's companion IN-list DELETE binds one parameter per
+ * row plus graph_id, which stays under the same budget.
+ */
+export const EMBEDDING_UPSERT_PARAM_COUNT = 5;
+
 export function vectorSlotFromParams(
   params: Omit<VectorSlot, "indexParams">,
 ): VectorSlot {

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -354,6 +354,30 @@ export type UpsertEmbeddingParams = Readonly<{
 }>;
 
 /**
+ * One row of a batched embedding upsert.
+ */
+type UpsertEmbeddingBatchRow = Readonly<{
+  nodeId: string;
+  embedding: readonly number[];
+}>;
+
+/**
+ * Parameters for a batched embedding upsert. Homogeneous per vector slot:
+ * one graph, one node kind, one field, many nodes. Duplicate `nodeId`
+ * values within a batch are deduplicated last-write-wins by the backend
+ * (a multi-row upsert cannot affect one row twice).
+ */
+export type UpsertEmbeddingBatchParams = Readonly<{
+  graphId: string;
+  nodeKind: string;
+  fieldPath: string;
+  dimensions: number;
+  metric: VectorMetric;
+  indexType: VectorIndexType;
+  rows: readonly UpsertEmbeddingBatchRow[];
+}>;
+
+/**
  * Parameters for deleting an embedding.
  *
  * `dimensions` / `metric` / `indexType` mirror {@link UpsertEmbeddingParams}
@@ -857,6 +881,13 @@ export type GraphBackend = Readonly<{
 
   // === Unique Constraint Operations ===
   insertUnique: (params: InsertUniqueParams) => Promise<void>;
+  /**
+   * Batched variant of `insertUnique`: one multi-row statement per chunk
+   * with the same per-entry conflict semantics (throws `UniquenessError`
+   * for the first entry whose key a different live node holds). Optional —
+   * callers fall back to per-entry `insertUnique` when unset.
+   */
+  insertUniqueBatch?: (entries: readonly InsertUniqueParams[]) => Promise<void>;
   deleteUnique: (params: DeleteUniqueParams) => Promise<void>;
   checkUnique: (params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
   checkUniqueBatch?: (
@@ -905,6 +936,11 @@ export type GraphBackend = Readonly<{
 
   // === Embedding Operations (optional - depends on vector capabilities) ===
   upsertEmbedding?: (params: UpsertEmbeddingParams) => Promise<void>;
+  /**
+   * Batched variant of `upsertEmbedding` for one vector slot. Optional —
+   * callers fall back to per-row `upsertEmbedding` when unset.
+   */
+  upsertEmbeddingBatch?: (params: UpsertEmbeddingBatchParams) => Promise<void>;
   deleteEmbedding?: (params: DeleteEmbeddingParams) => Promise<void>;
   vectorSearch?: (
     params: VectorSearchParams,
@@ -1294,7 +1330,11 @@ export type GraphEntityWriteBackend = NodeEntityWriteBackend &
 
 export type UniqueConstraintBackend = Pick<
   GraphBackend,
-  "insertUnique" | "deleteUnique" | "checkUnique" | "checkUniqueBatch"
+  | "insertUnique"
+  | "insertUniqueBatch"
+  | "deleteUnique"
+  | "checkUnique"
+  | "checkUniqueBatch"
 >;
 
 export type SchemaReadBackend = Pick<
@@ -1310,6 +1350,7 @@ export type SchemaCommitBackend = Pick<
 export type VectorOperationBackend = Pick<
   GraphBackend,
   | "upsertEmbedding"
+  | "upsertEmbeddingBatch"
   | "deleteEmbedding"
   | "vectorSearch"
   | "createVectorIndex"

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -21,7 +21,13 @@ import { type EdgeRegistration, type NodeRegistration } from "../core/types";
 import { UniquenessError } from "../errors";
 import { type KindRegistry } from "../registry/kind-registry";
 import {
+  createNodeBatchValidationBackend,
+  type NodeCreateDraft,
+  primeBatchValidationCaches,
+} from "../store/operations/node-operations";
+import {
   applyNodeInsertSideEffects,
+  applyNodeInsertSideEffectsBatch,
   applyNodeUpdate,
 } from "../store/operations/node-write-pipeline";
 import { runInWriteTransaction } from "../store/operations/write-transaction";
@@ -225,9 +231,272 @@ async function processNodes(
 
   for (let index = 0; index < nodes.length; index += batchSize) {
     const batch = nodes.slice(index, index + batchSize);
+    await processNodeSlice(
+      backend,
+      graphId,
+      registry,
+      batch,
+      schemas,
+      options,
+      result,
+      errors,
+      importedNodeIds,
+      lock,
+    );
+  }
+}
 
-    for (const node of batch) {
-      const importResult = await processNode(
+function recordNodeOutcome(
+  node: InterchangeNode,
+  outcome: ProcessResult,
+  result: ImportResult,
+  errors: ImportError[],
+  importedNodeIds: Set<string>,
+): void {
+  switch (outcome.status) {
+    case "created": {
+      result.nodes.created++;
+      importedNodeIds.add(makeNodeKey(node.kind, node.id));
+      break;
+    }
+    case "updated": {
+      result.nodes.updated++;
+      importedNodeIds.add(makeNodeKey(node.kind, node.id));
+      break;
+    }
+    case "skipped": {
+      result.nodes.skipped++;
+      // A live skipped row is still a valid edge endpoint; a tombstone
+      // is not.
+      if (outcome.liveTarget) {
+        importedNodeIds.add(makeNodeKey(node.kind, node.id));
+      }
+      break;
+    }
+    case "error": {
+      errors.push({
+        entityType: "node",
+        kind: node.kind,
+        id: node.id,
+        error: outcome.error,
+      });
+      break;
+    }
+  }
+}
+
+type NodeImportCandidate = Readonly<{
+  node: InterchangeNode;
+  schemaEntry: NodeSchemaEntry;
+  props: Record<string, unknown>;
+  draft: NodeCreateDraft;
+}>;
+
+/**
+ * Processes one batchSize slice of nodes with batched round trips:
+ * one `getNodes` per kind for existence, one `checkUniqueBatch` per
+ * (constraint, kind) for uniqueness pre-checks (both priming the shared
+ * batch validation caches), then one multi-row insert and one batched
+ * side-effect pass for the accepted creates. Per-row semantics are
+ * unchanged — conflicts route by `onConflict`, a uniqueness conflict is a
+ * per-row error entry, and rows repeating an id already seen in the slice
+ * defer to the per-row path after the flush (so they observe the first
+ * occurrence's row exactly as the sequential implementation did).
+ */
+async function processNodeSlice(
+  backend: GraphBackend | TransactionBackend,
+  graphId: string,
+  registry: KindRegistry,
+  batch: readonly InterchangeNode[],
+  schemas: ReadonlyMap<string, NodeSchemaEntry>,
+  options: ImportOptions,
+  result: ImportResult,
+  errors: ImportError[],
+  importedNodeIds: Set<string>,
+  lock: GraphWriteLock,
+): Promise<void> {
+  const record = (node: InterchangeNode, outcome: ProcessResult): void => {
+    recordNodeOutcome(node, outcome, result, errors, importedNodeIds);
+  };
+
+  // Pass 1 (synchronous): kind + property + validity validation, and
+  // in-slice duplicate deferral.
+  const candidates: NodeImportCandidate[] = [];
+  const deferred: InterchangeNode[] = [];
+  const seenKeys = new Set<string>();
+  for (const node of batch) {
+    const schemaEntry = schemas.get(node.kind);
+    if (!schemaEntry) {
+      record(node, {
+        status: "error",
+        error: `Unknown node kind: ${node.kind}`,
+      });
+      continue;
+    }
+    const propsResult = validateProperties(
+      node.properties,
+      schemaEntry.schema,
+      options.onUnknownProperty,
+    );
+    if (!propsResult.success) {
+      record(node, { status: "error", error: propsResult.error });
+      continue;
+    }
+    const validityError = validateValidityWindow(node);
+    if (validityError !== undefined) {
+      record(node, { status: "error", error: validityError });
+      continue;
+    }
+    const key = makeNodeKey(node.kind, node.id);
+    if (seenKeys.has(key)) {
+      deferred.push(node);
+      continue;
+    }
+    seenKeys.add(key);
+    candidates.push({
+      node,
+      schemaEntry,
+      props: propsResult.data,
+      draft: {
+        kind: node.kind,
+        id: node.id,
+        nodeKind: schemaEntry.registration.type,
+        uniqueConstraints: schemaEntry.registration.unique ?? [],
+        validatedProps: propsResult.data,
+        validFrom: node.validFrom,
+        validTo: node.validTo,
+      },
+    });
+  }
+
+  // Prime the validation caches with batched reads, then route each row
+  // against memory in input order.
+  const {
+    backend: validationBackend,
+    registerPendingNode,
+    registerPendingUniqueEntries,
+    seedNodeRow,
+    seedUniqueRow,
+  } = createNodeBatchValidationBackend(graphId, registry, backend);
+  await primeBatchValidationCaches(
+    { graphId, registry },
+    candidates.map((candidate) => candidate.draft),
+    backend,
+    { seedNodeRow, seedUniqueRow },
+  );
+
+  const writeContext = { graphId, registry, lock };
+  const accepted: NodeImportCandidate[] = [];
+  for (const candidate of candidates) {
+    const { node, schemaEntry, props } = candidate;
+    const uniqueConstraints = schemaEntry.registration.unique ?? [];
+    const existing = await validationBackend.getNode(
+      graphId,
+      node.kind,
+      node.id,
+    );
+
+    if (existing) {
+      switch (options.onConflict) {
+        case "skip": {
+          record(node, {
+            status: "skipped",
+            liveTarget: isLiveNodeRow(existing),
+          });
+          break;
+        }
+        case "error": {
+          record(node, {
+            status: "error",
+            error: `Node already exists: ${node.kind}:${node.id}`,
+          });
+          break;
+        }
+        case "update": {
+          if (!isLiveNodeRow(existing)) {
+            // Import never resurrects a tombstone — see processNode.
+            record(node, { status: "skipped", liveTarget: false });
+            break;
+          }
+          const updateResult = await catchUniquenessError(() =>
+            applyNodeUpdate(
+              writeContext,
+              {
+                existing,
+                schema: schemaEntry.registration.type.schema,
+                validatedProps: props,
+                uniqueConstraints,
+                ...(node.validTo !== undefined && { validTo: node.validTo }),
+              },
+              backend,
+            ),
+          );
+          record(
+            node,
+            updateResult.ok ?
+              { status: "updated" }
+            : { status: "error", error: updateResult.error },
+          );
+          break;
+        }
+      }
+      continue;
+    }
+
+    const uniquenessResult = await catchUniquenessError(() =>
+      checkUniquenessConstraints(
+        { graphId, registry, backend: validationBackend },
+        node.kind,
+        node.id,
+        props,
+        uniqueConstraints,
+      ),
+    );
+    if (!uniquenessResult.ok) {
+      record(node, { status: "error", error: uniquenessResult.error });
+      continue;
+    }
+
+    registerPendingNode(buildImportInsertParams(graphId, candidate));
+    registerPendingUniqueEntries(node.kind, node.id, props, uniqueConstraints);
+    accepted.push(candidate);
+  }
+
+  // Flush the accepted creates: one multi-row insert, then the batched
+  // side effects (uniqueness entries, fulltext, embeddings).
+  if (accepted.length > 0) {
+    const insertParamsList = accepted.map((candidate) =>
+      buildImportInsertParams(graphId, candidate),
+    );
+    if (backend.insertNodesBatch === undefined) {
+      for (const params of insertParamsList) {
+        await backend.insertNode(params);
+      }
+    } else {
+      await backend.insertNodesBatch(insertParamsList);
+    }
+    await applyNodeInsertSideEffectsBatch(
+      writeContext,
+      accepted.map((candidate) => ({
+        kind: candidate.node.kind,
+        id: candidate.node.id,
+        schema: candidate.schemaEntry.registration.type.schema,
+        props: candidate.props,
+        uniqueConstraints: candidate.schemaEntry.registration.unique ?? [],
+      })),
+      backend,
+    );
+    for (const candidate of accepted) {
+      record(candidate.node, { status: "created" });
+    }
+  }
+
+  // In-slice duplicate ids run per-row AFTER the flush so they observe the
+  // first occurrence's committed row, exactly as the sequential path did.
+  for (const node of deferred) {
+    record(
+      node,
+      await processNode(
         backend,
         graphId,
         registry,
@@ -235,40 +504,24 @@ async function processNodes(
         schemas,
         options,
         lock,
-      );
-
-      switch (importResult.status) {
-        case "created": {
-          result.nodes.created++;
-          importedNodeIds.add(makeNodeKey(node.kind, node.id));
-          break;
-        }
-        case "updated": {
-          result.nodes.updated++;
-          importedNodeIds.add(makeNodeKey(node.kind, node.id));
-          break;
-        }
-        case "skipped": {
-          result.nodes.skipped++;
-          // A live skipped row is still a valid edge endpoint; a tombstone
-          // is not.
-          if (importResult.liveTarget) {
-            importedNodeIds.add(makeNodeKey(node.kind, node.id));
-          }
-          break;
-        }
-        case "error": {
-          errors.push({
-            entityType: "node",
-            kind: node.kind,
-            id: node.id,
-            error: importResult.error,
-          });
-          break;
-        }
-      }
-    }
+      ),
+    );
   }
+}
+
+function buildImportInsertParams(
+  graphId: string,
+  candidate: NodeImportCandidate,
+): Parameters<GraphBackend["insertNode"]>[0] {
+  const { node, props } = candidate;
+  return {
+    graphId,
+    kind: node.kind,
+    id: node.id,
+    props,
+    ...(node.validFrom !== undefined && { validFrom: node.validFrom }),
+    ...(node.validTo !== undefined && { validTo: node.validTo }),
+  };
 }
 
 type ProcessResult =
@@ -475,9 +728,290 @@ async function processEdges(
 
   for (let index = 0; index < edges.length; index += batchSize) {
     const batch = edges.slice(index, index + batchSize);
+    await processEdgeSlice(
+      backend,
+      graphId,
+      registry,
+      batch,
+      edgeSchemas,
+      nodeSchemas,
+      options,
+      result,
+      errors,
+      importedNodeIds,
+    );
+  }
+}
 
-    for (const edge of batch) {
-      const importResult = await processEdge(
+function recordEdgeOutcome(
+  edge: InterchangeEdge,
+  outcome: ProcessResult,
+  result: ImportResult,
+  errors: ImportError[],
+): void {
+  switch (outcome.status) {
+    case "created": {
+      result.edges.created++;
+      break;
+    }
+    case "updated": {
+      result.edges.updated++;
+      break;
+    }
+    case "skipped": {
+      result.edges.skipped++;
+      break;
+    }
+    case "error": {
+      errors.push({
+        entityType: "edge",
+        kind: edge.kind,
+        id: edge.id,
+        error: outcome.error,
+      });
+      break;
+    }
+  }
+}
+
+type EdgeImportCandidate = Readonly<{
+  edge: InterchangeEdge;
+  props: Record<string, unknown>;
+}>;
+
+/**
+ * Processes one batchSize slice of edges with batched round trips: one
+ * `getNodes` per endpoint kind for reference liveness, one `getEdges` for
+ * existence, and one multi-row insert for the accepted creates. Per-row
+ * semantics are unchanged; duplicate ids within a slice defer to the
+ * per-row path after the flush.
+ */
+async function processEdgeSlice(
+  backend: GraphBackend | TransactionBackend,
+  graphId: string,
+  registry: KindRegistry,
+  batch: readonly InterchangeEdge[],
+  edgeSchemas: ReadonlyMap<string, EdgeSchemaEntry>,
+  nodeSchemas: ReadonlyMap<string, NodeSchemaEntry>,
+  options: ImportOptions,
+  result: ImportResult,
+  errors: ImportError[],
+  importedNodeIds: Set<string>,
+): Promise<void> {
+  const record = (edge: InterchangeEdge, outcome: ProcessResult): void => {
+    recordEdgeOutcome(edge, outcome, result, errors);
+  };
+
+  // Pass 1 (synchronous): kind, endpoint-kind, endpoint-assignability,
+  // property, and validity validation, plus in-slice duplicate deferral.
+  const candidates: EdgeImportCandidate[] = [];
+  const deferred: InterchangeEdge[] = [];
+  const seenIds = new Set<string>();
+  for (const edge of batch) {
+    const schemaEntry = edgeSchemas.get(edge.kind);
+    if (!schemaEntry) {
+      record(edge, {
+        status: "error",
+        error: `Unknown edge kind: ${edge.kind}`,
+      });
+      continue;
+    }
+    if (!nodeSchemas.has(edge.from.kind)) {
+      record(edge, {
+        status: "error",
+        error: `Unknown from node kind: ${edge.from.kind}`,
+      });
+      continue;
+    }
+    if (!nodeSchemas.has(edge.to.kind)) {
+      record(edge, {
+        status: "error",
+        error: `Unknown to node kind: ${edge.to.kind}`,
+      });
+      continue;
+    }
+    const endpointError = validateEdgeEndpoints(
+      edge.kind,
+      edge.from.kind,
+      edge.to.kind,
+      schemaEntry.registration,
+      registry,
+    );
+    if (endpointError !== undefined) {
+      record(edge, { status: "error", error: endpointError.message });
+      continue;
+    }
+    const propsResult = validateProperties(
+      edge.properties,
+      schemaEntry.schema,
+      options.onUnknownProperty,
+    );
+    if (!propsResult.success) {
+      record(edge, { status: "error", error: propsResult.error });
+      continue;
+    }
+    const validityError = validateValidityWindow(edge);
+    if (validityError !== undefined) {
+      record(edge, { status: "error", error: validityError });
+      continue;
+    }
+    if (seenIds.has(edge.id)) {
+      deferred.push(edge);
+      continue;
+    }
+    seenIds.add(edge.id);
+    candidates.push({ edge, props: propsResult.data });
+  }
+
+  // Batch the endpoint-liveness reads: one getNodes per endpoint kind for
+  // every key the import itself didn't create. Falls back to per-row
+  // getNode inside the routing loop when the backend lacks getNodes.
+  const liveEndpointKeys = new Set<string>();
+  const checkedEndpointKeys = new Set<string>();
+  if (options.validateReferences && backend.getNodes !== undefined) {
+    const idsByKind = new Map<string, Set<string>>();
+    for (const { edge } of candidates) {
+      for (const endpoint of [edge.from, edge.to]) {
+        const key = makeNodeKey(endpoint.kind, endpoint.id);
+        if (importedNodeIds.has(key) || checkedEndpointKeys.has(key)) continue;
+        checkedEndpointKeys.add(key);
+        const ids = idsByKind.get(endpoint.kind) ?? new Set<string>();
+        ids.add(endpoint.id);
+        idsByKind.set(endpoint.kind, ids);
+      }
+    }
+    for (const [kind, ids] of idsByKind) {
+      const rows = await backend.getNodes(graphId, kind, [...ids]);
+      for (const row of rows) {
+        if (isLiveNodeRow(row)) {
+          liveEndpointKeys.add(makeNodeKey(kind, row.id));
+        }
+      }
+    }
+  }
+
+  const endpointIsLive = async (endpoint: {
+    kind: string;
+    id: string;
+  }): Promise<boolean> => {
+    const key = makeNodeKey(endpoint.kind, endpoint.id);
+    if (importedNodeIds.has(key)) return true;
+    if (checkedEndpointKeys.has(key)) return liveEndpointKeys.has(key);
+    const row = await backend.getNode(graphId, endpoint.kind, endpoint.id);
+    return row !== undefined && isLiveNodeRow(row);
+  };
+
+  // Batch the existence reads. Falls back to per-row getEdge when the
+  // backend lacks getEdges.
+  const existingById = new Map<
+    string,
+    Awaited<ReturnType<GraphBackend["getEdge"]>>
+  >();
+  if (candidates.length > 0 && backend.getEdges !== undefined) {
+    const rows = await backend.getEdges(
+      graphId,
+      candidates.map((candidate) => candidate.edge.id),
+    );
+    for (const row of rows) {
+      existingById.set(row.id, row);
+    }
+    for (const { edge } of candidates) {
+      if (!existingById.has(edge.id)) existingById.set(edge.id, undefined);
+    }
+  }
+
+  const accepted: EdgeImportCandidate[] = [];
+  for (const candidate of candidates) {
+    const { edge, props } = candidate;
+
+    if (options.validateReferences) {
+      if (!(await endpointIsLive(edge.from))) {
+        record(edge, {
+          status: "error",
+          error: `From node not found: ${edge.from.kind}:${edge.from.id}`,
+        });
+        continue;
+      }
+      if (!(await endpointIsLive(edge.to))) {
+        record(edge, {
+          status: "error",
+          error: `To node not found: ${edge.to.kind}:${edge.to.id}`,
+        });
+        continue;
+      }
+    }
+
+    const existing =
+      existingById.has(edge.id) ?
+        existingById.get(edge.id)
+      : await backend.getEdge(graphId, edge.id);
+
+    if (existing) {
+      switch (options.onConflict) {
+        case "skip": {
+          record(edge, {
+            status: "skipped",
+            liveTarget: existing.deleted_at === undefined,
+          });
+          break;
+        }
+        case "error": {
+          record(edge, {
+            status: "error",
+            error: `Edge already exists: ${edge.id}`,
+          });
+          break;
+        }
+        case "update": {
+          if (existing.deleted_at !== undefined) {
+            record(edge, { status: "skipped", liveTarget: false });
+            break;
+          }
+          await backend.updateEdge({
+            graphId,
+            id: edge.id,
+            props,
+            ...(edge.validTo !== undefined && { validTo: edge.validTo }),
+          });
+          record(edge, { status: "updated" });
+          break;
+        }
+      }
+      continue;
+    }
+
+    accepted.push(candidate);
+  }
+
+  if (accepted.length > 0) {
+    const insertParamsList = accepted.map(({ edge, props }) => ({
+      graphId,
+      id: edge.id,
+      kind: edge.kind,
+      fromKind: edge.from.kind,
+      fromId: edge.from.id,
+      toKind: edge.to.kind,
+      toId: edge.to.id,
+      props,
+      ...(edge.validFrom !== undefined && { validFrom: edge.validFrom }),
+      ...(edge.validTo !== undefined && { validTo: edge.validTo }),
+    }));
+    if (backend.insertEdgesBatch === undefined) {
+      for (const params of insertParamsList) {
+        await backend.insertEdge(params);
+      }
+    } else {
+      await backend.insertEdgesBatch(insertParamsList);
+    }
+    for (const candidate of accepted) {
+      record(candidate.edge, { status: "created" });
+    }
+  }
+
+  for (const edge of deferred) {
+    record(
+      edge,
+      await processEdge(
         backend,
         graphId,
         registry,
@@ -486,32 +1020,8 @@ async function processEdges(
         nodeSchemas,
         options,
         importedNodeIds,
-      );
-
-      switch (importResult.status) {
-        case "created": {
-          result.edges.created++;
-          break;
-        }
-        case "updated": {
-          result.edges.updated++;
-          break;
-        }
-        case "skipped": {
-          result.edges.skipped++;
-          break;
-        }
-        case "error": {
-          errors.push({
-            entityType: "edge",
-            kind: edge.kind,
-            id: edge.id,
-            error: importResult.error,
-          });
-          break;
-        }
-      }
-    }
+      ),
+    );
   }
 }
 

--- a/packages/typegraph/src/query/dialect/vector-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector-strategy.ts
@@ -34,6 +34,7 @@ import { type SQL, sql } from "drizzle-orm";
 import { type StrategyTableContribution } from "../../backend/table-contribution";
 import {
   type DeleteEmbeddingParams,
+  type UpsertEmbeddingBatchParams,
   type UpsertEmbeddingParams,
   type VectorCapabilities,
   type VectorIndexType,
@@ -148,6 +149,19 @@ export interface VectorStrategy {
   buildUpsert(
     slot: VectorSlot,
     params: UpsertEmbeddingParams,
+    timestamp: string,
+  ): readonly SQL[];
+
+  /**
+   * Emits the statement(s) that upsert MANY embeddings into the slot's
+   * storage in multi-row form. Optional — the backend falls back to one
+   * {@link buildUpsert} per row when unset. The backend guarantees the
+   * rows carry distinct `nodeId`s and fit the connection's bound-parameter
+   * budget (it chunks before calling).
+   */
+  buildUpsertBatch?(
+    slot: VectorSlot,
+    params: UpsertEmbeddingBatchParams,
     timestamp: string,
   ): readonly SQL[];
 

--- a/packages/typegraph/src/query/dialect/vector/libsql-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector/libsql-strategy.ts
@@ -24,6 +24,7 @@ import { quotedTableName } from "../../../backend/drizzle/operations/shared";
 import { type StrategyTableContribution } from "../../../backend/table-contribution";
 import {
   type DeleteEmbeddingParams,
+  type UpsertEmbeddingBatchParams,
   type UpsertEmbeddingParams,
   type VectorCapabilities,
   type VectorMetric,
@@ -172,6 +173,34 @@ export const libsqlVectorStrategy: VectorStrategy = {
         VALUES (${params.graphId}, ${params.nodeId}, ${value}, ${timestamp}, ${timestamp})
         ON CONFLICT ("graph_id", "node_id")
         DO UPDATE SET "embedding" = ${value}, "updated_at" = ${timestamp}
+      `,
+    ];
+  },
+
+  buildUpsertBatch(
+    slot,
+    params: UpsertEmbeddingBatchParams,
+    timestamp,
+  ): readonly SQL[] {
+    const table = quotedTableName(
+      this.tableName(slot.graphId, slot.nodeKind, slot.fieldPath),
+    );
+    const valueRows = sql.join(
+      params.rows.map(
+        (row) =>
+          sql`(${params.graphId}, ${row.nodeId}, ${vector32Literal(row.embedding, "embedding")}, ${timestamp}, ${timestamp})`,
+      ),
+      sql`, `,
+    );
+    // `excluded."embedding"` reuses the row's already-converted F32_BLOB
+    // value, so the multi-row form needs no per-row conversion in the
+    // update arm (unlike buildUpsert's single bound value).
+    return [
+      sql`
+        INSERT INTO ${table} ("graph_id", "node_id", "embedding", "created_at", "updated_at")
+        VALUES ${valueRows}
+        ON CONFLICT ("graph_id", "node_id")
+        DO UPDATE SET "embedding" = excluded."embedding", "updated_at" = excluded."updated_at"
       `,
     ];
   },

--- a/packages/typegraph/src/query/dialect/vector/pgvector-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector/pgvector-strategy.ts
@@ -28,6 +28,7 @@ import { quotedTableName } from "../../../backend/drizzle/operations/shared";
 import { type StrategyTableContribution } from "../../../backend/table-contribution";
 import {
   type DeleteEmbeddingParams,
+  type UpsertEmbeddingBatchParams,
   type UpsertEmbeddingParams,
   type VectorCapabilities,
   type VectorMetric,
@@ -212,6 +213,31 @@ export const pgvectorStrategy: VectorStrategy = {
       sql`
         INSERT INTO ${table} ("graph_id", "node_id", "embedding", "created_at", "updated_at")
         VALUES (${params.graphId}, ${params.nodeId}, ${value}, ${timestamp}, ${timestamp})
+        ON CONFLICT ("graph_id", "node_id")
+        DO UPDATE SET "embedding" = EXCLUDED."embedding", "updated_at" = EXCLUDED."updated_at"
+      `,
+    ];
+  },
+
+  buildUpsertBatch(
+    slot,
+    params: UpsertEmbeddingBatchParams,
+    timestamp,
+  ): readonly SQL[] {
+    const table = quotedTableName(
+      this.tableName(slot.graphId, slot.nodeKind, slot.fieldPath),
+    );
+    const valueRows = sql.join(
+      params.rows.map(
+        (row) =>
+          sql`(${params.graphId}, ${row.nodeId}, ${vectorLiteral(row.embedding, "embedding")}, ${timestamp}, ${timestamp})`,
+      ),
+      sql`, `,
+    );
+    return [
+      sql`
+        INSERT INTO ${table} ("graph_id", "node_id", "embedding", "created_at", "updated_at")
+        VALUES ${valueRows}
         ON CONFLICT ("graph_id", "node_id")
         DO UPDATE SET "embedding" = EXCLUDED."embedding", "updated_at" = EXCLUDED."updated_at"
       `,

--- a/packages/typegraph/src/query/dialect/vector/sqlite-vec-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector/sqlite-vec-strategy.ts
@@ -58,6 +58,7 @@ import { quotedTableName } from "../../../backend/drizzle/operations/shared";
 import { type StrategyTableContribution } from "../../../backend/table-contribution";
 import {
   type DeleteEmbeddingParams,
+  type UpsertEmbeddingBatchParams,
   type UpsertEmbeddingParams,
   type VectorCapabilities,
   type VectorMetric,
@@ -209,6 +210,39 @@ export const sqliteVecStrategy: VectorStrategy = {
       sql`
         INSERT INTO ${table} ("node_id", "graph_id", "created_at", "updated_at", "embedding")
         VALUES (${params.nodeId}, ${params.graphId}, ${timestamp}, ${timestamp}, ${value})
+      `,
+    ];
+  },
+
+  buildUpsertBatch(
+    slot,
+    params: UpsertEmbeddingBatchParams,
+    timestamp,
+  ): readonly SQL[] {
+    const table = quotedTableName(
+      this.tableName(slot.graphId, slot.nodeKind, slot.fieldPath),
+    );
+    // Same DELETE + INSERT upsert emulation as buildUpsert, in multi-row
+    // form: one IN-list delete, one multi-row insert.
+    const nodeIds = sql.join(
+      params.rows.map((row) => sql`${row.nodeId}`),
+      sql`, `,
+    );
+    const valueRows = sql.join(
+      params.rows.map(
+        (row) =>
+          sql`(${row.nodeId}, ${params.graphId}, ${timestamp}, ${timestamp}, ${vecF32Literal(row.embedding, "embedding")})`,
+      ),
+      sql`, `,
+    );
+    return [
+      sql`
+        DELETE FROM ${table}
+        WHERE "graph_id" = ${params.graphId} AND "node_id" IN (${nodeIds})
+      `,
+      sql`
+        INSERT INTO ${table} ("node_id", "graph_id", "created_at", "updated_at", "embedding")
+        VALUES ${valueRows}
       `,
     ];
   },

--- a/packages/typegraph/src/store/embedding-sync.ts
+++ b/packages/typegraph/src/store/embedding-sync.ts
@@ -128,6 +128,88 @@ export async function syncEmbeddings(
 }
 
 /**
+ * Syncs embeddings for a batch of same-kind node creates through one
+ * `upsertEmbeddingBatch` per field (falling back to per-row
+ * `upsertEmbedding` when the backend lacks the batch primitive). Mirrors
+ * `syncEmbeddings` per row: present values upsert, `undefined` values
+ * delete any existing embedding for the field.
+ */
+export async function syncEmbeddingsBatchForKind(
+  args: Readonly<{
+    graphId: string;
+    nodeKind: string;
+    backend: GraphBackend | TransactionBackend;
+  }>,
+  schema: z.ZodType,
+  items: readonly Readonly<{
+    nodeId: string;
+    props: Record<string, unknown>;
+  }>[],
+): Promise<void> {
+  const { graphId, nodeKind, backend } = args;
+  if (!backend.upsertEmbedding || !backend.deleteEmbedding) {
+    return;
+  }
+
+  const embeddingFields = getEmbeddingFields(schema);
+  if (embeddingFields.length === 0) {
+    return;
+  }
+
+  for (const field of embeddingFields) {
+    const rows: { nodeId: string; embedding: readonly number[] }[] = [];
+    const deletionIds: string[] = [];
+    for (const item of items) {
+      const value = item.props[field.fieldPath];
+      if (isValidEmbeddingValue(value)) {
+        rows.push({ nodeId: item.nodeId, embedding: value });
+      } else if (value === undefined) {
+        deletionIds.push(item.nodeId);
+      }
+    }
+
+    if (rows.length > 0) {
+      if (backend.upsertEmbeddingBatch === undefined) {
+        for (const row of rows) {
+          await backend.upsertEmbedding({
+            graphId,
+            nodeKind,
+            nodeId: row.nodeId,
+            fieldPath: field.fieldPath,
+            embedding: row.embedding,
+            dimensions: field.dimensions,
+            metric: field.metric,
+            indexType: field.indexType,
+          });
+        }
+      } else {
+        await backend.upsertEmbeddingBatch({
+          graphId,
+          nodeKind,
+          fieldPath: field.fieldPath,
+          dimensions: field.dimensions,
+          metric: field.metric,
+          indexType: field.indexType,
+          rows,
+        });
+      }
+    }
+
+    for (const nodeId of deletionIds) {
+      await backend.deleteEmbedding({
+        graphId,
+        nodeKind,
+        nodeId,
+        fieldPath: field.fieldPath,
+        dimensions: field.dimensions,
+        metric: field.metric,
+        indexType: field.indexType,
+      });
+    }
+  }
+}
+
+/**
  * Deletes a node's embeddings for the embedding fields its kind CURRENTLY
  * declares. A field dropped from the schema after the node was written is
  * intentionally NOT swept here — its entire per-field table is reclaimed

--- a/packages/typegraph/src/store/fulltext-sync.ts
+++ b/packages/typegraph/src/store/fulltext-sync.ts
@@ -191,6 +191,77 @@ export async function syncFulltext(
 }
 
 /**
+ * Syncs the fulltext rows for a batch of same-kind node creates through
+ * one `upsertFulltextBatch` call (falling back to per-row `upsertFulltext`
+ * when the backend lacks the batch primitive). Mirrors `syncFulltext`
+ * per row: computed content upserts, empty content deletes any stale row
+ * when the schema declares searchable fields.
+ */
+export async function syncFulltextBatchForKind(
+  args: Readonly<{
+    graphId: string;
+    nodeKind: string;
+    backend: GraphBackend | TransactionBackend;
+  }>,
+  schema: z.ZodType,
+  items: readonly Readonly<{
+    nodeId: string;
+    props: Record<string, unknown>;
+  }>[],
+): Promise<void> {
+  const { graphId, nodeKind, backend } = args;
+  if (!backend.upsertFulltext || !backend.deleteFulltext) {
+    return;
+  }
+
+  const rows: { nodeId: string; content: string; language: string }[] = [];
+  const emptyContentIds: string[] = [];
+  const hasSearchableFields = getSearchableFields(schema).length > 0;
+  for (const item of items) {
+    const computed = computeFulltextContent(schema, item.props);
+    if (computed !== undefined) {
+      rows.push({
+        nodeId: item.nodeId,
+        content: computed.content,
+        language: computed.language,
+      });
+    } else if (hasSearchableFields) {
+      emptyContentIds.push(item.nodeId);
+    }
+  }
+
+  if (rows.length > 0) {
+    if (backend.upsertFulltextBatch === undefined) {
+      for (const row of rows) {
+        await backend.upsertFulltext({
+          graphId,
+          nodeKind,
+          nodeId: row.nodeId,
+          content: row.content,
+          language: row.language,
+        });
+      }
+    } else {
+      await backend.upsertFulltextBatch({ graphId, nodeKind, rows });
+    }
+  }
+
+  if (emptyContentIds.length > 0) {
+    if (backend.deleteFulltextBatch === undefined) {
+      for (const nodeId of emptyContentIds) {
+        await backend.deleteFulltext({ graphId, nodeKind, nodeId });
+      }
+    } else {
+      await backend.deleteFulltextBatch({
+        graphId,
+        nodeKind,
+        nodeIds: emptyContentIds,
+      });
+    }
+  }
+}
+
+/**
  * Deletes the fulltext row for a node.
  * Called on soft-delete; hard-delete is handled by the backend cascade.
  */

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -237,7 +237,7 @@ function resolveConstraint<G extends GraphDef>(
 // in the batch can see earlier ones during validation.
 // ============================================================
 
-function createNodeBatchValidationBackend(
+export function createNodeBatchValidationBackend(
   graphId: string,
   registry: KindRegistry,
   backend: GraphBackend | TransactionBackend,
@@ -407,7 +407,7 @@ function createNodeBatchValidationBackend(
  * first and then prime the validation caches with batched reads before
  * running {@link finishNodeCreatePreparation} per row.
  */
-type NodeCreateDraft = Readonly<{
+export type NodeCreateDraft = Readonly<{
   kind: string;
   id: string;
   nodeKind: NodeType;
@@ -619,8 +619,8 @@ async function performNodeUpdate<G extends GraphDef>(
  * one probe per row. Backends without the batch primitives skip priming
  * and keep the per-row fallback.
  */
-async function primeBatchValidationCaches<G extends GraphDef>(
-  ctx: NodeOperationContext<G>,
+export async function primeBatchValidationCaches(
+  ctx: Readonly<{ graphId: string; registry: KindRegistry }>,
   drafts: readonly NodeCreateDraft[],
   backend: GraphBackend | TransactionBackend,
   seams: Readonly<{

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -83,6 +83,7 @@ import {
 import {
   applyNodeHardDelete,
   applyNodeInsertSideEffects,
+  applyNodeInsertSideEffectsBatch,
   applyNodeSoftDelete,
   applyNodeUpdate,
   createNodeWriteContext,
@@ -249,6 +250,13 @@ function createNodeBatchValidationBackend(
     props: Record<string, unknown>,
     constraints: readonly UniqueConstraint[],
   ) => void;
+  seedNodeRow: (kind: string, id: string, row: CachedNodeRow) => void;
+  seedUniqueRow: (
+    kind: string,
+    constraintName: string,
+    key: string,
+    row: CachedUniqueRow,
+  ) => void;
 }> {
   const nodeCache = new Map<string, CachedNodeRow>();
   const pendingNodes = new Map<string, NonNullable<CachedNodeRow>>();
@@ -351,6 +359,29 @@ function createNodeBatchValidationBackend(
     }
   }
 
+  // Seed functions let batch preparation prime the caches from one
+  // getNodes / checkUniqueBatch round trip instead of a per-row probe.
+  // Seeding an absent result (`undefined`) is meaningful — it marks the
+  // key as known-missing so the per-row check skips the backend read.
+  // Existing entries are never overwritten: a pending registration or an
+  // earlier lookup always wins.
+  function seedNodeRow(kind: string, id: string, row: CachedNodeRow): void {
+    const cacheKey = buildNodeCacheKey(graphId, kind, id);
+    if (nodeCache.has(cacheKey)) return;
+    nodeCache.set(cacheKey, row);
+  }
+
+  function seedUniqueRow(
+    kind: string,
+    constraintName: string,
+    key: string,
+    row: CachedUniqueRow,
+  ): void {
+    const cacheKey = buildUniqueCacheKey(graphId, kind, constraintName, key);
+    if (uniqueCache.has(cacheKey)) return;
+    uniqueCache.set(cacheKey, row);
+  }
+
   const validationBackend = createBackendOverlay(backend, {
     getNode: getNodeCached,
     checkUnique: checkUniqueCached,
@@ -360,6 +391,8 @@ function createNodeBatchValidationBackend(
     backend: validationBackend,
     registerPendingNode,
     registerPendingUniqueEntries,
+    seedNodeRow,
+    seedUniqueRow,
   };
 }
 
@@ -367,12 +400,28 @@ function createNodeBatchValidationBackend(
 // Shared Create Pipeline
 // ============================================================
 
-async function validateAndPrepareNodeCreate<G extends GraphDef>(
+/**
+ * The synchronous half of create preparation: kind resolution, Zod
+ * validation, and date validation. Produces everything the async
+ * constraint checks need, so batch preparation can validate every input
+ * first and then prime the validation caches with batched reads before
+ * running {@link finishNodeCreatePreparation} per row.
+ */
+type NodeCreateDraft = Readonly<{
+  kind: string;
+  id: string;
+  nodeKind: NodeType;
+  uniqueConstraints: readonly UniqueConstraint[];
+  validatedProps: Record<string, unknown>;
+  validFrom: string | undefined;
+  validTo: string | undefined;
+}>;
+
+function draftNodeCreate<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
   input: CreateNodeInput,
   id: string,
-  backend: GraphBackend | TransactionBackend,
-): Promise<NodeCreatePrepared> {
+): NodeCreateDraft {
   const kind = input.kind;
   const registration = getNodeRegistration(ctx.graph, kind);
   const nodeKind = registration.type;
@@ -382,11 +431,24 @@ async function validateAndPrepareNodeCreate<G extends GraphDef>(
     operation: "create",
   });
 
-  const validFrom = validateOptionalCanonicalIsoDate(
-    input.validFrom,
-    "validFrom",
-  );
-  const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
+  return {
+    kind,
+    id,
+    nodeKind,
+    uniqueConstraints: registration.unique ?? [],
+    validatedProps,
+    validFrom: validateOptionalCanonicalIsoDate(input.validFrom, "validFrom"),
+    validTo: validateOptionalCanonicalIsoDate(input.validTo, "validTo"),
+  };
+}
+
+/** The async half: existence, disjointness, and uniqueness checks. */
+async function finishNodeCreatePreparation<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  draft: NodeCreateDraft,
+  backend: GraphBackend | TransactionBackend,
+): Promise<NodeCreatePrepared> {
+  const { kind, id, validatedProps, uniqueConstraints } = draft;
 
   const existingNode = await backend.getNode(ctx.graphId, kind, id);
   if (existingNode && !existingNode.deleted_at) {
@@ -400,7 +462,6 @@ async function validateAndPrepareNodeCreate<G extends GraphDef>(
   };
   await checkDisjointnessConstraint(constraintContext, kind, id);
 
-  const uniqueConstraints = registration.unique ?? [];
   await checkUniquenessConstraints(
     createUniquenessContext(ctx.graphId, ctx.registry, backend),
     kind,
@@ -412,7 +473,7 @@ async function validateAndPrepareNodeCreate<G extends GraphDef>(
   return {
     kind,
     id,
-    nodeKind,
+    nodeKind: draft.nodeKind,
     validatedProps,
     uniqueConstraints,
     insertParams: buildInsertNodeParams(
@@ -420,10 +481,47 @@ async function validateAndPrepareNodeCreate<G extends GraphDef>(
       kind,
       id,
       validatedProps,
-      validFrom,
-      validTo,
+      draft.validFrom,
+      draft.validTo,
     ),
   };
+}
+
+async function validateAndPrepareNodeCreate<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  input: CreateNodeInput,
+  id: string,
+  backend: GraphBackend | TransactionBackend,
+): Promise<NodeCreatePrepared> {
+  return finishNodeCreatePreparation(
+    ctx,
+    draftNodeCreate(ctx, input, id),
+    backend,
+  );
+}
+
+/**
+ * Batched {@link finalizeNodeCreate}: applies every prepared create's
+ * side effects through the batch pipeline (one uniqueness batch, one
+ * fulltext/embedding batch per kind) instead of a per-row statement fan.
+ */
+async function finalizeNodeCreateBatch<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  preparedCreates: readonly NodeCreatePrepared[],
+  backend: GraphBackend | TransactionBackend,
+  lock: GraphWriteLock,
+): Promise<void> {
+  await applyNodeInsertSideEffectsBatch(
+    createNodeWriteContext(ctx.graphId, ctx.registry, lock),
+    preparedCreates.map((prepared) => ({
+      kind: prepared.kind,
+      id: prepared.id,
+      schema: prepared.nodeKind.schema,
+      props: prepared.validatedProps,
+      uniqueConstraints: prepared.uniqueConstraints,
+    })),
+    backend,
+  );
 }
 
 async function finalizeNodeCreate<G extends GraphDef>(
@@ -513,6 +611,98 @@ async function performNodeUpdate<G extends GraphDef>(
 // validate-and-register loop. This extracts it.
 // ============================================================
 
+/**
+ * Primes the batch validation caches with batched reads: one `getNodes`
+ * per kind for existence probes and one `checkUniqueBatch` per
+ * (constraint, kind) for uniqueness pre-checks. The per-row checks in
+ * {@link finishNodeCreatePreparation} then hit memory instead of issuing
+ * one probe per row. Backends without the batch primitives skip priming
+ * and keep the per-row fallback.
+ */
+async function primeBatchValidationCaches<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  drafts: readonly NodeCreateDraft[],
+  backend: GraphBackend | TransactionBackend,
+  seams: Readonly<{
+    seedNodeRow: (kind: string, id: string, row: CachedNodeRow) => void;
+    seedUniqueRow: (
+      kind: string,
+      constraintName: string,
+      key: string,
+      row: CachedUniqueRow,
+    ) => void;
+  }>,
+): Promise<void> {
+  if (backend.getNodes !== undefined) {
+    const idsByKind = new Map<string, Set<string>>();
+    for (const draft of drafts) {
+      const ids = idsByKind.get(draft.kind) ?? new Set<string>();
+      ids.add(draft.id);
+      idsByKind.set(draft.kind, ids);
+    }
+    for (const [kind, ids] of idsByKind) {
+      const orderedIds = [...ids];
+      const rows = await backend.getNodes(ctx.graphId, kind, orderedIds);
+      const rowsById = new Map(rows.map((row) => [row.id, row]));
+      for (const id of orderedIds) {
+        seams.seedNodeRow(kind, id, rowsById.get(id));
+      }
+    }
+  }
+
+  if (backend.checkUniqueBatch !== undefined) {
+    interface ProbeGroup {
+      nodeKind: string;
+      constraintName: string;
+      keys: Set<string>;
+    }
+    const groups = new Map<string, ProbeGroup>();
+    for (const draft of drafts) {
+      for (const constraint of draft.uniqueConstraints) {
+        if (!checkWherePredicate(constraint, draft.validatedProps)) continue;
+        const key = computeUniqueKey(
+          draft.validatedProps,
+          constraint.fields,
+          constraint.collation,
+        );
+        const kindsToCheck = getKindsForUniquenessCheck(
+          draft.kind,
+          constraint.scope,
+          ctx.registry,
+        );
+        for (const kindToCheck of kindsToCheck) {
+          const groupKey = kindToCheck + CACHE_KEY_SEPARATOR + constraint.name;
+          const group = groups.get(groupKey) ?? {
+            nodeKind: kindToCheck,
+            constraintName: constraint.name,
+            keys: new Set<string>(),
+          };
+          group.keys.add(key);
+          groups.set(groupKey, group);
+        }
+      }
+    }
+    for (const group of groups.values()) {
+      const orderedKeys = [...group.keys];
+      const rows = await backend.checkUniqueBatch({
+        graphId: ctx.graphId,
+        nodeKind: group.nodeKind,
+        constraintName: group.constraintName,
+        keys: orderedKeys,
+      });
+      const rowsByKey = new Map(rows.map((row) => [row.key, row]));
+      for (const key of orderedKeys) {
+        seams.seedUniqueRow(
+          group.nodeKind,
+          group.constraintName,
+          key,
+          rowsByKey.get(key),
+        );
+      }
+    }
+  }
+}
+
 async function prepareBatchCreates<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
   inputs: readonly CreateNodeInput[],
@@ -525,16 +715,30 @@ async function prepareBatchCreates<G extends GraphDef>(
     backend: validationBackend,
     registerPendingNode,
     registerPendingUniqueEntries,
+    seedNodeRow,
+    seedUniqueRow,
   } = createNodeBatchValidationBackend(ctx.graphId, ctx.registry, backend);
 
-  const preparedCreates: NodeCreatePrepared[] = [];
+  // Pass 1 (synchronous): validate every input and assign ids. This
+  // surfaces a later row's validation error before an earlier row's
+  // constraint error — both fail the whole batch, so ordering across
+  // error categories is not part of the contract.
+  const drafts = inputs.map((input) =>
+    draftNodeCreate(ctx, input, input.id ?? generateId()),
+  );
 
-  for (const input of inputs) {
-    const id = input.id ?? generateId();
-    const prepared = await validateAndPrepareNodeCreate(
+  await primeBatchValidationCaches(ctx, drafts, backend, {
+    seedNodeRow,
+    seedUniqueRow,
+  });
+
+  // Pass 2: per-row constraint checks against the primed caches, in input
+  // order, registering pendings so later rows see earlier ones.
+  const preparedCreates: NodeCreatePrepared[] = [];
+  for (const draft of drafts) {
+    const prepared = await finishNodeCreatePreparation(
       ctx,
-      input,
-      id,
+      draft,
       validationBackend,
     );
     preparedCreates.push(prepared);
@@ -727,9 +931,7 @@ export async function executeNodeCreateNoReturnBatch<G extends GraphDef>(
 
     await runInsertBatch(nodeInsertDispatch(target), batchInsertParams);
 
-    for (const prepared of preparedCreates) {
-      await finalizeNodeCreate(ctx, prepared, target, lock);
-    }
+    await finalizeNodeCreateBatch(ctx, preparedCreates, target, lock);
   });
 }
 
@@ -761,9 +963,7 @@ export async function executeNodeCreateBatch<G extends GraphDef>(
       batchInsertParams,
     );
 
-    for (const prepared of preparedCreates) {
-      await finalizeNodeCreate(ctx, prepared, target, lock);
-    }
+    await finalizeNodeCreateBatch(ctx, preparedCreates, target, lock);
 
     return rows.map((row) => rowToNode(row));
   });

--- a/packages/typegraph/src/store/operations/node-write-pipeline.ts
+++ b/packages/typegraph/src/store/operations/node-write-pipeline.ts
@@ -27,14 +27,23 @@ import {
 import { type DeleteBehavior, type UniqueConstraint } from "../../core/types";
 import { RestrictedDeleteError } from "../../errors";
 import { type KindRegistry } from "../../registry/kind-registry";
-import { deleteNodeEmbeddings, syncEmbeddings } from "../embedding-sync";
-import { deleteNodeFulltext, syncFulltext } from "../fulltext-sync";
+import {
+  deleteNodeEmbeddings,
+  syncEmbeddings,
+  syncEmbeddingsBatchForKind,
+} from "../embedding-sync";
+import {
+  deleteNodeFulltext,
+  syncFulltext,
+  syncFulltextBatchForKind,
+} from "../fulltext-sync";
 import { type GraphWriteLock } from "../recorded-capture/clock";
 import {
   checkUniquenessConstraints,
   createUniquenessContext,
   deleteUniquenessEntries,
   insertUniquenessEntries,
+  insertUniquenessEntriesBatch,
   updateUniquenessEntries,
 } from "../uniqueness";
 
@@ -185,6 +194,58 @@ export async function applyNodeInsertSideEffects(
       args.props,
     ),
   ]);
+}
+
+/**
+ * Batched {@link applyNodeInsertSideEffects}: one uniqueness batch across
+ * every item, then one embedding batch per (kind, field) and one fulltext
+ * batch per kind — instead of the per-row statement fan the single-op path
+ * issues. Ordering matches the single-op path (uniqueness first, then the
+ * sync fans).
+ */
+export async function applyNodeInsertSideEffectsBatch(
+  ctx: NodeWriteContext,
+  items: readonly Readonly<{
+    kind: string;
+    id: string;
+    schema: z.ZodType;
+    props: Record<string, unknown>;
+    uniqueConstraints: readonly UniqueConstraint[];
+  }>[],
+  backend: Backend,
+): Promise<void> {
+  if (items.length === 0) return;
+
+  await insertUniquenessEntriesBatch(
+    uniquenessContext(ctx, backend),
+    items.map((item) => ({
+      kind: item.kind,
+      id: item.id,
+      props: item.props,
+      constraints: item.uniqueConstraints,
+    })),
+  );
+
+  interface KindGroup {
+    schema: z.ZodType;
+    rows: { nodeId: string; props: Record<string, unknown> }[];
+  }
+  const byKind = new Map<string, KindGroup>();
+  for (const item of items) {
+    const group = byKind.get(item.kind) ?? { schema: item.schema, rows: [] };
+    group.rows.push({ nodeId: item.id, props: item.props });
+    byKind.set(item.kind, group);
+  }
+
+  await Promise.all(
+    [...byKind.entries()].flatMap(([kind, group]) => {
+      const syncArguments = { graphId: ctx.graphId, nodeKind: kind, backend };
+      return [
+        syncEmbeddingsBatchForKind(syncArguments, group.schema, group.rows),
+        syncFulltextBatchForKind(syncArguments, group.schema, group.rows),
+      ];
+    }),
+  );
 }
 
 function parseRowProps(row: NodeRow): Record<string, unknown> {

--- a/packages/typegraph/src/store/uniqueness.ts
+++ b/packages/typegraph/src/store/uniqueness.ts
@@ -3,7 +3,11 @@
  *
  * Handles checking, inserting, updating, and deleting uniqueness constraint entries.
  */
-import { type GraphBackend, type TransactionBackend } from "../backend/types";
+import {
+  type GraphBackend,
+  type InsertUniqueParams,
+  type TransactionBackend,
+} from "../backend/types";
 import {
   checkWherePredicate,
   computeUniqueKey,
@@ -110,6 +114,53 @@ export async function insertUniquenessEntries(
       nodeId: id,
       concreteKind: kind,
     });
+  }
+}
+
+/**
+ * Inserts uniqueness entries for a batch of newly created nodes through one
+ * `insertUniqueBatch` call (falling back to per-entry `insertUnique` when
+ * the backend lacks the batch primitive). Same conflict semantics as the
+ * per-node path: the first entry whose key a different live node holds
+ * throws `UniquenessError`.
+ */
+export async function insertUniquenessEntriesBatch(
+  ctx: UniquenessContext,
+  items: readonly Readonly<{
+    kind: string;
+    id: string;
+    props: Record<string, unknown>;
+    constraints: readonly UniqueConstraint[];
+  }>[],
+): Promise<void> {
+  const entries: InsertUniqueParams[] = [];
+  for (const item of items) {
+    for (const constraint of item.constraints) {
+      if (!checkWherePredicate(constraint, item.props)) {
+        continue;
+      }
+      entries.push({
+        graphId: ctx.graphId,
+        nodeKind: item.kind,
+        constraintName: constraint.name,
+        key: computeUniqueKey(
+          item.props,
+          constraint.fields,
+          constraint.collation,
+        ),
+        nodeId: item.id,
+        concreteKind: item.kind,
+      });
+    }
+  }
+  if (entries.length === 0) return;
+
+  if (ctx.backend.insertUniqueBatch !== undefined) {
+    await ctx.backend.insertUniqueBatch(entries);
+    return;
+  }
+  for (const entry of entries) {
+    await ctx.backend.insertUnique(entry);
   }
 }
 

--- a/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
@@ -106,6 +106,7 @@ describe("computeSqliteBatchChunkSizes", () => {
       getEdgesChunkSize: 998,
       getNodesChunkSize: 997,
       nodeInsertBatchSize: 111,
+      uniqueInsertBatchSize: 166,
     });
   });
 
@@ -116,6 +117,7 @@ describe("computeSqliteBatchChunkSizes", () => {
       getEdgesChunkSize: 32_765,
       getNodesChunkSize: 32_764,
       nodeInsertBatchSize: 3640,
+      uniqueInsertBatchSize: 5461,
     });
   });
 
@@ -126,6 +128,7 @@ describe("computeSqliteBatchChunkSizes", () => {
       getEdgesChunkSize: 1,
       getNodesChunkSize: 1,
       nodeInsertBatchSize: 1,
+      uniqueInsertBatchSize: 1,
     });
   });
 });

--- a/packages/typegraph/tests/bulk-create-batching.test.ts
+++ b/packages/typegraph/tests/bulk-create-batching.test.ts
@@ -1,0 +1,318 @@
+/**
+ * bulkCreate round-trip batching.
+ *
+ * A batch create must not degenerate into per-row statements: existence
+ * probes go through one getNodes per kind, uniqueness pre-checks through
+ * one checkUniqueBatch per (constraint, kind), uniqueness entries through
+ * one insertUniqueBatch, fulltext sync through one upsertFulltextBatch per
+ * kind, and embedding sync through one upsertEmbeddingBatch per
+ * (kind, field). These tests count backend calls through a spying overlay
+ * (including inside the write transaction) and pin the batch-vs-per-row
+ * split, alongside the behavioral semantics that must not drift:
+ * in-batch conflicts, conflicts with existing rows, and create-over-
+ * tombstone.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  embedding,
+  searchable,
+} from "../src";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import type { GraphBackend, TransactionBackend } from "../src/backend/types";
+import { UniquenessError } from "../src/errors";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), email: z.string() }),
+});
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    title: searchable(),
+    body: searchable(),
+    embedding: embedding(4),
+  }),
+});
+
+function buildGraph() {
+  return defineGraph({
+    id: "bulk-batching",
+    nodes: {
+      Person: {
+        type: Person,
+        unique: [
+          {
+            name: "person_email",
+            fields: ["email"],
+            scope: "kind",
+            collation: "binary",
+          },
+        ],
+      },
+      Doc: { type: Document },
+    },
+    edges: {},
+  });
+}
+
+type CallCounts = Record<string, number>;
+
+const COUNTED_METHODS = [
+  "getNode",
+  "getNodes",
+  "checkUnique",
+  "checkUniqueBatch",
+  "insertUnique",
+  "insertUniqueBatch",
+  "upsertFulltext",
+  "upsertFulltextBatch",
+  "upsertEmbedding",
+  "upsertEmbeddingBatch",
+] as const;
+
+/**
+ * Wraps a backend (and every transaction-scoped backend it hands out) so
+ * each counted method increments a shared counter. Batch probes run inside
+ * the write transaction, so counting only the outer backend would miss
+ * everything.
+ */
+function withCallCounts(backend: GraphBackend): {
+  backend: GraphBackend;
+  counts: CallCounts;
+} {
+  const counts: CallCounts = {};
+  for (const name of COUNTED_METHODS) counts[name] = 0;
+
+  function wrapMethods<T extends GraphBackend | TransactionBackend>(
+    target: T,
+  ): T {
+    const wrapped = { ...target } as Record<string, unknown>;
+    for (const name of COUNTED_METHODS) {
+      const original = (target as Record<string, unknown>)[name];
+      if (typeof original !== "function") continue;
+      wrapped[name] = (...args: unknown[]) => {
+        counts[name] = (counts[name] ?? 0) + 1;
+        return (original as (...a: unknown[]) => unknown).apply(target, args);
+      };
+    }
+    return wrapped as T;
+  }
+
+  const outer = wrapMethods(backend);
+  const counted: GraphBackend = {
+    ...outer,
+    transaction: (fn, options) =>
+      backend.transaction((target, tx) => fn(wrapMethods(target), tx), options),
+  };
+  return { backend: counted, counts };
+}
+
+async function withCountedStore<T>(
+  run: (
+    store: Awaited<
+      ReturnType<typeof createStoreWithSchema<ReturnType<typeof buildGraph>>>
+    >[0],
+    counts: CallCounts,
+    raw: GraphBackend,
+  ) => Promise<T>,
+): Promise<T> {
+  const { backend: raw } = createLocalSqliteBackend();
+  try {
+    const { backend, counts } = withCallCounts(raw);
+    const [store] = await createStoreWithSchema(buildGraph(), backend);
+    // Boot traffic is not under test — count only what `run` triggers.
+    for (const name of COUNTED_METHODS) counts[name] = 0;
+    return await run(store, counts, raw);
+  } finally {
+    await raw.close();
+  }
+}
+
+const BATCH_SIZE = 40;
+
+function personInputs(offset = 0) {
+  return Array.from({ length: BATCH_SIZE }, (_, index) => ({
+    props: {
+      name: `person-${offset + index}`,
+      email: `p${offset + index}@example.com`,
+    },
+  }));
+}
+
+describe("bulkCreate probe batching", () => {
+  it("replaces per-row existence probes with one getNodes per kind", async () => {
+    await withCountedStore(async (store, counts) => {
+      const created = await store.nodes.Person.bulkCreate(personInputs());
+      expect(created).toHaveLength(BATCH_SIZE);
+
+      expect(counts.getNodes).toBe(1);
+      expect(counts.getNode).toBe(0);
+    });
+  });
+
+  it("replaces per-row uniqueness pre-checks with one checkUniqueBatch per constraint", async () => {
+    await withCountedStore(async (store, counts) => {
+      await store.nodes.Person.bulkCreate(personInputs());
+
+      expect(counts.checkUniqueBatch).toBe(1);
+      expect(counts.checkUnique).toBe(0);
+    });
+  });
+});
+
+describe("bulkCreate side-effect batching", () => {
+  it("writes uniqueness entries through one insertUniqueBatch", async () => {
+    await withCountedStore(async (store, counts) => {
+      await store.nodes.Person.bulkCreate(personInputs());
+
+      expect(counts.insertUniqueBatch).toBe(1);
+      expect(counts.insertUnique).toBe(0);
+    });
+  });
+
+  it("syncs fulltext through one upsertFulltextBatch", async () => {
+    await withCountedStore(async (store, counts) => {
+      const documents = Array.from({ length: BATCH_SIZE }, (_, index) => ({
+        props: {
+          title: `doc ${index}`,
+          body: `body text ${index}`,
+          embedding: [index, 1, 2, 3],
+        },
+      }));
+      await store.nodes.Doc.bulkCreate(documents);
+
+      expect(counts.upsertFulltextBatch).toBe(1);
+      expect(counts.upsertFulltext).toBe(0);
+    });
+  });
+
+  it("syncs embeddings through one upsertEmbeddingBatch per field", async () => {
+    await withCountedStore(async (store, counts, raw) => {
+      if (raw.capabilities.vector === undefined) return;
+      const documents = Array.from({ length: BATCH_SIZE }, (_, index) => ({
+        props: {
+          title: `doc ${index}`,
+          body: `body text ${index}`,
+          embedding: [index, 1, 2, 3],
+        },
+      }));
+      await store.nodes.Doc.bulkCreate(documents);
+
+      expect(counts.upsertEmbeddingBatch).toBe(1);
+      expect(counts.upsertEmbedding).toBe(0);
+    });
+  });
+});
+
+describe("bulkCreate batching semantics (must not drift)", () => {
+  it("creates rows readable by unique constraint and search after batching", async () => {
+    await withCountedStore(async (store) => {
+      await store.nodes.Person.bulkCreate(personInputs());
+      const found = await store.nodes.Person.findByConstraint("person_email", {
+        email: "p3@example.com",
+        name: "person-3",
+      });
+      expect(found?.name).toBe("person-3");
+
+      await store.nodes.Doc.bulkCreate([
+        {
+          props: {
+            title: "alpha report",
+            body: "quarterly earnings summary",
+            embedding: [1, 0, 0, 0],
+          },
+        },
+      ]);
+      const hits = await store.search.fulltext("Doc", {
+        query: "earnings",
+        limit: 5,
+      });
+      expect(hits).toHaveLength(1);
+    });
+  });
+
+  it("leaves batched embeddings searchable by vector", async () => {
+    await withCountedStore(async (store, _counts, raw) => {
+      if (raw.capabilities.vector === undefined) return;
+      await store.nodes.Doc.bulkCreate([
+        {
+          props: {
+            title: "alpha report",
+            body: "quarterly earnings summary",
+            embedding: [1, 0, 0, 0],
+          },
+        },
+      ]);
+      const vectorHits = await store.search.vector("Doc", {
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+        limit: 1,
+      });
+      expect(vectorHits).toHaveLength(1);
+    });
+  });
+
+  it("rejects an in-batch duplicate unique key", async () => {
+    await withCountedStore(async (store) => {
+      await expect(
+        store.nodes.Person.bulkCreate([
+          { props: { name: "a", email: "dup@example.com" } },
+          { props: { name: "b", email: "dup@example.com" } },
+        ]),
+      ).rejects.toThrow(UniquenessError);
+    });
+  });
+
+  it("rejects a duplicate of an existing unique key", async () => {
+    await withCountedStore(async (store) => {
+      await store.nodes.Person.create({
+        name: "existing",
+        email: "taken@example.com",
+      });
+      await expect(
+        store.nodes.Person.bulkCreate([
+          { props: { name: "x", email: "fresh@example.com" } },
+          { props: { name: "y", email: "taken@example.com" } },
+        ]),
+      ).rejects.toThrow(UniquenessError);
+    });
+  });
+
+  it("rejects an in-batch duplicate id", async () => {
+    await withCountedStore(async (store) => {
+      await expect(
+        store.nodes.Person.bulkCreate([
+          { id: "same-id", props: { name: "a", email: "a@example.com" } },
+          { id: "same-id", props: { name: "b", email: "b@example.com" } },
+        ]),
+      ).rejects.toThrow(/already exists/i);
+    });
+  });
+
+  it("still rejects create over a tombstoned id at the insert", async () => {
+    // Pins current semantics: the existence probe lets tombstoned ids
+    // through (only live rows raise NodeAlreadyExistsError) and the INSERT
+    // then fails on the primary key — resurrect goes through upsert paths,
+    // not create. Probe batching must not change this.
+    await withCountedStore(async (store) => {
+      const node = await store.nodes.Person.create({
+        name: "first",
+        email: "gone@example.com",
+      });
+      await store.nodes.Person.delete(node.id);
+
+      await expect(
+        store.nodes.Person.bulkCreate([
+          {
+            id: node.id,
+            props: { name: "second", email: "back@example.com" },
+          },
+        ]),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/typegraph/tests/import-batching.test.ts
+++ b/packages/typegraph/tests/import-batching.test.ts
@@ -1,0 +1,413 @@
+/**
+ * importGraph round-trip batching.
+ *
+ * The import path previously processed every node and edge one row at a
+ * time (existence probe, per-constraint uniqueness check, single-row
+ * INSERT per node; two endpoint reads and a single-row INSERT per edge)
+ * despite slicing by batchSize. It must now batch per slice: existence
+ * probes through getNodes/getEdges, uniqueness pre-checks through
+ * checkUniqueBatch, node inserts through insertNodesBatch (+ batched side
+ * effects), and edge inserts through insertEdgesBatch — while keeping the
+ * per-row semantics: conflicts route by onConflict, a uniqueness conflict
+ * is a per-row error entry (not an import abort), and reference
+ * validation rejects missing or tombstoned endpoints.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  searchable,
+} from "../src";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import type { GraphBackend, TransactionBackend } from "../src/backend/types";
+import {
+  FORMAT_VERSION,
+  type GraphData,
+  importGraph,
+  type ImportOptions,
+} from "../src/interchange";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), email: z.string() }),
+});
+
+const Note = defineNode("Note", {
+  schema: z.object({ body: searchable() }),
+});
+
+const knows = defineEdge("knows");
+
+function buildGraph() {
+  return defineGraph({
+    id: "import-batching",
+    nodes: {
+      Person: {
+        type: Person,
+        unique: [
+          {
+            name: "person_email",
+            fields: ["email"],
+            scope: "kind",
+            collation: "binary",
+          },
+        ],
+      },
+      Note: { type: Note },
+    },
+    edges: { knows: { type: knows, from: [Person], to: [Person] } },
+  });
+}
+
+function importOptions(overrides: Partial<ImportOptions> = {}): ImportOptions {
+  return {
+    onConflict: "skip",
+    onUnknownProperty: "error",
+    validateReferences: true,
+    batchSize: 100,
+    refreshStatistics: false,
+    ...overrides,
+  };
+}
+
+function payload(
+  nodes: GraphData["nodes"],
+  edges: GraphData["edges"] = [],
+): GraphData {
+  return {
+    formatVersion: FORMAT_VERSION,
+    exportedAt: new Date().toISOString(),
+    source: { type: "external", description: "import-batching test" },
+    nodes,
+    edges,
+  };
+}
+
+function personNode(index: number): GraphData["nodes"][number] {
+  return {
+    kind: "Person",
+    id: `p-${index}`,
+    properties: { name: `person-${index}`, email: `p${index}@example.com` },
+  };
+}
+
+function knowsEdge(index: number): GraphData["edges"][number] {
+  return {
+    kind: "knows",
+    id: `k-${index}`,
+    from: { kind: "Person", id: `p-${index}` },
+    to: { kind: "Person", id: `p-${(index + 1) % 50}` },
+    properties: {},
+  };
+}
+
+type CallCounts = Record<string, number>;
+
+const COUNTED_METHODS = [
+  "getNode",
+  "getNodes",
+  "getEdge",
+  "getEdges",
+  "checkUnique",
+  "checkUniqueBatch",
+  "insertNode",
+  "insertNodesBatch",
+  "insertEdge",
+  "insertEdgesBatch",
+  "insertUnique",
+  "insertUniqueBatch",
+  "upsertFulltext",
+  "upsertFulltextBatch",
+] as const;
+
+function withCallCounts(backend: GraphBackend): {
+  backend: GraphBackend;
+  counts: CallCounts;
+} {
+  const counts: CallCounts = {};
+  for (const name of COUNTED_METHODS) counts[name] = 0;
+
+  function wrapMethods<T extends GraphBackend | TransactionBackend>(
+    target: T,
+  ): T {
+    const wrapped = { ...target } as Record<string, unknown>;
+    for (const name of COUNTED_METHODS) {
+      const original = (target as Record<string, unknown>)[name];
+      if (typeof original !== "function") continue;
+      wrapped[name] = (...args: unknown[]) => {
+        counts[name] = (counts[name] ?? 0) + 1;
+        return (original as (...a: unknown[]) => unknown).apply(target, args);
+      };
+    }
+    return wrapped as T;
+  }
+
+  const outer = wrapMethods(backend);
+  const counted: GraphBackend = {
+    ...outer,
+    transaction: (fn, options) =>
+      backend.transaction((target, tx) => fn(wrapMethods(target), tx), options),
+  };
+  return { backend: counted, counts };
+}
+
+async function withCountedStore<T>(
+  run: (
+    store: Awaited<
+      ReturnType<typeof createStoreWithSchema<ReturnType<typeof buildGraph>>>
+    >[0],
+    counts: CallCounts,
+  ) => Promise<T>,
+): Promise<T> {
+  const { backend: raw } = createLocalSqliteBackend();
+  try {
+    const { backend, counts } = withCallCounts(raw);
+    const [store] = await createStoreWithSchema(buildGraph(), backend);
+    for (const name of COUNTED_METHODS) counts[name] = 0;
+    return await run(store, counts);
+  } finally {
+    await raw.close();
+  }
+}
+
+const NODE_COUNT = 50;
+
+describe("importGraph batching", () => {
+  it("imports nodes through batched probes, inserts, and side effects", async () => {
+    await withCountedStore(async (store, counts) => {
+      const result = await importGraph(
+        store,
+        payload(
+          Array.from({ length: NODE_COUNT }, (_, index) => personNode(index)),
+        ),
+        importOptions(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.nodes.created).toBe(NODE_COUNT);
+
+      expect(counts.getNode).toBe(0);
+      expect(counts.getNodes).toBeLessThanOrEqual(2);
+      expect(counts.checkUnique).toBe(0);
+      expect(counts.checkUniqueBatch).toBe(1);
+      expect(counts.insertNode).toBe(0);
+      expect(counts.insertNodesBatch).toBe(1);
+      expect(counts.insertUnique).toBe(0);
+      expect(counts.insertUniqueBatch).toBe(1);
+    });
+  });
+
+  it("imports edges through batched endpoint checks and inserts", async () => {
+    await withCountedStore(async (store, counts) => {
+      const result = await importGraph(
+        store,
+        payload(
+          Array.from({ length: NODE_COUNT }, (_, index) => personNode(index)),
+          Array.from({ length: NODE_COUNT }, (_, index) => knowsEdge(index)),
+        ),
+        importOptions(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.edges.created).toBe(NODE_COUNT);
+
+      expect(counts.getEdge).toBe(0);
+      expect(counts.getEdges).toBe(1);
+      expect(counts.insertEdge).toBe(0);
+      expect(counts.insertEdgesBatch).toBe(1);
+    });
+  });
+
+  it("syncs searchable imports through the fulltext batch", async () => {
+    await withCountedStore(async (store, counts) => {
+      const notes = Array.from({ length: 20 }, (_, index) => ({
+        kind: "Note",
+        id: `n-${index}`,
+        properties: { body: `note body ${index}` },
+      }));
+      const result = await importGraph(store, payload(notes), importOptions());
+
+      expect(result.nodes.created).toBe(20);
+      expect(counts.upsertFulltext).toBe(0);
+      expect(counts.upsertFulltextBatch).toBe(1);
+    });
+  });
+});
+
+describe("importGraph batching semantics (must not drift)", () => {
+  it("routes existing rows by onConflict: skip", async () => {
+    await withCountedStore(async (store) => {
+      await store.nodes.Person.create({
+        name: "existing",
+        email: "p1@example.com",
+      });
+      const nodes = [
+        personNode(0),
+        { ...personNode(1), id: (await firstPersonId(store))! },
+      ];
+      const result = await importGraph(store, payload(nodes), importOptions());
+      expect(result.nodes.created).toBe(1);
+      expect(result.nodes.skipped).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  it("records a per-row error for a uniqueness conflict and continues", async () => {
+    await withCountedStore(async (store) => {
+      await store.nodes.Person.create({
+        name: "existing",
+        email: "taken@example.com",
+      });
+      const nodes = [
+        personNode(0),
+        {
+          kind: "Person",
+          id: "p-conflict",
+          properties: { name: "dup", email: "taken@example.com" },
+        },
+        personNode(1),
+      ];
+      const result = await importGraph(store, payload(nodes), importOptions());
+
+      expect(result.nodes.created).toBe(2);
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.id).toBe("p-conflict");
+      expect(result.errors[0]?.error).toMatch(/person_email/);
+    });
+  });
+
+  it("records a per-row error for an in-payload duplicate unique key", async () => {
+    await withCountedStore(async (store) => {
+      const nodes = [
+        personNode(0),
+        {
+          kind: "Person",
+          id: "p-dup-key",
+          properties: { name: "dup", email: "p0@example.com" },
+        },
+      ];
+      const result = await importGraph(store, payload(nodes), importOptions());
+
+      expect(result.nodes.created).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.id).toBe("p-dup-key");
+    });
+  });
+
+  it("handles duplicate ids within one payload by conflict routing", async () => {
+    await withCountedStore(async (store) => {
+      const nodes = [
+        personNode(0),
+        {
+          kind: "Person",
+          id: "p-0",
+          properties: { name: "second", email: "other@example.com" },
+        },
+      ];
+      const skip = await importGraph(store, payload(nodes), importOptions());
+      expect(skip.nodes.created).toBe(1);
+      expect(skip.nodes.skipped).toBe(1);
+    });
+  });
+
+  it("updates existing live rows under onConflict: update", async () => {
+    await withCountedStore(async (store) => {
+      await importGraph(store, payload([personNode(0)]), importOptions());
+      const result = await importGraph(
+        store,
+        payload([
+          {
+            kind: "Person",
+            id: "p-0",
+            properties: { name: "renamed", email: "p0@example.com" },
+          },
+        ]),
+        importOptions({ onConflict: "update" }),
+      );
+      expect(result.nodes.updated).toBe(1);
+
+      const updated = await store.nodes.Person.getById("p-0" as never);
+      expect(updated?.name).toBe("renamed");
+    });
+  });
+
+  it("rejects edges whose endpoints are missing or tombstoned", async () => {
+    await withCountedStore(async (store) => {
+      const alive = await store.nodes.Person.create({
+        name: "alive",
+        email: "alive@example.com",
+      });
+      const dead = await store.nodes.Person.create({
+        name: "dead",
+        email: "dead@example.com",
+      });
+      await store.nodes.Person.delete(dead.id);
+
+      const edges = [
+        {
+          kind: "knows",
+          id: "k-missing",
+          from: { kind: "Person", id: alive.id },
+          to: { kind: "Person", id: "nope" },
+          properties: {},
+        },
+        {
+          kind: "knows",
+          id: "k-dead",
+          from: { kind: "Person", id: alive.id },
+          to: { kind: "Person", id: dead.id },
+          properties: {},
+        },
+      ];
+      const result = await importGraph(
+        store,
+        payload([], edges),
+        importOptions(),
+      );
+
+      expect(result.edges.created).toBe(0);
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors.map((entry) => entry.id).toSorted()).toEqual([
+        "k-dead",
+        "k-missing",
+      ]);
+    });
+  });
+
+  it("skips tombstoned rows under onConflict: update without resurrecting", async () => {
+    await withCountedStore(async (store) => {
+      const node = await store.nodes.Person.create({
+        name: "gone",
+        email: "gone@example.com",
+      });
+      await store.nodes.Person.delete(node.id);
+
+      const result = await importGraph(
+        store,
+        payload([
+          {
+            kind: "Person",
+            id: node.id,
+            properties: { name: "back", email: "back@example.com" },
+          },
+        ]),
+        importOptions({ onConflict: "update" }),
+      );
+      expect(result.nodes.skipped).toBe(1);
+      expect(result.nodes.updated).toBe(0);
+    });
+  });
+});
+
+async function firstPersonId(
+  store: Awaited<
+    ReturnType<typeof createStoreWithSchema<ReturnType<typeof buildGraph>>>
+  >[0],
+): Promise<string | undefined> {
+  const people = await store.nodes.Person.find({ limit: 1 });
+  return people[0]?.id;
+}


### PR DESCRIPTION
## Summary

Second slice of the performance audit "bulk paths aren't bulk." Stacked on #194 (base branch is `perf/default-engine-tuning`; retarget to `main` after #194 merges).

### bulkCreate (~2.6× on search-indexed batches)

`bulkCreate` issued one multi-row INSERT surrounded by per-row statements: an existence probe and per-constraint uniqueness pre-check per input, then per-row uniqueness entries, fulltext upserts, and embedding upserts (2 statements each on FTS5/vec0's DELETE+INSERT). Now:

- **Probes batch**: validation runs as a synchronous first pass, then the batch validation caches are primed with one `getNodes` per kind and one `checkUniqueBatch` per (constraint, kind); the per-row checks run against memory. (Error ordering across categories can change for multi-error batches — a later row's validation error may surface before an earlier row's constraint error; both fail the whole batch.)
- **Side effects batch**: uniqueness entries write through a new `insertUniqueBatch` (multi-row conditional upsert against `excluded`, RETURNING-based owner attribution preserving the single-row path's `UniquenessError` semantics, chunked by the connection's bound-parameter budget); fulltext syncs through the existing `upsertFulltextBatch`; embeddings through a new `upsertEmbeddingBatch` per (kind, field), implemented for pgvector, sqlite-vec, and libSQL native via an optional `VectorStrategy.buildUpsertBatch` seam with per-row fallback for custom strategies.

Measured (write bench, in-memory SQLite, 100-row batches with searchable + embedding fields): **~1,600 → ~4,100 rows/s**.

### importGraph (~4× in-memory; far larger on networked engines)

`importGraph` processed every row individually despite its `batchSize` option. Each slice now batches: nodes prime the same validation caches, route per row against memory, and flush accepted creates through `insertNodesBatch` + the batched side-effect pass; edges batch endpoint liveness (`getNodes` per endpoint kind), existence (`getEdges`), and inserts (`insertEdgesBatch`). Backends without the batch primitives keep the per-row fallback.

Per-row semantics preserved: conflicts route by `onConflict`; a uniqueness conflict is a per-row error entry, not an import abort; reference validation still rejects missing/tombstoned endpoints; in-slice duplicate ids defer to the per-row path after the flush so they observe the first occurrence's row exactly as before.

Measured (write bench, in-memory SQLite, 500 nodes + 500 edges per import): **~26k → ~96k entities/s**. On per-statement-networked engines (Turso, D1, Neon) the old path paid one round trip per row; the new one pays a handful per slice.

## Testing

- `tests/bulk-create-batching.test.ts` (11) and `tests/import-batching.test.ts` (10), written red-first: statement-count assertions via a backend spy that follows the transaction-scoped backend, plus semantics pins (in-batch/in-payload conflicts, duplicate ids, tombstone handling, endpoint liveness, searchability of batched rows).
- New `write:bulk-doc-create` bench shape covers the sidecar path.
