### PR TITLE
perf: route SQLite CRUD through the prepared-statement cache

### DIFF
--- a/.changeset/sqlite-crud-statement-cache.md
+++ b/.changeset/sqlite-crud-statement-cache.md
@@ -1,0 +1,19 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+SQLite CRUD statements now reuse the prepared-statement cache. The
+operation backend's read/write helpers previously executed through
+drizzle's `db.all()` / `db.run()`, which re-prepares every statement on
+every call — only the query engine's `backend.execute` path used the
+prepared-statement LRU. On synchronous drivers (better-sqlite3,
+bun:sqlite) CRUD statements and the per-write transaction frames
+(`BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`) now route through the
+execution adapter's compiled path, so a repeated operation shape re-binds
+parameters against a cached prepared statement. A warmed CRUD cycle
+re-prepares nothing. Async drivers (remote libsql/Turso, D1) have no
+statement cache and keep the existing execution path.
+
+Measured on the write bench (in-memory SQLite, order-controlled A/B):
+single-op creates ~18.3k → ~28.8k ops/s (~1.6×), transaction-batched
+creates ~23.9k → ~36k ops/s (~1.5×).

--- a/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
@@ -18,6 +18,18 @@ const DEFAULT_PREPARED_STATEMENT_CACHE_MAX = 256;
 
 type PreparedAllStatement = Readonly<{
   all: (...params: readonly unknown[]) => readonly unknown[];
+  /**
+   * Executes a statement that returns no rows. better-sqlite3 and
+   * bun:sqlite both expose it; better-sqlite3 additionally REQUIRES it for
+   * non-reader statements (`all()` on those throws).
+   */
+  run?: (...params: readonly unknown[]) => unknown;
+  /**
+   * better-sqlite3's "does this statement return rows" flag. bun:sqlite
+   * has no equivalent; `undefined` is treated as non-reader on the run
+   * path (bun's `run()` accepts any statement).
+   */
+  reader?: boolean;
 }>;
 
 type SqliteClientWithPrepare = Readonly<{
@@ -94,6 +106,13 @@ export type SqliteExecutionAdapter = Readonly<
   SqlExecutionAdapter & {
     clearStatementCache: () => void;
     profile: SqliteExecutionProfile;
+    /**
+     * Executes a compiled statement that returns no rows through the
+     * prepared-statement cache. Present only on synchronous drivers with a
+     * preparable client — the CRUD write path falls back to drizzle's
+     * `db.run()` when absent.
+     */
+    executeCompiledRun?: (compiledQuery: CompiledSqlQuery) => Promise<void>;
   }
 >;
 
@@ -344,6 +363,25 @@ export function createSqliteExecutionAdapter(
       return Promise.resolve(rows as readonly TRow[]);
     }
 
+    function executeCompiledRun(compiledQuery: CompiledSqlQuery): Promise<void> {
+      const preparedStatement = getOrCreatePreparedStatement(
+        statementCache,
+        client,
+        compiledQuery.sql,
+        statementCacheMax,
+      );
+      // better-sqlite3 rejects run() on reader statements and all() on
+      // non-reader statements, so pick by the statement's own flag; a
+      // client without run() (or without the reader flag but returning
+      // rows) drains through all() and discards.
+      if (preparedStatement.run === undefined || preparedStatement.reader === true) {
+        preparedStatement.all(...compiledQuery.params);
+      } else {
+        preparedStatement.run(...compiledQuery.params);
+      }
+      return Promise.resolve();
+    }
+
     return {
       clearStatementCache() {
         statementCache.clear();
@@ -354,6 +392,7 @@ export function createSqliteExecutionAdapter(
         return executeCompiled<TRow>(compiledQuery);
       },
       executeCompiled,
+      executeCompiledRun,
       prepare(sqlText: string): PreparedSqlStatement {
         return createPreparedStatementExecutor(
           client,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -481,29 +481,48 @@ function createSqliteOperationBackend(
     vectorSlotLatch,
   } = options;
 
+  // CRUD statements route through the execution adapter's compiled path on
+  // synchronous drivers so a repeated operation shape re-binds parameters
+  // against a cached prepared statement instead of re-preparing through
+  // drizzle's session on every call. Async drivers (remote libsql, D1)
+  // have no statement cache and keep the drizzle fallback.
+  const compiledExecute = executionAdapter.executeCompiled;
+  const compiledRun = executionAdapter.executeCompiledRun;
+
   function execGet<T>(query: SQL): Promise<T | undefined> {
-    // Workaround: drizzle-team/drizzle-orm#1049 — db.get() crashes with
-    // the libsql driver when no rows match (normalizeRow receives undefined).
-    // Using db.all()[0] avoids the crash for all drivers.
+    // Fallback uses db.all()[0], not db.get(): drizzle-team/drizzle-orm#1049
+    // — db.get() crashes with the libsql driver when no rows match
+    // (normalizeRow receives undefined).
     //
-    // All three exec helpers use `await` unconditionally rather than
+    // The fallback branches use `await` unconditionally rather than
     // `instanceof Promise` because Drizzle returns SQLiteRaw thenables
     // that are NOT Promise instances (drizzle-team/drizzle-orm#2275).
     return runWithSerializedQueue(serializedQueue, async () => {
-      const rows = await db.all(query);
-      return (rows as T[])[0];
+      if (compiledExecute === undefined) {
+        const rows = await db.all(query);
+        return (rows as T[])[0];
+      }
+      const rows = await compiledExecute<T>(executionAdapter.compile(query));
+      return rows[0];
     });
   }
 
   function execAll<T>(query: SQL): Promise<T[]> {
     return runWithSerializedQueue(serializedQueue, async () => {
-      return await db.all(query);
+      if (compiledExecute === undefined) {
+        return await db.all(query);
+      }
+      return [...(await compiledExecute<T>(executionAdapter.compile(query)))];
     });
   }
 
   function execRun(query: SQL): Promise<void> {
     return runWithSerializedQueue(serializedQueue, async () => {
-      await db.run(query);
+      if (compiledRun === undefined) {
+        await db.run(query);
+        return;
+      }
+      await compiledRun(executionAdapter.compile(query));
     });
   }
 
@@ -874,6 +893,22 @@ export function createSqliteBackend(
   }
 
   /**
+   * Executes a transaction-frame statement (BEGIN IMMEDIATE / COMMIT /
+   * ROLLBACK) through the prepared-statement cache when the driver has one.
+   * These are the hottest statements on the per-write path (every single
+   * write is its own transaction). Local libsql also uses "sql" transaction
+   * mode but is async (no compiled path) and keeps the drizzle fallback.
+   */
+  async function runFrameStatement(query: SQL): Promise<void> {
+    const compiledRun = executionAdapter.executeCompiledRun;
+    if (compiledRun === undefined) {
+      await db.run(query);
+      return;
+    }
+    await compiledRun(executionAdapter.compile(query));
+  }
+
+  /**
    * Runs `fn` inside a SQLite write transaction (BEGIN IMMEDIATE) so that
    * the read-then-write inside `commitSchemaVersion` / `setActiveVersion`
    * is serialized against concurrent writers — a deferred BEGIN would let
@@ -910,13 +945,13 @@ export function createSqliteBackend(
           vectorStrategy,
           vectorSlotLatch,
         });
-        await db.run(sql`BEGIN IMMEDIATE`);
+        await runFrameStatement(sql`BEGIN IMMEDIATE`);
         try {
           const result = await fn(txBackend);
-          await db.run(sql`COMMIT`);
+          await runFrameStatement(sql`COMMIT`);
           return result;
         } catch (error) {
-          await db.run(sql`ROLLBACK`);
+          await runFrameStatement(sql`ROLLBACK`);
           throw error;
         }
       });
@@ -1307,7 +1342,7 @@ export function createSqliteBackend(
           // immediately with "database is locked" against a writer on another
           // connection (the serialized queue only orders writes within THIS
           // backend); IMMEDIATE instead waits on SQLite's busy timeout.
-          await db.run(sql`BEGIN IMMEDIATE`);
+          await runFrameStatement(sql`BEGIN IMMEDIATE`);
 
           try {
             const result = await fn(
@@ -1317,10 +1352,10 @@ export function createSqliteBackend(
               ),
               db,
             );
-            await db.run(sql`COMMIT`);
+            await runFrameStatement(sql`COMMIT`);
             return result;
           } catch (error) {
-            await db.run(sql`ROLLBACK`);
+            await runFrameStatement(sql`ROLLBACK`);
             throw error;
           }
         });

--- a/packages/typegraph/tests/backends/sqlite/crud-statement-cache.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/crud-statement-cache.test.ts
@@ -79,10 +79,10 @@ describe("SQLite CRUD statement-cache reuse", () => {
       // touches (probes, inserts, uniqueness upserts, updates, deletes).
       await crudCycle("warmup");
 
-      (client as { prepare: unknown }).prepare = ((sqlText: string) => {
+      (client as { prepare: unknown }).prepare = (sqlText: string) => {
         prepareCalls += 1;
         return originalPrepare(sqlText);
-      });
+      };
 
       await crudCycle("second");
       await crudCycle("third");

--- a/packages/typegraph/tests/backends/sqlite/crud-statement-cache.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/crud-statement-cache.test.ts
@@ -1,0 +1,120 @@
+/**
+ * SQLite CRUD statement-cache reuse.
+ *
+ * The operation backend's CRUD helpers previously executed through
+ * drizzle's `db.all()` / `db.run()`, which re-prepares every statement on
+ * every call — only the query engine's `backend.execute` path used the
+ * prepared-statement LRU. CRUD now routes through the execution adapter's
+ * compiled path on synchronous drivers, so a repeated operation shape
+ * re-binds parameters against a cached prepared statement instead of
+ * re-preparing.
+ *
+ * The spy counts raw `$client.prepare` calls: after one warmup pass over a
+ * CRUD cycle (create, update, delete), repeating the same cycle must
+ * prepare nothing new.
+ */
+import type Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStore, defineEdge, defineGraph, defineNode } from "../../../src";
+import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), email: z.string() }),
+});
+
+const knows = defineEdge("knows");
+
+const graph = defineGraph({
+  id: "crud-stmt-cache",
+  nodes: {
+    Person: {
+      type: Person,
+      onDelete: "disconnect",
+      unique: [
+        {
+          name: "person_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+function rawClient(db: unknown): Database.Database {
+  return (db as { $client: Database.Database }).$client;
+}
+
+describe("SQLite CRUD statement-cache reuse", () => {
+  it("re-prepares nothing when a warmed CRUD cycle repeats", async () => {
+    const { backend, db } = createLocalSqliteBackend();
+    const client = rawClient(db);
+    const originalPrepare = client.prepare.bind(client);
+    let prepareCalls = 0;
+    try {
+      const store = createStore(graph, backend);
+
+      async function crudCycle(tag: string): Promise<void> {
+        const alice = await store.nodes.Person.create({
+          name: `alice-${tag}`,
+          email: `alice-${tag}@example.com`,
+        });
+        const bob = await store.nodes.Person.create({
+          name: `bob-${tag}`,
+          email: `bob-${tag}@example.com`,
+        });
+        await store.edges.knows.create(alice, bob);
+        await store.nodes.Person.update(alice.id, {
+          name: `alice-${tag}-renamed`,
+        });
+        await store.nodes.Person.delete(alice.id);
+        await store.nodes.Person.delete(bob.id);
+      }
+
+      // Warmup populates the cache with every statement shape the cycle
+      // touches (probes, inserts, uniqueness upserts, updates, deletes).
+      await crudCycle("warmup");
+
+      (client as { prepare: unknown }).prepare = ((sqlText: string) => {
+        prepareCalls += 1;
+        return originalPrepare(sqlText);
+      });
+
+      await crudCycle("second");
+      await crudCycle("third");
+
+      expect(prepareCalls).toBe(0);
+    } finally {
+      (client as { prepare: unknown }).prepare = originalPrepare;
+      await backend.close();
+    }
+  });
+
+  it("keeps CRUD results correct through the cached path", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const store = createStore(graph, backend);
+
+      const created = await store.nodes.Person.create({
+        name: "carol",
+        email: "carol@example.com",
+      });
+      const updated = await store.nodes.Person.update(created.id, {
+        name: "carol-2",
+      });
+      expect(updated.name).toBe("carol-2");
+
+      const fetched = await store.nodes.Person.getById(created.id);
+      expect(fetched?.name).toBe("carol-2");
+
+      await store.nodes.Person.delete(created.id);
+      expect(await store.nodes.Person.getById(created.id)).toBeUndefined();
+    } finally {
+      await backend.close();
+    }
+  });
+});


### PR DESCRIPTION
Third slice of the performance audit . The operation backend's CRUD helpers (`execGet`/`execAll`/`execRun`) executed through drizzle's `db.all()`/`db.run()`, which re-prepares every statement on every call; only the query engine's `backend.execute` path used the prepared-statement LRU, an asymmetry with PostgreSQL (whose CRUD path has used server-side prepared statements since #194's predecessor work).

On synchronous drivers (better-sqlite3, bun:sqlite):

- CRUD statements compile once per call and execute through the adapter's cached prepared statements.
- The per-write transaction frames (`BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`) — the hottest statements on the per-write path, since every single write is its own transaction — route through a new `executeCompiledRun`, which picks `run()` vs `all()` by the statement's `reader` flag (better-sqlite3 rejects the wrong method on each side; bun has no flag and its `run()` accepts any statement).

Async drivers (remote libsql/Turso, D1) have no statement cache and keep the existing drizzle path, as do sync drivers without a preparable client (Durable Objects storage).

## Measured

Order-controlled A/B on the write bench (in-memory SQLite, medians over 7 samples, both orders run):

| shape | before | after | delta |
| --- | --- | --- | --- |
| single-op create | ~18.3k ops/s | ~28.8k ops/s | **~1.6×** |
| create ×200 in one txn | ~23.9k ops/s | ~36k ops/s | **~1.5×** |

## Testing

- New `tests/backends/sqlite/crud-statement-cache.test.ts`, written red-first: after one warmup CRUD cycle (create ×2, edge create, update, delete ×2 — probes, inserts, uniqueness upserts, frames included), repeating the cycle re-prepares **zero** statements (was 36 re-prepares per cycle), plus a behavioral pin on CRUD results through the cached path.
