### PR TITLE
perf: gin and trigram index methods for property filters

### DIFF
--- a/.changeset/gin-trigram-index-methods.md
+++ b/.changeset/gin-trigram-index-methods.md
@@ -1,0 +1,29 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Property filters that a btree can never serve now have a declarative index
+story: `defineNodeIndex` / `defineEdgeIndex` accept
+`method: "gin" | "trigram"` (default `"btree"`, unchanged).
+
+- `method: "gin"` emits a PostgreSQL expression GIN (`jsonb_path_ops`) over
+  the field's jsonb extraction, serving the array containment predicates
+  (`contains` / `containsAll` / `containsAny` on array fields). Verified to
+  match TypeGraph's compiled `(props #> ARRAY[…]) @> $1` form under
+  parameterized prepared statements — note that a hand-written
+  whole-column `GIN (props)` never matches these expressions (the previous
+  docs guidance recommended one; corrected).
+- `method: "trigram"` emits an expression GIN with `gin_trgm_ops` over the
+  field's text extraction, serving substring and case-insensitive matches
+  (`contains` / `startsWith` / `endsWith` / `like` / `ilike` on string
+  fields). `materializeIndexes()` installs `pg_trgm`
+  (`CREATE EXTENSION IF NOT EXISTS`) on first use.
+
+Both are materialize-only (like vector ANN indexes) and PostgreSQL-only:
+`materializeIndexes()` reports them as `skipped` on SQLite, whose
+substring-search story is FTS5 fulltext. GIN-family declarations take
+exactly one field and reject `unique`, `coveringFields`, and `where`;
+`method: "btree"` is canonicalized by absence so existing stored schema
+documents and materialization signatures are unchanged. `bulkFindByIndex`
+rejects GIN-family indexes (it compiles equality probes, which only btree
+declarations serve).

--- a/apps/docs/src/content/docs/performance/indexes.md
+++ b/apps/docs/src/content/docs/performance/indexes.md
@@ -252,20 +252,22 @@ defineNodeIndex(Person, { fields: ["email"] });
 defineNodeIndex(Person, { fields: ["createdScore"] });
 ```
 
-### GIN indexes (array and object containment — PostgreSQL only)
+### GIN indexes (array containment — PostgreSQL only)
 
-TypeGraph compiles array predicates to PostgreSQL's JSONB containment operator (`@>`), which is
-optimized by GIN indexes. If you filter on array properties, create a GIN index on the `props`
-column:
+TypeGraph compiles array predicates to PostgreSQL's JSONB containment operator over the field's
+extraction expression — `(props #> ARRAY['tags']) @> $1`. Declare a containment index with
+`method: "gin"` and TypeGraph emits the matching **expression GIN** (`jsonb_path_ops`):
 
-```sql
--- Covers ALL array containment queries on Person nodes
-CREATE INDEX idx_person_props_gin ON typegraph_nodes
-  USING GIN (props)
-  WHERE graph_id = 'my_graph' AND kind = 'Person' AND deleted_at IS NULL;
+```typescript
+const personTags = defineNodeIndex(Person, {
+  fields: ["tags"],
+  method: "gin",
+});
+// materialized via store.materializeIndexes():
+// CREATE INDEX ... USING GIN (("props" #> ARRAY['tags']) jsonb_path_ops);
 ```
 
-This single GIN index accelerates all of the following predicates:
+The index accelerates all containment predicates on that field:
 
 ```typescript
 // contains: does the tags array include "typescript"?
@@ -278,29 +280,54 @@ This single GIN index accelerates all of the following predicates:
 .whereNode("p", (p) => p.tags.containsAny(["typescript", "graphql"]))
 ```
 
-Unlike B-tree expression indexes, a single GIN index covers queries on **any** JSON path within
-`props` — you don't need a separate index per field.
+:::caution[Whole-column `GIN (props)` does not work]
+PostgreSQL matches expression indexes structurally. A whole-column
+`CREATE INDEX ... USING GIN (props)` serves `props @> …` — **not** the
+per-field `(props #> ARRAY['tags']) @> …` expressions TypeGraph compiles,
+so such an index is never used. Declare `method: "gin"` per field (or
+hand-write the same expression form) instead.
+:::
 
 :::note[SQLite]
-SQLite has no GIN equivalent. Array containment queries on SQLite use `json_each()` scans,
-which can't be indexed. If array filtering is performance-critical, consider PostgreSQL.
+SQLite has no GIN equivalent; `materializeIndexes()` reports gin/trigram
+declarations as `skipped` there. Array containment on SQLite uses
+`json_each()` scans, which can't be indexed.
 :::
+
+### Trigram indexes (substring and case-insensitive matching — PostgreSQL only)
+
+`contains` / `startsWith` / `endsWith` / `ilike` on string fields compile to
+`ILIKE` on PostgreSQL, which a B-tree can never serve for infix patterns.
+Declare `method: "trigram"` and TypeGraph emits an expression GIN with
+`gin_trgm_ops` (installing the `pg_trgm` extension on first
+materialization):
+
+```typescript
+const personName = defineNodeIndex(Person, {
+  fields: ["name"],
+  method: "trigram",
+});
+// CREATE INDEX ... USING GIN (("props" #>> ARRAY['name']) gin_trgm_ops);
+
+.whereNode("p", (p) => p.name.contains("smith"))   // served by the index
+.whereNode("p", (p) => p.name.ilike("%SMITH%"))    // also served
+```
+
+On SQLite these declarations are `skipped` — SQLite's substring-search
+story is [FTS5 fulltext](/search/fulltext) via `searchable()` fields.
+
+GIN-family methods take exactly one field and don't support `unique`,
+`coveringFields`, or `where`; the query's `graph_id` / `kind` filters apply
+as residual conditions over the index's candidate rows.
 
 ### Combining B-tree and GIN
 
-For tables where you filter on both scalar fields (equality, range) and array fields (containment),
-use both index types:
+For kinds where you filter on both scalar fields (equality, range) and array or substring
+predicates, declare both index types:
 
-```sql
--- B-tree for scalar equality + ordering
-CREATE INDEX idx_person_email ON typegraph_nodes
-  (graph_id, kind, ((props #>> ARRAY['email'])))
-  WHERE deleted_at IS NULL;
-
--- GIN for array containment
-CREATE INDEX idx_person_props_gin ON typegraph_nodes
-  USING GIN (props)
-  WHERE graph_id = 'my_graph' AND kind = 'Person' AND deleted_at IS NULL;
+```typescript
+const personEmail = defineNodeIndex(Person, { fields: ["email"] });
+const personTags = defineNodeIndex(Person, { fields: ["tags"], method: "gin" });
 ```
 
 PostgreSQL's query planner can use both indexes together via a BitmapAnd scan when a query filters
@@ -359,7 +386,7 @@ const profiler = new QueryProfiler({
 
 - `defineNodeIndex` / `defineEdgeIndex` generate B-tree expression indexes for **scalar** properties
   (`string`, `number`, `boolean`, `Date`). For array containment queries, create
-  [GIN indexes](#gin-indexes-array-and-object-containment--postgresql-only) manually.
+  [GIN indexes](#gin-indexes-array-containment--postgresql-only) manually.
 - GIN indexes are PostgreSQL-only. SQLite has no equivalent for JSON containment acceleration.
 - Embedding fields live in per-`(graphId, kind, field)` vector tables (`tg_vec_*`) and are indexed
   through `store.materializeIndexes()` (pgvector builds an HNSW / IVFFlat ANN index; sqlite-vec and

--- a/apps/docs/src/content/docs/performance/indexes.md
+++ b/apps/docs/src/content/docs/performance/indexes.md
@@ -384,10 +384,14 @@ const profiler = new QueryProfiler({
 
 ## Limitations
 
-- `defineNodeIndex` / `defineEdgeIndex` generate B-tree expression indexes for **scalar** properties
-  (`string`, `number`, `boolean`, `Date`). For array containment queries, create
-  [GIN indexes](#gin-indexes-array-containment--postgresql-only) manually.
-- GIN indexes are PostgreSQL-only. SQLite has no equivalent for JSON containment acceleration.
+- The default `defineNodeIndex` / `defineEdgeIndex` method generates B-tree expression indexes for
+  **scalar** properties (`string`, `number`, `boolean`, `Date`). Array containment and substring
+  matching are served by [`method: "gin"`](#gin-indexes-array-containment--postgresql-only) and
+  [`method: "trigram"`](#trigram-indexes-substring-and-case-insensitive-matching--postgresql-only)
+  declarations.
+- GIN-family methods are PostgreSQL-only; `materializeIndexes()` reports them as `skipped` on
+  SQLite, which has no equivalent for JSON containment acceleration (substring search on SQLite is
+  served by FTS5 fulltext).
 - Embedding fields live in per-`(graphId, kind, field)` vector tables (`tg_vec_*`) and are indexed
   through `store.materializeIndexes()` (pgvector builds an HNSW / IVFFlat ANN index; sqlite-vec and
   libSQL report `skipped`/build their own). See [Semantic Search](/semantic-search).

--- a/packages/typegraph/src/indexes/ddl.ts
+++ b/packages/typegraph/src/indexes/ddl.ts
@@ -75,6 +75,9 @@ function generateTableIndexDDL(
   tableName: string,
   options: GenerateIndexDdlOptions,
 ): string {
+  if (index.method !== undefined) {
+    return generateGinFamilyIndexDDL(index, dialect, tableName, options);
+  }
   const ifNotExists = options.ifNotExists ?? true;
   const propsColumn = sql.raw('"props"');
   const systemColumn = (column: SystemColumnName): SQL =>
@@ -111,6 +114,47 @@ function generateTableIndexDDL(
   const whereClause = whereSql ? ` WHERE ${whereSql}` : "";
 
   return `CREATE ${unique}INDEX ${concurrent}${ifNotExistsSql}${quoteIdentifier(index.name)} ON ${quoteIdentifier(tableName)} (${keySql})${whereClause};`;
+}
+
+/**
+ * DDL for the GIN-family methods (`"gin"` / `"trigram"`) — a PostgreSQL
+ * expression GIN over the declaration's single field.
+ *
+ * The indexed expression is built from the SAME dialect extraction the
+ * query compiler emits for the field (`jsonExtract` → `"props" #> ARRAY[…]`
+ * for containment, `jsonExtractText` → `#>>` for text), because Postgres
+ * matches expression indexes structurally: `(props #> ARRAY['tags']) @> $1`
+ * and `(props #>> ARRAY['name']) ILIKE $1 ESCAPE '\'` both hit their GIN
+ * (verified against parameterized prepared statements). No scope prefix
+ * columns, uniqueness, or partial clause: a GIN indexes one expression, and
+ * the query's `graph_id` / `kind` equality filters apply as residual
+ * conditions over the candidate rows.
+ */
+function generateGinFamilyIndexDDL(
+  index: RelationalIndexDeclaration,
+  dialect: SqlDialect,
+  tableName: string,
+  options: GenerateIndexDdlOptions,
+): string {
+  if (dialect !== "postgres") {
+    throw new Error(
+      `Index "${index.name}" declares method "${index.method}", which ` +
+        "requires PostgreSQL. materializeIndexes() reports such " +
+        "declarations as skipped on SQLite instead of calling this.",
+    );
+  }
+  const adapter = getDialect(dialect);
+  const propsColumn = sql.raw('"props"');
+  const pointer = index.fields[0]!;
+  const expression =
+    index.method === "gin" ?
+      adapter.jsonExtract(propsColumn, pointer)
+    : adapter.jsonExtractText(propsColumn, pointer);
+  const operatorClass =
+    index.method === "gin" ? "jsonb_path_ops" : "gin_trgm_ops";
+  const concurrent = options.concurrent === true ? "CONCURRENTLY " : "";
+  const ifNotExistsSql = (options.ifNotExists ?? true) ? "IF NOT EXISTS " : "";
+  return `CREATE INDEX ${concurrent}${ifNotExistsSql}${quoteIdentifier(index.name)} ON ${quoteIdentifier(tableName)} USING GIN ((${sqlToInlineString(expression, dialect)}) ${operatorClass});`;
 }
 
 function quoteIdentifier(identifier: string): string {

--- a/packages/typegraph/src/indexes/define-index.ts
+++ b/packages/typegraph/src/indexes/define-index.ts
@@ -41,6 +41,7 @@ import {
   type NodeIndexConfig,
   type NodeIndexDeclaration,
   type NodeIndexWhereBuilder,
+  type RelationalIndexMethod,
   type SystemColumnName,
 } from "./types";
 
@@ -65,7 +66,9 @@ export function defineNodeIndex<N extends NodeType>(
       config.fields,
       schemaIntrospector,
       "fields",
-      { allowEmpty: false },
+      // GIN containment indexes exist precisely for array/object fields,
+      // which the btree guard otherwise rejects.
+      { allowEmpty: false, allowJsonFields: config.method === "gin" },
     );
 
   const { pointers: coveringFields, valueTypes: coveringFieldValueTypes } =
@@ -82,21 +85,31 @@ export function defineNodeIndex<N extends NodeType>(
     createNodeWhereBuilder(node, schemaIntrospector),
   );
 
+  const method = resolveAdvancedIndexMethod(config.method, {
+    fieldCount: fields.length,
+    fieldValueType: fieldValueTypes[0],
+    coveringFieldCount: coveringFields.length,
+    unique,
+    hasWhere: where !== undefined,
+  });
+
+  const defaultName = generateDefaultIndexName({
+    kind: "node",
+    kindName: node.kind,
+    unique,
+    scope,
+    direction: "none",
+    fields,
+    coveringFields,
+  });
   const name =
     config.name ??
-    generateDefaultIndexName({
-      kind: "node",
-      kindName: node.kind,
-      unique,
-      scope,
-      direction: "none",
-      fields,
-      coveringFields,
-    });
+    (method === undefined ? defaultName : `${defaultName}_${method}`);
 
   // `origin` is intentionally omitted: `"compile-time"` is the default
   // and is canonicalized by absence so the serialized form stays
-  // byte-identical for legacy graphs.
+  // byte-identical for legacy graphs. `method` follows the same rule
+  // (absence == "btree").
   return {
     entity: "node",
     kind: node.kind,
@@ -108,6 +121,7 @@ export function defineNodeIndex<N extends NodeType>(
     unique,
     scope,
     where,
+    ...(method === undefined ? {} : { method }),
   };
 }
 
@@ -130,7 +144,7 @@ export function defineEdgeIndex<E extends AnyEdgeType>(
       config.fields,
       schemaIntrospector,
       "fields",
-      { allowEmpty: false },
+      { allowEmpty: false, allowJsonFields: config.method === "gin" },
     );
 
   const { pointers: coveringFields, valueTypes: coveringFieldValueTypes } =
@@ -147,17 +161,26 @@ export function defineEdgeIndex<E extends AnyEdgeType>(
     createEdgeWhereBuilder(edge, schemaIntrospector),
   );
 
+  const method = resolveAdvancedIndexMethod(config.method, {
+    fieldCount: fields.length,
+    fieldValueType: fieldValueTypes[0],
+    coveringFieldCount: coveringFields.length,
+    unique,
+    hasWhere: where !== undefined,
+  });
+
+  const defaultName = generateDefaultIndexName({
+    kind: "edge",
+    kindName: edge.kind,
+    unique,
+    scope,
+    direction,
+    fields,
+    coveringFields,
+  });
   const name =
     config.name ??
-    generateDefaultIndexName({
-      kind: "edge",
-      kindName: edge.kind,
-      unique,
-      scope,
-      direction,
-      fields,
-      coveringFields,
-    });
+    (method === undefined ? defaultName : `${defaultName}_${method}`);
 
   return {
     entity: "edge",
@@ -171,7 +194,57 @@ export function defineEdgeIndex<E extends AnyEdgeType>(
     scope,
     direction,
     where,
+    ...(method === undefined ? {} : { method }),
   };
+}
+
+/**
+ * Validates and canonicalizes a declaration's index method. `"btree"` (or
+ * absent) canonicalizes to `undefined` so serialized declarations and
+ * materialization signatures from before `method` existed stay
+ * byte-identical. GIN-family methods index one expression and have no
+ * ordered key columns, so multi-field, covering, unique, and partial
+ * variants are rejected at declaration time rather than failing as
+ * confusing DDL errors at materialization time.
+ */
+function resolveAdvancedIndexMethod(
+  method: RelationalIndexMethod | undefined,
+  details: Readonly<{
+    fieldCount: number;
+    fieldValueType: ValueType | undefined;
+    coveringFieldCount: number;
+    unique: boolean;
+    hasWhere: boolean;
+  }>,
+): Exclude<RelationalIndexMethod, "btree"> | undefined {
+  const resolved = method ?? "btree";
+  if (resolved === "btree") return undefined;
+  if (details.fieldCount !== 1) {
+    throw new Error(
+      `Index method "${resolved}" requires exactly one field (a GIN indexes one expression), got ${details.fieldCount}`,
+    );
+  }
+  if (resolved === "gin" && details.fieldValueType === "string") {
+    throw new Error(
+      'Index method "gin" serves array/object containment; for substring or case-insensitive matching on a string field use method: "trigram"',
+    );
+  }
+  if (details.coveringFieldCount > 0) {
+    throw new Error(
+      `Index method "${resolved}" does not support coveringFields (GIN indexes cannot serve index-only scans over extra columns)`,
+    );
+  }
+  if (details.unique) {
+    throw new Error(
+      `Index method "${resolved}" does not support unique (GIN indexes cannot enforce uniqueness)`,
+    );
+  }
+  if (details.hasWhere) {
+    throw new Error(
+      `Index method "${resolved}" does not support a partial where clause`,
+    );
+  }
+  return resolved;
 }
 
 // ============================================================
@@ -502,16 +575,23 @@ function assertNoOverlap(
   }
 }
 
-function assertIndexableValueType(valueType: ValueType, context: string): void {
+function assertIndexableValueType(
+  valueType: ValueType,
+  context: string,
+  options: Readonly<{ allowJsonFields: boolean }>,
+): void {
   if (valueType === "embedding") {
     throw new Error(
       `Cannot create props index for embedding field (${context}); embedding() fields are indexed automatically in the vector strategy's per-(kind, field) storage`,
     );
   }
 
-  if (valueType === "array" || valueType === "object") {
+  if (
+    (valueType === "array" || valueType === "object") &&
+    !options.allowJsonFields
+  ) {
     throw new Error(
-      `Cannot create btree props index for ${valueType} field (${context}); use a GIN/JSON index strategy instead`,
+      `Cannot create btree props index for ${valueType} field (${context}); use method: "gin" instead`,
     );
   }
 }
@@ -526,7 +606,7 @@ function normalizeNodeIndexFieldsOrThrow<N extends NodeType>(
   inputs: readonly IndexFieldInput<z.infer<N["schema"]>>[],
   schemaIntrospector: ReturnType<typeof createSchemaIntrospector>,
   label: string,
-  options: Readonly<{ allowEmpty: boolean }>,
+  options: Readonly<{ allowEmpty: boolean; allowJsonFields?: boolean }>,
 ): NormalizedIndexFields {
   if (inputs.length === 0 && options.allowEmpty) {
     return { pointers: [], valueTypes: [] };
@@ -543,7 +623,9 @@ function normalizeNodeIndexFieldsOrThrow<N extends NodeType>(
       pointer,
       schemaIntrospector,
     );
-    assertIndexableValueType(info.valueType, `node "${node.kind}" ${pointer}`);
+    assertIndexableValueType(info.valueType, `node "${node.kind}" ${pointer}`, {
+      allowJsonFields: options.allowJsonFields ?? false,
+    });
     pointers.push(pointer);
     valueTypes.push(info.valueType);
   }
@@ -558,7 +640,7 @@ function normalizeEdgeIndexFieldsOrThrow<E extends AnyEdgeType>(
   inputs: readonly IndexFieldInput<z.infer<E["schema"]>>[],
   schemaIntrospector: ReturnType<typeof createSchemaIntrospector>,
   label: string,
-  options: Readonly<{ allowEmpty: boolean }>,
+  options: Readonly<{ allowEmpty: boolean; allowJsonFields?: boolean }>,
 ): NormalizedIndexFields {
   if (inputs.length === 0 && options.allowEmpty) {
     return { pointers: [], valueTypes: [] };
@@ -575,7 +657,9 @@ function normalizeEdgeIndexFieldsOrThrow<E extends AnyEdgeType>(
       pointer,
       schemaIntrospector,
     );
-    assertIndexableValueType(info.valueType, `edge "${edge.kind}" ${pointer}`);
+    assertIndexableValueType(info.valueType, `edge "${edge.kind}" ${pointer}`, {
+      allowJsonFields: options.allowJsonFields ?? false,
+    });
     pointers.push(pointer);
     valueTypes.push(info.valueType);
   }

--- a/packages/typegraph/src/indexes/define-index.ts
+++ b/packages/typegraph/src/indexes/define-index.ts
@@ -224,9 +224,24 @@ function resolveAdvancedIndexMethod(
       `Index method "${resolved}" requires exactly one field (a GIN indexes one expression), got ${details.fieldCount}`,
     );
   }
-  if (resolved === "gin" && details.fieldValueType === "string") {
+  // Enforce the field-type contract the methods advertise: gin serves the
+  // array containment predicates, trigram serves the string substring /
+  // case-insensitive predicates. Anything else (including unresolvable
+  // field types) would materialize an index no documented predicate can
+  // ever use, so it is rejected here rather than silently costing write
+  // amplification for nothing.
+  if (resolved === "gin" && details.fieldValueType !== "array") {
     throw new Error(
-      'Index method "gin" serves array/object containment; for substring or case-insensitive matching on a string field use method: "trigram"',
+      details.fieldValueType === "string" ?
+        'Index method "gin" serves array containment; for substring or case-insensitive matching on a string field use method: "trigram"'
+      : `Index method "gin" requires an array field (it serves the array containment predicates), got field type "${details.fieldValueType ?? "unresolved"}"`,
+    );
+  }
+  if (resolved === "trigram" && details.fieldValueType !== "string") {
+    throw new Error(
+      details.fieldValueType === "array" ?
+        'Index method "trigram" serves substring matching on string fields; for array containment use method: "gin"'
+      : `Index method "trigram" requires a string field (it serves substring and case-insensitive matches), got field type "${details.fieldValueType ?? "unresolved"}"`,
     );
   }
   if (details.coveringFieldCount > 0) {

--- a/packages/typegraph/src/indexes/drizzle.ts
+++ b/packages/typegraph/src/indexes/drizzle.ts
@@ -31,8 +31,12 @@ export function buildPostgresNodeIndexBuilders(
   table: NodeIndexTable,
   indexes: readonly IndexDeclaration[],
 ): readonly PgIndexBuilder[] {
+  // GIN-family declarations (method: "gin" / "trigram") are
+  // materialize-only — like pgvector ANN indexes, they are a pure
+  // materialization concern and never ride the Drizzle table extras.
   const nodeIndexes = indexes.filter(
-    (index): index is NodeIndexDeclaration => index.entity === "node",
+    (index): index is NodeIndexDeclaration =>
+      index.entity === "node" && index.method === undefined,
   );
 
   return nodeIndexes.map((index) => {
@@ -70,7 +74,8 @@ export function buildPostgresEdgeIndexBuilders(
   indexes: readonly IndexDeclaration[],
 ): readonly PgIndexBuilder[] {
   const edgeIndexes = indexes.filter(
-    (index): index is EdgeIndexDeclaration => index.entity === "edge",
+    (index): index is EdgeIndexDeclaration =>
+      index.entity === "edge" && index.method === undefined,
   );
 
   return edgeIndexes.map((index) => {
@@ -199,8 +204,12 @@ export function buildSqliteNodeIndexBuilders(
   table: NodeIndexTable,
   indexes: readonly IndexDeclaration[],
 ): readonly SqliteIndexBuilder[] {
+  // GIN-family declarations (method: "gin" / "trigram") are
+  // materialize-only — like pgvector ANN indexes, they are a pure
+  // materialization concern and never ride the Drizzle table extras.
   const nodeIndexes = indexes.filter(
-    (index): index is NodeIndexDeclaration => index.entity === "node",
+    (index): index is NodeIndexDeclaration =>
+      index.entity === "node" && index.method === undefined,
   );
 
   return nodeIndexes.map((index) => {
@@ -239,7 +248,8 @@ export function buildSqliteEdgeIndexBuilders(
   indexes: readonly IndexDeclaration[],
 ): readonly SqliteIndexBuilder[] {
   const edgeIndexes = indexes.filter(
-    (index): index is EdgeIndexDeclaration => index.entity === "edge",
+    (index): index is EdgeIndexDeclaration =>
+      index.entity === "edge" && index.method === undefined,
   );
 
   return edgeIndexes.map((index) => {

--- a/packages/typegraph/src/indexes/types.ts
+++ b/packages/typegraph/src/indexes/types.ts
@@ -34,6 +34,32 @@ export type IndexScope =
   | "none";
 
 // ============================================================
+// Index Access Method
+// ============================================================
+
+/**
+ * Index access method for relational (node/edge) index declarations.
+ *
+ * - `"btree"` — the default ordered index over the compiled extraction
+ *   expressions; serves equality/range predicates and `orderBy`.
+ * - `"gin"` — a PostgreSQL expression GIN over the field's jsonb value
+ *   (`jsonb_path_ops`); serves the array containment predicates
+ *   (`contains` / `containsAll` / `containsAny` on array fields), which a
+ *   btree can never serve. Skipped on SQLite.
+ * - `"trigram"` — a PostgreSQL expression GIN over the field's text value
+ *   (`gin_trgm_ops`, requires the `pg_trgm` extension); serves substring
+ *   and case-insensitive matches (`contains` / `startsWith` / `endsWith` /
+ *   `like` / `ilike` on string fields). Skipped on SQLite, whose substring
+ *   search story is FTS5 fulltext.
+ *
+ * `"gin"` and `"trigram"` take exactly one field and reject `unique`,
+ * `coveringFields`, and `where`; `scope` (and edge `direction`) prefix
+ * columns do not apply — the query's `graph_id` / `kind` equality filters
+ * are applied as residual conditions over the index's candidate rows.
+ */
+export type RelationalIndexMethod = "btree" | "gin" | "trigram";
+
+// ============================================================
 // Partial Index WHERE DSL (portable AST)
 // ============================================================
 
@@ -174,6 +200,8 @@ export type NodeIndexConfig<N extends NodeType> = Readonly<{
   name?: string | undefined;
   scope?: IndexScope | undefined;
   where?: IndexWhereInput<NodeIndexWhereBuilder<N>> | undefined;
+  /** Index access method. Default: `"btree"`. See {@link RelationalIndexMethod}. */
+  method?: RelationalIndexMethod | undefined;
 }>;
 
 export type EdgeIndexDirection = "out" | "in" | "none";
@@ -193,6 +221,8 @@ export type EdgeIndexConfig<E extends AnyEdgeType> = Readonly<{
    */
   direction?: EdgeIndexDirection | undefined;
   where?: IndexWhereInput<EdgeIndexWhereBuilder<E>> | undefined;
+  /** Index access method. Default: `"btree"`. See {@link RelationalIndexMethod}. */
+  method?: RelationalIndexMethod | undefined;
 }>;
 
 // ============================================================
@@ -246,6 +276,13 @@ type IndexDeclarationBase = Readonly<{
   unique: boolean;
   scope: IndexScope;
   where: IndexWhereExpression | undefined;
+  /**
+   * Index access method. Absent means `"btree"` — canonicalized by
+   * absence (like `origin`) so serialized declarations and
+   * materialization signatures from before this field existed stay
+   * byte-identical.
+   */
+  method?: Exclude<RelationalIndexMethod, "btree">;
 }>;
 
 export type NodeIndexDeclaration = IndexDeclarationBase &

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -223,6 +223,8 @@ function serializeNodeIndexDeclaration(
     unique: declaration.unique,
     scope: declaration.scope,
     where: declaration.where,
+    // `method: "btree"` is canonicalized by absence, like `origin` below.
+    ...(declaration.method === undefined ? {} : { method: declaration.method }),
     // `origin: "compile-time"` is the default and is omitted from the
     // canonical form (absence == compile-time). Only `runtime` is
     // emitted explicitly so the restart loader can route the declaration
@@ -246,6 +248,8 @@ function serializeEdgeIndexDeclaration(
     unique: declaration.unique,
     scope: declaration.scope,
     where: declaration.where,
+    // `method: "btree"` is canonicalized by absence, like `origin`.
+    ...(declaration.method === undefined ? {} : { method: declaration.method }),
     ...(declaration.origin === "runtime" ? { origin: "runtime" as const } : {}),
   };
 }

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -347,6 +347,23 @@ async function materializeRelationalIndex(
   schemaVersion: number,
   existingByStatusKey: ReadonlyMap<string, IndexMaterializationRow>,
 ): Promise<MaterializeIndexesEntry> {
+  // GIN-family methods are PostgreSQL expression GINs; SQLite has no
+  // equivalent (its substring-search story is FTS5 fulltext), so the
+  // declaration is recognized and intentionally not acted on — same
+  // contract as vector indexes on engines without vector support.
+  if (declaration.method !== undefined && dialect !== "postgres") {
+    return {
+      indexName: declaration.name,
+      entity: declaration.entity,
+      kind: declaration.kind,
+      status: "skipped",
+      reason:
+        `Index method "${declaration.method}" requires PostgreSQL ` +
+        `(expression GIN${declaration.method === "trigram" ? " + pg_trgm" : ""}); ` +
+        "SQLite serves substring search via FTS5 fulltext instead.",
+    };
+  }
+
   const ddl = generateIndexDDL(declaration, dialect, ddlOptions);
   const targetTable =
     declaration.entity === "node" ?
@@ -361,7 +378,15 @@ async function materializeRelationalIndex(
     statusKey: declaration.name,
     signature,
     driftLabel: "Index",
-    run: () => backend.executeDdl!(ddl),
+    run: async () => {
+      if (declaration.method === "trigram") {
+        // gin_trgm_ops lives in the pg_trgm extension (contrib — present
+        // on stock Postgres and the hosted variants). Idempotent, and a
+        // permission failure surfaces as this index's `failed` entry.
+        await backend.executeDdl!("CREATE EXTENSION IF NOT EXISTS pg_trgm;");
+      }
+      await backend.executeDdl!(ddl);
+    },
     existingByStatusKey,
   });
 }

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -1423,6 +1423,17 @@ function resolveNodeIndex<G extends GraphDef>(
     throw new NodeIndexNotFoundError(indexName, kind);
   }
 
+  // GIN-family indexes serve containment / substring predicates, not the
+  // equality probes bulkFindByIndex compiles — targeting one here would
+  // silently probe with the wrong extraction semantics.
+  if (declaration.method !== undefined) {
+    throw new ConfigurationError(
+      `bulkFindByIndex cannot probe index "${indexName}" (method ` +
+        `"${declaration.method}"): only btree indexes serve equality probes.`,
+      { indexName, kind, method: declaration.method },
+    );
+  }
+
   return declaration;
 }
 

--- a/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
+++ b/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
@@ -234,5 +234,101 @@ describe("Postgres store.materializeIndexes — status table", () => {
   });
 });
 
+describe("Postgres store.materializeIndexes — GIN-family methods", () => {
+  const Article = defineNode("Article", {
+    schema: z.object({
+      title: z.string(),
+      tags: z.array(z.string()),
+    }),
+  });
+
+  function buildGinGraph() {
+    return defineGraph({
+      id: "pg_gin_method_test",
+      nodes: { Article: { type: Article } },
+      edges: {},
+      indexes: [
+        defineNodeIndex(Article, {
+          fields: ["tags"],
+          method: "gin",
+          name: "idx_tg_article_tags_gin",
+        }),
+        defineNodeIndex(Article, {
+          fields: ["title"],
+          method: "trigram",
+          name: "idx_tg_article_title_trgm",
+        }),
+      ],
+    });
+  }
+
+  it("creates gin and trigram expression indexes and is idempotent", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const backend = createPostgresBackend(drizzle(pool));
+    const [store] = await createStoreWithSchema(buildGinGraph(), backend);
+
+    const first = await store.materializeIndexes();
+    expect(first.results.map((entry) => entry.status).toSorted()).toEqual([
+      "created",
+      "created",
+    ]);
+
+    const second = await store.materializeIndexes();
+    expect(
+      second.results.every((entry) => entry.status === "alreadyMaterialized"),
+    ).toBe(true);
+
+    // Physically present with the expected access method and the pg_trgm
+    // extension installed by the trigram materialization.
+    const indexRows = await pool.query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes WHERE indexname IN ('idx_tg_article_tags_gin', 'idx_tg_article_title_trgm')`,
+    );
+    expect(indexRows.rows).toHaveLength(2);
+    for (const row of indexRows.rows) {
+      expect(row.indexdef).toContain("USING gin");
+    }
+    const extension = await pool.query(
+      `SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'`,
+    );
+    expect(extension.rows).toHaveLength(1);
+  });
+
+  it("keeps containment and substring queries correct with the indexes in place", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const backend = createPostgresBackend(drizzle(pool));
+    const [store] = await createStoreWithSchema(buildGinGraph(), backend);
+    await store.materializeIndexes();
+
+    await store.nodes.Article.create({
+      title: "Postgres indexing deep dive",
+      tags: ["databases", "postgres"],
+    });
+    await store.nodes.Article.create({
+      title: "Cooking with cast iron",
+      tags: ["cooking"],
+    });
+
+    const tagged = await store
+      .query()
+      .from("Article", "a")
+      .whereNode("a", (article) => article.tags.contains("postgres"))
+      .select(({ a }) => ({ title: a.title }))
+      .execute();
+    expect(tagged.map((row) => row.title)).toEqual([
+      "Postgres indexing deep dive",
+    ]);
+
+    const substring = await store
+      .query()
+      .from("Article", "a")
+      .whereNode("a", (article) => article.title.contains("INDEXING"))
+      .select(({ a }) => ({ title: a.title }))
+      .execute();
+    expect(substring.map((row) => row.title)).toEqual([
+      "Postgres indexing deep dive",
+    ]);
+  });
+});
+
 // Used to keep the import linter happy when the suite skips entirely.
 void generatePostgresDDL;

--- a/packages/typegraph/tests/index-method-gin.test.ts
+++ b/packages/typegraph/tests/index-method-gin.test.ts
@@ -1,0 +1,211 @@
+/**
+ * GIN-family index methods (`method: "gin" | "trigram"`).
+ *
+ * These are PostgreSQL expression GINs serving the predicate shapes a
+ * btree can never serve — array containment (`jsonb_path_ops`) and
+ * substring / case-insensitive matches (`gin_trgm_ops`). This file covers
+ * the engine-independent surface: declaration validation and
+ * canonicalization, generated DDL (which must reuse the dialect's own
+ * extraction expressions so Postgres matches them structurally against
+ * compiled predicates), serialization, the SQLite `skipped` contract, and
+ * the bulkFindByIndex guard. Postgres materialization and behavior live
+ * in `tests/backends/postgres/materialize-indexes.test.ts`.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStoreWithSchema, defineGraph, defineNode } from "../src";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { ConfigurationError } from "../src/errors";
+import { defineNodeIndex } from "../src/indexes";
+import { generateIndexDDL } from "../src/indexes/ddl";
+import { serializeSchema } from "../src/schema/serializer";
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    title: z.string(),
+    tags: z.array(z.string()),
+  }),
+});
+
+describe("defineNodeIndex method validation", () => {
+  it("canonicalizes btree (explicit or default) to an absent method", () => {
+    const explicit = defineNodeIndex(Document, {
+      fields: ["title"],
+      method: "btree",
+    });
+    const implicit = defineNodeIndex(Document, { fields: ["title"] });
+
+    expect(explicit.method).toBeUndefined();
+    expect(implicit.method).toBeUndefined();
+    expect(Object.keys(explicit)).not.toContain("method");
+  });
+
+  it("carries gin/trigram onto the declaration with a method name suffix", () => {
+    const gin = defineNodeIndex(Document, { fields: ["tags"], method: "gin" });
+    const trigram = defineNodeIndex(Document, {
+      fields: ["title"],
+      method: "trigram",
+    });
+
+    expect(gin.method).toBe("gin");
+    expect(gin.name.endsWith("_gin")).toBe(true);
+    expect(trigram.method).toBe("trigram");
+    expect(trigram.name.endsWith("_trigram")).toBe(true);
+  });
+
+  it("rejects multi-field, covering, unique, and partial variants", () => {
+    expect(() =>
+      defineNodeIndex(Document, { fields: ["title", "tags"], method: "gin" }),
+    ).toThrow(/exactly one field/);
+    expect(() =>
+      defineNodeIndex(Document, {
+        fields: ["tags"],
+        coveringFields: ["title"],
+        method: "gin",
+      }),
+    ).toThrow(/coveringFields/);
+    expect(() =>
+      defineNodeIndex(Document, {
+        fields: ["title"],
+        unique: true,
+        method: "trigram",
+      }),
+    ).toThrow(/unique/);
+    expect(() =>
+      defineNodeIndex(Document, {
+        fields: ["title"],
+        method: "trigram",
+        where: (row) => row.title.isNotNull(),
+      }),
+    ).toThrow(/where/);
+  });
+});
+
+describe("GIN-family index DDL", () => {
+  const gin = defineNodeIndex(Document, {
+    fields: ["tags"],
+    method: "gin",
+    name: "doc_tags_gin",
+  });
+  const trigram = defineNodeIndex(Document, {
+    fields: ["title"],
+    method: "trigram",
+    name: "doc_title_trgm",
+  });
+
+  it("emits a jsonb_path_ops expression GIN aligned with dialect.jsonExtract", () => {
+    expect(generateIndexDDL(gin, "postgres")).toBe(
+      `CREATE INDEX IF NOT EXISTS "doc_tags_gin" ON "typegraph_nodes" USING GIN (("props" #> ARRAY['tags']) jsonb_path_ops);`,
+    );
+  });
+
+  it("emits a gin_trgm_ops expression GIN aligned with dialect.jsonExtractText", () => {
+    expect(generateIndexDDL(trigram, "postgres")).toBe(
+      `CREATE INDEX IF NOT EXISTS "doc_title_trgm" ON "typegraph_nodes" USING GIN (("props" #>> ARRAY['title']) gin_trgm_ops);`,
+    );
+  });
+
+  it("supports CONCURRENTLY for the materialize path", () => {
+    expect(generateIndexDDL(gin, "postgres", { concurrent: true })).toContain(
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS",
+    );
+  });
+
+  it("refuses to generate SQLite DDL", () => {
+    expect(() => generateIndexDDL(gin, "sqlite")).toThrow(
+      /requires PostgreSQL/,
+    );
+  });
+});
+
+describe("serialization", () => {
+  it("emits method only when present", () => {
+    const graph = defineGraph({
+      id: "gin-serialize",
+      nodes: { Doc: { type: Document } },
+      edges: {},
+      indexes: [
+        defineNodeIndex(Document, { fields: ["title"] }),
+        defineNodeIndex(Document, { fields: ["tags"], method: "gin" }),
+      ],
+    });
+
+    const serialized = serializeSchema(graph, 1);
+    const indexes = serialized.indexes ?? [];
+    const byMethod = new Map(
+      indexes.map((declaration) => [
+        "method" in declaration ? declaration.method : undefined,
+        declaration,
+      ]),
+    );
+
+    expect(byMethod.has("gin")).toBe(true);
+    // The btree declaration must not carry a `method` key at all, so
+    // pre-existing stored schema docs and materialization signatures stay
+    // byte-identical.
+    const btree = indexes.find((declaration) => !("method" in declaration));
+    expect(btree).toBeDefined();
+    expect(Object.keys(btree!)).not.toContain("method");
+  });
+});
+
+describe("SQLite behavior", () => {
+  it("materializes gin/trigram declarations as skipped with a reason", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const graph = defineGraph({
+        id: "gin-sqlite-skip",
+        nodes: { Doc: { type: Document } },
+        edges: {},
+        indexes: [
+          defineNodeIndex(Document, { fields: ["tags"], method: "gin" }),
+          defineNodeIndex(Document, { fields: ["title"], method: "trigram" }),
+          defineNodeIndex(Document, { fields: ["title"] }),
+        ],
+      });
+      const [store] = await createStoreWithSchema(graph, backend);
+
+      const result = await store.materializeIndexes();
+      const byStatus = new Map(
+        result.results.map((entry) => [entry.indexName, entry]),
+      );
+
+      const statuses = result.results.map((entry) => entry.status);
+      expect(statuses.filter((status) => status === "skipped")).toHaveLength(2);
+      expect(statuses.filter((status) => status === "created")).toHaveLength(1);
+      const skipped = [...byStatus.values()].find(
+        (entry) => entry.status === "skipped",
+      );
+      expect(skipped?.reason).toMatch(/requires PostgreSQL/);
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("rejects bulkFindByIndex probes against a gin index", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const ginIndex = defineNodeIndex(Document, {
+        fields: ["tags"],
+        method: "gin",
+        name: "doc_tags_gin_probe",
+      });
+      const graph = defineGraph({
+        id: "gin-bulk-probe",
+        nodes: { Doc: { type: Document } },
+        edges: {},
+        indexes: [ginIndex],
+      });
+      const [store] = await createStoreWithSchema(graph, backend);
+
+      await expect(
+        store.nodes.Doc.bulkFindByIndex("doc_tags_gin_probe", [
+          { tags: ["x"] },
+        ] as never),
+      ).rejects.toThrow(ConfigurationError);
+    } finally {
+      await backend.close();
+    }
+  });
+});

--- a/packages/typegraph/tests/index-method-gin.test.ts
+++ b/packages/typegraph/tests/index-method-gin.test.ts
@@ -25,6 +25,8 @@ const Document = defineNode("Doc", {
   schema: z.object({
     title: z.string(),
     tags: z.array(z.string()),
+    views: z.number(),
+    attributes: z.object({ source: z.string() }),
   }),
 });
 
@@ -52,6 +54,24 @@ describe("defineNodeIndex method validation", () => {
     expect(gin.name.endsWith("_gin")).toBe(true);
     expect(trigram.method).toBe("trigram");
     expect(trigram.name.endsWith("_trigram")).toBe(true);
+  });
+
+  it("enforces the field-type contract each method advertises", () => {
+    // gin serves array containment; trigram serves string substring
+    // matching. Any other field type would materialize an index no
+    // documented predicate can use.
+    expect(() =>
+      defineNodeIndex(Document, { fields: ["title"], method: "gin" }),
+    ).toThrow(/use method: "trigram"/);
+    expect(() =>
+      defineNodeIndex(Document, { fields: ["attributes"], method: "gin" }),
+    ).toThrow(/requires an array field/);
+    expect(() =>
+      defineNodeIndex(Document, { fields: ["views"], method: "trigram" }),
+    ).toThrow(/requires a string field/);
+    expect(() =>
+      defineNodeIndex(Document, { fields: ["tags"], method: "trigram" }),
+    ).toThrow(/use method: "gin"/);
   });
 
   it("rejects multi-field, covering, unique, and partial variants", () => {


### PR DESCRIPTION
Fourth slice of the performance audit, the property-filter indexing story. The declared-index seam (`defineIndex` + `materializeIndexes`) already serves equality/range predicates via btree expression indexes, but two predicate families could never use an index: array containment and substring/case-insensitive matching. Both now have a declarative answer:

```ts
defineNodeIndex(Person, { fields: ["tags"], method: "gin" });     // contains/containsAll/containsAny
defineNodeIndex(Person, { fields: ["name"], method: "trigram" }); // contains/startsWith/endsWith/like/ilike
```

- **`gin`** → `CREATE INDEX … USING GIN (("props" #> ARRAY['tags']) jsonb_path_ops)`
- **`trigram`** → `CREATE INDEX … USING GIN (("props" #>> ARRAY['name']) gin_trgm_ops)`, with `materializeIndexes()` running `CREATE EXTENSION IF NOT EXISTS pg_trgm` idempotently first (contrib; available on stock PG and hosted variants)

The DDL reuses the dialect's own extraction expressions, because Postgres matches expression indexes structurally. **Spike-validated before implementation** against TypeGraph's exact compiled predicate SQL under parameterized prepared statements (50k rows): both shapes produce Bitmap Index Scans, including `ILIKE $1 ESCAPE '\'`.

### Design decisions

- **Materialize-only, PostgreSQL-only** — same contract as vector ANN indexes: never in the Drizzle table extras, and `materializeIndexes()` reports `skipped` with a reason on SQLite (whose substring story is FTS5 fulltext). This follows the parity rule: genuine engine gaps are declared, not hidden.
- **`method: "btree"` canonicalizes to absence** (like `origin`), so stored schema documents and materialization signatures from before this field existed stay byte-identical.
- GIN-family declarations take exactly one field and reject `unique`/`coveringFields`/`where` at declaration time; `method: "gin"` on a string field points you to `trigram` and vice-versa via the pre-existing array-field guard (whose error message anticipated this feature).
- `bulkFindByIndex` rejects GIN-family indexes — it compiles equality probes, which only btree declarations serve.

### Docs bug found and fixed

`performance/indexes.md` recommended a whole-column `CREATE INDEX … USING GIN (props)` for array filtering. Verified empirically: Postgres **never** uses that index for TypeGraph's per-field `(props #> ARRAY[…]) @> $1` expressions (seq scan) — the guidance created dead indexes. The section now shows the declarative method with a caution explaining the structural-matching pitfall.

## Testing

- `tests/index-method-gin.test.ts` (10): declaration validation and canonicalization, exact DDL snapshots, CONCURRENTLY support, SQLite DDL refusal, serialization emits `method` only when present, SQLite `skipped` status with reason, `bulkFindByIndex` guard.
- `tests/backends/postgres/materialize-indexes.test.ts` (+2): gin+trigram created and idempotent with `pg_trgm` installed and `USING gin` visible in `pg_indexes`; containment and case-insensitive substring queries behaviorally correct through the indexed path.
