### PR TITLE
perf: fix PG subgraph nested-loop pathology via dialect CTE membership

### DIFF
--- a/.changeset/pg-subgraph-membership.md
+++ b/.changeset/pg-subgraph-membership.md
@@ -1,0 +1,17 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Subgraph extraction is ~4× faster on PostgreSQL. The final node/edge
+fetches filtered ids with `IN (SELECT id FROM included_ids)`; PostgreSQL
+pulls that form up into a join whose recursive-CTE row estimate (~10 rows
+for a single-row seed) drives the planner into a nested-loop join filter —
+measured at ~10 million discarded rows on the depth-3 benchmark shape. CTE
+membership now goes through a dialect seam: PostgreSQL emits
+`= ANY(ARRAY(subquery))`, which collapses the CTE once via an InitPlan and
+is hash-probed and index-condition eligible; SQLite keeps `IN (subquery)`,
+which it already evaluates optimally.
+
+Measured (benchmark suite, 1,200 users / depth-3 stress shape): PostgreSQL
+subgraph full hydration 322ms → 82ms, depth-2 11.5ms → 7.1ms; SQLite
+unchanged.

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -219,6 +219,15 @@ export const postgresDialect: DialectAdapter = {
     return sql`NOW()`;
   },
 
+  subqueryMembership(column, subquery) {
+    // ARRAY(subquery) collapses the CTE once via InitPlan; = ANY(array) is
+    // hash-probed (PG 14+) and index-condition eligible. The plain
+    // IN (subquery) form gets pulled up into a join whose recursive-CTE
+    // row estimate drives the planner into a nested-loop join FILTER —
+    // see the DialectAdapter docs for the measured pathology.
+    return sql`${column} = ANY(ARRAY(${subquery}))`;
+  },
+
   // ============================================================
   // Value Binding & Literals
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -229,6 +229,11 @@ export const sqliteDialect: DialectAdapter = {
     return sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`;
   },
 
+  subqueryMembership(column, subquery) {
+    // SQLite evaluates IN (subquery) with a transient index — optimal as-is.
+    return sql`${column} IN (${subquery})`;
+  },
+
   // ============================================================
   // Value Binding & Literals
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -322,6 +322,24 @@ export interface DialectAdapter {
    */
   currentTimestamp(): SQL;
 
+  /**
+   * Membership test of `column` against a same-statement subquery (a CTE
+   * scan in practice, e.g. the subgraph extractor's `included_ids`).
+   *
+   * SQLite: `column IN (subquery)` — evaluated as a hashed/indexed
+   * subquery, already optimal.
+   *
+   * PostgreSQL: `column = ANY(ARRAY(subquery))` — the subquery is
+   * collapsed to an array by an InitPlan once, and the scalar-array
+   * comparison is hash-probed (PG 14+) and index-condition eligible.
+   * The naive `IN (subquery)` form is pulled up into a join against the
+   * CTE, whose recursive-CTE row estimate (~10 rows for a single-row
+   * seed) drives the planner into a nested-loop join FILTER — measured
+   * at 10M discarded rows / 383ms on the depth-3 subgraph stress bench
+   * versus ~15ms for this form.
+   */
+  subqueryMembership(column: SQL, subquery: SQL): SQL;
+
   // ============================================================
   // Value Binding & Literals
   // ============================================================

--- a/packages/typegraph/src/store/subgraph.ts
+++ b/packages/typegraph/src/store/subgraph.ts
@@ -750,7 +750,7 @@ async function fetchSubgraphNodes(
     ...buildProjectedPropertyColumns("n", projectionPlan, ctx.dialect),
   ];
 
-  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.nodesTable} n WHERE n.graph_id = ${ctx.graphId} AND ${nodeTemporalFilter} AND n.id IN (SELECT id FROM included_ids)`;
+  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.nodesTable} n WHERE n.graph_id = ${ctx.graphId} AND ${nodeTemporalFilter} AND ${ctx.dialect.subqueryMembership(sql.raw("n.id"), sql.raw("SELECT id FROM included_ids"))}`;
 
   return ctx.backend.execute<SubgraphNodeFetchRow>(
     asCompiledRowsSql(query),
@@ -789,7 +789,7 @@ async function fetchSubgraphEdges(
     ...buildProjectedPropertyColumns("e", projectionPlan, ctx.dialect),
   ];
 
-  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND ${edgeTemporalFilter} AND e.from_id IN (SELECT id FROM included_ids) AND e.to_id IN (SELECT id FROM included_ids)`;
+  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND ${edgeTemporalFilter} AND ${ctx.dialect.subqueryMembership(sql.raw("e.from_id"), sql.raw("SELECT id FROM included_ids"))} AND ${ctx.dialect.subqueryMembership(sql.raw("e.to_id"), sql.raw("SELECT id FROM included_ids"))}`;
 
   return ctx.backend.execute<SubgraphEdgeFetchRow>(
     asCompiledRowsSql(query),

--- a/packages/typegraph/tests/subgraph-membership-dialect.test.ts
+++ b/packages/typegraph/tests/subgraph-membership-dialect.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Dialect-mediated CTE membership (`subqueryMembership`).
+ *
+ * The subgraph extractor's final fetches filter node/edge ids against the
+ * `included_ids` CTE. On SQLite, `IN (subquery)` is evaluated with a
+ * transient index and is optimal. On PostgreSQL, the same form is pulled
+ * up into a join whose recursive-CTE row estimate (~10 rows for a
+ * single-row seed) drives the planner into a nested-loop join FILTER —
+ * measured at ~10M discarded rows / 383ms on the depth-3 subgraph stress
+ * bench. `= ANY(ARRAY(subquery))` collapses the CTE once via InitPlan and
+ * is hash-probed and index-condition eligible (~15ms for the same fetch).
+ *
+ * These tests pin each dialect's emitted form and that the subgraph
+ * fetches actually route through it; cross-backend subgraph semantics are
+ * covered by the shared integration suite.
+ */
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStore, defineEdge, defineGraph, defineNode } from "../src";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import type { GraphBackend } from "../src/backend/types";
+import { getDialect } from "../src/query/dialect";
+
+describe("subqueryMembership dialect forms", () => {
+  const column = sql.raw("e.to_id");
+  const subquery = sql.raw("SELECT id FROM included_ids");
+
+  it("emits IN (subquery) on SQLite", () => {
+    const rendered = new SQLiteSyncDialect().sqlToQuery(
+      getDialect("sqlite").subqueryMembership(column, subquery),
+    );
+    expect(rendered.sql).toBe("e.to_id IN (SELECT id FROM included_ids)");
+  });
+
+  it("emits = ANY(ARRAY(subquery)) on PostgreSQL", () => {
+    const rendered = new PgDialect().sqlToQuery(
+      getDialect("postgres").subqueryMembership(column, subquery),
+    );
+    expect(rendered.sql).toBe(
+      "e.to_id = ANY(ARRAY(SELECT id FROM included_ids))",
+    );
+  });
+});
+
+describe("subgraph fetches route membership through the dialect", () => {
+  const Person = defineNode("Person", {
+    schema: z.object({ name: z.string() }),
+  });
+  const knows = defineEdge("knows");
+  const graph = defineGraph({
+    id: "subgraph-membership",
+    nodes: { Person: { type: Person } },
+    edges: { knows: { type: knows, from: [Person], to: [Person] } },
+  });
+
+  it("captures the membership form in both subgraph statements (SQLite)", async () => {
+    const { backend: raw } = createLocalSqliteBackend();
+    try {
+      const captured: string[] = [];
+      const backend: GraphBackend = {
+        ...raw,
+        async execute(query) {
+          const compiled = raw.compileSql?.(query);
+          if (compiled) captured.push(compiled.sql);
+          return raw.execute(query);
+        },
+      };
+      const store = createStore(graph, backend);
+
+      const alice = await store.nodes.Person.create({ name: "alice" });
+      const bob = await store.nodes.Person.create({ name: "bob" });
+      await store.edges.knows.create(alice, bob);
+
+      captured.length = 0;
+      const result = await store.subgraph(alice.id, {
+        edges: ["knows"],
+        maxDepth: 2,
+      });
+      expect(result.root?.id).toBe(alice.id);
+
+      const membershipStatements = captured.filter((text) =>
+        text.includes("included_ids"),
+      );
+      expect(membershipStatements.length).toBeGreaterThanOrEqual(2);
+      for (const text of membershipStatements) {
+        expect(text).toContain("IN (SELECT id FROM included_ids)");
+      }
+    } finally {
+      await raw.close();
+    }
+  });
+});


### PR DESCRIPTION
Resolves performance audit findings of two anomalies sitting in committed benchmark history.

### PG depth-3 subgraph at ~317ms vs ~20ms SQLite — root-caused and fixed (~4×)

Reproduced (342ms locally), captured the executed SQL, and EXPLAIN ANALYZE showed the pathology: the subgraph's final edge fetch filters `from_id`/`to_id` with `IN (SELECT id FROM included_ids)`, and PostgreSQL pulls that into a join whose recursive-CTE row estimate (~10 rows for a single-row seed) picks a **nested-loop join filter — 10,043,027 rows removed by filter**. The recursive traversal itself is fast; all the time went to the membership check.

Rewrites tested in psql before touching code: explicit double-joins and the `OFFSET 0` hashed-subplan fence both still nested-looped; **`= ANY(ARRAY(subquery))`** flips the plan to an index scan with the array as an index condition (the ARRAY collapses the CTE once via InitPlan; scalar-array ops are hash-probed since PG 14).

The fix is a new `DialectAdapter.subqueryMembership` member — a token-level dialect seam per the parity rules, enforced on every dialect by the type checker. PostgreSQL emits the `ANY(ARRAY(…))` form; SQLite keeps `IN (subquery)`, which it already evaluates optimally.

**Measured** (bench suite, 1,200 users / 19k edges):

| shape | before | after |
| --- | --- | --- |
| PG subgraph depth-3 stress (full hydration) | 322ms | **82ms** |
| PG subgraph depth-2 | 11.5ms | **7.1ms** |
| SQLite depth-3 stress | 22.7ms | unchanged |

The residual PG-vs-SQLite gap (~4×) has a known cause noted in the audit doc for follow-up: the node and edge fetches each re-run the recursive traversal CTE.

### SQLite aggregate ~2ms → ~12ms mid-history — explained, not a regression (no code change)

Git archaeology: commit `1e9ae18c` ("Aggregate honesty fix") removed a silent `.limit(20)` from the aggregate bench that LIMIT-pushdown had been rewriting into a 20-group GROUP BY while the label claimed 1,200 groups. The history jump is the bench starting to measure 60× more work; the current ~8–12ms is the honest 1,200-group number vs Neo4j's 5.2ms.

## Testing

- `tests/subgraph-membership-dialect.test.ts`: pins each dialect's emitted membership form, and a SQL-capture test proving the subgraph fetches route through the seam (SQLite form unchanged).
