### PR TITLE
perf: align degree() direction filters with the default edge indexes

### DIFF
--- a/.changeset/degree-index-alignment.md
+++ b/.changeset/degree-index-alignment.md
@@ -1,0 +1,20 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+`degree()` direction filters are now shaped for the default edge indexes.
+The filters previously compiled to bare `from_id = ?` / `to_id = ?`, which
+neither composite edge index can seek (both lead with the endpoint kind
+column) — so degree counts relied on engine-specific rescue: SQLite
+skip-scan (only with fresh statistics) or PostgreSQL 18's new btree skip
+scan, and degenerated to partition scans everywhere else (PostgreSQL ≤ 17,
+SQLite with stale statistics).
+
+The filters now enumerate the endpoint kinds the graph declaration permits
+for the counted edge kinds, expanded through the subClassOf closure — the
+same set edge writes validate against — making `edges_from_idx` /
+`edges_to_idx` structurally seekable on every engine and version.
+Measured on PostgreSQL 18 (where the old form was already skip-scan
+rescued): 0.30ms → 0.06ms per call; on older PostgreSQL the old form
+could not use these indexes at all. An edge set that declares no endpoint
+kinds on the required side now returns 0 without a round trip.

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -1,4 +1,5 @@
 import { type GraphBackend } from "../../backend/types";
+import { type GraphDef } from "../../core/define-graph";
 import {
   assertValidRecordedInstant,
   type RecordedInstant,
@@ -17,6 +18,7 @@ import {
   type TemporalFilterOptions,
 } from "../../query/compiler/temporal";
 import { type DialectAdapter } from "../../query/dialect/types";
+import { type KindRegistry } from "../../registry/kind-registry";
 import type { AlgorithmCyclePolicy, TraversalDirection } from "./types";
 
 export const DEFAULT_ALGORITHM_MAX_HOPS = 10;
@@ -24,6 +26,10 @@ export const DEFAULT_NEIGHBOR_DEPTH = 1;
 
 export type AlgorithmContext = Readonly<{
   graphId: string;
+  /** Graph definition — degree() enumerates declared edge endpoint kinds. */
+  graph: GraphDef;
+  /** Kind registry — expands declared endpoint kinds through subClassOf. */
+  registry: KindRegistry;
   backend: GraphBackend;
   dialect: DialectAdapter;
   schema: SqlSchema;

--- a/packages/typegraph/src/store/algorithms/degree.ts
+++ b/packages/typegraph/src/store/algorithms/degree.ts
@@ -22,11 +22,22 @@ export async function executeDegree(
   options: InternalDegreeOptions = {},
 ): Promise<number> {
   const direction = options.direction ?? "both";
+  const edgeKinds = options.edges ?? Object.keys(ctx.graph.edges);
+
+  const directionFilter = compileDirectionFilter(
+    ctx,
+    direction,
+    nodeId,
+    edgeKinds,
+  );
+  // No declared endpoint kinds for the counted edge set means no edge can
+  // match — provably zero without a round trip.
+  if (directionFilter === undefined) return 0;
 
   const whereClauses: SQL[] = [
     sql`graph_id = ${ctx.graphId}`,
     resolveTemporalFilter(ctx, options),
-    compileDirectionFilter(direction, nodeId),
+    directionFilter,
   ];
   if (options.edges !== undefined) {
     whereClauses.push(compileKindFilter(sql.raw("kind"), options.edges));
@@ -46,19 +57,69 @@ export async function executeDegree(
   return Number(rows[0]?.count ?? 0);
 }
 
+/**
+ * Endpoint kinds the graph declaration permits on one side of the counted
+ * edge kinds, expanded through the subClassOf closure (a stored
+ * `from_kind` / `to_kind` may be any subclass of a declared endpoint).
+ * Edge writes validate endpoints against exactly this set, so enumerating
+ * it here is complete.
+ */
+function collectEndpointKinds(
+  ctx: AlgorithmContext,
+  edgeKinds: readonly string[],
+  side: "from" | "to",
+): readonly string[] {
+  const kinds = new Set<string>();
+  for (const edgeKind of edgeKinds) {
+    const registration = ctx.graph.edges[edgeKind];
+    if (registration === undefined) continue;
+    for (const endpoint of registration[side]) {
+      for (const expanded of ctx.registry.expandSubClasses(endpoint.kind)) {
+        kinds.add(expanded);
+      }
+    }
+  }
+  return [...kinds];
+}
+
+/**
+ * Direction filter shaped for the default edge indexes: the endpoint-kind
+ * equality comes first so `edges_from_idx (graph_id, from_kind, from_id, …)`
+ * / `edges_to_idx (graph_id, to_kind, to_id, …)` can seek — a bare
+ * `from_id = ?` scans the whole edge partition because both indexes lead
+ * with the kind column. Returns `undefined` when the counted edge set
+ * declares no endpoint on the required side (provably zero matches).
+ */
 function compileDirectionFilter(
+  ctx: AlgorithmContext,
   direction: TraversalDirection,
   nodeId: string,
-): ReturnType<typeof sql> {
+  edgeKinds: readonly string[],
+): SQL | undefined {
+  const fromSide = (): SQL | undefined => {
+    const fromKinds = collectEndpointKinds(ctx, edgeKinds, "from");
+    if (fromKinds.length === 0) return undefined;
+    return sql`(${compileKindFilter(sql.raw("from_kind"), fromKinds)} AND from_id = ${nodeId})`;
+  };
+  const toSide = (): SQL | undefined => {
+    const toKinds = collectEndpointKinds(ctx, edgeKinds, "to");
+    if (toKinds.length === 0) return undefined;
+    return sql`(${compileKindFilter(sql.raw("to_kind"), toKinds)} AND to_id = ${nodeId})`;
+  };
+
   switch (direction) {
     case "out": {
-      return sql`from_id = ${nodeId}`;
+      return fromSide();
     }
     case "in": {
-      return sql`to_id = ${nodeId}`;
+      return toSide();
     }
     case "both": {
-      return sql`(from_id = ${nodeId} OR to_id = ${nodeId})`;
+      const from = fromSide();
+      const to = toSide();
+      if (from === undefined) return to;
+      if (to === undefined) return from;
+      return sql`(${from} OR ${to})`;
     }
   }
 }

--- a/packages/typegraph/src/store/algorithms/index.ts
+++ b/packages/typegraph/src/store/algorithms/index.ts
@@ -7,6 +7,7 @@ import {
   type SqlSchema,
 } from "../../query/compiler/schema";
 import { getDialect } from "../../query/dialect";
+import { type KindRegistry } from "../../registry/kind-registry";
 import { assertNoRecordedCoordinate } from "../recorded-coordinate-guard";
 import { type AlgorithmContext } from "./context";
 import { executeDegree } from "./degree";
@@ -136,6 +137,8 @@ export type InternalGraphAlgorithms<G extends GraphDef> = Readonly<{
 
 export type CreateGraphAlgorithmsParams = Readonly<{
   graphId: string;
+  graph: GraphDef;
+  registry: KindRegistry;
   backend: GraphBackend;
   schema: SqlSchema | undefined;
   recordedReadBinding: RecordedReadBinding | undefined;
@@ -164,6 +167,8 @@ export function createGraphAlgorithms<G extends GraphDef>(
   const allowRecordedAsOf = params.allowRecordedAsOf === true;
   const ctx: AlgorithmContext = {
     graphId: params.graphId,
+    graph: params.graph,
+    registry: params.registry,
     backend: params.backend,
     dialect: getDialect(params.backend.dialect),
     schema: params.schema ?? createSqlSchema(params.backend.tableNames),

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -543,6 +543,8 @@ export class Store<G extends GraphDef> {
     if (this.#algorithms === undefined) {
       this.#algorithms = createGraphAlgorithms<G>({
         graphId: this.graphId,
+        graph: this.#graph,
+        registry: this.#registry,
         backend: this.#backend,
         schema: this.#schema,
         recordedReadBinding: this.#recordedReadBinding,
@@ -1281,6 +1283,8 @@ export class Store<G extends GraphDef> {
   ): InternalGraphAlgorithms<G> {
     return createGraphAlgorithms<G>({
       graphId: this.graphId,
+      graph: this.#graph,
+      registry: this.#registry,
       backend: this.#recordedReads.backendForCoordinate(
         coordinate,
         "recorded-graph-algorithm",

--- a/packages/typegraph/tests/degree-index-alignment.test.ts
+++ b/packages/typegraph/tests/degree-index-alignment.test.ts
@@ -1,0 +1,180 @@
+/**
+ * degree() direction filters must be servable by the default edge indexes.
+ *
+ * The edge composite indexes lead with `from_kind` / `to_kind` before the
+ * id (`edges_from_idx (graph_id, from_kind, from_id, …)`), so a bare
+ * `from_id = ?` filter can never seek — degree() scanned the graph's whole
+ * edge partition. The direction filters now enumerate the endpoint kinds
+ * the graph declaration permits for the counted edge kinds (expanded
+ * through the subClassOf closure, since a stored `from_kind` may be any
+ * subclass of a declared endpoint), which makes both indexes seekable on
+ * both engines with no schema change.
+ */
+import type Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  subClassOf,
+} from "../src";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import type { GraphBackend } from "../src/backend/types";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const Employee = defineNode("Employee", {
+  schema: z.object({ name: z.string() }),
+});
+const Team = defineNode("Team", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows");
+const memberOf = defineEdge("memberOf");
+
+function buildGraph() {
+  return defineGraph({
+    id: "degree-idx",
+    nodes: {
+      Person: { type: Person },
+      Employee: { type: Employee },
+      Team: { type: Team },
+    },
+    edges: {
+      knows: { type: knows, from: [Person], to: [Person] },
+      memberOf: { type: memberOf, from: [Person], to: [Team] },
+    },
+    ontology: [subClassOf(Employee, Person)],
+  });
+}
+
+type CapturedStatement = Readonly<{ sql: string; params: readonly unknown[] }>;
+
+async function withCapturingStore<T>(
+  run: (
+    store: ReturnType<typeof createStore<ReturnType<typeof buildGraph>>>,
+    captured: CapturedStatement[],
+    client: Database.Database,
+  ) => Promise<T>,
+): Promise<T> {
+  const { backend: raw, db } = createLocalSqliteBackend();
+  try {
+    const captured: CapturedStatement[] = [];
+    const backend: GraphBackend = {
+      ...raw,
+      async execute(query) {
+        const compiled = raw.compileSql?.(query);
+        if (compiled) {
+          captured.push({ sql: compiled.sql, params: compiled.params });
+        }
+        return raw.execute(query);
+      },
+    };
+    const store = createStore(buildGraph(), backend);
+    const client = (db as unknown as { $client: Database.Database }).$client;
+    return await run(store, captured, client);
+  } finally {
+    await raw.close();
+  }
+}
+
+function explainPlan(
+  client: Database.Database,
+  statement: CapturedStatement,
+): string {
+  const rows = client
+    .prepare(`EXPLAIN QUERY PLAN ${statement.sql}`)
+    .all(...statement.params) as readonly { detail: string }[];
+  return rows.map((row) => row.detail).join("\n");
+}
+
+describe("degree() direction filter index alignment", () => {
+  it("seeks the from/to edge indexes instead of scanning the partition", async () => {
+    await withCapturingStore(async (store, captured, client) => {
+      // Enough rows (plus fresh statistics) that the planner's index choice
+      // is driven by selectivity, not tiny-fixture heuristics.
+      const people = await store.nodes.Person.bulkCreate(
+        Array.from({ length: 40 }, (_, index) => ({
+          props: { name: `p${index}` },
+        })),
+      );
+      for (const [index, person] of people.entries()) {
+        for (let step = 1; step <= 3; step++) {
+          await store.edges.knows.create(
+            person,
+            people[(index + step) % people.length]!,
+          );
+        }
+      }
+      await store.refreshStatistics();
+      const alice = people[0]!;
+      const bob = people[1]!;
+
+      captured.length = 0;
+      await store.algorithms.degree(alice.id, { direction: "out" });
+      const outPlan = explainPlan(client, captured.at(-1)!);
+      expect(outPlan).toContain("typegraph_edges_from_idx");
+      expect(outPlan).not.toContain("SCAN typegraph_edges");
+
+      captured.length = 0;
+      await store.algorithms.degree(bob.id, { direction: "in" });
+      const inPlan = explainPlan(client, captured.at(-1)!);
+      expect(inPlan).toContain("typegraph_edges_to_idx");
+      expect(inPlan).not.toContain("SCAN typegraph_edges");
+
+      captured.length = 0;
+      await store.algorithms.degree(alice.id);
+      const bothPlan = explainPlan(client, captured.at(-1)!);
+      expect(bothPlan).not.toContain("SCAN typegraph_edges");
+    });
+  });
+
+  it("counts edges whose endpoint kind is a subclass of the declared kind", async () => {
+    await withCapturingStore(async (store) => {
+      const employee = await store.nodes.Employee.create({ name: "emp" });
+      const person = await store.nodes.Person.create({ name: "per" });
+      const team = await store.nodes.Team.create({ name: "team" });
+
+      // knows declares from/to [Person]; Employee is a subclass, so the
+      // stored from_kind is "Employee" — the enumerated endpoint kinds
+      // must include subclasses or these edges silently vanish from the
+      // count.
+      await store.edges.knows.create(employee as never, person);
+      await store.edges.memberOf.create(employee as never, team);
+
+      expect(
+        await store.algorithms.degree(employee.id, { direction: "out" }),
+      ).toBe(2);
+      expect(
+        await store.algorithms.degree(person.id, { direction: "in" }),
+      ).toBe(1);
+      expect(await store.algorithms.degree(team.id, { direction: "in" })).toBe(
+        1,
+      );
+      expect(await store.algorithms.degree(employee.id)).toBe(2);
+      expect(
+        await store.algorithms.degree(employee.id, { edges: ["memberOf"] }),
+      ).toBe(1);
+    });
+  });
+
+  it("still deduplicates self-loops under direction both", async () => {
+    await withCapturingStore(async (store) => {
+      const solo = await store.nodes.Person.create({ name: "solo" });
+      await store.edges.knows.create(solo, solo);
+
+      expect(await store.algorithms.degree(solo.id)).toBe(1);
+      expect(await store.algorithms.degree(solo.id, { direction: "out" })).toBe(
+        1,
+      );
+      expect(await store.algorithms.degree(solo.id, { direction: "in" })).toBe(
+        1,
+      );
+    });
+  });
+});


### PR DESCRIPTION
`degree()`'s direction filters compiled to bare `from_id = ?` / `to_id = ?`, which neither composite edge index can seek — `edges_from_idx`/`edges_to_idx` both lead with the endpoint kind column.

The filters now enumerate the endpoint kinds the graph declaration permits for the counted edge kinds, **expanded through the `subClassOf` closure** — the same set edge writes validate against, so the enumeration is complete by the system's own invariant. `AlgorithmContext` gains `graph` + `registry`; an edge set with no declared endpoints on the queried side returns 0 without a round trip.

## What honest measurement showed

The initial A/B at bench scale found before ≈ after — two engine-specific rescues were masking the pathology, which reframes what this fix buys:

- **PostgreSQL ≤ 17** (most hosted deployments; PGlite is 16): no btree skip scan, so the old form *structurally cannot* use these indexes → partition scan. The new form seeks on any version. This is the main win and matches the audit's original analysis.
- **PostgreSQL 18** (CI, local container): the new skip scan rescues the old form, but the explicit form is still **5× faster (0.30ms → 0.06ms per call)** on the bench dataset.
- **SQLite**: skip-scan rescued the old form only with fresh statistics; on a stale-stats database it fell back to a `deleted_idx` slice scan (O(live edges)). The new form seeks regardless — removing a stats-dependency cliff.

The changeset describes exactly this rather than a single hero number.

## Testing

- `tests/degree-index-alignment.test.ts`: an EXPLAIN QUERY PLAN assertion pinning `from_idx`/`to_idx` seeks on SQLite (against a realistic fixture with fresh statistics — a 1-row fixture lets the planner pick arbitrary indexes); the subclass-expansion correctness case (`Employee → Person` edge under `from: [Person]` must count — where naive enumeration would silently undercount); self-loop dedupe under `direction: "both"`.
