### PR TITLE
perf: keep driver-parsed jsonb objects on the Postgres read path

### DIFF
--- a/.changeset/pg-jsonb-row-mapping.md
+++ b/.changeset/pg-jsonb-row-mapping.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+perf: eliminate the PostgreSQL JSONB parse→stringify→parse round trip per row. Backend rows now carry `props` as `RowProps` (JSON text on SQLite, the driver-parsed object on PostgreSQL); consumers normalize at the point of use via the new `rowPropsToObject`/`rowPropsToJsonText` helpers instead of re-serializing in the row mapper and re-parsing downstream.

--- a/.changeset/pg-jsonb-row-mapping.md
+++ b/.changeset/pg-jsonb-row-mapping.md
@@ -1,5 +1,7 @@
 ---
-"@nicia-ai/typegraph": patch
+"@nicia-ai/typegraph": minor
 ---
 
-perf: eliminate the PostgreSQL JSONB parse→stringify→parse round trip per row. Backend rows now carry `props` as `RowProps` (JSON text on SQLite, the driver-parsed object on PostgreSQL); consumers normalize at the point of use via the new `rowPropsToObject`/`rowPropsToJsonText` helpers instead of re-serializing in the row mapper and re-parsing downstream.
+perf: eliminate the PostgreSQL JSONB parse→stringify→parse round trip per row.
+
+**Public backend row contract change:** rows returned by `GraphBackend` read methods now carry `props` as `RowProps = string | Readonly<Record<string, unknown>>` — JSON text on SQLite, the driver-parsed object on PostgreSQL. Code that consumed backend rows directly with `JSON.parse(row.props)` must switch to the new `rowPropsToObject(row.props)` (or `rowPropsToJsonText` when text is required); both helpers and the `RowProps` type are exported from the package root. Store-level APIs (`store.nodes.*`, `store.query()`, search, export) are unaffected — they already return parsed objects.

--- a/packages/typegraph/src/backend/drizzle/row-mappers.ts
+++ b/packages/typegraph/src/backend/drizzle/row-mappers.ts
@@ -3,7 +3,7 @@
  */
 
 import { DatabaseOperationError } from "../../errors";
-import type { EdgeRow, NodeRow, SchemaVersionRow, UniqueRow } from "../types";
+import { type EdgeRow, type NodeRow, rowPropsToJsonText, type SchemaVersionRow, type UniqueRow } from "../types";
 
 function requireTimestamp(value: string | undefined, field: string): string {
   if (value === undefined) {
@@ -79,10 +79,18 @@ export function coerceNumericScore(value: number | string): number {
 }
 
 /**
- * Normalizes a JSON column that may be returned as a parsed object (JSONB) or string.
+ * Normalizes a JSON column that may be returned as a parsed object (JSONB)
+ * or string. PostgreSQL drivers hand jsonb back already parsed — keep the
+ * object instead of re-stringifying it, so the read path pays zero JSON
+ * work per row (consumers normalize via rowPropsToObject /
+ * rowPropsToJsonText at the point of use). SQLite text passes through.
  */
-function normalizeJsonColumn(value: unknown): string {
-  return typeof value === "string" ? value : JSON.stringify(value ?? {});
+function normalizeJsonColumn(value: unknown): string | Record<string, unknown> {
+  if (typeof value === "string") return value;
+  if (value !== null && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+  return JSON.stringify(value ?? {});
 }
 
 /**
@@ -95,7 +103,7 @@ function normalizeJsonColumn(value: unknown): string {
  */
 type DialectRowMapperConfig = Readonly<{
   formatTimestamp: (value: unknown) => string | undefined;
-  normalizeJson: (value: unknown) => string;
+  normalizeJson: (value: unknown) => string | Record<string, unknown>;
 }>;
 
 /**
@@ -200,7 +208,7 @@ export function createSchemaVersionRowMapper(
       graph_id: asString(row.graph_id, "graph_id"),
       version: asNumber(row.version, "version"),
       schema_hash: asString(row.schema_hash, "schema_hash"),
-      schema_doc: config.normalizeJson(row.schema_doc),
+      schema_doc: rowPropsToJsonText(config.normalizeJson(row.schema_doc)),
       created_at: requireTimestamp(config.formatTimestamp(row.created_at), "created_at"),
       is_active: isActive,
     };

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -136,13 +136,35 @@ export type BackendCapabilities = Readonly<{
 // ============================================================
 
 /**
+ * A node/edge row's `props` column as the driver returned it: SQLite always
+ * yields the JSON text; PostgreSQL drivers yield the jsonb value already
+ * parsed. Keeping the driver's shape avoids a per-row
+ * parse→stringify→re-parse round trip on the PostgreSQL read path —
+ * consumers normalize through {@link rowPropsToObject} /
+ * {@link rowPropsToJsonText} at the point of use.
+ */
+export type RowProps = string | Readonly<Record<string, unknown>>;
+
+/** The row's props as an object, parsing only when the driver gave text. */
+export function rowPropsToObject(props: RowProps): Record<string, unknown> {
+  return typeof props === "string" ?
+      (JSON.parse(props) as Record<string, unknown>)
+    : props;
+}
+
+/** The row's props as JSON text, serializing only when the driver gave an object. */
+export function rowPropsToJsonText(props: RowProps): string {
+  return typeof props === "string" ? props : JSON.stringify(props);
+}
+
+/**
  * A row from the typegraph_nodes table.
  */
 export type NodeRow = Readonly<{
   graph_id: string;
   kind: string;
   id: string;
-  props: string; // JSON string
+  props: RowProps;
   version: number;
   valid_from: string | undefined;
   valid_to: string | undefined;
@@ -203,7 +225,7 @@ export type EdgeRow = Readonly<{
   from_id: string;
   to_kind: string;
   to_id: string;
-  props: string; // JSON string
+  props: RowProps;
   valid_from: string | undefined;
   valid_to: string | undefined;
   created_at: string;

--- a/packages/typegraph/src/graph-merge/canonical-props.ts
+++ b/packages/typegraph/src/graph-merge/canonical-props.ts
@@ -104,21 +104,27 @@ export function edgeStateSignature(
 }
 
 /**
- * Parses a stored row's JSON `props` string into the PARSED plain object that
- * {@link canonicalizeProps} requires. Malformed JSON, a non-object, or an array
- * all collapse to `{}` — a parse error never escapes. Backend-written rows hold
- * valid JSON, but an external / legacy / truncated `props` value must not crash a
- * state diff or a base-version fingerprint. Centralized so the diff and the
- * fingerprint can never disagree on what a malformed row parses to.
+ * Normalizes a stored row's `props` — a JSON string on SQLite, an
+ * already-parsed object on Postgres (jsonb rows arrive driver-parsed) — into
+ * the plain object that {@link canonicalizeProps} requires. Malformed JSON, a
+ * non-object, or an array all collapse to `{}` — a parse error never escapes.
+ * Backend-written rows hold valid JSON, but an external / legacy / truncated
+ * `props` value must not crash a state diff or a base-version fingerprint.
+ * Centralized so the diff and the fingerprint can never disagree on what a
+ * malformed row parses to.
  */
 export function parseRowProps(
-  props: string,
+  props: string | Readonly<Record<string, unknown>>,
 ): Readonly<Record<string, unknown>> {
   let parsed: unknown;
-  try {
-    parsed = JSON.parse(props);
-  } catch {
-    return {};
+  if (typeof props === "string") {
+    try {
+      parsed = JSON.parse(props);
+    } catch {
+      return {};
+    }
+  } else {
+    parsed = props;
   }
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     return {};

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -8,8 +8,9 @@
  * the backend with `excludeDeleted: false` and read the raw `NodeRow`/`EdgeRow`.
  *
  * Row representation contract (verified against `NodeRow`/`EdgeRow`):
- *   - `props` is a JSON STRING — every comparison `JSON.parse`s it before
- *     `canonicalizeProps`, never feeding the raw string to the serializer (that
+ *   - `props` is a JSON string (SQLite) or a driver-parsed object (Postgres
+ *     jsonb) — every comparison routes it through `parseRowProps` before
+ *     `canonicalizeProps`, never feeding a raw string to the serializer (that
  *     would key on incidental string-literal order, not canonical structure).
  *   - `deleted_at` is a field, `undefined` for live rows. Liveness is
  *     `row.deleted_at === undefined`.
@@ -52,7 +53,7 @@ export type NodeRow = Readonly<{
   graph_id: string;
   kind: string;
   id: string;
-  props: string;
+  props: string | Readonly<Record<string, unknown>>;
   version: number;
   valid_from: string | undefined;
   valid_to: string | undefined;
@@ -70,7 +71,7 @@ export type EdgeRow = Readonly<{
   from_id: string;
   to_kind: string;
   to_id: string;
-  props: string;
+  props: string | Readonly<Record<string, unknown>>;
   valid_from: string | undefined;
   valid_to: string | undefined;
   created_at: string;

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -144,6 +144,11 @@ export type {
   VectorCapabilities,
   VectorOperationBackend,
 } from "./backend/types";
+export {
+  type RowProps,
+  rowPropsToJsonText,
+  rowPropsToObject,
+} from "./backend/types";
 export type { FulltextStrategy } from "./query/dialect/fulltext-strategy";
 export {
   fts5Strategy,

--- a/packages/typegraph/src/interchange/export.ts
+++ b/packages/typegraph/src/interchange/export.ts
@@ -3,7 +3,7 @@
  *
  * Exports nodes and edges from a store to the interchange format.
  */
-import { type GraphBackend } from "../backend/types";
+import { type GraphBackend, rowPropsToObject } from "../backend/types";
 import {
   getEdgeKinds,
   getNodeKinds,
@@ -117,7 +117,7 @@ async function exportNodesOfKind(
     const node: InterchangeNode = {
       kind: row.kind,
       id: row.id,
-      properties: JSON.parse(row.props) as Record<string, unknown>,
+      properties: rowPropsToObject(row.props),
     };
 
     if (options.includeTemporal) {
@@ -169,7 +169,7 @@ async function exportEdgesOfKind(
         kind: row.to_kind,
         id: row.to_id,
       },
-      properties: JSON.parse(row.props) as Record<string, unknown>,
+      properties: rowPropsToObject(row.props),
     };
 
     if (options.includeTemporal) {

--- a/packages/typegraph/src/provenance/index.ts
+++ b/packages/typegraph/src/provenance/index.ts
@@ -5,6 +5,7 @@ import {
   isTombstonedNodeRow,
   type LiveNodeRow,
   type NodeRow,
+  rowPropsToObject,
   type TombstonedNodeRow,
 } from "../backend/types";
 import type { GraphDef } from "../core/define-graph";
@@ -221,7 +222,7 @@ function sortedReferences<
 }
 
 function parseNodeProps(row: NodeRow): Record<string, unknown> {
-  const parsed = JSON.parse(row.props) as unknown;
+  const parsed = rowPropsToObject(row.props) as unknown;
   if (!isPlainObject(parsed)) {
     throw new ConfigurationError(
       `Node ${row.kind}/${row.id} props are not an object.`,

--- a/packages/typegraph/src/store/fulltext-rebuild.ts
+++ b/packages/typegraph/src/store/fulltext-rebuild.ts
@@ -14,6 +14,7 @@ import { type z } from "zod";
 import {
   type GraphBackend,
   type NodeRow,
+  rowPropsToObject,
   runOptionallyInTransaction,
   type TransactionBackend,
 } from "../backend/types";
@@ -262,7 +263,7 @@ function processPage(schema: z.ZodType, rows: readonly NodeRow[]): PageResult {
     }
     let parsed: unknown;
     try {
-      parsed = JSON.parse(row.props);
+      parsed = rowPropsToObject(row.props);
     } catch {
       skipped += 1;
       skippedIds.push(row.id);

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -9,6 +9,7 @@ import {
   type GraphBackend,
   type GraphReadBackend,
   type InsertEdgeParams,
+  rowPropsToObject,
   type TransactionBackend,
 } from "../../backend/types";
 import { validateEdgeEndpoints } from "../../constraints";
@@ -571,7 +572,7 @@ async function performEdgeUpdate<G extends GraphDef>(
   const registration = getEdgeRegistration(ctx.graph, existing.kind);
   const edgeKind = registration.type;
 
-  const existingProps = JSON.parse(existing.props) as Record<string, unknown>;
+  const existingProps = rowPropsToObject(existing.props);
   const mergedProps = { ...existingProps, ...input.props };
 
   const validatedProps = validateEdgeProps(edgeKind.schema, mergedProps, {
@@ -838,7 +839,7 @@ function findMatchingEdge(
 
   for (const row of rows) {
     if (matchOn.length > 0) {
-      const rowProps = JSON.parse(row.props) as Record<string, unknown>;
+      const rowProps = rowPropsToObject(row.props);
       const matches = matchOn.every(
         (field) =>
           stableStringify(rowProps[field]) ===

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -11,6 +11,7 @@ import {
   type InsertNodeParams,
   isLiveNodeRow,
   type NodeRow as BackendNodeRow,
+  rowPropsToObject,
   type TransactionBackend,
   type UniqueRow,
 } from "../../backend/types";
@@ -564,7 +565,7 @@ async function performNodeUpdate<G extends GraphDef>(
   const existing = await backend.getNode(ctx.graphId, kind, id);
   if (!existing) throw new NodeNotFoundError(kind, id);
 
-  const existingProps = JSON.parse(existing.props) as Record<string, unknown>;
+  const existingProps = rowPropsToObject(existing.props);
   const mergedProps = { ...existingProps, ...input.props };
 
   const nodeKind = registration.type;

--- a/packages/typegraph/src/store/operations/node-write-pipeline.ts
+++ b/packages/typegraph/src/store/operations/node-write-pipeline.ts
@@ -21,6 +21,7 @@ import {
   type GraphBackend,
   type LiveNodeRow,
   type NodeRow,
+  rowPropsToObject,
   type TombstonedNodeRow,
   type TransactionBackend,
 } from "../../backend/types";
@@ -249,7 +250,7 @@ export async function applyNodeInsertSideEffectsBatch(
 }
 
 function parseRowProps(row: NodeRow): Record<string, unknown> {
-  return JSON.parse(row.props) as Record<string, unknown>;
+  return rowPropsToObject(row.props);
 }
 
 /**

--- a/packages/typegraph/src/store/recorded-capture/relations.ts
+++ b/packages/typegraph/src/store/recorded-capture/relations.ts
@@ -4,6 +4,7 @@ import { sqlNull } from "../../backend/drizzle/operations/shared";
 import {
   type EdgeRow,
   type NodeRow,
+  rowPropsToJsonText,
   type TransactionBackend,
 } from "../../backend/types";
 import { RECORDED_MAX } from "../../core/temporal";
@@ -152,7 +153,7 @@ function recordedCommonCells<Row extends NodeRow | EdgeRow>(): Record<
     graph_id: (row) => sql`${row.graph_id}`,
     id: (row) => sql`${row.id}`,
     kind: (row) => sql`${row.kind}`,
-    props: (row) => sql`${row.props}`,
+    props: (row) => sql`${rowPropsToJsonText(row.props)}`,
     valid_from: (row) => sql`${sqlNull(row.valid_from)}`,
     valid_to: (row) => sql`${sqlNull(row.valid_to)}`,
     created_at: (row) => sql`${row.created_at}`,

--- a/packages/typegraph/src/store/row-mappers.ts
+++ b/packages/typegraph/src/store/row-mappers.ts
@@ -6,6 +6,7 @@
 import {
   type EdgeRow as BackendEdgeRow,
   type NodeRow as BackendNodeRow,
+  rowPropsToObject,
 } from "../backend/types";
 import {
   filterReservedKeys,
@@ -42,7 +43,7 @@ function nullToUndefined<T>(value: T | null | undefined): T | undefined {
  * Null values from database are normalized to undefined.
  */
 export function rowToNode(row: NodeRow): Node {
-  const rawProps = JSON.parse(row.props) as Record<string, unknown>;
+  const rawProps = rowPropsToObject(row.props);
   const props = filterReservedKeys(rawProps, RESERVED_NODE_KEYS);
   return {
     kind: row.kind,
@@ -81,7 +82,7 @@ export function rowToNodeMeta(
  * Null values from database are normalized to undefined.
  */
 export function rowToEdge(row: EdgeRow): Edge {
-  const rawProps = JSON.parse(row.props) as Record<string, unknown>;
+  const rawProps = rowPropsToObject(row.props);
   const props = filterReservedKeys(rawProps, RESERVED_EDGE_KEYS);
   return {
     id: row.id,

--- a/packages/typegraph/tests/backends/adapter-test-suite.ts
+++ b/packages/typegraph/tests/backends/adapter-test-suite.ts
@@ -15,7 +15,7 @@
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { GraphBackend } from "../../src/backend/types";
+import { type GraphBackend, rowPropsToObject } from "../../src/backend/types";
 import { asCompiledRowsSql } from "../../src/query/sql-intent";
 import type { SerializedSchema } from "../../src/schema/types";
 
@@ -120,7 +120,7 @@ export function createAdapterTestSuite(
         expect(inserted.created_at).toBeDefined();
         expect(inserted.updated_at).toBeDefined();
 
-        const props = JSON.parse(inserted.props);
+        const props = rowPropsToObject(inserted.props);
         expect(props.name).toBe("Alice");
         expect(props.email).toBe("alice@example.com");
 
@@ -281,7 +281,7 @@ export function createAdapterTestSuite(
         });
 
         expect(updated.version).toBe(1);
-        const props = JSON.parse(updated.props);
+        const props = rowPropsToObject(updated.props);
         expect(props.name).toBe("Alice Updated");
       });
 
@@ -302,7 +302,7 @@ export function createAdapterTestSuite(
         });
 
         expect(updated.version).toBe(2);
-        const props = JSON.parse(updated.props);
+        const props = rowPropsToObject(updated.props);
         expect(props.name).toBe("Alice Updated");
         expect(props.age).toBe(30);
       });
@@ -388,8 +388,8 @@ export function createAdapterTestSuite(
 
         expect(person).toBeDefined();
         expect(company).toBeDefined();
-        expect(JSON.parse(person!.props).name).toBe("Alice");
-        expect(JSON.parse(company!.props).name).toBe("Acme");
+        expect(rowPropsToObject(person!.props).name).toBe("Alice");
+        expect(rowPropsToObject(company!.props).name).toBe("Acme");
       });
 
       it("handles nodes in different graphs", async () => {
@@ -410,8 +410,8 @@ export function createAdapterTestSuite(
         const fromA = await backend.getNode("graph_a", "Person", "person-1");
         const fromB = await backend.getNode("graph_b", "Person", "person-1");
 
-        expect(JSON.parse(fromA!.props).name).toBe("Alice");
-        expect(JSON.parse(fromB!.props).name).toBe("Bob");
+        expect(rowPropsToObject(fromA!.props).name).toBe("Alice");
+        expect(rowPropsToObject(fromB!.props).name).toBe("Bob");
       });
     });
 
@@ -440,7 +440,7 @@ export function createAdapterTestSuite(
         expect(inserted.to_id).toBe("company-1");
         expect(inserted.deleted_at).toBeUndefined();
 
-        const props = JSON.parse(inserted.props);
+        const props = rowPropsToObject(inserted.props);
         expect(props.role).toBe("Engineer");
 
         // Retrieve
@@ -609,7 +609,7 @@ export function createAdapterTestSuite(
           props: { role: "Senior Engineer", startDate: "2024-01-01" },
         });
 
-        const props = JSON.parse(updated.props);
+        const props = rowPropsToObject(updated.props);
         expect(props.role).toBe("Senior Engineer");
         expect(props.startDate).toBe("2024-01-01");
       });
@@ -690,8 +690,8 @@ export function createAdapterTestSuite(
         const fromA = await backend.getEdge("graph_a", "edge-1");
         const fromB = await backend.getEdge("graph_b", "edge-1");
 
-        expect(JSON.parse(fromA!.props).graph).toBe("a");
-        expect(JSON.parse(fromB!.props).graph).toBe("b");
+        expect(rowPropsToObject(fromA!.props).graph).toBe("a");
+        expect(rowPropsToObject(fromB!.props).graph).toBe("b");
       });
     });
 

--- a/packages/typegraph/tests/backends/integration/recorded-time.ts
+++ b/packages/typegraph/tests/backends/integration/recorded-time.ts
@@ -25,9 +25,10 @@ import {
   searchable,
   type StoreSearch,
 } from "../../../src";
-import type {
-  GraphBackend,
-  TransactionBackend,
+import {
+  type GraphBackend,
+  rowPropsToJsonText,
+  type TransactionBackend,
 } from "../../../src/backend/types";
 import { RECORDED_MAX } from "../../../src/core/temporal";
 import { type ReadCoordinate } from "../../../src/core/temporal";
@@ -2602,7 +2603,10 @@ export function registerRecordedTimeIntegrationTests(
 
       expect(
         returnedEdges
-          .map((edge) => `${edge.graph_id}:${edge.id}:${edge.props}`)
+          .map(
+            (edge) =>
+              `${edge.graph_id}:${edge.id}:${rowPropsToJsonText(edge.props)}`,
+          )
           .toSorted(),
       ).toEqual([
         `${storeA.graphId}:${sharedEdgeId}:{"since":"graph-a"}`,

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -29,6 +29,7 @@ import {
   createPostgresBackend,
   createPostgresTables,
 } from "../../../src/backend/postgres";
+import { rowPropsToObject } from "../../../src/backend/types";
 import { createStore } from "../../../src/store";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
@@ -451,14 +452,11 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
         props: complexProps,
       });
 
-      const parsed = JSON.parse(inserted.props);
-      expect(parsed.name).toBe("Alice");
-      expect(parsed.nested.a).toBe(1);
-      expect(parsed.nested.b).toEqual([2, 3]);
-      expect(parsed.array).toEqual(["x", "y"]);
+      const parsed = rowPropsToObject(inserted.props);
+      expect(parsed).toEqual(complexProps);
 
       const fetched = await backend.getNode("test_graph", "Person", "person-1");
-      const fetchedProps = JSON.parse(fetched!.props);
+      const fetchedProps = rowPropsToObject(fetched!.props);
       expect(fetchedProps).toEqual(complexProps);
     });
   });

--- a/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 import { count, defineEdge, defineGraph, defineNode } from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
+import { rowPropsToObject } from "../../../src/backend/types";
 import { createStore } from "../../../src/store";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
@@ -221,12 +222,11 @@ describe("postgres-js driver — coercion sanity", () => {
       props: complexProps,
     });
 
-    // Backend's row contract stores `props` as a JSON string — drivers must
-    // agree on this wire-level representation so downstream JSON.parse is
-    // idempotent regardless of whether jsonb came back parsed or as text.
-    expect(typeof inserted.props).toBe("string");
-    const parsed = JSON.parse(inserted.props);
-    expect(parsed).toEqual(complexProps);
+    // Backend's row contract carries `props` as RowProps — a JSON string OR a
+    // driver-parsed object. postgres-js auto-parses jsonb, so the object must
+    // survive the row-mapper without a stringify/parse round trip and
+    // normalize identically through rowPropsToObject.
+    expect(rowPropsToObject(inserted.props)).toEqual(complexProps);
 
     const fetched = await backend.getNode(
       "postgres_js_test",
@@ -234,8 +234,7 @@ describe("postgres-js driver — coercion sanity", () => {
       "person-1",
     );
     expect(fetched).toBeDefined();
-    expect(typeof fetched!.props).toBe("string");
-    expect(JSON.parse(fetched!.props)).toEqual(complexProps);
+    expect(rowPropsToObject(fetched!.props)).toEqual(complexProps);
   });
 
   it("returns aggregate counts as plain numbers (not BigInt)", async (ctx) => {
@@ -294,7 +293,7 @@ describe("postgres-js driver — coercion sanity", () => {
 
     const fetched = await backend.getNode("postgres_js_test", "Person", "tx-1");
     expect(fetched).toBeDefined();
-    expect(JSON.parse(fetched!.props).name).toBe("Alice");
+    expect(rowPropsToObject(fetched!.props).name).toBe("Alice");
   });
 });
 

--- a/packages/typegraph/tests/backends/row-props.test.ts
+++ b/packages/typegraph/tests/backends/row-props.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Pins the RowProps contract: PostgreSQL drivers hand `jsonb` columns back as
+ * already-parsed objects, and the row-mapping layer must carry that object
+ * through untouched — no stringify → re-parse round trip per row. SQLite
+ * stores JSON as TEXT and must keep rejecting anything else. Consumers
+ * normalize at the point of use via rowPropsToObject / rowPropsToJsonText.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createNodeRowMapper,
+  createSchemaVersionRowMapper,
+  POSTGRES_ROW_MAPPER_CONFIG,
+  SQLITE_ROW_MAPPER_CONFIG,
+} from "../../src/backend/drizzle/row-mappers";
+import { rowPropsToJsonText, rowPropsToObject } from "../../src/backend/types";
+import { DatabaseOperationError } from "../../src/errors";
+import { rowToNode } from "../../src/store/row-mappers";
+
+const TIMESTAMP = "2026-07-03T00:00:00.000Z";
+
+function rawNodeRow(props: unknown): Record<string, unknown> {
+  return {
+    graph_id: "g",
+    kind: "Person",
+    id: "person-1",
+    props,
+    version: 1,
+    valid_from: TIMESTAMP,
+    valid_to: undefined,
+    created_at: TIMESTAMP,
+    updated_at: TIMESTAMP,
+    deleted_at: undefined,
+  };
+}
+
+describe("RowProps mapping", () => {
+  describe("postgres mapper", () => {
+    const mapNode = createNodeRowMapper(POSTGRES_ROW_MAPPER_CONFIG);
+
+    it("passes driver-parsed jsonb objects through by reference (zero re-serialization)", () => {
+      const parsedProps = { name: "Alice", nested: { a: 1, b: [2, 3] } };
+      const mapped = mapNode(rawNodeRow(parsedProps));
+      expect(mapped.props).toBe(parsedProps);
+    });
+
+    it("passes JSON text through unchanged when a driver returns text", () => {
+      const jsonText = '{"name":"Alice"}';
+      const mapped = mapNode(rawNodeRow(jsonText));
+      expect(mapped.props).toBe(jsonText);
+    });
+
+    it("keeps schema_doc a JSON string even when jsonb arrives parsed", () => {
+      const mapSchema = createSchemaVersionRowMapper(
+        POSTGRES_ROW_MAPPER_CONFIG,
+      );
+      const schemaDocument = { version: 2, nodes: { Person: {} } };
+      const mapped = mapSchema({
+        graph_id: "g",
+        version: 2,
+        schema_hash: "hash",
+        schema_doc: schemaDocument,
+        created_at: TIMESTAMP,
+        is_active: true,
+      });
+      expect(typeof mapped.schema_doc).toBe("string");
+      expect(JSON.parse(mapped.schema_doc)).toEqual(schemaDocument);
+    });
+  });
+
+  describe("sqlite mapper", () => {
+    const mapNode = createNodeRowMapper(SQLITE_ROW_MAPPER_CONFIG);
+
+    it("passes TEXT props through unchanged", () => {
+      const jsonText = '{"name":"Alice"}';
+      const mapped = mapNode(rawNodeRow(jsonText));
+      expect(mapped.props).toBe(jsonText);
+    });
+
+    it("rejects non-string props — SQLite JSON columns are TEXT", () => {
+      expect(() => mapNode(rawNodeRow({ name: "Alice" }))).toThrow(
+        DatabaseOperationError,
+      );
+    });
+  });
+
+  describe("point-of-use normalization", () => {
+    const objectProps = { name: "Alice", tags: ["x"] };
+
+    it("rowPropsToObject parses strings and passes objects through", () => {
+      expect(rowPropsToObject('{"name":"Alice","tags":["x"]}')).toEqual(
+        objectProps,
+      );
+      expect(rowPropsToObject(objectProps)).toBe(objectProps);
+    });
+
+    it("rowPropsToJsonText stringifies objects and passes strings through", () => {
+      const jsonText = '{"name":"Alice","tags":["x"]}';
+      expect(rowPropsToJsonText(jsonText)).toBe(jsonText);
+      expect(JSON.parse(rowPropsToJsonText(objectProps))).toEqual(objectProps);
+    });
+
+    it("rowToNode produces identical nodes from string and object props", () => {
+      const fromObject = rowToNode({
+        kind: "Person",
+        id: "person-1",
+        props: objectProps,
+        version: 1,
+        valid_from: TIMESTAMP,
+        valid_to: undefined,
+        created_at: TIMESTAMP,
+        updated_at: TIMESTAMP,
+        deleted_at: undefined,
+      });
+      const fromString = rowToNode({
+        kind: "Person",
+        id: "person-1",
+        props: JSON.stringify(objectProps),
+        version: 1,
+        valid_from: TIMESTAMP,
+        valid_to: undefined,
+        created_at: TIMESTAMP,
+        updated_at: TIMESTAMP,
+        deleted_at: undefined,
+      });
+      expect(fromObject).toEqual(fromString);
+      expect(fromObject.name).toBe("Alice");
+    });
+  });
+});

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -8,6 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { rowPropsToObject } from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
 import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
 import {
@@ -45,7 +46,7 @@ async function snapshotPeople(
     .filter((row) => row.deleted_at === undefined)
     .map((row) => ({
       id: row.id,
-      name: (JSON.parse(row.props) as Record<string, unknown>).name,
+      name: rowPropsToObject(row.props).name,
     }))
     .sort((left, right) =>
       left.id < right.id ? -1
@@ -67,7 +68,7 @@ async function snapshotEdges(
       id: row.id,
       from: row.from_id,
       to: row.to_id,
-      since: (JSON.parse(row.props) as Record<string, unknown>).since,
+      since: rowPropsToObject(row.props).since,
     }))
     .sort((left, right) =>
       left.id < right.id ? -1

--- a/packages/typegraph/tests/graph-merge/edge-delete-modify.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-delete-modify.test.ts
@@ -8,6 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { rowPropsToObject } from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
 import { merge } from "../../src/graph-merge/merge";
 import { isOk, unwrap } from "../../src/graph-merge/result";
@@ -67,7 +68,7 @@ async function liveLinks(
     .filter((row) => row.deleted_at === undefined)
     .map((row) => ({
       id: row.id,
-      props: JSON.parse(row.props) as Record<string, unknown>,
+      props: rowPropsToObject(row.props),
     }));
 }
 

--- a/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
@@ -25,6 +25,7 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { rowPropsToObject } from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
 import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
 import { mergeIncremental } from "../../src/graph-merge/merge";
@@ -1097,7 +1098,7 @@ describe.each(backendMatrix())(
         "base-ana",
       );
       expect(row).toBeDefined();
-      const props = JSON.parse(row!.props) as Record<string, unknown>;
+      const props = rowPropsToObject(row!.props);
       expect(props.legacyCode).toBe("KEEP-ME");
       expect(props.tag).toBeUndefined();
     });

--- a/packages/typegraph/tests/graph-merge/merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge.test.ts
@@ -9,6 +9,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { rowPropsToObject } from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
 import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
 import { merge } from "../../src/graph-merge/merge";
@@ -129,7 +130,7 @@ async function livePatients(
   return rows
     .filter((row) => row.deleted_at === undefined)
     .map((row) => {
-      const props = JSON.parse(row.props) as Record<string, unknown>;
+      const props = rowPropsToObject(row.props);
       return { id: row.id, name: props.name, mrn: props.mrn };
     })
     .sort((left, right) =>
@@ -657,7 +658,7 @@ describe.each(backendMatrix())("merge — FHIR care graph [$name]", (entry) => {
       "Patient",
     );
     const merged = rows.find((row) => row.id === origin.id)!;
-    expect((JSON.parse(merged.props) as { birthDate: string }).birthDate).toBe(
+    expect(rowPropsToObject(merged.props).birthDate).toBe(
       "2000-12-31", // B's edit survived too
     );
   });
@@ -769,7 +770,7 @@ describe.each(backendMatrix())(
       );
       const live = rows.filter((row) => row.deleted_at === undefined);
       expect(live).toHaveLength(1);
-      const props = JSON.parse(live[0]!.props) as Record<string, unknown>;
+      const props = rowPropsToObject(live[0]!.props);
       expect(props.since).toBe("2020");
       expect(props.note).toBeUndefined();
     });

--- a/packages/typegraph/tests/graph-merge/self-edge-collapse.test.ts
+++ b/packages/typegraph/tests/graph-merge/self-edge-collapse.test.ts
@@ -22,6 +22,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { rowPropsToObject } from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
 import { merge } from "../../src/graph-merge/merge";
 import { isOk, unwrap } from "../../src/graph-merge/result";
@@ -97,7 +98,7 @@ async function livePersons(
   return rows
     .filter((row) => row.deleted_at === undefined)
     .map((row) => {
-      const props = JSON.parse(row.props) as Record<string, unknown>;
+      const props = rowPropsToObject(row.props);
       return { id: row.id, name: props.name };
     })
     .sort((left, right) =>

--- a/packages/typegraph/tests/property/graph-merge/normalize.ts
+++ b/packages/typegraph/tests/property/graph-merge/normalize.ts
@@ -26,6 +26,7 @@
 import type { GraphDef, Store } from "@nicia-ai/typegraph";
 import { getEdgeKinds, getNodeKinds } from "@nicia-ai/typegraph";
 
+import { rowPropsToObject } from "../../../src/backend/types";
 import { canonicalizeProps } from "../../../src/graph-merge/canonical-props";
 import {
   enumerateAllEdges,
@@ -306,7 +307,7 @@ export async function normalizeGraph<G extends GraphDef>(
       if (row.deleted_at !== undefined) {
         continue;
       }
-      const props = JSON.parse(row.props) as Record<string, unknown>;
+      const props = rowPropsToObject(row.props);
       nodes.push({ id: row.id, kind: row.kind, props: canonicalProps(props) });
     }
   }
@@ -318,7 +319,7 @@ export async function normalizeGraph<G extends GraphDef>(
       if (row.deleted_at !== undefined) {
         continue;
       }
-      const props = JSON.parse(row.props) as Record<string, unknown>;
+      const props = rowPropsToObject(row.props);
       edges.push({
         id: row.id,
         kind: row.kind,

--- a/packages/typegraph/tests/state-snapshot.ts
+++ b/packages/typegraph/tests/state-snapshot.ts
@@ -16,7 +16,7 @@
  */
 import { sql } from "drizzle-orm";
 
-import type { GraphBackend } from "../src/backend/types";
+import { type GraphBackend, rowPropsToObject } from "../src/backend/types";
 import type { GraphDef } from "../src/core/define-graph";
 import { asCompiledRowsSql } from "../src/query/sql-intent";
 import type { Store } from "../src/store/store";
@@ -116,7 +116,7 @@ export async function dumpObservableState<G extends GraphDef>(
       nodes.push({
         kind: row.kind,
         id: row.id,
-        props: JSON.parse(row.props) as Record<string, unknown>,
+        props: rowPropsToObject(row.props),
         deleted: row.deleted_at !== undefined,
       });
     }
@@ -139,7 +139,7 @@ export async function dumpObservableState<G extends GraphDef>(
         fromId: row.from_id,
         toKind: row.to_kind,
         toId: row.to_id,
-        props: JSON.parse(row.props) as Record<string, unknown>,
+        props: rowPropsToObject(row.props),
         deleted: row.deleted_at !== undefined,
       });
     }


### PR DESCRIPTION
Every PostgreSQL read paid a parse→stringify→parse round trip per row — the driver parses jsonb to an object, `normalizeJsonColumn` re-stringified it, and every consumer immediately `JSON.parse`d it back.

## Change

- `NodeRow.props` / `EdgeRow.props` are now `RowProps = string | Readonly<Record<string, unknown>>`: JSON text on SQLite (TEXT column, strict — non-strings still rejected at the mapper), the driver-parsed object on PostgreSQL (passed through by reference, zero serialization work).
- New `rowPropsToObject` / `rowPropsToJsonText` helpers; every consumer normalizes at the point of use. The type change compiler-enumerated all of them: store row mappers, node write pipeline, node/edge update merge paths, interchange export, provenance, fulltext rebuild, graph-merge (`parseRowProps` widened, local row mirrors updated).
- `schema_doc` intentionally stays a JSON string (cold path, callers expect text).
- Recorded-capture pre-image INSERTs bind `rowPropsToJsonText(row.props)` explicitly so props serialization never depends on driver parameter-encoding behavior.
- The query result path and subgraph hydration already handled string-or-object and are untouched.
- `RowProps`, `rowPropsToObject`, and `rowPropsToJsonText` are now exported from the package root, so structural consumers of `GraphBackend` rows have the sanctioned migration path (`JSON.parse(row.props)` → `rowPropsToObject(row.props)`).

**Note:** `NodeRow`/`EdgeRow` themselves unexported — that's a long-standing deliberate boundary (consumers like graph-merge mirror them structurally), and exporting them is a separate decision from giving row consumers the props normalizers.

## Tests

- New `tests/backends/row-props.test.ts` pins the contract: PG mapper passes objects through **by reference** (identity assertion — a reintroduced stringify fails the test), PG text passthrough, SQLite strict-string rejection, `schema_doc` stringification, and `rowToNode` equivalence for both representations.
- postgres-js round-trip test updated from the old "always text" contract to the RowProps contract.

## Measurement

PG lane (5k nodes × ~600B props, ordered stash A/B, medians; machine under heavy external load so magnitudes are conservative — direction was consistent in every ordered pair):

| shape | before | after |
| --- | --- | --- |
| full-kind `find()` (5k rows) | 42–53ms | ~30ms (1.4–1.8×) |
| `getByIds` (5k ids) | 44ms | 32ms (~1.4×) |
| `exportGraph` | 36–40ms | ~29ms (~1.3×) |

