### PR TITLE
perf: compose hybrid search into a single SQL statement

### DIFF
--- a/.changeset/hybrid-single-statement.md
+++ b/.changeset/hybrid-single-statement.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+perf: `store.search.hybrid` now runs as a single SQL statement on the built-in backends — both sources, weighted RRF fusion, liveness, and node hydration composed into one round trip (previously two search statements plus an id-hydration fetch, with fusion in JS). Results are identical to the previous path; the saving scales with per-statement cost (serverless drivers, D1/Durable Objects, remote databases). `GraphBackend` gains an optional `hybridSearch` member; backends without it (custom backends, capability profiles without window functions) keep the multi-statement fallback.

--- a/apps/docs/src/content/docs/fulltext-search.md
+++ b/apps/docs/src/content/docs/fulltext-search.md
@@ -366,7 +366,15 @@ both paths.
 
 ### Hybrid Search (Store API)
 
-For tunable RRF parameters, use `store.search.hybrid()`:
+For tunable RRF parameters, use `store.search.hybrid()`. On the built-in
+backends this runs as a **single SQL statement** — both sources, RRF
+fusion, and node hydration composed together — so a hybrid query costs one
+round trip instead of three. The saving scales with per-statement cost:
+decisive on serverless HTTP drivers, Cloudflare D1 / Durable Objects, and
+remote databases; on a local low-latency connection the two paths are
+within a few milliseconds of each other. (Kind expansions via
+`includeSubClasses`, and custom backends without the composed statement,
+transparently use a multi-statement path with identical results.)
 
 ```typescript
 const results = await store.search.hybrid("Document", {

--- a/packages/typegraph/src/backend/drizzle/operations/hybrid.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/hybrid.ts
@@ -1,0 +1,138 @@
+/**
+ * Single-statement hybrid search: composes a vector source (the active
+ * `VectorStrategy`'s search SQL) and a fulltext source (the shared
+ * `buildFulltextSearch` SQL) into one statement that ranks each source,
+ * fuses via weighted Reciprocal Rank Fusion, joins live node rows for
+ * hydration, and pages the fused ranking — replacing the facade's two
+ * search round trips plus id-hydration fetch with one round trip.
+ *
+ * Fusion math matches the store's JS implementation exactly:
+ * `score = Σ_src weight_src / (fusionK + rank_src)`, ranked descending,
+ * ties broken by node id. Ranks are per-source `ROW_NUMBER()` over the
+ * source's own ordering (score, direction per metric convention), so the
+ * statement requires window functions — backends whose capability profile
+ * disables them fall back to the multi-statement path.
+ *
+ * The two-branch `UNION ALL` + `GROUP BY` fusion shape is deliberate: it
+ * needs no FULL OUTER JOIN (absent from older SQLite builds) and keeps the
+ * statement identical across dialects.
+ */
+import { type SQL, sql } from "drizzle-orm";
+
+import { quotedColumn, type Tables } from "./shared";
+
+export type HybridStatementInput = Readonly<{
+  /** Vector source SQL: `(node_id, score)` ordered best-first, bounded. */
+  vectorSql: SQL;
+  /**
+   * Whether higher vector scores rank first (cosine similarity) or lower
+   * (l2 / inner_product raw distance) — must match the source ordering.
+   */
+  vectorScoreDescending: boolean;
+  /** Fulltext source SQL: `(node_id, score, snippet)`, score-descending. */
+  fulltextSql: SQL;
+  nodes: Tables["nodes"];
+  graphId: string;
+  nodeKind: string;
+  fusionK: number;
+  vectorWeight: number;
+  fulltextWeight: number;
+  limit: number;
+  offset: number;
+}>;
+
+/**
+ * The raw column shape the statement returns: fusion fields plus the full
+ * node row (aliased to the mapper's expected column names). `node_id`
+ * (fusion side) and `id` (node side) intentionally coexist.
+ */
+export function buildHybridSearchStatement(input: HybridStatementInput): SQL {
+  const { nodes } = input;
+  const vectorOrder =
+    input.vectorScoreDescending ?
+      sql.raw("score DESC, node_id ASC")
+    : sql.raw("score ASC, node_id ASC");
+
+  const columnPairs: readonly (readonly [{ name: string }, string])[] = [
+    [nodes.graphId, "graph_id"],
+    [nodes.kind, "kind"],
+    [nodes.id, "id"],
+    [nodes.props, "props"],
+    [nodes.version, "version"],
+    [nodes.validFrom, "valid_from"],
+    [nodes.validTo, "valid_to"],
+    [nodes.createdAt, "created_at"],
+    [nodes.updatedAt, "updated_at"],
+    [nodes.deletedAt, "deleted_at"],
+  ];
+  const nodeColumns = sql.raw(
+    columnPairs
+      .map(
+        ([column, alias]) =>
+          `tg_hybrid_node."${column.name.replaceAll('"', '""')}" AS ${alias}`,
+      )
+      .join(", "),
+  );
+
+  // `* 1.0` forces float division: with integer binds, Postgres would
+  // otherwise evaluate `weight / (k + rank)` in integer arithmetic and
+  // collapse every contribution to zero.
+  return sql`
+    WITH tg_hybrid_vec AS (
+      SELECT node_id, score,
+             ROW_NUMBER() OVER (ORDER BY ${vectorOrder}) AS ord
+      FROM (${input.vectorSql}) AS tg_hybrid_vec_src
+    ),
+    tg_hybrid_fts AS (
+      SELECT node_id, score, snippet,
+             ROW_NUMBER() OVER (ORDER BY score DESC, node_id ASC) AS ord
+      FROM (${input.fulltextSql}) AS tg_hybrid_fts_src
+    ),
+    tg_hybrid_pairs AS (
+      SELECT node_id, ord AS vector_rank, score AS vector_score,
+             NULL AS fulltext_rank, NULL AS fulltext_score, NULL AS snippet
+      FROM tg_hybrid_vec
+      UNION ALL
+      SELECT node_id, NULL, NULL, ord, score, snippet
+      FROM tg_hybrid_fts
+    ),
+    tg_hybrid_fused AS (
+      SELECT node_id,
+        SUM(
+          COALESCE((${input.vectorWeight} * 1.0) / (${input.fusionK} + vector_rank), 0)
+          + COALESCE((${input.fulltextWeight} * 1.0) / (${input.fusionK} + fulltext_rank), 0)
+        ) AS fused_score,
+        MAX(vector_rank) AS vector_rank,
+        MAX(vector_score) AS vector_score,
+        MAX(fulltext_rank) AS fulltext_rank,
+        MAX(fulltext_score) AS fulltext_score,
+        MAX(snippet) AS snippet
+      FROM tg_hybrid_pairs
+      GROUP BY node_id
+    )
+    SELECT
+      tg_hybrid_fused.node_id AS node_id,
+      tg_hybrid_fused.fused_score AS fused_score,
+      tg_hybrid_fused.vector_rank AS vector_rank,
+      tg_hybrid_fused.vector_score AS vector_score,
+      tg_hybrid_fused.fulltext_rank AS fulltext_rank,
+      tg_hybrid_fused.fulltext_score AS fulltext_score,
+      tg_hybrid_fused.snippet AS snippet,
+      ${nodeColumns}
+    FROM tg_hybrid_fused
+    JOIN ${nodes} AS tg_hybrid_node
+      ON ${qualified(nodes, "graphId")} = ${input.graphId}
+     AND ${qualified(nodes, "kind")} = ${input.nodeKind}
+     AND ${qualified(nodes, "id")} = tg_hybrid_fused.node_id
+     AND ${qualified(nodes, "deletedAt")} IS NULL
+    ORDER BY fused_score DESC, node_id ASC
+    LIMIT ${input.limit} OFFSET ${input.offset}
+  `;
+}
+
+function qualified(
+  nodes: Tables["nodes"],
+  member: "graphId" | "kind" | "id" | "deletedAt",
+): SQL {
+  return sql`tg_hybrid_node.${quotedColumn(nodes[member])}`;
+}

--- a/packages/typegraph/src/backend/drizzle/operations/hybrid.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/hybrid.ts
@@ -19,6 +19,8 @@
  */
 import { type SQL, sql } from "drizzle-orm";
 
+import { type HybridSearchRow, type NodeRow } from "../../types";
+import { coerceNumericScore } from "../row-mappers";
 import { quotedColumn, type Tables } from "./shared";
 
 export type HybridStatementInput = Readonly<{
@@ -135,4 +137,41 @@ function qualified(
   member: "graphId" | "kind" | "id" | "deletedAt",
 ): SQL {
   return sql`tg_hybrid_node.${quotedColumn(nodes[member])}`;
+}
+
+function present(value: unknown): boolean {
+  return value !== null && value !== undefined;
+}
+
+/**
+ * Maps one raw statement row into a {@link HybridSearchRow}. Rank columns
+ * come from `ROW_NUMBER()` (bigint — node-postgres hands int8 back as a
+ * string) and scores from engine-native rank math (Postgres `numeric`
+ * can arrive as a string), so both coerce defensively.
+ */
+export function mapHybridSearchRow(
+  row: Record<string, unknown>,
+  toNodeRow: (raw: Record<string, unknown>) => NodeRow,
+): HybridSearchRow {
+  return {
+    node: toNodeRow(row),
+    fusedScore: coerceNumericScore(row.fused_score as number | string),
+    ...(present(row.vector_rank) ?
+      { vectorRank: Number(row.vector_rank) }
+    : {}),
+    ...(present(row.vector_score) ?
+      { vectorScore: coerceNumericScore(row.vector_score as number | string) }
+    : {}),
+    ...(present(row.fulltext_rank) ?
+      { fulltextRank: Number(row.fulltext_rank) }
+    : {}),
+    ...(present(row.fulltext_score) ?
+      {
+        fulltextScore: coerceNumericScore(
+          row.fulltext_score as number | string,
+        ),
+      }
+    : {}),
+    ...(present(row.snippet) ? { snippet: String(row.snippet) } : {}),
+  };
 }

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -20,6 +20,7 @@ import type {
   FulltextSearchParams,
   HardDeleteEdgeParams,
   HardDeleteNodeParams,
+  HybridSearchParams,
   InsertEdgeParams,
   InsertNodeParams,
   InsertSchemaParams,
@@ -55,6 +56,7 @@ import {
   buildUpdateEdge,
 } from "./edges";
 import { buildFulltextSearch } from "./fulltext";
+import { buildHybridSearchStatement } from "./hybrid";
 import {
   buildDeleteNode,
   buildGetNode,
@@ -107,6 +109,17 @@ export type CommonOperationStrategy = Readonly<{
    * fulltext search above, is computed over live rows in SQL.
    */
   buildLiveNodeIds: (graphId: string, nodeKind: string) => SQL;
+  /**
+   * Composes the single-statement hybrid search: the caller supplies the
+   * vector source SQL (strategy-owned); this member builds the fulltext
+   * source over the same candidate set and fuses both via
+   * {@link buildHybridSearchStatement}.
+   */
+  buildHybridSearch: (
+    params: HybridSearchParams,
+    vectorSql: SQL,
+    vectorScoreDescending: boolean,
+  ) => SQL;
   buildInsertNode: (params: InsertNodeParams, timestamp: string) => SQL;
   buildInsertNodeNoReturn: (
     params: InsertNodeParams,
@@ -300,6 +313,51 @@ function createCommonOperationStrategy(
       ),
     buildLiveNodeIds: (graphId: string, nodeKind: string): SQL =>
       liveNodeIdsSubquery(tables.nodes, graphId, nodeKind),
+    buildHybridSearch: (
+      params: HybridSearchParams,
+      vectorSql: SQL,
+      vectorScoreDescending: boolean,
+    ): SQL => {
+      const candidates =
+        params.candidates ??
+        liveNodeIdsSubquery(tables.nodes, params.graphId, params.nodeKind);
+      const fulltextSql = buildFulltextSearch(
+        fulltextTable,
+        {
+          graphId: params.graphId,
+          nodeKind: params.nodeKind,
+          query: params.fulltext.query,
+          limit: params.fulltext.k,
+          ...(params.fulltext.mode === undefined ?
+            {}
+          : { mode: params.fulltext.mode }),
+          ...(params.fulltext.language === undefined ?
+            {}
+          : { language: params.fulltext.language }),
+          ...(params.fulltext.minScore === undefined ?
+            {}
+          : { minScore: params.fulltext.minScore }),
+          ...(params.fulltext.includeSnippets === undefined ?
+            {}
+          : { includeSnippets: params.fulltext.includeSnippets }),
+        },
+        fulltextStrategy,
+        candidates,
+      );
+      return buildHybridSearchStatement({
+        vectorSql,
+        vectorScoreDescending,
+        fulltextSql,
+        nodes: tables.nodes,
+        graphId: params.graphId,
+        nodeKind: params.nodeKind,
+        fusionK: params.fusion.k,
+        vectorWeight: params.fusion.vectorWeight,
+        fulltextWeight: params.fusion.fulltextWeight,
+        limit: params.limit,
+        offset: params.offset ?? 0,
+      });
+    },
   };
 
   return {

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -74,6 +74,8 @@ import {
   type FulltextSearchParams,
   type FulltextSearchResult,
   type GraphBackend,
+  type HybridSearchParams,
+  type HybridSearchRow,
   type IndexMaterializationRow,
   type KindRemovalRow,
   POSTGRES_CAPABILITIES,
@@ -127,6 +129,7 @@ import {
   createCommonOperationBackend,
   type InternalOperationBackend,
 } from "./operation-backend-core";
+import { mapHybridSearchRow } from "./operations/hybrid";
 import {
   createCachedTableExistence,
   createPostgresOperationStrategy,
@@ -974,7 +977,7 @@ function createPostgresOperationBackend(
    *   MATERIALIZED wrapper (see `buildSearch`) to restore exact ordering.
    */
   async function vectorSearchGucOverrides(
-    params: VectorSearchParams,
+    params: Pick<VectorSearchParams, "efSearch" | "indexType">,
   ): Promise<readonly SearchGucOverride[]> {
     const overrides: SearchGucOverride[] = [];
     if (params.efSearch !== undefined) {
@@ -1018,12 +1021,12 @@ function createPostgresOperationBackend(
    * onto one connection. With none we take the unchanged single-statement
    * fast path and open no transaction.
    */
-  async function runVectorSearch(
+  async function runVectorSearch<Row = VectorSearchRow>(
     overrides: readonly SearchGucOverride[],
     query: SQL,
-  ): Promise<readonly VectorSearchRow[]> {
+  ): Promise<readonly Row[]> {
     if (overrides.length === 0) {
-      return execAll<VectorSearchRow>(query);
+      return execAll<Row>(query);
     }
     if (db instanceof PgTransaction) {
       // Already inside the caller's transaction (low-level
@@ -1046,7 +1049,7 @@ function createPostgresOperationBackend(
           sql`SELECT set_config(${override.name}, ${override.value}, true)`,
         );
       }
-      const rows = await execAll<VectorSearchRow>(query);
+      const rows = await execAll<Row>(query);
       // Restore only on success: a failed SELECT aborts the caller's
       // transaction, so its rollback discards the overrides anyway and a
       // restore here would just fail against the aborted tx, masking the
@@ -1068,7 +1071,7 @@ function createPostgresOperationBackend(
           sql`SELECT set_config(${override.name}, ${override.value}, true)`,
         );
       }
-      return txAdapter.execute<VectorSearchRow>(query);
+      return txAdapter.execute<Row>(query);
     });
   }
 
@@ -1244,6 +1247,66 @@ function createPostgresOperationBackend(
             nodeId: row.node_id,
             score: row.score,
           }));
+        },
+        async hybridSearch(
+          params: HybridSearchParams,
+        ): Promise<readonly HybridSearchRow[]> {
+          assertVectorSearchLimit(params.limit);
+          assertPgvectorEfSearch(params.vector.efSearch);
+          const slot = vectorSlotFromParams({
+            graphId: params.graphId,
+            nodeKind: params.nodeKind,
+            fieldPath: params.vector.fieldPath,
+            dimensions: params.vector.dimensions,
+            metric: params.vector.metric,
+            indexType: params.vector.indexType,
+          });
+          await ensureVectorSlotStorage(slot);
+          const candidates =
+            params.candidates ??
+            operationStrategy.buildLiveNodeIds(
+              params.graphId,
+              params.nodeKind,
+            );
+          const vectorParams: VectorSearchParams = {
+            graphId: params.graphId,
+            nodeKind: params.nodeKind,
+            fieldPath: params.vector.fieldPath,
+            queryEmbedding: params.vector.queryEmbedding,
+            metric: params.vector.metric,
+            dimensions: params.vector.dimensions,
+            indexType: params.vector.indexType,
+            limit: params.vector.k,
+            ...(params.vector.minScore === undefined ?
+              {}
+            : { minScore: params.vector.minScore }),
+          };
+          const vectorSql = vectorStrategy.buildSearch(
+            slot,
+            vectorParams,
+            candidates,
+          );
+          const statement = operationStrategy.buildHybridSearch(
+            { ...params, candidates },
+            vectorSql,
+            params.vector.metric === "cosine",
+          );
+          const gucOverrides = await vectorSearchGucOverrides({
+            indexType: params.vector.indexType,
+            ...(params.vector.efSearch === undefined ?
+              {}
+            : { efSearch: params.vector.efSearch }),
+          });
+          let raw: readonly Record<string, unknown>[];
+          try {
+            raw = await runVectorSearch<Record<string, unknown>>(
+              gucOverrides,
+              statement,
+            );
+          } catch (error) {
+            throw mapVectorWriteError(error, vectorParams);
+          }
+          return raw.map((row) => mapHybridSearchRow(row, toNodeRow));
         },
       };
 

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -1248,66 +1248,77 @@ function createPostgresOperationBackend(
             score: row.score,
           }));
         },
-        async hybridSearch(
-          params: HybridSearchParams,
-        ): Promise<readonly HybridSearchRow[]> {
-          assertVectorSearchLimit(params.limit);
-          assertPgvectorEfSearch(params.vector.efSearch);
-          const slot = vectorSlotFromParams({
-            graphId: params.graphId,
-            nodeKind: params.nodeKind,
-            fieldPath: params.vector.fieldPath,
-            dimensions: params.vector.dimensions,
-            metric: params.vector.metric,
-            indexType: params.vector.indexType,
-          });
-          await ensureVectorSlotStorage(slot);
-          const candidates =
-            params.candidates ??
-            operationStrategy.buildLiveNodeIds(
-              params.graphId,
-              params.nodeKind,
-            );
-          const vectorParams: VectorSearchParams = {
-            graphId: params.graphId,
-            nodeKind: params.nodeKind,
-            fieldPath: params.vector.fieldPath,
-            queryEmbedding: params.vector.queryEmbedding,
-            metric: params.vector.metric,
-            dimensions: params.vector.dimensions,
-            indexType: params.vector.indexType,
-            limit: params.vector.k,
-            ...(params.vector.minScore === undefined ?
-              {}
-            : { minScore: params.vector.minScore }),
-          };
-          const vectorSql = vectorStrategy.buildSearch(
-            slot,
-            vectorParams,
-            candidates,
-          );
-          const statement = operationStrategy.buildHybridSearch(
-            { ...params, candidates },
-            vectorSql,
-            params.vector.metric === "cosine",
-          );
-          const gucOverrides = await vectorSearchGucOverrides({
-            indexType: params.vector.indexType,
-            ...(params.vector.efSearch === undefined ?
-              {}
-            : { efSearch: params.vector.efSearch }),
-          });
-          let raw: readonly Record<string, unknown>[];
-          try {
-            raw = await runVectorSearch<Record<string, unknown>>(
-              gucOverrides,
-              statement,
-            );
-          } catch (error) {
-            throw mapVectorWriteError(error, vectorParams);
+        // Single-statement hybrid needs ROW_NUMBER(); a capability
+        // profile that disables window functions keeps the store's
+        // multi-statement fallback by simply not exposing the member.
+        ...(capabilities.windowFunctions ?
+          {
+            async hybridSearch(
+              params: HybridSearchParams,
+            ): Promise<readonly HybridSearchRow[]> {
+              assertVectorSearchLimit(params.limit);
+              // Source depths get the same boundary validation the fallback
+              // path applies (vectorSearch validates its limit; the fulltext
+              // depth is validated inside buildFulltextSearch).
+              assertVectorSearchLimit(params.vector.k);
+              assertPgvectorEfSearch(params.vector.efSearch);
+              const slot = vectorSlotFromParams({
+                graphId: params.graphId,
+                nodeKind: params.nodeKind,
+                fieldPath: params.vector.fieldPath,
+                dimensions: params.vector.dimensions,
+                metric: params.vector.metric,
+                indexType: params.vector.indexType,
+              });
+              await ensureVectorSlotStorage(slot);
+              const candidates =
+                params.candidates ??
+                operationStrategy.buildLiveNodeIds(
+                  params.graphId,
+                  params.nodeKind,
+                );
+              const vectorParams: VectorSearchParams = {
+                graphId: params.graphId,
+                nodeKind: params.nodeKind,
+                fieldPath: params.vector.fieldPath,
+                queryEmbedding: params.vector.queryEmbedding,
+                metric: params.vector.metric,
+                dimensions: params.vector.dimensions,
+                indexType: params.vector.indexType,
+                limit: params.vector.k,
+                ...(params.vector.minScore === undefined ?
+                  {}
+                : { minScore: params.vector.minScore }),
+              };
+              const vectorSql = vectorStrategy.buildSearch(
+                slot,
+                vectorParams,
+                candidates,
+              );
+              const statement = operationStrategy.buildHybridSearch(
+                { ...params, candidates },
+                vectorSql,
+                params.vector.metric === "cosine",
+              );
+              const gucOverrides = await vectorSearchGucOverrides({
+                indexType: params.vector.indexType,
+                ...(params.vector.efSearch === undefined ?
+                  {}
+                : { efSearch: params.vector.efSearch }),
+              });
+              let raw: readonly Record<string, unknown>[];
+              try {
+                raw = await runVectorSearch<Record<string, unknown>>(
+                  gucOverrides,
+                  statement,
+                );
+              } catch (error) {
+                throw mapVectorWriteError(error, vectorParams);
+              }
+              return raw.map((row) => mapHybridSearchRow(row, toNodeRow));
+            },
           }
-          return raw.map((row) => mapHybridSearchRow(row, toNodeRow));
-        },
+        : {}),
       };
 
   const operationBackend: InternalOperationBackend = {

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -59,6 +59,8 @@ import {
   type FulltextSearchParams,
   type FulltextSearchResult,
   type GraphBackend,
+  type HybridSearchParams,
+  type HybridSearchRow,
   type IndexMaterializationRow,
   type KindRemovalRow,
   type RecordContributionMaterializationParams,
@@ -121,6 +123,7 @@ import {
   createCommonOperationBackend,
   type InternalOperationBackend,
 } from "./operation-backend-core";
+import { mapHybridSearchRow } from "./operations/hybrid";
 import { createSqliteOperationStrategy } from "./operations/strategy";
 import {
   coerceNumericScore,
@@ -684,6 +687,63 @@ function createSqliteOperationBackend(
             score: row.score,
           }));
         },
+        // Single-statement hybrid needs ROW_NUMBER(); a capability profile
+        // that disables window functions keeps the store's multi-statement
+        // fallback by simply not exposing the member.
+        ...(capabilities.windowFunctions ?
+          {
+            async hybridSearch(
+              params: HybridSearchParams,
+            ): Promise<readonly HybridSearchRow[]> {
+              assertVectorSearchLimit(params.limit);
+              const slot = vectorSlotFromParams({
+                graphId: params.graphId,
+                nodeKind: params.nodeKind,
+                fieldPath: params.vector.fieldPath,
+                dimensions: params.vector.dimensions,
+                metric: params.vector.metric,
+                indexType: params.vector.indexType,
+              });
+              await ensureVectorSlotStorage(slot);
+              const candidates =
+                params.candidates ??
+                operationStrategy.buildLiveNodeIds(
+                  params.graphId,
+                  params.nodeKind,
+                );
+              const vectorParams: VectorSearchParams = {
+                graphId: params.graphId,
+                nodeKind: params.nodeKind,
+                fieldPath: params.vector.fieldPath,
+                queryEmbedding: params.vector.queryEmbedding,
+                metric: params.vector.metric,
+                dimensions: params.vector.dimensions,
+                indexType: params.vector.indexType,
+                limit: params.vector.k,
+                ...(params.vector.minScore === undefined ?
+                  {}
+                : { minScore: params.vector.minScore }),
+              };
+              const vectorSql = vectorStrategy.buildSearch(
+                slot,
+                vectorParams,
+                candidates,
+              );
+              const statement = operationStrategy.buildHybridSearch(
+                { ...params, candidates },
+                vectorSql,
+                params.vector.metric === "cosine",
+              );
+              let raw: readonly Record<string, unknown>[];
+              try {
+                raw = await execAll<Record<string, unknown>>(statement);
+              } catch (error) {
+                throw mapVectorWriteError(error, vectorParams);
+              }
+              return raw.map((row) => mapHybridSearchRow(row, toNodeRow));
+            },
+          }
+        : {}),
       };
 
   const operationBackend: InternalOperationBackend = {

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -696,6 +696,11 @@ function createSqliteOperationBackend(
               params: HybridSearchParams,
             ): Promise<readonly HybridSearchRow[]> {
               assertVectorSearchLimit(params.limit);
+              // Source depths get the same boundary validation the
+              // fallback path applies (vectorSearch validates its limit;
+              // the fulltext depth is validated inside
+              // buildFulltextSearch).
+              assertVectorSearchLimit(params.vector.k);
               const slot = vectorSlotFromParams({
                 graphId: params.graphId,
                 nodeKind: params.nodeKind,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -489,6 +489,63 @@ export type VectorSearchResult = Readonly<{
 }>;
 
 /**
+ * Parameters for a single-statement hybrid (vector + fulltext, RRF-fused)
+ * search. The store facade resolves every default before calling — the
+ * per-source candidate depths (`k`), the fusion constants, and the shared
+ * `candidates` subquery — so the backend composes SQL without policy.
+ */
+export type HybridSearchParams = Readonly<{
+  graphId: string;
+  nodeKind: string;
+  vector: Readonly<{
+    fieldPath: string;
+    queryEmbedding: readonly number[];
+    metric: VectorMetric;
+    dimensions: number;
+    indexType: VectorIndexType;
+    /** Candidate depth of the vector source (rows entering fusion). */
+    k: number;
+    minScore?: number;
+    efSearch?: number;
+  }>;
+  fulltext: Readonly<{
+    query: string;
+    mode?: FulltextQueryMode;
+    language?: string;
+    /** Candidate depth of the fulltext source (rows entering fusion). */
+    k: number;
+    minScore?: number;
+    includeSnippets?: boolean;
+  }>;
+  fusion: Readonly<{
+    /** RRF rank constant (`1 / (k + rank)`). */
+    k: number;
+    vectorWeight: number;
+    fulltextWeight: number;
+  }>;
+  /** Fused rows to return after `offset`. */
+  limit: number;
+  /** Fused rows to skip (rank-relative pagination). */
+  offset?: number;
+  /** See {@link VectorSearchParams.candidates}; applies to both sources. */
+  candidates?: SQL;
+}>;
+
+/**
+ * One fused hybrid hit, hydrated in the same statement: the node row
+ * rides along so the caller needs no follow-up id fetch.
+ */
+export type HybridSearchRow = Readonly<{
+  node: NodeRow;
+  fusedScore: number;
+  vectorRank?: number;
+  vectorScore?: number;
+  fulltextRank?: number;
+  fulltextScore?: number;
+  snippet?: string;
+}>;
+
+/**
  * Parameters for creating a vector index.
  */
 export type CreateVectorIndexParams = Readonly<{
@@ -1017,6 +1074,17 @@ export type GraphBackend = Readonly<{
   ) => Promise<readonly VectorSearchResult[]>;
   createVectorIndex?: (params: CreateVectorIndexParams) => Promise<void>;
   dropVectorIndex?: (params: DropVectorIndexParams) => Promise<void>;
+  /**
+   * Single-statement hybrid search: both sources, RRF fusion, liveness
+   * join, and node hydration composed into ONE statement — replacing the
+   * facade's two search round trips plus id-hydration fetch. Optional;
+   * the store falls back to the multi-statement path when unset (custom
+   * backends, engines without window functions). Same liveness contract
+   * as `vectorSearch` / `fulltextSearch`.
+   */
+  hybridSearch?: (
+    params: HybridSearchParams,
+  ) => Promise<readonly HybridSearchRow[]>;
 
   // === Fulltext Operations (optional - depends on fulltext capabilities) ===
   upsertFulltext?: (params: UpsertFulltextParams) => Promise<void>;

--- a/packages/typegraph/src/store/search.ts
+++ b/packages/typegraph/src/store/search.ts
@@ -722,6 +722,84 @@ export async function executeHybridSearch<N = Node>(
     }
   }
 
+  // Single-statement fast path: one kind, backend support. Both sources,
+  // fusion, liveness, and hydration compose into ONE statement (see
+  // `buildHybridSearchStatement`) — the multi-statement path below remains
+  // for kind expansions and backends without the member.
+  if (
+    backend.hybridSearch !== undefined &&
+    fulltextKinds.length === 1 &&
+    vectorKinds.length === 1 &&
+    fulltextKinds[0] === vectorKinds[0]!.kind
+  ) {
+    const kind = fulltextKinds[0];
+    const { slot } = vectorKinds[0]!;
+    const candidates = candidatesByKind.get(kind);
+    const rows = await backend.hybridSearch({
+      graphId,
+      nodeKind: kind,
+      vector: {
+        fieldPath: options.vector.fieldPath,
+        queryEmbedding: options.vector.queryEmbedding,
+        metric: vectorMetric,
+        dimensions: slot.dimensions,
+        indexType: slot.indexType,
+        k: vectorK,
+        ...(options.vector.minScore === undefined ?
+          {}
+        : { minScore: options.vector.minScore }),
+        ...(options.vector.efSearch === undefined ?
+          {}
+        : { efSearch: options.vector.efSearch }),
+      },
+      fulltext: {
+        query: options.fulltext.query,
+        k: fulltextK,
+        ...(options.fulltext.mode ? { mode: options.fulltext.mode } : {}),
+        ...(options.fulltext.language ?
+          { language: options.fulltext.language }
+        : {}),
+        ...(options.fulltext.minScore === undefined ?
+          {}
+        : { minScore: options.fulltext.minScore }),
+        ...(options.fulltext.includeSnippets === undefined ?
+          {}
+        : { includeSnippets: options.fulltext.includeSnippets }),
+      },
+      fusion: { k: fusionK, vectorWeight, fulltextWeight },
+      limit: options.limit,
+      ...(offset === 0 ? {} : { offset }),
+      ...(candidates === undefined ? {} : { candidates }),
+    });
+    return rows.map((row, index) => {
+      const typedNode = rowToNode(row.node) as N;
+      return {
+        node: typedNode,
+        score: row.fusedScore,
+        rank: index + 1,
+        ...(row.vectorRank !== undefined && row.vectorScore !== undefined ?
+          {
+            vector: {
+              node: typedNode,
+              score: row.vectorScore,
+              rank: row.vectorRank,
+            },
+          }
+        : {}),
+        ...(row.fulltextRank !== undefined && row.fulltextScore !== undefined ?
+          {
+            fulltext: {
+              node: typedNode,
+              score: row.fulltextScore,
+              rank: row.fulltextRank,
+              ...(row.snippet === undefined ? {} : { snippet: row.snippet }),
+            },
+          }
+        : {}),
+      };
+    });
+  }
+
   const vectorPromise = Promise.all(
     vectorKinds.map(
       async ({ kind, slot }): Promise<readonly RankedSourceRow[]> => {

--- a/packages/typegraph/tests/hybrid-single-statement.test.ts
+++ b/packages/typegraph/tests/hybrid-single-statement.test.ts
@@ -357,6 +357,26 @@ describe("single-statement hybrid search", () => {
           hits: fallback.map((hit) => projectHit(hit)),
         });
       }
+
+      // Invalid source depths reject identically on both paths — the fast
+      // path must not skip the boundary validation the fallback applies.
+      const invalidDepth = {
+        vector: {
+          fieldPath: FIELD_PATH,
+          queryEmbedding: QUERY_EMBEDDING,
+          k: 0,
+        },
+        fulltext: { query: FULLTEXT_QUERY },
+        limit: 3,
+      } as const;
+      await expect(
+        store.search.hybrid("Document", invalidDepth),
+        "native path must reject k: 0",
+      ).rejects.toThrow(/positive integer/);
+      await expect(
+        fallbackStore.search.hybrid("Document", invalidDepth),
+        "fallback path must reject k: 0",
+      ).rejects.toThrow(/positive integer/);
     } finally {
       await cleanup();
     }
@@ -374,5 +394,37 @@ describe("single-statement hybrid search", () => {
       return;
     }
     await runScenario(postgresDescriptor);
+  });
+
+  it("[postgres-pgvector] hides hybridSearch when window functions are disabled", async (ctx) => {
+    if (postgresPool === undefined) {
+      skipTest(ctx);
+      return;
+    }
+    // A capability profile without window functions cannot run the
+    // ROW_NUMBER() fusion statement; the member must be absent so the
+    // store's multi-statement fallback engages.
+    const { cleanup } = await postgresDescriptor.create();
+    try {
+      const noWindowBackend = createPostgresBackend(
+        drizzleNodePostgres(postgresPool),
+        { capabilities: { windowFunctions: false } },
+      );
+      expect(noWindowBackend.hybridSearch).toBeUndefined();
+
+      const store = await seedStore(noWindowBackend);
+      const vectorSpy = vi.spyOn(
+        noWindowBackend as {
+          vectorSearch: NonNullable<GraphBackend["vectorSearch"]>;
+        },
+        "vectorSearch",
+      );
+      const hits = await runHybrid(store, { limit: 4 });
+      expect(hits.length).toBeGreaterThan(0);
+      expect(vectorSpy).toHaveBeenCalled();
+      vectorSpy.mockRestore();
+    } finally {
+      await cleanup();
+    }
   });
 });

--- a/packages/typegraph/tests/hybrid-single-statement.test.ts
+++ b/packages/typegraph/tests/hybrid-single-statement.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Single-statement hybrid search: `backend.hybridSearch` composes both
+ * sources, RRF fusion, liveness, and node hydration into ONE statement.
+ *
+ * Two contracts pinned here, across the backend matrix:
+ *
+ * 1. ROUND TRIPS — on the fast path the facade calls neither
+ *    `backend.vectorSearch`, `backend.fulltextSearch`, nor the hydration
+ *    fetch (`getNodes`). One backend call in, hits out.
+ * 2. PARITY — the fused statement returns the same hits (ids, ranks,
+ *    scores, sub-results, snippets) as the multi-statement JS-fusion
+ *    path, for defaults, custom fusion weights/k, per-source minScore,
+ *    snippets, a `where` filter, and offset pagination.
+ *
+ * The multi-statement reference runs through the same facade against a
+ * shim backend whose `hybridSearch` is hidden — the fallback the store
+ * keeps for kind expansions, custom backends, and profiles without
+ * window functions.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { type Client, createClient } from "@libsql/client";
+import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { defineGraph, defineNode, searchable } from "../src";
+import { generatePostgresMigrationSQL } from "../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../src/backend/postgres";
+import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { type GraphBackend } from "../src/backend/types";
+import { embedding } from "../src/core/embedding";
+import { createStoreWithSchema } from "../src/store";
+import { type HybridSearchHit } from "../src/store/search";
+
+const GRAPH_ID = "hybrid_single_stmt";
+const FIELD_PATH = "embedding";
+const EMBEDDING_DIMENSIONS = 3;
+
+const QUERY_EMBEDDING: readonly number[] = [1, 0, 0];
+const FULLTEXT_QUERY = "signal";
+
+const Document = defineNode("Document", {
+  schema: z.object({
+    title: searchable({ language: "english" }),
+    category: z.string(),
+    embedding: embedding(EMBEDDING_DIMENSIONS),
+  }),
+});
+
+function buildGraph() {
+  return defineGraph({
+    id: GRAPH_ID,
+    nodes: { Document: { type: Document } },
+    edges: {},
+  });
+}
+
+/**
+ * Vector and fulltext rankings deliberately DISAGREE (dense term matches
+ * on the far vectors, sparse on the near ones) so RRF fusion has real
+ * work to do and any rank-handling drift between the SQL and JS fusion
+ * paths shows up as reordering.
+ */
+const CORPUS = [
+  { id: "d1", title: "signal", category: "a", embedding: [1, 0, 0] },
+  {
+    id: "d2",
+    title: "signal signal signal signal",
+    category: "b",
+    embedding: [0, 1, 0],
+  },
+  { id: "d3", title: "signal signal", category: "a", embedding: [0.9, 0.3, 0] },
+  {
+    id: "d4",
+    title: "signal signal signal",
+    category: "b",
+    embedding: [0.2, 0.9, 0.1],
+  },
+  {
+    id: "d5",
+    title: "faint signal here",
+    category: "a",
+    embedding: [0.7, 0.7, 0],
+  },
+  {
+    id: "d6",
+    title: "signal boost relay",
+    category: "b",
+    embedding: [0.5, 0.8, 0.2],
+  },
+] as const;
+
+type ScopedOptions = Readonly<{
+  limit: number;
+  offset?: number;
+  fusion?: Readonly<{
+    k?: number;
+    weights?: Readonly<{ vector?: number; fulltext?: number }>;
+  }>;
+  vectorMinScore?: number;
+  includeSnippets?: boolean;
+  whereCategory?: string;
+}>;
+
+const OPTION_CASES: readonly Readonly<{
+  label: string;
+  options: ScopedOptions;
+}>[] = [
+  { label: "defaults", options: { limit: 4 } },
+  {
+    label: "custom fusion weights and k",
+    options: {
+      limit: 4,
+      fusion: { k: 10, weights: { vector: 2, fulltext: 0.5 } },
+    },
+  },
+  { label: "vector minScore", options: { limit: 4, vectorMinScore: 0.5 } },
+  { label: "snippets", options: { limit: 4, includeSnippets: true } },
+  { label: "where filter", options: { limit: 3, whereCategory: "a" } },
+  { label: "offset page", options: { limit: 2, offset: 2 } },
+];
+
+function skipTest(ctx: { skip: () => void }): void {
+  ctx.skip();
+}
+
+// ============================================================
+// Backend matrix
+// ============================================================
+
+type BackendCleanup = () => Promise<void> | void;
+
+type CreatedBackend = Readonly<{
+  backend: GraphBackend;
+  cleanup: BackendCleanup;
+}>;
+
+type BackendDescriptor = Readonly<{
+  label: string;
+  create: () => Promise<CreatedBackend>;
+}>;
+
+const localSqliteDescriptor: BackendDescriptor = {
+  label: "local-sqlite-vec",
+  create() {
+    const { backend } = createLocalSqliteBackend();
+    return Promise.resolve({
+      backend,
+      cleanup: () => backend.close(),
+    });
+  },
+};
+
+function libsqlDescriptor(): BackendDescriptor & { tempDir: string } {
+  const temporaryDir = mkdtempSync(path.join(tmpdir(), "tg-hybrid-stmt-"));
+  let counter = 0;
+  return {
+    label: "libsql-file",
+    tempDir: temporaryDir,
+    async create() {
+      const client: Client = createClient({
+        url: `file:${path.join(temporaryDir, `hybrid-${counter++}.db`)}`,
+      });
+      const { backend } = await createLibsqlBackend(client);
+      return {
+        backend,
+        cleanup: async () => {
+          await backend.close();
+          client.close();
+        },
+      };
+    },
+  };
+}
+
+// ============================================================
+// Scenario
+// ============================================================
+
+async function seedStore(backend: GraphBackend) {
+  const [store] = await createStoreWithSchema(buildGraph(), backend);
+  for (const seed of CORPUS) {
+    await store.nodes.Document.create(
+      { title: seed.title, category: seed.category, embedding: seed.embedding },
+      { id: seed.id },
+    );
+  }
+  return store;
+}
+
+function runHybrid(
+  store: Awaited<ReturnType<typeof seedStore>>,
+  options: ScopedOptions,
+) {
+  return store.search.hybrid("Document", {
+    vector: {
+      fieldPath: FIELD_PATH,
+      queryEmbedding: QUERY_EMBEDDING,
+      ...(options.vectorMinScore === undefined ?
+        {}
+      : { minScore: options.vectorMinScore }),
+    },
+    fulltext: {
+      query: FULLTEXT_QUERY,
+      ...(options.includeSnippets === undefined ?
+        {}
+      : { includeSnippets: options.includeSnippets }),
+    },
+    limit: options.limit,
+    ...(options.offset === undefined ? {} : { offset: options.offset }),
+    ...(options.fusion === undefined ? {} : { fusion: options.fusion }),
+    ...(options.whereCategory === undefined ?
+      {}
+    : {
+        where: (document: { category: { eq: (v: string) => unknown } }) =>
+          document.category.eq(options.whereCategory!),
+      }),
+  } as never);
+}
+
+/** The comparable projection of one hybrid hit. */
+function projectHit(hit: HybridSearchHit) {
+  return {
+    id: hit.node.id,
+    rank: hit.rank,
+    score: Number(hit.score.toFixed(10)),
+    vectorRank: hit.vector?.rank,
+    vectorScore:
+      hit.vector === undefined ?
+        undefined
+      : Number(hit.vector.score.toFixed(6)),
+    fulltextRank: hit.fulltext?.rank,
+    hasSnippet: hit.fulltext?.snippet !== undefined,
+  };
+}
+
+describe("single-statement hybrid search", () => {
+  const libsql = libsqlDescriptor();
+
+  const TEST_DATABASE_URL =
+    process.env.POSTGRES_URL ??
+    "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+  let postgresPool: Pool | undefined;
+
+  beforeAll(async () => {
+    if (!process.env.POSTGRES_URL) return;
+    const pool = new Pool({
+      connectionString: TEST_DATABASE_URL,
+      connectionTimeoutMillis: 5000,
+    });
+    try {
+      await pool.query("SELECT 1");
+      postgresPool = pool;
+    } catch {
+      await pool.end().catch(() => {
+        // Unreachable Postgres degrades to "skip".
+      });
+    }
+  });
+
+  afterAll(async () => {
+    rmSync(libsql.tempDir, { recursive: true, force: true });
+    if (postgresPool !== undefined) await postgresPool.end();
+  });
+
+  const postgresDescriptor: BackendDescriptor = {
+    label: "postgres-pgvector",
+    async create() {
+      const pool = postgresPool!;
+      await pool.query(`
+        DROP TABLE IF EXISTS typegraph_index_materializations CASCADE;
+        DROP TABLE IF EXISTS typegraph_node_embeddings CASCADE;
+        DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
+        DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;
+        DROP TABLE IF EXISTS typegraph_edges CASCADE;
+        DROP TABLE IF EXISTS typegraph_nodes CASCADE;
+        DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+      `);
+      const perField = await pool.query<{ tablename: string }>(
+        String.raw`SELECT tablename FROM pg_tables
+          WHERE schemaname = 'public' AND tablename LIKE 'tg_vec\_%'`,
+      );
+      for (const { tablename } of perField.rows) {
+        await pool.query(`DROP TABLE IF EXISTS "${tablename}" CASCADE`);
+      }
+      await pool.query(generatePostgresMigrationSQL());
+
+      const backend = createPostgresBackend(drizzleNodePostgres(pool));
+      return {
+        backend,
+        cleanup: () => {
+          // Shared pool, closed once in afterAll.
+        },
+      };
+    },
+  };
+
+  async function runScenario(descriptor: BackendDescriptor): Promise<void> {
+    const { backend, cleanup } = await descriptor.create();
+    try {
+      if (backend.capabilities.vector?.supported !== true) return;
+      expect(backend.hybridSearch).toBeDefined();
+      const store = await seedStore(backend);
+
+      // --- Round trips: the fast path must not touch the per-source
+      //     searches or the hydration fetch. ---
+      const vectorSpy = vi.spyOn(
+        backend as { vectorSearch: NonNullable<GraphBackend["vectorSearch"]> },
+        "vectorSearch",
+      );
+      const fulltextSpy = vi.spyOn(
+        backend as {
+          fulltextSearch: NonNullable<GraphBackend["fulltextSearch"]>;
+        },
+        "fulltextSearch",
+      );
+      const getNodesSpy = vi.spyOn(
+        backend as { getNodes: NonNullable<GraphBackend["getNodes"]> },
+        "getNodes",
+      );
+      const hits = await runHybrid(store, { limit: 4 });
+      expect(hits.length).toBeGreaterThan(0);
+      expect(vectorSpy).not.toHaveBeenCalled();
+      expect(fulltextSpy).not.toHaveBeenCalled();
+      expect(getNodesSpy).not.toHaveBeenCalled();
+      vectorSpy.mockRestore();
+      fulltextSpy.mockRestore();
+      getNodesSpy.mockRestore();
+
+      // --- Parity vs the multi-statement path, option case by case. ---
+      // Hiding hybridSearch forces the store's fallback; both paths run
+      // through the same facade on the same data.
+      const fallbackBackend = new Proxy(backend, {
+        get(target, property, receiver) {
+          if (property === "hybridSearch") return;
+          return Reflect.get(target, property, receiver) as unknown;
+        },
+      });
+      const [fallbackStore] = await createStoreWithSchema(
+        buildGraph(),
+        fallbackBackend,
+      );
+
+      for (const { label, options } of OPTION_CASES) {
+        const native = await runHybrid(store, options);
+        const fallback = await runHybrid(fallbackStore, options);
+        expect({
+          case: label,
+          hits: native.map((hit) => projectHit(hit)),
+        }).toEqual({
+          case: label,
+          hits: fallback.map((hit) => projectHit(hit)),
+        });
+      }
+    } finally {
+      await cleanup();
+    }
+  }
+
+  for (const descriptor of [localSqliteDescriptor, libsql]) {
+    it(`[${descriptor.label}] fuses in one statement with multi-statement parity`, async () => {
+      await runScenario(descriptor);
+    });
+  }
+
+  it("[postgres-pgvector] fuses in one statement with multi-statement parity", async (ctx) => {
+    if (postgresPool === undefined) {
+      skipTest(ctx);
+      return;
+    }
+    await runScenario(postgresDescriptor);
+  });
+});


### PR DESCRIPTION
Stacked on #203 (which stacks on #202). Third slice of the search-unification work: hybrid drops from three round trips (two searches + hydration fetch, JS fusion) to **one statement** on the built-in backends.

## Design

New optional `GraphBackend.hybridSearch(params)`: the store facade resolves all policy (per-source `k`, fusion constants, the shared candidate subquery) and the backend composes SQL:

- Vector source = the active `VectorStrategy`'s own search SQL (ANN forms included) over the same candidates as the fulltext source.
- Fusion in SQL: per-source `ROW_NUMBER()` ranks → two-branch `UNION ALL` + `GROUP BY` weighted RRF (`Σ weight/(k+rank)`). No FULL OUTER JOIN (absent from older SQLite builds); `* 1.0` forces float division so integer binds can't zero out contributions on Postgres.
- Liveness join + full node hydration in the same statement — the facade builds hits straight from the rows.
- Postgres wraps the statement in the existing GUC machinery (`efSearch`, iterative scans); `runVectorSearch` generalized over the row type.
- Fallback preserved: kind expansions (`includeSubClasses`), custom backends without the member, and capability profiles with `windowFunctions: false` keep the multi-statement path with identical results. Both built-in backends gate the member on `capabilities.windowFunctions` (review finding — Postgres initially exposed it unconditionally); gating lives backend-side deliberately, since the member's presence means "this backend can fuse in one statement" and a custom backend could implement it without window functions.
- Source depths are validated at the backend boundary on the fast path (review finding): `params.vector.k` goes through the same `assertVectorSearchLimit` the fallback's `vectorSearch` applies, and the fulltext depth is validated inside `buildFulltextSearch` — `{ vector: { k: 0 } }` rejects identically on both paths.

## Tests

`tests/hybrid-single-statement.test.ts`, across local sqlite-vec / libSQL / Postgres:
1. **Round trips**: spies prove the fast path calls neither `vectorSearch`, `fulltextSearch`, nor `getNodes`.
2. **Regressions from review**: `k: 0` rejects identically on native and fallback paths; a Postgres backend built with `capabilities: { windowFunctions: false }` exposes no `hybridSearch` and demonstrably runs the fallback (per-source spy fires).
3. **Parity**: identical hits (ids, ranks, fused scores to 1e-10, sub-results, snippet presence) vs the multi-statement path run through the same facade (member hidden via Proxy), for defaults, custom fusion weights/k, vector `minScore`, snippets, `where` filter, and offset pages. Corpus built so the two sources' rankings disagree — fusion drift shows up as reordering.

## Measurement (honest)

The win is structural where statements are expensive: serverless HTTP drivers (every statement is an HTTP request), D1/Durable Objects, remote Postgres — 3 round trips → 1. On a **local docker pool** the multi-statement path's `Promise.all` parallelism roughly offsets the saved round trips: interleaved medians on a heavily loaded host were 32.0ms (single) vs 28.3ms (parallel multi) with ANN materialized; on quiet-host samples the single statement measured 7.9ms warm. Docs state this tradeoff plainly.

