### PR TITLE
feat: opt-in approximate retrieval for inline similarTo

### DIFF
--- a/.changeset/similar-to-approximate.md
+++ b/.changeset/similar-to-approximate.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+feat: `.similarTo(vector, k, { approximate: true })` — opt-in approximate retrieval for the inline vector predicate. Each declaring kind's relevance branch compiles to the engine's native ANN search form (vec0 `MATCH … k=`, libSQL `vector_top_k`, pgvector's index-eligible scan), scoped to the query's candidate nodes via the same pushdown the search facade uses, so composed predicates and traversals still constrain results. Never applied silently: the default remains the exact distance scan, and slots declared `indexType: "none"` keep it even with the opt-in.

--- a/apps/docs/src/content/docs/semantic-search.md
+++ b/apps/docs/src/content/docs/semantic-search.md
@@ -467,6 +467,33 @@ const similar = await store
   .execute();
 ```
 
+### Approximate retrieval for `.similarTo()` (opt-in)
+
+By default `.similarTo()` ranks with an exact distance scan — correct at any
+scale, and index-served by the PostgreSQL planner where the plan shape
+allows. When a kind declares an ANN index (`embedding(n)` defaults to
+`hnsw`), you can opt the predicate into the engine's native approximate
+retrieval:
+
+```typescript
+const similar = await store
+  .query()
+  .from("Document", "d")
+  .whereNode("d", (d) =>
+    d.embedding
+      .similarTo(queryEmbedding, 10, { approximate: true })
+      .and(d.status.eq("published")),
+  )
+  .select((ctx) => ctx.d)
+  .execute();
+```
+
+This is a semantic change, never applied silently: results are subject to
+the index's recall. Composed predicates constrain the ANN candidate set —
+exactly on pgvector and sqlite-vec, bounded by over-fetch on libSQL
+DiskANN. A kind declared with `indexType: "none"` keeps the exact scan even
+with the opt-in.
+
 ### Scoped facade search: filters, pagination, subclasses
 
 `store.search.vector` (and `fulltext` / `hybrid`) accept a `where`

--- a/packages/typegraph/src/query/ast.ts
+++ b/packages/typegraph/src/query/ast.ts
@@ -265,6 +265,11 @@ export type VectorSimilarityPredicate = Readonly<{
   limit: number;
   /** Optional minimum similarity score (0-1 for cosine) */
   minScore?: number;
+  /**
+   * Retrieve each kind's candidates via the engine's native ANN structure
+   * instead of an exact distance scan (see `SimilarToOptions.approximate`).
+   */
+  approximate?: boolean;
 }>;
 
 // ============================================================

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -839,7 +839,20 @@ export function buildStandardEmbeddingsCte(
     // re-derived from the strategy's score convention (cosine score =
     // `1 - distance`; l2 / inner_product score = raw distance) so the
     // shared ORDER BY / ROW_NUMBER machinery below is untouched.
-    if (vectorPredicate.approximate === true && slotDescriptor !== undefined) {
+    //
+    // The ANN path additionally requires the effective metric to MATCH the
+    // slot's declared metric: every engine materializes metric-specific
+    // ANN structures (vec0 bakes `distance_metric` into the virtual table,
+    // libSQL's DiskANN index and pgvector's operator class are built for
+    // one metric), so retrieving by the declared metric and re-scoring
+    // under an overridden one would silently miss the override metric's
+    // true nearest neighbors. A mismatched override falls back to the
+    // exact scan below — correct for any metric, like `indexType: "none"`.
+    if (
+      vectorPredicate.approximate === true &&
+      slotDescriptor !== undefined &&
+      branchMetric === slotDescriptor.metric
+    ) {
       const kindCandidates = sql`SELECT node_id FROM ${scopedNodes} WHERE ${sql.raw(`${SCOPED_RELEVANCE_NODES_ALIAS}.node_kind`)} = ${kind}`;
       const annSql = vectorStrategy.buildSearch(
         {

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -848,20 +848,23 @@ export function buildStandardEmbeddingsCte(
     // under an overridden one would silently miss the override metric's
     // true nearest neighbors. A mismatched override falls back to the
     // exact scan below — correct for any metric, like `indexType: "none"`.
-    if (
-      vectorPredicate.approximate === true &&
-      slotDescriptor !== undefined &&
-      branchMetric === slotDescriptor.metric
-    ) {
+    const annSlot =
+      (
+        vectorPredicate.approximate === true &&
+        branchMetric === slotDescriptor?.metric
+      ) ?
+        slotDescriptor
+      : undefined;
+    if (annSlot !== undefined) {
       const kindCandidates = sql`SELECT node_id FROM ${scopedNodes} WHERE ${sql.raw(`${SCOPED_RELEVANCE_NODES_ALIAS}.node_kind`)} = ${kind}`;
       const annSql = vectorStrategy.buildSearch(
         {
           graphId,
           nodeKind: kind,
           fieldPath,
-          dimensions: slotDescriptor.dimensions,
+          dimensions: annSlot.dimensions,
           metric: branchMetric,
-          indexType: slotDescriptor.indexType,
+          indexType: annSlot.indexType,
         },
         {
           graphId,
@@ -869,8 +872,8 @@ export function buildStandardEmbeddingsCte(
           fieldPath,
           queryEmbedding,
           metric: branchMetric,
-          dimensions: slotDescriptor.dimensions,
-          indexType: slotDescriptor.indexType,
+          dimensions: annSlot.dimensions,
+          indexType: annSlot.indexType,
           limit: vectorPredicate.limit,
           ...(minScore === undefined ? {} : { minScore }),
         },

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -770,14 +770,19 @@ type BuildStandardEmbeddingsCteInput = Readonly<{
 
 /**
  * Builds the relevance CTE for a `field.similarTo(...)` predicate in the query
- * builder. NOTE: this path is exact-but-brute-force — it splices the strategy's
- * `distanceExpression` and full-scans each declaring kind's per-field table
- * (`ORDER BY distance LIMIT k`); it does NOT use a strategy's engine-native ANN
- * (vec0 `MATCH … k=`, libSQL `vector_top_k`, pgvector's HNSW scan), which is
- * only reachable through the `store.search.vector` / `store.search.hybrid`
- * facade. For ANN-accelerated retrieval at scale use the facade; use
- * `.where(similarTo())` when you need to compose vector similarity with
- * arbitrary predicates / traversals in one query and exact ranking is fine.
+ * builder.
+ *
+ * Default (exact): splices the strategy's `distanceExpression` and scans each
+ * declaring kind's per-field table (`ORDER BY distance LIMIT k`). On
+ * pgvector >= 0.8 the planner can serve this shape from an HNSW index for a
+ * single-kind alias; on the SQLite-family engines it is a full scan.
+ *
+ * Opt-in (`{ approximate: true }`): each declaring kind's branch compiles to
+ * the strategy's own search SQL — the engine-native ANN form (vec0
+ * `MATCH … k=`, libSQL `vector_top_k`, pgvector's index-eligible scan) —
+ * scoped to the alias's candidate nodes via the same `candidates` pushdown
+ * the search facade uses. Semantics become approximate (index recall); a
+ * slot declared `indexType: "none"` degrades to the exact scan.
  */
 export function buildStandardEmbeddingsCte(
   input: BuildStandardEmbeddingsCteInput,
@@ -819,13 +824,52 @@ export function buildStandardEmbeddingsCte(
   // engines and the hybrid RRF / vector ORDER BY paths are untouched.
   const branches = declaringKinds.map((kind) => {
     const tableName = vectorStrategy.tableName(graphId, kind, fieldPath);
+    const slotDescriptor = vectorSlots?.get(vectorSlotKey(kind, fieldPath));
     // Use the predicate's explicit metric if given, else this kind's DECLARED
     // metric (the one its ANN index was built for). Resolving per kind keeps an
     // includeSubClasses union correct when subkinds declare different metrics.
-    const branchMetric =
-      metric ??
-      vectorSlots?.get(vectorSlotKey(kind, fieldPath))?.metric ??
-      "cosine";
+    const branchMetric = metric ?? slotDescriptor?.metric ?? "cosine";
+
+    // Approximate opt-in: retrieve this kind's candidates via the
+    // strategy's own search SQL — the engine's native ANN form — scoped to
+    // the alias's candidate nodes (predicates, currency, traversal
+    // reachability) via the same `candidates` pushdown the search facade
+    // uses. A slot declared `indexType: "none"` compiles to the strategy's
+    // exact scan, so the opt-in degrades to today's semantics. Distance is
+    // re-derived from the strategy's score convention (cosine score =
+    // `1 - distance`; l2 / inner_product score = raw distance) so the
+    // shared ORDER BY / ROW_NUMBER machinery below is untouched.
+    if (vectorPredicate.approximate === true && slotDescriptor !== undefined) {
+      const kindCandidates = sql`SELECT node_id FROM ${scopedNodes} WHERE ${sql.raw(`${SCOPED_RELEVANCE_NODES_ALIAS}.node_kind`)} = ${kind}`;
+      const annSql = vectorStrategy.buildSearch(
+        {
+          graphId,
+          nodeKind: kind,
+          fieldPath,
+          dimensions: slotDescriptor.dimensions,
+          metric: branchMetric,
+          indexType: slotDescriptor.indexType,
+        },
+        {
+          graphId,
+          nodeKind: kind,
+          fieldPath,
+          queryEmbedding,
+          metric: branchMetric,
+          dimensions: slotDescriptor.dimensions,
+          indexType: slotDescriptor.indexType,
+          limit: vectorPredicate.limit,
+          ...(minScore === undefined ? {} : { minScore }),
+        },
+        kindCandidates,
+      );
+      const distanceFromScore =
+        branchMetric === "cosine" ? sql.raw("(1.0 - score)") : sql.raw("score");
+      return sql`
+        SELECT node_id, ${kind} AS node_kind, ${distanceFromScore} AS distance, score
+        FROM (${annSql}) AS tg_ann_src
+      `;
+    }
     const distanceExpr = vectorStrategy.distanceExpression(
       qualifyColumn(tableName, "embedding"),
       queryEmbedding,

--- a/packages/typegraph/src/query/predicates.ts
+++ b/packages/typegraph/src/query/predicates.ts
@@ -331,6 +331,17 @@ export type SimilarToOptions = Readonly<{
    * For inner_product: minimum inner product value.
    */
   minScore?: number;
+  /**
+   * Opt into approximate retrieval: each declaring kind's candidates come
+   * from the engine's native ANN structure (pgvector HNSW/IVFFlat scans,
+   * vec0 `MATCH … k=`, libSQL `vector_top_k`) instead of an exact
+   * distance scan. This is a SEMANTIC change — results are subject to the
+   * index's recall, and predicates composed alongside constrain the ANN
+   * candidate set (exact on pgvector/vec0; bounded by over-fetch on
+   * libSQL). A slot declared with `indexType: "none"` falls back to the
+   * exact scan. Default: exact.
+   */
+  approximate?: boolean;
 }>;
 
 /**
@@ -747,6 +758,9 @@ function vectorSimilarity(
     ...(options?.metric !== undefined && { metric: options.metric }),
     limit,
     ...(options?.minScore !== undefined && { minScore: options.minScore }),
+    ...(options?.approximate !== undefined && {
+      approximate: options.approximate,
+    }),
   };
   return predicate(expr);
 }

--- a/packages/typegraph/tests/similar-to-approximate.test.ts
+++ b/packages/typegraph/tests/similar-to-approximate.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Opt-in approximate retrieval for the inline `.similarTo()` predicate:
+ * `{ approximate: true }` compiles each declaring kind's relevance branch
+ * to the engine's native ANN search form (vec0 `MATCH … k=`, libSQL
+ * `vector_top_k`, pgvector's index-eligible scan), scoped to the alias's
+ * candidate nodes through the same pushdown the search facade uses.
+ *
+ * Pinned here, across the backend matrix:
+ * - PARITY: on a small corpus (where ANN recall is total) approximate
+ *   results equal exact results — plain, composed with a property
+ *   predicate, and fused with fulltext — so the opt-in changes retrieval
+ *   strategy, not semantics, at this scale.
+ * - COMPILE SHAPE: the approximate branch actually reaches the ANN form
+ *   (`tg_ann_src` wrapper; vec0 `MATCH`; libSQL `vector_top_k`), and the
+ *   default path never does.
+ * - DEGRADATION: a slot declared `indexType: "none"` compiles the opt-in
+ *   to the strategy's exact scan (no MATCH), with identical results.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { type Client, createClient } from "@libsql/client";
+import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph, defineNode, searchable } from "../src";
+import { generatePostgresMigrationSQL } from "../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../src/backend/postgres";
+import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { type GraphBackend } from "../src/backend/types";
+import { embedding } from "../src/core/embedding";
+import { createStoreWithSchema } from "../src/store";
+
+const GRAPH_ID = "similar_to_ann";
+const EMBEDDING_DIMENSIONS = 3;
+const QUERY_EMBEDDING: readonly number[] = [1, 0, 0];
+
+const Document = defineNode("AnnDoc", {
+  schema: z.object({
+    category: z.string(),
+    title: searchable({ language: "english" }),
+    embedding: embedding(EMBEDDING_DIMENSIONS),
+  }),
+});
+
+/** A second kind whose slot declares no ANN index. */
+const FlatDocument = defineNode("FlatDoc", {
+  schema: z.object({
+    category: z.string(),
+    embedding: embedding(EMBEDDING_DIMENSIONS, { indexType: "none" }),
+  }),
+});
+
+function buildGraph() {
+  return defineGraph({
+    id: GRAPH_ID,
+    nodes: { AnnDoc: { type: Document }, FlatDoc: { type: FlatDocument } },
+    edges: {},
+  });
+}
+
+const CORPUS = [
+  { id: "d1", category: "a", embedding: [1, 0, 0] },
+  { id: "d2", category: "b", embedding: [0.95, 0.2, 0] },
+  { id: "d3", category: "a", embedding: [0.8, 0.6, 0] },
+  { id: "d4", category: "b", embedding: [0.5, 0.8, 0.2] },
+  { id: "d5", category: "a", embedding: [0.2, 0.9, 0.3] },
+  { id: "d6", category: "b", embedding: [0, 1, 0] },
+] as const;
+
+function skipTest(ctx: { skip: () => void }): void {
+  ctx.skip();
+}
+
+type BackendCleanup = () => Promise<void> | void;
+
+type CreatedBackend = Readonly<{
+  backend: GraphBackend;
+  cleanup: BackendCleanup;
+  /** Substring proving the engine-native ANN form was compiled. */
+  annMarker: string;
+}>;
+
+type BackendDescriptor = Readonly<{
+  label: string;
+  create: () => Promise<CreatedBackend>;
+}>;
+
+const localSqliteDescriptor: BackendDescriptor = {
+  label: "local-sqlite-vec",
+  create() {
+    const { backend } = createLocalSqliteBackend();
+    return Promise.resolve({
+      backend,
+      cleanup: () => backend.close(),
+      annMarker: "MATCH",
+    });
+  },
+};
+
+function libsqlDescriptor(): BackendDescriptor & { tempDir: string } {
+  const temporaryDir = mkdtempSync(path.join(tmpdir(), "tg-similar-ann-"));
+  let counter = 0;
+  return {
+    label: "libsql-file",
+    tempDir: temporaryDir,
+    async create() {
+      const client: Client = createClient({
+        url: `file:${path.join(temporaryDir, `ann-${counter++}.db`)}`,
+      });
+      const { backend } = await createLibsqlBackend(client);
+      return {
+        backend,
+        cleanup: async () => {
+          await backend.close();
+          client.close();
+        },
+        annMarker: "vector_top_k",
+      };
+    },
+  };
+}
+
+async function seedStore(backend: GraphBackend) {
+  const [store] = await createStoreWithSchema(buildGraph(), backend);
+  for (const seed of CORPUS) {
+    await store.nodes.AnnDoc.create(
+      {
+        category: seed.category,
+        title: `signal document ${seed.id}`,
+        embedding: seed.embedding,
+      },
+      { id: seed.id },
+    );
+    await store.nodes.FlatDoc.create(
+      { category: seed.category, embedding: seed.embedding },
+      { id: `flat-${seed.id}` },
+    );
+  }
+  await store.materializeIndexes();
+  return store;
+}
+
+type Store = Awaited<ReturnType<typeof seedStore>>;
+
+function documentQuery(
+  store: Store,
+  kind: "AnnDoc" | "FlatDoc",
+  options: Readonly<{ approximate?: boolean; category?: string }>,
+) {
+  const query = store
+    .query()
+    .from(kind, "d")
+    .whereNode("d", (document) => {
+      const similar = document.embedding.similarTo(QUERY_EMBEDDING, 4, {
+        ...(options.approximate === undefined ?
+          {}
+        : { approximate: options.approximate }),
+      });
+      return options.category === undefined ?
+          similar
+        : similar.and(document.category.eq(options.category));
+    });
+  return query.select((ctx) => ({ id: ctx.d.id }));
+}
+
+async function ids(
+  query: Readonly<{ execute: () => Promise<readonly unknown[]> }>,
+): Promise<readonly string[]> {
+  const rows = await query.execute();
+  return rows.map((row) => (row as { id: string }).id);
+}
+
+async function runScenario(created: CreatedBackend): Promise<void> {
+  const { backend, cleanup, annMarker } = created;
+  try {
+    if (backend.capabilities.vector?.supported !== true) return;
+    const store = await seedStore(backend);
+
+    // --- Parity: plain, filtered, and on the unindexed slot. ---
+    const exact = await ids(documentQuery(store, "AnnDoc", {}));
+    const approximate = await ids(
+      documentQuery(store, "AnnDoc", { approximate: true }),
+    );
+    expect(approximate).toEqual(exact);
+
+    const exactFiltered = await ids(
+      documentQuery(store, "AnnDoc", { category: "a" }),
+    );
+    const approximateFiltered = await ids(
+      documentQuery(store, "AnnDoc", { approximate: true, category: "a" }),
+    );
+    expect(approximateFiltered).toEqual(exactFiltered);
+    expect(exactFiltered.length).toBeGreaterThan(0);
+
+    const flatExact = await ids(documentQuery(store, "FlatDoc", {}));
+    const flatApproximate = await ids(
+      documentQuery(store, "FlatDoc", { approximate: true }),
+    );
+    expect(flatApproximate).toEqual(flatExact);
+
+    // --- Fusion composition: the approximate vector CTE feeds the same
+    //     RRF machinery; fused rankings must match the exact path. ---
+    function fusedQuery(approximate: boolean) {
+      return store
+        .query()
+        .from("AnnDoc", "d")
+        .whereNode("d", (document) =>
+          document.$fulltext.matches("signal", 6).and(
+            document.embedding.similarTo(QUERY_EMBEDDING, 6, {
+              approximate,
+            }),
+          ),
+        )
+        .select((ctx) => ({ id: ctx.d.id }));
+    }
+    const fusedExact = await ids(fusedQuery(false));
+    const fusedApproximate = await ids(fusedQuery(true));
+    expect(fusedApproximate).toEqual(fusedExact);
+    expect(fusedExact.length).toBeGreaterThan(0);
+
+    // --- Compile shape. ---
+    const approximateSql = documentQuery(store, "AnnDoc", {
+      approximate: true,
+    }).toSQL().sql;
+    expect(approximateSql).toContain("tg_ann_src");
+    expect(approximateSql).toContain(annMarker);
+
+    const exactSql = documentQuery(store, "AnnDoc", {}).toSQL().sql;
+    expect(exactSql).not.toContain("tg_ann_src");
+
+    // The unindexed slot degrades to the strategy's exact scan even
+    // with the opt-in: wrapper present, ANN form absent (pgvector's
+    // scan shape is index-driven, so this only distinguishes on the
+    // SQLite-family engines whose ANN form is syntactic).
+    const flatSql = documentQuery(store, "FlatDoc", {
+      approximate: true,
+    }).toSQL().sql;
+    expect(flatSql).toContain("tg_ann_src");
+    if (annMarker !== "tg_ann_src") {
+      expect(flatSql).not.toContain(annMarker);
+    }
+  } finally {
+    await cleanup();
+  }
+}
+
+describe("similarTo approximate opt-in", () => {
+  const libsql = libsqlDescriptor();
+
+  const TEST_DATABASE_URL =
+    process.env.POSTGRES_URL ??
+    "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+  let postgresPool: Pool | undefined;
+
+  beforeAll(async () => {
+    if (!process.env.POSTGRES_URL) return;
+    const pool = new Pool({
+      connectionString: TEST_DATABASE_URL,
+      connectionTimeoutMillis: 5000,
+    });
+    try {
+      await pool.query("SELECT 1");
+      postgresPool = pool;
+    } catch {
+      await pool.end().catch(() => {
+        // Unreachable Postgres degrades to "skip".
+      });
+    }
+  });
+
+  afterAll(async () => {
+    rmSync(libsql.tempDir, { recursive: true, force: true });
+    if (postgresPool !== undefined) await postgresPool.end();
+  });
+
+  const postgresDescriptor: BackendDescriptor = {
+    label: "postgres-pgvector",
+    async create() {
+      const pool = postgresPool!;
+      await pool.query(`
+        DROP TABLE IF EXISTS typegraph_index_materializations CASCADE;
+        DROP TABLE IF EXISTS typegraph_node_embeddings CASCADE;
+        DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
+        DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;
+        DROP TABLE IF EXISTS typegraph_edges CASCADE;
+        DROP TABLE IF EXISTS typegraph_nodes CASCADE;
+        DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+      `);
+      const perField = await pool.query<{ tablename: string }>(
+        String.raw`SELECT tablename FROM pg_tables
+          WHERE schemaname = 'public' AND tablename LIKE 'tg_vec\_%'`,
+      );
+      for (const { tablename } of perField.rows) {
+        await pool.query(`DROP TABLE IF EXISTS "${tablename}" CASCADE`);
+      }
+      await pool.query(generatePostgresMigrationSQL());
+
+      const backend = createPostgresBackend(drizzleNodePostgres(pool));
+      return {
+        backend,
+        cleanup: () => {
+          // Shared pool, closed once in afterAll.
+        },
+        // pgvector's ANN form is the same ORDER BY/LIMIT scan shape — the
+        // approximate wrapper is the observable compile-level marker.
+        annMarker: "tg_ann_src",
+      };
+    },
+  };
+
+  for (const descriptor of [localSqliteDescriptor, libsql]) {
+    it(`[${descriptor.label}] approximate mode reaches the ANN form with small-corpus parity`, async () => {
+      await runScenario(await descriptor.create());
+    });
+  }
+
+  it("[postgres-pgvector] approximate mode reaches the ANN form with small-corpus parity", async (ctx) => {
+    if (postgresPool === undefined) {
+      skipTest(ctx);
+      return;
+    }
+    await runScenario(await postgresDescriptor.create());
+  });
+});

--- a/packages/typegraph/tests/similar-to-approximate.test.ts
+++ b/packages/typegraph/tests/similar-to-approximate.test.ts
@@ -47,6 +47,18 @@ const Document = defineNode("AnnDoc", {
   }),
 });
 
+/**
+ * Cosine-declared kind with magnitude-skewed vectors: the cosine-nearest
+ * doc to the query is NOT the l2-nearest, so ANN retrieval under the
+ * declared metric followed by l2 re-scoring would return the wrong row —
+ * the exact regression surface for a metric override + approximate.
+ */
+const MagDocument = defineNode("MagDoc", {
+  schema: z.object({
+    embedding: embedding(EMBEDDING_DIMENSIONS),
+  }),
+});
+
 /** A second kind whose slot declares no ANN index. */
 const FlatDocument = defineNode("FlatDoc", {
   schema: z.object({
@@ -58,7 +70,11 @@ const FlatDocument = defineNode("FlatDoc", {
 function buildGraph() {
   return defineGraph({
     id: GRAPH_ID,
-    nodes: { AnnDoc: { type: Document }, FlatDoc: { type: FlatDocument } },
+    nodes: {
+      AnnDoc: { type: Document },
+      FlatDoc: { type: FlatDocument },
+      MagDoc: { type: MagDocument },
+    },
     edges: {},
   });
 }
@@ -141,6 +157,14 @@ async function seedStore(backend: GraphBackend) {
       { id: `flat-${seed.id}` },
     );
   }
+  // Magnitude-skewed corpus: query [1,0,0] — cosine ranks mag-far first
+  // (collinear, huge magnitude), l2 ranks mag-near first.
+  await store.nodes.MagDoc.create({ embedding: [10, 0, 0] }, { id: "mag-far" });
+  await store.nodes.MagDoc.create(
+    { embedding: [0.9, 0.1, 0] },
+    { id: "mag-near" },
+  );
+  await store.nodes.MagDoc.create({ embedding: [0, 1, 0] }, { id: "mag-off" });
   await store.materializeIndexes();
   return store;
 }
@@ -202,6 +226,45 @@ async function runScenario(created: CreatedBackend): Promise<void> {
       documentQuery(store, "FlatDoc", { approximate: true }),
     );
     expect(flatApproximate).toEqual(flatExact);
+
+    // --- Metric override + approximate: the ANN structure is built for
+    //     the DECLARED metric, so an overridden metric must fall back to
+    //     the exact scan. The corpus makes the failure observable: cosine
+    //     top-1 is mag-far, l2 top-1 is mag-near — ANN-retrieval under
+    //     cosine re-scored as l2 would return mag-far. ---
+    function magQuery(options: Readonly<{ approximate?: boolean }>) {
+      return store
+        .query()
+        .from("MagDoc", "d")
+        .whereNode("d", (document) =>
+          document.embedding.similarTo(QUERY_EMBEDDING, 1, {
+            metric: "l2",
+            ...(options.approximate === undefined ?
+              {}
+            : { approximate: options.approximate }),
+          }),
+        )
+        .select((ctx) => ({ id: ctx.d.id }));
+    }
+    const l2Exact = await ids(magQuery({}));
+    expect(l2Exact).toEqual(["mag-near"]);
+    const l2Approximate = await ids(magQuery({ approximate: true }));
+    expect(l2Approximate).toEqual(["mag-near"]);
+    // The mismatched override compiled to the exact scan, not the ANN form.
+    expect(magQuery({ approximate: true }).toSQL().sql).not.toContain(
+      "tg_ann_src",
+    );
+    // Sanity: cosine ranking really does disagree on this corpus.
+    const cosineTop = await ids(
+      store
+        .query()
+        .from("MagDoc", "d")
+        .whereNode("d", (document) =>
+          document.embedding.similarTo(QUERY_EMBEDDING, 1),
+        )
+        .select((ctx) => ({ id: ctx.d.id })),
+    );
+    expect(cosineTop).toEqual(["mag-far"]);
 
     // --- Fusion composition: the approximate vector CTE feeds the same
     //     RRF machinery; fused rankings must match the exact path. ---


### PR DESCRIPTION
Stacked on #204 (→ #203 → #202). Final implementation slice of the search-unification work: the inline `.similarTo()` predicate — the only vector path composable with arbitrary predicates and traversals — gains an explicit opt-in to engine-native ANN retrieval.

## Design

`{ approximate: true }` on `SimilarToOptions`:

- Each declaring kind's relevance branch compiles to the active `VectorStrategy.buildSearch` SQL — the same engine-native ANN forms the facade uses (vec0 `MATCH … k=`, libSQL `vector_top_k`, pgvector's index-eligible scan) — **scoped to the alias's candidate nodes** through the `candidates` pushdown, so composed predicates, currency, and traversal reachability constrain the ANN candidate set (exactly on pgvector/vec0; over-fetch-bounded on libSQL DiskANN).
- Distance is re-derived from the strategy's score convention (cosine score = `1 − distance`; l2/inner_product = raw distance), so the surrounding UNION/ORDER BY/ROW_NUMBER machinery — including `fuseWith` RRF fusion — is untouched.
- **Never silent**: default remains the exact scan; `indexType: "none"` slots keep it even with the opt-in.
- **Metric-mismatch guard** (review finding): the ANN path also requires the effective metric to match the slot's *declared* metric — every engine materializes metric-specific ANN structures (vec0 bakes `distance_metric` into the virtual table; libSQL's DiskANN index and pgvector's operator class are built for one metric), so retrieving by the declared metric and re-scoring under an override would silently miss the override metric's true nearest neighbors. A mismatched override falls back to the exact scan (correct for any metric). Regression uses a magnitude-skewed corpus where cosine top-1 ≠ l2 top-1: `{ metric: "l2", approximate: true }` on a cosine-declared field must return the l2 winner and compile without the ANN wrapper — verified red without the gate (returns the cosine ANN candidate).

Context from the earlier spike: on pgvector ≥ 0.8 the *exact* single-kind shape already gets the HNSW index scan from the planner, so on Postgres this option mostly matters for multi-kind unions (per-branch inner LIMIT makes each branch index-eligible); on the SQLite family it's the only route to ANN for composed queries.

## Tests

`tests/similar-to-approximate.test.ts` across local sqlite-vec / libSQL / Postgres:
- **Parity** on a small corpus (where ANN recall is total): approximate ≡ exact — plain, composed with a property predicate, and fused with fulltext.
- **Compile shape**: the ANN form is actually reached (`tg_ann_src` wrapper; vec0 `MATCH`; libSQL `vector_top_k`) and the default path never compiles it.
- **Degradation**: `indexType: "none"` + opt-in ⇒ exact scan SQL, identical results.

The emitter docstring that declared this path "exact-but-brute-force, facade-only ANN" is rewritten to the current truth.

