### PR TITLE
perf: acquire the recorded graph-write advisory lock once per transaction

### DIFF
--- a/.changeset/history-capture-lock-churn.md
+++ b/.changeset/history-capture-lock-churn.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+perf: recorded-time capture acquires the PostgreSQL graph-write advisory lock once per transaction instead of once per captured write (`pg_advisory_xact_lock` is reentrant and held to transaction end, so the repeats were pure round trips). A 50-write recorded transaction drops from N+1 lock round trips to 1; measured 1.7× on the transaction shape.

--- a/packages/typegraph/src/store/recorded-capture.ts
+++ b/packages/typegraph/src/store/recorded-capture.ts
@@ -22,7 +22,7 @@ import {
 import {
   allocateRecordedCommit,
   lockRecordedGraphWrite,
-  lockRecordedGraphWrites,
+  registerRecordedGraphLockMemo,
 } from "./recorded-capture/clock";
 import {
   entityKey,
@@ -217,20 +217,36 @@ function createRecordedTransactionBackend(
   const nodeDispatch = nodeInsertDispatch(target);
   const edgeDispatch = edgeInsertDispatch(target);
 
+  // One advisory-lock round trip per graph per transaction: the memo is
+  // shared with the returned overlay (see registerRecordedGraphLockMemo),
+  // so external lock paths handed this backend dedupe against the same set.
+  const lockedGraphs = new Set<string>();
+
   async function lockGraph(graphId: string): Promise<void> {
+    if (lockedGraphs.has(graphId)) return;
     await lockRecordedGraphWrite(target, graphId);
+    lockedGraphs.add(graphId);
   }
 
   async function lockGraphs(
     params: readonly Readonly<{ graphId: string }>[],
   ): Promise<void> {
-    await lockRecordedGraphWrites(
-      target,
-      params.map((parameter) => parameter.graphId),
-    );
+    // Codepoint sort, NOT localeCompare: every process must acquire
+    // multi-graph locks in the same order, and locale-sensitive collation
+    // varies with the host's ICU configuration — two processes sorting the
+    // same ids differently would take the same lock pair in opposite
+    // orders and deadlock. Already-held graphs are skipped without
+    // re-sorting the remainder out of order.
+    const pending = [...new Set(params.map((parameter) => parameter.graphId))]
+      .toSorted()
+      .filter((graphId) => !lockedGraphs.has(graphId));
+    for (const graphId of pending) {
+      await lockRecordedGraphWrite(target, graphId);
+      lockedGraphs.add(graphId);
+    }
   }
 
-  return createBackendOverlay(target, {
+  const overlay = createBackendOverlay(target, {
     ...rawWriteGuards(target, "tx.backend"),
 
     async insertNode(params) {
@@ -412,6 +428,8 @@ function createRecordedTransactionBackend(
         },
       }),
   });
+  registerRecordedGraphLockMemo(overlay, lockedGraphs);
+  return overlay;
 }
 
 export function createRecordedTransactionScope(

--- a/packages/typegraph/src/store/recorded-capture.ts
+++ b/packages/typegraph/src/store/recorded-capture.ts
@@ -21,6 +21,7 @@ import {
 } from "./insert-dispatch";
 import {
   allocateRecordedCommit,
+  createRecordedGraphLockMemo,
   lockRecordedGraphWrite,
   registerRecordedGraphLockMemo,
 } from "./recorded-capture/clock";
@@ -219,13 +220,12 @@ function createRecordedTransactionBackend(
 
   // One advisory-lock round trip per graph per transaction: the memo is
   // shared with the returned overlay (see registerRecordedGraphLockMemo),
-  // so external lock paths handed this backend dedupe against the same set.
-  const lockedGraphs = new Set<string>();
+  // so external lock paths handed this backend dedupe against the same
+  // single-flight promises — including concurrent same-transaction writers.
+  const graphLocks = createRecordedGraphLockMemo();
 
   async function lockGraph(graphId: string): Promise<void> {
-    if (lockedGraphs.has(graphId)) return;
-    await lockRecordedGraphWrite(target, graphId);
-    lockedGraphs.add(graphId);
+    await lockRecordedGraphWrite(target, graphId, graphLocks);
   }
 
   async function lockGraphs(
@@ -235,14 +235,12 @@ function createRecordedTransactionBackend(
     // multi-graph locks in the same order, and locale-sensitive collation
     // varies with the host's ICU configuration — two processes sorting the
     // same ids differently would take the same lock pair in opposite
-    // orders and deadlock. Already-held graphs are skipped without
-    // re-sorting the remainder out of order.
-    const pending = [...new Set(params.map((parameter) => parameter.graphId))]
-      .toSorted()
-      .filter((graphId) => !lockedGraphs.has(graphId));
-    for (const graphId of pending) {
-      await lockRecordedGraphWrite(target, graphId);
-      lockedGraphs.add(graphId);
+    // orders and deadlock.
+    const graphIds = [
+      ...new Set(params.map((parameter) => parameter.graphId)),
+    ].toSorted();
+    for (const graphId of graphIds) {
+      await lockRecordedGraphWrite(target, graphId, graphLocks);
     }
   }
 
@@ -428,7 +426,7 @@ function createRecordedTransactionBackend(
         },
       }),
   });
-  registerRecordedGraphLockMemo(overlay, lockedGraphs);
+  registerRecordedGraphLockMemo(overlay, graphLocks);
   return overlay;
 }
 

--- a/packages/typegraph/src/store/recorded-capture/clock.ts
+++ b/packages/typegraph/src/store/recorded-capture/clock.ts
@@ -92,30 +92,45 @@ export function uncapturedGraphWriteLock(): GraphWriteLock {
   return graphWriteLockEvidence();
 }
 
+/**
+ * Per-transaction memo of graphs whose advisory lock is already held.
+ *
+ * `pg_advisory_xact_lock` is reentrant and held until the top-level
+ * transaction ends, so re-acquiring it on every captured write inside one
+ * transaction is pure round-trip churn — a multi-write transaction paid one
+ * lock round trip per write. The capture layer registers its per-transaction
+ * backend here; every lock path that receives that backend (the capture
+ * delegate's own writes, `runInWriteTransaction`, provenance) then skips the
+ * SQL once the graph's lock is held.
+ *
+ * Keyed weakly by the backend object: the delegate is created per
+ * transaction, so memo lifetime equals lock lifetime. NOT savepoint-aware —
+ * a manual `SAVEPOINT` rolled back across the first acquisition releases the
+ * lock but not the memo entry. That matches the capture session's touch
+ * state (also not savepoint-scoped); manual savepoints inside a recorded
+ * transaction are outside the capture contract.
+ */
+const recordedGraphLockMemos = new WeakMap<object, Set<string>>();
+
+export function registerRecordedGraphLockMemo(
+  backend: object,
+  memo: Set<string>,
+): void {
+  recordedGraphLockMemos.set(backend, memo);
+}
+
 export async function lockRecordedGraphWrite(
   target: Pick<TransactionBackend, "dialect" | "execute">,
   graphId: string,
 ): Promise<GraphWriteLock> {
   if (target.dialect !== "postgres") return graphWriteLockEvidence();
+  const memo = recordedGraphLockMemos.get(target);
+  if (memo?.has(graphId)) return graphWriteLockEvidence();
   await target.execute(
     asCompiledRowsSql(recordedGraphWriteAdvisoryLockSql(graphId)),
   );
+  memo?.add(graphId);
   return graphWriteLockEvidence();
-}
-
-export async function lockRecordedGraphWrites(
-  target: Pick<TransactionBackend, "dialect" | "execute">,
-  graphIds: Iterable<string>,
-): Promise<void> {
-  if (target.dialect !== "postgres") return;
-  // Codepoint sort, NOT localeCompare: every process must acquire multi-graph
-  // locks in the same order, and locale-sensitive collation varies with the
-  // host's ICU configuration — two processes sorting the same ids differently
-  // would take the same lock pair in opposite orders and deadlock.
-  const uniqueGraphIds = [...new Set(graphIds)].toSorted();
-  for (const graphId of uniqueGraphIds) {
-    await lockRecordedGraphWrite(target, graphId);
-  }
 }
 
 function failInvalidClockTimestamp(value: unknown): never {

--- a/packages/typegraph/src/store/recorded-capture/clock.ts
+++ b/packages/typegraph/src/store/recorded-capture/clock.ts
@@ -110,26 +110,60 @@ export function uncapturedGraphWriteLock(): GraphWriteLock {
  * state (also not savepoint-scoped); manual savepoints inside a recorded
  * transaction are outside the capture contract.
  */
-const recordedGraphLockMemos = new WeakMap<object, Set<string>>();
+/**
+ * Single-flight per graph: the memo stores the IN-FLIGHT acquisition
+ * promise, not just completed acquisitions, so concurrent same-transaction
+ * writers (`Promise.all` over captured writes) coalesce onto one advisory
+ * round trip instead of racing past an empty resolved-set. A rejected
+ * acquisition evicts its entry so a retry is not poisoned (in practice a
+ * failed statement has aborted the Postgres transaction anyway).
+ */
+export type RecordedGraphLockMemo = Map<string, Promise<void>>;
+
+export function createRecordedGraphLockMemo(): RecordedGraphLockMemo {
+  return new Map();
+}
+
+const recordedGraphLockMemos = new WeakMap<object, RecordedGraphLockMemo>();
 
 export function registerRecordedGraphLockMemo(
   backend: object,
-  memo: Set<string>,
+  memo: RecordedGraphLockMemo,
 ): void {
   recordedGraphLockMemos.set(backend, memo);
+}
+
+async function acquireRecordedGraphWriteLock(
+  target: Pick<TransactionBackend, "execute">,
+  graphId: string,
+): Promise<void> {
+  await target.execute(
+    asCompiledRowsSql(recordedGraphWriteAdvisoryLockSql(graphId)),
+  );
 }
 
 export async function lockRecordedGraphWrite(
   target: Pick<TransactionBackend, "dialect" | "execute">,
   graphId: string,
+  memo?: RecordedGraphLockMemo,
 ): Promise<GraphWriteLock> {
   if (target.dialect !== "postgres") return graphWriteLockEvidence();
-  const memo = recordedGraphLockMemos.get(target);
-  if (memo?.has(graphId)) return graphWriteLockEvidence();
-  await target.execute(
-    asCompiledRowsSql(recordedGraphWriteAdvisoryLockSql(graphId)),
-  );
-  memo?.add(graphId);
+  const effectiveMemo = memo ?? recordedGraphLockMemos.get(target);
+  if (effectiveMemo === undefined) {
+    await acquireRecordedGraphWriteLock(target, graphId);
+    return graphWriteLockEvidence();
+  }
+  let pending = effectiveMemo.get(graphId);
+  if (pending === undefined) {
+    pending = acquireRecordedGraphWriteLock(target, graphId).catch(
+      (error: unknown) => {
+        effectiveMemo.delete(graphId);
+        throw error;
+      },
+    );
+    effectiveMemo.set(graphId, pending);
+  }
+  await pending;
   return graphWriteLockEvidence();
 }
 

--- a/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
+++ b/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
@@ -135,6 +135,22 @@ describe("recorded graph-write advisory lock churn", () => {
     await store.nodes.Person.create({ name: "solo-2" }, { id: "solo-2" });
     await store.nodes.Person.create({ name: "solo-3" }, { id: "solo-3" });
     expect(graphWriteLockCount(statements)).toBe(2);
+
+    // --- Concurrent same-transaction writers coalesce: the memo is
+    //     single-flight (in-flight promise, not resolved-set), so a
+    //     Promise.all over captured writes still pays ONE acquisition. ---
+    statements.length = 0;
+    await store.transaction(async (tx) => {
+      await Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          tx.nodes.Person.create(
+            { name: `par${index}` },
+            { id: `parallel-${index}` },
+          ),
+        ),
+      );
+    });
+    expect(graphWriteLockCount(statements)).toBe(1);
   });
 
   it("still serializes: the lock statement is present before row writes", async (ctx) => {

--- a/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
+++ b/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Recorded-capture advisory-lock churn: `pg_advisory_xact_lock` is
+ * reentrant and held to transaction end, so within one transaction the
+ * graph-write lock must be acquired ONCE per graph — not once per captured
+ * write. Previously a store.transaction with N writes paid N+1 lock round
+ * trips (one from the write-transaction boundary, one per delegate write).
+ *
+ * Counted through the drizzle statement logger, filtered to the
+ * graph-write namespace bind param so the late-flush recorded-clock lock
+ * (a different namespace, deliberately separate — see clock.ts) is not
+ * conflated. Also pinned: the lock is still acquired (exactly once) per
+ * NEW transaction — the memo must not leak across transactions.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStoreWithSchema, defineGraph, defineNode } from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+const GRAPH_WRITE_NAMESPACE = "typegraph:recorded-graph-write";
+
+let pool: Pool | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): Pool {
+  if (!isPostgresAvailable || pool === undefined) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return pool;
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  const candidate = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+  });
+  try {
+    await candidate.query("SELECT 1");
+    await candidate.query(`
+      DROP TABLE IF EXISTS typegraph_recorded_clock CASCADE;
+      DROP TABLE IF EXISTS typegraph_recorded_edges CASCADE;
+      DROP TABLE IF EXISTS typegraph_recorded_nodes CASCADE;
+      DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
+      DROP TABLE IF EXISTS typegraph_edges CASCADE;
+      DROP TABLE IF EXISTS typegraph_nodes CASCADE;
+      DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+    `);
+    await candidate.query(generatePostgresMigrationSQL());
+    pool = candidate;
+    isPostgresAvailable = true;
+  } catch {
+    await candidate.end().catch(() => {
+      // Unreachable Postgres degrades to "skip".
+    });
+  }
+});
+
+afterAll(async () => {
+  if (pool !== undefined) await pool.end();
+});
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+function buildGraph(graphId: string) {
+  return defineGraph({
+    id: graphId,
+    nodes: { Person: { type: Person } },
+    edges: {},
+  });
+}
+
+type LoggedStatement = Readonly<{ query: string; params: unknown[] }>;
+
+function graphWriteLockCount(statements: readonly LoggedStatement[]): number {
+  return statements.filter(
+    (statement) =>
+      statement.query.includes("pg_advisory_xact_lock") &&
+      statement.params[0] === GRAPH_WRITE_NAMESPACE,
+  ).length;
+}
+
+describe("recorded graph-write advisory lock churn", () => {
+  it("acquires the lock once per transaction, not once per write", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const statements: LoggedStatement[] = [];
+    const backend = createPostgresBackend(
+      drizzle(activePool, {
+        logger: {
+          logQuery(query: string, params: unknown[]) {
+            statements.push({ query, params });
+          },
+        },
+      }),
+    );
+    const [store] = await createStoreWithSchema(
+      buildGraph("lock_churn_txn"),
+      backend,
+      { history: true },
+    );
+
+    // --- Multi-write transaction: exactly ONE graph-write acquisition. ---
+    statements.length = 0;
+    await store.transaction(async (tx) => {
+      for (let index = 0; index < 10; index++) {
+        await tx.nodes.Person.create(
+          { name: `p${index}` },
+          { id: `txn-${index}` },
+        );
+      }
+    });
+    expect(graphWriteLockCount(statements)).toBe(1);
+
+    // --- Single autocommit write: also exactly one (was two — the
+    //     write-transaction boundary plus the delegate's own write). ---
+    statements.length = 0;
+    await store.nodes.Person.create({ name: "solo" }, { id: "solo" });
+    expect(graphWriteLockCount(statements)).toBe(1);
+
+    // --- The memo must not leak across transactions: a second operation
+    //     opens a new transaction and MUST re-acquire. ---
+    statements.length = 0;
+    await store.nodes.Person.create({ name: "solo-2" }, { id: "solo-2" });
+    await store.nodes.Person.create({ name: "solo-3" }, { id: "solo-3" });
+    expect(graphWriteLockCount(statements)).toBe(2);
+  });
+
+  it("still serializes: the lock statement is present before row writes", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const statements: LoggedStatement[] = [];
+    const backend = createPostgresBackend(
+      drizzle(activePool, {
+        logger: {
+          logQuery(query: string, params: unknown[]) {
+            statements.push({ query, params });
+          },
+        },
+      }),
+    );
+    const [store] = await createStoreWithSchema(
+      buildGraph("lock_churn_order"),
+      backend,
+      { history: true },
+    );
+
+    statements.length = 0;
+    await store.nodes.Person.create({ name: "ordered" }, { id: "ordered" });
+
+    const lockIndex = statements.findIndex(
+      (statement) =>
+        statement.query.includes("pg_advisory_xact_lock") &&
+        statement.params[0] === GRAPH_WRITE_NAMESPACE,
+    );
+    const insertIndex = statements.findIndex((statement) =>
+      statement.query.includes("typegraph_nodes"),
+    );
+    expect(lockIndex).toBeGreaterThanOrEqual(0);
+    expect(insertIndex).toBeGreaterThan(lockIndex);
+  });
+});


### PR DESCRIPTION
## Problem

Recorded-time capture took `pg_advisory_xact_lock` on **every captured write** plus the write-transaction boundary. The lock is reentrant and held to transaction end, so every repeat inside one transaction was a pure round trip: a `store.transaction` with N captured writes paid **N+1** lock round trips; a single autocommit write paid 2.

## Fix

The capture delegate keeps a per-transaction memo of graph-write locks and registers it in a WeakMap keyed by the delegate object, so every lock path handed that backend — the delegate's own writes, `runInWriteTransaction`, provenance transitions — dedupes against one map. Memo lifetime equals lock lifetime: both end with the transaction, and the WeakMap entry dies with the per-transaction delegate.

The memo is **single-flight** (review finding): it stores the in-flight acquisition promise per graph, not just completed acquisitions, so concurrent same-transaction writers (`Promise.all` over captured writes) coalesce onto one advisory round trip instead of racing past an empty resolved-set. A rejected acquisition evicts its entry so retries aren't poisoned.

- Multi-graph acquisition keeps the codepoint-sorted deadlock-free order (already-held graphs are skipped without reordering the remainder).
- The superseded `lockRecordedGraphWrites` helper is removed — the memoizing delegate path is its only caller's replacement.
- The late-flush **recorded-clock lock is untouched** — it's a different namespace at a different acquire-order position by design (see clock.ts), and the regression filters by namespace bind param so the two are never conflated.
- Honest caveat, documented in clock.ts: the memo is **not savepoint-aware** (a manual `SAVEPOINT` rolled back across the first acquisition releases the lock but not the memo entry). This matches the capture session's touch state, which is also not savepoint-scoped — manual savepoints inside a recorded transaction are outside the capture contract.

## Tests

`tests/backends/postgres/recorded-lock-churn.test.ts`, counting advisory statements by namespace bind param through the drizzle logger:
- 10-write transaction → exactly **1** graph-write acquisition (verified red: 11 without the memo);
- 8 **concurrent** creates via `Promise.all` in one transaction → still exactly 1 (the single-flight case);
- single autocommit write → 1 (was 2);
- the memo does not leak across transactions (two sequential ops → 2 acquisitions);
- the lock statement still precedes the first row write.

## Measurement (loaded host, local docker PG)

| shape | before | after |
| --- | --- | --- |
| recorded tx, 50 creates | 76.6ms | 45.6ms (1.7×) |
| single recorded create | 4.23ms | 3.91ms |

The saving is one round trip per captured write — it scales with write count and per-statement cost (remote PG).

