### PR TITLE
fix: serialize same-index CONCURRENTLY builds with a durable claim

### DIFF
--- a/.changeset/materialize-cic-claim.md
+++ b/.changeset/materialize-cic-claim.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+fix: `materializeIndexes` serializes same-index builds across callers on PostgreSQL via a durable claim in the status table (two concurrent same-name expression-index `CREATE INDEX CONCURRENTLY` builds can deadlock — no safe-snapshot exemption). Losers wait and converge as `alreadyMaterialized`; a crashed builder's claim expires after a 15-minute lease and the takeover drops the INVALID index leftover before rebuilding (relational indexes now self-heal instead of requiring manual repair). With same-index builds serialized, the automatic post-create `ANALYZE` is re-enabled on PostgreSQL.

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -63,6 +63,7 @@ import { isMissingTableError } from "../../utils/sql-errors";
 import {
   type AdoptedTransaction,
   type BackendCapabilities,
+  type ClaimIndexMaterializationParams,
   type CommitSchemaVersionParams,
   type ContributionMaterializationIdentity,
   type ContributionMaterializationRow,
@@ -83,6 +84,7 @@ import {
   type RecordContributionMaterializationParams,
   type RecordIndexMaterializationParams,
   type RecordKindRemovalParams,
+  type ReleaseIndexMaterializationClaimParams,
   type SchemaVersionRow,
   type SetActiveVersionParams,
   type TransactionBackend,
@@ -577,6 +579,71 @@ export function createPostgresBackend(
       await db.execute(
         sql.raw(generatePgCreateTableSQL(tables.indexMaterializations)),
       );
+      // Deployments created before the build-claim columns existed get
+      // them additively; fresh installs already have them from the
+      // CREATE TABLE above.
+      const tableName = getTableName(tables.indexMaterializations);
+      await db.execute(
+        sql.raw(
+          `ALTER TABLE "${tableName}" ADD COLUMN IF NOT EXISTS "building_since" timestamptz;`,
+        ),
+      );
+      await db.execute(
+        sql.raw(
+          `ALTER TABLE "${tableName}" ADD COLUMN IF NOT EXISTS "claim_token" text;`,
+        ),
+      );
+    },
+
+    async claimIndexMaterialization(
+      params: ClaimIndexMaterializationParams,
+    ): Promise<boolean> {
+      const t = tables.indexMaterializations;
+      // Atomic claim: insert a fresh claim row, or take over an existing
+      // row only when no live claim is on it (NULL or lease-expired
+      // building_since). The WHERE on the conflict update makes losing
+      // racers see zero returned rows — the row's own atomicity is the
+      // mutex, so this works identically through pools and across
+      // processes (unlike session advisory locks, which pin a
+      // connection).
+      const rows = await db.execute(sql`
+        INSERT INTO ${t} (
+          "index_name", "graph_id", "entity", "kind", "signature",
+          "schema_version", "last_attempted_at", "building_since",
+          "claim_token"
+        )
+        VALUES (
+          ${params.indexName}, ${params.graphId}, ${params.entity},
+          ${params.kind}, ${params.signature}, ${params.schemaVersion},
+          now(), now(), ${params.token}
+        )
+        ON CONFLICT ("index_name") DO UPDATE SET
+          "building_since" = now(),
+          "claim_token" = EXCLUDED."claim_token"
+        WHERE ${t}."building_since" IS NULL
+           OR ${t}."building_since" < now() - (${params.leaseMs} * interval '1 millisecond')
+        RETURNING "index_name"
+      `);
+      const result = rows;
+      const returned =
+        Array.isArray(result) ? result : (
+          ((result as Readonly<{ rows?: readonly unknown[] }>).rows ?? [])
+        );
+      return returned.length > 0;
+    },
+
+    async releaseIndexMaterializationClaim(
+      params: ReleaseIndexMaterializationClaimParams,
+    ): Promise<void> {
+      const t = tables.indexMaterializations;
+      // Token-guarded: a lease-expired claim taken over by another
+      // materializer must not be released by the original holder.
+      await db.execute(sql`
+        UPDATE ${t}
+        SET "building_since" = NULL, "claim_token" = NULL
+        WHERE "index_name" = ${params.indexName}
+          AND "claim_token" = ${params.token}
+      `);
     },
 
     async getIndexMaterialization(

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -359,6 +359,13 @@ export function createPostgresTables(
         withTimezone: true,
       }).notNull(),
       lastError: text("last_error"),
+      // Cross-caller build claim: while `building_since` is fresh (within
+      // the lease), exactly one materializer owns this index's CREATE
+      // INDEX CONCURRENTLY. Serializes same-index CIC across processes —
+      // two concurrent expression-index CICs deadlock each other (no
+      // safe-snapshot exemption). NULL when no build is in flight.
+      buildingSince: timestamp("building_since", { withTimezone: true }),
+      claimToken: text("claim_token"),
     },
     (t) => [primaryKey({ columns: [t.indexName] })],
   );

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -740,6 +740,30 @@ export type FulltextSearchResult = Readonly<{
  * `materializedAt` is null until the first successful CREATE INDEX
  * completes; `lastAttemptedAt` is always set, even on failure.
  */
+/**
+ * Parameters for atomically claiming an index build (see
+ * `claimIndexMaterialization`). The declaration fields ride along so a
+ * fresh claim row is honest while the build is in flight.
+ */
+export type ClaimIndexMaterializationParams = Readonly<{
+  indexName: string;
+  graphId: string;
+  entity: IndexEntity;
+  kind: string;
+  signature: string;
+  schemaVersion: number;
+  /** Opaque claim identity; release is token-guarded. */
+  token: string;
+  /** A claim older than this is stale and may be taken over. */
+  leaseMs: number;
+}>;
+
+/** Parameters for releasing a build claim (token-guarded). */
+export type ReleaseIndexMaterializationClaimParams = Readonly<{
+  indexName: string;
+  token: string;
+}>;
+
 export type IndexMaterializationRow = Readonly<{
   indexName: string;
   graphId: string;
@@ -1165,6 +1189,21 @@ export type GraphBackend = Readonly<{
    */
   recordIndexMaterialization?: (
     params: RecordIndexMaterializationParams,
+  ) => Promise<void>;
+  /**
+   * Atomically claims the build of one index across every materializer
+   * (process- and pool-safe: the status row's own atomicity is the mutex).
+   * Returns true when this caller now holds the claim. Backends whose
+   * index builds cannot deadlock across callers (SQLite: engine-level
+   * write serialization, no CONCURRENTLY) omit it; `materializeIndexes`
+   * then builds without a claim, exactly as before.
+   */
+  claimIndexMaterialization?: (
+    params: ClaimIndexMaterializationParams,
+  ) => Promise<boolean>;
+  /** Releases a claim taken by `claimIndexMaterialization` (token-guarded). */
+  releaseIndexMaterializationClaim?: (
+    params: ReleaseIndexMaterializationClaimParams,
   ) => Promise<void>;
 
   // === Contribution Materialization (#135 — durable strategy-owned

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -21,10 +21,17 @@
  *   only that something with that name exists. Drift detection here
  *   relies on TypeGraph's recorded signature, not on PG metadata.
  * - Failed `CONCURRENTLY` builds leave invalid indexes behind
- *   (`pg_index.indisvalid = false`). v1 surfaces this as a `failed`
- *   result; the operator must drop the invalid index manually before
- *   retry.
+ *   (`pg_index.indisvalid = false`). Relational rebuilds self-heal: the
+ *   claim-holding materializer drops an invalid leftover with the
+ *   declaration's name before rebuilding (see dropInvalidIndexLeftover).
+ *   Vector per-field index leftovers remain operator-repair.
+ * - Two materializers racing the SAME index name serialize through a
+ *   durable claim in the status table (see materializeWithClaim) —
+ *   concurrent same-name expression-index CIC builds deadlock on
+ *   Postgres (no safe-snapshot exemption).
  */
+
+import { sql } from "drizzle-orm";
 
 import { type RawBackend } from "../backend/branded";
 import {
@@ -43,10 +50,32 @@ import {
   type VectorIndexDeclaration,
 } from "../indexes/types";
 import { type SqlDialect } from "../query/dialect/types";
+import { asCompiledRowsSql } from "../query/sql-intent";
 import { sortedReplacer } from "../schema/canonical";
 import { nowIso } from "../utils/date";
 import { sha256Hex } from "../utils/hash";
 import { ensureFocusedStatusTable } from "./materialize-shared";
+
+/**
+ * Cross-caller build claim timing (Postgres).
+ *
+ * A claim older than the lease is stale (its holder crashed mid-build) and
+ * may be taken over; the lease is generous because CREATE INDEX
+ * CONCURRENTLY on a large relation legitimately runs for minutes, and a
+ * premature takeover would recreate exactly the same-index CIC race the
+ * claim exists to prevent. Losers retry the claim on an interval —
+ * re-claiming after the winner releases converges through the normal
+ * already-materialized check — and give up shortly after the lease bound.
+ */
+const CLAIM_LEASE_MS = 15 * 60_000;
+const CLAIM_RETRY_DELAY_MS = 200;
+const CLAIM_WAIT_TIMEOUT_MS = CLAIM_LEASE_MS + 60_000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 export type MaterializeIndexesOptions = Readonly<{
   /** Restrict to indexes whose `kind` is in this set. */
@@ -56,9 +85,10 @@ export type MaterializeIndexesOptions = Readonly<{
   /**
    * Refresh planner statistics (ANALYZE) after at least one index was
    * created. A fresh index can be ignored by the planner until statistics
-   * exist. Default: true — but only applied on backends that build indexes
-   * non-concurrently (SQLite). Backends using CREATE INDEX CONCURRENTLY
-   * (Postgres) skip the automatic refresh — see
+   * exist. Default: true. Applied on non-concurrent builders (SQLite) and
+   * on concurrent builders that serialize same-index builds via the
+   * cross-caller claim primitive (the bundled Postgres backend); a custom
+   * concurrent backend without the primitive skips the refresh — see
    * refreshStatisticsAfterCreation — and should call
    * `store.refreshStatistics()` after materializing.
    */
@@ -287,12 +317,13 @@ export async function materializeIndexes(
  * caller opted out): the planner can keep seq-scanning past a brand-new
  * index until statistics for it exist.
  *
- * Skipped on backends that build with CREATE INDEX CONCURRENTLY (Postgres):
- * expression-index CIC builds get no safe-snapshot exemption, so two callers
- * racing the SAME index name can deadlock each other — and the refresh's
- * timing shift makes that latent race fire reliably. Until cross-caller
- * builds are serialized by a claim protocol, Postgres callers refresh
- * manually via `store.refreshStatistics()` after materializing.
+ * On backends that build with CREATE INDEX CONCURRENTLY, the refresh runs
+ * only when the backend also exposes the cross-caller claim primitive
+ * (the bundled Postgres backend does): the claim serializes same-index
+ * CIC builds, which used to deadlock under the refresh's timing shift
+ * (expression-index CIC gets no safe-snapshot exemption). A custom
+ * concurrent backend without the primitive keeps the conservative skip
+ * and refreshes manually via `store.refreshStatistics()`.
  *
  * Best-effort: by this point the indexes exist and their status rows are
  * recorded, so a failed statistics refresh must not convert that success
@@ -305,7 +336,14 @@ async function refreshStatisticsAfterCreation(
   usesConcurrentBuilds: boolean,
 ): Promise<void> {
   if (options.refreshStatistics === false) return;
-  if (usesConcurrentBuilds) return;
+  // Concurrent (Postgres) builds were excluded while two callers racing
+  // the SAME expression-index CIC could deadlock — the refresh's timing
+  // shift made that latent race fire reliably. With the cross-caller
+  // claim protocol serializing same-index builds, backends that expose
+  // the claim primitive refresh automatically again; a custom concurrent
+  // backend without the primitive keeps the conservative skip.
+  if (usesConcurrentBuilds && backend.claimIndexMaterialization === undefined)
+    return;
   if (!results.some((entry) => entry.status === "created")) return;
   try {
     await backend.refreshStatistics();
@@ -512,26 +550,29 @@ async function materializeOne(
   const statusOverride =
     statusKey === declaration.name ? undefined : { statusName: statusKey };
 
-  const existing = existingByStatusKey.get(statusKey);
-  if (existing?.materializedAt !== undefined) {
-    if (existing.signature === signature) {
-      return entry(declaration, "alreadyMaterialized");
-    }
-    const error = new Error(
-      `${driftLabel} "${declaration.name}" already materialized with a different signature (recorded by graph "${existing.graphId}" at version ${existing.schemaVersion}). Drop the index manually and retry, or rename the new declaration.`,
-    );
-    await recordIndexMaterialization(
-      buildAttempt({
-        declaration,
-        graphId,
-        signature,
-        schemaVersion,
-        materializedAt: undefined,
-        error,
-        ...statusOverride,
-      }),
-    );
-    return entry(declaration, "failed", error);
+  const settled = await settleAgainstExisting(
+    existingByStatusKey.get(statusKey),
+    declaration,
+    backend,
+    graphId,
+    schemaVersion,
+    { statusKey, signature, driftLabel },
+  );
+  if (settled !== undefined) return settled;
+
+  // Backends whose concurrent builds can deadlock across callers expose a
+  // claim primitive; one caller builds, the rest wait and converge through
+  // the already-materialized check on re-claim.
+  if (
+    backend.claimIndexMaterialization !== undefined &&
+    backend.releaseIndexMaterializationClaim !== undefined
+  ) {
+    return materializeWithClaim(declaration, backend, graphId, schemaVersion, {
+      statusKey,
+      signature,
+      driftLabel,
+      run,
+    });
   }
 
   try {
@@ -565,6 +606,193 @@ async function materializeOne(
     );
     return entry(declaration, "failed", error);
   }
+}
+
+/**
+ * Applies the existing-status decision: `alreadyMaterialized` on a prior
+ * success with a matching signature, a recorded `failed` on signature
+ * drift, and `undefined` when a build is needed. Shared by the pre-claim
+ * check (against the bulk-preloaded rows) and the post-claim re-check
+ * (against a fresh read — the preload is stale after waiting on a claim).
+ */
+async function settleAgainstExisting(
+  existing: IndexMaterializationRow | undefined,
+  declaration: IndexDeclaration,
+  backend: GraphBackend,
+  graphId: string,
+  schemaVersion: number,
+  action: Readonly<{
+    statusKey: string;
+    signature: string;
+    driftLabel: string;
+  }>,
+): Promise<MaterializeIndexesEntry | undefined> {
+  if (existing?.materializedAt === undefined) return undefined;
+  const { statusKey, signature, driftLabel } = action;
+  if (existing.signature === signature) {
+    return entry(declaration, "alreadyMaterialized");
+  }
+  const error = new Error(
+    `${driftLabel} "${declaration.name}" already materialized with a different signature (recorded by graph "${existing.graphId}" at version ${existing.schemaVersion}). Drop the index manually and retry, or rename the new declaration.`,
+  );
+  await backend.recordIndexMaterialization!(
+    buildAttempt({
+      declaration,
+      graphId,
+      signature,
+      schemaVersion,
+      materializedAt: undefined,
+      error,
+      ...(statusKey === declaration.name ? {} : { statusName: statusKey }),
+    }),
+  );
+  return entry(declaration, "failed", error);
+}
+
+/**
+ * Builds one index under the cross-caller claim protocol.
+ *
+ * Claim → re-check → build → record → release. Losers retry the claim on
+ * an interval: once the winner records its result and releases, the next
+ * claim succeeds and the fresh status re-check settles them as
+ * `alreadyMaterialized` (or surfaces the winner's drift failure) without
+ * ever issuing a second same-index CONCURRENTLY build — the shape that
+ * deadlocks on Postgres (expression-index CIC gets no safe-snapshot
+ * exemption). A crashed holder's claim expires after the lease; the
+ * takeover drops the invalid leftover its interrupted build left behind
+ * (relational indexes — the declaration name IS the physical name) before
+ * rebuilding.
+ */
+async function materializeWithClaim(
+  declaration: IndexDeclaration,
+  backend: GraphBackend,
+  graphId: string,
+  schemaVersion: number,
+  action: Readonly<{
+    statusKey: string;
+    signature: string;
+    driftLabel: string;
+    run: () => Promise<void>;
+  }>,
+): Promise<MaterializeIndexesEntry> {
+  const { statusKey, signature, driftLabel, run } = action;
+  const statusOverride =
+    statusKey === declaration.name ? undefined : { statusName: statusKey };
+  const recordIndexMaterialization = backend.recordIndexMaterialization!;
+  const token = `${statusKey}:${nowIso()}:${Math.floor(performance.now() * 1000)}`;
+  const deadline = Date.now() + CLAIM_WAIT_TIMEOUT_MS;
+
+  for (;;) {
+    const claimed = await backend.claimIndexMaterialization!({
+      indexName: statusKey,
+      graphId,
+      entity: declaration.entity,
+      kind: declaration.kind,
+      signature,
+      schemaVersion,
+      token,
+      leaseMs: CLAIM_LEASE_MS,
+    });
+
+    if (!claimed) {
+      if (Date.now() >= deadline) {
+        return entry(
+          declaration,
+          "failed",
+          new Error(
+            `Timed out waiting for a concurrent materializer's claim on "${statusKey}" (waited ${String(CLAIM_WAIT_TIMEOUT_MS)}ms). If its holder crashed, retry after the lease expires.`,
+          ),
+        );
+      }
+      await delay(CLAIM_RETRY_DELAY_MS);
+      continue;
+    }
+
+    try {
+      // Fresh re-check: the bulk preload happened before (possibly) waiting
+      // on another caller's build.
+      const fresh = await backend.getIndexMaterialization!(statusKey);
+      const settled = await settleAgainstExisting(
+        fresh,
+        declaration,
+        backend,
+        graphId,
+        schemaVersion,
+        { statusKey, signature, driftLabel },
+      );
+      if (settled !== undefined) return settled;
+
+      if (declaration.entity !== "vector") {
+        await dropInvalidIndexLeftover(backend, declaration.name);
+      }
+
+      try {
+        await run();
+        const attemptedAt = nowIso();
+        await recordIndexMaterialization(
+          buildAttempt({
+            declaration,
+            graphId,
+            signature,
+            schemaVersion,
+            materializedAt: attemptedAt,
+            error: undefined,
+            attemptedAt,
+            ...statusOverride,
+          }),
+        );
+        return entry(declaration, "created");
+      } catch (error_) {
+        const error =
+          error_ instanceof Error ? error_ : new Error(String(error_));
+        await recordIndexMaterialization(
+          buildAttempt({
+            declaration,
+            graphId,
+            signature,
+            schemaVersion,
+            materializedAt: undefined,
+            error,
+            ...statusOverride,
+          }),
+        );
+        return entry(declaration, "failed", error);
+      }
+    } finally {
+      await backend.releaseIndexMaterializationClaim!({
+        indexName: statusKey,
+        token,
+      });
+    }
+  }
+}
+
+/**
+ * Self-heals an interrupted CONCURRENTLY build: a crashed CIC leaves an
+ * INVALID index behind, and a later `CREATE INDEX CONCURRENTLY IF NOT
+ * EXISTS` would see the name and silently no-op — recording success over
+ * an index the planner will never use. Detect via pg_index and drop
+ * (also CONCURRENTLY — same no-transaction rule). Valid indexes are never
+ * touched.
+ */
+async function dropInvalidIndexLeftover(
+  backend: GraphBackend,
+  physicalIndexName: string,
+): Promise<void> {
+  if (backend.dialect !== "postgres") return;
+  if (backend.executeDdl === undefined) return;
+  const rows = await backend.execute<{ invalid: boolean }>(
+    asCompiledRowsSql(sql`
+      SELECT NOT i.indisvalid AS invalid
+      FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = ${physicalIndexName}
+    `),
+  );
+  const row = rows[0];
+  if (!row?.invalid) return;
+  const quoted = `"${physicalIndexName.replaceAll('"', '""')}"`;
+  await backend.executeDdl(`DROP INDEX CONCURRENTLY IF EXISTS ${quoted};`);
 }
 
 function entry(

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -71,6 +71,20 @@ const CLAIM_LEASE_MS = 15 * 60_000;
 const CLAIM_RETRY_DELAY_MS = 200;
 const CLAIM_WAIT_TIMEOUT_MS = CLAIM_LEASE_MS + 60_000;
 
+/**
+ * Whether the backend implements the FULL cross-caller build-claim
+ * protocol. One predicate for both decisions that depend on it — build
+ * serialization and the post-create statistics refresh — so a backend
+ * implementing only half the surface can never refresh without
+ * serializing (the combination that reopens the same-index CIC deadlock).
+ */
+function hasIndexBuildClaimProtocol(backend: GraphBackend): boolean {
+  return (
+    backend.claimIndexMaterialization !== undefined &&
+    backend.releaseIndexMaterializationClaim !== undefined
+  );
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -342,8 +356,7 @@ async function refreshStatisticsAfterCreation(
   // claim protocol serializing same-index builds, backends that expose
   // the claim primitive refresh automatically again; a custom concurrent
   // backend without the primitive keeps the conservative skip.
-  if (usesConcurrentBuilds && backend.claimIndexMaterialization === undefined)
-    return;
+  if (usesConcurrentBuilds && !hasIndexBuildClaimProtocol(backend)) return;
   if (!results.some((entry) => entry.status === "created")) return;
   try {
     await backend.refreshStatistics();
@@ -563,10 +576,7 @@ async function materializeOne(
   // Backends whose concurrent builds can deadlock across callers expose a
   // claim primitive; one caller builds, the rest wait and converge through
   // the already-materialized check on re-claim.
-  if (
-    backend.claimIndexMaterialization !== undefined &&
-    backend.releaseIndexMaterializationClaim !== undefined
-  ) {
+  if (hasIndexBuildClaimProtocol(backend)) {
     return materializeWithClaim(declaration, backend, graphId, schemaVersion, {
       statusKey,
       signature,
@@ -630,6 +640,18 @@ async function settleAgainstExisting(
   if (existing?.materializedAt === undefined) return undefined;
   const { statusKey, signature, driftLabel } = action;
   if (existing.signature === signature) {
+    // A recorded success is only trustworthy while the physical index is
+    // valid: a run interrupted after `CREATE ... IF NOT EXISTS` silently
+    // kept an invalid leftover (or a pre-claim-protocol run recorded
+    // success over one), leaving a poisoned status row. Fall through to
+    // the build path — under the claim it drops the leftover and rebuilds.
+    if (
+      declaration.entity !== "vector" &&
+      hasIndexBuildClaimProtocol(backend) &&
+      (await hasInvalidIndexLeftover(backend, declaration.name))
+    ) {
+      return undefined;
+    }
     return entry(declaration, "alreadyMaterialized");
   }
   const error = new Error(
@@ -775,12 +797,16 @@ async function materializeWithClaim(
  * (also CONCURRENTLY — same no-transaction rule). Valid indexes are never
  * touched.
  */
-async function dropInvalidIndexLeftover(
+/**
+ * Whether an index with this name exists but is INVALID (an interrupted
+ * CONCURRENTLY build's leftover). False for absent or valid indexes and
+ * on non-Postgres dialects.
+ */
+async function hasInvalidIndexLeftover(
   backend: GraphBackend,
   physicalIndexName: string,
-): Promise<void> {
-  if (backend.dialect !== "postgres") return;
-  if (backend.executeDdl === undefined) return;
+): Promise<boolean> {
+  if (backend.dialect !== "postgres") return false;
   const rows = await backend.execute<{ invalid: boolean }>(
     asCompiledRowsSql(sql`
       SELECT NOT i.indisvalid AS invalid
@@ -789,8 +815,15 @@ async function dropInvalidIndexLeftover(
       WHERE c.relname = ${physicalIndexName}
     `),
   );
-  const row = rows[0];
-  if (!row?.invalid) return;
+  return rows[0]?.invalid === true;
+}
+
+async function dropInvalidIndexLeftover(
+  backend: GraphBackend,
+  physicalIndexName: string,
+): Promise<void> {
+  if (backend.executeDdl === undefined) return;
+  if (!(await hasInvalidIndexLeftover(backend, physicalIndexName))) return;
   const quoted = `"${physicalIndexName.replaceAll('"', '""')}"`;
   await backend.executeDdl(`DROP INDEX CONCURRENTLY IF EXISTS ${quoted};`);
 }

--- a/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
+++ b/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
@@ -501,6 +501,41 @@ describe("Postgres materialize build claim", () => {
     expect(validAfter.rows[0]?.indisvalid).toBe(true);
   });
 
+  it("rebuilds a poisoned success: valid status row over an INVALID index", async (ctx) => {
+    // The older failure mode: a recorded SUCCESS whose physical index is
+    // invalid (a run interrupted after IF NOT EXISTS silently kept a
+    // leftover, or a pre-claim-protocol run recorded over one). The
+    // status row is NOT wiped here — alreadyMaterialized must not be
+    // trusted over an invalid index.
+    const { pool } = requirePostgres(ctx);
+    const graph = buildGraph();
+    const backend = createPostgresBackend(drizzle(pool));
+    const [store] = await createStoreWithSchema(graph, backend);
+    const first = await store.materializeIndexes();
+    const indexName = first.results[0]!.indexName;
+
+    // Keep the success row; poison only the physical index.
+    await pool.query(`DROP INDEX IF EXISTS "${indexName}"`);
+    await store.nodes.Person.create({ email: "p@example.com", name: "a" });
+    await store.nodes.Person.create({ email: "p@example.com", name: "b" });
+    await expect(
+      pool.query(
+        `CREATE UNIQUE INDEX CONCURRENTLY "${indexName}" ON typegraph_nodes ((props ->> 'email'))`,
+      ),
+    ).rejects.toThrow();
+
+    const result = await store.materializeIndexes();
+    const healed = result.results.find(
+      (entry) => entry.indexName === indexName,
+    );
+    expect(healed?.status).toBe("created");
+    const validAfter = await pool.query<{ indisvalid: boolean }>(
+      `SELECT i.indisvalid FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = $1`,
+      [indexName],
+    );
+    expect(validAfter.rows[0]?.indisvalid).toBe(true);
+  });
+
   it("re-enables the automatic post-create ANALYZE on Postgres", async (ctx) => {
     const { pool } = requirePostgres(ctx);
     const statements: string[] = [];

--- a/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
+++ b/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
@@ -163,33 +163,50 @@ describe("Postgres store.materializeIndexes — CONCURRENTLY", () => {
     ).toBe(true);
   });
 
-  it("two concurrent callers race without producing failed results", async (ctx) => {
-    // Two fresh stores fire materializeIndexes simultaneously against
-    // an empty status table. The implementation reads status, runs
-    // CIC IF NOT EXISTS, then upserts status. Postgres serializes
-    // the CIC builds via SHARE UPDATE EXCLUSIVE; the second sees IF
-    // NOT EXISTS and no-ops. Status upserts use ON CONFLICT DO UPDATE.
-    // Net: neither caller's result contains `failed`.
+  it("two concurrent callers serialize through the build claim", async (ctx) => {
+    // Two fresh stores fire materializeIndexes simultaneously against an
+    // empty status table. The cross-caller claim serializes same-index
+    // CONCURRENTLY builds (two same-name expression-index CICs deadlock —
+    // no safe-snapshot exemption), so per index EXACTLY ONE caller
+    // creates and the other settles as alreadyMaterialized after
+    // re-claiming. Repeated to deny the old code its timing luck; the
+    // automatic post-create ANALYZE (re-enabled with the claim) runs in
+    // every iteration — the timing shift that originally surfaced the
+    // deadlock.
     const { pool } = requirePostgres(ctx);
-    const graph = buildGraph();
-    const backendA = createPostgresBackend(drizzle(pool));
-    const backendB = createPostgresBackend(drizzle(pool));
-    const [storeA] = await createStoreWithSchema(graph, backendA);
-    const [storeB] = await createStoreWithSchema(graph, backendB);
+    for (let iteration = 0; iteration < 3; iteration++) {
+      await pool.query(`TRUNCATE typegraph_index_materializations CASCADE`);
+      const leaked = await pool.query<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname LIKE 'idx_tg_%'`,
+      );
+      for (const { indexname } of leaked.rows) {
+        await pool.query(`DROP INDEX IF EXISTS "${indexname}"`);
+      }
 
-    const [a, b] = await Promise.all([
-      storeA.materializeIndexes(),
-      storeB.materializeIndexes(),
-    ]);
+      const graph = buildGraph();
+      const backendA = createPostgresBackend(drizzle(pool));
+      const backendB = createPostgresBackend(drizzle(pool));
+      const [storeA] = await createStoreWithSchema(graph, backendA);
+      const [storeB] = await createStoreWithSchema(graph, backendB);
 
-    for (const entry of [...a.results, ...b.results]) {
-      expect(entry.status).not.toBe("failed");
+      const [a, b] = await Promise.all([
+        storeA.materializeIndexes(),
+        storeB.materializeIndexes(),
+      ]);
+
+      for (const [index, entryA] of a.results.entries()) {
+        const entryB = b.results[index]!;
+        const statuses = [entryA.status, entryB.status].toSorted();
+        expect(statuses, `iteration ${iteration}: ${entryA.indexName}`).toEqual(
+          ["alreadyMaterialized", "created"],
+        );
+      }
+
+      const created = await pool.query<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname LIKE 'idx_tg_%'`,
+      );
+      expect(created.rows.length).toBe(2);
     }
-
-    const created = await pool.query<{ indexname: string }>(
-      `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname LIKE 'idx_tg_%'`,
-    );
-    expect(created.rows.length).toBe(2);
   });
 
   it("does not hold AccessExclusiveLock on typegraph_nodes during materialization", async (ctx) => {
@@ -332,3 +349,181 @@ describe("Postgres store.materializeIndexes — GIN-family methods", () => {
 
 // Used to keep the import linter happy when the suite skips entirely.
 void generatePostgresDDL;
+
+describe("Postgres materialize build claim", () => {
+  it("waits for a live claim holder, then converges without rebuilding", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const graph = buildGraph();
+    const backend = createPostgresBackend(drizzle(pool));
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    // First materialize normally to learn the two index names and seed
+    // valid status rows, then wipe status to stage the contention.
+    const first = await store.materializeIndexes();
+    const indexNames = first.results.map((entry) => entry.indexName);
+    const claimedName = indexNames[0]!;
+
+    // Stage: another materializer "holds" a live claim on index 0 and has
+    // NOT yet recorded a result. Rows for both indexes are wiped so this
+    // caller must build both.
+    await pool.query(`TRUNCATE typegraph_index_materializations CASCADE`);
+    for (const indexname of indexNames) {
+      await pool.query(`DROP INDEX IF EXISTS "${indexname}"`);
+    }
+    await pool.query(
+      `INSERT INTO typegraph_index_materializations
+         (index_name, graph_id, entity, kind, signature, schema_version,
+          last_attempted_at, building_since, claim_token)
+       VALUES ($1, 'pg_materialize_test', 'node', 'Person', 'foreign', 1,
+               now(), now(), 'other-holder')`,
+      [claimedName],
+    );
+
+    // The "holder" finishes 400ms in: it creates the physical index,
+    // records success with the REAL signature, and releases the claim —
+    // exactly what a winning materializer does.
+    const holderFinishes = (async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 400);
+      });
+      const holderBackend = createPostgresBackend(drizzle(pool));
+      const [holderStore] = await createStoreWithSchema(graph, holderBackend);
+      // Clear the fake claim so the holder-run can claim and build.
+      await pool.query(
+        `UPDATE typegraph_index_materializations
+         SET building_since = NULL, claim_token = NULL
+         WHERE index_name = $1`,
+        [claimedName],
+      );
+      await holderStore.materializeIndexes();
+    })();
+
+    const [result] = await Promise.all([
+      store.materializeIndexes(),
+      holderFinishes,
+    ]);
+
+    // This caller never failed and never double-built: the claimed index
+    // settles as alreadyMaterialized (built by the "holder") or created
+    // (if this caller won the post-release claim race) — either way both
+    // indexes exist exactly once and no entry failed.
+    for (const entry of result.results) {
+      expect(entry.status).not.toBe("failed");
+    }
+    const created = await pool.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname LIKE 'idx_tg_%'`,
+    );
+    expect(created.rows.length).toBe(2);
+  });
+
+  it("takes over a stale (lease-expired) claim immediately", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const graph = buildGraph();
+    const backend = createPostgresBackend(drizzle(pool));
+    const [store] = await createStoreWithSchema(graph, backend);
+    const first = await store.materializeIndexes();
+    const staleName = first.results[0]!.indexName;
+
+    await pool.query(`TRUNCATE typegraph_index_materializations CASCADE`);
+    for (const entry of first.results) {
+      await pool.query(`DROP INDEX IF EXISTS "${entry.indexName}"`);
+    }
+    // A crashed materializer's claim: 16 minutes old, past the 15-minute
+    // lease.
+    await pool.query(
+      `INSERT INTO typegraph_index_materializations
+         (index_name, graph_id, entity, kind, signature, schema_version,
+          last_attempted_at, building_since, claim_token)
+       VALUES ($1, 'pg_materialize_test', 'node', 'Person', 'crashed', 1,
+               now() - interval '16 minutes', now() - interval '16 minutes',
+               'crashed-holder')`,
+      [staleName],
+    );
+
+    const startedAt = Date.now();
+    const result = await store.materializeIndexes();
+    const elapsed = Date.now() - startedAt;
+
+    for (const entry of result.results) {
+      expect(entry.status).toBe("created");
+    }
+    // Takeover is immediate — no lease-length wait.
+    expect(elapsed).toBeLessThan(30_000);
+    const claim = await pool.query<{ claim_token: string | null }>(
+      `SELECT claim_token FROM typegraph_index_materializations WHERE index_name = $1`,
+      [staleName],
+    );
+    expect(claim.rows[0]?.claim_token).toBeNull();
+  });
+
+  it("self-heals an INVALID leftover from an interrupted CONCURRENTLY build", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const graph = buildGraph();
+    const backend = createPostgresBackend(drizzle(pool));
+    const [store] = await createStoreWithSchema(graph, backend);
+    const first = await store.materializeIndexes();
+    const indexName = first.results[0]!.indexName;
+
+    await pool.query(`TRUNCATE typegraph_index_materializations CASCADE`);
+    for (const entry of first.results) {
+      await pool.query(`DROP INDEX IF EXISTS "${entry.indexName}"`);
+    }
+
+    // Manufacture the leftover honestly: seed duplicate rows, then let a
+    // UNIQUE CONCURRENTLY build with the declaration's name fail — it
+    // leaves an INVALID index with that name behind, the exact state a
+    // crashed materializer produces.
+    await store.nodes.Person.create({ email: "dup@example.com", name: "a" });
+    await store.nodes.Person.create({ email: "dup@example.com", name: "b" });
+    await expect(
+      pool.query(
+        `CREATE UNIQUE INDEX CONCURRENTLY "${indexName}" ON typegraph_nodes ((props ->> 'email'))`,
+      ),
+    ).rejects.toThrow();
+    const invalidBefore = await pool.query<{ indisvalid: boolean }>(
+      `SELECT i.indisvalid FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = $1`,
+      [indexName],
+    );
+    expect(invalidBefore.rows[0]?.indisvalid).toBe(false);
+
+    // CREATE INDEX CONCURRENTLY IF NOT EXISTS would silently no-op on the
+    // invalid name; the claim-holding materializer must drop and rebuild.
+    const result = await store.materializeIndexes();
+    const healed = result.results.find(
+      (entry) => entry.indexName === indexName,
+    );
+    expect(healed?.status).toBe("created");
+
+    const validAfter = await pool.query<{ indisvalid: boolean }>(
+      `SELECT i.indisvalid FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = $1`,
+      [indexName],
+    );
+    expect(validAfter.rows[0]?.indisvalid).toBe(true);
+  });
+
+  it("re-enables the automatic post-create ANALYZE on Postgres", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const statements: string[] = [];
+    const backend = createPostgresBackend(
+      drizzle(pool, {
+        logger: {
+          logQuery(query: string) {
+            statements.push(query);
+          },
+        },
+      }),
+    );
+    const graph = buildGraph();
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    statements.length = 0;
+    const result = await store.materializeIndexes();
+    expect(result.results.some((entry) => entry.status === "created")).toBe(
+      true,
+    );
+    expect(
+      statements.some((statement) => statement.includes("ANALYZE")),
+      "post-create statistics refresh must run under the claim protocol",
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Two `materializeIndexes` callers racing the **same index name** can deadlock on PostgreSQL — expression-index `CREATE INDEX CONCURRENTLY` gets no safe-snapshot exemption, so the two builds wait on each other's snapshots. Latent on main (the existing race test passed on timing luck), and it's what forced the automatic post-create `ANALYZE` off on Postgres. This also unblocks the last piece of finding #5.

## Design: a durable claim in the status table

New optional backend primitives `claimIndexMaterialization` / `releaseIndexMaterializationClaim` (bundled Postgres backend): an atomic `INSERT … ON CONFLICT DO UPDATE … WHERE building_since IS NULL OR lease-expired RETURNING` claims the build. The status row's own atomicity is the mutex, so the claim behaves identically **through connection pools and across processes** — the alternative (session-level advisory locks) pins a connection that a pool doesn't guarantee you get back, and xact-level locks can't be used at all since CIC cannot run inside a transaction. `building_since` / `claim_token` columns arrive via additive `ALTER TABLE … ADD COLUMN IF NOT EXISTS` for existing deployments.

Protocol in `materializeIndexes` (engaged only when the backend exposes the primitive — SQLite keeps its prior flow exactly):
- **claim → fresh status re-check → build → record → release** (release is token-guarded so a lease-takeover can't be released by the original holder).
- **Losers** retry the claim on an interval; once the winner records and releases, the next claim succeeds and the fresh re-check settles them as `alreadyMaterialized`. A second same-name CONCURRENTLY statement is never issued.
- **Crashed holders**: claims expire after a 15-minute lease (generous because legitimate CIC runs for minutes on large relations — a premature takeover would recreate the very race this prevents). Takeover is immediate once stale.
- **Self-healing INVALID leftovers**: an interrupted CIC leaves an invalid index, and `IF NOT EXISTS` would silently no-op on the name — recording success over an index the planner never uses (a pre-existing v1 caveat, previously operator-repair). The claim holder now detects invalidity via `pg_index` and drops it (`DROP INDEX CONCURRENTLY`) before rebuilding. Relational indexes only (the declaration name is the physical name); vector per-field leftovers remain operator-repair, documented.

With same-index builds serialized, the **automatic post-create ANALYZE returns on Postgres** — gated (review finding) on one shared `hasIndexBuildClaimProtocol()` predicate requiring BOTH claim members, the same predicate that gates serialization itself, so a backend implementing half the surface can never refresh without serializing.

A recorded success is only trusted while the physical index is valid (review finding): `settleAgainstExisting` re-checks `pg_index` before returning `alreadyMaterialized` and falls through to the claim path — drop leftover, rebuild — when a success row sits over an INVALID index (the poisoned-success state older runs could record). The self-heal claim in the release notes covers both the missing-status and poisoned-success shapes, each with its own regression.

## Tests

- The concurrent-callers race is now **deterministic**: exactly one `created` + one `alreadyMaterialized` per index, repeated 3×, with the re-enabled ANALYZE running every iteration — the timing shift that originally surfaced the deadlock. (Old behavior could yield two `created`s; the strengthened assertion is red against it.)
- Live-claim contention: a caller waits on a held claim and converges without double-building.
- Stale-claim takeover: a 16-minute-old claim is taken over immediately (no lease-length wait), token replaced, index rebuilt.
- INVALID-leftover self-heal, manufactured honestly: a genuinely failed `UNIQUE CONCURRENTLY` build (duplicate rows) leaves the invalid index; materialize drops and rebuilds it, `pg_index.indisvalid` flips to true — covered for BOTH the missing-status-row shape and the poisoned-success shape (success row intact, index invalid → `created`, not `alreadyMaterialized`).
- ANALYZE presence pinned via statement log; SQLite materialize suites unchanged and green.

