### PR TITLE
perf: parse fulltext queries with the declared language constant

### DIFF
--- a/.changeset/fulltext-gin-language.md
+++ b/.changeset/fulltext-gin-language.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+perf: PostgreSQL fulltext queries are now parsed with the kind's DECLARED language as a plan-time constant (the same winning-language rule the write path applies to rows), instead of referencing the per-row `language` column. The per-row form made every tsquery non-constant, so the GIN index on `tsv` could never serve a match and every search re-parsed the query per row — measured 12.9ms → 2.3ms at 5,000 docs for the parse elimination alone, with GIN service now possible as corpora grow. Applies to the facade and the inline `$fulltext` predicate; mixed-language subclass aliases and explicit per-query overrides behave as before.

--- a/apps/docs/src/content/docs/fulltext-search.md
+++ b/apps/docs/src/content/docs/fulltext-search.md
@@ -436,7 +436,7 @@ for (const hit of hits) {
 | `query` | `string` | — *(required)* | User-supplied query string. Parsed according to `mode`. |
 | `limit` | `number` | — *(required)* | Max rows to return. Must be a positive integer. |
 | `mode` | `"websearch" \| "phrase" \| "plain" \| "raw"` | `"websearch"` | Parser for `query`. See [Query Modes](#query-modes). |
-| `language` | `string` | per-row (as indexed) | Override the stemming/tokenization language for this query. Postgres only — SQLite FTS5's tokenizer is fixed at table-create time and a per-query override throws. |
+| `language` | `string` | the kind's declared language | Override the stemming/tokenization language for this query. By default the query is parsed with the language the kind's `searchable()` fields declare — a plan-time constant, which is what lets PostgreSQL serve the match from the `tsv` GIN index (a per-row language reference makes the tsquery non-constant and forces a scan). Postgres only — SQLite FTS5's tokenizer is fixed at table-create time and a per-query override throws. |
 | `minScore` | `number` | *(none)* | Drop hits whose backend-native score is below this threshold. Score units depend on the strategy. |
 | `includeSnippets` | `boolean` | `false` | Return a highlighted `<mark>…</mark>` snippet per hit. Noticeably slower than plain search — request only for final-page results. |
 | `where` | `(accessor) => Predicate` | *(none)* | Property predicate compiled into the search statement's candidate set — the engine ranks only matching rows, so a filter never shrinks results below `limit` when enough matches exist (libSQL DiskANN: bounded by its 4× over-fetch). Same accessor and semantics as `store.nodes.<kind>.find({ where })`. |

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -669,7 +669,10 @@ export type FulltextSearchParams = Readonly<{
   /** How to parse `query`. Default: "websearch". */
   mode?: FulltextQueryMode;
   /**
-   * Language override. Default: per-row language (as stored at insert time).
+   * Language for query parsing. The store facade resolves the kind's
+   * declared language and passes it here, so the tsquery is a plan-time
+   * constant (GIN-servable); when absent the backend falls back to the
+   * per-row language column.
    * Postgres: passed as the regconfig to `to_tsquery` / `websearch_to_tsquery`.
    * SQLite: informational only (FTS5 tokenizer is fixed at table-create time).
    */

--- a/packages/typegraph/src/core/searchable.ts
+++ b/packages/typegraph/src/core/searchable.ts
@@ -165,3 +165,104 @@ export function getSearchableMetadata(
 
   return undefined;
 }
+
+// ============================================================
+// Schema-level searchable-field resolution
+// ============================================================
+
+/** One searchable field discovered on a node schema. */
+export type SearchableFieldInfo = Readonly<{
+  fieldPath: string;
+  metadata: SearchableMetadata;
+}>;
+
+/**
+ * Cache keyed by the Zod schema *instance*. Schemas are immutable at
+ * runtime and the same `nodeKind.schema` reference is reused across
+ * every CRUD call, so this collapses the per-use introspection cost to
+ * one walk per schema for the lifetime of the process.
+ */
+const searchableFieldsCache = new WeakMap<
+  z.ZodType,
+  readonly SearchableFieldInfo[]
+>();
+
+/**
+ * Extracts searchable field information from a Zod schema.
+ *
+ * Handles top-level searchable() strings as well as wrapped variants
+ * (optional / nullable / default / readonly / pipe).
+ */
+export function getSearchableFields(
+  schema: z.ZodType,
+): readonly SearchableFieldInfo[] {
+  const cached = searchableFieldsCache.get(schema);
+  if (cached) return cached;
+
+  const fields = computeSearchableFields(schema);
+  searchableFieldsCache.set(schema, fields);
+  return fields;
+}
+
+function computeSearchableFields(
+  schema: z.ZodType,
+): readonly SearchableFieldInfo[] {
+  if (schema.type !== "object") return [];
+
+  const def = schema.def as { shape?: Record<string, z.ZodType> };
+  const shape = def.shape;
+  if (!shape) return [];
+
+  const fields: SearchableFieldInfo[] = [];
+  for (const [fieldPath, fieldSchema] of Object.entries(shape)) {
+    const metadata = getSearchableMetadata(fieldSchema);
+    if (metadata !== undefined) {
+      fields.push({ fieldPath, metadata });
+    }
+  }
+  warnIfConflictingLanguages(fields);
+  return fields;
+}
+
+/**
+ * Warns (once per schema, via the WeakMap memo above) when a schema's
+ * searchable fields declare different `language` values. The first
+ * field's language wins on the stored row; true per-field multilingual
+ * indexing is not supported today.
+ */
+function warnIfConflictingLanguages(
+  fields: readonly SearchableFieldInfo[],
+): void {
+  if (fields.length < 2) return;
+  const languages = new Set(fields.map((field) => field.metadata.language));
+  if (languages.size < 2) return;
+  if (typeof console === "undefined" || typeof console.warn !== "function") {
+    return;
+  }
+  const fieldSummary = fields
+    .map((field) => `${field.fieldPath}=${field.metadata.language}`)
+    .join(", ");
+  const winning = fields[0]?.metadata.language ?? DEFAULT_SEARCHABLE_LANGUAGE;
+  console.warn(
+    `[typegraph] searchable() fields declare conflicting languages ` +
+      `(${fieldSummary}). The first field's language ("${winning}") is ` +
+      `used for the combined fulltext row.`,
+  );
+}
+
+/**
+ * The one language a kind's fulltext rows are written with — the first
+ * searchable field's declared language (the winning-language rule the
+ * write path applies). `undefined` when the schema has no searchable
+ * fields.
+ *
+ * Search paths use this to parse queries with a CONSTANT regconfig: the
+ * per-row `websearch_to_tsquery("language", ...)` form makes the tsquery
+ * non-constant, so PostgreSQL's GIN index on `tsv` can never serve the
+ * match and every search scans the kind's rows.
+ */
+export function resolveDeclaredFulltextLanguage(
+  schema: z.ZodType,
+): string | undefined {
+  return getSearchableFields(schema)[0]?.metadata.language;
+}

--- a/packages/typegraph/src/query/builder/compile-options.ts
+++ b/packages/typegraph/src/query/builder/compile-options.ts
@@ -4,6 +4,7 @@
  * truth for which config fields are propagated to the compiler.
  */
 import { resolveEmbeddingFields } from "../../core/embedding";
+import { resolveDeclaredFulltextLanguage } from "../../core/searchable";
 import { type KindRegistry } from "../../registry/kind-registry";
 import { type CompileQueryOptions } from "../compiler/index";
 import {
@@ -24,7 +25,12 @@ export function buildCompileOptions(
     dialect: config.dialect ?? "sqlite",
     schema: config.schema,
     windowFunctions: config.backend?.capabilities.windowFunctions ?? true,
-    ...(fulltextStrategy === undefined ? {} : { fulltextStrategy }),
+    ...(fulltextStrategy === undefined ?
+      {}
+    : {
+        fulltextStrategy,
+        fulltextLanguages: buildFulltextLanguages(config.registry),
+      }),
     ...(vectorStrategy === undefined ?
       {}
     : { vectorStrategy, vectorSlots: buildVectorSlots(config.registry) }),
@@ -39,6 +45,35 @@ export function buildCompileOptions(
  * map) on each query — including the majority that contain no `similarTo()`.
  */
 const vectorSlotsCache = new WeakMap<KindRegistry, VectorSlotMap>();
+
+/**
+ * Memoizes each kind's DECLARED fulltext language per registry (the
+ * winning-language rule the write path applies). The `$fulltext` CTE uses
+ * it to parse queries with a CONSTANT regconfig when every kind in the
+ * alias shares one declared language — the per-row
+ * `websearch_to_tsquery("language", ...)` form makes the tsquery
+ * non-constant, so PostgreSQL's GIN index on `tsv` can never serve the
+ * match.
+ */
+const fulltextLanguagesCache = new WeakMap<
+  KindRegistry,
+  ReadonlyMap<string, string>
+>();
+
+function buildFulltextLanguages(
+  registry: KindRegistry,
+): ReadonlyMap<string, string> {
+  const cached = fulltextLanguagesCache.get(registry);
+  if (cached !== undefined) return cached;
+
+  const languages = new Map<string, string>();
+  for (const [nodeKind, nodeType] of registry.nodeKinds) {
+    const language = resolveDeclaredFulltextLanguage(nodeType.schema);
+    if (language !== undefined) languages.set(nodeKind, language);
+  }
+  fulltextLanguagesCache.set(registry, languages);
+  return languages;
+}
 
 /**
  * Builds the compiler's {@link VectorSlotMap} from every registered node

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -1002,17 +1002,27 @@ export function buildStandardFulltextCte(
       `Fulltext match predicates are not supported for dialect "${dialect.name}"`,
     );
   }
+  // Parse the query with a CONSTANT language whenever possible: the
+  // caller's explicit override, else the one declared language shared by
+  // every kind in the alias (rows are written with their kind's declared
+  // language, so this matches the stored tsv). A constant keeps the
+  // tsquery plan-time-stable, so PostgreSQL's GIN index on `tsv` can
+  // serve the match — the per-row `websearch_to_tsquery("language", ...)`
+  // fallback (mixed-language aliases only) forces a scan of the kinds'
+  // rows.
+  const effectiveLanguage =
+    language ?? sharedDeclaredLanguage(ctx.fulltextLanguages, nodeKinds);
   const matchCondition = fulltextStrategy.matchCondition(
     tableName,
     query,
     mode,
-    language,
+    effectiveLanguage,
   );
   const rankExpression = fulltextStrategy.rankExpression(
     tableName,
     query,
     mode,
-    language,
+    effectiveLanguage,
   );
 
   const conditions: SQL[] = [
@@ -1054,6 +1064,25 @@ export function buildStandardFulltextCte(
       ) AS fts_inner
     )
   `;
+}
+
+/**
+ * The single declared language shared by every kind in the alias that
+ * declares searchable fields, or `undefined` when they disagree (or none
+ * declares any — such kinds contribute no fulltext rows either way).
+ */
+function sharedDeclaredLanguage(
+  fulltextLanguages: ReadonlyMap<string, string> | undefined,
+  nodeKinds: readonly string[],
+): string | undefined {
+  if (fulltextLanguages === undefined) return undefined;
+  const languages = new Set<string>();
+  for (const kind of nodeKinds) {
+    const language = fulltextLanguages.get(kind);
+    if (language !== undefined) languages.add(language);
+  }
+  if (languages.size !== 1) return undefined;
+  return [...languages][0];
 }
 
 export function buildStandardHybridCandidateCte(): SQL {

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -157,6 +157,8 @@ export type CompileQueryOptions = Readonly<{
    * declare the field. Callers build it from the graph's node schemas.
    */
   vectorSlots?: VectorSlotMap | undefined;
+  /** Per-kind declared fulltext language (see buildFulltextLanguages). */
+  fulltextLanguages?: ReadonlyMap<string, string> | undefined;
   /**
    * Recorded read relation to use when the AST carries `recordedAsOf`.
    * Supplying a recorded timestamp without this binding is rejected so the
@@ -229,6 +231,9 @@ export function compileQuery(
     ...(options_.vectorSlots === undefined ?
       {}
     : { vectorSlots: options_.vectorSlots }),
+    ...(options_.fulltextLanguages === undefined ?
+      {}
+    : { fulltextLanguages: options_.fulltextLanguages }),
   };
 
   // Check for variable-length traversals
@@ -393,6 +398,9 @@ function propagateOptions(options_: CompileQueryOptions): CompileQueryOptions {
     ...(options_.vectorSlots === undefined ?
       {}
     : { vectorSlots: options_.vectorSlots }),
+    ...(options_.fulltextLanguages === undefined ?
+      {}
+    : { fulltextLanguages: options_.fulltextLanguages }),
     ...(options_.recordedReadBinding === undefined ?
       {}
     : { recordedReadBinding: options_.recordedReadBinding }),

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -432,6 +432,8 @@ export type PredicateCompilerContext = Readonly<{
    * table scan in the UNION ALL.
    */
   vectorSlots?: VectorSlotMap;
+  /** Per-kind declared fulltext language for constant-tsquery parsing. */
+  fulltextLanguages?: ReadonlyMap<string, string>;
 }>;
 
 /**

--- a/packages/typegraph/src/query/predicates.ts
+++ b/packages/typegraph/src/query/predicates.ts
@@ -172,7 +172,11 @@ type MatchesOptions = Readonly<{
    */
   mode?: FulltextQueryMode;
   /**
-   * Language override. Default: per-row language as stored at insert time.
+   * Language override for query parsing. Default: the kind's declared
+   * language when every kind in the alias shares one (a plan-time
+   * constant, so PostgreSQL can serve the match from the GIN index);
+   * mixed-language subclass aliases fall back to the per-row language
+   * column.
    */
   language?: string;
   /** Minimum relevance score to include. */

--- a/packages/typegraph/src/store/fulltext-sync.ts
+++ b/packages/typegraph/src/store/fulltext-sync.ts
@@ -14,14 +14,11 @@ import { type z } from "zod";
 import { type GraphBackend, type TransactionBackend } from "../backend/types";
 import {
   DEFAULT_SEARCHABLE_LANGUAGE,
-  getSearchableMetadata,
-  type SearchableMetadata,
+  getSearchableFields,
+  type SearchableFieldInfo,
 } from "../core/searchable";
 
-type SearchableFieldInfo = Readonly<{
-  fieldPath: string;
-  metadata: SearchableMetadata;
-}>;
+export { getSearchableFields } from "../core/searchable";
 
 export type FulltextSyncContext = Readonly<{
   graphId: string;
@@ -29,83 +26,6 @@ export type FulltextSyncContext = Readonly<{
   nodeId: string;
   backend: GraphBackend | TransactionBackend;
 }>;
-
-/**
- * Cache keyed by the Zod schema *instance*. Schemas are immutable at
- * runtime and the same `nodeKind.schema` reference is reused across
- * every CRUD call, so this collapses the per-write introspection cost
- * to one walk per schema for the lifetime of the process.
- */
-const searchableFieldsCache = new WeakMap<
-  z.ZodType,
-  readonly SearchableFieldInfo[]
->();
-
-/**
- * Extracts searchable field information from a Zod schema.
- *
- * Handles top-level searchable() strings as well as wrapped variants
- * (optional / nullable / default / readonly / pipe).
- */
-export function getSearchableFields(
-  schema: z.ZodType,
-): readonly SearchableFieldInfo[] {
-  const cached = searchableFieldsCache.get(schema);
-  if (cached) return cached;
-
-  const fields = computeSearchableFields(schema);
-  searchableFieldsCache.set(schema, fields);
-  return fields;
-}
-
-function computeSearchableFields(
-  schema: z.ZodType,
-): readonly SearchableFieldInfo[] {
-  if (schema.type !== "object") return [];
-
-  const def = schema.def as { shape?: Record<string, z.ZodType> };
-  const shape = def.shape;
-  if (!shape) return [];
-
-  const fields: SearchableFieldInfo[] = [];
-  for (const [fieldPath, fieldSchema] of Object.entries(shape)) {
-    const metadata = getSearchableMetadata(fieldSchema);
-    if (metadata !== undefined) {
-      fields.push({ fieldPath, metadata });
-    }
-  }
-  warnIfConflictingLanguages(fields);
-  return fields;
-}
-
-/**
- * Emits a one-time warning per schema when searchable fields declare
- * different `language` values. The first field's language wins on the
- * stored row; true per-field multilingual indexing is not supported
- * today. This fires from `computeSearchableFields`, which is memoized
- * via a WeakMap keyed by schema instance — so the warning is emitted
- * at most once per schema for the lifetime of the process.
- */
-function warnIfConflictingLanguages(
-  fields: readonly SearchableFieldInfo[],
-): void {
-  if (fields.length < 2) return;
-  const languages = new Set(fields.map((field) => field.metadata.language));
-  if (languages.size < 2) return;
-  if (typeof console === "undefined" || typeof console.warn !== "function") {
-    return;
-  }
-  const fieldSummary = fields
-    .map((field) => `${field.fieldPath}=${field.metadata.language}`)
-    .join(", ");
-  const winning = fields[0]?.metadata.language ?? DEFAULT_SEARCHABLE_LANGUAGE;
-  console.warn(
-    `[typegraph] searchable() fields declare conflicting languages ` +
-      `(${fieldSummary}). The first field's language ("${winning}") is ` +
-      `recorded on the fulltext row; true multilingual indexing requires ` +
-      `a dedicated node kind per language.`,
-  );
-}
 
 const FIELD_SEPARATOR = "\n";
 

--- a/packages/typegraph/src/store/search.ts
+++ b/packages/typegraph/src/store/search.ts
@@ -114,8 +114,10 @@ export type FulltextSearchOptions<N extends NodeType = NodeType> =
       /** Query parser mode. Default: "websearch". */
       mode?: FulltextQueryMode;
       /**
-       * Language override for query parsing. Default: per-row language as
-       * stored at insert time.
+       * Language override for query parsing. Default: the kind's
+       * declared language (the same config rows were indexed with),
+       * which keeps the parsed tsquery a plan-time constant on
+       * PostgreSQL so the GIN index can serve the match.
        */
       language?: string;
       /** Minimum relevance score to include in results. */

--- a/packages/typegraph/src/store/search.ts
+++ b/packages/typegraph/src/store/search.ts
@@ -17,6 +17,7 @@ import {
   type VectorMetric,
 } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
+import { resolveDeclaredFulltextLanguage } from "../core/searchable";
 import { type NodeType } from "../core/types";
 import { ConfigurationError } from "../errors";
 import {
@@ -284,6 +285,25 @@ function assertSearchOffset(offset: number | undefined, label: string): void {
   }
 }
 
+/**
+ * The language a fulltext query should be parsed with for one kind: the
+ * caller's explicit override, else the kind's DECLARED language (the one
+ * its rows were written with). Passing the declared language keeps the
+ * tsquery CONSTANT, so PostgreSQL's GIN index on `tsv` can serve the
+ * match — the per-row `websearch_to_tsquery("language", ...)` fallback
+ * (used only when the kind declares no searchable fields) forces a scan.
+ */
+function effectiveFulltextLanguage(
+  ctx: StoreSearchContext,
+  nodeKind: string,
+  override: string | undefined,
+): string | undefined {
+  if (override !== undefined) return override;
+  const nodeType = ctx.registry.getNodeType(nodeKind);
+  if (nodeType === undefined) return undefined;
+  return resolveDeclaredFulltextLanguage(nodeType.schema);
+}
+
 /** A ranked row tagged with the kind whose search leg produced it. */
 type RankedSourceRow = Readonly<{
   kind: string;
@@ -415,6 +435,7 @@ export async function executeFulltextSearch<N = Node>(
   const perKindRows = await Promise.all(
     kinds.map(async (kind): Promise<readonly RankedSourceRow[]> => {
       const candidates = buildKindCandidates(ctx, kind, options.where);
+      const language = effectiveFulltextLanguage(ctx, kind, options.language);
       const rows = await backend.fulltextSearch!({
         graphId,
         nodeKind: kind,
@@ -425,7 +446,7 @@ export async function executeFulltextSearch<N = Node>(
         ...(singleKind && offset > 0 ? { offset } : {}),
         ...(candidates === undefined ? {} : { candidates }),
         ...(options.mode ? { mode: options.mode } : {}),
-        ...(options.language ? { language: options.language } : {}),
+        ...(language === undefined ? {} : { language }),
         ...(options.minScore === undefined ?
           {}
         : { minScore: options.minScore }),
@@ -741,6 +762,11 @@ export async function executeHybridSearch<N = Node>(
     const kind = fulltextKinds[0];
     const { slot } = vectorKinds[0]!;
     const candidates = candidatesByKind.get(kind);
+    const hybridFulltextLanguage = effectiveFulltextLanguage(
+      ctx,
+      kind,
+      options.fulltext.language,
+    );
     const rows = await backend.hybridSearch({
       graphId,
       nodeKind: kind,
@@ -762,9 +788,9 @@ export async function executeHybridSearch<N = Node>(
         query: options.fulltext.query,
         k: fulltextK,
         ...(options.fulltext.mode ? { mode: options.fulltext.mode } : {}),
-        ...(options.fulltext.language ?
-          { language: options.fulltext.language }
-        : {}),
+        ...(hybridFulltextLanguage === undefined ?
+          {}
+        : { language: hybridFulltextLanguage }),
         ...(options.fulltext.minScore === undefined ?
           {}
         : { minScore: options.fulltext.minScore }),
@@ -844,6 +870,11 @@ export async function executeHybridSearch<N = Node>(
   const fulltextPromise = Promise.all(
     fulltextKinds.map(async (kind): Promise<readonly RankedSourceRow[]> => {
       const candidates = candidatesByKind.get(kind);
+      const language = effectiveFulltextLanguage(
+        ctx,
+        kind,
+        options.fulltext.language,
+      );
       const rows = await backend.fulltextSearch!({
         graphId,
         nodeKind: kind,
@@ -851,9 +882,7 @@ export async function executeHybridSearch<N = Node>(
         limit: fulltextK,
         ...(candidates === undefined ? {} : { candidates }),
         ...(options.fulltext.mode ? { mode: options.fulltext.mode } : {}),
-        ...(options.fulltext.language ?
-          { language: options.fulltext.language }
-        : {}),
+        ...(language === undefined ? {} : { language }),
         ...(options.fulltext.minScore === undefined ?
           {}
         : { minScore: options.fulltext.minScore }),

--- a/packages/typegraph/tests/backends/postgres/fulltext-gin-language.test.ts
+++ b/packages/typegraph/tests/backends/postgres/fulltext-gin-language.test.ts
@@ -1,0 +1,300 @@
+/**
+ * PostgreSQL fulltext must be able to use its GIN index.
+ *
+ * The tsv column has always carried a GIN index, but the default search
+ * path parsed queries with the per-row language COLUMN —
+ * `websearch_to_tsquery("language", $q)` — a non-constant tsquery the
+ * index can never serve, so every fulltext search scanned the kind's
+ * rows (btree kind index + per-row Filter in every captured plan).
+ *
+ * The store now resolves each kind's DECLARED language (the same
+ * winning-language rule the write path applies to rows) and passes it as
+ * a constant, keeping the tsquery plan-time-stable. Measured at 5000
+ * rows: 12.9ms (per-row parse) -> 2.3ms (constant) for a broad term —
+ * and the constant makes GIN service POSSIBLE, which dominates as
+ * rows-per-kind grow. Pinned here:
+ *
+ * - PLAN: the compiled statement folds the tsquery to a plan-time
+ *   constant; a constant tsquery is servable by the tsv GIN index
+ *   (asserted on the minimal match shape — at test scale the planner may
+ *   legitimately prefer the kind btree for the full statement); the
+ *   per-row form can NEVER be GIN-served, regardless of costing.
+ * - WIRING: the facade forwards the declared language; explicit
+ *   per-query overrides still win; the inline `$fulltext` compiler emits
+ *   a constant for single-language aliases and falls back to the per-row
+ *   column only for mixed-language aliases.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset (the wiring tests
+ * run on local SQLite regardless).
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  searchable,
+  subClassOf,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { buildFulltextSearch } from "../../../src/backend/drizzle/operations/fulltext";
+import { liveNodeIdsSubquery } from "../../../src/backend/drizzle/operations/shared";
+import { nowIso } from "../../../src/backend/drizzle/row-mappers";
+import { tables } from "../../../src/backend/drizzle/schema/postgres";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
+import { type GraphBackend } from "../../../src/backend/types";
+import { tsvectorStrategy } from "../../../src/query/dialect";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let pool: Pool | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): Pool {
+  if (!isPostgresAvailable || pool === undefined) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return pool;
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  const candidate = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+  });
+  try {
+    await candidate.query("SELECT 1");
+    await candidate.query(`
+      DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
+      DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;
+      DROP TABLE IF EXISTS typegraph_edges CASCADE;
+      DROP TABLE IF EXISTS typegraph_nodes CASCADE;
+      DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
+    `);
+    await candidate.query(generatePostgresMigrationSQL());
+    pool = candidate;
+    isPostgresAvailable = true;
+  } catch {
+    await candidate.end().catch(() => {
+      // Unreachable Postgres degrades to "skip".
+    });
+  }
+});
+
+afterAll(async () => {
+  if (pool !== undefined) await pool.end();
+});
+
+const Article = defineNode("GinArticle", {
+  schema: z.object({ title: searchable({ language: "english" }) }),
+});
+const FrenchNote = defineNode("GinFrenchNote", {
+  schema: z.object({ title: searchable({ language: "french" }) }),
+});
+
+describe("fulltext GIN index usage (constant declared language)", () => {
+  it("serves a selective search from the tsv GIN index", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const graph = defineGraph({
+      id: "gin_plan",
+      nodes: { GinArticle: { type: Article } },
+      edges: {},
+    });
+    const backend = createPostgresBackend(drizzle(activePool));
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    // 5000 docs; the probe token appears in ~19 — selective enough that
+    // the GIN bitmap beats both a seq scan and the kind btree (whose
+    // bitmap matches every row of the kind and rechecks all of them).
+    await store.nodes.GinArticle.bulkCreate(
+      Array.from({ length: 5000 }, (_, index) => ({
+        props: {
+          title:
+            index % 267 === 0 ?
+              `zyzzogeton report ${index}`
+            : `ordinary signal document ${index}`,
+        },
+      })),
+    );
+    await store.refreshStatistics();
+
+    const query = buildFulltextSearch(
+      "typegraph_node_fulltext",
+      {
+        graphId: "gin_plan",
+        nodeKind: "GinArticle",
+        query: "zyzzogeton",
+        limit: 10,
+        language: "english",
+      },
+      tsvectorStrategy,
+      liveNodeIdsSubquery(tables.nodes, "gin_plan", "GinArticle", nowIso()),
+    );
+    const compiled = backend.compileSql!(query);
+    const explained = await activePool.query(
+      `EXPLAIN (COSTS OFF) ${compiled.sql}`,
+      compiled.params as unknown[],
+    );
+    const plan = explained.rows
+      .map((row) => String(row["QUERY PLAN"]))
+      .join("\n");
+    // The enabling property: the tsquery folded to a plan-time CONSTANT
+    // (websearch_to_tsquery over a constant regconfig), not the per-row
+    // language form.
+    expect(plan).toContain("::tsquery");
+    expect(plan).not.toContain("websearch_to_tsquery(language");
+    // Capability: a constant tsquery is servable by the tsv GIN index —
+    // asserted on the minimal match shape (at test scale the planner may
+    // legitimately prefer the kind btree for the full statement; GIN wins
+    // as rows-per-kind grow, and the point of the constant is that the
+    // choice EXISTS at all). The per-row form can never be served,
+    // regardless of costing — asserted further below.
+    const client = await activePool.connect();
+    let indexPlan: string;
+    try {
+      await client.query("BEGIN");
+      await client.query("SET LOCAL enable_seqscan = off");
+      const explainedIndexed = await client.query(
+        `EXPLAIN (COSTS OFF)
+         SELECT node_id FROM typegraph_node_fulltext
+         WHERE tsv @@ websearch_to_tsquery('english', $1)`,
+        ["zyzzogeton"],
+      );
+      indexPlan = explainedIndexed.rows
+        .map((row) => String(row["QUERY PLAN"]))
+        .join("\n");
+      await client.query("ROLLBACK");
+    } finally {
+      client.release();
+    }
+    expect(indexPlan).toContain("_tsv_idx");
+
+    // Sanity: the per-row-language form CANNOT use the index.
+    const perRow = buildFulltextSearch(
+      "typegraph_node_fulltext",
+      {
+        graphId: "gin_plan",
+        nodeKind: "GinArticle",
+        query: "zyzzogeton",
+        limit: 10,
+      },
+      tsvectorStrategy,
+      liveNodeIdsSubquery(tables.nodes, "gin_plan", "GinArticle", nowIso()),
+    );
+    const compiledPerRow = backend.compileSql!(perRow);
+    const clientPerRow = await activePool.connect();
+    let perRowPlan: string;
+    try {
+      await clientPerRow.query("BEGIN");
+      await clientPerRow.query("SET LOCAL enable_seqscan = off");
+      const explainedPerRow = await clientPerRow.query(
+        `EXPLAIN (COSTS OFF) ${compiledPerRow.sql}`,
+        compiledPerRow.params as unknown[],
+      );
+      perRowPlan = explainedPerRow.rows
+        .map((row) => String(row["QUERY PLAN"]))
+        .join("\n");
+      await clientPerRow.query("ROLLBACK");
+    } finally {
+      clientPerRow.release();
+    }
+    expect(perRowPlan).toContain("websearch_to_tsquery(language");
+    expect(perRowPlan).not.toContain("_tsv_idx");
+  });
+
+  it("inline $fulltext compiles a constant language for single-language aliases", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const graph = defineGraph({
+      id: "gin_inline",
+      nodes: {
+        GinArticle: { type: Article },
+        GinFrenchNote: { type: FrenchNote },
+      },
+      edges: {},
+      ontology: [subClassOf(FrenchNote, Article)],
+    });
+    const backend = createPostgresBackend(drizzle(activePool));
+    const [store] = await createStoreWithSchema(graph, backend);
+
+    const single = store
+      .query()
+      .from("GinArticle", "d")
+      .whereNode("d", (document) => document.$fulltext.matches("signal", 10))
+      .select((sel) => ({ id: sel.d.id }))
+      .toSQL();
+    expect(single.sql).not.toContain('websearch_to_tsquery("language"');
+    expect(single.params).toContain("english");
+
+    // Mixed-language alias (english base + french subclass): falls back
+    // to the per-row column — a constant would mis-parse one kind.
+    const mixed = store
+      .query()
+      .from("GinArticle", "d", { includeSubClasses: true })
+      .whereNode("d", (document) => document.$fulltext.matches("signal", 10))
+      .select((sel) => ({ id: sel.d.id }))
+      .toSQL();
+    expect(mixed.sql).toContain('websearch_to_tsquery("language"');
+  });
+});
+
+describe("facade forwards the declared language (any backend)", () => {
+  it("passes the declared language, and explicit overrides win", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const graph = defineGraph({
+        id: "gin_wiring",
+        nodes: { GinArticle: { type: Article } },
+        edges: {},
+      });
+      const [store] = await createStoreWithSchema(graph, backend);
+      await store.nodes.GinArticle.create({ title: "signal doc" });
+
+      const spy = vi.spyOn(
+        backend as {
+          fulltextSearch: NonNullable<GraphBackend["fulltextSearch"]>;
+        },
+        "fulltextSearch",
+      );
+      await store.search.fulltext("GinArticle", {
+        query: "signal",
+        limit: 5,
+      });
+      expect(spy.mock.calls[0]![0].language).toBe("english");
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("explicit per-query overrides win over the declared language", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const graph = defineGraph({
+      id: "gin_override",
+      nodes: { GinArticle: { type: Article } },
+      edges: {},
+    });
+    const backend = createPostgresBackend(drizzle(activePool));
+    const [store] = await createStoreWithSchema(graph, backend);
+    await store.nodes.GinArticle.create({ title: "signal doc" });
+
+    const spy = vi.spyOn(
+      backend as {
+        fulltextSearch: NonNullable<GraphBackend["fulltextSearch"]>;
+      },
+      "fulltextSearch",
+    );
+    await store.search.fulltext("GinArticle", {
+      query: "signal",
+      limit: 5,
+      language: "simple",
+    });
+    expect(spy.mock.calls[0]![0].language).toBe("simple");
+  });
+});


### PR DESCRIPTION
First item from the post-audit target list: **PostgreSQL fulltext could never use its GIN index.**

## The problem

The `tsv` column has always carried a GIN index, but the default search path parsed queries with the per-row language column — `websearch_to_tsquery("language", $q)` — a non-constant tsquery the index can never serve. Every captured plan confirms it: fulltext matches ran as a per-row `Filter` under the kind btree, re-parsing the query for every row of the kind. Invisible at bench scale; a scaling wall at 100k+ documents.

## The fix

The language was never actually dynamic: rows are written with their kind's **declared** language (the winning-language rule in `fulltext-sync`). Search now resolves that declared language and passes it as a plan-time constant:

- **Facade** (`fulltext` + both hybrid paths): resolved per kind from the registry; explicit per-query overrides still win.
- **Inline `$fulltext`**: a per-kind language map threads through compile options (memoized per registry, same pattern as vector slots); the CTE emits a constant when every kind in the alias shares one declared language, and keeps the per-row form for mixed-language subclass aliases — a constant would mis-parse one kind.
- `getSearchableFields` moves to `core/searchable` so the query layer can resolve languages without a store dependency (mirrors `core/embedding`).

## Measured (5,000 docs, PG lane)

| form | broad term |
| --- | --- |
| per-row language (before) | 12.9ms |
| declared-language constant (after) | 2.3ms |

That 5.6× is from eliminating the per-row query parse alone. On top of it, a constant tsquery is **GIN-servable** (0.016ms on the minimal match shape) — at test scale the planner may still prefer the kind btree on cost, but the index choice now *exists*, and it dominates as rows-per-kind grow. The per-row form can never be GIN-served regardless of costing — both directions pinned by plan tests.

## Semantics

Unchanged for the normal case: rows' `tsv` was built with the declared language, so parsing queries with the same config is what the per-row form did anyway. A kind whose language declaration changed without `rebuildFulltext()` now parses queries with the *new* declared config (previously mixed per row) — consistent with the rebuild contract. Explicit overrides and mixed-language aliases behave exactly as before.
