### PR TITLE
perf: run the subgraph traversal once on Postgres

### DIFF
--- a/.changeset/subgraph-shared-traversal.md
+++ b/.changeset/subgraph-shared-traversal.md
@@ -1,0 +1,17 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Subgraph extraction on PostgreSQL now runs the recursive traversal once
+instead of twice. The node and edge fetches previously each embedded the
+full recursive CTE; the closure ids are now fetched in one statement and
+passed to both fetches as a single `text[]` parameter, filtered via an
+`EXISTS` semi-join over `unnest`. Those id-filtered fetches execute as
+unnamed statements so PostgreSQL plans them against the actual array on
+every call — a named prepared statement flips to a generic plan after
+five executions, which mis-plans array-cardinality-dependent filters
+(measured 21ms → 310ms on the edge fetch). Depth-3 stress subgraph
+(1,109 nodes / 4,513 edges, wide payloads): 82.9ms → 30.9ms full
+hydration, 72.3ms → 15.6ms with SQL projection. SQLite keeps its
+existing single-statement-per-fetch form, which is already optimal for
+an in-process engine.

--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -1,6 +1,7 @@
 import { type SQL } from "drizzle-orm";
 import { type PgDatabase, type PgQueryResultHKT } from "drizzle-orm/pg-core";
 
+import { shouldForceCustomPlan } from "../../../query/sql-intent";
 import { getOrCreateLru } from "./lru";
 import {
   type CompiledSqlQuery,
@@ -28,6 +29,15 @@ type PgQueryResult = Readonly<{
  */
 type PgQueryClient = Readonly<{
   query: (sqlText: string, params: readonly unknown[]) => Promise<PgQueryResult>;
+  /**
+   * Executes WITHOUT a named server-side prepared statement, so the
+   * server plans against the actual parameter values on every call.
+   * Used for statements marked `markForceCustomPlan` (see sql-intent).
+   */
+  queryUnnamed: (
+    sqlText: string,
+    params: readonly unknown[],
+  ) => Promise<PgQueryResult>;
 }>;
 
 /**
@@ -265,6 +275,13 @@ function wrapNodePgClient(
       });
       return { rows: normalizeRows(result.rows) };
     },
+    async queryUnnamed(
+      sqlText: string,
+      params: readonly unknown[],
+    ): Promise<PgQueryResult> {
+      const result = await client.query(sqlText, params);
+      return { rows: normalizeRows(result.rows) };
+    },
   };
 }
 
@@ -279,29 +296,37 @@ function wrapNodePgClient(
  * downstream stays identical.
  */
 function wrapNodePgClientUnnamed(client: NodePgClient): PgQueryClient {
+  async function queryUnnamed(
+    sqlText: string,
+    params: readonly unknown[],
+  ): Promise<PgQueryResult> {
+    const result = await client.query(sqlText, params);
+    return { rows: normalizeRows(result.rows) };
+  }
   return {
-    async query(
-      sqlText: string,
-      params: readonly unknown[],
-    ): Promise<PgQueryResult> {
-      const result = await client.query(sqlText, params);
-      return { rows: normalizeRows(result.rows) };
-    },
+    query: queryUnnamed,
+    queryUnnamed,
   };
 }
 
 function adaptPostgresJsClient(sql: PostgresJsClient): PgQueryClient {
+  async function query(
+    sqlText: string,
+    params: readonly unknown[],
+  ): Promise<PgQueryResult> {
+    // postgres-js handles its own statement preparation internally
+    // (controlled by the `prepare` connection option, default true),
+    // so we don't need to name statements here ourselves.
+    const rows = await sql.unsafe(sqlText, params);
+    return { rows };
+  }
   return {
-    async query(
-      sqlText: string,
-      params: readonly unknown[],
-    ): Promise<PgQueryResult> {
-      // postgres-js handles its own statement preparation internally
-      // (controlled by the `prepare` connection option, default true),
-      // so we don't need to name statements here ourselves.
-      const rows = await sql.unsafe(sqlText, params);
-      return { rows };
-    },
+    query,
+    // postgres-js exposes no per-call opt-out of its internal
+    // preparation through `.unsafe`, so custom-plan-preferring
+    // statements take the same path; the generic-plan hazard on this
+    // driver is governed by its `prepare` connection option.
+    queryUnnamed: query,
   };
 }
 
@@ -479,6 +504,13 @@ export function createPostgresExecutionAdapter(
       // the server-side prepared-statement path because the wrapped
       // client assigns each unique SQL a stable statement name.
       const compiled = compile(query);
+      if (shouldForceCustomPlan(query)) {
+        const result = await pgQueryClient.queryUnnamed(
+          compiled.sql,
+          compiled.params,
+        );
+        return result.rows as readonly TRow[];
+      }
       return executeCompiled<TRow>(compiled);
     },
     executeCompiled,

--- a/packages/typegraph/src/query/sql-intent.ts
+++ b/packages/typegraph/src/query/sql-intent.ts
@@ -22,3 +22,23 @@ export function asCompiledSelectSql(query: SQL): CompiledSelectSql {
 export function asCompiledStatementSql(query: SQL): CompiledStatementSql {
   return query as CompiledStatementSql;
 }
+
+/**
+ * Statements whose good plan depends on the bound parameter values —
+ * e.g. an id-array membership filter where the array cardinality varies
+ * per call. PostgreSQL's prepared-statement machinery switches to a
+ * generic (parameter-blind) plan after five executions, which for these
+ * statements is catastrophically wrong (measured 21ms -> 310ms on the
+ * subgraph edge fetch). Marked statements are executed unnamed so every
+ * call is planned against the actual parameters; the re-parse cost is
+ * ~1ms, the generic-plan cliff it avoids is 10-300ms.
+ */
+const forceCustomPlanQueries = new WeakSet<SQL>();
+
+export function markForceCustomPlan(query: SQL): void {
+  forceCustomPlanQueries.add(query);
+}
+
+export function shouldForceCustomPlan(query: SQL): boolean {
+  return forceCustomPlanQueries.has(query);
+}

--- a/packages/typegraph/src/store/subgraph.ts
+++ b/packages/typegraph/src/store/subgraph.ts
@@ -43,7 +43,7 @@ import {
   type FieldTypeInfo,
   type SchemaIntrospector,
 } from "../query/schema-introspector";
-import { asCompiledRowsSql } from "../query/sql-intent";
+import { asCompiledRowsSql, markForceCustomPlan } from "../query/sql-intent";
 import { fnv1aBase36 } from "../utils/hash";
 import { buildReachableCte } from "./recursive-cte";
 import { validateProjectionField } from "./reserved-keys";
@@ -564,9 +564,44 @@ export async function executeSubgraph<
   });
   const includedIdsCte = buildIncludedIdsCte(ctx);
 
+  // The node and edge fetches both need the traversal closure. Embedding
+  // the recursive CTE in each statement runs the BFS twice; on Postgres
+  // the closure ids are fetched ONCE and passed to both fetches as a
+  // single text[] parameter, filtered via a hashed semi-join
+  // (EXISTS over unnest — measured faster than `= ANY` on the same
+  // closure). SQLite keeps the embedded form: its in-process traversal
+  // is cheap, an id list would bind one parameter per id (bind-budget
+  // pressure), and per-count SQL texts would churn the prepared-statement
+  // cache.
+  let membership: SubgraphMembership;
+  if (ctx.dialect.name === "postgres") {
+    const includedIds = await fetchIncludedIds(
+      ctx,
+      reachableCte,
+      includedIdsCte,
+    );
+    const idsArray = textArrayParam(includedIds);
+    membership = {
+      prefix: sql``,
+      idFilter: (column) =>
+        sql`EXISTS (SELECT 1 FROM unnest(${idsArray}) AS tg_included(id) WHERE tg_included.id = ${column})`,
+      parameterDependentPlan: true,
+    };
+  } else {
+    membership = {
+      prefix: sql`${reachableCte}${includedIdsCte} `,
+      idFilter: (column) =>
+        ctx.dialect.subqueryMembership(
+          column,
+          sql.raw("SELECT id FROM included_ids"),
+        ),
+      parameterDependentPlan: false,
+    };
+  }
+
   const [nodeRows, edgeRows] = await Promise.all([
-    fetchSubgraphNodes(ctx, reachableCte, includedIdsCte, nodeProjectionPlan),
-    fetchSubgraphEdges(ctx, reachableCte, includedIdsCte, edgeProjectionPlan),
+    fetchSubgraphNodes(ctx, membership, nodeProjectionPlan),
+    fetchSubgraphEdges(ctx, membership, edgeProjectionPlan),
   ]);
 
   const nodesMap = new Map<string, Node>();
@@ -722,10 +757,55 @@ function buildIncludedIdsCte(ctx: SubgraphContext): SQL {
   return sql`, included_ids AS (SELECT DISTINCT id FROM reachable${whereClause})`;
 }
 
-async function fetchSubgraphNodes(
+/**
+ * How the node/edge fetches restrict rows to the traversal closure:
+ * either a statement prefix re-declaring the recursive CTE with an
+ * `included_ids` membership subquery (SQLite), or an empty prefix with a
+ * pre-fetched id-array filter (Postgres).
+ */
+type SubgraphMembership = Readonly<{
+  prefix: SQL;
+  idFilter: (column: SQL) => SQL;
+  /**
+   * True in id-array mode: the fetch plans depend on the array
+   * cardinality, so the statements must never fall onto a prepared
+   * generic plan (see markForceCustomPlan).
+   */
+  parameterDependentPlan: boolean;
+}>;
+
+/**
+ * Binds a string list as ONE text parameter in Postgres array-literal
+ * form, cast to text[]. A single parameter keeps the statement text
+ * constant across id counts, and the fetch statements semi-join against
+ * `unnest` of the array. (Drizzle would otherwise serialize a JS array
+ * param as JSON text.)
+ */
+function textArrayParam(values: readonly string[]): SQL {
+  const elements = values.map(
+    (value) =>
+      `"${value.replaceAll("\\", "\\\\").replaceAll('"', String.raw`\"`)}"`,
+  );
+  return sql`${`{${elements.join(",")}}`}::text[]`;
+}
+
+/** Runs the traversal once and returns the closure's node ids. */
+async function fetchIncludedIds(
   ctx: SubgraphContext,
   reachableCte: SQL,
   includedIdsCte: SQL,
+): Promise<readonly string[]> {
+  const rows = await ctx.backend.execute<{ id: string }>(
+    asCompiledRowsSql(
+      sql`${reachableCte}${includedIdsCte} SELECT id FROM included_ids`,
+    ),
+  );
+  return rows.map((row) => row.id);
+}
+
+async function fetchSubgraphNodes(
+  ctx: SubgraphContext,
+  membership: SubgraphMembership,
   projectionPlan: ProjectionPlan,
 ): Promise<SubgraphNodeFetchRow[]> {
   const nodeTemporalFilter = compileTemporalFilter({
@@ -750,7 +830,8 @@ async function fetchSubgraphNodes(
     ...buildProjectedPropertyColumns("n", projectionPlan, ctx.dialect),
   ];
 
-  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.nodesTable} n WHERE n.graph_id = ${ctx.graphId} AND ${nodeTemporalFilter} AND ${ctx.dialect.subqueryMembership(sql.raw("n.id"), sql.raw("SELECT id FROM included_ids"))}`;
+  const query = sql`${membership.prefix}SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.nodesTable} n WHERE n.graph_id = ${ctx.graphId} AND ${nodeTemporalFilter} AND ${membership.idFilter(sql.raw("n.id"))}`;
+  if (membership.parameterDependentPlan) markForceCustomPlan(query);
 
   return ctx.backend.execute<SubgraphNodeFetchRow>(
     asCompiledRowsSql(query),
@@ -759,8 +840,7 @@ async function fetchSubgraphNodes(
 
 async function fetchSubgraphEdges(
   ctx: SubgraphContext,
-  reachableCte: SQL,
-  includedIdsCte: SQL,
+  membership: SubgraphMembership,
   projectionPlan: ProjectionPlan,
 ): Promise<SubgraphEdgeFetchRow[]> {
   const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), ctx.edgeKinds);
@@ -789,7 +869,8 @@ async function fetchSubgraphEdges(
     ...buildProjectedPropertyColumns("e", projectionPlan, ctx.dialect),
   ];
 
-  const query = sql`${reachableCte}${includedIdsCte} SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND ${edgeTemporalFilter} AND ${ctx.dialect.subqueryMembership(sql.raw("e.from_id"), sql.raw("SELECT id FROM included_ids"))} AND ${ctx.dialect.subqueryMembership(sql.raw("e.to_id"), sql.raw("SELECT id FROM included_ids"))}`;
+  const query = sql`${membership.prefix}SELECT ${sql.join(columns, sql`, `)} FROM ${ctx.schema.edgesTable} e WHERE e.graph_id = ${ctx.graphId} AND ${edgeKindFilter} AND ${edgeTemporalFilter} AND ${membership.idFilter(sql.raw("e.from_id"))} AND ${membership.idFilter(sql.raw("e.to_id"))}`;
+  if (membership.parameterDependentPlan) markForceCustomPlan(query);
 
   return ctx.backend.execute<SubgraphEdgeFetchRow>(
     asCompiledRowsSql(query),

--- a/packages/typegraph/tests/backends/postgres/subgraph-shared-traversal.test.ts
+++ b/packages/typegraph/tests/backends/postgres/subgraph-shared-traversal.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Subgraph shared traversal on Postgres: the recursive BFS closure is
+ * computed ONCE and its ids passed to the node and edge fetches as a
+ * single text[] parameter, instead of embedding the recursive CTE in
+ * both statements (which re-ran the traversal twice per call).
+ *
+ * Pinned here:
+ * 1. Statement shape — exactly one executed statement contains the
+ *    recursive traversal; the node/edge fetches semi-join an unnest of
+ *    the id-array parameter instead of re-declaring the CTE.
+ * 2. Array-literal escaping — user-supplied ids containing quotes,
+ *    backslashes, commas, and braces survive the text[] round trip.
+ * 3. Plan mode — the id-filtered fetches run as UNNAMED statements.
+ *    A named prepared statement flips to a generic (parameter-blind)
+ *    plan after five executions, and for an id-array filter whose
+ *    cardinality varies per call that plan is catastrophic (measured
+ *    21ms -> 310ms on the edge fetch). Unnamed execution re-plans
+ *    against the actual array every call.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { randomUUID } from "node:crypto";
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import type { GraphBackend } from "../../../src/backend/types";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let pool: Pool | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): Pool {
+  if (!isPostgresAvailable || pool === undefined) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return pool;
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  const candidate = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+  });
+  try {
+    await candidate.query("SELECT 1");
+    await candidate.query(generatePostgresMigrationSQL());
+    pool = candidate;
+    isPostgresAvailable = true;
+  } catch {
+    await candidate.end().catch(() => {
+      // Unreachable Postgres degrades to "skip".
+    });
+  }
+});
+
+afterAll(async () => {
+  if (pool !== undefined) await pool.end();
+});
+
+const Document = defineNode("Doc", {
+  schema: z.object({ title: z.string() }),
+});
+const references = defineEdge("references", { schema: z.object({}) });
+
+function buildGraph(graphId: string) {
+  return defineGraph({
+    id: graphId,
+    nodes: { Doc: { type: Document } },
+    edges: {
+      references: { type: references, from: [Document], to: [Document] },
+    },
+  });
+}
+
+/**
+ * Wraps GraphBackend.execute to record compiled statement text. The
+ * subgraph path executes through backend.execute (adapter prepared
+ * path), which the drizzle logger does not see.
+ */
+function withStatementCapture(backend: GraphBackend): {
+  backend: GraphBackend;
+  statements: string[];
+} {
+  const statements: string[] = [];
+  const compileSql = backend.compileSql;
+  if (compileSql === undefined) {
+    throw new Error("Postgres backend must expose compileSql");
+  }
+  const captured: GraphBackend = {
+    ...backend,
+    execute: (query) => {
+      statements.push(compileSql(query).sql);
+      return backend.execute(query);
+    },
+  };
+  return { backend: captured, statements };
+}
+
+describe("subgraph shared traversal (Postgres)", () => {
+  it("runs the recursive traversal once; fetches filter by id array", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const raw = createPostgresBackend(drizzle(activePool));
+    const { backend, statements } = withStatementCapture(raw);
+    const [store] = await createStoreWithSchema(
+      buildGraph(`subgraph_shape_${randomUUID().slice(0, 8)}`),
+      backend,
+    );
+
+    const root = await store.nodes.Doc.create({ title: "root" });
+    const child = await store.nodes.Doc.create({ title: "child" });
+    await store.edges.references.create(root, child, {});
+
+    statements.length = 0;
+    const result = await store.subgraph(root.id, {
+      edges: ["references"],
+      maxDepth: 3,
+    });
+    expect(result.nodes.size).toBe(2);
+
+    const recursive = statements.filter((statement) =>
+      statement.includes("WITH RECURSIVE"),
+    );
+    expect(recursive).toHaveLength(1);
+
+    const fetches = statements.filter((statement) =>
+      statement.includes("unnest("),
+    );
+    expect(fetches.length).toBeGreaterThanOrEqual(2);
+    for (const fetch of fetches) {
+      expect(fetch).not.toContain("WITH RECURSIVE");
+      expect(fetch).toContain("::text[]");
+    }
+  });
+
+  it("executes the id-filtered fetches unnamed, keeping custom plans", async (ctx) => {
+    requirePostgres(ctx);
+    const spyPool = new Pool({
+      connectionString: TEST_DATABASE_URL,
+      connectionTimeoutMillis: 5000,
+    });
+    try {
+      const submitted: { name: string | undefined; text: string }[] = [];
+      const originalQuery = spyPool.query.bind(spyPool);
+      (spyPool as { query: unknown }).query = (
+        config: unknown,
+        ...rest: unknown[]
+      ) => {
+        if (typeof config === "string") {
+          submitted.push({ name: undefined, text: config });
+        } else if (
+          typeof config === "object" &&
+          config !== null &&
+          "text" in config
+        ) {
+          const typed = config as { name?: string; text: string };
+          submitted.push({ name: typed.name, text: typed.text });
+        }
+        return (originalQuery as (...args: unknown[]) => unknown)(
+          config,
+          ...rest,
+        );
+      };
+
+      const backend = createPostgresBackend(drizzle(spyPool));
+      const [store] = await createStoreWithSchema(
+        buildGraph(`subgraph_plan_${randomUUID().slice(0, 8)}`),
+        backend,
+      );
+      const root = await store.nodes.Doc.create({ title: "root" });
+      const child = await store.nodes.Doc.create({ title: "child" });
+      await store.edges.references.create(root, child, {});
+
+      submitted.length = 0;
+      await store.subgraph(root.id, { edges: ["references"], maxDepth: 2 });
+
+      const fetches = submitted.filter((call) => call.text.includes("unnest("));
+      expect(fetches.length).toBeGreaterThanOrEqual(2);
+      for (const fetch of fetches) {
+        expect(fetch.name).toBeUndefined();
+      }
+
+      // The traversal itself has scalar parameters and stays on the
+      // named prepared path.
+      const traversal = submitted.filter((call) =>
+        call.text.includes("WITH RECURSIVE"),
+      );
+      expect(traversal).toHaveLength(1);
+      expect(traversal[0]?.name).toBeDefined();
+    } finally {
+      await spyPool.end();
+    }
+  });
+
+  it("round-trips hostile user-supplied ids through the array literal", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const backend = createPostgresBackend(drizzle(activePool));
+    const [store] = await createStoreWithSchema(
+      buildGraph(`subgraph_ids_${randomUUID().slice(0, 8)}`),
+      backend,
+    );
+
+    const hostileIds = [
+      'quote-"-id',
+      String.raw`backslash-\-id`,
+      "comma-,-id",
+      "brace-{}-id",
+      String.raw`mixed-\"{,}\\-id`,
+    ] as const;
+
+    const root = await store.nodes.Doc.create(
+      { title: "root" },
+      { id: "hostile-root" },
+    );
+    for (const id of hostileIds) {
+      const node = await store.nodes.Doc.create({ title: id }, { id });
+      await store.edges.references.create(root, node, {});
+    }
+
+    const result = await store.subgraph(root.id, {
+      edges: ["references"],
+      maxDepth: 2,
+    });
+
+    expect(result.nodes.size).toBe(hostileIds.length + 1);
+    for (const id of hostileIds) {
+      expect(
+        (result.nodes.get(id) as { title?: string } | undefined)?.title,
+      ).toBe(id);
+    }
+    expect(result.adjacency.get(root.id)?.get("references")).toHaveLength(
+      hostileIds.length,
+    );
+  });
+});


### PR DESCRIPTION
Second item from the post-audit target list: **PG subgraph ran the recursive traversal twice — and the fix surfaced a nastier prepared-statement plan cliff.**

## What was happening

`store.subgraph()` builds one recursive BFS CTE and embedded it in BOTH the node fetch and the edge fetch — every call paid the traversal twice. Depth-3 stress shape (1,109 nodes / 4,513 edges, wide payloads): 82.9ms.

## The fix

On Postgres the closure ids are fetched once, then both fetches filter by a single `text[]` parameter with an `EXISTS` semi-join over `unnest`. One parameter regardless of id count, so the statement text stays constant. SQLite keeps the embedded form deliberately: its in-process traversal is cheap, an id list would bind one parameter per id (bind-budget pressure), and per-count SQL texts would churn the prepared-statement cache.

## The plan cliff (the interesting part)

The first cut looked like a no-op in the bench (~82ms) while a 9-iteration spike showed 40ms. Per-iteration timing found the cause: **PostgreSQL's prepared statements flip to a generic, parameter-blind plan after five executions**, and for an id-array filter whose cardinality varies per call the generic plan is catastrophic:

| form | custom plan | generic plan (exec ≥6) |
| --- | --- | --- |
| `= ANY($1::text[])` | 21ms | **310ms** |
| `EXISTS … unnest($1)` | 10ms | 35ms |

No membership form survives the generic plan, so the id-filtered fetches now execute **unnamed** — a `markForceCustomPlan` brand in `sql-intent`, honored by the node-pg prepared path (`queryUnnamed` on the wrapped client). Every call re-plans against the actual array for ~1ms of parse; the traversal statement itself has scalar parameters and stays on the named prepared path. (postgres-js has no per-call opt-out of its internal preparation; its hazard is governed by the driver-level `prepare` option — noted in the adapter.)

## Measured (PG bench, depth-3 stress, medians — stable across 30 sustained iterations)

| scenario | before | after |
| --- | --- | --- |
| full hydration | 82.9ms | **30.9ms** |
| + app projection | 82.5ms | 32.4ms |
| SQL projection | 72.3ms | **15.6ms** |
| depth-2 full hydration | 7.2ms | 6.3ms |

## Tests

New PG suite `subgraph-shared-traversal.test.ts`: single recursive statement per call with unnest semi-join fetches; id-filtered fetches submitted unnamed while the traversal stays named (pool-level query spy); hostile user-supplied ids (quotes, backslashes, commas, braces) round-trip the array-literal encoding. Existing subgraph suites cover behavior on both backends.

## Verification

fix / typecheck / knip clean; SQLite 4504 passed; PG lane 1806 passed. Changeset: patch.