### PR TITLE
perf: auto-refresh planner statistics after large bulk writes

### DIFF
--- a/.changeset/auto-refresh-statistics.md
+++ b/.changeset/auto-refresh-statistics.md
@@ -2,7 +2,8 @@
 "@nicia-ai/typegraph": patch
 ---
 
-Autocommit `bulkCreate` calls (nodes and edges) now refresh planner
+Autocommit `bulkCreate` and `bulkInsert` calls (nodes and edges) now
+refresh planner
 statistics automatically when a single call writes 1,000 rows or more,
 closing the stale-statistics window after bulk loads where the planner
 keeps pre-load row estimates until ANALYZE runs (observed 25-200x

--- a/.changeset/auto-refresh-statistics.md
+++ b/.changeset/auto-refresh-statistics.md
@@ -1,0 +1,15 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Autocommit `bulkCreate` calls (nodes and edges) now refresh planner
+statistics automatically when a single call writes 1,000 rows or more,
+closing the stale-statistics window after bulk loads where the planner
+keeps pre-load row estimates until ANALYZE runs (observed 25-200x
+slowdowns on traversal and fulltext shapes). Tune the threshold or
+disable with the new `autoRefreshStatistics` store option
+(`createStore(graph, backend, { autoRefreshStatistics: 5000 })` or
+`false`). Bulk writes inside a caller-provided transaction never
+auto-refresh — statistics cannot see uncommitted rows — and a refresh
+failure degrades to a warning without failing the committed write.
+`importGraph()` keeps its existing built-in refresh.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -466,9 +466,26 @@ that created or updated rows, and `store.materializeIndexes()` does the
 same on SQLite after creating indexes (pass `refreshStatistics: false` to
 opt out). On PostgreSQL, `materializeIndexes()` builds with
 `CREATE INDEX CONCURRENTLY` and skips the automatic refresh — call
-`store.refreshStatistics()` after materializing. For other bulk paths — a
-`bulkCreate` loop, backend-level batch inserts — call
-`store.refreshStatistics()` yourself once the load completes.
+`store.refreshStatistics()` after materializing.
+
+`bulkCreate` on nodes and edges also refreshes automatically when a
+single autocommit call writes 1,000 rows or more. Tune or disable this
+with the `autoRefreshStatistics` store option:
+
+```typescript
+// Refresh after any autocommit bulkCreate of 5,000+ rows
+const store = createStore(graph, backend, { autoRefreshStatistics: 5000 });
+
+// Never refresh automatically after bulkCreate
+const store = createStore(graph, backend, { autoRefreshStatistics: false });
+```
+
+Bulk writes inside a `store.transaction(...)` block never auto-refresh —
+statistics collected mid-transaction cannot see the uncommitted rows —
+so refresh manually after the transaction commits. The same applies to
+loops of small `bulkCreate` batches that never individually reach the
+threshold, and to backend-level batch inserts — the loop example below
+covers that pattern.
 
 PostgreSQL's query planner relies on table statistics to choose
 between multi-column indexes on `typegraph_edges` (forward vs reverse vs

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -468,8 +468,8 @@ opt out). On PostgreSQL, `materializeIndexes()` builds with
 `CREATE INDEX CONCURRENTLY` and skips the automatic refresh — call
 `store.refreshStatistics()` after materializing.
 
-`bulkCreate` on nodes and edges also refreshes automatically when a
-single autocommit call writes 1,000 rows or more. Tune or disable this
+`bulkCreate` and `bulkInsert` on nodes and edges also refresh
+automatically when a single autocommit call writes 1,000 rows or more. Tune or disable this
 with the `autoRefreshStatistics` store option:
 
 ```typescript

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -459,7 +459,7 @@ function createStore<G extends GraphDef>(
 | `recordedRead` | `ExternalRecordedReadSource` | Bind an already-populated recorded relation for `store.asOfRecorded(T)` reads without enabling TypeGraph-managed capture. Must be created with `recordedRelation({ schema })` using a `createSqlSchema(...)` schema; the store validates those factory descriptors at runtime. Use `history: true` when TypeGraph should capture writes and advance `store.recordedNow()`. |
 | `schema` | `SqlSchema` | Custom table name configuration created with `createSqlSchema(...)` |
 | `queryDefaults.traversalExpansion` | `TraversalExpansion` | Default ontology expansion mode for traversals (default: `"inverse"`) |
-| `autoRefreshStatistics` | `false \| number` | Row threshold at which a single autocommit `bulkCreate` triggers an automatic planner-statistics refresh (default: `1000`); `false` disables. See [Refreshing planner statistics](/backend-setup#refreshing-planner-statistics-after-bulk-loads). |
+| `autoRefreshStatistics` | `false \| number` | Row threshold at which a single autocommit `bulkCreate`/`bulkInsert` triggers an automatic planner-statistics refresh (default: `1000`); `false` disables. See [Refreshing planner statistics](/backend-setup#refreshing-planner-statistics-after-bulk-loads). |
 
 **Example:**
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -459,6 +459,7 @@ function createStore<G extends GraphDef>(
 | `recordedRead` | `ExternalRecordedReadSource` | Bind an already-populated recorded relation for `store.asOfRecorded(T)` reads without enabling TypeGraph-managed capture. Must be created with `recordedRelation({ schema })` using a `createSqlSchema(...)` schema; the store validates those factory descriptors at runtime. Use `history: true` when TypeGraph should capture writes and advance `store.recordedNow()`. |
 | `schema` | `SqlSchema` | Custom table name configuration created with `createSqlSchema(...)` |
 | `queryDefaults.traversalExpansion` | `TraversalExpansion` | Default ontology expansion mode for traversals (default: `"inverse"`) |
+| `autoRefreshStatistics` | `false \| number` | Row threshold at which a single autocommit `bulkCreate` triggers an automatic planner-statistics refresh (default: `1000`); `false` disables. See [Refreshing planner statistics](/backend-setup#refreshing-planner-statistics-after-bulk-loads). |
 
 **Example:**
 

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -33,6 +33,13 @@ import {
 export type NodeOperations = Readonly<{
   defaultTemporalMode: TemporalMode;
   rowToNode: (row: NodeRow) => Node;
+  /**
+   * Store-provided hook run after an autocommit bulk write completes;
+   * refreshes planner statistics when the row count crosses the
+   * configured threshold. Absent on transaction-scoped collections.
+   */
+  maybeRefreshStatisticsAfterBulk?:
+    ((rowCount: number) => Promise<void>) | undefined;
   executeCreate: (
     input: CreateNodeInput,
     backend: GraphBackend | TransactionBackend,
@@ -105,6 +112,13 @@ export type NodeOperations = Readonly<{
 export type EdgeOperations = Readonly<{
   defaultTemporalMode: TemporalMode;
   rowToEdge: (row: EdgeRow) => Edge;
+  /**
+   * Store-provided hook run after an autocommit bulk write completes;
+   * refreshes planner statistics when the row count crosses the
+   * configured threshold. Absent on transaction-scoped collections.
+   */
+  maybeRefreshStatisticsAfterBulk?:
+    ((rowCount: number) => Promise<void>) | undefined;
   executeCreate: (
     input: CreateEdgeInput,
     backend: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -602,10 +602,12 @@ export function createEdgeCollection<
         await backend.transaction(async (txBackend) => {
           await executeEdgeCreateNoReturnBatch(batchInputs, txBackend);
         });
+        await config.maybeRefreshStatisticsAfterBulk?.(batchInputs.length);
         return;
       }
 
       await executeEdgeCreateNoReturnBatch(batchInputs, backend);
+      await config.maybeRefreshStatisticsAfterBulk?.(batchInputs.length);
     },
 
     async bulkDelete(ids: readonly string[]): Promise<void> {

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -58,6 +58,9 @@ export type EdgeCollectionConfig = Readonly<{
   backend: GraphBackend | TransactionBackend;
   defaultTemporalMode: TemporalMode;
   rowToEdge: (row: EdgeRow) => Edge;
+  /** See EdgeOperations.maybeRefreshStatisticsAfterBulk. */
+  maybeRefreshStatisticsAfterBulk?:
+    ((rowCount: number) => Promise<void>) | undefined;
   executeCreate: (
     input: CreateEdgeInput,
     backend: GraphBackend | TransactionBackend,
@@ -496,9 +499,11 @@ export function createEdgeCollection<
         const results = await backend.transaction(async (txBackend) =>
           executeEdgeCreateBatch(batchInputs, txBackend),
         );
+        await config.maybeRefreshStatisticsAfterBulk?.(results.length);
         return narrowEdges<E>(results);
       }
       const results = await executeEdgeCreateBatch(batchInputs, backend);
+      await config.maybeRefreshStatisticsAfterBulk?.(results.length);
       return narrowEdges<E>(results);
     },
 

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -59,6 +59,9 @@ export type NodeCollectionConfig = Readonly<{
   backend: GraphBackend | TransactionBackend;
   defaultTemporalMode: TemporalMode;
   rowToNode: (row: NodeRow) => Node;
+  /** See NodeOperations.maybeRefreshStatisticsAfterBulk. */
+  maybeRefreshStatisticsAfterBulk?:
+    ((rowCount: number) => Promise<void>) | undefined;
   executeCreate: (
     input: CreateNodeInput,
     backend: GraphBackend | TransactionBackend,
@@ -384,9 +387,11 @@ export function createNodeCollection<
         const results = await backend.transaction(async (txBackend) =>
           executeNodeCreateBatch(batchInputs, txBackend),
         );
+        await config.maybeRefreshStatisticsAfterBulk?.(results.length);
         return narrowNodes<N>(results);
       }
       const results = await executeNodeCreateBatch(batchInputs, backend);
+      await config.maybeRefreshStatisticsAfterBulk?.(results.length);
       return narrowNodes<N>(results);
     },
 

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -499,10 +499,12 @@ export function createNodeCollection<
         await backend.transaction(async (txBackend) => {
           await executeNodeCreateNoReturnBatch(batchInputs, txBackend);
         });
+        await config.maybeRefreshStatisticsAfterBulk?.(batchInputs.length);
         return;
       }
 
       await executeNodeCreateNoReturnBatch(batchInputs, backend);
+      await config.maybeRefreshStatisticsAfterBulk?.(batchInputs.length);
     },
 
     async bulkDelete(ids: readonly NodeId<N>[]): Promise<void> {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -182,6 +182,7 @@ import {
   type SubgraphResult,
 } from "./subgraph";
 import {
+  AUTO_REFRESH_STATISTICS_ROW_THRESHOLD,
   type DynamicEdgeCollection,
   type DynamicNodeCollection,
   type Edge,
@@ -702,10 +703,33 @@ export class Store<G extends GraphDef> {
     return this.#buildNodeOperations(this.#createNodeOperationContext());
   }
 
+  /**
+   * Refreshes planner statistics after an autocommit bulk write that
+   * reached the configured row threshold. A refresh failure must never
+   * fail the (already committed) write — it degrades to a warning.
+   */
+  async #maybeRefreshStatisticsAfterBulk(rowCount: number): Promise<void> {
+    const configured = this.#options?.autoRefreshStatistics;
+    if (configured === false) return;
+    const threshold = configured ?? AUTO_REFRESH_STATISTICS_ROW_THRESHOLD;
+    if (rowCount < threshold) return;
+    try {
+      await this.refreshStatistics();
+    } catch (error) {
+      console.warn(
+        "typegraph: statistics refresh after bulk write failed; run " +
+          "store.refreshStatistics() to avoid stale planner statistics.",
+        error,
+      );
+    }
+  }
+
   #buildNodeOperations(ctx: NodeOperationContext<G>): NodeOperations {
     return {
       defaultTemporalMode: this.#graph.defaults.temporalMode,
       rowToNode: (row) => rowToNode(row),
+      maybeRefreshStatisticsAfterBulk: (rowCount) =>
+        this.#maybeRefreshStatisticsAfterBulk(rowCount),
       executeCreate: (input, backend) => executeNodeCreate(ctx, input, backend),
       executeCreateBatch: (inputs, backend) =>
         executeNodeCreateBatch(ctx, inputs, backend),
@@ -789,6 +813,8 @@ export class Store<G extends GraphDef> {
     return {
       defaultTemporalMode: this.#graph.defaults.temporalMode,
       rowToEdge: (row) => rowToEdge(row),
+      maybeRefreshStatisticsAfterBulk: (rowCount) =>
+        this.#maybeRefreshStatisticsAfterBulk(rowCount),
       executeCreate: (input, backend) => executeEdgeCreate(ctx, input, backend),
       executeCreateBatch: (inputs, backend) =>
         executeEdgeCreateBatch(ctx, inputs, backend),
@@ -1604,13 +1630,18 @@ export class Store<G extends GraphDef> {
     sql?: AdoptedTransaction,
     runHooks: OperationHookRunner = this.#immediateHookRunner(),
   ): TransactionContext<G> {
+    // No statistics auto-refresh inside a caller-provided transaction:
+    // ANALYZE from another connection cannot see the uncommitted rows,
+    // so it would only reset the counter without fixing the estimates.
     const txNodeOperations: NodeOperations = {
       ...this.#buildNodeOperations(this.#createNodeOperationContext(runHooks)),
       createQuery: () => this.#createQueryForBackend(txBackend),
+      maybeRefreshStatisticsAfterBulk: undefined,
     };
     const txEdgeOperations: EdgeOperations = {
       ...this.#buildEdgeOperations(this.#createEdgeOperationContext(runHooks)),
       createQuery: () => this.#createQueryForBackend(txBackend),
+      maybeRefreshStatisticsAfterBulk: undefined,
     };
 
     const runNodeOperationHooks = <T>(

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -317,7 +317,7 @@ type BaseStoreOptions = Readonly<{
   hooks?: StoreHooks;
   /**
    * Automatic planner-statistics refresh after large autocommit bulk
-   * writes (bulkCreate on nodes and edges). Stale statistics after a
+   * writes (bulkCreate and bulkInsert on nodes and edges). Stale statistics after a
    * bulk load are a whole class of planner cliffs: the planner keeps
    * pre-load row estimates until ANALYZE runs. When a single
    * autocommit bulk write reaches the threshold

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -305,9 +305,30 @@ export type StoreHooks = Readonly<{
 // Store Configuration
 // ============================================================
 
+/**
+ * Default row count at which an autocommit bulk write triggers an
+ * automatic planner-statistics refresh. Below this, the refresh cost is
+ * not worth paying per call and autovacuum/PRAGMA optimize cover it.
+ */
+export const AUTO_REFRESH_STATISTICS_ROW_THRESHOLD = 1000;
+
 type BaseStoreOptions = Readonly<{
   /** Observability hooks for monitoring */
   hooks?: StoreHooks;
+  /**
+   * Automatic planner-statistics refresh after large autocommit bulk
+   * writes (bulkCreate on nodes and edges). Stale statistics after a
+   * bulk load are a whole class of planner cliffs: the planner keeps
+   * pre-load row estimates until ANALYZE runs. When a single
+   * autocommit bulk write reaches the threshold
+   * ({@link AUTO_REFRESH_STATISTICS_ROW_THRESHOLD} rows by default),
+   * the store runs `refreshStatistics()` after the write commits.
+   * Pass a number to change the threshold, or `false` to disable.
+   * Bulk writes inside a caller-provided transaction never
+   * auto-refresh (statistics cannot see uncommitted rows); refresh
+   * manually after commit. `importGraph` handles its own refresh.
+   */
+  autoRefreshStatistics?: false | number;
   /** SQL schema configuration from createSqlSchema(...) for custom table names */
   schema?: SqlSchema;
   /** Query default behaviors. */

--- a/packages/typegraph/tests/auto-refresh-statistics.test.ts
+++ b/packages/typegraph/tests/auto-refresh-statistics.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Auto-refresh of planner statistics after large autocommit bulk writes.
+ *
+ * Stale statistics after a bulk load are a whole class of planner
+ * cliffs (25-200x observed): the planner keeps zero-row estimates until
+ * ANALYZE runs. Collections therefore refresh statistics automatically
+ * when a single autocommit bulkCreate writes at least
+ * AUTO_REFRESH_STATISTICS_ROW_THRESHOLD rows. Counted through a backend
+ * overlay spying on refreshStatistics.
+ *
+ * Deliberately NOT auto-refreshed: bulk writes inside a caller-provided
+ * transaction (statistics would be collected against a snapshot that
+ * cannot see the uncommitted rows; callers refresh after commit).
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "../src";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import type { GraphBackend } from "../src/backend/types";
+
+const THRESHOLD = 1000;
+
+const Item = defineNode("Item", {
+  schema: z.object({ name: z.string() }),
+});
+const relates = defineEdge("relates", { schema: z.object({}) });
+
+function buildGraph(graphId: string) {
+  return defineGraph({
+    id: graphId,
+    nodes: { Item: { type: Item } },
+    edges: {
+      relates: { type: relates, from: [Item], to: [Item] },
+    },
+  });
+}
+
+function withRefreshSpy(backend: GraphBackend): {
+  backend: GraphBackend;
+  refreshCount: () => number;
+} {
+  let count = 0;
+  const spied: GraphBackend = {
+    ...backend,
+    refreshStatistics: async () => {
+      count += 1;
+      await backend.refreshStatistics();
+    },
+  };
+  return { backend: spied, refreshCount: () => count };
+}
+
+function nodeItems(count: number): { props: { name: string } }[] {
+  return Array.from({ length: count }, (_, index) => ({
+    props: { name: `item-${index}` },
+  }));
+}
+
+describe("auto-refresh statistics after bulk writes", () => {
+  it("refreshes once after an autocommit bulkCreate at the threshold", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, refreshCount } = withRefreshSpy(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_threshold"),
+        backend,
+      );
+
+      await store.nodes.Item.bulkCreate(nodeItems(THRESHOLD));
+      expect(refreshCount()).toBe(1);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("does not refresh below the threshold", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, refreshCount } = withRefreshSpy(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_below"),
+        backend,
+      );
+
+      await store.nodes.Item.bulkCreate(nodeItems(THRESHOLD - 1));
+      expect(refreshCount()).toBe(0);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("refreshes after a bulk edge create at the threshold", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, refreshCount } = withRefreshSpy(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_edges"),
+        backend,
+      );
+
+      const nodes = await store.nodes.Item.bulkCreate(nodeItems(THRESHOLD));
+      expect(refreshCount()).toBe(1);
+
+      const hub = nodes[0];
+      if (hub === undefined) throw new Error("seed failed");
+      await store.edges.relates.bulkCreate(
+        nodes.map((node) => ({
+          from: { kind: "Item", id: hub.id },
+          to: { kind: "Item", id: node.id },
+          props: {},
+        })),
+      );
+      expect(refreshCount()).toBe(2);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("does not refresh inside a caller-provided transaction", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, refreshCount } = withRefreshSpy(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_txn"),
+        backend,
+      );
+
+      await store.transaction(async (tx) => {
+        await tx.nodes.Item.bulkCreate(nodeItems(THRESHOLD));
+      });
+      expect(refreshCount()).toBe(0);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("honors a custom threshold", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, refreshCount } = withRefreshSpy(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_custom"),
+        backend,
+        { autoRefreshStatistics: 10 },
+      );
+
+      await store.nodes.Item.bulkCreate(nodeItems(10));
+      expect(refreshCount()).toBe(1);
+      await store.nodes.Item.bulkCreate(nodeItems(9));
+      expect(refreshCount()).toBe(1);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("can be disabled entirely", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, refreshCount } = withRefreshSpy(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_off"),
+        backend,
+        { autoRefreshStatistics: false },
+      );
+
+      await store.nodes.Item.bulkCreate(nodeItems(THRESHOLD * 2));
+      expect(refreshCount()).toBe(0);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("a refresh failure does not fail the bulk write", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const failing: GraphBackend = {
+        ...rawBackend,
+        refreshStatistics: () => Promise.reject(new Error("refresh exploded")),
+      };
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_failure"),
+        failing,
+      );
+
+      const created = await store.nodes.Item.bulkCreate(nodeItems(THRESHOLD));
+      expect(created).toHaveLength(THRESHOLD);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+});

--- a/packages/typegraph/tests/auto-refresh-statistics.test.ts
+++ b/packages/typegraph/tests/auto-refresh-statistics.test.ts
@@ -122,6 +122,40 @@ describe("auto-refresh statistics after bulk writes", () => {
     }
   });
 
+  it("refreshes after autocommit bulkInsert on nodes and edges", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, refreshCount } = withRefreshSpy(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildGraph("stats_insert"),
+        backend,
+      );
+
+      await store.nodes.Item.create({ name: "hub" }, { id: "hub" });
+      await store.nodes.Item.bulkInsert(
+        Array.from({ length: THRESHOLD }, (_, index) => ({
+          props: { name: `spoke-${index}` },
+          id: `spoke-${index}`,
+        })),
+      );
+      expect(refreshCount()).toBe(1);
+
+      await store.edges.relates.bulkInsert(
+        Array.from({ length: THRESHOLD }, (_, index) => ({
+          from: { kind: "Item", id: "hub" },
+          to: { kind: "Item", id: `spoke-${index}` },
+          props: {},
+        })),
+      );
+      expect(refreshCount()).toBe(2);
+
+      await store.nodes.Item.bulkInsert(nodeItems(THRESHOLD - 1));
+      expect(refreshCount()).toBe(2);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
   it("does not refresh inside a caller-provided transaction", async () => {
     const { backend: rawBackend } = createLocalSqliteBackend();
     try {
@@ -133,6 +167,11 @@ describe("auto-refresh statistics after bulk writes", () => {
 
       await store.transaction(async (tx) => {
         await tx.nodes.Item.bulkCreate(nodeItems(THRESHOLD));
+        await tx.nodes.Item.bulkInsert(
+          nodeItems(THRESHOLD).map((item, index) => ({
+            props: { name: `insert-${index}` },
+          })),
+        );
       });
       expect(refreshCount()).toBe(0);
     } finally {


### PR DESCRIPTION
Every bulk-load-then-query sequence hits the same trap: the planner keeps pre-load row estimates until ANALYZE runs, and with stale estimates no membership form, index choice, or CTE shape survives — we measured 25–200× cliffs on traversal and fulltext shapes during the audit, and the benches only produce stable numbers because they call `refreshStatistics()` manually after seeding. `importGraph()` already refreshes automatically; `bulkCreate` — the other bulk on-ramp — did not.

## What

Autocommit `bulkCreate` on nodes and edges now runs `refreshStatistics()` automatically when a single call writes **1,000 rows or more** (`AUTO_REFRESH_STATISTICS_ROW_THRESHOLD`). New store option:

```typescript
createStore(graph, backend, { autoRefreshStatistics: 5000 }); // custom threshold
createStore(graph, backend, { autoRefreshStatistics: false }); // disable
```

Wiring: the store injects a `maybeRefreshStatisticsAfterBulk` hook into the collection operations; the transaction surface explicitly nulls it — ANALYZE from another connection cannot see uncommitted rows, so refreshing mid-transaction would only churn without fixing estimates (callers refresh after commit, as documented). A refresh failure degrades to a `console.warn` without failing the already-committed write, matching the `importGraph` precedent.

Node and edge `bulkInsert` now call `maybeRefreshStatisticsAfterBulk` with the batch row count after the autocommit insert completes (both the transaction-capable and fallback branches); transaction-scoped collections still null the hook.

Deliberately NOT covered (documented): loops of small batches that never individually reach the threshold, and backend-level batch inserts — autovacuum eventually catches those, and the docs keep the manual-refresh guidance for them.

## Measurement

The headline numbers for this class are already established (traversal 0.5ms → 5ms with stale edge statistics, ~30× FTS5 fallback on SQLite, 25–200× audit cliffs). A fresh 5k-row A/B on a mild traversal shape shows 2.4ms → 1.8ms — shape-dependent; the option exists precisely because the bad shapes are catastrophic and unpredictable.

## Tests

`tests/auto-refresh-statistics.test.ts`, written red-first (3 of 7 failing before the implementation): fires exactly once at the threshold for node and edge bulkCreate, not below it, never inside a caller transaction, honors custom threshold and disable flag, and a refresh failure doesn't fail the write.

## Docs

`backend-setup.md` bulk-load section rewritten around the automatic path with tune/disable examples; `schemas-stores.md` store-options table gains the new row.
