### PR TITLE
perf: raise importGraph default batchSize to 1000

### DIFF
--- a/.changeset/import-batch-size-default.md
+++ b/.changeset/import-batch-size-default.md
@@ -1,0 +1,14 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+`importGraph`'s default `batchSize` is now 1,000 (was 100). Each batch
+pays fixed per-round-trip costs — existence probe, unique pre-check,
+one multi-row insert — so the old default dominated import time on
+client/server engines: a 20k-node + 5k-edge import on PostgreSQL drops
+from 1,515ms to 781ms (16.5k → 32k entities/s) with the new default.
+Above ~1,000 the multi-row insert itself dominates and larger batches
+stop paying. SQLite imports are insensitive to the value (in-process,
+no round trips; measured within noise). The backend still splits
+inserts by its per-driver bind-parameter budget, so a large batch never
+overruns driver limits. Explicit `batchSize` values are unaffected.

--- a/.changeset/import-batch-size-default.md
+++ b/.changeset/import-batch-size-default.md
@@ -2,13 +2,24 @@
 "@nicia-ai/typegraph": patch
 ---
 
-`importGraph`'s default `batchSize` is now 1,000 (was 100). Each batch
-pays fixed per-round-trip costs — existence probe, unique pre-check,
-one multi-row insert — so the old default dominated import time on
-client/server engines: a 20k-node + 5k-edge import on PostgreSQL drops
-from 1,515ms to 781ms (16.5k → 32k entities/s) with the new default.
-Above ~1,000 the multi-row insert itself dominates and larger batches
-stop paying. SQLite imports are insensitive to the value (in-process,
-no round trips; measured within noise). The backend still splits
-inserts by its per-driver bind-parameter budget, so a large batch never
-overruns driver limits. Explicit `batchSize` values are unaffected.
+`importGraph`'s default `batchSize` is now 1,000 (was 100), and the
+default now actually applies: options are parsed through
+`ImportOptionsSchema` at the function boundary, so direct calls that
+omit fields with schema defaults (e.g. `{ onConflict: "error" }`)
+resolve them instead of reading `undefined`. `ImportOptions` is now the
+schema's input type — fields with defaults are optional for callers.
+
+Each import batch pays fixed per-round-trip costs (existence probe,
+unique pre-check, one multi-row insert), so the old default dominated
+import time on client/server engines: a 20k-node + 5k-edge import on
+PostgreSQL drops from 1,515ms to 781ms (16.5k → 32k entities/s).
+SQLite imports are insensitive to the value (in-process, no round
+trips). Explicit `batchSize` values are unaffected.
+
+Fulltext batch upserts and deletes are now split by the driver's
+bind-parameter budget in the backend wrappers, like node/edge/unique
+inserts already were. Previously a searchable import slice emitted ONE
+FTS5 (or tsvector) statement over every row — 6 binds per row, so a
+1,000-row slice overflowed SQLite's 999-bind fallback ceiling and D1's
+~100-bind cap, and 6,000-row slices overflowed even better-sqlite3's
+32,766 budget ("too many SQL variables").

--- a/apps/docs/src/content/docs/interchange.md
+++ b/apps/docs/src/content/docs/interchange.md
@@ -139,7 +139,7 @@ const result = await importGraph(store, data, {
   onConflict: "update",
   onUnknownProperty: "strip",
   validateReferences: true,
-  batchSize: 100,
+  batchSize: 1000,
 });
 
 if (result.success) {
@@ -158,7 +158,7 @@ if (result.success) {
 | `onConflict` | `"skip" \| "update" \| "error"` | required | How to handle existing entities |
 | `onUnknownProperty` | `"error" \| "strip" \| "allow"` | `"error"` | How to handle extra properties |
 | `validateReferences` | `boolean` | `true` | Verify edge endpoints exist |
-| `batchSize` | `number` | `100` | Batch size for database operations |
+| `batchSize` | `number` | `1000` | Batch size for database operations. Each batch pays fixed per-round-trip costs, so undersized batches slow client/server imports; inserts are still split by the driver bind budget internally. |
 
 ### Conflict Strategies
 

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -256,6 +256,16 @@ const POSTGRES_GET_EDGES_ID_CHUNK_SIZE = Math.max(
   1,
   POSTGRES_MAX_BIND_PARAMETERS - 1,
 );
+const FULLTEXT_UPSERT_PARAM_COUNT = 6;
+const FULLTEXT_DELETE_FIXED_PARAM_COUNT = 2;
+const POSTGRES_FULLTEXT_UPSERT_BATCH_SIZE = Math.max(
+  1,
+  Math.floor(POSTGRES_MAX_BIND_PARAMETERS / FULLTEXT_UPSERT_PARAM_COUNT),
+);
+const POSTGRES_FULLTEXT_DELETE_CHUNK_SIZE = Math.max(
+  1,
+  POSTGRES_MAX_BIND_PARAMETERS - FULLTEXT_DELETE_FIXED_PARAM_COUNT,
+);
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
 const POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE = Math.max(
   1,
@@ -1445,12 +1455,20 @@ function createPostgresOperationBackend(
     ): Promise<void> {
       if (params.rows.length === 0) return;
       const timestamp = nowIso();
-      const statements = operationStrategy.buildUpsertFulltextBatch(
-        params,
-        timestamp,
-      );
-      for (const stmt of statements) {
-        await execRun(stmt);
+      // The strategy emits ONE statement over every row it is given, so
+      // the bind budget is enforced here — same contract as node/edge
+      // batch inserts.
+      for (const rows of chunkArray(
+        params.rows,
+        POSTGRES_FULLTEXT_UPSERT_BATCH_SIZE,
+      )) {
+        const statements = operationStrategy.buildUpsertFulltextBatch(
+          { ...params, rows },
+          timestamp,
+        );
+        for (const stmt of statements) {
+          await execRun(stmt);
+        }
       }
     },
 
@@ -1458,9 +1476,17 @@ function createPostgresOperationBackend(
       params: DeleteFulltextBatchParams,
     ): Promise<void> {
       if (params.nodeIds.length === 0) return;
-      const statements = operationStrategy.buildDeleteFulltextBatch(params);
-      for (const stmt of statements) {
-        await execRun(stmt);
+      for (const nodeIds of chunkArray(
+        params.nodeIds,
+        POSTGRES_FULLTEXT_DELETE_CHUNK_SIZE,
+      )) {
+        const statements = operationStrategy.buildDeleteFulltextBatch({
+          ...params,
+          nodeIds,
+        });
+        for (const stmt of statements) {
+          await execRun(stmt);
+        }
       }
     },
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -185,6 +185,8 @@ const EDGE_INSERT_PARAM_COUNT = 12;
 const GET_NODES_FIXED_PARAM_COUNT = 2;
 const GET_EDGES_FIXED_PARAM_COUNT = 1;
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
+const FULLTEXT_UPSERT_PARAM_COUNT = 6;
+const FULLTEXT_DELETE_FIXED_PARAM_COUNT = 2;
 const UNIQUE_INSERT_PARAM_COUNT = 6;
 
 /**
@@ -195,6 +197,10 @@ const UNIQUE_INSERT_PARAM_COUNT = 6;
 export type SqliteBatchChunkSizes = Readonly<{
   checkUniqueBatchChunkSize: number;
   edgeInsertBatchSize: number;
+  /** Rows per fulltext batch upsert (6 binds per row on FTS5). */
+  fulltextUpsertBatchSize: number;
+  /** Node ids per fulltext batch delete (2 fixed binds + one per id). */
+  fulltextDeleteChunkSize: number;
   getEdgesChunkSize: number;
   getNodesChunkSize: number;
   nodeInsertBatchSize: number;
@@ -214,6 +220,14 @@ export function computeSqliteBatchChunkSizes(
     checkUniqueBatchChunkSize: Math.max(
       1,
       maxBindParameters - CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT,
+    ),
+    fulltextUpsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / FULLTEXT_UPSERT_PARAM_COUNT),
+    ),
+    fulltextDeleteChunkSize: Math.max(
+      1,
+      maxBindParameters - FULLTEXT_DELETE_FIXED_PARAM_COUNT,
     ),
     edgeInsertBatchSize: Math.max(
       1,
@@ -529,10 +543,11 @@ function createSqliteOperationBackend(
     });
   }
 
+  const batchConfig = computeSqliteBatchChunkSizes(
+    capabilities.maxBindParameters ?? SQLITE_MAX_BIND_PARAMETERS,
+  );
   const commonBackend = createCommonOperationBackend({
-    batchConfig: computeSqliteBatchChunkSizes(
-      capabilities.maxBindParameters ?? SQLITE_MAX_BIND_PARAMETERS,
-    ),
+    batchConfig,
     execution: {
       execAll,
       execGet,
@@ -815,12 +830,20 @@ function createSqliteOperationBackend(
     ): Promise<void> {
       if (params.rows.length === 0) return;
       const timestamp = nowIso();
-      const statements = operationStrategy.buildUpsertFulltextBatch(
-        params,
-        timestamp,
-      );
-      for (const stmt of statements) {
-        await execRun(stmt);
+      // The strategy emits ONE statement over every row it is given, so
+      // the bind budget is enforced here — same contract as node/edge
+      // batch inserts.
+      for (const rows of chunkArray(
+        params.rows,
+        batchConfig.fulltextUpsertBatchSize,
+      )) {
+        const statements = operationStrategy.buildUpsertFulltextBatch(
+          { ...params, rows },
+          timestamp,
+        );
+        for (const stmt of statements) {
+          await execRun(stmt);
+        }
       }
     },
 
@@ -828,9 +851,17 @@ function createSqliteOperationBackend(
       params: DeleteFulltextBatchParams,
     ): Promise<void> {
       if (params.nodeIds.length === 0) return;
-      const statements = operationStrategy.buildDeleteFulltextBatch(params);
-      for (const stmt of statements) {
-        await execRun(stmt);
+      for (const nodeIds of chunkArray(
+        params.nodeIds,
+        batchConfig.fulltextDeleteChunkSize,
+      )) {
+        const statements = operationStrategy.buildDeleteFulltextBatch({
+          ...params,
+          nodeIds,
+        });
+        for (const stmt of statements) {
+          await execRun(stmt);
+        }
       }
     },
 

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -39,9 +39,11 @@ import {
   type GraphData,
   type ImportError,
   type ImportOptions,
+  ImportOptionsSchema,
   type ImportResult,
   type InterchangeEdge,
   type InterchangeNode,
+  type ResolvedImportOptions,
   type UnknownPropertyStrategy,
 } from "./types";
 
@@ -73,8 +75,12 @@ import {
 export async function importGraph<G extends GraphDef>(
   store: Store<G>,
   data: GraphData,
-  options: ImportOptions,
+  rawOptions: ImportOptions,
 ): Promise<ImportResult> {
+  // Parse ONCE at the public boundary: schema defaults (batchSize, ...)
+  // only exist after parsing, and every internal stage reads them
+  // directly.
+  const options = ImportOptionsSchema.parse(rawOptions);
   const result: ImportResult = {
     success: true,
     nodes: { created: 0, updated: 0, skipped: 0 },
@@ -221,7 +227,7 @@ async function processNodes(
   registry: KindRegistry,
   nodes: readonly InterchangeNode[],
   schemas: ReadonlyMap<string, NodeSchemaEntry>,
-  options: ImportOptions,
+  options: ResolvedImportOptions,
   result: ImportResult,
   errors: ImportError[],
   importedNodeIds: Set<string>,
@@ -309,7 +315,7 @@ async function processNodeSlice(
   registry: KindRegistry,
   batch: readonly InterchangeNode[],
   schemas: ReadonlyMap<string, NodeSchemaEntry>,
-  options: ImportOptions,
+  options: ResolvedImportOptions,
   result: ImportResult,
   errors: ImportError[],
   importedNodeIds: Set<string>,
@@ -591,7 +597,7 @@ async function processNode(
   registry: KindRegistry,
   node: InterchangeNode,
   schemas: ReadonlyMap<string, NodeSchemaEntry>,
-  options: ImportOptions,
+  options: ResolvedImportOptions,
   lock: GraphWriteLock,
 ): Promise<ProcessResult> {
   // Validate kind exists
@@ -719,7 +725,7 @@ async function processEdges(
   edges: readonly InterchangeEdge[],
   edgeSchemas: ReadonlyMap<string, EdgeSchemaEntry>,
   nodeSchemas: ReadonlyMap<string, NodeSchemaEntry>,
-  options: ImportOptions,
+  options: ResolvedImportOptions,
   result: ImportResult,
   errors: ImportError[],
   importedNodeIds: Set<string>,
@@ -793,7 +799,7 @@ async function processEdgeSlice(
   batch: readonly InterchangeEdge[],
   edgeSchemas: ReadonlyMap<string, EdgeSchemaEntry>,
   nodeSchemas: ReadonlyMap<string, NodeSchemaEntry>,
-  options: ImportOptions,
+  options: ResolvedImportOptions,
   result: ImportResult,
   errors: ImportError[],
   importedNodeIds: Set<string>,
@@ -1032,7 +1038,7 @@ async function processEdge(
   edge: InterchangeEdge,
   edgeSchemas: ReadonlyMap<string, EdgeSchemaEntry>,
   nodeSchemas: ReadonlyMap<string, NodeSchemaEntry>,
-  options: ImportOptions,
+  options: ResolvedImportOptions,
   importedNodeIds: Set<string>,
 ): Promise<ProcessResult> {
   // Validate edge kind exists

--- a/packages/typegraph/src/interchange/types.ts
+++ b/packages/typegraph/src/interchange/types.ts
@@ -158,7 +158,15 @@ export const ImportOptionsSchema = z.object({
   refreshStatistics: z.boolean().optional(),
 });
 
-export type ImportOptions = z.infer<typeof ImportOptionsSchema>;
+/**
+ * Caller-facing options: fields with schema defaults are optional.
+ * `importGraph` parses these once at its boundary; internal stages
+ * consume {@link ResolvedImportOptions} with every default applied.
+ */
+export type ImportOptions = z.input<typeof ImportOptionsSchema>;
+
+/** {@link ImportOptions} after schema parsing — all defaults resolved. */
+export type ResolvedImportOptions = z.infer<typeof ImportOptionsSchema>;
 
 // ============================================================
 // Graph Data Source

--- a/packages/typegraph/src/interchange/types.ts
+++ b/packages/typegraph/src/interchange/types.ts
@@ -138,8 +138,18 @@ export const ImportOptionsSchema = z.object({
   onUnknownProperty: UnknownPropertyStrategySchema.default("error"),
   /** Whether to validate that edge endpoints exist */
   validateReferences: z.boolean().default(true),
-  /** Number of items to process in each batch */
-  batchSize: z.number().int().positive().default(100),
+  /**
+   * Number of items to process in each batch. Each batch pays fixed
+   * per-round-trip costs (existence probe, unique check, one multi-row
+   * insert), so undersized batches dominate import time on client/server
+   * engines: measured on PostgreSQL, 20k nodes + 5k edges import in
+   * 1,515ms at 100 vs 781ms at 1,000. Above ~1,000 the multi-row insert
+   * itself dominates and larger batches stop paying; SQLite is
+   * insensitive to the value (in-process, no round trips). The backend
+   * further splits inserts by its bind-parameter budget, so a large
+   * batch never overruns driver limits.
+   */
+  batchSize: z.number().int().positive().default(1000),
   /**
    * Refresh planner statistics (ANALYZE) after an import that created or
    * updated rows. Bulk loads otherwise run against stale statistics until

--- a/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
@@ -103,6 +103,8 @@ describe("computeSqliteBatchChunkSizes", () => {
     expect(computeSqliteBatchChunkSizes(999)).toEqual({
       checkUniqueBatchChunkSize: 996,
       edgeInsertBatchSize: 83,
+      fulltextUpsertBatchSize: 166,
+      fulltextDeleteChunkSize: 997,
       getEdgesChunkSize: 998,
       getNodesChunkSize: 997,
       nodeInsertBatchSize: 111,
@@ -114,6 +116,8 @@ describe("computeSqliteBatchChunkSizes", () => {
     expect(computeSqliteBatchChunkSizes(MODERN_BETTER_SQLITE3_BUDGET)).toEqual({
       checkUniqueBatchChunkSize: 32_763,
       edgeInsertBatchSize: 2730,
+      fulltextUpsertBatchSize: 5461,
+      fulltextDeleteChunkSize: 32_764,
       getEdgesChunkSize: 32_765,
       getNodesChunkSize: 32_764,
       nodeInsertBatchSize: 3640,
@@ -121,10 +125,19 @@ describe("computeSqliteBatchChunkSizes", () => {
     });
   });
 
+  it("keeps fulltext batches within D1's ~100-bind cap", () => {
+    const sizes = computeSqliteBatchChunkSizes(100);
+    // 6 binds per fulltext row: 16 rows/statement fits, 17 would not.
+    expect(sizes.fulltextUpsertBatchSize).toBe(16);
+    expect(sizes.fulltextDeleteChunkSize).toBe(98);
+  });
+
   it("never returns a chunk size below one", () => {
     expect(computeSqliteBatchChunkSizes(1)).toEqual({
       checkUniqueBatchChunkSize: 1,
       edgeInsertBatchSize: 1,
+      fulltextUpsertBatchSize: 1,
+      fulltextDeleteChunkSize: 1,
       getEdgesChunkSize: 1,
       getNodesChunkSize: 1,
       nodeInsertBatchSize: 1,

--- a/packages/typegraph/tests/import-batching.test.ts
+++ b/packages/typegraph/tests/import-batching.test.ts
@@ -29,6 +29,7 @@ import {
   type GraphData,
   importGraph,
   type ImportOptions,
+  ImportOptionsSchema,
 } from "../src/interchange";
 
 const Person = defineNode("Person", {
@@ -176,6 +177,12 @@ async function withCountedStore<T>(
 const NODE_COUNT = 50;
 
 describe("importGraph batching", () => {
+  it("defaults batchSize to 1000 (round-trip cost dominates small batches)", () => {
+    expect(ImportOptionsSchema.parse({ onConflict: "error" }).batchSize).toBe(
+      1000,
+    );
+  });
+
   it("imports nodes through batched probes, inserts, and side effects", async () => {
     await withCountedStore(async (store, counts) => {
       const result = await importGraph(

--- a/packages/typegraph/tests/import-batching.test.ts
+++ b/packages/typegraph/tests/import-batching.test.ts
@@ -183,6 +183,53 @@ describe("importGraph batching", () => {
     );
   });
 
+  it("resolves schema defaults for direct calls that omit them", async () => {
+    // importGraph parses its options at the boundary; a caller passing
+    // only `onConflict` (the docs' minimal example) must get the
+    // batchSize default applied — previously options.batchSize was read
+    // raw and the import crashed on `undefined`.
+    await withCountedStore(async (store, counts) => {
+      const result = await importGraph(
+        store,
+        payload(Array.from({ length: 1500 }, (_, index) => personNode(index))),
+        { onConflict: "error" },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.nodes.created).toBe(1500);
+      // 1500 rows at the 1000-row default = exactly two slices.
+      expect(counts.insertNodesBatch).toBe(2);
+    });
+  });
+
+  it("chunks fulltext sync by the driver bind budget on large slices", async () => {
+    // The FTS5 batch upsert emits ONE statement over every row in the
+    // import slice (6 binds per row). better-sqlite3's budget is 32,766,
+    // so a 6,000-row searchable slice (36,000 binds) overflowed the
+    // statement before the backend wrappers chunked by bind budget.
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const [store] = await createStoreWithSchema(buildGraph(), backend);
+      const noteCount = 6000;
+      const result = await importGraph(
+        store,
+        payload(
+          Array.from({ length: noteCount }, (_, index) => ({
+            kind: "Note",
+            id: `note-${index}`,
+            properties: { body: `searchable body ${index}` },
+          })),
+        ),
+        { onConflict: "error", batchSize: noteCount },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.nodes.created).toBe(noteCount);
+    } finally {
+      await backend.close();
+    }
+  });
+
   it("imports nodes through batched probes, inserts, and side effects", async () => {
     await withCountedStore(async (store, counts) => {
       const result = await importGraph(


### PR DESCRIPTION
Fourth item from the post-audit target list was COPY-based `importGraph` on Postgres. Profiling first changed the conclusion — this PR ships the measured win (a default change), and documents why COPY is deferred.

## Profile (PG, 20k nodes + 5k edges, 1KB props)

At the default `batchSize: 100`, the import spends its time in per-batch round trips:

| batchSize | total | throughput |
| --- | --- | --- |
| 100 (old default) | 1,515ms | 16.5k entities/s |
| 500 | 870ms | 28.7k |
| **1,000 (new default)** | **781ms** | **32.0k** |
| 2,000 | 742ms | 33.7k |
| 20,000 | 765ms | 32.7k |

At 1,000 the breakdown is `insertNodesBatch` 491ms / `getNodes` existence probes 118ms / `insertEdgesBatch` 110ms / JS validation ~80ms — the multi-row insert dominates and bigger batches stop paying. SQLite is insensitive to the value (246ms vs 250ms, in-process). The backend already splits inserts by the per-driver bind budget, so a large batch can't overrun driver parameter limits. Explicit `batchSize` values are unaffected.

**1.94× on PG from a default change**, no new code paths.

## Why COPY is deferred (measured, not guessed)

- Raw `COPY FROM STDIN` of the same 20k rows: ~270ms — genuinely ~2× faster than our batched INSERTs (~490ms) **for the insert phase only**.
- End-to-end, COPY would take the import from ~780ms to roughly ~450ms (~1.7×), because existence probes, edge inserts, and JS validation don't move.
- The cost side: an optional `pg-copy-streams` dependency, extracting the raw client from the Drizzle transaction session, and hand-rolled COPY text-format escaping for user JSON (a data-corruption risk class we'd need property tests to hold down).
- The no-dependency alternative (`INSERT … SELECT FROM unnest($1::text[], …)`) measured **slower** than multi-row VALUES (578ms vs 403ms): node-postgres's client-side array-literal serialization of 20k 1KB JSON strings eats the server-side win.

~1.7× for that risk surface is a defensible "yes" only if import throughput is an actual pain point — happy to build it on request, but it shouldn't ride in silently on a default-change PR.

## Tests

`import-batching.test.ts` gains a pin that the schema default resolves to 1,000; the existing batching suite (statement-count overlays, conflict routing, reference validation) covers behavior.

## Verification

fix / typecheck clean; SQLite 4505 passed; PG lane 1803 passed. Docs updated (`interchange.md`). Changeset: patch.

## Review fixes

- **[P1] The default only existed in the schema**: `importGraph` never parsed `ImportOptionsSchema`, so direct calls passing partial options (the docs' minimal example) read `options.batchSize` as `undefined`. Options are now parsed once at the public boundary; internal stages consume a new `ResolvedImportOptions` (`z.infer`) and the exported `ImportOptions` becomes the schema's **input** type, so defaulted fields are optional for callers — a loosening, not a break. Regression: `importGraph(..., { onConflict: "error" })` with 1,500 nodes succeeds and slices exactly twice at the 1,000 default.
- **[P1] Fulltext side effects had no bind-budget chunking**: the FTS5/tsvector batch upsert emits one statement over every row it is given (6 binds per row), so the "never overruns driver limits" claim was false for searchable imports — 1,000-row slices overflow the 999-bind SQLite fallback and D1's ~100 cap, and 6,000-row slices overflow even better-sqlite3's 32,766 (reproduced: "too many SQL variables"). Both dialects' `upsertFulltextBatch`/`deleteFulltextBatch` wrappers now chunk by the driver budget (`fulltextUpsertBatchSize` = ⌊budget/6⌋, `fulltextDeleteChunkSize` = budget−2), matching the node/edge/unique insert contract. Tests: the 6,000-row searchable import (red before the fix), plus chunk-size math pinned at the 999 floor, 32,766, the D1 100-bind cap (16 rows/statement), and the floor-of-one guard.

Changeset rewritten to cover both. Re-verified: fix/typecheck/knip clean, SQLite 4508 passed, PG lane 1803 passed.
