### PR TITLE
perf: share the hybrid candidates set across both source legs

### DIFF
--- a/.changeset/hybrid-shared-candidates.md
+++ b/.changeset/hybrid-shared-candidates.md
@@ -1,0 +1,14 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+The single-statement hybrid search now emits the candidates set
+(liveness/currency filter, or the compiled `where` predicate query)
+once, as a CTE shared by the vector and fulltext legs, instead of
+embedding — and re-executing — a private copy inside each leg. The
+duplicate evaluation was most expensive with a `where` filter, whose
+compiled candidates query ran twice per search: measured on PostgreSQL,
+filtered hybrid drops 26.5ms → 17.1ms at 5k docs (bench shape
+11.8ms → 8.6ms; unfiltered 6.1ms → 4.9ms). This also removes a subtle
+inconsistency where each leg stamped its own currency instant. SQLite
+is unchanged within noise (in-process re-execution was cheap).

--- a/packages/typegraph/src/backend/drizzle/operations/hybrid.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/hybrid.ts
@@ -27,6 +27,15 @@ import { coerceNumericScore } from "../row-mappers";
 import { quotedColumn, type Tables } from "./shared";
 
 export type HybridStatementInput = Readonly<{
+  /**
+   * The candidates set (liveness/currency filter, or the store-compiled
+   * predicate query): `(node_id)` rows. Emitted ONCE as the
+   * `tg_hybrid_cand` CTE; both source legs must reference it via
+   * {@link hybridCandidatesRef} instead of embedding their own copy —
+   * previously each leg re-executed the candidates subquery (with two
+   * separate `nowIso()` stamps for the currency window, no less).
+   */
+  candidatesSql: SQL;
   /** Vector source SQL: `(node_id, score)` ordered best-first, bounded. */
   vectorSql: SQL;
   /**
@@ -51,6 +60,18 @@ export type HybridStatementInput = Readonly<{
  * node row (aliased to the mapper's expected column names). `node_id`
  * (fusion side) and `id` (node side) intentionally coexist.
  */
+/**
+ * The reference the vector/fulltext source legs embed in place of the
+ * candidates subquery (their strategies emit `node_id IN (<this>)`).
+ * Valid only inside {@link buildHybridSearchStatement}, which defines
+ * the `tg_hybrid_cand` CTE first in its WITH list — CTEs are visible to
+ * later members on both dialects, and a CTE referenced from both legs
+ * is evaluated once.
+ */
+export function hybridCandidatesRef(): SQL {
+  return sql`SELECT node_id FROM tg_hybrid_cand`;
+}
+
 export function buildHybridSearchStatement(input: HybridStatementInput): SQL {
   const { nodes } = input;
   const vectorOrder =
@@ -83,7 +104,10 @@ export function buildHybridSearchStatement(input: HybridStatementInput): SQL {
   // otherwise evaluate `weight / (k + rank)` in integer arithmetic and
   // collapse every contribution to zero.
   return sql`
-    WITH tg_hybrid_vec AS (
+    WITH tg_hybrid_cand AS (
+      SELECT node_id FROM (${input.candidatesSql}) AS tg_hybrid_cand_src
+    ),
+    tg_hybrid_vec AS (
       SELECT node_id, score,
              ROW_NUMBER() OVER (ORDER BY ${vectorOrder}) AS ord
       FROM (${input.vectorSql}) AS tg_hybrid_vec_src

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -60,7 +60,7 @@ import {
   buildUpdateEdge,
 } from "./edges";
 import { buildFulltextSearch } from "./fulltext";
-import { buildHybridSearchStatement } from "./hybrid";
+import { buildHybridSearchStatement, hybridCandidatesRef } from "./hybrid";
 import {
   buildDeleteNode,
   buildGetNode,
@@ -331,7 +331,12 @@ function createCommonOperationStrategy(
     ): SQL => {
       const candidates =
         params.candidates ??
-        liveNodeIdsSubquery(tables.nodes, params.graphId, params.nodeKind, nowIso());
+        liveNodeIdsSubquery(
+          tables.nodes,
+          params.graphId,
+          params.nodeKind,
+          nowIso(),
+        );
       const fulltextSql = buildFulltextSearch(
         fulltextTable,
         {
@@ -353,9 +358,12 @@ function createCommonOperationStrategy(
           : { includeSnippets: params.fulltext.includeSnippets }),
         },
         fulltextStrategy,
-        candidates,
+        // Reference, not copy: the statement evaluates the shared
+        // tg_hybrid_cand CTE once for both legs.
+        hybridCandidatesRef(),
       );
       return buildHybridSearchStatement({
+        candidatesSql: candidates,
         vectorSql,
         vectorScoreDescending,
         fulltextSql,

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -131,7 +131,10 @@ import {
   createCommonOperationBackend,
   type InternalOperationBackend,
 } from "./operation-backend-core";
-import { mapHybridSearchRow } from "./operations/hybrid";
+import {
+  hybridCandidatesRef,
+  mapHybridSearchRow,
+} from "./operations/hybrid";
 import {
   createCachedTableExistence,
   createPostgresOperationStrategy,
@@ -1357,10 +1360,13 @@ function createPostgresOperationBackend(
                   {}
                 : { minScore: params.vector.minScore }),
               };
+              // The vector leg references the statement's shared
+              // tg_hybrid_cand CTE; the actual candidates SQL is emitted
+              // once by buildHybridSearch.
               const vectorSql = vectorStrategy.buildSearch(
                 slot,
                 vectorParams,
-                candidates,
+                hybridCandidatesRef(),
               );
               const statement = operationStrategy.buildHybridSearch(
                 { ...params, candidates },

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -123,7 +123,10 @@ import {
   createCommonOperationBackend,
   type InternalOperationBackend,
 } from "./operation-backend-core";
-import { mapHybridSearchRow } from "./operations/hybrid";
+import {
+  hybridCandidatesRef,
+  mapHybridSearchRow,
+} from "./operations/hybrid";
 import { createSqliteOperationStrategy } from "./operations/strategy";
 import {
   coerceNumericScore,
@@ -729,10 +732,13 @@ function createSqliteOperationBackend(
                   {}
                 : { minScore: params.vector.minScore }),
               };
+              // The vector leg references the statement's shared
+              // tg_hybrid_cand CTE; the actual candidates SQL is emitted
+              // once by buildHybridSearch.
               const vectorSql = vectorStrategy.buildSearch(
                 slot,
                 vectorParams,
-                candidates,
+                hybridCandidatesRef(),
               );
               const statement = operationStrategy.buildHybridSearch(
                 { ...params, candidates },

--- a/packages/typegraph/tests/search-candidates-planning.test.ts
+++ b/packages/typegraph/tests/search-candidates-planning.test.ts
@@ -12,7 +12,7 @@
  * - The store compiles builder-query candidates ONLY when a `where`
  *   predicate exists; unfiltered searches use the flat backend form.
  */
-import { type SQL } from "drizzle-orm";
+import { type SQL,sql } from "drizzle-orm";
 import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
@@ -23,7 +23,10 @@ import {
   defineNode,
   searchable,
 } from "../src";
-import { buildHybridSearchStatement } from "../src/backend/drizzle/operations/hybrid";
+import {
+  buildHybridSearchStatement,
+  hybridCandidatesRef,
+} from "../src/backend/drizzle/operations/hybrid";
 import { liveNodeIdsSubquery } from "../src/backend/drizzle/operations/shared";
 import { tables } from "../src/backend/drizzle/schema/sqlite";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
@@ -37,6 +40,12 @@ function sqlToText(query: SQL): string {
 describe("search candidates planning shapes", () => {
   it("materializes the hybrid fused CTE", () => {
     const statement = buildHybridSearchStatement({
+      candidatesSql: liveNodeIdsSubquery(
+        tables.nodes,
+        "g",
+        "Doc",
+        "2026-01-01T00:00:00.000Z",
+      ),
       vectorSql: liveNodeIdsSubquery(
         tables.nodes,
         "g",
@@ -60,6 +69,43 @@ describe("search candidates planning shapes", () => {
       offset: 0,
     });
     expect(sqlToText(statement)).toContain("tg_hybrid_fused AS MATERIALIZED");
+  });
+
+  it("emits the candidates set once as a shared CTE both legs reference", () => {
+    const candidates = liveNodeIdsSubquery(
+      tables.nodes,
+      "g",
+      "Doc",
+      "2026-01-01T00:00:00.000Z",
+    );
+    // Source legs built the production way: against the CTE reference,
+    // never against their own copy of the candidates subquery.
+    const vectorSql = sql`SELECT node_id, 0.5 AS score FROM vec WHERE node_id IN (${hybridCandidatesRef()})`;
+    const fulltextSql = sql`SELECT node_id, 0.5 AS score, NULL AS snippet FROM fts WHERE node_id IN (${hybridCandidatesRef()})`;
+    const statement = buildHybridSearchStatement({
+      candidatesSql: candidates,
+      vectorSql,
+      vectorScoreDescending: true,
+      fulltextSql,
+      nodes: tables.nodes,
+      graphId: "g",
+      nodeKind: "Doc",
+      fusionK: 60,
+      vectorWeight: 1,
+      fulltextWeight: 1,
+      limit: 10,
+      offset: 0,
+    });
+    const text = sqlToText(statement);
+    expect(text.split("tg_hybrid_cand AS (")).toHaveLength(2);
+    // The candidates subquery body appears exactly once (inside the
+    // shared CTE) — previously each leg embedded and re-executed its
+    // own copy. `AS node_id FROM` is unique to the candidates shape;
+    // the hydration column aliases don't match it.
+    expect(text.split("AS node_id FROM")).toHaveLength(2);
+    expect(
+      text.split("SELECT node_id FROM tg_hybrid_cand").length,
+    ).toBeGreaterThanOrEqual(3);
   });
 
   it("default candidates bind the currency instant as a parameter", () => {

--- a/packages/typegraph/tests/search-candidates-planning.test.ts
+++ b/packages/typegraph/tests/search-candidates-planning.test.ts
@@ -12,7 +12,7 @@
  * - The store compiles builder-query candidates ONLY when a `where`
  *   predicate exists; unfiltered searches use the flat backend form.
  */
-import { type SQL,sql } from "drizzle-orm";
+import { type SQL, sql } from "drizzle-orm";
 import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";


### PR DESCRIPTION
First of the smaller post-audit items: **the single-statement hybrid search evaluated its candidates set twice.**

## What was happening

`buildHybridSearchStatement` composes a vector leg and a fulltext leg; each leg received the candidates subquery (the liveness/currency filter, or — with a facade `where` — the full store-compiled predicate query) and embedded its own copy. Two executions per search, and since each embed stamped its own `nowIso()`, the two legs could technically disagree about the currency instant.

## The fix

The statement now defines the candidates once as a leading `tg_hybrid_cand` CTE. Both legs are built against `hybridCandidatesRef()` — their strategies emit `node_id IN (SELECT node_id FROM tg_hybrid_cand)` — and the real candidates SQL appears exactly once. A CTE referenced from two places is evaluated once on both dialects (no MATERIALIZED keyword needed; Postgres only inlines single-reference CTEs). One currency instant for the whole statement.

## Measured (PG)

| shape | before | after |
| --- | --- | --- |
| hybrid + `where` (5k docs, compiled candidates) | 26.5ms | **17.1ms** |
| bench: filtered hybrid (RRF, where category) | 11.8ms | 8.6ms |
| bench: unfiltered hybrid (RRF) | 6.1ms | 4.9ms |

SQLite is unchanged within noise (31.2 → 30.7ms on the `where` shape) — in-process re-execution of the candidates scan was never the bottleneck there.

## Tests

`search-candidates-planning.test.ts` gains a shape pin: exactly one `tg_hybrid_cand` definition, exactly one candidates subquery body, both legs referencing the CTE. Behavior is covered by the existing hybrid suites (`hybrid-single-statement`, `fuse-with`, liveness, filter pushdown) on both lanes.
