### PR TITLE
perf: route exact SQLite vector search through vec0 KNN

### DIFF
--- a/.changeset/sqlite-vec-exact-knn.md
+++ b/.changeset/sqlite-vec-exact-knn.md
@@ -1,0 +1,14 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Non-approximate `.similarTo()` on SQLite now routes through sqlite-vec's
+vec0 KNN form. vec0's KNN is brute-force in C — exact by construction —
+so the default path keeps identical results (pinned against
+JS-computed ground truth) while dropping from the SQL distance scan to
+engine speed: 489ms → 124ms for top-10 over 50k 384-dim embeddings.
+Declared via a new `searchIsExact` flag on the vector-strategy
+contract; pgvector and libSQL leave it unset (their engine forms are
+approximate) and are unchanged. The metric gate still applies: an
+explicit metric override that differs from the slot's declared metric
+falls back to the SQL scan, which is correct for any metric.

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -848,11 +848,16 @@ export function buildStandardEmbeddingsCte(
     // under an overridden one would silently miss the override metric's
     // true nearest neighbors. A mismatched override falls back to the
     // exact scan below — correct for any metric, like `indexType: "none"`.
+    // Engines whose `buildSearch` is EXACT (vec0's brute-force C KNN)
+    // serve the non-approximate branch through it as well: identical
+    // results to the SQL distance scan at engine speed (489ms -> 113ms
+    // at 50k on the SQLite lane). The metric gate stays: the engine
+    // form is built for the slot's declared metric.
+    const engineFormEligible =
+      vectorPredicate.approximate === true ||
+      vectorStrategy.searchIsExact === true;
     const annSlot =
-      (
-        vectorPredicate.approximate === true &&
-        branchMetric === slotDescriptor?.metric
-      ) ?
+      engineFormEligible && branchMetric === slotDescriptor?.metric ?
         slotDescriptor
       : undefined;
     if (annSlot !== undefined) {

--- a/packages/typegraph/src/query/dialect/vector-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector-strategy.ts
@@ -203,6 +203,18 @@ export interface VectorStrategy {
   ): SQL;
 
   /**
+   * True when {@link buildSearch} returns EXACT rankings — a brute-force
+   * engine form, not an approximate index (sqlite-vec's vec0 KNN scans
+   * every row in C). The query compiler then routes the NON-approximate
+   * `.similarTo()` branch through `buildSearch` too: same results as the
+   * SQL distance scan, at engine speed (measured 489ms -> 113ms at 50k
+   * on the SQLite lane). Leave false/absent when the engine form is or
+   * can be approximate (pgvector planner rewrites, libSQL DiskANN):
+   * exactness of the default path is a semantic guarantee.
+   */
+  searchIsExact?: boolean;
+
+  /**
    * The distance expression over the slot's embedding column, used by the
    * **query compiler** to splice vector relevance into its CTE. This is the
    * one genuinely engine-specific fragment (`vec_distance_cosine` vs

--- a/packages/typegraph/src/query/dialect/vector/sqlite-vec-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector/sqlite-vec-strategy.ts
@@ -259,6 +259,12 @@ export const sqliteVecStrategy: VectorStrategy = {
     ];
   },
 
+  // vec0's KNN is brute force in C — exact by construction (the
+  // "index" is a partitioned scan, not a graph) — and the non-indexed
+  // fallback below is a plain SQL scan. The compiler may therefore
+  // route the NON-approximate `.similarTo()` branch through this form.
+  searchIsExact: true,
+
   buildSearch(slot, params: VectorSearchParams, candidates?: SQL): SQL {
     const table = quotedTableName(
       this.tableName(slot.graphId, slot.nodeKind, slot.fieldPath),

--- a/packages/typegraph/tests/similar-to-approximate.test.ts
+++ b/packages/typegraph/tests/similar-to-approximate.test.ts
@@ -99,6 +99,12 @@ type CreatedBackend = Readonly<{
   cleanup: BackendCleanup;
   /** Substring proving the engine-native ANN form was compiled. */
   annMarker: string;
+  /**
+   * True when the strategy declares `searchIsExact` (vec0's KNN is
+   * brute-force exact), so the NON-approximate path also routes through
+   * the engine form.
+   */
+  exactUsesEngineForm: boolean;
 }>;
 
 type BackendDescriptor = Readonly<{
@@ -114,6 +120,7 @@ const localSqliteDescriptor: BackendDescriptor = {
       backend,
       cleanup: () => backend.close(),
       annMarker: "MATCH",
+      exactUsesEngineForm: true,
     });
   },
 };
@@ -136,6 +143,7 @@ function libsqlDescriptor(): BackendDescriptor & { tempDir: string } {
           client.close();
         },
         annMarker: "vector_top_k",
+        exactUsesEngineForm: false,
       };
     },
   };
@@ -192,6 +200,19 @@ function documentQuery(
   return query.select((ctx) => ({ id: ctx.d.id }));
 }
 
+function cosineDistance(vector: readonly number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (const [index, value] of vector.entries()) {
+    const q = QUERY_EMBEDDING[index]!;
+    dot += value * q;
+    normA += value * value;
+    normB += q * q;
+  }
+  return 1 - dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
 async function ids(
   query: Readonly<{ execute: () => Promise<readonly unknown[]> }>,
 ): Promise<readonly string[]> {
@@ -200,13 +221,25 @@ async function ids(
 }
 
 async function runScenario(created: CreatedBackend): Promise<void> {
-  const { backend, cleanup, annMarker } = created;
+  const { backend, cleanup, annMarker, exactUsesEngineForm } = created;
   try {
     if (backend.capabilities.vector?.supported !== true) return;
     const store = await seedStore(backend);
 
     // --- Parity: plain, filtered, and on the unindexed slot. ---
+    // Anchor both paths to engine-independent JS truth: on strategies
+    // where the exact path routes through the engine form
+    // (searchIsExact), exact-vs-approximate parity alone would be
+    // tautological.
+    const jsTruth = CORPUS.map((document) => ({
+      id: document.id,
+      distance: cosineDistance(document.embedding),
+    }))
+      .toSorted((a, b) => a.distance - b.distance || (a.id < b.id ? -1 : 1))
+      .slice(0, 4)
+      .map((document) => document.id);
     const exact = await ids(documentQuery(store, "AnnDoc", {}));
+    expect(exact).toEqual(jsTruth);
     const approximate = await ids(
       documentQuery(store, "AnnDoc", { approximate: true }),
     );
@@ -294,7 +327,14 @@ async function runScenario(created: CreatedBackend): Promise<void> {
     expect(approximateSql).toContain(annMarker);
 
     const exactSql = documentQuery(store, "AnnDoc", {}).toSQL().sql;
-    expect(exactSql).not.toContain("tg_ann_src");
+    if (exactUsesEngineForm) {
+      // vec0's KNN is exact by construction, so the non-approximate
+      // path routes through the engine form too (searchIsExact).
+      expect(exactSql).toContain("tg_ann_src");
+      expect(exactSql).toContain(annMarker);
+    } else {
+      expect(exactSql).not.toContain("tg_ann_src");
+    }
 
     // The unindexed slot degrades to the strategy's exact scan even
     // with the opt-in: wrapper present, ANN form absent (pgvector's
@@ -372,6 +412,7 @@ describe("similarTo approximate opt-in", () => {
         // pgvector's ANN form is the same ORDER BY/LIMIT scan shape — the
         // approximate wrapper is the observable compile-level marker.
         annMarker: "tg_ann_src",
+        exactUsesEngineForm: false,
       };
     },
   };


### PR DESCRIPTION
Item 3 of the approved round: **SQLite exact vector search at engine speed, with zero semantics cost.**

## Why this is safe where PG wasn't

The vector lane showed the SQL distance scan at 489ms vs sqlite-vec's KNN at 113ms for the same 50k×384 top-10. Unlike pgvector's HNSW (the subject of #217), vec0's KNN is **brute-force in C — exact by construction**: the "index" is a partitioned scan, not an approximate graph. So the non-approximate path can take the engine form without violating the exactness guarantee #217 just enforced.

## How

- New `searchIsExact` flag on the `VectorStrategy` contract: "buildSearch returns exact rankings." sqlite-vec sets it; pgvector and libSQL (DiskANN — genuinely approximate) leave it unset and are unchanged.
- The compiler's vector CTE routes the non-approximate branch through `buildSearch` when the flag is set **and** the effective metric matches the slot's declared metric — vec0 bakes `distance_metric` into the virtual table, so a per-query metric override still falls back to the SQL scan (correct for any metric), same gate as the `approximate: true` path.

## Measured (SQLite lane, 50k × 384)

| leg | before | after |
| --- | --- | --- |
| exact top-10 | 489ms | **124ms** |
| exact-filtered + category node index | 55.6ms | 22.5ms |
| every recall probe | 1.000 | 1.000 |

The exact leg is fast even before `materializeIndexes()` — the vec0 virtual table exists from first write.

## Tests

The `similar-to-approximate` contract suite is extended rather than duplicated:
- **Ground truth anchor**: exact results are now asserted against JS-computed cosine rankings — exact-vs-approximate parity alone became tautological on sqlite-vec once both paths use the engine form (both could be wrong together).
- **Compile shape per strategy**: a new `exactUsesEngineForm` descriptor axis — local sqlite-vec compiles the vec0 `MATCH` form on the exact path; libSQL and pgvector still compile the flat scan there.
- Metric-override fallback and the unindexed-slot degradation keep their existing pins.

## Verification

Rebased on main with #216/#217 landed (the emitter now carries both the `+ 0.0` exact defense and this routing — they compose: PG exact stays flat, SQLite exact goes vec0). fix / typecheck / knip clean; SQLite 4518 passed; PG lane 1814 passed. Changeset: patch.