### PR TITLE
perf: per-call custom-plan opt-out on postgres-js

### DIFF
--- a/.changeset/postgres-js-custom-plan.md
+++ b/.changeset/postgres-js-custom-plan.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Statements whose good plan depends on their parameter values (the
+subgraph id-array fetches, marked internally with the custom-plan
+brand) now opt out of statement preparation per call on the postgres-js
+driver too, via `sql.unsafe(text, params, { prepare: false })`.
+Previously postgres-js prepared them like everything else, so after
+five executions PostgreSQL flipped them to a generic, parameter-blind
+plan — the same cliff fixed for node-postgres in the subgraph
+shared-traversal change (measured there: 21ms → 310ms on the edge
+fetch). Scalar-parameter statements keep the driver's prepared default.

--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -70,6 +70,7 @@ type PostgresJsClient = ((...args: readonly unknown[]) => unknown) &
     unsafe: (
       sqlText: string,
       params?: readonly unknown[],
+      queryOptions?: Readonly<{ prepare?: boolean }>,
     ) => PromiseLike<readonly unknown[]>;
   }>;
 
@@ -322,11 +323,18 @@ function adaptPostgresJsClient(sql: PostgresJsClient): PgQueryClient {
   }
   return {
     query,
-    // postgres-js exposes no per-call opt-out of its internal
-    // preparation through `.unsafe`, so custom-plan-preferring
-    // statements take the same path; the generic-plan hazard on this
-    // driver is governed by its `prepare` connection option.
-    queryUnnamed: query,
+    async queryUnnamed(
+      sqlText: string,
+      params: readonly unknown[],
+    ): Promise<PgQueryResult> {
+      // Per-call opt-out of postgres-js's internal preparation
+      // (verified: `unsafe(text, params, { prepare: false })` leaves
+      // pg_prepared_statements empty), so custom-plan-preferring
+      // statements are re-planned against their actual parameters on
+      // every call — same contract as the node-postgres unnamed path.
+      const rows = await sql.unsafe(sqlText, params, { prepare: false });
+      return { rows };
+    },
   };
 }
 

--- a/packages/typegraph/tests/backends/postgres/postgres-js-custom-plan.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-custom-plan.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-call custom-plan opt-out on the postgres-js driver.
+ *
+ * Statements marked `markForceCustomPlan` (parameter-dependent plans —
+ * the subgraph id-array fetches) must never fall onto a prepared
+ * generic plan. On node-postgres they execute unnamed; postgres-js
+ * prepares internally by default, so its adapter must pass
+ * `{ prepare: false }` per call — verified here through a spy on
+ * `sql.unsafe` while `store.subgraph()` runs. The recursive traversal
+ * (scalar parameters, stable plan) must keep the prepared default.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { randomUUID } from "node:crypto";
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres, { type Sql } from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let bootstrap: Sql | undefined;
+let isPostgresAvailable = false;
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  const candidate = postgres(TEST_DATABASE_URL, {
+    max: 1,
+    connect_timeout: 5,
+    onnotice: () => {
+      // Silence IF NOT EXISTS notices.
+    },
+  });
+  try {
+    await candidate.unsafe("SELECT 1");
+    await candidate.unsafe(generatePostgresMigrationSQL());
+    bootstrap = candidate;
+    isPostgresAvailable = true;
+  } catch {
+    await candidate.end().catch(() => {
+      // Unreachable Postgres degrades to "skip".
+    });
+  }
+});
+
+afterAll(async () => {
+  if (bootstrap !== undefined) await bootstrap.end();
+});
+
+const Document = defineNode("Doc", {
+  schema: z.object({ title: z.string() }),
+});
+const references = defineEdge("references", { schema: z.object({}) });
+
+describe("postgres-js custom-plan opt-out", () => {
+  it("passes prepare:false for the subgraph id-array fetches only", async (ctx) => {
+    if (!isPostgresAvailable) {
+      ctx.skip();
+      return;
+    }
+    const sql = postgres(TEST_DATABASE_URL, {
+      max: 2,
+      onnotice: () => {
+        // Silence IF NOT EXISTS notices.
+      },
+    });
+    try {
+      const calls: {
+        text: string;
+        prepare: boolean | undefined;
+      }[] = [];
+      const originalUnsafe = sql.unsafe.bind(sql);
+      (sql as { unsafe: unknown }).unsafe = (
+        text: string,
+        params?: readonly unknown[],
+        options?: Readonly<{ prepare?: boolean }>,
+      ) => {
+        calls.push({ text, prepare: options?.prepare });
+        return (
+          originalUnsafe as (
+            t: string,
+            p?: readonly unknown[],
+            o?: Readonly<{ prepare?: boolean }>,
+          ) => unknown
+        )(text, params, options);
+      };
+
+      const backend = createPostgresBackend(drizzle(sql));
+      const graph = defineGraph({
+        id: `pjs_plan_${randomUUID().slice(0, 8)}`,
+        nodes: { Doc: { type: Document } },
+        edges: {
+          references: { type: references, from: [Document], to: [Document] },
+        },
+      });
+      const [store] = await createStoreWithSchema(graph, backend);
+      const root = await store.nodes.Doc.create({ title: "root" });
+      const child = await store.nodes.Doc.create({ title: "child" });
+      await store.edges.references.create(root, child, {});
+
+      calls.length = 0;
+      const result = await store.subgraph(root.id, {
+        edges: ["references"],
+        maxDepth: 2,
+      });
+      expect(result.nodes.size).toBe(2);
+
+      const fetches = calls.filter((call) => call.text.includes("unnest("));
+      expect(fetches.length).toBeGreaterThanOrEqual(2);
+      for (const fetch of fetches) {
+        expect(fetch.prepare).toBe(false);
+      }
+
+      const traversal = calls.filter((call) =>
+        call.text.includes("WITH RECURSIVE"),
+      );
+      expect(traversal).toHaveLength(1);
+      expect(traversal[0]?.prepare).toBeUndefined();
+    } finally {
+      await sql.end();
+    }
+  });
+});


### PR DESCRIPTION
Item 4 of the approved round. Scoping note first: the original backlog framing ("postgres-js prepared-statement fast path") turned out to be stale — `adaptPostgresJsClient` already routes postgres-js through the compiled fast path. What was genuinely missing is narrower and worse: **the generic-plan cliff fixed for node-postgres in #211 was still open on postgres-js.**

## The gap

Statements branded `markForceCustomPlan` (parameter-dependent plans — today, the subgraph id-array fetches) execute unnamed on node-postgres so every call re-plans against the actual array. On postgres-js the adapter's `queryUnnamed` was an alias for the normal path, documented as "no per-call opt-out exists" — so those statements were prepared like everything else, and after five executions PostgreSQL flips them to a generic, parameter-blind plan (measured on the same statement class in #211: 21ms → 310ms).

## The fix

postgres-js does have a per-call opt-out: `sql.unsafe(text, params, { prepare: false })` — verified directly (`pg_prepared_statements` stays empty across repeated calls, vs one entry on the default path). `queryUnnamed` now uses it. Scalar-parameter statements are untouched and keep the driver's prepared default.

## Tests (red-checked without the adapter change)

`postgres-js-custom-plan.test.ts`: a spy on `sql.unsafe` during `store.subgraph()` asserts the unnest id-array fetches are submitted with `prepare: false` while the recursive traversal keeps the prepared default (`prepare` unset).

## Verification

fix / typecheck / knip clean; SQLite 4518 passed; PG lane 1815 passed (includes the new test on the shared serialized lane). Changeset: patch.