### PR TITLE
perf: drop the redundant in-transaction delete preflights

### DIFF
--- a/.changeset/delete-preflight-elimination.md
+++ b/.changeset/delete-preflight-elimination.md
@@ -1,0 +1,16 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Edge delete, edge hard delete, and node hard delete no longer re-read
+the row inside the write transaction. The in-transaction preflight was
+pure round-trip fat on these paths: nothing consumed the row, and the
+writes are already concurrency-correct on their own — the tombstone
+UPDATE is guarded by `deleted_at IS NULL` and the hard deletes are
+id-keyed and idempotent, so a row deleted concurrently between the
+outside gate and the write lock degrades to a 0-row no-op with
+identical observable behavior (verified including recorded-time history
+under a deliberately staled gate). One less statement per delete
+(~20% of the per-op round trips on client/server engines). Node SOFT
+delete keeps its preflight deliberately: its pipeline consumes the
+pre-image for uniqueness-key cleanup, now documented in place.

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -672,12 +672,10 @@ export async function executeEdgeDelete<G extends GraphDef>(
   const opContext = ctx.createOperationContext("delete", "edge", gate.kind, id);
 
   return runHookedWriteOperation(ctx, opContext, backend, async (target) => {
-    const existing = await target.getEdge(ctx.graphId, id);
-    if (!existing || existing.deleted_at) {
-      // Already deleted - nothing to do
-      return;
-    }
-
+    // No in-transaction preflight: the tombstone UPDATE is guarded by
+    // `deleted_at IS NULL`, so a concurrent delete between the gate and
+    // the write lock is a 0-row no-op — the statement itself is the
+    // concurrency-correct check, and nothing here consumes the row.
     await target.deleteEdge({
       graphId: ctx.graphId,
       id,
@@ -703,12 +701,9 @@ export async function executeEdgeHardDelete<G extends GraphDef>(
   const opContext = ctx.createOperationContext("delete", "edge", gate.kind, id);
 
   return runHookedWriteOperation(ctx, opContext, backend, async (target) => {
-    const existing = await target.getEdge(ctx.graphId, id);
-    if (!existing) {
-      // Doesn't exist - nothing to do
-      return;
-    }
-
+    // No in-transaction preflight: DELETE by primary key is idempotent
+    // (0 rows when concurrently removed) and nothing here consumes the
+    // row.
     await target.hardDeleteEdge({
       graphId: ctx.graphId,
       id,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -1058,6 +1058,10 @@ export async function executeNodeDelete<G extends GraphDef>(
     backend,
     async (target, lock) => {
       const registration = getNodeRegistration(ctx.graph, kind);
+      // This preflight is NOT removable round-trip fat: the soft-delete
+      // pipeline consumes the pre-image (uniqueness entries are keyed by
+      // props-derived constraint keys), and this in-transaction read is
+      // the concurrency-correct source for it.
       const preflight = await target.getNode(ctx.graphId, kind, id);
       if (!preflight || !isLiveNodeRow(preflight)) return;
 
@@ -1105,8 +1109,13 @@ export async function executeNodeHardDelete<G extends GraphDef>(
     backend,
     async (target, lock) => {
       const registration = getNodeRegistration(ctx.graph, kind);
-      const preflight = await target.getNode(ctx.graphId, kind, id);
-      if (!preflight) return;
+      // No in-transaction preflight (unlike soft delete, whose pipeline
+      // consumes the pre-image for uniqueness-key cleanup): every hard
+      // cascade member is id-keyed and idempotent — the delete-behavior
+      // check re-reads edges itself, `hardDeleteNode` deletes by primary
+      // key, and embeddings clean up by id — so a node concurrently
+      // removed between the gate and the write lock makes each statement
+      // a 0-row no-op.
 
       // The cascade (edges, node, embeddings) is not individually atomic, so
       // it runs in one write transaction. Embeddings live in strategy-owned

--- a/packages/typegraph/tests/write-path-roundtrips.test.ts
+++ b/packages/typegraph/tests/write-path-roundtrips.test.ts
@@ -34,6 +34,8 @@ type CallCounts = Record<string, number>;
 const COUNTED_METHODS = [
   "deleteEdge",
   "deleteEdgesBatch",
+  "getEdge",
+  "getNode",
   "hardDeleteEdge",
   "hardDeleteEdgesBatch",
 ] as const;
@@ -190,6 +192,143 @@ describe("cascade edge deletion batches", () => {
       expect(await store.edges.links.findFrom(hub)).toHaveLength(0);
     } finally {
       await backend.close();
+    }
+  });
+});
+
+// ============================================================
+// Delete preflight elimination
+// ============================================================
+
+describe("delete round trips", () => {
+  it("edge delete and hard delete read the row once (gate only)", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, counts } = withCallCounts(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildCascadeGraph("delete_rt_edges"),
+        backend,
+      );
+      const hub = await store.nodes.Hub.create({ name: "hub" }, { id: "hub" });
+      const spoke = await store.nodes.Spoke.create(
+        { name: "spoke" },
+        { id: "spoke" },
+      );
+      const soft = await store.edges.links.create(hub, spoke, {});
+      const hard = await store.edges.links.create(hub, spoke, {});
+
+      counts.getEdge = 0;
+      await store.edges.links.delete(soft.id);
+      expect(counts.getEdge).toBe(1);
+      expect(counts.deleteEdge).toBe(1);
+
+      counts.getEdge = 0;
+      await store.edges.links.hardDelete(hard.id);
+      expect(counts.getEdge).toBe(1);
+      expect(counts.hardDeleteEdge).toBe(1);
+
+      expect(await store.edges.links.findFrom(hub)).toHaveLength(0);
+
+      // Absent/tombstoned: the gate alone decides, still one read.
+      counts.getEdge = 0;
+      await store.edges.links.delete(soft.id);
+      expect(counts.getEdge).toBe(1);
+      expect(counts.deleteEdge).toBe(1);
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("node hard delete reads once; soft delete keeps its consumed preflight", async () => {
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      const { backend, counts } = withCallCounts(rawBackend);
+      const [store] = await createStoreWithSchema(
+        buildCascadeGraph("delete_rt_nodes"),
+        backend,
+      );
+      await store.nodes.Spoke.create({ name: "a" }, { id: "a" });
+      await store.nodes.Spoke.create({ name: "b" }, { id: "b" });
+
+      counts.getNode = 0;
+      await store.nodes.Spoke.hardDelete("a" as never);
+      expect(counts.getNode).toBe(1);
+      expect(await store.nodes.Spoke.getById("a" as never)).toBeUndefined();
+
+      // Soft delete's pipeline consumes the pre-image (uniqueness keys),
+      // so its in-transaction preflight is deliberate: gate + preflight.
+      counts.getNode = 0;
+      await store.nodes.Spoke.delete("b" as never);
+      expect(counts.getNode).toBe(2);
+      expect(await store.nodes.Spoke.getById("b" as never)).toBeUndefined();
+    } finally {
+      await rawBackend.close();
+    }
+  });
+
+  it("a stale gate read degrades to a guarded no-op, recorded history intact", async () => {
+    // Simulates the race the removed preflight used to absorb: the gate
+    // sees a live row, but the row is tombstoned before the write
+    // transaction runs. The tombstone UPDATE's `deleted_at IS NULL`
+    // guard makes it a 0-row no-op, and the recorded-capture touch of
+    // the unchanged row must not corrupt history.
+    const { backend: rawBackend } = createLocalSqliteBackend();
+    try {
+      let staleEdgeRow: unknown;
+      let serveStaleGate = false;
+      const lying: GraphBackend = {
+        ...rawBackend,
+        getEdge: async (graphId: string, id: string) => {
+          const row = await rawBackend.getEdge(graphId, id);
+          if (serveStaleGate) return staleEdgeRow as never;
+          staleEdgeRow = row;
+          return row;
+        },
+      };
+      const [store] = await createStoreWithSchema(
+        buildCascadeGraph("delete_rt_race"),
+        lying,
+        { history: true },
+      );
+      const hub = await store.nodes.Hub.create({ name: "hub" }, { id: "hub" });
+      const spoke = await store.nodes.Spoke.create({ name: "s" }, { id: "s" });
+      const edge = await store.edges.links.create(hub, spoke, {});
+      const beforeDelete = await store.recordedNow();
+      if (beforeDelete === undefined) throw new Error("recordedNow required");
+
+      // Prime the stale copy (live row), tombstone for real, then replay
+      // the delete against the stale gate.
+      await rawBackend.getEdge(store.graphId, edge.id);
+      await store.edges.links.delete(edge.id);
+      serveStaleGate = true;
+      await store.edges.links.delete(edge.id);
+      serveStaleGate = false;
+
+      expect(await store.edges.links.findFrom(hub)).toHaveLength(0);
+      // Recorded history: visible before the delete, exactly gone after —
+      // the spurious touch closed nothing twice and resurrected nothing.
+      const view = store.asOfRecorded(beforeDelete);
+      const edgesBefore = await view
+        .query()
+        .from("Hub", "h")
+        .traverse("links", "e")
+        .to("Spoke", "s")
+        .select((ctx) => ({ id: ctx.s.id }))
+        .execute();
+      expect(edgesBefore).toHaveLength(1);
+      const nowRecorded = await store.recordedNow();
+      if (nowRecorded === undefined) throw new Error("recordedNow required");
+      const edgesAfter = await store
+        .asOfRecorded(nowRecorded)
+        .query()
+        .from("Hub", "h")
+        .traverse("links", "e")
+        .to("Spoke", "s")
+        .select((ctx) => ({ id: ctx.s.id }))
+        .execute();
+      expect(edgesAfter).toHaveLength(0);
+    } finally {
+      await rawBackend.close();
     }
   });
 });


### PR DESCRIPTION
Performance audit findings: the audit had deferred "fold gate+preflight into `UPDATE … RETURNING`" because it would change the backend delete contracts. Re-examining the four paths found something simpler: **on three of them the preflight can just be deleted, no contract change at all.**

## What the reads were for

Each delete does a gate read outside the transaction (deliberate, kept: an absent delete fires no hooks and opens no transaction — empty transactions are costly on libsql) plus a re-read inside the transaction. Per path:

- **Edge delete / edge hard delete / node hard delete** — the in-tx row is never consumed. Existence is the only thing checked, and the writes already enforce it: the tombstone UPDATE carries `deleted_at IS NULL`, hard deletes are id-keyed DELETEs, and the hard-cascade members (delete-behavior check, uniques, embeddings) are all id-keyed and idempotent. The preflight removed exactly nothing but a race window the statement guard covers better. **Removed.**
- **Node soft delete** — the pipeline consumes the pre-image (`deleteUniquenessEntries` derives constraint keys from the row's props), and the in-tx read is the concurrency-correct source for it. **Kept**, with a comment saying why, so the next round-trip audit doesn't re-litigate it.

No `RETURNING` needed anywhere — which also sidesteps the pre-image problem an `UPDATE … RETURNING` fold would have had for recorded capture (RETURNING yields the post-image).

## Semantics

A row deleted concurrently between the gate and the write lock now degrades to a 0-row guarded write instead of an early return — same observable outcome, one fewer statement (~20% of the ~5 per-op round trips on client/server engines). Recorded capture is touch-based and flush-reconciled, so the spurious touch of an unchanged row in that race is a no-op — proven end-to-end below.

## Tests (red-checked without the change)

- Round-trip pins via the tx-following counting overlay: `getEdge`/`getNode` called exactly **once** (gate only) for edge delete, edge hard delete, and node hard delete — including the absent/tombstoned case — and exactly **twice** for node soft delete (the deliberate keep).
- The race, made deterministic: an overlay serves a stale (pre-delete) row to the gate while the real row is already tombstoned, driving the removed-preflight shape end-to-end under `history: true`. The edge stays deleted, recorded history shows exactly one close (visible before, gone after), nothing resurrects, nothing throws.
