### PR TITLE
Add transaction receipts

### DIFF
--- a/.changeset/transaction-receipts.md
+++ b/.changeset/transaction-receipts.md
@@ -2,6 +2,7 @@
 "@nicia-ai/typegraph": minor
 ---
 
-Add opt-in transaction receipts that summarize completed collection write
-intents and, for history-enabled stores, return the recorded commit instant
-allocated by the transaction.
+Add `store.transactionWithReceipt()`, which runs a transaction and returns a
+receipt summarizing completed collection write intents and, for
+history-enabled stores, the recorded commit instant allocated by the
+transaction.

--- a/.changeset/transaction-receipts.md
+++ b/.changeset/transaction-receipts.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add opt-in transaction receipts that summarize completed collection write
+intents and, for history-enabled stores, return the recorded commit instant
+allocated by the transaction.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1323,6 +1323,52 @@ const personId = await store.transaction(async (tx) => {
 // personId is available here
 ```
 
+#### Transaction receipts
+
+Pass `{ receipt: true }` when a caller needs a write summary without wrapping the
+transaction context itself:
+
+```typescript
+const outcome = await store.transaction(
+  async (tx) => {
+    const alice = await tx.nodes.Person.create({ name: "Alice" });
+    const bob = await tx.nodes.Person.create({ name: "Bob" });
+    await tx.edges.knows.getOrCreateByEndpoints(alice, bob, {
+      since: "2026",
+    });
+    return alice.id;
+  },
+  { receipt: true },
+);
+
+outcome.result; // Alice's id
+outcome.receipt.writes; // { nodes: { Person: 2 }, edges: { knows: 1 }, total: 3 }
+outcome.receipt.recorded; // RecordedInstant | undefined
+```
+
+Receipt counts are completed write intents at the collection surface, not rows
+affected:
+
+- Every successful completion of a write method on `tx.nodes.*` / `tx.edges.*`
+  counts. The authoritative method list is `NodeWrites` / `EdgeWrites`.
+- Bulk methods count by input length; an empty bulk call (`bulkCreate([])`)
+  counts 0.
+- Single-row methods count 1 on resolve — including `delete` of an absent id and
+  `getOrCreate*` that found an existing row. Consumers that need "did anything
+  actually change" semantics apply their own per-operation policy.
+- A method that rejects counts 0.
+- Rows-affected fidelity is intentionally out of scope for this first version; a
+  future extension could ask backends to return row counts.
+
+When the store was created with `{ history: true }` and the transaction flushed
+captured writes, `receipt.recorded` is the recorded commit instant allocated for
+this store's graph by this transaction. It is `undefined` when history capture is
+off, the transaction is read-only, or no captured writes were flushed. Writes
+that bypass the transaction collection surface — direct backend writes, raw SQL,
+and import helpers — are not counted. Adopted transactions
+(`withTransaction` / `withRecordedTransaction`) do not produce receipts in this
+version because their commit belongs to the caller.
+
 #### Rollback and error propagation
 
 If the callback throws, the transaction is rolled back and the error re-throws to the

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1356,7 +1356,14 @@ affected:
 - Single-row methods count 1 on resolve — including `delete` of an absent id and
   `getOrCreate*` that found an existing row. Consumers that need "did anything
   actually change" semantics apply their own per-operation policy.
-- A method that rejects counts 0.
+- A method that rejects counts 0 — even when the backend applied part of a bulk
+  input before failing. On SQLite a failed statement does not abort the
+  surrounding transaction, so a caller that catches the rejection and commits
+  can persist rows the receipt never counted. Do not read the receipt as
+  rows-affected in that scenario.
+- A node `delete` under `cascade` / `disconnect` removes connected edges through
+  the backend, not the edge-collection surface; those removals do not appear in
+  `edges`.
 - Rows-affected fidelity is intentionally out of scope for this first version; a
   future extension could ask backends to return row counts.
 
@@ -1367,7 +1374,13 @@ off, the transaction is read-only, or no captured writes were flushed. Writes
 that bypass the transaction collection surface — direct backend writes, raw SQL,
 and import helpers — are not counted. Adopted transactions
 (`withTransaction` / `withRecordedTransaction`) do not produce receipts in this
-version because their commit belongs to the caller.
+version because their commit belongs to the caller. On non-transactional
+backends a receipt describes operations that individually committed; if the
+callback rejects there, no receipt is returned even though earlier operations
+committed. Receipt detection is a runtime check on `options.receipt`, so
+forwarding receipt options through a variable typed as plain
+`TransactionOptions` returns a `TransactionOutcome` at runtime that the static
+`Promise<T>` type will not reflect — keep receipt options literally typed.
 
 #### Rollback and error propagation
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1325,21 +1325,19 @@ const personId = await store.transaction(async (tx) => {
 
 #### Transaction receipts
 
-Pass `{ receipt: true }` when a caller needs a write summary without wrapping the
-transaction context itself:
+Use `store.transactionWithReceipt()` when a caller needs a write summary
+without wrapping the transaction context itself. It runs the callback exactly
+like `store.transaction()` and returns the result together with a receipt:
 
 ```typescript
-const outcome = await store.transaction(
-  async (tx) => {
-    const alice = await tx.nodes.Person.create({ name: "Alice" });
-    const bob = await tx.nodes.Person.create({ name: "Bob" });
-    await tx.edges.knows.getOrCreateByEndpoints(alice, bob, {
-      since: "2026",
-    });
-    return alice.id;
-  },
-  { receipt: true },
-);
+const outcome = await store.transactionWithReceipt(async (tx) => {
+  const alice = await tx.nodes.Person.create({ name: "Alice" });
+  const bob = await tx.nodes.Person.create({ name: "Bob" });
+  await tx.edges.knows.getOrCreateByEndpoints(alice, bob, {
+    since: "2026",
+  });
+  return alice.id;
+});
 
 outcome.result; // Alice's id
 outcome.receipt.writes; // { nodes: { Person: 2 }, edges: { knows: 1 }, total: 3 }
@@ -1377,10 +1375,7 @@ and import helpers — are not counted. Adopted transactions
 version because their commit belongs to the caller. On non-transactional
 backends a receipt describes operations that individually committed; if the
 callback rejects there, no receipt is returned even though earlier operations
-committed. Receipt detection is a runtime check on `options.receipt`, so
-forwarding receipt options through a variable typed as plain
-`TransactionOptions` returns a `TransactionOutcome` at runtime that the static
-`Promise<T>` type will not reflect — keep receipt options literally typed.
+committed.
 
 #### Rollback and error propagation
 

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -450,6 +450,8 @@ export type {
   StoreProjection,
   StoreRef,
   TransactionContext,
+  TransactionOutcome,
+  TransactionReceipt,
   TypedEdgeCollection,
   UpdateEdgeInput,
   UpdateNodeInput,

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -43,6 +43,8 @@ export {
   type StoreViewNodeCollection,
   type StoreViewNodeCollections,
   type TransactionContext,
+  type TransactionOutcome,
+  type TransactionReceipt,
   type TypedEdgeCollection,
   type TypedRecordedStoreViewEdgeCollection,
   type TypedStoreViewEdgeCollection,

--- a/packages/typegraph/src/store/recorded-capture.ts
+++ b/packages/typegraph/src/store/recorded-capture.ts
@@ -81,12 +81,48 @@ type RecordedCaptureSession = Readonly<{
     target: TransactionBackend,
     schema: SqlSchema,
     ownsWriteLock: boolean,
-  ) => Promise<void>;
+  ) => Promise<RecordedFlushInstants>;
 }>;
+
+export type RecordedFlushInstants = ReadonlyMap<string, string>;
+
+type RecordedFlushObserver = (instants: RecordedFlushInstants) => void;
+
+const RECORDED_FLUSH_OBSERVER = Symbol("typegraph.recordedFlushObserver");
+
+type RecordedFlushObserverOptions = TransactionOptions &
+  Readonly<{
+    [RECORDED_FLUSH_OBSERVER]?: RecordedFlushObserver;
+  }>;
+
+function readRecordedFlushObserver(
+  options: TransactionOptions | undefined,
+): RecordedFlushObserver | undefined {
+  return (options as RecordedFlushObserverOptions | undefined)?.[
+    RECORDED_FLUSH_OBSERVER
+  ];
+}
+
+function stripRecordedFlushObserver(
+  options: TransactionOptions | undefined,
+): TransactionOptions | undefined {
+  if (options?.isolationLevel === undefined) return undefined;
+  return { isolationLevel: options.isolationLevel };
+}
+
+export function withRecordedFlushObserver(
+  options: TransactionOptions | undefined,
+  observer: RecordedFlushObserver,
+): TransactionOptions {
+  return {
+    ...stripRecordedFlushObserver(options),
+    [RECORDED_FLUSH_OBSERVER]: observer,
+  } as RecordedFlushObserverOptions;
+}
 
 type RecordedTransactionScope = Readonly<{
   backend: TransactionBackend;
-  flush: () => Promise<void>;
+  flush: () => Promise<RecordedFlushInstants>;
 }>;
 
 declare const NODE_IDENTITY_KEY_BRAND: unique symbol;
@@ -171,7 +207,7 @@ function createRecordedCaptureSession(): RecordedCaptureSession {
       target: TransactionBackend,
       schema: SqlSchema,
       ownsWriteLock: boolean,
-    ): Promise<void> {
+    ): Promise<RecordedFlushInstants> {
       if (sealed) {
         throw new ConfigurationError(
           "Recorded-time capture session was already flushed.",
@@ -187,7 +223,8 @@ function createRecordedCaptureSession(): RecordedCaptureSession {
       // flush() writes recorded rows directly (never via touch), so sealing here
       // does not block its own work.
       sealed = true;
-      if (touched.size === 0) return;
+      if (touched.size === 0) return new Map();
+      const recordedByGraph = new Map<string, string>();
       const byGraph = groupBy(touched.values(), (entity) => entity.graphId);
       for (const [graphId, entities] of byGraph) {
         const recordedCommit = await allocateRecordedCommit(
@@ -196,6 +233,7 @@ function createRecordedCaptureSession(): RecordedCaptureSession {
           graphId,
           ownsWriteLock,
         );
+        recordedByGraph.set(graphId, recordedCommit);
         const nodes = entities.filter(
           (entity): entity is TouchedNode => entity.entity === "node",
         );
@@ -206,6 +244,7 @@ function createRecordedCaptureSession(): RecordedCaptureSession {
         await flushEdges(target, schema, graphId, edges, recordedCommit);
       }
       touched.clear();
+      return recordedByGraph;
     },
   };
 }
@@ -451,11 +490,11 @@ export function createRecordedTransactionScope(
   const resolvedSchema = schema ?? requireRecordedSchema(target);
   return {
     backend: createRecordedTransactionBackend(target, session, resolvedSchema),
-    async flush(): Promise<void> {
+    async flush(): Promise<RecordedFlushInstants> {
       // By flush time the live write has committed within this transaction, so a
       // missing-table error can only be a recorded relation — surface it as the
       // typed precondition the constructor gate could not check.
-      await withRecordedRelationsPrecondition(
+      return withRecordedRelationsPrecondition(
         session.flush(target, resolvedSchema, ownsWriteLock),
         { dialect: target.dialect, surface: "capture-flush" },
       );
@@ -611,15 +650,18 @@ export function createRecordedBackend(
       }),
 
     async transaction(fn, options) {
-      assertRequestedRecordedIsolation(backend, options);
+      const observer = readRecordedFlushObserver(options);
+      const backendOptions = stripRecordedFlushObserver(options);
+      assertRequestedRecordedIsolation(backend, backendOptions);
       return backend.transaction(async (target) => {
         await assertRecordedCaptureTransactionIsolation(target);
         // Bundled BEGIN IMMEDIATE transaction — the write lock is already held.
         const scope = createRecordedTransactionScope(target, schema, true);
         const result = await fn(scope.backend, createHistoryUnsafeSqlRef());
-        await scope.flush();
+        const instants = await scope.flush();
+        observer?.(instants);
         return result;
-      }, options);
+      }, backendOptions);
     },
 
     ...(backend.adoptTransaction === undefined ?

--- a/packages/typegraph/src/store/recorded-capture.ts
+++ b/packages/typegraph/src/store/recorded-capture.ts
@@ -106,8 +106,12 @@ function readRecordedFlushObserver(
 function stripRecordedFlushObserver(
   options: TransactionOptions | undefined,
 ): TransactionOptions | undefined {
-  if (options?.isolationLevel === undefined) return undefined;
-  return { isolationLevel: options.isolationLevel };
+  if (options === undefined) return undefined;
+  // Omit only the observer symbol; every other (current or future)
+  // TransactionOptions field passes through to the wrapped backend untouched.
+  const { [RECORDED_FLUSH_OBSERVER]: _observer, ...backendOptions } =
+    options as RecordedFlushObserverOptions;
+  return backendOptions;
 }
 
 export function withRecordedFlushObserver(

--- a/packages/typegraph/src/store/recorded-capture/write-surface.ts
+++ b/packages/typegraph/src/store/recorded-capture/write-surface.ts
@@ -11,6 +11,7 @@ import {
   type UpdateEdgeParams,
   type UpdateNodeParams,
 } from "../../backend/types";
+import { type Assert, type Equal } from "../../utils/type-assert";
 
 /**
  * The graph-entity write surface that recorded-time capture must wrap. Both
@@ -95,14 +96,6 @@ type DerivedGraphEntityWriteMethod = {
 type ListedRecordedWriteMethod =
   | (typeof RECORDED_REQUIRED_WRITE_METHODS)[number]
   | (typeof RECORDED_OPTIONAL_WRITE_METHODS)[number];
-
-type Assert<T extends true> = T;
-type Equal<A, B> =
-  [A] extends [B] ?
-    [B] extends [A] ?
-      true
-    : false
-  : false;
 
 // If this line errors, the recorded-capture write lists no longer match the
 // backend's graph-entity write surface — reconcile RECORDED_*_WRITE_METHODS (and

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -160,6 +160,8 @@ import {
   lockRecordedGraphWrite,
   readRecordedClock,
   recordedCaptureRequiresCallbackTransactionError,
+  type RecordedFlushInstants,
+  withRecordedFlushObserver,
   withRecordedRelationsPrecondition,
 } from "./recorded-capture";
 import { assertNoRecordedCoordinate } from "./recorded-coordinate-guard";
@@ -182,6 +184,11 @@ import {
   type SubgraphResult,
 } from "./subgraph";
 import {
+  createTransactionReceiptRecorder,
+  type TransactionReceiptRecorder,
+  wrapTransactionCollections,
+} from "./transaction-receipt";
+import {
   AUTO_REFRESH_STATISTICS_ROW_THRESHOLD,
   type DynamicEdgeCollection,
   type DynamicNodeCollection,
@@ -198,6 +205,7 @@ import {
   type StoreOptions,
   type StoreRef,
   type TransactionContext,
+  type TransactionOutcome,
 } from "./types";
 
 type StoreSchemaMetadata = Readonly<{
@@ -332,6 +340,41 @@ type PendingOperationOutcome = Readonly<{
   ctx: OperationHookContext;
   durationMs: number;
 }>;
+
+type ReceiptTransactionOptions = TransactionOptions &
+  Readonly<{ receipt: true }>;
+
+type StoreTransactionOptions = TransactionOptions | ReceiptTransactionOptions;
+
+function requestsReceipt(
+  options: StoreTransactionOptions | undefined,
+): options is ReceiptTransactionOptions {
+  return (
+    (options as Readonly<{ receipt?: true }> | undefined)?.receipt === true
+  );
+}
+
+function stripReceiptOption(
+  options: StoreTransactionOptions | undefined,
+): TransactionOptions | undefined {
+  if (options?.isolationLevel === undefined) return undefined;
+  return { isolationLevel: options.isolationLevel };
+}
+
+function transactionOutcome<T>(
+  result: T,
+  recorder: TransactionReceiptRecorder,
+  recordedByGraph: RecordedFlushInstants | undefined,
+  graphId: string,
+): TransactionOutcome<T> {
+  const recorded = recordedByGraph?.get(graphId);
+  return {
+    result,
+    receipt: recorder.snapshot(
+      recorded === undefined ? undefined : asRecordedInstant(recorded),
+    ),
+  };
+}
 
 export class Store<G extends GraphDef> {
   readonly #graph: G;
@@ -1387,7 +1430,27 @@ export class Store<G extends GraphDef> {
    *   fallback ignores it entirely. Stores created with `{ history: true }`
    *   require read-committed semantics for PostgreSQL recorded-clock capture and
    *   reject stronger snapshot isolation levels.
+   *
+   * Pass `{ receipt: true }` to return a {@link TransactionOutcome}. The
+   * receipt counts completed write intents on the transaction-scoped collection
+   * surface. It does not count writes that bypass those collections, such as
+   * direct backend writes, raw SQL, or import helpers. Adopted transactions
+   * (`withTransaction` / `withRecordedTransaction`) do not produce receipts in
+   * this version because their commit belongs to the caller. On
+   * non-transactional backends, the receipt is still returned, but it describes
+   * operations that individually committed rather than one atomic commit.
    */
+  transaction<T>(
+    this: HistoryStore<G>,
+    fn: (tx: HistoryTransactionContext<G>) => Promise<T>,
+    options: ReceiptTransactionOptions,
+  ): Promise<TransactionOutcome<T>>;
+
+  transaction<T>(
+    fn: (tx: TransactionContext<G>) => Promise<T>,
+    options: ReceiptTransactionOptions,
+  ): Promise<TransactionOutcome<T>>;
+
   transaction<T>(
     this: HistoryStore<G>,
     fn: (tx: HistoryTransactionContext<G>) => Promise<T>,
@@ -1403,19 +1466,37 @@ export class Store<G extends GraphDef> {
     fn:
       | ((tx: TransactionContext<G>) => Promise<T>)
       | ((tx: HistoryTransactionContext<G>) => Promise<T>),
-    options?: TransactionOptions,
-  ): Promise<T> {
+    options?: StoreTransactionOptions,
+  ): Promise<T | TransactionOutcome<T>> {
     const invoke = fn as (tx: TransactionContext<G>) => Promise<T>;
+    const receiptRequested = requestsReceipt(options);
+    const receiptRecorder =
+      receiptRequested ? createTransactionReceiptRecorder() : undefined;
+    const backendOptions = stripReceiptOption(options);
     // Without a real transaction the tx-scoped collections would be
     // bound to the same backend as this.nodes/this.edges and exposing
     // the cached versions avoids rebuilding the proxies on every call.
     // An isolation-level request in `options` is equally meaningless here.
     if (!this.#backend.capabilities.transactions) {
-      return invoke({
-        nodes: this.nodes,
-        edges: this.edges,
+      let nodes = this.nodes;
+      let edges = this.edges;
+      if (receiptRecorder !== undefined) {
+        ({ nodes, edges } = wrapTransactionCollections(
+          nodes,
+          edges,
+          receiptRecorder,
+        ));
+      }
+      const result = await invoke({
+        nodes,
+        edges,
         backend: this.#backend,
-        getNodeCollection: (kind) => this.getNodeCollection(kind),
+        getNodeCollection: (kind) => {
+          if (!Object.hasOwn(this.#graph.nodes, kind)) return;
+          return nodes[
+            kind as keyof G["nodes"] & string
+          ] as unknown as DynamicNodeCollection;
+        },
         // No transaction, no deferral: operations apply as they happen, so
         // their hooks fire immediately.
         runNodeOperationHooks: (operation, kind, id, hookedFunction) =>
@@ -1424,6 +1505,13 @@ export class Store<G extends GraphDef> {
             hookedFunction,
           ),
       });
+      if (receiptRecorder === undefined) return result;
+      return transactionOutcome(
+        result,
+        receiptRecorder,
+        undefined,
+        this.graphId,
+      );
     }
 
     // #134/#135: no gate here. The backend's transaction() wraps the
@@ -1445,16 +1533,38 @@ export class Store<G extends GraphDef> {
     // "durable" even for tx-scoped collection operations.
     const pending: PendingOperationOutcome[] = [];
     const runHooks = this.#createBufferedHookRunner(pending);
+    let recordedByGraph: RecordedFlushInstants | undefined;
+    const transactionOptions =
+      receiptRecorder !== undefined && this.#captureEnabled ?
+        withRecordedFlushObserver(backendOptions, (instants) => {
+          recordedByGraph = instants;
+        })
+      : backendOptions;
     try {
       const result = await this.#backend.transaction(
         async (txBackend, sql) =>
-          invoke(this.#buildTransactionContext(txBackend, sql, runHooks)),
-        options,
+          invoke(
+            this.#buildTransactionContext(
+              txBackend,
+              sql,
+              runHooks,
+              receiptRecorder,
+            ),
+          ),
+        transactionOptions,
       );
       for (const outcome of pending) {
         this.#hooks.onOperationEnd?.(outcome.ctx, {
           durationMs: outcome.durationMs,
         });
+      }
+      if (receiptRecorder !== undefined) {
+        return transactionOutcome(
+          result,
+          receiptRecorder,
+          recordedByGraph,
+          this.graphId,
+        );
       }
       return result;
     } catch (error) {
@@ -1629,6 +1739,7 @@ export class Store<G extends GraphDef> {
     txBackend: TransactionBackend,
     sql?: AdoptedTransaction,
     runHooks: OperationHookRunner = this.#immediateHookRunner(),
+    receiptRecorder?: TransactionReceiptRecorder,
   ): TransactionContext<G> {
     // No statistics auto-refresh inside a caller-provided transaction:
     // ANALYZE from another connection cannot see the uncommitted rows,
@@ -1652,7 +1763,7 @@ export class Store<G extends GraphDef> {
     ): Promise<T> =>
       runHooks(this.#createOperationContext(operation, "node", kind, id), fn);
 
-    const nodes = createNodeCollectionsProxy(
+    let nodes = createNodeCollectionsProxy(
       this.#graph,
       this.graphId,
       this.#registry,
@@ -1660,13 +1771,21 @@ export class Store<G extends GraphDef> {
       txNodeOperations,
     );
 
-    const edges = createEdgeCollectionsProxy(
+    let edges = createEdgeCollectionsProxy(
       this.#graph,
       this.graphId,
       this.#registry,
       txBackend,
       txEdgeOperations,
     );
+
+    if (receiptRecorder !== undefined) {
+      ({ nodes, edges } = wrapTransactionCollections(
+        nodes,
+        edges,
+        receiptRecorder,
+      ));
+    }
 
     const getNodeCollection = (
       kind: string,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -341,37 +341,10 @@ type PendingOperationOutcome = Readonly<{
   durationMs: number;
 }>;
 
-type ReceiptTransactionOptions = TransactionOptions &
-  Readonly<{ receipt: true }>;
-
-type StoreTransactionOptions = TransactionOptions | ReceiptTransactionOptions;
-
-function requestsReceipt(
-  options: StoreTransactionOptions | undefined,
-): options is ReceiptTransactionOptions {
-  const receipt = (options as Readonly<{ receipt?: unknown }> | undefined)
-    ?.receipt;
-  if (receipt === undefined || typeof receipt === "boolean") {
-    return receipt === true;
-  }
-  // Untyped callers can pass any truthy value; silently returning the bare
-  // result there would mirror the corruption the receipt exists to prevent.
-  throw new ConfigurationError(
-    "Transaction option `receipt` must be `true` when requesting a receipt.",
-    { receipt },
-  );
-}
-
-function stripReceiptOption(
-  options: StoreTransactionOptions | undefined,
-): TransactionOptions | undefined {
-  if (options === undefined) return undefined;
-  // Omit only the store-level flag; every other (current or future)
-  // TransactionOptions field passes through to the backend untouched.
-  const { receipt: _receipt, ...backendOptions } =
-    options as ReceiptTransactionOptions;
-  return backendOptions;
-}
+type TransactionRunResult<T> = Readonly<{
+  result: T;
+  recordedByGraph: RecordedFlushInstants | undefined;
+}>;
 
 function transactionOutcome<T>(
   result: T,
@@ -1442,36 +1415,7 @@ export class Store<G extends GraphDef> {
    *   fallback ignores it entirely. Stores created with `{ history: true }`
    *   require read-committed semantics for PostgreSQL recorded-clock capture and
    *   reject stronger snapshot isolation levels.
-   *
-   * Pass `{ receipt: true }` to return a {@link TransactionOutcome}. The
-   * receipt counts completed write intents on the transaction-scoped collection
-   * surface. It does not count writes that bypass those collections, such as
-   * direct backend writes, raw SQL, or import helpers. Adopted transactions
-   * (`withTransaction` / `withRecordedTransaction`) do not produce receipts in
-   * this version because their commit belongs to the caller. On
-   * non-transactional backends, the receipt is still returned, but it describes
-   * operations that individually committed rather than one atomic commit. If
-   * the callback rejects on such a backend, no receipt is returned even though
-   * earlier operations committed individually.
-   *
-   * Receipt detection is a runtime check on `options.receipt`. Forwarding
-   * receipt options through a variable typed as plain `TransactionOptions`
-   * (`ReceiptTransactionOptions` is assignable to it) statically selects the
-   * `Promise<T>` overload while the call still returns a
-   * {@link TransactionOutcome} at runtime — keep receipt options literally
-   * typed, or thread the `{ receipt: true }` type through wrapper signatures.
    */
-  transaction<T>(
-    this: HistoryStore<G>,
-    fn: (tx: HistoryTransactionContext<G>) => Promise<T>,
-    options: ReceiptTransactionOptions,
-  ): Promise<TransactionOutcome<T>>;
-
-  transaction<T>(
-    fn: (tx: TransactionContext<G>) => Promise<T>,
-    options: ReceiptTransactionOptions,
-  ): Promise<TransactionOutcome<T>>;
-
   transaction<T>(
     this: HistoryStore<G>,
     fn: (tx: HistoryTransactionContext<G>) => Promise<T>,
@@ -1487,17 +1431,88 @@ export class Store<G extends GraphDef> {
     fn:
       | ((tx: TransactionContext<G>) => Promise<T>)
       | ((tx: HistoryTransactionContext<G>) => Promise<T>),
-    options?: StoreTransactionOptions,
-  ): Promise<T | TransactionOutcome<T>> {
+    options?: TransactionOptions,
+  ): Promise<T> {
     const invoke = fn as (tx: TransactionContext<G>) => Promise<T>;
-    const receiptRequested = requestsReceipt(options);
-    const receiptRecorder =
-      receiptRequested ? createTransactionReceiptRecorder() : undefined;
-    const backendOptions = stripReceiptOption(options);
+    const { result } = await this.#runTransaction(invoke, options, undefined);
+    return result;
+  }
+
+  /**
+   * Runs a transaction exactly like {@link transaction} and additionally
+   * returns a {@link TransactionOutcome} whose receipt summarizes the
+   * completed write intents on the transaction-scoped collection surface.
+   *
+   * A dedicated method (rather than an option on `transaction()`) keeps the
+   * return type tied to static dispatch: forwarding options through wrappers
+   * can never change what a call returns. See {@link TransactionReceipt} for
+   * exact count semantics.
+   *
+   * The receipt does not count writes that bypass the `tx.nodes.*` /
+   * `tx.edges.*` collections, such as direct backend writes, raw SQL, or
+   * import helpers. Adopted transactions (`withTransaction` /
+   * `withRecordedTransaction`) do not produce receipts in this version
+   * because their commit belongs to the caller. On non-transactional
+   * backends, the receipt is still returned, but it describes operations
+   * that individually committed rather than one atomic commit; if the
+   * callback rejects on such a backend, no receipt is returned even though
+   * earlier operations committed individually.
+   *
+   * For stores created with `{ history: true }`, `receipt.recorded` is the
+   * recorded commit instant this transaction allocated for the store's
+   * graph, or `undefined` when nothing was captured.
+   *
+   * @example
+   * ```typescript
+   * const outcome = await store.transactionWithReceipt(async (tx) => {
+   *   const alice = await tx.nodes.Person.create({ name: "Alice" });
+   *   return alice.id;
+   * });
+   * outcome.result; // Alice's id
+   * outcome.receipt.writes; // { nodes: { Person: 1 }, edges: {}, total: 1 }
+   * ```
+   */
+  transactionWithReceipt<T>(
+    this: HistoryStore<G>,
+    fn: (tx: HistoryTransactionContext<G>) => Promise<T>,
+    options?: TransactionOptions,
+  ): Promise<TransactionOutcome<T>>;
+
+  transactionWithReceipt<T>(
+    fn: (tx: TransactionContext<G>) => Promise<T>,
+    options?: TransactionOptions,
+  ): Promise<TransactionOutcome<T>>;
+
+  async transactionWithReceipt<T>(
+    fn:
+      | ((tx: TransactionContext<G>) => Promise<T>)
+      | ((tx: HistoryTransactionContext<G>) => Promise<T>),
+    options?: TransactionOptions,
+  ): Promise<TransactionOutcome<T>> {
+    const invoke = fn as (tx: TransactionContext<G>) => Promise<T>;
+    const receiptRecorder = createTransactionReceiptRecorder();
+    const { result, recordedByGraph } = await this.#runTransaction(
+      invoke,
+      options,
+      receiptRecorder,
+    );
+    return transactionOutcome(
+      result,
+      receiptRecorder,
+      recordedByGraph,
+      this.graphId,
+    );
+  }
+
+  async #runTransaction<T>(
+    invoke: (tx: TransactionContext<G>) => Promise<T>,
+    backendOptions: TransactionOptions | undefined,
+    receiptRecorder: TransactionReceiptRecorder | undefined,
+  ): Promise<TransactionRunResult<T>> {
     // Without a real transaction the tx-scoped collections would be
     // bound to the same backend as this.nodes/this.edges and exposing
     // the cached versions avoids rebuilding the proxies on every call.
-    // An isolation-level request in `options` is equally meaningless here.
+    // An isolation-level request in the options is equally meaningless here.
     if (!this.#backend.capabilities.transactions) {
       let nodes = this.nodes;
       let edges = this.edges;
@@ -1526,13 +1541,7 @@ export class Store<G extends GraphDef> {
             hookedFunction,
           ),
       });
-      if (receiptRecorder === undefined) return result;
-      return transactionOutcome(
-        result,
-        receiptRecorder,
-        undefined,
-        this.graphId,
-      );
+      return { result, recordedByGraph: undefined };
     }
 
     // #134/#135: no gate here. The backend's transaction() wraps the
@@ -1579,15 +1588,7 @@ export class Store<G extends GraphDef> {
           durationMs: outcome.durationMs,
         });
       }
-      if (receiptRecorder !== undefined) {
-        return transactionOutcome(
-          result,
-          receiptRecorder,
-          recordedByGraph,
-          this.graphId,
-        );
-      }
-      return result;
+      return { result, recordedByGraph };
     } catch (error) {
       const failure = asError(error);
       for (const outcome of pending) {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -349,16 +349,28 @@ type StoreTransactionOptions = TransactionOptions | ReceiptTransactionOptions;
 function requestsReceipt(
   options: StoreTransactionOptions | undefined,
 ): options is ReceiptTransactionOptions {
-  return (
-    (options as Readonly<{ receipt?: true }> | undefined)?.receipt === true
+  const receipt = (options as Readonly<{ receipt?: unknown }> | undefined)
+    ?.receipt;
+  if (receipt === undefined || typeof receipt === "boolean") {
+    return receipt === true;
+  }
+  // Untyped callers can pass any truthy value; silently returning the bare
+  // result there would mirror the corruption the receipt exists to prevent.
+  throw new ConfigurationError(
+    "Transaction option `receipt` must be `true` when requesting a receipt.",
+    { receipt },
   );
 }
 
 function stripReceiptOption(
   options: StoreTransactionOptions | undefined,
 ): TransactionOptions | undefined {
-  if (options?.isolationLevel === undefined) return undefined;
-  return { isolationLevel: options.isolationLevel };
+  if (options === undefined) return undefined;
+  // Omit only the store-level flag; every other (current or future)
+  // TransactionOptions field passes through to the backend untouched.
+  const { receipt: _receipt, ...backendOptions } =
+    options as ReceiptTransactionOptions;
+  return backendOptions;
 }
 
 function transactionOutcome<T>(
@@ -1438,7 +1450,16 @@ export class Store<G extends GraphDef> {
    * (`withTransaction` / `withRecordedTransaction`) do not produce receipts in
    * this version because their commit belongs to the caller. On
    * non-transactional backends, the receipt is still returned, but it describes
-   * operations that individually committed rather than one atomic commit.
+   * operations that individually committed rather than one atomic commit. If
+   * the callback rejects on such a backend, no receipt is returned even though
+   * earlier operations committed individually.
+   *
+   * Receipt detection is a runtime check on `options.receipt`. Forwarding
+   * receipt options through a variable typed as plain `TransactionOptions`
+   * (`ReceiptTransactionOptions` is assignable to it) statically selects the
+   * `Promise<T>` overload while the call still returns a
+   * {@link TransactionOutcome} at runtime — keep receipt options literally
+   * typed, or thread the `{ receipt: true }` type through wrapper signatures.
    */
   transaction<T>(
     this: HistoryStore<G>,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -586,6 +586,25 @@ export class Store<G extends GraphDef> {
   // === Dynamic Collection Access ===
 
   /**
+   * Resolves `kind` against `collections` (either `this.nodes` or a
+   * transaction-scoped — and possibly receipt-wrapped — node collection map),
+   * or `undefined` when the kind is not registered in this graph. Shared by
+   * `getNodeCollection` and both transaction contexts' `getNodeCollection` so
+   * a receipt-wrapped transaction counts writes made through the dynamic
+   * lookup exactly like `this.#graph.nodes` membership is checked everywhere
+   * else.
+   */
+  #resolveDynamicNodeCollection(
+    collections: GraphNodeCollections<G>,
+    kind: string,
+  ): DynamicNodeCollection | undefined {
+    if (!Object.hasOwn(this.#graph.nodes, kind)) return undefined;
+    return collections[
+      kind as keyof G["nodes"] & string
+    ] as unknown as DynamicNodeCollection;
+  }
+
+  /**
    * Returns the node collection for the given kind, or undefined if the kind
    * is not registered in this graph.
    *
@@ -596,10 +615,7 @@ export class Store<G extends GraphDef> {
    * throws `KindNotFoundError` instead of forcing a null-check.
    */
   getNodeCollection(kind: string): DynamicNodeCollection | undefined {
-    if (!Object.hasOwn(this.#graph.nodes, kind)) return undefined;
-    return this.nodes[
-      kind as keyof G["nodes"] & string
-    ] as unknown as DynamicNodeCollection;
+    return this.#resolveDynamicNodeCollection(this.nodes, kind);
   }
 
   /**
@@ -1527,12 +1543,8 @@ export class Store<G extends GraphDef> {
         nodes,
         edges,
         backend: this.#backend,
-        getNodeCollection: (kind) => {
-          if (!Object.hasOwn(this.#graph.nodes, kind)) return;
-          return nodes[
-            kind as keyof G["nodes"] & string
-          ] as unknown as DynamicNodeCollection;
-        },
+        getNodeCollection: (kind) =>
+          this.#resolveDynamicNodeCollection(nodes, kind),
         // No transaction, no deferral: operations apply as they happen, so
         // their hooks fire immediately.
         runNodeOperationHooks: (operation, kind, id, hookedFunction) =>
@@ -1811,12 +1823,8 @@ export class Store<G extends GraphDef> {
 
     const getNodeCollection = (
       kind: string,
-    ): DynamicNodeCollection | undefined => {
-      if (!Object.hasOwn(this.#graph.nodes, kind)) return undefined;
-      return nodes[
-        kind as keyof G["nodes"] & string
-      ] as unknown as DynamicNodeCollection;
-    };
+    ): DynamicNodeCollection | undefined =>
+      this.#resolveDynamicNodeCollection(nodes, kind);
 
     if (sql === undefined) {
       return {

--- a/packages/typegraph/src/store/transaction-receipt.ts
+++ b/packages/typegraph/src/store/transaction-receipt.ts
@@ -39,40 +39,58 @@ export type TransactionReceiptRecorder = Readonly<{
 
 type WrappedMethod = (...args: unknown[]) => Promise<unknown>;
 
-const NODE_BULK_FIRST_ARG_METHODS = new Set<NodeWriteMethodName>([
-  "bulkCreate",
-  "bulkUpsertById",
-  "bulkInsert",
-  "bulkDelete",
-]);
-
-const EDGE_BULK_FIRST_ARG_METHODS = new Set<EdgeWriteMethodName>([
-  "bulkCreate",
-  "bulkUpsertById",
-  "bulkInsert",
-  "bulkDelete",
-  "bulkGetOrCreateByEndpoints",
-]);
+type WriteIntentCounter = (args: readonly unknown[]) => number;
 
 function inputLength(value: unknown): number {
   return Array.isArray(value) ? value.length : 0;
 }
 
-function nodeWriteIntentCount(
-  method: NodeWriteMethodName,
-  args: readonly unknown[],
-): number {
-  if (NODE_BULK_FIRST_ARG_METHODS.has(method)) return inputLength(args[0]);
-  if (method === "bulkGetOrCreateByConstraint") return inputLength(args[1]);
+function countSingleWrite(): number {
   return 1;
 }
 
-function edgeWriteIntentCount(
-  method: EdgeWriteMethodName,
-  args: readonly unknown[],
-): number {
-  if (EDGE_BULK_FIRST_ARG_METHODS.has(method)) return inputLength(args[0]);
-  return 1;
+function countBulkInputAt(index: number): WriteIntentCounter {
+  return (args) => inputLength(args[index]);
+}
+
+// `satisfies Record<...MethodName, ...>` forces a per-method decision: a new
+// write method fails to compile here until its intent count is chosen, so a
+// future bulk method cannot silently fall back to counting 1 per call.
+const NODE_WRITE_INTENT_COUNTERS = {
+  create: countSingleWrite,
+  createFromRecord: countSingleWrite,
+  update: countSingleWrite,
+  delete: countSingleWrite,
+  hardDelete: countSingleWrite,
+  upsertById: countSingleWrite,
+  upsertByIdFromRecord: countSingleWrite,
+  bulkCreate: countBulkInputAt(0),
+  bulkUpsertById: countBulkInputAt(0),
+  bulkInsert: countBulkInputAt(0),
+  bulkDelete: countBulkInputAt(0),
+  getOrCreateByConstraint: countSingleWrite,
+  bulkGetOrCreateByConstraint: countBulkInputAt(1),
+} as const satisfies Record<NodeWriteMethodName, WriteIntentCounter>;
+
+const EDGE_WRITE_INTENT_COUNTERS = {
+  create: countSingleWrite,
+  update: countSingleWrite,
+  delete: countSingleWrite,
+  hardDelete: countSingleWrite,
+  bulkCreate: countBulkInputAt(0),
+  bulkUpsertById: countBulkInputAt(0),
+  bulkInsert: countBulkInputAt(0),
+  bulkDelete: countBulkInputAt(0),
+  getOrCreateByEndpoints: countSingleWrite,
+  bulkGetOrCreateByEndpoints: countBulkInputAt(0),
+} as const satisfies Record<EdgeWriteMethodName, WriteIntentCounter>;
+
+// Null-prototype buckets: kind names are arbitrary identifiers, so
+// `constructor`, `toString`, or `__proto__` are valid kinds. On a plain `{}`
+// they would read inherited Object.prototype members (corrupting the count)
+// or trigger the `__proto__` setter (dropping it).
+function createCountBucket(): Record<string, number> {
+  return Object.create(null) as Record<string, number>;
 }
 
 function increment(
@@ -85,8 +103,8 @@ function increment(
 }
 
 export function createTransactionReceiptRecorder(): TransactionReceiptRecorder {
-  const nodes: Record<string, number> = {};
-  const edges: Record<string, number> = {};
+  const nodes = createCountBucket();
+  const edges = createCountBucket();
   let total = 0;
 
   return {
@@ -101,10 +119,12 @@ export function createTransactionReceiptRecorder(): TransactionReceiptRecorder {
     },
 
     snapshot(recorded): TransactionReceipt {
+      // Object.assign onto a fresh null-prototype bucket (rather than spread)
+      // keeps prototype-colliding kind names readable on the returned receipt.
       return Object.freeze({
         writes: Object.freeze({
-          nodes: Object.freeze({ ...nodes }),
-          edges: Object.freeze({ ...edges }),
+          nodes: Object.freeze(Object.assign(createCountBucket(), nodes)),
+          edges: Object.freeze(Object.assign(createCountBucket(), edges)),
           total,
         }),
         ...(recorded === undefined ? {} : { recorded }),
@@ -143,8 +163,13 @@ function wrapNodeCollection<T extends object>(
 
       const method = property as NodeWriteMethodName;
       const wrapped: WrappedMethod = async (...args) => {
+        // Pin the intent count at call time: a caller may mutate a bulk input
+        // array while the write is in flight, and the backend has already
+        // snapshotted the items. Recording still waits for resolution so a
+        // rejected write counts 0.
+        const count = NODE_WRITE_INTENT_COUNTERS[method](args);
         const result = await Reflect.apply(value, target, args);
-        recorder.recordNode(kind, nodeWriteIntentCount(method, args));
+        recorder.recordNode(kind, count);
         return result;
       };
       cache.set(property, wrapped);
@@ -175,8 +200,9 @@ function wrapEdgeCollection<T extends object>(
 
       const method = property as EdgeWriteMethodName;
       const wrapped: WrappedMethod = async (...args) => {
+        const count = EDGE_WRITE_INTENT_COUNTERS[method](args);
         const result = await Reflect.apply(value, target, args);
-        recorder.recordEdge(kind, edgeWriteIntentCount(method, args));
+        recorder.recordEdge(kind, count);
         return result;
       };
       cache.set(property, wrapped);

--- a/packages/typegraph/src/store/transaction-receipt.ts
+++ b/packages/typegraph/src/store/transaction-receipt.ts
@@ -1,5 +1,6 @@
 import { type GraphDef } from "../core/define-graph";
 import { type AnyEdgeType, type NodeType } from "../core/types";
+import { type Assert, type Equal } from "../utils/type-assert";
 import { EDGE_WRITE_NAMES, NODE_WRITE_NAMES } from "./collection-surface";
 import type {
   EdgeWrites,
@@ -11,14 +12,6 @@ import type {
 
 type NodeWriteMethodName = (typeof NODE_WRITE_NAMES)[number];
 type EdgeWriteMethodName = (typeof EDGE_WRITE_NAMES)[number];
-
-type Assert<T extends true> = T;
-type Equal<A, B> =
-  [A] extends [B] ?
-    [B] extends [A] ?
-      true
-    : false
-  : false;
 
 // If these fail, the receipt wrapper drifted away from the collection write
 // surface that defines NodeWrites / EdgeWrites.
@@ -141,126 +134,110 @@ function isObject(value: unknown): value is object {
   return typeof value === "object" && Boolean(value);
 }
 
-function wrapNodeCollection<T extends object>(
-  collection: T,
-  kind: string,
-  recorder: TransactionReceiptRecorder,
-): T {
-  const methodNames = new Set<string>(NODE_WRITE_NAMES);
-  const cache = new Map<PropertyKey, unknown>();
+/**
+ * Which methods on a node/edge collection count as writes, and how each
+ * counts its intent. Bundled into one value per entity kind (below) rather
+ * than passed as separate `methodNames`/`counters` parameters, so a call
+ * site can only pick "the node surface" or "the edge surface" as a unit —
+ * it cannot independently mismatch a method-name set against the wrong
+ * counter table.
+ */
+type WriteIntentSurface<M extends string> = Readonly<{
+  methodNames: ReadonlySet<string>;
+  counters: Record<M, WriteIntentCounter>;
+}>;
 
-  return new Proxy(collection, {
-    get(target, property, receiver) {
-      if (typeof property !== "string" || !methodNames.has(property)) {
-        return Reflect.get(target, property, receiver);
+const NODE_WRITE_SURFACE: WriteIntentSurface<NodeWriteMethodName> = {
+  methodNames: new Set(NODE_WRITE_NAMES),
+  counters: NODE_WRITE_INTENT_COUNTERS,
+};
+
+const EDGE_WRITE_SURFACE: WriteIntentSurface<EdgeWriteMethodName> = {
+  methodNames: new Set(EDGE_WRITE_NAMES),
+  counters: EDGE_WRITE_INTENT_COUNTERS,
+};
+
+/**
+ * Proxies `target`, memoizing the wrapped value for each string-keyed
+ * property after first access. `shouldWrap` gates which properties run
+ * through `wrap`; everything else (including symbol keys) passes through
+ * via `Reflect.get` untouched. Shared by `wrapWriteCollection` (wraps write
+ * methods on one collection) and `wrapCollections` (wraps every collection
+ * in a kind-keyed map) — both are "lazily transform and cache one property
+ * of an object" with a different `shouldWrap`/`wrap` pair.
+ */
+function memoizedProxyGet<T extends object>(
+  target: T,
+  shouldWrap: (property: string) => boolean,
+  wrap: (value: unknown, property: string) => unknown,
+): T {
+  const cache = new Map<string, unknown>();
+
+  return new Proxy(target, {
+    get(proxyTarget, property, receiver) {
+      if (typeof property !== "string" || !shouldWrap(property)) {
+        return Reflect.get(proxyTarget, property, receiver);
       }
 
       const cached = cache.get(property);
       if (cached !== undefined) return cached;
 
-      const value = Reflect.get(target, property, receiver);
+      const value = Reflect.get(proxyTarget, property, receiver);
+      const wrapped = wrap(value, property);
+      cache.set(property, wrapped);
+      return wrapped;
+    },
+  });
+}
+
+/**
+ * Wraps one node/edge collection so every write method on it (per
+ * `surface.methodNames`) counts its intent through `record` before
+ * resolving.
+ */
+function wrapWriteCollection<T extends object, M extends string>(
+  collection: T,
+  kind: string,
+  surface: WriteIntentSurface<M>,
+  record: (kind: string, count: number) => void,
+): T {
+  return memoizedProxyGet(
+    collection,
+    (property) => surface.methodNames.has(property),
+    (value, property) => {
       if (!isWrappedMethod(value)) return value;
 
-      const method = property as NodeWriteMethodName;
+      const method = property as M;
       const wrapped: WrappedMethod = async (...args) => {
         // Pin the intent count at call time: a caller may mutate a bulk input
         // array while the write is in flight, and the backend has already
         // snapshotted the items. Recording still waits for resolution so a
         // rejected write counts 0.
-        const count = NODE_WRITE_INTENT_COUNTERS[method](args);
-        const result = await Reflect.apply(value, target, args);
-        recorder.recordNode(kind, count);
+        const count = surface.counters[method](args);
+        const result = await Reflect.apply(value, collection, args);
+        record(kind, count);
         return result;
       };
-      cache.set(property, wrapped);
       return wrapped;
     },
-  });
+  );
 }
 
-function wrapEdgeCollection<T extends object>(
-  collection: T,
-  kind: string,
-  recorder: TransactionReceiptRecorder,
+/**
+ * Wraps a kind-keyed collection map (`GraphNodeCollections<G>` /
+ * `GraphEdgeCollections<G>`), lazily wrapping each collection with
+ * `wrapOne` on first access.
+ */
+function wrapCollections<T extends object>(
+  collections: T,
+  wrapOne: (collection: object, kind: string) => unknown,
 ): T {
-  const methodNames = new Set<string>(EDGE_WRITE_NAMES);
-  const cache = new Map<PropertyKey, unknown>();
-
-  return new Proxy(collection, {
-    get(target, property, receiver) {
-      if (typeof property !== "string" || !methodNames.has(property)) {
-        return Reflect.get(target, property, receiver);
-      }
-
-      const cached = cache.get(property);
-      if (cached !== undefined) return cached;
-
-      const value = Reflect.get(target, property, receiver);
-      if (!isWrappedMethod(value)) return value;
-
-      const method = property as EdgeWriteMethodName;
-      const wrapped: WrappedMethod = async (...args) => {
-        const count = EDGE_WRITE_INTENT_COUNTERS[method](args);
-        const result = await Reflect.apply(value, target, args);
-        recorder.recordEdge(kind, count);
-        return result;
-      };
-      cache.set(property, wrapped);
-      return wrapped;
-    },
-  });
-}
-
-function wrapNodeCollections<G extends GraphDef>(
-  collections: GraphNodeCollections<G>,
-  recorder: TransactionReceiptRecorder,
-): GraphNodeCollections<G> {
-  const cache = new Map<string, unknown>();
-
-  return new Proxy(collections, {
-    get(target, property, receiver) {
-      if (typeof property !== "string") {
-        return Reflect.get(target, property, receiver);
-      }
-
-      const cached = cache.get(property);
-      if (cached !== undefined) return cached;
-
-      const collection = Reflect.get(target, property, receiver);
-      if (!isObject(collection)) {
-        return collection;
-      }
-      const wrapped = wrapNodeCollection(collection, property, recorder);
-      cache.set(property, wrapped);
-      return wrapped;
-    },
-  });
-}
-
-function wrapEdgeCollections<G extends GraphDef>(
-  collections: GraphEdgeCollections<G>,
-  recorder: TransactionReceiptRecorder,
-): GraphEdgeCollections<G> {
-  const cache = new Map<string, unknown>();
-
-  return new Proxy(collections, {
-    get(target, property, receiver) {
-      if (typeof property !== "string") {
-        return Reflect.get(target, property, receiver);
-      }
-
-      const cached = cache.get(property);
-      if (cached !== undefined) return cached;
-
-      const collection = Reflect.get(target, property, receiver);
-      if (!isObject(collection)) {
-        return collection;
-      }
-      const wrapped = wrapEdgeCollection(collection, property, recorder);
-      cache.set(property, wrapped);
-      return wrapped;
-    },
-  });
+  return memoizedProxyGet(
+    collections,
+    () => true,
+    (collection, kind) =>
+      isObject(collection) ? wrapOne(collection, kind) : collection,
+  );
 }
 
 export function wrapTransactionCollections<G extends GraphDef>(
@@ -272,7 +249,21 @@ export function wrapTransactionCollections<G extends GraphDef>(
   edges: GraphEdgeCollections<G>;
 }> {
   return {
-    nodes: wrapNodeCollections(nodes, recorder),
-    edges: wrapEdgeCollections(edges, recorder),
+    nodes: wrapCollections(nodes, (collection, kind) =>
+      wrapWriteCollection(
+        collection,
+        kind,
+        NODE_WRITE_SURFACE,
+        recorder.recordNode,
+      ),
+    ),
+    edges: wrapCollections(edges, (collection, kind) =>
+      wrapWriteCollection(
+        collection,
+        kind,
+        EDGE_WRITE_SURFACE,
+        recorder.recordEdge,
+      ),
+    ),
   };
 }

--- a/packages/typegraph/src/store/transaction-receipt.ts
+++ b/packages/typegraph/src/store/transaction-receipt.ts
@@ -1,0 +1,252 @@
+import { type GraphDef } from "../core/define-graph";
+import { type AnyEdgeType, type NodeType } from "../core/types";
+import { EDGE_WRITE_NAMES, NODE_WRITE_NAMES } from "./collection-surface";
+import type {
+  EdgeWrites,
+  GraphEdgeCollections,
+  GraphNodeCollections,
+  NodeWrites,
+  TransactionReceipt,
+} from "./types";
+
+type NodeWriteMethodName = (typeof NODE_WRITE_NAMES)[number];
+type EdgeWriteMethodName = (typeof EDGE_WRITE_NAMES)[number];
+
+type Assert<T extends true> = T;
+type Equal<A, B> =
+  [A] extends [B] ?
+    [B] extends [A] ?
+      true
+    : false
+  : false;
+
+// If these fail, the receipt wrapper drifted away from the collection write
+// surface that defines NodeWrites / EdgeWrites.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- compile-time assertion
+type _receiptNodeSurfaceIsComplete = Assert<
+  Equal<NodeWriteMethodName, keyof NodeWrites<NodeType, string>>
+>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- compile-time assertion
+type _receiptEdgeSurfaceIsComplete = Assert<
+  Equal<EdgeWriteMethodName, keyof EdgeWrites<AnyEdgeType, NodeType, NodeType>>
+>;
+
+export type TransactionReceiptRecorder = Readonly<{
+  recordNode: (kind: string, count: number) => void;
+  recordEdge: (kind: string, count: number) => void;
+  snapshot: (recorded?: TransactionReceipt["recorded"]) => TransactionReceipt;
+}>;
+
+type WrappedMethod = (...args: unknown[]) => Promise<unknown>;
+
+const NODE_BULK_FIRST_ARG_METHODS = new Set<NodeWriteMethodName>([
+  "bulkCreate",
+  "bulkUpsertById",
+  "bulkInsert",
+  "bulkDelete",
+]);
+
+const EDGE_BULK_FIRST_ARG_METHODS = new Set<EdgeWriteMethodName>([
+  "bulkCreate",
+  "bulkUpsertById",
+  "bulkInsert",
+  "bulkDelete",
+  "bulkGetOrCreateByEndpoints",
+]);
+
+function inputLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function nodeWriteIntentCount(
+  method: NodeWriteMethodName,
+  args: readonly unknown[],
+): number {
+  if (NODE_BULK_FIRST_ARG_METHODS.has(method)) return inputLength(args[0]);
+  if (method === "bulkGetOrCreateByConstraint") return inputLength(args[1]);
+  return 1;
+}
+
+function edgeWriteIntentCount(
+  method: EdgeWriteMethodName,
+  args: readonly unknown[],
+): number {
+  if (EDGE_BULK_FIRST_ARG_METHODS.has(method)) return inputLength(args[0]);
+  return 1;
+}
+
+function increment(
+  counts: Record<string, number>,
+  kind: string,
+  count: number,
+): void {
+  if (count === 0) return;
+  counts[kind] = (counts[kind] ?? 0) + count;
+}
+
+export function createTransactionReceiptRecorder(): TransactionReceiptRecorder {
+  const nodes: Record<string, number> = {};
+  const edges: Record<string, number> = {};
+  let total = 0;
+
+  return {
+    recordNode(kind, count): void {
+      increment(nodes, kind, count);
+      total += count;
+    },
+
+    recordEdge(kind, count): void {
+      increment(edges, kind, count);
+      total += count;
+    },
+
+    snapshot(recorded): TransactionReceipt {
+      return Object.freeze({
+        writes: Object.freeze({
+          nodes: Object.freeze({ ...nodes }),
+          edges: Object.freeze({ ...edges }),
+          total,
+        }),
+        ...(recorded === undefined ? {} : { recorded }),
+      });
+    },
+  };
+}
+
+function isWrappedMethod(value: unknown): value is WrappedMethod {
+  return typeof value === "function";
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === "object" && Boolean(value);
+}
+
+function wrapNodeCollection<T extends object>(
+  collection: T,
+  kind: string,
+  recorder: TransactionReceiptRecorder,
+): T {
+  const methodNames = new Set<string>(NODE_WRITE_NAMES);
+  const cache = new Map<PropertyKey, unknown>();
+
+  return new Proxy(collection, {
+    get(target, property, receiver) {
+      if (typeof property !== "string" || !methodNames.has(property)) {
+        return Reflect.get(target, property, receiver);
+      }
+
+      const cached = cache.get(property);
+      if (cached !== undefined) return cached;
+
+      const value = Reflect.get(target, property, receiver);
+      if (!isWrappedMethod(value)) return value;
+
+      const method = property as NodeWriteMethodName;
+      const wrapped: WrappedMethod = async (...args) => {
+        const result = await Reflect.apply(value, target, args);
+        recorder.recordNode(kind, nodeWriteIntentCount(method, args));
+        return result;
+      };
+      cache.set(property, wrapped);
+      return wrapped;
+    },
+  });
+}
+
+function wrapEdgeCollection<T extends object>(
+  collection: T,
+  kind: string,
+  recorder: TransactionReceiptRecorder,
+): T {
+  const methodNames = new Set<string>(EDGE_WRITE_NAMES);
+  const cache = new Map<PropertyKey, unknown>();
+
+  return new Proxy(collection, {
+    get(target, property, receiver) {
+      if (typeof property !== "string" || !methodNames.has(property)) {
+        return Reflect.get(target, property, receiver);
+      }
+
+      const cached = cache.get(property);
+      if (cached !== undefined) return cached;
+
+      const value = Reflect.get(target, property, receiver);
+      if (!isWrappedMethod(value)) return value;
+
+      const method = property as EdgeWriteMethodName;
+      const wrapped: WrappedMethod = async (...args) => {
+        const result = await Reflect.apply(value, target, args);
+        recorder.recordEdge(kind, edgeWriteIntentCount(method, args));
+        return result;
+      };
+      cache.set(property, wrapped);
+      return wrapped;
+    },
+  });
+}
+
+function wrapNodeCollections<G extends GraphDef>(
+  collections: GraphNodeCollections<G>,
+  recorder: TransactionReceiptRecorder,
+): GraphNodeCollections<G> {
+  const cache = new Map<string, unknown>();
+
+  return new Proxy(collections, {
+    get(target, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property, receiver);
+      }
+
+      const cached = cache.get(property);
+      if (cached !== undefined) return cached;
+
+      const collection = Reflect.get(target, property, receiver);
+      if (!isObject(collection)) {
+        return collection;
+      }
+      const wrapped = wrapNodeCollection(collection, property, recorder);
+      cache.set(property, wrapped);
+      return wrapped;
+    },
+  });
+}
+
+function wrapEdgeCollections<G extends GraphDef>(
+  collections: GraphEdgeCollections<G>,
+  recorder: TransactionReceiptRecorder,
+): GraphEdgeCollections<G> {
+  const cache = new Map<string, unknown>();
+
+  return new Proxy(collections, {
+    get(target, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property, receiver);
+      }
+
+      const cached = cache.get(property);
+      if (cached !== undefined) return cached;
+
+      const collection = Reflect.get(target, property, receiver);
+      if (!isObject(collection)) {
+        return collection;
+      }
+      const wrapped = wrapEdgeCollection(collection, property, recorder);
+      cache.set(property, wrapped);
+      return wrapped;
+    },
+  });
+}
+
+export function wrapTransactionCollections<G extends GraphDef>(
+  nodes: GraphNodeCollections<G>,
+  edges: GraphEdgeCollections<G>,
+  recorder: TransactionReceiptRecorder,
+): Readonly<{
+  nodes: GraphNodeCollections<G>;
+  edges: GraphEdgeCollections<G>;
+}> {
+  return {
+    nodes: wrapNodeCollections(nodes, recorder),
+    edges: wrapEdgeCollections(edges, recorder),
+  };
+}

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -423,8 +423,15 @@ export type TransactionOutcome<T> = Readonly<{
  *    id and `getOrCreate*` that found an existing row. Consumers that need
  *    "did anything actually change" semantics apply their own per-operation
  *    policy.
- * 4. A method that rejects counts 0.
- * 5. Rows-affected fidelity is intentionally out of scope for this first
+ * 4. A method that rejects counts 0 — even when the backend applied part of a
+ *    bulk input before failing. On SQLite a failed statement does not abort
+ *    the surrounding transaction, so a caller that catches the rejection and
+ *    commits can persist rows the receipt never counted. Do not read the
+ *    receipt as rows-affected in that scenario.
+ * 5. A node `delete` under `cascade` / `disconnect` removes connected edges
+ *    through the backend, not the edge-collection surface; those removals do
+ *    not appear in `edges`.
+ * 6. Rows-affected fidelity is intentionally out of scope for this first
  *    version; a future extension could ask backends to return row counts.
  */
 export type TransactionReceipt = Readonly<{

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -401,7 +401,7 @@ export interface StoreRef<T> {
 // ============================================================
 
 /**
- * Summary returned by `store.transaction(fn, { receipt: true })`.
+ * Summary returned by `store.transactionWithReceipt(fn)`.
  */
 export type TransactionOutcome<T> = Readonly<{
   result: T;

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -10,6 +10,7 @@ import {
   type TransactionBackend,
 } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
+import { type RecordedInstant } from "../core/temporal";
 import {
   type AnyEdgeType,
   type EdgeId,
@@ -394,6 +395,54 @@ export type StoreOptions = LiveStoreOptions | HistoryStoreOptions;
 export interface StoreRef<T> {
   current: T;
 }
+
+// ============================================================
+// Transaction Receipt Types
+// ============================================================
+
+/**
+ * Summary returned by `store.transaction(fn, { receipt: true })`.
+ */
+export type TransactionOutcome<T> = Readonly<{
+  result: T;
+  receipt: TransactionReceipt;
+}>;
+
+/**
+ * Transaction write summary.
+ *
+ * Receipt counts are completed write intents at the collection surface, not
+ * rows affected:
+ *
+ * 1. Every successful completion of a write method on `tx.nodes.*` /
+ *    `tx.edges.*` counts. The authoritative method list is
+ *    {@link NodeWrites} / {@link EdgeWrites}.
+ * 2. Bulk methods count by input length; an empty bulk call (`bulkCreate([])`)
+ *    counts 0.
+ * 3. Single-row methods count 1 on resolve — including `delete` of an absent
+ *    id and `getOrCreate*` that found an existing row. Consumers that need
+ *    "did anything actually change" semantics apply their own per-operation
+ *    policy.
+ * 4. A method that rejects counts 0.
+ * 5. Rows-affected fidelity is intentionally out of scope for this first
+ *    version; a future extension could ask backends to return row counts.
+ */
+export type TransactionReceipt = Readonly<{
+  writes: Readonly<{
+    /** Completed node write intents by node kind. */
+    nodes: Readonly<Record<string, number>>;
+    /** Completed edge write intents by edge kind. */
+    edges: Readonly<Record<string, number>>;
+    /** Sum of all node and edge write intents. */
+    total: number;
+  }>;
+  /**
+   * The recorded commit instant allocated for this store's graph by this
+   * transaction. Undefined when history capture is off, the transaction is
+   * read-only, or no captured writes were flushed.
+   */
+  recorded?: RecordedInstant;
+}>;
 
 // ============================================================
 // Get-Or-Create Types

--- a/packages/typegraph/src/utils/type-assert.ts
+++ b/packages/typegraph/src/utils/type-assert.ts
@@ -1,0 +1,14 @@
+/**
+ * Compile-time equality/assertion helpers for "this derived type must exactly
+ * match that one" invariants — e.g. a literal method-name union that must
+ * stay in sync with a mapped type's keys. A mismatch fails to compile instead
+ * of silently drifting at runtime.
+ */
+export type Assert<T extends true> = T;
+
+export type Equal<A, B> =
+  [A] extends [B] ?
+    [B] extends [A] ?
+      true
+    : false
+  : false;

--- a/packages/typegraph/test-d/public-api.test-d.ts
+++ b/packages/typegraph/test-d/public-api.test-d.ts
@@ -38,6 +38,8 @@ import {
   type SqlTableNames,
   type Store,
   type StoreOptions,
+  type TransactionOutcome,
+  type TransactionReceipt,
 } from "..";
 
 const Person = defineNode("Person", {
@@ -313,6 +315,29 @@ void store.transaction(async (tx) => {
   expectType<typeof tx.sql>(tx.sql);
   expectType<typeof tx.backend.executeStatement>(tx.backend.executeStatement);
   expectType<typeof tx.backend.executeDdl>(tx.backend.executeDdl);
+});
+
+// transactionWithReceipt mirrors transaction()'s callback signature, but
+// wraps the result in a TransactionOutcome carrying the write receipt
+// alongside it.
+const receiptOutcome = store.transactionWithReceipt(async (tx) => {
+  expectType<typeof tx.sql>(tx.sql);
+  return tx.nodes.Person.create({ email: "alice@example.com", name: "Alice" });
+});
+expectType<
+  Promise<
+    TransactionOutcome<Awaited<ReturnType<typeof store.nodes.Person.create>>>
+  >
+>(receiptOutcome);
+void receiptOutcome.then(({ receipt }) => {
+  expectType<TransactionReceipt>(receipt);
+});
+
+// The history-store overload narrows `tx` to HistoryTransactionContext, same
+// as transaction() does above.
+void historyStore.transactionWithReceipt(async (tx) => {
+  expectAssignable<HistoryTransactionContext<typeof graph>>(tx);
+  expectError(tx.sql?.select());
 });
 
 const nodeKinds = getNodeKinds(graph);

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -42,6 +42,7 @@ import {
   registerStoreViewIntegrationTests,
   registerSubgraphIntegrationTests,
   registerTemporalIntegrationTests,
+  registerTransactionReceiptIntegrationTests,
   registerTraversalIntegrationTests,
 } from "./integration";
 
@@ -122,6 +123,7 @@ export function createIntegrationTestSuite(
     registerProvenanceIntegrationTests(context);
     registerOrderingIntegrationTests(context);
     registerTemporalIntegrationTests(context);
+    registerTransactionReceiptIntegrationTests(context);
     registerRecordedTimeIntegrationTests(context);
     registerRecordedReadBindingIntegrationTests(context);
     registerSetOperationIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -21,4 +21,5 @@ export { registerStoreViewIntegrationTests } from "./store-view";
 export { registerSubgraphIntegrationTests } from "./subgraph";
 export { registerTemporalIntegrationTests } from "./temporal";
 export type { IntegrationTestContext } from "./test-context";
+export { registerTransactionReceiptIntegrationTests } from "./transaction-receipt";
 export { registerTraversalIntegrationTests } from "./traversals";

--- a/packages/typegraph/tests/backends/integration/transaction-receipt.ts
+++ b/packages/typegraph/tests/backends/integration/transaction-receipt.ts
@@ -155,30 +155,27 @@ export function registerTransactionReceiptIntegrationTests(
     it("counts completed write intents by kind", async () => {
       const store = context.getStore();
 
-      const outcome = await store.transaction(
-        async (tx) => {
-          const alice = await tx.nodes.Person.create({ name: "Alice" });
-          const bob = await tx.nodes.Person.create({ name: "Bob" });
-          await tx.nodes.Company.create({ name: "Acme" });
-          await tx.nodes.Person.update(alice.id, { age: 31 });
-          await tx.nodes.Person.delete(missingPersonId("absent-person"));
-          await tx.nodes.Person.bulkCreate([
-            { props: { name: "Carol" } },
-            { props: { name: "Dana" } },
-          ]);
-          await tx.nodes.Person.bulkCreate([]);
+      const outcome = await store.transactionWithReceipt(async (tx) => {
+        const alice = await tx.nodes.Person.create({ name: "Alice" });
+        const bob = await tx.nodes.Person.create({ name: "Bob" });
+        await tx.nodes.Company.create({ name: "Acme" });
+        await tx.nodes.Person.update(alice.id, { age: 31 });
+        await tx.nodes.Person.delete(missingPersonId("absent-person"));
+        await tx.nodes.Person.bulkCreate([
+          { props: { name: "Carol" } },
+          { props: { name: "Dana" } },
+        ]);
+        await tx.nodes.Person.bulkCreate([]);
 
-          await tx.edges.knows.create(alice, bob, { since: "2020" });
-          await tx.edges.knows.bulkCreate([
-            { from: alice, to: bob, props: { since: "2021" } },
-            { from: bob, to: alice, props: { since: "2022" } },
-          ]);
-          await tx.edges.knows.bulkCreate([]);
+        await tx.edges.knows.create(alice, bob, { since: "2020" });
+        await tx.edges.knows.bulkCreate([
+          { from: alice, to: bob, props: { since: "2021" } },
+          { from: bob, to: alice, props: { since: "2022" } },
+        ]);
+        await tx.edges.knows.bulkCreate([]);
 
-          return "done";
-        },
-        { receipt: true },
-      );
+        return "done";
+      });
 
       expect(outcome.result).toBe("done");
       expect(outcome.receipt.writes.nodes).toEqual({
@@ -201,10 +198,8 @@ export function registerTransactionReceiptIntegrationTests(
         return { alice, bob };
       });
 
-      const outcome = await store.transaction(
-        async (tx) =>
-          tx.edges.knows.getOrCreateByEndpoints(alice, bob, { since: "2020" }),
-        { receipt: true },
+      const outcome = await store.transactionWithReceipt(async (tx) =>
+        tx.edges.knows.getOrCreateByEndpoints(alice, bob, { since: "2020" }),
       );
 
       expect(outcome.result.action).toBe("found");
@@ -219,84 +214,81 @@ export function registerTransactionReceiptIntegrationTests(
         context.getStore().backend,
       );
 
-      const outcome = await store.transaction(
-        async (tx) => {
-          const nodes = tx.nodes.ReceiptEntity;
-          const nodeA = await nodes.create({ name: "a", slot: "a" });
-          const nodeB = await nodes.createFromRecord({ name: "b", slot: "b" });
-          await nodes.update(nodeA.id, { name: "a2" });
-          await nodes.upsertById("u1", { name: "u1", slot: "u1" });
-          const nodeU2 = await nodes.upsertByIdFromRecord("u2", {
-            name: "u2",
-            slot: "u2",
-          });
-          const [nodeC, nodeD] = await nodes.bulkCreate([
-            { props: { name: "c", slot: "c" } },
-            { props: { name: "d", slot: "d" } },
-          ]);
-          if (nodeC === undefined || nodeD === undefined) {
-            throw new Error("bulkCreate did not return the created nodes");
-          }
-          await nodes.bulkUpsertById([
-            { id: "u1", props: { name: "u1b", slot: "u1" } },
-            { id: "u3", props: { name: "u3", slot: "u3" } },
-          ]);
-          await nodes.bulkInsert([
-            { props: { name: "n5", slot: "n5" }, id: "n5" },
-            { props: { name: "n6", slot: "n6" }, id: "n6" },
-          ]);
-          await nodes.getOrCreateByConstraint("entity_slot", {
-            name: "g",
-            slot: "g",
-          });
-          // The one method whose bulk input is the SECOND argument.
-          await nodes.bulkGetOrCreateByConstraint("entity_slot", [
-            { props: { name: "h", slot: "h" } },
-            { props: { name: "a-again", slot: "a" } },
-          ]);
-          await nodes.delete(nodeU2.id);
-          await nodes.hardDelete(entityId("u3"));
-          await nodes.bulkDelete([entityId("n5"), entityId("n6")]);
+      const outcome = await store.transactionWithReceipt(async (tx) => {
+        const nodes = tx.nodes.ReceiptEntity;
+        const nodeA = await nodes.create({ name: "a", slot: "a" });
+        const nodeB = await nodes.createFromRecord({ name: "b", slot: "b" });
+        await nodes.update(nodeA.id, { name: "a2" });
+        await nodes.upsertById("u1", { name: "u1", slot: "u1" });
+        const nodeU2 = await nodes.upsertByIdFromRecord("u2", {
+          name: "u2",
+          slot: "u2",
+        });
+        const [nodeC, nodeD] = await nodes.bulkCreate([
+          { props: { name: "c", slot: "c" } },
+          { props: { name: "d", slot: "d" } },
+        ]);
+        if (nodeC === undefined || nodeD === undefined) {
+          throw new Error("bulkCreate did not return the created nodes");
+        }
+        await nodes.bulkUpsertById([
+          { id: "u1", props: { name: "u1b", slot: "u1" } },
+          { id: "u3", props: { name: "u3", slot: "u3" } },
+        ]);
+        await nodes.bulkInsert([
+          { props: { name: "n5", slot: "n5" }, id: "n5" },
+          { props: { name: "n6", slot: "n6" }, id: "n6" },
+        ]);
+        await nodes.getOrCreateByConstraint("entity_slot", {
+          name: "g",
+          slot: "g",
+        });
+        // The one method whose bulk input is the SECOND argument.
+        await nodes.bulkGetOrCreateByConstraint("entity_slot", [
+          { props: { name: "h", slot: "h" } },
+          { props: { name: "a-again", slot: "a" } },
+        ]);
+        await nodes.delete(nodeU2.id);
+        await nodes.hardDelete(entityId("u3"));
+        await nodes.bulkDelete([entityId("n5"), entityId("n6")]);
 
-          const edges = tx.edges.receiptLinks;
-          const edge1 = await edges.create(nodeA, nodeB, { label: "e1" });
-          await edges.update(edge1.id, { label: "e1b" });
-          await edges.getOrCreateByEndpoints(nodeA, nodeC, { label: "e2" });
-          const [edge3, edge4] = await edges.bulkCreate([
-            { from: nodeA, to: nodeD, props: { label: "e3" } },
-            { from: nodeB, to: nodeC, props: { label: "e4" } },
-          ]);
-          if (edge3 === undefined || edge4 === undefined) {
-            throw new Error("bulkCreate did not return the created edges");
-          }
-          await edges.bulkUpsertById([
-            {
-              id: linkId("be1"),
-              from: nodeA,
-              to: nodeB,
-              props: { label: "be1" },
-            },
-            {
-              id: linkId("be2"),
-              from: nodeC,
-              to: nodeD,
-              props: { label: "be2" },
-            },
-          ]);
-          await edges.bulkInsert([
-            { from: nodeD, to: nodeA, props: { label: "e5" } },
-            { from: nodeD, to: nodeB, props: { label: "e6" } },
-          ]);
-          await edges.bulkGetOrCreateByEndpoints([
-            { from: nodeB, to: nodeD, props: { label: "e7" } },
-            { from: nodeC, to: nodeA, props: { label: "e8" } },
-          ]);
-          await edges.delete(edge1.id);
-          await edges.hardDelete(edge3.id);
-          await edges.bulkDelete([edge4.id, linkId("be1")]);
-        },
-        { receipt: true },
-      );
+        const edges = tx.edges.receiptLinks;
+        const edge1 = await edges.create(nodeA, nodeB, { label: "e1" });
+        await edges.update(edge1.id, { label: "e1b" });
+        await edges.getOrCreateByEndpoints(nodeA, nodeC, { label: "e2" });
+        const [edge3, edge4] = await edges.bulkCreate([
+          { from: nodeA, to: nodeD, props: { label: "e3" } },
+          { from: nodeB, to: nodeC, props: { label: "e4" } },
+        ]);
+        if (edge3 === undefined || edge4 === undefined) {
+          throw new Error("bulkCreate did not return the created edges");
+        }
+        await edges.bulkUpsertById([
+          {
+            id: linkId("be1"),
+            from: nodeA,
+            to: nodeB,
+            props: { label: "be1" },
+          },
+          {
+            id: linkId("be2"),
+            from: nodeC,
+            to: nodeD,
+            props: { label: "be2" },
+          },
+        ]);
+        await edges.bulkInsert([
+          { from: nodeD, to: nodeA, props: { label: "e5" } },
+          { from: nodeD, to: nodeB, props: { label: "e6" } },
+        ]);
+        await edges.bulkGetOrCreateByEndpoints([
+          { from: nodeB, to: nodeD, props: { label: "e7" } },
+          { from: nodeC, to: nodeA, props: { label: "e8" } },
+        ]);
+        await edges.delete(edge1.id);
+        await edges.hardDelete(edge3.id);
+        await edges.bulkDelete([edge4.id, linkId("be1")]);
+      });
 
       // Node intents: create 1 + createFromRecord 1 + update 1 + upsertById 1
       // + upsertByIdFromRecord 1 + bulkCreate 2 + bulkUpsertById 2
@@ -332,9 +324,8 @@ export function registerTransactionReceiptIntegrationTests(
         return source;
       });
 
-      const outcome = await store.transaction(
-        async (tx) => tx.nodes.ReceiptEntity.delete(source.id),
-        { receipt: true },
+      const outcome = await store.transactionWithReceipt(async (tx) =>
+        tx.nodes.ReceiptEntity.delete(source.id),
       );
 
       // The cascade removes the connected edge through the backend, not the
@@ -350,16 +341,13 @@ export function registerTransactionReceiptIntegrationTests(
     it("counts writes made through tx.getNodeCollection", async () => {
       const store = context.getStore();
 
-      const outcome = await store.transaction(
-        async (tx) => {
-          const people = tx.getNodeCollection("Person");
-          if (people === undefined) {
-            throw new Error("Person collection missing from transaction");
-          }
-          await people.createFromRecord({ name: "Dynamic" });
-        },
-        { receipt: true },
-      );
+      const outcome = await store.transactionWithReceipt(async (tx) => {
+        const people = tx.getNodeCollection("Person");
+        if (people === undefined) {
+          throw new Error("Person collection missing from transaction");
+        }
+        await people.createFromRecord({ name: "Dynamic" });
+      });
 
       expect(outcome.receipt.writes.nodes).toEqual({ Person: 1 });
       expect(outcome.receipt.writes.total).toBe(1);
@@ -368,19 +356,16 @@ export function registerTransactionReceiptIntegrationTests(
     it("does not count a caught rejected write method", async () => {
       const store = context.getStore();
 
-      const outcome = await store.transaction(
-        async (tx) => {
-          try {
-            await tx.nodes.Person.update(missingPersonId("missing"), {
-              name: "Missing",
-            });
-          } catch {
-            // The rejected write intent contributes 0; the transaction continues.
-          }
-          await tx.nodes.Person.create({ name: "Committed" });
-        },
-        { receipt: true },
-      );
+      const outcome = await store.transactionWithReceipt(async (tx) => {
+        try {
+          await tx.nodes.Person.update(missingPersonId("missing"), {
+            name: "Missing",
+          });
+        } catch {
+          // The rejected write intent contributes 0; the transaction continues.
+        }
+        await tx.nodes.Person.create({ name: "Committed" });
+      });
 
       expect(outcome.receipt.writes.nodes).toEqual({ Person: 1 });
       expect(outcome.receipt.writes.edges).toEqual({});
@@ -391,12 +376,10 @@ export function registerTransactionReceiptIntegrationTests(
       const store = context.getStore();
 
       await expect(
-        store.transaction(
-          async (tx) =>
-            tx.nodes.Person.update(missingPersonId("missing"), {
-              name: "Missing",
-            }),
-          { receipt: true },
+        store.transactionWithReceipt(async (tx) =>
+          tx.nodes.Person.update(missingPersonId("missing"), {
+            name: "Missing",
+          }),
         ),
       ).rejects.toThrow();
     });
@@ -405,16 +388,13 @@ export function registerTransactionReceiptIntegrationTests(
       const store = context.getStore();
 
       await expect(
-        store.transaction(
-          async (tx) => {
-            await tx.nodes.Person.create(
-              { name: "Rollback" },
-              { id: "rollback-person" },
-            );
-            throw new Error("rollback");
-          },
-          { receipt: true },
-        ),
+        store.transactionWithReceipt(async (tx) => {
+          await tx.nodes.Person.create(
+            { name: "Rollback" },
+            { id: "rollback-person" },
+          );
+          throw new Error("rollback");
+        }),
       ).rejects.toThrow("rollback");
 
       await expect(
@@ -425,17 +405,14 @@ export function registerTransactionReceiptIntegrationTests(
     it("returns the recorded anchor for a mixed node and edge transaction", async () => {
       const store = await createHistoryStore(context);
 
-      const outcome = await store.transaction(
-        async (tx) => {
-          const alice = await tx.nodes.Person.create({ name: "Alice" });
-          const bob = await tx.nodes.Person.create({ name: "Bob" });
-          const edge = await tx.edges.knows.create(alice, bob, {
-            since: "2020",
-          });
-          return { alice, edge };
-        },
-        { receipt: true },
-      );
+      const outcome = await store.transactionWithReceipt(async (tx) => {
+        const alice = await tx.nodes.Person.create({ name: "Alice" });
+        const bob = await tx.nodes.Person.create({ name: "Bob" });
+        const edge = await tx.edges.knows.create(alice, bob, {
+          since: "2020",
+        });
+        return { alice, edge };
+      });
 
       const recorded = requireRecordedInstant(
         outcome.receipt.recorded,
@@ -457,9 +434,8 @@ export function registerTransactionReceiptIntegrationTests(
         return { alice, bob };
       });
 
-      const outcome = await store.transaction(
-        async (tx) => tx.edges.knows.create(alice, bob, { since: "2020" }),
-        { receipt: true },
+      const outcome = await store.transactionWithReceipt(async (tx) =>
+        tx.edges.knows.create(alice, bob, { since: "2020" }),
       );
 
       const recorded = requireRecordedInstant(
@@ -475,9 +451,8 @@ export function registerTransactionReceiptIntegrationTests(
 
     it("leaves recorded undefined without history and for read-only transactions", async () => {
       const historyStore = await createHistoryStore(context);
-      const readOnlyOutcome = await historyStore.transaction(
+      const readOnlyOutcome = await historyStore.transactionWithReceipt(
         async (tx) => tx.nodes.Person.count(),
-        { receipt: true },
       );
       expect(readOnlyOutcome.result).toBe(0);
       expect(readOnlyOutcome.receipt.writes.total).toBe(0);
@@ -485,22 +460,20 @@ export function registerTransactionReceiptIntegrationTests(
 
       const liveOutcome = await context
         .getStore()
-        .transaction(async (tx) => tx.nodes.Person.create({ name: "Live" }), {
-          receipt: true,
-        });
+        .transactionWithReceipt(async (tx) =>
+          tx.nodes.Person.create({ name: "Live" }),
+        );
       expect(liveOutcome.receipt.recorded).toBeUndefined();
     });
 
     it("returns strictly increasing recorded anchors for sequential write transactions", async () => {
       const store = await createHistoryStore(context);
 
-      const first = await store.transaction(
-        async (tx) => tx.nodes.Person.create({ name: "First" }),
-        { receipt: true },
+      const first = await store.transactionWithReceipt(async (tx) =>
+        tx.nodes.Person.create({ name: "First" }),
       );
-      const second = await store.transaction(
-        async (tx) => tx.nodes.Person.create({ name: "Second" }),
-        { receipt: true },
+      const second = await store.transactionWithReceipt(async (tx) =>
+        tx.nodes.Person.create({ name: "Second" }),
       );
 
       const firstRecorded = requireRecordedInstant(

--- a/packages/typegraph/tests/backends/integration/transaction-receipt.ts
+++ b/packages/typegraph/tests/backends/integration/transaction-receipt.ts
@@ -1,9 +1,14 @@
 import { type SQL, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import {
   asCompiledRowsSql,
   createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  type EdgeId,
   type GraphBackend,
   type NodeId,
   type RecordedInstant,
@@ -25,6 +30,53 @@ function missingPersonId(
   id: string,
 ): NodeId<typeof integrationTestGraph.nodes.Person.type> {
   return id as NodeId<typeof integrationTestGraph.nodes.Person.type>;
+}
+
+/**
+ * Local graph for the full write-surface count test: a uniqueness constraint
+ * (for the `getOrCreateByConstraint` variants) and `onDelete: "cascade"` (to
+ * pin that cascade-removed edges do not appear in the receipt).
+ */
+const ReceiptEntity = defineNode("ReceiptEntity", {
+  schema: z.object({ name: z.string(), slot: z.string() }),
+});
+
+const receiptLinks = defineEdge("receiptLinks", {
+  schema: z.object({ label: z.string() }),
+});
+
+const receiptSurfaceGraph = defineGraph({
+  id: "receipt_surface",
+  nodes: {
+    ReceiptEntity: {
+      type: ReceiptEntity,
+      onDelete: "cascade",
+      unique: [
+        {
+          name: "entity_slot",
+          fields: ["slot"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {
+    receiptLinks: {
+      type: receiptLinks,
+      from: [ReceiptEntity],
+      to: [ReceiptEntity],
+      cardinality: "many",
+    },
+  },
+});
+
+function entityId(id: string): NodeId<typeof ReceiptEntity> {
+  return id as NodeId<typeof ReceiptEntity>;
+}
+
+function linkId(id: string): EdgeId<typeof receiptLinks> {
+  return id as EdgeId<typeof receiptLinks>;
 }
 
 function requireRecordedInstant(
@@ -158,6 +210,158 @@ export function registerTransactionReceiptIntegrationTests(
       expect(outcome.result.action).toBe("found");
       expect(outcome.receipt.writes.nodes).toEqual({});
       expect(outcome.receipt.writes.edges).toEqual({ knows: 1 });
+      expect(outcome.receipt.writes.total).toBe(1);
+    });
+
+    it("counts every write method on the collection surface", async () => {
+      const [store] = await createStoreWithSchema(
+        receiptSurfaceGraph,
+        context.getStore().backend,
+      );
+
+      const outcome = await store.transaction(
+        async (tx) => {
+          const nodes = tx.nodes.ReceiptEntity;
+          const nodeA = await nodes.create({ name: "a", slot: "a" });
+          const nodeB = await nodes.createFromRecord({ name: "b", slot: "b" });
+          await nodes.update(nodeA.id, { name: "a2" });
+          await nodes.upsertById("u1", { name: "u1", slot: "u1" });
+          const nodeU2 = await nodes.upsertByIdFromRecord("u2", {
+            name: "u2",
+            slot: "u2",
+          });
+          const [nodeC, nodeD] = await nodes.bulkCreate([
+            { props: { name: "c", slot: "c" } },
+            { props: { name: "d", slot: "d" } },
+          ]);
+          if (nodeC === undefined || nodeD === undefined) {
+            throw new Error("bulkCreate did not return the created nodes");
+          }
+          await nodes.bulkUpsertById([
+            { id: "u1", props: { name: "u1b", slot: "u1" } },
+            { id: "u3", props: { name: "u3", slot: "u3" } },
+          ]);
+          await nodes.bulkInsert([
+            { props: { name: "n5", slot: "n5" }, id: "n5" },
+            { props: { name: "n6", slot: "n6" }, id: "n6" },
+          ]);
+          await nodes.getOrCreateByConstraint("entity_slot", {
+            name: "g",
+            slot: "g",
+          });
+          // The one method whose bulk input is the SECOND argument.
+          await nodes.bulkGetOrCreateByConstraint("entity_slot", [
+            { props: { name: "h", slot: "h" } },
+            { props: { name: "a-again", slot: "a" } },
+          ]);
+          await nodes.delete(nodeU2.id);
+          await nodes.hardDelete(entityId("u3"));
+          await nodes.bulkDelete([entityId("n5"), entityId("n6")]);
+
+          const edges = tx.edges.receiptLinks;
+          const edge1 = await edges.create(nodeA, nodeB, { label: "e1" });
+          await edges.update(edge1.id, { label: "e1b" });
+          await edges.getOrCreateByEndpoints(nodeA, nodeC, { label: "e2" });
+          const [edge3, edge4] = await edges.bulkCreate([
+            { from: nodeA, to: nodeD, props: { label: "e3" } },
+            { from: nodeB, to: nodeC, props: { label: "e4" } },
+          ]);
+          if (edge3 === undefined || edge4 === undefined) {
+            throw new Error("bulkCreate did not return the created edges");
+          }
+          await edges.bulkUpsertById([
+            {
+              id: linkId("be1"),
+              from: nodeA,
+              to: nodeB,
+              props: { label: "be1" },
+            },
+            {
+              id: linkId("be2"),
+              from: nodeC,
+              to: nodeD,
+              props: { label: "be2" },
+            },
+          ]);
+          await edges.bulkInsert([
+            { from: nodeD, to: nodeA, props: { label: "e5" } },
+            { from: nodeD, to: nodeB, props: { label: "e6" } },
+          ]);
+          await edges.bulkGetOrCreateByEndpoints([
+            { from: nodeB, to: nodeD, props: { label: "e7" } },
+            { from: nodeC, to: nodeA, props: { label: "e8" } },
+          ]);
+          await edges.delete(edge1.id);
+          await edges.hardDelete(edge3.id);
+          await edges.bulkDelete([edge4.id, linkId("be1")]);
+        },
+        { receipt: true },
+      );
+
+      // Node intents: create 1 + createFromRecord 1 + update 1 + upsertById 1
+      // + upsertByIdFromRecord 1 + bulkCreate 2 + bulkUpsertById 2
+      // + bulkInsert 2 + getOrCreateByConstraint 1
+      // + bulkGetOrCreateByConstraint 2 + delete 1 + hardDelete 1
+      // + bulkDelete 2 = 18.
+      expect(outcome.receipt.writes.nodes).toEqual({ ReceiptEntity: 18 });
+      // Edge intents: create 1 + update 1 + getOrCreateByEndpoints 1
+      // + bulkCreate 2 + bulkUpsertById 2 + bulkInsert 2
+      // + bulkGetOrCreateByEndpoints 2 + delete 1 + hardDelete 1
+      // + bulkDelete 2 = 15.
+      expect(outcome.receipt.writes.edges).toEqual({ receiptLinks: 15 });
+      expect(outcome.receipt.writes.total).toBe(33);
+    });
+
+    it("does not count cascade-removed edges", async () => {
+      const [store] = await createStoreWithSchema(
+        receiptSurfaceGraph,
+        context.getStore().backend,
+      );
+      const source = await store.transaction(async (tx) => {
+        const source = await tx.nodes.ReceiptEntity.create({
+          name: "src",
+          slot: "cascade-src",
+        });
+        const target = await tx.nodes.ReceiptEntity.create({
+          name: "dst",
+          slot: "cascade-dst",
+        });
+        await tx.edges.receiptLinks.create(source, target, {
+          label: "doomed",
+        });
+        return source;
+      });
+
+      const outcome = await store.transaction(
+        async (tx) => tx.nodes.ReceiptEntity.delete(source.id),
+        { receipt: true },
+      );
+
+      // The cascade removes the connected edge through the backend, not the
+      // edge-collection surface — the receipt reports the node intent only.
+      expect(outcome.receipt.writes.nodes).toEqual({ ReceiptEntity: 1 });
+      expect(outcome.receipt.writes.edges).toEqual({});
+      expect(outcome.receipt.writes.total).toBe(1);
+      await expect(store.edges.receiptLinks.findFrom(source)).resolves.toEqual(
+        [],
+      );
+    });
+
+    it("counts writes made through tx.getNodeCollection", async () => {
+      const store = context.getStore();
+
+      const outcome = await store.transaction(
+        async (tx) => {
+          const people = tx.getNodeCollection("Person");
+          if (people === undefined) {
+            throw new Error("Person collection missing from transaction");
+          }
+          await people.createFromRecord({ name: "Dynamic" });
+        },
+        { receipt: true },
+      );
+
+      expect(outcome.receipt.writes.nodes).toEqual({ Person: 1 });
       expect(outcome.receipt.writes.total).toBe(1);
     });
 

--- a/packages/typegraph/tests/backends/integration/transaction-receipt.ts
+++ b/packages/typegraph/tests/backends/integration/transaction-receipt.ts
@@ -1,0 +1,313 @@
+import { type SQL, sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import {
+  asCompiledRowsSql,
+  createStoreWithSchema,
+  type GraphBackend,
+  type NodeId,
+  type RecordedInstant,
+} from "../../../src";
+import { RECORDED_MAX } from "../../../src/core/temporal";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { toCanonicalIso } from "../../../src/store/recorded-capture";
+import { type IntegrationStore, integrationTestGraph } from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+type RecordedFromRow = Readonly<{ recorded_from: unknown }>;
+
+type RecordedSqlStore = Readonly<{
+  backend: GraphBackend;
+  graphId: string;
+}>;
+
+function missingPersonId(
+  id: string,
+): NodeId<typeof integrationTestGraph.nodes.Person.type> {
+  return id as NodeId<typeof integrationTestGraph.nodes.Person.type>;
+}
+
+function requireRecordedInstant(
+  instant: RecordedInstant | undefined,
+  message: string,
+): RecordedInstant {
+  expect(instant).toBeDefined();
+  if (instant === undefined) throw new Error(message);
+  return instant;
+}
+
+async function createHistoryStore(
+  context: IntegrationTestContext,
+): Promise<IntegrationStore> {
+  const [store] = await createStoreWithSchema(
+    integrationTestGraph,
+    context.getStore().backend,
+    { history: true },
+  );
+  return store;
+}
+
+async function readOpenRecordedFrom(
+  store: RecordedSqlStore,
+  table: SQL,
+  kind: string,
+  id: string,
+): Promise<string> {
+  const rows = await store.backend.execute<RecordedFromRow>(
+    asCompiledRowsSql(sql`
+      SELECT recorded_from
+      FROM ${table}
+      WHERE graph_id = ${store.graphId}
+        AND kind = ${kind}
+        AND id = ${id}
+        AND recorded_to = ${RECORDED_MAX}
+    `),
+  );
+  const row = rows[0];
+  if (row === undefined) {
+    throw new Error(`No open recorded row for ${kind}:${id}`);
+  }
+  return toCanonicalIso(row.recorded_from);
+}
+
+async function readOpenRecordedNodeFrom(
+  store: RecordedSqlStore,
+  kind: string,
+  id: string,
+): Promise<string> {
+  return readOpenRecordedFrom(
+    store,
+    createSqlSchema(store.backend.tableNames).recordedNodesTable,
+    kind,
+    id,
+  );
+}
+
+async function readOpenRecordedEdgeFrom(
+  store: RecordedSqlStore,
+  kind: string,
+  id: string,
+): Promise<string> {
+  return readOpenRecordedFrom(
+    store,
+    createSqlSchema(store.backend.tableNames).recordedEdgesTable,
+    kind,
+    id,
+  );
+}
+
+export function registerTransactionReceiptIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("transaction receipts", () => {
+    it("counts completed write intents by kind", async () => {
+      const store = context.getStore();
+
+      const outcome = await store.transaction(
+        async (tx) => {
+          const alice = await tx.nodes.Person.create({ name: "Alice" });
+          const bob = await tx.nodes.Person.create({ name: "Bob" });
+          await tx.nodes.Company.create({ name: "Acme" });
+          await tx.nodes.Person.update(alice.id, { age: 31 });
+          await tx.nodes.Person.delete(missingPersonId("absent-person"));
+          await tx.nodes.Person.bulkCreate([
+            { props: { name: "Carol" } },
+            { props: { name: "Dana" } },
+          ]);
+          await tx.nodes.Person.bulkCreate([]);
+
+          await tx.edges.knows.create(alice, bob, { since: "2020" });
+          await tx.edges.knows.bulkCreate([
+            { from: alice, to: bob, props: { since: "2021" } },
+            { from: bob, to: alice, props: { since: "2022" } },
+          ]);
+          await tx.edges.knows.bulkCreate([]);
+
+          return "done";
+        },
+        { receipt: true },
+      );
+
+      expect(outcome.result).toBe("done");
+      expect(outcome.receipt.writes.nodes).toEqual({
+        Person: 6,
+        Company: 1,
+      });
+      expect(outcome.receipt.writes.edges).toEqual({ knows: 3 });
+      expect(outcome.receipt.writes.total).toBe(10);
+      expect(outcome.receipt.recorded).toBeUndefined();
+    });
+
+    it("counts getOrCreateByEndpoints on an existing edge as one intent", async () => {
+      const store = context.getStore();
+      const { alice, bob } = await store.transaction(async (tx) => {
+        const alice = await tx.nodes.Person.create({ name: "Alice" });
+        const bob = await tx.nodes.Person.create({ name: "Bob" });
+        await tx.edges.knows.getOrCreateByEndpoints(alice, bob, {
+          since: "2020",
+        });
+        return { alice, bob };
+      });
+
+      const outcome = await store.transaction(
+        async (tx) =>
+          tx.edges.knows.getOrCreateByEndpoints(alice, bob, { since: "2020" }),
+        { receipt: true },
+      );
+
+      expect(outcome.result.action).toBe("found");
+      expect(outcome.receipt.writes.nodes).toEqual({});
+      expect(outcome.receipt.writes.edges).toEqual({ knows: 1 });
+      expect(outcome.receipt.writes.total).toBe(1);
+    });
+
+    it("does not count a caught rejected write method", async () => {
+      const store = context.getStore();
+
+      const outcome = await store.transaction(
+        async (tx) => {
+          try {
+            await tx.nodes.Person.update(missingPersonId("missing"), {
+              name: "Missing",
+            });
+          } catch {
+            // The rejected write intent contributes 0; the transaction continues.
+          }
+          await tx.nodes.Person.create({ name: "Committed" });
+        },
+        { receipt: true },
+      );
+
+      expect(outcome.receipt.writes.nodes).toEqual({ Person: 1 });
+      expect(outcome.receipt.writes.edges).toEqual({});
+      expect(outcome.receipt.writes.total).toBe(1);
+    });
+
+    it("rejects without an observable receipt when a write escapes uncaught", async () => {
+      const store = context.getStore();
+
+      await expect(
+        store.transaction(
+          async (tx) =>
+            tx.nodes.Person.update(missingPersonId("missing"), {
+              name: "Missing",
+            }),
+          { receipt: true },
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("does not expose a receipt for rolled-back transactions", async () => {
+      const store = context.getStore();
+
+      await expect(
+        store.transaction(
+          async (tx) => {
+            await tx.nodes.Person.create(
+              { name: "Rollback" },
+              { id: "rollback-person" },
+            );
+            throw new Error("rollback");
+          },
+          { receipt: true },
+        ),
+      ).rejects.toThrow("rollback");
+
+      await expect(
+        store.nodes.Person.getById(missingPersonId("rollback-person")),
+      ).resolves.toBeUndefined();
+    });
+
+    it("returns the recorded anchor for a mixed node and edge transaction", async () => {
+      const store = await createHistoryStore(context);
+
+      const outcome = await store.transaction(
+        async (tx) => {
+          const alice = await tx.nodes.Person.create({ name: "Alice" });
+          const bob = await tx.nodes.Person.create({ name: "Bob" });
+          const edge = await tx.edges.knows.create(alice, bob, {
+            since: "2020",
+          });
+          return { alice, edge };
+        },
+        { receipt: true },
+      );
+
+      const recorded = requireRecordedInstant(
+        outcome.receipt.recorded,
+        "expected a recorded receipt anchor",
+      );
+      await expect(
+        readOpenRecordedNodeFrom(store, "Person", outcome.result.alice.id),
+      ).resolves.toBe(recorded);
+      await expect(
+        readOpenRecordedEdgeFrom(store, "knows", outcome.result.edge.id),
+      ).resolves.toBe(recorded);
+    });
+
+    it("returns the recorded anchor for an edge-only transaction", async () => {
+      const store = await createHistoryStore(context);
+      const { alice, bob } = await store.transaction(async (tx) => {
+        const alice = await tx.nodes.Person.create({ name: "Alice" });
+        const bob = await tx.nodes.Person.create({ name: "Bob" });
+        return { alice, bob };
+      });
+
+      const outcome = await store.transaction(
+        async (tx) => tx.edges.knows.create(alice, bob, { since: "2020" }),
+        { receipt: true },
+      );
+
+      const recorded = requireRecordedInstant(
+        outcome.receipt.recorded,
+        "expected edge-only recorded receipt anchor",
+      );
+      expect(outcome.receipt.writes.nodes).toEqual({});
+      expect(outcome.receipt.writes.edges).toEqual({ knows: 1 });
+      await expect(
+        readOpenRecordedEdgeFrom(store, "knows", outcome.result.id),
+      ).resolves.toBe(recorded);
+    });
+
+    it("leaves recorded undefined without history and for read-only transactions", async () => {
+      const historyStore = await createHistoryStore(context);
+      const readOnlyOutcome = await historyStore.transaction(
+        async (tx) => tx.nodes.Person.count(),
+        { receipt: true },
+      );
+      expect(readOnlyOutcome.result).toBe(0);
+      expect(readOnlyOutcome.receipt.writes.total).toBe(0);
+      expect(readOnlyOutcome.receipt.recorded).toBeUndefined();
+
+      const liveOutcome = await context
+        .getStore()
+        .transaction(async (tx) => tx.nodes.Person.create({ name: "Live" }), {
+          receipt: true,
+        });
+      expect(liveOutcome.receipt.recorded).toBeUndefined();
+    });
+
+    it("returns strictly increasing recorded anchors for sequential write transactions", async () => {
+      const store = await createHistoryStore(context);
+
+      const first = await store.transaction(
+        async (tx) => tx.nodes.Person.create({ name: "First" }),
+        { receipt: true },
+      );
+      const second = await store.transaction(
+        async (tx) => tx.nodes.Person.create({ name: "Second" }),
+        { receipt: true },
+      );
+
+      const firstRecorded = requireRecordedInstant(
+        first.receipt.recorded,
+        "expected first recorded receipt anchor",
+      );
+      const secondRecorded = requireRecordedInstant(
+        second.receipt.recorded,
+        "expected second recorded receipt anchor",
+      );
+      expect(secondRecorded > firstRecorded).toBe(true);
+    });
+  });
+}

--- a/packages/typegraph/tests/property/transaction-receipt.test.ts
+++ b/packages/typegraph/tests/property/transaction-receipt.test.ts
@@ -128,60 +128,57 @@ describe("transaction receipt properties", () => {
             throw new Error("Seed nodes were not created");
           }
 
-          const outcome = await store.transaction(
-            async (tx) => {
-              let sequence = 0;
-              for (const operation of operations) {
-                switch (operation.kind) {
-                  case "personCreate": {
-                    await tx.nodes.ReceiptPerson.create(
-                      { name: `Person ${sequence}` },
-                      { id: `person-${sequence}` },
-                    );
-                    break;
-                  }
-                  case "personBulkCreate": {
-                    await tx.nodes.ReceiptPerson.bulkCreate(
-                      Array.from({ length: operation.count }, (_, index) => ({
-                        props: { name: `Bulk Person ${sequence}-${index}` },
-                        id: `person-${sequence}-${index}`,
-                      })),
-                    );
-                    break;
-                  }
-                  case "companyCreate": {
-                    await tx.nodes.ReceiptCompany.create(
-                      { name: `Company ${sequence}` },
-                      { id: `company-${sequence}` },
-                    );
-                    break;
-                  }
-                  case "edgeCreate": {
-                    await tx.edges.receiptKnows.create(
-                      alice,
-                      bob,
-                      { since: `edge-${sequence}` },
-                      { id: `edge-${sequence}` },
-                    );
-                    break;
-                  }
-                  case "edgeBulkCreate": {
-                    await tx.edges.receiptKnows.bulkCreate(
-                      Array.from({ length: operation.count }, (_, index) => ({
-                        from: alice,
-                        to: bob,
-                        props: { since: `bulk-edge-${sequence}-${index}` },
-                        id: `edge-${sequence}-${index}`,
-                      })),
-                    );
-                    break;
-                  }
+          const outcome = await store.transactionWithReceipt(async (tx) => {
+            let sequence = 0;
+            for (const operation of operations) {
+              switch (operation.kind) {
+                case "personCreate": {
+                  await tx.nodes.ReceiptPerson.create(
+                    { name: `Person ${sequence}` },
+                    { id: `person-${sequence}` },
+                  );
+                  break;
                 }
-                sequence += 1;
+                case "personBulkCreate": {
+                  await tx.nodes.ReceiptPerson.bulkCreate(
+                    Array.from({ length: operation.count }, (_, index) => ({
+                      props: { name: `Bulk Person ${sequence}-${index}` },
+                      id: `person-${sequence}-${index}`,
+                    })),
+                  );
+                  break;
+                }
+                case "companyCreate": {
+                  await tx.nodes.ReceiptCompany.create(
+                    { name: `Company ${sequence}` },
+                    { id: `company-${sequence}` },
+                  );
+                  break;
+                }
+                case "edgeCreate": {
+                  await tx.edges.receiptKnows.create(
+                    alice,
+                    bob,
+                    { since: `edge-${sequence}` },
+                    { id: `edge-${sequence}` },
+                  );
+                  break;
+                }
+                case "edgeBulkCreate": {
+                  await tx.edges.receiptKnows.bulkCreate(
+                    Array.from({ length: operation.count }, (_, index) => ({
+                      from: alice,
+                      to: bob,
+                      props: { since: `bulk-edge-${sequence}-${index}` },
+                      id: `edge-${sequence}-${index}`,
+                    })),
+                  );
+                  break;
+                }
               }
-            },
-            { receipt: true },
-          );
+              sequence += 1;
+            }
+          });
 
           const expected = expectedCountsFor(operations);
           expect(outcome.receipt.writes.nodes).toEqual(expected.nodes);

--- a/packages/typegraph/tests/property/transaction-receipt.test.ts
+++ b/packages/typegraph/tests/property/transaction-receipt.test.ts
@@ -1,0 +1,205 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineEdge, defineGraph, defineNode } from "../../src";
+import { createInitializedStore, createTestBackend } from "../test-utils";
+
+const Person = defineNode("ReceiptPerson", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Company = defineNode("ReceiptCompany", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("receiptKnows", {
+  schema: z.object({ since: z.string() }),
+});
+
+const receiptPropertyGraph = defineGraph({
+  id: "receipt_property",
+  nodes: {
+    ReceiptPerson: { type: Person },
+    ReceiptCompany: { type: Company },
+  },
+  edges: {
+    receiptKnows: {
+      type: knows,
+      from: [Person],
+      to: [Person],
+      cardinality: "many",
+    },
+  },
+});
+
+type ReceiptOperation =
+  | Readonly<{ kind: "personCreate" }>
+  | Readonly<{ kind: "personBulkCreate"; count: number }>
+  | Readonly<{ kind: "companyCreate" }>
+  | Readonly<{ kind: "edgeCreate" }>
+  | Readonly<{ kind: "edgeBulkCreate"; count: number }>;
+
+type ExpectedCounts = Readonly<{
+  nodes: Record<string, number>;
+  edges: Record<string, number>;
+  total: number;
+}>;
+
+const operationArbitrary: fc.Arbitrary<ReceiptOperation> = fc.oneof(
+  fc.constant<ReceiptOperation>({ kind: "personCreate" }),
+  fc.integer({ min: 0, max: 3 }).map<ReceiptOperation>((count) => ({
+    kind: "personBulkCreate",
+    count,
+  })),
+  fc.constant<ReceiptOperation>({ kind: "companyCreate" }),
+  fc.constant<ReceiptOperation>({ kind: "edgeCreate" }),
+  fc
+    .integer({ min: 0, max: 3 })
+    .map<ReceiptOperation>((count) => ({ kind: "edgeBulkCreate", count })),
+);
+
+function addCount(
+  counts: Record<string, number>,
+  kind: string,
+  count: number,
+): void {
+  if (count === 0) return;
+  counts[kind] = (counts[kind] ?? 0) + count;
+}
+
+function expectedCountsFor(
+  operations: readonly ReceiptOperation[],
+): ExpectedCounts {
+  const nodes: Record<string, number> = {};
+  const edges: Record<string, number> = {};
+  let total = 0;
+
+  for (const operation of operations) {
+    switch (operation.kind) {
+      case "personCreate": {
+        addCount(nodes, "ReceiptPerson", 1);
+        total += 1;
+        break;
+      }
+      case "personBulkCreate": {
+        addCount(nodes, "ReceiptPerson", operation.count);
+        total += operation.count;
+        break;
+      }
+      case "companyCreate": {
+        addCount(nodes, "ReceiptCompany", 1);
+        total += 1;
+        break;
+      }
+      case "edgeCreate": {
+        addCount(edges, "receiptKnows", 1);
+        total += 1;
+        break;
+      }
+      case "edgeBulkCreate": {
+        addCount(edges, "receiptKnows", operation.count);
+        total += operation.count;
+        break;
+      }
+    }
+  }
+
+  return { nodes, edges, total };
+}
+
+describe("transaction receipt properties", () => {
+  it("matches an independently tracked write-intent count", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(operationArbitrary, { minLength: 0, maxLength: 20 }),
+        async (operations) => {
+          const store = await createInitializedStore(
+            receiptPropertyGraph,
+            createTestBackend(),
+          );
+          const [alice, bob] = await store.transaction(async (tx) =>
+            tx.nodes.ReceiptPerson.bulkCreate([
+              { props: { name: "Alice" }, id: "seed-alice" },
+              { props: { name: "Bob" }, id: "seed-bob" },
+            ]),
+          );
+          if (alice === undefined || bob === undefined) {
+            throw new Error("Seed nodes were not created");
+          }
+
+          const outcome = await store.transaction(
+            async (tx) => {
+              let sequence = 0;
+              for (const operation of operations) {
+                switch (operation.kind) {
+                  case "personCreate": {
+                    await tx.nodes.ReceiptPerson.create(
+                      { name: `Person ${sequence}` },
+                      { id: `person-${sequence}` },
+                    );
+                    break;
+                  }
+                  case "personBulkCreate": {
+                    await tx.nodes.ReceiptPerson.bulkCreate(
+                      Array.from({ length: operation.count }, (_, index) => ({
+                        props: { name: `Bulk Person ${sequence}-${index}` },
+                        id: `person-${sequence}-${index}`,
+                      })),
+                    );
+                    break;
+                  }
+                  case "companyCreate": {
+                    await tx.nodes.ReceiptCompany.create(
+                      { name: `Company ${sequence}` },
+                      { id: `company-${sequence}` },
+                    );
+                    break;
+                  }
+                  case "edgeCreate": {
+                    await tx.edges.receiptKnows.create(
+                      alice,
+                      bob,
+                      { since: `edge-${sequence}` },
+                      { id: `edge-${sequence}` },
+                    );
+                    break;
+                  }
+                  case "edgeBulkCreate": {
+                    await tx.edges.receiptKnows.bulkCreate(
+                      Array.from({ length: operation.count }, (_, index) => ({
+                        from: alice,
+                        to: bob,
+                        props: { since: `bulk-edge-${sequence}-${index}` },
+                        id: `edge-${sequence}-${index}`,
+                      })),
+                    );
+                    break;
+                  }
+                }
+                sequence += 1;
+              }
+            },
+            { receipt: true },
+          );
+
+          const expected = expectedCountsFor(operations);
+          expect(outcome.receipt.writes.nodes).toEqual(expected.nodes);
+          expect(outcome.receipt.writes.edges).toEqual(expected.edges);
+          expect(outcome.receipt.writes.total).toBe(expected.total);
+          expect(outcome.receipt.writes.total).toBe(
+            Object.values(outcome.receipt.writes.nodes).reduce(
+              (sum, count) => sum + count,
+              0,
+            ) +
+              Object.values(outcome.receipt.writes.edges).reduce(
+                (sum, count) => sum + count,
+                0,
+              ),
+          );
+        },
+      ),
+      { numRuns: 25 },
+    );
+  });
+});

--- a/packages/typegraph/tests/transaction-receipt.test.ts
+++ b/packages/typegraph/tests/transaction-receipt.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineEdge, defineGraph, defineNode, type GraphBackend } from "../src";
+import { type TransactionBackend } from "../src/backend/types";
+import { createInitializedStore, createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string() }),
+});
+
+const receiptGraph = defineGraph({
+  id: "transaction_receipt",
+  nodes: {
+    Person: { type: Person },
+    Company: { type: Company },
+  },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "many",
+    },
+  },
+});
+
+function disableTransactions(backend: GraphBackend): GraphBackend {
+  return {
+    ...backend,
+    capabilities: { ...backend.capabilities, transactions: false },
+    transaction: () =>
+      Promise.reject(new Error("synthetic backend has transactions disabled")),
+  };
+}
+
+function recordTransactionTargetCalls(
+  target: TransactionBackend,
+  calls: string[],
+): TransactionBackend {
+  return {
+    ...target,
+    async insertNode(params) {
+      calls.push("insertNode");
+      return target.insertNode(params);
+    },
+    async insertEdge(params) {
+      calls.push("insertEdge");
+      return target.insertEdge(params);
+    },
+  };
+}
+
+function recordBackendCalls(
+  backend: GraphBackend,
+): Readonly<{ backend: GraphBackend; calls: string[] }> {
+  const calls: string[] = [];
+  return {
+    calls,
+    backend: {
+      ...backend,
+      async insertNode(params) {
+        calls.push("insertNode");
+        return backend.insertNode(params);
+      },
+      async insertEdge(params) {
+        calls.push("insertEdge");
+        return backend.insertEdge(params);
+      },
+      async transaction(fn, options) {
+        calls.push("transaction");
+        return backend.transaction(
+          (target, sql) => fn(recordTransactionTargetCalls(target, calls), sql),
+          options,
+        );
+      },
+    },
+  };
+}
+
+async function writeFixture(
+  backend: GraphBackend,
+  receipt: boolean,
+): Promise<readonly string[]> {
+  const recorded = recordBackendCalls(backend);
+  const store = await createInitializedStore(receiptGraph, recorded.backend);
+  recorded.calls.length = 0;
+
+  if (receipt) {
+    await store.transaction(
+      async (tx) => {
+        const person = await tx.nodes.Person.create({ name: "Alice" });
+        const company = await tx.nodes.Company.create({ name: "Acme" });
+        await tx.edges.worksAt.create(person, company, { role: "Engineer" });
+      },
+      { receipt: true },
+    );
+  } else {
+    await store.transaction(async (tx) => {
+      const person = await tx.nodes.Person.create({ name: "Alice" });
+      const company = await tx.nodes.Company.create({ name: "Acme" });
+      await tx.edges.worksAt.create(person, company, { role: "Engineer" });
+    });
+  }
+
+  return recorded.calls;
+}
+
+describe("transaction receipts", () => {
+  it("returns counts on non-transactional backends", async () => {
+    const backend = disableTransactions(createTestBackend());
+    const store = await createInitializedStore(receiptGraph, backend);
+
+    const outcome = await store.transaction(
+      async (tx) => {
+        const person = await tx.nodes.Person.create({ name: "Alice" });
+        const company = await tx.nodes.Company.create({ name: "Acme" });
+        await tx.edges.worksAt.create(person, company, { role: "Engineer" });
+        return person.id;
+      },
+      { receipt: true },
+    );
+
+    expect(outcome.receipt.writes.nodes).toEqual({ Person: 1, Company: 1 });
+    expect(outcome.receipt.writes.edges).toEqual({ worksAt: 1 });
+    expect(outcome.receipt.writes.total).toBe(3);
+    await expect(
+      store.nodes.Person.getById(outcome.result),
+    ).resolves.toMatchObject({ name: "Alice" });
+  });
+
+  it("does not add backend write calls when receipt counting is requested", async () => {
+    const withoutReceipt = await writeFixture(createTestBackend(), false);
+    const withReceipt = await writeFixture(createTestBackend(), true);
+
+    expect(withReceipt).toEqual(withoutReceipt);
+  });
+});

--- a/packages/typegraph/tests/transaction-receipt.test.ts
+++ b/packages/typegraph/tests/transaction-receipt.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import {
-  ConfigurationError,
-  defineEdge,
-  defineGraph,
-  defineNode,
-  type GraphBackend,
-} from "../src";
+import { defineEdge, defineGraph, defineNode, type GraphBackend } from "../src";
 import {
   type TransactionBackend,
   type TransactionOptions,
@@ -119,14 +113,11 @@ async function writeFixture(
   recorded.calls.length = 0;
 
   if (receipt) {
-    await store.transaction(
-      async (tx) => {
-        const person = await tx.nodes.Person.create({ name: "Alice" });
-        const company = await tx.nodes.Company.create({ name: "Acme" });
-        await tx.edges.worksAt.create(person, company, { role: "Engineer" });
-      },
-      { receipt: true },
-    );
+    await store.transactionWithReceipt(async (tx) => {
+      const person = await tx.nodes.Person.create({ name: "Alice" });
+      const company = await tx.nodes.Company.create({ name: "Acme" });
+      await tx.edges.worksAt.create(person, company, { role: "Engineer" });
+    });
   } else {
     await store.transaction(async (tx) => {
       const person = await tx.nodes.Person.create({ name: "Alice" });
@@ -143,15 +134,12 @@ describe("transaction receipts", () => {
     const backend = disableTransactions(createTestBackend());
     const store = await createInitializedStore(receiptGraph, backend);
 
-    const outcome = await store.transaction(
-      async (tx) => {
-        const person = await tx.nodes.Person.create({ name: "Alice" });
-        const company = await tx.nodes.Company.create({ name: "Acme" });
-        await tx.edges.worksAt.create(person, company, { role: "Engineer" });
-        return person.id;
-      },
-      { receipt: true },
-    );
+    const outcome = await store.transactionWithReceipt(async (tx) => {
+      const person = await tx.nodes.Person.create({ name: "Alice" });
+      const company = await tx.nodes.Company.create({ name: "Acme" });
+      await tx.edges.worksAt.create(person, company, { role: "Engineer" });
+      return person.id;
+    });
 
     expect(outcome.receipt.writes.nodes).toEqual({ Person: 1, Company: 1 });
     expect(outcome.receipt.writes.edges).toEqual({ worksAt: 1 });
@@ -168,7 +156,7 @@ describe("transaction receipts", () => {
     expect(withReceipt).toEqual(withoutReceipt);
   });
 
-  it("passes isolationLevel through to the backend and strips the receipt flag", async () => {
+  it("passes isolationLevel through to the backend", async () => {
     const backend = createTestBackend();
     const seenOptions: (TransactionOptions | undefined)[] = [];
     const spyingBackend: GraphBackend = {
@@ -181,31 +169,15 @@ describe("transaction receipts", () => {
     const store = await createInitializedStore(receiptGraph, spyingBackend);
     seenOptions.length = 0;
 
-    await store.transaction(
+    await store.transactionWithReceipt(
       async (tx) => {
         await tx.nodes.Person.create({ name: "Alice" });
       },
-      { receipt: true, isolationLevel: "read_committed" },
+      { isolationLevel: "read_committed" },
     );
 
     const forwarded = seenOptions.at(-1);
     expect(forwarded?.isolationLevel).toBe("read_committed");
-    expect(forwarded !== undefined && "receipt" in forwarded).toBe(false);
-  });
-
-  it("rejects a receipt option that is present but not boolean", async () => {
-    const store = await createInitializedStore(
-      receiptGraph,
-      createTestBackend(),
-    );
-    const truthyNonBoolean = { receipt: 1 } as unknown as { receipt: true };
-
-    await expect(
-      store.transaction(async (tx) => {
-        await tx.nodes.Person.create({ name: "Never" });
-      }, truthyNonBoolean),
-    ).rejects.toThrow(ConfigurationError);
-    await expect(store.nodes.Person.count()).resolves.toBe(0);
   });
 
   it("counts a node kind named after an Object.prototype member", async () => {
@@ -214,12 +186,9 @@ describe("transaction receipts", () => {
       createTestBackend(),
     );
 
-    const outcome = await store.transaction(
-      async (tx) => {
-        await tx.nodes.constructor.create({ name: "proto" });
-      },
-      { receipt: true },
-    );
+    const outcome = await store.transactionWithReceipt(async (tx) => {
+      await tx.nodes.constructor.create({ name: "proto" });
+    });
 
     expect(Object.entries(outcome.receipt.writes.nodes)).toEqual([
       ["constructor", 1],

--- a/packages/typegraph/tests/transaction-receipt.test.ts
+++ b/packages/typegraph/tests/transaction-receipt.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { defineEdge, defineGraph, defineNode, type GraphBackend } from "../src";
-import { type TransactionBackend } from "../src/backend/types";
+import {
+  ConfigurationError,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+} from "../src";
+import {
+  type TransactionBackend,
+  type TransactionOptions,
+} from "../src/backend/types";
+import { createTransactionReceiptRecorder } from "../src/store/transaction-receipt";
 import { createInitializedStore, createTestBackend } from "./test-utils";
 
 const Person = defineNode("Person", {
@@ -31,6 +41,20 @@ const receiptGraph = defineGraph({
       cardinality: "many",
     },
   },
+});
+
+// Kind names are arbitrary identifiers, so `constructor` is a legal node kind.
+// This graph pins the receipt path end-to-end for prototype-colliding names.
+const PrototypeNamed = defineNode("constructor", {
+  schema: z.object({ name: z.string() }),
+});
+
+const prototypeKindGraph = defineGraph({
+  id: "receipt_prototype_kind",
+  nodes: {
+    constructor: { type: PrototypeNamed },
+  },
+  edges: {},
 });
 
 function disableTransactions(backend: GraphBackend): GraphBackend {
@@ -142,5 +166,101 @@ describe("transaction receipts", () => {
     const withReceipt = await writeFixture(createTestBackend(), true);
 
     expect(withReceipt).toEqual(withoutReceipt);
+  });
+
+  it("passes isolationLevel through to the backend and strips the receipt flag", async () => {
+    const backend = createTestBackend();
+    const seenOptions: (TransactionOptions | undefined)[] = [];
+    const spyingBackend: GraphBackend = {
+      ...backend,
+      async transaction(fn, options) {
+        seenOptions.push(options);
+        return backend.transaction(fn, options);
+      },
+    };
+    const store = await createInitializedStore(receiptGraph, spyingBackend);
+    seenOptions.length = 0;
+
+    await store.transaction(
+      async (tx) => {
+        await tx.nodes.Person.create({ name: "Alice" });
+      },
+      { receipt: true, isolationLevel: "read_committed" },
+    );
+
+    const forwarded = seenOptions.at(-1);
+    expect(forwarded?.isolationLevel).toBe("read_committed");
+    expect(forwarded !== undefined && "receipt" in forwarded).toBe(false);
+  });
+
+  it("rejects a receipt option that is present but not boolean", async () => {
+    const store = await createInitializedStore(
+      receiptGraph,
+      createTestBackend(),
+    );
+    const truthyNonBoolean = { receipt: 1 } as unknown as { receipt: true };
+
+    await expect(
+      store.transaction(async (tx) => {
+        await tx.nodes.Person.create({ name: "Never" });
+      }, truthyNonBoolean),
+    ).rejects.toThrow(ConfigurationError);
+    await expect(store.nodes.Person.count()).resolves.toBe(0);
+  });
+
+  it("counts a node kind named after an Object.prototype member", async () => {
+    const store = await createInitializedStore(
+      prototypeKindGraph,
+      createTestBackend(),
+    );
+
+    const outcome = await store.transaction(
+      async (tx) => {
+        await tx.nodes.constructor.create({ name: "proto" });
+      },
+      { receipt: true },
+    );
+
+    expect(Object.entries(outcome.receipt.writes.nodes)).toEqual([
+      ["constructor", 1],
+    ]);
+    expect(outcome.receipt.writes.total).toBe(1);
+  });
+});
+
+describe("transaction receipt recorder", () => {
+  it("counts kinds whose names collide with Object.prototype members", () => {
+    const recorder = createTransactionReceiptRecorder();
+    recorder.recordNode("constructor", 1);
+    recorder.recordNode("constructor", 1);
+    recorder.recordNode("__proto__", 2);
+    recorder.recordNode("toString", 3);
+    recorder.recordEdge("hasOwnProperty", 4);
+
+    const receipt = recorder.snapshot();
+
+    expect(
+      Object.entries(receipt.writes.nodes).toSorted(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+    ).toEqual([
+      ["__proto__", 2],
+      ["constructor", 2],
+      ["toString", 3],
+    ]);
+    expect(Object.entries(receipt.writes.edges)).toEqual([
+      ["hasOwnProperty", 4],
+    ]);
+    expect(receipt.writes.total).toBe(11);
+  });
+
+  it("keeps zero-count intents out of the buckets and the total", () => {
+    const recorder = createTransactionReceiptRecorder();
+    recorder.recordNode("Person", 0);
+
+    const receipt = recorder.snapshot();
+
+    expect(Object.entries(receipt.writes.nodes)).toEqual([]);
+    expect(receipt.writes.total).toBe(0);
   });
 });


### PR DESCRIPTION
Adds `store.transactionWithReceipt()`, an opt-in surface for transaction receipts.

- Adds `TransactionOutcome<T>` and `TransactionReceipt` public types.
- Counts completed write intents at the collection surface for node and edge writes, including bulk input lengths.
- Returns the exact recorded commit anchor allocated by the transaction when `history: true` captured writes.
- Leaves `store.transaction()` untouched; both methods delegate to a shared runner, and receipt proxy wrapping only happens on the receipt path.
- Documents receipt semantics in the store docs and adds a minor changeset.

## Why

Library consumers that project external changes into TypeGraph need a first-class way to know whether a transaction completed TypeGraph writes. Integrators using recorded-time capture also need the exact recorded anchor allocated by that transaction, rather than sampling a graph-wide high-water mark after commit.

Without this API, consumers have to build local wrappers around the transaction collection surface and maintain their own copy of TypeGraph's write-method list. This PR moves that integration seam into the library while keeping it opt-in and neutral: it reports completed write intents and the transaction's recorded anchor, but does not introduce any delivery, subscription, or streaming surface.

## Why a dedicated method (not `transaction(fn, { receipt: true })`)

An earlier revision used an options flag. A flag that changes a method's return type is a pattern this codebase already rejected once (`bulkInsert` exists instead of `bulkCreate({ returnResults: false })`), and it opened a type-soundness hole: receipt options forwarded through a plain `TransactionOptions`-typed variable statically selected the `Promise<T>` overload while the call returned a `TransactionOutcome<T>` at runtime. A dedicated method makes static dispatch and runtime behavior coincide by construction and deleted the runtime option-sniffing machinery outright.