### PR TITLE
Add ID brand constructors

### DIFF
--- a/.changeset/id-brand-constructors.md
+++ b/.changeset/id-brand-constructors.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `asNodeId` and `asEdgeId` constructors for branding persisted ids that
+round-trip through untyped storage before being passed back to read, update, or
+delete APIs.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -596,6 +596,17 @@ Retrieves a node by ID.
 store.nodes.Person.getById(id: NodeId<Person>): Promise<Node<Person> | undefined>;
 ```
 
+When a persisted id crosses an untyped boundary, brand it before passing it to
+read/update/delete APIs:
+
+```typescript
+const id = asNodeId<typeof Person>(row.personId);
+const person = await store.nodes.Person.getById(id);
+```
+
+`create({ id })` and `upsertById` still accept plain strings because those are
+write surfaces that mint or claim ids.
+
 #### `getByIds(ids)`
 
 Retrieves multiple nodes by ID in a single query. Returns results in input order,
@@ -992,6 +1003,16 @@ Retrieves an edge by ID.
 ```typescript
 store.edges.worksAt.getById(id: EdgeId<worksAt>): Promise<Edge<worksAt> | undefined>;
 ```
+
+When a persisted id crosses an untyped boundary, brand it before passing it to
+read/update/delete APIs:
+
+```typescript
+const id = asEdgeId<typeof worksAt>(row.edgeId);
+const edge = await store.edges.worksAt.getById(id);
+```
+
+Edge write APIs that mint ids still accept plain strings.
 
 #### `getByIds(ids)`
 

--- a/packages/typegraph/src/core/index.ts
+++ b/packages/typegraph/src/core/index.ts
@@ -58,6 +58,8 @@ export {
 // Core types
 export {
   type AnyEdgeType,
+  asEdgeId,
+  asNodeId,
   type Cardinality,
   type Collation,
   type DeleteBehavior,

--- a/packages/typegraph/src/core/types.ts
+++ b/packages/typegraph/src/core/types.ts
@@ -1,5 +1,7 @@
 import { type z } from "zod";
 
+import { ValidationError } from "../errors";
+
 // ============================================================
 // Cross-cutting Discriminators
 // ============================================================
@@ -42,6 +44,28 @@ declare const __nodeId: unique symbol;
 
 /** Brand symbol for EdgeId */
 declare const __edgeId: unique symbol;
+
+function assertNonEmptyId(value: string, path: string): void {
+  if (value.length > 0) {
+    return;
+  }
+
+  throw new ValidationError(
+    `${path} must be a non-empty string.`,
+    {
+      issues: [
+        {
+          path,
+          message: "Expected a non-empty string.",
+        },
+      ],
+    },
+    {
+      suggestion:
+        "Use a persisted node or edge id value, or let TypeGraph generate an id on create.",
+    },
+  );
+}
 
 // ============================================================
 // Node Type
@@ -113,6 +137,24 @@ export type NodeId<N extends NodeType> = string &
   }>;
 
 /**
+ * Brands a non-empty string as a {@link NodeId}.
+ *
+ * Use this when a persisted node id has round-tripped through untyped storage
+ * or an external boundary and must be passed back to read/update/delete
+ * surfaces such as `getById`, `getByIds`, `update`, or `delete`.
+ * Write surfaces that mint or claim ids, such as `create({ id })` and
+ * `upsertById`, intentionally accept plain strings.
+ *
+ * @throws {ValidationError} when `value` is empty.
+ */
+export function asNodeId<N extends NodeType = NodeType>(
+  value: string,
+): NodeId<N> {
+  assertNonEmptyId(value, "asNodeId");
+  return value as NodeId<N>;
+}
+
+/**
  * Infer the props type from a NodeType.
  */
 export type NodeProps<N extends NodeType> = z.infer<N["schema"]>;
@@ -175,6 +217,23 @@ export type EdgeId<E extends AnyEdgeType = AnyEdgeType> = string &
   Readonly<{
     [__edgeId]: E;
   }>;
+
+/**
+ * Brands a non-empty string as an {@link EdgeId}.
+ *
+ * Use this when a persisted edge id has round-tripped through untyped storage
+ * or an external boundary and must be passed back to read/update/delete
+ * surfaces such as `getById`, `getByIds`, `update`, or `delete`.
+ * Write surfaces that mint ids intentionally accept plain strings.
+ *
+ * @throws {ValidationError} when `value` is empty.
+ */
+export function asEdgeId<E extends AnyEdgeType = AnyEdgeType>(
+  value: string,
+): EdgeId<E> {
+  assertNonEmptyId(value, "asEdgeId");
+  return value as EdgeId<E>;
+}
 
 /**
  * Infer the props type from an EdgeType.

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -54,6 +54,8 @@ export {
   // Type utilities
   type AllEdgeTypes,
   type AllNodeTypes,
+  asEdgeId,
+  asNodeId,
   // Recorded-time instant brand (the typed anchor for store.asOfRecorded)
   asRecordedInstant,
   // External reference type for hybrid overlay patterns

--- a/packages/typegraph/test-d/id-brand-constructors.test-d.ts
+++ b/packages/typegraph/test-d/id-brand-constructors.test-d.ts
@@ -1,0 +1,41 @@
+import { expectAssignable, expectNotAssignable, expectType } from "tsd";
+import { z } from "zod";
+
+import {
+  asEdgeId,
+  asNodeId,
+  defineEdge,
+  defineNode,
+  type EdgeId,
+  type NodeId,
+} from "..";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string() }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+});
+
+expectType<NodeId<typeof Person>>(asNodeId<typeof Person>("person-1"));
+expectType<EdgeId<typeof worksAt>>(asEdgeId<typeof worksAt>("edge-1"));
+
+expectAssignable<string>(asNodeId<typeof Person>("person-1"));
+expectAssignable<string>(asEdgeId<typeof worksAt>("edge-1"));
+
+expectNotAssignable<NodeId<typeof Person>>("person-1");
+expectNotAssignable<EdgeId<typeof worksAt>>("edge-1");
+
+expectNotAssignable<NodeId<typeof Company>>(
+  asNodeId<typeof Person>("person-1"),
+);
+expectNotAssignable<EdgeId<typeof knows>>(asEdgeId<typeof worksAt>("edge-1"));

--- a/packages/typegraph/tests/id-brand-constructors.test.ts
+++ b/packages/typegraph/tests/id-brand-constructors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { asEdgeId, asNodeId, ValidationError } from "../src";
+
+describe("id brand constructors", () => {
+  it("brands non-empty node and edge ids without changing the runtime value", () => {
+    expect(asNodeId("person-1")).toBe("person-1");
+    expect(asEdgeId("edge-1")).toBe("edge-1");
+  });
+
+  it("rejects empty ids at the brand boundary", () => {
+    expect(() => asNodeId("")).toThrow(ValidationError);
+    expect(() => asEdgeId("")).toThrow(ValidationError);
+    expect(() => asNodeId("")).toThrow("asNodeId must be a non-empty string.");
+    expect(() => asEdgeId("")).toThrow("asEdgeId must be a non-empty string.");
+  });
+});


### PR DESCRIPTION
## What changed

Adds public constructors for persisted ID brands:

- `asNodeId<N extends NodeType>(value: string): NodeId<N>`
- `asEdgeId<E extends AnyEdgeType>(value: string): EdgeId<E>`

The helpers validate that ids are non-empty, export from core and the package root, and are documented beside the collection `getById` APIs. The branch also adds runtime tests, tsd coverage, and a minor changeset.

## Why

Consumers often persist TypeGraph ids as plain strings across database, queue, cache, or API boundaries. When those ids come back into TypeGraph read/update/delete surfaces, they need a sanctioned way to re-apply the nominal brand without scattering local casts through application code.

This follows the existing brand-constructor pattern used elsewhere in the package: validate only the library-level invariant TypeGraph can own, then return the branded value. For ids, that invariant is intentionally minimal: user-defined ids must be non-empty strings, with no additional format assumptions.
