### PR TITLE
Document event log materialization

### DIFF
--- a/.changeset/materializing-event-logs.md
+++ b/.changeset/materializing-event-logs.md
@@ -1,0 +1,6 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Document external event-log materialization patterns and verify the
+export/import bulk-copy path into graph-merge branches.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -17,6 +17,7 @@ const LLMS_SMALL_PAGES = new Set([
   "graph-merge",
   "provenance",
   "integration",
+  "materializing-event-logs",
   "multiple-graphs",
   "queries/overview",
   "queries/filter",
@@ -83,6 +84,7 @@ const sidebar = [
       { label: "Common Patterns", slug: "recipes" },
       { label: "Data Sync", slug: "data-sync" },
       { label: "Integration Patterns", slug: "integration" },
+      { label: "Materializing Event Logs", slug: "materializing-event-logs" },
     ],
   },
   {

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -1,0 +1,225 @@
+---
+title: Materializing External Event Logs
+description: How to project at-least-once event streams into TypeGraph without making TypeGraph an event-log product
+---
+
+External logs are the transport. TypeGraph is the typed, entity-resolved
+materialization and merge layer.
+
+Use this pattern when agents or integration runtimes already run on an event log
+or stream: Electric Durable Streams, database changefeeds, message queues, or a
+custom append-only feed. The log owns delivery, ordering, replay, and offsets.
+TypeGraph owns the current graph, valid-time facts, recorded-time history, and
+mergeable working copies. The sibling
+[`agent-stream-graph`](https://github.com/nicia-ai/agent-stream-graph) package is
+the reference implementation of this posture.
+
+## The Shape of the Problem
+
+External log consumers usually have three properties:
+
+- **At-least-once delivery.** A change can be delivered more than once, especially
+  after a crash or reconnect.
+- **Resume from a cursor.** The consumer persists the last source offset it has
+  safely processed.
+- **Replay.** Reprocessing old events is normal: for recovery, backfills, or
+  rebuilding a derived graph.
+
+That means a projector must be idempotent. Re-delivering the same source change
+should converge on the same graph state, not create duplicates.
+
+## Idempotent Projectors
+
+Use stable source ids as TypeGraph ids whenever the source has them. For nodes,
+that usually means `upsertById`. For edges, prefer
+`getOrCreateByEndpoints` with a `matchOn` policy for the fields that identify
+the relationship. Avoid `create` in a log projector unless the source event
+itself carries a unique id you pass as the TypeGraph id.
+
+```typescript
+async function projectChange(
+  tx: TransactionContext<typeof graph>,
+  change: Change,
+) {
+  const issue = await tx.nodes.Issue.upsertById(change.issueId, {
+    title: change.title,
+    state: change.state,
+  });
+
+  const actor = await tx.nodes.Actor.upsertById(change.actorId, {
+    name: change.actorName,
+  });
+
+  await tx.edges.changedBy.getOrCreateByEndpoints(
+    issue,
+    actor,
+    {
+      sourceChangeId: change.id,
+      action: change.action,
+    },
+    {
+      matchOn: ["sourceChangeId"],
+    },
+  );
+}
+```
+
+The important rule is that the second delivery of the same change takes the same
+code path and reaches the same row identities.
+
+## Cursor Bookkeeping
+
+A cursor is application state: store it as an ordinary graph node or in a
+separate application table. The cursor should advance only at a source offset
+boundary, after every change in that batch has been projected.
+
+### Same-transaction cursor
+
+When the backend supports transactions, write the cursor row in the same
+`store.transaction` callback as the projected batch. On transactional backends,
+this gives exactly-once materialization relative to the source offset: either the
+batch and cursor commit together, or neither does.
+
+```typescript
+await store.transaction(async (tx) => {
+  for (const change of batch.changes) {
+    await projectChange(tx, change);
+  }
+
+  await tx.nodes.Cursor.upsertById(`source:${batch.sourceId}`, {
+    offset: batch.endOffset,
+    sourceId: batch.sourceId,
+  });
+});
+```
+
+Check `backend.capabilities.transactions` before relying on that atomicity. On
+backends where it is `false` (for example Cloudflare D1 or `neon-http`),
+`store.transaction` still runs the callback but cannot make the writes atomic.
+The guarantee degrades to at-least-once delivery plus idempotence and
+partial-failure recovery. Keeping the cursor update at the end of the callback
+still preserves ordering, but it does not make the batch atomic.
+
+### Separate cursor store
+
+If the cursor lives outside TypeGraph, the pattern is always at-least-once plus
+idempotence. A crash after the graph writes but before the cursor write replays
+the batch. That is acceptable only because projector writes converge.
+
+```typescript
+await store.transaction(async (tx) => {
+  for (const change of batch.changes) {
+    await projectChange(tx, change);
+  }
+});
+
+await cursorStore.save({
+  sourceId: batch.sourceId,
+  offset: batch.endOffset,
+});
+```
+
+Use the same-transaction cursor on transactional backends when the cursor is part
+of the graph's source-of-truth state. Use a separate cursor store when the
+runtime already owns checkpointing or when the backend cannot provide atomic
+transactions.
+
+## Transaction Receipts
+
+When you need to know what a projector did, request a transaction receipt:
+
+```typescript
+const outcome = await store.transaction(
+  async (tx) => {
+    for (const change of batch.changes) {
+      await projectChange(tx, change);
+    }
+
+    await tx.nodes.Cursor.upsertById(`source:${batch.sourceId}`, {
+      offset: batch.endOffset,
+      sourceId: batch.sourceId,
+    });
+  },
+  { receipt: true },
+);
+
+if (batch.changes.length > 0 && outcome.receipt.writes.total === 0) {
+  throw new Error("projector dropped a non-empty batch");
+}
+
+if (outcome.receipt.recorded !== undefined) {
+  await offsetAnchors.save(batch.endOffset, outcome.receipt.recorded);
+}
+```
+
+`receipt.writes` counts completed write intents at the TypeGraph collection
+surface. It is not a rows-affected count: a successful delete of an absent row
+still counts as one completed write intent, and a rejected write counts zero.
+Bulk methods count by input length, so `bulkCreate([])` contributes zero.
+
+With `history: true`, `receipt.recorded` is the recorded commit anchor allocated
+for the transaction. Persist that anchor beside the source offset when you need
+to replay the graph as it looked after processing a specific offset.
+
+## Bitemporal Mapping
+
+External streams usually carry domain time and delivery time. Keep those
+separate:
+
+- **Event time belongs in valid time.** If a source change says a fact became
+  true on January 1, pass that timestamp as `validFrom`; if it ended on January
+  31, pass `validTo`.
+- **Ingest time is recorded time.** TypeGraph records when the graph committed
+  the write. Recorded time is allocated by the backend and cannot be backdated.
+- **Backfills collapse recorded instants to now.** Replaying historical events
+  today writes historical valid-time facts with today's recorded-time anchors.
+  That is correct SQL:2011 bitemporal behavior, not a bug.
+
+To replay by source offset, load the anchor you saved for that offset and read a
+recorded-time view:
+
+```typescript
+const anchor = await offsetAnchors.anchorFor(offset);
+const graphAtOffset = store.asOfRecorded(anchor);
+const issue = await graphAtOffset.nodes.Issue.getById(issueId);
+```
+
+That answers "what did the materialized graph know after offset X?" even if
+later corrections changed or deleted rows.
+
+## Bulk Copy Between Stores
+
+Use interchange for bulk copy between stores. The same path powers graph-merge
+working copies: export the source subset, create a branch from the target base,
+then import with `onConflict: "update"`.
+
+```typescript
+import { importGraph, exportGraph } from "@nicia-ai/typegraph/interchange";
+import { asBranchId, branch, unwrap } from "@nicia-ai/typegraph/graph-merge";
+
+const data = await exportGraph(sourceStore, {
+  nodeKinds: ["Belief", "Claim"],
+  edgeKinds: ["supports"],
+  includeMeta: true,
+});
+
+const fork = unwrap(
+  await branch(baseStore, makeBranchBackend, {
+    id: asBranchId("source-a"),
+  }),
+);
+
+const result = await importGraph(fork.store, data, {
+  onConflict: "update",
+  validateReferences: true,
+});
+
+if (!result.success) {
+  throw new Error(`copy failed with ${result.errors.length} import errors`);
+}
+```
+
+This is the preferred bulk path for copying a materialized belief store into a
+merge branch. It preserves ids, routes existing rows through normal conflict
+handling, validates edge endpoints, and keeps the branch non-history unless you
+explicitly create it with history capture.

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -126,22 +126,20 @@ transactions.
 
 ## Transaction Receipts
 
-When you need to know what a projector did, request a transaction receipt:
+When you need to know what a projector did, use `store.transactionWithReceipt`
+instead of `store.transaction`:
 
 ```typescript
-const outcome = await store.transaction(
-  async (tx) => {
-    for (const change of batch.changes) {
-      await projectChange(tx, change);
-    }
+const outcome = await store.transactionWithReceipt(async (tx) => {
+  for (const change of batch.changes) {
+    await projectChange(tx, change);
+  }
 
-    await tx.nodes.Cursor.upsertById(`source:${batch.sourceId}`, {
-      offset: batch.endOffset,
-      sourceId: batch.sourceId,
-    });
-  },
-  { receipt: true },
-);
+  await tx.nodes.Cursor.upsertById(`source:${batch.sourceId}`, {
+    offset: batch.endOffset,
+    sourceId: batch.sourceId,
+  });
+});
 
 if (batch.changes.length > 0 && outcome.receipt.writes.total === 0) {
   throw new Error("projector dropped a non-empty batch");

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../src/graph-merge/state-diff";
 import { asBranchId } from "../../src/graph-merge/types";
 import { cloneWorkingCopyStrategy } from "../../src/graph-merge/working-copy";
+import { exportGraph, importGraph } from "../../src/interchange";
 import { backendMatrix } from "./test-utils";
 
 const Person = defineNode("Person", {
@@ -36,6 +37,40 @@ const graph = defineGraph({
 });
 
 type G = typeof graph;
+
+const WorkItem = defineNode("WorkItem", {
+  schema: z.object({
+    title: z.string(),
+    status: z.string(),
+  }),
+});
+
+const Label = defineNode("Label", {
+  schema: z.object({
+    name: z.string(),
+  }),
+});
+
+const blocks = defineEdge("blocks", {
+  schema: z.object({
+    reason: z.string(),
+  }),
+  from: [WorkItem],
+  to: [WorkItem],
+});
+
+const materializationGraph = defineGraph({
+  id: "branch-materialization-copy-test",
+  nodes: {
+    WorkItem: { type: WorkItem },
+    Label: { type: Label },
+  },
+  edges: {
+    blocks: { type: blocks, from: [WorkItem], to: [WorkItem] },
+  },
+});
+
+type MaterializationGraph = typeof materializationGraph;
 
 /** Live `{ id, name }` snapshot of every Person node in a store, sorted by id. */
 async function snapshotPeople(
@@ -241,5 +276,88 @@ describe.each(backendMatrix())("branch [$name]", (entry) => {
     expect((await created.store.nodes.Person.getById(aliceId))?.name).toBe(
       "Alice",
     );
+  });
+
+  it("bulk-copies a history source subset into a non-history branch with update conflicts", async () => {
+    const [sourceStore] = await createStoreWithSchema(
+      materializationGraph,
+      await makeBackend(),
+      { history: true },
+    );
+    const [baseStore] = await createStoreWithSchema(
+      materializationGraph,
+      await makeBackend(),
+    );
+
+    await baseStore.nodes.WorkItem.upsertById("work-1", {
+      title: "Old title",
+      status: "stale",
+    });
+
+    const sourceWork = await sourceStore.nodes.WorkItem.upsertById("work-1", {
+      title: "Fresh title",
+      status: "open",
+    });
+    const dependency = await sourceStore.nodes.WorkItem.upsertById("work-2", {
+      title: "Dependency",
+      status: "blocked",
+    });
+    const omittedLabel = await sourceStore.nodes.Label.upsertById("label-1", {
+      name: "not exported",
+    });
+    const copiedEdge = await sourceStore.edges.blocks.create(
+      sourceWork,
+      dependency,
+      { reason: "waiting on import" },
+    );
+    expect(await sourceStore.recordedNow()).toBeDefined();
+
+    const exported = await exportGraph(sourceStore, {
+      nodeKinds: ["WorkItem"],
+      edgeKinds: ["blocks"],
+      includeMeta: true,
+    });
+    expect(exported.nodes).toHaveLength(2);
+    expect(exported.nodes.every((node) => node.kind === "WorkItem")).toBe(true);
+    expect(exported.edges).toHaveLength(1);
+    expect(exported.edges[0]?.kind).toBe("blocks");
+
+    const branchResult = await branch<MaterializationGraph>(
+      baseStore,
+      () => makeBackend(),
+      { id: asBranchId("materialized-copy") },
+    );
+    expect(isOk(branchResult)).toBe(true);
+    const copiedBranch = unwrap(branchResult);
+
+    const result = await importGraph(copiedBranch.store, exported, {
+      onConflict: "update",
+      validateReferences: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.nodes.updated).toBe(1);
+    expect(result.nodes.created).toBe(1);
+    expect(result.edges.created).toBe(1);
+
+    const copiedWork = await copiedBranch.store.nodes.WorkItem.getById(
+      sourceWork.id,
+    );
+    const copiedDependency = await copiedBranch.store.nodes.WorkItem.getById(
+      dependency.id,
+    );
+    const omitted = await copiedBranch.store.nodes.Label.getById(
+      omittedLabel.id,
+    );
+    const copiedRelationship = await copiedBranch.store.edges.blocks.getById(
+      copiedEdge.id,
+    );
+
+    expect(copiedWork?.title).toBe("Fresh title");
+    expect(copiedWork?.status).toBe("open");
+    expect(copiedDependency?.title).toBe("Dependency");
+    expect(omitted).toBeUndefined();
+    expect(copiedRelationship?.fromId).toBe(sourceWork.id);
+    expect(copiedRelationship?.toId).toBe(dependency.id);
+    expect(copiedRelationship?.reason).toBe("waiting on import");
   });
 });


### PR DESCRIPTION
## What changed

Adds a new guide, `Materializing External Event Logs`, and registers it in the docs sidebar.

The guide covers:

- external logs as transport and TypeGraph as typed materialization/merge layer
- idempotent projector contracts with `upsertById` and `getOrCreateByEndpoints`
- cursor placement, including transactional and non-transactional backend caveats
- transaction receipts and recorded anchors for offset-to-anchor bookkeeping
- bitemporal mapping of event time to valid time and ingest time to recorded time
- export/import bulk copy into graph-merge branches

The branch also adds a graph-merge integration test proving `history: true` source store -> `exportGraph` subset -> `importGraph(..., { onConflict: "update" })` into a non-history `branch()` store.

## Dependency

PR #222 has landed. This branch is rebased onto current `main`, and the receipt
example now uses the API as it actually shipped: `store.transactionWithReceipt()`
(a dedicated method) rather than the `store.transaction(fn, { receipt: true })`
flag from #222's earlier revision.

## Why

Library integrators commonly consume external at-least-once event streams, changefeeds, or message queues and project them into TypeGraph. They need guidance on the boundary: the external system owns delivery, replay, and offsets; TypeGraph owns typed materialized state, valid-time facts, recorded-time history, and mergeable working copies.

This guide documents that integration pattern abstractly so consumers can build projectors that converge under re-delivery, place cursors correctly for their backend's transaction capabilities, and use the existing interchange path for bulk copy into branches.

