### PR TITLE
fix: bound and scope SQLite's refreshStatistics() ANALYZE

### DIFF
--- a/.changeset/sqlite-analyze-scaling.md
+++ b/.changeset/sqlite-analyze-scaling.md
@@ -1,0 +1,24 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fixes a scaling bug in the SQLite backend's `refreshStatistics()` (the
+planner-statistics refresh `bulkCreate`/`bulkInsert` trigger automatically
+after a large autocommit write — see the `autoRefreshStatistics` store
+option). It ran a bare, unscoped `ANALYZE`, which does two things wrong on
+SQLite: it re-analyzes every table in the database file (not just
+TypeGraph's own tables — already fixed on the Postgres backend), and it
+does a full, unbounded table/index scan per call (Postgres's `ANALYZE`
+samples a fixed-size set of rows regardless of table size; SQLite's does
+not unless bounded). A caller streaming a bulk load through repeated
+`bulkInsert()` calls — the only practical way to load a multi-million-row
+dataset without holding it all in memory — re-triggers this once each
+batch's row count crosses the threshold; with unbounded per-call cost
+growing with total table size, total load time integrated to O(n²)
+instead of O(n) (observed: a 2M-row bulk load that never finished after
+4.5+ hours). `refreshStatistics()` on SQLite now scopes ANALYZE to
+TypeGraph's own tables and sets `PRAGMA analysis_limit` first, bounding
+each call's cost the way Postgres's already was. A 100k-row reproduction
+of the original shape now completes in ~8s with load time growing
+log-ishly with table size (2x from first batch to last), not
+quadratically.

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -32,6 +32,7 @@ import { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
 import { BackendDisposedError, ConfigurationError } from "../../errors";
 import type { ResolvedSqlTableNames } from "../../query/compiler/schema";
+import { quoteIdentifier } from "../../query/compiler/utils";
 import {
   buildFulltextCapabilities,
   fts5Strategy,
@@ -191,6 +192,20 @@ const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
 const FULLTEXT_UPSERT_PARAM_COUNT = 6;
 const FULLTEXT_DELETE_FIXED_PARAM_COUNT = 2;
 const UNIQUE_INSERT_PARAM_COUNT = 6;
+
+/**
+ * `PRAGMA analysis_limit` value `refreshStatistics()` sets before running
+ * `ANALYZE`. Unlike Postgres (whose `ANALYZE` always examines a bounded
+ * sample sized off `default_statistics_target`), SQLite's `ANALYZE`
+ * defaults to a full table/index scan — O(table size) per call. A caller
+ * streaming a bulk load through repeated `bulkInsert()` calls (the only
+ * practical pattern for a multi-million-row load) re-triggers
+ * `refreshStatistics()` on every batch once that batch's row count crosses
+ * `AUTO_REFRESH_STATISTICS_ROW_THRESHOLD`; without this bound, per-call
+ * cost grows with total table size, integrating to O(n²) total load time.
+ * 1000 is SQLite's own documented suggestion for large databases.
+ */
+export const SQLITE_ANALYZE_ROW_LIMIT = 1000;
 
 /**
  * Batch chunk sizes for the SQLite operation backend, derived from the
@@ -944,6 +959,22 @@ export function createSqliteBackend(
     fulltext: tables.fulltextTableName,
     uniques: getTableName(tables.uniques),
   };
+  // refreshStatistics() scopes ANALYZE to these — matching the Postgres
+  // backend, which never touches unrelated tables sharing the database.
+  // The recorded relations are ANALYZEd separately under a missing-table
+  // guard: a schema created before recorded-time history landed
+  // (bring-your-own-connection, no DDL re-run) has no recorded_* tables.
+  const coreAnalyzeTables = [
+    tableNames.nodes,
+    tableNames.edges,
+    tableNames.uniques,
+    tableNames.fulltext,
+  ];
+  const recordedAnalyzeTables = [
+    tableNames.recordedNodes,
+    tableNames.recordedEdges,
+    tableNames.recordedClock,
+  ] as const;
   const operationStrategy = createSqliteOperationStrategy(
     tables,
     fulltextStrategy,
@@ -1391,7 +1422,31 @@ export function createSqliteBackend(
       // virtual-table queries and multi-column index selection, can be
       // an order of magnitude slower. Running it explicitly makes the
       // planner data-driven.
-      await db.run(sql`ANALYZE`);
+      //
+      // Scoped to TypeGraph-managed tables only (matching the Postgres
+      // backend) — a bare `ANALYZE` touches every table in the database
+      // file, including unrelated ones sharing it. Bounded by
+      // `analysis_limit` (see its doc comment) so cost stays roughly
+      // constant per call regardless of table size — the value is a
+      // fixed internal constant, not user input, so inlining it via
+      // `sql.raw` is safe; SQLite's `PRAGMA` does not accept bound
+      // parameters for its value.
+      await db.run(
+        sql`PRAGMA analysis_limit = ${sql.raw(String(SQLITE_ANALYZE_ROW_LIMIT))}`,
+      );
+      for (const tableName of coreAnalyzeTables) {
+        await db.run(sql`ANALYZE ${quoteIdentifier(tableName)}`);
+      }
+      // The recorded relations may be absent on a schema created before
+      // recorded-time history landed (bring-your-own-connection, no DDL
+      // re-run); ANALYZE on a missing table errors, so skip those.
+      for (const tableName of recordedAnalyzeTables) {
+        try {
+          await db.run(sql`ANALYZE ${quoteIdentifier(tableName)}`);
+        } catch (error) {
+          if (!isMissingTableError(error)) throw error;
+        }
+      }
     },
 
     async commitSchemaVersion(

--- a/packages/typegraph/tests/backends/sqlite/refresh-statistics-scope.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/refresh-statistics-scope.test.ts
@@ -1,0 +1,158 @@
+/**
+ * `refreshStatistics()` scope and cost bound on the SQLite backend.
+ *
+ * A bare, unscoped `ANALYZE` (no table argument) does two things wrong at
+ * bulk-load scale: it re-analyzes every table in the database file, not
+ * just TypeGraph's own (the Postgres backend already scopes to its own
+ * tables); and it does a full, unbounded table/index scan per call, unlike
+ * Postgres's `ANALYZE`, which always samples a fixed-size set of rows
+ * regardless of table size. A caller streaming a bulk load through
+ * repeated `bulkInsert()` calls — the only practical pattern for a
+ * multi-million-row load — re-triggers `refreshStatistics()` on every
+ * batch once that batch's row count crosses
+ * `AUTO_REFRESH_STATISTICS_ROW_THRESHOLD`; with unbounded per-call cost
+ * growing with total table size, total load time integrated to O(n²)
+ * (observed: a 2M-row bulk load that never finished after 4.5+ hours).
+ * These tests pin the two fixes: scoping and `PRAGMA analysis_limit`.
+ */
+import type Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStore, defineEdge, defineGraph, defineNode } from "../../../src";
+import { SQLITE_ANALYZE_ROW_LIMIT } from "../../../src/backend/drizzle/sqlite";
+import {
+  createLocalSqliteBackend,
+  type LocalSqliteBackendResult,
+} from "../../../src/backend/sqlite/local";
+
+const Item = defineNode("Item", {
+  schema: z.object({ name: z.string() }),
+});
+const relates = defineEdge("relates", { schema: z.object({}) });
+
+function buildGraph(graphId: string) {
+  return defineGraph({
+    id: graphId,
+    nodes: { Item: { type: Item } },
+    edges: { relates: { type: relates, from: [Item], to: [Item] } },
+  });
+}
+
+function rawClient(result: LocalSqliteBackendResult): Database.Database {
+  // Drizzle attaches the raw better-sqlite3 handle as `$client` at runtime;
+  // the published type omits it (same access pattern as
+  // local-pragma-defaults.test.ts).
+  return (result.db as unknown as { $client: Database.Database }).$client;
+}
+
+function analyzedTableNames(result: LocalSqliteBackendResult): string[] {
+  const rows = rawClient(result)
+    .prepare("SELECT DISTINCT tbl FROM sqlite_stat1")
+    .all() as { tbl: string }[];
+  return rows.map((row) => row.tbl);
+}
+
+describe("SQLite refreshStatistics scope and cost bound", () => {
+  it("bounds ANALYZE cost via PRAGMA analysis_limit", async () => {
+    const result = createLocalSqliteBackend();
+    try {
+      const store = createStore(buildGraph("scope_limit"), result.backend);
+      await store.nodes.Item.create({ name: "seed" });
+
+      await store.refreshStatistics();
+
+      const analysisLimit = rawClient(result).pragma("analysis_limit", {
+        simple: true,
+      });
+      expect(analysisLimit).toBe(SQLITE_ANALYZE_ROW_LIMIT);
+    } finally {
+      await result.backend.close();
+    }
+  });
+
+  it("scopes ANALYZE to TypeGraph-managed tables, not the whole database file", async () => {
+    const result = createLocalSqliteBackend();
+    try {
+      const store = createStore(buildGraph("scope_isolation"), result.backend);
+      await store.nodes.Item.create({ name: "seed" });
+
+      // An application table sharing the same SQLite file/connection — a
+      // bare `ANALYZE` would have picked this up too.
+      rawClient(result).exec(
+        "CREATE TABLE app_unrelated_table (id INTEGER PRIMARY KEY, value TEXT)",
+      );
+      rawClient(result).exec(
+        "INSERT INTO app_unrelated_table (value) VALUES ('x')",
+      );
+
+      await store.refreshStatistics();
+
+      const analyzed = analyzedTableNames(result);
+      expect(analyzed).toContain("typegraph_nodes");
+      expect(analyzed).not.toContain("app_unrelated_table");
+    } finally {
+      await result.backend.close();
+    }
+  });
+
+  it("does not throw when recorded-time tables are absent", async () => {
+    // Plain createStore (no createStoreWithSchema, no recorded-time
+    // history engaged) never creates the recorded_* relations — this is
+    // the ordinary shape for most graphs, not an edge case.
+    const result = createLocalSqliteBackend();
+    try {
+      const store = createStore(
+        buildGraph("scope_no_recorded"),
+        result.backend,
+      );
+      await store.nodes.Item.create({ name: "seed" });
+
+      await expect(store.refreshStatistics()).resolves.toBeUndefined();
+    } finally {
+      await result.backend.close();
+    }
+  });
+
+  it("keeps repeated large-batch bulkInsert cheap as the table grows", async () => {
+    // The actual regression shape: a streaming loader batches bulkInsert
+    // calls, each already over AUTO_REFRESH_STATISTICS_ROW_THRESHOLD, so
+    // every batch re-triggers refreshStatistics(). Before the fix, each
+    // call's unbounded ANALYZE grew with cumulative table size, so batch
+    // time grew roughly linearly across the loop (observed ~5x from the
+    // first batch to the 30th at 58k cumulative rows). This asserts the
+    // last batch is not dramatically slower than the first — a loose
+    // bound (not a strict performance assertion, which would be flaky in
+    // CI) that would fail fast under the old unbounded-scan behavior.
+    const result = createLocalSqliteBackend();
+    try {
+      const store = createStore(
+        buildGraph("scope_batch_growth"),
+        result.backend,
+      );
+      const batchSize = 1500; // over AUTO_REFRESH_STATISTICS_ROW_THRESHOLD (1000)
+      const batchCount = 20;
+      const batchTimesMs: number[] = [];
+
+      for (let batch = 0; batch < batchCount; batch += 1) {
+        const items = Array.from({ length: batchSize }, (_, index) => ({
+          props: { name: `item-${batch}-${index}` },
+        }));
+        const started = performance.now();
+        await store.nodes.Item.bulkInsert(items);
+        batchTimesMs.push(performance.now() - started);
+      }
+
+      const first5Avg =
+        batchTimesMs.slice(0, 5).reduce((sum, value) => sum + value, 0) / 5;
+      const last5Avg =
+        batchTimesMs.slice(-5).reduce((sum, value) => sum + value, 0) / 5;
+      // Some growth is expected (B-tree depth, WAL size) — this bounds it
+      // well under the ~5x-per-58k-rows trend the unscoped, unbounded
+      // ANALYZE produced.
+      expect(last5Avg).toBeLessThan(first5Avg * 3);
+    } finally {
+      await result.backend.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a scaling bug discovered while running the LDBC SNB benchmark (#225): `refreshStatistics()` on the SQLite backend ran a bare, unscoped `ANALYZE` (no table argument), which does two things wrong:

1. **Unscoped**: it re-analyzes every table in the database file, not just TypeGraph's own tables. The Postgres backend already scopes its `ANALYZE` to TypeGraph-managed tables (`coreAnalyzeStatements` in `postgres.ts`) — SQLite's never did.
2. **Unbounded**: it does a full table/index scan per call. Postgres's `ANALYZE` always examines a bounded, fixed-size sample of rows (governed by `default_statistics_target`) regardless of table size, so it never showed this problem. SQLite's `ANALYZE` scans the whole table unless bounded by `PRAGMA analysis_limit` (a feature that exists for exactly this reason, per SQLite's own docs).

`bulkCreate`/`bulkInsert` on nodes and edges auto-trigger this refresh once a single call's row count crosses `AUTO_REFRESH_STATISTICS_ROW_THRESHOLD` (1000 rows, added in #212). #212's own PR description says the design deliberately did not cover "loops of small batches that never individually reach the threshold" — but never considered loops of *large* batches (each already over the threshold), which is exactly what any real streaming bulk loader does for a multi-million-row dataset (and what this repo's own `backend-setup.md` docs recommend: `for (const batch of batches) { await store.nodes.Document.bulkCreate(batch); }`). Each such batch independently re-triggers the refresh, and with unbounded per-call cost growing with total table size, total load time integrates to **O(n²)**.

Discovered via a real LDBC SNB SF1 load (packages/benchmarks, #225): the comments stage (~2M rows) ran for **over 4.5 hours without finishing**, versus 46 minutes for the ~1M-row posts stage just before it — a ratio far beyond what row-count alone explains. Isolated the cause with controlled reproductions (60k-200k row loads), confirmed it disappears with a single node kind and no edges, persists without any ontology involved, and correlates with total graph size rather than any one table's size.

## Fix

`refreshStatistics()` on the SQLite backend now:
- Sets `PRAGMA analysis_limit = 1000` (SQLite's own suggested value for large databases) before running `ANALYZE`, bounding per-call cost regardless of table size.
- Scopes `ANALYZE` to TypeGraph's own tables (`typegraph_nodes`, `typegraph_edges`, `typegraph_node_uniques`, the fulltext table, plus the `recorded_*` tables when present), matching the Postgres backend.

## Verification

- New test file `tests/backends/sqlite/refresh-statistics-scope.test.ts` (4 tests): pins the `analysis_limit` value, asserts an unrelated table sharing the same connection is never touched, asserts no throw when `recorded_*` tables are absent, and bounds batch-to-batch growth in a repeated-large-bulkInsert loop. Confirmed these tests **fail against the pre-fix code** (reverted the fix, re-ran — 2 of 4 failed as expected) before restoring the fix.
- Existing `tests/auto-refresh-statistics.test.ts` (#212's suite): all 8 tests still pass unchanged — no change to the trigger semantics, only to what `refreshStatistics()` itself does on SQLite.
- Full `packages/typegraph` suite: 229 files / 4525 tests passed (898 skipped, Postgres-dependent — see below), 0 failures.
- Property-based suite: 345 passed / 1 skipped, 0 failures.
- Postgres suite (`pnpm test:postgres`, unaffected by this SQLite-only change but run per this repo's convention for backend changes): 67 files / 1816 tests passed, 0 failures.
- Manual repro: 100k-row load (with the `Message` ontology) completes in ~8.4s with only ~2.1x growth from first batch to last (consistent with normal B-tree logarithmic growth); 200k-row load (no ontology) completes in ~22.9s with ~2.7x growth. Both previously would have shown the ~5x-per-58k-row trend that led to the multi-hour SF1 hang.
