### PR TITLE
perf: batch edge-creation endpoint checks in bulkCreate/bulkInsert

### DIFF
--- a/.changeset/edge-batch-endpoint-prefetch.md
+++ b/.changeset/edge-batch-endpoint-prefetch.md
@@ -1,0 +1,23 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Batches edge creation's endpoint-existence checks in `bulkCreate`/`bulkInsert`
+into one `getNodes` call per distinct (kind) referenced across the whole
+batch, instead of an individual `getNode` probe per edge (mirroring the
+batched existence/uniqueness pre-check node creation already had via
+`primeBatchValidationCaches`). Found while investigating why a real
+LDBC SNB SF1 bulk load (millions of nodes and edges) was far slower than
+expected: a controlled 1M-row reproduction showed `bulkInsert` edge-batch
+time growing from ~90ms to ~630ms per 2,000-row batch as the graph grew,
+while an equivalent node-only batch (no edges) stayed roughly flat. The
+edge batch path validated each edge's `from`/`to` endpoints with a
+`getNode` call per edge — for a batch with mostly-unique endpoints, that's
+thousands of individual round trips per batch instead of one batched
+fetch per distinct node kind. With the fix, the same 1M-edge reproduction's
+per-batch time drops to roughly ~90-160ms and its growth curve flattens
+substantially (the residual growth matches the same mild index-maintenance
+cost already seen on plain node inserts). No behavior change: this is a
+pure internal optimization to `executeEdgeCreateNoReturnBatch`/
+`executeEdgeCreateBatch`; callers observe identical results, just fewer
+round trips.

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -179,6 +179,12 @@ function createEdgeBatchValidationBackend(
     insertParams: InsertEdgeParams,
     cardinality: Cardinality,
   ) => void;
+  seedEndpointRow: (
+    graphId: string,
+    kind: string,
+    id: string,
+    row: Awaited<ReturnType<GraphBackend["getNode"]>>,
+  ) => void;
 }> {
   const endpointCache = new Map<
     string,
@@ -202,6 +208,23 @@ function createEdgeBatchValidationBackend(
     const node = await backend.getNode(graphId, kind, id);
     endpointCache.set(cacheKey, node);
     return node;
+  }
+
+  // Lets batch preparation prime the endpoint cache from one getNodes
+  // round trip per (kind) instead of a per-edge getNode probe for each
+  // from/to endpoint — mirrors seedNodeRow in createNodeBatchValidationBackend.
+  // Seeding an absent result (`undefined`) is meaningful — it marks the key
+  // as known-missing so the per-edge check skips the backend read. An
+  // earlier lookup or seed always wins; seeding never overwrites.
+  function seedEndpointRow(
+    graphId: string,
+    kind: string,
+    id: string,
+    row: Awaited<ReturnType<GraphBackend["getNode"]>>,
+  ): void {
+    const cacheKey = buildEdgeEndpointCacheKey(graphId, kind, id);
+    if (endpointCache.has(cacheKey)) return;
+    endpointCache.set(cacheKey, row);
   }
 
   async function countEdgesFromCached(
@@ -290,6 +313,7 @@ function createEdgeBatchValidationBackend(
   return {
     backend: validationBackend,
     registerPendingEdgeForCardinality,
+    seedEndpointRow,
   };
 }
 
@@ -455,6 +479,93 @@ export async function executeEdgeCreateNoReturn<G extends GraphDef>(
 }
 
 /**
+ * Batch-primes an edge batch's endpoint validation cache with one
+ * `getNodes` round trip per distinct (kind) referenced across every
+ * from/to endpoint in the batch, instead of a `getNode` probe per edge.
+ * Mirrors `primeBatchValidationCaches`'s node-existence priming.
+ */
+async function primeEdgeBatchValidationCache<G extends GraphDef>(
+  ctx: EdgeOperationContext<G>,
+  inputs: readonly CreateEdgeInput[],
+  backend: GraphBackend | TransactionBackend,
+  seedEndpointRow: (
+    graphId: string,
+    kind: string,
+    id: string,
+    row: Awaited<ReturnType<GraphBackend["getNode"]>>,
+  ) => void,
+): Promise<void> {
+  if (backend.getNodes === undefined) return;
+
+  const idsByKind = new Map<string, Set<string>>();
+  const addEndpoint = (kind: string, id: string): void => {
+    const ids = idsByKind.get(kind) ?? new Set<string>();
+    ids.add(id);
+    idsByKind.set(kind, ids);
+  };
+  for (const input of inputs) {
+    addEndpoint(input.fromKind, input.fromId);
+    addEndpoint(input.toKind, input.toId);
+  }
+
+  for (const [kind, ids] of idsByKind) {
+    const orderedIds = [...ids];
+    const rows = await backend.getNodes(ctx.graphId, kind, orderedIds);
+    const rowsById = new Map(rows.map((row) => [row.id, row]));
+    for (const id of orderedIds) {
+      seedEndpointRow(ctx.graphId, kind, id, rowsById.get(id));
+    }
+  }
+}
+
+/**
+ * Shared batch preparation for edge creates: primes the endpoint
+ * validation cache with one `getNodes` call per referenced kind, then
+ * validates every input against the primed cache in order (so later
+ * inputs see earlier ones' pending cardinality/uniqueness registrations).
+ * Shared between the non-returning and RETURNING batch paths so both get
+ * the same batched-prefetch treatment.
+ */
+async function prepareEdgeBatchCreates<G extends GraphDef>(
+  ctx: EdgeOperationContext<G>,
+  inputs: readonly CreateEdgeInput[],
+  backend: GraphBackend | TransactionBackend,
+): Promise<{
+  preparedCreates: EdgeCreatePrepared[];
+  batchInsertParams: InsertEdgeParams[];
+}> {
+  const {
+    backend: validationBackend,
+    registerPendingEdgeForCardinality,
+    seedEndpointRow,
+  } = createEdgeBatchValidationBackend(backend);
+
+  await primeEdgeBatchValidationCache(ctx, inputs, backend, seedEndpointRow);
+
+  const preparedCreates: EdgeCreatePrepared[] = [];
+  for (const input of inputs) {
+    const id = input.id ?? generateId();
+    const prepared = await validateAndPrepareEdgeCreate(
+      ctx,
+      input,
+      id,
+      validationBackend,
+    );
+    preparedCreates.push(prepared);
+    registerPendingEdgeForCardinality(
+      prepared.insertParams,
+      prepared.cardinality,
+    );
+  }
+
+  const batchInsertParams = preparedCreates.map(
+    (prepared) => prepared.insertParams,
+  );
+
+  return { preparedCreates, batchInsertParams };
+}
+
+/**
  * Executes batched edge creates without returning inserted edge payloads.
  *
  * Note: `withOperationHooks` is intentionally skipped for batch throughput.
@@ -470,27 +581,10 @@ export async function executeEdgeCreateNoReturnBatch<G extends GraphDef>(
   }
 
   await runInWriteTransaction(ctx, backend, async (target) => {
-    const { backend: validationBackend, registerPendingEdgeForCardinality } =
-      createEdgeBatchValidationBackend(target);
-    const preparedCreates: EdgeCreatePrepared[] = [];
-
-    for (const input of inputs) {
-      const id = input.id ?? generateId();
-      const prepared = await validateAndPrepareEdgeCreate(
-        ctx,
-        input,
-        id,
-        validationBackend,
-      );
-      preparedCreates.push(prepared);
-      registerPendingEdgeForCardinality(
-        prepared.insertParams,
-        prepared.cardinality,
-      );
-    }
-
-    const batchInsertParams = preparedCreates.map(
-      (prepared) => prepared.insertParams,
+    const { batchInsertParams } = await prepareEdgeBatchCreates(
+      ctx,
+      inputs,
+      target,
     );
     await runInsertBatch(edgeInsertDispatch(target), batchInsertParams);
   });
@@ -515,27 +609,10 @@ export async function executeEdgeCreateBatch<G extends GraphDef>(
   }
 
   return runInWriteTransaction(ctx, backend, async (target) => {
-    const { backend: validationBackend, registerPendingEdgeForCardinality } =
-      createEdgeBatchValidationBackend(target);
-    const preparedCreates: EdgeCreatePrepared[] = [];
-
-    for (const input of inputs) {
-      const id = input.id ?? generateId();
-      const prepared = await validateAndPrepareEdgeCreate(
-        ctx,
-        input,
-        id,
-        validationBackend,
-      );
-      preparedCreates.push(prepared);
-      registerPendingEdgeForCardinality(
-        prepared.insertParams,
-        prepared.cardinality,
-      );
-    }
-
-    const batchInsertParams = preparedCreates.map(
-      (prepared) => prepared.insertParams,
+    const { batchInsertParams } = await prepareEdgeBatchCreates(
+      ctx,
+      inputs,
+      target,
     );
 
     const rows = await runInsertBatchReturning(

--- a/packages/typegraph/tests/collection-api.test.ts
+++ b/packages/typegraph/tests/collection-api.test.ts
@@ -1090,15 +1090,20 @@ describe("Bulk Operations (SQLite)", () => {
       expect(count).toBe(0);
     });
 
-    it("reuses endpoint existence checks for bulkInsert edge batches", async () => {
+    it("batch-prefetches endpoint existence checks for bulkInsert edge batches", async () => {
       const baseBackend = createSqliteBackend(createTestDatabase());
       let getNodeCalls = 0;
+      let getNodesCalls = 0;
 
       const backendWithNodeCounter: GraphBackend = {
         ...baseBackend,
         async getNode(graphId, kind, id) {
           getNodeCalls += 1;
           return baseBackend.getNode(graphId, kind, id);
+        },
+        async getNodes(graphId, kind, ids) {
+          getNodesCalls += 1;
+          return baseBackend.getNodes!(graphId, kind, ids);
         },
         async transaction(fn, options) {
           return baseBackend.transaction(async (tx, sql) => {
@@ -1107,6 +1112,14 @@ describe("Bulk Operations (SQLite)", () => {
               async getNode(graphId: string, kind: string, id: string) {
                 getNodeCalls += 1;
                 return tx.getNode(graphId, kind, id);
+              },
+              async getNodes(
+                graphId: string,
+                kind: string,
+                ids: readonly string[],
+              ) {
+                getNodesCalls += 1;
+                return tx.getNodes!(graphId, kind, ids);
               },
             };
             return fn(wrappedTx, sql);
@@ -1119,6 +1132,7 @@ describe("Bulk Operations (SQLite)", () => {
       const acme = await localStore.nodes.Company.create({ name: "Acme Inc" });
 
       getNodeCalls = 0;
+      getNodesCalls = 0;
       await localStore.edges.worksAt.bulkInsert([
         {
           id: "edge-cache-1",
@@ -1140,8 +1154,12 @@ describe("Bulk Operations (SQLite)", () => {
         },
       ]);
 
-      // Two endpoint checks total: one for from-node, one for to-node.
-      expect(getNodeCalls).toBe(2);
+      // The batch is prefetched with one getNodes() call per distinct
+      // endpoint kind (Person for `from`, Company for `to`) instead of a
+      // getNode() probe per edge — zero individual endpoint lookups even
+      // though the batch references two distinct nodes across three edges.
+      expect(getNodeCalls).toBe(0);
+      expect(getNodesCalls).toBe(2);
     });
   });
 


### PR DESCRIPTION
Batches edge creation's endpoint-existence checks in `bulkCreate`/`bulkInsert` into one `getNodes` call per distinct node kind referenced across the whole batch, instead of an individual `getNode` probe per edge — mirroring the batched existence/uniqueness pre-check node creation already had via `primeBatchValidationCaches` (node creation was already batched; edge creation never got the equivalent treatment).

Found while investigating why a real LDBC SNB SF1 bulk load (`packages/benchmarks`, a separate in-flight PR) was far slower on TypeGraph/SQLite and TypeGraph/Postgres (~75-81 min) than on Neo4j (~4.4 min) or LadybugDB (~45s). A controlled 1M-row synthetic reproduction isolated the specific cause: `hasCreator` edge-batch time grew from ~90ms to ~630ms per 2,000-row batch as the graph grew, while an equivalent node-only batch (no edges) stayed roughly flat. Reading `validateAndPrepareEdgeCreate` showed why: it calls `backend.getNode()` individually for both the `from` and `to` endpoint of every edge, so a batch with mostly-unique endpoints (the common bulk-load case) does thousands of individual round trips instead of one batched fetch per kind.

## Changes

- `createEdgeBatchValidationBackend` gains `seedEndpointRow` (mirrors `seedNodeRow` on the node side).
- New `primeEdgeBatchValidationCache`: collects every distinct `(kind, id)` pair referenced across a batch's `from`/`to` endpoints and issues one `getNodes()` call per kind before the per-edge validation loop runs.
- New shared `prepareEdgeBatchCreates` (mirrors the node side's `prepareBatchCreates`) — both `executeEdgeCreateNoReturnBatch` and `executeEdgeCreateBatch` now call it instead of duplicating the same loop.
- No behavior change: pure internal optimization. Callers observe identical results, just fewer round trips.