### PR TITLE
feat(query): add orderBy() to aggregate queries for top-N by count/sum

### DIFF
--- a/.changeset/aggregate-order-by.md
+++ b/.changeset/aggregate-order-by.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Aggregate queries now support `.orderBy()`. Previously `ExecutableAggregateQuery`
+exposed `limit()` but no way to order results, so `.aggregate({...}).limit(n)`
+returned an arbitrary `n` groups rather than the top `n` — the most common
+aggregate shape ("top N groups by count/sum") required fetching every group
+and sorting in JS.
+
+`.orderBy(key, direction?)` takes any output name from `.aggregate({...})` —
+either a grouped field or an aggregate alias — and can be chained for
+multi-key sorts:
+
+```typescript
+store
+  .query()
+  .from("Author", "a")
+  .traverse("wrote", "e")
+  .to("Book", "b")
+  .groupByNode("a")
+  .aggregate({ author: field("a", "name"), bookCount: count("b") })
+  .orderBy("bookCount", "desc")
+  .limit(2)
+  .execute();
+```
+
+Ordering resolves against the projected SELECT-list output alias rather than
+recompiling the underlying expression, so it works uniformly for grouped
+fields and aggregates on both SQLite and PostgreSQL with no dialect-specific
+handling.

--- a/apps/docs/src/content/docs/queries/aggregate.md
+++ b/apps/docs/src/content/docs/queries/aggregate.md
@@ -255,7 +255,10 @@ const topContributors = await store
 
 ## Ordering Aggregated Results
 
-Order by aggregate values:
+Aggregate queries have their own `orderBy(key, direction?)`, called after
+`.aggregate({...})`. `key` is any output name from the fields object — a
+grouped field or an aggregate alias — so `limit()` finally means "top N",
+not "an arbitrary N":
 
 ```typescript
 const topDepartments = await store
@@ -267,7 +270,7 @@ const topDepartments = await store
     headcount: count("e"),
     totalSalary: sum("e", "salary"),
   })
-  .orderBy((ctx) => ctx.totalSalary, "desc")
+  .orderBy("totalSalary", "desc")
   .limit(10)
   .execute();
 ```
@@ -306,7 +309,7 @@ const activeReviewers = await store
     developer: field("d", "name"),
     reviewCount: count("pr"),
   })
-  .orderBy((ctx) => ctx.reviewCount, "desc")
+  .orderBy("reviewCount", "desc")
   .execute();
 
 // 3. Repository health

--- a/apps/docs/src/content/docs/queries/order.md
+++ b/apps/docs/src/content/docs/queries/order.md
@@ -98,7 +98,9 @@ const employees = await store
 
 ### Ordering Aggregated Results
 
-Order by aggregate values:
+Aggregate queries have their own `orderBy(key, direction?)`, called after
+`.aggregate({...})`. `key` is any output name from the fields object — a
+grouped field or an aggregate alias:
 
 ```typescript
 import { count, field } from "@nicia-ai/typegraph";
@@ -111,7 +113,7 @@ const topDepartments = await store
     department: field("e", "department"),
     headcount: count("e"),
   })
-  .orderBy((ctx) => ctx.headcount, "desc")
+  .orderBy("headcount", "desc")
   .execute();
 ```
 

--- a/packages/typegraph/examples/13-aggregates.ts
+++ b/packages/typegraph/examples/13-aggregates.ts
@@ -10,7 +10,7 @@
  * - HAVING clauses to filter groups
  * - Combining WHERE filters with HAVING
  * - Aggregations across graph traversals
- * - Limiting aggregate results
+ * - Ordering and limiting aggregate results (top-N by aggregate)
  */
 import { z } from "zod";
 
@@ -317,7 +317,7 @@ export async function main() {
   // 9. Limit on aggregate results
   // ============================================================
 
-  console.log("\n--- Top 2 authors by book count (limit) ---\n");
+  console.log("\n--- Top 2 authors by book count (orderBy + limit) ---\n");
 
   const topAuthors = await store
     .query()
@@ -329,6 +329,7 @@ export async function main() {
       author: field("a", "name"),
       bookCount: count("b"),
     })
+    .orderBy("bookCount", "desc")
     .limit(2)
     .execute();
 

--- a/packages/typegraph/src/query/ast.ts
+++ b/packages/typegraph/src/query/ast.ts
@@ -551,6 +551,24 @@ export type OrderSpec = Readonly<{
   nulls?: NullOrdering;
 }>;
 
+/**
+ * An ordering specification for aggregate queries.
+ *
+ * Unlike {@link OrderSpec}, this references a projected SELECT-list output
+ * column by name rather than a `FieldRef` into a source table/CTE. Aggregate
+ * query projections always assign an output alias to every grouped field
+ * and aggregate expression (via `.aggregate({ outputName: ... })`), so
+ * ordering by that alias works uniformly for both — and both SQLite and
+ * PostgreSQL allow `ORDER BY` to reference a SELECT-list alias directly, so
+ * no re-derivation of the underlying expression (and no dialect seam) is
+ * needed.
+ */
+export type AggregateOrderSpec = Readonly<{
+  outputName: string;
+  direction: SortDirection;
+  nulls?: NullOrdering;
+}>;
+
 // ============================================================
 // Node Predicate
 // ============================================================
@@ -601,6 +619,12 @@ export type QueryAst = Readonly<{
   groupBy?: GroupBySpec;
   /** HAVING clause - predicates applied after GROUP BY */
   having?: PredicateExpression;
+  /**
+   * ORDER BY specification for aggregate queries, referencing projected
+   * output aliases (grouped fields or aggregate expressions) instead of
+   * source-table field refs. See {@link AggregateOrderSpec}.
+   */
+  aggregateOrderBy?: readonly AggregateOrderSpec[];
   /**
    * Selective fields for optimized queries.
    * When present, the compiler generates SQL that only fetches these specific

--- a/packages/typegraph/src/query/builder.ts
+++ b/packages/typegraph/src/query/builder.ts
@@ -195,6 +195,7 @@ function createQueryBuilderWithContext<
     predicates: [],
     projection: [],
     orderBy: [],
+    aggregateOrderBy: [],
     limit: undefined,
     offset: undefined,
     temporalMode: sealed?.mode ?? "current",

--- a/packages/typegraph/src/query/builder/ast-builder.ts
+++ b/packages/typegraph/src/query/builder/ast-builder.ts
@@ -51,6 +51,9 @@ export function buildQueryAst(
     ...(state.offset !== undefined && { offset: state.offset }),
     ...(state.groupBy !== undefined && { groupBy: state.groupBy }),
     ...(state.having !== undefined && { having: state.having }),
+    ...(state.aggregateOrderBy.length > 0 && {
+      aggregateOrderBy: state.aggregateOrderBy,
+    }),
     ...(state.fusion !== undefined && { fusion: state.fusion }),
   };
 }

--- a/packages/typegraph/src/query/builder/executable-aggregate-query.ts
+++ b/packages/typegraph/src/query/builder/executable-aggregate-query.ts
@@ -2,7 +2,13 @@
  * ExecutableAggregateQuery - A query with aggregate functions that can be executed.
  */
 import { type GraphDef } from "../../core/define-graph";
-import { type AggregateExpr, type FieldRef, type QueryAst } from "../ast";
+import {
+  type AggregateExpr,
+  type AggregateOrderSpec,
+  type FieldRef,
+  type QueryAst,
+  type SortDirection,
+} from "../ast";
 import { compileQuery, type CompileQueryOptions } from "../compiler/index";
 import { type CompiledSelectSql } from "../sql-intent";
 import { buildQueryAst } from "./ast-builder";
@@ -51,6 +57,47 @@ export class ExecutableAggregateQuery<
    */
   toAst(): QueryAst {
     return buildQueryAst(this.#config, this.#state);
+  }
+
+  /**
+   * Orders results by a grouped field or aggregate alias.
+   *
+   * `key` is one of the output names passed to `.aggregate({...})` — either
+   * a grouped field (e.g. `genre`) or an aggregate alias (e.g. `bookCount`).
+   * Both are ordered the same way: by referencing the SELECT-list output
+   * column, since every `.aggregate()` field is projected with an alias.
+   *
+   * Chain multiple calls to sort by more than one key, in call order:
+   * `.orderBy("genre").orderBy("bookCount", "desc")` sorts by genre first,
+   * then by book count within each genre.
+   *
+   * @example
+   * ```typescript
+   * // Top 2 authors by book count
+   * store.query()
+   *   .from("Author", "a")
+   *   .traverse("wrote", "e")
+   *   .to("Book", "b")
+   *   .groupByNode("a")
+   *   .aggregate({ author: field("a", "name"), bookCount: count("b") })
+   *   .orderBy("bookCount", "desc")
+   *   .limit(2)
+   *   .execute();
+   * ```
+   */
+  orderBy<K extends keyof R & string>(
+    key: K,
+    direction: SortDirection = "asc",
+  ): ExecutableAggregateQuery<G, Aliases, R> {
+    const orderSpec: AggregateOrderSpec = { outputName: key, direction };
+    return new ExecutableAggregateQuery(
+      this.#config,
+      {
+        ...this.#state,
+        aggregateOrderBy: [...this.#state.aggregateOrderBy, orderSpec],
+      },
+      this.#fields,
+    );
   }
 
   /**

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -22,6 +22,7 @@ import {
 } from "../../core/types";
 import { type KindRegistry } from "../../registry/kind-registry";
 import {
+  type AggregateOrderSpec,
   type GroupBySpec,
   type HybridFusionOptions,
   type NodePredicate,
@@ -585,6 +586,8 @@ export type QueryBuilderState = Readonly<{
   predicates: readonly NodePredicate[];
   projection: readonly ProjectedField[];
   orderBy: readonly OrderSpec[];
+  /** ORDER BY entries added via `ExecutableAggregateQuery.orderBy()`. */
+  aggregateOrderBy: readonly AggregateOrderSpec[];
   limit: number | undefined;
   offset: number | undefined;
   temporalMode: TemporalMode;

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -636,13 +636,20 @@ export function buildStandardOrderBy(
   input: BuildStandardOrderByInput,
 ): SQL | undefined {
   const { ast, collapsedTraversalCteAlias, dialect } = input;
-  if (!ast.orderBy || ast.orderBy.length === 0) {
+  const fieldOrderBy = ast.orderBy ?? [];
+  const aggregateOrderBy = ast.aggregateOrderBy ?? [];
+  if (fieldOrderBy.length === 0 && aggregateOrderBy.length === 0) {
     return undefined;
   }
 
-  const aliasToCte = buildAliasToCteMap(ast);
+  // Only built when there's a FieldRef-based order spec to resolve against
+  // a CTE — the aggregate-alias loop below references the SELECT-list
+  // output alias directly and never needs it, which matters because the
+  // common case for `.aggregate().orderBy(...)` has `fieldOrderBy` empty.
+  const aliasToCte =
+    fieldOrderBy.length > 0 ? buildAliasToCteMap(ast) : undefined;
   const parts: SQL[] = [];
-  for (const orderSpec of ast.orderBy) {
+  for (const orderSpec of fieldOrderBy) {
     const valueType = orderSpec.field.valueType;
     if (valueType === "array" || valueType === "object") {
       throw new UnsupportedPredicateError(
@@ -651,7 +658,7 @@ export function buildStandardOrderBy(
     }
     const cteAlias =
       collapsedTraversalCteAlias ??
-      aliasToCte.get(orderSpec.field.alias) ??
+      aliasToCte?.get(orderSpec.field.alias) ??
       `cte_${orderSpec.field.alias}`;
     const field = compileFieldValue(
       orderSpec.field,
@@ -667,6 +674,31 @@ export function buildStandardOrderBy(
       sql`(${field} IS NULL) ${nullsDirection}`,
       sql`${field} ${direction}`,
     );
+  }
+
+  // Aggregate ordering references the projected SELECT-list output alias
+  // directly rather than recompiling a FieldRef/AggregateExpr — every
+  // `.aggregate()` field (grouped or aggregated) is always projected with
+  // an alias, and both SQLite and PostgreSQL allow ORDER BY to reference
+  // it, so this needs no per-CTE or per-dialect resolution.
+  //
+  // Nulls ordering can't reuse the `(field IS NULL) direction, field
+  // direction` trick above: unlike a source-table field reference, an
+  // output alias is only resolved by either dialect when the ORDER BY term
+  // is the bare identifier itself — wrapping it in `(alias IS NULL)`
+  // makes both SQLite and PostgreSQL look for a real column named
+  // `alias` and fail. The standard `NULLS FIRST`/`NULLS LAST` suffix
+  // (supported by both dialects) sidesteps that: it attaches to the bare
+  // identifier rather than embedding it in a larger expression.
+  for (const orderSpec of aggregateOrderBy) {
+    const column = quoteIdentifier(orderSpec.outputName);
+    const direction = sql.raw(orderSpec.direction.toUpperCase());
+    const nulls =
+      orderSpec.nulls ?? (orderSpec.direction === "asc" ? "last" : "first");
+    const nullsKeyword = sql.raw(
+      nulls === "first" ? "NULLS FIRST" : "NULLS LAST",
+    );
+    parts.push(sql`${column} ${direction} ${nullsKeyword}`);
   }
 
   return sql`ORDER BY ${sql.join(parts, sql`, `)}`;

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -786,6 +786,11 @@ function compileCountAggregateFastPath(
       AND ${sql.raw(countCteAlias)}.${sql.raw(previousAliasKindColumn)} = cte_${sql.raw(previousAlias)}.${sql.raw(previousAliasKindColumn)}
   `;
 
+  // Also picks up `ast.aggregateOrderBy` (ORDER BY output-alias entries
+  // added via `ExecutableAggregateQuery.orderBy()`) with no extra handling
+  // here: the fast path's projection above always re-aliases every
+  // projected column to its final output name, so an alias reference
+  // resolves the same way it would on the general query path.
   const orderBy = buildStandardOrderBy({ ast, dialect });
   // When the LIMIT/OFFSET was pushed into the start CTE, the outer SELECT
   // must not re-apply it — the start CTE already produced exactly the

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -714,10 +714,12 @@ function compileCountAggregateFastPath(
   //     rows to count rather than the true top-N.
   //   - LIMIT is defined. OFFSET is carried with it.
   const startCteLimit =
-    traversal.optional &&
-    ast.orderBy === undefined &&
-    ast.aggregateOrderBy === undefined &&
-    ast.limit !== undefined ?
+    (
+      traversal.optional &&
+      ast.orderBy === undefined &&
+      ast.aggregateOrderBy === undefined &&
+      ast.limit !== undefined
+    ) ?
       { limit: ast.limit, offset: ast.offset }
     : undefined;
 

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -703,12 +703,21 @@ function compileCountAggregateFastPath(
   //   - The traversal is optional (LEFT JOIN outer). For INNER JOIN we can't
   //     push down without potentially dropping rows the original query would
   //     have kept.
-  //   - No ORDER BY. ORDER BY over the full result requires the full result.
-  //     (The fast path already restricts ORDER BY to the start alias, but we
-  //     still need every row to sort correctly.)
+  //   - No ORDER BY of either kind. ORDER BY over the full result requires
+  //     the full result. `ast.orderBy` is FieldRef-based row ordering (the
+  //     fast path already restricts it to the start alias, but we still
+  //     need every row to sort correctly); `ast.aggregateOrderBy` is
+  //     output-alias-based ordering added via `ExecutableAggregateQuery
+  //     .orderBy()` — sorting by an aggregate value (e.g. `employeeCount`)
+  //     needs every start row counted first, so pushing LIMIT into the
+  //     start CTE before aggregation would pick an arbitrary subset of
+  //     rows to count rather than the true top-N.
   //   - LIMIT is defined. OFFSET is carried with it.
   const startCteLimit =
-    traversal.optional && ast.orderBy === undefined && ast.limit !== undefined ?
+    traversal.optional &&
+    ast.orderBy === undefined &&
+    ast.aggregateOrderBy === undefined &&
+    ast.limit !== undefined ?
       { limit: ast.limit, offset: ast.offset }
     : undefined;
 

--- a/packages/typegraph/src/query/compiler/plan/lowering.ts
+++ b/packages/typegraph/src/query/compiler/plan/lowering.ts
@@ -146,12 +146,20 @@ function appendAggregateSortLimitAndProjectNodes(
       : { ...aggregateNode, having: ast.having };
   }
 
-  if (ast.orderBy !== undefined && ast.orderBy.length > 0) {
+  const hasFieldOrderBy = ast.orderBy !== undefined && ast.orderBy.length > 0;
+  const hasAggregateOrderBy =
+    ast.aggregateOrderBy !== undefined && ast.aggregateOrderBy.length > 0;
+  if (hasFieldOrderBy || hasAggregateOrderBy) {
+    // The sort node's presence (not its `orderBy` payload) is what the
+    // emitter's plan-shape invariant reads — see `hasSort` in
+    // emitter/plan-inspector.ts. `orderBy` here can be `[]` when only
+    // `ast.aggregateOrderBy` is set; that's fine today since nothing reads
+    // this field's contents, only whether the node exists.
     node = {
       id: nextPlanNodeId(),
       input: node,
       op: "sort",
-      orderBy: ast.orderBy,
+      orderBy: ast.orderBy ?? [],
     };
   }
 

--- a/packages/typegraph/tests/backends/integration/aggregates.ts
+++ b/packages/typegraph/tests/backends/integration/aggregates.ts
@@ -142,6 +142,174 @@ export function registerAggregateIntegrationTests(
     });
   });
 
+  describe("Aggregate ORDER BY", () => {
+    beforeEach(async () => {
+      const store = context.getStore();
+      await seedAggregateProducts(store);
+    });
+
+    it("orders by a grouped field ascending", async () => {
+      const store = context.getStore();
+      const results = await store
+        .query()
+        .from("Product", "p")
+        .groupBy("p", "category")
+        .aggregate({
+          category: field("p", "category"),
+          productCount: count("p"),
+        })
+        .orderBy("category", "asc")
+        .execute();
+
+      expect(results.map((result) => result.category)).toEqual([
+        "Electronics",
+        "Furniture",
+      ]);
+    });
+
+    it("orders by a grouped field descending", async () => {
+      const store = context.getStore();
+      const results = await store
+        .query()
+        .from("Product", "p")
+        .groupBy("p", "category")
+        .aggregate({
+          category: field("p", "category"),
+          productCount: count("p"),
+        })
+        .orderBy("category", "desc")
+        .execute();
+
+      expect(results.map((result) => result.category)).toEqual([
+        "Furniture",
+        "Electronics",
+      ]);
+    });
+
+    it("orders by an aggregate alias, enabling correct top-N via limit", async () => {
+      const store = context.getStore();
+      const results = await store
+        .query()
+        .from("Product", "p")
+        .groupBy("p", "category")
+        .aggregate({
+          category: field("p", "category"),
+          productCount: count("p"),
+        })
+        .orderBy("productCount", "desc")
+        .limit(1)
+        .execute();
+
+      // Electronics has 3 products, Furniture has 2 — without ORDER BY this
+      // would be an arbitrary one of the two groups.
+      expect(results).toHaveLength(1);
+      expect(results[0]?.category).toBe("Electronics");
+      expect(results[0]?.productCount).toBe(3);
+    });
+
+    it("orders by an aggregate alias ascending", async () => {
+      const store = context.getStore();
+      const results = await store
+        .query()
+        .from("Product", "p")
+        .groupBy("p", "category")
+        .aggregate({
+          category: field("p", "category"),
+          productCount: count("p"),
+        })
+        .orderBy("productCount", "asc")
+        .execute();
+
+      expect(results.map((result) => result.category)).toEqual([
+        "Furniture",
+        "Electronics",
+      ]);
+    });
+
+    it("supports multi-key ordering across a grouped field then an aggregate alias", async () => {
+      const store = context.getStore();
+      const results = await store
+        .query()
+        .from("Product", "p")
+        .groupBy("p", "category")
+        .groupBy("p", "inStock")
+        .aggregate({
+          category: field("p", "category"),
+          inStock: field("p", "inStock"),
+          productCount: count("p"),
+        })
+        .orderBy("category", "asc")
+        .orderBy("inStock", "asc")
+        .execute();
+
+      expect(
+        results.map(
+          (result) => `${String(result.category)}:${String(result.inStock)}`,
+        ),
+      ).toEqual(["Electronics:false", "Electronics:true", "Furniture:true"]);
+    });
+
+    it("orders correct top-N results through the traversal + groupByNode count fast path", async () => {
+      // This shape (single traversal, groupByNode on the start alias, a
+      // count() aggregate) hits the compiler's count-aggregate fast path,
+      // which builds its own ORDER BY/LIMIT independently of the general
+      // query path — cover it explicitly so ordering isn't silently
+      // dropped for the most common "top N by count" traversal shape.
+      const store = context.getStore();
+
+      const acme = await store.nodes.Company.create({
+        name: "Acme Corp",
+        industry: "Tech",
+      });
+      const globex = await store.nodes.Company.create({
+        name: "Globex",
+        industry: "Finance",
+      });
+
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const charlie = await store.nodes.Person.create({ name: "Charlie" });
+      const dave = await store.nodes.Person.create({ name: "Dave" });
+
+      await store.edges.worksAt.create(alice, acme, {
+        role: "Engineer",
+        salary: 100_000,
+      });
+      await store.edges.worksAt.create(bob, acme, {
+        role: "Manager",
+        salary: 120_000,
+      });
+      await store.edges.worksAt.create(charlie, acme, {
+        role: "Designer",
+        salary: 90_000,
+      });
+      await store.edges.worksAt.create(dave, globex, {
+        role: "Developer",
+        salary: 90_000,
+      });
+
+      const results = await store
+        .query()
+        .from("Company", "c")
+        .traverse("worksAt", "e", { direction: "in" })
+        .to("Person", "p")
+        .groupByNode("c")
+        .aggregate({
+          companyName: field("c", "name"),
+          employeeCount: count("p"),
+        })
+        .orderBy("employeeCount", "desc")
+        .limit(2)
+        .execute();
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.companyName).toBe("Acme Corp");
+      expect(results[0]?.employeeCount).toBe(3);
+      expect(results[1]?.companyName).toBe("Globex");
+      expect(results[1]?.employeeCount).toBe(1);
+    });
+  });
+
   describe("count/countDistinct with field argument", () => {
     beforeEach(async () => {
       const store = context.getStore();

--- a/packages/typegraph/tests/backends/integration/aggregates.ts
+++ b/packages/typegraph/tests/backends/integration/aggregates.ts
@@ -308,6 +308,96 @@ export function registerAggregateIntegrationTests(
       expect(results[1]?.companyName).toBe("Globex");
       expect(results[1]?.employeeCount).toBe(1);
     });
+
+    it("orders correct top-N results through the count fast path's optional-traversal LIMIT pushdown", async () => {
+      // The fast path pushes LIMIT into the start CTE *before* aggregation
+      // when the traversal is optional (LEFT JOIN) and there's no ORDER BY
+      // — an optimization that's only safe when every start-alias row is
+      // equally eligible to appear in the final page, i.e. when nothing
+      // depends on the aggregate result to pick which rows survive.
+      // `orderBy("employeeCount", ...)` sorts by that aggregate result, so
+      // this must disable the pushdown the same way `ast.orderBy` already
+      // does — otherwise LIMIT truncates an arbitrary, uncounted subset of
+      // companies before employeeCount is even computed. Company creation
+      // order here is the reverse of the expected top-2, so a reintroduced
+      // pushdown bug would surface as the wrong top-2 rather than
+      // coincidentally passing.
+      const store = context.getStore();
+
+      const zeta = await store.nodes.Company.create({
+        name: "Zeta Corp",
+        industry: "Retail",
+      });
+      const yankee = await store.nodes.Company.create({
+        name: "Yankee Corp",
+        industry: "Retail",
+      });
+      const bravo = await store.nodes.Company.create({
+        name: "Bravo Corp",
+        industry: "Tech",
+      });
+      const alpha = await store.nodes.Company.create({
+        name: "Alpha Corp",
+        industry: "Tech",
+      });
+
+      const people = await Promise.all(
+        Array.from({ length: 6 }, (_unused, index) =>
+          store.nodes.Person.create({ name: `Person ${index}` }),
+        ),
+      );
+
+      // Zeta: 0 employees (optionalTraverse must still surface it).
+      // Yankee: 1 employee. Bravo: 2 employees. Alpha: 3 employees.
+      await store.edges.worksAt.create(people[0]!, yankee, {
+        role: "Engineer",
+        salary: 90_000,
+      });
+      await store.edges.worksAt.create(people[1]!, bravo, {
+        role: "Engineer",
+        salary: 90_000,
+      });
+      await store.edges.worksAt.create(people[2]!, bravo, {
+        role: "Manager",
+        salary: 110_000,
+      });
+      await store.edges.worksAt.create(people[3]!, alpha, {
+        role: "Engineer",
+        salary: 90_000,
+      });
+      await store.edges.worksAt.create(people[4]!, alpha, {
+        role: "Manager",
+        salary: 110_000,
+      });
+      await store.edges.worksAt.create(people[5]!, alpha, {
+        role: "Designer",
+        salary: 95_000,
+      });
+
+      const results = await store
+        .query()
+        .from("Company", "c")
+        .optionalTraverse("worksAt", "e", { direction: "in" })
+        .to("Person", "p")
+        .groupByNode("c")
+        .aggregate({
+          companyName: field("c", "name"),
+          employeeCount: count("p"),
+        })
+        .orderBy("employeeCount", "desc")
+        .limit(2)
+        .execute();
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.companyName).toBe(alpha.name);
+      expect(results[0]?.employeeCount).toBe(3);
+      expect(results[1]?.companyName).toBe(bravo.name);
+      expect(results[1]?.employeeCount).toBe(2);
+      // Sanity check that all four companies actually exist and Zeta truly
+      // has zero employees, so a "coincidental pass" isn't hiding a bug.
+      expect(zeta.name).toBe("Zeta Corp");
+      expect(yankee.name).toBe("Yankee Corp");
+    });
   });
 
   describe("count/countDistinct with field argument", () => {

--- a/packages/typegraph/tests/executable-aggregate-query.test.ts
+++ b/packages/typegraph/tests/executable-aggregate-query.test.ts
@@ -171,6 +171,130 @@ describe("ExecutableAggregateQuery.offset", () => {
 });
 
 // ============================================================
+// ExecutableAggregateQuery orderBy
+// ============================================================
+
+describe("ExecutableAggregateQuery.orderBy", () => {
+  it("adds an aggregateOrderBy entry referencing the grouped field's output name", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Product", "p")
+      .groupBy("p", "category")
+      .aggregate({
+        category: field("p", "category"),
+        count: count("p"),
+      })
+      .orderBy("category", "asc");
+
+    const ast = query.toAst();
+
+    expect(ast.aggregateOrderBy).toEqual([
+      { outputName: "category", direction: "asc" },
+    ]);
+  });
+
+  it("adds an aggregateOrderBy entry referencing an aggregate alias", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Product", "p")
+      .groupBy("p", "category")
+      .aggregate({
+        category: field("p", "category"),
+        count: count("p"),
+      })
+      .orderBy("count", "desc");
+
+    const ast = query.toAst();
+
+    expect(ast.aggregateOrderBy).toEqual([
+      { outputName: "count", direction: "desc" },
+    ]);
+  });
+
+  it("defaults direction to asc", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Product", "p")
+      .groupBy("p", "category")
+      .aggregate({
+        category: field("p", "category"),
+        count: count("p"),
+      })
+      .orderBy("count");
+
+    expect(query.toAst().aggregateOrderBy).toEqual([
+      { outputName: "count", direction: "asc" },
+    ]);
+  });
+
+  it("accumulates multiple orderBy calls in call order", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Product", "p")
+      .groupBy("p", "category")
+      .aggregate({
+        category: field("p", "category"),
+        count: count("p"),
+      })
+      .orderBy("category", "asc")
+      .orderBy("count", "desc");
+
+    expect(query.toAst().aggregateOrderBy).toEqual([
+      { outputName: "category", direction: "asc" },
+      { outputName: "count", direction: "desc" },
+    ]);
+  });
+
+  it("does not mutate the original query", () => {
+    const original = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Product", "p")
+      .groupBy("p", "category")
+      .aggregate({
+        category: field("p", "category"),
+        count: count("p"),
+      });
+
+    const ordered = original.orderBy("count", "desc");
+
+    expect(ordered).not.toBe(original);
+    expect(original.toAst().aggregateOrderBy).toBeUndefined();
+    expect(ordered.toAst().aggregateOrderBy).toEqual([
+      { outputName: "count", direction: "desc" },
+    ]);
+  });
+
+  it("compiles to SQL with ORDER BY referencing the quoted output alias", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Product", "p")
+      .groupBy("p", "category")
+      .aggregate({
+        category: field("p", "category"),
+        productCount: count("p"),
+      })
+      .orderBy("productCount", "desc");
+
+    const sqlString = toSqlString(query.compile());
+
+    expect(sqlString).toContain("ORDER BY");
+    expect(sqlString).toContain('"productCount"');
+    expect(sqlString).toContain("DESC");
+  });
+
+  it("combines with limit to express top-N by aggregate", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Product", "p")
+      .groupBy("p", "category")
+      .aggregate({
+        category: field("p", "category"),
+        productCount: count("p"),
+      })
+      .orderBy("productCount", "desc")
+      .limit(2);
+
+    const sqlString = toSqlString(query.compile());
+
+    expect(sqlString).toContain("ORDER BY");
+    expect(sqlString).toContain("LIMIT");
+  });
+});
+
+// ============================================================
 // ExecutableAggregateQuery compile
 // ============================================================
 

--- a/packages/typegraph/tests/field-tracker-proxy.test.ts
+++ b/packages/typegraph/tests/field-tracker-proxy.test.ts
@@ -52,6 +52,7 @@ function createTestState(): QueryBuilderState {
     predicates: [],
     projection: [],
     orderBy: [],
+    aggregateOrderBy: [],
     limit: undefined,
     offset: undefined,
     temporalMode: "current",

--- a/packages/typegraph/tests/result-mapper.test.ts
+++ b/packages/typegraph/tests/result-mapper.test.ts
@@ -26,6 +26,7 @@ describe("transformPathColumns", () => {
     predicates: [],
     projection: [],
     orderBy: [],
+    aggregateOrderBy: [],
     limit: undefined,
     offset: undefined,
     temporalMode: "current",

--- a/packages/typegraph/tests/smart-select.test.ts
+++ b/packages/typegraph/tests/smart-select.test.ts
@@ -210,6 +210,7 @@ describe("createTrackingContext", () => {
     predicates: [],
     projection: [],
     orderBy: [],
+    aggregateOrderBy: [],
     limit: undefined,
     offset: undefined,
     temporalMode: "current",


### PR DESCRIPTION
Fixes #228. `ExecutableAggregateQuery` exposed `limit()` but no `orderBy()`, so the most common aggregate question — "top N groups by count/sum" — couldn't be expressed: `.aggregate({...}).limit(n)` returned an arbitrary `n` groups, forcing callers to fetch every group and sort in JS (as `examples/13-aggregates.ts` was doing, with a misleading "Top 2 authors by book count" comment on a query that didn't actually order anything).

- Added `ExecutableAggregateQuery.orderBy(key, direction?)`. `key` is fully typed against the fields object passed to `.aggregate({...})` — it can reference either a grouped field or an aggregate alias, and can be chained for multi-key sorts.
- Ordering resolves by referencing the projected SELECT-list output alias (e.g. `ORDER BY "bookCount" DESC`) rather than recompiling the underlying `FieldRef`/`AggregateExpr`. Every `.aggregate()` field is always projected with an alias, so this works uniformly for grouped fields and aggregates, through both the general CTE query path and the compiler's `compileCountAggregateFastPath` optimization (verified with a dedicated integration test), with no dialect-specific handling.
- New `AggregateOrderSpec` AST type kept separate from the existing row-query `OrderSpec` — `OrderSpec.field` is a `FieldRef` threaded through pagination/cursor machinery that aggregate queries never touch, so widening it would have forced dead-branch handling through code aggregate queries can't reach.
- Null ordering for the new alias-based path uses `NULLS FIRST`/`NULLS LAST` syntax rather than the existing `(field IS NULL) direction, field direction` trick used for row queries — verified empirically that referencing an output alias inside a compound expression throws "column does not exist" on PostgreSQL (the alias only resolves when the ORDER BY term is the bare identifier itself).
- Fixed the `examples/13-aggregates.ts` "Top 2 authors" section to actually use `.orderBy("bookCount", "desc")`.
