### PR TITLE
docs(examples): strengthen the example suite — defect fixes, rewrites, three new examples, lint coverage

### DIFF
--- a/packages/typegraph/eslint.config.mjs
+++ b/packages/typegraph/eslint.config.mjs
@@ -42,7 +42,6 @@ const DETERMINISM_RESTRICTIONS = [
 export default [
   ...createLibraryConfig(import.meta.dirname, {
     ignores: [
-      "examples/**",
       "test-d/**",
       "type-smoke/**",
       "tmp/**",
@@ -55,6 +54,21 @@ export default [
       "tests/do-sqlite/**",
     ],
   }),
+
+  // Examples are runnable teaching scripts (`npx tsx examples/NN-*.ts`) as
+  // well as importable modules, and they lint with the full library ruleset.
+  // Console output and process.exit(1) in the runner need no relaxation here:
+  // `no-console` is not enabled by the base config and
+  // `unicorn/no-process-exit` is already off globally.
+  {
+    files: ["examples/**/*.ts"],
+    rules: {
+      // Every example self-executes behind an `import.meta.url` guard so that
+      // importing it never runs it; top-level await would execute on import,
+      // which is fundamentally at odds with that runner idiom.
+      "unicorn/prefer-top-level-await": "off",
+    },
+  },
 
   // graph-merge is intentionally heavy on deterministic ordering helpers plus
   // branch-dependent assertions. Relax only STYLE-ONLY Unicorn/Vitest

--- a/packages/typegraph/examples/01-basic-usage.ts
+++ b/packages/typegraph/examples/01-basic-usage.ts
@@ -8,14 +8,14 @@
  * - Using upsert/get-or-create collection APIs
  * - Simple queries
  */
-import { z } from "zod";
-
 import {
   createStore,
-  defineGraph,
   defineEdge,
+  defineGraph,
   defineNode,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -26,7 +26,7 @@ import { createExampleBackend } from "./_helpers";
 const Person = defineNode("Person", {
   schema: z.object({
     name: z.string(),
-    email: z.string().email(),
+    email: z.email(),
     age: z.number().int().positive().optional(),
   }),
 });
@@ -95,108 +95,109 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  // Create some nodes using the collection API
-  const alice = await store.nodes.Person.create({
-    name: "Alice",
-    email: "alice@example.com",
-    age: 30,
-  });
-  console.log("Created Alice:", alice.id);
-
-  const bob = await store.nodes.Person.create({
-    name: "Bob",
-    email: "bob@example.com",
-  });
-  console.log("Created Bob:", bob.id);
-
-  const acme = await store.nodes.Company.upsertById("company:acme", {
-    name: "Acme Corp",
-    industry: "Technology",
-    founded: 2010,
-  });
-  console.log("Upserted Acme Corp by ID:", acme.id);
-
-  // Get or create by a uniqueness constraint (person_email)
-  const aliceByConstraint = await store.nodes.Person.getOrCreateByConstraint(
-    "person_email",
-    {
+  try {
+    // Create some nodes using the collection API
+    const alice = await store.nodes.Person.create({
       name: "Alice",
       email: "alice@example.com",
-      age: 31,
-    },
-    { ifExists: "update" },
-  );
-  console.log(
-    "getOrCreateByConstraint for Alice:",
-    aliceByConstraint.action,
-    aliceByConstraint.node.id,
-  );
-  console.log("Alice's age after update:", aliceByConstraint.node.age);
+      age: 30,
+    });
+    console.log("Created Alice:", alice.id);
 
-  // The person_email constraint uses caseInsensitive collation, so a
-  // differently-cased email still matches the existing Alice
-  const aliceUppercase = await store.nodes.Person.getOrCreateByConstraint(
-    "person_email",
-    {
-      name: "Alice",
-      email: "ALICE@EXAMPLE.COM",
-    },
-  );
-  console.log(
-    "getOrCreateByConstraint with ALICE@EXAMPLE.COM:",
-    aliceUppercase.action,
-    aliceUppercase.node.name,
-  );
+    const bob = await store.nodes.Person.create({
+      name: "Bob",
+      email: "bob@example.com",
+    });
+    console.log("Created Bob:", bob.id);
 
-  // Create edges by passing nodes directly
-  await store.edges.worksAt.create(aliceByConstraint.node, acme, {
-    role: "Engineer",
-    startDate: "2023-01-15",
-  });
-  console.log("Created edge: Alice worksAt Acme");
+    const acme = await store.nodes.Company.upsertById("company:acme", {
+      name: "Acme Corp",
+      industry: "Technology",
+      founded: 2010,
+    });
+    console.log("Upserted Acme Corp by ID:", acme.id);
 
-  const knowsResult = await store.edges.knows.getOrCreateByEndpoints(
-    aliceByConstraint.node,
-    bob,
-    { since: "2022-06-01" },
-    { ifExists: "return" },
-  );
-  console.log("getOrCreateByEndpoints (knows):", knowsResult.action, knowsResult.edge.id);
-
-  // Retrieve nodes by ID
-  const retrievedAlice = await store.nodes.Person.getById(aliceByConstraint.node.id);
-  console.log(
-    "\nRetrieved Alice:",
-    retrievedAlice && { name: retrievedAlice.name, email: retrievedAlice.email },
-  );
-
-  // Query using the fluent API - including edge properties
-  const results = await store
-    .query()
-    .from("Person", "p")
-    .traverse("worksAt", "e")
-    .to("Company", "c")
-    .select((ctx) => ({
-      personName: ctx.p.name,
-      companyName: ctx.c.name,
-      role: ctx.e.role,           // Access edge property
-      startDate: ctx.e.startDate, // Access optional edge property
-    }))
-    .execute();
-
-  console.log("\nQuery results (who works where):");
-  for (const row of results) {
-    console.log(
-      `  ${row.personName} works at ${row.companyName} as ${row.role} since ${row.startDate}`,
+    // Get or create by a uniqueness constraint (person_email)
+    const aliceByConstraint = await store.nodes.Person.getOrCreateByConstraint(
+      "person_email",
+      {
+        name: "Alice",
+        email: "alice@example.com",
+        age: 31,
+      },
+      { ifExists: "update" },
     );
-  }
+    console.log(
+      "getOrCreateByConstraint for Alice:",
+      aliceByConstraint.action,
+      aliceByConstraint.node.id,
+    );
+    console.log("Alice's age after update:", aliceByConstraint.node.age);
 
-  // Clean up
-  await backend.close();
+    // The person_email constraint uses caseInsensitive collation, so a
+    // differently-cased email still matches the existing Alice
+    const aliceUppercase = await store.nodes.Person.getOrCreateByConstraint(
+      "person_email",
+      {
+        name: "Alice",
+        email: "ALICE@EXAMPLE.COM",
+      },
+    );
+    console.log(
+      "getOrCreateByConstraint with ALICE@EXAMPLE.COM:",
+      aliceUppercase.action,
+      aliceUppercase.node.name,
+    );
+
+    // Create edges by passing nodes directly
+    await store.edges.worksAt.create(aliceByConstraint.node, acme, {
+      role: "Engineer",
+      startDate: "2023-01-15",
+    });
+    console.log("Created edge: Alice worksAt Acme");
+
+    const knowsResult = await store.edges.knows.getOrCreateByEndpoints(
+      aliceByConstraint.node,
+      bob,
+      { since: "2022-06-01" },
+      { ifExists: "return" },
+    );
+    console.log("getOrCreateByEndpoints (knows):", knowsResult.action, knowsResult.edge.id);
+
+    // Retrieve nodes by ID
+    const retrievedAlice = await store.nodes.Person.getById(aliceByConstraint.node.id);
+    console.log(
+      "\nRetrieved Alice:",
+      retrievedAlice && { name: retrievedAlice.name, email: retrievedAlice.email },
+    );
+
+    // Query using the fluent API - including edge properties
+    const results = await store
+      .query()
+      .from("Person", "p")
+      .traverse("worksAt", "e")
+      .to("Company", "c")
+      .select((ctx) => ({
+        personName: ctx.p.name,
+        companyName: ctx.c.name,
+        role: ctx.e.role,           // Access edge property
+        startDate: ctx.e.startDate, // Access optional edge property
+      }))
+      .execute();
+
+    console.log("\nQuery results (who works where):");
+    for (const row of results) {
+      console.log(
+        `  ${row.personName} works at ${row.companyName} as ${row.role} since ${row.startDate}`,
+      );
+    }
+  } finally {
+    await backend.close();
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/01-basic-usage.ts
+++ b/packages/typegraph/examples/01-basic-usage.ts
@@ -131,6 +131,22 @@ export async function main() {
     aliceByConstraint.action,
     aliceByConstraint.node.id,
   );
+  console.log("Alice's age after update:", aliceByConstraint.node.age);
+
+  // The person_email constraint uses caseInsensitive collation, so a
+  // differently-cased email still matches the existing Alice
+  const aliceUppercase = await store.nodes.Person.getOrCreateByConstraint(
+    "person_email",
+    {
+      name: "Alice",
+      email: "ALICE@EXAMPLE.COM",
+    },
+  );
+  console.log(
+    "getOrCreateByConstraint with ALICE@EXAMPLE.COM:",
+    aliceUppercase.action,
+    aliceUppercase.node.name,
+  );
 
   // Create edges by passing nodes directly
   await store.edges.worksAt.create(aliceByConstraint.node, acme, {
@@ -170,7 +186,9 @@ export async function main() {
 
   console.log("\nQuery results (who works where):");
   for (const row of results) {
-    console.log(`  ${row.personName} works at ${row.companyName} as ${row.role}`);
+    console.log(
+      `  ${row.personName} works at ${row.companyName} as ${row.role} since ${row.startDate}`,
+    );
   }
 
   // Clean up

--- a/packages/typegraph/examples/02-schema-validation.ts
+++ b/packages/typegraph/examples/02-schema-validation.ts
@@ -6,15 +6,15 @@
  * - Provide type safety at compile time
  * - Handle validation errors gracefully
  */
-import { z } from "zod";
-
 import {
   createStore,
-  defineGraph,
   defineEdge,
+  defineGraph,
   defineNode,
   ValidationError,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -29,7 +29,7 @@ const User = defineNode("User", {
       .min(3, "Username must be at least 3 characters")
       .max(20, "Username must be at most 20 characters")
       .regex(/^[a-z0-9_]+$/, "Username can only contain lowercase letters, numbers, and underscores"),
-    email: z.string().email("Invalid email format"),
+    email: z.email("Invalid email format"),
     age: z
       .number()
       .int("Age must be an integer")
@@ -61,7 +61,7 @@ const purchased = defineEdge("purchased", {
   schema: z.object({
     quantity: z.number().int().positive("Quantity must be a positive integer"),
     priceAtPurchase: z.number().positive(),
-    purchasedAt: z.string().datetime("Must be ISO datetime"),
+    purchasedAt: z.iso.datetime("Must be ISO datetime"),
   }),
 });
 
@@ -98,132 +98,134 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  console.log("=== Schema Validation Examples ===\n");
-
-  // 1. Valid node creation
-  console.log("1. Creating valid user...");
-  const user = await store.nodes.User.create({
-    username: "alice_dev",
-    email: "alice@example.com",
-    age: 28,
-    role: "admin",
-    tags: ["developer", "team-lead"],
-  });
-  console.log("   Created user:", user.username);
-
-  // 2. Invalid username - too short
-  console.log("\n2. Trying invalid username (too short)...");
   try {
-    await store.nodes.User.create({
-      username: "ab", // Too short!
-      email: "ab@example.com",
+    console.log("=== Schema Validation Examples ===\n");
+
+    // 1. Valid node creation
+    console.log("1. Creating valid user...");
+    const user = await store.nodes.User.create({
+      username: "alice_dev",
+      email: "alice@example.com",
+      age: 28,
+      role: "admin",
+      tags: ["developer", "team-lead"],
     });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      printValidationIssues(error);
-    } else {
-      throw error;
-    }
-  }
+    console.log("   Created user:", user.username);
 
-  // 3. Invalid email format
-  console.log("\n3. Trying invalid email...");
-  try {
-    await store.nodes.User.create({
-      username: "bob_test",
-      email: "not-an-email", // Invalid!
+    // 2. Invalid username - too short
+    console.log("\n2. Trying invalid username (too short)...");
+    try {
+      await store.nodes.User.create({
+        username: "ab", // Too short!
+        email: "ab@example.com",
+      });
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        printValidationIssues(error);
+      } else {
+        throw error;
+      }
+    }
+
+    // 3. Invalid email format
+    console.log("\n3. Trying invalid email...");
+    try {
+      await store.nodes.User.create({
+        username: "bob_test",
+        email: "not-an-email", // Invalid!
+      });
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        printValidationIssues(error);
+      } else {
+        throw error;
+      }
+    }
+
+    // 4. Invalid SKU format
+    console.log("\n4. Trying invalid product SKU...");
+    try {
+      await store.nodes.Product.create({
+        sku: "invalid-sku", // Doesn't match pattern!
+        name: "Widget",
+        price: 9.99,
+        categories: ["widgets"],
+      });
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        printValidationIssues(error);
+      } else {
+        throw error;
+      }
+    }
+
+    // 5. Valid product
+    console.log("\n5. Creating valid product...");
+    const product = await store.nodes.Product.create({
+      sku: "WDG-12345",
+      name: "Super Widget",
+      price: 29.99,
+      currency: "USD",
+      categories: ["widgets", "tools"],
     });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      printValidationIssues(error);
-    } else {
-      throw error;
+    console.log("   Created product:", product.name);
+
+    // 6. Invalid edge - negative quantity
+    // Note: Edges can be created using either:
+    // - Node objects directly: store.edges.purchased.create(user, product, {...})
+    // - NodeRef objects: store.edges.purchased.create({ kind: "User", id: user.id }, ...)
+    // Both forms are equivalent. NodeRef is useful when you only have the ID.
+    console.log("\n6. Trying invalid purchase (negative quantity)...");
+    try {
+      await store.edges.purchased.create(
+        { kind: "User", id: user.id },
+        { kind: "Product", id: product.id },
+        {
+          quantity: -5, // Invalid!
+          priceAtPurchase: 29.99,
+          purchasedAt: new Date().toISOString(),
+        },
+      );
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        printValidationIssues(error);
+      } else {
+        throw error;
+      }
     }
-  }
 
-  // 4. Invalid SKU format
-  console.log("\n4. Trying invalid product SKU...");
-  try {
-    await store.nodes.Product.create({
-      sku: "invalid-sku", // Doesn't match pattern!
-      name: "Widget",
-      price: 9.99,
-      categories: ["widgets"],
-    });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      printValidationIssues(error);
-    } else {
-      throw error;
-    }
-  }
-
-  // 5. Valid product
-  console.log("\n5. Creating valid product...");
-  const product = await store.nodes.Product.create({
-    sku: "WDG-12345",
-    name: "Super Widget",
-    price: 29.99,
-    currency: "USD",
-    categories: ["widgets", "tools"],
-  });
-  console.log("   Created product:", product.name);
-
-  // 6. Invalid edge - negative quantity
-  // Note: Edges can be created using either:
-  // - Node objects directly: store.edges.purchased.create(user, product, {...})
-  // - NodeRef objects: store.edges.purchased.create({ kind: "User", id: user.id }, ...)
-  // Both forms are equivalent. NodeRef is useful when you only have the ID.
-  console.log("\n6. Trying invalid purchase (negative quantity)...");
-  try {
-    await store.edges.purchased.create(
+    // 7. Valid edge
+    console.log("\n7. Creating valid purchase...");
+    const purchase = await store.edges.purchased.create(
       { kind: "User", id: user.id },
       { kind: "Product", id: product.id },
       {
-        quantity: -5, // Invalid!
+        quantity: 2,
         priceAtPurchase: 29.99,
         purchasedAt: new Date().toISOString(),
       },
     );
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      printValidationIssues(error);
-    } else {
-      throw error;
-    }
+    console.log("   Created purchase, quantity:", purchase.quantity);
+
+    // 8. Demonstrate default values
+    console.log("\n8. Creating user with defaults...");
+    const guestUser = await store.nodes.User.create({
+      username: "guest_user",
+      email: "guest@example.com",
+      // role defaults to "user"
+      // tags defaults to []
+    });
+    console.log("   User role (defaulted):", guestUser.role);
+    console.log("   User tags (defaulted):", guestUser.tags);
+
+    console.log("\n=== All validation examples complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // 7. Valid edge
-  console.log("\n7. Creating valid purchase...");
-  const purchase = await store.edges.purchased.create(
-    { kind: "User", id: user.id },
-    { kind: "Product", id: product.id },
-    {
-      quantity: 2,
-      priceAtPurchase: 29.99,
-      purchasedAt: new Date().toISOString(),
-    },
-  );
-  console.log("   Created purchase, quantity:", purchase.quantity);
-
-  // 8. Demonstrate default values
-  console.log("\n8. Creating user with defaults...");
-  const guestUser = await store.nodes.User.create({
-    username: "guest_user",
-    email: "guest@example.com",
-    // role defaults to "user"
-    // tags defaults to []
-  });
-  console.log("   User role (defaulted):", guestUser.role);
-  console.log("   User tags (defaulted):", guestUser.tags);
-
-  console.log("\n=== All validation examples complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/02-schema-validation.ts
+++ b/packages/typegraph/examples/02-schema-validation.ts
@@ -85,6 +85,15 @@ const graph = defineGraph({
 // Demonstrate Validation
 // ============================================================
 
+// ValidationError carries structured issues (path + message), so the
+// custom messages defined in the schemas above can be shown readably
+function printValidationIssues(error: ValidationError) {
+  console.log("   Validation failed:");
+  for (const issue of error.details.issues) {
+    console.log(`     - ${issue.path || "(root)"}: ${issue.message}`);
+  }
+}
+
 export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
@@ -111,7 +120,9 @@ export async function main() {
     });
   } catch (error) {
     if (error instanceof ValidationError) {
-      console.log("   Validation failed:", error.message);
+      printValidationIssues(error);
+    } else {
+      throw error;
     }
   }
 
@@ -124,7 +135,9 @@ export async function main() {
     });
   } catch (error) {
     if (error instanceof ValidationError) {
-      console.log("   Validation failed:", error.message);
+      printValidationIssues(error);
+    } else {
+      throw error;
     }
   }
 
@@ -139,7 +152,9 @@ export async function main() {
     });
   } catch (error) {
     if (error instanceof ValidationError) {
-      console.log("   Validation failed:", error.message);
+      printValidationIssues(error);
+    } else {
+      throw error;
     }
   }
 
@@ -172,7 +187,9 @@ export async function main() {
     );
   } catch (error) {
     if (error instanceof ValidationError) {
-      console.log("   Validation failed:", error.message);
+      printValidationIssues(error);
+    } else {
+      throw error;
     }
   }
 

--- a/packages/typegraph/examples/03-subclass-hierarchy.ts
+++ b/packages/typegraph/examples/03-subclass-hierarchy.ts
@@ -13,8 +13,6 @@
  * Run with:
  *   npx tsx examples/03-subclass-hierarchy.ts
  */
-import { z } from "zod";
-
 import {
   createStore,
   defineEdge,
@@ -22,6 +20,8 @@ import {
   defineNode,
   subClassOf,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -171,7 +171,7 @@ export async function main(): Promise<void> {
     const theOffice = await store.nodes.TVShow.create({
       title: "The Office",
       releaseYear: 2005,
-      rating: 9.0,
+      rating: 9,
       seasons: 9,
       episodeCount: 201,
     });
@@ -230,8 +230,8 @@ export async function main(): Promise<void> {
     }
 
     console.log("\nExpanding 'Documentary' includes:");
-    const docExpanded = registry.expandSubClasses("Documentary");
-    for (const kind of docExpanded) {
+    const documentExpanded = registry.expandSubClasses("Documentary");
+    for (const kind of documentExpanded) {
       console.log(`  - ${kind}`);
     }
 
@@ -254,7 +254,7 @@ export async function main(): Promise<void> {
       .execute();
 
     for (const row of allWatched) {
-      console.log(`  ${row.person} watched "${row.title}" (${row.kind})`);
+      console.log(`  ${row.person} watched "${String(row.title)}" (${row.kind})`);
     }
     console.log(
       "  ^ All four items, including both TVShows — Media expands to\n" +
@@ -278,7 +278,7 @@ export async function main(): Promise<void> {
       .execute();
 
     for (const row of moviesWatched) {
-      console.log(`  ${row.person} watched "${row.title}" (${row.kind})`);
+      console.log(`  ${row.person} watched "${String(row.title)}" (${row.kind})`);
     }
     console.log(
       '  ^ "Breaking Bad" and "The Office" are excluded: TVShow is a\n' +
@@ -345,7 +345,7 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/03-subclass-hierarchy.ts
+++ b/packages/typegraph/examples/03-subclass-hierarchy.ts
@@ -2,16 +2,23 @@
  * Example 03: Subclass Hierarchy
  *
  * This example demonstrates using subClassOf to create type hierarchies:
- * - Defining parent/child relationships between node kinds
- * - Query expansion to include subclasses
- * - Polymorphic edge endpoints
+ * - Sharing a base schema across subclasses with Zod's .extend()
+ * - Polymorphic edge endpoints: runtime endpoint validation uses
+ *   subsumption, so a `to: [Media]` edge accepts every subclass
+ *   instance (subclasses are also listed in the declaration purely
+ *   for TypeScript's benefit — see the edge definition below)
+ * - Query expansion with includeSubClasses — and what it excludes
+ * - Inspecting the hierarchy through the registry
+ *
+ * Run with:
+ *   npx tsx examples/03-subclass-hierarchy.ts
  */
 import { z } from "zod";
 
 import {
   createStore,
-  defineGraph,
   defineEdge,
+  defineGraph,
   defineNode,
   subClassOf,
 } from "@nicia-ai/typegraph";
@@ -20,33 +27,35 @@ import { createExampleBackend } from "./_helpers";
 // ============================================================
 // Define a Media Hierarchy
 // ============================================================
+//
+// Subclass schemas must include the parent's fields. Rather than
+// repeating them, extend a shared base object — this is the intended
+// pattern for subclass schemas.
+
+const mediaFields = z.object({
+  title: z.string(),
+  releaseYear: z.number().int(),
+  rating: z.number().min(0).max(10).optional(),
+});
 
 // Base type for all media
 const Media = defineNode("Media", {
-  schema: z.object({
-    title: z.string(),
-    releaseYear: z.number().int(),
-    rating: z.number().min(0).max(10).optional(),
-  }),
+  schema: mediaFields,
+});
+
+const movieFields = mediaFields.extend({
+  director: z.string(),
+  runtime: z.number().int().positive(), // minutes
 });
 
 // Movie is a subclass of Media
 const Movie = defineNode("Movie", {
-  schema: z.object({
-    title: z.string(),
-    releaseYear: z.number().int(),
-    rating: z.number().min(0).max(10).optional(),
-    director: z.string(),
-    runtime: z.number().int().positive(), // minutes
-  }),
+  schema: movieFields,
 });
 
 // TVShow is a subclass of Media
 const TVShow = defineNode("TVShow", {
-  schema: z.object({
-    title: z.string(),
-    releaseYear: z.number().int(),
-    rating: z.number().min(0).max(10).optional(),
+  schema: mediaFields.extend({
     seasons: z.number().int().positive(),
     episodeCount: z.number().int().positive(),
   }),
@@ -54,17 +63,12 @@ const TVShow = defineNode("TVShow", {
 
 // Documentary is a subclass of Movie (deeper hierarchy)
 const Documentary = defineNode("Documentary", {
-  schema: z.object({
-    title: z.string(),
-    releaseYear: z.number().int(),
-    rating: z.number().min(0).max(10).optional(),
-    director: z.string(),
-    runtime: z.number().int().positive(),
+  schema: movieFields.extend({
     subject: z.string(),
   }),
 });
 
-// Person who can be related to media
+// Person who watches media
 const Person = defineNode("Person", {
   schema: z.object({
     name: z.string(),
@@ -83,13 +87,6 @@ const watched = defineEdge("watched", {
   }),
 });
 
-// A person can recommend media to another person
-const recommended = defineEdge("recommended", {
-  schema: z.object({
-    comment: z.string().optional(),
-  }),
-});
-
 // ============================================================
 // Define Graph with Ontology
 // ============================================================
@@ -104,10 +101,20 @@ const graph = defineGraph({
     Person: { type: Person },
   },
   edges: {
-    // Person can watch any Media (or subclass)
-    watched: { type: watched, from: [Person], to: [Media, Movie, TVShow, Documentary] },
-    // Recommendation from person to person about media
-    recommended: { type: recommended, from: [Person], to: [Person] },
+    // At runtime, `to: [Media]` alone is enough: endpoint validation
+    // uses subsumption, so subClassOf makes instances of Movie,
+    // TVShow, and Documentary valid targets automatically.
+    //
+    // The subclasses are listed anyway for TypeScript's benefit. The
+    // ontology is invisible to the type system, so the declared list
+    // is what lets `watched.create(alice, someMovie)` and
+    // `.to("Movie", ...)` in the query builder typecheck. Omitting
+    // them changes nothing at runtime — only the static types.
+    watched: {
+      type: watched,
+      from: [Person],
+      to: [Media, Movie, TVShow, Documentary],
+    },
   },
   ontology: [
     // Define the hierarchy:
@@ -125,147 +132,216 @@ const graph = defineGraph({
 // Demonstrate Subclass Features
 // ============================================================
 
-export async function main() {
+export async function main(): Promise<void> {
   const backend = createExampleBackend();
-  const store = createStore(graph, backend);
 
-  console.log("=== Subclass Hierarchy Examples ===\n");
+  try {
+    const store = createStore(graph, backend);
 
-  // Create some media
-  console.log("Creating media items...");
+    console.log("=== Subclass Hierarchy Examples ===\n");
 
-  const inception = await store.nodes.Movie.create({
-    title: "Inception",
-    releaseYear: 2010,
-    rating: 8.8,
-    director: "Christopher Nolan",
-    runtime: 148,
-  });
+    // Create some media
+    console.log("Creating media items...");
 
-  const breakingBad = await store.nodes.TVShow.create({
-    title: "Breaking Bad",
-    releaseYear: 2008,
-    rating: 9.5,
-    seasons: 5,
-    episodeCount: 62,
-  });
+    const inception = await store.nodes.Movie.create({
+      title: "Inception",
+      releaseYear: 2010,
+      rating: 8.8,
+      director: "Christopher Nolan",
+      runtime: 148,
+    });
 
-  const planetEarth = await store.nodes.Documentary.create({
-    title: "Planet Earth II",
-    releaseYear: 2016,
-    rating: 9.5,
-    director: "David Attenborough",
-    runtime: 300,
-    subject: "Nature and Wildlife",
-  });
+    const breakingBad = await store.nodes.TVShow.create({
+      title: "Breaking Bad",
+      releaseYear: 2008,
+      rating: 9.5,
+      seasons: 5,
+      episodeCount: 62,
+    });
 
-  const theOffice = await store.nodes.TVShow.create({
-    title: "The Office",
-    releaseYear: 2005,
-    rating: 9.0,
-    seasons: 9,
-    episodeCount: 201,
-  });
+    const planetEarth = await store.nodes.Documentary.create({
+      title: "Planet Earth II",
+      releaseYear: 2016,
+      rating: 9.5,
+      director: "David Attenborough",
+      runtime: 300,
+      subject: "Nature and Wildlife",
+    });
 
-  console.log("  Created: Inception (Movie)");
-  console.log("  Created: Breaking Bad (TVShow)");
-  console.log("  Created: Planet Earth II (Documentary)");
-  console.log("  Created: The Office (TVShow)");
+    const theOffice = await store.nodes.TVShow.create({
+      title: "The Office",
+      releaseYear: 2005,
+      rating: 9.0,
+      seasons: 9,
+      episodeCount: 201,
+    });
 
-  // Create a person who watches stuff
-  const alice = await store.nodes.Person.create({ name: "Alice" });
+    console.log("  Created: Inception (Movie)");
+    console.log("  Created: Breaking Bad (TVShow)");
+    console.log("  Created: Planet Earth II (Documentary)");
+    console.log("  Created: The Office (TVShow)");
 
-  // Alice watches various media - pass nodes directly
-  await store.edges.watched.create(alice, inception, {
-    watchedOn: "2023-01-15",
-    completed: true,
-  });
+    // Create a person who watches stuff
+    const alice = await store.nodes.Person.create({ name: "Alice" });
 
-  await store.edges.watched.create(alice, planetEarth, {
-    watchedOn: "2023-02-20",
-    completed: true,
-  });
+    // None of these targets has the exact kind "Media", yet all are
+    // valid `watched` targets: endpoint validation accepts any
+    // subclass of a declared endpoint kind.
+    await store.edges.watched.create(alice, inception, {
+      watchedOn: "2023-01-15",
+      completed: true,
+    });
 
-  await store.edges.watched.create(alice, breakingBad, {
-    watchedOn: "2023-03-01",
-    completed: false,
-  });
+    await store.edges.watched.create(alice, planetEarth, {
+      watchedOn: "2023-02-20",
+      completed: true,
+    });
 
-  console.log("\nAlice has watched several items.\n");
+    await store.edges.watched.create(alice, breakingBad, {
+      watchedOn: "2023-03-01",
+      completed: false,
+    });
 
-  // Demonstrate registry expansion
-  console.log("=== Registry Subclass Expansion ===\n");
+    await store.edges.watched.create(alice, theOffice, {
+      watchedOn: "2023-04-10",
+      completed: true,
+    });
 
-  const registry = store.registry;
+    console.log(
+      "\nAlice watched all four — subsumption makes every subclass of\n" +
+        "Media a valid target for the watched edge.\n",
+    );
 
-  console.log("Expanding 'Media' includes:");
-  const mediaExpanded = registry.expandSubClasses("Media");
-  for (const kind of mediaExpanded) {
-    console.log(`  - ${kind}`);
+    // Demonstrate registry expansion
+    console.log("=== Registry Subclass Expansion ===\n");
+
+    const registry = store.registry;
+
+    console.log("Expanding 'Media' includes:");
+    const mediaExpanded = registry.expandSubClasses("Media");
+    for (const kind of mediaExpanded) {
+      console.log(`  - ${kind}`);
+    }
+
+    console.log("\nExpanding 'Movie' includes:");
+    const movieExpanded = registry.expandSubClasses("Movie");
+    for (const kind of movieExpanded) {
+      console.log(`  - ${kind}`);
+    }
+
+    console.log("\nExpanding 'Documentary' includes:");
+    const docExpanded = registry.expandSubClasses("Documentary");
+    for (const kind of docExpanded) {
+      console.log(`  - ${kind}`);
+    }
+
+    // Query with subclass expansion
+    console.log("\n=== Query with Subclass Expansion ===\n");
+
+    // Querying at the top of the hierarchy answers "what has Alice
+    // watched?" without caring about concrete kinds.
+    console.log("Query: All Media Alice watched (includeSubClasses: true)");
+    const allWatched = await store
+      .query()
+      .from("Person", "p")
+      .traverse("watched", "w")
+      .to("Media", "m", { includeSubClasses: true })
+      .select((ctx) => ({
+        person: ctx.p.name,
+        title: ctx.m.title,
+        kind: ctx.m.kind,
+      }))
+      .execute();
+
+    for (const row of allWatched) {
+      console.log(`  ${row.person} watched "${row.title}" (${row.kind})`);
+    }
+    console.log(
+      "  ^ All four items, including both TVShows — Media expands to\n" +
+        "    every kind in the hierarchy.",
+    );
+
+    // Expansion follows the hierarchy, so it also excludes: a Movie
+    // query pulls in Documentary but NOT TVShow, which sits on the
+    // other branch under Media.
+    console.log("\nQuery: All Movies Alice watched (includeSubClasses: true)");
+    const moviesWatched = await store
+      .query()
+      .from("Person", "p")
+      .traverse("watched", "w")
+      .to("Movie", "m", { includeSubClasses: true })
+      .select((ctx) => ({
+        person: ctx.p.name,
+        title: ctx.m.title,
+        kind: ctx.m.kind,
+      }))
+      .execute();
+
+    for (const row of moviesWatched) {
+      console.log(`  ${row.person} watched "${row.title}" (${row.kind})`);
+    }
+    console.log(
+      '  ^ "Breaking Bad" and "The Office" are excluded: TVShow is a\n' +
+        "    sibling of Movie, not a subclass of it.",
+    );
+
+    // Without subclass expansion
+    console.log("\nQuery: Only exact Movie type (includeSubClasses: false)");
+    const exactMovies = await store
+      .query()
+      .from("Person", "p")
+      .traverse("watched", "w")
+      .to("Movie", "m", { includeSubClasses: false })
+      .select((ctx) => ({
+        person: ctx.p.name,
+        title: ctx.m.title,
+        kind: ctx.m.kind,
+      }))
+      .execute();
+
+    for (const row of exactMovies) {
+      console.log(`  ${row.person} watched "${row.title}" (${row.kind})`);
+    }
+    console.log(
+      '  ^ Now "Planet Earth II" drops out too: only nodes whose exact\n' +
+        "    kind is Movie match.",
+    );
+
+    // Check ancestry
+    console.log("\n=== Checking Ancestry ===\n");
+
+    console.log(
+      "Is Documentary a subclass of Movie?",
+      registry.isSubClassOf("Documentary", "Movie"),
+    );
+    console.log(
+      "Is Documentary a subclass of Media?",
+      registry.isSubClassOf("Documentary", "Media"),
+    );
+    console.log(
+      "Is Movie a subclass of Documentary?",
+      registry.isSubClassOf("Movie", "Documentary"),
+    );
+    console.log(
+      "Is TVShow a subclass of Movie?",
+      registry.isSubClassOf("TVShow", "Movie"),
+    );
+
+    // isAssignableTo is the relation endpoint validation uses: it is
+    // why a Documentary node satisfies a Media endpoint at runtime.
+    console.log(
+      "\nCan a Documentary target an edge endpoint declared as Media?",
+      registry.isAssignableTo("Documentary", "Media"),
+    );
+    console.log(
+      "Can a Person target an edge endpoint declared as Media?",
+      registry.isAssignableTo("Person", "Media"),
+    );
+
+    console.log("\n=== Subclass hierarchy example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  console.log("\nExpanding 'Movie' includes:");
-  const movieExpanded = registry.expandSubClasses("Movie");
-  for (const kind of movieExpanded) {
-    console.log(`  - ${kind}`);
-  }
-
-  console.log("\nExpanding 'Documentary' includes:");
-  const docExpanded = registry.expandSubClasses("Documentary");
-  for (const kind of docExpanded) {
-    console.log(`  - ${kind}`);
-  }
-
-  // Query with subclass expansion
-  console.log("\n=== Query with Subclass Expansion ===\n");
-
-  // This query finds all Movies (including Documentaries) Alice watched
-  console.log("Query: All Movies Alice watched (includeSubClasses: true)");
-  const moviesWatched = await store
-    .query()
-    .from("Person", "p")
-    .traverse("watched", "w")
-    .to("Movie", "m", { includeSubClasses: true })
-    .select((ctx) => ({
-      person: ctx.p.name,
-      title: ctx.m.title,
-      kind: ctx.m.kind,
-    }))
-    .execute();
-
-  for (const row of moviesWatched) {
-    console.log(`  ${row.person} watched "${row.title}" (${row.kind})`);
-  }
-
-  // Without subclass expansion
-  console.log("\nQuery: Only exact Movie type (includeSubClasses: false)");
-  const exactMovies = await store
-    .query()
-    .from("Person", "p")
-    .traverse("watched", "w")
-    .to("Movie", "m", { includeSubClasses: false })
-    .select((ctx) => ({
-      person: ctx.p.name,
-      title: ctx.m.title,
-      kind: ctx.m.kind,
-    }))
-    .execute();
-
-  for (const row of exactMovies) {
-    console.log(`  ${row.person} watched "${row.title}" (${row.kind})`);
-  }
-
-  // Check ancestry
-  console.log("\n=== Checking Ancestry ===\n");
-
-  console.log("Is Documentary a subclass of Movie?", registry.isSubClassOf("Documentary", "Movie"));
-  console.log("Is Documentary a subclass of Media?", registry.isSubClassOf("Documentary", "Media"));
-  console.log("Is Movie a subclass of Documentary?", registry.isSubClassOf("Movie", "Documentary"));
-  console.log("Is TVShow a subclass of Movie?", registry.isSubClassOf("TVShow", "Movie"));
-
-  console.log("\n=== Subclass hierarchy example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/typegraph/examples/04-disjoint-constraints.ts
+++ b/packages/typegraph/examples/04-disjoint-constraints.ts
@@ -6,8 +6,6 @@
  * - Multi-kind nodes (same ID, different compatible kinds)
  * - Error handling for disjointness violations
  */
-import { z } from "zod";
-
 import {
   createStore,
   defineGraph,
@@ -16,6 +14,8 @@ import {
   disjointWith,
   subClassOf,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -104,123 +104,125 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  console.log("=== Disjoint Constraints Examples ===\n");
-
-  // 1. Create a Person
-  console.log("1. Creating a Person with ID 'entity-alice'...");
-  const alice = await store.nodes.Person.create(
-    { name: "Alice Smith", dateOfBirth: "1990-05-15" },
-    { id: "entity-alice" },
-  );
-  console.log("   Created Person:", alice.name);
-
-  // 2. Same ID can be used for Employee (not disjoint with Person)
-  console.log("\n2. Creating Employee with same ID 'entity-alice'...");
-  const aliceEmployee = await store.nodes.Employee.create(
-    {
-      employeeId: "EMP-001",
-      department: "Engineering",
-      hireDate: "2020-01-15",
-    },
-    { id: "entity-alice" },
-  );
-  console.log("   Created Employee:", aliceEmployee.employeeId);
-  console.log("   Same entity is now both Person AND Employee!");
-
-  // 3. Try to create Robot with same ID - should FAIL
-  console.log("\n3. Trying to create Robot with ID 'entity-alice'...");
   try {
-    await store.nodes.Robot.create(
+    console.log("=== Disjoint Constraints Examples ===\n");
+
+    // 1. Create a Person
+    console.log("1. Creating a Person with ID 'entity-alice'...");
+    const alice = await store.nodes.Person.create(
+      { name: "Alice Smith", dateOfBirth: "1990-05-15" },
+      { id: "entity-alice" },
+    );
+    console.log("   Created Person:", alice.name);
+
+    // 2. Same ID can be used for Employee (not disjoint with Person)
+    console.log("\n2. Creating Employee with same ID 'entity-alice'...");
+    const aliceEmployee = await store.nodes.Employee.create(
       {
-        model: "RX-78",
-        serialNumber: "001",
-        manufacturer: "Anaheim Electronics",
+        employeeId: "EMP-001",
+        department: "Engineering",
+        hireDate: "2020-01-15",
       },
       { id: "entity-alice" },
     );
-    console.log("   ERROR: This should have failed!");
-  } catch (error) {
-    if (error instanceof DisjointError) {
-      console.log("   Disjoint constraint enforced!");
-      console.log(`   Error: ${error.message}`);
-    } else {
-      throw error;
+    console.log("   Created Employee:", aliceEmployee.employeeId);
+    console.log("   Same entity is now both Person AND Employee!");
+
+    // 3. Try to create Robot with same ID - should FAIL
+    console.log("\n3. Trying to create Robot with ID 'entity-alice'...");
+    try {
+      await store.nodes.Robot.create(
+        {
+          model: "RX-78",
+          serialNumber: "001",
+          manufacturer: "Anaheim Electronics",
+        },
+        { id: "entity-alice" },
+      );
+      console.log("   ERROR: This should have failed!");
+    } catch (error) {
+      if (error instanceof DisjointError) {
+        console.log("   Disjoint constraint enforced!");
+        console.log(`   Error: ${error.message}`);
+      } else {
+        throw error;
+      }
     }
-  }
 
-  // 4. Create a Robot with different ID - works fine
-  console.log("\n4. Creating Robot with different ID 'robot-1'...");
-  const robot = await store.nodes.Robot.create(
-    {
-      model: "T-800",
-      serialNumber: "101",
-      manufacturer: "Cyberdyne",
-    },
-    { id: "robot-1" },
-  );
-  console.log("   Created Robot:", robot.model);
-
-  // 5. Try Vehicle with robot ID - should FAIL (Vehicle disjoint with Robot)
-  console.log("\n5. Trying to create Vehicle with ID 'robot-1'...");
-  try {
-    await store.nodes.Vehicle.create(
+    // 4. Create a Robot with different ID - works fine
+    console.log("\n4. Creating Robot with different ID 'robot-1'...");
+    const robot = await store.nodes.Robot.create(
       {
-        make: "Tesla",
-        model: "Model S",
-        vin: "5YJ3E1EA1JF000001",
+        model: "T-800",
+        serialNumber: "101",
+        manufacturer: "Cyberdyne",
       },
       { id: "robot-1" },
     );
-    console.log("   ERROR: This should have failed!");
-  } catch (error) {
-    if (error instanceof DisjointError) {
-      console.log("   Disjoint constraint enforced!");
-      console.log(`   Error: ${error.message}`);
-    } else {
-      throw error;
+    console.log("   Created Robot:", robot.model);
+
+    // 5. Try Vehicle with robot ID - should FAIL (Vehicle disjoint with Robot)
+    console.log("\n5. Trying to create Vehicle with ID 'robot-1'...");
+    try {
+      await store.nodes.Vehicle.create(
+        {
+          make: "Tesla",
+          model: "Model S",
+          vin: "5YJ3E1EA1JF000001",
+        },
+        { id: "robot-1" },
+      );
+      console.log("   ERROR: This should have failed!");
+    } catch (error) {
+      if (error instanceof DisjointError) {
+        console.log("   Disjoint constraint enforced!");
+        console.log(`   Error: ${error.message}`);
+      } else {
+        throw error;
+      }
     }
+
+    // 6. Check which kinds are disjoint
+    console.log("\n=== Checking Disjoint Relationships ===\n");
+    const registry = store.registry;
+
+    const pairs = [
+      ["Person", "Robot"],
+      ["Person", "Employee"],
+      ["Person", "Vehicle"],
+      ["Robot", "Vehicle"],
+      ["Employee", "Robot"],
+    ];
+
+    for (const [a, b] of pairs) {
+      const areDisjoint = registry.areDisjoint(a!, b!);
+      console.log(`  ${a} and ${b}: ${areDisjoint ? "DISJOINT" : "compatible"}`);
+    }
+
+    // 7. Delete person, then create robot with that ID
+    console.log("\n7. Delete Person 'entity-alice', then create Robot with that ID...");
+    await store.nodes.Person.delete(alice.id);
+    await store.nodes.Employee.delete(aliceEmployee.id); // Also delete Employee facet
+    console.log("   Deleted Person and Employee with ID 'entity-alice'");
+
+    const robotAlice = await store.nodes.Robot.create(
+      {
+        model: "Android",
+        serialNumber: "A-001",
+        manufacturer: "Detroit",
+      },
+      { id: "entity-alice" },
+    );
+    console.log("   Created Robot with previously used ID:", robotAlice.model);
+
+    console.log("\n=== Disjoint constraints example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // 6. Check which kinds are disjoint
-  console.log("\n=== Checking Disjoint Relationships ===\n");
-  const registry = store.registry;
-
-  const pairs = [
-    ["Person", "Robot"],
-    ["Person", "Employee"],
-    ["Person", "Vehicle"],
-    ["Robot", "Vehicle"],
-    ["Employee", "Robot"],
-  ];
-
-  for (const [a, b] of pairs) {
-    const areDisjoint = registry.areDisjoint(a!, b!);
-    console.log(`  ${a} and ${b}: ${areDisjoint ? "DISJOINT" : "compatible"}`);
-  }
-
-  // 7. Delete person, then create robot with that ID
-  console.log("\n7. Delete Person 'entity-alice', then create Robot with that ID...");
-  await store.nodes.Person.delete(alice.id);
-  await store.nodes.Employee.delete(aliceEmployee.id); // Also delete Employee facet
-  console.log("   Deleted Person and Employee with ID 'entity-alice'");
-
-  const robotAlice = await store.nodes.Robot.create(
-    {
-      model: "Android",
-      serialNumber: "A-001",
-      manufacturer: "Detroit",
-    },
-    { id: "entity-alice" },
-  );
-  console.log("   Created Robot with previously used ID:", robotAlice.model);
-
-  console.log("\n=== Disjoint constraints example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/05-edge-implications.ts
+++ b/packages/typegraph/examples/05-edge-implications.ts
@@ -189,6 +189,7 @@ export async function main() {
   const aliceKnows = await store
     .query()
     .from("Person", "alice")
+    .whereNode("alice", ({ name }) => name.eq("Alice"))
     .traverse("knows", "e", { expand: "implying" })
     .to("Person", "other")
     .select((ctx) => ({
@@ -202,12 +203,13 @@ export async function main() {
   }
 
   // Query without expansion
-  console.log("\nQuery: Who does Alice explicitly 'knows'? (no expansion)");
+  console.log("\nQuery: Who does Alice explicitly 'knows'? (default expansion)");
 
   const aliceExplicitlyKnows = await store
     .query()
     .from("Person", "alice")
-    .traverse("knows", "e") // No implying-edge expansion
+    .whereNode("alice", ({ name }) => name.eq("Alice"))
+    .traverse("knows", "e") // Default expansion — implying edges are not included
     .to("Person", "other")
     .select((ctx) => ({
       person: ctx.other.name,
@@ -228,6 +230,7 @@ export async function main() {
   const aliceFriends = await store
     .query()
     .from("Person", "alice")
+    .whereNode("alice", ({ name }) => name.eq("Alice"))
     .traverse("friends", "e", { expand: "implying" })
     .to("Person", "friend")
     .select((ctx) => ({

--- a/packages/typegraph/examples/05-edge-implications.ts
+++ b/packages/typegraph/examples/05-edge-implications.ts
@@ -6,15 +6,15 @@
  * - Query-time expansion to include implying edges
  * - Building semantic hierarchies of relationships
  */
-import { z } from "zod";
-
 import {
   createStore,
-  defineGraph,
   defineEdge,
+  defineGraph,
   defineNode,
   implies,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -128,128 +128,130 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  console.log("=== Edge Implications Examples ===\n");
+  try {
+    console.log("=== Edge Implications Examples ===\n");
 
-  // Create some people
-  const alice = await store.nodes.Person.create({ name: "Alice", birthYear: 1990 });
-  const bob = await store.nodes.Person.create({ name: "Bob", birthYear: 1988 });
-  const charlie = await store.nodes.Person.create({ name: "Charlie", birthYear: 1992 });
-  const diana = await store.nodes.Person.create({ name: "Diana", birthYear: 1995 });
-  const eve = await store.nodes.Person.create({ name: "Eve", birthYear: 1965 });
+    // Create some people
+    const alice = await store.nodes.Person.create({ name: "Alice", birthYear: 1990 });
+    const bob = await store.nodes.Person.create({ name: "Bob", birthYear: 1988 });
+    const charlie = await store.nodes.Person.create({ name: "Charlie", birthYear: 1992 });
+    const diana = await store.nodes.Person.create({ name: "Diana", birthYear: 1995 });
+    const eve = await store.nodes.Person.create({ name: "Eve", birthYear: 1965 });
 
-  console.log("Created people: Alice, Bob, Charlie, Diana, Eve\n");
+    console.log("Created people: Alice, Bob, Charlie, Diana, Eve\n");
 
-  // Create various relationships - pass nodes directly
-  console.log("Creating relationships...");
+    // Create various relationships - pass nodes directly
+    console.log("Creating relationships...");
 
-  // Alice and Bob are married
-  await store.edges.marriedTo.create(alice, bob, { marriageDate: "2018-06-15" });
-  console.log("  Alice marriedTo Bob");
+    // Alice and Bob are married
+    await store.edges.marriedTo.create(alice, bob, { marriageDate: "2018-06-15" });
+    console.log("  Alice marriedTo Bob");
 
-  // Alice and Charlie are best friends
-  await store.edges.bestFriends.create(alice, charlie, { since: "2005-09-01" });
-  console.log("  Alice bestFriends Charlie");
+    // Alice and Charlie are best friends
+    await store.edges.bestFriends.create(alice, charlie, { since: "2005-09-01" });
+    console.log("  Alice bestFriends Charlie");
 
-  // Diana is just a friend
-  await store.edges.friends.create(alice, diana, { since: "2020-01-01" });
-  console.log("  Alice friends Diana");
+    // Diana is just a friend
+    await store.edges.friends.create(alice, diana, { since: "2020-01-01" });
+    console.log("  Alice friends Diana");
 
-  // Eve is Alice's parent
-  await store.edges.parentOf.create(eve, alice, {});
-  console.log("  Eve parentOf Alice");
+    // Eve is Alice's parent
+    await store.edges.parentOf.create(eve, alice, {});
+    console.log("  Eve parentOf Alice");
 
-  // Show implication hierarchy
-  console.log("\n=== Implication Hierarchy ===\n");
+    // Show implication hierarchy
+    console.log("\n=== Implication Hierarchy ===\n");
 
-  const registry = store.registry;
+    const registry = store.registry;
 
-  console.log("What does 'marriedTo' imply?");
-  const marriedImplies = registry.getImpliedEdges("marriedTo");
-  console.log(`  marriedTo implies: [${marriedImplies.join(", ")}]`);
+    console.log("What does 'marriedTo' imply?");
+    const marriedImplies = registry.getImpliedEdges("marriedTo");
+    console.log(`  marriedTo implies: [${marriedImplies.join(", ")}]`);
 
-  console.log("\nWhat does 'bestFriends' imply?");
-  const bestFriendsImplies = registry.getImpliedEdges("bestFriends");
-  console.log(`  bestFriends implies: [${bestFriendsImplies.join(", ")}]`);
+    console.log("\nWhat does 'bestFriends' imply?");
+    const bestFriendsImplies = registry.getImpliedEdges("bestFriends");
+    console.log(`  bestFriends implies: [${bestFriendsImplies.join(", ")}]`);
 
-  console.log("\nWhat does 'parentOf' imply?");
-  const parentImplies = registry.getImpliedEdges("parentOf");
-  console.log(`  parentOf implies: [${parentImplies.join(", ")}]`);
+    console.log("\nWhat does 'parentOf' imply?");
+    const parentImplies = registry.getImpliedEdges("parentOf");
+    console.log(`  parentOf implies: [${parentImplies.join(", ")}]`);
 
-  console.log("\nWhat edges imply 'knows'? (reverse lookup)");
-  const knowsImplyingEdges = registry.getImplyingEdges("knows");
-  console.log(`  These edges imply knows: [${knowsImplyingEdges.join(", ")}]`);
+    console.log("\nWhat edges imply 'knows'? (reverse lookup)");
+    const knowsImplyingEdges = registry.getImplyingEdges("knows");
+    console.log(`  These edges imply knows: [${knowsImplyingEdges.join(", ")}]`);
 
-  // Query with implications
-  console.log("\n=== Query with Edge Implication Expansion ===\n");
+    // Query with implications
+    console.log("\n=== Query with Edge Implication Expansion ===\n");
 
-  // Query: "Who does Alice know?" using implication expansion
-  console.log('Query: Who does Alice know? (expand: "implying")');
-  console.log("  This will find: knows, friends, bestFriends, marriedTo, etc.\n");
+    // Query: "Who does Alice know?" using implication expansion
+    console.log('Query: Who does Alice know? (expand: "implying")');
+    console.log("  This will find: knows, friends, bestFriends, marriedTo, etc.\n");
 
-  const aliceKnows = await store
-    .query()
-    .from("Person", "alice")
-    .whereNode("alice", ({ name }) => name.eq("Alice"))
-    .traverse("knows", "e", { expand: "implying" })
-    .to("Person", "other")
-    .select((ctx) => ({
-      person: ctx.other.name,
-    }))
-    .execute();
+    const aliceKnows = await store
+      .query()
+      .from("Person", "alice")
+      .whereNode("alice", ({ name }) => name.eq("Alice"))
+      .traverse("knows", "e", { expand: "implying" })
+      .to("Person", "other")
+      .select((ctx) => ({
+        person: ctx.other.name,
+      }))
+      .execute();
 
-  console.log("  Alice knows (via any implying relationship):");
-  for (const row of aliceKnows) {
-    console.log(`    - ${row.person}`);
-  }
-
-  // Query without expansion
-  console.log("\nQuery: Who does Alice explicitly 'knows'? (default expansion)");
-
-  const aliceExplicitlyKnows = await store
-    .query()
-    .from("Person", "alice")
-    .whereNode("alice", ({ name }) => name.eq("Alice"))
-    .traverse("knows", "e") // Default expansion — implying edges are not included
-    .to("Person", "other")
-    .select((ctx) => ({
-      person: ctx.other.name,
-    }))
-    .execute();
-
-  if (aliceExplicitlyKnows.length === 0) {
-    console.log("  No explicit 'knows' edges (all relationships are more specific)");
-  } else {
-    for (const row of aliceExplicitlyKnows) {
+    console.log("  Alice knows (via any implying relationship):");
+    for (const row of aliceKnows) {
       console.log(`    - ${row.person}`);
     }
+
+    // Query without expansion
+    console.log("\nQuery: Who does Alice explicitly 'knows'? (default expansion)");
+
+    const aliceExplicitlyKnows = await store
+      .query()
+      .from("Person", "alice")
+      .whereNode("alice", ({ name }) => name.eq("Alice"))
+      .traverse("knows", "e") // Default expansion — implying edges are not included
+      .to("Person", "other")
+      .select((ctx) => ({
+        person: ctx.other.name,
+      }))
+      .execute();
+
+    if (aliceExplicitlyKnows.length === 0) {
+      console.log("  No explicit 'knows' edges (all relationships are more specific)");
+    } else {
+      for (const row of aliceExplicitlyKnows) {
+        console.log(`    - ${row.person}`);
+      }
+    }
+
+    // Query friends (including best friends)
+    console.log('\nQuery: Who is Alice friends with? (expand: "implying")');
+
+    const aliceFriends = await store
+      .query()
+      .from("Person", "alice")
+      .whereNode("alice", ({ name }) => name.eq("Alice"))
+      .traverse("friends", "e", { expand: "implying" })
+      .to("Person", "friend")
+      .select((ctx) => ({
+        friend: ctx.friend.name,
+      }))
+      .execute();
+
+    console.log("  Alice's friends (including best friends):");
+    for (const row of aliceFriends) {
+      console.log(`    - ${row.friend}`);
+    }
+
+    console.log("\n=== Edge implications example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // Query friends (including best friends)
-  console.log('\nQuery: Who is Alice friends with? (expand: "implying")');
-
-  const aliceFriends = await store
-    .query()
-    .from("Person", "alice")
-    .whereNode("alice", ({ name }) => name.eq("Alice"))
-    .traverse("friends", "e", { expand: "implying" })
-    .to("Person", "friend")
-    .select((ctx) => ({
-      friend: ctx.friend.name,
-    }))
-    .execute();
-
-  console.log("  Alice's friends (including best friends):");
-  for (const row of aliceFriends) {
-    console.log(`    - ${row.friend}`);
-  }
-
-  console.log("\n=== Edge implications example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/06-inverse-edges.ts
+++ b/packages/typegraph/examples/06-inverse-edges.ts
@@ -14,7 +14,6 @@ import {
   defineEdge,
   defineNode,
   inverseOf,
-  type NodeId,
 } from "@nicia-ai/typegraph";
 import { createExampleBackend } from "./_helpers";
 
@@ -151,7 +150,8 @@ export async function main() {
   console.log("Created employees: Sarah (CEO), Mike (VP), Alice (Senior), Bob (Junior)");
   console.log("Created team: Platform Team\n");
 
-  // Create management relationships (only need to create one direction!)
+  // Create management relationships (only need to create one direction —
+  // the reportsTo traversals below derive the other from the ontology!)
   console.log("Creating management chain...");
 
   await store.edges.manages.create(ceo, vpEng, { since: "2020-01-01" });
@@ -199,6 +199,7 @@ export async function main() {
   const aliceManages = await store
     .query()
     .from("Employee", "manager")
+    .whereNode("manager", ({ name }) => name.eq("Alice Senior"))
     .traverse("manages", "e")
     .to("Employee", "report")
     .select((ctx) => ({
@@ -208,18 +209,18 @@ export async function main() {
     .execute();
 
   for (const row of aliceManages) {
-    if (row.manager === "Alice Senior") {
-      console.log(`  ${row.manager} manages ${row.report}`);
-    }
+    console.log(`  ${row.manager} manages ${row.report}`);
   }
 
   // Reverse: Who does Bob report to?
-  // Since we only created "manages" edges, we query in reverse direction
-  console.log("\nQuery: Who does Bob report to? (using 'manages' with direction: 'in')");
+  // No reportsTo edge was ever created — the inverseOf(manages, reportsTo)
+  // ontology lets the traversal follow stored manages edges inversely
+  console.log("\nQuery: Who does Bob report to? (traversing 'reportsTo')");
   const bobReportsTo = await store
     .query()
     .from("Employee", "report")
-    .traverse("manages", "e", { direction: "in" })
+    .whereNode("report", ({ name }) => name.eq("Bob Junior"))
+    .traverse("reportsTo", "e")
     .to("Employee", "manager")
     .select((ctx) => ({
       report: ctx.report.name,
@@ -228,37 +229,35 @@ export async function main() {
     .execute();
 
   for (const row of bobReportsTo) {
-    if (row.report === "Bob Junior") {
-      console.log(`  ${row.report} reports to ${row.manager}`);
-    }
+    console.log(`  ${row.report} reports to ${row.manager}`);
   }
 
-  // Full management chain upward from Bob
-  console.log("\nBob's management chain (manual traversal):");
-  let currentId: NodeId<typeof Employee> | undefined = juniorDev.id;
+  // Full management chain upward from Bob — one bound reportsTo query per level
+  console.log("\nBob's management chain (reportsTo traversal per level):");
+  type ChainEntry = Readonly<{ id: string; name: string; title: string }>;
+  let current: ChainEntry | undefined = juniorDev;
   let level = 0;
 
-  while (currentId) {
-    const current = await store.nodes.Employee.getById(currentId);
-    if (!current) break;
-
+  while (current !== undefined) {
+    const employee = current;
     const indent = "  ".repeat(level);
-    console.log(`${indent}${current.name} (${current.title})`);
+    console.log(`${indent}${employee.name} (${employee.title})`);
 
-    // Find manager
-    const managerEdges = await store
+    // Find this employee's manager via the derived reportsTo edge
+    const managers: readonly ChainEntry[] = await store
       .query()
       .from("Employee", "emp")
-      .traverse("manages", "e", { direction: "in" })
+      .whereNode("emp", ({ id }) => id.eq(employee.id))
+      .traverse("reportsTo", "e")
       .to("Employee", "mgr")
       .select((ctx) => ({
-        empId: ctx.emp.id,
-        mgrId: ctx.mgr.id,
+        id: ctx.mgr.id,
+        name: ctx.mgr.name,
+        title: ctx.mgr.title,
       }))
       .execute();
 
-    const myManager = managerEdges.find((r) => r.empId === currentId);
-    currentId = myManager?.mgrId;
+    current = managers[0];
     level++;
   }
 

--- a/packages/typegraph/examples/06-inverse-edges.ts
+++ b/packages/typegraph/examples/06-inverse-edges.ts
@@ -6,15 +6,15 @@
  * - Querying in either direction
  * - Registry lookups for inverse edges
  */
-import { z } from "zod";
-
 import {
   createStore,
-  defineGraph,
   defineEdge,
+  defineGraph,
   defineNode,
   inverseOf,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -114,179 +114,181 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  console.log("=== Inverse Edges Examples ===\n");
+  try {
+    console.log("=== Inverse Edges Examples ===\n");
 
-  // Create employees
-  const ceo = await store.nodes.Employee.create({
-    name: "Sarah CEO",
-    title: "CEO",
-    department: "Executive",
-  });
+    // Create employees
+    const ceo = await store.nodes.Employee.create({
+      name: "Sarah CEO",
+      title: "CEO",
+      department: "Executive",
+    });
 
-  const vpEng = await store.nodes.Employee.create({
-    name: "Mike VP",
-    title: "VP Engineering",
-    department: "Engineering",
-  });
+    const vpEng = await store.nodes.Employee.create({
+      name: "Mike VP",
+      title: "VP Engineering",
+      department: "Engineering",
+    });
 
-  const seniorDev = await store.nodes.Employee.create({
-    name: "Alice Senior",
-    title: "Senior Developer",
-    department: "Engineering",
-  });
+    const seniorDevelopment = await store.nodes.Employee.create({
+      name: "Alice Senior",
+      title: "Senior Developer",
+      department: "Engineering",
+    });
 
-  const juniorDev = await store.nodes.Employee.create({
-    name: "Bob Junior",
-    title: "Junior Developer",
-    department: "Engineering",
-  });
+    const juniorDevelopment = await store.nodes.Employee.create({
+      name: "Bob Junior",
+      title: "Junior Developer",
+      department: "Engineering",
+    });
 
-  // Create a team
-  const platformTeam = await store.nodes.Team.create({
-    name: "Platform Team",
-    purpose: "Build core infrastructure",
-  });
+    // Create a team
+    const platformTeam = await store.nodes.Team.create({
+      name: "Platform Team",
+      purpose: "Build core infrastructure",
+    });
 
-  console.log("Created employees: Sarah (CEO), Mike (VP), Alice (Senior), Bob (Junior)");
-  console.log("Created team: Platform Team\n");
+    console.log("Created employees: Sarah (CEO), Mike (VP), Alice (Senior), Bob (Junior)");
+    console.log("Created team: Platform Team\n");
 
-  // Create management relationships (only need to create one direction —
-  // the reportsTo traversals below derive the other from the ontology!)
-  console.log("Creating management chain...");
+    // Create management relationships (only need to create one direction —
+    // the reportsTo traversals below derive the other from the ontology!)
+    console.log("Creating management chain...");
 
-  await store.edges.manages.create(ceo, vpEng, { since: "2020-01-01" });
-  console.log("  Sarah manages Mike");
+    await store.edges.manages.create(ceo, vpEng, { since: "2020-01-01" });
+    console.log("  Sarah manages Mike");
 
-  await store.edges.manages.create(vpEng, seniorDev, { since: "2021-03-15" });
-  console.log("  Mike manages Alice");
+    await store.edges.manages.create(vpEng, seniorDevelopment, { since: "2021-03-15" });
+    console.log("  Mike manages Alice");
 
-  await store.edges.manages.create(seniorDev, juniorDev, { since: "2023-06-01" });
-  console.log("  Alice manages Bob");
+    await store.edges.manages.create(seniorDevelopment, juniorDevelopment, { since: "2023-06-01" });
+    console.log("  Alice manages Bob");
 
-  // Create team membership
-  await store.edges.memberOf.create(seniorDev, platformTeam, { role: "Tech Lead" });
-  await store.edges.memberOf.create(juniorDev, platformTeam, { role: "Developer" });
-  console.log("\n  Alice and Bob are members of Platform Team");
+    // Create team membership
+    await store.edges.memberOf.create(seniorDevelopment, platformTeam, { role: "Tech Lead" });
+    await store.edges.memberOf.create(juniorDevelopment, platformTeam, { role: "Developer" });
+    console.log("\n  Alice and Bob are members of Platform Team");
 
-  // Create mentorship
-  await store.edges.mentors.create(seniorDev, juniorDev, { topic: "System Design" });
-  console.log("  Alice mentors Bob on System Design");
+    // Create mentorship
+    await store.edges.mentors.create(seniorDevelopment, juniorDevelopment, { topic: "System Design" });
+    console.log("  Alice mentors Bob on System Design");
 
-  // Show inverse relationships in registry
-  console.log("\n=== Registry Inverse Lookups ===\n");
+    // Show inverse relationships in registry
+    console.log("\n=== Registry Inverse Lookups ===\n");
 
-  const registry = store.registry;
+    const registry = store.registry;
 
-  const inversePairs = [
-    "manages",
-    "reportsTo",
-    "memberOf",
-    "hasMember",
-    "mentors",
-    "mentoredBy",
-  ];
+    const inversePairs = [
+      "manages",
+      "reportsTo",
+      "memberOf",
+      "hasMember",
+      "mentors",
+      "mentoredBy",
+    ];
 
-  for (const edgeKind of inversePairs) {
-    const inverse = registry.getInverseEdge(edgeKind);
-    console.log(`  ${edgeKind} ⟷ ${inverse ?? "(none)"}`);
-  }
+    for (const edgeKind of inversePairs) {
+      const inverse = registry.getInverseEdge(edgeKind);
+      console.log(`  ${edgeKind} ⟷ ${inverse ?? "(none)"}`);
+    }
 
-  // Query from different directions
-  console.log("\n=== Querying in Both Directions ===\n");
+    // Query from different directions
+    console.log("\n=== Querying in Both Directions ===\n");
 
-  // Forward: Who does Alice manage?
-  console.log("Query: Who does Alice manage?");
-  const aliceManages = await store
-    .query()
-    .from("Employee", "manager")
-    .whereNode("manager", ({ name }) => name.eq("Alice Senior"))
-    .traverse("manages", "e")
-    .to("Employee", "report")
-    .select((ctx) => ({
-      manager: ctx.manager.name,
-      report: ctx.report.name,
-    }))
-    .execute();
-
-  for (const row of aliceManages) {
-    console.log(`  ${row.manager} manages ${row.report}`);
-  }
-
-  // Reverse: Who does Bob report to?
-  // No reportsTo edge was ever created — the inverseOf(manages, reportsTo)
-  // ontology lets the traversal follow stored manages edges inversely
-  console.log("\nQuery: Who does Bob report to? (traversing 'reportsTo')");
-  const bobReportsTo = await store
-    .query()
-    .from("Employee", "report")
-    .whereNode("report", ({ name }) => name.eq("Bob Junior"))
-    .traverse("reportsTo", "e")
-    .to("Employee", "manager")
-    .select((ctx) => ({
-      report: ctx.report.name,
-      manager: ctx.manager.name,
-    }))
-    .execute();
-
-  for (const row of bobReportsTo) {
-    console.log(`  ${row.report} reports to ${row.manager}`);
-  }
-
-  // Full management chain upward from Bob — one bound reportsTo query per level
-  console.log("\nBob's management chain (reportsTo traversal per level):");
-  type ChainEntry = Readonly<{ id: string; name: string; title: string }>;
-  let current: ChainEntry | undefined = juniorDev;
-  let level = 0;
-
-  while (current !== undefined) {
-    const employee = current;
-    const indent = "  ".repeat(level);
-    console.log(`${indent}${employee.name} (${employee.title})`);
-
-    // Find this employee's manager via the derived reportsTo edge
-    const managers: readonly ChainEntry[] = await store
+    // Forward: Who does Alice manage?
+    console.log("Query: Who does Alice manage?");
+    const aliceManages = await store
       .query()
-      .from("Employee", "emp")
-      .whereNode("emp", ({ id }) => id.eq(employee.id))
-      .traverse("reportsTo", "e")
-      .to("Employee", "mgr")
+      .from("Employee", "manager")
+      .whereNode("manager", ({ name }) => name.eq("Alice Senior"))
+      .traverse("manages", "e")
+      .to("Employee", "report")
       .select((ctx) => ({
-        id: ctx.mgr.id,
-        name: ctx.mgr.name,
-        title: ctx.mgr.title,
+        manager: ctx.manager.name,
+        report: ctx.report.name,
       }))
       .execute();
 
-    current = managers[0];
-    level++;
+    for (const row of aliceManages) {
+      console.log(`  ${row.manager} manages ${row.report}`);
+    }
+
+    // Reverse: Who does Bob report to?
+    // No reportsTo edge was ever created — the inverseOf(manages, reportsTo)
+    // ontology lets the traversal follow stored manages edges inversely
+    console.log("\nQuery: Who does Bob report to? (traversing 'reportsTo')");
+    const bobReportsTo = await store
+      .query()
+      .from("Employee", "report")
+      .whereNode("report", ({ name }) => name.eq("Bob Junior"))
+      .traverse("reportsTo", "e")
+      .to("Employee", "manager")
+      .select((ctx) => ({
+        report: ctx.report.name,
+        manager: ctx.manager.name,
+      }))
+      .execute();
+
+    for (const row of bobReportsTo) {
+      console.log(`  ${row.report} reports to ${row.manager}`);
+    }
+
+    // Full management chain upward from Bob — one bound reportsTo query per level
+    console.log("\nBob's management chain (reportsTo traversal per level):");
+    type ChainEntry = Readonly<{ id: string; name: string; title: string }>;
+    let current: ChainEntry | undefined = juniorDevelopment;
+    let level = 0;
+
+    while (current !== undefined) {
+      const employee = current;
+      const indent = "  ".repeat(level);
+      console.log(`${indent}${employee.name} (${employee.title})`);
+
+      // Find this employee's manager via the derived reportsTo edge
+      const managers: readonly ChainEntry[] = await store
+        .query()
+        .from("Employee", "emp")
+        .whereNode("emp", ({ id }) => id.eq(employee.id))
+        .traverse("reportsTo", "e")
+        .to("Employee", "mgr")
+        .select((ctx) => ({
+          id: ctx.mgr.id,
+          name: ctx.mgr.name,
+          title: ctx.mgr.title,
+        }))
+        .execute();
+
+      current = managers[0];
+      level++;
+    }
+
+    // Team membership query
+    console.log("\n=== Team Membership ===\n");
+
+    console.log("Query: Who is on the Platform Team?");
+    const teamMembers = await store
+      .query()
+      .from("Team", "team")
+      .traverse("memberOf", "m", { direction: "in" })
+      .to("Employee", "member")
+      .select((ctx) => ({
+        team: ctx.team.name,
+        member: ctx.member.name,
+      }))
+      .execute();
+
+    for (const row of teamMembers) {
+      console.log(`  ${row.member} on ${row.team}`);
+    }
+
+    console.log("\n=== Inverse edges example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // Team membership query
-  console.log("\n=== Team Membership ===\n");
-
-  console.log("Query: Who is on the Platform Team?");
-  const teamMembers = await store
-    .query()
-    .from("Team", "team")
-    .traverse("memberOf", "m", { direction: "in" })
-    .to("Employee", "member")
-    .select((ctx) => ({
-      team: ctx.team.name,
-      member: ctx.member.name,
-    }))
-    .execute();
-
-  for (const row of teamMembers) {
-    console.log(`  ${row.member} on ${row.team}`);
-  }
-
-  console.log("\n=== Inverse edges example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/07-delete-behaviors.ts
+++ b/packages/typegraph/examples/07-delete-behaviors.ts
@@ -6,15 +6,15 @@
  * - cascade: Delete all connected edges when node is deleted
  * - disconnect: Soft-delete edges, leaving orphan references
  */
-import { z } from "zod";
-
 import {
   createStore,
-  defineGraph,
   defineEdge,
+  defineGraph,
   defineNode,
   RestrictedDeleteError,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -106,172 +106,174 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  console.log("=== Delete Behaviors Examples ===\n");
-
-  // Create an author
-  const author = await store.nodes.Author.create({
-    name: "Jane Austen",
-    bio: "English novelist",
-  });
-  console.log("Created author:", author.name);
-
-  // Create a book
-  const book = await store.nodes.Book.create({
-    title: "Pride and Prejudice",
-    isbn: "978-0141439518",
-    publishedYear: 1813,
-  });
-  console.log("Created book:", book.title);
-
-  // Create a reader
-  const reader = await store.nodes.Reader.create({
-    name: "Alice Reader",
-    username: "alice_reads",
-  });
-  console.log("Created reader:", reader.name);
-
-  // Create reviews
-  const review1 = await store.nodes.Review.create({
-    rating: 5,
-    text: "A timeless classic!",
-    reviewedAt: "2023-01-15",
-  });
-
-  const review2 = await store.nodes.Review.create({
-    rating: 4,
-    text: "Wonderful characters.",
-    reviewedAt: "2023-02-20",
-  });
-  console.log("Created 2 reviews\n");
-
-  // Connect everything - pass nodes directly
-  // For edges with empty schemas, no props argument needed
-  await store.edges.wrote.create(author, book);
-  await store.edges.hasReview.create(book, review1);
-  await store.edges.hasReview.create(book, review2);
-  await store.edges.writtenBy.create(review1, reader);
-
-  console.log("Connected: Author -> Book -> Reviews -> Reader\n");
-
-  // ============================================================
-  // Demonstrate RESTRICT (default)
-  // ============================================================
-
-  console.log("=== RESTRICT Behavior (Author) ===\n");
-  console.log("Trying to delete author who has written books...");
-
   try {
-    await store.nodes.Author.delete(author.id);
-    console.log("ERROR: Should have been blocked!");
-  } catch (error) {
-    if (error instanceof RestrictedDeleteError) {
-      console.log("Deletion BLOCKED!");
-      console.log(`  Reason: ${error.message}`);
-      console.log(`  Connected edges: ${error.details.edgeCount}`);
-      console.log(`  Edge kinds: [${error.details.edgeKinds.join(", ")}]`);
-    } else {
-      throw error;
+    console.log("=== Delete Behaviors Examples ===\n");
+
+    // Create an author
+    const author = await store.nodes.Author.create({
+      name: "Jane Austen",
+      bio: "English novelist",
+    });
+    console.log("Created author:", author.name);
+
+    // Create a book
+    const book = await store.nodes.Book.create({
+      title: "Pride and Prejudice",
+      isbn: "978-0141439518",
+      publishedYear: 1813,
+    });
+    console.log("Created book:", book.title);
+
+    // Create a reader
+    const reader = await store.nodes.Reader.create({
+      name: "Alice Reader",
+      username: "alice_reads",
+    });
+    console.log("Created reader:", reader.name);
+
+    // Create reviews
+    const review1 = await store.nodes.Review.create({
+      rating: 5,
+      text: "A timeless classic!",
+      reviewedAt: "2023-01-15",
+    });
+
+    const review2 = await store.nodes.Review.create({
+      rating: 4,
+      text: "Wonderful characters.",
+      reviewedAt: "2023-02-20",
+    });
+    console.log("Created 2 reviews\n");
+
+    // Connect everything - pass nodes directly
+    // For edges with empty schemas, no props argument needed
+    await store.edges.wrote.create(author, book);
+    await store.edges.hasReview.create(book, review1);
+    await store.edges.hasReview.create(book, review2);
+    await store.edges.writtenBy.create(review1, reader);
+
+    console.log("Connected: Author -> Book -> Reviews -> Reader\n");
+
+    // ============================================================
+    // Demonstrate RESTRICT (default)
+    // ============================================================
+
+    console.log("=== RESTRICT Behavior (Author) ===\n");
+    console.log("Trying to delete author who has written books...");
+
+    try {
+      await store.nodes.Author.delete(author.id);
+      console.log("ERROR: Should have been blocked!");
+    } catch (error) {
+      if (error instanceof RestrictedDeleteError) {
+        console.log("Deletion BLOCKED!");
+        console.log(`  Reason: ${error.message}`);
+        console.log(`  Connected edges: ${error.details.edgeCount}`);
+        console.log(`  Edge kinds: [${error.details.edgeKinds.join(", ")}]`);
+      } else {
+        throw error;
+      }
     }
+
+    // ============================================================
+    // Demonstrate CASCADE
+    // ============================================================
+
+    console.log("\n=== CASCADE Behavior (Book) ===\n");
+
+    // First verify reviews exist
+    const reviewsBefore = await store.nodes.Review.getById(review1.id);
+    console.log("Review exists before book deletion:", reviewsBefore !== undefined);
+
+    // Check edges before
+    const edgesBefore = await backend.findEdgesConnectedTo({
+      graphId: "bookstore",
+      nodeKind: "Book",
+      nodeId: book.id,
+    });
+    console.log("Edges connected to book:", edgesBefore.length);
+
+    // Delete book - should cascade and delete hasReview edges
+    console.log("\nDeleting book (cascade)...");
+    await store.nodes.Book.delete(book.id);
+    console.log("Book deleted!");
+
+    // Check edges after
+    const edgesAfter = await backend.findEdgesConnectedTo({
+      graphId: "bookstore",
+      nodeKind: "Book",
+      nodeId: book.id,
+    });
+    console.log("Edges connected to book after deletion:", edgesAfter.length);
+
+    // Reviews still exist (only edges were deleted, not target nodes)
+    const reviewsAfter = await store.nodes.Review.getById(review1.id);
+    console.log("Review still exists after cascade:", reviewsAfter !== undefined);
+
+    // Now author can be deleted (no more edges)
+    console.log("\nNow deleting author (no edges remain)...");
+    await store.nodes.Author.delete(author.id);
+    console.log("Author deleted successfully!");
+
+    // ============================================================
+    // Demonstrate DISCONNECT
+    // ============================================================
+
+    console.log("\n=== DISCONNECT Behavior (Review) ===\n");
+
+    // Check edges to reader before
+    const readerEdgesBefore = await backend.findEdgesConnectedTo({
+      graphId: "bookstore",
+      nodeKind: "Reader",
+      nodeId: reader.id,
+    });
+    console.log("Edges connected to reader before:", readerEdgesBefore.length);
+
+    // Delete review - should disconnect (soft-delete edges)
+    console.log("Deleting review (disconnect)...");
+    await store.nodes.Review.delete(review1.id);
+    console.log("Review deleted!");
+
+    // Edge should be soft-deleted (gone from active queries)
+    const readerEdgesAfter = await backend.findEdgesConnectedTo({
+      graphId: "bookstore",
+      nodeKind: "Reader",
+      nodeId: reader.id,
+    });
+    console.log("Active edges connected to reader after:", readerEdgesAfter.length);
+
+    // Reader still exists
+    const readerAfter = await store.nodes.Reader.getById(reader.id);
+    console.log("Reader still exists:", readerAfter !== undefined);
+
+    // ============================================================
+    // Summary
+    // ============================================================
+
+    console.log("\n=== Delete Behavior Summary ===\n");
+    console.log("RESTRICT (default):");
+    console.log("  - Blocks deletion if any edges exist");
+    console.log("  - Use for entities that must be cleaned up manually");
+    console.log("  - Example: Authors must have books removed first\n");
+
+    console.log("CASCADE:");
+    console.log("  - Automatically deletes all connected edges");
+    console.log("  - Use for aggregate roots that own their relationships");
+    console.log("  - Example: Deleting a book removes its review links\n");
+
+    console.log("DISCONNECT:");
+    console.log("  - Soft-deletes edges, leaving them as historical records");
+    console.log("  - Use when you need to preserve relationship history");
+    console.log("  - Example: Reviews deleted but history preserved");
+
+    console.log("\n=== Delete behaviors example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // ============================================================
-  // Demonstrate CASCADE
-  // ============================================================
-
-  console.log("\n=== CASCADE Behavior (Book) ===\n");
-
-  // First verify reviews exist
-  const reviewsBefore = await store.nodes.Review.getById(review1.id);
-  console.log("Review exists before book deletion:", reviewsBefore !== undefined);
-
-  // Check edges before
-  const edgesBefore = await backend.findEdgesConnectedTo({
-    graphId: "bookstore",
-    nodeKind: "Book",
-    nodeId: book.id,
-  });
-  console.log("Edges connected to book:", edgesBefore.length);
-
-  // Delete book - should cascade and delete hasReview edges
-  console.log("\nDeleting book (cascade)...");
-  await store.nodes.Book.delete(book.id);
-  console.log("Book deleted!");
-
-  // Check edges after
-  const edgesAfter = await backend.findEdgesConnectedTo({
-    graphId: "bookstore",
-    nodeKind: "Book",
-    nodeId: book.id,
-  });
-  console.log("Edges connected to book after deletion:", edgesAfter.length);
-
-  // Reviews still exist (only edges were deleted, not target nodes)
-  const reviewsAfter = await store.nodes.Review.getById(review1.id);
-  console.log("Review still exists after cascade:", reviewsAfter !== undefined);
-
-  // Now author can be deleted (no more edges)
-  console.log("\nNow deleting author (no edges remain)...");
-  await store.nodes.Author.delete(author.id);
-  console.log("Author deleted successfully!");
-
-  // ============================================================
-  // Demonstrate DISCONNECT
-  // ============================================================
-
-  console.log("\n=== DISCONNECT Behavior (Review) ===\n");
-
-  // Check edges to reader before
-  const readerEdgesBefore = await backend.findEdgesConnectedTo({
-    graphId: "bookstore",
-    nodeKind: "Reader",
-    nodeId: reader.id,
-  });
-  console.log("Edges connected to reader before:", readerEdgesBefore.length);
-
-  // Delete review - should disconnect (soft-delete edges)
-  console.log("Deleting review (disconnect)...");
-  await store.nodes.Review.delete(review1.id);
-  console.log("Review deleted!");
-
-  // Edge should be soft-deleted (gone from active queries)
-  const readerEdgesAfter = await backend.findEdgesConnectedTo({
-    graphId: "bookstore",
-    nodeKind: "Reader",
-    nodeId: reader.id,
-  });
-  console.log("Active edges connected to reader after:", readerEdgesAfter.length);
-
-  // Reader still exists
-  const readerAfter = await store.nodes.Reader.getById(reader.id);
-  console.log("Reader still exists:", readerAfter !== undefined);
-
-  // ============================================================
-  // Summary
-  // ============================================================
-
-  console.log("\n=== Delete Behavior Summary ===\n");
-  console.log("RESTRICT (default):");
-  console.log("  - Blocks deletion if any edges exist");
-  console.log("  - Use for entities that must be cleaned up manually");
-  console.log("  - Example: Authors must have books removed first\n");
-
-  console.log("CASCADE:");
-  console.log("  - Automatically deletes all connected edges");
-  console.log("  - Use for aggregate roots that own their relationships");
-  console.log("  - Example: Deleting a book removes its review links\n");
-
-  console.log("DISCONNECT:");
-  console.log("  - Soft-deletes edges, leaving them as historical records");
-  console.log("  - Use when you need to preserve relationship history");
-  console.log("  - Example: Reviews deleted but history preserved");
-
-  console.log("\n=== Delete behaviors example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/08-custom-ontology.ts
+++ b/packages/typegraph/examples/08-custom-ontology.ts
@@ -18,8 +18,6 @@
  * Run with:
  *   npx tsx examples/08-custom-ontology.ts
  */
-import { z } from "zod";
-
 import {
   broader,
   createStore,
@@ -30,8 +28,8 @@ import {
   equivalentTo,
   implies,
   inverseOf,
-  metaEdge,
   type MetaEdge,
+  metaEdge,
   narrower,
   type NodeType,
   type OntologyRelation,
@@ -39,6 +37,8 @@ import {
   relatedTo,
   subClassOf,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -446,7 +446,7 @@ export async function main() {
       .select((ctx) => ({ title: ctx.pub.title, kind: ctx.pub.kind }))
       .execute();
     for (const row of publications) {
-      console.log(`  [${row.kind}] "${row.title}"`);
+      console.log(`  [${row.kind}] "${String(row.title)}"`);
     }
 
     // Bound topic filter: only papers tagged with the Deep Learning field.
@@ -462,7 +462,7 @@ export async function main() {
       .select((ctx) => ({ title: ctx.p.title, topic: ctx.t.name }))
       .execute();
     for (const row of dlPapers) {
-      console.log(`  "${row.title}" is about ${row.topic}`);
+      console.log(`  "${row.title}" is about ${String(row.topic)}`);
     }
 
     // SKOS closure feeding a query: publications about AI or any narrower
@@ -477,7 +477,7 @@ export async function main() {
       .select((ctx) => ({ title: ctx.pub.title, field: ctx.t.name }))
       .execute();
     for (const row of aiPublications) {
-      console.log(`  "${row.title}" (via ${row.field})`);
+      console.log(`  "${String(row.title)}" (via ${String(row.field)})`);
     }
 
     // Implication expansion: the published paper has NO explicit cites edge,
@@ -501,7 +501,7 @@ export async function main() {
       .select((ctx) => ({ title: ctx.cited.title }))
       .execute();
     for (const row of impliedCites) {
-      console.log(`  With expand "implying": cites "${row.title}" (via buildsOn)`);
+      console.log(`  With expand "implying": cites "${String(row.title)}" (via buildsOn)`);
     }
 
     // Inverse + implication combined: nothing ever wrote a citedBy edge,
@@ -516,7 +516,7 @@ export async function main() {
       .select((ctx) => ({ title: ctx.citing.title }))
       .execute();
     for (const row of citingPublications) {
-      console.log(`  Cited by "${row.title}"`);
+      console.log(`  Cited by "${String(row.title)}"`);
     }
 
     // --- Custom meta-edges in practice ------------------------------
@@ -646,7 +646,7 @@ export async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/08-custom-ontology.ts
+++ b/packages/typegraph/examples/08-custom-ontology.ts
@@ -1,11 +1,22 @@
 /**
- * Example 08: Custom Ontology
+ * Example 08: Advanced Ontology and Custom Meta-Edges
  *
- * This example demonstrates advanced ontology features:
- * - Using the full set of core meta-edges
- * - Creating custom meta-edges for domain-specific semantics
- * - Combining multiple ontological relationships
- * - Building a rich domain model
+ * This example builds a research knowledge graph and demonstrates:
+ * - The core meta-edges working together: subClassOf, broader/narrower,
+ *   equivalentTo (with an external IRI), disjointWith, partOf, inverseOf,
+ *   and implies — each with an observable registry or query effect.
+ * - Custom meta-edges (`metaEdge(...)`) registered in `ontology: []`:
+ *   what the library does with them (persists, introspects, serializes)
+ *   and what it deliberately does not (no built-in inference — the
+ *   KindRegistry computes closures only for the core meta-edges, so
+ *   custom semantics are interpreted by your application, as shown here).
+ * - Ontology relations are TYPE-level (between kinds), never instance-level.
+ *   That is why research fields are modeled as node kinds below: a SKOS
+ *   statement like "DeepLearning narrower-than ArtificialIntelligence"
+ *   must relate kinds, not two rows in a Topic table.
+ *
+ * Run with:
+ *   npx tsx examples/08-custom-ontology.ts
  */
 import { z } from "zod";
 
@@ -17,54 +28,64 @@ import {
   defineNode,
   disjointWith,
   equivalentTo,
-  hasPart,
   implies,
   inverseOf,
   metaEdge,
+  type MetaEdge,
   narrower,
+  type NodeType,
+  type OntologyRelation,
   partOf,
   relatedTo,
-  sameAs,
   subClassOf,
 } from "@nicia-ai/typegraph";
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
-// Part 1: Using All Core Meta-Edges
+// Named Constants
 // ============================================================
 
-// Domain: A Research Knowledge Graph
+const SCHEMA_ORG_PERSON_IRI = "https://schema.org/Person";
+const DEEP_LEARNING_NAME = "Deep Learning";
+const ATTENTION_PAPER_TITLE = "Attention Is All You Need";
+const SEQ2SEQ_PAPER_TITLE = "Sequence to Sequence Learning with Neural Networks";
 
-// === Node Types ===
+// ============================================================
+// Part 1: Node and Edge Kinds
+// ============================================================
 
-const Concept = defineNode("Concept", {
-  schema: z.object({
-    name: z.string(),
-    definition: z.string().optional(),
-  }),
+// Research fields as node KINDS, arranged both in an is-a hierarchy
+// (every field is a Topic) and a SKOS concept hierarchy (AI ⊃ ML ⊃ DL).
+const TOPIC_SCHEMA = z.object({ name: z.string() });
+
+const Topic = defineNode("Topic", { schema: TOPIC_SCHEMA });
+const ArtificialIntelligence = defineNode("ArtificialIntelligence", {
+  schema: TOPIC_SCHEMA,
+});
+const MachineLearning = defineNode("MachineLearning", { schema: TOPIC_SCHEMA });
+const DeepLearning = defineNode("DeepLearning", { schema: TOPIC_SCHEMA });
+const NaturalLanguageProcessing = defineNode("NaturalLanguageProcessing", {
+  schema: TOPIC_SCHEMA,
 });
 
-const Topic = defineNode("Topic", {
-  schema: z.object({
-    name: z.string(),
-    field: z.string(),
-  }),
+// Publications: Paper and Preprint are both kinds of Publication.
+const PUBLICATION_SCHEMA = z.object({
+  title: z.string(),
+  year: z.number().int(),
 });
 
+const Publication = defineNode("Publication", { schema: PUBLICATION_SCHEMA });
 const Paper = defineNode("Paper", {
-  schema: z.object({
-    title: z.string(),
-    abstract: z.string().optional(),
-    year: z.number().int(),
-    doi: z.string().optional(),
-  }),
+  schema: PUBLICATION_SCHEMA.extend({ doi: z.string().optional() }),
+});
+const Preprint = defineNode("Preprint", {
+  schema: PUBLICATION_SCHEMA.extend({ server: z.string().optional() }),
 });
 
 const Author = defineNode("Author", {
   schema: z.object({
     name: z.string(),
-    affiliation: z.string().optional(),
-    orcid: z.string().optional(), // ORCID identifier
+    orcid: z.string().optional(),
   }),
 });
 
@@ -72,365 +93,556 @@ const Institution = defineNode("Institution", {
   schema: z.object({
     name: z.string(),
     country: z.string(),
-    rorId: z.string().optional(), // ROR identifier
   }),
 });
 
 const Department = defineNode("Department", {
-  schema: z.object({
-    name: z.string(),
-  }),
+  schema: z.object({ name: z.string() }),
 });
 
-const ResearchGroup = defineNode("ResearchGroup", {
-  schema: z.object({
-    name: z.string(),
-    focus: z.string(),
-  }),
-});
-
-// === Edge Types ===
-
+// Instance-level relationships. Runtime endpoint validation is
+// subclass-aware, so `to: [Publication]` alone would accept Paper and
+// Preprint nodes — but the compile-time endpoint types are exact, so we
+// also list the concrete kinds to keep direct node-handle creation
+// (`create(alice, somePaper)`) type-safe. Same pattern as example 03.
 const authorOf = defineEdge("authorOf", {
-  schema: z.object({
-    position: z.number().int().optional(), // Author position
-  }),
+  schema: z.object({ position: z.number().int().optional() }),
 });
 
-const cites = defineEdge("cites", {
-  schema: z.object({
-    context: z.string().optional(),
-  }),
-});
-
-const citedBy = defineEdge("citedBy", {
-  schema: z.object({
-    context: z.string().optional(),
-  }),
-});
-
-const about = defineEdge("about", {
-  schema: z.object({}),
-});
+const cites = defineEdge("cites", { schema: z.object({}) });
+const citedBy = defineEdge("citedBy", { schema: z.object({}) });
+const buildsOn = defineEdge("buildsOn", { schema: z.object({}) });
+const about = defineEdge("about", { schema: z.object({}) });
 
 const affiliatedWith = defineEdge("affiliatedWith", {
-  schema: z.object({
-    since: z.string().optional(),
-  }),
+  schema: z.object({ since: z.string().optional() }),
 });
 
-const memberOf = defineEdge("memberOf", {
-  schema: z.object({
-    role: z.string().optional(),
-  }),
-});
-
-const locatedIn = defineEdge("locatedIn", {
-  schema: z.object({}),
-});
+const belongsTo = defineEdge("belongsTo", { schema: z.object({}) });
 
 // ============================================================
-// Part 2: Create Custom Meta-Edges
+// Part 2: Custom Meta-Edges
 // ============================================================
 
-// Custom meta-edge for "prerequisite" relationships
-// If learning topic A requires knowing topic B first
+// A custom meta-edge is a TYPE-level vocabulary term. The library stores
+// its relations in the graph definition, exposes them through
+// `store.introspect().ontology`, and serializes them with the schema —
+// but the built-in KindRegistry computes closures ONLY for the core
+// meta-edges. Custom semantics (like the transitive walk below) are
+// interpreted by your application.
+
+// Learning prerequisite between topic kinds:
+// "you should know the from-kind before studying the to-kind".
 const prerequisiteOfMetaEdge = metaEdge("prerequisiteOf", {
-  transitive: true, // If A prereq B and B prereq C, then A prereq C
+  transitive: true, // AI prereq ML, ML prereq DL => AI prereq DL
   inference: "hierarchy",
-  description: "Learning prerequisite (Calculus prerequisiteOf Linear Algebra)",
+  description: "Learning prerequisite between research-field kinds",
 });
 
-// Custom meta-edge for "supersedes" relationships
-// When one thing replaces another (e.g., new API version)
+// Replacement between publication kinds:
+// "the from-kind is the authoritative successor of the to-kind".
 const supersedesMetaEdge = metaEdge("supersedes", {
-  transitive: true, // If A supersedes B and B supersedes C, then A supersedes C
   inference: "substitution",
-  description: "Replacement relationship (v2 supersedes v1)",
+  description: "The from-kind is the authoritative successor of the to-kind",
 });
 
-// Custom factory function for our meta-edge
+// Factory functions in the same style as the core `subClassOf`, `broader`, ...
 function prerequisiteOf(
-  prerequisite: typeof Topic,
-  dependent: typeof Topic,
-) {
-  return {
-    metaEdge: prerequisiteOfMetaEdge,
-    from: prerequisite,
-    to: dependent,
-  };
+  prerequisite: NodeType,
+  dependent: NodeType,
+): OntologyRelation {
+  return { metaEdge: prerequisiteOfMetaEdge, from: prerequisite, to: dependent };
 }
 
 function supersedes(
-  newer: typeof Paper,
-  older: typeof Paper,
-) {
-  return {
-    metaEdge: supersedesMetaEdge,
-    from: newer,
-    to: older,
-  };
+  newerKind: NodeType,
+  olderKind: NodeType,
+): OntologyRelation {
+  return { metaEdge: supersedesMetaEdge, from: newerKind, to: olderKind };
 }
 
 // ============================================================
-// Part 3: Define the Graph
+// Part 3: The Graph and Its Ontology
 // ============================================================
 
 const graph = defineGraph({
   id: "research_kg",
   nodes: {
-    Concept: { type: Concept },
     Topic: { type: Topic },
+    ArtificialIntelligence: { type: ArtificialIntelligence },
+    MachineLearning: { type: MachineLearning },
+    DeepLearning: { type: DeepLearning },
+    NaturalLanguageProcessing: { type: NaturalLanguageProcessing },
+    Publication: { type: Publication },
     Paper: { type: Paper },
+    Preprint: { type: Preprint },
     Author: { type: Author },
     Institution: { type: Institution },
     Department: { type: Department },
-    ResearchGroup: { type: ResearchGroup },
   },
   edges: {
-    authorOf: { type: authorOf, from: [Author], to: [Paper] },
-    cites: { type: cites, from: [Paper], to: [Paper] },
-    citedBy: { type: citedBy, from: [Paper], to: [Paper] },
-    about: { type: about, from: [Paper], to: [Topic, Concept] },
+    authorOf: {
+      type: authorOf,
+      from: [Author],
+      to: [Publication, Paper, Preprint],
+    },
+    cites: {
+      type: cites,
+      from: [Publication, Paper, Preprint],
+      to: [Publication, Paper, Preprint],
+    },
+    citedBy: {
+      type: citedBy,
+      from: [Publication, Paper, Preprint],
+      to: [Publication, Paper, Preprint],
+    },
+    buildsOn: {
+      type: buildsOn,
+      from: [Publication, Paper, Preprint],
+      to: [Publication, Paper, Preprint],
+    },
+    about: {
+      type: about,
+      from: [Publication, Paper, Preprint],
+      to: [
+        Topic,
+        ArtificialIntelligence,
+        MachineLearning,
+        DeepLearning,
+        NaturalLanguageProcessing,
+      ],
+    },
     affiliatedWith: { type: affiliatedWith, from: [Author], to: [Institution] },
-    memberOf: { type: memberOf, from: [Author], to: [ResearchGroup] },
-    locatedIn: { type: locatedIn, from: [Department, ResearchGroup], to: [Institution] },
+    belongsTo: { type: belongsTo, from: [Department], to: [Institution] },
   },
   ontology: [
-    // === Subsumption (Type Hierarchy) ===
-    // Topics and Concepts are both types of abstract knowledge
-    subClassOf(Topic, Concept),
+    // === Subsumption (is-a) ===
+    subClassOf(Paper, Publication),
+    subClassOf(Preprint, Publication),
+    subClassOf(ArtificialIntelligence, Topic),
+    subClassOf(MachineLearning, Topic),
+    subClassOf(DeepLearning, Topic),
+    subClassOf(NaturalLanguageProcessing, Topic),
 
-    // Departments and Research Groups are organizational units
-    subClassOf(Department, Institution),
+    // === SKOS-style concept hierarchy (independent of is-a) ===
+    // "Machine Learning is narrower than Artificial Intelligence" — and
+    // narrower/broader are inverses, so one statement per pair suffices.
+    broader(MachineLearning, ArtificialIntelligence),
+    narrower(MachineLearning, DeepLearning),
+    relatedTo(NaturalLanguageProcessing, MachineLearning),
 
-    // === Hierarchical Relationships (SKOS-style) ===
-    // Machine Learning is narrower than Artificial Intelligence
-    // (we'll create the actual instances in the demo)
+    // === Equivalence with an external IRI ===
+    equivalentTo(Author, SCHEMA_ORG_PERSON_IRI),
 
-    // === Equivalence ===
-    // sameAs is for exact identity (usually external IRIs)
-    // equivalentTo is for semantic equivalence
-
-    // === Disjoint Constraints ===
-    // A Paper cannot be an Author (and vice versa)
+    // === Disjointness constraints ===
     disjointWith(Paper, Author),
-    disjointWith(Paper, Institution),
     disjointWith(Author, Institution),
 
-    // === Composition ===
-    // Institutions have Departments as parts
-    hasPart(Institution, Department),
+    // === Composition (part-of) ===
+    // A Department is PART OF an Institution (part-whole), not a kind of
+    // Institution — `subClassOf(Department, Institution)` would wrongly
+    // claim every Department IS an Institution. Model is-a with
+    // subClassOf and part-of with partOf; hasPart is derived as its inverse.
     partOf(Department, Institution),
 
-    // === Edge Relationships ===
-    // cites and citedBy are inverses
+    // === Edge semantics ===
     inverseOf(cites, citedBy),
+    // Both edges are Publication -> Publication, so the implication is
+    // endpoint-compatible. Pitfall: the library does NOT validate this —
+    // an implication between edges with mismatched endpoints (say,
+    // Author->Paper implies Paper->Topic) is silently accepted, and
+    // `expand: "implying"` would then traverse the mismatched edges.
+    // Keep implication chains within compatible endpoint signatures.
+    implies(buildsOn, cites),
 
-    // authorOf implies the author is related to the paper's topics
-    // (if you authored a paper about X, you're related to X)
-    implies(authorOf, about),
-
-    // === Association ===
-    // Topics can be related to each other
-    relatedTo(Topic, Topic),
-
-    // Custom ontology relationships would go here
-    // prerequisiteOf(TopicA, TopicB),
-    // supersedes(PaperV2, PaperV1),
+    // === Custom meta-edge relations ===
+    prerequisiteOf(ArtificialIntelligence, MachineLearning),
+    prerequisiteOf(MachineLearning, DeepLearning),
+    supersedes(Paper, Preprint),
   ],
 });
 
 // ============================================================
-// Part 4: Demonstrate the Rich Domain Model
+// Part 4: Application-Level Inference over Custom Meta-Edges
 // ============================================================
+
+function endpointKindName(endpoint: OntologyRelation["from"]): string {
+  return typeof endpoint === "string" ? endpoint : endpoint.kind;
+}
+
+/**
+ * Answers "does `fromKind` relate to `toKind` via this custom meta-edge?"
+ * by reading the graph's own ontology relations. Honors the meta-edge's
+ * declared `transitive` property with a breadth-first walk — this is the
+ * pattern for giving custom meta-edges real semantics in your application.
+ */
+function relatesVia(
+  ontology: readonly OntologyRelation[],
+  customMetaEdge: MetaEdge,
+  fromKind: string,
+  toKind: string,
+): boolean {
+  const directPairs = ontology
+    .filter((relation) => relation.metaEdge.name === customMetaEdge.name)
+    .map(
+      (relation) =>
+        [endpointKindName(relation.from), endpointKindName(relation.to)] as const,
+    );
+
+  if (!customMetaEdge.properties.transitive) {
+    return directPairs.some(([from, to]) => from === fromKind && to === toKind);
+  }
+
+  const visited = new Set<string>([fromKind]);
+  const queue = [fromKind];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) break;
+    for (const [from, to] of directPairs) {
+      if (from !== current || visited.has(to)) continue;
+      if (to === toKind) return true;
+      visited.add(to);
+      queue.push(to);
+    }
+  }
+  return false;
+}
+
+// ============================================================
+// Part 5: Demonstration
+// ============================================================
+
+function assertClaim(claim: string, actual: boolean): void {
+  if (!actual) throw new Error(`Claim failed: ${claim}`);
+  console.log(`  [ok] ${claim}`);
+}
 
 export async function main() {
   const backend = createExampleBackend();
-  const store = createStore(graph, backend);
+  try {
+    const store = createStore(graph, backend);
+    const registry = store.registry;
 
-  console.log("=== Custom Ontology Examples ===\n");
+    console.log("=== Advanced Ontology and Custom Meta-Edges ===\n");
 
-  // Create some institutions
-  const mit = await store.nodes.Institution.create({
-    name: "Massachusetts Institute of Technology",
-    country: "USA",
-    rorId: "https://ror.org/042nb2s44",
-  });
+    // --- Instance data ---------------------------------------------
 
-  const stanford = await store.nodes.Institution.create({
-    name: "Stanford University",
-    country: "USA",
-    rorId: "https://ror.org/00f54p054",
-  });
+    const mit = await store.nodes.Institution.create({
+      name: "Massachusetts Institute of Technology",
+      country: "USA",
+    });
+    const csail = await store.nodes.Department.create({ name: "CSAIL" });
+    await store.edges.belongsTo.create(csail, mit);
 
-  console.log("Created institutions: MIT, Stanford");
+    const alice = await store.nodes.Author.create({
+      name: "Dr. Alice Researcher",
+      orcid: "0000-0001-2345-6789",
+    });
+    await store.edges.affiliatedWith.create(alice, mit, {
+      since: "2018-09-01",
+    });
 
-  // Create research groups
-  const mlGroup = await store.nodes.ResearchGroup.create({
-    name: "Machine Learning Group",
-    focus: "Deep Learning and Neural Networks",
-  });
+    const ml = await store.nodes.MachineLearning.create({
+      name: "Machine Learning",
+    });
+    const dl = await store.nodes.DeepLearning.create({
+      name: DEEP_LEARNING_NAME,
+    });
+    const nlp = await store.nodes.NaturalLanguageProcessing.create({
+      name: "Natural Language Processing",
+    });
 
-  await store.edges.locatedIn.create(
-    { kind: "ResearchGroup", id: mlGroup.id },
-    { kind: "Institution", id: mit.id },
-    {},
-  );
+    const seq2seq = await store.nodes.Paper.create({
+      title: SEQ2SEQ_PAPER_TITLE,
+      year: 2014,
+    });
+    const attentionPreprint = await store.nodes.Preprint.create({
+      title: `${ATTENTION_PAPER_TITLE} (preprint)`,
+      year: 2017,
+      server: "arXiv",
+    });
+    const attentionPaper = await store.nodes.Paper.create({
+      title: ATTENTION_PAPER_TITLE,
+      year: 2017,
+      doi: "10.5555/3295222.3295349",
+    });
 
-  console.log("Created research group at MIT");
+    await store.edges.authorOf.create(alice, attentionPaper, { position: 1 });
+    await store.edges.authorOf.create(alice, attentionPreprint, {
+      position: 1,
+    });
 
-  // Create authors
-  const alice = await store.nodes.Author.create({
-    name: "Dr. Alice Researcher",
-    affiliation: "MIT",
-    orcid: "0000-0001-2345-6789",
-  });
+    await store.edges.about.create(attentionPaper, dl);
+    await store.edges.about.create(attentionPaper, nlp);
+    await store.edges.about.create(seq2seq, ml);
 
-  await store.edges.affiliatedWith.create(
-    { kind: "Author", id: alice.id },
-    { kind: "Institution", id: mit.id },
-    { since: "2018-09-01" },
-  );
+    // The published paper only records buildsOn; `implies(buildsOn, cites)`
+    // lets queries surface it as a citation. The preprint cites explicitly.
+    await store.edges.buildsOn.create(attentionPaper, seq2seq);
+    await store.edges.cites.create(attentionPreprint, seq2seq);
 
-  await store.edges.memberOf.create(
-    { kind: "Author", id: alice.id },
-    { kind: "ResearchGroup", id: mlGroup.id },
-    { role: "Principal Investigator" },
-  );
+    console.log("Created 1 institution, 1 department, 1 author,");
+    console.log("3 research-field nodes, and 3 publications.\n");
 
-  console.log("Created author: Dr. Alice Researcher");
+    // --- Registry: core meta-edge reasoning ------------------------
 
-  // Create topics with hierarchy
-  const ai = await store.nodes.Topic.create({ name: "Artificial Intelligence", field: "Computer Science" });
-  const ml = await store.nodes.Topic.create({ name: "Machine Learning", field: "Computer Science" });
-  const dl = await store.nodes.Topic.create({ name: "Deep Learning", field: "Computer Science" });
-  const nlp = await store.nodes.Topic.create({ name: "Natural Language Processing", field: "Computer Science" });
+    console.log("=== Registry: Core Meta-Edge Reasoning ===\n");
 
-  console.log("Created topics: AI, ML, Deep Learning, NLP");
+    console.log("Subsumption (subClassOf):");
+    console.log(
+      "  Publication expands to:",
+      registry.expandSubClasses("Publication").join(", "),
+    );
 
-  // Create a paper
-  const paper = await store.nodes.Paper.create({
-    title: "Attention Is All You Need",
-    abstract: "The dominant sequence transduction models...",
-    year: 2017,
-    doi: "10.5555/3295222.3295349",
-  });
+    console.log("\nSKOS hierarchy (broader/narrower, transitive):");
+    console.log(
+      "  DeepLearning narrower than ArtificialIntelligence?",
+      registry.isNarrowerThan("DeepLearning", "ArtificialIntelligence"),
+    );
+    const aiOrNarrower = registry.expandNarrower("ArtificialIntelligence");
+    console.log(
+      "  ArtificialIntelligence and narrower:",
+      aiOrNarrower.join(", "),
+    );
 
-  await store.edges.authorOf.create(
-    { kind: "Author", id: alice.id },
-    { kind: "Paper", id: paper.id },
-    { position: 1 },
-  );
+    console.log("\nEquivalence (external IRI):");
+    console.log(
+      `  ${SCHEMA_ORG_PERSON_IRI} resolves to:`,
+      registry.resolveIri(SCHEMA_ORG_PERSON_IRI),
+    );
 
-  await store.edges.about.create(
-    { kind: "Paper", id: paper.id },
-    { kind: "Topic", id: dl.id },
-    {},
-  );
+    console.log("\nDisjointness:");
+    console.log(
+      "  Paper and Author disjoint?",
+      registry.areDisjoint("Paper", "Author"),
+    );
 
-  await store.edges.about.create(
-    { kind: "Paper", id: paper.id },
-    { kind: "Topic", id: nlp.id },
-    {},
-  );
+    console.log("\nComposition (partOf; hasPart derived as inverse):");
+    console.log(
+      "  Department part of Institution?",
+      registry.isPartOf("Department", "Institution"),
+    );
+    console.log(
+      "  Parts of Institution:",
+      registry.getParts("Institution").join(", "),
+    );
 
-  console.log("Created paper: 'Attention Is All You Need'\n");
+    console.log("\nEdge semantics:");
+    console.log("  Inverse of 'cites':", registry.getInverseEdge("cites"));
+    console.log(
+      "  'buildsOn' implies:",
+      registry.getImpliedEdges("buildsOn").join(", "),
+    );
 
-  // ============================================================
-  // Demonstrate Registry Capabilities
-  // ============================================================
+    // --- Queries shaped by the ontology -----------------------------
 
-  console.log("=== Registry Analysis ===\n");
+    console.log("\n=== Queries Shaped by the Ontology ===\n");
 
-  const registry = store.registry;
+    // Subsumption expansion: one query over the whole publication hierarchy.
+    console.log("All publications (from 'Publication', includeSubClasses):");
+    const publications = await store
+      .query()
+      .from("Publication", "pub", { includeSubClasses: true })
+      .select((ctx) => ({ title: ctx.pub.title, kind: ctx.pub.kind }))
+      .execute();
+    for (const row of publications) {
+      console.log(`  [${row.kind}] "${row.title}"`);
+    }
 
-  // Check disjointness
-  console.log("Disjoint checks:");
-  console.log("  Paper and Author disjoint?", registry.areDisjoint("Paper", "Author"));
-  console.log("  Topic and Concept disjoint?", registry.areDisjoint("Topic", "Concept"));
+    // Bound topic filter: only papers tagged with the Deep Learning field.
+    // `includeSubClasses` widens the target alias to the base kind, so we
+    // bind on `kind` (always statically typed) rather than a schema field.
+    console.log(`\nPapers about ${DEEP_LEARNING_NAME}:`);
+    const dlPapers = await store
+      .query()
+      .from("Paper", "p")
+      .traverse("about", "a")
+      .to("Topic", "t", { includeSubClasses: true })
+      .whereNode("t", (topic) => topic.kind.eq(DeepLearning.kind))
+      .select((ctx) => ({ title: ctx.p.title, topic: ctx.t.name }))
+      .execute();
+    for (const row of dlPapers) {
+      console.log(`  "${row.title}" is about ${row.topic}`);
+    }
 
-  // Check subsumption
-  console.log("\nSubsumption checks:");
-  console.log("  Topic subClassOf Concept?", registry.isSubClassOf("Topic", "Concept"));
+    // SKOS closure feeding a query: publications about AI or any narrower
+    // field, without tagging anything "Artificial Intelligence" directly.
+    console.log("\nPublications about AI or any narrower field:");
+    const aiPublications = await store
+      .query()
+      .from("Publication", "pub", { includeSubClasses: true })
+      .traverse("about", "a")
+      .to("Topic", "t", { includeSubClasses: true })
+      .whereNode("t", (topic) => topic.kind.in([...aiOrNarrower]))
+      .select((ctx) => ({ title: ctx.pub.title, field: ctx.t.name }))
+      .execute();
+    for (const row of aiPublications) {
+      console.log(`  "${row.title}" (via ${row.field})`);
+    }
 
-  // Check edge inverses
-  console.log("\nEdge inverses:");
-  console.log("  Inverse of 'cites':", registry.getInverseEdge("cites"));
-  console.log("  Inverse of 'citedBy':", registry.getInverseEdge("citedBy"));
+    // Implication expansion: the published paper has NO explicit cites edge,
+    // only buildsOn — `expand: "implying"` surfaces it as a citation.
+    console.log(`\nWhat does "${ATTENTION_PAPER_TITLE}" cite?`);
+    const explicitCites = await store
+      .query()
+      .from("Paper", "p")
+      .whereNode("p", ({ title }) => title.eq(ATTENTION_PAPER_TITLE))
+      .traverse("cites", "c", { expand: "none" })
+      .to("Publication", "cited", { includeSubClasses: true })
+      .select((ctx) => ({ title: ctx.cited.title }))
+      .execute();
+    console.log(`  Explicit cites edges: ${explicitCites.length}`);
+    const impliedCites = await store
+      .query()
+      .from("Paper", "p")
+      .whereNode("p", ({ title }) => title.eq(ATTENTION_PAPER_TITLE))
+      .traverse("cites", "c", { expand: "implying" })
+      .to("Publication", "cited", { includeSubClasses: true })
+      .select((ctx) => ({ title: ctx.cited.title }))
+      .execute();
+    for (const row of impliedCites) {
+      console.log(`  With expand "implying": cites "${row.title}" (via buildsOn)`);
+    }
 
-  // Check edge implications
-  console.log("\nEdge implications:");
-  console.log("  'authorOf' implies:", registry.getImpliedEdges("authorOf"));
+    // Inverse + implication combined: nothing ever wrote a citedBy edge,
+    // yet the inverse of cites (and the buildsOn implication) answers it.
+    console.log(`\nWho cites "${SEQ2SEQ_PAPER_TITLE}"?`);
+    const citingPublications = await store
+      .query()
+      .from("Paper", "s")
+      .whereNode("s", ({ title }) => title.eq(SEQ2SEQ_PAPER_TITLE))
+      .traverse("citedBy", "cb", { expand: "all" })
+      .to("Publication", "citing", { includeSubClasses: true })
+      .select((ctx) => ({ title: ctx.citing.title }))
+      .execute();
+    for (const row of citingPublications) {
+      console.log(`  Cited by "${row.title}"`);
+    }
 
-  // ============================================================
-  // Query Examples
-  // ============================================================
+    // --- Custom meta-edges in practice ------------------------------
 
-  console.log("\n=== Query Examples ===\n");
+    console.log("\n=== Custom Meta-Edges in Practice ===\n");
 
-  // Find papers by topic (including implied edges)
-  console.log("Query: Papers about Deep Learning");
-  const dlPapers = await store
-    .query()
-    .from("Paper", "p")
-    .traverse("about", "a")
-    .to("Topic", "t")
-    .select((ctx) => ({
-      title: ctx.p.title,
-      topic: ctx.t.name,
-    }))
-    .execute();
+    console.log("Custom relations visible via store.introspect().ontology:");
+    const customRelations = store
+      .introspect()
+      .ontology.filter(
+        (relation) =>
+          relation.metaEdge === prerequisiteOfMetaEdge.name ||
+          relation.metaEdge === supersedesMetaEdge.name,
+      );
+    for (const relation of customRelations) {
+      console.log(
+        `  ${relation.from} --${relation.metaEdge}--> ${relation.to}` +
+          ` (origin: ${relation.origin})`,
+      );
+    }
 
-  for (const row of dlPapers) {
-    console.log(`  "${row.title}" is about ${row.topic}`);
+    console.log("\nMeta-edge properties travel with the definition:");
+    console.log(
+      `  prerequisiteOf: transitive=${prerequisiteOfMetaEdge.properties.transitive},` +
+        ` inference=${prerequisiteOfMetaEdge.properties.inference}`,
+    );
+    console.log(
+      `  supersedes: transitive=${supersedesMetaEdge.properties.transitive},` +
+        ` inference=${supersedesMetaEdge.properties.inference}`,
+    );
+
+    console.log(
+      "\nApplication-level inference (the registry only reasons over core" +
+        "\nmeta-edges, so we walk the declared relations ourselves):",
+    );
+    console.log(
+      "  ArtificialIntelligence prerequisiteOf DeepLearning (transitive)?",
+      relatesVia(
+        graph.ontology,
+        prerequisiteOfMetaEdge,
+        "ArtificialIntelligence",
+        "DeepLearning",
+      ),
+    );
+    console.log(
+      "  Paper supersedes Preprint?",
+      relatesVia(graph.ontology, supersedesMetaEdge, "Paper", "Preprint"),
+    );
+
+    // --- Verified summary -------------------------------------------
+
+    console.log("\n=== Verified Summary ===\n");
+
+    assertClaim(
+      "subClassOf: Paper and Preprint are Publications",
+      registry.isSubClassOf("Paper", "Publication") &&
+        registry.isSubClassOf("Preprint", "Publication"),
+    );
+    assertClaim(
+      "broader/narrower: DeepLearning is (transitively) narrower than ArtificialIntelligence",
+      registry.isNarrowerThan("DeepLearning", "ArtificialIntelligence"),
+    );
+    assertClaim(
+      "equivalentTo: schema.org/Person resolves to Author",
+      registry.resolveIri(SCHEMA_ORG_PERSON_IRI) === "Author",
+    );
+    assertClaim(
+      "disjointWith: Paper and Author are disjoint",
+      registry.areDisjoint("Paper", "Author"),
+    );
+    assertClaim(
+      "partOf: Department is part of Institution (hasPart derived)",
+      registry.isPartOf("Department", "Institution") &&
+        registry.getParts("Institution").includes("Department"),
+    );
+    assertClaim(
+      "inverseOf: cites <-> citedBy",
+      registry.getInverseEdge("cites") === "citedBy" &&
+        registry.getInverseEdge("citedBy") === "cites",
+    );
+    assertClaim(
+      "implies: buildsOn implies cites",
+      registry.getImpliedEdges("buildsOn").includes("cites"),
+    );
+    assertClaim(
+      "subsumption query returned all 3 publications",
+      publications.length === 3,
+    );
+    assertClaim(
+      `topic-bound query returned exactly the ${DEEP_LEARNING_NAME} paper`,
+      dlPapers.length === 1 && dlPapers[0]?.title === ATTENTION_PAPER_TITLE,
+    );
+    assertClaim(
+      "SKOS-driven query found both ML- and DL-tagged publications",
+      aiPublications.length === 2,
+    );
+    assertClaim(
+      "implication query surfaced the buildsOn edge as a citation",
+      explicitCites.length === 0 && impliedCites.length === 1,
+    );
+    assertClaim(
+      "inverse+implying query found both citing publications",
+      citingPublications.length === 2,
+    );
+    assertClaim(
+      "custom meta-edge relations are introspectable",
+      customRelations.length === 3,
+    );
+    assertClaim(
+      "custom transitive inference: AI is a prerequisite of DL",
+      relatesVia(
+        graph.ontology,
+        prerequisiteOfMetaEdge,
+        "ArtificialIntelligence",
+        "DeepLearning",
+      ),
+    );
+    assertClaim(
+      "custom non-transitive inference: Paper supersedes Preprint",
+      relatesVia(graph.ontology, supersedesMetaEdge, "Paper", "Preprint"),
+    );
+
+    console.log("\n=== Custom Ontology example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // Find author affiliations
-  console.log("\nQuery: Author affiliations");
-  const affiliations = await store
-    .query()
-    .from("Author", "a")
-    .traverse("affiliatedWith", "aff")
-    .to("Institution", "i")
-    .select((ctx) => ({
-      author: ctx.a.name,
-      institution: ctx.i.name,
-    }))
-    .execute();
-
-  for (const row of affiliations) {
-    console.log(`  ${row.author} at ${row.institution}`);
-  }
-
-  // ============================================================
-  // Summary of Core Meta-Edges
-  // ============================================================
-
-  console.log("\n=== Available Core Meta-Edges ===\n");
-
-  const coreMetaEdges = [
-    { name: "subClassOf", use: "Type inheritance (Child subClassOf Parent)" },
-    { name: "broader", use: "Broader concept (ML broader AI)" },
-    { name: "narrower", use: "Narrower concept (AI narrower ML)" },
-    { name: "equivalentTo", use: "Semantic equivalence" },
-    { name: "sameAs", use: "Identity (usually external IRIs)" },
-    { name: "differentFrom", use: "Explicit non-identity" },
-    { name: "disjointWith", use: "Mutually exclusive types" },
-    { name: "partOf", use: "Composition (Wheel partOf Car)" },
-    { name: "hasPart", use: "Inverse of partOf" },
-    { name: "relatedTo", use: "General association" },
-    { name: "inverseOf", use: "Edge pairs (manages/managedBy)" },
-    { name: "implies", use: "Edge entailment (loves implies knows)" },
-  ];
-
-  for (const { name, use } of coreMetaEdges) {
-    console.log(`  ${name.padEnd(15)} - ${use}`);
-  }
-
-  console.log("\n=== Custom Ontology example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/typegraph/examples/09-pagination-streaming.ts
+++ b/packages/typegraph/examples/09-pagination-streaming.ts
@@ -7,9 +7,9 @@
  * - Streaming for batch processing large datasets
  * - Combining pagination with graph traversals
  */
+import { createStore, defineEdge, defineGraph, defineNode } from "@nicia-ai/typegraph";
 import { z } from "zod";
 
-import { createStore, defineGraph, defineEdge, defineNode } from "@nicia-ai/typegraph";
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -19,7 +19,7 @@ import { createExampleBackend } from "./_helpers";
 const User = defineNode("User", {
   schema: z.object({
     name: z.string(),
-    email: z.string().email(),
+    email: z.email(),
     createdAt: z.string(),
   }),
 });
@@ -65,206 +65,214 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  console.log("=== Pagination and Streaming Examples ===\n");
+  try {
+    console.log("=== Pagination and Streaming Examples ===\n");
 
-  // Create sample data
-  console.log("Creating sample data (100 posts)...\n");
+    // Create sample data
+    console.log("Creating sample data (100 posts)...\n");
 
-  const author = await store.nodes.User.create({
-    name: "Alice Author",
-    email: "alice@example.com",
-    createdAt: new Date().toISOString(),
-  });
-
-  const posts: Array<{ id: string; title: string }> = [];
-  for (let i = 1; i <= 100; i++) {
-    const post = await store.nodes.Post.create({
-      title: `Post ${i.toString().padStart(3, "0")}`,
-      content: `Content for post ${i}`,
-      publishedAt: new Date(Date.now() - (100 - i) * 60000).toISOString(),
-      views: Math.floor(Math.random() * 1000),
+    const author = await store.nodes.User.create({
+      name: "Alice Author",
+      email: "alice@example.com",
+      createdAt: new Date().toISOString(),
     });
-    posts.push({ id: post.id, title: post.title });
 
-    await store.edges.authored.create(author, post);
-  }
+    // Seed in two bulk calls instead of 200 round-trips — see example 24
+    // (bulk-writes) for the full bulk-write API.
+    const posts = await store.nodes.Post.bulkCreate(
+      Array.from({ length: 100 }, (_, index) => ({
+        props: {
+          title: `Post ${(index + 1).toString().padStart(3, "0")}`,
+          content: `Content for post ${index + 1}`,
+          publishedAt: new Date(Date.now() - (99 - index) * 60_000).toISOString(),
+          views: Math.floor(Math.random() * 1000),
+        },
+      })),
+    );
+    await store.edges.authored.bulkCreate(
+      posts.map((post) => ({
+        from: { kind: "User", id: author.id },
+        to: { kind: "Post", id: post.id },
+      })),
+    );
 
-  // ============================================================
-  // Basic Cursor Pagination
-  // ============================================================
+    // ============================================================
+    // Basic Cursor Pagination
+    // ============================================================
 
-  console.log("=== Basic Cursor Pagination ===\n");
+    console.log("=== Basic Cursor Pagination ===\n");
 
-  const query = store
-    .query()
-    .from("Post", "p")
-    .select((ctx) => ({
-      id: ctx.p.id,
-      title: ctx.p.title,
-      views: ctx.p.views,
-    }))
-    .orderBy("p", "title", "asc");
+    const query = store
+      .query()
+      .from("Post", "p")
+      .select((ctx) => ({
+        id: ctx.p.id,
+        title: ctx.p.title,
+        views: ctx.p.views,
+      }))
+      .orderBy("p", "title", "asc");
 
-  // Get first page
-  const page1 = await query.paginate({ first: 10 });
-  console.log("Page 1 (first 10 posts):");
-  for (const post of page1.data) {
-    console.log(`  - ${post.title} (${post.views} views)`);
-  }
-  console.log(`  hasNextPage: ${page1.hasNextPage}`);
-  console.log(`  hasPrevPage: ${page1.hasPrevPage}`);
-
-  // Get second page using the cursor
-  if (page1.nextCursor) {
-    console.log("\nPage 2 (next 10 posts):");
-    const page2 = await query.paginate({ first: 10, after: page1.nextCursor });
-    for (const post of page2.data) {
+    // Get first page
+    const page1 = await query.paginate({ first: 10 });
+    console.log("Page 1 (first 10 posts):");
+    for (const post of page1.data) {
       console.log(`  - ${post.title} (${post.views} views)`);
     }
-    console.log(`  hasNextPage: ${page2.hasNextPage}`);
-  }
+    console.log(`  hasNextPage: ${page1.hasNextPage}`);
+    console.log(`  hasPrevPage: ${page1.hasPrevPage}`);
 
-  // ============================================================
-  // Backward Pagination
-  // ============================================================
+    // Get second page using the cursor
+    if (page1.nextCursor) {
+      console.log("\nPage 2 (next 10 posts):");
+      const page2 = await query.paginate({ first: 10, after: page1.nextCursor });
+      for (const post of page2.data) {
+        console.log(`  - ${post.title} (${post.views} views)`);
+      }
+      console.log(`  hasNextPage: ${page2.hasNextPage}`);
+    }
 
-  console.log("\n=== Backward Pagination ===\n");
+    // ============================================================
+    // Backward Pagination
+    // ============================================================
 
-  // Get last page
-  const lastPage = await query.paginate({ last: 10 });
-  console.log("Last 10 posts:");
-  for (const post of lastPage.data) {
-    console.log(`  - ${post.title}`);
-  }
-  console.log(`  hasPrevPage: ${lastPage.hasPrevPage}`);
+    console.log("\n=== Backward Pagination ===\n");
 
-  // Go back one page
-  if (lastPage.prevCursor) {
-    console.log("\nPrevious 10 posts:");
-    const prevPage = await query.paginate({
-      last: 10,
-      before: lastPage.prevCursor,
-    });
-    for (const post of prevPage.data) {
+    // Get last page
+    const lastPage = await query.paginate({ last: 10 });
+    console.log("Last 10 posts:");
+    for (const post of lastPage.data) {
       console.log(`  - ${post.title}`);
     }
-  }
+    console.log(`  hasPrevPage: ${lastPage.hasPrevPage}`);
 
-  // ============================================================
-  // Pagination with Graph Traversal
-  // ============================================================
-
-  console.log("\n=== Pagination with Graph Traversal ===\n");
-
-  const authorPostsQuery = store
-    .query()
-    .from("User", "u")
-    .traverse("authored", "e")
-    .to("Post", "p")
-    .select((ctx) => ({
-      author: ctx.u.name,
-      postId: ctx.p.id,
-      title: ctx.p.title,
-    }))
-    .orderBy("p", "publishedAt", "desc");
-
-  const authorPage = await authorPostsQuery.paginate({ first: 5 });
-  console.log("Most recent 5 posts by author:");
-  for (const row of authorPage.data) {
-    console.log(`  - ${row.author}: "${row.title}"`);
-  }
-
-  // ============================================================
-  // Streaming Large Datasets
-  // ============================================================
-
-  console.log("\n=== Streaming Large Datasets ===\n");
-
-  const stream = store
-    .query()
-    .from("Post", "p")
-    .select((ctx) => ({
-      title: ctx.p.title,
-      views: ctx.p.views,
-    }))
-    .orderBy("p", "views", "desc")
-    .stream({ batchSize: 25 });
-
-  console.log("Streaming all posts (sorted by views):");
-  let count = 0;
-  let totalViews = 0;
-
-  for await (const post of stream) {
-    count++;
-    totalViews += post.views;
-
-    // Show first 5 and last 5
-    if (count <= 5) {
-      console.log(`  ${count}. ${post.title} - ${post.views} views`);
-    } else if (count === 6) {
-      console.log("  ...");
+    // Go back one page
+    if (lastPage.prevCursor) {
+      console.log("\nPrevious 10 posts:");
+      const previousPage = await query.paginate({
+        last: 10,
+        before: lastPage.prevCursor,
+      });
+      for (const post of previousPage.data) {
+        console.log(`  - ${post.title}`);
+      }
     }
+
+    // ============================================================
+    // Pagination with Graph Traversal
+    // ============================================================
+
+    console.log("\n=== Pagination with Graph Traversal ===\n");
+
+    const authorPostsQuery = store
+      .query()
+      .from("User", "u")
+      .traverse("authored", "e")
+      .to("Post", "p")
+      .select((ctx) => ({
+        author: ctx.u.name,
+        postId: ctx.p.id,
+        title: ctx.p.title,
+      }))
+      .orderBy("p", "publishedAt", "desc");
+
+    const authorPage = await authorPostsQuery.paginate({ first: 5 });
+    console.log("Most recent 5 posts by author:");
+    for (const row of authorPage.data) {
+      console.log(`  - ${row.author}: "${row.title}"`);
+    }
+
+    // ============================================================
+    // Streaming Large Datasets
+    // ============================================================
+
+    console.log("\n=== Streaming Large Datasets ===\n");
+
+    const stream = store
+      .query()
+      .from("Post", "p")
+      .select((ctx) => ({
+        title: ctx.p.title,
+        views: ctx.p.views,
+      }))
+      .orderBy("p", "views", "desc")
+      .stream({ batchSize: 25 });
+
+    console.log("Streaming all posts (sorted by views):");
+    let count = 0;
+    let totalViews = 0;
+
+    for await (const post of stream) {
+      count++;
+      totalViews += post.views;
+
+      // Show first 5 and last 5
+      if (count <= 5) {
+        console.log(`  ${count}. ${post.title} - ${post.views} views`);
+      } else if (count === 6) {
+        console.log("  ...");
+      }
+    }
+
+    console.log(`\nProcessed ${count} posts`);
+    console.log(`Total views: ${totalViews}`);
+    console.log(`Average views: ${Math.round(totalViews / count)}`);
+
+    // ============================================================
+    // Streaming with Early Exit
+    // ============================================================
+
+    console.log("\n=== Streaming with Early Exit ===\n");
+
+    const highViewsStream = store
+      .query()
+      .from("Post", "p")
+      .select((ctx) => ({
+        title: ctx.p.title,
+        views: ctx.p.views,
+      }))
+      .orderBy("p", "views", "desc")
+      .stream({ batchSize: 10 });
+
+    console.log("Finding top 3 posts with most views:");
+    let found = 0;
+    for await (const post of highViewsStream) {
+      console.log(`  ${found + 1}. ${post.title} - ${post.views} views`);
+      found++;
+      if (found >= 3) break; // Early exit - only first batch is fetched
+    }
+
+    // ============================================================
+    // Comparing Pagination Strategies
+    // ============================================================
+
+    console.log("\n=== Pagination Strategy Comparison ===\n");
+
+    console.log("Cursor Pagination (recommended):");
+    console.log("  - Uses ORDER BY columns as cursor values");
+    console.log("  - O(1) performance regardless of page number");
+    console.log("  - Stable results even when data changes");
+    console.log("  - Requires ORDER BY clause\n");
+
+    console.log("Offset Pagination (simple but slow):");
+    console.log("  - Uses LIMIT/OFFSET");
+    console.log("  - O(N) performance where N = offset");
+    console.log("  - Results may shift as data changes");
+    console.log("  - Good for small datasets only\n");
+
+    console.log("Streaming (for batch processing):");
+    console.log("  - Uses cursor pagination internally");
+    console.log("  - Processes results one at a time");
+    console.log("  - Low memory usage for large datasets");
+    console.log("  - Supports early exit");
+
+    console.log("\n=== Pagination and streaming example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  console.log(`\nProcessed ${count} posts`);
-  console.log(`Total views: ${totalViews}`);
-  console.log(`Average views: ${Math.round(totalViews / count)}`);
-
-  // ============================================================
-  // Streaming with Early Exit
-  // ============================================================
-
-  console.log("\n=== Streaming with Early Exit ===\n");
-
-  const highViewsStream = store
-    .query()
-    .from("Post", "p")
-    .select((ctx) => ({
-      title: ctx.p.title,
-      views: ctx.p.views,
-    }))
-    .orderBy("p", "views", "desc")
-    .stream({ batchSize: 10 });
-
-  console.log("Finding top 3 posts with most views:");
-  let found = 0;
-  for await (const post of highViewsStream) {
-    console.log(`  ${found + 1}. ${post.title} - ${post.views} views`);
-    found++;
-    if (found >= 3) break; // Early exit - only first batch is fetched
-  }
-
-  // ============================================================
-  // Comparing Pagination Strategies
-  // ============================================================
-
-  console.log("\n=== Pagination Strategy Comparison ===\n");
-
-  console.log("Cursor Pagination (recommended):");
-  console.log("  - Uses ORDER BY columns as cursor values");
-  console.log("  - O(1) performance regardless of page number");
-  console.log("  - Stable results even when data changes");
-  console.log("  - Requires ORDER BY clause\n");
-
-  console.log("Offset Pagination (simple but slow):");
-  console.log("  - Uses LIMIT/OFFSET");
-  console.log("  - O(N) performance where N = offset");
-  console.log("  - Results may shift as data changes");
-  console.log("  - Good for small datasets only\n");
-
-  console.log("Streaming (for batch processing):");
-  console.log("  - Uses cursor pagination internally");
-  console.log("  - Processes results one at a time");
-  console.log("  - Low memory usage for large datasets");
-  console.log("  - Supports early exit");
-
-  console.log("\n=== Pagination and streaming example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/10-postgresql.ts
+++ b/packages/typegraph/examples/10-postgresql.ts
@@ -14,14 +14,10 @@
  *   POSTGRES_URL=postgresql://user:pass@localhost:5432/typegraph_example \
  *   npx tsx examples/10-postgresql.ts
  */
-import { z } from "zod";
-import { Pool } from "pg";
-import { drizzle } from "drizzle-orm/node-postgres";
-
 import {
   createStore,
-  defineGraph,
   defineEdge,
+  defineGraph,
   defineNode,
   subClassOf,
 } from "@nicia-ai/typegraph";
@@ -29,6 +25,9 @@ import {
   createPostgresBackend,
   generatePostgresMigrationSQL,
 } from "@nicia-ai/typegraph/postgres";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { z } from "zod";
 
 // ============================================================
 // Schema Definition
@@ -43,7 +42,7 @@ const Entity = defineNode("Entity", {
 const Person = defineNode("Person", {
   schema: z.object({
     name: z.string(),
-    email: z.string().email(),
+    email: z.email(),
     metadata: z
       .object({
         preferences: z.record(z.string(), z.unknown()).optional(),
@@ -104,9 +103,13 @@ export async function main() {
   const pool = new Pool({
     connectionString,
     max: 10,
-    idleTimeoutMillis: 30000,
+    idleTimeoutMillis: 30_000,
     connectionTimeoutMillis: 5000,
   });
+
+  // Create Drizzle instance and backend (lazy — no connection is made yet)
+  const db = drizzle(pool);
+  const backend = createPostgresBackend(db);
 
   try {
     // Test connection
@@ -118,10 +121,6 @@ export async function main() {
     const migrationSQL = generatePostgresMigrationSQL();
     await pool.query(migrationSQL);
     console.log("Migrations complete!\n");
-
-    // Create Drizzle instance and backend
-    const db = drizzle(pool);
-    const backend = createPostgresBackend(db);
 
     // Create store
     const store = createStore(graph, backend);
@@ -288,14 +287,15 @@ export async function main() {
       throw error;
     }
   } finally {
-    // Close connection pool
+    // Close the backend, then the connection pool it wraps
+    await backend.close();
     await pool.end();
     console.log("\nConnection pool closed.");
   }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/10-postgresql.ts
+++ b/packages/typegraph/examples/10-postgresql.ts
@@ -116,9 +116,7 @@ export async function main() {
     // Run TypeGraph migrations
     console.log("Running TypeGraph migrations...");
     const migrationSQL = generatePostgresMigrationSQL();
-    for (const statement of migrationSQL.split(";").filter((s) => s.trim())) {
-      await pool.query(statement);
-    }
+    await pool.query(migrationSQL);
     console.log("Migrations complete!\n");
 
     // Create Drizzle instance and backend
@@ -259,19 +257,23 @@ export async function main() {
     console.log("=== Cleanup ===\n");
 
     // Delete in correct order (edges first due to constraints)
-    const allPeople = await store
-      .query()
-      .from("Person", "p")
-      .select((ctx) => ({ id: ctx.p.id }))
-      .execute();
+    const allWorksAt = await store.edges.worksAt.find();
+    for (const edge of allWorksAt) {
+      await store.edges.worksAt.delete(edge.id);
+    }
+    console.log(`Deleted ${allWorksAt.length} worksAt edges`);
 
+    const allPeople = await store.nodes.Person.find();
     for (const person of allPeople) {
-      await store.nodes.Person.delete(person.id as typeof alice.id);
+      await store.nodes.Person.delete(person.id);
     }
     console.log(`Deleted ${allPeople.length} people`);
 
-    await store.nodes.Organization.delete(org.id);
-    console.log("Deleted organization\n");
+    const allOrganizations = await store.nodes.Organization.find();
+    for (const organization of allOrganizations) {
+      await store.nodes.Organization.delete(organization.id);
+    }
+    console.log(`Deleted ${allOrganizations.length} organizations\n`);
 
     console.log("=== PostgreSQL example complete ===");
   } catch (error) {

--- a/packages/typegraph/examples/11-semantic-search.ts
+++ b/packages/typegraph/examples/11-semantic-search.ts
@@ -27,7 +27,11 @@ import {
   getEmbeddingDimensions,
   isEmbeddingSchema,
 } from "@nicia-ai/typegraph";
-import { createExampleBackend } from "./_helpers";
+import {
+  cosineSimilarity,
+  createExampleBackend,
+  mockTextEmbedding,
+} from "./_helpers";
 
 // ============================================================
 // Schema Definition with Embeddings
@@ -81,72 +85,6 @@ const graph = defineGraph({
 });
 
 // ============================================================
-// Mock Embedding Functions
-// ============================================================
-
-/**
- * Deterministic mock embedding via the bag-of-words "hashing trick": each
- * content word is hashed to one dimension and accumulated, then the vector is
- * unit-normalized. Texts that share vocabulary land on overlapping dimensions
- * and score high; texts with disjoint vocabulary are near-orthogonal and score
- * near zero — so cosine similarity tracks shared content the way a real model
- * does, only far more crudely (no synonyms or paraphrase). In production you
- * would call an actual embedding API.
- */
-const STOPWORDS = new Set([
-  "the", "and", "for", "with", "that", "this", "into", "from", "are", "was",
-  "can", "its", "but", "not", "all", "any", "has", "have", "will",
-]);
-
-function tokenize(text: string): string[] {
-  return text
-    .toLowerCase()
-    .split(/[^a-z0-9]+/u)
-    .filter((token) => token.length > 2 && !STOPWORDS.has(token));
-}
-
-/** Deterministic FNV-1a hash, so a given word always maps to the same dimension. */
-function hashWord(word: string): number {
-  let hash = 2166136261;
-  for (let index = 0; index < word.length; index += 1) {
-    hash ^= word.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-function mockTextEmbedding(text: string, dimensions: number): number[] {
-  const vector = new Array<number>(dimensions).fill(0);
-  for (const token of tokenize(text)) {
-    const dimension = hashWord(token) % dimensions;
-    vector[dimension] = (vector[dimension] ?? 0) + 1;
-  }
-  const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
-  // Stopword-only / empty text has no signal — return a fixed unit vector so the
-  // result is still a valid (non-zero) embedding.
-  if (magnitude === 0) {
-    vector[0] = 1;
-    return vector;
-  }
-  return vector.map((value) => value / magnitude);
-}
-
-/**
- * Computes cosine similarity between two vectors.
- */
-function cosineSimilarity(a: number[], b: number[]): number {
-  let dotProduct = 0;
-  let magA = 0;
-  let magB = 0;
-  for (let i = 0; i < a.length; i++) {
-    dotProduct += (a[i] ?? 0) * (b[i] ?? 0);
-    magA += (a[i] ?? 0) ** 2;
-    magB += (b[i] ?? 0) ** 2;
-  }
-  return dotProduct / (Math.sqrt(magA) * Math.sqrt(magB));
-}
-
-// ============================================================
 // Main Example
 // ============================================================
 
@@ -159,22 +97,15 @@ export async function main() {
 
   console.log("=== Part 1: Embedding Type Basics ===\n");
 
-  // The embedding() function creates a Zod schema for vector arrays
+  // embedding(dim) creates a Zod schema for fixed-length float arrays: it
+  // rejects wrong lengths and non-numeric elements at write time, and
+  // isEmbeddingSchema/getEmbeddingDimensions introspect it (this is how
+  // TypeGraph discovers which fields are vector-indexable).
   const docEmbeddingSchema = embedding(1536);
-
-  console.log("Embedding schema created:");
-  console.log(`  Is embedding schema: ${isEmbeddingSchema(docEmbeddingSchema)}`);
+  console.log(
+    `  Is embedding schema: ${isEmbeddingSchema(docEmbeddingSchema)}`,
+  );
   console.log(`  Dimensions: ${getEmbeddingDimensions(docEmbeddingSchema)}`);
-
-  // Validation examples
-  const validEmbedding = Array(1536).fill(0.1);
-  const invalidLength = Array(100).fill(0.1);
-  const invalidType = ["not", "numbers"];
-
-  console.log("\nValidation:");
-  console.log(`  Valid embedding (1536 floats): ${docEmbeddingSchema.safeParse(validEmbedding).success}`);
-  console.log(`  Invalid length (100 floats): ${docEmbeddingSchema.safeParse(invalidLength).success}`);
-  console.log(`  Invalid type (strings): ${docEmbeddingSchema.safeParse(invalidType).success}`);
 
   // ============================================================
   // Part 2: Storing Documents with Embeddings
@@ -183,231 +114,276 @@ export async function main() {
   console.log("\n=== Part 2: Storing Documents with Embeddings ===\n");
 
   const backend = createExampleBackend();
+  // Sync createStore is fine here: no searchable() fields means no fulltext
+  // storage to materialize (contrast with createStoreWithSchema in example 15).
   const store = createStore(graph, backend);
 
-  // Sample documents to index
-  const documents = [
-    {
-      title: "Introduction to Machine Learning",
-      content: "Machine learning is a subset of artificial intelligence...",
-      category: "AI",
-    },
-    {
-      title: "Deep Learning Fundamentals",
-      content: "Neural networks with multiple layers can learn complex patterns...",
-      category: "AI",
-    },
-    {
-      title: "Natural Language Processing",
-      content: "NLP uses neural networks to help computers understand human language...",
-      category: "AI",
-    },
-    {
-      title: "Web Development with React",
-      content: "React is a JavaScript library for building user interfaces...",
-      category: "Web",
-    },
-    {
-      title: "Database Design Patterns",
-      content: "Relational databases organize data into tables with relationships...",
-      category: "Database",
-    },
-  ];
+  try {
+    // Sample documents to index
+    const documents = [
+      {
+        title: "Introduction to Machine Learning",
+        content: "Machine learning is a subset of artificial intelligence...",
+        category: "AI",
+      },
+      {
+        title: "Deep Learning Fundamentals",
+        content:
+          "Neural networks with multiple layers can learn complex patterns...",
+        category: "AI",
+      },
+      {
+        title: "Natural Language Processing",
+        content:
+          "NLP uses neural networks to help computers understand human language...",
+        category: "AI",
+      },
+      {
+        title: "Web Development with React",
+        content:
+          "React is a JavaScript library for building user interfaces...",
+        category: "Web",
+      },
+      {
+        title: "Database Design Patterns",
+        content:
+          "Relational databases organize data into tables with relationships...",
+        category: "Database",
+      },
+    ];
 
-  console.log("Creating documents with embeddings...\n");
+    console.log("Creating documents with embeddings...\n");
 
-  const createdDocs = [];
-  for (const doc of documents) {
-    // Generate embedding from title + content
-    const textForEmbedding = `${doc.title} ${doc.content}`;
-    const docEmbedding = mockTextEmbedding(textForEmbedding, 1536);
+    // Kept solely for the no-vector-engine fallback in Part 3, which ranks
+    // in JS from these created nodes instead of querying the backend.
+    const createdDocs = [];
+    for (const doc of documents) {
+      // Generate embedding from title + content
+      const textForEmbedding = `${doc.title} ${doc.content}`;
+      const created = await store.nodes.Document.create({
+        ...doc,
+        embedding: mockTextEmbedding(textForEmbedding, 1536),
+      });
 
-    const created = await store.nodes.Document.create({
-      ...doc,
-      embedding: docEmbedding,
-    });
-
-    createdDocs.push({ ...created, embedding: docEmbedding });
-    console.log(`  Created: "${doc.title}" (${doc.category})`);
-  }
-
-  // ============================================================
-  // Part 3: Semantic Similarity Search
-  // ============================================================
-
-  console.log("\n=== Part 3: Semantic Similarity Search ===\n");
-
-  // Query: Find documents similar to "artificial intelligence and neural networks"
-  const queryText = "artificial intelligence and neural networks";
-  const queryEmbedding = mockTextEmbedding(queryText, 1536);
-
-  console.log(`Query: "${queryText}"\n`);
-
-  // TypeGraph runs native vector search on whichever backend is configured —
-  // sqlite-vec here, pgvector on PostgreSQL, or libSQL's built-in engine. The
-  // example backend loads sqlite-vec, so the queries below execute for real. We
-  // gate on the backend's advertised capability and fall back to an in-JS
-  // ranking only when no vector engine is present, so the example always runs.
-  const stars = (score: number): string =>
-    "★".repeat(Math.max(0, Math.min(5, Math.round(score * 5))));
-
-  if (backend.capabilities.vector?.supported) {
-    // Store facade: ranked hits with similarity scores.
-    const hits = await store.search.vector("Document", {
-      fieldPath: "embedding",
-      queryEmbedding,
-      limit: 5,
-      metric: "cosine",
-    });
-
-    console.log("Results via store.search.vector (ranked by similarity):");
-    for (const hit of hits) {
-      console.log(`  ${stars(hit.score).padEnd(5)} ${hit.score.toFixed(4)} - "${hit.node.title}"`);
+      createdDocs.push(created);
+      console.log(`  Created: "${doc.title}" (${doc.category})`);
     }
 
-    // Query builder: compose .similarTo() with a metadata predicate in one SQL
-    // statement (here, restrict the nearest neighbors to the "AI" category).
-    const aiOnly = await store
-      .query()
-      .from("Document", "d")
-      .whereNode("d", (d) =>
-        d.embedding
-          .similarTo(queryEmbedding, 5, { metric: "cosine" })
-          .and(d.category.eq("AI")),
-      )
-      .select((ctx) => ({ title: ctx.d.title, category: ctx.d.category }))
-      .execute();
+    // ============================================================
+    // Part 3: Semantic Similarity Search
+    // ============================================================
 
-    console.log('\nFiltered to category = "AI" via .similarTo() + predicate:');
-    for (const row of aiOnly) {
-      console.log(`  - "${row.title}" (${row.category})`);
+    console.log("\n=== Part 3: Semantic Similarity Search ===\n");
+
+    // Query: Find documents similar to "artificial intelligence and neural networks"
+    const queryText = "artificial intelligence and neural networks";
+    const queryEmbedding = mockTextEmbedding(queryText, 1536);
+
+    console.log(`Query: "${queryText}"\n`);
+
+    // TypeGraph runs native vector search on whichever backend is configured —
+    // sqlite-vec here, pgvector on PostgreSQL, or libSQL's built-in engine. The
+    // example backend loads sqlite-vec, so the queries below execute for real. We
+    // gate on the backend's advertised capability and fall back to an in-JS
+    // ranking only when no vector engine is present, so the example always runs.
+    const stars = (score: number): string =>
+      "★".repeat(Math.max(0, Math.min(5, Math.round(score * 5))));
+
+    if (backend.capabilities.vector?.supported) {
+      // Store facade: ranked hits with similarity scores.
+      const hits = await store.search.vector("Document", {
+        fieldPath: "embedding",
+        queryEmbedding,
+        limit: 5,
+        metric: "cosine",
+      });
+
+      console.log("Results via store.search.vector (ranked by similarity):");
+      for (const hit of hits) {
+        console.log(
+          `  ${stars(hit.score).padEnd(5)} ${hit.score.toFixed(4)} - "${hit.node.title}"`,
+        );
+      }
+
+      // A bare LIMIT pads the tail with whatever is nearest, however unrelated —
+      // note the ~0.0000-score hits above. minScore turns "top k" into
+      // "top k that actually match" by applying a similarity floor.
+      const confidentHits = await store.search.vector("Document", {
+        fieldPath: "embedding",
+        queryEmbedding,
+        limit: 5,
+        metric: "cosine",
+        minScore: 0.1,
+      });
+
+      console.log("\nSame query with minScore: 0.1 (padding hits drop out):");
+      for (const hit of confidentHits) {
+        console.log(
+          `  ${stars(hit.score).padEnd(5)} ${hit.score.toFixed(4)} - "${hit.node.title}"`,
+        );
+      }
+
+      // Query builder: compose .similarTo() with a metadata predicate in one SQL
+      // statement (here, restrict the nearest neighbors to the "AI" category).
+      const aiOnly = await store
+        .query()
+        .from("Document", "d")
+        .whereNode("d", (d) =>
+          d.embedding
+            .similarTo(queryEmbedding, 5, { metric: "cosine" })
+            .and(d.category.eq("AI")),
+        )
+        .select((ctx) => ({ title: ctx.d.title, category: ctx.d.category }))
+        .execute();
+
+      console.log(
+        '\nFiltered to category = "AI" via .similarTo() + predicate:',
+      );
+      for (const row of aiOnly) {
+        console.log(`  - "${row.title}" (${row.category})`);
+      }
+    } else {
+      // No vector engine loaded — rank in JS so the example still runs.
+      console.log("No vector engine loaded; ranking in JS (cosine):\n");
+      const similarities = createdDocs
+        .map((doc) => ({
+          title: doc.title,
+          similarity: cosineSimilarity(queryEmbedding, doc.embedding),
+        }))
+        .sort((a, b) => b.similarity - a.similarity);
+      for (const result of similarities) {
+        console.log(
+          `  ${stars(result.similarity).padEnd(5)} ${result.similarity.toFixed(4)} - "${result.title}"`,
+        );
+      }
     }
-  } else {
-    // No vector engine loaded — rank in JS so the example still runs.
-    console.log("No vector engine loaded; ranking in JS (cosine):\n");
-    const similarities = createdDocs
-      .map((doc) => ({
-        title: doc.title,
-        similarity: cosineSimilarity(queryEmbedding, doc.embedding),
-      }))
-      .sort((a, b) => b.similarity - a.similarity);
-    for (const result of similarities) {
-      console.log(`  ${stars(result.similarity).padEnd(5)} ${result.similarity.toFixed(4)} - "${result.title}"`);
+
+    // ============================================================
+    // Part 4: Multi-Modal Search with CLIP Embeddings
+    // ============================================================
+
+    console.log("\n=== Part 4: Multi-Modal Search (CLIP) ===\n");
+
+    // Create images with CLIP embeddings
+    const images = [
+      {
+        url: "/images/cat.jpg",
+        description: "A fluffy orange cat, a beloved house pet",
+      },
+      {
+        url: "/images/dog.jpg",
+        description: "A loyal golden retriever, a friendly pet dog",
+      },
+      {
+        url: "/images/landscape.jpg",
+        description: "A mountain landscape at sunset",
+      },
+    ];
+
+    console.log("Creating images with CLIP embeddings...\n");
+
+    for (const img of images) {
+      const clipEmbedding = mockTextEmbedding(img.description ?? img.url, 512);
+      await store.nodes.Image.create({
+        ...img,
+        clipEmbedding,
+      });
+      console.log(`  Created: ${img.url} - "${img.description}"`);
     }
-  }
 
-  // ============================================================
-  // Part 4: Multi-Modal Search with CLIP Embeddings
-  // ============================================================
+    // CLIP maps text and images into the same vector space, so a text query
+    // embedding searches the image embeddings directly (cross-modal retrieval).
+    const imageQueryText = "a fluffy pet";
+    const imageQuery = mockTextEmbedding(imageQueryText, 512);
 
-  console.log("\n=== Part 4: Multi-Modal Search (CLIP) ===\n");
+    if (backend.capabilities.vector?.supported) {
+      const imageHits = await store.search.vector("Image", {
+        fieldPath: "clipEmbedding",
+        queryEmbedding: imageQuery,
+        limit: 3,
+        metric: "cosine",
+      });
+      console.log(`\nText-to-image search for "${imageQueryText}":`);
+      for (const hit of imageHits) {
+        console.log(
+          `  ${hit.score.toFixed(4)} - ${hit.node.url} ("${hit.node.description ?? ""}")`,
+        );
+      }
+    } else {
+      console.log(
+        "\nCLIP enables searching images with text queries (no vector engine loaded here).",
+      );
+    }
 
-  // Create images with CLIP embeddings
-  const images = [
-    { url: "/images/cat.jpg", description: "A fluffy orange cat, a beloved house pet" },
-    { url: "/images/dog.jpg", description: "A loyal golden retriever, a friendly pet dog" },
-    { url: "/images/landscape.jpg", description: "A mountain landscape at sunset" },
-  ];
+    // ============================================================
+    // Part 5: Optional Embeddings
+    // ============================================================
 
-  console.log("Creating images with CLIP embeddings...\n");
+    console.log("\n=== Part 5: Optional Embeddings ===\n");
 
-  for (const img of images) {
-    const clipEmbedding = mockTextEmbedding(img.description ?? img.url, 512);
-    await store.nodes.Image.create({
-      ...img,
-      clipEmbedding,
+    // Sentences can optionally have embeddings
+    const sentence1 = await store.nodes.Sentence.create({
+      text: "This sentence has an embedding.",
+      embedding: mockTextEmbedding("This sentence has an embedding.", 384),
     });
-    console.log(`  Created: ${img.url} - "${img.description}"`);
-  }
 
-  // CLIP maps text and images into the same vector space, so a text query
-  // embedding searches the image embeddings directly (cross-modal retrieval).
-  const imageQueryText = "a fluffy pet";
-  const imageQuery = mockTextEmbedding(imageQueryText, 512);
-
-  if (backend.capabilities.vector?.supported) {
-    const imageHits = await store.search.vector("Image", {
-      fieldPath: "clipEmbedding",
-      queryEmbedding: imageQuery,
-      limit: 3,
-      metric: "cosine",
+    const sentence2 = await store.nodes.Sentence.create({
+      text: "This sentence has no embedding yet.",
+      // embedding is optional, so we can omit it
     });
-    console.log(`\nText-to-image search for "${imageQueryText}":`);
-    for (const hit of imageHits) {
-      console.log(`  ${hit.score.toFixed(4)} - ${hit.node.url} ("${hit.node.description ?? ""}")`);
-    }
-  } else {
-    console.log("\nCLIP enables searching images with text queries (no vector engine loaded here).");
+
+    console.log(`Sentence 1: "${sentence1.text}"`);
+    console.log(`  Has embedding: ${sentence1.embedding !== undefined}`);
+    console.log(`Sentence 2: "${sentence2.text}"`);
+    console.log(`  Has embedding: ${sentence2.embedding !== undefined}`);
+
+    // Later, we can update to add an embedding
+    const updated = await store.nodes.Sentence.update(sentence2.id, {
+      embedding: mockTextEmbedding(sentence2.text, 384),
+    });
+
+    console.log(`\nAfter update:`);
+    console.log(
+      `Sentence 2 now has embedding: ${updated.embedding !== undefined}`,
+    );
+
+    // Note on dimensions: pick the dimension of your embedding model (e.g. 384
+    // for all-MiniLM-L6-v2, 512 for CLIP ViT-B/32, 1536 for OpenAI ada-002,
+    // 3072 for text-embedding-3-large). TypeGraph validates that every stored
+    // embedding matches its schema dimension, as the three node kinds above show.
+
+    // ============================================================
+    // Summary
+    // ============================================================
+
+    console.log("\n=== Summary ===\n");
+
+    console.log("Key features demonstrated:");
+    console.log("  1. embedding(dim) creates a typed schema for vector arrays");
+    console.log("  2. Embeddings are validated for correct dimension");
+    console.log("  3. Different nodes can use different embedding dimensions");
+    console.log("  4. Embeddings can be optional with .optional()");
+    console.log("  5. Similarity search ranks results by vector distance");
+
+    console.log(
+      "\nNative vector search (pgvector, sqlite-vec, or libSQL built-in):",
+    );
+    console.log(
+      "  - Use .similarTo() (query builder) or store.search.vector() (facade)",
+    );
+    console.log("  - Automatic ORDER BY similarity with configurable LIMIT");
+    console.log(
+      "  - HNSW/IVFFlat indexes enable sub-millisecond search at scale",
+    );
+    console.log(
+      "  - Supports cosine, L2 (Euclidean), and inner product metrics",
+    );
+    console.log("  - minScore option filters results by similarity threshold");
+
+    console.log("\n=== Example Complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // ============================================================
-  // Part 5: Optional Embeddings
-  // ============================================================
-
-  console.log("\n=== Part 5: Optional Embeddings ===\n");
-
-  // Sentences can optionally have embeddings
-  const sentence1 = await store.nodes.Sentence.create({
-    text: "This sentence has an embedding.",
-    embedding: mockTextEmbedding("This sentence has an embedding.", 384),
-  });
-
-  const sentence2 = await store.nodes.Sentence.create({
-    text: "This sentence has no embedding yet.",
-    // embedding is optional, so we can omit it
-  });
-
-  console.log(`Sentence 1: "${sentence1.text}"`);
-  console.log(`  Has embedding: ${sentence1.embedding !== undefined}`);
-  console.log(`Sentence 2: "${sentence2.text}"`);
-  console.log(`  Has embedding: ${sentence2.embedding !== undefined}`);
-
-  // Later, we can update to add an embedding
-  const updated = await store.nodes.Sentence.update(sentence2.id, {
-    embedding: mockTextEmbedding(sentence2.text, 384),
-  });
-
-  console.log(`\nAfter update:`);
-  console.log(`Sentence 2 now has embedding: ${updated.embedding !== undefined}`);
-
-  // ============================================================
-  // Part 6: Different Embedding Dimensions
-  // ============================================================
-
-  console.log("\n=== Part 6: Embedding Dimension Summary ===\n");
-
-  console.log("Common embedding dimensions:");
-  console.log("  - 384:  all-MiniLM-L6-v2 (fast, lightweight)");
-  console.log("  - 512:  CLIP ViT-B/32 (multi-modal)");
-  console.log("  - 768:  BERT base, Sentence-BERT");
-  console.log("  - 1024: CLIP ViT-L/14");
-  console.log("  - 1536: OpenAI text-embedding-ada-002");
-  console.log("  - 3072: OpenAI text-embedding-3-large");
-
-  console.log("\nChoose dimensions based on your embedding model.");
-  console.log("TypeGraph validates that stored embeddings match the schema dimension.");
-
-  // ============================================================
-  // Summary
-  // ============================================================
-
-  console.log("\n=== Summary ===\n");
-
-  console.log("Key features demonstrated:");
-  console.log("  1. embedding(dim) creates a typed schema for vector arrays");
-  console.log("  2. Embeddings are validated for correct dimension");
-  console.log("  3. Different nodes can use different embedding dimensions");
-  console.log("  4. Embeddings can be optional with .optional()");
-  console.log("  5. Similarity search ranks results by vector distance");
-
-  console.log("\nNative vector search (pgvector, sqlite-vec, or libSQL built-in):");
-  console.log("  - Use .similarTo() (query builder) or store.search.vector() (facade)");
-  console.log("  - Automatic ORDER BY similarity with configurable LIMIT");
-  console.log("  - HNSW/IVFFlat indexes enable sub-millisecond search at scale");
-  console.log("  - Supports cosine, L2 (Euclidean), and inner product metrics");
-  console.log("  - minScore option filters results by similarity threshold");
-
-  console.log("\n=== Example Complete ===");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/typegraph/examples/11-semantic-search.ts
+++ b/packages/typegraph/examples/11-semantic-search.ts
@@ -17,8 +17,6 @@
  * Run with:
  *   npx tsx examples/11-semantic-search.ts
  */
-import { z } from "zod";
-
 import {
   createStore,
   defineGraph,
@@ -27,6 +25,8 @@ import {
   getEmbeddingDimensions,
   isEmbeddingSchema,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import {
   cosineSimilarity,
   createExampleBackend,
@@ -101,11 +101,11 @@ export async function main() {
   // rejects wrong lengths and non-numeric elements at write time, and
   // isEmbeddingSchema/getEmbeddingDimensions introspect it (this is how
   // TypeGraph discovers which fields are vector-indexable).
-  const docEmbeddingSchema = embedding(1536);
+  const documentEmbeddingSchema = embedding(1536);
   console.log(
-    `  Is embedding schema: ${isEmbeddingSchema(docEmbeddingSchema)}`,
+    `  Is embedding schema: ${isEmbeddingSchema(documentEmbeddingSchema)}`,
   );
-  console.log(`  Dimensions: ${getEmbeddingDimensions(docEmbeddingSchema)}`);
+  console.log(`  Dimensions: ${getEmbeddingDimensions(documentEmbeddingSchema)}`);
 
   // ============================================================
   // Part 2: Storing Documents with Embeddings
@@ -156,17 +156,17 @@ export async function main() {
 
     // Kept solely for the no-vector-engine fallback in Part 3, which ranks
     // in JS from these created nodes instead of querying the backend.
-    const createdDocs = [];
-    for (const doc of documents) {
+    const createdDocuments = [];
+    for (const document of documents) {
       // Generate embedding from title + content
-      const textForEmbedding = `${doc.title} ${doc.content}`;
+      const textForEmbedding = `${document.title} ${document.content}`;
       const created = await store.nodes.Document.create({
-        ...doc,
+        ...document,
         embedding: mockTextEmbedding(textForEmbedding, 1536),
       });
 
-      createdDocs.push(created);
-      console.log(`  Created: "${doc.title}" (${doc.category})`);
+      createdDocuments.push(created);
+      console.log(`  Created: "${document.title}" (${document.category})`);
     }
 
     // ============================================================
@@ -245,12 +245,12 @@ export async function main() {
     } else {
       // No vector engine loaded — rank in JS so the example still runs.
       console.log("No vector engine loaded; ranking in JS (cosine):\n");
-      const similarities = createdDocs
-        .map((doc) => ({
-          title: doc.title,
-          similarity: cosineSimilarity(queryEmbedding, doc.embedding),
+      const similarities = createdDocuments
+        .map((document) => ({
+          title: document.title,
+          similarity: cosineSimilarity(queryEmbedding, document.embedding),
         }))
-        .sort((a, b) => b.similarity - a.similarity);
+        .toSorted((a, b) => b.similarity - a.similarity);
       for (const result of similarities) {
         console.log(
           `  ${stars(result.similarity).padEnd(5)} ${result.similarity.toFixed(4)} - "${result.title}"`,
@@ -283,7 +283,7 @@ export async function main() {
     console.log("Creating images with CLIP embeddings...\n");
 
     for (const img of images) {
-      const clipEmbedding = mockTextEmbedding(img.description ?? img.url, 512);
+      const clipEmbedding = mockTextEmbedding(img.description, 512);
       await store.nodes.Image.create({
         ...img,
         clipEmbedding,
@@ -387,7 +387,7 @@ export async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/12-knowledge-graph-rag.ts
+++ b/packages/typegraph/examples/12-knowledge-graph-rag.ts
@@ -141,9 +141,9 @@ export async function main() {
     doc1Chunks.push(chunk);
     await store.edges.containsChunk.create(doc1, chunk, {});
     if (prevChunkNode) {
-      // Create both directions - inverseOf declares them equivalent but doesn't auto-create
+      // Store only nextChunk — the inverseOf ontology lets .traverse("prevChunk")
+      // follow stored nextChunk edges automatically.
       await store.edges.nextChunk.create(prevChunkNode, chunk, {});
-      await store.edges.prevChunk.create(chunk, prevChunkNode, {});
     }
     prevChunkNode = chunk;
   }
@@ -173,7 +173,6 @@ export async function main() {
     await store.edges.containsChunk.create(doc2, chunk, {});
     if (prevChunkNode) {
       await store.edges.nextChunk.create(prevChunkNode, chunk, {});
-      await store.edges.prevChunk.create(chunk, prevChunkNode, {});
     }
     prevChunkNode = chunk;
   }
@@ -413,5 +412,8 @@ export async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(console.error);
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
 }

--- a/packages/typegraph/examples/12-knowledge-graph-rag.ts
+++ b/packages/typegraph/examples/12-knowledge-graph-rag.ts
@@ -10,8 +10,6 @@
  * Run with:
  *   npx tsx examples/12-knowledge-graph-rag.ts
  */
-import { z } from "zod";
-
 import {
   createStore,
   defineEdge,
@@ -20,6 +18,8 @@ import {
   embedding,
   inverseOf,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend, mockTextEmbedding } from "./_helpers";
 
 // ============================================================
@@ -53,7 +53,7 @@ const Entity = defineNode("Entity", {
 
 const containsChunk = defineEdge("containsChunk");
 const nextChunk = defineEdge("nextChunk");
-const prevChunk = defineEdge("prevChunk");
+const previousChunk = defineEdge("prevChunk");
 const mentions = defineEdge("mentions");
 const relatesTo = defineEdge("relatesTo", {
   schema: z.object({ relationship: z.string() }),
@@ -79,11 +79,11 @@ const graph = defineGraph({
   edges: {
     containsChunk: { type: containsChunk, from: [Document], to: [Chunk] },
     nextChunk: { type: nextChunk, from: [Chunk], to: [Chunk] },
-    prevChunk: { type: prevChunk, from: [Chunk], to: [Chunk] },
+    prevChunk: { type: previousChunk, from: [Chunk], to: [Chunk] },
     mentions: { type: mentions, from: [Chunk], to: [Entity] },
     relatesTo: { type: relatesTo, from: [Entity], to: [Entity] },
   },
-  ontology: [inverseOf(nextChunk, prevChunk)],
+  ontology: [inverseOf(nextChunk, previousChunk)],
 });
 
 // ============================================================
@@ -104,7 +104,7 @@ export async function main() {
     console.log("--- Seeding Data ---\n");
 
     // Document 1: About OpenAI
-    const doc1 = await store.nodes.Document.create({
+    const document1 = await store.nodes.Document.create({
       title: "OpenAI History",
       source: "wikipedia.org/openai",
     });
@@ -115,28 +115,28 @@ export async function main() {
       "OpenAI released GPT-4 in March 2023.",
     ];
 
-    let prevChunkNode:
+    let previousChunkNode:
       Awaited<ReturnType<typeof store.nodes.Chunk.create>> | undefined;
-    const doc1Chunks = [];
+    const document1Chunks = [];
 
-    for (const [i, text] of chunks1.entries()) {
+    for (const [index, text] of chunks1.entries()) {
       const chunk = await store.nodes.Chunk.create({
         text,
         embedding: mockTextEmbedding(text, EMBEDDING_DIMENSIONS),
-        position: i,
+        position: index,
       });
-      doc1Chunks.push(chunk);
-      await store.edges.containsChunk.create(doc1, chunk, {});
-      if (prevChunkNode) {
+      document1Chunks.push(chunk);
+      await store.edges.containsChunk.create(document1, chunk, {});
+      if (previousChunkNode) {
         // Store only nextChunk — the inverseOf ontology lets .traverse("prevChunk")
         // follow stored nextChunk edges automatically.
-        await store.edges.nextChunk.create(prevChunkNode, chunk, {});
+        await store.edges.nextChunk.create(previousChunkNode, chunk, {});
       }
-      prevChunkNode = chunk;
+      previousChunkNode = chunk;
     }
 
     // Document 2: About Tesla
-    const doc2 = await store.nodes.Document.create({
+    const document2 = await store.nodes.Document.create({
       title: "Tesla Overview",
       source: "wikipedia.org/tesla",
     });
@@ -147,21 +147,21 @@ export async function main() {
       "Tesla produces electric vehicles and energy storage systems.",
     ];
 
-    prevChunkNode = undefined;
-    const doc2Chunks = [];
+    previousChunkNode = undefined;
+    const document2Chunks = [];
 
-    for (const [i, text] of chunks2.entries()) {
+    for (const [index, text] of chunks2.entries()) {
       const chunk = await store.nodes.Chunk.create({
         text,
         embedding: mockTextEmbedding(text, EMBEDDING_DIMENSIONS),
-        position: i,
+        position: index,
       });
-      doc2Chunks.push(chunk);
-      await store.edges.containsChunk.create(doc2, chunk, {});
-      if (prevChunkNode) {
-        await store.edges.nextChunk.create(prevChunkNode, chunk, {});
+      document2Chunks.push(chunk);
+      await store.edges.containsChunk.create(document2, chunk, {});
+      if (previousChunkNode) {
+        await store.edges.nextChunk.create(previousChunkNode, chunk, {});
       }
-      prevChunkNode = chunk;
+      previousChunkNode = chunk;
     }
 
     // Use getOrCreateByConstraint so re-running ingestion on overlapping
@@ -190,17 +190,17 @@ export async function main() {
     const gpt4 = await ensureEntity("GPT-4", "concept");
 
     // Link chunks to entities (mentions)
-    await store.edges.mentions.create(doc1Chunks[0]!, samAltman, {});
-    await store.edges.mentions.create(doc1Chunks[0]!, openai, {});
-    await store.edges.mentions.create(doc1Chunks[1]!, samAltman, {});
-    await store.edges.mentions.create(doc1Chunks[1]!, openai, {});
-    await store.edges.mentions.create(doc1Chunks[2]!, openai, {});
-    await store.edges.mentions.create(doc1Chunks[2]!, gpt4, {});
+    await store.edges.mentions.create(document1Chunks[0]!, samAltman, {});
+    await store.edges.mentions.create(document1Chunks[0]!, openai, {});
+    await store.edges.mentions.create(document1Chunks[1]!, samAltman, {});
+    await store.edges.mentions.create(document1Chunks[1]!, openai, {});
+    await store.edges.mentions.create(document1Chunks[2]!, openai, {});
+    await store.edges.mentions.create(document1Chunks[2]!, gpt4, {});
 
-    await store.edges.mentions.create(doc2Chunks[0]!, tesla, {});
-    await store.edges.mentions.create(doc2Chunks[1]!, elonMusk, {});
-    await store.edges.mentions.create(doc2Chunks[1]!, tesla, {});
-    await store.edges.mentions.create(doc2Chunks[2]!, tesla, {});
+    await store.edges.mentions.create(document2Chunks[0]!, tesla, {});
+    await store.edges.mentions.create(document2Chunks[1]!, elonMusk, {});
+    await store.edges.mentions.create(document2Chunks[1]!, tesla, {});
+    await store.edges.mentions.create(document2Chunks[2]!, tesla, {});
 
     // Entity relationships
     await store.edges.relatesTo.create(samAltman, openai, {
@@ -225,7 +225,7 @@ export async function main() {
     const samAltmanChunks = await store
       .query()
       .from("Entity", "e")
-      .whereNode("e", (e) => e.name.eq("Sam Altman"))
+      .whereNode("e", (entity) => entity.name.eq("Sam Altman"))
       .traverse("mentions", "m", { direction: "in" })
       .to("Chunk", "c")
       .select((ctx) => ctx.c.text)
@@ -245,7 +245,7 @@ export async function main() {
     const relatedToPersons = await store
       .query()
       .from("Entity", "e")
-      .whereNode("e", (e) => e.type.eq("person"))
+      .whereNode("e", (entity) => entity.type.eq("person"))
       .traverse("relatesTo", "r")
       .to("Entity", "target")
       .select((ctx) => ({
@@ -254,8 +254,8 @@ export async function main() {
       }))
       .execute();
 
-    for (const rel of relatedToPersons) {
-      console.log(`  ${rel.person} --> ${rel.target}`);
+    for (const relation of relatedToPersons) {
+      console.log(`  ${relation.person} --> ${relation.target}`);
     }
 
     // ----------------------------------------------------------
@@ -265,7 +265,7 @@ export async function main() {
     console.log("\n--- Pattern 3: Context Window Expansion ---");
     console.log("Get chunk with surrounding context\n");
 
-    const middleChunk = doc1Chunks[1]!;
+    const middleChunk = document1Chunks[1]!;
 
     // Get previous chunk
     const before = await store
@@ -333,7 +333,7 @@ export async function main() {
       {
         text: string;
         source: string;
-        entities: Array<{ name: string; type: string }>;
+        entities: { name: string; type: string }[];
       }
     >();
     for (const row of hybridResults) {
@@ -353,7 +353,7 @@ export async function main() {
     for (const [, chunk] of byChunk) {
       console.log(`  • [${chunk.source}] "${chunk.text.slice(0, 40)}..."`);
       console.log(
-        `    Entities: [${chunk.entities.map((e) => e.name).join(", ")}]`,
+        `    Entities: [${chunk.entities.map((entity) => entity.name).join(", ")}]`,
       );
     }
 
@@ -378,7 +378,7 @@ export async function main() {
     const entityRelations = await store
       .query()
       .from("Entity", "e")
-      .whereNode("e", (e) => e.name.eq("Sam Altman"))
+      .whereNode("e", (entity) => entity.name.eq("Sam Altman"))
       .traverse("relatesTo", "r")
       .to("Entity", "target")
       .select((ctx) => ({
@@ -394,8 +394,8 @@ export async function main() {
     }
 
     console.log("## Entity Relationships\n");
-    for (const rel of entityRelations) {
-      console.log(`- ${rel.from} → ${rel.to}`);
+    for (const relation of entityRelations) {
+      console.log(`- ${relation.from} → ${relation.to}`);
     }
 
     // ----------------------------------------------------------
@@ -440,7 +440,7 @@ export async function main() {
     // Only nextChunk edges are stored; every prevChunk hop below is resolved
     // through the inverseOf ontology. Repeating the single-hop traversal walks
     // the whole chain back to the first chunk.
-    const lastChunk = doc1Chunks[2]!;
+    const lastChunk = document1Chunks[2]!;
     console.log(`  start: "${lastChunk.text}"`);
 
     let cursorId = lastChunk.id;
@@ -466,7 +466,7 @@ export async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/12-knowledge-graph-rag.ts
+++ b/packages/typegraph/examples/12-knowledge-graph-rag.ts
@@ -20,11 +20,13 @@ import {
   embedding,
   inverseOf,
 } from "@nicia-ai/typegraph";
-import { createExampleBackend } from "./_helpers";
+import { createExampleBackend, mockTextEmbedding } from "./_helpers";
 
 // ============================================================
 // Schema
 // ============================================================
+
+const EMBEDDING_DIMENSIONS = 384;
 
 const Document = defineNode("Document", {
   schema: z.object({
@@ -36,7 +38,7 @@ const Document = defineNode("Document", {
 const Chunk = defineNode("Chunk", {
   schema: z.object({
     text: z.string(),
-    embedding: embedding(384),
+    embedding: embedding(EMBEDDING_DIMENSIONS),
     position: z.number().int(),
   }),
 });
@@ -45,7 +47,7 @@ const Entity = defineNode("Entity", {
   schema: z.object({
     name: z.string(),
     type: z.enum(["person", "organization", "location", "concept"]),
-    embedding: embedding(384).optional(),
+    embedding: embedding(EMBEDDING_DIMENSIONS).optional(),
   }),
 });
 
@@ -85,23 +87,6 @@ const graph = defineGraph({
 });
 
 // ============================================================
-// Helpers
-// ============================================================
-
-/** Generate deterministic mock embedding based on text */
-function mockEmbedding(text: string): number[] {
-  const embedding: number[] = [];
-  for (let i = 0; i < 384; i++) {
-    const charSum = text.split("").reduce((sum, char, idx) => {
-      return sum + char.charCodeAt(0) * (idx + 1) * (i + 1);
-    }, 0);
-    embedding.push(Math.sin(charSum + i) * 0.5 + 0.5);
-  }
-  const magnitude = Math.sqrt(embedding.reduce((sum, v) => sum + v * v, 0));
-  return embedding.map((v) => v / magnitude);
-}
-
-// ============================================================
 // Main
 // ============================================================
 
@@ -111,304 +96,373 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  // ----------------------------------------------------------
-  // Seed data: Two documents about AI companies
-  // ----------------------------------------------------------
+  try {
+    // ----------------------------------------------------------
+    // Seed data: Two documents about AI companies
+    // ----------------------------------------------------------
 
-  console.log("--- Seeding Data ---\n");
+    console.log("--- Seeding Data ---\n");
 
-  // Document 1: About OpenAI
-  const doc1 = await store.nodes.Document.create({
-    title: "OpenAI History",
-    source: "wikipedia.org/openai",
-  });
-
-  const chunks1 = [
-    "OpenAI was founded in 2015 by Sam Altman and others.",
-    "Sam Altman became CEO of OpenAI in 2019.",
-    "OpenAI released GPT-4 in March 2023.",
-  ];
-
-  let prevChunkNode: Awaited<ReturnType<typeof store.nodes.Chunk.create>> | undefined;
-  const doc1Chunks = [];
-
-  for (const [i, text] of chunks1.entries()) {
-    const chunk = await store.nodes.Chunk.create({
-      text,
-      embedding: mockEmbedding(text),
-      position: i,
+    // Document 1: About OpenAI
+    const doc1 = await store.nodes.Document.create({
+      title: "OpenAI History",
+      source: "wikipedia.org/openai",
     });
-    doc1Chunks.push(chunk);
-    await store.edges.containsChunk.create(doc1, chunk, {});
-    if (prevChunkNode) {
-      // Store only nextChunk — the inverseOf ontology lets .traverse("prevChunk")
-      // follow stored nextChunk edges automatically.
-      await store.edges.nextChunk.create(prevChunkNode, chunk, {});
-    }
-    prevChunkNode = chunk;
-  }
 
-  // Document 2: About Tesla
-  const doc2 = await store.nodes.Document.create({
-    title: "Tesla Overview",
-    source: "wikipedia.org/tesla",
-  });
+    const chunks1 = [
+      "OpenAI was founded in 2015 by Sam Altman and others.",
+      "Sam Altman became CEO of OpenAI in 2019.",
+      "OpenAI released GPT-4 in March 2023.",
+    ];
 
-  const chunks2 = [
-    "Tesla was founded in 2003 by Martin Eberhard and Marc Tarpenning.",
-    "Elon Musk joined Tesla in 2004 as chairman.",
-    "Tesla produces electric vehicles and energy storage systems.",
-  ];
+    let prevChunkNode:
+      Awaited<ReturnType<typeof store.nodes.Chunk.create>> | undefined;
+    const doc1Chunks = [];
 
-  prevChunkNode = undefined;
-  const doc2Chunks = [];
-
-  for (const [i, text] of chunks2.entries()) {
-    const chunk = await store.nodes.Chunk.create({
-      text,
-      embedding: mockEmbedding(text),
-      position: i,
-    });
-    doc2Chunks.push(chunk);
-    await store.edges.containsChunk.create(doc2, chunk, {});
-    if (prevChunkNode) {
-      await store.edges.nextChunk.create(prevChunkNode, chunk, {});
-    }
-    prevChunkNode = chunk;
-  }
-
-  // Use getOrCreateByConstraint so re-running ingestion on overlapping
-  // corpora dedupes entities via the `entity_name_type` unique constraint.
-  async function ensureEntity(
-    name: string,
-    type: "person" | "organization" | "location" | "concept",
-  ) {
-    const result = await store.nodes.Entity.getOrCreateByConstraint(
-      "entity_name_type",
-      { name, type, embedding: mockEmbedding(name) },
-    );
-    return result.node;
-  }
-
-  const samAltman = await ensureEntity("Sam Altman", "person");
-  const elonMusk = await ensureEntity("Elon Musk", "person");
-  const openai = await ensureEntity("OpenAI", "organization");
-  const tesla = await ensureEntity("Tesla", "organization");
-  const gpt4 = await ensureEntity("GPT-4", "concept");
-
-  // Link chunks to entities (mentions)
-  await store.edges.mentions.create(doc1Chunks[0]!, samAltman, {});
-  await store.edges.mentions.create(doc1Chunks[0]!, openai, {});
-  await store.edges.mentions.create(doc1Chunks[1]!, samAltman, {});
-  await store.edges.mentions.create(doc1Chunks[1]!, openai, {});
-  await store.edges.mentions.create(doc1Chunks[2]!, openai, {});
-  await store.edges.mentions.create(doc1Chunks[2]!, gpt4, {});
-
-  await store.edges.mentions.create(doc2Chunks[0]!, tesla, {});
-  await store.edges.mentions.create(doc2Chunks[1]!, elonMusk, {});
-  await store.edges.mentions.create(doc2Chunks[1]!, tesla, {});
-  await store.edges.mentions.create(doc2Chunks[2]!, tesla, {});
-
-  // Entity relationships
-  await store.edges.relatesTo.create(samAltman, openai, { relationship: "leads" });
-  await store.edges.relatesTo.create(elonMusk, tesla, { relationship: "leads" });
-  await store.edges.relatesTo.create(openai, gpt4, { relationship: "created" });
-
-  console.log("Created 2 documents, 6 chunks, 5 entities\n");
-
-  // ----------------------------------------------------------
-  // Pattern 1: Entity-Based Retrieval
-  // ----------------------------------------------------------
-
-  console.log("--- Pattern 1: Entity-Based Retrieval ---");
-  console.log('Find all chunks mentioning "Sam Altman"\n');
-
-  const samAltmanChunks = await store
-    .query()
-    .from("Entity", "e")
-    .whereNode("e", (e) => e.name.eq("Sam Altman"))
-    .traverse("mentions", "m", { direction: "in" })
-    .to("Chunk", "c")
-    .select((ctx) => ctx.c.text)
-    .execute();
-
-  for (const text of samAltmanChunks) {
-    console.log(`  • ${text}`);
-  }
-
-  // ----------------------------------------------------------
-  // Pattern 2: Multi-Hop Entity Traversal
-  // ----------------------------------------------------------
-
-  console.log("\n--- Pattern 2: Multi-Hop Entity Traversal ---");
-  console.log("Find entities related to people (1 hop)\n");
-
-  const relatedToPersons = await store
-    .query()
-    .from("Entity", "e")
-    .whereNode("e", (e) => e.type.eq("person"))
-    .traverse("relatesTo", "r")
-    .to("Entity", "target")
-    .select((ctx) => ({
-      person: ctx.e.name,
-      target: ctx.target.name,
-    }))
-    .execute();
-
-  for (const rel of relatedToPersons) {
-    console.log(`  ${rel.person} --> ${rel.target}`);
-  }
-
-  // ----------------------------------------------------------
-  // Pattern 3: Context Window Expansion
-  // ----------------------------------------------------------
-
-  console.log("\n--- Pattern 3: Context Window Expansion ---");
-  console.log("Get chunk with surrounding context\n");
-
-  const middleChunk = doc1Chunks[1]!;
-
-  // Get previous chunk
-  const before = await store
-    .query()
-    .from("Chunk", "c")
-    .whereNode("c", (c) => c.id.eq(middleChunk.id))
-    .traverse("prevChunk", "e")
-    .to("Chunk", "prev")
-    .select((ctx) => ctx.prev.text)
-    .execute();
-
-  // Get next chunk
-  const after = await store
-    .query()
-    .from("Chunk", "c")
-    .whereNode("c", (c) => c.id.eq(middleChunk.id))
-    .traverse("nextChunk", "e")
-    .to("Chunk", "next")
-    .select((ctx) => ctx.next.text)
-    .execute();
-
-  console.log(`  [before] ${before[0] ?? "(none)"}`);
-  console.log(`  [target] ${middleChunk.text}`);
-  console.log(`  [after]  ${after[0] ?? "(none)"}`);
-
-  // ----------------------------------------------------------
-  // Pattern 4: Hybrid Retrieval (Single Query with Fan-out)
-  // ----------------------------------------------------------
-
-  console.log("\n--- Pattern 4: Hybrid Retrieval (Single Query) ---");
-  console.log("Vector search + fan-out to entities AND document\n");
-
-  // Real vector similarity on the chunk embedding, fanning out in one query to
-  // the entities each matched chunk mentions AND back to its source document.
-  // (Falls back to a keyword filter if the backend has no vector engine.)
-  const vectorReady = backend.capabilities.vector?.supported === true;
-  const chunkQuery = mockEmbedding("company leadership and CEO");
-  const hybridResults = await store
-    .query()
-    .from("Chunk", "c")
-    .whereNode("c", (c) =>
-      vectorReady ? c.embedding.similarTo(chunkQuery, 3) : c.text.contains("CEO"),
-    )
-    .traverse("mentions", "m")
-    .to("Entity", "e")
-    .traverse("containsChunk", "d_edge", { direction: "in", from: "c" }) // Fan-out from chunk
-    .to("Document", "d")
-    .select((ctx) => ({
-      chunkId: ctx.c.id,
-      text: ctx.c.text,
-      source: ctx.d.title,
-      entityName: ctx.e.name,
-      entityType: ctx.e.type,
-    }))
-    .execute();
-
-  // Group by chunk (one row per chunk-entity pair)
-  const byChunk = new Map<
-    string,
-    { text: string; source: string; entities: Array<{ name: string; type: string }> }
-  >();
-  for (const row of hybridResults) {
-    const existing = byChunk.get(row.chunkId);
-    if (existing) {
-      existing.entities.push({ name: row.entityName, type: row.entityType });
-    } else {
-      byChunk.set(row.chunkId, {
-        text: row.text,
-        source: row.source,
-        entities: [{ name: row.entityName, type: row.entityType }],
+    for (const [i, text] of chunks1.entries()) {
+      const chunk = await store.nodes.Chunk.create({
+        text,
+        embedding: mockTextEmbedding(text, EMBEDDING_DIMENSIONS),
+        position: i,
       });
+      doc1Chunks.push(chunk);
+      await store.edges.containsChunk.create(doc1, chunk, {});
+      if (prevChunkNode) {
+        // Store only nextChunk — the inverseOf ontology lets .traverse("prevChunk")
+        // follow stored nextChunk edges automatically.
+        await store.edges.nextChunk.create(prevChunkNode, chunk, {});
+      }
+      prevChunkNode = chunk;
     }
+
+    // Document 2: About Tesla
+    const doc2 = await store.nodes.Document.create({
+      title: "Tesla Overview",
+      source: "wikipedia.org/tesla",
+    });
+
+    const chunks2 = [
+      "Tesla was founded in 2003 by Martin Eberhard and Marc Tarpenning.",
+      "Elon Musk joined Tesla in 2004 as chairman.",
+      "Tesla produces electric vehicles and energy storage systems.",
+    ];
+
+    prevChunkNode = undefined;
+    const doc2Chunks = [];
+
+    for (const [i, text] of chunks2.entries()) {
+      const chunk = await store.nodes.Chunk.create({
+        text,
+        embedding: mockTextEmbedding(text, EMBEDDING_DIMENSIONS),
+        position: i,
+      });
+      doc2Chunks.push(chunk);
+      await store.edges.containsChunk.create(doc2, chunk, {});
+      if (prevChunkNode) {
+        await store.edges.nextChunk.create(prevChunkNode, chunk, {});
+      }
+      prevChunkNode = chunk;
+    }
+
+    // Use getOrCreateByConstraint so re-running ingestion on overlapping
+    // corpora dedupes entities via the `entity_name_type` unique constraint.
+    // Each entity also gets a name embedding, used for mention disambiguation
+    // in Pattern 6.
+    async function ensureEntity(
+      name: string,
+      type: "person" | "organization" | "location" | "concept",
+    ) {
+      const result = await store.nodes.Entity.getOrCreateByConstraint(
+        "entity_name_type",
+        {
+          name,
+          type,
+          embedding: mockTextEmbedding(name, EMBEDDING_DIMENSIONS),
+        },
+      );
+      return result.node;
+    }
+
+    const samAltman = await ensureEntity("Sam Altman", "person");
+    const elonMusk = await ensureEntity("Elon Musk", "person");
+    const openai = await ensureEntity("OpenAI", "organization");
+    const tesla = await ensureEntity("Tesla", "organization");
+    const gpt4 = await ensureEntity("GPT-4", "concept");
+
+    // Link chunks to entities (mentions)
+    await store.edges.mentions.create(doc1Chunks[0]!, samAltman, {});
+    await store.edges.mentions.create(doc1Chunks[0]!, openai, {});
+    await store.edges.mentions.create(doc1Chunks[1]!, samAltman, {});
+    await store.edges.mentions.create(doc1Chunks[1]!, openai, {});
+    await store.edges.mentions.create(doc1Chunks[2]!, openai, {});
+    await store.edges.mentions.create(doc1Chunks[2]!, gpt4, {});
+
+    await store.edges.mentions.create(doc2Chunks[0]!, tesla, {});
+    await store.edges.mentions.create(doc2Chunks[1]!, elonMusk, {});
+    await store.edges.mentions.create(doc2Chunks[1]!, tesla, {});
+    await store.edges.mentions.create(doc2Chunks[2]!, tesla, {});
+
+    // Entity relationships
+    await store.edges.relatesTo.create(samAltman, openai, {
+      relationship: "leads",
+    });
+    await store.edges.relatesTo.create(elonMusk, tesla, {
+      relationship: "leads",
+    });
+    await store.edges.relatesTo.create(openai, gpt4, {
+      relationship: "created",
+    });
+
+    console.log("Created 2 documents, 6 chunks, 5 entities\n");
+
+    // ----------------------------------------------------------
+    // Pattern 1: Entity-Based Retrieval
+    // ----------------------------------------------------------
+
+    console.log("--- Pattern 1: Entity-Based Retrieval ---");
+    console.log('Find all chunks mentioning "Sam Altman"\n');
+
+    const samAltmanChunks = await store
+      .query()
+      .from("Entity", "e")
+      .whereNode("e", (e) => e.name.eq("Sam Altman"))
+      .traverse("mentions", "m", { direction: "in" })
+      .to("Chunk", "c")
+      .select((ctx) => ctx.c.text)
+      .execute();
+
+    for (const text of samAltmanChunks) {
+      console.log(`  • ${text}`);
+    }
+
+    // ----------------------------------------------------------
+    // Pattern 2: Multi-Hop Entity Traversal
+    // ----------------------------------------------------------
+
+    console.log("\n--- Pattern 2: Multi-Hop Entity Traversal ---");
+    console.log("Find entities related to people (1 hop)\n");
+
+    const relatedToPersons = await store
+      .query()
+      .from("Entity", "e")
+      .whereNode("e", (e) => e.type.eq("person"))
+      .traverse("relatesTo", "r")
+      .to("Entity", "target")
+      .select((ctx) => ({
+        person: ctx.e.name,
+        target: ctx.target.name,
+      }))
+      .execute();
+
+    for (const rel of relatedToPersons) {
+      console.log(`  ${rel.person} --> ${rel.target}`);
+    }
+
+    // ----------------------------------------------------------
+    // Pattern 3: Context Window Expansion
+    // ----------------------------------------------------------
+
+    console.log("\n--- Pattern 3: Context Window Expansion ---");
+    console.log("Get chunk with surrounding context\n");
+
+    const middleChunk = doc1Chunks[1]!;
+
+    // Get previous chunk
+    const before = await store
+      .query()
+      .from("Chunk", "c")
+      .whereNode("c", (c) => c.id.eq(middleChunk.id))
+      .traverse("prevChunk", "e")
+      .to("Chunk", "prev")
+      .select((ctx) => ctx.prev.text)
+      .execute();
+
+    // Get next chunk
+    const after = await store
+      .query()
+      .from("Chunk", "c")
+      .whereNode("c", (c) => c.id.eq(middleChunk.id))
+      .traverse("nextChunk", "e")
+      .to("Chunk", "next")
+      .select((ctx) => ctx.next.text)
+      .execute();
+
+    console.log(`  [before] ${before[0] ?? "(none)"}`);
+    console.log(`  [target] ${middleChunk.text}`);
+    console.log(`  [after]  ${after[0] ?? "(none)"}`);
+
+    // ----------------------------------------------------------
+    // Pattern 4: Hybrid Retrieval (Single Query with Fan-out)
+    // ----------------------------------------------------------
+
+    console.log("\n--- Pattern 4: Hybrid Retrieval (Single Query) ---");
+    console.log("Vector search + fan-out to entities AND document\n");
+
+    // Real vector similarity on the chunk embedding, fanning out in one query to
+    // the entities each matched chunk mentions AND back to its source document.
+    // (Falls back to a keyword filter if the backend has no vector engine.)
+    const vectorReady = backend.capabilities.vector?.supported === true;
+    const chunkQuery = mockTextEmbedding(
+      "company leadership and CEO",
+      EMBEDDING_DIMENSIONS,
+    );
+    const hybridResults = await store
+      .query()
+      .from("Chunk", "c")
+      .whereNode("c", (c) =>
+        vectorReady ?
+          c.embedding.similarTo(chunkQuery, 3)
+        : c.text.contains("CEO"),
+      )
+      .traverse("mentions", "m")
+      .to("Entity", "e")
+      .traverse("containsChunk", "d_edge", { direction: "in", from: "c" }) // Fan-out from chunk
+      .to("Document", "d")
+      .select((ctx) => ({
+        chunkId: ctx.c.id,
+        text: ctx.c.text,
+        source: ctx.d.title,
+        entityName: ctx.e.name,
+        entityType: ctx.e.type,
+      }))
+      .execute();
+
+    // Group by chunk (one row per chunk-entity pair)
+    const byChunk = new Map<
+      string,
+      {
+        text: string;
+        source: string;
+        entities: Array<{ name: string; type: string }>;
+      }
+    >();
+    for (const row of hybridResults) {
+      const existing = byChunk.get(row.chunkId);
+      if (existing) {
+        existing.entities.push({ name: row.entityName, type: row.entityType });
+      } else {
+        byChunk.set(row.chunkId, {
+          text: row.text,
+          source: row.source,
+          entities: [{ name: row.entityName, type: row.entityType }],
+        });
+      }
+    }
+
+    console.log("Results (single query, grouped by chunk):");
+    for (const [, chunk] of byChunk) {
+      console.log(`  • [${chunk.source}] "${chunk.text.slice(0, 40)}..."`);
+      console.log(
+        `    Entities: [${chunk.entities.map((e) => e.name).join(", ")}]`,
+      );
+    }
+
+    // ----------------------------------------------------------
+    // Pattern 5: Building Structured Context
+    // ----------------------------------------------------------
+
+    console.log("\n--- Pattern 5: Building Structured Context ---");
+    console.log("Retrieve chunks + entity facts for LLM prompt\n");
+
+    // Get chunks from a document
+    const contextChunks = await store
+      .query()
+      .from("Document", "d")
+      .whereNode("d", (d) => d.title.eq("OpenAI History"))
+      .traverse("containsChunk", "e")
+      .to("Chunk", "c")
+      .select((ctx) => ({ text: ctx.c.text, source: ctx.d.title }))
+      .execute();
+
+    // Get entity relationships, including the edge property.
+    const entityRelations = await store
+      .query()
+      .from("Entity", "e")
+      .whereNode("e", (e) => e.name.eq("Sam Altman"))
+      .traverse("relatesTo", "r")
+      .to("Entity", "target")
+      .select((ctx) => ({
+        from: ctx.e.name,
+        to: ctx.target.name,
+        relationship: ctx.r.relationship,
+      }))
+      .execute();
+
+    console.log("## Relevant Passages\n");
+    for (const chunk of contextChunks) {
+      console.log(`**${chunk.source}**: ${chunk.text}\n`);
+    }
+
+    console.log("## Entity Relationships\n");
+    for (const rel of entityRelations) {
+      console.log(`- ${rel.from} → ${rel.to}`);
+    }
+
+    // ----------------------------------------------------------
+    // Pattern 6: Entity Disambiguation via Vector Search
+    // ----------------------------------------------------------
+
+    console.log("\n--- Pattern 6: Entity Disambiguation via Vector Search ---");
+    console.log("Link free-text mentions to canonical entities\n");
+
+    // An extraction pipeline surfaces raw mention strings that rarely match an
+    // entity name exactly ("Altman", "the GPT-4 model"). Embedding the mention
+    // and vector-searching the Entity name embeddings links each mention to its
+    // canonical node — the entity-linking half of the header's promise.
+    if (vectorReady) {
+      const rawMentions = ["Altman", "the GPT-4 model"];
+      for (const mention of rawMentions) {
+        const [best] = await store.search.vector("Entity", {
+          fieldPath: "embedding",
+          queryEmbedding: mockTextEmbedding(mention, EMBEDDING_DIMENSIONS),
+          limit: 1,
+          metric: "cosine",
+        });
+        console.log(
+          best ?
+            `  "${mention}" → ${best.node.name} (${best.node.type}, score=${best.score.toFixed(4)})`
+          : `  "${mention}" → (no candidate)`,
+        );
+      }
+    } else {
+      console.log("  (skipped — no vector engine loaded on this backend)");
+    }
+
+    // ----------------------------------------------------------
+    // Pattern 7: Walking the Chunk Chain
+    // ----------------------------------------------------------
+
+    console.log("\n--- Pattern 7: Walking the Chunk Chain ---");
+    console.log(
+      "Reconstruct a document backwards via repeated prevChunk hops\n",
+    );
+
+    // Only nextChunk edges are stored; every prevChunk hop below is resolved
+    // through the inverseOf ontology. Repeating the single-hop traversal walks
+    // the whole chain back to the first chunk.
+    const lastChunk = doc1Chunks[2]!;
+    console.log(`  start: "${lastChunk.text}"`);
+
+    let cursorId = lastChunk.id;
+    for (;;) {
+      const previous = await store
+        .query()
+        .from("Chunk", "c")
+        .whereNode("c", (c) => c.id.eq(cursorId))
+        .traverse("prevChunk", "e")
+        .to("Chunk", "prev")
+        .select((ctx) => ({ id: ctx.prev.id, text: ctx.prev.text }))
+        .execute();
+      const step = previous[0];
+      if (step === undefined) break;
+      console.log(`  ← prev: "${step.text}"`);
+      cursorId = step.id;
+    }
+
+    console.log("\n=== Done ===");
+  } finally {
+    await backend.close();
   }
-
-  console.log("Results (single query, grouped by chunk):");
-  for (const [, chunk] of byChunk) {
-    console.log(`  • [${chunk.source}] "${chunk.text.slice(0, 40)}..."`);
-    console.log(`    Entities: [${chunk.entities.map((e) => e.name).join(", ")}]`);
-  }
-
-  // ----------------------------------------------------------
-  // Pattern 5: Building Structured Context
-  // ----------------------------------------------------------
-
-  console.log("\n--- Pattern 5: Building Structured Context ---");
-  console.log("Retrieve chunks + entity facts for LLM prompt\n");
-
-  // Get chunks from a document
-  const contextChunks = await store
-    .query()
-    .from("Document", "d")
-    .whereNode("d", (d) => d.title.eq("OpenAI History"))
-    .traverse("containsChunk", "e")
-    .to("Chunk", "c")
-    .select((ctx) => ({ text: ctx.c.text, source: ctx.d.title }))
-    .execute();
-
-  // Get entity relationships, including the edge property.
-  const entityRelations = await store
-    .query()
-    .from("Entity", "e")
-    .whereNode("e", (e) => e.name.eq("Sam Altman"))
-    .traverse("relatesTo", "r")
-    .to("Entity", "target")
-    .select((ctx) => ({
-      from: ctx.e.name,
-      to: ctx.target.name,
-      relationship: ctx.r.relationship,
-    }))
-    .execute();
-
-  console.log("## Relevant Passages\n");
-  for (const chunk of contextChunks) {
-    console.log(`**${chunk.source}**: ${chunk.text}\n`);
-  }
-
-  console.log("## Entity Relationships\n");
-  for (const rel of entityRelations) {
-    console.log(`- ${rel.from} → ${rel.to}`);
-  }
-
-  // ----------------------------------------------------------
-  // Pattern 6: Bidirectional Chunk Navigation
-  // ----------------------------------------------------------
-
-  console.log("\n--- Pattern 6: Bidirectional Chunk Navigation ---");
-  console.log("Navigate chunk chains in both directions\n");
-
-  const lastChunk = doc1Chunks[2]!;
-  const backwards = await store
-    .query()
-    .from("Chunk", "c")
-    .whereNode("c", (c) => c.id.eq(lastChunk.id))
-    .traverse("prevChunk", "e")
-    .to("Chunk", "prev")
-    .select((ctx) => ctx.prev.text)
-    .execute();
-
-  console.log(`  Last chunk: "${lastChunk.text.slice(0, 40)}..."`);
-  console.log(`  Previous:   "${backwards[0]?.slice(0, 40)}..."`);
-
-  console.log("\n=== Done ===");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/typegraph/examples/13-aggregates.ts
+++ b/packages/typegraph/examples/13-aggregates.ts
@@ -12,8 +12,6 @@
  * - Aggregations across graph traversals
  * - Ordering and limiting aggregate results (top-N by aggregate)
  */
-import { z } from "zod";
-
 import {
   avg,
   count,
@@ -29,6 +27,8 @@ import {
   min,
   sum,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -117,233 +117,239 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  await seedData(store);
+  try {
+    await seedData(store);
 
-  console.log("=== Aggregate Query Examples ===\n");
+    console.log("=== Aggregate Query Examples ===\n");
 
-  // ============================================================
-  // 1. Basic COUNT — books per genre
-  // ============================================================
+    // ============================================================
+    // 1. Basic COUNT — books per genre
+    // ============================================================
 
-  console.log("--- Books per genre (COUNT) ---\n");
+    console.log("--- Books per genre (COUNT) ---\n");
 
-  const booksPerGenre = await store
-    .query()
-    .from("Book", "b")
-    .groupBy("b", "genre")
-    .aggregate({
-      genre: field("b", "genre"),
-      bookCount: count("b"),
-    })
-    .execute();
+    const booksPerGenre = await store
+      .query()
+      .from("Book", "b")
+      .groupBy("b", "genre")
+      .aggregate({
+        genre: field("b", "genre"),
+        bookCount: count("b"),
+      })
+      .execute();
 
-  for (const row of booksPerGenre) {
-    console.log(`  ${row.genre}: ${row.bookCount} books`);
+    for (const row of booksPerGenre) {
+      console.log(`  ${String(row.genre)}: ${row.bookCount} books`);
+    }
+
+    // ============================================================
+    // 2. Multiple aggregates — price statistics per genre
+    // ============================================================
+
+    console.log("\n--- Price statistics per genre (SUM, AVG, MIN, MAX) ---\n");
+
+    const priceStats = await store
+      .query()
+      .from("Book", "b")
+      .groupBy("b", "genre")
+      .aggregate({
+        genre: field("b", "genre"),
+        totalValue: sum("b", "price"),
+        avgPrice: avg("b", "price"),
+        cheapest: min("b", "price"),
+        mostExpensive: max("b", "price"),
+      })
+      .execute();
+
+    for (const row of priceStats) {
+      console.log(`  ${String(row.genre)}:`);
+      console.log(`    Total: $${row.totalValue.toFixed(2)}`);
+      console.log(`    Avg:   $${row.avgPrice.toFixed(2)}`);
+      console.log(`    Range: $${row.cheapest.toFixed(2)} – $${row.mostExpensive.toFixed(2)}`);
+    }
+
+    // ============================================================
+    // 3. countDistinct — unique authors per genre
+    // ============================================================
+
+    console.log("\n--- Unique authors per genre (COUNT DISTINCT) ---\n");
+
+    // countDistinct counts unique node IDs within each group,
+    // useful when joins might produce duplicates
+    const authorsPerGenre = await store
+      .query()
+      .from("Author", "a")
+      .traverse("wrote", "e")
+      .to("Book", "b")
+      .groupBy("b", "genre")
+      .aggregate({
+        genre: field("b", "genre"),
+        totalBooks: count("b"),
+        uniqueAuthors: countDistinct("a"),
+      })
+      .execute();
+
+    for (const row of authorsPerGenre) {
+      const authorLabel = row.uniqueAuthors === 1 ? "author" : "authors";
+      console.log(`  ${String(row.genre)}: ${row.totalBooks} books by ${row.uniqueAuthors} ${authorLabel}`);
+    }
+
+    // ============================================================
+    // 4. Multiple groupBy fields — genre × availability
+    // ============================================================
+
+    console.log("\n--- Books by genre and availability (multiple GROUP BY) ---\n");
+
+    const breakdown = await store
+      .query()
+      .from("Book", "b")
+      .groupBy("b", "genre")
+      .groupBy("b", "inStock")
+      .aggregate({
+        genre: field("b", "genre"),
+        inStock: field("b", "inStock"),
+        bookCount: count("b"),
+      })
+      .execute();
+
+    for (const row of breakdown) {
+      const status = row.inStock ? "in stock" : "out of stock";
+      console.log(`  ${String(row.genre)} (${status}): ${row.bookCount}`);
+    }
+
+    // ============================================================
+    // 5. groupByNode — books per author via traversal
+    // ============================================================
+
+    console.log("\n--- Books per author (groupByNode + traversal) ---\n");
+
+    const booksPerAuthor = await store
+      .query()
+      .from("Author", "a")
+      .traverse("wrote", "e")
+      .to("Book", "b")
+      .groupByNode("a")
+      .aggregate({
+        author: field("a", "name"),
+        bookCount: count("b"),
+        avgRating: avg("b", "rating"),
+      })
+      .execute();
+
+    for (const row of booksPerAuthor) {
+      console.log(`  ${String(row.author)}: ${row.bookCount} books (avg rating: ${row.avgRating.toFixed(1)})`);
+    }
+
+    // ============================================================
+    // 6. HAVING — genres with 3+ books
+    // ============================================================
+
+    console.log("\n--- Genres with 3+ books (HAVING) ---\n");
+
+    const popularGenres = await store
+      .query()
+      .from("Book", "b")
+      .groupBy("b", "genre")
+      .having(havingGte(count("b"), 3))
+      .aggregate({
+        genre: field("b", "genre"),
+        bookCount: count("b"),
+      })
+      .execute();
+
+    for (const row of popularGenres) {
+      console.log(`  ${String(row.genre)}: ${row.bookCount} books`);
+    }
+
+    if (popularGenres.length === 0) {
+      console.log("  (no genres matched)");
+    }
+
+    // ============================================================
+    // 7. WHERE + HAVING — in-stock genres worth over $20
+    // ============================================================
+
+    console.log("\n--- In-stock books: genres with total value > $20 (WHERE + HAVING) ---\n");
+
+    const valuableInStock = await store
+      .query()
+      .from("Book", "b")
+      .whereNode("b", (b) => b.inStock.eq(true))
+      .groupBy("b", "genre")
+      .having(havingGt(sum("b", "price"), 20))
+      .aggregate({
+        genre: field("b", "genre"),
+        bookCount: count("b"),
+        totalValue: sum("b", "price"),
+      })
+      .execute();
+
+    for (const row of valuableInStock) {
+      console.log(`  ${String(row.genre)}: ${row.bookCount} books, $${row.totalValue.toFixed(2)} total`);
+    }
+
+    // ============================================================
+    // 8. Traversal aggregates — revenue per publisher
+    // ============================================================
+
+    console.log("\n--- Revenue per publisher (traversal + aggregates) ---\n");
+
+    const publisherRevenue = await store
+      .query()
+      .from("Book", "b")
+      .traverse("publishedBy", "e")
+      .to("Publisher", "p")
+      .groupByNode("p")
+      .aggregate({
+        publisher: field("p", "name"),
+        bookCount: count("b"),
+        totalRevenue: sum("b", "price"),
+        avgPrice: avg("b", "price"),
+        topRating: max("b", "rating"),
+      })
+      .execute();
+
+    for (const row of publisherRevenue) {
+      console.log(`  ${String(row.publisher)}:`);
+      console.log(`    ${row.bookCount} books, $${row.totalRevenue.toFixed(2)} total, avg $${row.avgPrice.toFixed(2)}`);
+      console.log(`    Highest rating: ${row.topRating}`);
+    }
+
+    // ============================================================
+    // 9. Ordering and limiting aggregate results
+    // ============================================================
+
+    console.log("\n--- Top 2 authors by book count (orderBy + limit) ---\n");
+
+    // orderBy accepts grouped fields and aggregate aliases; chained calls
+    // sort by the first key, then the next as a tiebreak
+    const topAuthors = await store
+      .query()
+      .from("Author", "a")
+      .traverse("wrote", "e")
+      .to("Book", "b")
+      .groupByNode("a")
+      .aggregate({
+        author: field("a", "name"),
+        bookCount: count("b"),
+      })
+      .orderBy("bookCount", "desc")
+      .orderBy("author")
+      .limit(2)
+      .execute();
+
+    for (const row of topAuthors) {
+      console.log(`  ${String(row.author)}: ${row.bookCount} books`);
+    }
+
+    console.log("\n=== Aggregate query example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // ============================================================
-  // 2. Multiple aggregates — price statistics per genre
-  // ============================================================
-
-  console.log("\n--- Price statistics per genre (SUM, AVG, MIN, MAX) ---\n");
-
-  const priceStats = await store
-    .query()
-    .from("Book", "b")
-    .groupBy("b", "genre")
-    .aggregate({
-      genre: field("b", "genre"),
-      totalValue: sum("b", "price"),
-      avgPrice: avg("b", "price"),
-      cheapest: min("b", "price"),
-      mostExpensive: max("b", "price"),
-    })
-    .execute();
-
-  for (const row of priceStats) {
-    console.log(`  ${row.genre}:`);
-    console.log(`    Total: $${row.totalValue.toFixed(2)}`);
-    console.log(`    Avg:   $${row.avgPrice.toFixed(2)}`);
-    console.log(`    Range: $${row.cheapest.toFixed(2)} – $${row.mostExpensive.toFixed(2)}`);
-  }
-
-  // ============================================================
-  // 3. countDistinct — unique authors per genre
-  // ============================================================
-
-  console.log("\n--- Unique authors per genre (COUNT DISTINCT) ---\n");
-
-  // countDistinct counts unique node IDs within each group,
-  // useful when joins might produce duplicates
-  const authorsPerGenre = await store
-    .query()
-    .from("Author", "a")
-    .traverse("wrote", "e")
-    .to("Book", "b")
-    .groupBy("b", "genre")
-    .aggregate({
-      genre: field("b", "genre"),
-      totalBooks: count("b"),
-      uniqueAuthors: countDistinct("a"),
-    })
-    .execute();
-
-  for (const row of authorsPerGenre) {
-    console.log(`  ${row.genre}: ${row.totalBooks} books by ${row.uniqueAuthors} authors`);
-  }
-
-  // ============================================================
-  // 4. Multiple groupBy fields — genre × availability
-  // ============================================================
-
-  console.log("\n--- Books by genre and availability (multiple GROUP BY) ---\n");
-
-  const breakdown = await store
-    .query()
-    .from("Book", "b")
-    .groupBy("b", "genre")
-    .groupBy("b", "inStock")
-    .aggregate({
-      genre: field("b", "genre"),
-      inStock: field("b", "inStock"),
-      bookCount: count("b"),
-    })
-    .execute();
-
-  for (const row of breakdown) {
-    const status = row.inStock ? "in stock" : "out of stock";
-    console.log(`  ${row.genre} (${status}): ${row.bookCount}`);
-  }
-
-  // ============================================================
-  // 5. groupByNode — books per author via traversal
-  // ============================================================
-
-  console.log("\n--- Books per author (groupByNode + traversal) ---\n");
-
-  const booksPerAuthor = await store
-    .query()
-    .from("Author", "a")
-    .traverse("wrote", "e")
-    .to("Book", "b")
-    .groupByNode("a")
-    .aggregate({
-      author: field("a", "name"),
-      bookCount: count("b"),
-      avgRating: avg("b", "rating"),
-    })
-    .execute();
-
-  for (const row of booksPerAuthor) {
-    console.log(`  ${row.author}: ${row.bookCount} books (avg rating: ${row.avgRating.toFixed(1)})`);
-  }
-
-  // ============================================================
-  // 6. HAVING — genres with 3+ books
-  // ============================================================
-
-  console.log("\n--- Genres with 3+ books (HAVING) ---\n");
-
-  const popularGenres = await store
-    .query()
-    .from("Book", "b")
-    .groupBy("b", "genre")
-    .having(havingGte(count("b"), 3))
-    .aggregate({
-      genre: field("b", "genre"),
-      bookCount: count("b"),
-    })
-    .execute();
-
-  for (const row of popularGenres) {
-    console.log(`  ${row.genre}: ${row.bookCount} books`);
-  }
-
-  if (popularGenres.length === 0) {
-    console.log("  (no genres matched)");
-  }
-
-  // ============================================================
-  // 7. WHERE + HAVING — in-stock genres worth over $20
-  // ============================================================
-
-  console.log("\n--- In-stock books: genres with total value > $20 (WHERE + HAVING) ---\n");
-
-  const valuableInStock = await store
-    .query()
-    .from("Book", "b")
-    .whereNode("b", (b) => b.inStock.eq(true))
-    .groupBy("b", "genre")
-    .having(havingGt(sum("b", "price"), 20))
-    .aggregate({
-      genre: field("b", "genre"),
-      bookCount: count("b"),
-      totalValue: sum("b", "price"),
-    })
-    .execute();
-
-  for (const row of valuableInStock) {
-    console.log(`  ${row.genre}: ${row.bookCount} books, $${row.totalValue.toFixed(2)} total`);
-  }
-
-  // ============================================================
-  // 8. Traversal aggregates — revenue per publisher
-  // ============================================================
-
-  console.log("\n--- Revenue per publisher (traversal + aggregates) ---\n");
-
-  const publisherRevenue = await store
-    .query()
-    .from("Book", "b")
-    .traverse("publishedBy", "e")
-    .to("Publisher", "p")
-    .groupByNode("p")
-    .aggregate({
-      publisher: field("p", "name"),
-      bookCount: count("b"),
-      totalRevenue: sum("b", "price"),
-      avgPrice: avg("b", "price"),
-      topRating: max("b", "rating"),
-    })
-    .execute();
-
-  for (const row of publisherRevenue) {
-    console.log(`  ${row.publisher}:`);
-    console.log(`    ${row.bookCount} books, $${row.totalRevenue.toFixed(2)} total, avg $${row.avgPrice.toFixed(2)}`);
-    console.log(`    Highest rating: ${row.topRating}`);
-  }
-
-  // ============================================================
-  // 9. Limit on aggregate results
-  // ============================================================
-
-  console.log("\n--- Top 2 authors by book count (orderBy + limit) ---\n");
-
-  const topAuthors = await store
-    .query()
-    .from("Author", "a")
-    .traverse("wrote", "e")
-    .to("Book", "b")
-    .groupByNode("a")
-    .aggregate({
-      author: field("a", "name"),
-      bookCount: count("b"),
-    })
-    .orderBy("bookCount", "desc")
-    .limit(2)
-    .execute();
-
-  for (const row of topAuthors) {
-    console.log(`  ${row.author}: ${row.bookCount} books`);
-  }
-
-  console.log("\n=== Aggregate query example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/14-research-copilot.ts
+++ b/packages/typegraph/examples/14-research-copilot.ts
@@ -25,8 +25,6 @@
  * Run with:
  *   npx tsx examples/14-research-copilot.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineEdge,
@@ -35,6 +33,8 @@ import {
   embedding,
   searchable,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -104,13 +104,13 @@ const graph = defineGraph({
 
 function mockEmbedding(text: string): number[] {
   const dim = 128;
-  const vector = new Array<number>(dim).fill(0);
+  const vector = Array.from({ length: dim }, () => 0);
   const tokens = text.toLowerCase().split(/\W+/).filter(Boolean);
   for (const token of tokens) {
     let hash = 0;
-    for (const char of token) hash = (hash * 31 + char.charCodeAt(0)) | 0;
-    for (let i = 0; i < dim; i++) {
-      vector[i]! += Math.sin(hash * (i + 1)) * 0.25 + Math.cos(hash + i) * 0.25;
+    for (const char of token) hash = Math.imul(hash, 31) + (char.codePointAt(0) ?? 0);
+    for (let index = 0; index < dim; index++) {
+      vector[index]! += Math.sin(hash * (index + 1)) * 0.25 + Math.cos(hash + index) * 0.25;
     }
   }
   const magnitude = Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0)) || 1;
@@ -119,7 +119,7 @@ function mockEmbedding(text: string): number[] {
 
 function cosine(a: readonly number[], b: readonly number[]): number {
   let dot = 0;
-  for (let i = 0; i < a.length; i++) dot += a[i]! * b[i]!;
+  for (let index = 0; index < a.length; index++) dot += a[index]! * b[index]!;
   return dot; // both vectors are unit-length
 }
 
@@ -511,7 +511,7 @@ export async function main(): Promise<void> {
   // so this runs native vector search (store.search.vector); pgvector / libSQL
   // run the identical call. If no vector engine is present we rank in JS so the
   // example still completes.
-  let ranked: ReadonlyArray<{ paper: PaperNode; similarity: number }>;
+  let ranked: readonly { paper: PaperNode; similarity: number }[];
   if (backend.capabilities.vector?.supported) {
     const hits = await store.search.vector("Paper", {
       fieldPath: "embedding",
@@ -529,7 +529,7 @@ export async function main(): Promise<void> {
         paper,
         similarity: cosine(queryEmbedding, paper.embedding),
       }))
-      .sort((a, b) => b.similarity - a.similarity);
+      .toSorted((a, b) => b.similarity - a.similarity);
   }
 
   console.log("\nTop semantic hits (vector similarity only):");
@@ -799,7 +799,7 @@ export async function main(): Promise<void> {
 
   const topCollaborators = [...collaboratorCounts.entries()]
     .filter(([id]) => !clipAuthorIds.has(id))
-    .sort((a, b) => b[1] - a[1])
+    .toSorted((a, b) => b[1] - a[1])
     .slice(0, 8);
 
   console.log(" Nearby collaborators beyond the original CLIP paper:");
@@ -822,7 +822,7 @@ export async function main(): Promise<void> {
 
   const topPicks = hybridScored
     .slice(0, 5)
-    .sort((a, b) => a.paper.year - b.paper.year);
+    .toSorted((a, b) => a.paper.year - b.paper.year);
 
   // Batch the metadata lookups: one `.in([...])` query per relation for all
   // five picks — the same pattern as the expanded-topic query in [1] —
@@ -889,7 +889,7 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/14-research-copilot.ts
+++ b/packages/typegraph/examples/14-research-copilot.ts
@@ -4,17 +4,23 @@
  * A showcase that combines everything TypeGraph does:
  *
  *   • Typed schema with Zod        → compile-time guarantees
- *   • Ontology (topic hierarchy)   → query expansion
+ *   • Concept-hierarchy expansion  → higher-recall topic matching
  *   • Vector embeddings            → semantic retrieval
  *   • Recursive CTE traversals     → subgraph extraction
  *   • Graph algorithms             → shortestPath / reachable /
  *                                      canReach / neighbors / degree
  *
  * The scenario: a researcher asks natural-language questions over a corpus
- * of landmark ML papers. The copilot combines semantic search, ontology-
- * expanded topic matching, citation-authority ranking (degree), explainable
- * recommendations (shortestPath), and co-author discovery (neighbors) — all
- * over a single SQLite database with zero external services.
+ * of landmark ML papers. The copilot combines semantic search, concept-
+ * hierarchy-expanded topic matching, citation-authority ranking (degree),
+ * explainable recommendations (shortestPath), and co-author discovery
+ * (neighbors + a multi-hop traversal query) — all over a single SQLite
+ * database with zero external services.
+ *
+ * Note: the concept hierarchy here is instance-level data — Topic nodes
+ * connected by a custom `broader_than` edge, expanded with a recursive
+ * traversal. It is distinct from TypeGraph's type-level ontology module
+ * (subClassOf / broader relationships between kinds — see examples 03–08).
  *
  * Run with:
  *   npx tsx examples/14-research-copilot.ts
@@ -40,9 +46,10 @@ const Paper = defineNode("Paper", {
     // `searchable()` on title + abstract puts both into the BM25 index so
     // rare-token queries (author surnames, dataset names, method acronyms)
     // hit exact matches where embeddings are weakest. The semantic-
-    // retrieval scene below ranks by JS cosine for self-containment; a
-    // production deployment pairs this schema with `store.search.hybrid`
-    // for fused vector+fulltext retrieval.
+    // retrieval scene below runs native `store.search.vector` when a
+    // vector engine is loaded (sqlite-vec here) and falls back to a JS
+    // cosine ranking otherwise; a production deployment pairs this schema
+    // with `store.search.hybrid` for fused vector+fulltext retrieval.
     title: searchable({ language: "english" }),
     year: z.number().int(),
     abstract: searchable({ language: "english" }),
@@ -398,11 +405,18 @@ export async function main(): Promise<void> {
   console.log("━".repeat(68));
   console.log(" Research Copilot — RAG + citation graph + graph algorithms");
   console.log("━".repeat(68));
+  const vectorEngineLabel =
+    backend.capabilities.vector?.supported ?
+      "native vector search (sqlite-vec)"
+    : "JS cosine fallback (no vector engine loaded)";
+  console.log(` Vector engine: ${vectorEngineLabel}`);
   console.log("\n Tour:");
-  console.log("  [1] Vector similarity + ontology expansion via reachable()");
+  console.log(
+    "  [1] Vector similarity + concept-hierarchy expansion via reachable()",
+  );
   console.log("  [2] Citation-aware re-ranking via degree()");
   console.log("  [3] Explainable lineage via shortestPath() + canReach()");
-  console.log("  [4] Collaborator expansion via neighbors()");
+  console.log("  [4] Collaborator discovery via one multi-hop traversal");
   console.log("  [5] Final reading list that combines the signals above");
 
   // ----------------------------------------------------------
@@ -476,7 +490,7 @@ export async function main(): Promise<void> {
   );
 
   // ----------------------------------------------------------
-  // [1] Semantic retrieval with ontology-expanded topics
+  // [1] Semantic retrieval with concept-hierarchy-expanded topics
   // ----------------------------------------------------------
 
   const query =
@@ -560,10 +574,10 @@ export async function main(): Promise<void> {
   }
 
   // ----------------------------------------------------------
-  // Ontology-expanded topic retrieval (sub-step of [1])
+  // Concept-hierarchy-expanded topic retrieval (sub-step of [1])
   // ----------------------------------------------------------
 
-  console.log("\n─── Ontology-expanded topic match ───");
+  console.log("\n─── Concept-hierarchy-expanded topic match ───");
   console.log(
     ' Query: "Contrastive" → recursively expand via broader_than → all',
   );
@@ -630,6 +644,9 @@ export async function main(): Promise<void> {
     ...matchByPaper.keys(),
   ]);
 
+  // Per-candidate degree() keeps the algorithm explicit here; for bulk
+  // citation counts over many nodes, one aggregate groupBy query does it
+  // in a single statement (see example 13).
   const hybridScored = await Promise.all(
     [...candidateIds].map(async (paperId) => {
       const paper = paperById.get(paperId)!;
@@ -723,11 +740,11 @@ export async function main(): Promise<void> {
   }
 
   // ----------------------------------------------------------
-  // [4] Co-author discovery via 2-hop neighborhood
+  // [4] Co-author discovery via one multi-hop traversal
   // ----------------------------------------------------------
 
   console.log("\n" + "━".repeat(68));
-  console.log(" [4] Collaborator discovery (neighbors, 2 hops)");
+  console.log(" [4] Collaborator discovery (2 hops from the seed's authors)");
   console.log("━".repeat(68));
   console.log(
     '\n "If I write a paper citing CLIP, who are my natural co-authors?"\n',
@@ -735,7 +752,8 @@ export async function main(): Promise<void> {
 
   const clip = paperByKey.get("clip")!;
 
-  // 1-hop out: CLIP → authors
+  // 1-hop out: CLIP → authors. `neighbors()` is the natural fit for a
+  // single node's adjacency.
   const clipAuthors = await store.algorithms.neighbors(clip.id, {
     edges: ["authored_by"],
     depth: 1,
@@ -747,48 +765,36 @@ export async function main(): Promise<void> {
     ` Seed paper authors: ${clipAuthors.map((author) => authorById.get(author.id) ?? author.id).join(", ")}\n`,
   );
 
-  // For each CLIP author: 1-hop in along authored_by = all their papers,
-  // then 1-hop out = all collaborators. Issue each level in parallel so the
-  // full fan-out finishes in O(depth) round-trips instead of O(authors × papers).
-  //
-  // Parallel arrays indexed by the same `i` as clipAuthors:
-  //   clipAuthors[i]                    → one CLIP author
-  //   perAuthorPapers[i]                → that author's papers
-  //   perAuthorCollaborators[i][j]      → co-authors on paper j of author i
-  const perAuthorPapers = await Promise.all(
-    clipAuthors.map((author) =>
-      store.algorithms.neighbors(author.id, {
-        edges: ["authored_by"],
-        direction: "in",
-        depth: 1,
-      }),
-    ),
-  );
-  const perAuthorCollaborators = await Promise.all(
-    perAuthorPapers.map((papers) =>
-      Promise.all(
-        papers.map((paper) =>
-          store.algorithms.neighbors(paper.id, {
-            edges: ["authored_by"],
-            depth: 1,
-          }),
-        ),
-      ),
-    ),
-  );
+  // From those authors, the whole collaborator fan-out is one traversal
+  // query instead of a 1+N+N×M `neighbors()` cascade: CLIP → its authors →
+  // (direction "in") their other papers → those papers' authors. The
+  // recursive-CTE compiler turns the four-alias chain into a single SQL
+  // statement; JS only tallies the rows.
+  const collaborationRows = await store
+    .query()
+    .from("Paper", "seed")
+    .whereNode("seed", (paper) => paper.id.eq(clip.id))
+    .traverse("authored_by", "wrote")
+    .to("Author", "clipAuthor")
+    .traverse("authored_by", "alsoWrote", { direction: "in" })
+    .to("Paper", "sharedPaper")
+    .traverse("authored_by", "coWrote")
+    .to("Author", "collaborator")
+    .select((ctx) => ({
+      clipAuthorId: ctx.clipAuthor.id,
+      collaboratorId: ctx.collaborator.id,
+    }))
+    .execute();
 
-  // Tally how often each person co-authored with any CLIP author.
+  // Tally how often each person co-authored with any CLIP author
+  // (one row per CLIP author × shared paper × collaborator).
   const collaboratorCounts = new Map<string, number>();
-  for (const [authorIndex, clipAuthor] of clipAuthors.entries()) {
-    for (const collaborators of perAuthorCollaborators[authorIndex]!) {
-      for (const collab of collaborators) {
-        if (collab.id === clipAuthor.id) continue;
-        collaboratorCounts.set(
-          collab.id,
-          (collaboratorCounts.get(collab.id) ?? 0) + 1,
-        );
-      }
-    }
+  for (const row of collaborationRows) {
+    if (row.collaboratorId === row.clipAuthorId) continue;
+    collaboratorCounts.set(
+      row.collaboratorId,
+      (collaboratorCounts.get(row.collaboratorId) ?? 0) + 1,
+    );
   }
 
   const topCollaborators = [...collaboratorCounts.entries()]
@@ -818,34 +824,47 @@ export async function main(): Promise<void> {
     .slice(0, 5)
     .sort((a, b) => a.paper.year - b.paper.year);
 
-  const picksWithMeta = await Promise.all(
-    topPicks.map(async (pick) => {
-      const [paperAuthors, paperTopics] = await Promise.all([
-        store
-          .query()
-          .from("Paper", "p")
-          .whereNode("p", (p) => p.id.eq(pick.paper.id))
-          .traverse("authored_by", "e")
-          .to("Author", "a")
-          .select((ctx) => ctx.a.name)
-          .execute(),
-        store
-          .query()
-          .from("Paper", "p")
-          .whereNode("p", (p) => p.id.eq(pick.paper.id))
-          .traverse("covers_topic", "e")
-          .to("Topic", "t")
-          .select((ctx) => ctx.t.name)
-          .execute(),
-      ]);
-      const matchedTopics = [
-        ...(matchByPaper.get(pick.paper.id) ?? new Set<string>()),
-      ];
-      return { pick, paperAuthors, paperTopics, matchedTopics };
-    }),
-  );
+  // Batch the metadata lookups: one `.in([...])` query per relation for all
+  // five picks — the same pattern as the expanded-topic query in [1] —
+  // instead of two queries per pick.
+  const pickIds = topPicks.map((pick) => pick.paper.id);
+  const [authorRows, topicRows] = await Promise.all([
+    store
+      .query()
+      .from("Paper", "p")
+      .whereNode("p", (p) => p.id.in(pickIds))
+      .traverse("authored_by", "e")
+      .to("Author", "a")
+      .select((ctx) => ({ paperId: ctx.p.id, name: ctx.a.name }))
+      .execute(),
+    store
+      .query()
+      .from("Paper", "p")
+      .whereNode("p", (p) => p.id.in(pickIds))
+      .traverse("covers_topic", "e")
+      .to("Topic", "t")
+      .select((ctx) => ({ paperId: ctx.p.id, topic: ctx.t.name }))
+      .execute(),
+  ]);
+  const authorsByPaper = new Map<string, string[]>();
+  for (const row of authorRows) {
+    const names = authorsByPaper.get(row.paperId) ?? [];
+    names.push(row.name);
+    authorsByPaper.set(row.paperId, names);
+  }
+  const topicsByPaper = new Map<string, string[]>();
+  for (const row of topicRows) {
+    const names = topicsByPaper.get(row.paperId) ?? [];
+    names.push(row.topic);
+    topicsByPaper.set(row.paperId, names);
+  }
 
-  for (const { pick, paperAuthors, paperTopics, matchedTopics } of picksWithMeta) {
+  for (const pick of topPicks) {
+    const paperAuthors = authorsByPaper.get(pick.paper.id) ?? [];
+    const paperTopics = topicsByPaper.get(pick.paper.id) ?? [];
+    const matchedTopics = [
+      ...(matchByPaper.get(pick.paper.id) ?? new Set<string>()),
+    ];
     const citationLabel = pick.citationCount === 1 ? "citation" : "citations";
     const why: string[] = [`semantic ${pick.similarity.toFixed(3)}`];
     if (matchedTopics.length > 0) why.push(`topic match: ${matchedTopics.join(", ")}`);
@@ -859,7 +878,10 @@ export async function main(): Promise<void> {
   }
 
   console.log("\n" + "━".repeat(68));
-  console.log(" Everything above ran against a single in-memory SQLite file.");
+  console.log(
+    " Everything above ran against a single in-memory SQLite database",
+  );
+  console.log(` using ${vectorEngineLabel}.`);
   console.log(" Swap to Postgres by changing one import.");
   console.log("━".repeat(68) + "\n");
 

--- a/packages/typegraph/examples/15-fulltext-hybrid-search.ts
+++ b/packages/typegraph/examples/15-fulltext-hybrid-search.ts
@@ -20,9 +20,8 @@
  * which loads FTS5 (built into SQLite, so fulltext needs no extension) AND
  * sqlite-vec (an optional peer dep). Both halves of hybrid search therefore run
  * natively here — the same code path runs on pgvector (Postgres) or libSQL's
- * built-in engine. If a backend without a vector engine is ever used, Part 6
- * falls back to a small in-JS cosine `vectorSearch` shim so the example still
- * completes end-to-end.
+ * built-in engine. On a backend without a vector engine, the hybrid demos in
+ * Part 6 are skipped (with a message) rather than faked.
  *
  * Run with:
  *   npx tsx examples/15-fulltext-hybrid-search.ts
@@ -34,10 +33,16 @@ import {
   defineGraph,
   defineNode,
   embedding,
-  type GraphBackend,
   searchable,
 } from "@nicia-ai/typegraph";
-import { createExampleBackend } from "./_helpers";
+import { createExampleBackend, mockTextEmbedding } from "./_helpers";
+
+/**
+ * Real applications use a model-sized dimension (384+); a small vector keeps
+ * this demo fast while leaving the bag-of-words mock embedding enough room to
+ * avoid hash collisions on the catalog's vocabulary.
+ */
+const EMBEDDING_DIMENSIONS = 64;
 
 // ============================================================
 // Schema
@@ -63,7 +68,7 @@ const Product = defineNode("Product", {
     category: z.enum(["outerwear", "footwear", "accessories", "climbing"]),
     basePrice: z.number().positive(),
     status: z.enum(["draft", "active", "discontinued"]).default("active"),
-    embedding: embedding(16).optional(),
+    embedding: embedding(EMBEDDING_DIMENSIONS).optional(),
   }),
 });
 
@@ -72,62 +77,6 @@ const graph = defineGraph({
   nodes: { Product: { type: Product } },
   edges: {},
 });
-
-// ============================================================
-// Mock embedding — deterministic, for demo purposes
-// ============================================================
-
-/**
- * Produces a deterministic 16-dim unit vector from a text string. In
- * production this would be a call to an embedding API (OpenAI,
- * Sentence Transformers, etc.). The tiny dimension keeps the example
- * fast; use 384+ in real applications.
- */
-function mockEmbedding(text: string, dimensions = 16): number[] {
-  const vector: number[] = [];
-  for (let index = 0; index < dimensions; index++) {
-    const charSum = text.split("").reduce((sum, char, position) => {
-      return sum + char.charCodeAt(0) * (position + 1) * (index + 1);
-    }, 0);
-    vector.push(Math.sin(charSum + index) * 0.5 + 0.5);
-  }
-  const magnitude = Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0));
-  return vector.map((v) => v / magnitude);
-}
-
-function cosineSimilarity(a: readonly number[], b: readonly number[]): number {
-  let dot = 0;
-  for (let index = 0; index < a.length; index += 1) {
-    dot += (a[index] ?? 0) * (b[index] ?? 0);
-  }
-  // mockEmbedding() already unit-normalizes, so dot product == cosine.
-  return dot;
-}
-
-/**
- * Fallback only: attaches a JS-side cosine-similarity `vectorSearch` to a
- * backend that has no native vector engine, so `store.search.hybrid()` still
- * has a vector source. The example backend loads sqlite-vec, so this is not
- * used here — it's a safety net for backends without a VectorStrategy.
- */
-function attachJsVectorSearchStub(
-  backend: GraphBackend,
-  productsWithEmbeddings: ReadonlyArray<
-    Readonly<{ id: string; embedding: readonly number[] }>
-  >,
-): void {
-  (backend as { vectorSearch?: GraphBackend["vectorSearch"] }).vectorSearch =
-    (params) => {
-      const scored = productsWithEmbeddings
-        .map((node) => ({
-          nodeId: node.id,
-          score: cosineSimilarity(params.queryEmbedding, node.embedding),
-        }))
-        .sort((a, b) => b.score - a.score)
-        .slice(0, params.limit);
-      return Promise.resolve(scored);
-    };
-}
 
 // ============================================================
 // Demo catalog
@@ -252,335 +201,346 @@ export async function main(): Promise<void> {
   const backend = createExampleBackend();
   const [store] = await createStoreWithSchema(graph, backend);
 
-  // ============================================================
-  // Part 1: Seed the catalog
-  // ============================================================
+  try {
+    // ============================================================
+    // Part 1: Seed the catalog
+    // ============================================================
 
-  divider("Part 1: Seed the catalog");
+    divider("Part 1: Seed the catalog");
 
-  const seededEmbeddings: Array<{
-    id: string;
-    embedding: readonly number[];
-  }> = [];
-  for (const product of seedProducts) {
-    const indexedText = `${product.name} ${product.description} ${product.sku}`;
-    const productEmbedding = mockEmbedding(indexedText);
-    const created = await store.nodes.Product.create({
-      ...product,
-      embedding: productEmbedding,
-    });
-    seededEmbeddings.push({ id: created.id, embedding: productEmbedding });
-  }
+    for (const product of seedProducts) {
+      const indexedText = `${product.name} ${product.description} ${product.sku}`;
+      await store.nodes.Product.create({
+        ...product,
+        embedding: mockTextEmbedding(indexedText, EMBEDDING_DIMENSIONS),
+      });
+    }
 
-  console.log(`Seeded ${seedProducts.length} products.`);
-  console.log(
-    "Each product has `searchable()` fields (name, description, sku) " +
-      "plus a 16-dim embedding. The fulltext index is kept in sync on " +
-      "every create/update/delete; no manual indexing step needed.",
-  );
-
-  // ============================================================
-  // Part 2: Fulltext-only search (store.search.fulltext)
-  // ============================================================
-
-  divider("Part 2: Fulltext-only search");
-
-  console.log(
-    "Run a BM25-ranked query against every searchable field, with " +
-      "highlighted snippets so users can see where the match is:\n",
-  );
-
-  const fulltextHits = await store.search.fulltext("Product", {
-    query: "waterproof jacket",
-    limit: 3,
-    includeSnippets: true,
-  });
-
-  console.log(`Query: "waterproof jacket"`);
-  for (const [index, hit] of fulltextHits.entries()) {
-    renderHit(index + 1, hit.node, hit.score, `snippet=${hit.snippet ?? ""}`);
-  }
-
-  // ============================================================
-  // Part 3: Why hybrid exists — exact-token queries break embeddings
-  // ============================================================
-
-  divider("Part 3: Why hybrid matters — exact-token queries");
-
-  console.log(
-    "Users routinely type SKUs, proper nouns, and model numbers. " +
-      "Embeddings smooth these out; BM25 nails them.\n",
-  );
-
-  const skuHits = await store.search.fulltext("Product", {
-    query: "PROD-1005-E",
-    limit: 3,
-  });
-
-  console.log(`Query: "PROD-1005-E" (looking up an exact SKU)`);
-  for (const [index, hit] of skuHits.entries()) {
-    renderHit(index + 1, hit.node, hit.score);
-  }
-  console.log(
-    "  ↑ Fulltext finds the exact SKU immediately. A pure-vector search " +
-      "on the same query would rank unrelated products higher because " +
-      "the SKU token doesn't participate meaningfully in the embedding.",
-  );
-
-  // ============================================================
-  // Part 4: Query modes — websearch, phrase, plain, raw
-  // ============================================================
-
-  divider("Part 4: Query modes");
-
-  console.log("websearch (default): Google-style syntax.\n");
-
-  const websearchHits = await store.search.fulltext("Product", {
-    query: `"ski goggles" -compression`,
-    limit: 5,
-    mode: "websearch",
-  });
-  console.log(`Query: "\\"ski goggles\\" -compression"`);
-  for (const [index, hit] of websearchHits.entries()) {
-    renderHit(index + 1, hit.node, hit.score);
-  }
-
-  console.log("\nphrase mode: exact adjacency.\n");
-  const phraseHits = await store.search.fulltext("Product", {
-    query: "climbing harness",
-    limit: 3,
-    mode: "phrase",
-  });
-  console.log(`Query (phrase): "climbing harness"`);
-  for (const [index, hit] of phraseHits.entries()) {
-    renderHit(index + 1, hit.node, hit.score);
-  }
-
-  console.log("\nplain mode: all terms must appear, no special syntax.\n");
-  const plainHits = await store.search.fulltext("Product", {
-    query: "lightweight shell",
-    limit: 3,
-    mode: "plain",
-  });
-  console.log(`Query (plain): "lightweight shell"`);
-  for (const [index, hit] of plainHits.entries()) {
-    renderHit(index + 1, hit.node, hit.score);
-  }
-
-  // ============================================================
-  // Part 5: $fulltext.matches() in the query builder
-  // ============================================================
-
-  divider("Part 5: $fulltext.matches() in the query builder");
-
-  console.log(
-    "The query-builder predicate composes with any other filter or " +
-      "traversal. Here we search for 'lightweight' but only among " +
-      "`active` products in the `outerwear` category:\n",
-  );
-
-  const activeOuterwear = await store
-    .query()
-    .from("Product", "p")
-    .whereNode("p", (p) =>
-      p.$fulltext
-        .matches("lightweight", 10)
-        .and(p.status.eq("active"))
-        .and(p.category.eq("outerwear")),
-    )
-    .select((ctx) => ({ sku: ctx.p.sku, name: ctx.p.name }))
-    .execute();
-
-  console.log(`Query: "lightweight" + status=active + category=outerwear`);
-  for (const [index, row] of activeOuterwear.entries()) {
-    console.log(`  ${String(index + 1).padStart(2)}. [${row.sku}] ${row.name}`);
-  }
-  console.log(
-    "  ↑ Metadata filters apply inside the fulltext CTE, so the " +
-      "discontinued 'Legacy Rain Shell' is filtered out before ranking.",
-  );
-
-  // ============================================================
-  // Part 6: Hybrid search — vector + fulltext fused with RRF
-  // ============================================================
-
-  divider("Part 6: Hybrid search — RRF fusion");
-
-  console.log(
-    "Production RAG typically needs both: embeddings for conceptual\n" +
-      "matching, fulltext for rare-token exactness. RRF is rank-based,\n" +
-      "so it fuses them without caring about score-scale differences.\n",
-  );
-
-  const hybridQuery = "waterproof shell";
-  const queryEmbedding = mockEmbedding(hybridQuery);
-
-  // createLocalSqliteBackend loads sqlite-vec, so the vector half runs
-  // natively. Only if a backend without a vector engine is used do we fall back
-  // to a small JS cosine shim so store.search.hybrid() still has a vector source.
-  if (!backend.capabilities.vector?.supported) {
-    attachJsVectorSearchStub(backend, seededEmbeddings);
-  }
-
-  const hybridHits = await store.search.hybrid("Product", {
-    limit: 5,
-    vector: {
-      fieldPath: "embedding",
-      queryEmbedding,
-      metric: "cosine",
-      k: 20,
-    },
-    fulltext: {
-      query: hybridQuery,
-      k: 20,
-      includeSnippets: true,
-    },
-    fusion: {
-      method: "rrf",
-      k: 60,
-      weights: { vector: 1, fulltext: 1.25 },
-    },
-  });
-
-  console.log(`Query: "${hybridQuery}"`);
-  console.log(
-    `  (limit=5, vector k=20, fulltext k=20, RRF k=60, fulltext weight=1.25)\n`,
-  );
-  for (const [index, hit] of hybridHits.entries()) {
-    const vectorRank = hit.vector ? `v#${hit.vector.rank}` : "v—";
-    const fulltextRank = hit.fulltext ? `f#${hit.fulltext.rank}` : "f—";
-    renderHit(
-      index + 1,
-      hit.node,
-      hit.score,
-      `(${vectorRank}, ${fulltextRank})`,
+    console.log(`Seeded ${seedProducts.length} products.`);
+    console.log(
+      "Each product has `searchable()` fields (name, description, sku) " +
+        `plus a ${EMBEDDING_DIMENSIONS}-dim embedding. The fulltext index is kept in sync on ` +
+        "every create/update/delete; no manual indexing step needed.",
     );
-  }
-  console.log(
-    "  ↑ The (v#, f#) tags show each sub-result's rank. A hit ranked by\n" +
-      "    only one side still lands well when it is highly ranked there;\n" +
-      "    hits ranked by both sides get a compounding RRF boost.",
-  );
 
-  console.log(
-    "\nThe same fusion is available in the query builder, composing both\n" +
-      "predicates with metadata filters in one SQL statement via .fuseWith().\n" +
-      "Here we additionally restrict to `active` products:\n",
-  );
+    // ============================================================
+    // Part 2: Fulltext-only search (store.search.fulltext)
+    // ============================================================
 
-  if (backend.capabilities.vector?.supported) {
-    const builderHybrid = await store
+    divider("Part 2: Fulltext-only search");
+
+    console.log(
+      "Run a BM25-ranked query against every searchable field, with " +
+        "highlighted snippets so users can see where the match is:\n",
+    );
+
+    const fulltextHits = await store.search.fulltext("Product", {
+      query: "waterproof jacket",
+      limit: 3,
+      includeSnippets: true,
+    });
+
+    console.log(`Query: "waterproof jacket"`);
+    for (const [index, hit] of fulltextHits.entries()) {
+      renderHit(index + 1, hit.node, hit.score, `snippet=${hit.snippet ?? ""}`);
+    }
+
+    // ============================================================
+    // Part 3: Why hybrid exists — exact-token queries break embeddings
+    // ============================================================
+
+    divider("Part 3: Why hybrid matters — exact-token queries");
+
+    console.log(
+      "Users routinely type SKUs, proper nouns, and model numbers. " +
+        "Embeddings smooth these out; BM25 nails them.\n",
+    );
+
+    const skuHits = await store.search.fulltext("Product", {
+      query: "PROD-1005-E",
+      limit: 3,
+    });
+
+    console.log(`Query: "PROD-1005-E" (looking up an exact SKU)`);
+    for (const [index, hit] of skuHits.entries()) {
+      renderHit(index + 1, hit.node, hit.score);
+    }
+    console.log(
+      "  ↑ Fulltext finds the exact SKU immediately. A pure-vector search " +
+        "on the same query would rank unrelated products higher because " +
+        "the SKU token doesn't participate meaningfully in the embedding.",
+    );
+
+    // ============================================================
+    // Part 4: Query modes — websearch, phrase, plain, raw
+    // ============================================================
+
+    divider("Part 4: Query modes");
+
+    console.log("websearch (default): Google-style syntax.\n");
+
+    const websearchHits = await store.search.fulltext("Product", {
+      query: `"ski goggles" -compression`,
+      limit: 5,
+      mode: "websearch",
+    });
+    console.log(`Query: "\\"ski goggles\\" -compression"`);
+    for (const [index, hit] of websearchHits.entries()) {
+      renderHit(index + 1, hit.node, hit.score);
+    }
+
+    console.log("\nphrase mode: exact adjacency.\n");
+    const phraseHits = await store.search.fulltext("Product", {
+      query: "climbing harness",
+      limit: 3,
+      mode: "phrase",
+    });
+    console.log(`Query (phrase): "climbing harness"`);
+    for (const [index, hit] of phraseHits.entries()) {
+      renderHit(index + 1, hit.node, hit.score);
+    }
+
+    console.log("\nplain mode: all terms must appear, no special syntax.\n");
+    const plainHits = await store.search.fulltext("Product", {
+      query: "lightweight shell",
+      limit: 3,
+      mode: "plain",
+    });
+    console.log(`Query (plain): "lightweight shell"`);
+    for (const [index, hit] of plainHits.entries()) {
+      renderHit(index + 1, hit.node, hit.score);
+    }
+
+    console.log(
+      "\nraw mode (not demoed): passes the string verbatim as engine syntax\n" +
+        "(FTS5 / tsquery) — malformed or user-supplied input becomes a query\n" +
+        "error, so reserve it for trusted, programmatically built queries.",
+    );
+
+    // ============================================================
+    // Part 5: $fulltext.matches() in the query builder
+    // ============================================================
+
+    divider("Part 5: $fulltext.matches() in the query builder");
+
+    console.log(
+      "The query-builder predicate composes with any other filter or " +
+        "traversal. Here we search for 'lightweight' but only among " +
+        "`active` products in the `outerwear` category:\n",
+    );
+
+    const activeOuterwear = await store
       .query()
       .from("Product", "p")
       .whereNode("p", (p) =>
         p.$fulltext
-          .matches(hybridQuery, 20)
-          .and(p.embedding.similarTo(queryEmbedding, 20))
-          .and(p.status.eq("active")),
+          .matches("lightweight", 10)
+          .and(p.status.eq("active"))
+          .and(p.category.eq("outerwear")),
       )
-      .fuseWith({ k: 60, weights: { vector: 1, fulltext: 1.25 } })
       .select((ctx) => ({ sku: ctx.p.sku, name: ctx.p.name }))
-      .limit(5)
       .execute();
 
-    console.log(`Builder hybrid (active only): "${hybridQuery}"`);
-    for (const [index, row] of builderHybrid.entries()) {
-      console.log(`  ${String(index + 1).padStart(2)}. [${row.sku}] ${row.name}`);
+    console.log(`Query: "lightweight" + status=active + category=outerwear`);
+    for (const [index, row] of activeOuterwear.entries()) {
+      console.log(
+        `  ${String(index + 1).padStart(2)}. [${row.sku}] ${row.name}`,
+      );
     }
-  } else {
-    console.log("  (skipped — the builder hybrid path needs a vector-capable backend)");
-  }
+    console.log(
+      "  ↑ Metadata filters apply inside the fulltext CTE, so the " +
+        "discontinued 'Legacy Rain Shell' is filtered out before ranking.",
+    );
 
-  // ============================================================
-  // Part 7: Rebuild the fulltext index
-  // ============================================================
+    // ============================================================
+    // Part 6: Hybrid search — vector + fulltext fused with RRF
+    // ============================================================
 
-  divider("Part 7: Rebuild the fulltext index");
+    divider("Part 6: Hybrid search — RRF fusion");
 
-  console.log(
-    "After schema changes (a new `searchable()` field, a `language`\n" +
-      "change) or direct DB writes that bypass the store, call\n" +
-      "`store.search.rebuildFulltext()` to backfill. It iterates nodes\n" +
-      "with keyset pagination, transacts per page, and returns counts.\n",
-  );
+    console.log(
+      "Production RAG typically needs both: embeddings for conceptual\n" +
+        "matching, fulltext for rare-token exactness. RRF is rank-based,\n" +
+        "so it fuses them without caring about score-scale differences.\n",
+    );
 
-  // Simulate drift: delete every fulltext row directly through the
-  // backend. Normal writes never need this — it's just to show the
-  // rebuild pathway.
-  const allProducts = await store.nodes.Product.find();
-  for (const product of allProducts) {
-    await backend.deleteFulltext?.({
-      graphId: store.graphId,
-      nodeKind: "Product",
-      nodeId: product.id,
+    const hybridQuery = "waterproof shell";
+
+    // createLocalSqliteBackend loads sqlite-vec, so the vector half runs
+    // natively here. On a backend without a vector engine, both hybrid demos are
+    // skipped — the fulltext-only searches above are the honest capability floor.
+    if (backend.capabilities.vector?.supported) {
+      const queryEmbedding = mockTextEmbedding(
+        hybridQuery,
+        EMBEDDING_DIMENSIONS,
+      );
+
+      const hybridHits = await store.search.hybrid("Product", {
+        limit: 5,
+        vector: {
+          fieldPath: "embedding",
+          queryEmbedding,
+          metric: "cosine",
+          k: 20,
+        },
+        fulltext: {
+          query: hybridQuery,
+          k: 20,
+          includeSnippets: true,
+        },
+        fusion: {
+          method: "rrf",
+          k: 60,
+          weights: { vector: 1, fulltext: 1.25 },
+        },
+      });
+
+      console.log(`Query: "${hybridQuery}"`);
+      console.log(
+        `  (limit=5, vector k=20, fulltext k=20, RRF k=60, fulltext weight=1.25)\n`,
+      );
+      for (const [index, hit] of hybridHits.entries()) {
+        const vectorRank = hit.vector ? `v#${hit.vector.rank}` : "v—";
+        const fulltextRank = hit.fulltext ? `f#${hit.fulltext.rank}` : "f—";
+        renderHit(
+          index + 1,
+          hit.node,
+          hit.score,
+          `(${vectorRank}, ${fulltextRank})`,
+        );
+      }
+      console.log(
+        "  ↑ The (v#, f#) tags show each sub-result's rank. A hit ranked by\n" +
+          "    only one side still lands well when it is highly ranked there;\n" +
+          "    hits ranked by both sides get a compounding RRF boost.",
+      );
+
+      console.log(
+        "\nThe same fusion is available in the query builder, composing both\n" +
+          "predicates with metadata filters in one SQL statement via .fuseWith().\n" +
+          "Here we additionally restrict to `active` products:\n",
+      );
+
+      const builderHybrid = await store
+        .query()
+        .from("Product", "p")
+        .whereNode("p", (p) =>
+          p.$fulltext
+            .matches(hybridQuery, 20)
+            .and(p.embedding.similarTo(queryEmbedding, 20))
+            .and(p.status.eq("active")),
+        )
+        .fuseWith({ k: 60, weights: { vector: 1, fulltext: 1.25 } })
+        .select((ctx) => ({ sku: ctx.p.sku, name: ctx.p.name }))
+        .limit(5)
+        .execute();
+
+      console.log(`Builder hybrid (active only): "${hybridQuery}"`);
+      for (const [index, row] of builderHybrid.entries()) {
+        console.log(
+          `  ${String(index + 1).padStart(2)}. [${row.sku}] ${row.name}`,
+        );
+      }
+    } else {
+      console.log(
+        "  (skipped — hybrid search needs a vector-capable backend; the\n" +
+          "   fulltext-only searches above are unaffected)",
+      );
+    }
+
+    // ============================================================
+    // Part 7: Rebuild the fulltext index
+    // ============================================================
+
+    divider("Part 7: Rebuild the fulltext index");
+
+    console.log(
+      "After schema changes (a new `searchable()` field, a `language`\n" +
+        "change) or direct DB writes that bypass the store, call\n" +
+        "`store.search.rebuildFulltext()` to backfill. It iterates nodes\n" +
+        "with keyset pagination, transacts per page, and returns counts.\n",
+    );
+
+    // Simulate drift: delete every fulltext row directly through the
+    // backend. Normal writes never need this — it's just to show the
+    // rebuild pathway.
+    const allProducts = await store.nodes.Product.find();
+    for (const product of allProducts) {
+      await backend.deleteFulltext?.({
+        graphId: store.graphId,
+        nodeKind: "Product",
+        nodeId: product.id,
+      });
+    }
+
+    const emptyAfterDrift = await store.search.fulltext("Product", {
+      query: "waterproof",
+      limit: 3,
     });
+    console.log(
+      `Before rebuild: "waterproof" → ${emptyAfterDrift.length} hits (fulltext rows cleared).`,
+    );
+
+    const stats = await store.search.rebuildFulltext();
+    console.log(
+      `Rebuilt: kinds=${stats.kinds.join(",")} processed=${stats.processed} ` +
+        `upserted=${stats.upserted} cleared=${stats.cleared} skipped=${stats.skipped}`,
+    );
+    if (stats.skippedIds.length > 0) {
+      console.log(
+        `Skipped IDs (repair targets): ${stats.skippedIds.join(", ")}`,
+      );
+    }
+
+    const recovered = await store.search.fulltext("Product", {
+      query: "waterproof",
+      limit: 3,
+    });
+    console.log(
+      `After rebuild: "waterproof" → ${recovered.length} hits restored.\n`,
+    );
+
+    // ============================================================
+    // Summary
+    // ============================================================
+
+    divider("Summary");
+
+    console.log("What this example demonstrated:");
+    console.log(
+      "  1. `searchable()` marks a string field for native BM25 indexing.",
+    );
+    console.log(
+      "  2. `store.search.fulltext()` runs BM25 with optional snippets.",
+    );
+    console.log(
+      "  3. Four query modes (websearch, phrase, plain, raw) cover the\n" +
+        "     common input shapes.",
+    );
+    console.log(
+      "  4. `n.$fulltext.matches()` composes with metadata predicates and\n" +
+        "     graph traversal in the query builder.",
+    );
+    console.log(
+      "  5. `store.search.hybrid()` (and `.fuseWith()` on the builder)\n" +
+        "     fuse vector + fulltext with RRF — the production-grade RAG\n" +
+        "     pattern.",
+    );
+    console.log(
+      "  6. `store.search.rebuildFulltext()` backfills the index after\n" +
+        "     schema changes or drift, returning per-kind counts.",
+    );
+
+    console.log(
+      "\nSee /fulltext-search in the docs for the full guide: tuning RRF,\n" +
+        "adding fulltext to existing data, swapping in alternate PostgreSQL\n" +
+        "strategies (pg_trgm, ParadeDB, pgroonga), and troubleshooting.",
+    );
+
+    console.log("\n=== Example Complete ===");
+  } finally {
+    await backend.close();
   }
-
-  const emptyAfterDrift = await store.search.fulltext("Product", {
-    query: "waterproof",
-    limit: 3,
-  });
-  console.log(
-    `Before rebuild: "waterproof" → ${emptyAfterDrift.length} hits (fulltext rows cleared).`,
-  );
-
-  const stats = await store.search.rebuildFulltext();
-  console.log(
-    `Rebuilt: kinds=${stats.kinds.join(",")} processed=${stats.processed} ` +
-      `upserted=${stats.upserted} cleared=${stats.cleared} skipped=${stats.skipped}`,
-  );
-  if (stats.skippedIds.length > 0) {
-    console.log(`Skipped IDs (repair targets): ${stats.skippedIds.join(", ")}`);
-  }
-
-  const recovered = await store.search.fulltext("Product", {
-    query: "waterproof",
-    limit: 3,
-  });
-  console.log(
-    `After rebuild: "waterproof" → ${recovered.length} hits restored.\n`,
-  );
-
-  // ============================================================
-  // Summary
-  // ============================================================
-
-  divider("Summary");
-
-  console.log("What this example demonstrated:");
-  console.log(
-    "  1. `searchable()` marks a string field for native BM25 indexing.",
-  );
-  console.log(
-    "  2. `store.search.fulltext()` runs BM25 with optional snippets.",
-  );
-  console.log(
-    "  3. Four query modes (websearch, phrase, plain, raw) cover the\n" +
-      "     common input shapes.",
-  );
-  console.log(
-    "  4. `n.$fulltext.matches()` composes with metadata predicates and\n" +
-      "     graph traversal in the query builder.",
-  );
-  console.log(
-    "  5. `store.search.hybrid()` (and `.fuseWith()` on the builder)\n" +
-      "     fuse vector + fulltext with RRF — the production-grade RAG\n" +
-      "     pattern.",
-  );
-  console.log(
-    "  6. `store.search.rebuildFulltext()` backfills the index after\n" +
-      "     schema changes or drift, returning per-kind counts.",
-  );
-
-  console.log(
-    "\nSee /fulltext-search in the docs for the full guide: tuning RRF,\n" +
-      "adding fulltext to existing data, swapping in alternate PostgreSQL\n" +
-      "strategies (pg_trgm, ParadeDB, pgroonga), and troubleshooting.",
-  );
-
-  await backend.close();
-
-  console.log("\n=== Example Complete ===");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/typegraph/examples/15-fulltext-hybrid-search.ts
+++ b/packages/typegraph/examples/15-fulltext-hybrid-search.ts
@@ -26,8 +26,6 @@
  * Run with:
  *   npx tsx examples/15-fulltext-hybrid-search.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineGraph,
@@ -35,6 +33,8 @@ import {
   embedding,
   searchable,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend, mockTextEmbedding } from "./_helpers";
 
 /**
@@ -179,10 +179,10 @@ function renderHit(
   score: number,
   extras?: string,
 ): void {
-  const scoreStr = score.toFixed(4);
-  const extrasStr = extras === undefined ? "" : ` ${extras}`;
+  const scoreString = score.toFixed(4);
+  const extrasString = extras === undefined ? "" : ` ${extras}`;
   console.log(
-    `  ${String(rank).padStart(2)}. [${node.sku}] ${node.name.padEnd(24)} score=${scoreStr}${extrasStr}`,
+    `  ${String(rank).padStart(2)}. [${node.sku}] ${node.name.padEnd(24)} score=${scoreString}${extrasString}`,
   );
 }
 
@@ -284,7 +284,7 @@ export async function main(): Promise<void> {
       limit: 5,
       mode: "websearch",
     });
-    console.log(`Query: "\\"ski goggles\\" -compression"`);
+    console.log(String.raw`Query: "\"ski goggles\" -compression"`);
     for (const [index, hit] of websearchHits.entries()) {
       renderHit(index + 1, hit.node, hit.score);
     }
@@ -544,7 +544,7 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/15-fulltext-hybrid-search.ts
+++ b/packages/typegraph/examples/15-fulltext-hybrid-search.ts
@@ -451,7 +451,7 @@ export async function main(): Promise<void> {
     const fulltextRank = hit.fulltext ? `f#${hit.fulltext.rank}` : "f—";
     renderHit(
       index + 1,
-      hit.node as ProductHit,
+      hit.node,
       hit.score,
       `(${vectorRank}, ${fulltextRank})`,
     );

--- a/packages/typegraph/examples/16-graph-extensions.ts
+++ b/packages/typegraph/examples/16-graph-extensions.ts
@@ -75,7 +75,7 @@ const baseGraph = defineGraph({
 });
 
 async function main() {
-  const { backend, db } = createLocalSqliteBackend();
+  const { backend } = createLocalSqliteBackend();
 
   const [store] = await createStoreWithSchema(baseGraph, backend);
   console.log("\n[1] Booted with compile-time kind: Document");
@@ -352,7 +352,7 @@ async function main() {
     restored.registry.hasNodeType("Paper"),
   );
   console.log(
-    "    registry.hasNodeType('Author') (removed in step 7):",
+    "    registry.hasNodeType('Author') (removed in step 8):",
     restored.registry.hasNodeType("Author"),
   );
   console.log(
@@ -365,10 +365,6 @@ async function main() {
   console.log(`    Found ${allPapers.length} Paper nodes after restart`);
 
   await backend.close();
-  // Keep `db` referenced so the linter doesn't strip it — it's the
-  // shared connection backing both the original and restored stores
-  // for the parity demonstration.
-  void db;
 }
 
 async function activeVersion(

--- a/packages/typegraph/examples/16-graph-extensions.ts
+++ b/packages/typegraph/examples/16-graph-extensions.ts
@@ -40,19 +40,19 @@
  *    every approved kind, the deprecation flag, and materialized
  *    indexes — without re-running any of the verbs above.
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineGraph,
   defineNode,
+  type GraphExtension,
   GraphExtensionValidationError,
   IncompatibleChangeError,
   validateGraphExtension,
-  type GraphExtension,
 } from "@nicia-ai/typegraph";
 import { defineNodeIndex } from "@nicia-ai/typegraph/indexes";
+// Imported directly (not via ./_helpers) to show the public subpath.
 import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+import { z } from "zod";
 
 // ============================================================
 // Step 1: Boot with a compile-time graph
@@ -74,297 +74,300 @@ const baseGraph = defineGraph({
   indexes: [documentTitle],
 });
 
-async function main() {
+export async function main() {
   const { backend } = createLocalSqliteBackend();
 
   const [store] = await createStoreWithSchema(baseGraph, backend);
-  console.log("\n[1] Booted with compile-time kind: Document");
-  console.log("    Active schema version:", await activeVersion(backend));
 
-  // Materialize the compile-time index up front. Idempotent.
-  await store.materializeIndexes();
-  console.log("    Materialized 1 compile-time index");
+  try {
+    console.log("\n[1] Booted with compile-time kind: Document");
+    console.log("    Active schema version:", await activeVersion(backend));
 
-  // ============================================================
-  // Step 2: Agent returns a JSON proposal — validate as `unknown`
-  // ============================================================
+    // Materialize the compile-time index up front. Idempotent.
+    await store.materializeIndexes();
+    console.log("    Materialized 1 compile-time index");
 
-  // What an agent (LLM, scraper, ETL) actually hands back is a JSON
-  // blob, not a typed value. `validateGraphExtension(unknown, { strict })`
-  // is the Result-style entry point: it walks the document, collects
-  // every issue, and returns a typed `GraphExtension` on success.
-  // Strict mode rejects unknown sibling keys so a field typo
-  // (`node` instead of `nodes`) fails loudly instead of silently
-  // producing an empty extension.
-  const agentJson: unknown = JSON.parse(`{
-    "nodes": {
-      "Paper": {
-        "description": "Academic paper inferred from the corpus",
-        "properties": {
-          "title": { "type": "string", "minLength": 1, "searchable": {} },
-          "abstract": { "type": "string", "searchable": {}, "optional": true },
-          "doi": { "type": "string", "minLength": 1 },
-          "year": { "type": "number", "int": true, "min": 1900, "max": 2100 }
+    // ============================================================
+    // Step 2: Agent returns a JSON proposal — validate as `unknown`
+    // ============================================================
+
+    // What an agent (LLM, scraper, ETL) actually hands back is a JSON
+    // blob, not a typed value. `validateGraphExtension(unknown, { strict })`
+    // is the Result-style entry point: it walks the document, collects
+    // every issue, and returns a typed `GraphExtension` on success.
+    // Strict mode rejects unknown sibling keys so a field typo
+    // (`node` instead of `nodes`) fails loudly instead of silently
+    // producing an empty extension.
+    const agentJson: unknown = JSON.parse(`{
+      "nodes": {
+        "Paper": {
+          "description": "Academic paper inferred from the corpus",
+          "properties": {
+            "title": { "type": "string", "minLength": 1, "searchable": {} },
+            "abstract": { "type": "string", "searchable": {}, "optional": true },
+            "doi": { "type": "string", "minLength": 1 },
+            "year": { "type": "number", "int": true, "min": 1900, "max": 2100 }
+          },
+          "unique": [{ "name": "paper_doi_unique", "fields": ["doi"] }]
         },
-        "unique": [{ "name": "paper_doi_unique", "fields": ["doi"] }]
+        "Author": {
+          "description": "Paper author",
+          "properties": {
+            "name": { "type": "string", "minLength": 1, "searchable": {} },
+            "affiliation": { "type": "string", "optional": true }
+          }
+        }
       },
-      "Author": {
-        "description": "Paper author",
-        "properties": {
-          "name": { "type": "string", "minLength": 1, "searchable": {} },
-          "affiliation": { "type": "string", "optional": true }
+      "edges": {
+        "authoredBy": {
+          "description": "Paper -> Author authorship",
+          "from": ["Paper"],
+          "to": ["Author"],
+          "properties": {
+            "order": { "type": "number", "int": true, "min": 1 }
+          }
         }
-      }
-    },
-    "edges": {
-      "authoredBy": {
-        "description": "Paper -> Author authorship",
-        "from": ["Paper"],
-        "to": ["Author"],
-        "properties": {
-          "order": { "type": "number", "int": true, "min": 1 }
+      },
+      "indexes": [
+        {
+          "entity": "node",
+          "kind": "Paper",
+          "name": "paper_by_year",
+          "fields": ["year"]
         }
-      }
-    },
-    "indexes": [
-      {
-        "entity": "node",
-        "kind": "Paper",
-        "name": "paper_by_year",
-        "fields": ["year"]
-      }
-    ]
-  }`);
+      ]
+    }`);
 
-  const result = validateGraphExtension(agentJson, { strict: true });
-  if (!result.success) {
-    // result.error is a GraphExtensionValidationError carrying every
-    // issue — path, message, and a stable code (UNKNOWN_DOCUMENT_KEY,
-    // INVALID_PROPERTY_REFINEMENT, etc.) suitable for routing to the
-    // agent for repair.
-    console.error(
-      "[2] Agent proposal rejected by validator:",
-      result.error.issues,
-    );
-    throw result.error;
-  }
-  const extension: GraphExtension = result.data;
-  console.log("\n[2] Agent proposal validated:");
-  console.log("    nodes:", Object.keys(extension.nodes ?? {}).join(", "));
-  console.log("    edges:", Object.keys(extension.edges ?? {}).join(", "));
+    const result = validateGraphExtension(agentJson, { strict: true });
+    if (!result.success) {
+      // result.error is a GraphExtensionValidationError carrying every
+      // issue — path, message, and a stable code (UNKNOWN_DOCUMENT_KEY,
+      // INVALID_PROPERTY_REFINEMENT, etc.) suitable for routing to the
+      // agent for repair.
+      console.error(
+        "[2] Agent proposal rejected by validator:",
+        result.error.issues,
+      );
+      throw result.error;
+    }
+    const extension: GraphExtension = result.data;
+    console.log("\n[2] Agent proposal validated:");
+    console.log("    nodes:", Object.keys(extension.nodes ?? {}).join(", "));
+    console.log("    edges:", Object.keys(extension.edges ?? {}).join(", "));
 
-  // ============================================================
-  // Step 3: Operator approves; commit + materialize atomically
-  // ============================================================
+    // ============================================================
+    // Step 3: Operator approves; commit + materialize atomically
+    // ============================================================
 
-  // `eager: {}` turns this into a one-call "schema committed AND
-  // indexes materialized" verb. The new Store is ready to ingest by
-  // the time `evolve` returns.
-  const evolved = await store.evolve(extension, { eager: {} });
-  console.log("\n[3] evolve() committed and materialized");
-  console.log("    Active schema version:", await activeVersion(backend));
-  console.log(
-    "    registry.hasNodeType('Paper'):",
-    evolved.registry.hasNodeType("Paper"),
-  );
-  console.log(
-    "    registry.hasEdgeType('authoredBy'):",
-    evolved.registry.hasEdgeType("authoredBy"),
-  );
-
-  // ============================================================
-  // Step 4: Ingest nodes + edges; fulltext-search over extension kind
-  // ============================================================
-
-  // Dynamic accessors return the same CRUD surface as `store.nodes.X`
-  // / `store.edges.X`, just typed as the dynamic variants because
-  // extension kinds aren't visible to the type system at compile time.
-  const papers = evolved.getNodeCollectionOrThrow("Paper");
-  const authors = evolved.getNodeCollectionOrThrow("Author");
-  const authoredBy = evolved.getEdgeCollectionOrThrow("authoredBy");
-
-  const attention = await papers.create({
-    title: "Attention is all you need",
-    abstract: "We propose a new simple network architecture, the Transformer.",
-    doi: "10.5555/3295222.3295349",
-    year: 2017,
-  });
-  const gpt2 = await papers.create({
-    title: "Language models are unsupervised multitask learners",
-    abstract: "Larger language models exhibit emergent zero-shot behaviour.",
-    doi: "10.5555/3454287.3454804",
-    year: 2019,
-  });
-  const vaswani = await authors.create({
-    name: "Ashish Vaswani",
-    affiliation: "Google Brain",
-  });
-  const radford = await authors.create({
-    name: "Alec Radford",
-    affiliation: "OpenAI",
-  });
-  await authoredBy.create(attention, vaswani, { order: 1 });
-  await authoredBy.create(gpt2, radford, { order: 1 });
-  console.log("\n[4] Ingested 2 Paper, 2 Author, 2 authoredBy edges");
-
-  // The `searchable: {}` brand on Paper.title flows through to the
-  // backend's fulltext index — extension kinds get the same first-class
-  // BM25 search as compile-time kinds.
-  const hits = await evolved.search.fulltext("Paper", {
-    query: "transformer architecture",
-    limit: 3,
-  });
-  console.log(
-    `    fulltext("Paper", "transformer architecture") -> ${hits.length} hit(s)`,
-  );
-  for (const hit of hits) {
-    // Extension kinds aren't visible to the type system, so the hit's
-    // `node` carries the generic `Node` shape — schema properties are
-    // present at the top level and accessed with a small cast.
-    const node = hit.node as unknown as { title: string };
-    console.log(`      score=${hit.score.toFixed(2)}  title="${node.title}"`);
-  }
-
-  // Unique-constraint enforcement is live for extension kinds too.
-  const duplicate = await papers
-    .create({
-      title: "Duplicate doi",
-      doi: "10.5555/3295222.3295349",
-      year: 2024,
-    })
-    .catch((error: unknown) => error);
-  console.log("    Duplicate doi rejected:", duplicate instanceof Error);
-
-  // ============================================================
-  // Step 5: Multi-hop traversal across runtime kinds
-  // ============================================================
-
-  // `fromDynamic` / `traverseDynamic` / `optionalTraverseDynamic` /
-  // `toDynamic` are string-keyed siblings of the typed builder methods.
-  // They validate the kind against the registry (typo →
-  // KindNotFoundError) and expose a `.field(name).number().gte(...)`
-  // discriminator on the predicate accessor. Dynamic aliases mix freely
-  // with typed ones — see the unit tests for a
-  // `from("Document", ...).traverseDynamic(...)` example.
-  const traversalRows = await evolved
-    .query()
-    .fromDynamic("Paper", "p")
-    .traverseDynamic("authoredBy", "a")
-    .toDynamic("Author", "u")
-    .whereNode("p", (p) => p.field("year").number().gte(2018))
-    .select((ctx) => ({
-      paperTitle: ctx.p.title,
-      authorName: ctx.u.name,
-      order: ctx.a.order,
-    }))
-    .execute();
-  console.log("\n[5] Dynamic multi-hop traversal Paper -> Author:");
-  for (const row of traversalRows) {
+    // `eager: {}` turns this into a one-call "schema committed AND
+    // indexes materialized" verb. The new Store is ready to ingest by
+    // the time `evolve` returns.
+    const evolved = await store.evolve(extension, { eager: {} });
+    console.log("\n[3] evolve() committed and materialized");
+    console.log("    Active schema version:", await activeVersion(backend));
     console.log(
-      `    ${String(row.paperTitle)} (#${String(row.order)}) by ${String(row.authorName)}`,
+      "    registry.hasNodeType('Paper'):",
+      evolved.registry.hasNodeType("Paper"),
     );
-  }
+    console.log(
+      "    registry.hasEdgeType('authoredBy'):",
+      evolved.registry.hasEdgeType("authoredBy"),
+    );
 
-  // ============================================================
-  // Step 6: A follow-up agent proposes an incompatible change
-  // ============================================================
+    // ============================================================
+    // Step 4: Ingest nodes + edges; fulltext-search over extension kind
+    // ============================================================
 
-  // The agent (or a less-careful caller) returns a re-proposal that
-  // narrows `Paper.year` from a number to a string. Against an empty
-  // kind this would be allowed; against the rows we just ingested it's
-  // a TYPE_CHANGE, which the classifier rejects unconditionally. The
-  // safety gate prevents data corruption — bad proposals don't
-  // commit.
-  const breakingProposal: GraphExtension = {
-    ...extension,
-    nodes: {
-      ...extension.nodes,
-      Paper: {
-        ...extension.nodes!.Paper!,
-        properties: {
-          ...extension.nodes!.Paper!.properties,
-          year: { type: "string" },
-        },
-      },
-    },
-  };
-  const rejection = await evolved
-    .evolve(breakingProposal)
-    .catch((error: unknown) => error);
-  if (rejection instanceof IncompatibleChangeError) {
-    console.log("\n[6] Incompatible re-proposal rejected:");
-    for (const change of rejection.changes) {
+    // Dynamic accessors return the same CRUD surface as `store.nodes.X`
+    // / `store.edges.X`, just typed as the dynamic variants because
+    // extension kinds aren't visible to the type system at compile time.
+    const papers = evolved.getNodeCollectionOrThrow("Paper");
+    const authors = evolved.getNodeCollectionOrThrow("Author");
+    const authoredBy = evolved.getEdgeCollectionOrThrow("authoredBy");
+
+    const attention = await papers.create({
+      title: "Attention is all you need",
+      abstract: "We propose a new simple network architecture, the Transformer.",
+      doi: "10.5555/3295222.3295349",
+      year: 2017,
+    });
+    const gpt2 = await papers.create({
+      title: "Language models are unsupervised multitask learners",
+      abstract: "Larger language models exhibit emergent zero-shot behaviour.",
+      doi: "10.5555/3454287.3454804",
+      year: 2019,
+    });
+    const vaswani = await authors.create({
+      name: "Ashish Vaswani",
+      affiliation: "Google Brain",
+    });
+    const radford = await authors.create({
+      name: "Alec Radford",
+      affiliation: "OpenAI",
+    });
+    await authoredBy.create(attention, vaswani, { order: 1 });
+    await authoredBy.create(gpt2, radford, { order: 1 });
+    console.log("\n[4] Ingested 2 Paper, 2 Author, 2 authoredBy edges");
+
+    // The `searchable: {}` brand on Paper.title flows through to the
+    // backend's fulltext index — extension kinds get the same first-class
+    // BM25 search as compile-time kinds.
+    const hits = await evolved.search.fulltext("Paper", {
+      query: "transformer architecture",
+      limit: 3,
+    });
+    console.log(
+      `    fulltext("Paper", "transformer architecture") -> ${hits.length} hit(s)`,
+    );
+    for (const hit of hits) {
+      // Extension kinds aren't visible to the type system, so the hit's
+      // `node` carries the generic `Node` shape — schema properties are
+      // present at the top level and accessed with a small cast.
+      const node = hit.node as unknown as { title: string };
+      console.log(`      score=${hit.score.toFixed(2)}  title="${node.title}"`);
+    }
+
+    // Unique-constraint enforcement is live for extension kinds too.
+    const duplicate = await papers
+      .create({
+        title: "Duplicate doi",
+        doi: "10.5555/3295222.3295349",
+        year: 2024,
+      })
+      .catch((error: unknown) => error);
+    console.log("    Duplicate doi rejected:", duplicate instanceof Error);
+
+    // ============================================================
+    // Step 5: Multi-hop traversal across runtime kinds
+    // ============================================================
+
+    // `fromDynamic` / `traverseDynamic` / `optionalTraverseDynamic` /
+    // `toDynamic` are string-keyed siblings of the typed builder methods.
+    // They validate the kind against the registry (typo →
+    // KindNotFoundError) and expose a `.field(name).number().gte(...)`
+    // discriminator on the predicate accessor. Dynamic aliases mix freely
+    // with typed ones — see the unit tests for a
+    // `from("Document", ...).traverseDynamic(...)` example.
+    const traversalRows = await evolved
+      .query()
+      .fromDynamic("Paper", "p")
+      .traverseDynamic("authoredBy", "a")
+      .toDynamic("Author", "u")
+      .whereNode("p", (p) => p.field("year").number().gte(2018))
+      .select((ctx) => ({
+        paperTitle: ctx.p.title,
+        authorName: ctx.u.name,
+        order: ctx.a.order,
+      }))
+      .execute();
+    console.log("\n[5] Dynamic multi-hop traversal Paper -> Author:");
+    for (const row of traversalRows) {
       console.log(
-        `    ${change.kind}.${change.field ?? "(kind)"}: ${change.type}` +
-          (change.detail ? ` (${change.detail})` : ""),
+        `    ${String(row.paperTitle)} (#${String(row.order)}) by ${String(row.authorName)}`,
       );
     }
-  } else {
-    throw new Error("expected IncompatibleChangeError, got " + String(rejection));
+
+    // ============================================================
+    // Step 6: A follow-up agent proposes an incompatible change
+    // ============================================================
+
+    // The agent (or a less-careful caller) returns a re-proposal that
+    // narrows `Paper.year` from a number to a string. Against an empty
+    // kind this would be allowed; against the rows we just ingested it's
+    // a TYPE_CHANGE, which the classifier rejects unconditionally. The
+    // safety gate prevents data corruption — bad proposals don't
+    // commit.
+    const breakingProposal: GraphExtension = {
+      ...extension,
+      nodes: {
+        ...extension.nodes,
+        Paper: {
+          ...extension.nodes!.Paper!,
+          properties: {
+            ...extension.nodes!.Paper!.properties,
+            year: { type: "string" },
+          },
+        },
+      },
+    };
+    const rejection = await evolved
+      .evolve(breakingProposal)
+      .catch((error: unknown) => error);
+    if (rejection instanceof IncompatibleChangeError) {
+      console.log("\n[6] Incompatible re-proposal rejected:");
+      for (const change of rejection.changes) {
+        console.log(
+          `    ${change.kind}.${change.field ?? "(kind)"}: ${change.type}` +
+            (change.detail ? ` (${change.detail})` : ""),
+        );
+      }
+    } else {
+      throw new Error("expected IncompatibleChangeError, got " + String(rejection));
+    }
+
+    // ============================================================
+    // Step 7: Soft-deprecate the legacy compile-time kind
+    // ============================================================
+
+    const deprecated = await evolved.deprecateKinds(["Document"]);
+    console.log(
+      "\n[7] Deprecated kinds:",
+      [...deprecated.introspect().deprecatedKinds],
+    );
+    // Deprecation is a signal, not a gate — reads/writes still work.
+    await deprecated.nodes.Document.create({
+      title: "Legacy doc",
+      body: "Still readable, just flagged",
+    });
+
+    // ============================================================
+    // Step 8: Remove an extension kind (cascade + eager cleanup)
+    // ============================================================
+
+    // After running the experiment, the operator decides Author should
+    // live in a different system. `removeKinds(["Author"], { eager: {} })`
+    // commits a new schema version that drops Author AND the authoredBy
+    // edge (the edge's only `to` endpoint is gone, so it cascades). With
+    // `eager: {}` the data-cleanup phase runs inline — Author rows AND
+    // authoredBy edges are deleted before the verb returns.
+    const trimmed = await deprecated.removeKinds(["Author"], { eager: {} });
+    console.log("\n[8] removeKinds(['Author']) — cascading edge cleanup");
+    console.log(
+      "    registry.hasNodeType('Author'):",
+      trimmed.registry.hasNodeType("Author"),
+    );
+    console.log(
+      "    registry.hasEdgeType('authoredBy'):",
+      trimmed.registry.hasEdgeType("authoredBy"),
+    );
+    console.log("    Active schema version:", await activeVersion(backend));
+
+    // ============================================================
+    // Step 9: Restart parity
+    // ============================================================
+
+    const [restored, validation] = await createStoreWithSchema(baseGraph, backend);
+    console.log("\n[9] Restart parity:");
+    console.log("    validation.status:", validation.status);
+    console.log(
+      "    registry.hasNodeType('Paper'):",
+      restored.registry.hasNodeType("Paper"),
+    );
+    console.log(
+      "    registry.hasNodeType('Author') (removed in step 8):",
+      restored.registry.hasNodeType("Author"),
+    );
+    console.log(
+      "    deprecatedKinds:",
+      [...restored.introspect().deprecatedKinds],
+    );
+
+    const restoredPapers = restored.getNodeCollectionOrThrow("Paper");
+    const allPapers = await restoredPapers.find({});
+    console.log(`    Found ${allPapers.length} Paper nodes after restart`);
+  } finally {
+    await backend.close();
   }
-
-  // ============================================================
-  // Step 7: Soft-deprecate the legacy compile-time kind
-  // ============================================================
-
-  const deprecated = await evolved.deprecateKinds(["Document"]);
-  console.log(
-    "\n[7] Deprecated kinds:",
-    [...deprecated.introspect().deprecatedKinds],
-  );
-  // Deprecation is a signal, not a gate — reads/writes still work.
-  await deprecated.nodes.Document.create({
-    title: "Legacy doc",
-    body: "Still readable, just flagged",
-  });
-
-  // ============================================================
-  // Step 8: Remove an extension kind (cascade + eager cleanup)
-  // ============================================================
-
-  // After running the experiment, the operator decides Author should
-  // live in a different system. `removeKinds(["Author"], { eager: {} })`
-  // commits a new schema version that drops Author AND the authoredBy
-  // edge (the edge's only `to` endpoint is gone, so it cascades). With
-  // `eager: {}` the data-cleanup phase runs inline — Author rows AND
-  // authoredBy edges are deleted before the verb returns.
-  const trimmed = await deprecated.removeKinds(["Author"], { eager: {} });
-  console.log("\n[8] removeKinds(['Author']) — cascading edge cleanup");
-  console.log(
-    "    registry.hasNodeType('Author'):",
-    trimmed.registry.hasNodeType("Author"),
-  );
-  console.log(
-    "    registry.hasEdgeType('authoredBy'):",
-    trimmed.registry.hasEdgeType("authoredBy"),
-  );
-  console.log("    Active schema version:", await activeVersion(backend));
-
-  // ============================================================
-  // Step 9: Restart parity
-  // ============================================================
-
-  const [restored, validation] = await createStoreWithSchema(baseGraph, backend);
-  console.log("\n[9] Restart parity:");
-  console.log("    validation.status:", validation.status);
-  console.log(
-    "    registry.hasNodeType('Paper'):",
-    restored.registry.hasNodeType("Paper"),
-  );
-  console.log(
-    "    registry.hasNodeType('Author') (removed in step 8):",
-    restored.registry.hasNodeType("Author"),
-  );
-  console.log(
-    "    deprecatedKinds:",
-    [...restored.introspect().deprecatedKinds],
-  );
-
-  const restoredPapers = restored.getNodeCollectionOrThrow("Paper");
-  const allPapers = await restoredPapers.find({});
-  console.log(`    Found ${allPapers.length} Paper nodes after restart`);
-
-  await backend.close();
 }
 
 async function activeVersion(
@@ -374,14 +377,18 @@ async function activeVersion(
   return row?.version ?? "uninitialized";
 }
 
-main().catch((error: unknown) => {
-  if (error instanceof GraphExtensionValidationError) {
-    console.error("Validation failed:");
-    for (const issue of error.issues) {
-      console.error(`  ${issue.path || "(root)"} [${issue.code}]: ${issue.message}`);
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    if (error instanceof GraphExtensionValidationError) {
+      console.error("Validation failed:");
+      for (const issue of error.issues) {
+        console.error(
+          `  ${issue.path || "(root)"} [${issue.code}]: ${issue.message}`,
+        );
+      }
+    } else {
+      console.error(error);
     }
-  } else {
-    console.error(error);
-  }
-  process.exitCode = 1;
-});
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/17-bulk-find-by-index.ts
+++ b/packages/typegraph/examples/17-bulk-find-by-index.ts
@@ -19,10 +19,10 @@
  * - null-safe equality (a missing key field matches a stored NULL)
  * - `limitPerInput` to cap each candidate bucket
  */
-import { z } from "zod";
-
 import { createStore, defineGraph, defineNode } from "@nicia-ai/typegraph";
 import { defineNodeIndex } from "@nicia-ai/typegraph/indexes";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -67,103 +67,105 @@ export async function main() {
   const backend = createExampleBackend();
   const store = createStore(graph, backend);
 
-  console.log("=== Batched Index Lookup (bulkFindByIndex) ===\n");
+  try {
+    console.log("=== Batched Index Lookup (bulkFindByIndex) ===\n");
 
-  // Existing graph state: contacts already imported from various systems.
-  // Note the deliberate duplicates and the email-less rows.
-  console.log("Seeding the existing contact graph...\n");
-  const seed = [
-    { orgId: "acme", fullName: "Jane Doe", email: "jane@acme.com", sourceSystem: "salesforce" },
-    { orgId: "acme", fullName: "Jane Doe", email: "jane.doe@acme.com", sourceSystem: "hubspot" },
-    { orgId: "acme", fullName: "John Smith", email: "john@acme.com", sourceSystem: "salesforce" },
-    { orgId: "acme", fullName: "Mystery Contact", sourceSystem: "manual" }, // no email → NULL
-    { orgId: "acme", fullName: "Walk-in Lead", sourceSystem: "manual" }, // no email → NULL
-    { orgId: "globex", fullName: "Jane Doe", email: "jane@globex.com", sourceSystem: "salesforce" },
-  ];
-  for (const record of seed) {
-    await store.nodes.Contact.create(record);
-  }
-  console.log(`  Seeded ${seed.length} contacts across 2 orgs\n`);
-
-  // ============================================================
-  // Reconcile an incoming import batch by (orgId, fullName)
-  // ============================================================
-
-  console.log("=== Reconcile incoming batch by (orgId, fullName) ===\n");
-
-  const incoming = [
-    { orgId: "acme", fullName: "Jane Doe" }, // 2 candidates → needs merge review
-    { orgId: "acme", fullName: "John Smith" }, // 1 candidate → likely the same person
-    { orgId: "acme", fullName: "Grace Hopper" }, // 0 candidates → create new
-    { orgId: "globex", fullName: "Jane Doe" }, // 1 candidate → org-scoped, not acme's Janes
-  ];
-
-  // bulkFindByIndex takes records shaped as { props }, one per input. Each
-  // input's candidates come back in the same position, ordered by node id.
-  const candidates = await store.nodes.Contact.bulkFindByIndex(
-    "contact_by_org_name",
-    incoming.map((record) => ({ props: record })),
-  );
-
-  for (const [index, record] of incoming.entries()) {
-    const bucket = candidates[index] ?? [];
-    const decision = bucket.length === 0 ? "CREATE NEW" : `REVIEW (${bucket.length} candidate(s))`;
-    console.log(`  ${record.orgId}/${record.fullName} → ${decision}`);
-    for (const candidate of bucket) {
-      console.log(`      ↳ ${candidate.id} via ${candidate.sourceSystem}`);
+    // Existing graph state: contacts already imported from various systems.
+    // Note the deliberate duplicates and the email-less rows.
+    console.log("Seeding the existing contact graph...\n");
+    const seed = [
+      { orgId: "acme", fullName: "Jane Doe", email: "jane@acme.com", sourceSystem: "salesforce" },
+      { orgId: "acme", fullName: "Jane Doe", email: "jane.doe@acme.com", sourceSystem: "hubspot" },
+      { orgId: "acme", fullName: "John Smith", email: "john@acme.com", sourceSystem: "salesforce" },
+      { orgId: "acme", fullName: "Mystery Contact", sourceSystem: "manual" }, // no email → NULL
+      { orgId: "acme", fullName: "Walk-in Lead", sourceSystem: "manual" }, // no email → NULL
+      { orgId: "globex", fullName: "Jane Doe", email: "jane@globex.com", sourceSystem: "salesforce" },
+    ];
+    for (const record of seed) {
+      await store.nodes.Contact.create(record);
     }
+    console.log(`  Seeded ${seed.length} contacts across 2 orgs\n`);
+
+    // ============================================================
+    // Reconcile an incoming import batch by (orgId, fullName)
+    // ============================================================
+
+    console.log("=== Reconcile incoming batch by (orgId, fullName) ===\n");
+
+    const incoming = [
+      { orgId: "acme", fullName: "Jane Doe" }, // 2 candidates → needs merge review
+      { orgId: "acme", fullName: "John Smith" }, // 1 candidate → likely the same person
+      { orgId: "acme", fullName: "Grace Hopper" }, // 0 candidates → create new
+      { orgId: "globex", fullName: "Jane Doe" }, // 1 candidate → org-scoped, not acme's Janes
+    ];
+
+    // bulkFindByIndex takes records shaped as { props }, one per input. Each
+    // input's candidates come back in the same position, ordered by node id.
+    const candidates = await store.nodes.Contact.bulkFindByIndex(
+      "contact_by_org_name",
+      incoming.map((record) => ({ props: record })),
+    );
+
+    for (const [index, record] of incoming.entries()) {
+      const bucket = candidates[index] ?? [];
+      const decision = bucket.length === 0 ? "CREATE NEW" : `REVIEW (${bucket.length} candidate(s))`;
+      console.log(`  ${record.orgId}/${record.fullName} → ${decision}`);
+      for (const candidate of bucket) {
+        console.log(`      ↳ ${candidate.id} via ${candidate.sourceSystem}`);
+      }
+    }
+
+    // ============================================================
+    // Null-safe matching by (orgId, email)
+    // ============================================================
+
+    console.log("\n=== Null-safe matching by (orgId, email) ===\n");
+
+    // A probe that omits `email` matches stored rows whose email is NULL —
+    // not every acme row. A probe with a concrete email matches that value.
+    const emailProbes = [
+      { orgId: "acme" }, // email omitted → matches the two NULL-email rows
+      { orgId: "acme", email: "jane@acme.com" }, // matches the one salesforce Jane
+    ];
+    const emailMatches = await store.nodes.Contact.bulkFindByIndex(
+      "contact_by_org_email",
+      emailProbes.map((record) => ({ props: record })),
+    );
+
+    console.log("  acme / (no email) →");
+    for (const match of emailMatches[0] ?? []) {
+      console.log(`      ↳ ${match.fullName} (email: ${match.email ?? "none"})`);
+    }
+    console.log("  acme / jane@acme.com →");
+    for (const match of emailMatches[1] ?? []) {
+      console.log(`      ↳ ${match.fullName} (${match.sourceSystem})`);
+    }
+
+    // ============================================================
+    // Capping candidates with limitPerInput
+    // ============================================================
+
+    console.log("\n=== Capping candidates with limitPerInput ===\n");
+
+    // Low-selectivity keys can return many candidates. `limitPerInput` caps each
+    // bucket (lowest node ids kept). On backends with SQL window functions the
+    // cap runs in-database via ROW_NUMBER(); otherwise it is applied in memory
+    // with the same result.
+    const [capped] = await store.nodes.Contact.bulkFindByIndex(
+      "contact_by_org_name",
+      [{ props: { orgId: "acme", fullName: "Jane Doe" } }],
+      { limitPerInput: 1 },
+    );
+    console.log(`  acme/Jane Doe with limitPerInput: 1 → ${capped?.length ?? 0} candidate (of 2)`);
+
+    console.log("\n=== Batched index lookup example complete ===");
+  } finally {
+    await backend.close();
   }
-
-  // ============================================================
-  // Null-safe matching by (orgId, email)
-  // ============================================================
-
-  console.log("\n=== Null-safe matching by (orgId, email) ===\n");
-
-  // A probe that omits `email` matches stored rows whose email is NULL —
-  // not every acme row. A probe with a concrete email matches that value.
-  const emailProbes = [
-    { orgId: "acme" }, // email omitted → matches the two NULL-email rows
-    { orgId: "acme", email: "jane@acme.com" }, // matches the one salesforce Jane
-  ];
-  const emailMatches = await store.nodes.Contact.bulkFindByIndex(
-    "contact_by_org_email",
-    emailProbes.map((record) => ({ props: record })),
-  );
-
-  console.log("  acme / (no email) →");
-  for (const match of emailMatches[0] ?? []) {
-    console.log(`      ↳ ${match.fullName} (email: ${match.email ?? "none"})`);
-  }
-  console.log("  acme / jane@acme.com →");
-  for (const match of emailMatches[1] ?? []) {
-    console.log(`      ↳ ${match.fullName} (${match.sourceSystem})`);
-  }
-
-  // ============================================================
-  // Capping candidates with limitPerInput
-  // ============================================================
-
-  console.log("\n=== Capping candidates with limitPerInput ===\n");
-
-  // Low-selectivity keys can return many candidates. `limitPerInput` caps each
-  // bucket (lowest node ids kept). On backends with SQL window functions the
-  // cap runs in-database via ROW_NUMBER(); otherwise it is applied in memory
-  // with the same result.
-  const [capped] = await store.nodes.Contact.bulkFindByIndex(
-    "contact_by_org_name",
-    [{ props: { orgId: "acme", fullName: "Jane Doe" } }],
-    { limitPerInput: 1 },
-  );
-  console.log(`  acme/Jane Doe with limitPerInput: 1 → ${capped?.length ?? 0} candidate (of 2)`);
-
-  console.log("\n=== Batched index lookup example complete ===");
-
-  await backend.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/18-fhir-graph-merge.ts
+++ b/packages/typegraph/examples/18-fhir-graph-merge.ts
@@ -28,6 +28,7 @@ import {
   merge,
   unwrap,
   type GraphBranch,
+  type MakeBackend,
   type MergeOptions,
   type MergeReport,
   type SimilarityStrategy,
@@ -103,9 +104,24 @@ const careGraph = defineGraph({
     MedicationRequest: { type: MedicationRequest },
   },
   edges: {
-    forPatient,
-    duringEncounter,
-    reasonFor,
+    // FHIR-ish endpoint constraints. The bare `{ forPatient }` shorthand would
+    // accept ANY node kind on either end; the explicit from/to pins each
+    // care-context edge to its real shape.
+    forPatient: {
+      type: forPatient,
+      from: [Encounter, Observation, MedicationRequest],
+      to: [Patient],
+    },
+    duringEncounter: {
+      type: duringEncounter,
+      from: [Observation, MedicationRequest],
+      to: [Encounter],
+    },
+    reasonFor: {
+      type: reasonFor,
+      from: [MedicationRequest],
+      to: [Observation],
+    },
   },
 });
 
@@ -115,27 +131,20 @@ type CareStore = Store<CareGraph>;
 const EHR_BRANCH = asBranchId("ehr-agent");
 const CLAIMS_BRANCH = asBranchId("claims-agent");
 
-async function makeExampleBackend(): Promise<GraphBackend> {
-  return createExampleBackend();
-}
-
 const patientSimilarity: SimilarityStrategy<CareGraph> = {
   kind: "fulltext",
   fields: ["name"],
 };
 
-function blockPatient(node: Node): string | undefined {
-  const patient = node as unknown as { birthDate?: string };
-  // Block by shared birth date. The unique MRN constraint forces exact-identity
-  // matches in its own bucket independently of blocking, so blocking does not
-  // need the MRN — and using it would split the different-MRN fuzzy pair apart.
-  return patient.birthDate;
-}
-
 const mergeOptions: MergeOptions<CareGraph> = {
   resolve: {
     Patient: {
-      block: blockPatient,
+      // Block by shared birth date. `block` is typed to THIS kind's node shape,
+      // so `node.birthDate` needs no cast. The unique MRN constraint forces
+      // exact-identity matches in its own bucket independently of blocking, so
+      // blocking does not need the MRN — and using it would split the
+      // different-MRN fuzzy pair apart.
+      block: (node) => node.birthDate,
       similarity: patientSimilarity,
       // This demo exercises BOTH resolution paths:
       //   - Anna/Ana share MRN-001, so the unique constraint forces that merge
@@ -158,42 +167,55 @@ const mergeOptions: MergeOptions<CareGraph> = {
 
 async function createBranch(
   base: CareStore,
+  makeBackend: MakeBackend,
   id: typeof EHR_BRANCH | typeof CLAIMS_BRANCH,
 ): Promise<GraphBranch<CareGraph>> {
-  return unwrap(await branch(base, makeExampleBackend, { id }));
+  return unwrap(await branch(base, makeBackend, { id }));
 }
 
 async function seedEhrBranch(branchStore: CareStore): Promise<void> {
-  const patient = await branchStore.nodes.Patient.create({
-    fhirId: "Patient/ehr-anna",
-    name: "Anna Rivera",
-    birthDate: "1974-03-09",
-    mrn: "MRN-001",
-  }, {
-    id: "patient-anna",
-  });
-  const encounter = await branchStore.nodes.Encounter.create({
-    fhirId: "Encounter/ehr-follow-up",
-    reason: "Hypertension follow-up",
-    startedAt: "2026-04-11T09:30:00-07:00",
-  }, {
-    id: "encounter-follow-up",
-  });
-  const bloodPressure = await branchStore.nodes.Observation.create({
-    fhirId: "Observation/ehr-bp",
-    display: "Blood pressure panel",
-    value: "152/96 mmHg",
-    interpretation: "high",
-  }, {
-    id: "observation-blood-pressure",
-  });
-  const medication = await branchStore.nodes.MedicationRequest.create({
-    fhirId: "MedicationRequest/ehr-lisinopril",
-    medication: "Lisinopril 10 MG Oral Tablet",
-    dosage: "Take one tablet by mouth daily",
-  }, {
-    id: "medication-lisinopril",
-  });
+  const patient = await branchStore.nodes.Patient.create(
+    {
+      fhirId: "Patient/ehr-anna",
+      name: "Anna Rivera",
+      birthDate: "1974-03-09",
+      mrn: "MRN-001",
+    },
+    {
+      id: "patient-anna",
+    },
+  );
+  const encounter = await branchStore.nodes.Encounter.create(
+    {
+      fhirId: "Encounter/ehr-follow-up",
+      reason: "Hypertension follow-up",
+      startedAt: "2026-04-11T09:30:00-07:00",
+    },
+    {
+      id: "encounter-follow-up",
+    },
+  );
+  const bloodPressure = await branchStore.nodes.Observation.create(
+    {
+      fhirId: "Observation/ehr-bp",
+      display: "Blood pressure panel",
+      value: "152/96 mmHg",
+      interpretation: "high",
+    },
+    {
+      id: "observation-blood-pressure",
+    },
+  );
+  const medication = await branchStore.nodes.MedicationRequest.create(
+    {
+      fhirId: "MedicationRequest/ehr-lisinopril",
+      medication: "Lisinopril 10 MG Oral Tablet",
+      dosage: "Take one tablet by mouth daily",
+    },
+    {
+      id: "medication-lisinopril",
+    },
+  );
 
   await branchStore.edges.forPatient.create(encounter, patient, {
     sourcePath: "Encounter.subject",
@@ -237,29 +259,38 @@ async function seedEhrBranch(branchStore: CareStore): Promise<void> {
 }
 
 async function seedClaimsBranch(branchStore: CareStore): Promise<void> {
-  const patient = await branchStore.nodes.Patient.create({
-    fhirId: "Patient/claims-ana",
-    name: "Ana Rivera",
-    birthDate: "1974-03-09",
-    mrn: "MRN-001",
-  }, {
-    id: "patient-ana",
-  });
-  const encounter = await branchStore.nodes.Encounter.create({
-    fhirId: "Encounter/claims-kidney-review",
-    reason: "Kidney function review",
-    startedAt: "2026-04-14T10:00:00-07:00",
-  }, {
-    id: "encounter-kidney-review",
-  });
-  const kidneyLab = await branchStore.nodes.Observation.create({
-    fhirId: "Observation/claims-egfr",
-    display: "Estimated glomerular filtration rate",
-    value: "54 mL/min/1.73m2",
-    interpretation: "low",
-  }, {
-    id: "observation-egfr",
-  });
+  const patient = await branchStore.nodes.Patient.create(
+    {
+      fhirId: "Patient/claims-ana",
+      name: "Ana Rivera",
+      birthDate: "1974-03-09",
+      mrn: "MRN-001",
+    },
+    {
+      id: "patient-ana",
+    },
+  );
+  const encounter = await branchStore.nodes.Encounter.create(
+    {
+      fhirId: "Encounter/claims-kidney-review",
+      reason: "Kidney function review",
+      startedAt: "2026-04-14T10:00:00-07:00",
+    },
+    {
+      id: "encounter-kidney-review",
+    },
+  );
+  const kidneyLab = await branchStore.nodes.Observation.create(
+    {
+      fhirId: "Observation/claims-egfr",
+      display: "Estimated glomerular filtration rate",
+      value: "54 mL/min/1.73m2",
+      interpretation: "low",
+    },
+    {
+      id: "observation-egfr",
+    },
+  );
 
   await branchStore.edges.forPatient.create(encounter, patient, {
     sourcePath: "Encounter.subject",
@@ -300,12 +331,22 @@ async function seedClaimsBranch(branchStore: CareStore): Promise<void> {
 // Reporting helpers
 // ============================================================
 
+function compareStrings(left: string, right: string): number {
+  return (
+    left < right ? -1
+    : left > right ? 1
+    : 0
+  );
+}
+
 function summarizePatient(node: Node<typeof Patient>): string {
   return `${node.name} (${node.mrn}, ${node.birthDate})`;
 }
 
 /** An `id -> human-readable label` map for every clinical resource in the store. */
-async function resourceDisplays(store: CareStore): Promise<Map<string, string>> {
+async function resourceDisplays(
+  store: CareStore,
+): Promise<Map<string, string>> {
   const displays = new Map<string, string>();
   for (const encounter of await store.nodes.Encounter.find()) {
     displays.set(
@@ -342,12 +383,35 @@ async function careContextFor(
 ): Promise<readonly string[]> {
   const edges = await store.edges.forPatient.findTo(patient);
   return edges
-    .map((edge) => displays.get(edge.fromId) ?? `${edge.fromKind} ${edge.fromId}`)
-    .sort((left, right) =>
-      left < right ? -1
-      : left > right ? 1
-      : 0,
+    .map(
+      (edge) => displays.get(edge.fromId) ?? `${edge.fromKind} ${edge.fromId}`,
+    )
+    .sort((left, right) => compareStrings(left, right));
+}
+
+/**
+ * Prints each entity resolution: which branch records collapsed onto which
+ * canonical patient, and which branches contributed the members.
+ */
+async function printResolutions(
+  store: CareStore,
+  report: MergeReport<CareGraph>,
+): Promise<void> {
+  const patientNamesById = new Map<string, string>();
+  for (const patient of await store.nodes.Patient.find()) {
+    patientNamesById.set(patient.id, patient.name);
+  }
+  console.log(`  entity resolutions (${report.resolutions.length}):`);
+  const resolutions = [...report.resolutions].sort((left, right) =>
+    compareStrings(left.canonicalId, right.canonicalId),
+  );
+  for (const resolution of resolutions) {
+    const display =
+      patientNamesById.get(resolution.canonicalId) ?? resolution.canonicalId;
+    console.log(
+      `    - ${resolution.kind} "${display}": [${resolution.memberIds.join(", ")}] -> canonical "${resolution.canonicalId}" (branches: ${resolution.branchOrigins.join(", ")})`,
     );
+  }
 }
 
 function printConflicts(report: MergeReport<CareGraph>): void {
@@ -365,6 +429,10 @@ function printConflicts(report: MergeReport<CareGraph>): void {
       `    - ${conflict.kind}.${conflict.property} on ${conflict.entityId}: ${values}`,
     );
   }
+  console.log(
+    "  note: fhirId is a source-scoped record id, so cross-system fhirId\n" +
+      "  conflicts are EXPECTED — the real signal is the name/mrn disagreements.",
+  );
 }
 
 function printProvenance(report: MergeReport<CareGraph>): void {
@@ -381,58 +449,73 @@ function printProvenance(report: MergeReport<CareGraph>): void {
 // Demo
 // ============================================================
 
-async function main() {
-  const backend = await makeExampleBackend();
-  const [base] = await createStoreWithSchema(careGraph, backend);
-
-  const ehr = await createBranch(base, EHR_BRANCH);
-  const claims = await createBranch(base, CLAIMS_BRANCH);
-
-  await seedEhrBranch(ehr.store);
-  await seedClaimsBranch(claims.store);
-
-  console.log("=== FHIR Graph Merge ===\n");
-  console.log("Before merge:");
-  console.log("  base patients:", (await base.nodes.Patient.find()).length);
-  console.log("  EHR branch patients:", (await ehr.store.nodes.Patient.find()).length);
-  console.log(
-    "  claims branch patients:",
-    (await claims.store.nodes.Patient.find()).length,
-  );
-
-  const result = await merge(base, [ehr, claims], mergeOptions);
-  if (!isOk(result)) {
-    throw result.error;
+async function main(): Promise<void> {
+  // Every backend this example opens — directly or through `branch()`'s factory —
+  // is tracked here and closed in the finally below.
+  const openedBackends: GraphBackend[] = [];
+  async function makeBackend(): Promise<GraphBackend> {
+    const backend = createExampleBackend();
+    openedBackends.push(backend);
+    return backend;
   }
-  const report = result.data;
 
-  console.log("\nAfter merge:");
-  console.log(`  merged nodes: ${report.merged.nodes}`);
-  console.log(`  merged edges: ${report.merged.edges}`);
-  console.log(`  entity resolutions: ${report.resolutions.length}`);
-  printConflicts(report);
-  printProvenance(report);
+  try {
+    const [base] = await createStoreWithSchema(careGraph, await makeBackend());
 
-  // Two patients collapsed by two different mechanisms — Anna/Ana by the shared
-  // MRN (exact identity), Mohammed/Mohamed by fulltext name similarity. The care
-  // context below is read by following `forPatient` edges INTO each survivor, so
-  // it proves both branches' edges were repointed onto the canonical patient.
-  const patients = (await base.nodes.Patient.find()).sort((left, right) =>
-    left.name < right.name ? -1
-    : left.name > right.name ? 1
-    : 0,
-  );
-  const displays = await resourceDisplays(base);
-  console.log("\nCanonical patients and their repointed care context:");
-  for (const patient of patients) {
-    console.log(`  ${summarizePatient(patient)}`);
-    for (const line of await careContextFor(base, patient, displays)) {
-      console.log(`    - ${line}`);
+    const ehr = await createBranch(base, makeBackend, EHR_BRANCH);
+    const claims = await createBranch(base, makeBackend, CLAIMS_BRANCH);
+
+    await seedEhrBranch(ehr.store);
+    await seedClaimsBranch(claims.store);
+
+    console.log("=== FHIR Graph Merge ===\n");
+    console.log("Before merge:");
+    console.log("  base patients:", (await base.nodes.Patient.find()).length);
+    console.log(
+      "  EHR branch patients:",
+      (await ehr.store.nodes.Patient.find()).length,
+    );
+    console.log(
+      "  claims branch patients:",
+      (await claims.store.nodes.Patient.find()).length,
+    );
+
+    const result = await merge(base, [ehr, claims], mergeOptions);
+    if (!isOk(result)) {
+      throw result.error;
     }
+    const report = result.data;
+
+    console.log("\nAfter merge:");
+    console.log(`  merged nodes: ${report.merged.nodes}`);
+    console.log(`  merged edges: ${report.merged.edges}`);
+    await printResolutions(base, report);
+    printConflicts(report);
+    printProvenance(report);
+
+    // Two patients collapsed by two different mechanisms — Anna/Ana by the shared
+    // MRN (exact identity), Mohammed/Mohamed by fulltext name similarity. The care
+    // context below is read by following `forPatient` edges INTO each survivor, so
+    // it proves both branches' edges were repointed onto the canonical patient.
+    const patients = (await base.nodes.Patient.find()).sort((left, right) =>
+      compareStrings(left.name, right.name),
+    );
+    const displays = await resourceDisplays(base);
+    console.log("\nCanonical patients and their repointed care context:");
+    for (const patient of patients) {
+      console.log(`  ${summarizePatient(patient)}`);
+      for (const line of await careContextFor(base, patient, displays)) {
+        console.log(`    - ${line}`);
+      }
+    }
+  } finally {
+    await Promise.all(openedBackends.map((backend) => backend.close()));
   }
 }
 
-main().catch((error: unknown) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/18-fhir-graph-merge.ts
+++ b/packages/typegraph/examples/18-fhir-graph-merge.ts
@@ -9,30 +9,30 @@
  * Run with:
  *   npx tsx examples/18-fhir-graph-merge.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineEdge,
   defineGraph,
   defineNode,
-  searchable,
   type GraphBackend,
   type Node,
+  searchable,
   type Store,
 } from "@nicia-ai/typegraph";
 import {
   asBranchId,
   branch,
-  isOk,
-  merge,
-  unwrap,
   type GraphBranch,
+  isOk,
   type MakeBackend,
+  merge,
   type MergeOptions,
   type MergeReport,
   type SimilarityStrategy,
+  unwrap,
 } from "@nicia-ai/typegraph/graph-merge";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -168,7 +168,7 @@ const mergeOptions: MergeOptions<CareGraph> = {
 async function createBranch(
   base: CareStore,
   makeBackend: MakeBackend,
-  id: typeof EHR_BRANCH | typeof CLAIMS_BRANCH,
+  id: typeof EHR_BRANCH  ,
 ): Promise<GraphBranch<CareGraph>> {
   return unwrap(await branch(base, makeBackend, { id }));
 }
@@ -386,7 +386,7 @@ async function careContextFor(
     .map(
       (edge) => displays.get(edge.fromId) ?? `${edge.fromKind} ${edge.fromId}`,
     )
-    .sort((left, right) => compareStrings(left, right));
+    .toSorted((left, right) => compareStrings(left, right));
 }
 
 /**
@@ -402,7 +402,7 @@ async function printResolutions(
     patientNamesById.set(patient.id, patient.name);
   }
   console.log(`  entity resolutions (${report.resolutions.length}):`);
-  const resolutions = [...report.resolutions].sort((left, right) =>
+  const resolutions = [...report.resolutions].toSorted((left, right) =>
     compareStrings(left.canonicalId, right.canonicalId),
   );
   for (const resolution of resolutions) {
@@ -453,10 +453,10 @@ async function main(): Promise<void> {
   // Every backend this example opens — directly or through `branch()`'s factory —
   // is tracked here and closed in the finally below.
   const openedBackends: GraphBackend[] = [];
-  async function makeBackend(): Promise<GraphBackend> {
+  function makeBackend(): Promise<GraphBackend> {
     const backend = createExampleBackend();
     openedBackends.push(backend);
-    return backend;
+    return Promise.resolve(backend);
   }
 
   try {
@@ -470,15 +470,12 @@ async function main(): Promise<void> {
 
     console.log("=== FHIR Graph Merge ===\n");
     console.log("Before merge:");
-    console.log("  base patients:", (await base.nodes.Patient.find()).length);
-    console.log(
-      "  EHR branch patients:",
-      (await ehr.store.nodes.Patient.find()).length,
-    );
-    console.log(
-      "  claims branch patients:",
-      (await claims.store.nodes.Patient.find()).length,
-    );
+    const basePatients = await base.nodes.Patient.find();
+    const ehrPatients = await ehr.store.nodes.Patient.find();
+    const claimsPatients = await claims.store.nodes.Patient.find();
+    console.log("  base patients:", basePatients.length);
+    console.log("  EHR branch patients:", ehrPatients.length);
+    console.log("  claims branch patients:", claimsPatients.length);
 
     const result = await merge(base, [ehr, claims], mergeOptions);
     if (!isOk(result)) {
@@ -497,7 +494,8 @@ async function main(): Promise<void> {
     // MRN (exact identity), Mohammed/Mohamed by fulltext name similarity. The care
     // context below is read by following `forPatient` edges INTO each survivor, so
     // it proves both branches' edges were repointed onto the canonical patient.
-    const patients = (await base.nodes.Patient.find()).sort((left, right) =>
+    const mergedPatients = await base.nodes.Patient.find();
+    const patients = mergedPatients.toSorted((left, right) =>
       compareStrings(left.name, right.name),
     );
     const displays = await resourceDisplays(base);
@@ -514,7 +512,7 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/19-incremental-merge.ts
+++ b/packages/typegraph/examples/19-incremental-merge.ts
@@ -12,14 +12,12 @@
  * Run with:
  *   npx tsx examples/19-incremental-merge.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineGraph,
   defineNode,
-  searchable,
   type GraphBackend,
+  searchable,
   type Store,
 } from "@nicia-ai/typegraph";
 import {
@@ -27,11 +25,12 @@ import {
   branch,
   isOk,
   mergeIncremental,
+  type MergeIncrementalArgs,
   openProvenanceStore,
   readProvenance,
   unwrap,
-  type MergeIncrementalArgs,
 } from "@nicia-ai/typegraph/graph-merge";
+import { z } from "zod";
 
 import { createExampleBackend } from "./_helpers";
 
@@ -83,17 +82,17 @@ async function listCompanies(store: KbStore): Promise<readonly string[]> {
   const companies = await store.nodes.Company.find();
   return companies
     .map((company) => `${company.name} (${company.domain})`)
-    .sort((left, right) => compareStrings(left, right));
+    .toSorted((left, right) => compareStrings(left, right));
 }
 
 async function main(): Promise<void> {
   // Every backend this example opens — directly or through `branch()`'s factory —
   // is tracked here and closed in the finally below.
   const openedBackends: GraphBackend[] = [];
-  async function makeBackend(): Promise<GraphBackend> {
+  function makeBackend(): Promise<GraphBackend> {
     const backend = createExampleBackend();
     openedBackends.push(backend);
-    return backend;
+    return Promise.resolve(backend);
   }
 
   try {
@@ -174,7 +173,7 @@ async function main(): Promise<void> {
     }
     const report = result.data;
 
-    console.log("Target after: ", await listCompanies(target));
+    console.log("Target after:", await listCompanies(target));
     console.log(
       `\nNo duplicate was created: the provider's "ACME Corporation" merged onto`,
     );
@@ -246,7 +245,7 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/19-incremental-merge.ts
+++ b/packages/typegraph/examples/19-incremental-merge.ts
@@ -5,9 +5,9 @@
  * `mergeIncremental()` folds a new source's branch into a `target` that already
  * holds committed entities: it re-discovers an already-committed company (by its
  * unique `domain`) and merges the new spelling ONTO it instead of creating a
- * duplicate, commits the genuinely-new company, handles inherited edits against
- * the fork-point, flags the name disagreement, and persists a queryable
- * provenance trail.
+ * duplicate, commits the genuinely-new company, carries the branch's inherited
+ * edit against the fork-point into the merge (flagging it where the live target
+ * has advanced past the fork), and persists a queryable provenance trail.
  *
  * Run with:
  *   npx tsx examples/19-incremental-merge.ts
@@ -69,120 +69,185 @@ const kbGraph = defineGraph({
 type KbGraph = typeof kbGraph;
 type KbStore = Store<KbGraph>;
 
-async function makeBackend(): Promise<GraphBackend> {
-  return createExampleBackend();
-}
-
 const PROVIDER = asBranchId("provider-crunchbase");
+
+function compareStrings(left: string, right: string): number {
+  return (
+    left < right ? -1
+    : left > right ? 1
+    : 0
+  );
+}
 
 async function listCompanies(store: KbStore): Promise<readonly string[]> {
   const companies = await store.nodes.Company.find();
   return companies
     .map((company) => `${company.name} (${company.domain})`)
-    .sort((left, right) =>
-      left < right ? -1
-      : left > right ? 1
-      : 0,
-    );
+    .sort((left, right) => compareStrings(left, right));
 }
 
 async function main(): Promise<void> {
-  // The LIVE target graph, already holding one canonical company from an earlier
-  // ingestion wave. This is the "base that has advanced" mergeIncremental targets.
-  const [target] = await createStoreWithSchema(kbGraph, await makeBackend());
-  await target.nodes.Company.create(
-    { name: "Acme Corp", domain: "acme.com" },
-    { id: "acme" },
-  );
-
-  // The frozen fork-point a new provider's branch forks from. This example keeps
-  // it empty so the provider's company rows are additions, but mergeIncremental()
-  // also propagates inherited modifications and deletions relative to this store.
-  const [forkPoint] = await createStoreWithSchema(kbGraph, await makeBackend());
-  const provider = unwrap(await branch(forkPoint, makeBackend, { id: PROVIDER }));
-
-  // The provider re-reports Acme (same domain, different spelling) and adds a
-  // genuinely new company.
-  await provider.store.nodes.Company.create(
-    { name: "ACME Corporation", domain: "acme.com" },
-    { id: "cb-acme" },
-  );
-  await provider.store.nodes.Company.create(
-    { name: "Globex", domain: "globex.io" },
-    { id: "cb-globex" },
-  );
-
-  console.log("=== Incremental Graph Merge ===\n");
-  console.log("Target before:", await listCompanies(target));
-
-  const args: MergeIncrementalArgs<KbGraph> = {
-    forkPoint,
-    target,
-    branches: [provider],
-    options: {
-      resolve: {
-        Company: {
-          // `similarity` is required, but the unique `domain` constraint forces the
-          // new-vs-base match here regardless of the name-spelling difference.
-          similarity: { kind: "fulltext", fields: ["name"] },
-          threshold: 0.9,
-        },
-      },
-      onPropertyConflict: "flag",
-      onBasePropertyConflict: "flag", // required by mergeIncremental (keep-base)
-      branchOrder: [PROVIDER],
-      persistProvenance: true,
-    },
-  };
-
-  const result = await mergeIncremental(args);
-  if (!isOk(result)) {
-    throw result.error;
+  // Every backend this example opens — directly or through `branch()`'s factory —
+  // is tracked here and closed in the finally below.
+  const openedBackends: GraphBackend[] = [];
+  async function makeBackend(): Promise<GraphBackend> {
+    const backend = createExampleBackend();
+    openedBackends.push(backend);
+    return backend;
   }
-  const report = result.data;
 
-  console.log("Target after: ", await listCompanies(target));
-  console.log(
-    `\nNo duplicate was created: the provider's "ACME Corporation" merged onto the`,
-  );
-  console.log(`committed "Acme Corp" via the shared domain.\n`);
-  console.log(`Merged nodes: ${report.merged.nodes}`);
-  console.log(`Entity resolutions: ${report.resolutions.length}`);
-  if (report.conflicts.length === 0) {
-    console.log("Conflicts: none");
-  } else {
-    for (const conflict of report.conflicts) {
-      const values = conflict.values
-        .map((value) => `${value.branchId}=${JSON.stringify(value.value)}`)
-        .join(", ");
+  try {
+    // The LIVE target graph, already holding committed companies from earlier
+    // ingestion waves. This is the "base that has advanced" mergeIncremental
+    // targets: Initech was renamed ON THE TARGET after the fork-point snapshot
+    // below was frozen.
+    const [target] = await createStoreWithSchema(kbGraph, await makeBackend());
+    await target.nodes.Company.create(
+      { name: "Acme Corp", domain: "acme.com" },
+      { id: "acme" },
+    );
+    await target.nodes.Company.create(
+      { name: "Initech Software", domain: "initech.com" },
+      { id: "initech" },
+    );
+
+    // The frozen fork-point the provider's branch forks from. It carries Initech
+    // as it looked AT FORK TIME — before the target's rename — so the provider's
+    // edit to its inherited copy is a genuine inherited edit against the
+    // fork-point that collides with the target's own committed rename.
+    const [forkPoint] = await createStoreWithSchema(
+      kbGraph,
+      await makeBackend(),
+    );
+    const initechAtFork = await forkPoint.nodes.Company.create(
+      { name: "Initech", domain: "initech.com" },
+      { id: "initech" },
+    );
+    const provider = unwrap(
+      await branch(forkPoint, makeBackend, { id: PROVIDER }),
+    );
+
+    // The provider re-reports Acme (same domain, different spelling), adds a
+    // genuinely new company, and RENAMES its inherited fork-point copy of
+    // Initech — an inherited edit the live target disagrees with.
+    await provider.store.nodes.Company.create(
+      { name: "ACME Corporation", domain: "acme.com" },
+      { id: "cb-acme" },
+    );
+    await provider.store.nodes.Company.create(
+      { name: "Globex", domain: "globex.io" },
+      { id: "cb-globex" },
+    );
+    await provider.store.nodes.Company.update(initechAtFork.id, {
+      name: "Initech Inc",
+    });
+
+    console.log("=== Incremental Graph Merge ===\n");
+    console.log("Target before:", await listCompanies(target));
+
+    const args: MergeIncrementalArgs<KbGraph> = {
+      forkPoint,
+      target,
+      branches: [provider],
+      options: {
+        resolve: {
+          Company: {
+            // `similarity` is required, but the unique `domain` constraint forces the
+            // new-vs-base match here regardless of the name-spelling difference.
+            similarity: { kind: "fulltext", fields: ["name"] },
+            threshold: 0.9,
+          },
+        },
+        onPropertyConflict: "flag",
+        // Optional — "flag" is already the default (MERGE_OPTION_DEFAULTS), and the
+        // ONLY value mergeIncremental() accepts. Spelled out to document the
+        // deliberate keep-base policy: committed target values always survive.
+        onBasePropertyConflict: "flag",
+        branchOrder: [PROVIDER],
+        persistProvenance: true,
+      },
+    };
+
+    const result = await mergeIncremental(args);
+    if (!isOk(result)) {
+      throw result.error;
+    }
+    const report = result.data;
+
+    console.log("Target after: ", await listCompanies(target));
+    console.log(
+      `\nNo duplicate was created: the provider's "ACME Corporation" merged onto`,
+    );
+    console.log(
+      `the committed "Acme Corp" via the shared domain, and the provider's rename`,
+    );
+    console.log(
+      `of inherited Initech was flagged against the target's own rename — the`,
+    );
+    console.log(`committed value survived both disagreements.\n`);
+    console.log(`Merged nodes: ${report.merged.nodes}`);
+    console.log(`Entity resolutions: ${report.resolutions.length}`);
+    if (report.conflicts.length === 0) {
+      console.log("Conflicts: none");
+    } else {
+      // A conflict on a cluster canonical is a NEW entity matched onto a committed
+      // row; any other conflicted id is an inherited fork-point row that BOTH the
+      // branch and the live target edited. Either way keep-base means the committed
+      // value survives (printed as "kept"); the branch's value is the "incoming".
+      const clusterCanonicalIds = new Set<string>(
+        report.resolutions.map((resolution) => resolution.canonicalId),
+      );
+      console.log("Conflicts:");
+      for (const conflict of report.conflicts) {
+        const incoming = conflict.values
+          .map((value) => `${value.branchId}=${JSON.stringify(value.value)}`)
+          .join(", ");
+        const origin =
+          clusterCanonicalIds.has(conflict.entityId) ? "new-entity match" : (
+            "inherited edit"
+          );
+        console.log(
+          `  - [${origin}] ${conflict.kind}.${conflict.property} @ ${conflict.entityId}: kept ${JSON.stringify(conflict.resolution)}, incoming ${incoming}`,
+        );
+      }
+    }
+    if (report.provenancePersisted !== undefined) {
       console.log(
-        `Conflict on ${conflict.kind}.${conflict.property} @ ${conflict.entityId}: ${values}`,
+        `\nProvenance persisted: ${report.provenancePersisted.count} row(s) in sidecar "${report.provenancePersisted.graphId}"`,
       );
     }
-  }
-  if (report.provenancePersisted !== undefined) {
-    console.log(
-      `\nProvenance persisted: ${report.provenancePersisted.count} row(s) in sidecar "${report.provenancePersisted.graphId}"`,
-    );
-  }
 
-  // Query the DURABLE provenance back later: "what did this provider contribute?"
-  const provenanceStore = await openProvenanceStore(
-    target.backend,
-    target.graphId,
-  );
-  const contributed = await readProvenance(provenanceStore, {
-    branchId: PROVIDER,
-  });
-  console.log("\nProvenance — canonical entities this provider contributed to:");
-  for (const node of contributed) {
-    console.log(
-      `  - ${node.canonicalKind} "${node.canonicalId}" (from source "${node.sourceId}")`,
+    // Query the DURABLE provenance back later: "what did this provider
+    // contribute?" The sidecar store SHARES the target's backend, so it must not
+    // be closed separately — it goes away when the target's backend closes below.
+    const provenanceStore = await openProvenanceStore(
+      target.backend,
+      target.graphId,
     );
+    const contributed = await readProvenance(provenanceStore, {
+      branchId: PROVIDER,
+    });
+    const companyNameById = new Map<string, string>();
+    for (const company of await target.nodes.Company.find()) {
+      companyNameById.set(company.id, company.name);
+    }
+    console.log(
+      "\nProvenance — canonical entities this provider contributed to:",
+    );
+    for (const node of contributed) {
+      const display = companyNameById.get(node.canonicalId) ?? node.canonicalId;
+      console.log(
+        `  - ${node.canonicalKind} "${display}" (canonical id "${node.canonicalId}", from source "${node.sourceId}")`,
+      );
+    }
+  } finally {
+    await Promise.all(openedBackends.map((backend) => backend.close()));
   }
 }
 
-main().catch((error: unknown) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/20-bitemporal-time-travel.ts
+++ b/packages/typegraph/examples/20-bitemporal-time-travel.ts
@@ -19,14 +19,14 @@
  * Run with:
  *   npx tsx examples/20-bitemporal-time-travel.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineGraph,
   defineNode,
   type RecordedInstant,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend, requireRecordedNow } from "./_helpers";
 
 // ============================================================
@@ -76,157 +76,159 @@ export async function main(): Promise<void> {
     history: true,
   });
 
-  console.log("━".repeat(70));
-  console.log(" Bitemporal Time Travel — valid time × recorded time");
-  console.log("━".repeat(70));
+  try {
+    console.log("━".repeat(70));
+    console.log(" Bitemporal Time Travel — valid time × recorded time");
+    console.log("━".repeat(70));
 
-  // ----------------------------------------------------------
-  // [1] Recorded time: a correction
-  // ----------------------------------------------------------
-  //
-  // The recorded axis is value time-travel for TypeGraph-managed writes: it
-  // remembers every captured value, so you can reconstruct what TypeGraph
-  // recorded at a past instant — even values that were later corrected.
+    // ----------------------------------------------------------
+    // [1] Recorded time: a correction
+    // ----------------------------------------------------------
+    //
+    // The recorded axis is value time-travel for TypeGraph-managed writes: it
+    // remembers every captured value, so you can reconstruct what TypeGraph
+    // recorded at a past instant — even values that were later corrected.
 
-  console.log("\n" + "━".repeat(70));
-  console.log(" [1] Recorded time — a correction");
-  console.log("━".repeat(70));
+    console.log("\n" + "━".repeat(70));
+    console.log(" [1] Recorded time — a correction");
+    console.log("━".repeat(70));
 
-  const invoice = await store.nodes.Invoice.create({
-    vendor: "Acme",
-    amount: 1000,
-  });
-  const asReported = await requireRecordedNow(store);
+    const invoice = await store.nodes.Invoice.create({
+      vendor: "Acme",
+      amount: 1000,
+    });
+    const asReported = await requireRecordedNow(store);
 
-  // Three weeks later, finance finds the invoice was actually $1,250.
-  await store.nodes.Invoice.update(invoice.id, {
-    vendor: "Acme",
-    amount: 1250,
-  });
+    // Three weeks later, finance finds the invoice was actually $1,250.
+    await store.nodes.Invoice.update(invoice.id, {
+      vendor: "Acme",
+      amount: 1250,
+    });
 
-  const reportedThen = await store
-    .asOfRecorded(asReported)
-    .nodes.Invoice.getById(invoice.id);
-  const knownNow = await store.nodes.Invoice.getById(invoice.id);
+    const reportedThen = await store
+      .asOfRecorded(asReported)
+      .nodes.Invoice.getById(invoice.id);
+    const knownNow = await store.nodes.Invoice.getById(invoice.id);
 
-  console.log(`\n  Invoice ${invoice.id} (vendor: Acme)\n`);
-  console.log(`    as reported    (asOfRecorded): $${reportedThen?.amount}`);
-  console.log(`    as known now   (live read):    $${knownNow?.amount}`);
-  console.log(
-    "\n  Same invoice, two correct answers — the report you filed and the",
-  );
-  console.log("  truth you discovered later. No audit table; just two reads.");
-
-  // ----------------------------------------------------------
-  // [2] Valid time: effective dating
-  // ----------------------------------------------------------
-  //
-  // The valid axis is a validity *window*: `validFrom` / `validTo` say when a
-  // fact is in effect. `asOf(T)` returns only what was effective at T.
-
-  console.log("\n" + "━".repeat(70));
-  console.log(" [2] Valid time — effective dating");
-  console.log("━".repeat(70));
-
-  // A promotion that runs for July only.
-  await store.nodes.Promotion.create(
-    { code: "SUMMER24" },
-    { validFrom: JUL_1, validTo: AUG_1 },
-  );
-
-  console.log('\n  Promotion "SUMMER24" is valid for July only.\n');
-  for (const [label, when] of [
-    ["Jun 1 (before)", JUN_1],
-    ["Jul 15 (during)", JUL_15],
-    ["Sep 1 (after)", SEP_1],
-  ] as const) {
-    const live = await store.asOf(when).nodes.Promotion.find();
+    console.log(`\n  Invoice ${invoice.id} (vendor: Acme)\n`);
+    console.log(`    as reported    (asOfRecorded): $${reportedThen?.amount}`);
+    console.log(`    as known now   (live read):    $${knownNow?.amount}`);
     console.log(
-      `    asOf ${label.padEnd(16)} → ${live.length > 0 ? "SUMMER24 in effect" : "no promotion"}`,
+      "\n  Same invoice, two correct answers — the report you filed and the",
     );
-  }
+    console.log("  truth you discovered later. No audit table; just two reads.");
 
-  // ----------------------------------------------------------
-  // [3] Both axes at once: the bitemporal 2x2
-  // ----------------------------------------------------------
-  //
-  // A subscription cancelled "effective Jun 1" — then the cancellation date is
-  // corrected to Sep 1. Now "was it active on date X?" has different answers
-  // depending on WHEN you valid-time-ask AND WHEN TypeGraph captured the state.
+    // ----------------------------------------------------------
+    // [2] Valid time: effective dating
+    // ----------------------------------------------------------
+    //
+    // The valid axis is a validity *window*: `validFrom` / `validTo` say when a
+    // fact is in effect. `asOf(T)` returns only what was effective at T.
 
-  console.log("\n" + "━".repeat(70));
-  console.log(" [3] Both axes — the bitemporal 2×2");
-  console.log("━".repeat(70));
+    console.log("\n" + "━".repeat(70));
+    console.log(" [2] Valid time — effective dating");
+    console.log("━".repeat(70));
 
-  const sub = await store.nodes.Subscription.create(
-    { plan: "Pro" },
-    { validFrom: JAN_1 },
-  );
+    // A promotion that runs for July only.
+    await store.nodes.Promotion.create(
+      { code: "SUMMER24" },
+      { validFrom: JUL_1, validTo: AUG_1 },
+    );
 
-  // First we record: the customer cancelled effective Jun 1.
-  await store.nodes.Subscription.update(
-    sub.id,
-    { plan: "Pro" },
-    { validTo: JUN_1 },
-  );
-  const beforeFix = await requireRecordedNow(store);
+    console.log('\n  Promotion "SUMMER24" is valid for July only.\n');
+    for (const [label, when] of [
+      ["Jun 1 (before)", JUN_1],
+      ["Jul 15 (during)", JUL_15],
+      ["Sep 1 (after)", SEP_1],
+    ] as const) {
+      const live = await store.asOf(when).nodes.Promotion.find();
+      console.log(
+        `    asOf ${label.padEnd(16)} → ${live.length > 0 ? "SUMMER24 in effect" : "no promotion"}`,
+      );
+    }
 
-  // Support later finds the real cancellation date was Sep 1, and corrects it.
-  await store.nodes.Subscription.update(
-    sub.id,
-    { plan: "Pro" },
-    { validTo: SEP_1 },
-  );
+    // ----------------------------------------------------------
+    // [3] Both axes at once: the bitemporal 2x2
+    // ----------------------------------------------------------
+    //
+    // A subscription cancelled "effective Jun 1" — then the cancellation date is
+    // corrected to Sep 1. Now "was it active on date X?" has different answers
+    // depending on WHEN you valid-time-ask AND WHEN TypeGraph captured the state.
 
-  async function activeOn(
-    validAt: string,
-    recordedAt?: RecordedInstant,
-  ): Promise<boolean> {
-    const view =
-      recordedAt === undefined ?
-        store.asOf(validAt)
-      : store.asOf(validAt).asOfRecorded(recordedAt);
-    return (await view.nodes.Subscription.getById(sub.id)) !== undefined;
-  }
+    console.log("\n" + "━".repeat(70));
+    console.log(" [3] Both axes — the bitemporal 2×2");
+    console.log("━".repeat(70));
 
-  console.log("\n  Subscription cancelled 'effective Jun 1' — later corrected");
-  console.log("  to Sep 1. Was it active on a given date?\n");
-  console.log(
-    "    valid-time ↓ \\ recorded-time →   before correction      now",
-  );
-  for (const [label, validAt] of [
-    ["May 1", MAY_1],
-    ["Jul 15", JUL_15],
-  ] as const) {
-    const before = await activeOn(validAt, beforeFix);
-    const now = await activeOn(validAt);
+    const sub = await store.nodes.Subscription.create(
+      { plan: "Pro" },
+      { validFrom: JAN_1 },
+    );
+
+    // First we record: the customer cancelled effective Jun 1.
+    await store.nodes.Subscription.update(
+      sub.id,
+      { plan: "Pro" },
+      { validTo: JUN_1 },
+    );
+    const beforeFix = await requireRecordedNow(store);
+
+    // Support later finds the real cancellation date was Sep 1, and corrects it.
+    await store.nodes.Subscription.update(
+      sub.id,
+      { plan: "Pro" },
+      { validTo: SEP_1 },
+    );
+
+    async function activeOn(
+      validAt: string,
+      recordedAt?: RecordedInstant,
+    ): Promise<boolean> {
+      const view =
+        recordedAt === undefined ?
+          store.asOf(validAt)
+        : store.asOf(validAt).asOfRecorded(recordedAt);
+      return (await view.nodes.Subscription.getById(sub.id)) !== undefined;
+    }
+
+    console.log("\n  Subscription cancelled 'effective Jun 1' — later corrected");
+    console.log("  to Sep 1. Was it active on a given date?\n");
     console.log(
-      `    valid ${label.padEnd(26)} ${yesNo(before).padEnd(22)} ${yesNo(now)}`,
+      String.raw`    valid-time ↓ \ recorded-time →   before correction      now`,
     );
+    for (const [label, validAt] of [
+      ["May 1", MAY_1],
+      ["Jul 15", JUL_15],
+    ] as const) {
+      const before = await activeOn(validAt, beforeFix);
+      const now = await activeOn(validAt);
+      console.log(
+        `    valid ${label.padEnd(26)} ${yesNo(before).padEnd(22)} ${yesNo(now)}`,
+      );
+    }
+
+    console.log(
+      "\n  The Jul-15 / before-correction cell is the one no single-clock store",
+    );
+    console.log(
+      "  can express: on Jul 15 the captured graph state had the subscription",
+    );
+    console.log(
+      "  already cancelled — even though we now know it was still active.",
+    );
+
+    console.log("\n" + "━".repeat(70));
+    console.log(
+      " valid time = when a fact is true · recorded time = when we knew",
+    );
+    console.log(" Pin either or both; every read time-travels. One SQLite file.");
+    console.log("━".repeat(70) + "\n");
+  } finally {
+    await store.close();
   }
-
-  console.log(
-    "\n  The Jul-15 / before-correction cell is the one no single-clock store",
-  );
-  console.log(
-    "  can express: on Jul 15 the captured graph state had the subscription",
-  );
-  console.log(
-    "  already cancelled — even though we now know it was still active.",
-  );
-
-  console.log("\n" + "━".repeat(70));
-  console.log(
-    " valid time = when a fact is true · recorded time = when we knew",
-  );
-  console.log(" Pin either or both; every read time-travels. One SQLite file.");
-  console.log("━".repeat(70) + "\n");
-
-  await store.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/21-agent-decision-replay.ts
+++ b/packages/typegraph/examples/21-agent-decision-replay.ts
@@ -19,8 +19,6 @@
  * Run with:
  *   npx tsx examples/21-agent-decision-replay.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineEdge,
@@ -28,6 +26,8 @@ import {
   defineNode,
   type RecordedStoreView,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend, requireRecordedNow } from "./_helpers";
 
 // ============================================================
@@ -109,120 +109,122 @@ export async function main(): Promise<void> {
     history: true,
   });
 
-  console.log("━".repeat(70));
-  console.log(" Replay an agent's decision over the graph it actually saw");
-  console.log("━".repeat(70));
+  try {
+    console.log("━".repeat(70));
+    console.log(" Replay an agent's decision over the graph it actually saw");
+    console.log("━".repeat(70));
 
-  // ----------------------------------------------------------
-  // Build the knowledge graph the agent will reason over
-  // ----------------------------------------------------------
+    // ----------------------------------------------------------
+    // Build the knowledge graph the agent will reason over
+    // ----------------------------------------------------------
 
-  const claim = await store.nodes.Claim.create({
-    text: "Scaling model size improves downstream accuracy",
-  });
+    const claim = await store.nodes.Claim.create({
+      text: "Scaling model size improves downstream accuracy",
+    });
 
-  const kaplan = await store.nodes.Paper.create({
-    title: "Kaplan — Scaling Laws",
-  });
-  const chinchilla = await store.nodes.Paper.create({
-    title: "Hoffmann — Compute-Optimal LLMs",
-  });
-  const ablation = await store.nodes.Paper.create({
-    title: "Internal ablation memo",
-  });
+    const kaplan = await store.nodes.Paper.create({
+      title: "Kaplan — Scaling Laws",
+    });
+    const chinchilla = await store.nodes.Paper.create({
+      title: "Hoffmann — Compute-Optimal LLMs",
+    });
+    const ablation = await store.nodes.Paper.create({
+      title: "Internal ablation memo",
+    });
 
-  // All three support the claim.
-  for (const p of [kaplan, chinchilla, ablation]) {
-    await store.edges.supports.create(p, claim, {});
-  }
+    // All three support the claim.
+    for (const p of [kaplan, chinchilla, ablation]) {
+      await store.edges.supports.create(p, claim, {});
+    }
 
-  // Citation authority: Kaplan is cited by 3 papers, Chinchilla by 1, memo by 0.
-  const citers: Array<Awaited<ReturnType<typeof store.nodes.Paper.create>>> =
-    [];
-  for (let index = 0; index < 4; index += 1) {
-    citers.push(
-      await store.nodes.Paper.create({ title: `Follow-up paper ${index + 1}` }),
+    // Citation authority: Kaplan is cited by 3 papers, Chinchilla by 1, memo by 0.
+    const citers: Awaited<ReturnType<typeof store.nodes.Paper.create>>[] =
+      [];
+    for (let index = 0; index < 4; index += 1) {
+      citers.push(
+        await store.nodes.Paper.create({ title: `Follow-up paper ${index + 1}` }),
+      );
+    }
+    await store.edges.cites.create(citers[0]!, kaplan, {});
+    await store.edges.cites.create(citers[1]!, kaplan, {});
+    await store.edges.cites.create(citers[2]!, kaplan, {});
+    await store.edges.cites.create(citers[3]!, chinchilla, {});
+
+    // ----------------------------------------------------------
+    // The agent decides — and we note WHEN it decided
+    // ----------------------------------------------------------
+
+    // A deterministic recorded anchor for the exact graph the agent reasoned over.
+    const decisionTime = await requireRecordedNow(store);
+
+    const original = await recommendSource(
+      store.view({ mode: "current" }),
+      claim.id,
     );
+    console.log("\n  Agent answers: 'best source for the claim?'\n");
+    console.log(`    → ${original?.title}  (${original?.citations} citations)`);
+    console.log(`    recorded at: ${decisionTime}`);
+
+    // ----------------------------------------------------------
+    // The world moves on
+    // ----------------------------------------------------------
+
+    console.log("\n" + "─".repeat(70));
+    console.log("  …time passes. The evidence graph changes:");
+    console.log("    • the Kaplan paper is RETRACTED (removed from the corpus)");
+    console.log("    • two new follow-ups now cite the Chinchilla paper");
+    console.log("─".repeat(70));
+
+    await store.nodes.Paper.hardDelete(kaplan.id); // retraction cascades its edges
+    const late1 = await store.nodes.Paper.create({ title: "Follow-up paper 5" });
+    const late2 = await store.nodes.Paper.create({ title: "Follow-up paper 6" });
+    await store.edges.cites.create(late1, chinchilla, {});
+    await store.edges.cites.create(late2, chinchilla, {});
+
+    // ----------------------------------------------------------
+    // The audit: "why did the agent recommend Kaplan?"
+    // ----------------------------------------------------------
+
+    console.log("\n" + "━".repeat(70));
+    console.log(" The audit asks: why did the agent recommend that source?");
+    console.log("━".repeat(70));
+
+    // Same agent code, on the LIVE graph — the evidence has moved, so it can't
+    // explain the original decision.
+    const liveNow = await recommendSource(
+      store.view({ mode: "current" }),
+      claim.id,
+    );
+    console.log("\n  Re-run on the CURRENT graph (the evidence moved):");
+    console.log(`    → ${liveNow?.title}  (${liveNow?.citations} citations)`);
+    console.log("    ✗ This is a different answer. The live graph no longer");
+    console.log("      explains what the agent did — Kaplan isn't even in it.");
+
+    // Same agent code, pinned to the recorded graph as of the decision instant.
+    const replay = await recommendSource(
+      store.asOfRecorded(decisionTime),
+      claim.id,
+    );
+    console.log("\n  Replay on `store.asOfRecorded(decisionTime)` (same code):");
+    console.log(`    → ${replay?.title}  (${replay?.citations} citations)`);
+    console.log("    ✓ Reproduced exactly — the retracted paper, its citations,");
+    console.log("      and the ranking, reconstructed as the agent saw them.");
+
+    console.log("\n" + "━".repeat(70));
+    console.log(
+      " Point-in-time-correct reasoning: the same query, pinned to the",
+    );
+    console.log(
+      " instant the agent acted. No event log, no snapshots, one file.",
+    );
+    console.log("━".repeat(70) + "\n");
+  } finally {
+    await store.close();
   }
-  await store.edges.cites.create(citers[0]!, kaplan, {});
-  await store.edges.cites.create(citers[1]!, kaplan, {});
-  await store.edges.cites.create(citers[2]!, kaplan, {});
-  await store.edges.cites.create(citers[3]!, chinchilla, {});
-
-  // ----------------------------------------------------------
-  // The agent decides — and we note WHEN it decided
-  // ----------------------------------------------------------
-
-  // A deterministic recorded anchor for the exact graph the agent reasoned over.
-  const decisionTime = await requireRecordedNow(store);
-
-  const original = await recommendSource(
-    store.view({ mode: "current" }),
-    claim.id,
-  );
-  console.log("\n  Agent answers: 'best source for the claim?'\n");
-  console.log(`    → ${original?.title}  (${original?.citations} citations)`);
-  console.log(`    recorded at: ${decisionTime}`);
-
-  // ----------------------------------------------------------
-  // The world moves on
-  // ----------------------------------------------------------
-
-  console.log("\n" + "─".repeat(70));
-  console.log("  …time passes. The evidence graph changes:");
-  console.log("    • the Kaplan paper is RETRACTED (removed from the corpus)");
-  console.log("    • two new follow-ups now cite the Chinchilla paper");
-  console.log("─".repeat(70));
-
-  await store.nodes.Paper.hardDelete(kaplan.id); // retraction cascades its edges
-  const late1 = await store.nodes.Paper.create({ title: "Follow-up paper 5" });
-  const late2 = await store.nodes.Paper.create({ title: "Follow-up paper 6" });
-  await store.edges.cites.create(late1, chinchilla, {});
-  await store.edges.cites.create(late2, chinchilla, {});
-
-  // ----------------------------------------------------------
-  // The audit: "why did the agent recommend Kaplan?"
-  // ----------------------------------------------------------
-
-  console.log("\n" + "━".repeat(70));
-  console.log(" The audit asks: why did the agent recommend that source?");
-  console.log("━".repeat(70));
-
-  // Same agent code, on the LIVE graph — the evidence has moved, so it can't
-  // explain the original decision.
-  const liveNow = await recommendSource(
-    store.view({ mode: "current" }),
-    claim.id,
-  );
-  console.log("\n  Re-run on the CURRENT graph (the evidence moved):");
-  console.log(`    → ${liveNow?.title}  (${liveNow?.citations} citations)`);
-  console.log("    ✗ This is a different answer. The live graph no longer");
-  console.log("      explains what the agent did — Kaplan isn't even in it.");
-
-  // Same agent code, pinned to the recorded graph as of the decision instant.
-  const replay = await recommendSource(
-    store.asOfRecorded(decisionTime),
-    claim.id,
-  );
-  console.log("\n  Replay on `store.asOfRecorded(decisionTime)` (same code):");
-  console.log(`    → ${replay?.title}  (${replay?.citations} citations)`);
-  console.log("    ✓ Reproduced exactly — the retracted paper, its citations,");
-  console.log("      and the ranking, reconstructed as the agent saw them.");
-
-  console.log("\n" + "━".repeat(70));
-  console.log(
-    " Point-in-time-correct reasoning: the same query, pinned to the",
-  );
-  console.log(
-    " instant the agent acted. No event log, no snapshots, one file.",
-  );
-  console.log("━".repeat(70) + "\n");
-
-  await store.close();
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/22-breach-forensics.ts
+++ b/packages/typegraph/examples/22-breach-forensics.ts
@@ -18,8 +18,6 @@
  * the breach instant, and what did they reach?" Run with:
  *   npx tsx examples/22-breach-forensics.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineEdge,
@@ -28,6 +26,8 @@ import {
   type RecordedStoreView,
   type Store,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend, requireRecordedNow } from "./_helpers";
 
 // ============================================================
@@ -94,7 +94,7 @@ async function exposedResources(
     .whereNode("r", (r) => r.id.in(resourceIds))
     .select((ctx) => ({ name: ctx.r.name, sensitivity: ctx.r.sensitivity }))
     .execute();
-  return [...resources].sort((a, b) => a.name.localeCompare(b.name));
+  return [...resources].toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 const EXPOSED_LEVELS = new Set(["high", "critical"]);
@@ -139,7 +139,7 @@ async function runForensics(store: Store<typeof graph>): Promise<void> {
     { name: "ci-secrets", sensitivity: "medium" },
     eff,
   );
-  const prodDb = await store.nodes.Resource.create(
+  const productionDb = await store.nodes.Resource.create(
     { name: "prod-db", sensitivity: "high" },
     eff,
   );
@@ -150,7 +150,7 @@ async function runForensics(store: Store<typeof graph>): Promise<void> {
 
   await store.edges.assumes.create(account, deployer, {}, eff);
   await store.edges.grants.create(deployer, ciSecrets, {}, eff);
-  await store.edges.grants.create(admin, prodDb, {}, eff);
+  await store.edges.grants.create(admin, productionDb, {}, eff);
   await store.edges.grants.create(admin, pii, {}, eff);
   // The dangerous grant: a contractor's deploy role may escalate to admin —
   // but only during the March maintenance window.
@@ -162,7 +162,7 @@ async function runForensics(store: Store<typeof graph>): Promise<void> {
   );
 
   const nodeName = new Map<string, string>(
-    [account, deployer, admin, ciSecrets, prodDb, pii].map(
+    [account, deployer, admin, ciSecrets, productionDb, pii].map(
       (node) => [node.id, node.name] as [string, string],
     ),
   );
@@ -266,7 +266,7 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/22-breach-forensics.ts
+++ b/packages/typegraph/examples/22-breach-forensics.ts
@@ -5,29 +5,28 @@
  *
  *     "At the moment of the breach, what could the compromised account reach?"
  *
- * The honest answer needs the access graph *as it was recorded at breach time*
- * — not as it is now. By the time you investigate, the dangerous grant has been
- * revoked and deleted, so a live query understates the blast radius and a plain
- * audit log can't traverse the permission chain.
+ * That question has TWO time axes, and getting either wrong misstates the
+ * blast radius. Valid time: was the grant IN EFFECT at the breach instant?
+ * (a contractor's grant is time-boxed to a maintenance window via
+ * `validFrom` / `validTo`.) Recorded time: what did the store KNOW?
+ * (incident response deletes the dangerous grant, so a live query can't
+ * see the path the attacker had.) Pin both axes and ask directly:
  *
- * With recorded-time capture (`history: true`) you pin the graph to the breach
- * instant and run reachability over it — reconstructing the exact exposure,
- * including the over-permissive edge that has since been removed.
+ *     store.asOf(breachAt).asOfRecorded(alertAnchor).reachable(account, ...)
  *
- *     store.asOfRecorded(breachTime).reachable(account, { edges: [...] })
- *
- * Bitemporal + graph + one line. Run with:
+ * — "per what we knew when the alert fired, which grants were in effect at
+ * the breach instant, and what did they reach?" Run with:
  *   npx tsx examples/22-breach-forensics.ts
  */
 import { z } from "zod";
 
 import {
-  asNodeId,
   createStoreWithSchema,
   defineEdge,
   defineGraph,
   defineNode,
   type RecordedStoreView,
+  type Store,
 } from "@nicia-ai/typegraph";
 import { createExampleBackend, requireRecordedNow } from "./_helpers";
 
@@ -63,11 +62,59 @@ const graph = defineGraph({
   },
 });
 
-export async function main(): Promise<void> {
-  const [store] = await createStoreWithSchema(graph, createExampleBackend(), {
-    history: true,
-  });
+// Fixed valid-time instants (canonical UTC ISO-8601, as the API requires).
+const JAN_1 = "2024-01-01T00:00:00.000Z"; // baseline access model takes effect
+const MAR_1 = "2024-03-01T00:00:00.000Z"; // maintenance window opens
+const BREACH_AT = "2024-03-05T00:00:00.000Z"; // the compromise, mid-window
+const MAR_8 = "2024-03-08T00:00:00.000Z"; // maintenance window closes
+const MAR_20 = "2024-03-20T00:00:00.000Z"; // a quiet day after the window
 
+// The reads forensics needs — a live `store.view(...)` and a composed
+// `store.asOf(...).asOfRecorded(...)` both satisfy it (same code, any pin).
+type AccessView = Pick<RecordedStoreView<typeof graph>, "reachable" | "query">;
+
+type ExposedResource = Readonly<{ name: string; sensitivity: string }>;
+
+// Which resources can the account reach, under a given view?
+async function exposedResources(
+  view: AccessView,
+  accountId: string,
+): Promise<readonly ExposedResource[]> {
+  const reached = await view.reachable(accountId, {
+    edges: [...ACCESS_EDGES],
+    maxHops: 10,
+  });
+  const resourceIds = reached
+    .filter((node) => node.kind === "Resource")
+    .map((node) => node.id);
+  if (resourceIds.length === 0) return [];
+  const resources = await view
+    .query()
+    .from("Resource", "r")
+    .whereNode("r", (r) => r.id.in(resourceIds))
+    .select((ctx) => ({ name: ctx.r.name, sensitivity: ctx.r.sensitivity }))
+    .execute();
+  return [...resources].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const EXPOSED_LEVELS = new Set(["high", "critical"]);
+
+function printExposure(resources: readonly ExposedResource[]): void {
+  for (const resource of resources) {
+    const flag = EXPOSED_LEVELS.has(resource.sensitivity) ? " ◀── EXPOSED" : "";
+    console.log(
+      `    • ${resource.name.padEnd(14)} (${resource.sensitivity})${flag}`,
+    );
+  }
+}
+
+// Edge kind for a hop; the schema makes each node-kind pair unambiguous.
+function hopLabel(fromKind: string, toKind: string): string {
+  if (fromKind === "Account") return "assumes";
+  return toKind === "Role" ? "escalates" : "grants";
+}
+
+async function runForensics(store: Store<typeof graph>): Promise<void> {
   console.log("━".repeat(70));
   console.log(" Breach forensics over a bitemporal access graph");
   console.log("━".repeat(70));
@@ -78,123 +125,144 @@ export async function main(): Promise<void> {
   //
   //   svc-deploy ──assumes──▶ deployer ──grants──▶ ci-secrets
   //                              │
-  //                          escalates  ◀── the dangerous misconfiguration
-  //                              ▼
+  //                          escalates  ◀── contractor grant, valid ONLY
+  //                              ▼          for the Mar 1–8 window
   //                            admin ──grants──▶ prod-db, customer-pii
+  //
+  // The baseline model is effective Jan 1; the escalation is time-boxed.
 
-  const account = await store.nodes.Account.create({ name: "svc-deploy" });
-  const deployer = await store.nodes.Role.create({ name: "deployer" });
-  const admin = await store.nodes.Role.create({ name: "admin" });
+  const eff = { validFrom: JAN_1 };
+  const account = await store.nodes.Account.create({ name: "svc-deploy" }, eff);
+  const deployer = await store.nodes.Role.create({ name: "deployer" }, eff);
+  const admin = await store.nodes.Role.create({ name: "admin" }, eff);
+  const ciSecrets = await store.nodes.Resource.create(
+    { name: "ci-secrets", sensitivity: "medium" },
+    eff,
+  );
+  const prodDb = await store.nodes.Resource.create(
+    { name: "prod-db", sensitivity: "high" },
+    eff,
+  );
+  const pii = await store.nodes.Resource.create(
+    { name: "customer-pii", sensitivity: "critical" },
+    eff,
+  );
 
-  const ciSecrets = await store.nodes.Resource.create({
-    name: "ci-secrets",
-    sensitivity: "medium",
-  });
-  const prodDb = await store.nodes.Resource.create({
-    name: "prod-db",
-    sensitivity: "high",
-  });
-  const pii = await store.nodes.Resource.create({
-    name: "customer-pii",
-    sensitivity: "critical",
-  });
+  await store.edges.assumes.create(account, deployer, {}, eff);
+  await store.edges.grants.create(deployer, ciSecrets, {}, eff);
+  await store.edges.grants.create(admin, prodDb, {}, eff);
+  await store.edges.grants.create(admin, pii, {}, eff);
+  // The dangerous grant: a contractor's deploy role may escalate to admin —
+  // but only during the March maintenance window.
+  const windowGrant = await store.edges.escalates.create(
+    deployer,
+    admin,
+    {},
+    { validFrom: MAR_1, validTo: MAR_8 },
+  );
 
-  await store.edges.assumes.create(account, deployer, {});
-  await store.edges.grants.create(deployer, ciSecrets, {});
-  await store.edges.grants.create(admin, prodDb, {});
-  await store.edges.grants.create(admin, pii, {});
-  // The over-permissive edge: a deploy role that can escalate to admin.
-  const overGrant = await store.edges.escalates.create(deployer, admin, {});
+  const nodeName = new Map<string, string>(
+    [account, deployer, admin, ciSecrets, prodDb, pii].map(
+      (node) => [node.id, node.name] as [string, string],
+    ),
+  );
 
   // ----------------------------------------------------------
-  // The breach happens — note the instant
+  // The breach happens — anchor BOTH clocks
   // ----------------------------------------------------------
 
-  // The breach instant — a deterministic recorded anchor. A real one comes from
-  // your alert/SIEM; here we capture the recorded high-water mark.
-  const breachTime = await requireRecordedNow(store);
-  console.log(`\n  ⚠  svc-deploy compromised at ${breachTime}\n`);
-
-  // The reads forensics needs. A live `store.view(...)` and a recorded
-  // `store.asOfRecorded(...)` both satisfy this surface, so the same code runs
-  // at either pin.
-  type AccessView = Pick<
-    RecordedStoreView<typeof graph>,
-    "reachable" | "nodes"
-  >;
-
-  // Which resources can `account` reach, under a given view?
-  async function exposedResources(
-    view: AccessView,
-  ): Promise<readonly { name: string; sensitivity: string }[]> {
-    const reached = await view.reachable(account.id, {
-      edges: [...ACCESS_EDGES],
-      maxHops: 10,
-    });
-    // `reachable()` walks mixed node kinds in one pass, so its result is
-    // deliberately kind-erased (`id: string`) — unlike a `.select()`
-    // projection, there's no single statically-known kind to brand against.
-    // The `kind` filter is a runtime check TypeScript can't turn into a
-    // `NodeId<Resource>` narrowing, so re-branding the id at this boundary
-    // is still required — `asNodeId` does that with a checked cast instead
-    // of an unsafe one.
-    const resourceIds = reached
-      .filter((node) => node.kind === "Resource")
-      .map((node) => asNodeId<typeof Resource>(node.id));
-    const resources = await view.nodes.Resource.getByIds(resourceIds);
-    return resources.filter((r): r is NonNullable<typeof r> => r !== undefined);
-  }
+  // When the alert fires, capture `store.recordedNow()` and persist it with
+  // the incident record: `asOfRecorded` takes a branded RecordedInstant
+  // obtained from that clock — not a wall-clock timestamp from your SIEM
+  // (recorded instants are monotonic and can run ahead of the wall clock).
+  const alertAnchor = await requireRecordedNow(store);
+  console.log(`\n  ⚠  svc-deploy compromised at ${BREACH_AT} (valid time)`);
+  console.log(`     alert anchor: recordedNow() = ${alertAnchor}\n`);
 
   // ----------------------------------------------------------
   // Incident response tightens permissions — and removes the evidence
   // ----------------------------------------------------------
 
   console.log("─".repeat(70));
-  console.log("  Incident response revokes the deployer→admin escalation");
-  console.log("  (the grant is removed entirely — not just disabled).");
+  console.log("  Incident response deletes the deployer→admin escalation");
+  console.log("  outright — removed entirely, not just disabled.");
   console.log("─".repeat(70));
 
-  await store.edges.escalates.hardDelete(overGrant.id);
+  await store.edges.escalates.hardDelete(windowGrant.id);
 
   // ----------------------------------------------------------
-  // Two reads of "what could svc-deploy reach?"
+  // Three reads of "what could svc-deploy reach?"
   // ----------------------------------------------------------
 
-  const liveExposure = await exposedResources(store.view({ mode: "current" }));
-  console.log("\n  Reachable resources on the CURRENT graph:");
-  for (const r of liveExposure) {
-    console.log(`    • ${r.name.padEnd(14)} (${r.sensitivity})`);
-  }
-  console.log(
-    "    Looks contained — but the escalation was deleted, so a live",
-  );
-  console.log("    query can't see the path the attacker actually had.");
+  const live = store.view({ mode: "current" });
+  console.log("\n  [1] CURRENT graph (live read):");
+  printExposure(await exposedResources(live, account.id));
+  console.log("      Looks contained — the deleted grant is invisible live.");
 
-  const breachExposure = await exposedResources(store.asOfRecorded(breachTime));
-  console.log("\n  Reachable resources reconstructed AT THE BREACH INSTANT");
-  console.log("  via store.asOfRecorded(breachTime).reachable(...):");
-  for (const r of breachExposure) {
-    const flag =
-      r.sensitivity === "critical" || r.sensitivity === "high" ?
-        " ◀── EXPOSED"
-      : "";
-    console.log(`    • ${r.name.padEnd(14)} (${r.sensitivity})${flag}`);
-  }
-  console.log(
-    "    The real blast radius — including prod-db and customer-pii,",
-  );
-  console.log("    reachable only through the since-deleted escalation edge.");
+  // Valid pin = the breach instant; recorded pin = what we knew at the alert.
+  const atBreach = store.asOf(BREACH_AT).asOfRecorded(alertAnchor);
+  console.log("\n  [2] store.asOf(breachAt).asOfRecorded(alertAnchor):");
+  printExposure(await exposedResources(atBreach, account.id));
+  console.log("      The real blast radius: the window grant was in effect");
+  console.log("      on Mar 5 AND captured at the anchor — both axes agree.");
+
+  // Same recorded pin, different valid time: the axes are independent.
+  const afterWindow = store.asOf(MAR_20).asOfRecorded(alertAnchor);
+  console.log("\n  [3] store.asOf(mar20).asOfRecorded(alertAnchor):");
+  printExposure(await exposedResources(afterWindow, account.id));
+  console.log("      Same recorded pin, later valid time: the window grant");
+  console.log("      had expired — no exposure even in the reconstruction.");
+
+  // ----------------------------------------------------------
+  // Not just WHAT was exposed — HOW: the escalation path itself
+  // ----------------------------------------------------------
 
   console.log("\n" + "━".repeat(70));
+  console.log(" The escalation path, reconstructed on the pinned view");
+  console.log("━".repeat(70));
+
+  const pathAtBreach = await atBreach.shortestPath(account.id, pii.id, {
+    edges: [...ACCESS_EDGES],
+    maxHops: 10,
+  });
+  if (pathAtBreach === undefined) throw new Error("expected a pinned path");
+  const chain = pathAtBreach.nodes
+    .map((node, index) => {
+      const name = nodeName.get(node.id) ?? node.id;
+      if (index === 0) return name;
+      const label = hopLabel(pathAtBreach.nodes[index - 1]!.kind, node.kind);
+      const gone = label === "escalates" ? " (edge later DELETED)" : "";
+      return `─${label}${gone}→ ${name}`;
+    })
+    .join(" ");
+  console.log("\n  atBreach.shortestPath(svc-deploy, customer-pii):");
+  console.log(`    ${chain}   [${pathAtBreach.depth} hops]`);
+
+  const pathLive = await live.shortestPath(account.id, pii.id, {
+    edges: [...ACCESS_EDGES],
+    maxHops: 10,
+  });
+  const liveVerdict =
+    pathLive === undefined ? "no path — the deleted edge is gone" : "??";
+  console.log(`\n  Same shortestPath on the live graph: ${liveVerdict}`);
+
+  console.log("\n" + "━".repeat(70));
+  console.log(" valid time asks 'was the grant in effect?' · recorded time");
   console.log(
-    " Bitemporal + graph: pin the access graph to the breach instant",
-  );
-  console.log(
-    " and traverse it. The evidence survives even after you delete it.",
+    " asks 'what did we know?' Pin both: deleted evidence traverses.",
   );
   console.log("━".repeat(70) + "\n");
+}
 
-  await store.close();
+export async function main(): Promise<void> {
+  const [store] = await createStoreWithSchema(graph, createExampleBackend(), {
+    history: true,
+  });
+  try {
+    await runForensics(store);
+  } finally {
+    await store.close();
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/typegraph/examples/23-provenance-retraction.ts
+++ b/packages/typegraph/examples/23-provenance-retraction.ts
@@ -23,8 +23,6 @@
  * Run with:
  *   npx tsx examples/23-provenance-retraction.ts
  */
-import { z } from "zod";
-
 import {
   createStoreWithSchema,
   defineEdge,
@@ -38,6 +36,7 @@ import {
   type RetractionCapability,
   type RetractionReport,
 } from "@nicia-ai/typegraph/provenance";
+import { z } from "zod";
 
 import { createExampleBackend, requireRecordedNow } from "./_helpers";
 
@@ -127,7 +126,7 @@ type ExampleProvenance = RetractionCapability<
   "Justification"
 >;
 
-function formatFactRefs(
+function formatFactReferences(
   facts: readonly ProvenanceFactRef<typeof graph, FactKind>[],
 ): string {
   if (facts.length === 0) return "(none)";
@@ -149,9 +148,9 @@ function formatReport(report: ExampleReport): string {
         .toSorted((left, right) => left.localeCompare(right))
         .join("; ");
   return [
-    `    died:        ${formatFactRefs(report.died)}`,
+    `    died:        ${formatFactReferences(report.died)}`,
     `    survived:    ${survived}`,
-    `    unaffected:  ${formatFactRefs(report.unaffected)}`,
+    `    unaffected:  ${formatFactReferences(report.unaffected)}`,
   ].join("\n");
 }
 
@@ -165,7 +164,7 @@ async function printHolding(
   label: string,
   provenance: ExampleProvenance,
 ): Promise<void> {
-  console.log(`${label}: ${formatFactRefs(await provenance.holding())}`);
+  console.log(`${label}: ${formatFactReferences(await provenance.holding())}`);
 }
 
 export async function main(): Promise<void> {
@@ -354,7 +353,7 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/23-provenance-retraction.ts
+++ b/packages/typegraph/examples/23-provenance-retraction.ts
@@ -13,6 +13,13 @@
  * edges, with `history: true` preserving what the graph believed before and
  * after the retraction.
  *
+ * Scenes:
+ *   [1] Derive facts from sources through justifications
+ *   [2] Retract one source — facts survive via alternate support
+ *   [3] Retract the other source — facts lose all support and die
+ *   [4] Un-retract — belief currency returns
+ *   [5] Recorded time keeps the audit trail, even across the un-retract
+ *
  * Run with:
  *   npx tsx examples/23-provenance-retraction.ts
  */
@@ -41,6 +48,11 @@ import { createExampleBackend, requireRecordedNow } from "./_helpers";
 const ScannerSource = defineNode("ScannerSource", {
   schema: z.object({
     title: z.string(),
+    // `retracted` is a hard contract of the retraction capability:
+    // createRetractionCapability requires every source kind's schema to
+    // declare a boolean field with this name (default "retracted",
+    // overridable via `source.retractedField`) and flips it inside
+    // retract()/unRetract(). It is not unused — do not remove it.
     retracted: z.boolean().default(false),
   }),
 });
@@ -48,6 +60,7 @@ const ScannerSource = defineNode("ScannerSource", {
 const VendorSource = defineNode("VendorSource", {
   schema: z.object({
     title: z.string(),
+    // Required by the retraction capability — see ScannerSource above.
     retracted: z.boolean().default(false),
   }),
 });
@@ -98,101 +111,20 @@ const retractionConfig = {
   derives: { kind: "derives" },
 } as const;
 
-type ExampleStore = Awaited<ReturnType<typeof createExampleStore>>;
-type ScannerSourceRef = Node<typeof ScannerSource>;
-type VendorSourceRef = Node<typeof VendorSource>;
-type VulnerabilityRef = Node<typeof Vulnerability>;
-type DeployDecisionRef = Node<typeof DeployDecision>;
-type JustificationRef = Node<typeof Justification>;
-type SourceRef = ScannerSourceRef | VendorSourceRef;
-type PremiseRef = SourceRef | VulnerabilityRef;
-type FactRef = VulnerabilityRef | DeployDecisionRef;
 type SourceKind = "ScannerSource" | "VendorSource";
 type FactKind = "Vulnerability" | "DeployDecision";
-type JustificationKind = "Justification";
+type Premise =
+  | Node<typeof ScannerSource>
+  | Node<typeof VendorSource>
+  | Node<typeof Vulnerability>;
+type Fact = Node<typeof Vulnerability> | Node<typeof DeployDecision>;
 
-async function createExampleStore() {
-  const [store] = await createStoreWithSchema(graph, createExampleBackend(), {
-    history: true,
-  });
-  return store;
-}
-
-async function createScannerSource(
-  store: ExampleStore,
-  id: string,
-  title: string,
-): Promise<ScannerSourceRef> {
-  return store.nodes.ScannerSource.create({ title, retracted: false }, { id });
-}
-
-async function createVendorSource(
-  store: ExampleStore,
-  id: string,
-  title: string,
-): Promise<VendorSourceRef> {
-  return store.nodes.VendorSource.create({ title, retracted: false }, { id });
-}
-
-async function createVulnerability(
-  store: ExampleStore,
-  id: string,
-  cve: string,
-  packageName: string,
-): Promise<VulnerabilityRef> {
-  return store.nodes.Vulnerability.create({ cve, packageName }, { id });
-}
-
-async function createDeployDecision(
-  store: ExampleStore,
-  id: string,
-  action: string,
-): Promise<DeployDecisionRef> {
-  return store.nodes.DeployDecision.create({ action }, { id });
-}
-
-async function createJustification(
-  store: ExampleStore,
-  id: string,
-  text: string,
-  premises: readonly PremiseRef[],
-  fact: FactRef,
-): Promise<JustificationRef> {
-  const justification = await store.nodes.Justification.create(
-    { text },
-    { id },
-  );
-  for (const [index, premise] of premises.entries()) {
-    await store.edges.premiseOf.create(
-      premise,
-      justification,
-      {},
-      {
-        id: `${id}-premise-${index + 1}`,
-      },
-    );
-  }
-  await store.edges.derives.create(
-    justification,
-    fact,
-    {},
-    {
-      id: `${id}-derives-${fact.id}`,
-    },
-  );
-  return justification;
-}
-
-type ExampleReport = RetractionReport<
-  typeof graph,
-  FactKind,
-  JustificationKind
->;
-type ExampleRetractionCapability = RetractionCapability<
+type ExampleReport = RetractionReport<typeof graph, FactKind, "Justification">;
+type ExampleProvenance = RetractionCapability<
   typeof graph,
   SourceKind,
   FactKind,
-  JustificationKind
+  "Justification"
 >;
 
 function formatFactRefs(
@@ -205,135 +137,220 @@ function formatFactRefs(
     .join(", ");
 }
 
-function formatSurvivedVia(entries: ExampleReport["survivedVia"]): string {
-  if (entries.length === 0) return "(none)";
-  return entries
-    .map((entry) => {
-      const via = entry.via.map((justification) => justification.id);
-      return `${entry.fact.id} via ${via.join(" + ")}`;
-    })
-    .toSorted((left, right) => left.localeCompare(right))
-    .join("; ");
-}
-
-function formatDecisionAction(decision: DeployDecisionRef | undefined): string {
-  return decision === undefined ? "not current" : decision.action;
-}
-
 function formatReport(report: ExampleReport): string {
-  const died = formatFactRefs(report.died);
-  const survived = formatSurvivedVia(report.survivedVia);
-  const unaffected = formatFactRefs(report.unaffected);
+  const survived =
+    report.survivedVia.length === 0 ?
+      "(none)"
+    : report.survivedVia
+        .map((entry) => {
+          const via = entry.via.map((justification) => justification.id);
+          return `${entry.fact.id} via ${via.join(" + ")}`;
+        })
+        .toSorted((left, right) => left.localeCompare(right))
+        .join("; ");
   return [
-    `    died:        ${died}`,
+    `    died:        ${formatFactRefs(report.died)}`,
     `    survived:    ${survived}`,
-    `    unaffected:  ${unaffected}`,
+    `    unaffected:  ${formatFactRefs(report.unaffected)}`,
   ].join("\n");
+}
+
+function formatDecisionAction(
+  decision: Node<typeof DeployDecision> | undefined,
+): string {
+  return decision === undefined ? "not current" : decision.action;
 }
 
 async function printHolding(
   label: string,
-  provenance: ExampleRetractionCapability,
+  provenance: ExampleProvenance,
 ): Promise<void> {
   console.log(`${label}: ${formatFactRefs(await provenance.holding())}`);
 }
 
 export async function main(): Promise<void> {
-  const store = await createExampleStore();
+  const backend = createExampleBackend();
+  try {
+    const [store] = await createStoreWithSchema(graph, backend, {
+      history: true,
+    });
 
-  console.log("=".repeat(72));
-  console.log(" Provenance retraction over derived facts");
-  console.log("=".repeat(72));
+    console.log("━".repeat(70));
+    console.log(" Provenance retraction over derived facts");
+    console.log("━".repeat(70));
 
-  const scanner = await createScannerSource(
-    store,
-    "scanner-source",
-    "Unverified scanner finding",
-  );
-  const vendor = await createVendorSource(
-    store,
-    "vendor-source",
-    "Vendor security advisory",
-  );
+    // ----------------------------------------------------------
+    // [1] Derive facts from sources through justifications
+    // ----------------------------------------------------------
 
-  const vulnerable = await createVulnerability(
-    store,
-    "vulnerability-libvector",
-    "CVE-2026-1234",
-    "libvector",
-  );
-  const blockDeploy = await createDeployDecision(
-    store,
-    "decision-block-deploy",
-    "Block the production deploy",
-  );
+    console.log("\n" + "━".repeat(70));
+    console.log(" [1] Derive facts from sources through justifications");
+    console.log("━".repeat(70));
 
-  await createJustification(
-    store,
-    "justification-scanner-finding",
-    "The scanner reported CVE-2026-1234 in libvector",
-    [scanner],
-    vulnerable,
-  );
-  await createJustification(
-    store,
-    "justification-vendor-advisory",
-    "The vendor advisory confirms CVE-2026-1234 in libvector",
-    [vendor],
-    vulnerable,
-  );
-  await createJustification(
-    store,
-    "justification-block-deploy",
-    "The deploy should stop whenever libvector is believed vulnerable",
-    [vulnerable],
-    blockDeploy,
-  );
+    async function createSource(
+      kind: SourceKind,
+      id: string,
+      title: string,
+    ): Promise<Node<typeof ScannerSource> | Node<typeof VendorSource>> {
+      return store.nodes[kind].create({ title, retracted: false }, { id });
+    }
 
-  const provenance = createRetractionCapability(store, retractionConfig);
+    async function createJustification(
+      id: string,
+      text: string,
+      premises: readonly Premise[],
+      fact: Fact,
+    ): Promise<void> {
+      const justification = await store.nodes.Justification.create(
+        { text },
+        { id },
+      );
+      for (const [index, premise] of premises.entries()) {
+        await store.edges.premiseOf.create(premise, justification, {}, {
+          id: `${id}-premise-${index + 1}`,
+        });
+      }
+      await store.edges.derives.create(justification, fact, {}, {
+        id: `${id}-derives-${fact.id}`,
+      });
+    }
 
-  console.log("\nInitial derived beliefs:");
-  await printHolding("  holding()", provenance);
+    const scanner = await createSource(
+      "ScannerSource",
+      "scanner-source",
+      "Unverified scanner finding",
+    );
+    const vendor = await createSource(
+      "VendorSource",
+      "vendor-source",
+      "Vendor security advisory",
+    );
 
-  console.log("\nRetract the unverified scanner source.");
-  const scannerReport = await provenance.retract(scanner);
-  console.log(formatReport(scannerReport));
-  await printHolding("  holding()", provenance);
-  console.log(
-    "  The vulnerability and deploy-block facts survive through the vendor advisory.",
-  );
+    const vulnerable = await store.nodes.Vulnerability.create(
+      { cve: "CVE-2026-1234", packageName: "libvector" },
+      { id: "vulnerability-libvector" },
+    );
+    const blockDeploy = await store.nodes.DeployDecision.create(
+      { action: "Block the production deploy" },
+      { id: "decision-block-deploy" },
+    );
 
-  const beforeVendorRetraction = await requireRecordedNow(store);
+    await createJustification(
+      "justification-scanner-finding",
+      "The scanner reported CVE-2026-1234 in libvector",
+      [scanner],
+      vulnerable,
+    );
+    await createJustification(
+      "justification-vendor-advisory",
+      "The vendor advisory confirms CVE-2026-1234 in libvector",
+      [vendor],
+      vulnerable,
+    );
+    await createJustification(
+      "justification-block-deploy",
+      "The deploy should stop whenever libvector is believed vulnerable",
+      [vulnerable],
+      blockDeploy,
+    );
 
-  console.log("\nRetract the vendor advisory too.");
-  const vendorReport = await provenance.retract(vendor);
-  console.log(formatReport(vendorReport));
-  await printHolding("  holding()", provenance);
+    const provenance = createRetractionCapability(store, retractionConfig);
 
-  const afterVendorRetraction = await requireRecordedNow(store);
-  const before = await store
-    .asOfRecorded(beforeVendorRetraction)
-    .nodes.DeployDecision.getById(blockDeploy.id);
-  const after = await store
-    .asOfRecorded(afterVendorRetraction)
-    .nodes.DeployDecision.getById(blockDeploy.id);
+    console.log("\nInitial derived beliefs:");
+    await printHolding("  holding()", provenance);
 
-  console.log("\nRecorded-time replay of the deploy-block fact:");
-  console.log(`  before vendor retraction: ${formatDecisionAction(before)}`);
-  console.log(`  after vendor retraction:  ${formatDecisionAction(after)}`);
+    // ----------------------------------------------------------
+    // [2] Retract one source — facts survive via alternate support
+    // ----------------------------------------------------------
 
-  console.log("\nUn-retract the scanner source.");
-  const restoreReport = await provenance.unRetract(scanner);
-  console.log(formatReport(restoreReport));
-  await printHolding("  holding()", provenance);
+    console.log("\n" + "━".repeat(70));
+    console.log(" [2] Retract the scanner — alternate support survives");
+    console.log("━".repeat(70));
 
-  console.log("\n" + "=".repeat(72));
-  console.log(
-    " Retraction changes belief currency; recorded time keeps the audit trail.",
-  );
-  console.log("=".repeat(72) + "\n");
+    console.log("\nRetract the unverified scanner source.");
+    const scannerReport = await provenance.retract(scanner);
+    console.log(formatReport(scannerReport));
+    await printHolding("  holding()", provenance);
+    console.log(
+      "  The vulnerability and deploy-block facts survive through the vendor advisory.",
+    );
 
-  await store.close();
+    // Pin the recorded clock while the facts are still believed.
+    const beforeVendorRetraction = await requireRecordedNow(store);
+
+    // ----------------------------------------------------------
+    // [3] Retract the other source — facts lose all support
+    // ----------------------------------------------------------
+
+    console.log("\n" + "━".repeat(70));
+    console.log(" [3] Retract the vendor advisory too — the facts die");
+    console.log("━".repeat(70));
+
+    console.log("\nRetract the vendor advisory.");
+    const vendorReport = await provenance.retract(vendor);
+    console.log(formatReport(vendorReport));
+    await printHolding("  holding()", provenance);
+
+    // Pin the recorded clock inside the interval where the facts are dead.
+    const afterVendorRetraction = await requireRecordedNow(store);
+
+    // ----------------------------------------------------------
+    // [4] Un-retract — belief currency returns
+    // ----------------------------------------------------------
+
+    console.log("\n" + "━".repeat(70));
+    console.log(" [4] Un-retract the scanner — belief currency returns");
+    console.log("━".repeat(70));
+
+    console.log("\nUn-retract the scanner source.");
+    const restoreReport = await provenance.unRetract(scanner);
+    console.log(formatReport(restoreReport));
+    await printHolding("  holding()", provenance);
+
+    // ----------------------------------------------------------
+    // [5] Recorded time keeps the audit trail
+    // ----------------------------------------------------------
+
+    console.log("\n" + "━".repeat(70));
+    console.log(" [5] Recorded time keeps the audit trail");
+    console.log("━".repeat(70));
+
+    const liveDecision = await store.nodes.DeployDecision.getById(
+      blockDeploy.id,
+    );
+    const decisionBeforeVendorRetraction = await store
+      .asOfRecorded(beforeVendorRetraction)
+      .nodes.DeployDecision.getById(blockDeploy.id);
+    const decisionAfterVendorRetraction = await store
+      .asOfRecorded(afterVendorRetraction)
+      .nodes.DeployDecision.getById(blockDeploy.id);
+
+    console.log("\nThe deploy-block fact, read at three moments:");
+    console.log(
+      `  live (after the un-retract):      ${formatDecisionAction(liveDecision)}`,
+    );
+    console.log(
+      `  pinned before vendor retraction:  ${formatDecisionAction(decisionBeforeVendorRetraction)}`,
+    );
+    console.log(
+      `  pinned after vendor retraction:   ${formatDecisionAction(decisionAfterVendorRetraction)}`,
+    );
+    console.log(
+      "\n  The un-retract restored the fact's currency, but the recorded pin",
+    );
+    console.log(
+      "  taken while it was dead still reads as not current — the dead",
+    );
+    console.log("  interval stays replayable; history is never rewritten.");
+
+    console.log("\n" + "━".repeat(70));
+    console.log(
+      " Retraction changes belief currency; recorded time keeps the audit trail.",
+    );
+    console.log("━".repeat(70) + "\n");
+  } finally {
+    await backend.close();
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/typegraph/examples/24-bulk-writes.ts
+++ b/packages/typegraph/examples/24-bulk-writes.ts
@@ -1,0 +1,318 @@
+/**
+ * Example 24: Bulk Writes — Recurring Catalog Sync
+ *
+ * Node and edge collections expose four bulk write operations, each a single
+ * transactional call instead of N round-trips:
+ *
+ * - `bulkCreate(items)` — multi-row INSERT, returns the created nodes/edges
+ *   in input order. Every item is Zod-validated up front.
+ * - `bulkInsert(items)` — the dedicated fast path: same validated multi-row
+ *   INSERT but returns nothing (no RETURNING clause, no result allocation).
+ *   Prefer it for maximum-throughput ingestion when you don't need results.
+ * - `bulkUpsertById(items)` — batched create-or-update keyed by ID. Existence
+ *   is checked with one batched read; missing IDs are created (version 1),
+ *   existing IDs are updated (version bumps). Returns results in input order.
+ * - `bulkDelete(ids)` — batched soft delete. IDs that don't exist (or are
+ *   already deleted) are silently ignored, so it is safe to re-run.
+ *
+ * Shared semantics worth knowing:
+ * - Each call is all-or-nothing: bad items (schema violations, ID conflicts)
+ *   fail the whole call and nothing is written, demonstrated in Part 5.
+ * - Per-item operation hooks are intentionally skipped for throughput.
+ * - PostgreSQL's 65,535 bind-parameter limit is handled internally — pass
+ *   arrays of any size and TypeGraph chunks the INSERTs for you.
+ *
+ * The scenario is a recurring product-feed sync: an initial bulk load, a
+ * nightly wave of changed rows, then pruning products that left the feed.
+ * Example 17 (`bulkFindByIndex`) is the read-side companion: batched
+ * candidate lookup for reconciling incoming rows that lack stable IDs.
+ *
+ * Run with:
+ *   npx tsx examples/24-bulk-writes.ts
+ */
+import { z } from "zod";
+
+import { createStore, defineEdge, defineGraph, defineNode } from "@nicia-ai/typegraph";
+import { createExampleBackend } from "./_helpers";
+
+// ============================================================
+// Schema Definition
+// ============================================================
+
+const Product = defineNode("Product", {
+  schema: z.object({
+    sku: z.string(),
+    name: z.string(),
+    price: z.number().positive(),
+  }),
+});
+
+const Category = defineNode("Category", {
+  schema: z.object({ name: z.string() }),
+});
+
+const inCategory = defineEdge("inCategory", {
+  schema: z.object({}),
+});
+
+const graph = defineGraph({
+  id: "catalog_sync",
+  nodes: {
+    // cascade: pruning a product soft-deletes its inCategory edges too.
+    Product: { type: Product, onDelete: "cascade" },
+    Category: { type: Category },
+  },
+  edges: {
+    inCategory: { type: inCategory, from: [Product], to: [Category] },
+  },
+});
+
+// ============================================================
+// Feed Data
+// ============================================================
+
+// The vendor feed keys rows by SKU. Deriving the node ID from the SKU is
+// what makes bulkUpsertById an idempotent sync primitive: re-processing a
+// feed row always lands on the same node.
+function productIdForSku(sku: string): string {
+  return `product:${sku}`;
+}
+
+function categoryIdForSlug(slug: string): string {
+  return `category:${slug}`;
+}
+
+type FeedRow = Readonly<{ sku: string; name: string; price: number; category: string }>;
+
+const INITIAL_FEED: readonly FeedRow[] = [
+  { sku: "CLM-001", name: "Crash Pad", price: 189, category: "climbing" },
+  { sku: "CLM-002", name: "Chalk Bag", price: 19, category: "climbing" },
+  { sku: "CLM-003", name: "Quickdraw Set", price: 120, category: "climbing" },
+  { sku: "FTW-101", name: "Approach Shoe", price: 139, category: "footwear" },
+  { sku: "FTW-102", name: "Trail Sandal", price: 75, category: "footwear" },
+  { sku: "FTW-103", name: "Winter Boot", price: 210, category: "footwear" },
+];
+
+// The nightly delta: two price changes and two brand-new products.
+const CHANGED_ROWS_FEED: readonly FeedRow[] = [
+  { sku: "CLM-001", name: "Crash Pad", price: 179, category: "climbing" },
+  { sku: "FTW-101", name: "Approach Shoe", price: 149, category: "footwear" },
+  { sku: "CLM-004", name: "Belay Device", price: 34, category: "climbing" },
+  { sku: "FTW-104", name: "Trail Runner", price: 129, category: "footwear" },
+];
+
+// The feed's full manifest of currently-sold SKUs. FTW-102 and FTW-103
+// are gone, so the prune step must remove them.
+const CURRENT_SKU_MANIFEST: ReadonlySet<string> = new Set([
+  "CLM-001",
+  "CLM-002",
+  "CLM-003",
+  "CLM-004",
+  "FTW-101",
+  "FTW-104",
+]);
+
+const TIMING_ROW_COUNT = 500;
+
+function divider(title: string): void {
+  console.log(`\n=== ${title} ===\n`);
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+export async function main(): Promise<void> {
+  console.log("=== Bulk Writes — Recurring Catalog Sync ===");
+
+  const backend = createExampleBackend();
+  const store = createStore(graph, backend);
+
+  try {
+    // ============================================================
+    // Part 1: Initial load — bulkCreate for nodes and edges
+    // ============================================================
+
+    divider("Part 1: Initial load (bulkCreate)");
+
+    const categorySlugs = [...new Set(INITIAL_FEED.map((row) => row.category))];
+    const categories = await store.nodes.Category.bulkCreate(
+      categorySlugs.map((slug) => ({ id: categoryIdForSlug(slug), props: { name: slug } })),
+    );
+
+    const initialProducts = await store.nodes.Product.bulkCreate(
+      INITIAL_FEED.map((row) => ({
+        id: productIdForSku(row.sku),
+        props: { sku: row.sku, name: row.name, price: row.price },
+      })),
+    );
+
+    const initialEdges = await store.edges.inCategory.bulkCreate(
+      INITIAL_FEED.map((row) => ({
+        from: { kind: "Product", id: productIdForSku(row.sku) },
+        to: { kind: "Category", id: categoryIdForSlug(row.category) },
+      })),
+    );
+
+    console.log(`Created ${categories.length} categories, ${initialProducts.length} products,`);
+    console.log(`and ${initialEdges.length} inCategory edges — 3 bulk calls, not 14 row-by-row writes.`);
+    console.log("Results come back in input order with all metadata populated:");
+    for (const product of initialProducts.slice(0, 2)) {
+      console.log(`  ${product.sku}  ${product.name.padEnd(14)} $${String(product.price).padEnd(4)} v${product.meta.version}`);
+    }
+    console.log("  ...");
+
+    // ============================================================
+    // Part 2: Nightly wave — bulkUpsertById (create-or-update by ID)
+    // ============================================================
+
+    divider("Part 2: Nightly changed-rows feed (bulkUpsertById)");
+
+    console.log("Each row lands by ID: existing IDs are updated, new IDs are created.");
+    console.log("`meta.version` makes the outcome observable — 1 = created, >1 = updated.\n");
+
+    const upserted = await store.nodes.Product.bulkUpsertById(
+      CHANGED_ROWS_FEED.map((row) => ({
+        id: productIdForSku(row.sku),
+        props: { sku: row.sku, name: row.name, price: row.price },
+      })),
+    );
+
+    let createdCount = 0;
+    let updatedCount = 0;
+    for (const product of upserted) {
+      const outcome = product.meta.version === 1 ? "CREATED" : `UPDATED (v${product.meta.version})`;
+      if (product.meta.version === 1) createdCount += 1;
+      else updatedCount += 1;
+      console.log(`  ${product.sku}  ${product.name.padEnd(14)} $${String(product.price).padEnd(4)} → ${outcome}`);
+    }
+    console.log(`\nWave result: ${createdCount} created, ${updatedCount} updated.`);
+
+    // New products still need their category edges.
+    const newProducts = upserted.filter((product) => product.meta.version === 1);
+    await store.edges.inCategory.bulkCreate(
+      CHANGED_ROWS_FEED.filter((row) => newProducts.some((p) => p.sku === row.sku)).map((row) => ({
+        from: { kind: "Product", id: productIdForSku(row.sku) },
+        to: { kind: "Category", id: categoryIdForSlug(row.category) },
+      })),
+    );
+
+    // ============================================================
+    // Part 3: Prune — bulkDelete products that left the feed
+    // ============================================================
+
+    divider("Part 3: Prune departed SKUs (bulkDelete)");
+
+    const allProducts = await store.nodes.Product.find();
+    const staleIds = allProducts
+      .filter((product) => !CURRENT_SKU_MANIFEST.has(product.sku))
+      .map((product) => product.id);
+
+    const productsBefore = await store.nodes.Product.count();
+    const edgesBefore = await store.edges.inCategory.count();
+
+    await store.nodes.Product.bulkDelete(staleIds);
+
+    const productsAfter = await store.nodes.Product.count();
+    const edgesAfter = await store.edges.inCategory.count();
+
+    console.log(`Manifest diff found ${staleIds.length} stale products: ${staleIds.join(", ")}`);
+    console.log(`Products: ${productsBefore} → ${productsAfter} (soft-deleted, recoverable via temporal reads)`);
+    console.log(`Edges:    ${edgesBefore} → ${edgesAfter} (onDelete: "cascade" removed their inCategory edges)`);
+
+    // bulkDelete silently ignores missing/already-deleted IDs, so re-running
+    // the prune is a no-op — safe for at-least-once sync jobs.
+    await store.nodes.Product.bulkDelete(staleIds);
+    console.log(`Re-running the same prune: still ${await store.nodes.Product.count()} products (idempotent).`);
+
+    // ============================================================
+    // Part 4: Throughput — per-row loop vs bulkCreate vs bulkInsert
+    // ============================================================
+
+    divider(`Part 4: Throughput over ${TIMING_ROW_COUNT} rows`);
+
+    console.log("Per-row create() pays per-item transaction and hook overhead. The bulk");
+    console.log("APIs validate every item, then issue one multi-row INSERT per chunk.");
+    console.log("Absolute times vary by machine — the ordering is the point.\n");
+
+    function timingRows(prefix: string): { id: string; props: z.input<typeof Product.schema> }[] {
+      return Array.from({ length: TIMING_ROW_COUNT }, (_, index) => ({
+        id: productIdForSku(`${prefix}-${index}`),
+        props: { sku: `${prefix}-${index}`, name: `Bulk Item ${index}`, price: 10 + index },
+      }));
+    }
+
+    const loopStart = performance.now();
+    for (const row of timingRows("LOOP")) {
+      await store.nodes.Product.create(row.props, { id: row.id });
+    }
+    const loopMs = performance.now() - loopStart;
+
+    const bulkCreateStart = performance.now();
+    await store.nodes.Product.bulkCreate(timingRows("BULKC"));
+    const bulkCreateMs = performance.now() - bulkCreateStart;
+
+    const bulkInsertStart = performance.now();
+    await store.nodes.Product.bulkInsert(timingRows("BULKI"));
+    const bulkInsertMs = performance.now() - bulkInsertStart;
+
+    console.log(`  per-row create() loop : ${loopMs.toFixed(1).padStart(7)} ms`);
+    console.log(`  bulkCreate (returns)  : ${bulkCreateMs.toFixed(1).padStart(7)} ms  (${(loopMs / bulkCreateMs).toFixed(1)}x faster on this run)`);
+    console.log(`  bulkInsert (void)     : ${bulkInsertMs.toFixed(1).padStart(7)} ms  (${(loopMs / bulkInsertMs).toFixed(1)}x faster on this run)`);
+
+    // ============================================================
+    // Part 5: Atomicity — one bad item aborts the whole batch
+    // ============================================================
+
+    divider("Part 5: Atomicity on failure");
+
+    console.log("A bad item — here an ID collision with an existing product — fails the");
+    console.log("whole call. Nothing is written, not even the valid rows before it.\n");
+
+    const countBeforeFailure = await store.nodes.Product.count();
+    try {
+      await store.nodes.Product.bulkInsert([
+        { id: productIdForSku("ATOMIC-1"), props: { sku: "ATOMIC-1", name: "Valid Row", price: 1 } },
+        { id: productIdForSku("CLM-001"), props: { sku: "CLM-001", name: "Collision", price: 2 } },
+      ]);
+    } catch (error) {
+      console.log(`  bulkInsert threw: ${error instanceof Error ? `${error.constructor.name}: ${error.message}` : String(error)}`);
+    }
+    const countAfterFailure = await store.nodes.Product.count();
+    const leakedRows = await store
+      .query()
+      .from("Product", "p")
+      .whereNode("p", (p) => p.sku.eq("ATOMIC-1"))
+      .select((ctx) => ({ id: ctx.p.id }))
+      .execute();
+    console.log(`  Product count unchanged: ${countBeforeFailure} → ${countAfterFailure}.`);
+    console.log(`  The valid first row was not written either: ${leakedRows.length === 0 ? "correct" : "LEAKED"}.`);
+
+    // ============================================================
+    // Summary
+    // ============================================================
+
+    divider("Summary");
+
+    console.log("  1. bulkCreate: validated multi-row INSERT, results in input order.");
+    console.log("  2. bulkUpsertById: idempotent create-or-update keyed by stable IDs;");
+    console.log("     meta.version distinguishes created (1) from updated (>1).");
+    console.log("  3. bulkDelete: batched soft delete; missing IDs ignored, cascades");
+    console.log("     per the node's onDelete behavior, safe to re-run.");
+    console.log("  4. bulkInsert: the void-returning fast path for pure ingestion.");
+    console.log("  5. Each call is all-or-nothing: a bad item means nothing is written.");
+    console.log("\nFor feeds without stable IDs, reconcile first with bulkFindByIndex");
+    console.log("(example 17), then route rows to bulkCreate or bulkUpsertById.");
+  } finally {
+    await backend.close();
+  }
+
+  console.log("\n=== Example Complete ===");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/24-bulk-writes.ts
+++ b/packages/typegraph/examples/24-bulk-writes.ts
@@ -30,9 +30,9 @@
  * Run with:
  *   npx tsx examples/24-bulk-writes.ts
  */
+import { createStore, defineEdge, defineGraph, defineNode } from "@nicia-ai/typegraph";
 import { z } from "zod";
 
-import { createStore, defineEdge, defineGraph, defineNode } from "@nicia-ai/typegraph";
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -311,7 +311,7 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/25-transactions.ts
+++ b/packages/typegraph/examples/25-transactions.ts
@@ -1,0 +1,280 @@
+/**
+ * Example 25: Transactions — Atomic Multi-Write Operations
+ *
+ * `store.transaction(async (tx) => { ... })` runs a callback in which every
+ * write either commits together or rolls back together. The callback receives
+ * a transaction context with the same collection API as the store —
+ * `tx.nodes.<Kind>` and `tx.edges.<name>` — plus `tx.sql`, the raw Drizzle
+ * handle bound to the same transaction for the caller's own relational
+ * tables. The callback's return value becomes the return value of
+ * `store.transaction()`.
+ *
+ * The motivating scenario: placing an order must write an Order node,
+ * decrement the inventory it draws from, AND link the two with a `fulfills`
+ * edge. Any one of those without the others corrupts the books — atomicity
+ * is the point, not a nicety.
+ *
+ * This example demonstrates:
+ * - a successful transaction and its returned value
+ * - full rollback when the callback throws mid-way
+ * - the partial state the same failure leaves behind WITHOUT a transaction
+ * - the fail-loud guard against using the root `store` inside the callback
+ * - `store.withTransaction(externalTx)` for joining a caller-owned transaction
+ *
+ * Run with:
+ *   npx tsx examples/25-transactions.ts
+ */
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+
+import {
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+import { createExampleBackend } from "./_helpers";
+
+// ============================================================
+// Schema Definition
+// ============================================================
+
+const InventoryItem = defineNode("InventoryItem", {
+  schema: z.object({
+    sku: z.string(),
+    onHand: z.number().int(),
+  }),
+});
+
+const Order = defineNode("Order", {
+  schema: z.object({
+    sku: z.string(),
+    quantity: z.number().int(),
+  }),
+});
+
+// The invariant: every committed Order is fulfilled from inventory.
+const fulfills = defineEdge("fulfills", {
+  schema: z.object({ quantity: z.number().int() }),
+});
+
+const graph = defineGraph({
+  id: "order_fulfillment",
+  nodes: {
+    InventoryItem: { type: InventoryItem },
+    Order: { type: Order },
+  },
+  edges: {
+    fulfills: { type: fulfills, from: [InventoryItem], to: [Order] },
+  },
+});
+
+// ============================================================
+// Demonstrate Transactions
+// ============================================================
+
+export async function main() {
+  const backend = createExampleBackend();
+  const store = createStore(graph, backend);
+
+  try {
+    console.log("=== Transactions (store.transaction) ===\n");
+
+    const widget = await store.nodes.InventoryItem.create({
+      sku: "WIDGET",
+      onHand: 10,
+    });
+    console.log(`Seeded inventory: ${widget.sku} onHand=${widget.onHand}\n`);
+
+    // ============================================================
+    // 1. A successful transaction — three writes, one commit
+    // ============================================================
+
+    console.log("=== 1. Successful transaction ===\n");
+
+    // The callback's return value propagates out of store.transaction().
+    const order = await store.transaction(async (tx) => {
+      const created = await tx.nodes.Order.create({
+        sku: "WIDGET",
+        quantity: 3,
+      });
+      await tx.nodes.InventoryItem.update(widget.id, {
+        sku: "WIDGET",
+        onHand: 10 - 3,
+      });
+      await tx.edges.fulfills.create(widget, created, { quantity: 3 });
+
+      // Reads through `tx` observe the still-uncommitted writes.
+      const uncommitted = await tx.nodes.Order.find();
+      console.log(
+        `  inside tx: order visible to tx reads (count=${uncommitted.length})`,
+      );
+      return created;
+    });
+
+    const onHandAfterCommit = (
+      await store.nodes.InventoryItem.getById(widget.id)
+    )?.onHand;
+    const edgesAfterCommit = await store.edges.fulfills.findFrom(widget);
+    console.log(`  committed: order ${order.id} (quantity=${order.quantity})`);
+    console.log(
+      `  committed: onHand=${onHandAfterCommit}, fulfills edges=${edgesAfterCommit.length}\n`,
+    );
+
+    // ============================================================
+    // 2. A failing transaction — thrown error rolls EVERYTHING back
+    // ============================================================
+
+    console.log("=== 2. Failing transaction rolls back completely ===\n");
+
+    // Write the order AND the inventory decrement first, then discover the
+    // stock went negative — exactly the mid-flight failure that would
+    // otherwise strand partial writes.
+    try {
+      await store.transaction(async (tx) => {
+        const doomed = await tx.nodes.Order.create({
+          sku: "WIDGET",
+          quantity: 50,
+        });
+        const remaining = 7 - 50;
+        await tx.nodes.InventoryItem.update(widget.id, {
+          sku: "WIDGET",
+          onHand: remaining,
+        });
+        await tx.edges.fulfills.create(widget, doomed, { quantity: 50 });
+        console.log(
+          "  inside tx: 3 writes applied, about to fail the stock check...",
+        );
+        if (remaining < 0)
+          throw new Error(`insufficient stock: onHand would be ${remaining}`);
+      });
+    } catch (error) {
+      console.log(`  caught: ${(error as Error).message}`);
+    }
+
+    const orders = await store.nodes.Order.find();
+    const onHandAfterRollback = (
+      await store.nodes.InventoryItem.getById(widget.id)
+    )?.onHand;
+    const edgesAfterRollback = await store.edges.fulfills.findFrom(widget);
+    console.log(
+      `  rolled back: order count still ${orders.length} (the doomed order is gone)`,
+    );
+    console.log(
+      `  rolled back: onHand still ${onHandAfterRollback} (decrement undone)`,
+    );
+    console.log(
+      `  rolled back: fulfills edges still ${edgesAfterRollback.length}\n`,
+    );
+
+    // ============================================================
+    // 3. The same failure WITHOUT a transaction strands partial state
+    // ============================================================
+
+    console.log("=== 3. Without a transaction: partial writes survive ===\n");
+
+    try {
+      const orphan = await store.nodes.Order.create({
+        sku: "WIDGET",
+        quantity: 50,
+      });
+      const remaining = 7 - 50;
+      if (remaining < 0)
+        throw new Error(
+          `insufficient stock for order ${orphan.id}: onHand would be ${remaining}`,
+        );
+      await store.nodes.InventoryItem.update(widget.id, {
+        sku: "WIDGET",
+        onHand: remaining,
+      });
+    } catch (error) {
+      console.log(`  caught: ${(error as Error).message}`);
+    }
+
+    const strandedOrders = await store.nodes.Order.find();
+    const unfulfilled =
+      strandedOrders.length -
+      (await store.edges.fulfills.findFrom(widget)).length;
+    console.log(
+      `  stranded: order count is now ${strandedOrders.length} — ${unfulfilled} order has NO fulfills edge`,
+    );
+    console.log(
+      "  the invariant is broken; cleanup is now the caller's problem.",
+    );
+
+    // Repair the books before moving on.
+    const orphaned = strandedOrders.filter(
+      (candidate) => candidate.quantity === 50,
+    );
+    for (const stranded of orphaned) {
+      await store.nodes.Order.delete(stranded.id);
+    }
+    console.log(`  cleaned up ${orphaned.length} orphaned order manually\n`);
+
+    // ============================================================
+    // 4. Inside the callback, use `tx` — never the root `store`
+    // ============================================================
+
+    console.log("=== 4. The root store is guarded inside a transaction ===\n");
+
+    // The transaction holds the SQLite backend's serialized execution slot,
+    // so awaiting a root-store operation (including a nested
+    // store.transaction()) inside the callback would deadlock. TypeGraph
+    // detects this and fails loudly instead of hanging.
+    try {
+      await store.transaction(async () => {
+        await store.nodes.Order.find(); // WRONG: root store, not tx.nodes
+      });
+    } catch (error) {
+      console.log(`  guarded: ${(error as Error).message.split(":")[0]}\n`);
+    }
+
+    // ============================================================
+    // 5. Adopting a caller-owned transaction (store.withTransaction)
+    // ============================================================
+
+    console.log(
+      "=== 5. Joining an external transaction (withTransaction) ===\n",
+    );
+
+    // When the relational layer owns the transaction, `store.withTransaction`
+    // enlists graph writes on the caller's connection instead of opening its
+    // own. The synchronous better-sqlite3 driver cannot run an async Drizzle
+    // transaction callback, so the caller drives BEGIN/COMMIT/ROLLBACK
+    // explicitly. (History-enabled stores use `store.withRecordedTransaction`.)
+    const { backend: externalBackend, db } = createLocalSqliteBackend();
+    try {
+      const externalStore = createStore(graph, externalBackend);
+
+      db.run(sql`BEGIN`);
+      const txStore = externalStore.withTransaction(db);
+      const adopted = await txStore.nodes.Order.create({
+        sku: "WIDGET",
+        quantity: 1,
+      });
+      db.run(sql`ROLLBACK`); // the CALLER decides — and rolls back
+
+      const visible = await externalStore.nodes.Order.getById(adopted.id);
+      console.log(
+        `  caller rolled back: adopted graph write persisted? ${visible !== undefined}`,
+      );
+      console.log(
+        "  the caller's COMMIT/ROLLBACK is the single boundary for both layers.\n",
+      );
+    } finally {
+      await externalBackend.close();
+    }
+
+    console.log("=== Transactions example complete ===");
+  } finally {
+    await backend.close();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/25-transactions.ts
+++ b/packages/typegraph/examples/25-transactions.ts
@@ -24,9 +24,6 @@
  * Run with:
  *   npx tsx examples/25-transactions.ts
  */
-import { sql } from "drizzle-orm";
-import { z } from "zod";
-
 import {
   createStore,
   defineEdge,
@@ -34,6 +31,9 @@ import {
   defineNode,
 } from "@nicia-ai/typegraph";
 import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -113,9 +113,10 @@ export async function main() {
       return created;
     });
 
-    const onHandAfterCommit = (
-      await store.nodes.InventoryItem.getById(widget.id)
-    )?.onHand;
+    const widgetAfterCommit = await store.nodes.InventoryItem.getById(
+      widget.id,
+    );
+    const onHandAfterCommit = widgetAfterCommit?.onHand;
     const edgesAfterCommit = await store.edges.fulfills.findFrom(widget);
     console.log(`  committed: order ${order.id} (quantity=${order.quantity})`);
     console.log(
@@ -154,9 +155,10 @@ export async function main() {
     }
 
     const orders = await store.nodes.Order.find();
-    const onHandAfterRollback = (
-      await store.nodes.InventoryItem.getById(widget.id)
-    )?.onHand;
+    const widgetAfterRollback = await store.nodes.InventoryItem.getById(
+      widget.id,
+    );
+    const onHandAfterRollback = widgetAfterRollback?.onHand;
     const edgesAfterRollback = await store.edges.fulfills.findFrom(widget);
     console.log(
       `  rolled back: order count still ${orders.length} (the doomed order is gone)`,
@@ -193,9 +195,8 @@ export async function main() {
     }
 
     const strandedOrders = await store.nodes.Order.find();
-    const unfulfilled =
-      strandedOrders.length -
-      (await store.edges.fulfills.findFrom(widget)).length;
+    const fulfilledEdges = await store.edges.fulfills.findFrom(widget);
+    const unfulfilled = strandedOrders.length - fulfilledEdges.length;
     console.log(
       `  stranded: order count is now ${strandedOrders.length} — ${unfulfilled} order has NO fulfills edge`,
     );
@@ -273,7 +274,7 @@ export async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/26-store-views.ts
+++ b/packages/typegraph/examples/26-store-views.ts
@@ -1,0 +1,373 @@
+/**
+ * Example 26: Store Views — read lenses over one graph
+ *
+ * The same graph answers different questions for different callers:
+ *
+ *   • the APP shows what is live right now            → current mode
+ *   • the AUDIT screen shows soft-deleted rows too    → includeTombstones
+ *   • the HISTORY panel shows assignments that ended  → includeEnded
+ *   • the REPORT job needs one consistent instant     → store.snapshot()
+ *   • the REVIEW tool asks "who held this in April?"  → store.asOf(T)
+ *
+ * A `StoreView` (from `store.view({ mode, asOf })`, `store.asOf(T)`, or
+ * `store.snapshot()`) pins one temporal coordinate and routes every read
+ * through it — collections, `query()`, `subgraph()`, graph algorithms,
+ * and edge endpoint reads. It is read-only by construction: writes stay
+ * on the live `Store`.
+ *
+ * Examples 20–23 cover the bitemporal pins themselves (asOf ×
+ * asOfRecorded). This example owns the LENS surface: the view modes,
+ * the snapshot idiom, pinned edge reads, introspection, and the
+ * read-only refusal contract. Valid-time lenses need no `history: true`.
+ *
+ * Scenes:
+ *   [1] current vs includeTombstones — the app vs the moderation screen
+ *   [2] includeEnded — assignments that ended are history, not garbage
+ *   [3] asOf lens — pinned edge reads answer "who held this in April?"
+ *   [4] snapshot() — a report job reads many collections at one instant
+ *   [5] read-only by construction — the exact refusal errors
+ *
+ * Run with:
+ *   npx tsx examples/26-store-views.ts
+ */
+import { z } from "zod";
+
+import {
+  ConfigurationError,
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { createExampleBackend } from "./_helpers";
+
+// ============================================================
+// Schema — a small content workspace
+// ============================================================
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Document = defineNode("Document", {
+  schema: z.object({ title: z.string() }),
+});
+
+const assignedTo = defineEdge("assignedTo", {
+  schema: z.object({ role: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "store_views_example",
+  nodes: {
+    Person: { type: Person },
+    Document: { type: Document },
+  },
+  edges: {
+    assignedTo: { type: assignedTo, from: [Document], to: [Person] },
+  },
+});
+
+// ============================================================
+// Time helpers
+// ============================================================
+
+/**
+ * Canonical fixed-width UTC ISO-8601 (what every temporal API requires),
+ * anchored relative to "now" so the example works whenever it is run.
+ */
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * Valid-time comparisons are inclusive on `validFrom` (`validFrom <= asOf`),
+ * so a write landing in the same millisecond as a snapshot would still be
+ * visible to it. A few milliseconds of separation keeps the "snapshot first,
+ * write after" ordering unambiguous.
+ */
+function pause(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+const WORKSPACE_FOUNDED = daysAgo(180);
+const MAYA_TOOK_THE_FAQ = daysAgo(120);
+const APRIL_REVIEW_INSTANT = daysAgo(90);
+const MAYA_HANDED_OFF = daysAgo(30);
+
+function banner(title: string): void {
+  console.log("\n" + "━".repeat(70));
+  console.log(` ${title}`);
+  console.log("━".repeat(70));
+}
+
+function printRefusal(label: string, error: unknown): void {
+  if (!(error instanceof ConfigurationError)) throw error;
+  console.log(`  ${label}`);
+  console.log(`    name:         ${error.name}`);
+  console.log(`    details.code: ${String(error.details.code)}`);
+  console.log(`    message:      ${error.message.split(". ")[0]}.`);
+}
+
+export async function main(): Promise<void> {
+  const backend = createExampleBackend();
+  const [store] = await createStoreWithSchema(graph, backend);
+
+  try {
+    console.log("━".repeat(70));
+    console.log(" Store Views — one graph, many read lenses");
+    console.log("━".repeat(70));
+
+    // Seed: two people, three documents, two assignments. Validity starts
+    // are explicit: a create WITHOUT `validFrom` stores NULL, which reads
+    // as "valid since forever" and would show up at every asOf pin. Give
+    // rows real activation instants when you plan to time-travel.
+    const maya = await store.nodes.Person.create({ name: "Maya" });
+    const rafael = await store.nodes.Person.create({ name: "Rafael" });
+    const personName = new Map<string, string>([
+      [maya.id, "Maya"],
+      [rafael.id, "Rafael"],
+    ]);
+
+    const faq = await store.nodes.Document.create(
+      { title: "Launch FAQ" },
+      { validFrom: WORKSPACE_FOUNDED },
+    );
+    const pricing = await store.nodes.Document.create(
+      { title: "Pricing Page" },
+      { validFrom: WORKSPACE_FOUNDED },
+    );
+    const onboarding = await store.nodes.Document.create(
+      { title: "Old Onboarding Guide" },
+      { validFrom: WORKSPACE_FOUNDED },
+    );
+
+    const faqMaya = await store.edges.assignedTo.create(
+      faq,
+      maya,
+      { role: "editor" },
+      { validFrom: MAYA_TOOK_THE_FAQ },
+    );
+    const pricingRafael = await store.edges.assignedTo.create(
+      pricing,
+      rafael,
+      { role: "reviewer" },
+      { validFrom: MAYA_TOOK_THE_FAQ },
+    );
+
+    // ----------------------------------------------------------
+    // [1] current vs includeTombstones — app vs moderation screen
+    // ----------------------------------------------------------
+
+    banner(" [1] current vs includeTombstones — what did we soft-delete?");
+
+    await store.nodes.Document.delete(onboarding.id); // soft delete
+
+    const liveTitles = (await store.nodes.Document.find())
+      .map((document) => document.title)
+      .toSorted((a, b) => a.localeCompare(b));
+    console.log(`\n  App (live store, current mode): ${liveTitles.join(", ")}`);
+
+    // A `current` view is the same lens the live store reads through.
+    const appView = store.view({ mode: "current" });
+    console.log(
+      `  view({ mode: "current" }) agrees:  ${await appView.nodes.Document.count()} documents ` +
+        `(live: ${await store.nodes.Document.count()})`,
+    );
+
+    const moderation = store.view({ mode: "includeTombstones" });
+    const everything = (await moderation.nodes.Document.find())
+      .map((document) => document.title)
+      .toSorted((a, b) => a.localeCompare(b));
+    const ghost = await moderation.nodes.Document.getById(onboarding.id);
+    console.log(`\n  Moderation (includeTombstones): ${everything.join(", ")}`);
+    console.log(
+      `  Tombstone: "${ghost?.title}" deletedAt=${String(ghost?.meta.deletedAt)}`,
+    );
+
+    // ----------------------------------------------------------
+    // [2] includeEnded — ended assignments are history, not garbage
+    // ----------------------------------------------------------
+    //
+    // "Ended" is valid-time vocabulary: the edge's validity window has a
+    // `validTo` that has passed. Maya hands the FAQ to Rafael — we END her
+    // assignment (update with validTo) rather than delete it.
+
+    banner(" [2] includeEnded — assignments that ended");
+
+    await store.edges.assignedTo.update(
+      faqMaya.id,
+      { role: "editor" },
+      { validTo: MAYA_HANDED_OFF },
+    );
+    await store.edges.assignedTo.create(
+      faq,
+      rafael,
+      { role: "editor" },
+      { validFrom: MAYA_HANDED_OFF },
+    );
+
+    const faqNow = await store.edges.assignedTo.findFrom(faq);
+    console.log(
+      `\n  Live store — "Launch FAQ" assignees now: ` +
+        faqNow.map((edge) => personName.get(edge.toId)).join(", "),
+    );
+
+    const historyPanel = store.view({ mode: "includeEnded" });
+    const faqEver = await historyPanel.edges.assignedTo.findFrom(faq);
+    console.log(`  includeEnded — every assignment the FAQ ever had:`);
+    for (const edge of faqEver) {
+      const window = `${edge.meta.validFrom?.slice(0, 10) ?? "always"} → ${edge.meta.validTo?.slice(0, 10) ?? "open"}`;
+      console.log(
+        `    ${personName.get(edge.toId)?.padEnd(7)} (${edge.role})  valid ${window}`,
+      );
+    }
+    console.log(
+      "\n  includeEnded keeps ended validity windows but still hides",
+    );
+    console.log("  soft-deletes — only includeTombstones shows those.");
+
+    // ----------------------------------------------------------
+    // [3] asOf lens — pinned edge reads
+    // ----------------------------------------------------------
+
+    banner(' [3] asOf lens — "who held the Launch FAQ in April?"');
+
+    const aprilReview = store.asOf(APRIL_REVIEW_INSTANT);
+
+    // Views are introspectable: the pinned coordinate is on the view.
+    console.log(`\n  Lens coordinates (mode / asOf):`);
+    console.log(`    appView:     ${appView.mode} / ${String(appView.asOf)}`);
+    console.log(
+      `    moderation:  ${moderation.mode} / ${String(moderation.asOf)}`,
+    );
+    console.log(`    aprilReview: ${aprilReview.mode} / ${aprilReview.asOf}`);
+
+    const faqThen = await aprilReview.edges.assignedTo.findFrom(faq);
+    console.log(
+      `\n  findFrom(faq) at the pin:  ` +
+        faqThen
+          .map((edge) => `${personName.get(edge.toId)} (${edge.role})`)
+          .join(", "),
+    );
+
+    const mayaThen = await aprilReview.edges.assignedTo.findByEndpoints(
+      faq,
+      maya,
+    );
+    const mayaNow = await store.edges.assignedTo.findByEndpoints(faq, maya);
+    console.log(
+      `  findByEndpoints(faq, maya): pinned=${mayaThen === undefined ? "not found" : "found"}, ` +
+        `live=${mayaNow === undefined ? "not found" : "found"}`,
+    );
+    const toMayaThen = await aprilReview.edges.assignedTo.findTo(maya);
+    console.log(`  findTo(maya) at the pin:    ${toMayaThen.length} edge(s)`);
+
+    // Honest caveat: soft-deletes are hidden on every mode except
+    // includeTombstones — even at a past pin where the row was alive.
+    console.log(
+      `\n  Documents at the pin: ${await aprilReview.nodes.Document.count()} ` +
+        `— the soft-deleted guide stays hidden even in the past.`,
+    );
+
+    // ----------------------------------------------------------
+    // [4] snapshot() — the report job's consistent instant
+    // ----------------------------------------------------------
+    //
+    // `store.snapshot()` pins ONE instant at construction (sugar for
+    // store.asOf(now)). Every read on it observes that same instant, so a
+    // job reading many collections cannot tear across concurrent writes.
+
+    banner(" [4] snapshot() — frozen instant while the live store moves on");
+
+    await pause(5);
+    const report = store.snapshot();
+    await pause(5);
+    console.log(`\n  Snapshot pinned: mode=${report.mode} asOf=${report.asOf}`);
+
+    // The workspace keeps changing AFTER the snapshot was taken. The new
+    // document gets an explicit validFrom of "now" — omitting it would
+    // store NULL ("valid since forever") and leak into the snapshot.
+    await store.nodes.Document.create(
+      { title: "Q3 Roadmap" },
+      { validFrom: new Date().toISOString() },
+    );
+    await store.edges.assignedTo.update(
+      pricingRafael.id,
+      { role: "reviewer" },
+      { validTo: new Date().toISOString() }, // ended just now
+    );
+
+    const reportTitles = (await report.nodes.Document.find())
+      .map((document) => document.title)
+      .toSorted((a, b) => a.localeCompare(b));
+    console.log(`\n  ${"".padEnd(24)}snapshot view        live store`);
+    console.log(
+      `  documents:              ${String(reportTitles.length).padEnd(21)}` +
+        `${await store.nodes.Document.count()}`,
+    );
+    console.log(
+      `  open assignments:       ${String(await report.edges.assignedTo.count()).padEnd(21)}` +
+        `${await store.edges.assignedTo.count()}`,
+    );
+    console.log(`\n  Snapshot document list: ${reportTitles.join(", ")}`);
+    console.log('  The post-snapshot "Q3 Roadmap" and the just-ended pricing');
+    console.log(
+      "  assignment moved the live numbers; the report's did not budge.",
+    );
+
+    // ----------------------------------------------------------
+    // [5] Read-only by construction
+    // ----------------------------------------------------------
+    //
+    // The view's TypeScript surface omits writes entirely (calling
+    // `report.nodes.Document.create` is a compile error). The runtime
+    // enforces the same contract for untyped callers: reaching a write
+    // through a cast gets a typed refusal, not a silent no-op.
+
+    banner(" [5] Read-only by construction — the refusal contract");
+    console.log();
+
+    const untypedWriter = report.nodes.Document as unknown as Readonly<{
+      create: (props: unknown) => Promise<unknown>;
+    }>;
+    try {
+      await untypedWriter.create({ title: "Backdated Doc" });
+    } catch (error) {
+      printRefusal("Write through a view:", error);
+    }
+
+    // Search is refused on any non-current pin: the fulltext / vector
+    // index reflects current state only, so a pinned search would lie.
+    try {
+      await aprilReview.search.fulltext("Document", {
+        query: "roadmap",
+        limit: 5,
+      });
+    } catch (error) {
+      console.log();
+      printRefusal("Search on a temporal pin:", error);
+    }
+
+    banner(" Summary");
+    console.log(`
+  store.view({ mode: "current" })            the app's lens (≡ live reads)
+  store.view({ mode: "includeTombstones" })  moderation / audit lens
+  store.view({ mode: "includeEnded" })       history lens (ended validity)
+  store.asOf(T)                              the graph as valid at T
+  store.snapshot()                           one consistent instant, many reads
+
+  Every lens is read-only by construction, introspectable via
+  view.mode / view.asOf, and pins collections, query(), subgraph(),
+  graph algorithms, and edge endpoint reads all at once.`);
+  } finally {
+    await backend.close();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/typegraph/examples/26-store-views.ts
+++ b/packages/typegraph/examples/26-store-views.ts
@@ -30,8 +30,6 @@
  * Run with:
  *   npx tsx examples/26-store-views.ts
  */
-import { z } from "zod";
-
 import {
   ConfigurationError,
   createStoreWithSchema,
@@ -39,6 +37,8 @@ import {
   defineGraph,
   defineNode,
 } from "@nicia-ai/typegraph";
+import { z } from "zod";
+
 import { createExampleBackend } from "./_helpers";
 
 // ============================================================
@@ -163,7 +163,8 @@ export async function main(): Promise<void> {
 
     await store.nodes.Document.delete(onboarding.id); // soft delete
 
-    const liveTitles = (await store.nodes.Document.find())
+    const liveDocuments = await store.nodes.Document.find();
+    const liveTitles = liveDocuments
       .map((document) => document.title)
       .toSorted((a, b) => a.localeCompare(b));
     console.log(`\n  App (live store, current mode): ${liveTitles.join(", ")}`);
@@ -176,7 +177,8 @@ export async function main(): Promise<void> {
     );
 
     const moderation = store.view({ mode: "includeTombstones" });
-    const everything = (await moderation.nodes.Document.find())
+    const moderationDocuments = await moderation.nodes.Document.find();
+    const everything = moderationDocuments
       .map((document) => document.title)
       .toSorted((a, b) => a.localeCompare(b));
     const ghost = await moderation.nodes.Document.getById(onboarding.id);
@@ -298,7 +300,8 @@ export async function main(): Promise<void> {
       { validTo: new Date().toISOString() }, // ended just now
     );
 
-    const reportTitles = (await report.nodes.Document.find())
+    const reportDocuments = await report.nodes.Document.find();
+    const reportTitles = reportDocuments
       .map((document) => document.title)
       .toSorted((a, b) => a.localeCompare(b));
     console.log(`\n  ${"".padEnd(24)}snapshot view        live store`);
@@ -366,7 +369,7 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     console.error(error);
     process.exit(1);
   });

--- a/packages/typegraph/examples/README.md
+++ b/packages/typegraph/examples/README.md
@@ -27,11 +27,11 @@ npx tsx examples/<example-name>.ts
 
 | Example | Description |
 |---------|-------------|
-| [03-subclass-hierarchy.ts](./03-subclass-hierarchy.ts) | Type inheritance with `subClassOf` |
+| [03-subclass-hierarchy.ts](./03-subclass-hierarchy.ts) | Type hierarchies with `subClassOf`: shared base schemas, polymorphic edge endpoints, `includeSubClasses` query expansion (and what it excludes), and registry introspection |
 | [04-disjoint-constraints.ts](./04-disjoint-constraints.ts) | Mutual exclusion with `disjointWith` |
 | [05-edge-implications.ts](./05-edge-implications.ts) | Edge hierarchies with `implies` |
 | [06-inverse-edges.ts](./06-inverse-edges.ts) | Bidirectional relationships with `inverseOf` |
-| [08-custom-ontology.ts](./08-custom-ontology.ts) | Advanced ontology features and meta-edges |
+| [08-custom-ontology.ts](./08-custom-ontology.ts) | The core meta-edges working together (`broader`, `equivalentTo`, `disjointWith`, `partOf`, `inverseOf`, `implies`) plus custom `metaEdge()` relations — persisted, introspectable, and serialized, with custom semantics interpreted by your application |
 
 ### Data Management
 
@@ -43,14 +43,17 @@ npx tsx examples/<example-name>.ts
 | [17-bulk-find-by-index.ts](./17-bulk-find-by-index.ts) | Batched candidate lookup by declared index for import reconciliation and dedup, with null-safe matching and `limitPerInput` |
 | [18-fhir-graph-merge.ts](./18-fhir-graph-merge.ts) | Branch and merge overlapping FHIR-style records into a canonical patient care graph with conflict and provenance reporting |
 | [19-incremental-merge.ts](./19-incremental-merge.ts) | Incrementally ingest a new source into a live graph with `mergeIncremental()` — recall an already-committed entity by its unique key (no duplicate), flag the conflict, and persist queryable provenance |
+| [24-bulk-writes.ts](./24-bulk-writes.ts) | High-throughput sync with `bulkCreate`, `bulkInsert`, `bulkUpsertById`, and `bulkDelete` — created-vs-updated tracking, atomic failure semantics, and a per-row-loop timing comparison |
+| [25-transactions.ts](./25-transactions.ts) | Atomic multi-write operations with `store.transaction()`: commit-or-rollback guarantees, rollback proof, and joining a caller-owned transaction via `withTransaction()` |
 
-### Time Travel & Bitemporal
+### Time Travel, Views & Bitemporal
 
 | Example | Description |
 |---------|-------------|
 | [20-bitemporal-time-travel.ts](./20-bitemporal-time-travel.ts) | Valid time (`store.asOf`) + recorded time (`store.asOfRecorded`, `history: true`): corrections, effective dating, and the bitemporal 2×2 — what TypeGraph captured as true at a recorded instant |
 | [21-agent-decision-replay.ts](./21-agent-decision-replay.ts) | Reconstruct the exact knowledge graph an AI agent saw at decision time and replay the *same* `query()` / `degree()` over it — point-in-time-correct reasoning for audit, eval, and debugging |
-| [22-breach-forensics.ts](./22-breach-forensics.ts) | Bitemporal + graph: pin an access graph to the breach instant and run `reachable()` to recover the true blast radius — including the over-permissive edge that was deleted afterward |
+| [22-breach-forensics.ts](./22-breach-forensics.ts) | Bitemporal + graph: valid-time-windowed grants (`validFrom`/`validTo`), composed pins (`store.asOf(breachAt).asOfRecorded(alertAnchor)`), `reachable()` for the true blast radius, and a pinned `shortestPath()` that names the attack path incident response later deleted |
+| [26-store-views.ts](./26-store-views.ts) | Read lenses over one graph: view modes (current / includeTombstones / includeEnded), asOf-pinned edge reads, consistent snapshots, and the read-only refusal contract |
 
 ### Provenance & Retraction
 
@@ -58,11 +61,11 @@ npx tsx examples/<example-name>.ts
 |---------|-------------|
 | [23-provenance-retraction.ts](./23-provenance-retraction.ts) | Retract bad scanner/vendor sources, keep facts with alternate support, close unsupported terminal facts, and replay the before/after belief state with recorded time |
 
-Docs walkthroughs:
+Docs walkthroughs for the temporal examples (20–23):
 [Bitemporal Time Travel](https://typegraph.dev/examples/bitemporal-time-travel)
 · [Agent Decision Replay](https://typegraph.dev/examples/agent-decision-replay)
-· [Provenance Retraction](https://typegraph.dev/examples/provenance-retraction)
 · [Breach Forensics](https://typegraph.dev/examples/breach-forensics)
+· [Provenance Retraction](https://typegraph.dev/examples/provenance-retraction)
 
 ### Backend Configuration
 
@@ -81,7 +84,7 @@ the only diff from example 10 is the import line and connection setup.
 | Example | Description |
 |---------|-------------|
 | [11-semantic-search.ts](./11-semantic-search.ts) | Vector embeddings and similarity search |
-| [12-knowledge-graph-rag.ts](./12-knowledge-graph-rag.ts) | Knowledge graph patterns for RAG applications |
+| [12-knowledge-graph-rag.ts](./12-knowledge-graph-rag.ts) | What graph structure adds to RAG beyond vector similarity: entity linking, multi-hop traversal, context window expansion via chunk chains, and hybrid vector + graph retrieval |
 | [14-research-copilot.ts](./14-research-copilot.ts) | End-to-end showcase: semantic search + ontology-expanded topics + all five Tier 1 graph algorithms over a citation graph |
 | [15-fulltext-hybrid-search.ts](./15-fulltext-hybrid-search.ts) | BM25 fulltext + hybrid (vector + fulltext) retrieval with RRF, query modes, and index rebuild |
 
@@ -150,14 +153,18 @@ Each example follows a consistent pattern:
 4. Understand data lifecycle with **07-delete-behaviors**
 5. Learn efficient data access with **09-pagination-streaming**
 6. Learn aggregate queries with **13-aggregates**
-7. Reconcile imports and find dedup candidates with **17-bulk-find-by-index**
-8. Merge independently edited graph branches with **18-fhir-graph-merge**, then
+7. Make multi-write invariants atomic with **25-transactions**
+8. Move high-volume ingestion to **24-bulk-writes**, and reconcile imports
+   and find dedup candidates with **17-bulk-find-by-index**
+9. Merge independently edited graph branches with **18-fhir-graph-merge**, then
    ingest into a live graph in waves with **19-incremental-merge**
-9. For production, see **10-postgresql** for backend configuration
-10. For AI/ML applications, see **11-semantic-search** and **12-knowledge-graph-rag**
-11. For end-to-end application demos, see **14-research-copilot**
-12. For time travel and bitemporal history, start with **20-bitemporal-time-travel**,
+10. For production, see **10-postgresql** for backend configuration
+11. For AI/ML applications, see **11-semantic-search** and **12-knowledge-graph-rag**
+12. For end-to-end application demos, see **14-research-copilot**
+13. For read lenses over one graph — view modes, pinned reads, consistent
+    snapshots — see **26-store-views**
+14. For time travel and bitemporal history, start with **20-bitemporal-time-travel**,
     then see **21-agent-decision-replay** (reconstruct what an agent saw) and
     **22-breach-forensics** (bitemporal reachability)
-13. For source lineage and belief transitions, run
+15. For source lineage and belief transitions, run
     **23-provenance-retraction**

--- a/packages/typegraph/examples/_helpers.ts
+++ b/packages/typegraph/examples/_helpers.ts
@@ -64,16 +64,16 @@ function tokenize(text: string): string[] {
 
 /** Deterministic FNV-1a hash, so a given word always maps to the same dimension. */
 function hashWord(word: string): number {
-  let hash = 2166136261;
+  let hash = 2_166_136_261;
   for (let index = 0; index < word.length; index += 1) {
-    hash ^= word.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
+    hash ^= word.codePointAt(index) ?? 0;
+    hash = Math.imul(hash, 16_777_619);
   }
   return hash >>> 0;
 }
 
 export function mockTextEmbedding(text: string, dimensions: number): number[] {
-  const vector = new Array<number>(dimensions).fill(0);
+  const vector = Array.from({ length: dimensions }, () => 0);
   for (const token of tokenize(text)) {
     const dimension = hashWord(token) % dimensions;
     vector[dimension] = (vector[dimension] ?? 0) + 1;
@@ -98,9 +98,9 @@ export function cosineSimilarity(
   let dotProduct = 0;
   let magnitudeA = 0;
   let magnitudeB = 0;
-  for (let index = 0; index < a.length; index += 1) {
-    dotProduct += (a[index] ?? 0) * (b[index] ?? 0);
-    magnitudeA += (a[index] ?? 0) ** 2;
+  for (const [index, element] of a.entries()) {
+    dotProduct += element * (b[index] ?? 0);
+    magnitudeA += element ** 2;
     magnitudeB += (b[index] ?? 0) ** 2;
   }
   return dotProduct / (Math.sqrt(magnitudeA) * Math.sqrt(magnitudeB));

--- a/packages/typegraph/examples/_helpers.ts
+++ b/packages/typegraph/examples/_helpers.ts
@@ -1,10 +1,15 @@
 /**
  * Shared helpers for examples
  *
- * Provides an easy way to create an in-memory SQLite database
- * for running examples with full query support.
+ * - `createExampleBackend()` — an in-memory SQLite backend with full query
+ *   support (FTS5 fulltext plus sqlite-vec vector search).
+ * - `mockTextEmbedding()` / `cosineSimilarity()` — a deterministic,
+ *   dependency-free stand-in for a real embedding model, used by the
+ *   vector-search examples.
+ * - `requireRecordedNow()` — asserts a store has recorded history and returns
+ *   its current recorded timestamp, for the time-travel examples.
  */
-import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
 
 /**
  * Creates an in-memory SQLite backend for examples.
@@ -15,13 +20,103 @@ export function createExampleBackend() {
   return backend;
 }
 
+// ============================================================
+// Mock embeddings
+// ============================================================
+
+/**
+ * Deterministic mock embedding via the bag-of-words "hashing trick": each
+ * content word is hashed to one dimension and accumulated, then the vector is
+ * unit-normalized. Texts that share vocabulary land on overlapping dimensions
+ * and score high; texts with disjoint vocabulary are near-orthogonal and score
+ * near zero — so cosine similarity tracks vocabulary overlap the way a real
+ * model does, only far more crudely (no synonyms or paraphrase). In production
+ * you would call an actual embedding model (OpenAI, Sentence Transformers, ...).
+ */
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "that",
+  "this",
+  "into",
+  "from",
+  "are",
+  "was",
+  "can",
+  "its",
+  "but",
+  "not",
+  "all",
+  "any",
+  "has",
+  "have",
+  "will",
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/u)
+    .filter((token) => token.length > 2 && !STOPWORDS.has(token));
+}
+
+/** Deterministic FNV-1a hash, so a given word always maps to the same dimension. */
+function hashWord(word: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < word.length; index += 1) {
+    hash ^= word.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function mockTextEmbedding(text: string, dimensions: number): number[] {
+  const vector = new Array<number>(dimensions).fill(0);
+  for (const token of tokenize(text)) {
+    const dimension = hashWord(token) % dimensions;
+    vector[dimension] = (vector[dimension] ?? 0) + 1;
+  }
+  const magnitude = Math.sqrt(
+    vector.reduce((sum, value) => sum + value * value, 0),
+  );
+  // Stopword-only / empty text has no signal — return a fixed unit vector so the
+  // result is still a valid (non-zero) embedding.
+  if (magnitude === 0) {
+    vector[0] = 1;
+    return vector;
+  }
+  return vector.map((value) => value / magnitude);
+}
+
+/** Computes cosine similarity between two vectors. */
+export function cosineSimilarity(
+  a: readonly number[],
+  b: readonly number[],
+): number {
+  let dotProduct = 0;
+  let magnitudeA = 0;
+  let magnitudeB = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    dotProduct += (a[index] ?? 0) * (b[index] ?? 0);
+    magnitudeA += (a[index] ?? 0) ** 2;
+    magnitudeB += (b[index] ?? 0) ** 2;
+  }
+  return dotProduct / (Math.sqrt(magnitudeA) * Math.sqrt(magnitudeB));
+}
+
+// ============================================================
+// Recorded history
+// ============================================================
+
 type RecordedClock<Instant extends string> = Readonly<{
   recordedNow: () => Promise<Instant | undefined>;
 }>;
 
 export async function requireRecordedNow<Instant extends string>(
   store: RecordedClock<Instant>,
-  message = "expected recorded history",
+  message = "expected recorded history — create the store with { history: true } and commit at least one write first",
 ): Promise<Instant> {
   const recordedNow = await store.recordedNow();
   if (recordedNow === undefined) throw new Error(message);


### PR DESCRIPTION
A full review of all 23 runnable examples (every file executed and checked against `src/`), followed by three phases of strengthening. Every example was verified by running it after each change; the suite is now 26 examples, all passing (SQLite + the Postgres example against a live DB).

### 1. Defect fixes

- **10-postgresql crashed on every run** — cleanup deleted nodes before their edges despite its own "edges first" comment (`RestrictedDeleteError`); also replaced the brittle split-on-`;` migration execution with one batched query.
- **05** — "Who does Alice know?" queries were unbound and matched every Person (output listed Alice knowing herself).
- **06** — never demonstrated `inverseOf`: it used the `direction: "in"` workaround that works *without* the ontology. Now traverses the derived `reportsTo` edge.
- **12** — stored both edge directions while claiming `inverseOf` requires it; inverse expansion made traversals return duplicate rows (masked by `[0]` indexing). Runner also swallowed failures (exit 0 on error).
- **13** — "Top 2 authors" was `limit(2)` with no ordering and cut the actual top author.
- Smaller: 01 (constraint payoff shown), 02 (rethrow + structured issue output), 15 (unneeded cast), 16 (wrong step label, `void db` hack).

### 2. Rewrites

- **08 custom ontology** — the headline custom meta-edges were commented out *since the initial commit* (referencing variables that never existed). Now registers `prerequisiteOf`/`supersedes` for real, delivers the promised broader/narrower hierarchy, fixes the is-a vs part-of modeling error, and verifies every printed claim with runtime assertions.
- **22 breach forensics** — claimed "bitemporal" but only used the recorded axis. Grants now carry validity windows, the forensic question uses the composed `asOf().asOfRecorded()` pin, a scene proves axis independence, and a pinned `shortestPath` prints the escalation chain through the later-deleted edge.
- **19 incremental merge** — the fork-point was empty, so the header's "inherited edits" promise never executed. Now seeded and demonstrated, with both sides of each conflict printed.
- **18 FHIR merge** — prints the actual resolution clusters (canonical/members/branch origins), typed `block` config, endpoint-constrained edges.
- **03 subclass hierarchy** — teaches the two-layer endpoint story: runtime validation subsumes (`to: [Media]` works) but `subClassOf` is type-erased, so the enumerated list is what powers static typing. Explicit instead of silently enumerating.
- **14 / 23** — stale comments fixed, the 1+N+N×M `neighbors()` fan-out replaced with one traversal query, "ontology" terminology disambiguated; 23's scaffolding halved and its audit-trail claim now proven (dead interval reads not-current at its recorded pin after `unRetract`).
- **Mock embeddings consolidated** — 11's content-tracking hashing-trick embedding moved to `_helpers` and used everywhere; previously 12 and 15 used sin-based noise whose vector output contradicted their own narratives (12's leadership query missed the CEO chunk; 15's vector ranks were meaningless). Both now demonstrably work. `_helpers` also imports the public subpath instead of reaching into `src/`.

### 3. New examples + suite hygiene

- **24-bulk-writes** — catalog sync with `bulkCreate`/`bulkInsert`/`bulkUpsertById`/`bulkDelete`, created-vs-updated via `meta.version`, atomic-failure proof, honest timing comparison.
- **25-transactions** — commit/rollback proof, the fail-loud deadlock guard on root-store calls inside the callback, `withTransaction` enlistment.
- **26-store-views** — the read-lens surface: view modes, asOf-pinned edge reads, `snapshot()`, the typed read-only refusal, view introspection.
- **ESLint now lints `examples/`** — the blanket ignore is how dead code accumulated. One principled override (`unicorn/prefer-top-level-await` conflicts with the import-guarded runner idiom); 169 violations fixed for real, including Zod 4 deprecations.
- Conventions unified across all 26 files (guarded runner, try/finally cleanup); README refreshed (new rows, stale rows rewritten, learning path updated).

## Coordination note

~~#231 (aggregate `orderBy`) also touches example 13.~~ **Resolved:** #231 has merged and this branch has merged main — example 13 now demonstrates native `.orderBy("bookCount", "desc").orderBy("author").limit(2)` (including chained-key tiebreak ordering) instead of the interim JS-sort workaround.

## Related issues

Filed from the review: #228 (aggregate `orderBy`), #229 (NodeId brand lost in projections — bit examples 06/21/22), #230 (`RestrictedDeleteError.details` untyped).

Library findings surfaced during the rewrites, candidates for follow-up issues:
- `implies()` accepts endpoint-violating implications and `expand: "implying"` actually traverses the mismatched edges (probed in the 08 rewrite; the example now documents the pitfall).
- A create without `validFrom` stores NULL, which reads as "valid since forever" and passes every `asOf` filter (hit while writing 26).
- Custom meta-edges get zero built-in inference (declarative vocabulary only) — fine by design, but underdocumented.
- `subClassOf` type erasure forces enumerated edge endpoints for static typing (documented in 03).

