### PR TITLE
fix(errors): give every fixed-shape TypeGraphError subclass typed details

### DIFF
--- a/.changeset/typed-error-details.md
+++ b/.changeset/typed-error-details.md
@@ -1,0 +1,23 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Every `TypeGraphError` subclass with a fixed-shape `details` payload now
+declares a narrowed `readonly details` type (e.g.
+`RestrictedDeleteError.details` is `RestrictedDeleteErrorDetails`, not the
+base class's `Readonly<Record<string, unknown>>`), so reading structured
+fields like `error.details.edgeCount` no longer requires a cast. The new
+`XxxErrorDetails` types (`NodeNotFoundErrorDetails`,
+`EdgeNotFoundErrorDetails`, `KindNotFoundErrorDetails`,
+`NodeConstraintNotFoundErrorDetails`, `NodeIndexNotFoundErrorDetails`,
+`EndpointNotFoundErrorDetails`, `EndpointErrorDetails`,
+`UniquenessErrorDetails`, `CardinalityErrorDetails`, `DisjointErrorDetails`,
+`RestrictedDeleteErrorDetails`, `VersionConflictErrorDetails`,
+`SchemaMismatchErrorDetails`, `MigrationErrorDetails`,
+`EagerMaterializationErrorDetails`, `StaleVersionErrorDetails`,
+`SchemaContentConflictErrorDetails`, `StoreNotInitializedErrorDetails`,
+`DatabaseOperationErrorDetails`, `EmbeddingDimensionChangedErrorDetails`) are
+exported from the package root alongside the existing
+`ValidationErrorDetails`. Classes with intentionally open, per-call-site
+details (`ConfigurationError`, `UnsupportedPredicateError`,
+`CompilerInvariantError`, `BackendDisposedError`) are unchanged.

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -135,7 +135,7 @@ try {
   if (error instanceof DisjointError) {
     console.log(error.category); // "constraint"
     console.log(error.details);
-    // { existingType: "Person", attemptedType: "Organization" }
+    // { nodeId: "entity-1", attemptedKind: "Organization", conflictingKind: "Person" }
     console.log(error.suggestion);
     // "Use a different ID for the new node, or delete the existing node first..."
   }
@@ -172,7 +172,8 @@ try {
 } catch (error) {
   if (error instanceof CardinalityError) {
     console.log(error.category); // "constraint"
-    console.log(error.details); // { edge: "worksAt", cardinality: "one" }
+    console.log(error.details);
+    // { edgeKind: "worksAt", fromKind: "Person", fromId: "<alice-id>", cardinality: "one", existingCount: 1 }
     console.log(error.suggestion);
     // "Remove the existing edge before creating a new one, or update the existing edge..."
   }
@@ -192,7 +193,8 @@ try {
 } catch (error) {
   if (error instanceof UniquenessError) {
     console.log(error.category); // "constraint"
-    console.log(error.details); // { field: "email", value: "alice@example.com" }
+    console.log(error.details);
+    // { constraintName: "unique_email", kind: "Person", existingId: "<alice-id>", newId: "<bob-id>", fields: ["email"] }
     console.log(error.suggestion);
     // "Use a different value for the unique field, or update the existing record..."
   }
@@ -211,7 +213,7 @@ try {
 } catch (error) {
   if (error instanceof NodeNotFoundError) {
     console.log(error.category); // "user"
-    console.log(error.details); // { id: "nonexistent-id", type: "Person" }
+    console.log(error.details); // { kind: "Person", id: "nonexistent-id" }
     console.log(error.suggestion);
     // "Verify the node ID is correct and the node hasn't been deleted..."
   }
@@ -228,7 +230,7 @@ try {
 } catch (error) {
   if (error instanceof EdgeNotFoundError) {
     console.log(error.category); // "user"
-    console.log(error.details); // { id: "nonexistent-edge" }
+    console.log(error.details); // { kind: "worksAt", id: "nonexistent-edge" }
     console.log(error.suggestion);
     // "Verify the edge ID is correct and the edge hasn't been deleted..."
   }
@@ -245,7 +247,7 @@ try {
 } catch (error) {
   if (error instanceof KindNotFoundError) {
     console.log(error.category); // "user"
-    console.log(error.details); // { kind: "NonExistentType" }
+    console.log(error.details); // { kindName: "NonExistentType", entity: "node" }
     console.log(error.suggestion);
     // "Check the graph definition to see which node and edge types are available..."
   }
@@ -266,7 +268,8 @@ try {
 } catch (error) {
   if (error instanceof EndpointNotFoundError) {
     console.log(error.category); // "user"
-    console.log(error.details); // { kind: "Person", id: "nonexistent" }
+    console.log(error.details);
+    // { edgeKind: "worksAt", endpoint: "from", nodeKind: "Person", nodeId: "nonexistent" }
     console.log(error.suggestion);
     // "Create the referenced node first, or verify the node ID is correct..."
   }
@@ -286,7 +289,8 @@ try {
 } catch (error) {
   if (error instanceof RestrictedDeleteError) {
     console.log(error.category); // "constraint"
-    console.log(error.details); // { nodeId: "...", edgeCount: 3 }
+    console.log(error.details);
+    // { nodeKind: "Person", nodeId: "<alice-id>", edgeCount: 3, edgeKinds: ["worksAt", "authored"] }
     console.log(error.suggestion);
     // "Delete all edges connected to this node first, or change the delete behavior..."
   }
@@ -324,7 +328,8 @@ try {
 } catch (error) {
   if (error instanceof SchemaMismatchError) {
     console.log(error.category); // "system"
-    console.log(error.details); // { expected: "...", actual: "..." }
+    console.log(error.details);
+    // { graphId: "my-graph", expectedHash: "<hash>", actualHash: "<hash>" }
     console.log(error.suggestion);
     // "Run migrations to update the database schema..."
   }
@@ -341,8 +346,8 @@ try {
 } catch (error) {
   if (error instanceof MigrationError) {
     console.log(error.category); // "system"
-    console.log(error.details.breakingChanges);
-    // ["Removed required field 'email' from Person"]
+    console.log(error.details);
+    // { graphId: "my-graph", fromVersion: 3, toVersion: 4, reason: "Removed required field 'email' from Person" }
     console.log(error.suggestion);
     // "Review the breaking changes and perform manual migration if needed..."
   }
@@ -528,7 +533,7 @@ try {
 | `DISJOINT_ERROR` | `DisjointError` | constraint | Disjointness constraint violated |
 | `ENDPOINT_ERROR` | `EndpointError` | user | Invalid edge endpoint types |
 | `CARDINALITY_ERROR` | `CardinalityError` | constraint | Cardinality constraint violated |
-| `UNIQUENESS_ERROR` | `UniquenessError` | constraint | Uniqueness constraint violated |
+| `UNIQUENESS_VIOLATION` | `UniquenessError` | constraint | Uniqueness constraint violated |
 | `NODE_NOT_FOUND` | `NodeNotFoundError` | user | Referenced node doesn't exist |
 | `EDGE_NOT_FOUND` | `EdgeNotFoundError` | user | Referenced edge doesn't exist |
 | `KIND_NOT_FOUND` | `KindNotFoundError` | user | Unknown node/edge type |

--- a/packages/typegraph/examples/07-delete-behaviors.ts
+++ b/packages/typegraph/examples/07-delete-behaviors.ts
@@ -167,9 +167,8 @@ export async function main() {
     if (error instanceof RestrictedDeleteError) {
       console.log("Deletion BLOCKED!");
       console.log(`  Reason: ${error.message}`);
-      const details = error.details as { edgeCount: number; edgeKinds: string[] };
-      console.log(`  Connected edges: ${details.edgeCount}`);
-      console.log(`  Edge kinds: [${details.edgeKinds.join(", ")}]`);
+      console.log(`  Connected edges: ${error.details.edgeCount}`);
+      console.log(`  Edge kinds: [${error.details.edgeKinds.join(", ")}]`);
     } else {
       throw error;
     }

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -966,11 +966,17 @@ export class StoreNotInitializedError extends TypeGraphError {
 
   // `graphId`/`reason` are positional and required: both are
   // load-bearing for the message and for programmatic handling via
-  // `details.reason`. Caller `details` merge on top.
+  // `details.reason`. Caller `details` merge underneath — spread first
+  // so `graphId`/`reason` win and can't be clobbered by an
+  // accidentally-colliding extra key.
   constructor(
     graphId: string,
     reason: StoreNotInitializedReason,
-    options?: { cause?: unknown; details?: Record<string, unknown> },
+    options?: {
+      cause?: unknown;
+      details?: Readonly<Record<string, unknown>> &
+        Readonly<{ graphId?: never; reason?: never }>;
+    },
   ) {
     super(
       `fulltext storage for graph "${graphId}" ${STORE_NOT_INITIALIZED_REASON_PHRASE[reason]}. ` +
@@ -978,7 +984,7 @@ export class StoreNotInitializedError extends TypeGraphError {
         `outside request handlers and adopted transactions, before using createStore().`,
       "STORE_NOT_INITIALIZED",
       {
-        details: { graphId, reason, ...options?.details },
+        details: { ...options?.details, graphId, reason },
         category: "user",
         suggestion:
           "Call createStoreWithSchema(graph, backend) once at application " +

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -232,6 +232,14 @@ export class ValidationError extends TypeGraphError {
 // ============================================================
 
 /**
+ * Details for NodeNotFoundError.
+ */
+export type NodeNotFoundErrorDetails = Readonly<{
+  kind: string;
+  id: string;
+}>;
+
+/**
  * Thrown when a node is not found.
  *
  * @example
@@ -246,6 +254,8 @@ export class ValidationError extends TypeGraphError {
  * ```
  */
 export class NodeNotFoundError extends TypeGraphError {
+  declare readonly details: NodeNotFoundErrorDetails;
+
   constructor(kind: string, id: string, options?: { cause?: unknown }) {
     super(`Node not found: ${kind}/${id}`, "NODE_NOT_FOUND", {
       details: { kind, id },
@@ -258,9 +268,19 @@ export class NodeNotFoundError extends TypeGraphError {
 }
 
 /**
+ * Details for EdgeNotFoundError.
+ */
+export type EdgeNotFoundErrorDetails = Readonly<{
+  kind: string;
+  id: string;
+}>;
+
+/**
  * Thrown when an edge is not found.
  */
 export class EdgeNotFoundError extends TypeGraphError {
+  declare readonly details: EdgeNotFoundErrorDetails;
+
   constructor(kind: string, id: string, options?: { cause?: unknown }) {
     super(`Edge not found: ${kind}/${id}`, "EDGE_NOT_FOUND", {
       details: { kind, id },
@@ -273,6 +293,15 @@ export class EdgeNotFoundError extends TypeGraphError {
 }
 
 /**
+ * Details for KindNotFoundError.
+ */
+export type KindNotFoundErrorDetails = Readonly<{
+  kindName: string;
+  entity: KindEntity;
+  graphId?: string;
+}>;
+
+/**
  * Thrown when an operation references a kind that isn't registered on
  * the graph — `getNodeCollectionOrThrow` against an unknown kind, a
  * `materializeIndexes({ kinds })` filter naming a missing kind, an
@@ -282,6 +311,7 @@ export class EdgeNotFoundError extends TypeGraphError {
  * process.
  */
 export class KindNotFoundError extends TypeGraphError {
+  declare readonly details: KindNotFoundErrorDetails;
   readonly kindName: string;
   readonly entity: KindEntity;
 
@@ -321,9 +351,19 @@ export class KindNotFoundError extends TypeGraphError {
 }
 
 /**
+ * Details for NodeConstraintNotFoundError.
+ */
+export type NodeConstraintNotFoundErrorDetails = Readonly<{
+  constraintName: string;
+  kind: string;
+}>;
+
+/**
  * Thrown when a uniqueness constraint name is not found on a node kind.
  */
 export class NodeConstraintNotFoundError extends TypeGraphError {
+  declare readonly details: NodeConstraintNotFoundErrorDetails;
+
   constructor(
     constraintName: string,
     kind: string,
@@ -344,9 +384,19 @@ export class NodeConstraintNotFoundError extends TypeGraphError {
 }
 
 /**
+ * Details for NodeIndexNotFoundError.
+ */
+export type NodeIndexNotFoundErrorDetails = Readonly<{
+  indexName: string;
+  kind: string;
+}>;
+
+/**
  * Thrown when a declared node index name is not found on a node kind.
  */
 export class NodeIndexNotFoundError extends TypeGraphError {
+  declare readonly details: NodeIndexNotFoundErrorDetails;
+
   constructor(indexName: string, kind: string, options?: { cause?: unknown }) {
     super(
       `Index not found: "${indexName}" on node kind "${kind}"`,
@@ -367,16 +417,23 @@ export class NodeIndexNotFoundError extends TypeGraphError {
 // ============================================================
 
 /**
+ * Details for EndpointNotFoundError.
+ */
+export type EndpointNotFoundErrorDetails = Readonly<{
+  edgeKind: string;
+  endpoint: "from" | "to";
+  nodeKind: string;
+  nodeId: string;
+}>;
+
+/**
  * Thrown when edge endpoint node does not exist or is deleted.
  */
 export class EndpointNotFoundError extends TypeGraphError {
+  declare readonly details: EndpointNotFoundErrorDetails;
+
   constructor(
-    details: Readonly<{
-      edgeKind: string;
-      endpoint: "from" | "to";
-      nodeKind: string;
-      nodeId: string;
-    }>,
+    details: EndpointNotFoundErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(
@@ -394,18 +451,22 @@ export class EndpointNotFoundError extends TypeGraphError {
 }
 
 /**
+ * Details for EndpointError.
+ */
+export type EndpointErrorDetails = Readonly<{
+  edgeKind: string;
+  endpoint: "from" | "to";
+  actualKind: string;
+  expectedKinds: readonly string[];
+}>;
+
+/**
  * Thrown when edge endpoint has wrong node type.
  */
 export class EndpointError extends TypeGraphError {
-  constructor(
-    details: Readonly<{
-      edgeKind: string;
-      endpoint: "from" | "to";
-      actualKind: string;
-      expectedKinds: readonly string[];
-    }>,
-    options?: { cause?: unknown },
-  ) {
+  declare readonly details: EndpointErrorDetails;
+
+  constructor(details: EndpointErrorDetails, options?: { cause?: unknown }) {
     const expected = details.expectedKinds.join(" | ");
     super(
       `Invalid ${details.endpoint} endpoint for edge "${details.edgeKind}": got "${details.actualKind}", expected ${expected}`,
@@ -422,19 +483,23 @@ export class EndpointError extends TypeGraphError {
 }
 
 /**
+ * Details for UniquenessError.
+ */
+export type UniquenessErrorDetails = Readonly<{
+  constraintName: string;
+  kind: string;
+  existingId: string;
+  newId: string;
+  fields: readonly string[];
+}>;
+
+/**
  * Thrown when uniqueness constraint is violated.
  */
 export class UniquenessError extends TypeGraphError {
-  constructor(
-    details: Readonly<{
-      constraintName: string;
-      kind: string;
-      existingId: string;
-      newId: string;
-      fields: readonly string[];
-    }>,
-    options?: { cause?: unknown },
-  ) {
+  declare readonly details: UniquenessErrorDetails;
+
+  constructor(details: UniquenessErrorDetails, options?: { cause?: unknown }) {
     const fieldList = details.fields.join(", ");
     super(
       `Uniqueness violation on "${details.kind}": constraint "${details.constraintName}" (fields: ${fieldList}) conflicts with existing node ${details.existingId}`,
@@ -451,19 +516,23 @@ export class UniquenessError extends TypeGraphError {
 }
 
 /**
+ * Details for CardinalityError.
+ */
+export type CardinalityErrorDetails = Readonly<{
+  edgeKind: string;
+  fromKind: string;
+  fromId: string;
+  cardinality: string;
+  existingCount: number;
+}>;
+
+/**
  * Thrown when cardinality constraint is violated.
  */
 export class CardinalityError extends TypeGraphError {
-  constructor(
-    details: Readonly<{
-      edgeKind: string;
-      fromKind: string;
-      fromId: string;
-      cardinality: string;
-      existingCount: number;
-    }>,
-    options?: { cause?: unknown },
-  ) {
+  declare readonly details: CardinalityErrorDetails;
+
+  constructor(details: CardinalityErrorDetails, options?: { cause?: unknown }) {
     super(
       `Cardinality violation: "${details.edgeKind}" from ${details.fromKind}/${details.fromId} allows "${details.cardinality}" but ${details.existingCount} edge(s) already exist`,
       "CARDINALITY_ERROR",
@@ -482,20 +551,24 @@ export class CardinalityError extends TypeGraphError {
 }
 
 /**
+ * Details for DisjointError.
+ */
+export type DisjointErrorDetails = Readonly<{
+  nodeId: string;
+  attemptedKind: string;
+  conflictingKind: string;
+}>;
+
+/**
  * Thrown when disjointness constraint is violated.
  *
  * Disjoint types cannot share the same ID - a node cannot be both
  * a Person and an Organization if they are declared disjoint.
  */
 export class DisjointError extends TypeGraphError {
-  constructor(
-    details: Readonly<{
-      nodeId: string;
-      attemptedKind: string;
-      conflictingKind: string;
-    }>,
-    options?: { cause?: unknown },
-  ) {
+  declare readonly details: DisjointErrorDetails;
+
+  constructor(details: DisjointErrorDetails, options?: { cause?: unknown }) {
     super(
       `Disjoint constraint violation: cannot create ${details.attemptedKind} with ID "${details.nodeId}" - conflicts with existing ${details.conflictingKind}`,
       "DISJOINT_ERROR",
@@ -511,16 +584,23 @@ export class DisjointError extends TypeGraphError {
 }
 
 /**
+ * Details for RestrictedDeleteError.
+ */
+export type RestrictedDeleteErrorDetails = Readonly<{
+  nodeKind: string;
+  nodeId: string;
+  edgeCount: number;
+  edgeKinds: readonly string[];
+}>;
+
+/**
  * Thrown when deletion is blocked due to existing edges (restrict behavior).
  */
 export class RestrictedDeleteError extends TypeGraphError {
+  declare readonly details: RestrictedDeleteErrorDetails;
+
   constructor(
-    details: Readonly<{
-      nodeKind: string;
-      nodeId: string;
-      edgeCount: number;
-      edgeKinds: readonly string[];
-    }>,
+    details: RestrictedDeleteErrorDetails,
     options?: { cause?: unknown },
   ) {
     const edgeList = details.edgeKinds.join(", ");
@@ -543,19 +623,26 @@ export class RestrictedDeleteError extends TypeGraphError {
 // ============================================================
 
 /**
+ * Details for VersionConflictError.
+ */
+export type VersionConflictErrorDetails = Readonly<{
+  kind: string;
+  id: string;
+  expectedVersion: number;
+  actualVersion: number;
+}>;
+
+/**
  * Thrown when optimistic locking detects a concurrent modification.
  *
  * This occurs when two operations try to update the same entity simultaneously.
  * The operation with the stale version fails.
  */
 export class VersionConflictError extends TypeGraphError {
+  declare readonly details: VersionConflictErrorDetails;
+
   constructor(
-    details: Readonly<{
-      kind: string;
-      id: string;
-      expectedVersion: number;
-      actualVersion: number;
-    }>,
+    details: VersionConflictErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(
@@ -577,15 +664,22 @@ export class VersionConflictError extends TypeGraphError {
 // ============================================================
 
 /**
+ * Details for SchemaMismatchError.
+ */
+export type SchemaMismatchErrorDetails = Readonly<{
+  graphId: string;
+  expectedHash: string;
+  actualHash: string;
+}>;
+
+/**
  * Thrown when the schema in code doesn't match the schema in the database.
  */
 export class SchemaMismatchError extends TypeGraphError {
+  declare readonly details: SchemaMismatchErrorDetails;
+
   constructor(
-    details: Readonly<{
-      graphId: string;
-      expectedHash: string;
-      actualHash: string;
-    }>,
+    details: SchemaMismatchErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(
@@ -603,17 +697,24 @@ export class SchemaMismatchError extends TypeGraphError {
 }
 
 /**
+ * Details for MigrationError.
+ */
+export type MigrationErrorDetails = Readonly<{
+  graphId: string;
+  fromVersion: number;
+  toVersion: number;
+  reason?: string;
+}>;
+
+/**
  * Thrown when schema migration fails.
  */
 export class MigrationError extends TypeGraphError {
+  declare readonly details: MigrationErrorDetails;
+
   constructor(
     message: string,
-    details: Readonly<{
-      graphId: string;
-      fromVersion: number;
-      toVersion: number;
-      reason?: string;
-    }>,
+    details: MigrationErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(message, "MIGRATION_ERROR", {
@@ -625,6 +726,14 @@ export class MigrationError extends TypeGraphError {
     this.name = "MigrationError";
   }
 }
+
+/**
+ * Details for EagerMaterializationError.
+ */
+export type EagerMaterializationErrorDetails = Readonly<{
+  graphId: string;
+  failedIndexNames: readonly string[];
+}>;
 
 /**
  * Thrown by `Store.evolve(extension, { eager })` when the schema
@@ -657,6 +766,8 @@ export class MigrationError extends TypeGraphError {
  * ```
  */
 export class EagerMaterializationError extends TypeGraphError {
+  declare readonly details: EagerMaterializationErrorDetails;
+
   /**
    * The full materialization result, including successful and failed
    * entries. Same shape as `Store.materializeIndexes()` returns.
@@ -698,6 +809,16 @@ function collectFailedIndexNames(
 }
 
 /**
+ * Details for StaleVersionError. `actual` is `0` when no active version
+ * exists yet (initial-commit race where another writer initialized first).
+ */
+export type StaleVersionErrorDetails = Readonly<{
+  graphId: string;
+  expected: number;
+  actual: number;
+}>;
+
+/**
  * Thrown by `commitSchemaVersion` and `setActiveVersion` when the
  * caller's view of the active schema version is out of date — another
  * writer has already advanced it.
@@ -705,23 +826,12 @@ function collectFailedIndexNames(
  * Recovery: re-read the active version with `getActiveSchema(graphId)`,
  * recompute against the new baseline, and retry. This is a routine
  * concurrency signal, not a bug.
- *
- * `actual` is `0` when no active version exists yet (initial-commit race
- * where another writer initialized first).
  */
 export class StaleVersionError extends TypeGraphError {
-  declare readonly details: Readonly<{
-    graphId: string;
-    expected: number;
-    actual: number;
-  }>;
+  declare readonly details: StaleVersionErrorDetails;
 
   constructor(
-    details: Readonly<{
-      graphId: string;
-      expected: number;
-      actual: number;
-    }>,
+    details: StaleVersionErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(
@@ -739,6 +849,16 @@ export class StaleVersionError extends TypeGraphError {
 }
 
 /**
+ * Details for SchemaContentConflictError.
+ */
+export type SchemaContentConflictErrorDetails = Readonly<{
+  graphId: string;
+  version: number;
+  existingHash: string;
+  incomingHash: string;
+}>;
+
+/**
  * Thrown by `commitSchemaVersion` when a row already exists at the
  * target version with a *different* schema hash — i.e. two writers
  * committed materially different schemas at the same version number.
@@ -749,20 +869,10 @@ export class StaleVersionError extends TypeGraphError {
  * deployments writing schemas that hash differently.
  */
 export class SchemaContentConflictError extends TypeGraphError {
-  declare readonly details: Readonly<{
-    graphId: string;
-    version: number;
-    existingHash: string;
-    incomingHash: string;
-  }>;
+  declare readonly details: SchemaContentConflictErrorDetails;
 
   constructor(
-    details: Readonly<{
-      graphId: string;
-      version: number;
-      existingHash: string;
-      incomingHash: string;
-    }>,
+    details: SchemaContentConflictErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(
@@ -830,6 +940,17 @@ const STORE_NOT_INITIALIZED_REASON_PHRASE: Readonly<
 };
 
 /**
+ * Details for StoreNotInitializedError. `graphId`/`reason` are always
+ * present; callers may merge additional context (e.g. `logicalName`) via
+ * `options.details`.
+ */
+export type StoreNotInitializedErrorDetails = Readonly<{
+  graphId: string;
+  reason: StoreNotInitializedReason;
+}> &
+  Readonly<Record<string, unknown>>;
+
+/**
  * Thrown when a fulltext-dependent operation runs against a connection
  * whose strategy-owned storage has not been durably materialized.
  *
@@ -841,6 +962,8 @@ const STORE_NOT_INITIALIZED_REASON_PHRASE: Readonly<
  * loudly here instead of lazily emitting DDL on the hot path.
  */
 export class StoreNotInitializedError extends TypeGraphError {
+  declare readonly details: StoreNotInitializedErrorDetails;
+
   // `graphId`/`reason` are positional and required: both are
   // load-bearing for the message and for programmatic handling via
   // `details.reason`. Caller `details` merge on top.
@@ -873,15 +996,25 @@ export class StoreNotInitializedError extends TypeGraphError {
 // ============================================================
 
 /**
+ * Details for DatabaseOperationError.
+ */
+export type DatabaseOperationErrorDetails = Readonly<{
+  operation: string;
+  entity: string;
+}>;
+
+/**
  * Thrown when a database operation fails unexpectedly.
  *
  * This indicates a system-level failure in the database backend,
  * not a user-recoverable error.
  */
 export class DatabaseOperationError extends TypeGraphError {
+  declare readonly details: DatabaseOperationErrorDetails;
+
   constructor(
     message: string,
-    details: Readonly<{ operation: string; entity: string }>,
+    details: DatabaseOperationErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(message, "DATABASE_OPERATION_ERROR", {
@@ -899,6 +1032,16 @@ export class DatabaseOperationError extends TypeGraphError {
 // ============================================================
 
 /**
+ * Details for EmbeddingDimensionChangedError.
+ */
+export type EmbeddingDimensionChangedErrorDetails = Readonly<{
+  kind: string;
+  fieldPath: string;
+  declaredDimensions?: number;
+  storedDimensions?: number;
+}>;
+
+/**
  * Thrown when an embedding field's declared dimension no longer matches the
  * dimension of its materialized per-field storage — i.e. a field's
  * `embedding(N)` was changed to `embedding(M)`. The stored vectors are invalid
@@ -908,14 +1051,11 @@ export class DatabaseOperationError extends TypeGraphError {
  * the new dimension and re-embed existing rows.
  */
 export class EmbeddingDimensionChangedError extends TypeGraphError {
+  declare readonly details: EmbeddingDimensionChangedErrorDetails;
+
   constructor(
     message: string,
-    details: Readonly<{
-      kind: string;
-      fieldPath: string;
-      declaredDimensions?: number;
-      storedDimensions?: number;
-    }>,
+    details: EmbeddingDimensionChangedErrorDetails,
     options?: { cause?: unknown },
   ) {
     super(message, "EMBEDDING_DIMENSION_CHANGED", {

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -248,11 +248,31 @@ export {
 // ============================================================
 
 export type {
+  CardinalityErrorDetails,
+  DatabaseOperationErrorDetails,
+  DisjointErrorDetails,
+  EagerMaterializationErrorDetails,
+  EdgeNotFoundErrorDetails,
+  EmbeddingDimensionChangedErrorDetails,
+  EndpointErrorDetails,
+  EndpointNotFoundErrorDetails,
   ErrorCategory,
+  KindNotFoundErrorDetails,
+  MigrationErrorDetails,
+  NodeConstraintNotFoundErrorDetails,
+  NodeIndexNotFoundErrorDetails,
+  NodeNotFoundErrorDetails,
+  RestrictedDeleteErrorDetails,
+  SchemaContentConflictErrorDetails,
+  SchemaMismatchErrorDetails,
+  StaleVersionErrorDetails,
+  StoreNotInitializedErrorDetails,
   StoreNotInitializedReason,
   TypeGraphErrorOptions,
+  UniquenessErrorDetails,
   ValidationErrorDetails,
   ValidationIssue,
+  VersionConflictErrorDetails,
 } from "./errors";
 export {
   // Error classes

--- a/packages/typegraph/tests/errors.test.ts
+++ b/packages/typegraph/tests/errors.test.ts
@@ -899,6 +899,25 @@ describe("StoreNotInitializedError", () => {
       "missing" | "stale" | "failed"
     >();
   });
+
+  it("keeps the constructor's graphId/reason authoritative over colliding extra details", () => {
+    const spoofedDetails = {
+      graphId: "spoofed",
+      reason: "spoofed",
+      logicalName: "vector:summary",
+    };
+    const error = new StoreNotInitializedError(
+      "lib",
+      "stale",
+      // @ts-expect-error graphId/reason are reserved and cannot be overridden via extra details
+      { details: spoofedDetails },
+    );
+    expect(error.details).toEqual({
+      graphId: "lib",
+      reason: "stale",
+      logicalName: "vector:summary",
+    });
+  });
 });
 
 describe("EagerMaterializationError", () => {

--- a/packages/typegraph/tests/errors.test.ts
+++ b/packages/typegraph/tests/errors.test.ts
@@ -1,15 +1,39 @@
 /**
  * Unit tests for TypeGraph error classes.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
+import type {
+  CardinalityErrorDetails,
+  DatabaseOperationErrorDetails,
+  DisjointErrorDetails,
+  EagerMaterializationErrorDetails,
+  EdgeNotFoundErrorDetails,
+  EmbeddingDimensionChangedErrorDetails,
+  EndpointErrorDetails,
+  EndpointNotFoundErrorDetails,
+  KindNotFoundErrorDetails,
+  MigrationErrorDetails,
+  NodeConstraintNotFoundErrorDetails,
+  NodeIndexNotFoundErrorDetails,
+  NodeNotFoundErrorDetails,
+  RestrictedDeleteErrorDetails,
+  SchemaContentConflictErrorDetails,
+  SchemaMismatchErrorDetails,
+  StaleVersionErrorDetails,
+  StoreNotInitializedErrorDetails,
+  UniquenessErrorDetails,
+  VersionConflictErrorDetails,
+} from "../src/errors";
 import {
   CardinalityError,
   CompilerInvariantError,
   ConfigurationError,
   DatabaseOperationError,
   DisjointError,
+  EagerMaterializationError,
   EdgeNotFoundError,
+  EmbeddingDimensionChangedError,
   EndpointError,
   EndpointNotFoundError,
   getErrorSuggestion,
@@ -19,15 +43,21 @@ import {
   isUserRecoverable,
   KindNotFoundError,
   MigrationError,
+  NodeConstraintNotFoundError,
+  NodeIndexNotFoundError,
   NodeNotFoundError,
   RestrictedDeleteError,
+  SchemaContentConflictError,
   SchemaMismatchError,
+  StaleVersionError,
+  StoreNotInitializedError,
   TypeGraphError,
   UniquenessError,
   UnsupportedPredicateError,
   ValidationError,
   VersionConflictError,
 } from "../src/errors";
+import type { MaterializeIndexesResult } from "../src/store/materialize-indexes";
 
 describe("TypeGraphError", () => {
   it("creates error with message, code, and options", () => {
@@ -155,6 +185,13 @@ describe("NodeNotFoundError", () => {
     expect(error.details).toEqual({ kind: "Post", id: "post-456" });
   });
 
+  it("exposes details typed as NodeNotFoundErrorDetails, no cast needed", () => {
+    const error = new NodeNotFoundError("Post", "post-456");
+    expectTypeOf(error.details).toEqualTypeOf<NodeNotFoundErrorDetails>();
+    expectTypeOf(error.details.kind).toBeString();
+    expectTypeOf(error.details.id).toBeString();
+  });
+
   it("has suggestion about verifying ID", () => {
     const error = new NodeNotFoundError("User", "user-123");
     expect(error.suggestion).toContain("user-123");
@@ -173,6 +210,13 @@ describe("EdgeNotFoundError", () => {
   it("stores kind and id in details", () => {
     const error = new EdgeNotFoundError("Follows", "edge-abc");
     expect(error.details).toEqual({ kind: "Follows", id: "edge-abc" });
+  });
+
+  it("exposes details typed as EdgeNotFoundErrorDetails, no cast needed", () => {
+    const error = new EdgeNotFoundError("Follows", "edge-abc");
+    expectTypeOf(error.details).toEqualTypeOf<EdgeNotFoundErrorDetails>();
+    expectTypeOf(error.details.kind).toBeString();
+    expectTypeOf(error.details.id).toBeString();
   });
 });
 
@@ -200,6 +244,17 @@ describe("EndpointNotFoundError", () => {
     };
     const error = new EndpointNotFoundError(details);
     expect(error.details).toEqual(details);
+  });
+
+  it("exposes details typed as EndpointNotFoundErrorDetails, no cast needed", () => {
+    const error = new EndpointNotFoundError({
+      edgeKind: "Follows",
+      endpoint: "to",
+      nodeKind: "User",
+      nodeId: "user-456",
+    });
+    expectTypeOf(error.details).toEqualTypeOf<EndpointNotFoundErrorDetails>();
+    expectTypeOf(error.details.nodeId).toBeString();
   });
 });
 
@@ -229,6 +284,18 @@ describe("VersionConflictError", () => {
     const error = new VersionConflictError(details);
     expect(error.details).toEqual(details);
   });
+
+  it("exposes details typed as VersionConflictErrorDetails, no cast needed", () => {
+    const error = new VersionConflictError({
+      kind: "Post",
+      id: "post-456",
+      expectedVersion: 1,
+      actualVersion: 2,
+    });
+    expectTypeOf(error.details).toEqualTypeOf<VersionConflictErrorDetails>();
+    expectTypeOf(error.details.expectedVersion).toBeNumber();
+    expectTypeOf(error.details.actualVersion).toBeNumber();
+  });
 });
 
 describe("RestrictedDeleteError", () => {
@@ -256,6 +323,18 @@ describe("RestrictedDeleteError", () => {
     const error = new RestrictedDeleteError(details);
     expect(error.details).toEqual(details);
   });
+
+  it("exposes details typed as RestrictedDeleteErrorDetails, no cast needed (issue #230)", () => {
+    const error = new RestrictedDeleteError({
+      nodeKind: "Post",
+      nodeId: "post-456",
+      edgeCount: 3,
+      edgeKinds: ["HasComment"],
+    });
+    expectTypeOf(error.details).toEqualTypeOf<RestrictedDeleteErrorDetails>();
+    expectTypeOf(error.details.edgeCount).toBeNumber();
+    expectTypeOf(error.details.edgeKinds).toEqualTypeOf<readonly string[]>();
+  });
 });
 
 describe("SchemaMismatchError", () => {
@@ -280,6 +359,16 @@ describe("SchemaMismatchError", () => {
     const error = new SchemaMismatchError(details);
     expect(error.details).toEqual(details);
   });
+
+  it("exposes details typed as SchemaMismatchErrorDetails, no cast needed", () => {
+    const error = new SchemaMismatchError({
+      graphId: "test-graph",
+      expectedHash: "hash1",
+      actualHash: "hash2",
+    });
+    expectTypeOf(error.details).toEqualTypeOf<SchemaMismatchErrorDetails>();
+    expectTypeOf(error.details.graphId).toBeString();
+  });
 });
 
 describe("MigrationError", () => {
@@ -303,6 +392,16 @@ describe("MigrationError", () => {
     };
     const error = new MigrationError("Migration failed", details);
     expect(error.details).toEqual(details);
+  });
+
+  it("exposes details typed as MigrationErrorDetails, no cast needed", () => {
+    const error = new MigrationError("Migration failed", {
+      graphId: "test-graph",
+      fromVersion: 3,
+      toVersion: 5,
+    });
+    expectTypeOf(error.details).toEqualTypeOf<MigrationErrorDetails>();
+    expectTypeOf(error.details.fromVersion).toBeNumber();
   });
 });
 
@@ -352,6 +451,15 @@ describe("DatabaseOperationError", () => {
       { cause },
     );
     expect(error.cause).toBe(cause);
+  });
+
+  it("exposes details typed as DatabaseOperationErrorDetails, no cast needed", () => {
+    const error = new DatabaseOperationError("Delete failed", {
+      operation: "delete",
+      entity: "edge",
+    });
+    expectTypeOf(error.details).toEqualTypeOf<DatabaseOperationErrorDetails>();
+    expectTypeOf(error.details.operation).toBeString();
   });
 });
 
@@ -438,6 +546,64 @@ describe("KindNotFoundError", () => {
       graphId: "lib",
     });
   });
+
+  it("exposes details typed as KindNotFoundErrorDetails, no cast needed", () => {
+    const error = new KindNotFoundError("Paper", "node", { graphId: "lib" });
+    expectTypeOf(error.details).toEqualTypeOf<KindNotFoundErrorDetails>();
+    expectTypeOf(error.details.kindName).toBeString();
+    expectTypeOf(error.details.graphId).toEqualTypeOf<string | undefined>();
+  });
+});
+
+describe("NodeConstraintNotFoundError", () => {
+  it("formats message with constraint name and kind", () => {
+    const error = new NodeConstraintNotFoundError("unique_email", "User");
+    expect(error.message).toBe(
+      'Constraint not found: "unique_email" on node kind "User"',
+    );
+    expect(error.code).toBe("CONSTRAINT_NOT_FOUND");
+    expect(error.name).toBe("NodeConstraintNotFoundError");
+    expect(error.category).toBe("user");
+  });
+
+  it("stores constraint name and kind in details", () => {
+    const error = new NodeConstraintNotFoundError("unique_slug", "Post");
+    expect(error.details).toEqual({
+      constraintName: "unique_slug",
+      kind: "Post",
+    });
+  });
+
+  it("exposes details typed as NodeConstraintNotFoundErrorDetails, no cast needed", () => {
+    const error = new NodeConstraintNotFoundError("unique_slug", "Post");
+    expectTypeOf(
+      error.details,
+    ).toEqualTypeOf<NodeConstraintNotFoundErrorDetails>();
+    expectTypeOf(error.details.constraintName).toBeString();
+  });
+});
+
+describe("NodeIndexNotFoundError", () => {
+  it("formats message with index name and kind", () => {
+    const error = new NodeIndexNotFoundError("by_email", "User");
+    expect(error.message).toBe(
+      'Index not found: "by_email" on node kind "User"',
+    );
+    expect(error.code).toBe("INDEX_NOT_FOUND");
+    expect(error.name).toBe("NodeIndexNotFoundError");
+    expect(error.category).toBe("user");
+  });
+
+  it("stores index name and kind in details", () => {
+    const error = new NodeIndexNotFoundError("by_slug", "Post");
+    expect(error.details).toEqual({ indexName: "by_slug", kind: "Post" });
+  });
+
+  it("exposes details typed as NodeIndexNotFoundErrorDetails, no cast needed", () => {
+    const error = new NodeIndexNotFoundError("by_slug", "Post");
+    expectTypeOf(error.details).toEqualTypeOf<NodeIndexNotFoundErrorDetails>();
+    expectTypeOf(error.details.indexName).toBeString();
+  });
 });
 
 describe("UniquenessError", () => {
@@ -466,6 +632,18 @@ describe("UniquenessError", () => {
     };
     const error = new UniquenessError(details);
     expect(error.details).toEqual(details);
+  });
+
+  it("exposes details typed as UniquenessErrorDetails, no cast needed", () => {
+    const error = new UniquenessError({
+      constraintName: "unique_slug",
+      kind: "Post",
+      existingId: "post-1",
+      newId: "post-2",
+      fields: ["slug"],
+    });
+    expectTypeOf(error.details).toEqualTypeOf<UniquenessErrorDetails>();
+    expectTypeOf(error.details.fields).toEqualTypeOf<readonly string[]>();
   });
 });
 
@@ -496,6 +674,18 @@ describe("CardinalityError", () => {
     const error = new CardinalityError(details);
     expect(error.details).toEqual(details);
   });
+
+  it("exposes details typed as CardinalityErrorDetails, no cast needed", () => {
+    const error = new CardinalityError({
+      edgeKind: "BelongsTo",
+      fromKind: "Post",
+      fromId: "post-1",
+      cardinality: "one",
+      existingCount: 2,
+    });
+    expectTypeOf(error.details).toEqualTypeOf<CardinalityErrorDetails>();
+    expectTypeOf(error.details.existingCount).toBeNumber();
+  });
 });
 
 describe("EndpointError", () => {
@@ -523,6 +713,19 @@ describe("EndpointError", () => {
     const error = new EndpointError(details);
     expect(error.details).toEqual(details);
   });
+
+  it("exposes details typed as EndpointErrorDetails, no cast needed", () => {
+    const error = new EndpointError({
+      edgeKind: "Follows",
+      endpoint: "to",
+      actualKind: "Post",
+      expectedKinds: ["User"],
+    });
+    expectTypeOf(error.details).toEqualTypeOf<EndpointErrorDetails>();
+    expectTypeOf(error.details.expectedKinds).toEqualTypeOf<
+      readonly string[]
+    >();
+  });
 });
 
 describe("DisjointError", () => {
@@ -548,6 +751,195 @@ describe("DisjointError", () => {
     };
     const error = new DisjointError(details);
     expect(error.details).toEqual(details);
+  });
+
+  it("exposes details typed as DisjointErrorDetails, no cast needed", () => {
+    const error = new DisjointError({
+      nodeId: "user-123",
+      attemptedKind: "Employee",
+      conflictingKind: "Contractor",
+    });
+    expectTypeOf(error.details).toEqualTypeOf<DisjointErrorDetails>();
+    expectTypeOf(error.details.nodeId).toBeString();
+  });
+});
+
+describe("EmbeddingDimensionChangedError", () => {
+  it("formats message and stores field details", () => {
+    const error = new EmbeddingDimensionChangedError(
+      "Embedding dimension changed",
+      {
+        kind: "Document",
+        fieldPath: "summary",
+        declaredDimensions: 768,
+        storedDimensions: 384,
+      },
+    );
+    expect(error.message).toBe("Embedding dimension changed");
+    expect(error.code).toBe("EMBEDDING_DIMENSION_CHANGED");
+    expect(error.name).toBe("EmbeddingDimensionChangedError");
+    expect(error.category).toBe("user");
+    expect(error.details).toEqual({
+      kind: "Document",
+      fieldPath: "summary",
+      declaredDimensions: 768,
+      storedDimensions: 384,
+    });
+  });
+
+  it("exposes details typed as EmbeddingDimensionChangedErrorDetails, no cast needed", () => {
+    const error = new EmbeddingDimensionChangedError("changed", {
+      kind: "Document",
+      fieldPath: "summary",
+    });
+    expectTypeOf(
+      error.details,
+    ).toEqualTypeOf<EmbeddingDimensionChangedErrorDetails>();
+    expectTypeOf(error.details.declaredDimensions).toEqualTypeOf<
+      number | undefined
+    >();
+  });
+});
+
+describe("StaleVersionError", () => {
+  it("formats message with version info", () => {
+    const error = new StaleVersionError({
+      graphId: "lib",
+      expected: 3,
+      actual: 4,
+    });
+    expect(error.message).toContain("lib");
+    expect(error.code).toBe("STALE_SCHEMA_VERSION");
+    expect(error.name).toBe("StaleVersionError");
+    expect(error.category).toBe("system");
+  });
+
+  it("stores version details", () => {
+    const details = { graphId: "lib", expected: 3, actual: 4 };
+    const error = new StaleVersionError(details);
+    expect(error.details).toEqual(details);
+  });
+
+  it("exposes details typed as StaleVersionErrorDetails, no cast needed", () => {
+    const error = new StaleVersionError({
+      graphId: "lib",
+      expected: 3,
+      actual: 4,
+    });
+    expectTypeOf(error.details).toEqualTypeOf<StaleVersionErrorDetails>();
+    expectTypeOf(error.details.actual).toBeNumber();
+  });
+});
+
+describe("SchemaContentConflictError", () => {
+  it("formats message with version and hashes", () => {
+    const error = new SchemaContentConflictError({
+      graphId: "lib",
+      version: 2,
+      existingHash: "abc",
+      incomingHash: "def",
+    });
+    expect(error.message).toContain("lib");
+    expect(error.code).toBe("SCHEMA_CONTENT_CONFLICT");
+    expect(error.name).toBe("SchemaContentConflictError");
+    expect(error.category).toBe("system");
+  });
+
+  it("stores conflict details", () => {
+    const details = {
+      graphId: "lib",
+      version: 2,
+      existingHash: "abc",
+      incomingHash: "def",
+    };
+    const error = new SchemaContentConflictError(details);
+    expect(error.details).toEqual(details);
+  });
+
+  it("exposes details typed as SchemaContentConflictErrorDetails, no cast needed", () => {
+    const error = new SchemaContentConflictError({
+      graphId: "lib",
+      version: 2,
+      existingHash: "abc",
+      incomingHash: "def",
+    });
+    expectTypeOf(
+      error.details,
+    ).toEqualTypeOf<SchemaContentConflictErrorDetails>();
+    expectTypeOf(error.details.version).toBeNumber();
+  });
+});
+
+describe("StoreNotInitializedError", () => {
+  it("formats message with graphId and reason", () => {
+    const error = new StoreNotInitializedError("lib", "missing");
+    expect(error.message).toContain("lib");
+    expect(error.code).toBe("STORE_NOT_INITIALIZED");
+    expect(error.name).toBe("StoreNotInitializedError");
+    expect(error.category).toBe("user");
+  });
+
+  it("stores graphId, reason, and merged extra details", () => {
+    const error = new StoreNotInitializedError("lib", "stale", {
+      details: { logicalName: "vector:summary" },
+    });
+    expect(error.details).toEqual({
+      graphId: "lib",
+      reason: "stale",
+      logicalName: "vector:summary",
+    });
+  });
+
+  it("exposes details typed as StoreNotInitializedErrorDetails, no cast needed", () => {
+    const error = new StoreNotInitializedError("lib", "missing");
+    expectTypeOf(
+      error.details,
+    ).toEqualTypeOf<StoreNotInitializedErrorDetails>();
+    expectTypeOf(error.details.reason).toEqualTypeOf<
+      "missing" | "stale" | "failed"
+    >();
+  });
+});
+
+describe("EagerMaterializationError", () => {
+  const materialization: MaterializeIndexesResult = {
+    results: [
+      {
+        indexName: "by_email",
+        entity: "node",
+        kind: "User",
+        status: "failed",
+      },
+      {
+        indexName: "by_slug",
+        entity: "node",
+        kind: "Post",
+        status: "created",
+      },
+    ],
+  };
+
+  it("formats message and stores graphId/failedIndexNames in details", () => {
+    const error = new EagerMaterializationError(materialization, "lib");
+    expect(error.code).toBe("EAGER_MATERIALIZATION_FAILED");
+    expect(error.name).toBe("EagerMaterializationError");
+    expect(error.category).toBe("system");
+    expect(error.details).toEqual({
+      graphId: "lib",
+      failedIndexNames: ["by_email"],
+    });
+    expect(error.materialization).toBe(materialization);
+    expect(error.failedIndexNames).toEqual(["by_email"]);
+  });
+
+  it("exposes details typed as EagerMaterializationErrorDetails, no cast needed", () => {
+    const error = new EagerMaterializationError(materialization, "lib");
+    expectTypeOf(
+      error.details,
+    ).toEqualTypeOf<EagerMaterializationErrorDetails>();
+    expectTypeOf(error.details.failedIndexNames).toEqualTypeOf<
+      readonly string[]
+    >();
   });
 });
 
@@ -618,6 +1010,20 @@ describe("error inheritance chain", () => {
         attemptedKind: "A",
         conflictingKind: "B",
       }),
+      new NodeConstraintNotFoundError("c", "K"),
+      new NodeIndexNotFoundError("i", "K"),
+      new EmbeddingDimensionChangedError("test", {
+        kind: "K",
+        fieldPath: "field",
+      }),
+      new StaleVersionError({ graphId: "g", expected: 1, actual: 2 }),
+      new SchemaContentConflictError({
+        graphId: "g",
+        version: 1,
+        existingHash: "a",
+        incomingHash: "b",
+      }),
+      new StoreNotInitializedError("g", "missing"),
     ];
 
     for (const error of errors) {


### PR DESCRIPTION
- `RestrictedDeleteError.details` stayed typed as the base class's `Readonly<Record<string, unknown>>`, forcing consumers to cast (`examples/07-delete-behaviors.ts` had `error.details as { edgeCount: number; edgeKinds: string[] }`) to reach the structured payload.
- Fixed `RestrictedDeleteError` and, per the issue's request, audited every other `TypeGraphError` subclass for the same gap.
- Applied the existing `ValidationError`/`ValidationErrorDetails` pattern (a named exported `XxxErrorDetails` type + `declare readonly details: XxxErrorDetails`) to every subclass whose constructor builds a fixed-shape `details` object: `NodeNotFoundError`, `EdgeNotFoundError`, `KindNotFoundError`, `NodeConstraintNotFoundError`, `NodeIndexNotFoundError`, `EndpointNotFoundError`, `EndpointError`, `UniquenessError`, `CardinalityError`, `DisjointError`, `RestrictedDeleteError`, `VersionConflictError`, `SchemaMismatchError`, `MigrationError`, `EagerMaterializationError`, `StoreNotInitializedError`, `DatabaseOperationError`, `EmbeddingDimensionChangedError`.
- Also refactored `StaleVersionError`/`SchemaContentConflictError` — they already had `declare readonly details`, but as inline anonymous types duplicated between the field and the constructor param — onto the same named-type convention for consistency.
- Left `ConfigurationError`, `UnsupportedPredicateError`, `CompilerInvariantError`, and `BackendDisposedError` untouched: these are used with intentionally open/varying `details` shapes across many call sites, so a fixed narrowed type would be wrong.
- Re-exported all new `XxxErrorDetails` types from `packages/typegraph/src/index.ts`.
- Removed the now-unnecessary cast in `packages/typegraph/examples/07-delete-behaviors.ts`.

Fixes #230.