### PR TITLE
perf: push traversal props extraction into CTEs instead of carrying raw props outward

### DIFF
--- a/.changeset/traversal-props-projection-pushdown.md
+++ b/.changeset/traversal-props-projection-pushdown.md
@@ -6,9 +6,11 @@ perf: push selected top-level `props` field extractions into the
 start/traversal CTEs instead of carrying the whole raw `props` JSONB/JSON
 column outward for later extraction at the final projection. Each
 selected field is extracted once, inline, as its own typed CTE column
-(`__tg_<alias>_<field>`); the outer projection and any matching
-`ORDER BY` on the same field just reference that column directly instead
-of re-extracting from a carried-forward `<alias>_props` column.
+(named from a length-prefixed encoding of its alias and field, so
+distinct alias/field pairs can never collide on the same column name);
+the outer projection and any matching `ORDER BY` on the same field just
+reference that column directly instead of re-extracting from a
+carried-forward `<alias>_props` column.
 
 Found while investigating why a covering index on a system column (see
 `keySystemColumns`) still couldn't get Postgres to serve an indexed join

--- a/.changeset/traversal-props-projection-pushdown.md
+++ b/.changeset/traversal-props-projection-pushdown.md
@@ -1,0 +1,20 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+perf: push selected top-level `props` field extractions into the
+start/traversal CTEs instead of carrying the whole raw `props` JSONB/JSON
+column outward for later extraction at the final projection. Each
+selected field is extracted once, inline, as its own typed CTE column
+(`__tg_<alias>_<field>`); the outer projection and any matching
+`ORDER BY` on the same field just reference that column directly instead
+of re-extracting from a carried-forward `<alias>_props` column.
+
+Found while investigating why a covering index on a system column (see
+`keySystemColumns`) still couldn't get Postgres to serve an indexed join
+index-only: the compiled query was asking for the entire `props` column
+in the join step even though the final `.select()` only needed one
+extracted field, so the specific indexed expression was never actually
+what got read from the table. No behavior change: compiled query results
+are identical; this only changes which columns each CTE carries and
+where field extraction happens.

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -70,8 +70,19 @@ function qualifyColumn(owner: string, name: string): SQL {
 
 const SCOPED_RELEVANCE_NODES_ALIAS = "scoped_relevance_nodes";
 
+/**
+ * Builds a synthetic CTE column name for a selectively-extracted props field.
+ *
+ * Length-prefixes each component (`<length>:<value>`) rather than joining
+ * `alias`/`field` on a bare `_`: alias and field are both attacker/user-controlled
+ * strings that may themselves contain `_`, so naive concatenation lets two distinct
+ * (alias, field) pairs collide on the same column name (e.g. alias="p_full",
+ * field="name" vs. alias="p", field="full_name" would otherwise both produce
+ * "__tg_p_full_name"). The length prefix makes the encoding unambiguous regardless
+ * of what characters alias/field contain.
+ */
 function selectivePropsCteColumnName(field: SelectiveField): string {
-  return `__tg_${field.alias}_${field.field}`;
+  return `__tg_${field.alias.length}:${field.alias}:${field.field.length}:${field.field}`;
 }
 
 function buildScopedNodeIdsSubquery(nodeAlias: string): SQL {
@@ -86,18 +97,21 @@ function buildScopedNodeIdsSubquery(nodeAlias: string): SQL {
   `;
 }
 
+type CompileSelectivePropsSelectColumnsInput = Readonly<{
+  alias: string;
+  dialect: DialectAdapter;
+  selectiveFields: readonly SelectiveField[] | undefined;
+  tableAlias: string | undefined;
+}>;
+
 function compileSelectivePropsSelectColumns(
-  input: Readonly<{
-    alias: string;
-    dialect: DialectAdapter;
-    fields: readonly SelectiveField[] | undefined;
-    tableAlias: string | undefined;
-  }>,
+  input: CompileSelectivePropsSelectColumnsInput,
 ): SQL[] {
-  const { alias, dialect, fields, tableAlias } = input;
+  const { alias, dialect, selectiveFields, tableAlias } = input;
   const propsFields =
-    fields?.filter((field) => !field.isSystemField && field.alias === alias) ??
-    [];
+    selectiveFields?.filter(
+      (field) => !field.isSystemField && field.alias === alias,
+    ) ?? [];
   if (propsFields.length === 0) return [];
 
   const propsColumn = compileColumnReference(tableAlias, "props");
@@ -112,15 +126,22 @@ function compileSelectivePropsSelectColumns(
   });
 }
 
-function compileNodeSelectColumns(
-  input: Readonly<{
-    alias: string;
-    dialect: DialectAdapter;
-    requiredColumns: ReadonlySet<string> | undefined;
-    selectiveFields: readonly SelectiveField[] | undefined;
-    tableAlias: string | undefined;
-  }>,
+function appendSelectivePropsColumns(
+  baseColumns: readonly SQL[],
+  input: CompileSelectivePropsSelectColumnsInput,
 ): SQL[] {
+  return [...baseColumns, ...compileSelectivePropsSelectColumns(input)];
+}
+
+type CompileNodeSelectColumnsInput = Readonly<{
+  alias: string;
+  dialect: DialectAdapter;
+  requiredColumns: ReadonlySet<string> | undefined;
+  selectiveFields: readonly SelectiveField[] | undefined;
+  tableAlias: string | undefined;
+}>;
+
+function compileNodeSelectColumns(input: CompileNodeSelectColumnsInput): SQL[] {
   const { alias, dialect, requiredColumns, selectiveFields, tableAlias } =
     input;
   const baseColumns = NODE_COLUMNS.filter(
@@ -132,26 +153,23 @@ function compileNodeSelectColumns(
     (column) =>
       sql`${compileColumnReference(tableAlias, column)} AS ${sql.raw(`${alias}_${column}`)}`,
   );
-  return [
-    ...baseColumns,
-    ...compileSelectivePropsSelectColumns({
-      alias,
-      dialect,
-      fields: selectiveFields,
-      tableAlias,
-    }),
-  ];
+  return appendSelectivePropsColumns(baseColumns, {
+    alias,
+    dialect,
+    selectiveFields,
+    tableAlias,
+  });
 }
 
-function compileEdgeSelectColumns(
-  input: Readonly<{
-    alias: string;
-    dialect: DialectAdapter;
-    requiredColumns: ReadonlySet<string> | undefined;
-    selectiveFields: readonly SelectiveField[] | undefined;
-    tableAlias: string | undefined;
-  }>,
-): SQL[] {
+type CompileEdgeSelectColumnsInput = Readonly<{
+  alias: string;
+  dialect: DialectAdapter;
+  requiredColumns: ReadonlySet<string> | undefined;
+  selectiveFields: readonly SelectiveField[] | undefined;
+  tableAlias: string | undefined;
+}>;
+
+function compileEdgeSelectColumns(input: CompileEdgeSelectColumnsInput): SQL[] {
   const { alias, dialect, requiredColumns, selectiveFields, tableAlias } =
     input;
   const baseColumns = EDGE_COLUMNS.filter((column) =>
@@ -160,15 +178,12 @@ function compileEdgeSelectColumns(
     (column) =>
       sql`${compileColumnReference(tableAlias, column)} AS ${sql.raw(`${alias}_${column}`)}`,
   );
-  return [
-    ...baseColumns,
-    ...compileSelectivePropsSelectColumns({
-      alias,
-      dialect,
-      fields: selectiveFields,
-      tableAlias,
-    }),
-  ];
+  return appendSelectivePropsColumns(baseColumns, {
+    alias,
+    dialect,
+    selectiveFields,
+    tableAlias,
+  });
 }
 
 type BuildStandardStartCteInput = Readonly<{

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -43,6 +43,7 @@ import { compileTypedJsonExtract } from "../typed-json-extract";
 import {
   EDGE_COLUMNS,
   EMPTY_REQUIRED_COLUMNS,
+  findSelectivePropsFieldForFieldRef,
   isAggregateExpr,
   mapSelectiveSystemFieldToColumn,
   NODE_COLUMNS,
@@ -69,6 +70,10 @@ function qualifyColumn(owner: string, name: string): SQL {
 
 const SCOPED_RELEVANCE_NODES_ALIAS = "scoped_relevance_nodes";
 
+function selectivePropsCteColumnName(field: SelectiveField): string {
+  return `__tg_${field.alias}_${field.field}`;
+}
+
 function buildScopedNodeIdsSubquery(nodeAlias: string): SQL {
   const cteAlias = `${ALIAS_CTE_PREFIX}${nodeAlias}`;
   return sql`
@@ -81,12 +86,44 @@ function buildScopedNodeIdsSubquery(nodeAlias: string): SQL {
   `;
 }
 
-function compileNodeSelectColumns(
-  tableAlias: string | undefined,
-  alias: string,
-  requiredColumns: ReadonlySet<string> | undefined,
+function compileSelectivePropsSelectColumns(
+  input: Readonly<{
+    alias: string;
+    dialect: DialectAdapter;
+    fields: readonly SelectiveField[] | undefined;
+    tableAlias: string | undefined;
+  }>,
 ): SQL[] {
-  return NODE_COLUMNS.filter(
+  const { alias, dialect, fields, tableAlias } = input;
+  const propsFields =
+    fields?.filter((field) => !field.isSystemField && field.alias === alias) ??
+    [];
+  if (propsFields.length === 0) return [];
+
+  const propsColumn = compileColumnReference(tableAlias, "props");
+  return propsFields.map((field) => {
+    const extracted = compileTypedJsonExtract({
+      column: propsColumn,
+      dialect,
+      pointer: jsonPointer([field.field]),
+      valueType: field.valueType,
+    });
+    return sql`${extracted} AS ${quoteIdentifier(selectivePropsCteColumnName(field))}`;
+  });
+}
+
+function compileNodeSelectColumns(
+  input: Readonly<{
+    alias: string;
+    dialect: DialectAdapter;
+    requiredColumns: ReadonlySet<string> | undefined;
+    selectiveFields: readonly SelectiveField[] | undefined;
+    tableAlias: string | undefined;
+  }>,
+): SQL[] {
+  const { alias, dialect, requiredColumns, selectiveFields, tableAlias } =
+    input;
+  const baseColumns = NODE_COLUMNS.filter(
     (column) =>
       column === "id" ||
       column === "kind" ||
@@ -95,19 +132,43 @@ function compileNodeSelectColumns(
     (column) =>
       sql`${compileColumnReference(tableAlias, column)} AS ${sql.raw(`${alias}_${column}`)}`,
   );
+  return [
+    ...baseColumns,
+    ...compileSelectivePropsSelectColumns({
+      alias,
+      dialect,
+      fields: selectiveFields,
+      tableAlias,
+    }),
+  ];
 }
 
 function compileEdgeSelectColumns(
-  tableAlias: string | undefined,
-  alias: string,
-  requiredColumns: ReadonlySet<string> | undefined,
+  input: Readonly<{
+    alias: string;
+    dialect: DialectAdapter;
+    requiredColumns: ReadonlySet<string> | undefined;
+    selectiveFields: readonly SelectiveField[] | undefined;
+    tableAlias: string | undefined;
+  }>,
 ): SQL[] {
-  return EDGE_COLUMNS.filter((column) =>
+  const { alias, dialect, requiredColumns, selectiveFields, tableAlias } =
+    input;
+  const baseColumns = EDGE_COLUMNS.filter((column) =>
     shouldProjectColumn(requiredColumns, column),
   ).map(
     (column) =>
       sql`${compileColumnReference(tableAlias, column)} AS ${sql.raw(`${alias}_${column}`)}`,
   );
+  return [
+    ...baseColumns,
+    ...compileSelectivePropsSelectColumns({
+      alias,
+      dialect,
+      fields: selectiveFields,
+      tableAlias,
+    }),
+  ];
 }
 
 type BuildStandardStartCteInput = Readonly<{
@@ -166,7 +227,13 @@ export function buildStandardStartCte(input: BuildStandardStartCteInput): SQL {
   return sql`
     cte_${sql.raw(alias)} AS ${cteMaterialization}(
       SELECT ${sql.join(
-        compileNodeSelectColumns(undefined, alias, effectiveRequiredColumns),
+        compileNodeSelectColumns({
+          alias,
+          dialect: ctx.dialect,
+          requiredColumns: effectiveRequiredColumns,
+          selectiveFields: ast.selectiveFields,
+          tableAlias: undefined,
+        }),
         sql`, `,
       )}
       FROM ${ctx.schema.nodesTable}
@@ -267,8 +334,20 @@ export function buildStandardTraversalCte(
       ];
   const selectColumns = [
     ...previousRowColumns,
-    ...compileEdgeSelectColumns("e", edgeAlias, requiredEdgeColumns),
-    ...compileNodeSelectColumns("n", nodeAlias, requiredNodeColumns),
+    ...compileEdgeSelectColumns({
+      alias: edgeAlias,
+      dialect: ctx.dialect,
+      requiredColumns: requiredEdgeColumns,
+      selectiveFields: ast.selectiveFields,
+      tableAlias: "e",
+    }),
+    ...compileNodeSelectColumns({
+      alias: nodeAlias,
+      dialect: ctx.dialect,
+      requiredColumns: requiredNodeColumns,
+      selectiveFields: ast.selectiveFields,
+      tableAlias: "n",
+    }),
   ];
   const cteMaterialization =
     materializeCte ? sql`MATERIALIZED `
@@ -462,7 +541,6 @@ export function buildStandardProjection(
   if (ast.selectiveFields && ast.selectiveFields.length > 0) {
     return compileSelectiveProjection(
       ast.selectiveFields,
-      dialect,
       ast,
       collapsedTraversalCteAlias,
     );
@@ -497,7 +575,6 @@ function buildAliasToCteMap(ast: QueryAst): Map<string, string> {
 
 function compileSelectiveProjection(
   fields: readonly SelectiveField[],
-  dialect: DialectAdapter,
   ast: QueryAst,
   collapsedTraversalCteAlias?: string,
 ): SQL {
@@ -515,19 +592,27 @@ function compileSelectiveProjection(
       return sql`${sql.raw(cteAlias)}.${sql.raw(`${field.alias}_${dbColumn}`)} AS ${quoteIdentifier(field.outputName)}`;
     }
 
-    const propsColumn = `${field.alias}_props`;
-    const column = sql`${sql.raw(cteAlias)}.${sql.raw(propsColumn)}`;
-    const pointer = jsonPointer([field.field]);
-    const extracted = compileTypedJsonExtract({
-      column,
-      dialect,
-      pointer,
-      valueType: field.valueType,
-    });
-    return sql`${extracted} AS ${quoteIdentifier(field.outputName)}`;
+    return sql`${sql.raw(cteAlias)}.${quoteIdentifier(selectivePropsCteColumnName(field))} AS ${quoteIdentifier(field.outputName)}`;
   });
 
   return sql.join(columns, sql`, `);
+}
+
+function compileOrderFieldValue(
+  ast: QueryAst,
+  field: FieldRef,
+  dialect: DialectAdapter,
+  cteAlias: string,
+): SQL {
+  const selectiveField = findSelectivePropsFieldForFieldRef(
+    ast.selectiveFields,
+    field,
+  );
+  if (selectiveField !== undefined) {
+    return sql`${sql.raw(cteAlias)}.${quoteIdentifier(selectivePropsCteColumnName(selectiveField))}`;
+  }
+
+  return compileFieldValue(field, dialect, field.valueType, cteAlias);
 }
 
 function buildRelevanceJoins(
@@ -660,10 +745,10 @@ export function buildStandardOrderBy(
       collapsedTraversalCteAlias ??
       aliasToCte?.get(orderSpec.field.alias) ??
       `cte_${orderSpec.field.alias}`;
-    const field = compileFieldValue(
+    const field = compileOrderFieldValue(
+      ast,
       orderSpec.field,
       dialect,
-      valueType,
       cteAlias,
     );
     const direction = sql.raw(orderSpec.direction.toUpperCase());
@@ -1178,10 +1263,10 @@ function compileUserOrderBy(
     const cteAlias =
       aliasToCte.get(orderSpec.field.alias) ??
       `${ALIAS_CTE_PREFIX}${orderSpec.field.alias}`;
-    const field = compileFieldValue(
+    const field = compileOrderFieldValue(
+      ast,
       orderSpec.field,
       dialect,
-      valueType,
       cteAlias,
     );
     const direction = sql.raw(orderSpec.direction.toUpperCase());

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -108,7 +108,7 @@ export function compileFieldColumn(
 /**
  * Gets the JSON pointer for a field reference.
  */
-function getFieldPointer(field: FieldRef): JsonPointer | undefined {
+export function getFieldPointer(field: FieldRef): JsonPointer | undefined {
   if (field.jsonPointer !== undefined) {
     return field.jsonPointer;
   }

--- a/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
+++ b/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
@@ -26,9 +26,10 @@ import { type PredicateCompilerContext } from "./predicates";
 import { assertRecordedQueryDoesNotUseCurrentIndexes } from "./recorded-current-index-guard";
 import {
   addRequiredColumn,
+  findSelectivePropsFieldForFieldRef,
   isIdFieldRef,
+  mapSelectiveSystemFieldToColumn,
   markFieldRefAsRequired,
-  markSelectiveFieldAsRequired,
   type RequiredColumnsByAlias,
 } from "./utils";
 
@@ -118,7 +119,13 @@ function collectRequiredColumnsByAlias(ast: QueryAst): RequiredColumnsByAlias {
 
   if (ast.selectiveFields && ast.selectiveFields.length > 0) {
     for (const field of ast.selectiveFields) {
-      markSelectiveFieldAsRequired(requiredColumnsByAlias, field);
+      if (field.isSystemField) {
+        addRequiredColumn(
+          requiredColumnsByAlias,
+          field.alias,
+          mapSelectiveSystemFieldToColumn(field.field),
+        );
+      }
     }
   } else {
     for (const projectedField of ast.projection.fields) {
@@ -140,6 +147,14 @@ function collectRequiredColumnsByAlias(ast: QueryAst): RequiredColumnsByAlias {
 
   if (ast.orderBy) {
     for (const orderSpec of ast.orderBy) {
+      if (
+        findSelectivePropsFieldForFieldRef(
+          ast.selectiveFields,
+          orderSpec.field,
+        ) !== undefined
+      ) {
+        continue;
+      }
       markFieldRefAsRequired(requiredColumnsByAlias, orderSpec.field);
     }
   }
@@ -148,8 +163,13 @@ function collectRequiredColumnsByAlias(ast: QueryAst): RequiredColumnsByAlias {
     markPredicateFieldsAsRequired(requiredColumnsByAlias, ast.having);
   }
 
-  for (const predicate of ast.predicates) {
-    markPredicateFieldsAsRequired(requiredColumnsByAlias, predicate.expression);
+  if (ast.selectiveFields === undefined || ast.selectiveFields.length === 0) {
+    for (const predicate of ast.predicates) {
+      markPredicateFieldsAsRequired(
+        requiredColumnsByAlias,
+        predicate.expression,
+      );
+    }
   }
 
   return requiredColumnsByAlias;

--- a/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
+++ b/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
@@ -117,8 +117,10 @@ function collectRequiredColumnsByAlias(ast: QueryAst): RequiredColumnsByAlias {
     addRequiredColumn(requiredColumnsByAlias, traversal.nodeAlias, "id");
   }
 
-  if (ast.selectiveFields && ast.selectiveFields.length > 0) {
-    for (const field of ast.selectiveFields) {
+  const hasSelectiveFields = (ast.selectiveFields?.length ?? 0) > 0;
+
+  if (hasSelectiveFields) {
+    for (const field of ast.selectiveFields ?? []) {
       if (field.isSystemField) {
         addRequiredColumn(
           requiredColumnsByAlias,
@@ -163,7 +165,7 @@ function collectRequiredColumnsByAlias(ast: QueryAst): RequiredColumnsByAlias {
     markPredicateFieldsAsRequired(requiredColumnsByAlias, ast.having);
   }
 
-  if (ast.selectiveFields === undefined || ast.selectiveFields.length === 0) {
+  if (!hasSelectiveFields) {
     for (const predicate of ast.predicates) {
       markPredicateFieldsAsRequired(
         requiredColumnsByAlias,

--- a/packages/typegraph/src/query/compiler/utils.ts
+++ b/packages/typegraph/src/query/compiler/utils.ts
@@ -6,6 +6,7 @@
 import { type SQL, sql } from "drizzle-orm";
 
 import { type AggregateExpr, type FieldRef, type SelectiveField } from "../ast";
+import { parseJsonPointer } from "../json-pointer";
 
 // ============================================================
 // Constants
@@ -120,6 +121,38 @@ export function markSelectiveFieldAsRequired(
     return;
   }
   addRequiredColumn(requiredColumnsByAlias, field.alias, "props");
+}
+
+export function getTopLevelPropsFieldName(field: FieldRef): string | undefined {
+  if (field.path.length === 0 || field.path[0] !== "props") {
+    return undefined;
+  }
+
+  if (field.jsonPointer !== undefined) {
+    const segments = parseJsonPointer(field.jsonPointer);
+    return segments.length === 1 ? segments[0] : undefined;
+  }
+
+  return field.path.length === 2 ? field.path[1] : undefined;
+}
+
+export function findSelectivePropsFieldForFieldRef(
+  selectiveFields: readonly SelectiveField[] | undefined,
+  field: FieldRef,
+): SelectiveField | undefined {
+  if (selectiveFields === undefined || selectiveFields.length === 0) {
+    return undefined;
+  }
+
+  const propsFieldName = getTopLevelPropsFieldName(field);
+  if (propsFieldName === undefined) return undefined;
+
+  return selectiveFields.find(
+    (selectiveField) =>
+      !selectiveField.isSystemField &&
+      selectiveField.alias === field.alias &&
+      selectiveField.field === propsFieldName,
+  );
 }
 
 // ============================================================

--- a/packages/typegraph/src/query/compiler/utils.ts
+++ b/packages/typegraph/src/query/compiler/utils.ts
@@ -123,7 +123,7 @@ export function markSelectiveFieldAsRequired(
   addRequiredColumn(requiredColumnsByAlias, field.alias, "props");
 }
 
-export function getTopLevelPropsFieldName(field: FieldRef): string | undefined {
+function getTopLevelPropsFieldName(field: FieldRef): string | undefined {
   if (field.path.length === 0 || field.path[0] !== "props") {
     return undefined;
   }

--- a/packages/typegraph/src/query/compiler/utils.ts
+++ b/packages/typegraph/src/query/compiler/utils.ts
@@ -7,6 +7,7 @@ import { type SQL, sql } from "drizzle-orm";
 
 import { type AggregateExpr, type FieldRef, type SelectiveField } from "../ast";
 import { parseJsonPointer } from "../json-pointer";
+import { getFieldPointer } from "./predicates";
 
 // ============================================================
 // Constants
@@ -124,16 +125,11 @@ export function markSelectiveFieldAsRequired(
 }
 
 function getTopLevelPropsFieldName(field: FieldRef): string | undefined {
-  if (field.path.length === 0 || field.path[0] !== "props") {
-    return undefined;
-  }
+  const pointer = getFieldPointer(field);
+  if (pointer === undefined) return undefined;
 
-  if (field.jsonPointer !== undefined) {
-    const segments = parseJsonPointer(field.jsonPointer);
-    return segments.length === 1 ? segments[0] : undefined;
-  }
-
-  return field.path.length === 2 ? field.path[1] : undefined;
+  const segments = parseJsonPointer(pointer);
+  return segments.length === 1 ? segments[0] : undefined;
 }
 
 export function findSelectivePropsFieldForFieldRef(

--- a/packages/typegraph/tests/query-builder.test.ts
+++ b/packages/typegraph/tests/query-builder.test.ts
@@ -603,7 +603,7 @@ describe("Query Compilation to SQL", () => {
     const { sql } = toSqlWithParams(sqlObject);
 
     expect(sql).toContain(
-      'json_extract(n.props, \'$."name"\') AS "__tg_friend_name"',
+      'json_extract(n.props, \'$."name"\') AS "__tg_6:friend:4:name"',
     );
     expect(sql).not.toContain("p_props");
     expect(sql).not.toContain("p_version");
@@ -647,10 +647,55 @@ describe("Query Compilation to SQL", () => {
     const sqlObject = compileQuery(selectiveAst, graph.id, "postgres");
     const { sql } = toSqlWithParams(sqlObject, "postgres");
 
-    expect(sql).toContain("n.props #>> ARRAY['name'] AS \"__tg_friend_name\"");
-    expect(sql).toContain('cte_friend."__tg_friend_name" AS "friend_name"');
-    expect(sql).toContain('ORDER BY (cte_friend."__tg_friend_name" IS NULL)');
+    expect(sql).toContain(
+      "n.props #>> ARRAY['name'] AS \"__tg_6:friend:4:name\"",
+    );
+    expect(sql).toContain('cte_friend."__tg_6:friend:4:name" AS "friend_name"');
+    expect(sql).toContain(
+      'ORDER BY (cte_friend."__tg_6:friend:4:name" IS NULL)',
+    );
     expect(sql).not.toContain("friend_props");
+  });
+
+  it("does not collide CTE column names for aliases/fields that are ambiguous under naive underscore-joining", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p_full")
+      .traverse("knows", "e")
+      .to("Person", "p")
+      .select((context) => ({
+        a: context.p_full.name,
+        b: context.p.name,
+      }));
+
+    const ast = query.toAst();
+    const selectiveAst = {
+      ...ast,
+      selectiveFields: [
+        {
+          alias: "p_full",
+          field: "name",
+          outputName: "a",
+          isSystemField: false,
+          valueType: "string" as const,
+        },
+        {
+          alias: "p",
+          field: "full_name",
+          outputName: "b",
+          isSystemField: false,
+          valueType: "string" as const,
+        },
+      ],
+    };
+    const sqlObject = compileQuery(selectiveAst, graph.id);
+    const { sql } = toSqlWithParams(sqlObject);
+
+    // Naively joining alias + "_" + field would produce the identical
+    // "__tg_p_full_name" column for both (alias="p_full", field="name") and
+    // (alias="p", field="full_name"). The length-prefixed encoding must keep
+    // them distinct so both end up as separate, unambiguous CTE columns.
+    expect(sql).toContain('AS "__tg_6:p_full:4:name"');
+    expect(sql).toContain('AS "__tg_1:p:9:full_name"');
   });
 
   it("compiles LIMIT and OFFSET", () => {

--- a/packages/typegraph/tests/query-builder.test.ts
+++ b/packages/typegraph/tests/query-builder.test.ts
@@ -602,11 +602,55 @@ describe("Query Compilation to SQL", () => {
     const sqlObject = compileQuery(selectiveAst, graph.id);
     const { sql } = toSqlWithParams(sqlObject);
 
-    expect(sql).toContain("friend_props");
+    expect(sql).toContain(
+      'json_extract(n.props, \'$."name"\') AS "__tg_friend_name"',
+    );
     expect(sql).not.toContain("p_props");
     expect(sql).not.toContain("p_version");
     expect(sql).not.toContain("e_props");
+    expect(sql).not.toContain("friend_props");
     expect(sql).not.toContain("friend_version");
+  });
+
+  it("pushes selected traversal props into the traversal CTE for ordering", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .traverse("knows", "e")
+      .to("Person", "friend")
+      .select((context) => ({
+        friendId: context.friend.id,
+        friendName: context.friend.name,
+      }))
+      .orderBy("friend", "name", "desc")
+      .orderBy("friend", "id", "desc")
+      .limit(10);
+
+    const ast = query.toAst();
+    const selectiveAst = {
+      ...ast,
+      selectiveFields: [
+        {
+          alias: "friend",
+          field: "id",
+          outputName: "friend_id",
+          isSystemField: true,
+        },
+        {
+          alias: "friend",
+          field: "name",
+          outputName: "friend_name",
+          isSystemField: false,
+          valueType: "string" as const,
+        },
+      ],
+    };
+    const sqlObject = compileQuery(selectiveAst, graph.id, "postgres");
+    const { sql } = toSqlWithParams(sqlObject, "postgres");
+
+    expect(sql).toContain("n.props #>> ARRAY['name'] AS \"__tg_friend_name\"");
+    expect(sql).toContain('cte_friend."__tg_friend_name" AS "friend_name"');
+    expect(sql).toContain('ORDER BY (cte_friend."__tg_friend_name" IS NULL)');
+    expect(sql).not.toContain("friend_props");
   });
 
   it("compiles LIMIT and OFFSET", () => {

--- a/packages/typegraph/tests/standard-pass-pipeline.test.ts
+++ b/packages/typegraph/tests/standard-pass-pipeline.test.ts
@@ -174,14 +174,14 @@ describe("column pruning pass", () => {
     expect(state.requiredColumnsByAlias).toBeUndefined();
   });
 
-  it("enables column pruning when selectiveFields are present", () => {
+  it("does not carry raw props for selective prop fields", () => {
     const ast = makeMinimalAst({
       selectiveFields: [makeSelectiveField("p", "name", false, "string")],
     });
     const ctx = makePipelineContext();
     const state = runStandardQueryPassPipeline(ast, "test_graph", ctx);
     expect(state.requiredColumnsByAlias).toBeDefined();
-    expect(state.requiredColumnsByAlias?.get("p")?.has("props")).toBe(true);
+    expect(state.requiredColumnsByAlias?.get("p")?.has("props")).toBe(false);
     expect(state.requiredColumnsByAlias?.get("p")?.has("id")).toBe(true);
   });
 
@@ -232,7 +232,7 @@ describe("column pruning pass", () => {
     expect(state.requiredColumnsByAlias).toBeDefined();
   });
 
-  it("includes predicate fields in required columns", () => {
+  it("does not carry predicate-only props for selective queries", () => {
     const ast = makeMinimalAst({
       selectiveFields: [makeSelectiveField("p", "name", false, "string")],
       predicates: [
@@ -241,7 +241,7 @@ describe("column pruning pass", () => {
     });
     const ctx = makePipelineContext();
     const state = runStandardQueryPassPipeline(ast, "test_graph", ctx);
-    expect(state.requiredColumnsByAlias?.get("p")?.has("props")).toBe(true);
+    expect(state.requiredColumnsByAlias?.get("p")?.has("props")).toBe(false);
   });
 
   it("includes orderBy fields in required columns", () => {
@@ -254,6 +254,18 @@ describe("column pruning pass", () => {
     const ctx = makePipelineContext();
     const state = runStandardQueryPassPipeline(ast, "test_graph", ctx);
     expect(state.requiredColumnsByAlias?.get("p")?.has("props")).toBe(true);
+  });
+
+  it("does not carry raw props when orderBy is covered by selectiveFields", () => {
+    const ast = makeMinimalAst({
+      selectiveFields: [makeSelectiveField("p", "age", false, "number")],
+      orderBy: [
+        { field: makeFieldRef("p", ["props", "age"]), direction: "asc" },
+      ],
+    });
+    const ctx = makePipelineContext();
+    const state = runStandardQueryPassPipeline(ast, "test_graph", ctx);
+    expect(state.requiredColumnsByAlias?.get("p")?.has("props")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Selected top-level `props` fields are now extracted once, inline, inside the start/traversal CTE that owns them (as a typed CTE column, `__tg_<alias>_<field>`), instead of carrying the whole raw `props` JSONB/JSON column outward for extraction at the final projection. The outer projection and any matching `ORDER BY` on the same field reference that pre-extracted column directly.

No behavior change — compiled query results are identical, only which columns each CTE carries and where field extraction happens changes.

## Motivation

Found while investigating a real-world Postgres bottleneck (LDBC SNB benchmark, `packages/benchmarks`): a covering index on a system column couldn't get Postgres to serve an indexed join index-only, because the compiled query was asking for the entire `props` column in the join step even though the final `.select()` only needed one extracted field, so the specific indexed expression was never actually what got read from the table.