### PR TITLE
feat: keySystemColumns index option for system-column-keyed covering indexes

### DIFF
--- a/.changeset/index-key-system-columns.md
+++ b/.changeset/index-key-system-columns.md
@@ -1,0 +1,26 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+`defineNodeIndex` accepts a new `keySystemColumns` option: system columns
+(e.g. `"id"`) to include in the index key, positioned after the `scope`
+prefix and before `fields`/`coveringFields`. `fields` is now optional (was
+a required non-empty tuple) — an index must declare at least one of
+`fields`, `coveringFields`, or `keySystemColumns`.
+
+This closes a real gap: a covering index can only serve a query's join
+index-only (avoiding a heap fetch per candidate row) if the index's key
+matches the join's actual predicate. Queries that join on a system column
+directly (e.g. TypeGraph's compiled `n.id = e.from_id` for a reverse
+traversal) had no way to declare a matching index, since `fields`/
+`coveringFields` only ever accept the node's own schema properties.
+`keySystemColumns: ["id"]` (plus `coveringFields` for whatever the query
+also projects) now lets that same join be served index-only.
+
+Rejects edge-only system columns (`from_kind`/`from_id`/`to_kind`/
+`to_id`) on a node index, and rejects any column already implied by
+`scope`. Not supported with `method: "gin" | "trigram"` (same restriction
+as `coveringFields`). Canonicalized by absence, like `method`: indexes
+that don't use it produce byte-identical names/hashes to before this
+field existed, so existing stored schema documents and materialization
+signatures are unaffected.

--- a/.changeset/index-key-system-columns.md
+++ b/.changeset/index-key-system-columns.md
@@ -20,7 +20,10 @@ also projects) now lets that same join be served index-only.
 Rejects edge-only system columns (`from_kind`/`from_id`/`to_kind`/
 `to_id`) on a node index, and rejects any column already implied by
 `scope`. Not supported with `method: "gin" | "trigram"` (same restriction
-as `coveringFields`). Canonicalized by absence, like `method`: indexes
-that don't use it produce byte-identical names/hashes to before this
-field existed, so existing stored schema documents and materialization
-signatures are unaffected.
+as `coveringFields`). Also rejects `unique: true` combined with
+`keySystemColumns: ["id"]` — every node's `id` is already unique per
+row, so a unique index keyed on `id` plus other columns can never
+enforce a meaningful constraint across those other columns. Canonicalized
+by absence, like `method`: indexes that don't use it produce byte-identical
+names/hashes to before this field existed, so existing stored schema
+documents and materialization signatures are unaffected.

--- a/apps/docs/src/content/docs/performance/indexes.md
+++ b/apps/docs/src/content/docs/performance/indexes.md
@@ -71,13 +71,25 @@ export const typegraphTables = createSqliteTables({}, {
 
 ## Node Indexes
 
-`defineNodeIndex(nodeType, config)` creates an index definition for node properties.
+`defineNodeIndex(nodeType, config)` creates an index definition for node properties and, via
+`keySystemColumns`, TypeGraph system columns.
 
 **Key options:**
 
-- `fields`: JSON property paths used for filtering/ordering (B-tree expression keys).
+- `fields`: JSON property paths used for filtering/ordering (B-tree expression keys). Optional — an
+  index can instead be keyed entirely by `coveringFields`/`keySystemColumns` — but the declaration
+  must supply at least one of `fields`, `coveringFields`, or `keySystemColumns`.
 - `coveringFields`: additional properties frequently selected with the same filters. These become
   additional index keys to enable index-only reads when combined with smart select.
+- `keySystemColumns`: system columns (e.g. `"id"`) to include in the index key, alongside
+  `fields`/`coveringFields`. A covering index can only serve a query's join index-only if the
+  index's key matches the join's actual predicate — a query that joins on a system column directly
+  (e.g. a compiled `n.id = e.from_id` for a reverse traversal) needs a matching key column that
+  `fields`/`coveringFields` can't provide, since those only ever accept schema properties. Rejects
+  edge-only system columns on a node index and any column `scope` already prefixes the key with;
+  not supported together with `method: "gin"`/`"trigram"`. Rejects `"id"` combined with `unique:
+  true` — every node's `id` is already unique per row, so a unique index keyed on `id` plus other
+  columns can never enforce a meaningful constraint across those other columns.
 - `unique`: create a unique index.
 - `scope`: prefixes index keys with TypeGraph system columns (default is `"graphAndKind"`).
 - `where`: partial index predicate (portable DSL, compiled per dialect).
@@ -206,7 +218,9 @@ Semantics:
   each bucket is a (possibly empty) array — this is candidate retrieval, not a uniqueness guarantee.
   For unique lookups prefer `bulkFindByConstraint` (backed by the uniqueness side-table).
 - TypeGraph computes the lookup key from **`index.fields` only** (JSON-pointer extraction, reusing the
-  index's own extraction expressions). `coveringFields` are not part of the key.
+  index's own extraction expressions). Neither `coveringFields` nor `keySystemColumns` are part of the
+  probe key. An index declared without `fields` (only `coveringFields` and/or `keySystemColumns`) has
+  nothing to probe by and throws `ConfigurationError`.
 - The index's partial `where` is applied in SQL to **stored** rows only; probes carry index-field
   values, nothing else. Only the indexed fields are validated — full records are not required.
 - A missing/`undefined` indexed field matches stored `NULL` (null-safe equality). Live,

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -937,17 +937,20 @@ const candidates = await store.nodes.Person.bulkFindByIndex("by_tenant", [
 
 Semantics: one bucket per input in input order (empty input → `[]`); live,
 non-soft-deleted nodes only; buckets ordered by node id; only `index.fields`
-are used (not `coveringFields`), with the index's partial `where` applied to
-stored rows. A missing/`undefined` indexed field matches stored `NULL`.
+are used (not `coveringFields` or `keySystemColumns`), with the index's
+partial `where` applied to stored rows. A missing/`undefined` indexed field
+matches stored `NULL`.
 
 - `options.limitPerInput` caps each bucket (positive integer); unbounded by
   default. On backends without SQL window functions
   (`capabilities.windowFunctions: false`) the cap is applied in memory rather
   than via `ROW_NUMBER()` — same result.
-- Throws `NodeIndexNotFoundError` for an unknown index, `ValidationError` for a
-  non-positive `limitPerInput` or a non-scalar probe value, and
-  `ConfigurationError` for a date-typed key field (which can't compare
-  identically across SQLite and PostgreSQL).
+- Throws `NodeIndexNotFoundError` for an unknown index, `ConfigurationError`
+  for an index declared without `fields` (only `coveringFields` and/or
+  `keySystemColumns` — nothing to probe by) or for a date-typed key field
+  (which can't compare identically across SQLite and PostgreSQL), and
+  `ValidationError` for a non-positive `limitPerInput` or a non-scalar probe
+  value.
 
 See [Index-backed lookup](/performance/indexes#batched-index-lookup-bulkfindbyindex)
 for details.

--- a/packages/typegraph/src/indexes/compiler.ts
+++ b/packages/typegraph/src/indexes/compiler.ts
@@ -46,6 +46,10 @@ export function compileNodeIndexKeys(
     keys.push(systemColumn(column));
   }
 
+  for (const column of index.keySystemColumns ?? []) {
+    keys.push(systemColumn(column));
+  }
+
   const allPointers = [...index.fields, ...index.coveringFields];
   const allValueTypes = [
     ...index.fieldValueTypes,
@@ -158,7 +162,7 @@ function compileIndexKeyValue(
   }
 }
 
-function getNodeScopeColumns(
+export function getNodeScopeColumns(
   scope: NodeIndexDeclaration["scope"],
 ): readonly SystemColumnName[] {
   switch (scope) {

--- a/packages/typegraph/src/indexes/compiler.ts
+++ b/packages/typegraph/src/indexes/compiler.ts
@@ -42,11 +42,11 @@ export function compileNodeIndexKeys(
   const adapter = getDialect(dialect);
   const keys: SQL[] = [];
 
-  for (const column of getNodeScopeColumns(index.scope)) {
-    keys.push(systemColumn(column));
-  }
-
-  for (const column of index.keySystemColumns ?? []) {
+  const systemColumns = [
+    ...getNodeScopeColumns(index.scope),
+    ...(index.keySystemColumns ?? []),
+  ];
+  for (const column of systemColumns) {
     keys.push(systemColumn(column));
   }
 

--- a/packages/typegraph/src/indexes/define-index.ts
+++ b/packages/typegraph/src/indexes/define-index.ts
@@ -26,6 +26,7 @@ import {
 } from "../query/schema-introspector";
 import { EDGE_META_KEYS, NODE_META_KEYS } from "../system-fields";
 import { fnv1aBase36 } from "../utils/hash";
+import { getNodeScopeColumns } from "./compiler";
 import {
   type EdgeIndexConfig,
   type EdgeIndexDeclaration,
@@ -45,6 +46,18 @@ import {
   type SystemColumnName,
 } from "./types";
 
+const NODE_KEY_SYSTEM_COLUMNS: ReadonlySet<SystemColumnName> = new Set([
+  "graph_id",
+  "kind",
+  "id",
+  "deleted_at",
+  "valid_from",
+  "valid_to",
+  "created_at",
+  "updated_at",
+  "version",
+]);
+
 // ============================================================
 // Public API
 // ============================================================
@@ -55,6 +68,10 @@ export function defineNodeIndex<N extends NodeType>(
 ): NodeIndexDeclaration {
   const scope = config.scope ?? "graphAndKind";
   const unique = config.unique ?? false;
+  const keySystemColumns = normalizeKeySystemColumnsOrThrow(
+    config.keySystemColumns ?? [],
+    scope,
+  );
 
   const schemaIntrospector = createSchemaIntrospector(
     new Map([[node.kind, { schema: node.schema }]]),
@@ -63,12 +80,12 @@ export function defineNodeIndex<N extends NodeType>(
   const { pointers: fields, valueTypes: fieldValueTypes } =
     normalizeNodeIndexFieldsOrThrow(
       node,
-      config.fields,
+      config.fields ?? [],
       schemaIntrospector,
       "fields",
       // GIN containment indexes exist precisely for array/object fields,
       // which the btree guard otherwise rejects.
-      { allowEmpty: false, allowJsonFields: config.method === "gin" },
+      { allowEmpty: true, allowJsonFields: config.method === "gin" },
     );
 
   const { pointers: coveringFields, valueTypes: coveringFieldValueTypes } =
@@ -81,6 +98,16 @@ export function defineNodeIndex<N extends NodeType>(
     );
   assertNoOverlap(fields, coveringFields, "fields", "coveringFields");
 
+  if (
+    fields.length === 0 &&
+    coveringFields.length === 0 &&
+    keySystemColumns.length === 0
+  ) {
+    throw new Error(
+      "Index must declare at least one of fields, coveringFields, or keySystemColumns",
+    );
+  }
+
   const where = normalizeWhereInput(config.where, () =>
     createNodeWhereBuilder(node, schemaIntrospector),
   );
@@ -89,6 +116,7 @@ export function defineNodeIndex<N extends NodeType>(
     fieldCount: fields.length,
     fieldValueType: fieldValueTypes[0],
     coveringFieldCount: coveringFields.length,
+    keySystemColumnCount: keySystemColumns.length,
     unique,
     hasWhere: where !== undefined,
   });
@@ -101,6 +129,7 @@ export function defineNodeIndex<N extends NodeType>(
     direction: "none",
     fields,
     coveringFields,
+    keySystemColumns,
   });
   const name =
     config.name ??
@@ -108,8 +137,8 @@ export function defineNodeIndex<N extends NodeType>(
 
   // `origin` is intentionally omitted: `"compile-time"` is the default
   // and is canonicalized by absence so the serialized form stays
-  // byte-identical for legacy graphs. `method` follows the same rule
-  // (absence == "btree").
+  // byte-identical for legacy graphs. `method` and `keySystemColumns`
+  // follow the same rule (absence == "btree" / no system key columns).
   return {
     entity: "node",
     kind: node.kind,
@@ -122,7 +151,41 @@ export function defineNodeIndex<N extends NodeType>(
     scope,
     where,
     ...(method === undefined ? {} : { method }),
+    ...(keySystemColumns.length === 0 ? {} : { keySystemColumns }),
   };
+}
+
+/**
+ * Validates `keySystemColumns`: must be node system columns (not
+ * edge-only `from_kind`/`from_id`/`to_kind`/`to_id`), must not repeat
+ * each other, and must not repeat a column `scope` already prefixes the
+ * key with.
+ */
+function normalizeKeySystemColumnsOrThrow(
+  columns: readonly SystemColumnName[],
+  scope: IndexScope,
+): readonly SystemColumnName[] {
+  if (columns.length === 0) return [];
+
+  for (const column of columns) {
+    if (!NODE_KEY_SYSTEM_COLUMNS.has(column)) {
+      throw new Error(
+        `Node index keySystemColumns does not support "${column}" (edge-only system column)`,
+      );
+    }
+  }
+  assertUnique(columns, "keySystemColumns");
+
+  const scopeColumns = new Set(getNodeScopeColumns(scope));
+  for (const column of columns) {
+    if (scopeColumns.has(column)) {
+      throw new Error(
+        `Node index keySystemColumns must not repeat a column already implied by scope "${scope}": "${column}"`,
+      );
+    }
+  }
+
+  return columns;
 }
 
 export function defineEdgeIndex<E extends AnyEdgeType>(
@@ -165,6 +228,7 @@ export function defineEdgeIndex<E extends AnyEdgeType>(
     fieldCount: fields.length,
     fieldValueType: fieldValueTypes[0],
     coveringFieldCount: coveringFields.length,
+    keySystemColumnCount: 0,
     unique,
     hasWhere: where !== undefined,
   });
@@ -213,6 +277,7 @@ function resolveAdvancedIndexMethod(
     fieldCount: number;
     fieldValueType: ValueType | undefined;
     coveringFieldCount: number;
+    keySystemColumnCount: number;
     unique: boolean;
     hasWhere: boolean;
   }>,
@@ -247,6 +312,11 @@ function resolveAdvancedIndexMethod(
   if (details.coveringFieldCount > 0) {
     throw new Error(
       `Index method "${resolved}" does not support coveringFields (GIN indexes cannot serve index-only scans over extra columns)`,
+    );
+  }
+  if (details.keySystemColumnCount > 0) {
+    throw new Error(
+      `Index method "${resolved}" does not support keySystemColumns (GIN indexes cannot serve index-only scans over extra columns)`,
     );
   }
   if (details.unique) {
@@ -790,9 +860,16 @@ type DefaultNameParts = Readonly<{
   direction: EdgeIndexDirection;
   fields: readonly string[];
   coveringFields: readonly string[];
+  /**
+   * Node-only, defaults to `[]` for edges. Folded into the hash/name only
+   * when non-empty so indexes that don't use it keep byte-identical
+   * default names to before this field existed.
+   */
+  keySystemColumns?: readonly string[];
 }>;
 
 function generateDefaultIndexName(parts: DefaultNameParts): string {
+  const keySystemColumns = parts.keySystemColumns ?? [];
   const hash = fnv1aBase36(
     JSON.stringify({
       kind: parts.kind,
@@ -802,6 +879,7 @@ function generateDefaultIndexName(parts: DefaultNameParts): string {
       direction: parts.direction,
       fields: parts.fields,
       covering: parts.coveringFields,
+      ...(keySystemColumns.length > 0 ? { keySystemColumns } : {}),
     }),
   );
 
@@ -813,6 +891,9 @@ function generateDefaultIndexName(parts: DefaultNameParts): string {
     sanitizeIdentifierComponent(parts.fields.join("_")),
     parts.coveringFields.length > 0 ?
       `cov_${sanitizeIdentifierComponent(parts.coveringFields.join("_"))}`
+    : undefined,
+    keySystemColumns.length > 0 ?
+      `sys_${sanitizeIdentifierComponent(keySystemColumns.join("_"))}`
     : undefined,
     parts.direction === "none" ? undefined : parts.direction,
     parts.unique ? "uniq" : undefined,

--- a/packages/typegraph/src/indexes/define-index.ts
+++ b/packages/typegraph/src/indexes/define-index.ts
@@ -46,17 +46,17 @@ import {
   type SystemColumnName,
 } from "./types";
 
-const NODE_KEY_SYSTEM_COLUMNS: ReadonlySet<SystemColumnName> = new Set([
-  "graph_id",
-  "kind",
-  "id",
-  "deleted_at",
-  "valid_from",
-  "valid_to",
-  "created_at",
-  "updated_at",
-  "version",
-]);
+// `keySystemColumns` on a node index must fail closed: reject anything that
+// isn't a known node-valid column, not just the known edge-only ones. A
+// caller whose array escapes TypeScript's literal-union checking (`any`-typed
+// data, a value round-tripped through JSON) could otherwise pass a typo'd or
+// otherwise-invalid column that silently reaches SQL DDL generation instead
+// of failing here with a clear error. Derived from the single source of
+// truth (`createSystemColumnMapForNode`, hoisted — see below) rather than a
+// second hand-maintained list, so it can't drift from it.
+const NODE_KEY_SYSTEM_COLUMNS: ReadonlySet<SystemColumnName> = new Set(
+  [...createSystemColumnMapForNode().values()].map((entry) => entry.column),
+);
 
 // ============================================================
 // Public API
@@ -71,6 +71,7 @@ export function defineNodeIndex<N extends NodeType>(
   const keySystemColumns = normalizeKeySystemColumnsOrThrow(
     config.keySystemColumns ?? [],
     scope,
+    unique,
   );
 
   const schemaIntrospector = createSchemaIntrospector(
@@ -85,7 +86,7 @@ export function defineNodeIndex<N extends NodeType>(
       "fields",
       // GIN containment indexes exist precisely for array/object fields,
       // which the btree guard otherwise rejects.
-      { allowEmpty: true, allowJsonFields: config.method === "gin" },
+      { allowJsonFields: config.method === "gin" },
     );
 
   const { pointers: coveringFields, valueTypes: coveringFieldValueTypes } =
@@ -94,7 +95,7 @@ export function defineNodeIndex<N extends NodeType>(
       config.coveringFields ?? [],
       schemaIntrospector,
       "coveringFields",
-      { allowEmpty: true },
+      {},
     );
   assertNoOverlap(fields, coveringFields, "fields", "coveringFields");
 
@@ -158,12 +159,15 @@ export function defineNodeIndex<N extends NodeType>(
 /**
  * Validates `keySystemColumns`: must be node system columns (not
  * edge-only `from_kind`/`from_id`/`to_kind`/`to_id`), must not repeat
- * each other, and must not repeat a column `scope` already prefixes the
- * key with.
+ * each other, must not repeat a column `scope` already prefixes the key
+ * with, and must not combine `"id"` with `unique` (every node's `id` is
+ * already unique per row, so that combination can never enforce a
+ * meaningful constraint across the index's other key columns).
  */
 function normalizeKeySystemColumnsOrThrow(
   columns: readonly SystemColumnName[],
   scope: IndexScope,
+  unique: boolean,
 ): readonly SystemColumnName[] {
   if (columns.length === 0) return [];
 
@@ -185,7 +189,17 @@ function normalizeKeySystemColumnsOrThrow(
     }
   }
 
-  return columns;
+  if (unique && columns.includes("id")) {
+    throw new Error(
+      `unique node indexes cannot include keySystemColumns: ["id"]; id is already unique per node, so including it defeats uniqueness across the prop fields`,
+    );
+  }
+
+  // Return a fresh array: the declaration must own an immutable snapshot, not
+  // a reference to the caller's array. Otherwise a post-call mutation of the
+  // original `config.keySystemColumns` bypasses these checks and desyncs the
+  // already-computed name/hash from the compiled index keys.
+  return [...columns];
 }
 
 export function defineEdgeIndex<E extends AnyEdgeType>(
@@ -309,15 +323,16 @@ function resolveAdvancedIndexMethod(
       : `Index method "trigram" requires a string field (it serves substring and case-insensitive matches), got field type "${details.fieldValueType ?? "unresolved"}"`,
     );
   }
-  if (details.coveringFieldCount > 0) {
-    throw new Error(
-      `Index method "${resolved}" does not support coveringFields (GIN indexes cannot serve index-only scans over extra columns)`,
-    );
-  }
-  if (details.keySystemColumnCount > 0) {
-    throw new Error(
-      `Index method "${resolved}" does not support keySystemColumns (GIN indexes cannot serve index-only scans over extra columns)`,
-    );
+  const extraKeyColumns: readonly [string, number][] = [
+    ["coveringFields", details.coveringFieldCount],
+    ["keySystemColumns", details.keySystemColumnCount],
+  ];
+  for (const [label, count] of extraKeyColumns) {
+    if (count > 0) {
+      throw new Error(
+        `Index method "${resolved}" does not support ${label} (GIN indexes cannot serve index-only scans over extra columns)`,
+      );
+    }
   }
   if (details.unique) {
     throw new Error(
@@ -691,12 +706,15 @@ function normalizeNodeIndexFieldsOrThrow<N extends NodeType>(
   inputs: readonly IndexFieldInput<z.infer<N["schema"]>>[],
   schemaIntrospector: ReturnType<typeof createSchemaIntrospector>,
   label: string,
-  options: Readonly<{ allowEmpty: boolean; allowJsonFields?: boolean }>,
+  options: Readonly<{ allowJsonFields?: boolean }>,
 ): NormalizedIndexFields {
-  if (inputs.length === 0 && options.allowEmpty) {
+  // Node `fields`/`coveringFields` are both optional (an index can be keyed
+  // by `keySystemColumns` alone), so unlike the edge equivalent below, an
+  // empty input is always valid here — `defineNodeIndex` enforces that at
+  // least one of `fields`/`coveringFields`/`keySystemColumns` is non-empty.
+  if (inputs.length === 0) {
     return { pointers: [], valueTypes: [] };
   }
-  assertNonEmpty(inputs, label);
 
   const pointers: JsonPointer[] = [];
   const valueTypes: (ValueType | undefined)[] = [];
@@ -888,7 +906,9 @@ function generateDefaultIndexName(parts: DefaultNameParts): string {
     "tg",
     parts.kind,
     sanitizeIdentifierComponent(parts.kindName),
-    sanitizeIdentifierComponent(parts.fields.join("_")),
+    parts.fields.length > 0 ?
+      sanitizeIdentifierComponent(parts.fields.join("_"))
+    : undefined,
     parts.coveringFields.length > 0 ?
       `cov_${sanitizeIdentifierComponent(parts.coveringFields.join("_"))}`
     : undefined,

--- a/packages/typegraph/src/indexes/types.ts
+++ b/packages/typegraph/src/indexes/types.ts
@@ -193,9 +193,9 @@ export type IndexFieldInput<T> =
 export type NodeIndexConfig<N extends NodeType> = Readonly<{
   /**
    * Prop-based key fields. May be empty (or omitted) only if
-   * `keySystemColumns` supplies at least one key column instead — an
-   * index needs at least one of `fields`, `coveringFields`, or
-   * `keySystemColumns` to be non-empty.
+   * `coveringFields` or `keySystemColumns` supplies at least one key
+   * column instead — an index needs at least one of `fields`,
+   * `coveringFields`, or `keySystemColumns` to be non-empty.
    */
   fields?: readonly IndexFieldInput<z.infer<N["schema"]>>[] | undefined;
   coveringFields?: readonly IndexFieldInput<z.infer<N["schema"]>>[] | undefined;

--- a/packages/typegraph/src/indexes/types.ts
+++ b/packages/typegraph/src/indexes/types.ts
@@ -191,11 +191,27 @@ export type IndexFieldInput<T> =
   | JsonPointer;
 
 export type NodeIndexConfig<N extends NodeType> = Readonly<{
-  fields: readonly [
-    IndexFieldInput<z.infer<N["schema"]>>,
-    ...IndexFieldInput<z.infer<N["schema"]>>[],
-  ];
+  /**
+   * Prop-based key fields. May be empty (or omitted) only if
+   * `keySystemColumns` supplies at least one key column instead — an
+   * index needs at least one of `fields`, `coveringFields`, or
+   * `keySystemColumns` to be non-empty.
+   */
+  fields?: readonly IndexFieldInput<z.infer<N["schema"]>>[] | undefined;
   coveringFields?: readonly IndexFieldInput<z.infer<N["schema"]>>[] | undefined;
+  /**
+   * System columns (e.g. `"id"`) to include in the index key, positioned
+   * after the `scope` prefix and before `fields`/`coveringFields`.
+   *
+   * Needed when an index must serve a join predicate on a system column
+   * TypeGraph's compiled queries filter on directly — e.g. `n.id =
+   * e.from_id` — so the index can be used for an index-only scan instead
+   * of falling back to a heap fetch per candidate row. Must not repeat a
+   * column already implied by `scope`, and must only reference node
+   * system columns (`"from_kind"` / `"from_id"` / `"to_kind"` / `"to_id"`
+   * are edge-only and are rejected).
+   */
+  keySystemColumns?: readonly SystemColumnName[] | undefined;
   unique?: boolean | undefined;
   name?: string | undefined;
   scope?: IndexScope | undefined;
@@ -289,6 +305,13 @@ export type NodeIndexDeclaration = IndexDeclarationBase &
   Readonly<{
     entity: "node";
     kind: string;
+    /**
+     * System columns included in the index key (see
+     * {@link NodeIndexConfig.keySystemColumns}). Absent means none —
+     * canonicalized by absence like `origin`/`method` so declarations
+     * that don't use this stay byte-identical to before it existed.
+     */
+    keySystemColumns?: readonly SystemColumnName[];
   }>;
 
 export type EdgeIndexDeclaration = IndexDeclarationBase &

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -225,8 +225,15 @@ function serializeNodeIndexDeclaration(
     where: declaration.where,
     // `method: "btree"` is canonicalized by absence, like `origin` below.
     ...(declaration.method === undefined ? {} : { method: declaration.method }),
-    // `keySystemColumns: []` is canonicalized by absence, same rule.
-    ...(declaration.keySystemColumns === undefined ?
+    // `keySystemColumns: []` is canonicalized by absence, same rule. Checked
+    // against length, not just `undefined` — `NodeIndexDeclaration` is
+    // exported and `nodeIndexDeclarationZod` accepts an explicit `[]`, so a
+    // raw/persisted declaration can carry a present-but-empty array that
+    // must still canonicalize to absent.
+    ...((
+      declaration.keySystemColumns === undefined ||
+      declaration.keySystemColumns.length === 0
+    ) ?
       {}
     : { keySystemColumns: declaration.keySystemColumns }),
     // `origin: "compile-time"` is the default and is omitted from the

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -225,6 +225,10 @@ function serializeNodeIndexDeclaration(
     where: declaration.where,
     // `method: "btree"` is canonicalized by absence, like `origin` below.
     ...(declaration.method === undefined ? {} : { method: declaration.method }),
+    // `keySystemColumns: []` is canonicalized by absence, same rule.
+    ...(declaration.keySystemColumns === undefined ?
+      {}
+    : { keySystemColumns: declaration.keySystemColumns }),
     // `origin: "compile-time"` is the default and is omitted from the
     // canonical form (absence == compile-time). Only `runtime` is
     // emitted explicitly so the restart loader can route the declaration

--- a/packages/typegraph/src/schema/serializer.ts
+++ b/packages/typegraph/src/schema/serializer.ts
@@ -181,7 +181,16 @@ function serializeIndexes(
     .map((index) => serializeIndexDeclaration(index));
 }
 
-function serializeIndexDeclaration(
+/**
+ * Canonicalizes a single index declaration to its serialized form (see
+ * {@link serializeIndexes} for the canonical-form rules). Exported so
+ * consumers that hash a declaration directly — e.g.
+ * `computeIndexSignature` in `store/materialize-indexes.ts` — can
+ * normalize it first, rather than hashing the raw object and risking a
+ * present-but-canonically-absent field (like an explicit `keySystemColumns:
+ * []`) producing a different hash than the omitted form.
+ */
+export function serializeIndexDeclaration(
   declaration: IndexDeclaration,
 ): IndexDeclaration {
   if (declaration.entity === "node") {
@@ -227,9 +236,11 @@ function serializeNodeIndexDeclaration(
     ...(declaration.method === undefined ? {} : { method: declaration.method }),
     // `keySystemColumns: []` is canonicalized by absence, same rule. Checked
     // against length, not just `undefined` — `NodeIndexDeclaration` is
-    // exported and `nodeIndexDeclarationZod` accepts an explicit `[]`, so a
-    // raw/persisted declaration can carry a present-but-empty array that
-    // must still canonicalize to absent.
+    // exported and `defineGraph` accepts pre-built declarations directly
+    // (bypassing `defineNodeIndex`'s own canonicalization and the
+    // `nodeIndexDeclarationZod` parse boundary, which rejects an explicit
+    // `[]` via `.min(1)`), so an in-memory declaration can still carry a
+    // present-but-empty array that must canonicalize to absent here.
     ...((
       declaration.keySystemColumns === undefined ||
       declaration.keySystemColumns.length === 0

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -99,6 +99,18 @@ const systemColumnNameZod = z.enum([
   "version",
 ]);
 
+// A node index's `keySystemColumns` must reject the 4 edge-only join columns,
+// mirroring the construction-time check in `indexes/define-index.ts`'s
+// `normalizeKeySystemColumnsOrThrow`. Excluding from the shared enum (rather
+// than a second hand-written node-column list) keeps this narrowed exactly in
+// sync with `systemColumnNameZod` as the union evolves.
+const nodeSystemColumnNameZod = systemColumnNameZod.exclude([
+  "from_kind",
+  "from_id",
+  "to_kind",
+  "to_id",
+]);
+
 const indexWhereOperandZod = z.discriminatedUnion("__type", [
   z.object({
     __type: z.literal("index_operand_system"),
@@ -200,6 +212,9 @@ const nodeIndexDeclarationZod = z
     entity: z.literal("node"),
     kind: z.string(),
     ...indexDeclarationCommonShape,
+    // Node-only; canonicalized by absence like `method`, so absent/optional
+    // here matches `defineNodeIndex` only emitting it when non-empty.
+    keySystemColumns: z.array(nodeSystemColumnNameZod).optional(),
   })
   .loose();
 

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -214,7 +214,10 @@ const nodeIndexDeclarationZod = z
     ...indexDeclarationCommonShape,
     // Node-only; canonicalized by absence like `method`, so absent/optional
     // here matches `defineNodeIndex` only emitting it when non-empty.
-    keySystemColumns: z.array(nodeSystemColumnNameZod).optional(),
+    // `.min(1)` rejects an explicit `[]` at the boundary rather than
+    // silently accepting a present-but-empty array that would have to be
+    // canonicalized away again downstream (see `serializeNodeIndexDeclaration`).
+    keySystemColumns: z.array(nodeSystemColumnNameZod).min(1).optional(),
   })
   .loose();
 

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -52,6 +52,7 @@ import {
 import { type SqlDialect } from "../query/dialect/types";
 import { asCompiledRowsSql } from "../query/sql-intent";
 import { sortedReplacer } from "../schema/canonical";
+import { serializeIndexDeclaration } from "../schema/serializer";
 import { nowIso } from "../utils/date";
 import { sha256Hex } from "../utils/hash";
 import { ensureFocusedStatusTable } from "./materialize-shared";
@@ -940,13 +941,24 @@ function buildAttempt(
  * signature would falsely report "already materialized" after a table
  * rename. Excludes execution flags (`CONCURRENTLY`, `IF NOT EXISTS`)
  * because those are runtime modifiers, not shape.
+ *
+ * `declaration` is canonicalized via `serializeIndexDeclaration` before
+ * hashing — `defineGraph` accepts pre-built `IndexDeclaration`s directly
+ * (bypassing `defineNodeIndex`'s own canonicalization), so a raw
+ * declaration with e.g. a present-but-empty `keySystemColumns: []` would
+ * otherwise hash differently from the same declaration with the field
+ * omitted, spuriously forcing re-materialization for no real shape change.
  */
 export async function computeIndexSignature(
   dialect: SqlDialect,
   targetTableName: string,
   declaration: IndexDeclaration,
 ): Promise<string> {
-  const hashable = { dialect, targetTableName, declaration };
+  const hashable = {
+    dialect,
+    targetTableName,
+    declaration: serializeIndexDeclaration(declaration),
+  };
   const json = JSON.stringify(hashable, sortedReplacer);
   return sha256Hex(json, 16);
 }

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -1609,6 +1609,17 @@ export async function executeNodeBulkFindByIndex<G extends GraphDef>(
 
   const index = resolveNodeIndex(ctx.graph, kind, indexName);
 
+  if (index.fields.length === 0) {
+    throw new ConfigurationError(
+      `bulkFindByIndex requires an index with at least one prop-based field on index "${indexName}" (node kind "${kind}")`,
+      { indexName, kind },
+      {
+        suggestion:
+          "bulkFindByIndex probes by prop values from each item; an index declared with only keySystemColumns/coveringFields (no fields) has nothing to probe by.",
+      },
+    );
+  }
+
   // Date-typed lookup keys can't satisfy the cross-backend parity guarantee:
   // SQLite compares stored ISO text byte-wise while Postgres compares
   // timestamptz instants, so equal instants in different ISO forms diverge.

--- a/packages/typegraph/tests/indexes.test.ts
+++ b/packages/typegraph/tests/indexes.test.ts
@@ -198,6 +198,61 @@ describe("indexes", () => {
     expect(pg).toContain(`ARRAY['startDate']`);
   });
 
+  it("supports keySystemColumns for index-only join coverage", () => {
+    const idCoveringName = defineNodeIndex(Person, {
+      keySystemColumns: ["id"],
+      coveringFields: ["name"],
+    });
+
+    const pg = generateIndexDDL(idCoveringName, "postgres");
+    expect(pg).toContain('"graph_id"');
+    expect(pg).toContain('"kind"');
+    expect(pg).toContain('"id"');
+    expect(pg).toContain(`ARRAY['name']`);
+
+    const sqlite = generateIndexDDL(idCoveringName, "sqlite");
+    expect(sqlite).toContain('"id"');
+    expect(sqlite).toContain(`$."name"`);
+
+    // Canonicalized by absence, like `method`: an index that never uses
+    // keySystemColumns must not carry the key at all.
+    const plainEmailIndex = defineNodeIndex(Person, { fields: ["email"] });
+    expect(Object.hasOwn(plainEmailIndex, "keySystemColumns")).toBe(false);
+  });
+
+  it("rejects edge-only system columns in a node index's keySystemColumns", () => {
+    expect(() => {
+      defineNodeIndex(Person, {
+        keySystemColumns: ["from_id"],
+        coveringFields: ["name"],
+      });
+    }).toThrow(/edge-only system column/);
+  });
+
+  it("rejects keySystemColumns that duplicate a column scope already implies", () => {
+    expect(() => {
+      defineNodeIndex(Person, {
+        // Default scope is "graphAndKind", which already prefixes graph_id/kind.
+        keySystemColumns: ["graph_id"],
+        coveringFields: ["name"],
+      });
+    }).toThrow(/must not repeat a column already implied by scope/);
+  });
+
+  it("rejects keySystemColumns combined with gin/trigram methods", () => {
+    const Tagged = defineNode("Tagged", {
+      schema: z.object({ tags: z.array(z.string()) }),
+    });
+
+    expect(() => {
+      defineNodeIndex(Tagged, {
+        fields: ["tags"],
+        keySystemColumns: ["id"],
+        method: "gin",
+      });
+    }).toThrow(/does not support keySystemColumns/);
+  });
+
   it("throws when covering fields overlap with index fields", () => {
     expect(() => {
       defineNodeIndex(Person, {
@@ -207,13 +262,10 @@ describe("indexes", () => {
     }).toThrow(/must not overlap/);
   });
 
-  it("throws when fields array is empty", () => {
+  it("throws when fields, coveringFields, and keySystemColumns are all empty", () => {
     expect(() => {
-      defineNodeIndex(Person, {
-        // @ts-expect-error Empty fields should be a type error
-        fields: [],
-      });
-    }).toThrow(/must not be empty/);
+      defineNodeIndex(Person, { fields: [] });
+    }).toThrow(/must declare at least one of/);
   });
 
   it("throws for unknown fields in index definition", () => {

--- a/packages/typegraph/tests/indexes.test.ts
+++ b/packages/typegraph/tests/indexes.test.ts
@@ -15,6 +15,7 @@ import {
   generateIndexDDL,
   notWhere,
   orWhere,
+  type SystemColumnName,
 } from "../src/indexes";
 
 const Person = defineNode("Person", {
@@ -220,6 +221,45 @@ describe("indexes", () => {
     expect(Object.hasOwn(plainEmailIndex, "keySystemColumns")).toBe(false);
   });
 
+  it("generates a default name with no empty segment for a fields-less index", () => {
+    // Regression: the default-name builder guarded the coveringFields/
+    // keySystemColumns segments against being empty, but not the fields
+    // segment — for a fields-less index (only possible since this PR made
+    // `fields` optional) that left a blank segment in the name, producing a
+    // double underscore.
+    const idCoveringName = defineNodeIndex(Person, {
+      keySystemColumns: ["id"],
+      coveringFields: ["name"],
+    });
+
+    expect(idCoveringName.name).not.toContain("__");
+  });
+
+  it("is unaffected by a caller mutating the keySystemColumns array after the call", () => {
+    // Regression: normalizeKeySystemColumnsOrThrow previously returned the
+    // caller's array by reference after validation, so a later mutation of
+    // the original array would bypass the edge-only/scope/duplicate checks
+    // and desync the declaration's already-computed name/hash from what
+    // the compiler actually reads off `keySystemColumns`.
+    const columns: SystemColumnName[] = ["id"];
+    const declaration = defineNodeIndex(Person, {
+      keySystemColumns: columns,
+      coveringFields: ["name"],
+    });
+    const nameBeforeMutation = declaration.name;
+
+    columns.push("graph_id");
+
+    expect(declaration.keySystemColumns).toEqual(["id"]);
+    expect(declaration.name).toBe(nameBeforeMutation);
+
+    // Default scope "graphAndKind" already prefixes the key with graph_id; if
+    // the mutated ["id", "graph_id"] array leaked through, the compiler would
+    // emit "graph_id" a second time as a keySystemColumns entry.
+    const pg = generateIndexDDL(declaration, "postgres");
+    expect(pg.split('"graph_id"').length - 1).toBe(1);
+  });
+
   it("rejects edge-only system columns in a node index's keySystemColumns", () => {
     expect(() => {
       defineNodeIndex(Person, {
@@ -227,6 +267,20 @@ describe("indexes", () => {
         coveringFields: ["name"],
       });
     }).toThrow(/edge-only system column/);
+  });
+
+  it("fails closed on a keySystemColumns value outside the known system-column set", () => {
+    // Regression: the validity check must be an allowlist of known node
+    // columns, not a denylist of known edge-only ones — a denylist would
+    // silently accept a value that escapes TypeScript's literal-union
+    // checking (e.g. `any`-typed data, a value round-tripped through JSON)
+    // instead of failing here with a clear error.
+    expect(() => {
+      defineNodeIndex(Person, {
+        keySystemColumns: ["not_a_real_column" as SystemColumnName],
+        coveringFields: ["name"],
+      });
+    }).toThrow(/does not support "not_a_real_column"/);
   });
 
   it("rejects keySystemColumns that duplicate a column scope already implies", () => {
@@ -237,6 +291,32 @@ describe("indexes", () => {
         coveringFields: ["name"],
       });
     }).toThrow(/must not repeat a column already implied by scope/);
+  });
+
+  it('rejects unique combined with keySystemColumns: ["id"]', () => {
+    // Every node's `id` is already unique per row, so a "unique" index that
+    // also keys on `id` can never enforce a meaningful constraint across its
+    // other key columns (e.g. `unique: true` on `email` + `keySystemColumns:
+    // ["id"]` would let two nodes share the same email, since (email, id) is
+    // always distinct). Reject at declaration time rather than silently
+    // producing a unique index that isn't.
+    expect(() => {
+      defineNodeIndex(Person, {
+        fields: ["email"],
+        keySystemColumns: ["id"],
+        unique: true,
+      });
+    }).toThrow(/unique node indexes cannot include keySystemColumns: \["id"\]/);
+  });
+
+  it("allows unique combined with other keySystemColumns (only id is degenerate)", () => {
+    expect(() =>
+      defineNodeIndex(Person, {
+        fields: ["email"],
+        keySystemColumns: ["deleted_at"],
+        unique: true,
+      }),
+    ).not.toThrow();
   });
 
   it("rejects keySystemColumns combined with gin/trigram methods", () => {

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -952,6 +952,63 @@ describe("Schema Serialization Properties", () => {
       expect(canonical).not.toContain('"origin"');
     });
 
+    // `keySystemColumns` follows the same canonicalize-by-absence rule as
+    // `method`/`origin`: indexes that don't use it must hash/serialize
+    // identically to before the field existed.
+    it("indexes without keySystemColumns omit the field from canonical serialization", () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ email: z.string() }),
+      });
+      const personEmail = defineNodeIndex(Person, { fields: ["email"] });
+
+      const graph = defineGraph({
+        id: "key_system_columns_omit",
+        nodes: { Person: { type: Person } },
+        edges: {},
+        indexes: [personEmail],
+      });
+
+      const serialized = serializeSchema(graph, 1);
+      expect(serialized.indexes).toBeDefined();
+      for (const index of serialized.indexes ?? []) {
+        expect("keySystemColumns" in index).toBe(false);
+      }
+
+      const canonical = JSON.stringify(serialized, sortedReplacer);
+      expect(canonical).not.toContain('"keySystemColumns"');
+    });
+
+    it("indexes using keySystemColumns emit and round-trip it in canonical serialization", () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ name: z.string() }),
+      });
+      const idCoveringName = defineNodeIndex(Person, {
+        keySystemColumns: ["id"],
+        coveringFields: ["name"],
+      });
+
+      const graph = defineGraph({
+        id: "key_system_columns_emit",
+        nodes: { Person: { type: Person } },
+        edges: {},
+        indexes: [idCoveringName],
+      });
+
+      const serialized = serializeSchema(graph, 1);
+      const serializedIndex = serialized.indexes?.[0];
+      expect(serializedIndex?.entity).toBe("node");
+      expect(
+        serializedIndex?.entity === "node" ?
+          serializedIndex.keySystemColumns
+        : undefined,
+      ).toEqual(["id"]);
+
+      const json = JSON.stringify(serialized, sortedReplacer);
+      const parsed = serializedSchemaZod.parse(JSON.parse(json));
+      const reSerialized = JSON.stringify(parsed, sortedReplacer);
+      expect(reSerialized).toBe(json);
+    });
+
     // Conversely, `origin: "runtime"` is emitted explicitly so the
     // restart loader can route it through the runtime compiler.
     it('graph-extension indexes emit `origin: "runtime"` in canonical serialization', () => {

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -1009,6 +1009,74 @@ describe("Schema Serialization Properties", () => {
       expect(reSerialized).toBe(json);
     });
 
+    // Regression: `keySystemColumns` previously had no entry in
+    // `nodeIndexDeclarationZod`, so `.loose()` let any value ride through the
+    // persisted-schema parse boundary unchecked — a malformed value would
+    // only surface later, inside SQL compilation.
+    it("rejects a malformed keySystemColumns value at the serializedSchemaZod boundary", () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ name: z.string() }),
+      });
+      const idCoveringName = defineNodeIndex(Person, {
+        keySystemColumns: ["id"],
+        coveringFields: ["name"],
+      });
+
+      const graph = defineGraph({
+        id: "key_system_columns_malformed",
+        nodes: { Person: { type: Person } },
+        edges: {},
+        indexes: [idCoveringName],
+      });
+
+      const serialized = serializeSchema(graph, 1);
+      const tampered = {
+        ...serialized,
+        indexes: serialized.indexes?.map((index) =>
+          index.entity === "node" ?
+            { ...index, keySystemColumns: ["not_a_system_column"] }
+          : index,
+        ),
+      };
+
+      expect(serializedSchemaZod.safeParse(tampered).success).toBe(false);
+    });
+
+    // Regression: the malformed-value check above only exercised a value
+    // outside the full `SystemColumnName` enum. A value that IS a valid
+    // system column, but edge-only, needs its own check — `keySystemColumns`
+    // previously validated against the shared 13-member enum, which doesn't
+    // distinguish node-valid from edge-only columns the way
+    // `defineNodeIndex`'s own construction-time check does.
+    it("rejects an edge-only keySystemColumns value on a node index at the serializedSchemaZod boundary", () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ name: z.string() }),
+      });
+      const idCoveringName = defineNodeIndex(Person, {
+        keySystemColumns: ["id"],
+        coveringFields: ["name"],
+      });
+
+      const graph = defineGraph({
+        id: "key_system_columns_edge_only",
+        nodes: { Person: { type: Person } },
+        edges: {},
+        indexes: [idCoveringName],
+      });
+
+      const serialized = serializeSchema(graph, 1);
+      const tampered = {
+        ...serialized,
+        indexes: serialized.indexes?.map((index) =>
+          index.entity === "node" ?
+            { ...index, keySystemColumns: ["from_id"] }
+          : index,
+        ),
+      };
+
+      expect(serializedSchemaZod.safeParse(tampered).success).toBe(false);
+    });
+
     // Conversely, `origin: "runtime"` is emitted explicitly so the
     // restart loader can route it through the runtime compiler.
     it('graph-extension indexes emit `origin: "runtime"` in canonical serialization', () => {

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -978,6 +978,65 @@ describe("Schema Serialization Properties", () => {
       expect(canonical).not.toContain('"keySystemColumns"');
     });
 
+    it("canonicalizes a present-but-empty keySystemColumns to absent, same as omitted", () => {
+      // Regression: `NodeIndexDeclaration` is exported and
+      // `nodeIndexDeclarationZod` used to accept `keySystemColumns: []`, so a
+      // raw/persisted declaration could carry `keySystemColumns: []` (present
+      // but empty) rather than omitting the key entirely.
+      // `serializeNodeIndexDeclaration` only checked `=== undefined`, so that
+      // shape would hash/diff/materialize differently from the omitted form
+      // — contradicting the canonicalize-by-absence promise this field is
+      // supposed to keep, the same way `method: "btree"` does.
+      const Person = defineNode("Person", {
+        schema: z.object({ email: z.string() }),
+      });
+      const compiled = defineNodeIndex(Person, { fields: ["email"] });
+      const presentButEmpty: IndexDeclaration = {
+        ...compiled,
+        keySystemColumns: [],
+      };
+
+      const graph = defineGraph({
+        id: "key_system_columns_present_but_empty",
+        nodes: { Person: { type: Person } },
+        edges: {},
+        indexes: [presentButEmpty],
+      });
+
+      const serialized = serializeSchema(graph, 1);
+      expect(serialized.indexes).toBeDefined();
+      for (const index of serialized.indexes ?? []) {
+        expect("keySystemColumns" in index).toBe(false);
+      }
+
+      const canonical = JSON.stringify(serialized, sortedReplacer);
+      expect(canonical).not.toContain('"keySystemColumns"');
+    });
+
+    it("rejects an explicit empty keySystemColumns array at the serializedSchemaZod boundary", () => {
+      const Person = defineNode("Person", {
+        schema: z.object({ email: z.string() }),
+      });
+      const compiled = defineNodeIndex(Person, { fields: ["email"] });
+
+      const graph = defineGraph({
+        id: "key_system_columns_explicit_empty_rejected",
+        nodes: { Person: { type: Person } },
+        edges: {},
+        indexes: [compiled],
+      });
+
+      const serialized = serializeSchema(graph, 1);
+      const tampered = {
+        ...serialized,
+        indexes: serialized.indexes?.map((index) =>
+          index.entity === "node" ? { ...index, keySystemColumns: [] } : index,
+        ),
+      };
+
+      expect(serializedSchemaZod.safeParse(tampered).success).toBe(false);
+    });
+
     it("indexes using keySystemColumns emit and round-trip it in canonical serialization", () => {
       const Person = defineNode("Person", {
         schema: z.object({ name: z.string() }),

--- a/packages/typegraph/tests/store-materialize-indexes.test.ts
+++ b/packages/typegraph/tests/store-materialize-indexes.test.ts
@@ -21,6 +21,7 @@ import { defineGraph } from "../src/core/define-graph";
 import { defineNode } from "../src/core/node";
 import { ConfigurationError } from "../src/errors";
 import { defineNodeIndex } from "../src/indexes";
+import { computeIndexSignature } from "../src/store/materialize-indexes";
 import { createStore, createStoreWithSchema } from "../src/store/store";
 import { createTestBackend } from "./test-utils";
 
@@ -233,6 +234,31 @@ describe("Store.materializeIndexes — signature drift", () => {
     const result = await store.materializeIndexes({ stopOnError: true });
     expect(result.results).toHaveLength(1);
     expect(result.results[0]!.status).toBe("failed");
+  });
+
+  it("computeIndexSignature is unaffected by a present-but-empty keySystemColumns", async () => {
+    // Regression: computeIndexSignature hashed the raw declaration object.
+    // `defineGraph` accepts pre-built `IndexDeclaration`s directly (bypassing
+    // `defineNodeIndex`'s own canonicalization), so a hand-authored
+    // declaration with `keySystemColumns: []` present hashed differently
+    // from the same declaration with the field omitted — spuriously forcing
+    // re-materialization for no real shape change, and narrowly falsifying
+    // the changeset's "materialization signatures are unaffected" claim.
+    const omitted = defineNodeIndex(Person, { fields: ["email"] });
+    const presentButEmpty = { ...omitted, keySystemColumns: [] };
+
+    const signatureOmitted = await computeIndexSignature(
+      "sqlite",
+      "typegraph_nodes",
+      omitted,
+    );
+    const signaturePresentButEmpty = await computeIndexSignature(
+      "sqlite",
+      "typegraph_nodes",
+      presentButEmpty,
+    );
+
+    expect(signaturePresentButEmpty).toBe(signatureOmitted);
   });
 });
 


### PR DESCRIPTION
`defineNodeIndex` accepts a new `keySystemColumns` option: system columns (e.g. `"id"`) to include in the index key, alongside the existing `fields`/`coveringFields` (props-only, until now). `fields` is now optional (was a required non-empty tuple) — an index must declare at least one of `fields`, `coveringFields`, or `keySystemColumns`.

Closes a real gap: a covering index can only serve a query's join index-only if the index's key matches the join's actual predicate. Queries that join on a system column directly (e.g. a compiled `n.id = e.from_id` for a reverse traversal) had no way to declare a matching index, since `fields`/`coveringFields` only ever accepted the node's own schema properties.

Rejects edge-only system columns on a node index, rejects a column `scope` already implies, and isn't supported with `method: "gin"/"trigram"` (same restriction as `coveringFields`). Canonicalized by absence like `method`: indexes that don't use it produce byte-identical names/hashes to before this field existed.

## Motivation

Found while investigating a real-world Postgres bottleneck (LDBC SNB benchmark, `packages/benchmarks`, to be published in a follow-up PR): a covering index keyed by a prop alone had no `id` column, so the planner could never choose it for the actual join and it went unused.
