### PR TITLE
fix: preserve NodeId brand through .select() node id projections

### DIFF
--- a/.changeset/select-projection-nodeid-brand.md
+++ b/.changeset/select-projection-nodeid-brand.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fixes `.select()` query projections losing the `NodeId<N>`/`EdgeId<E>` brand on
+`id` fields. Previously `ctx.alias.id` in a `.select()` callback was typed as
+plain `string`, so feeding a projected id back into `getById`/`getByIds`
+required an unsafe cast (`as never` or worse). `SelectableNode<N>.id` and
+`SelectableEdge<E>.id` are now typed `NodeId<N>`/`EdgeId<E>`, matching what
+`getById`/`getByIds` already require — no runtime change, no cast needed.
+
+`SelectableEdge.fromId`/`.toId` are unaffected (still plain `string`); see
+#235 for that follow-up.

--- a/.changeset/select-projection-nodeid-brand.md
+++ b/.changeset/select-projection-nodeid-brand.md
@@ -2,12 +2,15 @@
 "@nicia-ai/typegraph": patch
 ---
 
-Fixes `.select()` query projections losing the `NodeId<N>`/`EdgeId<E>` brand on
-`id` fields. Previously `ctx.alias.id` in a `.select()` callback was typed as
-plain `string`, so feeding a projected id back into `getById`/`getByIds`
-required an unsafe cast (`as never` or worse). `SelectableNode<N>.id` and
-`SelectableEdge<E>.id` are now typed `NodeId<N>`/`EdgeId<E>`, matching what
-`getById`/`getByIds` already require — no runtime change, no cast needed.
+Fixes `.select()` query projections losing the `NodeId<N>` brand on node `id`
+fields. Previously `ctx.alias.id` in a `.select()` callback was typed as plain
+`string`, so feeding a projected node id back into `getById`/`getByIds`
+required an unsafe cast (`as never` or worse). `SelectableNode<N>.id` is now
+typed `NodeId<N>`, matching what `getById`/`getByIds` already require — no
+runtime change, no cast needed.
 
-`SelectableEdge.fromId`/`.toId` are unaffected (still plain `string`); see
-#235 for that follow-up.
+Edge ids from `.select()` stay plain `string` on purpose: `traverse()`
+defaults to `expand: "inverse"`, which can back an edge alias with a row of
+the registered *inverse* edge kind, so the alias's static edge type doesn't
+reliably describe the row. Use `asEdgeId` to re-brand a projected edge id
+before a point read.

--- a/packages/typegraph/examples/06-inverse-edges.ts
+++ b/packages/typegraph/examples/06-inverse-edges.ts
@@ -14,6 +14,7 @@ import {
   defineEdge,
   defineNode,
   inverseOf,
+  type NodeId,
 } from "@nicia-ai/typegraph";
 import { createExampleBackend } from "./_helpers";
 
@@ -234,11 +235,11 @@ export async function main() {
 
   // Full management chain upward from Bob
   console.log("\nBob's management chain (manual traversal):");
-  let currentId: string | undefined = juniorDev.id;
+  let currentId: NodeId<typeof Employee> | undefined = juniorDev.id;
   let level = 0;
 
   while (currentId) {
-    const current = await store.nodes.Employee.getById(currentId as typeof juniorDev.id);
+    const current = await store.nodes.Employee.getById(currentId);
     if (!current) break;
 
     const indent = "  ".repeat(level);

--- a/packages/typegraph/examples/21-agent-decision-replay.ts
+++ b/packages/typegraph/examples/21-agent-decision-replay.ts
@@ -96,7 +96,7 @@ async function recommendSource(
 
   const top = scored[0];
   if (top === undefined) return undefined;
-  const paper = await view.nodes.Paper.getById(top.id as never);
+  const paper = await view.nodes.Paper.getById(top.id);
   return {
     id: top.id,
     title: paper?.title ?? top.id,

--- a/packages/typegraph/examples/22-breach-forensics.ts
+++ b/packages/typegraph/examples/22-breach-forensics.ts
@@ -22,11 +22,11 @@
 import { z } from "zod";
 
 import {
+  asNodeId,
   createStoreWithSchema,
   defineEdge,
   defineGraph,
   defineNode,
-  type NodeId,
   type RecordedStoreView,
 } from "@nicia-ai/typegraph";
 import { createExampleBackend, requireRecordedNow } from "./_helpers";
@@ -135,11 +135,12 @@ export async function main(): Promise<void> {
     // deliberately kind-erased (`id: string`) — unlike a `.select()`
     // projection, there's no single statically-known kind to brand against.
     // The `kind` filter is a runtime check TypeScript can't turn into a
-    // `NodeId<Resource>` narrowing, so a single targeted cast is still
-    // required here.
+    // `NodeId<Resource>` narrowing, so re-branding the id at this boundary
+    // is still required — `asNodeId` does that with a checked cast instead
+    // of an unsafe one.
     const resourceIds = reached
       .filter((node) => node.kind === "Resource")
-      .map((node) => node.id as NodeId<typeof Resource>);
+      .map((node) => asNodeId<typeof Resource>(node.id));
     const resources = await view.nodes.Resource.getByIds(resourceIds);
     return resources.filter((r): r is NonNullable<typeof r> => r !== undefined);
   }

--- a/packages/typegraph/examples/22-breach-forensics.ts
+++ b/packages/typegraph/examples/22-breach-forensics.ts
@@ -26,6 +26,7 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  type NodeId,
   type RecordedStoreView,
 } from "@nicia-ai/typegraph";
 import { createExampleBackend, requireRecordedNow } from "./_helpers";
@@ -130,12 +131,16 @@ export async function main(): Promise<void> {
       edges: [...ACCESS_EDGES],
       maxHops: 10,
     });
+    // `reachable()` walks mixed node kinds in one pass, so its result is
+    // deliberately kind-erased (`id: string`) — unlike a `.select()`
+    // projection, there's no single statically-known kind to brand against.
+    // The `kind` filter is a runtime check TypeScript can't turn into a
+    // `NodeId<Resource>` narrowing, so a single targeted cast is still
+    // required here.
     const resourceIds = reached
       .filter((node) => node.kind === "Resource")
-      .map((node) => node.id);
-    const resources = await view.nodes.Resource.getByIds(
-      resourceIds as unknown as readonly never[],
-    );
+      .map((node) => node.id as NodeId<typeof Resource>);
+    const resources = await view.nodes.Resource.getByIds(resourceIds);
     return resources.filter((r): r is NonNullable<typeof r> => r !== undefined);
   }
 

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -15,8 +15,10 @@ import { type EmbeddingValue } from "../../core/embedding";
 import { type RecordedInstant } from "../../core/temporal";
 import {
   type AnyEdgeType,
+  type EdgeId,
   type EdgeRegistration,
   type EdgeType,
+  type NodeId,
   type NodeType,
   type TemporalMode,
 } from "../../core/types";
@@ -427,11 +429,15 @@ export type SelectableNodeMeta = Readonly<{
  * For aliases declared via `fromDynamic` / `toDynamic` this resolves to
  * `DynamicSelectableNode` — same wire shape, schema properties typed
  * `unknown` for narrowing at the call site.
+ *
+ * `id` carries the same `NodeId<N>` brand as `Node<N>` (see `store/types.ts`)
+ * so a projected id can be passed straight back into `getById`/`getByIds`
+ * without a cast.
  */
 export type SelectableNode<N extends NodeType> =
   IsDynamicNodeType<N> extends true ? DynamicSelectableNode
   : Readonly<{
-      id: string;
+      id: NodeId<N>;
       kind: N["kind"];
       meta: SelectableNodeMeta;
     }> &
@@ -456,11 +462,19 @@ export type SelectableEdgeMeta = Readonly<{
  * - System metadata is under `edge.meta.*`
  *
  * Dynamic-mode counterpart: see `SelectableNode`.
+ *
+ * `id` carries the same `EdgeId<E>` brand as `Edge<E>` (see `store/types.ts`)
+ * so a projected id can be passed straight back into `getById`/`getByIds`
+ * without a cast. `fromId`/`toId` stay plain `string` for now: branding them
+ * as `NodeId<From>`/`NodeId<To>` (matching `Edge<E, From, To>`) needs the
+ * endpoint kinds from the graph's `EdgeRegistration` threaded through
+ * `EdgeAlias`/`SelectContext`, which isn't wired up yet — tracked separately
+ * in #235, since no reported case has needed it yet (unlike `id`, see #229).
  */
 export type SelectableEdge<E extends AnyEdgeType = EdgeType> =
   IsDynamicEdgeType<E> extends true ? DynamicSelectableEdge
   : Readonly<{
-      id: string;
+      id: EdgeId<E>;
       kind: E["kind"];
       fromId: string;
       toId: string;

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -15,7 +15,6 @@ import { type EmbeddingValue } from "../../core/embedding";
 import { type RecordedInstant } from "../../core/temporal";
 import {
   type AnyEdgeType,
-  type EdgeId,
   type EdgeRegistration,
   type EdgeType,
   type NodeId,
@@ -463,18 +462,24 @@ export type SelectableEdgeMeta = Readonly<{
  *
  * Dynamic-mode counterpart: see `SelectableNode`.
  *
- * `id` carries the same `EdgeId<E>` brand as `Edge<E>` (see `store/types.ts`)
- * so a projected id can be passed straight back into `getById`/`getByIds`
- * without a cast. `fromId`/`toId` stay plain `string` for now: branding them
- * as `NodeId<From>`/`NodeId<To>` (matching `Edge<E, From, To>`) needs the
- * endpoint kinds from the graph's `EdgeRegistration` threaded through
- * `EdgeAlias`/`SelectContext`, which isn't wired up yet — tracked separately
- * in #235, since no reported case has needed it yet (unlike `id`, see #229).
+ * `id`/`kind`/`fromId`/`toId` stay plain `string`, unlike `SelectableNode`'s
+ * `id: NodeId<N>`. `traverse(edgeKind, alias)` defaults to
+ * `expand: "inverse"` (see `GraphAlgorithms`/`QueryBuilder.traverse`'s
+ * `defaultTraversalExpansion`), which UNIONs in rows for the *registered
+ * inverse* edge kind alongside the requested one — `EdgeAlias<E>`'s `E`
+ * stays pinned to the single requested kind regardless, so under the
+ * default expansion mode the row backing `alias` can genuinely be a
+ * different edge kind than `E` says. Branding `id` as `EdgeId<E>` there
+ * would compile but be actively wrong: `store.edges.<E>.getById()` filters
+ * on `row.kind !== kind` and silently returns `undefined` for a
+ * mismatched-kind id — worse than the unsafe cast it would have replaced.
+ * Safe to brand once `EdgeAlias` tracks whether expansion could have
+ * produced a different kind (`expand: "none"` vs not); see #235's note.
  */
 export type SelectableEdge<E extends AnyEdgeType = EdgeType> =
   IsDynamicEdgeType<E> extends true ? DynamicSelectableEdge
   : Readonly<{
-      id: EdgeId<E>;
+      id: string;
       kind: E["kind"];
       fromId: string;
       toId: string;

--- a/packages/typegraph/tests/query-builder-types.test.ts
+++ b/packages/typegraph/tests/query-builder-types.test.ts
@@ -450,7 +450,15 @@ describe("Query Builder Type Safety", () => {
       expect(query).toBeDefined();
     });
 
-    it("brands a projected edge id as EdgeId<E>, not a plain string", () => {
+    it("leaves a projected edge id as plain string, unlike node id", () => {
+      // Unlike node ids, an edge alias's id must NOT be branded EdgeId<E>.
+      // `traverse(edgeKind, alias)` defaults to `expand: "inverse"`, which
+      // UNIONs in rows for the registered *inverse* edge kind alongside the
+      // requested one — the row backing `alias` can genuinely be a
+      // different edge kind than the alias's static type says. Branding
+      // `id` here would let a wrong-kind id compile straight into
+      // `getById`, which silently returns undefined for a kind mismatch
+      // instead of erroring. See SelectableEdge's docblock.
       const query = createQueryBuilder<typeof graph>(graph.id, registry)
         .from("Person", "p")
         .traverse("worksAt", "e")
@@ -462,9 +470,9 @@ describe("Query Builder Type Safety", () => {
         Store<typeof graph>["edges"]["worksAt"]["getById"]
       >[0];
 
-      expectTypeOf<ProjectedId>().toEqualTypeOf<EdgeId<typeof worksAt>>();
-      expectTypeOf<ProjectedId>().toEqualTypeOf<GetByIdParam>();
-      expectTypeOf<ProjectedId>().not.toEqualTypeOf<string>();
+      expectTypeOf<ProjectedId>().toEqualTypeOf<string>();
+      expectTypeOf<ProjectedId>().not.toEqualTypeOf<GetByIdParam>();
+      expectTypeOf<ProjectedId>().not.toEqualTypeOf<EdgeId<typeof worksAt>>();
 
       expect(query).toBeDefined();
     });

--- a/packages/typegraph/tests/query-builder-types.test.ts
+++ b/packages/typegraph/tests/query-builder-types.test.ts
@@ -11,7 +11,7 @@
  * - Aliases must be unique
  * - whereNode aliases must reference existing aliases
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 
 import {
@@ -20,6 +20,8 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  type EdgeId,
+  type NodeId,
   type Store,
   type TypedEdgeCollection,
 } from "../src";
@@ -425,6 +427,44 @@ describe("Query Builder Type Safety", () => {
           person: context.p,
           // ctx.c would be a type error here since "c" alias doesn't exist
         }));
+
+      expect(query).toBeDefined();
+    });
+
+    it("brands a projected node id as NodeId<N>, not a plain string", () => {
+      const query = createQueryBuilder<typeof graph>(graph.id, registry)
+        .from("Person", "p")
+        .select((context) => context.p.id);
+
+      type ProjectedId = Awaited<ReturnType<(typeof query)["execute"]>>[number];
+      type GetByIdParam = Parameters<
+        Store<typeof graph>["nodes"]["Person"]["getById"]
+      >[0];
+
+      // The id flowing out of .select() must line up exactly with what
+      // getById/getByIds require, with no cast at the call site.
+      expectTypeOf<ProjectedId>().toEqualTypeOf<NodeId<typeof Person>>();
+      expectTypeOf<ProjectedId>().toEqualTypeOf<GetByIdParam>();
+      expectTypeOf<ProjectedId>().not.toEqualTypeOf<string>();
+
+      expect(query).toBeDefined();
+    });
+
+    it("brands a projected edge id as EdgeId<E>, not a plain string", () => {
+      const query = createQueryBuilder<typeof graph>(graph.id, registry)
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .select((context) => context.e.id);
+
+      type ProjectedId = Awaited<ReturnType<(typeof query)["execute"]>>[number];
+      type GetByIdParam = Parameters<
+        Store<typeof graph>["edges"]["worksAt"]["getById"]
+      >[0];
+
+      expectTypeOf<ProjectedId>().toEqualTypeOf<EdgeId<typeof worksAt>>();
+      expectTypeOf<ProjectedId>().toEqualTypeOf<GetByIdParam>();
+      expectTypeOf<ProjectedId>().not.toEqualTypeOf<string>();
 
       expect(query).toBeDefined();
     });

--- a/packages/typegraph/tests/query-execution.test.ts
+++ b/packages/typegraph/tests/query-execution.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  asEdgeId,
   count,
   defineEdge,
   defineGraph,
@@ -633,7 +634,12 @@ describe("Query Execution (SQLite)", () => {
       expect(aliceAgain?.name).toBe("Alice");
     });
 
-    it("round-trips a projected edge id into getById with no cast", async () => {
+    it("keeps a projected edge id as string, requiring asEdgeId to re-brand it", async () => {
+      // Edge ids from .select() stay plain string (see SelectableEdge's
+      // docblock: traverse()'s default expand: "inverse" can back an alias
+      // with a different edge kind than its static type, so getById would
+      // silently return undefined for a mismatched-kind id if this were
+      // auto-branded). asEdgeId is the sanctioned way to re-apply the brand.
       const edgeIds = await store
         .query()
         .from("Person", "p")
@@ -645,11 +651,66 @@ describe("Query Execution (SQLite)", () => {
 
       const [worksAtId] = edgeIds;
       expect(worksAtId).toBeDefined();
+      const brandedWorksAtId = asEdgeId<typeof worksAt>(worksAtId!);
 
-      // No cast: SelectableEdge.id is branded EdgeId<worksAt>, matching what
-      // getById requires.
-      const edge = await store.edges.worksAt.getById(worksAtId!);
+      const edge = await store.edges.worksAt.getById(brandedWorksAtId);
       expect(edge?.role).toBe("Engineer");
+    });
+
+    it("proves why edge ids can't be auto-branded: default expand mixes in the inverse kind", async () => {
+      // Concrete reproduction of the hazard SelectableEdge's docblock
+      // describes: traverse()'s default expand: "inverse" unions in rows
+      // for the registered inverse edge kind, so the row backing an alias
+      // can be a genuinely different edge kind than the one requested.
+      const manages = defineEdge("manages", { schema: z.object({}) });
+      const managedBy = defineEdge("managedBy", { schema: z.object({}) });
+      const orgGraph = defineGraph({
+        id: "inverse_kind_mismatch",
+        nodes: { Person: { type: Person } },
+        edges: {
+          manages: { type: manages, from: [Person], to: [Person] },
+          managedBy: { type: managedBy, from: [Person], to: [Person] },
+        },
+        ontology: [inverseOf(manages, managedBy)],
+      });
+      const orgBackend = createSqliteBackend(createTestDatabase());
+      const orgStore = createStore(orgGraph, orgBackend);
+
+      const boss = await orgStore.nodes.Person.create({ name: "Boss" });
+      const report = await orgStore.nodes.Person.create({ name: "Report" });
+      // Only a `managedBy` edge exists — no literal `manages` edge.
+      const managedByEdge = await orgStore.edges.managedBy.create(
+        report,
+        boss,
+        {},
+      );
+
+      const rows = await orgStore
+        .query()
+        .from("Person", "boss")
+        .whereNode("boss", (p) => p.name.eq("Boss"))
+        .traverse("manages", "e") // default expand: "inverse"
+        .to("Person", "report")
+        .select((context) => ({ id: context.e.id, kind: context.e.kind }))
+        .execute();
+
+      expect(rows).toHaveLength(1);
+      // Statically typed E["kind"] says "manages"; the actual row is the
+      // managedBy edge matched via inverse expansion.
+      expect(rows[0]!.kind).toBe("managedBy");
+      expect(rows[0]!.id).toBe(managedByEdge.id);
+
+      // Blindly trusting the requested alias's kind silently loses data...
+      const wrongKindLookup = await orgStore.edges.manages.getById(
+        asEdgeId<typeof manages>(rows[0]!.id),
+      );
+      expect(wrongKindLookup).toBeUndefined();
+
+      // ...the row only resolves under its real kind.
+      const rightKindLookup = await orgStore.edges.managedBy.getById(
+        asEdgeId<typeof managedBy>(rows[0]!.id),
+      );
+      expect(rightKindLookup?.id).toBe(managedByEdge.id);
     });
   });
 

--- a/packages/typegraph/tests/query-execution.test.ts
+++ b/packages/typegraph/tests/query-execution.test.ts
@@ -611,6 +611,46 @@ describe("Query Execution (SQLite)", () => {
         "Charlie (charlie)",
       ]);
     });
+
+    it("round-trips a projected node id into getById/getByIds with no cast", async () => {
+      const ids = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.eq("Alice"))
+        .select((context) => context.p.id)
+        .execute();
+
+      const [aliceId] = ids;
+      expect(aliceId).toBeDefined();
+
+      // No cast: SelectableNode.id is branded NodeId<Person>, matching what
+      // getById/getByIds require.
+      const [alice, [aliceAgain]] = await Promise.all([
+        store.nodes.Person.getById(aliceId!),
+        store.nodes.Person.getByIds([aliceId!]),
+      ]);
+      expect(alice?.name).toBe("Alice");
+      expect(aliceAgain?.name).toBe("Alice");
+    });
+
+    it("round-trips a projected edge id into getById with no cast", async () => {
+      const edgeIds = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.eq("Alice"))
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .select((context) => context.e.id)
+        .execute();
+
+      const [worksAtId] = edgeIds;
+      expect(worksAtId).toBeDefined();
+
+      // No cast: SelectableEdge.id is branded EdgeId<worksAt>, matching what
+      // getById requires.
+      const edge = await store.edges.worksAt.getById(worksAtId!);
+      expect(edge?.role).toBe("Engineer");
+    });
   });
 
   describe("Query Compilation", () => {


### PR DESCRIPTION
Node ids selected through the query builder (`.select((ctx) => ctx.alias.id)`) now keep their `NodeId<N>` brand instead of widening to plain `string`. `SelectableNode<N>.id` in `packages/typegraph/src/query/builder/types.ts` is typed against the alias's statically-known node type, matching `getById`/`getByIds`'s existing signatures. Type-only change — `N` was already available at that point in the query builder's generics, and ids are plain strings at runtime regardless, so `result-mapper.ts`'s construction path needs no changes.

Removes the unsafe casts from the three examples cited in #229:
- `examples/06-inverse-edges.ts` — `getById(currentId as typeof juniorDev.id)` → `getById(currentId)`, with `currentId` now typed `NodeId<typeof Employee>` instead of `string`.
- `examples/21-agent-decision-replay.ts` — `getById(top.id as never)` → `getById(top.id)`.
- `examples/22-breach-forensics.ts` — this one goes through `store.reachable()`, a heterogeneous multi-kind traversal API whose result (`ReachableNode`) is deliberately kind-erased (`id: string`, `kind: string`) since it walks mixed node kinds in one pass — `.select()`'s fix doesn't apply here. Now uses `asNodeId<typeof Resource>(node.id)` (from #223, merged) in place of the original unsafe double-cast — a checked re-brand instead of an unchecked one.

## SelectableEdge.id is intentionally NOT branded (caught in review)

This PR originally branded `SelectableEdge<E>.id` as `EdgeId<E>` too, for symmetry. That was wrong and got caught before merge: `traverse(edgeKind, alias)` defaults to `expand: "inverse"`, which UNIONs in rows for the graph's *registered inverse* edge kind alongside the requested one (`compileTraversalBranch` in `packages/typegraph/src/query/compiler/emitter/standard-builders.ts`, selecting `e.kind`/`e.id` from whichever branch matched). `EdgeAlias<E>`'s `E` stays pinned to the single requested kind regardless of expansion — so under the **default** expansion mode, the row backing an edge alias can genuinely be a different edge kind than its static type says.

Branding `id` there compiled cleanly but was actively wrong: `store.edges.<E>.getById()` filters on `row.kind !== kind` and silently returns `undefined` for a mismatched-kind id — worse than the unsafe cast it would have replaced. `SelectableEdge.id` stays plain `string`; `asEdgeId` (from #223) is the sanctioned way to re-brand a projected edge id when the caller knows the traversal is single-kind. A concrete regression test proves the mechanism with a genuine two-distinct-kind `inverseOf(manages, managedBy)` pair (self-inverse pairs don't surface the mismatch, since the kind is identical both directions).

`SelectableEdge.fromId`/`.toId` were already unbranded before this PR and remain so — see #235, which has the identical hazard and is noted there.

## Testing

- `packages/typegraph/tests/query-builder-types.test.ts` — compile-time assertions that a projected node id equals `NodeId<N>` and lines up exactly with `getById`'s parameter type (`expectTypeOf`), and that it's no longer plain `string`. A companion assertion locks in that a projected **edge** id stays plain `string` and is NOT assignable to `getById`'s branded parameter — a regression guard against re-introducing the unsound brand.
- `packages/typegraph/tests/query-execution.test.ts`:
  - Runtime round-trip: query → project node `.id` → `getById`/`getByIds` with no cast, against a real SQLite-backed store.
  - Runtime: a projected edge id requires `asEdgeId` to re-brand before `getById` — demonstrates the sanctioned pattern.
  - Concrete repro (`"proves why edge ids can't be auto-branded: default expand mixes in the inverse kind"`): builds a `manages`/`managedBy` `inverseOf` pair, seeds only a `managedBy` edge, traverses `"manages"` with default expansion, and shows the resulting row's `kind` is actually `"managedBy"` — then shows `store.edges.manages.getById()` silently returns `undefined` for that id while `store.edges.managedBy.getById()` resolves it correctly.
- Ran all three affected examples manually to confirm behavior is unchanged.

Filed #235 (fromId/toId branding, now flagged with the same expansion hazard) as tracked follow-up work, out of scope here.

Fixes #229