### PR TITLE
docs: close #235 - SelectableEdge.fromId/.toId can't be safely auto-branded

### DIFF
--- a/apps/docs/src/content/docs/types.md
+++ b/apps/docs/src/content/docs/types.md
@@ -207,9 +207,11 @@ type SelectableEdge<E extends EdgeType> = Readonly<{
 ```
 
 `traverse()` defaults to `expand: "inverse"`, which can match the graph's
-*registered inverse* edge kind alongside the one you asked for, so the row
-behind an edge alias isn't guaranteed to be the requested kind. This affects
-`SelectableEdge` in two different ways:
+*registered inverse* edge kind alongside the one you asked for — and
+`inverseOf(edgeA, edgeB)` doesn't require `edgeA`/`edgeB` to share a props
+schema — so the row behind an edge alias isn't guaranteed to be the
+requested kind, or to have the requested kind's schema. This affects
+`SelectableEdge` in three different ways:
 
 - **`kind: E["kind"]` can already be wrong today.** It's a literal type
   (e.g. `"manages"`), not `string` — but the runtime value can be the
@@ -217,6 +219,10 @@ behind an edge alias isn't guaranteed to be the requested kind. This affects
   mode. This isn't a missing brand, it's an existing type-accuracy gap:
   don't trust `ctx.e.kind` without knowing the traversal can't have
   expanded into a different kind.
+- **The flattened schema properties have the same gap.** `ctx.e.role` is
+  typed against the requested edge kind's schema, but an inverse-branch
+  row's real props came from a different schema and may not have a `role`
+  field at all — reading it returns `undefined`, not a type error.
 - **`id`/`fromId`/`toId` stay plain `string`**, unlike `SelectableNode<N>.id`
   — deliberately not branded `EdgeId<E>`/`NodeId<From>`/`NodeId<To>`. This
   one's just an ergonomics gap (`string` never overclaims), but branding
@@ -244,7 +250,9 @@ const company = await store.nodes.Company.getById(asNodeId<typeof Company>(rows[
 **Example:**
 
 ```typescript
-// Access edge properties in select context
+// Access edge properties in select context. expand: "none" makes the
+// schema (and kind/id) trustworthy — see the warning above.
+.traverse("worksAt", "e", { expand: "none" })
 .select((ctx) => ({
   role: ctx.e.role,           // Direct edge property access
   salary: ctx.e.salary,

--- a/apps/docs/src/content/docs/types.md
+++ b/apps/docs/src/content/docs/types.md
@@ -92,7 +92,7 @@ The node type available in `select()` context. Properties are flattened (not nes
 
 ```typescript
 type SelectableNode<N extends NodeType> = Readonly<{
-  id: string;
+  id: NodeId<N>;
   kind: N["kind"];
   meta: {
     version: number;
@@ -105,12 +105,15 @@ type SelectableNode<N extends NodeType> = Readonly<{
 }> & z.infer<N["schema"]>;  // Properties are flattened
 ```
 
+`id` carries the same `NodeId<N>` brand as `Node<N>`, so a projected id can be
+passed straight into `getById`/`getByIds` without a cast.
+
 **Example:**
 
 ```typescript
 // In select context, access properties directly
 .select((ctx) => ({
-  id: ctx.p.id,           // string
+  id: ctx.p.id,           // NodeId<Person>
   name: ctx.p.name,       // Direct property access (not ctx.p.props.name)
   email: ctx.p.email,
   created: ctx.p.meta.createdAt,
@@ -201,6 +204,41 @@ type SelectableEdge<E extends EdgeType> = Readonly<{
     deletedAt: string | undefined;
   };
 }> & z.infer<E["schema"]>;  // Edge properties are flattened
+```
+
+`traverse()` defaults to `expand: "inverse"`, which can match the graph's
+*registered inverse* edge kind alongside the one you asked for, so the row
+behind an edge alias isn't guaranteed to be the requested kind. This affects
+`SelectableEdge` in two different ways:
+
+- **`kind: E["kind"]` can already be wrong today.** It's a literal type
+  (e.g. `"manages"`), not `string` — but the runtime value can be the
+  registered inverse kind (e.g. `"managedBy"`) under the default expansion
+  mode. This isn't a missing brand, it's an existing type-accuracy gap:
+  don't trust `ctx.e.kind` without knowing the traversal can't have
+  expanded into a different kind.
+- **`id`/`fromId`/`toId` stay plain `string`**, unlike `SelectableNode<N>.id`
+  — deliberately not branded `EdgeId<E>`/`NodeId<From>`/`NodeId<To>`. This
+  one's just an ergonomics gap (`string` never overclaims), but branding
+  these fields would compile while being actively wrong for the same
+  reason: a mismatched-kind id would compile straight into `getById` and
+  silently return `undefined` instead of erroring.
+
+When you know a traversal is single-kind, re-brand explicitly:
+
+```typescript
+import { asEdgeId, asNodeId } from "@nicia-ai/typegraph";
+
+const rows = await store
+  .query()
+  .from("Person", "p")
+  .traverse("worksAt", "e", { expand: "none" })
+  .to("Company", "c")
+  .select((ctx) => ({ edgeId: ctx.e.id, companyId: ctx.e.toId }))
+  .execute();
+
+const edge = await store.edges.worksAt.getById(asEdgeId<typeof worksAt>(rows[0]!.edgeId));
+const company = await store.nodes.Company.getById(asNodeId<typeof Company>(rows[0]!.companyId));
 ```
 
 **Example:**

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -468,15 +468,22 @@ export type SelectableEdgeMeta = Readonly<{
  * requested one — `EdgeAlias<E>`'s `E` stays pinned to the single requested
  * kind regardless, so under the default expansion mode the row backing
  * `alias` can genuinely be a different edge kind (with different endpoint
- * kinds) than `E` says. Two distinct consequences follow:
+ * kinds and a different props schema — `inverseOf(edgeA, edgeB)` doesn't
+ * require `edgeA`/`edgeB` to share a schema) than `E` says. Three distinct
+ * consequences follow:
  *
  * - `kind: E["kind"]` is a **literal type that can already be wrong today**
  *   — not a branding gap, a plain type-accuracy gap. It's typed as the
  *   requested kind (e.g. `"manages"`) but the runtime value can be the
- *   inverse kind (e.g. `"managedBy"`); see the `"proves why edge ids
- *   can't be auto-branded"` test in `tests/query-execution.test.ts` for a
- *   concrete repro. This predates and is independent of the id/endpoint
- *   branding question below.
+ *   inverse kind (e.g. `"managedBy"`); see the `"proves why edge
+ *   id/kind/schema props can't be trusted"` test in
+ *   `tests/query-execution.test.ts` for a concrete repro. This predates
+ *   and is independent of the id/endpoint branding question below.
+ * - The flattened `z.infer<E["schema"]>` properties have the same
+ *   type-accuracy gap as `kind`, for the same reason: `ctx.e.role` is typed
+ *   against the requested kind's schema, but an inverse-branch row's real
+ *   props came from a different schema and may not have a `role` field at
+ *   all (reading it returns `undefined`, not a type error).
  * - `id`/`fromId`/`toId` stay plain `string`, unlike `SelectableNode`'s
  *   `id: NodeId<N>` — a real ergonomics gap, but not an accuracy one: `string`
  *   never overclaims. Branding them would compile but be actively wrong:
@@ -484,15 +491,16 @@ export type SelectableEdgeMeta = Readonly<{
  *   silently returns `undefined` for a mismatched-kind id — worse than the
  *   unsafe cast it would have replaced.
  *
- * Proving either is safe requires tracking `expand` mode (`"none"` vs not)
- * at the type level through `TraversalBuilder`/`EdgeAlias` — evaluated for
- * #235 and deliberately not built: the machinery would touch every
+ * Proving any of these safe requires tracking `expand` mode (`"none"` vs
+ * not) at the type level through `TraversalBuilder`/`EdgeAlias` — evaluated
+ * for #235 and deliberately not built: the machinery would touch every
  * traversal-entry overload for a benefit that only applies when a caller
  * opts out of the default expansion. When you know a traversal is
- * single-kind, re-brand `id`/`fromId`/`toId` explicitly with
- * `asNodeId`/`asEdgeId` (see #223) — e.g.
- * `asNodeId<typeof Company>(edge.fromId)` — and don't trust `kind` without
- * independently verifying the traversal can't have expanded.
+ * single-kind (e.g. via `expand: "none"`), re-brand `id`/`fromId`/`toId`
+ * explicitly with `asNodeId`/`asEdgeId` (see #223) — e.g.
+ * `asNodeId<typeof Person>(edge.fromId)` for a `Person -> Company` edge —
+ * and don't trust `kind` or schema properties without independently
+ * verifying the traversal can't have expanded.
  */
 export type SelectableEdge<E extends AnyEdgeType = EdgeType> =
   IsDynamicEdgeType<E> extends true ? DynamicSelectableEdge

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -462,19 +462,37 @@ export type SelectableEdgeMeta = Readonly<{
  *
  * Dynamic-mode counterpart: see `SelectableNode`.
  *
- * `id`/`kind`/`fromId`/`toId` stay plain `string`, unlike `SelectableNode`'s
- * `id: NodeId<N>`. `traverse(edgeKind, alias)` defaults to
- * `expand: "inverse"` (see `GraphAlgorithms`/`QueryBuilder.traverse`'s
- * `defaultTraversalExpansion`), which UNIONs in rows for the *registered
- * inverse* edge kind alongside the requested one — `EdgeAlias<E>`'s `E`
- * stays pinned to the single requested kind regardless, so under the
- * default expansion mode the row backing `alias` can genuinely be a
- * different edge kind than `E` says. Branding `id` as `EdgeId<E>` there
- * would compile but be actively wrong: `store.edges.<E>.getById()` filters
- * on `row.kind !== kind` and silently returns `undefined` for a
- * mismatched-kind id — worse than the unsafe cast it would have replaced.
- * Safe to brand once `EdgeAlias` tracks whether expansion could have
- * produced a different kind (`expand: "none"` vs not); see #235's note.
+ * `traverse(edgeKind, alias)` defaults to `expand: "inverse"` (see
+ * `GraphAlgorithms`/`QueryBuilder.traverse`'s `defaultTraversalExpansion`),
+ * which UNIONs in rows for the *registered inverse* edge kind alongside the
+ * requested one — `EdgeAlias<E>`'s `E` stays pinned to the single requested
+ * kind regardless, so under the default expansion mode the row backing
+ * `alias` can genuinely be a different edge kind (with different endpoint
+ * kinds) than `E` says. Two distinct consequences follow:
+ *
+ * - `kind: E["kind"]` is a **literal type that can already be wrong today**
+ *   — not a branding gap, a plain type-accuracy gap. It's typed as the
+ *   requested kind (e.g. `"manages"`) but the runtime value can be the
+ *   inverse kind (e.g. `"managedBy"`); see the `"proves why edge ids
+ *   can't be auto-branded"` test in `tests/query-execution.test.ts` for a
+ *   concrete repro. This predates and is independent of the id/endpoint
+ *   branding question below.
+ * - `id`/`fromId`/`toId` stay plain `string`, unlike `SelectableNode`'s
+ *   `id: NodeId<N>` — a real ergonomics gap, but not an accuracy one: `string`
+ *   never overclaims. Branding them would compile but be actively wrong:
+ *   e.g. `store.edges.<E>.getById()` filters on `row.kind !== kind` and
+ *   silently returns `undefined` for a mismatched-kind id — worse than the
+ *   unsafe cast it would have replaced.
+ *
+ * Proving either is safe requires tracking `expand` mode (`"none"` vs not)
+ * at the type level through `TraversalBuilder`/`EdgeAlias` — evaluated for
+ * #235 and deliberately not built: the machinery would touch every
+ * traversal-entry overload for a benefit that only applies when a caller
+ * opts out of the default expansion. When you know a traversal is
+ * single-kind, re-brand `id`/`fromId`/`toId` explicitly with
+ * `asNodeId`/`asEdgeId` (see #223) — e.g.
+ * `asNodeId<typeof Company>(edge.fromId)` — and don't trust `kind` without
+ * independently verifying the traversal can't have expanded.
  */
 export type SelectableEdge<E extends AnyEdgeType = EdgeType> =
   IsDynamicEdgeType<E> extends true ? DynamicSelectableEdge

--- a/packages/typegraph/tests/query-builder-types.test.ts
+++ b/packages/typegraph/tests/query-builder-types.test.ts
@@ -476,6 +476,30 @@ describe("Query Builder Type Safety", () => {
 
       expect(query).toBeDefined();
     });
+
+    it("leaves projected fromId/toId as plain string, not NodeId<From>/NodeId<To>", () => {
+      // Same hazard as ctx.e.id above: fromId/toId describe the traversal's
+      // requested endpoint kinds, but under the default expand: "inverse"
+      // the matched row (and its real endpoints) can belong to the
+      // registered inverse edge kind instead. See SelectableEdge's
+      // docblock and issue #235 for why this is closed as
+      // documentation-only rather than auto-branded.
+      const query = createQueryBuilder<typeof graph>(graph.id, registry)
+        .from("Person", "p")
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .select((context) => ({
+          fromId: context.e.fromId,
+          toId: context.e.toId,
+        }));
+
+      type Projected = Awaited<ReturnType<(typeof query)["execute"]>>[number];
+
+      expectTypeOf<Projected["fromId"]>().toEqualTypeOf<string>();
+      expectTypeOf<Projected["toId"]>().toEqualTypeOf<string>();
+
+      expect(query).toBeDefined();
+    });
   });
 });
 

--- a/packages/typegraph/tests/query-execution.test.ts
+++ b/packages/typegraph/tests/query-execution.test.ts
@@ -687,13 +687,19 @@ describe("Query Execution (SQLite)", () => {
       expect(company?.name).toBe("Acme Inc");
     });
 
-    it("proves why edge ids can't be auto-branded: default expand mixes in the inverse kind", async () => {
+    it("proves why edge id/kind/schema props can't be trusted: default expand mixes in the inverse kind", async () => {
       // Concrete reproduction of the hazard SelectableEdge's docblock
       // describes: traverse()'s default expand: "inverse" unions in rows
       // for the registered inverse edge kind, so the row backing an alias
-      // can be a genuinely different edge kind than the one requested.
-      const manages = defineEdge("manages", { schema: z.object({}) });
-      const managedBy = defineEdge("managedBy", { schema: z.object({}) });
+      // can be a genuinely different edge kind than the one requested -
+      // with a genuinely different schema, since inverseOf() doesn't
+      // require the two edge kinds to share one.
+      const manages = defineEdge("manages", {
+        schema: z.object({ note: z.string().optional() }),
+      });
+      const managedBy = defineEdge("managedBy", {
+        schema: z.object({ department: z.string().optional() }),
+      });
       const orgGraph = defineGraph({
         id: "inverse_kind_mismatch",
         nodes: { Person: { type: Person } },
@@ -712,7 +718,7 @@ describe("Query Execution (SQLite)", () => {
       const managedByEdge = await orgStore.edges.managedBy.create(
         report,
         boss,
-        {},
+        { department: "Engineering" },
       );
 
       const rows = await orgStore
@@ -721,7 +727,11 @@ describe("Query Execution (SQLite)", () => {
         .whereNode("boss", (p) => p.name.eq("Boss"))
         .traverse("manages", "e") // default expand: "inverse"
         .to("Person", "report")
-        .select((context) => ({ id: context.e.id, kind: context.e.kind }))
+        .select((context) => ({
+          id: context.e.id,
+          kind: context.e.kind,
+          note: context.e.note,
+        }))
         .execute();
 
       expect(rows).toHaveLength(1);
@@ -729,6 +739,10 @@ describe("Query Execution (SQLite)", () => {
       // managedBy edge matched via inverse expansion.
       expect(rows[0]!.kind).toBe("managedBy");
       expect(rows[0]!.id).toBe(managedByEdge.id);
+      // `note` is typed string | undefined per manages's schema, but the
+      // real row is managedBy's { department } - there's no `note` key at
+      // all, so this silently reads as undefined rather than erroring.
+      expect(rows[0]!.note).toBeUndefined();
 
       // Blindly trusting the requested alias's kind silently loses data...
       const wrongKindLookup = await orgStore.edges.manages.getById(
@@ -736,11 +750,12 @@ describe("Query Execution (SQLite)", () => {
       );
       expect(wrongKindLookup).toBeUndefined();
 
-      // ...the row only resolves under its real kind.
+      // ...the row only resolves under its real kind, with its real schema.
       const rightKindLookup = await orgStore.edges.managedBy.getById(
         asEdgeId<typeof managedBy>(rows[0]!.id),
       );
       expect(rightKindLookup?.id).toBe(managedByEdge.id);
+      expect(rightKindLookup?.department).toBe("Engineering");
     });
   });
 

--- a/packages/typegraph/tests/query-execution.test.ts
+++ b/packages/typegraph/tests/query-execution.test.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import {
   asEdgeId,
+  asNodeId,
   count,
   defineEdge,
   defineGraph,
@@ -655,6 +656,35 @@ describe("Query Execution (SQLite)", () => {
 
       const edge = await store.edges.worksAt.getById(brandedWorksAtId);
       expect(edge?.role).toBe("Engineer");
+    });
+
+    it("keeps projected fromId/toId as string, requiring asNodeId to re-brand them", async () => {
+      // Same hazard as edge id (see SelectableEdge's docblock and #235):
+      // fromId/toId describe the requested traversal's endpoint kinds, but
+      // under expand: "inverse" the matched row's real endpoints can
+      // differ. asNodeId is the sanctioned way to re-apply the brand once
+      // the caller knows the traversal is actually single-kind.
+      const rows = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.eq("Alice"))
+        .traverse("worksAt", "e")
+        .to("Company", "c")
+        .select((context) => ({
+          fromId: context.e.fromId,
+          toId: context.e.toId,
+        }))
+        .execute();
+
+      const [row] = rows;
+      expect(row).toBeDefined();
+
+      const [person, company] = await Promise.all([
+        store.nodes.Person.getById(asNodeId<typeof Person>(row!.fromId)),
+        store.nodes.Company.getById(asNodeId<typeof Company>(row!.toId)),
+      ]);
+      expect(person?.name).toBe("Alice");
+      expect(company?.name).toBe("Acme Inc");
     });
 
     it("proves why edge ids can't be auto-branded: default expand mixes in the inverse kind", async () => {


### PR DESCRIPTION
## What changed

Issue #235 proposed branding `SelectableEdge.fromId`/`.toId` as `NodeId<From>`/`NodeId<To>` (matching how `Edge<E, From, To>` already brands them outside `.select()`). Investigating the implementation surfaced the identical hazard that got `SelectableEdge.id`'s brand reverted in #237: `traverse(edgeKind, alias)` defaults to `expand: "inverse"`, which UNIONs in rows for the graph's *registered inverse* edge kind alongside the requested one — so the row backing an edge alias isn't guaranteed to have the requested endpoint kinds either.

Proving it's safe requires tracking `expand` mode (`"none"` vs not) as a type parameter threaded through `TraversalBuilder` (11 type parameters today) and every traversal-entry overload (`traverse`, `.to()`, `.recursive()`, `.whereEdge()`, and for consistency `optionalTraverse`), only branding when a caller explicitly proves single-kind via `expand: "none"`. I evaluated this and it's disproportionate: it touches many overload signatures across two large, already-intricate files, for a benefit that only applies when a caller opts out of the default expansion mode. `asNodeId<Type>(edge.fromId)` (from #223, merged) already provides a sound manual re-brand path with zero code changes needed — closing this as **documentation-only**.

## Doc bugs fixed along the way (found via review, not the original scope)

- `apps/docs/src/content/docs/types.md`'s `SelectableNode<N>` reference was stale — it still showed `id: string`, even though #237 already changed this to `NodeId<N>` in code. Missed updating this doc page in that PR; fixed here.
- The `SelectableEdge` docblock originally lumped `kind` in with "stays plain string," which is wrong on two counts: `kind: E["kind"]` is a literal type, not `string`, and it's a *worse*, pre-existing problem than the branding question — `kind` already lies at runtime under default expansion today, independent of any branding decision. Caught by `/simplify`'s altitude review.
- The flattened schema properties (`z.infer<E["schema"]>`) have the identical accuracy gap as `kind`: `inverseOf(edgeA, edgeB)` doesn't require the two edge kinds to share a schema, so `ctx.e.role` can be typed against the requested kind while the real (inverse-branch) row has a totally different props shape. Extended the docblock, the docs page, and the repro test to cover this. Also made the docs' property-access example explicit about needing `expand: "none"` to trust it.
- The docblock's own re-brand example had `fromId`/`toId` backwards — `asNodeId<typeof Company>(edge.fromId)` implied `fromId` is the `Company` side of a `Person -> Company` edge, when it's actually `Person`. Fixed. Both caught by a pre-landing review pass.

## Testing

- `packages/typegraph/tests/query-builder-types.test.ts` — compile-time assertion that projected `fromId`/`toId` stay plain `string` (regression guard against a future attempt to brand them without the expand-tracking mechanism).
- `packages/typegraph/tests/query-execution.test.ts`:
  - Runtime test: query → project `fromId`/`toId` → re-brand with `asNodeId` → `getById` resolves correctly. Demonstrates the sanctioned pattern.
  - Extended the existing inverse-kind repro test (`"proves why edge id/kind/schema props can't be trusted"`) to also cover the schema-props hazard: `manages`/`managedBy` now have distinct schema fields, and the test asserts the requested kind's field reads back `undefined` on the inverse-branch row, while the real kind's field resolves correctly.

Closes #235