### PR TITLE
fix: reject endpoint-incompatible implies() ontology relations

### DIFF
--- a/.changeset/implies-endpoint-validation.md
+++ b/.changeset/implies-endpoint-validation.md
@@ -1,0 +1,26 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fixes `implies(edgeA, edgeB)` silently accepting endpoint-incompatible edge
+pairs. Previously an ontology declaration like `implies(about, writes)` — where
+`about` connects `Paper -> Topic` and `writes` connects `Author -> Paper` —
+was accepted without complaint, and `expand: "implying"` query traversal
+would then silently fold `about` rows into a `writes` traversal even though
+the two edges connect entirely different node kinds.
+
+`implies()` relations are now validated wherever a query-capable
+`KindRegistry` is built — `createStore()`/`createStoreWithSchema()` for a
+live graph definition, and `deserializeSchema(...).buildRegistry()` for a
+persisted schema — including relations authored through
+`store.evolve({ ontology })`. A relation is accepted when every kind the
+implying edge allows on a side (`from`/`to`) is assignable — equal, or a
+`subClassOf` descendant — to at least one kind the implied edge allows on
+that same side; otherwise construction throws a `ConfigurationError`
+describing the incompatible kinds and how to fix the declaration.
+
+This is a behavior change: a graph with a previously-silent
+endpoint-incompatible `implies()` relation will now throw when a store is
+created or a persisted schema's registry is rebuilt. Fix such relations by
+narrowing the implying edge's endpoints, adding a `subClassOf` relation to
+bridge the mismatch, or removing the `implies()` declaration.

--- a/apps/docs/src/content/docs/ontology.md
+++ b/apps/docs/src/content/docs/ontology.md
@@ -198,6 +198,18 @@ const connections = await store
   .execute();
 ```
 
+**Endpoint compatibility is required.** `implies(edgeA, edgeB)` only makes
+sense if every node kind `edgeA` can connect could also, in principle,
+satisfy `edgeB`'s own domain/range — otherwise `expand: "implying"` would
+traverse rows whose kinds don't match what the traversal actually asked for.
+Every kind `edgeA` allows on a side (`from`/`to`) must be assignable — equal,
+or a `subClassOf` descendant — to at least one kind `edgeB` allows on that
+same side. An incompatible pair (say, `Author -> Paper` implying
+`Paper -> Topic`) throws `ConfigurationError` wherever the graph is built
+into a store or committed as a schema version (`createStore`,
+`createStoreWithSchema`, `store.evolve({ ontology })`) — including relations
+authored through a graph extension, not just `implies()` calls in code.
+
 ## Using the Ontology
 
 ### In Graph Definition
@@ -474,6 +486,12 @@ Declares that one edge type implies another exists.
 ```typescript
 function implies(edgeA: EdgeType, edgeB: EdgeType): OntologyRelation;
 ```
+
+`edgeA`'s endpoints must be assignable to `edgeB`'s endpoints (equal, or a
+`subClassOf` descendant) on both the `from` and `to` side. Throws
+`ConfigurationError` when the graph is built into a store or committed as a
+schema version if they aren't — see [Edge Relationships](#edge-relationships)
+above.
 
 #### `metaEdge(name, options?)`
 

--- a/apps/docs/src/content/docs/queries/traverse.md
+++ b/apps/docs/src/content/docs/queries/traverse.md
@@ -248,6 +248,15 @@ const connections = await store
 // Returns people connected via "knows", "marriedTo", or "bestFriends"
 ```
 
+`expand: "implying"` is only reachable for endpoint-compatible implications:
+every node kind an implying edge (e.g. `marriedTo`) allows on a side must be
+assignable to a kind the implied edge (`knows`) allows on that same side.
+`implies()` relations that don't satisfy this are rejected with a
+`ConfigurationError` when the graph is built into a store, so an
+`expand: "implying"` traversal can never fold in rows whose kind couldn't
+actually satisfy the traversal's own endpoints. See
+[Ontology → Edge Relationships](/ontology#edge-relationships) for details.
+
 If your ontology defines inverse edge kinds, you can expand traversals to include inverse edges:
 
 ```typescript

--- a/packages/typegraph/examples/08-custom-ontology.ts
+++ b/packages/typegraph/examples/08-custom-ontology.ts
@@ -248,11 +248,11 @@ const graph = defineGraph({
     // === Edge semantics ===
     inverseOf(cites, citedBy),
     // Both edges are Publication -> Publication, so the implication is
-    // endpoint-compatible. Pitfall: the library does NOT validate this —
-    // an implication between edges with mismatched endpoints (say,
-    // Author->Paper implies Paper->Topic) is silently accepted, and
-    // `expand: "implying"` would then traverse the mismatched edges.
-    // Keep implication chains within compatible endpoint signatures.
+    // endpoint-compatible. The library rejects implications between edges
+    // with mismatched endpoints (say, Author->Paper implies Paper->Topic)
+    // with a ConfigurationError — wherever the graph is built into a store
+    // or committed as a schema version — since `expand: "implying"` would
+    // otherwise traverse the mismatched edges.
     implies(buildsOn, cites),
 
     // === Custom meta-edge relations ===

--- a/packages/typegraph/src/constraints/index.ts
+++ b/packages/typegraph/src/constraints/index.ts
@@ -330,11 +330,7 @@ export function validateEdgeEndpoints(
 ): EndpointError | undefined {
   // Check from kinds
   const validFromKinds = registration.from.map((node) => node.kind);
-  const fromValid = validFromKinds.some((validKind) =>
-    registry.isAssignableTo(fromKind, validKind),
-  );
-
-  if (!fromValid) {
+  if (!registry.isAssignableToAny(fromKind, validFromKinds)) {
     return new EndpointError({
       edgeKind,
       endpoint: "from",
@@ -345,11 +341,7 @@ export function validateEdgeEndpoints(
 
   // Check to kinds
   const validToKinds = registration.to.map((node) => node.kind);
-  const toValid = validToKinds.some((validKind) =>
-    registry.isAssignableTo(toKind, validKind),
-  );
-
-  if (!toValid) {
+  if (!registry.isAssignableToAny(toKind, validToKinds)) {
     return new EndpointError({
       edgeKind,
       endpoint: "to",

--- a/packages/typegraph/src/registry/builders.ts
+++ b/packages/typegraph/src/registry/builders.ts
@@ -17,6 +17,10 @@ import {
   createEmptyClosures,
   KindRegistry,
 } from "./kind-registry";
+import {
+  type EdgeEndpointKinds,
+  validateImpliesEndpointCompatibility,
+} from "./validate-implies";
 
 // ============================================================
 // Build Registry from GraphDef
@@ -53,7 +57,38 @@ export function buildKindRegistry<G extends GraphDef>(graph: G): KindRegistry {
       computeClosuresFromOntology(graph.ontology)
     : createEmptyClosures();
 
-  return new KindRegistry(nodeTypes, edgeTypes, closures);
+  const registry = new KindRegistry(nodeTypes, edgeTypes, closures);
+  validateImpliesEndpointCompatibility(
+    graph.ontology.map((relation) => ({
+      metaEdgeName: relation.metaEdge.name,
+      from: relation.from,
+      to: relation.to,
+    })),
+    buildEdgeEndpointKinds(graph.edges),
+    registry,
+  );
+
+  return registry;
+}
+
+/**
+ * Maps each registered edge kind to its declared domain/range kind names,
+ * for `validateImpliesEndpointCompatibility`. A `Map` (rather than the
+ * plain `graph.edges` object) so a lookup for an edge kind literally named
+ * "toString" or another `Object.prototype` member can't resolve to an
+ * inherited member instead of `undefined`.
+ */
+function buildEdgeEndpointKinds(
+  edges: Record<string, EdgeRegistration>,
+): ReadonlyMap<string, EdgeEndpointKinds> {
+  const result = new Map<string, EdgeEndpointKinds>();
+  for (const [kind, registration] of Object.entries(edges)) {
+    result.set(kind, {
+      from: registration.from.map((node) => node.kind),
+      to: registration.to.map((node) => node.kind),
+    });
+  }
+  return result;
 }
 
 // ============================================================

--- a/packages/typegraph/src/registry/kind-registry.ts
+++ b/packages/typegraph/src/registry/kind-registry.ts
@@ -277,6 +277,21 @@ export class KindRegistry {
   }
 
   /**
+   * Checks if a concrete kind is assignable to at least one of the given
+   * target kinds. Shared by every "is this kind usable where one of these
+   * kinds is expected" check (edge endpoint validation, ontology relation
+   * endpoint compatibility) so they can't independently drift.
+   */
+  isAssignableToAny(
+    concreteKind: string,
+    targetKinds: readonly string[],
+  ): boolean {
+    return targetKinds.some((targetKind) =>
+      this.isAssignableTo(concreteKind, targetKind),
+    );
+  }
+
+  /**
    * Validates that a kind exists in the registry.
    */
   hasNodeType(name: string): boolean {

--- a/packages/typegraph/src/registry/validate-implies.ts
+++ b/packages/typegraph/src/registry/validate-implies.ts
@@ -1,0 +1,121 @@
+/**
+ * Endpoint-compatibility validation for `implies()` ontology relations.
+ *
+ * Every place that builds a query-capable `KindRegistry` — `buildKindRegistry`
+ * for a live `GraphDef`, and the schema deserializer for a persisted schema —
+ * calls this so an endpoint-incompatible `implies(edgeA, edgeB)` can never
+ * reach `KindRegistry.expandImplyingEdges()`. Without this gate, `edgeA`
+ * would be folded into any `expand: "implying"` traversal for `edgeB` even
+ * when `edgeA` connects entirely different node kinds — the query compiler
+ * filters by expanded edge kind plus the *queried* node aliases, not by
+ * `edgeB`'s own domain/range, so a mismatched edge would silently satisfy
+ * whatever kinds the traversal alias happens to ask for.
+ */
+import { ConfigurationError } from "../errors/index";
+import { META_EDGE_IMPLIES } from "../ontology/constants";
+import { getTypeName, type OntologyRelation } from "../ontology/types";
+import { type KindRegistry } from "./kind-registry";
+
+/**
+ * The minimal shape both a live `OntologyRelation` (`metaEdge` is a
+ * `MetaEdge` object, `from`/`to` may be `EdgeType` objects) and a
+ * `SerializedOntologyRelation` (`metaEdge`/`from`/`to` are all plain
+ * strings) can be adapted to — this validator only needs the meta-edge
+ * name and each endpoint's kind name. `from`/`to` reuse `OntologyRelation`'s
+ * own field type so this can never drift from what `getTypeName()` accepts.
+ */
+export type ImpliesRelationLike = Readonly<{
+  metaEdgeName: string;
+  from: OntologyRelation["from"];
+  to: OntologyRelation["to"];
+}>;
+
+/** An edge kind's declared domain (`from`) and range (`to`) kind names. */
+export type EdgeEndpointKinds = Readonly<{
+  from: readonly string[];
+  to: readonly string[];
+}>;
+
+/**
+ * Rejects `implies(edgeA, edgeB)` relations whose declared endpoints can
+ * never be compatible with the edge they imply.
+ *
+ * A relation is compatible when every kind the implying edge allows on a
+ * side is assignable — via `registry.isAssignableToAny` (equal, or a
+ * `subClassOf` descendant) — to at least one kind the implied edge allows
+ * on that same side. Relations naming an edge kind absent from
+ * `edgeEndpoints` are skipped — they cannot affect this graph's traversals.
+ *
+ * Soundness holds transitively: validating each direct relation certifies
+ * the whole `edgeImplyingClosure`, since subclass assignability composes
+ * (if A implies B and B implies C, A→B and B→C compatibility together
+ * guarantee A→C compatibility) — no separate check of the expanded closure
+ * is needed.
+ */
+export function validateImpliesEndpointCompatibility(
+  relations: readonly ImpliesRelationLike[],
+  edgeEndpoints: ReadonlyMap<string, EdgeEndpointKinds>,
+  registry: KindRegistry,
+): void {
+  for (const relation of relations) {
+    if (relation.metaEdgeName !== META_EDGE_IMPLIES) continue;
+
+    const implyingEdgeKind = getTypeName(relation.from);
+    const impliedEdgeKind = getTypeName(relation.to);
+    const implyingEndpoints = edgeEndpoints.get(implyingEdgeKind);
+    const impliedEndpoints = edgeEndpoints.get(impliedEdgeKind);
+    if (!implyingEndpoints || !impliedEndpoints) continue;
+
+    assertEndpointCompatible(
+      "from",
+      implyingEdgeKind,
+      implyingEndpoints.from,
+      impliedEdgeKind,
+      impliedEndpoints.from,
+      registry,
+    );
+    assertEndpointCompatible(
+      "to",
+      implyingEdgeKind,
+      implyingEndpoints.to,
+      impliedEdgeKind,
+      impliedEndpoints.to,
+      registry,
+    );
+  }
+}
+
+function assertEndpointCompatible(
+  side: "from" | "to",
+  implyingEdgeKind: string,
+  implyingKinds: readonly string[],
+  impliedEdgeKind: string,
+  impliedKinds: readonly string[],
+  registry: KindRegistry,
+): void {
+  const incompatibleKinds = implyingKinds.filter(
+    (kind) => !registry.isAssignableToAny(kind, impliedKinds),
+  );
+  if (incompatibleKinds.length === 0) return;
+
+  throw new ConfigurationError(
+    `implies("${implyingEdgeKind}", "${impliedEdgeKind}") is endpoint-incompatible: ` +
+      `${side} kind(s) [${incompatibleKinds.join(", ")}] declared on "${implyingEdgeKind}" ` +
+      `cannot be assigned to any of "${impliedEdgeKind}"'s ${side} kind(s) [${impliedKinds.join(", ")}].`,
+    {
+      metaEdge: META_EDGE_IMPLIES,
+      implyingEdge: implyingEdgeKind,
+      impliedEdge: impliedEdgeKind,
+      endpoint: side,
+      incompatibleKinds,
+      allowedKinds: impliedKinds,
+    },
+    {
+      suggestion:
+        `Add a subClassOf relation from each of [${incompatibleKinds.join(", ")}] to one of ` +
+        `"${impliedEdgeKind}"'s ${side} kind(s) [${impliedKinds.join(", ")}], narrow "${implyingEdgeKind}"'s ` +
+        `${side} declaration to exclude [${incompatibleKinds.join(", ")}], or remove ` +
+        `implies("${implyingEdgeKind}", "${impliedEdgeKind}").`,
+    },
+  );
+}

--- a/packages/typegraph/src/schema/deserializer.ts
+++ b/packages/typegraph/src/schema/deserializer.ts
@@ -7,6 +7,10 @@
  */
 import { KindRegistry } from "../registry/kind-registry";
 import {
+  type EdgeEndpointKinds,
+  validateImpliesEndpointCompatibility,
+} from "../registry/validate-implies";
+import {
   type SerializedClosures,
   type SerializedEdgeDef,
   type SerializedMetaEdge,
@@ -136,7 +140,7 @@ function buildRegistryFromClosures(schema: SerializedSchema): KindRegistry {
   const nodeKinds = new Map();
   const edgeKinds = new Map();
 
-  return new KindRegistry(nodeKinds, edgeKinds, {
+  const registry = new KindRegistry(nodeKinds, edgeKinds, {
     subClassAncestors,
     subClassDescendants,
     broaderClosure,
@@ -150,6 +154,35 @@ function buildRegistryFromClosures(schema: SerializedSchema): KindRegistry {
     edgeImplicationsClosure,
     edgeImplyingClosure,
   });
+
+  validateImpliesEndpointCompatibility(
+    schema.ontology.relations.map((relation) => ({
+      metaEdgeName: relation.metaEdge,
+      from: relation.from,
+      to: relation.to,
+    })),
+    buildEdgeEndpointKinds(schema.edges),
+    registry,
+  );
+
+  return registry;
+}
+
+/**
+ * Maps each edge kind's serialized definition to its domain/range kind
+ * names, for `validateImpliesEndpointCompatibility`. A `Map` (rather than
+ * the plain `schema.edges` object) so a lookup for an edge kind literally
+ * named "toString" or another `Object.prototype` member can't resolve to
+ * an inherited member instead of `undefined`.
+ */
+function buildEdgeEndpointKinds(
+  edges: Record<string, SerializedEdgeDef>,
+): ReadonlyMap<string, EdgeEndpointKinds> {
+  const result = new Map<string, EdgeEndpointKinds>();
+  for (const [kind, def] of Object.entries(edges)) {
+    result.set(kind, { from: def.fromKinds, to: def.toKinds });
+  }
+  return result;
 }
 
 /**

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -15,6 +15,7 @@ import {
   MigrationError,
 } from "../errors";
 import { mergeGraphExtension } from "../graph-extension/merge";
+import { buildKindRegistry } from "../registry";
 import { freezeDeep } from "../utils/object";
 import { isMissingTableError } from "../utils/sql-errors";
 import {
@@ -594,6 +595,12 @@ export async function initializeSchema<G extends GraphDef>(
   backend: GraphBackend,
   graph: G,
 ): Promise<SchemaVersionRow> {
+  // Structural gates (e.g. endpoint-incompatible implies() relations)
+  // must reject before the schema is durably committed, not only when a
+  // Store is later constructed against it — buildKindRegistry throws the
+  // same ConfigurationError a Store construction would, just earlier.
+  buildKindRegistry(graph);
+
   const schema = serializeSchema(graph, 1);
   const hash = await computeSchemaHash(schema);
 
@@ -646,6 +653,11 @@ export async function commitNewSchemaVersion<G extends GraphDef>(
   graph: G,
   currentVersion: number,
 ): Promise<SchemaVersionRow> {
+  // See initializeSchema: reject structurally invalid graphs (e.g.
+  // endpoint-incompatible implies() relations) before committing, not
+  // only when a Store is later built against the committed version.
+  buildKindRegistry(graph);
+
   const newVersion = currentVersion + 1;
   const schema = serializeSchema(graph, newVersion);
   const hash = await computeSchemaHash(schema);

--- a/packages/typegraph/tests/ontology-enforcement.test.ts
+++ b/packages/typegraph/tests/ontology-enforcement.test.ts
@@ -14,6 +14,7 @@ import {
   createQueryBuilder,
   defineEdge,
   defineGraph,
+  defineGraphExtension,
   defineNode,
   disjointWith,
   implies,
@@ -23,7 +24,7 @@ import {
 import { ConfigurationError, RestrictedDeleteError } from "../src/errors";
 import { buildKindRegistry } from "../src/registry/builders";
 import { deserializeSchema, serializeSchema } from "../src/schema";
-import { createStore } from "../src/store/store";
+import { createStore, createStoreWithSchema } from "../src/store/store";
 import { createTestBackend } from "./test-utils";
 
 // ============================================================
@@ -766,6 +767,112 @@ describe("implies() Endpoint Compatibility Validation", () => {
     ).toThrow(
       /from kind\(s\) \[OrganizationMsg\] declared on "memberOfMsg" cannot be assigned/,
     );
+  });
+
+  it("createStoreWithSchema rejects a bad implies() relation before committing any schema version", async () => {
+    const AuthorCommit = defineNode("AuthorCommit", { schema: z.object({}) });
+    const PaperCommit = defineNode("PaperCommit", { schema: z.object({}) });
+    const TopicCommit = defineNode("TopicCommit", { schema: z.object({}) });
+
+    const writes = defineEdge("writesCommit", { schema: z.object({}) });
+    const about = defineEdge("aboutCommit", { schema: z.object({}) });
+
+    const graph = defineGraph({
+      id: "implies_no_commit_on_reject",
+      nodes: {
+        AuthorCommit: { type: AuthorCommit },
+        PaperCommit: { type: PaperCommit },
+        TopicCommit: { type: TopicCommit },
+      },
+      edges: {
+        writesCommit: {
+          type: writes,
+          from: [AuthorCommit],
+          to: [PaperCommit],
+        },
+        aboutCommit: { type: about, from: [PaperCommit], to: [TopicCommit] },
+      },
+      ontology: [implies(about, writes)],
+    });
+
+    const backend = createTestBackend();
+
+    await expect(createStoreWithSchema(graph, backend)).rejects.toThrow(
+      ConfigurationError,
+    );
+
+    // The rejection must happen before the schema is durably committed —
+    // otherwise the invalid schema becomes the "active" version and every
+    // subsequent store construction against it throws forever, with no
+    // way to recover short of a manual rollback.
+    expect(await backend.getActiveSchema(graph.id)).toBeUndefined();
+
+    await backend.close();
+  });
+
+  it("store.evolve() rejects a bad implies() relation before committing a new schema version", async () => {
+    const AuthorEvolveCommit = defineNode("AuthorEvolveCommit", {
+      schema: z.object({}),
+    });
+    const PaperEvolveCommit = defineNode("PaperEvolveCommit", {
+      schema: z.object({}),
+    });
+    const TopicEvolveCommit = defineNode("TopicEvolveCommit", {
+      schema: z.object({}),
+    });
+
+    const writes = defineEdge("writesEvolveCommit", { schema: z.object({}) });
+    const about = defineEdge("aboutEvolveCommit", { schema: z.object({}) });
+
+    // The compile-time graph is valid on its own — no implies() yet.
+    const graph = defineGraph({
+      id: "implies_evolve_no_commit_on_reject",
+      nodes: {
+        AuthorEvolveCommit: { type: AuthorEvolveCommit },
+        PaperEvolveCommit: { type: PaperEvolveCommit },
+        TopicEvolveCommit: { type: TopicEvolveCommit },
+      },
+      edges: {
+        writesEvolveCommit: {
+          type: writes,
+          from: [AuthorEvolveCommit],
+          to: [PaperEvolveCommit],
+        },
+        aboutEvolveCommit: {
+          type: about,
+          from: [PaperEvolveCommit],
+          to: [TopicEvolveCommit],
+        },
+      },
+    });
+
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(graph, backend);
+    const initialRow = await backend.getActiveSchema(graph.id);
+    expect(initialRow?.version).toBe(1);
+
+    // Graph-extension-authored implies() relations carry plain edge-kind
+    // name strings rather than EdgeType objects — this reproduces #239's
+    // other real-world trigger (store.evolve, not compile-time implies()).
+    const badExtension = defineGraphExtension({
+      ontology: [
+        {
+          metaEdge: "implies",
+          from: "aboutEvolveCommit",
+          to: "writesEvolveCommit",
+        },
+      ],
+    });
+
+    await expect(store.evolve(badExtension)).rejects.toThrow(
+      ConfigurationError,
+    );
+
+    // No new schema version was committed — the active version is still 1.
+    const rowAfterRejectedEvolve = await backend.getActiveSchema(graph.id);
+    expect(rowAfterRejectedEvolve?.version).toBe(1);
+
+    await backend.close();
   });
 });
 

--- a/packages/typegraph/tests/ontology-enforcement.test.ts
+++ b/packages/typegraph/tests/ontology-enforcement.test.ts
@@ -20,8 +20,9 @@ import {
   inverseOf,
   subClassOf,
 } from "../src";
-import { RestrictedDeleteError } from "../src/errors";
+import { ConfigurationError, RestrictedDeleteError } from "../src/errors";
 import { buildKindRegistry } from "../src/registry/builders";
+import { deserializeSchema, serializeSchema } from "../src/schema";
 import { createStore } from "../src/store/store";
 import { createTestBackend } from "./test-utils";
 
@@ -458,6 +459,313 @@ describe("Edge Relationships - implies", () => {
     const registry = buildKindRegistry(graph);
 
     expect(registry.getImpliedEdges("likes")).toEqual([]);
+  });
+});
+
+// ============================================================
+// implies() Endpoint Compatibility Validation (issue #239)
+// ============================================================
+
+describe("implies() Endpoint Compatibility Validation", () => {
+  it("rejects an implication whose endpoints share no compatible kind on either side", () => {
+    // Reproduces #239: about (Paper -> Topic) implying writes (Author -> Paper)
+    // has no relationship between {Paper} and {Author}, nor {Topic} and {Paper}.
+    const Author = defineNode("Author", {
+      schema: z.object({ name: z.string() }),
+    });
+    const Paper = defineNode("Paper", {
+      schema: z.object({ title: z.string() }),
+    });
+    const Topic = defineNode("Topic", {
+      schema: z.object({ name: z.string() }),
+    });
+
+    const writes = defineEdge("writes", { schema: z.object({}) });
+    const about = defineEdge("about", { schema: z.object({}) });
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_endpoint_repro",
+          nodes: {
+            Author: { type: Author },
+            Paper: { type: Paper },
+            Topic: { type: Topic },
+          },
+          edges: {
+            writes: { type: writes, from: [Author], to: [Paper] },
+            about: { type: about, from: [Paper], to: [Topic] },
+          },
+          ontology: [implies(about, writes)],
+        }),
+      ),
+    ).toThrow(ConfigurationError);
+  });
+
+  it("rejects an implication that is only incompatible on the 'to' side", () => {
+    const Person = defineNode("PersonEp", { schema: z.object({}) });
+    const Document = defineNode("DocumentEp", { schema: z.object({}) });
+    const Report = defineNode("ReportEp", { schema: z.object({}) });
+
+    const authored = defineEdge("authored", { schema: z.object({}) });
+    const filed = defineEdge("filed", { schema: z.object({}) });
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_to_mismatch",
+          nodes: {
+            Person: { type: Person },
+            Document: { type: Document },
+            Report: { type: Report },
+          },
+          edges: {
+            authored: { type: authored, from: [Person], to: [Document] },
+            filed: { type: filed, from: [Person], to: [Report] },
+          },
+          ontology: [implies(authored, filed)],
+        }),
+      ),
+    ).toThrow(/endpoint-incompatible/);
+  });
+
+  it("accepts an implication when the implying edge's endpoint is a subclass of the implied edge's endpoint", () => {
+    const Organization = defineNode("OrganizationEp", { schema: z.object({}) });
+    const Company = defineNode("CompanyEp", { schema: z.object({}) });
+    const Person = defineNode("PersonEp2", { schema: z.object({}) });
+
+    const employedBy = defineEdge("employedBy", { schema: z.object({}) });
+    const affiliatedWith = defineEdge("affiliatedWith", {
+      schema: z.object({}),
+    });
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_subclass_ok",
+          nodes: {
+            Organization: { type: Organization },
+            Company: { type: Company },
+            Person: { type: Person },
+          },
+          edges: {
+            employedBy: { type: employedBy, from: [Person], to: [Company] },
+            affiliatedWith: {
+              type: affiliatedWith,
+              from: [Person],
+              to: [Organization],
+            },
+          },
+          ontology: [
+            subClassOf(Company, Organization),
+            implies(employedBy, affiliatedWith),
+          ],
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("requires every implying-side kind to be assignable, not just some", () => {
+    const Organization = defineNode("OrganizationEp2", {
+      schema: z.object({}),
+    });
+    const Company = defineNode("CompanyEp2", { schema: z.object({}) });
+
+    // memberOf allows Company OR Organization as its source; affiliatedWith
+    // only allows Company. Organization is not a Company (and not declared
+    // as its subclass), so this must fail even though Company alone would pass.
+    const memberOf = defineEdge("memberOf", { schema: z.object({}) });
+    const affiliatedWith = defineEdge("affiliatedWith2", {
+      schema: z.object({}),
+    });
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_partial_mismatch",
+          nodes: {
+            Organization: { type: Organization },
+            Company: { type: Company },
+          },
+          edges: {
+            memberOf: {
+              type: memberOf,
+              from: [Company, Organization],
+              to: [Company],
+            },
+            affiliatedWith2: {
+              type: affiliatedWith,
+              from: [Company],
+              to: [Company],
+            },
+          },
+          ontology: [
+            subClassOf(Company, Organization),
+            implies(memberOf, affiliatedWith),
+          ],
+        }),
+      ),
+    ).toThrow(ConfigurationError);
+  });
+
+  it("does not validate ontology relations naming an edge kind not registered on the graph", () => {
+    const Person = defineNode("PersonEp5", { schema: z.object({}) });
+
+    // "about" is a real EdgeType but is never added to this graph's `edges`
+    // — its declared endpoints can't affect this graph's traversals, so the
+    // relation is inert rather than validated.
+    const about = defineEdge("aboutEp", { schema: z.object({}) });
+    const knowsEp = defineEdge("knowsEp", { schema: z.object({}) });
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_unregistered_edge",
+          nodes: { Person: { type: Person } },
+          edges: {
+            knowsEp: { type: knowsEp, from: [Person], to: [Person] },
+          },
+          ontology: [implies(about, knowsEp)],
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects an implies() relation whose endpoints are plain kind-name strings, as graph-extension-authored relations carry", () => {
+    // compileOntologyRelation (graph-extension/compiler.ts) resolves an
+    // implies() relation's endpoints to plain edge-kind-name strings, not
+    // EdgeType objects — the shape store.evolve({ ontology }) produces.
+    // Simulate that shape directly rather than round-tripping through the
+    // full extension-merge pipeline.
+    const Author = defineNode("AuthorStr", { schema: z.object({}) });
+    const Paper = defineNode("PaperStr", { schema: z.object({}) });
+    const Topic = defineNode("TopicStr", { schema: z.object({}) });
+
+    const writes = defineEdge("writesStr", { schema: z.object({}) });
+    const about = defineEdge("aboutStr", { schema: z.object({}) });
+    const impliesMetaEdge = implies(writes, about).metaEdge;
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_string_endpoints",
+          nodes: {
+            Author: { type: Author },
+            Paper: { type: Paper },
+            Topic: { type: Topic },
+          },
+          edges: {
+            writesStr: { type: writes, from: [Author], to: [Paper] },
+            aboutStr: { type: about, from: [Paper], to: [Topic] },
+          },
+          ontology: [
+            { metaEdge: impliesMetaEdge, from: "aboutStr", to: "writesStr" },
+          ],
+        }),
+      ),
+    ).toThrow(ConfigurationError);
+  });
+
+  it("enforces the same validation when a registry is rebuilt from a persisted schema", () => {
+    const Author = defineNode("AuthorDs", { schema: z.object({}) });
+    const Paper = defineNode("PaperDs", { schema: z.object({}) });
+    const Topic = defineNode("TopicDs", { schema: z.object({}) });
+
+    const writes = defineEdge("writesDs", { schema: z.object({}) });
+    const about = defineEdge("aboutDs", { schema: z.object({}) });
+
+    // defineGraph() alone never validates implies() endpoints (only
+    // buildKindRegistry does), so this graph can be constructed and
+    // serialized without ever going through createStore.
+    const graph = defineGraph({
+      id: "implies_deserialized",
+      nodes: {
+        Author: { type: Author },
+        Paper: { type: Paper },
+        Topic: { type: Topic },
+      },
+      edges: {
+        writesDs: { type: writes, from: [Author], to: [Paper] },
+        aboutDs: { type: about, from: [Paper], to: [Topic] },
+      },
+      ontology: [implies(about, writes)],
+    });
+
+    const serialized = serializeSchema(graph, 1);
+
+    expect(() => deserializeSchema(serialized).buildRegistry()).toThrow(
+      ConfigurationError,
+    );
+  });
+
+  it("does not crash when an unregistered edge kind collides with an Object.prototype member name", () => {
+    const Person = defineNode("PersonProto", { schema: z.object({}) });
+
+    // "toString" is never added to this graph's `edges` — the lookup must
+    // resolve to undefined (correctly skipped), not to the inherited
+    // Object.prototype.toString function.
+    const toStringEdge = defineEdge("toString", { schema: z.object({}) });
+    const knowsProto = defineEdge("knowsProto", { schema: z.object({}) });
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_prototype_collision",
+          nodes: { Person: { type: Person } },
+          edges: {
+            knowsProto: { type: knowsProto, from: [Person], to: [Person] },
+          },
+          ontology: [implies(toStringEdge, knowsProto)],
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("error message scopes the incompatible kinds without implying they are the edge's full allowed set", () => {
+    const Organization = defineNode("OrganizationMsg", {
+      schema: z.object({}),
+    });
+    const Company = defineNode("CompanyMsg", { schema: z.object({}) });
+
+    const memberOf = defineEdge("memberOfMsg", { schema: z.object({}) });
+    const affiliatedWith = defineEdge("affiliatedWithMsg", {
+      schema: z.object({}),
+    });
+
+    expect(
+      () =>
+        buildKindRegistry(
+          defineGraph({
+            id: "implies_message_scope",
+            nodes: {
+              Organization: { type: Organization },
+              Company: { type: Company },
+            },
+            edges: {
+              memberOfMsg: {
+                type: memberOf,
+                from: [Company, Organization],
+                to: [Company],
+              },
+              affiliatedWithMsg: {
+                type: affiliatedWith,
+                from: [Company],
+                to: [Company],
+              },
+            },
+            ontology: [
+              subClassOf(Company, Organization),
+              implies(memberOf, affiliatedWith),
+            ],
+          }),
+        ),
+      // Company is compatible (subClassOf Organization is irrelevant here —
+      // Company matches affiliatedWith's Company directly); only
+      // Organization is incompatible. The message must not read as if
+      // Organization were memberOf's only allowed "from" kind.
+    ).toThrow(
+      /from kind\(s\) \[OrganizationMsg\] declared on "memberOfMsg" cannot be assigned/,
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #239: `implies(edgeA, edgeB)` accepted ontology relations whose declared
endpoints could never be compatible (e.g. an `about` edge connecting
`Paper -> Topic` "implying" a `writes` edge connecting `Author -> Paper`).
`expand: "implying"` query traversal would then silently fold `about` rows
into a `writes` traversal even though the two edges connect entirely
different node kinds — the query compiler filters by expanded edge kind
plus the *queried* node aliases, not by the implied edge's own domain/range.

- Adds `validateImpliesEndpointCompatibility` (`src/registry/validate-implies.ts`),
  called wherever a query-capable `KindRegistry` is built: `buildKindRegistry`
  for a live `GraphDef` (`createStore`/`createStoreWithSchema`), and the
  schema deserializer for a persisted schema (`deserializeSchema(...).buildRegistry()`)
  — including `implies()` relations authored via `store.evolve({ ontology })`,
  which carry plain kind-name strings rather than `EdgeType` objects.
- A relation is accepted when every kind the implying edge allows on a side
  (`from`/`to`) is assignable — equal, or a `subClassOf` descendant — to at
  least one kind the implied edge allows on that same side. Otherwise it
  throws `ConfigurationError` naming the incompatible kinds and how to fix
  the declaration.
- Adds `KindRegistry.isAssignableToAny`, reused by both this new check and
  the existing `validateEdgeEndpoints` (`src/constraints/index.ts`) so the
  "kind assignable to any of a list" logic has one implementation.
- Adds a changeset describing the behavior change: a graph with a
  previously-silent endpoint-incompatible `implies()` relation now throws
  when a store is created or a persisted schema's registry is rebuilt.

An earlier version of this fix only validated the live-`GraphDef` path and
read `.kind` directly off relation endpoints; a multi-agent code review
(`/code-review xhigh`) caught that this silently no-opped for
graph-extension/`evolve()`-authored relations (string endpoints) and that a
second `KindRegistry`-construction path (schema deserialization) bypassed
validation entirely, plus a prototype-pollution-style crash risk from a
plain-object edge-kind lookup. All three are fixed here, with regression
tests for each.

## Update: pre-commit validation + rebase

A follow-up review caught that the check ran too late for durable schema
paths: `createStoreWithSchema()` and `store.evolve()` both commit a new
schema version (`initializeSchema`/`commitNewSchemaVersion` in
`schema/manager.ts`) *before* constructing the `Store` that runs the
`implies()` check — so an invalid relation could become the persisted
active schema version before `ConfigurationError` ever fired.

- `initializeSchema`/`commitNewSchemaVersion` now call `buildKindRegistry`
  before serializing/committing, so every caller (`ensureSchema`'s
  init/auto-migrate paths, `migrateSchema`, `store.evolve()`,
  `store.removeKinds()`) is covered from one place.
- Added regression tests asserting no schema version is committed when
  `createStoreWithSchema()` or `store.evolve({ ontology })` is given an
  endpoint-incompatible relation.
- Rebased onto `main`, which landed a full rewrite of example 08 in the
  interim (#232). Main's rewritten example already used an
  endpoint-compatible pair (`implies(buildsOn, cites)`, both
  `Publication -> Publication`) — it just had a stale comment claiming
  "the library does NOT validate this." Kept main's example as-is and only
  updated that comment to describe the new fail-loud behavior. (An earlier
  revision of this PR description said example 08 was changed to
  `implies(mentions, about)` — that was accurate against the pre-rebase
  file, not the current one; superseded by this note.)
- Documented the endpoint-compatibility requirement in `ontology.md` and
  `queries/traverse.md`.
