### PR TITLE
fix: default omitted validFrom to the create timestamp, not open-left NULL

### DIFF
--- a/.changeset/validfrom-defaults-to-creation-time.md
+++ b/.changeset/validfrom-defaults-to-creation-time.md
@@ -1,0 +1,25 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix: creating a node or edge without an explicit `validFrom` now stamps the
+operation's own creation timestamp instead of storing SQL `NULL`.
+
+`NULL` is interpreted by temporal filters as open-left validity ("valid
+since forever"), so a record created without `validFrom` was visible at
+*any* historical `asOf` instant — including ones before the record existed.
+This contradicted the documented contract ("omitted `validFrom` defaults to
+now") and is fixed at the insert layer for every write path: `create`,
+`createFromRecord`, `upsertById`/`upsertByIdFromRecord` (create branch),
+`bulkCreate`, `bulkInsert`, `bulkUpsertById`, and get-or-create, for both
+nodes and edges.
+
+`branch()`'s working-copy clone now also exports with `includeTemporal:
+true`, so a fork's `validFrom`/`validTo` exactly match the base's — without
+this, the clone would re-stamp any implicit `validFrom` to the fork's own
+(later) creation time, narrowing the fork's valid-time window relative to
+the base it was cloned from.
+
+`exportGraph`/`importGraph` round trips still default `includeTemporal` to
+`false`; without it, imported records get a fresh `validFrom` at import
+time rather than the source's original value (see the Interchange docs).

--- a/.changeset/validfrom-defaults-to-creation-time.md
+++ b/.changeset/validfrom-defaults-to-creation-time.md
@@ -18,7 +18,12 @@ nodes and edges.
 true`, so a fork's `validFrom`/`validTo` exactly match the base's — without
 this, the clone would re-stamp any implicit `validFrom` to the fork's own
 (later) creation time, narrowing the fork's valid-time window relative to
-the base it was cloned from.
+the base it was cloned from. This includes rows that still have a `NULL`
+`valid_from` (predating this fix, or written directly via the backend):
+`exportGraph`/`importGraph` now round-trip a confirmed open-left window as
+an explicit `null` rather than silently dropping it, so a legacy row's
+"valid since forever" semantics survive a clone unchanged instead of being
+narrowed to the clone's own creation time.
 
 `exportGraph`/`importGraph` round trips still default `includeTemporal` to
 `false`; without it, imported records get a fresh `validFrom` at import

--- a/apps/docs/src/content/docs/core-concepts.md
+++ b/apps/docs/src/content/docs/core-concepts.md
@@ -122,7 +122,7 @@ const alice = await store.nodes.Person.create({ name: "Alice", email: "a@example
 //     createdAt: "2024-01-15T10:30:00.000Z",
 //     updatedAt: "2024-01-15T10:30:00.000Z",
 //     deletedAt: undefined,
-//     validFrom: undefined,
+//     validFrom: "2024-01-15T10:30:00.000Z", // defaults to createdAt when omitted
 //     validTo: undefined,
 //   }
 // }

--- a/apps/docs/src/content/docs/interchange.md
+++ b/apps/docs/src/content/docs/interchange.md
@@ -58,7 +58,7 @@ interface GraphData {
     kind: string;
     id: string;
     properties: Record<string, unknown>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     meta?: {
       version?: number;
@@ -72,7 +72,7 @@ interface GraphData {
     from: { kind: string; id: string };
     to: { kind: string; id: string };
     properties: Record<string, unknown>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     meta?: {
       createdAt?: string;
@@ -81,6 +81,13 @@ interface GraphData {
   }>;
 }
 ```
+
+`validFrom` has three states: the key **absent** means it wasn't requested
+(`includeTemporal: false`, the default) — import defaults it to the
+import's own creation timestamp. An **explicit `null`** means the source
+row is confirmed to have no lower bound (open-left validity) — import
+preserves that instead of re-stamping it. A **string** is an explicit
+value, carried through unchanged.
 
 ## Exporting Data
 

--- a/apps/docs/src/content/docs/interchange.md
+++ b/apps/docs/src/content/docs/interchange.md
@@ -128,6 +128,15 @@ const withDeleted = await exportGraph(store, {
 | `includeTemporal` | `boolean` | `false` | Include validFrom/validTo fields |
 | `includeDeleted` | `boolean` | `false` | Include soft-deleted records |
 
+**Round-trip caveat:** with the default `includeTemporal: false`, exported
+records carry no `validFrom`/`validTo`. On import, an omitted `validFrom`
+defaults to the *import's own* creation timestamp — so a plain
+`exportGraph` + `importGraph` round trip does **not** reproduce the
+source's original valid-time window; every imported record becomes valid
+from import time forward. Pass `includeTemporal: true` on export when the
+clone needs to match the source's `asOf` behavior exactly (this is what
+`branch()` does internally).
+
 ## Importing Data
 
 Use `importGraph` to load data into a store:

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -300,7 +300,9 @@ For distributed graph workloads, consider a dedicated graph database.
 Temporal queries (`asOf`, `includeEnded`) work correctly but have some constraints:
 
 - Point-in-time queries cannot be combined with streaming (`.stream()`)
-- Historical data is only available if temporal fields (`validFrom`, `validTo`) were populated at creation time
+- `validFrom` defaults to the record's own creation timestamp when omitted, so `asOf` queries
+  work out of the box; an end boundary still requires an explicit `validTo` — an open `validTo`
+  means "still valid"
 - Clock skew between application servers can affect temporal accuracy
 
 ### Recorded / system time (`history: true`)

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -562,6 +562,12 @@ example with multiple graphs.
 
 The store provides typed node and edge collections via `store.nodes.*` and `store.edges.*`.
 
+Every write method below that accepts a `validFrom` option (`create`,
+`createFromRecord`, `upsertById`, `upsertByIdFromRecord`, `bulkCreate`,
+`bulkInsert`, `bulkUpsertById`, and their edge equivalents) defaults it to
+that operation's own creation timestamp when omitted — `validFrom` is never
+left open-ended. `validTo` remains optional and open-ended until set.
+
 ### Node Collections
 
 Each node type has a collection with these methods:

--- a/packages/typegraph/src/backend/drizzle/operations/edges.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/edges.ts
@@ -11,7 +11,13 @@ import type {
   InsertEdgeParams,
   UpdateEdgeParams,
 } from "../../types";
-import { edgeColumnList, quotedColumn, sqlNull, type Tables } from "./shared";
+import {
+  edgeColumnList,
+  quotedColumn,
+  resolveValidFrom,
+  sqlNull,
+  type Tables,
+} from "./shared";
 
 /**
  * Builds an INSERT query for an edge.
@@ -31,7 +37,7 @@ export function buildInsertEdge(
     VALUES (
       ${params.graphId}, ${params.id}, ${params.kind},
       ${params.fromKind}, ${params.fromId}, ${params.toKind}, ${params.toId},
-      ${propsJson}, ${sqlNull(params.validFrom)}, ${sqlNull(params.validTo)},
+      ${propsJson}, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
     RETURNING *
@@ -55,7 +61,7 @@ export function buildInsertEdgeNoReturn(
     VALUES (
       ${params.graphId}, ${params.id}, ${params.kind},
       ${params.fromKind}, ${params.fromId}, ${params.toKind}, ${params.toId},
-      ${propsJson}, ${sqlNull(params.validFrom)}, ${sqlNull(params.validTo)},
+      ${propsJson}, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
   `;
@@ -73,7 +79,7 @@ export function buildInsertEdgesBatch(
   const columns = edgeColumnList(edges);
   const values = params.map((edgeParams) => {
     const propsJson = JSON.stringify(edgeParams.props);
-    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(edgeParams.validFrom)}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${resolveValidFrom(edgeParams.validFrom, timestamp)}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -94,7 +100,7 @@ export function buildInsertEdgesBatchReturning(
   const columns = edgeColumnList(edges);
   const values = params.map((edgeParams) => {
     const propsJson = JSON.stringify(edgeParams.props);
-    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(edgeParams.validFrom)}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${resolveValidFrom(edgeParams.validFrom, timestamp)}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`

--- a/packages/typegraph/src/backend/drizzle/operations/edges.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/edges.ts
@@ -37,7 +37,7 @@ export function buildInsertEdge(
     VALUES (
       ${params.graphId}, ${params.id}, ${params.kind},
       ${params.fromKind}, ${params.fromId}, ${params.toKind}, ${params.toId},
-      ${propsJson}, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
+      ${propsJson}, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
     RETURNING *
@@ -61,7 +61,7 @@ export function buildInsertEdgeNoReturn(
     VALUES (
       ${params.graphId}, ${params.id}, ${params.kind},
       ${params.fromKind}, ${params.fromId}, ${params.toKind}, ${params.toId},
-      ${propsJson}, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
+      ${propsJson}, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
   `;
@@ -79,7 +79,7 @@ export function buildInsertEdgesBatch(
   const columns = edgeColumnList(edges);
   const values = params.map((edgeParams) => {
     const propsJson = JSON.stringify(edgeParams.props);
-    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${resolveValidFrom(edgeParams.validFrom, timestamp)}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(resolveValidFrom(edgeParams.validFrom, timestamp))}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -100,7 +100,7 @@ export function buildInsertEdgesBatchReturning(
   const columns = edgeColumnList(edges);
   const values = params.map((edgeParams) => {
     const propsJson = JSON.stringify(edgeParams.props);
-    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${resolveValidFrom(edgeParams.validFrom, timestamp)}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(resolveValidFrom(edgeParams.validFrom, timestamp))}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`

--- a/packages/typegraph/src/backend/drizzle/operations/nodes.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/nodes.ts
@@ -32,7 +32,7 @@ export function buildInsertNode(
     INSERT INTO ${nodes} (${columns})
     VALUES (
       ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
-      1, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
+      1, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
     RETURNING *
@@ -55,7 +55,7 @@ export function buildInsertNodeNoReturn(
     INSERT INTO ${nodes} (${columns})
     VALUES (
       ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
-      1, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
+      1, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
   `;
@@ -73,7 +73,7 @@ export function buildInsertNodesBatch(
   const columns = nodeColumnList(nodes);
   const values = params.map((nodeParams) => {
     const propsJson = JSON.stringify(nodeParams.props);
-    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${resolveValidFrom(nodeParams.validFrom, timestamp)}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(resolveValidFrom(nodeParams.validFrom, timestamp))}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -94,7 +94,7 @@ export function buildInsertNodesBatchReturning(
   const columns = nodeColumnList(nodes);
   const values = params.map((nodeParams) => {
     const propsJson = JSON.stringify(nodeParams.props);
-    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${resolveValidFrom(nodeParams.validFrom, timestamp)}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(resolveValidFrom(nodeParams.validFrom, timestamp))}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`

--- a/packages/typegraph/src/backend/drizzle/operations/nodes.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/nodes.ts
@@ -7,7 +7,13 @@ import type {
   InsertNodeParams,
   UpdateNodeParams,
 } from "../../types";
-import { nodeColumnList, quotedColumn, sqlNull, type Tables } from "./shared";
+import {
+  nodeColumnList,
+  quotedColumn,
+  resolveValidFrom,
+  sqlNull,
+  type Tables,
+} from "./shared";
 
 /**
  * Builds an INSERT query for a node.
@@ -26,7 +32,7 @@ export function buildInsertNode(
     INSERT INTO ${nodes} (${columns})
     VALUES (
       ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
-      1, ${sqlNull(params.validFrom)}, ${sqlNull(params.validTo)},
+      1, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
     RETURNING *
@@ -49,7 +55,7 @@ export function buildInsertNodeNoReturn(
     INSERT INTO ${nodes} (${columns})
     VALUES (
       ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
-      1, ${sqlNull(params.validFrom)}, ${sqlNull(params.validTo)},
+      1, ${resolveValidFrom(params.validFrom, timestamp)}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
   `;
@@ -67,7 +73,7 @@ export function buildInsertNodesBatch(
   const columns = nodeColumnList(nodes);
   const values = params.map((nodeParams) => {
     const propsJson = JSON.stringify(nodeParams.props);
-    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(nodeParams.validFrom)}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${resolveValidFrom(nodeParams.validFrom, timestamp)}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -88,7 +94,7 @@ export function buildInsertNodesBatchReturning(
   const columns = nodeColumnList(nodes);
   const values = params.map((nodeParams) => {
     const propsJson = JSON.stringify(nodeParams.props);
-    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(nodeParams.validFrom)}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${resolveValidFrom(nodeParams.validFrom, timestamp)}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`

--- a/packages/typegraph/src/backend/drizzle/operations/shared.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/shared.ts
@@ -13,6 +13,19 @@ export function sqlNull(value: string | undefined): SQL | string {
   return value ?? sql.raw("NULL");
 }
 
+/**
+ * Resolves an omitted `validFrom` to the row's creation timestamp — an
+ * explicit value always wins. Keeps every insert path (single, batch,
+ * returning/non-returning) agreeing that "no validFrom" means "valid from
+ * creation", not open-left NULL (see issue #240).
+ */
+export function resolveValidFrom(
+  validFrom: string | undefined,
+  timestamp: string,
+): string {
+  return validFrom ?? timestamp;
+}
+
 export function quotedColumn(column: { name: string }): SQL {
   return sql.raw(`"${column.name.replaceAll('"', '""')}"`);
 }

--- a/packages/typegraph/src/backend/drizzle/operations/shared.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/shared.ts
@@ -14,15 +14,24 @@ export function sqlNull(value: string | undefined): SQL | string {
 }
 
 /**
- * Resolves an omitted `validFrom` to the row's creation timestamp — an
- * explicit value always wins. Keeps every insert path (single, batch,
- * returning/non-returning) agreeing that "no validFrom" means "valid from
- * creation", not open-left NULL (see issue #240).
+ * Resolves a `validFrom` insert value against the row's creation timestamp.
+ * Three states, matching {@link InsertNodeParams.validFrom} /
+ * {@link InsertEdgeParams.validFrom}:
+ *  - `undefined` (omitted): defaults to `timestamp` — every insert path
+ *    (single, batch, returning/non-returning) agrees that "no validFrom"
+ *    means "valid from creation", not open-left NULL (see issue #240).
+ *  - `null`: preserves an explicit open-left window — returned as
+ *    `undefined` here so the caller's {@link sqlNull} wrap emits SQL NULL,
+ *    letting interchange import round-trip a row that predates the #240
+ *    fix without narrowing its validity window on re-import (e.g. via a
+ *    `branch()` clone).
+ *  - a string: passed through unchanged.
  */
 export function resolveValidFrom(
-  validFrom: string | undefined,
+  validFrom: string | null | undefined,
   timestamp: string,
-): string {
+): string | undefined {
+  if (validFrom === null) return undefined;
   return validFrom ?? timestamp;
 }
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -270,6 +270,7 @@ export type InsertNodeParams = Readonly<{
   kind: string;
   id: string;
   props: Readonly<Record<string, unknown>>;
+  /** Defaults to the insert's creation timestamp when omitted. */
   validFrom?: string;
   validTo?: string;
 }>;
@@ -309,6 +310,7 @@ export type InsertEdgeParams = Readonly<{
   toKind: string;
   toId: string;
   props: Readonly<Record<string, unknown>>;
+  /** Defaults to the insert's creation timestamp when omitted. */
   validFrom?: string;
   validTo?: string;
 }>;

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -270,8 +270,13 @@ export type InsertNodeParams = Readonly<{
   kind: string;
   id: string;
   props: Readonly<Record<string, unknown>>;
-  /** Defaults to the insert's creation timestamp when omitted. */
-  validFrom?: string;
+  /**
+   * Omitted (`undefined`): defaults to the insert's creation timestamp.
+   * `null`: preserves an explicit open-left validity window (no lower
+   * bound) — used by interchange import to round-trip a row that was
+   * already NULL, instead of re-stamping it to the import's own timestamp.
+   */
+  validFrom?: string | null;
   validTo?: string;
 }>;
 
@@ -310,8 +315,13 @@ export type InsertEdgeParams = Readonly<{
   toKind: string;
   toId: string;
   props: Readonly<Record<string, unknown>>;
-  /** Defaults to the insert's creation timestamp when omitted. */
-  validFrom?: string;
+  /**
+   * Omitted (`undefined`): defaults to the insert's creation timestamp.
+   * `null`: preserves an explicit open-left validity window (no lower
+   * bound) — used by interchange import to round-trip a row that was
+   * already NULL, instead of re-stamping it to the import's own timestamp.
+   */
+  validFrom?: string | null;
   validTo?: string;
 }>;
 

--- a/packages/typegraph/src/graph-merge/working-copy.ts
+++ b/packages/typegraph/src/graph-merge/working-copy.ts
@@ -21,6 +21,15 @@
  * only) as the immutable reference, never against the clone (clones regenerate
  * `created_at`/`updated_at`, which would otherwise destabilize `base@V`).
  *
+ * `includeTemporal: true` carries `validFrom`/`validTo` through unchanged: an
+ * omitted `validFrom` on the base row is never NULL (create-time paths default
+ * it to the row's own creation instant — see #240), so exporting it verbatim
+ * preserves the base's exact valid-time window on the clone. Without this, the
+ * clone's re-import would re-stamp any base row that relied on the default to
+ * the CLONE's creation instant instead — narrowing its validity window and
+ * making `asOf` reads on the fork diverge from identical reads on the base for
+ * any instant between the row's real creation and the clone.
+ *
  * Logical-namespace (copy-on-write within one backend, no full data copy) is a
  * future strategy slot — see the `WorkingCopyStrategy` interface — deferred past
  * P0.
@@ -71,12 +80,15 @@ export type MakeBackend = () => Promise<GraphBackend>;
  * The P0 default working-copy strategy: faithful clone via export/import.
  *
  * On each `create(baseStore)`:
- *   1. `exportGraph(baseStore, { includeMeta: true, includeDeleted: false })` —
- *      `includeMeta: true` carries `created_at`/`updated_at`; `includeDeleted:
- *      false` keeps the clone to LIVE rows only. Shipping soft-deleted rows is
- *      unsafe: the meta schema has no `deletedAt`, so they would import as live and
- *      resurrect on the fork's diff (see the fidelity note above). `branch()` only
- *      needs the base's live state.
+ *   1. `exportGraph(baseStore, { includeMeta: true, includeTemporal: true,
+ *      includeDeleted: false })` — `includeMeta: true` carries
+ *      `created_at`/`updated_at`; `includeTemporal: true` carries
+ *      `validFrom`/`validTo` so the clone's valid-time window matches the base's
+ *      exactly (see the fidelity note above); `includeDeleted: false` keeps the
+ *      clone to LIVE rows only. Shipping soft-deleted rows is unsafe: the meta
+ *      schema has no `deletedAt`, so they would import as live and resurrect on
+ *      the fork's diff (see the fidelity note above). `branch()` only needs the
+ *      base's live state.
  *   2. Create a fresh store over the caller-provided backend with the SAME graph
  *      definition via `createStoreWithSchema`.
  *   3. `importGraph(freshStore, data, { onConflict: "error", ... })` — ids are
@@ -102,6 +114,7 @@ export function cloneWorkingCopyStrategy<G extends GraphDef>(
     create: async (baseStore: Store<G>): Promise<Store<G>> => {
       const data = await exportGraph(baseStore, {
         includeMeta: true,
+        includeTemporal: true,
         includeDeleted: false,
       });
       const backend = await makeBackend();

--- a/packages/typegraph/src/graph-merge/working-copy.ts
+++ b/packages/typegraph/src/graph-merge/working-copy.ts
@@ -21,14 +21,17 @@
  * only) as the immutable reference, never against the clone (clones regenerate
  * `created_at`/`updated_at`, which would otherwise destabilize `base@V`).
  *
- * `includeTemporal: true` carries `validFrom`/`validTo` through unchanged: an
- * omitted `validFrom` on the base row is never NULL (create-time paths default
- * it to the row's own creation instant — see #240), so exporting it verbatim
- * preserves the base's exact valid-time window on the clone. Without this, the
- * clone's re-import would re-stamp any base row that relied on the default to
- * the CLONE's creation instant instead — narrowing its validity window and
- * making `asOf` reads on the fork diverge from identical reads on the base for
- * any instant between the row's real creation and the clone.
+ * `includeTemporal: true` carries `validFrom`/`validTo` through unchanged,
+ * preserving the base's exact valid-time window on the clone: create-time
+ * paths default an omitted `validFrom` to the row's own creation instant
+ * (see #240), and export/import round-trip a still-open-left `valid_from`
+ * (e.g. a row that predates the #240 fix) as an explicit `null` rather than
+ * silently dropping it — see `InterchangeNodeSchema.validFrom`'s doc.
+ * Without either half of this, the clone's re-import would re-stamp the
+ * affected base rows to the CLONE's creation instant instead — narrowing
+ * their validity window and making `asOf` reads on the fork diverge from
+ * identical reads on the base for any instant between the row's real
+ * creation and the clone.
  *
  * Logical-namespace (copy-on-write within one backend, no full data copy) is a
  * future strategy slot — see the `WorkingCopyStrategy` interface — deferred past

--- a/packages/typegraph/src/interchange/export.ts
+++ b/packages/typegraph/src/interchange/export.ts
@@ -121,9 +121,17 @@ async function exportNodesOfKind(
     };
 
     if (options.includeTemporal) {
-      if (row.valid_from) {
-        (node as { validFrom?: string }).validFrom = row.valid_from;
-      }
+      // validFrom is always emitted (as `null` when the row has no lower
+      // bound) so import can tell "confirmed open-left" apart from "not
+      // requested" and preserve it instead of defaulting to import time —
+      // see the schema doc on InterchangeNodeSchema.validFrom. validTo has
+      // no such ambiguity (it was never defaulted), so it stays gated.
+      // `null` (not `undefined`) is the wire-protocol signal here — JSON has
+      // no other way to say "explicitly cleared" vs. "field absent".
+      const validFrom =
+        // eslint-disable-next-line unicorn/no-null
+        row.valid_from ?? null;
+      (node as { validFrom?: string | null }).validFrom = validFrom;
       if (row.valid_to) {
         (node as { validTo?: string }).validTo = row.valid_to;
       }
@@ -173,9 +181,13 @@ async function exportEdgesOfKind(
     };
 
     if (options.includeTemporal) {
-      if (row.valid_from) {
-        (edge as { validFrom?: string }).validFrom = row.valid_from;
-      }
+      // See exportNodesOfKind's validFrom comment: always emitted (as
+      // `null` when open-left) so import can distinguish "confirmed no
+      // lower bound" from "not requested".
+      const validFrom =
+        // eslint-disable-next-line unicorn/no-null
+        row.valid_from ?? null;
+      (edge as { validFrom?: string | null }).validFrom = validFrom;
       if (row.valid_to) {
         (edge as { validTo?: string }).validTo = row.valid_to;
       }

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -369,7 +369,12 @@ async function processNodeSlice(
         nodeKind: schemaEntry.registration.type,
         uniqueConstraints: schemaEntry.registration.unique ?? [],
         validatedProps: propsResult.data,
-        validFrom: node.validFrom,
+        // NodeCreateDraft.validFrom is string | undefined (never null) — it
+        // only feeds batch validation-cache priming, which never inspects
+        // it, so normalizing the explicit-NULL sentinel away here is inert.
+        // The actual insert (buildImportInsertParams) reads node.validFrom
+        // directly and preserves the null.
+        validFrom: node.validFrom ?? undefined,
         validTo: node.validTo,
       },
     });
@@ -578,12 +583,18 @@ async function catchUniquenessError<T>(
  */
 function validateValidityWindow(
   entity: Readonly<{
-    validFrom?: string | undefined;
+    validFrom?: string | null | undefined;
     validTo?: string | undefined;
   }>,
 ): string | undefined {
   try {
-    validateOptionalCanonicalIsoDate(entity.validFrom, "validFrom");
+    // null is a confirmed open-left window (see InterchangeNodeSchema's
+    // validFrom doc), not a value to format-check — treat it like
+    // "not provided" here, same as the canonical-date validator does.
+    validateOptionalCanonicalIsoDate(
+      entity.validFrom ?? undefined,
+      "validFrom",
+    );
     validateOptionalCanonicalIsoDate(entity.validTo, "validTo");
     return undefined;
   } catch (error) {

--- a/packages/typegraph/src/interchange/types.ts
+++ b/packages/typegraph/src/interchange/types.ts
@@ -51,7 +51,14 @@ export const InterchangeNodeSchema = z.object({
   kind: z.string().min(1),
   id: z.string().min(1),
   properties: z.record(z.string(), z.unknown()),
-  validFrom: ValidityTimestampSchema.optional(),
+  /**
+   * `undefined` (key absent): not requested (`includeTemporal: false`) —
+   * import defaults it to the import's own creation timestamp. `null`:
+   * requested and confirmed the row has no lower bound (e.g. a legacy row
+   * predating the "omitted validFrom defaults to creation time" fix) —
+   * import preserves that open-left validity instead of re-stamping it.
+   */
+  validFrom: ValidityTimestampSchema.nullable().optional(),
   validTo: ValidityTimestampSchema.optional(),
   meta: z
     .object({
@@ -86,7 +93,8 @@ export const InterchangeEdgeSchema = z.object({
     id: z.string().min(1),
   }),
   properties: z.record(z.string(), z.unknown()).default({}),
-  validFrom: ValidityTimestampSchema.optional(),
+  /** See {@link InterchangeNodeSchema}'s `validFrom` for the null/undefined contract. */
+  validFrom: ValidityTimestampSchema.nullable().optional(),
   validTo: ValidityTimestampSchema.optional(),
   meta: z
     .object({

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -311,7 +311,11 @@ export function createNodeBatchValidationBackend(
       id: params.id,
       props: JSON.stringify(params.props),
       version: 1,
-      valid_from: params.validFrom,
+      // The simulated cached row only needs a NodeRow-shaped valid_from
+      // (string | undefined, never null) for existence/uniqueness checks,
+      // which don't inspect its value — normalize import's explicit-NULL
+      // sentinel away rather than widen this cache's row shape.
+      valid_from: params.validFrom ?? undefined,
       valid_to: params.validTo,
       created_at: "",
       updated_at: "",

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -491,7 +491,11 @@ export type NodeCollection<
   N extends NodeType,
   CN extends string = string,
 > = Readonly<{
-  /** Create a new node */
+  /**
+   * Create a new node.
+   *
+   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   */
   create: (
     props: z.input<N["schema"]>,
     options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
@@ -556,6 +560,8 @@ export type NodeCollection<
    * Use this for dynamic dispatch (changesets, migrations, imports) where
    * the data shape is determined at runtime, not compile time.
    * The return type is fully typed — only the input gate is relaxed.
+   *
+   * `validFrom` defaults to the operation's creation timestamp when omitted.
    */
   createFromRecord: (
     data: Record<string, unknown>,
@@ -567,6 +573,9 @@ export type NodeCollection<
    *
    * If a node with the given ID exists, updates it with the provided props.
    * Otherwise, creates a new node with that ID.
+   *
+   * `validFrom` only applies on the create branch, defaulting to the
+   * operation's creation timestamp when omitted; it has no effect on update.
    */
   upsertById: (
     id: string,
@@ -580,6 +589,9 @@ export type NodeCollection<
    * Use this for dynamic dispatch (changesets, migrations, imports) where
    * the data shape is determined at runtime, not compile time.
    * The return type is fully typed — only the input gate is relaxed.
+   *
+   * `validFrom` only applies on the create branch, defaulting to the
+   * operation's creation timestamp when omitted; it has no effect on update.
    */
   upsertByIdFromRecord: (
     id: string,
@@ -592,6 +604,8 @@ export type NodeCollection<
    *
    * More efficient than calling create() multiple times.
    * Use `bulkInsert` for the dedicated fast path that skips returning results.
+   *
+   * `validFrom` defaults to the operation's creation timestamp when omitted.
    */
   bulkCreate: (
     items: readonly Readonly<{
@@ -607,6 +621,9 @@ export type NodeCollection<
    *
    * For each item, if a node with the given ID exists, updates it.
    * Otherwise, creates a new node with that ID.
+   *
+   * `validFrom` only applies on the create branch, defaulting to the
+   * operation's creation timestamp when omitted; it has no effect on update.
    */
   bulkUpsertById: (
     items: readonly Readonly<{
@@ -623,6 +640,8 @@ export type NodeCollection<
    * This is the dedicated fast path for bulk inserts. Unlike `bulkCreate`
    * with `returnResults: false`, the intent is unambiguous: no results
    * are returned and the operation is wrapped in a transaction.
+   *
+   * `validFrom` defaults to the operation's creation timestamp when omitted.
    */
   bulkInsert: (
     items: readonly Readonly<{
@@ -791,6 +810,8 @@ export type EdgeCollection<
   /**
    * Create a new edge.
    *
+   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   *
    * @param from - Source node (must be one of the allowed 'from' types)
    * @param to - Target node (must be one of the allowed 'to' types)
    * @param args - Edge properties (optional if schema is empty) and creation options
@@ -918,6 +939,8 @@ export type EdgeCollection<
    *
    * More efficient than calling create() multiple times.
    * Use `bulkInsert` for the dedicated fast path that skips returning results.
+   *
+   * `validFrom` defaults to the operation's creation timestamp when omitted.
    */
   bulkCreate: (
     items: readonly Readonly<{
@@ -935,6 +958,9 @@ export type EdgeCollection<
    *
    * For each item, if an edge with the given ID exists, updates it.
    * Otherwise, creates a new edge with that ID.
+   *
+   * `validFrom` only applies on the create branch, defaulting to the
+   * operation's creation timestamp when omitted; it has no effect on update.
    */
   bulkUpsertById: (
     items: readonly Readonly<{
@@ -953,6 +979,8 @@ export type EdgeCollection<
    * This is the dedicated fast path for bulk inserts. Unlike `bulkCreate`
    * with `returnResults: false`, the intent is unambiguous: no results
    * are returned and the operation is wrapped in a transaction.
+   *
+   * `validFrom` defaults to the operation's creation timestamp when omitted.
    */
   bulkInsert: (
     items: readonly Readonly<{

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -648,9 +648,10 @@ describe("store.algorithms temporal behavior", () => {
       });
       const reachedIds = reached.map((row) => row.id).toSorted();
 
-      // Eve not yet valid (validFrom = FUTURE), Ghost not yet deleted but also
-      // its edge is current and asOf BEFORE is prior to the edge's implicit
-      // validFrom (ULID-based createdAt). Bob and David are reachable via the
+      // Eve not yet valid (validFrom = FUTURE). Ghost is excluded regardless
+      // of asOf — it's soft-deleted, and deleted_at is unconditional in
+      // asOf mode (see "includeTombstones surfaces the deleted ghost node"
+      // below for that coverage). Bob and David are reachable via the
       // historical edge.
       expect(reachedIds).toContain(temporalIds.bob);
       expect(reachedIds).toContain(temporalIds.david);

--- a/packages/typegraph/tests/backends/integration/temporal.ts
+++ b/packages/typegraph/tests/backends/integration/temporal.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { TEMPORAL_ANCHORS } from "../../test-utils";
 import { type IntegrationTestContext } from "./test-context";
 
 export function registerTemporalIntegrationTests(
@@ -164,6 +165,54 @@ export function registerTemporalIntegrationTests(
 
       expect(nowResults).toHaveLength(1);
       expect(nowResults[0]).toBe("Alice");
+    });
+
+    it("defaults an omitted validFrom to the create timestamp, not open-left NULL", async () => {
+      // Regression test for #240: an omitted validFrom must stamp the
+      // operation's creation time, not persist as NULL — NULL is
+      // interpreted as "valid since forever" by asOf filters, which made a
+      // node created today visible at any historical asOf, including
+      // instants before it existed.
+      const { PAST } = TEMPORAL_ANCHORS;
+      const store = context.getStore();
+
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+
+      expect(alice.meta.validFrom).toBeDefined();
+
+      const pastNode = await store.nodes.Person.getById(alice.id, {
+        temporalMode: "asOf",
+        asOf: PAST,
+      });
+      expect(pastNode).toBeUndefined();
+    });
+
+    it("defaults an omitted edge validFrom to the create timestamp, even when both endpoints predate it", async () => {
+      // Regression test for #240's "test gap": pair the implicit-validFrom
+      // edge with endpoints that are ALREADY valid at the historical asOf,
+      // so only the edge's own (formerly NULL) validFrom can hide or
+      // surface it — a future-dated endpoint would mask the edge bug.
+      const { PAST, BEFORE } = TEMPORAL_ANCHORS;
+      const store = context.getStore();
+
+      const [alice, bob] = await Promise.all([
+        store.nodes.Person.create({ name: "Alice" }, { validFrom: PAST }),
+        store.nodes.Person.create({ name: "Bob" }, { validFrom: PAST }),
+      ]);
+      const edge = await store.edges.knows.create(alice, bob);
+
+      expect(edge.meta.validFrom).toBeDefined();
+
+      const pastEdges = await store.edges.knows.findFrom(alice, {
+        temporalMode: "asOf",
+        asOf: BEFORE,
+      });
+      expect(pastEdges).toHaveLength(0);
+
+      const currentEdges = await store.edges.knows.findFrom(alice, {
+        temporalMode: "current",
+      });
+      expect(currentEdges.map((row) => row.id)).toEqual([edge.id]);
     });
   });
 }

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -192,6 +192,35 @@ describe.each(backendMatrix())("branch [$name]", (entry) => {
     expect(forkedEdge?.meta.validFrom).toBe(edge?.meta.validFrom);
   });
 
+  it("preserves a legacy row with no lower bound (valid_from = NULL) on the clone, still visible at an ancient asOf", async () => {
+    // Regression test: a row predating the #240 fix (or written directly
+    // via the backend, which the collection API can no longer produce) has
+    // valid_from = NULL — "valid since forever". A faithful clone must NOT
+    // narrow that to the fork's own creation instant.
+    const { baseStore } = await seedBase();
+    const legacy = await baseStore.backend.insertNode({
+      graphId: baseStore.graphId,
+      kind: "Person",
+      id: "legacy-null-validfrom",
+      props: { name: "Legacy" },
+       
+      validFrom: null,
+    });
+    expect(legacy.valid_from).toBeUndefined();
+
+    const result = await branch<G>(baseStore, () => makeBackend());
+    expect(isOk(result)).toBe(true);
+    const forkStore = unwrap(result).store;
+
+    const ancientAsOf = "1900-01-01T00:00:00.000Z";
+    const forkedLegacy = await forkStore.nodes.Person.getById(
+      legacy.id as never,
+      { temporalMode: "asOf", asOf: ancientAsOf },
+    );
+    expect(forkedLegacy).toBeDefined();
+    expect(forkedLegacy?.meta.validFrom).toBeUndefined();
+  });
+
   it("honors an explicit branch id from options", async () => {
     const { baseStore } = await seedBase();
     const explicitId = asBranchId("branch-explicit-id");

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -168,6 +168,30 @@ describe.each(backendMatrix())("branch [$name]", (entry) => {
     expect(await snapshotEdges(branchA.store)).toHaveLength(0);
   });
 
+  it("preserves the base's exact validFrom on the clone, even when it was never set explicitly", async () => {
+    // Regression test: an omitted validFrom defaults to the row's OWN
+    // creation instant (#240), not open-left NULL. A branch is a clone taken
+    // at a LATER instant, so if the export/import round trip dropped
+    // validFrom, the clone would re-stamp it to the clone's own (later)
+    // creation time — silently narrowing the fork's valid-time window and
+    // making asOf reads on the fork diverge from identical reads on the base.
+    const { baseStore, aliceId, edgeId } = await seedBase();
+    const alice = await baseStore.nodes.Person.getById(aliceId);
+    const edge = await baseStore.edges.knows.getById(edgeId);
+
+    const result = await branch<G>(baseStore, () => makeBackend());
+    expect(isOk(result)).toBe(true);
+    const forkStore = unwrap(result).store;
+
+    const forkedAlice = await forkStore.nodes.Person.getById(aliceId);
+    const forkedEdge = await forkStore.edges.knows.getById(edgeId);
+
+    expect(forkedAlice?.meta.validFrom).toBeDefined();
+    expect(forkedAlice?.meta.validFrom).toBe(alice?.meta.validFrom);
+    expect(forkedEdge?.meta.validFrom).toBeDefined();
+    expect(forkedEdge?.meta.validFrom).toBe(edge?.meta.validFrom);
+  });
+
   it("honors an explicit branch id from options", async () => {
     const { baseStore } = await seedBase();
     const explicitId = asBranchId("branch-explicit-id");

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -203,7 +203,6 @@ describe.each(backendMatrix())("branch [$name]", (entry) => {
       kind: "Person",
       id: "legacy-null-validfrom",
       props: { name: "Legacy" },
-       
       validFrom: null,
     });
     expect(legacy.valid_from).toBeUndefined();

--- a/packages/typegraph/tests/interchange.test.ts
+++ b/packages/typegraph/tests/interchange.test.ts
@@ -319,6 +319,63 @@ describe("Export Options", () => {
       expect(node.meta).toBeUndefined();
     }
   });
+
+  it("includes an explicit validFrom when includeTemporal is true", async () => {
+    const exported = await exportGraph(store, { includeTemporal: true });
+
+    for (const node of exported.nodes) {
+      // Every node here was created via the collection API, so validFrom
+      // always defaults to a real creation timestamp (#240) — never null.
+      expect(typeof node.validFrom).toBe("string");
+    }
+  });
+
+  it("omits validFrom entirely by default (includeTemporal: false)", async () => {
+    const exported = await exportGraph(store);
+
+    for (const node of exported.nodes) {
+      expect(node.validFrom).toBeUndefined();
+    }
+  });
+
+  it("round-trips a legacy row with no lower bound (valid_from = NULL) as explicit null, not a re-stamped timestamp", async () => {
+    // Regression test: a row predating the #240 fix (or written directly
+    // via the backend, bypassing the collection API, which can no longer
+    // produce NULL) has valid_from = NULL — "valid since forever". A
+    // faithful includeTemporal: true export/import must preserve that
+    // open-left window, not silently narrow it to the import's own
+    // creation timestamp.
+    const legacy = await backend.insertNode({
+      graphId: store.graphId,
+      kind: "Person",
+      id: "legacy-null-validfrom",
+      props: { name: "Legacy" },
+      // eslint-disable-next-line unicorn/no-null -- simulates a pre-#240 row
+      validFrom: null,
+    });
+    expect(legacy.valid_from).toBeUndefined();
+
+    const exported = await exportGraph(store, { includeTemporal: true });
+    const legacyExport = exported.nodes.find((n) => n.id === legacy.id);
+    expect(legacyExport?.validFrom).toBeNull();
+
+    const targetBackend = createTestBackend();
+    const targetStore = createStore(testGraph, targetBackend);
+    const result = await importGraph(
+      targetStore,
+      exported,
+      importOptions({ onConflict: "error" }),
+    );
+    expect(result.success).toBe(true);
+
+    const ancientAsOf = "1900-01-01T00:00:00.000Z";
+    const importedLegacy = await targetStore.nodes.Person.getById(
+      legacy.id as never,
+      { temporalMode: "asOf", asOf: ancientAsOf },
+    );
+    expect(importedLegacy).toBeDefined();
+    expect(importedLegacy?.meta.validFrom).toBeUndefined();
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
Creating a node or edge without an explicit `validFrom` stored SQL `NULL` in `valid_from`. Temporal filters interpret `NULL` as open-left validity, so records created today were visible at any historical `asOf` instant — including instants before the record existed. This contradicted the documented "omitted `validFrom` defaults to now" contract.

## Root cause & fix

Every node/edge insert path (single, no-return, batch, batch-returning — for both the store's collection API and the interchange bulk-import path) funnels through 8 SQL-builder call sites in `backend/drizzle/operations/{nodes,edges}.ts`. Each already threads a `timestamp` parameter (the same one stamped into `created_at`/`updated_at`) but discarded it for `validFrom` when omitted (`sqlNull(params.validFrom)` → `NULL`).

Fixed at that single choke point with a new `resolveValidFrom(validFrom, timestamp)` helper in `shared.ts` (mirroring the existing `sqlNull` helper): an omitted `validFrom` now resolves to the exact same timestamp as `created_at`, applying uniformly across every write path with no changes needed to the store-operation layer, `import.ts`, or the temporal query compiler (`valid_from IS NULL` handling stays, correctly, for any pre-existing legacy-NULL rows).

## Second-order fix: `branch()` working-copy fidelity

A code review caught a real regression this change introduced: `branch()`'s default working-copy strategy clones a store via `exportGraph`/`importGraph` without `includeTemporal: true`, so `validFrom` was dropped on export. Post-fix, re-importing an omitted `validFrom` re-stamps it to the *clone's own* (later) creation time instead of the base row's original instant — silently narrowing a fork's valid-time window relative to its base for any `asOf` between the row's real creation and the fork.

Fixed by passing `includeTemporal: true` in `cloneWorkingCopyStrategy`'s export call, so a fork's `validFrom`/`validTo` now match the base exactly (verified safe against `base@V` fingerprinting, which is computed only off the original store, never the clone). Added a dedicated regression test (`branch.test.ts`) that fails without this fix and passes with it, on both SQLite and PGlite backends.

## Also fixed (review findings)

- Removed a new test assertion that looked like it validated the fix but was actually driven by an unrelated `deleted_at` exclusion (false-confidence regression coverage).
- Updated `limitations.md`, `interchange.md`, and `schemas-stores.md` to reflect the new default behavior and the `exportGraph`/`importGraph` round-trip caveat.
- Added `validFrom`-defaults-to-creation-time JSDoc to every sibling collection method that accepts the option (`createFromRecord`, `upsertById`, `bulkCreate`, `bulkInsert`, `bulkUpsertById`, and edge equivalents).
- Added a changeset (`patch`).

Fixes #240