### PR TITLE
Pre-release review & hardening: #242 clock-skew fix, correctness fixes, refactors

### DIFF
--- a/.changeset/auto-refresh-statistics.md
+++ b/.changeset/auto-refresh-statistics.md
@@ -1,5 +1,5 @@
 ---
-"@nicia-ai/typegraph": patch
+"@nicia-ai/typegraph": minor
 ---
 
 Autocommit `bulkCreate` and `bulkInsert` calls (nodes and edges) now

--- a/.changeset/current-read-app-clock.md
+++ b/.changeset/current-read-app-clock.md
@@ -1,0 +1,24 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix: "current" temporal reads now evaluate validity against the application
+clock, not the database clock — repairing a read-after-write consistency
+violation on Postgres.
+
+`valid_from` is stamped from the application clock (`Date.toISOString()`) on
+write, but a "current" read compiled its validity filter against the database
+clock (`valid_from <= NOW()` on Postgres). On any deployment where the
+application-server clock runs ahead of the database-server clock — i.e. the
+app and database on separate hosts, which is the norm — a freshly-created node
+or edge could be missing from the very "current" read that immediately
+followed its creation, until the database clock caught up. SQLite (a single
+in-process clock) was never exposed.
+
+The "current" read now binds the application clock (`nowIso()`) as a
+parameter — the same clock `valid_from`, the facade search-currency filter,
+and the recorded/logical clock already use — across every current-read path
+(standard and recursive queries, subgraph extraction, graph algorithms, and
+recorded-time reads). The temporal-visibility clock is now a single source.
+Because the current-read instant is no longer dialect-specific, the internal
+`DialectAdapter.currentTimestamp()` seam has been removed.

--- a/.changeset/degree-index-alignment.md
+++ b/.changeset/degree-index-alignment.md
@@ -18,3 +18,13 @@ Measured on PostgreSQL 18 (where the old form was already skip-scan
 rescued): 0.30ms → 0.06ms per call; on older PostgreSQL the old form
 could not use these indexes at all. An edge set that declares no endpoint
 kinds on the required side now returns 0 without a round trip.
+
+Behavior note: because the counted set is now restricted to edges whose
+stored endpoint kind falls within the declaration's `subClassOf` closure,
+`degree()` no longer counts an edge whose stored `from_kind` / `to_kind`
+lies *outside* that closure — e.g. a row written before the endpoint
+declaration was narrowed, or written directly through the backend bypassing
+endpoint validation. This matches how typed traversals already treat such
+rows (invisible to a schema-consistent read), but it is a change from the
+previous "count every edge touching this node regardless of stored kind"
+behavior.

--- a/.changeset/implies-endpoint-validation.md
+++ b/.changeset/implies-endpoint-validation.md
@@ -1,5 +1,5 @@
 ---
-"@nicia-ai/typegraph": patch
+"@nicia-ai/typegraph": minor
 ---
 
 Fixes `implies(edgeA, edgeB)` silently accepting endpoint-incompatible edge

--- a/.changeset/pg-subgraph-membership.md
+++ b/.changeset/pg-subgraph-membership.md
@@ -6,10 +6,11 @@ Subgraph extraction is ~4× faster on PostgreSQL. The final node/edge
 fetches filtered ids with `IN (SELECT id FROM included_ids)`; PostgreSQL
 pulls that form up into a join whose recursive-CTE row estimate (~10 rows
 for a single-row seed) drives the planner into a nested-loop join filter —
-measured at ~10 million discarded rows on the depth-3 benchmark shape. CTE
-membership now goes through a dialect seam: PostgreSQL emits
-`= ANY(ARRAY(subquery))`, which collapses the CTE once via an InitPlan and
-is hash-probed and index-condition eligible; SQLite keeps `IN (subquery)`,
+measured at ~10 million discarded rows on the depth-3 benchmark shape.
+PostgreSQL now evaluates membership against the materialized closure ids
+with a parameterized `text[]` semi-join
+(`EXISTS (SELECT 1 FROM unnest($ids) AS t(id) WHERE t.id = column)`) rather
+than pulling the recursive CTE into that join; SQLite keeps `IN (subquery)`,
 which it already evaluates optimally.
 
 Measured (benchmark suite, 1,200 users / depth-3 stress shape): PostgreSQL

--- a/.changeset/typed-error-details.md
+++ b/.changeset/typed-error-details.md
@@ -1,5 +1,5 @@
 ---
-"@nicia-ai/typegraph": patch
+"@nicia-ai/typegraph": minor
 ---
 
 Every `TypeGraphError` subclass with a fixed-shape `details` payload now

--- a/.changeset/validfrom-defaults-to-creation-time.md
+++ b/.changeset/validfrom-defaults-to-creation-time.md
@@ -28,3 +28,8 @@ narrowed to the clone's own creation time.
 `exportGraph`/`importGraph` round trips still default `includeTemporal` to
 `false`; without it, imported records get a fresh `validFrom` at import
 time rather than the source's original value (see the Interchange docs).
+
+Custom `GraphBackend` implementations that build their own inserts (rather
+than reusing the bundled Drizzle operation builders) should apply the same
+rule: an omitted `validFrom` defaults to the row's creation instant, and an
+explicit `null` is preserved as SQL `NULL` (open-left).

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -433,7 +433,13 @@ export function createCommonOperationBackend(
     async deleteEdgesBatch(params: DeleteEdgesBatchParams): Promise<void> {
       if (params.ids.length === 0) return;
       const timestamp = nowIso();
-      for (const chunk of chunkArray(params.ids, batchConfig.getEdgesChunkSize)) {
+      // The soft-delete UPDATE binds one extra parameter (the `deleted_at`
+      // timestamp) on top of the graphId + id-list that `getEdgesChunkSize`
+      // is budgeted for, so a full chunk would overflow the bind limit by 1.
+      // Reserve a slot for the timestamp. The hard-delete batch below has no
+      // such extra bind and keeps the full chunk size.
+      const softDeleteChunkSize = Math.max(1, batchConfig.getEdgesChunkSize - 1);
+      for (const chunk of chunkArray(params.ids, softDeleteChunkSize)) {
         const query = operationStrategy.buildDeleteEdgesBatch(
           { graphId: params.graphId, ids: chunk },
           timestamp,

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -1169,15 +1169,26 @@ function createPostgresOperationBackend(
     });
   }
 
+  const batchConfig = {
+    checkUniqueBatchChunkSize: POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE,
+    edgeInsertBatchSize: POSTGRES_EDGE_INSERT_BATCH_SIZE,
+    // Unlike the static siblings, the embedding upsert honors a runtime
+    // `maxBindParameters` override so its chunk size tracks the connection's
+    // actual bind budget.
+    embeddingUpsertBatchSize: Math.max(
+      1,
+      Math.floor(
+        (capabilities.maxBindParameters ?? POSTGRES_MAX_BIND_PARAMETERS) /
+          EMBEDDING_UPSERT_PARAM_COUNT,
+      ),
+    ),
+    getEdgesChunkSize: POSTGRES_GET_EDGES_ID_CHUNK_SIZE,
+    getNodesChunkSize: POSTGRES_GET_NODES_ID_CHUNK_SIZE,
+    nodeInsertBatchSize: POSTGRES_NODE_INSERT_BATCH_SIZE,
+    uniqueInsertBatchSize: POSTGRES_UNIQUE_INSERT_BATCH_SIZE,
+  };
   const commonBackend = createCommonOperationBackend({
-    batchConfig: {
-      checkUniqueBatchChunkSize: POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE,
-      edgeInsertBatchSize: POSTGRES_EDGE_INSERT_BATCH_SIZE,
-      getEdgesChunkSize: POSTGRES_GET_EDGES_ID_CHUNK_SIZE,
-      getNodesChunkSize: POSTGRES_GET_NODES_ID_CHUNK_SIZE,
-      nodeInsertBatchSize: POSTGRES_NODE_INSERT_BATCH_SIZE,
-      uniqueInsertBatchSize: POSTGRES_UNIQUE_INSERT_BATCH_SIZE,
-    },
+    batchConfig,
     execution: {
       execAll,
       execGet,
@@ -1240,16 +1251,12 @@ function createPostgresOperationBackend(
             params.rows.map((row) => [row.nodeId, row] as const),
           );
           const rows = [...rowsById.values()];
-          const chunkSize = Math.max(
-            1,
-            Math.floor(
-              (capabilities.maxBindParameters ??
-                POSTGRES_MAX_BIND_PARAMETERS) / EMBEDDING_UPSERT_PARAM_COUNT,
-            ),
-          );
           const timestamp = nowIso();
           try {
-            for (const chunk of chunkArray(rows, chunkSize)) {
+            for (const chunk of chunkArray(
+              rows,
+              batchConfig.embeddingUpsertBatchSize,
+            )) {
               const statements =
                 vectorStrategy.buildUpsertBatch === undefined ?
                   chunk.flatMap((row) =>

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -215,6 +215,8 @@ export const SQLITE_ANALYZE_ROW_LIMIT = 1000;
 export type SqliteBatchChunkSizes = Readonly<{
   checkUniqueBatchChunkSize: number;
   edgeInsertBatchSize: number;
+  /** Rows per embedding batch upsert (5 binds per row). */
+  embeddingUpsertBatchSize: number;
   /** Rows per fulltext batch upsert (6 binds per row on FTS5). */
   fulltextUpsertBatchSize: number;
   /** Node ids per fulltext batch delete (2 fixed binds + one per id). */
@@ -238,6 +240,10 @@ export function computeSqliteBatchChunkSizes(
     checkUniqueBatchChunkSize: Math.max(
       1,
       maxBindParameters - CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT,
+    ),
+    embeddingUpsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / EMBEDDING_UPSERT_PARAM_COUNT),
     ),
     fulltextUpsertBatchSize: Math.max(
       1,
@@ -634,16 +640,12 @@ function createSqliteOperationBackend(
             params.rows.map((row) => [row.nodeId, row] as const),
           );
           const rows = [...rowsById.values()];
-          const chunkSize = Math.max(
-            1,
-            Math.floor(
-              (capabilities.maxBindParameters ?? SQLITE_MAX_BIND_PARAMETERS) /
-                EMBEDDING_UPSERT_PARAM_COUNT,
-            ),
-          );
           const timestamp = nowIso();
           try {
-            for (const chunk of chunkArray(rows, chunkSize)) {
+            for (const chunk of chunkArray(
+              rows,
+              batchConfig.embeddingUpsertBatchSize,
+            )) {
               const statements =
                 vectorStrategy.buildUpsertBatch === undefined ?
                   chunk.flatMap((row) =>

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -441,7 +441,14 @@ async function processNodeSlice(
                 uniqueConstraints,
                 ...(node.validTo !== undefined && { validTo: node.validTo }),
               },
-              backend,
+              // The pending-aware overlay, not the raw backend: the update's
+              // uniqueness pre-check must see a unique value already reserved by
+              // an unflushed create EARLIER in this slice, so it degrades to a
+              // per-row error exactly as the sequential path does — rather than
+              // claiming the key on the real backend and colliding with that
+              // create at flush (which would throw and roll back the whole
+              // import). Writes still delegate to the real backend.
+              validationBackend,
             ),
           );
           if (updateResult.ok) {

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -9,6 +9,7 @@ import type { z } from "zod";
 import {
   type GraphBackend,
   isLiveNodeRow,
+  rowPropsToObject,
   type TransactionBackend,
 } from "../backend/types";
 import { validateEdgeEndpoints } from "../constraints";
@@ -386,6 +387,7 @@ async function processNodeSlice(
     backend: validationBackend,
     registerPendingNode,
     registerPendingUniqueEntries,
+    registerAppliedNodeUpdate,
     seedNodeRow,
     seedUniqueRow,
   } = createNodeBatchValidationBackend(graphId, registry, backend);
@@ -442,6 +444,19 @@ async function processNodeSlice(
               backend,
             ),
           );
+          if (updateResult.ok) {
+            // The update mutated the real backend's uniqueness rows directly;
+            // reconcile the shared prime caches so a later create in this
+            // slice sees the post-update reservation state (matching the
+            // sequential path). See registerAppliedNodeUpdate.
+            registerAppliedNodeUpdate(
+              node.kind,
+              node.id,
+              rowPropsToObject(existing.props),
+              props,
+              uniqueConstraints,
+            );
+          }
           record(
             node,
             updateResult.ok ?

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -17,7 +17,6 @@ import {
   vectorMinScoreCondition,
   vectorScoreExpression,
 } from "../../dialect/vector-strategy";
-import { jsonPointer } from "../../json-pointer";
 import { type TemporalFilterPass } from "../passes";
 import {
   compileKindFilter,
@@ -39,7 +38,7 @@ import {
   HYBRID_CANDIDATES_CTE_ALIAS,
   vectorSlotKey,
 } from "../schema";
-import { compileTypedJsonExtract } from "../typed-json-extract";
+import { compileSelectivePropsExtraction } from "../typed-json-extract";
 import {
   EDGE_COLUMNS,
   EMPTY_REQUIRED_COLUMNS,
@@ -116,12 +115,11 @@ function compileSelectivePropsSelectColumns(
 
   const propsColumn = compileColumnReference(tableAlias, "props");
   return propsFields.map((field) => {
-    const extracted = compileTypedJsonExtract({
-      column: propsColumn,
+    const extracted = compileSelectivePropsExtraction(
+      field,
+      propsColumn,
       dialect,
-      pointer: jsonPointer([field.field]),
-      valueType: field.valueType,
-    });
+    );
     return sql`${extracted} AS ${quoteIdentifier(selectivePropsCteColumnName(field))}`;
   });
 }

--- a/packages/typegraph/src/query/compiler/passes/temporal.ts
+++ b/packages/typegraph/src/query/compiler/passes/temporal.ts
@@ -1,22 +1,24 @@
 import { type SQL } from "drizzle-orm";
 
 import type { QueryAst } from "../../ast";
-import { compileTemporalFilter, extractTemporalOptions } from "../temporal";
+import {
+  compileTemporalFilter,
+  currentReadInstant,
+  extractTemporalOptions,
+} from "../temporal";
 
 export type TemporalFilterPass = Readonly<{
   forAlias: (tableAlias?: string) => SQL;
 }>;
 
 /**
- * Creates a temporal filter pass bound to a query AST and timestamp source.
+ * Creates a temporal filter pass bound to a query AST.
  *
- * Invariant:
- * - All temporal clauses for a query use the same timestamp expression.
+ * Invariant: all temporal clauses for a query use the same "current" instant,
+ * bound once here from the application clock (see {@link currentReadInstant}).
  */
-export function createTemporalFilterPass(
-  ast: QueryAst,
-  currentTimestamp: SQL,
-): TemporalFilterPass {
+export function createTemporalFilterPass(ast: QueryAst): TemporalFilterPass {
+  const currentTimestamp = currentReadInstant();
   return {
     forAlias(tableAlias?: string): SQL {
       return compileTemporalFilter({

--- a/packages/typegraph/src/query/compiler/recursive.ts
+++ b/packages/typegraph/src/query/compiler/recursive.ts
@@ -15,7 +15,6 @@ import {
   type DialectAdapter,
   type DialectRecursiveQueryStrategy,
 } from "../dialect";
-import { jsonPointer } from "../json-pointer";
 import { emitRecursiveQuerySql } from "./emitter";
 import {
   createTemporalFilterPass,
@@ -32,7 +31,7 @@ import {
   type PredicateCompilerContext,
 } from "./predicates";
 import { assertRecordedQueryAstDoesNotUseCurrentIndexes } from "./recorded-current-index-guard";
-import { compileTypedJsonExtract } from "./typed-json-extract";
+import { compileSelectivePropsExtraction } from "./typed-json-extract";
 import {
   addRequiredColumn,
   EMPTY_REQUIRED_COLUMNS,
@@ -112,10 +111,7 @@ function runRecursiveQueryPassPipeline(
   const temporalPass = runCompilerPass(state, {
     name: "temporal_filters",
     execute(currentState): TemporalFilterPass {
-      return createTemporalFilterPass(
-        currentState.ast,
-        currentState.ctx.dialect.currentTimestamp(),
-      );
+      return createTemporalFilterPass(currentState.ast);
     },
     update(currentState, temporalFilterPass): RecursiveQueryPassState {
       return {
@@ -730,12 +726,7 @@ function compileRecursiveSelectiveProjection(
     }
 
     const column = sql.raw(`${field.alias}_props`);
-    const extracted = compileTypedJsonExtract({
-      column,
-      dialect,
-      pointer: jsonPointer([field.field]),
-      valueType: field.valueType,
-    });
+    const extracted = compileSelectivePropsExtraction(field, column, dialect);
     return sql`${extracted} AS ${quoteIdentifier(field.outputName)}`;
   });
 

--- a/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
+++ b/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
@@ -426,10 +426,7 @@ export function runStandardQueryPassPipeline(
   const temporalPass = runCompilerPass(state, {
     name: "temporal_filters",
     execute(currentState): TemporalFilterPass {
-      return createTemporalFilterPass(
-        currentState.ast,
-        currentState.ctx.dialect.currentTimestamp(),
-      );
+      return createTemporalFilterPass(currentState.ast);
     },
     update(currentState, temporalFilterPass): StandardQueryPassState {
       return {

--- a/packages/typegraph/src/query/compiler/temporal.ts
+++ b/packages/typegraph/src/query/compiler/temporal.ts
@@ -8,6 +8,26 @@
 import { type SQL, sql } from "drizzle-orm";
 
 import { type TemporalMode } from "../../core/types";
+import { nowIso } from "../../utils/date";
+
+/**
+ * The "current" valid-time read instant, bound as a parameter — the
+ * APPLICATION clock (`nowIso()`), NOT the database clock (`NOW()`).
+ *
+ * `valid_from` is stamped from the application clock on write, so a "current"
+ * read must compare against the same clock. Comparing `valid_from` (app clock)
+ * against the database `NOW()` would hide a freshly-created row from an
+ * immediately-following current read whenever the app server's clock runs
+ * ahead of the database server's clock — a read-after-write consistency
+ * violation on Postgres (issue #242; SQLite is single-process so it was never
+ * exposed). This binds the same clock the facade search-currency filter
+ * (`liveNodeIdsSubquery`) and the recorded/logical clock already use, and the
+ * same form the `asOf` predicate uses (a bound ISO instant), so it needs no
+ * dialect-specific expression.
+ */
+export function currentReadInstant(): SQL {
+  return sql`${nowIso()}`;
+}
 
 /**
  * Temporal filter options.
@@ -70,7 +90,7 @@ export function compileTemporalFilter(options: TemporalFilterOptions): SQL {
         // valid-current when recorded but ended before the read.
         const now =
           recordedAsOf === undefined ?
-            (currentTimestamp ?? sql`CURRENT_TIMESTAMP`)
+            (currentTimestamp ?? currentReadInstant())
           : sql`${recordedAsOf}`;
         return sql`${deletedAt} IS NULL AND (${validFrom} IS NULL OR ${validFrom} <= ${now}) AND (${validTo} IS NULL OR ${validTo} > ${now})`;
       }

--- a/packages/typegraph/src/query/compiler/typed-json-extract.ts
+++ b/packages/typegraph/src/query/compiler/typed-json-extract.ts
@@ -1,7 +1,8 @@
 import { type SQL } from "drizzle-orm";
 
+import { type SelectiveField } from "../ast";
 import { type DialectAdapter } from "../dialect/types";
-import { type JsonPointer } from "../json-pointer";
+import { type JsonPointer, jsonPointer } from "../json-pointer";
 
 type JsonExtractFallback = "json" | "text";
 
@@ -45,4 +46,27 @@ export function compileTypedJsonExtract(input: TypedJsonExtractInput): SQL {
         : dialect.jsonExtract(column, pointer);
     }
   }
+}
+
+/**
+ * Extracts a single top-level selective-projection field from a JSON props
+ * column, typed by the field's declared value type.
+ *
+ * Shared by both projection shapes: the standard emitter pushes this extraction
+ * into a CTE synthetic column, while the recursive emitter applies it in the
+ * outer SELECT over the props carried through the recursive CTE. The two SQL
+ * shapes differ by design, but they must extract identically — centralizing the
+ * pointer/valueType wiring here keeps their extraction semantics from drifting.
+ */
+export function compileSelectivePropsExtraction(
+  field: SelectiveField,
+  column: SQL,
+  dialect: DialectAdapter,
+): SQL {
+  return compileTypedJsonExtract({
+    column,
+    dialect,
+    pointer: jsonPointer([field.field]),
+    valueType: field.valueType,
+  });
 }

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -212,23 +212,6 @@ export const postgresDialect: DialectAdapter = {
   },
 
   // ============================================================
-  // Type Utilities
-  // ============================================================
-
-  currentTimestamp() {
-    return sql`NOW()`;
-  },
-
-  subqueryMembership(column, subquery) {
-    // ARRAY(subquery) collapses the CTE once via InitPlan; = ANY(array) is
-    // hash-probed (PG 14+) and index-condition eligible. The plain
-    // IN (subquery) form gets pulled up into a join whose recursive-CTE
-    // row estimate drives the planner into a nested-loop join FILTER —
-    // see the DialectAdapter docs for the measured pathology.
-    return sql`${column} = ANY(ARRAY(${subquery}))`;
-  },
-
-  // ============================================================
   // Value Binding & Literals
   // ============================================================
 

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -220,21 +220,6 @@ export const sqliteDialect: DialectAdapter = {
   },
 
   // ============================================================
-  // Type Utilities
-  // ============================================================
-
-  currentTimestamp() {
-    // Keep ISO-8601 format aligned with stored timestamps from Date.toISOString()
-    // so string-based temporal comparisons remain correct in SQLite TEXT columns.
-    return sql`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`;
-  },
-
-  subqueryMembership(column, subquery) {
-    // SQLite evaluates IN (subquery) with a transient index — optimal as-is.
-    return sql`${column} IN (${subquery})`;
-  },
-
-  // ============================================================
   // Value Binding & Literals
   // ============================================================
 

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -310,37 +310,6 @@ export interface DialectAdapter {
   cycleCheck(nodeId: SQL, path: SQL): SQL;
 
   // ============================================================
-  // Type Utilities
-  // ============================================================
-
-  /**
-   * Returns the current timestamp expression.
-   *
-   * @example
-   * SQLite: datetime('now')
-   * PostgreSQL: NOW()
-   */
-  currentTimestamp(): SQL;
-
-  /**
-   * Membership test of `column` against a same-statement subquery (a CTE
-   * scan in practice, e.g. the subgraph extractor's `included_ids`).
-   *
-   * SQLite: `column IN (subquery)` — evaluated as a hashed/indexed
-   * subquery, already optimal.
-   *
-   * PostgreSQL: `column = ANY(ARRAY(subquery))` — the subquery is
-   * collapsed to an array by an InitPlan once, and the scalar-array
-   * comparison is hash-probed (PG 14+) and index-condition eligible.
-   * The naive `IN (subquery)` form is pulled up into a join against the
-   * CTE, whose recursive-CTE row estimate (~10 rows for a single-row
-   * seed) drives the planner into a nested-loop join FILTER — measured
-   * at 10M discarded rows / 383ms on the depth-3 subgraph stress bench
-   * versus ~15ms for this form.
-   */
-  subqueryMembership(column: SQL, subquery: SQL): SQL;
-
-  // ============================================================
   // Value Binding & Literals
   // ============================================================
 

--- a/packages/typegraph/src/query/dialect/vector/libsql-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector/libsql-strategy.ts
@@ -40,6 +40,7 @@ import {
   type VectorSlot,
   type VectorStrategy,
 } from "../vector-strategy";
+import { vectorPageClause } from "./pagination";
 
 /** Physical-name prefixes for the per-field table and its DiskANN index. */
 const TABLE_PREFIX = "tg_vec";
@@ -254,10 +255,7 @@ export const libsqlVectorStrategy: VectorStrategy = {
       const pageK = params.limit + (params.offset ?? 0);
       const annK =
         candidates === undefined ? pageK : pageK * CANDIDATE_FILTER_OVERFETCH;
-      const pageClause =
-        params.offset === undefined || params.offset === 0 ?
-          sql`LIMIT ${params.limit}`
-        : sql`LIMIT ${params.limit} OFFSET ${params.offset}`;
+      const pageClause = vectorPageClause(params.limit, params.offset);
       return sql`
         SELECT ${quoted}."node_id" AS node_id, ${score} AS score
         FROM vector_top_k(${indexName}, ${query}, ${annK})
@@ -278,10 +276,7 @@ export const libsqlVectorStrategy: VectorStrategy = {
         vectorMinScoreCondition(distance, params.metric, params.minScore),
       );
     }
-    const pageClause =
-      params.offset === undefined || params.offset === 0 ?
-        sql`LIMIT ${params.limit}`
-      : sql`LIMIT ${params.limit} OFFSET ${params.offset}`;
+    const pageClause = vectorPageClause(params.limit, params.offset);
     return sql`
       SELECT ${quoted}."node_id" AS node_id, ${score} AS score
       FROM ${quoted}

--- a/packages/typegraph/src/query/dialect/vector/pagination.ts
+++ b/packages/typegraph/src/query/dialect/vector/pagination.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared vector-search pagination clause.
+ *
+ * Every vector strategy pages its ordered relevance scan the same way: emit a
+ * bare `LIMIT` for the first page (`offset` unset or `0`), and `LIMIT … OFFSET`
+ * only when a non-zero offset must discard the leading rows. The three engines'
+ * `buildSearch` methods each repeated this ternary verbatim; it lives here once
+ * so the emitted clause can never drift between dialects.
+ *
+ * `limit` and `offset` ride as bound parameters (never interpolated), so the
+ * clause — string and bound values alike — is identical across engines.
+ */
+import { type SQL, sql } from "drizzle-orm";
+
+export function vectorPageClause(limit: number, offset?: number): SQL {
+  return offset === undefined || offset === 0 ?
+      sql`LIMIT ${limit}`
+    : sql`LIMIT ${limit} OFFSET ${offset}`;
+}

--- a/packages/typegraph/src/query/dialect/vector/pgvector-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector/pgvector-strategy.ts
@@ -44,6 +44,7 @@ import {
   type VectorSlot,
   type VectorStrategy,
 } from "../vector-strategy";
+import { vectorPageClause } from "./pagination";
 
 /** Physical-name prefixes for the per-field table and its ANN index. */
 const TABLE_PREFIX = "tg_vec";
@@ -295,10 +296,7 @@ export const pgvectorStrategy: VectorStrategy = {
     // Pagination is rank-relative: the scan fetches `limit + offset`
     // ordered candidates and OFFSET discards the leading page.
     const pageOffset = params.offset ?? 0;
-    const pageClause =
-      pageOffset === 0 ?
-        sql`LIMIT ${params.limit}`
-      : sql`LIMIT ${params.limit} OFFSET ${params.offset}`;
+    const pageClause = vectorPageClause(params.limit, params.offset);
     // IVFFlat's iterative scan only offers `relaxed_order` (no
     // strict_order mode), so under the backend-applied
     // `ivfflat.iterative_scan` the index may emit the candidate set

--- a/packages/typegraph/src/query/dialect/vector/sqlite-vec-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector/sqlite-vec-strategy.ts
@@ -74,6 +74,7 @@ import {
   type VectorSlot,
   type VectorStrategy,
 } from "../vector-strategy";
+import { vectorPageClause } from "./pagination";
 
 /** Physical-name prefix for the per-field `vec0` virtual table. */
 const TABLE_PREFIX = "tg_vec";
@@ -332,10 +333,7 @@ export const sqliteVecStrategy: VectorStrategy = {
         vectorMinScoreCondition(distance, params.metric, params.minScore),
       );
     }
-    const pageClause =
-      params.offset === undefined || params.offset === 0 ?
-        sql`LIMIT ${params.limit}`
-      : sql`LIMIT ${params.limit} OFFSET ${params.offset}`;
+    const pageClause = vectorPageClause(params.limit, params.offset);
     return sql`
       SELECT ${table}."node_id" AS node_id, ${score} AS score
       FROM ${table}

--- a/packages/typegraph/src/registry/builders.ts
+++ b/packages/typegraph/src/registry/builders.ts
@@ -59,11 +59,6 @@ export function buildKindRegistry<G extends GraphDef>(graph: G): KindRegistry {
 
   const registry = new KindRegistry(nodeTypes, edgeTypes, closures);
   validateImpliesEndpointCompatibility(
-    graph.ontology.map((relation) => ({
-      metaEdgeName: relation.metaEdge.name,
-      from: relation.from,
-      to: relation.to,
-    })),
     buildEdgeEndpointKinds(graph.edges),
     registry,
   );

--- a/packages/typegraph/src/registry/validate-implies.ts
+++ b/packages/typegraph/src/registry/validate-implies.ts
@@ -3,32 +3,17 @@
  *
  * Every place that builds a query-capable `KindRegistry` — `buildKindRegistry`
  * for a live `GraphDef`, and the schema deserializer for a persisted schema —
- * calls this so an endpoint-incompatible `implies(edgeA, edgeB)` can never
- * reach `KindRegistry.expandImplyingEdges()`. Without this gate, `edgeA`
- * would be folded into any `expand: "implying"` traversal for `edgeB` even
- * when `edgeA` connects entirely different node kinds — the query compiler
- * filters by expanded edge kind plus the *queried* node aliases, not by
- * `edgeB`'s own domain/range, so a mismatched edge would silently satisfy
- * whatever kinds the traversal alias happens to ask for.
+ * calls this so an endpoint-incompatible implication can never reach
+ * `KindRegistry.expandImplyingEdges()`. Without this gate, an implying edge
+ * would be folded into any `expand: "implying"` traversal for the edge it
+ * implies even when it connects entirely different node kinds — the query
+ * compiler filters by expanded edge kind plus the *queried* node aliases, not
+ * by the implied edge's own domain/range, so a mismatched edge would silently
+ * satisfy whatever kinds the traversal alias happens to ask for.
  */
 import { ConfigurationError } from "../errors/index";
 import { META_EDGE_IMPLIES } from "../ontology/constants";
-import { getTypeName, type OntologyRelation } from "../ontology/types";
 import { type KindRegistry } from "./kind-registry";
-
-/**
- * The minimal shape both a live `OntologyRelation` (`metaEdge` is a
- * `MetaEdge` object, `from`/`to` may be `EdgeType` objects) and a
- * `SerializedOntologyRelation` (`metaEdge`/`from`/`to` are all plain
- * strings) can be adapted to — this validator only needs the meta-edge
- * name and each endpoint's kind name. `from`/`to` reuse `OntologyRelation`'s
- * own field type so this can never drift from what `getTypeName()` accepts.
- */
-export type ImpliesRelationLike = Readonly<{
-  metaEdgeName: string;
-  from: OntologyRelation["from"];
-  to: OntologyRelation["to"];
-}>;
 
 /** An edge kind's declared domain (`from`) and range (`to`) kind names. */
 export type EdgeEndpointKinds = Readonly<{
@@ -37,51 +22,54 @@ export type EdgeEndpointKinds = Readonly<{
 }>;
 
 /**
- * Rejects `implies(edgeA, edgeB)` relations whose declared endpoints can
- * never be compatible with the edge they imply.
+ * Rejects implications whose implying edge can never be endpoint-compatible
+ * with the edge it implies.
  *
- * A relation is compatible when every kind the implying edge allows on a
- * side is assignable — via `registry.isAssignableToAny` (equal, or a
- * `subClassOf` descendant) — to at least one kind the implied edge allows
- * on that same side. Relations naming an edge kind absent from
- * `edgeEndpoints` are skipped — they cannot affect this graph's traversals.
+ * The check runs over the *effective transitive closure*, not the authored
+ * direct relations: for every registered edge `C`, every edge `A` that
+ * `registry.expandImplyingEdges(C)` reports as (transitively) implying `C` is
+ * validated directly against `C`. This is what keeps the gate sound through an
+ * unregistered intermediate — given `A implies B implies C` with `B` absent
+ * from `edgeEndpoints`, neither direct hop is individually checkable, yet the
+ * precomputed closure still folds `A` into a traversal of `C`, so `A` must be
+ * validated against `C` regardless of `B`.
  *
- * Soundness holds transitively: validating each direct relation certifies
- * the whole `edgeImplyingClosure`, since subclass assignability composes
- * (if A implies B and B implies C, A→B and B→C compatibility together
- * guarantee A→C compatibility) — no separate check of the expanded closure
- * is needed.
+ * A relation is compatible when every kind the implying edge allows on a side
+ * is assignable — via `registry.isAssignableToAny` (equal, or a `subClassOf`
+ * descendant) — to at least one kind the implied edge allows on that same
+ * side. An implying edge kind absent from `edgeEndpoints` is skipped: it is
+ * unregistered on this graph, has no stored rows, and so can never fold
+ * anything into a traversal.
  */
 export function validateImpliesEndpointCompatibility(
-  relations: readonly ImpliesRelationLike[],
   edgeEndpoints: ReadonlyMap<string, EdgeEndpointKinds>,
   registry: KindRegistry,
 ): void {
-  for (const relation of relations) {
-    if (relation.metaEdgeName !== META_EDGE_IMPLIES) continue;
-
-    const implyingEdgeKind = getTypeName(relation.from);
-    const impliedEdgeKind = getTypeName(relation.to);
-    const implyingEndpoints = edgeEndpoints.get(implyingEdgeKind);
-    const impliedEndpoints = edgeEndpoints.get(impliedEdgeKind);
-    if (!implyingEndpoints || !impliedEndpoints) continue;
-
-    assertEndpointCompatible(
-      "from",
-      implyingEdgeKind,
-      implyingEndpoints.from,
+  for (const [impliedEdgeKind, impliedEndpoints] of edgeEndpoints) {
+    for (const implyingEdgeKind of registry.expandImplyingEdges(
       impliedEdgeKind,
-      impliedEndpoints.from,
-      registry,
-    );
-    assertEndpointCompatible(
-      "to",
-      implyingEdgeKind,
-      implyingEndpoints.to,
-      impliedEdgeKind,
-      impliedEndpoints.to,
-      registry,
-    );
+    )) {
+      if (implyingEdgeKind === impliedEdgeKind) continue;
+      const implyingEndpoints = edgeEndpoints.get(implyingEdgeKind);
+      if (!implyingEndpoints) continue;
+
+      assertEndpointCompatible(
+        "from",
+        implyingEdgeKind,
+        implyingEndpoints.from,
+        impliedEdgeKind,
+        impliedEndpoints.from,
+        registry,
+      );
+      assertEndpointCompatible(
+        "to",
+        implyingEdgeKind,
+        implyingEndpoints.to,
+        impliedEdgeKind,
+        impliedEndpoints.to,
+        registry,
+      );
+    }
   }
 }
 

--- a/packages/typegraph/src/schema/deserializer.ts
+++ b/packages/typegraph/src/schema/deserializer.ts
@@ -156,11 +156,6 @@ function buildRegistryFromClosures(schema: SerializedSchema): KindRegistry {
   });
 
   validateImpliesEndpointCompatibility(
-    schema.ontology.relations.map((relation) => ({
-      metaEdgeName: relation.metaEdge,
-      from: relation.from,
-      to: relation.to,
-    })),
     buildEdgeEndpointKinds(schema.edges),
     registry,
   );

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -15,6 +15,7 @@ import {
 } from "../../query/compiler/schema";
 import {
   compileTemporalFilter,
+  currentReadInstant,
   type TemporalFilterOptions,
 } from "../../query/compiler/temporal";
 import { type DialectAdapter } from "../../query/dialect/types";
@@ -115,7 +116,7 @@ export function resolveTemporalFilter(
     asOf: resolved.asOf,
     recordedAsOf: resolved.recordedAsOf,
     tableAlias,
-    currentTimestamp: ctx.dialect.currentTimestamp(),
+    currentTimestamp: currentReadInstant(),
   };
   return compileTemporalFilter(filterOptions);
 }

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -580,10 +580,15 @@ export function createEdgeCollection<
         return results;
       };
 
-      if (backend.capabilities.transactions && "transaction" in backend) {
-        return backend.transaction(async (txBackend) => upsertAll(txBackend));
-      }
-      return upsertAll(backend);
+      const results =
+        backend.capabilities.transactions && "transaction" in backend ?
+          await backend.transaction(async (txBackend) => upsertAll(txBackend))
+        : await upsertAll(backend);
+      // Match bulkCreate/bulkInsert: refresh planner statistics after a large
+      // autocommit bulk write. Threshold-gated, and a no-op inside a caller
+      // transaction (the hook is intentionally undefined there).
+      await config.maybeRefreshStatisticsAfterBulk?.(results.length);
+      return results;
     },
 
     async bulkInsert(

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -479,10 +479,15 @@ export function createNodeCollection<
         return results;
       };
 
-      if (backend.capabilities.transactions && "transaction" in backend) {
-        return backend.transaction(async (txBackend) => upsertAll(txBackend));
-      }
-      return upsertAll(backend);
+      const results =
+        backend.capabilities.transactions && "transaction" in backend ?
+          await backend.transaction(async (txBackend) => upsertAll(txBackend))
+        : await upsertAll(backend);
+      // Match bulkCreate/bulkInsert: refresh planner statistics after a large
+      // autocommit bulk write. Threshold-gated, and a no-op inside a caller
+      // transaction (the hook is intentionally undefined there).
+      await config.maybeRefreshStatisticsAfterBulk?.(results.length);
+      return results;
     },
 
     async bulkInsert(

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -49,6 +49,7 @@ import {
   type RelationalIndexDeclaration,
   type VectorIndexDeclaration,
 } from "../indexes/types";
+import { sqlValueList } from "../query/compiler/predicate-utils";
 import { type SqlDialect } from "../query/dialect/types";
 import { asCompiledRowsSql } from "../query/sql-intent";
 import { sortedReplacer } from "../schema/canonical";
@@ -241,6 +242,22 @@ export async function materializeIndexes(
     statusKeys,
   );
 
+  // Bulk-preload INVALID index leftovers (interrupted CONCURRENTLY builds)
+  // for the relational candidates in one `pg_index` query. On a warm start
+  // `settleAgainstExisting` would otherwise fire one leftover check per
+  // already-materialized index — the same N-round-trip cost the status
+  // preload above just eliminated. Vector entries are excluded: their
+  // per-field physical index leftovers are operator-repair, and
+  // `settleAgainstExisting` only consults this set for non-vector
+  // declarations. Physical names are the declaration names.
+  const relationalPhysicalNames = candidates
+    .filter((declaration) => declaration.entity !== "vector")
+    .map((declaration) => declaration.name);
+  const invalidLeftovers = await preloadInvalidIndexLeftovers(
+    backend,
+    relationalPhysicalNames,
+  );
+
   const materializeEntry = (
     declaration: IndexDeclaration,
   ): Promise<MaterializeIndexesEntry> =>
@@ -251,6 +268,7 @@ export async function materializeIndexes(
         graphId,
         schemaVersion,
         existingByStatusKey,
+        invalidLeftovers,
       )
     : materializeRelationalIndex(
         declaration,
@@ -260,6 +278,7 @@ export async function materializeIndexes(
         graphId,
         schemaVersion,
         existingByStatusKey,
+        invalidLeftovers,
       );
 
   if (options.stopOnError === true) {
@@ -398,6 +417,7 @@ async function materializeRelationalIndex(
   graphId: string,
   schemaVersion: number,
   existingByStatusKey: ReadonlyMap<string, IndexMaterializationRow>,
+  invalidLeftovers: ReadonlySet<string>,
 ): Promise<MaterializeIndexesEntry> {
   // GIN-family methods are PostgreSQL expression GINs; SQLite has no
   // equivalent (its substring-search story is FTS5 fulltext), so the
@@ -440,6 +460,7 @@ async function materializeRelationalIndex(
       await backend.executeDdl!(ddl);
     },
     existingByStatusKey,
+    invalidLeftovers,
   });
 }
 
@@ -449,6 +470,7 @@ async function materializeVectorIndex(
   graphId: string,
   schemaVersion: number,
   existingByStatusKey: ReadonlyMap<string, IndexMaterializationRow>,
+  invalidLeftovers: ReadonlySet<string>,
 ): Promise<MaterializeIndexesEntry> {
   // `indexType: "none"` is a declarative opt-out — the declaration
   // carries shape metadata (dimensions, metric) for tooling but the
@@ -532,6 +554,7 @@ async function materializeVectorIndex(
     driftLabel: "Vector index",
     run: () => backend.createVectorIndex!(params),
     existingByStatusKey,
+    invalidLeftovers,
   });
 }
 
@@ -554,6 +577,7 @@ async function materializeOne(
     driftLabel: string;
     run: () => Promise<void>;
     existingByStatusKey: ReadonlyMap<string, IndexMaterializationRow>;
+    invalidLeftovers: ReadonlySet<string>;
   }>,
 ): Promise<MaterializeIndexesEntry> {
   // Narrowed by callsite — guaranteed defined when this is reached
@@ -564,13 +588,21 @@ async function materializeOne(
   const statusOverride =
     statusKey === declaration.name ? undefined : { statusName: statusKey };
 
+  // Pre-claim leftover check reads the bulk-preloaded set (one `pg_index`
+  // query for all candidates), not one round-trip per index.
   const settled = await settleAgainstExisting(
     existingByStatusKey.get(statusKey),
     declaration,
     backend,
     graphId,
     schemaVersion,
-    { statusKey, signature, driftLabel },
+    {
+      statusKey,
+      signature,
+      driftLabel,
+      isInvalidLeftover: (physicalIndexName) =>
+        action.invalidLeftovers.has(physicalIndexName),
+    },
   );
   if (settled !== undefined) return settled;
 
@@ -636,10 +668,19 @@ async function settleAgainstExisting(
     statusKey: string;
     signature: string;
     driftLabel: string;
+    /**
+     * Whether a physical index with this name exists but is INVALID. The
+     * pre-claim caller reads a bulk-preloaded set (one query for all
+     * candidates); the post-claim caller reads fresh (the preload is stale
+     * after waiting on another builder's claim).
+     */
+    isInvalidLeftover: (
+      physicalIndexName: string,
+    ) => boolean | Promise<boolean>;
   }>,
 ): Promise<MaterializeIndexesEntry | undefined> {
   if (existing?.materializedAt === undefined) return undefined;
-  const { statusKey, signature, driftLabel } = action;
+  const { statusKey, signature, driftLabel, isInvalidLeftover } = action;
   if (existing.signature === signature) {
     // A recorded success is only trustworthy while the physical index is
     // valid: a run interrupted after `CREATE ... IF NOT EXISTS` silently
@@ -649,7 +690,7 @@ async function settleAgainstExisting(
     if (
       declaration.entity !== "vector" &&
       hasIndexBuildClaimProtocol(backend) &&
-      (await hasInvalidIndexLeftover(backend, declaration.name))
+      (await isInvalidLeftover(declaration.name))
     ) {
       return undefined;
     }
@@ -741,7 +782,15 @@ async function materializeWithClaim(
         backend,
         graphId,
         schemaVersion,
-        { statusKey, signature, driftLabel },
+        {
+          statusKey,
+          signature,
+          driftLabel,
+          // Post-claim the bulk preload is stale (we may have waited on
+          // another builder's claim), so re-check this index fresh.
+          isInvalidLeftover: (physicalIndexName) =>
+            hasInvalidIndexLeftover(backend, physicalIndexName),
+        },
       );
       if (settled !== undefined) return settled;
 
@@ -782,22 +831,28 @@ async function materializeWithClaim(
         return entry(declaration, "failed", error);
       }
     } finally {
-      await backend.releaseIndexMaterializationClaim!({
-        indexName: statusKey,
-        token,
-      });
+      // A claim-release failure must not mask the build's own outcome — a
+      // successful build must not surface as a thrown rejection, and one
+      // bucket's release error must not abort its siblings. The claim carries
+      // a lease (CLAIM_LEASE_MS) and self-expires, so a missed release is
+      // reclaimed by the next materializer; warn and move on.
+      try {
+        await backend.releaseIndexMaterializationClaim!({
+          indexName: statusKey,
+          token,
+        });
+      } catch (releaseError) {
+        console.warn(
+          `typegraph: failed to release the index materialization claim for ` +
+            `"${statusKey}"; it will expire on its lease and be reclaimed ` +
+            `automatically.`,
+          releaseError,
+        );
+      }
     }
   }
 }
 
-/**
- * Self-heals an interrupted CONCURRENTLY build: a crashed CIC leaves an
- * INVALID index behind, and a later `CREATE INDEX CONCURRENTLY IF NOT
- * EXISTS` would see the name and silently no-op — recording success over
- * an index the planner will never use. Detect via pg_index and drop
- * (also CONCURRENTLY — same no-transaction rule). Valid indexes are never
- * touched.
- */
 /**
  * Whether an index with this name exists but is INVALID (an interrupted
  * CONCURRENTLY build's leftover). False for absent or valid indexes and
@@ -819,6 +874,44 @@ async function hasInvalidIndexLeftover(
   return rows[0]?.invalid === true;
 }
 
+/**
+ * Bulk variant of `hasInvalidIndexLeftover`: the set of INVALID leftover
+ * index names among `physicalIndexNames`, resolved in ONE `pg_index` query.
+ * Empty set on non-Postgres dialects or empty input.
+ *
+ * A warm start (every index already materialized with a matching signature)
+ * would otherwise fire `hasInvalidIndexLeftover` once per already-materialized
+ * relational index inside `settleAgainstExisting` — N `pg_index` round-trips.
+ * Preloading the whole set collapses that to one, mirroring how
+ * `preloadMaterializations` batches the status reads it sits beside.
+ */
+async function preloadInvalidIndexLeftovers(
+  backend: GraphBackend,
+  physicalIndexNames: readonly string[],
+): Promise<ReadonlySet<string>> {
+  if (backend.dialect !== "postgres" || physicalIndexNames.length === 0) {
+    return new Set();
+  }
+  const rows = await backend.execute<{ name: string }>(
+    asCompiledRowsSql(sql`
+      SELECT c.relname AS name
+      FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname IN (${sqlValueList(physicalIndexNames)})
+        AND NOT i.indisvalid
+    `),
+  );
+  return new Set(rows.map((row) => row.name));
+}
+
+/**
+ * Self-heals an interrupted CONCURRENTLY build: a crashed CIC leaves an
+ * INVALID index behind, and a later `CREATE INDEX CONCURRENTLY IF NOT
+ * EXISTS` would see the name and silently no-op — recording success over an
+ * index the planner will never use. Detect via `hasInvalidIndexLeftover` and
+ * drop (also CONCURRENTLY — same no-transaction rule). Valid indexes are
+ * never touched.
+ */
 async function dropInvalidIndexLeftover(
   backend: GraphBackend,
   physicalIndexName: string,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -251,6 +251,13 @@ export function createNodeBatchValidationBackend(
     props: Record<string, unknown>,
     constraints: readonly UniqueConstraint[],
   ) => void;
+  registerAppliedNodeUpdate: (
+    kind: string,
+    id: string,
+    oldProps: Record<string, unknown>,
+    newProps: Record<string, unknown>,
+    constraints: readonly UniqueConstraint[],
+  ) => void;
   seedNodeRow: (kind: string, id: string, row: CachedNodeRow) => void;
   seedUniqueRow: (
     kind: string,
@@ -364,6 +371,77 @@ export function createNodeBatchValidationBackend(
     }
   }
 
+  // Reflects a completed in-slice node update in the uniqueness caches so a
+  // later row's pre-check sees the post-update reservation state — the state
+  // the sequential path's per-row backend read would observe. The batch path
+  // primes the caches ONCE before routing, but an in-slice update mutates the
+  // real backend's uniqueness rows directly; without reconciling here a later
+  // create either (a) claims a value this update just freed yet gets rejected
+  // against the stale reservation, or (b) passes the stale "free" cache for a
+  // value this update just took and then violates the real constraint at
+  // flush, aborting the whole import. Mirrors updateUniquenessEntries' key
+  // diff: for each constraint whose key changed, the released old key becomes
+  // free and the reserved new key becomes owned by this node, across every
+  // kind the constraint's scope checks.
+  function registerAppliedNodeUpdate(
+    kind: string,
+    id: string,
+    oldProps: Record<string, unknown>,
+    newProps: Record<string, unknown>,
+    constraints: readonly UniqueConstraint[],
+  ): void {
+    for (const constraint of constraints) {
+      const oldApplies = checkWherePredicate(constraint, oldProps);
+      const newApplies = checkWherePredicate(constraint, newProps);
+      const oldKey =
+        oldApplies ?
+          computeUniqueKey(oldProps, constraint.fields, constraint.collation)
+        : undefined;
+      const newKey =
+        newApplies ?
+          computeUniqueKey(newProps, constraint.fields, constraint.collation)
+        : undefined;
+      if (oldKey === newKey) continue;
+
+      const kindsToCheck = getKindsForUniquenessCheck(
+        kind,
+        constraint.scope,
+        registry,
+      );
+
+      if (oldKey !== undefined) {
+        for (const kindToCheck of kindsToCheck) {
+          const cacheKey = buildUniqueCacheKey(
+            graphId,
+            kindToCheck,
+            constraint.name,
+            oldKey,
+          );
+          // This node released the key on the real backend, so it is now
+          // free. Clear any pending reservation and record the known-free
+          // state (overwriting a stale seeded owner) so a later create's
+          // pre-check sees a vacancy instead of a redundant backend read.
+          pendingUniqueOwners.delete(cacheKey);
+          uniqueCache.set(cacheKey, undefined);
+        }
+      }
+      if (newKey !== undefined) {
+        for (const kindToCheck of kindsToCheck) {
+          const cacheKey = buildUniqueCacheKey(
+            graphId,
+            kindToCheck,
+            constraint.name,
+            newKey,
+          );
+          // This node now holds the key on the real backend. A pending owner
+          // shadows the seeded uniqueCache entry (checkUniqueCached consults
+          // it first), matching registerPendingUniqueEntries' reservation.
+          pendingUniqueOwners.set(cacheKey, id);
+        }
+      }
+    }
+  }
+
   // Seed functions let batch preparation prime the caches from one
   // getNodes / checkUniqueBatch round trip instead of a per-row probe.
   // Seeding an absent result (`undefined`) is meaningful — it marks the
@@ -396,6 +474,7 @@ export function createNodeBatchValidationBackend(
     backend: validationBackend,
     registerPendingNode,
     registerPendingUniqueEntries,
+    registerAppliedNodeUpdate,
     seedNodeRow,
     seedUniqueRow,
   };

--- a/packages/typegraph/src/store/recorded-read-service.ts
+++ b/packages/typegraph/src/store/recorded-read-service.ts
@@ -20,8 +20,10 @@ import {
   recordedReadSqlSchema,
   requireRecordedReadBinding,
 } from "../query/compiler/schema";
-import { compileTemporalFilter } from "../query/compiler/temporal";
-import { getDialect } from "../query/dialect";
+import {
+  compileTemporalFilter,
+  currentReadInstant,
+} from "../query/compiler/temporal";
 import { asCompiledRowsSql, type CompiledRowsSql } from "../query/sql-intent";
 import { chunk } from "../utils/array";
 import { withRecordedRelationsPrecondition } from "../utils/sql-errors";
@@ -144,7 +146,7 @@ function recordedTemporalFilter(
     asOf: coordinate.valid.asOf,
     recordedAsOf,
     tableAlias,
-    currentTimestamp: getDialect(backend.dialect).currentTimestamp(),
+    currentTimestamp: currentReadInstant(),
   });
 }
 

--- a/packages/typegraph/src/store/recursive-cte.ts
+++ b/packages/typegraph/src/store/recursive-cte.ts
@@ -9,7 +9,10 @@ import {
   recordedReadSchemaFor,
   type SqlSchema,
 } from "../query/compiler/schema";
-import { compileTemporalFilter } from "../query/compiler/temporal";
+import {
+  compileTemporalFilter,
+  currentReadInstant,
+} from "../query/compiler/temporal";
 import { type DialectAdapter } from "../query/dialect/types";
 import { type TraversalDirection } from "./algorithms/types";
 
@@ -47,7 +50,7 @@ export function buildReachableCte(options: BuildReachableCteOptions): SQL {
     sql.raw("e.kind"),
     options.edgeKinds,
   );
-  const currentTimestamp = options.dialect.currentTimestamp();
+  const currentTimestamp = currentReadInstant();
   const nodeTemporalFilter = compileTemporalFilter({
     mode: options.temporalMode,
     asOf: options.asOf,

--- a/packages/typegraph/src/store/subgraph.ts
+++ b/packages/typegraph/src/store/subgraph.ts
@@ -32,7 +32,10 @@ import {
   recordedReadSchemaFor,
   type SqlSchema,
 } from "../query/compiler/schema";
-import { compileTemporalFilter } from "../query/compiler/temporal";
+import {
+  compileTemporalFilter,
+  currentReadInstant,
+} from "../query/compiler/temporal";
 import { compileTypedJsonExtract } from "../query/compiler/typed-json-extract";
 import { quoteIdentifier } from "../query/compiler/utils";
 import type { DialectAdapter } from "../query/dialect/types";
@@ -590,11 +593,9 @@ export async function executeSubgraph<
   } else {
     membership = {
       prefix: sql`${reachableCte}${includedIdsCte} `,
-      idFilter: (column) =>
-        ctx.dialect.subqueryMembership(
-          column,
-          sql.raw("SELECT id FROM included_ids"),
-        ),
+      // SQLite: `column IN (subquery)` evaluates via a transient index —
+      // optimal as-is. (Postgres takes the parameterized text[] form above.)
+      idFilter: (column) => sql`${column} IN (SELECT id FROM included_ids)`,
       parameterDependentPlan: false,
     };
   }
@@ -813,7 +814,7 @@ async function fetchSubgraphNodes(
     asOf: ctx.asOf,
     recordedAsOf: ctx.recordedAsOf,
     tableAlias: "n",
-    currentTimestamp: ctx.dialect.currentTimestamp(),
+    currentTimestamp: currentReadInstant(),
   });
   const columns: SQL[] = [
     sql`n.kind`,
@@ -849,7 +850,7 @@ async function fetchSubgraphEdges(
     asOf: ctx.asOf,
     recordedAsOf: ctx.recordedAsOf,
     tableAlias: "e",
-    currentTimestamp: ctx.dialect.currentTimestamp(),
+    currentTimestamp: currentReadInstant(),
   });
   const columns: SQL[] = [
     sql`e.id`,

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -31,6 +31,7 @@ import {
   registerEdgeOperationIntegrationTests,
   registerEdgePropertyIntegrationTests,
   registerFulltextIntegrationTests,
+  registerImportUniquenessIntegrationTests,
   registerOrderingIntegrationTests,
   registerPaginationIntegrationTests,
   registerPredicateIntegrationTests,
@@ -137,6 +138,7 @@ export function createIntegrationTestSuite(
     registerStoreViewIntegrationTests(context);
     registerAlgorithmIntegrationTests(context);
     registerFulltextIntegrationTests(context);
+    registerImportUniquenessIntegrationTests(context);
     registerEdgeCaseIntegrationTests(context);
     registerCrossBackendConsistencyTests(context);
   });

--- a/packages/typegraph/tests/backends/integration/bulk-find-by-index.ts
+++ b/packages/typegraph/tests/backends/integration/bulk-find-by-index.ts
@@ -257,5 +257,25 @@ export function registerBulkFindByIndexIntegrationTests(
         ]),
       ).rejects.toBeInstanceOf(ConfigurationError);
     });
+
+    it("rejects a fields-less (keySystemColumns-only) index with ConfigurationError", async () => {
+      const store = context.getStore();
+      // A keySystemColumns/coveringFields-only index carries no prop `fields`,
+      // so bulkFindByIndex has nothing to probe by; it declares the gap rather
+      // than running an unconstrained scan.
+      const caught = await store.nodes.Company.bulkFindByIndex(
+        "company_id_covering",
+        [{ props: { name: "Acme" } }],
+      ).catch((error: unknown) => error);
+
+      expect(caught).toBeInstanceOf(ConfigurationError);
+      expect((caught as ConfigurationError).message).toBe(
+        'bulkFindByIndex requires an index with at least one prop-based field on index "company_id_covering" (node kind "Company")',
+      );
+      expect((caught as ConfigurationError).details).toEqual({
+        indexName: "company_id_covering",
+        kind: "Company",
+      });
+    });
   });
 }

--- a/packages/typegraph/tests/backends/integration/fixtures.ts
+++ b/packages/typegraph/tests/backends/integration/fixtures.ts
@@ -123,6 +123,14 @@ const documentPublishedAtIndex = defineNodeIndex(Document, {
   fields: ["publishedAt"],
 });
 
+// keySystemColumns-only covering index (index-only join coverage): it carries
+// no prop `fields`, so bulkFindByIndex has nothing to probe by and rejects it.
+const companyIdCoveringIndex = defineNodeIndex(Company, {
+  name: "company_id_covering",
+  keySystemColumns: ["id"],
+  coveringFields: ["name"],
+});
+
 export const integrationTestGraph = defineGraph({
   id: "integration_test",
   nodes: {
@@ -138,6 +146,7 @@ export const integrationTestGraph = defineGraph({
     personActiveNameIndex,
     documentAuthorIndex,
     documentPublishedAtIndex,
+    companyIdCoveringIndex,
   ],
   edges: {
     worksAt: {

--- a/packages/typegraph/tests/backends/integration/import-uniqueness.ts
+++ b/packages/typegraph/tests/backends/integration/import-uniqueness.ts
@@ -1,0 +1,205 @@
+/**
+ * Cross-backend importGraph uniqueness parity.
+ *
+ * Batch import primes a shared uniqueness pre-check cache ONCE per slice and
+ * then routes each record (create vs onConflict:"update") against it. An
+ * in-slice update mutates the real backend's uniqueness rows directly, so the
+ * batched path must reconcile the cache with that mutation or it diverges from
+ * the one-record-per-slice (sequential-equivalent) path:
+ *
+ *  - an update that FREES a unique value must let a later create claim it, and
+ *  - an update that CLAIMS a free value must turn a later create of that value
+ *    into a per-row error — never a flush-time constraint violation that
+ *    throws and rolls back the whole import.
+ *
+ * These live in the shared suite so both SQLite and PostgreSQL certify the
+ * same observable outcome (the batching path was previously SQLite-only).
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  type NodeId,
+} from "../../../src";
+import {
+  FORMAT_VERSION,
+  type GraphData,
+  importGraph,
+  type ImportOptions,
+} from "../../../src/interchange";
+import { type IntegrationTestContext } from "./test-context";
+
+const ImportPerson = defineNode("ImportPerson", {
+  schema: z.object({ name: z.string(), email: z.string() }),
+});
+
+// Each run gets its own graph id so the sequential (batchSize 1) and batched
+// runs within one test are fully isolated on the shared backend — node rows
+// are namespaced by graph_id, so distinct ids never see each other's writes.
+function buildImportUniquenessGraph(graphId: string) {
+  return defineGraph({
+    id: graphId,
+    nodes: {
+      ImportPerson: {
+        type: ImportPerson,
+        unique: [
+          {
+            name: "import_person_email",
+            fields: ["email"],
+            scope: "kind",
+            collation: "binary",
+          },
+        ],
+      },
+    },
+    edges: {},
+  });
+}
+
+let graphIdCounter = 0;
+
+function personId(id: string): NodeId<typeof ImportPerson> {
+  return id as NodeId<typeof ImportPerson>;
+}
+
+function payload(nodes: GraphData["nodes"]): GraphData {
+  return {
+    formatVersion: FORMAT_VERSION,
+    exportedAt: new Date().toISOString(),
+    source: { type: "external", description: "import uniqueness parity" },
+    nodes,
+    edges: [],
+  };
+}
+
+function personNode(
+  id: string,
+  name: string,
+  email: string,
+): GraphData["nodes"][number] {
+  return { kind: "ImportPerson", id, properties: { name, email } };
+}
+
+function options(batchSize: number): ImportOptions {
+  return {
+    onConflict: "update",
+    onUnknownProperty: "error",
+    validateReferences: true,
+    batchSize,
+    refreshStatistics: false,
+  };
+}
+
+export function registerImportUniquenessIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  // Hoisted to this scope (not inside `describe`) because it closes over
+  // `context`; each call gets its own graph id so a test's sequential
+  // (batchSize 1) and batched runs stay isolated on the shared backend.
+  async function createGraphStore() {
+    graphIdCounter += 1;
+    const [store] = await createStoreWithSchema(
+      buildImportUniquenessGraph(`import_uniqueness_parity_${graphIdCounter}`),
+      context.getStore().backend,
+    );
+    return store;
+  }
+
+  describe("importGraph uniqueness parity", () => {
+    it("in-slice update that frees a unique key lets a later create claim it", async () => {
+      const outcomes = new Map<number, unknown>();
+      for (const batchSize of [1, 100]) {
+        const store = await createGraphStore();
+        await importGraph(
+          store,
+          payload([personNode("free-a", "a", "shared@example.com")]),
+          options(1),
+        );
+        const result = await importGraph(
+          store,
+          payload([
+            personNode("free-a", "a2", "moved@example.com"),
+            personNode("free-b", "b", "shared@example.com"),
+          ]),
+          options(batchSize),
+        );
+        const personA = await store.nodes.ImportPerson.getById(
+          personId("free-a"),
+        );
+        const personB = await store.nodes.ImportPerson.getById(
+          personId("free-b"),
+        );
+        outcomes.set(batchSize, {
+          created: result.nodes.created,
+          updated: result.nodes.updated,
+          errorIds: result.errors.map((entry) => entry.id),
+          emailA: personA?.email,
+          emailB: personB?.email,
+        });
+      }
+
+      const sequential = outcomes.get(1);
+      const batched = outcomes.get(100);
+
+      expect(sequential).toEqual({
+        created: 1,
+        updated: 1,
+        errorIds: [],
+        emailA: "moved@example.com",
+        emailB: "shared@example.com",
+      });
+      expect(batched).toEqual(sequential);
+    });
+
+    it("in-slice update that claims a free unique key makes a later create a per-row error, not an import abort", async () => {
+      const outcomes = new Map<number, unknown>();
+      for (const batchSize of [1, 100]) {
+        const store = await createGraphStore();
+        await importGraph(
+          store,
+          payload([personNode("claim-a", "a", "a-orig@example.com")]),
+          options(1),
+        );
+        const result = await importGraph(
+          store,
+          payload([
+            personNode("claim-a", "a2", "target@example.com"),
+            personNode("claim-c", "c", "target@example.com"),
+          ]),
+          options(batchSize),
+        );
+        const personA = await store.nodes.ImportPerson.getById(
+          personId("claim-a"),
+        );
+        const personC = await store.nodes.ImportPerson.getById(
+          personId("claim-c"),
+        );
+        outcomes.set(batchSize, {
+          created: result.nodes.created,
+          updated: result.nodes.updated,
+          errors: result.errors.map((entry) => ({
+            id: entry.id,
+            matchesConstraint: entry.error.includes("import_person_email"),
+          })),
+          emailA: personA?.email,
+          personCExists: personC !== undefined,
+        });
+      }
+
+      const sequential = outcomes.get(1);
+      const batched = outcomes.get(100);
+
+      expect(sequential).toEqual({
+        created: 0,
+        updated: 1,
+        errors: [{ id: "claim-c", matchesConstraint: true }],
+        emailA: "target@example.com",
+        personCExists: false,
+      });
+      expect(batched).toEqual(sequential);
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/import-uniqueness.ts
+++ b/packages/typegraph/tests/backends/integration/import-uniqueness.ts
@@ -201,5 +201,57 @@ export function registerImportUniquenessIntegrationTests(
       });
       expect(batched).toEqual(sequential);
     });
+
+    it("in-slice create reserving a unique value makes a later update to it a per-row error, not an import abort", async () => {
+      const outcomes = new Map<number, unknown>();
+      for (const batchSize of [1, 100]) {
+        const store = await createGraphStore();
+        await importGraph(
+          store,
+          payload([personNode("inv-a", "a", "a-orig@example.com")]),
+          options(1),
+        );
+        const result = await importGraph(
+          store,
+          payload([
+            personNode("inv-b", "b", "target@example.com"),
+            personNode("inv-a", "a2", "target@example.com"),
+          ]),
+          options(batchSize),
+        );
+        const personA = await store.nodes.ImportPerson.getById(
+          personId("inv-a"),
+        );
+        const personB = await store.nodes.ImportPerson.getById(
+          personId("inv-b"),
+        );
+        outcomes.set(batchSize, {
+          created: result.nodes.created,
+          updated: result.nodes.updated,
+          errors: result.errors.map((entry) => ({
+            id: entry.id,
+            matchesConstraint: entry.error.includes("import_person_email"),
+          })),
+          emailA: personA?.email,
+          emailB: personB?.email,
+        });
+      }
+
+      const sequential = outcomes.get(1);
+      const batched = outcomes.get(100);
+
+      // Sequential creates B owning "target", then A's update to "target" is a
+      // per-row uniqueness error (A keeps its original value). Batched must
+      // match: the update's pre-check has to see B's still-unflushed
+      // reservation instead of claiming the key and colliding at flush.
+      expect(sequential).toEqual({
+        created: 1,
+        updated: 0,
+        errors: [{ id: "inv-a", matchesConstraint: true }],
+        emailA: "a-orig@example.com",
+        emailB: "target@example.com",
+      });
+      expect(batched).toEqual(sequential);
+    });
   });
 }

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -9,6 +9,7 @@ export { registerAdvancedEdgePropertyIntegrationTests } from "./edge-properties-
 export type { IntegrationStore } from "./fixtures";
 export { integrationTestGraph } from "./fixtures";
 export { registerFulltextIntegrationTests } from "./fulltext";
+export { registerImportUniquenessIntegrationTests } from "./import-uniqueness";
 export { registerOrderingIntegrationTests } from "./ordering";
 export { registerPaginationIntegrationTests } from "./pagination";
 export { registerPredicateIntegrationTests } from "./predicates";

--- a/packages/typegraph/tests/backends/integration/temporal.ts
+++ b/packages/typegraph/tests/backends/integration/temporal.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { TEMPORAL_ANCHORS } from "../../test-utils";
 import { type IntegrationTestContext } from "./test-context";
@@ -47,6 +47,40 @@ export function registerTemporalIntegrationTests(
 
       expect(results).toHaveLength(2);
       expect(results.toSorted()).toEqual(["Alice", "Bob"]);
+    });
+
+    it("keeps a freshly-created row visible to an immediately-following current read despite app-vs-database clock skew (#242)", async () => {
+      const store = context.getStore();
+
+      // Simulate the app-server clock running AHEAD of the database clock by
+      // pinning `Date` to a far-future instant. An omitted `validFrom` is
+      // stamped from this (app) clock, so a "current" read must compare
+      // against the same app clock to see the row. Under a database-clock read
+      // (`valid_from <= NOW()`), the row's future `validFrom` would exceed the
+      // database's real wall clock and vanish from the very read that created
+      // it — the read-after-write regression from issue #242.
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        vi.setSystemTime(new Date("2099-01-01T00:00:00.000Z"));
+
+        const created = await store.nodes.Person.create({
+          name: "Skewed",
+          age: 42,
+        });
+
+        const queried = await store
+          .query()
+          .from("Person", "p")
+          .whereNode("p", (p) => p.name.eq("Skewed"))
+          .select((ctx) => ctx.p.name)
+          .execute();
+        expect(queried).toEqual(["Skewed"]);
+
+        const fetched = await store.nodes.Person.getById(created.id);
+        expect(fetched?.name).toBe("Skewed");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("creates edges with validTo for temporal relationships", async () => {

--- a/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
+++ b/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
@@ -12,14 +12,14 @@ import { Pool } from "pg";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { defineGraph, defineNode } from "../../../src";
+import { defineEdge, defineGraph, defineNode } from "../../../src";
 import {
   generatePostgresDDL,
   generatePostgresMigrationSQL,
 } from "../../../src/backend/drizzle/ddl";
 import { tables as defaultPostgresTables } from "../../../src/backend/drizzle/schema/postgres";
 import { createPostgresBackend } from "../../../src/backend/postgres";
-import { defineNodeIndex } from "../../../src/indexes";
+import { defineEdgeIndex, defineNodeIndex } from "../../../src/indexes";
 import { createStoreWithSchema } from "../../../src/store";
 
 const TEST_DATABASE_URL =
@@ -344,6 +344,72 @@ describe("Postgres store.materializeIndexes — GIN-family methods", () => {
     expect(substring.map((row) => row.title)).toEqual([
       "Postgres indexing deep dive",
     ]);
+  });
+});
+
+describe("Postgres store.materializeIndexes — edge GIN-family methods", () => {
+  const Tagged = defineEdge("tagged", {
+    schema: z.object({
+      labels: z.array(z.string()),
+      note: z.string(),
+    }),
+  });
+
+  function buildEdgeGinGraph() {
+    return defineGraph({
+      id: "pg_edge_gin_method_test",
+      nodes: { Person: { type: Person } },
+      edges: {
+        tagged: {
+          type: Tagged,
+          from: [Person],
+          to: [Person],
+          cardinality: "many",
+        },
+      },
+      indexes: [
+        defineEdgeIndex(Tagged, {
+          fields: ["labels"],
+          method: "gin",
+          name: "idx_tg_tagged_labels_gin",
+        }),
+        defineEdgeIndex(Tagged, {
+          fields: ["note"],
+          method: "trigram",
+          name: "idx_tg_tagged_note_trgm",
+        }),
+      ],
+    });
+  }
+
+  it("creates edge gin/trigram expression indexes on typegraph_edges and is idempotent", async (ctx) => {
+    const { pool } = requirePostgres(ctx);
+    const backend = createPostgresBackend(drizzle(pool));
+    const [store] = await createStoreWithSchema(buildEdgeGinGraph(), backend);
+
+    const first = await store.materializeIndexes();
+    expect(first.results.map((entry) => entry.status).toSorted()).toEqual([
+      "created",
+      "created",
+    ]);
+    for (const entry of first.results) {
+      expect(entry.entity).toBe("edge");
+    }
+
+    const second = await store.materializeIndexes();
+    expect(
+      second.results.every((entry) => entry.status === "alreadyMaterialized"),
+    ).toBe(true);
+
+    // Physically present on typegraph_edges with the GIN access method.
+    const indexRows = await pool.query<{ indexdef: string; tablename: string }>(
+      `SELECT indexdef, tablename FROM pg_indexes WHERE indexname IN ('idx_tg_tagged_labels_gin', 'idx_tg_tagged_note_trgm')`,
+    );
+    expect(indexRows.rows).toHaveLength(2);
+    for (const row of indexRows.rows) {
+      expect(row.indexdef).toContain("USING gin");
+      expect(row.tablename).toBe("typegraph_edges");
+    }
   });
 });
 

--- a/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
@@ -102,6 +102,7 @@ describe("computeSqliteBatchChunkSizes", () => {
   it("reproduces the historic chunk sizes at the 999 floor", () => {
     expect(computeSqliteBatchChunkSizes(999)).toEqual({
       checkUniqueBatchChunkSize: 996,
+      embeddingUpsertBatchSize: 199,
       edgeInsertBatchSize: 83,
       fulltextUpsertBatchSize: 166,
       fulltextDeleteChunkSize: 997,
@@ -115,6 +116,7 @@ describe("computeSqliteBatchChunkSizes", () => {
   it("scales chunk sizes with the modern budget", () => {
     expect(computeSqliteBatchChunkSizes(MODERN_BETTER_SQLITE3_BUDGET)).toEqual({
       checkUniqueBatchChunkSize: 32_763,
+      embeddingUpsertBatchSize: 6553,
       edgeInsertBatchSize: 2730,
       fulltextUpsertBatchSize: 5461,
       fulltextDeleteChunkSize: 32_764,
@@ -135,6 +137,7 @@ describe("computeSqliteBatchChunkSizes", () => {
   it("never returns a chunk size below one", () => {
     expect(computeSqliteBatchChunkSizes(1)).toEqual({
       checkUniqueBatchChunkSize: 1,
+      embeddingUpsertBatchSize: 1,
       edgeInsertBatchSize: 1,
       fulltextUpsertBatchSize: 1,
       fulltextDeleteChunkSize: 1,

--- a/packages/typegraph/tests/import-batching.test.ts
+++ b/packages/typegraph/tests/import-batching.test.ts
@@ -432,6 +432,134 @@ describe("importGraph batching semantics (must not drift)", () => {
     });
   });
 
+  it("in-slice update that frees a unique key lets a later create claim it", async () => {
+    // p-a holds "shared@example.com". A single onConflict:update slice
+    // updates p-a to release that value, then creates p-b claiming it. The
+    // sequential (one-record-per-slice) path frees the key before the create
+    // runs, so p-b is created. The batched slice primes the uniqueness cache
+    // once up front and must reflect the in-slice update, or it wrongly
+    // rejects p-b against the stale reservation.
+    const outcomes = new Map<number, unknown>();
+    for (const batchSize of [1, 100]) {
+      const outcome = await withCountedStore(async (store) => {
+        await importGraph(
+          store,
+          payload([
+            {
+              kind: "Person",
+              id: "p-a",
+              properties: { name: "a", email: "shared@example.com" },
+            },
+          ]),
+          importOptions(),
+        );
+        const result = await importGraph(
+          store,
+          payload([
+            {
+              kind: "Person",
+              id: "p-a",
+              properties: { name: "a2", email: "moved@example.com" },
+            },
+            {
+              kind: "Person",
+              id: "p-b",
+              properties: { name: "b", email: "shared@example.com" },
+            },
+          ]),
+          importOptions({ onConflict: "update", batchSize }),
+        );
+        const personA = await store.nodes.Person.getById("p-a" as never);
+        const personB = await store.nodes.Person.getById("p-b" as never);
+        return {
+          created: result.nodes.created,
+          updated: result.nodes.updated,
+          errorIds: result.errors.map((entry) => entry.id),
+          emailA: personA?.email,
+          emailB: personB?.email,
+        };
+      });
+      outcomes.set(batchSize, outcome);
+    }
+
+    const sequential = outcomes.get(1);
+    const batched = outcomes.get(100);
+
+    expect(sequential).toEqual({
+      created: 1,
+      updated: 1,
+      errorIds: [],
+      emailA: "moved@example.com",
+      emailB: "shared@example.com",
+    });
+    expect(batched).toEqual(sequential);
+  });
+
+  it("in-slice update that claims a free unique key makes a later create a per-row error, not an import abort", async () => {
+    // p-a moves onto a currently-free "target@example.com"; a later create
+    // of the same value must become a per-row uniqueness error (as the
+    // sequential path reports), NOT slip past the stale prime cache into a
+    // flush-time constraint violation that throws and rolls back the whole
+    // import.
+    const outcomes = new Map<number, unknown>();
+    for (const batchSize of [1, 100]) {
+      const outcome = await withCountedStore(async (store) => {
+        await importGraph(
+          store,
+          payload([
+            {
+              kind: "Person",
+              id: "p-a",
+              properties: { name: "a", email: "a-orig@example.com" },
+            },
+          ]),
+          importOptions(),
+        );
+        const result = await importGraph(
+          store,
+          payload([
+            {
+              kind: "Person",
+              id: "p-a",
+              properties: { name: "a2", email: "target@example.com" },
+            },
+            {
+              kind: "Person",
+              id: "p-c",
+              properties: { name: "c", email: "target@example.com" },
+            },
+          ]),
+          importOptions({ onConflict: "update", batchSize }),
+        );
+        const personA = await store.nodes.Person.getById("p-a" as never);
+        const personC = await store.nodes.Person.getById("p-c" as never);
+        return {
+          created: result.nodes.created,
+          updated: result.nodes.updated,
+          errors: result.errors.map((entry) => ({
+            id: entry.id,
+            matchesConstraint: entry.error.includes("person_email"),
+          })),
+          emailA: personA?.email,
+          personCExists: personC !== undefined,
+        };
+      });
+      outcomes.set(batchSize, outcome);
+    }
+
+    const sequential = outcomes.get(1);
+    const batched = outcomes.get(100);
+
+    expect(sequential).toEqual({
+      created: 0,
+      updated: 1,
+      errors: [{ id: "p-c", matchesConstraint: true }],
+      emailA: "target@example.com",
+      personCExists: false,
+    });
+    expect(batched).toEqual(sequential);
+  });
+
   it("skips tombstoned rows under onConflict: update without resurrecting", async () => {
     await withCountedStore(async (store) => {
       const node = await store.nodes.Person.create({

--- a/packages/typegraph/tests/index-method-gin.test.ts
+++ b/packages/typegraph/tests/index-method-gin.test.ts
@@ -14,10 +14,15 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { createStoreWithSchema, defineGraph, defineNode } from "../src";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "../src";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import { ConfigurationError } from "../src/errors";
-import { defineNodeIndex } from "../src/indexes";
+import { defineEdgeIndex, defineNodeIndex } from "../src/indexes";
 import { generateIndexDDL } from "../src/indexes/ddl";
 import { serializeSchema } from "../src/schema/serializer";
 
@@ -203,27 +208,174 @@ describe("SQLite behavior", () => {
     }
   });
 
-  it("rejects bulkFindByIndex probes against a gin index", async () => {
+  it("rejects bulkFindByIndex probes against gin and trigram indexes", async () => {
+    // bulkFindByIndex compiles equality probes, which a GIN-family index can
+    // never serve (it indexes one expression for containment/substring, not
+    // ordered key columns). The guard fires in resolveNodeIndex — before any
+    // query runs — so it is backend-independent; SQLite just supplies a store.
     const { backend } = createLocalSqliteBackend();
     try {
-      const ginIndex = defineNodeIndex(Document, {
-        fields: ["tags"],
-        method: "gin",
-        name: "doc_tags_gin_probe",
-      });
       const graph = defineGraph({
         id: "gin-bulk-probe",
         nodes: { Doc: { type: Document } },
         edges: {},
-        indexes: [ginIndex],
+        indexes: [
+          defineNodeIndex(Document, {
+            fields: ["tags"],
+            method: "gin",
+            name: "doc_tags_gin_probe",
+          }),
+          defineNodeIndex(Document, {
+            fields: ["title"],
+            method: "trigram",
+            name: "doc_title_trgm_probe",
+          }),
+        ],
       });
       const [store] = await createStoreWithSchema(graph, backend);
 
-      await expect(
-        store.nodes.Doc.bulkFindByIndex("doc_tags_gin_probe", [
-          { tags: ["x"] },
-        ] as never),
-      ).rejects.toThrow(ConfigurationError);
+      const ginError = await store.nodes.Doc.bulkFindByIndex(
+        "doc_tags_gin_probe",
+        [{ props: { tags: ["x"] } }],
+      ).catch((error: unknown) => error);
+      expectMethodProbeRejection(ginError, "doc_tags_gin_probe", "gin");
+
+      const trigramError = await store.nodes.Doc.bulkFindByIndex(
+        "doc_title_trgm_probe",
+        [{ props: { title: "x" } }],
+      ).catch((error: unknown) => error);
+      expectMethodProbeRejection(
+        trigramError,
+        "doc_title_trgm_probe",
+        "trigram",
+      );
+    } finally {
+      await backend.close();
+    }
+  });
+});
+
+/**
+ * Asserts the exact ConfigurationError bulkFindByIndex raises when pointed at
+ * a GIN-family index: type, code, message, and structured details (the
+ * `Document` node in this file is declared with kind `"Doc"`).
+ */
+function expectMethodProbeRejection(
+  error: unknown,
+  indexName: string,
+  method: string,
+): void {
+  expect(error).toBeInstanceOf(ConfigurationError);
+  const configError = error as ConfigurationError;
+  expect(configError.code).toBe("CONFIGURATION_ERROR");
+  expect(configError.message).toBe(
+    `bulkFindByIndex cannot probe index "${indexName}" (method "${method}"): ` +
+      "only btree indexes serve equality probes.",
+  );
+  expect(configError.details).toEqual({
+    indexName,
+    kind: "Doc",
+    method,
+  });
+}
+
+describe("defineEdgeIndex GIN-family methods", () => {
+  const Tagged = defineEdge("tagged", {
+    schema: z.object({
+      labels: z.array(z.string()),
+      note: z.string(),
+    }),
+  });
+
+  it("carries gin/trigram onto an edge declaration with a method-name suffix", () => {
+    // Exercises the edge `method` wiring: `allowJsonFields: method === "gin"`
+    // lets the `labels` array field through the btree-only guard, and the
+    // resolved method is stamped onto the declaration with a name suffix.
+    const gin = defineEdgeIndex(Tagged, { fields: ["labels"], method: "gin" });
+    const trigram = defineEdgeIndex(Tagged, {
+      fields: ["note"],
+      method: "trigram",
+    });
+
+    expect(gin.entity).toBe("edge");
+    expect(gin.method).toBe("gin");
+    expect(gin.name.endsWith("_gin")).toBe(true);
+    expect(trigram.method).toBe("trigram");
+    expect(trigram.name.endsWith("_trigram")).toBe(true);
+  });
+
+  it("enforces the field-type contract each method advertises on edges", () => {
+    expect(() =>
+      defineEdgeIndex(Tagged, { fields: ["note"], method: "gin" }),
+    ).toThrow(/use method: "trigram"/);
+    expect(() =>
+      defineEdgeIndex(Tagged, { fields: ["labels"], method: "trigram" }),
+    ).toThrow(/use method: "gin"/);
+  });
+
+  it("emits an expression GIN on typegraph_edges aligned with the dialect extraction", () => {
+    const gin = defineEdgeIndex(Tagged, {
+      fields: ["labels"],
+      method: "gin",
+      name: "tagged_labels_gin",
+    });
+    expect(generateIndexDDL(gin, "postgres")).toBe(
+      `CREATE INDEX IF NOT EXISTS "tagged_labels_gin" ON "typegraph_edges" USING GIN (("props" #> ARRAY['labels']) jsonb_path_ops);`,
+    );
+
+    const trigram = defineEdgeIndex(Tagged, {
+      fields: ["note"],
+      method: "trigram",
+      name: "tagged_note_trgm",
+    });
+    expect(generateIndexDDL(trigram, "postgres")).toBe(
+      `CREATE INDEX IF NOT EXISTS "tagged_note_trgm" ON "typegraph_edges" USING GIN (("props" #>> ARRAY['note']) gin_trgm_ops);`,
+    );
+  });
+
+  it("refuses to generate SQLite DDL for an edge gin index", () => {
+    const gin = defineEdgeIndex(Tagged, {
+      fields: ["labels"],
+      method: "gin",
+      name: "tagged_labels_gin",
+    });
+    expect(() => generateIndexDDL(gin, "sqlite")).toThrow(
+      /requires PostgreSQL/,
+    );
+  });
+
+  it("materializes edge gin/trigram declarations as skipped on SQLite", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const Item = defineNode("Item", {
+        schema: z.object({ label: z.string() }),
+      });
+      const graph = defineGraph({
+        id: "edge-gin-sqlite-skip",
+        nodes: { Item: { type: Item } },
+        edges: {
+          tagged: {
+            type: Tagged,
+            from: [Item],
+            to: [Item],
+            cardinality: "many",
+          },
+        },
+        indexes: [
+          defineEdgeIndex(Tagged, { fields: ["labels"], method: "gin" }),
+          defineEdgeIndex(Tagged, { fields: ["note"], method: "trigram" }),
+        ],
+      });
+      const [store] = await createStoreWithSchema(graph, backend);
+
+      const result = await store.materializeIndexes();
+
+      expect(result.results).toHaveLength(2);
+      for (const entry of result.results) {
+        expect(entry.entity).toBe("edge");
+        expect(entry.status).toBe("skipped");
+        expect(entry.reason).toMatch(/requires PostgreSQL/);
+      }
     } finally {
       await backend.close();
     }

--- a/packages/typegraph/tests/ontology-enforcement.test.ts
+++ b/packages/typegraph/tests/ontology-enforcement.test.ts
@@ -874,6 +874,43 @@ describe("implies() Endpoint Compatibility Validation", () => {
 
     await backend.close();
   });
+
+  it("rejects an implies() chain that bridges incompatible endpoints through an UNREGISTERED intermediate edge", () => {
+    // Transitivity hole: `writes` (Author -> Paper) implies an intermediate
+    // `about` edge that is NOT registered on the graph, which in turn implies
+    // `likes` (Reader -> Reader). Both direct hops touch the unregistered
+    // `about`, so a per-direct-relation gate would skip BOTH — yet the
+    // precomputed transitive closure still folds `writes` rows into any
+    // `expand: "implying"` traversal of `likes`, even though Author/Paper are
+    // endpoint-incompatible with Reader. The gate must validate the effective
+    // closure, not rely on each direct hop being individually checkable.
+    const Author = defineNode("AuthorBridge", { schema: z.object({}) });
+    const Paper = defineNode("PaperBridge", { schema: z.object({}) });
+    const Reader = defineNode("ReaderBridge", { schema: z.object({}) });
+
+    const writes = defineEdge("writesBridge", { schema: z.object({}) });
+    // `about` is intentionally never added to the graph's `edges`.
+    const about = defineEdge("aboutBridge", { schema: z.object({}) });
+    const likes = defineEdge("likesBridge", { schema: z.object({}) });
+
+    expect(() =>
+      buildKindRegistry(
+        defineGraph({
+          id: "implies_transitive_bridge",
+          nodes: {
+            Author: { type: Author },
+            Paper: { type: Paper },
+            Reader: { type: Reader },
+          },
+          edges: {
+            writesBridge: { type: writes, from: [Author], to: [Paper] },
+            likesBridge: { type: likes, from: [Reader], to: [Reader] },
+          },
+          ontology: [implies(writes, about), implies(about, likes)],
+        }),
+      ),
+    ).toThrow(ConfigurationError);
+  });
 });
 
 // ============================================================

--- a/packages/typegraph/tests/subgraph-membership-dialect.test.ts
+++ b/packages/typegraph/tests/subgraph-membership-dialect.test.ts
@@ -1,52 +1,28 @@
 /**
- * Dialect-mediated CTE membership (`subqueryMembership`).
+ * Subgraph CTE membership emission.
  *
  * The subgraph extractor's final fetches filter node/edge ids against the
- * `included_ids` CTE. On SQLite, `IN (subquery)` is evaluated with a
- * transient index and is optimal. On PostgreSQL, the same form is pulled
- * up into a join whose recursive-CTE row estimate (~10 rows for a
- * single-row seed) drives the planner into a nested-loop join FILTER —
- * measured at ~10M discarded rows / 383ms on the depth-3 subgraph stress
- * bench. `= ANY(ARRAY(subquery))` collapses the CTE once via InitPlan and
- * is hash-probed and index-condition eligible (~15ms for the same fetch).
+ * `included_ids` CTE. On SQLite this is inlined as `IN (subquery)` — evaluated
+ * with a transient index and optimal as-is. On PostgreSQL the same
+ * `IN (subquery)` form is pulled up into a join whose recursive-CTE row
+ * estimate (~10 rows for a single-row seed) drives the planner into a
+ * nested-loop join FILTER (measured at ~10M discarded rows / 383ms on the
+ * depth-3 subgraph stress bench), so the PG path instead fetches the closure
+ * ids once and passes them as a single `text[]` parameter, filtered via an
+ * `unnest` semi-join (see `store/subgraph.ts`).
  *
- * These tests pin each dialect's emitted form and that the subgraph
- * fetches actually route through it; cross-backend subgraph semantics are
- * covered by the shared integration suite.
+ * This test pins SQLite's emitted membership form and that the subgraph fetches
+ * actually route through it; cross-backend subgraph semantics — including the
+ * PostgreSQL parameterized form — are covered by the shared integration suite.
  */
-import { sql } from "drizzle-orm";
-import { PgDialect } from "drizzle-orm/pg-core";
-import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { createStore, defineEdge, defineGraph, defineNode } from "../src";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import type { GraphBackend } from "../src/backend/types";
-import { getDialect } from "../src/query/dialect";
 
-describe("subqueryMembership dialect forms", () => {
-  const column = sql.raw("e.to_id");
-  const subquery = sql.raw("SELECT id FROM included_ids");
-
-  it("emits IN (subquery) on SQLite", () => {
-    const rendered = new SQLiteSyncDialect().sqlToQuery(
-      getDialect("sqlite").subqueryMembership(column, subquery),
-    );
-    expect(rendered.sql).toBe("e.to_id IN (SELECT id FROM included_ids)");
-  });
-
-  it("emits = ANY(ARRAY(subquery)) on PostgreSQL", () => {
-    const rendered = new PgDialect().sqlToQuery(
-      getDialect("postgres").subqueryMembership(column, subquery),
-    );
-    expect(rendered.sql).toBe(
-      "e.to_id = ANY(ARRAY(SELECT id FROM included_ids))",
-    );
-  });
-});
-
-describe("subgraph fetches route membership through the dialect", () => {
+describe("subgraph fetches inline the SQLite CTE membership form", () => {
   const Person = defineNode("Person", {
     schema: z.object({ name: z.string() }),
   });

--- a/packages/typegraph/tests/temporal-compiler.test.ts
+++ b/packages/typegraph/tests/temporal-compiler.test.ts
@@ -51,11 +51,16 @@ describe("compileTemporalFilter", () => {
       expect(sql).toContain("e.valid_to");
     });
 
-    it("uses execution-time timestamp expression", () => {
+    it("binds an application-clock instant, not the database clock", () => {
       const sql = getSqlString({ mode: "current" });
 
-      expect(sql).toContain("CURRENT_TIMESTAMP");
-      expect(sql).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      // The current-read "now" is the application clock — an ISO instant bound
+      // at build time — NOT the database `CURRENT_TIMESTAMP` / `NOW()`. This
+      // keeps valid-time visibility on the same clock that stamps `valid_from`,
+      // so a freshly-created row can't be hidden by app/database clock skew
+      // (issue #242).
+      expect(sql).not.toContain("CURRENT_TIMESTAMP");
+      expect(sql).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     });
   });
 


### PR DESCRIPTION
## Pre-release review & hardening (0.34.0 → 0.35.0)

A comprehensive review of the 43 commits since `@nicia-ai/typegraph@0.34.0` (280 files, ~28k insertions — mostly perf work, a few features), plus the fixes and refactors it surfaced. Reviewed with a multi-agent pass over the full diff; every finding was independently verified against the code before any change (two findings were disproven and dropped).

### 🔴 The headline: a production read-after-write bug (#242 clock skew)

#242 changed an omitted `validFrom` default from SQL `NULL` to the **application** clock. But a "current" read compiled its validity filter against the **database** clock (`valid_from <= NOW()` on Postgres). On any deployment where the app-server clock runs ahead of the DB-server clock — i.e. app and DB on separate hosts, the norm — a freshly-created node/edge could be **missing from the very "current" read that follows its creation** until the DB clock caught up. It surfaced as nondeterministic PG test flakiness (0/3/6/32 failures across identical runs); SQLite (single in-process clock) was never exposed. A deterministic raw-`pg` repro hid 2987/3000 fresh rows.

**Fix:** the "current" read now binds the **application** clock (`nowIso()`) — the same clock `valid_from`, the facade search-currency filter, and the recorded/logical clock already use — across all 7 current-read paths (standard + recursive queries, subgraph, algorithms, recursive-cte, recorded-read). The now-redundant dialect `currentTimestamp()` seam is removed (internal). One clock under valid-time / search-currency / recorded-time; no clock split. A cross-backend regression test (fake the app clock ahead of the DB → the row stays visible) guards it.

### Correctness fixes

- **`deleteEdgesBatch` bind overflow** — the soft-delete UPDATE binds an extra `deleted_at` timestamp on top of the id-list `getEdgesChunkSize` is budgeted for, overflowing the bind limit by 1 on a full chunk (both backends). Reserved a slot.
- **`implies()` transitivity soundness (#241)** — `A implies B implies C` with an *unregistered* intermediate `B` skipped both direct checks while the closure still folded `A` into a traversal of `C`. The gate now validates the effective transitive closure. + regression test.
- **Batch-import uniqueness integrity (#213)** — a batch slice primes its uniqueness pre-check cache once, so an in-slice `onConflict:"update"` that mutated a unique value diverged from the per-row (sequential) path in *both* orderings: an update that **freed** a value left the cache stale (dropping a valid later create), and an update that **claimed** a value ran its preflight against the raw backend — blind to a create reserving that same value earlier in the slice — so it claimed the key on the real backend and collided at flush, throwing and rolling back the whole import instead of degrading to a per-row error. Both directions now route through the pending-aware overlay (`validationBackend`): the cache is reconciled after each applied update, and the update preflight sees unflushed create reservations; writes still delegate to the real backend. + cross-backend parity tests in both orderings (closing the SQLite-only gap).
- **`materializeIndexes` claim-release** — a release failure in `finally` could turn a *successful* build into a thrown rejection and abort sibling buckets; now warn-and-continue (the claim self-expires on its lease).
- **`bulkUpsertById` stats refresh** — now refreshes planner statistics post-bulk like `bulkCreate`/`bulkInsert` (node **and** edge collections).

### Refactors / perf

- **Warm-start `pg_index` bulk-preload** — `settleAgainstExisting` fired one `pg_index` probe per already-materialized index on every Postgres warm start, defeating this release's own status bulk-preload. Now one batched query (N → 1); the post-claim path keeps its fresh per-index check.
- **Dead `subqueryMembership` dialect seam removed** — unreachable (the #199 param-array path bypasses it) and its doc misdescribed PG's actual behavior; inlined the SQLite form. The `pg-subgraph-membership` changeset is corrected to match the shipped path (parameterized `text[]`/`unnest` semi-join, not the old `= ANY(ARRAY(subquery))` seam).
- **Vector pagination dedup** — the `LIMIT/OFFSET` clause, copy-pasted across 3 vector strategies, is now a shared `vectorPageClause` helper (byte-identical SQL).
- **Selective-props extraction** — single-sourced the shared JSON-extraction primitive across the standard (CTE synthetic column) and recursive (carried props) paths without collapsing their intentionally-different SQL shapes.
- **Embedding-batch chunk size** — routed through each backend's `batchConfig` instead of inline.

### Tests & changesets

- New regression tests: clock-skew visibility (cross-backend), `implies()` transitivity, batch-import uniqueness parity in both orderings (cross-backend), and index-guard coverage (`bulkFindByIndex` GIN/empty-fields rejection, edge gin/trigram index method).
- Changeset bump corrections (semver/CHANGELOG honesty): `implies-endpoint-validation` (breaking behavior change) and `typed-error-details` / `auto-refresh-statistics` (new public API) → `minor`.
- Disclosure notes added: `degree()` endpoint-kind narrowing, `validFrom` custom-backend rule.
- New changeset: `current-read-app-clock` (the #242 fix).

### Verified false positives (no change)

Aggregate-`orderBy` "silently ignored" (unreachable — the aggregate builder exposes no vector/fulltext predicate); serializer `method:"btree"` canonicalization (the type forbids an explicit `"btree"`).

### Known / deferred (documented, not in this PR)

- **Edge soft-delete recorded-churn** (real, MINOR): under a staled-gate concurrent double-delete, the dropped preflight (#220) lets a 0-row delete emit a redundant tombstone→tombstone recorded transition. Query results stay correct; only raw-recorded-table / event-log consumers see it. The fix (skip no-op touch, or a flush before/after diff) is a delicate recorded-capture-core change, disproportionate for the severity pre-release.
- **Cross-file PG test-isolation** (pre-existing): some PG test files share a pool/DB and fail when run together in one vitest process (`pool after end`, DDL races) though each passes alone; the managed `--no-file-parallelism` suite is green.
