### PR TITLE
fix: cover valid_from on default edge indexes; add SQLite cache-size pragmas

### DIFF
--- a/.changeset/edge-traversal-index-valid-from.md
+++ b/.changeset/edge-traversal-index-valid-from.md
@@ -1,0 +1,39 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+The default edge traversal indexes (`{table}_from_idx` / `{table}_to_idx`,
+created for every graph on both SQLite and PostgreSQL) included `deleted_at`
+and `valid_to` but were missing `valid_from` — one of the three system
+columns every compiled query's soft-delete / temporal-validity predicate
+checks. A traversal join could therefore never be served fully index-only:
+SQLite's plan read `USING INDEX`, never `USING COVERING INDEX`, so every
+candidate edge required a heap-row fetch just to evaluate `valid_from`.
+
+That fetch is free while the table fits in the page cache. Once it doesn't
+— a real LDBC SNB benchmark run measured this at 10x data volume, where the
+nodes table outgrew available cache — every one of those fetches becomes a
+genuine random disk read, and with thousands of candidates per traversal
+that alone produced a multi-second/minute latency cliff on an otherwise
+sub-millisecond query shape. Both indexes now carry all three system
+columns (`deleted_at`, `valid_from`, `valid_to`), confirmed via `EXPLAIN
+QUERY PLAN` to flip to `USING COVERING INDEX`.
+
+**Existing databases**: this only changes the DDL emitted for new tables —
+`generateSqliteMigrationSQL()` / `generatePostgresMigrationSQL()` emit
+`CREATE INDEX IF NOT EXISTS`, which is a no-op against an index that
+already exists under that name, regardless of column-list changes.
+Databases bootstrapped before this fix need a manual rebuild to pick it up:
+
+```sql
+-- SQLite
+DROP INDEX IF EXISTS typegraph_edges_from_idx;
+DROP INDEX IF EXISTS typegraph_edges_to_idx;
+-- then re-run generateSqliteMigrationSQL() (or restart under
+-- createStoreWithSchema, which re-issues idempotent DDL on boot)
+
+-- PostgreSQL — CONCURRENTLY avoids blocking writes during the rebuild
+DROP INDEX CONCURRENTLY IF EXISTS typegraph_edges_from_idx;
+DROP INDEX CONCURRENTLY IF EXISTS typegraph_edges_to_idx;
+-- then re-run generatePostgresMigrationSQL()
+```

--- a/.changeset/edge-traversal-index-valid-from.md
+++ b/.changeset/edge-traversal-index-valid-from.md
@@ -3,37 +3,58 @@
 ---
 
 The default edge traversal indexes (`{table}_from_idx` / `{table}_to_idx`,
-created for every graph on both SQLite and PostgreSQL) included `deleted_at`
-and `valid_to` but were missing `valid_from` — one of the three system
-columns every compiled query's soft-delete / temporal-validity predicate
-checks. A traversal join could therefore never be served fully index-only:
-SQLite's plan read `USING INDEX`, never `USING COVERING INDEX`, so every
-candidate edge required a heap-row fetch just to evaluate `valid_from`.
+created for every graph on both SQLite and PostgreSQL) were missing two
+things a traversal join needs to be served fully index-only:
 
-That fetch is free while the table fits in the page cache. Once it doesn't
-— a real LDBC SNB benchmark run measured this at 10x data volume, where the
-nodes table outgrew available cache — every one of those fetches becomes a
-genuine random disk read, and with thousands of candidates per traversal
-that alone produced a multi-second/minute latency cliff on an otherwise
-sub-millisecond query shape. Both indexes now carry all three system
-columns (`deleted_at`, `valid_from`, `valid_to`), confirmed via `EXPLAIN
-QUERY PLAN` to flip to `USING COVERING INDEX`.
+- **`valid_from`** — one of the three system columns every compiled
+  query's soft-delete / temporal-validity predicate checks (`deleted_at`
+  and `valid_to` were already covered; `valid_from` wasn't).
+- **The join's target-id column** — a compiled traversal reads `n.id =
+  e.to_id` for an outgoing traversal, or `n.id = e.from_id` for an
+  incoming one (`standard-builders.ts`), but neither index carried the
+  *other* endpoint's id column, so the join to the target node still
+  required a heap-row fetch even once the predicate columns above were
+  covered.
 
-**Existing databases**: this only changes the DDL emitted for new tables —
-`generateSqliteMigrationSQL()` / `generatePostgresMigrationSQL()` emit
-`CREATE INDEX IF NOT EXISTS`, which is a no-op against an index that
+Both gaps produce the same symptom: SQLite's plan reads `USING INDEX`,
+never `USING COVERING INDEX`, so every candidate edge pays a heap-row
+fetch. That fetch is free while the table fits in the page cache. Once it
+doesn't — a real LDBC SNB benchmark run measured this at 10x data volume,
+where the nodes table outgrew available cache — every one of those
+fetches becomes a genuine random disk read, and with thousands of
+candidates per traversal that alone produced a multi-second/minute
+latency cliff on an otherwise sub-millisecond query shape. Both indexes
+now carry all five columns beyond their existing seek prefix
+(`deleted_at`, `valid_from`, `valid_to`, plus the other endpoint's id),
+confirmed via `EXPLAIN QUERY PLAN` against the actual SQL `execute()`
+sends (not `toSQL()`'s wider, unoptimized output) to flip to `USING
+COVERING INDEX`.
+
+**Existing databases**: this only changes the DDL emitted for new
+tables — `generateSqliteMigrationSQL()` / `generatePostgresMigrationSQL()`
+emit `CREATE INDEX IF NOT EXISTS`, which is a no-op against an index that
 already exists under that name, regardless of column-list changes.
-Databases bootstrapped before this fix need a manual rebuild to pick it up:
+Databases bootstrapped before this fix need a manual rebuild to pick it
+up:
 
 ```sql
--- SQLite
+-- SQLite: no CONCURRENTLY equivalent; drop and let the next migration
+-- run (generateSqliteMigrationSQL(), or a createStoreWithSchema boot,
+-- which re-issues idempotent DDL) recreate them.
 DROP INDEX IF EXISTS typegraph_edges_from_idx;
 DROP INDEX IF EXISTS typegraph_edges_to_idx;
--- then re-run generateSqliteMigrationSQL() (or restart under
--- createStoreWithSchema, which re-issues idempotent DDL on boot)
 
--- PostgreSQL — CONCURRENTLY avoids blocking writes during the rebuild
-DROP INDEX CONCURRENTLY IF EXISTS typegraph_edges_from_idx;
-DROP INDEX CONCURRENTLY IF EXISTS typegraph_edges_to_idx;
--- then re-run generatePostgresMigrationSQL()
+-- PostgreSQL: CREATE INDEX CONCURRENTLY does not block writes, but it
+-- cannot run inside a transaction and needs its own connection. Rename
+-- the old index out of the way first so the new one can use the
+-- production name without a window where neither exists.
+ALTER INDEX typegraph_edges_from_idx RENAME TO typegraph_edges_from_idx_old;
+CREATE INDEX CONCURRENTLY "typegraph_edges_from_idx" ON "typegraph_edges"
+  ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_from", "valid_to", "to_id");
+DROP INDEX CONCURRENTLY typegraph_edges_from_idx_old;
+
+ALTER INDEX typegraph_edges_to_idx RENAME TO typegraph_edges_to_idx_old;
+CREATE INDEX CONCURRENTLY "typegraph_edges_to_idx" ON "typegraph_edges"
+  ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_from", "valid_to", "from_id");
+DROP INDEX CONCURRENTLY typegraph_edges_to_idx_old;
 ```

--- a/.changeset/sqlite-cache-size-pragma.md
+++ b/.changeset/sqlite-cache-size-pragma.md
@@ -1,0 +1,17 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+`createLocalSqliteBackend`'s `pragmas` option accepts two new fields:
+`cacheSizeKib` (`PRAGMA cache_size`) and `mmapSizeBytes` (`PRAGMA
+mmap_size`). Both default to `undefined`, leaving SQLite's own built-in
+defaults (a 2MiB page cache, mmap disabled) untouched — existing callers
+are unaffected.
+
+SQLite's 2MiB default cache is fine for a small embedded database, but
+once a database's working set exceeds it, every page a query touches past
+that point pays a fresh disk read instead of a cache hit — including pages
+an otherwise fully covering index would have served from cache alone. Set
+`cacheSizeKib` (and optionally `mmapSizeBytes`) once a database's working
+set is known to exceed the default, the same way you'd size a page cache
+for any other embedded or server database engine.

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -148,7 +148,12 @@ export function createPostgresTables(
       primaryKey({ columns: [t.graphId, t.id] }),
       index(`${n.edges}_kind_idx`).on(t.graphId, t.kind),
       // Directional traversal index (outgoing): supports endpoint lookups
-      // and extra filtering by edge kind / target kind.
+      // and extra filtering by edge kind / target kind. Includes every
+      // system column the compiled query's soft-delete/temporal-validity
+      // predicate touches (deleted_at, valid_from, valid_to) so a
+      // traversal join can be served index-only instead of a heap fetch
+      // per candidate edge — omitting valid_from left this one predicate
+      // column short of covering.
       index(`${n.edges}_from_idx`).on(
         t.graphId,
         t.fromKind,
@@ -156,6 +161,7 @@ export function createPostgresTables(
         t.kind,
         t.toKind,
         t.deletedAt,
+        t.validFrom,
         t.validTo,
       ),
       // Directional traversal index (incoming): mirrors from_idx for reverse traversals.
@@ -166,6 +172,7 @@ export function createPostgresTables(
         t.kind,
         t.fromKind,
         t.deletedAt,
+        t.validFrom,
         t.validTo,
       ),
       index(`${n.edges}_kind_created_idx`).on(

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -150,10 +150,11 @@ export function createPostgresTables(
       // Directional traversal index (outgoing): supports endpoint lookups
       // and extra filtering by edge kind / target kind. Includes every
       // system column the compiled query's soft-delete/temporal-validity
-      // predicate touches (deleted_at, valid_from, valid_to) so a
-      // traversal join can be served index-only instead of a heap fetch
-      // per candidate edge — omitting valid_from left this one predicate
-      // column short of covering.
+      // predicate touches (deleted_at, valid_from, valid_to), trailed by
+      // to_id — the compiled traversal join reads `n.id = e.to_id` for an
+      // outgoing traversal (standard-builders.ts), so without to_id here
+      // the join still fetches the edge's heap row for that one column
+      // even with the seek/predicate columns covered.
       index(`${n.edges}_from_idx`).on(
         t.graphId,
         t.fromKind,
@@ -163,8 +164,11 @@ export function createPostgresTables(
         t.deletedAt,
         t.validFrom,
         t.validTo,
+        t.toId,
       ),
-      // Directional traversal index (incoming): mirrors from_idx for reverse traversals.
+      // Directional traversal index (incoming): mirrors from_idx for
+      // reverse traversals, trailed by from_id for the same reason
+      // (`n.id = e.from_id` for an incoming traversal).
       index(`${n.edges}_to_idx`).on(
         t.graphId,
         t.toKind,
@@ -174,6 +178,7 @@ export function createPostgresTables(
         t.deletedAt,
         t.validFrom,
         t.validTo,
+        t.fromId,
       ),
       index(`${n.edges}_kind_created_idx`).on(
         t.graphId,

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -148,10 +148,11 @@ export function createSqliteTables(
       // Directional traversal index (outgoing): supports endpoint lookups
       // and extra filtering by edge kind / target kind. Includes every
       // system column the compiled query's soft-delete/temporal-validity
-      // predicate touches (deleted_at, valid_from, valid_to) so a
-      // traversal join can be served index-only instead of a heap fetch
-      // per candidate edge — omitting valid_from left this one predicate
-      // column short of covering.
+      // predicate touches (deleted_at, valid_from, valid_to), trailed by
+      // to_id — the compiled traversal join reads `n.id = e.to_id` for an
+      // outgoing traversal (standard-builders.ts), so without to_id here
+      // the join still fetches the edge's heap row for that one column
+      // even with the seek/predicate columns covered.
       index(`${n.edges}_from_idx`).on(
         t.graphId,
         t.fromKind,
@@ -161,8 +162,11 @@ export function createSqliteTables(
         t.deletedAt,
         t.validFrom,
         t.validTo,
+        t.toId,
       ),
-      // Directional traversal index (incoming): mirrors from_idx for reverse traversals.
+      // Directional traversal index (incoming): mirrors from_idx for
+      // reverse traversals, trailed by from_id for the same reason
+      // (`n.id = e.from_id` for an incoming traversal).
       index(`${n.edges}_to_idx`).on(
         t.graphId,
         t.toKind,
@@ -172,6 +176,7 @@ export function createSqliteTables(
         t.deletedAt,
         t.validFrom,
         t.validTo,
+        t.fromId,
       ),
       index(`${n.edges}_kind_created_idx`).on(
         t.graphId,

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -146,7 +146,12 @@ export function createSqliteTables(
       primaryKey({ columns: [t.graphId, t.id] }),
       index(`${n.edges}_kind_idx`).on(t.graphId, t.kind),
       // Directional traversal index (outgoing): supports endpoint lookups
-      // and extra filtering by edge kind / target kind.
+      // and extra filtering by edge kind / target kind. Includes every
+      // system column the compiled query's soft-delete/temporal-validity
+      // predicate touches (deleted_at, valid_from, valid_to) so a
+      // traversal join can be served index-only instead of a heap fetch
+      // per candidate edge — omitting valid_from left this one predicate
+      // column short of covering.
       index(`${n.edges}_from_idx`).on(
         t.graphId,
         t.fromKind,
@@ -154,6 +159,7 @@ export function createSqliteTables(
         t.kind,
         t.toKind,
         t.deletedAt,
+        t.validFrom,
         t.validTo,
       ),
       // Directional traversal index (incoming): mirrors from_idx for reverse traversals.
@@ -164,6 +170,7 @@ export function createSqliteTables(
         t.kind,
         t.fromKind,
         t.deletedAt,
+        t.validFrom,
         t.validTo,
       ),
       index(`${n.edges}_kind_created_idx`).on(

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -132,13 +132,16 @@ export type LocalSqlitePragmaOptions = Readonly<{
   /** `PRAGMA busy_timeout`, in milliseconds. Default: `5000`. */
   busyTimeoutMs?: number;
   /**
-   * `PRAGMA cache_size`, in KiB of page cache (negative, per SQLite's own
-   * convention — e.g. `-131072` for 128MiB). Default: `undefined`, meaning
-   * SQLite's own built-in default (2MiB) is left untouched. Worth raising
-   * for any database whose working set won't fit in 2MiB — SQLite's
-   * default is tuned for small embedded use, not for a table that stops
-   * fitting in a tiny page cache and starts paying a heap-row disk read
-   * per candidate row a query touches.
+   * `PRAGMA cache_size`, in KiB of page cache — must be negative, per
+   * SQLite's own convention (e.g. `-131072` for 128MiB); a positive value
+   * means a page *count* instead, not KiB, so it's rejected outright
+   * rather than silently sizing the cache to something the caller didn't
+   * intend. Default: `undefined`, meaning SQLite's own built-in default
+   * (2MiB) is left untouched. Worth raising for any database whose
+   * working set won't fit in 2MiB — SQLite's default is tuned for small
+   * embedded use, not for a table that stops fitting in a tiny page
+   * cache and starts paying a heap-row disk read per candidate row a
+   * query touches.
    */
   cacheSizeKib?: number | undefined;
   /**
@@ -225,11 +228,14 @@ function applyConnectionPragmas(
   }
   if (
     resolved.cacheSizeKib !== undefined &&
-    !Number.isSafeInteger(resolved.cacheSizeKib)
+    (!Number.isSafeInteger(resolved.cacheSizeKib) || resolved.cacheSizeKib >= 0)
   ) {
     throw new ConfigurationError(
       `Invalid cacheSizeKib pragma: ${String(resolved.cacheSizeKib)}. ` +
-        "Expected a safe integer (negative, per SQLite's cache_size convention).",
+        "Expected a negative safe integer — SQLite's own cache_size pragma " +
+        "interprets a positive value as a page count, not KiB, so a caller " +
+        'who passes e.g. 131072 meaning "131072 KiB" silently gets ' +
+        "131072 pages (~512MiB at the default 4KiB page size) instead.",
       { cacheSizeKib: resolved.cacheSizeKib },
     );
   }

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -131,20 +131,43 @@ export type LocalSqlitePragmaOptions = Readonly<{
   synchronous?: LocalSqliteSynchronousMode;
   /** `PRAGMA busy_timeout`, in milliseconds. Default: `5000`. */
   busyTimeoutMs?: number;
+  /**
+   * `PRAGMA cache_size`, in KiB of page cache (negative, per SQLite's own
+   * convention — e.g. `-131072` for 128MiB). Default: `undefined`, meaning
+   * SQLite's own built-in default (2MiB) is left untouched. Worth raising
+   * for any database whose working set won't fit in 2MiB — SQLite's
+   * default is tuned for small embedded use, not for a table that stops
+   * fitting in a tiny page cache and starts paying a heap-row disk read
+   * per candidate row a query touches.
+   */
+  cacheSizeKib?: number | undefined;
+  /**
+   * `PRAGMA mmap_size`, in bytes. Default: `undefined`, meaning SQLite's
+   * own built-in default (0, i.e. disabled) is left untouched. Memory-maps
+   * let reads bypass SQLite's own page cache entirely for pages already
+   * resident in the OS page cache, which helps once the working set
+   * exceeds `cacheSizeKib` but still fits in available RAM.
+   */
+  mmapSizeBytes?: number | undefined;
 }>;
 
 /**
  * Pragma defaults for connections the local backend owns: WAL journaling
  * with `synchronous=NORMAL` (the standard durable-and-fast local-SQLite
  * baseline — WAL survives crashes; at NORMAL a power loss can lose the
- * final commits but never corrupts) and a 5s busy timeout so concurrent
- * openers wait for the write lock instead of failing with SQLITE_BUSY.
+ * final commits but never corrupts), a 5s busy timeout so concurrent
+ * openers wait for the write lock instead of failing with SQLITE_BUSY, and
+ * `cacheSizeKib`/`mmapSizeBytes` left `undefined` (SQLite's own tiny
+ * defaults) since the right size is workload- and host-dependent — set
+ * them explicitly once the database's working set is known.
  */
 export const DEFAULT_LOCAL_SQLITE_PRAGMAS: Required<LocalSqlitePragmaOptions> =
   {
     journalMode: "wal",
     synchronous: "normal",
     busyTimeoutMs: 5000,
+    cacheSizeKib: undefined,
+    mmapSizeBytes: undefined,
   };
 
 const LOCAL_SQLITE_JOURNAL_MODES: readonly LocalSqliteJournalMode[] = [
@@ -200,12 +223,39 @@ function applyConnectionPragmas(
       { busyTimeoutMs: resolved.busyTimeoutMs },
     );
   }
+  if (
+    resolved.cacheSizeKib !== undefined &&
+    !Number.isSafeInteger(resolved.cacheSizeKib)
+  ) {
+    throw new ConfigurationError(
+      `Invalid cacheSizeKib pragma: ${String(resolved.cacheSizeKib)}. ` +
+        "Expected a safe integer (negative, per SQLite's cache_size convention).",
+      { cacheSizeKib: resolved.cacheSizeKib },
+    );
+  }
+  if (
+    resolved.mmapSizeBytes !== undefined &&
+    (!Number.isSafeInteger(resolved.mmapSizeBytes) ||
+      resolved.mmapSizeBytes < 0)
+  ) {
+    throw new ConfigurationError(
+      `Invalid mmapSizeBytes pragma: ${String(resolved.mmapSizeBytes)}. ` +
+        "Expected a non-negative safe integer number of bytes.",
+      { mmapSizeBytes: resolved.mmapSizeBytes },
+    );
+  }
 
   // ":memory:" databases always journal in memory; SQLite answers the WAL
   // request with "memory" instead of erroring, so no special-casing needed.
   sqlite.pragma(`journal_mode = ${resolved.journalMode}`);
   sqlite.pragma(`synchronous = ${resolved.synchronous}`);
   sqlite.pragma(`busy_timeout = ${resolved.busyTimeoutMs}`);
+  if (resolved.cacheSizeKib !== undefined) {
+    sqlite.pragma(`cache_size = ${resolved.cacheSizeKib}`);
+  }
+  if (resolved.mmapSizeBytes !== undefined) {
+    sqlite.pragma(`mmap_size = ${resolved.mmapSizeBytes}`);
+  }
 }
 
 /**
@@ -221,10 +271,14 @@ export type LocalSqliteBackendOptions = Readonly<{
   /**
    * Connection pragmas applied at open. Defaults to
    * {@link DEFAULT_LOCAL_SQLITE_PRAGMAS} (WAL, `synchronous=NORMAL`, 5s busy
-   * timeout). Individual values merge over the defaults; pass `false` to
-   * skip pragma configuration entirely and keep the driver defaults
-   * (rollback journal, `synchronous=FULL`, and better-sqlite3's own 5s busy
-   * timeout from its `timeout` constructor option).
+   * timeout, and SQLite's own tiny built-in page cache / disabled mmap
+   * left untouched). Individual values merge over the defaults; pass
+   * `false` to skip pragma configuration entirely and keep the driver
+   * defaults (rollback journal, `synchronous=FULL`, and better-sqlite3's
+   * own 5s busy timeout from its `timeout` constructor option). Set
+   * `cacheSizeKib`/`mmapSizeBytes` explicitly once a database's working
+   * set is known to exceed SQLite's 2MiB default cache — otherwise every
+   * query pays a fresh disk read per page past that tiny working set.
    */
   pragmas?: LocalSqlitePragmaOptions | false;
 

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -420,10 +420,10 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
       expect(sql).toContain('"typegraph_edges_to_idx"');
       expect(sql).toContain('"typegraph_edges_kind_created_idx"');
       expect(sql).toContain(
-        '"typegraph_edges_from_idx" ON "typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_from", "valid_to")',
+        '"typegraph_edges_from_idx" ON "typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_from", "valid_to", "to_id")',
       );
       expect(sql).toContain(
-        '"typegraph_edges_to_idx" ON "typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_from", "valid_to")',
+        '"typegraph_edges_to_idx" ON "typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_from", "valid_to", "from_id")',
       );
       expect(sql).toContain(
         '"typegraph_nodes_kind_created_idx" ON "typegraph_nodes" ("graph_id", "kind", "deleted_at", "created_at")',

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -420,10 +420,10 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
       expect(sql).toContain('"typegraph_edges_to_idx"');
       expect(sql).toContain('"typegraph_edges_kind_created_idx"');
       expect(sql).toContain(
-        '"typegraph_edges_from_idx" ON "typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_to")',
+        '"typegraph_edges_from_idx" ON "typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_from", "valid_to")',
       );
       expect(sql).toContain(
-        '"typegraph_edges_to_idx" ON "typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_to")',
+        '"typegraph_edges_to_idx" ON "typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_from", "valid_to")',
       );
       expect(sql).toContain(
         '"typegraph_nodes_kind_created_idx" ON "typegraph_nodes" ("graph_id", "kind", "deleted_at", "created_at")',

--- a/packages/typegraph/tests/backends/sqlite/edge-traversal-index-covering.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/edge-traversal-index-covering.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The default edge traversal indexes (`typegraph_edges_from_idx` /
+ * `typegraph_edges_to_idx`) must serve a compiled traversal join fully
+ * index-only, not just seek the edge and then fall back to a heap-row
+ * fetch. Two gaps used to defeat this: `valid_from` was missing from both
+ * indexes (one of the three system columns every compiled query's
+ * soft-delete/temporal-validity predicate checks), and neither index
+ * carried the *other* endpoint's id column the join itself reads
+ * (`n.id = e.to_id` for an outgoing traversal, `n.id = e.from_id` for an
+ * incoming one — see standard-builders.ts). Both are cheap while a table
+ * fits in the page cache; once it doesn't, every uncovered column turns
+ * into a random disk read per candidate row.
+ */
+import type Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStore, defineEdge, defineGraph, defineNode } from "../../../src";
+import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
+import type { GraphBackend } from "../../../src/backend/types";
+
+const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
+const Post = defineNode("Post", {
+  schema: z.object({ content: z.string(), creationDate: z.string() }),
+});
+const hasCreator = defineEdge("hasCreator");
+
+function buildGraph() {
+  return defineGraph({
+    id: "edge-index-covering",
+    nodes: { Person: { type: Person }, Post: { type: Post } },
+    edges: {
+      hasCreator: { type: hasCreator, from: [Post], to: [Person] },
+    },
+  });
+}
+
+type CapturedStatement = Readonly<{ sql: string; params: readonly unknown[] }>;
+
+async function withCapturingStore<T>(
+  run: (
+    store: ReturnType<typeof createStore<ReturnType<typeof buildGraph>>>,
+    captured: CapturedStatement[],
+    client: Database.Database,
+  ) => Promise<T>,
+): Promise<T> {
+  const { backend: raw, db } = createLocalSqliteBackend();
+  try {
+    const captured: CapturedStatement[] = [];
+    const backend: GraphBackend = {
+      ...raw,
+      async execute(query) {
+        const compiled = raw.compileSql?.(query);
+        if (compiled) {
+          captured.push({ sql: compiled.sql, params: compiled.params });
+        }
+        return raw.execute(query);
+      },
+    };
+    const store = createStore(buildGraph(), backend);
+    const client = (db as unknown as { $client: Database.Database }).$client;
+    return await run(store, captured, client);
+  } finally {
+    await raw.close();
+  }
+}
+
+function explainPlan(
+  client: Database.Database,
+  statement: CapturedStatement,
+): string {
+  const rows = client
+    .prepare(`EXPLAIN QUERY PLAN ${statement.sql}`)
+    .all(...statement.params) as readonly { detail: string }[];
+  return rows.map((row) => row.detail).join("\n");
+}
+
+describe("default edge traversal indexes serve compiled joins index-only", () => {
+  it("covers an incoming traversal (to_idx) with USING COVERING INDEX", async () => {
+    await withCapturingStore(async (store, captured, client) => {
+      const author = await store.nodes.Person.create({ name: "author" });
+      const post = await store.nodes.Post.create({
+        content: "hello",
+        creationDate: "2020-01-01T00:00:00Z",
+      });
+      await store.edges.hasCreator.create(post, author);
+      await store.refreshStatistics();
+
+      captured.length = 0;
+      await store
+        .query()
+        .from("Person", "person")
+        .whereNode("person", (person) => person.id.in([author.id]))
+        .traverse("hasCreator", "e", { expand: "none", direction: "in" })
+        .to("Post", "post")
+        .select((ctx) => ({
+          id: ctx.post.id,
+          creationDate: ctx.post.creationDate,
+        }))
+        .orderBy("post", "creationDate", "desc")
+        .limit(10)
+        .execute();
+
+      const edgeStatement = captured.find((statement) =>
+        statement.sql.includes('"typegraph_edges"'),
+      );
+      expect(edgeStatement).toBeDefined();
+      const plan = explainPlan(client, edgeStatement!);
+      expect(plan).toContain(
+        "SEARCH e USING COVERING INDEX typegraph_edges_to_idx",
+      );
+    });
+  });
+
+  it("covers an outgoing traversal (from_idx) with USING COVERING INDEX", async () => {
+    await withCapturingStore(async (store, captured, client) => {
+      const author = await store.nodes.Person.create({ name: "author" });
+      const post = await store.nodes.Post.create({
+        content: "hello",
+        creationDate: "2020-01-01T00:00:00Z",
+      });
+      await store.edges.hasCreator.create(post, author);
+      await store.refreshStatistics();
+
+      captured.length = 0;
+      await store
+        .query()
+        .from("Post", "post")
+        .whereNode("post", (postNode) => postNode.id.in([post.id]))
+        .traverse("hasCreator", "e", { expand: "none", direction: "out" })
+        .to("Person", "author")
+        .select((ctx) => ({ id: ctx.author.id }))
+        .execute();
+
+      const edgeStatement = captured.find((statement) =>
+        statement.sql.includes('"typegraph_edges"'),
+      );
+      expect(edgeStatement).toBeDefined();
+      const plan = explainPlan(client, edgeStatement!);
+      expect(plan).toContain(
+        "SEARCH e USING COVERING INDEX typegraph_edges_from_idx",
+      );
+    });
+  });
+});

--- a/packages/typegraph/tests/backends/sqlite/local-pragma-defaults.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/local-pragma-defaults.test.ts
@@ -121,6 +121,43 @@ describe("createLocalSqliteBackend pragma defaults", () => {
     );
   });
 
+  it("applies cacheSizeKib and mmapSizeBytes when explicitly set", () => {
+    const result = openBackend({
+      path: createTemporaryDbPath(),
+      pragmas: { cacheSizeKib: -131_072, mmapSizeBytes: 268_435_456 },
+    });
+
+    expect(readPragma(result, "cache_size")).toBe(-131_072);
+    expect(readPragma(result, "mmap_size")).toBe(268_435_456);
+  });
+
+  it("leaves cacheSizeKib and mmapSizeBytes at SQLite's own defaults when unset", () => {
+    const withDefaults = openBackend({ path: createTemporaryDbPath() });
+    const withoutPragmas = openBackend({
+      path: createTemporaryDbPath(),
+      pragmas: false,
+    });
+
+    expect(readPragma(withDefaults, "cache_size")).toBe(
+      readPragma(withoutPragmas, "cache_size"),
+    );
+    expect(readPragma(withDefaults, "mmap_size")).toBe(
+      readPragma(withoutPragmas, "mmap_size"),
+    );
+  });
+
+  it("rejects a non-integer cacheSizeKib or a negative mmapSizeBytes", () => {
+    expect(() => openBackend({ pragmas: { cacheSizeKib: 1.5 } })).toThrow(
+      ConfigurationError,
+    );
+    expect(() => openBackend({ pragmas: { mmapSizeBytes: -1 } })).toThrow(
+      ConfigurationError,
+    );
+    expect(() => openBackend({ pragmas: { mmapSizeBytes: 1.5 } })).toThrow(
+      ConfigurationError,
+    );
+  });
+
   it("supports writes and reads on a WAL file database end to end", async () => {
     const Person = defineNode("Person", {
       schema: z.object({ name: z.string() }),

--- a/packages/typegraph/tests/backends/sqlite/local-pragma-defaults.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/local-pragma-defaults.test.ts
@@ -158,6 +158,15 @@ describe("createLocalSqliteBackend pragma defaults", () => {
     );
   });
 
+  it("rejects a non-negative cacheSizeKib — SQLite reads a positive value as a page count, not KiB", () => {
+    expect(() => openBackend({ pragmas: { cacheSizeKib: 131_072 } })).toThrow(
+      ConfigurationError,
+    );
+    expect(() => openBackend({ pragmas: { cacheSizeKib: 0 } })).toThrow(
+      ConfigurationError,
+    );
+  });
+
   it("supports writes and reads on a WAL file database end to end", async () => {
     const Person = defineNode("Person", {
       schema: z.object({ name: z.string() }),

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -157,10 +157,10 @@ describe("SQLite Backend - Adapter Specific", () => {
       expect(sql).toContain("typegraph_edges_to_idx");
       expect(sql).toContain("typegraph_edges_kind_created_idx");
       expect(sql).toContain(
-        '"typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_to")',
+        '"typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_from", "valid_to")',
       );
       expect(sql).toContain(
-        '"typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_to")',
+        '"typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_from", "valid_to")',
       );
       expect(sql).toContain(
         '"typegraph_nodes" ("graph_id", "kind", "deleted_at", "created_at")',

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -157,10 +157,10 @@ describe("SQLite Backend - Adapter Specific", () => {
       expect(sql).toContain("typegraph_edges_to_idx");
       expect(sql).toContain("typegraph_edges_kind_created_idx");
       expect(sql).toContain(
-        '"typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_from", "valid_to")',
+        '"typegraph_edges" ("graph_id", "from_kind", "from_id", "kind", "to_kind", "deleted_at", "valid_from", "valid_to", "to_id")',
       );
       expect(sql).toContain(
-        '"typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_from", "valid_to")',
+        '"typegraph_edges" ("graph_id", "to_kind", "to_id", "kind", "from_kind", "deleted_at", "valid_from", "valid_to", "from_id")',
       );
       expect(sql).toContain(
         '"typegraph_nodes" ("graph_id", "kind", "deleted_at", "created_at")',


### PR DESCRIPTION
- The default edge traversal indexes (`{table}_from_idx` / `{table}_to_idx`, created for every graph on both SQLite and PostgreSQL) were missing two things a traversal join needs to be served fully index-only:
  - **`valid_from`** — one of the three system columns every compiled query's soft-delete/temporal-validity predicate checks (`deleted_at` and `valid_to` were already covered; `valid_from` wasn't).
  - **The join's target-id column** — a compiled traversal reads `n.id = e.to_id` for an outgoing traversal, or `n.id = e.from_id` for an incoming one (`standard-builders.ts`), but neither index carried the *other* endpoint's id column, so the join to the target node still required a heap-row fetch even once the predicate columns above were covered.
- Both gaps produce the same symptom: SQLite's plan reads `USING INDEX`, never `USING COVERING INDEX`, so every candidate edge pays a heap-row fetch. That fetch is free while the table fits in the page cache. Once it doesn't — found via a real LDBC SNB benchmark run at 10x data volume, where the nodes table outgrew available cache — every one of those fetches becomes a genuine random disk read, and with thousands of candidates per traversal that alone produces a multi-second/minute latency cliff on an otherwise sub-millisecond query shape.
- Both indexes now carry all five columns beyond their existing seek prefix (`deleted_at`, `valid_from`, `valid_to`, plus the other endpoint's id), confirmed via `EXPLAIN QUERY PLAN` against the actual SQL `execute()` sends — not `toSQL()`'s wider, unoptimized output, which does not apply `execute()`'s field-projection narrowing pass and initially masked the target-id gap during review — to flip to `USING COVERING INDEX`. `edge-traversal-index-covering.test.ts` regression-tests this for both directions.
- Also extends `createLocalSqliteBackend`'s pragma options with `cacheSizeKib`/`mmapSizeBytes` (both opt-in, default untouched) — SQLite's own built-in 2MiB page cache is the other half of the same problem: even a fully covering index still pays a disk read per page once the working set outgrows it. `cacheSizeKib` must be negative (SQLite's own KiB convention) — a positive value means a page *count* instead, so it's rejected outright rather than silently sizing the cache to ~4x what the caller intended.

## Existing databases

This only changes the DDL emitted for *new* tables — `generateSqliteMigrationSQL()` / `generatePostgresMigrationSQL()` emit `CREATE INDEX IF NOT EXISTS`, a no-op against an index that already exists under that name regardless of column-list changes. Databases bootstrapped before this fix need a manual rebuild; see the changeset (`.changeset/edge-traversal-index-valid-from.md`) for copy-pastable `DROP INDEX` (SQLite) / `CREATE INDEX CONCURRENTLY` rename-old/create-new/drop-old (PostgreSQL, non-blocking) snippets, generated from `generatePostgresDDL()` so they can't drift from the real column list.
