### PR TITLE
fix: recompile query-builder SQL fresh every call, never cache across executions [CRITICAL]

### DIFF
--- a/.changeset/query-builder-read-freshness.md
+++ b/.changeset/query-builder-read-freshness.md
@@ -1,0 +1,11 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+**Critical fix**: `.prepare()`d queries, and any `ExecutableQuery`/`UnionableQuery`/`ExecutableAggregateQuery` instance whose `.execute()` was called more than once, could silently miss rows created after the query was first compiled.
+
+A "current" (live) temporal-validity read binds its read instant (`currentReadInstant()`) at SQL compile time. All four query-builder classes cached their compiled SQL text across calls — `.prepare()` compiled once and every subsequent `execute({...})` reused that same SQL text, and a reused `ExecutableQuery`/`UnionableQuery`/`ExecutableAggregateQuery` instance cached its first `.execute()`'s compilation the same way. Both patterns froze "now" at the moment of first compilation: any row created afterward had a `valid_from` later than the frozen instant, so `valid_from <= now` silently evaluated to false for it, for the query's entire remaining lifetime.
+
+This is a regression introduced by the `current-read-app-clock` fix (the #242 clock-skew correction): the prior behavior (`NOW()` / `strftime('now')`, evaluated fresh by the database on every execution) did not have this problem. It is more severe than #242 — that bug required app/DB clock skew across separate hosts; this one reproduces unconditionally, in a single process, on the very next insert after a query is prepared or first executed. `.prepare()`-once-`.execute()`-many is this library's own documented, recommended pattern, so this affected the common case, not an edge case.
+
+**Fix**: none of the four classes cache compiled SQL text across calls anymore — each `execute()`/`compile()`/`toSQL()` call recompiles fresh, so `currentReadInstant()` is re-evaluated every time. `.prepare()` still builds and structurally validates the query AST once (so a malformed query still fails fast, before the first `execute()`); only the SQL-text compilation moved from prepare-time to each execute-time call. `param()`-bound values are unaffected — those were already correctly re-bound per call.

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -307,12 +307,18 @@ The default TypeGraph schema includes optimized indexes for the most common acce
 
 For application-specific indexes on JSON properties, see [Indexes](/performance/indexes).
 
-### Compilation Caching
+### SQL Compilation
 
 Each builder method (`.where()`, `.limit()`, `.orderBy()`, etc.) returns a new immutable instance.
-The compiled SQL for each instance is cached internally — repeated `.execute()` calls on the same
-builder skip recompilation entirely. This applies to standard queries, aggregate queries, and
-set-operation queries (`union`, `intersect`, `except`). This is transparent and requires no API changes.
+`.execute()`/`.toSQL()`/`.compile()` compile fresh SQL from the AST on every call — this applies to
+standard queries, aggregate queries, and set-operation queries (`union`, `intersect`, `except`).
+Compilation is pure, in-memory string-building with no I/O, so recompiling is cheap; the query's
+actual database round-trip dominates the cost either way.
+
+This is deliberate, not just unoptimized: a "current" (live) read binds its temporal-validity filter
+to the instant it's compiled at. Caching compiled SQL across calls would freeze that instant at
+whichever call first triggered compilation, silently hiding any row created afterward from every
+later call on the same query instance.
 
 ```typescript
 const activeUsers = store
@@ -321,23 +327,27 @@ const activeUsers = store
   .whereNode("u", (u) => u.status.eq("active"))
   .select((ctx) => ctx.u);
 
-// First call: compiles AST → SQL → executes
+// Each call compiles AST → SQL fresh, so a user created between these two
+// calls is visible to the second one.
 await activeUsers.execute();
-
-// Second call: reuses cached SQL → executes
 await activeUsers.execute();
 ```
 
 ### Prepared Queries
 
-For hot paths that execute the same query shape with different values, `.prepare()` pre-compiles the
-entire query pipeline (AST build, SQL compilation, text extraction) once. Subsequent
-`.execute(bindings)` calls only substitute parameter values and execute.
+For hot paths that execute the same query shape with different values, `.prepare()` builds and
+structurally validates the query AST once — a malformed query fails fast, before the first
+`.execute()`, instead of on first use. The AST itself carries no timestamp, so this validation is
+safe to do once and reuse. SQL text is still compiled fresh on every `.execute(bindings)` call, for
+the same reason as above: the compiled text is what carries the current-read instant, the bound
+parameter values, and the query's structure.
 
-When `executeRaw` is available (both SQLite and PostgreSQL backends), the pre-compiled SQL text is
-sent directly to the driver — zero recompilation overhead.
+When `executeRaw` is available (both SQLite and PostgreSQL backends), the freshly compiled SQL text
+is sent directly to the driver with the bindings substituted in.
 
-Best for: API endpoints, hot loops, or any code path that runs the same query shape repeatedly.
+Best for: validating a query shape once (fail fast on a malformed query) and reusing it with
+different parameter values — not for avoiding SQL compilation cost, which is negligible next to the
+database round-trip.
 
 See [Prepared Queries](/queries/execute#prepared-queries) for usage details.
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -284,8 +284,9 @@ See [Batch Query Execution](/schemas-stores#batch-query-execution) for full API 
 
 ## Prepared Queries
 
-Prepared queries let you compile a query once and execute it many times with different parameter
-values. This eliminates recompilation overhead for repeated query shapes.
+Prepared queries let you build and structurally validate a query's AST once — so a malformed query
+fails fast, before the first `.execute()` — and execute it many times with different parameter
+values.
 
 ### `param(name)`
 
@@ -297,8 +298,10 @@ import { param } from "@nicia-ai/typegraph";
 
 ### `prepare()`
 
-Call `.prepare()` on an executable query to pre-compile the AST and SQL. Returns a `PreparedQuery<R>`
-that can be executed with different bindings.
+Call `.prepare()` on an executable query to build and validate the AST once. Returns a
+`PreparedQuery<R>` that can be executed with different bindings; SQL text is compiled fresh on each
+`.execute()` call (see [Prepared query SQL compilation](#prepared-query-sql-compilation) below for
+why).
 
 ```typescript
 const findByName = store
@@ -308,7 +311,7 @@ const findByName = store
   .select((ctx) => ctx.p)
   .prepare();
 
-// Execute with different bindings — no recompilation
+// Execute with different bindings
 const alices = await findByName.execute({ name: "Alice" });
 const bobs = await findByName.execute({ name: "Bob" });
 ```
@@ -349,12 +352,20 @@ provided, and unknown binding keys are rejected.
 `param()` is **not** supported in `in()` / `notIn()` — the array length must be known at compile time.
 :::
 
-### Performance
+### Prepared Query SQL Compilation
 
-When the backend supports `executeRaw` (both SQLite and PostgreSQL backends do), the pre-compiled
-SQL text is sent directly to the database driver with substituted parameter values — zero
-recompilation overhead. When `executeRaw` is unavailable, the prepared query substitutes parameters
-into the AST and recompiles.
+`.prepare()` builds and validates the AST once, but does **not** cache compiled SQL text across
+`.execute()` calls — each call recompiles fresh. This is deliberate: a "current" (live) read binds
+its temporal-validity filter to the instant it's compiled at. Caching the compiled text from
+`.prepare()` time would freeze that instant for the prepared query's entire lifetime, silently
+hiding any row created after `.prepare()` ran from every subsequent `.execute()` call — exactly the
+bug this behavior was fixed to avoid. Recompiling is pure, in-memory string-building with no I/O, so
+the cost is negligible next to the query's actual database round-trip.
+
+When the backend supports `executeRaw` (both SQLite and PostgreSQL backends do), the freshly
+compiled SQL text is sent directly to the database driver with substituted parameter values. When
+`executeRaw` is unavailable, the prepared query substitutes parameters into the AST and compiles
+through the standard path instead — same freshness guarantee, different code path.
 
 ## Query Debugging
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1857,7 +1857,7 @@ const results = await store
 | `exists()` | `Promise<boolean>` | Check if any results exist |
 | `paginate(options)` | `Promise<PaginatedResult<T>>` | Cursor-based pagination |
 | `stream(options?)` | `AsyncIterable<T>` | Stream results in batches |
-| `prepare()` | `PreparedQuery<T>` | Pre-compile query for repeated execution with parameters |
+| `prepare()` | `PreparedQuery<T>` | Validate query AST once for repeated execution with different parameters |
 
 #### `store.batch(...queries)`
 

--- a/packages/typegraph/src/query/builder/executable-aggregate-query.ts
+++ b/packages/typegraph/src/query/builder/executable-aggregate-query.ts
@@ -19,8 +19,6 @@ import {
   type QueryBuilderState,
 } from "./types";
 
-const NOT_COMPUTED = Symbol("NOT_COMPUTED");
-
 /**
  * Result type for aggregate queries.
  * Maps field refs to their value types and aggregates to numbers.
@@ -44,7 +42,6 @@ export class ExecutableAggregateQuery<
   readonly #config: QueryBuilderConfig;
   readonly #state: QueryBuilderState;
   readonly #fields: R;
-  #cachedCompiled: CompiledSelectSql | typeof NOT_COMPUTED = NOT_COMPUTED;
 
   constructor(config: QueryBuilderConfig, state: QueryBuilderState, fields: R) {
     this.#config = config;
@@ -142,17 +139,12 @@ export class ExecutableAggregateQuery<
    * Compiles the query to a Drizzle SQL object.
    */
   compile(): CompiledSelectSql {
-    if (this.#cachedCompiled !== NOT_COMPUTED) {
-      return this.#cachedCompiled;
-    }
+    // Not cached — a "current" temporal filter binds its read instant at
+    // compile time, so caching across calls would freeze "now" at first
+    // compilation (see PreparedQuery's class doc comment for the full
+    // rationale).
     const ast = this.toAst();
-    const compiled = compileQuery(
-      ast,
-      this.#config.graphId,
-      this.#compileOptions(),
-    );
-    this.#cachedCompiled = compiled;
-    return compiled;
+    return compileQuery(ast, this.#config.graphId, this.#compileOptions());
   }
 
   #compileOptions(): CompileQueryOptions {

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -346,8 +346,11 @@ export class ExecutableQuery<
   }
 
   /**
-   * Creates a prepared (pre-compiled) query that can be executed
-   * multiple times with different parameter bindings.
+   * Creates a prepared (pre-validated) query that can be executed multiple
+   * times with different parameter bindings. Builds and structurally
+   * validates the AST once (a malformed query fails fast, here, instead of
+   * on first use); SQL text still compiles fresh on every execute() call —
+   * see PreparedQuery's class doc comment for why.
    *
    * Use `param("name")` in predicates to create parameterized slots,
    * then pass values via `prepared.execute({ name: "value" })`.

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -104,9 +104,6 @@ export class ExecutableQuery<
   readonly #selectFn: (
     context: SelectContext<Aliases, EdgeAliases, RecursiveAliases>,
   ) => R;
-  #cachedCompiled: CompiledSelectSql | typeof NOT_COMPUTED = NOT_COMPUTED;
-  #cachedOptimizedCompiled: CompiledSelectSql | typeof NOT_COMPUTED =
-    NOT_COMPUTED;
   #cachedSelectiveFieldsForExecute:
     readonly SelectiveField[] | typeof NOT_COMPUTED | undefined = NOT_COMPUTED;
   #cachedSelectiveFieldsForPagination:
@@ -341,15 +338,11 @@ export class ExecutableQuery<
    * with db.all(), db.get(), etc.
    */
   compile(): CompiledSelectSql {
-    if (this.#cachedCompiled !== NOT_COMPUTED) return this.#cachedCompiled;
+    // Not cached — see #tryOptimizedExecution's comment for why: a "current"
+    // temporal filter binds its read instant at compile time, so caching
+    // across calls would freeze "now" at first compilation.
     const ast = this.toAst();
-    const compiled = compileQuery(
-      ast,
-      this.#config.graphId,
-      this.#compileOptions(),
-    );
-    this.#cachedCompiled = compiled;
-    return compiled;
+    return compileQuery(ast, this.#config.graphId, this.#compileOptions());
   }
 
   /**
@@ -392,38 +385,20 @@ export class ExecutableQuery<
       selectiveFields === undefined ? baseAst : { ...baseAst, selectiveFields };
     const unoptimizedAst = baseAst;
 
-    // Compile once
+    // Compile once here purely to fail fast on a malformed query — the AST
+    // itself carries no timestamp, so this validation compile is safe to
+    // discard. PreparedQuery re-compiles to SQL text fresh on every
+    // execute() call instead of caching it from here: a "current" temporal
+    // filter binds its read instant at compile time, and caching that
+    // compiled text would freeze "now" at prepare() time for the prepared
+    // query's entire lifetime (see PreparedQuery's class doc comment).
     const compileOptions = this.#compileOptions();
-    const compiled = compileQuery(ast, this.#config.graphId, compileOptions);
-
-    // Pre-compile to SQL text if the backend supports it
-    let sqlText: string | undefined;
-    let sqlParams: readonly unknown[] | undefined;
-    let unoptimizedSqlText: string | undefined;
-    let unoptimizedSqlParams: readonly unknown[] | undefined;
-    if (this.#config.backend.compileSql !== undefined) {
-      const result = this.#config.backend.compileSql(compiled);
-      sqlText = result.sql;
-      sqlParams = result.params;
-
-      const unoptimizedCompiled = compileQuery(
-        unoptimizedAst,
-        this.#config.graphId,
-        compileOptions,
-      );
-      const unoptimizedResult =
-        this.#config.backend.compileSql(unoptimizedCompiled);
-      unoptimizedSqlText = unoptimizedResult.sql;
-      unoptimizedSqlParams = unoptimizedResult.params;
-    }
+    compileQuery(ast, this.#config.graphId, compileOptions);
+    compileQuery(unoptimizedAst, this.#config.graphId, compileOptions);
 
     return new PreparedQuery({
       ast,
       unoptimizedAst,
-      sqlText,
-      sqlParams,
-      unoptimizedSqlText,
-      unoptimizedSqlParams,
       backend: this.#config.backend,
       dialect: this.#config.dialect ?? "sqlite",
       graphId: this.#config.graphId,
@@ -573,23 +548,19 @@ export class ExecutableQuery<
       return undefined;
     }
 
-    // Build and compile optimized query (cached per instance)
-    let compiled: CompiledSelectSql;
-    if (this.#cachedOptimizedCompiled === NOT_COMPUTED) {
-      const baseAst = buildQueryAst(this.#config, this.#state);
-      const selectiveAst = {
-        ...baseAst,
-        selectiveFields,
-      };
-      compiled = compileQuery(
-        selectiveAst,
-        this.#config.graphId,
-        this.#compileOptions(),
-      );
-      this.#cachedOptimizedCompiled = compiled;
-    } else {
-      compiled = this.#cachedOptimizedCompiled;
-    }
+    // Compile fresh on every call — NOT cached. A "current" temporal filter
+    // binds its read instant at compile time (see PreparedQuery's class doc
+    // comment for the full rationale); caching the compiled SQL across
+    // `.execute()` calls on a reused query instance would freeze "now" at
+    // whichever call first triggered compilation and silently hide any row
+    // created after that, for every subsequent call on this instance.
+    const baseAst = buildQueryAst(this.#config, this.#state);
+    const selectiveAst = { ...baseAst, selectiveFields };
+    const compiled = compileQuery(
+      selectiveAst,
+      this.#config.graphId,
+      this.#compileOptions(),
+    );
 
     const backend = this.#requireBackend();
     const rawSelectiveRows = await this.#executeOnBackend(
@@ -612,12 +583,10 @@ export class ExecutableQuery<
     } catch (error) {
       if (error instanceof MissingSelectiveFieldError) {
         this.#cachedSelectiveFieldsForExecute = undefined;
-        this.#cachedOptimizedCompiled = NOT_COMPUTED;
         return undefined;
       }
       if (error instanceof UnsupportedPredicateError) {
         this.#cachedSelectiveFieldsForExecute = undefined;
-        this.#cachedOptimizedCompiled = NOT_COMPUTED;
         return undefined;
       }
       throw error;
@@ -636,22 +605,14 @@ export class ExecutableQuery<
       return undefined;
     }
 
-    let compiled: CompiledSelectSql;
-    if (this.#cachedOptimizedCompiled === NOT_COMPUTED) {
-      const baseAst = buildQueryAst(this.#config, this.#state);
-      const selectiveAst = {
-        ...baseAst,
-        selectiveFields,
-      };
-      compiled = compileQuery(
-        selectiveAst,
-        this.#config.graphId,
-        this.#compileOptions(),
-      );
-      this.#cachedOptimizedCompiled = compiled;
-    } else {
-      compiled = this.#cachedOptimizedCompiled;
-    }
+    // Compile fresh on every call — see #tryOptimizedExecution's comment.
+    const baseAst = buildQueryAst(this.#config, this.#state);
+    const selectiveAst = { ...baseAst, selectiveFields };
+    const compiled = compileQuery(
+      selectiveAst,
+      this.#config.graphId,
+      this.#compileOptions(),
+    );
 
     const rawSelectiveRows = await this.#executeOnBackend(
       backend,
@@ -672,12 +633,10 @@ export class ExecutableQuery<
     } catch (error) {
       if (error instanceof MissingSelectiveFieldError) {
         this.#cachedSelectiveFieldsForExecute = undefined;
-        this.#cachedOptimizedCompiled = NOT_COMPUTED;
         return undefined;
       }
       if (error instanceof UnsupportedPredicateError) {
         this.#cachedSelectiveFieldsForExecute = undefined;
-        this.#cachedOptimizedCompiled = NOT_COMPUTED;
         return undefined;
       }
       throw error;

--- a/packages/typegraph/src/query/builder/prepared-query.ts
+++ b/packages/typegraph/src/query/builder/prepared-query.ts
@@ -1,14 +1,21 @@
 /**
- * PreparedQuery — a pre-compiled, parameterized query.
+ * PreparedQuery — a pre-validated, parameterized query.
  *
- * Created via `ExecutableQuery.prepare()`. Compiles the query AST to SQL once
- * at prepare time, then executes with different parameter bindings on each call.
+ * Created via `ExecutableQuery.prepare()`. Builds and structurally validates
+ * the query AST once at prepare time (so a malformed query fails fast,
+ * before the first `execute()`), then re-compiles it to SQL text on every
+ * `execute()` call — NOT once at prepare time. This is deliberate: a
+ * "current" (live) temporal-validity filter binds the read instant fresh at
+ * compile time (see `currentReadInstant()`); caching that compiled SQL text
+ * across calls would freeze "now" at prepare time and silently hide every
+ * row created after prepare() ran for the entire lifetime of the prepared
+ * query — the AST itself carries no timestamp, only the compiled SQL does.
  *
- * Fast path: when `backend.executeRaw` is available, executes pre-compiled SQL
- * text directly with substituted parameter values.
+ * Fast path: when `backend.executeRaw` is available, executes freshly
+ * compiled SQL text directly with substituted parameter values.
  *
- * Fallback: substitutes parameter refs in the AST, recompiles to SQL, and
- * executes via the standard `backend.execute` path.
+ * Fallback: substitutes parameter refs in the AST, compiles to SQL (also
+ * fresh), and executes via the standard `backend.execute` path.
  */
 import { Placeholder } from "drizzle-orm";
 
@@ -259,10 +266,6 @@ function fillPlaceholders(
 type PreparedQueryConfig<R> = Readonly<{
   ast: QueryAst;
   unoptimizedAst: QueryAst;
-  sqlText: string | undefined;
-  sqlParams: readonly unknown[] | undefined;
-  unoptimizedSqlText: string | undefined;
-  unoptimizedSqlParams: readonly unknown[] | undefined;
   backend: GraphBackend;
   dialect: SqlDialect;
   graphId: string;
@@ -292,10 +295,6 @@ type PreparedQueryConfig<R> = Readonly<{
 export class PreparedQuery<R> {
   readonly #ast: QueryAst;
   readonly #unoptimizedAst: QueryAst;
-  readonly #sqlText: string | undefined;
-  readonly #sqlParams: readonly unknown[] | undefined;
-  readonly #unoptimizedSqlText: string | undefined;
-  readonly #unoptimizedSqlParams: readonly unknown[] | undefined;
   readonly #backend: GraphBackend;
   readonly #dialect: SqlDialect;
   readonly #graphId: string;
@@ -309,10 +308,6 @@ export class PreparedQuery<R> {
   constructor(config: PreparedQueryConfig<R>) {
     this.#ast = config.ast;
     this.#unoptimizedAst = config.unoptimizedAst;
-    this.#sqlText = config.sqlText;
-    this.#sqlParams = config.sqlParams;
-    this.#unoptimizedSqlText = config.unoptimizedSqlText;
-    this.#unoptimizedSqlParams = config.unoptimizedSqlParams;
     this.#backend = config.backend;
     this.#dialect = config.dialect;
     this.#graphId = config.graphId;
@@ -322,6 +317,20 @@ export class PreparedQuery<R> {
     this.#selectFn = config.selectFn;
     this.#schemaIntrospector = config.schemaIntrospector;
     this.#parameterMetadata = collectParameterMetadata(this.#ast);
+  }
+
+  /**
+   * Compiles `ast` to SQL text + params, fresh — never cached. See the class
+   * doc comment for why: a "current" temporal filter binds its read instant
+   * at compile time, so the instant must be recomputed on every call, not
+   * reused from a cached compilation.
+   */
+  #compileFresh(
+    ast: QueryAst,
+  ): Readonly<{ sql: string; params: readonly unknown[] }> | undefined {
+    if (this.#backend.compileSql === undefined) return undefined;
+    const compiled = compileQuery(ast, this.#graphId, this.#compileOptions);
+    return this.#backend.compileSql(compiled);
   }
 
   /** The set of parameter names required by this prepared query. */
@@ -371,18 +380,18 @@ export class PreparedQuery<R> {
   async #executeSelectiveRows(
     bindings: Readonly<Record<string, unknown>>,
   ): Promise<readonly Record<string, unknown>[]> {
-    if (
-      this.#sqlText !== undefined &&
-      this.#sqlParams !== undefined &&
-      this.#backend.executeRaw !== undefined
-    ) {
+    const fresh =
+      this.#backend.executeRaw === undefined ?
+        undefined
+      : this.#compileFresh(this.#ast);
+    if (fresh !== undefined && this.#backend.executeRaw !== undefined) {
       const filledParams = fillPlaceholders(
-        this.#sqlParams,
+        fresh.params,
         bindings,
         this.#dialect,
       );
       const rawRows = await this.#backend.executeRaw<Record<string, unknown>>(
-        this.#sqlText,
+        fresh.sql,
         filledParams,
       );
       return transformPathColumns(rawRows, this.#state, this.#dialect);
@@ -414,18 +423,18 @@ export class PreparedQuery<R> {
   async #executeUnoptimizedRows(
     bindings: Readonly<Record<string, unknown>>,
   ): Promise<readonly Record<string, unknown>[]> {
-    if (
-      this.#unoptimizedSqlText !== undefined &&
-      this.#unoptimizedSqlParams !== undefined &&
-      this.#backend.executeRaw !== undefined
-    ) {
+    const fresh =
+      this.#backend.executeRaw === undefined ?
+        undefined
+      : this.#compileFresh(this.#unoptimizedAst);
+    if (fresh !== undefined && this.#backend.executeRaw !== undefined) {
       const filledParams = fillPlaceholders(
-        this.#unoptimizedSqlParams,
+        fresh.params,
         bindings,
         this.#dialect,
       );
       const rawRows = await this.#backend.executeRaw<Record<string, unknown>>(
-        this.#unoptimizedSqlText,
+        fresh.sql,
         filledParams,
       );
       return transformPathColumns(rawRows, this.#state, this.#dialect);

--- a/packages/typegraph/src/query/builder/prepared-query.ts
+++ b/packages/typegraph/src/query/builder/prepared-query.ts
@@ -277,7 +277,8 @@ type PreparedQueryConfig<R> = Readonly<{
 }>;
 
 /**
- * A pre-compiled, parameterized query.
+ * A pre-validated, parameterized query — see the module doc comment above
+ * for why SQL text is compiled fresh per call, not cached from prepare().
  *
  * @example
  * ```typescript

--- a/packages/typegraph/src/query/builder/unionable-query.ts
+++ b/packages/typegraph/src/query/builder/unionable-query.ts
@@ -29,8 +29,6 @@ import {
   type SelectContext,
 } from "./types";
 
-const NOT_COMPUTED = Symbol("NOT_COMPUTED");
-
 function executeOnBackend<T>(
   backend: GraphBackend | TransactionBackend,
   recordedAsOf: string | undefined,
@@ -89,7 +87,6 @@ type UnionableQueryState = Readonly<{
 export class UnionableQuery<G extends GraphDef, R> {
   readonly #config: QueryBuilderConfig;
   readonly #state: UnionableQueryState;
-  #cachedCompiled: CompiledSelectSql | typeof NOT_COMPUTED = NOT_COMPUTED;
 
   constructor(config: QueryBuilderConfig, state: UnionableQueryState) {
     this.#config = config;
@@ -228,17 +225,15 @@ export class UnionableQuery<G extends GraphDef, R> {
    * Compiles the set operation to SQL.
    */
   compile(): CompiledSelectSql {
-    if (this.#cachedCompiled !== NOT_COMPUTED) {
-      return this.#cachedCompiled;
-    }
-
-    const compiled = compileSetOperation(
+    // Not cached — a "current" temporal filter binds its read instant at
+    // compile time, so caching across calls would freeze "now" at first
+    // compilation (see PreparedQuery's class doc comment for the full
+    // rationale).
+    return compileSetOperation(
       this.toAst(),
       this.#config.graphId,
       this.#compileOptions(),
     );
-    this.#cachedCompiled = compiled;
-    return compiled;
   }
 
   #compileOptions(): CompileQueryOptions {

--- a/packages/typegraph/tests/executable-aggregate-query.test.ts
+++ b/packages/typegraph/tests/executable-aggregate-query.test.ts
@@ -315,7 +315,12 @@ describe("ExecutableAggregateQuery.compile", () => {
     expect(sqlString).toContain("GROUP BY");
   });
 
-  it("reuses cached compiled SQL for repeated compile calls", () => {
+  it("compiles equivalent SQL on repeated compile calls", () => {
+    // Deliberately NOT cached across calls: a "current" temporal filter
+    // binds its read instant at compile time, so caching the compiled
+    // result would freeze "now" at the first call for the query's entire
+    // lifetime (see PreparedQuery's class doc comment). Repeated calls
+    // must still produce the same SQL shape, just not the same object.
     const query = createQueryBuilder<typeof graph>(graph.id, registry)
       .from("Product", "p")
       .groupBy("p", "category")
@@ -327,7 +332,7 @@ describe("ExecutableAggregateQuery.compile", () => {
     const firstCompile = query.compile();
     const secondCompile = query.compile();
 
-    expect(secondCompile).toBe(firstCompile);
+    expect(toSqlString(secondCompile)).toBe(toSqlString(firstCompile));
   });
 
   it("includes LIMIT and OFFSET in compiled SQL", () => {

--- a/packages/typegraph/tests/executable-aggregate-query.test.ts
+++ b/packages/typegraph/tests/executable-aggregate-query.test.ts
@@ -44,6 +44,16 @@ const MOCK_BACKEND_CAPABILITIES = {
   windowFunctions: true,
 } as const;
 
+/** Strips the millisecond-precision "current instant" bound in a compiled
+ * temporal filter, so two genuinely fresh compiles of the same query can be
+ * compared for structural equality. */
+function normalizeTimestamps(sql: string): string {
+  return sql.replaceAll(
+    /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/g,
+    "<timestamp>",
+  );
+}
+
 // ============================================================
 // ExecutableAggregateQuery toAst
 // ============================================================
@@ -320,7 +330,9 @@ describe("ExecutableAggregateQuery.compile", () => {
     // binds its read instant at compile time, so caching the compiled
     // result would freeze "now" at the first call for the query's entire
     // lifetime (see PreparedQuery's class doc comment). Repeated calls
-    // must still produce the same SQL shape, just not the same object.
+    // must still produce the same SQL shape — but the bound "now" value
+    // itself may legitimately differ by a millisecond between two calls,
+    // so timestamps are normalized before comparing.
     const query = createQueryBuilder<typeof graph>(graph.id, registry)
       .from("Product", "p")
       .groupBy("p", "category")
@@ -332,7 +344,9 @@ describe("ExecutableAggregateQuery.compile", () => {
     const firstCompile = query.compile();
     const secondCompile = query.compile();
 
-    expect(toSqlString(secondCompile)).toBe(toSqlString(firstCompile));
+    expect(normalizeTimestamps(toSqlString(secondCompile))).toBe(
+      normalizeTimestamps(toSqlString(firstCompile)),
+    );
   });
 
   it("includes LIMIT and OFFSET in compiled SQL", () => {

--- a/packages/typegraph/tests/query-builder-read-freshness.test.ts
+++ b/packages/typegraph/tests/query-builder-read-freshness.test.ts
@@ -23,7 +23,7 @@ import {
   defineGraph,
   defineNode,
   field,
-  param,
+  param as parameter,
 } from "../src";
 import type { GraphBackend } from "../src/backend/types";
 import { createTestBackend } from "./test-utils";
@@ -50,7 +50,7 @@ describe("query builder read freshness", () => {
     const personById = store
       .query()
       .from("Person", "p")
-      .whereNode("p", (p) => p.id.eq(param("id")))
+      .whereNode("p", (p) => p.id.eq(parameter("id")))
       .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
       .prepare();
 

--- a/packages/typegraph/tests/query-builder-read-freshness.test.ts
+++ b/packages/typegraph/tests/query-builder-read-freshness.test.ts
@@ -1,0 +1,131 @@
+/**
+ * A "current" (live) temporal-validity filter binds its read instant at SQL
+ * compile time (`currentReadInstant()`). `ExecutableQuery`, `UnionableQuery`,
+ * `ExecutableAggregateQuery`, and `PreparedQuery` all used to cache their
+ * compiled SQL across calls — `.prepare()` compiled once and every
+ * `execute()` reused that SQL text forever; a reused `ExecutableQuery`
+ * instance cached its first `.execute()`'s compilation the same way. Both
+ * froze "now" at the moment of first compilation, silently hiding every row
+ * created afterward from that query for its entire remaining lifetime — a
+ * severe regression, since `.prepare()`-once-`.execute()`-many is this
+ * library's own documented, recommended pattern. Compiled SQL text is no
+ * longer cached across calls in any of the four classes; these tests pin
+ * that a row created after prepare()/first-execute() is visible on the very
+ * next execute() call.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  count,
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  field,
+  param,
+} from "../src";
+import type { GraphBackend } from "../src/backend/types";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
+const knows = defineEdge("knows");
+
+const graph = defineGraph({
+  id: "query-builder-read-freshness",
+  nodes: { Person: { type: Person } },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+describe("query builder read freshness", () => {
+  let backend: GraphBackend;
+
+  beforeEach(() => {
+    backend = createTestBackend();
+  });
+
+  it("PreparedQuery sees a row created after prepare(), not just after the first execute()", async () => {
+    const store = createStore(graph, backend);
+
+    const personById = store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.id.eq(param("id")))
+      .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
+      .prepare();
+
+    // prepare() ran before this row existed.
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+
+    const result = await personById.execute({ id: alice.id });
+    expect(result).toEqual([{ id: alice.id, name: "Alice" }]);
+
+    // A second row, created after the FIRST execute() too — pins that
+    // execute() itself doesn't freeze anything either.
+    const bob = await store.nodes.Person.create({ name: "Bob" });
+    const bobResult = await personById.execute({ id: bob.id });
+    expect(bobResult).toEqual([{ id: bob.id, name: "Bob" }]);
+  });
+
+  it("a reused ExecutableQuery instance sees rows created between execute() calls", async () => {
+    const store = createStore(graph, backend);
+
+    const allPeople = store
+      .query()
+      .from("Person", "p")
+      .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }));
+
+    const before = await allPeople.execute();
+    expect(before).toHaveLength(0);
+
+    await store.nodes.Person.create({ name: "Alice" });
+
+    const after = await allPeople.execute();
+    expect(after).toHaveLength(1);
+  });
+
+  it("a reused UnionableQuery instance sees rows created between execute() calls", async () => {
+    const store = createStore(graph, backend);
+
+    const named = store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.name.eq("Alice"))
+      .select((ctx) => ({ id: ctx.p.id }));
+    const otherNamed = store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.name.eq("Bob"))
+      .select((ctx) => ({ id: ctx.p.id }));
+    const unioned = named.union(otherNamed);
+
+    const before = await unioned.execute();
+    expect(before).toHaveLength(0);
+
+    await store.nodes.Person.create({ name: "Alice" });
+
+    const after = await unioned.execute();
+    expect(after).toHaveLength(1);
+  });
+
+  it("a reused ExecutableAggregateQuery instance sees rows created between execute() calls", async () => {
+    const store = createStore(graph, backend);
+
+    const countByName = store
+      .query()
+      .from("Person", "p")
+      .groupBy("p", "name")
+      .aggregate({
+        name: field("p", "name"),
+        total: count("p"),
+      });
+
+    const before = await countByName.execute();
+    expect(before).toHaveLength(0);
+
+    await store.nodes.Person.create({ name: "Alice" });
+
+    const after = await countByName.execute();
+    expect(after).toEqual([{ name: "Alice", total: 1 }]);
+  });
+});

--- a/packages/typegraph/tests/query-builder-read-freshness.test.ts
+++ b/packages/typegraph/tests/query-builder-read-freshness.test.ts
@@ -37,6 +37,21 @@ const graph = defineGraph({
   edges: { knows: { type: knows, from: [Person], to: [Person] } },
 });
 
+/**
+ * Forces a real wall-clock millisecond boundary. `valid_from`/the "current
+ * instant" bound in a compiled temporal filter are both ISO-8601 strings at
+ * millisecond precision — without this, a fast test runner could compile
+ * and insert within the same millisecond, in which case even the buggy
+ * (frozen-instant) behavior would pass `valid_from <= now` by coincidence,
+ * silently weakening these as regression guards.
+ */
+async function waitForNextMillisecond(): Promise<void> {
+  const start = Date.now();
+  while (Date.now() === start) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 describe("query builder read freshness", () => {
   let backend: GraphBackend;
 
@@ -54,7 +69,9 @@ describe("query builder read freshness", () => {
       .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
       .prepare();
 
-    // prepare() ran before this row existed.
+    // prepare() ran before this row existed — force it onto a strictly
+    // later millisecond so the assertion can't pass by timing coincidence.
+    await waitForNextMillisecond();
     const alice = await store.nodes.Person.create({ name: "Alice" });
 
     const result = await personById.execute({ id: alice.id });
@@ -62,6 +79,7 @@ describe("query builder read freshness", () => {
 
     // A second row, created after the FIRST execute() too — pins that
     // execute() itself doesn't freeze anything either.
+    await waitForNextMillisecond();
     const bob = await store.nodes.Person.create({ name: "Bob" });
     const bobResult = await personById.execute({ id: bob.id });
     expect(bobResult).toEqual([{ id: bob.id, name: "Bob" }]);
@@ -78,6 +96,7 @@ describe("query builder read freshness", () => {
     const before = await allPeople.execute();
     expect(before).toHaveLength(0);
 
+    await waitForNextMillisecond();
     await store.nodes.Person.create({ name: "Alice" });
 
     const after = await allPeople.execute();
@@ -102,6 +121,7 @@ describe("query builder read freshness", () => {
     const before = await unioned.execute();
     expect(before).toHaveLength(0);
 
+    await waitForNextMillisecond();
     await store.nodes.Person.create({ name: "Alice" });
 
     const after = await unioned.execute();
@@ -123,6 +143,7 @@ describe("query builder read freshness", () => {
     const before = await countByName.execute();
     expect(before).toHaveLength(0);
 
+    await waitForNextMillisecond();
     await store.nodes.Person.create({ name: "Alice" });
 
     const after = await countByName.execute();

--- a/packages/typegraph/tests/unionable-query.test.ts
+++ b/packages/typegraph/tests/unionable-query.test.ts
@@ -387,7 +387,12 @@ describe("UnionableQuery.compile", () => {
     expect(sqlString).toContain("UNION");
   });
 
-  it("reuses cached compiled SQL for repeated compile calls", () => {
+  it("compiles equivalent SQL on repeated compile calls", () => {
+    // Deliberately NOT cached across calls: a "current" temporal filter
+    // binds its read instant at compile time, so caching the compiled
+    // result would freeze "now" at the first call for the query's entire
+    // lifetime (see PreparedQuery's class doc comment). Repeated calls
+    // must still produce the same SQL shape, just not the same object.
     const q1 = createQueryBuilder<typeof graph>(graph.id, registry)
       .from("User", "u")
       .select((ctx) => ({ id: ctx.u.id }));
@@ -400,7 +405,7 @@ describe("UnionableQuery.compile", () => {
     const firstCompile = unionQuery.compile();
     const secondCompile = unionQuery.compile();
 
-    expect(secondCompile).toBe(firstCompile);
+    expect(sqlToString(secondCompile)).toBe(sqlToString(firstCompile));
   });
 
   it("compiles UNION ALL to SQL", () => {

--- a/packages/typegraph/tests/unionable-query.test.ts
+++ b/packages/typegraph/tests/unionable-query.test.ts
@@ -80,6 +80,16 @@ const graph = defineGraph({
 
 const registry = buildKindRegistry(graph);
 
+/** Strips the millisecond-precision "current instant" bound in a compiled
+ * temporal filter, so two genuinely fresh compiles of the same query can be
+ * compared for structural equality. */
+function normalizeTimestamps(sql: string): string {
+  return sql.replaceAll(
+    /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/g,
+    "<timestamp>",
+  );
+}
+
 // ============================================================
 // UnionableQuery.union
 // ============================================================
@@ -392,7 +402,9 @@ describe("UnionableQuery.compile", () => {
     // binds its read instant at compile time, so caching the compiled
     // result would freeze "now" at the first call for the query's entire
     // lifetime (see PreparedQuery's class doc comment). Repeated calls
-    // must still produce the same SQL shape, just not the same object.
+    // must still produce the same SQL shape — but the bound "now" value
+    // itself may legitimately differ by a millisecond between two calls,
+    // so timestamps are normalized before comparing.
     const q1 = createQueryBuilder<typeof graph>(graph.id, registry)
       .from("User", "u")
       .select((ctx) => ({ id: ctx.u.id }));
@@ -405,7 +417,9 @@ describe("UnionableQuery.compile", () => {
     const firstCompile = unionQuery.compile();
     const secondCompile = unionQuery.compile();
 
-    expect(sqlToString(secondCompile)).toBe(sqlToString(firstCompile));
+    expect(normalizeTimestamps(sqlToString(secondCompile))).toBe(
+      normalizeTimestamps(sqlToString(firstCompile)),
+    );
   });
 
   it("compiles UNION ALL to SQL", () => {


### PR DESCRIPTION
## Critical regression

`.prepare()`d queries, and any `ExecutableQuery`/`UnionableQuery`/`ExecutableAggregateQuery` instance whose `.execute()` was called more than once, could **silently miss rows created after the query was first compiled**.

## Root cause

A "current" (live) temporal-validity read binds its read instant (`currentReadInstant()`) at SQL compile time. All four query-builder classes cached their compiled SQL text across calls:
- `.prepare()` compiled once; every subsequent `execute({...})` reused that same SQL text.
- A reused `ExecutableQuery`/`UnionableQuery`/`ExecutableAggregateQuery` instance cached its first `.execute()`'s compilation the same way.

Both patterns froze "now" at the moment of first compilation. Any row created afterward has a `valid_from` later than the frozen instant, so `valid_from <= now` silently evaluates to `false` for it — for the query's entire remaining lifetime.

**This is a regression** introduced by the `current-read-app-clock` fix (the #242 clock-skew correction, merged in #244). The prior behavior (`NOW()` / `strftime('now')`, evaluated fresh by the database on every execution) did not have this problem. It's more severe than #242: that bug required app/DB clock skew across separate hosts; this one reproduces unconditionally, in a single process, on the very next insert after a query is prepared or first executed. `.prepare()`-once-`.execute()`-many is this library's own documented, recommended pattern, so this hit the common case, not an edge case.

## How this was found

While rebasing a benchmark branch onto a freshly-updated main (picking up #244/#245) ahead of a real SF10-scale EC2 benchmark re-run, a local smoke test caught it first: `resolveRootPostId`'s recursive `replyOf` walk (a `.prepare()`d query) threw `"found no ancestors"` for a comment that demonstrably had them, because the query was prepared before the data load ran. Confirmed independently on a minimal non-recursive prepared query, and on a plain `ExecutableQuery` reused across two `execute()` calls — universal across all four builder classes, not specific to recursive queries.

## Fix

None of the four classes cache compiled SQL text across calls anymore — `compile()`/`toSQL()`/`execute()` always recompile fresh, so `currentReadInstant()` is re-evaluated every time. `.prepare()` still builds and structurally validates the query AST once (fails fast on a malformed query before the first `execute()`); only the SQL-text compilation moved from prepare-time to each execute-time call. `param()`-bound values are unaffected — those already correctly re-bound per call via `sql.placeholder()`.
