### PR TITLE
feat: add revision anchors and streaming branches

### DIFF
--- a/.changeset/revisioned-physical-branches.md
+++ b/.changeset/revisioned-physical-branches.md
@@ -1,0 +1,12 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add revision-anchored graph branches and streaming interchange. Stores can opt
+into `revisionTracking: true` (or use `history: true`) so branch and merge
+validation read a durable per-graph origin and revision instead of
+fingerprinting every live row or accepting a coincident revision from another
+store. Physical branch clones now stream bounded interchange batches, enabling
+large branch copies, exports, and imports without materializing the full graph
+in memory. Direct backend writes remain outside the revision-tracking contract;
+tracked stores fail loudly if `tx.sql` would bypass that contract.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -51,10 +51,14 @@ report you can act on.**
 
 The mental model is a three-act lifecycle:
 
-1. **`branch()`** stamps the base store's `base@V` (a hash of its schema *and*
-   live content) and materializes an isolated, independently-mutable working
-   copy. Writers edit the working copy with the normal store API; the base is
-   never touched.
+1. **`branch()`** stamps the base store's `base@V` and materializes an
+   isolated, independently-mutable working copy. With `revisionTracking: true`
+   (or `history: true`), `base@V` uses the store's durable revision anchor: a
+   per-graph random origin plus a monotonic clock. Validation therefore does
+   not fingerprint every live row or mistake a coincident revision in a
+   separately created store for the branch's base. Existing stores retain the
+   schema-and-content-fingerprint fallback. Writers edit the working copy with
+   the normal store API; the base is never touched.
 2. Writers do whatever they want — create nodes/edges, modify inherited rows,
    delete inherited rows.
 3. **`merge()`** diffs every branch against the base, then runs a fixed
@@ -86,7 +90,10 @@ then merge them back into the target.
 import { createStoreWithSchema } from "@nicia-ai/typegraph";
 import { asBranchId, branch, isOk, merge, unwrap } from "@nicia-ai/typegraph/graph-merge";
 
-const [base] = await createStoreWithSchema(graph, baseBackend);
+const [base] = await createStoreWithSchema(graph, baseBackend, {
+  // Recommended for graphs that branch repeatedly or stay live while agents work.
+  revisionTracking: true,
+});
 
 // branch() is backend-agnostic: you supply a factory for each branch's backend.
 const makeBranchBackend = async () => createFreshBackend();
@@ -116,7 +123,50 @@ console.log(result.data.conflicts); // the "Anna" vs "Ana" spelling disagreement
 
 `branch()` returns a `Result`; `unwrap` throws on failure (or branch on
 `isOk`). The default working-copy strategy clones the base through TypeGraph's
-export/import, so each branch gets a fresh backend from your factory.
+streaming interchange, so each branch gets a fresh backend from your factory
+without building a graph-sized export document in memory.
+
+## Scaling branches and interchange
+
+`revisionTracking: true` is the recommended mode for long-lived, repeatedly
+branched graphs. It advances one durable revision anchor inside each successful
+Store write transaction. The anchor combines a per-graph random origin with the
+monotonic commit clock, so a branch can only match the store that created it —
+not an independent database whose clock happens to share the same timestamp. A
+branch and its merge precondition then read that constant-size anchor instead of
+hashing every live node and edge. Stores created with `history: true` already
+have the same guarantee through their recorded-time commit clock.
+
+On PostgreSQL, the guarantee serializes writes to the same graph with a
+transaction-scoped advisory lock. That is the correct trade-off for a live graph
+whose branch merges must fail closed, but it can reduce throughput and increase
+write latency for a high-concurrency, single-graph workload. Partition that
+workload across graphs or leave revision tracking off when the content-fingerprint
+fallback is acceptable.
+
+This unlocks:
+
+- Many concurrent agent, importer, or review branches without base-version
+  validation growing with the graph.
+- Large graph copies, backup/export, and transfer pipelines that keep only one
+  interchange batch resident at a time via `exportGraphStream()` and
+  `importGraphStream()`.
+- A safe fast path for a live base: a branch is rejected if any tracked base
+  write lands before its merge commits, rather than silently merging a stale
+  plan.
+
+Streaming removes the graph-sized heap spike, but a physical working copy still
+copies `O(graph)` rows and snapshot merge staging still compares branch state to
+the base. Copy-on-write logical branches and delta-only staging remain the next
+larger architectural step; they are not hidden behind a micro-optimization.
+
+Revision tracking covers writes through the Store API. Direct backend writes and
+raw graph-table writes through `tx.sql` bypass the anchor, so applications using
+either escape hatch must avoid them for a branchable graph or retain the default
+content-fingerprint validation. Streaming export is likewise not a transactional
+backup snapshot: concurrent writes can produce a stream that spans multiple
+committed graph states. Use a database snapshot or quiesce writes when backup
+consistency matters.
 
 ## Entity resolution
 
@@ -386,8 +436,11 @@ const whoMadeX = await readProvenance(store, { canonicalId: "patient-123" }); //
 ## Snapshot vs incremental
 
 A branch is forked from a `base@V` — a token combining the base's schema hash
-and a fingerprint of its live content. The two merge entry points differ in how
-they treat that token.
+with either its durable revision anchor (`revisionTracking: true` / `history:
+true`) or the compatibility fingerprint of live content. A revision anchor is
+namespaced by a durable per-graph origin, so it is not transferable between
+independently created stores. The two merge entry points differ in how they treat
+that token.
 
 **`merge()` is a snapshot merge.** Every branch must have forked from the
 target's *current* `base@V`. If the target advanced since the branch was taken,

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -374,6 +374,7 @@ export function createPostgresBackend(
     recordedNodes: getTableName(tables.recordedNodes),
     recordedEdges: getTableName(tables.recordedEdges),
     recordedClock: getTableName(tables.recordedClock),
+    revisionOrigins: getTableName(tables.revisionOrigins),
     fulltext: tables.fulltextTableName,
     uniques: getTableName(tables.uniques),
   };
@@ -597,6 +598,12 @@ export function createPostgresBackend(
       for (const statement of statements) {
         await db.execute(sql.raw(statement));
       }
+    },
+
+    async ensureRevisionOriginsTable(): Promise<void> {
+      await db.execute(
+        sql.raw(generatePgCreateTableSQL(tables.revisionOrigins)),
+      );
     },
 
     // Every fulltext-touching method asserts the durable marker instead

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -53,6 +53,7 @@ export type PostgresTableNames = Readonly<{
   recordedNodes: string;
   recordedEdges: string;
   recordedClock: string;
+  revisionOrigins: string;
   uniques: string;
   schemaVersions: string;
   fulltext: string;
@@ -78,6 +79,7 @@ const DEFAULT_TABLE_NAMES: PostgresTableNames = {
   recordedNodes: "typegraph_recorded_nodes",
   recordedEdges: "typegraph_recorded_edges",
   recordedClock: "typegraph_recorded_clock",
+  revisionOrigins: "typegraph_revision_origins",
   uniques: "typegraph_node_uniques",
   schemaVersions: "typegraph_schema_versions",
   fulltext: "typegraph_node_fulltext",
@@ -307,6 +309,15 @@ export function createPostgresTables(
     (t) => [primaryKey({ columns: [t.graphId] })],
   );
 
+  const revisionOrigins = pgTable(
+    n.revisionOrigins,
+    {
+      graphId: text("graph_id").notNull(),
+      origin: text("origin").notNull(),
+    },
+    (t) => [primaryKey({ columns: [t.graphId] })],
+  );
+
   const uniques = pgTable(
     n.uniques,
     {
@@ -515,6 +526,7 @@ export function createPostgresTables(
     recordedNodes,
     recordedEdges,
     recordedClock,
+    revisionOrigins,
     uniques,
     schemaVersions,
     indexMaterializations,

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -43,6 +43,7 @@ export type SqliteTableNames = Readonly<{
   recordedNodes: string;
   recordedEdges: string;
   recordedClock: string;
+  revisionOrigins: string;
   uniques: string;
   schemaVersions: string;
   fulltext: string;
@@ -76,6 +77,7 @@ const DEFAULT_TABLE_NAMES: SqliteTableNames = {
   recordedNodes: "typegraph_recorded_nodes",
   recordedEdges: "typegraph_recorded_edges",
   recordedClock: "typegraph_recorded_clock",
+  revisionOrigins: "typegraph_revision_origins",
   uniques: "typegraph_node_uniques",
   schemaVersions: "typegraph_schema_versions",
   fulltext: "typegraph_node_fulltext",
@@ -305,6 +307,15 @@ export function createSqliteTables(
     (t) => [primaryKey({ columns: [t.graphId] })],
   );
 
+  const revisionOrigins = sqliteTable(
+    n.revisionOrigins,
+    {
+      graphId: text("graph_id").notNull(),
+      origin: text("origin").notNull(),
+    },
+    (t) => [primaryKey({ columns: [t.graphId] })],
+  );
+
   const uniques = sqliteTable(
     n.uniques,
     {
@@ -456,6 +467,7 @@ export function createSqliteTables(
     recordedNodes,
     recordedEdges,
     recordedClock,
+    revisionOrigins,
     uniques,
     schemaVersions,
     indexMaterializations,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -958,6 +958,7 @@ export function createSqliteBackend(
     recordedNodes: getTableName(tables.recordedNodes),
     recordedEdges: getTableName(tables.recordedEdges),
     recordedClock: getTableName(tables.recordedClock),
+    revisionOrigins: getTableName(tables.revisionOrigins),
     fulltext: tables.fulltextTableName,
     uniques: getTableName(tables.uniques),
   };
@@ -1245,6 +1246,12 @@ export function createSqliteBackend(
       for (const statement of statements) {
         await db.run(sql.raw(statement));
       }
+    },
+
+    async ensureRevisionOriginsTable(): Promise<void> {
+      await db.run(
+        sql.raw(generateSqliteCreateTableSQL(tables.revisionOrigins)),
+      );
     },
 
     // Every fulltext-touching method asserts the durable marker instead

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1252,6 +1252,17 @@ export type GraphBackend = Readonly<{
   ensureIndexMaterializationsTable?: () => Promise<void>;
 
   /**
+   * Idempotently ensure ONLY the `typegraph_revision_origins` table exists.
+   *
+   * Revision-tracked stores use this per-graph, durable random origin together
+   * with the recorded clock to prevent two independent stores with coincident
+   * timestamps from sharing a merge base anchor. It is focused rather than
+   * using `bootstrapTables` so existing deployments can adopt revision anchors
+   * without replaying all base-table DDL during a merge read.
+   */
+  ensureRevisionOriginsTable?: () => Promise<void>;
+
+  /**
    * Look up a recorded materialization for a declared index by its
    * physical SQL index name. Returns `undefined` if no row exists.
    */

--- a/packages/typegraph/src/graph-merge/base-version.ts
+++ b/packages/typegraph/src/graph-merge/base-version.ts
@@ -12,7 +12,13 @@
  *      This is content-addressed (the public `computeSchemaHash` deliberately
  *      excludes the version number and `generatedAt`, so it is stable across
  *      re-saves of the same schema).
- *   2. A **content fingerprint** — a SHA-256 digest (truncated to a fixed-width
+ *   2. A **revision anchor** when the Store has `revisionTracking` (or
+ *      `history`) enabled — a durable random per-graph origin plus the
+ *      monotonic revision clock. This is O(1) to read and changes after every
+ *      successful Store write; the origin prevents independent stores with
+ *      coincident timestamps from sharing an anchor.
+ *      Stores without tracking retain the compatibility fallback: a
+ *      **content fingerprint**, a SHA-256 digest (truncated to a fixed-width
  *      hex string) of every LIVE node and edge over the base store (`id`,
  *      `updated_at`, the bitemporal `valid_from`/`valid_to`, and canonicalized
  *      `props`; edges also carry their endpoint ids), sorted by id, so two stores
@@ -27,9 +33,10 @@
  * fingerprint would not match its source. (See the working-copy fidelity note in
  * T4.)
  *
- * `computeBaseVersion` is async because schema hashing and live-content
- * enumeration go through async TypeGraph internals. The design's synchronous
- * illustrative signature does not survive contact with the real store surface.
+ * `computeBaseVersion` is async because schema hashing, revision reads, and the
+ * compatibility live-content enumeration go through async TypeGraph internals.
+ * The design's synchronous illustrative signature does not survive contact with
+ * the real store surface.
  */
 
 import { canonicalizeProps, parseRowProps } from "./canonical-props";
@@ -47,11 +54,14 @@ import type { BaseVersion } from "./types";
 import { asBaseVersion } from "./types";
 
 /**
- * Separator between the schema-hash and content-fingerprint token components.
- * Both components are fixed-width hex digests (no NUL byte), so a single NUL
- * unambiguously delimits the two components.
+ * Separator between the schema-hash and revision-or-content token components.
+ * The schema hash contains no NUL byte, so one NUL unambiguously delimits the
+ * two components.
  */
 const TOKEN_SEPARATOR = "\0";
+const REVISION_COMPONENT_PREFIX = "revision:";
+const REVISION_COMPONENT_SEPARATOR = ":";
+const INITIAL_REVISION = "initial";
 
 /**
  * Falls back to schema version `1` when the backend has not recorded an active
@@ -200,14 +210,26 @@ export async function computeContentComponent<G extends GraphDef>(
 
 /**
  * Computes the immutable `base@V` token for a store. Combines the schema hash
- * with a live-content fingerprint into a single branded {@link BaseVersion}.
+ * with a durable revision anchor when tracking is enabled, otherwise with the
+ * compatibility live-content fingerprint.
  *
  * MUST be called on the ORIGINAL base store, not a clone (clones regenerate
- * timestamps and would fingerprint differently).
+ * timestamps and would fingerprint differently when the compatibility path is
+ * in use).
  */
 export async function computeBaseVersion<G extends GraphDef>(
   store: Store<G>,
 ): Promise<BaseVersion> {
+  if (store.revisionTrackingEnabled) {
+    const [schemaComponent, origin, revision] = await Promise.all([
+      computeSchemaComponent(store),
+      store.revisionOriginNow(),
+      store.revisionNow(),
+    ]);
+    return asBaseVersion(
+      `${schemaComponent}${TOKEN_SEPARATOR}${revisionComponent(origin, revision)}`,
+    );
+  }
   const [schemaComponent, contentComponent] = await Promise.all([
     computeSchemaComponent(store),
     computeContentComponent(store.backend, store.graphId, store.graph),
@@ -217,15 +239,60 @@ export async function computeBaseVersion<G extends GraphDef>(
   );
 }
 
+function revisionComponent(
+  origin: string,
+  revision: string | undefined,
+): string {
+  return `${REVISION_COMPONENT_PREFIX}${origin}${REVISION_COMPONENT_SEPARATOR}${revision ?? INITIAL_REVISION}`;
+}
+
+/** True when a base token uses the O(1) durable revision-anchor component. */
+export function hasRevisionAnchor(version: BaseVersion): boolean {
+  return contentComponentOf(version).startsWith(REVISION_COMPONENT_PREFIX);
+}
+
 /**
- * Extracts the content-fingerprint component from a `base@V` token. The schema
- * component is a fixed-width hex digest with no NUL byte, so the substring after
- * the single NUL separator is exactly the content fingerprint.
+ * Extracts the durable revision from a revision-anchored base token. Undefined
+ * represents the stable initial state before the first tracked write.
+ */
+export function revisionAnchorOf(version: BaseVersion): string | undefined {
+  const revision = revisionPartsOf(version)?.revision;
+  return revision === undefined || revision === INITIAL_REVISION ?
+      undefined
+    : revision;
+}
+
+/**
+ * Extracts the durable store-specific namespace from a revision-anchored base
+ * token. Undefined denotes a legacy timestamp-only anchor, which must never
+ * be treated as equivalent to a current store's namespaced revision.
+ */
+export function revisionOriginOf(version: BaseVersion): string | undefined {
+  return revisionPartsOf(version)?.origin;
+}
+
+function revisionPartsOf(
+  version: BaseVersion,
+): Readonly<{ origin: string; revision: string }> | undefined {
+  const component = contentComponentOf(version);
+  if (!component.startsWith(REVISION_COMPONENT_PREFIX)) return undefined;
+  const encoded = component.slice(REVISION_COMPONENT_PREFIX.length);
+  const separator = encoded.indexOf(REVISION_COMPONENT_SEPARATOR);
+  if (separator <= 0 || separator === encoded.length - 1) return undefined;
+  return {
+    origin: encoded.slice(0, separator),
+    revision: encoded.slice(separator + 1),
+  };
+}
+
+/**
+ * Extracts the second component from a `base@V` token. The schema component
+ * contains no NUL byte, so the substring after the separator is exactly the
+ * durable revision or compatibility content fingerprint.
  *
- * Used by the in-transaction re-validation: the SCHEMA component is a pure
- * function of the in-memory graph definition (it cannot drift between the
- * precondition check and the commit), so only the content component needs to be
- * re-compared against live rows.
+ * Used by both revision-token parsing and legacy in-transaction content
+ * re-validation. The schema component is a pure function of the in-memory
+ * graph definition, so only the second component needs runtime checking.
  */
 export function contentComponentOf(version: BaseVersion): string {
   const separatorIndex = (version as string).indexOf(TOKEN_SEPARATOR);

--- a/packages/typegraph/src/graph-merge/branch.ts
+++ b/packages/typegraph/src/graph-merge/branch.ts
@@ -8,7 +8,8 @@
  * branch's own backend seeded with the base's live state.
  *
  * The copy mechanism is pluggable behind {@link WorkingCopyStrategy}. The P0
- * default is the faithful export/import clone ({@link cloneWorkingCopyStrategy}),
+ * default is the faithful streamed-interchange clone
+ * ({@link cloneWorkingCopyStrategy}),
  * which keeps this primitive backend-agnostic: the caller supplies a
  * `makeBackend` factory, and `branch()` never names a concrete backend.
  */
@@ -34,7 +35,7 @@ import { cloneWorkingCopyStrategy } from "./working-copy";
  * logical-namespace copy-on-write).
  *
  * Returns a {@link Result}: success yields the {@link GraphBranch}; any failure
- * (base-version stamping, backend construction, export/import) is wrapped in a
+ * (base-version stamping, backend construction, streamed interchange) is wrapped in a
  * {@link BranchError} with the underlying cause attached. Errors are returned,
  * never thrown — this is internal-logic surface (the caller converts to a thrown
  * error at the framework boundary).

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -5,7 +5,7 @@
  *
  *   1. PRECONDITION — compute the target's `base@V` and reject any branch whose
  *      `base` token does not match it (`BaseVersionMismatchError`). A branch
- *      forked from a divergent schema or content fingerprint cannot be merged
+ *      forked from a divergent schema or base revision cannot be merged
  *      safely (design §5.2 / §13.6).
  *   2. STAGE — `stageBranches` (T7): the provenance-tagged UNION of every
  *      branch's state-diff against the immutable base.
@@ -45,6 +45,9 @@ import {
   computeContentComponent,
   computeSchemaComponent,
   contentComponentOf,
+  hasRevisionAnchor,
+  revisionAnchorOf,
+  revisionOriginOf,
 } from "./base-version";
 import { blockNodes } from "./blocking";
 import { canonicalizeProps, edgeStateSignature } from "./canonical-props";
@@ -121,6 +124,11 @@ import type {
   TransactionBackend,
   TransactionOptions,
   UniqueIntrospection,
+} from "./typegraph-internal";
+import {
+  lockRecordedGraphWrite,
+  readRecordedClock,
+  readRevisionOrigin,
 } from "./typegraph-internal";
 import type {
   BaseAmbiguity,
@@ -1291,12 +1299,10 @@ export async function commitPlan<G extends GraphDef>(
     target.transaction(async (tx) => {
       // TOCTOU guard: the plan was resolved from reads taken OUTSIDE this
       // transaction, so the target may have been written between the base@V
-      // precondition and this commit. Re-deriving the content fingerprint
-      // through the tx-scoped backend (this transaction's snapshot) and
-      // comparing it to the captured token proves the plan still describes the
-      // live target; SERIALIZABLE isolation makes the proof race-free — a
-      // concurrent write that invalidates these reads aborts one transaction
-      // with a retryable serialization failure instead of committing silently.
+      // precondition and this commit. Revision-anchored stores check their
+      // durable clock under the graph write lock; legacy stores re-derive the
+      // content fingerprint through this transaction's snapshot. Either proof
+      // ensures the plan still describes the live target before committing.
       if (expectedBaseVersion !== undefined) {
         await assertTargetUnchanged(tx.backend, target, expectedBaseVersion);
       }
@@ -1305,7 +1311,7 @@ export async function commitPlan<G extends GraphDef>(
         tx.nodes as unknown as TxNodes,
         tx.edges as unknown as TxEdges,
       );
-    }, MERGE_COMMIT_TX_OPTIONS),
+    }, mergeCommitTransactionOptions(target)),
   );
 }
 
@@ -1320,18 +1326,68 @@ const MERGE_COMMIT_TX_OPTIONS = {
   isolationLevel: "serializable",
 } as const satisfies TransactionOptions;
 
+function mergeCommitTransactionOptions<G extends GraphDef>(
+  target: Store<G>,
+): TransactionOptions | undefined {
+  // Recorded-time capture only supports read-committed transactions because it
+  // allocates its durable clock inside the write transaction. Revision-anchored
+  // merges hold that same per-graph lock before checking the anchor, which
+  // closes the TOCTOU gap without asking a history store for SERIALIZABLE.
+  return target.historyEnabled ? undefined : MERGE_COMMIT_TX_OPTIONS;
+}
+
 /**
- * The in-transaction half of the base@V guard: recomputes the target's content
- * fingerprint through the TRANSACTION-SCOPED backend and compares it to the
- * token captured by the precondition (`merge()`) or at plan start
- * (`mergeAgainstBase()`). The schema component cannot drift (it is a pure
- * function of the in-memory graph definition), so only content is compared.
+ * The in-transaction half of the base@V guard: revision-anchored targets read
+ * their durable clock under the graph lock; legacy targets recompute their
+ * content fingerprint through the transaction-scoped backend. The schema
+ * component cannot drift because it is a pure function of the in-memory graph
+ * definition.
  */
 async function assertTargetUnchanged<G extends GraphDef>(
   txBackend: TransactionBackend,
   target: Store<G>,
   expectedBaseVersion: BaseVersion,
 ): Promise<void> {
+  if (hasRevisionAnchor(expectedBaseVersion)) {
+    // All tracked writers acquire this lock before touching graph rows and
+    // advance the same clock before committing. Holding it around the
+    // read→apply sequence makes the O(1) anchor check a TOCTOU guard without
+    // relying on the transaction's snapshot being the latest committed state.
+    await lockRecordedGraphWrite(txBackend, target.graphId);
+    const expectedOrigin = revisionOriginOf(expectedBaseVersion);
+    const liveOrigin = await readRevisionOrigin(
+      txBackend,
+      target.revisionSchema,
+      target.graphId,
+    );
+    if (liveOrigin !== expectedOrigin) {
+      throw new BaseVersionMismatchError(
+        "The merge branch was forked from a different revision-tracked store; the resolved plan was not applied.",
+        {
+          details: { expectedOrigin, liveOrigin },
+          suggestion:
+            "Merge the branch back into its original base store, or fork a new branch from this target.",
+        },
+      );
+    }
+    const liveRevision = await readRecordedClock(
+      txBackend,
+      target.revisionSchema,
+      target.graphId,
+    );
+    const expectedRevision = revisionAnchorOf(expectedBaseVersion);
+    if (liveRevision !== expectedRevision) {
+      throw new BaseVersionMismatchError(
+        "The merge target was modified between the revision-anchor check and the commit transaction; the resolved plan was not applied.",
+        {
+          details: { expectedRevision, liveRevision },
+          suggestion:
+            "Re-run the merge (and re-branch if the divergence is real), or route all graph writes through the revision-tracked Store.",
+        },
+      );
+    }
+    return;
+  }
   const liveContent = await computeContentComponent(
     txBackend,
     target.graphId,
@@ -1445,7 +1501,7 @@ function edgeCollection(edges: TxEdges, kind: string): EdgeCollectionLike {
 /**
  * Validates the `base@V` precondition: every branch's `base` token MUST equal the
  * target's current base version. A mismatch means the branch forked from a
- * divergent schema or content fingerprint, which cannot be merged safely.
+ * divergent schema or base revision, which cannot be merged safely.
  */
 async function validateBaseVersions<G extends GraphDef>(
   target: Store<G>,
@@ -2597,12 +2653,19 @@ async function commitIncrementalPlan<G extends GraphDef>(
     );
   }
 
-  // SERIALIZABLE + retry for the same reason as `commitPlan`: the per-row
-  // guards read inside this transaction, and SSI turns a concurrent write that
-  // invalidates those reads into a retryable abort instead of a lost update.
-  // Every retry re-runs the guards, so a real hazard fails typed, never stale.
+  // Legacy targets use SERIALIZABLE + retry: the per-row guards read inside
+  // this transaction, and SSI turns a conflicting concurrent write into a
+  // retryable abort. Recorded-history targets cannot use SERIALIZABLE because
+  // capture allocates its clock in read-committed mode; they instead acquire the
+  // same graph write lock as every captured write before the guards run. In
+  // PostgreSQL read committed each subsequent statement sees committed work that
+  // landed before the lock was acquired, while the lock excludes later tracked
+  // writes until this plan commits.
   return withTxConflictRetry(() =>
     target.transaction(async (tx) => {
+      if (target.revisionTrackingEnabled) {
+        await lockRecordedGraphWrite(tx.backend, target.graphId);
+      }
       const nodesApi = tx.nodes as unknown as TxNodes;
       const edgesApi = tx.edges as unknown as TxEdges;
       // Identity-resolution TOCTOU guard: the base-source lookups ran OUTSIDE
@@ -2616,7 +2679,7 @@ async function commitIncrementalPlan<G extends GraphDef>(
       await validateIncrementalNodeWrites(target, nodesApi, plan);
       await validateIncrementalEdgeWrites(target, edgesApi, plan);
       return applyMergePlan(plan, nodesApi, edgesApi);
-    }, MERGE_COMMIT_TX_OPTIONS),
+    }, mergeCommitTransactionOptions(target)),
   );
 }
 

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -15,8 +15,8 @@ export {
 export { defineNode } from "../core/node";
 export type { EdgeId, JsonValue, NodeId, NodeType } from "../core/types";
 export { TypeGraphError, type TypeGraphErrorOptions } from "../errors";
-export { exportGraph } from "../interchange/export";
-export { importGraph } from "../interchange/import";
+export { exportGraphStream } from "../interchange/export";
+export { importGraphStream } from "../interchange/import";
 export { computeTransitiveClosure, isReachable } from "../ontology/closures";
 export { sortedReplacer } from "../schema/canonical";
 export { computeSchemaHash, serializeSchema } from "../schema/serializer";
@@ -24,6 +24,11 @@ export {
   type OntologyIntrospection,
   type UniqueIntrospection,
 } from "../store/introspect";
+export {
+  lockRecordedGraphWrite,
+  readRecordedClock,
+  readRevisionOrigin,
+} from "../store/recorded-capture";
 export type { Store } from "../store/store";
 export { createStoreWithSchema } from "../store/store";
 export type { Edge, Node } from "../store/types";

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -32,8 +32,10 @@ export type BranchId = string & Readonly<{ readonly __brand: "BranchId" }>;
 
 /**
  * Opaque token identifying the immutable `base@V` a branch was forked from.
- * Combines a schema hash with a content fingerprint (computed in T3). Branded so
- * it cannot be confused with an arbitrary string.
+ * Combines a schema hash with a staleness component. Branded so it cannot be
+ * confused with an arbitrary string. The second component is a
+ * durable revision anchor for stores with revision tracking enabled and a
+ * compatibility content fingerprint otherwise.
  */
 export type BaseVersion = string &
   Readonly<{ readonly __brand: "BaseVersion" }>;

--- a/packages/typegraph/src/graph-merge/working-copy.ts
+++ b/packages/typegraph/src/graph-merge/working-copy.ts
@@ -2,12 +2,12 @@
  * Pluggable working-copy strategy: how `branch()` produces an isolated,
  * independently-mutable copy of a base store.
  *
- * The P0 default is a faithful CLONE via the public interchange API
- * ({@link cloneWorkingCopyStrategy}): `exportGraph` the base, then `importGraph`
- * into a fresh store on a caller-provided backend. IDs are preserved by
- * interchange, so the diff engine (T3) can key on stable ids across base and
- * fork. This leverages public entrypoints only, needs zero schema changes, and
- * behaves identically across SQLite and Postgres.
+ * The P0 default is a faithful CLONE via streamed public interchange
+ * ({@link cloneWorkingCopyStrategy}): `exportGraphStream` the base, then
+ * `importGraphStream` into a fresh store on a caller-provided backend. IDs are
+ * preserved by interchange, so the diff engine (T3) can key on stable ids across
+ * base and fork. This leverages public entrypoints only, needs zero schema
+ * changes, and behaves identically across SQLite and Postgres.
  *
  * INTERCHANGE FIDELITY LIMITATION (verified, design §13.x): the interchange
  * `meta` schema has no `deletedAt` field, so a base row that is already
@@ -41,10 +41,10 @@
 import { BranchError } from "./errors";
 import type { GraphBackend, GraphDef, Store } from "./typegraph-internal";
 import { createStoreWithSchema } from "./typegraph-internal";
-import { exportGraph, importGraph } from "./typegraph-internal";
+import { exportGraphStream, importGraphStream } from "./typegraph-internal";
 
 /**
- * Batch size for the clone's `importGraph` pass. Large enough to keep
+ * Batch size for the clone's `importGraphStream` pass. Large enough to keep
  * round-trips low on demo-scale graphs; correctness is independent of the value.
  */
 const CLONE_IMPORT_BATCH_SIZE = 1000;
@@ -73,17 +73,20 @@ export type WorkingCopyStrategy<G extends GraphDef> = Readonly<{
  * in-process Postgres engine) be constructed lazily at branch time.
  *
  * The returned backend MUST be EMPTY (no rows for the base graph): the clone
- * seeds it from the base via `importGraph` with `onConflict: "error"`, so a
+ * seeds it from the base via `importGraphStream` with `onConflict: "error"`, so a
  * pre-existing row is surfaced as a {@link BranchError} rather than silently
  * skipped (which would leave the working copy diverging from the base).
+ * When the source store uses `revisionTracking`, the backend must also satisfy
+ * that option's transactional revision-clock requirements because the clone
+ * preserves the source's branchability contract.
  */
 export type MakeBackend = () => Promise<GraphBackend>;
 
 /**
- * The P0 default working-copy strategy: faithful clone via export/import.
+ * The P0 default working-copy strategy: faithful clone via streamed interchange.
  *
  * On each `create(baseStore)`:
- *   1. `exportGraph(baseStore, { includeMeta: true, includeTemporal: true,
+ *   1. `exportGraphStream(baseStore, { includeMeta: true, includeTemporal: true,
  *      includeDeleted: false })` — `includeMeta: true` carries
  *      `created_at`/`updated_at`; `includeTemporal: true` carries
  *      `validFrom`/`validTo` so the clone's valid-time window matches the base's
@@ -94,12 +97,12 @@ export type MakeBackend = () => Promise<GraphBackend>;
  *      base's live state.
  *   2. Create a fresh store over the caller-provided backend with the SAME graph
  *      definition via `createStoreWithSchema`.
- *   3. `importGraph(freshStore, data, { onConflict: "error", ... })` — ids are
+ *   3. `importGraphStream(freshStore, data, { onConflict: "error", ... })` — ids are
  *      preserved so the diff engine can key on them. `onConflict: "error"`
  *      requires the backend to be EMPTY: a pre-existing row is a contract
  *      violation that must surface loudly, never be silently skipped (a skipped
  *      row would leave the clone diverging from the base, so the fork's diff would
- *      report phantom modifications/deletions). `importGraph` RETURNS
+ *      report phantom modifications/deletions). `importGraphStream` RETURNS
  *      `{ success, errors }` rather than throwing on a per-row rejection, so its
  *      result is checked and any failure fails the branch.
  *
@@ -115,23 +118,32 @@ export function cloneWorkingCopyStrategy<G extends GraphDef>(
 ): WorkingCopyStrategy<G> {
   return {
     create: async (baseStore: Store<G>): Promise<Store<G>> => {
-      const data = await exportGraph(baseStore, {
-        includeMeta: true,
-        includeTemporal: true,
-        includeDeleted: false,
-      });
       const backend = await makeBackend();
       try {
         const [freshStore] = await createStoreWithSchema(
           baseStore.graph,
           backend,
+          {
+            // Keep descendants branchable with the same O(1) anchor contract,
+            // but do not copy recorded-time history into the disposable fork.
+            revisionTracking: baseStore.revisionTrackingEnabled,
+          },
         );
-        const result = await importGraph(freshStore, data, {
-          onConflict: "error",
-          onUnknownProperty: "error",
-          validateReferences: true,
-          batchSize: CLONE_IMPORT_BATCH_SIZE,
-        });
+        const result = await importGraphStream(
+          freshStore,
+          exportGraphStream(baseStore, {
+            includeMeta: true,
+            includeTemporal: true,
+            includeDeleted: false,
+            batchSize: CLONE_IMPORT_BATCH_SIZE,
+          }),
+          {
+            onConflict: "error",
+            onUnknownProperty: "error",
+            validateReferences: true,
+            batchSize: CLONE_IMPORT_BATCH_SIZE,
+          },
+        );
         if (!result.success) {
           throw new BranchError(
             "Clone import failed: the working copy could not be seeded from the base store. The backend returned by makeBackend() must be empty.",

--- a/packages/typegraph/src/interchange/export.ts
+++ b/packages/typegraph/src/interchange/export.ts
@@ -13,8 +13,12 @@ import { type Store } from "../store/store";
 import { nowIso } from "../utils/date";
 import {
   type ExportOptionsInput,
+  type ExportStreamOptionsInput,
+  ExportStreamOptionsSchema,
   FORMAT_VERSION,
   type GraphData,
+  type GraphDataHeader,
+  type GraphInterchangeChunk,
   type InterchangeEdge,
   type InterchangeNode,
 } from "./types";
@@ -45,50 +49,67 @@ export async function exportGraph<G extends GraphDef>(
   store: Store<G>,
   options?: ExportOptionsInput,
 ): Promise<GraphData> {
-  const options_ = {
-    nodeKinds: options?.nodeKinds,
-    edgeKinds: options?.edgeKinds,
-    includeTemporal: options?.includeTemporal ?? false,
-    includeMeta: options?.includeMeta ?? false,
-    includeDeleted: options?.includeDeleted ?? false,
-  };
+  const nodes: InterchangeNode[] = [];
+  const edges: InterchangeEdge[] = [];
+  let header: GraphDataHeader | undefined;
+  for await (const chunk of exportGraphStream(store, options)) {
+    switch (chunk.type) {
+      case "header": {
+        header = chunk.header;
+        break;
+      }
+      case "nodes": {
+        nodes.push(...chunk.nodes);
+        break;
+      }
+      case "edges": {
+        edges.push(...chunk.edges);
+        break;
+      }
+    }
+  }
+  if (header === undefined) {
+    throw new Error("Graph export stream ended before emitting its header.");
+  }
+  return { ...header, nodes, edges };
+}
 
-  const graph = store.graph;
+/**
+ * Exports a graph as bounded node and edge chunks. The stream always yields one
+ * header, then every node chunk, then every edge chunk. Consumers that write to
+ * a network, file, or fresh working copy can process one chunk at a time rather
+ * than materializing a graph-sized {@link GraphData} value.
+ */
+export async function* exportGraphStream<G extends GraphDef>(
+  store: Store<G>,
+  options?: ExportStreamOptionsInput,
+): AsyncIterable<GraphInterchangeChunk> {
+  const resolved = ExportStreamOptionsSchema.parse(options ?? {});
   const graphId = store.graphId;
   const backend = store.backend;
-
-  // Determine which kinds to export
-  const nodeKindsToExport = options_.nodeKinds ?? getNodeKinds(graph);
-  const edgeKindsToExport = options_.edgeKinds ?? getEdgeKinds(graph);
-
-  // Export nodes
-  const nodes: InterchangeNode[] = [];
-  for (const kind of nodeKindsToExport) {
-    const kindNodes = await exportNodesOfKind(backend, graphId, kind, options_);
-    nodes.push(...kindNodes);
-  }
-
-  // Export edges
-  const edges: InterchangeEdge[] = [];
-  for (const kind of edgeKindsToExport) {
-    const kindEdges = await exportEdgesOfKind(backend, graphId, kind, options_);
-    edges.push(...kindEdges);
-  }
-
-  // Get current schema version
+  const nodeKinds = resolved.nodeKinds ?? getNodeKinds(store.graph);
+  const edgeKinds = resolved.edgeKinds ?? getEdgeKinds(store.graph);
   const schemaVersion = await backend.getActiveSchema(graphId);
 
-  return {
-    formatVersion: FORMAT_VERSION,
-    exportedAt: nowIso(),
-    source: {
-      type: "typegraph-export",
-      graphId,
-      schemaVersion: schemaVersion?.version ?? 1,
+  yield {
+    type: "header",
+    header: {
+      formatVersion: FORMAT_VERSION,
+      exportedAt: nowIso(),
+      source: {
+        type: "typegraph-export",
+        graphId,
+        schemaVersion: schemaVersion?.version ?? 1,
+      },
     },
-    nodes,
-    edges,
   };
+
+  for (const kind of nodeKinds) {
+    yield* exportNodeChunks(backend, graphId, kind, resolved);
+  }
+  for (const kind of edgeKinds) {
+    yield* exportEdgeChunks(backend, graphId, kind, resolved);
+  }
 }
 
 // ============================================================
@@ -101,105 +122,123 @@ type ExportOptions_ = Readonly<{
   includeDeleted: boolean;
 }>;
 
-async function exportNodesOfKind(
+async function* exportNodeChunks(
   backend: GraphBackend,
   graphId: string,
   kind: string,
-  options: ExportOptions_,
-): Promise<InterchangeNode[]> {
-  const rows = await backend.findNodesByKind({
-    graphId,
-    kind,
-    excludeDeleted: !options.includeDeleted,
-  });
-
-  return rows.map((row) => {
-    const node: InterchangeNode = {
-      kind: row.kind,
-      id: row.id,
-      properties: rowPropsToObject(row.props),
-    };
-
-    if (options.includeTemporal) {
-      // validFrom is always emitted (as `null` when the row has no lower
-      // bound) so import can tell "confirmed open-left" apart from "not
-      // requested" and preserve it instead of defaulting to import time —
-      // see the schema doc on InterchangeNodeSchema.validFrom. validTo has
-      // no such ambiguity (it was never defaulted), so it stays gated.
-      // `null` (not `undefined`) is the wire-protocol signal here — JSON has
-      // no other way to say "explicitly cleared" vs. "field absent".
-      const validFrom =
-        // eslint-disable-next-line unicorn/no-null
-        row.valid_from ?? null;
-      (node as { validFrom?: string | null }).validFrom = validFrom;
-      if (row.valid_to) {
-        (node as { validTo?: string }).validTo = row.valid_to;
-      }
-    }
-
-    if (options.includeMeta) {
-      (node as { meta?: InterchangeNode["meta"] }).meta = {
-        version: row.version,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
+  options: ExportOptions_ & Readonly<{ batchSize: number }>,
+): AsyncIterable<GraphInterchangeChunk> {
+  let after: string | undefined;
+  for (;;) {
+    const rows = await backend.findNodesByKind({
+      graphId,
+      kind,
+      excludeDeleted: !options.includeDeleted,
+      orderBy: "id",
+      limit: options.batchSize,
+      ...(after === undefined ? {} : { after }),
+    });
+    if (rows.length === 0) return;
+    const nodes = rows.map((row) => {
+      const node: InterchangeNode = {
+        kind: row.kind,
+        id: row.id,
+        properties: rowPropsToObject(row.props),
       };
-    }
 
-    return node;
-  });
+      if (options.includeTemporal) {
+        // validFrom is always emitted (as `null` when the row has no lower
+        // bound) so import can tell "confirmed open-left" apart from "not
+        // requested" and preserve it instead of defaulting to import time —
+        // see the schema doc on InterchangeNodeSchema.validFrom. validTo has
+        // no such ambiguity (it was never defaulted), so it stays gated.
+        // `null` (not `undefined`) is the wire-protocol signal here — JSON has
+        // no other way to say "explicitly cleared" vs. "field absent".
+        const validFrom =
+          // eslint-disable-next-line unicorn/no-null
+          row.valid_from ?? null;
+        (node as { validFrom?: string | null }).validFrom = validFrom;
+        if (row.valid_to) {
+          (node as { validTo?: string }).validTo = row.valid_to;
+        }
+      }
+
+      if (options.includeMeta) {
+        (node as { meta?: InterchangeNode["meta"] }).meta = {
+          version: row.version,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        };
+      }
+
+      return node;
+    });
+    yield { type: "nodes", nodes };
+    if (rows.length < options.batchSize) return;
+    after = rows.at(-1)!.id;
+  }
 }
 
 // ============================================================
 // Edge Export
 // ============================================================
 
-async function exportEdgesOfKind(
+async function* exportEdgeChunks(
   backend: GraphBackend,
   graphId: string,
   kind: string,
-  options: ExportOptions_,
-): Promise<InterchangeEdge[]> {
-  const rows = await backend.findEdgesByKind({
-    graphId,
-    kind,
-    excludeDeleted: !options.includeDeleted,
-  });
-
-  return rows.map((row) => {
-    const edge: InterchangeEdge = {
-      kind: row.kind,
-      id: row.id,
-      from: {
-        kind: row.from_kind,
-        id: row.from_id,
-      },
-      to: {
-        kind: row.to_kind,
-        id: row.to_id,
-      },
-      properties: rowPropsToObject(row.props),
-    };
-
-    if (options.includeTemporal) {
-      // See exportNodesOfKind's validFrom comment: always emitted (as
-      // `null` when open-left) so import can distinguish "confirmed no
-      // lower bound" from "not requested".
-      const validFrom =
-        // eslint-disable-next-line unicorn/no-null
-        row.valid_from ?? null;
-      (edge as { validFrom?: string | null }).validFrom = validFrom;
-      if (row.valid_to) {
-        (edge as { validTo?: string }).validTo = row.valid_to;
-      }
-    }
-
-    if (options.includeMeta) {
-      (edge as { meta?: InterchangeEdge["meta"] }).meta = {
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
+  options: ExportOptions_ & Readonly<{ batchSize: number }>,
+): AsyncIterable<GraphInterchangeChunk> {
+  let after: string | undefined;
+  for (;;) {
+    const rows = await backend.findEdgesByKind({
+      graphId,
+      kind,
+      excludeDeleted: !options.includeDeleted,
+      orderBy: "id",
+      limit: options.batchSize,
+      ...(after === undefined ? {} : { after }),
+    });
+    if (rows.length === 0) return;
+    const edges = rows.map((row) => {
+      const edge: InterchangeEdge = {
+        kind: row.kind,
+        id: row.id,
+        from: {
+          kind: row.from_kind,
+          id: row.from_id,
+        },
+        to: {
+          kind: row.to_kind,
+          id: row.to_id,
+        },
+        properties: rowPropsToObject(row.props),
       };
-    }
 
-    return edge;
-  });
+      if (options.includeTemporal) {
+        // See exportNodesOfKind's validFrom comment: always emitted (as
+        // `null` when open-left) so import can distinguish "confirmed no
+        // lower bound" from "not requested".
+        const validFrom =
+          // eslint-disable-next-line unicorn/no-null
+          row.valid_from ?? null;
+        (edge as { validFrom?: string | null }).validFrom = validFrom;
+        if (row.valid_to) {
+          (edge as { validTo?: string }).validTo = row.valid_to;
+        }
+      }
+
+      if (options.includeMeta) {
+        (edge as { meta?: InterchangeEdge["meta"] }).meta = {
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        };
+      }
+
+      return edge;
+    });
+    yield { type: "edges", edges };
+    if (rows.length < options.batchSize) return;
+    after = rows.at(-1)!.id;
+  }
 }

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -38,6 +38,8 @@ import { checkUniquenessConstraints } from "../store/uniqueness";
 import { validateOptionalCanonicalIsoDate } from "../utils/date";
 import {
   type GraphData,
+  type GraphDataHeader,
+  type GraphInterchangeChunk,
   type ImportError,
   type ImportOptions,
   ImportOptionsSchema,
@@ -82,12 +84,7 @@ export async function importGraph<G extends GraphDef>(
   // only exist after parsing, and every internal stage reads them
   // directly.
   const options = ImportOptionsSchema.parse(rawOptions);
-  const result: ImportResult = {
-    success: true,
-    nodes: { created: 0, updated: 0, skipped: 0 },
-    edges: { created: 0, updated: 0, skipped: 0 },
-    errors: [],
-  };
+  const result = emptyImportResult();
 
   const errors: ImportError[] = [];
   const graph = store.graph;
@@ -142,6 +139,144 @@ export async function importGraph<G extends GraphDef>(
   // statistics refresh must not convert the completed (non-atomic on some
   // backends, non-retryable) import into a thrown failure — it degrades to
   // a warning, and the caller can run `store.refreshStatistics()`.
+  await refreshStatisticsAfterImport(store, options, result, "importGraph");
+
+  return {
+    ...result,
+    success: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Imports a header-first stream of bounded interchange chunks.
+ *
+ * Each chunk is committed through the same {@link importGraph} implementation
+ * as an in-memory import, so validation and conflict semantics stay identical.
+ * Chunks are individually atomic on transactional backends; a consumer needing
+ * all-or-nothing behavior can import into a disposable working-copy backend and
+ * publish it only after this function succeeds.
+ *
+ * Nodes must precede edges. Once a node chunk commits, edge validation reads the
+ * target store rather than retaining every imported node id in memory.
+ */
+export async function importGraphStream<G extends GraphDef>(
+  store: Store<G>,
+  chunks: AsyncIterable<GraphInterchangeChunk>,
+  rawOptions: ImportOptions,
+): Promise<ImportResult> {
+  const options = ImportOptionsSchema.parse(rawOptions);
+  const result = emptyImportResult();
+  let header: GraphDataHeader | undefined;
+  let receivedEdges = false;
+
+  for await (const chunk of chunks) {
+    switch (chunk.type) {
+      case "header": {
+        if (header !== undefined) {
+          throw new Error(
+            "Graph interchange stream emitted more than one header.",
+          );
+        }
+        header = chunk.header;
+        break;
+      }
+      case "nodes": {
+        if (header === undefined) {
+          throw new Error("Graph interchange stream must start with a header.");
+        }
+        if (receivedEdges) {
+          throw new Error(
+            "Graph interchange stream cannot emit nodes after edges.",
+          );
+        }
+        if (chunk.nodes.length === 0) break;
+        mergeImportResult(
+          result,
+          await importGraph(store, graphDataForChunk(header, chunk.nodes, []), {
+            ...options,
+            refreshStatistics: false,
+          }),
+        );
+        throwIfStreamChunkFailed(result, options);
+        break;
+      }
+      case "edges": {
+        if (header === undefined) {
+          throw new Error("Graph interchange stream must start with a header.");
+        }
+        receivedEdges = true;
+        if (chunk.edges.length === 0) break;
+        mergeImportResult(
+          result,
+          await importGraph(store, graphDataForChunk(header, [], chunk.edges), {
+            ...options,
+            refreshStatistics: false,
+          }),
+        );
+        throwIfStreamChunkFailed(result, options);
+        break;
+      }
+    }
+  }
+
+  if (header === undefined) {
+    throw new Error("Graph interchange stream ended before emitting a header.");
+  }
+  await refreshStatisticsAfterImport(
+    store,
+    options,
+    result,
+    "importGraphStream",
+  );
+  return { ...result, success: result.errors.length === 0 };
+}
+
+function throwIfStreamChunkFailed(
+  result: ImportResult,
+  options: ResolvedImportOptions,
+): void {
+  if (options.onStreamChunkError === "continue" || result.errors.length === 0) {
+    return;
+  }
+  throw new Error(
+    "Graph interchange stream aborted after a chunk reported import errors. " +
+      'Earlier chunks remain committed; use onStreamChunkError: "continue" for best-effort ingestion.',
+  );
+}
+
+function emptyImportResult(): ImportResult {
+  return {
+    success: true,
+    nodes: { created: 0, updated: 0, skipped: 0 },
+    edges: { created: 0, updated: 0, skipped: 0 },
+    errors: [],
+  };
+}
+
+function graphDataForChunk(
+  header: GraphDataHeader,
+  nodes: GraphData["nodes"],
+  edges: GraphData["edges"],
+): GraphData {
+  return { ...header, nodes, edges };
+}
+function mergeImportResult(target: ImportResult, source: ImportResult): void {
+  target.nodes.created += source.nodes.created;
+  target.nodes.updated += source.nodes.updated;
+  target.nodes.skipped += source.nodes.skipped;
+  target.edges.created += source.edges.created;
+  target.edges.updated += source.edges.updated;
+  target.edges.skipped += source.edges.skipped;
+  target.errors.push(...source.errors);
+}
+
+async function refreshStatisticsAfterImport<G extends GraphDef>(
+  store: Store<G>,
+  options: ResolvedImportOptions,
+  result: ImportResult,
+  surface: "importGraph" | "importGraphStream",
+): Promise<void> {
   const mutationCount =
     result.nodes.created +
     result.nodes.updated +
@@ -156,7 +291,7 @@ export async function importGraph<G extends GraphDef>(
         typeof console.warn === "function"
       ) {
         console.warn(
-          "[typegraph] importGraph committed its rows but the follow-up " +
+          `[typegraph] ${surface} committed its rows but the follow-up ` +
             "statistics refresh failed; run store.refreshStatistics() to " +
             "give the planner fresh statistics.",
           error,
@@ -164,12 +299,6 @@ export async function importGraph<G extends GraphDef>(
       }
     }
   }
-
-  return {
-    ...result,
-    success: errors.length === 0,
-    errors,
-  };
 }
 
 // ============================================================

--- a/packages/typegraph/src/interchange/index.ts
+++ b/packages/typegraph/src/interchange/index.ts
@@ -35,11 +35,18 @@ export {
   type ExportOptions,
   type ExportOptionsInput,
   ExportOptionsSchema,
+  type ExportStreamOptions,
+  type ExportStreamOptionsInput,
+  ExportStreamOptionsSchema,
   FORMAT_VERSION,
   type GraphData,
+  type GraphDataHeader,
+  GraphDataHeaderSchema,
   GraphDataSchema,
   type GraphDataSource,
   GraphDataSourceSchema,
+  type GraphInterchangeChunk,
+  GraphInterchangeChunkSchema,
   type ImportError,
   ImportErrorSchema,
   type ImportOptions,
@@ -58,5 +65,5 @@ export {
 // Functions
 // ============================================================
 
-export { exportGraph } from "./export";
-export { importGraph } from "./import";
+export { exportGraph, exportGraphStream } from "./export";
+export { importGraph, importGraphStream } from "./import";

--- a/packages/typegraph/src/interchange/types.ts
+++ b/packages/typegraph/src/interchange/types.ts
@@ -164,6 +164,13 @@ export const ImportOptionsSchema = z.object({
    * the engine catches up on its own. Default: true.
    */
   refreshStatistics: z.boolean().optional(),
+  /**
+   * How a streamed import reacts when one chunk reports entity-level errors.
+   * `abort` is the safe default: earlier chunks are already committed, so
+   * callers must not mistake a partial stream for a successful retryable load.
+   * `continue` is reserved for explicit best-effort ingestion.
+   */
+  onStreamChunkError: z.enum(["abort", "continue"]).default("abort"),
 });
 
 /**
@@ -220,6 +227,27 @@ export const GraphDataSchema = z.object({
 });
 
 export type GraphData = z.infer<typeof GraphDataSchema>;
+
+/** The metadata envelope emitted before streamed graph entities. */
+export const GraphDataHeaderSchema = GraphDataSchema.omit({
+  nodes: true,
+  edges: true,
+});
+
+export type GraphDataHeader = z.infer<typeof GraphDataHeaderSchema>;
+
+/**
+ * One bounded unit in the streamed interchange protocol. Nodes always precede
+ * edges, so an importer can validate endpoints from rows already written to its
+ * target without retaining all prior nodes in memory.
+ */
+export const GraphInterchangeChunkSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("header"), header: GraphDataHeaderSchema }),
+  z.object({ type: z.literal("nodes"), nodes: z.array(InterchangeNodeSchema) }),
+  z.object({ type: z.literal("edges"), edges: z.array(InterchangeEdgeSchema) }),
+]);
+
+export type GraphInterchangeChunk = z.infer<typeof GraphInterchangeChunkSchema>;
 
 // ============================================================
 // Import Result
@@ -284,3 +312,16 @@ export type ExportOptions = z.infer<typeof ExportOptionsSchema>;
 
 /** Export options as accepted by exportGraph (input type with optional defaults) */
 export type ExportOptionsInput = z.input<typeof ExportOptionsSchema>;
+
+/**
+ * Export options for {@link exportGraphStream}. `batchSize` bounds the number
+ * of node or edge entities retained for one yielded chunk.
+ */
+export const ExportStreamOptionsSchema = ExportOptionsSchema.extend({
+  batchSize: z.number().int().positive().default(1000),
+});
+
+export type ExportStreamOptions = z.infer<typeof ExportStreamOptionsSchema>;
+export type ExportStreamOptionsInput = z.input<
+  typeof ExportStreamOptionsSchema
+>;

--- a/packages/typegraph/src/query/compiler/schema.ts
+++ b/packages/typegraph/src/query/compiler/schema.ts
@@ -33,6 +33,8 @@ export type SqlTableNames = Readonly<{
   recordedEdges?: string | undefined;
   /** Recorded-time commit clock table name (default: "typegraph_recorded_clock") */
   recordedClock?: string | undefined;
+  /** Durable per-graph revision-origin table name (default: "typegraph_revision_origins") */
+  revisionOrigins?: string | undefined;
   /** Node fulltext table name (default: "typegraph_node_fulltext") */
   fulltext: string;
   /** Node uniques table name (default: "typegraph_node_uniques") */
@@ -50,6 +52,8 @@ export type ResolvedSqlTableNames = Readonly<{
   recordedEdges: string;
   /** Recorded-time commit clock table name */
   recordedClock: string;
+  /** Durable per-graph revision-origin table name */
+  revisionOrigins: string;
   /** Node fulltext table name */
   fulltext: string;
   /** Node uniques table name */
@@ -69,6 +73,8 @@ type SqlSchemaFields = Readonly<{
   recordedEdgesTable: SQL;
   /** Get a SQL reference to the recorded-time commit clock */
   recordedClockTable: SQL;
+  /** Get a SQL reference to the durable per-graph revision origins */
+  revisionOriginsTable: SQL;
   /** Get a SQL reference to the fulltext table */
   fulltextTable: SQL;
 }>;
@@ -91,6 +97,7 @@ class SqlSchemaDescriptor implements SqlSchemaFields {
   readonly recordedNodesTable: SQL;
   readonly recordedEdgesTable: SQL;
   readonly recordedClockTable: SQL;
+  readonly revisionOriginsTable: SQL;
   readonly fulltextTable: SQL;
 
   constructor(fields: SqlSchemaFields) {
@@ -100,6 +107,7 @@ class SqlSchemaDescriptor implements SqlSchemaFields {
     this.recordedNodesTable = fields.recordedNodesTable;
     this.recordedEdgesTable = fields.recordedEdgesTable;
     this.recordedClockTable = fields.recordedClockTable;
+    this.revisionOriginsTable = fields.revisionOriginsTable;
     this.fulltextTable = fields.fulltextTable;
     void this.#brand;
     Object.freeze(this);
@@ -115,6 +123,7 @@ const DEFAULT_TABLE_NAMES: ResolvedSqlTableNames = {
   recordedNodes: "typegraph_recorded_nodes",
   recordedEdges: "typegraph_recorded_edges",
   recordedClock: "typegraph_recorded_clock",
+  revisionOrigins: "typegraph_revision_origins",
   fulltext: "typegraph_node_fulltext",
   uniques: "typegraph_node_uniques",
 };
@@ -128,6 +137,8 @@ function resolveTableNames(
     recordedNodes: names.recordedNodes ?? DEFAULT_TABLE_NAMES.recordedNodes,
     recordedEdges: names.recordedEdges ?? DEFAULT_TABLE_NAMES.recordedEdges,
     recordedClock: names.recordedClock ?? DEFAULT_TABLE_NAMES.recordedClock,
+    revisionOrigins:
+      names.revisionOrigins ?? DEFAULT_TABLE_NAMES.revisionOrigins,
     fulltext: names.fulltext ?? DEFAULT_TABLE_NAMES.fulltext,
     uniques: names.uniques ?? DEFAULT_TABLE_NAMES.uniques,
   };
@@ -228,6 +239,7 @@ export function createSqlSchema(names: Partial<SqlTableNames> = {}): SqlSchema {
   validateTableName(tables.recordedNodes, "recordedNodes");
   validateTableName(tables.recordedEdges, "recordedEdges");
   validateTableName(tables.recordedClock, "recordedClock");
+  validateTableName(tables.revisionOrigins, "revisionOrigins");
   validateTableName(tables.fulltext, "fulltext");
   validateTableName(tables.uniques, "uniques");
 
@@ -238,6 +250,7 @@ export function createSqlSchema(names: Partial<SqlTableNames> = {}): SqlSchema {
     recordedNodesTable: sql.raw(quoteIdentifier(tables.recordedNodes)),
     recordedEdgesTable: sql.raw(quoteIdentifier(tables.recordedEdges)),
     recordedClockTable: sql.raw(quoteIdentifier(tables.recordedClock)),
+    revisionOriginsTable: sql.raw(quoteIdentifier(tables.revisionOrigins)),
     fulltextTable: sql.raw(quoteIdentifier(tables.fulltext)),
   });
 }
@@ -408,6 +421,7 @@ export function recordedReadSqlSchema(binding: RecordedReadBinding): SqlSchema {
     recordedNodesTable: schema.recordedNodesTable,
     recordedEdgesTable: schema.recordedEdgesTable,
     recordedClockTable: schema.recordedClockTable,
+    revisionOriginsTable: schema.revisionOriginsTable,
     fulltextTable: schema.fulltextTable,
   });
 }

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -28,6 +28,7 @@ import {
   ValidationError,
 } from "../../errors";
 import { validateEdgeProps } from "../../errors/validation";
+import { type SqlSchema } from "../../query/compiler/schema";
 import { type KindRegistry } from "../../registry/kind-registry";
 import { validateOptionalCanonicalIsoDate } from "../../utils/date";
 import { generateId } from "../../utils/id";
@@ -65,6 +66,8 @@ export type EdgeOperationContext<G extends GraphDef> = Readonly<{
   graph: G;
   graphId: string;
   historyEnabled: boolean;
+  revisionTrackingEnabled: boolean;
+  revisionSchema: SqlSchema;
   registry: KindRegistry;
   createOperationContext: (
     operation: "create" | "update" | "delete",

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -47,6 +47,7 @@ import { type ValueType } from "../../query/ast";
 import {
   createSqlSchema,
   DEFAULT_SQL_SCHEMA,
+  type SqlSchema,
 } from "../../query/compiler/schema";
 import { getDialect } from "../../query/dialect";
 import { type DialectAdapter } from "../../query/dialect/types";
@@ -102,6 +103,8 @@ export type NodeOperationContext<G extends GraphDef> = Readonly<{
   graph: G;
   graphId: string;
   historyEnabled: boolean;
+  revisionTrackingEnabled: boolean;
+  revisionSchema: SqlSchema;
   registry: KindRegistry;
   createOperationContext: (
     operation: "create" | "update" | "delete",

--- a/packages/typegraph/src/store/operations/write-transaction.ts
+++ b/packages/typegraph/src/store/operations/write-transaction.ts
@@ -21,7 +21,11 @@ import {
   runOptionallyInTransaction,
   type TransactionBackend,
 } from "../../backend/types";
-import { lockRecordedGraphWrite } from "../recorded-capture";
+import { type SqlSchema } from "../../query/compiler/schema";
+import {
+  advanceRevisionClock,
+  lockRecordedGraphWrite,
+} from "../recorded-capture";
 import {
   type GraphWriteLock,
   uncapturedGraphWriteLock,
@@ -36,6 +40,8 @@ import { type OperationHookContext } from "../types";
 export type WriteTransactionContext = Readonly<{
   graphId: string;
   historyEnabled: boolean;
+  revisionTrackingEnabled: boolean;
+  revisionSchema: SqlSchema;
 }>;
 
 /**
@@ -61,12 +67,26 @@ export function runInWriteTransaction<T>(
     lock: GraphWriteLock,
   ) => Promise<T>,
 ): Promise<T> {
+  const ownsWriteLock =
+    "transaction" in backend && backend.capabilities.transactions;
   return runOptionallyInTransaction(backend, async (target) => {
     const lock =
-      ctx.historyEnabled ?
+      ctx.historyEnabled || ctx.revisionTrackingEnabled ?
         await lockRecordedGraphWrite(target, ctx.graphId)
       : uncapturedGraphWriteLock();
-    return fn(target, lock);
+    const result = await fn(target, lock);
+    // History capture advances the same clock when it flushes its recorded
+    // after-images. Live stores opt into revisions independently, so advance
+    // only there and only after every row/sidecar write succeeded.
+    if (ctx.revisionTrackingEnabled && !ctx.historyEnabled) {
+      await advanceRevisionClock(
+        target,
+        ctx.revisionSchema,
+        ctx.graphId,
+        ownsWriteLock,
+      );
+    }
+    return result;
   });
 }
 

--- a/packages/typegraph/src/store/recorded-capture.ts
+++ b/packages/typegraph/src/store/recorded-capture.ts
@@ -47,8 +47,11 @@ import {
 } from "./recorded-capture/guards";
 
 export {
+  advanceRevisionClock,
+  ensureRevisionOrigin,
   lockRecordedGraphWrite,
   readRecordedClock,
+  readRevisionOrigin,
   recordedClockAdvisoryLockSql,
   recordedGraphWriteAdvisoryLockSql,
   toCanonicalIso,
@@ -56,7 +59,9 @@ export {
 export { closeRecordedHardDeletedKind } from "./recorded-capture/flush";
 export {
   assertRecordedCaptureTransactionIsolation,
+  assertRevisionTrackableBackend,
   createHistoryUnsafeSqlRef,
+  createRevisionTrackingUnsafeSqlRef,
   recordedCaptureRequiresCallbackTransactionError,
   withRecordedRelationsPrecondition,
 } from "./recorded-capture/guards";

--- a/packages/typegraph/src/store/recorded-capture/clock.ts
+++ b/packages/typegraph/src/store/recorded-capture/clock.ts
@@ -1,17 +1,26 @@
 import { type SQL, sql } from "drizzle-orm";
 
-import {
-  type GraphBackend,
-  type TransactionBackend,
-} from "../../backend/types";
+import { type GraphBackend } from "../../backend/types";
 import { RECORDED_MAX } from "../../core/temporal";
 import { ConfigurationError } from "../../errors";
 import { type SqlSchema } from "../../query/compiler/schema";
 import { asCompiledRowsSql } from "../../query/sql-intent";
 import { nowIso } from "../../utils/date";
+import { generateId } from "../../utils/id";
 import { executeStatement } from "./guards";
 
 type ClockRow = Readonly<{ recorded_at: unknown }>;
+type RevisionOriginRow = Readonly<{ origin: unknown }>;
+
+type RecordedClockBackend = Pick<
+  GraphBackend,
+  "dialect" | "execute" | "executeStatement"
+>;
+
+type RevisionOriginBackend = Pick<
+  GraphBackend,
+  "dialect" | "ensureRevisionOriginsTable" | "execute" | "executeStatement"
+>;
 
 /**
  * Floor sentinel used only to seed-and-lock a graph's clock row before the
@@ -134,7 +143,7 @@ export function registerRecordedGraphLockMemo(
 }
 
 async function acquireRecordedGraphWriteLock(
-  target: Pick<TransactionBackend, "execute">,
+  target: Pick<GraphBackend, "execute">,
   graphId: string,
 ): Promise<void> {
   await target.execute(
@@ -143,7 +152,7 @@ async function acquireRecordedGraphWriteLock(
 }
 
 export async function lockRecordedGraphWrite(
-  target: Pick<TransactionBackend, "dialect" | "execute">,
+  target: Pick<GraphBackend, "dialect" | "execute">,
   graphId: string,
   memo?: RecordedGraphLockMemo,
 ): Promise<GraphWriteLock> {
@@ -271,8 +280,77 @@ export async function readRecordedClock(
   return first === undefined ? undefined : toCanonicalIso(first.recorded_at);
 }
 
+/**
+ * Reads the durable, random origin assigned to one graph's revision clock.
+ * The origin namespaces an otherwise timestamp-only revision anchor, so a
+ * branch cannot mistake another store's coincident clock value for its base.
+ */
+export async function readRevisionOrigin(
+  target: Pick<GraphBackend, "execute">,
+  schema: SqlSchema,
+  graphId: string,
+): Promise<string | undefined> {
+  const rows = await target.execute<RevisionOriginRow>(
+    asCompiledRowsSql(sql`
+      SELECT origin
+      FROM ${schema.revisionOriginsTable}
+      WHERE graph_id = ${graphId}
+    `),
+  );
+  const first = rows[0];
+  if (first === undefined) return undefined;
+  if (typeof first.origin !== "string" || first.origin.length === 0) {
+    throw new ConfigurationError(
+      "Revision origin row contained an invalid origin",
+      { graphId, origin: first.origin },
+    );
+  }
+  return first.origin;
+}
+
+/**
+ * Returns a graph's durable revision-origin nonce, creating it exactly once.
+ * The unique graph-id row makes concurrent first readers converge on the
+ * winner's origin rather than manufacturing incompatible anchors.
+ */
+export async function ensureRevisionOrigin(
+  target: RevisionOriginBackend,
+  schema: SqlSchema,
+  graphId: string,
+): Promise<string> {
+  const ensureTable = target.ensureRevisionOriginsTable;
+  if (ensureTable === undefined) {
+    throw new ConfigurationError(
+      "Revision tracking requires a backend that can bootstrap revision origins.",
+      { dialect: target.dialect },
+      {
+        suggestion:
+          "Use a built-in SQLite/PostgreSQL backend, or implement ensureRevisionOriginsTable on the custom backend.",
+      },
+    );
+  }
+  await ensureTable();
+  const existing = await readRevisionOrigin(target, schema, graphId);
+  if (existing !== undefined) return existing;
+
+  await executeStatement(
+    target,
+    sql`
+      INSERT INTO ${schema.revisionOriginsTable} (graph_id, origin)
+      VALUES (${graphId}, ${generateId()})
+      ON CONFLICT (graph_id) DO NOTHING
+    `,
+  );
+  const origin = await readRevisionOrigin(target, schema, graphId);
+  if (origin !== undefined) return origin;
+  throw new ConfigurationError(
+    "Revision origin was not persisted after initialization.",
+    { graphId, dialect: target.dialect },
+  );
+}
+
 async function writeRecordedClock(
-  target: TransactionBackend,
+  target: RecordedClockBackend,
   schema: SqlSchema,
   graphId: string,
   recordedAt: string,
@@ -288,7 +366,7 @@ async function writeRecordedClock(
 }
 
 async function lockRecordedClock(
-  target: TransactionBackend,
+  target: RecordedClockBackend,
   schema: SqlSchema,
   graphId: string,
   ownsWriteLock: boolean,
@@ -323,13 +401,15 @@ async function lockRecordedClock(
 }
 
 export async function allocateRecordedCommit(
-  target: TransactionBackend,
+  target: RecordedClockBackend,
   schema: SqlSchema,
   graphId: string,
   ownsWriteLock: boolean,
+  previousRevision?: string,
 ): Promise<string> {
   await lockRecordedClock(target, schema, graphId, ownsWriteLock);
-  const previous = await readRecordedClock(target, schema, graphId);
+  const previous =
+    previousRevision ?? (await readRecordedClock(target, schema, graphId));
   const recordedCommitTime = nextRecordedCommitTime(previous);
   if (
     !Number.isFinite(recordedCommitTime) ||
@@ -347,4 +427,32 @@ export async function allocateRecordedCommit(
   const recordedCommit = new Date(recordedCommitTime).toISOString();
   await writeRecordedClock(target, schema, graphId, recordedCommit);
   return recordedCommit;
+}
+
+/**
+ * Advances the durable graph revision after a successful live-store write.
+ *
+ * Revision tracking deliberately reuses the monotonic per-graph clock already
+ * owned by recorded-time capture. The write path holds the graph write lock
+ * before this runs. Callers additionally state whether their SQLite
+ * transaction owns the write lock so `allocateRecordedCommit` can skip its
+ * redundant seed-UPSERT only on bundled `BEGIN IMMEDIATE` paths. It preserves
+ * monotonicity even when wall-clock milliseconds repeat. History capture calls
+ * `allocateRecordedCommit` during its own flush instead, so a captured write
+ * remains one revision rather than being advanced twice.
+ */
+export async function advanceRevisionClock(
+  target: RecordedClockBackend,
+  schema: SqlSchema,
+  graphId: string,
+  ownsWriteLock: boolean,
+  previousRevision?: string,
+): Promise<string> {
+  return allocateRecordedCommit(
+    target,
+    schema,
+    graphId,
+    ownsWriteLock,
+    previousRevision,
+  );
 }

--- a/packages/typegraph/src/store/recorded-capture/guards.ts
+++ b/packages/typegraph/src/store/recorded-capture/guards.ts
@@ -47,10 +47,10 @@ export function requireRecordedSchema(
  * backend's transaction target can differ from it.
  */
 export function requireCaptureStatements(
-  target: TransactionBackend,
-): asserts target is TransactionBackend &
+  target: Pick<GraphBackend, "dialect" | "executeStatement">,
+): asserts target is Pick<GraphBackend, "dialect" | "executeStatement"> &
   Readonly<{
-    executeStatement: NonNullable<TransactionBackend["executeStatement"]>;
+    executeStatement: NonNullable<GraphBackend["executeStatement"]>;
   }> {
   if (target.executeStatement === undefined) {
     throw new ConfigurationError(
@@ -65,7 +65,7 @@ export function requireCaptureStatements(
 }
 
 export async function executeStatement(
-  target: TransactionBackend,
+  target: Pick<GraphBackend, "dialect" | "executeStatement">,
   query: SQL,
 ): Promise<void> {
   requireCaptureStatements(target);
@@ -163,8 +163,25 @@ function historyUnsafeRawWriteError(surface: string): ConfigurationError {
   );
 }
 
+function revisionTrackingUnsafeRawWriteError(
+  surface: string,
+): ConfigurationError {
+  return new ConfigurationError(
+    `${surface} is not available when revision tracking is enabled because raw SQL writes bypass the revision anchor.`,
+    { code: "REVISION_TRACKING_RAW_SQL_DISABLED" },
+    {
+      suggestion:
+        "Run graph writes through store.nodes/store.edges (or tx.nodes/tx.edges inside a transaction), so TypeGraph can advance the revision anchor.",
+    },
+  );
+}
+
 function failHistoryUnsafeSqlRef(): never {
   throw historyUnsafeRawWriteError("tx.sql");
+}
+
+function failRevisionTrackingUnsafeSqlRef(): never {
+  throw revisionTrackingUnsafeRawWriteError("tx.sql");
 }
 
 /**
@@ -175,40 +192,53 @@ function failHistoryUnsafeSqlRef(): never {
  * capture.
  */
 export function createHistoryUnsafeSqlRef(): AdoptedTransaction {
+  return createUnsafeSqlRef(failHistoryUnsafeSqlRef);
+}
+
+/**
+ * A fail-loud replacement for `tx.sql` on a revision-tracked live store. It
+ * deliberately names revision tracking rather than history capture so callers
+ * see the invariant their store actually enabled.
+ */
+export function createRevisionTrackingUnsafeSqlRef(): AdoptedTransaction {
+  return createUnsafeSqlRef(failRevisionTrackingUnsafeSqlRef);
+}
+
+function createUnsafeSqlRef(fail: () => never): AdoptedTransaction {
   return new Proxy(
-    function historyUnsafeSqlRef(): never {
-      return failHistoryUnsafeSqlRef();
+    function unsafeSqlRef(): never {
+      return fail();
     },
     {
       get(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       apply(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       set(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       defineProperty(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       deleteProperty(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       // Enumeration / inspection traps too, so spreading (`{...tx.sql}`),
       // `Object.keys`, `in`, and prototype reads also fail loudly rather than
       // silently yielding an empty object that reads as "no raw handle".
       has(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       ownKeys(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       getOwnPropertyDescriptor(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
       getPrototypeOf(): never {
-        return failHistoryUnsafeSqlRef();
+        return fail();
       },
     },
   ) as unknown as AdoptedTransaction;
@@ -287,6 +317,54 @@ export function assertCapturableBackend(backend: GraphBackend): void {
       {
         suggestion:
           "Use a built-in SQLite/PostgreSQL backend, or set tableNames on the custom backend so recorded-time capture can resolve the recorded relations instead of silently falling back to defaults.",
+      },
+    );
+  }
+}
+
+/**
+ * Verifies the narrower backend contract for live-store revision tracking.
+ * Unlike recorded-time history, a revision anchor does not capture after-images
+ * and therefore does not require `UPDATE … RETURNING`.
+ */
+export function assertRevisionTrackableBackend(backend: GraphBackend): void {
+  if (!backend.capabilities.transactions) {
+    throw new ConfigurationError(
+      "revisionTracking: true requires a backend with transaction support.",
+      { dialect: backend.dialect },
+      {
+        suggestion:
+          "Use a transactional SQLite/PostgreSQL backend or leave revision tracking disabled.",
+      },
+    );
+  }
+  if (backend.executeStatement === undefined) {
+    throw new ConfigurationError(
+      "revisionTracking: true requires a backend that supports executeStatement.",
+      { dialect: backend.dialect },
+      {
+        suggestion:
+          "Use a built-in SQLite/PostgreSQL backend, or implement executeStatement so TypeGraph can advance the revision clock.",
+      },
+    );
+  }
+  if (backend.tableNames === undefined) {
+    throw new ConfigurationError(
+      "revisionTracking: true requires a backend that exposes tableNames.",
+      { dialect: backend.dialect },
+      {
+        suggestion:
+          "Use a built-in SQLite/PostgreSQL backend, or set tableNames so TypeGraph can address the revision clock relation.",
+      },
+    );
+  }
+  if (backend.ensureRevisionOriginsTable === undefined) {
+    throw new ConfigurationError(
+      "revisionTracking: true requires a backend that can bootstrap revision origins.",
+      { dialect: backend.dialect },
+      {
+        suggestion:
+          "Use a built-in SQLite/PostgreSQL backend, or implement ensureRevisionOriginsTable so TypeGraph can durably namespace revision anchors.",
       },
     );
   }

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -153,10 +153,14 @@ import {
   type NodeOperationContext,
 } from "./operations";
 import {
+  advanceRevisionClock,
   assertRecordedCaptureTransactionIsolation,
+  assertRevisionTrackableBackend,
   createHistoryUnsafeSqlRef,
   createRecordedBackend,
   createRecordedTransactionScope,
+  createRevisionTrackingUnsafeSqlRef,
+  ensureRevisionOrigin,
   lockRecordedGraphWrite,
   readRecordedClock,
   recordedCaptureRequiresCallbackTransactionError,
@@ -370,6 +374,8 @@ export class Store<G extends GraphDef> {
   readonly #baseBackend: RawBackend;
   readonly #backend: GraphWriteBackend;
   readonly #captureEnabled: boolean;
+  readonly #revisionTrackingEnabled: boolean;
+  #revisionOrigin: Promise<string> | undefined;
   readonly #recordedReadBinding: RecordedReadBinding | undefined;
   readonly #registry: KindRegistry;
   readonly #hooks: StoreHooks;
@@ -396,6 +402,11 @@ export class Store<G extends GraphDef> {
     this.#graph = graph;
     this.#baseBackend = asRawBackend(backend);
     this.#captureEnabled = options?.history === true;
+    this.#revisionTrackingEnabled =
+      this.#captureEnabled || options?.revisionTracking === true;
+    if (this.#revisionTrackingEnabled) {
+      assertRevisionTrackableBackend(backend);
+    }
     // Resolve the schema before wrapping so recorded-time capture targets the
     // same relations recorded reads do (the explicit `schema` option, not just
     // `backend.tableNames`).
@@ -474,6 +485,24 @@ export class Store<G extends GraphDef> {
    */
   get historyEnabled(): boolean {
     return this.#captureEnabled;
+  }
+
+  /**
+   * Whether this Store advances a durable revision anchor for graph writes.
+   *
+   * @internal
+   */
+  get revisionTrackingEnabled(): boolean {
+    return this.#revisionTrackingEnabled;
+  }
+
+  /**
+   * SQL schema that owns the durable revision clock relation.
+   *
+   * @internal
+   */
+  get revisionSchema(): SqlSchema {
+    return this.#sqlSchema();
   }
 
   /**
@@ -1115,6 +1144,51 @@ export class Store<G extends GraphDef> {
   }
 
   /**
+   * Returns the durable graph revision used by graph branching. It is undefined
+   * until the first successful tracked write, which is itself a stable initial
+   * anchor. Unlike {@link recordedNow}, this is also available on a live Store
+   * created with `{ revisionTracking: true }`.
+   *
+   * @internal
+   */
+  async revisionNow(): Promise<string | undefined> {
+    if (!this.#revisionTrackingEnabled) return undefined;
+    return readRecordedClock(this.#backend, this.#sqlSchema(), this.graphId);
+  }
+
+  /**
+   * Returns the durable random namespace for this graph's revision clock. A
+   * tracked base token combines it with {@link revisionNow}, preventing a
+   * branch from one independent store from matching a coincident timestamp in
+   * another store.
+   *
+   * @internal
+   */
+  async revisionOriginNow(): Promise<string> {
+    if (!this.#revisionTrackingEnabled) {
+      throw new ConfigurationError(
+        "revisionOriginNow() requires revisionTracking: true or history: true.",
+        { code: "REVISION_ORIGIN_REQUIRES_TRACKING" },
+      );
+    }
+    const pendingOrigin =
+      this.#revisionOrigin ??
+      ensureRevisionOrigin(this.#baseBackend, this.#sqlSchema(), this.graphId);
+    this.#revisionOrigin = pendingOrigin;
+    try {
+      return await pendingOrigin;
+    } catch (error) {
+      // A transient DDL/connection failure must not permanently poison this
+      // Store's cached initialization promise. Preserve a newer in-flight
+      // attempt if another caller replaced it before this rejection arrived.
+      if (this.#revisionOrigin === pendingOrigin) {
+        this.#revisionOrigin = undefined;
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Returns a read-only {@link StoreView} pinned to an arbitrary public
    * temporal mode. Use {@link Store.asOf} for the common valid-time case;
    * reach for `view` to pin `"current"`, `"includeEnded"`, or
@@ -1381,9 +1455,10 @@ export class Store<G extends GraphDef> {
    *   {@link Store.withTransaction}). See {@link TransactionContext}
    *   for per-backend semantics; it is `undefined` only on the
    *   non-transactional fallback.
-   *   When the store was created with `{ history: true }`, `tx.sql` is
-   *   replaced by a fail-loud guard because raw SQL would bypass
-   *   recorded-time capture; use the typed collections inside
+   *   When the store was created with `{ history: true }` or
+   *   `{ revisionTracking: true }`, `tx.sql` is replaced by a fail-loud guard
+   *   because raw SQL would bypass recorded-time capture or revision tracking;
+   *   use the typed collections inside
    *   `transaction()` or {@link Store.withRecordedTransaction}.
    *
    * @example
@@ -1859,7 +1934,10 @@ export class Store<G extends GraphDef> {
         runNodeOperationHooks,
       };
     }
-    const exposedSql = this.#captureEnabled ? createHistoryUnsafeSqlRef() : sql;
+    const exposedSql =
+      this.#captureEnabled ? createHistoryUnsafeSqlRef()
+      : this.#revisionTrackingEnabled ? createRevisionTrackingUnsafeSqlRef()
+      : sql;
     return {
       nodes,
       edges,
@@ -1885,7 +1963,29 @@ export class Store<G extends GraphDef> {
     const doClear = async (
       target: GraphBackend | TransactionBackend,
     ): Promise<void> => {
+      if (this.#revisionTrackingEnabled) {
+        await lockRecordedGraphWrite(target, this.graphId);
+      }
+      const previousRevision =
+        this.#revisionTrackingEnabled && !this.#captureEnabled ?
+          await readRecordedClock(target, this.#sqlSchema(), this.graphId)
+        : undefined;
       await target.clearGraph(this.graphId);
+      // `clearGraph` deletes the recorded-clock row alongside graph data.
+      // Live revision tracking immediately seeds a fresh anchor so a pre-clear
+      // branch cannot match a now-empty graph. History capture intentionally
+      // preserves its long-standing `recordedNow() === undefined` clear
+      // contract; a pre-clear history branch already carries a non-empty clock
+      // value and therefore still fails the base-version precondition.
+      if (this.#revisionTrackingEnabled && !this.#captureEnabled) {
+        await advanceRevisionClock(
+          target,
+          this.#sqlSchema(),
+          this.graphId,
+          this.#baseBackend.capabilities.transactions,
+          previousRevision,
+        );
+      }
     };
 
     await (this.#baseBackend.capabilities.transactions ?
@@ -2784,6 +2884,8 @@ export class Store<G extends GraphDef> {
       graph: this.#graph,
       graphId: this.graphId,
       historyEnabled: this.#captureEnabled,
+      revisionTrackingEnabled: this.#revisionTrackingEnabled,
+      revisionSchema: this.#sqlSchema(),
       registry: this.#registry,
       createOperationContext: (operation, entity, kind, id) =>
         this.#createOperationContext(operation, entity, kind, id),
@@ -2798,6 +2900,8 @@ export class Store<G extends GraphDef> {
       graph: this.#graph,
       graphId: this.graphId,
       historyEnabled: this.#captureEnabled,
+      revisionTrackingEnabled: this.#revisionTrackingEnabled,
+      revisionSchema: this.#sqlSchema(),
       registry: this.#registry,
       createOperationContext: (operation, entity, kind, id) =>
         this.#createOperationContext(operation, entity, kind, id),

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -317,6 +317,25 @@ type BaseStoreOptions = Readonly<{
   /** Observability hooks for monitoring */
   hooks?: StoreHooks;
   /**
+   * Maintain a durable, graph-wide revision anchor for TypeGraph writes:
+   * a random per-graph origin plus a monotonic revision clock. `branch()` uses
+   * this anchor to validate that its base has not moved without
+   * re-fingerprinting every live row, and cannot confuse a coincident clock in
+   * a separately created store for its original base. `history: true` enables
+   * the same tracking automatically through its recorded-time commit clock.
+   *
+   * This is intentionally opt-in for live stores: each successful graph write
+   * advances the anchor inside its write transaction. On PostgreSQL, those
+   * transactions take a graph-scoped advisory lock until commit; writes to the
+   * same graph therefore serialize. Enable it for branchable graphs, but size
+   * high-throughput multi-writer workloads for that trade-off.
+   *
+   * Writes performed directly through a backend — including raw graph-table
+   * writes through `tx.sql` — bypass the anchor and are outside the
+   * revision-tracking contract.
+   */
+  revisionTracking?: boolean;
+  /**
    * Automatic planner-statistics refresh after large autocommit bulk
    * writes (bulkCreate and bulkInsert on nodes and edges). Stale statistics after a
    * bulk load are a whole class of planner cliffs: the planner keeps
@@ -1420,9 +1439,10 @@ export type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
  * Its type is the `AdoptedTransaction` union; cast to your concrete
  * Drizzle database type at the call site.
  *
- * When the store was created with `{ history: true }`, `tx.sql` is present but
- * replaced by a fail-loud guard because raw SQL would bypass recorded-time
- * capture. Use the typed `tx.nodes` / `tx.edges` collections inside
+ * When the store was created with `{ history: true }` or
+ * `{ revisionTracking: true }`, `tx.sql` is present but replaced by a fail-loud
+ * guard because raw SQL would bypass recorded-time capture or the revision
+ * anchor. Use the typed `tx.nodes` / `tx.edges` collections inside
  * `transaction()`, or use `store.withRecordedTransaction(externalTx, fn)` when
  * the relational layer owns the transaction boundary.
  *

--- a/packages/typegraph/test-d/interchange.test-d.ts
+++ b/packages/typegraph/test-d/interchange.test-d.ts
@@ -1,0 +1,30 @@
+import { expectError, expectType } from "tsd";
+import { z } from "zod";
+
+import { defineGraph, defineNode, type Store } from "..";
+import {
+  exportGraphStream,
+  type GraphInterchangeChunk,
+  importGraphStream,
+  type ImportResult,
+} from "../dist/interchange";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "interchange_type_test",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+declare const store: Store<typeof graph>;
+
+const stream = exportGraphStream(store, { batchSize: 100 });
+expectType<AsyncIterable<GraphInterchangeChunk>>(stream);
+expectError(exportGraphStream(store, { batchSize: "100" }));
+
+expectType<Promise<ImportResult>>(
+  importGraphStream(store, stream, { onConflict: "error" }),
+);

--- a/packages/typegraph/test-d/public-api.test-d.ts
+++ b/packages/typegraph/test-d/public-api.test-d.ts
@@ -246,6 +246,9 @@ expectType<true>(historyStore.historyEnabled);
 expectType<true>(historyStore.recordedReadBound);
 expectAssignable<HistorySafeBackend>(historyStore.backend);
 
+const revisionStore = createStore(graph, backend, { revisionTracking: true });
+expectType<boolean>(revisionStore.revisionTrackingEnabled);
+
 // `history: true` means TypeGraph owns capture; external recorded bindings are
 // read-only sources and cannot be confused with built-in write capture.
 expectError(

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -117,6 +117,7 @@ async function setupTestDatabase(): Promise<void> {
   if (!sharedPool) return;
 
   await sharedPool.query(`
+    DROP TABLE IF EXISTS typegraph_revision_origins CASCADE;
     DROP TABLE IF EXISTS typegraph_recorded_clock CASCADE;
     DROP TABLE IF EXISTS typegraph_recorded_edges CASCADE;
     DROP TABLE IF EXISTS typegraph_recorded_nodes CASCADE;
@@ -173,6 +174,7 @@ async function clearTestData(): Promise<void> {
               typegraph_kind_removals,
               typegraph_reconciliation_markers,
               typegraph_node_fulltext,
+              typegraph_revision_origins,
               typegraph_recorded_clock,
               typegraph_recorded_nodes,
               typegraph_recorded_edges,

--- a/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
@@ -99,6 +99,7 @@ async function clearTestData(): Promise<void> {
               typegraph_kind_removals,
               typegraph_reconciliation_markers,
               typegraph_node_fulltext,
+              typegraph_revision_origins,
               typegraph_recorded_clock,
               typegraph_recorded_nodes,
               typegraph_recorded_edges,

--- a/packages/typegraph/tests/backends/postgres/provenance-advisory-lock.test.ts
+++ b/packages/typegraph/tests/backends/postgres/provenance-advisory-lock.test.ts
@@ -71,6 +71,7 @@ beforeAll(async () => {
   try {
     await candidate.query("SELECT 1");
     await candidate.query(`
+      DROP TABLE IF EXISTS typegraph_revision_origins CASCADE;
       DROP TABLE IF EXISTS typegraph_recorded_clock CASCADE;
       DROP TABLE IF EXISTS typegraph_recorded_edges CASCADE;
       DROP TABLE IF EXISTS typegraph_recorded_nodes CASCADE;
@@ -102,7 +103,8 @@ afterAll(async () => {
 beforeEach(async () => {
   if (pool === undefined) return;
   await pool.query(
-    `TRUNCATE typegraph_recorded_clock,
+    `TRUNCATE typegraph_revision_origins,
+              typegraph_recorded_clock,
               typegraph_recorded_edges,
               typegraph_recorded_nodes,
               typegraph_node_uniques,

--- a/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
+++ b/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
@@ -48,6 +48,7 @@ beforeAll(async () => {
   try {
     await candidate.query("SELECT 1");
     await candidate.query(`
+      DROP TABLE IF EXISTS typegraph_revision_origins CASCADE;
       DROP TABLE IF EXISTS typegraph_recorded_clock CASCADE;
       DROP TABLE IF EXISTS typegraph_recorded_edges CASCADE;
       DROP TABLE IF EXISTS typegraph_recorded_nodes CASCADE;

--- a/packages/typegraph/tests/custom-table-names.test.ts
+++ b/packages/typegraph/tests/custom-table-names.test.ts
@@ -50,6 +50,7 @@ describe("custom table names", () => {
     recordedNodes: "app_recorded_nodes",
     recordedEdges: "app_recorded_edges",
     recordedClock: "app_recorded_clock",
+    revisionOrigins: "app_revision_origins",
     fulltext: "app_fulltext",
     uniques: "app_uniques",
   } as const;
@@ -63,6 +64,7 @@ describe("custom table names", () => {
       recordedNodes: CUSTOM_NAMES.recordedNodes,
       recordedEdges: CUSTOM_NAMES.recordedEdges,
       recordedClock: CUSTOM_NAMES.recordedClock,
+      revisionOrigins: CUSTOM_NAMES.revisionOrigins,
       fulltext: CUSTOM_NAMES.fulltext,
       uniques: CUSTOM_NAMES.uniques,
     });
@@ -159,6 +161,7 @@ describe("custom table names", () => {
       recordedNodes: "typegraph_recorded_nodes",
       recordedEdges: "typegraph_recorded_edges",
       recordedClock: "typegraph_recorded_clock",
+      revisionOrigins: "typegraph_revision_origins",
       fulltext: "typegraph_node_fulltext",
       uniques: "typegraph_node_uniques",
     });

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 
 import { rowPropsToObject } from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
 import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
 import {
   enumerateAllEdges,
@@ -201,6 +202,50 @@ describe.each(backendMatrix())("branch [$name]", (entry) => {
       "Dave (A only)",
     ]);
     expect(await snapshotEdges(branchA.store)).toHaveLength(0);
+  });
+
+  it("uses a revision anchor through branch validation and merge commit", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      graph,
+      await makeBackend(),
+      { revisionTracking: true },
+    );
+    const fork = await branch<G>(baseStore, () => makeBackend());
+    expect(isOk(fork)).toBe(true);
+    if (!isOk(fork)) throw fork.error;
+    const forkBranch = unwrap(fork);
+    expect(forkBranch.base).toContain("\0revision:");
+    expect(forkBranch.store.revisionTrackingEnabled).toBe(true);
+
+    await forkBranch.store.nodes.Person.create({ name: "From fork" });
+    const firstMerge = await merge(baseStore, [forkBranch], {});
+    expect(isOk(firstMerge)).toBe(true);
+    expect(
+      (await baseStore.nodes.Person.find()).map((node) => node.name),
+    ).toEqual(["From fork"]);
+
+    // The successful merge advanced the target's anchor, so a stale branch
+    // cannot be applied twice.
+    const secondMerge = await merge(baseStore, [forkBranch], {});
+    expect(isErr(secondMerge)).toBe(true);
+  });
+
+  it("uses the recorded-time clock as the revision anchor for history stores", async () => {
+    const [baseStore] = await createStoreWithSchema(
+      graph,
+      await makeBackend(),
+      { history: true },
+    );
+    const forkResult = await branch<G>(baseStore, () => makeBackend());
+    expect(isOk(forkResult)).toBe(true);
+    if (!isOk(forkResult)) throw forkResult.error;
+    const fork = unwrap(forkResult);
+    expect(fork.base).toContain("\0revision:");
+
+    await fork.store.nodes.Person.create({ name: "History fork" });
+    const result = await merge(baseStore, [fork], {});
+    expect(isOk(result)).toBe(true);
+    expect(await baseStore.recordedNow()).toBeDefined();
   });
 
   it("preserves the base's exact validFrom on the clone, even when it was never set explicitly", async () => {

--- a/packages/typegraph/tests/graph-merge/commit-revalidation.test.ts
+++ b/packages/typegraph/tests/graph-merge/commit-revalidation.test.ts
@@ -23,9 +23,14 @@ import {
   defineGraph,
   defineNode,
 } from "@nicia-ai/typegraph";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
+import {
+  computeBaseVersion,
+  revisionAnchorOf,
+  revisionOriginOf,
+} from "../../src/graph-merge/base-version";
 import { branch } from "../../src/graph-merge/branch";
 import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
 import { merge, mergeAgainstBase } from "../../src/graph-merge/merge";
@@ -122,7 +127,9 @@ describe.each(backendMatrix())(
     }
 
     /** Base with one anchor patient plus a branch that adds two more. */
-    async function seedScenario(): Promise<
+    async function seedScenario(
+      options?: Readonly<{ history?: boolean; revisionTracking?: boolean }>,
+    ): Promise<
       Readonly<{
         baseStore: Store<DriftGraph>;
         branchA: GraphBranch<DriftGraph>;
@@ -131,6 +138,7 @@ describe.each(backendMatrix())(
       const [baseStore] = await createStoreWithSchema(
         driftGraph,
         await makeBackend(),
+        options,
       );
       await baseStore.nodes.Patient.bulkCreate([
         {
@@ -194,6 +202,78 @@ describe.each(backendMatrix())(
         "pat-base",
         "pat-drift",
       ]);
+    });
+
+    it.each([
+      { name: "revision tracking", options: { revisionTracking: true } },
+      { name: "recorded history", options: { history: true } },
+    ])(
+      "rechecks the durable anchor inside the commit transaction for $name",
+      async ({ options }) => {
+        const { baseStore, branchA } = await seedScenario(options);
+
+        const result = await merge<DriftGraph>(
+          baseStore,
+          [branchA],
+          revalidationMergeOptions(driftingEmbedder(baseStore)),
+        );
+
+        expect(isErr(result)).toBe(true);
+        if (isErr(result)) {
+          expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+          expect(result.error.message).toContain(
+            "modified between the revision-anchor check and the commit transaction",
+          );
+        }
+        expect(await livePatientIds(baseStore)).toEqual([
+          "pat-base",
+          "pat-drift",
+        ]);
+      },
+    );
+
+    it("rejects a branch from another store when their revision timestamps coincide", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      try {
+        const [source] = await createStoreWithSchema(
+          driftGraph,
+          await makeBackend(),
+          { revisionTracking: true },
+        );
+        await source.nodes.Patient.create({
+          name: "Same content",
+          birthDate: "2000-01-01",
+        });
+        const foreignBranch = await makeBranch(source, BRANCH_A);
+
+        const [target] = await createStoreWithSchema(
+          driftGraph,
+          await makeBackend(),
+          { revisionTracking: true },
+        );
+        await target.nodes.Patient.create({
+          name: "Same content",
+          birthDate: "2000-01-01",
+        });
+
+        const targetVersion = await computeBaseVersion(target);
+        expect(revisionAnchorOf(targetVersion)).toBe(
+          revisionAnchorOf(foreignBranch.base),
+        );
+        expect(revisionOriginOf(targetVersion)).not.toBe(
+          revisionOriginOf(foreignBranch.base),
+        );
+
+        const result = await merge(target, [foreignBranch]);
+        expect(isErr(result)).toBe(true);
+        if (isErr(result)) {
+          expect(result.error).toBeInstanceOf(BaseVersionMismatchError);
+        }
+        expect(await livePatientIds(target)).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("commits normally when no write lands in the window (control)", async () => {

--- a/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
@@ -144,6 +144,15 @@ describe.each(backendMatrix())(
       return store;
     }
 
+    async function historyStore(): Promise<CareStore> {
+      const [store] = await createStoreWithSchema(
+        careGraph,
+        await makeBackend(),
+        { history: true },
+      );
+      return store;
+    }
+
     async function forkOf(
       forkPoint: CareStore,
     ): Promise<GraphBranch<CareGraph>> {
@@ -169,6 +178,32 @@ describe.each(backendMatrix())(
       ]);
       return edge!;
     }
+
+    it("commits an incremental merge into a history-backed target", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Patient.bulkCreate([
+        {
+          id: "new-ana",
+          props: { name: "Ana Rivera", mrn: "MRN-1" },
+        },
+      ]);
+      const target = await historyStore();
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+
+      expect(isOk(result)).toBe(true);
+      expect(await target.nodes.Patient.find()).toMatchObject([
+        { id: "new-ana", name: "Ana Rivera", mrn: "MRN-1" },
+      ]);
+      expect(await target.recordedNow()).toBeDefined();
+    });
 
     it("HAPPY PATH: resolves a branch addition onto an advanced target's base entity", async () => {
       cleanups = [];

--- a/packages/typegraph/tests/graph-merge/state-diff.test.ts
+++ b/packages/typegraph/tests/graph-merge/state-diff.test.ts
@@ -6,10 +6,15 @@ import {
   defineNode,
 } from "@nicia-ai/typegraph";
 import { exportGraph, importGraph } from "@nicia-ai/typegraph/interchange";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
-import { computeBaseVersion } from "../../src/graph-merge/base-version";
+import {
+  computeBaseVersion,
+  hasRevisionAnchor,
+  revisionAnchorOf,
+  revisionOriginOf,
+} from "../../src/graph-merge/base-version";
 import {
   diffAgainstBase,
   enumerateAllEdges,
@@ -282,5 +287,98 @@ describe.each(backendMatrix())("computeBaseVersion [$name]", (entry) => {
     // Live content is back to just `keep`, so the fingerprint returns to baseline.
     expect(await computeBaseVersion(store)).toBe(baseline);
     expect(keep.id).toBeDefined();
+  });
+
+  it("uses an O(1) durable revision anchor when revision tracking is enabled", async () => {
+    const rawBackend = await makeBackend();
+    let entityEnumerationCalls = 0;
+    const backend = new Proxy(rawBackend, {
+      get(target, property, receiver) {
+        if (property === "findNodesByKind") {
+          const findNodesByKind = target.findNodesByKind.bind(target);
+          return async (
+            ...args: Parameters<GraphBackend["findNodesByKind"]>
+          ) => {
+            entityEnumerationCalls++;
+            return findNodesByKind(...args);
+          };
+        }
+        if (property === "findEdgesByKind") {
+          const findEdgesByKind = target.findEdgesByKind.bind(target);
+          return async (
+            ...args: Parameters<GraphBackend["findEdgesByKind"]>
+          ) => {
+            entityEnumerationCalls++;
+            return findEdgesByKind(...args);
+          };
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const [store] = await createStoreWithSchema(graph, backend, {
+      revisionTracking: true,
+    });
+
+    const initial = await computeBaseVersion(store);
+    expect(hasRevisionAnchor(initial)).toBe(true);
+    expect(revisionAnchorOf(initial)).toBeUndefined();
+    expect(entityEnumerationCalls).toBe(0);
+
+    const node = await store.nodes.Person.create({ name: "Alice" });
+    entityEnumerationCalls = 0;
+    const afterCreate = await computeBaseVersion(store);
+    expect(hasRevisionAnchor(afterCreate)).toBe(true);
+    expect(revisionAnchorOf(afterCreate)).toBeDefined();
+    expect(afterCreate).not.toBe(initial);
+    expect(entityEnumerationCalls).toBe(0);
+
+    await store.nodes.Person.update(node.id, { name: "Alice Renamed" });
+    const afterUpdate = await computeBaseVersion(store);
+    expect(afterUpdate).not.toBe(afterCreate);
+    expect(revisionAnchorOf(afterUpdate)).not.toBe(
+      revisionAnchorOf(afterCreate),
+    );
+
+    await store.clear();
+    const afterClear = await computeBaseVersion(store);
+    expect(afterClear).not.toBe(afterUpdate);
+    expect(revisionAnchorOf(afterClear)).toBeDefined();
+  });
+
+  it("bootstraps revision origins for an existing tracked-store schema", async () => {
+    const backend = await makeBackend();
+    const [store] = await createStoreWithSchema(graph, backend, {
+      revisionTracking: true,
+    });
+    if (backend.executeDdl === undefined) {
+      throw new Error("Backend matrix entries must expose executeDdl");
+    }
+    await backend.executeDdl(
+      `DROP TABLE "${store.revisionSchema.tables.revisionOrigins}"`,
+    );
+
+    const baseVersion = await computeBaseVersion(store);
+    expect(revisionOriginOf(baseVersion)).toBeDefined();
+  });
+
+  it("keeps the revision anchor monotonic when clear reseeds under a frozen clock", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    try {
+      const [store] = await createStoreWithSchema(graph, await makeBackend(), {
+        revisionTracking: true,
+      });
+      await store.nodes.Person.create({ name: "Alice" });
+      const beforeClear = revisionAnchorOf(await computeBaseVersion(store));
+
+      await store.clear();
+      const afterClear = revisionAnchorOf(await computeBaseVersion(store));
+
+      expect(afterClear).toBeDefined();
+      expect(Date.parse(afterClear!)).toBeGreaterThan(Date.parse(beforeClear!));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/typegraph/tests/interchange.test.ts
+++ b/packages/typegraph/tests/interchange.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests that graphs can be exported and imported while preserving data integrity.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import { defineEdge, defineGraph, defineNode } from "../src";
@@ -11,8 +11,11 @@ import type { GraphBackend } from "../src/backend/types";
 import { UniquenessError } from "../src/errors";
 import {
   exportGraph,
+  exportGraphStream,
   type GraphData,
+  type GraphInterchangeChunk,
   importGraph,
+  importGraphStream,
   ImportOptionsSchema,
   InterchangeEdgeSchema,
   InterchangeNodeSchema,
@@ -85,6 +88,25 @@ function importOptions(
   return ImportOptionsSchema.parse(overrides);
 }
 
+async function collectChunks(
+  chunks: AsyncIterable<GraphInterchangeChunk>,
+): Promise<GraphInterchangeChunk[]> {
+  const collected: GraphInterchangeChunk[] = [];
+  for await (const chunk of chunks) {
+    collected.push(chunk);
+  }
+  return collected;
+}
+
+async function* chunkStream(
+  chunks: readonly GraphInterchangeChunk[],
+): AsyncIterable<GraphInterchangeChunk> {
+  for (const chunk of chunks) {
+    await Promise.resolve();
+    yield chunk;
+  }
+}
+
 // ============================================================
 // Round-Trip Tests
 // ============================================================
@@ -118,6 +140,185 @@ describe("Interchange Round-Trip", () => {
     expect(result.success).toBe(true);
     expect(result.nodes.created).toBe(0);
     expect(result.edges.created).toBe(0);
+  });
+
+  it("streams bounded header, node, and edge chunks before importing them", async () => {
+    const alice = await sourceStore.nodes.Person.create({ name: "Alice" });
+    const bob = await sourceStore.nodes.Person.create({ name: "Bob" });
+    const acme = await sourceStore.nodes.Company.create({ name: "Acme" });
+    await sourceStore.edges.knows.create(alice, bob, { since: "2020" });
+    await sourceStore.edges.worksAt.create(alice, acme, { role: "Engineer" });
+
+    const chunks = await collectChunks(
+      exportGraphStream(sourceStore, { batchSize: 1 }),
+    );
+    expect(chunks.map((chunk) => chunk.type)).toEqual([
+      "header",
+      "nodes",
+      "nodes",
+      "nodes",
+      "edges",
+      "edges",
+    ]);
+    expect(
+      chunks
+        .filter((chunk) => chunk.type === "nodes")
+        .map((chunk) => chunk.nodes),
+    ).toEqual([[expect.anything()], [expect.anything()], [expect.anything()]]);
+    expect(
+      chunks
+        .filter((chunk) => chunk.type === "edges")
+        .map((chunk) => chunk.edges),
+    ).toEqual([[expect.anything()], [expect.anything()]]);
+
+    const targetStore = createStore(testGraph, createTestBackend());
+    const result = await importGraphStream(
+      targetStore,
+      exportGraphStream(sourceStore, { batchSize: 1 }),
+      importOptions({ onConflict: "error" }),
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      nodes: { created: 3, updated: 0, skipped: 0 },
+      edges: { created: 2, updated: 0, skipped: 0 },
+      errors: [],
+    });
+    expect(await targetStore.nodes.Person.getById(alice.id)).toMatchObject({
+      name: "Alice",
+    });
+  });
+
+  it("rejects malformed streamed-chunk ordering before it writes later chunks", async () => {
+    const [headerChunk] = await collectChunks(exportGraphStream(sourceStore));
+    if (headerChunk?.type !== "header") {
+      throw new Error("Expected the export stream to start with a header.");
+    }
+    const header = headerChunk.header;
+    const targetStore = createStore(testGraph, createTestBackend());
+
+    await expect(
+      importGraphStream(
+        targetStore,
+        chunkStream([
+          { type: "header", header },
+          { type: "edges", edges: [] },
+          { type: "nodes", nodes: [] },
+        ]),
+        importOptions({ onConflict: "error" }),
+      ),
+    ).rejects.toThrow("cannot emit nodes after edges");
+  });
+
+  it("rejects streams with missing or duplicate headers before importing rows", async () => {
+    const [headerChunk] = await collectChunks(exportGraphStream(sourceStore));
+    if (headerChunk?.type !== "header") {
+      throw new Error("Expected the export stream to start with a header.");
+    }
+    const header = headerChunk.header;
+
+    await expect(
+      importGraphStream(
+        createStore(testGraph, createTestBackend()),
+        chunkStream([{ type: "nodes", nodes: [] }]),
+        importOptions({ onConflict: "error" }),
+      ),
+    ).rejects.toThrow("must start with a header");
+    await expect(
+      importGraphStream(
+        createStore(testGraph, createTestBackend()),
+        chunkStream([
+          { type: "header", header },
+          { type: "header", header },
+        ]),
+        importOptions({ onConflict: "error" }),
+      ),
+    ).rejects.toThrow("more than one header");
+  });
+
+  it("rejects streams that end before emitting a header", async () => {
+    await expect(
+      importGraphStream(
+        createStore(testGraph, createTestBackend()),
+        chunkStream([]),
+        importOptions({ onConflict: "error" }),
+      ),
+    ).rejects.toThrow("ended before emitting a header");
+  });
+
+  it("aborts a streamed import on the first entity error unless best-effort is explicit", async () => {
+    const alice = await sourceStore.nodes.Person.create({ name: "Alice" });
+    const chunks = await collectChunks(exportGraphStream(sourceStore));
+    const header = chunks[0];
+    if (header?.type !== "header") throw new Error("Expected stream header.");
+    const duplicate = chunks.find((chunk) => chunk.type === "nodes");
+    if (duplicate?.type !== "nodes") throw new Error("Expected node chunk.");
+
+    const targetStore = createStore(testGraph, createTestBackend());
+    await expect(
+      importGraphStream(
+        targetStore,
+        chunkStream([
+          { type: "header", header: header.header },
+          duplicate,
+          duplicate,
+        ]),
+        importOptions({ onConflict: "error" }),
+      ),
+    ).rejects.toThrow("stream aborted after a chunk reported import errors");
+    expect(await targetStore.nodes.Person.getById(alice.id)).toBeDefined();
+  });
+
+  it.each(["skip", "update"] as const)(
+    "aggregates %s conflicts across streamed chunks",
+    async (onConflict) => {
+      await sourceStore.nodes.Person.create({ name: "Alice" });
+      const chunks = await collectChunks(exportGraphStream(sourceStore));
+      const [header, nodes] = chunks;
+      if (header?.type !== "header" || nodes?.type !== "nodes") {
+        throw new Error("Expected a header followed by a node chunk.");
+      }
+
+      const result = await importGraphStream(
+        createStore(testGraph, createTestBackend()),
+        chunkStream([header, nodes, nodes]),
+        importOptions({ onConflict }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.nodes.created).toBe(1);
+      expect(result.nodes[onConflict === "skip" ? "skipped" : "updated"]).toBe(
+        1,
+      );
+    },
+  );
+
+  it("warns without failing when streamed-import statistics refresh fails", async () => {
+    await sourceStore.nodes.Person.create({ name: "Alice" });
+    const targetStore = createStore(testGraph, createTestBackend());
+    const refreshError = new Error("planner unavailable");
+    const refreshStatistics = vi
+      .spyOn(targetStore, "refreshStatistics")
+      .mockRejectedValue(refreshError);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => false);
+
+    try {
+      const result = await importGraphStream(
+        targetStore,
+        exportGraphStream(sourceStore),
+        importOptions({ onConflict: "error" }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(refreshStatistics).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("importGraphStream committed its rows"),
+        refreshError,
+      );
+    } finally {
+      refreshStatistics.mockRestore();
+      warn.mockRestore();
+    }
   });
 
   it("preserves nodes after round-trip", async () => {

--- a/packages/typegraph/tests/property/interchange-roundtrip.test.ts
+++ b/packages/typegraph/tests/property/interchange-roundtrip.test.ts
@@ -22,7 +22,12 @@ import {
   defineNode,
   searchable,
 } from "../../src";
-import { exportGraph, importGraph } from "../../src/interchange";
+import {
+  exportGraph,
+  exportGraphStream,
+  importGraph,
+  importGraphStream,
+} from "../../src/interchange";
 import {
   type GraphData,
   ImportOptionsSchema,
@@ -189,6 +194,28 @@ describe("interchange round-trip laws", () => {
           expect(second).toEqual(first);
         },
       ),
+      { numRuns: 20 },
+    );
+  }, 60_000);
+
+  it("streaming export/import reproduces the current state without graph-sized chunks", async () => {
+    await fc.assert(
+      fc.asyncProperty(worldArb, async (world) => {
+        const source = await seedWorld(world);
+        const [target] = await createStoreWithSchema(
+          graph,
+          createTestBackend(),
+        );
+        const result = await importGraphStream(
+          target,
+          exportGraphStream(source, { batchSize: 2 }),
+          importOptions({ onConflict: "error" }),
+        );
+        expect(result.success).toBe(true);
+        expect(currentState(await dumpObservableState(target))).toEqual(
+          currentState(await dumpObservableState(source)),
+        );
+      }),
       { numRuns: 20 },
     );
   }, 60_000);

--- a/packages/typegraph/tests/recorded-capture-capability-gate.test.ts
+++ b/packages/typegraph/tests/recorded-capture-capability-gate.test.ts
@@ -39,6 +39,36 @@ function postgresLikeBackend(): GraphBackend {
   return { ...backendWithReturning(true), dialect: "postgres" };
 }
 
+function backendWithoutTransactions(): GraphBackend {
+  const base = createTestBackend();
+  return {
+    ...base,
+    capabilities: { ...base.capabilities, transactions: false },
+  };
+}
+
+function backendWithoutExecuteStatement(): GraphBackend {
+  const base = createTestBackend();
+  const { executeStatement: _executeStatement, ...withoutExecuteStatement } =
+    base;
+  return withoutExecuteStatement;
+}
+
+function backendWithoutTableNames(): GraphBackend {
+  const base = createTestBackend();
+  const { tableNames: _tableNames, ...withoutTableNames } = base;
+  return withoutTableNames;
+}
+
+function backendWithoutRevisionOriginsTableBootstrap(): GraphBackend {
+  const base = createTestBackend();
+  const {
+    ensureRevisionOriginsTable: _ensureRevisionOriginsTable,
+    ...withoutRevisionOriginsTableBootstrap
+  } = base;
+  return withoutRevisionOriginsTableBootstrap;
+}
+
 describe("recorded-time capture capability gate", () => {
   it("refuses { history: true } when the backend declares no RETURNING support", () => {
     expect(() =>
@@ -60,6 +90,82 @@ describe("recorded-time capture capability gate", () => {
 
   it("does not gate on RETURNING when history capture is disabled", () => {
     expect(() => createStore(graph, backendWithReturning(false))).not.toThrow();
+  });
+
+  it("refuses revision tracking without transactions", () => {
+    expect(() =>
+      createStore(graph, backendWithoutTransactions(), {
+        revisionTracking: true,
+      }),
+    ).toThrow("requires a backend with transaction support");
+  });
+
+  it("refuses revision tracking without executeStatement", () => {
+    expect(() =>
+      createStore(graph, backendWithoutExecuteStatement(), {
+        revisionTracking: true,
+      }),
+    ).toThrow("requires a backend that supports executeStatement");
+  });
+
+  it("refuses revision tracking without table names", () => {
+    expect(() =>
+      createStore(graph, backendWithoutTableNames(), {
+        revisionTracking: true,
+      }),
+    ).toThrow("requires a backend that exposes tableNames");
+  });
+
+  it("refuses revision tracking without revision-origin table bootstrap", () => {
+    expect(() =>
+      createStore(graph, backendWithoutRevisionOriginsTableBootstrap(), {
+        revisionTracking: true,
+      }),
+    ).toThrow("requires a backend that can bootstrap revision origins");
+  });
+
+  it("names the revision-anchor contract when it guards tx.sql", async () => {
+    const store = createStore(graph, createTestBackend(), {
+      revisionTracking: true,
+    });
+
+    await expect(
+      store.transaction((tx) => {
+        const sqlHandle = tx.sql as unknown as Readonly<{ insert: unknown }>;
+        void sqlHandle.insert;
+        return Promise.resolve();
+      }),
+    ).rejects.toThrow(
+      "tx.sql is not available when revision tracking is enabled",
+    );
+  });
+
+  it("retries revision-origin bootstrap after a transient failure", async () => {
+    const base = createTestBackend();
+    const ensureRevisionOriginsTable = base.ensureRevisionOriginsTable;
+    if (ensureRevisionOriginsTable === undefined) {
+      throw new Error("Test backend must bootstrap revision origins");
+    }
+    let bootstrapAttempts = 0;
+    const backend: GraphBackend = {
+      ...base,
+      async ensureRevisionOriginsTable(): Promise<void> {
+        bootstrapAttempts++;
+        if (bootstrapAttempts === 1) {
+          throw new Error("transient revision-origin DDL failure");
+        }
+        await ensureRevisionOriginsTable();
+      },
+    };
+    const store = createStore(graph, backend, { revisionTracking: true });
+
+    await expect(store.revisionOriginNow()).rejects.toThrow(
+      "transient revision-origin DDL failure",
+    );
+    await expect(store.revisionOriginNow()).resolves.toEqual(
+      expect.any(String),
+    );
+    expect(bootstrapAttempts).toBe(2);
   });
 
   it("refuses PostgreSQL snapshot isolation for history capture transactions", async () => {


### PR DESCRIPTION
Graph Merge is meant to let agents, importers, and reviewers work independently, then fold changes back into a live canonical graph. The original base-version check protected that flow by fingerprinting every live row. That is safe, but it becomes increasingly expensive as a graph grows, and it could only prove the target was unchanged before staging began. A write that landed after that check but before the commit transaction could otherwise make a planned merge stale.

Graph interchange had the same scaling shape: export, import, and physical branch cloning first assembled a graph-sized document in memory. Large copies therefore carried a graph-sized heap spike, and a streamed import needed to stop at the first chunk that reported a non-best-effort error.

## What changed

- Add a durable revision anchor for revision-tracked and history stores: a per-graph random origin plus a monotonic commit clock. A branch can validate its base in constant space without confusing an independently-created store that happens to share a timestamp.
- Recheck that anchor while holding the target graph lock inside the merge commit transaction. A target that advances during staging now fails closed before any merge writes are applied.
- Make the revision-origin schema upgrade lazy and retryable, protect raw `tx.sql` from silently bypassing revision tracking, and document PostgreSQL write serialization.
- Stream graph export, import, and physical working-copy creation in bounded chunks. The importer aggregates expected conflicts but aborts on the first unexpected chunk error.
- Allow `mergeIncremental()` to commit into history-backed PostgreSQL targets using the transaction semantics required by recorded history.

## What this unlocks

- Long-lived, repeatedly branched graphs can validate a branch base without an O(graph) live-row fingerprint on every branch or merge.
- Parallel agents, ETL feeds, and review workflows get a safe fast path for a live target: any tracked write that lands before commit turns into an explicit stale-base rejection rather than a silent merge of an outdated plan.
- Large graph copies, transfers, and exports keep one interchange batch resident at a time instead of materializing the entire graph.
- Incremental ingestion can safely target history-backed PostgreSQL stores, extending the live-graph merge path across supported backends.

## Operational boundaries

Revision tracking covers TypeGraph-managed writes. Direct backend writes or raw graph-table writes are intentionally rejected through `tx.sql` because they would bypass the anchor. On PostgreSQL, same-graph writes serialize under a transaction-scoped advisory lock; partition hot workloads across graphs when more write parallelism is needed. Streaming export lowers memory use but is not a transactional backup snapshot, so use a database snapshot or quiesce writes when backup consistency matters.
