### PR TITLE
perf(ci): speed up test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,7 @@ jobs:
           --coverage.thresholds.lines=0
 
       - name: Upload coverage blob
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,8 +201,9 @@ jobs:
         run: >-
           pnpm --filter @nicia-ai/typegraph exec vitest run --coverage
           --shard=${{ matrix.shard }}
+          --reporter=default
           --reporter=blob
-          --outputFile=.vitest-reports/blob-${{ matrix.artifact }}.json
+          --outputFile.blob=.vitest-reports/blob-${{ matrix.artifact }}.json
           --coverage.thresholds.branches=0
           --coverage.thresholds.functions=0
           --coverage.thresholds.lines=0
@@ -214,6 +215,7 @@ jobs:
           path: packages/typegraph/.vitest-reports/*.json
           if-no-files-found: error
           include-hidden-files: true
+          overwrite: true
 
   test-coverage-merge:
     name: Test (Coverage)
@@ -221,8 +223,9 @@ jobs:
     needs: [detect-release-metadata-push, test-coverage]
     if: >-
       ${{
+        always() &&
         needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' &&
-        needs.test-coverage.result == 'success'
+        needs.test-coverage.result != 'skipped'
       }}
     timeout-minutes: 10
     steps:
@@ -237,6 +240,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Fail when a coverage shard failed
+        if: ${{ needs.test-coverage.result != 'success' }}
+        run: |
+          echo "Coverage shards finished with result: ${{ needs.test-coverage.result }}"
+          exit 1
 
       - name: Download coverage blobs
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         run: pnpm test:unused
 
   test-sqlite-unit:
-    name: Test Unit (SQLite, Node ${{ matrix.node-version }})
+    name: Test Unit (SQLite, Node 22, shard ${{ matrix.shard }})
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
     if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24]
+        shard: ["1/2", "2/2"]
     steps:
       - uses: actions/checkout@v6
 
@@ -114,14 +114,14 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Run unit tests
-        run: pnpm turbo run test:unit
+        run: pnpm turbo run test:unit -- --shard=${{ matrix.shard }}
 
   test-sqlite-property:
     name: Test Property (SQLite, Node 24)
@@ -171,11 +171,19 @@ jobs:
         run: pnpm --filter @nicia-ai/typegraph exec tsx examples/01-basic-usage.ts
 
   test-coverage:
-    name: Test (Coverage)
+    name: Coverage shard ${{ matrix.shard }}
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
     if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: "1/2"
+            artifact: coverage-blob-1
+          - shard: "2/2"
+            artifact: coverage-blob-2
     steps:
       - uses: actions/checkout@v6
 
@@ -189,8 +197,56 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Enforce coverage thresholds
-        run: pnpm --filter @nicia-ai/typegraph test:coverage
+      - name: Run coverage shard
+        run: >-
+          pnpm --filter @nicia-ai/typegraph exec vitest run --coverage
+          --shard=${{ matrix.shard }}
+          --reporter=blob
+          --outputFile=.vitest-reports/blob-${{ matrix.artifact }}.json
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.lines=0
+
+      - name: Upload coverage blob
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: packages/typegraph/.vitest-reports/*.json
+          if-no-files-found: error
+          include-hidden-files: true
+
+  test-coverage-merge:
+    name: Test (Coverage)
+    runs-on: ubuntu-24.04
+    needs: [detect-release-metadata-push, test-coverage]
+    if: >-
+      ${{
+        needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' &&
+        needs.test-coverage.result == 'success'
+      }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download coverage blobs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-blob-*
+          path: packages/typegraph/.vitest-reports
+          merge-multiple: true
+
+      - name: Enforce merged coverage thresholds
+        run: pnpm --filter @nicia-ai/typegraph test:coverage:merge
 
   test-typescript-compat:
     name: Type Tests (TS ${{ matrix.typescript-version }})
@@ -221,11 +277,15 @@ jobs:
           TYPEGRAPH_TYPESCRIPT_VERSION: ${{ matrix.typescript-version }}
 
   test-postgres:
-    name: Test (PostgreSQL)
+    name: Test (PostgreSQL, shard ${{ matrix.shard }})
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
     if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ["1/2", "2/2"]
     services:
       postgres:
         image: pgvector/pgvector:pg18
@@ -259,8 +319,10 @@ jobs:
         env:
           # Use 127.0.0.1 instead of localhost to avoid IPv6 resolution issues
           POSTGRES_URL: postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test
+          VITEST_SHARD: ${{ matrix.shard }}
 
       - name: Run PostgreSQL perf sanity
+        if: ${{ matrix.shard == '1/2' }}
         run: pnpm --filter @nicia-ai/typegraph-benchmarks perf:check:postgres
         env:
           # Use 127.0.0.1 instead of localhost to avoid IPv6 resolution issues
@@ -298,7 +360,7 @@ jobs:
       - test-sqlite-unit
       - test-sqlite-property
       - test-sqlite-smoke
-      - test-coverage
+      - test-coverage-merge
       - test-typescript-compat
       - test-postgres
       - test-durable-objects

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@
 .tanstack/
 .wrangler/
 coverage/
+.vitest-reports/
 drizzle/
 examples/
 pnpm-lock.yaml

--- a/packages/typegraph/.gitignore
+++ b/packages/typegraph/.gitignore
@@ -1,2 +1,3 @@
 .stryker-tmp/
 coverage/
+.vitest-reports/

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -102,7 +102,7 @@
     "test:postgres": "./scripts/test-postgres.sh",
     "test:do": "vitest run --config vitest.workers.config.ts",
     "test:coverage": "vitest run --coverage",
-    "test:coverage:merge": "vitest --merge-reports=.vitest-reports --coverage",
+    "test:coverage:merge": "vitest run --merge-reports=.vitest-reports --coverage",
     "test:mutation": "stryker run",
     "test:mutation:critical": "stryker run stryker.critical.config.json"
   },

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -91,7 +91,7 @@
     "pretest": "node --import tsx scripts/ensure-native-sqlite.ts",
     "test": "vitest run",
     "pretest:unit": "node --import tsx scripts/ensure-native-sqlite.ts",
-    "test:unit": "vitest run",
+    "test:unit": "TYPEGRAPH_TEST_SCOPE=unit vitest run",
     "pretest:property": "node --import tsx scripts/ensure-native-sqlite.ts",
     "test:property": "vitest run tests/property",
     "pretest:perf": "node --import tsx scripts/ensure-native-sqlite.ts",
@@ -102,6 +102,7 @@
     "test:postgres": "./scripts/test-postgres.sh",
     "test:do": "vitest run --config vitest.workers.config.ts",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:merge": "vitest --merge-reports=.vitest-reports --coverage",
     "test:mutation": "stryker run",
     "test:mutation:critical": "stryker run stryker.critical.config.json"
   },

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -32,11 +32,27 @@ fi
 # suite targets the same `typegraph_test` database, and several files'
 # `beforeAll` hooks run schema-destructive DDL (DROP TABLE). Running
 # files in parallel is a recipe for flaky mid-test table disappearance.
-# (Graph-merge fixtures isolate per-fixture schemas, but they share the
-# serialized lane for the same connection-budget reasons.)
+# (Graph-merge fixtures isolate per-fixture schemas, but each shard still keeps
+# its own database lane serialized for the same connection-budget reasons.)
 #
 # With POSTGRES_URL set, the graph-merge backendMatrix() gains its
 # server-Postgres entry, so those suites run on SQLite, PGlite, AND the
 # production pg driver in this lane.
 echo "Running PostgreSQL tests..."
-POSTGRES_URL="$POSTGRES_URL" vitest run --no-file-parallelism tests/backends/postgres/ tests/backends/integration/ tests/graph-merge/ tests/property/graph-merge/
+vitest_args=(
+  run
+  --no-file-parallelism
+)
+
+if [[ -n "${VITEST_SHARD:-}" ]]; then
+  vitest_args+=("--shard=$VITEST_SHARD")
+fi
+
+vitest_args+=(
+  tests/backends/postgres/
+  tests/backends/integration/
+  tests/graph-merge/
+  tests/property/graph-merge/
+)
+
+POSTGRES_URL="$POSTGRES_URL" vitest "${vitest_args[@]}"

--- a/packages/typegraph/tests/graph-merge/test-utils.test.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.test.ts
@@ -221,6 +221,9 @@ describe("setupSharedPgliteMergeEngine", () => {
       const created = await firstStore.nodes.Person.create({ name: "Ada" });
 
       await expect(
+        firstStore.nodes.Person.getById(created.id),
+      ).resolves.toEqual(created);
+      await expect(
         secondStore.nodes.Person.getById(created.id),
       ).resolves.toBeUndefined();
     } finally {

--- a/packages/typegraph/tests/graph-merge/test-utils.test.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.test.ts
@@ -17,8 +17,16 @@ import {
 } from "../../src/graph-merge/errors";
 import type { Result } from "../../src/graph-merge/result";
 import { err, isErr, isOk, ok, unwrap } from "../../src/graph-merge/result";
-import type { BackendMatrixEntry, MergeBackendFixture } from "./test-utils";
-import { backendMatrix, createSqliteMergeBackend } from "./test-utils";
+import type {
+  BackendMatrixEntry,
+  MergeBackendFixture,
+  SharedPgliteMergeEngine,
+} from "./test-utils";
+import {
+  backendMatrix,
+  createSqliteMergeBackend,
+  setupSharedPgliteMergeEngine,
+} from "./test-utils";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -193,5 +201,31 @@ describe("createSqliteMergeBackend (direct)", () => {
     const [store] = await createStoreWithSchema(graph, fixture.backend);
     expect(store.graphId).toBe("merge-test-utils");
     await fixture.cleanup();
+  });
+});
+
+describe("setupSharedPgliteMergeEngine", () => {
+  let engine: SharedPgliteMergeEngine | undefined;
+
+  afterEach(async () => {
+    await engine?.dispose();
+  });
+
+  it("isolates simultaneously active stores on one PGlite engine", async () => {
+    engine = await setupSharedPgliteMergeEngine();
+    const first = await engine.makeFixture();
+    const second = await engine.makeFixture();
+    try {
+      const [firstStore] = await createStoreWithSchema(graph, first.backend);
+      const [secondStore] = await createStoreWithSchema(graph, second.backend);
+      const created = await firstStore.nodes.Person.create({ name: "Ada" });
+
+      await expect(
+        secondStore.nodes.Person.getById(created.id),
+      ).resolves.toBeUndefined();
+    } finally {
+      await first.cleanup();
+      await second.cleanup();
+    }
   });
 });

--- a/packages/typegraph/tests/graph-merge/test-utils.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.ts
@@ -78,9 +78,11 @@ export async function createPgliteMergeBackend(): Promise<MergeBackendFixture> {
  * Graph-merge property cases need several stores alive concurrently: a base and
  * its branches, and sometimes two independent materializations. Reusing one
  * default table set would make those stores collide. Instead, the engine stays
- * alive for the test file while each fixture receives its own tables and drops
- * them at cleanup. This removes repeated WASM/pgvector boot cost without
- * weakening fixture isolation.
+ * alive for the test file while each fixture receives its own core TypeGraph
+ * tables and drops them at cleanup. This removes repeated WASM/pgvector boot
+ * cost without weakening fixture isolation. Strategy-owned vector and index
+ * tables remain keyed by graph identity; these property fixtures do not
+ * materialize those strategies.
  */
 export type SharedPgliteMergeEngine = Readonly<{
   makeFixture: () => Promise<MergeBackendFixture>;
@@ -108,6 +110,20 @@ export async function setupSharedPgliteMergeEngine(): Promise<SharedPgliteMergeE
         cleanup: async () => {
           await backend.close();
           await client.exec(dropTablesSql(tables));
+          const remaining = await client.query<{ tablename: string }>(
+            `SELECT tablename
+             FROM pg_tables
+             WHERE schemaname = 'public'
+               AND left(tablename, length($1)) = $1`,
+            [prefixForFixture(tables)],
+          );
+          if (remaining.rows.length > 0) {
+            throw new Error(
+              `Shared PGlite fixture cleanup left tables: ${remaining.rows
+                .map((row) => row.tablename)
+                .join(", ")}`,
+            );
+          }
         },
       };
     },
@@ -133,6 +149,12 @@ function sharedPgliteTableNames(fixtureSequence: number): PostgresTableNames {
     kindRemovals: `${prefix}_kind_removals`,
     reconciliationMarkers: `${prefix}_reconciliation_markers`,
   };
+}
+
+function prefixForFixture(tables: PostgresTables): string {
+  const tableName = getTableName(tables.nodes);
+  const prefix = tableName.slice(0, tableName.lastIndexOf("_nodes"));
+  return prefix;
 }
 
 function dropTablesSql(tables: PostgresTables): string {

--- a/packages/typegraph/tests/graph-merge/test-utils.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.ts
@@ -4,9 +4,16 @@ import type { GraphBackend } from "@nicia-ai/typegraph";
 import { createPostgresBackend } from "@nicia-ai/typegraph/postgres";
 import { createLocalPgliteBackend } from "@nicia-ai/typegraph/postgres/pglite";
 import { createLocalSqliteBackend } from "@nicia-ai/typegraph/sqlite/local";
+import { getTableName, is, Table } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client, Pool } from "pg";
 
+import { generatePostgresMigrationSQL } from "../../src/backend/drizzle/ddl";
+import {
+  createPostgresTables,
+  type PostgresTableNames,
+  type PostgresTables,
+} from "../../src/backend/drizzle/schema/postgres";
 import type { Embedder } from "../../src/graph-merge/types";
 
 /**
@@ -63,6 +70,76 @@ export async function createPgliteMergeBackend(): Promise<MergeBackendFixture> {
       await backend.close();
     },
   };
+}
+
+/**
+ * A shared PGlite engine with independently named table sets for merge tests.
+ *
+ * Graph-merge property cases need several stores alive concurrently: a base and
+ * its branches, and sometimes two independent materializations. Reusing one
+ * default table set would make those stores collide. Instead, the engine stays
+ * alive for the test file while each fixture receives its own tables and drops
+ * them at cleanup. This removes repeated WASM/pgvector boot cost without
+ * weakening fixture isolation.
+ */
+export type SharedPgliteMergeEngine = Readonly<{
+  makeFixture: () => Promise<MergeBackendFixture>;
+  dispose: () => Promise<void>;
+}>;
+
+/**
+ * Starts a reusable PGlite engine for a graph-merge property test file.
+ */
+export async function setupSharedPgliteMergeEngine(): Promise<SharedPgliteMergeEngine> {
+  const { client, db } = await createLocalPgliteBackend();
+  let fixtureSequence = 0;
+
+  return {
+    makeFixture: async () => {
+      fixtureSequence += 1;
+      const tables = createPostgresTables(
+        sharedPgliteTableNames(fixtureSequence),
+      );
+      await client.exec(generatePostgresMigrationSQL(tables));
+
+      const backend = createPostgresBackend(db, { tables });
+      return {
+        backend,
+        cleanup: async () => {
+          await backend.close();
+          await client.exec(dropTablesSql(tables));
+        },
+      };
+    },
+    dispose: async () => {
+      await client.close();
+    },
+  };
+}
+
+function sharedPgliteTableNames(fixtureSequence: number): PostgresTableNames {
+  const prefix = `merge_fixture_${fixtureSequence}`;
+  return {
+    nodes: `${prefix}_nodes`,
+    edges: `${prefix}_edges`,
+    recordedNodes: `${prefix}_recorded_nodes`,
+    recordedEdges: `${prefix}_recorded_edges`,
+    recordedClock: `${prefix}_recorded_clock`,
+    uniques: `${prefix}_uniques`,
+    schemaVersions: `${prefix}_schema_versions`,
+    fulltext: `${prefix}_fulltext`,
+    indexMaterializations: `${prefix}_index_materializations`,
+    contributionMaterializations: `${prefix}_contribution_materializations`,
+    kindRemovals: `${prefix}_kind_removals`,
+    reconciliationMarkers: `${prefix}_reconciliation_markers`,
+  };
+}
+
+function dropTablesSql(tables: PostgresTables): string {
+  const names = Object.values(tables)
+    .filter((value) => is(value, Table))
+    .map((table) => `"${getTableName(table)}"`);
+  return `DROP TABLE IF EXISTS ${names.join(", ")} CASCADE`;
 }
 
 /**

--- a/packages/typegraph/tests/graph-merge/test-utils.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.ts
@@ -141,6 +141,7 @@ function sharedPgliteTableNames(fixtureSequence: number): PostgresTableNames {
     recordedNodes: `${prefix}_recorded_nodes`,
     recordedEdges: `${prefix}_recorded_edges`,
     recordedClock: `${prefix}_recorded_clock`,
+    revisionOrigins: `${prefix}_revision_origins`,
     uniques: `${prefix}_uniques`,
     schemaVersions: `${prefix}_schema_versions`,
     fulltext: `${prefix}_fulltext`,

--- a/packages/typegraph/tests/property/graph-merge/determinism.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/determinism.test.ts
@@ -36,7 +36,7 @@ import {
   subClassOf,
 } from "@nicia-ai/typegraph";
 import fc from "fast-check";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { branch } from "../../../src/graph-merge/branch";
@@ -49,7 +49,11 @@ import type {
   SimilarityStrategy,
 } from "../../../src/graph-merge/types";
 import { asBranchId } from "../../../src/graph-merge/types";
-import { backendMatrix } from "../../graph-merge/test-utils";
+import {
+  backendMatrix,
+  setupSharedPgliteMergeEngine,
+  type SharedPgliteMergeEngine,
+} from "../../graph-merge/test-utils";
 import type { DeterminismScenario } from "./arbitraries";
 import { determinismScenarioArb } from "./arbitraries";
 import { normalizeGraph, normalizeReport } from "./normalize";
@@ -109,12 +113,11 @@ const BRANCH_B = asBranchId("branch-b");
 const FIXED_BRANCH_ORDER: readonly BranchId[] = [BRANCH_A, BRANCH_B];
 
 /**
- * fast-check iterations. Each run boots ~6 in-process PGlite (WASM Postgres)
- * engines (two materializations × base + two branches), which is markedly slower
- * on CI runners — 30 runs there blow past any sane timeout. So CI runs fewer
- * iterations (still meaningful, and the order-independence property is ALSO pinned
- * by the deterministic, non-property tests on both backends); a dev box runs the
- * full set. (A shared-PGlite-engine fixture would let CI run the full count.)
+ * fast-check iterations. Each run needs ~6 PGlite-backed stores (two
+ * materializations × base + two branches), so CI keeps a smaller run budget even
+ * though the PGlite engine is reused with isolated tables within this file. The
+ * deterministic, non-property tests pin the same order-independence paths on both
+ * backends; a dev box runs the full set.
  */
 const DETERMINISM_RUNS = process.env.CI ? 12 : 30;
 
@@ -175,9 +178,21 @@ type Fixture = Readonly<{
 describe.each(backendMatrix())(
   "determinism property — shuffled branch order [$name]",
   (entry) => {
+    let sharedPglite: SharedPgliteMergeEngine | undefined;
+
+    beforeAll(async () => {
+      if (entry.name === "PGlite") {
+        sharedPglite = await setupSharedPgliteMergeEngine();
+      }
+    });
+
+    afterAll(async () => {
+      await sharedPglite?.dispose();
+    });
+
     // Disposers for backends still open at test end (belt-and-suspenders — the
-    // property body also disposes each iteration's backends inline so PGlite's
-    // in-process engines never accumulate across the 30 runs).
+    // property body also disposes each iteration's backends inline so the
+    // shared PGlite engine's fixture tables never accumulate).
     let cleanups: (() => Promise<void>)[];
 
     afterEach(async () => {
@@ -189,7 +204,10 @@ describe.each(backendMatrix())(
     async function makeBackend(
       disposers: (() => Promise<void>)[],
     ): Promise<GraphBackend> {
-      const fixture = await entry.make();
+      const fixture =
+        sharedPglite === undefined ?
+          await entry.make()
+        : await sharedPglite.makeFixture();
       disposers.push(fixture.cleanup);
       return fixture.backend;
     }

--- a/packages/typegraph/tests/property/graph-merge/determinism.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/determinism.test.ts
@@ -36,7 +36,7 @@ import {
   subClassOf,
 } from "@nicia-ai/typegraph";
 import fc from "fast-check";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { branch } from "../../../src/graph-merge/branch";
@@ -188,17 +188,6 @@ describe.each(backendMatrix())(
 
     afterAll(async () => {
       await sharedPglite?.dispose();
-    });
-
-    // Disposers for backends still open at test end (belt-and-suspenders — the
-    // property body also disposes each iteration's backends inline so the
-    // shared PGlite engine's fixture tables never accumulate).
-    let cleanups: (() => Promise<void>)[];
-
-    afterEach(async () => {
-      for (const cleanup of cleanups) {
-        await cleanup();
-      }
     });
 
     async function makeBackend(
@@ -366,7 +355,6 @@ describe.each(backendMatrix())(
       "yields a deep-equal normalized report + graph for any branch ordering",
       { timeout: 300_000 },
       async () => {
-        cleanups = [];
         await fc.assert(
           fc.asyncProperty(
             determinismScenarioArb,

--- a/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
@@ -34,7 +34,7 @@ import {
   defineNode,
 } from "@nicia-ai/typegraph";
 import fc from "fast-check";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { branch } from "../../../src/graph-merge/branch";
@@ -47,7 +47,11 @@ import type {
   SimilarityStrategy,
 } from "../../../src/graph-merge/types";
 import { asBranchId } from "../../../src/graph-merge/types";
-import { backendMatrix } from "../../graph-merge/test-utils";
+import {
+  backendMatrix,
+  setupSharedPgliteMergeEngine,
+  type SharedPgliteMergeEngine,
+} from "../../graph-merge/test-utils";
 import type { MergeLawScenario } from "./arbitraries";
 import { mergeLawScenarioArb } from "./arbitraries";
 import { normalizeGraph, normalizeReport } from "./normalize";
@@ -88,9 +92,10 @@ const BRANCH_A = asBranchId("law-branch-a");
 const BRANCH_B = asBranchId("law-branch-b");
 
 /**
- * fast-check iterations. Each idempotence iteration boots up to 5 in-process
- * backends (two bases + three branches), so CI runs fewer iterations — same
- * rationale as the determinism gate's run budget.
+ * fast-check iterations. Each idempotence iteration needs up to 5 stores (two
+ * bases + three branches). CI keeps a smaller run budget while reusing one
+ * PGlite engine with isolated tables for this file, matching the determinism
+ * gate's rationale.
  */
 const LAW_RUNS = process.env.CI ? 8 : 16;
 
@@ -136,7 +141,18 @@ const ADDED_ENCOUNTER_ID = "enc-added";
 const ADDED_EDGE_ID = "edge-added";
 
 describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
+  let sharedPglite: SharedPgliteMergeEngine | undefined;
   let cleanups: (() => Promise<void>)[];
+
+  beforeAll(async () => {
+    if (entry.name === "PGlite") {
+      sharedPglite = await setupSharedPgliteMergeEngine();
+    }
+  });
+
+  afterAll(async () => {
+    await sharedPglite?.dispose();
+  });
 
   afterEach(async () => {
     for (const cleanup of cleanups) {
@@ -147,7 +163,10 @@ describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
   async function makeBackend(
     disposers: (() => Promise<void>)[],
   ): Promise<GraphBackend> {
-    const fixture = await entry.make();
+    const fixture =
+      sharedPglite === undefined ?
+        await entry.make()
+      : await sharedPglite.makeFixture();
     disposers.push(fixture.cleanup);
     return fixture.backend;
   }

--- a/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
@@ -34,7 +34,7 @@ import {
   defineNode,
 } from "@nicia-ai/typegraph";
 import fc from "fast-check";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { branch } from "../../../src/graph-merge/branch";
@@ -142,7 +142,6 @@ const ADDED_EDGE_ID = "edge-added";
 
 describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
   let sharedPglite: SharedPgliteMergeEngine | undefined;
-  let cleanups: (() => Promise<void>)[];
 
   beforeAll(async () => {
     if (entry.name === "PGlite") {
@@ -152,12 +151,6 @@ describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
 
   afterAll(async () => {
     await sharedPglite?.dispose();
-  });
-
-  afterEach(async () => {
-    for (const cleanup of cleanups) {
-      await cleanup();
-    }
   });
 
   async function makeBackend(
@@ -294,7 +287,6 @@ describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
     "IDENTITY — an unchanged branch merges as a no-op",
     { timeout: 300_000 },
     async () => {
-      cleanups = [];
       await fc.assert(
         fc.asyncProperty(mergeLawScenarioArb, async (scenario) => {
           const disposers: (() => Promise<void>)[] = [];
@@ -340,7 +332,6 @@ describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
     "DIFF-COHERENCE — a single branch's non-colliding diff is applied faithfully",
     { timeout: 300_000 },
     async () => {
-      cleanups = [];
       await fc.assert(
         fc.asyncProperty(mergeLawScenarioArb, async (scenario) => {
           const disposers: (() => Promise<void>)[] = [];
@@ -390,7 +381,6 @@ describe.each(backendMatrix())("merge law properties [$name]", (entry) => {
     "IDEMPOTENCE — merging an identical twin branch adds nothing",
     { timeout: 300_000 },
     async () => {
-      cleanups = [];
       await fc.assert(
         fc.asyncProperty(mergeLawScenarioArb, async (scenario) => {
           const disposers: (() => Promise<void>)[] = [];

--- a/packages/typegraph/tests/property/graph-merge/new-vs-base-determinism.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/new-vs-base-determinism.test.ts
@@ -34,7 +34,7 @@ import {
   defineNode,
 } from "@nicia-ai/typegraph";
 import fc from "fast-check";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { branch } from "../../../src/graph-merge/branch";
@@ -46,7 +46,11 @@ import type {
   MergeOptions,
 } from "../../../src/graph-merge/types";
 import { asBranchId } from "../../../src/graph-merge/types";
-import { backendMatrix } from "../../graph-merge/test-utils";
+import {
+  backendMatrix,
+  setupSharedPgliteMergeEngine,
+  type SharedPgliteMergeEngine,
+} from "../../graph-merge/test-utils";
 import { normalizeGraph, normalizeReport } from "./normalize";
 
 const Patient = defineNode("Patient", {
@@ -77,10 +81,10 @@ const B = asBranchId("provider-b");
 const FIXED_ORDER: readonly BranchId[] = [A, B];
 
 /**
- * fast-check iterations. Each run boots 5 backends (forkBase + two branches + two
- * targets); PGlite (in-process WASM Postgres) makes that the slow axis, so CI runs
- * fewer (still meaningful — the deterministic new-vs-base tests pin the same paths on
- * both backends). A dev box runs the full set.
+ * fast-check iterations. Each run needs 5 stores (forkBase + two branches + two
+ * targets); PGlite makes that the slow axis, so CI runs fewer while reusing one
+ * engine with isolated tables within this file. The deterministic new-vs-base
+ * tests pin the same paths on both backends; a dev box runs the full set.
  */
 const RUNS = process.env.CI ? 8 : 16;
 
@@ -207,10 +211,25 @@ function options(
 describe.each(backendMatrix())(
   "new-vs-base determinism property — shuffled branch order [$name]",
   (entry) => {
+    let sharedPglite: SharedPgliteMergeEngine | undefined;
+
+    beforeAll(async () => {
+      if (entry.name === "PGlite") {
+        sharedPglite = await setupSharedPgliteMergeEngine();
+      }
+    });
+
+    afterAll(async () => {
+      await sharedPglite?.dispose();
+    });
+
     async function makeBackend(
       disposers: (() => Promise<void>)[],
     ): Promise<GraphBackend> {
-      const fixture = await entry.make();
+      const fixture =
+        sharedPglite === undefined ?
+          await entry.make()
+        : await sharedPglite.makeFixture();
       disposers.push(fixture.cleanup);
       return fixture.backend;
     }

--- a/packages/typegraph/vitest.config.ts
+++ b/packages/typegraph/vitest.config.ts
@@ -3,14 +3,16 @@ import { resolve } from "node:path";
 import { configDefaults, defineConfig } from "vitest/config";
 
 /**
- * Test globs for the graph-merge subsystem. These suites boot an in-process
- * PGlite (WASM Postgres) per fixture and run on BOTH backends, so they get their
- * own project with file serialization + generous timeouts. The rest of the
- * package keeps default parallelism and fast-fail timeouts.
+ * Test globs for the graph-merge subsystem. These suites exercise an in-process
+ * PGlite (WASM Postgres) backend and run on BOTH backends, so they get their own
+ * project with file serialization + generous timeouts. The rest of the package
+ * keeps default parallelism and fast-fail timeouts.
  */
+const UNIT_SCOPE = process.env.TYPEGRAPH_TEST_SCOPE === "unit";
+
 const GRAPH_MERGE_GLOBS = [
   "tests/graph-merge/**/*.test.ts",
-  "tests/property/graph-merge/**/*.test.ts",
+  ...(UNIT_SCOPE ? [] : ["tests/property/graph-merge/**/*.test.ts"]),
 ];
 
 const SHARED_EXCLUDE = [
@@ -22,6 +24,8 @@ const SHARED_EXCLUDE = [
   "**/.{idea,git,cache,output,temp}/**",
   "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc}.config.*",
 ];
+
+const UNIT_PROPERTY_EXCLUDE = UNIT_SCOPE ? ["tests/property/**"] : [];
 
 export default defineConfig({
   resolve: {
@@ -79,7 +83,11 @@ export default defineConfig({
           name: "main",
           include: ["tests/**/*.test.ts"],
           // Graph-merge runs under its own (serialized) project below.
-          exclude: [...SHARED_EXCLUDE, ...GRAPH_MERGE_GLOBS],
+          exclude: [
+            ...SHARED_EXCLUDE,
+            ...GRAPH_MERGE_GLOBS,
+            ...UNIT_PROPERTY_EXCLUDE,
+          ],
         },
       },
       {


### PR DESCRIPTION
CI perf improvements

**CI parallelism**
- Split the Node 22 SQLite unit lane into two shards and remove the duplicate full Node 24 unit matrix.
- Split PostgreSQL integration and graph-merge tests into two serialized shards, each with its own CI service database; keep the PostgreSQL performance sanity check on one shard.

**Coverage and test scope**
- Split V8 coverage into two blob-report shards and add a merge gate that enforces the existing combined thresholds.
- Make `test:unit` exclude property-based tests so the dedicated property lane is no longer duplicated.
- Ignore Vitest blob output in repository formatting and package working-tree checks.

**PGlite graph-merge fixtures**
- Reuse one PGlite engine per graph-merge property file while allocating isolated table sets per fixture.
- Add coverage proving simultaneously active stores remain isolated and clean up their tables after each case.
