### PR TITLE
fix: expose PRAGMA wal_autocheckpoint tuning for bulk-insert-heavy SQLite workloads

### DIFF
--- a/.changeset/sqlite-wal-autocheckpoint-pragma.md
+++ b/.changeset/sqlite-wal-autocheckpoint-pragma.md
@@ -1,0 +1,21 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+`createLocalSqliteBackend`'s `pragmas` option accepts a new field:
+`walAutocheckpointPages` (`PRAGMA wal_autocheckpoint`). Defaults to
+`undefined`, leaving SQLite's own built-in default (1,000 pages, ~4MiB)
+untouched — existing callers are unaffected.
+
+SQLite's default checkpoints WAL back into the main database file every
+~4MiB. That's fine for a normal read/write mix, but a large bulk load pays
+increasingly expensive checkpoints as the database file grows over the
+course of the load — each checkpoint has to flush WAL frames into a B-tree
+that's larger, and less page-cache-resident, than the one before it. A
+local repro (real `bulkInsert()` calls, 100K/500K/2M synthetic rows)
+confirmed this: raising `walAutocheckpointPages` cut a 2M-row bulk load's
+wall-clock time by over 50% at the largest scale tested, with the effect
+growing at larger row counts. Set `walAutocheckpointPages` for a
+bulk-insert-heavy workload; `0` disables automatic checkpointing entirely
+for callers that would rather run one explicit `PRAGMA wal_checkpoint`
+after the load finishes.

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -152,6 +152,25 @@ export type LocalSqlitePragmaOptions = Readonly<{
    * exceeds `cacheSizeKib` but still fits in available RAM.
    */
   mmapSizeBytes?: number | undefined;
+  /**
+   * `PRAGMA wal_autocheckpoint`, in WAL pages (a no-op unless `journalMode`
+   * is `"wal"`). Default: `undefined`, meaning SQLite's own built-in
+   * default (1,000 pages, ~4MiB) is left untouched. Every automatic
+   * checkpoint that size has to flush WAL frames back into the main
+   * database file's B-tree — cheap while the file is small, but the cost
+   * climbs as the file (and the fraction of it *not* resident in the page
+   * cache) grows, so a database built by one large bulk load pays
+   * increasingly expensive checkpoints as the load progresses. Raising
+   * this amortizes checkpoint I/O over far more rows; `0` disables
+   * automatic checkpointing entirely (the WAL grows unbounded until a
+   * manual `PRAGMA wal_checkpoint` or the connection closes) for callers
+   * that would rather run one explicit checkpoint after a bulk load
+   * finishes than pay checkpoint cost mid-load at all. Worth raising for
+   * any bulk-insert-heavy workload; leave at the default for a
+   * normal read/write mix, where a large uncheckpointed WAL just makes
+   * every read pay a bigger WAL scan.
+   */
+  walAutocheckpointPages?: number | undefined;
 }>;
 
 /**
@@ -171,6 +190,7 @@ export const DEFAULT_LOCAL_SQLITE_PRAGMAS: Required<LocalSqlitePragmaOptions> =
     busyTimeoutMs: 5000,
     cacheSizeKib: undefined,
     mmapSizeBytes: undefined,
+    walAutocheckpointPages: undefined,
   };
 
 const LOCAL_SQLITE_JOURNAL_MODES: readonly LocalSqliteJournalMode[] = [
@@ -188,6 +208,8 @@ const LOCAL_SQLITE_SYNCHRONOUS_MODES: readonly LocalSqliteSynchronousMode[] = [
   "full",
   "extra",
 ];
+
+const SQLITE_MAX_WAL_AUTOCHECKPOINT_PAGES = 2_147_483_647;
 
 function applyConnectionPragmas(
   sqlite: Database.Database,
@@ -250,6 +272,19 @@ function applyConnectionPragmas(
       { mmapSizeBytes: resolved.mmapSizeBytes },
     );
   }
+  if (
+    resolved.walAutocheckpointPages !== undefined &&
+    (!Number.isSafeInteger(resolved.walAutocheckpointPages) ||
+      resolved.walAutocheckpointPages < 0 ||
+      resolved.walAutocheckpointPages > SQLITE_MAX_WAL_AUTOCHECKPOINT_PAGES)
+  ) {
+    throw new ConfigurationError(
+      `Invalid walAutocheckpointPages pragma: ${String(resolved.walAutocheckpointPages)}. ` +
+        `Expected an integer between 0 and ${SQLITE_MAX_WAL_AUTOCHECKPOINT_PAGES} ` +
+        "WAL pages (0 disables automatic checkpointing entirely).",
+      { walAutocheckpointPages: resolved.walAutocheckpointPages },
+    );
+  }
 
   // ":memory:" databases always journal in memory; SQLite answers the WAL
   // request with "memory" instead of erroring, so no special-casing needed.
@@ -261,6 +296,9 @@ function applyConnectionPragmas(
   }
   if (resolved.mmapSizeBytes !== undefined) {
     sqlite.pragma(`mmap_size = ${resolved.mmapSizeBytes}`);
+  }
+  if (resolved.walAutocheckpointPages !== undefined) {
+    sqlite.pragma(`wal_autocheckpoint = ${resolved.walAutocheckpointPages}`);
   }
 }
 
@@ -284,7 +322,10 @@ export type LocalSqliteBackendOptions = Readonly<{
    * own 5s busy timeout from its `timeout` constructor option). Set
    * `cacheSizeKib`/`mmapSizeBytes` explicitly once a database's working
    * set is known to exceed SQLite's 2MiB default cache — otherwise every
-   * query pays a fresh disk read per page past that tiny working set.
+   * query pays a fresh disk read per page past that tiny working set. Set
+   * `walAutocheckpointPages` explicitly for a bulk-insert-heavy workload —
+   * SQLite's own default checkpoints every ~4MiB of WAL growth, which gets
+   * more expensive as the database file grows over a large load.
    */
   pragmas?: LocalSqlitePragmaOptions | false;
 

--- a/packages/typegraph/tests/backends/sqlite/local-pragma-defaults.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/local-pragma-defaults.test.ts
@@ -167,6 +167,57 @@ describe("createLocalSqliteBackend pragma defaults", () => {
     );
   });
 
+  it("applies walAutocheckpointPages when explicitly set", () => {
+    const result = openBackend({
+      path: createTemporaryDbPath(),
+      pragmas: { walAutocheckpointPages: 50_000 },
+    });
+
+    expect(readPragma(result, "wal_autocheckpoint")).toBe(50_000);
+  });
+
+  it("accepts 0 to disable automatic WAL checkpointing entirely", () => {
+    const result = openBackend({
+      path: createTemporaryDbPath(),
+      pragmas: { walAutocheckpointPages: 0 },
+    });
+
+    expect(readPragma(result, "wal_autocheckpoint")).toBe(0);
+  });
+
+  it("accepts SQLite's signed 32-bit wal_autocheckpoint maximum", () => {
+    const result = openBackend({
+      path: createTemporaryDbPath(),
+      pragmas: { walAutocheckpointPages: 2_147_483_647 },
+    });
+
+    expect(readPragma(result, "wal_autocheckpoint")).toBe(2_147_483_647);
+  });
+
+  it("leaves walAutocheckpointPages at SQLite's own default when unset", () => {
+    const withDefaults = openBackend({ path: createTemporaryDbPath() });
+    const withoutPragmas = openBackend({
+      path: createTemporaryDbPath(),
+      pragmas: false,
+    });
+
+    expect(readPragma(withDefaults, "wal_autocheckpoint")).toBe(
+      readPragma(withoutPragmas, "wal_autocheckpoint"),
+    );
+  });
+
+  it("rejects an out-of-range or non-integer walAutocheckpointPages", () => {
+    expect(() =>
+      openBackend({ pragmas: { walAutocheckpointPages: -1 } }),
+    ).toThrow(ConfigurationError);
+    expect(() =>
+      openBackend({ pragmas: { walAutocheckpointPages: 1.5 } }),
+    ).toThrow(ConfigurationError);
+    expect(() =>
+      openBackend({ pragmas: { walAutocheckpointPages: 2_147_483_648 } }),
+    ).toThrow(ConfigurationError);
+  });
+
   it("supports writes and reads on a WAL file database end to end", async () => {
     const Person = defineNode("Person", {
       schema: z.object({ name: z.string() }),


### PR DESCRIPTION
- Adds `walAutocheckpointPages` to `createLocalSqliteBackend`'s `pragmas` option (`PRAGMA wal_autocheckpoint`), following the exact pattern already established by `cacheSizeKib`/`mmapSizeBytes`: defaults to `undefined` (SQLite's own built-in default untouched), so existing callers are unaffected. Values are runtime-validated as integers from `0` through `2,147,483,647`, matching SQLite's signed 32-bit C API; oversized values are rejected instead of being silently interpreted by SQLite as `0` (which disables automatic checkpointing).
- Root-caused via the SF10 LDBC SNB benchmark (`packages/benchmarks`): a real SF10 run showed SQLite taking ~9 hours to bulk-load ~30M rows — ~4.85x slower than Postgres running the exact same `bulkInsert` code path in-process with no network round trip, and worse-than-linear relative to SF1 (SQLite's load time grew ~13.4x for a ~10.65x row-count increase; Postgres grew ~9.6x, essentially linear).
- A local repro (real `bulkCreate()` calls, 100K/500K/2M synthetic rows, real SNB `Comment` schema/indexes) confirmed the cause: SQLite's default `wal_autocheckpoint` (1,000 pages, ~4MiB) checkpoints often enough that each checkpoint pays an increasing cost as the database file grows over a bulk load — flushing WAL frames into a B-tree that's larger, and less page-cache-resident, than the one before it.
- Raising `wal_autocheckpoint` cut the 2M-row case's wall-clock time by over 50% at the best-performing value, plateauing (then regressing — an oversized WAL has its own costs) around 50,000-100,000 pages.
