### PR TITLE
feat: add opt-in coalesceUnchangedUpserts store option (#256)

### DIFF
--- a/.changeset/coalesce-unchanged-upserts.md
+++ b/.changeset/coalesce-unchanged-upserts.md
@@ -1,0 +1,34 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add an opt-in `coalesceUnchangedUpserts` store option for at-least-once /
+replay materializers.
+
+Idempotent event-log projectors converge live state correctly, but every
+re-delivery of a byte-identical value still performed a real write:
+`upsertById` on an existing id called `updateNode` unconditionally, allocating
+a fresh recorded instant and a new history row. A full replay of an N-event log
+therefore rewrote every row and grew recorded history by N — the recovery /
+rebuild workload inflates history the most.
+
+With `createStore(graph, backend, { coalesceUnchangedUpserts: true })`, an
+`upsertById` (or `bulkUpsertById` item) whose validated props are
+value-identical to the existing **live** row performs **no write at all**: no
+`updateNode`, no recorded-time capture, no history row, no revision-anchor
+advance, and no `update` operation hooks. It resolves with the existing node.
+The dirty-check compares the storage-normalized representation (props run
+through the kind's Zod schema, key-order-independent), so it answers exactly
+"would the persisted value differ?".
+
+A write still happens (never coalesced) when the row is soft-deleted (an upsert
+resurrects it), when an explicit `validFrom` / `validTo` is passed, or when any
+prop differs. Default off, because some consumers want an audit row per
+re-delivery. Covered symmetrically for edge `bulkUpsertById` (props only —
+endpoints are the edge's identity).
+
+Receipt semantics are unchanged and need no new signal: a coalesced upsert
+still counts as one write intent (`writes.total`) but captures nothing
+(`recorded` stays `undefined`) — the same two-signal shape as a no-op delete,
+which at-least-once consumers already handle by carrying the prior anchor
+forward.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -460,6 +460,7 @@ function createStore<G extends GraphDef>(
 | `schema` | `SqlSchema` | Custom table name configuration created with `createSqlSchema(...)` |
 | `queryDefaults.traversalExpansion` | `TraversalExpansion` | Default ontology expansion mode for traversals (default: `"inverse"`) |
 | `autoRefreshStatistics` | `false \| number` | Row threshold at which a single autocommit `bulkCreate`/`bulkInsert` triggers an automatic planner-statistics refresh (default: `1000`); `false` disables. See [Refreshing planner statistics](/backend-setup#refreshing-planner-statistics-after-bulk-loads). |
+| `coalesceUnchangedUpserts` | `boolean` | Skip the write for an `upsertById` / `bulkUpsertById` item whose validated props already equal the existing live row (default: `false`). For at-least-once / replay materializers: a byte-identical re-delivery performs no write, no history row, and no revision advance. See [`upsertById`](#upsertbyidid-props-options) and [Materializing external event logs](/materializing-event-logs). |
 
 **Example:**
 
@@ -748,6 +749,22 @@ store.nodes.Person.upsertById(
 - Updates the existing node if one exists
 - Un-deletes soft-deleted nodes (clears `deletedAt`)
 
+**Coalescing unchanged upserts.** When the store is created with
+[`coalesceUnchangedUpserts: true`](#createstoregraph-backend-options), an upsert
+whose validated props are value-identical to the existing **live** row performs
+**no write at all** — no update, no recorded history row, no revision-anchor
+advance, and no `update` operation hooks — and resolves with the existing node
+(its original `validFrom` / `updatedAt` / `version`). Enable it for
+at-least-once / replay materializers, where a byte-identical re-delivery would
+otherwise rewrite every row and grow recorded history by one per delivery. A
+write still happens (never coalesced) when the row is soft-deleted (an upsert
+resurrects it), when an explicit `validFrom` / `validTo` is passed, or when any
+prop differs after Zod normalization. The default is off, because some
+consumers want an audit row per re-delivery as proof the event was reprocessed.
+In a receipt, a coalesced upsert still counts as one write intent
+(`writes.total`) but captures nothing (`recorded` stays `undefined`) — the same
+shape as a no-op delete.
+
 #### `upsertByIdFromRecord(id, data, options?)`
 
 Upserts a node from untyped data, relying on runtime Zod validation. Same behavior
@@ -820,6 +837,11 @@ store.nodes.Person.bulkUpsertById(
   }[]
 ): Promise<Node<Person>[]>;
 ```
+
+With [`coalesceUnchangedUpserts: true`](#createstoregraph-backend-options) the
+dirty-check is applied per item: value-identical items are skipped from the
+write batch but still appear in the returned array (the existing node, in input
+order). See [`upsertById`](#upsertbyidid-props-options).
 
 #### `bulkDelete(ids)`
 

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -1283,6 +1283,16 @@ async function applyMergePlan<G extends GraphDef>(
  * merged edges already carry the canonical endpoint) attaches to the surviving
  * row, never a duplicate insert. This is what lets a base member be the canonical
  * survivor once base sources land. Exported for isolated commit-path testing.
+ *
+ * COALESCE INTERACTION: when the target store was created with
+ * `coalesceUnchangedUpserts`, a canonical/inherited upsert whose props already
+ * equal the committed row is skipped (no write, no recorded row). This is sound
+ * for merge and needs no bypass: the base@V guard runs BEFORE any upsert
+ * (see {@link assertTargetUnchanged}), conflicts are resolved at plan time, and
+ * an upsert-by-id never rewrites endpoints — so coalescing only elides writes
+ * that would persist a byte-identical value, leaving the merged state
+ * identical. It merely declines to re-stamp recorded time on rows the merge did
+ * not actually change, which is exactly the option's intent.
  */
 export async function commitPlan<G extends GraphDef>(
   target: Store<G>,

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -62,6 +62,19 @@ export type NodeOperations = Readonly<{
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Node>;
+  /**
+   * Coalesce dirty-check for `upsertById` / `bulkUpsertById`. Present only
+   * when the store was created with `coalesceUnchangedUpserts: true`; its
+   * absence is the off switch. Returns whether upserting `props` onto the
+   * given existing live row would leave the stored value unchanged (rule 4);
+   * the collection owns the other preconditions (not soft-deleted, no
+   * explicit temporal override).
+   */
+  isUpsertUnchanged?: (
+    kind: string,
+    existing: NodeRow,
+    props: Record<string, unknown>,
+  ) => boolean;
   executeDelete: (
     kind: string,
     id: string,
@@ -148,6 +161,17 @@ export type EdgeOperations = Readonly<{
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Edge>;
+  /**
+   * Coalesce dirty-check for `bulkUpsertById`. Present only when the store was
+   * created with `coalesceUnchangedUpserts: true`; its absence is the off
+   * switch. Returns whether upserting `props` onto the given existing live
+   * edge would leave the stored value unchanged (props only — endpoints are
+   * the edge's identity). The collection owns the other preconditions.
+   */
+  isUpsertUnchanged?: (
+    existing: EdgeRow,
+    props: Record<string, unknown>,
+  ) => boolean;
   executeDelete: (
     id: string,
     backend: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -67,11 +67,9 @@ export type NodeOperations = Readonly<{
    * when the store was created with `coalesceUnchangedUpserts: true`; its
    * absence is the off switch. Returns whether upserting `props` onto the
    * given existing live row would leave the stored value unchanged (rule 4);
-   * the collection owns the other preconditions (not soft-deleted, no
-   * explicit temporal override).
+   * the collection owns the other preconditions via `shouldCoalesceUpsert`.
    */
   isUpsertUnchanged?: (
-    kind: string,
     existing: NodeRow,
     props: Record<string, unknown>,
   ) => boolean;
@@ -166,7 +164,8 @@ export type EdgeOperations = Readonly<{
    * created with `coalesceUnchangedUpserts: true`; its absence is the off
    * switch. Returns whether upserting `props` onto the given existing live
    * edge would leave the stored value unchanged (props only — endpoints are
-   * the edge's identity). The collection owns the other preconditions.
+   * the edge's identity). The collection owns the other preconditions via
+   * `shouldCoalesceUpsert`.
    */
   isUpsertUnchanged?: (
     existing: EdgeRow,

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -11,6 +11,7 @@ import { KindNotFoundError } from "../errors";
 import { type QueryBuilder } from "../query/builder";
 import { type KindRegistry } from "../registry/kind-registry";
 import { createEdgeCollection, createNodeCollection } from "./collections";
+import { type UpsertDirtyCheckFunction } from "./collections/coalesce";
 import { type EdgeRow, type NodeRow } from "./row-mappers";
 import {
   type CreateEdgeInput,
@@ -63,16 +64,13 @@ export type NodeOperations = Readonly<{
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Node>;
   /**
-   * Coalesce dirty-check for `upsertById` / `bulkUpsertById`. Present only
-   * when the store was created with `coalesceUnchangedUpserts: true`; its
-   * absence is the off switch. Returns whether upserting `props` onto the
-   * given existing live row would leave the stored value unchanged (rule 4);
-   * the collection owns the other preconditions via `shouldCoalesceUpsert`.
+   * Coalesce dirty-check for `upsertById` / `bulkUpsertById`. Present only when
+   * the store was created with `coalesceUnchangedUpserts: true`; its absence is
+   * the off switch. Given the current (parsed) props, returns the props the
+   * upsert would persist and whether they are unchanged; the collection owns
+   * the other preconditions.
    */
-  isUpsertUnchanged?: (
-    existing: NodeRow,
-    props: Record<string, unknown>,
-  ) => boolean;
+  upsertDirtyCheck?: UpsertDirtyCheckFunction;
   executeDelete: (
     kind: string,
     id: string,
@@ -160,17 +158,11 @@ export type EdgeOperations = Readonly<{
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Edge>;
   /**
-   * Coalesce dirty-check for `bulkUpsertById`. Present only when the store was
-   * created with `coalesceUnchangedUpserts: true`; its absence is the off
-   * switch. Returns whether upserting `props` onto the given existing live
-   * edge would leave the stored value unchanged (props only — endpoints are
-   * the edge's identity). The collection owns the other preconditions via
-   * `shouldCoalesceUpsert`.
+   * Coalesce dirty-check for `bulkUpsertById` (props only — endpoints are the
+   * edge's identity). Present only when the store was created with
+   * `coalesceUnchangedUpserts: true`; its absence is the off switch.
    */
-  isUpsertUnchanged?: (
-    existing: EdgeRow,
-    props: Record<string, unknown>,
-  ) => boolean;
+  upsertDirtyCheck?: UpsertDirtyCheckFunction;
   executeDelete: (
     id: string,
     backend: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -19,16 +19,29 @@
  * `isUnchanged` returns `undefined` when the store did not enable coalescing
  * (the seam is absent), which fails the `=== true` check — so an unconfigured
  * store never coalesces.
+ *
+ * `isUnchanged` validates the input (rule 4 runs it through the kind's Zod
+ * schema) and so can throw a `ValidationError`. That throw is swallowed and
+ * treated as "do not coalesce": the write must not fail HERE, at the collection
+ * layer, ahead of the operation hooks — falling through to the normal write
+ * path re-runs the same validation inside the hooked pipeline, which raises the
+ * error with correct `onError` wiring (matching flag-off behavior).
  */
 export function shouldCoalesceUpsert(
   existing: Readonly<{ deleted_at: string | undefined }>,
   options: Readonly<{ validFrom?: string; validTo?: string }> | undefined,
   isUnchanged: () => boolean | undefined,
 ): boolean {
-  return (
-    existing.deleted_at === undefined &&
-    options?.validFrom === undefined &&
-    options?.validTo === undefined &&
-    isUnchanged() === true
-  );
+  if (
+    existing.deleted_at !== undefined ||
+    options?.validFrom !== undefined ||
+    options?.validTo !== undefined
+  ) {
+    return false;
+  }
+  try {
+    return isUnchanged() === true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared coalesce precondition gate for `upsertById` / `bulkUpsertById`.
+ *
+ * Centralizes the rules that must ALL hold before a value-identical upsert is
+ * skipped, so the node single-upsert, node bulk, and edge bulk paths cannot
+ * drift on when coalescing is legal (see
+ * {@link file://../types.ts BaseStoreOptions.coalesceUnchangedUpserts}):
+ *
+ *   1. The store enabled coalescing (`isUnchanged` is defined — its absence is
+ *      the off switch).
+ *   2. The existing row is not soft-deleted (an upsert onto a tombstone
+ *      resurrects it — a real write — never coalesce).
+ *   3. The caller passed no explicit `validFrom` / `validTo` (an explicit
+ *      temporal override is a deliberate request).
+ *   4. The validated props are value-identical to the stored props
+ *      (`isUnchanged`, evaluated last so the dirty-check runs only when the
+ *      cheap preconditions already passed).
+ *
+ * `isUnchanged` returns `undefined` when the store did not enable coalescing
+ * (the seam is absent), which fails the `=== true` check — so an unconfigured
+ * store never coalesces.
+ */
+export function shouldCoalesceUpsert(
+  existing: Readonly<{ deleted_at: string | undefined }>,
+  options: Readonly<{ validFrom?: string; validTo?: string }> | undefined,
+  isUnchanged: () => boolean | undefined,
+): boolean {
+  return (
+    existing.deleted_at === undefined &&
+    options?.validFrom === undefined &&
+    options?.validTo === undefined &&
+    isUnchanged() === true
+  );
+}

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -1,38 +1,56 @@
 /**
- * Shared coalesce precondition gate for `upsertById` / `bulkUpsertById`.
+ * Coalesce dirty-check shared by `upsertById` / `bulkUpsertById`.
  *
- * Centralizes the rules that must ALL hold before a value-identical upsert is
- * skipped, so the node single-upsert, node bulk, and edge bulk paths cannot
- * drift on when coalescing is legal (see
- * {@link file://../types.ts BaseStoreOptions.coalesceUnchangedUpserts}):
+ * A store created with `coalesceUnchangedUpserts` skips the write for an upsert
+ * whose validated props already equal the row's stored props (see
+ * {@link file://../types.ts BaseStoreOptions.coalesceUnchangedUpserts}).
+ */
+
+/**
+ * Result of the dirty check: the props the update WOULD persist (input merged
+ * over the current props and run through the kind's Zod schema), and whether
+ * they equal the current props (so the write can be skipped). `validatedProps`
+ * doubles as the batch-local running value a later same-id item is compared
+ * against in the bulk path.
+ */
+export type UpsertDirtyCheck = Readonly<{
+  validatedProps: Record<string, unknown>;
+  unchanged: boolean;
+}>;
+
+/**
+ * The seam collections call to run the dirty check. Present only when the store
+ * enabled coalescing; its absence is the off switch. `existingProps` is the
+ * PARSED current props — the prefetched row's, or the batch-local running value
+ * for a repeated id.
+ */
+export type UpsertDirtyCheckFunction = (
+  kind: string,
+  id: string,
+  existingProps: Record<string, unknown>,
+  inputProps: Record<string, unknown>,
+) => UpsertDirtyCheck;
+
+/**
+ * Whether a single upsert may be coalesced: coalescing is enabled
+ * (`runDirtyCheck` present), the row is live, no explicit temporal override was
+ * requested, and the props are unchanged. The dirty check runs last (only when
+ * the cheap preconditions pass).
  *
- *   1. The store enabled coalescing (`isUnchanged` is defined — its absence is
- *      the off switch).
- *   2. The existing row is not soft-deleted (an upsert onto a tombstone
- *      resurrects it — a real write — never coalesce).
- *   3. The caller passed no explicit `validFrom` / `validTo` (an explicit
- *      temporal override is a deliberate request).
- *   4. The validated props are value-identical to the stored props
- *      (`isUnchanged`, evaluated last so the dirty-check runs only when the
- *      cheap preconditions already passed).
- *
- * `isUnchanged` returns `undefined` when the store did not enable coalescing
- * (the seam is absent), which fails the `=== true` check — so an unconfigured
- * store never coalesces.
- *
- * `isUnchanged` validates the input (rule 4 runs it through the kind's Zod
- * schema) and so can throw a `ValidationError`. That throw is swallowed and
- * treated as "do not coalesce": the write must not fail HERE, at the collection
- * layer, ahead of the operation hooks — falling through to the normal write
- * path re-runs the same validation inside the hooked pipeline, which raises the
- * error with correct `onError` wiring (matching flag-off behavior).
+ * A throw from the dirty check is treated as "do not coalesce". The check
+ * validates the input, so it can throw a `ValidationError`; that must not fail
+ * HERE, ahead of the operation hooks. Falling through to the normal write path
+ * re-validates inside the hooked pipeline, which raises the error with correct
+ * `onError` wiring (matching flag-off) — the error is re-raised there, not
+ * swallowed.
  */
 export function shouldCoalesceUpsert(
   existing: Readonly<{ deleted_at: string | undefined }>,
   options: Readonly<{ validFrom?: string; validTo?: string }> | undefined,
-  isUnchanged: () => boolean | undefined,
+  runDirtyCheck: (() => UpsertDirtyCheck) | undefined,
 ): boolean {
   if (
+    runDirtyCheck === undefined ||
     existing.deleted_at !== undefined ||
     options?.validFrom !== undefined ||
     options?.validTo !== undefined
@@ -40,7 +58,7 @@ export function shouldCoalesceUpsert(
     return false;
   }
   try {
-    return isUnchanged() === true;
+    return runDirtyCheck().unchanged;
   } catch {
     return false;
   }

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -29,6 +29,7 @@ import {
   type NodeRef,
   type QueryOptions,
 } from "../types";
+import { shouldCoalesceUpsert } from "./coalesce";
 import {
   resolveTemporalReadParams,
   type TemporalReadParams,
@@ -548,19 +549,17 @@ export function createEdgeCollection<
           const existing = existingMap.get(item.id);
 
           if (existing) {
-            const clearDeleted = existing.deleted_at !== undefined;
             if (
-              !clearDeleted &&
-              item.validFrom === undefined &&
-              item.validTo === undefined &&
-              config.isUpsertUnchanged?.(existing, item.props ?? {}) === true
+              shouldCoalesceUpsert(existing, item, () =>
+                config.isUpsertUnchanged?.(existing, item.props ?? {}),
+              )
             ) {
               results[itemIndex] = narrowEdge<E>(rowToEdge(existing));
             } else {
               toUpdate.push({
                 index: itemIndex,
                 input: buildUpdateEdgeInput(item.id, item.props ?? {}, item),
-                clearDeleted,
+                clearDeleted: existing.deleted_at !== undefined,
               });
             }
           } else {
@@ -577,7 +576,6 @@ export function createEdgeCollection<
           }
           itemIndex++;
         }
-
 
         if (toCreate.length > 0) {
           const createInputs = toCreate.map((entry) => entry.input);

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -90,6 +90,11 @@ export type EdgeCollectionConfig = Readonly<{
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Edge>;
+  /** See EdgeOperations.isUpsertUnchanged. */
+  isUpsertUnchanged?: (
+    existing: EdgeRow,
+    props: Record<string, unknown>,
+  ) => boolean;
   executeDelete: (
     id: string,
     backend: GraphBackend | TransactionBackend,
@@ -525,6 +530,11 @@ export function createEdgeCollection<
         const ids = items.map((item) => item.id);
         const existingMap = await getEdgeRowsByIds(target, graphId, ids);
 
+        // Coalesced items are written straight to results (the existing edge)
+        // and skipped from the write batch; see the node collection and
+        // BaseStoreOptions.coalesceUnchangedUpserts.
+        const results: Edge<E>[] = Array.from({ length: items.length });
+
         // Bucket items into creates and updates
         const toCreate: { index: number; input: CreateEdgeInput }[] = [];
         const toUpdate: {
@@ -538,11 +548,21 @@ export function createEdgeCollection<
           const existing = existingMap.get(item.id);
 
           if (existing) {
-            toUpdate.push({
-              index: itemIndex,
-              input: buildUpdateEdgeInput(item.id, item.props ?? {}, item),
-              clearDeleted: existing.deleted_at !== undefined,
-            });
+            const clearDeleted = existing.deleted_at !== undefined;
+            if (
+              !clearDeleted &&
+              item.validFrom === undefined &&
+              item.validTo === undefined &&
+              config.isUpsertUnchanged?.(existing, item.props ?? {}) === true
+            ) {
+              results[itemIndex] = narrowEdge<E>(rowToEdge(existing));
+            } else {
+              toUpdate.push({
+                index: itemIndex,
+                input: buildUpdateEdgeInput(item.id, item.props ?? {}, item),
+                clearDeleted,
+              });
+            }
           } else {
             toCreate.push({
               index: itemIndex,
@@ -558,8 +578,6 @@ export function createEdgeCollection<
           itemIndex++;
         }
 
-        // Hookless batch create
-        const results: Edge<E>[] = Array.from({ length: items.length });
 
         if (toCreate.length > 0) {
           const createInputs = toCreate.map((entry) => entry.input);

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -8,6 +8,7 @@ import { type z } from "zod";
 import {
   type FindEdgesByKindParams,
   type GraphBackend,
+  rowPropsToObject,
   type TransactionBackend,
 } from "../../backend/types";
 import { type GraphDef } from "../../core/define-graph";
@@ -29,7 +30,10 @@ import {
   type NodeRef,
   type QueryOptions,
 } from "../types";
-import { shouldCoalesceUpsert } from "./coalesce";
+import {
+  type UpsertDirtyCheck,
+  type UpsertDirtyCheckFunction,
+} from "./coalesce";
 import {
   resolveTemporalReadParams,
   type TemporalReadParams,
@@ -91,11 +95,8 @@ export type EdgeCollectionConfig = Readonly<{
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Edge>;
-  /** See EdgeOperations.isUpsertUnchanged. */
-  isUpsertUnchanged?: (
-    existing: EdgeRow,
-    props: Record<string, unknown>,
-  ) => boolean;
+  /** See EdgeOperations.upsertDirtyCheck. */
+  upsertDirtyCheck?: UpsertDirtyCheckFunction;
   executeDelete: (
     id: string,
     backend: GraphBackend | TransactionBackend,
@@ -531,9 +532,9 @@ export function createEdgeCollection<
         const ids = items.map((item) => item.id);
         const existingMap = await getEdgeRowsByIds(target, graphId, ids);
 
-        // Coalesced items are written straight to results (the existing edge)
-        // and skipped from the write batch; see the node collection and
-        // BaseStoreOptions.coalesceUnchangedUpserts.
+        // Coalesced items are written straight to results (the existing or
+        // last-written edge) and skipped from the write batch; see the node
+        // collection and BaseStoreOptions.coalesceUnchangedUpserts.
         const results: Edge<E>[] = Array.from({ length: items.length });
 
         // Bucket items into creates and updates
@@ -544,42 +545,84 @@ export function createEdgeCollection<
           clearDeleted: boolean;
         }[] = [];
 
-        // Only the FIRST occurrence of an id may coalesce; a repeated id always
-        // writes so last-write-wins is preserved. See the node collection.
-        const seenIds = new Set<string>();
+        // Batch-local running state per id so a repeated id coalesces against
+        // the value earlier items in this batch would write, preserving
+        // last-write-wins. See the node collection for the full rationale.
+        const pending = new Map<
+          string,
+          { props: Record<string, unknown>; sourceIndex: number }
+        >();
+        const deferred: { index: number; sourceIndex: number }[] = [];
 
         let itemIndex = 0;
         for (const item of items) {
-          const existing = existingMap.get(item.id);
-          const firstOccurrence = !seenIds.has(item.id);
-          seenIds.add(item.id);
+          const pendingEntry = pending.get(item.id);
+          const original = existingMap.get(item.id);
+          const inputProps = item.props ?? {};
 
-          if (existing) {
-            if (
-              firstOccurrence &&
-              shouldCoalesceUpsert(existing, item, () =>
-                config.isUpsertUnchanged?.(existing, item.props ?? {}),
-              )
-            ) {
-              results[itemIndex] = narrowEdge<E>(rowToEdge(existing));
-            } else {
-              toUpdate.push({
-                index: itemIndex,
-                input: buildUpdateEdgeInput(item.id, item.props ?? {}, item),
-                clearDeleted: existing.deleted_at !== undefined,
-              });
-            }
-          } else {
+          if (pendingEntry === undefined && original === undefined) {
             toCreate.push({
               index: itemIndex,
               input: buildCreateEdgeInput(
                 kind,
                 item.from,
                 item.to,
-                item.props ?? {},
+                inputProps,
                 item,
               ),
             });
+            itemIndex++;
+            continue;
+          }
+
+          const deletedAt =
+            pendingEntry === undefined ? original!.deleted_at : undefined;
+
+          let dirty: UpsertDirtyCheck | undefined;
+          if (config.upsertDirtyCheck !== undefined) {
+            const currentProps =
+              pendingEntry?.props ?? rowPropsToObject(original!.props);
+            try {
+              // The fetched edge carries the authoritative kind (an id may
+              // resolve to a different edge kind than this collection).
+              dirty = config.upsertDirtyCheck(
+                original?.kind ?? kind,
+                item.id,
+                currentProps,
+                inputProps,
+              );
+            } catch {
+              dirty = undefined;
+            }
+          }
+
+          const coalesce =
+            dirty?.unchanged === true &&
+            deletedAt === undefined &&
+            item.validFrom === undefined &&
+            item.validTo === undefined;
+
+          if (coalesce) {
+            if (pendingEntry === undefined) {
+              results[itemIndex] = narrowEdge<E>(rowToEdge(original!));
+            } else {
+              deferred.push({
+                index: itemIndex,
+                sourceIndex: pendingEntry.sourceIndex,
+              });
+            }
+          } else {
+            toUpdate.push({
+              index: itemIndex,
+              input: buildUpdateEdgeInput(item.id, inputProps, item),
+              clearDeleted: deletedAt !== undefined,
+            });
+            if (dirty !== undefined) {
+              pending.set(item.id, {
+                props: dirty.validatedProps,
+                sourceIndex: itemIndex,
+              });
+            }
           }
           itemIndex++;
         }
@@ -598,6 +641,12 @@ export function createEdgeCollection<
             clearDeleted: entry.clearDeleted,
           });
           results[entry.index] = narrowEdge<E>(result);
+        }
+
+        // Items that coalesced against an in-batch write take that write's
+        // result (now filled). Its sourceIndex is always a write slot.
+        for (const { index, sourceIndex } of deferred) {
+          results[index] = results[sourceIndex]!;
         }
 
         return { results, mutations: toCreate.length + toUpdate.length };

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -527,7 +527,7 @@ export function createEdgeCollection<
 
       const upsertAll = async (
         target: GraphBackend | TransactionBackend,
-      ): Promise<Edge<E>[]> => {
+      ): Promise<{ results: Edge<E>[]; mutations: number }> => {
         const ids = items.map((item) => item.id);
         const existingMap = await getEdgeRowsByIds(target, graphId, ids);
 
@@ -544,12 +544,19 @@ export function createEdgeCollection<
           clearDeleted: boolean;
         }[] = [];
 
+        // Only the FIRST occurrence of an id may coalesce; a repeated id always
+        // writes so last-write-wins is preserved. See the node collection.
+        const seenIds = new Set<string>();
+
         let itemIndex = 0;
         for (const item of items) {
           const existing = existingMap.get(item.id);
+          const firstOccurrence = !seenIds.has(item.id);
+          seenIds.add(item.id);
 
           if (existing) {
             if (
+              firstOccurrence &&
               shouldCoalesceUpsert(existing, item, () =>
                 config.isUpsertUnchanged?.(existing, item.props ?? {}),
               )
@@ -593,17 +600,18 @@ export function createEdgeCollection<
           results[entry.index] = narrowEdge<E>(result);
         }
 
-        return results;
+        return { results, mutations: toCreate.length + toUpdate.length };
       };
 
-      const results =
+      const { results, mutations } =
         backend.capabilities.transactions && "transaction" in backend ?
           await backend.transaction(async (txBackend) => upsertAll(txBackend))
         : await upsertAll(backend);
       // Match bulkCreate/bulkInsert: refresh planner statistics after a large
-      // autocommit bulk write. Threshold-gated, and a no-op inside a caller
+      // autocommit bulk write. Coalesced items wrote nothing, so only real
+      // mutations count toward the threshold. A no-op inside a caller
       // transaction (the hook is intentionally undefined there).
-      await config.maybeRefreshStatisticsAfterBulk?.(results.length);
+      await config.maybeRefreshStatisticsAfterBulk?.(mutations);
       return results;
     },
 

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -84,6 +84,12 @@ export type NodeCollectionConfig = Readonly<{
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Node>;
+  /** See NodeOperations.isUpsertUnchanged. */
+  isUpsertUnchanged?: (
+    kind: string,
+    existing: NodeRow,
+    props: Record<string, unknown>,
+  ) => boolean;
   executeDelete: (
     kind: string,
     id: string,
@@ -358,6 +364,19 @@ export function createNodeCollection<
 
       if (existing) {
         const clearDeleted = existing.deleted_at !== undefined;
+        // Coalesce a value-identical replay: skip the write entirely (no
+        // updateNode, no recorded capture, no revision advance, no hooks) and
+        // resolve with the existing node. Only when the store enabled it, the
+        // row is live, no explicit temporal override was requested, and the
+        // validated props match. See BaseStoreOptions.coalesceUnchangedUpserts.
+        if (
+          !clearDeleted &&
+          options?.validFrom === undefined &&
+          options?.validTo === undefined &&
+          config.isUpsertUnchanged?.(kind, existing, data) === true
+        ) {
+          return narrowNode<N>(rowToNode(existing));
+        }
         const result = await executeNodeUpdate(
           buildUpdateInput(kind, id, data, options),
           backend,
@@ -409,12 +428,9 @@ export function createNodeCollection<
         target: GraphBackend | TransactionBackend,
       ): Promise<Node<N>[]> => {
         const ids = items.map((item) => item.id);
-        const existingMap = new Map<
-          string,
-          {
-            deleted_at: string | undefined;
-          }
-        >();
+        // Full existing rows: the coalesce dirty-check needs their stored
+        // props, not just deleted_at.
+        const existingMap = new Map<string, NodeRow>();
 
         if (target.getNodes === undefined) {
           const rows = await Promise.all(
@@ -430,6 +446,11 @@ export function createNodeCollection<
           }
         }
 
+        // Coalesced items are written straight to results (the existing node)
+        // and skipped from the write batch; see the single-upsert path and
+        // BaseStoreOptions.coalesceUnchangedUpserts.
+        const results: Node<N>[] = Array.from({ length: items.length });
+
         // Bucket items into creates and updates
         const toCreate: { index: number; input: CreateNodeInput }[] = [];
         const toUpdate: {
@@ -443,11 +464,21 @@ export function createNodeCollection<
           const existing = existingMap.get(item.id);
 
           if (existing) {
-            toUpdate.push({
-              index: itemIndex,
-              input: buildUpdateInput(kind, item.id, item.props, item),
-              clearDeleted: existing.deleted_at !== undefined,
-            });
+            const clearDeleted = existing.deleted_at !== undefined;
+            if (
+              !clearDeleted &&
+              item.validFrom === undefined &&
+              item.validTo === undefined &&
+              config.isUpsertUnchanged?.(kind, existing, item.props) === true
+            ) {
+              results[itemIndex] = narrowNode<N>(rowToNode(existing));
+            } else {
+              toUpdate.push({
+                index: itemIndex,
+                input: buildUpdateInput(kind, item.id, item.props, item),
+                clearDeleted,
+              });
+            }
           } else {
             toCreate.push({
               index: itemIndex,
@@ -457,8 +488,6 @@ export function createNodeCollection<
           itemIndex++;
         }
 
-        // Hookless batch create
-        const results: Node<N>[] = Array.from({ length: items.length });
 
         if (toCreate.length > 0) {
           const createInputs = toCreate.map((entry) => entry.input);

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -423,7 +423,7 @@ export function createNodeCollection<
 
       const upsertAll = async (
         target: GraphBackend | TransactionBackend,
-      ): Promise<Node<N>[]> => {
+      ): Promise<{ results: Node<N>[]; mutations: number }> => {
         const ids = items.map((item) => item.id);
         // Full existing rows: the coalesce dirty-check needs their stored
         // props, not just deleted_at.
@@ -456,12 +456,23 @@ export function createNodeCollection<
           clearDeleted: boolean;
         }[] = [];
 
+        // Only the FIRST occurrence of an id in this batch may coalesce: the
+        // dirty-check compares against the once-prefetched row, so a later
+        // same-id item would otherwise coalesce against stale state and drop
+        // an earlier queued write (breaking last-write-wins). A repeated id
+        // always writes; the sequential updates below re-read in order, so the
+        // last item's value wins as before coalescing existed.
+        const seenIds = new Set<string>();
+
         let itemIndex = 0;
         for (const item of items) {
           const existing = existingMap.get(item.id);
+          const firstOccurrence = !seenIds.has(item.id);
+          seenIds.add(item.id);
 
           if (existing) {
             if (
+              firstOccurrence &&
               shouldCoalesceUpsert(existing, item, () =>
                 config.isUpsertUnchanged?.(existing, item.props),
               )
@@ -499,17 +510,18 @@ export function createNodeCollection<
           results[entry.index] = narrowNode<N>(result);
         }
 
-        return results;
+        return { results, mutations: toCreate.length + toUpdate.length };
       };
 
-      const results =
+      const { results, mutations } =
         backend.capabilities.transactions && "transaction" in backend ?
           await backend.transaction(async (txBackend) => upsertAll(txBackend))
         : await upsertAll(backend);
       // Match bulkCreate/bulkInsert: refresh planner statistics after a large
-      // autocommit bulk write. Threshold-gated, and a no-op inside a caller
+      // autocommit bulk write. Coalesced items wrote nothing, so only real
+      // mutations count toward the threshold. A no-op inside a caller
       // transaction (the hook is intentionally undefined there).
-      await config.maybeRefreshStatisticsAfterBulk?.(results.length);
+      await config.maybeRefreshStatisticsAfterBulk?.(mutations);
       return results;
     },
 

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -7,6 +7,7 @@ import { type z } from "zod";
 
 import {
   type GraphBackend,
+  rowPropsToObject,
   type TransactionBackend,
 } from "../../backend/types";
 import { type GraphDef } from "../../core/define-graph";
@@ -30,7 +31,11 @@ import {
   type QueryOptions,
   type UpdateNodeInput,
 } from "../types";
-import { shouldCoalesceUpsert } from "./coalesce";
+import {
+  shouldCoalesceUpsert,
+  type UpsertDirtyCheck,
+  type UpsertDirtyCheckFunction,
+} from "./coalesce";
 import {
   resolveTemporalReadParams,
   type TemporalReadParams,
@@ -85,11 +90,8 @@ export type NodeCollectionConfig = Readonly<{
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{ clearDeleted?: boolean }>,
   ) => Promise<Node>;
-  /** See NodeOperations.isUpsertUnchanged. */
-  isUpsertUnchanged?: (
-    existing: NodeRow,
-    props: Record<string, unknown>,
-  ) => boolean;
+  /** See NodeOperations.upsertDirtyCheck. */
+  upsertDirtyCheck?: UpsertDirtyCheckFunction;
   executeDelete: (
     kind: string,
     id: string,
@@ -367,11 +369,16 @@ export function createNodeCollection<
         // updateNode, no recorded capture, no revision advance, no hooks) and
         // resolve with the existing node. See
         // BaseStoreOptions.coalesceUnchangedUpserts.
-        if (
-          shouldCoalesceUpsert(existing, options, () =>
-            config.isUpsertUnchanged?.(existing, data),
-          )
-        ) {
+        const runDirtyCheck =
+          config.upsertDirtyCheck &&
+          (() =>
+            config.upsertDirtyCheck!(
+              kind,
+              id,
+              rowPropsToObject(existing.props),
+              data,
+            ));
+        if (shouldCoalesceUpsert(existing, options, runDirtyCheck)) {
           return narrowNode<N>(rowToNode(existing));
         }
         const result = await executeNodeUpdate(
@@ -443,9 +450,9 @@ export function createNodeCollection<
           }
         }
 
-        // Coalesced items are written straight to results (the existing node)
-        // and skipped from the write batch; see the single-upsert path and
-        // BaseStoreOptions.coalesceUnchangedUpserts.
+        // Coalesced items are written straight to results (the existing or
+        // last-written node) and skipped from the write batch; see the
+        // single-upsert path and BaseStoreOptions.coalesceUnchangedUpserts.
         const results: Node<N>[] = Array.from({ length: items.length });
 
         // Bucket items into creates and updates
@@ -456,40 +463,84 @@ export function createNodeCollection<
           clearDeleted: boolean;
         }[] = [];
 
-        // Only the FIRST occurrence of an id in this batch may coalesce: the
-        // dirty-check compares against the once-prefetched row, so a later
-        // same-id item would otherwise coalesce against stale state and drop
-        // an earlier queued write (breaking last-write-wins). A repeated id
-        // always writes; the sequential updates below re-read in order, so the
-        // last item's value wins as before coalescing existed.
-        const seenIds = new Set<string>();
+        // Batch-local running state per id: the props the row would hold after
+        // the writes queued so far, and the item index that queued that write.
+        // A later same-id item coalesces against this running value, not the
+        // once-prefetched row — otherwise [{x:B},{x:A}] on a row holding A would
+        // coalesce the second item against the stale prefetched A and drop the
+        // first item's write, breaking last-write-wins.
+        const pending = new Map<
+          string,
+          { props: Record<string, unknown>; sourceIndex: number }
+        >();
+        // A coalesced item that matched an in-batch write resolves to that
+        // write's result (filled once the writes run), not a fabricated row.
+        const deferred: { index: number; sourceIndex: number }[] = [];
 
         let itemIndex = 0;
         for (const item of items) {
-          const existing = existingMap.get(item.id);
-          const firstOccurrence = !seenIds.has(item.id);
-          seenIds.add(item.id);
+          const pendingEntry = pending.get(item.id);
+          const original = existingMap.get(item.id);
 
-          if (existing) {
-            if (
-              firstOccurrence &&
-              shouldCoalesceUpsert(existing, item, () =>
-                config.isUpsertUnchanged?.(existing, item.props),
-              )
-            ) {
-              results[itemIndex] = narrowNode<N>(rowToNode(existing));
-            } else {
-              toUpdate.push({
-                index: itemIndex,
-                input: buildUpdateInput(kind, item.id, item.props, item),
-                clearDeleted: existing.deleted_at !== undefined,
-              });
-            }
-          } else {
+          if (pendingEntry === undefined && original === undefined) {
             toCreate.push({
               index: itemIndex,
               input: buildCreateInput(kind, item.props, item),
             });
+            itemIndex++;
+            continue;
+          }
+
+          // A prior in-batch write left the row live; only the prefetched row
+          // (no prior write) can be soft-deleted and trigger a resurrection.
+          const deletedAt =
+            pendingEntry === undefined ? original!.deleted_at : undefined;
+
+          let dirty: UpsertDirtyCheck | undefined;
+          if (config.upsertDirtyCheck !== undefined) {
+            const currentProps =
+              pendingEntry?.props ?? rowPropsToObject(original!.props);
+            try {
+              dirty = config.upsertDirtyCheck(
+                kind,
+                item.id,
+                currentProps,
+                item.props,
+              );
+            } catch {
+              // Validation error → fall through to the write path, which
+              // re-validates and rejects the batch (matching flag-off).
+              dirty = undefined;
+            }
+          }
+
+          const coalesce =
+            dirty?.unchanged === true &&
+            deletedAt === undefined &&
+            item.validFrom === undefined &&
+            item.validTo === undefined;
+
+          if (coalesce) {
+            if (pendingEntry === undefined) {
+              results[itemIndex] = narrowNode<N>(rowToNode(original!));
+            } else {
+              deferred.push({
+                index: itemIndex,
+                sourceIndex: pendingEntry.sourceIndex,
+              });
+            }
+          } else {
+            toUpdate.push({
+              index: itemIndex,
+              input: buildUpdateInput(kind, item.id, item.props, item),
+              clearDeleted: deletedAt !== undefined,
+            });
+            if (dirty !== undefined) {
+              pending.set(item.id, {
+                props: dirty.validatedProps,
+                sourceIndex: itemIndex,
+              });
+            }
           }
           itemIndex++;
         }
@@ -508,6 +559,12 @@ export function createNodeCollection<
             clearDeleted: entry.clearDeleted,
           });
           results[entry.index] = narrowNode<N>(result);
+        }
+
+        // Items that coalesced against an in-batch write take that write's
+        // result (now filled). Its sourceIndex is always a write slot.
+        for (const { index, sourceIndex } of deferred) {
+          results[index] = results[sourceIndex]!;
         }
 
         return { results, mutations: toCreate.length + toUpdate.length };

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -30,6 +30,7 @@ import {
   type QueryOptions,
   type UpdateNodeInput,
 } from "../types";
+import { shouldCoalesceUpsert } from "./coalesce";
 import {
   resolveTemporalReadParams,
   type TemporalReadParams,
@@ -86,7 +87,6 @@ export type NodeCollectionConfig = Readonly<{
   ) => Promise<Node>;
   /** See NodeOperations.isUpsertUnchanged. */
   isUpsertUnchanged?: (
-    kind: string,
     existing: NodeRow,
     props: Record<string, unknown>,
   ) => boolean;
@@ -363,24 +363,21 @@ export function createNodeCollection<
       const existing = await backend.getNode(graphId, kind, id);
 
       if (existing) {
-        const clearDeleted = existing.deleted_at !== undefined;
         // Coalesce a value-identical replay: skip the write entirely (no
         // updateNode, no recorded capture, no revision advance, no hooks) and
-        // resolve with the existing node. Only when the store enabled it, the
-        // row is live, no explicit temporal override was requested, and the
-        // validated props match. See BaseStoreOptions.coalesceUnchangedUpserts.
+        // resolve with the existing node. See
+        // BaseStoreOptions.coalesceUnchangedUpserts.
         if (
-          !clearDeleted &&
-          options?.validFrom === undefined &&
-          options?.validTo === undefined &&
-          config.isUpsertUnchanged?.(kind, existing, data) === true
+          shouldCoalesceUpsert(existing, options, () =>
+            config.isUpsertUnchanged?.(existing, data),
+          )
         ) {
           return narrowNode<N>(rowToNode(existing));
         }
         const result = await executeNodeUpdate(
           buildUpdateInput(kind, id, data, options),
           backend,
-          { clearDeleted },
+          { clearDeleted: existing.deleted_at !== undefined },
         );
         return narrowNode<N>(result);
       }
@@ -464,19 +461,17 @@ export function createNodeCollection<
           const existing = existingMap.get(item.id);
 
           if (existing) {
-            const clearDeleted = existing.deleted_at !== undefined;
             if (
-              !clearDeleted &&
-              item.validFrom === undefined &&
-              item.validTo === undefined &&
-              config.isUpsertUnchanged?.(kind, existing, item.props) === true
+              shouldCoalesceUpsert(existing, item, () =>
+                config.isUpsertUnchanged?.(existing, item.props),
+              )
             ) {
               results[itemIndex] = narrowNode<N>(rowToNode(existing));
             } else {
               toUpdate.push({
                 index: itemIndex,
                 input: buildUpdateInput(kind, item.id, item.props, item),
-                clearDeleted,
+                clearDeleted: existing.deleted_at !== undefined,
               });
             }
           } else {
@@ -487,7 +482,6 @@ export function createNodeCollection<
           }
           itemIndex++;
         }
-
 
         if (toCreate.length > 0) {
           const createInputs = toCreate.map((entry) => entry.input);

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -33,6 +33,7 @@ import { type KindRegistry } from "../../registry/kind-registry";
 import { canonicalEqual } from "../../schema/canonical";
 import { validateOptionalCanonicalIsoDate } from "../../utils/date";
 import { generateId } from "../../utils/id";
+import { type UpsertDirtyCheck } from "../collections/coalesce";
 import {
   checkCardinalityConstraint,
   type ConstraintContext,
@@ -629,11 +630,30 @@ export async function executeEdgeCreateBatch<G extends GraphDef>(
 }
 
 /**
- * The exact props an edge update would persist: the live edge's stored props
- * with the caller's partial input merged over them, run through the edge
- * kind's Zod schema. Shared by {@link performEdgeUpdate} and
- * {@link isEdgeUpsertUnchanged} so the coalesce dirty-check and the write it
- * guards can never disagree on "what would be written".
+ * The exact props an edge update would persist: the caller's partial input
+ * merged over the current props and run through the edge kind's Zod schema.
+ * Operates on PARSED props so the write path and the coalesce dirty-check
+ * (which may compare against a batch-local running value, never a row) share
+ * one validation. Endpoints are the edge's identity and are not part of an
+ * upsert-by-id update, so only props are involved.
+ */
+function computeEdgeUpdate<G extends GraphDef>(
+  ctx: EdgeOperationContext<G>,
+  kind: string,
+  id: string,
+  existingProps: Record<string, unknown>,
+  inputProps: Partial<Record<string, unknown>>,
+): Record<string, unknown> {
+  const registration = getEdgeRegistration(ctx.graph, kind);
+  return validateEdgeProps(
+    registration.type.schema,
+    { ...existingProps, ...inputProps },
+    { kind, operation: "update", id },
+  );
+}
+
+/**
+ * Row-based wrapper over {@link computeEdgeUpdate} for the write path.
  */
 function resolveEdgeUpdateProps<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
@@ -643,44 +663,40 @@ function resolveEdgeUpdateProps<G extends GraphDef>(
   existingProps: Record<string, unknown>;
   validatedProps: Record<string, unknown>;
 }> {
-  const registration = getEdgeRegistration(ctx.graph, existing.kind);
   const existingProps = rowPropsToObject(existing.props);
-  const mergedProps = { ...existingProps, ...inputProps };
-  const validatedProps = validateEdgeProps(
-    registration.type.schema,
-    mergedProps,
-    {
-      kind: existing.kind,
-      operation: "update",
-      id: existing.id,
-    },
+  const validatedProps = computeEdgeUpdate(
+    ctx,
+    existing.kind,
+    existing.id,
+    existingProps,
+    inputProps,
   );
   return { existingProps, validatedProps };
 }
 
 /**
- * Whether an upsert of `inputProps` onto the given live edge would leave the
- * stored value unchanged — the edge coalesce dirty-check. Endpoints are the
- * edge's identity and are not part of an upsert-by-id update, so only props
- * are compared, on the storage-normalized (validated, key-order-independent)
- * representation.
- *
- * Callers own the other coalescing preconditions (existing, not soft-deleted,
- * no explicit temporal override); this covers rule 4 only. Mirrors
- * {@link isNodeUpsertUnchanged}: the resolved props are not threaded into the
- * write path, which re-reads and re-validates under its own transaction.
+ * The edge coalesce dirty-check: returns the props an upsert would persist and
+ * whether they equal `existingProps`. `existingProps` is the PARSED current
+ * props — the edge's, or the batch-local running value for a repeated id.
  */
-export function isEdgeUpsertUnchanged<G extends GraphDef>(
+export function edgeUpsertDirtyCheck<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
-  existing: EdgeRow,
+  kind: string,
+  id: string,
+  existingProps: Record<string, unknown>,
   inputProps: Record<string, unknown>,
-): boolean {
-  const { existingProps, validatedProps } = resolveEdgeUpdateProps(
+): UpsertDirtyCheck {
+  const validatedProps = computeEdgeUpdate(
     ctx,
-    existing,
+    kind,
+    id,
+    existingProps,
     inputProps,
   );
-  return canonicalEqual(validatedProps, existingProps);
+  return {
+    validatedProps,
+    unchanged: canonicalEqual(validatedProps, existingProps),
+  };
 }
 
 /**

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -42,7 +42,8 @@ import {
   runInsertBatchReturning,
   runInsertNoReturn,
 } from "../insert-dispatch";
-import { rowToEdge } from "../row-mappers";
+import { canonicalEqual } from "../../schema/canonical";
+import { type EdgeRow, rowToEdge } from "../row-mappers";
 import {
   type CreateEdgeInput,
   type Edge,
@@ -632,6 +633,55 @@ export async function executeEdgeCreateBatch<G extends GraphDef>(
  * and validates props, and writes. A plain update requires a live edge; a
  * resurrecting upsert (`clearDeleted`) may target a tombstoned one.
  */
+/**
+ * The exact props an edge update would persist: the live edge's stored props
+ * with the caller's partial input merged over them, run through the edge
+ * kind's Zod schema. Shared by {@link performEdgeUpdate} and
+ * {@link isEdgeUpsertUnchanged} so the coalesce dirty-check and the write it
+ * guards can never disagree on "what would be written".
+ */
+function resolveEdgeUpdateProps<G extends GraphDef>(
+  ctx: EdgeOperationContext<G>,
+  existing: Pick<EdgeRow, "kind" | "id" | "props">,
+  inputProps: Partial<Record<string, unknown>>,
+): Readonly<{
+  existingProps: Record<string, unknown>;
+  validatedProps: Record<string, unknown>;
+}> {
+  const registration = getEdgeRegistration(ctx.graph, existing.kind);
+  const existingProps = rowPropsToObject(existing.props);
+  const mergedProps = { ...existingProps, ...inputProps };
+  const validatedProps = validateEdgeProps(registration.type.schema, mergedProps, {
+    kind: existing.kind,
+    operation: "update",
+    id: existing.id,
+  });
+  return { existingProps, validatedProps };
+}
+
+/**
+ * Whether an upsert of `inputProps` onto the given live edge would leave the
+ * stored value unchanged — the edge coalesce dirty-check. Endpoints are the
+ * edge's identity and are not part of an upsert-by-id update, so only props
+ * are compared, on the storage-normalized (validated, key-order-independent)
+ * representation.
+ *
+ * Callers own the other coalescing preconditions (existing, not soft-deleted,
+ * no explicit temporal override); this covers rule 4 only.
+ */
+export function isEdgeUpsertUnchanged<G extends GraphDef>(
+  ctx: EdgeOperationContext<G>,
+  existing: EdgeRow,
+  inputProps: Record<string, unknown>,
+): boolean {
+  const { existingProps, validatedProps } = resolveEdgeUpdateProps(
+    ctx,
+    existing,
+    inputProps,
+  );
+  return canonicalEqual(validatedProps, existingProps);
+}
+
 async function performEdgeUpdate<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
   input: {
@@ -649,17 +699,7 @@ async function performEdgeUpdate<G extends GraphDef>(
     throw new EdgeNotFoundError("unknown", id);
   }
 
-  const registration = getEdgeRegistration(ctx.graph, existing.kind);
-  const edgeKind = registration.type;
-
-  const existingProps = rowPropsToObject(existing.props);
-  const mergedProps = { ...existingProps, ...input.props };
-
-  const validatedProps = validateEdgeProps(edgeKind.schema, mergedProps, {
-    kind: existing.kind,
-    operation: "update",
-    id,
-  });
+  const { validatedProps } = resolveEdgeUpdateProps(ctx, existing, input.props);
 
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
 

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -30,6 +30,7 @@ import {
 import { validateEdgeProps } from "../../errors/validation";
 import { type SqlSchema } from "../../query/compiler/schema";
 import { type KindRegistry } from "../../registry/kind-registry";
+import { canonicalEqual } from "../../schema/canonical";
 import { validateOptionalCanonicalIsoDate } from "../../utils/date";
 import { generateId } from "../../utils/id";
 import {
@@ -42,7 +43,6 @@ import {
   runInsertBatchReturning,
   runInsertNoReturn,
 } from "../insert-dispatch";
-import { canonicalEqual } from "../../schema/canonical";
 import { type EdgeRow, rowToEdge } from "../row-mappers";
 import {
   type CreateEdgeInput,
@@ -629,11 +629,6 @@ export async function executeEdgeCreateBatch<G extends GraphDef>(
 }
 
 /**
- * Shared edge-update body: re-reads the edge inside the transaction, merges
- * and validates props, and writes. A plain update requires a live edge; a
- * resurrecting upsert (`clearDeleted`) may target a tombstoned one.
- */
-/**
  * The exact props an edge update would persist: the live edge's stored props
  * with the caller's partial input merged over them, run through the edge
  * kind's Zod schema. Shared by {@link performEdgeUpdate} and
@@ -651,11 +646,15 @@ function resolveEdgeUpdateProps<G extends GraphDef>(
   const registration = getEdgeRegistration(ctx.graph, existing.kind);
   const existingProps = rowPropsToObject(existing.props);
   const mergedProps = { ...existingProps, ...inputProps };
-  const validatedProps = validateEdgeProps(registration.type.schema, mergedProps, {
-    kind: existing.kind,
-    operation: "update",
-    id: existing.id,
-  });
+  const validatedProps = validateEdgeProps(
+    registration.type.schema,
+    mergedProps,
+    {
+      kind: existing.kind,
+      operation: "update",
+      id: existing.id,
+    },
+  );
   return { existingProps, validatedProps };
 }
 
@@ -667,7 +666,9 @@ function resolveEdgeUpdateProps<G extends GraphDef>(
  * representation.
  *
  * Callers own the other coalescing preconditions (existing, not soft-deleted,
- * no explicit temporal override); this covers rule 4 only.
+ * no explicit temporal override); this covers rule 4 only. Mirrors
+ * {@link isNodeUpsertUnchanged}: the resolved props are not threaded into the
+ * write path, which re-reads and re-validates under its own transaction.
  */
 export function isEdgeUpsertUnchanged<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
@@ -682,6 +683,11 @@ export function isEdgeUpsertUnchanged<G extends GraphDef>(
   return canonicalEqual(validatedProps, existingProps);
 }
 
+/**
+ * Shared edge-update body: re-reads the edge inside the transaction, merges
+ * and validates props, and writes. A plain update requires a live edge; a
+ * resurrecting upsert (`clearDeleted`) may target a tombstoned one.
+ */
 async function performEdgeUpdate<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
   input: {

--- a/packages/typegraph/src/store/operations/index.ts
+++ b/packages/typegraph/src/store/operations/index.ts
@@ -17,6 +17,7 @@ export {
   executeEdgeHardDelete,
   executeEdgeUpdate,
   executeEdgeUpsertUpdate,
+  isEdgeUpsertUnchanged,
 } from "./edge-operations";
 export {
   executeNodeBulkFindByConstraint,
@@ -32,5 +33,6 @@ export {
   executeNodeHardDelete,
   executeNodeUpdate,
   executeNodeUpsertUpdate,
+  isNodeUpsertUnchanged,
   type NodeOperationContext,
 } from "./node-operations";

--- a/packages/typegraph/src/store/operations/index.ts
+++ b/packages/typegraph/src/store/operations/index.ts
@@ -6,6 +6,7 @@
 
 export {
   type EdgeOperationContext,
+  edgeUpsertDirtyCheck,
   executeEdgeBulkGetOrCreateByEndpoints,
   executeEdgeCreate,
   executeEdgeCreateBatch,
@@ -17,7 +18,6 @@ export {
   executeEdgeHardDelete,
   executeEdgeUpdate,
   executeEdgeUpsertUpdate,
-  isEdgeUpsertUnchanged,
 } from "./edge-operations";
 export {
   executeNodeBulkFindByConstraint,
@@ -33,6 +33,6 @@ export {
   executeNodeHardDelete,
   executeNodeUpdate,
   executeNodeUpsertUpdate,
-  isNodeUpsertUnchanged,
   type NodeOperationContext,
+  nodeUpsertDirtyCheck,
 } from "./node-operations";

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -57,6 +57,7 @@ import { type KindRegistry } from "../../registry/kind-registry";
 import { canonicalEqual } from "../../schema/canonical";
 import { validateOptionalCanonicalIsoDate } from "../../utils/date";
 import { generateId } from "../../utils/id";
+import { type UpsertDirtyCheck } from "../collections/coalesce";
 import {
   checkDisjointnessConstraint,
   type ConstraintContext,
@@ -660,54 +661,76 @@ async function finalizeNodeCreate<G extends GraphDef>(
 // ============================================================
 
 /**
- * The exact props an update would persist: the live row's stored props with
- * the caller's partial input merged over them, run through the kind's Zod
- * schema (defaults applied, values normalized). Also returns the resolved
- * registration so callers need not look it up again. Shared by
- * {@link performNodeUpdate} and {@link isNodeUpsertUnchanged} so the coalesce
- * dirty-check and the write it guards can never disagree on "what would be
- * written". Reads the kind/id off the row (a `getNode(kind, id)` result always
- * carries the requested kind), matching {@link resolveEdgeUpdateProps}.
+ * The exact props an update would persist: the caller's partial input merged
+ * over the current props and run through the kind's Zod schema (defaults
+ * applied, values normalized). Also returns the resolved registration so
+ * callers need not look it up again. Operates on PARSED props so both the write
+ * path (which parses the row) and the coalesce dirty-check (which may compare
+ * against a batch-local running value, never a row) share one validation.
+ */
+function computeNodeUpdate<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  kind: string,
+  id: string,
+  existingProps: Record<string, unknown>,
+  inputProps: Partial<Record<string, unknown>>,
+) {
+  const registration = getNodeRegistration(ctx.graph, kind);
+  const validatedProps = validateNodeProps(
+    registration.type.schema,
+    { ...existingProps, ...inputProps },
+    { kind, operation: "update", id },
+  );
+  return { registration, validatedProps };
+}
+
+/**
+ * Row-based wrapper over {@link computeNodeUpdate} for the write path. Reads the
+ * kind/id off the row (a `getNode(kind, id)` result always carries the
+ * requested kind), matching {@link resolveEdgeUpdateProps}.
  */
 function resolveNodeUpdateProps<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
   existing: Pick<NodeRow, "kind" | "id" | "props">,
   inputProps: Partial<Record<string, unknown>>,
 ) {
-  const registration = getNodeRegistration(ctx.graph, existing.kind);
   const existingProps = rowPropsToObject(existing.props);
-  const validatedProps = validateNodeProps(
-    registration.type.schema,
-    { ...existingProps, ...inputProps },
-    { kind: existing.kind, operation: "update", id: existing.id },
+  const { registration, validatedProps } = computeNodeUpdate(
+    ctx,
+    existing.kind,
+    existing.id,
+    existingProps,
+    inputProps,
   );
   return { registration, existingProps, validatedProps };
 }
 
 /**
- * Whether an `upsertById` of `inputProps` onto the given live row would leave
- * the stored value unchanged — the coalesce dirty-check. Compares on the
- * storage-normalized representation (validated, key-order-independent), so it
- * answers exactly "would the persisted JSON differ?".
- *
- * Callers own the other coalescing preconditions (existing, not soft-deleted,
- * no explicit temporal override); this covers rule 4 only. When it returns
- * `false`, the write path re-reads and re-validates under its own transaction
- * (concurrency-correct merge), so the resolved props are intentionally not
- * threaded into the write — the extra validation falls only on a genuinely
- * changed upsert, where the database write dominates its cost.
+ * The coalesce dirty-check: returns the props an `upsertById` would persist and
+ * whether they equal `existingProps` (so the write can be skipped). Compares on
+ * the storage-normalized representation (validated, key-order-independent), so
+ * it answers exactly "would the persisted JSON differ?". `existingProps` is the
+ * PARSED current props — the row's, or the batch-local running value for a
+ * repeated id in `bulkUpsertById`.
  */
-export function isNodeUpsertUnchanged<G extends GraphDef>(
+export function nodeUpsertDirtyCheck<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
-  existing: NodeRow,
+  kind: string,
+  id: string,
+  existingProps: Record<string, unknown>,
   inputProps: Record<string, unknown>,
-): boolean {
-  const { existingProps, validatedProps } = resolveNodeUpdateProps(
+): UpsertDirtyCheck {
+  const { validatedProps } = computeNodeUpdate(
     ctx,
-    existing,
+    kind,
+    id,
+    existingProps,
     inputProps,
   );
-  return canonicalEqual(validatedProps, existingProps);
+  return {
+    validatedProps,
+    unchanged: canonicalEqual(validatedProps, existingProps),
+  };
 }
 
 async function performNodeUpdate<G extends GraphDef>(

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -66,9 +66,10 @@ import {
   runInsertBatchReturning,
   runInsertNoReturn,
 } from "../insert-dispatch";
+import { canonicalEqual } from "../../schema/canonical";
 import { getNodeRowsByIds } from "../node-fetch";
 import { type GraphWriteLock } from "../recorded-capture/clock";
-import { rowToNode } from "../row-mappers";
+import { type NodeRow, rowToNode } from "../row-mappers";
 import {
   type CreateNodeInput,
   type GetOrCreateAction,
@@ -658,6 +659,60 @@ async function finalizeNodeCreate<G extends GraphDef>(
 // getOrCreate resurrections.
 // ============================================================
 
+/**
+ * The exact props an update would persist: the live row's stored props with
+ * the caller's partial input merged over them, run through the kind's Zod
+ * schema (defaults applied, values normalized). Shared by
+ * {@link performNodeUpdate} and {@link isNodeUpsertUnchanged} so the coalesce
+ * dirty-check and the write it guards can never disagree on "what would be
+ * written".
+ */
+function resolveNodeUpdateProps<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  kind: string,
+  id: string,
+  existing: Pick<NodeRow, "props">,
+  inputProps: Partial<Record<string, unknown>>,
+): Readonly<{
+  existingProps: Record<string, unknown>;
+  validatedProps: Record<string, unknown>;
+}> {
+  const registration = getNodeRegistration(ctx.graph, kind);
+  const existingProps = rowPropsToObject(existing.props);
+  const mergedProps = { ...existingProps, ...inputProps };
+  const validatedProps = validateNodeProps(
+    registration.type.schema,
+    mergedProps,
+    { kind, operation: "update", id },
+  );
+  return { existingProps, validatedProps };
+}
+
+/**
+ * Whether an `upsertById` of `inputProps` onto the given live row would leave
+ * the stored value unchanged — the coalesce dirty-check. Compares on the
+ * storage-normalized representation (validated, key-order-independent), so it
+ * answers exactly "would the persisted JSON differ?".
+ *
+ * Callers are responsible for the other coalescing preconditions (existing,
+ * not soft-deleted, no explicit temporal override); this covers rule 4 only.
+ */
+export function isNodeUpsertUnchanged<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  kind: string,
+  existing: NodeRow,
+  inputProps: Record<string, unknown>,
+): boolean {
+  const { existingProps, validatedProps } = resolveNodeUpdateProps(
+    ctx,
+    kind,
+    existing.id,
+    existing,
+    inputProps,
+  );
+  return canonicalEqual(validatedProps, existingProps);
+}
+
 async function performNodeUpdate<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
   input: UpdateNodeInput,
@@ -671,15 +726,14 @@ async function performNodeUpdate<G extends GraphDef>(
   const existing = await backend.getNode(ctx.graphId, kind, id);
   if (!existing) throw new NodeNotFoundError(kind, id);
 
-  const existingProps = rowPropsToObject(existing.props);
-  const mergedProps = { ...existingProps, ...input.props };
-
-  const nodeKind = registration.type;
-  const validatedProps = validateNodeProps(nodeKind.schema, mergedProps, {
+  const { validatedProps } = resolveNodeUpdateProps(
+    ctx,
     kind,
-    operation: "update",
     id,
-  });
+    existing,
+    input.props,
+  );
+  const nodeKind = registration.type;
 
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
 

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -54,6 +54,7 @@ import { type DialectAdapter } from "../../query/dialect/types";
 import { type JsonPointer, resolveJsonPointer } from "../../query/json-pointer";
 import { asCompiledRowsSql } from "../../query/sql-intent";
 import { type KindRegistry } from "../../registry/kind-registry";
+import { canonicalEqual } from "../../schema/canonical";
 import { validateOptionalCanonicalIsoDate } from "../../utils/date";
 import { generateId } from "../../utils/id";
 import {
@@ -66,7 +67,6 @@ import {
   runInsertBatchReturning,
   runInsertNoReturn,
 } from "../insert-dispatch";
-import { canonicalEqual } from "../../schema/canonical";
 import { getNodeRowsByIds } from "../node-fetch";
 import { type GraphWriteLock } from "../recorded-capture/clock";
 import { type NodeRow, rowToNode } from "../row-mappers";
@@ -662,30 +662,26 @@ async function finalizeNodeCreate<G extends GraphDef>(
 /**
  * The exact props an update would persist: the live row's stored props with
  * the caller's partial input merged over them, run through the kind's Zod
- * schema (defaults applied, values normalized). Shared by
+ * schema (defaults applied, values normalized). Also returns the resolved
+ * registration so callers need not look it up again. Shared by
  * {@link performNodeUpdate} and {@link isNodeUpsertUnchanged} so the coalesce
  * dirty-check and the write it guards can never disagree on "what would be
- * written".
+ * written". Reads the kind/id off the row (a `getNode(kind, id)` result always
+ * carries the requested kind), matching {@link resolveEdgeUpdateProps}.
  */
 function resolveNodeUpdateProps<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
-  kind: string,
-  id: string,
-  existing: Pick<NodeRow, "props">,
+  existing: Pick<NodeRow, "kind" | "id" | "props">,
   inputProps: Partial<Record<string, unknown>>,
-): Readonly<{
-  existingProps: Record<string, unknown>;
-  validatedProps: Record<string, unknown>;
-}> {
-  const registration = getNodeRegistration(ctx.graph, kind);
+) {
+  const registration = getNodeRegistration(ctx.graph, existing.kind);
   const existingProps = rowPropsToObject(existing.props);
-  const mergedProps = { ...existingProps, ...inputProps };
   const validatedProps = validateNodeProps(
     registration.type.schema,
-    mergedProps,
-    { kind, operation: "update", id },
+    { ...existingProps, ...inputProps },
+    { kind: existing.kind, operation: "update", id: existing.id },
   );
-  return { existingProps, validatedProps };
+  return { registration, existingProps, validatedProps };
 }
 
 /**
@@ -694,19 +690,20 @@ function resolveNodeUpdateProps<G extends GraphDef>(
  * storage-normalized representation (validated, key-order-independent), so it
  * answers exactly "would the persisted JSON differ?".
  *
- * Callers are responsible for the other coalescing preconditions (existing,
- * not soft-deleted, no explicit temporal override); this covers rule 4 only.
+ * Callers own the other coalescing preconditions (existing, not soft-deleted,
+ * no explicit temporal override); this covers rule 4 only. When it returns
+ * `false`, the write path re-reads and re-validates under its own transaction
+ * (concurrency-correct merge), so the resolved props are intentionally not
+ * threaded into the write — the extra validation falls only on a genuinely
+ * changed upsert, where the database write dominates its cost.
  */
 export function isNodeUpsertUnchanged<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
-  kind: string,
   existing: NodeRow,
   inputProps: Record<string, unknown>,
 ): boolean {
   const { existingProps, validatedProps } = resolveNodeUpdateProps(
     ctx,
-    kind,
-    existing.id,
     existing,
     inputProps,
   );
@@ -721,15 +718,12 @@ async function performNodeUpdate<G extends GraphDef>(
   options?: Readonly<{ clearDeleted?: boolean }>,
 ): Promise<Node> {
   const { kind, id } = input;
-  const registration = getNodeRegistration(ctx.graph, kind);
 
   const existing = await backend.getNode(ctx.graphId, kind, id);
   if (!existing) throw new NodeNotFoundError(kind, id);
 
-  const { validatedProps } = resolveNodeUpdateProps(
+  const { registration, validatedProps } = resolveNodeUpdateProps(
     ctx,
-    kind,
-    id,
     existing,
     input.props,
   );

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -821,8 +821,8 @@ export class Store<G extends GraphDef> {
         ),
       // Present only when opted in; its absence is the coalesce off switch.
       ...(this.#options?.coalesceUnchangedUpserts === true && {
-        isUpsertUnchanged: (kind, existing, props) =>
-          isNodeUpsertUnchanged(ctx, kind, existing, props),
+        isUpsertUnchanged: (existing, props) =>
+          isNodeUpsertUnchanged(ctx, existing, props),
       }),
       executeDelete: (kind, id, backend) =>
         executeNodeDelete(ctx, kind, id, backend),

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -128,6 +128,7 @@ import {
 } from "./materialize-removals";
 import {
   type EdgeOperationContext,
+  edgeUpsertDirtyCheck,
   executeEdgeBulkGetOrCreateByEndpoints,
   executeEdgeCreate,
   executeEdgeCreateBatch,
@@ -150,9 +151,8 @@ import {
   executeNodeHardDelete,
   executeNodeUpdate,
   executeNodeUpsertUpdate,
-  isEdgeUpsertUnchanged,
-  isNodeUpsertUnchanged,
   type NodeOperationContext,
+  nodeUpsertDirtyCheck,
 } from "./operations";
 import {
   advanceRevisionClock,
@@ -821,8 +821,8 @@ export class Store<G extends GraphDef> {
         ),
       // Present only when opted in; its absence is the coalesce off switch.
       ...(this.#options?.coalesceUnchangedUpserts === true && {
-        isUpsertUnchanged: (existing, props) =>
-          isNodeUpsertUnchanged(ctx, existing, props),
+        upsertDirtyCheck: (kind, id, existingProps, inputProps) =>
+          nodeUpsertDirtyCheck(ctx, kind, id, existingProps, inputProps),
       }),
       executeDelete: (kind, id, backend) =>
         executeNodeDelete(ctx, kind, id, backend),
@@ -905,8 +905,8 @@ export class Store<G extends GraphDef> {
         executeEdgeUpsertUpdate(ctx, input, backend, options),
       // Present only when opted in; its absence is the coalesce off switch.
       ...(this.#options?.coalesceUnchangedUpserts === true && {
-        isUpsertUnchanged: (existing, props) =>
-          isEdgeUpsertUnchanged(ctx, existing, props),
+        upsertDirtyCheck: (kind, id, existingProps, inputProps) =>
+          edgeUpsertDirtyCheck(ctx, kind, id, existingProps, inputProps),
       }),
       executeDelete: (id, backend) => executeEdgeDelete(ctx, id, backend),
       executeHardDelete: (id, backend) =>

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -150,6 +150,8 @@ import {
   executeNodeHardDelete,
   executeNodeUpdate,
   executeNodeUpsertUpdate,
+  isEdgeUpsertUnchanged,
+  isNodeUpsertUnchanged,
   type NodeOperationContext,
 } from "./operations";
 import {
@@ -817,6 +819,11 @@ export class Store<G extends GraphDef> {
           backend,
           options,
         ),
+      // Present only when opted in; its absence is the coalesce off switch.
+      ...(this.#options?.coalesceUnchangedUpserts === true && {
+        isUpsertUnchanged: (kind, existing, props) =>
+          isNodeUpsertUnchanged(ctx, kind, existing, props),
+      }),
       executeDelete: (kind, id, backend) =>
         executeNodeDelete(ctx, kind, id, backend),
       executeHardDelete: (kind, id, backend) =>
@@ -896,6 +903,11 @@ export class Store<G extends GraphDef> {
       executeUpdate: (input, backend) => executeEdgeUpdate(ctx, input, backend),
       executeUpsertUpdate: (input, backend, options) =>
         executeEdgeUpsertUpdate(ctx, input, backend, options),
+      // Present only when opted in; its absence is the coalesce off switch.
+      ...(this.#options?.coalesceUnchangedUpserts === true && {
+        isUpsertUnchanged: (existing, props) =>
+          isEdgeUpsertUnchanged(ctx, existing, props),
+      }),
       executeDelete: (id, backend) => executeEdgeDelete(ctx, id, backend),
       executeHardDelete: (id, backend) =>
         executeEdgeHardDelete(ctx, id, backend),

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -349,6 +349,49 @@ type BaseStoreOptions = Readonly<{
    * manually after commit. `importGraph` handles its own refresh.
    */
   autoRefreshStatistics?: false | number;
+  /**
+   * Skip the write for an `upsertById` (or `bulkUpsertById` item) whose
+   * validated props are value-identical to the existing live row. Default
+   * off.
+   *
+   * Enable this for at-least-once / replay materializers. An event log that
+   * re-delivers a byte-identical change, or a full replay that reprocesses an
+   * already-materialized log, would otherwise rewrite every row it touches:
+   * today an `upsertById` on an existing id calls `updateNode`
+   * unconditionally, allocating a fresh recorded instant and a new history row
+   * per re-delivery. A rebuild — the workload replay is recommended for — is
+   * the one that inflates recorded history most, with a dense band of
+   * "changes" that changed nothing.
+   *
+   * When enabled, an upsert that would not change the stored value performs
+   * **no write at all**: no `updateNode`, no recorded-time capture, no history
+   * row, no revision-anchor advance, and no `update` operation hooks (nothing
+   * happened, so nothing is reported). It resolves with the **existing** node,
+   * preserving its original `validFrom` / `updatedAt` / `version`.
+   *
+   * Receipt shape is unchanged and needs no new signal: a coalesced upsert
+   * still counts as one write intent (`writes.total` includes it), but
+   * captures nothing (`receipt.recorded` stays `undefined` when it is the only
+   * write) — the same shape a no-op delete already produces, so a consumer
+   * that carries the prior anchor forward on `recorded === undefined` handles
+   * it unchanged.
+   *
+   * A write is coalesced only when **all** of the following hold; otherwise the
+   * normal write happens:
+   *   1. An existing row is found for the id (else it is a create).
+   *   2. That row is not soft-deleted (a deleted row resurrects — a real
+   *      change — and is never coalesced).
+   *   3. The caller passed no explicit `validFrom` / `validTo` (an explicit
+   *      temporal override is a deliberate request and is never coalesced;
+   *      applied per item in the bulk path).
+   *   4. The new props, merged over the stored props and run through the
+   *      kind's Zod schema (defaults applied, values normalized), are deeply
+   *      value-identical to the stored props (key order aside).
+   *
+   * Default-off because some consumers *want* an audit row per re-delivery as
+   * proof the event was reprocessed; coalescing removes that signal.
+   */
+  coalesceUnchangedUpserts?: boolean;
   /** SQL schema configuration from createSqlSchema(...) for custom table names */
   schema?: SqlSchema;
   /** Query default behaviors. */

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -26,6 +26,7 @@ import {
   registerAggregateIntegrationTests,
   registerAlgorithmIntegrationTests,
   registerBulkFindByIndexIntegrationTests,
+  registerCoalesceUpsertIntegrationTests,
   registerCrossBackendConsistencyTests,
   registerEdgeCaseIntegrationTests,
   registerEdgeOperationIntegrationTests,
@@ -120,6 +121,7 @@ export function createIntegrationTestSuite(
 
     registerAggregateIntegrationTests(context);
     registerBulkFindByIndexIntegrationTests(context);
+    registerCoalesceUpsertIntegrationTests(context);
     registerPredicateIntegrationTests(context);
     registerProvenanceIntegrationTests(context);
     registerOrderingIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   asCompiledRowsSql,
+  asEdgeId,
+  asNodeId,
   createStoreWithSchema,
   type EdgeId,
   type NodeId,
@@ -11,7 +13,9 @@ import { createSqlSchema } from "../../../src/query/compiler/schema";
 import { type IntegrationStore, integrationTestGraph } from "./fixtures";
 import { type IntegrationTestContext } from "./test-context";
 
-type CountRow = Readonly<{ cnt: number }>;
+// Postgres returns COUNT(*) as a string/bigint, SQLite as a number, so the
+// value is genuinely not statically a number — Number(...) is a real coercion.
+type CountRow = Readonly<{ cnt: unknown }>;
 
 /**
  * Creates a fresh store on the shared backend with
@@ -29,12 +33,16 @@ async function createCoalesceStore(
   return store;
 }
 
-function personId(id: string): NodeId<typeof integrationTestGraph.nodes.Person.type> {
-  return id as NodeId<typeof integrationTestGraph.nodes.Person.type>;
+function personId(
+  id: string,
+): NodeId<typeof integrationTestGraph.nodes.Person.type> {
+  return asNodeId(id);
 }
 
-function knowsId(id: string): EdgeId<typeof integrationTestGraph.edges.knows.type> {
-  return id as EdgeId<typeof integrationTestGraph.edges.knows.type>;
+function knowsId(
+  id: string,
+): EdgeId<typeof integrationTestGraph.edges.knows.type> {
+  return asEdgeId(id);
 }
 
 /**
@@ -94,11 +102,14 @@ export function registerCoalesceUpsertIntegrationTests(
         email: "zoe@example.com",
       });
 
-      const replayed = await store.nodes.Person.upsertByIdFromRecord("p-order", {
-        email: "zoe@example.com",
-        age: 20,
-        name: "Zoe",
-      });
+      const replayed = await store.nodes.Person.upsertByIdFromRecord(
+        "p-order",
+        {
+          email: "zoe@example.com",
+          age: 20,
+          name: "Zoe",
+        },
+      );
 
       expect(replayed.meta.version).toBe(created.meta.version);
       expect(replayed.meta.updatedAt).toBe(created.meta.updatedAt);
@@ -214,12 +225,27 @@ export function registerCoalesceUpsertIntegrationTests(
       }
 
       await store.edges.knows.bulkUpsertById([
-        { id: knowsId("edge-1"), from: alice, to: bob, props: { since: "2020" } },
+        {
+          id: knowsId("edge-1"),
+          from: alice,
+          to: bob,
+          props: { since: "2020" },
+        },
       ]);
 
       const results = await store.edges.knows.bulkUpsertById([
-        { id: knowsId("edge-1"), from: alice, to: bob, props: { since: "2020" } }, // coalesced
-        { id: knowsId("edge-2"), from: bob, to: alice, props: { since: "2021" } }, // created
+        {
+          id: knowsId("edge-1"),
+          from: alice,
+          to: bob,
+          props: { since: "2020" },
+        }, // coalesced
+        {
+          id: knowsId("edge-2"),
+          from: bob,
+          to: alice,
+          props: { since: "2021" },
+        }, // created
       ]);
 
       const first = await store.edges.knows.getById(knowsId("edge-1"));
@@ -240,12 +266,22 @@ export function registerCoalesceUpsertIntegrationTests(
       }
 
       await store.edges.knows.bulkUpsertById([
-        { id: knowsId("ec-edge"), from: alice, to: bob, props: { since: "2020" } },
+        {
+          id: knowsId("ec-edge"),
+          from: alice,
+          to: bob,
+          props: { since: "2020" },
+        },
       ]);
       const before = await store.edges.knows.getById(knowsId("ec-edge"));
 
       await store.edges.knows.bulkUpsertById([
-        { id: knowsId("ec-edge"), from: alice, to: bob, props: { since: "2099" } },
+        {
+          id: knowsId("ec-edge"),
+          from: alice,
+          to: bob,
+          props: { since: "2099" },
+        },
       ]);
       const after = await store.edges.knows.getById(knowsId("ec-edge"));
 
@@ -259,7 +295,11 @@ export function registerCoalesceUpsertIntegrationTests(
 
         await store.nodes.Person.upsertById("h1", { name: "Faye", age: 60 });
         const afterFirst = await store.recordedNow();
-        const rowsAfterFirst = await countRecordedNodeRows(store, "Person", "h1");
+        const rowsAfterFirst = await countRecordedNodeRows(
+          store,
+          "Person",
+          "h1",
+        );
         expect(afterFirst).toBeDefined();
 
         await store.nodes.Person.upsertById("h1", { name: "Faye", age: 60 });
@@ -282,7 +322,9 @@ export function registerCoalesceUpsertIntegrationTests(
           "Person",
           "h1",
         );
-        expect(afterChange !== undefined && afterFirst !== undefined).toBe(true);
+        expect(afterChange !== undefined && afterFirst !== undefined).toBe(
+          true,
+        );
         expect(afterChange! > afterFirst!).toBe(true);
         expect(rowsAfterChange).toBeGreaterThan(rowsAfterReplay);
       });

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -7,8 +7,14 @@ import {
   asNodeId,
   createStoreWithSchema,
   type EdgeId,
+  type GraphBackend,
   type NodeId,
 } from "../../../src";
+import {
+  type AdoptedTransaction,
+  type TransactionBackend,
+  type TransactionOptions,
+} from "../../../src/backend/types";
 import { createSqlSchema } from "../../../src/query/compiler/schema";
 import { type IntegrationStore, integrationTestGraph } from "./fixtures";
 import { type IntegrationTestContext } from "./test-context";
@@ -66,6 +72,46 @@ async function countRecordedNodeRows(
     `),
   );
   return Number(rows[0]?.cnt ?? 0);
+}
+
+type EdgeWriteCounter = Readonly<{
+  backend: GraphBackend;
+  updates: () => number;
+}>;
+
+/**
+ * Wraps a backend — and every transaction-scoped backend it hands out — so
+ * each `updateEdge` call is counted. Edges carry no version counter, so the
+ * duplicate-id probe matrix needs an exact write count that survives the
+ * transaction the bulk-upsert path opens.
+ */
+function withEdgeUpdateCounting(base: GraphBackend): EdgeWriteCounter {
+  let updates = 0;
+  function countingUpdateEdge(
+    target: Pick<GraphBackend, "updateEdge">,
+  ): GraphBackend["updateEdge"] {
+    return (params) => {
+      updates += 1;
+      return target.updateEdge(params);
+    };
+  }
+  const backend: GraphBackend = {
+    ...base,
+    updateEdge: countingUpdateEdge(base),
+    transaction: <T>(
+      fn: (tx: TransactionBackend, sqlHandle: AdoptedTransaction) => Promise<T>,
+      options?: TransactionOptions,
+    ) =>
+      base.transaction<T>(
+        (txBackend, sqlHandle) =>
+          fn(
+            { ...txBackend, updateEdge: countingUpdateEdge(txBackend) },
+            sqlHandle,
+          ),
+        options,
+      ),
+  };
+  return { backend, updates: () => updates };
 }
 
 export function registerCoalesceUpsertIntegrationTests(
@@ -493,6 +539,68 @@ export function registerCoalesceUpsertIntegrationTests(
 
         const after = await store.edges.knows.getById(knowsId("dupc-e"));
         expect(after?.meta.updatedAt).toBe(seeded?.meta.updatedAt);
+      });
+
+      it("applies the duplicate-id probe matrix to edges: write counts and per-position results", async () => {
+        // Mirrors the node matrix above. Nodes pin write counts via
+        // `meta.version`; edges have no version counter, so the count comes
+        // from an updateEdge-counting backend wrapper instead.
+        const counter = withEdgeUpdateCounting(context.getStore().backend);
+        const [store] = await createStoreWithSchema(
+          integrationTestGraph,
+          counter.backend,
+          { coalesceUnchangedUpserts: true },
+        );
+
+        const [alice, bob] = await store.nodes.Person.bulkCreate([
+          { props: { name: "A" }, id: "matrix-a" },
+          { props: { name: "B" }, id: "matrix-b" },
+        ]);
+        if (alice === undefined || bob === undefined) {
+          throw new Error("expected both people");
+        }
+
+        const shapes = [
+          { id: "e-aa", inputs: ["A", "A"], writes: 0, final: "A" }, // both coalesce
+          { id: "e-ba", inputs: ["B", "A"], writes: 2, final: "A" }, // write B, write A
+          { id: "e-bb", inputs: ["B", "B"], writes: 1, final: "B" }, // write B, coalesce
+          { id: "e-ab", inputs: ["A", "B"], writes: 1, final: "B" }, // coalesce A, write B
+        ] as const;
+
+        for (const shape of shapes) {
+          // Seed each shape's edge holding "A" (a create, not counted).
+          await store.edges.knows.bulkUpsertById([
+            {
+              id: knowsId(shape.id),
+              from: alice,
+              to: bob,
+              props: { since: "A" },
+            },
+          ]);
+
+          const updatesBefore = counter.updates();
+          const results = await store.edges.knows.bulkUpsertById(
+            shape.inputs.map((since) => ({
+              id: knowsId(shape.id),
+              from: alice,
+              to: bob,
+              props: { since },
+            })),
+          );
+          expect(counter.updates() - updatesBefore).toBe(shape.writes);
+
+          const final = await store.edges.knows.getById(knowsId(shape.id));
+          expect((final as { since?: string }).since).toBe(shape.final);
+          // Each position returns the row as of its own item — a coalesced
+          // item resolves to its (matching) input value, so results mirror
+          // inputs.
+          expect(results).toHaveLength(shape.inputs.length);
+          for (const [index, edge] of results.entries()) {
+            expect((edge as { since?: string }).since).toBe(
+              shape.inputs[index],
+            );
+          }
+        }
       });
 
       it("routes a dirty-check validation error through onError (not the collection layer)", async () => {

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -1,0 +1,331 @@
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import {
+  asCompiledRowsSql,
+  createStoreWithSchema,
+  type EdgeId,
+  type NodeId,
+} from "../../../src";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { type IntegrationStore, integrationTestGraph } from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+type CountRow = Readonly<{ cnt: number }>;
+
+/**
+ * Creates a fresh store on the shared backend with
+ * `coalesceUnchangedUpserts` enabled, plus any extra options.
+ */
+async function createCoalesceStore(
+  context: IntegrationTestContext,
+  extra?: Readonly<{ history?: true; revisionTracking?: true }>,
+): Promise<IntegrationStore> {
+  const [store] = await createStoreWithSchema(
+    integrationTestGraph,
+    context.getStore().backend,
+    { coalesceUnchangedUpserts: true, ...extra },
+  );
+  return store;
+}
+
+function personId(id: string): NodeId<typeof integrationTestGraph.nodes.Person.type> {
+  return id as NodeId<typeof integrationTestGraph.nodes.Person.type>;
+}
+
+function knowsId(id: string): EdgeId<typeof integrationTestGraph.edges.knows.type> {
+  return id as EdgeId<typeof integrationTestGraph.edges.knows.type>;
+}
+
+/**
+ * Total recorded history rows (open and closed) captured for a node id — the
+ * count the issue predicts grows by one per re-delivery on the write path and
+ * stays flat when coalesced.
+ */
+async function countRecordedNodeRows(
+  store: IntegrationStore,
+  kind: string,
+  id: string,
+): Promise<number> {
+  const table = createSqlSchema(store.backend.tableNames).recordedNodesTable;
+  const rows = await store.backend.execute<CountRow>(
+    asCompiledRowsSql(sql`
+      SELECT COUNT(*) AS cnt
+      FROM ${table}
+      WHERE graph_id = ${store.graphId}
+        AND kind = ${kind}
+        AND id = ${id}
+    `),
+  );
+  return Number(rows[0]?.cnt ?? 0);
+}
+
+export function registerCoalesceUpsertIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("coalesceUnchangedUpserts", () => {
+    it("coalesces a value-identical upsert: no write, returns the existing node", async () => {
+      const store = await createCoalesceStore(context);
+
+      const created = await store.nodes.Person.upsertById("p1", {
+        name: "Alice",
+        age: 30,
+      });
+      expect(created.meta.version).toBe(1);
+
+      const replayed = await store.nodes.Person.upsertById("p1", {
+        name: "Alice",
+        age: 30,
+      });
+
+      // No write happened: the returned node is the existing row, its version
+      // and updatedAt unchanged.
+      expect(replayed.meta.version).toBe(1);
+      expect(replayed.meta.updatedAt).toBe(created.meta.updatedAt);
+      expect(replayed.meta.validFrom).toBe(created.meta.validFrom);
+    });
+
+    it("coalesces regardless of prop key order (canonical comparison)", async () => {
+      const store = await createCoalesceStore(context);
+
+      const created = await store.nodes.Person.upsertById("p-order", {
+        name: "Zoe",
+        age: 20,
+        email: "zoe@example.com",
+      });
+
+      const replayed = await store.nodes.Person.upsertByIdFromRecord("p-order", {
+        email: "zoe@example.com",
+        age: 20,
+        name: "Zoe",
+      });
+
+      expect(replayed.meta.version).toBe(created.meta.version);
+      expect(replayed.meta.updatedAt).toBe(created.meta.updatedAt);
+    });
+
+    it("writes when a prop changes", async () => {
+      const store = await createCoalesceStore(context);
+
+      const created = await store.nodes.Person.upsertById("p2", {
+        name: "Bob",
+        age: 40,
+      });
+
+      const changed = await store.nodes.Person.upsertById("p2", {
+        name: "Bob",
+        age: 41,
+      });
+
+      expect(changed.meta.version).toBe(created.meta.version + 1);
+      const age = (changed as { age?: number }).age;
+      expect(age).toBe(41);
+    });
+
+    it("resurrects a soft-deleted row rather than coalescing", async () => {
+      const store = await createCoalesceStore(context);
+
+      const created = await store.nodes.Person.upsertById("p3", {
+        name: "Carol",
+        age: 33,
+      });
+      await store.nodes.Person.delete(personId("p3"));
+
+      // The upsert props equal the pre-delete stored props, but a soft-deleted
+      // row must resurrect — a real write — never coalesce.
+      const resurrected = await store.nodes.Person.upsertById("p3", {
+        name: "Carol",
+        age: 33,
+      });
+
+      expect(resurrected.meta.deletedAt).toBeUndefined();
+      expect(resurrected.meta.version).toBeGreaterThan(created.meta.version);
+      await expect(
+        store.nodes.Person.getById(personId("p3")),
+      ).resolves.toBeDefined();
+    });
+
+    it("writes when an explicit validFrom / validTo override is passed", async () => {
+      const store = await createCoalesceStore(context);
+
+      const created = await store.nodes.Person.upsertById("p4", {
+        name: "Dana",
+        age: 25,
+      });
+
+      const overridden = await store.nodes.Person.upsertById(
+        "p4",
+        { name: "Dana", age: 25 },
+        { validFrom: "2020-01-01T00:00:00.000Z" },
+      );
+
+      expect(overridden.meta.version).toBe(created.meta.version + 1);
+    });
+
+    it("with the flag OFF, an identical re-upsert still writes (default behavior)", async () => {
+      const store = context.getStore();
+
+      const created = await store.nodes.Person.upsertById("p5", {
+        name: "Erin",
+        age: 50,
+      });
+      const replayed = await store.nodes.Person.upsertById("p5", {
+        name: "Erin",
+        age: 50,
+      });
+
+      expect(replayed.meta.version).toBe(created.meta.version + 1);
+    });
+
+    it("coalesces per-item in a mixed bulk batch, preserving input order", async () => {
+      const store = await createCoalesceStore(context);
+
+      await store.nodes.Person.upsertById("b-same", { name: "Same", age: 1 });
+      await store.nodes.Person.upsertById("b-change", {
+        name: "Change",
+        age: 2,
+      });
+
+      const results = await store.nodes.Person.bulkUpsertById([
+        { id: "b-same", props: { name: "Same", age: 1 } }, // coalesced
+        { id: "b-change", props: { name: "Change", age: 3 } }, // written
+        { id: "b-new", props: { name: "New", age: 4 } }, // created
+      ]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0]?.id).toBe("b-same");
+      expect(results[0]?.meta.version).toBe(1); // untouched
+      expect(results[1]?.id).toBe("b-change");
+      expect(results[1]?.meta.version).toBe(2); // real update
+      expect((results[1] as { age?: number }).age).toBe(3);
+      expect(results[2]?.id).toBe("b-new");
+      expect(results[2]?.meta.version).toBe(1); // created
+    });
+
+    it("coalesces edge bulkUpsertById symmetrically", async () => {
+      const store = await createCoalesceStore(context);
+
+      const [alice, bob] = await store.nodes.Person.bulkCreate([
+        { props: { name: "Alice" }, id: "e-alice" },
+        { props: { name: "Bob" }, id: "e-bob" },
+      ]);
+      if (alice === undefined || bob === undefined) {
+        throw new Error("expected both people to be created");
+      }
+
+      await store.edges.knows.bulkUpsertById([
+        { id: knowsId("edge-1"), from: alice, to: bob, props: { since: "2020" } },
+      ]);
+
+      const results = await store.edges.knows.bulkUpsertById([
+        { id: knowsId("edge-1"), from: alice, to: bob, props: { since: "2020" } }, // coalesced
+        { id: knowsId("edge-2"), from: bob, to: alice, props: { since: "2021" } }, // created
+      ]);
+
+      const first = await store.edges.knows.getById(knowsId("edge-1"));
+      // The coalesced edge kept its original creation timestamp.
+      expect(results[0]?.id).toBe("edge-1");
+      expect(results[0]?.meta.updatedAt).toBe(first?.meta.updatedAt);
+      expect(results[1]?.id).toBe("edge-2");
+    });
+
+    it("writes an edge when its props change", async () => {
+      const store = await createCoalesceStore(context);
+      const [alice, bob] = await store.nodes.Person.bulkCreate([
+        { props: { name: "A" }, id: "ec-a" },
+        { props: { name: "B" }, id: "ec-b" },
+      ]);
+      if (alice === undefined || bob === undefined) {
+        throw new Error("expected both people");
+      }
+
+      await store.edges.knows.bulkUpsertById([
+        { id: knowsId("ec-edge"), from: alice, to: bob, props: { since: "2020" } },
+      ]);
+      const before = await store.edges.knows.getById(knowsId("ec-edge"));
+
+      await store.edges.knows.bulkUpsertById([
+        { id: knowsId("ec-edge"), from: alice, to: bob, props: { since: "2099" } },
+      ]);
+      const after = await store.edges.knows.getById(knowsId("ec-edge"));
+
+      expect((after as { since?: string }).since).toBe("2099");
+      expect(after?.meta.updatedAt).not.toBe(before?.meta.updatedAt);
+    });
+
+    describe("with history capture", () => {
+      it("creates no recorded row and does not advance recordedNow on a coalesced replay", async () => {
+        const store = await createCoalesceStore(context, { history: true });
+
+        await store.nodes.Person.upsertById("h1", { name: "Faye", age: 60 });
+        const afterFirst = await store.recordedNow();
+        const rowsAfterFirst = await countRecordedNodeRows(store, "Person", "h1");
+        expect(afterFirst).toBeDefined();
+
+        await store.nodes.Person.upsertById("h1", { name: "Faye", age: 60 });
+        const afterReplay = await store.recordedNow();
+        const rowsAfterReplay = await countRecordedNodeRows(
+          store,
+          "Person",
+          "h1",
+        );
+
+        // No capture: the recorded clock and the row count are unchanged.
+        expect(afterReplay).toBe(afterFirst);
+        expect(rowsAfterReplay).toBe(rowsAfterFirst);
+
+        // A real change resumes capture.
+        await store.nodes.Person.upsertById("h1", { name: "Faye", age: 61 });
+        const afterChange = await store.recordedNow();
+        const rowsAfterChange = await countRecordedNodeRows(
+          store,
+          "Person",
+          "h1",
+        );
+        expect(afterChange !== undefined && afterFirst !== undefined).toBe(true);
+        expect(afterChange! > afterFirst!).toBe(true);
+        expect(rowsAfterChange).toBeGreaterThan(rowsAfterReplay);
+      });
+    });
+
+    describe("with revision tracking", () => {
+      it("does not advance the revision anchor on a coalesced replay", async () => {
+        const store = await createCoalesceStore(context, {
+          revisionTracking: true,
+        });
+
+        await store.nodes.Person.upsertById("r1", { name: "Gwen", age: 70 });
+        const afterFirst = await store.revisionNow();
+
+        await store.nodes.Person.upsertById("r1", { name: "Gwen", age: 70 });
+        const afterReplay = await store.revisionNow();
+        expect(afterReplay).toBe(afterFirst);
+
+        await store.nodes.Person.upsertById("r1", { name: "Gwen", age: 71 });
+        const afterChange = await store.revisionNow();
+        expect(afterChange).not.toBe(afterFirst);
+      });
+    });
+
+    describe("transaction receipt shape (issue #256)", () => {
+      it("first delivery captures; identical replay counts one write but records nothing", async () => {
+        const store = await createCoalesceStore(context, { history: true });
+
+        const first = await store.transactionWithReceipt(async (tx) =>
+          tx.nodes.Person.upsertById("rcpt", { name: "Ivy", age: 80 }),
+        );
+        expect(first.receipt.writes.total).toBe(1);
+        expect(first.receipt.recorded).toBeDefined();
+
+        const replay = await store.transactionWithReceipt(async (tx) =>
+          tx.nodes.Person.upsertById("rcpt", { name: "Ivy", age: 80 }),
+        );
+        // The write intent still completed (dropped-change detection intact),
+        // but nothing was captured — the same two-signal shape as a no-op
+        // delete, which at-least-once consumers already handle.
+        expect(replay.receipt.writes.total).toBe(1);
+        expect(replay.receipt.recorded).toBeUndefined();
+      });
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -273,7 +273,6 @@ export function registerCoalesceUpsertIntegrationTests(
           props: { since: "2020" },
         },
       ]);
-      const before = await store.edges.knows.getById(knowsId("ec-edge"));
 
       await store.edges.knows.bulkUpsertById([
         {
@@ -285,8 +284,11 @@ export function registerCoalesceUpsertIntegrationTests(
       ]);
       const after = await store.edges.knows.getById(knowsId("ec-edge"));
 
+      // The persisted value is the proof the write happened: had this
+      // coalesced, `after` would be the untouched edge with since = "2020".
+      // (Edges carry no version, and updatedAt can collide within a
+      // millisecond, so the value change is the reliable signal.)
       expect((after as { since?: string }).since).toBe("2099");
-      expect(after?.meta.updatedAt).not.toBe(before?.meta.updatedAt);
     });
 
     describe("with history capture", () => {

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -377,9 +377,9 @@ export function registerCoalesceUpsertIntegrationTests(
         const store = await createCoalesceStore(context);
         await store.nodes.Person.upsertById("dup", { name: "A" });
 
-        // The second item's props equal the PREFETCHED row; without the
-        // first-occurrence guard it would coalesce against stale state and
-        // drop the first item's write, leaving "B". Last-write-wins is "A".
+        // The second item's props equal the once-PREFETCHED row; without
+        // batch-local pending state it would coalesce against that stale value
+        // and drop the first item's write, leaving "B". Last-write-wins is "A".
         await store.nodes.Person.bulkUpsertById([
           { id: "dup", props: { name: "B" } },
           { id: "dup", props: { name: "A" } },
@@ -389,27 +389,38 @@ export function registerCoalesceUpsertIntegrationTests(
         expect((final as { name?: string }).name).toBe("A");
       });
 
-      it("coalesces the first duplicate occurrence but still writes the last (history)", async () => {
-        const store = await createCoalesceStore(context, { history: true });
-        await store.nodes.Person.upsertById("dup2", { name: "A" });
-        const rowsAfterSeed = await countRecordedNodeRows(
-          store,
-          "Person",
-          "dup2",
-        );
+      it("coalesces a duplicate against the batch-local pending value", async () => {
+        // Each shape is applied to its own id, seeded to version 1 holding "A".
+        // A write bumps the node version; a coalesced item does not — so the
+        // final version minus the seed's 1 is exactly the number of writes.
+        const store = await createCoalesceStore(context);
+        const shapes = [
+          { id: "p-aa", inputs: ["A", "A"], writes: 0, final: "A" }, // both coalesce
+          { id: "p-ba", inputs: ["B", "A"], writes: 2, final: "A" }, // write B, write A
+          { id: "p-bb", inputs: ["B", "B"], writes: 1, final: "B" }, // write B, coalesce
+          { id: "p-ab", inputs: ["A", "B"], writes: 1, final: "B" }, // coalesce A, write B
+        ] as const;
 
-        // [{A},{B}]: the first item equals the row and coalesces (no write);
-        // the second writes "B". Final "B", and exactly one new recorded row.
-        await store.nodes.Person.bulkUpsertById([
-          { id: "dup2", props: { name: "A" } },
-          { id: "dup2", props: { name: "B" } },
-        ]);
+        for (const shape of shapes) {
+          const seed = await store.nodes.Person.upsertById(shape.id, {
+            name: "A",
+          });
+          expect(seed.meta.version).toBe(1);
 
-        const final = await store.nodes.Person.getById(personId("dup2"));
-        expect((final as { name?: string }).name).toBe("B");
-        expect(await countRecordedNodeRows(store, "Person", "dup2")).toBe(
-          rowsAfterSeed + 1,
-        );
+          const results = await store.nodes.Person.bulkUpsertById(
+            shape.inputs.map((name) => ({ id: shape.id, props: { name } })),
+          );
+
+          const final = await store.nodes.Person.getById(personId(shape.id));
+          expect(final?.meta.version).toBe(1 + shape.writes);
+          expect((final as { name?: string }).name).toBe(shape.final);
+          // Each position returns the row as of its own item — for a coalesced
+          // item that is its (matching) input value, so results mirror inputs.
+          expect(results).toHaveLength(shape.inputs.length);
+          for (const [index, node] of results.entries()) {
+            expect((node as { name?: string }).name).toBe(shape.inputs[index]);
+          }
+        }
       });
 
       it("preserves last-write-wins for duplicate edge ids in one batch", async () => {
@@ -442,6 +453,46 @@ export function registerCoalesceUpsertIntegrationTests(
 
         const final = await store.edges.knows.getById(knowsId("dup-e"));
         expect((final as { since?: string }).since).toBe("2020");
+      });
+
+      it("coalesces a value-identical duplicate edge in one batch", async () => {
+        const store = await createCoalesceStore(context);
+        const [alice, bob] = await store.nodes.Person.bulkCreate([
+          { props: { name: "A" }, id: "dupc-a" },
+          { props: { name: "B" }, id: "dupc-b" },
+        ]);
+        if (alice === undefined || bob === undefined) {
+          throw new Error("expected both people");
+        }
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("dupc-e"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+          },
+        ]);
+        const seeded = await store.edges.knows.getById(knowsId("dupc-e"));
+
+        // Both items equal the row; both coalesce, so nothing is written and
+        // the edge's updatedAt is unchanged (edges carry no version counter).
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("dupc-e"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+          },
+          {
+            id: knowsId("dupc-e"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+          },
+        ]);
+
+        const after = await store.edges.knows.getById(knowsId("dupc-e"));
+        expect(after?.meta.updatedAt).toBe(seeded?.meta.updatedAt);
       });
 
       it("routes a dirty-check validation error through onError (not the collection layer)", async () => {
@@ -477,11 +528,12 @@ export function registerCoalesceUpsertIntegrationTests(
         // #maybeRefreshStatisticsAfterBulk invokes it as this.refreshStatistics().
         let refreshCalls = 0;
         const runRefresh = store.refreshStatistics.bind(store);
-        (store as { refreshStatistics: () => Promise<void> }).refreshStatistics =
-          async () => {
-            refreshCalls += 1;
-            await runRefresh();
-          };
+        (
+          store as { refreshStatistics: () => Promise<void> }
+        ).refreshStatistics = async () => {
+          refreshCalls += 1;
+          await runRefresh();
+        };
 
         // All coalesced → zero mutations → below threshold → no refresh.
         await store.nodes.Person.bulkUpsertById([

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   asCompiledRowsSql,
@@ -369,6 +369,134 @@ export function registerCoalesceUpsertIntegrationTests(
         // delete, which at-least-once consumers already handle.
         expect(replay.receipt.writes.total).toBe(1);
         expect(replay.receipt.recorded).toBeUndefined();
+      });
+    });
+
+    describe("post-review fixes (#262)", () => {
+      it("preserves last-write-wins for duplicate node ids in one batch", async () => {
+        const store = await createCoalesceStore(context);
+        await store.nodes.Person.upsertById("dup", { name: "A" });
+
+        // The second item's props equal the PREFETCHED row; without the
+        // first-occurrence guard it would coalesce against stale state and
+        // drop the first item's write, leaving "B". Last-write-wins is "A".
+        await store.nodes.Person.bulkUpsertById([
+          { id: "dup", props: { name: "B" } },
+          { id: "dup", props: { name: "A" } },
+        ]);
+
+        const final = await store.nodes.Person.getById(personId("dup"));
+        expect((final as { name?: string }).name).toBe("A");
+      });
+
+      it("coalesces the first duplicate occurrence but still writes the last (history)", async () => {
+        const store = await createCoalesceStore(context, { history: true });
+        await store.nodes.Person.upsertById("dup2", { name: "A" });
+        const rowsAfterSeed = await countRecordedNodeRows(
+          store,
+          "Person",
+          "dup2",
+        );
+
+        // [{A},{B}]: the first item equals the row and coalesces (no write);
+        // the second writes "B". Final "B", and exactly one new recorded row.
+        await store.nodes.Person.bulkUpsertById([
+          { id: "dup2", props: { name: "A" } },
+          { id: "dup2", props: { name: "B" } },
+        ]);
+
+        const final = await store.nodes.Person.getById(personId("dup2"));
+        expect((final as { name?: string }).name).toBe("B");
+        expect(await countRecordedNodeRows(store, "Person", "dup2")).toBe(
+          rowsAfterSeed + 1,
+        );
+      });
+
+      it("preserves last-write-wins for duplicate edge ids in one batch", async () => {
+        const store = await createCoalesceStore(context);
+        const [alice, bob] = await store.nodes.Person.bulkCreate([
+          { props: { name: "A" }, id: "dup-a" },
+          { props: { name: "B" }, id: "dup-b" },
+        ]);
+        if (alice === undefined || bob === undefined) {
+          throw new Error("expected both people");
+        }
+        await store.edges.knows.bulkUpsertById([
+          { id: knowsId("dup-e"), from: alice, to: bob, props: { since: "x" } },
+        ]);
+
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("dup-e"),
+            from: alice,
+            to: bob,
+            props: { since: "2050" },
+          },
+          {
+            id: knowsId("dup-e"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+          },
+        ]);
+
+        const final = await store.edges.knows.getById(knowsId("dup-e"));
+        expect((final as { since?: string }).since).toBe("2020");
+      });
+
+      it("routes a dirty-check validation error through onError (not the collection layer)", async () => {
+        const onError = vi.fn();
+        const [store] = await createStoreWithSchema(
+          integrationTestGraph,
+          context.getStore().backend,
+          { coalesceUnchangedUpserts: true, hooks: { onError } },
+        );
+        await store.nodes.Person.upsertById("bad", { name: "Valid" });
+
+        // `name: 42` fails the Zod schema. The dirty check validates first at
+        // the collection layer; the fix makes that throw fall through to the
+        // hooked write path so onError still fires, matching flag-off.
+        await expect(
+          store.nodes.Person.upsertByIdFromRecord("bad", { name: 42 }),
+        ).rejects.toThrow();
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
+
+      it("counts only real mutations toward the statistics-refresh threshold", async () => {
+        const [store] = await createStoreWithSchema(
+          integrationTestGraph,
+          context.getStore().backend,
+          { coalesceUnchangedUpserts: true, autoRefreshStatistics: 2 },
+        );
+        await store.nodes.Person.bulkUpsertById([
+          { id: "s1", props: { name: "S1" } },
+          { id: "s2", props: { name: "S2" } },
+        ]);
+
+        // Count refreshStatistics() calls by overriding the instance method —
+        // #maybeRefreshStatisticsAfterBulk invokes it as this.refreshStatistics().
+        let refreshCalls = 0;
+        const runRefresh = store.refreshStatistics.bind(store);
+        (store as { refreshStatistics: () => Promise<void> }).refreshStatistics =
+          async () => {
+            refreshCalls += 1;
+            await runRefresh();
+          };
+
+        // All coalesced → zero mutations → below threshold → no refresh.
+        await store.nodes.Person.bulkUpsertById([
+          { id: "s1", props: { name: "S1" } },
+          { id: "s2", props: { name: "S2" } },
+        ]);
+        expect(refreshCalls).toBe(0);
+
+        // One coalesced + one update + one create = two real mutations → refresh.
+        await store.nodes.Person.bulkUpsertById([
+          { id: "s1", props: { name: "S1" } },
+          { id: "s2", props: { name: "S2-changed" } },
+          { id: "s3", props: { name: "S3" } },
+        ]);
+        expect(refreshCalls).toBe(1);
       });
     });
   });

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -1,6 +1,7 @@
 export { registerAggregateIntegrationTests } from "./aggregates";
 export { registerAlgorithmIntegrationTests } from "./algorithms";
 export { registerBulkFindByIndexIntegrationTests } from "./bulk-find-by-index";
+export { registerCoalesceUpsertIntegrationTests } from "./coalesce-upserts";
 export { registerCrossBackendConsistencyTests } from "./cross-backend";
 export { registerEdgeCaseIntegrationTests } from "./edge-cases";
 export { registerEdgeOperationIntegrationTests } from "./edge-operations";

--- a/packages/typegraph/tests/property/coalesce-upserts.test.ts
+++ b/packages/typegraph/tests/property/coalesce-upserts.test.ts
@@ -36,7 +36,9 @@ const coalesceGraph = defineGraph({
 });
 
 type ClockRow = Readonly<{ recorded_at: unknown }>;
-type CountRow = Readonly<{ cnt: number }>;
+// Postgres returns COUNT(*) as a string/bigint, SQLite as a number, so the
+// value is genuinely not statically a number — Number(...) is a real coercion.
+type CountRow = Readonly<{ cnt: unknown }>;
 
 async function readRecordedClock(
   backend: GraphBackend,
@@ -78,25 +80,29 @@ const propsArb = fc.record(
 describe("coalesceUnchangedUpserts property", () => {
   it("re-upserting identical props is history-idempotent", async () => {
     await fc.assert(
-      fc.asyncProperty(propsArb, fc.string({ maxLength: 12 }), async (props, id) => {
-        const backend = createTestBackend();
-        const [store] = await createStoreWithSchema(coalesceGraph, backend, {
-          history: true,
-          coalesceUnchangedUpserts: true,
-        });
+      fc.asyncProperty(
+        propsArb,
+        fc.string({ maxLength: 12 }),
+        async (props, id) => {
+          const backend = createTestBackend();
+          const [store] = await createStoreWithSchema(coalesceGraph, backend, {
+            history: true,
+            coalesceUnchangedUpserts: true,
+          });
 
-        await store.nodes.Item.upsertById(id, props);
-        const clockAfterFirst = await readRecordedClock(backend);
-        const rowsAfterFirst = await countRecordedRows(backend);
-        expect(clockAfterFirst).toBeDefined();
+          await store.nodes.Item.upsertById(id, props);
+          const clockAfterFirst = await readRecordedClock(backend);
+          const rowsAfterFirst = await countRecordedRows(backend);
+          expect(clockAfterFirst).toBeDefined();
 
-        // Any number of byte-identical replays must not touch history.
-        await store.nodes.Item.upsertById(id, props);
-        await store.nodes.Item.upsertById(id, props);
+          // Any number of byte-identical replays must not touch history.
+          await store.nodes.Item.upsertById(id, props);
+          await store.nodes.Item.upsertById(id, props);
 
-        expect(await readRecordedClock(backend)).toBe(clockAfterFirst);
-        expect(await countRecordedRows(backend)).toBe(rowsAfterFirst);
-      }),
+          expect(await readRecordedClock(backend)).toBe(clockAfterFirst);
+          expect(await countRecordedRows(backend)).toBe(rowsAfterFirst);
+        },
+      ),
       { numRuns: 60 },
     );
   }, 60_000);

--- a/packages/typegraph/tests/property/coalesce-upserts.test.ts
+++ b/packages/typegraph/tests/property/coalesce-upserts.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Property: under `coalesceUnchangedUpserts`, upserting the same validated
+ * props twice is history-idempotent — the second (byte-identical) delivery
+ * performs no write, so the per-graph recorded clock does not advance and no
+ * new recorded row is captured. This is the at-least-once replay invariant the
+ * option exists to provide (issue #256).
+ */
+import { sql } from "drizzle-orm";
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  asCompiledRowsSql,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "../../src";
+import { type GraphBackend } from "../../src/backend/types";
+import { createSqlSchema } from "../../src/query/compiler/schema";
+import { toCanonicalIso } from "../../src/store/recorded-capture";
+import { createTestBackend } from "../test-utils";
+
+const Item = defineNode("Item", {
+  schema: z.object({
+    name: z.string(),
+    count: z.number().optional(),
+    flag: z.boolean().optional(),
+  }),
+});
+
+const coalesceGraph = defineGraph({
+  id: "prop_coalesce_upserts",
+  nodes: { Item: { type: Item } },
+  edges: {},
+});
+
+type ClockRow = Readonly<{ recorded_at: unknown }>;
+type CountRow = Readonly<{ cnt: number }>;
+
+async function readRecordedClock(
+  backend: GraphBackend,
+): Promise<string | undefined> {
+  const rows = await backend.execute<ClockRow>(
+    asCompiledRowsSql(sql`
+      SELECT recorded_at
+      FROM ${createSqlSchema(backend.tableNames).recordedClockTable}
+      WHERE graph_id = ${coalesceGraph.id}
+    `),
+  );
+  const value = rows[0]?.recorded_at;
+  return value === undefined ? undefined : toCanonicalIso(value);
+}
+
+async function countRecordedRows(backend: GraphBackend): Promise<number> {
+  const rows = await backend.execute<CountRow>(
+    asCompiledRowsSql(sql`
+      SELECT COUNT(*) AS cnt
+      FROM ${createSqlSchema(backend.tableNames).recordedNodesTable}
+      WHERE graph_id = ${coalesceGraph.id}
+    `),
+  );
+  return Number(rows[0]?.cnt ?? 0);
+}
+
+// Props whose re-validation is a fixed point: scalars with no defaults or
+// transforms, and no explicitly-undefined optional keys (requiredKeys pins the
+// only always-present field).
+const propsArb = fc.record(
+  {
+    name: fc.string({ maxLength: 16 }),
+    count: fc.integer({ min: -1000, max: 1000 }),
+    flag: fc.boolean(),
+  },
+  { requiredKeys: ["name"] },
+);
+
+describe("coalesceUnchangedUpserts property", () => {
+  it("re-upserting identical props is history-idempotent", async () => {
+    await fc.assert(
+      fc.asyncProperty(propsArb, fc.string({ maxLength: 12 }), async (props, id) => {
+        const backend = createTestBackend();
+        const [store] = await createStoreWithSchema(coalesceGraph, backend, {
+          history: true,
+          coalesceUnchangedUpserts: true,
+        });
+
+        await store.nodes.Item.upsertById(id, props);
+        const clockAfterFirst = await readRecordedClock(backend);
+        const rowsAfterFirst = await countRecordedRows(backend);
+        expect(clockAfterFirst).toBeDefined();
+
+        // Any number of byte-identical replays must not touch history.
+        await store.nodes.Item.upsertById(id, props);
+        await store.nodes.Item.upsertById(id, props);
+
+        expect(await readRecordedClock(backend)).toBe(clockAfterFirst);
+        expect(await countRecordedRows(backend)).toBe(rowsAfterFirst);
+      }),
+      { numRuns: 60 },
+    );
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #256.

Opt-in store option for at-least-once / replay materializers: with `coalesceUnchangedUpserts: true`, an upsert whose validated props are value-identical to the existing live row performs **no write at all** — no `updateNode`, no recorded-history row, no revision-clock advance, no operation hooks — and resolves with the existing node. A full N-event replay of an already-converged log now writes nothing and leaves recorded time untouched, instead of rewriting every row and growing history by N.

Default is **off**: some consumers want an audit row per re-delivery (proof the event was reprocessed). A per-call flag was considered and rejected — #256 asks for a store option, and the workloads that want this (replay materializers, merge) want it store-wide.

## Coalescing rules (all must hold, else the normal write happens)
1. A live row exists for the id (else it's a create).
2. The row is not soft-deleted (upsert resurrects; never coalesced).
3. No explicit `validFrom`/`validTo` was passed (an explicit temporal override is a real request).
4. Validated new props deep-equal the stored props (`canonicalEqual` — key-order-independent, schema defaults applied), compared on exactly what the write path would write: the dirty check shares `resolveNodeUpdateProps`/`resolveEdgeUpdateProps` with the update path, so the two cannot disagree.

Covers the full upsert-by-id surface: node `upsertById` / `upsertByIdFromRecord` / `bulkUpsertById`, edge `bulkUpsertById` (edges have no single upsert; endpoints are never rewritten by upsert, so props-only comparison is exact). Bulk batches coalesce per item with input-order-preserved results. The option reaches transaction-scoped collections automatically.

## Receipt semantics (verified — the composability claim in #256 holds)
A coalesced replay through `transactionWithReceipt` surfaces as `writes.total === 1` with `recorded === undefined` — byte-identical to the no-op delete shape consumers already handle by carrying the prior anchor forward. No new receipt surface needed; the two-signal split does the work. (Caveat inherited from receipt granularity: the shape is per-transaction, so a coalesced upsert mixed with other real writes in one transaction is masked — same as no-op deletes today.)

## graph-merge interaction: sound, no bypass
Merge commits through tx collections and inherits the flag. Safe because: the base@V guard runs before any upsert and reads the revision clock, unaffected by elided writes; conflicts are resolved at plan time and a coalesced write is by definition byte-identical; the final merged state is identical — unchanged rows just don't get re-stamped with a new recorded instant, which is the option's purpose. Full merge suites (482 tests) green. Documented on `commitPlan`.

## Honest cost note
With the flag ON, a genuinely-*changed* upsert pays one extra Zod validation (the dirty check); the write path deliberately re-resolves under its own transaction (re-read under lock — threading the pre-lock resolution in would be a TOCTOU). The replay path this targets validates once and skips the write entirely.

## Tests
- Shared cross-backend suite (`tests/backends/integration/coalesce-upserts.ts`, SQLite + PostgreSQL): the full rules matrix (unchanged/changed/soft-deleted/explicit-validFrom/flag-off), key-order independence, mixed bulk batches, edge symmetry, history assertions (no new recorded row, `recordedNow()` stable, capture resumes on real change), revision-anchor non-advance, and the #256 receipt shape end-to-end.
- Property test: arbitrary props re-upserted identically is history-idempotent under the flag.

Gates: typecheck clean, SQLite 4888 passed, PostgreSQL 1983 passed, `pnpm fix` clean (the docs-app lint failure seen mid-review was a fresh-worktree Astro codegen artifact, resolved by `astro sync`; nothing in this diff).

Independent of #260/#261 (different seams); all three target the same release.