### PR TITLE
docs: rewrite event-log guide against the post-fix transaction API (#259)

### DIFF
--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -31,10 +31,9 @@ should converge on the same graph state, not create duplicates.
 ## Idempotent Projectors
 
 Use stable source ids as TypeGraph ids whenever the source has them. For nodes,
-that usually means `upsertById`. For edges, prefer
-`getOrCreateByEndpoints` with a `matchOn` policy for the fields that identify
-the relationship. Avoid `create` in a log projector unless the source event
-itself carries a unique id you pass as the TypeGraph id.
+that usually means `upsertById`. For edges, prefer `getOrCreateByEndpoints`.
+Avoid `create` in a log projector unless the source event itself carries a
+unique id you pass as the TypeGraph id.
 
 ```typescript
 async function projectChange(
@@ -50,61 +49,134 @@ async function projectChange(
     name: change.actorName,
   });
 
-  await tx.edges.changedBy.getOrCreateByEndpoints(
-    issue,
-    actor,
-    {
-      sourceChangeId: change.id,
-      action: change.action,
-    },
-    {
-      matchOn: ["sourceChangeId"],
-    },
-  );
+  await tx.edges.changedBy.getOrCreateByEndpoints(issue, actor, {
+    action: change.action,
+  });
 }
 ```
 
 The important rule is that the second delivery of the same change takes the same
 code path and reaches the same row identities.
 
+### `matchOn` widens the identity key — don't reach for it by default
+
+`getOrCreateByEndpoints` matches on the endpoints `(from, to)` alone unless you
+pass `matchOn`. Endpoints-only is the **more** idempotent choice and is right for
+most projectors: a re-delivered edge between the same two nodes converges on the
+one existing edge regardless of how its properties drifted between deliveries.
+
+`matchOn` adds the named property fields to the match key, so it *widens*
+identity — two edges between the same endpoints are now distinct if they differ
+on a matched field. Use it only when the relationship model genuinely allows
+several parallel edges between one pair (say, one `changedBy` edge per distinct
+`action`), and know the footgun: if a re-delivered change carries a **changed**
+value in a matched field, it no longer matches the earlier edge and you get a
+**second** edge instead of convergence. Reach for `matchOn` when the domain
+needs the extra edges, not as a reflex.
+
 ## Cursor Bookkeeping
 
-A cursor is application state: store it as an ordinary graph node or in a
-separate application table. The cursor should advance only at a source offset
-boundary, after every change in that batch has been projected.
+A cursor is application state: the last source offset you have safely processed.
+It should advance only at a source offset boundary, after every change in that
+batch has been projected. Where the cursor lives — a row in your own relational
+table, or a node in the graph — decides which guarantees you can get.
 
-### Same-transaction cursor
+### Exactly-once with an adopted transaction
 
-When the backend supports transactions, write the cursor row in the same
-`store.transaction` callback as the projected batch. On transactional backends,
-this gives exactly-once materialization relative to the source offset: either the
-batch and cursor commit together, or neither does.
+To commit the projected batch **and** the cursor as one unit, let the caller own
+the transaction and adopt it with
+[`store.withRecordedTransaction(externalTx, fn)`](/schemas-stores/#transaction-receipts).
+The graph writes and your own cursor write land on the same connection inside the
+same commit: either both persist or neither does, so the cursor can never advance
+past a batch the graph did not durably record.
+
+Two constraints make this the *only* sanctioned transactional recipe on a store
+created with `{ history: true }` — which the Transaction Receipts and Bitemporal
+sections below both require:
+
+- **Write your own tables through the external handle you passed in**, never
+  through `tx.sql`. Under history capture `tx.sql` is a present-but-throwing
+  guard (raw SQL would bypass recorded-time capture); its static type is
+  `sql?: never` and every access raises a
+  [`ConfigurationError`](/errors/#recorded-capture-guard-codes). The external
+  handle *is* the pinned connection, so writing your cursor row through it keeps
+  both layers in the one transaction.
+- **`store.withTransaction()` — the non-recorded sibling — is a compile error on
+  a history store** (its `externalTx` argument is rejected against a message
+  type), and its runtime guard throws
+  `RECORDED_CAPTURE_REQUIRES_CALLBACK_TRANSACTION`. It has no flush point before
+  the caller commits, so recorded-time capture could not seal. Use
+  `withRecordedTransaction` instead.
+
+**Async drivers (Postgres / libsql)** open the boundary with `db.transaction`:
 
 ```typescript
-await store.transaction(async (tx) => {
-  for (const change of batch.changes) {
-    await projectChange(tx, change);
-  }
-
-  await tx.nodes.Cursor.upsertById(`source:${batch.sourceId}`, {
-    offset: batch.endOffset,
-    sourceId: batch.sourceId,
+const receipt = await db.transaction(async (dbTx) => {
+  const outcome = await store.withRecordedTransaction(dbTx, async (tx) => {
+    for (const change of batch.changes) {
+      await projectChange(tx, change);
+    }
   });
-});
+
+  // The cursor row goes through the external handle, in the same transaction.
+  await dbTx
+    .insert(streamCursors)
+    .values({ sourceId: batch.sourceId, offset: batch.endOffset })
+    .onConflictDoUpdate({
+      target: streamCursors.sourceId,
+      set: { offset: batch.endOffset },
+    });
+
+  return outcome.receipt;
+}); // one COMMIT / ROLLBACK across both layers
 ```
 
-Check `backend.capabilities.transactions` before relying on that atomicity. On
-backends where it is `false` (for example Cloudflare D1 or `neon-http`),
-`store.transaction` still runs the callback but cannot make the writes atomic.
-The guarantee degrades to at-least-once delivery plus idempotence and
-partial-failure recovery. Keeping the cursor update at the end of the callback
-still preserves ordering, but it does not make the batch atomic.
+**Synchronous `better-sqlite3`** cannot adopt an `async` transaction callback
+(its driver rejects a promise-returning `db.transaction`), so the caller frames
+the boundary by hand with `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK` on the single
+connection:
 
-### Separate cursor store
+```typescript
+await db.run(sql`BEGIN IMMEDIATE`);
+try {
+  const { receipt } = await store.withRecordedTransaction(db, async (tx) => {
+    for (const change of batch.changes) {
+      await projectChange(tx, change);
+    }
+    await db.run(sql`
+      INSERT INTO stream_cursor (source_id, offset)
+      VALUES (${batch.sourceId}, ${batch.endOffset})
+      ON CONFLICT (source_id) DO UPDATE SET offset = excluded.offset
+    `);
+  });
+  await db.run(sql`COMMIT`);
+  // persist receipt.recorded as the offset's replay anchor — see below
+} catch (error) {
+  await db.run(sql`ROLLBACK`); // graph writes and cursor roll back together
+  throw error;
+}
+```
 
-If the cursor lives outside TypeGraph, the pattern is always at-least-once plus
-idempotence. A crash after the graph writes but before the cursor write replays
-the batch. That is acceptable only because projector writes converge.
+The graph writes and your own statements share the caller's one pinned
+connection. TypeGraph serializes the statements its collections issue; sequence
+your own raw statements yourself (don't `Promise.all` them with graph writes) so
+two queries never race on that connection.
+
+For a portable materializer that runs against several backends, branch on
+capability rather than message-matching: use
+[`tx.sqlAvailability`](/recipes/#cross-store-transactions-drizzle--typegraph) to
+decide whether raw SQL is usable inside `store.transaction`, and
+[`isRecordedCaptureGuardError(error, code?)`](/errors/#recorded-capture-guard-codes)
+to recognize a history-store guard when you catch one.
+
+### At-least-once with a separate cursor store
+
+When the runtime already owns checkpointing, or the backend cannot provide atomic
+transactions (`backend.capabilities.transactions === false` — Cloudflare D1,
+`drizzle-orm/neon-http`), keep the cursor outside the graph transaction. The
+pattern is at-least-once plus idempotence: a crash after the graph writes but
+before the cursor write replays the batch, which is safe precisely because the
+projector converges.
 
 ```typescript
 await store.transaction(async (tx) => {
@@ -119,45 +191,133 @@ await cursorStore.save({
 });
 ```
 
-Use the same-transaction cursor on transactional backends when the cursor is part
-of the graph's source-of-truth state. Use a separate cursor store when the
-runtime already owns checkpointing or when the backend cannot provide atomic
-transactions.
+This at-least-once path plus an idempotent projector is the workload TypeGraph is
+built for. It is also the one that churns recorded history the hardest: every
+re-delivery of a byte-identical change rewrites its row, allocating a fresh
+recorded instant and a new history row per delivery. Enable
+[`coalesceUnchangedUpserts: true`](/schemas-stores/#createstoregraph-backend-options)
+on the store to suppress that: an `upsertById` whose validated props already
+equal the live row performs no write, no history row, and no revision advance,
+and resolves with the existing node. See
+[Transaction Receipts](#transaction-receipts) for how a coalesced upsert reads on
+a receipt.
+
+### In-graph cursors and the receipt
+
+A cursor can also live inside the graph as an ordinary node — convenient, and it
+travels with the graph. But if you also use the transaction receipt (next
+section) to detect a projector that dropped a change, an in-graph cursor
+**corrupts that signal**: the receipt counts writes per transaction with no
+attribution, so the cursor's own upsert is indistinguishable from the projector's
+writes. A projector that drops a change in a transaction that also checkpoints an
+in-graph cursor produces `writes.total === 1` from the cursor alone —
+`writes.total > 0` no longer means "the projector wrote," the drop goes
+undetected, and the cursor advances past the lost event.
+
+Two ways out:
+
+- **Scope the projector with `tx.measure`.** On a receipt-enabled context
+  (`transactionWithReceipt` or `withRecordedTransaction`),
+  [`tx.measure(fn)`](/schemas-stores/#scoped-receipts-txmeasure) returns a
+  sub-receipt counting only the writes that resolved while `fn` ran, so the
+  cursor's write — made outside the measured region — is excluded. This is what
+  makes an in-graph cursor and drop-detection composable; see the full loop
+  below.
+- **Keep the cursor in your own relational table.** The
+  [exactly-once recipe](#exactly-once-with-an-adopted-transaction) makes that
+  atomic anyway, and it keeps the belief graph pristine: an in-graph cursor node
+  still lands in every `asOfRecorded` reconstruction of the graph, so a consumer
+  that wants recorded-time reads to show only projected facts should keep the
+  cursor out of the graph entirely.
 
 ## Transaction Receipts
 
 When you need to know what a projector did, use `store.transactionWithReceipt`
-instead of `store.transaction`:
+(TypeGraph owns the boundary) or `store.withRecordedTransaction` (you adopt an
+open transaction); both return a `TransactionOutcome` with a `receipt`.
+
+The receipt carries **two signals that deliberately disagree**, and a
+materializer needs both. `receipt.writes.total` counts completed write intents at
+the collection surface; `receipt.recorded` (on a `{ history: true }` store) is
+the recorded commit instant this transaction allocated, or `undefined` when
+nothing was captured. The common, load-bearing case is where they diverge:
+
+| case                                          | `writes.total` | `recorded`      |
+| --------------------------------------------- | -------------- | --------------- |
+| projector wrote                               | `> 0`          | defined         |
+| no-op delete of an absent key (a real intent) | `1`            | **`undefined`** |
+| coalesced upsert (value-identical, opt-in)    | `1`            | **`undefined`** |
+| projector dropped the change                  | `0`            | `undefined`     |
+
+A no-op delete completes a write *intent* but captures nothing; a
+[coalesced upsert](/schemas-stores/#createstoregraph-backend-options) is the same
+shape by design. In both, `writes.total` counts (the method resolved) but
+`recorded` is `undefined`. **An offset whose transaction reports
+`recorded === undefined` must carry the prior anchor forward** — otherwise
+replay-by-offset breaks at exactly the offsets where nothing changed.
+
+Two counting rules bite materializers specifically, both worth internalizing
+before you read `writes.total` as "the projector did work":
+
+- **Bulk methods count by input length**, so `bulkCreate([])` contributes `0`. A
+  projector that filters a batch down to nothing and issues an empty bulk call
+  must not read as a writer.
+- **A method that rejects counts `0`** — even on SQLite, where a failed statement
+  does **not** abort the surrounding transaction. A projector that swallows a
+  write error and commits can persist rows the receipt never counted, so do not
+  read the receipt as rows-affected in that scenario.
+
+### The full materializer loop
+
+Putting the pieces together: an adopted transaction for exactly-once cursors, a
+`tx.measure`-scoped projector so a single dropped change is caught within a
+multi-change batch — the outer receipt only tells you the whole batch wrote
+nothing, `measure` attributes per change (and, if you keep an in-graph cursor,
+excludes its write from the count) — `receipt.recorded` as the per-offset replay
+anchor, and `writes.total === 0` on a non-delete change as the drop signal.
 
 ```typescript
-const outcome = await store.transactionWithReceipt(async (tx) => {
-  for (const change of batch.changes) {
-    await projectChange(tx, change);
-  }
+const receipt = await db.transaction(async (dbTx) => {
+  const outcome = await store.withRecordedTransaction(dbTx, async (tx) => {
+    for (const change of batch.changes) {
+      const projected = await tx.measure(() => projectChange(tx, change));
 
-  await tx.nodes.Cursor.upsertById(`source:${batch.sourceId}`, {
-    offset: batch.endOffset,
-    sourceId: batch.sourceId,
+      // A non-delete change that wrote nothing was silently dropped.
+      if (
+        projected.receipt.writes.total === 0 &&
+        change.operation !== "delete"
+      ) {
+        throw new DroppedChangeError(change); // rolls the whole batch back
+      }
+    }
   });
+
+  await dbTx
+    .insert(streamCursors)
+    .values({ sourceId: batch.sourceId, offset: batch.endOffset })
+    .onConflictDoUpdate({
+      target: streamCursors.sourceId,
+      set: { offset: batch.endOffset },
+    });
+
+  return outcome.receipt;
 });
 
-if (batch.changes.length > 0 && outcome.receipt.writes.total === 0) {
-  throw new Error("projector dropped a non-empty batch");
-}
-
-if (outcome.receipt.recorded !== undefined) {
-  await offsetAnchors.save(batch.endOffset, outcome.receipt.recorded);
+// Anchor the offset from the receipt, never from a post-commit recordedNow().
+if (receipt.recorded !== undefined) {
+  await offsetAnchors.save(batch.endOffset, receipt.recorded);
+} else {
+  await offsetAnchors.carryForward(batch.endOffset); // nothing captured
 }
 ```
 
-`receipt.writes` counts completed write intents at the TypeGraph collection
-surface. It is not a rows-affected count: a successful delete of an absent row
-still counts as one completed write intent, and a rejected write counts zero.
-Bulk methods count by input length, so `bulkCreate([])` contributes zero.
-
-With `history: true`, `receipt.recorded` is the recorded commit anchor allocated
-for the transaction. Persist that anchor beside the source offset when you need
-to replay the graph as it looked after processing a specific offset.
+**Take the replay anchor from `receipt.recorded`, never from a post-commit
+`store.recordedNow()`.** `recordedNow()` is the graph-global recorded
+high-water mark, advanced by **any** writer to the graph. Between your commit and
+your read of it, a concurrent writer can advance it, and `asOfRecorded(that)`
+then reconstructs a belief your stream never produced. The receipt hands you the
+instant *this* transaction allocated; that is the only anchor that reconstructs
+exactly what this offset materialized.
 
 ## Bitemporal Mapping
 
@@ -174,50 +334,89 @@ separate:
   That is correct SQL:2011 bitemporal behavior, not a bug.
 
 To replay by source offset, load the anchor you saved for that offset and read a
-recorded-time view:
+recorded-time view. The `receipt.recorded` you persisted is a branded
+`RecordedInstant`, but round-tripping through your cursor table stores it as a
+plain string — re-brand it with `asRecordedInstant` on the way back before
+passing it to `asOfRecorded`:
 
 ```typescript
-const anchor = await offsetAnchors.anchorFor(offset);
+import { asRecordedInstant } from "@nicia-ai/typegraph";
+
+const stored = await offsetAnchors.anchorFor(offset); // plain string from storage
+const anchor = asRecordedInstant(stored); // validates + re-brands
 const graphAtOffset = store.asOfRecorded(anchor);
 const issue = await graphAtOffset.nodes.Issue.getById(issueId);
 ```
 
 That answers "what did the materialized graph know after offset X?" even if
-later corrections changed or deleted rows.
+later corrections changed or deleted rows. See
+[Recorded time](/queries/temporal/#recorded-time-bitemporal) for the full view
+surface.
+
+### Refresh planner statistics after a large replay
+
+A replay or backfill runs its writes **inside caller-provided transactions** (the
+projector transaction, or interchange's own). Those never auto-refresh the query
+planner's table statistics — `ANALYZE` from another connection cannot see rows
+that are still uncommitted, so the store deliberately skips the automatic refresh
+it does after large autocommit bulk writes. Left alone, the planner keeps
+pre-load row estimates and can pick an order-of-magnitude-slower plan. After a
+large replay, refresh once:
+
+```typescript
+await replayEverything();
+await store.refreshStatistics(); // once, after the bulk replay commits
+```
 
 ## Bulk Copy Between Stores
 
-Use interchange for bulk copy between stores. The same path powers graph-merge
-working copies: export the source subset, create a branch from the target base,
-then import with `onConflict: "update"`.
+To copy a materialized graph into another store — most often a graph-merge
+working copy — stream interchange directly from source to target with
+`exportGraphStream` / `importGraphStream`. This is the same path
+[graph-merge](/interchange/) uses internally, so a copy produces byte-identical
+merge results, conflicts, and provenance to a native branch:
 
 ```typescript
-import { importGraph, exportGraph } from "@nicia-ai/typegraph/interchange";
-import { asBranchId, branch, unwrap } from "@nicia-ai/typegraph/graph-merge";
+import {
+  exportGraphStream,
+  importGraphStream,
+} from "@nicia-ai/typegraph/interchange";
 
-const data = await exportGraph(sourceStore, {
-  nodeKinds: ["Belief", "Claim"],
-  edgeKinds: ["supports"],
-  includeMeta: true,
-});
-
-const fork = unwrap(
-  await branch(baseStore, makeBranchBackend, {
-    id: asBranchId("source-a"),
+const result = await importGraphStream(
+  branch.store,
+  exportGraphStream(beliefStore, {
+    nodeKinds: ["Belief", "Claim"],
+    edgeKinds: ["supports"],
+    includeTemporal: true,
   }),
+  { onConflict: "update" },
 );
-
-const result = await importGraph(fork.store, data, {
-  onConflict: "update",
-  validateReferences: true,
-});
 
 if (!result.success) {
   throw new Error(`copy failed with ${result.errors.length} import errors`);
 }
 ```
 
-This is the preferred bulk path for copying a materialized belief store into a
-merge branch. It preserves ids, routes existing rows through normal conflict
-handling, validates edge endpoints, and keeps the branch non-history unless you
-explicitly create it with history capture.
+Two option defaults are exactly right here and worth stating because they are not
+obvious:
+
+- **`includeDeleted` defaults to `false`.** A retracted fact must not resurface
+  in the copy — a soft-deleted row stays deleted on the target.
+- **`includeTemporal` must be set to `true`** (it defaults to `false`). It is
+  what carries each fact's original `validFrom` / `validTo` across the copy;
+  without it the import re-stamps every fact with the *copy's* wall clock,
+  destroying valid-time fidelity in the merged branch.
+
+`importGraphStream` preserves ids, routes existing rows through normal
+`onConflict` handling, validates edge endpoints (`validateReferences` defaults to
+`true`), and refreshes planner statistics once after the import commits.
+
+## Cursor-Based Resumption and Electric
+
+The examples above assume a per-change offset. **Electric does not provide one** —
+every change in a `ShapeStream` catch-up batch shares the stream's
+`lastOffset`. A cursor keyed on Electric's offset can therefore only advance at a
+**batch boundary**, after the whole batch is projected. Advancing mid-batch is
+unsafe: Electric's `read(after)` is strictly-after, so resuming from a
+mid-batch offset permanently skips that batch's remaining changes. Project the
+whole batch, then checkpoint the cursor once at its boundary.

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -218,11 +218,14 @@ Two ways out:
 
 - **Scope the projector with `tx.measure`.** On a receipt-enabled context
   (`transactionWithReceipt` or `withRecordedTransaction`),
-  [`tx.measure(fn)`](/schemas-stores/#scoped-receipts-txmeasure) returns a
-  sub-receipt counting only the writes that resolved while `fn` ran, so the
-  cursor's write — made outside the measured region — is excluded. This is what
-  makes an in-graph cursor and drop-detection composable; see the full loop
-  below.
+  [`tx.measure((scopedTx) => …)`](/schemas-stores/#scoped-receipts-txmeasure)
+  hands your callback a **scoped context** and returns a sub-receipt that counts
+  exactly the writes made **through that scoped context** (`scopedTx.nodes` /
+  `scopedTx.edges`). Run the projector through `scopedTx`; write the cursor
+  through the outer `tx` (or your own table). Attribution is by which context you
+  write through, not by timing, so the cursor's write counts only in the outer
+  receipt and the scope reflects the projector alone. This is what makes an
+  in-graph cursor and drop-detection composable; see the full loop below.
 - **Keep the cursor in your own relational table.** The
   [exactly-once recipe](#exactly-once-with-an-adopted-transaction) makes that
   atomic anyway, and it keeps the belief graph pristine: an in-graph cursor node
@@ -272,9 +275,11 @@ before you read `writes.total` as "the projector did work":
 Putting the pieces together: an adopted transaction for exactly-once cursors, a
 `tx.measure`-scoped projector so a single dropped change is caught within a
 multi-change batch — the outer receipt only tells you the whole batch wrote
-nothing, `measure` attributes per change (and, if you keep an in-graph cursor,
-excludes its write from the count) — `receipt.recorded` as the per-offset replay
-anchor, and `writes.total === 0` on a non-delete change as the drop signal.
+nothing, whereas a `measure` scope attributes writes per change by having the
+projector write through the scoped context it receives (any cursor written
+through the outer `tx` stays out of that count) — `receipt.recorded` as the
+per-offset replay anchor, and `writes.total === 0` on a non-delete change as the
+drop signal.
 
 `withRecordedTransaction` flushes recorded-time capture and resolves **before**
 the caller's commit, so `outcome.receipt.recorded` is already known inside the
@@ -291,7 +296,11 @@ let lastAnchor: RecordedInstant | undefined = await loadLastAnchor(); // on resu
 lastAnchor = await db.transaction(async (dbTx) => {
   const outcome = await store.withRecordedTransaction(dbTx, async (tx) => {
     for (const change of batch.changes) {
-      const projected = await tx.measure(() => projectChange(tx, change));
+      // The projector writes through the scoped context, so `projected`
+      // counts its writes alone — nothing else in the transaction.
+      const projected = await tx.measure((scopedTx) =>
+        projectChange(scopedTx, change),
+      );
 
       // A non-delete change that wrote nothing was silently dropped.
       if (

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -276,8 +276,19 @@ nothing, `measure` attributes per change (and, if you keep an in-graph cursor,
 excludes its write from the count) — `receipt.recorded` as the per-offset replay
 anchor, and `writes.total === 0` on a non-delete change as the drop signal.
 
+`withRecordedTransaction` flushes recorded-time capture and resolves **before**
+the caller's commit, so `outcome.receipt.recorded` is already known inside the
+`db.transaction` callback. Write the cursor advance **and** its replay anchor
+through `dbTx` there, in the same commit as the graph writes. Persisting the
+anchor after the commit — as a separate step — would reopen the exactly-once gap
+the adopted transaction exists to close: a crash between the commit and the
+anchor write leaves the cursor advanced with no anchor, and that offset can never
+be replayed.
+
 ```typescript
-const receipt = await db.transaction(async (dbTx) => {
+let lastAnchor: RecordedInstant | undefined = await loadLastAnchor(); // on resume
+
+lastAnchor = await db.transaction(async (dbTx) => {
   const outcome = await store.withRecordedTransaction(dbTx, async (tx) => {
     for (const change of batch.changes) {
       const projected = await tx.measure(() => projectChange(tx, change));
@@ -292,6 +303,17 @@ const receipt = await db.transaction(async (dbTx) => {
     }
   });
 
+  // `recorded` is undefined when the batch captured nothing (all drops, no-op
+  // deletes, or coalesced upserts) — carry the prior anchor forward so replay
+  // by offset still resolves. Anchor comes from the receipt, never from a
+  // post-commit store.recordedNow() (see below).
+  const anchor = outcome.receipt.recorded ?? lastAnchor;
+
+  // Cursor and anchor commit atomically with the graph writes: no window where
+  // the cursor has advanced past an offset whose anchor was never persisted.
+  await dbTx
+    .insert(offsetAnchors)
+    .values({ sourceId: batch.sourceId, offset: batch.endOffset, recorded: anchor });
   await dbTx
     .insert(streamCursors)
     .values({ sourceId: batch.sourceId, offset: batch.endOffset })
@@ -300,15 +322,8 @@ const receipt = await db.transaction(async (dbTx) => {
       set: { offset: batch.endOffset },
     });
 
-  return outcome.receipt;
+  return anchor; // updates lastAnchor only once the transaction commits
 });
-
-// Anchor the offset from the receipt, never from a post-commit recordedNow().
-if (receipt.recorded !== undefined) {
-  await offsetAnchors.save(batch.endOffset, receipt.recorded);
-} else {
-  await offsetAnchors.carryForward(batch.endOffset); // nothing captured
-}
 ```
 
 **Take the replay anchor from `receipt.recorded`, never from a post-commit
@@ -355,18 +370,23 @@ surface.
 
 ### Refresh planner statistics after a large replay
 
-A replay or backfill runs its writes **inside caller-provided transactions** (the
-projector transaction, or interchange's own). Those never auto-refresh the query
-planner's table statistics — `ANALYZE` from another connection cannot see rows
-that are still uncommitted, so the store deliberately skips the automatic refresh
-it does after large autocommit bulk writes. Left alone, the planner keeps
-pre-load row estimates and can pick an order-of-magnitude-slower plan. After a
-large replay, refresh once:
+A **custom** replay or backfill loop — one built from the projector recipes above
+— runs its writes **inside a caller-provided transaction**, which never
+auto-refreshes the query planner's table statistics: `ANALYZE` from another
+connection cannot see rows that are still uncommitted, so the store deliberately
+skips the automatic refresh it does after large autocommit bulk writes. Left
+alone, the planner keeps pre-load row estimates and can pick an
+order-of-magnitude-slower plan. After a large custom replay, refresh once:
 
 ```typescript
 await replayEverything();
 await store.refreshStatistics(); // once, after the bulk replay commits
 ```
+
+The interchange path handles this for you: `importGraph` and `importGraphStream`
+call `refreshStatistics()` once after the import commits (see
+[Bulk Copy Between Stores](#bulk-copy-between-stores)), so a bulk copy needs no
+manual refresh.
 
 ## Bulk Copy Between Stores
 
@@ -400,8 +420,13 @@ if (!result.success) {
 Two option defaults are exactly right here and worth stating because they are not
 obvious:
 
-- **`includeDeleted` defaults to `false`.** A retracted fact must not resurface
-  in the copy — a soft-deleted row stays deleted on the target.
+- **`includeDeleted` defaults to `false`, and the copy clones live state — it
+  does not synchronize deletions.** The exporter simply omits soft-deleted rows;
+  it cannot round-trip `deletedAt` at all (the wire format carries no deletion
+  flag). So a fact deleted on the source is merely *absent* from the stream: on a
+  fresh target it never appears, but on a populated target an existing live row
+  **stays live** — the copy never deletes it. If the target must reflect
+  deletions, apply them through your projector, not the bulk copy.
 - **`includeTemporal` must be set to `true`** (it defaults to `false`). It is
   what carries each fact's original `validFrom` / `validTo` across the copy;
   without it the import re-stamps every fact with the *copy's* wall clock,


### PR DESCRIPTION
Closes #259.

Full revision of the "Materializing External Event Logs" guide per the seven findings from its first real implementation (`@nicia-ai/agent-stream-graph`), written against the API surface of #260, #261, and #262. **Merge after those three** — the guide documents `withRecordedTransaction` returning `TransactionOutcome`, `tx.measure`, `tx.sqlAvailability`, the guard error codes, and `coalesceUnchangedUpserts`.

Per §:

1. **Cursor Management** — the unimplementable `store.transaction` cursor advice is replaced by the adopted-transaction recipe: `withRecordedTransaction`, cursor rows written through the **external handle**, examples for async drivers and better-sqlite3's manual `BEGIN IMMEDIATE` framing, and the note that `withTransaction()` on a history store is now a compile error.
2. **In-graph cursors** — the receipt-contamination trap, with both fixes: `tx.measure` scoping, or an external cursor table; plus the honest note that an in-graph cursor lands in every `asOfRecorded` reconstruction.
3. **Composition** — "The full materializer loop": adopted tx + measured projector + cursor + `receipt.recorded` anchor + drop detection. (§3 of the issue predates #255 landing; the composed loop replaces the "forfeits the receipt" caveat the issue asked for as a fallback.)
4. **`recordedNow()` warning** — anchors come from `receipt.recorded`, never a post-commit `recordedNow()` (graph-global high-water).
5. **Two-signal receipt table** — wrote / no-op delete / coalesced upsert / dropped change; carry-prior-anchor-forward rule; bulk-counts-by-input-length and rejected-counts-0 footguns.
6. **Replay statistics** — caller-provided transactions never auto-refresh; `refreshStatistics()` once after a large replay.
7. **Smaller** — `matchOn` corrected (endpoints-only default is the *more* idempotent choice; `matchOn` widens the identity key); Bulk Transfer made actionable (`importGraphStream(target, exportGraphStream(source, { includeTemporal: true }), { onConflict: "update" })`, with precise framing: `includeDeleted` defaults `false`; `includeTemporal` must be explicitly `true` — the issue's "two defaults" phrasing was slightly off); Electric batch-boundary cursor caveat (shared `lastOffset`; mid-batch advance skips the rest on resume).

Also woven in: `coalesceUnchangedUpserts` for at-least-once replay, `tx.sqlAvailability` / `isRecordedCaptureGuardError` for portable materializers, and persisted-anchor re-branding via `asRecordedInstant()`.

Every code block was verified against source on the actual PR branches (not memory); cross-link anchors verified against the sibling branches' headings. Prettier + markdownlint clean.