### PR TITLE
docs: scope the coalesceUnchangedUpserts benefit to re-delivery churn

### DIFF
--- a/.changeset/coalesce-replay-scope-docs.md
+++ b/.changeset/coalesce-replay-scope-docs.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Docs: scope the `coalesceUnchangedUpserts` benefit correctly. Coalescing
+eliminates _re-delivery_ churn (an already-applied change delivered again,
+value-identical to the live row). It does not make a full replay-from-zero
+free when the stream supersedes values in place: re-applying an older value
+over the live row is a genuine change, and restoring the current value
+afterwards is another, so such a replay still writes — and leaves a spurious
+back-and-forth band in the live store's recorded history. Churn-free rebuilds
+replay into a fresh store instead. Clarified in the option's TSDoc and in the
+"Materializing external event logs" guide; no behavior change.

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -202,6 +202,20 @@ and resolves with the existing node. See
 [Transaction Receipts](#transaction-receipts) for how a coalesced upsert reads on
 a receipt.
 
+**Coalescing eliminates *re-delivery* churn, not replay cost.** The win is
+scoped to re-delivery of the current value — the realistic at-least-once case,
+where a change that was already applied arrives again (a crash-window replay, a
+duplicate) and is value-identical to the live row. A full **replay-from-zero**
+over the current state is different: if the stream contains in-place updates,
+replaying `insert a=1 … update a=2` re-applies `a=1` over the live `a=2` — a
+genuine backward change that writes — and then `a=2` restores it. Both writes
+are correct (the replay faithfully re-walks each historical state), but
+"coalescing makes replay free" holds only for streams whose rows never
+supersede each other. It also leaves a spurious `a=2 → a=1 → a=2` band in the
+live store's recorded history, stamped at replay time. To rebuild without
+either cost, replay into a **fresh store** and publish it, rather than
+re-applying the log over the current state.
+
 ### In-graph cursors and the receipt
 
 A cursor can also live inside the graph as an ordinary node — convenient, and it

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -355,13 +355,19 @@ type BaseStoreOptions = Readonly<{
    * off.
    *
    * Enable this for at-least-once / replay materializers. An event log that
-   * re-delivers a byte-identical change, or a full replay that reprocesses an
-   * already-materialized log, would otherwise rewrite every row it touches:
+   * re-delivers a byte-identical change would otherwise rewrite the row anyway:
    * today an `upsertById` on an existing id calls `updateNode`
    * unconditionally, allocating a fresh recorded instant and a new history row
-   * per re-delivery. A rebuild — the workload replay is recommended for — is
-   * the one that inflates recorded history most, with a dense band of
-   * "changes" that changed nothing.
+   * per re-delivery.
+   *
+   * The win is scoped to re-delivery of the **current** value. A full
+   * replay-from-zero over the current state still writes wherever the stream
+   * superseded a value in place: re-applying an older value over the live row
+   * is a genuine change (and restoring the current value afterwards is
+   * another), so only streams whose rows never supersede each other replay
+   * without churn. A rebuild that should avoid that re-walk belongs in a fresh
+   * store — replay into it and publish it, rather than re-applying the log
+   * over current state.
    *
    * When enabled, an upsert that would not change the stored value performs
    * **no write at all**: no `updateNode`, no recorded-time capture, no history


### PR DESCRIPTION
`coalesceUnchangedUpserts` (#256, shipped in 0.36) removes **re-delivery** churn: an already-applied change delivered again is value-identical to the live row and coalesces to a true no-op. Both the option's TSDoc and the materializing-event-logs guide implied the benefit extended to full replays; it doesn't when the stream supersedes values in place, and the first external consumer hit exactly that (agent-stream-graph's first test draft — surfaced on #259).

Replaying `insert a=1 … update a=2` over the current state re-applies `a=1` over the live `a=2` — a genuine backward change that writes — then `a=2` restores it. Correct behavior, but two real writes plus a spurious `a=2 → a=1 → a=2` band in the live store's recorded history, stamped at replay time. "Coalescing makes replay free" holds only for streams whose rows never supersede each other; churn-free rebuilds replay into a fresh store and publish it.

## Changes

- **`materializing-event-logs.md`**: new paragraph after the coalescing recommendation drawing the re-delivery vs replay-from-zero line, including the recorded-history side effect and the fresh-store rebuild recipe.
- **`store/types.ts`** (`coalesceUnchangedUpserts` TSDoc): the previous text claimed a full replay "would otherwise rewrite every row it touches", implying coalescing fixes replays generally — rescoped to re-delivery of the current value, with the supersession caveat and fresh-store guidance. Comment-only; no behavior change.
- Patch changeset (the TSDoc ships in the package).
