### PR TITLE
fix(vector): provision per-field embedding storage via durable markers (least-privilege safe)

### DIFF
--- a/.changeset/marker-gated-vector-storage.md
+++ b/.changeset/marker-gated-vector-storage.md
@@ -35,3 +35,9 @@ creating the table.
 once under the schema-owner role. It creates the per-field vector tables +
 markers; least-privilege runtimes then assert markers (SELECT) and run vector
 DML with zero DDL — no `GRANT CREATE` required.
+
+Consumers that boot manually (raw DDL + the sync `createStore` attach +
+`backend.ensureRuntimeContributions`) provision vectors the same way: the new
+`resolveGraphVectorSlots(graph)` export enumerates every embedding
+`(kind, field)` slot, and `backend.ensureVectorSlotContribution(slot)`
+materializes each — the exact step `createStoreWithSchema` performs.

--- a/.changeset/marker-gated-vector-storage.md
+++ b/.changeset/marker-gated-vector-storage.md
@@ -52,4 +52,8 @@ Consumers that boot manually (raw DDL + the sync `createStore` attach +
 `backend.ensureRuntimeContributions`) provision vectors the same way: the new
 `resolveGraphVectorSlots(graph)` export enumerates every embedding
 `(kind, field)` slot, and `backend.ensureVectorSlotContribution(slot)`
-materializes each — the exact step `createStoreWithSchema` performs.
+materializes each — the exact step `createStoreWithSchema` performs. Batch
+counterparts (`backend.ensureVectorSlotContributions(slots)` /
+`backend.assertVectorSlotsInitialized(slots)`) resolve every slot's markers
+with one graph-scoped query — what boot and verified attach use, and the
+right choice for many embedding fields over a remote connection.

--- a/.changeset/marker-gated-vector-storage.md
+++ b/.changeset/marker-gated-vector-storage.md
@@ -1,0 +1,37 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Vector storage now rides the #135 durable-contribution machinery, so the
+runtime never issues DDL on the embedding hot path.
+
+Previously every vector op (`upsertEmbedding` / `deleteEmbedding` /
+`vectorSearch` / `createVectorIndex`) lazily ran `CREATE TABLE IF NOT EXISTS`
+for its per-`(kind, field)` table on whatever connection it executed on. On a
+least-privilege Postgres role (USAGE on `public`, full DML, but no `CREATE`)
+this failed with `permission denied for schema public` (SQLSTATE 42501) — even
+when the table already existed, because Postgres runs the schema aclcheck before
+the `IF NOT EXISTS` short-circuit. The fulltext path already avoided this via
+durable markers; vectors now do too.
+
+What changed:
+
+- **Boot (privileged):** `createStoreWithSchema` provisions every embedding
+  `(kind, field)` table + a durable contribution marker, enumerated from the
+  graph. `evolve()` provisions any embedding fields it introduces.
+- **Runtime (DML-only):** the hot path asserts the durable marker with a cached
+  SELECT and runs DML — never DDL. `createVerifiedStore` verifies vector markers
+  at attach, alongside fulltext.
+- `reembedVectorField` re-stamps the marker after recreating storage at a new
+  dimension; vector-field reclaim (`materializeRemovals`) clears the marker when
+  it drops a table.
+
+**Breaking:** vector ops now require a prior privileged `createStoreWithSchema`
+(exactly as fulltext already does). A plain `createStore` + embedding write with
+no provisioning step throws `StoreNotInitializedError` instead of lazily
+creating the table.
+
+**Migration:** after upgrading, run `createStoreWithSchema(graph, adminBackend)`
+once under the schema-owner role. It creates the per-field vector tables +
+markers; least-privilege runtimes then assert markers (SELECT) and run vector
+DML with zero DDL — no `GRANT CREATE` required.

--- a/.changeset/marker-gated-vector-storage.md
+++ b/.changeset/marker-gated-vector-storage.md
@@ -18,10 +18,22 @@ What changed:
 
 - **Boot (privileged):** `createStoreWithSchema` provisions every embedding
   `(kind, field)` table + a durable contribution marker, enumerated from the
-  graph. `evolve()` provisions any embedding fields it introduces.
-- **Runtime (DML-only):** the hot path asserts the durable marker with a cached
-  SELECT and runs DML — never DDL. `createVerifiedStore` verifies vector markers
+  graph. `evolve()` provisions any embedding fields it introduces. A slot
+  already provisioned at a *different* shape (the declared dimension changed)
+  is warned about and left untouched — boot stays reachable so
+  `store.reembedVectorField()` can recreate it; until then, writes to that
+  field fail with a `stale` `StoreNotInitializedError` that points at
+  `reembedVectorField`.
+- **Runtime writes (DML-only):** `upsertEmbedding` (single and batch) and
+  `deleteEmbedding` assert the durable marker with a cached, signature-checked
+  SELECT and run DML — never DDL. `createVerifiedStore` verifies vector markers
   at attach, alongside fulltext.
+- **Vector reads are not marker-gated:** `store.search.vector`,
+  `store.search.hybrid`, and query-builder `.similarTo()` predicates compile to
+  SQL against the per-field table directly (searches may override the metric at
+  query time, so their slot legitimately differs from the provisioned shape);
+  against an un-provisioned database they surface the engine's missing-relation
+  error, which `createVerifiedStore` catches at attach.
 - `reembedVectorField` re-stamps the marker after recreating storage at a new
   dimension; vector-field reclaim (`materializeRemovals`) clears the marker when
   it drops a table.

--- a/apps/docs/src/content/docs/architecture.md
+++ b/apps/docs/src/content/docs/architecture.md
@@ -442,9 +442,10 @@ backend.capabilities.vector; // { supported, metrics, indexTypes, maxDimensions,
 ### Storage
 
 Embeddings are stored in **per-field typed tables**, one per `(graphId, nodeKind, fieldPath)`, each carrying
-that field's fixed dimension. Tables are created lazily on first write and named
-`tg_vec_<graphId>_<kind>_<field>`. Graph-scoping the table name lets multiple graphs in one database declare the
-same kind+field at different dimensions without collision.
+that field's fixed dimension. Tables are provisioned by the privileged migrator (`createStoreWithSchema`, and
+`evolve()` for runtime-added fields), with a durable contribution marker; the runtime hot path asserts the
+marker and never issues DDL. They are named `tg_vec_<graphId>_<kind>_<field>`. Graph-scoping the table name lets
+multiple graphs in one database declare the same kind+field at different dimensions without collision.
 
 ```sql
 -- PostgreSQL with pgvector: one table per (graphId, kind, field). The kind
@@ -463,7 +464,7 @@ CREATE INDEX ON tg_vec_my_graph_document_embedding
 ```
 
 `generatePostgresMigrationSQL()` runs `CREATE EXTENSION IF NOT EXISTS vector` but creates no embedding table —
-the per-field tables are created at runtime on first write.
+the per-field tables are provisioned by `createStoreWithSchema` at boot (under the privileged role).
 
 ### Query Flow
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -46,11 +46,12 @@ createLocalSqliteBackend({ path: "./app.db", pragmas: { busyTimeoutMs: 10_000 } 
 createLocalSqliteBackend({ path: "./app.db", pragmas: false });
 ```
 
-:::caution[Fulltext requires `createStoreWithSchema`]
-`createLocalSqliteBackend` creates the tables but does not durably
-materialize fulltext storage. If your graph has `searchable()` fields,
-boot with `const [store] = await createStoreWithSchema(graph, backend);`
-instead of bare `createStore()` — otherwise the first fulltext operation
+:::caution[Fulltext and embeddings require `createStoreWithSchema`]
+`createLocalSqliteBackend` creates the base tables but does not durably
+materialize strategy-owned storage. If your graph has `searchable()` or
+`embedding()` fields, boot with
+`const [store] = await createStoreWithSchema(graph, backend);` instead of
+bare `createStore()` — otherwise the first fulltext or embedding operation
 throws `StoreNotInitializedError`.
 :::
 
@@ -113,7 +114,9 @@ const backend = createSqliteBackend(db, { vector: sqliteVecStrategy });
 ```
 
 sqlite-vec stores embeddings in `vec0` virtual tables and supports the `cosine` and `l2` metrics. Per-field
-vector tables are created lazily on first write — no embedding-table DDL is part of the migration.
+vector tables are provisioned by `createStoreWithSchema` at boot (not by the generated migration SQL), and the
+runtime asserts a durable marker rather than issuing DDL on first write — see
+[Database roles & least privilege](#database-roles--least-privilege).
 
 See [Semantic Search](/semantic-search) for query examples.
 
@@ -453,9 +456,9 @@ const db = drizzle(pool);
 const backend = createPostgresBackend(db);
 ```
 
-pgvector stores embeddings in per-field typed `vector(N)` tables (created lazily on first write — the migration
-creates no embedding table) with HNSW or IVFFlat indexes, and supports the `cosine`, `l2`, and `inner_product`
-metrics.
+pgvector stores embeddings in per-field typed `vector(N)` tables (provisioned by `createStoreWithSchema` at boot
+— the generated migration SQL creates no embedding table) with HNSW or IVFFlat indexes, and supports the
+`cosine`, `l2`, and `inner_product` metrics.
 
 See [Semantic Search](/semantic-search) for query examples.
 
@@ -889,19 +892,25 @@ least-privilege, DML-only database role.
 
 - **`createStoreWithSchema(graph, backend)` runs DDL.** It bootstraps the
   base tables on a fresh database, applies safe auto-migrations, and
-  durably materializes strategy-owned runtime storage (e.g. fulltext). It
-  re-issues idempotent DDL on every cold boot — at minimum a
-  `CREATE TABLE IF NOT EXISTS` for the contribution-marker table — so the
-  role it runs under **must hold `CREATE` / DDL privileges**. Run it once
-  at startup, outside request handlers and transactions.
+  durably materializes strategy-owned runtime storage — both fulltext and
+  each `embedding()` field's per-`(kind, field)` vector table, plus a
+  durable marker for each. It re-issues idempotent DDL on every cold boot
+  — at minimum a `CREATE TABLE IF NOT EXISTS` for the contribution-marker
+  table — so the role it runs under **must hold `CREATE` / DDL
+  privileges**. Run it once at startup, outside request handlers and
+  transactions. (`store.evolve()` likewise provisions any embedding field
+  it introduces, so it too needs DDL privileges.)
 
 - **`createStore(graph, backend)` is a synchronous, zero-I/O attach.**
   It does not create tables, repair DDL, or record that runtime storage
   is materialized — it issues **no DDL ever**. Use it only to attach to a
   database a prior `createStoreWithSchema` boot already initialized. A
-  fulltext read or write against a database that was never initialized
-  throws `StoreNotInitializedError` rather than silently emitting DDL on
-  the hot path. Graphs with no `searchable()` fields are unaffected.
+  fulltext or **embedding** read/write against a database that was never
+  initialized — a `create({ embedding })` write or a `store.search.vector`
+  / `.similarTo()` query — throws `StoreNotInitializedError` rather than
+  silently emitting `CREATE TABLE` on the hot path. This is what lets a
+  least-privilege role run vector ops: the table already exists. Graphs
+  with no `searchable()` or `embedding()` fields are unaffected.
 
 - **`createVerifiedStore(graph, backend)` is the same zero-DDL attach
   with a verification gate.** It reads the active schema row, folds the

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -905,12 +905,19 @@ least-privilege, DML-only database role.
   It does not create tables, repair DDL, or record that runtime storage
   is materialized — it issues **no DDL ever**. Use it only to attach to a
   database a prior `createStoreWithSchema` boot already initialized. A
-  fulltext or **embedding** read/write against a database that was never
-  initialized — a `create({ embedding })` write or a `store.search.vector`
-  / `.similarTo()` query — throws `StoreNotInitializedError` rather than
-  silently emitting `CREATE TABLE` on the hot path. This is what lets a
-  least-privilege role run vector ops: the table already exists. Graphs
-  with no `searchable()` or `embedding()` fields are unaffected.
+  fulltext operation or an **embedding write** against a database that was
+  never initialized — a `create({ embedding })` or embedding update/delete
+  — throws `StoreNotInitializedError` rather than silently emitting
+  `CREATE TABLE` on the hot path. (Vector *reads* are not marker-gated:
+  `store.search.vector`, `store.search.hybrid`, and a query-builder
+  `.similarTo()` predicate compile to SQL against the per-field table
+  directly, so on an un-provisioned database they surface the engine's own
+  missing-relation error instead — `no such table: tg_vec_…` on SQLite,
+  `relation … does not exist` on Postgres. Same cause, same fix; use
+  `createVerifiedStore` to catch it at attach rather than at first query.)
+  This is what lets a least-privilege role run vector ops: the table
+  already exists. Graphs with no `searchable()` or `embedding()` fields
+  are unaffected.
 
 - **`createVerifiedStore(graph, backend)` is the same zero-DDL attach
   with a verification gate.** It reads the active schema row, folds the

--- a/apps/docs/src/content/docs/graph-extensions.md
+++ b/apps/docs/src/content/docs/graph-extensions.md
@@ -587,8 +587,12 @@ const Manual = defineNode("Manual", {
 
 Embeddings live in per-`(graphId, nodeKind, fieldPath)` typed tables
 named `tg_vec_<graphId>_<kind>_<field>` (each carrying the field's
-fixed dimension), created lazily on first write — there is no single
-shared embeddings table.
+fixed dimension) — there is no single shared embeddings table. The
+privileged migrator provisions each table plus a durable marker: at boot
+via `createStoreWithSchema`, and for a field a runtime `evolve()`
+introduces, by that `evolve()` call. The runtime hot path then asserts
+the marker (never DDL), so a least-privilege role can read/write
+embeddings.
 
 On `materializeIndexes()`:
 

--- a/apps/docs/src/content/docs/schema-evolution.md
+++ b/apps/docs/src/content/docs/schema-evolution.md
@@ -528,11 +528,13 @@ if (result.status === "migrated" && result.toVersion === 3) {
 
 ## Reclaiming Removed Embedding Storage
 
-Embeddings live in per-`(graphId, kind, field)` tables (`tg_vec_*`), created
-lazily on first write. When you remove an `embedding()` field from a **surviving**
+Embeddings live in per-`(graphId, kind, field)` tables (`tg_vec_*`), provisioned
+by the privileged migrator (`createStoreWithSchema`, or `evolve()` for a
+runtime-added field). When you remove an `embedding()` field from a **surviving**
 kind, the schema change commits fast but the field's now-orphaned vector table
-remains until you reconcile it. `store.materializeRemovals()` drops it (this is
-the same pass that cleans up storage for fully removed kinds):
+remains until you reconcile it. `store.materializeRemovals()` drops it — and
+clears its durable contribution marker so a later re-add re-provisions cleanly
+(this is the same pass that cleans up storage for fully removed kinds):
 
 ```typescript
 const result = await store.materializeRemovals();

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -272,9 +272,11 @@ const result = await ensureSchema(backend, graph, {
 ## Migrating Legacy Embedding Storage
 
 Embeddings now live in per-`(graphId, kind, field)` typed tables
-(`tg_vec_<graphId>_<kind>_<field>`), created lazily on first write. This
-replaces the single shared `typegraph_node_embeddings` table. New deployments
-need no action — the per-field tables materialize as you write vectors.
+(`tg_vec_<graphId>_<kind>_<field>`), provisioned by `createStoreWithSchema` (the
+privileged migrator) at boot. This replaces the single shared
+`typegraph_node_embeddings` table. New deployments need no action — the per-field
+tables are materialized by `createStoreWithSchema`, which the legacy migration
+below also relies on having run.
 
 Deployments that already hold rows in the legacy table run a one-time, idempotent
 cutover with `migrateLegacyEmbeddings()`, exported from the package root:

--- a/apps/docs/src/content/docs/semantic-search.md
+++ b/apps/docs/src/content/docs/semantic-search.md
@@ -149,8 +149,8 @@ import { generatePostgresMigrationSQL } from "@nicia-ai/typegraph/postgres";
 
 // Generates DDL including `CREATE EXTENSION IF NOT EXISTS vector;`.
 // It does NOT create a single embeddings table — each embedding field gets
-// its own typed `vector(N)` table, created lazily on first write (see
-// Storage Layout below).
+// its own typed `vector(N)` table, provisioned by `createStoreWithSchema`
+// (the privileged migrator) at boot (see Storage Layout below).
 const migrationSQL = generatePostgresMigrationSQL();
 ```
 
@@ -235,12 +235,17 @@ do not share this bound.
 
 Each embedding field is stored in its own typed, graph-scoped table named
 `tg_vec_<graphId>_<kind>_<field>`, carrying that field's fixed dimension
-(pgvector `vector(N)`, libSQL `F32_BLOB(N)`, sqlite-vec `vec0`). Tables are
-created lazily on the first write, so no migration step provisions them.
-Graph-scoping means several graphs in one database can declare the same
-`kind`+`field` at different dimensions without collision. This is transparent
-to queries — `.similarTo()`, `store.search.vector`, and `store.search.hybrid`
-read it for you.
+(pgvector `vector(N)`, libSQL `F32_BLOB(N)`, sqlite-vec `vec0`). The privileged
+migrator (`createStoreWithSchema`, and `evolve()` for runtime-added fields)
+provisions each table plus a durable contribution marker at boot; the runtime
+hot path then asserts the marker (a cached SELECT) and never issues DDL, so a
+least-privilege, DML-only role can read and write embeddings. A vector op
+against an un-provisioned slot throws `StoreNotInitializedError` rather than
+lazily creating the table — see [Database roles & least
+privilege](/backend-setup#database-roles--least-privilege). Graph-scoping means
+several graphs in one database can declare the same `kind`+`field` at different
+dimensions without collision. This is transparent to queries — `.similarTo()`,
+`store.search.vector`, and `store.search.hybrid` read it for you.
 
 ### Deleted nodes never rank
 

--- a/apps/docs/src/content/docs/semantic-search.md
+++ b/apps/docs/src/content/docs/semantic-search.md
@@ -239,9 +239,12 @@ Each embedding field is stored in its own typed, graph-scoped table named
 migrator (`createStoreWithSchema`, and `evolve()` for runtime-added fields)
 provisions each table plus a durable contribution marker at boot; the runtime
 hot path then asserts the marker (a cached SELECT) and never issues DDL, so a
-least-privilege, DML-only role can read and write embeddings. A vector op
-against an un-provisioned slot throws `StoreNotInitializedError` rather than
-lazily creating the table — see [Database roles & least
+least-privilege, DML-only role can read and write embeddings. An embedding
+write against an un-provisioned slot throws `StoreNotInitializedError` rather
+than lazily creating the table; vector reads (`store.search.vector`,
+`store.search.hybrid`, and query-builder `.similarTo()` predicates) compile
+straight to SQL, so they surface the engine's missing-relation error instead —
+use `createVerifiedStore` to catch both at attach. See [Database roles & least
 privilege](/backend-setup#database-roles--least-privilege). Graph-scoping means
 several graphs in one database can declare the same `kind`+`field` at different
 dimensions without collision. This is transparent to queries — `.similarTo()`,
@@ -277,6 +280,15 @@ await store.reembedVectorField("Document", "embedding", {
 });
 // → { recreated: true, reembedded: <count> }
 ```
+
+Between the declaration change and the `reembedVectorField()` call, the slot
+is in a deliberate limbo: boot (`createStoreWithSchema` / `evolve()`) detects
+that the provisioned storage no longer matches the declared shape, warns, and
+leaves it untouched — it never recreates the table implicitly, because that
+would silently drop every stored vector. Embedding writes to the field fail
+with a `StoreNotInitializedError` whose reason is `stale` (its message points
+here) until `reembedVectorField()` recreates the storage and re-stamps its
+durable marker.
 
 Without an `embed` callback the storage is recreated empty and you re-embed via
 normal `update()` writes.

--- a/apps/docs/src/content/docs/troubleshooting.md
+++ b/apps/docs/src/content/docs/troubleshooting.md
@@ -369,8 +369,12 @@ markers. See
 that never materializes runtime storage) against a database that no
 `createStoreWithSchema()` boot has initialized — commonly the runtime
 started before the privileged migration step ran, or the wrong role/
-database is configured. `createVerifiedStore()` catches this case at
-boot rather than at first hot-path operation.
+database is configured. This covers both fulltext and **embedding**
+operations: a `store.nodes.*.create({ embedding })` write or a
+`store.search.vector` / `.similarTo()` query against an un-provisioned
+per-`(kind, field)` table throws here rather than lazily issuing
+`CREATE TABLE` on the hot path. `createVerifiedStore()` catches this
+case at boot rather than at the first hot-path operation.
 
 **Solution:** Run `createStoreWithSchema(graph, adminBackend)` once
 under the privileged role before the runtime attaches (it writes the

--- a/apps/docs/src/content/docs/troubleshooting.md
+++ b/apps/docs/src/content/docs/troubleshooting.md
@@ -369,12 +369,24 @@ markers. See
 that never materializes runtime storage) against a database that no
 `createStoreWithSchema()` boot has initialized — commonly the runtime
 started before the privileged migration step ran, or the wrong role/
-database is configured. This covers both fulltext and **embedding**
-operations: a `store.nodes.*.create({ embedding })` write or a
-`store.search.vector` / `.similarTo()` query against an un-provisioned
-per-`(kind, field)` table throws here rather than lazily issuing
-`CREATE TABLE` on the hot path. `createVerifiedStore()` catches this
-case at boot rather than at the first hot-path operation.
+database is configured. This covers fulltext operations and **embedding
+writes**: a `store.nodes.*.create({ embedding })` (or embedding
+update/delete) against an un-provisioned per-`(kind, field)` table throws
+here rather than lazily issuing `CREATE TABLE` on the hot path. Vector
+*reads* — `store.search.vector`, `store.search.hybrid`, and a
+query-builder `.similarTo()` predicate — compile straight to SQL against
+the per-field table, so they surface the engine's own missing-relation
+error instead (`no such table: tg_vec_…` on SQLite, `relation … does not
+exist` on Postgres) — same cause, same solution.
+`createVerifiedStore()` catches every one of these cases at boot rather
+than at the first hot-path operation.
+
+A **`stale`** variant of this error on a vector field means something
+different: the storage exists but was provisioned at a different shape —
+typically the field's declared dimension changed after the table was
+created. Boot deliberately leaves such a slot untouched (with a console
+warning); run `store.reembedVectorField(kind, fieldPath)` to recreate the
+storage at the new shape and re-embed.
 
 **Solution:** Run `createStoreWithSchema(graph, adminBackend)` once
 under the privileged role before the runtime attaches (it writes the

--- a/packages/benchmarks/src/backend.ts
+++ b/packages/benchmarks/src/backend.ts
@@ -6,7 +6,11 @@ import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
 import { drizzle as drizzlePostgresJs } from "drizzle-orm/postgres-js";
 import { Pool } from "pg";
 import postgres, { type Sql } from "postgres";
-import { createStore, type GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStore,
+  type GraphBackend,
+  resolveGraphVectorSlots,
+} from "@nicia-ai/typegraph";
 import {
   createPostgresBackend,
   createPostgresTables,
@@ -43,9 +47,12 @@ type BackendResources = Readonly<{
   hasHybridFacade: boolean;
 }>;
 
-// Embeddings live in per-`(graphId, kind, field)` tables (`tg_vec_*`), created
-// lazily on first write, so a clean reset drops whatever this graph
-// materialized in a prior run — there is no single shared embeddings table.
+// Embeddings live in per-`(graphId, kind, field)` tables (`tg_vec_*`),
+// provisioned by the privileged boot step, so a clean reset drops whatever
+// this graph materialized in a prior run — there is no single shared
+// embeddings table. The durable contribution markers are dropped in lockstep:
+// a marker that outlived its dropped `tg_vec_*` table would make the next
+// provisioning pass trust it and skip the CREATE.
 const POSTGRES_RESET_DDL = `
   DO $$
   DECLARE tbl text;
@@ -63,7 +70,24 @@ const POSTGRES_RESET_DDL = `
   DROP TABLE IF EXISTS typegraph_schema_versions CASCADE;
   DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;
   DROP TABLE IF EXISTS typegraph_index_materializations CASCADE;
+  DROP TABLE IF EXISTS typegraph_contribution_materializations CASCADE;
 `;
+
+/**
+ * The vector counterpart of `ensureRuntimeContributions`: provision every
+ * embedding `(kind, field)` slot's per-field table + durable marker — the
+ * boot step `createStoreWithSchema` performs, done manually here because the
+ * harness deliberately uses the sync `createStore` attach. A no-op per slot
+ * on backends without vector support (`ensureVectorSlotContribution` absent,
+ * e.g. SQLite without sqlite-vec).
+ */
+async function materializePerfVectorSlots(
+  backend: GraphBackend,
+): Promise<void> {
+  for (const slot of resolveGraphVectorSlots(perfGraph)) {
+    await backend.ensureVectorSlotContribution?.(slot);
+  }
+}
 
 async function resetPostgresTablesViaPool(pool: Pool): Promise<void> {
   await pool.query(POSTGRES_RESET_DDL);
@@ -100,6 +124,7 @@ export async function createBackendResources(
     // createStore, so it writes the durable fulltext-materialization
     // marker itself — the boot step createStoreWithSchema performs.
     await sqliteBackend.ensureRuntimeContributions?.(perfGraph.id);
+    await materializePerfVectorSlots(sqliteBackend);
     return {
       store: createStore(perfGraph, sqliteBackend, {
         queryDefaults: { traversalExpansion: "none" },
@@ -138,6 +163,7 @@ export async function createBackendResources(
     const tables = createPostgresTables({}, { indexes: perfIndexes });
     const postgresBackend = createPostgresBackend(drizzleDb, { tables });
     await postgresBackend.ensureRuntimeContributions?.(perfGraph.id);
+    await materializePerfVectorSlots(postgresBackend);
     return {
       store: createStore(perfGraph, postgresBackend, {
         queryDefaults: { traversalExpansion: "none" },
@@ -180,6 +206,7 @@ export async function createBackendResources(
   const tables = createPostgresTables({}, { indexes: perfIndexes });
   const postgresBackend = createPostgresBackend(drizzleDb, { tables });
   await postgresBackend.ensureRuntimeContributions?.(perfGraph.id);
+  await materializePerfVectorSlots(postgresBackend);
   return {
     store: createStore(perfGraph, postgresBackend, {
       queryDefaults: { traversalExpansion: "none" },

--- a/packages/typegraph/examples/11-semantic-search.ts
+++ b/packages/typegraph/examples/11-semantic-search.ts
@@ -18,7 +18,7 @@
  *   npx tsx examples/11-semantic-search.ts
  */
 import {
-  createStore,
+  createStoreWithSchema,
   defineGraph,
   defineNode,
   embedding,
@@ -114,9 +114,10 @@ export async function main() {
   console.log("\n=== Part 2: Storing Documents with Embeddings ===\n");
 
   const backend = createExampleBackend();
-  // Sync createStore is fine here: no searchable() fields means no fulltext
-  // storage to materialize (contrast with createStoreWithSchema in example 15).
-  const store = createStore(graph, backend);
+  // createStoreWithSchema provisions each embedding field's per-(kind, field)
+  // vector table + durable marker under the (privileged) migrator role, so
+  // runtime embedding writes/searches never issue DDL. Run it once at boot.
+  const [store] = await createStoreWithSchema(graph, backend);
 
   try {
     // Sample documents to index

--- a/packages/typegraph/examples/12-knowledge-graph-rag.ts
+++ b/packages/typegraph/examples/12-knowledge-graph-rag.ts
@@ -11,7 +11,7 @@
  *   npx tsx examples/12-knowledge-graph-rag.ts
  */
 import {
-  createStore,
+  createStoreWithSchema,
   defineEdge,
   defineGraph,
   defineNode,
@@ -94,7 +94,10 @@ export async function main() {
   console.log("=== Knowledge Graph for RAG ===\n");
 
   const backend = createExampleBackend();
-  const store = createStore(graph, backend);
+  // createStoreWithSchema provisions each embedding field's per-(kind, field)
+  // vector table + durable marker under the (privileged) migrator role, so
+  // runtime embedding writes/searches never issue DDL. Run it once at boot.
+  const [store] = await createStoreWithSchema(graph, backend);
 
   try {
     // ----------------------------------------------------------

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -397,11 +397,15 @@ export type ContributionMaterializer = Readonly<{
    * its durable marker, idempotently. Pass `{ force: true }` to bypass
    * the drift-guard and overwrite the marker at the current signature —
    * the sanctioned path for `reembedVectorField`'s deliberate
-   * dimension change. No-op when vector support is disabled.
+   * dimension change. Pass `{ onDrift: "skip" }` to leave a drifted slot
+   * untouched (warn, no marker write, no throw) instead of refusing —
+   * the boot/evolve path, where the declared shape may have moved ahead
+   * of a `reembedVectorField` the operator has not run yet. No-op when
+   * vector support is disabled.
    */
   ensureVectorSlot: (
     slot: VectorSlot,
-    options?: Readonly<{ force?: boolean }>,
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
   ) => Promise<void>;
   /**
    * Hot-path gate for one vector slot: SELECT-only marker assert over
@@ -443,14 +447,17 @@ export function createContributionMaterializer(
   const { dialect, fulltextStrategy, fulltextTableName } = deps;
 
   // Positive-only cache keyed per contribution identity
-  // (`graphId | owner | logicalName | tableName`): a key lands here once
-  // its durable marker has been observed materialized at the current
-  // signature on this connection. Per-contribution (not per-graph) so
-  // each per-`(kind, field)` vector slot caches independently and the
-  // hot-path assert stays a pure `Set.has` after the first SELECT.
-  // Missing/stale/failed verdicts are never cached, so a concurrent boot
-  // that fixes the state is picked up on the next call.
-  const initializedKeys = new Set<string>();
+  // (`graphId | owner | logicalName | tableName`), holding the SIGNATURE the
+  // marker was last observed materialized at on this connection. A cache hit
+  // requires the freshly-computed signature to match the cached one, so a
+  // changed shape (dimension, metric, storage DDL) on the same instance
+  // misses the cache and falls through to the drift-guard / stale verdict —
+  // the warm cache can never bless a contribution whose shape moved.
+  // Per-contribution (not per-graph) so each per-`(kind, field)` vector slot
+  // caches independently and the hot-path assert stays a pure `Map.get`
+  // after the first SELECT. Missing/stale/failed verdicts are never cached,
+  // so a concurrent boot that fixes the state is picked up on the next call.
+  const initializedSignatures = new Map<string, string>();
 
   function runtimeContributions(): readonly StrategyTableContribution[] {
     return runtimeStrategyContributions(fulltextStrategy, fulltextTableName);
@@ -459,14 +466,10 @@ export function createContributionMaterializer(
   async function materializeOne(
     graphId: string,
     contribution: StrategyTableContribution,
-    options?: Readonly<{ force?: boolean }>,
-  ): Promise<void> {
+    signature: string,
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
+  ): Promise<"materialized" | "drift-skipped"> {
     const force = options?.force === true;
-    const signature = await computeContributionSignature(
-      dialect,
-      contribution,
-      contribution.createDdl,
-    );
     const identity = identityOf(graphId, contribution);
     const existing = await deps.getMarker(identity);
 
@@ -477,7 +480,7 @@ export function createContributionMaterializer(
       !force &&
       evaluateContributionState(existing, signature) === "initialized"
     ) {
-      return;
+      return "materialized";
     }
     const priorSuccess = existing?.materializedAt !== undefined;
 
@@ -490,6 +493,20 @@ export function createContributionMaterializer(
     // `force` deliberately bypasses this — the caller has already dropped
     // and recreated the table at the new shape (`reembedVectorField`).
     if (!force && priorSuccess && existing.signature !== signature) {
+      // `onDrift: "skip"` (boot/evolve): leave the slot exactly as it is —
+      // marker untouched (so old-shape reads keep their verdict), nothing
+      // cached, no throw. Writes to the new shape fail as `stale` until
+      // `store.reembedVectorField` recreates storage and force-restamps.
+      if (options?.onDrift === "skip") {
+        console.warn(
+          `[typegraph] contribution "${contribution.logicalName}" (table ` +
+            `"${contribution.tableName}") is provisioned at a different ` +
+            `shape than the current declaration — left untouched. Writes ` +
+            `to it will fail until store.reembedVectorField(kind, ` +
+            `fieldPath) recreates the storage at the new shape.`,
+        );
+        return "drift-skipped";
+      }
       const error = new Error(
         `Contribution "${contribution.logicalName}" (owner ` +
           `"${contribution.owner}", table "${contribution.tableName}") was ` +
@@ -530,6 +547,7 @@ export function createContributionMaterializer(
       materializedAt: attemptedAt,
       error: undefined,
     });
+    return "materialized";
   }
 
   /**
@@ -545,15 +563,11 @@ export function createContributionMaterializer(
   async function readContributionState(
     graphId: string,
     contribution: StrategyTableContribution,
+    signature: string,
   ): Promise<
     | Readonly<{ kind: "state"; state: ContributionMaterializationState }>
     | Readonly<{ kind: "missing-table"; error: unknown }>
   > {
-    const signature = await computeContributionSignature(
-      dialect,
-      contribution,
-      contribution.createDdl,
-    );
     const identity = identityOf(graphId, contribution);
     try {
       const existing = await deps.getMarker(identity);
@@ -569,7 +583,8 @@ export function createContributionMaterializer(
 
   /**
    * Privileged materialize over an arbitrary contribution set. Per
-   * contribution: skip if cached; else (unless `force`) a read-only
+   * contribution: skip if cached at the current signature; else (unless
+   * `force`) a read-only
    * pre-check short-circuits the whole pending set when every marker is
    * already initialized at its current signature, so a warm graph stays
    * DDL-free — the marker `CREATE TABLE IF NOT EXISTS` itself would fail
@@ -581,39 +596,65 @@ export function createContributionMaterializer(
   async function ensureContributions(
     graphId: string,
     contributions: readonly StrategyTableContribution[],
-    options?: Readonly<{ force?: boolean }>,
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
   ): Promise<void> {
     const force = options?.force === true;
+    const entries = await Promise.all(
+      contributions.map(async (contribution) => ({
+        contribution,
+        key: contributionKey(graphId, contribution),
+        signature: await computeContributionSignature(
+          dialect,
+          contribution,
+          contribution.createDdl,
+        ),
+      })),
+    );
+    // A cache hit requires the signature to match — a contribution whose
+    // shape changed on this instance falls through to the drift-guard.
     const pending =
-      force ?
-        contributions
-      : contributions.filter(
-          (contribution) =>
-            !initializedKeys.has(contributionKey(graphId, contribution)),
-        );
+      force ? entries : (
+        entries.filter(
+          (entry) => initializedSignatures.get(entry.key) !== entry.signature,
+        )
+      );
     if (pending.length === 0) return;
 
     if (!force) {
       let allInitialized = true;
-      for (const contribution of pending) {
-        const read = await readContributionState(graphId, contribution);
+      for (const entry of pending) {
+        const read = await readContributionState(
+          graphId,
+          entry.contribution,
+          entry.signature,
+        );
         if (read.kind !== "state" || read.state !== "initialized") {
           allInitialized = false;
           break;
         }
       }
       if (allInitialized) {
-        for (const contribution of pending) {
-          initializedKeys.add(contributionKey(graphId, contribution));
+        for (const entry of pending) {
+          initializedSignatures.set(entry.key, entry.signature);
         }
         return;
       }
     }
 
     await deps.ensureMarkerTable();
-    for (const contribution of pending) {
-      await materializeOne(graphId, contribution, { force });
-      initializedKeys.add(contributionKey(graphId, contribution));
+    for (const entry of pending) {
+      const outcome = await materializeOne(
+        graphId,
+        entry.contribution,
+        entry.signature,
+        { force, ...(options?.onDrift === undefined ? {} : { onDrift: options.onDrift }) },
+      );
+      // A drift-skipped contribution is deliberately NOT cached: nothing
+      // was materialized at this signature, and asserts must keep reading
+      // it as stale until reembedVectorField restamps it.
+      if (outcome === "materialized") {
+        initializedSignatures.set(entry.key, entry.signature);
+      }
     }
   }
 
@@ -621,8 +662,9 @@ export function createContributionMaterializer(
    * SELECT-only gate over an arbitrary contribution set: throws
    * `StoreNotInitializedError` on the first missing/stale/failed
    * contribution (or a never-bootstrapped marker table). Caches each
-   * confirmed-initialized contribution so the steady state is a pure
-   * `Set.has`. Never runs DDL or writes.
+   * confirmed-initialized contribution BY SIGNATURE so the steady state is
+   * a pure `Map.get` — and a shape change on the same instance misses the
+   * cache and surfaces as `stale`. Never runs DDL or writes.
    */
   async function assertContributions(
     graphId: string,
@@ -630,8 +672,15 @@ export function createContributionMaterializer(
   ): Promise<void> {
     for (const contribution of contributions) {
       const key = contributionKey(graphId, contribution);
-      if (initializedKeys.has(key)) continue;
-      const read = await readContributionState(graphId, contribution);
+      const signature = await computeContributionSignature(
+        dialect,
+        contribution,
+        contribution.createDdl,
+      );
+      // Signature-checked cache hit: a shape change on this instance misses
+      // and reaches the stale verdict below instead of being blessed.
+      if (initializedSignatures.get(key) === signature) continue;
+      const read = await readContributionState(graphId, contribution, signature);
       // A never-bootstrapped database has no marker table — that is
       // precisely "not initialized". `readContributionState` has already
       // rethrown any non-missing-table fault (connection, permission,
@@ -648,7 +697,7 @@ export function createContributionMaterializer(
           details: { logicalName: contribution.logicalName },
         });
       }
-      initializedKeys.add(key);
+      initializedSignatures.set(key, signature);
     }
   }
 
@@ -662,7 +711,7 @@ export function createContributionMaterializer(
 
   async function ensureVectorSlot(
     slot: VectorSlot,
-    options?: Readonly<{ force?: boolean }>,
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
   ): Promise<void> {
     if (deps.vectorStrategy === undefined) return;
     await ensureContributions(
@@ -684,7 +733,7 @@ export function createContributionMaterializer(
     if (deps.vectorStrategy === undefined) return;
     for (const contribution of deps.vectorStrategy.ownedTables(slot)) {
       await deps.deleteMarker(identityOf(slot.graphId, contribution));
-      initializedKeys.delete(contributionKey(slot.graphId, contribution));
+      initializedSignatures.delete(contributionKey(slot.graphId, contribution));
     }
   }
 

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -22,6 +22,10 @@ import {
 } from "../../errors";
 import { type FulltextStrategy } from "../../query/dialect/fulltext-strategy";
 import { type SqlDialect } from "../../query/dialect/types";
+import {
+  type VectorSlot,
+  type VectorStrategy,
+} from "../../query/dialect/vector-strategy";
 import { sortedReplacer } from "../../schema/canonical";
 import { sha256Hex } from "../../utils/hash";
 import { isMissingTableError } from "../../utils/sql-errors";
@@ -349,6 +353,14 @@ export type ContributionMaterializerDeps = Readonly<{
   dialect: SqlDialect;
   fulltextStrategy: FulltextStrategy;
   fulltextTableName: string;
+  /**
+   * Active vector strategy, or `undefined` when vector support is
+   * disabled. When present, its per-`(kind, field)` `ownedTables(slot)`
+   * contributions ride this same durable-marker machinery — boot
+   * materializes them under the privileged role, the runtime hot path
+   * asserts them with a SELECT (never DDL), exactly like fulltext.
+   */
+  vectorStrategy: VectorStrategy | undefined;
   /** Run one raw DDL statement (dialect's `execute`/`run` of `sql.raw`). */
   execDdl: (statement: string) => Promise<void>;
   /** Idempotently create the `contribution_materializations` table. */
@@ -358,6 +370,15 @@ export type ContributionMaterializerDeps = Readonly<{
   ) => Promise<ContributionMaterializationRow | undefined>;
   recordMarker: (
     params: RecordContributionMaterializationParams,
+  ) => Promise<void>;
+  /**
+   * Delete a marker row by identity. Used when a contribution's physical
+   * table is torn down out-of-band (vector-field reclaim) so a later
+   * re-provision sees "missing" and re-creates the table rather than
+   * trusting an orphaned "initialized" marker.
+   */
+  deleteMarker: (
+    identity: ContributionMaterializationIdentity,
   ) => Promise<void>;
 }>;
 
@@ -370,18 +391,66 @@ export type ContributionMaterializer = Readonly<{
    * the first missing/stale/failed contribution. Zero DDL, zero writes.
    */
   assertInitialized: (graphId: string) => Promise<void>;
+  /**
+   * Privileged materializer for one vector slot's `ownedTables`
+   * contribution(s): creates the per-`(kind, field)` table and records
+   * its durable marker, idempotently. Pass `{ force: true }` to bypass
+   * the drift-guard and overwrite the marker at the current signature —
+   * the sanctioned path for `reembedVectorField`'s deliberate
+   * dimension change. No-op when vector support is disabled.
+   */
+  ensureVectorSlot: (
+    slot: VectorSlot,
+    options?: Readonly<{ force?: boolean }>,
+  ) => Promise<void>;
+  /**
+   * Hot-path gate for one vector slot: SELECT-only marker assert over
+   * the slot's `ownedTables` contribution(s), cached per backend
+   * instance. Throws `StoreNotInitializedError` when the slot is
+   * missing/stale/failed. No-op when vector support is disabled.
+   */
+  assertVectorSlot: (slot: VectorSlot) => Promise<void>;
+  /**
+   * Forget a vector slot: delete its `ownedTables` contribution
+   * marker(s) and evict the per-instance cache. Called after the slot's
+   * physical table is dropped (vector-field reclaim) so a future
+   * `ensureVectorSlot` re-creates the table instead of trusting an
+   * orphaned marker. No-op when vector support is disabled.
+   */
+  dropVectorSlot: (slot: VectorSlot) => Promise<void>;
 }>;
+
+// NUL separator for the per-instance contribution cache key: collision-safe
+// across arbitrary graph ids / names (a printable delimiter could appear in a
+// caller-supplied graph id).
+const CONTRIBUTION_KEY_SEPARATOR = String.fromCodePoint(0);
+
+function contributionKey(
+  graphId: string,
+  contribution: StrategyTableContribution,
+): string {
+  return [
+    graphId,
+    contribution.owner,
+    contribution.logicalName,
+    contribution.tableName,
+  ].join(CONTRIBUTION_KEY_SEPARATOR);
+}
 
 export function createContributionMaterializer(
   deps: ContributionMaterializerDeps,
 ): ContributionMaterializer {
   const { dialect, fulltextStrategy, fulltextTableName } = deps;
 
-  // Positive-only cache: a graph id lands here once every runtime
-  // contribution's durable marker has been observed materialized for
-  // it. Missing/stale/failed verdicts are never cached, so a concurrent
-  // boot that fixes the state is picked up on the next call.
-  const initializedGraphIds = new Set<string>();
+  // Positive-only cache keyed per contribution identity
+  // (`graphId | owner | logicalName | tableName`): a key lands here once
+  // its durable marker has been observed materialized at the current
+  // signature on this connection. Per-contribution (not per-graph) so
+  // each per-`(kind, field)` vector slot caches independently and the
+  // hot-path assert stays a pure `Set.has` after the first SELECT.
+  // Missing/stale/failed verdicts are never cached, so a concurrent boot
+  // that fixes the state is picked up on the next call.
+  const initializedKeys = new Set<string>();
 
   function runtimeContributions(): readonly StrategyTableContribution[] {
     return runtimeStrategyContributions(fulltextStrategy, fulltextTableName);
@@ -390,7 +459,9 @@ export function createContributionMaterializer(
   async function materializeOne(
     graphId: string,
     contribution: StrategyTableContribution,
+    options?: Readonly<{ force?: boolean }>,
   ): Promise<void> {
+    const force = options?.force === true;
     const signature = await computeContributionSignature(
       dialect,
       contribution,
@@ -399,8 +470,13 @@ export function createContributionMaterializer(
     const identity = identityOf(graphId, contribution);
     const existing = await deps.getMarker(identity);
 
-    // Already materialized at this exact shape — nothing to do.
-    if (evaluateContributionState(existing, signature) === "initialized") {
+    // Already materialized at this exact shape — nothing to do. `force`
+    // re-runs the DDL and re-stamps the marker even on a match: the path
+    // `reembedVectorField` relies on after it has recreated the table.
+    if (
+      !force &&
+      evaluateContributionState(existing, signature) === "initialized"
+    ) {
       return;
     }
     const priorSuccess = existing?.materializedAt !== undefined;
@@ -411,7 +487,9 @@ export function createContributionMaterializer(
     // table. Refuse loudly instead — mirrors the index materializer's
     // signature-drift handling. (A row with no prior success, or one
     // whose last attempt errored, falls through and re-runs the DDL.)
-    if (priorSuccess && existing.signature !== signature) {
+    // `force` deliberately bypasses this — the caller has already dropped
+    // and recreated the table at the new shape (`reembedVectorField`).
+    if (!force && priorSuccess && existing.signature !== signature) {
       const error = new Error(
         `Contribution "${contribution.logicalName}" (owner ` +
           `"${contribution.owner}", table "${contribution.tableName}") was ` +
@@ -490,53 +568,69 @@ export function createContributionMaterializer(
   }
 
   /**
-   * SELECT-only verdict over every runtime contribution: `true` only when
-   * each one is already materialized at its current signature. Short-
-   * circuits on the first non-initialized read — a missing marker table
-   * or any missing/stale/failed contribution. Never runs DDL.
+   * Privileged materialize over an arbitrary contribution set. Per
+   * contribution: skip if cached; else (unless `force`) a read-only
+   * pre-check short-circuits the whole pending set when every marker is
+   * already initialized at its current signature, so a warm graph stays
+   * DDL-free — the marker `CREATE TABLE IF NOT EXISTS` itself would fail
+   * on a connection that can't run DDL (#149). Otherwise ensure the
+   * marker table and `materializeOne` each pending contribution. `force`
+   * re-runs the DDL and re-stamps the marker unconditionally (drift-guard
+   * bypassed) — the `reembedVectorField` recreate path.
    */
-  async function allContributionsInitialized(
+  async function ensureContributions(
     graphId: string,
     contributions: readonly StrategyTableContribution[],
-  ): Promise<boolean> {
-    for (const contribution of contributions) {
-      const read = await readContributionState(graphId, contribution);
-      if (read.kind !== "state" || read.state !== "initialized") return false;
-    }
-    return true;
-  }
+    options?: Readonly<{ force?: boolean }>,
+  ): Promise<void> {
+    const force = options?.force === true;
+    const pending =
+      force ?
+        contributions
+      : contributions.filter(
+          (contribution) =>
+            !initializedKeys.has(contributionKey(graphId, contribution)),
+        );
+    if (pending.length === 0) return;
 
-  async function ensureRuntimeContributions(graphId: string): Promise<void> {
-    // Cache guard so a redundant boot call (the warm path materializes
-    // via loadActiveSchemaWithBootstrap, then createStoreWithSchema
-    // calls again) is a true O(1) no-op rather than a re-SELECT.
-    if (initializedGraphIds.has(graphId)) return;
-    const contributions = runtimeContributions();
-
-    // Read-only pre-check mirroring `assertInitialized` (#149): when every
-    // contribution is already materialized at its current signature, this
-    // open needs no DDL — skip `ensureMarkerTable()` / `materializeOne`
-    // entirely. A consumer that builds a fresh backend per request (empty
-    // per-instance cache) therefore stays DDL-free on a warm graph instead
-    // of re-running the marker `CREATE TABLE IF NOT EXISTS` on every open,
-    // which fails on connections that can't run it. A missing marker table
-    // or any missing/stale/failed contribution falls through to the
-    // privileged first-materialization path below, unchanged.
-    if (await allContributionsInitialized(graphId, contributions)) {
-      initializedGraphIds.add(graphId);
-      return;
+    if (!force) {
+      let allInitialized = true;
+      for (const contribution of pending) {
+        const read = await readContributionState(graphId, contribution);
+        if (read.kind !== "state" || read.state !== "initialized") {
+          allInitialized = false;
+          break;
+        }
+      }
+      if (allInitialized) {
+        for (const contribution of pending) {
+          initializedKeys.add(contributionKey(graphId, contribution));
+        }
+        return;
+      }
     }
 
     await deps.ensureMarkerTable();
-    for (const contribution of contributions) {
-      await materializeOne(graphId, contribution);
+    for (const contribution of pending) {
+      await materializeOne(graphId, contribution, { force });
+      initializedKeys.add(contributionKey(graphId, contribution));
     }
-    initializedGraphIds.add(graphId);
   }
 
-  async function assertInitialized(graphId: string): Promise<void> {
-    if (initializedGraphIds.has(graphId)) return;
-    for (const contribution of runtimeContributions()) {
+  /**
+   * SELECT-only gate over an arbitrary contribution set: throws
+   * `StoreNotInitializedError` on the first missing/stale/failed
+   * contribution (or a never-bootstrapped marker table). Caches each
+   * confirmed-initialized contribution so the steady state is a pure
+   * `Set.has`. Never runs DDL or writes.
+   */
+  async function assertContributions(
+    graphId: string,
+    contributions: readonly StrategyTableContribution[],
+  ): Promise<void> {
+    for (const contribution of contributions) {
+      const key = contributionKey(graphId, contribution);
+      if (initializedKeys.has(key)) continue;
       const read = await readContributionState(graphId, contribution);
       // A never-bootstrapped database has no marker table — that is
       // precisely "not initialized". `readContributionState` has already
@@ -554,9 +648,51 @@ export function createContributionMaterializer(
           details: { logicalName: contribution.logicalName },
         });
       }
+      initializedKeys.add(key);
     }
-    initializedGraphIds.add(graphId);
   }
 
-  return { ensureRuntimeContributions, assertInitialized };
+  async function ensureRuntimeContributions(graphId: string): Promise<void> {
+    await ensureContributions(graphId, runtimeContributions());
+  }
+
+  async function assertInitialized(graphId: string): Promise<void> {
+    await assertContributions(graphId, runtimeContributions());
+  }
+
+  async function ensureVectorSlot(
+    slot: VectorSlot,
+    options?: Readonly<{ force?: boolean }>,
+  ): Promise<void> {
+    if (deps.vectorStrategy === undefined) return;
+    await ensureContributions(
+      slot.graphId,
+      deps.vectorStrategy.ownedTables(slot),
+      options,
+    );
+  }
+
+  async function assertVectorSlot(slot: VectorSlot): Promise<void> {
+    if (deps.vectorStrategy === undefined) return;
+    await assertContributions(
+      slot.graphId,
+      deps.vectorStrategy.ownedTables(slot),
+    );
+  }
+
+  async function dropVectorSlot(slot: VectorSlot): Promise<void> {
+    if (deps.vectorStrategy === undefined) return;
+    for (const contribution of deps.vectorStrategy.ownedTables(slot)) {
+      await deps.deleteMarker(identityOf(slot.graphId, contribution));
+      initializedKeys.delete(contributionKey(slot.graphId, contribution));
+    }
+  }
+
+  return {
+    ensureRuntimeContributions,
+    assertInitialized,
+    ensureVectorSlot,
+    assertVectorSlot,
+    dropVectorSlot,
+  };
 }

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -176,7 +176,7 @@ export function buildContributionOnConflictSet(
  * logical slot changes the signature → detectable drift. 32 hex chars
  * because it is compared against an externally-stored signature.
  */
-async function computeContributionSignature(
+function contributionSignatureInput(
   dialect: SqlDialect,
   identity: Readonly<{
     owner: string;
@@ -184,7 +184,7 @@ async function computeContributionSignature(
     tableName: string;
   }>,
   createDdl: readonly string[],
-): Promise<string> {
+): string {
   const hashable = {
     dialect,
     owner: identity.owner,
@@ -192,7 +192,7 @@ async function computeContributionSignature(
     tableName: identity.tableName,
     createDdl,
   };
-  return sha256Hex(JSON.stringify(hashable, sortedReplacer), 16);
+  return JSON.stringify(hashable, sortedReplacer);
 }
 
 /**
@@ -365,9 +365,10 @@ export type ContributionMaterializerDeps = Readonly<{
   execDdl: (statement: string) => Promise<void>;
   /** Idempotently create the `contribution_materializations` table. */
   ensureMarkerTable: () => Promise<void>;
-  getMarker: (
-    identity: ContributionMaterializationIdentity,
-  ) => Promise<ContributionMaterializationRow | undefined>;
+  /** Read every contribution marker for one graph in a single query. */
+  getMarkers: (
+    graphId: string,
+  ) => Promise<readonly ContributionMaterializationRow[]>;
   recordMarker: (
     params: RecordContributionMaterializationParams,
   ) => Promise<void>;
@@ -407,6 +408,11 @@ export type ContributionMaterializer = Readonly<{
     slot: VectorSlot,
     options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
   ) => Promise<void>;
+  /** Batch form used by boot to share marker reads across every vector slot. */
+  ensureVectorSlots: (
+    slots: readonly VectorSlot[],
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
+  ) => Promise<void>;
   /**
    * Hot-path gate for one vector slot: SELECT-only marker assert over
    * the slot's `ownedTables` contribution(s), cached per backend
@@ -414,6 +420,8 @@ export type ContributionMaterializer = Readonly<{
    * missing/stale/failed. No-op when vector support is disabled.
    */
   assertVectorSlot: (slot: VectorSlot) => Promise<void>;
+  /** Batch form used by verified attach to perform one marker read. */
+  assertVectorSlots: (slots: readonly VectorSlot[]) => Promise<void>;
   /**
    * Forget a vector slot: delete its `ownedTables` contribution
    * marker(s) and evict the per-instance cache. Called after the slot's
@@ -431,7 +439,11 @@ const CONTRIBUTION_KEY_SEPARATOR = String.fromCodePoint(0);
 
 function contributionKey(
   graphId: string,
-  contribution: StrategyTableContribution,
+  contribution: Readonly<{
+    owner: string;
+    logicalName: string;
+    tableName: string;
+  }>,
 ): string {
   return [
     graphId,
@@ -454,10 +466,59 @@ export function createContributionMaterializer(
   // misses the cache and falls through to the drift-guard / stale verdict —
   // the warm cache can never bless a contribution whose shape moved.
   // Per-contribution (not per-graph) so each per-`(kind, field)` vector slot
-  // caches independently and the hot-path assert stays a pure `Map.get`
-  // after the first SELECT. Missing/stale/failed verdicts are never cached,
-  // so a concurrent boot that fixes the state is picked up on the next call.
+  // caches independently and the hot-path assert stays a small DDL-string
+  // comparison plus `Map.get` after the first SELECT. Missing/stale/failed
+  // verdicts are never cached, so a concurrent boot that fixes the state is
+  // picked up on the next call.
   const initializedSignatures = new Map<string, string>();
+  // Computing the durable signature requires WebCrypto. Keep the canonical
+  // DDL beside its digest so the hot path only compares the current DDL
+  // strings. A same-instance shape change produces a mismatch and therefore
+  // a fresh canonical input + digest; unchanged contributions reuse the
+  // settled promise without serialization or new crypto work. The cache key
+  // already covers every non-DDL signature field (owner/logical/table), while
+  // dialect is fixed for the lifetime of this materializer.
+  const computedSignatures = new Map<
+    string,
+    Readonly<{ createDdl: readonly string[]; signature: Promise<string> }>
+  >();
+
+  async function resolveContributionSignature(
+    key: string,
+    contribution: StrategyTableContribution,
+  ): Promise<string> {
+    const cached = computedSignatures.get(key);
+    const cachedCreateDdl = cached?.createDdl;
+    const cachedSignature = cached?.signature;
+    if (
+      cachedCreateDdl?.length === contribution.createDdl.length &&
+      cachedSignature !== undefined &&
+      contribution.createDdl.every(
+        (statement, index) => cachedCreateDdl[index] === statement,
+      )
+    ) {
+      return cachedSignature;
+    }
+
+    const input = contributionSignatureInput(
+      dialect,
+      contribution,
+      contribution.createDdl,
+    );
+    const entry = {
+      createDdl: [...contribution.createDdl],
+      signature: sha256Hex(input, 16),
+    } as const;
+    computedSignatures.set(key, entry);
+    try {
+      return await entry.signature;
+    } catch (error) {
+      if (computedSignatures.get(key) === entry) {
+        computedSignatures.delete(key);
+      }
+      throw error;
+    }
+  }
 
   function runtimeContributions(): readonly StrategyTableContribution[] {
     return runtimeStrategyContributions(fulltextStrategy, fulltextTableName);
@@ -467,11 +528,11 @@ export function createContributionMaterializer(
     graphId: string,
     contribution: StrategyTableContribution,
     signature: string,
+    existing: ContributionMaterializationRow | undefined,
     options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
   ): Promise<"materialized" | "drift-skipped"> {
     const force = options?.force === true;
     const identity = identityOf(graphId, contribution);
-    const existing = await deps.getMarker(identity);
 
     // Already materialized at this exact shape — nothing to do. `force`
     // re-runs the DDL and re-stamps the marker even on a match: the path
@@ -550,30 +611,33 @@ export function createContributionMaterializer(
     return "materialized";
   }
 
-  /**
-   * Durable state of a single contribution on the current connection:
-   * its freshly-computed signature read back against the marker row. A
-   * missing marker *table* (never bootstrapped) is reported as its own
-   * variant so each caller decides what it means — `assertInitialized`
-   * treats it as "not initialized" and throws; `ensureRuntimeContributions`
-   * treats it as "needs first materialization" and falls through to DDL.
-   * Any non-missing-table read fault (connection/permission/driver) is a
-   * real system error and propagates as-is rather than being masked.
-   */
-  async function readContributionState(
+  function indexMarkerRows(
     graphId: string,
-    contribution: StrategyTableContribution,
-    signature: string,
+    rows: readonly ContributionMaterializationRow[],
+  ): ReadonlyMap<string, ContributionMaterializationRow> {
+    return new Map(
+      rows.map((row) => [contributionKey(graphId, row), row] as const),
+    );
+  }
+
+  /**
+   * Read every marker for a graph in one round trip. A missing marker table
+   * is its own verdict so boot can create it while hot-path asserts translate
+   * it to `StoreNotInitializedError`. All other database faults propagate.
+   */
+  async function readMarkerRows(
+    graphId: string,
   ): Promise<
-    | Readonly<{ kind: "state"; state: ContributionMaterializationState }>
+    | Readonly<{
+        kind: "rows";
+        rows: ReadonlyMap<string, ContributionMaterializationRow>;
+      }>
     | Readonly<{ kind: "missing-table"; error: unknown }>
   > {
-    const identity = identityOf(graphId, contribution);
     try {
-      const existing = await deps.getMarker(identity);
       return {
-        kind: "state",
-        state: evaluateContributionState(existing, signature),
+        kind: "rows",
+        rows: indexMarkerRows(graphId, await deps.getMarkers(graphId)),
       };
     } catch (error) {
       if (!isMissingTableError(error)) throw error;
@@ -600,15 +664,14 @@ export function createContributionMaterializer(
   ): Promise<void> {
     const force = options?.force === true;
     const entries = await Promise.all(
-      contributions.map(async (contribution) => ({
-        contribution,
-        key: contributionKey(graphId, contribution),
-        signature: await computeContributionSignature(
-          dialect,
+      contributions.map(async (contribution) => {
+        const key = contributionKey(graphId, contribution);
+        return {
           contribution,
-          contribution.createDdl,
-        ),
-      })),
+          key,
+          signature: await resolveContributionSignature(key, contribution),
+        };
+      }),
     );
     // A cache hit requires the signature to match — a contribution whose
     // shape changed on this instance falls through to the drift-guard.
@@ -620,34 +683,44 @@ export function createContributionMaterializer(
       );
     if (pending.length === 0) return;
 
-    if (!force) {
-      let allInitialized = true;
+    const initialRead = force ? undefined : await readMarkerRows(graphId);
+    if (
+      !force &&
+      initialRead?.kind === "rows" &&
+      pending.every(
+        (entry) =>
+          evaluateContributionState(
+            initialRead.rows.get(entry.key),
+            entry.signature,
+          ) === "initialized",
+      )
+    ) {
       for (const entry of pending) {
-        const read = await readContributionState(
-          graphId,
-          entry.contribution,
-          entry.signature,
-        );
-        if (read.kind !== "state" || read.state !== "initialized") {
-          allInitialized = false;
-          break;
-        }
+        initializedSignatures.set(entry.key, entry.signature);
       }
-      if (allInitialized) {
-        for (const entry of pending) {
-          initializedSignatures.set(entry.key, entry.signature);
-        }
-        return;
-      }
+      return;
     }
 
     await deps.ensureMarkerTable();
+    // Preserve the original race check after marker-table bootstrap, but
+    // refresh every pending contribution in one query rather than one query
+    // per slot.
+    const existingRows = indexMarkerRows(
+      graphId,
+      await deps.getMarkers(graphId),
+    );
     for (const entry of pending) {
       const outcome = await materializeOne(
         graphId,
         entry.contribution,
         entry.signature,
-        { force, ...(options?.onDrift === undefined ? {} : { onDrift: options.onDrift }) },
+        existingRows.get(entry.key),
+        {
+          force,
+          ...(options?.onDrift === undefined ?
+            {}
+          : { onDrift: options.onDrift }),
+        },
       );
       // A drift-skipped contribution is deliberately NOT cached: nothing
       // was materialized at this signature, and asserts must keep reading
@@ -662,38 +735,45 @@ export function createContributionMaterializer(
    * SELECT-only gate over an arbitrary contribution set: throws
    * `StoreNotInitializedError` on the first missing/stale/failed
    * contribution (or a never-bootstrapped marker table). Caches each
-   * confirmed-initialized contribution BY SIGNATURE so the steady state is
-   * a pure `Map.get` — and a shape change on the same instance misses the
-   * cache and surfaces as `stale`. Never runs DDL or writes.
+   * confirmed-initialized contribution BY SIGNATURE so the steady state is a
+   * crypto-free DDL-string comparison + `Map.get`. A shape change on the same
+   * instance computes a fresh signature, misses the initialized cache, and
+   * surfaces as `stale`. Never runs DDL or writes.
    */
   async function assertContributions(
     graphId: string,
     contributions: readonly StrategyTableContribution[],
   ): Promise<void> {
-    for (const contribution of contributions) {
-      const key = contributionKey(graphId, contribution);
-      const signature = await computeContributionSignature(
-        dialect,
-        contribution,
-        contribution.createDdl,
-      );
-      // Signature-checked cache hit: a shape change on this instance misses
-      // and reaches the stale verdict below instead of being blessed.
-      if (initializedSignatures.get(key) === signature) continue;
-      const read = await readContributionState(graphId, contribution, signature);
-      // A never-bootstrapped database has no marker table — that is
-      // precisely "not initialized". `readContributionState` has already
-      // rethrown any non-missing-table fault (connection, permission,
-      // driver), so a real system error never surfaces here masked as a
-      // user init error.
-      if (read.kind === "missing-table") {
-        throw new StoreNotInitializedError(graphId, "missing", {
-          cause: read.error,
-          details: { logicalName: contribution.logicalName },
-        });
-      }
-      if (read.state !== "initialized") {
-        throw new StoreNotInitializedError(graphId, read.state, {
+    const entries = await Promise.all(
+      contributions.map(async (contribution) => {
+        const key = contributionKey(graphId, contribution);
+        return {
+          contribution,
+          key,
+          signature: await resolveContributionSignature(key, contribution),
+        };
+      }),
+    );
+    const pending = entries.filter(
+      (entry) => initializedSignatures.get(entry.key) !== entry.signature,
+    );
+    if (pending.length === 0) return;
+
+    const read = await readMarkerRows(graphId);
+    if (read.kind === "missing-table") {
+      const first = pending[0];
+      if (first === undefined) return;
+      throw new StoreNotInitializedError(graphId, "missing", {
+        cause: read.error,
+        details: { logicalName: first.contribution.logicalName },
+      });
+    }
+
+    for (const entry of pending) {
+      const { contribution, key, signature } = entry;
+      const state = evaluateContributionState(read.rows.get(key), signature);
+      if (state !== "initialized") {
+        throw new StoreNotInitializedError(graphId, state, {
           details: { logicalName: contribution.logicalName },
         });
       }
@@ -713,27 +793,52 @@ export function createContributionMaterializer(
     slot: VectorSlot,
     options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
   ): Promise<void> {
-    if (deps.vectorStrategy === undefined) return;
-    await ensureContributions(
-      slot.graphId,
-      deps.vectorStrategy.ownedTables(slot),
-      options,
-    );
+    await ensureVectorSlots([slot], options);
   }
 
   async function assertVectorSlot(slot: VectorSlot): Promise<void> {
-    if (deps.vectorStrategy === undefined) return;
-    await assertContributions(
-      slot.graphId,
-      deps.vectorStrategy.ownedTables(slot),
-    );
+    await assertVectorSlots([slot]);
+  }
+
+  function groupVectorContributions(
+    slots: readonly VectorSlot[],
+  ): ReadonlyMap<string, readonly StrategyTableContribution[]> {
+    const grouped = new Map<
+      string,
+      readonly StrategyTableContribution[]
+    >();
+    if (deps.vectorStrategy === undefined) return grouped;
+    for (const slot of slots) {
+      grouped.set(slot.graphId, [
+        ...(grouped.get(slot.graphId) ?? []),
+        ...deps.vectorStrategy.ownedTables(slot),
+      ]);
+    }
+    return grouped;
+  }
+
+  async function ensureVectorSlots(
+    slots: readonly VectorSlot[],
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
+  ): Promise<void> {
+    for (const [graphId, contributions] of groupVectorContributions(slots)) {
+      await ensureContributions(graphId, contributions, options);
+    }
+  }
+
+  async function assertVectorSlots(slots: readonly VectorSlot[]): Promise<void> {
+    for (const [graphId, contributions] of groupVectorContributions(slots)) {
+      await assertContributions(graphId, contributions);
+    }
   }
 
   async function dropVectorSlot(slot: VectorSlot): Promise<void> {
     if (deps.vectorStrategy === undefined) return;
     for (const contribution of deps.vectorStrategy.ownedTables(slot)) {
       await deps.deleteMarker(identityOf(slot.graphId, contribution));
-      initializedSignatures.delete(contributionKey(slot.graphId, contribution));
+      const key = contributionKey(slot.graphId, contribution);
+      initializedSignatures.delete(key);
+      computedSignatures.delete(key);
     }
   }
 
@@ -741,7 +846,9 @@ export function createContributionMaterializer(
     ensureRuntimeContributions,
     assertInitialized,
     ensureVectorSlot,
+    ensureVectorSlots,
     assertVectorSlot,
+    assertVectorSlots,
     dropVectorSlot,
   };
 }

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -455,6 +455,21 @@ export function createPostgresBackend(
     );
   }
 
+  async function getContributionMaterializationRows(
+    graphId: string,
+  ): Promise<readonly ContributionMaterializationRow[]> {
+    const rows = await db
+      .select()
+      .from(matTable)
+      .where(eq(matTable.graphId, graphId));
+    return rows.map((row) =>
+      mapContributionMaterializationRow(
+        row,
+        POSTGRES_CONTRIBUTION_MAT_TIMESTAMPS.decode,
+      ),
+    );
+  }
+
   async function recordContributionMaterializationRow(
     params: RecordContributionMaterializationParams,
   ): Promise<void> {
@@ -504,7 +519,7 @@ export function createPostgresBackend(
       await db.execute(sql.raw(statement));
     },
     ensureMarkerTable: ensureContributionMaterializationsTableImpl,
-    getMarker: getContributionMaterializationRow,
+    getMarkers: getContributionMaterializationRows,
     recordMarker: recordContributionMaterializationRow,
     deleteMarker: deleteContributionMaterializationRow,
   });
@@ -850,8 +865,21 @@ export function createPostgresBackend(
           await contributionMaterializer.ensureVectorSlot(slot, options_);
         },
 
+        async ensureVectorSlotContributions(
+          slots: readonly VectorSlot[],
+          options_?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
+        ): Promise<void> {
+          await contributionMaterializer.ensureVectorSlots(slots, options_);
+        },
+
         async assertVectorSlotInitialized(slot: VectorSlot): Promise<void> {
           await contributionMaterializer.assertVectorSlot(slot);
+        },
+
+        async assertVectorSlotsInitialized(
+          slots: readonly VectorSlot[],
+        ): Promise<void> {
+          await contributionMaterializer.assertVectorSlots(slots);
         },
 
         async deleteVectorSlotContribution(slot: VectorSlot): Promise<void> {

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -103,6 +103,7 @@ import {
 import {
   buildContributionInsertValues,
   buildContributionOnConflictSet,
+  type ContributionMaterializer,
   createContributionMaterializer,
   gateFulltext,
   gateFulltextMethods,
@@ -158,13 +159,11 @@ import {
   tables as defaultTables,
 } from "./schema/postgres";
 import {
-  createVectorSlotLatch,
   EMBEDDING_UPSERT_PARAM_COUNT,
   mapVectorWriteError,
   vectorSlotFromCreateIndexParams,
   vectorSlotFromDropIndexParams,
   vectorSlotFromParams,
-  type VectorSlotLatch,
 } from "./vector-runtime";
 
 // ============================================================
@@ -335,11 +334,6 @@ export function createPostgresBackend(
   // default strategy's `vector(N)` DDL would hard-fail.
   const vectorStrategy =
     options.vector === false ? undefined : (options.vector ?? pgvectorStrategy);
-  // One latch per backend instance, shared with every transaction-scoped
-  // backend so a slot's per-field table is created at most once per process.
-  // Absent when vector support is disabled.
-  const vectorSlotLatch =
-    vectorStrategy === undefined ? undefined : createVectorSlotLatch();
   // One probe per backend instance, shared with every transaction-scoped
   // backend so the pgvector version check runs — and its pre-0.8 warning
   // fires — at most once per backend, not once per `store.transaction()`.
@@ -410,18 +404,6 @@ export function createPostgresBackend(
     tables,
     fulltextStrategy,
   );
-  const operations = createPostgresOperationBackend({
-    db,
-    executionAdapter,
-    adapterOptions,
-    operationStrategy,
-    tableNames,
-    capabilities,
-    fulltextStrategy,
-    vectorStrategy,
-    vectorSlotLatch,
-    iterativeScanProbe,
-  });
 
   // Whether `tableName` currently exists, via the same catalog probe `clear()`
   // uses — so refreshStatistics() never ANALYZEs a recorded relation that a
@@ -438,65 +420,13 @@ export function createPostgresBackend(
     { cacheExisting: false },
   );
 
-  /**
-   * Runs `fn` inside a Postgres transaction, holding an
-   * `pg_advisory_xact_lock` keyed on the graph id. The advisory lock
-   * serializes all schema commits per-graph: the read-then-write CAS in
-   * `commitSchemaVersion` is safe even for the initial-commit case
-   * where there is no row yet to `SELECT ... FOR UPDATE`.
-   *
-   * Refuses on backends that don't support transactions
-   * (`drizzle-orm/neon-http`). The orphan-row crash window cannot be
-   * eliminated without atomicity, so silent best-effort degradation is
-   * worse than a typed error.
-   */
-  function runSchemaWriteTransaction<T>(
-    graphId: string,
-    fn: (tx: CommonOperationBackend) => Promise<T>,
-  ): Promise<T> {
-    if (!capabilities.transactions) {
-      throw new ConfigurationError(
-        "commitSchemaVersion and setActiveVersion require atomic transactions, " +
-          "but this Postgres backend does not provide them. The drizzle-orm/neon-http " +
-          "driver communicates over HTTP and cannot hold a session across statements; " +
-          "use drizzle-orm/neon-serverless (websocket) for transactional writes.",
-        {
-          backend: "postgres",
-          capability: "transactions",
-          supportsTransactions: false,
-        },
-      );
-    }
-
-    return db.transaction(async (tx) => {
-      // Advisory lock: hashtext($graphId) is collision-tolerant for the
-      // size of an active graph set; collisions just serialize unrelated
-      // graphs which is harmless. Held until the transaction commits.
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${graphId}))`);
-      // Advisory lock is held here, so the schema-write-capable
-      // InternalOperationBackend is used intentionally (see its type).
-      const { backend: txBackend, drainAndClose } = createTransactionBackend({
-        db: tx,
-        adapterOptions,
-        operationStrategy,
-        tableNames,
-        capabilities,
-        fulltextStrategy,
-        vectorStrategy,
-        vectorSlotLatch,
-        iterativeScanProbe,
-      });
-      try {
-        return await fn(txBackend);
-      } finally {
-        await drainAndClose();
-      }
-    });
-  }
-
-  // Durable fulltext materialization (#135): the dialect-specific
+  // Durable fulltext + vector materialization (#135): the dialect-specific
   // marker-table primitives. Orchestration (materialize / assert /
-  // per-instance cache) lives once in `createContributionMaterializer`.
+  // per-instance cache) lives once in `createContributionMaterializer`,
+  // shared by the outer backend and every transaction-scoped backend so a
+  // slot's marker is resolved at most once per process. Built before
+  // `operations` so the operation backend's vector methods can assert/
+  // ensure through it instead of issuing DDL on the hot path.
   const matTable = tables.contributionMaterializations;
 
   async function ensureContributionMaterializationsTableImpl(): Promise<void> {
@@ -550,17 +480,103 @@ export function createPostgresBackend(
       });
   }
 
+  async function deleteContributionMaterializationRow(
+    identity: ContributionMaterializationIdentity,
+  ): Promise<void> {
+    await db
+      .delete(matTable)
+      .where(
+        and(
+          eq(matTable.graphId, identity.graphId),
+          eq(matTable.logicalName, identity.logicalName),
+          eq(matTable.owner, identity.owner),
+          eq(matTable.tableName, identity.tableName),
+        ),
+      );
+  }
+
   const contributionMaterializer = createContributionMaterializer({
     dialect: "postgres",
     fulltextStrategy,
     fulltextTableName: tables.fulltextTableName,
+    vectorStrategy,
     execDdl: async (statement) => {
       await db.execute(sql.raw(statement));
     },
     ensureMarkerTable: ensureContributionMaterializationsTableImpl,
     getMarker: getContributionMaterializationRow,
     recordMarker: recordContributionMaterializationRow,
+    deleteMarker: deleteContributionMaterializationRow,
   });
+
+  const operations = createPostgresOperationBackend({
+    db,
+    executionAdapter,
+    adapterOptions,
+    operationStrategy,
+    tableNames,
+    capabilities,
+    fulltextStrategy,
+    vectorStrategy,
+    contributionMaterializer,
+    iterativeScanProbe,
+  });
+
+  /**
+   * Runs `fn` inside a Postgres transaction, holding an
+   * `pg_advisory_xact_lock` keyed on the graph id. The advisory lock
+   * serializes all schema commits per-graph: the read-then-write CAS in
+   * `commitSchemaVersion` is safe even for the initial-commit case
+   * where there is no row yet to `SELECT ... FOR UPDATE`.
+   *
+   * Refuses on backends that don't support transactions
+   * (`drizzle-orm/neon-http`). The orphan-row crash window cannot be
+   * eliminated without atomicity, so silent best-effort degradation is
+   * worse than a typed error.
+   */
+  function runSchemaWriteTransaction<T>(
+    graphId: string,
+    fn: (tx: CommonOperationBackend) => Promise<T>,
+  ): Promise<T> {
+    if (!capabilities.transactions) {
+      throw new ConfigurationError(
+        "commitSchemaVersion and setActiveVersion require atomic transactions, " +
+          "but this Postgres backend does not provide them. The drizzle-orm/neon-http " +
+          "driver communicates over HTTP and cannot hold a session across statements; " +
+          "use drizzle-orm/neon-serverless (websocket) for transactional writes.",
+        {
+          backend: "postgres",
+          capability: "transactions",
+          supportsTransactions: false,
+        },
+      );
+    }
+
+    return db.transaction(async (tx) => {
+      // Advisory lock: hashtext($graphId) is collision-tolerant for the
+      // size of an active graph set; collisions just serialize unrelated
+      // graphs which is harmless. Held until the transaction commits.
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${graphId}))`);
+      // Advisory lock is held here, so the schema-write-capable
+      // InternalOperationBackend is used intentionally (see its type).
+      const { backend: txBackend, drainAndClose } = createTransactionBackend({
+        db: tx,
+        adapterOptions,
+        operationStrategy,
+        tableNames,
+        capabilities,
+        fulltextStrategy,
+        vectorStrategy,
+        contributionMaterializer,
+        iterativeScanProbe,
+      });
+      try {
+        return await fn(txBackend);
+      } finally {
+        await drainAndClose();
+      }
+    });
+  }
 
   // Shared by `transaction()` (TypeGraph opens the tx) and
   // `adoptTransaction()` (#134 — the caller already opened it): bind a
@@ -578,7 +594,7 @@ export function createPostgresBackend(
       capabilities,
       fulltextStrategy,
       vectorStrategy,
-      vectorSlotLatch,
+      contributionMaterializer,
       iterativeScanProbe,
     });
     return {
@@ -820,6 +836,29 @@ export function createPostgresBackend(
       await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
+    // Vector counterparts of the runtime-contribution methods. Present
+    // only when a vector strategy is wired (omitted under `vector: false`,
+    // mirroring the embedding/search methods), so a no-vector backend
+    // doesn't advertise vector materialization it can't perform.
+    ...(vectorStrategy === undefined ?
+      {}
+    : {
+        async ensureVectorSlotContribution(
+          slot: VectorSlot,
+          options_?: Readonly<{ force?: boolean }>,
+        ): Promise<void> {
+          await contributionMaterializer.ensureVectorSlot(slot, options_);
+        },
+
+        async assertVectorSlotInitialized(slot: VectorSlot): Promise<void> {
+          await contributionMaterializer.assertVectorSlot(slot);
+        },
+
+        async deleteVectorSlotContribution(slot: VectorSlot): Promise<void> {
+          await contributionMaterializer.dropVectorSlot(slot);
+        },
+      }),
+
     async getReconciliationMarker(
       graphId: string,
     ): Promise<number | undefined> {
@@ -1050,10 +1089,13 @@ type CreatePostgresOperationBackendOptions = Readonly<{
    */
   vectorStrategy: VectorStrategy | undefined;
   /**
-   * Shared per-`(kind, field)` storage-ensure latch. Paired with
-   * `vectorStrategy`: both present, or both `undefined`.
+   * Shared durable-marker materializer. The vector methods assert a
+   * slot's marker (SELECT, never DDL) on the hot path and `createVectorIndex`
+   * ensures it (privileged) — replacing the old in-process ensure-latch.
+   * Shared across the outer backend and every transaction-scoped backend
+   * so a slot's marker is resolved at most once per process.
    */
-  vectorSlotLatch: VectorSlotLatch | undefined;
+  contributionMaterializer: ContributionMaterializer;
   /**
    * Shared pgvector iterative-scan probe (memoized version check + one-shot
    * pre-0.8 warning). Owned by the top-level backend and reused by every
@@ -1071,8 +1113,8 @@ type CreatePostgresTransactionBackendOptions = Readonly<{
   fulltextStrategy: FulltextStrategy;
   /** Active vector strategy. See {@link CreatePostgresOperationBackendOptions}. */
   vectorStrategy: VectorStrategy | undefined;
-  /** Shared storage-ensure latch. See {@link CreatePostgresOperationBackendOptions}. */
-  vectorSlotLatch: VectorSlotLatch | undefined;
+  /** Shared durable-marker materializer. See {@link CreatePostgresOperationBackendOptions}. */
+  contributionMaterializer: ContributionMaterializer;
   /** Shared iterative-scan probe. See {@link CreatePostgresOperationBackendOptions}. */
   iterativeScanProbe: IterativeScanProbe;
 }>;
@@ -1089,7 +1131,7 @@ function createPostgresOperationBackend(
     capabilities,
     fulltextStrategy,
     vectorStrategy,
-    vectorSlotLatch,
+    contributionMaterializer,
     iterativeScanProbe,
   } = options;
 
@@ -1291,16 +1333,6 @@ function createPostgresOperationBackend(
     });
   }
 
-  // Runs the strategy's per-field DDL on this backend's connection (the tx
-  // client for a transaction-scoped backend) so a slot's table exists
-  // before the first write/search hits it.
-  async function ensureVectorSlotStorage(slot: VectorSlot): Promise<void> {
-    if (vectorStrategy === undefined || vectorSlotLatch === undefined) return;
-    await vectorSlotLatch.ensure(vectorStrategy, slot, async (statement) => {
-      await execRun(sql.raw(statement));
-    });
-  }
-
   const batchConfig = {
     checkUniqueBatchChunkSize: POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE,
     edgeInsertBatchSize: POSTGRES_EDGE_INSERT_BATCH_SIZE,
@@ -1319,6 +1351,7 @@ function createPostgresOperationBackend(
     nodeInsertBatchSize: POSTGRES_NODE_INSERT_BATCH_SIZE,
     uniqueInsertBatchSize: POSTGRES_UNIQUE_INSERT_BATCH_SIZE,
   };
+
   const commonBackend = createCommonOperationBackend({
     batchConfig,
     execution: {
@@ -1360,7 +1393,11 @@ function createPostgresOperationBackend(
     : {
         async upsertEmbedding(params: UpsertEmbeddingParams): Promise<void> {
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          // Assert the slot's durable marker (SELECT, cached) — never DDL.
+          // The per-field table is provisioned by the privileged migrator
+          // (`createStoreWithSchema` → `materializeVectorContributions`), so
+          // a least-privilege runtime role writes embeddings without CREATE.
+          await contributionMaterializer.assertVectorSlot(slot);
           const statements = vectorStrategy.buildUpsert(slot, params, nowIso());
           try {
             for (const statement of statements) {
@@ -1376,7 +1413,8 @@ function createPostgresOperationBackend(
         ): Promise<void> {
           if (params.rows.length === 0) return;
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          // Same SELECT-only marker assert as the single-row path — never DDL.
+          await contributionMaterializer.assertVectorSlot(slot);
           // Last-write-wins dedupe: a multi-row upsert cannot affect one
           // row twice.
           const rowsById = new Map(
@@ -1422,15 +1460,15 @@ function createPostgresOperationBackend(
         },
 
         async deleteEmbedding(params: DeleteEmbeddingParams): Promise<void> {
-          // Ensure the per-field table exists before deleting. A delete can
+          // Assert the slot's durable marker before deleting. A delete can
           // run before any embedding was ever written for the field (e.g. a
-          // node hard-deleted having never carried one), and on Postgres a
-          // DELETE against a missing relation INSIDE a transaction aborts the
-          // whole transaction — swallowing the JS error can't un-abort it.
-          // The idempotent ensure makes the DELETE target an existing
-          // (possibly empty) table, so it's always a clean no-op.
+          // node hard-deleted having never carried one); the per-field table
+          // was provisioned at boot, so the DELETE targets an existing
+          // (possibly empty) table and is a clean no-op — never a DELETE
+          // against a missing relation, which would abort an enclosing
+          // Postgres transaction. SELECT-only assert, never DDL.
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          await contributionMaterializer.assertVectorSlot(slot);
           const statements = vectorStrategy.buildDelete(slot, params);
           for (const statement of statements) {
             await execRun(statement);
@@ -1445,7 +1483,7 @@ function createPostgresOperationBackend(
           // before `runVectorSearch` applies it via `set_config`.
           assertPgvectorEfSearch(params.efSearch);
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          await contributionMaterializer.assertVectorSlot(slot);
           const query = vectorStrategy.buildSearch(
             slot,
             params,
@@ -1493,7 +1531,7 @@ function createPostgresOperationBackend(
                 metric: params.vector.metric,
                 indexType: params.vector.indexType,
               });
-              await ensureVectorSlotStorage(slot);
+              await contributionMaterializer.assertVectorSlot(slot);
               const candidates =
                 params.candidates ??
                 operationStrategy.buildLiveNodeIds(
@@ -1562,12 +1600,12 @@ function createPostgresOperationBackend(
     async createVectorIndex(params: CreateVectorIndexParams): Promise<void> {
       if (vectorStrategy === undefined) return;
       const slot = vectorSlotFromCreateIndexParams(params);
-      // Ensure the per-field table exists first (idempotent), then create its
-      // ANN index. pgvector's `ownedTables` builds the table only — the HNSW/
-      // IVFFlat index is created here (and only here) so it picks up the
-      // declared `m`/`ef_construction`/`lists` from `slot.indexParams` rather
-      // than defaults.
-      await ensureVectorSlotStorage(slot);
+      // Ensure the per-field table + its durable marker first (privileged,
+      // idempotent), then create its ANN index. pgvector's `ownedTables`
+      // builds the table only — the HNSW/IVFFlat index is created here (and
+      // only here) so it picks up the declared `m`/`ef_construction`/`lists`
+      // from `slot.indexParams` rather than defaults.
+      await contributionMaterializer.ensureVectorSlot(slot);
       // Honor the `concurrent` flag materializeIndexes passes on Postgres so the
       // ANN build doesn't take a write-blocking lock on a live table. execRun is
       // autocommit, which CONCURRENTLY requires.
@@ -1762,13 +1800,12 @@ function createTransactionBackend(
     createPostgresExecutionAdapter(options.db, options.adapterOptions),
   );
 
-  // A transaction-scoped backend gets its OWN per-field ensure-latch, never
-  // the outer process-global one: a `CREATE TABLE/INDEX` that runs inside the
-  // caller's transaction and then rolls back must not leave the shared latch
-  // marking the slot "ensured" (which would skip the re-CREATE and make every
-  // later write fail with "relation does not exist"). The fresh latch is
-  // discarded with the transaction, so the next write re-ensures idempotently.
-  // No latch when vector support is disabled (`vector: false`).
+  // The transaction-scoped backend shares the outer backend's
+  // contribution materializer: the per-field vector table is provisioned
+  // (DDL) only by the privileged outer backend, so a tx-scoped vector op
+  // only ASSERTS the durable marker (SELECT, never DDL) and can't poison
+  // anything on rollback. The shared per-instance cache means a slot
+  // confirmed once stays a pure `Set.has` inside every later transaction.
   const backend = createPostgresOperationBackend({
     db: options.db,
     executionAdapter: txExecutionAdapter,
@@ -1778,10 +1815,9 @@ function createTransactionBackend(
     capabilities: options.capabilities,
     fulltextStrategy: options.fulltextStrategy,
     vectorStrategy: options.vectorStrategy,
-    vectorSlotLatch:
-      options.vectorStrategy === undefined ? undefined : createVectorSlotLatch(),
-    // The probe is process-wide truth, so — unlike the slot latch — the outer
-    // instance's is reused rather than a fresh one per transaction.
+    contributionMaterializer: options.contributionMaterializer,
+    // The probe is process-wide truth, so the outer instance's is reused
+    // rather than a fresh one per transaction.
     iterativeScanProbe: options.iterativeScanProbe,
   });
 

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -845,7 +845,7 @@ export function createPostgresBackend(
     : {
         async ensureVectorSlotContribution(
           slot: VectorSlot,
-          options_?: Readonly<{ force?: boolean }>,
+          options_?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
         ): Promise<void> {
           await contributionMaterializer.ensureVectorSlot(slot, options_);
         },
@@ -1483,7 +1483,15 @@ function createPostgresOperationBackend(
           // before `runVectorSearch` applies it via `set_config`.
           assertPgvectorEfSearch(params.efSearch);
           const slot = vectorSlotFromParams(params);
-          await contributionMaterializer.assertVectorSlot(slot);
+          // Deliberately NOT marker-gated: search is read-only (no DDL
+          // hazard to gate), and its params carry the caller's runtime
+          // metric override, which legitimately diverges from the
+          // provisioned shape on strategies that bake the metric into the
+          // DDL (sqlite-vec; pgvector's table DDL is metric-free but the
+          // contract is kept identical across dialects). An unprovisioned
+          // slot surfaces the engine's missing-relation error — the same
+          // contract as a query-builder `similarTo()` predicate;
+          // `createVerifiedStore` catches both at attach.
           const query = vectorStrategy.buildSearch(
             slot,
             params,
@@ -1531,7 +1539,7 @@ function createPostgresOperationBackend(
                 metric: params.vector.metric,
                 indexType: params.vector.indexType,
               });
-              await contributionMaterializer.assertVectorSlot(slot);
+              // Read-only, not marker-gated — see vectorSearch above.
               const candidates =
                 params.candidates ??
                 operationStrategy.buildLiveNodeIds(

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1030,6 +1030,21 @@ export function createSqliteBackend(
     );
   }
 
+  async function getContributionMaterializationRows(
+    graphId: string,
+  ): Promise<readonly ContributionMaterializationRow[]> {
+    const rows = await db
+      .select()
+      .from(matTable)
+      .where(eq(matTable.graphId, graphId));
+    return rows.map((row) =>
+      mapContributionMaterializationRow(
+        row,
+        SQLITE_CONTRIBUTION_MAT_TIMESTAMPS.decode,
+      ),
+    );
+  }
+
   async function recordContributionMaterializationRow(
     params: RecordContributionMaterializationParams,
   ): Promise<void> {
@@ -1079,7 +1094,7 @@ export function createSqliteBackend(
       await db.run(sql.raw(statement));
     },
     ensureMarkerTable: ensureContributionMaterializationsTableImpl,
-    getMarker: getContributionMaterializationRow,
+    getMarkers: getContributionMaterializationRows,
     recordMarker: recordContributionMaterializationRow,
     deleteMarker: deleteContributionMaterializationRow,
   });
@@ -1437,8 +1452,21 @@ export function createSqliteBackend(
           await contributionMaterializer.ensureVectorSlot(slot, options_);
         },
 
+        async ensureVectorSlotContributions(
+          slots: readonly VectorSlot[],
+          options_?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
+        ): Promise<void> {
+          await contributionMaterializer.ensureVectorSlots(slots, options_);
+        },
+
         async assertVectorSlotInitialized(slot: VectorSlot): Promise<void> {
           await contributionMaterializer.assertVectorSlot(slot);
+        },
+
+        async assertVectorSlotsInitialized(
+          slots: readonly VectorSlot[],
+        ): Promise<void> {
+          await contributionMaterializer.assertVectorSlots(slots);
         },
 
         async deleteVectorSlotContribution(slot: VectorSlot): Promise<void> {

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -690,8 +690,15 @@ function createSqliteOperationBackend(
           params: VectorSearchParams,
         ): Promise<readonly VectorSearchResult[]> {
           assertVectorSearchLimit(params.limit);
+          // Deliberately NOT marker-gated: search is read-only (no DDL
+          // hazard to gate), and its params carry the caller's runtime
+          // metric override, which legitimately diverges from the
+          // provisioned shape on strategies that bake the metric into the
+          // DDL (sqlite-vec). An unprovisioned slot surfaces the engine's
+          // missing-relation error — the same contract as a query-builder
+          // `similarTo()` predicate; `createVerifiedStore` catches both at
+          // attach.
           const slot = vectorSlotFromParams(params);
-          await contributionMaterializer.assertVectorSlot(slot);
           const query = vectorStrategy.buildSearch(
             slot,
             params,
@@ -738,7 +745,7 @@ function createSqliteOperationBackend(
                 metric: params.vector.metric,
                 indexType: params.vector.indexType,
               });
-              await contributionMaterializer.assertVectorSlot(slot);
+              // Read-only, not marker-gated — see vectorSearch above.
               const candidates =
                 params.candidates ??
                 operationStrategy.buildLiveNodeIds(
@@ -1425,7 +1432,7 @@ export function createSqliteBackend(
     : {
         async ensureVectorSlotContribution(
           slot: VectorSlot,
-          options_?: Readonly<{ force?: boolean }>,
+          options_?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
         ): Promise<void> {
           await contributionMaterializer.ensureVectorSlot(slot, options_);
         },

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -87,18 +87,17 @@ import {
   type SqliteExecutionProfileHints,
 } from "./execution/sqlite-execution";
 import {
-  createVectorSlotLatch,
   EMBEDDING_UPSERT_PARAM_COUNT,
   mapVectorWriteError,
   vectorSlotFromCreateIndexParams,
   vectorSlotFromDropIndexParams,
   vectorSlotFromParams,
-  type VectorSlotLatch,
 } from "./vector-runtime";
 export type { SqliteTransactionMode } from "./execution/sqlite-execution";
 import {
   buildContributionInsertValues,
   buildContributionOnConflictSet,
+  type ContributionMaterializer,
   createContributionMaterializer,
   gateFulltext,
   gateFulltextMethods,
@@ -485,12 +484,13 @@ type CreateSqliteOperationBackendOptions = Readonly<{
    */
   vectorStrategy?: VectorStrategy | undefined;
   /**
-   * Per-`(kind, field)` storage-ensure latch shared across the outer
-   * backend and every transaction-scoped backend (see
-   * {@link createVectorSlotLatch}). Required whenever `vectorStrategy` is
-   * set so writes never hit a missing per-field table.
+   * Shared durable-marker materializer. The vector methods assert a
+   * slot's marker (SELECT, never DDL) on the hot path and `createVectorIndex`
+   * ensures it (privileged) — replacing the old in-process ensure-latch.
+   * Shared across the outer backend and every transaction-scoped backend
+   * so a slot's marker is resolved at most once per process.
    */
-  vectorSlotLatch?: VectorSlotLatch | undefined;
+  contributionMaterializer: ContributionMaterializer;
 }>;
 
 type CreateSqliteTransactionBackendOptions = Readonly<{
@@ -503,8 +503,8 @@ type CreateSqliteTransactionBackendOptions = Readonly<{
   fulltextStrategy: FulltextStrategy;
   /** Active vector strategy. See {@link CreateSqliteOperationBackendOptions}. */
   vectorStrategy?: VectorStrategy | undefined;
-  /** Shared storage-ensure latch. See {@link CreateSqliteOperationBackendOptions}. */
-  vectorSlotLatch?: VectorSlotLatch | undefined;
+  /** Shared durable-marker materializer. See {@link CreateSqliteOperationBackendOptions}. */
+  contributionMaterializer: ContributionMaterializer;
 }>;
 
 function createSqliteOperationBackend(
@@ -519,7 +519,7 @@ function createSqliteOperationBackend(
     tableNames,
     fulltextStrategy,
     vectorStrategy,
-    vectorSlotLatch,
+    contributionMaterializer,
   } = options;
 
   // CRUD statements route through the execution adapter's compiled path on
@@ -602,23 +602,16 @@ function createSqliteOperationBackend(
         },
       };
 
-  // The latch runs per-field DDL on the same connection a write/search
-  // executes on, so a transaction-scoped write materializes its slot inside
-  // the caller's transaction.
-  async function ensureVectorSlotStorage(slot: VectorSlot): Promise<void> {
-    if (vectorStrategy === undefined || vectorSlotLatch === undefined) return;
-    await vectorSlotLatch.ensure(vectorStrategy, slot, async (statement) => {
-      await execRun(sql.raw(statement));
-    });
-  }
-
   const vectorEmbeddingMethods =
     vectorStrategy === undefined ?
       {}
     : {
         async upsertEmbedding(params: UpsertEmbeddingParams): Promise<void> {
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          // Assert the slot's durable marker (SELECT, cached) — never DDL.
+          // The per-field table is provisioned by the privileged migrator
+          // (`createStoreWithSchema` → `materializeVectorContributions`).
+          await contributionMaterializer.assertVectorSlot(slot);
           const statements = vectorStrategy.buildUpsert(slot, params, nowIso());
           try {
             for (const statement of statements) {
@@ -633,7 +626,8 @@ function createSqliteOperationBackend(
         ): Promise<void> {
           if (params.rows.length === 0) return;
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          // Same SELECT-only marker assert as the single-row path — never DDL.
+          await contributionMaterializer.assertVectorSlot(slot);
           // Last-write-wins dedupe: a multi-row upsert cannot affect one
           // row twice.
           const rowsById = new Map(
@@ -678,15 +672,15 @@ function createSqliteOperationBackend(
           }
         },
         async deleteEmbedding(params: DeleteEmbeddingParams): Promise<void> {
-          // Ensure the per-field table exists before deleting. A delete
-          // can run before any embedding was ever written for the field
-          // (e.g. a node hard-deleted having never carried one); the
-          // idempotent ensure makes the DELETE a clean no-op against an
-          // existing (possibly empty) table, matching the Postgres path
-          // (where a DELETE on a missing relation would abort an
-          // enclosing transaction).
+          // Assert the slot's durable marker before deleting. A delete can
+          // run before any embedding was ever written for the field (e.g. a
+          // node hard-deleted having never carried one); the per-field table
+          // was provisioned at boot, so the DELETE is a clean no-op against
+          // an existing (possibly empty) table, matching the Postgres path
+          // (where a DELETE on a missing relation would abort an enclosing
+          // transaction). SELECT-only assert, never DDL.
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          await contributionMaterializer.assertVectorSlot(slot);
           const statements = vectorStrategy.buildDelete(slot, params);
           for (const statement of statements) {
             await execRun(statement);
@@ -697,7 +691,7 @@ function createSqliteOperationBackend(
         ): Promise<readonly VectorSearchResult[]> {
           assertVectorSearchLimit(params.limit);
           const slot = vectorSlotFromParams(params);
-          await ensureVectorSlotStorage(slot);
+          await contributionMaterializer.assertVectorSlot(slot);
           const query = vectorStrategy.buildSearch(
             slot,
             params,
@@ -744,7 +738,7 @@ function createSqliteOperationBackend(
                 metric: params.vector.metric,
                 indexType: params.vector.indexType,
               });
-              await ensureVectorSlotStorage(slot);
+              await contributionMaterializer.assertVectorSlot(slot);
               const candidates =
                 params.candidates ??
                 operationStrategy.buildLiveNodeIds(
@@ -802,11 +796,12 @@ function createSqliteOperationBackend(
     async createVectorIndex(params: CreateVectorIndexParams): Promise<void> {
       if (vectorStrategy === undefined) return;
       const slot = vectorSlotFromCreateIndexParams(params);
-      // Ensure the per-field table exists first (idempotent), then create
-      // its ANN index. `ownedTables` already folds the index DDL in, so the
-      // explicit `buildCreateIndex` step is belt-and-suspenders for slots
-      // whose index intent changed after the table was first materialized.
-      await ensureVectorSlotStorage(slot);
+      // Ensure the per-field table + its durable marker first (privileged,
+      // idempotent), then create its ANN index. `ownedTables` already folds
+      // the index DDL in, so the explicit `buildCreateIndex` step is
+      // belt-and-suspenders for slots whose index intent changed after the
+      // table was first materialized.
+      await contributionMaterializer.ensureVectorSlot(slot);
       const indexStatement = vectorStrategy.buildCreateIndex?.(slot);
       if (indexStatement !== undefined) {
         await execRun(indexStatement);
@@ -938,10 +933,6 @@ export function createSqliteBackend(
   // (`createLibsqlBackend` always; `createLocalSqliteBackend` when the
   // extension loads); absent for plain SQLite drivers with no extension.
   const vectorStrategy = options.vector;
-  // One latch per backend instance, shared with every transaction-scoped
-  // backend so a slot's per-field table is created at most once per process.
-  const vectorSlotLatch =
-    vectorStrategy === undefined ? undefined : createVectorSlotLatch();
   const capabilities: BackendCapabilities = {
     ...buildSqliteCapabilities({
       fulltextStrategy,
@@ -996,6 +987,96 @@ export function createSqliteBackend(
   // stay unqueued.
   const serializedQueue =
     transactionMode === "none" ? undefined : createSerializedExecutionQueue();
+
+  // Durable fulltext + vector materialization (#135): the dialect-specific
+  // marker-table primitives. Orchestration (materialize / assert /
+  // per-instance cache) lives once in `createContributionMaterializer`,
+  // shared by the outer backend and every transaction-scoped backend so a
+  // slot's marker is resolved at most once per process. Built before
+  // `operations` so the operation backend's vector methods can assert/
+  // ensure through it instead of issuing DDL on the hot path.
+  const matTable = tables.contributionMaterializations;
+
+  async function ensureContributionMaterializationsTableImpl(): Promise<void> {
+    await db.run(sql.raw(generateSqliteCreateTableSQL(matTable)));
+  }
+
+  async function getContributionMaterializationRow(
+    identity: ContributionMaterializationIdentity,
+  ): Promise<ContributionMaterializationRow | undefined> {
+    const rows = await db
+      .select()
+      .from(matTable)
+      .where(
+        and(
+          eq(matTable.graphId, identity.graphId),
+          eq(matTable.logicalName, identity.logicalName),
+          eq(matTable.owner, identity.owner),
+          eq(matTable.tableName, identity.tableName),
+        ),
+      );
+    const row = rows[0];
+    if (row === undefined) return undefined;
+    return mapContributionMaterializationRow(
+      row,
+      SQLITE_CONTRIBUTION_MAT_TIMESTAMPS.decode,
+    );
+  }
+
+  async function recordContributionMaterializationRow(
+    params: RecordContributionMaterializationParams,
+  ): Promise<void> {
+    await db
+      .insert(matTable)
+      .values(
+        buildContributionInsertValues(
+          params,
+          SQLITE_CONTRIBUTION_MAT_TIMESTAMPS.encode,
+        ),
+      )
+      .onConflictDoUpdate({
+        target: [
+          matTable.graphId,
+          matTable.logicalName,
+          matTable.owner,
+          matTable.tableName,
+        ],
+        set: buildContributionOnConflictSet(
+          matTable.materializedAt,
+          params.materializedAt,
+        ),
+      });
+  }
+
+  async function deleteContributionMaterializationRow(
+    identity: ContributionMaterializationIdentity,
+  ): Promise<void> {
+    await db
+      .delete(matTable)
+      .where(
+        and(
+          eq(matTable.graphId, identity.graphId),
+          eq(matTable.logicalName, identity.logicalName),
+          eq(matTable.owner, identity.owner),
+          eq(matTable.tableName, identity.tableName),
+        ),
+      );
+  }
+
+  const contributionMaterializer = createContributionMaterializer({
+    dialect: "sqlite",
+    fulltextStrategy,
+    fulltextTableName: tables.fulltextTableName,
+    vectorStrategy,
+    execDdl: async (statement) => {
+      await db.run(sql.raw(statement));
+    },
+    ensureMarkerTable: ensureContributionMaterializationsTableImpl,
+    getMarker: getContributionMaterializationRow,
+    recordMarker: recordContributionMaterializationRow,
+    deleteMarker: deleteContributionMaterializationRow,
+  });
+
   const operations = createSqliteOperationBackend({
     capabilities,
     db,
@@ -1004,7 +1085,7 @@ export function createSqliteBackend(
     tableNames,
     fulltextStrategy,
     vectorStrategy,
-    vectorSlotLatch,
+    contributionMaterializer,
     ...(serializedQueue === undefined ? {} : { serializedQueue }),
   });
 
@@ -1089,7 +1170,7 @@ export function createSqliteBackend(
           tableNames,
           fulltextStrategy,
           vectorStrategy,
-          vectorSlotLatch,
+          contributionMaterializer,
         });
         await runFrameStatement(sql`BEGIN IMMEDIATE`);
         try {
@@ -1120,7 +1201,7 @@ export function createSqliteBackend(
           tableNames,
           fulltextStrategy,
           vectorStrategy,
-          vectorSlotLatch,
+          contributionMaterializer,
         });
         return fn(txBackend);
       });
@@ -1143,7 +1224,7 @@ export function createSqliteBackend(
               tableNames,
               fulltextStrategy,
               vectorStrategy,
-              vectorSlotLatch,
+              contributionMaterializer,
             });
             return fn(txBackend);
           },
@@ -1151,74 +1232,6 @@ export function createSqliteBackend(
         ) as Promise<T>,
     );
   }
-
-  // Durable fulltext materialization (#135): the dialect-specific
-  // marker-table primitives. Orchestration (materialize / assert /
-  // per-instance cache) lives once in `createContributionMaterializer`.
-  const matTable = tables.contributionMaterializations;
-
-  async function ensureContributionMaterializationsTableImpl(): Promise<void> {
-    await db.run(sql.raw(generateSqliteCreateTableSQL(matTable)));
-  }
-
-  async function getContributionMaterializationRow(
-    identity: ContributionMaterializationIdentity,
-  ): Promise<ContributionMaterializationRow | undefined> {
-    const rows = await db
-      .select()
-      .from(matTable)
-      .where(
-        and(
-          eq(matTable.graphId, identity.graphId),
-          eq(matTable.logicalName, identity.logicalName),
-          eq(matTable.owner, identity.owner),
-          eq(matTable.tableName, identity.tableName),
-        ),
-      );
-    const row = rows[0];
-    if (row === undefined) return undefined;
-    return mapContributionMaterializationRow(
-      row,
-      SQLITE_CONTRIBUTION_MAT_TIMESTAMPS.decode,
-    );
-  }
-
-  async function recordContributionMaterializationRow(
-    params: RecordContributionMaterializationParams,
-  ): Promise<void> {
-    await db
-      .insert(matTable)
-      .values(
-        buildContributionInsertValues(
-          params,
-          SQLITE_CONTRIBUTION_MAT_TIMESTAMPS.encode,
-        ),
-      )
-      .onConflictDoUpdate({
-        target: [
-          matTable.graphId,
-          matTable.logicalName,
-          matTable.owner,
-          matTable.tableName,
-        ],
-        set: buildContributionOnConflictSet(
-          matTable.materializedAt,
-          params.materializedAt,
-        ),
-      });
-  }
-
-  const contributionMaterializer = createContributionMaterializer({
-    dialect: "sqlite",
-    fulltextStrategy,
-    fulltextTableName: tables.fulltextTableName,
-    execDdl: async (statement) => {
-      await db.run(sql.raw(statement));
-    },
-    ensureMarkerTable: ensureContributionMaterializationsTableImpl,
-    getMarker: getContributionMaterializationRow,
-    recordMarker: recordContributionMaterializationRow,
-  });
 
   // Shared by the "drizzle" branch of `transaction()` (TypeGraph opens
   // the tx) and `adoptTransaction()` (#134 — the caller already opened
@@ -1233,7 +1246,7 @@ export function createSqliteBackend(
       tableNames,
       fulltextStrategy,
       vectorStrategy,
-      vectorSlotLatch,
+      contributionMaterializer,
     });
     return gateFulltext(txBackend, contributionMaterializer.assertInitialized);
   }
@@ -1403,6 +1416,29 @@ export function createSqliteBackend(
       await contributionMaterializer.ensureRuntimeContributions(graphId);
     },
 
+    // Vector counterparts of the runtime-contribution methods. Present
+    // only when a vector strategy is wired (omitted on a plain SQLite
+    // connection with no vector extension), mirroring the embedding/
+    // search methods.
+    ...(vectorStrategy === undefined ?
+      {}
+    : {
+        async ensureVectorSlotContribution(
+          slot: VectorSlot,
+          options_?: Readonly<{ force?: boolean }>,
+        ): Promise<void> {
+          await contributionMaterializer.ensureVectorSlot(slot, options_);
+        },
+
+        async assertVectorSlotInitialized(slot: VectorSlot): Promise<void> {
+          await contributionMaterializer.assertVectorSlot(slot);
+        },
+
+        async deleteVectorSlotContribution(slot: VectorSlot): Promise<void> {
+          await contributionMaterializer.dropVectorSlot(slot);
+        },
+      }),
+
     async getReconciliationMarker(
       graphId: string,
     ): Promise<number | undefined> {
@@ -1509,7 +1545,7 @@ export function createSqliteBackend(
             tableNames,
             fulltextStrategy,
             vectorStrategy,
-            vectorSlotLatch,
+            contributionMaterializer,
           });
           // BEGIN IMMEDIATE, matching runSchemaWriteTransaction and the
           // "drizzle" branch below: take the reserved write lock at the start of
@@ -1603,12 +1639,12 @@ function createTransactionBackend(
       profileHints: options.profileHints,
     });
 
-  // A transaction-scoped backend gets its OWN per-field ensure-latch, never
-  // the outer process-global one. A `CREATE TABLE/INDEX` that runs inside the
-  // caller's transaction and then rolls back must not leave the shared latch
-  // marking the slot "ensured" — that would skip the re-CREATE and make every
-  // later write fail with "no such table". The fresh latch is discarded with
-  // the transaction, so the next write re-ensures idempotently.
+  // The transaction-scoped backend shares the outer backend's
+  // contribution materializer: the per-field vector table is provisioned
+  // (DDL) only by the privileged outer backend, so a tx-scoped vector op
+  // only ASSERTS the durable marker (SELECT, never DDL) and can't poison
+  // anything on rollback. The shared per-instance cache means a slot
+  // confirmed once stays a pure `Set.has` inside every later transaction.
   return createSqliteOperationBackend({
     capabilities: options.capabilities,
     db: options.db,
@@ -1617,9 +1653,7 @@ function createTransactionBackend(
     tableNames: options.tableNames,
     fulltextStrategy: options.fulltextStrategy,
     vectorStrategy: options.vectorStrategy,
-    ...(options.vectorStrategy === undefined ?
-      {}
-    : { vectorSlotLatch: createVectorSlotLatch() }),
+    contributionMaterializer: options.contributionMaterializer,
   });
 }
 

--- a/packages/typegraph/src/backend/drizzle/vector-runtime.ts
+++ b/packages/typegraph/src/backend/drizzle/vector-runtime.ts
@@ -1,89 +1,30 @@
 /**
- * Backend-runtime glue between a {@link VectorStrategy} and the Drizzle
- * SQLite / PostgreSQL backends. Holds the two responsibilities that belong
- * in the backend rather than the strategy:
+ * Backend-runtime glue between a `VectorStrategy` and the Drizzle
+ * SQLite / PostgreSQL backends. Holds the slot-construction and
+ * write-error-mapping responsibilities that belong in the backend rather
+ * than the strategy:
  *
- * 1. **Slot construction.** The backend stays graph-agnostic: it never
- *    inspects the graph/registry. The store resolves a field's
- *    `dimensions` / `metric` / `indexType` from the schema and threads
- *    them through `UpsertEmbeddingParams` / `VectorSearchParams` /
- *    `CreateVectorIndexParams`; these helpers reshape those params into the
- *    `VectorSlot` a strategy addresses its storage with.
- * 2. **The storage-ensure latch.** A per-storage-shape
- *    in-process latch that runs `strategy.ownedTables(slot).createDdl`
- *    (idempotent `CREATE ... IF NOT EXISTS`) once before the first write to
- *    a slot, so a write never hits a missing per-field table. Shared across
- *    the outer backend and every transaction-scoped backend within one
- *    `createBackend` call. `materializeIndexes()` creates the same storage
- *    idempotently, so the two never conflict.
+ * - **Slot construction.** The backend stays graph-agnostic: it never
+ *   inspects the graph/registry. The store resolves a field's
+ *   `dimensions` / `metric` / `indexType` from the schema and threads
+ *   them through `UpsertEmbeddingParams` / `VectorSearchParams` /
+ *   `CreateVectorIndexParams`; these helpers reshape those params into the
+ *   `VectorSlot` a strategy addresses its storage with.
+ * - **Write-error mapping.** Turns a raw engine dimension-mismatch into a
+ *   typed {@link EmbeddingDimensionChangedError} with actionable guidance.
+ *
+ * Per-field table creation is no longer done here: it rides the #135
+ * durable-contribution machinery (`createContributionMaterializer`),
+ * materialized by the privileged migrator at boot and asserted (SELECT,
+ * never DDL) on the runtime hot path — see `contribution-materializations.ts`.
  */
 import { EmbeddingDimensionChangedError } from "../../errors";
-import {
-  type VectorSlot,
-  type VectorStrategy,
-} from "../../query/dialect/vector-strategy";
+import { type VectorSlot } from "../../query/dialect/vector-strategy";
 import { parseDimensionMismatch } from "../../utils/sql-errors";
 import {
   type CreateVectorIndexParams,
   type DropVectorIndexParams,
 } from "../types";
-
-/**
- * In-process per-storage-shape storage-ensure latch. The DDL it runs is
- * idempotent, so re-running it is harmless; the latch only avoids redundant
- * round-trips and de-duplicates concurrent ensures.
- */
-export type VectorSlotLatch = Readonly<{
-  ensure: (
-    strategy: VectorStrategy,
-    slot: VectorSlot,
-    execDdl: (statement: string) => Promise<void>,
-  ) => Promise<void>;
-}>;
-
-function vectorSlotKey(slot: VectorSlot): string {
-  // JSON of the storage-shaping fields: collision-safe across arbitrary
-  // graph/kind/field strings (a raw delimiter could otherwise appear in a name).
-  // Metric and index type matter even when the physical table name does not:
-  // libSQL folds DiskANN DDL into `ownedTables` only for ANN slots, and
-  // sqlite-vec bakes the metric into its virtual-table declaration.
-  return JSON.stringify([
-    slot.graphId,
-    slot.nodeKind,
-    slot.fieldPath,
-    slot.dimensions,
-    slot.metric,
-    slot.indexType,
-  ]);
-}
-
-export function createVectorSlotLatch(): VectorSlotLatch {
-  const inFlight = new Map<string, Promise<void>>();
-
-  return {
-    ensure(strategy, slot, execDdl): Promise<void> {
-      const key = vectorSlotKey(slot);
-      const existing = inFlight.get(key);
-      if (existing !== undefined) return existing;
-
-      const run = (async (): Promise<void> => {
-        for (const contribution of strategy.ownedTables(slot)) {
-          for (const statement of contribution.createDdl) {
-            await execDdl(statement);
-          }
-        }
-      })();
-      // Cache only the successful resolution: a failed CREATE (e.g. a
-      // transient lock) must not poison the slot so the next write retries.
-      const cached = run.catch((error: unknown) => {
-        inFlight.delete(key);
-        throw error;
-      });
-      inFlight.set(key, cached);
-      return cached;
-    },
-  };
-}
 
 /**
  * Placeholder dimension for slots built from params that don't carry one

--- a/packages/typegraph/src/backend/migrate-vectors.ts
+++ b/packages/typegraph/src/backend/migrate-vectors.ts
@@ -224,10 +224,20 @@ export async function migrateLegacyEmbeddings(
     );
   }
   const upsertEmbedding = backend.upsertEmbedding;
+  const ensureVectorSlotContribution = backend.ensureVectorSlotContribution;
 
   const perField: Record<string, number> = {};
   const skippedDimensionMismatch: Record<string, number> = {};
   const skippedDecodeError: Record<string, number> = {};
+  // (kind, field) slots whose per-field table + durable marker this run has
+  // already provisioned. `upsertEmbedding` asserts the marker (#135) and no
+  // longer self-creates the table, so this offline migration (privileged)
+  // provisions each slot once — at the first row's dimension, which fixes the
+  // typed table just as the original lazy write did. Differently-sized later
+  // rows for the same slot are skipped by the dimension-mismatch path below,
+  // so the ensure is deliberately NOT re-run per row (that would trip the
+  // marker drift-guard).
+  const ensuredSlots = new Set<string>();
   let migrated = 0;
 
   let cursor: LegacyRowCursor | undefined;
@@ -271,20 +281,36 @@ export async function migrateLegacyEmbeddings(
         continue;
       }
       const config = resolveSlotConfig?.(row.node_kind, row.field_path);
+      // The decoded length is the authoritative fixed dimension — the
+      // strategy provisions its column type (e.g. `F32_BLOB(N)`) from it.
+      const slot = {
+        graphId: row.graph_id,
+        nodeKind: row.node_kind,
+        fieldPath: row.field_path,
+        dimensions: embedding.length,
+        metric: config?.metric ?? DEFAULT_SLOT_METRIC,
+        indexType: config?.indexType ?? DEFAULT_SLOT_INDEX_TYPE,
+      };
+
+      // Provision the per-field table + durable marker before the first
+      // write into this slot. Once per (graph, kind, field): the first row's
+      // dimension fixes the table. Keyed by graph id too — the legacy table
+      // is graph-scoped, so the same `kind.field` can recur across graphs.
+      const ensuredKey = JSON.stringify([
+        row.graph_id,
+        row.node_kind,
+        row.field_path,
+      ]);
+      if (
+        ensureVectorSlotContribution !== undefined &&
+        !ensuredSlots.has(ensuredKey)
+      ) {
+        await ensureVectorSlotContribution(slot);
+        ensuredSlots.add(ensuredKey);
+      }
 
       try {
-        await upsertEmbedding({
-          graphId: row.graph_id,
-          nodeKind: row.node_kind,
-          nodeId: row.node_id,
-          fieldPath: row.field_path,
-          embedding,
-          // The decoded length is the authoritative fixed dimension — the
-          // strategy provisions its column type (e.g. `F32_BLOB(N)`) from it.
-          dimensions: embedding.length,
-          metric: config?.metric ?? DEFAULT_SLOT_METRIC,
-          indexType: config?.indexType ?? DEFAULT_SLOT_INDEX_TYPE,
-        });
+        await upsertEmbedding({ ...slot, nodeId: row.node_id, embedding });
       } catch (error) {
         // The legacy shared column allowed mixed dimensions for one
         // (nodeKind, fieldPath); the per-field table is fixed at the first

--- a/packages/typegraph/src/backend/migrate-vectors.ts
+++ b/packages/typegraph/src/backend/migrate-vectors.ts
@@ -230,14 +230,16 @@ export async function migrateLegacyEmbeddings(
   const skippedDimensionMismatch: Record<string, number> = {};
   const skippedDecodeError: Record<string, number> = {};
   // (kind, field) slots whose per-field table + durable marker this run has
-  // already provisioned. `upsertEmbedding` asserts the marker (#135) and no
-  // longer self-creates the table, so this offline migration (privileged)
-  // provisions each slot once — at the first row's dimension, which fixes the
-  // typed table just as the original lazy write did. Differently-sized later
-  // rows for the same slot are skipped by the dimension-mismatch path below,
-  // so the ensure is deliberately NOT re-run per row (that would trip the
-  // marker drift-guard).
-  const ensuredSlots = new Set<string>();
+  // already provisioned, mapped to the dimension the table was fixed at.
+  // `upsertEmbedding` asserts the marker (#135) and no longer self-creates
+  // the table, so this offline migration (privileged) provisions each slot
+  // once — at the first row's dimension, which fixes the typed table just as
+  // the original lazy write did. Differently-sized later rows for the same
+  // slot are detected against this map and skipped BEFORE the upsert: the
+  // marker assert would otherwise read the differently-dimensioned slot as
+  // stale and abort the whole migration, and the ensure is deliberately not
+  // re-run per row (that would trip the marker drift-guard).
+  const ensuredSlots = new Map<string, number>();
   let migrated = 0;
 
   let cursor: LegacyRowCursor | undefined;
@@ -306,7 +308,22 @@ export async function migrateLegacyEmbeddings(
         !ensuredSlots.has(ensuredKey)
       ) {
         await ensureVectorSlotContribution(slot);
-        ensuredSlots.add(ensuredKey);
+        ensuredSlots.set(ensuredKey, slot.dimensions);
+      }
+
+      // The legacy shared column allowed mixed dimensions for one
+      // (nodeKind, fieldPath); the per-field table is fixed at the first
+      // migrated row's dimension. Skip a differently-sized row up front —
+      // its slot would fail the marker assert as stale (different
+      // signature), aborting the migration instead of skipping the row.
+      const provisionedDimensions = ensuredSlots.get(ensuredKey);
+      if (
+        provisionedDimensions !== undefined &&
+        provisionedDimensions !== embedding.length
+      ) {
+        skippedDimensionMismatch[slotKey] =
+          (skippedDimensionMismatch[slotKey] ?? 0) + 1;
+        continue;
       }
 
       try {

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1431,11 +1431,16 @@ export type GraphBackend = Readonly<{
    * the privileged role. Pass `{ force: true }` to overwrite the marker
    * at the current signature, bypassing the drift-guard — the sanctioned
    * path `store.reembedVectorField()` uses after recreating storage at a
-   * new dimension. Present only on backends wired with a vector strategy.
+   * new dimension. Pass `{ onDrift: "skip" }` to leave an
+   * already-provisioned slot whose shape has since changed untouched
+   * (warn + no-op) instead of refusing — the boot/evolve path, so a
+   * declared dimension change never blocks startup before the operator
+   * can run `reembedVectorField`. Present only on backends wired with a
+   * vector strategy.
    */
   ensureVectorSlotContribution?: (
     slot: VectorSlot,
-    options?: Readonly<{ force?: boolean }>,
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
   ) => Promise<void>;
 
   /**

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -13,7 +13,10 @@ import {
 } from "../core/types";
 import { type SqlTableNames } from "../query/compiler/schema";
 import { type FulltextStrategy } from "../query/dialect/fulltext-strategy";
-import { type VectorStrategy } from "../query/dialect/vector-strategy";
+import {
+  type VectorSlot,
+  type VectorStrategy,
+} from "../query/dialect/vector-strategy";
 import {
   type CompiledRowsSql,
   type CompiledStatementSql,
@@ -1417,6 +1420,45 @@ export type GraphBackend = Readonly<{
    * records the marker (success or failure) keyed by `graphId`.
    */
   ensureRuntimeContributions?: (graphId: string) => Promise<void>;
+
+  /**
+   * Privileged materializer for one embedding `(kind, field)` slot's
+   * `ownedTables` contribution(s): creates the per-field vector table and
+   * records its durable marker, idempotently. The vector counterpart of
+   * `ensureRuntimeContributions` — vectors are per-`(kind, field)` and
+   * graph-derived, so the store enumerates slots (via
+   * `resolveEmbeddingFields`) and calls this once per slot at boot under
+   * the privileged role. Pass `{ force: true }` to overwrite the marker
+   * at the current signature, bypassing the drift-guard — the sanctioned
+   * path `store.reembedVectorField()` uses after recreating storage at a
+   * new dimension. Present only on backends wired with a vector strategy.
+   */
+  ensureVectorSlotContribution?: (
+    slot: VectorSlot,
+    options?: Readonly<{ force?: boolean }>,
+  ) => Promise<void>;
+
+  /**
+   * SELECT-only gate for one embedding `(kind, field)` slot: asserts the
+   * durable marker(s) for the slot's `ownedTables` contribution(s),
+   * cached per backend instance. Throws `StoreNotInitializedError` when
+   * the slot is missing, stale (signature drift), or recorded a failed
+   * last attempt. The vector counterpart of
+   * `assertRuntimeContributionsInitialized`, consulted by the verified
+   * runtime attach. Performs ZERO DDL and ZERO writes. Present only on
+   * backends wired with a vector strategy.
+   */
+  assertVectorSlotInitialized?: (slot: VectorSlot) => Promise<void>;
+
+  /**
+   * Forget one embedding `(kind, field)` slot's durable contribution
+   * marker(s). Called after the slot's per-field table is dropped
+   * (vector-field reclaim) so a later `ensureVectorSlotContribution`
+   * re-creates the table instead of trusting an orphaned "initialized"
+   * marker. Does NOT drop the table itself (the caller already did).
+   * Present only on backends wired with a vector strategy.
+   */
+  deleteVectorSlotContribution?: (slot: VectorSlot) => Promise<void>;
 
   /**
    * Bootstraps the fulltext storage table the active `FulltextStrategy`

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1427,7 +1427,7 @@ export type GraphBackend = Readonly<{
    * records its durable marker, idempotently. The vector counterpart of
    * `ensureRuntimeContributions` — vectors are per-`(kind, field)` and
    * graph-derived, so the store enumerates slots (via
-   * `resolveEmbeddingFields`) and calls this once per slot at boot under
+   * `resolveEmbeddingFields`) and uses the batch counterpart at boot under
    * the privileged role. Pass `{ force: true }` to overwrite the marker
    * at the current signature, bypassing the drift-guard — the sanctioned
    * path `store.reembedVectorField()` uses after recreating storage at a
@@ -1444,6 +1444,16 @@ export type GraphBackend = Readonly<{
   ) => Promise<void>;
 
   /**
+   * Batch form of `ensureVectorSlotContribution`, used by privileged boot to
+   * resolve every slot's durable markers with one graph-scoped query. The
+   * singular method remains available for re-embedding and compatibility.
+   */
+  ensureVectorSlotContributions?: (
+    slots: readonly VectorSlot[],
+    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
+  ) => Promise<void>;
+
+  /**
    * SELECT-only gate for one embedding `(kind, field)` slot: asserts the
    * durable marker(s) for the slot's `ownedTables` contribution(s),
    * cached per backend instance. Throws `StoreNotInitializedError` when
@@ -1454,6 +1464,14 @@ export type GraphBackend = Readonly<{
    * backends wired with a vector strategy.
    */
   assertVectorSlotInitialized?: (slot: VectorSlot) => Promise<void>;
+
+  /**
+   * Batch form of `assertVectorSlotInitialized`, used by verified attach to
+   * resolve every slot's durable markers with one graph-scoped query.
+   */
+  assertVectorSlotsInitialized?: (
+    slots: readonly VectorSlot[],
+  ) => Promise<void>;
 
   /**
    * Forget one embedding `(kind, field)` slot's durable contribution

--- a/packages/typegraph/src/core/embedding.ts
+++ b/packages/typegraph/src/core/embedding.ts
@@ -6,6 +6,9 @@
  */
 import { z } from "zod";
 
+import type { VectorSlot } from "../query/dialect/vector-strategy";
+import type { GraphDef } from "./define-graph";
+
 // ============================================================
 // Embedding Brand Symbol
 // ============================================================
@@ -329,6 +332,35 @@ export function resolveEmbeddingFields(
     });
   }
   return fields;
+}
+
+/**
+ * Enumerates every embedding `(kind, field)` slot a graph declares, as a
+ * fully-resolved {@link VectorSlot}. The single source of truth for "what
+ * vector slots does this graph have?", shared by the privileged boot
+ * materializer (`materializeVectorContributions`) and the verified-attach
+ * gate (`assertVectorContributionsInitialized`) so the two can never
+ * provision and assert different sets. Walks `graph.nodes` and reuses
+ * {@link resolveEmbeddingFields} per node schema.
+ */
+export function resolveGraphVectorSlots(
+  graph: GraphDef,
+): readonly VectorSlot[] {
+  const slots: VectorSlot[] = [];
+  for (const registration of Object.values(graph.nodes)) {
+    const node = registration.type;
+    for (const field of resolveEmbeddingFields(node.schema)) {
+      slots.push({
+        graphId: graph.id,
+        nodeKind: node.kind,
+        fieldPath: field.fieldPath,
+        dimensions: field.dimensions,
+        metric: field.metric,
+        indexType: field.indexType,
+      });
+    }
+  }
+  return slots;
 }
 
 function resolveEmbeddingDimensions(schema: z.ZodType): number | undefined {

--- a/packages/typegraph/src/core/index.ts
+++ b/packages/typegraph/src/core/index.ts
@@ -14,6 +14,7 @@ export {
   type EmbeddingValue,
   getEmbeddingDimensions,
   isEmbeddingSchema,
+  resolveGraphVectorSlots,
 } from "./embedding";
 
 // Searchable type for fulltext search

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -1046,14 +1046,14 @@ export type StoreNotInitializedErrorDetails = Readonly<{
   Readonly<Record<string, unknown>>;
 
 /**
- * Thrown when a fulltext-dependent operation runs against a connection
- * whose strategy-owned storage has not been durably materialized.
+ * Thrown when a fulltext- or vector-dependent operation runs against a
+ * connection whose strategy-owned storage has not been durably materialized.
  *
  * `createStore()` is a synchronous, zero-I/O attach: it never creates
  * tables, repairs DDL, or writes materialization markers. The durable
  * marker is written exclusively by the async boot path
- * (`createStoreWithSchema`). When a fulltext read/write — or an
- * adopted/business transaction — observes no valid marker, it refuses
+ * (`createStoreWithSchema`). When a fulltext or embedding read/write — or
+ * an adopted/business transaction — observes no valid marker, it refuses
  * loudly here instead of lazily emitting DDL on the hot path.
  */
 export class StoreNotInitializedError extends TypeGraphError {
@@ -1074,7 +1074,8 @@ export class StoreNotInitializedError extends TypeGraphError {
     },
   ) {
     super(
-      `fulltext storage for graph "${graphId}" ${STORE_NOT_INITIALIZED_REASON_PHRASE[reason]}. ` +
+      `${storageLabelFromLogicalName(options?.details?.logicalName)} for ` +
+        `graph "${graphId}" ${STORE_NOT_INITIALIZED_REASON_PHRASE[reason]}. ` +
         `Run createStoreWithSchema(graph, backend) during application boot, ` +
         `outside request handlers and adopted transactions, before using createStore().`,
       "STORE_NOT_INITIALIZED",
@@ -1090,6 +1091,23 @@ export class StoreNotInitializedError extends TypeGraphError {
     );
     this.name = "StoreNotInitializedError";
   }
+}
+
+/**
+ * Human label for the un-materialized storage, derived from the
+ * contribution `logicalName`: fulltext keeps "fulltext storage"; a vector
+ * slot ("vector:&lt;kind&gt;.&lt;field&gt;") reads as `vector storage
+ * "&lt;kind&gt;.&lt;field&gt;"` so the message names the exact embedding
+ * field. Falls back to a neutral phrase when no logical name is supplied.
+ */
+function storageLabelFromLogicalName(logicalName: unknown): string {
+  if (typeof logicalName !== "string") return "runtime storage";
+  const VECTOR_PREFIX = "vector:";
+  if (logicalName.startsWith(VECTOR_PREFIX)) {
+    return `vector storage "${logicalName.slice(VECTOR_PREFIX.length)}"`;
+  }
+  if (logicalName === "fulltext") return "fulltext storage";
+  return `"${logicalName}" storage`;
 }
 
 // ============================================================

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -1076,21 +1076,63 @@ export class StoreNotInitializedError extends TypeGraphError {
     super(
       `${storageLabelFromLogicalName(options?.details?.logicalName)} for ` +
         `graph "${graphId}" ${STORE_NOT_INITIALIZED_REASON_PHRASE[reason]}. ` +
-        `Run createStoreWithSchema(graph, backend) during application boot, ` +
-        `outside request handlers and adopted transactions, before using createStore().`,
+        storeNotInitializedAction(reason, options?.details?.logicalName),
       "STORE_NOT_INITIALIZED",
       {
         details: { ...options?.details, graphId, reason },
         category: "user",
         suggestion:
-          "Call createStoreWithSchema(graph, backend) once at application " +
-          "startup. createStore() attaches to an already-initialized " +
-          "database and does not materialize storage itself.",
+          isStaleVectorSlot(reason, options?.details?.logicalName) ?
+            "The field's declared shape (e.g. its dimension) changed after " +
+            "its storage was provisioned. Run store.reembedVectorField(" +
+            "kind, fieldPath) to recreate the storage at the new shape and " +
+            "re-embed."
+          : "Call createStoreWithSchema(graph, backend) once at application " +
+            "startup. createStore() attaches to an already-initialized " +
+            "database and does not materialize storage itself.",
         cause: options?.cause,
       },
     );
     this.name = "StoreNotInitializedError";
   }
+}
+
+const VECTOR_LOGICAL_NAME_PREFIX = "vector:";
+
+/**
+ * A stale VECTOR slot is its own failure mode: the storage exists but was
+ * provisioned at a different shape (the declared dimension changed), and
+ * the fix is `store.reembedVectorField`, not a re-run of
+ * `createStoreWithSchema` (whose boot pass deliberately skips drifted
+ * slots). Drives the action sentence and the suggestion.
+ */
+function isStaleVectorSlot(
+  reason: StoreNotInitializedReason,
+  logicalName: unknown,
+): boolean {
+  return (
+    reason === "stale" &&
+    typeof logicalName === "string" &&
+    logicalName.startsWith(VECTOR_LOGICAL_NAME_PREFIX)
+  );
+}
+
+/** The actionable trailing sentence of the error message, per failure mode. */
+function storeNotInitializedAction(
+  reason: StoreNotInitializedReason,
+  logicalName: unknown,
+): string {
+  if (isStaleVectorSlot(reason, logicalName)) {
+    return (
+      `The declared shape changed after provisioning — run ` +
+      `store.reembedVectorField(kind, fieldPath) to recreate the storage ` +
+      `at the new shape.`
+    );
+  }
+  return (
+    `Run createStoreWithSchema(graph, backend) during application boot, ` +
+    `outside request handlers and adopted transactions, before using createStore().`
+  );
 }
 
 /**
@@ -1102,9 +1144,8 @@ export class StoreNotInitializedError extends TypeGraphError {
  */
 function storageLabelFromLogicalName(logicalName: unknown): string {
   if (typeof logicalName !== "string") return "runtime storage";
-  const VECTOR_PREFIX = "vector:";
-  if (logicalName.startsWith(VECTOR_PREFIX)) {
-    return `vector storage "${logicalName.slice(VECTOR_PREFIX.length)}"`;
+  if (logicalName.startsWith(VECTOR_LOGICAL_NAME_PREFIX)) {
+    return `vector storage "${logicalName.slice(VECTOR_LOGICAL_NAME_PREFIX.length)}"`;
   }
   if (logicalName === "fulltext") return "fulltext storage";
   return `"${logicalName}" storage`;

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -91,6 +91,9 @@ export {
   metaEdge,
   type NodeKinds,
   type RecordedInstant,
+  // Vector-slot enumeration for manual provisioning (the boot step
+  // createStoreWithSchema performs via backend.ensureVectorSlotContribution)
+  resolveGraphVectorSlots,
   // Searchable type for fulltext search
   searchable,
   type SearchableMetadata,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -9,6 +9,7 @@
  */
 import { type GraphBackend, type SchemaVersionRow } from "../backend/types";
 import { type GraphDef } from "../core/define-graph";
+import { resolveGraphVectorSlots } from "../core/embedding";
 import {
   ConfigurationError,
   DatabaseOperationError,
@@ -472,11 +473,38 @@ export async function loadAndVerifyGraph<G extends GraphDef>(
   }
 
   await backend.assertRuntimeContributionsInitialized?.(merged.id);
+  await assertVectorContributionsInitialized(backend, merged);
   return {
     graph: merged,
     activeRow,
     result: { status: "unchanged", version: activeRow.version },
   };
+}
+
+/**
+ * SELECT-only verification that every embedding `(kind, field)` slot's
+ * durable contribution marker is initialized — the vector counterpart of
+ * `backend.assertRuntimeContributionsInitialized` (which covers fulltext).
+ * Keeps `createVerifiedStore`'s "throws when runtime-contribution markers
+ * are missing/stale" guarantee honest for vectors: without it the verified
+ * attach would pass but the first vector op would then throw. Enumerated
+ * from the merged graph (same idiom as the privileged boot materializer);
+ * a no-op on backends without vector support or graphs with no embeddings.
+ */
+async function assertVectorContributionsInitialized(
+  backend: GraphBackend,
+  graph: GraphDef,
+): Promise<void> {
+  const assertVectorSlotInitialized = backend.assertVectorSlotInitialized;
+  if (
+    assertVectorSlotInitialized === undefined ||
+    backend.capabilities.vector?.supported !== true
+  ) {
+    return;
+  }
+  for (const slot of resolveGraphVectorSlots(graph)) {
+    await assertVectorSlotInitialized(slot);
+  }
 }
 
 function schemaBehindError(

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -495,14 +495,16 @@ async function assertVectorContributionsInitialized(
   backend: GraphBackend,
   graph: GraphDef,
 ): Promise<void> {
-  const assertVectorSlotInitialized = backend.assertVectorSlotInitialized;
-  if (
-    assertVectorSlotInitialized === undefined ||
-    backend.capabilities.vector?.supported !== true
-  ) {
+  if (backend.capabilities.vector?.supported !== true) return;
+  const slots = resolveGraphVectorSlots(graph);
+  const assertVectorSlotsInitialized = backend.assertVectorSlotsInitialized;
+  if (assertVectorSlotsInitialized !== undefined) {
+    await assertVectorSlotsInitialized(slots);
     return;
   }
-  for (const slot of resolveGraphVectorSlots(graph)) {
+  const assertVectorSlotInitialized = backend.assertVectorSlotInitialized;
+  if (assertVectorSlotInitialized === undefined) return;
+  for (const slot of slots) {
     await assertVectorSlotInitialized(slot);
   }
 }

--- a/packages/typegraph/src/store/materialize-removals.ts
+++ b/packages/typegraph/src/store/materialize-removals.ts
@@ -511,7 +511,7 @@ function buildEmbeddingTableCleanup(
     const slots = await resolveRemovedKindEmbeddingSlots(ctx.backend, row);
     await Promise.all(
       slots.map((slot) =>
-        dropVectorSlotStorage(vectorStrategy, executeDdl, slot),
+        dropVectorSlotStorage(ctx.backend, vectorStrategy, executeDdl, slot),
       ),
     );
   })();
@@ -527,6 +527,7 @@ function buildEmbeddingTableCleanup(
  * removed-field reclamation so both reclaim storage the same way.
  */
 async function dropVectorSlotStorage(
+  backend: GraphBackend,
   strategy: VectorStrategy,
   executeDdl: (statement: string) => Promise<void>,
   slot: VectorSlot,
@@ -538,6 +539,12 @@ async function dropVectorSlotStorage(
   } catch (error) {
     if (!isMissingTableError(error)) throw error;
   }
+  // Forget the slot's durable contribution marker(s) in lockstep with the
+  // table drop (#135), so a later re-add of the same `(kind, field)` field
+  // re-creates the table instead of trusting an orphaned "initialized"
+  // marker. Runs even when the table was already absent — the marker can
+  // outlive the table. No-op on backends without the vector marker method.
+  await backend.deleteVectorSlotContribution?.(slot);
 }
 
 /**
@@ -686,7 +693,12 @@ async function reclaimRemovedVectorFieldTables(
     // materialized field has nothing to reclaim), so reaching the catch means
     // a genuine failure.
     try {
-      await dropVectorSlotStorage(vectorStrategy, executeDdl, field.slot);
+      await dropVectorSlotStorage(
+        backend,
+        vectorStrategy,
+        executeDdl,
+        field.slot,
+      );
       results.push({
         kind: field.kind,
         fieldPath: field.fieldPath,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -37,7 +37,10 @@ import {
   isKnownKind,
   type NodeKinds,
 } from "../core/define-graph";
-import { resolveEmbeddingFields } from "../core/embedding";
+import {
+  resolveEmbeddingFields,
+  resolveGraphVectorSlots,
+} from "../core/embedding";
 import {
   asRecordedInstant,
   type ReadCoordinate,
@@ -2396,6 +2399,15 @@ export class Store<G extends GraphDef> {
       merged,
       activeRow.version,
     );
+    // Provision per-field vector tables + durable markers for any embedding
+    // fields this evolution introduced (idempotent for fields that already
+    // existed). `evolve()` is a privileged migrator path — it commits schema
+    // versions and runs index DDL in eager mode — so emitting the table DDL
+    // here mirrors how `createStoreWithSchema` provisions at first boot, and
+    // keeps a runtime write to a freshly-added embedding field from hitting
+    // an unmaterialized slot. The shared fulltext table needs no such step
+    // (one table for all kinds); vectors are per-`(kind, field)`.
+    await materializeVectorContributions(this.#backend, merged);
     const evolved = this.#cloneWithGraph(
       merged,
       options?.ref,
@@ -2580,18 +2592,26 @@ export class Store<G extends GraphDef> {
       indexType: declaration.indexType,
     };
 
-    // Recreate storage at the new dimension: drop, then re-emit the table DDL
-    // the strategy owns (libSQL/sqlite-vec also (re)create their index/vtable
-    // here; pgvector's index is built via createVectorIndex below). Run via
-    // executeDdl directly so it bypasses the ensure-latch, which may still
-    // record the pre-drop slot as ensured.
+    // Recreate storage at the new dimension: drop, then re-create the per-
+    // field table the strategy owns (libSQL/sqlite-vec also (re)create their
+    // index/vtable here; pgvector's index is built via createVectorIndex
+    // below). `ensureVectorSlotContribution({ force: true })` re-runs the
+    // table DDL AND re-stamps the durable contribution marker at the new
+    // signature, bypassing the drift-guard — this is the sanctioned shape
+    // change. Without the marker reset, the post-reembed runtime assert would
+    // see a stale marker and refuse every write. Backends without the marker
+    // method (custom, pre-#135) fall back to raw recreate DDL.
     for (const ddl of strategy.buildDropStorage(slot)) {
       await backend.executeDdl(ddl);
     }
-    for (const contribution of strategy.ownedTables(slot)) {
-      for (const ddl of contribution.createDdl) {
-        await backend.executeDdl(ddl);
+    if (backend.ensureVectorSlotContribution === undefined) {
+      for (const contribution of strategy.ownedTables(slot)) {
+        for (const ddl of contribution.createDdl) {
+          await backend.executeDdl(ddl);
+        }
       }
+    } else {
+      await backend.ensureVectorSlotContribution(slot, { force: true });
     }
 
     // Whether this backend would actually materialize an ANN index for the
@@ -3384,6 +3404,33 @@ async function materializeRuntimeContributions(
   await backend.ensureFulltextTable?.(graphId);
 }
 
+/**
+ * Privileged boot step: materialize every embedding `(kind, field)` slot's
+ * per-field vector table + durable marker, enumerated from the graph via
+ * {@link resolveGraphVectorSlots}. The vector counterpart of
+ * {@link materializeRuntimeContributions} (fulltext) — runs once under the
+ * privileged role inside `createStoreWithSchema` so a least-privilege runtime
+ * can assert the markers (a cached SELECT) and write embeddings without
+ * holding `CREATE` on the schema. No-op on backends without vector support
+ * (`ensureVectorSlotContribution` absent, or `capabilities.vector` unsupported)
+ * and for graphs that declare no embedding fields.
+ */
+async function materializeVectorContributions(
+  backend: GraphBackend,
+  graph: GraphDef,
+): Promise<void> {
+  const ensureVectorSlotContribution = backend.ensureVectorSlotContribution;
+  if (
+    ensureVectorSlotContribution === undefined ||
+    backend.capabilities.vector?.supported !== true
+  ) {
+    return;
+  }
+  for (const slot of resolveGraphVectorSlots(graph)) {
+    await ensureVectorSlotContribution(slot);
+  }
+}
+
 // ============================================================
 // Async Factory with Schema Management
 // ============================================================
@@ -3466,6 +3513,10 @@ export async function createStoreWithSchema<G extends GraphDef>(
   // first — otherwise contribution DDL derived from the new code graph
   // would hit a stale table shape and mask `MigrationError`.
   await materializeRuntimeContributions(backend, merged.id);
+  // Provision every embedding field's per-`(kind, field)` vector table +
+  // durable marker under the privileged role, so a least-privilege runtime
+  // asserts the markers (SELECT) and writes embeddings without `CREATE`.
+  await materializeVectorContributions(backend, merged);
 
   const store = new Store(
     merged,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -3414,6 +3414,13 @@ async function materializeRuntimeContributions(
  * holding `CREATE` on the schema. No-op on backends without vector support
  * (`ensureVectorSlotContribution` absent, or `capabilities.vector` unsupported)
  * and for graphs that declare no embedding fields.
+ *
+ * `onDrift: "skip"`: a slot already provisioned at a DIFFERENT shape (the
+ * declared dimension changed since the table was created) is warned about
+ * and left untouched rather than refused — boot must stay reachable so the
+ * operator can run `store.reembedVectorField(kind, fieldPath)`, the
+ * sanctioned recreate-and-restamp path. Until then, writes to that slot
+ * fail with a typed `stale` StoreNotInitializedError.
  */
 async function materializeVectorContributions(
   backend: GraphBackend,
@@ -3427,7 +3434,7 @@ async function materializeVectorContributions(
     return;
   }
   for (const slot of resolveGraphVectorSlots(graph)) {
-    await ensureVectorSlotContribution(slot);
+    await ensureVectorSlotContribution(slot, { onDrift: "skip" });
   }
 }
 

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -3412,8 +3412,9 @@ async function materializeRuntimeContributions(
  * privileged role inside `createStoreWithSchema` so a least-privilege runtime
  * can assert the markers (a cached SELECT) and write embeddings without
  * holding `CREATE` on the schema. No-op on backends without vector support
- * (`ensureVectorSlotContribution` absent, or `capabilities.vector` unsupported)
- * and for graphs that declare no embedding fields.
+ * (both vector contribution methods absent, or `capabilities.vector`
+ * unsupported) and for graphs that declare no embedding fields. Built-in
+ * backends use the batch method; the singular loop is the compatibility path.
  *
  * `onDrift: "skip"`: a slot already provisioned at a DIFFERENT shape (the
  * declared dimension changed since the table was created) is warned about
@@ -3426,14 +3427,16 @@ async function materializeVectorContributions(
   backend: GraphBackend,
   graph: GraphDef,
 ): Promise<void> {
-  const ensureVectorSlotContribution = backend.ensureVectorSlotContribution;
-  if (
-    ensureVectorSlotContribution === undefined ||
-    backend.capabilities.vector?.supported !== true
-  ) {
+  if (backend.capabilities.vector?.supported !== true) return;
+  const slots = resolveGraphVectorSlots(graph);
+  const ensureVectorSlotContributions = backend.ensureVectorSlotContributions;
+  if (ensureVectorSlotContributions !== undefined) {
+    await ensureVectorSlotContributions(slots, { onDrift: "skip" });
     return;
   }
-  for (const slot of resolveGraphVectorSlots(graph)) {
+  const ensureVectorSlotContribution = backend.ensureVectorSlotContribution;
+  if (ensureVectorSlotContribution === undefined) return;
+  for (const slot of slots) {
     await ensureVectorSlotContribution(slot, { onDrift: "skip" });
   }
 }

--- a/packages/typegraph/tests/backends/postgres/migrate-vectors.test.ts
+++ b/packages/typegraph/tests/backends/postgres/migrate-vectors.test.ts
@@ -64,6 +64,15 @@ beforeEach(async () => {
   for (const { tablename } of tables.rows) {
     await sharedPool.query(`DROP TABLE IF EXISTS "${tablename}" CASCADE`);
   }
+  // Drop the durable contribution markers (#135) in lockstep with the per-
+  // field tables above: `migrateLegacyEmbeddings` now provisions each slot via
+  // `ensureVectorSlotContribution`, which trusts the marker and skips the
+  // CREATE when one already exists. On this shared, long-lived database a
+  // marker left over from a prior run would outlive the dropped table and the
+  // migration's first write would hit a missing relation.
+  await sharedPool.query(
+    `DROP TABLE IF EXISTS "typegraph_contribution_materializations" CASCADE`,
+  );
 });
 
 type LegacySeed = Readonly<{

--- a/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
@@ -27,7 +27,7 @@ import { defineGraph, defineNode, embedding } from "../../../src";
 import { generatePostgresDDL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import { createLocalPgliteBackend } from "../../../src/backend/postgres/pglite";
-import { createStore } from "../../../src/store";
+import { createStore, createStoreWithSchema } from "../../../src/store";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string(), email: z.string().optional() }),
@@ -87,7 +87,7 @@ describe("PGlite backend", () => {
       cleanups.push(() => backend.close());
       expect(backend.capabilities.vector?.supported).toBe(true);
 
-      const store = createStore(documentsGraph, backend);
+      const [store] = await createStoreWithSchema(documentsGraph, backend);
       await store.nodes.Doc.create({ title: "near", embedding: [1, 0, 0, 0] });
       await store.nodes.Doc.create({ title: "far", embedding: [0, 0, 0, 1] });
 
@@ -139,7 +139,7 @@ describe("PGlite backend", () => {
       cleanups.push(() => backend.close());
       expect(backend.capabilities.vector?.supported).toBe(true);
 
-      const store = createStore(documentsGraph, backend);
+      const [store] = await createStoreWithSchema(documentsGraph, backend);
       await store.nodes.Doc.create({ title: "only", embedding: [0, 1, 0, 0] });
       const hits = await store.search.vector("Doc", {
         fieldPath: "embedding",
@@ -155,11 +155,17 @@ describe("PGlite backend", () => {
       cleanups.push(() => rm(dataDir, { recursive: true, force: true }));
 
       // Session 1: write a node + embedding, then close to flush to disk.
+      // createStoreWithSchema provisions the per-field vector table + marker
+      // (both persist to the dataDir for session 2 to assert against).
       const first = await createLocalPgliteBackend({ dataDir });
-      const created = await createStore(
+      const [firstStore] = await createStoreWithSchema(
         documentsGraph,
         first.backend,
-      ).nodes.Doc.create({ title: "persisted", embedding: [1, 0, 0, 0] });
+      );
+      const created = await firstStore.nodes.Doc.create({
+        title: "persisted",
+        embedding: [1, 0, 0, 0],
+      });
       await first.backend.close();
 
       // Session 2: reopen the same dataDir — the node and its embedding

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -30,7 +30,7 @@ import {
   createPostgresTables,
 } from "../../../src/backend/postgres";
 import { rowPropsToObject } from "../../../src/backend/types";
-import { createStore } from "../../../src/store";
+import { createStore, createStoreWithSchema } from "../../../src/store";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
 
@@ -168,6 +168,12 @@ async function clearTestData(): Promise<void> {
   // can outrank fresh ones and cause missing hits). The materialization
   // status tables also carry graph-id scoped completion markers, so stale
   // rows there can make a fresh graph cleanup look already completed.
+  //
+  // The durable contribution markers (#135) are cleared alongside the data so
+  // each test starts genuinely un-provisioned and the integration suite's
+  // per-test createStoreWithSchema re-materializes every per-field vector
+  // table + marker in lockstep. Otherwise a marker could outlive a dropped
+  // table on this shared database and a later boot would skip the CREATE.
   await sharedPool.query(
     `TRUNCATE typegraph_index_materializations,
               typegraph_contribution_materializations,
@@ -181,12 +187,13 @@ async function clearTestData(): Promise<void> {
               typegraph_nodes,
               typegraph_edges,
               typegraph_node_uniques,
+              typegraph_contribution_materializations,
               typegraph_schema_versions CASCADE`,
   );
 
-  // Per-(kind, field) vector tables are created lazily by the strategy,
-  // so enumerate and truncate any that exist to keep embedding rows from
-  // leaking across tests that reuse graph ids.
+  // Per-(kind, field) vector tables are materialized per field, so enumerate
+  // and truncate any that exist to keep embedding rows from leaking across
+  // tests that reuse graph ids; createStoreWithSchema re-creates any missing.
   await truncatePerFieldVectorTables(sharedPool);
 }
 
@@ -1845,7 +1852,7 @@ describe("Vector Search End-to-End (Query Builder)", () => {
     const { db } = requirePostgres(ctx);
 
     const backend = createPostgresBackend(db);
-    const store = createStore(vectorTestGraph, backend);
+    const [store] = await createStoreWithSchema(vectorTestGraph, backend);
 
     // Create documents with embeddings. The store's embedding-sync path
     // persists each through the pgvector strategy's per-field table —
@@ -1899,7 +1906,7 @@ describe("Vector Search End-to-End (Query Builder)", () => {
     const { db } = requirePostgres(ctx);
 
     const backend = createPostgresBackend(db);
-    const store = createStore(vectorTestGraph, backend);
+    const [store] = await createStoreWithSchema(vectorTestGraph, backend);
 
     // Create documents — embeddings persist through the strategy's
     // per-field table via the store's embedding-sync path.

--- a/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
@@ -93,6 +93,13 @@ async function setupTestDatabase(): Promise<void> {
 
 async function clearTestData(): Promise<void> {
   if (!sharedSql) return;
+  // Clear the durable contribution markers (#135) alongside the data so each
+  // test starts genuinely un-provisioned: `createStoreWithSchema` (run per
+  // test by the integration suite) then re-materializes every per-field
+  // vector table + marker in lockstep. Leaving markers behind on this shared,
+  // long-lived test database would let a marker outlive a dropped table, so a
+  // later boot would trust the marker, skip the CREATE, and writes would hit a
+  // missing relation.
   await sharedSql.unsafe(
     `TRUNCATE typegraph_index_materializations,
               typegraph_contribution_materializations,
@@ -106,11 +113,12 @@ async function clearTestData(): Promise<void> {
               typegraph_nodes,
               typegraph_edges,
               typegraph_node_uniques,
+              typegraph_contribution_materializations,
               typegraph_schema_versions CASCADE`,
   );
-  // Per-(kind, field) vector tables are created lazily by the strategy,
-  // so enumerate and truncate any that exist (there is no single shared
-  // embeddings table to TRUNCATE).
+  // Per-(kind, field) vector tables are materialized per field, so enumerate
+  // and truncate any that exist (there is no single shared embeddings table).
+  // createStoreWithSchema re-creates any that are missing (markers cleared).
   const rows = await sharedSql.unsafe<{ tablename: string }[]>(
     String.raw`SELECT tablename FROM pg_tables
       WHERE schemaname = 'public' AND tablename LIKE 'tg_vec\_%'`,

--- a/packages/typegraph/tests/backends/postgres/postgres-vector-least-privilege.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-vector-least-privilege.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Regression test for the prod failure that drove the marker-based vector
+ * gate: a least-privilege Postgres role (USAGE on schema `public`, full DML,
+ * but NO `CREATE`) must be able to run every runtime vector op — because the
+ * privileged migrator (`createStoreWithSchema`) provisions each per-`(kind,
+ * field)` embedding table + durable marker up front, and the runtime hot path
+ * only ASSERTS the marker (a SELECT) instead of issuing `CREATE TABLE`.
+ *
+ * Before the fix, `upsertEmbedding`/`vectorSearch` lazily ran
+ * `CREATE TABLE IF NOT EXISTS` on the request connection, which a USAGE-only
+ * role rejects with `permission denied for schema public` (SQLSTATE 42501) —
+ * even when the table already exists, because Postgres runs the schema
+ * aclcheck before the `IF NOT EXISTS` short-circuit.
+ *
+ * Skipped unless `POSTGRES_URL` is set (or `scripts/test-postgres.sh`).
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { z } from "zod";
+
+import {
+  createStore,
+  createStoreWithSchema,
+  createVerifiedStore,
+  defineGraph,
+  defineNode,
+  embedding,
+  pgvectorStrategy,
+  StoreNotInitializedError,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+const LEAST_PRIV_ROLE = "tg_vec_lp_runtime";
+const LEAST_PRIV_PASSWORD = "lp_runtime_pw";
+
+const Document = defineNode("Doc", {
+  schema: z.object({
+    title: z.string(),
+    embedding: embedding(4),
+  }),
+});
+
+const VecGraph = defineGraph({
+  // Distinct graph id so this file runs alongside the other postgres suites.
+  id: "pg_vector_least_privilege",
+  nodes: { Doc: { type: Document } },
+  edges: {},
+});
+
+const PER_FIELD_TABLE = pgvectorStrategy.tableName(
+  VecGraph.id,
+  "Doc",
+  "embedding",
+);
+const CONTRIB_MAT_TABLE = "typegraph_contribution_materializations";
+
+let ownerPool: Pool | undefined;
+let leastPrivPool: Pool | undefined;
+let postgresAvailable = false;
+
+/** A Pool authenticating as the USAGE-only role against the same database. */
+function leastPrivConnection(): Pool {
+  const url = new URL(TEST_DATABASE_URL);
+  return new Pool({
+    host: url.hostname,
+    port: url.port ? Number(url.port) : 5432,
+    database: url.pathname.replace(/^\//, ""),
+    user: LEAST_PRIV_ROLE,
+    password: LEAST_PRIV_PASSWORD,
+  });
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  try {
+    ownerPool = new Pool({ connectionString: TEST_DATABASE_URL });
+    await ownerPool.query("SELECT 1");
+    // Base typegraph_* tables for the shared test database.
+    await ownerPool.query(generatePostgresMigrationSQL());
+
+    // (Re)create the least-privilege runtime role: USAGE + full DML, but no
+    // CREATE on schema public — the exact prod `nicia_app` shape.
+    await ownerPool.query(`DROP OWNED BY ${LEAST_PRIV_ROLE}`).catch(() => {
+      // The role may not exist yet (first run) — nothing to drop.
+    });
+    await ownerPool.query(`DROP ROLE IF EXISTS ${LEAST_PRIV_ROLE}`);
+    await ownerPool.query(
+      `CREATE ROLE ${LEAST_PRIV_ROLE} LOGIN PASSWORD '${LEAST_PRIV_PASSWORD}'`,
+    );
+    await ownerPool.query(`GRANT USAGE ON SCHEMA public TO ${LEAST_PRIV_ROLE}`);
+    await ownerPool.query(
+      `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${LEAST_PRIV_ROLE}`,
+    );
+    // DML on tables the owner creates later (the per-field vector table).
+    await ownerPool.query(
+      `ALTER DEFAULT PRIVILEGES IN SCHEMA public ` +
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${LEAST_PRIV_ROLE}`,
+    );
+    // The crux: deny DDL. (Legacy databases grant CREATE to PUBLIC.)
+    await ownerPool.query(`REVOKE CREATE ON SCHEMA public FROM PUBLIC`);
+    await ownerPool.query(
+      `REVOKE CREATE ON SCHEMA public FROM ${LEAST_PRIV_ROLE}`,
+    );
+
+    leastPrivPool = leastPrivConnection();
+    await leastPrivPool.query("SELECT 1");
+    postgresAvailable = true;
+  } catch {
+    postgresAvailable = false;
+  }
+});
+
+afterAll(async () => {
+  if (leastPrivPool) await leastPrivPool.end();
+  if (ownerPool && postgresAvailable) {
+    // Restore PUBLIC's CREATE so we don't leave the shared test database
+    // more restrictive than other suites expect, then drop the role.
+    await ownerPool.query(`GRANT CREATE ON SCHEMA public TO PUBLIC`);
+    await ownerPool.query(`DROP OWNED BY ${LEAST_PRIV_ROLE}`).catch(() => {
+      // The role may not exist yet (first run) — nothing to drop.
+    });
+    await ownerPool.query(`DROP ROLE IF EXISTS ${LEAST_PRIV_ROLE}`);
+  }
+  if (ownerPool) await ownerPool.end();
+});
+
+describe.runIf(process.env.POSTGRES_URL)(
+  "PostgreSQL vector ops under a least-privilege (USAGE-only) role",
+  () => {
+    const transientPools: Pool[] = [];
+
+    function ownerBackend(): ReturnType<typeof createPostgresBackend> {
+      const pool = new Pool({ connectionString: TEST_DATABASE_URL });
+      transientPools.push(pool);
+      return createPostgresBackend(drizzle(pool));
+    }
+
+    function runtimeBackend(): ReturnType<typeof createPostgresBackend> {
+      const pool = leastPrivConnection();
+      transientPools.push(pool);
+      return createPostgresBackend(drizzle(pool));
+    }
+
+    beforeEach(async () => {
+      if (!postgresAvailable || !ownerPool) return;
+      // Start each test genuinely un-provisioned for this graph.
+      await ownerPool.query(`DROP TABLE IF EXISTS "${PER_FIELD_TABLE}"`);
+      await ownerPool.query(
+        `DELETE FROM ${CONTRIB_MAT_TABLE} WHERE graph_id = $1`,
+        [VecGraph.id],
+      );
+      await ownerPool.query(`DELETE FROM typegraph_nodes WHERE graph_id = $1`, [
+        VecGraph.id,
+      ]);
+    });
+
+    afterEach(async () => {
+      while (transientPools.length > 0) {
+        const pool = transientPools.pop()!;
+        await pool.end();
+      }
+    });
+
+    it("the runtime role genuinely lacks CREATE on schema public (control)", async () => {
+      await expect(
+        leastPrivPool!.query(`CREATE TABLE tg_lp_probe (id text)`),
+      ).rejects.toMatchObject({ code: "42501" });
+    });
+
+    it("owner provisions; the USAGE-only role then upserts + searches with zero DDL", async () => {
+      // Privileged migrator (owner) creates the per-field table + marker.
+      await createStoreWithSchema(VecGraph, ownerBackend());
+
+      // The per-field vector table now exists, owned by the migrator.
+      const tableExists = await ownerPool!.query<{ exists: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM pg_tables
+           WHERE schemaname = 'public' AND tablename = $1
+         ) AS exists`,
+        [PER_FIELD_TABLE],
+      );
+      expect(tableExists.rows[0]?.exists).toBe(true);
+
+      // Runtime attaches as the least-privilege role and verifies markers
+      // (SELECT-only) — exercising the createVerifiedStore vector gate.
+      const [store] = await createVerifiedStore(VecGraph, runtimeBackend());
+
+      // The write that reproduced `permission denied for schema public`
+      // before the fix now succeeds: assert marker (SELECT) + INSERT (DML).
+      const near = await store.nodes.Doc.create({
+        title: "near",
+        embedding: [1, 0, 0, 0],
+      });
+      await store.nodes.Doc.create({ title: "far", embedding: [0, 0, 0, 1] });
+
+      const hits = await store.search.vector("Doc", {
+        fieldPath: "embedding",
+        queryEmbedding: [1, 0, 0, 0],
+        limit: 2,
+        metric: "cosine",
+      });
+      expect(hits.map((hit) => hit.node.id)).toContain(near.id);
+      expect(hits[0]?.node.title).toBe("near");
+    });
+
+    it("an un-provisioned slot makes the runtime role throw StoreNotInitializedError, not a DDL permission error", async () => {
+      // No owner provisioning this time. The hot path asserts the (missing)
+      // durable marker via SELECT and refuses loudly — it must NOT attempt
+      // CREATE TABLE and surface a raw 42501.
+      const store = createStore(VecGraph, runtimeBackend());
+
+      const error = await store.nodes.Doc.create({
+        title: "x",
+        embedding: [1, 0, 0, 0],
+      }).catch((error_: unknown) => error_);
+
+      expect(error).toBeInstanceOf(StoreNotInitializedError);
+      expect((error as StoreNotInitializedError).code).toBe(
+        "STORE_NOT_INITIALIZED",
+      );
+    });
+  },
+);

--- a/packages/typegraph/tests/backends/postgres/reclaim-removed-vector-fields.test.ts
+++ b/packages/typegraph/tests/backends/postgres/reclaim-removed-vector-fields.test.ts
@@ -65,8 +65,14 @@ afterAll(async () => {
 
 beforeEach(async () => {
   if (sharedPool === undefined) return;
+  // Clear the durable contribution markers (#135) alongside dropping the
+  // per-field tables below: this suite drops `tg_vec_*` tables directly
+  // (bypassing reclaim), so a marker left behind on this shared database
+  // would outlive its table and make a later evolve()/createStoreWithSchema
+  // trust the marker and skip re-creating the table.
   await sharedPool.query(
     `TRUNCATE typegraph_index_materializations,
+              typegraph_contribution_materializations,
               typegraph_node_uniques,
               typegraph_nodes,
               typegraph_edges,

--- a/packages/typegraph/tests/backends/sqlite/libsql-vector-strategy.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/libsql-vector-strategy.test.ts
@@ -220,14 +220,15 @@ describe("libsqlVectorStrategy (executed against @libsql/client)", () => {
     expect(ids).not.toContain("d2"); // orthogonal vector excluded from top-2
   });
 
-  it("backend ensure reruns DiskANN DDL when indexType changes at the same dimension", async () => {
+  it("provisioning a DiskANN (hnsw) slot materializes its index for vector_top_k via the backend methods", async () => {
     const { backend } = await createLibsqlBackend(client);
-    const base = {
+    const slot = {
       graphId: GRAPH,
       nodeKind: "Document",
       fieldPath: "embedding",
       dimensions: 3,
       metric: "cosine" as const,
+      indexType: "hnsw" as const,
     };
 
     // vectorSearch computes top-k over LIVE nodes only, so the embedding
@@ -238,20 +239,22 @@ describe("libsqlVectorStrategy (executed against @libsql/client)", () => {
       id: "d1",
       props: {},
     });
-    // First write ensures only brute-force storage. A later schema change can
-    // keep the same dimension while switching the slot to ANN-backed `hnsw`;
-    // the backend must run the hnsw ensure path so `vector_top_k` has an index.
+    // The privileged migrator provisions the per-field table + DiskANN index
+    // (libsql folds the index DDL into `ownedTables` for ANN slots) and the
+    // durable marker. The runtime backend methods then assert the marker
+    // (never DDL) and `vector_top_k` has its index. A later none→hnsw change
+    // at the same dimension is a deliberate shape change handled by
+    // `store.reembedVectorField`, not a lazy re-ensure on the hot path.
+    await backend.ensureVectorSlotContribution!(slot);
     await backend.upsertEmbedding!({
-      ...base,
+      ...slot,
       nodeId: "d1",
       embedding: [1, 0, 0],
-      indexType: "none",
     });
 
     const result = await backend.vectorSearch!({
-      ...base,
+      ...slot,
       queryEmbedding: [1, 0, 0],
-      indexType: "hnsw",
       limit: 1,
     });
 

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -787,12 +787,19 @@ describe("SQLite backend.vectorSearch", () => {
         indexType: "none" as const,
       };
       return (async () => {
+        // Provision at the DECLARED shape (cosine — matching the upsert
+        // wrapper), never at the search's runtime metric: a metric override
+        // is a query-time preference over the same physical table, exactly
+        // how the store facade behaves (writes/provisioning use the schema-
+        // declared metric; searches may override). Ensuring at the query's
+        // metric would read as signature drift on sqlite-vec, which bakes
+        // the metric into the vtable DDL.
         await backend.ensureVectorSlotContribution?.({
           graphId: full.graphId,
           nodeKind: full.nodeKind,
           fieldPath: full.fieldPath,
           dimensions: full.dimensions,
-          metric: full.metric,
+          metric: "cosine",
           indexType: full.indexType,
         });
         return rawVectorSearch(full);

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -582,7 +582,8 @@ describe("SQLite embedding persistence via createSqliteBackend", () => {
       return;
     }
 
-    const { embedding, defineNode, defineGraph } = await import("../../../src");
+    const { embedding, defineNode, defineGraph, createStoreWithSchema } =
+      await import("../../../src");
     const Document = defineNode("Doc", {
       schema: z.object({
         title: z.string(),
@@ -606,7 +607,9 @@ describe("SQLite embedding persistence via createSqliteBackend", () => {
     });
     expect(backend.upsertEmbedding).toBeDefined();
 
-    const store = createStore(graph, backend);
+    // createStoreWithSchema provisions the per-field vector table + marker
+    // (privileged), so the embedding write below asserts cleanly.
+    const [store] = await createStoreWithSchema(graph, backend);
     await store.nodes.Doc.create({
       title: "Similar",
       embedding: [1, 0, 0, 0],
@@ -749,25 +752,51 @@ describe("SQLite backend.vectorSearch", () => {
     // Inject the store-resolved slot fields the backend now requires.
     // sqlite-vec storage is metric-agnostic and brute-force here, so the
     // defaults (`cosine` / `none` / dimension from the vector length)
-    // preserve every existing call site's intended behavior.
+    // preserve every existing call site's intended behavior. Each wrapper
+    // first provisions the per-field table + durable marker (#135) — the
+    // privileged step the store's `createStoreWithSchema` would normally do;
+    // these backend-facade tests drive the backend directly, so they stand
+    // in for the migrator. Idempotent and cached after the first call.
     function upsertEmbedding(
       params: Omit<UpsertEmbeddingParams, "metric" | "indexType">,
     ): Promise<void> {
-      return rawUpsertEmbedding({
+      const full = {
         ...params,
-        metric: "cosine",
-        indexType: "none",
-      });
+        metric: "cosine" as const,
+        indexType: "none" as const,
+      };
+      return (async () => {
+        await backend.ensureVectorSlotContribution?.({
+          graphId: full.graphId,
+          nodeKind: full.nodeKind,
+          fieldPath: full.fieldPath,
+          dimensions: full.dimensions,
+          metric: full.metric,
+          indexType: full.indexType,
+        });
+        await rawUpsertEmbedding(full);
+      })();
     }
 
     function vectorSearch(
       params: Omit<VectorSearchParams, "dimensions" | "indexType">,
     ): Promise<readonly VectorSearchResult[]> {
-      return rawVectorSearch({
+      const full = {
         ...params,
         dimensions: params.queryEmbedding.length,
-        indexType: "none",
-      });
+        indexType: "none" as const,
+      };
+      return (async () => {
+        await backend.ensureVectorSlotContribution?.({
+          graphId: full.graphId,
+          nodeKind: full.nodeKind,
+          fieldPath: full.fieldPath,
+          dimensions: full.dimensions,
+          metric: full.metric,
+          indexType: full.indexType,
+        });
+        return rawVectorSearch(full);
+      })();
     }
 
     async function seed(

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -13,7 +13,11 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-import { fts5Strategy, StoreNotInitializedError } from "../src";
+import {
+  fts5Strategy,
+  pgvectorStrategy,
+  StoreNotInitializedError,
+} from "../src";
 import {
   type ContributionMaterializerDeps,
   createContributionMaterializer,
@@ -23,6 +27,7 @@ import type {
   ContributionMaterializationRow,
   RecordContributionMaterializationParams,
 } from "../src/backend/types";
+import { type VectorStrategy } from "../src/query/dialect/vector-strategy";
 
 const GRAPH_ID = "contrib-mat-unit";
 const FULLTEXT_TABLE = "typegraph_node_fulltext";
@@ -95,6 +100,7 @@ function createMockMaterializer(
   getMarkerOverride?: (
     identity: ContributionMaterializationIdentity,
   ) => Promise<ContributionMaterializationRow | undefined>,
+  vectorStrategy?: VectorStrategy,
 ) {
   const ensureMarkerTable = vi.fn((): Promise<void> => Promise.resolve());
   const execDdl = vi.fn((_statement: string): Promise<void> =>
@@ -113,22 +119,47 @@ function createMockMaterializer(
       return Promise.resolve();
     },
   );
+  const deleteMarker = vi.fn(
+    (identity: ContributionMaterializationIdentity): Promise<void> => {
+      markers.delete(markerKey(identity));
+      return Promise.resolve();
+    },
+  );
 
   const deps = {
-    dialect: "sqlite",
+    dialect: vectorStrategy === undefined ? "sqlite" : "postgres",
     fulltextStrategy: fts5Strategy,
     fulltextTableName: FULLTEXT_TABLE,
+    vectorStrategy,
     execDdl,
     ensureMarkerTable,
     getMarker,
     recordMarker,
+    deleteMarker,
   } satisfies ContributionMaterializerDeps;
 
   return {
     materializer: createContributionMaterializer(deps),
-    spies: { ensureMarkerTable, execDdl, getMarker, recordMarker },
+    spies: {
+      ensureMarkerTable,
+      execDdl,
+      getMarker,
+      recordMarker,
+      deleteMarker,
+    },
   };
 }
+
+// A representative embedding slot for the vector-contribution tests. Its
+// physical table + marker identity derive from `pgvectorStrategy.ownedTables`.
+const VECTOR_SLOT = {
+  graphId: GRAPH_ID,
+  nodeKind: "Document",
+  fieldPath: "embedding",
+  dimensions: 8,
+  metric: "cosine",
+  indexType: "hnsw",
+} as const;
 
 describe("#149 ensureRuntimeContributions is read-only when already materialized", () => {
   it("a fresh materializer over an already-materialized graph runs zero DDL", async () => {
@@ -200,10 +231,12 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
       dialect: "sqlite",
       fulltextStrategy: fts5Strategy,
       fulltextTableName: FULLTEXT_TABLE,
+      vectorStrategy: undefined,
       execDdl,
       ensureMarkerTable,
       getMarker,
       recordMarker,
+      deleteMarker: vi.fn((): Promise<void> => Promise.resolve()),
     } satisfies ContributionMaterializerDeps;
 
     await createContributionMaterializer(deps).ensureRuntimeContributions(
@@ -250,10 +283,12 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
       dialect: "postgres",
       fulltextStrategy: fts5Strategy,
       fulltextTableName: FULLTEXT_TABLE,
+      vectorStrategy: undefined,
       execDdl,
       ensureMarkerTable,
       getMarker,
       recordMarker,
+      deleteMarker: vi.fn((): Promise<void> => Promise.resolve()),
     } satisfies ContributionMaterializerDeps;
 
     await expect(
@@ -319,5 +354,130 @@ describe("assertInitialized verdicts after the readContributionState refactor", 
       .catch((error: unknown) => error);
     expect(rejection).toBe(fault);
     expect(rejection).not.toBeInstanceOf(StoreNotInitializedError);
+  });
+});
+
+describe("vector slot contributions ride the same durable-marker machinery", () => {
+  it("ensureVectorSlot materializes the per-field table + marker on cold boot", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const cold = createMockMaterializer(markers, undefined, pgvectorStrategy);
+
+    await cold.materializer.ensureVectorSlot(VECTOR_SLOT);
+
+    expect(cold.spies.ensureMarkerTable).toHaveBeenCalledTimes(1);
+    expect(cold.spies.execDdl).toHaveBeenCalled();
+    expect(markers.size).toBe(1);
+  });
+
+  it("assertVectorSlot throws StoreNotInitializedError before provisioning — never DDL", async () => {
+    const { materializer, spies } = createMockMaterializer(
+      new Map(),
+      () => Promise.reject(MISSING_MARKER_TABLE_ERROR),
+      pgvectorStrategy,
+    );
+
+    await expect(
+      materializer.assertVectorSlot(VECTOR_SLOT),
+    ).rejects.toMatchObject({
+      name: "StoreNotInitializedError",
+      details: { reason: "missing" },
+    });
+    // The hot-path gate never tries to create anything on a USAGE-only role.
+    expect(spies.execDdl).not.toHaveBeenCalled();
+    expect(spies.ensureMarkerTable).not.toHaveBeenCalled();
+  });
+
+  it("assertVectorSlot resolves with zero DDL once a fresh instance reopens a provisioned slot", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    await createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    ).materializer.ensureVectorSlot(VECTOR_SLOT);
+
+    const warm = createMockMaterializer(markers, undefined, pgvectorStrategy);
+    await expect(
+      warm.materializer.assertVectorSlot(VECTOR_SLOT),
+    ).resolves.toBeUndefined();
+    expect(warm.spies.execDdl).not.toHaveBeenCalled();
+    expect(warm.spies.ensureMarkerTable).not.toHaveBeenCalled();
+    expect(warm.spies.getMarker).toHaveBeenCalled();
+  });
+
+  it("ensureVectorSlot refuses a dimension change as drift, but { force: true } re-stamps it", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    await createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    ).materializer.ensureVectorSlot(VECTOR_SLOT);
+
+    // A dimension change keeps the same (kind, field) table identity but
+    // changes the createDdl signature — drift. A fresh instance (no cache)
+    // must refuse it loudly rather than silently bless a stale table.
+    const changed = { ...VECTOR_SLOT, dimensions: 16 } as const;
+    await expect(
+      createMockMaterializer(
+        markers,
+        undefined,
+        pgvectorStrategy,
+      ).materializer.ensureVectorSlot(changed),
+    ).rejects.toThrow(/different signature/);
+
+    // `reembedVectorField`'s path: force past the drift-guard after the
+    // table was recreated at the new dimension.
+    await createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    ).materializer.ensureVectorSlot(changed, { force: true });
+
+    // The marker now reads back as initialized at the new shape.
+    const warm = createMockMaterializer(markers, undefined, pgvectorStrategy);
+    await expect(
+      warm.materializer.assertVectorSlot(changed),
+    ).resolves.toBeUndefined();
+  });
+
+  it("dropVectorSlot forgets the marker so a later ensure re-creates the table", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const first = createMockMaterializer(markers, undefined, pgvectorStrategy);
+    await first.materializer.ensureVectorSlot(VECTOR_SLOT);
+    expect(markers.size).toBe(1);
+
+    // Reclaim drops the physical table; dropVectorSlot must delete the marker
+    // so a stale "initialized" row can't outlive it.
+    await first.materializer.dropVectorSlot(VECTOR_SLOT);
+    expect(markers.size).toBe(0);
+
+    // A fresh instance (cold cache) now sees "missing" and the assert refuses.
+    const warm = createMockMaterializer(markers, undefined, pgvectorStrategy);
+    await expect(
+      warm.materializer.assertVectorSlot(VECTOR_SLOT),
+    ).rejects.toBeInstanceOf(StoreNotInitializedError);
+
+    // ...and a re-provision runs the CREATE again rather than trusting a marker.
+    const reprovision = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    );
+    await reprovision.materializer.ensureVectorSlot(VECTOR_SLOT);
+    expect(reprovision.spies.execDdl).toHaveBeenCalled();
+    expect(markers.size).toBe(1);
+  });
+
+  it("ensureVectorSlot/assertVectorSlot are no-ops when vector support is disabled", async () => {
+    // No vectorStrategy → the materializer can't address any slot; both
+    // methods resolve without touching the marker store.
+    const { materializer, spies } = createMockMaterializer(new Map());
+    await expect(
+      materializer.ensureVectorSlot(VECTOR_SLOT),
+    ).resolves.toBeUndefined();
+    await expect(
+      materializer.assertVectorSlot(VECTOR_SLOT),
+    ).resolves.toBeUndefined();
+    expect(spies.getMarker).not.toHaveBeenCalled();
+    expect(spies.execDdl).not.toHaveBeenCalled();
   });
 });

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -413,8 +413,8 @@ describe("vector slot contributions ride the same durable-marker machinery", () 
     ).materializer.ensureVectorSlot(VECTOR_SLOT);
 
     // A dimension change keeps the same (kind, field) table identity but
-    // changes the createDdl signature — drift. A fresh instance (no cache)
-    // must refuse it loudly rather than silently bless a stale table.
+    // changes the createDdl signature — drift. A fresh instance must refuse
+    // it loudly rather than silently bless a stale table.
     const changed = { ...VECTOR_SLOT, dimensions: 16 } as const;
     await expect(
       createMockMaterializer(
@@ -437,6 +437,136 @@ describe("vector slot contributions ride the same durable-marker machinery", () 
     await expect(
       warm.materializer.assertVectorSlot(changed),
     ).resolves.toBeUndefined();
+  });
+
+  it("the SAME instance's warm cache does not skip the drift-guard on a dimension change", async () => {
+    // The positive cache is keyed by contribution identity AND signature: a
+    // shape change on the very instance that just ensured the slot must
+    // miss the cache and reach the drift-guard, not be silently accepted.
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    );
+    await materializer.ensureVectorSlot(VECTOR_SLOT);
+
+    await expect(
+      materializer.ensureVectorSlot({ ...VECTOR_SLOT, dimensions: 16 }),
+    ).rejects.toThrow(/different signature/);
+
+    // The guard is SIGNATURE-based, not parameter-based: a pgvector metric
+    // change leaves the table DDL (and so the physical shape) identical —
+    // metric only affects the search operator and the ANN index — so it is
+    // correctly treated as already materialized rather than as drift.
+    await expect(
+      materializer.ensureVectorSlot({ ...VECTOR_SLOT, metric: "l2" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("the SAME instance's warm assert sees a shape change as stale, not initialized", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer, spies } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    );
+    await materializer.ensureVectorSlot(VECTOR_SLOT);
+    // Warm the assert cache at the original shape.
+    await expect(
+      materializer.assertVectorSlot(VECTOR_SLOT),
+    ).resolves.toBeUndefined();
+
+    // The changed shape must not ride the warm cache: it reads the marker,
+    // sees signature drift, and refuses as stale — still with zero DDL.
+    const changed = { ...VECTOR_SLOT, dimensions: 16 } as const;
+    await expect(materializer.assertVectorSlot(changed)).rejects.toMatchObject({
+      name: "StoreNotInitializedError",
+      details: { reason: "stale" },
+    });
+    expect(spies.execDdl).toHaveBeenCalledTimes(
+      pgvectorStrategy
+        .ownedTables(VECTOR_SLOT)
+        .flatMap((contribution) => contribution.createDdl).length,
+    ); // only the original ensure's DDL — the assert path added none
+
+    // The original shape stays cached and keeps passing.
+    await expect(
+      materializer.assertVectorSlot(VECTOR_SLOT),
+    ).resolves.toBeUndefined();
+  });
+
+  it("a { force: true } re-stamp on the SAME instance invalidates the old shape's cache entry", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    );
+    await materializer.ensureVectorSlot(VECTOR_SLOT);
+    await materializer.assertVectorSlot(VECTOR_SLOT); // warm at dim 8
+
+    // reembedVectorField's path: recreate at dim 16 and force-restamp.
+    const changed = { ...VECTOR_SLOT, dimensions: 16 } as const;
+    await materializer.ensureVectorSlot(changed, { force: true });
+
+    // The new shape asserts clean; the OLD shape must now read as stale on
+    // this same instance — its cache entry was overwritten by the restamp.
+    await expect(
+      materializer.assertVectorSlot(changed),
+    ).resolves.toBeUndefined();
+    await expect(
+      materializer.assertVectorSlot(VECTOR_SLOT),
+    ).rejects.toMatchObject({
+      name: "StoreNotInitializedError",
+      details: { reason: "stale" },
+    });
+  });
+
+  it("ensureVectorSlot({ onDrift: 'skip' }) leaves a drifted slot untouched instead of refusing", async () => {
+    // The boot/evolve path: the declared dimension moved ahead of the
+    // provisioned table. Boot must complete (warn, no throw), the marker
+    // must stay EXACTLY as it was (old shape still reads initialized; new
+    // shape reads stale until reembedVectorField force-restamps), and no
+    // DDL may run against the stale table.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+      // Silence the drift warning in test output; the spy asserts it fired.
+    });
+    try {
+      const markers = new Map<string, ContributionMaterializationRow>();
+      const { materializer, spies } = createMockMaterializer(
+        markers,
+        undefined,
+        pgvectorStrategy,
+      );
+      await materializer.ensureVectorSlot(VECTOR_SLOT);
+      const markerBefore = [...markers.values()];
+      spies.execDdl.mockClear();
+      spies.recordMarker.mockClear();
+
+      const changed = { ...VECTOR_SLOT, dimensions: 16 } as const;
+      await expect(
+        materializer.ensureVectorSlot(changed, { onDrift: "skip" }),
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(spies.execDdl).not.toHaveBeenCalled();
+      expect(spies.recordMarker).not.toHaveBeenCalled();
+      expect([...markers.values()]).toEqual(markerBefore);
+
+      // Nothing was blessed: the drifted shape still asserts stale on this
+      // same instance, and the provisioned shape keeps passing.
+      await expect(
+        materializer.assertVectorSlot(changed),
+      ).rejects.toMatchObject({
+        name: "StoreNotInitializedError",
+        details: { reason: "stale" },
+      });
+      await expect(
+        materializer.assertVectorSlot(VECTOR_SLOT),
+      ).resolves.toBeUndefined();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("dropVectorSlot forgets the marker so a later ensure re-creates the table", async () => {

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -39,7 +39,7 @@ const MISSING_MARKER_TABLE_ERROR = new Error(
 );
 
 // Postgres' missing-relation failure as it actually reaches the gate:
-// drizzle-orm wraps the query-builder `getMarker` SELECT in a
+// drizzle-orm wraps the query-builder marker SELECT in a
 // `DrizzleQueryError` whose `.message` is the SQL text, with the real pg
 // error (`relation ... does not exist` / SQLSTATE 42P01) on `.cause`.
 // This is the #152 regression shape — the pre-check must still recognize
@@ -92,26 +92,26 @@ function recordMarkerInto(
 
 /**
  * A materializer wired to an in-memory marker store with spied DDL seams.
- * `getMarker` defaults to a map lookup; pass an override to simulate a
- * missing marker table or a hard read fault.
+ * `getMarkers` defaults to a graph-scoped map lookup; pass an override to
+ * simulate a missing marker table or a hard read fault.
  */
 function createMockMaterializer(
   markers: Map<string, ContributionMaterializationRow>,
-  getMarkerOverride?: (
-    identity: ContributionMaterializationIdentity,
-  ) => Promise<ContributionMaterializationRow | undefined>,
+  getMarkersOverride?: (
+    graphId: string,
+  ) => Promise<readonly ContributionMaterializationRow[]>,
   vectorStrategy?: VectorStrategy,
 ) {
   const ensureMarkerTable = vi.fn((): Promise<void> => Promise.resolve());
   const execDdl = vi.fn((_statement: string): Promise<void> =>
     Promise.resolve(),
   );
-  const getMarker = vi.fn(
-    getMarkerOverride ??
-      ((
-        identity: ContributionMaterializationIdentity,
-      ): Promise<ContributionMaterializationRow | undefined> =>
-        Promise.resolve(markers.get(markerKey(identity)))),
+  const getMarkers = vi.fn(
+    getMarkersOverride ??
+      ((graphId: string): Promise<readonly ContributionMaterializationRow[]> =>
+        Promise.resolve(
+          [...markers.values()].filter((row) => row.graphId === graphId),
+        )),
   );
   const recordMarker = vi.fn(
     (params: RecordContributionMaterializationParams): Promise<void> => {
@@ -133,7 +133,7 @@ function createMockMaterializer(
     vectorStrategy,
     execDdl,
     ensureMarkerTable,
-    getMarker,
+    getMarkers,
     recordMarker,
     deleteMarker,
   } satisfies ContributionMaterializerDeps;
@@ -143,7 +143,7 @@ function createMockMaterializer(
     spies: {
       ensureMarkerTable,
       execDdl,
-      getMarker,
+      getMarkers,
       recordMarker,
       deleteMarker,
     },
@@ -159,6 +159,11 @@ const VECTOR_SLOT = {
   dimensions: 8,
   metric: "cosine",
   indexType: "hnsw",
+} as const;
+
+const SECOND_VECTOR_SLOT = {
+  ...VECTOR_SLOT,
+  fieldPath: "summaryEmbedding",
 } as const;
 
 describe("#149 ensureRuntimeContributions is read-only when already materialized", () => {
@@ -183,7 +188,7 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
     expect(warm.spies.execDdl).not.toHaveBeenCalled();
     expect(warm.spies.recordMarker).not.toHaveBeenCalled();
     // It did consult the durable marker — a SELECT-only pre-check.
-    expect(warm.spies.getMarker).toHaveBeenCalled();
+    expect(warm.spies.getMarkers).toHaveBeenCalled();
   });
 
   it("the per-materializer cache makes a redundant warm call a true no-op", async () => {
@@ -194,11 +199,11 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
 
     const warm = createMockMaterializer(markers);
     await warm.materializer.ensureRuntimeContributions(GRAPH_ID);
-    warm.spies.getMarker.mockClear();
+    warm.spies.getMarkers.mockClear();
 
     // Second call on the same instance hits the cache before any read.
     await warm.materializer.ensureRuntimeContributions(GRAPH_ID);
-    expect(warm.spies.getMarker).not.toHaveBeenCalled();
+    expect(warm.spies.getMarkers).not.toHaveBeenCalled();
   });
 
   it("still materializes (with DDL) when the marker table is missing", async () => {
@@ -213,12 +218,12 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
     );
     // Faithful to the real backend: the marker SELECT throws until
     // `ensureMarkerTable` has created the table.
-    const getMarker = vi.fn(
-      (
-        identity: ContributionMaterializationIdentity,
-      ): Promise<ContributionMaterializationRow | undefined> => {
+    const getMarkers = vi.fn(
+      (graphId: string): Promise<readonly ContributionMaterializationRow[]> => {
         if (!tableExists) return Promise.reject(MISSING_MARKER_TABLE_ERROR);
-        return Promise.resolve(markers.get(markerKey(identity)));
+        return Promise.resolve(
+          [...markers.values()].filter((row) => row.graphId === graphId),
+        );
       },
     );
     const recordMarker = vi.fn(
@@ -234,7 +239,7 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
       vectorStrategy: undefined,
       execDdl,
       ensureMarkerTable,
-      getMarker,
+      getMarkers,
       recordMarker,
       deleteMarker: vi.fn((): Promise<void> => Promise.resolve()),
     } satisfies ContributionMaterializerDeps;
@@ -253,7 +258,7 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
   });
 
   it("falls through to DDL when the marker table is missing behind a DrizzleQueryError (Postgres)", async () => {
-    // The #152 regression: on Postgres the pre-check `getMarker` SELECT
+    // The #152 regression: on Postgres the pre-check marker SELECT
     // fails wrapped, so the missing-table signal lives on `.cause`. Before
     // the cause-walking fix this rethrew and broke first boot.
     let tableExists = false;
@@ -265,12 +270,12 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
       Promise.resolve(),
     );
     const markers = new Map<string, ContributionMaterializationRow>();
-    const getMarker = vi.fn(
-      (
-        identity: ContributionMaterializationIdentity,
-      ): Promise<ContributionMaterializationRow | undefined> =>
+    const getMarkers = vi.fn(
+      (graphId: string): Promise<readonly ContributionMaterializationRow[]> =>
         tableExists ?
-          Promise.resolve(markers.get(markerKey(identity)))
+          Promise.resolve(
+            [...markers.values()].filter((row) => row.graphId === graphId),
+          )
         : Promise.reject(POSTGRES_MISSING_MARKER_TABLE_ERROR),
     );
     const recordMarker = vi.fn(
@@ -286,7 +291,7 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
       vectorStrategy: undefined,
       execDdl,
       ensureMarkerTable,
-      getMarker,
+      getMarkers,
       recordMarker,
       deleteMarker: vi.fn((): Promise<void> => Promise.resolve()),
     } satisfies ContributionMaterializerDeps;
@@ -358,6 +363,40 @@ describe("assertInitialized verdicts after the readContributionState refactor", 
 });
 
 describe("vector slot contributions ride the same durable-marker machinery", () => {
+  it("batches marker reads across vector slots at boot and verified attach", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const cold = createMockMaterializer(markers, undefined, pgvectorStrategy);
+
+    await cold.materializer.ensureVectorSlots([
+      VECTOR_SLOT,
+      SECOND_VECTOR_SLOT,
+    ]);
+
+    expect(cold.spies.ensureMarkerTable).toHaveBeenCalledTimes(1);
+    // One read-only pre-check plus one post-bootstrap race check, independent
+    // of the number of slots.
+    expect(cold.spies.getMarkers).toHaveBeenCalledTimes(2);
+    expect(markers.size).toBe(2);
+
+    const verified = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+    );
+    await verified.materializer.assertVectorSlots([
+      VECTOR_SLOT,
+      SECOND_VECTOR_SLOT,
+    ]);
+    expect(verified.spies.getMarkers).toHaveBeenCalledTimes(1);
+
+    verified.spies.getMarkers.mockClear();
+    await verified.materializer.assertVectorSlots([
+      VECTOR_SLOT,
+      SECOND_VECTOR_SLOT,
+    ]);
+    expect(verified.spies.getMarkers).not.toHaveBeenCalled();
+  });
+
   it("ensureVectorSlot materializes the per-field table + marker on cold boot", async () => {
     const markers = new Map<string, ContributionMaterializationRow>();
     const cold = createMockMaterializer(markers, undefined, pgvectorStrategy);
@@ -401,7 +440,7 @@ describe("vector slot contributions ride the same durable-marker machinery", () 
     ).resolves.toBeUndefined();
     expect(warm.spies.execDdl).not.toHaveBeenCalled();
     expect(warm.spies.ensureMarkerTable).not.toHaveBeenCalled();
-    expect(warm.spies.getMarker).toHaveBeenCalled();
+    expect(warm.spies.getMarkers).toHaveBeenCalled();
   });
 
   it("ensureVectorSlot refuses a dimension change as drift, but { force: true } re-stamps it", async () => {
@@ -462,6 +501,35 @@ describe("vector slot contributions ride the same durable-marker machinery", () 
     await expect(
       materializer.ensureVectorSlot({ ...VECTOR_SLOT, metric: "l2" }),
     ).resolves.toBeUndefined();
+  });
+
+  it("memoizes WebCrypto signatures until the canonical DDL input changes", async () => {
+    const digest = vi.spyOn(globalThis.crypto.subtle, "digest");
+    try {
+      const markers = new Map<string, ContributionMaterializationRow>();
+      const { materializer } = createMockMaterializer(
+        markers,
+        undefined,
+        pgvectorStrategy,
+      );
+      await materializer.ensureVectorSlot(VECTOR_SLOT);
+      const digestCallsAfterProvisioning = digest.mock.calls.length;
+
+      await materializer.assertVectorSlot(VECTOR_SLOT);
+      await materializer.assertVectorSlot(VECTOR_SLOT);
+      await materializer.ensureVectorSlot(VECTOR_SLOT);
+      expect(digest).toHaveBeenCalledTimes(digestCallsAfterProvisioning);
+
+      await expect(
+        materializer.assertVectorSlot({ ...VECTOR_SLOT, dimensions: 16 }),
+      ).rejects.toMatchObject({
+        name: "StoreNotInitializedError",
+        details: { reason: "stale" },
+      });
+      expect(digest).toHaveBeenCalledTimes(digestCallsAfterProvisioning + 1);
+    } finally {
+      digest.mockRestore();
+    }
   });
 
   it("the SAME instance's warm assert sees a shape change as stale, not initialized", async () => {
@@ -607,7 +675,7 @@ describe("vector slot contributions ride the same durable-marker machinery", () 
     await expect(
       materializer.assertVectorSlot(VECTOR_SLOT),
     ).resolves.toBeUndefined();
-    expect(spies.getMarker).not.toHaveBeenCalled();
+    expect(spies.getMarkers).not.toHaveBeenCalled();
     expect(spies.execDdl).not.toHaveBeenCalled();
   });
 });

--- a/packages/typegraph/tests/reembed-vector-field.test.ts
+++ b/packages/typegraph/tests/reembed-vector-field.test.ts
@@ -177,10 +177,11 @@ describe("store.reembedVectorField (sqlite-vec)", () => {
     );
   });
 
-  it("write-time: a wrong-dimension upsert surfaces EmbeddingDimensionChangedError", async () => {
+  it("write-time: a length-mismatched upsert surfaces EmbeddingDimensionChangedError", async () => {
     if (
       backend.vectorStrategy === undefined ||
-      backend.upsertEmbedding === undefined
+      backend.upsertEmbedding === undefined ||
+      backend.ensureVectorSlotContribution === undefined
     ) {
       return;
     }
@@ -191,21 +192,25 @@ describe("store.reembedVectorField (sqlite-vec)", () => {
       metric: "cosine" as const,
       indexType: "none" as const,
     };
-    // First write fixes the per-field table at dimension 3.
+    // Provision + fix the per-field table at dimension 3 (the privileged step
+    // the migrator does; this test drives the backend directly).
+    await backend.ensureVectorSlotContribution({ ...base, dimensions: 3 });
     await backend.upsertEmbedding({
       ...base,
       nodeId: "n1",
       embedding: [1, 0, 0],
       dimensions: 3,
     });
-    // A later 4-dim write (the field's dimension changed) must surface the
-    // typed error, not the raw engine "expected N dimensions" message.
+    // A vector whose length doesn't match the column's fixed dimension must
+    // surface the typed error (via mapVectorWriteError), not the raw engine
+    // "expected N dimensions" message. The marker assert passes (dimensions
+    // still 3); the engine rejects the 4-length vector.
     await expect(
       backend.upsertEmbedding({
         ...base,
         nodeId: "n2",
         embedding: [1, 0, 0, 0],
-        dimensions: 4,
+        dimensions: 3,
       }),
     ).rejects.toBeInstanceOf(EmbeddingDimensionChangedError);
   });
@@ -296,9 +301,23 @@ describe("store.reembedVectorField (sqlite-vec)", () => {
   });
 
   it("backend.vectorSearch rejects a non-finite minScore (#6)", async () => {
-    if (backend.vectorSearch === undefined) return;
-    // Direct backend call bypasses the facade — buildSearch must still reject a
-    // non-finite minScore instead of compiling `distance <= (1 - NaN)`.
+    if (
+      backend.vectorSearch === undefined ||
+      backend.ensureVectorSlotContribution === undefined
+    ) {
+      return;
+    }
+    // Provision the slot so the marker assert passes and execution reaches
+    // buildSearch — which must still reject a non-finite minScore instead of
+    // compiling `distance <= (1 - NaN)`.
+    await backend.ensureVectorSlotContribution({
+      graphId: "g",
+      nodeKind: "Doc",
+      fieldPath: "embedding",
+      dimensions: 3,
+      metric: "cosine",
+      indexType: "none",
+    });
     await expect(
       backend.vectorSearch({
         graphId: "g",


### PR DESCRIPTION
Closes #267. Reimplementation of #169 against current main.

## Problem

Every runtime vector op (`upsertEmbedding` / `upsertEmbeddingBatch` / `deleteEmbedding` / `vectorSearch` / `hybridSearch` / `createVectorIndex`) lazily ran `CREATE TABLE IF NOT EXISTS` for its per-`(kind, field)` table on the request connection via the in-process `vectorSlotLatch`. On a least-privilege Postgres role (USAGE on the schema, full DML, no `CREATE`) this failed with `permission denied for schema public` (42501) — even when the table already existed, because Postgres runs the schema aclcheck before the `IF NOT EXISTS` short-circuit. Fulltext already avoided this via the #135 durable-marker machinery; the #161 vector cutover shipped the latch shortcut instead.

## Fix

Vectors now ride the **same** durable-marker machinery as fulltext:

- **Boot (privileged):** `createStoreWithSchema` provisions every embedding `(kind, field)` table + durable marker (enumerated via `resolveGraphVectorSlots`, the single source of truth); `evolve()` provisions fields it introduces. Boot/evolve warn and skip drifted slots so `reembedVectorField` remains reachable.
- **Runtime writes (DML-only):** embedding writes assert the marker with a cached SELECT — **never DDL**. An unprovisioned write throws `StoreNotInitializedError`; a drifted write reports `stale` and points to `reembedVectorField`. Vector reads are not marker-gated because they carry no DDL hazard and query-time metric overrides are legitimate; an unprovisioned read surfaces the engine’s missing-relation error. `createVerifiedStore` verifies all markers at attach.
- `reembedVectorField` re-stamps the marker (`{ force: true }`, bypassing the drift guard) after recreating storage at a new dimension; vector-field reclaim (`materializeRemovals`) deletes the marker in lockstep with the table drop.
- `migrateLegacyEmbeddings` pre-skips mixed-dimension rows against the provisioned slot dimension instead of depending on the engine write error.
- `vectorSlotLatch` is removed. The contribution materializer is shared across the outer backend and every transaction-scoped backend, so transaction-scoped vector writes assert only and cannot poison anything on rollback.

## Performance hardening

- Contribution signatures are memoized by identity and exact DDL shape. An unchanged warm fulltext/vector guard reuses the SHA-256 promise; a shape change still recomputes the signature and reaches the drift/stale checks.
- Built-in SQLite and Postgres backends fetch durable markers once per graph for batched vector boot/attach checks. Cold boot now uses two graph-scoped reads total, verified attach uses one, and a warm instance uses zero, instead of repeating reads per embedding slot.
- Focused warm-guard benchmark: **12.67 µs → 0.49 µs per assertion (~96% reduction)**.

## What’s new vs #169

This is a fresh implementation against main, not a rebase — it integrates the post-#169 changes the old branch predated: `upsertEmbeddingBatch` (now marker-asserted in both dialects), the candidates pushdown + GUC overrides in `vectorSearch`, the single-statement `hybridSearch`, the shared `iterativeScanProbe`, and the `drainAndClose` transaction-backend shape (pg@9 pinned-connection work).

## ⚠️ Breaking (pre-1.0 minor)

Embedding writes now require a prior privileged `createStoreWithSchema`, exactly as fulltext writes already do. **Migration:** run `createStoreWithSchema(graph, adminBackend)` once under the schema-owner role; least-privilege runtimes then assert markers (SELECT) and run vector DML with zero DDL — no `GRANT CREATE` needed. Use `createVerifiedStore` when attach-time verification of both reads and writes is required. Changeset included.

## Verification

- New `postgres-vector-least-privilege.test.ts` — the canonical regression: a USAGE-only role (verified to lack `CREATE`) runs vector upsert + search after owner provisioning, and gets `StoreNotInitializedError` (not 42501) on an unprovisioned write. Verified against Docker Postgres.
- New same-instance drift tests cover dimension changes, warm assert-stale behavior, force-restamp invalidation, and the pgvector metric case where parameters change but table DDL does not.
- New performance tests verify SHA-256 memoization and graph-scoped marker query counts.
- Full suites green: **SQLite 4,965 passed · Postgres 2,031 passed** · `pnpm fix` · `pnpm typecheck`.

Docs updated: architecture, backend setup (least-privilege and dimension-change guidance), semantic search, schema evolution, schema management, graph extensions, troubleshooting, and the changeset. They now state the exact contract: embedding writes throw typed initialization errors, vector reads surface engine missing-relation errors, and `createVerifiedStore` catches both at attach.
