### PR TITLE
Fix graph traversal path explosion with set-based BFS

### DIFF
--- a/.changeset/set-based-graph-traversal.md
+++ b/.changeset/set-based-graph-traversal.md
@@ -1,0 +1,13 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Replace path-enumerating recursive CTEs in `reachable`, `neighbors`,
+`shortestPath`, and `canReach` with set-based breadth-first search.
+
+Transactional SQLite and PostgreSQL backends now execute graph iterations
+against a connection-local temporary working table, de-duplicated by node kind
+and ID on every round. Non-transactional backends retain parity through a
+bind-limit-aware inline frontier. Traversals run in one snapshot where the
+backend supports transactions, preserve temporal filtering, and clean up
+temporary state on success or failure.

--- a/apps/docs/src/content/docs/examples/document-management.md
+++ b/apps/docs/src/content/docs/examples/document-management.md
@@ -684,9 +684,8 @@ async function getBreadcrumb(
 }
 ```
 
-`reachable` returns `{ id, kind, depth }` — one recursive-CTE query returns
-the full ancestor chain, then a single batched `getByIds` hydrates the folder
-properties.
+`reachable` returns `{ id, kind, depth }` from a set-based BFS frontier, then a
+single batched `getByIds` hydrates the folder properties.
 
 ## Bulk Operations
 

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -16,9 +16,13 @@ store.algorithms.neighbors(alice, { edges: ["knows"], depth: 2 });
 store.algorithms.degree(alice, { edges: ["knows"] });
 ```
 
-Each call compiles to a single `WITH RECURSIVE` CTE (or a plain `COUNT` for
-`degree`), using the same path-tracking and cycle-detection machinery as
-`.recursive()` and `store.subgraph()`. The algorithms work identically on
+Traversal calls use a set-based breadth-first frontier. Each level expands the
+current `(id, kind)` set with a bind-limit-aware SQL query. Transactional
+backends keep the visited set in a temporary working table; backends without a
+pinned transaction use a chunked inline working relation. Each node is admitted
+only at its minimum depth. `shortestPath` and `canReach` search from both
+endpoints and stop when the frontiers meet.
+`degree` remains a single `COUNT` query. The algorithms work identically on
 SQLite and PostgreSQL.
 
 ## When to Reach for Algorithms
@@ -46,13 +50,14 @@ Every traversal algorithm takes the same base options:
 | `edges` | `readonly EdgeKinds<G>[]` | *(required)* | Edge kinds to follow |
 | `maxHops` | `number` | `10` | Maximum traversal depth (1 – 1000) |
 | `direction` | `"out" \| "in" \| "both"` | `"out"` | Edge direction |
-| `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Skip visited nodes per path |
+| `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Compatibility option; both values use set-based node de-duplication |
 | `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to nodes and edges along the traversal — see [Temporal Behavior](#temporal-behavior) |
 | `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
 
-`direction: "both"` treats edges as undirected. `cyclePolicy: "allow"` skips
-cycle tracking and relies solely on `maxHops` to terminate — use it only
-when you know the graph is acyclic or you want maximum raw performance.
+`direction: "both"` treats edges as undirected. `cyclePolicy` remains accepted
+for compatibility with recursive query-builder traversals, but it does not
+change these algorithms: their node-set results and shortest paths never need
+to revisit a node.
 
 ## shortestPath
 
@@ -102,8 +107,8 @@ sorted by ascending depth.
 
 ## canReach
 
-Fast boolean check that short-circuits with `LIMIT 1` so the database stops
-traversing as soon as it finds the target.
+Fast boolean check that uses the same balanced bidirectional BFS as
+`shortestPath` and stops as soon as the two visited sets meet.
 
 ```typescript
 const connected = await store.algorithms.canReach(alice, bob, {
@@ -112,8 +117,8 @@ const connected = await store.algorithms.canReach(alice, bob, {
 });
 ```
 
-Use this when you only care whether a path exists — it's cheaper than
-`shortestPath` because it never decodes the path.
+Use this when you only care whether a path exists. It shares the same search
+cost as `shortestPath` but does not return the reconstructed path.
 
 ## neighbors
 
@@ -195,18 +200,26 @@ const knew = await store.algorithms.canReach(dave, alice, {
 });
 ```
 
-Cycles are prevented by default. The underlying CTE tracks visited nodes
-per path (the same mechanism described in
-[Cycle Detection](/queries/recursive#cycle-detection) for `.recursive()`).
-Switch to `cyclePolicy: "allow"` only when you're confident the traversal
-terminates via `maxHops` alone.
+Cycles cannot multiply work: a node enters the visited set once, at its minimum
+depth. This differs from `.recursive()`, whose path-returning semantics use the
+per-path behavior described in
+[Cycle Detection](/queries/recursive#cycle-detection). The algorithm
+`cyclePolicy` option is therefore compatibility-only.
 
 ## Depth Limits
 
-`maxHops` is capped at `MAX_EXPLICIT_RECURSIVE_DEPTH` (1000) to prevent
-runaway queries. The default of 10 covers typical connectivity questions on
-most graphs. Graphs with branching factor *B* produce O(*B*^depth) rows
-before cycle detection can prune them, so raise `maxHops` deliberately.
+`maxHops` is capped at `MAX_EXPLICIT_RECURSIVE_DEPTH` (1000). The default of 10
+covers typical connectivity questions on most graphs. Within that bound,
+single-source traversal examines each reached node once and each incident edge
+at most once per direction, rather than enumerating paths.
+
+Each expanded level costs a database round trip (inline working relations are
+split to respect the backend bind limit). Transactional backends keep those
+statements in one snapshot and drop their temporary working table in a
+`finally` cleanup; non-transactional backends use their normal best-effort
+multi-statement behavior. The application-clock valid-time instant is pinned
+once for the whole traversal, and recorded-time views remain pinned to their
+requested recorded coordinate.
 
 ## Temporal Behavior
 

--- a/apps/docs/src/content/docs/overview.md
+++ b/apps/docs/src/content/docs/overview.md
@@ -129,8 +129,9 @@ policy. Cycle prevention is the default.
 See [Recursive Traversals](/queries/recursive) for details.
 
 Note: TypeGraph ships **Tier 1 graph algorithms** (shortest path, reachability,
-neighborhoods, and degree) on `store.algorithms.*`. Each call compiles to a
-single recursive CTE. See [Graph Algorithms](/graph-algorithms) for details.
+neighborhoods, and degree) on `store.algorithms.*`. Traversal calls use a
+set-based BFS frontier, while degree uses a single count query. See
+[Graph Algorithms](/graph-algorithms) for details.
 
 Note: TypeGraph supports **runtime schema induction** via graph
 extensions. An LLM or ingestion agent can propose a typed schema as a

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1831,7 +1831,7 @@ TypeGraph offers several ways to load related data. The right choice depends on 
 | Multiple independent queries with per-query control | `store.batch()` | Single connection, snapshot consistency, typed tuple results |
 | Check if an edge exists | `edges.X.findFrom()` | Lightweight — no node resolution needed; honors the graph's temporal mode by default |
 | Traverse + resolve one edge type | `edges.X.findFrom()` + `nodes.X.getByIds()` | Two queries, simple and explicit; pass `temporalMode` / `asOf` when reading history |
-| Shortest path, reachability, neighborhoods, degree | `store.algorithms.*` | Single recursive CTE or `COUNT` per call — see [Graph Algorithms](/graph-algorithms) |
+| Shortest path, reachability, neighborhoods, degree | `store.algorithms.*` | Set-based BFS frontier or a single `COUNT` — see [Graph Algorithms](/graph-algorithms) |
 
 **Key insight:** `subgraph()` issues a single SQL statement regardless of how many edge types it
 traverses. Parallel `findFrom` calls scale linearly in round trips — one per edge type, plus
@@ -1880,13 +1880,13 @@ const total = await store.algorithms.degree(alice, { edges: ["knows"] });
 ```
 
 Every traversal algorithm accepts `edges`, `maxHops` (default 10),
-`direction` (`"out" | "in" | "both"`, default `"out"`), and `cyclePolicy`
-(`"prevent" | "allow"`, default `"prevent"`), plus `temporalMode` / `asOf`
-for temporal filtering — see [Temporal Behavior](/graph-algorithms#temporal-behavior).
-Each call compiles to a single recursive CTE; `degree` compiles to a
-single `COUNT`. Node arguments accept either raw IDs or any object with
-an `id` field — `Node`, `NodeRef`, and the lightweight records returned
-by these algorithms all work.
+`direction` (`"out" | "in" | "both"`, default `"out"`), and the
+compatibility-only `cyclePolicy`, plus `temporalMode` / `asOf` for temporal
+filtering — see [Temporal Behavior](/graph-algorithms#temporal-behavior).
+Traversal calls expand a de-duplicated BFS frontier one level at a time;
+`degree` compiles to a single `COUNT`. Node arguments accept either raw IDs or
+any object with an `id` field — `Node`, `NodeRef`, and the lightweight records
+returned by these algorithms all work.
 
 ### Query Builder
 

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -67,6 +67,7 @@ export type CommonOperationBackend = Pick<
   | "deleteUnique"
   | "edgeExistsBetween"
   | "executeStatement"
+  | "executeTemporaryStatement"
   | "findEdgesByKind"
   | "findEdgesConnectedTo"
   | "findNodesByKind"
@@ -189,10 +190,11 @@ export function createCommonOperationBackend(
   // recorded DDL is stable; Postgres disables that cache because visibility is
   // search_path-sensitive. Missing tables stay re-probable unless a caller opts
   // into negative caching.
-  const requiredClearTableExists = createCachedTableExistence((tableName) =>
-    execution.execGet<Record<string, unknown>>(
-      operationStrategy.buildTableExists(tableName),
-    ),
+  const requiredClearTableExists = createCachedTableExistence(
+    (tableName) =>
+      execution.execGet<Record<string, unknown>>(
+        operationStrategy.buildTableExists(tableName),
+      ),
     options.tableExistenceCache,
   );
 
@@ -231,17 +233,28 @@ export function createCommonOperationBackend(
       await execution.execRun(query);
     },
 
+    async executeTemporaryStatement(query: SQL): Promise<void> {
+      await execution.execRun(query);
+    },
+
     async insertNode(params: InsertNodeParams): Promise<NodeRow> {
       const timestamp = nowIso();
       const query = operationStrategy.buildInsertNode(params, timestamp);
       const row = await execution.execGet<Record<string, unknown>>(query);
-      if (!row) throw new DatabaseOperationError("Insert node failed: no row returned", { operation: "insert", entity: "node" });
+      if (!row)
+        throw new DatabaseOperationError(
+          "Insert node failed: no row returned",
+          { operation: "insert", entity: "node" },
+        );
       return rowMappers.toNodeRow(row);
     },
 
     async insertNodeNoReturn(params: InsertNodeParams): Promise<void> {
       const timestamp = nowIso();
-      const query = operationStrategy.buildInsertNodeNoReturn(params, timestamp);
+      const query = operationStrategy.buildInsertNodeNoReturn(
+        params,
+        timestamp,
+      );
       await execution.execRun(query);
     },
 
@@ -265,8 +278,10 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       const allRows: NodeRow[] = [];
       for (const chunk of chunkArray(params, batchConfig.nodeInsertBatchSize)) {
-        const query =
-          operationStrategy.buildInsertNodesBatchReturning(chunk, timestamp);
+        const query = operationStrategy.buildInsertNodesBatchReturning(
+          chunk,
+          timestamp,
+        );
         const rows = await execution.execAll<Record<string, unknown>>(query);
         allRows.push(...rows.map((row) => rowMappers.toNodeRow(row)));
       }
@@ -302,7 +317,11 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       const query = operationStrategy.buildUpdateNode(params, timestamp);
       const row = await execution.execGet<Record<string, unknown>>(query);
-      if (!row) throw new DatabaseOperationError("Update node failed: no row returned", { operation: "update", entity: "node" });
+      if (!row)
+        throw new DatabaseOperationError(
+          "Update node failed: no row returned",
+          { operation: "update", entity: "node" },
+        );
       return rowMappers.toNodeRow(row);
     },
 
@@ -353,13 +372,20 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       const query = operationStrategy.buildInsertEdge(params, timestamp);
       const row = await execution.execGet<Record<string, unknown>>(query);
-      if (!row) throw new DatabaseOperationError("Insert edge failed: no row returned", { operation: "insert", entity: "edge" });
+      if (!row)
+        throw new DatabaseOperationError(
+          "Insert edge failed: no row returned",
+          { operation: "insert", entity: "edge" },
+        );
       return rowMappers.toEdgeRow(row);
     },
 
     async insertEdgeNoReturn(params: InsertEdgeParams): Promise<void> {
       const timestamp = nowIso();
-      const query = operationStrategy.buildInsertEdgeNoReturn(params, timestamp);
+      const query = operationStrategy.buildInsertEdgeNoReturn(
+        params,
+        timestamp,
+      );
       await execution.execRun(query);
     },
 
@@ -383,8 +409,10 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       const allRows: EdgeRow[] = [];
       for (const chunk of chunkArray(params, batchConfig.edgeInsertBatchSize)) {
-        const query =
-          operationStrategy.buildInsertEdgesBatchReturning(chunk, timestamp);
+        const query = operationStrategy.buildInsertEdgesBatchReturning(
+          chunk,
+          timestamp,
+        );
         const rows = await execution.execAll<Record<string, unknown>>(query);
         allRows.push(...rows.map((row) => rowMappers.toEdgeRow(row)));
       }
@@ -415,7 +443,11 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       const query = operationStrategy.buildUpdateEdge(params, timestamp);
       const row = await execution.execGet<Record<string, unknown>>(query);
-      if (!row) throw new DatabaseOperationError("Update edge failed: no row returned", { operation: "update", entity: "edge" });
+      if (!row)
+        throw new DatabaseOperationError(
+          "Update edge failed: no row returned",
+          { operation: "update", entity: "edge" },
+        );
       return rowMappers.toEdgeRow(row);
     },
 
@@ -438,7 +470,10 @@ export function createCommonOperationBackend(
       // is budgeted for, so a full chunk would overflow the bind limit by 1.
       // Reserve a slot for the timestamp. The hard-delete batch below has no
       // such extra bind and keeps the full chunk size.
-      const softDeleteChunkSize = Math.max(1, batchConfig.getEdgesChunkSize - 1);
+      const softDeleteChunkSize = Math.max(
+        1,
+        batchConfig.getEdgesChunkSize - 1,
+      );
       for (const chunk of chunkArray(params.ids, softDeleteChunkSize)) {
         const query = operationStrategy.buildDeleteEdgesBatch(
           { graphId: params.graphId, ids: chunk },
@@ -450,7 +485,10 @@ export function createCommonOperationBackend(
 
     async hardDeleteEdgesBatch(params: DeleteEdgesBatchParams): Promise<void> {
       if (params.ids.length === 0) return;
-      for (const chunk of chunkArray(params.ids, batchConfig.getEdgesChunkSize)) {
+      for (const chunk of chunkArray(
+        params.ids,
+        batchConfig.getEdgesChunkSize,
+      )) {
         const query = operationStrategy.buildHardDeleteEdgesBatch({
           graphId: params.graphId,
           ids: chunk,
@@ -603,8 +641,14 @@ export function createCommonOperationBackend(
     ): Promise<readonly UniqueRow[]> {
       if (params.keys.length === 0) return [];
       const allRows: UniqueRow[] = [];
-      for (const chunk of chunkArray(params.keys, batchConfig.checkUniqueBatchChunkSize)) {
-        const query = operationStrategy.buildCheckUniqueBatch({ ...params, keys: chunk });
+      for (const chunk of chunkArray(
+        params.keys,
+        batchConfig.checkUniqueBatchChunkSize,
+      )) {
+        const query = operationStrategy.buildCheckUniqueBatch({
+          ...params,
+          keys: chunk,
+        });
         const rows = await execution.execAll<Record<string, unknown>>(query);
         allRows.push(...rows.map((row) => rowMappers.toUniqueRow(row)));
       }
@@ -637,10 +681,7 @@ export function createCommonOperationBackend(
       // sequence below is serialized against concurrent commits.
 
       const existingRaw = await execution.execGet<Record<string, unknown>>(
-        operationStrategy.buildGetSchemaVersion(
-          params.graphId,
-          params.version,
-        ),
+        operationStrategy.buildGetSchemaVersion(params.graphId, params.version),
       );
       const actualActiveVersion = await readActiveVersion(params.graphId);
 
@@ -732,10 +773,7 @@ export function createCommonOperationBackend(
       );
 
       const targetRaw = await execution.execGet<Record<string, unknown>>(
-        operationStrategy.buildGetSchemaVersion(
-          params.graphId,
-          params.version,
-        ),
+        operationStrategy.buildGetSchemaVersion(params.graphId, params.version),
       );
       if (!targetRaw) {
         throw new MigrationError(

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -82,6 +82,7 @@ import {
   type HybridSearchParams,
   type HybridSearchRow,
   type IndexMaterializationRow,
+  INTERNAL_TEMPORARY_WRITES,
   type KindRemovalRow,
   POSTGRES_CAPABILITIES,
   POSTGRES_MAX_BIND_PARAMETERS,
@@ -137,10 +138,7 @@ import {
   createCommonOperationBackend,
   type InternalOperationBackend,
 } from "./operation-backend-core";
-import {
-  hybridCandidatesRef,
-  mapHybridSearchRow,
-} from "./operations/hybrid";
+import { hybridCandidatesRef, mapHybridSearchRow } from "./operations/hybrid";
 import {
   createCachedTableExistence,
   createPostgresOperationStrategy,
@@ -964,19 +962,48 @@ export function createPostgresBackend(
       // fulltext never asserts; one that does runs pure DML against an
       // already-materialized table, with the "no DDL in the business
       // transaction" guarantee backed by the durable fact.
+      const temporaryWrites =
+        options?.temporaryWrites === INTERNAL_TEMPORARY_WRITES;
+      if (temporaryWrites && options.accessMode !== "read_only") {
+        throw new ConfigurationError(
+          "Temporary-write transactions must be semantically read-only.",
+          { dialect: "postgres" },
+        );
+      }
       const txConfig =
-        options?.isolationLevel ?
+        (
+          options?.isolationLevel !== undefined ||
+          options?.accessMode !== undefined ||
+          temporaryWrites
+        ) ?
           {
-            isolationLevel: options.isolationLevel.replace("_", " ") as
-              | "read uncommitted"
-              | "read committed"
-              | "repeatable read"
-              | "serializable",
+            ...(options.isolationLevel === undefined ?
+              {}
+            : {
+                isolationLevel: options.isolationLevel.replace("_", " ") as
+                  | "read uncommitted"
+                  | "read committed"
+                  | "repeatable read"
+                  | "serializable",
+              }),
+            ...((
+              options.accessMode === undefined &&
+              !temporaryWrites
+            ) ?
+              {}
+            : {
+                accessMode:
+                  temporaryWrites ?
+                    ("read write" as const)
+                  : (options.accessMode!.replace("_", " ") as
+                      "read only" | "read write"),
+              }),
           }
         : undefined;
 
       return db.transaction(async (tx) => {
-        const { backend: txBackend, drainAndClose } = bindTransactionBackend(tx);
+        const { backend: txBackend, drainAndClose } =
+          bindTransactionBackend(tx);
         try {
           return await fn(txBackend, tx);
         } finally {
@@ -1674,9 +1701,7 @@ function createPostgresOperationBackend(
               slot.fieldPath,
             ),
           );
-          await execRun(
-            sql`ALTER TABLE ${table} SET (parallel_workers = 0)`,
-          );
+          await execRun(sql`ALTER TABLE ${table} SET (parallel_workers = 0)`);
           try {
             await execRun(indexStatement);
           } finally {
@@ -1794,9 +1819,7 @@ function createPostgresOperationBackend(
         const overrides: SearchGucOverride[] = [];
         for (const indexType of annTypes) {
           if (indexType !== "hnsw" && indexType !== "ivfflat") continue;
-          overrides.push(
-            ...(await vectorSearchGucOverrides({ indexType })),
-          );
+          overrides.push(...(await vectorSearchGucOverrides({ indexType })));
         }
         return runVectorSearch<T>(overrides, query);
       }

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -63,6 +63,7 @@ import {
   type HybridSearchParams,
   type HybridSearchRow,
   type IndexMaterializationRow,
+  INTERNAL_TEMPORARY_WRITES,
   type KindRemovalRow,
   type RecordContributionMaterializationParams,
   type RecordIndexMaterializationParams,
@@ -123,10 +124,7 @@ import {
   createCommonOperationBackend,
   type InternalOperationBackend,
 } from "./operation-backend-core";
-import {
-  hybridCandidatesRef,
-  mapHybridSearchRow,
-} from "./operations/hybrid";
+import { hybridCandidatesRef, mapHybridSearchRow } from "./operations/hybrid";
 import { createSqliteOperationStrategy } from "./operations/strategy";
 import {
   coerceNumericScore,
@@ -389,9 +387,9 @@ function createSerializedExecutionQueue(): SerializedExecutionQueue {
         if (isDisposed()) return pendingForever<T>();
         try {
           const context = queueTaskContext;
-          return context === undefined ? await task() : (
-              await context.run(taskMarker, () => task())
-            );
+          return context === undefined ?
+              await task()
+            : await context.run(taskMarker, () => task());
         } catch (error) {
           if (isDisposed()) return pendingForever<T>();
           throw error;
@@ -1545,8 +1543,16 @@ export function createSqliteBackend(
 
     async transaction<T>(
       fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
-      _options?: TransactionOptions,
+      options?: TransactionOptions,
     ): Promise<T> {
+      const temporaryWrites =
+        options?.temporaryWrites === INTERNAL_TEMPORARY_WRITES;
+      if (temporaryWrites && options.accessMode !== "read_only") {
+        throw new ConfigurationError(
+          "Temporary-write transactions must be semantically read-only.",
+          { dialect: "sqlite" },
+        );
+      }
       if (transactionMode === "none") {
         throwSqliteTransactionsDisabled(
           "This SQLite backend does not support atomic transactions. " +
@@ -1582,14 +1588,17 @@ export function createSqliteBackend(
             vectorStrategy,
             contributionMaterializer,
           });
-          // BEGIN IMMEDIATE, matching runSchemaWriteTransaction and the
-          // "drizzle" branch below: take the reserved write lock at the start of
-          // the transaction rather than on first write. A deferred BEGIN lets a
-          // read-then-write upgrade the lock mid-transaction, which fails
-          // immediately with "database is locked" against a writer on another
-          // connection (the serialized queue only orders writes within THIS
-          // backend); IMMEDIATE instead waits on SQLite's busy timeout.
-          await runFrameStatement(sql`BEGIN IMMEDIATE`);
+          // Read-only multi-statement operations need one snapshot but must not
+          // reserve SQLite's single writer slot. Business transactions retain
+          // BEGIN IMMEDIATE so read-then-write cannot lose a lock-upgrade race.
+          await runFrameStatement(
+            (
+              options?.accessMode === "read_only" ||
+                temporaryWrites
+            ) ?
+              sql`BEGIN`
+            : sql`BEGIN IMMEDIATE`,
+          );
 
           try {
             const result = await fn(
@@ -1614,17 +1623,19 @@ export function createSqliteBackend(
         );
       }
 
-      // transactionMode === "drizzle". Open with BEGIN IMMEDIATE (the same
-      // behavior runSchemaWriteTransaction uses) so the reserved write lock is
-      // taken at the start of the transaction rather than on first write — a
-      // deferred BEGIN would let a read-then-write race the lock upgrade and
-      // fail with SQLITE_BUSY. The serialized queue orders transactions within
-      // this backend; the immediate lock covers contention across connections.
+      // transactionMode === "drizzle". Read-only work uses a deferred snapshot;
+      // business transactions retain BEGIN IMMEDIATE for safe lock upgrades.
       return runWithSerializedQueue(
         serializedQueue,
         async () =>
           db.transaction(async (tx) => fn(bindTransactionBackend(tx), tx), {
-            behavior: "immediate",
+            behavior:
+              (
+                options?.accessMode === "read_only" ||
+                temporaryWrites
+              ) ?
+                "deferred"
+              : "immediate",
           }) as Promise<T>,
       );
     },

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -20,6 +20,7 @@ import {
 import {
   type CompiledRowsSql,
   type CompiledStatementSql,
+  type CompiledTemporaryStatementSql,
 } from "../query/sql-intent";
 import { type SerializedSchema } from "../schema/types";
 import {
@@ -992,6 +993,11 @@ export type RecordKindRemovalParams = Readonly<{
 // Query Types
 // ============================================================
 
+/** @internal Capability token for connection-local temporary writes. */
+export const INTERNAL_TEMPORARY_WRITES = Symbol(
+  "typegraph.internalTemporaryWrites",
+);
+
 /**
  * Transaction options.
  */
@@ -999,6 +1005,17 @@ export type TransactionOptions = Readonly<{
   /** Transaction isolation level (if supported) */
   isolationLevel?:
     "read_uncommitted" | "read_committed" | "repeatable_read" | "serializable";
+  /**
+   * Transaction access mode (if supported). `read_only` is intended for
+   * multi-statement reads that need one snapshot and must not perform writes.
+   */
+  accessMode?: "read_only" | "read_write";
+  /**
+   * @internal Permit writes only to connection-local temporary state. The
+   * iterative-operation primitive uses this when an engine rejects temporary
+   * DDL in a read-only transaction.
+   */
+  temporaryWrites?: typeof INTERNAL_TEMPORARY_WRITES;
 }>;
 
 /**
@@ -1560,6 +1577,16 @@ export type GraphBackend = Readonly<{
    */
   executeStatement?: (query: CompiledStatementSql) => Promise<void>;
 
+  /**
+   * Execute an internally compiled statement against connection-local
+   * temporary state. History wrappers preserve this path because it cannot
+   * mutate graph or history tables; callers cannot construct its branded
+   * input through the public API.
+   */
+  executeTemporaryStatement?: (
+    query: CompiledTemporaryStatementSql,
+  ) => Promise<void>;
+
   /** Execute pre-compiled SQL text with bound parameters. Available on sync SQLite and pg backends. */
   executeRaw?: <T>(
     sqlText: string,
@@ -1777,7 +1804,7 @@ export type RawQueryExecutionBackend = Pick<
 
 export type RawStatementExecutionBackend = Pick<
   GraphBackend,
-  "executeStatement" | "executeDdl"
+  "executeStatement" | "executeTemporaryStatement" | "executeDdl"
 >;
 
 export type BackendMaintenance = Pick<GraphBackend, "refreshStatistics">;

--- a/packages/typegraph/src/query/sql-intent.ts
+++ b/packages/typegraph/src/query/sql-intent.ts
@@ -2,7 +2,7 @@ import { type SQL } from "drizzle-orm";
 
 declare const SqlIntentBrand: unique symbol;
 
-export type SqlIntent = "rows" | "statement";
+export type SqlIntent = "rows" | "statement" | "temporary-statement";
 
 export type IntentSql<I extends SqlIntent> = SQL &
   Readonly<{ [SqlIntentBrand]: I }>;
@@ -10,6 +10,7 @@ export type IntentSql<I extends SqlIntent> = SQL &
 export type CompiledRowsSql = IntentSql<"rows">;
 export type CompiledSelectSql = CompiledRowsSql;
 export type CompiledStatementSql = IntentSql<"statement">;
+export type CompiledTemporaryStatementSql = IntentSql<"temporary-statement">;
 
 export function asCompiledRowsSql(query: SQL): CompiledRowsSql {
   return query as CompiledRowsSql;
@@ -21,6 +22,18 @@ export function asCompiledSelectSql(query: SQL): CompiledSelectSql {
 
 export function asCompiledStatementSql(query: SQL): CompiledStatementSql {
   return query as CompiledStatementSql;
+}
+
+/**
+ * Marks an internal statement that may write only connection-local temporary
+ * state. This is intentionally separate from the public raw-statement intent:
+ * history-enabled stores block arbitrary raw writes but iterative graph
+ * operations still need to manage ephemeral working tables.
+ */
+export function asCompiledTemporaryStatementSql(
+  query: SQL,
+): CompiledTemporaryStatementSql {
+  return query as CompiledTemporaryStatementSql;
 }
 
 /**

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -1,0 +1,661 @@
+import { sql } from "drizzle-orm";
+
+import { asCompiledRowsSql } from "../../query/sql-intent";
+import { compareStrings } from "../../utils/compare";
+import type { AlgorithmContext, InternalTraversalOptions } from "./context";
+import {
+  compareNodeIdentity,
+  compileWorkingTableExpansion,
+  fetchVisibleWorkingNodes,
+  type IterativeGraphOperation,
+  type IterativeGraphRunContext,
+  type NodeExpansion,
+  type NodeIdentityKey,
+  nodeIdentityKey,
+  reduceExpandedWorkingSet,
+  runIterativeGraphOperation,
+  withInlineIterativeGraphOperation,
+} from "./iterative-graph-operation";
+import type {
+  PathNode,
+  ReachableNode,
+  ShortestPathResult,
+  TraversalDirection,
+} from "./types";
+
+type FrontierCandidate = Readonly<{
+  id: string;
+  kind: string;
+  parentId: string;
+  parentKind: string;
+}>;
+
+type VisitedNode = Readonly<{
+  id: string;
+  kind: string;
+  depth: number;
+  parentKey: NodeIdentityKey | undefined;
+}>;
+
+type WorkingRow = Readonly<{
+  side: WorkingSide;
+  node_id: string;
+  node_kind: string;
+  depth: number | string;
+  predecessor_id: unknown;
+  predecessor_kind: unknown;
+}>;
+
+type CountRow = Readonly<{ count: number | string }>;
+type InsertedRow = Readonly<{ node_id: string }>;
+type WorkingSide = "forward" | "reverse";
+
+type MeetingNode = Readonly<{
+  id: string;
+  kind: string;
+  depth: number;
+}>;
+
+export async function findReachableNodes(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  maxHops: number,
+  options: InternalTraversalOptions,
+): Promise<readonly ReachableNode[]> {
+  if (supportsTemporaryIteration(ctx)) {
+    return findReachableNodesInWorkingTable(ctx, sourceId, maxHops, options);
+  }
+  return findReachableNodesInline(ctx, sourceId, maxHops, options);
+}
+
+export async function findShortestPath(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  maxHops: number,
+  options: InternalTraversalOptions,
+): Promise<ShortestPathResult | undefined> {
+  if (supportsTemporaryIteration(ctx)) {
+    return findShortestPathInWorkingTable(
+      ctx,
+      sourceId,
+      targetId,
+      maxHops,
+      options,
+    );
+  }
+  return findShortestPathInline(ctx, sourceId, targetId, maxHops, options);
+}
+
+function supportsTemporaryIteration(ctx: AlgorithmContext): boolean {
+  return (
+    ctx.backend.capabilities.transactions &&
+    ctx.backend.executeTemporaryStatement !== undefined
+  );
+}
+
+async function findReachableNodesInWorkingTable(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  maxHops: number,
+  options: InternalTraversalOptions,
+): Promise<readonly ReachableNode[]> {
+  return runIterativeGraphOperation(ctx, options, {
+    maxIterations: maxHops,
+    createWorkingTable,
+    async initialize(context) {
+      await seedWorkingSide(context, sourceId, "forward");
+      return {
+        depth: 0,
+        frontierCount: await countWorkingDepth(context, "forward", 0),
+      };
+    },
+    async runRound(context, state) {
+      const nextDepth = state.depth + 1;
+      const frontierCount = await expandWorkingTableRound(
+        context,
+        "forward",
+        state.depth,
+        nextDepth,
+        context.operation.direction,
+      );
+      return { depth: nextDepth, frontierCount };
+    },
+    hasConverged(state) {
+      return state.frontierCount === 0 || state.depth >= maxHops;
+    },
+    async extractResult(context) {
+      const rows = await readWorkingRows(context, "forward");
+      return rows
+        .map((row) => ({
+          id: row.node_id,
+          kind: row.node_kind,
+          depth: Number(row.depth),
+        }))
+        .toSorted(
+          (left, right) =>
+            left.depth - right.depth || compareNodeIdentity(left, right),
+        );
+    },
+  });
+}
+
+async function findShortestPathInWorkingTable(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  maxHops: number,
+  options: InternalTraversalOptions,
+): Promise<ShortestPathResult | undefined> {
+  return runIterativeGraphOperation(ctx, options, {
+    maxIterations: maxHops,
+    createWorkingTable,
+    async initialize(context) {
+      await seedWorkingSide(context, sourceId, "forward");
+      await seedWorkingSide(context, targetId, "reverse");
+      const [forwardFrontierCount, reverseFrontierCount, meeting] =
+        await Promise.all([
+          countWorkingDepth(context, "forward", 0),
+          countWorkingDepth(context, "reverse", 0),
+          findWorkingMeeting(context, maxHops),
+        ]);
+      return {
+        forwardDepth: 0,
+        reverseDepth: 0,
+        forwardFrontierCount,
+        reverseFrontierCount,
+        meeting,
+      };
+    },
+    async runRound(context, state) {
+      const expandForward =
+        state.forwardFrontierCount <= state.reverseFrontierCount;
+      const side = expandForward ? "forward" : "reverse";
+      const currentDepth =
+        expandForward ? state.forwardDepth : state.reverseDepth;
+      const nextDepth = currentDepth + 1;
+      const direction =
+        expandForward ?
+          context.operation.direction
+        : reverseDirection(context.operation.direction);
+      const frontierCount = await expandWorkingTableRound(
+        context,
+        side,
+        currentDepth,
+        nextDepth,
+        direction,
+      );
+      const meeting = await findWorkingMeeting(context, maxHops);
+
+      return {
+        forwardDepth: expandForward ? nextDepth : state.forwardDepth,
+        reverseDepth: expandForward ? state.reverseDepth : nextDepth,
+        forwardFrontierCount:
+          expandForward ? frontierCount : state.forwardFrontierCount,
+        reverseFrontierCount:
+          expandForward ? state.reverseFrontierCount : frontierCount,
+        meeting,
+      };
+    },
+    hasConverged(state) {
+      return (
+        state.meeting !== undefined ||
+        state.forwardFrontierCount === 0 ||
+        state.reverseFrontierCount === 0 ||
+        state.forwardDepth + state.reverseDepth >= maxHops
+      );
+    },
+    async extractResult(context, state) {
+      if (state.meeting === undefined) return;
+      const rows = await readWorkingRows(context);
+      return buildShortestPath(
+        nodeIdentityKey(state.meeting),
+        createVisitedMapFromRows(rows, "forward"),
+        createVisitedMapFromRows(rows, "reverse"),
+      );
+    },
+  });
+}
+
+function createWorkingTable(context: IterativeGraphRunContext) {
+  return sql`
+    CREATE TEMP TABLE ${context.workingTable} (
+        graph_id TEXT NOT NULL,
+        run_id TEXT NOT NULL,
+        side TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        node_kind TEXT NOT NULL,
+        depth INTEGER NOT NULL,
+        predecessor_id TEXT,
+        predecessor_kind TEXT,
+        PRIMARY KEY (graph_id, run_id, side, node_kind, node_id)
+      )
+  `;
+}
+
+async function seedWorkingSide(
+  context: IterativeGraphRunContext,
+  nodeId: string,
+  side: WorkingSide,
+): Promise<void> {
+  const { operation, workingTable, graphId, runId } = context;
+  await context.executeTemporary(sql`
+    INSERT INTO ${workingTable}
+      (graph_id, run_id, side, node_id, node_kind, depth,
+       predecessor_id, predecessor_kind)
+    SELECT ${graphId}, ${runId}, ${side}, n.id, n.kind, 0, NULL, NULL
+    FROM ${operation.schema.nodesTable} n
+    WHERE n.graph_id = ${graphId}
+      AND n.id = ${nodeId}
+      AND ${operation.nodeTemporalFilter}
+    ON CONFLICT (graph_id, run_id, side, node_kind, node_id) DO NOTHING
+  `);
+}
+
+async function countWorkingDepth(
+  context: IterativeGraphRunContext,
+  side: WorkingSide,
+  depth: number,
+): Promise<number> {
+  const rows = await context.backend.execute<CountRow>(
+    asCompiledRowsSql(sql`
+      SELECT COUNT(*) AS count
+      FROM ${context.workingTable}
+      WHERE graph_id = ${context.graphId}
+        AND run_id = ${context.runId}
+        AND side = ${side}
+        AND depth = ${depth}
+    `),
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+async function expandWorkingTableRound(
+  context: IterativeGraphRunContext,
+  side: WorkingSide,
+  currentDepth: number,
+  nextDepth: number,
+  direction: TraversalDirection,
+): Promise<number> {
+  let insertedCount = 0;
+  for (const edgeKinds of context.operation.edgeKindChunks) {
+    const sourceFilter = sql`
+      w.graph_id = ${context.graphId}
+      AND w.run_id = ${context.runId}
+      AND w.side = ${side}
+      AND w.depth = ${currentDepth}
+    `;
+    const expansion = compileWorkingTableExpansion(
+      context.operation,
+      context.workingTable,
+      sourceFilter,
+      direction,
+      edgeKinds,
+    );
+    const rows = await context.backend.execute<InsertedRow>(
+      asCompiledRowsSql(sql`
+        INSERT INTO ${context.workingTable}
+          (graph_id, run_id, side, node_id, node_kind, depth,
+           predecessor_id, predecessor_kind)
+        SELECT
+          ${context.graphId}, ${context.runId}, ${side},
+          ranked.target_id, ranked.target_kind, ${nextDepth},
+          ranked.source_id, ranked.source_kind
+        FROM (
+          SELECT expanded.*,
+            ROW_NUMBER() OVER (
+              PARTITION BY expanded.target_kind, expanded.target_id
+              ORDER BY expanded.source_id, expanded.source_kind
+            ) AS candidate_rank
+          FROM (${expansion}) expanded
+        ) ranked
+        WHERE ranked.candidate_rank = 1
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${context.workingTable} visited
+            WHERE visited.graph_id = ${context.graphId}
+              AND visited.run_id = ${context.runId}
+              AND visited.side = ${side}
+              AND visited.node_id = ranked.target_id
+              AND visited.node_kind = ranked.target_kind
+          )
+        ON CONFLICT (graph_id, run_id, side, node_kind, node_id) DO NOTHING
+        RETURNING node_id
+      `),
+    );
+    insertedCount += rows.length;
+  }
+  return insertedCount;
+}
+
+async function findWorkingMeeting(
+  context: IterativeGraphRunContext,
+  maxHops: number,
+): Promise<MeetingNode | undefined> {
+  const rows = await context.backend.execute<
+    Readonly<{
+      node_id: string;
+      node_kind: string;
+      total_depth: number | string;
+    }>
+  >(
+    asCompiledRowsSql(sql`
+      SELECT
+        forward.node_id,
+        forward.node_kind,
+        forward.depth + reverse.depth AS total_depth
+      FROM ${context.workingTable} forward
+      JOIN ${context.workingTable} reverse
+        ON reverse.graph_id = forward.graph_id
+        AND reverse.run_id = forward.run_id
+        AND reverse.node_id = forward.node_id
+        AND reverse.node_kind = forward.node_kind
+      WHERE forward.graph_id = ${context.graphId}
+        AND forward.run_id = ${context.runId}
+        AND forward.side = 'forward'
+        AND reverse.side = 'reverse'
+        AND forward.depth + reverse.depth <= ${maxHops}
+      ORDER BY total_depth, forward.node_id, forward.node_kind
+      LIMIT 1
+    `),
+  );
+  const row = rows[0];
+  if (row === undefined) return;
+  return {
+    id: row.node_id,
+    kind: row.node_kind,
+    depth: Number(row.total_depth),
+  };
+}
+
+async function readWorkingRows(
+  context: IterativeGraphRunContext,
+  side?: WorkingSide,
+): Promise<readonly WorkingRow[]> {
+  const sideFilter = side === undefined ? sql`TRUE` : sql`side = ${side}`;
+  return context.backend.execute<WorkingRow>(
+    asCompiledRowsSql(sql`
+      SELECT side, node_id, node_kind, depth,
+        predecessor_id, predecessor_kind
+      FROM ${context.workingTable}
+      WHERE graph_id = ${context.graphId}
+        AND run_id = ${context.runId}
+        AND ${sideFilter}
+      ORDER BY side, depth, node_id, node_kind
+    `),
+  );
+}
+
+async function findReachableNodesInline(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  maxHops: number,
+  options: InternalTraversalOptions,
+): Promise<readonly ReachableNode[]> {
+  return withInlineIterativeGraphOperation(ctx, options, async (operation) => {
+    const sources = await fetchVisibleWorkingNodes(operation, [sourceId]);
+    if (sources.length === 0) return [];
+
+    const reached = new Map<NodeIdentityKey, ReachableNode>(
+      sources.map((source) => [
+        nodeIdentityKey(source),
+        { id: source.id, kind: source.kind, depth: 0 },
+      ]),
+    );
+    let workingSet: readonly PathNode[] = sources;
+
+    for (let depth = 1; depth <= maxHops && workingSet.length > 0; depth++) {
+      const candidates = await expandInlineWorkingSet(
+        operation,
+        workingSet,
+        operation.direction,
+        reached,
+      );
+      const nextWorkingSet = sortCandidates(candidates);
+      for (const candidate of nextWorkingSet) {
+        reached.set(nodeIdentityKey(candidate), {
+          id: candidate.id,
+          kind: candidate.kind,
+          depth,
+        });
+      }
+      workingSet = nextWorkingSet;
+    }
+
+    return [...reached.values()].toSorted(
+      (left, right) =>
+        left.depth - right.depth || compareNodeIdentity(left, right),
+    );
+  });
+}
+
+async function findShortestPathInline(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  maxHops: number,
+  options: InternalTraversalOptions,
+): Promise<ShortestPathResult | undefined> {
+  return withInlineIterativeGraphOperation(ctx, options, async (operation) => {
+    const visibleNodes = await fetchVisibleWorkingNodes(operation, [
+      sourceId,
+      targetId,
+    ]);
+    const sources = visibleNodes.filter((node) => node.id === sourceId);
+    const targets = visibleNodes.filter((node) => node.id === targetId);
+    if (sources.length === 0 || targets.length === 0) return;
+    if (sourceId === targetId) return { nodes: [sources[0]!], depth: 0 };
+
+    const forwardVisited = createVisitedMap(sources);
+    const reverseVisited = createVisitedMap(targets);
+    let forwardWorkingSet: readonly PathNode[] = sources;
+    let reverseWorkingSet: readonly PathNode[] = targets;
+    let forwardDepth = 0;
+    let reverseDepth = 0;
+
+    while (
+      forwardWorkingSet.length > 0 &&
+      reverseWorkingSet.length > 0 &&
+      forwardDepth + reverseDepth < maxHops
+    ) {
+      const expandForward =
+        forwardWorkingSet.length <= reverseWorkingSet.length;
+      const activeVisited = expandForward ? forwardVisited : reverseVisited;
+      const oppositeVisited = expandForward ? reverseVisited : forwardVisited;
+      const currentWorkingSet =
+        expandForward ? forwardWorkingSet : reverseWorkingSet;
+      const direction =
+        expandForward ?
+          operation.direction
+        : reverseDirection(operation.direction);
+      const candidates = await expandInlineWorkingSet(
+        operation,
+        currentWorkingSet,
+        direction,
+        activeVisited,
+      );
+      const nextDepth = (expandForward ? forwardDepth : reverseDepth) + 1;
+      const nextWorkingSet = sortCandidates(candidates);
+
+      for (const candidate of nextWorkingSet) {
+        activeVisited.set(nodeIdentityKey(candidate), {
+          id: candidate.id,
+          kind: candidate.kind,
+          depth: nextDepth,
+          parentKey: nodeIdentityKey({
+            id: candidate.parentId,
+            kind: candidate.parentKind,
+          }),
+        });
+      }
+
+      const meetingKey = findMeetingNodeKey(
+        nextWorkingSet,
+        activeVisited,
+        oppositeVisited,
+      );
+      if (meetingKey !== undefined) {
+        return buildShortestPath(meetingKey, forwardVisited, reverseVisited);
+      }
+
+      if (expandForward) {
+        forwardWorkingSet = nextWorkingSet;
+        forwardDepth = nextDepth;
+      } else {
+        reverseWorkingSet = nextWorkingSet;
+        reverseDepth = nextDepth;
+      }
+    }
+    return;
+  });
+}
+
+async function expandInlineWorkingSet(
+  operation: IterativeGraphOperation,
+  workingSet: readonly PathNode[],
+  direction: TraversalDirection,
+  visited: ReadonlyMap<NodeIdentityKey, unknown>,
+): Promise<ReadonlyMap<NodeIdentityKey, FrontierCandidate>> {
+  return reduceExpandedWorkingSet(
+    operation,
+    workingSet,
+    direction,
+    (existing, expansion) => selectPredecessor(existing, expansion, visited),
+  );
+}
+
+function selectPredecessor(
+  existing: FrontierCandidate | undefined,
+  expansion: NodeExpansion,
+  visited: ReadonlyMap<NodeIdentityKey, unknown>,
+): FrontierCandidate | undefined {
+  if (visited.has(nodeIdentityKey(expansion.target))) return existing;
+  if (
+    existing !== undefined &&
+    compareNodeIdentity(expansion.source, {
+      id: existing.parentId,
+      kind: existing.parentKind,
+    }) >= 0
+  ) {
+    return existing;
+  }
+  return {
+    id: expansion.target.id,
+    kind: expansion.target.kind,
+    parentId: expansion.source.id,
+    parentKind: expansion.source.kind,
+  };
+}
+
+function sortCandidates(
+  candidates: ReadonlyMap<NodeIdentityKey, FrontierCandidate>,
+): readonly FrontierCandidate[] {
+  return [...candidates.values()].toSorted((left, right) =>
+    compareNodeIdentity(left, right),
+  );
+}
+
+function findMeetingNodeKey(
+  candidates: readonly FrontierCandidate[],
+  activeVisited: ReadonlyMap<NodeIdentityKey, VisitedNode>,
+  oppositeVisited: ReadonlyMap<NodeIdentityKey, VisitedNode>,
+): NodeIdentityKey | undefined {
+  let best: Readonly<{ key: NodeIdentityKey; depth: number }> | undefined;
+  for (const candidate of candidates) {
+    const key = nodeIdentityKey(candidate);
+    const active = activeVisited.get(key);
+    const opposite = oppositeVisited.get(key);
+    if (active === undefined || opposite === undefined) continue;
+    const meeting = { key, depth: active.depth + opposite.depth };
+    if (
+      best === undefined ||
+      meeting.depth < best.depth ||
+      (meeting.depth === best.depth &&
+        compareStrings(meeting.key, best.key) < 0)
+    ) {
+      best = meeting;
+    }
+  }
+  return best?.key;
+}
+
+function buildShortestPath(
+  meetingKey: NodeIdentityKey,
+  forwardVisited: ReadonlyMap<NodeIdentityKey, VisitedNode>,
+  reverseVisited: ReadonlyMap<NodeIdentityKey, VisitedNode>,
+): ShortestPathResult {
+  const forwardKeys: NodeIdentityKey[] = [];
+  let cursor: NodeIdentityKey | undefined = meetingKey;
+  while (cursor !== undefined) {
+    forwardKeys.push(cursor);
+    cursor = forwardVisited.get(cursor)?.parentKey;
+  }
+  forwardKeys.reverse();
+
+  const pathKeys = [...forwardKeys];
+  cursor = reverseVisited.get(meetingKey)?.parentKey;
+  while (cursor !== undefined) {
+    pathKeys.push(cursor);
+    cursor = reverseVisited.get(cursor)?.parentKey;
+  }
+
+  const nodes = pathKeys.map((key) => {
+    const node = forwardVisited.get(key) ?? reverseVisited.get(key);
+    return { id: node?.id ?? "", kind: node?.kind ?? "" };
+  });
+  return { nodes, depth: nodes.length - 1 };
+}
+
+function createVisitedMap(
+  nodes: readonly PathNode[],
+): Map<NodeIdentityKey, VisitedNode> {
+  return new Map(
+    nodes.map((node) => [
+      nodeIdentityKey(node),
+      { id: node.id, kind: node.kind, depth: 0, parentKey: undefined },
+    ]),
+  );
+}
+
+function createVisitedMapFromRows(
+  rows: readonly WorkingRow[],
+  side: WorkingSide,
+): Map<NodeIdentityKey, VisitedNode> {
+  return new Map(
+    rows
+      .filter((row) => row.side === side)
+      .map((row) => {
+        const parentKey =
+          (
+            typeof row.predecessor_id !== "string" ||
+            typeof row.predecessor_kind !== "string"
+          ) ?
+            undefined
+          : nodeIdentityKey({
+              id: row.predecessor_id,
+              kind: row.predecessor_kind,
+            });
+        const node = {
+          id: row.node_id,
+          kind: row.node_kind,
+          depth: Number(row.depth),
+          parentKey,
+        } satisfies VisitedNode;
+        return [nodeIdentityKey(node), node];
+      }),
+  );
+}
+
+function reverseDirection(direction: TraversalDirection): TraversalDirection {
+  switch (direction) {
+    case "out": {
+      return "in";
+    }
+    case "in": {
+      return "out";
+    }
+    case "both": {
+      return "both";
+    }
+  }
+}

--- a/packages/typegraph/src/store/algorithms/index.ts
+++ b/packages/typegraph/src/store/algorithms/index.ts
@@ -84,7 +84,7 @@ export type GraphAlgorithms<G extends GraphDef> = Readonly<{
 
   /**
    * Fast boolean check: is `to` reachable from `from` within `maxHops`
-   * edges? Short-circuits the underlying recursive CTE with `LIMIT 1`.
+   * edges? Uses bidirectional BFS and stops when the frontiers meet.
    */
   canReach: (
     from: NodeIdentifier,

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -1,0 +1,482 @@
+import { type SQL, sql } from "drizzle-orm";
+
+import {
+  type GraphBackend,
+  INTERNAL_TEMPORARY_WRITES,
+  type TransactionBackend,
+} from "../../backend/types";
+import { ConfigurationError } from "../../errors";
+import {
+  compileKindFilter,
+  sqlValueList,
+} from "../../query/compiler/predicate-utils";
+import {
+  compileTemporalFilter,
+  currentReadInstant,
+} from "../../query/compiler/temporal";
+import {
+  asCompiledRowsSql,
+  asCompiledTemporaryStatementSql,
+} from "../../query/sql-intent";
+import { compareStrings } from "../../utils/compare";
+import { generateId } from "../../utils/id";
+import type { AlgorithmContext, InternalTraversalOptions } from "./context";
+import { resolveReadSchema, resolveTemporalOptions } from "./context";
+import type { PathNode, TraversalDirection } from "./types";
+
+type QueryBackend = Pick<GraphBackend, "capabilities" | "execute">;
+type WorkingTableIdentifier = ReturnType<typeof sql.identifier>;
+
+export type IterativeGraphOperation = Readonly<{
+  backend: QueryBackend;
+  ctx: AlgorithmContext;
+  edgeKindChunks: readonly (readonly string[])[];
+  direction: TraversalDirection;
+  maxWorkingSetSize: number;
+  nodeTemporalFilter: ReturnType<typeof compileTemporalFilter>;
+  edgeTemporalFilter: ReturnType<typeof compileTemporalFilter>;
+  schema: ReturnType<typeof resolveReadSchema>;
+}>;
+
+export type NodeIdentityKey = string & {
+  readonly __nodeIdentityKey: unique symbol;
+};
+
+export type NodeExpansion = Readonly<{
+  source: PathNode;
+  target: PathNode;
+}>;
+
+type TemporaryStatementBackend = QueryBackend &
+  Pick<TransactionBackend, "executeTemporaryStatement"> &
+  Readonly<{
+    executeTemporaryStatement: NonNullable<
+      TransactionBackend["executeTemporaryStatement"]
+    >;
+  }>;
+
+export type IterativeGraphRunContext = Readonly<{
+  operation: IterativeGraphOperation;
+  backend: TemporaryStatementBackend;
+  workingTable: WorkingTableIdentifier;
+  graphId: string;
+  runId: string;
+  executeTemporary: (query: SQL) => Promise<void>;
+}>;
+
+export type IterativeGraphPlan<State, Result> = Readonly<{
+  maxIterations: number;
+  createWorkingTable: (context: IterativeGraphRunContext) => SQL;
+  initialize: (context: IterativeGraphRunContext) => Promise<State>;
+  runRound: (
+    context: IterativeGraphRunContext,
+    state: State,
+    iteration: number,
+  ) => Promise<State>;
+  hasConverged: (state: State) => boolean;
+  extractResult: (
+    context: IterativeGraphRunContext,
+    state: State,
+  ) => Promise<Result>;
+}>;
+
+type ExpansionRow = Readonly<{
+  source_id: string;
+  source_kind: string;
+  target_id: string;
+  target_kind: string;
+}>;
+
+type VisibleNodeRow = Readonly<{
+  id: string;
+  kind: string;
+}>;
+
+const DEFAULT_MAX_BIND_PARAMETERS = 999;
+const RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH = 12;
+
+/**
+ * Opens the shared execution scope for iterative graph algorithms. The host
+ * controls rounds and convergence; this scope supplies a snapshot-consistent,
+ * bind-limit-aware SQL working relation for each round.
+ *
+ * The working relation is emitted as chunked `VALUES` rows rather than a
+ * connection-local temporary table. That keeps the primitive portable to
+ * backends such as D1 that cannot promise one pinned connection. Transactional
+ * backends still run all rounds in one read-only snapshot.
+ */
+export async function withInlineIterativeGraphOperation<T>(
+  ctx: AlgorithmContext,
+  options: InternalTraversalOptions,
+  run: (operation: IterativeGraphOperation) => Promise<T>,
+): Promise<T> {
+  if (ctx.backend.capabilities.transactions) {
+    return ctx.backend.transaction(
+      async (backend) => run(createOperation(ctx, options, backend)),
+      {
+        isolationLevel: "repeatable_read",
+        accessMode: "read_only",
+      },
+    );
+  }
+  return run(createOperation(ctx, options, ctx.backend));
+}
+
+/**
+ * Runs a compiler-defined iterative algorithm against a real temporary working
+ * table. The primitive owns the read-only snapshot, iteration cap, convergence
+ * check, and `finally` cleanup; the plan owns only table shape, round SQL, and
+ * result extraction.
+ */
+export async function runIterativeGraphOperation<State, Result>(
+  ctx: AlgorithmContext,
+  options: InternalTraversalOptions,
+  plan: IterativeGraphPlan<State, Result>,
+): Promise<Result> {
+  if (!ctx.backend.capabilities.transactions) {
+    throw new ConfigurationError(
+      "Temporary-table graph iteration requires a transactional backend.",
+      { dialect: ctx.backend.dialect },
+    );
+  }
+
+  return ctx.backend.transaction(
+    async (backend) => {
+      const temporaryBackend = requireTemporaryStatements(backend);
+      const runId = generateId();
+      const workingTable = sql.identifier(
+        `typegraph_iterative_${runId.replaceAll("-", "_")}`,
+      );
+      const context: IterativeGraphRunContext = {
+        operation: createOperation(ctx, options, temporaryBackend),
+        backend: temporaryBackend,
+        workingTable,
+        graphId: ctx.graphId,
+        runId,
+        executeTemporary: async (query) => {
+          await temporaryBackend.executeTemporaryStatement(
+            asCompiledTemporaryStatementSql(query),
+          );
+        },
+      };
+
+      await context.executeTemporary(plan.createWorkingTable(context));
+      let operationError: unknown;
+      try {
+        let state = await plan.initialize(context);
+        for (
+          let iteration = 1;
+          iteration <= plan.maxIterations && !plan.hasConverged(state);
+          iteration++
+        ) {
+          state = await plan.runRound(context, state, iteration);
+        }
+        return await plan.extractResult(context, state);
+      } catch (error) {
+        operationError = error;
+        throw error;
+      } finally {
+        await dropWorkingTable(context, operationError);
+      }
+    },
+    {
+      isolationLevel: "repeatable_read",
+      accessMode: "read_only",
+      temporaryWrites: INTERNAL_TEMPORARY_WRITES,
+    },
+  );
+}
+
+async function dropWorkingTable(
+  context: IterativeGraphRunContext,
+  operationError: unknown,
+): Promise<void> {
+  try {
+    await context.executeTemporary(
+      sql`DROP TABLE IF EXISTS ${context.workingTable}`,
+    );
+  } catch (cleanupError) {
+    // A failed PostgreSQL statement aborts the transaction, so DROP is
+    // rejected too; rollback then owns cleanup. Preserve the algorithm's root
+    // error instead of masking it with "transaction is aborted".
+    if (operationError === undefined) throw cleanupError;
+  }
+}
+
+export async function fetchVisibleWorkingNodes(
+  operation: IterativeGraphOperation,
+  nodeIds: readonly string[],
+): Promise<readonly PathNode[]> {
+  const nodes = new Map<NodeIdentityKey, PathNode>();
+  for (const chunk of chunkValues(nodeIds, operation.maxWorkingSetSize)) {
+    const query = sql`SELECT n.id, n.kind FROM ${operation.schema.nodesTable} n WHERE n.graph_id = ${operation.ctx.graphId} AND n.id IN (${sqlValueList(chunk)}) AND ${operation.nodeTemporalFilter}`;
+    const rows = await operation.backend.execute<VisibleNodeRow>(
+      asCompiledRowsSql(query),
+    );
+    for (const row of rows) nodes.set(nodeIdentityKey(row), row);
+  }
+  return [...nodes.values()].toSorted((left, right) =>
+    compareNodeIdentity(left, right),
+  );
+}
+
+/**
+ * Expands one working-set round and reduces all matching edges by target-node
+ * identity before returning to the host loop. Callers choose the reduction:
+ * BFS keeps one predecessor, label-min keeps the smallest propagated label,
+ * and other fixpoint algorithms can define their own associative merge.
+ */
+export async function reduceExpandedWorkingSet<T>(
+  operation: IterativeGraphOperation,
+  workingSet: readonly PathNode[],
+  direction: TraversalDirection,
+  reduce: (current: T | undefined, expansion: NodeExpansion) => T | undefined,
+): Promise<ReadonlyMap<NodeIdentityKey, T>> {
+  const reduced = new Map<NodeIdentityKey, T>();
+  for (const edgeKinds of operation.edgeKindChunks) {
+    for (const chunk of chunkValues(workingSet, operation.maxWorkingSetSize)) {
+      const rows = await operation.backend.execute<ExpansionRow>(
+        asCompiledRowsSql(
+          compileExpansionQuery(operation, chunk, direction, edgeKinds),
+        ),
+      );
+      for (const row of rows) {
+        const expansion = {
+          source: { id: row.source_id, kind: row.source_kind },
+          target: { id: row.target_id, kind: row.target_kind },
+        } satisfies NodeExpansion;
+        const targetKey = nodeIdentityKey(expansion.target);
+        const selected = reduce(reduced.get(targetKey), expansion);
+        if (selected !== undefined) reduced.set(targetKey, selected);
+      }
+    }
+  }
+  return reduced;
+}
+
+export function nodeIdentityKey(node: PathNode): NodeIdentityKey {
+  return `${node.kind}\u0000${node.id}` as NodeIdentityKey;
+}
+
+export function compareNodeIdentity(left: PathNode, right: PathNode): number {
+  return (
+    compareStrings(left.id, right.id) || compareStrings(left.kind, right.kind)
+  );
+}
+
+function compileExpansionQuery(
+  operation: IterativeGraphOperation,
+  workingSet: readonly PathNode[],
+  direction: TraversalDirection,
+  edgeKinds: readonly string[],
+): ReturnType<typeof sql> {
+  const workingValues = sql.join(
+    workingSet.map((node) => sql`(${node.id}, ${node.kind})`),
+    sql`, `,
+  );
+  const workingCte = sql`WITH working_set(node_id, node_kind) AS (VALUES ${workingValues})`;
+
+  switch (direction) {
+    case "out": {
+      return sql`${workingCte} ${compileDirectionalExpansion(operation, sql`working_set`, sql`TRUE`, edgeKinds, "from_id", "from_kind", "to_id", "to_kind")}`;
+    }
+    case "in": {
+      return sql`${workingCte} ${compileDirectionalExpansion(operation, sql`working_set`, sql`TRUE`, edgeKinds, "to_id", "to_kind", "from_id", "from_kind")}`;
+    }
+    case "both": {
+      const outgoing = compileDirectionalExpansion(
+        operation,
+        sql`working_set`,
+        sql`TRUE`,
+        edgeKinds,
+        "from_id",
+        "from_kind",
+        "to_id",
+        "to_kind",
+      );
+      const incoming = compileDirectionalExpansion(
+        operation,
+        sql`working_set`,
+        sql`TRUE`,
+        edgeKinds,
+        "to_id",
+        "to_kind",
+        "from_id",
+        "from_kind",
+      );
+      return sql`${workingCte} ${outgoing} UNION ALL ${incoming}`;
+    }
+  }
+}
+
+export function compileWorkingTableExpansion(
+  operation: IterativeGraphOperation,
+  workingTable: WorkingTableIdentifier,
+  sourceFilter: SQL,
+  direction: TraversalDirection,
+  edgeKinds: readonly string[],
+): SQL {
+  switch (direction) {
+    case "out": {
+      return compileDirectionalExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "from_id",
+        "from_kind",
+        "to_id",
+        "to_kind",
+      );
+    }
+    case "in": {
+      return compileDirectionalExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "to_id",
+        "to_kind",
+        "from_id",
+        "from_kind",
+      );
+    }
+    case "both": {
+      const outgoing = compileDirectionalExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "from_id",
+        "from_kind",
+        "to_id",
+        "to_kind",
+      );
+      const incoming = compileDirectionalExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "to_id",
+        "to_kind",
+        "from_id",
+        "from_kind",
+      );
+      return sql`${outgoing} UNION ALL ${incoming}`;
+    }
+  }
+}
+
+function compileDirectionalExpansion(
+  operation: IterativeGraphOperation,
+  workingRelation: SQL | WorkingTableIdentifier,
+  sourceFilter: SQL,
+  edgeKinds: readonly string[],
+  joinField: "from_id" | "to_id",
+  joinKindField: "from_kind" | "to_kind",
+  targetField: "from_id" | "to_id",
+  targetKindField: "from_kind" | "to_kind",
+): ReturnType<typeof sql> {
+  const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
+  return sql`SELECT w.node_id AS source_id, w.node_kind AS source_kind, n.id AS target_id, n.kind AS target_kind FROM ${workingRelation} w JOIN ${operation.schema.edgesTable} e ON e.${sql.raw(joinField)} = w.node_id AND e.${sql.raw(joinKindField)} = w.node_kind AND e.graph_id = ${operation.ctx.graphId} JOIN ${operation.schema.nodesTable} n ON n.graph_id = e.graph_id AND n.id = e.${sql.raw(targetField)} AND n.kind = e.${sql.raw(targetKindField)} WHERE ${sourceFilter} AND ${edgeKindFilter} AND ${operation.edgeTemporalFilter} AND ${operation.nodeTemporalFilter}`;
+}
+
+function chunkValues<T>(
+  values: readonly T[],
+  chunkSize: number,
+): readonly (readonly T[])[] {
+  const chunks: T[][] = [];
+  for (let offset = 0; offset < values.length; offset += chunkSize) {
+    chunks.push(values.slice(offset, offset + chunkSize));
+  }
+  return chunks;
+}
+
+function createOperation(
+  ctx: AlgorithmContext,
+  options: InternalTraversalOptions,
+  backend: QueryBackend | TransactionBackend,
+): IterativeGraphOperation {
+  const temporal = resolveTemporalOptions(ctx, options);
+  const currentTimestamp = currentReadInstant();
+  const nodeTemporalFilter = compileTemporalFilter({
+    mode: temporal.temporalMode,
+    ...(temporal.asOf === undefined ? {} : { asOf: temporal.asOf }),
+    ...(temporal.recordedAsOf === undefined ?
+      {}
+    : { recordedAsOf: temporal.recordedAsOf }),
+    tableAlias: "n",
+    currentTimestamp,
+  });
+  const edgeTemporalFilter = compileTemporalFilter({
+    mode: temporal.temporalMode,
+    ...(temporal.asOf === undefined ? {} : { asOf: temporal.asOf }),
+    ...(temporal.recordedAsOf === undefined ?
+      {}
+    : { recordedAsOf: temporal.recordedAsOf }),
+    tableAlias: "e",
+    currentTimestamp,
+  });
+  const direction = options.direction ?? "out";
+  const branchCount = direction === "both" ? 2 : 1;
+  const parameterLimit =
+    backend.capabilities.maxBindParameters ?? DEFAULT_MAX_BIND_PARAMETERS;
+  const fixedParameters =
+    branchCount * RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH;
+  const sharedBudget = parameterLimit - fixedParameters;
+  const maxEdgeKindsPerQuery = Math.floor(sharedBudget / (branchCount + 2));
+  if (maxEdgeKindsPerQuery < 1) {
+    throw new ConfigurationError(
+      "An iterative graph operation cannot fit its fixed filters within the backend bind-parameter limit.",
+      { parameterLimit, direction },
+    );
+  }
+  const edgeKindChunks = chunkValues(
+    [...new Set(options.edges)].toSorted((left, right) =>
+      compareStrings(left, right),
+    ),
+    maxEdgeKindsPerQuery,
+  );
+  const largestEdgeKindChunk = Math.max(
+    ...edgeKindChunks.map((chunk) => chunk.length),
+  );
+  const maxWorkingSetSize = Math.floor(
+    (parameterLimit -
+      branchCount *
+        (largestEdgeKindChunk + RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH)) /
+      2,
+  );
+  if (maxWorkingSetSize < 1) {
+    throw new ConfigurationError(
+      "An iterative graph operation cannot fit one working-set node within the backend bind-parameter limit.",
+      { parameterLimit, direction },
+    );
+  }
+
+  return {
+    backend,
+    ctx,
+    edgeKindChunks,
+    direction,
+    maxWorkingSetSize,
+    nodeTemporalFilter,
+    edgeTemporalFilter,
+    schema: resolveReadSchema(ctx, options),
+  };
+}
+
+function requireTemporaryStatements(
+  backend: TransactionBackend,
+): TemporaryStatementBackend {
+  if (backend.executeTemporaryStatement === undefined) {
+    throw new ConfigurationError(
+      "Iterative graph operations require temporary-statement support on the transaction backend.",
+      { dialect: backend.dialect },
+      {
+        suggestion:
+          "Use a built-in SQLite/PostgreSQL backend or implement executeTemporaryStatement on the custom backend.",
+      },
+    );
+  }
+  return backend as TemporaryStatementBackend;
+}

--- a/packages/typegraph/src/store/algorithms/reachable.ts
+++ b/packages/typegraph/src/store/algorithms/reachable.ts
@@ -1,7 +1,4 @@
-import { sql } from "drizzle-orm";
-
-import { asCompiledRowsSql } from "../../query/sql-intent";
-import { buildReachableCte } from "../recursive-cte";
+import { findReachableNodes, findShortestPath } from "./breadth-first";
 import {
   type AlgorithmContext,
   assertEdgeKinds,
@@ -9,7 +6,6 @@ import {
   DEFAULT_NEIGHBOR_DEPTH,
   type InternalTraversalOptions,
   resolveMaxHops,
-  resolveTemporalOptions,
 } from "./context";
 import type { ReachableNode } from "./types";
 
@@ -18,12 +14,6 @@ type InternalReachableOptions = InternalTraversalOptions &
 
 type InternalNeighborsOptions = Omit<InternalTraversalOptions, "maxHops"> &
   Readonly<{ depth?: number }>;
-
-type ReachableRow = Readonly<{
-  id: string;
-  kind: string;
-  depth: number | string;
-}>;
 
 export async function executeReachable(
   ctx: AlgorithmContext,
@@ -37,35 +27,10 @@ export async function executeReachable(
     "maxHops",
   );
 
-  const cte = buildReachableCte({
-    graphId: ctx.graphId,
-    sourceId,
-    edgeKinds: options.edges,
-    maxHops,
-    direction: options.direction ?? "out",
-    cyclePolicy: options.cyclePolicy ?? "prevent",
-    includePath: false,
-    ...resolveTemporalOptions(ctx, options),
-    dialect: ctx.dialect,
-    schema: ctx.schema,
-    ...(ctx.recordedReadBinding === undefined ?
-      {}
-    : { recordedReadBinding: ctx.recordedReadBinding }),
-  });
-
-  const sourceFilter =
-    options.excludeSource === true ? sql` WHERE id != ${sourceId}` : sql``;
-
-  const query = sql`${cte} SELECT id, kind, MIN(depth) AS depth FROM reachable${sourceFilter} GROUP BY id, kind ORDER BY depth ASC, id ASC`;
-
-  const rows = await ctx.backend.execute<ReachableRow>(
-    asCompiledRowsSql(query),
-  );
-  return rows.map((row) => ({
-    id: row.id,
-    kind: row.kind,
-    depth: Number(row.depth),
-  }));
+  const reached = await findReachableNodes(ctx, sourceId, maxHops, options);
+  return options.excludeSource === true ?
+      reached.filter((node) => node.id !== sourceId)
+    : reached;
 }
 
 export async function executeCanReach(
@@ -82,32 +47,10 @@ export async function executeCanReach(
     "maxHops",
   );
 
-  // Self-case (sourceId === targetId) is not short-circuited: the CTE base
-  // case emits the source row only if it passes the temporal filter, so
-  // `canReach(a, a)` correctly returns false when `a` is not visible under
-  // the resolved mode — consistent with `shortestPath(a, a)`.
-  const cte = buildReachableCte({
-    graphId: ctx.graphId,
-    sourceId,
-    edgeKinds: options.edges,
-    maxHops,
-    direction: options.direction ?? "out",
-    cyclePolicy: options.cyclePolicy ?? "prevent",
-    includePath: false,
-    ...resolveTemporalOptions(ctx, options),
-    dialect: ctx.dialect,
-    schema: ctx.schema,
-    ...(ctx.recordedReadBinding === undefined ?
-      {}
-    : { recordedReadBinding: ctx.recordedReadBinding }),
-  });
-
-  const query = sql`${cte} SELECT 1 AS hit FROM reachable WHERE id = ${targetId} LIMIT 1`;
-
-  const rows = await ctx.backend.execute<Readonly<{ hit: number }>>(
-    asCompiledRowsSql(query),
+  return (
+    (await findShortestPath(ctx, sourceId, targetId, maxHops, options)) !==
+    undefined
   );
-  return rows.length > 0;
 }
 
 export async function executeNeighbors(

--- a/packages/typegraph/src/store/algorithms/shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/shortest-path.ts
@@ -1,30 +1,12 @@
-import { type SQL, sql } from "drizzle-orm";
-
-import { asCompiledRowsSql } from "../../query/sql-intent";
-import { normalizePath } from "../../utils";
-import { buildReachableCte } from "../recursive-cte";
+import { findShortestPath } from "./breadth-first";
 import {
   type AlgorithmContext,
   assertEdgeKinds,
   DEFAULT_ALGORITHM_MAX_HOPS,
   type InternalTraversalOptions,
   resolveMaxHops,
-  resolveReadSchema,
-  resolveTemporalFilter,
-  resolveTemporalOptions,
 } from "./context";
-import type { PathNode, ShortestPathResult } from "./types";
-
-type ShortestPathRow = Readonly<{
-  hit_id: string;
-  hit_kind: string;
-  hit_depth: number | string;
-  hit_path: unknown;
-  node_id: string | undefined;
-  node_kind: string | undefined;
-}>;
-
-type NodeKindRow = Readonly<{ id: string; kind: string }>;
+import type { ShortestPathResult } from "./types";
 
 export async function executeShortestPath(
   ctx: AlgorithmContext,
@@ -38,84 +20,5 @@ export async function executeShortestPath(
     DEFAULT_ALGORITHM_MAX_HOPS,
     "maxHops",
   );
-
-  // Self-path short-circuit: avoids the recursive CTE entirely while still
-  // honouring the configured temporal mode via a lightweight existence check.
-  if (sourceId === targetId) {
-    const source = await fetchNodeKind(ctx, sourceId, options);
-    if (source === undefined) return undefined;
-    return { nodes: [source], depth: 0 };
-  }
-
-  const cte = buildReachableCte({
-    graphId: ctx.graphId,
-    sourceId,
-    edgeKinds: options.edges,
-    maxHops,
-    direction: options.direction ?? "out",
-    cyclePolicy: options.cyclePolicy ?? "prevent",
-    includePath: true,
-    ...resolveTemporalOptions(ctx, options),
-    dialect: ctx.dialect,
-    schema: ctx.schema,
-    ...(ctx.recordedReadBinding === undefined ?
-      {}
-    : { recordedReadBinding: ctx.recordedReadBinding }),
-  });
-
-  // `cycleCheck` returns TRUE when id is NOT in path; negating it yields the
-  // "id is in path" predicate needed to hydrate every hop's kind in one query.
-  //
-  // Cost model: the LEFT JOIN scans `reachable` with an O(path length) check
-  // per row. Under cyclePolicy: "prevent" (default), |reachable| ≤ V, so this
-  // is bounded by V × p. Under "allow" + high maxHops, |reachable| grows with
-  // the CTE itself (O(V × maxHops)) — but that cost is proportional to the
-  // CTE materialization the user already opted into, not a new asymptotic
-  // class. If this ever dominates in a real workload, the path-unpack +
-  // nodes-PK join variant is the likely next step.
-  const pathContainsCheck = sql`NOT (${ctx.dialect.cycleCheck(sql.raw("r.id"), sql.raw("h.path"))})`;
-
-  const query = sql`${cte}, hit AS (SELECT id, kind, depth, path FROM reachable WHERE id = ${targetId} ORDER BY depth ASC LIMIT 1) SELECT h.id AS hit_id, h.kind AS hit_kind, h.depth AS hit_depth, h.path AS hit_path, r.id AS node_id, r.kind AS node_kind FROM hit h LEFT JOIN reachable r ON ${pathContainsCheck}`;
-
-  const rows = await ctx.backend.execute<ShortestPathRow>(
-    asCompiledRowsSql(query),
-  );
-  const first = rows[0];
-  if (first === undefined) return undefined;
-
-  const pathIds = normalizePath(first.hit_path);
-  const kindById = buildKindIndex(rows);
-
-  const pathNodes: PathNode[] = pathIds.map((id) => ({
-    id,
-    kind: kindById.get(id) ?? "",
-  }));
-
-  return { nodes: pathNodes, depth: Number(first.hit_depth) };
-}
-
-function buildKindIndex(
-  rows: readonly ShortestPathRow[],
-): ReadonlyMap<string, string> {
-  const map = new Map<string, string>();
-  for (const row of rows) {
-    if (row.node_id !== undefined && row.node_kind !== undefined) {
-      map.set(row.node_id, row.node_kind);
-    }
-  }
-  return map;
-}
-
-async function fetchNodeKind(
-  ctx: AlgorithmContext,
-  nodeId: string,
-  options: InternalTraversalOptions,
-): Promise<PathNode | undefined> {
-  const temporalFilter = resolveTemporalFilter(ctx, options);
-  const schema = resolveReadSchema(ctx, options);
-  const query: SQL = sql`SELECT id, kind FROM ${schema.nodesTable} WHERE graph_id = ${ctx.graphId} AND id = ${nodeId} AND ${temporalFilter} LIMIT 1`;
-  const rows = await ctx.backend.execute<NodeKindRow>(asCompiledRowsSql(query));
-  const row = rows[0];
-  if (row === undefined) return undefined;
-  return { id: row.id, kind: row.kind };
+  return findShortestPath(ctx, sourceId, targetId, maxHops, options);
 }

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -20,14 +20,10 @@ import type { NoRecordedCoordinate } from "../types";
 export type TraversalDirection = "out" | "in" | "both";
 
 /**
- * Cycle-handling strategy during recursive traversal.
- *
- * - `"prevent"` — skip any node already on the current path (default).
- *   Guarantees termination even in cyclic graphs.
- * - `"allow"` — permit revisiting nodes. Only safe with a bounded `maxHops`.
- *
- * Aliased to `RecursiveCyclePolicy` so algorithms and query-builder traversals
- * share a single canonical union.
+ * Cycle-handling option retained for compatibility with recursive query-builder
+ * traversals. Store algorithms are set-based and visit each node once at its
+ * minimum depth, so `"prevent"` and `"allow"` produce the same algorithm
+ * result. Aliased to `RecursiveCyclePolicy` so both APIs share one union.
  */
 export type AlgorithmCyclePolicy = RecursiveCyclePolicy;
 
@@ -72,7 +68,7 @@ export type BaseTraversalOptions<G extends GraphDef> =
       maxHops?: number;
       /** Direction of traversal (default: `"out"`). */
       direction?: TraversalDirection;
-      /** Cycle policy (default: `"prevent"`). */
+      /** Compatibility option; set-based algorithms always visit a node once. */
       cyclePolicy?: AlgorithmCyclePolicy;
     }>;
 
@@ -151,7 +147,7 @@ export type NeighborsOptions<G extends GraphDef> = TemporalAlgorithmOptions &
     depth?: number;
     /** Direction of traversal (default: `"out"`). */
     direction?: TraversalDirection;
-    /** Cycle policy (default: `"prevent"`). */
+    /** Compatibility option; set-based algorithms always visit a node once. */
     cyclePolicy?: AlgorithmCyclePolicy;
   }>;
 

--- a/packages/typegraph/src/store/recorded-capture.ts
+++ b/packages/typegraph/src/store/recorded-capture.ts
@@ -701,9 +701,9 @@ export function createRecordedBackend(
       const backendOptions = stripRecordedFlushObserver(options);
       assertRequestedRecordedIsolation(backend, backendOptions);
       return backend.transaction(async (target) => {
-        await assertRecordedCaptureTransactionIsolation(target);
-        // Bundled BEGIN IMMEDIATE transaction — the write lock is already held.
-        const scope = createRecordedTransactionScope(target, schema, true);
+        await assertRecordedCaptureTransactionIsolation(target, backendOptions);
+        const readOnly = backendOptions?.accessMode === "read_only";
+        const scope = createRecordedTransactionScope(target, schema, !readOnly);
         const result = await fn(scope.backend, createHistoryUnsafeSqlRef());
         const instants = await scope.flush();
         observer?.(instants);

--- a/packages/typegraph/src/store/recorded-capture/guards.ts
+++ b/packages/typegraph/src/store/recorded-capture/guards.ts
@@ -103,6 +103,7 @@ export function assertRequestedRecordedIsolation(
   options: TransactionOptions | undefined,
 ): void {
   if (backend.dialect !== "postgres") return;
+  if (options?.accessMode === "read_only") return;
   const isolationLevel = options?.isolationLevel;
   if (isSupportedRecordedIsolationLevel(isolationLevel)) return;
 
@@ -116,8 +117,10 @@ function normalizeIsolationLevel(value: unknown): string | undefined {
 
 export async function assertRecordedCaptureTransactionIsolation(
   target: Pick<TransactionBackend, "dialect" | "execute">,
+  options?: TransactionOptions,
 ): Promise<void> {
   if (target.dialect !== "postgres") return;
+  if (options?.accessMode === "read_only") return;
 
   const rows = await target.execute<IsolationRow>(
     asCompiledRowsSql(sql`

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -596,9 +596,11 @@ export class Store<G extends GraphDef> {
    * Tier 1 graph algorithms: shortest path, reachability, neighborhoods, and
    * degree centrality.
    *
-   * Each call compiles to a single recursive-CTE query against the backend.
-   * The facade is built lazily on first access and cached for the lifetime
-   * of the store.
+   * Traversal calls use the iterative graph-operation substrate: a set-based
+   * breadth-first frontier backed by a temporary working table, or a chunked
+   * inline relation when the backend cannot pin a transactional connection.
+   * `degree` uses a single count query. The facade is built lazily on first
+   * access and cached for the lifetime of the store.
    *
    * @example
    * ```typescript

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -9,9 +9,18 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { defineEdge, defineGraph, defineNode } from "../src";
-import type { GraphBackend } from "../src/backend/types";
+import type {
+  AdoptedTransaction,
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../src/backend/types";
 import type { NodeId } from "../src/core/types";
 import { ConfigurationError, ValidationError } from "../src/errors";
+import type {
+  CompiledRowsSql,
+  CompiledTemporaryStatementSql,
+} from "../src/query/sql-intent";
 import { createStore, type Store } from "../src/store";
 import {
   collectAllEdges,
@@ -329,6 +338,111 @@ describe("store.algorithms", () => {
           reachable[index - 1]!.depth,
         );
       }
+    });
+
+    it("uses bounded frontier queries and stops when the frontier is empty", async () => {
+      const statements: string[] = [];
+      const observedBackend: GraphBackend = {
+        ...backend,
+        capabilities: { ...backend.capabilities, transactions: false },
+        execute<T>(query: CompiledRowsSql): Promise<readonly T[]> {
+          statements.push(backend.compileSql!(query).sql);
+          return backend.execute<T>(query);
+        },
+      };
+      const observedStore = createStore(testGraph, observedBackend);
+
+      const reachable = await observedStore.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        maxHops: 1000,
+      });
+
+      expect(reachable).toHaveLength(5);
+      expect(statements).toHaveLength(5);
+      expect(
+        statements.every((statement) => !statement.includes("RECURSIVE")),
+      ).toBe(true);
+    });
+
+    it("chunks duplicate edge filters within a small bind budget", async () => {
+      const constrainedBackend: GraphBackend = {
+        ...backend,
+        capabilities: {
+          ...backend.capabilities,
+          transactions: false,
+          maxBindParameters: 100,
+        },
+      };
+      const constrainedStore = createStore(testGraph, constrainedBackend);
+
+      const reachable = await constrainedStore.algorithms.reachable(ids.alice, {
+        edges: Array.from({ length: 49 }, () => "knows" as const),
+        maxHops: 3,
+        direction: "both",
+      });
+
+      expect(reachable.some((node) => node.id === ids.dave)).toBe(true);
+    });
+
+    it("runs through the temporary working-table seam with history enabled", async () => {
+      const historyStore = createStore(testGraph, backend, { history: true });
+
+      const reachable = await historyStore.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        maxHops: 3,
+      });
+
+      expect(reachable.some((node) => node.id === ids.dave)).toBe(true);
+    });
+
+    it("drops the temporary working table when initialization fails", async () => {
+      const temporaryStatements: string[] = [];
+      let failNextRead = false;
+      const failingBackend: GraphBackend = {
+        ...backend,
+        transaction<T>(
+          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> {
+          return backend.transaction(async (tx, adoptedTransaction) => {
+            const failingTransaction: TransactionBackend = {
+              ...tx,
+              async executeTemporaryStatement(
+                query: CompiledTemporaryStatementSql,
+              ): Promise<void> {
+                const statement = backend.compileSql!(query).sql;
+                temporaryStatements.push(statement);
+                await tx.executeTemporaryStatement!(query);
+                if (temporaryStatements.length === 1) {
+                  failNextRead = true;
+                }
+              },
+              execute<Result>(
+                query: CompiledRowsSql,
+              ): Promise<readonly Result[]> {
+                if (failNextRead) {
+                  failNextRead = false;
+                  return Promise.reject(new Error("forced round failure"));
+                }
+                return tx.execute<Result>(query);
+              },
+            };
+            return fn(failingTransaction, adoptedTransaction);
+          }, options);
+        },
+      };
+      const failingStore = createStore(testGraph, failingBackend);
+
+      await expect(
+        failingStore.algorithms.reachable(ids.alice, {
+          edges: ["knows"],
+        }),
+      ).rejects.toThrow("forced round failure");
+
+      expect(temporaryStatements[0]?.trimStart()).toMatch(/^CREATE TEMP TABLE/);
+      expect(temporaryStatements.at(-1)?.trimStart()).toMatch(
+        /^DROP TABLE IF EXISTS/,
+      );
     });
   });
 

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -207,6 +207,89 @@ export function registerAlgorithmIntegrationTests(
       });
     });
 
+    describe("dense cyclic graph", () => {
+      it("visits each node once instead of enumerating simple paths", async () => {
+        const store = context.getStore();
+        const people = await store.nodes.Person.bulkCreate(
+          Array.from({ length: 9 }, (_, index) => ({
+            props: { name: `Dense ${index}` },
+          })),
+        );
+        await store.edges.knows.bulkCreate(
+          people.flatMap((from) =>
+            people
+              .filter((to) => to.id !== from.id)
+              .map((to) => ({ from, to, props: { since: "2020" } })),
+          ),
+        );
+
+        const source = people[0]!;
+        const target = people.at(-1)!;
+        const reached = await store.algorithms.reachable(source, {
+          edges: ["knows"],
+          maxHops: 8,
+        });
+        const neighbors = await store.algorithms.neighbors(source, {
+          edges: ["knows"],
+          depth: 8,
+        });
+        const path = await store.algorithms.shortestPath(source, target, {
+          edges: ["knows"],
+          maxHops: 8,
+        });
+
+        expect(reached).toHaveLength(9);
+        expect(reached.filter((node) => node.depth === 1)).toHaveLength(8);
+        expect(neighbors).toHaveLength(8);
+        expect(path).toEqual({
+          nodes: [
+            { id: source.id, kind: "Person" },
+            { id: target.id, kind: "Person" },
+          ],
+          depth: 1,
+        });
+        await expect(
+          store.algorithms.canReach(source, target, {
+            edges: ["knows"],
+            maxHops: 8,
+          }),
+        ).resolves.toBe(true);
+      });
+    });
+
+    describe("node identity", () => {
+      it("keeps different node kinds that share an ID", async () => {
+        const store = context.getStore();
+        const source = await store.nodes.Person.create(
+          { name: "Identity source" },
+          { id: "algorithm-identity-source" },
+        );
+        const person = await store.nodes.Person.create(
+          { name: "Shared person" },
+          { id: "algorithm-shared-id" },
+        );
+        const company = await store.nodes.Company.create(
+          { name: "Shared company" },
+          { id: "algorithm-shared-id" },
+        );
+        await Promise.all([
+          store.edges.knows.create(source, person, {}),
+          store.edges.worksAt.create(source, company, { role: "Founder" }),
+        ]);
+
+        const reached = await store.algorithms.reachable(source, {
+          edges: ["knows", "worksAt"],
+          maxHops: 1,
+          excludeSource: true,
+        });
+
+        expect(reached).toEqual([
+          { id: "algorithm-shared-id", kind: "Company", depth: 1 },
+          { id: "algorithm-shared-id", kind: "Person", depth: 1 },
+        ]);
+      });
+    });
+
     describe("temporal behavior", () => {
       const { BEFORE } = TEMPORAL_ANCHORS;
       let ids: TemporalFixture;

--- a/packages/typegraph/tests/backends/postgres/pglite-integration-suite.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-integration-suite.test.ts
@@ -11,8 +11,10 @@
  * suites run on separate vitest workers (parallel files) rather than one serial
  * long-pole. One shared engine per file; data is reset between tests.
  */
+import { sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach } from "vitest";
 
+import { asCompiledRowsSql } from "../../../src";
 import { createIntegrationTestSuite } from "../integration-test-suite";
 import {
   setupSharedPgliteEngine,
@@ -26,6 +28,19 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  const leakedWorkingTables = await engine.makeBackend().execute(
+    asCompiledRowsSql(sql`
+      SELECT relation.relname
+      FROM pg_catalog.pg_class relation
+      WHERE relation.relpersistence = 't'
+        AND relation.relname LIKE 'typegraph_iterative_%'
+    `),
+  );
+  if (leakedWorkingTables.length > 0) {
+    throw new Error(
+      `Iterative graph operations leaked temporary tables: ${JSON.stringify(leakedWorkingTables)}`,
+    );
+  }
   await engine.dispose();
 });
 

--- a/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
@@ -12,15 +12,26 @@
  * EXISTS` DDL and per-test TRUNCATE, and the harness runs files
  * serially.
  */
+import { sql as drizzleSql } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres, { type Sql } from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { count, defineEdge, defineGraph, defineNode } from "../../../src";
+import {
+  asCompiledRowsSql,
+  count,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
-import { rowPropsToObject } from "../../../src/backend/types";
+import {
+  INTERNAL_TEMPORARY_WRITES,
+  rowPropsToObject,
+} from "../../../src/backend/types";
+import { asCompiledTemporaryStatementSql } from "../../../src/query/sql-intent";
 import { createStore } from "../../../src/store";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
@@ -303,6 +314,74 @@ describe("postgres-js driver — coercion sanity", () => {
     const fetched = await backend.getNode("postgres_js_test", "Person", "tx-1");
     expect(fetched).toBeDefined();
     expect(rowPropsToObject(fetched!.props).name).toBe("Alice");
+  });
+
+  it("honors repeatable-read access for read-only transactions", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+
+    const settings = await backend.transaction(
+      async (tx) =>
+        tx.execute<
+          Readonly<{
+            isolation_level: string;
+            read_only: string;
+          }>
+        >(
+          asCompiledRowsSql(drizzleSql`
+            SELECT
+              current_setting('transaction_isolation') AS isolation_level,
+              current_setting('transaction_read_only') AS read_only
+          `),
+        ),
+      { accessMode: "read_only", isolationLevel: "repeatable_read" },
+    );
+
+    expect(settings).toEqual([
+      { isolation_level: "repeatable read", read_only: "on" },
+    ]);
+  });
+
+  it("allows only temporary writes in the internal snapshot mode", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const backend = createPostgresBackend(db);
+
+    const settings = await backend.transaction(
+      async (tx) => {
+        await tx.executeTemporaryStatement!(
+          asCompiledTemporaryStatementSql(
+            drizzleSql`CREATE TEMP TABLE iterative_probe (value INTEGER)`,
+          ),
+        );
+        const rows = await tx.execute<
+          Readonly<{
+            isolation_level: string;
+            read_only: string;
+          }>
+        >(
+          asCompiledRowsSql(drizzleSql`
+            SELECT
+              current_setting('transaction_isolation') AS isolation_level,
+              current_setting('transaction_read_only') AS read_only
+          `),
+        );
+        await tx.executeTemporaryStatement!(
+          asCompiledTemporaryStatementSql(
+            drizzleSql`DROP TABLE iterative_probe`,
+          ),
+        );
+        return rows;
+      },
+      {
+        accessMode: "read_only",
+        isolationLevel: "repeatable_read",
+        temporaryWrites: INTERNAL_TEMPORARY_WRITES,
+      },
+    );
+
+    expect(settings).toEqual([
+      { isolation_level: "repeatable read", read_only: "off" },
+    ]);
   });
 });
 

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -36,11 +36,13 @@ import {
 } from "../../../src/backend/sqlite";
 import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
 import {
+  INTERNAL_TEMPORARY_WRITES,
   type UpsertEmbeddingParams,
   type VectorSearchParams,
   type VectorSearchResult,
 } from "../../../src/backend/types";
 import { sqliteVecStrategy } from "../../../src/query/dialect/vector/sqlite-vec-strategy";
+import { asCompiledTemporaryStatementSql } from "../../../src/query/sql-intent";
 import { createStore } from "../../../src/store";
 import { createTestBackend, createTestDatabase } from "../../test-utils";
 import { createAdapterTestSuite } from "../adapter-test-suite";
@@ -1190,5 +1192,101 @@ describe("SQLite Backend - business transaction write lock", () => {
     }
 
     expect(probeTookLock).toBe(false);
+  });
+
+  it("leaves the writer slot free for a read-only transaction", async () => {
+    const dbPath = temporaryDbPath();
+    const { backend } = createLocalSqliteBackend({ path: dbPath });
+
+    let signalInside!: () => void;
+    const inside = new Promise<void>((resolve) => {
+      signalInside = resolve;
+    });
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const txDone = backend.transaction(
+      async (tx) => {
+        await tx.execute(asCompiledRowsSql(sql`SELECT 1 AS value`));
+        signalInside();
+        await barrier;
+      },
+      { accessMode: "read_only", isolationLevel: "repeatable_read" },
+    );
+    await inside;
+
+    try {
+      const probe = new Database(dbPath);
+      try {
+        probe.pragma("busy_timeout = 100");
+        probe.exec("BEGIN IMMEDIATE");
+        probe.exec("ROLLBACK");
+      } finally {
+        probe.close();
+      }
+    } finally {
+      release();
+      await txDone;
+      await backend.close();
+      removeDbFiles(dbPath);
+    }
+  });
+
+  it("leaves the writer slot free while writing temporary working state", async () => {
+    const dbPath = temporaryDbPath();
+    const { backend } = createLocalSqliteBackend({ path: dbPath });
+
+    let signalInside!: () => void;
+    const inside = new Promise<void>((resolve) => {
+      signalInside = resolve;
+    });
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const txDone = backend.transaction(
+      async (tx) => {
+        await tx.executeTemporaryStatement!(
+          asCompiledTemporaryStatementSql(
+            sql`CREATE TEMP TABLE iterative_probe (value INTEGER)`,
+          ),
+        );
+        await tx.executeTemporaryStatement!(
+          asCompiledTemporaryStatementSql(
+            sql`INSERT INTO iterative_probe (value) VALUES (1)`,
+          ),
+        );
+        signalInside();
+        await barrier;
+        await tx.executeTemporaryStatement!(
+          asCompiledTemporaryStatementSql(sql`DROP TABLE iterative_probe`),
+        );
+      },
+      {
+        accessMode: "read_only",
+        isolationLevel: "repeatable_read",
+        temporaryWrites: INTERNAL_TEMPORARY_WRITES,
+      },
+    );
+    await inside;
+
+    try {
+      const probe = new Database(dbPath);
+      try {
+        probe.pragma("busy_timeout = 100");
+        probe.exec("BEGIN IMMEDIATE");
+        probe.exec("ROLLBACK");
+      } finally {
+        probe.close();
+      }
+    } finally {
+      release();
+      await txDone;
+      await backend.close();
+      removeDbFiles(dbPath);
+    }
   });
 });

--- a/packages/typegraph/tests/recorded-capture-capability-gate.test.ts
+++ b/packages/typegraph/tests/recorded-capture-capability-gate.test.ts
@@ -182,4 +182,15 @@ describe("recorded-time capture capability gate", () => {
       }),
     ).rejects.toThrow("requires read_committed isolation");
   });
+
+  it("allows snapshot isolation for read-only history transactions", async () => {
+    const store = createStore(graph, postgresLikeBackend(), { history: true });
+
+    await expect(
+      store.transaction(() => Promise.resolve("snapshot"), {
+        accessMode: "read_only",
+        isolationLevel: "repeatable_read",
+      }),
+    ).resolves.toBe("snapshot");
+  });
 });


### PR DESCRIPTION
- replace `reachable`, `neighbors`, `shortestPath`, and `canReach` recursive path enumeration with set-based BFS
- add the iterative graph-operation substrate: a host round loop over a node-keyed temporary working table with convergence, snapshot, bind-budget, and cleanup ownership
- use bidirectional BFS for shortest path and reachability checks, preserving `(kind, id)` identity and temporal semantics
- retain a chunked inline frontier for bounded traversal on backends without a pinned transactional connection
- add an internal branded temporary-statement seam so history-enabled stores can use ephemeral working state without reopening arbitrary raw writes

## Why

The recursive CTEs admitted one row per simple path and only grouped after recursion. Dense cyclic graphs therefore produced combinatorial intermediate work even though the public algorithms return node-set or shortest-path results.

This change admits each `(kind, id)` once at its minimum depth. Work is now bounded by reached nodes and incident edges rather than the number of paths. It also establishes the iterative execution shape described in the SQL community-detection design, so WCC/CDLP/PageRank can reuse the same working-table lifecycle instead of introducing a second iteration engine.

## Backend behavior

- SQLite uses a deferred snapshot for semantically read-only temporary work and leaves the main database writer slot free.
- PostgreSQL/PGlite use repeatable read on one pinned connection; an unforgeable internal capability permits temporary DDL/DML while permanent graph/history state remains protected.
- Temporary tables are dropped in `finally`; rollback owns cleanup after an aborted PostgreSQL statement, without masking the original error.
- Non-transactional backends use bind-limit-aware `VALUES` frontiers for these bounded algorithms.

## Performance

Reproduced issue #271 with its committed LDBC smoke fixture: 31 people, 240 directed `knows` edges, source person `0`, and `reachable(..., maxHops: 2..8)` through the public API. Result cardinality was unchanged (28 nodes at depth 2; all 30 component nodes from depth 3 onward).

Measured on an Apple M4 Pro with Node 26.5.0 and in-memory SQLite. The same-machine pre-fix run used commit `92479d44` and one sweep, matching the original issue's methodology; the PR column is the median of 20 sweeps at `4775532b` with p95 in parentheses.

| maxHops | Original issue | Same-machine pre-fix | This PR median (p95) | Same-machine speedup |
|---:|---:|---:|---:|---:|
| 2 | 2.0 ms | 1.007 ms | 0.499 ms (0.765) | 2x |
| 3 | 2.5 ms | 1.518 ms | 0.772 ms (1.028) | 2x |
| 4 | 17 ms | 10.061 ms | 0.940 ms (1.176) | 11x |
| 5 | 128 ms | 70.276 ms | 0.950 ms (1.237) | 74x |
| 6 | 0.9 s | 466.813 ms | 0.952 ms (1.074) | 490x |
| 7 | 6.1 s | 3.282 s | 0.942 ms (1.176) | 3,484x |
| 8 | **44.6 s** | **20.311 s** | **0.938 ms (1.020)** | **21,652x** |

The absolute pre-fix time is lower on this machine than in the original report, but it reproduces the same failure shape: approximately 6–7x more work per added hop from depth 3 onward. The PR is flat after the component converges. At depth 8 it is 47,543x faster than the original issue measurement and 21,652x faster than the same-machine pre-fix run.

## Validation

- `pnpm fix`
- `pnpm typecheck`
- `pnpm test` — 247 files passed, 4,978 tests passed
- `pnpm test:postgres` — 71 files passed, 2,039 tests passed
- dense cyclic graph, cross-kind same-ID identity, bind-budget, bounded-work, history-enabled, failed-initialization cleanup, SQLite writer-slot, PostgreSQL access-mode, and PGlite temp-leak coverage
- exact issue #271 LDBC fixture benchmark described above

Closes #271
