### PR TITLE
feat: add exact weakly connected components

### DIFF
--- a/.changeset/weakly-connected-components.md
+++ b/.changeset/weakly-connected-components.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add exact `store.algorithms.weaklyConnectedComponents()` for transactional
+SQLite and PostgreSQL backends. Results include deterministic component
+representatives and sizes, honor valid/recorded temporal views, and fail with a
+typed convergence error instead of returning partial labels when the configured
+iteration budget is exhausted.

--- a/.changeset/weakly-connected-components.md
+++ b/.changeset/weakly-connected-components.md
@@ -6,9 +6,16 @@ Add exact `store.algorithms.weaklyConnectedComponents()` for transactional
 SQLite and PostgreSQL backends. Results include deterministic component
 representatives and sizes, honor valid/recorded temporal views, and fail with a
 typed convergence error instead of returning partial labels when the configured
-iteration budget is exhausted.
+iteration budget is exhausted. Callers can restrict WCC to a `nodeKinds`
+induced subgraph, retaining isolated in-scope nodes without seeding unrelated
+node kinds.
 
 PostgreSQL iterative operations now refresh temporary-table planner statistics
 after sufficiently large seeds and multiplicative growth, avoiding plans based
 on the engine's initial one-row estimate. The policy also covers growing BFS
 working tables and is a no-op on SQLite.
+
+Set-based reachability now deduplicates edge targets before target-node
+visibility checks and avoids computing unused predecessor paths. This reduces
+dense-frontier work while preserving minimum-depth results and cross-backend
+semantics.

--- a/.changeset/weakly-connected-components.md
+++ b/.changeset/weakly-connected-components.md
@@ -7,3 +7,8 @@ SQLite and PostgreSQL backends. Results include deterministic component
 representatives and sizes, honor valid/recorded temporal views, and fail with a
 typed convergence error instead of returning partial labels when the configured
 iteration budget is exhausted.
+
+PostgreSQL iterative operations now refresh temporary-table planner statistics
+after sufficiently large seeds and multiplicative growth, avoiding plans based
+on the engine's initial one-row estimate. The policy also covers growing BFS
+working tables and is a no-op on SQLite.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ TypeGraph is not designed for:
 
 - Distributed graph processing
 - Advanced graph analytics (PageRank, community detection, weighted shortest
-  path, centrality beyond degree) — it does ship basic traversal algorithms
+  path, centrality beyond degree) — it does ship connectivity algorithms
   ([Graph Algorithms](https://typegraph.dev/graph-algorithms): unweighted
-  shortest path, reachability, neighborhoods, degree)
+  shortest path, reachability, neighborhoods, degree, exact WCC)
 - Billion-scale graphs requiring dedicated graph-engine performance
 
 ## Installation

--- a/apps/docs/src/content/docs/architecture.md
+++ b/apps/docs/src/content/docs/architecture.md
@@ -499,7 +499,8 @@ nearest neighbor search efficiently.
 ### What's Slower
 
 - **Deep recursive traversals**: Recursive CTEs are more expensive than simple JOINs
-- **Whole-graph algorithms**: WCC iterates over every visible node and its selected edges
+- **Whole-graph algorithms**: WCC iterates over every visible node by default,
+  or over an explicit `nodeKinds` induced subgraph, and its selected edges
 - **Large property filtering without indexes**: JSON extraction is slower than column access
 - **Cross-kind queries**: `includeSubClasses: true` increases the WHERE IN set
 

--- a/apps/docs/src/content/docs/architecture.md
+++ b/apps/docs/src/content/docs/architecture.md
@@ -492,13 +492,14 @@ nearest neighbor search efficiently.
 ### What's Fast
 
 - **Point lookups by ID**: O(1) with primary key index
-- **Traversals**: Single SQL query with JOINs, optimized by the database
+- **Traversal frontiers**: Set-based SQL rounds with database-managed joins and de-duplication
 - **Ontology expansion**: Precomputed at initialization, O(1) at query time
 - **Semantic search**: ANN indexes (pgvector HNSW/IVFFlat, sqlite-vec `vec0`, libSQL DiskANN) provide sub-linear search
 
 ### What's Slower
 
 - **Deep recursive traversals**: Recursive CTEs are more expensive than simple JOINs
+- **Whole-graph algorithms**: WCC iterates over every visible node and its selected edges
 - **Large property filtering without indexes**: JSON extraction is slower than column access
 - **Cross-kind queries**: `includeSubClasses: true` increases the WHERE IN set
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -771,6 +771,7 @@ if (backend.capabilities.vector?.supported) {
 | --- | --- |
 | `transactions` | Atomic transactions available (see note below) |
 | `windowFunctions` | SQL window functions such as `ROW_NUMBER()` are available |
+| `graphAnalytics?.{supported,mathFunctions}` | Whole-graph temporary-table iteration, plus availability of deferred transcendental-math algorithms |
 | `vector?.metrics` / `vector?.indexTypes` / `vector?.maxDimensions` | Vector strategy capabilities (present once a vector strategy is configured) |
 | `fulltext?.{supported,languages,phraseQueries,prefixQueries,highlighting}` | Fulltext strategy capabilities |
 

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -14,15 +14,20 @@ store.algorithms.reachable(alice, { edges: ["knows"] });
 store.algorithms.canReach(alice, bob, { edges: ["knows"] });
 store.algorithms.neighbors(alice, { edges: ["knows"], depth: 2 });
 store.algorithms.degree(alice, { edges: ["knows"] });
-store.algorithms.weaklyConnectedComponents({ edges: ["knows"] });
+store.algorithms.weaklyConnectedComponents({
+  edges: ["knows"],
+  nodeKinds: ["Person"],
+});
 ```
 
 Traversal calls use a set-based breadth-first frontier. Each level expands the
 current `(id, kind)` set with a bind-limit-aware SQL query. Transactional
 backends keep the visited set in a temporary working table; backends without a
 pinned transaction use a chunked inline working relation. Each node is admitted
-only at its minimum depth. `shortestPath` and `canReach` search from both
-endpoints and stop when the frontiers meet.
+only at its minimum depth. Reachability rounds deduplicate edge targets before
+checking target-node visibility and do not compute unused predecessors.
+`shortestPath` and `canReach` search from both endpoints, retain predecessors for
+path reconstruction, and stop when the frontiers meet.
 `degree` remains a single `COUNT` query. The algorithms work identically on
 SQLite and PostgreSQL.
 
@@ -175,14 +180,16 @@ efficient even for hub nodes with thousands of edges.
 
 ## weaklyConnectedComponents
 
-Computes an exact whole-graph partition over the undirected projection of the
-selected edge kinds. Every visible node is returned; a node with no selected
-incident edge forms a singleton component.
+Computes an exact partition over the undirected projection of the selected edge
+kinds. By default every visible node is returned. `nodeKinds` restricts the
+operation to the induced subgraph over those kinds; an in-scope node with no
+selected incident edge forms a singleton component.
 
 ```typescript
 const memberships =
   await store.algorithms.weaklyConnectedComponents({
     edges: ["knows", "worksAt"],
+    nodeKinds: ["Person", "Company"], // optional; all kinds by default
     maxIterations: 1000, // default
   });
 // [{ id, kind, componentId, componentKind, size }, ...]
@@ -207,10 +214,10 @@ plans based on PostgreSQL's initial one-row estimate for a new temporary table.
 The policy is automatic, applies to WCC and growing traversal frontiers, and is
 a no-op on SQLite.
 
-WCC currently seeds every visible node. Selecting edge kinds controls which
-connections participate, but it does not restrict node kinds; unrelated nodes
-still appear as singleton components. On heterogeneous graphs with millions of
-visible nodes, seeding that full set can dominate the operation's cost.
+Without `nodeKinds`, WCC seeds every visible node, so unrelated nodes still
+appear as singleton components. On heterogeneous graphs, pass the kinds that
+define the graph being analyzed. For example, `{ edges: ["knows"], nodeKinds:
+["Person"] }` avoids seeding posts and comments while retaining isolated people.
 
 Temporal views expose the same facade with the coordinate sealed:
 

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -39,9 +39,10 @@ SQLite and PostgreSQL.
 | Filter, sort, or project over traversal results | `.query().traverse()` / `.recursive()` |
 | Hydrate an entity plus all its relationships | `store.subgraph()` |
 
-The algorithms return lightweight `{ id, kind, depth }` records rather than
-fully hydrated nodes. Use `store.nodes.<Kind>.getByIds(...)` when you need
-the full node data.
+Traversal algorithms return lightweight `{ id, kind, depth }` records rather
+than fully hydrated nodes. WCC returns one
+`{ id, kind, componentId, componentKind, size }` membership per visible node.
+Use `store.nodes.<Kind>.getByIds(...)` when you need the full node data.
 
 ## Shared Options
 
@@ -199,6 +200,17 @@ transactional SQLite and PostgreSQL backends advertise support. If propagation
 has not converged after `maxIterations`, TypeGraph throws
 `GraphAlgorithmConvergenceError` rather than returning a partial partition.
 
+PostgreSQL refreshes planner statistics for a sufficiently large temporary
+working table and refreshes them again after multiplicative growth. This avoids
+plans based on PostgreSQL's initial one-row estimate for a new temporary table.
+The policy is automatic, applies to WCC and growing traversal frontiers, and is
+a no-op on SQLite.
+
+WCC currently seeds every visible node. Selecting edge kinds controls which
+connections participate, but it does not restrict node kinds; unrelated nodes
+still appear as singleton components. On heterogeneous graphs with millions of
+visible nodes, seeding that full set can dominate the operation's cost.
+
 Temporal views expose the same facade with the coordinate sealed:
 
 ```typescript
@@ -209,9 +221,10 @@ const historical = await store
 
 ## Passing Nodes or IDs
 
-Every algorithm accepts either a raw ID string or any object with an
-`id: string` field — `Node`, `NodeRef`, the lightweight records returned by
-these algorithms, and `store.subgraph()` results all work:
+Every node-oriented algorithm accepts either a raw ID string or any object with
+an `id: string` field — `Node`, `NodeRef`, the lightweight records returned by
+traversals, and `store.subgraph()` results all work. WCC is a whole-graph
+operation and does not take a node identifier.
 
 ```typescript
 const alice = await store.nodes.Person.getById(aliceId);

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -1,6 +1,6 @@
 ---
 title: Graph Algorithms
-description: Shortest path, reachability, neighborhoods, and degree on store.algorithms
+description: Shortest path, reachability, neighborhoods, degree, and weakly connected components on store.algorithms
 ---
 
 Graph queries like "are Alice and Bob connected?" or "who is within two hops
@@ -14,6 +14,7 @@ store.algorithms.reachable(alice, { edges: ["knows"] });
 store.algorithms.canReach(alice, bob, { edges: ["knows"] });
 store.algorithms.neighbors(alice, { edges: ["knows"], depth: 2 });
 store.algorithms.degree(alice, { edges: ["knows"] });
+store.algorithms.weaklyConnectedComponents({ edges: ["knows"] });
 ```
 
 Traversal calls use a set-based breadth-first frontier. Each level expands the
@@ -34,6 +35,7 @@ SQLite and PostgreSQL.
 | Check whether a node is reachable at all | `canReach` |
 | Get the k-hop neighborhood of a node | `neighbors` |
 | Count incident edges (in, out, or both) | `degree` |
+| Partition all visible nodes by undirected connectivity | `weaklyConnectedComponents` |
 | Filter, sort, or project over traversal results | `.query().traverse()` / `.recursive()` |
 | Hydrate an entity plus all its relationships | `store.subgraph()` |
 
@@ -170,6 +172,41 @@ const everything = await store.algorithms.degree(alice);
 `degree` runs a single `COUNT` query, not a recursive CTE, so it's
 efficient even for hub nodes with thousands of edges.
 
+## weaklyConnectedComponents
+
+Computes an exact whole-graph partition over the undirected projection of the
+selected edge kinds. Every visible node is returned; a node with no selected
+incident edge forms a singleton component.
+
+```typescript
+const memberships =
+  await store.algorithms.weaklyConnectedComponents({
+    edges: ["knows", "worksAt"],
+    maxIterations: 1000, // default
+  });
+// [{ id, kind, componentId, componentKind, size }, ...]
+```
+
+The component identity is the smallest `(id, kind)` member under portable
+binary ordering. Results and representatives are therefore deterministic on
+SQLite and PostgreSQL even when the PostgreSQL database uses a linguistic
+default collation. Edges are always treated as undirected—WCC has no
+`direction` option.
+
+WCC is iterative and runs multiple SQL rounds in one repeatable snapshot. It
+requires `backend.capabilities.graphAnalytics?.supported === true`; built-in
+transactional SQLite and PostgreSQL backends advertise support. If propagation
+has not converged after `maxIterations`, TypeGraph throws
+`GraphAlgorithmConvergenceError` rather than returning a partial partition.
+
+Temporal views expose the same facade with the coordinate sealed:
+
+```typescript
+const historical = await store
+  .asOf("2024-01-01T00:00:00.000Z")
+  .algorithms.weaklyConnectedComponents({ edges: ["knows"] });
+```
+
 ## Passing Nodes or IDs
 
 Every algorithm accepts either a raw ID string or any object with an
@@ -281,11 +318,11 @@ file — a good starting point for your own RAG + graph workloads.
 
 ## What's Not Included
 
-These algorithms cover shortest path, reachability, neighborhoods, and
-degree. They do **not** cover:
+These algorithms cover shortest path, reachability, neighborhoods, degree,
+and weakly connected components. They do **not** cover:
 
 - Weighted shortest path (Dijkstra / A*)
-- Connected components or strongly connected components
+- Strongly connected components
 - Topological sort
 - Centrality measures beyond degree (betweenness, closeness, eigenvector)
 - PageRank or community detection
@@ -293,5 +330,5 @@ degree. They do **not** cover:
 For those, export edges via `.query().traverse()` or `store.subgraph()` and
 use a specialized library such as
 [graphology](https://graphology.github.io/) in memory. See
-[Limitations](/limitations#no-built-in-graph-analytics) for the full list
+[Limitations](/limitations#graph-analytics-limits) for the full list
 of excluded analytics.

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -196,8 +196,9 @@ default collation. Edges are always treated as undirected—WCC has no
 
 WCC is iterative and runs multiple SQL rounds in one repeatable snapshot. It
 requires `backend.capabilities.graphAnalytics?.supported === true`; built-in
-transactional SQLite and PostgreSQL backends advertise support. If propagation
-has not converged after `maxIterations`, TypeGraph throws
+transactional SQLite and PostgreSQL backends advertise support. Other backends
+throw `UnsupportedBackendCapabilityError` before temporary state is created. If
+propagation has not converged after `maxIterations`, TypeGraph throws
 `GraphAlgorithmConvergenceError` rather than returning a partial partition.
 
 PostgreSQL refreshes planner statistics for a sufficiently large temporary

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -263,11 +263,11 @@ for (let i = 0; i < items.length; i += BATCH_SIZE) {
 }
 ```
 
-## No Built-in Graph Analytics
+## Graph Analytics Limits
 
-TypeGraph ships a small set of Tier 1 connectivity algorithms on
-`store.algorithms.*` — shortest path, reachability, k-hop neighborhoods,
-and degree. See [Graph Algorithms](/graph-algorithms) for the full API.
+TypeGraph ships connectivity algorithms on `store.algorithms.*` — shortest
+path, reachability, k-hop neighborhoods, degree, and exact weakly connected
+components. See [Graph Algorithms](/graph-algorithms) for the full API.
 
 The following heavier analytics are **not** provided:
 
@@ -275,7 +275,7 @@ The following heavier analytics are **not** provided:
 - PageRank
 - Community detection
 - Centrality measures beyond degree (betweenness, closeness, eigenvector)
-- Connected components / strongly connected components
+- Strongly connected components
 - Topological sort
 - Graph partitioning
 

--- a/apps/docs/src/content/docs/overview.md
+++ b/apps/docs/src/content/docs/overview.md
@@ -169,7 +169,7 @@ Graph databases are powerful but come with operational overhead:
 | **Network** | Additional latency for every query | In-process, no network hop |
 | **Transactions** | Separate transaction scope from your SQL data | Same ACID transaction as your other data |
 | **Learning curve** | New query language (Cypher, Gremlin) | TypeScript you already know |
-| **Graph algorithms** | Built-in (PageRank, shortest path, community detection) | Tier 1 only (shortest path, reachability, neighborhoods, degree) |
+| **Graph algorithms** | Built-in (PageRank, shortest path, community detection) | Connectivity algorithms (shortest path, reachability, neighborhoods, degree, WCC) |
 | **Scale** | Optimized for billions of nodes | Best for thousands to millions |
 
 **Choose TypeGraph** when your graph is part of your application domain (knowledge bases, org

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -85,6 +85,7 @@ import {
   type IndexMaterializationRow,
   INTERNAL_TEMPORARY_WRITES,
   type KindRemovalRow,
+  normalizeGraphAnalyticsCapabilities,
   POSTGRES_CAPABILITIES,
   POSTGRES_MAX_BIND_PARAMETERS,
   type RecordContributionMaterializationParams,
@@ -355,12 +356,21 @@ export function createPostgresBackend(
   // unavailable regardless of what we declare. Auto-detect and downgrade
   // the capability so callers get correct fallback behavior without
   // having to remember to override it themselves.
-  const httpOnlyOverrides = isNeonHttpClient(db) ? { transactions: false } : {};
-  const capabilities: BackendCapabilities = {
+  const httpOnlyOverrides =
+    isNeonHttpClient(db) ?
+      {
+        transactions: false,
+        graphAnalytics: {
+          ...(baseCapabilities.graphAnalytics ?? { mathFunctions: true }),
+          supported: false,
+        },
+      }
+    : {};
+  const capabilities = normalizeGraphAnalyticsCapabilities({
     ...baseCapabilities,
     ...httpOnlyOverrides,
     ...options.capabilities,
-  };
+  });
   const adapterOptions: PostgresExecutionAdapterOptions = {
     ...(options.prepareStatements === undefined ?
       {}

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -65,6 +65,7 @@ import {
   type IndexMaterializationRow,
   INTERNAL_TEMPORARY_WRITES,
   type KindRemovalRow,
+  normalizeGraphAnalyticsCapabilities,
   type RecordContributionMaterializationParams,
   type RecordIndexMaterializationParams,
   type RecordKindRemovalParams,
@@ -449,7 +450,16 @@ function buildSqliteCapabilities(
 ): BackendCapabilities {
   const base =
     options.transactionMode === "none" ?
-      { ...SQLITE_CAPABILITIES, transactions: false }
+      {
+        ...SQLITE_CAPABILITIES,
+        transactions: false,
+        graphAnalytics: {
+          ...(SQLITE_CAPABILITIES.graphAnalytics ?? {
+            mathFunctions: false,
+          }),
+          supported: false,
+        },
+      }
     : SQLITE_CAPABILITIES;
   return {
     ...base,
@@ -946,7 +956,7 @@ export function createSqliteBackend(
   // (`createLibsqlBackend` always; `createLocalSqliteBackend` when the
   // extension loads); absent for plain SQLite drivers with no extension.
   const vectorStrategy = options.vector;
-  const capabilities: BackendCapabilities = {
+  const capabilities = normalizeGraphAnalyticsCapabilities({
     ...buildSqliteCapabilities({
       fulltextStrategy,
       vectorStrategy,
@@ -954,7 +964,7 @@ export function createSqliteBackend(
       maxBindParameters: executionAdapter.profile.maxBindParameters,
     }),
     ...options.capabilities,
-  };
+  });
 
   const tableNames: ResolvedSqlTableNames = {
     nodes: getTableName(tables.nodes),

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -417,7 +417,16 @@ export function createLocalSqliteBackend(
     },
     tables,
     ...(hasSqliteVec ? { vector: sqliteVecStrategy } : {}),
-    ...(options.capabilities ? { capabilities: options.capabilities } : {}),
+    capabilities: {
+      ...options.capabilities,
+      graphAnalytics: {
+        supported:
+          options.capabilities?.graphAnalytics?.supported ??
+          options.capabilities?.transactions !== false,
+        mathFunctions:
+          options.capabilities?.graphAnalytics?.mathFunctions ?? true,
+      },
+    },
   });
   const managedBackend = wrapWithManagedClose(backend, () => {
     sqlite.close();

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -160,6 +160,20 @@ export type FulltextCapabilities = Readonly<{
   highlighting: boolean;
 }>;
 
+/**
+ * Whole-graph analytics capabilities declared by a backend.
+ *
+ * `supported` means the backend can pin one transactional connection while
+ * an algorithm creates, updates, and drops session-local temporary state.
+ * `mathFunctions` records whether transcendental SQL functions needed by
+ * deferred algorithms such as MCL/spectral are available; exact WCC does not
+ * require them.
+ */
+export type GraphAnalyticsCapabilities = Readonly<{
+  supported: boolean;
+  mathFunctions: boolean;
+}>;
+
 // ============================================================
 // SQL Dialect & Capabilities
 // ============================================================
@@ -200,7 +214,27 @@ export type BackendCapabilities = Readonly<{
   vector?: VectorCapabilities | undefined;
   /** Fulltext search capabilities (undefined if not configured) */
   fulltext?: FulltextCapabilities | undefined;
+  /** Whole-graph analytics capabilities (undefined when unavailable). */
+  graphAnalytics?: GraphAnalyticsCapabilities | undefined;
 }>;
+
+/** Keeps session-scoped analytics honest when a required SQL feature is absent. */
+export function normalizeGraphAnalyticsCapabilities(
+  capabilities: BackendCapabilities,
+): BackendCapabilities {
+  if (
+    capabilities.graphAnalytics?.supported !== true ||
+    (capabilities.transactions &&
+      capabilities.windowFunctions &&
+      capabilities.returning !== false)
+  ) {
+    return capabilities;
+  }
+  return {
+    ...capabilities,
+    graphAnalytics: { ...capabilities.graphAnalytics, supported: false },
+  };
+}
 
 // ============================================================
 // Row Types (Database Records)
@@ -2292,6 +2326,9 @@ export const SQLITE_CAPABILITIES: BackendCapabilities = {
   windowFunctions: true, // SQLite has supported window functions since 3.25.0
   returning: true, // SQLite has supported RETURNING since 3.35.0
   maxBindParameters: SQLITE_MAX_BIND_PARAMETERS,
+  // Generic SQLite builds do not guarantee ENABLE_MATH_FUNCTIONS. The local
+  // better-sqlite3 factory overrides this flag for its bundled build contract.
+  graphAnalytics: { supported: true, mathFunctions: false },
 };
 
 /**
@@ -2302,4 +2339,5 @@ export const POSTGRES_CAPABILITIES: BackendCapabilities = {
   windowFunctions: true, // PostgreSQL supports ROW_NUMBER() and related windows
   returning: true, // PostgreSQL has supported RETURNING since 8.2
   maxBindParameters: POSTGRES_MAX_BIND_PARAMETERS,
+  graphAnalytics: { supported: true, mathFunctions: true },
 };

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -916,6 +916,49 @@ export class ConfigurationError extends TypeGraphError {
   }
 }
 
+/**
+ * Thrown when an iterative graph algorithm exhausts its caller-visible round
+ * budget before reaching its convergence predicate.
+ */
+export class GraphAlgorithmConvergenceError extends TypeGraphError {
+  constructor(algorithm: string, maxIterations: number) {
+    super(
+      `${algorithm} did not converge within ${maxIterations} iterations.`,
+      "GRAPH_ALGORITHM_CONVERGENCE_ERROR",
+      {
+        details: { algorithm, maxIterations },
+        category: "user",
+        suggestion:
+          "Increase maxIterations or reduce the selected graph before retrying.",
+      },
+    );
+    this.name = "GraphAlgorithmConvergenceError";
+  }
+}
+
+/** Thrown when an operation requires a backend capability it does not expose. */
+export class UnsupportedBackendCapabilityError extends TypeGraphError {
+  constructor(
+    operation: string,
+    capability: string,
+    details: Readonly<Record<string, unknown>> = {},
+    suggestion?: string,
+  ) {
+    super(
+      `${operation} requires backend capability '${capability}'.`,
+      "UNSUPPORTED_BACKEND_CAPABILITY",
+      {
+        details: { operation, capability, ...details },
+        category: "user",
+        suggestion:
+          suggestion ??
+          "Use a backend that advertises this capability before invoking the operation.",
+      },
+    );
+    this.name = "UnsupportedBackendCapabilityError";
+  }
+}
+
 /** Stable reasons an intentionally trusted initial import can be rejected. */
 export type TrustedImportErrorReason =
   | "backend_unsupported"

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -130,6 +130,7 @@ export type {
   FulltextQueryMode,
   FulltextSearchParams,
   FulltextSearchResult,
+  GraphAnalyticsCapabilities,
   GraphBackend,
   GraphEntityReadBackend,
   GraphEntityWriteBackend,
@@ -300,6 +301,7 @@ export {
   EndpointNotFoundError,
   // Error utility functions
   getErrorSuggestion,
+  GraphAlgorithmConvergenceError,
   isConstraintError,
   isRecordedCaptureGuardError,
   isSystemError,
@@ -320,6 +322,7 @@ export {
   TrustedImportError,
   TypeGraphError,
   UniquenessError,
+  UnsupportedBackendCapabilityError,
   UnsupportedPredicateError,
   ValidationError,
   VersionConflictError,
@@ -389,12 +392,14 @@ export type {
   StoreViewDegreeOptions,
   StoreViewEdgeCollection,
   StoreViewEdgeCollections,
+  StoreViewGraphAlgorithms,
   StoreViewNeighborsOptions,
   StoreViewNodeCollection,
   StoreViewNodeCollections,
   StoreViewReachableOptions,
   StoreViewShortestPathOptions,
   StoreViewSubgraphOptions,
+  StoreViewWeaklyConnectedComponentsOptions,
   TypedRecordedStoreViewEdgeCollection,
   TypedStoreViewEdgeCollection,
 } from "./store";
@@ -420,6 +425,8 @@ export type {
   ShortestPathResult,
   TemporalAlgorithmOptions,
   TraversalDirection,
+  WeaklyConnectedComponentMembership,
+  WeaklyConnectedComponentsOptions,
 } from "./store/algorithms";
 export type {
   AnyEdge,

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -66,6 +66,10 @@ export const postgresDialect: DialectAdapter = {
     supportsFulltext: true,
   },
 
+  binaryText(expression) {
+    return sql`${expression} COLLATE "C"`;
+  },
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -70,6 +70,10 @@ export const postgresDialect: DialectAdapter = {
     return sql`${expression} COLLATE "C"`;
   },
 
+  analyzeTemporaryTable(table) {
+    return sql`ANALYZE ${table}`;
+  },
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -70,6 +70,10 @@ export const sqliteDialect: DialectAdapter = {
     supportsFulltext: true,
   },
 
+  binaryText(expression) {
+    return expression;
+  },
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -74,6 +74,10 @@ export const sqliteDialect: DialectAdapter = {
     return expression;
   },
 
+  analyzeTemporaryTable(): undefined {
+    return;
+  },
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -5,7 +5,7 @@
  * Implementing a new dialect (MySQL, SQL Server, etc.) requires
  * implementing this interface.
  */
-import { type SQL } from "drizzle-orm";
+import { type SQL, type SQLWrapper } from "drizzle-orm";
 
 import { type VectorMetric } from "../../backend/types";
 import { type JsonPointer } from "../json-pointer";
@@ -111,6 +111,13 @@ export interface DialectAdapter {
    * labels or query tie-breaks.
    */
   binaryText(expression: SQL): SQL;
+
+  /**
+   * Builds the dialect's planner-statistics refresh for a temporary table.
+   * Returns undefined when the engine plans temporary tables well enough
+   * without an explicit refresh.
+   */
+  analyzeTemporaryTable(table: SQLWrapper): SQL | undefined;
 
   // ============================================================
   // JSON Path Operations

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -104,6 +104,14 @@ export interface DialectAdapter {
    */
   readonly capabilities: DialectCapabilities;
 
+  /**
+   * Applies the dialect's binary/code-point text collation to an expression.
+   * SQLite's default BINARY collation already has this order; PostgreSQL must
+   * force `COLLATE "C"` so database locale cannot change deterministic graph
+   * labels or query tie-breaks.
+   */
+  binaryText(expression: SQL): SQL;
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -101,6 +101,7 @@ async function findReachableNodesInWorkingTable(
   options: InternalTraversalOptions,
 ): Promise<readonly ReachableNode[]> {
   return runIterativeGraphOperation(ctx, options, {
+    algorithm: "reachable",
     maxIterations: maxHops,
     createWorkingTable,
     async initialize(context) {
@@ -148,6 +149,7 @@ async function findShortestPathInWorkingTable(
   options: InternalTraversalOptions,
 ): Promise<ShortestPathResult | undefined> {
   return runIterativeGraphOperation(ctx, options, {
+    algorithm: "shortestPath",
     maxIterations: maxHops,
     createWorkingTable,
     async initialize(context) {

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -106,9 +106,11 @@ async function findReachableNodesInWorkingTable(
     createWorkingTable,
     async initialize(context) {
       await seedWorkingSide(context, sourceId, "forward");
+      const frontierCount = await countWorkingDepth(context, "forward", 0);
       return {
         depth: 0,
-        frontierCount: await countWorkingDepth(context, "forward", 0),
+        frontierCount,
+        workingTableSize: frontierCount,
       };
     },
     async runRound(context, state) {
@@ -120,7 +122,11 @@ async function findReachableNodesInWorkingTable(
         nextDepth,
         context.operation.direction,
       );
-      return { depth: nextDepth, frontierCount };
+      return {
+        depth: nextDepth,
+        frontierCount,
+        workingTableSize: state.workingTableSize + frontierCount,
+      };
     },
     hasConverged(state) {
       return state.frontierCount === 0 || state.depth >= maxHops;
@@ -167,6 +173,7 @@ async function findShortestPathInWorkingTable(
         forwardFrontierCount,
         reverseFrontierCount,
         meeting,
+        workingTableSize: forwardFrontierCount + reverseFrontierCount,
       };
     },
     async runRound(context, state) {
@@ -197,6 +204,7 @@ async function findShortestPathInWorkingTable(
         reverseFrontierCount:
           expandForward ? state.reverseFrontierCount : frontierCount,
         meeting,
+        workingTableSize: state.workingTableSize + frontierCount,
       };
     },
     hasConverged(state) {

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -5,6 +5,7 @@ import { compareStrings } from "../../utils/compare";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
 import {
   compareNodeIdentity,
+  compileWorkingTableEdgeExpansion,
   compileWorkingTableExpansion,
   fetchVisibleWorkingNodes,
   type IterativeGraphOperation,
@@ -115,7 +116,7 @@ async function findReachableNodesInWorkingTable(
     },
     async runRound(context, state) {
       const nextDepth = state.depth + 1;
-      const frontierCount = await expandWorkingTableRound(
+      const frontierCount = await expandReachableWorkingTableRound(
         context,
         "forward",
         state.depth,
@@ -328,6 +329,70 @@ async function expandWorkingTableRound(
               AND visited.side = ${side}
               AND visited.node_id = ranked.target_id
               AND visited.node_kind = ranked.target_kind
+          )
+        ON CONFLICT (graph_id, run_id, side, node_kind, node_id) DO NOTHING
+        RETURNING node_id
+      `),
+    );
+    insertedCount += rows.length;
+  }
+  return insertedCount;
+}
+
+/**
+ * Reachability needs only minimum depth, not a reconstructable predecessor.
+ * Reduce duplicate edge targets before checking target-node visibility so a
+ * dense frontier performs one node lookup per candidate identity rather than
+ * one lookup per incident edge.
+ */
+async function expandReachableWorkingTableRound(
+  context: IterativeGraphRunContext,
+  side: WorkingSide,
+  currentDepth: number,
+  nextDepth: number,
+  direction: TraversalDirection,
+): Promise<number> {
+  let insertedCount = 0;
+  for (const edgeKinds of context.operation.edgeKindChunks) {
+    const sourceFilter = sql`
+      w.graph_id = ${context.graphId}
+      AND w.run_id = ${context.runId}
+      AND w.side = ${side}
+      AND w.depth = ${currentDepth}
+    `;
+    const edgeExpansion = compileWorkingTableEdgeExpansion(
+      context.operation,
+      context.workingTable,
+      sourceFilter,
+      direction,
+      edgeKinds,
+    );
+    const rows = await context.backend.execute<InsertedRow>(
+      asCompiledRowsSql(sql`
+        INSERT INTO ${context.workingTable}
+          (graph_id, run_id, side, node_id, node_kind, depth,
+           predecessor_id, predecessor_kind)
+        SELECT
+          ${context.graphId}, ${context.runId}, ${side},
+          candidates.target_id, candidates.target_kind, ${nextDepth},
+          NULL, NULL
+        FROM (
+          SELECT DISTINCT expanded.target_id, expanded.target_kind
+          FROM (${edgeExpansion}) expanded
+        ) candidates
+        JOIN ${context.operation.schema.nodesTable} n
+          ON n.graph_id = ${context.graphId}
+          AND n.id = candidates.target_id
+          AND n.kind = candidates.target_kind
+        WHERE ${context.operation.nodeTemporalFilter}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${context.workingTable} visited
+            WHERE visited.graph_id = ${context.graphId}
+              AND visited.run_id = ${context.runId}
+              AND visited.side = ${side}
+              AND visited.node_id = candidates.target_id
+              AND visited.node_kind = candidates.target_kind
           )
         ON CONFLICT (graph_id, run_id, side, node_kind, node_id) DO NOTHING
         RETURNING node_id

--- a/packages/typegraph/src/store/algorithms/index.ts
+++ b/packages/typegraph/src/store/algorithms/index.ts
@@ -25,12 +25,16 @@ import type {
   InternalNeighborsOptions,
   InternalReachableOptions,
   InternalShortestPathOptions,
+  InternalWeaklyConnectedComponentsOptions,
   NeighborsOptions,
   ReachableNode,
   ReachableOptions,
   ShortestPathOptions,
   ShortestPathResult,
+  WeaklyConnectedComponentMembership,
+  WeaklyConnectedComponentsOptions,
 } from "./types";
+import { executeWeaklyConnectedComponents } from "./weakly-connected-components";
 
 /**
  * Raw node id or any object with an `id: string` field. Covers `Node`,
@@ -108,6 +112,16 @@ export type GraphAlgorithms<G extends GraphDef> = Readonly<{
    * With `direction: "both"` (default), self-loops contribute once.
    */
   degree: (node: NodeIdentifier, options?: DegreeOptions<G>) => Promise<number>;
+
+  /**
+   * Computes exact weakly connected components over the selected edge kinds.
+   *
+   * Iterative: runs multiple SQL rounds in one snapshot and requires
+   * `backend.capabilities.graphAnalytics.supported`.
+   */
+  weaklyConnectedComponents: (
+    options: WeaklyConnectedComponentsOptions<G>,
+  ) => Promise<readonly WeaklyConnectedComponentMembership[]>;
 }>;
 
 export type InternalGraphAlgorithms<G extends GraphDef> = Readonly<{
@@ -133,6 +147,9 @@ export type InternalGraphAlgorithms<G extends GraphDef> = Readonly<{
     node: NodeIdentifier,
     options?: InternalDegreeOptions<G>,
   ) => Promise<number>;
+  weaklyConnectedComponents: (
+    options: InternalWeaklyConnectedComponentsOptions<G>,
+  ) => Promise<readonly WeaklyConnectedComponentMembership[]>;
 }>;
 
 export type CreateGraphAlgorithmsParams = Readonly<{
@@ -157,7 +174,7 @@ function assertRecordedAsOfInternalOnly(
     message: `recordedAsOf is only available through store.asOfRecorded(...).${method}(...).`,
     context: { method },
     suggestion:
-      "Use store.asOfRecorded(recordedAt).reachable/shortestPath/canReach/neighbors/degree(...) instead of passing recordedAsOf directly.",
+      "Use store.asOfRecorded(recordedAt) or a recorded StoreView instead of passing recordedAsOf directly.",
   });
 }
 
@@ -211,6 +228,14 @@ export function createGraphAlgorithms<G extends GraphDef>(
       assertRecordedAsOfInternalOnly(options, "degree", allowRecordedAsOf);
       return executeDegree(ctx, resolveNodeId(node), options ?? {});
     },
+    weaklyConnectedComponents(options) {
+      assertRecordedAsOfInternalOnly(
+        options,
+        "weaklyConnectedComponents",
+        allowRecordedAsOf,
+      );
+      return executeWeaklyConnectedComponents(ctx, options);
+    },
   };
 }
 
@@ -224,6 +249,7 @@ export type {
   InternalReachableOptions,
   InternalShortestPathOptions,
   InternalTemporalAlgorithmOptions,
+  InternalWeaklyConnectedComponentsOptions,
   NeighborsOptions,
   PathNode,
   ReachableNode,
@@ -232,4 +258,6 @@ export type {
   ShortestPathResult,
   TemporalAlgorithmOptions,
   TraversalDirection,
+  WeaklyConnectedComponentMembership,
+  WeaklyConnectedComponentsOptions,
 } from "./types";

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -107,10 +107,11 @@ const DEFAULT_MAX_BIND_PARAMETERS = 999;
 const RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH = 12;
 /**
  * PostgreSQL initially estimates an un-analyzed temporary relation at one row.
- * A 64x miss is large enough to distort join ordering, while ANALYZE remains a
- * low-single-digit-millisecond operation at this size.
+ * Even a few dozen rows can distort join ordering on a dense edge expansion,
+ * while ANALYZE remains a low-single-digit-millisecond operation at this size.
+ * Keep the trigger below the 31-person smoke graph that exposed this cliff.
  */
-export const WORKING_TABLE_ANALYZE_MINIMUM_ROWS = 64;
+export const WORKING_TABLE_ANALYZE_MINIMUM_ROWS = 16;
 /** Caps statistics drift for growing BFS-style working tables at under 4x. */
 export const WORKING_TABLE_ANALYZE_GROWTH_FACTOR = 4;
 

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -435,6 +435,70 @@ export function compileWorkingTableExpansion(
   }
 }
 
+/**
+ * Expands a working-table frontier through visible edges without joining target
+ * nodes. Callers that reduce duplicate targets first can defer the target-node
+ * visibility join until after that reduction, avoiding repeated point lookups
+ * for the same target on dense frontiers.
+ */
+export function compileWorkingTableEdgeExpansion(
+  operation: IterativeGraphOperation,
+  workingTable: WorkingTableIdentifier,
+  sourceFilter: SQL,
+  direction: TraversalDirection,
+  edgeKinds: readonly string[],
+): SQL {
+  switch (direction) {
+    case "out": {
+      return compileDirectionalEdgeExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "from_id",
+        "from_kind",
+        "to_id",
+        "to_kind",
+      );
+    }
+    case "in": {
+      return compileDirectionalEdgeExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "to_id",
+        "to_kind",
+        "from_id",
+        "from_kind",
+      );
+    }
+    case "both": {
+      const outgoing = compileDirectionalEdgeExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "from_id",
+        "from_kind",
+        "to_id",
+        "to_kind",
+      );
+      const incoming = compileDirectionalEdgeExpansion(
+        operation,
+        workingTable,
+        sourceFilter,
+        edgeKinds,
+        "to_id",
+        "to_kind",
+        "from_id",
+        "from_kind",
+      );
+      return sql`${outgoing} UNION ALL ${incoming}`;
+    }
+  }
+}
+
 function compileDirectionalExpansion(
   operation: IterativeGraphOperation,
   workingRelation: SQL | WorkingTableIdentifier,
@@ -445,8 +509,31 @@ function compileDirectionalExpansion(
   targetField: "from_id" | "to_id",
   targetKindField: "from_kind" | "to_kind",
 ): ReturnType<typeof sql> {
+  const edgeExpansion = compileDirectionalEdgeExpansion(
+    operation,
+    workingRelation,
+    sourceFilter,
+    edgeKinds,
+    joinField,
+    joinKindField,
+    targetField,
+    targetKindField,
+  );
+  return sql`SELECT expanded.source_id, expanded.source_kind, n.id AS target_id, n.kind AS target_kind FROM (${edgeExpansion}) expanded JOIN ${operation.schema.nodesTable} n ON n.graph_id = ${operation.ctx.graphId} AND n.id = expanded.target_id AND n.kind = expanded.target_kind WHERE ${operation.nodeTemporalFilter}`;
+}
+
+function compileDirectionalEdgeExpansion(
+  operation: IterativeGraphOperation,
+  workingRelation: SQL | WorkingTableIdentifier,
+  sourceFilter: SQL,
+  edgeKinds: readonly string[],
+  joinField: "from_id" | "to_id",
+  joinKindField: "from_kind" | "to_kind",
+  targetField: "from_id" | "to_id",
+  targetKindField: "from_kind" | "to_kind",
+): ReturnType<typeof sql> {
   const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
-  return sql`SELECT w.node_id AS source_id, w.node_kind AS source_kind, n.id AS target_id, n.kind AS target_kind FROM ${workingRelation} w JOIN ${operation.schema.edgesTable} e ON e.${sql.raw(joinField)} = w.node_id AND e.${sql.raw(joinKindField)} = w.node_kind AND e.graph_id = ${operation.ctx.graphId} JOIN ${operation.schema.nodesTable} n ON n.graph_id = e.graph_id AND n.id = e.${sql.raw(targetField)} AND n.kind = e.${sql.raw(targetKindField)} WHERE ${sourceFilter} AND ${edgeKindFilter} AND ${operation.edgeTemporalFilter} AND ${operation.nodeTemporalFilter}`;
+  return sql`SELECT w.node_id AS source_id, w.node_kind AS source_kind, e.${sql.raw(targetField)} AS target_id, e.${sql.raw(targetKindField)} AS target_kind FROM ${workingRelation} w JOIN ${operation.schema.edgesTable} e ON e.${sql.raw(joinField)} = w.node_id AND e.${sql.raw(joinKindField)} = w.node_kind AND e.graph_id = ${operation.ctx.graphId} WHERE ${sourceFilter} AND ${edgeKindFilter} AND ${operation.edgeTemporalFilter}`;
 }
 
 function chunkValues<T>(

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -67,7 +67,14 @@ export type IterativeGraphRunContext = Readonly<{
   executeTemporary: (query: SQL) => Promise<void>;
 }>;
 
-export type IterativeGraphPlan<State, Result> = Readonly<{
+export type IterativeGraphState = Readonly<{
+  workingTableSize: number;
+}>;
+
+export type IterativeGraphPlan<
+  State extends IterativeGraphState,
+  Result,
+> = Readonly<{
   algorithm: string;
   maxIterations: number;
   createWorkingTable: (context: IterativeGraphRunContext) => SQL;
@@ -98,6 +105,14 @@ type VisibleNodeRow = Readonly<{
 
 const DEFAULT_MAX_BIND_PARAMETERS = 999;
 const RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH = 12;
+/**
+ * PostgreSQL initially estimates an un-analyzed temporary relation at one row.
+ * A 64x miss is large enough to distort join ordering, while ANALYZE remains a
+ * low-single-digit-millisecond operation at this size.
+ */
+export const WORKING_TABLE_ANALYZE_MINIMUM_ROWS = 64;
+/** Caps statistics drift for growing BFS-style working tables at under 4x. */
+export const WORKING_TABLE_ANALYZE_GROWTH_FACTOR = 4;
 
 /**
  * Opens the shared execution scope for iterative graph algorithms. The host
@@ -132,7 +147,10 @@ export async function withInlineIterativeGraphOperation<T>(
  * check, and `finally` cleanup; the plan owns only table shape, round SQL, and
  * result extraction.
  */
-export async function runIterativeGraphOperation<State, Result>(
+export async function runIterativeGraphOperation<
+  State extends IterativeGraphState,
+  Result,
+>(
   ctx: AlgorithmContext,
   options: InternalTraversalOptions,
   plan: IterativeGraphPlan<State, Result>,
@@ -168,12 +186,23 @@ export async function runIterativeGraphOperation<State, Result>(
       let operationError: unknown;
       try {
         let state = await plan.initialize(context);
+        let analyzedRowCount = await refreshWorkingTableStatistics(
+          context,
+          state.workingTableSize,
+        );
         for (
           let iteration = 1;
           iteration <= plan.maxIterations && !plan.hasConverged(state);
           iteration++
         ) {
           state = await plan.runRound(context, state, iteration);
+          if (!plan.hasConverged(state)) {
+            analyzedRowCount = await refreshWorkingTableStatistics(
+              context,
+              state.workingTableSize,
+              analyzedRowCount,
+            );
+          }
         }
         if (!plan.hasConverged(state)) {
           throw new GraphAlgorithmConvergenceError(
@@ -195,6 +224,35 @@ export async function runIterativeGraphOperation<State, Result>(
       temporaryWrites: INTERNAL_TEMPORARY_WRITES,
     },
   );
+}
+
+export function shouldRefreshWorkingTableStatistics(
+  workingTableSize: number,
+  analyzedRowCount?: number,
+): boolean {
+  if (workingTableSize < WORKING_TABLE_ANALYZE_MINIMUM_ROWS) return false;
+  if (analyzedRowCount === undefined) return true;
+  return (
+    workingTableSize >= analyzedRowCount * WORKING_TABLE_ANALYZE_GROWTH_FACTOR
+  );
+}
+
+async function refreshWorkingTableStatistics(
+  context: IterativeGraphRunContext,
+  workingTableSize: number,
+  analyzedRowCount?: number,
+): Promise<number | undefined> {
+  if (
+    !shouldRefreshWorkingTableStatistics(workingTableSize, analyzedRowCount)
+  ) {
+    return analyzedRowCount;
+  }
+  const statement = context.operation.ctx.dialect.analyzeTemporaryTable(
+    context.workingTable,
+  );
+  if (statement === undefined) return analyzedRowCount;
+  await context.executeTemporary(statement);
+  return workingTableSize;
 }
 
 async function dropWorkingTable(

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -5,7 +5,10 @@ import {
   INTERNAL_TEMPORARY_WRITES,
   type TransactionBackend,
 } from "../../backend/types";
-import { ConfigurationError } from "../../errors";
+import {
+  ConfigurationError,
+  GraphAlgorithmConvergenceError,
+} from "../../errors";
 import {
   compileKindFilter,
   sqlValueList,
@@ -65,6 +68,7 @@ export type IterativeGraphRunContext = Readonly<{
 }>;
 
 export type IterativeGraphPlan<State, Result> = Readonly<{
+  algorithm: string;
   maxIterations: number;
   createWorkingTable: (context: IterativeGraphRunContext) => SQL;
   initialize: (context: IterativeGraphRunContext) => Promise<State>;
@@ -170,6 +174,12 @@ export async function runIterativeGraphOperation<State, Result>(
           iteration++
         ) {
           state = await plan.runRound(context, state, iteration);
+        }
+        if (!plan.hasConverged(state)) {
+          throw new GraphAlgorithmConvergenceError(
+            plan.algorithm,
+            plan.maxIterations,
+          );
         }
         return await plan.extractResult(context, state);
       } catch (error) {

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -175,3 +175,35 @@ export type DegreeOptions<G extends GraphDef> = TemporalAlgorithmOptions &
 export type InternalDegreeOptions<G extends GraphDef> =
   InternalTemporalAlgorithmOptions &
     Omit<DegreeOptions<G>, keyof TemporalAlgorithmOptions>;
+
+/**
+ * Options for exact weakly connected components.
+ *
+ * Selected edges are treated as undirected, regardless of their declared
+ * direction. Every visible graph node is returned; nodes with no selected
+ * incident edge form singleton components.
+ */
+export type WeaklyConnectedComponentsOptions<G extends GraphDef> =
+  TemporalAlgorithmOptions &
+    Readonly<{
+      /** Edge kinds whose undirected projection defines connectivity. */
+      edges: readonly EdgeKinds<G>[];
+      /** Maximum label-propagation rounds before throwing. Defaults to 1000. */
+      maxIterations?: number;
+    }>;
+
+export type InternalWeaklyConnectedComponentsOptions<G extends GraphDef> =
+  InternalTemporalAlgorithmOptions &
+    Omit<WeaklyConnectedComponentsOptions<G>, keyof TemporalAlgorithmOptions>;
+
+/** One node's membership in an exact weakly connected component. */
+export type WeaklyConnectedComponentMembership = Readonly<{
+  id: string;
+  kind: string;
+  /** Deterministic minimum node id in this component. */
+  componentId: string;
+  /** Kind paired with `componentId`; node identity is `(kind, id)`. */
+  componentKind: string;
+  /** Number of visible nodes in this component. */
+  size: number;
+}>;

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -4,7 +4,7 @@
  * Algorithms operate over one or more edge kinds and may traverse edges
  * in the forward direction ("out"), reverse ("in"), or undirected ("both").
  */
-import type { EdgeKinds, GraphDef } from "../../core/define-graph";
+import type { EdgeKinds, GraphDef, NodeKinds } from "../../core/define-graph";
 import type { RecordedInstant } from "../../core/temporal";
 import type { TemporalMode } from "../../core/types";
 import type { RecursiveCyclePolicy } from "../../query/ast";
@@ -180,14 +180,17 @@ export type InternalDegreeOptions<G extends GraphDef> =
  * Options for exact weakly connected components.
  *
  * Selected edges are treated as undirected, regardless of their declared
- * direction. Every visible graph node is returned; nodes with no selected
- * incident edge form singleton components.
+ * direction. By default every visible graph node is returned; `nodeKinds`
+ * restricts the operation to the induced subgraph over those kinds. Nodes in
+ * scope with no selected incident edge form singleton components.
  */
 export type WeaklyConnectedComponentsOptions<G extends GraphDef> =
   TemporalAlgorithmOptions &
     Readonly<{
       /** Edge kinds whose undirected projection defines connectivity. */
       edges: readonly EdgeKinds<G>[];
+      /** Optional node kinds defining the induced subgraph to analyze. */
+      nodeKinds?: readonly NodeKinds<G>[];
       /** Maximum label-propagation rounds before throwing. Defaults to 1000. */
       maxIterations?: number;
     }>;

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -5,6 +5,7 @@ import {
   ConfigurationError,
   UnsupportedBackendCapabilityError,
 } from "../../errors";
+import { compileKindFilter } from "../../query/compiler/predicate-utils";
 import { asCompiledRowsSql } from "../../query/sql-intent";
 import { compareCodePoints } from "../../utils/compare";
 import {
@@ -46,6 +47,12 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
   assertEdgeKinds(options.edges);
   assertWeaklyConnectedComponentsSupported(ctx);
   const maxIterations = resolveMaxIterations(options.maxIterations);
+  const nodeKinds =
+    options.nodeKinds === undefined ?
+      undefined
+    : [...new Set(options.nodeKinds)].toSorted((left, right) =>
+        compareCodePoints(left, right),
+      );
   const traversalOptions: InternalTraversalOptions = {
     edges: options.edges,
     direction: "both",
@@ -62,7 +69,7 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
     algorithm: "weaklyConnectedComponents",
     maxIterations,
     createWorkingTable,
-    initialize: initializeWorkingTable,
+    initialize: (context) => initializeWorkingTable(context, nodeKinds),
     runRound: runLabelPropagationRound,
     hasConverged(state) {
       return state.changedCount === 0;
@@ -120,8 +127,13 @@ function createWorkingTable(context: IterativeGraphRunContext): SQL {
 
 async function initializeWorkingTable(
   context: IterativeGraphRunContext,
+  nodeKinds: readonly string[] | undefined,
 ): Promise<IterationState> {
   const { operation, workingTable, graphId, runId } = context;
+  const nodeKindFilter =
+    nodeKinds === undefined ?
+      sql`TRUE`
+    : compileKindFilter(sql.raw("n.kind"), nodeKinds);
   await context.executeTemporary(sql`
     INSERT INTO ${workingTable}
       (graph_id, run_id, node_id, node_kind, label_id, label_kind,
@@ -130,6 +142,7 @@ async function initializeWorkingTable(
       ${graphId}, ${runId}, n.id, n.kind, n.id, n.kind, n.id, n.kind
     FROM ${operation.schema.nodesTable} n
     WHERE n.graph_id = ${graphId}
+      AND ${nodeKindFilter}
       AND ${operation.nodeTemporalFilter}
   `);
 
@@ -207,6 +220,11 @@ async function propagateChunkLabels(
         AND source.run_id = ${runId}
         AND source.node_id = expanded.source_id
         AND source.node_kind = expanded.source_kind
+      JOIN ${workingTable} scoped_target
+        ON scoped_target.graph_id = ${graphId}
+        AND scoped_target.run_id = ${runId}
+        AND scoped_target.node_id = expanded.target_id
+        AND scoped_target.node_kind = expanded.target_kind
     ), ranked AS (
       SELECT
         target_id,

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -22,7 +22,10 @@ import type {
   WeaklyConnectedComponentMembership,
 } from "./types";
 
-type IterationState = Readonly<{ changedCount: number }>;
+type IterationState = Readonly<{
+  changedCount: number;
+  workingTableSize: number;
+}>;
 type CountRow = Readonly<{ count: number | string }>;
 type ChangedRow = Readonly<{ node_id: string }>;
 type MembershipRow = Readonly<{
@@ -137,18 +140,23 @@ async function initializeWorkingTable(
       WHERE graph_id = ${graphId} AND run_id = ${runId}
     `),
   );
-  return { changedCount: Number(rows[0]?.count ?? 0) };
+  const workingTableSize = Number(rows[0]?.count ?? 0);
+  return { changedCount: workingTableSize, workingTableSize };
 }
 
 async function runLabelPropagationRound(
   context: IterativeGraphRunContext,
+  state: IterationState,
 ): Promise<IterationState> {
   await resetNextLabels(context);
   for (const edgeKinds of context.operation.edgeKindChunks) {
     await propagateChunkLabels(context, edgeKinds);
   }
   const changedRows = await applyNextLabels(context);
-  return { changedCount: changedRows.length };
+  return {
+    changedCount: changedRows.length,
+    workingTableSize: state.workingTableSize,
+  };
 }
 
 async function resetNextLabels(

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -1,0 +1,295 @@
+import { type SQL, sql } from "drizzle-orm";
+
+import type { GraphDef } from "../../core/define-graph";
+import {
+  ConfigurationError,
+  UnsupportedBackendCapabilityError,
+} from "../../errors";
+import { asCompiledRowsSql } from "../../query/sql-intent";
+import { compareCodePoints } from "../../utils/compare";
+import {
+  type AlgorithmContext,
+  assertEdgeKinds,
+  type InternalTraversalOptions,
+} from "./context";
+import {
+  compileWorkingTableExpansion,
+  type IterativeGraphRunContext,
+  runIterativeGraphOperation,
+} from "./iterative-graph-operation";
+import type {
+  InternalWeaklyConnectedComponentsOptions,
+  WeaklyConnectedComponentMembership,
+} from "./types";
+
+type IterationState = Readonly<{ changedCount: number }>;
+type CountRow = Readonly<{ count: number | string }>;
+type ChangedRow = Readonly<{ node_id: string }>;
+type MembershipRow = Readonly<{
+  node_id: string;
+  node_kind: string;
+  component_id: string;
+  component_kind: string;
+  component_size: number | string;
+}>;
+
+const DEFAULT_WCC_MAX_ITERATIONS = 1000;
+
+/** Runs exact label-min weakly connected components in the shared SQL loop. */
+export async function executeWeaklyConnectedComponents<G extends GraphDef>(
+  ctx: AlgorithmContext,
+  options: InternalWeaklyConnectedComponentsOptions<G>,
+): Promise<readonly WeaklyConnectedComponentMembership[]> {
+  assertEdgeKinds(options.edges);
+  assertWeaklyConnectedComponentsSupported(ctx);
+  const maxIterations = resolveMaxIterations(options.maxIterations);
+  const traversalOptions: InternalTraversalOptions = {
+    edges: options.edges,
+    direction: "both",
+    ...(options.temporalMode === undefined ?
+      {}
+    : { temporalMode: options.temporalMode }),
+    ...(options.asOf === undefined ? {} : { asOf: options.asOf }),
+    ...(options.recordedAsOf === undefined ?
+      {}
+    : { recordedAsOf: options.recordedAsOf }),
+  };
+
+  return runIterativeGraphOperation(ctx, traversalOptions, {
+    algorithm: "weaklyConnectedComponents",
+    maxIterations,
+    createWorkingTable,
+    initialize: initializeWorkingTable,
+    runRound: runLabelPropagationRound,
+    hasConverged(state) {
+      return state.changedCount === 0;
+    },
+    extractResult: extractMemberships,
+  });
+}
+
+function assertWeaklyConnectedComponentsSupported(ctx: AlgorithmContext): void {
+  if (
+    ctx.backend.capabilities.graphAnalytics?.supported === true &&
+    ctx.backend.capabilities.windowFunctions
+  ) {
+    return;
+  }
+
+  throw new UnsupportedBackendCapabilityError(
+    "weaklyConnectedComponents",
+    "graphAnalytics",
+    {
+      dialect: ctx.backend.dialect,
+      supported: ctx.backend.capabilities.graphAnalytics?.supported === true,
+      windowFunctions: ctx.backend.capabilities.windowFunctions,
+    },
+    "Use a built-in transactional SQLite/PostgreSQL backend, or declare graphAnalytics support on a compatible custom backend.",
+  );
+}
+
+function resolveMaxIterations(value: number | undefined): number {
+  const maxIterations = value ?? DEFAULT_WCC_MAX_ITERATIONS;
+  if (!Number.isSafeInteger(maxIterations) || maxIterations < 1) {
+    throw new ConfigurationError(
+      `weaklyConnectedComponents maxIterations must be a positive safe integer, got ${String(maxIterations)}.`,
+      { maxIterations },
+    );
+  }
+  return maxIterations;
+}
+
+function createWorkingTable(context: IterativeGraphRunContext): SQL {
+  return sql`
+    CREATE TEMP TABLE ${context.workingTable} (
+      graph_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      node_id TEXT NOT NULL,
+      node_kind TEXT NOT NULL,
+      label_id TEXT NOT NULL,
+      label_kind TEXT NOT NULL,
+      next_label_id TEXT NOT NULL,
+      next_label_kind TEXT NOT NULL,
+      PRIMARY KEY (graph_id, run_id, node_kind, node_id)
+    )
+  `;
+}
+
+async function initializeWorkingTable(
+  context: IterativeGraphRunContext,
+): Promise<IterationState> {
+  const { operation, workingTable, graphId, runId } = context;
+  await context.executeTemporary(sql`
+    INSERT INTO ${workingTable}
+      (graph_id, run_id, node_id, node_kind, label_id, label_kind,
+       next_label_id, next_label_kind)
+    SELECT
+      ${graphId}, ${runId}, n.id, n.kind, n.id, n.kind, n.id, n.kind
+    FROM ${operation.schema.nodesTable} n
+    WHERE n.graph_id = ${graphId}
+      AND ${operation.nodeTemporalFilter}
+  `);
+
+  const rows = await context.backend.execute<CountRow>(
+    asCompiledRowsSql(sql`
+      SELECT COUNT(*) AS count
+      FROM ${workingTable}
+      WHERE graph_id = ${graphId} AND run_id = ${runId}
+    `),
+  );
+  return { changedCount: Number(rows[0]?.count ?? 0) };
+}
+
+async function runLabelPropagationRound(
+  context: IterativeGraphRunContext,
+): Promise<IterationState> {
+  await resetNextLabels(context);
+  for (const edgeKinds of context.operation.edgeKindChunks) {
+    await propagateChunkLabels(context, edgeKinds);
+  }
+  const changedRows = await applyNextLabels(context);
+  return { changedCount: changedRows.length };
+}
+
+async function resetNextLabels(
+  context: IterativeGraphRunContext,
+): Promise<void> {
+  await context.executeTemporary(sql`
+    UPDATE ${context.workingTable}
+    SET next_label_id = label_id, next_label_kind = label_kind
+    WHERE graph_id = ${context.graphId} AND run_id = ${context.runId}
+  `);
+}
+
+async function propagateChunkLabels(
+  context: IterativeGraphRunContext,
+  edgeKinds: readonly string[],
+): Promise<void> {
+  const { operation, workingTable, graphId, runId } = context;
+  const expansion = compileWorkingTableExpansion(
+    operation,
+    workingTable,
+    sql`w.graph_id = ${graphId} AND w.run_id = ${runId}`,
+    "both",
+    edgeKinds,
+  );
+  const candidateId = operation.ctx.dialect.binaryText(sql`ranked.label_id`);
+  const candidateKind = operation.ctx.dialect.binaryText(
+    sql`ranked.label_kind`,
+  );
+  const currentId = operation.ctx.dialect.binaryText(sql`target.next_label_id`);
+  const currentKind = operation.ctx.dialect.binaryText(
+    sql`target.next_label_kind`,
+  );
+  const sourceId = operation.ctx.dialect.binaryText(sql`source.label_id`);
+  const sourceKind = operation.ctx.dialect.binaryText(sql`source.label_kind`);
+  const targetId = operation.ctx.dialect.binaryText(sql`source.target_id`);
+  const targetKind = operation.ctx.dialect.binaryText(sql`source.target_kind`);
+
+  await context.executeTemporary(sql`
+    WITH candidates AS (
+      SELECT
+        expanded.target_id,
+        expanded.target_kind,
+        source.label_id,
+        source.label_kind
+      FROM (${expansion}) expanded
+      JOIN ${workingTable} source
+        ON source.graph_id = ${graphId}
+        AND source.run_id = ${runId}
+        AND source.node_id = expanded.source_id
+        AND source.node_kind = expanded.source_kind
+    ), ranked AS (
+      SELECT
+        target_id,
+        target_kind,
+        label_id,
+        label_kind,
+        ROW_NUMBER() OVER (
+          PARTITION BY ${targetKind}, ${targetId}
+          ORDER BY ${sourceId}, ${sourceKind}
+        ) AS candidate_rank
+      FROM candidates source
+    )
+    UPDATE ${workingTable} AS target
+    SET next_label_id = ranked.label_id,
+        next_label_kind = ranked.label_kind
+    FROM ranked
+    WHERE target.graph_id = ${graphId}
+      AND target.run_id = ${runId}
+      AND target.node_id = ranked.target_id
+      AND target.node_kind = ranked.target_kind
+      AND ranked.candidate_rank = 1
+      AND (
+        ${candidateId} < ${currentId}
+        OR (
+          ${candidateId} = ${currentId}
+          AND ${candidateKind} < ${currentKind}
+        )
+      )
+  `);
+}
+
+function applyNextLabels(
+  context: IterativeGraphRunContext,
+): Promise<readonly ChangedRow[]> {
+  return context.backend.execute<ChangedRow>(
+    asCompiledRowsSql(sql`
+      UPDATE ${context.workingTable}
+      SET label_id = next_label_id, label_kind = next_label_kind
+      WHERE graph_id = ${context.graphId}
+        AND run_id = ${context.runId}
+        AND (
+          label_id <> next_label_id OR label_kind <> next_label_kind
+        )
+      RETURNING node_id
+    `),
+  );
+}
+
+async function extractMemberships(
+  context: IterativeGraphRunContext,
+): Promise<readonly WeaklyConnectedComponentMembership[]> {
+  const { operation } = context;
+  const componentId = operation.ctx.dialect.binaryText(sql`label_id`);
+  const componentKind = operation.ctx.dialect.binaryText(sql`label_kind`);
+  const nodeId = operation.ctx.dialect.binaryText(sql`node_id`);
+  const nodeKind = operation.ctx.dialect.binaryText(sql`node_kind`);
+  const rows = await context.backend.execute<MembershipRow>(
+    asCompiledRowsSql(sql`
+      SELECT
+        node_id,
+        node_kind,
+        label_id AS component_id,
+        label_kind AS component_kind,
+        COUNT(*) OVER (
+          PARTITION BY ${componentKind}, ${componentId}
+        ) AS component_size
+      FROM ${context.workingTable}
+      WHERE graph_id = ${context.graphId} AND run_id = ${context.runId}
+      ORDER BY ${componentId}, ${componentKind}, ${nodeId}, ${nodeKind}
+    `),
+  );
+
+  return rows
+    .map((row) => ({
+      id: row.node_id,
+      kind: row.node_kind,
+      componentId: row.component_id,
+      componentKind: row.component_kind,
+      size: Number(row.component_size),
+    }))
+    .toSorted(compareMemberships);
+}
+
+function compareMemberships(
+  left: WeaklyConnectedComponentMembership,
+  right: WeaklyConnectedComponentMembership,
+): number {
+  return (
+    compareCodePoints(left.componentId, right.componentId) ||
+    compareCodePoints(left.componentKind, right.componentKind) ||
+    compareCodePoints(left.id, right.id) ||
+    compareCodePoints(left.kind, right.kind)
+  );
+}

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -60,10 +60,12 @@ export type {
   StoreViewCanReachOptions,
   StoreViewCoordinate,
   StoreViewDegreeOptions,
+  StoreViewGraphAlgorithms,
   StoreViewNeighborsOptions,
   StoreViewReachableOptions,
   StoreViewShortestPathOptions,
   StoreViewSubgraphOptions,
+  StoreViewWeaklyConnectedComponentsOptions,
 } from "./store-view";
 export { RecordedStoreView, StoreView } from "./store-view";
 

--- a/packages/typegraph/src/store/store-view.ts
+++ b/packages/typegraph/src/store/store-view.ts
@@ -51,6 +51,8 @@ import {
   type ShortestPathOptions,
   type ShortestPathResult,
   type TemporalAlgorithmOptions,
+  type WeaklyConnectedComponentMembership,
+  type WeaklyConnectedComponentsOptions,
 } from "./algorithms";
 import {
   CURRENT_ONLY_READ_NAMES,
@@ -144,6 +146,39 @@ export type StoreViewDegreeOptions<G extends GraphDef> = Omit<
   DegreeOptions<G>,
   keyof TemporalAlgorithmOptions
 >;
+
+/** WCC options with the temporal axis removed (the view's pin supplies it). */
+export type StoreViewWeaklyConnectedComponentsOptions<G extends GraphDef> =
+  Omit<WeaklyConnectedComponentsOptions<G>, keyof TemporalAlgorithmOptions>;
+
+/** Graph-algorithm facade sealed to a {@link StoreView}'s coordinate. */
+export type StoreViewGraphAlgorithms<G extends GraphDef> = Readonly<{
+  shortestPath: (
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: StoreViewShortestPathOptions<G>,
+  ) => Promise<ShortestPathResult | undefined>;
+  reachable: (
+    from: NodeIdentifier,
+    options: StoreViewReachableOptions<G>,
+  ) => Promise<readonly ReachableNode[]>;
+  canReach: (
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: StoreViewCanReachOptions<G>,
+  ) => Promise<boolean>;
+  neighbors: (
+    node: NodeIdentifier,
+    options: StoreViewNeighborsOptions<G>,
+  ) => Promise<readonly ReachableNode[]>;
+  degree: (
+    node: NodeIdentifier,
+    options?: StoreViewDegreeOptions<G>,
+  ) => Promise<number>;
+  weaklyConnectedComponents: (
+    options: StoreViewWeaklyConnectedComponentsOptions<G>,
+  ) => Promise<readonly WeaklyConnectedComponentMembership[]>;
+}>;
 
 function isReadCoordinate(
   coordinate: StoreViewCoordinate | ReadCoordinate,
@@ -722,7 +757,8 @@ function recordedSearch<G extends GraphDef>(
 abstract class CoordinatePinnedView<G extends GraphDef> {
   protected readonly store: Store<G>;
   protected readonly coordinate: ReadCoordinate;
-  #algorithms: InternalGraphAlgorithms<G> | undefined;
+  #algorithmFacade: StoreViewGraphAlgorithms<G> | undefined;
+  #internalAlgorithms: InternalGraphAlgorithms<G> | undefined;
 
   constructor(store: Store<G>, coordinate: ReadCoordinate) {
     this.store = store;
@@ -748,9 +784,25 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
     return this.store.sealedQuery(this.coordinate);
   }
 
-  protected algorithms(): InternalGraphAlgorithms<G> {
-    this.#algorithms ??= this.store.algorithmsAtCoordinate(this.coordinate);
-    return this.#algorithms;
+  protected internalAlgorithms(): InternalGraphAlgorithms<G> {
+    this.#internalAlgorithms ??= this.store.algorithmsAtCoordinate(
+      this.coordinate,
+    );
+    return this.#internalAlgorithms;
+  }
+
+  /** Graph algorithms pinned to this view's immutable temporal coordinate. */
+  get algorithms(): StoreViewGraphAlgorithms<G> {
+    this.#algorithmFacade ??= Object.freeze({
+      shortestPath: (from, to, options) => this.shortestPath(from, to, options),
+      reachable: (from, options) => this.reachable(from, options),
+      canReach: (from, to, options) => this.canReach(from, to, options),
+      neighbors: (node, options) => this.neighbors(node, options),
+      degree: (node, options) => this.degree(node, options),
+      weaklyConnectedComponents: (options) =>
+        this.weaklyConnectedComponents(options),
+    });
+    return this.#algorithmFacade;
   }
 
   /** Extracts a subgraph at this view's pinned coordinate. */
@@ -775,7 +827,7 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
     to: NodeIdentifier,
     options: StoreViewShortestPathOptions<G>,
   ): Promise<ShortestPathResult | undefined> {
-    return this.algorithms().shortestPath(from, to, {
+    return this.internalAlgorithms().shortestPath(from, to, {
       ...options,
       ...withCoordinate(this.coordinate),
     });
@@ -786,7 +838,7 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
     from: NodeIdentifier,
     options: StoreViewReachableOptions<G>,
   ): Promise<readonly ReachableNode[]> {
-    return this.algorithms().reachable(from, {
+    return this.internalAlgorithms().reachable(from, {
       ...options,
       ...withCoordinate(this.coordinate),
     });
@@ -798,7 +850,7 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
     to: NodeIdentifier,
     options: StoreViewCanReachOptions<G>,
   ): Promise<boolean> {
-    return this.algorithms().canReach(from, to, {
+    return this.internalAlgorithms().canReach(from, to, {
       ...options,
       ...withCoordinate(this.coordinate),
     });
@@ -809,7 +861,7 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
     node: NodeIdentifier,
     options: StoreViewNeighborsOptions<G>,
   ): Promise<readonly ReachableNode[]> {
-    return this.algorithms().neighbors(node, {
+    return this.internalAlgorithms().neighbors(node, {
       ...options,
       ...withCoordinate(this.coordinate),
     });
@@ -820,7 +872,17 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
     node: NodeIdentifier,
     options?: StoreViewDegreeOptions<G>,
   ): Promise<number> {
-    return this.algorithms().degree(node, {
+    return this.internalAlgorithms().degree(node, {
+      ...options,
+      ...withCoordinate(this.coordinate),
+    });
+  }
+
+  /** Exact WCC memberships at this view's pinned coordinate. */
+  weaklyConnectedComponents(
+    options: StoreViewWeaklyConnectedComponentsOptions<G>,
+  ): Promise<readonly WeaklyConnectedComponentMembership[]> {
+    return this.internalAlgorithms().weaklyConnectedComponents({
       ...options,
       ...withCoordinate(this.coordinate),
     });

--- a/packages/typegraph/test-d/store-view.test-d.ts
+++ b/packages/typegraph/test-d/store-view.test-d.ts
@@ -139,7 +139,10 @@ expectAssignable<Promise<readonly ReachableNode[]>>(
   view.reachable(personId, { edges: ["knows"] }),
 );
 expectAssignable<Promise<readonly WeaklyConnectedComponentMembership[]>>(
-  view.algorithms.weaklyConnectedComponents({ edges: ["knows"] }),
+  view.algorithms.weaklyConnectedComponents({
+    edges: ["knows"],
+    nodeKinds: ["Person"],
+  }),
 );
 
 // StoreView owns the read coordinate. Its query builder stays fluent for

--- a/packages/typegraph/test-d/store-view.test-d.ts
+++ b/packages/typegraph/test-d/store-view.test-d.ts
@@ -44,6 +44,7 @@ import {
   type StoreViewEdgeCollection,
   type StoreViewNodeCollection,
   type TemporalMode,
+  type WeaklyConnectedComponentMembership,
 } from "..";
 
 const Person = defineNode("Person", {
@@ -137,6 +138,9 @@ expectType<StoreSearch<typeof graph>>(view.search);
 expectAssignable<Promise<readonly ReachableNode[]>>(
   view.reachable(personId, { edges: ["knows"] }),
 );
+expectAssignable<Promise<readonly WeaklyConnectedComponentMembership[]>>(
+  view.algorithms.weaklyConnectedComponents({ edges: ["knows"] }),
+);
 
 // StoreView owns the read coordinate. Its query builder stays fluent for
 // predicates/projections, but callers cannot re-coordinate it with
@@ -212,6 +216,12 @@ expectError(
 );
 expectError(view.degree(personId, { temporalMode: "asOf" }));
 expectError(
+  view.algorithms.weaklyConnectedComponents({
+    edges: ["knows"],
+    temporalMode: "asOf",
+  }),
+);
+expectError(
   view.subgraph(personId, { edges: ["knows"], temporalMode: "asOf" }),
 );
 expectError(
@@ -270,6 +280,12 @@ expectError(
 );
 expectError(
   store.algorithms.degree(personId, {
+    edges: ["knows"],
+    ...LEAKED_RECORDED_OPTIONS,
+  }),
+);
+expectError(
+  store.algorithms.weaklyConnectedComponents({
     edges: ["knows"],
     ...LEAKED_RECORDED_OPTIONS,
   }),
@@ -380,6 +396,8 @@ type RecordedSharedKeys =
   | "shortestPath"
   | "neighbors"
   | "degree"
+  | "weaklyConnectedComponents"
+  | "algorithms"
   | "mode"
   | "asOf";
 

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -16,7 +16,11 @@ import type {
   TransactionOptions,
 } from "../src/backend/types";
 import type { NodeId } from "../src/core/types";
-import { ConfigurationError, ValidationError } from "../src/errors";
+import {
+  ConfigurationError,
+  GraphAlgorithmConvergenceError,
+  ValidationError,
+} from "../src/errors";
 import type {
   CompiledRowsSql,
   CompiledTemporaryStatementSql,
@@ -592,6 +596,86 @@ describe("store.algorithms", () => {
   });
 
   // --------------------------------------------------------------
+  // weaklyConnectedComponents
+  // --------------------------------------------------------------
+
+  describe("weaklyConnectedComponents", () => {
+    it("returns exact component membership and singleton nodes", async () => {
+      const memberships = await store.algorithms.weaklyConnectedComponents({
+        edges: ["knows"],
+      });
+      const byId = new Map(memberships.map((row) => [row.id, row]));
+      const connectedIds = [ids.alice, ids.bob, ids.charlie, ids.dave, ids.eve];
+      const connectedLabels = new Set(
+        connectedIds.map((id) => {
+          const membership = byId.get(id)!;
+          expect(membership.size).toBe(5);
+          return `${membership.componentKind}\u0000${membership.componentId}`;
+        }),
+      );
+
+      expect(connectedLabels.size).toBe(1);
+      expect(byId.get(ids.xavier)?.size).toBe(2);
+      expect(byId.get(ids.yves)?.size).toBe(2);
+      expect(byId.get(ids.frank)?.size).toBe(1);
+      expect(byId.get(ids.t1)?.size).toBe(1);
+      expect(memberships).toHaveLength(13);
+    });
+
+    it("uses only the selected edge kinds", async () => {
+      const memberships = await store.algorithms.weaklyConnectedComponents({
+        edges: ["depends_on"],
+      });
+      const taskMemberships = memberships.filter((row) => row.kind === "Task");
+      expect(taskMemberships).toHaveLength(4);
+      expect(taskMemberships.every((row) => row.size === 4)).toBe(true);
+      expect(
+        memberships
+          .filter((row) => row.kind === "Person")
+          .every((row) => row.size === 1),
+      ).toBe(true);
+    });
+
+    it("rejects a backend without graph-analytics support", async () => {
+      const unsupportedBackend: GraphBackend = {
+        ...backend,
+        capabilities: {
+          ...backend.capabilities,
+          graphAnalytics: { supported: false, mathFunctions: false },
+        },
+      };
+      const unsupportedStore = createStore(testGraph, unsupportedBackend);
+
+      await expect(
+        unsupportedStore.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+        }),
+      ).rejects.toMatchObject({
+        code: "UNSUPPORTED_BACKEND_CAPABILITY",
+        details: { capability: "graphAnalytics", supported: false },
+      });
+    });
+
+    it("validates maxIterations", async () => {
+      await expect(
+        store.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+          maxIterations: 0,
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+    });
+
+    it("throws a typed error when exact convergence is not reached", async () => {
+      await expect(
+        store.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+          maxIterations: 1,
+        }),
+      ).rejects.toBeInstanceOf(GraphAlgorithmConvergenceError);
+    });
+  });
+
+  // --------------------------------------------------------------
   // validation
   // --------------------------------------------------------------
 
@@ -608,6 +692,9 @@ describe("store.algorithms", () => {
       ).rejects.toBeInstanceOf(ConfigurationError);
       await expect(
         store.algorithms.neighbors(ids.alice, { edges: [] }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(
+        store.algorithms.weaklyConnectedComponents({ edges: [] }),
       ).rejects.toBeInstanceOf(ConfigurationError);
     });
 

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -368,6 +368,47 @@ describe("store.algorithms", () => {
       ).toBe(true);
     });
 
+    it("deduplicates edge targets before node visibility without ranking predecessors", async () => {
+      const statements: string[] = [];
+      const observedBackend: GraphBackend = {
+        ...backend,
+        transaction<T>(
+          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> {
+          return backend.transaction(async (tx, adoptedTransaction) => {
+            const observedTransaction: TransactionBackend = {
+              ...tx,
+              execute<Result>(
+                query: CompiledRowsSql,
+              ): Promise<readonly Result[]> {
+                statements.push(backend.compileSql!(query).sql);
+                return tx.execute<Result>(query);
+              },
+            };
+            return fn(observedTransaction, adoptedTransaction);
+          }, options);
+        },
+      };
+      const observedStore = createStore(testGraph, observedBackend);
+
+      await observedStore.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        maxHops: 3,
+      });
+
+      const expansionStatement = statements.find(
+        (statement) =>
+          statement.includes("SELECT DISTINCT") &&
+          statement.includes("RETURNING node_id"),
+      );
+      expect(expansionStatement).toBeDefined();
+      expect(expansionStatement).not.toContain("ROW_NUMBER");
+      expect(expansionStatement).toMatch(
+        /SELECT DISTINCT[\s\S]+JOIN "typegraph_nodes"/,
+      );
+    });
+
     it("chunks duplicate edge filters within a small bind budget", async () => {
       const constrainedBackend: GraphBackend = {
         ...backend,

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -9,6 +9,7 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { GraphAlgorithmConvergenceError } from "../../../src";
 import { TEMPORAL_ANCHORS } from "../../test-utils";
 import { type IntegrationStore } from "./fixtures";
 import { seedKnowsChain } from "./seed-helpers";
@@ -207,6 +208,87 @@ export function registerAlgorithmIntegrationTests(
       });
     });
 
+    describe("weaklyConnectedComponents", () => {
+      it("returns deterministic memberships, sizes, isolated nodes, and cross-kind identities", async () => {
+        const store = context.getStore();
+        const [alpha, beta, gamma, company, isolated] = await Promise.all([
+          store.nodes.Person.create({ name: "WCC alpha" }, { id: "wcc-A" }),
+          store.nodes.Person.create({ name: "WCC beta" }, { id: "wcc-b" }),
+          store.nodes.Person.create({ name: "WCC gamma" }, { id: "wcc-c" }),
+          store.nodes.Company.create({ name: "WCC company" }, { id: "wcc-b" }),
+          store.nodes.Person.create({ name: "WCC isolated" }, { id: "wcc-z" }),
+        ]);
+        await Promise.all([
+          // Reverse the intuitive order to pin weak/undirected semantics.
+          store.edges.knows.create(beta, alpha, {}),
+          store.edges.knows.create(gamma, beta, {}),
+          store.edges.worksAt.create(gamma, company, { role: "Founder" }),
+        ]);
+
+        const memberships = await store.algorithms.weaklyConnectedComponents({
+          edges: ["knows", "worksAt"],
+        });
+
+        expect(memberships).toEqual([
+          {
+            id: "wcc-A",
+            kind: "Person",
+            componentId: "wcc-A",
+            componentKind: "Person",
+            size: 4,
+          },
+          {
+            id: "wcc-b",
+            kind: "Company",
+            componentId: "wcc-A",
+            componentKind: "Person",
+            size: 4,
+          },
+          {
+            id: "wcc-b",
+            kind: "Person",
+            componentId: "wcc-A",
+            componentKind: "Person",
+            size: 4,
+          },
+          {
+            id: "wcc-c",
+            kind: "Person",
+            componentId: "wcc-A",
+            componentKind: "Person",
+            size: 4,
+          },
+          {
+            id: isolated.id,
+            kind: "Person",
+            componentId: isolated.id,
+            componentKind: "Person",
+            size: 1,
+          },
+        ]);
+      });
+
+      it("throws instead of returning partial labels at the iteration limit", async () => {
+        const store = context.getStore();
+        const [alpha, beta, gamma] = await Promise.all([
+          store.nodes.Person.create({ name: "Limit alpha" }, { id: "limit-a" }),
+          store.nodes.Person.create({ name: "Limit beta" }, { id: "limit-b" }),
+          store.nodes.Person.create({ name: "Limit gamma" }, { id: "limit-c" }),
+        ]);
+        await Promise.all([
+          store.edges.knows.create(alpha, beta, {}),
+          store.edges.knows.create(beta, gamma, {}),
+        ]);
+
+        await expect(
+          store.algorithms.weaklyConnectedComponents({
+            edges: ["knows"],
+            maxIterations: 1,
+          }),
+        ).rejects.toBeInstanceOf(GraphAlgorithmConvergenceError);
+      });
+    });
+
     describe("dense cyclic graph", () => {
       it("visits each node once instead of enumerating simple paths", async () => {
         const store = context.getStore();
@@ -321,6 +403,23 @@ export function registerAlgorithmIntegrationTests(
         expect(reachedIds).toContain(ids.activeId);
         expect(reachedIds).toContain(ids.endedId);
         expect(reachedIds).not.toContain(ids.futureId);
+      });
+
+      it("exposes WCC through the StoreView algorithms facade", async () => {
+        const store = context.getStore();
+        const current = await store.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+        });
+        const historical = await store
+          .asOf(BEFORE)
+          .algorithms.weaklyConnectedComponents({ edges: ["knows"] });
+
+        const currentRoot = current.find((row) => row.id === ids.rootId);
+        const historicalRoot = historical.find((row) => row.id === ids.rootId);
+        expect(currentRoot?.size).toBe(2);
+        expect(historicalRoot?.size).toBe(3);
+        expect(historical.some((row) => row.id === ids.endedId)).toBe(true);
+        expect(historical.some((row) => row.id === ids.futureId)).toBe(false);
       });
 
       it("reachable under includeEnded includes validity-ended nodes and edges", async () => {

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -266,6 +266,57 @@ export function registerAlgorithmIntegrationTests(
             size: 1,
           },
         ]);
+
+        const personMemberships =
+          await store.algorithms.weaklyConnectedComponents({
+            edges: ["knows", "worksAt"],
+            nodeKinds: ["Person"],
+          });
+        expect(personMemberships).toEqual([
+          {
+            id: "wcc-A",
+            kind: "Person",
+            componentId: "wcc-A",
+            componentKind: "Person",
+            size: 3,
+          },
+          {
+            id: "wcc-b",
+            kind: "Person",
+            componentId: "wcc-A",
+            componentKind: "Person",
+            size: 3,
+          },
+          {
+            id: "wcc-c",
+            kind: "Person",
+            componentId: "wcc-A",
+            componentKind: "Person",
+            size: 3,
+          },
+          {
+            id: isolated.id,
+            kind: "Person",
+            componentId: isolated.id,
+            componentKind: "Person",
+            size: 1,
+          },
+        ]);
+      });
+
+      it("returns an empty induced subgraph for an empty node-kind scope", async () => {
+        const store = context.getStore();
+        await store.nodes.Person.create(
+          { name: "Outside empty WCC scope" },
+          { id: "empty-scope" },
+        );
+
+        await expect(
+          store.algorithms.weaklyConnectedComponents({
+            edges: ["knows"],
+            nodeKinds: [],
+          }),
+        ).resolves.toEqual([]);
       });
 
       it("throws instead of returning partial labels at the iteration limit", async () => {

--- a/packages/typegraph/tests/backends/integration/recorded-time.ts
+++ b/packages/typegraph/tests/backends/integration/recorded-time.ts
@@ -1076,6 +1076,13 @@ export function registerRecordedTimeIntegrationTests(
       });
       expect(earlyPath?.depth).toBe(2);
       expect(await early.degree(b.id, { edges: ["knows"] })).toBe(2);
+      const earlyComponents = await early.algorithms.weaklyConnectedComponents({
+        edges: ["knows"],
+      });
+      expect(earlyComponents).toHaveLength(3);
+      expect(earlyComponents.every((membership) => membership.size === 3)).toBe(
+        true,
+      );
 
       const earlySubgraph = await early.subgraph(a.id, {
         edges: ["knows"],

--- a/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
+++ b/packages/typegraph/tests/backends/postgres/neon-http-smoke.test.ts
@@ -76,6 +76,7 @@ describe("@nicia-ai/typegraph/postgres on @neondatabase/serverless (HTTP)", () =
     // `commitSchemaVersion` is the exception — it requires atomicity
     // and refuses with a typed ConfigurationError on this backend.
     expect(backend.capabilities.transactions).toBe(false);
+    expect(backend.capabilities.graphAnalytics?.supported).toBe(false);
     // Other capabilities are unchanged.
     expect(backend.capabilities.windowFunctions).toBe(true);
     expect(backend.capabilities.vector?.supported).toBe(true);

--- a/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
@@ -86,6 +86,10 @@ describe("PGlite backend", () => {
       const { backend } = await createLocalPgliteBackend();
       cleanups.push(() => backend.close());
       expect(backend.capabilities.vector?.supported).toBe(true);
+      expect(backend.capabilities.graphAnalytics).toEqual({
+        supported: true,
+        mathFunctions: true,
+      });
 
       const [store] = await createStoreWithSchema(documentsGraph, backend);
       await store.nodes.Doc.create({ title: "near", embedding: [1, 0, 0, 0] });

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -29,7 +29,14 @@ import {
   createPostgresBackend,
   createPostgresTables,
 } from "../../../src/backend/postgres";
+import type {
+  AdoptedTransaction,
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../../../src/backend/types";
 import { rowPropsToObject } from "../../../src/backend/types";
+import type { CompiledTemporaryStatementSql } from "../../../src/query/sql-intent";
 import { createStore, createStoreWithSchema } from "../../../src/store";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
@@ -294,6 +301,37 @@ const testGraph = defineGraph({
   },
   ontology: [subClassOf(Company, Organization)],
 });
+
+function observeTemporaryAnalyzeStatements(backend: GraphBackend): Readonly<{
+  backend: GraphBackend;
+  statements: string[];
+}> {
+  const statements: string[] = [];
+  return {
+    statements,
+    backend: {
+      ...backend,
+      transaction<T>(
+        fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+        options?: TransactionOptions,
+      ): Promise<T> {
+        return backend.transaction(async (tx, adoptedTransaction) => {
+          const observedTransaction: TransactionBackend = {
+            ...tx,
+            async executeTemporaryStatement(
+              query: CompiledTemporaryStatementSql,
+            ): Promise<void> {
+              const statement = tx.compileSql!(query).sql;
+              if (statement.startsWith("ANALYZE ")) statements.push(statement);
+              await tx.executeTemporaryStatement!(query);
+            },
+          };
+          return fn(observedTransaction, adoptedTransaction);
+        }, options);
+      },
+    },
+  };
+}
 
 // ============================================================
 // Shared Adapter Test Suite
@@ -750,6 +788,66 @@ describe("Store with PostgreSQL Backend", () => {
 
     expect(store.graphId).toBe("test_graph");
     expect(store.registry).toBeDefined();
+  });
+
+  it("analyzes a bulk-seeded iterative working table once", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const observed = observeTemporaryAnalyzeStatements(
+      createPostgresBackend(db),
+    );
+    const store = createStore(testGraph, observed.backend);
+    await store.nodes.Person.bulkCreate(
+      Array.from({ length: 64 }, (_, index) => ({
+        props: { name: `WCC ${index}` },
+      })),
+    );
+
+    const memberships = await store.algorithms.weaklyConnectedComponents({
+      edges: ["knows"],
+    });
+
+    expect(memberships).toHaveLength(64);
+    expect(observed.statements).toHaveLength(1);
+  });
+
+  it("re-analyzes a growing iterative working table at multiplicative thresholds", async (ctx) => {
+    const { db } = requirePostgres(ctx);
+    const observed = observeTemporaryAnalyzeStatements(
+      createPostgresBackend(db),
+    );
+    const store = createStore(testGraph, observed.backend);
+    const root = await store.nodes.Person.create({ name: "Root" });
+    const firstLayer = await store.nodes.Person.bulkCreate(
+      Array.from({ length: 63 }, (_, index) => ({
+        props: { name: `First ${index}` },
+      })),
+    );
+    const secondLayer = await store.nodes.Person.bulkCreate(
+      Array.from({ length: 192 }, (_, index) => ({
+        props: { name: `Second ${index}` },
+      })),
+    );
+    await store.edges.knows.bulkCreate([
+      ...firstLayer.map((node) => ({ from: root, to: node, props: {} })),
+      ...secondLayer.map((node, index) => ({
+        from: firstLayer[index % firstLayer.length]!,
+        to: node,
+        props: {},
+      })),
+    ]);
+
+    const reached = await store.algorithms.reachable(root, {
+      edges: ["knows"],
+      maxHops: 3,
+    });
+
+    expect(reached).toHaveLength(256);
+    expect(observed.statements).toHaveLength(2);
+    expect(
+      observed.statements.every((statement) =>
+        /^ANALYZE "typegraph_iterative_[^"]+"$/.test(statement),
+      ),
+    ).toBe(true);
   });
 
   it("creates and retrieves nodes through the store", async (ctx) => {

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -83,6 +83,10 @@ describe("SQLite Backend - Adapter Specific", () => {
 
       expect(backend.dialect).toBe("sqlite");
       expect(backend.capabilities.transactions).toBe(true);
+      expect(backend.capabilities.graphAnalytics).toEqual({
+        supported: true,
+        mathFunctions: false,
+      });
     });
 
     it("reuses prepared statements in execute() for repeated SQL shapes", async () => {
@@ -475,6 +479,7 @@ describe("SQLite Backend - Transaction Modes", () => {
       executionProfile: { transactionMode: "none" },
     });
     expect(backend.capabilities.transactions).toBe(false);
+    expect(backend.capabilities.graphAnalytics?.supported).toBe(false);
 
     await expect(backend.transaction(() => Promise.resolve())).rejects.toThrow(
       /does not support atomic transactions/,
@@ -526,6 +531,15 @@ describe("SQLite Backend - Transaction Modes", () => {
 // ============================================================
 
 describe("SQLite Backend - close() disposes serialized queue", () => {
+  it("advertises bundled better-sqlite3 math functions", async () => {
+    const { backend } = createLocalSqliteBackend();
+    expect(backend.capabilities.graphAnalytics).toEqual({
+      supported: true,
+      mathFunctions: true,
+    });
+    await backend.close();
+  });
+
   it("throws BackendDisposedError for operations after close()", async () => {
     const { backend } = createLocalSqliteBackend();
     const store = createStore(testGraph, backend);

--- a/packages/typegraph/tests/iterative-graph-operation.test.ts
+++ b/packages/typegraph/tests/iterative-graph-operation.test.ts
@@ -1,0 +1,62 @@
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { postgresDialect } from "../src/query/dialect/postgres";
+import { sqliteDialect } from "../src/query/dialect/sqlite";
+import {
+  shouldRefreshWorkingTableStatistics,
+  WORKING_TABLE_ANALYZE_GROWTH_FACTOR,
+  WORKING_TABLE_ANALYZE_MINIMUM_ROWS,
+} from "../src/store/algorithms/iterative-graph-operation";
+
+describe("iterative graph working-table statistics", () => {
+  it("refreshes after a bulk seed reaches the minimum size", () => {
+    expect(
+      shouldRefreshWorkingTableStatistics(
+        WORKING_TABLE_ANALYZE_MINIMUM_ROWS - 1,
+      ),
+    ).toBe(false);
+    expect(
+      shouldRefreshWorkingTableStatistics(WORKING_TABLE_ANALYZE_MINIMUM_ROWS),
+    ).toBe(true);
+  });
+
+  it("refreshes again only after multiplicative table growth", () => {
+    const analyzedRowCount = WORKING_TABLE_ANALYZE_MINIMUM_ROWS;
+    expect(
+      shouldRefreshWorkingTableStatistics(
+        analyzedRowCount * WORKING_TABLE_ANALYZE_GROWTH_FACTOR - 1,
+        analyzedRowCount,
+      ),
+    ).toBe(false);
+    expect(
+      shouldRefreshWorkingTableStatistics(
+        analyzedRowCount * WORKING_TABLE_ANALYZE_GROWTH_FACTOR,
+        analyzedRowCount,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a stable whole-graph working table on one refresh", () => {
+    const workingTableSize = 181;
+    expect(shouldRefreshWorkingTableStatistics(workingTableSize)).toBe(true);
+    expect(
+      shouldRefreshWorkingTableStatistics(workingTableSize, workingTableSize),
+    ).toBe(false);
+  });
+
+  it("uses a dialect seam so only PostgreSQL emits ANALYZE", () => {
+    const workingTable = sql.identifier("typegraph_iterative_test");
+    const postgresStatement =
+      postgresDialect.analyzeTemporaryTable(workingTable);
+
+    if (postgresStatement === undefined) {
+      throw new Error("PostgreSQL must emit a temporary-table ANALYZE");
+    }
+    expect(new PgDialect().sqlToQuery(postgresStatement).sql).toBe(
+      'ANALYZE "typegraph_iterative_test"',
+    );
+    expect(sqliteDialect.analyzeTemporaryTable(workingTable)).toBeUndefined();
+  });
+});

--- a/packages/typegraph/tests/iterative-graph-operation.test.ts
+++ b/packages/typegraph/tests/iterative-graph-operation.test.ts
@@ -39,7 +39,7 @@ describe("iterative graph working-table statistics", () => {
   });
 
   it("keeps a stable whole-graph working table on one refresh", () => {
-    const workingTableSize = 181;
+    const workingTableSize = 31;
     expect(shouldRefreshWorkingTableStatistics(workingTableSize)).toBe(true);
     expect(
       shouldRefreshWorkingTableStatistics(workingTableSize, workingTableSize),

--- a/packages/typegraph/type-smoke/consumer.ts
+++ b/packages/typegraph/type-smoke/consumer.ts
@@ -152,7 +152,10 @@ void store.algorithms.shortestPath(
 void store.algorithms.reachable(aliceId, { edges: ["knows"] });
 void store.algorithms.canReach(aliceId, bobId, { edges: ["knows"] });
 void store.algorithms.neighbors(aliceId, { edges: ["knows"], depth: 2 });
-void store.algorithms.weaklyConnectedComponents({ edges: ["knows"] });
+void store.algorithms.weaklyConnectedComponents({
+  edges: ["knows"],
+  nodeKinds: ["Person"],
+});
 
 // Degree accepts an options-less call and a specific edge-kind selection.
 void store.algorithms.degree(aliceId);
@@ -189,6 +192,12 @@ void store.algorithms.reachable(aliceId, { edges: ["not_a_kind"] });
 
 // @ts-expect-error - "not_a_kind" isn't a registered WCC edge kind
 void store.algorithms.weaklyConnectedComponents({ edges: ["not_a_kind"] });
+
+void store.algorithms.weaklyConnectedComponents({
+  edges: ["knows"],
+  // @ts-expect-error - "not_a_kind" isn't a registered WCC node kind
+  nodeKinds: ["not_a_kind"],
+});
 
 void store.algorithms.reachable(aliceId, {
   edges: ["knows"],

--- a/packages/typegraph/type-smoke/consumer.ts
+++ b/packages/typegraph/type-smoke/consumer.ts
@@ -152,6 +152,7 @@ void store.algorithms.shortestPath(
 void store.algorithms.reachable(aliceId, { edges: ["knows"] });
 void store.algorithms.canReach(aliceId, bobId, { edges: ["knows"] });
 void store.algorithms.neighbors(aliceId, { edges: ["knows"], depth: 2 });
+void store.algorithms.weaklyConnectedComponents({ edges: ["knows"] });
 
 // Degree accepts an options-less call and a specific edge-kind selection.
 void store.algorithms.degree(aliceId);
@@ -170,6 +171,10 @@ void store.algorithms.shortestPath(aliceId, bobId, {
 void store.algorithms.reachable(aliceId, { edges: ["knows"], ...temporal });
 void store.algorithms.neighbors(aliceId, { edges: ["knows"], ...temporal });
 void store.algorithms.degree(aliceId, { ...temporal });
+void store.algorithms.weaklyConnectedComponents({
+  edges: ["knows"],
+  ...temporal,
+});
 
 // Subgraph also accepts the temporal options (requires a branded NodeId).
 void store.subgraph(aliceNodeId, {
@@ -181,6 +186,9 @@ void store.subgraph(aliceNodeId, {
 
 // @ts-expect-error - "not_a_kind" isn't a registered edge kind
 void store.algorithms.reachable(aliceId, { edges: ["not_a_kind"] });
+
+// @ts-expect-error - "not_a_kind" isn't a registered WCC edge kind
+void store.algorithms.weaklyConnectedComponents({ edges: ["not_a_kind"] });
 
 void store.algorithms.reachable(aliceId, {
   edges: ["knows"],


### PR DESCRIPTION
## Summary

- Add exact `store.algorithms.weaklyConnectedComponents()` for transactional SQLite, PostgreSQL, and PGlite backends.
- Return deterministic `(id, kind)` representatives, component sizes, and singleton components across current, valid-time, and recorded-time views.
- Add `nodeKinds` induced-subgraph scoping so heterogeneous graphs avoid seeding unrelated visible nodes.
- Reuse the D2 iterative-operation substrate with typed capability/convergence failures and cleanup-safe temporary tables.
- Add a reusable PostgreSQL working-table statistics policy: analyze at 16 rows and again after 4× growth; other dialects no-op.
- Optimize predecessor-free `reachable()` rounds by deduplicating edge targets before target-node visibility joins and skipping shortest-path-only predecessor ranking.

## Benchmark validation

Smoke fixture, scoped to the 31-person `knows` graph:

| Engine | Pre-stats fix | Stats fix, all nodes | Scoped WCC + tuned trigger |
| --- | ---: | ---: | ---: |
| pgGraph | 0.8 ms | 1.1 ms | 0.9 ms |
| TypeGraph SQLite | 5.2 ms | 4.9 ms | 4.7 ms |
| TypeGraph PostgreSQL | 1146 ms | 23.2 ms | 18.8 ms (~61× faster) |

The parity gate reports `comparable=yes` for GA_WCC, GA_BFS, and GA_SSSP across SQLite, PostgreSQL, and pgGraph. The first scoped WCC run exposed that the old 64-row ANALYZE trigger missed the 31-person working set (160.7 ms); lowering the generic trigger to 16 restored the hash-join plan (18.8 ms).

A PostgreSQL query-shape control at SF1 dimensions reduced the dominant predecessor-free reachability expansion from 709–772 ms to 194 ms (~3.7×). The next full SF1 lane will measure the end-to-end effect.

## Scale gate

Targeted SF1 PostgreSQL vs pgGraph on the real 9,892-person / ~180k-undirected-edge graph passed before the reachability optimization:

| Query | TypeGraph PostgreSQL | pgGraph | parity |
| --- | ---: | ---: | :---: |
| GA_BFS | 2867 ms | 129 ms | `comparable=yes` |
| GA_SSSP | 2969 ms | 130 ms | `comparable=yes` |

This confirms the growth-triggered ANALYZE path avoids the stale-statistics planner cliff at scale and preserves byte-identical results.

## Verification

- `pnpm fix`
- `pnpm typecheck`
- `pnpm test` — 249 files passed, 6 skipped; 5,018 tests passed, 1,040 skipped
- Live PostgreSQL graph-algorithm suites — 48 passed across both PostgreSQL drivers
- `pnpm test:unused`
- Smoke benchmark parity — GA_WCC, GA_BFS, GA_SSSP all `comparable=yes`
- Full PostgreSQL CI is running on the pushed head

## Plan completion

The scoped WCC slice of `docs/design/sql-community-detection.md` is complete, including reusable D2 statistics maintenance, induced-subgraph scoping, deterministic cross-backend semantics, and benchmark parity against pgGraph.

## Follow-up

- Run the full SF1 comparison across all five engines and all 16 queries on EC2, now including the optimized reachability path and scoped WCC.

Closes #272.