### PR TITLE
perf(query): index nodes by (graph_id, id) for bare-id lookups (#280)

### DIFF
--- a/.changeset/bare-id-node-index.md
+++ b/.changeset/bare-id-node-index.md
@@ -1,0 +1,17 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Add a `(graph_id, id)` index to the live and recorded node tables so bare-id
+lookups (a node's `id` without its `kind`) seek instead of scanning the
+graph's node partition — the composite keys lead with `kind`, so they can't
+serve that probe. `store.algorithms.degree()`'s node-kind subquery is the
+main consumer: ~95 ms → sub-millisecond at LDBC SNB SF1 (3.16M nodes) on
+SQLite, at the live and recorded coordinates alike.
+
+New databases get both indexes at bootstrap. Existing databases adopt them
+with a one-time `await backend.bootstrapTables()` — every statement is
+`CREATE … IF NOT EXISTS`, so the call is idempotent and only creates what's
+missing. On PostgreSQL this issues a plain `CREATE INDEX` (briefly locks
+writes on large tables); schedule it, or apply the equivalent
+`CREATE INDEX CONCURRENTLY` statements manually.

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -125,6 +125,11 @@ export function createPostgresTables(
       ),
       index(`${n.nodes}_deleted_idx`).on(t.graphId, t.deletedAt),
       index(`${n.nodes}_valid_idx`).on(t.graphId, t.validFrom, t.validTo),
+      // Bare-id lookup: the primary key leads with `kind` (graph_id, kind, id),
+      // so a `WHERE graph_id = ? AND id = ?` probe that doesn't know the kind
+      // can't seek it. `store.algorithms.degree`'s node-kind subquery resolves a
+      // seed's kind by id, so it depends on this access path. See typegraph#280.
+      index(`${n.nodes}_id_idx`).on(t.graphId, t.id),
       ...buildPostgresNodeIndexBuilders(t, indexes),
     ],
   );

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -242,6 +242,12 @@ export function createPostgresTables(
         t.validFrom,
         t.validTo,
       ),
+      // Bare-id lookup parity with the live nodes table: recorded-pinned
+      // reads swap this relation in as the node source, and `_entity_idx`
+      // leads with `kind`, so the same kind-by-bare-id probe (e.g.
+      // `degree()` at a recorded coordinate) would otherwise scan every
+      // historical version in the graph. See typegraph#280.
+      index(`${n.recordedNodes}_id_idx`).on(t.graphId, t.id),
     ],
   );
 

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -123,6 +123,14 @@ export function createSqliteTables(
       ),
       index(`${n.nodes}_deleted_idx`).on(t.graphId, t.deletedAt),
       index(`${n.nodes}_valid_idx`).on(t.graphId, t.validFrom, t.validTo),
+      // Bare-id lookup: the primary key leads with `kind` (graph_id, kind, id),
+      // so a `WHERE graph_id = ? AND id = ?` probe that doesn't know the kind
+      // can't seek it — SQLite falls back to a graph_id-only scan of every node
+      // in the graph (~3M at LDBC SF1). `store.algorithms.degree`'s
+      // node-kind subquery does exactly that lookup (it resolves the seed's
+      // kind by id), so without this index degree is a full nodes scan (~95ms
+      // at SF1). See typegraph#280.
+      index(`${n.nodes}_id_idx`).on(t.graphId, t.id),
       ...buildSqliteNodeIndexBuilders(t, indexes),
     ],
   );

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -243,6 +243,12 @@ export function createSqliteTables(
         t.validFrom,
         t.validTo,
       ),
+      // Bare-id lookup parity with the live nodes table: recorded-pinned
+      // reads swap this relation in as the node source, and `_entity_idx`
+      // leads with `kind`, so the same kind-by-bare-id probe (e.g.
+      // `degree()` at a recorded coordinate) would otherwise scan every
+      // historical version in the graph. See typegraph#280.
+      index(`${n.recordedNodes}_id_idx`).on(t.graphId, t.id),
     ],
   );
 

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -429,6 +429,9 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
       expect(sql).toContain(
         '"typegraph_nodes_id_idx" ON "typegraph_nodes" ("graph_id", "id")',
       );
+      expect(sql).toContain(
+        '"typegraph_recorded_nodes_id_idx" ON "typegraph_recorded_nodes" ("graph_id", "id")',
+      );
       expect(sql).toContain('"typegraph_edges_from_idx"');
       expect(sql).toContain('"typegraph_edges_to_idx"');
       expect(sql).toContain('"typegraph_edges_kind_created_idx"');
@@ -493,6 +496,33 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
 
       const fetched = await backend.getNode("test_graph", "Person", "person-1");
       expect(fetched).toBeDefined();
+    });
+  });
+
+  describe("bootstrapTables() index adoption", () => {
+    it("adds newly shipped indexes to an already-initialized database", async (ctx) => {
+      const { db, pool } = requirePostgres(ctx);
+      const backend = createPostgresBackend(db);
+      await backend.bootstrapTables!();
+
+      // Simulate a database initialized before the bare-id indexes shipped.
+      // Bootstrap never re-runs automatically on an initialized database
+      // (createStore is zero-DDL), so a one-time explicit
+      // `backend.bootstrapTables()` is the documented adoption path — every
+      // statement is CREATE … IF NOT EXISTS.
+      await pool.query('DROP INDEX IF EXISTS "typegraph_nodes_id_idx"');
+      await pool.query(
+        'DROP INDEX IF EXISTS "typegraph_recorded_nodes_id_idx"',
+      );
+
+      await backend.bootstrapTables!();
+
+      const adopted = await pool.query<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND tablename IN ('typegraph_nodes', 'typegraph_recorded_nodes')`,
+      );
+      const names = adopted.rows.map((row) => row.indexname);
+      expect(names).toContain("typegraph_nodes_id_idx");
+      expect(names).toContain("typegraph_recorded_nodes_id_idx");
     });
   });
 

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -425,6 +425,10 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
 
       expect(sql).toContain('"typegraph_nodes_kind_idx"');
       expect(sql).toContain('"typegraph_nodes_kind_created_idx"');
+      // Bare-id node lookup (kind resolved by id) — see typegraph#280.
+      expect(sql).toContain(
+        '"typegraph_nodes_id_idx" ON "typegraph_nodes" ("graph_id", "id")',
+      );
       expect(sql).toContain('"typegraph_edges_from_idx"');
       expect(sql).toContain('"typegraph_edges_to_idx"');
       expect(sql).toContain('"typegraph_edges_kind_created_idx"');

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -155,6 +155,8 @@ describe("SQLite Backend - Adapter Specific", () => {
       expect(sql).toContain("CREATE INDEX IF NOT EXISTS");
       expect(sql).toContain("typegraph_nodes_kind_idx");
       expect(sql).toContain("typegraph_nodes_kind_created_idx");
+      // Bare-id node lookup (kind resolved by id) — see typegraph#280.
+      expect(sql).toContain('"typegraph_nodes" ("graph_id", "id")');
       expect(sql).toContain("typegraph_edges_from_idx");
       expect(sql).toContain("typegraph_edges_to_idx");
       expect(sql).toContain("typegraph_edges_kind_created_idx");

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -133,6 +133,41 @@ describe("SQLite Backend - Adapter Specific", () => {
     });
   });
 
+  describe("bootstrapTables() index adoption", () => {
+    it("adds newly shipped indexes to an already-initialized database", async () => {
+      const { backend, db } = createLocalSqliteBackend();
+      try {
+        await backend.bootstrapTables!();
+
+        // Simulate a database initialized before the bare-id indexes
+        // shipped. Bootstrap never re-runs automatically on an initialized
+        // database (createStore is zero-DDL), so a one-time explicit
+        // `backend.bootstrapTables()` is the documented adoption path —
+        // every statement is CREATE … IF NOT EXISTS.
+        db.run(sql`DROP INDEX "typegraph_nodes_id_idx"`);
+        db.run(sql`DROP INDEX "typegraph_recorded_nodes_id_idx"`);
+
+        async function indexNames(): Promise<readonly string[]> {
+          const rows = await backend.execute<{ name: string }>(
+            asCompiledRowsSql(
+              sql`SELECT name FROM sqlite_master WHERE type = 'index'`,
+            ),
+          );
+          return rows.map((row) => row.name);
+        }
+        expect(await indexNames()).not.toContain("typegraph_nodes_id_idx");
+
+        await backend.bootstrapTables!();
+
+        const adopted = await indexNames();
+        expect(adopted).toContain("typegraph_nodes_id_idx");
+        expect(adopted).toContain("typegraph_recorded_nodes_id_idx");
+      } finally {
+        await backend.close();
+      }
+    });
+  });
+
   describe("generateSqliteDDL()", () => {
     it("generates DDL that creates all required tables", () => {
       const ddl = generateSqliteDDL(tables);
@@ -157,6 +192,7 @@ describe("SQLite Backend - Adapter Specific", () => {
       expect(sql).toContain("typegraph_nodes_kind_created_idx");
       // Bare-id node lookup (kind resolved by id) — see typegraph#280.
       expect(sql).toContain('"typegraph_nodes" ("graph_id", "id")');
+      expect(sql).toContain('"typegraph_recorded_nodes" ("graph_id", "id")');
       expect(sql).toContain("typegraph_edges_from_idx");
       expect(sql).toContain("typegraph_edges_to_idx");
       expect(sql).toContain("typegraph_edges_kind_created_idx");

--- a/packages/typegraph/tests/degree-index-alignment.test.ts
+++ b/packages/typegraph/tests/degree-index-alignment.test.ts
@@ -66,6 +66,7 @@ async function withCapturingStore<T>(
     captured: CapturedStatement[],
     client: Database.Database,
   ) => Promise<T>,
+  options?: Readonly<{ history?: boolean }>,
 ): Promise<T> {
   const { backend: raw, db } = createLocalSqliteBackend();
   try {
@@ -87,7 +88,7 @@ async function withCapturingStore<T>(
         return raw.executeRaw!<T>(sqlText, params);
       },
     };
-    const store = createStore(buildGraph(), backend);
+    const store = createStore(buildGraph(), backend, options);
     const client = (db as unknown as { $client: Database.Database }).$client;
     return await run(store, captured, client);
   } finally {
@@ -132,6 +133,10 @@ describe("degree() direction filter index alignment", () => {
       const outPlan = explainPlan(client, captured.at(-1)!);
       expect(outPlan).toContain("typegraph_edges_from_idx");
       expect(outPlan).not.toContain("SCAN typegraph_edges");
+      // The node-kind subquery resolves the seed's kind by bare id; without
+      // the (graph_id, id) node index it scans the graph's node partition.
+      expect(outPlan).toContain("typegraph_nodes_id_idx");
+      expect(outPlan).not.toContain("SCAN typegraph_nodes");
 
       captured.length = 0;
       await store.algorithms.degree(bob.id, { direction: "in" });
@@ -144,6 +149,45 @@ describe("degree() direction filter index alignment", () => {
       const bothPlan = explainPlan(client, captured.at(-1)!);
       expect(bothPlan).not.toContain("SCAN typegraph_edges");
     });
+  });
+
+  it("seeks the recorded bare-id node index at a recorded coordinate", async () => {
+    await withCapturingStore(
+      async (store, captured, client) => {
+        const people = await store.nodes.Person.bulkCreate(
+          Array.from({ length: 40 }, (_, index) => ({
+            props: { name: `p${index}` },
+          })),
+        );
+        for (const [index, person] of people.entries()) {
+          for (let step = 1; step <= 3; step++) {
+            await store.edges.knows.create(
+              person,
+              people[(index + step) % people.length]!,
+            );
+          }
+        }
+        await store.refreshStatistics();
+        const pin = await store.recordedNow();
+        if (pin === undefined) {
+          throw new Error("recorded clock was not written");
+        }
+        const alice = people[0]!;
+
+        // A recorded pin swaps the node source to the recorded relation,
+        // whose entity index leads with `kind` — the kind-by-bare-id probe
+        // needs the recorded (graph_id, id) index to seek.
+        captured.length = 0;
+        const outDegree = await store
+          .asOfRecorded(pin)
+          .degree(alice.id, { direction: "out" });
+        expect(outDegree).toBe(3);
+        const plan = explainPlan(client, captured.at(-1)!);
+        expect(plan).toContain("typegraph_recorded_nodes_id_idx");
+        expect(plan).not.toContain("SCAN typegraph_recorded_nodes");
+      },
+      { history: true },
+    );
   });
 
   it("counts edges whose endpoint kind is a subclass of the declared kind", async () => {


### PR DESCRIPTION
Closes #280.

## Problem

The nodes primary key is `(graph_id, kind, id)`. A lookup that knows a node's `id` but **not** its `kind` cannot seek that key. `store.algorithms.degree`'s node-kind subquery (`SELECT kind FROM typegraph_nodes WHERE graph_id = ? AND id = ? LIMIT 1`) does exactly that, so SQLite falls back to a `graph_id`-only scan of every node in the graph — ~3.16M nodes at LDBC SNB SF1 — making `degree()` ~95 ms per call.

The same probe exists at a **recorded coordinate**: `store.asOfRecorded(rt).degree(...)` swaps the node source to `typegraph_recorded_nodes`, whose entity index also leads with `kind` — and the recorded partition is strictly larger (one row per historical version), so the scan is worse there.

## Fix

Add a `(graph_id, id)` index to **both node relations** in **both dialect schemas**:

- `typegraph_nodes_id_idx` on the live nodes table
- `typegraph_recorded_nodes_id_idx` on the recorded nodes table (parity for recorded-pinned reads)

## Verification (real SF1, 3.16M nodes)

| | before | after |
| --- | --: | --: |
| bare-id lookup plan | scan of 3.16M nodes (`graph_id=?` only) | `SEARCH … USING INDEX typegraph_nodes_id_idx (graph_id=? AND id=?)` |
| `store.algorithms.degree` | ~95 ms | **0.06–0.49 ms** (~200–1500×) |

Validated at SF1 in the full suite re-run: GA_DEGREE 102 ms → **0.05 ms** on tg-sqlite. PostgreSQL already coped via its planner (~0.2 ms) but is indexed too, so the bare-id access path is explicit rather than planner-luck-dependent — and the PG EXPLAIN for IC9 confirmed `typegraph_nodes_id_idx` is used for the bare-id join there as well.

## Existing databases (upgrade path)

This index does **not** reach an already-initialized database automatically: `bootstrapTables()` only runs on first boot (missing-table), and `createStore`/`createVerifiedStore` are zero-DDL by contract. To adopt the indexes on an existing deployment, run once:

```ts
await backend.bootstrapTables();
```

Every bootstrap statement is `CREATE … IF NOT EXISTS`, so the call is idempotent and only the two new indexes are created. Caveats: on PostgreSQL this issues a plain `CREATE INDEX` (briefly locks writes on large tables — run in a maintenance window, or apply the equivalent `CREATE INDEX CONCURRENTLY` statements manually), and it should not be raced from many replicas simultaneously (concurrent multi-table DDL can deadlock on Postgres SHARE locks). A declarative system-index materialization path (riding the existing `typegraph_index_materializations` machinery) is planned as a follow-up so future base-index additions roll out without this manual step.

## Tests

- DDL-presence assertions for both new indexes in both backend suites.
- **Query-plan assertions** (`EXPLAIN QUERY PLAN`): `degree()` now must seek `typegraph_nodes_id_idx` (no `SCAN typegraph_nodes`) at the live coordinate, and `typegraph_recorded_nodes_id_idx` (no `SCAN typegraph_recorded_nodes`) at a recorded pin, in `tests/degree-index-alignment.test.ts`.
- **Upgrade-path tests** (SQLite + PostgreSQL): start from the pre-PR physical schema (indexes dropped), run `backend.bootstrapTables()` once, assert both indexes exist.
- Full SQLite suite green; PostgreSQL lane green. `pnpm fix` + `pnpm typecheck` clean.
