### PR TITLE
perf(query): late materialization for ORDER BY … LIMIT queries (#281)

### DIFF
--- a/.changeset/late-materialization-order-by-limit.md
+++ b/.changeset/late-materialization-order-by-limit.md
@@ -1,0 +1,16 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Selective `ORDER BY … LIMIT` queries now compile with late materialization:
+the query sorts and limits a lean candidate set carrying only identity, sort
+keys, and predicate columns, then re-fetches the deferred projection columns
+by primary key for only the surviving rows — instead of extracting every
+projected column for every candidate and discarding all but the `LIMIT`
+survivors after the sort. At LDBC SNB SF1, IC9's top-20 over a 1.18M-comment
+fan-out stops extracting `content` 1.18M times, ~30–37% faster on SQLite.
+
+The transform fires only on the selective `.select()` path with `ORDER BY`
+and a positive `LIMIT` at the live coordinate. Aggregates, vector/fulltext,
+optional (LEFT JOIN) traversals, edge-field projections, non-selective
+queries, and recorded-time reads keep the flat plan unchanged.

--- a/packages/typegraph/src/query/compiler/emitter/index.ts
+++ b/packages/typegraph/src/query/compiler/emitter/index.ts
@@ -18,6 +18,9 @@ export {
   type StandardQueryEmitterInput,
 } from "./standard";
 export {
+  buildLateMaterializedOuterOrderBy,
+  buildLateMaterializedOuterProjection,
+  buildLateMaterializedTopKCte,
   buildLimitOffsetClause,
   buildStandardEmbeddingsCte,
   buildStandardFromClause,
@@ -32,5 +35,8 @@ export {
   buildStandardStartCte,
   buildStandardTraversalCte,
   buildStandardVectorOrderBy,
+  LATE_MAT_TOPK_CTE_ALIAS,
+  lateMaterializedPhysicalAlias,
+  lateMaterializedProjectedNodeAliases,
   type StandardEmitterPredicateIndex,
 } from "./standard-builders";

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -810,6 +810,171 @@ export function buildStandardOrderBy(
   return sql`ORDER BY ${sql.join(parts, sql`, `)}`;
 }
 
+// ============================================================
+// Late materialization (deferred projection)
+// ============================================================
+//
+// For an ORDER BY … LIMIT query whose projection reads columns beyond the
+// ordering/identity keys, the flat plan carries every projected column (e.g. a
+// large `content` prop) through the sorter for every candidate row and then
+// discards all but the LIMIT survivors. Late materialization sorts+limits a
+// *lean* candidate set (identity + sort keys only), then re-joins the physical
+// node table by `(graph_id, kind, id)` to fetch the deferred columns for only
+// the surviving rows. See the standard emitter's late-materialization branch
+// for the eligibility gate; these builders assume it already held.
+
+export const LATE_MAT_TOPK_CTE_ALIAS = "cte_lm_topk";
+const LATE_MAT_SORT_KEY_PREFIX = "__lm_sk";
+const LATE_MAT_PHYSICAL_ALIAS_PREFIX = "lm_";
+
+export function lateMaterializedPhysicalAlias(alias: string): string {
+  return `${LATE_MAT_PHYSICAL_ALIAS_PREFIX}${alias}`;
+}
+
+/** Node aliases in the query: the start alias plus each traversal's node. */
+export function lateMaterializedNodeAliases(ast: QueryAst): readonly string[] {
+  return [
+    ast.start.alias,
+    ...ast.traversals.map((traversal) => traversal.nodeAlias),
+  ];
+}
+
+/**
+ * Node aliases the projection actually reads — the physical tables the outer
+ * SELECT must re-join. Edge aliases are gated out upstream, so every projected
+ * alias resolves to a node table here.
+ */
+export function lateMaterializedProjectedNodeAliases(
+  ast: QueryAst,
+): readonly string[] {
+  const referenced = new Set<string>();
+  for (const field of ast.selectiveFields ?? []) {
+    referenced.add(field.alias);
+  }
+  return lateMaterializedNodeAliases(ast).filter((alias) =>
+    referenced.has(alias),
+  );
+}
+
+type BuildLateMaterializedTopKCteInput = Readonly<{
+  ast: QueryAst;
+  collapsedTraversalCteAlias?: string;
+  dialect: DialectAdapter;
+  fromClause: SQL;
+  limit: number;
+  offset?: number | undefined;
+}>;
+
+/**
+ * The topK CTE: selects each node alias's identity `(id, kind)` plus each sort
+ * key value (aliased `__lm_sk{n}` so the outer SELECT can re-order the survivors
+ * without re-extracting), ordered and limited on the lean candidate set.
+ *
+ * When the traversal rowset is collapsed onto a single CTE, every alias's
+ * identity is carried into that one CTE (keyed by alias prefix), so all columns
+ * resolve against `collapsedTraversalCteAlias` and the FROM references it alone.
+ */
+export function buildLateMaterializedTopKCte(
+  input: BuildLateMaterializedTopKCteInput,
+): SQL {
+  const { ast, collapsedTraversalCteAlias, dialect, fromClause } = input;
+  const aliasToCte = buildAliasToCteMap(ast);
+  const cteAliasFor = (alias: string): string =>
+    collapsedTraversalCteAlias ??
+    aliasToCte.get(alias) ??
+    `${ALIAS_CTE_PREFIX}${alias}`;
+
+  const columns: SQL[] = [];
+  for (const alias of lateMaterializedNodeAliases(ast)) {
+    const cteAlias = cteAliasFor(alias);
+    columns.push(
+      sql`${qualifyColumn(cteAlias, `${alias}_id`)} AS ${sql.raw(`${alias}_id`)}`,
+      sql`${qualifyColumn(cteAlias, `${alias}_kind`)} AS ${sql.raw(`${alias}_kind`)}`,
+    );
+  }
+  for (const [index, orderSpec] of (ast.orderBy ?? []).entries()) {
+    const value = compileOrderFieldValue(
+      ast,
+      orderSpec.field,
+      dialect,
+      cteAliasFor(orderSpec.field.alias),
+    );
+    columns.push(
+      sql`${value} AS ${sql.raw(`${LATE_MAT_SORT_KEY_PREFIX}${index}`)}`,
+    );
+  }
+
+  const innerOrderBy = buildStandardOrderBy({
+    ast,
+    dialect,
+    ...(collapsedTraversalCteAlias === undefined ?
+      {}
+    : { collapsedTraversalCteAlias }),
+  });
+  const limitOffset = buildLimitOffsetClause({
+    limit: input.limit,
+    offset: input.offset,
+  });
+
+  const parts: SQL[] = [sql`SELECT ${sql.join(columns, sql`, `)}`, fromClause];
+  if (innerOrderBy !== undefined) parts.push(innerOrderBy);
+  if (limitOffset !== undefined) parts.push(limitOffset);
+
+  return sql`${sql.raw(LATE_MAT_TOPK_CTE_ALIAS)} AS (${sql.join(parts, sql` `)})`;
+}
+
+/**
+ * The outer projection: each selective field sourced from the re-joined
+ * physical node table alias `lm_<alias>` rather than a candidate CTE, so the
+ * deferred columns are read only for the surviving rows.
+ */
+export function buildLateMaterializedOuterProjection(
+  ast: QueryAst,
+  dialect: DialectAdapter,
+): SQL {
+  const columns = (ast.selectiveFields ?? []).map((field) => {
+    const physicalAlias = lateMaterializedPhysicalAlias(field.alias);
+    if (field.isSystemField) {
+      const dbColumn = mapSelectiveSystemFieldToColumn(field.field);
+      return sql`${compileColumnReference(physicalAlias, dbColumn)} AS ${quoteIdentifier(field.outputName)}`;
+    }
+    const extracted = compileSelectivePropsExtraction(
+      field,
+      compileColumnReference(physicalAlias, "props"),
+      dialect,
+    );
+    return sql`${extracted} AS ${quoteIdentifier(field.outputName)}`;
+  });
+  return sql.join(columns, sql`, `);
+}
+
+/**
+ * The outer ORDER BY: re-orders the LIMIT survivors by the `__lm_sk{n}` sort
+ * values carried out of the topK CTE, matching `buildStandardOrderBy`'s
+ * null-ordering semantics. Referencing the CTE's real columns (not bare output
+ * aliases) keeps the `(x IS NULL)` null-placement trick valid on both dialects.
+ */
+export function buildLateMaterializedOuterOrderBy(
+  ast: QueryAst,
+): SQL | undefined {
+  const orderBy = ast.orderBy ?? [];
+  if (orderBy.length === 0) return undefined;
+  const topk = sql.raw(LATE_MAT_TOPK_CTE_ALIAS);
+  const parts: SQL[] = [];
+  for (const [index, orderSpec] of orderBy.entries()) {
+    const column = sql`${topk}.${sql.raw(`${LATE_MAT_SORT_KEY_PREFIX}${index}`)}`;
+    const direction = sql.raw(orderSpec.direction.toUpperCase());
+    const nulls =
+      orderSpec.nulls ?? (orderSpec.direction === "asc" ? "last" : "first");
+    const nullsDirection = sql.raw(nulls === "first" ? "DESC" : "ASC");
+    parts.push(
+      sql`(${column} IS NULL) ${nullsDirection}`,
+      sql`${column} ${direction}`,
+    );
+  }
+  return sql`ORDER BY ${sql.join(parts, sql`, `)}`;
+}
+
 function fieldRefKey(field: FieldRef): string {
   const pointer = field.jsonPointer ?? "";
   return `${field.alias}:${field.path.join(".")}:${pointer}`;

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -832,7 +832,7 @@ export function lateMaterializedPhysicalAlias(alias: string): string {
 }
 
 /** Node aliases in the query: the start alias plus each traversal's node. */
-export function lateMaterializedNodeAliases(ast: QueryAst): readonly string[] {
+function lateMaterializedNodeAliases(ast: QueryAst): readonly string[] {
   return [
     ast.start.alias,
     ...ast.traversals.map((traversal) => traversal.nodeAlias),

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -873,6 +873,66 @@ function stripLimitOffsetFromPlanNode(node: LogicalPlanNode): LogicalPlanNode {
   return node;
 }
 
+/**
+ * The start CTE followed by one CTE per traversal — the candidate-set prefix
+ * shared by the flat plan and the late-materialization plan (which feeds it a
+ * lean AST/column set and no per-traversal limit).
+ */
+function buildStandardStartAndTraversalCtes(
+  input: Readonly<{
+    ast: QueryAst;
+    carryForwardPreviousColumns: boolean;
+    ctx: PredicateCompilerContext;
+    graphId: string;
+    predicateIndex: PredicateIndex;
+    requiredColumnsByAlias: RequiredColumnsByAlias | undefined;
+    temporalFilterPass: TemporalFilterPass;
+    traversalLimit: number | undefined;
+  }>,
+): SQL[] {
+  const {
+    ast,
+    carryForwardPreviousColumns,
+    ctx,
+    graphId,
+    predicateIndex,
+    requiredColumnsByAlias,
+    temporalFilterPass,
+    traversalLimit,
+  } = input;
+  const ctes: SQL[] = [
+    buildStandardStartCte({
+      ast,
+      ctx,
+      graphId,
+      predicateIndex,
+      requiredColumnsByAlias,
+      temporalFilterPass,
+    }),
+  ];
+  for (let index = 0; index < ast.traversals.length; index++) {
+    ctes.push(
+      buildStandardTraversalCte({
+        ast,
+        carryForwardPreviousColumns,
+        ctx,
+        graphId,
+        materializeCte: shouldMaterializeTraversalCte(
+          ctx.dialect,
+          ast.traversals.length,
+          index,
+        ),
+        predicateIndex,
+        requiredColumnsByAlias,
+        temporalFilterPass,
+        traversalIndex: index,
+        traversalLimit,
+      }),
+    );
+  }
+  return ctes;
+}
+
 type LateMaterializationPlan = Readonly<{
   leanAst: QueryAst;
   limit: number;
@@ -900,6 +960,15 @@ function selectiveFieldIsIdentity(field: SelectiveField): boolean {
 function resolveLateMaterializationPlan(
   ast: QueryAst,
 ): LateMaterializationPlan | undefined {
+  // Recorded-time reads swap `ctx.schema.nodesTable` to the recorded history
+  // relation (see `recordedReadSchemaFor`), where `(graph_id, kind, id)` is
+  // NOT unique — one row per recorded interval. The outer re-fetch joins on
+  // exactly that key with no temporal predicate, so it would match every
+  // historical version of each survivor (duplicate rows, stale props).
+  if (ast.recordedAsOf !== undefined) {
+    return undefined;
+  }
+
   // v1 targets the selective `.select()` path. The non-selective path would
   // have to carry the full `props` blob into the lean CTE to order by a prop,
   // which defeats the deferral — left to a follow-up.
@@ -986,9 +1055,11 @@ function resolveLateMaterializationPlan(
 
 /**
  * The outer FROM clause: the topK CTE joined to the physical node table for each
- * projected alias, keyed on `(graph_id, kind, id)`. The topK already validated
- * temporal/soft-delete visibility, so this is a pure PK re-fetch of the deferred
- * columns for the surviving rows.
+ * projected alias, keyed on `(graph_id, kind, id)`. Sound only because that key
+ * is the live nodes PK (one row per identity, the exact row the topK already
+ * validated for temporal/soft-delete visibility). Recorded-time reads are gated
+ * out in `resolveLateMaterializationPlan` — under a recorded pin `nodesTable`
+ * is the history relation where this key matches every version.
  */
 function buildLateMaterializedOuterFromClause(
   ast: QueryAst,
@@ -1026,36 +1097,16 @@ function compileLateMaterializedQuery(
     includeProjection: false,
   });
 
-  const ctes: SQL[] = [
-    buildStandardStartCte({
-      ast: leanAst,
-      ctx,
-      graphId,
-      predicateIndex,
-      requiredColumnsByAlias: leanRequiredColumns,
-      temporalFilterPass,
-    }),
-  ];
-  for (let index = 0; index < leanAst.traversals.length; index++) {
-    ctes.push(
-      buildStandardTraversalCte({
-        ast: leanAst,
-        carryForwardPreviousColumns: shouldCollapseSelectiveTraversalRowset,
-        ctx,
-        graphId,
-        materializeCte: shouldMaterializeTraversalCte(
-          dialect,
-          leanAst.traversals.length,
-          index,
-        ),
-        predicateIndex,
-        requiredColumnsByAlias: leanRequiredColumns,
-        temporalFilterPass,
-        traversalIndex: index,
-        traversalLimit: undefined,
-      }),
-    );
-  }
+  const ctes = buildStandardStartAndTraversalCtes({
+    ast: leanAst,
+    carryForwardPreviousColumns: shouldCollapseSelectiveTraversalRowset,
+    ctx,
+    graphId,
+    predicateIndex,
+    requiredColumnsByAlias: leanRequiredColumns,
+    temporalFilterPass,
+    traversalLimit: undefined,
+  });
   ctes.push(
     buildLateMaterializedTopKCte({
       ast: leanAst,
@@ -1248,40 +1299,17 @@ function compileStandardQueryWithCteStrategy(
     }
   }
 
-  // Build CTEs
-  const ctes: SQL[] = [
-    buildStandardStartCte({
-      ast,
-      ctx,
-      graphId,
-      predicateIndex,
-      requiredColumnsByAlias,
-      temporalFilterPass,
-    }),
-  ];
-
-  // Traversal CTEs
-  for (let index = 0; index < ast.traversals.length; index++) {
-    const materializeTraversalCte = shouldMaterializeTraversalCte(
-      dialect,
-      ast.traversals.length,
-      index,
-    );
-    ctes.push(
-      buildStandardTraversalCte({
-        ast,
-        carryForwardPreviousColumns: shouldCollapseSelectiveTraversalRowset,
-        ctx,
-        graphId,
-        materializeCte: materializeTraversalCte,
-        predicateIndex,
-        requiredColumnsByAlias,
-        temporalFilterPass,
-        traversalIndex: index,
-        traversalLimit: traversalCteLimit,
-      }),
-    );
-  }
+  // Start + traversal candidate CTEs
+  const ctes = buildStandardStartAndTraversalCtes({
+    ast,
+    carryForwardPreviousColumns: shouldCollapseSelectiveTraversalRowset,
+    ctx,
+    graphId,
+    predicateIndex,
+    requiredColumnsByAlias,
+    temporalFilterPass,
+    traversalLimit: traversalCteLimit,
+  });
 
   // Add embeddings CTE if vector similarity is used
   if (vectorPredicate) {

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -55,6 +55,7 @@ import {
   type FulltextMatchPredicate,
   type HybridFusionOptions,
   type QueryAst,
+  type SelectiveField,
   type SetOperation,
   type VectorSimilarityPredicate,
 } from "../ast";
@@ -74,6 +75,9 @@ import {
 } from "../sql-intent";
 import { emitStandardQuerySql } from "./emitter";
 import {
+  buildLateMaterializedOuterOrderBy,
+  buildLateMaterializedOuterProjection,
+  buildLateMaterializedTopKCte,
   buildLimitOffsetClause,
   buildStandardEmbeddingsCte,
   buildStandardFromClause,
@@ -88,6 +92,9 @@ import {
   buildStandardStartCte,
   buildStandardTraversalCte,
   buildStandardVectorOrderBy,
+  LATE_MAT_TOPK_CTE_ALIAS,
+  lateMaterializedPhysicalAlias,
+  lateMaterializedProjectedNodeAliases,
 } from "./emitter";
 import { type TemporalFilterPass } from "./passes";
 import { type LogicalPlan, type LogicalPlanNode } from "./plan";
@@ -114,12 +121,15 @@ import {
 } from "./schema";
 import { compileSetOperation as compileSetOp } from "./set-operations";
 import {
+  collectRequiredColumnsByAlias,
   runStandardQueryPassPipeline,
   shouldMaterializeTraversalCte,
 } from "./standard-pass-pipeline";
 import {
+  findSelectivePropsFieldForFieldRef,
   isAggregateExpr,
   isIdFieldRef,
+  mapSelectiveSystemFieldToColumn,
   quoteIdentifier,
   type RequiredColumnsByAlias,
 } from "./utils";
@@ -863,6 +873,217 @@ function stripLimitOffsetFromPlanNode(node: LogicalPlanNode): LogicalPlanNode {
   return node;
 }
 
+type LateMaterializationPlan = Readonly<{
+  leanAst: QueryAst;
+  limit: number;
+  offset: number | undefined;
+}>;
+
+/**
+ * A selective field that resolves to a node's identity (`id`/`kind`) — already
+ * carried in the topK CTE, so it needs no deferred re-fetch.
+ */
+function selectiveFieldIsIdentity(field: SelectiveField): boolean {
+  if (!field.isSystemField) {
+    return false;
+  }
+  const column = mapSelectiveSystemFieldToColumn(field.field);
+  return column === "id" || column === "kind";
+}
+
+/**
+ * Decides whether a query is eligible for late materialization and, if so,
+ * produces the lean AST whose CTEs carry only identity, ordering, and predicate
+ * columns. Returns undefined (fall back to the flat plan) for anything outside
+ * the v1 envelope — see the inline gates.
+ */
+function resolveLateMaterializationPlan(
+  ast: QueryAst,
+): LateMaterializationPlan | undefined {
+  // v1 targets the selective `.select()` path. The non-selective path would
+  // have to carry the full `props` blob into the lean CTE to order by a prop,
+  // which defeats the deferral — left to a follow-up.
+  const selectiveFields = ast.selectiveFields;
+  if (selectiveFields === undefined || selectiveFields.length === 0) {
+    return undefined;
+  }
+
+  // The transform only pays off when rows past the LIMIT are discarded before
+  // their deferred columns are materialized — so both ORDER BY and a positive
+  // LIMIT must be present.
+  const orderBy = ast.orderBy;
+  if (orderBy === undefined || orderBy.length === 0) {
+    return undefined;
+  }
+  if (ast.limit === undefined || ast.limit <= 0) {
+    return undefined;
+  }
+
+  // Aggregation owns the count fast path / group-by shape, not this transform.
+  if (ast.groupBy !== undefined || ast.having !== undefined) {
+    return undefined;
+  }
+  if (ast.aggregateOrderBy !== undefined && ast.aggregateOrderBy.length > 0) {
+    return undefined;
+  }
+
+  // Optional (LEFT JOIN) traversals yield NULL-identity candidate rows that the
+  // outer identity re-join would drop. Out of v1 scope.
+  if (ast.traversals.some((traversal) => traversal.optional)) {
+    return undefined;
+  }
+
+  const nodeAliases = new Set<string>([
+    ast.start.alias,
+    ...ast.traversals.map((traversal) => traversal.nodeAlias),
+  ]);
+
+  // Every projected and ordered field must resolve to a node alias — edge
+  // fields live in the traversal CTE keyed differently, a follow-up.
+  for (const field of selectiveFields) {
+    if (!nodeAliases.has(field.alias)) {
+      return undefined;
+    }
+  }
+  for (const orderSpec of orderBy) {
+    if (!nodeAliases.has(orderSpec.field.alias)) {
+      return undefined;
+    }
+  }
+
+  // Sort-key props fields must stay in the lean CTE so the topK can order by
+  // them; everything else non-identity is deferred to the outer re-fetch.
+  const orderReferenced = new Set<SelectiveField>();
+  for (const orderSpec of orderBy) {
+    const matched = findSelectivePropsFieldForFieldRef(
+      selectiveFields,
+      orderSpec.field,
+    );
+    if (matched !== undefined) {
+      orderReferenced.add(matched);
+    }
+  }
+
+  // Worth doing only if some projected column is genuinely deferrable: a
+  // non-identity field that isn't already carried as a sort key.
+  const hasDeferredColumn = selectiveFields.some(
+    (field) => !selectiveFieldIsIdentity(field) && !orderReferenced.has(field),
+  );
+  if (!hasDeferredColumn) {
+    return undefined;
+  }
+
+  const prunedSelectiveFields = selectiveFields.filter(
+    (field) => field.isSystemField || orderReferenced.has(field),
+  );
+
+  return {
+    leanAst: { ...ast, selectiveFields: prunedSelectiveFields },
+    limit: ast.limit,
+    offset: ast.offset,
+  };
+}
+
+/**
+ * The outer FROM clause: the topK CTE joined to the physical node table for each
+ * projected alias, keyed on `(graph_id, kind, id)`. The topK already validated
+ * temporal/soft-delete visibility, so this is a pure PK re-fetch of the deferred
+ * columns for the surviving rows.
+ */
+function buildLateMaterializedOuterFromClause(
+  ast: QueryAst,
+  graphId: string,
+  ctx: PredicateCompilerContext,
+): SQL {
+  const topk = sql.raw(LATE_MAT_TOPK_CTE_ALIAS);
+  const joins = lateMaterializedProjectedNodeAliases(ast).map((alias) => {
+    const physical = sql.raw(lateMaterializedPhysicalAlias(alias));
+    return sql`JOIN ${ctx.schema.nodesTable} ${physical} ON ${physical}.graph_id = ${graphId} AND ${physical}.kind = ${topk}.${sql.raw(`${alias}_kind`)} AND ${physical}.id = ${topk}.${sql.raw(`${alias}_id`)}`;
+  });
+  return joins.length === 0 ?
+      sql`FROM ${topk}`
+    : sql`FROM ${topk} ${sql.join(joins, sql` `)}`;
+}
+
+function compileLateMaterializedQuery(
+  ast: QueryAst,
+  graphId: string,
+  ctx: PredicateCompilerContext,
+  logicalPlan: LogicalPlan,
+  predicateIndex: PredicateIndex,
+  temporalFilterPass: TemporalFilterPass,
+  collapsedTraversalCteAlias: string | undefined,
+  shouldCollapseSelectiveTraversalRowset: boolean,
+): SQL | undefined {
+  const plan = resolveLateMaterializationPlan(ast);
+  if (plan === undefined) {
+    return undefined;
+  }
+
+  const { leanAst, limit, offset } = plan;
+  const { dialect } = ctx;
+  const leanRequiredColumns = collectRequiredColumnsByAlias(leanAst, {
+    includeProjection: false,
+  });
+
+  const ctes: SQL[] = [
+    buildStandardStartCte({
+      ast: leanAst,
+      ctx,
+      graphId,
+      predicateIndex,
+      requiredColumnsByAlias: leanRequiredColumns,
+      temporalFilterPass,
+    }),
+  ];
+  for (let index = 0; index < leanAst.traversals.length; index++) {
+    ctes.push(
+      buildStandardTraversalCte({
+        ast: leanAst,
+        carryForwardPreviousColumns: shouldCollapseSelectiveTraversalRowset,
+        ctx,
+        graphId,
+        materializeCte: shouldMaterializeTraversalCte(
+          dialect,
+          leanAst.traversals.length,
+          index,
+        ),
+        predicateIndex,
+        requiredColumnsByAlias: leanRequiredColumns,
+        temporalFilterPass,
+        traversalIndex: index,
+        traversalLimit: undefined,
+      }),
+    );
+  }
+  ctes.push(
+    buildLateMaterializedTopKCte({
+      ast: leanAst,
+      dialect,
+      fromClause: buildStandardFromClause({
+        ast: leanAst,
+        ...(collapsedTraversalCteAlias === undefined ?
+          {}
+        : { collapsedTraversalCteAlias }),
+      }),
+      limit,
+      offset,
+      ...(collapsedTraversalCteAlias === undefined ?
+        {}
+      : { collapsedTraversalCteAlias }),
+    }),
+  );
+
+  const orderBy = buildLateMaterializedOuterOrderBy(ast);
+  return emitStandardQuerySql({
+    ctes,
+    fromClause: buildLateMaterializedOuterFromClause(ast, graphId, ctx),
+    ...(orderBy === undefined ? {} : { orderBy }),
+    logicalPlan: stripLimitOffsetFromPlan(logicalPlan),
+    projection: buildLateMaterializedOuterProjection(ast, dialect),
+  });
+}
+
 /**
  * Compiles a standard (non-recursive) query to SQL using CTEs.
  */
@@ -1010,6 +1231,20 @@ function compileStandardQueryWithCteStrategy(
     );
     if (fastPathSql) {
       return fastPathSql;
+    }
+
+    const lateMaterializedSql = compileLateMaterializedQuery(
+      ast,
+      graphId,
+      ctx,
+      logicalPlan,
+      predicateIndex,
+      temporalFilterPass,
+      collapsedTraversalCteAlias,
+      shouldCollapseSelectiveTraversalRowset,
+    );
+    if (lateMaterializedSql) {
+      return lateMaterializedSql;
     }
   }
 

--- a/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
+++ b/packages/typegraph/src/query/compiler/standard-pass-pipeline.ts
@@ -109,7 +109,20 @@ function markPredicateFieldsAsRequired(
   }
 }
 
-function collectRequiredColumnsByAlias(ast: QueryAst): RequiredColumnsByAlias {
+/**
+ * Collects the columns each alias must carry out of its CTE.
+ *
+ * `includeProjection` (default true) folds in the SELECT-list fields. The late
+ * materialization path passes `false` to build a *lean* candidate CTE that
+ * carries only identity, ordering, and predicate columns — the projection-only
+ * columns (e.g. a large `content` prop) are deferred and re-fetched by identity
+ * for the surviving rows, not materialized for every candidate.
+ */
+export function collectRequiredColumnsByAlias(
+  ast: QueryAst,
+  options?: Readonly<{ includeProjection?: boolean }>,
+): RequiredColumnsByAlias {
+  const includeProjection = options?.includeProjection ?? true;
   const requiredColumnsByAlias = new Map<string, Set<string>>();
 
   addRequiredColumn(requiredColumnsByAlias, ast.start.alias, "id");
@@ -119,24 +132,26 @@ function collectRequiredColumnsByAlias(ast: QueryAst): RequiredColumnsByAlias {
 
   const hasSelectiveFields = (ast.selectiveFields?.length ?? 0) > 0;
 
-  if (hasSelectiveFields) {
-    for (const field of ast.selectiveFields ?? []) {
-      if (field.isSystemField) {
-        addRequiredColumn(
-          requiredColumnsByAlias,
-          field.alias,
-          mapSelectiveSystemFieldToColumn(field.field),
-        );
+  if (includeProjection) {
+    if (hasSelectiveFields) {
+      for (const field of ast.selectiveFields ?? []) {
+        if (field.isSystemField) {
+          addRequiredColumn(
+            requiredColumnsByAlias,
+            field.alias,
+            mapSelectiveSystemFieldToColumn(field.field),
+          );
+        }
       }
-    }
-  } else {
-    for (const projectedField of ast.projection.fields) {
-      const source = projectedField.source;
-      if (source.__type === "field_ref") {
-        markFieldRefAsRequired(requiredColumnsByAlias, source);
-      } else {
-        addRequiredColumn(requiredColumnsByAlias, source.field.alias, "id");
-        markFieldRefAsRequired(requiredColumnsByAlias, source.field);
+    } else {
+      for (const projectedField of ast.projection.fields) {
+        const source = projectedField.source;
+        if (source.__type === "field_ref") {
+          markFieldRefAsRequired(requiredColumnsByAlias, source);
+        } else {
+          addRequiredColumn(requiredColumnsByAlias, source.field.alias, "id");
+          markFieldRefAsRequired(requiredColumnsByAlias, source.field);
+        }
       }
     }
   }

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -33,6 +33,7 @@ import {
   registerEdgePropertyIntegrationTests,
   registerFulltextIntegrationTests,
   registerImportUniquenessIntegrationTests,
+  registerLateMaterializationIntegrationTests,
   registerOrderingIntegrationTests,
   registerPaginationIntegrationTests,
   registerPredicateIntegrationTests,
@@ -126,6 +127,7 @@ export function createIntegrationTestSuite(
     registerPredicateIntegrationTests(context);
     registerProvenanceIntegrationTests(context);
     registerOrderingIntegrationTests(context);
+    registerLateMaterializationIntegrationTests(context);
     registerTemporalIntegrationTests(context);
     registerTransactionReceiptIntegrationTests(context);
     registerRecordedTimeIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -11,6 +11,7 @@ export type { IntegrationStore } from "./fixtures";
 export { integrationTestGraph } from "./fixtures";
 export { registerFulltextIntegrationTests } from "./fulltext";
 export { registerImportUniquenessIntegrationTests } from "./import-uniqueness";
+export { registerLateMaterializationIntegrationTests } from "./late-materialization";
 export { registerOrderingIntegrationTests } from "./ordering";
 export { registerPaginationIntegrationTests } from "./pagination";
 export { registerPredicateIntegrationTests } from "./predicates";

--- a/packages/typegraph/tests/backends/integration/late-materialization.ts
+++ b/packages/typegraph/tests/backends/integration/late-materialization.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { createStore } from "../../../src";
+import { createStore, createStoreWithSchema } from "../../../src";
 import { type IntegrationStore, integrationTestGraph } from "./fixtures";
 import { type IntegrationTestContext } from "./test-context";
 
@@ -10,9 +10,12 @@ import { type IntegrationTestContext } from "./test-context";
  * These cases run `ORDER BY … LIMIT` selective queries whose projection reads
  * columns beyond the sort/identity keys, which routes through the compiler's
  * late-materialization branch (sort+limit a lean candidate set, then re-fetch
- * the deferred columns by identity for the survivors). The transform must be
- * result-identical to the flat plan on every backend, so these assert the exact
- * top-K rows and their deferred-column values.
+ * the deferred columns by identity for the survivors). The transform must
+ * return the same rows as the flat plan on every backend whenever the ORDER BY
+ * determines a unique top-K, so these assert the exact top-K rows and their
+ * deferred-column values. (When ties span the LIMIT boundary both plans pick
+ * an arbitrary tied subset, and the two plan shapes may pick differently —
+ * the same non-determinism class the flat plan already has.)
  *
  * A `traversalExpansion: "none"` store is used so traversal `.select()` queries
  * take the selective path the transform targets (matching how a fulltext/graph
@@ -175,6 +178,54 @@ export function registerLateMaterializationIntegrationTests(
         "Hana",
         "Ivan",
         "June",
+      ]);
+    });
+
+    it("returns exact single-version rows for a recorded-time read", async () => {
+      // A recorded pin swaps the query's node source to the recorded history
+      // relation, where (graph_id, kind, id) matches one row per version. The
+      // late-mat outer re-join keys on exactly that identity with no temporal
+      // predicate, so recorded reads must fall back to the flat plan — this
+      // guards against duplicated survivors and stale-version props.
+      const [history] = await createStoreWithSchema(
+        integrationTestGraph,
+        context.getStore().backend,
+        { history: true },
+      );
+
+      const nodes = [];
+      for (const person of [
+        { name: "Rae", age: 41, email: "rae@v1.example.com" },
+        { name: "Sam", age: 36, email: "sam@v1.example.com" },
+        { name: "Tia", age: 31, email: "tia@v1.example.com" },
+      ]) {
+        nodes.push(await history.nodes.Person.create(person));
+      }
+      const pin = await history.recordedNow();
+      if (pin === undefined) throw new Error("recorded clock was not written");
+
+      // A second recorded version per node after the pin: an outer re-join
+      // without a temporal predicate would both multiply the survivors and
+      // surface these later emails at the pin.
+      for (const node of nodes) {
+        await history.nodes.Person.update(node.id, {
+          email: `${node.name.toLowerCase()}@v2.example.com`,
+        });
+      }
+
+      const results = await history
+        .asOfRecorded(pin)
+        .query()
+        .from("Person", "person")
+        .whereNode("person", (person) => person.age.gte(30))
+        .select((ctx) => ({ name: ctx.person.name, email: ctx.person.email }))
+        .orderBy("person", "age", "desc")
+        .limit(2)
+        .execute();
+
+      expect(results).toEqual([
+        { name: "Rae", email: "rae@v1.example.com" },
+        { name: "Sam", email: "sam@v1.example.com" },
       ]);
     });
 

--- a/packages/typegraph/tests/backends/integration/late-materialization.ts
+++ b/packages/typegraph/tests/backends/integration/late-materialization.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createStore } from "../../../src";
+import { type IntegrationStore, integrationTestGraph } from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+/**
+ * Late materialization (deferred projection) — see typegraph#281.
+ *
+ * These cases run `ORDER BY … LIMIT` selective queries whose projection reads
+ * columns beyond the sort/identity keys, which routes through the compiler's
+ * late-materialization branch (sort+limit a lean candidate set, then re-fetch
+ * the deferred columns by identity for the survivors). The transform must be
+ * result-identical to the flat plan on every backend, so these assert the exact
+ * top-K rows and their deferred-column values.
+ *
+ * A `traversalExpansion: "none"` store is used so traversal `.select()` queries
+ * take the selective path the transform targets (matching how a fulltext/graph
+ * consumer configures its store); the transform is otherwise engine-neutral.
+ */
+export function registerLateMaterializationIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("Late materialization (deferred projection)", () => {
+    let store: IntegrationStore;
+
+    beforeEach(async () => {
+      store = createStore(integrationTestGraph, context.getStore().backend, {
+        queryDefaults: { traversalExpansion: "none" },
+      });
+
+      const root = await store.nodes.Person.create({ name: "Root" });
+      const friends = [
+        { name: "Frida", age: 40, email: "frida@example.com" },
+        { name: "Gus", age: 35, email: "gus@example.com" },
+        { name: "Hana", age: 30, email: "hana@example.com" },
+        { name: "Ivan", age: 25, email: "ivan@example.com" },
+        { name: "June", age: undefined, email: undefined },
+      ];
+      for (const friend of friends) {
+        const node = await store.nodes.Person.create(friend);
+        await store.edges.knows.create(root, node, {});
+      }
+    });
+
+    it("returns the correct top-K by a node sort key with deferred columns", async () => {
+      const results = await store
+        .query()
+        .from("Person", "root")
+        .whereNode("root", (person) => person.name.eq("Root"))
+        .traverse("knows", "edge", { expand: "none", direction: "out" })
+        .to("Person", "friend")
+        .whereNode("friend", (friend) => friend.age.gte(30))
+        .select((ctx) => ({
+          name: ctx.friend.name,
+          email: ctx.friend.email,
+          age: ctx.friend.age,
+        }))
+        .orderBy("friend", "age", "desc")
+        .limit(2)
+        .execute();
+
+      expect(results).toEqual([
+        { name: "Frida", email: "frida@example.com", age: 40 },
+        { name: "Gus", email: "gus@example.com", age: 35 },
+      ]);
+    });
+
+    it("applies OFFSET with the pushed-down LIMIT", async () => {
+      const results = await store
+        .query()
+        .from("Person", "root")
+        .whereNode("root", (person) => person.name.eq("Root"))
+        .traverse("knows", "edge", { expand: "none", direction: "out" })
+        .to("Person", "friend")
+        .whereNode("friend", (friend) => friend.age.gte(25))
+        .select((ctx) => ({ name: ctx.friend.name, age: ctx.friend.age }))
+        .orderBy("friend", "age", "desc")
+        .limit(2)
+        .offset(1)
+        .execute();
+
+      expect(results.map((row) => row.name)).toEqual(["Gus", "Hana"]);
+    });
+
+    it("honors a predicate on the deferred target node", async () => {
+      const results = await store
+        .query()
+        .from("Person", "root")
+        .whereNode("root", (person) => person.name.eq("Root"))
+        .traverse("knows", "edge", { expand: "none", direction: "out" })
+        .to("Person", "friend")
+        .whereNode("friend", (friend) => friend.age.gte(35))
+        .select((ctx) => ({ name: ctx.friend.name, email: ctx.friend.email }))
+        .orderBy("friend", "age", "desc")
+        .limit(10)
+        .execute();
+
+      expect(results.map((row) => row.name)).toEqual(["Frida", "Gus"]);
+      expect(results[0]?.email).toBe("frida@example.com");
+    });
+
+    it("orders ascending with nulls-last semantics", async () => {
+      const results = await store
+        .query()
+        .from("Person", "root")
+        .whereNode("root", (person) => person.name.eq("Root"))
+        .traverse("knows", "edge", { expand: "none", direction: "out" })
+        .to("Person", "friend")
+        .select((ctx) => ({ name: ctx.friend.name, age: ctx.friend.age }))
+        .orderBy("friend", "age", "asc")
+        .limit(3)
+        .execute();
+
+      expect(results.map((row) => row.name)).toEqual(["Ivan", "Hana", "Gus"]);
+    });
+
+    it("breaks ties with a secondary sort key", async () => {
+      // Two friends share an age; the secondary key (name asc) orders them.
+      const root = await store.nodes.Person.create({ name: "Root2" });
+      for (const friend of [
+        { name: "Zed", age: 50 },
+        { name: "Amy", age: 50 },
+      ]) {
+        const node = await store.nodes.Person.create(friend);
+        await store.edges.knows.create(root, node, {});
+      }
+
+      const results = await store
+        .query()
+        .from("Person", "root")
+        .whereNode("root", (person) => person.name.eq("Root2"))
+        .traverse("knows", "edge", { expand: "none", direction: "out" })
+        .to("Person", "friend")
+        .select((ctx) => ({ name: ctx.friend.name, age: ctx.friend.age }))
+        .orderBy("friend", "age", "desc")
+        .orderBy("friend", "name", "asc")
+        .limit(2)
+        .execute();
+
+      expect(results.map((row) => row.name)).toEqual(["Amy", "Zed"]);
+    });
+
+    it("late-materializes a start-only query (no traversal)", async () => {
+      const results = await store
+        .query()
+        .from("Person", "person")
+        .whereNode("person", (person) => person.age.gte(30))
+        .select((ctx) => ({ name: ctx.person.name, email: ctx.person.email }))
+        .orderBy("person", "age", "desc")
+        .limit(2)
+        .execute();
+
+      expect(results).toEqual([
+        { name: "Frida", email: "frida@example.com" },
+        { name: "Gus", email: "gus@example.com" },
+      ]);
+    });
+
+    it("returns all rows when LIMIT exceeds the result set", async () => {
+      const results = await store
+        .query()
+        .from("Person", "root")
+        .whereNode("root", (person) => person.name.eq("Root"))
+        .traverse("knows", "edge", { expand: "none", direction: "out" })
+        .to("Person", "friend")
+        .select((ctx) => ({ name: ctx.friend.name }))
+        .orderBy("friend", "name", "asc")
+        .limit(100)
+        .execute();
+
+      expect(results.map((row) => row.name)).toEqual([
+        "Frida",
+        "Gus",
+        "Hana",
+        "Ivan",
+        "June",
+      ]);
+    });
+
+    it("matches the flat plan for a multi-hop traversal", async () => {
+      // root → knows → friend → knows → fof, ordered by the terminal node.
+      const fofRoot = await store.nodes.Person.create({ name: "MultiRoot" });
+      const mid = await store.nodes.Person.create({ name: "Mid" });
+      await store.edges.knows.create(fofRoot, mid, {});
+      for (const fof of [
+        { name: "Nia", age: 22, email: "nia@example.com" },
+        { name: "Omar", age: 44, email: "omar@example.com" },
+      ]) {
+        const node = await store.nodes.Person.create(fof);
+        await store.edges.knows.create(mid, node, {});
+      }
+
+      const results = await store
+        .query()
+        .from("Person", "root")
+        .whereNode("root", (person) => person.name.eq("MultiRoot"))
+        .traverse("knows", "e1", { expand: "none", direction: "out" })
+        .to("Person", "mid")
+        .traverse("knows", "e2", { expand: "none", direction: "out" })
+        .to("Person", "fof")
+        .select((ctx) => ({ name: ctx.fof.name, email: ctx.fof.email }))
+        .orderBy("fof", "age", "desc")
+        .limit(1)
+        .execute();
+
+      expect(results).toEqual([{ name: "Omar", email: "omar@example.com" }]);
+    });
+  });
+}


### PR DESCRIPTION
Closes #281.

## Problem

A selective query with `ORDER BY … LIMIT` compiled to a single flat `SELECT` that projected **every** column — including large ones not needed for ordering, such as a `content` prop — for **every candidate row**, carried them through the sorter, then discarded all but the `LIMIT` survivors.

At LDBC SNB SF1, IC9's Comment leg fans out to **1,184,787 candidate comments** for a top-20; `content` was extracted for all 1.18M and sorted, even though only 20 survive.

## Fix

Add a late-materialization (deferred-projection) branch to the standard compile path, alongside the existing count-aggregate fast path:

1. Build a **lean** candidate CTE set carrying only identity + ordering + predicate columns (the projection-only columns are dropped via `collectRequiredColumnsByAlias(..., { includeProjection: false })` + a pruned `selectiveFields`).
2. A `cte_lm_topk` CTE sorts + limits that lean set, carrying each sort key out as `__lm_sk{n}`.
3. The outer `SELECT` re-joins the physical `nodes` table by `(graph_id, kind, id)` for each projected alias and fetches the deferred columns **for only the surviving rows**, re-ordering by the carried sort keys.

The logical plan is reconciled with `stripLimitOffsetFromPlan` (the LIMIT moves into the inner CTE), exactly as the count fast path does. The start + traversal candidate-CTE prefix is now built by a helper (`buildStandardStartAndTraversalCtes`) shared with the flat plan rather than a third inline copy.

### Properties

- **Backend-neutral** — a plain `SELECT … FROM (topK) JOIN nodes ON identity` is standard SQL on both dialects; no new `DialectAdapter` member, no `=== "sqlite"` branching under `src/query`.
- **Live-table only** — the outer identity re-join is sound because `(graph_id, kind, id)` is the live nodes PK. Recorded-time reads (`ast.recordedAsOf`) swap the node source to the recorded history relation, where that key matches **one row per version** — the re-join would duplicate survivors and read stale-version props. Recorded reads therefore fall back to the flat plan, guarded by a regression test that fails with duplicated rows if the gate is removed.
- **Collapse-aware** — handles the common rowset-collapsed selective-traversal shape (all identities carried into one CTE) as well as the separate-CTE and start-only shapes.
- **Tightly gated** — fires only for the selective `.select()` path with `ORDER BY` + a positive `LIMIT` and at least one deferrable column, at the live coordinate. Aggregates, vector/fulltext, optional (LEFT JOIN) traversals, edge-field projections, non-selective queries, and recorded-time reads fall back to the flat plan unchanged.

### Ordering semantics

The outer `SELECT` re-orders survivors by the carried `__lm_sk{n}` sort keys with the same `(col IS NULL)` null-placement pattern as the flat plan. When the `ORDER BY` determines a unique top-K, results are identical to the flat plan. When ties span the LIMIT boundary, both plan shapes pick an arbitrary tied subset (SQL non-determinism the flat plan already has) and may pick differently.

## Results (LDBC SNB SF1, real data)

IC9 Comment leg (top-20 over the friend/FoF message fan-out), `late-mat` confirmed active on the executed SQL:

| seed (FoF authors) | before | after | speedup |
| --- | --: | --: | --: |
| 2,089 | 1,674 ms | **1,180 ms** | ~30% |
| 3,374 | 2,737 ms | **1,893 ms** | ~31% |
| 3,662 | 2,968 ms | **2,108 ms** | ~29% |

`content` is now extracted for 20 rows instead of ~1.18M — matching the ~33% content-materialization cost measured for #281. The residual cost is the inherent candidate fan-out (a separate, architectural item noted in the issue). Validated at SF1 in the full suite re-run: IC9 4,325 ms → 2,718 ms (~37%) on tg-sqlite.

## Tests

- New shared cross-backend suite `tests/backends/integration/late-materialization.ts` — 9 cases (top-K, OFFSET, predicate on the deferred node, null ordering, tie-breaks, start-only/non-collapse path, multi-hop, limit-exceeds-set, **recorded-time fallback with multi-version history**) run on SQLite, libSQL, and PGlite.
- The recorded-time case was verified to fail (4 rows returned for `limit(2)`, duplicated survivors) when the recorded gate is disabled.
- Full SQLite suite green (**5,022 passed**); PostgreSQL lane green (**2,072 passed**); existing `orderBy + limit + select` tests now route through the new branch with no changes.
- `pnpm fix` + `pnpm typecheck` clean.
