### PR TITLE
feat(indexes): system-index declarations with boot materialization

### DIFF
--- a/.changeset/system-index-declarations.md
+++ b/.changeset/system-index-declarations.md
@@ -36,5 +36,14 @@ gap #282 exposed). Now:
 - `IndexEntity` gains a `"system"` member; system status rows carry the
   relation key (e.g. `"recordedNodes"`) in their `kind` column.
 
-Generated DDL is unchanged — same index names, columns, and order — so
-existing databases and drizzle-kit migrations are unaffected.
+Generated DDL is unchanged for default and short custom table names — same
+index names, columns, and order — so existing databases and drizzle-kit
+migrations are unaffected. Names that would exceed PostgreSQL's 63-char
+identifier bound (very long custom table names) are now deterministically
+truncated + hash-suffixed instead of being silently truncated by the engine
+into collisions. System index names are reserved: a graph-declared index
+using one is rejected at table definition and by `materializeIndexes()`
+(previously its `CREATE INDEX IF NOT EXISTS` silently no-opped against the
+differently-shaped system index while recording success). Legacy databases
+that predate the recorded relations skip those indexes cleanly instead of
+attempting failing DDL at every boot.

--- a/.changeset/system-index-declarations.md
+++ b/.changeset/system-index-declarations.md
@@ -20,8 +20,15 @@ gap #282 exposed). Now:
   CONCURRENTLY` on PostgreSQL, riding the same status table, drift
   signatures, invalid-leftover healing, and cross-caller claim protocol as
   graph-declared indexes. A database whose indexes all exist settles from
-  one catalog read with no DDL and no writes. Failures degrade to a warning
-  (indexes are a performance concern; the store still boots).
+  one catalog read (scoped to the session `search_path`, so schema-per-
+  tenant databases never observe each other's indexes) with no DDL and no
+  writes; a system index that is physically absent or invalid is rebuilt
+  even when a stale success row survives (dump/restore, manual drop).
+  Failures — including status-table infrastructure errors — degrade to a
+  warning: indexes are a performance concern and the store still boots.
+  Deployments that must not run index builds inline at boot pass
+  `systemIndexes: "skip"` to `createStoreWithSchema` and materialize
+  out-of-band.
 - **New API: `store.materializeSystemIndexes()`** for deployments that boot
   without `createStoreWithSchema` (zero-DDL attach) — call once under a
   DDL-capable role after upgrading. Strict where the boot path is lenient:

--- a/.changeset/system-index-declarations.md
+++ b/.changeset/system-index-declarations.md
@@ -1,0 +1,33 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+TypeGraph's base-relation indexes are now **system-index declarations** — a
+single declared list (`SYSTEM_INDEX_DECLARATIONS`) that both dialect schemas
+derive from and that materializes onto already-initialized databases.
+
+Previously the base indexes were hand-written twice (once per dialect schema)
+and applied only by first-boot bootstrap DDL, so an index added in a newer
+library version never reached an existing database without manual DDL (the
+gap #282 exposed). Now:
+
+- **Single source, parity by construction.** `createSqliteTables` /
+  `createPostgresTables` build their node/edge/recorded-relation indexes from
+  the same declarations, and a cross-dialect extraction test asserts the two
+  generated DDL scripts' full index sets stay identical.
+- **Upgrade path.** `createStoreWithSchema` brings a database's system
+  indexes up to the running library version at boot — `CREATE INDEX
+  CONCURRENTLY` on PostgreSQL, riding the same status table, drift
+  signatures, invalid-leftover healing, and cross-caller claim protocol as
+  graph-declared indexes. A database whose indexes all exist settles from
+  one catalog read with no DDL and no writes. Failures degrade to a warning
+  (indexes are a performance concern; the store still boots).
+- **New API: `store.materializeSystemIndexes()`** for deployments that boot
+  without `createStoreWithSchema` (zero-DDL attach) — call once under a
+  DDL-capable role after upgrading. Strict where the boot path is lenient:
+  throws `ConfigurationError` on backends without DDL/status primitives.
+- `IndexEntity` gains a `"system"` member; system status rows carry the
+  relation key (e.g. `"recordedNodes"`) in their `kind` column.
+
+Generated DDL is unchanged — same index names, columns, and order — so
+existing databases and drizzle-kit migrations are unaffected.

--- a/.changeset/system-index-declarations.md
+++ b/.changeset/system-index-declarations.md
@@ -20,9 +20,12 @@ gap #282 exposed). Now:
   CONCURRENTLY` on PostgreSQL, riding the same status table, drift
   signatures, invalid-leftover healing, and cross-caller claim protocol as
   graph-declared indexes. A database whose indexes all exist settles from
-  one catalog read (scoped to the session `search_path`, so schema-per-
-  tenant databases never observe each other's indexes) with no DDL and no
-  writes; a system index that is physically absent or invalid is rebuilt
+  three concurrent catalog/status reads (scoped to the session
+  `search_path`, so schema-per-tenant databases never observe each other's
+  indexes) with no index DDL and no status writes — the only DDL on that
+  warm path is the idempotent status-table `CREATE TABLE IF NOT EXISTS`
+  ensure step every materialize verb runs. A system index that is
+  physically absent or invalid is rebuilt
   even when a stale success row survives (dump/restore, manual drop).
   Failures — including status-table infrastructure errors — degrade to a
   warning: indexes are a performance concern and the store still boots.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -908,7 +908,9 @@ least-privilege, DML-only database role.
   Deployments that never run `createStoreWithSchema` (manual-DDL boot with
   a plain `createStore` attach) adopt new system indexes by calling
   `store.materializeSystemIndexes()` once under a DDL-capable role after
-  upgrading.
+  upgrading; deployments that must not run index builds inline at boot
+  (large tables behind a readiness probe) pass `systemIndexes: "skip"` to
+  `createStoreWithSchema` and materialize out-of-band the same way.
 
 - **`createStore(graph, backend)` is a synchronous, zero-I/O attach.**
   It does not create tables, repair DDL, or record that runtime storage

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -894,12 +894,21 @@ least-privilege, DML-only database role.
   base tables on a fresh database, applies safe auto-migrations, and
   durably materializes strategy-owned runtime storage — both fulltext and
   each `embedding()` field's per-`(kind, field)` vector table, plus a
-  durable marker for each. It re-issues idempotent DDL on every cold boot
-  — at minimum a `CREATE TABLE IF NOT EXISTS` for the contribution-marker
-  table — so the role it runs under **must hold `CREATE` / DDL
-  privileges**. Run it once at startup, outside request handlers and
-  transactions. (`store.evolve()` likewise provisions any embedding field
-  it introduces, so it too needs DDL privileges.)
+  durable marker for each. It also brings TypeGraph's own base-relation
+  **system indexes** up to the running library version: bootstrap DDL only
+  runs on the very first boot, so an index shipped in a newer version
+  reaches an already-initialized database through this step (built with
+  `CREATE INDEX CONCURRENTLY` on PostgreSQL; a database whose indexes all
+  exist settles from the catalog with no DDL). It re-issues idempotent DDL
+  on every cold boot — at minimum a `CREATE TABLE IF NOT EXISTS` for the
+  contribution-marker table — so the role it runs under **must hold
+  `CREATE` / DDL privileges**. Run it once at startup, outside request
+  handlers and transactions. (`store.evolve()` likewise provisions any
+  embedding field it introduces, so it too needs DDL privileges.)
+  Deployments that never run `createStoreWithSchema` (manual-DDL boot with
+  a plain `createStore` attach) adopt new system indexes by calling
+  `store.materializeSystemIndexes()` once under a DDL-capable role after
+  upgrading.
 
 - **`createStore(graph, backend)` is a synchronous, zero-I/O attach.**
   It does not create tables, repair DDL, or record that runtime storage

--- a/apps/docs/src/content/docs/performance/indexes.md
+++ b/apps/docs/src/content/docs/performance/indexes.md
@@ -458,6 +458,21 @@ const profiler = new QueryProfiler({
   through `store.materializeIndexes()` (pgvector builds an HNSW / IVFFlat ANN index; sqlite-vec and
   libSQL report `skipped`/build their own). See [Semantic Search](/semantic-search).
 
+## System Indexes
+
+TypeGraph ships a set of **system indexes** on its own relations (nodes, edges, and the recorded
+history tables) — the traversal, listing, temporal-validity, and bare-id access paths every
+compiled query relies on. They are declared once (`SYSTEM_INDEX_DECLARATIONS`, exported for
+inspection), and both dialects' schemas derive from that single list, so SQLite and PostgreSQL
+always carry the same set.
+
+You normally never manage them: fresh databases get them at bootstrap, and
+`createStoreWithSchema()` brings an already-initialized database up to the running library
+version's set on boot (with `CREATE INDEX CONCURRENTLY` on PostgreSQL). Deployments that boot
+without `createStoreWithSchema` can run `store.materializeSystemIndexes()` once after a library
+upgrade; it shares `materializeIndexes()`'s status tracking, drift signatures, and concurrent-build
+claim protocol, and settles with no DDL when everything already exists.
+
 ## Next Steps
 
 - [Performance Overview](/performance/overview) — Best practices, N+1 prevention, batch patterns

--- a/packages/typegraph/src/backend/drizzle/index-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/index-materializations.ts
@@ -127,27 +127,33 @@ export function buildMaterializationInsertValues<TEncoded>(
 /**
  * Build the `set` clause for the upsert's ON CONFLICT DO UPDATE.
  *
- * The `materializedAt` column uses `COALESCE` to preserve any prior
- * successful timestamp when this attempt failed (`materializedAt ===
- * undefined`). On success the new timestamp wins. This keeps the
- * status table truthful: the most recent successful materialization
- * timestamp survives even if a subsequent re-attempt errored.
+ * A failed attempt (`materializedAt === undefined`) updates ONLY the
+ * attempt bookkeeping (`lastAttemptedAt`/`lastError`): the row's shape
+ * columns (`signature`, `entity`, `kind`, `graphId`, `schemaVersion`)
+ * and `materializedAt` describe the index that IS materialized, and a
+ * failed re-attempt must not overwrite them. In particular, a
+ * signature-drift failure that rewrote `signature` to the new value
+ * while keeping the old success `materializedAt` would settle as
+ * `alreadyMaterialized` on the very next run — silencing the drift
+ * signal after one report. Omitted columns are preserved by ON CONFLICT
+ * DO UPDATE semantics. On success every column takes the new value.
  */
 export function buildMaterializationOnConflictSet(
-  materializedAtColumn: unknown,
   paramsMaterializedAt: string | undefined,
 ): Readonly<Record<string, ReturnType<typeof sql>>> {
-  const materializedAtSet =
-    paramsMaterializedAt === undefined ?
-      sql`COALESCE(excluded.${sql.identifier("materialized_at")}, ${materializedAtColumn})`
-    : sql`excluded.${sql.identifier("materialized_at")}`;
+  if (paramsMaterializedAt === undefined) {
+    return {
+      lastAttemptedAt: sql`excluded.${sql.identifier("last_attempted_at")}`,
+      lastError: sql`excluded.${sql.identifier("last_error")}`,
+    };
+  }
   return {
     graphId: sql`excluded.${sql.identifier("graph_id")}`,
     entity: sql`excluded.${sql.identifier("entity")}`,
     kind: sql`excluded.${sql.identifier("kind")}`,
     signature: sql`excluded.${sql.identifier("signature")}`,
     schemaVersion: sql`excluded.${sql.identifier("schema_version")}`,
-    materializedAt: materializedAtSet,
+    materializedAt: sql`excluded.${sql.identifier("materialized_at")}`,
     lastAttemptedAt: sql`excluded.${sql.identifier("last_attempted_at")}`,
     lastError: sql`excluded.${sql.identifier("last_error")}`,
   };

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -811,10 +811,7 @@ export function createPostgresBackend(
         )
         .onConflictDoUpdate({
           target: t.indexName,
-          set: buildMaterializationOnConflictSet(
-            t.materializedAt,
-            params.materializedAt,
-          ),
+          set: buildMaterializationOnConflictSet(params.materializedAt),
         });
     },
 

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -42,6 +42,7 @@ import {
   buildPostgresNodeIndexBuilders,
   buildPostgresSystemIndexBuilders,
 } from "../../../indexes/drizzle";
+import { assertNoSystemIndexNameCollision } from "../../../indexes/system";
 import { type IndexDeclaration } from "../../../indexes/types";
 import { regconfig, tsvector } from "../columns/fulltext";
 
@@ -100,6 +101,7 @@ export function createPostgresTables(
 ) {
   const n: PostgresTableNames = { ...DEFAULT_TABLE_NAMES, ...names };
   const indexes = options.indexes ?? [];
+  assertNoSystemIndexNameCollision(indexes, n);
 
   const nodes = pgTable(
     n.nodes,

--- a/packages/typegraph/src/backend/drizzle/schema/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/postgres.ts
@@ -40,6 +40,7 @@ import {
 import {
   buildPostgresEdgeIndexBuilders,
   buildPostgresNodeIndexBuilders,
+  buildPostgresSystemIndexBuilders,
 } from "../../../indexes/drizzle";
 import { type IndexDeclaration } from "../../../indexes/types";
 import { regconfig, tsvector } from "../columns/fulltext";
@@ -116,20 +117,9 @@ export function createPostgresTables(
     },
     (t) => [
       primaryKey({ columns: [t.graphId, t.kind, t.id] }),
-      index(`${n.nodes}_kind_idx`).on(t.graphId, t.kind),
-      index(`${n.nodes}_kind_created_idx`).on(
-        t.graphId,
-        t.kind,
-        t.deletedAt,
-        t.createdAt,
-      ),
-      index(`${n.nodes}_deleted_idx`).on(t.graphId, t.deletedAt),
-      index(`${n.nodes}_valid_idx`).on(t.graphId, t.validFrom, t.validTo),
-      // Bare-id lookup: the primary key leads with `kind` (graph_id, kind, id),
-      // so a `WHERE graph_id = ? AND id = ?` probe that doesn't know the kind
-      // can't seek it. `store.algorithms.degree`'s node-kind subquery resolves a
-      // seed's kind by id, so it depends on this access path. See typegraph#280.
-      index(`${n.nodes}_id_idx`).on(t.graphId, t.id),
+      // System indexes come from SYSTEM_INDEX_DECLARATIONS (single source
+      // for both dialects + the runtime materializer).
+      ...buildPostgresSystemIndexBuilders("nodes", n.nodes, t),
       ...buildPostgresNodeIndexBuilders(t, indexes),
     ],
   );
@@ -153,55 +143,7 @@ export function createPostgresTables(
     },
     (t) => [
       primaryKey({ columns: [t.graphId, t.id] }),
-      index(`${n.edges}_kind_idx`).on(t.graphId, t.kind),
-      // Directional traversal index (outgoing): supports endpoint lookups
-      // and extra filtering by edge kind / target kind. Includes every
-      // system column the compiled query's soft-delete/temporal-validity
-      // predicate touches (deleted_at, valid_from, valid_to), trailed by
-      // to_id — the compiled traversal join reads `n.id = e.to_id` for an
-      // outgoing traversal (standard-builders.ts), so without to_id here
-      // the join still fetches the edge's heap row for that one column
-      // even with the seek/predicate columns covered.
-      index(`${n.edges}_from_idx`).on(
-        t.graphId,
-        t.fromKind,
-        t.fromId,
-        t.kind,
-        t.toKind,
-        t.deletedAt,
-        t.validFrom,
-        t.validTo,
-        t.toId,
-      ),
-      // Directional traversal index (incoming): mirrors from_idx for
-      // reverse traversals, trailed by from_id for the same reason
-      // (`n.id = e.from_id` for an incoming traversal).
-      index(`${n.edges}_to_idx`).on(
-        t.graphId,
-        t.toKind,
-        t.toId,
-        t.kind,
-        t.fromKind,
-        t.deletedAt,
-        t.validFrom,
-        t.validTo,
-        t.fromId,
-      ),
-      index(`${n.edges}_kind_created_idx`).on(
-        t.graphId,
-        t.kind,
-        t.deletedAt,
-        t.createdAt,
-      ),
-      index(`${n.edges}_deleted_idx`).on(t.graphId, t.deletedAt),
-      index(`${n.edges}_valid_idx`).on(t.graphId, t.validFrom, t.validTo),
-      index(`${n.edges}_cardinality_idx`).on(
-        t.graphId,
-        t.kind,
-        t.fromKind,
-        t.fromId,
-        t.validTo,
-      ),
+      ...buildPostgresSystemIndexBuilders("edges", n.edges, t),
       ...buildPostgresEdgeIndexBuilders(t, indexes),
     ],
   );
@@ -229,25 +171,7 @@ export function createPostgresTables(
     },
     (t) => [
       primaryKey({ columns: [t.historyId] }),
-      index(`${n.recordedNodes}_entity_idx`).on(
-        t.graphId,
-        t.kind,
-        t.id,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedNodes}_open_idx`).on(t.graphId, t.recordedTo),
-      index(`${n.recordedNodes}_valid_idx`).on(
-        t.graphId,
-        t.validFrom,
-        t.validTo,
-      ),
-      // Bare-id lookup parity with the live nodes table: recorded-pinned
-      // reads swap this relation in as the node source, and `_entity_idx`
-      // leads with `kind`, so the same kind-by-bare-id probe (e.g.
-      // `degree()` at a recorded coordinate) would otherwise scan every
-      // historical version in the graph. See typegraph#280.
-      index(`${n.recordedNodes}_id_idx`).on(t.graphId, t.id),
+      ...buildPostgresSystemIndexBuilders("recordedNodes", n.recordedNodes, t),
     ],
   );
 
@@ -277,37 +201,7 @@ export function createPostgresTables(
     },
     (t) => [
       primaryKey({ columns: [t.historyId] }),
-      index(`${n.recordedEdges}_entity_idx`).on(
-        t.graphId,
-        t.kind,
-        t.id,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedEdges}_open_idx`).on(t.graphId, t.recordedTo),
-      index(`${n.recordedEdges}_from_idx`).on(
-        t.graphId,
-        t.fromKind,
-        t.fromId,
-        t.kind,
-        t.toKind,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedEdges}_to_idx`).on(
-        t.graphId,
-        t.toKind,
-        t.toId,
-        t.kind,
-        t.fromKind,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedEdges}_valid_idx`).on(
-        t.graphId,
-        t.validFrom,
-        t.validTo,
-      ),
+      ...buildPostgresSystemIndexBuilders("recordedEdges", n.recordedEdges, t),
     ],
   );
 

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -33,6 +33,7 @@ import {
   buildSqliteNodeIndexBuilders,
   buildSqliteSystemIndexBuilders,
 } from "../../../indexes/drizzle";
+import { assertNoSystemIndexNameCollision } from "../../../indexes/system";
 import { type IndexDeclaration } from "../../../indexes/types";
 
 /**
@@ -98,6 +99,7 @@ export function createSqliteTables(
 ) {
   const n: SqliteTableNames = { ...DEFAULT_TABLE_NAMES, ...names };
   const indexes = options.indexes ?? [];
+  assertNoSystemIndexNameCollision(indexes, n);
 
   const nodes = sqliteTable(
     n.nodes,

--- a/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/schema/sqlite.ts
@@ -31,6 +31,7 @@ import {
 import {
   buildSqliteEdgeIndexBuilders,
   buildSqliteNodeIndexBuilders,
+  buildSqliteSystemIndexBuilders,
 } from "../../../indexes/drizzle";
 import { type IndexDeclaration } from "../../../indexes/types";
 
@@ -114,23 +115,9 @@ export function createSqliteTables(
     },
     (t) => [
       primaryKey({ columns: [t.graphId, t.kind, t.id] }),
-      index(`${n.nodes}_kind_idx`).on(t.graphId, t.kind),
-      index(`${n.nodes}_kind_created_idx`).on(
-        t.graphId,
-        t.kind,
-        t.deletedAt,
-        t.createdAt,
-      ),
-      index(`${n.nodes}_deleted_idx`).on(t.graphId, t.deletedAt),
-      index(`${n.nodes}_valid_idx`).on(t.graphId, t.validFrom, t.validTo),
-      // Bare-id lookup: the primary key leads with `kind` (graph_id, kind, id),
-      // so a `WHERE graph_id = ? AND id = ?` probe that doesn't know the kind
-      // can't seek it — SQLite falls back to a graph_id-only scan of every node
-      // in the graph (~3M at LDBC SF1). `store.algorithms.degree`'s
-      // node-kind subquery does exactly that lookup (it resolves the seed's
-      // kind by id), so without this index degree is a full nodes scan (~95ms
-      // at SF1). See typegraph#280.
-      index(`${n.nodes}_id_idx`).on(t.graphId, t.id),
+      // System indexes come from SYSTEM_INDEX_DECLARATIONS (single source
+      // for both dialects + the runtime materializer).
+      ...buildSqliteSystemIndexBuilders("nodes", n.nodes, t),
       ...buildSqliteNodeIndexBuilders(t, indexes),
     ],
   );
@@ -154,55 +141,7 @@ export function createSqliteTables(
     },
     (t) => [
       primaryKey({ columns: [t.graphId, t.id] }),
-      index(`${n.edges}_kind_idx`).on(t.graphId, t.kind),
-      // Directional traversal index (outgoing): supports endpoint lookups
-      // and extra filtering by edge kind / target kind. Includes every
-      // system column the compiled query's soft-delete/temporal-validity
-      // predicate touches (deleted_at, valid_from, valid_to), trailed by
-      // to_id — the compiled traversal join reads `n.id = e.to_id` for an
-      // outgoing traversal (standard-builders.ts), so without to_id here
-      // the join still fetches the edge's heap row for that one column
-      // even with the seek/predicate columns covered.
-      index(`${n.edges}_from_idx`).on(
-        t.graphId,
-        t.fromKind,
-        t.fromId,
-        t.kind,
-        t.toKind,
-        t.deletedAt,
-        t.validFrom,
-        t.validTo,
-        t.toId,
-      ),
-      // Directional traversal index (incoming): mirrors from_idx for
-      // reverse traversals, trailed by from_id for the same reason
-      // (`n.id = e.from_id` for an incoming traversal).
-      index(`${n.edges}_to_idx`).on(
-        t.graphId,
-        t.toKind,
-        t.toId,
-        t.kind,
-        t.fromKind,
-        t.deletedAt,
-        t.validFrom,
-        t.validTo,
-        t.fromId,
-      ),
-      index(`${n.edges}_kind_created_idx`).on(
-        t.graphId,
-        t.kind,
-        t.deletedAt,
-        t.createdAt,
-      ),
-      index(`${n.edges}_deleted_idx`).on(t.graphId, t.deletedAt),
-      index(`${n.edges}_valid_idx`).on(t.graphId, t.validFrom, t.validTo),
-      index(`${n.edges}_cardinality_idx`).on(
-        t.graphId,
-        t.kind,
-        t.fromKind,
-        t.fromId,
-        t.validTo,
-      ),
+      ...buildSqliteSystemIndexBuilders("edges", n.edges, t),
       ...buildSqliteEdgeIndexBuilders(t, indexes),
     ],
   );
@@ -230,25 +169,7 @@ export function createSqliteTables(
     },
     (t) => [
       primaryKey({ columns: [t.historyId] }),
-      index(`${n.recordedNodes}_entity_idx`).on(
-        t.graphId,
-        t.kind,
-        t.id,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedNodes}_open_idx`).on(t.graphId, t.recordedTo),
-      index(`${n.recordedNodes}_valid_idx`).on(
-        t.graphId,
-        t.validFrom,
-        t.validTo,
-      ),
-      // Bare-id lookup parity with the live nodes table: recorded-pinned
-      // reads swap this relation in as the node source, and `_entity_idx`
-      // leads with `kind`, so the same kind-by-bare-id probe (e.g.
-      // `degree()` at a recorded coordinate) would otherwise scan every
-      // historical version in the graph. See typegraph#280.
-      index(`${n.recordedNodes}_id_idx`).on(t.graphId, t.id),
+      ...buildSqliteSystemIndexBuilders("recordedNodes", n.recordedNodes, t),
     ],
   );
 
@@ -278,37 +199,7 @@ export function createSqliteTables(
     },
     (t) => [
       primaryKey({ columns: [t.historyId] }),
-      index(`${n.recordedEdges}_entity_idx`).on(
-        t.graphId,
-        t.kind,
-        t.id,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedEdges}_open_idx`).on(t.graphId, t.recordedTo),
-      index(`${n.recordedEdges}_from_idx`).on(
-        t.graphId,
-        t.fromKind,
-        t.fromId,
-        t.kind,
-        t.toKind,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedEdges}_to_idx`).on(
-        t.graphId,
-        t.toKind,
-        t.toId,
-        t.kind,
-        t.fromKind,
-        t.recordedFrom,
-        t.recordedTo,
-      ),
-      index(`${n.recordedEdges}_valid_idx`).on(
-        t.graphId,
-        t.validFrom,
-        t.validTo,
-      ),
+      ...buildSqliteSystemIndexBuilders("recordedEdges", n.recordedEdges, t),
     ],
   );
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1377,10 +1377,7 @@ export function createSqliteBackend(
         )
         .onConflictDoUpdate({
           target: t.indexName,
-          set: buildMaterializationOnConflictSet(
-            t.materializedAt,
-            params.materializedAt,
-          ),
+          set: buildMaterializationOnConflictSet(params.materializedAt),
         });
     },
 

--- a/packages/typegraph/src/core/types.ts
+++ b/packages/typegraph/src/core/types.ts
@@ -18,8 +18,13 @@ export type KindEntity = "node" | "edge";
  * kind directly (they back a per-`(kind, field)` typed embedding table
  * owned by the active `VectorStrategy`), but they participate in the same
  * materialization and diff pipelines, so they share this discriminator.
+ *
+ * `"system"` marks TypeGraph's own base-relation indexes
+ * (`SYSTEM_INDEX_DECLARATIONS`) — graph-independent, but materialized and
+ * status-tracked through the same pipeline; their status rows carry the
+ * relation key (e.g. `"recordedNodes"`) in the `kind` column.
  */
-export type IndexEntity = "node" | "edge" | "vector";
+export type IndexEntity = "node" | "edge" | "vector" | "system";
 
 /**
  * Field-level null-check operations that round-trip through persisted

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -355,6 +355,7 @@ export type {
   MaterializeRemovalsEntry,
   MaterializeRemovalsOptions,
   MaterializeRemovalsResult,
+  MaterializeSystemIndexesOptions,
   MeasurableHistoryTransactionContext,
   OntologyIntrospection,
   RebuildFulltextOptions,
@@ -619,6 +620,9 @@ export {
   type NodeIndexWhereBuilder,
   notWhere,
   orWhere,
+  SYSTEM_INDEX_DECLARATIONS,
+  type SystemIndexDeclaration,
+  type SystemIndexTable,
 } from "./indexes";
 
 // ============================================================

--- a/packages/typegraph/src/indexes/drizzle.ts
+++ b/packages/typegraph/src/indexes/drizzle.ts
@@ -389,17 +389,26 @@ function getSqliteEdgeSystemColumn(
 // SQL wrappers) so the DDL generator renders plain quoted column names —
 // byte-identical to the runtime DDL `materializeSystemIndexes` emits.
 
-type SystemIndexColumns<C> = Readonly<Record<string, C>>;
+type SystemIndexColumns<C extends { name: string }> = Readonly<
+  Record<string, C>
+>;
 
-function resolveSystemIndexColumns<C>(
+/**
+ * Resolves a declaration's physical column names against the table's own
+ * column objects by each column's `.name` — the SQL name Drizzle carries on
+ * the column itself — so no naming convention sits between the declaration
+ * and the schema. A column the table doesn't define throws at
+ * table-construction time (exercised by the system-index parity tests).
+ */
+function resolveSystemIndexColumns<C extends { name: string }>(
   declaration: SystemIndexDeclaration,
   columns: SystemIndexColumns<C>,
 ): readonly [C, ...C[]] {
+  const byPhysicalName = new Map(
+    Object.values(columns).map((column) => [column.name, column]),
+  );
   const resolved = declaration.columns.map((column) => {
-    const camel = column.replaceAll(/_([a-z])/gu, (_match, letter: string) =>
-      letter.toUpperCase(),
-    );
-    const value = columns[camel];
+    const value = byPhysicalName.get(column);
     if (value === undefined) {
       throw new Error(
         `System index "${declaration.table}_${declaration.suffix}" references ` +
@@ -412,17 +421,37 @@ function resolveSystemIndexColumns<C>(
   return resolved as [C, ...C[]];
 }
 
+/**
+ * The two dialect variants do no dialect-specific work (no unique, no
+ * where, no expression compilation — unlike the node/edge builder pairs
+ * above), so they share one body parameterized by the dialect's index
+ * factory.
+ */
+function buildSystemIndexBuilders<C extends { name: string }, B>(
+  tableKey: SystemIndexTable,
+  physicalTableName: string,
+  columns: SystemIndexColumns<C>,
+  indexFactory: (name: string) => { on: (...cols: [C, ...C[]]) => B },
+): readonly B[] {
+  return SYSTEM_INDEX_DECLARATIONS.filter(
+    (declaration) => declaration.table === tableKey,
+  ).map((declaration) =>
+    indexFactory(systemIndexName(physicalTableName, declaration.suffix)).on(
+      ...resolveSystemIndexColumns(declaration, columns),
+    ),
+  );
+}
+
 export function buildSqliteSystemIndexBuilders(
   tableKey: SystemIndexTable,
   physicalTableName: string,
   columns: SystemIndexColumns<SQLiteColumn>,
 ): readonly SqliteIndexBuilder[] {
-  return SYSTEM_INDEX_DECLARATIONS.filter(
-    (declaration) => declaration.table === tableKey,
-  ).map((declaration) =>
-    sqliteIndex(systemIndexName(physicalTableName, declaration.suffix)).on(
-      ...resolveSystemIndexColumns(declaration, columns),
-    ),
+  return buildSystemIndexBuilders(
+    tableKey,
+    physicalTableName,
+    columns,
+    (name) => sqliteIndex(name),
   );
 }
 
@@ -431,12 +460,11 @@ export function buildPostgresSystemIndexBuilders(
   physicalTableName: string,
   columns: SystemIndexColumns<PgColumn>,
 ): readonly PgIndexBuilder[] {
-  return SYSTEM_INDEX_DECLARATIONS.filter(
-    (declaration) => declaration.table === tableKey,
-  ).map((declaration) =>
-    pgIndex(systemIndexName(physicalTableName, declaration.suffix)).on(
-      ...resolveSystemIndexColumns(declaration, columns),
-    ),
+  return buildSystemIndexBuilders(
+    tableKey,
+    physicalTableName,
+    columns,
+    (name) => pgIndex(name),
   );
 }
 

--- a/packages/typegraph/src/indexes/drizzle.ts
+++ b/packages/typegraph/src/indexes/drizzle.ts
@@ -2,11 +2,13 @@ import { type SQL, sql, type SQLWrapper } from "drizzle-orm";
 import {
   index as pgIndex,
   type IndexBuilder as PgIndexBuilder,
+  type PgColumn,
   uniqueIndex as pgUniqueIndex,
 } from "drizzle-orm/pg-core";
 import {
   index as sqliteIndex,
   type IndexBuilder as SqliteIndexBuilder,
+  type SQLiteColumn,
   uniqueIndex as sqliteUniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
@@ -16,6 +18,12 @@ import {
   compileNodeIndexKeys,
   type IndexCompilationContext,
 } from "./compiler";
+import {
+  SYSTEM_INDEX_DECLARATIONS,
+  type SystemIndexDeclaration,
+  systemIndexName,
+  type SystemIndexTable,
+} from "./system";
 import {
   type EdgeIndexDeclaration,
   type IndexDeclaration,
@@ -369,6 +377,67 @@ function getSqliteEdgeSystemColumn(
       throw new Error(`Unsupported edge system column for indexes: ${column}`);
     }
   }
+}
+
+// ============================================================
+// System indexes (both dialects)
+// ============================================================
+//
+// The schema factories derive their system-index Drizzle builders from
+// `SYSTEM_INDEX_DECLARATIONS` so both dialects emit the same index set by
+// construction. The builders receive the table's real column objects (not
+// SQL wrappers) so the DDL generator renders plain quoted column names —
+// byte-identical to the runtime DDL `materializeSystemIndexes` emits.
+
+type SystemIndexColumns<C> = Readonly<Record<string, C>>;
+
+function resolveSystemIndexColumns<C>(
+  declaration: SystemIndexDeclaration,
+  columns: SystemIndexColumns<C>,
+): readonly [C, ...C[]] {
+  const resolved = declaration.columns.map((column) => {
+    const camel = column.replaceAll(/_([a-z])/gu, (_match, letter: string) =>
+      letter.toUpperCase(),
+    );
+    const value = columns[camel];
+    if (value === undefined) {
+      throw new Error(
+        `System index "${declaration.table}_${declaration.suffix}" references ` +
+          `a column "${column}" the ${declaration.table} table does not define`,
+      );
+    }
+    return value;
+  });
+  // `declaration.columns` is non-empty by type, so `resolved` is too.
+  return resolved as [C, ...C[]];
+}
+
+export function buildSqliteSystemIndexBuilders(
+  tableKey: SystemIndexTable,
+  physicalTableName: string,
+  columns: SystemIndexColumns<SQLiteColumn>,
+): readonly SqliteIndexBuilder[] {
+  return SYSTEM_INDEX_DECLARATIONS.filter(
+    (declaration) => declaration.table === tableKey,
+  ).map((declaration) =>
+    sqliteIndex(systemIndexName(physicalTableName, declaration.suffix)).on(
+      ...resolveSystemIndexColumns(declaration, columns),
+    ),
+  );
+}
+
+export function buildPostgresSystemIndexBuilders(
+  tableKey: SystemIndexTable,
+  physicalTableName: string,
+  columns: SystemIndexColumns<PgColumn>,
+): readonly PgIndexBuilder[] {
+  return SYSTEM_INDEX_DECLARATIONS.filter(
+    (declaration) => declaration.table === tableKey,
+  ).map((declaration) =>
+    pgIndex(systemIndexName(physicalTableName, declaration.suffix)).on(
+      ...resolveSystemIndexColumns(declaration, columns),
+    ),
+  );
 }
 
 // ============================================================

--- a/packages/typegraph/src/indexes/index.ts
+++ b/packages/typegraph/src/indexes/index.ts
@@ -54,6 +54,12 @@ export {
   buildSqliteNodeIndexBuilders,
 } from "./drizzle";
 export { toDeclaredIndex, toDeclaredIndexes } from "./profiler";
+export {
+  generateSystemIndexDDL,
+  SYSTEM_INDEX_DECLARATIONS,
+  type SystemIndexDeclaration,
+  type SystemIndexTable,
+} from "./system";
 export type {
   EdgeIndexConfig,
   EdgeIndexDeclaration,

--- a/packages/typegraph/src/indexes/system.ts
+++ b/packages/typegraph/src/indexes/system.ts
@@ -21,6 +21,7 @@
  * operator drops the old physical index. Rename (new suffix) instead,
  * exactly like graph-declared indexes.
  */
+import { quoteIdentifier } from "../query/dialect/vector-strategy";
 
 /** The TypeGraph relations that carry system indexes. */
 export type SystemIndexTable =
@@ -260,10 +261,6 @@ export function systemIndexName(
   suffix: string,
 ): string {
   return `${physicalTableName}_${suffix}`;
-}
-
-function quoteIdentifier(name: string): string {
-  return `"${name.replaceAll('"', '""')}"`;
 }
 
 /**

--- a/packages/typegraph/src/indexes/system.ts
+++ b/packages/typegraph/src/indexes/system.ts
@@ -26,7 +26,7 @@
  * strands the old physical index (the runner only adds). When the first
  * rename actually happens, add a retired-suffixes list + drop path here.
  */
-import { quoteIdentifier } from "../query/dialect/vector-strategy";
+import { quoteIdentifier, shortHash } from "../query/dialect/vector-strategy";
 
 /** The TypeGraph relations that carry system indexes. */
 export type SystemIndexTable =
@@ -260,12 +260,81 @@ export function resolveSystemIndexTableName(
   return overrides?.[table] ?? DEFAULT_SYSTEM_INDEX_TABLE_NAMES[table];
 }
 
-/** Physical index name: `${physicalTableName}_${suffix}`. */
+/**
+ * PostgreSQL truncates identifiers to NAMEDATALEN-1 = 63 bytes SILENTLY —
+ * two suffixes of one long custom table name would collide after
+ * truncation, and the catalog probes (which compare by exact name) would
+ * never match the stored name, re-attempting the build on every boot.
+ * SQLite has no such limit but uses the same bound so the two dialects'
+ * index sets stay in byte-for-byte parity. (Char-based like the vector
+ * identifier bound — multibyte table names are out of scope.)
+ */
+const MAX_SQL_IDENTIFIER_LENGTH = 63;
+
+/**
+ * Physical index name: `${physicalTableName}_${suffix}`, deterministically
+ * truncated + hash-suffixed past the 63-char identifier bound so distinct
+ * indexes stay distinct. Single choke point — the Drizzle builders, the
+ * runtime DDL, the catalog probes, and the status keys all derive the
+ * name here, so they can never disagree.
+ */
 export function systemIndexName(
   physicalTableName: string,
   suffix: string,
 ): string {
-  return `${physicalTableName}_${suffix}`;
+  const full = `${physicalTableName}_${suffix}`;
+  if (full.length <= MAX_SQL_IDENTIFIER_LENGTH) return full;
+  const hash = shortHash(JSON.stringify([physicalTableName, suffix]));
+  return `${full.slice(0, MAX_SQL_IDENTIFIER_LENGTH - 1 - hash.length)}_${hash}`;
+}
+
+/**
+ * Every system index name for a deployment's (possibly overridden) table
+ * names. Graph-declared index names must not collide with these: a
+ * colliding `CREATE INDEX IF NOT EXISTS` would silently no-op against the
+ * system index (wrong shape) while recording a false success — see the
+ * guards in the schema factories and `materializeIndexes`.
+ */
+export function resolveSystemIndexNames(
+  overrides:
+    Readonly<Partial<Record<SystemIndexTable, string | undefined>>> | undefined,
+): ReadonlySet<string> {
+  return new Set(
+    SYSTEM_INDEX_DECLARATIONS.map((declaration) =>
+      systemIndexName(
+        resolveSystemIndexTableName(declaration.table, overrides),
+        declaration.suffix,
+      ),
+    ),
+  );
+}
+
+/**
+ * Rejects graph-declared indexes whose names collide with this
+ * deployment's system index names. Called by both dialect schema
+ * factories so a colliding declaration fails at table-definition time
+ * instead of silently no-opping against the (differently shaped) system
+ * index at CREATE INDEX IF NOT EXISTS time. `materializeIndexes` applies
+ * the same check per-declaration on its runtime path.
+ */
+export function assertNoSystemIndexNameCollision(
+  indexes: readonly Readonly<{ name: string }>[],
+  overrides:
+    Readonly<Partial<Record<SystemIndexTable, string | undefined>>> | undefined,
+): void {
+  if (indexes.length === 0) return;
+  const reserved = resolveSystemIndexNames(overrides);
+  for (const index of indexes) {
+    if (reserved.has(index.name)) {
+      throw new Error(
+        `Index name "${index.name}" collides with a TypeGraph system ` +
+          `index. Choose a different name — system index names are ` +
+          `reserved, and a same-named CREATE INDEX IF NOT EXISTS would ` +
+          `silently no-op against the system index instead of creating ` +
+          `the declared one.`,
+      );
+    }
+  }
 }
 
 /**

--- a/packages/typegraph/src/indexes/system.ts
+++ b/packages/typegraph/src/indexes/system.ts
@@ -1,0 +1,289 @@
+/**
+ * System-index declarations — the single source of truth for the plain
+ * btree indexes TypeGraph ships on its own relations.
+ *
+ * Both dialect schema factories (`createSqliteTables` /
+ * `createPostgresTables`) derive their Drizzle index builders from this
+ * list, so the two dialects cannot drift, and
+ * `materializeSystemIndexes()` derives the same indexes as runtime DDL so
+ * an index added in a new library version reaches already-initialized
+ * databases (bootstrap DDL only runs on first boot — see
+ * `loadActiveSchemaWithBootstrap`).
+ *
+ * Scope: non-unique btree column indexes on the four graph relations,
+ * where performance iteration actually happens. Primary keys, unique /
+ * partial-unique constraints, and status-table indexes are structural —
+ * they are created with their table and never retrofitted — and stay in
+ * the schema files.
+ *
+ * Changing a declaration's shape under the same suffix is a signature
+ * drift: `materializeSystemIndexes` reports `failed` for it until the
+ * operator drops the old physical index. Rename (new suffix) instead,
+ * exactly like graph-declared indexes.
+ */
+
+/** The TypeGraph relations that carry system indexes. */
+export type SystemIndexTable =
+  "nodes" | "edges" | "recordedNodes" | "recordedEdges";
+
+type LiveColumn =
+  | "graph_id"
+  | "kind"
+  | "id"
+  | "deleted_at"
+  | "valid_from"
+  | "valid_to"
+  | "created_at";
+
+type LiveEdgeColumn =
+  LiveColumn | "from_kind" | "from_id" | "to_kind" | "to_id";
+
+type RecordedColumn =
+  | "graph_id"
+  | "kind"
+  | "id"
+  | "valid_from"
+  | "valid_to"
+  | "recorded_from"
+  | "recorded_to";
+
+type RecordedEdgeColumn =
+  RecordedColumn | "from_kind" | "from_id" | "to_kind" | "to_id";
+
+type SystemIndexColumnsFor<T extends SystemIndexTable> =
+  T extends "nodes" ? LiveColumn
+  : T extends "edges" ? LiveEdgeColumn
+  : T extends "recordedNodes" ? RecordedColumn
+  : RecordedEdgeColumn;
+
+type SystemIndexDeclarationFor<T extends SystemIndexTable> = Readonly<{
+  table: T;
+  /** Physical index name is `${physicalTableName}_${suffix}`. */
+  suffix: string;
+  columns: readonly [SystemIndexColumnsFor<T>, ...SystemIndexColumnsFor<T>[]];
+}>;
+
+export type SystemIndexDeclaration =
+  | SystemIndexDeclarationFor<"nodes">
+  | SystemIndexDeclarationFor<"edges">
+  | SystemIndexDeclarationFor<"recordedNodes">
+  | SystemIndexDeclarationFor<"recordedEdges">;
+
+export const SYSTEM_INDEX_DECLARATIONS: readonly SystemIndexDeclaration[] = [
+  // ---------------------------------------------------------- nodes
+  { table: "nodes", suffix: "kind_idx", columns: ["graph_id", "kind"] },
+  // Listing shape: kind partition ordered by creation with the
+  // soft-delete column ahead of it so `deleted_at IS NULL` list queries
+  // stay index-served.
+  {
+    table: "nodes",
+    suffix: "kind_created_idx",
+    columns: ["graph_id", "kind", "deleted_at", "created_at"],
+  },
+  {
+    table: "nodes",
+    suffix: "deleted_idx",
+    columns: ["graph_id", "deleted_at"],
+  },
+  {
+    table: "nodes",
+    suffix: "valid_idx",
+    columns: ["graph_id", "valid_from", "valid_to"],
+  },
+  // Bare-id lookup: the primary key leads with `kind` (graph_id, kind,
+  // id), so a `WHERE graph_id = ? AND id = ?` probe that doesn't know the
+  // kind can't seek it — SQLite falls back to a graph_id-only scan of
+  // every node in the graph (~3M at LDBC SF1).
+  // `store.algorithms.degree`'s node-kind subquery does exactly that
+  // lookup (it resolves the seed's kind by id), so without this index
+  // degree is a full nodes scan (~95ms at SF1). See typegraph#280.
+  { table: "nodes", suffix: "id_idx", columns: ["graph_id", "id"] },
+
+  // ---------------------------------------------------------- edges
+  { table: "edges", suffix: "kind_idx", columns: ["graph_id", "kind"] },
+  // Directional traversal index (outgoing): supports endpoint lookups
+  // and extra filtering by edge kind / target kind. Includes every
+  // system column the compiled query's soft-delete/temporal-validity
+  // predicate touches (deleted_at, valid_from, valid_to), trailed by
+  // to_id — the compiled traversal join reads `n.id = e.to_id` for an
+  // outgoing traversal (standard-builders.ts), so without to_id here
+  // the join still fetches the edge's heap row for that one column
+  // even with the seek/predicate columns covered.
+  {
+    table: "edges",
+    suffix: "from_idx",
+    columns: [
+      "graph_id",
+      "from_kind",
+      "from_id",
+      "kind",
+      "to_kind",
+      "deleted_at",
+      "valid_from",
+      "valid_to",
+      "to_id",
+    ],
+  },
+  // Directional traversal index (incoming): mirrors from_idx for
+  // reverse traversals, trailed by from_id for the same reason
+  // (`n.id = e.from_id` for an incoming traversal).
+  {
+    table: "edges",
+    suffix: "to_idx",
+    columns: [
+      "graph_id",
+      "to_kind",
+      "to_id",
+      "kind",
+      "from_kind",
+      "deleted_at",
+      "valid_from",
+      "valid_to",
+      "from_id",
+    ],
+  },
+  {
+    table: "edges",
+    suffix: "kind_created_idx",
+    columns: ["graph_id", "kind", "deleted_at", "created_at"],
+  },
+  {
+    table: "edges",
+    suffix: "deleted_idx",
+    columns: ["graph_id", "deleted_at"],
+  },
+  {
+    table: "edges",
+    suffix: "valid_idx",
+    columns: ["graph_id", "valid_from", "valid_to"],
+  },
+  // Cardinality enforcement: the one-per-endpoint check probes for a
+  // currently-valid edge of a kind from a specific endpoint.
+  {
+    table: "edges",
+    suffix: "cardinality_idx",
+    columns: ["graph_id", "kind", "from_kind", "from_id", "valid_to"],
+  },
+
+  // ---------------------------------------------------------- recordedNodes
+  {
+    table: "recordedNodes",
+    suffix: "entity_idx",
+    columns: ["graph_id", "kind", "id", "recorded_from", "recorded_to"],
+  },
+  {
+    table: "recordedNodes",
+    suffix: "open_idx",
+    columns: ["graph_id", "recorded_to"],
+  },
+  {
+    table: "recordedNodes",
+    suffix: "valid_idx",
+    columns: ["graph_id", "valid_from", "valid_to"],
+  },
+  // Bare-id lookup parity with the live nodes table: recorded-pinned
+  // reads swap this relation in as the node source, and `entity_idx`
+  // leads with `kind`, so the same kind-by-bare-id probe (e.g.
+  // `degree()` at a recorded coordinate) would otherwise scan every
+  // historical version in the graph. See typegraph#280.
+  { table: "recordedNodes", suffix: "id_idx", columns: ["graph_id", "id"] },
+
+  // ---------------------------------------------------------- recordedEdges
+  {
+    table: "recordedEdges",
+    suffix: "entity_idx",
+    columns: ["graph_id", "kind", "id", "recorded_from", "recorded_to"],
+  },
+  {
+    table: "recordedEdges",
+    suffix: "open_idx",
+    columns: ["graph_id", "recorded_to"],
+  },
+  {
+    table: "recordedEdges",
+    suffix: "from_idx",
+    columns: [
+      "graph_id",
+      "from_kind",
+      "from_id",
+      "kind",
+      "to_kind",
+      "recorded_from",
+      "recorded_to",
+    ],
+  },
+  {
+    table: "recordedEdges",
+    suffix: "to_idx",
+    columns: [
+      "graph_id",
+      "to_kind",
+      "to_id",
+      "kind",
+      "from_kind",
+      "recorded_from",
+      "recorded_to",
+    ],
+  },
+  {
+    table: "recordedEdges",
+    suffix: "valid_idx",
+    columns: ["graph_id", "valid_from", "valid_to"],
+  },
+];
+
+/** Default physical table names for the system-index relations. */
+const DEFAULT_SYSTEM_INDEX_TABLE_NAMES: Readonly<
+  Record<SystemIndexTable, string>
+> = {
+  nodes: "typegraph_nodes",
+  edges: "typegraph_edges",
+  recordedNodes: "typegraph_recorded_nodes",
+  recordedEdges: "typegraph_recorded_edges",
+};
+
+/**
+ * Resolves the physical table name for a system-index relation, honoring
+ * a backend's table-name overrides.
+ */
+export function resolveSystemIndexTableName(
+  table: SystemIndexTable,
+  overrides:
+    Readonly<Partial<Record<SystemIndexTable, string | undefined>>> | undefined,
+): string {
+  return overrides?.[table] ?? DEFAULT_SYSTEM_INDEX_TABLE_NAMES[table];
+}
+
+/** Physical index name: `${physicalTableName}_${suffix}`. */
+export function systemIndexName(
+  physicalTableName: string,
+  suffix: string,
+): string {
+  return `${physicalTableName}_${suffix}`;
+}
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`;
+}
+
+/**
+ * Runtime DDL for one system index — byte-compatible with the index the
+ * bootstrap path creates from the Drizzle schema (same name, same
+ * columns), plus `CONCURRENTLY` where the dialect supports building
+ * without blocking writes.
+ */
+export function generateSystemIndexDDL(
+  declaration: SystemIndexDeclaration,
+  physicalTableName: string,
+  options: Readonly<{ concurrent: boolean }>,
+): string {
+  const name = quoteIdentifier(
+    systemIndexName(physicalTableName, declaration.suffix),
+  );
+  const table = quoteIdentifier(physicalTableName);
+  const columns = declaration.columns
+    .map((column) => quoteIdentifier(column))
+    .join(", ");
+  const concurrently = options.concurrent ? "CONCURRENTLY " : "";
+  return `CREATE INDEX ${concurrently}IF NOT EXISTS ${name} ON ${table} (${columns});`;
+}

--- a/packages/typegraph/src/indexes/system.ts
+++ b/packages/typegraph/src/indexes/system.ts
@@ -19,7 +19,12 @@
  * Changing a declaration's shape under the same suffix is a signature
  * drift: `materializeSystemIndexes` reports `failed` for it until the
  * operator drops the old physical index. Rename (new suffix) instead,
- * exactly like graph-declared indexes.
+ * exactly like graph-declared indexes. Two acknowledged limits of that
+ * contract: on databases whose indexes were bootstrap-created (no status
+ * rows) an in-place reshape is undetectable at runtime — the rename rule
+ * is enforced by review and the parity tests; and a renamed suffix
+ * strands the old physical index (the runner only adds). When the first
+ * rename actually happens, add a retired-suffixes list + drop path here.
  */
 import { quoteIdentifier } from "../query/dialect/vector-strategy";
 

--- a/packages/typegraph/src/query/dialect/vector-strategy.ts
+++ b/packages/typegraph/src/query/dialect/vector-strategy.ts
@@ -381,7 +381,7 @@ function sanitizeIdentifierPart(value: string): string {
  * identifiers. Self-contained so the strategy layer has no backend-runtime
  * dependency.
  */
-function shortHash(input: string): string {
+export function shortHash(input: string): string {
   let h1 = 0xde_ad_be_ef;
   let h2 = 0x41_c6_ce_57;
   for (let index = 0; index < input.length; index++) {

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -276,6 +276,15 @@ export type SchemaManagerOptions = Readonly<{
   autoMigrate?: boolean;
   /** If true, throw on breaking changes. Default: true */
   throwOnBreaking?: boolean;
+  /**
+   * Whether `createStoreWithSchema` brings the base-relation system
+   * indexes up to the running library version at boot. Default:
+   * `"materialize"`. Pass `"skip"` when a boot must not run potentially
+   * long index builds inline (e.g. a large PostgreSQL deployment behind a
+   * readiness probe) — then run `store.materializeSystemIndexes()`
+   * out-of-band after upgrading.
+   */
+  systemIndexes?: "materialize" | "skip";
   /** Called before a safe auto-migration is applied. For observability only. */
   onBeforeMigrate?: (context: MigrationHookContext) => void | Promise<void>;
   /** Called after a safe auto-migration is applied. For observability only. */

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -83,6 +83,7 @@ export type {
   MaterializeIndexesEntry,
   MaterializeIndexesOptions,
   MaterializeIndexesResult,
+  MaterializeSystemIndexesOptions,
 } from "./materialize-indexes";
 export type {
   MaterializeRemovalsEntry,

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -63,7 +63,10 @@ import { sortedReplacer } from "../schema/canonical";
 import { serializeIndexDeclaration } from "../schema/serializer";
 import { nowIso } from "../utils/date";
 import { sha256Hex } from "../utils/hash";
-import { ensureFocusedStatusTable } from "./materialize-shared";
+import {
+  ensureFocusedStatusTable,
+  runBucketedMaterialization,
+} from "./materialize-shared";
 
 /**
  * Cross-caller build claim timing (Postgres).
@@ -288,61 +291,19 @@ export async function materializeIndexes(
         invalidLeftovers,
       );
 
-  if (options.stopOnError === true) {
-    const results: MaterializeIndexesEntry[] = [];
-    for (const declaration of candidates) {
-      const entry = await materializeEntry(declaration);
-      results.push(entry);
-      if (entry.status === "failed") break;
-    }
-    await refreshStatisticsAfterCreation(
-      backend,
-      results,
-      options,
-      ddlOptions.concurrent,
-    );
-    return { results };
-  }
-
   // Postgres restricts `CREATE INDEX CONCURRENTLY` to one in-flight
-  // build per relation, so we group declarations by target table and
-  // run each group sequentially while running the groups in parallel.
+  // build per relation, so declarations group by target relation and
+  // each group runs sequentially while the groups run in parallel.
   // Typical schemas land in three buckets (nodes, edges, vector
   // embeddings), giving a ~3× round-trip win over fully sequential
   // without ever issuing two CONCURRENTLY builds against the same
   // relation. SQLite ignores the grouping (writes serialize at the
   // engine level either way).
-  const buckets = new Map<IndexEntity, IndexDeclaration[]>();
-  for (const declaration of candidates) {
-    const key = parallelBucketKey(declaration);
-    const list = buckets.get(key);
-    if (list === undefined) buckets.set(key, [declaration]);
-    else list.push(declaration);
-  }
-
-  const bucketResults = await Promise.all(
-    [...buckets.values()].map(async (group) => {
-      const out: MaterializeIndexesEntry[] = [];
-      for (const declaration of group) {
-        out.push(await materializeEntry(declaration));
-      }
-      return out;
-    }),
-  );
-
-  // Flatten in declaration order so callers see a stable result shape
-  // regardless of how the buckets resolved.
-  const byDeclaration = new Map<IndexDeclaration, MaterializeIndexesEntry>();
-  let bucketIndex = 0;
-  for (const group of buckets.values()) {
-    const entries = bucketResults[bucketIndex]!;
-    for (const [declarationIndex, declaration] of group.entries()) {
-      byDeclaration.set(declaration, entries[declarationIndex]!);
-    }
-    bucketIndex += 1;
-  }
-  const results = candidates.map((declaration) =>
-    byDeclaration.get(declaration)!,
+  const results = await runBucketedMaterialization(
+    candidates,
+    options,
+    (declaration) => parallelBucketKey(declaration),
+    (declaration) => materializeEntry(declaration),
   );
   await refreshStatisticsAfterCreation(
     backend,
@@ -911,16 +872,58 @@ async function preloadInvalidIndexLeftovers(
   if (backend.dialect !== "postgres" || physicalIndexNames.length === 0) {
     return new Set();
   }
+  const { invalid } = await preloadPhysicalIndexStates(
+    backend,
+    physicalIndexNames,
+  );
+  return invalid;
+}
+
+type PhysicalIndexStates = Readonly<{
+  /** Names that exist as usable indexes in the engine catalog. */
+  valid: ReadonlySet<string>;
+  /** Postgres INVALID leftovers from interrupted CONCURRENTLY builds. */
+  invalid: ReadonlySet<string>;
+}>;
+
+/**
+ * Partitions `physicalIndexNames` by their catalog state in ONE query:
+ * `valid` (usable index exists) and `invalid` (Postgres CONCURRENTLY
+ * leftover needing the healing build path). SQLite has no invalid state,
+ * so its `invalid` set is always empty. The single query serves both the
+ * relational runner's leftover preload and the system runner's
+ * name-presence fast path — the two predicates are complementary halves
+ * of the same `pg_class ⋈ pg_index` probe.
+ */
+async function preloadPhysicalIndexStates(
+  backend: GraphBackend,
+  physicalIndexNames: readonly string[],
+): Promise<PhysicalIndexStates> {
+  const valid = new Set<string>();
+  const invalid = new Set<string>();
+  if (physicalIndexNames.length === 0) return { valid, invalid };
+  if (backend.dialect === "postgres") {
+    const rows = await backend.execute<{ name: string; valid: boolean }>(
+      asCompiledRowsSql(sql`
+        SELECT c.relname AS name, i.indisvalid AS valid
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE c.relname IN (${sqlValueList(physicalIndexNames)})
+      `),
+    );
+    for (const row of rows) (row.valid ? valid : invalid).add(row.name);
+    return { valid, invalid };
+  }
   const rows = await backend.execute<{ name: string }>(
     asCompiledRowsSql(sql`
-      SELECT c.relname AS name
-      FROM pg_class c
-      JOIN pg_index i ON i.indexrelid = c.oid
-      WHERE c.relname IN (${sqlValueList(physicalIndexNames)})
-        AND NOT i.indisvalid
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'index'
+        AND name IN (${sqlValueList(physicalIndexNames)})
     `),
   );
-  return new Set(rows.map((row) => row.name));
+  for (const row of rows) valid.add(row.name);
+  return { valid, invalid };
 }
 
 /**
@@ -1072,7 +1075,7 @@ type SystemIndexCandidate = Readonly<{
  * status table, drift signatures, invalid-leftover healing, and Postgres
  * `CREATE INDEX CONCURRENTLY` cross-caller claim protocol as
  * graph-declared indexes; on a database whose indexes all exist, a warm
- * call costs two reads (status preload + leftover preload) and runs no
+ * call costs two concurrent reads (status preload + catalog preload) and runs no
  * DDL after the first recorded success.
  *
  * Graph-independent: the declarations don't depend on `GraphDef`. The
@@ -1084,10 +1087,27 @@ type SystemIndexCandidate = Readonly<{
  * (valid, with no recorded status row) settles as `alreadyMaterialized`
  * from one bulk catalog read — no claim, no DDL, no status write. Status
  * rows are recorded only for genuine builds and failures, which keeps the
- * common boot (fresh bootstrap or wiped status table) at three reads
- * total. A status row that exists with a mismatching signature still
+ * common boot (fresh bootstrap or wiped status table) at two concurrent
+ * reads. A status row that exists with a mismatching signature still
  * surfaces as drift, exactly like graph-declared indexes.
  */
+/**
+ * Whether the backend carries every primitive index materialization
+ * requires (DDL execution + status reads/writes). The strict runners
+ * throw `ConfigurationError` exactly when this is false; the boot path
+ * (`createStoreWithSchema`) consults the same predicate to skip instead
+ * — one definition so the two contracts cannot drift apart.
+ */
+export function backendSupportsIndexMaterialization(
+  backend: GraphBackend,
+): boolean {
+  return (
+    backend.executeDdl !== undefined &&
+    backend.getIndexMaterialization !== undefined &&
+    backend.recordIndexMaterialization !== undefined
+  );
+}
+
 export async function materializeSystemIndexes(
   context: Readonly<{
     backend: RawBackend;
@@ -1138,19 +1158,16 @@ export async function materializeSystemIndexes(
       };
     });
 
+  // The two preloads are mutually independent reads (status table +
+  // catalog); running them concurrently keeps the warm boot at one
+  // round-trip latency after the ensure step.
   const statusKeys = candidates.map((candidate) => candidate.name);
-  const existingByStatusKey = await preloadMaterializations(
-    backend,
-    statusKeys,
-  );
-  const invalidLeftovers = await preloadInvalidIndexLeftovers(
-    backend,
-    statusKeys,
-  );
-  const physicallyPresent = await preloadValidPhysicalIndexes(
-    backend,
-    statusKeys,
-  );
+  const [existingByStatusKey, physicalStates] = await Promise.all([
+    preloadMaterializations(backend, statusKeys),
+    preloadPhysicalIndexStates(backend, statusKeys),
+  ]);
+  const { valid: physicallyPresent, invalid: invalidLeftovers } =
+    physicalStates;
 
   const materializeEntry = async (
     candidate: SystemIndexCandidate,
@@ -1160,9 +1177,15 @@ export async function materializeSystemIndexes(
       entity: "system",
       kind: candidate.declaration.table,
     };
-    // Name-presence fast path: valid physical index, no status row. A row
-    // with a mismatching signature must NOT take it — that is drift, and
-    // the frame below records it as a failure.
+    // Name-presence fast path: valid physical index, no status row — the
+    // normal steady state, since bootstrap DDL creates system indexes
+    // without recording status rows. Trusting name-presence is sound
+    // ONLY here: system index names are library-owned with a stable
+    // name→shape contract (reshaping requires a rename), whereas a
+    // graph-declared index name could collide with a foreign index whose
+    // shape only the recorded signature can vouch for. A row with a
+    // mismatching signature must NOT take the fast path — that is drift,
+    // and the frame below records it as a failure.
     if (
       existingByStatusKey.get(candidate.name) === undefined &&
       physicallyPresent.has(candidate.name)
@@ -1189,78 +1212,16 @@ export async function materializeSystemIndexes(
     });
   };
 
-  if (options.stopOnError === true) {
-    const results: MaterializeIndexesEntry[] = [];
-    for (const candidate of candidates) {
-      const result = await materializeEntry(candidate);
-      results.push(result);
-      if (result.status === "failed") break;
-    }
-    await refreshStatisticsAfterCreation(backend, results, options, concurrent);
-    return { results };
-  }
-
-  // Postgres restricts CREATE INDEX CONCURRENTLY to one in-flight build
-  // per relation — group by physical table, sequential within a group,
-  // groups in parallel (same shape as the relational bucketing above).
-  const buckets = new Map<string, SystemIndexCandidate[]>();
-  for (const candidate of candidates) {
-    const bucket = buckets.get(candidate.physicalTable);
-    if (bucket === undefined) buckets.set(candidate.physicalTable, [candidate]);
-    else bucket.push(candidate);
-  }
-  const bucketResults = await Promise.all(
-    [...buckets.values()].map(async (group) => {
-      const out: MaterializeIndexesEntry[] = [];
-      for (const candidate of group) {
-        out.push(await materializeEntry(candidate));
-      }
-      return out;
-    }),
+  // Same shape as the relational runner: one CONCURRENTLY build per
+  // relation, so buckets key on the physical table.
+  const results = await runBucketedMaterialization(
+    candidates,
+    options,
+    (candidate) => candidate.physicalTable,
+    (candidate) => materializeEntry(candidate),
   );
-  const byName = new Map<string, MaterializeIndexesEntry>();
-  for (const group of bucketResults) {
-    for (const result of group) byName.set(result.indexName, result);
-  }
-  const results = candidates.map((candidate) => byName.get(candidate.name)!);
   await refreshStatisticsAfterCreation(backend, results, options, concurrent);
   return { results };
-}
-
-/**
- * The subset of `physicalIndexNames` that exist as VALID indexes in the
- * engine catalog, in one query. Plain system indexes are fully identified
- * by name, so catalog presence is a sound "already built" signal — unlike
- * expression indexes, where only the recorded signature proves shape.
- * Postgres excludes INVALID leftovers (interrupted CONCURRENTLY builds)
- * so they fall through to the healing build path.
- */
-async function preloadValidPhysicalIndexes(
-  backend: GraphBackend,
-  physicalIndexNames: readonly string[],
-): Promise<ReadonlySet<string>> {
-  if (physicalIndexNames.length === 0) return new Set();
-  if (backend.dialect === "postgres") {
-    const rows = await backend.execute<{ name: string }>(
-      asCompiledRowsSql(sql`
-        SELECT c.relname AS name
-        FROM pg_class c
-        JOIN pg_index i ON i.indexrelid = c.oid
-        WHERE c.relname IN (${sqlValueList(physicalIndexNames)})
-          AND i.indisvalid
-      `),
-    );
-    return new Set(rows.map((row) => row.name));
-  }
-  const rows = await backend.execute<{ name: string }>(
-    asCompiledRowsSql(sql`
-      SELECT name
-      FROM sqlite_master
-      WHERE type = 'index'
-        AND name IN (${sqlValueList(physicalIndexNames)})
-    `),
-  );
-  return new Set(rows.map((row) => row.name));
 }
 
 /**

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -169,26 +169,10 @@ export async function materializeIndexes(
 ): Promise<MaterializeIndexesResult> {
   const { graph, graphId, backend, schemaVersion } = context;
 
-  if (backend.executeDdl === undefined) {
-    throw new ConfigurationError(
-      "store.materializeIndexes() requires a backend with `executeDdl` " +
-        "support. The bundled SQLite and Postgres backends provide it; " +
-        "a custom backend without `executeDdl` cannot run index DDL.",
-      { code: "MATERIALIZE_BACKEND_UNSUPPORTED" },
-    );
-  }
-  if (
-    backend.getIndexMaterialization === undefined ||
-    backend.recordIndexMaterialization === undefined
-  ) {
-    throw new ConfigurationError(
-      "store.materializeIndexes() requires a backend with index " +
-        "materialization status primitives. The bundled SQLite and " +
-        "Postgres backends provide them; a custom backend must implement " +
-        "`getIndexMaterialization` and `recordIndexMaterialization`.",
-      { code: "MATERIALIZE_BACKEND_UNSUPPORTED" },
-    );
-  }
+  assertBackendSupportsIndexMaterialization(
+    backend,
+    "store.materializeIndexes()",
+  );
 
   const declared = graph.indexes ?? [];
   const kindFilter =
@@ -428,7 +412,7 @@ async function materializeRelationalIndex(
       await backend.executeDdl!(ddl);
     },
     existingByStatusKey,
-    invalidLeftovers,
+    physicalRebuildPreload: invalidLeftovers,
   });
 }
 
@@ -522,7 +506,7 @@ async function materializeVectorIndex(
     driftLabel: "Vector index",
     run: () => backend.createVectorIndex!(params),
     existingByStatusKey,
-    invalidLeftovers,
+    physicalRebuildPreload: invalidLeftovers,
   });
 }
 
@@ -557,7 +541,27 @@ async function materializeOne(
     driftLabel: string;
     run: () => Promise<void>;
     existingByStatusKey: ReadonlyMap<string, IndexMaterializationRow>;
-    invalidLeftovers: ReadonlySet<string>;
+    /**
+     * Physical index names whose catalog state requires a rebuild despite
+     * a matching success row. Relational: INVALID `CONCURRENTLY`
+     * leftovers. System: leftovers plus physically absent indexes —
+     * name-presence identifies a system index, so absence is proof the
+     * recorded success is stale (dump/restore, manual drop).
+     */
+    physicalRebuildPreload: ReadonlySet<string>;
+    /**
+     * Fresh per-name variant of `physicalRebuildPreload` for the
+     * post-claim re-check (the preload is stale after waiting on another
+     * builder's claim). Defaults to the Postgres invalid-leftover query.
+     */
+    freshNeedsPhysicalRebuild?: (physicalIndexName: string) => Promise<boolean>;
+    /**
+     * Allow the physical-rebuild check to trigger even on backends
+     * without the claim protocol (SQLite). Sound only when the rebuild is
+     * a plain idempotent CREATE (system indexes); relational leftover
+     * healing requires the claim and keeps the default `false`.
+     */
+    rebuildWithoutClaim?: boolean;
   }>,
 ): Promise<MaterializeIndexesEntry> {
   // Narrowed by callsite — guaranteed defined when this is reached
@@ -568,7 +572,7 @@ async function materializeOne(
   const statusOverride =
     statusKey === declaration.name ? undefined : { statusName: statusKey };
 
-  // Pre-claim leftover check reads the bulk-preloaded set (one `pg_index`
+  // Pre-claim physical check reads the bulk-preloaded set (one catalog
   // query for all candidates), not one round-trip per index.
   const settled = await settleAgainstExisting(
     existingByStatusKey.get(statusKey),
@@ -580,8 +584,11 @@ async function materializeOne(
       statusKey,
       signature,
       driftLabel,
-      isInvalidLeftover: (physicalIndexName) =>
-        action.invalidLeftovers.has(physicalIndexName),
+      needsPhysicalRebuild: (physicalIndexName) =>
+        action.physicalRebuildPreload.has(physicalIndexName),
+      ...(action.rebuildWithoutClaim === undefined ?
+        {}
+      : { rebuildWithoutClaim: action.rebuildWithoutClaim }),
     },
   );
   if (settled !== undefined) return settled;
@@ -595,6 +602,12 @@ async function materializeOne(
       signature,
       driftLabel,
       run,
+      ...(action.freshNeedsPhysicalRebuild === undefined ?
+        {}
+      : { freshNeedsPhysicalRebuild: action.freshNeedsPhysicalRebuild }),
+      ...(action.rebuildWithoutClaim === undefined ?
+        {}
+      : { rebuildWithoutClaim: action.rebuildWithoutClaim }),
     });
   }
 
@@ -649,28 +662,35 @@ async function settleAgainstExisting(
     signature: string;
     driftLabel: string;
     /**
-     * Whether a physical index with this name exists but is INVALID. The
-     * pre-claim caller reads a bulk-preloaded set (one query for all
-     * candidates); the post-claim caller reads fresh (the preload is stale
-     * after waiting on another builder's claim).
+     * Whether the physical index behind this name is unusable and must be
+     * rebuilt despite the recorded success (INVALID leftover; for system
+     * indexes also physically absent). The pre-claim caller reads a
+     * bulk-preloaded set (one query for all candidates); the post-claim
+     * caller reads fresh (the preload is stale after waiting on another
+     * builder's claim).
      */
-    isInvalidLeftover: (
+    needsPhysicalRebuild: (
       physicalIndexName: string,
     ) => boolean | Promise<boolean>;
+    /** See `materializeOne`'s action field of the same name. */
+    rebuildWithoutClaim?: boolean;
   }>,
 ): Promise<MaterializeIndexesEntry | undefined> {
   if (existing?.materializedAt === undefined) return undefined;
-  const { statusKey, signature, driftLabel, isInvalidLeftover } = action;
+  const { statusKey, signature, driftLabel, needsPhysicalRebuild } = action;
   if (existing.signature === signature) {
     // A recorded success is only trustworthy while the physical index is
-    // valid: a run interrupted after `CREATE ... IF NOT EXISTS` silently
+    // usable: a run interrupted after `CREATE ... IF NOT EXISTS` silently
     // kept an invalid leftover (or a pre-claim-protocol run recorded
-    // success over one), leaving a poisoned status row. Fall through to
-    // the build path — under the claim it drops the leftover and rebuilds.
+    // success over one), and a dump/restore or manual drop can leave a
+    // success row for an index that no longer exists. Fall through to the
+    // build path — under the claim it drops any leftover and rebuilds;
+    // `rebuildWithoutClaim` callers re-run their plain idempotent CREATE.
     if (
       declaration.entity !== "vector" &&
-      hasIndexBuildClaimProtocol(backend) &&
-      (await isInvalidLeftover(declaration.name))
+      (hasIndexBuildClaimProtocol(backend) ||
+        action.rebuildWithoutClaim === true) &&
+      (await needsPhysicalRebuild(declaration.name))
     ) {
       return undefined;
     }
@@ -717,6 +737,8 @@ async function materializeWithClaim(
     signature: string;
     driftLabel: string;
     run: () => Promise<void>;
+    freshNeedsPhysicalRebuild?: (physicalIndexName: string) => Promise<boolean>;
+    rebuildWithoutClaim?: boolean;
   }>,
 ): Promise<MaterializeIndexesEntry> {
   const { statusKey, signature, driftLabel, run } = action;
@@ -768,8 +790,13 @@ async function materializeWithClaim(
           driftLabel,
           // Post-claim the bulk preload is stale (we may have waited on
           // another builder's claim), so re-check this index fresh.
-          isInvalidLeftover: (physicalIndexName) =>
-            hasInvalidIndexLeftover(backend, physicalIndexName),
+          needsPhysicalRebuild:
+            action.freshNeedsPhysicalRebuild ??
+            ((physicalIndexName) =>
+              hasInvalidIndexLeftover(backend, physicalIndexName)),
+          ...(action.rebuildWithoutClaim === undefined ?
+            {}
+          : { rebuildWithoutClaim: action.rebuildWithoutClaim }),
         },
       );
       if (settled !== undefined) return settled;
@@ -843,12 +870,16 @@ async function hasInvalidIndexLeftover(
   physicalIndexName: string,
 ): Promise<boolean> {
   if (backend.dialect !== "postgres") return false;
+  // Scoped to the session search_path like preloadPhysicalIndexStates —
+  // an unscoped probe could steer the unqualified DROP INDEX heal at
+  // another schema's identically-named (valid) index.
   const rows = await backend.execute<{ invalid: boolean }>(
     asCompiledRowsSql(sql`
       SELECT NOT i.indisvalid AS invalid
       FROM pg_class c
       JOIN pg_index i ON i.indexrelid = c.oid
       WHERE c.relname = ${physicalIndexName}
+        AND pg_catalog.pg_table_is_visible(c.oid)
     `),
   );
   return rows[0]?.invalid === true;
@@ -903,12 +934,18 @@ async function preloadPhysicalIndexStates(
   const invalid = new Set<string>();
   if (physicalIndexNames.length === 0) return { valid, invalid };
   if (backend.dialect === "postgres") {
+    // `pg_table_is_visible` scopes the probe to the session search_path —
+    // the same resolution the unqualified CREATE/DROP INDEX DDL uses — so
+    // a schema-per-tenant database never settles one schema's index based
+    // on another schema's identically-named one (matches buildTableExists
+    // in backend/drizzle/operations/strategy.ts).
     const rows = await backend.execute<{ name: string; valid: boolean }>(
       asCompiledRowsSql(sql`
         SELECT c.relname AS name, i.indisvalid AS valid
         FROM pg_class c
         JOIN pg_index i ON i.indexrelid = c.oid
         WHERE c.relname IN (${sqlValueList(physicalIndexNames)})
+          AND pg_catalog.pg_table_is_visible(c.oid)
       `),
     );
     for (const row of rows) (row.valid ? valid : invalid).add(row.name);
@@ -1108,6 +1145,25 @@ export function backendSupportsIndexMaterialization(
   );
 }
 
+/**
+ * Strict-side counterpart of {@link backendSupportsIndexMaterialization}:
+ * the runners' throw-guard, derived from the same predicate the boot
+ * path's skip-guard consults.
+ */
+function assertBackendSupportsIndexMaterialization(
+  backend: GraphBackend,
+  surface: string,
+): void {
+  if (backendSupportsIndexMaterialization(backend)) return;
+  throw new ConfigurationError(
+    `${surface} requires a backend with \`executeDdl\` and the index ` +
+      "materialization status primitives (`getIndexMaterialization`, " +
+      "`recordIndexMaterialization`). The bundled SQLite and Postgres " +
+      "backends provide them; a custom backend must implement all three.",
+    { code: "MATERIALIZE_BACKEND_UNSUPPORTED" },
+  );
+}
+
 export async function materializeSystemIndexes(
   context: Readonly<{
     backend: RawBackend;
@@ -1118,26 +1174,10 @@ export async function materializeSystemIndexes(
 ): Promise<MaterializeIndexesResult> {
   const { backend, graphId, schemaVersion } = context;
 
-  if (backend.executeDdl === undefined) {
-    throw new ConfigurationError(
-      "materializeSystemIndexes() requires a backend with `executeDdl` " +
-        "support. The bundled SQLite and Postgres backends provide it; " +
-        "a custom backend without `executeDdl` cannot run index DDL.",
-      { code: "MATERIALIZE_BACKEND_UNSUPPORTED" },
-    );
-  }
-  if (
-    backend.getIndexMaterialization === undefined ||
-    backend.recordIndexMaterialization === undefined
-  ) {
-    throw new ConfigurationError(
-      "materializeSystemIndexes() requires a backend with index " +
-        "materialization status primitives. The bundled SQLite and " +
-        "Postgres backends provide them; a custom backend must implement " +
-        "`getIndexMaterialization` and `recordIndexMaterialization`.",
-      { code: "MATERIALIZE_BACKEND_UNSUPPORTED" },
-    );
-  }
+  assertBackendSupportsIndexMaterialization(
+    backend,
+    "store.materializeSystemIndexes()",
+  );
 
   await ensureFocusedStatusTable(
     backend,
@@ -1166,8 +1206,13 @@ export async function materializeSystemIndexes(
     preloadMaterializations(backend, statusKeys),
     preloadPhysicalIndexStates(backend, statusKeys),
   ]);
-  const { valid: physicallyPresent, invalid: invalidLeftovers } =
-    physicalStates;
+  const { valid: physicallyPresent } = physicalStates;
+  // Physical state is authoritative for system indexes: absent or INVALID
+  // must rebuild even under a matching success row (dump/restore, manual
+  // drop). One set serves every candidate's pre-claim check.
+  const physicalRebuildPreload: ReadonlySet<string> = new Set(
+    statusKeys.filter((name) => !physicallyPresent.has(name)),
+  );
 
   const materializeEntry = async (
     candidate: SystemIndexCandidate,
@@ -1177,19 +1222,39 @@ export async function materializeSystemIndexes(
       entity: "system",
       kind: candidate.declaration.table,
     };
+    const existing = existingByStatusKey.get(candidate.name);
+
+    // A status row owned by another entity means a graph-declared index
+    // was materialized under this name. Refuse WITHOUT writing: driving
+    // this through the drift path would record a system-signature failure
+    // over the graph-declared index's row and permanently brick it.
+    if (existing !== undefined && existing.entity !== "system") {
+      return entry(
+        identity,
+        "failed",
+        new Error(
+          `System index name "${candidate.name}" is already recorded by a ` +
+            `${existing.entity} index declaration (graph "${existing.graphId}"). ` +
+            `Rename the graph-declared index — "typegraph_"-prefixed names ` +
+            `belong to TypeGraph's system indexes.`,
+        ),
+      );
+    }
+
     // Name-presence fast path: valid physical index, no status row — the
     // normal steady state, since bootstrap DDL creates system indexes
     // without recording status rows. Trusting name-presence is sound
     // ONLY here: system index names are library-owned with a stable
     // name→shape contract (reshaping requires a rename), whereas a
     // graph-declared index name could collide with a foreign index whose
-    // shape only the recorded signature can vouch for. A row with a
-    // mismatching signature must NOT take the fast path — that is drift,
-    // and the frame below records it as a failure.
-    if (
-      existingByStatusKey.get(candidate.name) === undefined &&
-      physicallyPresent.has(candidate.name)
-    ) {
+    // shape only the recorded signature can vouch for. Known limitation
+    // of that contract: a declaration reshaped in place (violating the
+    // rename rule) is NOT detected on bootstrap-created databases, since
+    // there is no recorded signature to drift against — the rename rule
+    // is enforced by review and the parity tests, not at runtime. A row
+    // with a mismatching signature must NOT take the fast path — that is
+    // drift, and the frame below records it as a failure.
+    if (existing === undefined && physicallyPresent.has(candidate.name)) {
       return entry(identity, "alreadyMaterialized");
     }
     const signature = await computeSystemIndexSignature(
@@ -1208,7 +1273,14 @@ export async function materializeSystemIndexes(
       driftLabel: "System index",
       run: () => backend.executeDdl!(ddl),
       existingByStatusKey,
-      invalidLeftovers,
+      physicalRebuildPreload,
+      freshNeedsPhysicalRebuild: async (physicalIndexName) => {
+        const fresh = await preloadPhysicalIndexStates(backend, [
+          physicalIndexName,
+        ]);
+        return !fresh.valid.has(physicalIndexName);
+      },
+      rebuildWithoutClaim: true,
     });
   };
 

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -45,6 +45,13 @@ import type { IndexEntity } from "../core/types";
 import { ConfigurationError, KindNotFoundError } from "../errors";
 import { generateIndexDDL } from "../indexes/ddl";
 import {
+  generateSystemIndexDDL,
+  resolveSystemIndexTableName,
+  SYSTEM_INDEX_DECLARATIONS,
+  type SystemIndexDeclaration,
+  systemIndexName,
+} from "../indexes/system";
+import {
   type IndexDeclaration,
   type RelationalIndexDeclaration,
   type VectorIndexDeclaration,
@@ -559,15 +566,27 @@ async function materializeVectorIndex(
 }
 
 /**
- * Shared "check existing → run → record" frame for both relational and
- * vector materialization. Both paths track a per-deployment status row
+ * The identity a materialization run needs from its declaration: the
+ * physical/status name plus the `(entity, kind)` pair recorded on the
+ * status row. Relational and vector declarations satisfy it structurally;
+ * system indexes construct it from `SYSTEM_INDEX_DECLARATIONS`.
+ */
+type MaterializableIndexIdentity = Readonly<{
+  name: string;
+  entity: IndexEntity;
+  kind: string;
+}>;
+
+/**
+ * Shared "check existing → run → record" frame for relational, vector,
+ * and system materialization. All paths track a per-deployment status row
  * keyed by `statusKey`, short-circuit on a matching signature, surface
  * signature drift as a recorded failure, and execute `run()` on first
  * materialization. Differences live entirely in the `MaterializeAction`
  * the caller passes.
  */
 async function materializeOne(
-  declaration: IndexDeclaration,
+  declaration: MaterializableIndexIdentity,
   backend: GraphBackend,
   graphId: string,
   schemaVersion: number,
@@ -660,7 +679,7 @@ async function materializeOne(
  */
 async function settleAgainstExisting(
   existing: IndexMaterializationRow | undefined,
-  declaration: IndexDeclaration,
+  declaration: MaterializableIndexIdentity,
   backend: GraphBackend,
   graphId: string,
   schemaVersion: number,
@@ -728,7 +747,7 @@ async function settleAgainstExisting(
  * rebuilding.
  */
 async function materializeWithClaim(
-  declaration: IndexDeclaration,
+  declaration: MaterializableIndexIdentity,
   backend: GraphBackend,
   graphId: string,
   schemaVersion: number,
@@ -923,7 +942,7 @@ async function dropInvalidIndexLeftover(
 }
 
 function entry(
-  declaration: IndexDeclaration,
+  declaration: MaterializableIndexIdentity,
   status: MaterializeIndexesEntry["status"],
   error?: Error,
 ): MaterializeIndexesEntry {
@@ -997,7 +1016,7 @@ async function preloadMaterializations(
 
 function buildAttempt(
   args: Readonly<{
-    declaration: IndexDeclaration;
+    declaration: MaterializableIndexIdentity;
     graphId: string;
     signature: string;
     schemaVersion: number;
@@ -1024,6 +1043,243 @@ function buildAttempt(
     materializedAt: args.materializedAt,
     error: args.error?.message,
   };
+}
+
+// ============================================================
+// System indexes
+// ============================================================
+
+export type MaterializeSystemIndexesOptions = Readonly<{
+  /** Stop on the first failure. Default: false (best-effort). */
+  stopOnError?: boolean;
+  /** Refresh planner statistics after a creation. Default: true. */
+  refreshStatistics?: boolean;
+}>;
+
+type SystemIndexCandidate = Readonly<{
+  declaration: SystemIndexDeclaration;
+  physicalTable: string;
+  name: string;
+}>;
+
+/**
+ * Materializes TypeGraph's own base-relation indexes
+ * (`SYSTEM_INDEX_DECLARATIONS`) against the live database.
+ *
+ * Bootstrap DDL runs only on first boot, so a system index added in a new
+ * library version never reaches an already-initialized database on its
+ * own — this runner is the upgrade path. It rides the same per-deployment
+ * status table, drift signatures, invalid-leftover healing, and Postgres
+ * `CREATE INDEX CONCURRENTLY` cross-caller claim protocol as
+ * graph-declared indexes; on a database whose indexes all exist, a warm
+ * call costs two reads (status preload + leftover preload) and runs no
+ * DDL after the first recorded success.
+ *
+ * Graph-independent: the declarations don't depend on `GraphDef`. The
+ * `graphId` is recorded on status rows for observability only ("who
+ * materialized this"), matching relational rows' semantics.
+ *
+ * Unlike expression indexes, a system index is fully identified by its
+ * physical name, so a candidate that already exists in the engine catalog
+ * (valid, with no recorded status row) settles as `alreadyMaterialized`
+ * from one bulk catalog read — no claim, no DDL, no status write. Status
+ * rows are recorded only for genuine builds and failures, which keeps the
+ * common boot (fresh bootstrap or wiped status table) at three reads
+ * total. A status row that exists with a mismatching signature still
+ * surfaces as drift, exactly like graph-declared indexes.
+ */
+export async function materializeSystemIndexes(
+  context: Readonly<{
+    backend: RawBackend;
+    graphId: string;
+    schemaVersion: number;
+  }>,
+  options: MaterializeSystemIndexesOptions = {},
+): Promise<MaterializeIndexesResult> {
+  const { backend, graphId, schemaVersion } = context;
+
+  if (backend.executeDdl === undefined) {
+    throw new ConfigurationError(
+      "materializeSystemIndexes() requires a backend with `executeDdl` " +
+        "support. The bundled SQLite and Postgres backends provide it; " +
+        "a custom backend without `executeDdl` cannot run index DDL.",
+      { code: "MATERIALIZE_BACKEND_UNSUPPORTED" },
+    );
+  }
+  if (
+    backend.getIndexMaterialization === undefined ||
+    backend.recordIndexMaterialization === undefined
+  ) {
+    throw new ConfigurationError(
+      "materializeSystemIndexes() requires a backend with index " +
+        "materialization status primitives. The bundled SQLite and " +
+        "Postgres backends provide them; a custom backend must implement " +
+        "`getIndexMaterialization` and `recordIndexMaterialization`.",
+      { code: "MATERIALIZE_BACKEND_UNSUPPORTED" },
+    );
+  }
+
+  await ensureFocusedStatusTable(
+    backend,
+    backend.ensureIndexMaterializationsTable,
+  );
+
+  const concurrent = backend.dialect === "postgres";
+  const candidates: readonly SystemIndexCandidate[] =
+    SYSTEM_INDEX_DECLARATIONS.map((declaration) => {
+      const physicalTable = resolveSystemIndexTableName(
+        declaration.table,
+        backend.tableNames,
+      );
+      return {
+        declaration,
+        physicalTable,
+        name: systemIndexName(physicalTable, declaration.suffix),
+      };
+    });
+
+  const statusKeys = candidates.map((candidate) => candidate.name);
+  const existingByStatusKey = await preloadMaterializations(
+    backend,
+    statusKeys,
+  );
+  const invalidLeftovers = await preloadInvalidIndexLeftovers(
+    backend,
+    statusKeys,
+  );
+  const physicallyPresent = await preloadValidPhysicalIndexes(
+    backend,
+    statusKeys,
+  );
+
+  const materializeEntry = async (
+    candidate: SystemIndexCandidate,
+  ): Promise<MaterializeIndexesEntry> => {
+    const identity: MaterializableIndexIdentity = {
+      name: candidate.name,
+      entity: "system",
+      kind: candidate.declaration.table,
+    };
+    // Name-presence fast path: valid physical index, no status row. A row
+    // with a mismatching signature must NOT take it — that is drift, and
+    // the frame below records it as a failure.
+    if (
+      existingByStatusKey.get(candidate.name) === undefined &&
+      physicallyPresent.has(candidate.name)
+    ) {
+      return entry(identity, "alreadyMaterialized");
+    }
+    const signature = await computeSystemIndexSignature(
+      backend.dialect,
+      candidate.physicalTable,
+      candidate.declaration,
+    );
+    const ddl = generateSystemIndexDDL(
+      candidate.declaration,
+      candidate.physicalTable,
+      { concurrent },
+    );
+    return materializeOne(identity, backend, graphId, schemaVersion, {
+      statusKey: candidate.name,
+      signature,
+      driftLabel: "System index",
+      run: () => backend.executeDdl!(ddl),
+      existingByStatusKey,
+      invalidLeftovers,
+    });
+  };
+
+  if (options.stopOnError === true) {
+    const results: MaterializeIndexesEntry[] = [];
+    for (const candidate of candidates) {
+      const result = await materializeEntry(candidate);
+      results.push(result);
+      if (result.status === "failed") break;
+    }
+    await refreshStatisticsAfterCreation(backend, results, options, concurrent);
+    return { results };
+  }
+
+  // Postgres restricts CREATE INDEX CONCURRENTLY to one in-flight build
+  // per relation — group by physical table, sequential within a group,
+  // groups in parallel (same shape as the relational bucketing above).
+  const buckets = new Map<string, SystemIndexCandidate[]>();
+  for (const candidate of candidates) {
+    const bucket = buckets.get(candidate.physicalTable);
+    if (bucket === undefined) buckets.set(candidate.physicalTable, [candidate]);
+    else bucket.push(candidate);
+  }
+  const bucketResults = await Promise.all(
+    [...buckets.values()].map(async (group) => {
+      const out: MaterializeIndexesEntry[] = [];
+      for (const candidate of group) {
+        out.push(await materializeEntry(candidate));
+      }
+      return out;
+    }),
+  );
+  const byName = new Map<string, MaterializeIndexesEntry>();
+  for (const group of bucketResults) {
+    for (const result of group) byName.set(result.indexName, result);
+  }
+  const results = candidates.map((candidate) => byName.get(candidate.name)!);
+  await refreshStatisticsAfterCreation(backend, results, options, concurrent);
+  return { results };
+}
+
+/**
+ * The subset of `physicalIndexNames` that exist as VALID indexes in the
+ * engine catalog, in one query. Plain system indexes are fully identified
+ * by name, so catalog presence is a sound "already built" signal — unlike
+ * expression indexes, where only the recorded signature proves shape.
+ * Postgres excludes INVALID leftovers (interrupted CONCURRENTLY builds)
+ * so they fall through to the healing build path.
+ */
+async function preloadValidPhysicalIndexes(
+  backend: GraphBackend,
+  physicalIndexNames: readonly string[],
+): Promise<ReadonlySet<string>> {
+  if (physicalIndexNames.length === 0) return new Set();
+  if (backend.dialect === "postgres") {
+    const rows = await backend.execute<{ name: string }>(
+      asCompiledRowsSql(sql`
+        SELECT c.relname AS name
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE c.relname IN (${sqlValueList(physicalIndexNames)})
+          AND i.indisvalid
+      `),
+    );
+    return new Set(rows.map((row) => row.name));
+  }
+  const rows = await backend.execute<{ name: string }>(
+    asCompiledRowsSql(sql`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'index'
+        AND name IN (${sqlValueList(physicalIndexNames)})
+    `),
+  );
+  return new Set(rows.map((row) => row.name));
+}
+
+/**
+ * Canonical hash of `{ dialect, targetTableName, declaration }` for a
+ * system-index declaration — same drift contract as
+ * `computeIndexSignature`: changing a declaration's shape under the same
+ * suffix mismatches the recorded signature and surfaces as a `failed`
+ * entry until the operator drops the old physical index (rename instead).
+ */
+async function computeSystemIndexSignature(
+  dialect: SqlDialect,
+  targetTableName: string,
+  declaration: SystemIndexDeclaration,
+): Promise<string> {
+  const json = JSON.stringify(
+    { dialect, targetTableName, declaration },
+    sortedReplacer,
+  );
+  return sha256Hex(json, 16);
 }
 
 /**

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -46,6 +46,7 @@ import { ConfigurationError, KindNotFoundError } from "../errors";
 import { generateIndexDDL } from "../indexes/ddl";
 import {
   generateSystemIndexDDL,
+  resolveSystemIndexNames,
   resolveSystemIndexTableName,
   SYSTEM_INDEX_DECLARATIONS,
   type SystemIndexDeclaration,
@@ -252,28 +253,53 @@ export async function materializeIndexes(
     relationalPhysicalNames,
   );
 
+  // System index names are reserved: a colliding relational declaration's
+  // `CREATE INDEX IF NOT EXISTS` would silently no-op against the
+  // (differently shaped) system index while recording a false success.
+  // The schema factories reject the same collision at table-definition
+  // time; this covers declarations that never pass through them.
+  const reservedSystemNames = resolveSystemIndexNames(backend.tableNames);
+
   const materializeEntry = (
     declaration: IndexDeclaration,
-  ): Promise<MaterializeIndexesEntry> =>
-    declaration.entity === "vector" ?
-      materializeVectorIndex(
-        declaration,
-        backend,
-        graphId,
-        schemaVersion,
-        existingByStatusKey,
-        invalidLeftovers,
-      )
-    : materializeRelationalIndex(
-        declaration,
-        backend,
-        dialect,
-        ddlOptions,
-        graphId,
-        schemaVersion,
-        existingByStatusKey,
-        invalidLeftovers,
+  ): Promise<MaterializeIndexesEntry> => {
+    if (
+      declaration.entity !== "vector" &&
+      reservedSystemNames.has(declaration.name)
+    ) {
+      return Promise.resolve(
+        entry(
+          declaration,
+          "failed",
+          new Error(
+            `Index name "${declaration.name}" collides with a TypeGraph ` +
+              `system index. Rename the declaration — a same-named CREATE ` +
+              `INDEX IF NOT EXISTS would silently no-op against the system ` +
+              `index instead of creating the declared one.`,
+          ),
+        ),
       );
+    }
+    return declaration.entity === "vector" ?
+        materializeVectorIndex(
+          declaration,
+          backend,
+          graphId,
+          schemaVersion,
+          existingByStatusKey,
+          invalidLeftovers,
+        )
+      : materializeRelationalIndex(
+          declaration,
+          backend,
+          dialect,
+          ddlOptions,
+          graphId,
+          schemaVersion,
+          existingByStatusKey,
+          invalidLeftovers,
+        );
+  };
 
   // Postgres restricts `CREATE INDEX CONCURRENTLY` to one in-flight
   // build per relation, so declarations group by target relation and
@@ -910,6 +936,38 @@ async function preloadInvalidIndexLeftovers(
   return invalid;
 }
 
+/**
+ * The subset of `tableNames` that exist as tables in the engine catalog,
+ * in one query — `search_path`-scoped on Postgres like the index probes.
+ */
+async function preloadExistingTables(
+  backend: GraphBackend,
+  tableNames: readonly string[],
+): Promise<ReadonlySet<string>> {
+  if (tableNames.length === 0) return new Set();
+  if (backend.dialect === "postgres") {
+    const rows = await backend.execute<{ name: string }>(
+      asCompiledRowsSql(sql`
+        SELECT c.relname AS name
+        FROM pg_class c
+        WHERE c.relname IN (${sqlValueList(tableNames)})
+          AND c.relkind IN ('r', 'p')
+          AND pg_catalog.pg_table_is_visible(c.oid)
+      `),
+    );
+    return new Set(rows.map((row) => row.name));
+  }
+  const rows = await backend.execute<{ name: string }>(
+    asCompiledRowsSql(sql`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table'
+        AND name IN (${sqlValueList(tableNames)})
+    `),
+  );
+  return new Set(rows.map((row) => row.name));
+}
+
 type PhysicalIndexStates = Readonly<{
   /** Names that exist as usable indexes in the engine catalog. */
   valid: ReadonlySet<string>;
@@ -1198,14 +1256,19 @@ export async function materializeSystemIndexes(
       };
     });
 
-  // The two preloads are mutually independent reads (status table +
-  // catalog); running them concurrently keeps the warm boot at one
-  // round-trip latency after the ensure step.
+  // The three preloads are mutually independent reads (status table +
+  // two catalog probes); running them concurrently keeps the warm boot at
+  // one round-trip latency after the ensure step.
   const statusKeys = candidates.map((candidate) => candidate.name);
-  const [existingByStatusKey, physicalStates] = await Promise.all([
-    preloadMaterializations(backend, statusKeys),
-    preloadPhysicalIndexStates(backend, statusKeys),
-  ]);
+  const targetTables = [
+    ...new Set(candidates.map((candidate) => candidate.physicalTable)),
+  ];
+  const [existingByStatusKey, physicalStates, existingTables] =
+    await Promise.all([
+      preloadMaterializations(backend, statusKeys),
+      preloadPhysicalIndexStates(backend, statusKeys),
+      preloadExistingTables(backend, targetTables),
+    ]);
   const { valid: physicallyPresent } = physicalStates;
   // Physical state is authoritative for system indexes: absent or INVALID
   // must rebuild even under a matching success row (dump/restore, manual
@@ -1222,6 +1285,21 @@ export async function materializeSystemIndexes(
       entity: "system",
       kind: candidate.declaration.table,
     };
+    // Legacy databases can predate optional relations (the recorded
+    // tables ship with history support; `operation-backend-core` guards
+    // its clears the same way). Their indexes are skipped, not failed —
+    // the relation appearing later (bootstrap on a fresh database always
+    // creates it) brings the indexes with it.
+    if (!existingTables.has(candidate.physicalTable)) {
+      return {
+        indexName: candidate.name,
+        entity: "system",
+        kind: candidate.declaration.table,
+        status: "skipped",
+        reason: `Relation "${candidate.physicalTable}" does not exist in this database`,
+      };
+    }
+
     const existing = existingByStatusKey.get(candidate.name);
 
     // A status row owned by another entity means a graph-declared index

--- a/packages/typegraph/src/store/materialize-indexes.ts
+++ b/packages/typegraph/src/store/materialize-indexes.ts
@@ -1170,7 +1170,8 @@ type SystemIndexCandidate = Readonly<{
  * status table, drift signatures, invalid-leftover healing, and Postgres
  * `CREATE INDEX CONCURRENTLY` cross-caller claim protocol as
  * graph-declared indexes; on a database whose indexes all exist, a warm
- * call costs two concurrent reads (status preload + catalog preload) and runs no
+ * call costs three concurrent reads (status, index-catalog, and
+ * table-catalog preloads) after the idempotent status-table ensure, and runs no
  * DDL after the first recorded success.
  *
  * Graph-independent: the declarations don't depend on `GraphDef`. The
@@ -1182,7 +1183,7 @@ type SystemIndexCandidate = Readonly<{
  * (valid, with no recorded status row) settles as `alreadyMaterialized`
  * from one bulk catalog read — no claim, no DDL, no status write. Status
  * rows are recorded only for genuine builds and failures, which keeps the
- * common boot (fresh bootstrap or wiped status table) at two concurrent
+ * common boot (fresh bootstrap or wiped status table) at three concurrent
  * reads. A status row that exists with a mismatching signature still
  * surfaces as drift, exactly like graph-declared indexes.
  */

--- a/packages/typegraph/src/store/materialize-shared.ts
+++ b/packages/typegraph/src/store/materialize-shared.ts
@@ -33,13 +33,61 @@ export async function ensureFocusedStatusTable(
 }
 
 /**
+ * Bucketed orchestration for index-materialization runners.
+ *
+ * `stopOnError === true` runs sequentially in input order and
+ * short-circuits after the first `failed` entry (returning the partial
+ * results). Otherwise items are grouped by `bucketKey` and the groups run
+ * concurrently with each group sequential — the shape Postgres requires
+ * for `CREATE INDEX CONCURRENTLY` (one in-flight build per relation).
+ * Results always come back in input order regardless of how the buckets
+ * resolved.
+ */
+export async function runBucketedMaterialization<
+  TItem,
+  TEntry extends { status: string },
+>(
+  items: readonly TItem[],
+  options: Readonly<{ stopOnError?: boolean }>,
+  bucketKey: (item: TItem) => string,
+  runOne: (item: TItem) => Promise<TEntry>,
+): Promise<readonly TEntry[]> {
+  if (options.stopOnError === true) {
+    const results: TEntry[] = [];
+    for (const item of items) {
+      const entry = await runOne(item);
+      results.push(entry);
+      if (entry.status === "failed") break;
+    }
+    return results;
+  }
+
+  const buckets = new Map<string, [number, TItem][]>();
+  for (const [index, item] of items.entries()) {
+    const key = bucketKey(item);
+    const bucket = buckets.get(key);
+    if (bucket === undefined) buckets.set(key, [[index, item]]);
+    else bucket.push([index, item]);
+  }
+
+  const results: TEntry[] = Array.from({ length: items.length });
+  await Promise.all(
+    [...buckets.values()].map(async (group) => {
+      for (const [index, item] of group) {
+        results[index] = await runOne(item);
+      }
+    }),
+  );
+  return results;
+}
+
+/**
  * Best-effort vs strict orchestration for materialization runners.
  * `stopOnError === true` runs sequentially and short-circuits on the
  * first `failed` entry (mirrors typical schema-migration safety
  * semantics); the default best-effort path runs `runOne` over `items`
- * concurrently. Custom orchestrators (e.g. `materializeIndexes`'s
- * per-relation bucketing) bypass this helper and assemble their own
- * Promise topology.
+ * concurrently. Custom orchestrators bypass this helper and assemble
+ * their own Promise topology.
  */
 export async function runMaterialization<
   TInput,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -117,6 +117,7 @@ import {
 import { resolveTemporalReadParams } from "./collections/temporal-read-params";
 import { introspectSchema, type SchemaIntrospection } from "./introspect";
 import {
+  backendSupportsIndexMaterialization,
   computeIndexSignature,
   materializeIndexes as materializeIndexesImpl,
   type MaterializeIndexesOptions,
@@ -3590,13 +3591,7 @@ async function materializeSystemIndexesOnBoot(
   result: SchemaValidationResult,
 ): Promise<void> {
   if (result.status === "breaking") return;
-  if (
-    backend.executeDdl === undefined ||
-    backend.getIndexMaterialization === undefined ||
-    backend.recordIndexMaterialization === undefined
-  ) {
-    return;
-  }
+  if (!backendSupportsIndexMaterialization(backend)) return;
   const schemaVersion =
     result.status === "migrated" ? result.toVersion : result.version;
   const { results } = await materializeSystemIndexesImpl(

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -3561,8 +3561,12 @@ export async function createStoreWithSchema<G extends GraphDef>(
   // Bring the base-relation system indexes up to this library version.
   // Bootstrap DDL only runs on first boot, so an index shipped in a newer
   // version reaches already-initialized databases here — this is the same
-  // privileged-boot step the contributions above use.
-  await materializeSystemIndexesOnBoot(backend, merged.id, result);
+  // privileged-boot step the contributions above use. `systemIndexes:
+  // "skip"` defers to an out-of-band store.materializeSystemIndexes()
+  // for deployments that must not run index builds inline at boot.
+  if (options?.systemIndexes !== "skip") {
+    await materializeSystemIndexesOnBoot(backend, merged.id, result);
+  }
 
   const store = new Store(
     merged,
@@ -3594,22 +3598,35 @@ async function materializeSystemIndexesOnBoot(
   if (!backendSupportsIndexMaterialization(backend)) return;
   const schemaVersion =
     result.status === "migrated" ? result.toVersion : result.version;
-  const { results } = await materializeSystemIndexesImpl(
-    { backend: asRawBackend(backend), graphId, schemaVersion },
-    {},
-  );
-  const failed = results.filter(
-    (entryResult) => entryResult.status === "failed",
-  );
-  if (failed.length === 0) return;
-  console.warn(
-    `[typegraph] ${String(failed.length)} system index(es) failed to ` +
-      `materialize at boot (${failed
-        .map((entryResult) => entryResult.indexName)
-        .join(", ")}); the store is usable but the affected access paths ` +
-      "fall back to scans. Retry via store.materializeSystemIndexes().",
-    failed[0]?.error,
-  );
+  try {
+    const { results } = await materializeSystemIndexesImpl(
+      { backend: asRawBackend(backend), graphId, schemaVersion },
+      {},
+    );
+    const failed = results.filter(
+      (entryResult) => entryResult.status === "failed",
+    );
+    if (failed.length === 0) return;
+    console.warn(
+      `[typegraph] ${String(failed.length)} system index(es) failed to ` +
+        `materialize at boot (${failed
+          .map((entryResult) => entryResult.indexName)
+          .join(", ")}); the store is usable but the affected access paths ` +
+        "fall back to scans. Retry via store.materializeSystemIndexes().",
+      failed[0]?.error,
+    );
+  } catch (error) {
+    // Leniency must hold for infrastructure throws too (status-table
+    // ensure/preload/record failures, claim writes) — not only per-index
+    // build failures. A store that booted on the previous version must
+    // still come up after an upgrade; the operator retries explicitly.
+    console.warn(
+      "[typegraph] system-index materialization failed at boot; the store " +
+        "is usable but new system indexes were not adopted. Retry via " +
+        "store.materializeSystemIndexes().",
+      error,
+    );
+  }
 }
 
 /**

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -121,6 +121,8 @@ import {
   materializeIndexes as materializeIndexesImpl,
   type MaterializeIndexesOptions,
   type MaterializeIndexesResult,
+  materializeSystemIndexes as materializeSystemIndexesImpl,
+  type MaterializeSystemIndexesOptions,
   vectorStatusKey,
 } from "./materialize-indexes";
 import {
@@ -2529,6 +2531,32 @@ export class Store<G extends GraphDef> {
   }
 
   /**
+   * Materializes TypeGraph's own base-relation indexes
+   * (`SYSTEM_INDEX_DECLARATIONS`) against the live database.
+   *
+   * Bootstrap DDL runs only on first boot, so a system index shipped in a
+   * newer library version never reaches an already-initialized database on
+   * its own. `createStoreWithSchema` runs this automatically; deployments
+   * that boot with plain `createStore` / `createVerifiedStore` (zero-DDL by
+   * contract) adopt new system indexes by calling this once under a role
+   * that may run DDL. Same status-table, drift-signature, and Postgres
+   * `CREATE INDEX CONCURRENTLY` claim semantics as `materializeIndexes`.
+   */
+  async materializeSystemIndexes(
+    options?: MaterializeSystemIndexesOptions,
+  ): Promise<MaterializeIndexesResult> {
+    const { activeRow } = await this.#loadCaughtUp("materialize");
+    return materializeSystemIndexesImpl(
+      {
+        backend: this.#baseBackend,
+        graphId: this.graphId,
+        schemaVersion: activeRow.version,
+      },
+      options ?? {},
+    );
+  }
+
+  /**
    * Recreate a vector field's per-field storage at its current declared
    * dimension, then optionally re-embed existing rows.
    *
@@ -3529,6 +3557,11 @@ export async function createStoreWithSchema<G extends GraphDef>(
   // durable marker under the privileged role, so a least-privilege runtime
   // asserts the markers (SELECT) and writes embeddings without `CREATE`.
   await materializeVectorContributions(backend, merged);
+  // Bring the base-relation system indexes up to this library version.
+  // Bootstrap DDL only runs on first boot, so an index shipped in a newer
+  // version reaches already-initialized databases here — this is the same
+  // privileged-boot step the contributions above use.
+  await materializeSystemIndexesOnBoot(backend, merged.id, result);
 
   const store = new Store(
     merged,
@@ -3537,6 +3570,51 @@ export async function createStoreWithSchema<G extends GraphDef>(
     schemaMetadataForResult(activeRow, result),
   );
   return [store, result];
+}
+
+/**
+ * Boot-path system-index materialization. Lenient where the explicit
+ * `store.materializeSystemIndexes()` API is strict:
+ *
+ * - Backends without `executeDdl` / status primitives are skipped —
+ *   their deployments keep the bootstrap-only behavior they had before
+ *   system indexes were materialized at boot, instead of failing to boot.
+ * - Skipped when the schema gate did not pass (`"breaking"`).
+ * - Individual index failures degrade to a warning: system indexes are a
+ *   performance concern, and a store that cannot build one must still
+ *   come up (the operator retries via `store.materializeSystemIndexes()`).
+ */
+async function materializeSystemIndexesOnBoot(
+  backend: GraphBackend,
+  graphId: string,
+  result: SchemaValidationResult,
+): Promise<void> {
+  if (result.status === "breaking") return;
+  if (
+    backend.executeDdl === undefined ||
+    backend.getIndexMaterialization === undefined ||
+    backend.recordIndexMaterialization === undefined
+  ) {
+    return;
+  }
+  const schemaVersion =
+    result.status === "migrated" ? result.toVersion : result.version;
+  const { results } = await materializeSystemIndexesImpl(
+    { backend: asRawBackend(backend), graphId, schemaVersion },
+    {},
+  );
+  const failed = results.filter(
+    (entryResult) => entryResult.status === "failed",
+  );
+  if (failed.length === 0) return;
+  console.warn(
+    `[typegraph] ${String(failed.length)} system index(es) failed to ` +
+      `materialize at boot (${failed
+        .map((entryResult) => entryResult.indexName)
+        .join(", ")}); the store is usable but the affected access paths ` +
+      "fall back to scans. Retry via store.materializeSystemIndexes().",
+    failed[0]?.error,
+  );
 }
 
 /**

--- a/packages/typegraph/test-d/public-api.test-d.ts
+++ b/packages/typegraph/test-d/public-api.test-d.ts
@@ -582,7 +582,9 @@ declare const materializeEntry: MaterializeIndexesEntry;
 expectAssignable<"created" | "alreadyMaterialized" | "failed" | "skipped">(
   materializeEntry.status,
 );
-expectAssignable<"node" | "edge" | "vector">(materializeEntry.entity);
+expectAssignable<"node" | "edge" | "vector" | "system">(
+  materializeEntry.entity,
+);
 
 // defineNodeIndex / defineEdgeIndex are the current 1.0 surface — the
 // `(Type, { fields: [...] })` config shape, not the legacy

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -526,6 +526,42 @@ describe("PostgreSQL Backend - Adapter Specific", () => {
     });
   });
 
+  describe("materializeSystemIndexes()", () => {
+    it("adopts a physically missing system index via the CONCURRENTLY build path", async (ctx) => {
+      const { db, pool } = requirePostgres(ctx);
+      const backend = createPostgresBackend(db);
+      const [store] = await createStoreWithSchema(testGraph, backend);
+
+      // Simulate a database initialized by an older library version: the
+      // index does not exist and no materialization row was recorded.
+      await pool.query('DROP INDEX IF EXISTS "typegraph_nodes_id_idx"');
+      await pool.query(
+        `DELETE FROM typegraph_index_materializations WHERE index_name = 'typegraph_nodes_id_idx'`,
+      );
+
+      const { results } = await store.materializeSystemIndexes();
+      const target = results.find(
+        (result) => result.indexName === "typegraph_nodes_id_idx",
+      );
+      expect(target?.status).toBe("created");
+      expect(target?.entity).toBe("system");
+      // Everything else settles from the catalog without DDL or writes.
+      for (const result of results) {
+        expect(["created", "alreadyMaterialized"]).toContain(result.status);
+      }
+
+      const created = await pool.query<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'typegraph_nodes_id_idx'`,
+      );
+      expect(created.rows.length).toBe(1);
+
+      const status = await pool.query<{ entity: string; kind: string }>(
+        `SELECT entity, kind FROM typegraph_index_materializations WHERE index_name = 'typegraph_nodes_id_idx'`,
+      );
+      expect(status.rows[0]).toEqual({ entity: "system", kind: "nodes" });
+    });
+  });
+
   describe("refreshStatistics()", () => {
     it("runs ANALYZE on the default TypeGraph tables", async (ctx) => {
       const { db } = requirePostgres(ctx);

--- a/packages/typegraph/tests/degree-index-alignment.test.ts
+++ b/packages/typegraph/tests/degree-index-alignment.test.ts
@@ -27,7 +27,11 @@ import {
   subClassOf,
 } from "../src";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
-import type { GraphBackend } from "../src/backend/types";
+import {
+  type CapturedStatement,
+  createPlanCaptureBackend,
+  explainQueryPlan,
+} from "./test-utils";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -58,8 +62,6 @@ function buildGraph() {
   });
 }
 
-type CapturedStatement = Readonly<{ sql: string; params: readonly unknown[] }>;
-
 async function withCapturingStore<T>(
   run: (
     store: ReturnType<typeof createStore<ReturnType<typeof buildGraph>>>,
@@ -68,42 +70,9 @@ async function withCapturingStore<T>(
   ) => Promise<T>,
   options?: Readonly<{ history?: boolean }>,
 ): Promise<T> {
-  const { backend: raw, db } = createLocalSqliteBackend();
-  try {
-    const captured: CapturedStatement[] = [];
-    const backend: GraphBackend = {
-      ...raw,
-      async execute(query) {
-        const compiled = raw.compileSql?.(query);
-        if (compiled) {
-          captured.push({ sql: compiled.sql, params: compiled.params });
-        }
-        return raw.execute(query);
-      },
-      // Reads run through the cached-template fast path (executeRaw), which
-      // receives SQL text with all placeholders already filled — directly
-      // EXPLAIN-able.
-      async executeRaw<T>(sqlText: string, params: readonly unknown[]) {
-        captured.push({ sql: sqlText, params });
-        return raw.executeRaw!<T>(sqlText, params);
-      },
-    };
-    const store = createStore(buildGraph(), backend, options);
-    const client = (db as unknown as { $client: Database.Database }).$client;
-    return await run(store, captured, client);
-  } finally {
-    await raw.close();
-  }
-}
-
-function explainPlan(
-  client: Database.Database,
-  statement: CapturedStatement,
-): string {
-  const rows = client
-    .prepare(`EXPLAIN QUERY PLAN ${statement.sql}`)
-    .all(...statement.params) as readonly { detail: string }[];
-  return rows.map((row) => row.detail).join("\n");
+  const { backend, captured, client } = createPlanCaptureBackend();
+  const store = createStore(buildGraph(), backend, options);
+  return await run(store, captured, client);
 }
 
 describe("degree() direction filter index alignment", () => {
@@ -130,7 +99,7 @@ describe("degree() direction filter index alignment", () => {
 
       captured.length = 0;
       await store.algorithms.degree(alice.id, { direction: "out" });
-      const outPlan = explainPlan(client, captured.at(-1)!);
+      const outPlan = explainQueryPlan(client, captured.at(-1)!);
       expect(outPlan).toContain("typegraph_edges_from_idx");
       expect(outPlan).not.toContain("SCAN typegraph_edges");
       // The node-kind subquery resolves the seed's kind by bare id; without
@@ -140,13 +109,13 @@ describe("degree() direction filter index alignment", () => {
 
       captured.length = 0;
       await store.algorithms.degree(bob.id, { direction: "in" });
-      const inPlan = explainPlan(client, captured.at(-1)!);
+      const inPlan = explainQueryPlan(client, captured.at(-1)!);
       expect(inPlan).toContain("typegraph_edges_to_idx");
       expect(inPlan).not.toContain("SCAN typegraph_edges");
 
       captured.length = 0;
       await store.algorithms.degree(alice.id);
-      const bothPlan = explainPlan(client, captured.at(-1)!);
+      const bothPlan = explainQueryPlan(client, captured.at(-1)!);
       expect(bothPlan).not.toContain("SCAN typegraph_edges");
     });
   });
@@ -182,7 +151,7 @@ describe("degree() direction filter index alignment", () => {
           .asOfRecorded(pin)
           .degree(alice.id, { direction: "out" });
         expect(outDegree).toBe(3);
-        const plan = explainPlan(client, captured.at(-1)!);
+        const plan = explainQueryPlan(client, captured.at(-1)!);
         expect(plan).toContain("typegraph_recorded_nodes_id_idx");
         expect(plan).not.toContain("SCAN typegraph_recorded_nodes");
       },

--- a/packages/typegraph/tests/system-indexes.test.ts
+++ b/packages/typegraph/tests/system-indexes.test.ts
@@ -1,0 +1,197 @@
+/**
+ * System-index declarations: single source of truth for TypeGraph's own
+ * base-relation indexes.
+ *
+ * - Dialect parity: both schema factories derive their index builders from
+ *   SYSTEM_INDEX_DECLARATIONS, and the extraction test proves the two
+ *   dialects' full index sets (including the hand-written structural
+ *   remainder) agree name-by-name and column-by-column.
+ * - Upgrade path: bootstrap DDL runs only on first boot, so
+ *   materializeSystemIndexes() / the createStoreWithSchema boot step are
+ *   what carry a new library version's indexes onto an already-initialized
+ *   database.
+ */
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  asCompiledRowsSql,
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  SYSTEM_INDEX_DECLARATIONS,
+} from "../src";
+import {
+  createPostgresTables,
+  generatePostgresDDL,
+} from "../src/backend/postgres";
+import { createSqliteTables, generateSqliteDDL } from "../src/backend/sqlite";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { type GraphBackend } from "../src/backend/types";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const knows = defineEdge("knows");
+
+const graph = defineGraph({
+  id: "system-indexes",
+  nodes: { Person: { type: Person } },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+type ExtractedIndex = Readonly<{
+  name: string;
+  table: string;
+  columns: string;
+  unique: boolean;
+}>;
+
+/**
+ * Pulls every plain-column CREATE INDEX out of a generated DDL script.
+ * Expression indexes (none exist for system/base tables) and partial
+ * WHERE clauses are captured via the trailing segment so the comparison
+ * still sees a difference if one dialect grows a predicate.
+ */
+function extractIndexes(statements: readonly string[]): ExtractedIndex[] {
+  const pattern =
+    /CREATE (UNIQUE )?INDEX IF NOT EXISTS "([^"]+)" ON "([^"]+)" \(([^;]*)\)(?: WHERE .*)?;/u;
+  const extracted: ExtractedIndex[] = [];
+  for (const statement of statements) {
+    const match = pattern.exec(statement);
+    if (match === null) continue;
+    extracted.push({
+      unique: match[1] !== undefined,
+      name: match[2]!,
+      table: match[3]!,
+      columns: match[4]!,
+    });
+  }
+  return extracted;
+}
+
+describe("system-index dialect parity", () => {
+  it("emits the same index set (names, columns, uniqueness) on both dialects", () => {
+    const sqliteIndexes = extractIndexes(
+      generateSqliteDDL(createSqliteTables()),
+    );
+    const postgresIndexes = extractIndexes(generatePostgresDDL());
+
+    // The fulltext table is an intentional asymmetry: SQLite uses an FTS5
+    // virtual table (no plain indexes), Postgres a typed table + GIN.
+    const fulltextTable = "typegraph_node_fulltext";
+    const normalize = (indexes: readonly ExtractedIndex[]): string[] =>
+      indexes
+        .filter((index) => index.table !== fulltextTable)
+        .map(
+          (index) =>
+            `${index.unique ? "unique " : ""}${index.table}.${index.name}(${index.columns})`,
+        )
+        .toSorted((a, b) => a.localeCompare(b));
+
+    const sqliteSet = normalize(sqliteIndexes);
+    const postgresSet = normalize(postgresIndexes);
+    expect(sqliteSet).toEqual(postgresSet);
+    expect(sqliteSet.length).toBeGreaterThan(0);
+  });
+
+  it("covers every declaration in both dialects' generated DDL", () => {
+    const scripts = [
+      generateSqliteDDL(createSqliteTables()).join("\n"),
+      generatePostgresDDL(createPostgresTables()).join("\n"),
+    ];
+    for (const script of scripts) {
+      for (const declaration of SYSTEM_INDEX_DECLARATIONS) {
+        const columns = declaration.columns
+          .map((column) => `"${column}"`)
+          .join(", ");
+        expect(script).toContain(`(${columns})`);
+      }
+    }
+  });
+});
+
+async function indexNames(backend: GraphBackend): Promise<readonly string[]> {
+  const rows = await backend.execute<{ name: string }>(
+    asCompiledRowsSql(sql`SELECT name FROM sqlite_master WHERE type = 'index'`),
+  );
+  return rows.map((row) => row.name);
+}
+
+describe("materializeSystemIndexes", () => {
+  it("adopts indexes missing from an initialized database and records status", async () => {
+    const { backend, db } = createLocalSqliteBackend();
+    try {
+      const [store] = await createStoreWithSchema(graph, backend);
+
+      // Simulate a database initialized by an older library version: the
+      // index does not exist AND no materialization was ever recorded.
+      // (The materializer trusts recorded status rows by design — same
+      // contract as graph-declared indexes — so a drop with a surviving
+      // success row is operator repair, not the upgrade scenario.)
+      db.run(sql`DROP INDEX "typegraph_nodes_id_idx"`);
+      db.run(sql`DROP INDEX "typegraph_recorded_edges_from_idx"`);
+      db.run(
+        sql`DELETE FROM "typegraph_index_materializations" WHERE index_name IN ('typegraph_nodes_id_idx', 'typegraph_recorded_edges_from_idx')`,
+      );
+      expect(await indexNames(backend)).not.toContain("typegraph_nodes_id_idx");
+
+      const { results } = await store.materializeSystemIndexes();
+      expect(results).toHaveLength(SYSTEM_INDEX_DECLARATIONS.length);
+      // Every entry either created its index or found the recorded boot
+      // materialization; none may fail or be skipped on the bundled backend.
+      for (const result of results) {
+        expect(["created", "alreadyMaterialized"]).toContain(result.status);
+        expect(result.entity).toBe("system");
+      }
+
+      const adopted = await indexNames(backend);
+      expect(adopted).toContain("typegraph_nodes_id_idx");
+      expect(adopted).toContain("typegraph_recorded_edges_from_idx");
+
+      // Status rows carry the system entity and the relation key.
+      const statusRows = await backend.execute<{
+        entity: string;
+        kind: string;
+      }>(
+        asCompiledRowsSql(
+          sql`SELECT entity, kind FROM "typegraph_index_materializations" WHERE index_name = 'typegraph_nodes_id_idx'`,
+        ),
+      );
+      expect(statusRows[0]).toEqual({ entity: "system", kind: "nodes" });
+
+      // Second call settles everything without DDL.
+      const second = await store.materializeSystemIndexes();
+      for (const result of second.results) {
+        expect(result.status).toBe("alreadyMaterialized");
+      }
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("createStoreWithSchema brings an initialized database up to the current index set", async () => {
+    const { backend, db } = createLocalSqliteBackend();
+    try {
+      await createStoreWithSchema(graph, backend);
+
+      db.run(sql`DROP INDEX "typegraph_recorded_nodes_id_idx"`);
+      // Clear the recorded materialization so the next boot cannot settle
+      // on the (now stale) success row — this mirrors a database created
+      // by a version that predates the index entirely, where no status
+      // row exists.
+      db.run(
+        sql`DELETE FROM "typegraph_index_materializations" WHERE index_name = 'typegraph_recorded_nodes_id_idx'`,
+      );
+
+      await createStoreWithSchema(graph, backend);
+      expect(await indexNames(backend)).toContain(
+        "typegraph_recorded_nodes_id_idx",
+      );
+    } finally {
+      await backend.close();
+    }
+  });
+});

--- a/packages/typegraph/tests/system-indexes.test.ts
+++ b/packages/typegraph/tests/system-indexes.test.ts
@@ -127,10 +127,7 @@ describe("materializeSystemIndexes", () => {
       const [store] = await createStoreWithSchema(graph, backend);
 
       // Simulate a database initialized by an older library version: the
-      // index does not exist AND no materialization was ever recorded.
-      // (The materializer trusts recorded status rows by design — same
-      // contract as graph-declared indexes — so a drop with a surviving
-      // success row is operator repair, not the upgrade scenario.)
+      // index does not exist and no materialization was ever recorded.
       db.run(sql`DROP INDEX "typegraph_nodes_id_idx"`);
       db.run(sql`DROP INDEX "typegraph_recorded_edges_from_idx"`);
       db.run(
@@ -167,6 +164,102 @@ describe("materializeSystemIndexes", () => {
       for (const result of second.results) {
         expect(result.status).toBe("alreadyMaterialized");
       }
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("rebuilds a physically missing index even when a success row survives", async () => {
+    const { backend, db } = createLocalSqliteBackend();
+    try {
+      const [store] = await createStoreWithSchema(graph, backend);
+      // Adopt once so a genuine success row exists for the index.
+      db.run(sql`DROP INDEX "typegraph_nodes_id_idx"`);
+      await store.materializeSystemIndexes();
+
+      // Dump/restore or a manual drop can lose the index but keep the
+      // row. Physical state is authoritative for system indexes: the
+      // runner must rebuild, not settle on the stale success.
+      db.run(sql`DROP INDEX "typegraph_nodes_id_idx"`);
+      const { results } = await store.materializeSystemIndexes();
+      const target = results.find(
+        (result) => result.indexName === "typegraph_nodes_id_idx",
+      );
+      expect(target?.status).toBe("created");
+      expect(await indexNames(backend)).toContain("typegraph_nodes_id_idx");
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("reports signature drift persistently instead of self-silencing", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const [store] = await createStoreWithSchema(graph, backend);
+      // A recorded success under a DIFFERENT signature — the shape an
+      // in-place declaration change would leave behind.
+      await backend.recordIndexMaterialization!({
+        indexName: "typegraph_nodes_id_idx",
+        graphId: "system-indexes",
+        entity: "system",
+        kind: "nodes",
+        signature: "stale-signature",
+        schemaVersion: 1,
+        attemptedAt: new Date().toISOString(),
+        materializedAt: new Date().toISOString(),
+        error: undefined,
+      });
+
+      const first = await store.materializeSystemIndexes();
+      const firstTarget = first.results.find(
+        (result) => result.indexName === "typegraph_nodes_id_idx",
+      );
+      expect(firstTarget?.status).toBe("failed");
+      expect(firstTarget?.error?.message).toContain("different signature");
+
+      // The drift record must not overwrite the row's signature — the
+      // second run has to keep failing, not settle as alreadyMaterialized.
+      const second = await store.materializeSystemIndexes();
+      const secondTarget = second.results.find(
+        (result) => result.indexName === "typegraph_nodes_id_idx",
+      );
+      expect(secondTarget?.status).toBe("failed");
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("refuses a name collision with a graph-declared index without touching its row", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const [store] = await createStoreWithSchema(graph, backend);
+      // A graph-declared index materialized under a system index's name.
+      await backend.recordIndexMaterialization!({
+        indexName: "typegraph_nodes_id_idx",
+        graphId: "someone-elses-graph",
+        entity: "node",
+        kind: "Person",
+        signature: "relational-signature",
+        schemaVersion: 3,
+        attemptedAt: new Date().toISOString(),
+        materializedAt: new Date().toISOString(),
+        error: undefined,
+      });
+
+      const { results } = await store.materializeSystemIndexes();
+      const target = results.find(
+        (result) => result.indexName === "typegraph_nodes_id_idx",
+      );
+      expect(target?.status).toBe("failed");
+      expect(target?.error?.message).toContain("Rename the graph-declared");
+
+      // The foreign row is untouched — no drift write bricked it.
+      const row = await backend.getIndexMaterialization!(
+        "typegraph_nodes_id_idx",
+      );
+      expect(row?.signature).toBe("relational-signature");
+      expect(row?.entity).toBe("node");
+      expect(row?.materializedAt).toBeDefined();
     } finally {
       await backend.close();
     }

--- a/packages/typegraph/tests/system-indexes.test.ts
+++ b/packages/typegraph/tests/system-indexes.test.ts
@@ -21,6 +21,7 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  defineNodeIndex,
   SYSTEM_INDEX_DECLARATIONS,
 } from "../src";
 import {
@@ -30,6 +31,7 @@ import {
 import { createSqliteTables, generateSqliteDDL } from "../src/backend/sqlite";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import { type GraphBackend } from "../src/backend/types";
+import { systemIndexName } from "../src/indexes/system";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -109,6 +111,93 @@ describe("system-index dialect parity", () => {
           .join(", ");
         expect(script).toContain(`(${columns})`);
       }
+    }
+  });
+});
+
+describe("system-index identifier bounds", () => {
+  it("keeps every generated name distinct and within 63 characters for long custom table names", () => {
+    // A valid 58-char custom table name: naive `${table}_${suffix}` names
+    // would exceed PostgreSQL's 63-byte identifier bound, get silently
+    // truncated by the engine, and collide (kind_idx vs kind_created_idx
+    // share their first 63 chars).
+    const longBase = `t${"x".repeat(57)}`;
+    // Distinctness matters within one physical table (suffixes repeat
+    // across tables by design — their physical names differ in practice).
+    // Edges carries the largest suffix set, including the kind_idx /
+    // kind_created_idx pair whose first 63 chars collide when naively
+    // truncated.
+    const edgeNames = SYSTEM_INDEX_DECLARATIONS.filter(
+      (declaration) => declaration.table === "edges",
+    ).map((declaration) => systemIndexName(longBase, declaration.suffix));
+    for (const name of edgeNames) {
+      expect(name.length).toBeLessThanOrEqual(63);
+    }
+    expect(new Set(edgeNames).size).toBe(edgeNames.length);
+    // Deterministic: the same inputs must resolve to the same name (the
+    // Drizzle builders, runtime DDL, and catalog probes all derive it).
+    expect(systemIndexName(longBase, "kind_idx")).toBe(
+      systemIndexName(longBase, "kind_idx"),
+    );
+    // Short names stay exactly as before — no gratuitous hashing.
+    expect(systemIndexName("typegraph_nodes", "id_idx")).toBe(
+      "typegraph_nodes_id_idx",
+    );
+  });
+
+  it("emits the bounded names in generated DDL for long custom table names", () => {
+    const longNodes = `n${"x".repeat(57)}`;
+    const ddl = generateSqliteDDL(createSqliteTables({ nodes: longNodes }));
+    const script = ddl.join("\n");
+    expect(script).toContain(`"${systemIndexName(longNodes, "kind_idx")}"`);
+    expect(script).toContain(
+      `"${systemIndexName(longNodes, "kind_created_idx")}"`,
+    );
+  });
+});
+
+describe("system-index name reservation", () => {
+  it("rejects a graph-declared index named like a system index at table definition", () => {
+    const colliding = defineNodeIndex(Person, {
+      fields: ["name"],
+      name: "typegraph_nodes_id_idx",
+    });
+    expect(() => createSqliteTables({}, { indexes: [colliding] })).toThrow(
+      /collides with a TypeGraph system index/,
+    );
+    expect(() => createPostgresTables({}, { indexes: [colliding] })).toThrow(
+      /collides with a TypeGraph system index/,
+    );
+  });
+
+  it("fails a colliding declaration in materializeIndexes without any write", async () => {
+    const { backend } = createLocalSqliteBackend();
+    try {
+      const colliding = defineNodeIndex(Person, {
+        fields: ["name"],
+        name: "typegraph_nodes_id_idx",
+      });
+      const collidingGraph = defineGraph({
+        id: "system-indexes-collide",
+        nodes: { Person: { type: Person } },
+        edges: {},
+        indexes: [colliding],
+      });
+      const [store] = await createStoreWithSchema(collidingGraph, backend);
+
+      const { results } = await store.materializeIndexes();
+      const target = results.find(
+        (result) => result.indexName === "typegraph_nodes_id_idx",
+      );
+      expect(target?.status).toBe("failed");
+      expect(target?.error?.message).toContain("collides with a TypeGraph");
+      // No false-success row was recorded over the system index's name.
+      const row = await backend.getIndexMaterialization!(
+        "typegraph_nodes_id_idx",
+      );
+      expect(row?.entity === "node").toBe(false);
+    } finally {
+      await backend.close();
     }
   });
 });
@@ -260,6 +349,39 @@ describe("materializeSystemIndexes", () => {
       expect(row?.signature).toBe("relational-signature");
       expect(row?.entity).toBe("node");
       expect(row?.materializedAt).toBeDefined();
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("skips indexes for optional relations the database predates", async () => {
+    const { backend, db } = createLocalSqliteBackend();
+    try {
+      const [store] = await createStoreWithSchema(graph, backend);
+      // A legacy database that predates the recorded relations.
+      db.run(sql`DROP TABLE "typegraph_recorded_edges"`);
+      db.run(sql`DROP TABLE "typegraph_recorded_nodes"`);
+
+      const { results } = await store.materializeSystemIndexes();
+      const recorded = results.filter(
+        (result) =>
+          result.kind === "recordedNodes" || result.kind === "recordedEdges",
+      );
+      expect(recorded.length).toBeGreaterThan(0);
+      for (const result of recorded) {
+        expect(result.status).toBe("skipped");
+        expect(result.reason).toContain("does not exist");
+      }
+      const live = results.filter(
+        (result) => result.kind === "nodes" || result.kind === "edges",
+      );
+      for (const result of live) {
+        expect(result.status).toBe("alreadyMaterialized");
+      }
+
+      // Boot on the same legacy database stays quiet too (no failing DDL,
+      // no warnings) — the lenient boot path reuses the same runner.
+      await createStoreWithSchema(graph, backend);
     } finally {
       await backend.close();
     }

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -3,6 +3,7 @@
  *
  * Uses createLocalSqliteBackend from the public sqlite module.
  */
+import type Database from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { afterEach } from "vitest";
 
@@ -63,6 +64,77 @@ export async function createInitializedStore<G extends GraphDef>(
 ): Promise<Store<G>> {
   const [store] = await createStoreWithSchema(graph, backend);
   return store;
+}
+
+export type CapturedStatement = Readonly<{
+  sql: string;
+  params: readonly unknown[];
+}>;
+
+export type PlanCaptureHarness = Readonly<{
+  /** Pass to createStore/createStoreWithSchema; auto-closed after the test. */
+  backend: GraphBackend;
+  /** Every executed statement, in order. Reset with `captured.length = 0`. */
+  captured: CapturedStatement[];
+  /** Raw better-sqlite3 client, for EXPLAIN QUERY PLAN. */
+  client: Database.Database;
+}>;
+
+/**
+ * An in-memory SQLite backend that captures every executed statement so a
+ * test can assert its actual query plan — the "index exists but the
+ * planner won't use it" failure class that DDL-presence assertions can't
+ * catch. Pair with {@link explainQueryPlan}:
+ *
+ * ```ts
+ * const { backend, captured, client } = createPlanCaptureBackend();
+ * const store = createStore(graph, backend);
+ * // ... seed data, refreshStatistics() ...
+ * captured.length = 0;
+ * await store.algorithms.degree(node.id);
+ * const plan = explainQueryPlan(client, captured.at(-1)!);
+ * expect(plan).toContain("my_expected_idx");
+ * expect(plan).not.toContain("SCAN typegraph_nodes");
+ * ```
+ */
+export function createPlanCaptureBackend(): PlanCaptureHarness {
+  const { backend: raw, db } = createLocalSqliteBackend();
+  const captured: CapturedStatement[] = [];
+  const backend: GraphBackend = {
+    ...raw,
+    async execute(query) {
+      const compiled = raw.compileSql?.(query);
+      if (compiled) {
+        captured.push({ sql: compiled.sql, params: compiled.params });
+      }
+      return raw.execute(query);
+    },
+    // Reads run through the cached-template fast path (executeRaw), which
+    // receives SQL text with all placeholders already filled — directly
+    // EXPLAIN-able.
+    async executeRaw<T>(sqlText: string, params: readonly unknown[]) {
+      captured.push({ sql: sqlText, params });
+      return raw.executeRaw!<T>(sqlText, params);
+    },
+  };
+  backendsToClose.push(raw);
+  const client = (db as unknown as { $client: Database.Database }).$client;
+  return { backend, captured, client };
+}
+
+/**
+ * The `EXPLAIN QUERY PLAN` detail lines for a captured statement, joined
+ * with newlines — assert index usage with `toContain("<index name>")` and
+ * scan absence with `not.toContain("SCAN <table>")`.
+ */
+export function explainQueryPlan(
+  client: Database.Database,
+  statement: CapturedStatement,
+): string {
+  const rows = client
+    .prepare(`EXPLAIN QUERY PLAN ${statement.sql}`)
+    .all(...statement.params) as readonly { detail: string }[];
+  return rows.map((row) => row.detail).join("\n");
 }
 
 /**


### PR DESCRIPTION
TypeGraph's base-relation indexes were maintained as two hand-synced lists (one per dialect schema file) and applied only by first-boot bootstrap DDL. That structure produced the exact failure #282 exposed: an index added in a newer library version **never reaches an already-initialized database** — `bootstrapTables()` only runs on a missing-table error, `createStore`/`createVerifiedStore` are zero-DDL by contract, and `schema/migration.ts` classifies index diffs as "safe" but never emits index actions. With six index-touching perf PRs merged in three weeks and more coming from the benchmark work, the per-index bolt-on pattern needed a foundation.

## Design

Complete the existing seam rather than adding a new abstraction: graph-declared indexes already have declarations, a DDL generator, a materializer with durable status rows, drift signatures, and a Postgres `CREATE INDEX CONCURRENTLY` cross-caller claim protocol. This PR brings the system indexes into that machinery.

- **`SYSTEM_INDEX_DECLARATIONS` — single source of truth** (`src/indexes/system.ts`) for the 21 plain btree indexes on nodes/edges/recorded relations, with per-table column-union types and the access-path rationale comments consolidated in one place. Both dialect schema factories derive their Drizzle index builders from it (columns resolved by each drizzle column's own physical `.name` — no naming convention in between), so **the two dialects cannot drift by construction**. Generated DDL is byte-identical to main: same names, columns, and order.
- **`materializeSystemIndexes()`** rides the shared materialization frame (status rows, drift signatures, invalid-leftover healing, CIC claim protocol) with system-specific physical-state semantics: a system index is fully identified by its library-owned name, so one bulk catalog read (scoped to the session `search_path` via `pg_table_is_visible`) both settles present indexes with zero DDL/writes **and** forces a rebuild when an index is physically absent or INVALID despite a stale success row (dump/restore, manual drop). Warm call: two concurrent reads, no DDL.
- **Boot integration**: `createStoreWithSchema` brings system indexes up to the running library version (the same privileged-boot step as fulltext/vector contributions). Lenient by contract — capability-missing backends are skipped, per-index and infrastructure failures degrade to a warning, the store always comes up. `systemIndexes: "skip"` opts out for deployments that must not run index builds inline at boot; **`store.materializeSystemIndexes()`** is the strict explicit API for zero-DDL deployments (replaces #282's "call `backend.bootstrapTables()`" guidance).
- **Plan-contract helpers**: `createPlanCaptureBackend()`/`explainQueryPlan()` extracted into `tests/test-utils.ts` so index changes can assert actual `EXPLAIN QUERY PLAN` shapes, not just DDL presence (the `degree-index-alignment` tests now consume them).

## Review hardening

The branch went through a 4-agent quality pass and a 19-agent high-effort correctness review; all verified findings are addressed in the third commit, including three that reached beyond the new code:

- The Postgres catalog probes are `search_path`-scoped — a schema-per-tenant database can never settle (or steer the `DROP INDEX` heal at) another schema's identically-named index.
- `buildMaterializationOnConflictSet` no longer overwrites a status row's shape columns on a **failed** attempt — signature drift now reports persistently instead of self-silencing after one run (pre-existing frame bug; fixes relational drift reporting too).
- A status row owned by a graph-declared index that collides with a system index name is refused **without writing**, instead of drift-failing over it and permanently bricking the user's index row.

Documented limitations (deliberate, in `system.ts`): an in-place declaration reshape is undetectable on bootstrap-created databases — the rename-on-reshape rule is enforced by review and the parity tests; and a renamed suffix strands the old physical index until a retired-suffixes drop path is added alongside the first real rename.

## Tests

- Cross-dialect parity: extraction test pins both generated DDL scripts' full index sets (names, columns, uniqueness) to each other; declaration-coverage test on both dialects.
- Upgrade paths: runtime adoption + boot adoption on SQLite; CONCURRENTLY-path adoption with status-row assertions on PostgreSQL.
- Hardening regressions: rebuild-on-physically-missing, persistent drift reporting, collision-refusal with untouched foreign row.
- Full SQLite suite 5,031 passed; PostgreSQL lane 71 files / 2,074 passed; `pnpm fix`, `pnpm typecheck`, knip clean.

Changeset: minor (`store.materializeSystemIndexes()`, `systemIndexes` boot option, `SYSTEM_INDEX_DECLARATIONS` export, `IndexEntity` gains `"system"`).
