### PR TITLE
perf(algorithms): remove iterative-round overheads (WCC join, round-trips, work_mem)

### DIFF
--- a/.changeset/iterative-algorithm-overheads.md
+++ b/.changeset/iterative-algorithm-overheads.md
@@ -27,11 +27,15 @@ collation could pick a different (equally shortest) path.
 
 New option: iterative algorithm calls (`reachable`, `shortestPath`,
 `canReach`, `neighbors`, `weaklyConnectedComponents`) accept
-`workingMemory?: string` (default `"64MB"`), a transaction-scoped memory
-budget applied on PostgreSQL with `SET LOCAL work_mem` semantics via
-parameterized `set_config`. It prevents whole-graph rounds from spilling
-their sorts to disk (measured ~106MB external merges per WCC round on SF1),
-never touches the session or server setting, is validated as
-`<digits>kB|MB|GB` within PostgreSQL's accepted `work_mem` range
-(64kB–2147483647kB) with the same typed error on both backends, and is
-ignored by SQLite.
+`workingMemory?: string`, an opt-in, transaction-scoped override of the
+session's `work_mem`, applied on PostgreSQL with `SET LOCAL` semantics via
+parameterized `set_config`. By default (option omitted) operations inherit
+the server's configured `work_mem` — nothing is overridden. `work_mem` is a
+threshold each sort/hash operator (and each parallel worker) may allocate up
+to, not a per-operation budget, and concurrent calls multiply it; set it
+deliberately (e.g. `"64MB"`) for large single-tenant analytical runs where
+the configured default spills whole-graph sorts to disk (measured ~106MB
+external merges per WCC round on SF1). The override never touches the
+session or server setting, is validated as `<digits>kB|MB|GB` within
+PostgreSQL's accepted `work_mem` range (64kB–2147483647kB) with the same
+typed error on both backends, and is ignored by SQLite.

--- a/.changeset/iterative-algorithm-overheads.md
+++ b/.changeset/iterative-algorithm-overheads.md
@@ -20,6 +20,10 @@ shortest-path traversal that used to issue two to three statements per round
 now issues one, roughly halving round-trip latency on latency-bound
 connections. The working-table `ANALYZE` policy is unchanged in its
 thresholds but no longer runs when no further round will read the table.
+When several equal-depth meetings exist, the tie now breaks by node id then
+kind in code-unit order on both backends — previously the selection followed
+the database collation, so a PostgreSQL cluster with a linguistic default
+collation could pick a different (equally shortest) path.
 
 New option: iterative algorithm calls (`reachable`, `shortestPath`,
 `canReach`, `neighbors`, `weaklyConnectedComponents`) accept
@@ -28,4 +32,6 @@ budget applied on PostgreSQL with `SET LOCAL work_mem` semantics via
 parameterized `set_config`. It prevents whole-graph rounds from spilling
 their sorts to disk (measured ~106MB external merges per WCC round on SF1),
 never touches the session or server setting, is validated as
-`<digits>kB|MB|GB`, and is ignored by SQLite.
+`<digits>kB|MB|GB` within PostgreSQL's accepted `work_mem` range
+(64kB–2147483647kB) with the same typed error on both backends, and is
+ignored by SQLite.

--- a/.changeset/iterative-algorithm-overheads.md
+++ b/.changeset/iterative-algorithm-overheads.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Cut three overheads out of the iterative graph algorithms, root-caused with
+`EXPLAIN (ANALYZE, BUFFERS)` against LDBC SNB SF1 on PostgreSQL.
+
+Weakly connected components no longer re-validates node visibility per edge in
+its propagate rounds. The working table is seeded through the same
+graph/kind/temporal filters inside the same snapshot and both edge endpoints
+are already joined against it, so membership is the visibility proof; the
+per-edge `typegraph_nodes` index loops (hundreds of thousands per round on
+SF1) added nothing. Results are byte-identical.
+
+Traversal rounds now carry their own bookkeeping instead of issuing follow-up
+statements: seeding returns the frontier through `INSERT … RETURNING`, and
+bidirectional shortest-path rounds detect the frontier meeting inside the
+expansion statement rather than with a separate probe per round. A
+shortest-path traversal that used to issue two to three statements per round
+now issues one, roughly halving round-trip latency on latency-bound
+connections. The working-table `ANALYZE` policy is unchanged in its
+thresholds but no longer runs when no further round will read the table.
+
+New option: iterative algorithm calls (`reachable`, `shortestPath`,
+`canReach`, `neighbors`, `weaklyConnectedComponents`) accept
+`workingMemory?: string` (default `"64MB"`), a transaction-scoped memory
+budget applied on PostgreSQL with `SET LOCAL work_mem` semantics via
+parameterized `set_config`. It prevents whole-graph rounds from spilling
+their sorts to disk (measured ~106MB external merges per WCC round on SF1),
+never touches the session or server setting, is validated as
+`<digits>kB|MB|GB`, and is ignored by SQLite.

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -61,7 +61,7 @@ Every traversal algorithm takes the same base options:
 | `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Compatibility option; both values use set-based node de-duplication |
 | `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to nodes and edges along the traversal — see [Temporal Behavior](#temporal-behavior) |
 | `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
-| `workingMemory` | `string` | `"64MB"` | Transaction-scoped memory budget for iterative rounds on PostgreSQL (`SET LOCAL work_mem` semantics); validated as `<digits>kB\|MB\|GB` within 64kB–2147483647kB, ignored by SQLite |
+| `workingMemory` | `string` | *(inherits server `work_mem`)* | Opt-in, transaction-scoped `work_mem` override for iterative rounds on PostgreSQL (`SET LOCAL` semantics); validated as `<digits>kB\|MB\|GB` within 64kB–2147483647kB, ignored by SQLite |
 
 `direction: "both"` treats edges as undirected. `cyclePolicy` remains accepted
 for compatibility with recursive query-builder traversals, but it does not
@@ -215,13 +215,22 @@ plans based on PostgreSQL's initial one-row estimate for a new temporary table.
 The policy is automatic, applies to WCC and growing traversal frontiers, and is
 a no-op on SQLite.
 
-Iterative operations (WCC and the working-table traversals) also raise
-PostgreSQL's per-operation memory budget for their rounds. The `workingMemory`
-option (default `"64MB"`) is applied with `SET LOCAL work_mem` semantics inside
-the operation's own transaction — the session and server settings are never
-modified, and the override ends with the transaction. The value must be a
-plain integer with a `kB`, `MB`, or `GB` suffix within PostgreSQL's accepted
-`work_mem` range (64kB to 2147483647kB) — both backends reject out-of-range
+Iterative operations (WCC and the working-table traversals) accept an opt-in
+`workingMemory` override of the session's `work_mem` for their rounds. When
+set, it is applied with `SET LOCAL work_mem` semantics inside the operation's
+own transaction — the session and server settings are never modified, and the
+override ends with the transaction. When omitted (the default), operations
+inherit the server's configured `work_mem`.
+
+Note that `work_mem` is a threshold each sort/hash operator (and each parallel
+worker) may allocate up to, **not** a per-operation budget: a single round can
+allocate several multiples of it, and concurrent algorithm calls multiply
+again. Raise it deliberately — for example `workingMemory: "64MB"` keeps
+whole-graph rounds from spilling their sorts to disk on large single-tenant
+analytical runs (such as LDBC SNB SF1-scale benchmarks) — rather than as a
+blanket setting on a shared cluster. The value must be a plain integer with a
+`kB`, `MB`, or `GB` suffix within PostgreSQL's accepted `work_mem` range
+(64kB to 2147483647kB) — both backends reject malformed or out-of-range
 values with the same error. SQLite validates and otherwise ignores it.
 
 Without `nodeKinds`, WCC seeds every visible node, so unrelated nodes still

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -61,7 +61,7 @@ Every traversal algorithm takes the same base options:
 | `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Compatibility option; both values use set-based node de-duplication |
 | `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to nodes and edges along the traversal — see [Temporal Behavior](#temporal-behavior) |
 | `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
-| `workingMemory` | `string` | `"64MB"` | Transaction-scoped memory budget for iterative rounds on PostgreSQL (`SET LOCAL work_mem` semantics); validated as `<digits>kB\|MB\|GB`, ignored by SQLite |
+| `workingMemory` | `string` | `"64MB"` | Transaction-scoped memory budget for iterative rounds on PostgreSQL (`SET LOCAL work_mem` semantics); validated as `<digits>kB\|MB\|GB` within 64kB–2147483647kB, ignored by SQLite |
 
 `direction: "both"` treats edges as undirected. `cyclePolicy` remains accepted
 for compatibility with recursive query-builder traversals, but it does not
@@ -175,7 +175,6 @@ const everything = await store.algorithms.degree(alice);
 | `direction` | `"out" \| "in" \| "both"` | `"both"` | Count outgoing, incoming, or either |
 | `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to the counted edges |
 | `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
-| `workingMemory` | `string` | `"64MB"` | Transaction-scoped memory budget for iterative rounds on PostgreSQL (`SET LOCAL work_mem` semantics); validated as `<digits>kB\|MB\|GB`, ignored by SQLite |
 
 `degree` runs a single `COUNT` query, not a recursive CTE, so it's
 efficient even for hub nodes with thousands of edges.
@@ -221,8 +220,9 @@ PostgreSQL's per-operation memory budget for their rounds. The `workingMemory`
 option (default `"64MB"`) is applied with `SET LOCAL work_mem` semantics inside
 the operation's own transaction — the session and server settings are never
 modified, and the override ends with the transaction. The value must be a
-plain integer with a `kB`, `MB`, or `GB` suffix; SQLite validates and ignores
-it.
+plain integer with a `kB`, `MB`, or `GB` suffix within PostgreSQL's accepted
+`work_mem` range (64kB to 2147483647kB) — both backends reject out-of-range
+values with the same error. SQLite validates and otherwise ignores it.
 
 Without `nodeKinds`, WCC seeds every visible node, so unrelated nodes still
 appear as singleton components. On heterogeneous graphs, pass the kinds that

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -61,6 +61,7 @@ Every traversal algorithm takes the same base options:
 | `cyclePolicy` | `"prevent" \| "allow"` | `"prevent"` | Compatibility option; both values use set-based node de-duplication |
 | `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to nodes and edges along the traversal — see [Temporal Behavior](#temporal-behavior) |
 | `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
+| `workingMemory` | `string` | `"64MB"` | Transaction-scoped memory budget for iterative rounds on PostgreSQL (`SET LOCAL work_mem` semantics); validated as `<digits>kB\|MB\|GB`, ignored by SQLite |
 
 `direction: "both"` treats edges as undirected. `cyclePolicy` remains accepted
 for compatibility with recursive query-builder traversals, but it does not
@@ -174,6 +175,7 @@ const everything = await store.algorithms.degree(alice);
 | `direction` | `"out" \| "in" \| "both"` | `"both"` | Count outgoing, incoming, or either |
 | `temporalMode` | `TemporalMode` | `graph.defaults.temporalMode` | Filter applied to the counted edges |
 | `asOf` | `string` (ISO-8601) | *(none)* | Snapshot timestamp, required when `temporalMode: "asOf"` |
+| `workingMemory` | `string` | `"64MB"` | Transaction-scoped memory budget for iterative rounds on PostgreSQL (`SET LOCAL work_mem` semantics); validated as `<digits>kB\|MB\|GB`, ignored by SQLite |
 
 `degree` runs a single `COUNT` query, not a recursive CTE, so it's
 efficient even for hub nodes with thousands of edges.
@@ -213,6 +215,14 @@ working table and refreshes them again after multiplicative growth. This avoids
 plans based on PostgreSQL's initial one-row estimate for a new temporary table.
 The policy is automatic, applies to WCC and growing traversal frontiers, and is
 a no-op on SQLite.
+
+Iterative operations (WCC and the working-table traversals) also raise
+PostgreSQL's per-operation memory budget for their rounds. The `workingMemory`
+option (default `"64MB"`) is applied with `SET LOCAL work_mem` semantics inside
+the operation's own transaction — the session and server settings are never
+modified, and the override ends with the transaction. The value must be a
+plain integer with a `kB`, `MB`, or `GB` suffix; SQLite validates and ignores
+it.
 
 Without `nodeKinds`, WCC seeds every visible node, so unrelated nodes still
 appear as singleton components. On heterogeneous graphs, pass the kinds that

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -74,6 +74,13 @@ export const postgresDialect: DialectAdapter = {
     return sql`ANALYZE ${table}`;
   },
 
+  setTransactionWorkingMemory(workingMemory) {
+    // The parameterizable form of `SET LOCAL work_mem`: is_local => true
+    // scopes the override to the current transaction, matching the pgvector
+    // iterative-scan GUC handling elsewhere in the backend.
+    return sql`SELECT set_config('work_mem', ${workingMemory}, true)`;
+  },
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -78,6 +78,11 @@ export const sqliteDialect: DialectAdapter = {
     return;
   },
 
+  setTransactionWorkingMemory(): undefined {
+    // SQLite has no per-transaction working-memory budget to raise.
+    return;
+  },
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -119,6 +119,17 @@ export interface DialectAdapter {
    */
   analyzeTemporaryTable(table: SQLWrapper): SQL | undefined;
 
+  /**
+   * Builds the dialect's transaction-scoped working-memory override for
+   * sort/hash-heavy iterative rounds. PostgreSQL emits the parameterized
+   * `SET LOCAL work_mem` form (`set_config(..., is_local => true)`), which
+   * reverts automatically when the transaction ends and never touches the
+   * session or server setting. Returns undefined when the engine has no
+   * per-operation memory budget to raise (SQLite). Callers must run the
+   * statement inside a transaction and validate the value's shape first.
+   */
+  setTransactionWorkingMemory(workingMemory: string): SQL | undefined;
+
   // ============================================================
   // JSON Path Operations
   // ============================================================

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -283,8 +283,9 @@ async function seedWorkingSide(
 /**
  * Detects the depth-zero meeting for bidirectional search: a node seeded on
  * both sides (source equals target, possibly across kinds sharing that id).
- * Ties break like the SQL meeting probe used to — smallest node id, then
- * kind.
+ * Ties break by node id then kind in UTF-16 code-unit order — deterministic
+ * and identical on both backends, unlike the collation-dependent SQL probe
+ * this replaced.
  */
 function findSeedMeeting(
   forwardSeeds: readonly SeededRow[],
@@ -387,9 +388,12 @@ async function expandWorkingTableRound(
 }
 
 /**
- * Folds one round's inserted rows into the best meeting so far, matching the
- * former SQL probe's selection: smallest total depth within `maxHops`, ties
- * broken by node id then kind.
+ * Folds one round's inserted rows into the best meeting so far: smallest
+ * total depth within `maxHops`, ties broken by node id then kind in UTF-16
+ * code-unit order. That tie-break is deterministic and identical on both
+ * backends; the SQL probe it replaced ordered under the database collation,
+ * so equal-depth meetings could previously pick a different node on a
+ * PostgreSQL cluster with a linguistic default collation.
  */
 function selectRoundMeeting(
   currentMeeting: MeetingNode | undefined,
@@ -399,10 +403,10 @@ function selectRoundMeeting(
 ): MeetingNode | undefined {
   let meeting = currentMeeting;
   for (const row of rows) {
-    if (
-      typeof row.meeting_depth !== "number" &&
-      typeof row.meeting_depth !== "string"
-    ) {
+    // Drivers may deliver the INTEGER column as number, text, or bigint
+    // (e.g. better-sqlite3 with defaultSafeIntegers); only its absence means
+    // "no meeting". Number() coerces every numeric shape.
+    if (row.meeting_depth === null || row.meeting_depth === undefined) {
       continue;
     }
     const totalDepth = nextDepth + Number(row.meeting_depth);

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -47,14 +47,24 @@ type WorkingRow = Readonly<{
   predecessor_kind: unknown;
 }>;
 
-type CountRow = Readonly<{ count: number | string }>;
 type InsertedRow = Readonly<{ node_id: string }>;
+type SeededRow = Readonly<{ node_id: string; node_kind: string }>;
+type InsertedFrontierRow = Readonly<{
+  node_id: string;
+  node_kind: string;
+  meeting_depth: unknown;
+}>;
 type WorkingSide = "forward" | "reverse";
 
 type MeetingNode = Readonly<{
   id: string;
   kind: string;
   depth: number;
+}>;
+
+type FrontierRound = Readonly<{
+  insertedCount: number;
+  meeting: MeetingNode | undefined;
 }>;
 
 export async function findReachableNodes(
@@ -89,8 +99,12 @@ export async function findShortestPath(
 }
 
 function supportsTemporaryIteration(ctx: AlgorithmContext): boolean {
+  // Working-table rounds fold their frontier and meeting bookkeeping into
+  // `INSERT … RETURNING`, so an engine without RETURNING must take the
+  // inline fallback.
   return (
     ctx.backend.capabilities.transactions &&
+    ctx.backend.capabilities.returning !== false &&
     ctx.backend.executeTemporaryStatement !== undefined
   );
 }
@@ -106,12 +120,11 @@ async function findReachableNodesInWorkingTable(
     maxIterations: maxHops,
     createWorkingTable,
     async initialize(context) {
-      await seedWorkingSide(context, sourceId, "forward");
-      const frontierCount = await countWorkingDepth(context, "forward", 0);
+      const seeded = await seedWorkingSide(context, sourceId, "forward");
       return {
         depth: 0,
-        frontierCount,
-        workingTableSize: frontierCount,
+        frontierCount: seeded.length,
+        workingTableSize: seeded.length,
       };
     },
     async runRound(context, state) {
@@ -160,21 +173,15 @@ async function findShortestPathInWorkingTable(
     maxIterations: maxHops,
     createWorkingTable,
     async initialize(context) {
-      await seedWorkingSide(context, sourceId, "forward");
-      await seedWorkingSide(context, targetId, "reverse");
-      const [forwardFrontierCount, reverseFrontierCount, meeting] =
-        await Promise.all([
-          countWorkingDepth(context, "forward", 0),
-          countWorkingDepth(context, "reverse", 0),
-          findWorkingMeeting(context, maxHops),
-        ]);
+      const forwardSeeds = await seedWorkingSide(context, sourceId, "forward");
+      const reverseSeeds = await seedWorkingSide(context, targetId, "reverse");
       return {
         forwardDepth: 0,
         reverseDepth: 0,
-        forwardFrontierCount,
-        reverseFrontierCount,
-        meeting,
-        workingTableSize: forwardFrontierCount + reverseFrontierCount,
+        forwardFrontierCount: forwardSeeds.length,
+        reverseFrontierCount: reverseSeeds.length,
+        meeting: findSeedMeeting(forwardSeeds, reverseSeeds),
+        workingTableSize: forwardSeeds.length + reverseSeeds.length,
       };
     },
     async runRound(context, state) {
@@ -188,24 +195,24 @@ async function findShortestPathInWorkingTable(
         expandForward ?
           context.operation.direction
         : reverseDirection(context.operation.direction);
-      const frontierCount = await expandWorkingTableRound(
+      const round = await expandWorkingTableRound(
         context,
         side,
         currentDepth,
         nextDepth,
         direction,
+        maxHops,
       );
-      const meeting = await findWorkingMeeting(context, maxHops);
 
       return {
         forwardDepth: expandForward ? nextDepth : state.forwardDepth,
         reverseDepth: expandForward ? state.reverseDepth : nextDepth,
         forwardFrontierCount:
-          expandForward ? frontierCount : state.forwardFrontierCount,
+          expandForward ? round.insertedCount : state.forwardFrontierCount,
         reverseFrontierCount:
-          expandForward ? state.reverseFrontierCount : frontierCount,
-        meeting,
-        workingTableSize: state.workingTableSize + frontierCount,
+          expandForward ? state.reverseFrontierCount : round.insertedCount,
+        meeting: round.meeting,
+        workingTableSize: state.workingTableSize + round.insertedCount,
       };
     },
     hasConverged(state) {
@@ -239,56 +246,86 @@ function createWorkingTable(context: IterativeGraphRunContext) {
         depth INTEGER NOT NULL,
         predecessor_id TEXT,
         predecessor_kind TEXT,
+        meeting_depth INTEGER,
         PRIMARY KEY (graph_id, run_id, side, node_kind, node_id)
       )
   `;
 }
 
+/**
+ * Seeds one traversal side and returns the seeded node identities from the
+ * same statement, so the caller reads the frontier size (and, for
+ * bidirectional search, the source-equals-target meeting) without a
+ * follow-up COUNT round-trip.
+ */
 async function seedWorkingSide(
   context: IterativeGraphRunContext,
   nodeId: string,
   side: WorkingSide,
-): Promise<void> {
+): Promise<readonly SeededRow[]> {
   const { operation, workingTable, graphId, runId } = context;
-  await context.executeTemporary(sql`
-    INSERT INTO ${workingTable}
-      (graph_id, run_id, side, node_id, node_kind, depth,
-       predecessor_id, predecessor_kind)
-    SELECT ${graphId}, ${runId}, ${side}, n.id, n.kind, 0, NULL, NULL
-    FROM ${operation.schema.nodesTable} n
-    WHERE n.graph_id = ${graphId}
-      AND n.id = ${nodeId}
-      AND ${operation.nodeTemporalFilter}
-    ON CONFLICT (graph_id, run_id, side, node_kind, node_id) DO NOTHING
-  `);
-}
-
-async function countWorkingDepth(
-  context: IterativeGraphRunContext,
-  side: WorkingSide,
-  depth: number,
-): Promise<number> {
-  const rows = await context.backend.execute<CountRow>(
+  return context.backend.execute<SeededRow>(
     asCompiledRowsSql(sql`
-      SELECT COUNT(*) AS count
-      FROM ${context.workingTable}
-      WHERE graph_id = ${context.graphId}
-        AND run_id = ${context.runId}
-        AND side = ${side}
-        AND depth = ${depth}
+      INSERT INTO ${workingTable}
+        (graph_id, run_id, side, node_id, node_kind, depth,
+         predecessor_id, predecessor_kind)
+      SELECT ${graphId}, ${runId}, ${side}, n.id, n.kind, 0, NULL, NULL
+      FROM ${operation.schema.nodesTable} n
+      WHERE n.graph_id = ${graphId}
+        AND n.id = ${nodeId}
+        AND ${operation.nodeTemporalFilter}
+      ON CONFLICT (graph_id, run_id, side, node_kind, node_id) DO NOTHING
+      RETURNING node_id, node_kind
     `),
   );
-  return Number(rows[0]?.count ?? 0);
 }
 
+/**
+ * Detects the depth-zero meeting for bidirectional search: a node seeded on
+ * both sides (source equals target, possibly across kinds sharing that id).
+ * Ties break like the SQL meeting probe used to — smallest node id, then
+ * kind.
+ */
+function findSeedMeeting(
+  forwardSeeds: readonly SeededRow[],
+  reverseSeeds: readonly SeededRow[],
+): MeetingNode | undefined {
+  const reverseKeys = new Set(
+    reverseSeeds.map((row) =>
+      nodeIdentityKey({ id: row.node_id, kind: row.node_kind }),
+    ),
+  );
+  let meeting: MeetingNode | undefined;
+  for (const row of forwardSeeds) {
+    const candidate = { id: row.node_id, kind: row.node_kind, depth: 0 };
+    if (!reverseKeys.has(nodeIdentityKey(candidate))) continue;
+    if (meeting === undefined || compareNodeIdentity(candidate, meeting) < 0) {
+      meeting = candidate;
+    }
+  }
+  return meeting;
+}
+
+/**
+ * Expands one bidirectional round and detects meetings in the same
+ * statement. Each inserted frontier row captures the opposite side's depth
+ * for the same node identity (`meeting_depth`); a non-null value marks a
+ * meeting. Only newly inserted rows can create a new meeting — both sides'
+ * existing rows are immutable and any meeting among them would have
+ * converged an earlier round — so the returned rows are a complete meeting
+ * probe and the separate per-round meeting query is unnecessary.
+ */
 async function expandWorkingTableRound(
   context: IterativeGraphRunContext,
   side: WorkingSide,
   currentDepth: number,
   nextDepth: number,
   direction: TraversalDirection,
-): Promise<number> {
+  maxHops: number,
+): Promise<FrontierRound> {
+  const oppositeSide: WorkingSide = side === "forward" ? "reverse" : "forward";
   let insertedCount = 0;
+  let meeting: MeetingNode | undefined;
   for (const edgeKinds of context.operation.edgeKindChunks) {
     const sourceFilter = sql`
       w.graph_id = ${context.graphId}
@@ -303,15 +340,24 @@ async function expandWorkingTableRound(
       direction,
       edgeKinds,
     );
-    const rows = await context.backend.execute<InsertedRow>(
+    const rows = await context.backend.execute<InsertedFrontierRow>(
       asCompiledRowsSql(sql`
         INSERT INTO ${context.workingTable}
           (graph_id, run_id, side, node_id, node_kind, depth,
-           predecessor_id, predecessor_kind)
+           predecessor_id, predecessor_kind, meeting_depth)
         SELECT
           ${context.graphId}, ${context.runId}, ${side},
           ranked.target_id, ranked.target_kind, ${nextDepth},
-          ranked.source_id, ranked.source_kind
+          ranked.source_id, ranked.source_kind,
+          (
+            SELECT opposite.depth
+            FROM ${context.workingTable} opposite
+            WHERE opposite.graph_id = ${context.graphId}
+              AND opposite.run_id = ${context.runId}
+              AND opposite.side = ${oppositeSide}
+              AND opposite.node_id = ranked.target_id
+              AND opposite.node_kind = ranked.target_kind
+          )
         FROM (
           SELECT expanded.*,
             ROW_NUMBER() OVER (
@@ -331,12 +377,51 @@ async function expandWorkingTableRound(
               AND visited.node_kind = ranked.target_kind
           )
         ON CONFLICT (graph_id, run_id, side, node_kind, node_id) DO NOTHING
-        RETURNING node_id
+        RETURNING node_id, node_kind, meeting_depth
       `),
     );
     insertedCount += rows.length;
+    meeting = selectRoundMeeting(meeting, rows, nextDepth, maxHops);
   }
-  return insertedCount;
+  return { insertedCount, meeting };
+}
+
+/**
+ * Folds one round's inserted rows into the best meeting so far, matching the
+ * former SQL probe's selection: smallest total depth within `maxHops`, ties
+ * broken by node id then kind.
+ */
+function selectRoundMeeting(
+  currentMeeting: MeetingNode | undefined,
+  rows: readonly InsertedFrontierRow[],
+  nextDepth: number,
+  maxHops: number,
+): MeetingNode | undefined {
+  let meeting = currentMeeting;
+  for (const row of rows) {
+    if (
+      typeof row.meeting_depth !== "number" &&
+      typeof row.meeting_depth !== "string"
+    ) {
+      continue;
+    }
+    const totalDepth = nextDepth + Number(row.meeting_depth);
+    if (totalDepth > maxHops) continue;
+    const candidate = {
+      id: row.node_id,
+      kind: row.node_kind,
+      depth: totalDepth,
+    };
+    if (
+      meeting === undefined ||
+      candidate.depth < meeting.depth ||
+      (candidate.depth === meeting.depth &&
+        compareNodeIdentity(candidate, meeting) < 0)
+    ) {
+      meeting = candidate;
+    }
+  }
+  return meeting;
 }
 
 /**
@@ -401,46 +486,6 @@ async function expandReachableWorkingTableRound(
     insertedCount += rows.length;
   }
   return insertedCount;
-}
-
-async function findWorkingMeeting(
-  context: IterativeGraphRunContext,
-  maxHops: number,
-): Promise<MeetingNode | undefined> {
-  const rows = await context.backend.execute<
-    Readonly<{
-      node_id: string;
-      node_kind: string;
-      total_depth: number | string;
-    }>
-  >(
-    asCompiledRowsSql(sql`
-      SELECT
-        forward.node_id,
-        forward.node_kind,
-        forward.depth + reverse.depth AS total_depth
-      FROM ${context.workingTable} forward
-      JOIN ${context.workingTable} reverse
-        ON reverse.graph_id = forward.graph_id
-        AND reverse.run_id = forward.run_id
-        AND reverse.node_id = forward.node_id
-        AND reverse.node_kind = forward.node_kind
-      WHERE forward.graph_id = ${context.graphId}
-        AND forward.run_id = ${context.runId}
-        AND forward.side = 'forward'
-        AND reverse.side = 'reverse'
-        AND forward.depth + reverse.depth <= ${maxHops}
-      ORDER BY total_depth, forward.node_id, forward.node_kind
-      LIMIT 1
-    `),
-  );
-  const row = rows[0];
-  if (row === undefined) return;
-  return {
-    id: row.node_id,
-    kind: row.node_kind,
-    depth: Number(row.total_depth),
-  };
 }
 
 async function readWorkingRows(

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -50,6 +50,7 @@ export type InternalTraversalOptions = InternalTemporalOptions &
     maxHops?: number;
     direction?: TraversalDirection;
     cyclePolicy?: AlgorithmCyclePolicy;
+    workingMemory?: string;
   }>;
 
 /**

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -39,6 +39,8 @@ export type IterativeGraphOperation = Readonly<{
   nodeTemporalFilter: ReturnType<typeof compileTemporalFilter>;
   edgeTemporalFilter: ReturnType<typeof compileTemporalFilter>;
   schema: ReturnType<typeof resolveReadSchema>;
+  /** Validated transaction-scoped memory budget for working-table rounds. */
+  workingMemory: string;
 }>;
 
 export type NodeIdentityKey = string & {
@@ -116,6 +118,34 @@ export const WORKING_TABLE_ANALYZE_MINIMUM_ROWS = 16;
 export const WORKING_TABLE_ANALYZE_GROWTH_FACTOR = 4;
 
 /**
+ * Default transaction-scoped working-memory budget for iterative graph
+ * operations. PostgreSQL's stock `work_mem` (4MB) makes whole-graph rounds
+ * spill their candidate sorts and DISTINCT reductions to disk (measured
+ * ~106MB external merges per WCC round on LDBC SNB SF1); 64MB keeps typical
+ * rounds in memory while staying transaction-local. SQLite ignores it.
+ */
+export const DEFAULT_ITERATIVE_WORKING_MEMORY = "64MB";
+
+/**
+ * Accepts only a plain integer with a binary unit suffix. The value reaches
+ * the engine as a bound parameter, but a strict shape keeps the option from
+ * ever smuggling arbitrary text into a settings statement and rejects
+ * ambiguous inputs (fractions, spaces, unknown units) up front.
+ */
+const ITERATIVE_WORKING_MEMORY_PATTERN = /^\d+(kB|MB|GB)$/;
+
+function resolveWorkingMemory(workingMemory: string | undefined): string {
+  const resolved = workingMemory ?? DEFAULT_ITERATIVE_WORKING_MEMORY;
+  if (!ITERATIVE_WORKING_MEMORY_PATTERN.test(resolved)) {
+    throw new ConfigurationError(
+      `Iterative graph operation workingMemory must be digits followed by kB, MB, or GB (for example "64MB"), got ${JSON.stringify(workingMemory)}.`,
+      { workingMemory },
+    );
+  }
+  return resolved;
+}
+
+/**
  * Opens the shared execution scope for iterative graph algorithms. The host
  * controls rounds and convergence; this scope supplies a snapshot-consistent,
  * bind-limit-aware SQL working relation for each round.
@@ -183,6 +213,15 @@ export async function runIterativeGraphOperation<
         },
       };
 
+      // Transaction-scoped only: `set_config(..., is_local => true)` reverts
+      // when this transaction ends, so the session/server setting is never
+      // touched. SQLite returns no statement here.
+      const workingMemoryStatement = ctx.dialect.setTransactionWorkingMemory(
+        context.operation.workingMemory,
+      );
+      if (workingMemoryStatement !== undefined) {
+        await context.executeTemporary(workingMemoryStatement);
+      }
       await context.executeTemporary(plan.createWorkingTable(context));
       let operationError: unknown;
       try {
@@ -621,6 +660,7 @@ function createOperation(
     nodeTemporalFilter,
     edgeTemporalFilter,
     schema: resolveReadSchema(ctx, options),
+    workingMemory: resolveWorkingMemory(options.workingMemory),
   };
 }
 

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -197,7 +197,10 @@ export async function runIterativeGraphOperation<
           iteration++
         ) {
           state = await plan.runRound(context, state, iteration);
-          if (!plan.hasConverged(state)) {
+          // Statistics only pay off in a subsequent round: skip the refresh
+          // when the operation just converged or the iteration budget is
+          // spent — no further round will read the working table.
+          if (iteration < plan.maxIterations && !plan.hasConverged(state)) {
             analyzedRowCount = await refreshWorkingTableStatistics(
               context,
               state.workingTableSize,

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -132,14 +132,41 @@ export const DEFAULT_ITERATIVE_WORKING_MEMORY = "64MB";
  * ever smuggling arbitrary text into a settings statement and rejects
  * ambiguous inputs (fractions, spaces, unknown units) up front.
  */
-const ITERATIVE_WORKING_MEMORY_PATTERN = /^\d+(kB|MB|GB)$/;
+const ITERATIVE_WORKING_MEMORY_PATTERN = /^(\d+)(kB|MB|GB)$/;
+
+const WORKING_MEMORY_KILOBYTES_PER_UNIT: Readonly<Record<string, number>> = {
+  kB: 1,
+  MB: 1024,
+  GB: 1024 * 1024,
+};
+
+/**
+ * PostgreSQL's accepted `work_mem` range (in kB, its base unit). Values
+ * outside it fail `set_config` mid-transaction with a raw engine error on
+ * PostgreSQL while SQLite would silently accept them — so both backends
+ * reject them up front with the same typed error instead.
+ */
+const MIN_WORKING_MEMORY_KILOBYTES = 64;
+const MAX_WORKING_MEMORY_KILOBYTES = 2_147_483_647;
 
 function resolveWorkingMemory(workingMemory: string | undefined): string {
   const resolved = workingMemory ?? DEFAULT_ITERATIVE_WORKING_MEMORY;
-  if (!ITERATIVE_WORKING_MEMORY_PATTERN.test(resolved)) {
+  const match = ITERATIVE_WORKING_MEMORY_PATTERN.exec(resolved);
+  if (match === null) {
     throw new ConfigurationError(
       `Iterative graph operation workingMemory must be digits followed by kB, MB, or GB (for example "64MB"), got ${JSON.stringify(workingMemory)}.`,
       { workingMemory },
+    );
+  }
+  const kilobytes =
+    Number(match[1]) * (WORKING_MEMORY_KILOBYTES_PER_UNIT[match[2] ?? ""] ?? 0);
+  if (
+    kilobytes < MIN_WORKING_MEMORY_KILOBYTES ||
+    kilobytes > MAX_WORKING_MEMORY_KILOBYTES
+  ) {
+    throw new ConfigurationError(
+      `Iterative graph operation workingMemory must be between ${MIN_WORKING_MEMORY_KILOBYTES}kB and ${MAX_WORKING_MEMORY_KILOBYTES}kB, got ${JSON.stringify(workingMemory)}.`,
+      { workingMemory, kilobytes },
     );
   }
   return resolved;

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -39,8 +39,11 @@ export type IterativeGraphOperation = Readonly<{
   nodeTemporalFilter: ReturnType<typeof compileTemporalFilter>;
   edgeTemporalFilter: ReturnType<typeof compileTemporalFilter>;
   schema: ReturnType<typeof resolveReadSchema>;
-  /** Validated transaction-scoped memory budget for working-table rounds. */
-  workingMemory: string;
+  /**
+   * Validated caller-requested transaction-scoped memory override for
+   * working-table rounds; `undefined` inherits the engine's configuration.
+   */
+  workingMemory: string | undefined;
 }>;
 
 export type NodeIdentityKey = string & {
@@ -118,15 +121,6 @@ export const WORKING_TABLE_ANALYZE_MINIMUM_ROWS = 16;
 export const WORKING_TABLE_ANALYZE_GROWTH_FACTOR = 4;
 
 /**
- * Default transaction-scoped working-memory budget for iterative graph
- * operations. PostgreSQL's stock `work_mem` (4MB) makes whole-graph rounds
- * spill their candidate sorts and DISTINCT reductions to disk (measured
- * ~106MB external merges per WCC round on LDBC SNB SF1); 64MB keeps typical
- * rounds in memory while staying transaction-local. SQLite ignores it.
- */
-export const DEFAULT_ITERATIVE_WORKING_MEMORY = "64MB";
-
-/**
  * Accepts only a plain integer with a binary unit suffix. The value reaches
  * the engine as a bound parameter, but a strict shape keeps the option from
  * ever smuggling arbitrary text into a settings statement and rejects
@@ -149,9 +143,19 @@ const WORKING_MEMORY_KILOBYTES_PER_UNIT: Readonly<Record<string, number>> = {
 const MIN_WORKING_MEMORY_KILOBYTES = 64;
 const MAX_WORKING_MEMORY_KILOBYTES = 2_147_483_647;
 
-function resolveWorkingMemory(workingMemory: string | undefined): string {
-  const resolved = workingMemory ?? DEFAULT_ITERATIVE_WORKING_MEMORY;
-  const match = ITERATIVE_WORKING_MEMORY_PATTERN.exec(resolved);
+/**
+ * Validates an explicitly requested working-memory override. `undefined`
+ * means the caller did not opt in: the operation inherits the engine's
+ * configured setting and emits no override — `work_mem` is a threshold each
+ * sort/hash operator (and each parallel worker) may allocate up to, not a
+ * per-operation budget, so silently raising it for every algorithm call
+ * could multiply memory use far past what a DBA provisioned.
+ */
+function resolveWorkingMemory(
+  workingMemory: string | undefined,
+): string | undefined {
+  if (workingMemory === undefined) return undefined;
+  const match = ITERATIVE_WORKING_MEMORY_PATTERN.exec(workingMemory);
   if (match === null) {
     throw new ConfigurationError(
       `Iterative graph operation workingMemory must be digits followed by kB, MB, or GB (for example "64MB"), got ${JSON.stringify(workingMemory)}.`,
@@ -169,7 +173,7 @@ function resolveWorkingMemory(workingMemory: string | undefined): string {
       { workingMemory, kilobytes },
     );
   }
-  return resolved;
+  return workingMemory;
 }
 
 /**
@@ -240,14 +244,18 @@ export async function runIterativeGraphOperation<
         },
       };
 
-      // Transaction-scoped only: `set_config(..., is_local => true)` reverts
+      // Opt-in only: without an explicit workingMemory the rounds inherit
+      // the engine's configured setting. When requested, the override is
+      // transaction-scoped — `set_config(..., is_local => true)` reverts
       // when this transaction ends, so the session/server setting is never
       // touched. SQLite returns no statement here.
-      const workingMemoryStatement = ctx.dialect.setTransactionWorkingMemory(
-        context.operation.workingMemory,
-      );
-      if (workingMemoryStatement !== undefined) {
-        await context.executeTemporary(workingMemoryStatement);
+      if (context.operation.workingMemory !== undefined) {
+        const workingMemoryStatement = ctx.dialect.setTransactionWorkingMemory(
+          context.operation.workingMemory,
+        );
+        if (workingMemoryStatement !== undefined) {
+          await context.executeTemporary(workingMemoryStatement);
+        }
       }
       await context.executeTemporary(plan.createWorkingTable(context));
       let operationError: unknown;

--- a/packages/typegraph/src/store/algorithms/reachable.ts
+++ b/packages/typegraph/src/store/algorithms/reachable.ts
@@ -72,6 +72,9 @@ export async function executeNeighbors(
     ...(options.recordedAsOf !== undefined && {
       recordedAsOf: options.recordedAsOf,
     }),
+    ...(options.workingMemory !== undefined && {
+      workingMemory: options.workingMemory,
+    }),
     excludeSource: true,
   });
 }

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -54,18 +54,31 @@ export type InternalTemporalAlgorithmOptions = Omit<
   Readonly<{ recordedAsOf?: RecordedInstant }>;
 
 /**
- * Transaction-scoped memory budget for iterative graph rounds.
+ * Opt-in, transaction-scoped override of the session's working memory for
+ * iterative graph rounds.
  *
- * Applies to backends with a per-operation memory setting (PostgreSQL
- * `work_mem`, applied via `SET LOCAL` semantics inside the operation's own
- * transaction — the session and server settings are never modified). SQLite
- * has no equivalent setting and ignores the option. The value must be a
- * plain integer with a `kB`, `MB`, or `GB` suffix within PostgreSQL's
- * accepted `work_mem` range (`64kB` to `2147483647kB`); both backends reject
- * out-of-range values identically. Defaults to `"64MB"`.
+ * When set, PostgreSQL applies it with `SET LOCAL work_mem` semantics inside
+ * the operation's own transaction — the override ends with the transaction
+ * and the session and server settings are never modified. When omitted (the
+ * default), the operation inherits the server's configured `work_mem`.
+ *
+ * `work_mem` is a threshold each sort/hash operator (and each parallel
+ * worker) may allocate up to, NOT a per-operation budget: a single round can
+ * allocate several multiples of it, and concurrent algorithm calls multiply
+ * again. Raise it deliberately — e.g. `"64MB"` for large single-tenant
+ * analytical runs where the configured default spills whole-graph sorts to
+ * disk — not as a blanket setting on a shared cluster.
+ *
+ * The value must be a plain integer with a `kB`, `MB`, or `GB` suffix within
+ * PostgreSQL's accepted `work_mem` range (`64kB` to `2147483647kB`); both
+ * backends reject malformed or out-of-range values identically. SQLite has
+ * no equivalent setting and otherwise ignores the option.
  */
 type IterativeMemoryOptions = Readonly<{
-  /** Per-operation round memory budget, e.g. `"64MB"` (the default). */
+  /**
+   * Transaction-scoped `work_mem` override, e.g. `"64MB"`. Omit to inherit
+   * the server's configured setting.
+   */
   workingMemory?: string;
 }>;
 

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -64,7 +64,7 @@ export type InternalTemporalAlgorithmOptions = Omit<
  * accepted `work_mem` range (`64kB` to `2147483647kB`); both backends reject
  * out-of-range values identically. Defaults to `"64MB"`.
  */
-export type IterativeMemoryOptions = Readonly<{
+type IterativeMemoryOptions = Readonly<{
   /** Per-operation round memory budget, e.g. `"64MB"` (the default). */
   workingMemory?: string;
 }>;

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -54,10 +54,25 @@ export type InternalTemporalAlgorithmOptions = Omit<
   Readonly<{ recordedAsOf?: RecordedInstant }>;
 
 /**
+ * Transaction-scoped memory budget for iterative graph rounds.
+ *
+ * Applies to backends with a per-operation memory setting (PostgreSQL
+ * `work_mem`, applied via `SET LOCAL` semantics inside the operation's own
+ * transaction — the session and server settings are never modified). SQLite
+ * has no equivalent setting and ignores the option. The value must be a
+ * plain integer with a `kB`, `MB`, or `GB` suffix; defaults to `"64MB"`.
+ */
+export type IterativeMemoryOptions = Readonly<{
+  /** Per-operation round memory budget, e.g. `"64MB"` (the default). */
+  workingMemory?: string;
+}>;
+
+/**
  * Base options for traversal-style algorithms.
  */
 export type BaseTraversalOptions<G extends GraphDef> =
   TemporalAlgorithmOptions &
+    IterativeMemoryOptions &
     Readonly<{
       /** Edge kinds to follow. At least one kind is required. */
       edges: readonly EdgeKinds<G>[];
@@ -140,6 +155,7 @@ export type InternalReachableOptions<G extends GraphDef> =
  * The source is always excluded.
  */
 export type NeighborsOptions<G extends GraphDef> = TemporalAlgorithmOptions &
+  IterativeMemoryOptions &
   Readonly<{
     /** Edge kinds to follow. At least one kind is required. */
     edges: readonly EdgeKinds<G>[];
@@ -186,6 +202,7 @@ export type InternalDegreeOptions<G extends GraphDef> =
  */
 export type WeaklyConnectedComponentsOptions<G extends GraphDef> =
   TemporalAlgorithmOptions &
+    IterativeMemoryOptions &
     Readonly<{
       /** Edge kinds whose undirected projection defines connectivity. */
       edges: readonly EdgeKinds<G>[];

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -60,7 +60,9 @@ export type InternalTemporalAlgorithmOptions = Omit<
  * `work_mem`, applied via `SET LOCAL` semantics inside the operation's own
  * transaction — the session and server settings are never modified). SQLite
  * has no equivalent setting and ignores the option. The value must be a
- * plain integer with a `kB`, `MB`, or `GB` suffix; defaults to `"64MB"`.
+ * plain integer with a `kB`, `MB`, or `GB` suffix within PostgreSQL's
+ * accepted `work_mem` range (`64kB` to `2147483647kB`); both backends reject
+ * out-of-range values identically. Defaults to `"64MB"`.
  */
 export type IterativeMemoryOptions = Readonly<{
   /** Per-operation round memory budget, e.g. `"64MB"` (the default). */

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -14,7 +14,7 @@ import {
   type InternalTraversalOptions,
 } from "./context";
 import {
-  compileWorkingTableExpansion,
+  compileWorkingTableEdgeExpansion,
   type IterativeGraphRunContext,
   runIterativeGraphOperation,
 } from "./iterative-graph-operation";
@@ -182,12 +182,22 @@ async function resetNextLabels(
   `);
 }
 
+/**
+ * Propagates the minimum neighbor label along one edge-kind chunk. The
+ * expansion deliberately skips the target-node visibility join: the working
+ * table was seeded through the same graph/kind/temporal filters inside the
+ * same snapshot, WCC never inserts rows after seeding, and both edge
+ * endpoints are re-joined against the working table below — membership is
+ * the visibility-and-scope proof, so a per-edge `typegraph_nodes` lookup
+ * would only re-check what the `source`/`scoped_target` joins already
+ * guarantee.
+ */
 async function propagateChunkLabels(
   context: IterativeGraphRunContext,
   edgeKinds: readonly string[],
 ): Promise<void> {
   const { operation, workingTable, graphId, runId } = context;
-  const expansion = compileWorkingTableExpansion(
+  const expansion = compileWorkingTableEdgeExpansion(
     operation,
     workingTable,
     sql`w.graph_id = ${graphId} AND w.run_id = ${runId}`,

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -63,6 +63,9 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
     ...(options.recordedAsOf === undefined ?
       {}
     : { recordedAsOf: options.recordedAsOf }),
+    ...(options.workingMemory === undefined ?
+      {}
+    : { workingMemory: options.workingMemory }),
   };
 
   return runIterativeGraphOperation(ctx, traversalOptions, {

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -159,6 +159,42 @@ async function seed(store: Store<TestGraph>): Promise<Fixture> {
   };
 }
 
+/**
+ * Counts every statement (row-returning and temporary) issued inside a
+ * traversal's transaction, so a reintroduced per-round COUNT or meeting
+ * probe fails the round-trip budget tests instead of silently doubling
+ * round-trips.
+ */
+function createCountingBackend(
+  backend: GraphBackend,
+  collected: string[],
+): GraphBackend {
+  return {
+    ...backend,
+    transaction<T>(
+      fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+      options?: TransactionOptions,
+    ): Promise<T> {
+      return backend.transaction(async (tx, adoptedTransaction) => {
+        const observedTransaction: TransactionBackend = {
+          ...tx,
+          execute<Result>(query: CompiledRowsSql): Promise<readonly Result[]> {
+            collected.push(backend.compileSql!(query).sql);
+            return tx.execute<Result>(query);
+          },
+          async executeTemporaryStatement(
+            query: CompiledTemporaryStatementSql,
+          ): Promise<void> {
+            collected.push(backend.compileSql!(query).sql);
+            await tx.executeTemporaryStatement!(query);
+          },
+        };
+        return fn(observedTransaction, adoptedTransaction);
+      }, options);
+    },
+  };
+}
+
 // ============================================================
 // Test Setup
 // ============================================================
@@ -496,45 +532,11 @@ describe("store.algorithms", () => {
   // --------------------------------------------------------------
 
   describe("working-table round-trip budget", () => {
-    /**
-     * Counts every statement (row-returning and temporary) issued inside the
-     * traversal's transaction, so a reintroduced per-round COUNT or meeting
-     * probe fails this test instead of silently doubling round-trips.
-     */
-    function createCountingBackend(collected: string[]): GraphBackend {
-      return {
-        ...backend,
-        transaction<T>(
-          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
-          options?: TransactionOptions,
-        ): Promise<T> {
-          return backend.transaction(async (tx, adoptedTransaction) => {
-            const observedTransaction: TransactionBackend = {
-              ...tx,
-              execute<Result>(
-                query: CompiledRowsSql,
-              ): Promise<readonly Result[]> {
-                collected.push(backend.compileSql!(query).sql);
-                return tx.execute<Result>(query);
-              },
-              async executeTemporaryStatement(
-                query: CompiledTemporaryStatementSql,
-              ): Promise<void> {
-                collected.push(backend.compileSql!(query).sql);
-                await tx.executeTemporaryStatement!(query);
-              },
-            };
-            return fn(observedTransaction, adoptedTransaction);
-          }, options);
-        },
-      };
-    }
-
     it("runs a 3-hop reachable in one statement per round", async () => {
       const statements: string[] = [];
       const observedStore = createStore(
         testGraph,
-        createCountingBackend(statements),
+        createCountingBackend(backend, statements),
       );
 
       const reached = await observedStore.algorithms.reachable(ids.alice, {
@@ -552,7 +554,7 @@ describe("store.algorithms", () => {
       const statements: string[] = [];
       const observedStore = createStore(
         testGraph,
-        createCountingBackend(statements),
+        createCountingBackend(backend, statements),
       );
 
       const path = await observedStore.algorithms.shortestPath(
@@ -573,6 +575,26 @@ describe("store.algorithms", () => {
         statements.some((statement) =>
           statement.trimStart().startsWith("SELECT COUNT"),
         ),
+      ).toBe(false);
+    });
+
+    it("emits no working-memory settings statement on SQLite", async () => {
+      const statements: string[] = [];
+      const observedStore = createStore(
+        testGraph,
+        createCountingBackend(backend, statements),
+      );
+
+      const reached = await observedStore.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        maxHops: 3,
+        workingMemory: "32MB",
+      });
+
+      expect(reached.map((node) => node.id)).toContain(ids.dave);
+      expect(statements).toHaveLength(7);
+      expect(
+        statements.some((statement) => statement.includes("set_config")),
       ).toBe(false);
     });
   });
@@ -882,6 +904,48 @@ describe("store.algorithms", () => {
           depth: -1,
         }),
       ).rejects.toBeInstanceOf(ConfigurationError);
+    });
+
+    it("rejects malformed workingMemory values across iterative algorithms", async () => {
+      // SET LOCAL work_mem cannot take arbitrary text, so the option accepts
+      // only <digits><kB|MB|GB> — no spaces, fractions, lowercase units, or
+      // anything that could smuggle SQL into a settings statement.
+      const malformedValues = [
+        "64 MB",
+        "64mb",
+        "-64MB",
+        "1.5GB",
+        "64MB; DROP TABLE typegraph_nodes",
+        "",
+      ];
+      for (const workingMemory of malformedValues) {
+        await expect(
+          store.algorithms.reachable(ids.alice, {
+            edges: ["knows"],
+            workingMemory,
+          }),
+        ).rejects.toBeInstanceOf(ConfigurationError);
+        await expect(
+          store.algorithms.shortestPath(ids.alice, ids.bob, {
+            edges: ["knows"],
+            workingMemory,
+          }),
+        ).rejects.toBeInstanceOf(ConfigurationError);
+        await expect(
+          store.algorithms.weaklyConnectedComponents({
+            edges: ["knows"],
+            workingMemory,
+          }),
+        ).rejects.toBeInstanceOf(ConfigurationError);
+      }
+    });
+
+    it("accepts a well-formed workingMemory value", async () => {
+      const reached = await store.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        workingMemory: "32MB",
+      });
+      expect(reached.some((node) => node.id === ids.dave)).toBe(true);
     });
 
     it("rejects maxHops over the explicit recursive limit", async () => {

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -677,6 +677,50 @@ describe("store.algorithms", () => {
       ).toBe(true);
     });
 
+    it("propagates labels without re-joining node visibility per edge", async () => {
+      const statements: string[] = [];
+      const observedBackend: GraphBackend = {
+        ...backend,
+        transaction<T>(
+          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> {
+          return backend.transaction(async (tx, adoptedTransaction) => {
+            const observedTransaction: TransactionBackend = {
+              ...tx,
+              async executeTemporaryStatement(
+                query: CompiledTemporaryStatementSql,
+              ): Promise<void> {
+                statements.push(backend.compileSql!(query).sql);
+                await tx.executeTemporaryStatement!(query);
+              },
+            };
+            return fn(observedTransaction, adoptedTransaction);
+          }, options);
+        },
+      };
+      const observedStore = createStore(testGraph, observedBackend);
+
+      await observedStore.algorithms.weaklyConnectedComponents({
+        edges: ["knows"],
+      });
+
+      // The working table is seeded with exactly the visible, in-scope nodes
+      // and WCC never inserts rows afterwards, so the propagate round proves
+      // endpoint visibility via working-table membership alone.
+      const seedStatement = statements.find((statement) =>
+        statement.trimStart().startsWith("INSERT INTO"),
+      );
+      expect(seedStatement).toContain('"typegraph_nodes"');
+      const propagateStatements = statements.filter((statement) =>
+        statement.includes("WITH candidates"),
+      );
+      expect(propagateStatements.length).toBeGreaterThan(0);
+      for (const statement of propagateStatements) {
+        expect(statement).not.toContain('"typegraph_nodes"');
+      }
+    });
+
     it("rejects a backend without graph-analytics support", async () => {
       const unsupportedBackend: GraphBackend = {
         ...backend,

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -545,9 +545,17 @@ describe("store.algorithms", () => {
       });
 
       expect(reached.map((node) => node.id)).toContain(ids.dave);
-      // CREATE TEMP TABLE, seed (INSERT … RETURNING), 3 expansion rounds,
-      // result read, DROP TABLE. SQLite emits no working-table ANALYZE.
-      expect(statements).toHaveLength(7);
+      // Budget: CREATE TEMP TABLE + seed (INSERT … RETURNING) + one
+      // statement per round (3 on this fixture) + result read + DROP TABLE
+      // = 7. An upper bound so incidental fixture changes don't fail it; a
+      // reintroduced per-round COUNT would push a round to two statements
+      // and blow the budget.
+      expect(statements.length).toBeLessThanOrEqual(7);
+      expect(
+        statements.some((statement) =>
+          statement.trimStart().startsWith("SELECT COUNT"),
+        ),
+      ).toBe(false);
     });
 
     it("runs a 3-hop shortestPath in one statement per round", async () => {
@@ -564,9 +572,13 @@ describe("store.algorithms", () => {
       );
 
       expect(path?.depth).toBe(3);
-      // CREATE TEMP TABLE, two seeds (INSERT … RETURNING), 3 bidirectional
-      // rounds carrying their own meeting probe, result read, DROP TABLE.
-      expect(statements).toHaveLength(8);
+      // Budget: CREATE TEMP TABLE + two seeds (INSERT … RETURNING) + one
+      // statement per bidirectional round (3 on this fixture) + result read
+      // + DROP TABLE = 8. An upper bound so incidental fixture changes don't
+      // fail it; the content assertions below are the real regression guard.
+      expect(statements.length).toBeLessThanOrEqual(8);
+      // Rounds must carry their own meeting probe (meeting_depth) rather
+      // than issuing separate COUNT / meeting statements.
       const roundStatements = statements.filter((statement) =>
         statement.includes("meeting_depth"),
       );
@@ -575,6 +587,9 @@ describe("store.algorithms", () => {
         statements.some((statement) =>
           statement.trimStart().startsWith("SELECT COUNT"),
         ),
+      ).toBe(false);
+      expect(
+        statements.some((statement) => statement.includes("AS total_depth")),
       ).toBe(false);
     });
 
@@ -592,10 +607,54 @@ describe("store.algorithms", () => {
       });
 
       expect(reached.map((node) => node.id)).toContain(ids.dave);
-      expect(statements).toHaveLength(7);
+      // Same 7-statement budget as the plain 3-hop reachable above: SQLite
+      // must not add a settings statement for workingMemory.
+      expect(statements.length).toBeLessThanOrEqual(7);
       expect(
         statements.some((statement) => statement.includes("set_config")),
       ).toBe(false);
+    });
+
+    it("detects a meeting when the driver returns meeting_depth as BigInt", async () => {
+      // better-sqlite3 with defaultSafeIntegers(true) (and custom pg int
+      // parsers) deliver INTEGER columns as BigInt. A meeting must still be
+      // detected — regression for a typeof guard that silently dropped
+      // BigInt rows and made shortestPath return undefined.
+      const bigintBackend: GraphBackend = {
+        ...backend,
+        transaction<T>(
+          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> {
+          return backend.transaction(async (tx, adoptedTransaction) => {
+            const observedTransaction: TransactionBackend = {
+              ...tx,
+              async execute<Result>(
+                query: CompiledRowsSql,
+              ): Promise<readonly Result[]> {
+                const rows = await tx.execute<Record<string, unknown>>(query);
+                return rows.map((row) =>
+                  typeof row.meeting_depth === "number" ?
+                    { ...row, meeting_depth: BigInt(row.meeting_depth) }
+                  : row,
+                ) as readonly Result[];
+              },
+            };
+            return fn(observedTransaction, adoptedTransaction);
+          }, options);
+        },
+      };
+      const bigintStore = createStore(testGraph, bigintBackend);
+
+      const path = await bigintStore.algorithms.shortestPath(
+        ids.alice,
+        ids.dave,
+        { edges: ["knows"], maxHops: 3 },
+      );
+
+      expect(path?.depth).toBe(3);
+      expect(path?.nodes.at(0)?.id).toBe(ids.alice);
+      expect(path?.nodes.at(-1)?.id).toBe(ids.dave);
     });
   });
 
@@ -940,12 +999,41 @@ describe("store.algorithms", () => {
       }
     });
 
-    it("accepts a well-formed workingMemory value", async () => {
-      const reached = await store.algorithms.reachable(ids.alice, {
-        edges: ["knows"],
-        workingMemory: "32MB",
-      });
-      expect(reached.some((node) => node.id === ids.dave)).toBe(true);
+    it("rejects workingMemory values outside PostgreSQL's work_mem range", async () => {
+      // work_mem accepts 64kB..2147483647kB; anything outside would fail
+      // set_config mid-transaction with a raw engine error on PostgreSQL
+      // while SQLite silently succeeded. Both backends reject up front.
+      const outOfRangeValues = [
+        "0MB",
+        "1kB",
+        "63kB",
+        "2147483648kB",
+        "999999GB",
+      ];
+      for (const workingMemory of outOfRangeValues) {
+        await expect(
+          store.algorithms.reachable(ids.alice, {
+            edges: ["knows"],
+            workingMemory,
+          }),
+        ).rejects.toBeInstanceOf(ConfigurationError);
+        await expect(
+          store.algorithms.weaklyConnectedComponents({
+            edges: ["knows"],
+            workingMemory,
+          }),
+        ).rejects.toBeInstanceOf(ConfigurationError);
+      }
+    });
+
+    it("accepts well-formed workingMemory values including the range bounds", async () => {
+      for (const workingMemory of ["32MB", "64kB", "2147483647kB", "2GB"]) {
+        const reached = await store.algorithms.reachable(ids.alice, {
+          edges: ["knows"],
+          workingMemory,
+        });
+        expect(reached.some((node) => node.id === ids.dave)).toBe(true);
+      }
     });
 
     it("rejects maxHops over the explicit recursive limit", async () => {

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -492,6 +492,92 @@ describe("store.algorithms", () => {
   });
 
   // --------------------------------------------------------------
+  // round-trip budget
+  // --------------------------------------------------------------
+
+  describe("working-table round-trip budget", () => {
+    /**
+     * Counts every statement (row-returning and temporary) issued inside the
+     * traversal's transaction, so a reintroduced per-round COUNT or meeting
+     * probe fails this test instead of silently doubling round-trips.
+     */
+    function createCountingBackend(collected: string[]): GraphBackend {
+      return {
+        ...backend,
+        transaction<T>(
+          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> {
+          return backend.transaction(async (tx, adoptedTransaction) => {
+            const observedTransaction: TransactionBackend = {
+              ...tx,
+              execute<Result>(
+                query: CompiledRowsSql,
+              ): Promise<readonly Result[]> {
+                collected.push(backend.compileSql!(query).sql);
+                return tx.execute<Result>(query);
+              },
+              async executeTemporaryStatement(
+                query: CompiledTemporaryStatementSql,
+              ): Promise<void> {
+                collected.push(backend.compileSql!(query).sql);
+                await tx.executeTemporaryStatement!(query);
+              },
+            };
+            return fn(observedTransaction, adoptedTransaction);
+          }, options);
+        },
+      };
+    }
+
+    it("runs a 3-hop reachable in one statement per round", async () => {
+      const statements: string[] = [];
+      const observedStore = createStore(
+        testGraph,
+        createCountingBackend(statements),
+      );
+
+      const reached = await observedStore.algorithms.reachable(ids.alice, {
+        edges: ["knows"],
+        maxHops: 3,
+      });
+
+      expect(reached.map((node) => node.id)).toContain(ids.dave);
+      // CREATE TEMP TABLE, seed (INSERT … RETURNING), 3 expansion rounds,
+      // result read, DROP TABLE. SQLite emits no working-table ANALYZE.
+      expect(statements).toHaveLength(7);
+    });
+
+    it("runs a 3-hop shortestPath in one statement per round", async () => {
+      const statements: string[] = [];
+      const observedStore = createStore(
+        testGraph,
+        createCountingBackend(statements),
+      );
+
+      const path = await observedStore.algorithms.shortestPath(
+        ids.alice,
+        ids.dave,
+        { edges: ["knows"], maxHops: 3 },
+      );
+
+      expect(path?.depth).toBe(3);
+      // CREATE TEMP TABLE, two seeds (INSERT … RETURNING), 3 bidirectional
+      // rounds carrying their own meeting probe, result read, DROP TABLE.
+      expect(statements).toHaveLength(8);
+      const roundStatements = statements.filter((statement) =>
+        statement.includes("meeting_depth"),
+      );
+      expect(roundStatements.length).toBeGreaterThan(0);
+      expect(
+        statements.some((statement) =>
+          statement.trimStart().startsWith("SELECT COUNT"),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------
   // canReach
   // --------------------------------------------------------------
 

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -319,6 +319,32 @@ export function registerAlgorithmIntegrationTests(
         ).resolves.toEqual([]);
       });
 
+      it("honors an explicit workingMemory budget for iterative rounds", async () => {
+        // PostgreSQL applies the value as a transaction-scoped work_mem via
+        // set_config(..., is_local => true); SQLite validates and ignores it.
+        // Results must be identical on both backends either way.
+        const store = context.getStore();
+        const [left, right] = await Promise.all([
+          store.nodes.Person.create({ name: "Memory left" }, { id: "mem-a" }),
+          store.nodes.Person.create({ name: "Memory right" }, { id: "mem-b" }),
+        ]);
+        await store.edges.knows.create(left, right, {});
+
+        const memberships = await store.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+          workingMemory: "32MB",
+        });
+        const byId = new Map(memberships.map((row) => [row.id, row]));
+        expect(byId.get("mem-a")?.componentId).toBe("mem-a");
+        expect(byId.get("mem-b")?.componentId).toBe("mem-a");
+
+        const reached = await store.algorithms.reachable("mem-a", {
+          edges: ["knows"],
+          workingMemory: "32MB",
+        });
+        expect(reached.map((row) => row.id)).toContain("mem-b");
+      });
+
       it("throws instead of returning partial labels at the iteration limit", async () => {
         const store = context.getStore();
         const [alpha, beta, gamma] = await Promise.all([

--- a/packages/typegraph/tests/backends/postgres/iterative-working-memory.test.ts
+++ b/packages/typegraph/tests/backends/postgres/iterative-working-memory.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Iterative-algorithm working-memory wiring on Postgres.
+ *
+ * Pinned here:
+ * 1. Opt-in only — an algorithm call WITHOUT `workingMemory` emits no
+ *    `set_config` statement, inheriting the server's configured `work_mem`
+ *    (a DBA's deliberately conservative setting must not be silently
+ *    overridden; `work_mem` is a per-sort/hash-operator threshold, so a
+ *    blanket default would multiply under concurrency).
+ * 2. When `workingMemory` IS passed, exactly one transaction-scoped
+ *    override runs — the parameterized `SET LOCAL` form,
+ *    `SELECT set_config('work_mem', $1, true)` — with the value bound as a
+ *    parameter, before the working table is created.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { randomUUID } from "node:crypto";
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import type {
+  AdoptedTransaction,
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../../../src/backend/types";
+import type {
+  CompiledRowsSql,
+  CompiledTemporaryStatementSql,
+} from "../../../src/query/sql-intent";
+
+const TEST_DATABASE_URL =
+  process.env.POSTGRES_URL ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+let pool: Pool | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): Pool {
+  if (!isPostgresAvailable || pool === undefined) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return pool;
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) return;
+  const candidate = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+  });
+  try {
+    await candidate.query("SELECT 1");
+    await candidate.query(generatePostgresMigrationSQL());
+    pool = candidate;
+    isPostgresAvailable = true;
+  } catch {
+    await candidate.end().catch(() => {
+      // Unreachable Postgres degrades to "skip".
+    });
+  }
+});
+
+afterAll(async () => {
+  if (pool !== undefined) await pool.end();
+});
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const knows = defineEdge("knows", { schema: z.object({}) });
+
+function buildGraph(graphId: string) {
+  return defineGraph({
+    id: graphId,
+    nodes: { Person: { type: Person } },
+    edges: { knows: { type: knows, from: [Person], to: [Person] } },
+  });
+}
+
+type CapturedStatement = Readonly<{
+  sql: string;
+  params: readonly unknown[];
+}>;
+
+/**
+ * Wraps the transaction so every in-transaction statement — both
+ * row-returning and temporary — is captured. The working-memory override
+ * runs through `executeTemporaryStatement` inside the algorithm's own
+ * transaction, which an outer `execute` wrapper never sees.
+ */
+function withTransactionCapture(backend: GraphBackend): {
+  backend: GraphBackend;
+  statements: CapturedStatement[];
+} {
+  const compileSql = backend.compileSql;
+  if (compileSql === undefined) {
+    throw new Error("Postgres backend must expose compileSql");
+  }
+  const statements: CapturedStatement[] = [];
+  const captured: GraphBackend = {
+    ...backend,
+    transaction<T>(
+      fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+      options?: TransactionOptions,
+    ): Promise<T> {
+      return backend.transaction(async (tx, adoptedTransaction) => {
+        const observedTransaction: TransactionBackend = {
+          ...tx,
+          execute<Result>(query: CompiledRowsSql): Promise<readonly Result[]> {
+            statements.push(compileSql(query));
+            return tx.execute<Result>(query);
+          },
+          async executeTemporaryStatement(
+            query: CompiledTemporaryStatementSql,
+          ): Promise<void> {
+            statements.push(compileSql(query));
+            await tx.executeTemporaryStatement!(query);
+          },
+        };
+        return fn(observedTransaction, adoptedTransaction);
+      }, options);
+    },
+  };
+  return { backend: captured, statements };
+}
+
+const WORK_MEM_OVERRIDE_SQL = "SELECT set_config('work_mem', $1, true)";
+
+describe("iterative working-memory wiring (Postgres)", () => {
+  it("emits no set_config when workingMemory is not passed", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const raw = createPostgresBackend(drizzle(activePool));
+    const { backend, statements } = withTransactionCapture(raw);
+    const [store] = await createStoreWithSchema(
+      buildGraph(`workmem_inherit_${randomUUID().slice(0, 8)}`),
+      backend,
+    );
+
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const bob = await store.nodes.Person.create({ name: "Bob" });
+    await store.edges.knows.create(alice, bob, {});
+
+    statements.length = 0;
+    const reached = await store.algorithms.reachable(alice.id, {
+      edges: ["knows"],
+    });
+    expect(reached.map((node) => node.id)).toContain(bob.id);
+
+    const memberships = await store.algorithms.weaklyConnectedComponents({
+      edges: ["knows"],
+    });
+    expect(memberships.length).toBeGreaterThan(0);
+
+    expect(
+      statements.filter((statement) => statement.sql.includes("set_config")),
+    ).toEqual([]);
+  });
+
+  it("emits one parameterized transaction-local override when passed", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const raw = createPostgresBackend(drizzle(activePool));
+    const { backend, statements } = withTransactionCapture(raw);
+    const [store] = await createStoreWithSchema(
+      buildGraph(`workmem_override_${randomUUID().slice(0, 8)}`),
+      backend,
+    );
+
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const bob = await store.nodes.Person.create({ name: "Bob" });
+    await store.edges.knows.create(alice, bob, {});
+
+    statements.length = 0;
+    const reached = await store.algorithms.reachable(alice.id, {
+      edges: ["knows"],
+      workingMemory: "32MB",
+    });
+    expect(reached.map((node) => node.id)).toContain(bob.id);
+
+    const overrides = statements.filter((statement) =>
+      statement.sql.includes("set_config"),
+    );
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0]?.sql).toBe(WORK_MEM_OVERRIDE_SQL);
+    expect(overrides[0]?.params).toEqual(["32MB"]);
+
+    // The override precedes the working table so every round runs under it.
+    const overrideIndex = statements.findIndex((statement) =>
+      statement.sql.includes("set_config"),
+    );
+    const createIndex = statements.findIndex((statement) =>
+      statement.sql.includes("CREATE TEMP TABLE"),
+    );
+    expect(overrideIndex).toBeGreaterThanOrEqual(0);
+    expect(createIndex).toBeGreaterThan(overrideIndex);
+  });
+});

--- a/packages/typegraph/tests/iterative-graph-operation.test.ts
+++ b/packages/typegraph/tests/iterative-graph-operation.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { postgresDialect } from "../src/query/dialect/postgres";
 import { sqliteDialect } from "../src/query/dialect/sqlite";
 import {
+  DEFAULT_ITERATIVE_WORKING_MEMORY,
   shouldRefreshWorkingTableStatistics,
   WORKING_TABLE_ANALYZE_GROWTH_FACTOR,
   WORKING_TABLE_ANALYZE_MINIMUM_ROWS,
@@ -58,5 +59,29 @@ describe("iterative graph working-table statistics", () => {
       'ANALYZE "typegraph_iterative_test"',
     );
     expect(sqliteDialect.analyzeTemporaryTable(workingTable)).toBeUndefined();
+  });
+});
+
+describe("iterative graph working-memory dialect seam", () => {
+  it("emits a parameterized, transaction-local work_mem override on PostgreSQL only", () => {
+    const postgresStatement = postgresDialect.setTransactionWorkingMemory(
+      DEFAULT_ITERATIVE_WORKING_MEMORY,
+    );
+
+    if (postgresStatement === undefined) {
+      throw new Error("PostgreSQL must emit a work_mem override");
+    }
+    const compiled = new PgDialect().sqlToQuery(postgresStatement);
+    // set_config(..., is_local => true) is the parameterizable form of
+    // SET LOCAL: it reverts at transaction end and binds the value instead
+    // of splicing it into the statement text.
+    expect(compiled.sql).toBe("SELECT set_config('work_mem', $1, true)");
+    expect(compiled.params).toEqual([DEFAULT_ITERATIVE_WORKING_MEMORY]);
+
+    expect(
+      sqliteDialect.setTransactionWorkingMemory(
+        DEFAULT_ITERATIVE_WORKING_MEMORY,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/packages/typegraph/tests/iterative-graph-operation.test.ts
+++ b/packages/typegraph/tests/iterative-graph-operation.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from "vitest";
 import { postgresDialect } from "../src/query/dialect/postgres";
 import { sqliteDialect } from "../src/query/dialect/sqlite";
 import {
-  DEFAULT_ITERATIVE_WORKING_MEMORY,
   shouldRefreshWorkingTableStatistics,
   WORKING_TABLE_ANALYZE_GROWTH_FACTOR,
   WORKING_TABLE_ANALYZE_MINIMUM_ROWS,
@@ -64,9 +63,9 @@ describe("iterative graph working-table statistics", () => {
 
 describe("iterative graph working-memory dialect seam", () => {
   it("emits a parameterized, transaction-local work_mem override on PostgreSQL only", () => {
-    const postgresStatement = postgresDialect.setTransactionWorkingMemory(
-      DEFAULT_ITERATIVE_WORKING_MEMORY,
-    );
+    const workingMemory = "64MB";
+    const postgresStatement =
+      postgresDialect.setTransactionWorkingMemory(workingMemory);
 
     if (postgresStatement === undefined) {
       throw new Error("PostgreSQL must emit a work_mem override");
@@ -76,12 +75,10 @@ describe("iterative graph working-memory dialect seam", () => {
     // SET LOCAL: it reverts at transaction end and binds the value instead
     // of splicing it into the statement text.
     expect(compiled.sql).toBe("SELECT set_config('work_mem', $1, true)");
-    expect(compiled.params).toEqual([DEFAULT_ITERATIVE_WORKING_MEMORY]);
+    expect(compiled.params).toEqual([workingMemory]);
 
     expect(
-      sqliteDialect.setTransactionWorkingMemory(
-        DEFAULT_ITERATIVE_WORKING_MEMORY,
-      ),
+      sqliteDialect.setTransactionWorkingMemory(workingMemory),
     ).toBeUndefined();
   });
 });


### PR DESCRIPTION
The SF1 `EXPLAIN (ANALYZE, BUFFERS)` investigation against pgGraph-on-the-same-engine attributed tg-postgres's iterative-algorithm gap to three removable overheads (none of them missing indexes — every access path was already index-served):

1. **WCC propagate rounds re-validated node visibility per edge** — two Index-Only-Scan loops over `typegraph_nodes` at `loops=361,246` (~3.17M buffers/round at SF1), re-checking endpoints whose working-table membership already proves visibility + scope.
2. **Per-round bookkeeping ran as separate statements** — IC13-shape traversals issued ~11 sequential round-trips for 4.8ms of actual SQL (~50% round-trip latency): separate seed COUNT, separate bidirectional meeting probes, and 1–3 working-table ANALYZE statements per traversal.
3. **Sorts spilled to disk every round** — WCC's 722k-row candidate sort wrote `external merge Disk: 106128kB` per round; BFS `DISTINCT` spilled similarly, all at default `work_mem`.

## Changes (one commit per lever)

**1. WCC: drop the redundant per-edge node-visibility join.** The invariant was verified before removal: the working table is seeded once through the same graph/kind/temporal filters the join re-applied (the join was strictly weaker — it never checked `nodeKinds`), inside one repeatable-read transaction with a single bound read instant, and WCC rounds only UPDATE label columns — they never insert. Membership ⇒ visibility + scope, so the join proved nothing. `propagateChunkLabels` now uses the edge-only expansion (`compileWorkingTableEdgeExpansion`) that reachable rounds already had. `reachable`/`shortestPath` rounds are untouched — they insert new nodes each round, so their target-visibility join is load-bearing. A unit test pins the round SQL shape (no `typegraph_nodes` join in propagate).

**2. Fold per-round bookkeeping into the round statements.** Seeds are `INSERT … RETURNING` (frontier count + seed-level meeting come back with the seed). Bidirectional rounds detect meetings via a new `meeting_depth` working-table column populated by a scalar subquery inside the expansion's INSERT and carried out through RETURNING — the only cross-dialect single-statement shape (SQLite forbids both wCTEs and subqueries in RETURNING). Correctness: working-table rows are immutable once inserted, and any meeting among pre-existing rows would have converged an earlier round, so newly inserted rows are a complete probe. On the 3-hop regression fixture: **shortestPath 14 → 8 statements, reachable 8 → 7**, pinned by budget tests (upper bounds + shape assertions: no `SELECT COUNT`, no standalone meeting probe). ANALYZE thresholds are unchanged but no longer emitted after the final budgeted round. `supportsTemporaryIteration` now also requires `capabilities.returning !== false` (the temp-table path already depended on RETURNING; a `returning: false` custom backend would have broken on main and now takes the inline fallback).

Equal-depth meeting **tie-breaks** are now UTF-16 code-unit order in JS — deterministic and identical across backends (consistent with WCC's representative ordering), where the old SQL `ORDER BY` was database-collation-dependent. Called out in the changeset: a linguistically-collated PG cluster may pick a different (equally shortest) path than the previous release when multiple meetings tie.

**3. Opt-in transaction-scoped working memory.** New `DialectAdapter.setTransactionWorkingMemory` seam (the `analyzeTemporaryTable` pattern): PostgreSQL emits parameterized `SELECT set_config('work_mem', $1, true)` — `SET LOCAL` semantics, transaction-scoped, reverts on commit/abort, session and server never touched, injection impossible by construction; SQLite no-ops. Exposed as `workingMemory?: string` on the iterative algorithm options (`reachable`/`shortestPath`/`canReach`/`neighbors`/`weaklyConnectedComponents`), validated to PostgreSQL's actual `work_mem` range (64kB–2147483647kB) with the same `ConfigurationError` on both backends. **The default inherits the server's configured `work_mem`** — `work_mem` is a per-sort/hash-operator (and per parallel worker) threshold, not a per-operation budget, so a library default would silently override the DBA's setting and multiply under concurrency (post-review fix). Set it explicitly (e.g. `"64MB"`) for large single-tenant analytical runs; the SF1 bench harness should do so to realize the spill elimination. The inline (non-transactional) fallback never emits it.

## Expected impact (SF1, to be confirmed by the bench re-run)

- GA_WCC on PG: ~48–65s → est. 15–25s (join elimination + no disk spills).
- IC13-lane: ~2× on the round-trip-bound constant factor.
- All graph algorithms on PG: no more per-round 106MB disk spills when `workingMemory` is set for the run.

These shave removable overhead; they do not close the architectural gap to pgGraph's in-memory CSR (single C call vs SQL iteration) — that framing is per the investigation report.
