### PR TITLE
feat(algorithms): weighted shortest path (LDBC IC14)

### DIFF
--- a/.changeset/weighted-shortest-path.md
+++ b/.changeset/weighted-shortest-path.md
@@ -1,0 +1,14 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `store.algorithms.weightedShortestPath` — a minimum-total-weight path
+search weighting each traversed edge by a numeric edge property (LDBC
+Interactive IC14 shape). Runs frontier-based relaxation on the shared
+iterative substrate with best-target pruning, works on both execution paths
+(temporary working table and inline fallback), and honors valid-time and
+recorded-time coordinates including pinned StoreViews. Edge weights are
+audited up front: negative, non-numeric, or (without `defaultWeight`)
+missing weights throw the new typed `InvalidEdgeWeightError`. Weight
+arithmetic is IEEE 754 double precision on both backends, so paths and
+totals are backend-identical.

--- a/.changeset/weighted-shortest-path.md
+++ b/.changeset/weighted-shortest-path.md
@@ -8,7 +8,10 @@ Interactive IC14 shape). Runs frontier-based relaxation on the shared
 iterative substrate with best-target pruning, works on both execution paths
 (temporary working table and inline fallback), and honors valid-time and
 recorded-time coordinates including pinned StoreViews. Edge weights are
-audited up front: negative, non-numeric, or (without `defaultWeight`)
-missing weights throw the new typed `InvalidEdgeWeightError`. Weight
-arithmetic is IEEE 754 double precision on both backends, so paths and
-totals are backend-identical.
+audited up front: negative, non-numeric, out-of-range, or (without
+`defaultWeight`) missing weights throw the new typed
+`InvalidEdgeWeightError`. Weight arithmetic is IEEE 754 double precision on
+both backends, so total weights are backend-identical; among
+equal-total-weight paths the returned node sequence is too, except when the
+`edges` list exceeds the backend's bind-parameter budget (hundreds of edge
+kinds in one call).

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ TypeGraph works well for:
 TypeGraph is not designed for:
 
 - Distributed graph processing
-- Advanced graph analytics (PageRank, community detection, weighted shortest
-  path, centrality beyond degree) — it does ship connectivity algorithms
-  ([Graph Algorithms](https://typegraph.dev/graph-algorithms): unweighted
-  shortest path, reachability, neighborhoods, degree, exact WCC)
+- Advanced graph analytics (PageRank, community detection, centrality
+  beyond degree) — it does ship connectivity algorithms
+  ([Graph Algorithms](https://typegraph.dev/graph-algorithms): shortest
+  path both weighted and unweighted, reachability, neighborhoods, degree,
+  exact WCC)
 - Billion-scale graphs requiring dedicated graph-engine performance
 
 ## Installation

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -137,7 +137,7 @@ Options differ from the unweighted traversals:
 |--------|------|---------|-------------|
 | `edges` | `readonly EdgeKinds<G>[]` | *(required)* | Edge kinds to follow |
 | `weightProperty` | `string` | *(required)* | Top-level edge property holding each edge's non-negative numeric weight |
-| `defaultWeight` | `number` | *(none)* | Substituted for edges missing the property; must be finite and non-negative |
+| `defaultWeight` | `number` | *(none)* | Substituted for edges missing the property; must be non-negative and within the audit's upper bound (~9.7e289) |
 | `direction` | `"out" \| "in" \| "both"` | `"out"` | Edge direction |
 | `maxIterations` | `number` | `1000` | Relaxation-round backstop; exceeding it throws `GraphAlgorithmConvergenceError` |
 | `temporalMode` / `asOf` / `workingMemory` | | | Same as the shared options above |
@@ -145,8 +145,10 @@ Options differ from the unweighted traversals:
 There is no `maxHops`: cost-ordered search does not settle nodes in hop
 order, so a hop bound is not a natural stopping rule here. The algorithm
 relaxes frontier nodes round by round (with parallel edges collapsing to
-their cheapest member), prunes any candidate that already costs at least as
-much as a known path to the target, and stops when no distance improves.
+their cheapest member), prunes any candidate costing strictly more than a
+known path to the target — equal-cost candidates stay in play so every
+equal-cost route to the target is considered — and stops when no distance
+improves.
 
 **Weights are validated up front.** Before any traversal rounds run, every
 visible edge of the selected kinds is audited; the call throws a typed
@@ -167,11 +169,10 @@ visible edge of the selected kinds is audited; the call throws a typed
 The audit covers the selected edge kinds globally (not just edges the
 traversal happens to reach), so a data problem fails deterministically no
 matter which endpoints you query. Weight arithmetic uses IEEE 754 double
-precision on both backends, so paths and totals are backend-identical. (One
-documented corner: with enough edge kinds in a single call to exceed the
-backend's bind-parameter budget — hundreds of kinds — equal-weight
-predecessor ties can resolve differently across backends; totals are
-unaffected.)
+precision on both backends: total weights are always backend-identical,
+and — unless a single call's `edges` list exceeds the backend's
+bind-parameter budget (hundreds of kinds, where equal-weight predecessor
+ties can resolve differently) — so is the returned node sequence.
 
 ## reachable
 

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -155,13 +155,19 @@ visible edge of the selected kinds is audited; the call throws a typed
 - **negative** — the pruning that makes the search terminate early assumes
   non-negative weights, so they are rejected rather than silently mis-answered;
 - **non-numeric** — a JSON string like `"5"` does not count; the property
-  must be stored as a JSON number;
+  must be stored as a JSON number (a JSON `null` counts as missing, not
+  non-numeric);
+- **not finite** — a JSON number beyond the IEEE 754 double range;
 - **missing** without a configured `defaultWeight`.
 
 The audit covers the selected edge kinds globally (not just edges the
 traversal happens to reach), so a data problem fails deterministically no
 matter which endpoints you query. Weight arithmetic uses IEEE 754 double
-precision on both backends, so paths and totals are backend-identical.
+precision on both backends, so paths and totals are backend-identical. (One
+documented corner: with enough edge kinds in a single call to exceed the
+backend's bind-parameter budget — hundreds of kinds — equal-weight
+predecessor ties can resolve differently across backends; totals are
+unaffected.)
 
 ## reachable
 

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -1,6 +1,6 @@
 ---
 title: Graph Algorithms
-description: Shortest path, reachability, neighborhoods, degree, and weakly connected components on store.algorithms
+description: Shortest path (weighted and unweighted), reachability, neighborhoods, degree, and weakly connected components on store.algorithms
 ---
 
 Graph queries like "are Alice and Bob connected?" or "who is within two hops
@@ -10,6 +10,10 @@ facade on the store:
 
 ```typescript
 store.algorithms.shortestPath(alice, bob, { edges: ["knows"] });
+store.algorithms.weightedShortestPath(alice, bob, {
+  edges: ["knows"],
+  weightProperty: "strength",
+});
 store.algorithms.reachable(alice, { edges: ["knows"] });
 store.algorithms.canReach(alice, bob, { edges: ["knows"] });
 store.algorithms.neighbors(alice, { edges: ["knows"], depth: 2 });
@@ -36,6 +40,7 @@ SQLite and PostgreSQL.
 | You want to... | Use |
 |----------------|-----|
 | Find the fewest-hop route between two nodes | `shortestPath` |
+| Find the cheapest route by a numeric edge property | `weightedShortestPath` |
 | List every node reachable from a source | `reachable` |
 | Check whether a node is reachable at all | `canReach` |
 | Get the k-hop neighborhood of a node | `neighbors` |
@@ -97,6 +102,66 @@ type ShortestPathResult = Readonly<{
 Source equal to target returns a zero-length path containing just that
 node. Endpoints that don't pass the resolved temporal filter return
 `undefined` — see [Temporal Behavior](#temporal-behavior).
+
+## weightedShortestPath
+
+Finds the minimum-total-weight path from `from` to `to`, weighting each
+traversed edge by a numeric property stored on it. This is the shape of
+LDBC's "trusted connection paths" query (Interactive IC14): the cheapest
+route where each hop's cost reflects, say, interaction strength — which is
+usually not the fewest-hop route.
+
+```typescript
+const path = await store.algorithms.weightedShortestPath(alice, bob, {
+  edges: ["knows"],
+  weightProperty: "interactionCost",
+  direction: "both",
+});
+
+if (path) {
+  console.log(`weight ${path.totalWeight} over ${path.depth} hops`);
+}
+```
+
+```typescript
+type WeightedShortestPathResult = Readonly<{
+  nodes: readonly Readonly<{ id: string; kind: string }>[];
+  depth: number; // hop count, nodes.length - 1
+  totalWeight: number; // sum of traversed edge weights
+}>;
+```
+
+Options differ from the unweighted traversals:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `edges` | `readonly EdgeKinds<G>[]` | *(required)* | Edge kinds to follow |
+| `weightProperty` | `string` | *(required)* | Top-level edge property holding each edge's non-negative numeric weight |
+| `defaultWeight` | `number` | *(none)* | Substituted for edges missing the property; must be finite and non-negative |
+| `direction` | `"out" \| "in" \| "both"` | `"out"` | Edge direction |
+| `maxIterations` | `number` | `1000` | Relaxation-round backstop; exceeding it throws `GraphAlgorithmConvergenceError` |
+| `temporalMode` / `asOf` / `workingMemory` | | | Same as the shared options above |
+
+There is no `maxHops`: cost-ordered search does not settle nodes in hop
+order, so a hop bound is not a natural stopping rule here. The algorithm
+relaxes frontier nodes round by round (with parallel edges collapsing to
+their cheapest member), prunes any candidate that already costs at least as
+much as a known path to the target, and stops when no distance improves.
+
+**Weights are validated up front.** Before any traversal rounds run, every
+visible edge of the selected kinds is audited; the call throws a typed
+`InvalidEdgeWeightError` naming the offending edge when a weight is:
+
+- **negative** — the pruning that makes the search terminate early assumes
+  non-negative weights, so they are rejected rather than silently mis-answered;
+- **non-numeric** — a JSON string like `"5"` does not count; the property
+  must be stored as a JSON number;
+- **missing** without a configured `defaultWeight`.
+
+The audit covers the selected edge kinds globally (not just edges the
+traversal happens to reach), so a data problem fails deterministically no
+matter which endpoints you query. Weight arithmetic uses IEEE 754 double
+precision on both backends, so paths and totals are backend-identical.
 
 ## reachable
 
@@ -358,10 +423,10 @@ file — a good starting point for your own RAG + graph workloads.
 
 ## What's Not Included
 
-These algorithms cover shortest path, reachability, neighborhoods, degree,
-and weakly connected components. They do **not** cover:
+These algorithms cover shortest path (weighted and unweighted),
+reachability, neighborhoods, degree, and weakly connected components. They
+do **not** cover:
 
-- Weighted shortest path (Dijkstra / A*)
 - Strongly connected components
 - Topological sort
 - Centrality measures beyond degree (betweenness, closeness, eigenvector)

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -157,7 +157,11 @@ visible edge of the selected kinds is audited; the call throws a typed
 - **non-numeric** — a JSON string like `"5"` does not count; the property
   must be stored as a JSON number (a JSON `null` counts as missing, not
   non-numeric);
-- **not finite** — a JSON number beyond the IEEE 754 double range;
+- **out of range** — a magnitude above ~9.7e289 (bounded so path sums can
+  never overflow the double range, on either backend) or a nonzero
+  magnitude below the smallest IEEE 754 double. One engine caveat:
+  SQLite's JSON parser rounds sub-denormal text like `1e-400` to `0`
+  before SQL can observe it, so only PostgreSQL can reject that case;
 - **missing** without a configured `defaultWeight`.
 
 The audit covers the selected edge kinds globally (not just edges the

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -266,12 +266,12 @@ for (let i = 0; i < items.length; i += BATCH_SIZE) {
 ## Graph Analytics Limits
 
 TypeGraph ships connectivity algorithms on `store.algorithms.*` — shortest
-path, reachability, k-hop neighborhoods, degree, and exact weakly connected
-components. See [Graph Algorithms](/graph-algorithms) for the full API.
+path (weighted and unweighted), reachability, k-hop neighborhoods, degree,
+and exact weakly connected components. See
+[Graph Algorithms](/graph-algorithms) for the full API.
 
 The following heavier analytics are **not** provided:
 
-- Weighted shortest path (Dijkstra, A*)
 - PageRank
 - Community detection
 - Centrality measures beyond degree (betweenness, closeness, eigenvector)

--- a/apps/docs/src/content/docs/overview.md
+++ b/apps/docs/src/content/docs/overview.md
@@ -106,8 +106,8 @@ The same query code works with SQLite and PostgreSQL.
 
 TypeGraph deliberately excludes:
 
-- **Advanced graph analytics**: No PageRank, community detection, weighted
-  shortest path, or centrality measures beyond degree
+- **Advanced graph analytics**: No PageRank, community detection, or
+  centrality measures beyond degree
 - **Distributed storage**: Single-database deployment only
 
 These exclusions keep TypeGraph focused and maintainable.
@@ -234,6 +234,7 @@ TypeGraph is not ideal for:
 - Large-scale graph analytics requiring distributed processing
 - Social networks with billions of edges
 - Real-time streaming graph data
-- Applications requiring advanced graph algorithms such as PageRank,
-  community detection, or weighted shortest path (use Neo4j or a graph
-  library; Tier 1 connectivity algorithms ship on `store.algorithms.*`)
+- Applications requiring advanced graph algorithms such as PageRank or
+  community detection (use Neo4j or a graph library; Tier 1 connectivity
+  algorithms — including weighted shortest path — ship on
+  `store.algorithms.*`)

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -939,23 +939,27 @@ export class GraphAlgorithmConvergenceError extends TypeGraphError {
 /** Stable reasons a weighted traversal can reject an edge's weight value. */
 export type InvalidEdgeWeightReason = "missing" | "negative" | "non_numeric";
 
-const EDGE_WEIGHT_REASON_MESSAGES: Readonly<
-  Record<InvalidEdgeWeightReason, string>
+const EDGE_WEIGHT_REASONS: Readonly<
+  Record<
+    InvalidEdgeWeightReason,
+    Readonly<{ message: string; suggestion: string }>
+  >
 > = {
-  missing: "has no value for weight property",
-  negative: "has a negative value for weight property",
-  non_numeric: "has a non-numeric value for weight property",
-};
-
-const EDGE_WEIGHT_REASON_SUGGESTIONS: Readonly<
-  Record<InvalidEdgeWeightReason, string>
-> = {
-  missing:
-    "Set the property on every selected edge, or provide defaultWeight for edges without it.",
-  negative:
-    "Weighted traversal requires non-negative weights; repair the edge data before retrying.",
-  non_numeric:
-    "Store the weight property as a JSON number on every selected edge before retrying.",
+  missing: {
+    message: "has no value for weight property",
+    suggestion:
+      "Set the property on every selected edge, or provide defaultWeight for edges without it.",
+  },
+  negative: {
+    message: "has a negative value for weight property",
+    suggestion:
+      "Weighted traversal requires non-negative weights; repair the edge data before retrying.",
+  },
+  non_numeric: {
+    message: "has a non-numeric value for weight property",
+    suggestion:
+      "Store the weight property as a JSON number on every selected edge before retrying.",
+  },
 };
 
 /**
@@ -975,14 +979,14 @@ export class InvalidEdgeWeightError extends TypeGraphError {
     }>,
   ) {
     super(
-      `Edge '${details.edgeId}' (kind '${details.edgeKind}') ${EDGE_WEIGHT_REASON_MESSAGES[details.reason]} '${details.property}'${
+      `Edge '${details.edgeId}' (kind '${details.edgeKind}') ${EDGE_WEIGHT_REASONS[details.reason].message} '${details.property}'${
         details.value === undefined ? "" : ` (value: ${details.value})`
       }.`,
       "INVALID_EDGE_WEIGHT",
       {
         details: { ...details },
         category: "user",
-        suggestion: EDGE_WEIGHT_REASON_SUGGESTIONS[details.reason],
+        suggestion: EDGE_WEIGHT_REASONS[details.reason].suggestion,
       },
     );
     this.name = "InvalidEdgeWeightError";

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -937,7 +937,8 @@ export class GraphAlgorithmConvergenceError extends TypeGraphError {
 }
 
 /** Stable reasons a weighted traversal can reject an edge's weight value. */
-export type InvalidEdgeWeightReason = "missing" | "negative" | "non_numeric";
+export type InvalidEdgeWeightReason =
+  "missing" | "negative" | "non_numeric" | "not_finite";
 
 const EDGE_WEIGHT_REASONS: Readonly<
   Record<
@@ -959,6 +960,12 @@ const EDGE_WEIGHT_REASONS: Readonly<
     message: "has a non-numeric value for weight property",
     suggestion:
       "Store the weight property as a JSON number on every selected edge before retrying.",
+  },
+  not_finite: {
+    message:
+      "has a value outside the IEEE 754 double range for weight property",
+    suggestion:
+      "Keep weight values within the finite double-precision range on every selected edge.",
   },
 };
 

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -936,6 +936,59 @@ export class GraphAlgorithmConvergenceError extends TypeGraphError {
   }
 }
 
+/** Stable reasons a weighted traversal can reject an edge's weight value. */
+export type InvalidEdgeWeightReason = "missing" | "negative" | "non_numeric";
+
+const EDGE_WEIGHT_REASON_MESSAGES: Readonly<
+  Record<InvalidEdgeWeightReason, string>
+> = {
+  missing: "has no value for weight property",
+  negative: "has a negative value for weight property",
+  non_numeric: "has a non-numeric value for weight property",
+};
+
+const EDGE_WEIGHT_REASON_SUGGESTIONS: Readonly<
+  Record<InvalidEdgeWeightReason, string>
+> = {
+  missing:
+    "Set the property on every selected edge, or provide defaultWeight for edges without it.",
+  negative:
+    "Weighted traversal requires non-negative weights; repair the edge data before retrying.",
+  non_numeric:
+    "Store the weight property as a JSON number on every selected edge before retrying.",
+};
+
+/**
+ * Thrown when a weighted graph algorithm finds an edge whose weight property
+ * violates the weighted-traversal contract (missing without a default,
+ * non-numeric, or negative). Raised before any traversal rounds run, so a
+ * weighted call either observes a fully valid weight domain or fails fast.
+ */
+export class InvalidEdgeWeightError extends TypeGraphError {
+  constructor(
+    details: Readonly<{
+      edgeId: string;
+      edgeKind: string;
+      property: string;
+      reason: InvalidEdgeWeightReason;
+      value?: string;
+    }>,
+  ) {
+    super(
+      `Edge '${details.edgeId}' (kind '${details.edgeKind}') ${EDGE_WEIGHT_REASON_MESSAGES[details.reason]} '${details.property}'${
+        details.value === undefined ? "" : ` (value: ${details.value})`
+      }.`,
+      "INVALID_EDGE_WEIGHT",
+      {
+        details: { ...details },
+        category: "user",
+        suggestion: EDGE_WEIGHT_REASON_SUGGESTIONS[details.reason],
+      },
+    );
+    this.name = "InvalidEdgeWeightError";
+  }
+}
+
 /** Thrown when an operation requires a backend capability it does not expose. */
 export class UnsupportedBackendCapabilityError extends TypeGraphError {
   constructor(

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -938,7 +938,21 @@ export class GraphAlgorithmConvergenceError extends TypeGraphError {
 
 /** Stable reasons a weighted traversal can reject an edge's weight value. */
 export type InvalidEdgeWeightReason =
-  "missing" | "negative" | "non_numeric" | "not_finite";
+  "missing" | "negative" | "non_numeric" | "out_of_range";
+
+/** Details for InvalidEdgeWeightError. */
+export type InvalidEdgeWeightErrorDetails = Readonly<{
+  /** Id of the first offending edge, in binary-collation order. */
+  edgeId: string;
+  /** Kind of the offending edge. */
+  edgeKind: string;
+  /** The audited weight property. */
+  property: string;
+  /** Why the weight was rejected. */
+  reason: InvalidEdgeWeightReason;
+  /** The offending value, when one was present and renderable. */
+  value?: string;
+}>;
 
 const EDGE_WEIGHT_REASONS: Readonly<
   Record<
@@ -961,11 +975,10 @@ const EDGE_WEIGHT_REASONS: Readonly<
     suggestion:
       "Store the weight property as a JSON number on every selected edge before retrying.",
   },
-  not_finite: {
-    message:
-      "has a value outside the IEEE 754 double range for weight property",
+  out_of_range: {
+    message: "has a value outside the supported range for weight property",
     suggestion:
-      "Keep weight values within the finite double-precision range on every selected edge.",
+      "Keep weight magnitudes within the range weightedShortestPath documents (large enough to be a normal IEEE 754 double, small enough that path sums cannot overflow).",
   },
 };
 
@@ -976,15 +989,9 @@ const EDGE_WEIGHT_REASONS: Readonly<
  * weighted call either observes a fully valid weight domain or fails fast.
  */
 export class InvalidEdgeWeightError extends TypeGraphError {
-  constructor(
-    details: Readonly<{
-      edgeId: string;
-      edgeKind: string;
-      property: string;
-      reason: InvalidEdgeWeightReason;
-      value?: string;
-    }>,
-  ) {
+  declare readonly details: InvalidEdgeWeightErrorDetails;
+
+  constructor(details: InvalidEdgeWeightErrorDetails) {
     super(
       `Edge '${details.edgeId}' (kind '${details.edgeKind}') ${EDGE_WEIGHT_REASONS[details.reason].message} '${details.property}'${
         details.value === undefined ? "" : ` (value: ${details.value})`

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -266,6 +266,7 @@ export type {
   EndpointErrorDetails,
   EndpointNotFoundErrorDetails,
   ErrorCategory,
+  InvalidEdgeWeightReason,
   KindNotFoundErrorDetails,
   MigrationErrorDetails,
   NodeConstraintNotFoundErrorDetails,
@@ -302,6 +303,7 @@ export {
   // Error utility functions
   getErrorSuggestion,
   GraphAlgorithmConvergenceError,
+  InvalidEdgeWeightError,
   isConstraintError,
   isRecordedCaptureGuardError,
   isSystemError,
@@ -401,6 +403,7 @@ export type {
   StoreViewShortestPathOptions,
   StoreViewSubgraphOptions,
   StoreViewWeaklyConnectedComponentsOptions,
+  StoreViewWeightedShortestPathOptions,
   TypedRecordedStoreViewEdgeCollection,
   TypedStoreViewEdgeCollection,
 } from "./store";
@@ -428,6 +431,8 @@ export type {
   TraversalDirection,
   WeaklyConnectedComponentMembership,
   WeaklyConnectedComponentsOptions,
+  WeightedShortestPathOptions,
+  WeightedShortestPathResult,
 } from "./store/algorithms";
 export type {
   AnyEdge,

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -266,6 +266,7 @@ export type {
   EndpointErrorDetails,
   EndpointNotFoundErrorDetails,
   ErrorCategory,
+  InvalidEdgeWeightErrorDetails,
   InvalidEdgeWeightReason,
   KindNotFoundErrorDetails,
   MigrationErrorDetails,

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -172,6 +172,13 @@ export const postgresDialect: DialectAdapter = {
     return sql`(${column} #> ${path} IS NULL OR ${column} #>> ${path} = 'null')`;
   },
 
+  jsonPathIsNumber(column, pointer) {
+    const path = toPostgresPath(pointer);
+    // jsonb_typeof returns NULL for a missing path; COALESCE keeps the
+    // predicate two-valued so negations don't silently drop rows.
+    return sql`COALESCE(jsonb_typeof(${column} #> ${path}) = 'number', FALSE)`;
+  },
+
   jsonPathIsNotNull(column, pointer) {
     const path = toPostgresPath(pointer);
     return sql`(${column} #> ${path} IS NOT NULL AND ${column} #>> ${path} != 'null')`;

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -12,10 +12,23 @@ import { likeEscapeClause } from "./like-escape";
 import { type DialectAdapter } from "./types";
 
 /**
- * Escapes a string for use in a PostgreSQL string literal.
- * Uses single quotes and escapes embedded single quotes.
+ * Escapes a string for use in a PostgreSQL string literal, independent of
+ * server configuration.
+ *
+ * A plain `'…'` literal is only safe when the value contains no backslash:
+ * under the legacy `standard_conforming_strings = off` setting, backslashes
+ * act as escape characters inside regular literals, so a value ending in
+ * `\` could swallow the closing quote and change how the statement parses.
+ * Values containing a backslash therefore use the `E'…'` form — where
+ * backslash is an escape character under BOTH settings — with backslashes
+ * and quotes doubled. Backslash-free values keep the plain form so the
+ * emitted SQL text (which callers rely on being identical across clauses)
+ * is unchanged for the common case.
  */
 function escapePostgresLiteral(value: string): string {
+  if (value.includes("\\")) {
+    return `E'${value.replaceAll("\\", "\\\\").replaceAll("'", "''")}'`;
+  }
   // PostgreSQL uses '' to escape single quotes inside string literals
   return `'${value.replaceAll("'", "''")}'`;
 }
@@ -25,7 +38,10 @@ function escapePostgresLiteral(value: string): string {
  *
  * Uses raw SQL (non-parameterized) to ensure the same expression text
  * is generated when the same field is used in multiple clauses (SELECT, GROUP BY).
- * This is safe because JSON pointers come from schema definitions, not user input.
+ * Pointers usually come from schema definitions, but some (e.g. a weighted
+ * traversal's `weightProperty`) are runtime strings — safe either way
+ * because {@link escapePostgresLiteral} escapes independently of server
+ * configuration.
  *
  * @example
  * "/name" → ARRAY['name']

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -186,6 +186,15 @@ export const postgresDialect: DialectAdapter = {
     return sql`COALESCE(jsonb_typeof(${column} #> ${path}) = 'number', FALSE)`;
   },
 
+  jsonPathIsMissingOrNull(column, pointer) {
+    const path = toPostgresPath(pointer);
+    // Type-based: a JSON string "null" is a string, not null (the `#>>`
+    // text comparison in jsonPathIsNull cannot tell them apart), and
+    // jsonb_typeof of a JSON null is 'null' rather than SQL NULL, so this
+    // stays two-valued where `column #> path IS NULL` would not.
+    return sql`COALESCE(jsonb_typeof(${column} #> ${path}) = 'null', TRUE)`;
+  },
+
   jsonPathIsNotNull(column, pointer) {
     const path = toPostgresPath(pointer);
     return sql`(${column} #> ${path} IS NOT NULL AND ${column} #>> ${path} != 'null')`;

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -107,6 +107,13 @@ export const postgresDialect: DialectAdapter = {
     return sql`(${column} #>> ${path})::numeric`;
   },
 
+  jsonExtractDouble(column, pointer) {
+    // float8, not ::numeric — decimal arithmetic would diverge from
+    // SQLite's binary doubles when values accumulate.
+    const path = toPostgresPath(pointer);
+    return sql`(${column} #>> ${path})::double precision`;
+  },
+
   jsonExtractBoolean(column, pointer) {
     // Extract as text then cast to boolean
     const path = toPostgresPath(pointer);

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -111,6 +111,13 @@ export const sqliteDialect: DialectAdapter = {
     return sql`json_extract(${column}, ${sql.raw(escapeSqliteLiteral(path))})`;
   },
 
+  jsonExtractDouble(column, pointer) {
+    // json_extract already yields INTEGER/REAL affinity for JSON numbers,
+    // and SQLite arithmetic on those values is IEEE 754 double.
+    const path = toSqlitePath(pointer);
+    return sql`json_extract(${column}, ${sql.raw(escapeSqliteLiteral(path))})`;
+  },
+
   jsonExtractBoolean(column, pointer) {
     // SQLite json_extract returns 0/1 for boolean values
     const path = toSqlitePath(pointer);

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -189,6 +189,14 @@ export const sqliteDialect: DialectAdapter = {
     return sql`COALESCE(json_type(${column}, ${pathSql}) IN ('integer', 'real'), 0)`;
   },
 
+  jsonPathIsMissingOrNull(column, pointer) {
+    const path = toSqlitePath(pointer);
+    const pathSql = sql.raw(escapeSqliteLiteral(path));
+    // Type-based: a JSON string "null" is a string, not null. json_type
+    // returns NULL for a missing path, which COALESCE maps to TRUE.
+    return sql`COALESCE(json_type(${column}, ${pathSql}) = 'null', 1)`;
+  },
+
   jsonPathIsNotNull(column, pointer) {
     const path = toSqlitePath(pointer);
     const pathSql = sql.raw(escapeSqliteLiteral(path));

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -174,6 +174,14 @@ export const sqliteDialect: DialectAdapter = {
     return sql`(json_extract(${column}, ${pathSql}) IS NULL OR json_type(${column}, ${pathSql}) = 'null')`;
   },
 
+  jsonPathIsNumber(column, pointer) {
+    const path = toSqlitePath(pointer);
+    const pathSql = sql.raw(escapeSqliteLiteral(path));
+    // json_type returns NULL for a missing path; COALESCE keeps the
+    // predicate two-valued so negations don't silently drop rows.
+    return sql`COALESCE(json_type(${column}, ${pathSql}) IN ('integer', 'real'), 0)`;
+  },
+
   jsonPathIsNotNull(column, pointer) {
     const path = toSqlitePath(pointer);
     const pathSql = sql.raw(escapeSqliteLiteral(path));

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -171,6 +171,20 @@ export interface DialectAdapter {
   jsonExtractNumber(column: SQL, pointer: JsonPointer): SQL;
 
   /**
+   * Extracts a JSON value at a path as an IEEE 754 double.
+   *
+   * Unlike {@link jsonExtractNumber} — whose PostgreSQL form casts to
+   * `numeric` and therefore computes in exact decimal — this member
+   * guarantees binary double arithmetic on every dialect, so accumulated
+   * results (e.g. graph traversal weights) are backend-identical.
+   *
+   * @example
+   * SQLite: json_extract(column, '$.path')
+   * PostgreSQL: (column #>> ARRAY['path'])::double precision
+   */
+  jsonExtractDouble(column: SQL, pointer: JsonPointer): SQL;
+
+  /**
    * Extracts a JSON value at a path and casts to boolean.
    *
    * @example

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -255,6 +255,18 @@ export interface DialectAdapter {
    */
   jsonPathIsNotNull(column: SQL, pointer: JsonPointer): SQL;
 
+  /**
+   * Checks if the JSON value at a path exists and is a JSON number.
+   *
+   * Never evaluates to SQL NULL: a missing path yields FALSE, so the
+   * predicate can be negated safely inside audit-style WHERE clauses.
+   *
+   * @example
+   * SQLite: json_type(column, '$.path') IN ('integer', 'real')
+   * PostgreSQL: jsonb_typeof(column #> path) = 'number'
+   */
+  jsonPathIsNumber(column: SQL, pointer: JsonPointer): SQL;
+
   // ============================================================
   // Comparison Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -281,6 +281,21 @@ export interface DialectAdapter {
    */
   jsonPathIsNumber(column: SQL, pointer: JsonPointer): SQL;
 
+  /**
+   * Checks if the JSON value at a path is absent or the JSON `null`
+   * literal — i.e. carries no usable value.
+   *
+   * Unlike {@link jsonPathIsNull}, this predicate is type-based
+   * (`json_type` / `jsonb_typeof`), so a JSON *string* `"null"` is NOT
+   * treated as null, and it never evaluates to SQL NULL — a missing path
+   * yields TRUE — so it composes safely inside audit-style WHERE clauses.
+   *
+   * @example
+   * SQLite: COALESCE(json_type(column, '$.path') = 'null', 1)
+   * PostgreSQL: COALESCE(jsonb_typeof(column #> path) = 'null', TRUE)
+   */
+  jsonPathIsMissingOrNull(column: SQL, pointer: JsonPointer): SQL;
+
   // ============================================================
   // Comparison Operations
   // ============================================================

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -13,6 +13,7 @@ import {
   type NodeExpansion,
   type NodeIdentityKey,
   nodeIdentityKey,
+  nodeIdentityKeyFromRow,
   reduceExpandedWorkingSet,
   runIterativeGraphOperation,
   supportsTemporaryIteration,
@@ -739,16 +740,10 @@ function createVisitedMapFromRows(
     rows
       .filter((row) => row.side === side)
       .map((row) => {
-        const parentKey =
-          (
-            typeof row.predecessor_id !== "string" ||
-            typeof row.predecessor_kind !== "string"
-          ) ?
-            undefined
-          : nodeIdentityKey({
-              id: row.predecessor_id,
-              kind: row.predecessor_kind,
-            });
+        const parentKey = nodeIdentityKeyFromRow(
+          row.predecessor_id,
+          row.predecessor_kind,
+        );
         const node = {
           id: row.node_id,
           kind: row.node_kind,

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -15,6 +15,7 @@ import {
   nodeIdentityKey,
   reduceExpandedWorkingSet,
   runIterativeGraphOperation,
+  supportsTemporaryIteration,
   withInlineIterativeGraphOperation,
 } from "./iterative-graph-operation";
 import type {
@@ -96,17 +97,6 @@ export async function findShortestPath(
     );
   }
   return findShortestPathInline(ctx, sourceId, targetId, maxHops, options);
-}
-
-function supportsTemporaryIteration(ctx: AlgorithmContext): boolean {
-  // Working-table rounds fold their frontier and meeting bookkeeping into
-  // `INSERT … RETURNING`, so an engine without RETURNING must take the
-  // inline fallback.
-  return (
-    ctx.backend.capabilities.transactions &&
-    ctx.backend.capabilities.returning !== false &&
-    ctx.backend.executeTemporaryStatement !== undefined
-  );
 }
 
 async function findReachableNodesInWorkingTable(

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -51,6 +51,14 @@ export type InternalTraversalOptions = InternalTemporalOptions &
     direction?: TraversalDirection;
     cyclePolicy?: AlgorithmCyclePolicy;
     workingMemory?: string;
+    /**
+     * Numeric edge property supplying per-edge traversal weights. When set,
+     * the iterative operation compiles a shared weight expression and every
+     * edge expansion carries a `weight` column.
+     */
+    weightProperty?: string;
+    /** Weight substituted for edges missing `weightProperty`. */
+    defaultWeight?: number;
   }>;
 
 /**
@@ -151,6 +159,27 @@ export function resolveMaxHops(
   }
 
   return value;
+}
+
+/**
+ * Validates an iterative algorithm's round budget. Unlike {@link
+ * resolveMaxHops}, the budget is not a traversal depth bound — convergence
+ * normally ends the run first — so it is not capped at the recursive-CTE
+ * depth limit.
+ */
+export function resolveMaxIterations(
+  value: number | undefined,
+  fallback: number,
+  algorithm: string,
+): number {
+  const maxIterations = value ?? fallback;
+  if (!Number.isSafeInteger(maxIterations) || maxIterations < 1) {
+    throw new ConfigurationError(
+      `${algorithm} maxIterations must be a positive safe integer, got ${String(maxIterations)}.`,
+      { maxIterations },
+    );
+  }
+  return maxIterations;
 }
 
 export function assertEdgeKinds(edges: readonly string[]): void {

--- a/packages/typegraph/src/store/algorithms/index.ts
+++ b/packages/typegraph/src/store/algorithms/index.ts
@@ -26,6 +26,7 @@ import type {
   InternalReachableOptions,
   InternalShortestPathOptions,
   InternalWeaklyConnectedComponentsOptions,
+  InternalWeightedShortestPathOptions,
   NeighborsOptions,
   ReachableNode,
   ReachableOptions,
@@ -33,8 +34,11 @@ import type {
   ShortestPathResult,
   WeaklyConnectedComponentMembership,
   WeaklyConnectedComponentsOptions,
+  WeightedShortestPathOptions,
+  WeightedShortestPathResult,
 } from "./types";
 import { executeWeaklyConnectedComponents } from "./weakly-connected-components";
+import { executeWeightedShortestPath } from "./weighted-shortest-path";
 
 /**
  * Raw node id or any object with an `id: string` field. Covers `Node`,
@@ -76,6 +80,32 @@ export type GraphAlgorithms<G extends GraphDef> = Readonly<{
     to: NodeIdentifier,
     options: ShortestPathOptions<G>,
   ) => Promise<ShortestPathResult | undefined>;
+
+  /**
+   * Finds the minimum-total-weight path from `from` to `to`, weighting each
+   * traversed edge by the numeric `weightProperty` stored on it. Returns
+   * `undefined` when no path exists. Weights must be non-negative; a
+   * negative, non-numeric, or (without `defaultWeight`) missing weight on
+   * any visible edge of the selected kinds throws `InvalidEdgeWeightError`
+   * before traversal starts.
+   *
+   * @example
+   * ```typescript
+   * const path = await store.algorithms.weightedShortestPath(alice, bob, {
+   *   edges: ["knows"],
+   *   weightProperty: "interactionCost",
+   *   direction: "both",
+   * });
+   * if (path) {
+   *   console.log(`total weight ${path.totalWeight} over ${path.depth} hops`);
+   * }
+   * ```
+   */
+  weightedShortestPath: (
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: WeightedShortestPathOptions<G>,
+  ) => Promise<WeightedShortestPathResult | undefined>;
 
   /**
    * Returns every node reachable from `from` within `maxHops` edges of the
@@ -130,6 +160,11 @@ export type InternalGraphAlgorithms<G extends GraphDef> = Readonly<{
     to: NodeIdentifier,
     options: InternalShortestPathOptions<G>,
   ) => Promise<ShortestPathResult | undefined>;
+  weightedShortestPath: (
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: InternalWeightedShortestPathOptions<G>,
+  ) => Promise<WeightedShortestPathResult | undefined>;
   reachable: (
     from: NodeIdentifier,
     options: InternalReachableOptions<G>,
@@ -207,6 +242,19 @@ export function createGraphAlgorithms<G extends GraphDef>(
         options,
       );
     },
+    weightedShortestPath(from, to, options) {
+      assertRecordedAsOfInternalOnly(
+        options,
+        "weightedShortestPath",
+        allowRecordedAsOf,
+      );
+      return executeWeightedShortestPath(
+        ctx,
+        resolveNodeId(from),
+        resolveNodeId(to),
+        options,
+      );
+    },
     reachable(from, options) {
       assertRecordedAsOfInternalOnly(options, "reachable", allowRecordedAsOf);
       return executeReachable(ctx, resolveNodeId(from), options);
@@ -250,6 +298,7 @@ export type {
   InternalShortestPathOptions,
   InternalTemporalAlgorithmOptions,
   InternalWeaklyConnectedComponentsOptions,
+  InternalWeightedShortestPathOptions,
   NeighborsOptions,
   PathNode,
   ReachableNode,
@@ -260,4 +309,6 @@ export type {
   TraversalDirection,
   WeaklyConnectedComponentMembership,
   WeaklyConnectedComponentsOptions,
+  WeightedShortestPathOptions,
+  WeightedShortestPathResult,
 } from "./types";

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -6,6 +6,7 @@ import {
   type TransactionBackend,
 } from "../../backend/types";
 import {
+  CompilerInvariantError,
   ConfigurationError,
   GraphAlgorithmConvergenceError,
 } from "../../errors";
@@ -25,6 +26,7 @@ import {
 } from "../../query/sql-intent";
 import { compareStrings } from "../../utils/compare";
 import { generateId } from "../../utils/id";
+import { isPresent } from "../../utils/presence";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
 import { resolveReadSchema, resolveTemporalOptions } from "./context";
 import type { PathNode, TraversalDirection } from "./types";
@@ -402,14 +404,21 @@ export async function reduceExpandedWorkingSet<T>(
         ),
       );
       for (const row of rows) {
+        // A weighted operation compiles a weight column into every
+        // expansion, and weighted algorithms audit their weight domain
+        // before expanding — so a NULL weight here means a plan skipped
+        // that audit, and silently dropping the edge would return
+        // plausible-but-wrong results.
+        if (operation.weightExpression !== undefined && !isPresent(row.weight)) {
+          throw new CompilerInvariantError(
+            "Weighted graph expansion produced a NULL weight; the operation's weight domain was not audited.",
+            { source: row.source_id, target: row.target_id },
+          );
+        }
         const expansion = {
           source: { id: row.source_id, kind: row.source_kind },
           target: { id: row.target_id, kind: row.target_kind },
-          // Missing-weight edges are pre-audited away unless a default is
-          // configured, so a NULL weight can only mean "not a weighted run".
-          ...(row.weight === undefined || row.weight === null ?
-            {}
-          : { weight: Number(row.weight) }),
+          ...(isPresent(row.weight) ? { weight: Number(row.weight) } : {}),
         } satisfies NodeExpansion;
         const targetKey = nodeIdentityKey(expansion.target);
         const selected = reduce(reduced.get(targetKey), expansion);
@@ -422,6 +431,19 @@ export async function reduceExpandedWorkingSet<T>(
 
 export function nodeIdentityKey(node: PathNode): NodeIdentityKey {
   return `${node.kind}\u0000${node.id}` as NodeIdentityKey;
+}
+
+/**
+ * Builds a node-identity key from a working-table row's nullable
+ * predecessor columns. Drivers deliver SQL NULL in varying shapes, so only
+ * a string pair counts as a real predecessor.
+ */
+export function nodeIdentityKeyFromRow(
+  id: unknown,
+  kind: unknown,
+): NodeIdentityKey | undefined {
+  if (typeof id !== "string" || typeof kind !== "string") return undefined;
+  return nodeIdentityKey({ id, kind });
 }
 
 export function compareNodeIdentity(left: PathNode, right: PathNode): number {
@@ -753,7 +775,10 @@ function compileWeightExpression(
   weightProperty: string,
   defaultWeight: number | undefined,
 ): SQL {
-  const extracted = sql`CAST(${dialect.jsonExtractText(sql.raw("e.props"), jsonPointer([weightProperty]))} AS DOUBLE PRECISION)`;
+  const extracted = dialect.jsonExtractDouble(
+    sql.raw("e.props"),
+    jsonPointer([weightProperty]),
+  );
   return defaultWeight === undefined ? extracted : (
       sql`COALESCE(${extracted}, ${defaultWeight})`
     );

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -17,6 +17,8 @@ import {
   compileTemporalFilter,
   currentReadInstant,
 } from "../../query/compiler/temporal";
+import { type DialectAdapter } from "../../query/dialect/types";
+import { jsonPointer } from "../../query/json-pointer";
 import {
   asCompiledRowsSql,
   asCompiledTemporaryStatementSql,
@@ -44,6 +46,13 @@ export type IterativeGraphOperation = Readonly<{
    * working-table rounds; `undefined` inherits the engine's configuration.
    */
   workingMemory: string | undefined;
+  /**
+   * Per-edge traversal weight over the expansion's edge alias `e`, compiled
+   * from the caller's `weightProperty`/`defaultWeight`. When set, every edge
+   * expansion carries it as a `weight` column; `undefined` for unweighted
+   * operations.
+   */
+  weightExpression: SQL | undefined;
 }>;
 
 export type NodeIdentityKey = string & {
@@ -53,6 +62,8 @@ export type NodeIdentityKey = string & {
 export type NodeExpansion = Readonly<{
   source: PathNode;
   target: PathNode;
+  /** Edge weight; present exactly when the operation is weighted. */
+  weight?: number;
 }>;
 
 type TemporaryStatementBackend = QueryBackend &
@@ -101,6 +112,8 @@ type ExpansionRow = Readonly<{
   source_kind: string;
   target_id: string;
   target_kind: string;
+  /** Present when the operation is weighted; drivers may deliver text. */
+  weight?: number | string | null;
 }>;
 
 type VisibleNodeRow = Readonly<{
@@ -110,6 +123,8 @@ type VisibleNodeRow = Readonly<{
 
 const DEFAULT_MAX_BIND_PARAMETERS = 999;
 const RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH = 12;
+/** Headroom for the weight expression's path and default-weight binds. */
+const RESERVED_WEIGHT_BIND_PARAMETERS_PER_BRANCH = 4;
 /**
  * PostgreSQL initially estimates an un-analyzed temporary relation at one row.
  * Even a few dozen rows can distort join ordering on a dense edge expansion,
@@ -390,6 +405,11 @@ export async function reduceExpandedWorkingSet<T>(
         const expansion = {
           source: { id: row.source_id, kind: row.source_kind },
           target: { id: row.target_id, kind: row.target_kind },
+          // Missing-weight edges are pre-audited away unless a default is
+          // configured, so a NULL weight can only mean "not a weighted run".
+          ...(row.weight === undefined || row.weight === null ?
+            {}
+          : { weight: Number(row.weight) }),
         } satisfies NodeExpansion;
         const targetKey = nodeIdentityKey(expansion.target);
         const selected = reduce(reduced.get(targetKey), expansion);
@@ -597,7 +617,9 @@ function compileDirectionalExpansion(
     targetField,
     targetKindField,
   );
-  return sql`SELECT expanded.source_id, expanded.source_kind, n.id AS target_id, n.kind AS target_kind FROM (${edgeExpansion}) expanded JOIN ${operation.schema.nodesTable} n ON n.graph_id = ${operation.ctx.graphId} AND n.id = expanded.target_id AND n.kind = expanded.target_kind WHERE ${operation.nodeTemporalFilter}`;
+  const weightColumn =
+    operation.weightExpression === undefined ? sql`` : sql`, expanded.weight`;
+  return sql`SELECT expanded.source_id, expanded.source_kind, n.id AS target_id, n.kind AS target_kind${weightColumn} FROM (${edgeExpansion}) expanded JOIN ${operation.schema.nodesTable} n ON n.graph_id = ${operation.ctx.graphId} AND n.id = expanded.target_id AND n.kind = expanded.target_kind WHERE ${operation.nodeTemporalFilter}`;
 }
 
 function compileDirectionalEdgeExpansion(
@@ -611,7 +633,11 @@ function compileDirectionalEdgeExpansion(
   targetKindField: "from_kind" | "to_kind",
 ): ReturnType<typeof sql> {
   const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
-  return sql`SELECT w.node_id AS source_id, w.node_kind AS source_kind, e.${sql.raw(targetField)} AS target_id, e.${sql.raw(targetKindField)} AS target_kind FROM ${workingRelation} w JOIN ${operation.schema.edgesTable} e ON e.${sql.raw(joinField)} = w.node_id AND e.${sql.raw(joinKindField)} = w.node_kind AND e.graph_id = ${operation.ctx.graphId} WHERE ${sourceFilter} AND ${edgeKindFilter} AND ${operation.edgeTemporalFilter}`;
+  const weightColumn =
+    operation.weightExpression === undefined ?
+      sql``
+    : sql`, ${operation.weightExpression} AS weight`;
+  return sql`SELECT w.node_id AS source_id, w.node_kind AS source_kind, e.${sql.raw(targetField)} AS target_id, e.${sql.raw(targetKindField)} AS target_kind${weightColumn} FROM ${workingRelation} w JOIN ${operation.schema.edgesTable} e ON e.${sql.raw(joinField)} = w.node_id AND e.${sql.raw(joinKindField)} = w.node_kind AND e.graph_id = ${operation.ctx.graphId} WHERE ${sourceFilter} AND ${edgeKindFilter} AND ${operation.edgeTemporalFilter}`;
 }
 
 function chunkValues<T>(
@@ -650,12 +676,24 @@ function createOperation(
     tableAlias: "e",
     currentTimestamp,
   });
+  const weightExpression =
+    options.weightProperty === undefined ? undefined : (
+      compileWeightExpression(
+        ctx.dialect,
+        options.weightProperty,
+        options.defaultWeight,
+      )
+    );
   const direction = options.direction ?? "out";
   const branchCount = direction === "both" ? 2 : 1;
   const parameterLimit =
     backend.capabilities.maxBindParameters ?? DEFAULT_MAX_BIND_PARAMETERS;
-  const fixedParameters =
-    branchCount * RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH;
+  const reservedPerBranch =
+    RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH +
+    (weightExpression === undefined ? 0 : (
+      RESERVED_WEIGHT_BIND_PARAMETERS_PER_BRANCH
+    ));
+  const fixedParameters = branchCount * reservedPerBranch;
   const sharedBudget = parameterLimit - fixedParameters;
   const maxEdgeKindsPerQuery = Math.floor(sharedBudget / (branchCount + 2));
   if (maxEdgeKindsPerQuery < 1) {
@@ -674,9 +712,7 @@ function createOperation(
     ...edgeKindChunks.map((chunk) => chunk.length),
   );
   const maxWorkingSetSize = Math.floor(
-    (parameterLimit -
-      branchCount *
-        (largestEdgeKindChunk + RESERVED_TEMPORAL_BIND_PARAMETERS_PER_BRANCH)) /
+    (parameterLimit - branchCount * (largestEdgeKindChunk + reservedPerBranch)) /
       2,
   );
   if (maxWorkingSetSize < 1) {
@@ -696,7 +732,45 @@ function createOperation(
     edgeTemporalFilter,
     schema: resolveReadSchema(ctx, options),
     workingMemory: resolveWorkingMemory(options.workingMemory),
+    weightExpression,
   };
+}
+
+/**
+ * Compiles the per-edge weight expression over the expansion's edge alias
+ * `e`. The extraction is cast to DOUBLE PRECISION — a spelling both engines
+ * accept — so weight arithmetic is IEEE 754 double on both backends.
+ * PostgreSQL's `::numeric` extraction would use exact decimal arithmetic and
+ * could produce different accumulated distances (and therefore different
+ * paths) than SQLite's binary doubles.
+ *
+ * The weight audit runs before any expansion, so by the time this expression
+ * evaluates, every selected edge's property is a JSON number (never text the
+ * cast could mangle or reject) or absent with a configured default.
+ */
+function compileWeightExpression(
+  dialect: DialectAdapter,
+  weightProperty: string,
+  defaultWeight: number | undefined,
+): SQL {
+  const extracted = sql`CAST(${dialect.jsonExtractText(sql.raw("e.props"), jsonPointer([weightProperty]))} AS DOUBLE PRECISION)`;
+  return defaultWeight === undefined ? extracted : (
+      sql`COALESCE(${extracted}, ${defaultWeight})`
+    );
+}
+
+/**
+ * Whether the backend can host working-table rounds: a pinned transactional
+ * connection, temporary-statement support, and `INSERT … RETURNING` for the
+ * folded frontier bookkeeping. Callers without it take the inline
+ * chunked-`VALUES` fallback.
+ */
+export function supportsTemporaryIteration(ctx: AlgorithmContext): boolean {
+  return (
+    ctx.backend.capabilities.transactions &&
+    ctx.backend.capabilities.returning !== false &&
+    ctx.backend.executeTemporaryStatement !== undefined
+  );
 }
 
 function requireTemporaryStatements(

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -406,12 +406,16 @@ export async function reduceExpandedWorkingSet<T>(
       for (const row of rows) {
         // A weighted operation compiles a weight column into every
         // expansion, and weighted algorithms audit their weight domain
-        // before expanding — so a NULL weight here means a plan skipped
-        // that audit, and silently dropping the edge would return
-        // plausible-but-wrong results.
-        if (operation.weightExpression !== undefined && !isPresent(row.weight)) {
+        // before expanding — so a NULL weight here means either a plan
+        // skipped that audit, or (on a backend without snapshot isolation)
+        // a concurrent write invalidated a weight mid-run. Silently
+        // dropping the edge would return plausible-but-wrong results.
+        if (
+          operation.weightExpression !== undefined &&
+          !isPresent(row.weight)
+        ) {
           throw new CompilerInvariantError(
-            "Weighted graph expansion produced a NULL weight; the operation's weight domain was not audited.",
+            "Weighted graph expansion produced a NULL weight. Either the plan skipped its weight audit, or edge data changed concurrently during a run on a backend without snapshot isolation.",
             { source: row.source_id, target: row.target_id },
           );
         }
@@ -699,13 +703,13 @@ function createOperation(
     currentTimestamp,
   });
   const weightExpression =
-    options.weightProperty === undefined ? undefined : (
-      compileWeightExpression(
+    options.weightProperty === undefined ?
+      undefined
+    : compileWeightExpression(
         ctx.dialect,
         options.weightProperty,
         options.defaultWeight,
-      )
-    );
+      );
   const direction = options.direction ?? "out";
   const branchCount = direction === "both" ? 2 : 1;
   const parameterLimit =
@@ -734,7 +738,8 @@ function createOperation(
     ...edgeKindChunks.map((chunk) => chunk.length),
   );
   const maxWorkingSetSize = Math.floor(
-    (parameterLimit - branchCount * (largestEdgeKindChunk + reservedPerBranch)) /
+    (parameterLimit -
+      branchCount * (largestEdgeKindChunk + reservedPerBranch)) /
       2,
   );
   if (maxWorkingSetSize < 1) {

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -162,28 +162,25 @@ export type InternalShortestPathOptions<G extends GraphDef> =
  * — the algorithm normally converges (and prunes against the best known
  * target distance) long before reaching it.
  */
-export type WeightedShortestPathOptions<G extends GraphDef> =
-  TemporalAlgorithmOptions &
-    IterativeMemoryOptions &
-    Readonly<{
-      /** Edge kinds to follow. At least one kind is required. */
-      edges: readonly EdgeKinds<G>[];
-      /**
-       * Top-level edge property supplying each edge's non-negative numeric
-       * weight.
-       */
-      weightProperty: string;
-      /**
-       * Weight substituted for edges missing `weightProperty`. Must be a
-       * finite non-negative number. Without it, a missing weight throws
-       * `InvalidEdgeWeightError`.
-       */
-      defaultWeight?: number;
-      /** Direction of traversal (default: `"out"`). */
-      direction?: TraversalDirection;
-      /** Maximum relaxation rounds before throwing. Defaults to 1000. */
-      maxIterations?: number;
-    }>;
+export type WeightedShortestPathOptions<G extends GraphDef> = Omit<
+  BaseTraversalOptions<G>,
+  "maxHops" | "cyclePolicy"
+> &
+  Readonly<{
+    /**
+     * Top-level edge property supplying each edge's non-negative numeric
+     * weight.
+     */
+    weightProperty: string;
+    /**
+     * Weight substituted for edges missing `weightProperty`. Must be a
+     * finite non-negative number. Without it, a missing weight throws
+     * `InvalidEdgeWeightError`.
+     */
+    defaultWeight?: number;
+    /** Maximum relaxation rounds before throwing. Defaults to 1000. */
+    maxIterations?: number;
+  }>;
 
 export type InternalWeightedShortestPathOptions<G extends GraphDef> =
   InternalTemporalAlgorithmOptions &

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -153,11 +153,11 @@ export type InternalShortestPathOptions<G extends GraphDef> =
  * fails fast with `InvalidEdgeWeightError` (before any rounds run) when any
  * visible edge of the selected kinds has a negative, non-numeric, or
  * out-of-range weight, or is missing the property with no `defaultWeight`
- * configured. Weight arithmetic uses IEEE 754 doubles on both backends, so
- * total weights are backend-identical; among equal-total-weight paths, the
- * returned node sequence is also backend-identical except when the `edges`
- * list is large enough to exceed the backend's bind-parameter budget
- * (hundreds of kinds in one call).
+ * configured. Weight arithmetic uses IEEE 754 doubles on both backends:
+ * total weights are always backend-identical, and — unless the `edges` list
+ * is large enough to exceed the backend's bind-parameter budget (hundreds
+ * of kinds in one call, where equal-weight predecessor ties may resolve
+ * differently) — so is the returned node sequence.
  *
  * Unlike `shortestPath`, there is no `maxHops`: cost-ordered discovery does
  * not settle nodes in hop order, so a hop bound is not a natural stopping
@@ -177,7 +177,9 @@ export type WeightedShortestPathOptions<G extends GraphDef> = Omit<
     weightProperty: string;
     /**
      * Weight substituted for edges missing `weightProperty`. Must be a
-     * finite non-negative number. Without it, a missing weight throws
+     * non-negative number within the same upper bound the audit applies to
+     * stored weights (~9.7e289, so accumulated path sums can never
+     * overflow). Without it, a missing weight throws
      * `InvalidEdgeWeightError`.
      */
     defaultWeight?: number;

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -151,10 +151,13 @@ export type InternalShortestPathOptions<G extends GraphDef> =
  * Each traversed edge contributes the value of `weightProperty` — a JSON
  * number stored on the edge — to the path's total weight. The traversal
  * fails fast with `InvalidEdgeWeightError` (before any rounds run) when any
- * visible edge of the selected kinds has a negative or non-numeric weight,
- * or is missing the property with no `defaultWeight` configured. Weight
- * arithmetic uses IEEE 754 doubles on both backends, so results are
- * backend-identical.
+ * visible edge of the selected kinds has a negative, non-numeric, or
+ * out-of-range weight, or is missing the property with no `defaultWeight`
+ * configured. Weight arithmetic uses IEEE 754 doubles on both backends, so
+ * total weights are backend-identical; among equal-total-weight paths, the
+ * returned node sequence is also backend-identical except when the `edges`
+ * list is large enough to exceed the backend's bind-parameter budget
+ * (hundreds of kinds in one call).
  *
  * Unlike `shortestPath`, there is no `maxHops`: cost-ordered discovery does
  * not settle nodes in hop order, so a hop bound is not a natural stopping

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -146,6 +146,63 @@ export type InternalShortestPathOptions<G extends GraphDef> =
   InternalBaseTraversalOptions<G>;
 
 /**
+ * Options for `weightedShortestPath`.
+ *
+ * Each traversed edge contributes the value of `weightProperty` — a JSON
+ * number stored on the edge — to the path's total weight. The traversal
+ * fails fast with `InvalidEdgeWeightError` (before any rounds run) when any
+ * visible edge of the selected kinds has a negative or non-numeric weight,
+ * or is missing the property with no `defaultWeight` configured. Weight
+ * arithmetic uses IEEE 754 doubles on both backends, so results are
+ * backend-identical.
+ *
+ * Unlike `shortestPath`, there is no `maxHops`: cost-ordered discovery does
+ * not settle nodes in hop order, so a hop bound is not a natural stopping
+ * rule. `maxIterations` caps relaxation rounds purely as a runaway backstop
+ * — the algorithm normally converges (and prunes against the best known
+ * target distance) long before reaching it.
+ */
+export type WeightedShortestPathOptions<G extends GraphDef> =
+  TemporalAlgorithmOptions &
+    IterativeMemoryOptions &
+    Readonly<{
+      /** Edge kinds to follow. At least one kind is required. */
+      edges: readonly EdgeKinds<G>[];
+      /**
+       * Top-level edge property supplying each edge's non-negative numeric
+       * weight.
+       */
+      weightProperty: string;
+      /**
+       * Weight substituted for edges missing `weightProperty`. Must be a
+       * finite non-negative number. Without it, a missing weight throws
+       * `InvalidEdgeWeightError`.
+       */
+      defaultWeight?: number;
+      /** Direction of traversal (default: `"out"`). */
+      direction?: TraversalDirection;
+      /** Maximum relaxation rounds before throwing. Defaults to 1000. */
+      maxIterations?: number;
+    }>;
+
+export type InternalWeightedShortestPathOptions<G extends GraphDef> =
+  InternalTemporalAlgorithmOptions &
+    Omit<WeightedShortestPathOptions<G>, keyof TemporalAlgorithmOptions>;
+
+/**
+ * Result of `weightedShortestPath`: the minimum-total-weight node sequence
+ * from source to target.
+ */
+export type WeightedShortestPathResult = Readonly<{
+  /** Ordered nodes from source to target (inclusive). */
+  nodes: readonly PathNode[];
+  /** Number of edges traversed. Equals `nodes.length - 1`. */
+  depth: number;
+  /** Sum of the traversed edges' weights. 0 for a self-path. */
+  totalWeight: number;
+}>;
+
+/**
  * Options for `reachable`.
  *
  * Returns every node reachable from the source within `maxHops`, each

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -1,10 +1,7 @@
 import { type SQL, sql } from "drizzle-orm";
 
 import type { GraphDef } from "../../core/define-graph";
-import {
-  ConfigurationError,
-  UnsupportedBackendCapabilityError,
-} from "../../errors";
+import { UnsupportedBackendCapabilityError } from "../../errors";
 import { compileKindFilter } from "../../query/compiler/predicate-utils";
 import { asCompiledRowsSql } from "../../query/sql-intent";
 import { compareCodePoints } from "../../utils/compare";
@@ -12,6 +9,7 @@ import {
   type AlgorithmContext,
   assertEdgeKinds,
   type InternalTraversalOptions,
+  resolveMaxIterations,
 } from "./context";
 import {
   compileWorkingTableEdgeExpansion,
@@ -46,7 +44,11 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
 ): Promise<readonly WeaklyConnectedComponentMembership[]> {
   assertEdgeKinds(options.edges);
   assertWeaklyConnectedComponentsSupported(ctx);
-  const maxIterations = resolveMaxIterations(options.maxIterations);
+  const maxIterations = resolveMaxIterations(
+    options.maxIterations,
+    DEFAULT_WCC_MAX_ITERATIONS,
+    "weaklyConnectedComponents",
+  );
   const nodeKinds =
     options.nodeKinds === undefined ?
       undefined
@@ -99,17 +101,6 @@ function assertWeaklyConnectedComponentsSupported(ctx: AlgorithmContext): void {
     },
     "Use a built-in transactional SQLite/PostgreSQL backend, or declare graphAnalytics support on a compatible custom backend.",
   );
-}
-
-function resolveMaxIterations(value: number | undefined): number {
-  const maxIterations = value ?? DEFAULT_WCC_MAX_ITERATIONS;
-  if (!Number.isSafeInteger(maxIterations) || maxIterations < 1) {
-    throw new ConfigurationError(
-      `weaklyConnectedComponents maxIterations must be a positive safe integer, got ${String(maxIterations)}.`,
-      { maxIterations },
-    );
-  }
-  return maxIterations;
 }
 
 function createWorkingTable(context: IterativeGraphRunContext): SQL {

--- a/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
@@ -21,6 +21,7 @@ import {
   type NodeExpansion,
   type NodeIdentityKey,
   nodeIdentityKey,
+  nodeIdentityKeyFromRow,
   reduceExpandedWorkingSet,
   runIterativeGraphOperation,
   supportsTemporaryIteration,
@@ -43,10 +44,21 @@ type WeightedTraversalOptions = InternalTraversalOptions &
 type WeightedState = Readonly<{
   frontierCount: number;
   workingTableSize: number;
+  /**
+   * Cheapest known distance to any node with the target id, tracked in JS
+   * from each round's RETURNING rows so the next round can prune with a
+   * plain bound parameter instead of per-candidate subqueries.
+   */
+  bestTargetDistance: number | undefined;
 }>;
 
 type SeededRow = Readonly<{ node_id: string }>;
-type ImprovedRow = Readonly<{ node_id: string }>;
+type ImprovedRow = Readonly<{ node_id: string; distance: number | string }>;
+
+type FrontierRound = Readonly<{
+  frontierCount: number;
+  bestTargetDistance: number | undefined;
+}>;
 
 type DistanceRow = Readonly<{
   node_id: string;
@@ -109,26 +121,16 @@ export async function executeWeightedShortestPath<G extends GraphDef>(
     DEFAULT_WEIGHTED_SHORTEST_PATH_MAX_ITERATIONS,
     WEIGHTED_ALGORITHM_NAME,
   );
-  const traversalOptions: WeightedTraversalOptions = {
-    edges: options.edges,
-    weightProperty: options.weightProperty,
-    ...(options.defaultWeight === undefined ?
-      {}
-    : { defaultWeight: options.defaultWeight }),
-    ...(options.direction === undefined ?
-      {}
-    : { direction: options.direction }),
-    ...(options.temporalMode === undefined ?
-      {}
-    : { temporalMode: options.temporalMode }),
-    ...(options.asOf === undefined ? {} : { asOf: options.asOf }),
-    ...(options.recordedAsOf === undefined ?
-      {}
-    : { recordedAsOf: options.recordedAsOf }),
-    ...(options.workingMemory === undefined ?
-      {}
-    : { workingMemory: options.workingMemory }),
-  };
+  // Structurally assignable — the internal options are the traversal options
+  // plus the algorithm-only `maxIterations`, which the substrate ignores.
+  const traversalOptions: WeightedTraversalOptions = options;
+
+  // Non-negative weights make distance 0 unbeatable, so a self path needs
+  // no relaxation rounds — only the weight audit (for deterministic data
+  // errors) and a visibility check on the node itself.
+  if (sourceId === targetId) {
+    return findWeightedSelfPath(ctx, sourceId, traversalOptions);
+  }
 
   if (supportsTemporaryIteration(ctx)) {
     return findWeightedShortestPathInWorkingTable(
@@ -189,31 +191,42 @@ async function assertValidEdgeWeights(
   const { dialect } = operation.ctx;
   const pointer = jsonPointer([weightProperty]);
   const propsColumn = sql.raw("e.props");
+  // The inner projection extracts the JSON path once per edge; the outer
+  // violation predicate then works over plain projected columns. Composing
+  // the checks directly over `e.props` would re-parse the JSON payload for
+  // every predicate branch on the audit's full edge scan.
   const isNumber = dialect.jsonPathIsNumber(propsColumn, pointer);
   const isMissing = dialect.jsonPathIsNull(propsColumn, pointer);
   const weightText = dialect.jsonExtractText(propsColumn, pointer);
-  // CASE keeps the cast unreachable for non-numeric values: PostgreSQL does
-  // not short-circuit AND, and casting arbitrary text would error before the
-  // audit could produce its typed report.
-  const isNegative = sql`CASE WHEN ${isNumber} THEN CAST(${weightText} AS DOUBLE PRECISION) < 0 ELSE ${dialect.booleanLiteral(false)} END`;
   const missingViolation =
-    defaultWeight === undefined ? isMissing : dialect.booleanLiteral(false);
-  const invalid = sql`(${missingViolation}) OR ((NOT ${isMissing}) AND (NOT ${isNumber})) OR (${isNegative})`;
+    defaultWeight === undefined ?
+      sql`audited.is_missing = 1`
+    : dialect.booleanLiteral(false);
+  // CASE keeps the cast unreachable for non-numeric values: PostgreSQL does
+  // not short-circuit OR/AND, and casting arbitrary text would error before
+  // the audit could produce its typed report.
+  const negativeViolation = sql`CASE WHEN audited.is_number = 1 THEN CAST(audited.weight_text AS DOUBLE PRECISION) < 0 ELSE ${dialect.booleanLiteral(false)} END`;
 
   for (const edgeKinds of operation.edgeKindChunks) {
     const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
     const rows = await operation.backend.execute<WeightAuditRow>(
       asCompiledRowsSql(sql`
-        SELECT e.id AS edge_id, e.kind AS edge_kind,
-          ${weightText} AS weight_text,
-          CASE WHEN ${isNumber} THEN 1 ELSE 0 END AS is_number,
-          CASE WHEN ${isMissing} THEN 1 ELSE 0 END AS is_missing
-        FROM ${operation.schema.edgesTable} e
-        WHERE e.graph_id = ${operation.ctx.graphId}
-          AND ${edgeKindFilter}
-          AND ${operation.edgeTemporalFilter}
-          AND (${invalid})
-        ORDER BY ${dialect.binaryText(sql`e.id`)}
+        SELECT audited.edge_id, audited.edge_kind, audited.weight_text,
+          audited.is_number, audited.is_missing
+        FROM (
+          SELECT e.id AS edge_id, e.kind AS edge_kind,
+            ${weightText} AS weight_text,
+            CASE WHEN ${isNumber} THEN 1 ELSE 0 END AS is_number,
+            CASE WHEN ${isMissing} THEN 1 ELSE 0 END AS is_missing
+          FROM ${operation.schema.edgesTable} e
+          WHERE e.graph_id = ${operation.ctx.graphId}
+            AND ${edgeKindFilter}
+            AND ${operation.edgeTemporalFilter}
+        ) audited
+        WHERE (${missingViolation})
+          OR (audited.is_missing = 0 AND audited.is_number = 0)
+          OR (${negativeViolation})
+        ORDER BY ${dialect.binaryText(sql`audited.edge_id`)}
         LIMIT 1
       `),
     );
@@ -261,7 +274,10 @@ async function findWeightedShortestPathInWorkingTable(
   maxIterations: number,
   options: WeightedTraversalOptions,
 ): Promise<WeightedShortestPathResult | undefined> {
-  return runIterativeGraphOperation(ctx, options, {
+  return runIterativeGraphOperation<
+    WeightedState,
+    WeightedShortestPathResult | undefined
+  >(ctx, options, {
     algorithm: WEIGHTED_ALGORITHM_NAME,
     maxIterations,
     createWorkingTable,
@@ -275,17 +291,22 @@ async function findWeightedShortestPathInWorkingTable(
       return {
         frontierCount: seeded.length,
         workingTableSize: seeded.length,
+        // Seeds carry the source id, never the target's — the self-path
+        // case is short-circuited before this plan runs.
+        bestTargetDistance: undefined,
       };
     },
     async runRound(context, state, iteration) {
-      const frontierCount = await relaxFrontierRound(
+      const round = await relaxFrontierRound(
         context,
         targetId,
         iteration,
+        state.bestTargetDistance,
       );
       return {
-        frontierCount,
-        workingTableSize: state.workingTableSize + frontierCount,
+        frontierCount: round.frontierCount,
+        workingTableSize: state.workingTableSize + round.frontierCount,
+        bestTargetDistance: round.bestTargetDistance,
       };
     },
     hasConverged(state: WeightedState) {
@@ -342,18 +363,25 @@ async function seedDistances(
  * Relaxes one round: expands the previous round's frontier through visible
  * edges, keeps the cheapest candidate per target identity (ties broken by
  * source id then kind in binary collation, so both backends pick the same
- * predecessor), and upserts only strict distance improvements. Candidates
- * that already cost at least as much as a known path to the target are
- * pruned — sound because the audit guarantees non-negative weights.
+ * predecessor), and upserts only strict distance improvements.
+ *
+ * Candidates costing at least `roundBound` — the cheapest path to the
+ * target known at round start, tracked in JS from RETURNING rows — are
+ * pruned. Sound because the audit guarantees non-negative weights: no
+ * extension of such a candidate can beat the known path. A bound parameter
+ * keeps the pruning O(1) per candidate and applies the same round-start
+ * state on both execution paths, so they run identical round sequences.
  */
 async function relaxFrontierRound(
   context: IterativeGraphRunContext,
   targetId: string,
   iteration: number,
-): Promise<number> {
+  roundBound: number | undefined,
+): Promise<FrontierRound> {
   const { operation, workingTable, graphId, runId } = context;
   const { dialect } = operation.ctx;
   let frontierCount = 0;
+  let bestTargetDistance = roundBound;
   for (const edgeKinds of operation.edgeKindChunks) {
     const sourceFilter = sql`
       w.graph_id = ${graphId}
@@ -397,14 +425,7 @@ async function relaxFrontierRound(
               AND frontier.node_id = expanded.source_id
               AND frontier.node_kind = expanded.source_kind
           ) candidates
-          WHERE NOT EXISTS (
-            SELECT 1
-            FROM ${workingTable} settled_target
-            WHERE settled_target.graph_id = ${graphId}
-              AND settled_target.run_id = ${runId}
-              AND settled_target.node_id = ${targetId}
-              AND settled_target.distance <= candidates.candidate_distance
-          )
+          WHERE ${roundBound === undefined ? sql`TRUE` : sql`candidates.candidate_distance < ${roundBound}`}
         ) ranked
         WHERE ranked.candidate_rank = 1
         ON CONFLICT (graph_id, run_id, node_kind, node_id) DO UPDATE SET
@@ -414,12 +435,19 @@ async function relaxFrontierRound(
           predecessor_kind = excluded.predecessor_kind,
           improved_round = excluded.improved_round
         WHERE excluded.distance < ${workingTable}.distance
-        RETURNING node_id
+        RETURNING node_id, distance
       `),
     );
     frontierCount += rows.length;
+    for (const row of rows) {
+      if (row.node_id !== targetId) continue;
+      const distance = Number(row.distance);
+      if (bestTargetDistance === undefined || distance < bestTargetDistance) {
+        bestTargetDistance = distance;
+      }
+    }
   }
-  return frontierCount;
+  return { frontierCount, bestTargetDistance };
 }
 
 async function readVisitedFromWorkingTable(
@@ -436,26 +464,42 @@ async function readVisitedFromWorkingTable(
   );
   return new Map(
     rows.map((row) => {
-      const parentKey =
-        (
-          typeof row.predecessor_id !== "string" ||
-          typeof row.predecessor_kind !== "string"
-        ) ?
-          undefined
-        : nodeIdentityKey({
-            id: row.predecessor_id,
-            kind: row.predecessor_kind,
-          });
       const node = {
         id: row.node_id,
         kind: row.node_kind,
         distance: Number(row.distance),
         hops: Number(row.hops),
-        parentKey,
+        parentKey: nodeIdentityKeyFromRow(
+          row.predecessor_id,
+          row.predecessor_kind,
+        ),
       } satisfies WeightedVisitedNode;
       return [nodeIdentityKey(node), node];
     }),
   );
+}
+
+/**
+ * Zero-weight self path: audits the weight domain (so data errors surface
+ * identically to a full traversal) and checks the node's visibility, with
+ * no relaxation rounds. Multiple kinds sharing the id resolve to the
+ * smallest node identity, matching the traversal tie-break.
+ */
+async function findWeightedSelfPath(
+  ctx: AlgorithmContext,
+  nodeId: string,
+  options: WeightedTraversalOptions,
+): Promise<WeightedShortestPathResult | undefined> {
+  return withInlineIterativeGraphOperation(ctx, options, async (operation) => {
+    await assertValidEdgeWeights(
+      operation,
+      options.weightProperty,
+      options.defaultWeight,
+    );
+    const node = (await fetchVisibleWorkingNodes(operation, [nodeId]))[0];
+    if (node === undefined) return undefined;
+    return { nodes: [node], depth: 0, totalWeight: 0 };
+  });
 }
 
 // ============================================================
@@ -490,7 +534,7 @@ async function findWeightedShortestPathInline(
         },
       ]),
     );
-    let bestTargetDistance = sourceId === targetId ? 0 : undefined;
+    let bestTargetDistance: number | undefined;
     let frontier: readonly PathNode[] = sources;
     let rounds = 0;
 
@@ -561,8 +605,8 @@ function reduceWeightedCandidate(
   expansion: NodeExpansion,
   settled: ReadonlyMap<NodeIdentityKey, WeightedVisitedNode>,
 ): WeightedCandidate | undefined {
-  // Weighted operations always compile a weight column; the guard narrows
-  // the optional field.
+  // Unreachable on a weighted run — the substrate rejects NULL weights with
+  // an invariant error — but the field is optional, so narrow it.
   const weight = expansion.weight;
   if (weight === undefined) return existing;
   const sourceEntry = settled.get(nodeIdentityKey(expansion.source));

--- a/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
@@ -21,7 +21,6 @@ import {
   type NodeExpansion,
   type NodeIdentityKey,
   nodeIdentityKey,
-  nodeIdentityKeyFromRow,
   reduceExpandedWorkingSet,
   runIterativeGraphOperation,
   supportsTemporaryIteration,
@@ -36,6 +35,27 @@ import type {
 const DEFAULT_WEIGHTED_SHORTEST_PATH_MAX_ITERATIONS = 1000;
 
 const WEIGHTED_ALGORITHM_NAME = "weightedShortestPath";
+
+/**
+ * Largest accepted edge weight (~9.7e289). Auditing weights to this bound
+ * makes accumulated overflow impossible rather than merely unlikely: a path
+ * gains one working-table row per hop, so it has at most 2^53 hops, and
+ * 2^53 · MAX_EDGE_WEIGHT stays far below Number.MAX_VALUE even after
+ * float-addition rounding (the 2^64 divisor leaves an ~2000x margin).
+ * Without the bound, PostgreSQL's float8 addition would raise a raw 22003
+ * overflow mid-round while SQLite silently saturated to Infinity.
+ */
+const MAX_EDGE_WEIGHT = Number.MAX_VALUE / 2 ** 64;
+
+/**
+ * Smallest accepted nonzero weight magnitude: the smallest IEEE 754 double
+ * (5e-324). PostgreSQL stores smaller nonzero JSON numbers exactly in jsonb
+ * and raises a raw underflow when the traversal casts them to float8, so
+ * the audit rejects them with the typed error instead. SQLite's JSON parser
+ * has already rounded such text to 0 before any SQL can observe it — an
+ * engine-level difference the audit cannot detect there.
+ */
+const MIN_EDGE_WEIGHT = Number.MIN_VALUE;
 
 /** Traversal options with the weight source guaranteed present. */
 type WeightedTraversalOptions = InternalTraversalOptions &
@@ -60,13 +80,11 @@ type FrontierRound = Readonly<{
   bestTargetDistance: number | undefined;
 }>;
 
-type DistanceRow = Readonly<{
+type ChainRow = Readonly<{
   node_id: string;
   node_kind: string;
   distance: number | string;
   hops: number | string;
-  predecessor_id: unknown;
-  predecessor_kind: unknown;
 }>;
 
 type WeightAuditRow = Readonly<{
@@ -214,10 +232,13 @@ async function assertValidEdgeWeights(
       sql`audited.is_missing = 1`
     : dialect.booleanLiteral(false);
   const negativeViolation = sql`audited.is_number = 1 AND audited.weight_number < 0`;
-  // CAST the bound to NUMERIC so PostgreSQL compares in the arbitrary-
+  // CAST the bounds to NUMERIC so PostgreSQL compares in the arbitrary-
   // precision domain — a numeric-vs-float8 comparison would coerce the
-  // out-of-range value to float8 and overflow before comparing.
-  const outOfRangeViolation = sql`audited.is_number = 1 AND ABS(audited.weight_number) > CAST(${Number.MAX_VALUE} AS NUMERIC)`;
+  // out-of-range value to float8 and overflow before comparing. The lower
+  // arm rejects sub-denormal magnitudes (float8 cast underflow on
+  // PostgreSQL); on SQLite they parsed to exactly 0 and the arm cannot
+  // fire, which is the declared engine caveat on MIN_EDGE_WEIGHT.
+  const outOfRangeViolation = sql`audited.is_number = 1 AND (ABS(audited.weight_number) > CAST(${MAX_EDGE_WEIGHT} AS NUMERIC) OR (audited.weight_number <> 0 AND ABS(audited.weight_number) < CAST(${MIN_EDGE_WEIGHT} AS NUMERIC)))`;
 
   for (const edgeKinds of operation.edgeKindChunks) {
     const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
@@ -274,10 +295,10 @@ function resolveInvalidWeightReason(
 ): InvalidEdgeWeightReason {
   if (flagIsSet(row.is_missing)) return "missing";
   if (!flagIsSet(row.is_number)) return "non_numeric";
-  // A numeric violation is either negative or beyond the double range;
-  // Number() maps an out-of-range magnitude to ±Infinity, which is exactly
-  // the distinction needed here.
-  return Number(row.weight_text) < 0 ? "negative" : "not_finite";
+  // A numeric violation is either negative or outside the accepted
+  // magnitude range; the sign distinguishes them (Number() of an oversized
+  // magnitude yields ±Infinity, whose sign still holds).
+  return Number(row.weight_text) < 0 ? "negative" : "out_of_range";
 }
 
 /** Coerces a driver-shaped 0/1 flag (number, bigint, or boolean) to boolean. */
@@ -339,6 +360,22 @@ async function findWeightedShortestPathInWorkingTable(
         options.weightProperty,
         options.defaultWeight,
       );
+      // A target no visible node carries can never be reached; converge
+      // immediately instead of relaxing the source's entire component.
+      if (!(await hasVisibleNode(context.operation, targetId))) {
+        return {
+          frontierCount: 0,
+          workingTableSize: 0,
+          bestTargetDistance: undefined,
+        };
+      }
+      // Each round scans only the previous round's frontier; without this
+      // index that filter re-scans the whole (growing) working table, since
+      // the identity primary key cannot serve an improved_round lookup.
+      await context.executeTemporary(sql`
+        CREATE INDEX ${frontierIndexIdentifier(context)}
+        ON ${context.workingTable} (graph_id, run_id, improved_round)
+      `);
       const seeded = await seedDistances(context, sourceId);
       return {
         frontierCount: seeded.length,
@@ -368,10 +405,34 @@ async function findWeightedShortestPathInWorkingTable(
       return state.frontierCount === 0;
     },
     async extractResult(context) {
-      const visited = await readVisitedFromWorkingTable(context);
-      return buildWeightedPathResult(visited, targetId);
+      return extractPathFromWorkingTable(context, targetId, maxIterations);
     },
   });
+}
+
+function frontierIndexIdentifier(context: IterativeGraphRunContext) {
+  return sql.identifier(
+    `typegraph_iterative_${context.runId.replaceAll("-", "_")}_frontier`,
+  );
+}
+
+/**
+ * Point lookup: does any visible node carry this id (under any kind)?
+ */
+async function hasVisibleNode(
+  operation: IterativeGraphOperation,
+  nodeId: string,
+): Promise<boolean> {
+  const rows = await operation.backend.execute<Readonly<{ id: string }>>(
+    asCompiledRowsSql(sql`
+      SELECT n.id FROM ${operation.schema.nodesTable} n
+      WHERE n.graph_id = ${operation.ctx.graphId}
+        AND n.id = ${nodeId}
+        AND ${operation.nodeTemporalFilter}
+      LIMIT 1
+    `),
+  );
+  return rows.length > 0;
 }
 
 function createWorkingTable(context: IterativeGraphRunContext): SQL {
@@ -420,12 +481,16 @@ async function seedDistances(
  * source id then kind in binary collation, so both backends pick the same
  * predecessor), and upserts only strict distance improvements.
  *
- * Candidates costing at least `roundBound` — the cheapest path to the
- * target known at round start, tracked in JS from RETURNING rows — are
+ * Candidates costing strictly more than `roundBound` — the cheapest path to
+ * the target known at round start, tracked in JS from RETURNING rows — are
  * pruned. Sound because the audit guarantees non-negative weights: no
- * extension of such a candidate can beat the known path. A bound parameter
- * keeps the pruning O(1) per candidate and applies the same round-start
- * state on both execution paths, so they run identical round sequences.
+ * extension of such a candidate can beat the known path. Equal-cost
+ * candidates stay admitted, because zero-weight edges can extend an
+ * equal-cost node to another node with the target id, and the documented
+ * smallest-identity target tie-break must see that node; strict-improvement
+ * upserts keep the equal-cost plateau finite. A bound parameter keeps the
+ * pruning O(1) per candidate and applies the same round-start state on both
+ * execution paths, so they run identical round sequences.
  */
 async function relaxFrontierRound(
   context: IterativeGraphRunContext,
@@ -481,13 +546,9 @@ async function relaxFrontierRound(
               AND frontier.node_kind = expanded.source_kind
           ) candidates
           WHERE ${
-            // Equal-distance candidates for the target id itself stay
-            // admitted: when the id exists under several kinds, the
-            // documented smallest-identity tie-break must see an equal-cost
-            // target found in a later round, not have it pruned away.
             roundBound === undefined ?
               sql`TRUE`
-            : sql`(candidates.candidate_distance < ${roundBound} OR (candidates.target_id = ${targetId} AND candidates.candidate_distance <= ${roundBound}))`
+            : sql`candidates.candidate_distance <= ${roundBound}`
           }
         ) ranked
         WHERE ranked.candidate_rank = 1
@@ -513,33 +574,61 @@ async function relaxFrontierRound(
   return { frontierCount, bestTargetDistance };
 }
 
-async function readVisitedFromWorkingTable(
+/**
+ * Extracts the result path directly in SQL: pick the cheapest row carrying
+ * the target id (ties by kind in binary collation, matching the inline
+ * path's code-point tie-break since the id is fixed), then walk predecessor
+ * pointers through a recursive CTE. Transfer and JS memory stay
+ * proportional to the path length instead of the visited set. The
+ * `position` guard bounds recursion at the round budget — predecessor
+ * chains cannot cycle, but a recursive CTE should never rely on that alone.
+ */
+async function extractPathFromWorkingTable(
   context: IterativeGraphRunContext,
-): Promise<ReadonlyMap<NodeIdentityKey, WeightedVisitedNode>> {
-  const rows = await context.backend.execute<DistanceRow>(
+  targetId: string,
+  maxIterations: number,
+): Promise<WeightedShortestPathResult | undefined> {
+  const { operation, workingTable, graphId, runId } = context;
+  const { dialect } = operation.ctx;
+  const rows = await context.backend.execute<ChainRow>(
     asCompiledRowsSql(sql`
-      SELECT node_id, node_kind, distance, hops,
-        predecessor_id, predecessor_kind
-      FROM ${context.workingTable}
-      WHERE graph_id = ${context.graphId}
-        AND run_id = ${context.runId}
+      WITH RECURSIVE chain AS (
+        SELECT best.node_id, best.node_kind, best.distance, best.hops,
+          best.predecessor_id, best.predecessor_kind, 0 AS position
+        FROM (
+          SELECT node_id, node_kind, distance, hops,
+            predecessor_id, predecessor_kind
+          FROM ${workingTable}
+          WHERE graph_id = ${graphId}
+            AND run_id = ${runId}
+            AND node_id = ${targetId}
+          ORDER BY distance ASC, ${dialect.binaryText(sql`node_kind`)}
+          LIMIT 1
+        ) best
+        UNION ALL
+        SELECT w.node_id, w.node_kind, w.distance, w.hops,
+          w.predecessor_id, w.predecessor_kind, c.position + 1
+        FROM chain c
+        JOIN ${workingTable} w
+          ON w.graph_id = ${graphId}
+          AND w.run_id = ${runId}
+          AND w.node_id = c.predecessor_id
+          AND w.node_kind = c.predecessor_kind
+        WHERE c.position <= ${maxIterations}
+      )
+      SELECT node_id, node_kind, distance, hops
+      FROM chain
+      ORDER BY position DESC
     `),
   );
-  return new Map(
-    rows.map((row) => {
-      const node = {
-        id: row.node_id,
-        kind: row.node_kind,
-        distance: Number(row.distance),
-        hops: Number(row.hops),
-        parentKey: nodeIdentityKeyFromRow(
-          row.predecessor_id,
-          row.predecessor_kind,
-        ),
-      } satisfies WeightedVisitedNode;
-      return [nodeIdentityKey(node), node];
-    }),
-  );
+  // position DESC orders source-first, target-last.
+  const target = rows.at(-1);
+  if (target === undefined) return undefined;
+  return {
+    nodes: rows.map((row) => ({ id: row.node_id, kind: row.node_kind })),
+    depth: Number(target.hops),
+    totalWeight: Number(target.distance),
+  };
 }
 
 /**
@@ -585,8 +674,19 @@ async function findWeightedShortestPathInline(
       options.weightProperty,
       options.defaultWeight,
     );
-    const sources = await fetchVisibleWorkingNodes(operation, [sourceId]);
-    if (sources.length === 0) return;
+    const endpoints = await fetchVisibleWorkingNodes(operation, [
+      sourceId,
+      targetId,
+    ]);
+    const sources = endpoints.filter((node) => node.id === sourceId);
+    // A target no visible node carries can never be reached; skip relaxing
+    // the source's entire component.
+    if (
+      sources.length === 0 ||
+      !endpoints.some((node) => node.id === targetId)
+    ) {
+      return;
+    }
 
     const settled = new Map<NodeIdentityKey, WeightedVisitedNode>(
       sources.map((source) => [
@@ -631,14 +731,11 @@ async function findWeightedShortestPathInline(
         if (existing !== undefined && existing.distance <= candidate.distance) {
           continue;
         }
-        // Mirrors the working-table prune: equal-distance candidates are
-        // dropped unless they carry the target id, so a smaller-identity
-        // target kind found later still reaches the result tie-break.
-        if (
-          roundBound !== undefined &&
-          (candidate.distance > roundBound ||
-            (candidate.distance === roundBound && candidate.id !== targetId))
-        ) {
+        // Mirrors the working-table prune: only strictly-worse candidates
+        // are dropped. Equal-cost ones stay admitted so zero-weight edges
+        // from the equal-cost plateau can still reach a smaller-identity
+        // node carrying the target id.
+        if (roundBound !== undefined && candidate.distance > roundBound) {
           continue;
         }
         settled.set(candidateKey, {

--- a/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
@@ -1,0 +1,632 @@
+import { type SQL, sql } from "drizzle-orm";
+
+import type { GraphDef } from "../../core/define-graph";
+import {
+  ConfigurationError,
+  GraphAlgorithmConvergenceError,
+  InvalidEdgeWeightError,
+  type InvalidEdgeWeightReason,
+} from "../../errors";
+import { compileKindFilter } from "../../query/compiler/predicate-utils";
+import { jsonPointer } from "../../query/json-pointer";
+import { asCompiledRowsSql } from "../../query/sql-intent";
+import type { AlgorithmContext, InternalTraversalOptions } from "./context";
+import { assertEdgeKinds, resolveMaxIterations } from "./context";
+import {
+  compareNodeIdentity,
+  compileWorkingTableExpansion,
+  fetchVisibleWorkingNodes,
+  type IterativeGraphOperation,
+  type IterativeGraphRunContext,
+  type NodeExpansion,
+  type NodeIdentityKey,
+  nodeIdentityKey,
+  reduceExpandedWorkingSet,
+  runIterativeGraphOperation,
+  supportsTemporaryIteration,
+  withInlineIterativeGraphOperation,
+} from "./iterative-graph-operation";
+import type {
+  InternalWeightedShortestPathOptions,
+  PathNode,
+  WeightedShortestPathResult,
+} from "./types";
+
+const DEFAULT_WEIGHTED_SHORTEST_PATH_MAX_ITERATIONS = 1000;
+
+const WEIGHTED_ALGORITHM_NAME = "weightedShortestPath";
+
+/** Traversal options with the weight source guaranteed present. */
+type WeightedTraversalOptions = InternalTraversalOptions &
+  Readonly<{ weightProperty: string }>;
+
+type WeightedState = Readonly<{
+  frontierCount: number;
+  workingTableSize: number;
+}>;
+
+type SeededRow = Readonly<{ node_id: string }>;
+type ImprovedRow = Readonly<{ node_id: string }>;
+
+type DistanceRow = Readonly<{
+  node_id: string;
+  node_kind: string;
+  distance: number | string;
+  hops: number | string;
+  predecessor_id: unknown;
+  predecessor_kind: unknown;
+}>;
+
+type WeightAuditRow = Readonly<{
+  edge_id: string;
+  edge_kind: string;
+  weight_text: unknown;
+  is_number: unknown;
+  is_missing: unknown;
+}>;
+
+/**
+ * A node settled by weighted relaxation: its best known distance from the
+ * source, the hop count of the path achieving it, and the predecessor along
+ * that path.
+ */
+type WeightedVisitedNode = Readonly<{
+  id: string;
+  kind: string;
+  distance: number;
+  hops: number;
+  parentKey: NodeIdentityKey | undefined;
+}>;
+
+type WeightedCandidate = Readonly<{
+  id: string;
+  kind: string;
+  distance: number;
+  hops: number;
+  parentId: string;
+  parentKind: string;
+}>;
+
+/**
+ * Finds the minimum-total-weight path from `sourceId` to `targetId` by
+ * frontier-based label-correcting relaxation: each round relaxes the edges
+ * out of the nodes improved in the previous round, keeping one best
+ * `(distance, predecessor)` per node identity, until no distance improves.
+ * Weights must be non-negative, which makes pruning against the best known
+ * target distance safe: once a candidate costs at least as much as a path
+ * already reaching the target, no extension of it can win.
+ */
+export async function executeWeightedShortestPath<G extends GraphDef>(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  options: InternalWeightedShortestPathOptions<G>,
+): Promise<WeightedShortestPathResult | undefined> {
+  assertEdgeKinds(options.edges);
+  assertWeightOptions(options.weightProperty, options.defaultWeight);
+  const maxIterations = resolveMaxIterations(
+    options.maxIterations,
+    DEFAULT_WEIGHTED_SHORTEST_PATH_MAX_ITERATIONS,
+    WEIGHTED_ALGORITHM_NAME,
+  );
+  const traversalOptions: WeightedTraversalOptions = {
+    edges: options.edges,
+    weightProperty: options.weightProperty,
+    ...(options.defaultWeight === undefined ?
+      {}
+    : { defaultWeight: options.defaultWeight }),
+    ...(options.direction === undefined ?
+      {}
+    : { direction: options.direction }),
+    ...(options.temporalMode === undefined ?
+      {}
+    : { temporalMode: options.temporalMode }),
+    ...(options.asOf === undefined ? {} : { asOf: options.asOf }),
+    ...(options.recordedAsOf === undefined ?
+      {}
+    : { recordedAsOf: options.recordedAsOf }),
+    ...(options.workingMemory === undefined ?
+      {}
+    : { workingMemory: options.workingMemory }),
+  };
+
+  if (supportsTemporaryIteration(ctx)) {
+    return findWeightedShortestPathInWorkingTable(
+      ctx,
+      sourceId,
+      targetId,
+      maxIterations,
+      traversalOptions,
+    );
+  }
+  return findWeightedShortestPathInline(
+    ctx,
+    sourceId,
+    targetId,
+    maxIterations,
+    traversalOptions,
+  );
+}
+
+function assertWeightOptions(
+  weightProperty: string,
+  defaultWeight: number | undefined,
+): void {
+  if (typeof weightProperty !== "string" || weightProperty.length === 0) {
+    throw new ConfigurationError(
+      `${WEIGHTED_ALGORITHM_NAME} weightProperty must be a non-empty string.`,
+      { weightProperty },
+    );
+  }
+  if (
+    defaultWeight !== undefined &&
+    (!Number.isFinite(defaultWeight) || defaultWeight < 0)
+  ) {
+    throw new ConfigurationError(
+      `${WEIGHTED_ALGORITHM_NAME} defaultWeight must be a finite non-negative number, got ${String(defaultWeight)}.`,
+      { defaultWeight },
+    );
+  }
+}
+
+/**
+ * Fails fast on the first visible edge of the selected kinds whose weight
+ * violates the weighted-traversal contract: a non-numeric value, a negative
+ * number, or a missing value with no configured default. Runs inside the
+ * operation's snapshot before any relaxation round, so a weighted call
+ * either observes a fully valid weight domain or throws — the traversal's
+ * own weight cast never sees a value it could silently mangle.
+ *
+ * The audit deliberately covers every visible edge of the selected kinds,
+ * not just edges the traversal happens to reach: reachability-dependent
+ * validation would make the error nondeterministic in the data.
+ */
+async function assertValidEdgeWeights(
+  operation: IterativeGraphOperation,
+  weightProperty: string,
+  defaultWeight: number | undefined,
+): Promise<void> {
+  const { dialect } = operation.ctx;
+  const pointer = jsonPointer([weightProperty]);
+  const propsColumn = sql.raw("e.props");
+  const isNumber = dialect.jsonPathIsNumber(propsColumn, pointer);
+  const isMissing = dialect.jsonPathIsNull(propsColumn, pointer);
+  const weightText = dialect.jsonExtractText(propsColumn, pointer);
+  // CASE keeps the cast unreachable for non-numeric values: PostgreSQL does
+  // not short-circuit AND, and casting arbitrary text would error before the
+  // audit could produce its typed report.
+  const isNegative = sql`CASE WHEN ${isNumber} THEN CAST(${weightText} AS DOUBLE PRECISION) < 0 ELSE ${dialect.booleanLiteral(false)} END`;
+  const missingViolation =
+    defaultWeight === undefined ? isMissing : dialect.booleanLiteral(false);
+  const invalid = sql`(${missingViolation}) OR ((NOT ${isMissing}) AND (NOT ${isNumber})) OR (${isNegative})`;
+
+  for (const edgeKinds of operation.edgeKindChunks) {
+    const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
+    const rows = await operation.backend.execute<WeightAuditRow>(
+      asCompiledRowsSql(sql`
+        SELECT e.id AS edge_id, e.kind AS edge_kind,
+          ${weightText} AS weight_text,
+          CASE WHEN ${isNumber} THEN 1 ELSE 0 END AS is_number,
+          CASE WHEN ${isMissing} THEN 1 ELSE 0 END AS is_missing
+        FROM ${operation.schema.edgesTable} e
+        WHERE e.graph_id = ${operation.ctx.graphId}
+          AND ${edgeKindFilter}
+          AND ${operation.edgeTemporalFilter}
+          AND (${invalid})
+        ORDER BY ${dialect.binaryText(sql`e.id`)}
+        LIMIT 1
+      `),
+    );
+    const row = rows[0];
+    if (row !== undefined) {
+      throw createInvalidEdgeWeightError(row, weightProperty);
+    }
+  }
+}
+
+function createInvalidEdgeWeightError(
+  row: WeightAuditRow,
+  weightProperty: string,
+): InvalidEdgeWeightError {
+  const reason: InvalidEdgeWeightReason =
+    flagIsSet(row.is_missing) ? "missing"
+    : flagIsSet(row.is_number) ? "negative"
+    : "non_numeric";
+  const value =
+    reason === "missing" || row.weight_text === null ?
+      undefined
+    : String(row.weight_text);
+  return new InvalidEdgeWeightError({
+    edgeId: row.edge_id,
+    edgeKind: row.edge_kind,
+    property: weightProperty,
+    reason,
+    ...(value === undefined ? {} : { value }),
+  });
+}
+
+/** Coerces a driver-shaped 0/1 flag (number, bigint, or boolean) to boolean. */
+function flagIsSet(value: unknown): boolean {
+  return Number(value) !== 0;
+}
+
+// ============================================================
+// Working-table execution
+// ============================================================
+
+async function findWeightedShortestPathInWorkingTable(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  maxIterations: number,
+  options: WeightedTraversalOptions,
+): Promise<WeightedShortestPathResult | undefined> {
+  return runIterativeGraphOperation(ctx, options, {
+    algorithm: WEIGHTED_ALGORITHM_NAME,
+    maxIterations,
+    createWorkingTable,
+    async initialize(context) {
+      await assertValidEdgeWeights(
+        context.operation,
+        options.weightProperty,
+        options.defaultWeight,
+      );
+      const seeded = await seedDistances(context, sourceId);
+      return {
+        frontierCount: seeded.length,
+        workingTableSize: seeded.length,
+      };
+    },
+    async runRound(context, state, iteration) {
+      const frontierCount = await relaxFrontierRound(
+        context,
+        targetId,
+        iteration,
+      );
+      return {
+        frontierCount,
+        workingTableSize: state.workingTableSize + frontierCount,
+      };
+    },
+    hasConverged(state: WeightedState) {
+      return state.frontierCount === 0;
+    },
+    async extractResult(context) {
+      const visited = await readVisitedFromWorkingTable(context);
+      return buildWeightedPathResult(visited, targetId);
+    },
+  });
+}
+
+function createWorkingTable(context: IterativeGraphRunContext): SQL {
+  // DOUBLE PRECISION is accepted by both engines: PostgreSQL's float8, and
+  // REAL affinity on SQLite — the same IEEE 754 double either way.
+  return sql`
+    CREATE TEMP TABLE ${context.workingTable} (
+      graph_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      node_id TEXT NOT NULL,
+      node_kind TEXT NOT NULL,
+      distance DOUBLE PRECISION NOT NULL,
+      hops INTEGER NOT NULL,
+      predecessor_id TEXT,
+      predecessor_kind TEXT,
+      improved_round INTEGER NOT NULL,
+      PRIMARY KEY (graph_id, run_id, node_kind, node_id)
+    )
+  `;
+}
+
+async function seedDistances(
+  context: IterativeGraphRunContext,
+  sourceId: string,
+): Promise<readonly SeededRow[]> {
+  const { operation, workingTable, graphId, runId } = context;
+  return context.backend.execute<SeededRow>(
+    asCompiledRowsSql(sql`
+      INSERT INTO ${workingTable}
+        (graph_id, run_id, node_id, node_kind, distance, hops,
+         predecessor_id, predecessor_kind, improved_round)
+      SELECT ${graphId}, ${runId}, n.id, n.kind, 0, 0, NULL, NULL, 0
+      FROM ${operation.schema.nodesTable} n
+      WHERE n.graph_id = ${graphId}
+        AND n.id = ${sourceId}
+        AND ${operation.nodeTemporalFilter}
+      ON CONFLICT (graph_id, run_id, node_kind, node_id) DO NOTHING
+      RETURNING node_id
+    `),
+  );
+}
+
+/**
+ * Relaxes one round: expands the previous round's frontier through visible
+ * edges, keeps the cheapest candidate per target identity (ties broken by
+ * source id then kind in binary collation, so both backends pick the same
+ * predecessor), and upserts only strict distance improvements. Candidates
+ * that already cost at least as much as a known path to the target are
+ * pruned — sound because the audit guarantees non-negative weights.
+ */
+async function relaxFrontierRound(
+  context: IterativeGraphRunContext,
+  targetId: string,
+  iteration: number,
+): Promise<number> {
+  const { operation, workingTable, graphId, runId } = context;
+  const { dialect } = operation.ctx;
+  let frontierCount = 0;
+  for (const edgeKinds of operation.edgeKindChunks) {
+    const sourceFilter = sql`
+      w.graph_id = ${graphId}
+      AND w.run_id = ${runId}
+      AND w.improved_round = ${iteration - 1}
+    `;
+    const expansion = compileWorkingTableExpansion(
+      operation,
+      workingTable,
+      sourceFilter,
+      operation.direction,
+      edgeKinds,
+    );
+    const rows = await context.backend.execute<ImprovedRow>(
+      asCompiledRowsSql(sql`
+        INSERT INTO ${workingTable}
+          (graph_id, run_id, node_id, node_kind, distance, hops,
+           predecessor_id, predecessor_kind, improved_round)
+        SELECT
+          ${graphId}, ${runId}, ranked.target_id, ranked.target_kind,
+          ranked.candidate_distance, ranked.candidate_hops,
+          ranked.source_id, ranked.source_kind, ${iteration}
+        FROM (
+          SELECT candidates.*,
+            ROW_NUMBER() OVER (
+              PARTITION BY ${dialect.binaryText(sql`candidates.target_kind`)},
+                ${dialect.binaryText(sql`candidates.target_id`)}
+              ORDER BY candidates.candidate_distance,
+                ${dialect.binaryText(sql`candidates.source_id`)},
+                ${dialect.binaryText(sql`candidates.source_kind`)}
+            ) AS candidate_rank
+          FROM (
+            SELECT expanded.source_id, expanded.source_kind,
+              expanded.target_id, expanded.target_kind,
+              frontier.distance + expanded.weight AS candidate_distance,
+              frontier.hops + 1 AS candidate_hops
+            FROM (${expansion}) expanded
+            JOIN ${workingTable} frontier
+              ON frontier.graph_id = ${graphId}
+              AND frontier.run_id = ${runId}
+              AND frontier.node_id = expanded.source_id
+              AND frontier.node_kind = expanded.source_kind
+          ) candidates
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM ${workingTable} settled_target
+            WHERE settled_target.graph_id = ${graphId}
+              AND settled_target.run_id = ${runId}
+              AND settled_target.node_id = ${targetId}
+              AND settled_target.distance <= candidates.candidate_distance
+          )
+        ) ranked
+        WHERE ranked.candidate_rank = 1
+        ON CONFLICT (graph_id, run_id, node_kind, node_id) DO UPDATE SET
+          distance = excluded.distance,
+          hops = excluded.hops,
+          predecessor_id = excluded.predecessor_id,
+          predecessor_kind = excluded.predecessor_kind,
+          improved_round = excluded.improved_round
+        WHERE excluded.distance < ${workingTable}.distance
+        RETURNING node_id
+      `),
+    );
+    frontierCount += rows.length;
+  }
+  return frontierCount;
+}
+
+async function readVisitedFromWorkingTable(
+  context: IterativeGraphRunContext,
+): Promise<ReadonlyMap<NodeIdentityKey, WeightedVisitedNode>> {
+  const rows = await context.backend.execute<DistanceRow>(
+    asCompiledRowsSql(sql`
+      SELECT node_id, node_kind, distance, hops,
+        predecessor_id, predecessor_kind
+      FROM ${context.workingTable}
+      WHERE graph_id = ${context.graphId}
+        AND run_id = ${context.runId}
+    `),
+  );
+  return new Map(
+    rows.map((row) => {
+      const parentKey =
+        (
+          typeof row.predecessor_id !== "string" ||
+          typeof row.predecessor_kind !== "string"
+        ) ?
+          undefined
+        : nodeIdentityKey({
+            id: row.predecessor_id,
+            kind: row.predecessor_kind,
+          });
+      const node = {
+        id: row.node_id,
+        kind: row.node_kind,
+        distance: Number(row.distance),
+        hops: Number(row.hops),
+        parentKey,
+      } satisfies WeightedVisitedNode;
+      return [nodeIdentityKey(node), node];
+    }),
+  );
+}
+
+// ============================================================
+// Inline execution (backends without temporary-table support)
+// ============================================================
+
+async function findWeightedShortestPathInline(
+  ctx: AlgorithmContext,
+  sourceId: string,
+  targetId: string,
+  maxIterations: number,
+  options: WeightedTraversalOptions,
+): Promise<WeightedShortestPathResult | undefined> {
+  return withInlineIterativeGraphOperation(ctx, options, async (operation) => {
+    await assertValidEdgeWeights(
+      operation,
+      options.weightProperty,
+      options.defaultWeight,
+    );
+    const sources = await fetchVisibleWorkingNodes(operation, [sourceId]);
+    if (sources.length === 0) return undefined;
+
+    const settled = new Map<NodeIdentityKey, WeightedVisitedNode>(
+      sources.map((source) => [
+        nodeIdentityKey(source),
+        {
+          id: source.id,
+          kind: source.kind,
+          distance: 0,
+          hops: 0,
+          parentKey: undefined,
+        },
+      ]),
+    );
+    let bestTargetDistance = sourceId === targetId ? 0 : undefined;
+    let frontier: readonly PathNode[] = sources;
+    let rounds = 0;
+
+    while (frontier.length > 0) {
+      if (rounds >= maxIterations) {
+        throw new GraphAlgorithmConvergenceError(
+          WEIGHTED_ALGORITHM_NAME,
+          maxIterations,
+        );
+      }
+      rounds++;
+
+      const candidates = await reduceExpandedWorkingSet<WeightedCandidate>(
+        operation,
+        frontier,
+        operation.direction,
+        (existing, expansion) =>
+          reduceWeightedCandidate(existing, expansion, settled),
+      );
+
+      // Prune against the best target distance as of the round start, the
+      // same state the working-table round's pre-statement snapshot sees, so
+      // both execution paths run identical round sequences.
+      const roundBound = bestTargetDistance;
+      const improved: PathNode[] = [];
+      for (const [candidateKey, candidate] of candidates) {
+        const existing = settled.get(candidateKey);
+        if (existing !== undefined && existing.distance <= candidate.distance) {
+          continue;
+        }
+        if (roundBound !== undefined && candidate.distance >= roundBound) {
+          continue;
+        }
+        settled.set(candidateKey, {
+          id: candidate.id,
+          kind: candidate.kind,
+          distance: candidate.distance,
+          hops: candidate.hops,
+          parentKey: nodeIdentityKey({
+            id: candidate.parentId,
+            kind: candidate.parentKind,
+          }),
+        });
+        improved.push({ id: candidate.id, kind: candidate.kind });
+        if (
+          candidate.id === targetId &&
+          (bestTargetDistance === undefined ||
+            candidate.distance < bestTargetDistance)
+        ) {
+          bestTargetDistance = candidate.distance;
+        }
+      }
+      frontier = improved.toSorted((left, right) =>
+        compareNodeIdentity(left, right),
+      );
+    }
+
+    return buildWeightedPathResult(settled, targetId);
+  });
+}
+
+/**
+ * Keeps the cheapest candidate per target identity; ties break by source id
+ * then kind, mirroring the working-table round's ROW_NUMBER ordering.
+ */
+function reduceWeightedCandidate(
+  existing: WeightedCandidate | undefined,
+  expansion: NodeExpansion,
+  settled: ReadonlyMap<NodeIdentityKey, WeightedVisitedNode>,
+): WeightedCandidate | undefined {
+  // Weighted operations always compile a weight column; the guard narrows
+  // the optional field.
+  const weight = expansion.weight;
+  if (weight === undefined) return existing;
+  const sourceEntry = settled.get(nodeIdentityKey(expansion.source));
+  if (sourceEntry === undefined) return existing;
+  const candidateDistance = sourceEntry.distance + weight;
+  if (
+    existing !== undefined &&
+    (existing.distance < candidateDistance ||
+      (existing.distance === candidateDistance &&
+        compareNodeIdentity(
+          { id: existing.parentId, kind: existing.parentKind },
+          expansion.source,
+        ) <= 0))
+  ) {
+    return existing;
+  }
+  return {
+    id: expansion.target.id,
+    kind: expansion.target.kind,
+    distance: candidateDistance,
+    hops: sourceEntry.hops + 1,
+    parentId: expansion.source.id,
+    parentKind: expansion.source.kind,
+  };
+}
+
+// ============================================================
+// Shared result construction
+// ============================================================
+
+/**
+ * Selects the cheapest settled node matching the target id (ties by node id
+ * then kind) and reconstructs the path by walking predecessors back to the
+ * source. Returns `undefined` when the target was never settled.
+ */
+function buildWeightedPathResult(
+  visited: ReadonlyMap<NodeIdentityKey, WeightedVisitedNode>,
+  targetId: string,
+): WeightedShortestPathResult | undefined {
+  let target: WeightedVisitedNode | undefined;
+  for (const node of visited.values()) {
+    if (node.id !== targetId) continue;
+    if (
+      target === undefined ||
+      node.distance < target.distance ||
+      (node.distance === target.distance &&
+        compareNodeIdentity(node, target) < 0)
+    ) {
+      target = node;
+    }
+  }
+  if (target === undefined) return undefined;
+
+  const reversedNodes: PathNode[] = [];
+  let cursor: WeightedVisitedNode | undefined = target;
+  while (cursor !== undefined) {
+    reversedNodes.push({ id: cursor.id, kind: cursor.kind });
+    cursor =
+      cursor.parentKey === undefined ? undefined : visited.get(cursor.parentKey);
+  }
+
+  return {
+    nodes: reversedNodes.toReversed(),
+    depth: target.hops,
+    totalWeight: target.distance,
+  };
+}

--- a/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
@@ -10,10 +10,10 @@ import {
 import { compileKindFilter } from "../../query/compiler/predicate-utils";
 import { jsonPointer } from "../../query/json-pointer";
 import { asCompiledRowsSql } from "../../query/sql-intent";
+import { compareCodePoints } from "../../utils/compare";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
 import { assertEdgeKinds, resolveMaxIterations } from "./context";
 import {
-  compareNodeIdentity,
   compileWorkingTableExpansion,
   fetchVisibleWorkingNodes,
   type IterativeGraphOperation,
@@ -195,17 +195,29 @@ async function assertValidEdgeWeights(
   // violation predicate then works over plain projected columns. Composing
   // the checks directly over `e.props` would re-parse the JSON payload for
   // every predicate branch on the audit's full edge scan.
+  //
+  // Both type predicates are the never-NULL, type-based dialect members —
+  // jsonPathIsNull's PostgreSQL text-comparison form would misclassify a
+  // JSON string "null" as null and go three-valued on a JSON null.
   const isNumber = dialect.jsonPathIsNumber(propsColumn, pointer);
-  const isMissing = dialect.jsonPathIsNull(propsColumn, pointer);
+  const isMissing = dialect.jsonPathIsMissingOrNull(propsColumn, pointer);
   const weightText = dialect.jsonExtractText(propsColumn, pointer);
+  // CASE keeps the numeric extraction unreachable for non-numeric values:
+  // PostgreSQL does not short-circuit OR/AND, and casting arbitrary text
+  // would error before the audit could produce its typed report. The
+  // extraction is jsonExtractNumber (PostgreSQL `numeric`), NOT the double
+  // extraction the traversal uses: a JSON number beyond the float8 range
+  // must reach the range check below instead of overflowing the cast.
+  const weightNumber = sql`CASE WHEN ${isNumber} THEN ${dialect.jsonExtractNumber(propsColumn, pointer)} END`;
   const missingViolation =
     defaultWeight === undefined ?
       sql`audited.is_missing = 1`
     : dialect.booleanLiteral(false);
-  // CASE keeps the cast unreachable for non-numeric values: PostgreSQL does
-  // not short-circuit OR/AND, and casting arbitrary text would error before
-  // the audit could produce its typed report.
-  const negativeViolation = sql`CASE WHEN audited.is_number = 1 THEN CAST(audited.weight_text AS DOUBLE PRECISION) < 0 ELSE ${dialect.booleanLiteral(false)} END`;
+  const negativeViolation = sql`audited.is_number = 1 AND audited.weight_number < 0`;
+  // CAST the bound to NUMERIC so PostgreSQL compares in the arbitrary-
+  // precision domain — a numeric-vs-float8 comparison would coerce the
+  // out-of-range value to float8 and overflow before comparing.
+  const outOfRangeViolation = sql`audited.is_number = 1 AND ABS(audited.weight_number) > CAST(${Number.MAX_VALUE} AS NUMERIC)`;
 
   for (const edgeKinds of operation.edgeKindChunks) {
     const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
@@ -216,6 +228,7 @@ async function assertValidEdgeWeights(
         FROM (
           SELECT e.id AS edge_id, e.kind AS edge_kind,
             ${weightText} AS weight_text,
+            ${weightNumber} AS weight_number,
             CASE WHEN ${isNumber} THEN 1 ELSE 0 END AS is_number,
             CASE WHEN ${isMissing} THEN 1 ELSE 0 END AS is_missing
           FROM ${operation.schema.edgesTable} e
@@ -226,6 +239,7 @@ async function assertValidEdgeWeights(
         WHERE (${missingViolation})
           OR (audited.is_missing = 0 AND audited.is_number = 0)
           OR (${negativeViolation})
+          OR (${outOfRangeViolation})
         ORDER BY ${dialect.binaryText(sql`audited.edge_id`)}
         LIMIT 1
       `),
@@ -241,14 +255,11 @@ function createInvalidEdgeWeightError(
   row: WeightAuditRow,
   weightProperty: string,
 ): InvalidEdgeWeightError {
-  const reason: InvalidEdgeWeightReason =
-    flagIsSet(row.is_missing) ? "missing"
-    : flagIsSet(row.is_number) ? "negative"
-    : "non_numeric";
+  const reason = resolveInvalidWeightReason(row);
   const value =
     reason === "missing" || row.weight_text === null ?
       undefined
-    : String(row.weight_text);
+    : formatWeightValue(row.weight_text);
   return new InvalidEdgeWeightError({
     edgeId: row.edge_id,
     edgeKind: row.edge_kind,
@@ -258,9 +269,50 @@ function createInvalidEdgeWeightError(
   });
 }
 
+function resolveInvalidWeightReason(
+  row: WeightAuditRow,
+): InvalidEdgeWeightReason {
+  if (flagIsSet(row.is_missing)) return "missing";
+  if (!flagIsSet(row.is_number)) return "non_numeric";
+  // A numeric violation is either negative or beyond the double range;
+  // Number() maps an out-of-range magnitude to ±Infinity, which is exactly
+  // the distinction needed here.
+  return Number(row.weight_text) < 0 ? "negative" : "not_finite";
+}
+
 /** Coerces a driver-shaped 0/1 flag (number, bigint, or boolean) to boolean. */
 function flagIsSet(value: unknown): boolean {
   return Number(value) !== 0;
+}
+
+/** Renders an extracted weight value for the error message. */
+function formatWeightValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (
+    typeof value === "number" ||
+    typeof value === "bigint" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Node-identity comparison in code-point order — the order SQLite BINARY
+ * and PostgreSQL `COLLATE "C"` sort in. Every JS-side tie-break in this
+ * algorithm must reproduce the working-table round's `binaryText` ORDER BY,
+ * and the substrate's UTF-16 `compareNodeIdentity` disagrees with it for
+ * astral characters.
+ */
+function compareNodeIdentityCodePoints(
+  left: PathNode,
+  right: PathNode,
+): number {
+  return (
+    compareCodePoints(left.id, right.id) ||
+    compareCodePoints(left.kind, right.kind)
+  );
 }
 
 // ============================================================
@@ -305,6 +357,9 @@ async function findWeightedShortestPathInWorkingTable(
       );
       return {
         frontierCount: round.frontierCount,
+        // Overcounts by re-improved existing rows (RETURNING includes
+        // updates); acceptable because the size only paces the substrate's
+        // ANALYZE refresh, where too-early merely refreshes stats sooner.
         workingTableSize: state.workingTableSize + round.frontierCount,
         bestTargetDistance: round.bestTargetDistance,
       };
@@ -425,7 +480,15 @@ async function relaxFrontierRound(
               AND frontier.node_id = expanded.source_id
               AND frontier.node_kind = expanded.source_kind
           ) candidates
-          WHERE ${roundBound === undefined ? sql`TRUE` : sql`candidates.candidate_distance < ${roundBound}`}
+          WHERE ${
+            // Equal-distance candidates for the target id itself stay
+            // admitted: when the id exists under several kinds, the
+            // documented smallest-identity tie-break must see an equal-cost
+            // target found in a later round, not have it pruned away.
+            roundBound === undefined ?
+              sql`TRUE`
+            : sql`(candidates.candidate_distance < ${roundBound} OR (candidates.target_id = ${targetId} AND candidates.candidate_distance <= ${roundBound}))`
+          }
         ) ranked
         WHERE ranked.candidate_rank = 1
         ON CONFLICT (graph_id, run_id, node_kind, node_id) DO UPDATE SET
@@ -496,8 +559,11 @@ async function findWeightedSelfPath(
       options.weightProperty,
       options.defaultWeight,
     );
-    const node = (await fetchVisibleWorkingNodes(operation, [nodeId]))[0];
-    if (node === undefined) return undefined;
+    const nodes = await fetchVisibleWorkingNodes(operation, [nodeId]);
+    const node = nodes.toSorted((left, right) =>
+      compareNodeIdentityCodePoints(left, right),
+    )[0];
+    if (node === undefined) return;
     return { nodes: [node], depth: 0, totalWeight: 0 };
   });
 }
@@ -520,7 +586,7 @@ async function findWeightedShortestPathInline(
       options.defaultWeight,
     );
     const sources = await fetchVisibleWorkingNodes(operation, [sourceId]);
-    if (sources.length === 0) return undefined;
+    if (sources.length === 0) return;
 
     const settled = new Map<NodeIdentityKey, WeightedVisitedNode>(
       sources.map((source) => [
@@ -565,7 +631,14 @@ async function findWeightedShortestPathInline(
         if (existing !== undefined && existing.distance <= candidate.distance) {
           continue;
         }
-        if (roundBound !== undefined && candidate.distance >= roundBound) {
+        // Mirrors the working-table prune: equal-distance candidates are
+        // dropped unless they carry the target id, so a smaller-identity
+        // target kind found later still reaches the result tie-break.
+        if (
+          roundBound !== undefined &&
+          (candidate.distance > roundBound ||
+            (candidate.distance === roundBound && candidate.id !== targetId))
+        ) {
           continue;
         }
         settled.set(candidateKey, {
@@ -588,7 +661,7 @@ async function findWeightedShortestPathInline(
         }
       }
       frontier = improved.toSorted((left, right) =>
-        compareNodeIdentity(left, right),
+        compareNodeIdentityCodePoints(left, right),
       );
     }
 
@@ -616,7 +689,7 @@ function reduceWeightedCandidate(
     existing !== undefined &&
     (existing.distance < candidateDistance ||
       (existing.distance === candidateDistance &&
-        compareNodeIdentity(
+        compareNodeIdentityCodePoints(
           { id: existing.parentId, kind: existing.parentKind },
           expansion.source,
         ) <= 0))
@@ -653,7 +726,7 @@ function buildWeightedPathResult(
       target === undefined ||
       node.distance < target.distance ||
       (node.distance === target.distance &&
-        compareNodeIdentity(node, target) < 0)
+        compareNodeIdentityCodePoints(node, target) < 0)
     ) {
       target = node;
     }
@@ -665,7 +738,9 @@ function buildWeightedPathResult(
   while (cursor !== undefined) {
     reversedNodes.push({ id: cursor.id, kind: cursor.kind });
     cursor =
-      cursor.parentKey === undefined ? undefined : visited.get(cursor.parentKey);
+      cursor.parentKey === undefined ?
+        undefined
+      : visited.get(cursor.parentKey);
   }
 
   return {

--- a/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
@@ -123,8 +123,9 @@ type WeightedCandidate = Readonly<{
  * out of the nodes improved in the previous round, keeping one best
  * `(distance, predecessor)` per node identity, until no distance improves.
  * Weights must be non-negative, which makes pruning against the best known
- * target distance safe: once a candidate costs at least as much as a path
- * already reaching the target, no extension of it can win.
+ * target distance safe: a candidate costing strictly more than a path
+ * already reaching the target can never win, while equal-cost candidates
+ * stay admitted so the result tie-break sees every equal-cost target.
  */
 export async function executeWeightedShortestPath<G extends GraphDef>(
   ctx: AlgorithmContext,
@@ -178,13 +179,18 @@ function assertWeightOptions(
       { weightProperty },
     );
   }
+  // The same upper bound the audit applies to stored weights: a default
+  // above it would reopen the accumulated-overflow gap for missing-weight
+  // edges the audit deliberately lets through.
   if (
     defaultWeight !== undefined &&
-    (!Number.isFinite(defaultWeight) || defaultWeight < 0)
+    (!Number.isFinite(defaultWeight) ||
+      defaultWeight < 0 ||
+      defaultWeight > MAX_EDGE_WEIGHT)
   ) {
     throw new ConfigurationError(
-      `${WEIGHTED_ALGORITHM_NAME} defaultWeight must be a finite non-negative number, got ${String(defaultWeight)}.`,
-      { defaultWeight },
+      `${WEIGHTED_ALGORITHM_NAME} defaultWeight must be a non-negative number no greater than ${MAX_EDGE_WEIGHT}, got ${String(defaultWeight)}.`,
+      { defaultWeight, maximum: MAX_EDGE_WEIGHT },
     );
   }
 }

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -66,6 +66,7 @@ export type {
   StoreViewShortestPathOptions,
   StoreViewSubgraphOptions,
   StoreViewWeaklyConnectedComponentsOptions,
+  StoreViewWeightedShortestPathOptions,
 } from "./store-view";
 export { RecordedStoreView, StoreView } from "./store-view";
 

--- a/packages/typegraph/src/store/store-view.ts
+++ b/packages/typegraph/src/store/store-view.ts
@@ -53,6 +53,8 @@ import {
   type TemporalAlgorithmOptions,
   type WeaklyConnectedComponentMembership,
   type WeaklyConnectedComponentsOptions,
+  type WeightedShortestPathOptions,
+  type WeightedShortestPathResult,
 } from "./algorithms";
 import {
   CURRENT_ONLY_READ_NAMES,
@@ -129,6 +131,15 @@ export type StoreViewShortestPathOptions<G extends GraphDef> = Omit<
   keyof TemporalAlgorithmOptions
 >;
 
+/**
+ * `weightedShortestPath` options with the temporal axis removed (the pin
+ * supplies it).
+ */
+export type StoreViewWeightedShortestPathOptions<G extends GraphDef> = Omit<
+  WeightedShortestPathOptions<G>,
+  keyof TemporalAlgorithmOptions
+>;
+
 /** `canReach` options with the temporal axis removed (the pin supplies it). */
 export type StoreViewCanReachOptions<G extends GraphDef> = Omit<
   BaseTraversalOptions<G>,
@@ -158,6 +169,11 @@ export type StoreViewGraphAlgorithms<G extends GraphDef> = Readonly<{
     to: NodeIdentifier,
     options: StoreViewShortestPathOptions<G>,
   ) => Promise<ShortestPathResult | undefined>;
+  weightedShortestPath: (
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: StoreViewWeightedShortestPathOptions<G>,
+  ) => Promise<WeightedShortestPathResult | undefined>;
   reachable: (
     from: NodeIdentifier,
     options: StoreViewReachableOptions<G>,
@@ -795,6 +811,8 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
   get algorithms(): StoreViewGraphAlgorithms<G> {
     this.#algorithmFacade ??= Object.freeze({
       shortestPath: (from, to, options) => this.shortestPath(from, to, options),
+      weightedShortestPath: (from, to, options) =>
+        this.weightedShortestPath(from, to, options),
       reachable: (from, options) => this.reachable(from, options),
       canReach: (from, to, options) => this.canReach(from, to, options),
       neighbors: (node, options) => this.neighbors(node, options),
@@ -828,6 +846,18 @@ abstract class CoordinatePinnedView<G extends GraphDef> {
     options: StoreViewShortestPathOptions<G>,
   ): Promise<ShortestPathResult | undefined> {
     return this.internalAlgorithms().shortestPath(from, to, {
+      ...options,
+      ...withCoordinate(this.coordinate),
+    });
+  }
+
+  /** Minimum-total-weight path at this view's pinned coordinate. */
+  weightedShortestPath(
+    from: NodeIdentifier,
+    to: NodeIdentifier,
+    options: StoreViewWeightedShortestPathOptions<G>,
+  ): Promise<WeightedShortestPathResult | undefined> {
+    return this.internalAlgorithms().weightedShortestPath(from, to, {
       ...options,
       ...withCoordinate(this.coordinate),
     });

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -5,10 +5,12 @@
  * neighbors, degree}` against the SQLite backend with a fixture that
  * includes branching paths, cycles, self-loops, and disconnected regions.
  */
+import { sql as drizzleSql } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { defineEdge, defineGraph, defineNode } from "../src";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import type {
   AdoptedTransaction,
   GraphBackend,
@@ -64,7 +66,7 @@ const testGraph = defineGraph({
     knows: { type: knows, from: [Person], to: [Person] },
     reports_to: { type: reportsTo, from: [Person], to: [Person] },
     depends_on: { type: dependsOn, from: [Task], to: [Task] },
-    road: { type: road, from: [Person], to: [Person] },
+    road: { type: road, from: [Person], to: [Person, Task] },
   },
 });
 
@@ -379,11 +381,9 @@ describe("store.algorithms", () => {
         roads.c,
       ]);
 
-      const unweighted = await store.algorithms.shortestPath(
-        roads.a,
-        roads.c,
-        { edges: ["road"] },
-      );
+      const unweighted = await store.algorithms.shortestPath(roads.a, roads.c, {
+        edges: ["road"],
+      });
       expect(unweighted?.depth).toBe(1);
     });
 
@@ -568,6 +568,58 @@ describe("store.algorithms", () => {
           maxIterations: 1,
         }),
       ).rejects.toBeInstanceOf(GraphAlgorithmConvergenceError);
+    });
+
+    it("keeps the smallest-identity tie-break for a target id under multiple kinds", async () => {
+      // Target id exists as both a Person and a Task at equal total weight,
+      // with the smaller identity (Person) discovered one round later — the
+      // best-target pruning must still admit it.
+      const targetId = "wsp-multi-kind-target";
+      const a = await store.nodes.Person.create({ name: "MultiA" });
+      const b = await store.nodes.Person.create({ name: "MultiB" });
+      const personTarget = await store.nodes.Person.create(
+        { name: "MultiTarget" },
+        { id: targetId },
+      );
+      const taskTarget = await store.nodes.Task.create(
+        { title: "MultiTarget" },
+        { id: targetId },
+      );
+      await store.edges.road.create(a, taskTarget, { cost: 2 });
+      await store.edges.road.create(a, b, { cost: 1 });
+      await store.edges.road.create(b, personTarget, { cost: 1 });
+
+      const path = await store.algorithms.weightedShortestPath(a, targetId, {
+        edges: ["road"],
+        weightProperty: "cost",
+      });
+      expect(path?.totalWeight).toBe(2);
+      expect(path?.nodes.at(-1)).toEqual({ id: targetId, kind: "Person" });
+    });
+
+    it("rejects weights beyond the double range instead of overflowing", async () => {
+      const { backend: rawBackend, db } = createLocalSqliteBackend();
+      try {
+        const rawStore = createStore(testGraph, rawBackend);
+        const a = await rawStore.nodes.Person.create({ name: "HugeA" });
+        const b = await rawStore.nodes.Person.create({ name: "HugeB" });
+        await rawStore.edges.road.create(a, b, { cost: 1 });
+        // 1e999 is valid JSON but outside IEEE 754 double range; it can only
+        // enter through raw writes or imports, never the Zod write path.
+        db.run(drizzleSql`UPDATE typegraph_edges SET props = '{"cost":1e999}'`);
+
+        await expect(
+          rawStore.algorithms.weightedShortestPath(a, b, {
+            edges: ["road"],
+            weightProperty: "cost",
+          }),
+        ).rejects.toMatchObject({
+          name: "InvalidEdgeWeightError",
+          details: { reason: "not_finite" },
+        });
+      } finally {
+        await rawBackend.close();
+      }
     });
 
     it("produces identical results through the inline fallback", async () => {

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -47,6 +47,12 @@ const Task = defineNode("Task", {
 const knows = defineEdge("knows", { schema: z.object({}) });
 const reportsTo = defineEdge("reports_to", { schema: z.object({}) });
 const dependsOn = defineEdge("depends_on", { schema: z.object({}) });
+const road = defineEdge("road", {
+  schema: z.object({
+    cost: z.number().optional(),
+    note: z.string().optional(),
+  }),
+});
 
 const testGraph = defineGraph({
   id: "algorithms_test",
@@ -58,6 +64,7 @@ const testGraph = defineGraph({
     knows: { type: knows, from: [Person], to: [Person] },
     reports_to: { type: reportsTo, from: [Person], to: [Person] },
     depends_on: { type: dependsOn, from: [Task], to: [Task] },
+    road: { type: road, from: [Person], to: [Person] },
   },
 });
 
@@ -323,6 +330,282 @@ describe("store.algorithms", () => {
         edges: ["knows"],
       });
       expect(path?.depth).toBe(1);
+    });
+  });
+
+  // --------------------------------------------------------------
+  // weightedShortestPath
+  // --------------------------------------------------------------
+
+  describe("weightedShortestPath", () => {
+    type RoadFixture = Readonly<{
+      a: string;
+      b: string;
+      c: string;
+      d: string;
+    }>;
+
+    /**
+     * Weighted road network:
+     *   a --(5)--> c            expensive direct road
+     *   a --(1)--> b --(1)--> c cheap detour
+     *   c --(2)--> d
+     * `d` has no outgoing roads; nothing reaches `a`.
+     */
+    async function seedRoads(): Promise<RoadFixture> {
+      const a = await store.nodes.Person.create({ name: "RoadA" });
+      const b = await store.nodes.Person.create({ name: "RoadB" });
+      const c = await store.nodes.Person.create({ name: "RoadC" });
+      const d = await store.nodes.Person.create({ name: "RoadD" });
+      await store.edges.road.create(a, c, { cost: 5 });
+      await store.edges.road.create(a, b, { cost: 1 });
+      await store.edges.road.create(b, c, { cost: 1 });
+      await store.edges.road.create(c, d, { cost: 2 });
+      return { a: a.id, b: b.id, c: c.id, d: d.id };
+    }
+
+    it("prefers a cheaper multi-hop path over an expensive direct edge", async () => {
+      const roads = await seedRoads();
+      const path = await store.algorithms.weightedShortestPath(
+        roads.a,
+        roads.c,
+        { edges: ["road"], weightProperty: "cost" },
+      );
+      expect(path?.totalWeight).toBe(2);
+      expect(path?.depth).toBe(2);
+      expect(path?.nodes.map((node) => node.id)).toEqual([
+        roads.a,
+        roads.b,
+        roads.c,
+      ]);
+
+      const unweighted = await store.algorithms.shortestPath(
+        roads.a,
+        roads.c,
+        { edges: ["road"] },
+      );
+      expect(unweighted?.depth).toBe(1);
+    });
+
+    it("accumulates weights across longer paths", async () => {
+      const roads = await seedRoads();
+      const path = await store.algorithms.weightedShortestPath(
+        roads.a,
+        roads.d,
+        { edges: ["road"], weightProperty: "cost" },
+      );
+      expect(path?.totalWeight).toBe(4);
+      expect(path?.depth).toBe(3);
+      expect(path?.nodes.map((node) => node.id)).toEqual([
+        roads.a,
+        roads.b,
+        roads.c,
+        roads.d,
+      ]);
+    });
+
+    it("uses the cheapest of parallel edges between the same endpoints", async () => {
+      const a = await store.nodes.Person.create({ name: "ParallelA" });
+      const b = await store.nodes.Person.create({ name: "ParallelB" });
+      await store.edges.road.create(a, b, { cost: 9 });
+      await store.edges.road.create(a, b, { cost: 3 });
+
+      const path = await store.algorithms.weightedShortestPath(a, b, {
+        edges: ["road"],
+        weightProperty: "cost",
+      });
+      expect(path?.totalWeight).toBe(3);
+      expect(path?.depth).toBe(1);
+    });
+
+    it("supports zero-weight edges, including zero-weight cycles", async () => {
+      const a = await store.nodes.Person.create({ name: "ZeroA" });
+      const b = await store.nodes.Person.create({ name: "ZeroB" });
+      const c = await store.nodes.Person.create({ name: "ZeroC" });
+      await store.edges.road.create(a, b, { cost: 0 });
+      await store.edges.road.create(b, a, { cost: 0 });
+      await store.edges.road.create(b, c, { cost: 1 });
+
+      const path = await store.algorithms.weightedShortestPath(a, c, {
+        edges: ["road"],
+        weightProperty: "cost",
+      });
+      expect(path?.totalWeight).toBe(1);
+      expect(path?.nodes.map((node) => node.id)).toEqual([a.id, b.id, c.id]);
+    });
+
+    it("returns a zero-weight self path", async () => {
+      const roads = await seedRoads();
+      const path = await store.algorithms.weightedShortestPath(
+        roads.a,
+        roads.a,
+        { edges: ["road"], weightProperty: "cost" },
+      );
+      expect(path?.totalWeight).toBe(0);
+      expect(path?.depth).toBe(0);
+      expect(path?.nodes.map((node) => node.id)).toEqual([roads.a]);
+    });
+
+    it("returns undefined when the target is unreachable", async () => {
+      const roads = await seedRoads();
+      const path = await store.algorithms.weightedShortestPath(
+        roads.d,
+        roads.a,
+        { edges: ["road"], weightProperty: "cost" },
+      );
+      expect(path).toBeUndefined();
+    });
+
+    it("follows direction 'in' and 'both'", async () => {
+      const roads = await seedRoads();
+      const inbound = await store.algorithms.weightedShortestPath(
+        roads.c,
+        roads.a,
+        { edges: ["road"], weightProperty: "cost", direction: "in" },
+      );
+      expect(inbound?.totalWeight).toBe(2);
+      expect(inbound?.nodes.map((node) => node.id)).toEqual([
+        roads.c,
+        roads.b,
+        roads.a,
+      ]);
+
+      const undirected = await store.algorithms.weightedShortestPath(
+        roads.d,
+        roads.a,
+        { edges: ["road"], weightProperty: "cost", direction: "both" },
+      );
+      expect(undirected?.totalWeight).toBe(4);
+    });
+
+    it("throws InvalidEdgeWeightError for a missing weight without defaultWeight", async () => {
+      const a = await store.nodes.Person.create({ name: "MissingA" });
+      const b = await store.nodes.Person.create({ name: "MissingB" });
+      await store.edges.road.create(a, b, {});
+
+      await expect(
+        store.algorithms.weightedShortestPath(a, b, {
+          edges: ["road"],
+          weightProperty: "cost",
+        }),
+      ).rejects.toMatchObject({
+        name: "InvalidEdgeWeightError",
+        details: { reason: "missing", property: "cost" },
+      });
+    });
+
+    it("substitutes defaultWeight for edges missing the property", async () => {
+      const a = await store.nodes.Person.create({ name: "DefaultA" });
+      const b = await store.nodes.Person.create({ name: "DefaultB" });
+      const c = await store.nodes.Person.create({ name: "DefaultC" });
+      await store.edges.road.create(a, b, {});
+      await store.edges.road.create(b, c, { cost: 2 });
+
+      const path = await store.algorithms.weightedShortestPath(a, c, {
+        edges: ["road"],
+        weightProperty: "cost",
+        defaultWeight: 7,
+      });
+      expect(path?.totalWeight).toBe(9);
+    });
+
+    it("throws InvalidEdgeWeightError for a negative weight anywhere in the selected kinds", async () => {
+      const roads = await seedRoads();
+      const x = await store.nodes.Person.create({ name: "NegativeX" });
+      const y = await store.nodes.Person.create({ name: "NegativeY" });
+      await store.edges.road.create(x, y, { cost: -1 });
+
+      // The offending edge is not even reachable from the queried source —
+      // the audit is global over the selected kinds, so the failure is
+      // deterministic regardless of traversal order.
+      await expect(
+        store.algorithms.weightedShortestPath(roads.a, roads.c, {
+          edges: ["road"],
+          weightProperty: "cost",
+        }),
+      ).rejects.toMatchObject({
+        name: "InvalidEdgeWeightError",
+        details: { reason: "negative" },
+      });
+    });
+
+    it("throws InvalidEdgeWeightError for a non-numeric weight property", async () => {
+      const a = await store.nodes.Person.create({ name: "TextA" });
+      const b = await store.nodes.Person.create({ name: "TextB" });
+      await store.edges.road.create(a, b, { cost: 1, note: "scenic" });
+
+      await expect(
+        store.algorithms.weightedShortestPath(a, b, {
+          edges: ["road"],
+          weightProperty: "note",
+        }),
+      ).rejects.toMatchObject({
+        name: "InvalidEdgeWeightError",
+        details: { reason: "non_numeric", value: "scenic" },
+      });
+    });
+
+    it("supports fractional weights with double-precision totals", async () => {
+      const a = await store.nodes.Person.create({ name: "FracA" });
+      const b = await store.nodes.Person.create({ name: "FracB" });
+      const c = await store.nodes.Person.create({ name: "FracC" });
+      await store.edges.road.create(a, b, { cost: 0.1 });
+      await store.edges.road.create(b, c, { cost: 0.2 });
+
+      const path = await store.algorithms.weightedShortestPath(a, c, {
+        edges: ["road"],
+        weightProperty: "cost",
+      });
+      expect(path?.totalWeight).toBe(0.1 + 0.2);
+    });
+
+    it("throws GraphAlgorithmConvergenceError when maxIterations is exhausted", async () => {
+      const roads = await seedRoads();
+      await expect(
+        store.algorithms.weightedShortestPath(roads.a, roads.d, {
+          edges: ["road"],
+          weightProperty: "cost",
+          maxIterations: 1,
+        }),
+      ).rejects.toBeInstanceOf(GraphAlgorithmConvergenceError);
+    });
+
+    it("produces identical results through the inline fallback", async () => {
+      const roads = await seedRoads();
+      const inlineBackend: GraphBackend = {
+        ...backend,
+        capabilities: { ...backend.capabilities, transactions: false },
+      };
+      const inlineStore = createStore(testGraph, inlineBackend);
+
+      const workingTablePath = await store.algorithms.weightedShortestPath(
+        roads.a,
+        roads.d,
+        { edges: ["road"], weightProperty: "cost" },
+      );
+      const inlinePath = await inlineStore.algorithms.weightedShortestPath(
+        roads.a,
+        roads.d,
+        { edges: ["road"], weightProperty: "cost" },
+      );
+      expect(inlinePath).toEqual(workingTablePath);
+
+      await expect(
+        inlineStore.algorithms.weightedShortestPath(roads.d, roads.a, {
+          edges: ["road"],
+          weightProperty: "cost",
+        }),
+      ).resolves.toBeUndefined();
+
+      const x = await store.nodes.Person.create({ name: "InlineNegX" });
+      const y = await store.nodes.Person.create({ name: "InlineNegY" });
+      await store.edges.road.create(x, y, { cost: -2 });
+      await expect(
+        inlineStore.algorithms.weightedShortestPath(roads.a, roads.d, {
+          edges: ["road"],
+          weightProperty: "cost",
+        }),
+      ).rejects.toMatchObject({ name: "InvalidEdgeWeightError" });
     });
   });
 
@@ -948,6 +1231,39 @@ describe("store.algorithms", () => {
       await expect(
         store.algorithms.weaklyConnectedComponents({ edges: [] }),
       ).rejects.toBeInstanceOf(ConfigurationError);
+      await expect(
+        store.algorithms.weightedShortestPath(ids.alice, ids.bob, {
+          edges: [],
+          weightProperty: "cost",
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+    });
+
+    it("rejects malformed weightedShortestPath weight options", async () => {
+      await expect(
+        store.algorithms.weightedShortestPath(ids.alice, ids.bob, {
+          edges: ["road"],
+          weightProperty: "",
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+      for (const defaultWeight of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+        await expect(
+          store.algorithms.weightedShortestPath(ids.alice, ids.bob, {
+            edges: ["road"],
+            weightProperty: "cost",
+            defaultWeight,
+          }),
+        ).rejects.toBeInstanceOf(ConfigurationError);
+      }
+      for (const maxIterations of [0, -5, 1.5, Number.NaN]) {
+        await expect(
+          store.algorithms.weightedShortestPath(ids.alice, ids.bob, {
+            edges: ["road"],
+            weightProperty: "cost",
+            maxIterations,
+          }),
+        ).rejects.toBeInstanceOf(ConfigurationError);
+      }
     });
 
     it("rejects non-positive maxHops", async () => {

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -509,6 +509,35 @@ describe("store.algorithms", () => {
       expect(path?.totalWeight).toBe(9);
     });
 
+    it("bounds defaultWeight like stored weights so missing-weight sums cannot overflow", async () => {
+      const maxEdgeWeight = Number.MAX_VALUE / 2 ** 64;
+      const a = await store.nodes.Person.create({ name: "BoundA" });
+      const b = await store.nodes.Person.create({ name: "BoundB" });
+      const c = await store.nodes.Person.create({ name: "BoundC" });
+      await store.edges.road.create(a, b, {});
+      await store.edges.road.create(b, c, {});
+
+      // Above the audit bound: rejected up front, before any SQL runs —
+      // otherwise two defaulted hops at MAX_VALUE would overflow float8 on
+      // PostgreSQL (raw 22003) while SQLite returned Infinity.
+      await expect(
+        store.algorithms.weightedShortestPath(a, c, {
+          edges: ["road"],
+          weightProperty: "cost",
+          defaultWeight: Number.MAX_VALUE,
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+
+      // At the exact bound: accepted, and the two-hop sum stays finite.
+      const path = await store.algorithms.weightedShortestPath(a, c, {
+        edges: ["road"],
+        weightProperty: "cost",
+        defaultWeight: maxEdgeWeight,
+      });
+      expect(path?.totalWeight).toBe(maxEdgeWeight * 2);
+      expect(Number.isFinite(path?.totalWeight)).toBe(true);
+    });
+
     it("throws InvalidEdgeWeightError for a negative weight anywhere in the selected kinds", async () => {
       const roads = await seedRoads();
       const x = await store.nodes.Person.create({ name: "NegativeX" });
@@ -1345,7 +1374,15 @@ describe("store.algorithms", () => {
           weightProperty: "",
         }),
       ).rejects.toBeInstanceOf(ConfigurationError);
-      for (const defaultWeight of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      // Number.MAX_VALUE is finite but above the audit's accumulation
+      // bound — accepting it would reopen the overflow gap for
+      // missing-weight edges that skip the stored-weight audit.
+      for (const defaultWeight of [
+        -1,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.MAX_VALUE,
+      ]) {
         await expect(
           store.algorithms.weightedShortestPath(ids.alice, ids.bob, {
             edges: ["road"],

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -597,6 +597,53 @@ describe("store.algorithms", () => {
       expect(path?.nodes.at(-1)).toEqual({ id: targetId, kind: "Person" });
     });
 
+    it("reaches a smaller-identity target through a zero-weight edge from an equal-cost intermediate", async () => {
+      // Equal-bound pruning regression: after TaskT settles at cost 2, the
+      // intermediate x also costs exactly 2, and only a zero-weight edge
+      // from x reaches PersonT — the documented smallest-identity winner.
+      // Pruning must drop strictly-worse candidates only, or x (and with it
+      // PersonT) disappears.
+      const targetId = "wsp-zero-weight-target";
+      const a = await store.nodes.Person.create({ name: "PlateauA" });
+      const b = await store.nodes.Person.create({ name: "PlateauB" });
+      const x = await store.nodes.Person.create({ name: "PlateauX" });
+      const personTarget = await store.nodes.Person.create(
+        { name: "PlateauTarget" },
+        { id: targetId },
+      );
+      const taskTarget = await store.nodes.Task.create(
+        { title: "PlateauTarget" },
+        { id: targetId },
+      );
+      await store.edges.road.create(a, taskTarget, { cost: 2 });
+      await store.edges.road.create(a, b, { cost: 1 });
+      await store.edges.road.create(b, x, { cost: 1 });
+      await store.edges.road.create(x, personTarget, { cost: 0 });
+
+      const options = { edges: ["road"], weightProperty: "cost" } as const;
+      const workingTablePath = await store.algorithms.weightedShortestPath(
+        a,
+        targetId,
+        options,
+      );
+      expect(workingTablePath?.totalWeight).toBe(2);
+      expect(workingTablePath?.nodes.at(-1)).toEqual({
+        id: targetId,
+        kind: "Person",
+      });
+
+      const inlineStore = createStore(testGraph, {
+        ...backend,
+        capabilities: { ...backend.capabilities, transactions: false },
+      });
+      const inlinePath = await inlineStore.algorithms.weightedShortestPath(
+        a,
+        targetId,
+        options,
+      );
+      expect(inlinePath).toEqual(workingTablePath);
+    });
+
     it("rejects weights beyond the double range instead of overflowing", async () => {
       const { backend: rawBackend, db } = createLocalSqliteBackend();
       try {
@@ -615,7 +662,7 @@ describe("store.algorithms", () => {
           }),
         ).rejects.toMatchObject({
           name: "InvalidEdgeWeightError",
-          details: { reason: "not_finite" },
+          details: { reason: "out_of_range" },
         });
       } finally {
         await rawBackend.close();

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -81,6 +81,21 @@ async function seedTemporalGraph(
   };
 }
 
+/**
+ * Anna --(weight 5)--> Clara, and a cheaper detour through Bruno (1 + 1).
+ * Unweighted shortest path takes the direct edge; weighted must take the
+ * detour.
+ */
+async function seedWeightedTriangle(store: IntegrationStore) {
+  const anna = await store.nodes.Person.create({ name: "Anna" });
+  const bruno = await store.nodes.Person.create({ name: "Bruno" });
+  const clara = await store.nodes.Person.create({ name: "Clara" });
+  await store.edges.knows.create(anna, clara, { weight: 5 });
+  await store.edges.knows.create(anna, bruno, { weight: 1 });
+  await store.edges.knows.create(bruno, clara, { weight: 1 });
+  return { anna, bruno, clara };
+}
+
 export function registerAlgorithmIntegrationTests(
   context: IntegrationTestContext,
 ): void {
@@ -209,25 +224,9 @@ export function registerAlgorithmIntegrationTests(
     });
 
     describe("weightedShortestPath", () => {
-      /**
-       * Anna --(weight 5)--> Clara, and a cheaper detour through Bruno
-       * (1 + 1). Unweighted shortest path takes the direct edge; weighted
-       * must take the detour.
-       */
-      async function seedWeightedTriangle() {
-        const store = context.getStore();
-        const anna = await store.nodes.Person.create({ name: "Anna" });
-        const bruno = await store.nodes.Person.create({ name: "Bruno" });
-        const clara = await store.nodes.Person.create({ name: "Clara" });
-        await store.edges.knows.create(anna, clara, { weight: 5 });
-        await store.edges.knows.create(anna, bruno, { weight: 1 });
-        await store.edges.knows.create(bruno, clara, { weight: 1 });
-        return { anna, bruno, clara };
-      }
-
       it("finds the minimum-weight path, not the minimum-hop path", async () => {
         const store = context.getStore();
-        const ids = await seedWeightedTriangle();
+        const ids = await seedWeightedTriangle(store);
 
         const weighted = await store.algorithms.weightedShortestPath(
           ids.anna,
@@ -252,7 +251,7 @@ export function registerAlgorithmIntegrationTests(
 
       it("traverses undirected with direction 'both'", async () => {
         const store = context.getStore();
-        const ids = await seedWeightedTriangle();
+        const ids = await seedWeightedTriangle(store);
 
         const path = await store.algorithms.weightedShortestPath(
           ids.clara,
@@ -269,7 +268,7 @@ export function registerAlgorithmIntegrationTests(
 
       it("fails fast on missing weights unless defaultWeight is provided", async () => {
         const store = context.getStore();
-        const ids = await seedWeightedTriangle();
+        const ids = await seedWeightedTriangle(store);
         const dora = await store.nodes.Person.create({ name: "Dora" });
         await store.edges.knows.create(ids.clara, dora, {});
 
@@ -308,6 +307,51 @@ export function registerAlgorithmIntegrationTests(
         });
       });
 
+      it('classifies the JSON string "null" as non-numeric, not missing', async () => {
+        // Regression: PostgreSQL's text-comparison null check cannot tell a
+        // JSON string "null" from a JSON null; the type-based audit must.
+        const store = context.getStore();
+        const anna = await store.nodes.Person.create({ name: "StrNullAnna" });
+        const bruno = await store.nodes.Person.create({ name: "StrNullBruno" });
+        await store.edges.knows.create(anna, bruno, { since: "null" });
+
+        await expect(
+          store.algorithms.weightedShortestPath(anna, bruno, {
+            edges: ["knows"],
+            weightProperty: "since",
+            defaultWeight: 1,
+          }),
+        ).rejects.toMatchObject({
+          name: "InvalidEdgeWeightError",
+          details: { reason: "non_numeric", value: "null" },
+        });
+      });
+
+      it("treats a JSON null weight as missing on both backends", async () => {
+        const store = context.getStore();
+        const anna = await store.nodes.Person.create({ name: "NullAnna" });
+        const bruno = await store.nodes.Person.create({ name: "NullBruno" });
+        // eslint-disable-next-line unicorn/no-null -- the JSON null value is the case under test
+        await store.edges.knows.create(anna, bruno, { weight: null });
+
+        await expect(
+          store.algorithms.weightedShortestPath(anna, bruno, {
+            edges: ["knows"],
+            weightProperty: "weight",
+          }),
+        ).rejects.toMatchObject({
+          name: "InvalidEdgeWeightError",
+          details: { reason: "missing", property: "weight" },
+        });
+
+        const withDefault = await store.algorithms.weightedShortestPath(
+          anna,
+          bruno,
+          { edges: ["knows"], weightProperty: "weight", defaultWeight: 4 },
+        );
+        expect(withDefault?.totalWeight).toBe(4);
+      });
+
       it("accumulates fractional weights identically on both backends", async () => {
         const store = context.getStore();
         const anna = await store.nodes.Person.create({ name: "FracAnna" });
@@ -316,11 +360,10 @@ export function registerAlgorithmIntegrationTests(
         await store.edges.knows.create(anna, bruno, { weight: 0.1 });
         await store.edges.knows.create(bruno, clara, { weight: 0.2 });
 
-        const path = await store.algorithms.weightedShortestPath(
-          anna,
-          clara,
-          { edges: ["knows"], weightProperty: "weight" },
-        );
+        const path = await store.algorithms.weightedShortestPath(anna, clara, {
+          edges: ["knows"],
+          weightProperty: "weight",
+        });
         // Both backends must do IEEE 754 double arithmetic — a decimal
         // NUMERIC accumulation would yield exactly 0.3 and diverge.
         expect(path?.totalWeight).toBe(0.1 + 0.2);

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -208,6 +208,166 @@ export function registerAlgorithmIntegrationTests(
       });
     });
 
+    describe("weightedShortestPath", () => {
+      /**
+       * Anna --(weight 5)--> Clara, and a cheaper detour through Bruno
+       * (1 + 1). Unweighted shortest path takes the direct edge; weighted
+       * must take the detour.
+       */
+      async function seedWeightedTriangle() {
+        const store = context.getStore();
+        const anna = await store.nodes.Person.create({ name: "Anna" });
+        const bruno = await store.nodes.Person.create({ name: "Bruno" });
+        const clara = await store.nodes.Person.create({ name: "Clara" });
+        await store.edges.knows.create(anna, clara, { weight: 5 });
+        await store.edges.knows.create(anna, bruno, { weight: 1 });
+        await store.edges.knows.create(bruno, clara, { weight: 1 });
+        return { anna, bruno, clara };
+      }
+
+      it("finds the minimum-weight path, not the minimum-hop path", async () => {
+        const store = context.getStore();
+        const ids = await seedWeightedTriangle();
+
+        const weighted = await store.algorithms.weightedShortestPath(
+          ids.anna,
+          ids.clara,
+          { edges: ["knows"], weightProperty: "weight" },
+        );
+        expect(weighted?.totalWeight).toBe(2);
+        expect(weighted?.depth).toBe(2);
+        expect(weighted?.nodes.map((node) => node.id)).toEqual([
+          ids.anna.id,
+          ids.bruno.id,
+          ids.clara.id,
+        ]);
+
+        const unweighted = await store.algorithms.shortestPath(
+          ids.anna,
+          ids.clara,
+          { edges: ["knows"] },
+        );
+        expect(unweighted?.depth).toBe(1);
+      });
+
+      it("traverses undirected with direction 'both'", async () => {
+        const store = context.getStore();
+        const ids = await seedWeightedTriangle();
+
+        const path = await store.algorithms.weightedShortestPath(
+          ids.clara,
+          ids.anna,
+          { edges: ["knows"], weightProperty: "weight", direction: "both" },
+        );
+        expect(path?.totalWeight).toBe(2);
+        expect(path?.nodes.map((node) => node.id)).toEqual([
+          ids.clara.id,
+          ids.bruno.id,
+          ids.anna.id,
+        ]);
+      });
+
+      it("fails fast on missing weights unless defaultWeight is provided", async () => {
+        const store = context.getStore();
+        const ids = await seedWeightedTriangle();
+        const dora = await store.nodes.Person.create({ name: "Dora" });
+        await store.edges.knows.create(ids.clara, dora, {});
+
+        await expect(
+          store.algorithms.weightedShortestPath(ids.anna, dora.id, {
+            edges: ["knows"],
+            weightProperty: "weight",
+          }),
+        ).rejects.toMatchObject({
+          name: "InvalidEdgeWeightError",
+          details: { reason: "missing", property: "weight" },
+        });
+
+        const withDefault = await store.algorithms.weightedShortestPath(
+          ids.anna,
+          dora.id,
+          { edges: ["knows"], weightProperty: "weight", defaultWeight: 10 },
+        );
+        expect(withDefault?.totalWeight).toBe(12);
+      });
+
+      it("rejects a non-numeric weight property identically on both backends", async () => {
+        const store = context.getStore();
+        const anna = await store.nodes.Person.create({ name: "TextAnna" });
+        const bruno = await store.nodes.Person.create({ name: "TextBruno" });
+        await store.edges.knows.create(anna, bruno, { since: "2020" });
+
+        await expect(
+          store.algorithms.weightedShortestPath(anna, bruno, {
+            edges: ["knows"],
+            weightProperty: "since",
+          }),
+        ).rejects.toMatchObject({
+          name: "InvalidEdgeWeightError",
+          details: { reason: "non_numeric", value: "2020" },
+        });
+      });
+
+      it("accumulates fractional weights identically on both backends", async () => {
+        const store = context.getStore();
+        const anna = await store.nodes.Person.create({ name: "FracAnna" });
+        const bruno = await store.nodes.Person.create({ name: "FracBruno" });
+        const clara = await store.nodes.Person.create({ name: "FracClara" });
+        await store.edges.knows.create(anna, bruno, { weight: 0.1 });
+        await store.edges.knows.create(bruno, clara, { weight: 0.2 });
+
+        const path = await store.algorithms.weightedShortestPath(
+          anna,
+          clara,
+          { edges: ["knows"], weightProperty: "weight" },
+        );
+        // Both backends must do IEEE 754 double arithmetic — a decimal
+        // NUMERIC accumulation would yield exactly 0.3 and diverge.
+        expect(path?.totalWeight).toBe(0.1 + 0.2);
+      });
+
+      it("honors the temporal coordinate, including through a pinned StoreView", async () => {
+        const store = context.getStore();
+        const { PAST, BEFORE, EDGE_ENDED } = TEMPORAL_ANCHORS;
+        const anna = await store.nodes.Person.create(
+          { name: "TemporalAnna" },
+          { validFrom: PAST },
+        );
+        const bruno = await store.nodes.Person.create(
+          { name: "TemporalBruno" },
+          { validFrom: PAST },
+        );
+        // A cheap edge that ended, and a pricier one still valid.
+        await store.edges.knows.create(
+          anna,
+          bruno,
+          { weight: 1 },
+          { validFrom: PAST, validTo: EDGE_ENDED },
+        );
+        await store.edges.knows.create(
+          anna,
+          bruno,
+          { weight: 8 },
+          { validFrom: PAST },
+        );
+
+        const current = await store.algorithms.weightedShortestPath(
+          anna,
+          bruno,
+          { edges: ["knows"], weightProperty: "weight" },
+        );
+        expect(current?.totalWeight).toBe(8);
+
+        const pinned = await store
+          .asOf(BEFORE)
+          .algorithms.weightedShortestPath(anna, bruno, {
+            edges: ["knows"],
+            weightProperty: "weight",
+          });
+        expect(pinned?.totalWeight).toBe(1);
+      });
+    });
+
     describe("weaklyConnectedComponents", () => {
       it("returns deterministic memberships, sizes, isolated nodes, and cross-kind identities", async () => {
         const store = context.getStore();

--- a/packages/typegraph/tests/backends/integration/fixtures.ts
+++ b/packages/typegraph/tests/backends/integration/fixtures.ts
@@ -88,6 +88,7 @@ const worksAt = defineEdge("worksAt", {
 const knows = defineEdge("knows", {
   schema: z.object({
     since: z.string().optional(),
+    weight: z.number().optional(),
   }),
 });
 

--- a/packages/typegraph/tests/backends/integration/fixtures.ts
+++ b/packages/typegraph/tests/backends/integration/fixtures.ts
@@ -88,7 +88,8 @@ const worksAt = defineEdge("worksAt", {
 const knows = defineEdge("knows", {
   schema: z.object({
     since: z.string().optional(),
-    weight: z.number().optional(),
+    // Nullable so weighted-traversal tests can pin the JSON-null case.
+    weight: z.number().nullable().optional(),
   }),
 });
 

--- a/packages/typegraph/tests/backends/integration/recorded-time.ts
+++ b/packages/typegraph/tests/backends/integration/recorded-time.ts
@@ -1109,6 +1109,48 @@ export function registerRecordedTimeIntegrationTests(
       expect(replayedPath?.depth).toBe(2);
     });
 
+    it("reconstructs weighted shortest paths at recorded instants", async () => {
+      const store = await createHistoryStore(context);
+      const a = await store.nodes.Person.create({ name: "WA", age: 1 });
+      const b = await store.nodes.Person.create({ name: "WB", age: 2 });
+      const c = await store.nodes.Person.create({ name: "WC", age: 3 });
+      await store.edges.knows.create(a, b, { weight: 5 });
+      const beforeDetour = await readRecordedClock(store);
+
+      // A cheaper two-hop detour appears later; the weight audit and the
+      // relaxation rounds must both read the recorded relation at the pin.
+      await store.edges.knows.create(a, c, { weight: 1 });
+      await store.edges.knows.create(c, b, { weight: 1 });
+      const afterDetour = await readRecordedClock(store);
+
+      const early = await store
+        .asOfRecorded(beforeDetour)
+        .weightedShortestPath(a.id, b.id, {
+          edges: ["knows"],
+          weightProperty: "weight",
+        });
+      expect(early?.totalWeight).toBe(5);
+      expect(early?.depth).toBe(1);
+
+      const late = await store
+        .asOfRecorded(afterDetour)
+        .weightedShortestPath(a.id, b.id, {
+          edges: ["knows"],
+          weightProperty: "weight",
+        });
+      expect(late?.totalWeight).toBe(2);
+      expect(late?.nodes.map((node) => node.id)).toEqual([a.id, c.id, b.id]);
+
+      // History is immutable: replaying the earlier pin still sees weight 5.
+      const replayed = await store
+        .asOfRecorded(beforeDetour)
+        .weightedShortestPath(a.id, b.id, {
+          edges: ["knows"],
+          weightProperty: "weight",
+        });
+      expect(replayed?.totalWeight).toBe(5);
+    });
+
     it("rejects the recorded-time open sentinel in internal algorithm options", async () => {
       const store = await createHistoryStore(context);
       const alice = await store.nodes.Person.create({ name: "Alice", age: 30 });

--- a/packages/typegraph/tests/backends/integration/recorded-time.ts
+++ b/packages/typegraph/tests/backends/integration/recorded-time.ts
@@ -1279,6 +1279,16 @@ export function registerRecordedTimeIntegrationTests(
           message: "recordedAsOf is only available through",
         },
         {
+          surface: "weightedShortestPath",
+          invoke: () =>
+            invokeRuntimeMethod(algorithms, "weightedShortestPath", [
+              alice.id,
+              bob.id,
+              { ...algorithmOptions, weightProperty: "weight" },
+            ]),
+          message: "recordedAsOf is only available through",
+        },
+        {
           surface: "reachable",
           invoke: () =>
             invokeRuntimeMethod(algorithms, "reachable", [

--- a/packages/typegraph/tests/recorded-store-view-types.test.ts
+++ b/packages/typegraph/tests/recorded-store-view-types.test.ts
@@ -49,6 +49,7 @@ describe("RecordedStoreView typed surface", () => {
     expectTypeOf(recorded).toHaveProperty("query");
     expectTypeOf(recorded).toHaveProperty("subgraph");
     expectTypeOf(recorded).toHaveProperty("shortestPath");
+    expectTypeOf(recorded).toHaveProperty("weightedShortestPath");
     expectTypeOf(recorded).toHaveProperty("reachable");
     expectTypeOf(recorded).toHaveProperty("degree");
     expectTypeOf(recorded).toHaveProperty("nodes");


### PR DESCRIPTION
Adds `store.algorithms.weightedShortestPath(from, to, options)` — a minimum-total-weight path search where each traversed edge contributes a numeric edge property (`weightProperty`) to the path cost. This is the shape LDBC Interactive IC14 needs: the cheapest route by interaction weight, which is usually not the fewest-hop route.

## API

```typescript
const path = await store.algorithms.weightedShortestPath(alice, bob, {
  edges: ["knows"],
  weightProperty: "interactionCost",
  direction: "both",
});
// { nodes: [...], depth: 3, totalWeight: 2.5 } | undefined
```

- Separate method rather than a `weight` option on `shortestPath`, per the convention that option flags must not change return types.
- Options mirror the sibling algorithms (`edges`, `direction`, temporal options, `workingMemory`); `maxIterations` (default 1000, like WCC) replaces `maxHops` — cost-ordered search doesn't settle nodes in hop order, so the round cap is a runaway backstop, not a depth bound.
- Exposed on `Store`, `StoreView` (`store.asOf(...).weightedShortestPath`), and recorded views, with the same `recordedAsOf` gating as the other algorithms.

## Algorithm

Frontier-based label-correcting relaxation on the #274 iterative substrate: each round relaxes edges out of the nodes improved in the previous round, keeping one best `(distance, predecessor)` per `(kind, id)` identity, until no distance improves. Candidates that already cost at least as much as a known path to the target are pruned (sound because weights are non-negative), with the bound tracked in JS from each round's `RETURNING` rows so pruning is a plain bind parameter.

Both substrate execution paths are implemented, mirroring BFS: temporary working-table rounds on transactional backends, and the chunked inline `VALUES` fallback elsewhere. Self paths short-circuit to a visibility check plus the weight audit.

## Weight contract

Weights are audited **up front**, inside the operation's snapshot, across every visible edge of the selected kinds — so a weighted call either observes a fully valid weight domain or fails fast with the new typed `InvalidEdgeWeightError` naming the offending edge:

- `negative` — target pruning assumes non-negative weights;
- `non_numeric` — the property must be a JSON number (a JSON string `"5"` or `"null"` does not count);
- `not_finite` — a JSON number beyond the IEEE 754 double range (checked in the NUMERIC domain on PostgreSQL, so it reports the typed error instead of a raw 22003 overflow);
- `missing` — unless `defaultWeight` is configured, in which case it substitutes.

The global scan is a deliberate O(E-of-selected-kinds) cost per call: reachability-scoped validation would make data errors nondeterministic in which endpoints you happen to query.

## Backend parity

- Weight arithmetic is IEEE 754 double on both backends via a new `DialectAdapter.jsonExtractDouble` seam (`json_extract` / `::double precision`) — `jsonExtractNumber`'s PostgreSQL `::numeric` would accumulate in exact decimal and diverge from SQLite doubles.
- Two new type-based dialect predicates, `jsonPathIsNumber` and `jsonPathIsMissingOrNull`, are never-NULL by contract; the latter exists because `jsonPathIsNull`'s PostgreSQL text-comparison form goes three-valued on a JSON `null` and misclassifies the JSON string `"null"`.
- Equal-weight tie-breaks (predecessor choice, multi-kind target selection) use code-point comparisons matching SQLite `BINARY` / PostgreSQL `COLLATE "C"` on both execution paths, and equal-distance candidates carrying the target id survive pruning so multi-kind target ids honor the documented smallest-identity tie-break.
- Documented corner: edge-kind lists large enough to exceed the bind-parameter budget (hundreds of kinds in one call) can resolve equal-weight predecessor ties differently across backends; totals are unaffected.

## Validation

- New coverage: cross-backend integration tests (min-weight vs min-hop, `direction: "both"`, missing/default weights, JSON null vs string `"null"`, fractional double-parity, temporal + pinned StoreView) and unit tests (parallel edges, zero-weight cycles, self path, direction variants, inline-fallback parity, convergence error, multi-kind target tie-break, out-of-range weight injection, option validation)

Closes #275
