### PR TITLE
fix Durable Object bind parameter budget

### DIFF
--- a/.changeset/durable-object-bind-budget.md
+++ b/.changeset/durable-object-bind-budget.md
@@ -3,6 +3,8 @@
 ---
 
 Cap SQLite-backed Durable Object statements at Cloudflare's 100-bound-parameter
-limit. The resolved `do-sqlite` execution profile now advertises the platform
-ceiling, so recorded-history capture and every capability-driven SQLite batch
-path chunk large writes before workerd rejects the query.
+limit. Structural client detection now makes platform identity authoritative
+over stale execution hints, and capability overrides cannot raise the hard
+ceiling. Recorded-history capture and every capability-driven SQLite batch path
+chunk large writes before workerd rejects the query, while SQLite literal list
+predicates use one JSON-bound parameter instead of one bind per element.

--- a/.changeset/durable-object-bind-budget.md
+++ b/.changeset/durable-object-bind-budget.md
@@ -1,0 +1,8 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Cap SQLite-backed Durable Object statements at Cloudflare's 100-bound-parameter
+limit. The resolved `do-sqlite` execution profile now advertises the platform
+ceiling, so recorded-history capture and every capability-driven SQLite batch
+path chunk large writes before workerd rejects the query.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -710,9 +710,11 @@ A store backed by `drizzle(ctx.storage)` inside a Durable Object is
 `capabilities.transactions: true` — no `executionProfile` hint needed.
 Unlike D1, Durable Objects expose an interactive storage transaction runner,
 so `store.transaction()` and `store.withTransaction()` are fully atomic.
-The same profile advertises Cloudflare's 100-bound-parameter query limit, so
-TypeGraph automatically chunks bulk writes and recorded-history flushes below
-the platform ceiling.
+The same profile advertises Cloudflare's 100-bound-parameter query limit.
+TypeGraph uses that hard ceiling for its managed write batches and
+recorded-history flushes; capability overrides may lower it but cannot raise
+it. Literal `.in()` and `.notIn()` query lists are packed into one JSON-bound
+parameter, so the list itself does not exhaust the Durable Object budget.
 
 ```typescript
 import { drizzle } from "drizzle-orm/durable-sqlite";

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -710,6 +710,9 @@ A store backed by `drizzle(ctx.storage)` inside a Durable Object is
 `capabilities.transactions: true` — no `executionProfile` hint needed.
 Unlike D1, Durable Objects expose an interactive storage transaction runner,
 so `store.transaction()` and `store.withTransaction()` are fully atomic.
+The same profile advertises Cloudflare's 100-bound-parameter query limit, so
+TypeGraph automatically chunks bulk writes and recorded-history flushes below
+the platform ceiling.
 
 ```typescript
 import { drizzle } from "drizzle-orm/durable-sqlite";

--- a/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
@@ -54,7 +54,7 @@ export type DurableObjectStorageClient = Readonly<{
   transactionSync: <Result>(run: () => Result) => Result;
 }>;
 
-export type SqliteHostedPlatform = "d1" | "durable-object";
+type SqliteHostedPlatform = "d1" | "durable-object";
 
 type SessionLike = Readonly<{
   constructor?: Readonly<{

--- a/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
@@ -37,9 +37,24 @@ type SqliteClientWithPrepare = Readonly<{
   prepare: (sqlText: string) => PreparedAllStatement;
 }>;
 
-type SqliteClientCarrier = Readonly<{
-  $client?: SqliteClientWithPrepare;
+type SqliteClientCarrier = Readonly<{ $client?: unknown }>;
+
+type DurableObjectSqlApi = Readonly<{
+  exec: (...args: readonly unknown[]) => unknown;
 }>;
+
+/**
+ * Runtime shape of the Durable Object storage client exposed as
+ * `drizzle(ctx.storage).$client`. Structural because Drizzle does not export
+ * this client type and constructor names are not stable under bundling.
+ */
+export type DurableObjectStorageClient = Readonly<{
+  sql: DurableObjectSqlApi;
+  transaction: <Result>(run: () => Promise<Result>) => Promise<Result>;
+  transactionSync: <Result>(run: () => Result) => Result;
+}>;
+
+export type SqliteHostedPlatform = "d1" | "durable-object";
 
 type SessionLike = Readonly<{
   constructor?: Readonly<{
@@ -91,6 +106,10 @@ type SqliteExecutionAdapterOptions = Readonly<{
 export type AnySqliteDatabase = BaseSQLiteDatabase<"sync" | "async", unknown>;
 
 export type SqliteExecutionProfile = Readonly<{
+  /** Hosted runtime detected independently of caller-supplied hints. */
+  hostedPlatform?: SqliteHostedPlatform;
+  /** Platform ceiling that capability overrides may lower but never raise. */
+  hardMaxBindParameters?: number;
   isSync: boolean;
   /**
    * Detected per-statement bound-parameter ceiling for this connection:
@@ -147,6 +166,47 @@ function isDurableObjectBySessionName(db: AnySqliteDatabase): boolean {
   );
 }
 
+function isDurableObjectStorageClient(
+  value: unknown,
+): value is DurableObjectStorageClient {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  const sqlApi = candidate.sql;
+  return (
+    typeof candidate.transaction === "function" &&
+    typeof candidate.transactionSync === "function" &&
+    typeof sqlApi === "object" &&
+    sqlApi !== null &&
+    typeof (sqlApi as Record<string, unknown>).exec === "function"
+  );
+}
+
+/**
+ * Returns the real Durable Object storage client when the Drizzle connection
+ * exposes its distinctive async + sync transaction runners and SQL API.
+ * Requiring the full shape avoids mistaking better-sqlite3's transaction
+ * wrapper factory for the Durable Object async runner.
+ */
+export function getDurableObjectStorageClient(
+  db: AnySqliteDatabase,
+): DurableObjectStorageClient | undefined {
+  const client = (db as SqliteClientCarrier).$client;
+  return isDurableObjectStorageClient(client) ? client : undefined;
+}
+
+function detectHostedPlatform(
+  db: AnySqliteDatabase,
+): SqliteHostedPlatform | undefined {
+  if (
+    getDurableObjectStorageClient(db) !== undefined ||
+    isDurableObjectBySessionName(db)
+  ) {
+    return "durable-object";
+  }
+  if (isD1DatabaseBySessionName(db)) return "d1";
+  return undefined;
+}
+
 function isSyncDatabaseBySessionName(db: AnySqliteDatabase): boolean {
   const sessionName = getSessionName(db);
   return (
@@ -157,22 +217,20 @@ function isSyncDatabaseBySessionName(db: AnySqliteDatabase): boolean {
 function detectSyncProfile(
   db: AnySqliteDatabase,
   profileHints: SqliteExecutionProfileHints,
+  hostedPlatform: SqliteHostedPlatform | undefined,
 ): boolean {
+  if (hostedPlatform === "durable-object") return true;
+  if (hostedPlatform === "d1") return false;
   if (profileHints.isSync !== undefined) {
     return profileHints.isSync;
   }
 
   const sessionName = getSessionName(db);
-  if (sessionName === "BetterSQLiteSession" || sessionName === "BunSQLiteSession") {
+  if (
+    sessionName === "BetterSQLiteSession" ||
+    sessionName === "BunSQLiteSession"
+  ) {
     return true;
-  }
-  // Durable Objects SQLite is synchronous (`ctx.storage` exec /
-  // `transactionSync`); detect it by name rather than the SQL probe.
-  if (isDurableObjectBySessionName(db)) {
-    return true;
-  }
-  if (sessionName === "SQLiteD1Session") {
-    return false;
   }
 
   try {
@@ -184,10 +242,14 @@ function detectSyncProfile(
 }
 
 function detectTransactionMode(
-  db: AnySqliteDatabase,
   profileHints: SqliteExecutionProfileHints,
   isSync: boolean,
+  hostedPlatform: SqliteHostedPlatform | undefined,
 ): SqliteTransactionMode {
+  // Hosted platform identity is authoritative. A stale hint must not disable
+  // Durable Object rollback or opt D1 into unsupported interactive writes.
+  if (hostedPlatform === "durable-object") return "do-sqlite";
+  if (hostedPlatform === "d1") return "none";
   if (profileHints.transactionMode !== undefined) {
     return profileHints.transactionMode;
   }
@@ -199,12 +261,6 @@ function detectTransactionMode(
   // `db.$client.transaction`) — route those through "do-sqlite" (#140).
   // D1 has no equivalent interactive runner (only batch); it stays
   // "none" pending a separate batch-mode investigation.
-  if (isDurableObjectBySessionName(db)) {
-    return "do-sqlite";
-  }
-  if (isD1DatabaseBySessionName(db)) {
-    return "none";
-  }
   if (isSync) return "sql";
   return "drizzle";
 }
@@ -252,15 +308,25 @@ function hasModernBindLimitByVersion(rows: readonly unknown[]): boolean {
  * runtime and too low wastes round trips (999 vs 32,766 is ~33× more
  * chunks per bulk insert).
  */
-function detectMaxBindParameters(
-  db: AnySqliteDatabase,
-  sqliteClient: SqliteClientWithPrepare | undefined,
+function detectHardMaxBindParameters(
   transactionMode: SqliteTransactionMode,
-): number {
-  if (transactionMode === "do-sqlite") {
+  hostedPlatform: SqliteHostedPlatform | undefined,
+): number | undefined {
+  if (
+    hostedPlatform === "durable-object" ||
+    transactionMode === "do-sqlite"
+  ) {
     return DURABLE_OBJECT_MAX_BIND_PARAMETERS;
   }
-  if (isD1DatabaseBySessionName(db)) return D1_MAX_BIND_PARAMETERS;
+  if (hostedPlatform === "d1") return D1_MAX_BIND_PARAMETERS;
+  return undefined;
+}
+
+function detectMaxBindParameters(
+  sqliteClient: SqliteClientWithPrepare | undefined,
+  hardMaxBindParameters: number | undefined,
+): number {
+  if (hardMaxBindParameters !== undefined) return hardMaxBindParameters;
   if (sqliteClient === undefined) return SQLITE_MAX_BIND_PARAMETERS;
   try {
     const compiled = parseCompiledMaxVariableNumber(
@@ -282,12 +348,11 @@ function detectMaxBindParameters(
 function resolveSqliteClient(
   db: AnySqliteDatabase,
 ): SqliteClientWithPrepare | undefined {
-  const databaseWithClient = db as SqliteClientCarrier;
-  const sqliteClient = databaseWithClient.$client;
-  if (sqliteClient?.prepare === undefined) {
-    return undefined;
-  }
-  return sqliteClient;
+  const sqliteClient = (db as SqliteClientCarrier).$client;
+  if (typeof sqliteClient !== "object" || sqliteClient === null) return;
+  const candidate = sqliteClient as Record<string, unknown>;
+  if (typeof candidate.prepare !== "function") return;
+  return sqliteClient as SqliteClientWithPrepare;
 }
 
 function getOrCreatePreparedStatement(
@@ -342,17 +407,30 @@ export function createSqliteExecutionAdapter(
     options.statementCacheMax ?? DEFAULT_PREPARED_STATEMENT_CACHE_MAX;
   const profileHints = options.profileHints ?? {};
 
-  const isSync = detectSyncProfile(db, profileHints);
+  const hostedPlatform = detectHostedPlatform(db);
+  const isSync = detectSyncProfile(db, profileHints, hostedPlatform);
   const sqliteClient = isSync ? resolveSqliteClient(db) : undefined;
-  const transactionMode = detectTransactionMode(db, profileHints, isSync);
+  const transactionMode = detectTransactionMode(
+    profileHints,
+    isSync,
+    hostedPlatform,
+  );
+  const hardMaxBindParameters = detectHardMaxBindParameters(
+    transactionMode,
+    hostedPlatform,
+  );
+  const maxBindParameters = detectMaxBindParameters(
+    sqliteClient,
+    hardMaxBindParameters,
+  );
 
   const profile: SqliteExecutionProfile = {
+    ...(hostedPlatform === undefined ? {} : { hostedPlatform }),
+    ...(hardMaxBindParameters === undefined ?
+      {}
+    : { hardMaxBindParameters }),
     isSync,
-    maxBindParameters: detectMaxBindParameters(
-      db,
-      sqliteClient,
-      transactionMode,
-    ),
+    maxBindParameters,
     supportsCompiledExecution: sqliteClient !== undefined,
     transactionMode,
   };

--- a/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/sqlite-execution.ts
@@ -3,6 +3,7 @@ import { type BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
 import {
   D1_MAX_BIND_PARAMETERS,
+  DURABLE_OBJECT_MAX_BIND_PARAMETERS,
   MODERN_SQLITE_MAX_BIND_PARAMETERS,
   SQLITE_MAX_BIND_PARAMETERS,
 } from "../../types";
@@ -93,9 +94,9 @@ export type SqliteExecutionProfile = Readonly<{
   isSync: boolean;
   /**
    * Detected per-statement bound-parameter ceiling for this connection:
-   * D1's documented cap, the probed `SQLITE_MAX_VARIABLE_NUMBER` on
-   * synchronous drivers, or the conservative 999 floor when the limit
-   * cannot be probed (async/remote drivers).
+   * Cloudflare's documented D1 / Durable Objects cap, the probed
+   * `SQLITE_MAX_VARIABLE_NUMBER` on synchronous drivers, or the conservative
+   * 999 floor when the limit cannot be probed (async/remote drivers).
    */
   maxBindParameters: number;
   supportsCompiledExecution: boolean;
@@ -254,7 +255,11 @@ function hasModernBindLimitByVersion(rows: readonly unknown[]): boolean {
 function detectMaxBindParameters(
   db: AnySqliteDatabase,
   sqliteClient: SqliteClientWithPrepare | undefined,
+  transactionMode: SqliteTransactionMode,
 ): number {
+  if (transactionMode === "do-sqlite") {
+    return DURABLE_OBJECT_MAX_BIND_PARAMETERS;
+  }
   if (isD1DatabaseBySessionName(db)) return D1_MAX_BIND_PARAMETERS;
   if (sqliteClient === undefined) return SQLITE_MAX_BIND_PARAMETERS;
   try {
@@ -343,7 +348,11 @@ export function createSqliteExecutionAdapter(
 
   const profile: SqliteExecutionProfile = {
     isSync,
-    maxBindParameters: detectMaxBindParameters(db, sqliteClient),
+    maxBindParameters: detectMaxBindParameters(
+      db,
+      sqliteClient,
+      transactionMode,
+    ),
     supportsCompiledExecution: sqliteClient !== undefined,
     transactionMode,
   };

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -86,7 +86,9 @@ import {
 import {
   type AnySqliteDatabase,
   createSqliteExecutionAdapter,
+  getDurableObjectStorageClient,
   type SqliteExecutionAdapter,
+  type SqliteExecutionProfile,
   type SqliteExecutionProfileHints,
 } from "./execution/sqlite-execution";
 import {
@@ -163,7 +165,8 @@ export type SqliteBackendOptions = Readonly<{
    * Optional execution profile hints used to avoid runtime driver reflection.
    * Set `transactionMode: "none"` for drivers without transactions (e.g.
    * Cloudflare D1). Durable Objects (`drizzle(ctx.storage)`) auto-detect
-   * `transactionMode: "do-sqlite"` and do not need a hint.
+   * `transactionMode: "do-sqlite"` and do not need a hint. Hosted platform
+   * identity is authoritative when it conflicts with a stale hint.
    */
   executionProfile?: SqliteExecutionProfileHints;
   /**
@@ -185,7 +188,8 @@ export type SqliteBackendOptions = Readonly<{
   vector?: VectorStrategy;
   /**
    * Override specific backend capabilities. Useful for custom SQLite builds
-   * or tests that need to simulate an engine-level capability gap.
+   * or tests that need to simulate an engine-level capability gap. Overrides
+   * may lower, but cannot raise, a hosted platform's hard parameter ceiling.
    */
   capabilities?: Partial<BackendCapabilities>;
 }>;
@@ -422,15 +426,6 @@ function runWithSerializedQueue<T>(
   return queue.runExclusive(task);
 }
 
-/**
- * The async storage transaction runner Drizzle's durable-sqlite driver
- * exposes as `db.$client` (`ctx.storage.transaction(async () => ...)`).
- * Structural because drizzle-orm does not export the DO `$client` type.
- */
-interface DurableObjectStorageClient {
-  transaction?: <R>(closure: () => Promise<R>) => Promise<R>;
-}
-
 /** Every SQLite "atomic transactions unavailable" refusal shares this shape. */
 function throwSqliteTransactionsDisabled(message: string): never {
   throw new ConfigurationError(message, {
@@ -469,6 +464,16 @@ function buildSqliteCapabilities(
       {}
     : { vector: buildVectorCapabilities(options.vectorStrategy) }),
   };
+}
+
+function resolveMaxBindParametersCapability(
+  profile: SqliteExecutionProfile,
+  override: number | undefined,
+): number {
+  const requested = override ?? profile.maxBindParameters;
+  return profile.hardMaxBindParameters === undefined ?
+      requested
+    : Math.min(requested, profile.hardMaxBindParameters);
 }
 
 // ============================================================
@@ -956,6 +961,7 @@ export function createSqliteBackend(
   // (`createLibsqlBackend` always; `createLocalSqliteBackend` when the
   // extension loads); absent for plain SQLite drivers with no extension.
   const vectorStrategy = options.vector;
+  const capabilityOverrides = options.capabilities ?? {};
   const capabilities = normalizeGraphAnalyticsCapabilities({
     ...buildSqliteCapabilities({
       fulltextStrategy,
@@ -963,7 +969,11 @@ export function createSqliteBackend(
       transactionMode,
       maxBindParameters: executionAdapter.profile.maxBindParameters,
     }),
-    ...options.capabilities,
+    ...capabilityOverrides,
+    maxBindParameters: resolveMaxBindParametersCapability(
+      executionAdapter.profile,
+      capabilityOverrides.maxBindParameters,
+    ),
   });
 
   const tableNames: ResolvedSqlTableNames = {
@@ -1142,18 +1152,17 @@ export function createSqliteBackend(
    * holds because `bootstrapTables` runs outside any transaction).
    */
   function runDoSqliteStorageTransaction<T>(run: () => Promise<T>): Promise<T> {
-    const storage = (db as { $client?: DurableObjectStorageClient }).$client;
-    const storageTransaction = storage?.transaction;
-    if (typeof storageTransaction !== "function") {
+    const storage = getDurableObjectStorageClient(db);
+    if (storage === undefined) {
       throwSqliteTransactionsDisabled(
         "transactionMode 'do-sqlite' requires a Drizzle Durable Objects " +
-          "database (drizzle(ctx.storage)) whose `$client` exposes the " +
-          "async storage `transaction(async () => ...)` runner.",
+          "database (drizzle(ctx.storage)) whose `$client` exposes the SQL, " +
+          "transactionSync, and async transaction runners.",
       );
     }
     return runWithSerializedQueue(
       serializedQueue,
-      async () => storageTransaction.call(storage, run) as Promise<T>,
+      () => storage.transaction(run),
     );
   }
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -202,11 +202,12 @@ export type BackendCapabilities = Readonly<{
   /**
    * Maximum number of bound parameters the engine accepts in one statement.
    * SQLite defaults to 999 (raisable at compile time via
-   * `SQLITE_MAX_VARIABLE_NUMBER`); PostgreSQL's wire protocol caps it at 65535.
+   * `SQLITE_MAX_VARIABLE_NUMBER`), while hosted SQLite runtimes may impose a
+   * lower platform ceiling; PostgreSQL's wire protocol caps it at 65535.
    * Recorded-time capture and recorded point reads size their multi-row
    * statements to this ceiling — the same budget the backend's own batched
-   * inserts use — instead of a conservative dialect-blind constant. A custom
-   * build that raises the SQLite limit can override this here. Absent means the
+   * inserts use — instead of a conservative dialect-blind constant. Custom
+   * runtimes can override the detected limit here. Absent means the
    * recorded-time fallback budget applies.
    */
   maxBindParameters?: number;
@@ -2310,6 +2311,13 @@ export const MODERN_SQLITE_MAX_BIND_PARAMETERS = 32_766;
  * batched writes fail at runtime.
  */
 export const D1_MAX_BIND_PARAMETERS = 100;
+
+/**
+ * Cloudflare SQLite-backed Durable Objects' documented per-statement
+ * bound-parameter ceiling. The resolved `do-sqlite` execution profile must
+ * advertise this limit so every capability-driven batch path stays below it.
+ */
+export const DURABLE_OBJECT_MAX_BIND_PARAMETERS = 100;
 
 /**
  * PostgreSQL's wire-protocol bound-parameter ceiling (a 16-bit count). Single

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -207,8 +207,9 @@ export type BackendCapabilities = Readonly<{
    * Recorded-time capture and recorded point reads size their multi-row
    * statements to this ceiling — the same budget the backend's own batched
    * inserts use — instead of a conservative dialect-blind constant. Custom
-   * runtimes can override the detected limit here. Absent means the
-   * recorded-time fallback budget applies.
+   * runtimes can override a detected or probed limit here, but hosted platform
+   * hard ceilings may only be lowered. Absent means the recorded-time fallback
+   * budget applies.
    */
   maxBindParameters?: number;
   /** Vector search capabilities (undefined if not configured) */

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -668,11 +668,10 @@ function compileComparisonPredicate(
     if (values.length === 0) {
       return expr.op === "in" ? sql.raw("1=0") : sql.raw("1=1");
     }
-    const placeholders = values.map(
-      (v) => sql`${convertValueForSql(v.value, dialect)}`,
+    const convertedValues = values.map((value) =>
+      convertValueForSql(value.value, dialect),
     );
-    const op = expr.op === "in" ? sql.raw("IN") : sql.raw("NOT IN");
-    return sql`${left} ${op} (${sql.join(placeholders, sql`, `)})`;
+    return dialect.inList(left, convertedValues, expr.op === "notIn");
   }
 
   // For single-value comparisons, extract the literal value

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -185,6 +185,12 @@ export const postgresDialect: DialectAdapter = {
     return sql`${left} IS NOT DISTINCT FROM ${right}`;
   },
 
+  inList(left, values, negated) {
+    const operator = negated ? sql.raw("NOT IN") : sql.raw("IN");
+    const placeholders = values.map((value) => sql`${value}`);
+    return sql`${left} ${operator} (${sql.join(placeholders, sql`, `)})`;
+  },
+
   // ============================================================
   // String Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -139,24 +139,31 @@ export const sqliteDialect: DialectAdapter = {
     if (values.length === 0) {
       return sql.raw("1=1");
     }
-
-    const conditions = values.map(
-      (value) =>
-        sql`EXISTS (SELECT 1 FROM json_each(${column}) WHERE json_each.value = ${value})`,
-    );
-    return sql`(${sql.join(conditions, sql` AND `)})`;
+    const packedValues = JSON.stringify(values);
+    return sql`
+      NOT EXISTS (
+            SELECT 1 FROM json_each(${packedValues}) AS tg_required
+            WHERE NOT EXISTS (
+              SELECT 1 FROM json_each(${column}) AS tg_actual
+              WHERE tg_actual.value = tg_required.value
+            )
+          )
+    `;
   },
 
   jsonArrayContainsAny(column, values) {
     if (values.length === 0) {
       return sql.raw("1=0");
     }
-
-    const conditions = values.map(
-      (value) =>
-        sql`EXISTS (SELECT 1 FROM json_each(${column}) WHERE json_each.value = ${value})`,
-    );
-    return sql`(${sql.join(conditions, sql` OR `)})`;
+    const packedValues = JSON.stringify(values);
+    return sql`
+      EXISTS (
+            SELECT 1
+            FROM json_each(${column}) AS tg_actual
+            JOIN json_each(${packedValues}) AS tg_wanted
+              ON tg_actual.value = tg_wanted.value
+          )
+    `;
   },
 
   // ============================================================
@@ -188,6 +195,12 @@ export const sqliteDialect: DialectAdapter = {
     // SQLite's IS operator is null-safe equality (equivalent to = for
     // non-null operands, TRUE when both sides are NULL).
     return sql`${left} IS ${right}`;
+  },
+
+  inList(left, values, negated) {
+    const operator = negated ? sql.raw("NOT IN") : sql.raw("IN");
+    const packedValues = JSON.stringify(values);
+    return sql`${left} ${operator} (SELECT value FROM json_each(${packedValues}))`;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -273,6 +273,16 @@ export interface DialectAdapter {
    */
   nullSafeEquals(left: SQL, right: SQL): SQL;
 
+  /**
+   * Tests scalar membership in a literal list. Dialects may choose a packed
+   * representation to keep the statement's bound-parameter count constant.
+   *
+   * @example
+   * SQLite: left IN (SELECT value FROM json_each(?))
+   * PostgreSQL: left IN ($1, $2, ...)
+   */
+  inList(left: SQL, values: readonly unknown[], negated: boolean): SQL;
+
   // ============================================================
   // String Operations
   // ============================================================

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -87,6 +87,23 @@ export function registerPredicateIntegrationTests(
       expect(results.toSorted()).toEqual(["Alice", "Charlie"]);
     });
 
+    it("executes an IN predicate larger than Durable Objects' bind limit", async () => {
+      const store = context.getStore();
+      const names = [
+        ...Array.from({ length: 150 }, (_, index) => `missing-${index}`),
+        "Alice",
+        "Charlie",
+      ];
+      const results = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.in(names))
+        .select((ctx) => ctx.p.name)
+        .execute();
+
+      expect(results.toSorted()).toEqual(["Alice", "Charlie"]);
+    });
+
     it("executes IN predicate with empty array (returns no results)", async () => {
       const store = context.getStore();
       const results = await store

--- a/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
@@ -13,14 +13,18 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { createStore, defineGraph, defineNode } from "../../../src";
-import { computeSqliteBatchChunkSizes } from "../../../src/backend/drizzle/sqlite";
+import {
+  computeSqliteBatchChunkSizes,
+  createSqliteBackend,
+} from "../../../src/backend/drizzle/sqlite";
 import { createLibsqlBackend } from "../../../src/backend/sqlite/libsql";
 import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
 import {
+  DURABLE_OBJECT_MAX_BIND_PARAMETERS,
   SQLITE_MAX_BIND_PARAMETERS,
   wrapWithManagedClose,
 } from "../../../src/backend/types";
-import { createTestBackend } from "../../test-utils";
+import { createTestBackend, createTestDatabase } from "../../test-utils";
 
 const MODERN_BETTER_SQLITE3_BUDGET = 32_766;
 
@@ -77,6 +81,17 @@ describe("SQLite bind-parameter budget detection", () => {
     } finally {
       await backend.close();
     }
+  });
+
+  it("caps an explicit do-sqlite profile in the default unit-test lane", () => {
+    const backend = createSqliteBackend(createTestDatabase(), {
+      capabilities: { maxBindParameters: 999 },
+      executionProfile: { transactionMode: "do-sqlite" },
+    });
+
+    expect(backend.capabilities.maxBindParameters).toBe(
+      DURABLE_OBJECT_MAX_BIND_PARAMETERS,
+    );
   });
 
   it("bulk-creates beyond the historic 999-parameter budget in one call", async () => {

--- a/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/sqlite-backend.test.ts
@@ -562,6 +562,20 @@ describe("SQLite Backend - Transaction Modes", () => {
       /cannot return a promise/i,
     );
   });
+
+  it("rejects do-sqlite mode when the client is not Durable Object storage", async () => {
+    const backend = createSqliteBackend(db, {
+      executionProfile: { transactionMode: "do-sqlite" },
+    });
+
+    await expect(
+      backend.transaction(() =>
+        Promise.reject(new Error("transaction body must not run")),
+      ),
+    ).rejects.toThrow(
+      /exposes the SQL, transactionSync, and async transaction/u,
+    );
+  });
 });
 
 // ============================================================

--- a/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
+++ b/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
@@ -38,6 +38,8 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  asEdgeId,
+  createStore,
   createStoreWithSchema,
   defineEdge,
   defineGraph,
@@ -46,6 +48,7 @@ import {
 import { createSqliteBackend } from "../../src/backend/drizzle/sqlite";
 import { tables as defaultTables } from "../../src/backend/sqlite";
 import { DURABLE_OBJECT_MAX_BIND_PARAMETERS } from "../../src/backend/types";
+import { RECORDED_EDGE_COLUMNS } from "../../src/store/recorded-capture";
 
 import { SpikeDO } from "./worker";
 
@@ -92,6 +95,12 @@ const HistoryGraph = defineGraph({
     },
   },
 });
+
+// Exercise several chunks, with enough margin that a modest reduction in
+// recorded columns cannot make the pre-fix single statement fit accidentally.
+const RECORDED_EDGE_COUNT_EXCEEDING_ONE_STATEMENT =
+  Math.ceil(DURABLE_OBJECT_MAX_BIND_PARAMETERS / RECORDED_EDGE_COLUMNS.length) *
+  4;
 
 async function bootInsideDurableObject(storage: DurableObjectStorage) {
   // No executionProfile hint: detection must classify drizzle(ctx.storage)
@@ -150,6 +159,47 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
       expect(backend.capabilities.maxBindParameters).toBe(
         DURABLE_OBJECT_MAX_BIND_PARAMETERS,
       );
+
+      const staleHintBackend = createSqliteBackend(db, {
+        capabilities: { maxBindParameters: 999 },
+        executionProfile: { isSync: false, transactionMode: "none" },
+        tables: defaultTables,
+      });
+      expect(staleHintBackend.capabilities.transactions).toBe(true);
+      expect(staleHintBackend.capabilities.maxBindParameters).toBe(
+        DURABLE_OBJECT_MAX_BIND_PARAMETERS,
+      );
+      const staleHintStore = createStore(DocGraph, staleHintBackend);
+      await expect(
+        staleHintStore.transaction(async (tx) => {
+          await tx.nodes.Doc.create({ title: "must-roll-back" });
+          throw new Error("stale-hint-rollback");
+        }),
+      ).rejects.toThrow("stale-hint-rollback");
+      expect(await staleHintStore.nodes.Doc.count()).toBe(0);
+    });
+  });
+
+  it("packs a literal IN list larger than the platform bind limit", async () => {
+    await inObject("large-in-list", async ({ store }) => {
+      await store.nodes.Doc.create({ title: "included" });
+      await store.nodes.Doc.create({ title: "excluded" });
+      const titles = [
+        ...Array.from(
+          { length: DURABLE_OBJECT_MAX_BIND_PARAMETERS + 1 },
+          (_, index) => `missing-${index}`,
+        ),
+        "included",
+      ];
+
+      const results = await store
+        .query()
+        .from("Doc", "doc")
+        .whereNode("doc", (doc) => doc.title.in(titles))
+        .select((ctx) => ctx.doc.title)
+        .execute();
+
+      expect(results).toEqual(["included"]);
     });
   });
 
@@ -167,7 +217,11 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
             { text: "hello" },
             { id: "message" },
           );
-          for (let index = 0; index < 7; index += 1) {
+          for (
+            let index = 0;
+            index < RECORDED_EDGE_COUNT_EXCEEDING_ONE_STATEMENT;
+            index += 1
+          ) {
             const person = await tx.nodes.Person.create(
               { name: `person-${index}` },
               { id: `person-${index}` },
@@ -183,18 +237,26 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
           }
         });
 
-        expect(await store.nodes.Person.count()).toBe(7);
-        expect(await store.edges.mentions.count()).toBe(7);
+        expect(await store.nodes.Person.count()).toBe(
+          RECORDED_EDGE_COUNT_EXCEEDING_ONE_STATEMENT,
+        );
+        expect(await store.edges.mentions.count()).toBe(
+          RECORDED_EDGE_COUNT_EXCEEDING_ONE_STATEMENT,
+        );
         const recordedAt = await store.recordedNow();
         expect(recordedAt).toBeDefined();
         if (recordedAt === undefined) {
           throw new Error("expected a recorded commit instant");
         }
         const recordedEdges = await Promise.all(
-          Array.from({ length: 7 }, (_, index) =>
-            store
-              .asOfRecorded(recordedAt)
-              .edges.mentions.getById(`mention-${index}` as never),
+          Array.from(
+            { length: RECORDED_EDGE_COUNT_EXCEEDING_ONE_STATEMENT },
+            (_, index) =>
+              store
+                .asOfRecorded(recordedAt)
+                .edges.mentions.getById(
+                  asEdgeId<typeof mentions>(`mention-${index}`),
+                ),
           ),
         );
         expect(recordedEdges.every((edge) => edge !== undefined)).toBe(true);

--- a/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
+++ b/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
@@ -37,9 +37,15 @@ import {
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "../../src";
 import { createSqliteBackend } from "../../src/backend/drizzle/sqlite";
 import { tables as defaultTables } from "../../src/backend/sqlite";
+import { DURABLE_OBJECT_MAX_BIND_PARAMETERS } from "../../src/backend/types";
 
 import { SpikeDO } from "./worker";
 
@@ -62,6 +68,29 @@ const DocGraph = defineGraph({
   id: "do-sqlite",
   nodes: { Doc: { type: Doc } },
   edges: {},
+});
+
+const Message = defineNode("Message", {
+  schema: z.object({ text: z.string() }),
+});
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const mentions = defineEdge("mentions");
+
+const HistoryGraph = defineGraph({
+  id: "do-sqlite-history",
+  nodes: { Message: { type: Message }, Person: { type: Person } },
+  edges: {
+    mentions: {
+      type: mentions,
+      from: [Message],
+      to: [Person],
+      cardinality: "many",
+    },
+  },
 });
 
 async function bootInsideDurableObject(storage: DurableObjectStorage) {
@@ -88,6 +117,15 @@ async function bootInsideDurableObject(storage: DurableObjectStorage) {
   return { db, backend, store };
 }
 
+async function bootHistoryInsideDurableObject(storage: DurableObjectStorage) {
+  const db = drizzle(storage);
+  const backend = createSqliteBackend(db, { tables: defaultTables });
+  const [store] = await createStoreWithSchema(HistoryGraph, backend, {
+    history: true,
+  });
+  return store;
+}
+
 function inObject<T>(
   name: string,
   body: (
@@ -109,7 +147,59 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
       expect(db.$client).toBe(storage);
       expect(typeof storage.transaction).toBe("function");
       expect(backend.capabilities.transactions).toBe(true);
+      expect(backend.capabilities.maxBindParameters).toBe(
+        DURABLE_OBJECT_MAX_BIND_PARAMETERS,
+      );
     });
+  });
+
+  it("chunks recorded history flushes to Durable Objects' 100-bind limit", async () => {
+    const stub = env.SPIKE_DO.get(
+      env.SPIKE_DO.idFromName("history-bind-limit"),
+    );
+    await runInDurableObject(
+      stub,
+      async (_instance: SpikeDO, state: DurableObjectState) => {
+        const store = await bootHistoryInsideDurableObject(state.storage);
+
+        await store.transaction(async (tx) => {
+          const message = await tx.nodes.Message.create(
+            { text: "hello" },
+            { id: "message" },
+          );
+          for (let index = 0; index < 7; index += 1) {
+            const person = await tx.nodes.Person.create(
+              { name: `person-${index}` },
+              { id: `person-${index}` },
+            );
+            await tx.edges.mentions.create(
+              message,
+              person,
+              {},
+              {
+                id: `mention-${index}`,
+              },
+            );
+          }
+        });
+
+        expect(await store.nodes.Person.count()).toBe(7);
+        expect(await store.edges.mentions.count()).toBe(7);
+        const recordedAt = await store.recordedNow();
+        expect(recordedAt).toBeDefined();
+        if (recordedAt === undefined) {
+          throw new Error("expected a recorded commit instant");
+        }
+        const recordedEdges = await Promise.all(
+          Array.from({ length: 7 }, (_, index) =>
+            store
+              .asOfRecorded(recordedAt)
+              .edges.mentions.getById(`mention-${index}` as never),
+          ),
+        );
+        expect(recordedEdges.every((edge) => edge !== undefined)).toBe(true);
+      },
+    );
   });
 
   it("A) graph-owned store.transaction(): throw-after-await rolls back BOTH TypeGraph and product writes", async () => {

--- a/packages/typegraph/tests/execution-adapter.test.ts
+++ b/packages/typegraph/tests/execution-adapter.test.ts
@@ -6,7 +6,14 @@ import {
   createPostgresExecutionAdapter,
   resetStatementNameCacheForTests,
 } from "../src/backend/drizzle/execution/postgres-execution";
-import { createSqliteExecutionAdapter } from "../src/backend/drizzle/execution/sqlite-execution";
+import {
+  type AnySqliteDatabase,
+  createSqliteExecutionAdapter,
+} from "../src/backend/drizzle/execution/sqlite-execution";
+import {
+  D1_MAX_BIND_PARAMETERS,
+  DURABLE_OBJECT_MAX_BIND_PARAMETERS,
+} from "../src/backend/types";
 import { createTestDatabase } from "./test-utils";
 
 describe("sqlite execution adapter", () => {
@@ -174,6 +181,45 @@ describe("sqlite execution adapter", () => {
         profileHints: { isSync: false },
       });
       expect(adapter.profile.transactionMode).toBe("drizzle");
+    });
+
+    it("uses the structural Durable Object client despite minified names and stale hints", () => {
+      const db = {
+        $client: {
+          sql: { exec: vi.fn() },
+          transaction: <Result>(run: () => Promise<Result>) => run(),
+          transactionSync: <Result>(run: () => Result) => run(),
+        },
+        session: { constructor: { name: "a" } },
+      } as unknown as AnySqliteDatabase;
+      const adapter = createSqliteExecutionAdapter(db, {
+        profileHints: { isSync: false, transactionMode: "none" },
+      });
+
+      expect(adapter.profile).toMatchObject({
+        hardMaxBindParameters: DURABLE_OBJECT_MAX_BIND_PARAMETERS,
+        hostedPlatform: "durable-object",
+        isSync: true,
+        maxBindParameters: DURABLE_OBJECT_MAX_BIND_PARAMETERS,
+        transactionMode: "do-sqlite",
+      });
+    });
+
+    it("keeps detected D1 limits and transaction mode authoritative", () => {
+      const db = {
+        session: { constructor: { name: "SQLiteD1Session" } },
+      } as unknown as AnySqliteDatabase;
+      const adapter = createSqliteExecutionAdapter(db, {
+        profileHints: { isSync: true, transactionMode: "drizzle" },
+      });
+
+      expect(adapter.profile).toMatchObject({
+        hardMaxBindParameters: D1_MAX_BIND_PARAMETERS,
+        hostedPlatform: "d1",
+        isSync: false,
+        maxBindParameters: D1_MAX_BIND_PARAMETERS,
+        transactionMode: "none",
+      });
     });
   });
 });

--- a/packages/typegraph/tests/predicate-compiler.test.ts
+++ b/packages/typegraph/tests/predicate-compiler.test.ts
@@ -30,7 +30,7 @@ import { DEFAULT_SQL_SCHEMA } from "../src/query/compiler/schema";
 import { postgresDialect } from "../src/query/dialect/postgres";
 import { sqliteDialect } from "../src/query/dialect/sqlite";
 import { type JsonPointer } from "../src/query/json-pointer";
-import { toSqlString } from "./sql-test-utils";
+import { toSqlString, toSqlWithParams } from "./sql-test-utils";
 
 // ============================================================
 // Test Helpers
@@ -399,6 +399,22 @@ describe("comparison predicates", () => {
       };
       const result = compilePredicateExpression(expr, ctx);
       expect(toSqlString(result)).toContain("IN");
+    });
+
+    it("packs a large SQLite IN list into one bound parameter", () => {
+      const values = Array.from({ length: 150 }, (_, index) => `id-${index}`);
+      const expr: ComparisonPredicate = {
+        __type: "comparison",
+        op: "in",
+        left: field("p", ["id"]),
+        right: values.map((value) => literal(value)),
+      };
+
+      const result = compilePredicateExpression(expr, ctx);
+      const compiled = toSqlWithParams(result);
+
+      expect(compiled.sql).toContain("json_each(?)");
+      expect(compiled.params).toEqual([JSON.stringify(values)]);
     });
 
     it("compiles notIn with multiple values", () => {
@@ -926,9 +942,10 @@ describe("array predicates", () => {
       values: [literal("a"), literal("b"), literal("c")],
     };
     const result = compilePredicateExpression(expr, ctx);
-    const sqlString = toSqlString(result);
-    expect(sqlString).toContain("AND");
-    expect(sqlString).toContain("json_each");
+    const compiled = toSqlWithParams(result);
+    expect(compiled.sql).toContain("NOT EXISTS");
+    expect(compiled.sql).toContain("json_each");
+    expect(compiled.params).toEqual([JSON.stringify(["a", "b", "c"])]);
   });
 
   it("compiles containsAll with empty values as true", () => {
@@ -950,9 +967,10 @@ describe("array predicates", () => {
       values: [literal("x"), literal("y")],
     };
     const result = compilePredicateExpression(expr, ctx);
-    const sqlString = toSqlString(result);
-    expect(sqlString).toContain("OR");
-    expect(sqlString).toContain("json_each");
+    const compiled = toSqlWithParams(result);
+    expect(compiled.sql).toContain("JOIN");
+    expect(compiled.sql).toContain("json_each");
+    expect(compiled.params).toEqual([JSON.stringify(["x", "y"])]);
   });
 
   it("compiles containsAny with empty values as false", () => {


### PR DESCRIPTION
Fixes #287.

## Root cause

TypeGraph treated Cloudflare's 100-bound-parameter ceiling as a soft, inferred capability. Durable Object identity depended on Drizzle's session constructor name and could be overridden by stale execution hints, while a caller-provided capability could raise the platform limit. Bulk writes and recorded-history capture therefore chunked against an invalid budget. Query-side literal lists also bound one parameter per element and bypassed the write-batching protections entirely.

## Changes

- Detect `drizzle(ctx.storage)` structurally from the Durable Object storage client, so minified constructor names remain safe.
- Make hosted platform identity authoritative over stale `isSync` and `transactionMode` hints.
- Model Cloudflare's 100-parameter limit as a hard ceiling: capability overrides may lower it but cannot raise it.
- Reject `do-sqlite` transaction mode unless the client exposes the Durable Object SQL, synchronous transaction, and asynchronous transaction APIs. This prevents better-sqlite3's wrapper factory from being mistaken for a transaction runner.
- Route literal `.in()` / `.notIn()` compilation through the dialect adapter. SQLite packs lists into one JSON-bound parameter via `json_each(?)`; PostgreSQL keeps its native placeholder list.
- Pack SQLite JSON-array `containsAll` / `containsAny` values into one bound JSON array for the same budget guarantee.
- Strengthen the workerd recorded-history regression by deriving its row count from the actual recorded-edge column count with several budget widths of margin.
- Replace the unsafe edge-ID cast with `asEdgeId()`.
- Document the hard ceiling and query-list behavior, and expand the patch changeset.

## Architecture

The query compiler remains a single shared path. The only dialect difference is the token-level `DialectAdapter.inList` seam, which preserves PostgreSQL behavior and gives SQLite constant bind usage without query splitting, so ordering, limits, and transaction semantics remain intact.

The execution profile now distinguishes detected hosted platform identity, a hard platform ceiling, and the effective bind budget. That separation prevents user configuration from weakening an externally imposed limit while preserving lower custom budgets.

## Validation

- `pnpm fix && pnpm typecheck && pnpm test` — 5,079 passed, 1,066 skipped
- `pnpm test:postgres` — 2,096 passed
- `pnpm --filter @nicia-ai/typegraph test:do` — 10 passed
- Focused SQLite/compiler adapter suite — 628 passed
