### PR TITLE
fix(query): type-based JSON null predicates on PostgreSQL

### DIFF
--- a/.changeset/json-null-predicate-parity.md
+++ b/.changeset/json-null-predicate-parity.md
@@ -1,0 +1,15 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix PostgreSQL pointer-level `pathIsNull()` / `pathIsNotNull()` predicates
+misclassifying two stored value shapes. The previous text-comparison form
+(`#>> path = 'null'`) went three-valued on a stored JSON `null` — so
+`pathIsNull()` silently failed to match those rows on PostgreSQL while
+matching them on SQLite — and misread the JSON *string* `"null"` as null,
+falsely matching it with `pathIsNull()` and excluding it from
+`pathIsNotNull()`. Both predicates are now type-based (`jsonb_typeof`) and
+never SQL NULL, converging on SQLite's (correct) semantics. Field-level
+`isNull()` / `isNotNull()` predicates were already correct and are unchanged.
+Behavior change on PostgreSQL for affected data: rows holding a JSON `null`
+now match `pathIsNull()`, and rows holding the string `"null"` no longer do.

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -191,8 +191,13 @@ export const postgresDialect: DialectAdapter = {
 
   jsonPathIsNull(column, pointer) {
     const path = toPostgresPath(pointer);
-    // Check both SQL NULL and JSON null literal
-    return sql`(${column} #> ${path} IS NULL OR ${column} #>> ${path} = 'null')`;
+    // Type-based, not the `#>> path = 'null'` text comparison this used to
+    // be: `#>>` renders a JSON null as SQL NULL (making the old form
+    // three-valued, so `.pathIsNull()` silently missed stored JSON nulls) and
+    // renders the JSON *string* "null" as the same text 'null' (falsely
+    // matching it). jsonb_typeof distinguishes both, and COALESCE maps a
+    // missing path to TRUE, keeping the predicate two-valued.
+    return sql`COALESCE(jsonb_typeof(${column} #> ${path}) = 'null', TRUE)`;
   },
 
   jsonPathIsNumber(column, pointer) {
@@ -202,18 +207,10 @@ export const postgresDialect: DialectAdapter = {
     return sql`COALESCE(jsonb_typeof(${column} #> ${path}) = 'number', FALSE)`;
   },
 
-  jsonPathIsMissingOrNull(column, pointer) {
-    const path = toPostgresPath(pointer);
-    // Type-based: a JSON string "null" is a string, not null (the `#>>`
-    // text comparison in jsonPathIsNull cannot tell them apart), and
-    // jsonb_typeof of a JSON null is 'null' rather than SQL NULL, so this
-    // stays two-valued where `column #> path IS NULL` would not.
-    return sql`COALESCE(jsonb_typeof(${column} #> ${path}) = 'null', TRUE)`;
-  },
-
   jsonPathIsNotNull(column, pointer) {
     const path = toPostgresPath(pointer);
-    return sql`(${column} #> ${path} IS NOT NULL AND ${column} #>> ${path} != 'null')`;
+    // Mirror image of jsonPathIsNull; COALESCE maps a missing path to FALSE.
+    return sql`COALESCE(jsonb_typeof(${column} #> ${path}) <> 'null', FALSE)`;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -178,7 +178,7 @@ export const sqliteDialect: DialectAdapter = {
   jsonPathIsNull(column, pointer) {
     const path = toSqlitePath(pointer);
     const pathSql = sql.raw(escapeSqliteLiteral(path));
-    return sql`(json_extract(${column}, ${pathSql}) IS NULL OR json_type(${column}, ${pathSql}) = 'null')`;
+    return sql`COALESCE(json_type(${column}, ${pathSql}) = 'null', 1)`;
   },
 
   jsonPathIsNumber(column, pointer) {
@@ -189,18 +189,10 @@ export const sqliteDialect: DialectAdapter = {
     return sql`COALESCE(json_type(${column}, ${pathSql}) IN ('integer', 'real'), 0)`;
   },
 
-  jsonPathIsMissingOrNull(column, pointer) {
-    const path = toSqlitePath(pointer);
-    const pathSql = sql.raw(escapeSqliteLiteral(path));
-    // Type-based: a JSON string "null" is a string, not null. json_type
-    // returns NULL for a missing path, which COALESCE maps to TRUE.
-    return sql`COALESCE(json_type(${column}, ${pathSql}) = 'null', 1)`;
-  },
-
   jsonPathIsNotNull(column, pointer) {
     const path = toSqlitePath(pointer);
     const pathSql = sql.raw(escapeSqliteLiteral(path));
-    return sql`(json_extract(${column}, ${pathSql}) IS NOT NULL AND json_type(${column}, ${pathSql}) != 'null')`;
+    return sql`COALESCE(json_type(${column}, ${pathSql}) <> 'null', 0)`;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -256,16 +256,23 @@ export interface DialectAdapter {
   jsonHasPath(column: SQL, pointer: JsonPointer): SQL;
 
   /**
-   * Checks if a JSON value at a path is SQL NULL or JSON null.
+   * Checks if a JSON value at a path is absent or the JSON `null` literal —
+   * i.e. carries no usable value.
+   *
+   * The check is type-based (`json_type` / `jsonb_typeof`): a JSON *string*
+   * `"null"` is a string, not null. Never evaluates to SQL NULL — a missing
+   * path yields TRUE — so the predicate composes safely under NOT/OR.
    *
    * @example
-   * SQLite: json_extract(column, '$.path') IS NULL OR json_type(column, '$.path') = 'null'
-   * PostgreSQL: column #> path IS NULL OR column #>> path = 'null'
+   * SQLite: COALESCE(json_type(column, '$.path') = 'null', 1)
+   * PostgreSQL: COALESCE(jsonb_typeof(column #> path) = 'null', TRUE)
    */
   jsonPathIsNull(column: SQL, pointer: JsonPointer): SQL;
 
   /**
-   * Checks if a JSON value at a path is not null (neither SQL NULL nor JSON null).
+   * Checks if a JSON value at a path is present and not the JSON `null`
+   * literal. Exact negation of {@link jsonPathIsNull}: type-based, and
+   * never SQL NULL — a missing path yields FALSE.
    */
   jsonPathIsNotNull(column: SQL, pointer: JsonPointer): SQL;
 
@@ -280,21 +287,6 @@ export interface DialectAdapter {
    * PostgreSQL: jsonb_typeof(column #> path) = 'number'
    */
   jsonPathIsNumber(column: SQL, pointer: JsonPointer): SQL;
-
-  /**
-   * Checks if the JSON value at a path is absent or the JSON `null`
-   * literal — i.e. carries no usable value.
-   *
-   * Unlike {@link jsonPathIsNull}, this predicate is type-based
-   * (`json_type` / `jsonb_typeof`), so a JSON *string* `"null"` is NOT
-   * treated as null, and it never evaluates to SQL NULL — a missing path
-   * yields TRUE — so it composes safely inside audit-style WHERE clauses.
-   *
-   * @example
-   * SQLite: COALESCE(json_type(column, '$.path') = 'null', 1)
-   * PostgreSQL: COALESCE(jsonb_typeof(column #> path) = 'null', TRUE)
-   */
-  jsonPathIsMissingOrNull(column: SQL, pointer: JsonPointer): SQL;
 
   // ============================================================
   // Comparison Operations

--- a/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
@@ -220,11 +220,10 @@ async function assertValidEdgeWeights(
   // the checks directly over `e.props` would re-parse the JSON payload for
   // every predicate branch on the audit's full edge scan.
   //
-  // Both type predicates are the never-NULL, type-based dialect members —
-  // jsonPathIsNull's PostgreSQL text-comparison form would misclassify a
-  // JSON string "null" as null and go three-valued on a JSON null.
+  // Both type predicates are never-NULL by contract, so the multi-branch
+  // violation predicate below stays two-valued.
   const isNumber = dialect.jsonPathIsNumber(propsColumn, pointer);
-  const isMissing = dialect.jsonPathIsMissingOrNull(propsColumn, pointer);
+  const isMissing = dialect.jsonPathIsNull(propsColumn, pointer);
   const weightText = dialect.jsonExtractText(propsColumn, pointer);
   // CASE keeps the numeric extraction unreachable for non-numeric values:
   // PostgreSQL does not short-circuit OR/AND, and casting arbitrary text

--- a/packages/typegraph/tests/backends/integration/fixtures.ts
+++ b/packages/typegraph/tests/backends/integration/fixtures.ts
@@ -51,6 +51,8 @@ const Document = defineNode("Document", {
     metadata: z
       .object({
         author: z.string().optional(),
+        // Nullable so pointer-predicate tests can pin the JSON-null case.
+        reviewer: z.string().nullable().optional(),
         version: z.number().optional(),
         flags: z
           .object({

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { param as parameter } from "../../../src";
+import { type IntegrationStore } from "./fixtures";
 import {
   seedDocumentsForArrayPredicates,
   seedDocumentsForObjectPredicates,
@@ -8,6 +9,27 @@ import {
   seedPeopleForStringPredicates,
 } from "./seed-helpers";
 import { type IntegrationTestContext } from "./test-context";
+
+/**
+ * Seeds the three shapes a "nullish-looking" property can take in stored
+ * JSON: absent, the JSON null literal, and the JSON *string* "null".
+ * isNull must match the first two and NOT the third; isNotNull is the exact
+ * complement.
+ */
+async function seedNullShapeEdges(store: IntegrationStore): Promise<void> {
+  const anna = await store.nodes.Person.create({ name: "ShapeAnna" });
+  const missing = await store.nodes.Person.create({ name: "ShapeMissing" });
+  const jsonNull = await store.nodes.Person.create({ name: "ShapeJsonNull" });
+  const stringNull = await store.nodes.Person.create({
+    name: "ShapeStringNull",
+  });
+  const numeric = await store.nodes.Person.create({ name: "ShapeNumeric" });
+  await store.edges.knows.create(anna, missing, {});
+  // eslint-disable-next-line unicorn/no-null -- the JSON null value is the case under test
+  await store.edges.knows.create(anna, jsonNull, { weight: null });
+  await store.edges.knows.create(anna, stringNull, { since: "null" });
+  await store.edges.knows.create(anna, numeric, { weight: 7 });
+}
 
 export function registerPredicateIntegrationTests(
   context: IntegrationTestContext,
@@ -136,6 +158,115 @@ export function registerPredicateIntegrationTests(
 
       expect(results).toHaveLength(3);
       expect(results.toSorted()).toEqual(["Alice", "Bob", "Charlie"]);
+    });
+  });
+
+  describe("Null predicates across stored value shapes", () => {
+    it('isNull matches absent and JSON-null values but not the string "null"', async () => {
+      const store = context.getStore();
+      await seedNullShapeEdges(store);
+
+      const nullWeights = await store
+        .query()
+        .from("Person", "p")
+        .traverse("knows", "e")
+        .whereEdge("e", (edge) => edge.weight.isNull())
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.name)
+        .execute();
+      expect(nullWeights.toSorted()).toEqual([
+        "ShapeJsonNull",
+        "ShapeMissing",
+        "ShapeStringNull",
+      ]);
+
+      const nullSince = await store
+        .query()
+        .from("Person", "p")
+        .traverse("knows", "e")
+        .whereEdge("e", (edge) => edge.since.isNull())
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.name)
+        .execute();
+      // "ShapeStringNull" stores the string "null" in `since` — a real
+      // value, so isNull must not match it.
+      expect(nullSince.toSorted()).toEqual([
+        "ShapeJsonNull",
+        "ShapeMissing",
+        "ShapeNumeric",
+      ]);
+    });
+
+    it("isNotNull is the exact complement across value shapes", async () => {
+      const store = context.getStore();
+      await seedNullShapeEdges(store);
+
+      const presentWeights = await store
+        .query()
+        .from("Person", "p")
+        .traverse("knows", "e")
+        .whereEdge("e", (edge) => edge.weight.isNotNull())
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.name)
+        .execute();
+      expect(presentWeights).toEqual(["ShapeNumeric"]);
+
+      const presentSince = await store
+        .query()
+        .from("Person", "p")
+        .traverse("knows", "e")
+        .whereEdge("e", (edge) => edge.since.isNotNull())
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.name)
+        .execute();
+      expect(presentSince).toEqual(["ShapeStringNull"]);
+    });
+
+    it('pathIsNull / pathIsNotNull distinguish JSON null from the string "null"', async () => {
+      // Regression for the PostgreSQL jsonPathIsNull dialect member, whose
+      // former `#>> path = 'null'` text comparison went three-valued on a
+      // stored JSON null (silently unmatched) and falsely matched the JSON
+      // *string* "null".
+      const store = context.getStore();
+      await store.nodes.Document.create({
+        title: "Reviewer JSON Null",
+        // eslint-disable-next-line unicorn/no-null -- the JSON null value is the case under test
+        metadata: { reviewer: null },
+      });
+      await store.nodes.Document.create({
+        title: "Reviewer String Null",
+        metadata: { reviewer: "null" },
+      });
+      await store.nodes.Document.create({
+        title: "Reviewer Missing",
+        metadata: {},
+      });
+      await store.nodes.Document.create({
+        title: "Reviewer Present",
+        metadata: { reviewer: "Ada" },
+      });
+
+      const nullish = await store
+        .query()
+        .from("Document", "d")
+        .whereNode("d", (d) => d.metadata.pathIsNull("/reviewer"))
+        .select((ctx) => ctx.d.title)
+        .execute();
+      expect(nullish.toSorted()).toEqual([
+        "Reviewer JSON Null",
+        "Reviewer Missing",
+      ]);
+
+      const present = await store
+        .query()
+        .from("Document", "d")
+        .whereNode("d", (d) => d.metadata.pathIsNotNull("/reviewer"))
+        .select((ctx) => ctx.d.title)
+        .execute();
+      expect(present.toSorted()).toEqual([
+        "Reviewer Present",
+        "Reviewer String Null",
+      ]);
     });
   });
 

--- a/packages/typegraph/tests/predicate-compiler.test.ts
+++ b/packages/typegraph/tests/predicate-compiler.test.ts
@@ -1073,7 +1073,7 @@ describe("object predicates", () => {
     );
   });
 
-  it("compiles pathIsNull", () => {
+  it("compiles pathIsNull as a type-only null check", () => {
     const expr: ObjectPredicate = {
       __type: "object_op",
       op: "pathIsNull",
@@ -1082,10 +1082,13 @@ describe("object predicates", () => {
     };
     const result = compilePredicateExpression(expr, ctx);
     const sqlString = toSqlString(result);
-    expect(sqlString).toContain("IS NULL");
+    expect(sqlString).toContain("COALESCE");
+    expect(sqlString).toContain("json_type");
+    expect(sqlString).toContain("= 'null'");
+    expect(sqlString).not.toContain("json_extract");
   });
 
-  it("compiles pathIsNotNull", () => {
+  it("compiles pathIsNotNull as the type-only complement", () => {
     const expr: ObjectPredicate = {
       __type: "object_op",
       op: "pathIsNotNull",
@@ -1094,7 +1097,10 @@ describe("object predicates", () => {
     };
     const result = compilePredicateExpression(expr, ctx);
     const sqlString = toSqlString(result);
-    expect(sqlString).toContain("IS NOT NULL");
+    expect(sqlString).toContain("COALESCE");
+    expect(sqlString).toContain("json_type");
+    expect(sqlString).toContain("<> 'null'");
+    expect(sqlString).not.toContain("json_extract");
   });
 });
 


### PR DESCRIPTION
**Stacked on #288** (base branch is `feat/weighted-shortest-path`; retarget/merge after #288 lands). Fixes the pre-existing PostgreSQL dialect bug that #288's weight-audit work exposed.

## The bug

`pathIsNull()` / `pathIsNotNull()` — the pointer-level object predicates — compiled on PostgreSQL to a text comparison:

```sql
(column #> path IS NULL OR column #>> path = 'null')
```

which fails in both directions:

- **Stored JSON `null`**: `#>` returns jsonb `'null'` (not SQL NULL) and `#>>` returns SQL NULL, so the predicate evaluates to `FALSE OR NULL = NULL` — three-valued, treated as no-match. `pathIsNull()` silently missed rows holding JSON `null` on PostgreSQL while matching them on SQLite.
- **Stored JSON string `"null"`**: `#>>` renders it as the text `null`, so `pathIsNull()` falsely matched a real string value (and `pathIsNotNull()` falsely excluded it).

Blast radius is limited to the pointer predicates: `field.isNull()` / `field.isNotNull()` compile through a text-extraction `IS NULL` and were already correct — verified by mutation-testing the new coverage against the old implementation (the pointer-predicate test fails on it; the field-predicate tests pass).

## The fix

Both members are now type-based (`jsonb_typeof`) and never SQL NULL, converging on SQLite's already-correct semantics:

```sql
COALESCE(jsonb_typeof(column #> path) = 'null', TRUE)   -- pathIsNull
COALESCE(jsonb_typeof(column #> path) <> 'null', FALSE) -- pathIsNotNull
```

With `jsonPathIsNull` fixed, the `jsonPathIsMissingOrNull` member #288 introduced as a workaround became semantically identical, so it is folded back in and the weight audit uses `jsonPathIsNull` again — net one dialect member fewer than #288 alone.

**Behavior change on PostgreSQL for affected data** (patch changeset): rows holding a JSON `null` now match `pathIsNull()`; rows holding the string `"null"` no longer do.

## Tests

- Cross-backend regression: `pathIsNull`/`pathIsNotNull` over all four value shapes (absent, JSON `null`, string `"null"`, present) — fails against the old PG implementation
- Cross-backend value-shape coverage for `field.isNull()`/`isNotNull()` (locks in the already-correct `null_check` path)
- Fixture gains a nullable `metadata.reviewer` field to pin the JSON-null case

## Validation

`pnpm fix`, typecheck, full SQLite suite (5,125 passed), full PostgreSQL suite (2,129 passed).