### PR TITLE
fix: restore graph algorithms on Durable Objects SQLite

### DIFF
--- a/.changeset/do-sqlite-inline-algorithms.md
+++ b/.changeset/do-sqlite-inline-algorithms.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Restore graph algorithms on Cloudflare Durable Objects SQLite. The
+auto-detected `do-sqlite` profile now marks temporary-table graph analytics as
+unsupported, routes shortest-path and reachability algorithms through their
+inline fallback, and rejects temporary-table-only algorithms with the existing
+typed capability error instead of leaking workerd's `SQLITE_AUTH` failure.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -710,6 +710,11 @@ A store backed by `drizzle(ctx.storage)` inside a Durable Object is
 `capabilities.transactions: true` — no `executionProfile` hint needed.
 Unlike D1, Durable Objects expose an interactive storage transaction runner,
 so `store.transaction()` and `store.withTransaction()` are fully atomic.
+The runtime authorizer forbids temporary tables, so the same profile reports
+`capabilities.graphAnalytics.supported: false`. Traversal algorithms such as
+`shortestPath`, `reachable`, and `weightedShortestPath` automatically use their
+inline fallback; temporary-table-only analytics such as
+`weaklyConnectedComponents` throw `UnsupportedBackendCapabilityError`.
 The same profile advertises Cloudflare's 100-bound-parameter query limit.
 TypeGraph uses that hard ceiling for its managed write batches and
 recorded-history flushes; capability overrides may lower it but cannot raise
@@ -790,12 +795,13 @@ including traversal, subquery, `GROUP BY`/`HAVING`, and per-leaf `ORDER BY`/`LIM
 `plain`, `raw`) all behave identically. A query you write against one backend compiles and runs the same way on the
 other.
 
-The remaining differences are **engine-capability gaps in the vector and fulltext layers** — they stem from what
-`sqlite-vec`/FTS5 implement versus `pgvector`/`tsvector`, not from TypeGraph choosing to support a feature on one
-backend only:
+The remaining differences are **engine and runtime capability gaps** — they
+stem from what each database or hosted authorizer implements, not from
+TypeGraph choosing separate query semantics per backend:
 
 | Capability | SQLite | PostgreSQL | Behavior on the unsupported side |
 | --- | --- | --- | --- |
+| Whole-graph temporary-table analytics | ✓ standard connections / ✗ D1 and Durable Objects | ✓ connection-based drivers / ✗ `neon-http` | Throws `UnsupportedBackendCapabilityError`; traversal algorithms with an inline engine fall back automatically |
 | Vector metric `inner_product` | ✗ | ✓ | Rejected at compile time on SQLite (`sqlite-vec`/`libsql-native` expose `cosine` + `l2`; `pgvector` adds `inner_product`) |
 | Vector index type `ivfflat` | ✗ | ✓ | Index declaration is **skipped** on SQLite (`indexTypes`: `hnsw`/`none` vs `hnsw`/`ivfflat`/`none`) |
 | Filtered approximate search **guarantees** a full page | ✓ `sqlite-vec` / ✗ `libsql-native` | ✗ (`pgvector` recovers, but is bounded) | Only `sqlite-vec` guarantees it; the others can return **fewer than `limit`** rows under heavy filtering — see below |

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -280,9 +280,10 @@ default collation. Edges are always treated as undirected—WCC has no
 
 WCC is iterative and runs multiple SQL rounds in one repeatable snapshot. It
 requires `backend.capabilities.graphAnalytics?.supported === true`; built-in
-transactional SQLite and PostgreSQL backends advertise support. Other backends
-throw `UnsupportedBackendCapabilityError` before temporary state is created. If
-propagation has not converged after `maxIterations`, TypeGraph throws
+SQLite and PostgreSQL connections that permit temporary tables advertise
+support. Cloudflare D1, Durable Objects SQLite, `neon-http`, and other
+restricted backends throw `UnsupportedBackendCapabilityError` before temporary
+state is created. If propagation has not converged after `maxIterations`, TypeGraph throws
 `GraphAlgorithmConvergenceError` rather than returning a partial partition.
 
 PostgreSQL refreshes planner statistics for a sufficiently large temporary

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -59,6 +59,7 @@ import {
   type DropVectorIndexParams,
   type FulltextSearchParams,
   type FulltextSearchResult,
+  type GraphAnalyticsCapabilities,
   type GraphBackend,
   type HybridSearchParams,
   type HybridSearchRow,
@@ -474,6 +475,25 @@ function resolveMaxBindParametersCapability(
   return profile.hardMaxBindParameters === undefined ?
       requested
     : Math.min(requested, profile.hardMaxBindParameters);
+}
+
+function resolveSqliteGraphAnalyticsCapabilities(
+  profile: SqliteExecutionProfile,
+  override: GraphAnalyticsCapabilities | undefined,
+): GraphAnalyticsCapabilities {
+  const requested =
+    override ??
+    SQLITE_CAPABILITIES.graphAnalytics ?? {
+      supported: false,
+      mathFunctions: false,
+    };
+  if (
+    profile.transactionMode !== "do-sqlite" &&
+    profile.transactionMode !== "none"
+  ) {
+    return requested;
+  }
+  return { ...requested, supported: false };
 }
 
 // ============================================================
@@ -973,6 +993,10 @@ export function createSqliteBackend(
     maxBindParameters: resolveMaxBindParametersCapability(
       executionAdapter.profile,
       capabilityOverrides.maxBindParameters,
+    ),
+    graphAnalytics: resolveSqliteGraphAnalyticsCapabilities(
+      executionAdapter.profile,
+      capabilityOverrides.graphAnalytics,
     ),
   });
 

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -798,6 +798,7 @@ function compileWeightExpression(
 export function supportsTemporaryIteration(ctx: AlgorithmContext): boolean {
   return (
     ctx.backend.capabilities.transactions &&
+    ctx.backend.capabilities.graphAnalytics?.supported !== false &&
     ctx.backend.capabilities.returning !== false &&
     ctx.backend.executeTemporaryStatement !== undefined
   );

--- a/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
+++ b/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
@@ -66,11 +66,14 @@ const docVersions = sqliteTable(
 );
 
 const Doc = defineNode("Doc", { schema: z.object({ title: z.string() }) });
+const linksTo = defineEdge("links_to", {
+  schema: z.object({ cost: z.number() }),
+});
 
 const DocGraph = defineGraph({
   id: "do-sqlite",
   nodes: { Doc: { type: Doc } },
-  edges: {},
+  edges: { links_to: { type: linksTo, from: [Doc], to: [Doc] } },
 });
 
 const Message = defineNode("Message", {
@@ -156,16 +159,23 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
       expect(db.$client).toBe(storage);
       expect(typeof storage.transaction).toBe("function");
       expect(backend.capabilities.transactions).toBe(true);
+      expect(backend.capabilities.graphAnalytics?.supported).toBe(false);
       expect(backend.capabilities.maxBindParameters).toBe(
         DURABLE_OBJECT_MAX_BIND_PARAMETERS,
       );
 
       const staleHintBackend = createSqliteBackend(db, {
-        capabilities: { maxBindParameters: 999 },
+        capabilities: {
+          graphAnalytics: { supported: true, mathFunctions: false },
+          maxBindParameters: 999,
+        },
         executionProfile: { isSync: false, transactionMode: "none" },
         tables: defaultTables,
       });
       expect(staleHintBackend.capabilities.transactions).toBe(true);
+      expect(staleHintBackend.capabilities.graphAnalytics?.supported).toBe(
+        false,
+      );
       expect(staleHintBackend.capabilities.maxBindParameters).toBe(
         DURABLE_OBJECT_MAX_BIND_PARAMETERS,
       );
@@ -177,6 +187,49 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
         }),
       ).rejects.toThrow("stale-hint-rollback");
       expect(await staleHintStore.nodes.Doc.count()).toBe(0);
+    });
+  });
+
+  it("routes graph algorithms around forbidden temporary tables", async () => {
+    await inObject("algorithms", async ({ store }) => {
+      const source = await store.nodes.Doc.create({ title: "source" });
+      const target = await store.nodes.Doc.create({ title: "target" });
+      await store.edges.links_to.create(source, target, { cost: 2 });
+
+      const path = await store.algorithms.shortestPath(source, target, {
+        edges: ["links_to"],
+      });
+
+      expect(path?.nodes.map((node) => node.id)).toEqual([
+        source.id,
+        target.id,
+      ]);
+
+      const reachable = await store.algorithms.reachable(source, {
+        edges: ["links_to"],
+      });
+      expect(reachable.map((node) => [node.id, node.depth])).toEqual([
+        [source.id, 0],
+        [target.id, 1],
+      ]);
+
+      const weightedPath = await store.algorithms.weightedShortestPath(
+        source,
+        target,
+        { edges: ["links_to"], weightProperty: "cost" },
+      );
+      expect(weightedPath?.totalWeight).toBe(2);
+      expect(weightedPath?.nodes.map((node) => node.id)).toEqual([
+        source.id,
+        target.id,
+      ]);
+
+      await expect(
+        store.algorithms.weaklyConnectedComponents({ edges: ["links_to"] }),
+      ).rejects.toMatchObject({
+        code: "UNSUPPORTED_BACKEND_CAPABILITY",
+        details: { capability: "graphAnalytics", supported: false },
+      });
     });
   });
 


### PR DESCRIPTION
- mark temporary-table graph analytics unsupported for the auto-detected `do-sqlite` profile
- route shortest-path, reachability, and weighted-shortest-path operations through their inline fallback
- fail temporary-table-only algorithms with the existing typed capability error
- add real-workerd regression coverage, documentation, and a patch changeset

Fixes #291.

## Root cause

The iterative algorithm dispatcher treated an available `executeTemporaryStatement` method as proof that the runtime permitted temporary tables. The shared Drizzle SQLite backend exposes that method on Durable Objects, but workerd's SQLite authorizer rejects `CREATE TEMP TABLE` with `SQLITE_AUTH`.

The fix reuses the existing `graphAnalytics.supported` capability, whose contract already represents whether a backend can maintain session-local temporary state. Durable Objects remain transactional while correctly advertising that temporary-table analytics are unavailable.

## Impact

Durable Objects consumers can again use `shortestPath`, `reachable`, `canReach`, and `weightedShortestPath`. Algorithms without an inline engine, such as weakly connected components, now fail early with `UnsupportedBackendCapabilityError` instead of leaking a raw workerd authorization failure.
