### PR TITLE
perf(algorithms): use delta frontiers for WCC

### DIFF
--- a/.changeset/fast-wcc-frontiers.md
+++ b/.changeset/fast-wcc-frontiers.md
@@ -1,0 +1,8 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Speed up exact weakly connected components with indexed changed-label
+frontiers, changed-row-only writes, and one fewer working-table join. Preserve
+synchronous convergence across bind-limited edge-kind chunks, and align
+shortest-path identity tie-breaks with portable binary ordering.

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -35,6 +35,11 @@ path reconstruction, and stop when the frontiers meet.
 `degree` remains a single `COUNT` query. The algorithms work identically on
 SQLite and PostgreSQL.
 
+The inline fallback is intentionally limited to bounded traversals. Whole-graph
+iterative algorithms such as WCC require a pinned transactional connection and
+fail through their typed capability gate when one is unavailable; they never
+silently switch to a second full algorithm implementation.
+
 ## When to Reach for Algorithms
 
 | You want to... | Use |
@@ -102,6 +107,9 @@ type ShortestPathResult = Readonly<{
 Source equal to target returns a zero-length path containing just that
 node. Endpoints that don't pass the resolved temporal filter return
 `undefined` — see [Temporal Behavior](#temporal-behavior).
+When several minimum-hop paths exist, predecessor and meeting-node ties use
+the smallest `(id, kind)` identity under portable binary ordering, so the
+selected path is identical across backends and execution strategies.
 
 ## weightedShortestPath
 
@@ -284,6 +292,12 @@ transactional SQLite and PostgreSQL backends advertise support. Other backends
 throw `UnsupportedBackendCapabilityError` before temporary state is created. If
 propagation has not converged after `maxIterations`, TypeGraph throws
 `GraphAlgorithmConvergenceError` rather than returning a partial partition.
+
+Each round expands only the indexed frontier of nodes whose label changed in
+the previous round. Candidate labels remain staged until every edge-kind chunk
+has run, preserving synchronous and bind-limit-independent iteration semantics;
+only changed rows are written back. Late convergence rounds therefore avoid
+rescanning the full edge set and do not churn unchanged working rows.
 
 PostgreSQL refreshes planner statistics for a sufficiently large temporary
 working table and refreshes them again after multiplicative growth. This avoids

--- a/packages/typegraph/src/store/algorithms/breadth-first.ts
+++ b/packages/typegraph/src/store/algorithms/breadth-first.ts
@@ -1,7 +1,6 @@
 import { sql } from "drizzle-orm";
 
 import { asCompiledRowsSql } from "../../query/sql-intent";
-import { compareStrings } from "../../utils/compare";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
 import {
   compareNodeIdentity,
@@ -274,7 +273,7 @@ async function seedWorkingSide(
 /**
  * Detects the depth-zero meeting for bidirectional search: a node seeded on
  * both sides (source equals target, possibly across kinds sharing that id).
- * Ties break by node id then kind in UTF-16 code-unit order — deterministic
+ * Ties break by node id then kind in code-point order — deterministic
  * and identical on both backends, unlike the collation-dependent SQL probe
  * this replaced.
  */
@@ -318,6 +317,11 @@ async function expandWorkingTableRound(
   const oppositeSide: WorkingSide = side === "forward" ? "reverse" : "forward";
   let insertedCount = 0;
   let meeting: MeetingNode | undefined;
+  const { dialect } = context.operation.ctx;
+  const targetKind = dialect.binaryText(sql`expanded.target_kind`);
+  const targetId = dialect.binaryText(sql`expanded.target_id`);
+  const sourceId = dialect.binaryText(sql`expanded.source_id`);
+  const sourceKind = dialect.binaryText(sql`expanded.source_kind`);
   for (const edgeKinds of context.operation.edgeKindChunks) {
     const sourceFilter = sql`
       w.graph_id = ${context.graphId}
@@ -353,8 +357,8 @@ async function expandWorkingTableRound(
         FROM (
           SELECT expanded.*,
             ROW_NUMBER() OVER (
-              PARTITION BY expanded.target_kind, expanded.target_id
-              ORDER BY expanded.source_id, expanded.source_kind
+              PARTITION BY ${targetKind}, ${targetId}
+              ORDER BY ${sourceId}, ${sourceKind}
             ) AS candidate_rank
           FROM (${expansion}) expanded
         ) ranked
@@ -380,8 +384,8 @@ async function expandWorkingTableRound(
 
 /**
  * Folds one round's inserted rows into the best meeting so far: smallest
- * total depth within `maxHops`, ties broken by node id then kind in UTF-16
- * code-unit order. That tie-break is deterministic and identical on both
+ * total depth within `maxHops`, ties broken by node id then kind in code-point
+ * order. That tie-break is deterministic and identical on both
  * backends; the SQL probe it replaced ordered under the database collation,
  * so equal-depth meetings could previously pick a different node on a
  * PostgreSQL cluster with a linguistic default collation.
@@ -496,7 +500,6 @@ async function readWorkingRows(
       WHERE graph_id = ${context.graphId}
         AND run_id = ${context.runId}
         AND ${sideFilter}
-      ORDER BY side, depth, node_id, node_kind
     `),
   );
 }
@@ -675,18 +678,28 @@ function findMeetingNodeKey(
   activeVisited: ReadonlyMap<NodeIdentityKey, VisitedNode>,
   oppositeVisited: ReadonlyMap<NodeIdentityKey, VisitedNode>,
 ): NodeIdentityKey | undefined {
-  let best: Readonly<{ key: NodeIdentityKey; depth: number }> | undefined;
+  let best:
+    | Readonly<{
+        key: NodeIdentityKey;
+        node: PathNode;
+        depth: number;
+      }>
+    | undefined;
   for (const candidate of candidates) {
     const key = nodeIdentityKey(candidate);
     const active = activeVisited.get(key);
     const opposite = oppositeVisited.get(key);
     if (active === undefined || opposite === undefined) continue;
-    const meeting = { key, depth: active.depth + opposite.depth };
+    const meeting = {
+      key,
+      node: { id: candidate.id, kind: candidate.kind },
+      depth: active.depth + opposite.depth,
+    };
     if (
       best === undefined ||
       meeting.depth < best.depth ||
       (meeting.depth === best.depth &&
-        compareStrings(meeting.key, best.key) < 0)
+        compareNodeIdentity(meeting.node, best.node) < 0)
     ) {
       best = meeting;
     }

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -61,6 +61,21 @@ export type InternalTraversalOptions = InternalTemporalOptions &
     defaultWeight?: number;
   }>;
 
+/** Copies only explicitly supplied temporal overrides for option forwarding. */
+export function pickTemporalOptions(
+  options: InternalTemporalOptions,
+): InternalTemporalOptions {
+  return {
+    ...(options.temporalMode === undefined ?
+      {}
+    : { temporalMode: options.temporalMode }),
+    ...(options.asOf === undefined ? {} : { asOf: options.asOf }),
+    ...(options.recordedAsOf === undefined ?
+      {}
+    : { recordedAsOf: options.recordedAsOf }),
+  };
+}
+
 /**
  * Resolves per-call temporal overrides against the graph's default mode into
  * a plain `{ temporalMode, asOf? }` object. Shared by callers that forward

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -24,7 +24,7 @@ import {
   asCompiledRowsSql,
   asCompiledTemporaryStatementSql,
 } from "../../query/sql-intent";
-import { compareStrings } from "../../utils/compare";
+import { compareCodePoints, compareStrings } from "../../utils/compare";
 import { generateId } from "../../utils/id";
 import { isPresent } from "../../utils/presence";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
@@ -88,6 +88,12 @@ export type IterativeGraphRunContext = Readonly<{
 export type IterativeGraphState = Readonly<{
   workingTableSize: number;
 }>;
+
+export function frontierIndexIdentifier(context: IterativeGraphRunContext) {
+  return sql.identifier(
+    `typegraph_iterative_${context.runId.replaceAll("-", "_")}_frontier`,
+  );
+}
 
 export type IterativeGraphPlan<
   State extends IterativeGraphState,
@@ -452,7 +458,55 @@ export function nodeIdentityKeyFromRow(
 
 export function compareNodeIdentity(left: PathNode, right: PathNode): number {
   return (
-    compareStrings(left.id, right.id) || compareStrings(left.kind, right.kind)
+    compareCodePoints(left.id, right.id) ||
+    compareCodePoints(left.kind, right.kind)
+  );
+}
+
+type DirectionFields = Readonly<{
+  joinField: "from_id" | "to_id";
+  joinKindField: "from_kind" | "to_kind";
+  targetField: "from_id" | "to_id";
+  targetKindField: "from_kind" | "to_kind";
+}>;
+
+const OUTGOING_DIRECTION_FIELDS = {
+  joinField: "from_id",
+  joinKindField: "from_kind",
+  targetField: "to_id",
+  targetKindField: "to_kind",
+} as const satisfies DirectionFields;
+
+const INCOMING_DIRECTION_FIELDS = {
+  joinField: "to_id",
+  joinKindField: "to_kind",
+  targetField: "from_id",
+  targetKindField: "from_kind",
+} as const satisfies DirectionFields;
+
+function fieldsForDirection(
+  direction: TraversalDirection,
+): readonly DirectionFields[] {
+  switch (direction) {
+    case "out": {
+      return [OUTGOING_DIRECTION_FIELDS];
+    }
+    case "in": {
+      return [INCOMING_DIRECTION_FIELDS];
+    }
+    case "both": {
+      return [OUTGOING_DIRECTION_FIELDS, INCOMING_DIRECTION_FIELDS];
+    }
+  }
+}
+
+function compileDirectionUnion(
+  direction: TraversalDirection,
+  compileDirection: (fields: DirectionFields) => SQL,
+): SQL {
+  return sql.join(
+    fieldsForDirection(direction).map((fields) => compileDirection(fields)),
+    sql` UNION ALL `,
   );
 }
 
@@ -468,37 +522,19 @@ function compileExpansionQuery(
   );
   const workingCte = sql`WITH working_set(node_id, node_kind) AS (VALUES ${workingValues})`;
 
-  switch (direction) {
-    case "out": {
-      return sql`${workingCte} ${compileDirectionalExpansion(operation, sql`working_set`, sql`TRUE`, edgeKinds, "from_id", "from_kind", "to_id", "to_kind")}`;
-    }
-    case "in": {
-      return sql`${workingCte} ${compileDirectionalExpansion(operation, sql`working_set`, sql`TRUE`, edgeKinds, "to_id", "to_kind", "from_id", "from_kind")}`;
-    }
-    case "both": {
-      const outgoing = compileDirectionalExpansion(
-        operation,
-        sql`working_set`,
-        sql`TRUE`,
-        edgeKinds,
-        "from_id",
-        "from_kind",
-        "to_id",
-        "to_kind",
-      );
-      const incoming = compileDirectionalExpansion(
-        operation,
-        sql`working_set`,
-        sql`TRUE`,
-        edgeKinds,
-        "to_id",
-        "to_kind",
-        "from_id",
-        "from_kind",
-      );
-      return sql`${workingCte} ${outgoing} UNION ALL ${incoming}`;
-    }
-  }
+  const expansion = compileDirectionUnion(direction, (fields) =>
+    compileDirectionalExpansion(
+      operation,
+      sql`working_set`,
+      sql`TRUE`,
+      edgeKinds,
+      fields.joinField,
+      fields.joinKindField,
+      fields.targetField,
+      fields.targetKindField,
+    ),
+  );
+  return sql`${workingCte} ${expansion}`;
 }
 
 export function compileWorkingTableExpansion(
@@ -508,62 +544,26 @@ export function compileWorkingTableExpansion(
   direction: TraversalDirection,
   edgeKinds: readonly string[],
 ): SQL {
-  switch (direction) {
-    case "out": {
-      return compileDirectionalExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "from_id",
-        "from_kind",
-        "to_id",
-        "to_kind",
-      );
-    }
-    case "in": {
-      return compileDirectionalExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "to_id",
-        "to_kind",
-        "from_id",
-        "from_kind",
-      );
-    }
-    case "both": {
-      const outgoing = compileDirectionalExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "from_id",
-        "from_kind",
-        "to_id",
-        "to_kind",
-      );
-      const incoming = compileDirectionalExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "to_id",
-        "to_kind",
-        "from_id",
-        "from_kind",
-      );
-      return sql`${outgoing} UNION ALL ${incoming}`;
-    }
-  }
+  return compileDirectionUnion(direction, (fields) =>
+    compileDirectionalExpansion(
+      operation,
+      workingTable,
+      sourceFilter,
+      edgeKinds,
+      fields.joinField,
+      fields.joinKindField,
+      fields.targetField,
+      fields.targetKindField,
+    ),
+  );
 }
 
 /**
  * Expands a working-table frontier through visible edges without joining target
  * nodes. Callers that reduce duplicate targets first can defer the target-node
  * visibility join until after that reduction, avoiding repeated point lookups
- * for the same target on dense frontiers.
+ * for the same target on dense frontiers. `sourceProjection` lets callers
+ * carry trusted working-row state through the expansion without re-joining it.
  */
 export function compileWorkingTableEdgeExpansion(
   operation: IterativeGraphOperation,
@@ -571,56 +571,21 @@ export function compileWorkingTableEdgeExpansion(
   sourceFilter: SQL,
   direction: TraversalDirection,
   edgeKinds: readonly string[],
+  sourceProjection?: SQL,
 ): SQL {
-  switch (direction) {
-    case "out": {
-      return compileDirectionalEdgeExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "from_id",
-        "from_kind",
-        "to_id",
-        "to_kind",
-      );
-    }
-    case "in": {
-      return compileDirectionalEdgeExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "to_id",
-        "to_kind",
-        "from_id",
-        "from_kind",
-      );
-    }
-    case "both": {
-      const outgoing = compileDirectionalEdgeExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "from_id",
-        "from_kind",
-        "to_id",
-        "to_kind",
-      );
-      const incoming = compileDirectionalEdgeExpansion(
-        operation,
-        workingTable,
-        sourceFilter,
-        edgeKinds,
-        "to_id",
-        "to_kind",
-        "from_id",
-        "from_kind",
-      );
-      return sql`${outgoing} UNION ALL ${incoming}`;
-    }
-  }
+  return compileDirectionUnion(direction, (fields) =>
+    compileDirectionalEdgeExpansion(
+      operation,
+      workingTable,
+      sourceFilter,
+      edgeKinds,
+      fields.joinField,
+      fields.joinKindField,
+      fields.targetField,
+      fields.targetKindField,
+      sourceProjection,
+    ),
+  );
 }
 
 function compileDirectionalExpansion(
@@ -657,13 +622,16 @@ function compileDirectionalEdgeExpansion(
   joinKindField: "from_kind" | "to_kind",
   targetField: "from_id" | "to_id",
   targetKindField: "from_kind" | "to_kind",
+  sourceProjection?: SQL,
 ): ReturnType<typeof sql> {
   const edgeKindFilter = compileKindFilter(sql.raw("e.kind"), edgeKinds);
   const weightColumn =
     operation.weightExpression === undefined ?
       sql``
     : sql`, ${operation.weightExpression} AS weight`;
-  return sql`SELECT w.node_id AS source_id, w.node_kind AS source_kind, e.${sql.raw(targetField)} AS target_id, e.${sql.raw(targetKindField)} AS target_kind${weightColumn} FROM ${workingRelation} w JOIN ${operation.schema.edgesTable} e ON e.${sql.raw(joinField)} = w.node_id AND e.${sql.raw(joinKindField)} = w.node_kind AND e.graph_id = ${operation.ctx.graphId} WHERE ${sourceFilter} AND ${edgeKindFilter} AND ${operation.edgeTemporalFilter}`;
+  const sourceColumns =
+    sourceProjection === undefined ? sql`` : sql`, ${sourceProjection}`;
+  return sql`SELECT w.node_id AS source_id, w.node_kind AS source_kind${sourceColumns}, e.${sql.raw(targetField)} AS target_id, e.${sql.raw(targetKindField)} AS target_kind${weightColumn} FROM ${workingRelation} w JOIN ${operation.schema.edgesTable} e ON e.${sql.raw(joinField)} = w.node_id AND e.${sql.raw(joinKindField)} = w.node_kind AND e.graph_id = ${operation.ctx.graphId} WHERE ${sourceFilter} AND ${edgeKindFilter} AND ${operation.edgeTemporalFilter}`;
 }
 
 function chunkValues<T>(

--- a/packages/typegraph/src/store/algorithms/reachable.ts
+++ b/packages/typegraph/src/store/algorithms/reachable.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_ALGORITHM_MAX_HOPS,
   DEFAULT_NEIGHBOR_DEPTH,
   type InternalTraversalOptions,
+  pickTemporalOptions,
   resolveMaxHops,
 } from "./context";
 import type { ReachableNode } from "./types";
@@ -65,13 +66,7 @@ export async function executeNeighbors(
     maxHops: depth,
     direction: options.direction ?? "out",
     cyclePolicy: options.cyclePolicy ?? "prevent",
-    ...(options.temporalMode !== undefined && {
-      temporalMode: options.temporalMode,
-    }),
-    ...(options.asOf !== undefined && { asOf: options.asOf }),
-    ...(options.recordedAsOf !== undefined && {
-      recordedAsOf: options.recordedAsOf,
-    }),
+    ...pickTemporalOptions(options),
     ...(options.workingMemory !== undefined && {
       workingMemory: options.workingMemory,
     }),

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -9,10 +9,12 @@ import {
   type AlgorithmContext,
   assertEdgeKinds,
   type InternalTraversalOptions,
+  pickTemporalOptions,
   resolveMaxIterations,
 } from "./context";
 import {
   compileWorkingTableEdgeExpansion,
+  frontierIndexIdentifier,
   type IterativeGraphRunContext,
   runIterativeGraphOperation,
 } from "./iterative-graph-operation";
@@ -58,13 +60,7 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
   const traversalOptions: InternalTraversalOptions = {
     edges: options.edges,
     direction: "both",
-    ...(options.temporalMode === undefined ?
-      {}
-    : { temporalMode: options.temporalMode }),
-    ...(options.asOf === undefined ? {} : { asOf: options.asOf }),
-    ...(options.recordedAsOf === undefined ?
-      {}
-    : { recordedAsOf: options.recordedAsOf }),
+    ...pickTemporalOptions(options),
     ...(options.workingMemory === undefined ?
       {}
     : { workingMemory: options.workingMemory }),
@@ -114,6 +110,7 @@ function createWorkingTable(context: IterativeGraphRunContext): SQL {
       label_kind TEXT NOT NULL,
       next_label_id TEXT NOT NULL,
       next_label_kind TEXT NOT NULL,
+      improved_round INTEGER NOT NULL,
       PRIMARY KEY (graph_id, run_id, node_kind, node_id)
     )
   `;
@@ -131,13 +128,17 @@ async function initializeWorkingTable(
   await context.executeTemporary(sql`
     INSERT INTO ${workingTable}
       (graph_id, run_id, node_id, node_kind, label_id, label_kind,
-       next_label_id, next_label_kind)
+       next_label_id, next_label_kind, improved_round)
     SELECT
-      ${graphId}, ${runId}, n.id, n.kind, n.id, n.kind, n.id, n.kind
+      ${graphId}, ${runId}, n.id, n.kind, n.id, n.kind, n.id, n.kind, 0
     FROM ${operation.schema.nodesTable} n
     WHERE n.graph_id = ${graphId}
       AND ${nodeKindFilter}
       AND ${operation.nodeTemporalFilter}
+  `);
+  await context.executeTemporary(sql`
+    CREATE INDEX ${frontierIndexIdentifier(context)}
+    ON ${workingTable} (graph_id, run_id, improved_round)
   `);
 
   const rows = await context.backend.execute<CountRow>(
@@ -154,49 +155,45 @@ async function initializeWorkingTable(
 async function runLabelPropagationRound(
   context: IterativeGraphRunContext,
   state: IterationState,
+  iteration: number,
 ): Promise<IterationState> {
-  await resetNextLabels(context);
   for (const edgeKinds of context.operation.edgeKindChunks) {
-    await propagateChunkLabels(context, edgeKinds);
+    await propagateChunkLabels(context, edgeKinds, iteration);
   }
-  const changedRows = await applyNextLabels(context);
+  const changedRows = await applyNextLabels(context, iteration);
   return {
     changedCount: changedRows.length,
     workingTableSize: state.workingTableSize,
   };
 }
 
-async function resetNextLabels(
-  context: IterativeGraphRunContext,
-): Promise<void> {
-  await context.executeTemporary(sql`
-    UPDATE ${context.workingTable}
-    SET next_label_id = label_id, next_label_kind = label_kind
-    WHERE graph_id = ${context.graphId} AND run_id = ${context.runId}
-  `);
-}
-
 /**
  * Propagates the minimum neighbor label along one edge-kind chunk. The
- * expansion deliberately skips the target-node visibility join: the working
+ * expansion deliberately skips the target-node visibility join. The working
  * table was seeded through the same graph/kind/temporal filters inside the
- * same snapshot, WCC never inserts rows after seeding, and both edge
- * endpoints are re-joined against the working table below — membership is
- * the visibility-and-scope proof, so a per-edge `typegraph_nodes` lookup
- * would only re-check what the `source`/`scoped_target` joins already
- * guarantee.
+ * same snapshot, WCC never inserts rows after seeding, source labels are
+ * projected from the frontier, and each target is joined against the working
+ * table below. Membership is therefore the visibility-and-scope proof, so a
+ * per-edge `typegraph_nodes` lookup would only re-check what the frontier and
+ * `scoped_target` already guarantee.
  */
 async function propagateChunkLabels(
   context: IterativeGraphRunContext,
   edgeKinds: readonly string[],
+  iteration: number,
 ): Promise<void> {
   const { operation, workingTable, graphId, runId } = context;
   const expansion = compileWorkingTableEdgeExpansion(
     operation,
     workingTable,
-    sql`w.graph_id = ${graphId} AND w.run_id = ${runId}`,
+    sql`
+      w.graph_id = ${graphId}
+      AND w.run_id = ${runId}
+      AND w.improved_round = ${iteration - 1}
+    `,
     "both",
     edgeKinds,
+    sql`w.label_id AS source_label_id, w.label_kind AS source_label_kind`,
   );
   const candidateId = operation.ctx.dialect.binaryText(sql`ranked.label_id`);
   const candidateKind = operation.ctx.dialect.binaryText(
@@ -216,14 +213,9 @@ async function propagateChunkLabels(
       SELECT
         expanded.target_id,
         expanded.target_kind,
-        source.label_id,
-        source.label_kind
+        expanded.source_label_id AS label_id,
+        expanded.source_label_kind AS label_kind
       FROM (${expansion}) expanded
-      JOIN ${workingTable} source
-        ON source.graph_id = ${graphId}
-        AND source.run_id = ${runId}
-        AND source.node_id = expanded.source_id
-        AND source.node_kind = expanded.source_kind
       JOIN ${workingTable} scoped_target
         ON scoped_target.graph_id = ${graphId}
         AND scoped_target.run_id = ${runId}
@@ -262,11 +254,14 @@ async function propagateChunkLabels(
 
 function applyNextLabels(
   context: IterativeGraphRunContext,
+  iteration: number,
 ): Promise<readonly ChangedRow[]> {
   return context.backend.execute<ChangedRow>(
     asCompiledRowsSql(sql`
       UPDATE ${context.workingTable}
-      SET label_id = next_label_id, label_kind = next_label_kind
+      SET label_id = next_label_id,
+          label_kind = next_label_kind,
+          improved_round = ${iteration}
       WHERE graph_id = ${context.graphId}
         AND run_id = ${context.runId}
         AND (
@@ -301,25 +296,11 @@ async function extractMemberships(
     `),
   );
 
-  return rows
-    .map((row) => ({
-      id: row.node_id,
-      kind: row.node_kind,
-      componentId: row.component_id,
-      componentKind: row.component_kind,
-      size: Number(row.component_size),
-    }))
-    .toSorted(compareMemberships);
-}
-
-function compareMemberships(
-  left: WeaklyConnectedComponentMembership,
-  right: WeaklyConnectedComponentMembership,
-): number {
-  return (
-    compareCodePoints(left.componentId, right.componentId) ||
-    compareCodePoints(left.componentKind, right.componentKind) ||
-    compareCodePoints(left.id, right.id) ||
-    compareCodePoints(left.kind, right.kind)
-  );
+  return rows.map((row) => ({
+    id: row.node_id,
+    kind: row.node_kind,
+    componentId: row.component_id,
+    componentKind: row.component_kind,
+    size: Number(row.component_size),
+  }));
 }

--- a/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
+++ b/packages/typegraph/src/store/algorithms/weighted-shortest-path.ts
@@ -10,12 +10,13 @@ import {
 import { compileKindFilter } from "../../query/compiler/predicate-utils";
 import { jsonPointer } from "../../query/json-pointer";
 import { asCompiledRowsSql } from "../../query/sql-intent";
-import { compareCodePoints } from "../../utils/compare";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
 import { assertEdgeKinds, resolveMaxIterations } from "./context";
 import {
+  compareNodeIdentity,
   compileWorkingTableExpansion,
   fetchVisibleWorkingNodes,
+  frontierIndexIdentifier,
   type IterativeGraphOperation,
   type IterativeGraphRunContext,
   type NodeExpansion,
@@ -324,23 +325,6 @@ function formatWeightValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
-/**
- * Node-identity comparison in code-point order — the order SQLite BINARY
- * and PostgreSQL `COLLATE "C"` sort in. Every JS-side tie-break in this
- * algorithm must reproduce the working-table round's `binaryText` ORDER BY,
- * and the substrate's UTF-16 `compareNodeIdentity` disagrees with it for
- * astral characters.
- */
-function compareNodeIdentityCodePoints(
-  left: PathNode,
-  right: PathNode,
-): number {
-  return (
-    compareCodePoints(left.id, right.id) ||
-    compareCodePoints(left.kind, right.kind)
-  );
-}
-
 // ============================================================
 // Working-table execution
 // ============================================================
@@ -413,12 +397,6 @@ async function findWeightedShortestPathInWorkingTable(
       return extractPathFromWorkingTable(context, targetId, maxIterations);
     },
   });
-}
-
-function frontierIndexIdentifier(context: IterativeGraphRunContext) {
-  return sql.identifier(
-    `typegraph_iterative_${context.runId.replaceAll("-", "_")}_frontier`,
-  );
 }
 
 /**
@@ -655,7 +633,7 @@ async function findWeightedSelfPath(
     );
     const nodes = await fetchVisibleWorkingNodes(operation, [nodeId]);
     const node = nodes.toSorted((left, right) =>
-      compareNodeIdentityCodePoints(left, right),
+      compareNodeIdentity(left, right),
     )[0];
     if (node === undefined) return;
     return { nodes: [node], depth: 0, totalWeight: 0 };
@@ -763,7 +741,7 @@ async function findWeightedShortestPathInline(
         }
       }
       frontier = improved.toSorted((left, right) =>
-        compareNodeIdentityCodePoints(left, right),
+        compareNodeIdentity(left, right),
       );
     }
 
@@ -791,7 +769,7 @@ function reduceWeightedCandidate(
     existing !== undefined &&
     (existing.distance < candidateDistance ||
       (existing.distance === candidateDistance &&
-        compareNodeIdentityCodePoints(
+        compareNodeIdentity(
           { id: existing.parentId, kind: existing.parentKind },
           expansion.source,
         ) <= 0))
@@ -828,7 +806,7 @@ function buildWeightedPathResult(
       target === undefined ||
       node.distance < target.distance ||
       (node.distance === target.distance &&
-        compareNodeIdentityCodePoints(node, target) < 0)
+        compareNodeIdentity(node, target) < 0)
     ) {
       target = node;
     }

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -1255,37 +1255,36 @@ describe("store.algorithms", () => {
       ).toBe(true);
     });
 
-    it("propagates labels without re-joining node visibility per edge", async () => {
+    it("uses indexed delta frontiers without reset or redundant joins", async () => {
       const statements: string[] = [];
-      const observedBackend: GraphBackend = {
-        ...backend,
-        transaction<T>(
-          fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
-          options?: TransactionOptions,
-        ): Promise<T> {
-          return backend.transaction(async (tx, adoptedTransaction) => {
-            const observedTransaction: TransactionBackend = {
-              ...tx,
-              async executeTemporaryStatement(
-                query: CompiledTemporaryStatementSql,
-              ): Promise<void> {
-                statements.push(backend.compileSql!(query).sql);
-                await tx.executeTemporaryStatement!(query);
-              },
-            };
-            return fn(observedTransaction, adoptedTransaction);
-          }, options);
-        },
-      };
+      const observedBackend = createCountingBackend(backend, statements);
       const observedStore = createStore(testGraph, observedBackend);
 
       await observedStore.algorithms.weaklyConnectedComponents({
         edges: ["knows"],
       });
 
-      // The working table is seeded with exactly the visible, in-scope nodes
-      // and WCC never inserts rows afterwards, so the propagate round proves
-      // endpoint visibility via working-table membership alone.
+      const createTableStatement = statements.find((statement) =>
+        statement.trimStart().startsWith("CREATE TEMP TABLE"),
+      );
+      expect(createTableStatement).toContain("improved_round INTEGER NOT NULL");
+      const createIndexStatement = statements.find((statement) =>
+        statement.trimStart().startsWith("CREATE INDEX"),
+      );
+      expect(createIndexStatement).toContain(
+        "(graph_id, run_id, improved_round)",
+      );
+      const seedStatementIndex = statements.findIndex((statement) =>
+        statement.trimStart().startsWith("INSERT INTO"),
+      );
+      const createIndexStatementIndex = statements.findIndex((statement) =>
+        statement.trimStart().startsWith("CREATE INDEX"),
+      );
+      expect(createIndexStatementIndex).toBeGreaterThan(seedStatementIndex);
+
+      // The working table is seeded with exactly the visible, in-scope nodes,
+      // so frontier and target membership prove endpoint visibility without
+      // re-checking the node table or re-joining the frontier row.
       const seedStatement = statements.find((statement) =>
         statement.trimStart().startsWith("INSERT INTO"),
       );
@@ -1295,8 +1294,18 @@ describe("store.algorithms", () => {
       );
       expect(propagateStatements.length).toBeGreaterThan(0);
       for (const statement of propagateStatements) {
+        expect(statement).toContain("w.improved_round = ?");
+        expect(statement).toContain("expanded.source_label_id AS label_id");
         expect(statement).not.toContain('"typegraph_nodes"');
+        expect(statement).not.toMatch(
+          /JOIN "typegraph_iterative_[^"]+" source/u,
+        );
       }
+      expect(
+        statements.some((statement) =>
+          statement.includes("SET next_label_id = label_id"),
+        ),
+      ).toBe(false);
     });
 
     it("rejects a backend without graph-analytics support", async () => {

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -9,9 +9,19 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { GraphAlgorithmConvergenceError } from "../../../src";
+import { createStore, GraphAlgorithmConvergenceError } from "../../../src";
+import type {
+  AdoptedTransaction,
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../../../src/backend/types";
+import type {
+  CompiledRowsSql,
+  CompiledTemporaryStatementSql,
+} from "../../../src/query/sql-intent";
 import { TEMPORAL_ANCHORS } from "../../test-utils";
-import { type IntegrationStore } from "./fixtures";
+import { type IntegrationStore, integrationTestGraph } from "./fixtures";
 import { seedKnowsChain } from "./seed-helpers";
 import { type IntegrationTestContext } from "./test-context";
 
@@ -96,6 +106,53 @@ async function seedWeightedTriangle(store: IntegrationStore) {
   return { anna, bruno, clara };
 }
 
+function withBindLimit(backend: GraphBackend, maxBindParameters: number) {
+  return {
+    ...backend,
+    capabilities: { ...backend.capabilities, maxBindParameters },
+    transaction<T>(
+      fn: (tx: TransactionBackend, sql: AdoptedTransaction) => Promise<T>,
+      options?: TransactionOptions,
+    ): Promise<T> {
+      return backend.transaction(async (tx, adoptedTransaction) => {
+        const constrainedTransaction: TransactionBackend = {
+          ...tx,
+          capabilities: { ...tx.capabilities, maxBindParameters },
+          execute<Result>(query: CompiledRowsSql): Promise<readonly Result[]> {
+            assertWithinBindLimit(backend, query, maxBindParameters);
+            return tx.execute<Result>(query);
+          },
+          async executeTemporaryStatement(
+            query: CompiledTemporaryStatementSql,
+          ): Promise<void> {
+            assertWithinBindLimit(backend, query, maxBindParameters);
+            await tx.executeTemporaryStatement!(query);
+          },
+        };
+        return fn(constrainedTransaction, adoptedTransaction);
+      }, options);
+    },
+  } satisfies GraphBackend;
+}
+
+function assertWithinBindLimit(
+  backend: GraphBackend,
+  query: CompiledRowsSql | CompiledTemporaryStatementSql,
+  maxBindParameters: number,
+): void {
+  const parameterCount = backend.compileSql!(query).params.length;
+  if (parameterCount <= maxBindParameters) return;
+  throw new Error(
+    `Statement used ${parameterCount} bind parameters; limit is ${maxBindParameters}.`,
+  );
+}
+
+function withoutTemporaryStatements(backend: GraphBackend): GraphBackend {
+  const { executeTemporaryStatement, ...inlineBackend } = backend;
+  void executeTemporaryStatement;
+  return inlineBackend;
+}
+
 export function registerAlgorithmIntegrationTests(
   context: IntegrationTestContext,
 ): void {
@@ -133,6 +190,57 @@ export function registerAlgorithmIntegrationTests(
         expect(path?.depth).toBe(3);
         expect(path?.nodes.at(0)?.id).toBe(ids.aliceId);
         expect(path?.nodes.at(-1)?.id).toBe(ids.eveId);
+      });
+
+      it("uses the same code-point predecessor tie-break in both execution paths", async () => {
+        const store = context.getStore();
+        const [source, bmpPredecessor, astralPredecessor, target] =
+          await Promise.all([
+            store.nodes.Person.create(
+              { name: "Collation source" },
+              { id: "bfs-collation-source" },
+            ),
+            store.nodes.Person.create(
+              { name: "BMP predecessor" },
+              { id: "bfs-collation-\uE000" },
+            ),
+            store.nodes.Person.create(
+              { name: "Astral predecessor" },
+              { id: "bfs-collation-\u{10000}" },
+            ),
+            store.nodes.Person.create(
+              { name: "Collation target" },
+              { id: "bfs-collation-target" },
+            ),
+          ]);
+        await Promise.all([
+          store.edges.knows.create(source, bmpPredecessor, {}),
+          store.edges.knows.create(source, astralPredecessor, {}),
+          store.edges.knows.create(bmpPredecessor, target, {}),
+          store.edges.knows.create(astralPredecessor, target, {}),
+        ]);
+
+        const options = { edges: ["knows"] } as const;
+        const workingTablePath = await store.algorithms.shortestPath(
+          source,
+          target,
+          options,
+        );
+        const inlineStore = createStore(
+          integrationTestGraph,
+          withoutTemporaryStatements(store.backend),
+        );
+        const inlinePath = await inlineStore.algorithms.shortestPath(
+          source,
+          target,
+          options,
+        );
+
+        const expectedIds = [source.id, bmpPredecessor.id, target.id];
+        expect(workingTablePath?.nodes.map((node) => node.id)).toEqual(
+          expectedIds,
+        );
+        expect(inlinePath).toEqual(workingTablePath);
       });
 
       it("shortestPath returns undefined for an unreachable target", async () => {
@@ -424,7 +532,9 @@ export function registerAlgorithmIntegrationTests(
         await Promise.all([
           // Reverse the intuitive order to pin weak/undirected semantics.
           store.edges.knows.create(beta, alpha, {}),
+          store.edges.knows.create(beta, alpha, {}),
           store.edges.knows.create(gamma, beta, {}),
+          store.edges.knows.create(gamma, gamma, {}),
           store.edges.worksAt.create(gamma, company, { role: "Founder" }),
         ]);
 
@@ -505,6 +615,176 @@ export function registerAlgorithmIntegrationTests(
             size: 1,
           },
         ]);
+      });
+
+      it("chooses exact binary representatives across ids and kinds", async () => {
+        const store = context.getStore();
+        const [upper, lower, bmp, astral, person, company] = await Promise.all([
+          store.nodes.Person.create(
+            { name: "Uppercase representative" },
+            { id: "wcc-collation-A" },
+          ),
+          store.nodes.Person.create(
+            { name: "Lowercase member" },
+            { id: "wcc-collation-a" },
+          ),
+          store.nodes.Person.create(
+            { name: "BMP representative" },
+            { id: "wcc-collation-\uE000" },
+          ),
+          store.nodes.Person.create(
+            { name: "Astral member" },
+            { id: "wcc-collation-\u{10000}" },
+          ),
+          store.nodes.Person.create(
+            { name: "Kind tie person" },
+            { id: "wcc-collation-shared" },
+          ),
+          store.nodes.Company.create(
+            { name: "Kind tie company" },
+            { id: "wcc-collation-shared" },
+          ),
+        ]);
+        await Promise.all([
+          store.edges.knows.create(upper, lower, {}),
+          store.edges.knows.create(bmp, astral, {}),
+          store.edges.worksAt.create(person, company, { role: "Member" }),
+        ]);
+
+        const allMemberships = await store.algorithms.weaklyConnectedComponents(
+          {
+            edges: ["knows", "worksAt"],
+          },
+        );
+        const memberships = allMemberships.filter((membership) =>
+          membership.id.startsWith("wcc-collation-"),
+        );
+
+        expect(memberships).toEqual([
+          {
+            id: upper.id,
+            kind: "Person",
+            componentId: upper.id,
+            componentKind: "Person",
+            size: 2,
+          },
+          {
+            id: lower.id,
+            kind: "Person",
+            componentId: upper.id,
+            componentKind: "Person",
+            size: 2,
+          },
+          {
+            id: company.id,
+            kind: "Company",
+            componentId: company.id,
+            componentKind: "Company",
+            size: 2,
+          },
+          {
+            id: person.id,
+            kind: "Person",
+            componentId: company.id,
+            componentKind: "Company",
+            size: 2,
+          },
+          {
+            id: bmp.id,
+            kind: "Person",
+            componentId: bmp.id,
+            componentKind: "Person",
+            size: 2,
+          },
+          {
+            id: astral.id,
+            kind: "Person",
+            componentId: bmp.id,
+            componentKind: "Person",
+            size: 2,
+          },
+        ]);
+      });
+
+      it("preserves synchronous convergence across edge-kind chunks", async () => {
+        const store = context.getStore();
+        const [alpha, beta, gamma] = await Promise.all([
+          store.nodes.Person.create(
+            { name: "Chunk alpha" },
+            { id: "wcc-chunk-a" },
+          ),
+          store.nodes.Person.create(
+            { name: "Chunk beta" },
+            { id: "wcc-chunk-b" },
+          ),
+          store.nodes.Company.create(
+            { name: "Chunk gamma" },
+            { id: "wcc-chunk-c" },
+          ),
+        ]);
+        await store.edges.knows.create(alpha, beta, {});
+        await store.edges.worksAt.create(beta, gamma, { role: "Member" });
+
+        const constrainedStore = createStore(
+          integrationTestGraph,
+          withBindLimit(store.backend, 28),
+        );
+        const limitedOptions = {
+          edges: ["knows", "worksAt"],
+          nodeKinds: ["Person", "Company"],
+          maxIterations: 2,
+        } as const;
+        await expect(
+          store.algorithms.weaklyConnectedComponents(limitedOptions),
+        ).rejects.toMatchObject({
+          code: "GRAPH_ALGORITHM_CONVERGENCE_ERROR",
+          details: {
+            algorithm: "weaklyConnectedComponents",
+            maxIterations: 2,
+          },
+        });
+        await expect(
+          constrainedStore.algorithms.weaklyConnectedComponents(limitedOptions),
+        ).rejects.toMatchObject({
+          code: "GRAPH_ALGORITHM_CONVERGENCE_ERROR",
+          details: {
+            algorithm: "weaklyConnectedComponents",
+            maxIterations: 2,
+          },
+        });
+
+        const convergingOptions = { ...limitedOptions, maxIterations: 3 };
+        const expected = [
+          {
+            id: alpha.id,
+            kind: "Person",
+            componentId: alpha.id,
+            componentKind: "Person",
+            size: 3,
+          },
+          {
+            id: beta.id,
+            kind: "Person",
+            componentId: alpha.id,
+            componentKind: "Person",
+            size: 3,
+          },
+          {
+            id: gamma.id,
+            kind: "Company",
+            componentId: alpha.id,
+            componentKind: "Person",
+            size: 3,
+          },
+        ];
+        await expect(
+          store.algorithms.weaklyConnectedComponents(convergingOptions),
+        ).resolves.toEqual(expected);
+        await expect(
+          constrainedStore.algorithms.weaklyConnectedComponents(
+            convergingOptions,
+          ),
+        ).resolves.toEqual(expected);
       });
 
       it("returns an empty induced subgraph for an empty node-kind scope", async () => {


### PR DESCRIPTION
- make weakly connected components propagate only from the previous round's changed frontier
- apply label improvements in place and preserve synchronous round semantics across bind-parameter chunks
- add a frontier index after bulk seeding and project source labels directly through edge expansion
- centralize graph-expansion direction/temporal helpers and binary node-identity ordering
- harden BFS/WCC deterministic tie-breaking across SQLite and PostgreSQL
- document iteration bounds, binary tie semantics, and delta-frontier behavior

## Why

The previous WCC implementation rescanned every eligible edge and rewrote the full working set on every round. Profiling showed that repeated edge work and PostgreSQL MVCC churn dominated runtime. Delta propagation keeps the same monotone minimum-label fixed point while making the long convergence tail proportional to the changed frontier.

## Performance

Exact SF1 Person/knows fixture (9,892 nodes, 180,623 edges), SQLite, three samples each:

- before median: 4,985.4 ms
- after median: 2,533.8 ms
- improvement: 49.2% lower runtime / 1.97x faster
- result digest unchanged: `c11823bde8601b4f66399441a3ac7909cf589bd06ed51de8e24cdb81c560c13d`
