### PR TITLE
Isolate declarations for strict SQLite and PGlite consumers

### DIFF
--- a/.changeset/strict-local-store-facades.md
+++ b/.changeset/strict-local-store-facades.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Add declaration-isolated `core`, `sqlite/local-store`, and
+`postgres/pglite-store` entrypoints for strict local database consumers. The
+shared typed CRUD facade preserves schema-derived node, edge, endpoint, and
+property types without loading unused Drizzle dialect declarations or requiring
+unrelated database drivers.

--- a/packages/typegraph/README.md
+++ b/packages/typegraph/README.md
@@ -42,6 +42,53 @@ const bob = await store.nodes.Person.create({ name: "Bob" });
 await store.edges.knows.create(alice, bob);
 ```
 
+### Strict local SQLite and PGlite consumers
+
+Applications that typecheck dependencies with `skipLibCheck: false` can keep
+unused Drizzle dialect declarations outside their TypeScript program by using
+the declaration-isolated subpaths:
+
+```ts
+import { defineGraph, defineNode } from "@nicia-ai/typegraph/core";
+import { createLocalPgliteStore } from "@nicia-ai/typegraph/postgres/pglite-store";
+import { createLocalSqliteStore } from "@nicia-ai/typegraph/sqlite/local-store";
+import { z } from "zod";
+
+const Fact = defineNode("Fact", {
+  schema: z.object({ statement: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "facts",
+  nodes: { Fact: { type: Fact } },
+  edges: {},
+});
+
+const sqliteStore = await createLocalSqliteStore(graph);
+const sqliteFact = await sqliteStore.nodes.Fact.create({ statement: "hello" });
+await sqliteStore.close();
+
+const pgliteStore = await createLocalPgliteStore(graph, { vector: false });
+const pgliteFact = await pgliteStore.nodes.Fact.create({ statement: "hello" });
+await pgliteStore.close();
+```
+
+Both convenience functions create the standard TypeGraph schema and return the
+existing runtime store through the same narrow, schema-derived CRUD interface.
+The facade intentionally omits query builders, custom backend/table
+configuration, transactions, history, and raw SQL. Import the existing root and
+backend entrypoints when those advanced surfaces are required.
+
+`sqlite/local-store` is Node.js-only because it opens `better-sqlite3`. Pass
+`{ path: "./graph.db" }` for file-backed storage; the default is an in-memory
+database with the standard local SQLite pragmas.
+
+`postgres/pglite-store` requires `@electric-sql/pglite`. It loads pgvector by
+default, which additionally requires `@electric-sql/pglite-pgvector`; pass
+`{ vector: false }` for graphs without embedding fields. Pass
+`{ dataDir: "./pgdata" }` for persistent storage. Production PostgreSQL remains
+available through the driver-agnostic `postgres` entrypoint.
+
 See the repo README for more.
 
 Examples: [github.com/nicia-ai/typegraph/tree/main/packages/typegraph/examples](https://github.com/nicia-ai/typegraph/tree/main/packages/typegraph/examples)

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./core": {
+      "types": "./dist/core/index.d.ts",
+      "import": "./dist/core/index.js",
+      "require": "./dist/core/index.cjs"
+    },
     "./interchange": {
       "types": "./dist/interchange/index.d.ts",
       "import": "./dist/interchange/index.js",
@@ -62,10 +67,20 @@
       "import": "./dist/backend/postgres/pglite.js",
       "require": "./dist/backend/postgres/pglite.cjs"
     },
+    "./postgres/pglite-store": {
+      "types": "./dist/backend/postgres/pglite-store.d.ts",
+      "import": "./dist/backend/postgres/pglite-store.js",
+      "require": "./dist/backend/postgres/pglite-store.cjs"
+    },
     "./sqlite/local": {
       "types": "./dist/backend/sqlite/local.d.ts",
       "import": "./dist/backend/sqlite/local.js",
       "require": "./dist/backend/sqlite/local.cjs"
+    },
+    "./sqlite/local-store": {
+      "types": "./dist/backend/sqlite/local-store.d.ts",
+      "import": "./dist/backend/sqlite/local-store.js",
+      "require": "./dist/backend/sqlite/local-store.cjs"
     },
     "./sqlite/libsql": {
       "types": "./dist/backend/sqlite/libsql.d.ts",
@@ -80,14 +95,15 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "dev": "tsup --watch",
-    "build": "tsup",
+    "dev": "tsup --watch --onSuccess \"pnpm exec tsup --config tsup.safe-declarations.config.ts\"",
+    "build": "tsup && tsup --config tsup.safe-declarations.config.ts",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "test:types": "node --import tsx scripts/test-types.ts all",
     "test:types:inline": "node --import tsx scripts/test-types.ts inline",
     "test:types:declarations": "node --import tsx scripts/test-types.ts declarations",
     "test:types:consumer": "node --import tsx scripts/test-types.ts consumer",
+    "test:strict-local-consumers": "node --import tsx scripts/test-strict-local-consumers.ts",
     "pretest": "node --import tsx scripts/ensure-native-sqlite.ts",
     "test": "vitest run",
     "pretest:unit": "node --import tsx scripts/ensure-native-sqlite.ts",

--- a/packages/typegraph/scripts/smoke-exports.mjs
+++ b/packages/typegraph/scripts/smoke-exports.mjs
@@ -26,6 +26,7 @@ const PACKAGE_NAME = "@nicia-ai/typegraph";
 // entry here.
 const PUBLIC_SUBPATHS = [
   { subpath: "", expectedExport: "createStore" },
+  { subpath: "/core", expectedExport: "defineGraph" },
   { subpath: "/interchange", expectedExport: "importGraph" },
   { subpath: "/profiler", expectedExport: "QueryProfiler" },
   { subpath: "/schema", expectedExport: "deserializeSchema" },
@@ -36,8 +37,16 @@ const PUBLIC_SUBPATHS = [
   { subpath: "/sqlite", expectedExport: "createSqliteBackend" },
   { subpath: "/postgres", expectedExport: "createPostgresBackend" },
   { subpath: "/sqlite/local", expectedExport: "createLocalSqliteBackend" },
+  {
+    subpath: "/sqlite/local-store",
+    expectedExport: "createLocalSqliteStore",
+  },
   { subpath: "/sqlite/libsql", expectedExport: "createLibsqlBackend" },
   { subpath: "/postgres/pglite", expectedExport: "createLocalPgliteBackend" },
+  {
+    subpath: "/postgres/pglite-store",
+    expectedExport: "createLocalPgliteStore",
+  },
 ];
 
 function findPackageManifest(startPath, packageName) {

--- a/packages/typegraph/scripts/test-strict-local-consumers.ts
+++ b/packages/typegraph/scripts/test-strict-local-consumers.ts
@@ -1,0 +1,226 @@
+import { spawn } from "node:child_process";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TYPESCRIPT_VERSION = "6.0.3";
+const FORBIDDEN_DRIVERS = ["gel", "mysql2", "pg", "postgres"] as const;
+
+type PackageJson = Readonly<{
+  devDependencies?: Readonly<Record<string, string>>;
+}>;
+
+function normalizedVersion(
+  value: string | undefined,
+  fallback: string,
+): string {
+  return value?.replace(/^[~^]/, "") ?? fallback;
+}
+
+function parsePackageJson(contents: string): PackageJson {
+  const value: unknown = JSON.parse(contents);
+  if (typeof value !== "object" || value === null) {
+    throw new Error("TypeGraph package manifest must be a JSON object.");
+  }
+  if (!("devDependencies" in value) || value.devDependencies === undefined) {
+    return {};
+  }
+  if (
+    typeof value.devDependencies !== "object" ||
+    value.devDependencies === null ||
+    !Object.values(value.devDependencies).every(
+      (dependency) => typeof dependency === "string",
+    )
+  ) {
+    throw new Error("TypeGraph devDependencies must be a string map.");
+  }
+  return {
+    devDependencies: value.devDependencies as Readonly<Record<string, string>>,
+  };
+}
+
+async function run(
+  command: string,
+  arguments_: readonly string[],
+  cwd: string,
+  capture = false,
+): Promise<string> {
+  const environment =
+    command === "npm" ?
+      Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([key]) => !key.toLowerCase().startsWith("npm_config_"),
+        ),
+      )
+    : process.env;
+
+  return new Promise<string>((resolve, reject) => {
+    let output = "";
+    const child = spawn(command, arguments_, {
+      cwd,
+      env: environment,
+      stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve(output);
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${arguments_.join(" ")} failed (${code ?? "unknown"}).\n${output}`,
+        ),
+      );
+    });
+  });
+}
+
+async function assertPathAbsent(pathToCheck: string, message: string) {
+  try {
+    await stat(pathToCheck);
+  } catch {
+    return;
+  }
+  throw new Error(message);
+}
+
+async function main(): Promise<void> {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const packageDirectory = path.dirname(scriptDirectory);
+  const packageJson = parsePackageJson(
+    await readFile(path.join(packageDirectory, "package.json"), "utf8"),
+  );
+  const temporaryDirectory = await mkdtemp(
+    path.join(tmpdir(), "typegraph-strict-local-consumers-"),
+  );
+  const fixtureDirectory = path.join(temporaryDirectory, "fixture");
+  const tarballPath = path.join(temporaryDirectory, "typegraph.tgz");
+
+  try {
+    await run("pnpm", ["build"], packageDirectory, true);
+    await run("pnpm", ["pack", "--out", tarballPath], packageDirectory, true);
+    await mkdir(path.join(fixtureDirectory, "src"), { recursive: true });
+    await copyFile(
+      path.join(packageDirectory, "type-smoke", "strict-local-consumers.ts"),
+      path.join(fixtureDirectory, "src", "index.ts"),
+    );
+
+    const dependencies = {
+      "@electric-sql/pglite": normalizedVersion(
+        packageJson.devDependencies?.["@electric-sql/pglite"],
+        "0.5.4",
+      ),
+      "@nicia-ai/typegraph": `file:${tarballPath}`,
+      "better-sqlite3": normalizedVersion(
+        packageJson.devDependencies?.["better-sqlite3"],
+        "12.11.1",
+      ),
+      "drizzle-orm": "0.45.2",
+      zod: normalizedVersion(packageJson.devDependencies?.zod, "4.4.3"),
+    };
+    const devDependencies = {
+      "@types/better-sqlite3": normalizedVersion(
+        packageJson.devDependencies?.["@types/better-sqlite3"],
+        "7.6.13",
+      ),
+      "@types/node": normalizedVersion(
+        packageJson.devDependencies?.["@types/node"],
+        "24.13.2",
+      ),
+      typescript: TYPESCRIPT_VERSION,
+    };
+    await writeFile(
+      path.join(fixtureDirectory, "package.json"),
+      `${JSON.stringify(
+        { private: true, type: "module", dependencies, devDependencies },
+        undefined,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      path.join(fixtureDirectory, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            strict: true,
+            noUncheckedIndexedAccess: true,
+            exactOptionalPropertyTypes: true,
+            verbatimModuleSyntax: true,
+            isolatedModules: true,
+            declaration: true,
+            skipLibCheck: false,
+            rootDir: "src",
+            outDir: "dist",
+            lib: ["ES2023"],
+            types: ["node"],
+          },
+          include: ["src/**/*.ts"],
+        },
+        undefined,
+        2,
+      )}\n`,
+    );
+
+    await run("npm", ["install", "--omit=optional"], fixtureDirectory);
+    const listFiles = await run(
+      path.join(fixtureDirectory, "node_modules", ".bin", "tsc"),
+      ["--listFiles"],
+      fixtureDirectory,
+      true,
+    );
+
+    if (
+      listFiles.includes(
+        `${path.sep}node_modules${path.sep}drizzle-orm${path.sep}`,
+      )
+    ) {
+      throw new Error("A Drizzle declaration entered the TypeScript program.");
+    }
+    for (const driver of FORBIDDEN_DRIVERS) {
+      await assertPathAbsent(
+        path.join(fixtureDirectory, "node_modules", driver),
+        `Unused database driver was installed: ${driver}`,
+      );
+    }
+
+    await writeFile(
+      path.join(fixtureDirectory, "run.mjs"),
+      [
+        'import { exerciseStrictLocalConsumers } from "./dist/index.js";',
+        "const result = await exerciseStrictLocalConsumers();",
+        'const expectedStoreResult = { statement: "verified", confidence: 0.9, factCount: 0 };',
+        "const expected = { sqlite: expectedStoreResult, pglite: expectedStoreResult };",
+        "if (JSON.stringify(result) !== JSON.stringify(expected)) throw new Error(JSON.stringify(result));",
+        "",
+      ].join("\n"),
+    );
+    await run("node", ["run.mjs"], fixtureDirectory);
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+
+  console.log(
+    `Strict packed SQLite and PGlite consumers passed with TypeScript ${TYPESCRIPT_VERSION}, skipLibCheck=false, and no unused drivers or dialect declarations.`,
+  );
+}
+
+await main();

--- a/packages/typegraph/src/backend/postgres/pglite-store.ts
+++ b/packages/typegraph/src/backend/postgres/pglite-store.ts
@@ -1,0 +1,59 @@
+/**
+ * Declaration-isolated local PGlite store for strict TypeScript consumers.
+ *
+ * This entrypoint owns its public options and deliberately omits query-builder,
+ * raw backend, transaction, and Drizzle surfaces. Use the root PostgreSQL and
+ * PGlite entrypoints when those advanced APIs are required.
+ */
+import { type GraphDef } from "../../core/define-graph";
+import { createStoreWithSchema } from "../../store/store";
+import { type TypedStoreFacade } from "../../store/typed-store-facade";
+import { createLocalPgliteBackend } from "./pglite";
+
+export type {
+  TypedCreateOptions,
+  TypedEdge,
+  TypedEdgeCollection,
+  TypedEdgeCollections,
+  TypedEdgeCreateArguments,
+  TypedEdgeMeta,
+  TypedFindOptions,
+  TypedNode,
+  TypedNodeCollection,
+  TypedNodeCollections,
+  TypedNodeMeta,
+  TypedNodeRef,
+  TypedStoreFacade,
+} from "../../store/typed-store-facade";
+
+/** Options accepted by {@link createLocalPgliteStore}. */
+export type LocalPgliteStoreOptions = Readonly<{
+  /** PGlite data directory. Defaults to an in-memory database. */
+  dataDir?: string;
+  /** Whether to load pgvector. Defaults to true. */
+  vector?: boolean;
+}>;
+
+/**
+ * Creates, provisions, and returns a typed local PGlite store.
+ *
+ * The facade uses standard TypeGraph tables. It loads pgvector by default;
+ * pass `{ vector: false }` when the graph has no embedding fields and the
+ * optional pgvector package is not installed.
+ */
+export async function createLocalPgliteStore<G extends GraphDef>(
+  graph: G,
+  options: LocalPgliteStoreOptions = {},
+): Promise<TypedStoreFacade<G>> {
+  const { backend } = await createLocalPgliteBackend({
+    ...(options.dataDir === undefined ? {} : { dataDir: options.dataDir }),
+    ...(options.vector === false ? { vector: false as const } : {}),
+  });
+  try {
+    const [store] = await createStoreWithSchema(graph, backend);
+    return store;
+  } catch (error) {
+    await backend.close();
+    throw error;
+  }
+}

--- a/packages/typegraph/src/backend/sqlite/local-store.ts
+++ b/packages/typegraph/src/backend/sqlite/local-store.ts
@@ -1,0 +1,57 @@
+/**
+ * Declaration-isolated local SQLite store for strict TypeScript consumers.
+ *
+ * This Node.js-only entrypoint owns its public options and deliberately omits
+ * query-builder, raw backend, transaction, and Drizzle surfaces. Use the root
+ * package entrypoint when those advanced APIs are required.
+ */
+import { type GraphDef } from "../../core/define-graph";
+import { createStoreWithSchema } from "../../store/store";
+import { type TypedStoreFacade } from "../../store/typed-store-facade";
+import { createLocalSqliteBackend } from "./local";
+
+export type {
+  TypedCreateOptions,
+  TypedEdge,
+  TypedEdgeCollection,
+  TypedEdgeCollections,
+  TypedEdgeCreateArguments,
+  TypedEdgeMeta,
+  TypedFindOptions,
+  TypedNode,
+  TypedNodeCollection,
+  TypedNodeCollections,
+  TypedNodeMeta,
+  TypedNodeRef,
+  TypedStoreFacade,
+} from "../../store/typed-store-facade";
+
+/** Options accepted by {@link createLocalSqliteStore}. */
+export type LocalSqliteStoreOptions = Readonly<{
+  /** SQLite file path. Defaults to an in-memory database. */
+  path?: string;
+}>;
+
+/**
+ * Creates, provisions, and returns a typed local SQLite store.
+ *
+ * This convenience entrypoint is Node.js-only because it opens
+ * `better-sqlite3`. It uses the standard TypeGraph tables and default local
+ * SQLite pragmas. Import advanced backend, query, transaction, history, or raw
+ * SQL APIs from the existing root and SQLite entrypoints instead.
+ */
+export async function createLocalSqliteStore<G extends GraphDef>(
+  graph: G,
+  options: LocalSqliteStoreOptions = {},
+): Promise<TypedStoreFacade<G>> {
+  const { backend } = createLocalSqliteBackend(
+    options.path === undefined ? {} : { path: options.path },
+  );
+  try {
+    const [store] = await createStoreWithSchema(graph, backend);
+    return store;
+  } catch (error) {
+    await backend.close();
+    throw error;
+  }
+}

--- a/packages/typegraph/src/store/typed-store-facade.ts
+++ b/packages/typegraph/src/store/typed-store-facade.ts
@@ -1,0 +1,188 @@
+/**
+ * Declaration-safe structural view of TypeGraph's collection store.
+ *
+ * These public types deliberately depend only on the core graph DSL and Zod.
+ * Backend, query-builder, transaction, history, and raw SQL types are omitted.
+ */
+import { type z } from "zod";
+
+import { type GraphDef } from "../core/define-graph";
+import {
+  type AnyEdgeType,
+  type EdgeId,
+  type EdgeRegistration,
+  type NodeId,
+  type NodeType,
+} from "../core/types";
+
+/** Creation options shared by node and edge collection writes. */
+export type TypedCreateOptions = Readonly<{
+  id?: string;
+  validFrom?: string;
+  validTo?: string;
+}>;
+
+/** Temporal and audit metadata returned with a node. */
+export type TypedNodeMeta = Readonly<{
+  validFrom: string | undefined;
+  validTo: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | undefined;
+  version: number;
+}>;
+
+/** Temporal and audit metadata returned with an edge. */
+export type TypedEdgeMeta = Readonly<{
+  validFrom: string | undefined;
+  validTo: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | undefined;
+}>;
+
+/** A schema-derived node returned by the typed store facade. */
+export type TypedNode<N extends NodeType> = Readonly<{
+  kind: N["kind"];
+  id: NodeId<N>;
+  meta: TypedNodeMeta;
+}> &
+  Readonly<z.output<N["schema"]>>;
+
+/** A schema-derived edge returned by the typed store facade. */
+export type TypedEdge<
+  E extends AnyEdgeType,
+  From extends NodeType = NodeType,
+  To extends NodeType = NodeType,
+> = Readonly<{
+  id: EdgeId<E>;
+  kind: E["kind"];
+  fromKind: From["kind"];
+  fromId: NodeId<From>;
+  toKind: To["kind"];
+  toId: NodeId<To>;
+  meta: TypedEdgeMeta;
+}> &
+  Readonly<z.output<E["schema"]>>;
+
+/** A typed node or explicit node identity accepted as an edge endpoint. */
+export type TypedNodeRef<N extends NodeType> =
+  TypedNode<N> | Readonly<{ kind: N["kind"]; id: string }>;
+
+/** Pagination supported by the declaration-safe collection facade. */
+export type TypedFindOptions = Readonly<{
+  limit?: number;
+  offset?: number;
+}>;
+
+/** Safe CRUD operations for one schema-derived node kind. */
+export type TypedNodeCollection<N extends NodeType> = Readonly<{
+  create: (
+    props: z.input<N["schema"]>,
+    options?: TypedCreateOptions,
+  ) => Promise<TypedNode<N>>;
+  getById: (id: NodeId<N>) => Promise<TypedNode<N> | undefined>;
+  getByIds: (
+    ids: readonly NodeId<N>[],
+  ) => Promise<readonly (TypedNode<N> | undefined)[]>;
+  update: (
+    id: NodeId<N>,
+    props: Partial<z.input<N["schema"]>>,
+    options?: Readonly<{ validTo?: string }>,
+  ) => Promise<TypedNode<N>>;
+  delete: (id: NodeId<N>) => Promise<void>;
+  find: (options?: TypedFindOptions) => Promise<TypedNode<N>[]>;
+  count: () => Promise<number>;
+}>;
+
+/**
+ * Arguments after edge endpoints. Properties are optional only when the edge
+ * schema accepts an empty object.
+ */
+/* eslint-disable @typescript-eslint/no-empty-object-type -- {} tests whether the schema accepts an empty object */
+export type TypedEdgeCreateArguments<E extends AnyEdgeType> =
+  {} extends z.input<E["schema"]> ?
+    [props?: z.input<E["schema"]>, options?: TypedCreateOptions]
+  : [props: z.input<E["schema"]>, options?: TypedCreateOptions];
+/* eslint-enable @typescript-eslint/no-empty-object-type */
+
+/** Safe CRUD operations for one schema-derived edge kind. */
+export type TypedEdgeCollection<
+  E extends AnyEdgeType,
+  From extends NodeType = NodeType,
+  To extends NodeType = NodeType,
+> = Readonly<{
+  create: (
+    from: TypedNodeRef<From>,
+    to: TypedNodeRef<To>,
+    ...args: TypedEdgeCreateArguments<E>
+  ) => Promise<TypedEdge<E, From, To>>;
+  getById: (id: EdgeId<E>) => Promise<TypedEdge<E, From, To> | undefined>;
+  getByIds: (
+    ids: readonly EdgeId<E>[],
+  ) => Promise<readonly (TypedEdge<E, From, To> | undefined)[]>;
+  update: (
+    id: EdgeId<E>,
+    props: Partial<z.input<E["schema"]>>,
+    options?: Readonly<{ validTo?: string }>,
+  ) => Promise<TypedEdge<E, From, To>>;
+  delete: (id: EdgeId<E>) => Promise<void>;
+  findFrom: (from: TypedNodeRef<From>) => Promise<TypedEdge<E, From, To>[]>;
+  findTo: (to: TypedNodeRef<To>) => Promise<TypedEdge<E, From, To>[]>;
+  find: (
+    options?: TypedFindOptions &
+      Readonly<{
+        from?: TypedNodeRef<From>;
+        to?: TypedNodeRef<To>;
+      }>,
+  ) => Promise<TypedEdge<E, From, To>[]>;
+  count: (
+    endpoints?: Readonly<{
+      from?: TypedNodeRef<From>;
+      to?: TypedNodeRef<To>;
+    }>,
+  ) => Promise<number>;
+}>;
+
+/** Schema-derived node collections for a graph. */
+export type TypedNodeCollections<G extends GraphDef> = {
+  [K in keyof G["nodes"] & string]-?: TypedNodeCollection<
+    G["nodes"][K]["type"]
+  >;
+};
+
+/** Extracts the permitted source node types from an edge registration. */
+export type TypedEdgeFromTypes<R extends EdgeRegistration> =
+  R["from"] extends readonly (infer N)[] ? N : never;
+
+/** Extracts the permitted target node types from an edge registration. */
+export type TypedEdgeToTypes<R extends EdgeRegistration> =
+  R["to"] extends readonly (infer N)[] ? N : never;
+
+/** Builds a typed edge collection from a graph edge registration. */
+export type TypedEdgeCollectionFor<R extends EdgeRegistration> =
+  TypedEdgeCollection<
+    R["type"],
+    TypedEdgeFromTypes<R> extends NodeType ? TypedEdgeFromTypes<R> : NodeType,
+    TypedEdgeToTypes<R> extends NodeType ? TypedEdgeToTypes<R> : NodeType
+  >;
+
+/** Schema-derived edge collections for a graph. */
+export type TypedEdgeCollections<G extends GraphDef> = {
+  [K in keyof G["edges"] & string]-?: TypedEdgeCollectionFor<G["edges"][K]>;
+};
+
+/**
+ * Narrow structural view of the existing runtime Store.
+ *
+ * Advanced query, backend, transaction, history, and raw SQL members are
+ * intentionally absent so their Drizzle-linked declarations remain outside a
+ * strict consumer's TypeScript program.
+ */
+export type TypedStoreFacade<G extends GraphDef> = Readonly<{
+  graph: G;
+  graphId: string;
+  nodes: TypedNodeCollections<G>;
+  edges: TypedEdgeCollections<G>;
+  close: () => Promise<void>;
+}>;

--- a/packages/typegraph/tsup.config.ts
+++ b/packages/typegraph/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    "core/index": "src/core/index.ts",
     "interchange/index": "src/interchange/index.ts",
     "profiler/index": "src/profiler/index.ts",
     "schema/index": "src/schema/index.ts",
@@ -12,9 +13,11 @@ export default defineConfig({
     "provenance/index": "src/provenance/index.ts",
     "backend/sqlite/index": "src/backend/sqlite/index.ts",
     "backend/sqlite/local": "src/backend/sqlite/local.ts",
+    "backend/sqlite/local-store": "src/backend/sqlite/local-store.ts",
     "backend/sqlite/libsql": "src/backend/sqlite/libsql.ts",
     "backend/postgres/index": "src/backend/postgres/index.ts",
     "backend/postgres/pglite": "src/backend/postgres/pglite.ts",
+    "backend/postgres/pglite-store": "src/backend/postgres/pglite-store.ts",
   },
   format: ["esm", "cjs"],
   dts: true,

--- a/packages/typegraph/tsup.safe-declarations.config.ts
+++ b/packages/typegraph/tsup.safe-declarations.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    "core/index": "src/core/index.ts",
+    "backend/sqlite/local-store": "src/backend/sqlite/local-store.ts",
+    "backend/postgres/pglite-store": "src/backend/postgres/pglite-store.ts",
+  },
+  outDir: "dist",
+  format: ["esm", "cjs"],
+  dts: { only: true },
+  clean: false,
+});

--- a/packages/typegraph/type-smoke/strict-local-consumers.ts
+++ b/packages/typegraph/type-smoke/strict-local-consumers.ts
@@ -1,0 +1,83 @@
+import { defineEdge, defineGraph, defineNode } from "@nicia-ai/typegraph/core";
+import { createLocalPgliteStore } from "@nicia-ai/typegraph/postgres/pglite-store";
+import {
+  createLocalSqliteStore,
+  type TypedStoreFacade,
+} from "@nicia-ai/typegraph/sqlite/local-store";
+import { z } from "zod";
+
+const Fact = defineNode("Fact", {
+  schema: z.object({ statement: z.string() }),
+});
+
+const Source = defineNode("Source", {
+  schema: z.object({ url: z.url() }),
+});
+
+const supports = defineEdge("supports", {
+  schema: z.object({ confidence: z.number().min(0).max(1) }),
+});
+
+const graph = defineGraph({
+  id: "strict-local-consumers",
+  nodes: { Fact: { type: Fact }, Source: { type: Source } },
+  edges: {
+    supports: { type: supports, from: [Source], to: [Fact] },
+  },
+});
+
+type ExerciseResult = Readonly<{
+  statement: string;
+  confidence: number;
+  factCount: number;
+}>;
+
+async function exerciseStore(
+  store: TypedStoreFacade<typeof graph>,
+): Promise<ExerciseResult> {
+  try {
+    const source = await store.nodes.Source.create({
+      url: "https://example.com/source",
+    });
+    const fact = await store.nodes.Fact.create({ statement: "draft" });
+    if (false) {
+      // @ts-expect-error The Fact schema requires a string statement.
+      await store.nodes.Fact.create({ statement: 42 });
+      // @ts-expect-error The supports edge only accepts Source -> Fact.
+      await store.edges.supports.create(fact, source, { confidence: 0.5 });
+    }
+    const updatedFact = await store.nodes.Fact.update(fact.id, {
+      statement: "verified",
+    });
+    const edge = await store.edges.supports.create(source, updatedFact, {
+      confidence: 0.9,
+    });
+
+    const fetchedFact = await store.nodes.Fact.getById(updatedFact.id);
+    const fetchedEdge = await store.edges.supports.getById(edge.id);
+    if (fetchedFact === undefined || fetchedEdge === undefined) {
+      throw new Error("Packed local consumer could not read created records.");
+    }
+
+    await store.edges.supports.delete(edge.id);
+    await store.nodes.Fact.delete(updatedFact.id);
+
+    return {
+      statement: fetchedFact.statement,
+      confidence: fetchedEdge.confidence,
+      factCount: await store.nodes.Fact.count(),
+    };
+  } finally {
+    await store.close();
+  }
+}
+
+export async function exerciseStrictLocalConsumers(): Promise<
+  Readonly<{ sqlite: ExerciseResult; pglite: ExerciseResult }>
+> {
+  const sqliteStore = await createLocalSqliteStore(graph);
+  const sqlite = await exerciseStore(sqliteStore);
+  const pgliteStore = await createLocalPgliteStore(graph, { vector: false });
+  const pglite = await exerciseStore(pgliteStore);
+  return { sqlite, pglite };
+}


### PR DESCRIPTION
Closes #299.

## What changed

- add a declaration-isolated `@nicia-ai/typegraph/core` subpath
- add managed `sqlite/local-store` and `postgres/pglite-store` convenience entrypoints
- expose the existing runtime store through one small, TypeGraph-owned structural CRUD facade
- preserve schema-derived node, edge, property, ID, and endpoint types
- emit the safe entrypoint declarations in an isolated second pass so shared tsup chunks cannot pull Drizzle declarations back in
- add documentation, release export coverage, and a patch changeset

## Root cause

The public root `Store<G>` declaration reaches query and backend types, which in turn reaches Drizzle's root declaration graph. Even a `Pick<Store<...>>` forces strict consumers to typecheck unused Drizzle dialect declarations. A combined multi-entry tsup declaration build also shares declaration chunks broadly enough to contaminate an otherwise clean core entrypoint.

The new local-store entrypoints own their public types and return the existing runtime store structurally. Their declaration graph depends only on TypeGraph core types and Zod.

Production PostgreSQL remains on the existing driver-agnostic entrypoint; the new PostgreSQL convenience path covers the directly parallel in-process PGlite consumer without choosing `pg`, postgres.js, or Neon on the caller's behalf.

## Validation

- `pnpm test` — 5,143 passed, 1,096 skipped
- `pnpm test:postgres` — 2,141 passed
- `pnpm typecheck` — passed
- `pnpm --filter @nicia-ai/typegraph lint` — 0 errors (8 existing disabled-test warnings)
- packed TypeScript 6.0.3 fixture with `skipLibCheck: false` — passed for SQLite and PGlite
- packed compiler file list — zero Drizzle declarations loaded and no unrelated database drivers installed
- runtime node/edge CRUD — passed on both SQLite and PGlite
- release tarball smoke — 16 public subpaths passed under ESM and CommonJS
- Prettier, Markdown lint, and `git diff --check` — passed

The repository-wide `pnpm fix` remains blocked by two unrelated pre-existing unsafe-assignment errors in `apps/docs/src/actions/index.ts`; the changed package and documentation files were checked directly.