### PR TITLE
Harden TypeGraph 0.38 adapter capability surfaces

### DIFF
--- a/.changeset/honest-adapter-capabilities.md
+++ b/.changeset/honest-adapter-capabilities.md
@@ -1,0 +1,8 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Require adapter transaction callers to narrow `sqlAvailability` before reading
+`tx.sql`, skip unsupported statistics maintenance on Durable Object SQLite, and
+open graph-merge provenance sidecars from the target Store instead of requiring
+a full backend handle.

--- a/.changeset/honest-adapter-capabilities.md
+++ b/.changeset/honest-adapter-capabilities.md
@@ -2,7 +2,17 @@
 "@nicia-ai/typegraph": minor
 ---
 
-Require adapter transaction callers to narrow `sqlAvailability` before reading
-`tx.sql`, skip unsupported statistics maintenance on Durable Object SQLite, and
-open graph-merge provenance sidecars from the target Store instead of requiring
-a full backend handle.
+Harden adapter capability surfaces and document their migrations.
+
+This is source-breaking for adapter code that reads `tx.sql` without first
+narrowing `tx.sqlAvailability === "available"`: non-available union arms now
+omit `sql` instead of exposing it as an optional `never`/`undefined` property.
+The runtime history and revision-tracking guards remain fail-loud for JavaScript
+and type-suppressed callers.
+
+Add `openProvenanceStore(targetStore)` as the preferred graph-merge provenance
+API while retaining `openProvenanceStore(backend, targetGraphId)` for standalone
+inspection tools. On Cloudflare D1 and Durable Object SQLite, ignore only a
+recognized `SQLITE_AUTH` rejection of the performance-only `analysis_limit`
+PRAGMA and continue with scoped `ANALYZE`; unexpected maintenance failures stay
+visible.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -815,7 +815,9 @@ export class MyObject {
     // Atomic across TypeGraph + the product's own relational tables:
     await store.transaction(async (tx) => {
       await tx.nodes.Document.update(documentId, props);
-      if (tx.sql === undefined) throw new Error("Native transaction unavailable");
+      if (tx.sqlAvailability !== "available") {
+        throw new Error(`Native transaction unavailable: ${tx.sqlAvailability}`);
+      }
       const sqlTx = tx.sql;
       await sqlTx.insert(documentVersions).values(versionRow);
     });

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -508,9 +508,15 @@ await store.refreshStatistics();
 
 The implementation runs `ANALYZE` against the TypeGraph-managed tables in
 the configured backend — the call is safe regardless of custom table names
-or fulltext / embedding configuration. If you need to bypass the API for an
-unusual deployment (for example issuing `ANALYZE` over a separate admin
-connection), call `backend.execute()` with raw SQL as the escape hatch.
+or fulltext / embedding configuration. Cloudflare D1 and Durable Object SQLite
+reject the performance-only `PRAGMA analysis_limit` tuning statement through
+their authorizer. TypeGraph recognizes only that `SQLITE_AUTH` failure and
+continues with scoped `ANALYZE`; workerd permits `ANALYZE`, so planner statistics
+are still refreshed but without bounded sampling. Unexpected PRAGMA or ANALYZE
+failures stay visible through the existing caller warning or rejection. If you
+need to bypass the API for an unusual deployment (for example issuing `ANALYZE`
+over a separate admin connection), call `backend.execute()` with raw SQL as the
+escape hatch.
 
 ### pgbouncer / transaction-pool mode
 
@@ -790,6 +796,9 @@ The runtime authorizer forbids temporary tables, so the same profile reports
 `shortestPath`, `reachable`, and `weightedShortestPath` automatically use their
 inline fallback; temporary-table-only analytics such as
 `weaklyConnectedComponents` throw `UnsupportedBackendCapabilityError`.
+The authorizer also rejects SQLite's `analysis_limit` tuning PRAGMA. Statistics
+refresh catches that specific authorization error and still runs scoped
+`ANALYZE`; this affects refresh cost only, not query results.
 The same profile advertises Cloudflare's 100-bound-parameter query limit.
 TypeGraph uses that hard ceiling for its managed write batches and
 recorded-history flushes; capability overrides may lower it but cannot raise
@@ -886,6 +895,7 @@ TypeGraph choosing separate query semantics per backend:
 | Filtered approximate search **guarantees** a full page | ✓ `sqlite-vec` / ✗ `libsql-native`                | ✗ (`pgvector` recovers, but is bounded)    | Only `sqlite-vec` guarantees it; the others can return **fewer than `limit`** rows under heavy filtering — see below      |
 | Per-query fulltext `language` override                 | ✗                                                 | ✓                                          | Throws on SQLite — FTS5's tokenizer is fixed at table-create time; `tsvector` accepts a regconfig per query               |
 | HNSW `efSearch` query tuning                           | ✗                                                 | ✓                                          | Silent no-op on SQLite; Postgres applies `hnsw.ef_search`. Performance only — same results                                |
+| Bounded planner-statistics sampling                    | ✓ standard connections / ✗ D1 and Durable Objects | Native `ANALYZE` sampling                  | Restricted SQLite skips `analysis_limit` but still attempts scoped `ANALYZE`. Performance only — same results             |
 
 ### Filtered approximate search
 

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -428,7 +428,7 @@ Query persisted provenance back later:
 ```typescript
 import { openProvenanceStore, readProvenance } from "@nicia-ai/typegraph/graph-merge";
 
-const store = await openProvenanceStore(target.backend, target.graphId);
+const store = await openProvenanceStore(target);
 const fromAgentA = await readProvenance(store, { branchId: "agent-a" }); // what did agent A contribute?
 const whoMadeX = await readProvenance(store, { canonicalId: "patient-123" }); // who contributed node X?
 ```

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -433,6 +433,13 @@ const fromAgentA = await readProvenance(store, { branchId: "agent-a" }); // what
 const whoMadeX = await readProvenance(store, { canonicalId: "patient-123" }); // who contributed node X?
 ```
 
+Inspection tools that have a backend and graph id but not the target's
+`GraphDef` can use the standalone overload:
+
+```typescript
+const store = await openProvenanceStore(backend, targetGraphId);
+```
+
 ## Snapshot vs incremental
 
 A branch is forked from a `base@V` — a token combining the base's schema hash

--- a/apps/docs/src/content/docs/integration.md
+++ b/apps/docs/src/content/docs/integration.md
@@ -638,7 +638,9 @@ export class GraphObject {
     // Atomic across TypeGraph + the caller's own relational tables:
     await store.transaction(async (tx) => {
       await tx.nodes.Document.update(documentId, props);
-      if (tx.sql === undefined) throw new Error("Native transaction unavailable");
+      if (tx.sqlAvailability !== "available") {
+        throw new Error(`Native transaction unavailable: ${tx.sqlAvailability}`);
+      }
       const sqlTx = tx.sql;
       await sqlTx.insert(documentVersions).values(versionRow);
     });

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -96,9 +96,9 @@ created with `createAdapterStore` or `createAdapterStoreWithSchema` and
 below both require:
 
 - **Write your own tables through the external handle you passed in**, never
-  through `tx.sql`. Under history capture `tx.sql` is a present-but-throwing
-  guard (raw SQL would bypass recorded-time capture); its static type is
-  `sql?: never` and every access raises a
+  through `tx.sql`. Under history capture the typed transaction context omits
+  `sql` (raw SQL would bypass recorded-time capture); suppressed access reaches
+  a runtime guard and raises a
   [`ConfigurationError`](/errors/#recorded-capture-guard-codes). The external
   handle *is* the pinned connection, so writing your cursor row through it keeps
   both layers in the one transaction.

--- a/apps/docs/src/content/docs/queries/temporal.md
+++ b/apps/docs/src/content/docs/queries/temporal.md
@@ -283,11 +283,11 @@ internal to TypeGraph's query and transaction implementation.
 `store.withTransaction` on a history-enabled store is a **compile error** (the
 `externalTx` argument is rejected with a message naming
 `withRecordedTransaction`); the runtime guard still throws `ConfigurationError`
-if suppressed. Inside an `AdapterHistoryStore.transaction(...)`, `tx.sql` is
-present but throwing:
-its static type is `sql?: never`, and `tx.sqlAvailability` reports `"history"`
-(or `"revisionTracking"`) so portable code can branch without touching the
-throwing handle — see the `tx.sqlAvailability` guidance in
+if suppressed. Inside an `AdapterHistoryStore.transaction(...)`, the typed
+context omits `tx.sql`, and `tx.sqlAvailability` reports `"history"` (or
+`"revisionTracking"`) so portable code can branch without touching the runtime
+guard. Suppressed JavaScript or TypeScript access still throws — see the
+`tx.sqlAvailability` guidance in
 [Cross-Store Transactions](/recipes/).
 Both guards carry a branchable `details.code`; see
 [Recorded-capture guard codes](/errors/#recorded-capture-guard-codes).

--- a/apps/docs/src/content/docs/recipes.md
+++ b/apps/docs/src/content/docs/recipes.md
@@ -729,7 +729,9 @@ handle automatically:
 ```typescript
 await store.transaction(async (tx) => {
   await tx.nodes.Document.update(documentId, props);
-  if (tx.sql === undefined) throw new Error("Native transaction unavailable");
+  if (tx.sqlAvailability !== "available") {
+    throw new Error(`Native transaction unavailable: ${tx.sqlAvailability}`);
+  }
   const sqlTx = tx.sql;
   await sqlTx.insert(documentVersions).values(versionRow);
   await sqlTx.insert(changeEvents).values(eventRow);
@@ -754,13 +756,12 @@ not on `tx.sql`'s truthiness:
 await store.transaction(async (tx) => {
   switch (tx.sqlAvailability) {
     case "available": {
-      if (tx.sql === undefined) throw new Error("Native transaction unavailable");
       const sqlTx = tx.sql;
       await sqlTx.insert(documentVersions).values(versionRow);
       break;
     }
     case "unavailable":
-      // Non-transactional fallback: tx.sql === undefined, no atomicity.
+      // Non-transactional fallback: no tx.sql property and no atomicity.
       await writeWithoutAtomicity();
       break;
     case "history":
@@ -773,14 +774,12 @@ await store.transaction(async (tx) => {
 });
 ```
 
-`tx.sql` is `undefined` — and `tx.sqlAvailability` is `"unavailable"` — only on
-the non-transactional fallback (`capabilities.transactions === false`), where
-`store.transaction` runs the callback with no atomicity and there is no
-transaction to join. Under `history: true` or `revisionTracking: true`, `tx.sql`
-is **present but throwing** (`sqlAvailability` is `"history"` /
-`"revisionTracking"`); its static type is `sql?: never` so a mistaken
-`tx.sql.run(...)` fails to typecheck, and at runtime every access throws
-`ConfigurationError`. The thrown error carries a branchable `details.code` — see
+When `tx.sqlAvailability` is `"unavailable"`, the callback is running without
+atomicity and there is no native transaction to join. The non-available union
+arms omit the `sql` property, so even reading `tx.sql` requires first narrowing
+the discriminant to `"available"`. Suppressed JavaScript or TypeScript access
+under `history: true` or `revisionTracking: true` still throws
+`ConfigurationError`; the error carries a branchable `details.code` — see
 [Recorded-capture guard codes](/errors/#recorded-capture-guard-codes).
 
 ## Enforcing Unique Constraints

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -2245,8 +2245,9 @@ asRecordedInstant(value: string): RecordedInstant; // brand an external timestam
 Adopt an external transaction under `history: true` with the callback form
 `store.withRecordedTransaction(externalTx, async (tx) => ...)`, which flushes
 capture before the caller commits. `store.withTransaction(...)` is a compile
-error on a history store, and raw `tx.sql` is present-but-throwing — branch on
-`tx.sqlAvailability` (`"history"`) rather than truthiness-testing `tx.sql`. See
+error on a history store, and the typed history transaction context omits raw
+`tx.sql`. Branch on `tx.sqlAvailability` (`"history"`) before accessing the SQL
+handle. See
 [Recorded time](/queries/temporal#recorded-time-bitemporal) for the full guide.
 
 ## Observability Hooks

--- a/packages/typegraph/CHANGELOG.md
+++ b/packages/typegraph/CHANGELOG.md
@@ -60,6 +60,10 @@
   `StoreRef` values are preserved without downstream casts. Remove casts that
   existed only to restore the old widened evolution result.
 
+  Requiring the `sqlAvailability` check is source-breaking for adapter code that
+  previously read `tx.sql` from the unnarrowed union. Narrow on the discriminant
+  before passing the handle to even an `unknown`-typed sink.
+
   `GraphBackend` is now the portable TypeGraph backend port. Native transaction
   adoption lives on `AdapterBackend<TNativeTransaction>`, so a capability-less
   backend cannot be passed to an adapter-store factory. Portable transaction

--- a/packages/typegraph/CHANGELOG.md
+++ b/packages/typegraph/CHANGELOG.md
@@ -41,6 +41,25 @@
   `createAdapterStoreWithSchema`, and `createVerifiedAdapterStore` counterparts
   when the application deliberately needs adapter-native interoperability.
 
+  Migration map:
+
+  | 0.37 use | 0.38 replacement |
+  | --- | --- |
+  | `createStoreWithSchema(...)` followed by `tx.sql` | `createAdapterStoreWithSchema(...)` |
+  | `Store<G, TNativeTransaction>` | `AdapterStore<G, TNativeTransaction>` |
+  | `TransactionContext<G, TNativeTransaction>` | `AdapterTransactionContext<G, TNativeTransaction>` |
+  | `HistoryTransactionContext<G>` | `TransactionContext<G>` for portable history stores, or `AdapterHistoryTransactionContext<G>` for adapter history stores |
+  | `AdoptedTransaction` | The adapter's concrete native-handle type, such as `AnySqliteDatabase` or `AnyPgTransaction`, passed as the adapter generic |
+
+  `HistoryTransactionContext` and `MeasurableHistoryTransactionContext` were
+  removed rather than retained as aliases. Portable stores have one SQL-free
+  transaction context across live and history modes. Adapter contexts expose
+  `sql` only after `sqlAvailability === "available"`; the other discriminated
+  union arms omit the property. Store evolution is now generic over the exact
+  Store flavor, so adapter/history/recorded-read surfaces and compatible
+  `StoreRef` values are preserved without downstream casts. Remove casts that
+  existed only to restore the old widened evolution result.
+
   `GraphBackend` is now the portable TypeGraph backend port. Native transaction
   adoption lives on `AdapterBackend<TNativeTransaction>`, so a capability-less
   backend cannot be passed to an adapter-store factory. Portable transaction
@@ -100,6 +119,25 @@
   SQL values come from TypeGraph's query compiler. Managed local stores now live
   at `/sqlite/local` and `/postgres/pglite`; bring-your-own-connection APIs live
   under `/adapters/drizzle/sqlite...` and `/adapters/drizzle/postgres...`.
+
+  The old `@nicia-ai/typegraph/sqlite` and
+  `@nicia-ai/typegraph/postgres` entrypoints were removed. They are not
+  compatibility aliases because those names now distinguish the managed Store
+  API from bring-your-own-connection adapters. Move imports as follows:
+
+  | 0.37 entrypoint | 0.38 entrypoint |
+  | --- | --- |
+  | `/sqlite` | `/adapters/drizzle/sqlite` |
+  | `/sqlite/local` for `createLocalSqliteBackend` | `/adapters/drizzle/sqlite/local` |
+  | `/sqlite/libsql` | `/adapters/drizzle/sqlite/libsql` |
+  | `/postgres` | `/adapters/drizzle/postgres` |
+  | `/postgres/pglite` for `createLocalPgliteBackend` | `/adapters/drizzle/postgres/pglite` |
+
+  The managed `/sqlite/local` and `/postgres/pglite` entrypoints keep Drizzle
+  out of their public declarations, but their built-in database implementation
+  still uses Drizzle internally. `drizzle-orm` therefore remains a required peer
+  of the 0.38 package; declaration isolation does not imply installation
+  isolation.
 
 - [#298](https://github.com/nicia-ai/typegraph/pull/298) [`f178663`](https://github.com/nicia-ai/typegraph/commit/f1786634e7867b892805349dc922269e155d1d65) Thanks [@pdlug](https://github.com/pdlug)! - Add deterministic synchronous label propagation with exact binary tie-breaking,
   induced node-kind scope, temporal and recorded-time views, bind-independent

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2527,6 +2527,9 @@ type OntologyRelation = Readonly<{
 export function openProvenanceStore<G extends GraphDef>(target: Store<G>): Promise<Store<ProvenanceGraph>>;
 
 // @public
+export function openProvenanceStore(backend: GraphBackend, targetGraphId: string): Promise<Store<ProvenanceGraph>>;
+
+// @public
 type OrderSpec = Readonly<{
     field: FieldRef;
     direction: SortDirection;

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2524,7 +2524,7 @@ type OntologyRelation = Readonly<{
 }>;
 
 // @public
-export function openProvenanceStore(backend: GraphBackend, targetGraphId: string): Promise<Store<ProvenanceGraph>>;
+export function openProvenanceStore<G extends GraphDef>(target: Store<G>): Promise<Store<ProvenanceGraph>>;
 
 // @public
 type OrderSpec = Readonly<{

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -37,7 +37,6 @@ type AdapterHistoryStoreTransactions<G extends GraphDef, TNativeTransaction> = R
 
 // @public (undocumented)
 export type AdapterHistoryTransactionContext<G extends GraphDef, TNativeTransaction> = Omit<AdapterTransactionContext<G, TNativeTransaction>, "sql" | "sqlAvailability"> & Readonly<{
-    sql?: never;
     sqlAvailability: "history";
 }>;
 
@@ -68,10 +67,8 @@ type AdapterTransactionSqlAccess<TNativeTransaction> = Readonly<{
     sql: TNativeTransaction;
     sqlAvailability: "available";
 }> | Readonly<{
-    sql?: never;
     sqlAvailability: "history" | "revisionTracking";
 }> | Readonly<{
-    sql?: undefined;
     sqlAvailability: "unavailable";
 }>;
 

--- a/packages/typegraph/examples/19-incremental-merge.ts
+++ b/packages/typegraph/examples/19-incremental-merge.ts
@@ -221,10 +221,7 @@ async function main(): Promise<void> {
     // Query the DURABLE provenance back later: "what did this provider
     // contribute?" The sidecar store SHARES the target's backend, so it must not
     // be closed separately — it goes away when the target's backend closes below.
-    const provenanceStore = await openProvenanceStore(
-      target.backend,
-      target.graphId,
-    );
+    const provenanceStore = await openProvenanceStore(target);
     const contributed = await readProvenance(provenanceStore, {
       branchId: PROVIDER,
     });

--- a/packages/typegraph/examples/25-transactions.ts
+++ b/packages/typegraph/examples/25-transactions.ts
@@ -4,10 +4,10 @@
  * `store.transaction(async (tx) => { ... })` runs a callback in which every
  * write either commits together or rolls back together. The callback receives
  * a transaction context with the same collection API as the store —
- * `tx.nodes.<Kind>` and `tx.edges.<name>` — plus `tx.sql`, the raw Drizzle
- * handle bound to the same transaction for the caller's own relational
- * tables. The callback's return value becomes the return value of
- * `store.transaction()`.
+ * `tx.nodes.<Kind>` and `tx.edges.<name>`. Adapter stores additionally expose a
+ * raw Drizzle handle for the caller's own relational tables after
+ * `tx.sqlAvailability` is narrowed to `"available"`. The callback's return
+ * value becomes the return value of `store.transaction()`.
  *
  * The motivating scenario: placing an order must write an Order node,
  * decrement the inventory it draws from, AND link the two with a `fulfills`

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1580,6 +1580,12 @@ export function createSqliteBackend(
     },
 
     async refreshStatistics(): Promise<void> {
+      // Cloudflare Durable Object SQLite forbids maintenance PRAGMAs such as
+      // `analysis_limit` with SQLITE_AUTH. Index DDL itself is supported, so
+      // boot/materialization may still create the index; statistics refresh is
+      // the only unsupported follow-up and is intentionally a no-op.
+      if (transactionMode === "do-sqlite") return;
+
       // `ANALYZE` populates `sqlite_stat1`. With no stat table, the
       // planner falls back to heuristics that, at least for FTS5
       // virtual-table queries and multi-column index selection, can be

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -50,7 +50,10 @@ import {
 } from "../../query/sql-fragment";
 import { type CompiledRowsSql } from "../../query/sql-intent";
 import { chunk as chunkArray } from "../../utils/array";
-import { isMissingTableError } from "../../utils/sql-errors";
+import {
+  isMissingTableError,
+  isSqliteNotAuthorizedError,
+} from "../../utils/sql-errors";
 import { buildLiveNodeCandidates } from "../live-node-candidates";
 import {
   type AdapterBackend,
@@ -1580,12 +1583,6 @@ export function createSqliteBackend(
     },
 
     async refreshStatistics(): Promise<void> {
-      // Cloudflare Durable Object SQLite forbids maintenance PRAGMAs such as
-      // `analysis_limit` with SQLITE_AUTH. Index DDL itself is supported, so
-      // boot/materialization may still create the index; statistics refresh is
-      // the only unsupported follow-up and is intentionally a no-op.
-      if (transactionMode === "do-sqlite") return;
-
       // `ANALYZE` populates `sqlite_stat1`. With no stat table, the
       // planner falls back to heuristics that, at least for FTS5
       // virtual-table queries and multi-column index selection, can be
@@ -1600,12 +1597,19 @@ export function createSqliteBackend(
       // fixed internal constant, not user input, so inlining it via
       // `sql.raw` is safe; SQLite's `PRAGMA` does not accept bound
       // parameters for its value.
-      await db.run(
-        toDrizzleSql(
-          portableSql`PRAGMA analysis_limit = ${portableSql.raw(String(SQLITE_ANALYZE_ROW_LIMIT))}`,
-          "sqlite",
-        ),
-      );
+      try {
+        await db.run(
+          toDrizzleSql(
+            portableSql`PRAGMA analysis_limit = ${portableSql.raw(String(SQLITE_ANALYZE_ROW_LIMIT))}`,
+            "sqlite",
+          ),
+        );
+      } catch (error) {
+        // Cloudflare D1 and Durable Object SQLite reject this performance-only
+        // tuning PRAGMA through their authorizer. Continue with scoped ANALYZE,
+        // which workerd permits, but keep every unexpected failure loud.
+        if (!isSqliteNotAuthorizedError(error)) throw error;
+      }
       for (const tableName of coreAnalyzeTables) {
         await db.run(
           toDrizzleSql(

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -1715,10 +1715,7 @@ async function resolveMerge<G extends GraphDef>(
       // write failure must NOT fail the merge — it surfaces as a warning. The
       // sidecar node ids are deterministic, so this UPSERTS (idempotent re-runs).
       try {
-        const provenanceStore = await openProvenanceStore(
-          storeBackend(target),
-          target.graphId,
-        );
+        const provenanceStore = await openProvenanceStore(target);
         const count = await persistProvenanceRecords(
           provenanceStore,
           target.graphId,

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -20,7 +20,7 @@
 import { z } from "zod";
 
 import { compareStrings } from "./node-key";
-import type { GraphDef, Node, Store } from "./typegraph-internal";
+import type { GraphBackend, GraphDef, Node, Store } from "./typegraph-internal";
 import {
   createStoreWithSchema,
   defineGraph,
@@ -67,17 +67,32 @@ export type ProvenanceGraph = ReturnType<typeof buildProvenanceGraph>;
 export type ProvenanceNode = Node<typeof Provenance>;
 
 /**
- * Opens — materializing the schema if needed — the provenance store for a target
- * store. Idempotent: safe to call before every persist/query, and shares the
- * backend with the target (so the caller must NOT close it
- * separately — closing the shared backend is the target owner's job).
+ * Opens — materializing the schema if needed — the provenance store for a target.
+ * Pass the target Store in ordinary application code; inspection tools that do
+ * not have its GraphDef may instead pass the backend and target graph id.
+ *
+ * Idempotent: safe to call before every persist/query, and shares the backend
+ * with the target (so the caller must NOT close it separately — closing the
+ * shared backend is the target owner's job).
  */
-export async function openProvenanceStore<G extends GraphDef>(
+export function openProvenanceStore<G extends GraphDef>(
   target: Store<G>,
+): Promise<Store<ProvenanceGraph>>;
+/** Opens a provenance store for standalone inspection without a target GraphDef. */
+export function openProvenanceStore(
+  backend: GraphBackend,
+  targetGraphId: string,
+): Promise<Store<ProvenanceGraph>>;
+export async function openProvenanceStore<G extends GraphDef>(
+  ...args:
+    | readonly [target: Store<G>]
+    | readonly [backend: GraphBackend, targetGraphId: string]
 ): Promise<Store<ProvenanceGraph>> {
+  const [backend, targetGraphId] =
+    args.length === 1 ? [storeBackend(args[0]), args[0].graphId] : args;
   const [store] = await createStoreWithSchema(
-    buildProvenanceGraph(target.graphId),
-    storeBackend(target),
+    buildProvenanceGraph(targetGraphId),
+    backend,
   );
   return store;
 }

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -20,12 +20,13 @@
 import { z } from "zod";
 
 import { compareStrings } from "./node-key";
-import type { GraphBackend, Node, Store } from "./typegraph-internal";
+import type { GraphDef, Node, Store } from "./typegraph-internal";
 import {
   createStoreWithSchema,
   defineGraph,
   defineNode,
   sha256Hex,
+  storeBackend,
 } from "./typegraph-internal";
 import type { BranchId, ProvenanceRecord } from "./types";
 
@@ -67,17 +68,16 @@ export type ProvenanceNode = Node<typeof Provenance>;
 
 /**
  * Opens — materializing the schema if needed — the provenance store for a target
- * graph on the given backend. Idempotent: safe to call before every persist/query,
- * and shares the backend with the target (so the caller must NOT close it
+ * store. Idempotent: safe to call before every persist/query, and shares the
+ * backend with the target (so the caller must NOT close it
  * separately — closing the shared backend is the target owner's job).
  */
-export async function openProvenanceStore(
-  backend: GraphBackend,
-  targetGraphId: string,
+export async function openProvenanceStore<G extends GraphDef>(
+  target: Store<G>,
 ): Promise<Store<ProvenanceGraph>> {
   const [store] = await createStoreWithSchema(
-    buildProvenanceGraph(targetGraphId),
-    backend,
+    buildProvenanceGraph(target.graphId),
+    storeBackend(target),
   );
   return store;
 }

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -411,6 +411,15 @@ function overlayPropertyDescriptors<
   }) as TBase & TOverlay;
 }
 
+/** Keeps suppressed/JavaScript raw-SQL access fail-loud without advertising it. */
+function defineUnavailableSqlGuard(context: object, guard: () => never): void {
+  Object.defineProperty(context, "sql", {
+    configurable: false,
+    enumerable: true,
+    get: guard,
+  });
+}
+
 type StoreCore<G extends GraphDef> = Readonly<{
   [STORE_RUNTIME]: StoreRuntime<G>;
   graph: G;
@@ -1725,7 +1734,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * ```typescript
    * await store.transaction(async (tx) => {
    *   await tx.nodes.Document.update(documentId, props);
-   *   // cast `tx.sql` to your concrete Drizzle database type
+   *   if (tx.sqlAvailability !== "available") {
+   *     throw new Error("This operation requires a SQL-backed transaction");
+   *   }
+   *   // Narrowing makes the precisely typed native handle available.
    *   const sqlTx = tx.sql as NodePgDatabase;
    *   await sqlTx.insert(documentVersions).values(versionRow);
    * });
@@ -2357,18 +2369,16 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       withSql = {
         ...base,
         sqlAvailability: "history",
-        get sql(): never {
-          return throwHistoryUnsafeSqlAccess();
-        },
       };
+      defineUnavailableSqlGuard(withSql, () => throwHistoryUnsafeSqlAccess());
     } else if (this.#revisionTrackingEnabled) {
       withSql = {
         ...base,
         sqlAvailability: "revisionTracking",
-        get sql(): never {
-          return throwRevisionTrackingUnsafeSqlAccess();
-        },
       };
+      defineUnavailableSqlGuard(withSql, () =>
+        throwRevisionTrackingUnsafeSqlAccess(),
+      );
     } else if (sql === undefined) {
       withSql = { ...base, sqlAvailability: "unavailable" };
     } else {
@@ -3724,7 +3734,6 @@ export type AdapterHistoryTransactionContext<
   "sql" | "sqlAvailability"
 > &
   Readonly<{
-    sql?: never;
     sqlAvailability: "history";
   }>;
 
@@ -3732,7 +3741,7 @@ export type AdapterHistoryTransactionContext<
  * The {@link AdapterHistoryTransactionContext} handed to a `withRecordedTransaction`
  * callback, extended with {@link ScopedMeasure}. Its `measure` scopes to a child
  * {@link MeasurableAdapterHistoryTransactionContext} (so nested scopes keep the
- * history-safe `sql?: never` / backend typing). Assignable to
+ * history-safe absent-`sql` / backend typing). Assignable to
  * {@link MeasurableTransactionContext} (and hence to {@link TransactionContext}),
  * so a projector helper typed against either still accepts it.
  */

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -1469,9 +1469,10 @@ export type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
  * Whether — and why — `tx.sql` can be used on a transaction context. A single
  * required discriminant covering exactly the four states raw-SQL access can be
  * in, so an adapter caller branches on capability instead of truthiness-testing
- * `tx.sql`. Under history / revision tracking the public type makes `tx.sql`
- * unusable (`sql?: never`), while the runtime object keeps a fail-loud getter
- * for JavaScript and type-suppressed callers. See
+ * `tx.sql`. The non-available variants omit `sql` entirely, so even reading the
+ * handle requires first narrowing `sqlAvailability` to `"available"`. The
+ * runtime object keeps a fail-loud getter under history / revision tracking for
+ * JavaScript and type-suppressed callers. See
  * {@link AdapterTransactionContext} for the per-value semantics.
  */
 export type SqlAvailability =
@@ -1483,11 +1484,9 @@ type AdapterTransactionSqlAccess<TNativeTransaction> =
       sqlAvailability: "available";
     }>
   | Readonly<{
-      sql?: never;
       sqlAvailability: "history" | "revisionTracking";
     }>
   | Readonly<{
-      sql?: undefined;
       sqlAvailability: "unavailable";
     }>;
 

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -23,6 +23,7 @@ import { ConfigurationError } from "../errors";
 
 const SQLITE_MISSING_TABLE_PATTERN = "no such table";
 const SQLITE_GENERIC_ERROR_CODE = "SQLITE_ERROR";
+const SQLITE_NOT_AUTHORIZED_CODE = "SQLITE_AUTH";
 const DRIZZLE_QUERY_ERROR_PREFIX = "Failed query:";
 const POSTGRES_UNDEFINED_RELATION_PATTERN =
   /\b(?:relation|table)\s+"[^"]+"\s+does not exist\b/i;
@@ -178,6 +179,27 @@ export function isMissingTableError(error: unknown): boolean {
       }
     }
     if (!(link instanceof Error)) everyPriorLinkWasError = false;
+  }
+  return false;
+}
+
+/**
+ * Whether SQLite rejected a statement through its authorizer. Cloudflare D1
+ * and Durable Objects surface this as `not authorized: SQLITE_AUTH`, usually on
+ * a Drizzle wrapper's `.cause`; native drivers may instead expose
+ * `code: "SQLITE_AUTH"`. Both shapes are structural enough to distinguish from
+ * an unrelated permission or connection failure.
+ */
+export function isSqliteNotAuthorizedError(error: unknown): boolean {
+  for (const link of errorChain(error)) {
+    if (sqliteErrorCode(link) === SQLITE_NOT_AUTHORIZED_CODE) return true;
+    const message = messageProperty(link);
+    if (
+      message?.includes(SQLITE_NOT_AUTHORIZED_CODE) === true &&
+      message.toLowerCase().includes("not authorized")
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/typegraph/test-d/graph-merge.test-d.ts
+++ b/packages/typegraph/test-d/graph-merge.test-d.ts
@@ -1,7 +1,13 @@
 import { expectAssignable, expectError, expectType } from "tsd";
 import { z } from "zod";
 
-import { type GraphBackend, defineGraph, defineNode, type Store } from "..";
+import {
+  type AdapterHistoryStore,
+  type GraphBackend,
+  defineGraph,
+  defineNode,
+  type Store,
+} from "..";
 import {
   BranchError,
   type GraphBranch,
@@ -18,6 +24,8 @@ import {
   isOk,
   merge,
   normalizeMergeOptions,
+  openProvenanceStore,
+  type ProvenanceGraph,
   unwrap,
 } from "../dist/graph-merge";
 
@@ -36,6 +44,7 @@ const graph = defineGraph({
 
 declare const backend: GraphBackend;
 declare const store: Store<typeof graph>;
+declare const adapterHistoryStore: AdapterHistoryStore<typeof graph, unknown>;
 declare const branches: readonly GraphBranch<typeof graph>[];
 
 const makeBackend: MakeBackend = () => Promise.resolve(backend);
@@ -74,6 +83,10 @@ expectType<Promise<Result<GraphBranch<typeof graph>, BranchError>>>(
 );
 expectType<Promise<Result<MergeReport<typeof graph>, MergeError>>>(
   merge(store, branches, options),
+);
+expectType<Promise<Store<ProvenanceGraph>>>(openProvenanceStore(store));
+expectType<Promise<Store<ProvenanceGraph>>>(
+  openProvenanceStore(adapterHistoryStore),
 );
 
 declare const mergeResult: Result<MergeReport<typeof graph>, MergeError>;

--- a/packages/typegraph/test-d/graph-merge.test-d.ts
+++ b/packages/typegraph/test-d/graph-merge.test-d.ts
@@ -88,6 +88,9 @@ expectType<Promise<Store<ProvenanceGraph>>>(openProvenanceStore(store));
 expectType<Promise<Store<ProvenanceGraph>>>(
   openProvenanceStore(adapterHistoryStore),
 );
+expectType<Promise<Store<ProvenanceGraph>>>(
+  openProvenanceStore(backend, graph.id),
+);
 
 declare const mergeResult: Result<MergeReport<typeof graph>, MergeError>;
 if (isOk(mergeResult)) {

--- a/packages/typegraph/test-d/public-api.test-d.ts
+++ b/packages/typegraph/test-d/public-api.test-d.ts
@@ -505,7 +505,7 @@ const recordedOutcome = adapterHistoryStore.withRecordedTransaction(
         >
       >
     >(tx.measure);
-    expectError(tx.sql?.select());
+    expectError(tx.sql);
     expectError(tx.backend.executeRaw);
     expectError(tx.backend.executeStatement);
     expectError(tx.backend.executeDdl?.("DROP TABLE typegraph_nodes"));

--- a/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
@@ -268,7 +268,10 @@ describe.runIf(process.env["POSTGRES_URL"])(
       const store = createAdapterStore(PlainGraph, backend);
 
       const source = await store.transaction(async (tx) => {
-        const sqlTx = requireDefined(tx.sql);
+        if (tx.sqlAvailability !== "available") {
+          throw new Error("PostgreSQL adapter transaction did not expose SQL");
+        }
+        const sqlTx = tx.sql;
         const inserted = await sqlTx
           .insert(connectors)
           .values({ name: "github" })
@@ -292,7 +295,12 @@ describe.runIf(process.env["POSTGRES_URL"])(
 
       await expect(
         store.transaction(async (tx) => {
-          const sqlTx = requireDefined(tx.sql);
+          if (tx.sqlAvailability !== "available") {
+            throw new Error(
+              "PostgreSQL adapter transaction did not expose SQL",
+            );
+          }
+          const sqlTx = tx.sql;
           await sqlTx.insert(connectors).values({ name: "orphan" });
           await tx.nodes.ArtifactSource.create({
             connectorId: 999,

--- a/packages/typegraph/tests/backends/sqlite/libsql-cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/libsql-cross-store-transaction.test.ts
@@ -132,7 +132,10 @@ describe("#134 cross-store atomicity (libsql, documented async shape)", () => {
     const store = createAdapterStore(PlainGraph, backend);
 
     const source = await store.transaction(async (tx) => {
-      const sqlTx = tx.sql as typeof db;
+      if (tx.sqlAvailability !== "available") {
+        throw new Error("libSQL adapter transaction did not expose SQL");
+      }
+      const sqlTx = tx.sql;
       const inserted = await sqlTx
         .insert(connectors)
         .values({ name: "github" })
@@ -151,7 +154,10 @@ describe("#134 cross-store atomicity (libsql, documented async shape)", () => {
 
     await expect(
       store.transaction(async (tx) => {
-        const sqlTx = tx.sql as typeof db;
+        if (tx.sqlAvailability !== "available") {
+          throw new Error("libSQL adapter transaction did not expose SQL");
+        }
+        const sqlTx = tx.sql;
         await sqlTx.insert(connectors).values({ name: "orphan" });
         await tx.nodes.ArtifactSource.create({
           connectorId: 999,

--- a/packages/typegraph/tests/cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/cross-store-transaction.test.ts
@@ -273,6 +273,9 @@ describe("#140 graph-owned cross-store via tx.sql (SQLite)", () => {
     const store = createAdapterStore(PlainGraph, backend);
 
     const source = await store.transaction(async (tx) => {
+      if (tx.sqlAvailability !== "available") {
+        throw new Error("SQLite adapter transaction did not expose SQL");
+      }
       const sqlTx = tx.sql as typeof db;
       const connectorId = requireDefined(
         sqlTx
@@ -301,6 +304,9 @@ describe("#140 graph-owned cross-store via tx.sql (SQLite)", () => {
 
     await expect(
       store.transaction(async (tx) => {
+        if (tx.sqlAvailability !== "available") {
+          throw new Error("SQLite adapter transaction did not expose SQL");
+        }
         const sqlTx = tx.sql as typeof db;
         sqlTx.insert(connectors).values({ name: "orphan" }).run();
         await tx.nodes.ArtifactSource.create({

--- a/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
+++ b/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
@@ -163,6 +163,10 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
       expect(backend.capabilities.maxBindParameters).toBe(
         DURABLE_OBJECT_MAX_BIND_PARAMETERS,
       );
+      // Workerd rejects SQLite maintenance PRAGMAs with SQLITE_AUTH. The
+      // do-sqlite profile makes planner-statistics refresh a safe no-op so a
+      // boot that adopts a newly shipped system index stays warning-free.
+      await expect(backend.refreshStatistics()).resolves.toBeUndefined();
 
       const staleHintBackend = createSqliteBackend(db, {
         capabilities: {
@@ -448,6 +452,9 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
     await inObject("tx-sql", async ({ db, store }) => {
       // Adapter tx.sql is the precisely typed bound do-sqlite Drizzle handle.
       await store.transaction(async (tx) => {
+        if (tx.sqlAvailability !== "available") {
+          throw new Error("Durable Object transaction did not expose SQL");
+        }
         await tx.nodes.Doc.create({ title: "via-tx-sql" });
         await tx.sql
           .insert(docVersions)
@@ -458,6 +465,9 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
 
       await expect(
         store.transaction(async (tx) => {
+          if (tx.sqlAvailability !== "available") {
+            throw new Error("Durable Object transaction did not expose SQL");
+          }
           await tx.nodes.Doc.create({ title: "doomed" });
           await tx.sql
             .insert(docVersions)

--- a/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
+++ b/packages/typegraph/tests/do-sqlite/do-sqlite-transactions.test.ts
@@ -49,6 +49,7 @@ import { createSqliteBackend } from "../../src/backend/drizzle/sqlite";
 import { tables as defaultTables } from "../../src/backend/sqlite";
 import { DURABLE_OBJECT_MAX_BIND_PARAMETERS } from "../../src/backend/types";
 import { RECORDED_EDGE_COLUMNS } from "../../src/store/recorded-capture";
+import { isSqliteNotAuthorizedError } from "../../src/utils/sql-errors";
 
 import { SpikeDO } from "./worker";
 
@@ -154,6 +155,38 @@ function inObject<T>(
 }
 
 describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
+  it("continues with ANALYZE when workerd forbids analysis_limit", async () => {
+    await inObject(
+      "statistics-authorization",
+      async ({ db, backend, store }) => {
+        await store.nodes.Doc.create({ title: "statistics seed" });
+
+        // Bypass TypeGraph to pin the real engine gap: workerd rejects the tuning
+        // PRAGMA through SQLite's authorizer. This must fail if workerd ever starts
+        // allowing it, forcing us to reconsider the compatibility path.
+        let pragmaError: unknown;
+        try {
+          await db.run(sql.raw("PRAGMA analysis_limit = 1000"));
+        } catch (error) {
+          pragmaError = error;
+        }
+        expect(isSqliteNotAuthorizedError(pragmaError)).toBe(true);
+
+        // TypeGraph suppresses only that recognized performance-tuning failure.
+        // ANALYZE itself is permitted and must still populate planner statistics.
+        await expect(backend.refreshStatistics()).resolves.toBeUndefined();
+        const analyzedTables = await db.all(
+          sql.raw("SELECT DISTINCT tbl FROM sqlite_stat1"),
+        );
+        expect(analyzedTables).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ tbl: "typegraph_nodes" }),
+          ]),
+        );
+      },
+    );
+  });
+
   it("auto-detects do-sqlite and advertises capabilities.transactions:true", async () => {
     await inObject("detect", async ({ db, backend }, storage) => {
       expect(db.$client).toBe(storage);
@@ -163,11 +196,6 @@ describe("#140 do-sqlite transactions (Durable Objects, real workerd)", () => {
       expect(backend.capabilities.maxBindParameters).toBe(
         DURABLE_OBJECT_MAX_BIND_PARAMETERS,
       );
-      // Workerd rejects SQLite maintenance PRAGMAs with SQLITE_AUTH. The
-      // do-sqlite profile makes planner-statistics refresh a safe no-op so a
-      // boot that adopts a newly shipped system index stays warning-free.
-      await expect(backend.refreshStatistics()).resolves.toBeUndefined();
-
       const staleHintBackend = createSqliteBackend(db, {
         capabilities: {
           graphAnalytics: { supported: true, mathFunctions: false },

--- a/packages/typegraph/tests/graph-merge/base-property-conflict.test.ts
+++ b/packages/typegraph/tests/graph-merge/base-property-conflict.test.ts
@@ -33,7 +33,7 @@ import {
 import { isOk, unwrap } from "../../src/graph-merge/result";
 import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
 import { asBranchId } from "../../src/graph-merge/types";
-import { backendMatrix, getStoreBackend } from "./test-utils";
+import { backendMatrix } from "./test-utils";
 
 const Patient = defineNode("Patient", {
   schema: z.object({ name: z.string(), mrn: z.string() }),
@@ -188,10 +188,7 @@ describe.each(backendMatrix())(
       }
       expect(result.data.provenancePersisted).toBeDefined();
 
-      const provenanceStore = await openProvenanceStore(
-        getStoreBackend(target),
-        target.graphId,
-      );
+      const provenanceStore = await openProvenanceStore(target);
       const baseRecords = await readProvenance(provenanceStore, {
         branchId: BASE_PROVENANCE_BRANCH,
       });

--- a/packages/typegraph/tests/graph-merge/provenance-store.test.ts
+++ b/packages/typegraph/tests/graph-merge/provenance-store.test.ts
@@ -76,6 +76,7 @@ function provMergeOptions(persistProvenance: boolean): MergeOptions<CareGraph> {
 }
 
 type Fixture = Readonly<{
+  backend: GraphBackend;
   base: Store<CareGraph>;
   branches: readonly GraphBranch<CareGraph>[];
 }>;
@@ -102,7 +103,8 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
    * Patients into one canonical and repoints both edges onto it.
    */
   async function materialize(): Promise<Fixture> {
-    const [base] = await createStoreWithSchema(careGraph, await makeBackend());
+    const backend = await makeBackend();
+    const [base] = await createStoreWithSchema(careGraph, backend);
     const branchA = unwrap(
       await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_A }),
     );
@@ -143,8 +145,17 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
       },
     ]);
 
-    return { base, branches: [branchA, branchB] };
+    return { backend, base, branches: [branchA, branchB] };
   }
+
+  it("opens from a backend and graph id without the target GraphDef", async () => {
+    cleanups = [];
+    const { backend, base, branches } = await materialize();
+    unwrap(await merge<CareGraph>(base, branches, provMergeOptions(true)));
+
+    const provStore = await openProvenanceStore(backend, base.graphId);
+    expect(await provStore.nodes.Provenance.find()).not.toHaveLength(0);
+  });
 
   it("persists {branch, sourceId} rows that match the report index", async () => {
     cleanups = [];

--- a/packages/typegraph/tests/graph-merge/provenance-store.test.ts
+++ b/packages/typegraph/tests/graph-merge/provenance-store.test.ts
@@ -33,7 +33,7 @@ import { isOk, unwrap } from "../../src/graph-merge/result";
 import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
 import { asBranchId } from "../../src/graph-merge/types";
 import { requireDefined } from "../../src/utils/presence";
-import { backendMatrix, getStoreBackend } from "./test-utils";
+import { backendMatrix } from "./test-utils";
 
 const Patient = defineNode("Patient", {
   schema: z.object({ name: z.string(), birthDate: z.string() }),
@@ -165,10 +165,7 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
     expect(report.provenancePersisted?.count).toBeGreaterThan(0);
     expect(report.warnings).toEqual([]);
 
-    const provStore = await openProvenanceStore(
-      getStoreBackend(base),
-      base.graphId,
-    );
+    const provStore = await openProvenanceStore(base);
 
     // Every node id the in-memory index credits to a branch is persisted for it.
     for (const branchId of [BRANCH_A, BRANCH_B]) {
@@ -194,10 +191,7 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
     expect(patients).toHaveLength(1);
     const canonicalId = requireDefined(patients[0]).id;
 
-    const provStore = await openProvenanceStore(
-      getStoreBackend(base),
-      base.graphId,
-    );
+    const provStore = await openProvenanceStore(base);
     const forCanonical = (await provStore.nodes.Provenance.find()).filter(
       (p) => p.canonicalId === canonicalId,
     );
@@ -222,10 +216,7 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
     const { base, branches } = await materialize();
     unwrap(await merge<CareGraph>(base, branches, provMergeOptions(true)));
 
-    const provStore = await openProvenanceStore(
-      getStoreBackend(base),
-      base.graphId,
-    );
+    const provStore = await openProvenanceStore(base);
     const firstCount = (await provStore.nodes.Provenance.find()).length;
 
     // Re-persist the SAME records (as a re-run would): deterministic ids → upsert.
@@ -251,10 +242,7 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
     );
     expect(report.provenancePersisted).toBeUndefined();
 
-    const provStore = await openProvenanceStore(
-      getStoreBackend(base),
-      base.graphId,
-    );
+    const provStore = await openProvenanceStore(base);
     expect(await provStore.nodes.Provenance.find()).toHaveLength(0);
   });
 });

--- a/packages/typegraph/tests/recorded-capture-capability-gate.test.ts
+++ b/packages/typegraph/tests/recorded-capture-capability-gate.test.ts
@@ -136,7 +136,9 @@ describe("recorded-time capture capability gate", () => {
 
     await expect(
       store.transaction((tx) => {
-        const sqlHandle = tx.sql as Readonly<{ insert: unknown }>;
+        const sqlHandle = Reflect.get(tx, "sql") as Readonly<{
+          insert: unknown;
+        }>;
         void sqlHandle.insert;
         return Promise.resolve();
       }),

--- a/packages/typegraph/tests/sql-errors.test.ts
+++ b/packages/typegraph/tests/sql-errors.test.ts
@@ -15,7 +15,10 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { isMissingTableError } from "../src/utils/sql-errors";
+import {
+  isMissingTableError,
+  isSqliteNotAuthorizedError,
+} from "../src/utils/sql-errors";
 
 /**
  * Mirrors drizzle-orm's `DrizzleQueryError`: `.message` is the query
@@ -251,5 +254,44 @@ describe("isMissingTableError", () => {
     (a as { cause?: unknown }).cause = b;
     (b as { cause?: unknown }).cause = a;
     expect(isMissingTableError(a)).toBe(false);
+  });
+});
+
+describe("isSqliteNotAuthorizedError", () => {
+  it("detects native, workerd, and D1 authorization failures", () => {
+    expect(
+      isSqliteNotAuthorizedError({ code: "SQLITE_AUTH", message: "denied" }),
+    ).toBe(true);
+    expect(
+      isSqliteNotAuthorizedError(
+        drizzleQueryError(
+          "PRAGMA analysis_limit = 1000",
+          new Error("not authorized: SQLITE_AUTH"),
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isSqliteNotAuthorizedError(
+        new Error("D1_ERROR: not authorized: SQLITE_AUTH"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not swallow unrelated authorization or SQLite failures", () => {
+    expect(
+      isSqliteNotAuthorizedError(
+        pgError("permission denied for relation foo", "42501"),
+      ),
+    ).toBe(false);
+    expect(
+      isSqliteNotAuthorizedError(
+        new Error("SQLITE_ERROR: too many SQL variables"),
+      ),
+    ).toBe(false);
+    expect(
+      isSqliteNotAuthorizedError(
+        new Error("request not authorized by application policy"),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/typegraph/tests/transaction-surface-honesty.test.ts
+++ b/packages/typegraph/tests/transaction-surface-honesty.test.ts
@@ -66,9 +66,9 @@ describe("backend capability descriptors", () => {
   });
 });
 
-/** Reads `tx.sql.run` — the access the guard fail-louds on under capture. */
-function readSqlRunAccessor(tx: Readonly<{ sql?: unknown }>): unknown {
-  return (tx.sql as { run?: unknown }).run;
+/** Reflectively reads `tx.sql.run` to exercise the runtime-only guard. */
+function readSqlRunAccessor(tx: object): unknown {
+  return (Reflect.get(tx, "sql") as { run?: unknown }).run;
 }
 
 /** Returns whatever `fn` throws, or `undefined` if it does not throw. */
@@ -87,6 +87,9 @@ describe("#254 tx.sqlAvailability discriminant", () => {
     await store.transaction(async (tx) => {
       await tx.nodes.Person.create({ name: "probe" });
       expect(tx.sqlAvailability).toBe("available");
+      if (tx.sqlAvailability !== "available") {
+        throw new Error("Expected an available adapter transaction");
+      }
       expect(tx.sql).toBeDefined();
     });
   });
@@ -99,7 +102,7 @@ describe("#254 tx.sqlAvailability discriminant", () => {
     await store.transaction(async (tx) => {
       await tx.nodes.Person.create({ name: "probe" });
       expect(tx.sqlAvailability).toBe("unavailable");
-      expect(tx.sql).toBeUndefined();
+      expect(Reflect.get(tx, "sql")).toBeUndefined();
     });
   });
 
@@ -454,11 +457,11 @@ function nativeTransactionTypeAssertions(
   const store = createAdapterStore(graph, backend);
 
   void store.transaction((tx) => {
-    expectTypeOf(tx.sql).toEqualTypeOf<NativeTransactionProbe | undefined>();
+    // @ts-expect-error Native handles require an explicit availability check.
+    const leakedToUnknown: unknown = tx.sql;
+    void leakedToUnknown;
     if (tx.sqlAvailability === "available") {
       expectTypeOf(tx.sql).toEqualTypeOf<NativeTransactionProbe>();
-    } else {
-      expectTypeOf(tx.sql).toEqualTypeOf<undefined>();
     }
     return Promise.resolve();
   });

--- a/packages/typegraph/tests/transaction-surface-honesty.test.ts
+++ b/packages/typegraph/tests/transaction-surface-honesty.test.ts
@@ -87,6 +87,7 @@ describe("#254 tx.sqlAvailability discriminant", () => {
     await store.transaction(async (tx) => {
       await tx.nodes.Person.create({ name: "probe" });
       expect(tx.sqlAvailability).toBe("available");
+      // The runtime assertion above does not narrow the TypeScript union.
       if (tx.sqlAvailability !== "available") {
         throw new Error("Expected an available adapter transaction");
       }

--- a/packages/typegraph/type-smoke/strict-local-consumers.ts
+++ b/packages/typegraph/type-smoke/strict-local-consumers.ts
@@ -171,6 +171,11 @@ function assertFactoryContracts(
   const portableAdapterProjection: Store<typeof graph> = adapterStore;
   void portableAdapterProjection;
   void adapterStore.transaction((tx) => {
+    if (false) {
+      // @ts-expect-error Native handles require an explicit availability check.
+      const leakedToUnknown: unknown = tx.sql;
+      void leakedToUnknown;
+    }
     if (tx.sqlAvailability === "available") {
       tx.sql.executeNative("select 1");
     }


### PR DESCRIPTION
- require adapter transaction callers to narrow `sqlAvailability` before reading `tx.sql`, while retaining fail-loud runtime guards for JavaScript and type-suppressed history access
- open graph-merge provenance sidecars from the target Store while retaining the backend-plus-graph-id overload for standalone inspection tools
- recognize only `SQLITE_AUTH` rejection of SQLite's performance-only `analysis_limit` PRAGMA on Cloudflare runtimes, then continue with scoped `ANALYZE`
- add concrete 0.38 migration recipes and future release notes for removed context types, exact Store evolution, adapter factories, moved entrypoints, and the source-breaking `tx.sql` refinement
- update examples, API reports, type assertions, capability documentation, and guides

## Why

Adoption of 0.38 exposed several places where the intended portable/adapter split was either under-documented or weaker than the runtime contract:

- non-available adapter transaction arms still exposed a readable optional `sql` property
- a history Store's safe backend projection could not be passed back to `openProvenanceStore`
- Cloudflare SQLite rejects `PRAGMA analysis_limit` through its authorizer
- the changelog omitted hard type removals and did not provide symbol-for-symbol migration guidance

This keeps the cleaner 0.38 surface: it does not restore deprecated type aliases or old entrypoint shims.

A real workerd regression test now bypasses TypeGraph and proves that `PRAGMA analysis_limit` fails with `SQLITE_AUTH`, while `ANALYZE` succeeds and populates `sqlite_stat1`. The implementation catches only the recognized authorization failure and leaves all unexpected maintenance errors loud.

The managed SQLite declarations are Drizzle-free, but the implementation still imports Drizzle at runtime. A packed install with peer auto-installation disabled reproduces `ERR_MODULE_NOT_FOUND`, so this PR deliberately retains the required Drizzle peer; making it optional requires a native implementation boundary or package split.
