### PR TITLE
Add recorded-time collection scans

### DIFF
--- a/.changeset/calm-rivers-scan.md
+++ b/.changeset/calm-rivers-scan.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add bounded, deterministic `scan()` pagination to recorded-time node and edge collections so adapters can reconstruct complete historical snapshots without retaining a separate identity inventory.

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -328,10 +328,11 @@ adopt a caller-owned transaction:
   writes only. Out-of-band database writes and row-returning raw SQL paths are
   not captured into the recorded relations.
 - **Reconstructing reads only.** A recorded view exposes point reads
-  (`getById` / `getByIds`), `query()`, `subgraph()`, and the graph algorithms.
-  Broad collection reads (`find` / `count` / `findFrom`), `search`, and fulltext
-  / vector predicates are refused — those indexes reflect current state and
-  cannot answer a recorded-time query.
+  (`getById` / `getByIds`), bounded deterministic `scan()` pages, `query()`,
+  `subgraph()`, and the graph algorithms. Broad filtered collection reads
+  (`find` / `count` / `findFrom`), `search`, and fulltext / vector predicates are
+  refused — those indexes reflect current state and cannot answer a
+  recorded-time query.
 - **Transactional backend required.** Capture needs a backend with atomic
   transactions and statement execution — the built-in SQLite / PostgreSQL
   backends qualify. A custom backend must implement `executeStatement` (optional

--- a/apps/docs/src/content/docs/queries/temporal.md
+++ b/apps/docs/src/content/docs/queries/temporal.md
@@ -187,6 +187,28 @@ const cited = await recorded.edges.cites.getByIds(citationIds);
 const reachable = await recorded.reachable(docId, { edges: ["cites"] });
 ```
 
+Recorded collections also expose `scan()` for complete snapshot reconstruction.
+Each call returns at most 1,000 entities in canonical `id` order; use the opaque
+`nextCursor` to continue without retaining a separate identity inventory:
+
+```typescript
+const first = await recorded.nodes.Document.scan({ limit: 500 });
+const second =
+  first.nextCursor === undefined ?
+    undefined
+  : await recorded.nodes.Document.scan({
+      limit: 500,
+      after: first.nextCursor,
+    });
+
+const citations = await recorded.edges.cites.scan({ limit: 500 });
+```
+
+Scan cursors are forward-only and bound to the graph, entity kind, and both
+temporal coordinates. Passing a cursor to another collection or recorded-time
+view throws a `ValidationError` instead of silently skipping data. Iterate each
+declared node and edge kind to reconstruct a complete historical graph snapshot.
+
 A raw wall-clock string — `store.asOfRecorded(new Date().toISOString())` — does
 **not** type-check, by design. Recorded instants are monotonic and can briefly
 run ahead of wall-clock time under bursty writes, so a wall-clock value may sort

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -2234,10 +2234,11 @@ asRecordedInstant(value: string): RecordedInstant; // brand an external timestam
   `recordedRelation({ schema })` using a `createSqlSchema(...)` schema and
   cannot be combined with `history: true`.
 - The view exposes only **reconstructing** reads: `nodes` / `edges` point reads
-  (`getById` / `getByIds`), a sealed `query()`, `subgraph()`, and the graph
-  algorithms (`reachable` / `canReach` / `shortestPath` / `degree`). Broad
-  collection reads, `search`, and fulltext / vector predicates reject — those
-  indexes reflect current state only.
+  (`getById` / `getByIds`) and bounded deterministic `scan()` pages, a sealed
+  `query()`, `subgraph()`, and the graph algorithms (`reachable` / `canReach` /
+  `shortestPath` / `degree`). Broad filtered collection reads, `search`, and
+  fulltext / vector predicates reject — those indexes reflect current state
+  only.
 - Built-in capture covers TypeGraph collection writes. Out-of-band database
   writes and row-returning raw SQL paths are not captured into the recorded
   relations.

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2977,6 +2977,19 @@ type RecordedReadBinding = RecordedReadSource;
 type RecordedReadSource = ExternalRecordedReadSource | TypeGraphRecordedReadSource;
 
 // @public
+type RecordedScanOptions = Readonly<{
+    limit?: number;
+    after?: string;
+}>;
+
+// @public
+type RecordedScanPage<T> = Readonly<{
+    data: readonly T[];
+    nextCursor: string | undefined;
+    hasNextPage: boolean;
+}>;
+
+// @public
 class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get asOfRecorded(): string;
@@ -2985,7 +2998,9 @@ class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
 }
 
 // @public
-type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+}>;
 
 // @public
 type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
@@ -2993,7 +3008,9 @@ type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
 };
 
 // @public
-type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+}>;
 
 // @public
 type RecordedStoreViewNodeCollections<G extends GraphDef> = {
@@ -3608,8 +3625,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     sealedQuery: (coordinate: ReadCoordinate) => InitialQueryBuilder<G, "sealed">;
     recordedNodeGetById: <N extends NodeType>(kind: string, id: NodeId<N>, coordinate: ReadCoordinate) => Promise<Node<N> | undefined>;
     recordedNodeGetByIds: <N extends NodeType>(kind: string, ids: readonly NodeId<N>[], coordinate: ReadCoordinate) => Promise<readonly (Node<N> | undefined)[]>;
+    recordedNodeScan: <N extends NodeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
     recordedEdgeGetById: <E extends AnyEdgeType>(kind: string, id: EdgeId<E>, coordinate: ReadCoordinate) => Promise<Edge<E> | undefined>;
     recordedEdgeGetByIds: <E extends AnyEdgeType>(kind: string, ids: readonly EdgeId<E>[], coordinate: ReadCoordinate) => Promise<readonly (Edge<E> | undefined)[]>;
+    recordedEdgeScan: <E extends AnyEdgeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E>>>;
     subgraphAtCoordinate: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: InternalSubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     algorithmsAtCoordinate: (coordinate: ReadCoordinate) => InternalGraphAlgorithms<G>;
 }>;

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -2860,6 +2860,19 @@ type RecordedReadBinding = RecordedReadSource;
 type RecordedReadSource = ExternalRecordedReadSource | TypeGraphRecordedReadSource;
 
 // @public
+type RecordedScanOptions = Readonly<{
+    limit?: number;
+    after?: string;
+}>;
+
+// @public
+type RecordedScanPage<T> = Readonly<{
+    data: readonly T[];
+    nextCursor: string | undefined;
+    hasNextPage: boolean;
+}>;
+
+// @public
 class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get asOfRecorded(): string;
@@ -2868,7 +2881,9 @@ class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
 }
 
 // @public
-type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+}>;
 
 // @public
 type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
@@ -2876,7 +2891,9 @@ type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
 };
 
 // @public
-type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+}>;
 
 // @public
 type RecordedStoreViewNodeCollections<G extends GraphDef> = {
@@ -3407,8 +3424,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     sealedQuery: (coordinate: ReadCoordinate) => InitialQueryBuilder<G, "sealed">;
     recordedNodeGetById: <N extends NodeType>(kind: string, id: NodeId<N>, coordinate: ReadCoordinate) => Promise<Node<N> | undefined>;
     recordedNodeGetByIds: <N extends NodeType>(kind: string, ids: readonly NodeId<N>[], coordinate: ReadCoordinate) => Promise<readonly (Node<N> | undefined)[]>;
+    recordedNodeScan: <N extends NodeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
     recordedEdgeGetById: <E extends AnyEdgeType>(kind: string, id: EdgeId<E>, coordinate: ReadCoordinate) => Promise<Edge<E> | undefined>;
     recordedEdgeGetByIds: <E extends AnyEdgeType>(kind: string, ids: readonly EdgeId<E>[], coordinate: ReadCoordinate) => Promise<readonly (Edge<E> | undefined)[]>;
+    recordedEdgeScan: <E extends AnyEdgeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E>>>;
     subgraphAtCoordinate: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: InternalSubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     algorithmsAtCoordinate: (coordinate: ReadCoordinate) => InternalGraphAlgorithms<G>;
 }>;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -2722,6 +2722,19 @@ type RecordedReadStoreOptions = LiveStoreOptions & Readonly<{
 }>;
 
 // @public
+type RecordedScanOptions = Readonly<{
+    limit?: number;
+    after?: string;
+}>;
+
+// @public
+type RecordedScanPage<T> = Readonly<{
+    data: readonly T[];
+    nextCursor: string | undefined;
+    hasNextPage: boolean;
+}>;
+
+// @public
 class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get asOfRecorded(): string;
@@ -2730,7 +2743,9 @@ class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
 }
 
 // @public
-type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+}>;
 
 // @public
 type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
@@ -2738,7 +2753,9 @@ type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
 };
 
 // @public
-type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+}>;
 
 // @public
 type RecordedStoreViewNodeCollections<G extends GraphDef> = {
@@ -3311,8 +3328,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     sealedQuery: (coordinate: ReadCoordinate) => InitialQueryBuilder<G, "sealed">;
     recordedNodeGetById: <N extends NodeType>(kind: string, id: NodeId<N>, coordinate: ReadCoordinate) => Promise<Node<N> | undefined>;
     recordedNodeGetByIds: <N extends NodeType>(kind: string, ids: readonly NodeId<N>[], coordinate: ReadCoordinate) => Promise<readonly (Node<N> | undefined)[]>;
+    recordedNodeScan: <N extends NodeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
     recordedEdgeGetById: <E extends AnyEdgeType>(kind: string, id: EdgeId<E>, coordinate: ReadCoordinate) => Promise<Edge<E> | undefined>;
     recordedEdgeGetByIds: <E extends AnyEdgeType>(kind: string, ids: readonly EdgeId<E>[], coordinate: ReadCoordinate) => Promise<readonly (Edge<E> | undefined)[]>;
+    recordedEdgeScan: <E extends AnyEdgeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E>>>;
     subgraphAtCoordinate: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: InternalSubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     algorithmsAtCoordinate: (coordinate: ReadCoordinate) => InternalGraphAlgorithms<G>;
 }>;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -2656,6 +2656,19 @@ type RecordedReadBinding = RecordedReadSource;
 type RecordedReadSource = ExternalRecordedReadSource | TypeGraphRecordedReadSource;
 
 // @public
+type RecordedScanOptions = Readonly<{
+    limit?: number;
+    after?: string;
+}>;
+
+// @public
+type RecordedScanPage<T> = Readonly<{
+    data: readonly T[];
+    nextCursor: string | undefined;
+    hasNextPage: boolean;
+}>;
+
+// @public
 class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get asOfRecorded(): string;
@@ -2664,7 +2677,9 @@ class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
 }
 
 // @public
-type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+}>;
 
 // @public
 type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
@@ -2672,7 +2687,9 @@ type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
 };
 
 // @public
-type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+}>;
 
 // @public
 type RecordedStoreViewNodeCollections<G extends GraphDef> = {
@@ -3203,8 +3220,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     sealedQuery: (coordinate: ReadCoordinate) => InitialQueryBuilder<G, "sealed">;
     recordedNodeGetById: <N extends NodeType>(kind: string, id: NodeId<N>, coordinate: ReadCoordinate) => Promise<Node<N> | undefined>;
     recordedNodeGetByIds: <N extends NodeType>(kind: string, ids: readonly NodeId<N>[], coordinate: ReadCoordinate) => Promise<readonly (Node<N> | undefined)[]>;
+    recordedNodeScan: <N extends NodeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
     recordedEdgeGetById: <E extends AnyEdgeType>(kind: string, id: EdgeId<E>, coordinate: ReadCoordinate) => Promise<Edge<E> | undefined>;
     recordedEdgeGetByIds: <E extends AnyEdgeType>(kind: string, ids: readonly EdgeId<E>[], coordinate: ReadCoordinate) => Promise<readonly (Edge<E> | undefined)[]>;
+    recordedEdgeScan: <E extends AnyEdgeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E>>>;
     subgraphAtCoordinate: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: InternalSubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     algorithmsAtCoordinate: (coordinate: ReadCoordinate) => InternalGraphAlgorithms<G>;
 }>;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -2631,6 +2631,19 @@ type RecordedReadBinding = RecordedReadSource;
 type RecordedReadSource = ExternalRecordedReadSource | TypeGraphRecordedReadSource;
 
 // @public
+type RecordedScanOptions = Readonly<{
+    limit?: number;
+    after?: string;
+}>;
+
+// @public
+type RecordedScanPage<T> = Readonly<{
+    data: readonly T[];
+    nextCursor: string | undefined;
+    hasNextPage: boolean;
+}>;
+
+// @public
 class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get asOfRecorded(): string;
@@ -2639,7 +2652,9 @@ class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
 }
 
 // @public
-type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+}>;
 
 // @public
 type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
@@ -2647,7 +2662,9 @@ type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
 };
 
 // @public
-type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+}>;
 
 // @public
 type RecordedStoreViewNodeCollections<G extends GraphDef> = {
@@ -3197,8 +3214,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     sealedQuery: (coordinate: ReadCoordinate) => InitialQueryBuilder<G, "sealed">;
     recordedNodeGetById: <N extends NodeType>(kind: string, id: NodeId<N>, coordinate: ReadCoordinate) => Promise<Node<N> | undefined>;
     recordedNodeGetByIds: <N extends NodeType>(kind: string, ids: readonly NodeId<N>[], coordinate: ReadCoordinate) => Promise<readonly (Node<N> | undefined)[]>;
+    recordedNodeScan: <N extends NodeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
     recordedEdgeGetById: <E extends AnyEdgeType>(kind: string, id: EdgeId<E>, coordinate: ReadCoordinate) => Promise<Edge<E> | undefined>;
     recordedEdgeGetByIds: <E extends AnyEdgeType>(kind: string, ids: readonly EdgeId<E>[], coordinate: ReadCoordinate) => Promise<readonly (Edge<E> | undefined)[]>;
+    recordedEdgeScan: <E extends AnyEdgeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E>>>;
     subgraphAtCoordinate: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: InternalSubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     algorithmsAtCoordinate: (coordinate: ReadCoordinate) => InternalGraphAlgorithms<G>;
 }>;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -2742,6 +2742,19 @@ type RecordedReadStoreOptions = LiveStoreOptions & Readonly<{
 }>;
 
 // @public
+type RecordedScanOptions = Readonly<{
+    limit?: number;
+    after?: string;
+}>;
+
+// @public
+type RecordedScanPage<T> = Readonly<{
+    data: readonly T[];
+    nextCursor: string | undefined;
+    hasNextPage: boolean;
+}>;
+
+// @public
 class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get asOfRecorded(): string;
@@ -2750,7 +2763,9 @@ class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
 }
 
 // @public
-type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+}>;
 
 // @public
 type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
@@ -2758,7 +2773,9 @@ type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
 };
 
 // @public
-type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+}>;
 
 // @public
 type RecordedStoreViewNodeCollections<G extends GraphDef> = {
@@ -3331,8 +3348,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     sealedQuery: (coordinate: ReadCoordinate) => InitialQueryBuilder<G, "sealed">;
     recordedNodeGetById: <N extends NodeType>(kind: string, id: NodeId<N>, coordinate: ReadCoordinate) => Promise<Node<N> | undefined>;
     recordedNodeGetByIds: <N extends NodeType>(kind: string, ids: readonly NodeId<N>[], coordinate: ReadCoordinate) => Promise<readonly (Node<N> | undefined)[]>;
+    recordedNodeScan: <N extends NodeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
     recordedEdgeGetById: <E extends AnyEdgeType>(kind: string, id: EdgeId<E>, coordinate: ReadCoordinate) => Promise<Edge<E> | undefined>;
     recordedEdgeGetByIds: <E extends AnyEdgeType>(kind: string, ids: readonly EdgeId<E>[], coordinate: ReadCoordinate) => Promise<readonly (Edge<E> | undefined)[]>;
+    recordedEdgeScan: <E extends AnyEdgeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E>>>;
     subgraphAtCoordinate: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: InternalSubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     algorithmsAtCoordinate: (coordinate: ReadCoordinate) => InternalGraphAlgorithms<G>;
 }>;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -4113,6 +4113,19 @@ export type RecordedRelationOptions = Readonly<{
 }>;
 
 // @public
+export type RecordedScanOptions = Readonly<{
+    limit?: number;
+    after?: string;
+}>;
+
+// @public
+export type RecordedScanPage<T> = Readonly<{
+    data: readonly T[];
+    nextCursor: string | undefined;
+    hasNextPage: boolean;
+}>;
+
+// @public
 export class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get asOfRecorded(): string;
@@ -4121,7 +4134,9 @@ export class RecordedStoreView<G extends GraphDef> extends CoordinatePinnedView<
 }
 
 // @public
-export type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+export type RecordedStoreViewEdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Pick<StoreViewEdgeCollection<E, From, To>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+}>;
 
 // @public
 export type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
@@ -4129,7 +4144,9 @@ export type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
 };
 
 // @public
-export type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]>;
+export type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<StoreViewNodeCollection<N>, (typeof RECORDED_POINT_READ_NAMES)[number]> & Readonly<{
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+}>;
 
 // @public
 export type RecordedStoreViewNodeCollections<G extends GraphDef> = {
@@ -4933,8 +4950,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     sealedQuery: (coordinate: ReadCoordinate) => InitialQueryBuilder<G, "sealed">;
     recordedNodeGetById: <N extends NodeType>(kind: string, id: NodeId<N>, coordinate: ReadCoordinate) => Promise<Node<N> | undefined>;
     recordedNodeGetByIds: <N extends NodeType>(kind: string, ids: readonly NodeId<N>[], coordinate: ReadCoordinate) => Promise<readonly (Node<N> | undefined)[]>;
+    recordedNodeScan: <N extends NodeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
     recordedEdgeGetById: <E extends AnyEdgeType>(kind: string, id: EdgeId<E>, coordinate: ReadCoordinate) => Promise<Edge<E> | undefined>;
     recordedEdgeGetByIds: <E extends AnyEdgeType>(kind: string, ids: readonly EdgeId<E>[], coordinate: ReadCoordinate) => Promise<readonly (Edge<E> | undefined)[]>;
+    recordedEdgeScan: <E extends AnyEdgeType>(kind: string, coordinate: ReadCoordinate, options?: RecordedScanOptions) => Promise<RecordedScanPage<Edge<E>>>;
     subgraphAtCoordinate: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: InternalSubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     algorithmsAtCoordinate: (coordinate: ReadCoordinate) => InternalGraphAlgorithms<G>;
 }>;

--- a/packages/typegraph/examples/21-agent-decision-replay.ts
+++ b/packages/typegraph/examples/21-agent-decision-replay.ts
@@ -62,10 +62,13 @@ const graph = defineGraph({
 // The reconstructing reads the agent uses. A live `store.view(...)` and a
 // recorded `store.asOfRecorded(...)` both satisfy this surface, so the agent
 // runs the *identical* code against either coordinate.
-type EvidenceView = Pick<
-  RecordedStoreView<typeof graph>,
-  "query" | "degree" | "nodes"
->;
+type RecordedEvidenceView = RecordedStoreView<typeof graph>;
+type EvidenceView = Pick<RecordedEvidenceView, "query" | "degree"> &
+  Readonly<{
+    nodes: Readonly<{
+      Paper: Pick<RecordedEvidenceView["nodes"]["Paper"], "getById">;
+    }>;
+  }>;
 
 // ============================================================
 // The agent: "recommend the most-cited paper that supports a claim"

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -80,36 +80,36 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "0f36d8f84e9a9d75255b39940c5308ae4df2c3dbe1e0cb2683b00ee8cb974f73",
   },
   "./graph-merge": {
-    count: 520,
-    sha256: "e95c3e4f115b96507af506eb5b379fe7a80261666bd374fb38e12d8e562d5691",
+    count: 522,
+    sha256: "562b22d710680e663291ea653290446a555f52902959960bc83606b11606bfde",
   },
   "./indexes": {
     count: 43,
     sha256: "49144a0eeda76d83d8ebe63f533e25796e1b7d46fe521a4adc997fb58cb876bb",
   },
   "./interchange": {
-    count: 506,
-    sha256: "adf0753d4aefedada8f1cee33b73f849e52acbf2472a16df4a491bb790349490",
+    count: 508,
+    sha256: "ec8a65db9f4cbdde6d034b730745c89d7821e5514069ae64783379bb3214f714",
   },
   "./postgres/pglite": {
-    count: 529,
-    sha256: "996efad69aee5bfdc45baa96e6287730de9a2af2742a459e4e6d205fdb49b115",
+    count: 531,
+    sha256: "e7bfd582d3ff47def583b5a00b8b042a725de493757170cba27b68d457a50cb2",
   },
   "./profiler": {
-    count: 508,
-    sha256: "858567388ef0abc9a36c26e56fbeff7ef06dad17134623735ee57d3b75f8d065",
+    count: 510,
+    sha256: "3252644a33bfb6c9d5b282da276c60da9dfbf6babd8a48bf03035b4ab942317e",
   },
   "./provenance": {
-    count: 514,
-    sha256: "4802d3e59aacb04fdde2962a1e40f3bbc30165a9f3ab8d4e29cbbc24267b97ab",
+    count: 516,
+    sha256: "663e9a678f88b2d059953a1a9d39a0d2ff1b1bf4f9362714f860806c38c67265",
   },
   "./schema": {
     count: 189,
     sha256: "ecef7303ae1380caa6170fff330a0f8ca0a5290508409c4ad679272a72457d03",
   },
   "./sqlite/local": {
-    count: 529,
-    sha256: "996efad69aee5bfdc45baa96e6287730de9a2af2742a459e4e6d205fdb49b115",
+    count: 531,
+    sha256: "e7bfd582d3ff47def583b5a00b8b042a725de493757170cba27b68d457a50cb2",
   },
 };
 

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -372,6 +372,8 @@ export type {
   RebuildFulltextResult,
   ReclaimedVectorFieldEntry,
   RecordedReadStore,
+  RecordedScanOptions,
+  RecordedScanPage,
   ReembedFunction,
   ReembedVectorFieldOptions,
   ReembedVectorFieldResult,

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -36,6 +36,8 @@ export {
   type QueryHookContext,
   type QueryOptions,
   type RecordedReadStoreOptions,
+  type RecordedScanOptions,
+  type RecordedScanPage,
   type RecordedStoreViewEdgeCollection,
   type RecordedStoreViewEdgeCollections,
   type RecordedStoreViewNodeCollection,

--- a/packages/typegraph/src/store/recorded-read-service.ts
+++ b/packages/typegraph/src/store/recorded-read-service.ts
@@ -12,7 +12,7 @@ import {
   type NodeId,
   type NodeType,
 } from "../core/types";
-import { ConfigurationError } from "../errors";
+import { ConfigurationError, ValidationError } from "../errors";
 import { sqlValueList } from "../query/compiler/predicate-utils";
 import {
   type RecordedReadBinding,
@@ -23,6 +23,7 @@ import {
   compileTemporalFilter,
   currentReadInstant,
 } from "../query/compiler/temporal";
+import { decodeCursor, encodeCursor } from "../query/cursor";
 import { sql, type SqlFragment } from "../query/sql-fragment";
 import { asCompiledRowsSql, type CompiledRowsSql } from "../query/sql-intent";
 import { chunk } from "../utils/array";
@@ -30,9 +31,15 @@ import { requireDefined } from "../utils/presence";
 import { withRecordedRelationsPrecondition } from "../utils/sql-errors";
 import { recordedBindParamBudget } from "./recorded-capture/relations";
 import { rowToEdge, rowToNode } from "./row-mappers";
-import { type Edge, type Node } from "./types";
+import {
+  type Edge,
+  type Node,
+  type RecordedScanOptions,
+  type RecordedScanPage,
+} from "./types";
 
 const RECORDED_POINT_READ_FIXED_BIND_PARAMS = 8;
+const RECORDED_SCAN_LIMIT = 1000;
 
 type RecordedReadServiceParams = Readonly<{
   graphId: string;
@@ -52,6 +59,16 @@ type RecordedGetByIdsParams<T extends Readonly<{ id: string }>> = Readonly<{
   toEntity: (row: Record<string, unknown>) => T;
 }>;
 
+type RecordedScanParams<T extends Readonly<{ id: string }>> = Readonly<{
+  entity: "node" | "edge";
+  table: SqlFragment;
+  alias: string;
+  kind: string;
+  coordinate: ReadCoordinate;
+  options: RecordedScanOptions | undefined;
+  toEntity: (row: Record<string, unknown>) => T;
+}>;
+
 export type RecordedReadService = Readonly<{
   backendForCoordinate: (
     coordinate: ReadCoordinate,
@@ -67,6 +84,11 @@ export type RecordedReadService = Readonly<{
     ids: readonly NodeId<N>[],
     coordinate: ReadCoordinate,
   ) => Promise<readonly (Node<N> | undefined)[]>;
+  nodeScan: <N extends NodeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ) => Promise<RecordedScanPage<Node<N>>>;
   edgeGetById: <E extends AnyEdgeType>(
     kind: string,
     id: EdgeId<E>,
@@ -77,6 +99,11 @@ export type RecordedReadService = Readonly<{
     ids: readonly EdgeId<E>[],
     coordinate: ReadCoordinate,
   ) => Promise<readonly (Edge<E> | undefined)[]>;
+  edgeScan: <E extends AnyEdgeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ) => Promise<RecordedScanPage<Edge<E>>>;
 }>;
 
 /**
@@ -165,7 +192,7 @@ function recordedRelationInvariantError(
   }>,
 ): ConfigurationError {
   return new ConfigurationError(
-    "Recorded relation invariant violation: more than one recorded row matched the requested point read.",
+    "Recorded relation invariant violation: more than one recorded row matched the requested read.",
     {
       code: "RECORDED_RELATION_INVARIANT_VIOLATION",
       graphId: params.graphId,
@@ -183,6 +210,77 @@ function recordedRelationInvariantError(
   );
 }
 
+function validateRecordedScanLimit(limit: number | undefined): number {
+  if (limit === undefined) return RECORDED_SCAN_LIMIT;
+  if (!Number.isInteger(limit) || limit <= 0 || limit > RECORDED_SCAN_LIMIT) {
+    throw new ValidationError(
+      `Recorded scan limit must be an integer between 1 and ${RECORDED_SCAN_LIMIT}, got: ${String(limit)}`,
+      {
+        issues: [
+          {
+            path: "limit",
+            message: `Must be an integer between 1 and ${RECORDED_SCAN_LIMIT}.`,
+          },
+        ],
+      },
+    );
+  }
+  return limit;
+}
+
+function recordedScanCursorScope(
+  graphId: string,
+  entity: "node" | "edge",
+  kind: string,
+  coordinate: ReadCoordinate,
+): string {
+  return JSON.stringify([
+    "recorded-scan",
+    graphId,
+    entity,
+    kind,
+    coordinate.valid.mode,
+    coordinate.valid.asOf,
+    coordinate.recorded?.asOf,
+  ]);
+}
+
+function invalidRecordedScanCursor(): ValidationError {
+  return new ValidationError(
+    "Recorded scan cursor does not match this graph, collection, or temporal coordinate.",
+    {
+      issues: [
+        {
+          path: "after",
+          message:
+            "Use a cursor returned by the same recorded collection scan.",
+        },
+      ],
+    },
+  );
+}
+
+function decodeRecordedScanCursor(
+  cursor: string,
+  expectedScope: string,
+): string {
+  const decoded = decodeCursor(cursor);
+  if (
+    decoded.d !== "f" ||
+    decoded.cols.length !== 1 ||
+    decoded.cols[0] !== expectedScope ||
+    decoded.vals.length !== 1 ||
+    typeof decoded.vals[0] !== "string"
+  ) {
+    throw invalidRecordedScanCursor();
+  }
+  return decoded.vals[0];
+}
+
+function encodeRecordedScanCursor(id: string, scope: string): string {
+  return encodeCursor({ v: 1, d: "f", vals: [id], cols: [scope] });
+}
+
 export function createRecordedReadService(
   params: RecordedReadServiceParams,
 ): RecordedReadService {
@@ -197,6 +295,15 @@ export function createRecordedReadService(
     recordedReadBinding === undefined ? undefined : (
       recordedReadSqlSchema(recordedReadBinding)
     );
+
+  function schemaForRecordedRead(surface: string) {
+    return (
+      recordedSchema ??
+      recordedReadSqlSchema(
+        requireRecordedReadBinding(recordedReadBinding, surface),
+      )
+    );
+  }
 
   async function recordedGetByIds<T extends Readonly<{ id: string }>>(
     read: RecordedGetByIdsParams<T>,
@@ -245,16 +352,65 @@ export function createRecordedReadService(
     return ids.map((id) => byId.get(id));
   }
 
+  async function recordedScan<T extends Readonly<{ id: string }>>(
+    scan: RecordedScanParams<T>,
+  ): Promise<RecordedScanPage<T>> {
+    const { table, alias, kind, coordinate, options, toEntity, entity } = scan;
+    const limit = validateRecordedScanLimit(options?.limit);
+    const scope = recordedScanCursorScope(graphId, entity, kind, coordinate);
+    const after =
+      options?.after === undefined ?
+        undefined
+      : decodeRecordedScanCursor(options.after, scope);
+    const aliasSql = sql.raw(alias);
+    const temporalFilter = recordedTemporalFilter(backend, coordinate, alias);
+    const rows = await withRelationsPrecondition(
+      backend,
+      backend.execute<Record<string, unknown>>(
+        asCompiledRowsSql(sql`
+          SELECT * FROM ${table} ${aliasSql}
+          WHERE ${aliasSql}.graph_id = ${graphId}
+            AND ${aliasSql}.kind = ${kind}
+            ${after === undefined ? sql.raw("") : sql`AND ${aliasSql}.id > ${after}`}
+            AND ${temporalFilter}
+          ORDER BY ${aliasSql}.id ASC, ${aliasSql}.recorded_from ASC
+          LIMIT ${limit + 1}
+        `),
+      ),
+      "recorded-scan",
+    );
+    const entities = rows.map((row) => toEntity(row));
+    for (let index = 1; index < entities.length; index += 1) {
+      const previous = requireDefined(entities[index - 1]);
+      const current = requireDefined(entities[index]);
+      if (previous.id !== current.id) continue;
+      throw recordedRelationInvariantError({
+        graphId,
+        entity,
+        kind,
+        id: current.id,
+        coordinate,
+      });
+    }
+
+    const hasNextPage = entities.length > limit;
+    const data = hasNextPage ? entities.slice(0, limit) : entities;
+    return {
+      data,
+      nextCursor:
+        hasNextPage ?
+          encodeRecordedScanCursor(requireDefined(data.at(-1)).id, scope)
+        : undefined,
+      hasNextPage,
+    };
+  }
+
   function nodeGetByIds<N extends NodeType>(
     kind: string,
     ids: readonly NodeId<N>[],
     coordinate: ReadCoordinate,
   ): Promise<readonly (Node<N> | undefined)[]> {
-    const schema =
-      recordedSchema ??
-      recordedReadSqlSchema(
-        requireRecordedReadBinding(recordedReadBinding, "recorded-point-read"),
-      );
+    const schema = schemaForRecordedRead("recorded-point-read");
     return recordedGetByIds({
       entity: "node",
       table: schema.nodesTable,
@@ -271,11 +427,7 @@ export function createRecordedReadService(
     ids: readonly EdgeId<E>[],
     coordinate: ReadCoordinate,
   ): Promise<readonly (Edge<E> | undefined)[]> {
-    const schema =
-      recordedSchema ??
-      recordedReadSqlSchema(
-        requireRecordedReadBinding(recordedReadBinding, "recorded-point-read"),
-      );
+    const schema = schemaForRecordedRead("recorded-point-read");
     return recordedGetByIds({
       entity: "edge",
       table: schema.edgesTable,
@@ -283,6 +435,40 @@ export function createRecordedReadService(
       kind,
       ids,
       coordinate,
+      toEntity: (row) => rowToEdge(mapRecordedEdgeRow(row)) as Edge<E>,
+    });
+  }
+
+  function nodeScan<N extends NodeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ): Promise<RecordedScanPage<Node<N>>> {
+    const schema = schemaForRecordedRead("recorded-scan");
+    return recordedScan({
+      entity: "node",
+      table: schema.nodesTable,
+      alias: "n",
+      kind,
+      coordinate,
+      options,
+      toEntity: (row) => rowToNode(mapRecordedNodeRow(row)) as Node<N>,
+    });
+  }
+
+  function edgeScan<E extends AnyEdgeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ): Promise<RecordedScanPage<Edge<E>>> {
+    const schema = schemaForRecordedRead("recorded-scan");
+    return recordedScan({
+      entity: "edge",
+      table: schema.edgesTable,
+      alias: "e",
+      kind,
+      coordinate,
+      options,
       toEntity: (row) => rowToEdge(mapRecordedEdgeRow(row)) as Edge<E>,
     });
   }
@@ -307,6 +493,7 @@ export function createRecordedReadService(
     },
 
     nodeGetByIds,
+    nodeScan,
 
     async edgeGetById<E extends AnyEdgeType>(
       kind: string,
@@ -318,5 +505,6 @@ export function createRecordedReadService(
     },
 
     edgeGetByIds,
+    edgeScan,
   };
 }

--- a/packages/typegraph/src/store/runtime-port.ts
+++ b/packages/typegraph/src/store/runtime-port.ts
@@ -20,7 +20,13 @@ import {
   type SubgraphProject,
   type SubgraphResult,
 } from "./subgraph";
-import { type Edge, type Node, TRANSACTION_RUNTIME } from "./types";
+import {
+  type Edge,
+  type Node,
+  type RecordedScanOptions,
+  type RecordedScanPage,
+  TRANSACTION_RUNTIME,
+} from "./types";
 
 export const STORE_RUNTIME: unique symbol =
   typeGraphGlobalSymbol("store-runtime-v1");
@@ -44,6 +50,11 @@ export type StoreRuntime<G extends GraphDef> = Readonly<{
     ids: readonly NodeId<N>[],
     coordinate: ReadCoordinate,
   ) => Promise<readonly (Node<N> | undefined)[]>;
+  recordedNodeScan: <N extends NodeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ) => Promise<RecordedScanPage<Node<N>>>;
   recordedEdgeGetById: <E extends AnyEdgeType>(
     kind: string,
     id: EdgeId<E>,
@@ -54,6 +65,11 @@ export type StoreRuntime<G extends GraphDef> = Readonly<{
     ids: readonly EdgeId<E>[],
     coordinate: ReadCoordinate,
   ) => Promise<readonly (Edge<E> | undefined)[]>;
+  recordedEdgeScan: <E extends AnyEdgeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ) => Promise<RecordedScanPage<Edge<E>>>;
   subgraphAtCoordinate: <
     const EK extends EdgeKinds<G>,
     const NK extends NodeKinds<G> = NodeKinds<G>,

--- a/packages/typegraph/src/store/store-view.ts
+++ b/packages/typegraph/src/store/store-view.ts
@@ -346,7 +346,7 @@ function createRecordedUnsupportedRefusal(
       new ConfigurationError(
         `'${method}' is not available on a RecordedStoreView (${describeCoordinate(coordinate)}). ` +
           `Recorded-time reads are reconstructing reads; this view exposes only query, ` +
-          `subgraph, graph algorithms, and point getById/getByIds collection reads.`,
+          `subgraph, graph algorithms, and collection getById/getByIds/scan reads.`,
         {
           code: "RECORDED_STORE_VIEW_UNSUPPORTED",
           entity,
@@ -612,6 +612,8 @@ function recordedNodeCollection<G extends GraphDef>(
       storeRuntime(store).recordedNodeGetById(kind, id, coordinate),
     getByIds: (ids) =>
       storeRuntime(store).recordedNodeGetByIds(kind, ids, coordinate),
+    scan: (options) =>
+      storeRuntime(store).recordedNodeScan(kind, coordinate, options),
   };
   return recordedCollectionProxy(reads, live, coordinate, "node");
 }
@@ -640,6 +642,8 @@ function recordedEdgeCollection<G extends GraphDef>(
       storeRuntime(store).recordedEdgeGetById(kind, id, coordinate),
     getByIds: (ids) =>
       storeRuntime(store).recordedEdgeGetByIds(kind, ids, coordinate),
+    scan: (options) =>
+      storeRuntime(store).recordedEdgeScan(kind, coordinate, options),
   };
   return recordedCollectionProxy(reads, live, coordinate, "edge");
 }
@@ -1081,7 +1085,7 @@ export class StoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
 /**
  * A narrow recorded-time read lens. It preserves the valid-time coordinate
  * carried by the source view and adds a recorded/system-time pin. Collection
- * reads are intentionally limited to point reconstruction; broad collection
+ * reads expose point reconstruction and bounded scans; broad collection
  * predicates, endpoint reads, search, and further coordinate changes are absent
  * from the typed surface and refused by the runtime proxies for JS callers.
  */
@@ -1139,7 +1143,7 @@ export class RecordedStoreView<
     return recorded.asOf;
   }
 
-  /** Recorded-time node point-read collections. */
+  /** Recorded-time node reconstructing-read collections. */
   get nodes(): RecordedStoreViewNodeCollections<G> {
     this.#nodes ??= pinnedNodeCollectionsFor(
       this.store,
@@ -1150,7 +1154,7 @@ export class RecordedStoreView<
     return this.#nodes;
   }
 
-  /** Recorded-time edge point-read collections. */
+  /** Recorded-time edge reconstructing-read collections. */
   get edges(): RecordedStoreViewEdgeCollections<G> {
     this.#edges ??= pinnedEdgeCollectionsFor(
       this.store,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -227,6 +227,8 @@ import {
   type OperationHookContext,
   type QueryOptions,
   type RecordedReadStoreOptions,
+  type RecordedScanOptions,
+  type RecordedScanPage,
   type ScopedMeasure,
   type StoreHooks,
   type StoreOptions,
@@ -676,10 +678,14 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         this.recordedNodeGetById(kind, id, coordinate),
       recordedNodeGetByIds: (kind, ids, coordinate) =>
         this.recordedNodeGetByIds(kind, ids, coordinate),
+      recordedNodeScan: (kind, coordinate, options) =>
+        this.recordedNodeScan(kind, coordinate, options),
       recordedEdgeGetById: (kind, id, coordinate) =>
         this.recordedEdgeGetById(kind, id, coordinate),
       recordedEdgeGetByIds: (kind, ids, coordinate) =>
         this.recordedEdgeGetByIds(kind, ids, coordinate),
+      recordedEdgeScan: (kind, coordinate, options) =>
+        this.recordedEdgeScan(kind, coordinate, options),
       subgraphAtCoordinate: (rootId, subgraphOptions) =>
         this.subgraphAtCoordinate(rootId, subgraphOptions),
       algorithmsAtCoordinate: (coordinate) =>
@@ -1264,6 +1270,15 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     return this.#recordedReads.nodeGetByIds(kind, ids, coordinate);
   }
 
+  /** @internal Bounded recorded-time node enumeration for RecordedStoreView. */
+  async recordedNodeScan<N extends NodeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ): Promise<RecordedScanPage<Node<N>>> {
+    return this.#recordedReads.nodeScan(kind, coordinate, options);
+  }
+
   /**
    * Internal seam for {@link RecordedStoreView}: reconstruct an edge point read
    * from the recorded-time relation while preserving live getById behavior.
@@ -1290,6 +1305,15 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     coordinate: ReadCoordinate,
   ): Promise<readonly (Edge<E> | undefined)[]> {
     return this.#recordedReads.edgeGetByIds(kind, ids, coordinate);
+  }
+
+  /** @internal Bounded recorded-time edge enumeration for RecordedStoreView. */
+  async recordedEdgeScan<E extends AnyEdgeType>(
+    kind: string,
+    coordinate: ReadCoordinate,
+    options?: RecordedScanOptions,
+  ): Promise<RecordedScanPage<Edge<E>>> {
+    return this.#recordedReads.edgeScan(kind, coordinate, options);
   }
 
   // === Temporal Views ===

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -1423,13 +1423,35 @@ export type StoreViewEdgeCollections<G extends GraphDef> = {
   >;
 };
 
-/** Recorded-time node point reads for one node kind. */
+/** Options for one bounded, forward-only recorded-time collection scan. */
+export type RecordedScanOptions = Readonly<{
+  /** Maximum entities to return. Defaults to 1,000 and cannot exceed 1,000. */
+  limit?: number;
+  /** Opaque cursor returned by the preceding page. */
+  after?: string;
+}>;
+
+/** One page from a deterministic recorded-time collection scan. */
+export type RecordedScanPage<T> = Readonly<{
+  /** Entities ordered by canonical id ascending. */
+  data: readonly T[];
+  /** Cursor for the next page, or `undefined` when the scan is complete. */
+  nextCursor: string | undefined;
+  /** Whether another page exists after this one. */
+  hasNextPage: boolean;
+}>;
+
+/** Recorded-time reconstructing reads for one node kind. */
 export type RecordedStoreViewNodeCollection<N extends NodeType> = Pick<
   StoreViewNodeCollection<N>,
   (typeof RECORDED_POINT_READ_NAMES)[number]
->;
+> &
+  Readonly<{
+    /** Scan one bounded page at the view's pinned coordinate. */
+    scan: (options?: RecordedScanOptions) => Promise<RecordedScanPage<Node<N>>>;
+  }>;
 
-/** Recorded-time edge point reads for one edge kind. */
+/** Recorded-time reconstructing reads for one edge kind. */
 export type RecordedStoreViewEdgeCollection<
   E extends AnyEdgeType,
   From extends NodeType = NodeType,
@@ -1437,7 +1459,13 @@ export type RecordedStoreViewEdgeCollection<
 > = Pick<
   StoreViewEdgeCollection<E, From, To>,
   (typeof RECORDED_POINT_READ_NAMES)[number]
->;
+> &
+  Readonly<{
+    /** Scan one bounded page at the view's pinned coordinate. */
+    scan: (
+      options?: RecordedScanOptions,
+    ) => Promise<RecordedScanPage<Edge<E, From, To>>>;
+  }>;
 
 /** Recorded-time edge collection derived from an `EdgeRegistration`. */
 export type TypedRecordedStoreViewEdgeCollection<R extends EdgeRegistration> =
@@ -1447,14 +1475,14 @@ export type TypedRecordedStoreViewEdgeCollection<R extends EdgeRegistration> =
     EdgeToTypes<R> extends NodeType ? EdgeToTypes<R> : NodeType
   >;
 
-/** Mapped type of all recorded-time node point-read collections. */
+/** Mapped type of all recorded-time node reconstructing-read collections. */
 export type RecordedStoreViewNodeCollections<G extends GraphDef> = {
   [K in keyof G["nodes"] & string]-?: RecordedStoreViewNodeCollection<
     G["nodes"][K]["type"]
   >;
 };
 
-/** Mapped type of all recorded-time edge point-read collections. */
+/** Mapped type of all recorded-time edge reconstructing-read collections. */
 export type RecordedStoreViewEdgeCollections<G extends GraphDef> = {
   [K in keyof G["edges"] & string]-?: TypedRecordedStoreViewEdgeCollection<
     G["edges"][K]

--- a/packages/typegraph/test-d/store-view.test-d.ts
+++ b/packages/typegraph/test-d/store-view.test-d.ts
@@ -480,32 +480,33 @@ expectAssignable<Pick<RecordedStoreView<typeof graph>, RecordedSharedKeys>>(
 
 // ============================================================
 // Conformance: the recorded view's collections expose EXACTLY the two
-// reconstructing point reads, and those reads ARE StoreView's point reads.
+// reconstructing point reads plus the bounded scan, and the point reads ARE
+// StoreView's point reads.
 // Narrowness (the `keyof` checks) turns silently widening the recorded surface
 // back to include find / findFrom / etc. into a build break; the mutual
 // assignability locks each point read's signature to StoreView's, so a getById
 // change can't drift the two apart.
 // ============================================================
 
-expectType<"getById" | "getByIds">(
+expectType<"getById" | "getByIds" | "scan">(
   {} as keyof RecordedStoreViewNodeCollection<typeof Person>,
 );
-expectType<"getById" | "getByIds">(
+expectType<"getById" | "getByIds" | "scan">(
   {} as keyof RecordedStoreViewEdgeCollection<typeof worksAt>,
 );
 
 expectAssignable<
   Pick<StoreViewNodeCollection<typeof Person>, "getById" | "getByIds">
 >({} as RecordedStoreViewNodeCollection<typeof Person>);
-expectAssignable<RecordedStoreViewNodeCollection<typeof Person>>(
-  {} as Pick<StoreViewNodeCollection<typeof Person>, "getById" | "getByIds">,
-);
+expectAssignable<
+  Pick<RecordedStoreViewNodeCollection<typeof Person>, "getById" | "getByIds">
+>({} as Pick<StoreViewNodeCollection<typeof Person>, "getById" | "getByIds">);
 expectAssignable<
   Pick<StoreViewEdgeCollection<typeof worksAt>, "getById" | "getByIds">
 >({} as RecordedStoreViewEdgeCollection<typeof worksAt>);
-expectAssignable<RecordedStoreViewEdgeCollection<typeof worksAt>>(
-  {} as Pick<StoreViewEdgeCollection<typeof worksAt>, "getById" | "getByIds">,
-);
+expectAssignable<
+  Pick<RecordedStoreViewEdgeCollection<typeof worksAt>, "getById" | "getByIds">
+>({} as Pick<StoreViewEdgeCollection<typeof worksAt>, "getById" | "getByIds">);
 
 // The recorded view's per-kind accessors yield exactly those narrow
 // collections, so the class wiring cannot drift from the collection types.

--- a/packages/typegraph/tests/backends/integration/recorded-read-binding.ts
+++ b/packages/typegraph/tests/backends/integration/recorded-read-binding.ts
@@ -84,6 +84,12 @@ export function registerRecordedReadBindingIntegrationTests(
         .execute();
       expect(rows).toEqual(["Alice"]);
 
+      const scan = await readStore
+        .asOfRecorded(recordedAtCreate)
+        .nodes.Person.scan({ limit: 1 });
+      expect(scan.data.map((person) => person.name)).toEqual(["Alice"]);
+      expect(scan.hasNextPage).toBe(false);
+
       await readStore.nodes.Person.update(alice.id, {
         name: "Live-only update",
       });
@@ -146,6 +152,12 @@ export function registerRecordedReadBindingIntegrationTests(
         undefined,
         "2021",
       ]);
+
+      const scan = await readStore
+        .asOfRecorded(recordedAtCreate)
+        .edges.knows.scan({ limit: 1 });
+      expect(scan.data.map((found) => found.since)).toEqual(["2020"]);
+      expect(scan.hasNextPage).toBe(false);
 
       await readStore.edges.knows.update(edge.id, { since: "live-only" });
       expect(await historyStore.recordedNow()).toBe(recordedAtUpdate);

--- a/packages/typegraph/tests/backends/integration/recorded-time.ts
+++ b/packages/typegraph/tests/backends/integration/recorded-time.ts
@@ -861,6 +861,87 @@ export function registerRecordedTimeIntegrationTests(
       expect(await countRecordedEdgeRows(store, edge.id)).toBe(2);
     });
 
+    it("scans complete recorded node and edge snapshots in bounded id order", async () => {
+      const store = await createHistoryStore(context);
+      const charlie = await store.nodes.Person.create(
+        { name: "Charlie", age: 32 },
+        { id: "scan-person-c" },
+      );
+      const alice = await store.nodes.Person.create(
+        { name: "Alice", age: 30 },
+        { id: "scan-person-a" },
+      );
+      const bob = await store.nodes.Person.create(
+        { name: "Bob", age: 31 },
+        { id: "scan-person-b" },
+      );
+      const laterEdge = await store.edges.knows.create(
+        charlie,
+        alice,
+        { since: "2021" },
+        { id: "scan-edge-b" },
+      );
+      const firstEdge = await store.edges.knows.create(
+        alice,
+        bob,
+        { since: "2020" },
+        { id: "scan-edge-a" },
+      );
+      const recordedAtSnapshot = await readRecordedClock(store);
+
+      await store.nodes.Person.update(bob.id, { name: "Bobby" });
+      await store.nodes.Person.create(
+        { name: "Dana", age: 33 },
+        { id: "scan-person-d" },
+      );
+      await store.edges.knows.create(
+        bob,
+        charlie,
+        { since: "2022" },
+        { id: "scan-edge-c" },
+      );
+
+      const recorded = store.asOfRecorded(recordedAtSnapshot);
+      const firstNodePage = await recorded.nodes.Person.scan({ limit: 2 });
+      expect(firstNodePage.data.map((node) => [node.id, node.name])).toEqual([
+        [alice.id, "Alice"],
+        [bob.id, "Bob"],
+      ]);
+      expect(firstNodePage.hasNextPage).toBe(true);
+      expect(firstNodePage.nextCursor).toBeDefined();
+
+      const secondNodePage = await recorded.nodes.Person.scan({
+        limit: 2,
+        after: requireDefined(firstNodePage.nextCursor),
+      });
+      expect(secondNodePage.data.map((node) => node.id)).toEqual([charlie.id]);
+      expect(secondNodePage.hasNextPage).toBe(false);
+      expect(secondNodePage.nextCursor).toBeUndefined();
+
+      const firstEdgePage = await recorded.edges.knows.scan({ limit: 1 });
+      expect(firstEdgePage.data.map((edge) => edge.id)).toEqual([firstEdge.id]);
+      expect(firstEdgePage.hasNextPage).toBe(true);
+
+      const secondEdgePage = await recorded.edges.knows.scan({
+        limit: 1,
+        after: requireDefined(firstEdgePage.nextCursor),
+      });
+      expect(secondEdgePage.data.map((edge) => edge.id)).toEqual([
+        laterEdge.id,
+      ]);
+      expect(secondEdgePage.hasNextPage).toBe(false);
+
+      await expect(
+        recorded.edges.knows.scan({
+          limit: 1,
+          after: requireDefined(firstNodePage.nextCursor),
+        }),
+      ).rejects.toThrow("cursor does not match");
+      await expect(recorded.nodes.Person.scan({ limit: 1001 })).rejects.toThrow(
+        "between 1 and 1000",
+      );
+    });
+
     it("supports chained valid-time and recorded-time coordinates", async () => {
       const store = await createHistoryStore(context);
 
@@ -2442,7 +2523,7 @@ export function registerRecordedTimeIntegrationTests(
       ).toBe(true);
     });
 
-    it("fails loud when a recorded point read matches overlapping intervals", async () => {
+    it("fails loud when a recorded read matches overlapping intervals", async () => {
       const baseBackend = context.getStore().backend;
       const store = await createHistoryStore(context);
       if (baseBackend.executeStatement === undefined) {
@@ -2502,6 +2583,16 @@ export function registerRecordedTimeIntegrationTests(
 
       await expect(
         store.asOfRecorded(recordedAtCreate).nodes.Person.getById(alice.id),
+      ).rejects.toMatchObject({
+        details: {
+          code: "RECORDED_RELATION_INVARIANT_VIOLATION",
+          entity: "node",
+          kind: "Person",
+          id: alice.id,
+        },
+      });
+      await expect(
+        store.asOfRecorded(recordedAtCreate).nodes.Person.scan(),
       ).rejects.toMatchObject({
         details: {
           code: "RECORDED_RELATION_INVARIANT_VIOLATION",

--- a/packages/typegraph/tests/recorded-store-view-types.test.ts
+++ b/packages/typegraph/tests/recorded-store-view-types.test.ts
@@ -13,6 +13,9 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  type Edge,
+  type Node,
+  type RecordedScanPage,
   RecordedStoreView,
 } from "../src";
 import { createTestBackend } from "./test-utils";
@@ -60,10 +63,14 @@ describe("RecordedStoreView typed surface", () => {
     // ...but the live-state search facade is intentionally absent.
     expectTypeOf(recorded).not.toHaveProperty("search");
 
-    // Node collections are narrowed to point reconstruction only — broad reads
-    // (find / count) and every write are absent.
+    // Node collections expose point reads plus bounded deterministic scans;
+    // broad reads (find / count) and every write remain absent.
     expectTypeOf(recorded.nodes.Person).toHaveProperty("getById");
     expectTypeOf(recorded.nodes.Person).toHaveProperty("getByIds");
+    expectTypeOf(recorded.nodes.Person).toHaveProperty("scan");
+    expectTypeOf(recorded.nodes.Person.scan()).toEqualTypeOf<
+      Promise<RecordedScanPage<Node<typeof Person>>>
+    >();
     expectTypeOf(recorded.nodes.Person).not.toHaveProperty("find");
     expectTypeOf(recorded.nodes.Person).not.toHaveProperty("count");
     expectTypeOf(recorded.nodes.Person).not.toHaveProperty("create");
@@ -71,11 +78,16 @@ describe("RecordedStoreView typed surface", () => {
     expectTypeOf(recorded.nodes.Person).not.toHaveProperty("delete");
     expectTypeOf(recorded.nodes.Person).not.toHaveProperty("findFrom");
 
-    // Edge collections likewise — point reads only; the endpoint reads that the
-    // valid-time StoreView *does* support stay absent here (recorded-time
-    // endpoint reads are not yet reconstructed), as do all writes.
+    // Edge collections likewise add bounded scans; the endpoint reads that the
+    // valid-time StoreView supports stay absent here, as do all writes.
     expectTypeOf(recorded.edges.knows).toHaveProperty("getById");
     expectTypeOf(recorded.edges.knows).toHaveProperty("getByIds");
+    expectTypeOf(recorded.edges.knows).toHaveProperty("scan");
+    expectTypeOf(recorded.edges.knows.scan()).toEqualTypeOf<
+      Promise<
+        RecordedScanPage<Edge<typeof knows, typeof Person, typeof Person>>
+      >
+    >();
     expectTypeOf(recorded.edges.knows).not.toHaveProperty("find");
     expectTypeOf(recorded.edges.knows).not.toHaveProperty("findFrom");
     expectTypeOf(recorded.edges.knows).not.toHaveProperty("findTo");


### PR DESCRIPTION
## What

- add bounded, deterministic `scan()` pagination to recorded-time node and edge collections
- scope opaque forward cursors to the graph, collection, and valid/recorded coordinates
- support both TypeGraph-managed history and external recorded-relation adapters
- document snapshot reconstruction and publish the public API/change contract

## Why

Recorded-time point reads reconstruct a known identity correctly, but external adapters otherwise need to retain a separate canonical identity inventory to rebuild a complete historical snapshot. Collection scans make that identity discovery part of the recorded-time API.

## Impact

The recorded view remains read-only and reconstructing-only. Scans return at most 1,000 entities in canonical ID order, detect overlapping visible versions, and reject cursors reused across collections or temporal coordinates.

## Checks

- `pnpm prettier`
- package ESLint (0 errors; 8 pre-existing disabled-test warnings)
- `pnpm test:docs`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:postgres` (72 files, 2,179 tests)
- `pnpm test:types`
- `pnpm test:api-report`
- `pnpm test:examples`
- `pnpm test:unused`

Note: the monorepo `pnpm fix` command reaches two pre-existing `no-unsafe-assignment` errors in `apps/docs/src/actions/index.ts`; formatting, package lint, and docs lint were run separately and passed.