### PR TITLE
Make verified adapter stores reusable across connections

### DIFF
--- a/.changeset/cacheable-adapter-store.md
+++ b/.changeset/cacheable-adapter-store.md
@@ -1,0 +1,19 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Make verified adapter stores reusable across connections so serverless/edge
+deployments that open a fresh database connection per request can verify once
+per isolate instead of paying a schema-reconcile round-trip on every request.
+
+`AdapterStore` now exposes `reconciledSchema`, an opaque snapshot of a store's
+reconciled (compile-time + runtime-committed) graph and committed schema
+version. Pass it to a synchronous `createAdapterStore(graph, backend,
+{ reconciled })` — which issues **zero** database queries and still validates
+reads and writes against runtime-committed kinds — or call
+`store.withBackend(freshBackend)` to rebind an already-verified store onto a new
+connection with no re-verify (the store's connection is captured immutably, so
+this returns a new equivalent store rather than mutating in place). The new
+`getCommittedSchemaVersion(backend, graphId)` reads the committed version with a
+single indexed SELECT, the cheap cross-isolate probe for detecting when another
+process committed a schema change and the cached snapshot must be refreshed.

--- a/apps/docs/src/content/docs/integration.md
+++ b/apps/docs/src/content/docs/integration.md
@@ -734,6 +734,71 @@ const store = createStore(graph, backend);
 - Vector search (cosine/L2): sqlite-vec on the local better-sqlite3 backend;
   libSQL's built-in vectors on the libSQL / Turso backend
 
+### Per-Request Connections (Cache the Verified Store)
+
+Some serverless Postgres setups — Cloudflare Workers behind Hyperdrive, or any
+platform that pools connections for you — want a **fresh connection per
+request**. `createVerifiedAdapterStore` reconciles the committed schema and
+checks index materialization at open time (a few `SELECT`s), so re-opening a
+verified store on every request adds that cost to every graph-backed route.
+
+Verify **once per isolate**, then build a zero-query store per request from the
+cached reconciled schema:
+
+```typescript
+import {
+  createAdapterStore,
+  createVerifiedAdapterStore,
+  getCommittedSchemaVersion,
+  type ReconciledSchema,
+} from "@nicia-ai/typegraph";
+import { createPostgresBackend } from "@nicia-ai/typegraph/adapters/drizzle/postgres";
+
+// Per-isolate cache. Populated on the first request the isolate serves.
+let cached: { reconciled: ReconciledSchema<typeof graph>; version: number | undefined } | undefined;
+
+async function reconcileOnce(verifyBackend: GraphBackend) {
+  const [store, result] = await createVerifiedAdapterStore(graph, verifyBackend);
+  cached = {
+    reconciled: store.reconciledSchema,
+    version: result.status === "unchanged" ? result.version : store.reconciledSchema.version,
+  };
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const backend = createPostgresBackend(newPoolForThisRequest(env));
+
+    // First request per isolate verifies; later requests reuse the snapshot.
+    if (cached === undefined) await reconcileOnce(backend);
+
+    // A cheap single-row probe detects a schema commit from another isolate.
+    const committed = await getCommittedSchemaVersion(backend, graph.id);
+    if (committed !== cached!.version) await reconcileOnce(backend);
+
+    // Zero database round-trips. Reads and writes still validate against
+    // runtime-committed kinds carried by the reconciled snapshot.
+    const store = createAdapterStore(graph, backend, { reconciled: cached!.reconciled });
+
+    const results = await store.query().from("Document", "d").select((ctx) => ctx.d).execute();
+    return Response.json(results);
+  },
+};
+```
+
+`store.reconciledSchema` is an opaque snapshot of the reconciled graph
+(compile-time kinds folded with any runtime-committed kinds) plus the committed
+version it reflects. `createAdapterStore(graph, backend, { reconciled })` issues
+**no** queries and validates writes against that snapshot, so kinds committed at
+runtime remain writable without re-verifying. If you already hold a verified
+store and only need to swap the connection, `store.withBackend(freshBackend)`
+returns an equivalent store bound to the new connection with no re-verify.
+
+The `getCommittedSchemaVersion` probe is your read-your-writes seam: it is a
+single indexed `SELECT`, far cheaper than the full verified open, and re-verify
+only fires when the version actually moves. Skip the probe entirely (and accept
+bounded cross-isolate staleness) if your schema only changes on deploy.
+
 ### Read Replica Separation
 
 Route heavy graph queries to read replicas while writes go to primary.

--- a/apps/docs/src/content/docs/integration.md
+++ b/apps/docs/src/content/docs/integration.md
@@ -149,16 +149,7 @@ export const typegraphTables = createSqliteTables({
 });
 
 // Export individual tables for drizzle-kit
-export const {
-  nodes: myappGraphNodes,
-  edges: myappGraphEdges,
-  uniques: myappGraphUniques,
-  schemaVersions: myappGraphSchemaVersions,
-  embeddings: myappGraphEmbeddings,
-  indexMaterializations: myappGraphIndexMaterializations,
-  kindRemovals: myappGraphKindRemovals,
-  reconciliationMarkers: myappGraphReconciliationMarkers,
-} = typegraphTables;
+export const { nodes: myappGraphNodes, edges: myappGraphEdges, uniques: myappGraphUniques, schemaVersions: myappGraphSchemaVersions, embeddings: myappGraphEmbeddings, indexMaterializations: myappGraphIndexMaterializations, kindRemovals: myappGraphKindRemovals, reconciliationMarkers: myappGraphReconciliationMarkers } = typegraphTables;
 
 // SQLite fulltext is an FTS5 virtual table — drizzle-kit can't model
 // virtual tables, so this name is exposed as a string. The backend
@@ -166,8 +157,7 @@ export const {
 // `ensureFulltextTable()` ensure (idempotent CREATE VIRTUAL TABLE
 // IF NOT EXISTS), so drizzle-kit-managed setups work without an
 // extra manual step.
-export const myappGraphFulltextTableName =
-  typegraphTables.fulltextTableName;
+export const myappGraphFulltextTableName = typegraphTables.fulltextTableName;
 ```
 
 For PostgreSQL with the default `tsvectorStrategy`, the factory
@@ -363,14 +353,7 @@ stores only the relationships and graph-specific metadata.
 Use the `externalRef()` helper to create type-safe references to external tables:
 
 ```typescript
-import {
-  createExternalRef,
-  defineEdge,
-  defineGraph,
-  defineNode,
-  embedding,
-  externalRef,
-} from "@nicia-ai/typegraph";
+import { createExternalRef, defineEdge, defineGraph, defineNode, embedding, externalRef } from "@nicia-ai/typegraph";
 import { z } from "zod";
 
 // Define nodes that reference your existing tables
@@ -474,10 +457,7 @@ async function findRelatedDocuments(documentId: string) {
 
   // Hydrate with full data from app database
   const externalIds = related.map((r) => r.source.id);
-  const fullDocuments = await appDb
-    .select()
-    .from(documents)
-    .where(inArray(documents.id, externalIds));
+  const fullDocuments = await appDb.select().from(documents).where(inArray(documents.id, externalIds));
 
   return related.map((r) => ({
     ...r,
@@ -746,41 +726,56 @@ Verify **once per isolate**, then build a zero-query store per request from the
 cached reconciled schema:
 
 ```typescript
-import {
-  createAdapterStore,
-  createVerifiedAdapterStore,
-  getCommittedSchemaVersion,
-  type ReconciledSchema,
-} from "@nicia-ai/typegraph";
+import { createAdapterStore, createVerifiedAdapterStore, getCommittedSchemaVersion, type GraphBackend, type ReconciledSchema } from "@nicia-ai/typegraph";
 import { createPostgresBackend } from "@nicia-ai/typegraph/adapters/drizzle/postgres";
 
-// Per-isolate cache. Populated on the first request the isolate serves.
-let cached: { reconciled: ReconciledSchema<typeof graph>; version: number | undefined } | undefined;
+type Cached = {
+  reconciled: ReconciledSchema<typeof graph>;
+  version: number | undefined;
+};
 
-async function reconcileOnce(verifyBackend: GraphBackend) {
-  const [store, result] = await createVerifiedAdapterStore(graph, verifyBackend);
-  cached = {
-    reconciled: store.reconciledSchema,
-    version: result.status === "unchanged" ? result.version : store.reconciledSchema.version,
-  };
+// Per-isolate cache, plus the in-flight reconciliation. Memoizing the promise
+// collapses concurrent cold (or stale) requests onto ONE verify instead of each
+// running its own — otherwise a burst of first requests reproduces the fan-out
+// stampede this pattern exists to avoid.
+let cached: Cached | undefined;
+let inFlight: Promise<Cached> | undefined;
+
+function reconcileOnce(verifyBackend: GraphBackend): Promise<Cached> {
+  inFlight ??= (async () => {
+    const [store, result] = await createVerifiedAdapterStore(graph, verifyBackend);
+    cached = {
+      reconciled: store.reconciledSchema,
+      version: result.status === "unchanged" ? result.version : store.reconciledSchema.version,
+    };
+    return cached;
+  })().finally(() => {
+    inFlight = undefined;
+  });
+  return inFlight;
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const backend = createPostgresBackend(newPoolForThisRequest(env));
 
-    // First request per isolate verifies; later requests reuse the snapshot.
-    if (cached === undefined) await reconcileOnce(backend);
+    // Cold start: concurrent first requests all await the same reconciliation.
+    let snapshot = cached ?? (await reconcileOnce(backend));
 
-    // A cheap single-row probe detects a schema commit from another isolate.
+    // A one-row probe detects a schema commit from another isolate; a moved
+    // version refreshes through the same single-flight path.
     const committed = await getCommittedSchemaVersion(backend, graph.id);
-    if (committed !== cached!.version) await reconcileOnce(backend);
+    if (committed !== snapshot.version) snapshot = await reconcileOnce(backend);
 
     // Zero database round-trips. Reads and writes still validate against
     // runtime-committed kinds carried by the reconciled snapshot.
-    const store = createAdapterStore(graph, backend, { reconciled: cached!.reconciled });
+    const store = createAdapterStore(graph, backend, { reconciled: snapshot.reconciled });
 
-    const results = await store.query().from("Document", "d").select((ctx) => ctx.d).execute();
+    const results = await store
+      .query()
+      .from("Document", "d")
+      .select((ctx) => ctx.d)
+      .execute();
     return Response.json(results);
   },
 };
@@ -794,10 +789,11 @@ runtime remain writable without re-verifying. If you already hold a verified
 store and only need to swap the connection, `store.withBackend(freshBackend)`
 returns an equivalent store bound to the new connection with no re-verify.
 
-The `getCommittedSchemaVersion` probe is your read-your-writes seam: it is a
-single indexed `SELECT`, far cheaper than the full verified open, and re-verify
-only fires when the version actually moves. Skip the probe entirely (and accept
-bounded cross-isolate staleness) if your schema only changes on deploy.
+The `getCommittedSchemaVersion` probe is your read-your-writes seam: one
+round-trip, far cheaper than the full verified open (which also reconciles the
+schema and checks index materialization), and re-verify only fires when the
+version actually moves. Skip the probe entirely (and accept bounded
+cross-isolate staleness) if your schema only changes on deploy.
 
 ### Read Replica Separation
 
@@ -886,16 +882,11 @@ function createTenantQuery(store: Store, tenantId: string) {
       store
         .query()
         .from("Document", "d")
-        .whereNode("d", (d) =>
-          d.tenantId
-            .eq(tenantId)
-            .and(d.embedding.similarTo(queryEmbedding, 10)),
-        )
+        .whereNode("d", (d) => d.tenantId.eq(tenantId).and(d.embedding.similarTo(queryEmbedding, 10)))
         .select((ctx) => ctx.d)
         .execute(),
 
-    createDocument: (data: Omit<DocumentInput, "tenantId">) =>
-      store.nodes.Document.create({ ...data, tenantId }),
+    createDocument: (data: Omit<DocumentInput, "tenantId">) => store.nodes.Document.create({ ...data, tenantId }),
   };
 }
 

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -630,6 +630,9 @@ type FulltextStrategy = Readonly<{
 export function getActiveSchema(backend: GraphBackend, graphId: string): Promise<SerializedSchema | undefined>;
 
 // @public
+export function getCommittedSchemaVersion(backend: GraphBackend, graphId: string): Promise<number | undefined>;
+
+// @public
 export function getMigrationActions(diff: SchemaDiff): readonly string[];
 
 // @public

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -22,7 +22,7 @@ export type AdapterBackend<TNativeTransaction> = GraphBackend & Readonly<{
 export type AdapterBackendTransactions<TNativeTransaction> = Pick<AdapterBackend<TNativeTransaction>, "transactionWithNative" | "adoptTransaction">;
 
 // @public (undocumented)
-export type AdapterHistoryStore<G extends GraphDef, TNativeTransaction> = StoreCore<G> & StoreEvolution<G, AdapterHistoryStore<G, TNativeTransaction>> & AdapterHistoryStoreTransactions<G, TNativeTransaction> & Readonly<{
+export type AdapterHistoryStore<G extends GraphDef, TNativeTransaction> = StoreCore<G> & StoreEvolution<G, AdapterHistoryStore<G, TNativeTransaction>> & AdapterHistoryStoreTransactions<G, TNativeTransaction> & AdapterStoreReconciliation<G, TNativeTransaction, AdapterHistoryStore<G, TNativeTransaction>> & Readonly<{
     backend: HistoryStoreBackend;
     historyEnabled: true;
     recordedReadBound: true;
@@ -41,15 +41,21 @@ export type AdapterHistoryTransactionContext<G extends GraphDef, TNativeTransact
 }>;
 
 // @public (undocumented)
-export type AdapterRecordedReadStore<G extends GraphDef, TNativeTransaction> = StoreCore<G> & StoreEvolution<G, AdapterRecordedReadStore<G, TNativeTransaction>> & AdapterStoreTransactions<G, TNativeTransaction> & Readonly<{
+export type AdapterRecordedReadStore<G extends GraphDef, TNativeTransaction> = StoreCore<G> & StoreEvolution<G, AdapterRecordedReadStore<G, TNativeTransaction>> & AdapterStoreTransactions<G, TNativeTransaction> & AdapterStoreReconciliation<G, TNativeTransaction, AdapterRecordedReadStore<G, TNativeTransaction>> & Readonly<{
     backend: GraphBackend;
     recordedReadBound: true;
 }>;
 
 // @public
-export type AdapterStore<G extends GraphDef, TNativeTransaction> = StoreCore<G> & StoreEvolution<G, AdapterStore<G, TNativeTransaction>> & AdapterStoreTransactions<G, TNativeTransaction> & Readonly<{
+export type AdapterStore<G extends GraphDef, TNativeTransaction> = StoreCore<G> & StoreEvolution<G, AdapterStore<G, TNativeTransaction>> & AdapterStoreTransactions<G, TNativeTransaction> & AdapterStoreReconciliation<G, TNativeTransaction, AdapterStore<G, TNativeTransaction>> & Readonly<{
     backend: GraphBackend;
 }>;
+
+// @public
+interface AdapterStoreReconciliation<G extends GraphDef, TNativeTransaction, Self> {
+    readonly reconciledSchema: ReconciledSchema<G>;
+    readonly withBackend: (backend: AdapterBackend<TNativeTransaction>) => Self;
+}
 
 // @public (undocumented)
 type AdapterStoreTransactions<G extends GraphDef, TNativeTransaction> = Readonly<{
@@ -681,19 +687,19 @@ type CountNodesByKindParams = Readonly<{
 }>;
 
 // @public (undocumented)
-export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: HistoryStoreOptions): AdapterHistoryStore<G, TNativeTransaction>;
+export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: HistoryStoreOptions & ReconciledOption<G>): AdapterHistoryStore<G, TNativeTransaction>;
 
 // @public (undocumented)
-export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: RecordedReadStoreOptions): AdapterRecordedReadStore<G, TNativeTransaction>;
+export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: RecordedReadStoreOptions & ReconciledOption<G>): AdapterRecordedReadStore<G, TNativeTransaction>;
 
 // @public (undocumented)
-export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options?: UnboundLiveStoreOptions): AdapterStore<G, TNativeTransaction>;
+export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options?: UnboundLiveStoreOptions & ReconciledOption<G>): AdapterStore<G, TNativeTransaction>;
 
 // @public (undocumented)
-export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: LiveStoreOptions | undefined): AdapterStore<G, TNativeTransaction> | AdapterRecordedReadStore<G, TNativeTransaction>;
+export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: (LiveStoreOptions & ReconciledOption<G>) | undefined): AdapterStore<G, TNativeTransaction> | AdapterRecordedReadStore<G, TNativeTransaction>;
 
 // @public (undocumented)
-export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: StoreOptions | undefined): AdapterStore<G, TNativeTransaction> | AdapterHistoryStore<G, TNativeTransaction> | AdapterRecordedReadStore<G, TNativeTransaction>;
+export function createAdapterStore<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: (StoreOptions & ReconciledOption<G>) | undefined): AdapterStore<G, TNativeTransaction> | AdapterHistoryStore<G, TNativeTransaction> | AdapterRecordedReadStore<G, TNativeTransaction>;
 
 // @public (undocumented)
 export function createAdapterStoreWithSchema<G extends GraphDef, TNativeTransaction>(graph: G, backend: AdapterBackend<TNativeTransaction>, options: HistoryStoreOptions & SchemaManagerOptions): Promise<[
@@ -2018,6 +2024,9 @@ export type FulltextStrategy = Readonly<{
 
 // @public
 export function generateId(): string;
+
+// @public
+export function getCommittedSchemaVersion(backend: GraphBackend, graphId: string): Promise<number | undefined>;
 
 // @public
 export function getEdgeKinds<G extends GraphDef>(graph: G): readonly (keyof G["edges"] & string)[];
@@ -4086,6 +4095,18 @@ export type ReclaimedVectorFieldEntry = Readonly<{
     fieldPath: string;
     status: "reclaimed" | "failed";
     error?: Error;
+}>;
+
+// @public
+type ReconciledOption<G extends GraphDef> = Readonly<{
+    reconciled?: ReconciledSchema<G>;
+}>;
+
+// @public
+export type ReconciledSchema<G extends GraphDef> = Readonly<{
+    graph: G;
+    version: number | undefined;
+    hash: string | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -44,8 +44,8 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  */
 const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   ".": {
-    count: 310,
-    sha256: "72229672cb7ec0dd9886a96d938ea691df727c22755024632b34f23dabf752d6",
+    count: 312,
+    sha256: "9c41137a0292a9ecb5f57ca6e677e73a90eb9096a200d4327970d4998a3952e0",
   },
   "./adapters/drizzle/indexes": {
     count: 24,

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -383,6 +383,7 @@ export type {
   RebuildFulltextOptions,
   RebuildFulltextResult,
   ReclaimedVectorFieldEntry,
+  ReconciledSchema,
   RecordedReadStore,
   RecordedScanOptions,
   RecordedScanPage,
@@ -440,6 +441,9 @@ export {
   StoreSearch,
   StoreView,
 } from "./store";
+// The cross-isolate invalidation probe for a cached ReconciledSchema. Also
+// available from the "./schema" subpath alongside its schema-read siblings.
+export { getCommittedSchemaVersion } from "./schema";
 export type {
   AlgorithmCyclePolicy,
   BaseTraversalOptions,

--- a/packages/typegraph/src/schema/index.ts
+++ b/packages/typegraph/src/schema/index.ts
@@ -39,6 +39,7 @@ export {
   assertSchemaCurrent,
   ensureSchema,
   getActiveSchema,
+  getCommittedSchemaVersion,
   getSchemaChanges,
   initializeSchema,
   isSchemaInitialized,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -796,3 +796,27 @@ export async function getSchemaChanges<G extends GraphDef>(
 
   return computeSchemaDiff(storedSchema, currentSchema);
 }
+
+/**
+ * Reads the committed schema version for a graph with a single indexed
+ * SELECT — no reconcile, no diff, no materialization-marker reads.
+ *
+ * This is the cheap cross-isolate invalidation probe for a cached
+ * reconciled schema: compare the returned version against the one a verified
+ * open recorded (`store.reconciledSchema.version`); when it has moved, another
+ * process committed a schema change and the cached reconciliation must be
+ * refreshed via `createVerifiedAdapterStore`. One row read replaces the full
+ * three-query verified open on the steady-state (unchanged) path.
+ *
+ * @param backend - The database backend
+ * @param graphId - The graph ID
+ * @returns The active committed version, or `undefined` if the schema has not
+ *   been initialized for this graph.
+ */
+export async function getCommittedSchemaVersion(
+  backend: GraphBackend,
+  graphId: string,
+): Promise<number | undefined> {
+  const row = await backend.getActiveSchema(graphId);
+  return row?.version;
+}

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -798,15 +798,22 @@ export async function getSchemaChanges<G extends GraphDef>(
 }
 
 /**
- * Reads the committed schema version for a graph with a single indexed
- * SELECT — no reconcile, no diff, no materialization-marker reads.
+ * Reads the committed schema version for a graph in a single round-trip — no
+ * schema reconcile, no diff, no materialization-marker reads.
  *
- * This is the cheap cross-isolate invalidation probe for a cached
- * reconciled schema: compare the returned version against the one a verified
- * open recorded (`store.reconciledSchema.version`); when it has moved, another
- * process committed a schema change and the cached reconciliation must be
- * refreshed via `createVerifiedAdapterStore`. One row read replaces the full
- * three-query verified open on the steady-state (unchanged) path.
+ * This is the cross-isolate invalidation probe for a cached reconciled schema:
+ * compare the returned version against the one a verified open recorded
+ * (`store.reconciledSchema.version`); when it has moved, another process
+ * committed a schema change and the cached reconciliation must be refreshed via
+ * `createVerifiedAdapterStore`. One read replaces the three-query verified open
+ * on the steady-state (unchanged) path — the round-trip that saturated the
+ * connection pool under fan-out.
+ *
+ * It reads the active schema *row* (via `backend.getActiveSchema`), so the
+ * committed `schema_doc` is transferred and normalized even though only the
+ * version is used. A version-only backend query would shrink the payload
+ * further; it is a backward-compatible follow-up, not required for the
+ * round-trip win above.
  *
  * @param backend - The database backend
  * @param graphId - The graph ID

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -112,6 +112,7 @@ export type {
   AdapterStore,
   HistoryStore,
   MeasurableAdapterHistoryTransactionContext,
+  ReconciledSchema,
   RecordedReadStore,
   ReembedFunction,
   ReembedVectorFieldOptions,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -4075,6 +4075,19 @@ export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
   | AdapterHistoryStore<G, TNativeTransaction>
   | AdapterRecordedReadStore<G, TNativeTransaction> {
   const reconciled = options?.reconciled;
+  if (reconciled !== undefined && reconciled.graph.id !== graph.id) {
+    // Same-shaped graphs are structurally interchangeable to TypeScript, so a
+    // snapshot from a different graph would silently reroute reads/writes to
+    // the wrong graph ID. Reject it — this is a zero-query check.
+    throw new ConfigurationError(
+      `Reconciled snapshot is for graph "${reconciled.graph.id}", not "${graph.id}".`,
+      { code: "RECONCILED_GRAPH_MISMATCH" },
+      {
+        suggestion:
+          "Pass the ReconciledSchema produced from the same graph you are building the store with; snapshots are not interchangeable across graphs.",
+      },
+    );
+  }
   const storeOptions = stripReconciledOption(options);
   // A reconciled snapshot is a pre-computed (graph, schemaMetadata) — the
   // zero-round-trip equivalent of `prepareVerifiedStore`. Resolve the inputs,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -552,6 +552,64 @@ export type Store<G extends GraphDef> = StoreCore<G> &
   StoreEvolution<G, Store<G>>;
 
 /**
+ * An opaque, in-memory snapshot of a store's reconciled schema: the merged
+ * compile-time + runtime-committed graph plus the committed schema version and
+ * hash it reflects. Produced by {@link AdapterStore.reconciledSchema} after a
+ * verified open, cached once per isolate/process, and handed to
+ * {@link createAdapterStore} via `{ reconciled }` (or used implicitly by
+ * {@link AdapterStore.withBackend}) to build request-scoped stores against
+ * fresh connections with **zero** database round-trips. Reads and writes are
+ * validated against the reconciled graph, so runtime-committed kinds seen at
+ * the reconcile are honored without re-querying.
+ *
+ * Treat it as opaque and immutable — do not construct or mutate it. Its
+ * `version` is the value to compare against {@link getCommittedSchemaVersion}
+ * to detect a schema commit from another process and refresh the snapshot.
+ */
+export type ReconciledSchema<G extends GraphDef> = Readonly<{
+  graph: G;
+  version: number | undefined;
+  hash: string | undefined;
+}>;
+
+/** Construction option carrying a cached {@link ReconciledSchema}. */
+type ReconciledOption<G extends GraphDef> = Readonly<{
+  reconciled?: ReconciledSchema<G>;
+}>;
+
+/**
+ * The reconciliation surface shared by every adapter store flavor: read the
+ * cached {@link ReconciledSchema} and rebind to a fresh connection with no
+ * verify round-trip. `Self` is the receiver's own surface so `withBackend`
+ * preserves the store flavor (live / history / recorded-read).
+ *
+ * Declared as an `interface` (not a `type`): the surface aliases intersect it
+ * with `Self` bound to themselves, which a `type` alias rejects as a circular
+ * self-reference (TS2456) but an interface resolves lazily — the same idiom as
+ * {@link StoreEvolution}.
+ */
+interface AdapterStoreReconciliation<
+  G extends GraphDef,
+  TNativeTransaction,
+  Self,
+> {
+  /**
+   * An opaque snapshot of this store's reconciled schema. Cache it after a
+   * verified open and pass it to {@link createAdapterStore} `{ reconciled }`
+   * to build per-request stores with zero database round-trips.
+   */
+  readonly reconciledSchema: ReconciledSchema<G>;
+  /**
+   * Build an equivalent store bound to a fresh backend/connection, reusing
+   * this store's already-reconciled schema — no verify round-trip. The
+   * per-request primitive for serverless deployments that open a new
+   * connection per request; the returned store validates writes against the
+   * same reconciled graph as the receiver.
+   */
+  readonly withBackend: (backend: AdapterBackend<TNativeTransaction>) => Self;
+}
+
+/**
  * A Store with explicit adapter interoperability. Adapter entrypoints return
  * this surface so native transaction handles remain precisely typed without
  * leaking into the default Store contract.
@@ -562,6 +620,11 @@ export type AdapterStore<
 > = StoreCore<G> &
   StoreEvolution<G, AdapterStore<G, TNativeTransaction>> &
   AdapterStoreTransactions<G, TNativeTransaction> &
+  AdapterStoreReconciliation<
+    G,
+    TNativeTransaction,
+    AdapterStore<G, TNativeTransaction>
+  > &
   Readonly<{ backend: GraphBackend }>;
 
 type AdapterStoreTransactions<
@@ -729,6 +792,43 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   /** The kind registry for ontology lookups */
   get registry(): KindRegistry {
     return this.#registry;
+  }
+
+  /**
+   * An opaque, in-memory snapshot of this store's reconciled schema — the
+   * merged compile-time + runtime-committed graph plus the committed version
+   * it reflects. Cache it after a verified open and hand it to
+   * {@link createAdapterStore} via `{ reconciled }` (or call
+   * {@link AdapterStoreImplementation.withBackend}) to build request-scoped
+   * stores against fresh connections with zero database round-trips. Refresh
+   * it when {@link getCommittedSchemaVersion} reports a moved version.
+   */
+  get reconciledSchema(): ReconciledSchema<G> {
+    return Object.freeze({
+      graph: this.#graph,
+      version: this.#schemaMetadata.schemaVersion,
+      hash: this.#schemaMetadata.schemaHash,
+    });
+  }
+
+  /**
+   * Reconstruction inputs for a connection rebind: the merged graph, the
+   * verbatim construction options, and the reconciled schema metadata. Lets an
+   * adapter subclass rebuild an equivalent store against a fresh backend
+   * without a verify round-trip.
+   *
+   * @internal
+   */
+  protected reconstructionState(): Readonly<{
+    graph: G;
+    options: StoreOptions | undefined;
+    schemaMetadata: StoreSchemaMetadata;
+  }> {
+    return {
+      graph: this.#graph,
+      options: this.#options,
+      schemaMetadata: this.#schemaMetadata,
+    };
   }
 
   /**
@@ -3600,6 +3700,26 @@ class AdapterStoreImplementation<
         );
   }
 
+  /**
+   * Rebind this store's already-reconciled schema onto a fresh backend/
+   * connection, returning a new equivalent store with **no** verify round-trip.
+   * The connection is captured at construction and never mutated, so this
+   * returns a new instance rather than rebinding in place — the serverless
+   * per-request primitive: verify once per isolate, then `withBackend` the
+   * per-request connection.
+   */
+  withBackend(
+    backend: AdapterBackend<TNativeTransaction>,
+  ): AdapterStoreImplementation<G, TNativeTransaction> {
+    const state = this.reconstructionState();
+    return new AdapterStoreImplementation(
+      state.graph,
+      backend,
+      state.options,
+      state.schemaMetadata,
+    );
+  }
+
   override async evolve<TRefStore extends StoreCore<G>>(
     extension: GraphExtension,
     options?: Readonly<{
@@ -3790,6 +3910,11 @@ export type AdapterRecordedReadStore<
 > = StoreCore<G> &
   StoreEvolution<G, AdapterRecordedReadStore<G, TNativeTransaction>> &
   AdapterStoreTransactions<G, TNativeTransaction> &
+  AdapterStoreReconciliation<
+    G,
+    TNativeTransaction,
+    AdapterRecordedReadStore<G, TNativeTransaction>
+  > &
   Readonly<{
     backend: GraphBackend;
     recordedReadBound: true;
@@ -3814,6 +3939,11 @@ export type AdapterHistoryStore<
 > = StoreCore<G> &
   StoreEvolution<G, AdapterHistoryStore<G, TNativeTransaction>> &
   AdapterHistoryStoreTransactions<G, TNativeTransaction> &
+  AdapterStoreReconciliation<
+    G,
+    TNativeTransaction,
+    AdapterHistoryStore<G, TNativeTransaction>
+  > &
   Readonly<{
     backend: HistoryStoreBackend;
     historyEnabled: true;
@@ -3909,29 +4039,29 @@ export function createStore<G extends GraphDef>(
 export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
   graph: G,
   backend: AdapterBackend<TNativeTransaction>,
-  options: HistoryStoreOptions,
+  options: HistoryStoreOptions & ReconciledOption<G>,
 ): AdapterHistoryStore<G, TNativeTransaction>;
 export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
   graph: G,
   backend: AdapterBackend<TNativeTransaction>,
-  options: RecordedReadStoreOptions,
+  options: RecordedReadStoreOptions & ReconciledOption<G>,
 ): AdapterRecordedReadStore<G, TNativeTransaction>;
 export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
   graph: G,
   backend: AdapterBackend<TNativeTransaction>,
-  options?: UnboundLiveStoreOptions,
+  options?: UnboundLiveStoreOptions & ReconciledOption<G>,
 ): AdapterStore<G, TNativeTransaction>;
 export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
   graph: G,
   backend: AdapterBackend<TNativeTransaction>,
-  options: LiveStoreOptions | undefined,
+  options: (LiveStoreOptions & ReconciledOption<G>) | undefined,
 ):
   | AdapterStore<G, TNativeTransaction>
   | AdapterRecordedReadStore<G, TNativeTransaction>;
 export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
   graph: G,
   backend: AdapterBackend<TNativeTransaction>,
-  options: StoreOptions | undefined,
+  options: (StoreOptions & ReconciledOption<G>) | undefined,
 ):
   | AdapterStore<G, TNativeTransaction>
   | AdapterHistoryStore<G, TNativeTransaction>
@@ -3939,13 +4069,27 @@ export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
 export function createAdapterStore<G extends GraphDef, TNativeTransaction>(
   graph: G,
   backend: AdapterBackend<TNativeTransaction>,
-  options?: StoreOptions,
+  options?: StoreOptions & ReconciledOption<G>,
 ):
   | AdapterStore<G, TNativeTransaction>
   | AdapterHistoryStore<G, TNativeTransaction>
   | AdapterRecordedReadStore<G, TNativeTransaction> {
+  const reconciled = options?.reconciled;
+  const storeOptions = stripReconciledOption(options);
+  // A reconciled snapshot is a pre-computed (graph, schemaMetadata) — the
+  // zero-round-trip equivalent of `prepareVerifiedStore`. Resolve the inputs,
+  // then take the single construction path. The merged graph is a superset of
+  // the compile-time `graph`, so runtime-committed kinds validate.
+  const resolvedGraph = reconciled?.graph ?? graph;
+  const schemaMetadata =
+    reconciled === undefined ? undefined : reconciledSchemaMetadata(reconciled);
   return asAdapterStoreSurface(
-    new AdapterStoreImplementation(graph, backend, options),
+    new AdapterStoreImplementation(
+      resolvedGraph,
+      backend,
+      storeOptions,
+      schemaMetadata,
+    ),
   );
 }
 
@@ -3967,6 +4111,29 @@ function schemaMetadataFromRow(
     schemaVersion: row.version,
     schemaHash: row.schema_hash,
   });
+}
+
+function reconciledSchemaMetadata(
+  reconciled: ReconciledSchema<GraphDef>,
+): StoreSchemaMetadata {
+  return Object.freeze({
+    schemaVersion: reconciled.version,
+    schemaHash: reconciled.hash,
+  });
+}
+
+/**
+ * Splits the construction-time `reconciled` snapshot off the persisted store
+ * options. The store keeps its options verbatim to reconstruct the next store
+ * on `evolve()`, so the snapshot — a one-shot construction source — must never
+ * be carried forward.
+ */
+function stripReconciledOption<G extends GraphDef>(
+  options: (StoreOptions & ReconciledOption<G>) | undefined,
+): StoreOptions | undefined {
+  if (options === undefined || !("reconciled" in options)) return options;
+  const { reconciled: _reconciled, ...rest } = options;
+  return rest;
 }
 
 function schemaMetadataForResult(

--- a/packages/typegraph/tests/adapter-store-reconciled.test.ts
+++ b/packages/typegraph/tests/adapter-store-reconciled.test.ts
@@ -1,0 +1,75 @@
+/**
+ * SQLite-specific wiring for the cacheable adapter store (§7): rebinding a
+ * verified store onto a *second backend over the same physical database* — the
+ * per-request-reconnection shape the harness's one-backend-per-test factory
+ * can't express. The dialect-agnostic guarantees (zero round-trip construction,
+ * runtime-committed-kind validation, the version probe) are proven on every
+ * backend by the shared `backends/integration/reconciled-schema.ts` group.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createAdapterStoreWithSchema,
+  createVerifiedAdapterStore,
+  defineGraph,
+  defineNode,
+} from "../src";
+import { createSqliteBackend } from "../src/backend/sqlite";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { defineGraphExtension } from "../src/graph-extension";
+import { requireDefined } from "../src/utils/presence";
+import { spyGetActiveSchema } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const baseGraph = defineGraph({
+  id: "reconciled_store",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+/** A kind committed at runtime, deliberately absent from `baseGraph`. */
+const refundTicketExtension = defineGraphExtension({
+  nodes: {
+    RefundTicket: {
+      properties: {
+        reason: { type: "string" },
+        amount: { type: "number" },
+      },
+    },
+  },
+});
+
+describe("store.withBackend", () => {
+  it("rebinds to a second connection over the same database with no re-verify", async () => {
+    const { backend, db } = createLocalSqliteBackend();
+    const [seed] = await createAdapterStoreWithSchema(baseGraph, backend);
+    const evolved = await seed.evolve(refundTicketExtension);
+    const [verified] = await createVerifiedAdapterStore(baseGraph, backend);
+
+    // A second backend over the same Drizzle database — the per-request handle.
+    const requestBackend = createSqliteBackend(db);
+    const spy = spyGetActiveSchema(requestBackend);
+    const perRequest = verified.withBackend(spy.backend);
+    expect(spy.calls()).toBe(0);
+    expect(perRequest.reconciledSchema.version).toBe(
+      verified.reconciledSchema.version,
+    );
+
+    // Write through the rebound store...
+    const tickets = requireDefined(
+      perRequest.getNodeCollection("RefundTicket"),
+    );
+    const created = await tickets.create({ reason: "late", amount: 7 });
+
+    // ...and read it back through the original connection (same database).
+    const viaOriginal = requireDefined(
+      evolved.getNodeCollection("RefundTicket"),
+    );
+    const read = requireDefined(await viaOriginal.getById(created.id));
+    expect(read).toMatchObject({ reason: "late", amount: 7 });
+  });
+});

--- a/packages/typegraph/tests/adapter-store-reconciled.test.ts
+++ b/packages/typegraph/tests/adapter-store-reconciled.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  createAdapterStore,
   createAdapterStoreWithSchema,
   createVerifiedAdapterStore,
   defineGraph,
@@ -41,6 +42,28 @@ const refundTicketExtension = defineGraphExtension({
       },
     },
   },
+});
+
+describe("createAdapterStore reconciled-graph guard", () => {
+  it("rejects a snapshot built for a different graph", async () => {
+    const { backend } = createLocalSqliteBackend();
+    const [seed] = await createAdapterStoreWithSchema(baseGraph, backend);
+
+    const otherGraph = defineGraph({
+      id: "other_reconciled_store",
+      nodes: { Person: { type: Person } },
+      edges: {},
+    });
+
+    // Same-shaped graphs are structurally interchangeable to TypeScript, so a
+    // snapshot for `baseGraph` type-checks against `otherGraph` with no cast.
+    // The runtime guard is what stops it silently routing to the wrong graph ID.
+    expect(() =>
+      createAdapterStore(otherGraph, backend, {
+        reconciled: seed.reconciledSchema,
+      }),
+    ).toThrow(/not "other_reconciled_store"/);
+  });
 });
 
 describe("store.withBackend", () => {

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -38,6 +38,7 @@ import {
   registerPaginationIntegrationTests,
   registerPredicateIntegrationTests,
   registerProvenanceIntegrationTests,
+  registerReconciledSchemaIntegrationTests,
   registerRecordedReadBindingIntegrationTests,
   registerRecordedTimeIntegrationTests,
   registerRecursiveIntegrationTests,
@@ -102,6 +103,12 @@ export function createIntegrationTestSuite<TNativeTransaction>(
         }
         return store;
       },
+      getBackend: () => {
+        if (adapterBackend === undefined) {
+          throw new Error("Integration backend is not initialized.");
+        }
+        return adapterBackend as AdapterBackend<unknown>;
+      },
       createStore: async (graph, options) => {
         if (adapterBackend === undefined) {
           throw new Error("Integration backend is not initialized.");
@@ -155,6 +162,7 @@ export function createIntegrationTestSuite<TNativeTransaction>(
     registerLateMaterializationIntegrationTests(context);
     registerTemporalIntegrationTests(context);
     registerTransactionReceiptIntegrationTests(context);
+    registerReconciledSchemaIntegrationTests(context);
     registerRecordedTimeIntegrationTests(context);
     registerRecordedReadBindingIntegrationTests(context);
     registerSetOperationIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -16,6 +16,7 @@ export { registerOrderingIntegrationTests } from "./ordering";
 export { registerPaginationIntegrationTests } from "./pagination";
 export { registerPredicateIntegrationTests } from "./predicates";
 export { registerProvenanceIntegrationTests } from "./provenance";
+export { registerReconciledSchemaIntegrationTests } from "./reconciled-schema";
 export { registerRecordedReadBindingIntegrationTests } from "./recorded-read-binding";
 export { registerRecordedTimeIntegrationTests } from "./recorded-time";
 export { registerRecursiveIntegrationTests } from "./recursive";

--- a/packages/typegraph/tests/backends/integration/reconciled-schema.ts
+++ b/packages/typegraph/tests/backends/integration/reconciled-schema.ts
@@ -177,5 +177,42 @@ export function registerReconciledSchemaIntegrationTests(
       );
       expect(read.name).toBe("Rebound");
     });
+
+    it("evolve through a reconciled store commits the kind and bumps the committed version", async () => {
+      const backend = context.getBackend();
+      const [verified] = await createVerifiedAdapterStore(
+        integrationTestGraph,
+        backend,
+      );
+      const before = requireDefined(
+        await getCommittedSchemaVersion(backend, integrationTestGraph.id),
+      );
+
+      // The write path a brain actually hits: evolve a new kind through a
+      // per-request store built from the cached snapshot, not a verified one.
+      const perRequest = createAdapterStore(integrationTestGraph, backend, {
+        reconciled: verified.reconciledSchema,
+      });
+      const evolved = await perRequest.evolve(
+        defineGraphExtension({
+          nodes: {
+            EvolveProbe: { properties: { label: { type: "string" } } },
+          },
+        }),
+      );
+
+      // The new kind is committed and writable through the evolved handle...
+      const probes = requireDefined(evolved.getNodeCollection("EvolveProbe"));
+      const created = await probes.create({ label: "via-reconciled" });
+      expect(requireDefined(await probes.getById(created.id))).toMatchObject({
+        label: "via-reconciled",
+      });
+
+      // ...and the committed version moved, so another isolate's probe catches it.
+      const after = requireDefined(
+        await getCommittedSchemaVersion(backend, integrationTestGraph.id),
+      );
+      expect(after).toBeGreaterThan(before);
+    });
   });
 }

--- a/packages/typegraph/tests/backends/integration/reconciled-schema.ts
+++ b/packages/typegraph/tests/backends/integration/reconciled-schema.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAdapterStore,
+  createVerifiedAdapterStore,
+  getCommittedSchemaVersion,
+} from "../../../src";
+import { defineGraphExtension } from "../../../src/graph-extension";
+import { requireDefined } from "../../../src/utils/presence";
+import { spyGetActiveSchema } from "../../test-utils";
+import { integrationTestGraph } from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+/**
+ * Cross-backend parity for the cacheable adapter-store path: a store built
+ * from a cached {@link createVerifiedAdapterStore} snapshot must read and,
+ * crucially, *validate writes against runtime-committed kinds* identically on
+ * every backend — with no verify round-trip — and {@link getCommittedSchemaVersion}
+ * must report the same committed version the snapshot recorded. These are the
+ * guarantees the §7 serverless per-request cache leans on, so they belong in
+ * the shared suite rather than a per-dialect test.
+ */
+export function registerReconciledSchemaIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("Reconciled schema (cacheable adapter store)", () => {
+    it("reconciledSchema exposes the committed version and merged graph", async () => {
+      const backend = context.getBackend();
+      const [store, result] = await createVerifiedAdapterStore(
+        integrationTestGraph,
+        backend,
+      );
+
+      // A store committed by the suite's beforeEach is always caught up, so
+      // the verified open reports "unchanged" and carries the live version.
+      const committedVersion =
+        result.status === "unchanged" ? result.version : undefined;
+      expect(store.reconciledSchema.graph.id).toBe(integrationTestGraph.id);
+      expect(typeof store.reconciledSchema.version).toBe("number");
+      expect(result.status).toBe("unchanged");
+      expect(store.reconciledSchema.version).toBe(committedVersion);
+    });
+
+    it("getCommittedSchemaVersion matches the reconciled snapshot", async () => {
+      const backend = context.getBackend();
+      const [store] = await createVerifiedAdapterStore(
+        integrationTestGraph,
+        backend,
+      );
+
+      const probed = await getCommittedSchemaVersion(
+        backend,
+        integrationTestGraph.id,
+      );
+      expect(probed).toBe(store.reconciledSchema.version);
+    });
+
+    it("constructs from a snapshot with zero database round-trips", async () => {
+      const backend = context.getBackend();
+      const [verified] = await createVerifiedAdapterStore(
+        integrationTestGraph,
+        backend,
+      );
+
+      // The whole point of the feature: no schema-reconcile read at construction
+      // or on the write path. Proven on every backend, not just SQLite.
+      const spy = spyGetActiveSchema(backend);
+      const perRequest = createAdapterStore(integrationTestGraph, spy.backend, {
+        reconciled: verified.reconciledSchema,
+      });
+      expect(spy.calls()).toBe(0);
+      await perRequest.nodes.Person.create({ name: "Zero Roundtrip" });
+      expect(spy.calls()).toBe(0);
+    });
+
+    it("getCommittedSchemaVersion is a single indexed read that moves on commit", async () => {
+      const backend = context.getBackend();
+
+      const spy = spyGetActiveSchema(backend);
+      const before = requireDefined(
+        await getCommittedSchemaVersion(spy.backend, integrationTestGraph.id),
+      );
+      expect(spy.calls()).toBe(1);
+
+      await context.getStore().evolve(
+        defineGraphExtension({
+          nodes: {
+            VersionProbe: { properties: { label: { type: "string" } } },
+          },
+        }),
+      );
+
+      const after = requireDefined(
+        await getCommittedSchemaVersion(backend, integrationTestGraph.id),
+      );
+      expect(after).toBeGreaterThan(before);
+    });
+
+    it("getCommittedSchemaVersion returns undefined for an uncommitted graph", async () => {
+      const backend = context.getBackend();
+      expect(
+        await getCommittedSchemaVersion(backend, "never_committed_graph"),
+      ).toBeUndefined();
+    });
+
+    it("createAdapterStore({ reconciled }) reads and writes an existing kind", async () => {
+      const backend = context.getBackend();
+      const [verified] = await createVerifiedAdapterStore(
+        integrationTestGraph,
+        backend,
+      );
+
+      const perRequest = createAdapterStore(integrationTestGraph, backend, {
+        reconciled: verified.reconciledSchema,
+      });
+      const created = await perRequest.nodes.Person.create({
+        name: "Reconciled Reader",
+      });
+      const read = requireDefined(
+        await perRequest.nodes.Person.getById(created.id),
+      );
+      expect(read.name).toBe("Reconciled Reader");
+    });
+
+    it("validates a runtime-committed kind through a store built from the compile-time graph", async () => {
+      const backend = context.getBackend();
+      // Commit a kind absent from the compile-time `integrationTestGraph`.
+      await context.getStore().evolve(
+        defineGraphExtension({
+          nodes: {
+            ReconcileProbe: {
+              properties: { label: { type: "string" } },
+            },
+          },
+        }),
+      );
+
+      // Verify once (folds in the runtime kind), then build a per-request store
+      // from the *compile-time* graph plus the cached snapshot — no re-query.
+      const [verified] = await createVerifiedAdapterStore(
+        integrationTestGraph,
+        backend,
+      );
+      const perRequest = createAdapterStore(integrationTestGraph, backend, {
+        reconciled: verified.reconciledSchema,
+      });
+
+      const probes = requireDefined(
+        perRequest.getNodeCollection("ReconcileProbe"),
+      );
+      const created = await probes.create({ label: "hello" });
+      const read = requireDefined(await probes.getById(created.id));
+      expect(read).toMatchObject({ label: "hello" });
+
+      // A store WITHOUT the snapshot cannot see the runtime kind — the snapshot
+      // is exactly what carries the runtime-committed shape.
+      const withoutSnapshot = createAdapterStore(integrationTestGraph, backend);
+      expect(
+        withoutSnapshot.getNodeCollection("ReconcileProbe"),
+      ).toBeUndefined();
+    });
+
+    it("withBackend rebuilds an equivalent store with no re-verify", async () => {
+      const backend = context.getBackend();
+      const [verified] = await createVerifiedAdapterStore(
+        integrationTestGraph,
+        backend,
+      );
+
+      const rebound = verified.withBackend(backend);
+      expect(rebound.reconciledSchema.version).toBe(
+        verified.reconciledSchema.version,
+      );
+      const created = await rebound.nodes.Person.create({ name: "Rebound" });
+      const read = requireDefined(
+        await rebound.nodes.Person.getById(created.id),
+      );
+      expect(read.name).toBe("Rebound");
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/test-context.ts
+++ b/packages/typegraph/tests/backends/integration/test-context.ts
@@ -1,4 +1,5 @@
 import type { GraphBackend, GraphDef, HistoryStoreBackend } from "../../../src";
+import type { AdapterBackend } from "../../../src/backend/types";
 import type { HistoryStore, Store } from "../../../src/store/store";
 import type {
   HistoryStoreOptions,
@@ -14,6 +15,13 @@ type InspectableHistoryStore<G extends GraphDef> = HistoryStore<G> &
 
 export type IntegrationTestContext = Readonly<{
   getStore: () => IntegrationStore;
+  /**
+   * The adapter backend for the current test, for exercising construction
+   * functions (`createVerifiedAdapterStore`, `createAdapterStore`) and
+   * schema-read helpers (`getCommittedSchemaVersion`) directly against a
+   * backend rather than through the pre-built store.
+   */
+  getBackend: () => AdapterBackend<unknown>;
   createStore: <G extends GraphDef>(
     graph: G,
     options?: LiveStoreOptions,

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -190,6 +190,30 @@ export function createPlanCaptureBackend(): PlanCaptureHarness {
 }
 
 /**
+ * Wraps an adapter backend so calls to `getActiveSchema` — the schema-reconcile
+ * read a verified open performs — can be counted, using the same spread-override
+ * idiom as {@link createPlanCaptureBackend}. Every other method delegates
+ * unchanged. Used to assert that the cacheable-store path issues no verify
+ * round-trip, and that `getCommittedSchemaVersion` is a single read.
+ */
+export function spyGetActiveSchema<TNativeTransaction>(
+  backend: AdapterBackend<TNativeTransaction>,
+): Readonly<{
+  backend: AdapterBackend<TNativeTransaction>;
+  calls: () => number;
+}> {
+  let calls = 0;
+  const wrapped: AdapterBackend<TNativeTransaction> = {
+    ...backend,
+    getActiveSchema: (graphId) => {
+      calls += 1;
+      return backend.getActiveSchema(graphId);
+    },
+  };
+  return { backend: wrapped, calls: () => calls };
+}
+
+/**
  * The `EXPLAIN QUERY PLAN` detail lines for a captured statement, joined
  * with newlines — assert index usage with `toContain("<index name>")` and
  * scan absence with `not.toContain("SCAN <table>")`.


### PR DESCRIPTION
Serverless/edge deployments that open a **fresh database connection per request** (Cloudflare Workers + Hyperdrive → Neon, RDS Proxy, etc.) re-ran the full schema-reconcile verify on *every* request. `createVerifiedAdapterStore` computes the reconciled graph then discards it, and the backend is captured immutably at open time, so a store cached under a per-request connection can never be reused.

A production trace on `@nicia-ai/typegraph@0.40.0` (Workers + Hyperdrive) showed **0% cross-request cache hit** and per-open latency degrading into 10–14s under fan-out as the verify `SELECT`s tipped the connection pool over.

## Fix

Expose the reconciliation so it can be verified **once per isolate** and reused with zero round-trips:

| API | What it does |
|---|---|
| `AdapterStore.reconciledSchema` | Opaque `ReconciledSchema<G>` snapshot — merged (compile-time + runtime-committed) graph + committed `version`/`hash`. |
| `createAdapterStore(graph, backend, { reconciled })` | **Zero-query** sync construction; validates reads *and writes* against the snapshot's merged graph, so runtime-committed kinds stay writable without re-verify. |
| `store.withBackend(freshBackend)` | Rebind an already-verified store onto a new connection, no re-verify. Non-mutating (the connection is captured immutably), so it returns a new equivalent store. |
| `getCommittedSchemaVersion(backend, graphId)` | Single indexed `SELECT` — the cheap cross-isolate probe to detect a schema commit from another process and refresh the snapshot. |

Usage pattern (documented in `integration.md` → *Per-Request Connections*):

```ts
// once per isolate
const [store, result] = await createVerifiedAdapterStore(graph, backend);
const reconciled = store.reconciledSchema;

// per request, fresh connection, zero queries
const perRequest = createAdapterStore(graph, requestBackend, { reconciled });

// cheap cross-isolate invalidation
if (await getCommittedSchemaVersion(requestBackend, graph.id) !== reconciled.version) {
  /* re-verify, refresh snapshot */
}
```

## Design notes

- `withBackend` deliberately **returns a new store** rather than mutating the connection in place — the backend is held in deep-frozen `readonly` fields by design, and reusing the reconciled snapshot achieves the same goal without breaking that invariant.
- `AdapterStoreReconciliation` is an `interface` (not a `type`) to dodge a TS2456 self-reference on the surface intersection — the same idiom as `StoreEvolution`.
- `getCommittedSchemaVersion` lives in `schema/manager.ts` beside its read siblings but is re-exported at the package root too, so the whole cacheable-store workflow imports from one place.

## Testing

- **Cross-backend** (`tests/backends/integration/reconciled-schema.ts`, runs on SQLite **and** Postgres): reconciled snapshot exposes the committed version; `createAdapterStore({ reconciled })` reads/writes with **zero** `getActiveSchema` round-trips; a **runtime-committed kind is writable** through a store built from the compile-time graph; `getCommittedSchemaVersion` is a single read that moves on commit; `withBackend` rebuilds an equivalent store.
- **SQLite-specific** (`tests/adapter-store-reconciled.test.ts`): rebinding a second backend over one physical database.
