### PR TITLE
Fix PGlite bind-parameter batching

### DIFF
--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -6,6 +6,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { type ExtractTablesWithRelations } from "drizzle-orm/relations";
 
+import { ConfigurationError } from "../../../errors";
 import { isSqlFragment } from "../../../query/sql-fragment";
 import { shouldForceCustomPlan } from "../../../query/sql-intent";
 import { getOrCreateLru } from "./lru";
@@ -156,6 +157,19 @@ function isPgliteClient(candidate: unknown): candidate is NodePgClient {
     hasFunctionProperty(candidate, "query") &&
     hasFunctionProperty(candidate, "dumpDataDir")
   );
+}
+
+/**
+ * PGlite 0.5.x serializes the wire-protocol parameter count as a signed
+ * 16-bit integer. At 32,768 binds it silently returns no rows and leaves the
+ * client returning false-empty results, so the advertised budget must stay at
+ * the largest signed 16-bit value.
+ */
+export const PGLITE_MAX_BIND_PARAMETERS = 32_767;
+
+/** Detects a root Drizzle database backed by PGlite without importing it. */
+export function isPgliteDatabase(db: AnyPgDatabase): boolean {
+  return isPgliteClient((db as PgClientCarrier).$client);
 }
 
 function transactionSession(
@@ -489,9 +503,11 @@ async function executeDrizzleQuery<TRow>(
 function createPgPreparedStatement(
   pgClient: PgQueryClient,
   sqlText: string,
+  maxBindParameters: number | undefined,
 ): PreparedSqlStatement {
   return {
     async execute<TRow>(params: readonly unknown[]): Promise<readonly TRow[]> {
+      assertWithinBindParameterLimit(params.length, maxBindParameters);
       const result = await pgClient.query(sqlText, params);
       return result.rows as readonly TRow[];
     },
@@ -531,6 +547,12 @@ export type PostgresExecutionAdapterOptions = Readonly<{
    */
   preparedStatementCacheMax?: number;
   /**
+   * Maximum parameters that one statement may dispatch. Backend factories
+   * pass their normalized capability here so every execution surface has a
+   * final fail-loud guard after batch sizing.
+   */
+  maxBindParameters?: number;
+  /**
    * @internal Resolve Drizzle's pinned transaction client. Trusted import uses
    * this on its private adapter; ordinary transaction backends deliberately do
    * not expose a new raw-execution surface that would change routing behavior.
@@ -545,6 +567,7 @@ export function createPostgresExecutionAdapter(
   const prepareStatements = options.prepareStatements ?? true;
   const cacheMax =
     options.preparedStatementCacheMax ?? DEFAULT_POSTGRES_STATEMENT_CACHE_MAX;
+  const maxBindParameters = options.maxBindParameters;
   const pgClient = resolvePgClient(
     db,
     prepareStatements,
@@ -556,10 +579,20 @@ export function createPostgresExecutionAdapter(
     return compileQueryWithDialect(db, query, "PostgreSQL");
   }
 
+  function assertCompiledWithinBindParameterLimit(
+    compiledQuery: CompiledSqlQuery,
+  ): void {
+    assertWithinBindParameterLimit(
+      compiledQuery.params.length,
+      maxBindParameters,
+    );
+  }
+
   if (pgClient === undefined) {
     return {
       compile,
       async execute<TRow>(query: ExecutableSql): Promise<readonly TRow[]> {
+        assertCompiledWithinBindParameterLimit(compile(query));
         return executeDrizzleQuery<TRow>(
           db,
           isSqlFragment(query) ? toDrizzleSql(query, "postgres") : query,
@@ -573,6 +606,7 @@ export function createPostgresExecutionAdapter(
   async function executeCompiled<TRow>(
     compiledQuery: CompiledSqlQuery,
   ): Promise<readonly TRow[]> {
+    assertCompiledWithinBindParameterLimit(compiledQuery);
     const result = await pgQueryClient.query(
       compiledQuery.sql,
       compiledQuery.params,
@@ -590,6 +624,7 @@ export function createPostgresExecutionAdapter(
       // the server-side prepared-statement path because the wrapped
       // client assigns each unique SQL a stable statement name.
       const compiled = compile(query);
+      assertCompiledWithinBindParameterLimit(compiled);
       if (isSqlFragment(query) && shouldForceCustomPlan(query)) {
         const result = await pgQueryClient.queryUnnamed(
           compiled.sql,
@@ -601,7 +636,36 @@ export function createPostgresExecutionAdapter(
     },
     executeCompiled,
     prepare(sqlText: string): PreparedSqlStatement {
-      return createPgPreparedStatement(pgQueryClient, sqlText);
+      return createPgPreparedStatement(
+        pgQueryClient,
+        sqlText,
+        maxBindParameters,
+      );
     },
   };
+}
+
+function assertWithinBindParameterLimit(
+  parameterCount: number,
+  maxBindParameters: number | undefined,
+): void {
+  if (
+    maxBindParameters === undefined ||
+    parameterCount <= maxBindParameters
+  ) {
+    return;
+  }
+  throw new ConfigurationError(
+    `PostgreSQL statement uses ${parameterCount} bound parameters, exceeding ` +
+      `this backend's limit of ${maxBindParameters}.`,
+    {
+      capability: "maxBindParameters",
+      maxBindParameters,
+      parameterCount,
+    },
+    {
+      suggestion:
+        "Split the operation into smaller batches or lower the batch size before retrying.",
+    },
+  );
 }

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -137,6 +137,8 @@ import {
   type AnyPgTransaction,
   createPostgresExecutionAdapter,
   isNeonHttpClient,
+  isPgliteDatabase,
+  PGLITE_MAX_BIND_PARAMETERS,
   type PostgresExecutionAdapter,
   type PostgresExecutionAdapterOptions,
 } from "./execution/postgres-execution";
@@ -266,42 +268,67 @@ export type PostgresBackendOptions = Readonly<{
 
 const NODE_INSERT_PARAM_COUNT = 9;
 const EDGE_INSERT_PARAM_COUNT = 12;
-const POSTGRES_NODE_INSERT_BATCH_SIZE = Math.max(
-  1,
-  Math.floor(POSTGRES_MAX_BIND_PARAMETERS / NODE_INSERT_PARAM_COUNT),
-);
-const POSTGRES_EDGE_INSERT_BATCH_SIZE = Math.max(
-  1,
-  Math.floor(POSTGRES_MAX_BIND_PARAMETERS / EDGE_INSERT_PARAM_COUNT),
-);
-const POSTGRES_GET_NODES_ID_CHUNK_SIZE = Math.max(
-  1,
-  POSTGRES_MAX_BIND_PARAMETERS - 2,
-);
-const POSTGRES_GET_EDGES_ID_CHUNK_SIZE = Math.max(
-  1,
-  POSTGRES_MAX_BIND_PARAMETERS - 1,
-);
+const GET_NODES_FIXED_PARAM_COUNT = 2;
+const GET_EDGES_FIXED_PARAM_COUNT = 1;
 const FULLTEXT_UPSERT_PARAM_COUNT = 6;
 const FULLTEXT_DELETE_FIXED_PARAM_COUNT = 2;
-const POSTGRES_FULLTEXT_UPSERT_BATCH_SIZE = Math.max(
-  1,
-  Math.floor(POSTGRES_MAX_BIND_PARAMETERS / FULLTEXT_UPSERT_PARAM_COUNT),
-);
-const POSTGRES_FULLTEXT_DELETE_CHUNK_SIZE = Math.max(
-  1,
-  POSTGRES_MAX_BIND_PARAMETERS - FULLTEXT_DELETE_FIXED_PARAM_COUNT,
-);
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
-const POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE = Math.max(
-  1,
-  POSTGRES_MAX_BIND_PARAMETERS - CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT,
-);
 const UNIQUE_INSERT_PARAM_COUNT = 6;
-const POSTGRES_UNIQUE_INSERT_BATCH_SIZE = Math.max(
-  1,
-  Math.floor(POSTGRES_MAX_BIND_PARAMETERS / UNIQUE_INSERT_PARAM_COUNT),
-);
+
+type PostgresBatchChunkSizes = Readonly<{
+  checkUniqueBatchChunkSize: number;
+  edgeInsertBatchSize: number;
+  embeddingUpsertBatchSize: number;
+  fulltextDeleteChunkSize: number;
+  fulltextUpsertBatchSize: number;
+  getEdgesChunkSize: number;
+  getNodesChunkSize: number;
+  nodeInsertBatchSize: number;
+  uniqueInsertBatchSize: number;
+}>;
+
+function computePostgresBatchChunkSizes(
+  maxBindParameters: number,
+): PostgresBatchChunkSizes {
+  return {
+    checkUniqueBatchChunkSize: Math.max(
+      1,
+      maxBindParameters - CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT,
+    ),
+    edgeInsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / EDGE_INSERT_PARAM_COUNT),
+    ),
+    embeddingUpsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / EMBEDDING_UPSERT_PARAM_COUNT),
+    ),
+    fulltextDeleteChunkSize: Math.max(
+      1,
+      maxBindParameters - FULLTEXT_DELETE_FIXED_PARAM_COUNT,
+    ),
+    fulltextUpsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / FULLTEXT_UPSERT_PARAM_COUNT),
+    ),
+    getEdgesChunkSize: Math.max(
+      1,
+      maxBindParameters - GET_EDGES_FIXED_PARAM_COUNT,
+    ),
+    getNodesChunkSize: Math.max(
+      1,
+      maxBindParameters - GET_NODES_FIXED_PARAM_COUNT,
+    ),
+    nodeInsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / NODE_INSERT_PARAM_COUNT),
+    ),
+    uniqueInsertBatchSize: Math.max(
+      1,
+      Math.floor(maxBindParameters / UNIQUE_INSERT_PARAM_COUNT),
+    ),
+  };
+}
 
 // ============================================================
 // Utilities
@@ -376,10 +403,22 @@ export function createPostgresBackend(
         },
       }
     : {};
+  const configuredMaxBindParameters =
+    options.capabilities?.maxBindParameters ?? POSTGRES_MAX_BIND_PARAMETERS;
+  const driverBindParameterOverrides =
+    isPgliteDatabase(db) ?
+      {
+        maxBindParameters: Math.min(
+          configuredMaxBindParameters,
+          PGLITE_MAX_BIND_PARAMETERS,
+        ),
+      }
+    : {};
   const capabilities = normalizeGraphAnalyticsCapabilities({
     ...baseCapabilities,
     ...httpOnlyOverrides,
     ...options.capabilities,
+    ...driverBindParameterOverrides,
   });
   const adapterOptions: PostgresExecutionAdapterOptions = {
     ...(options.prepareStatements === undefined ?
@@ -388,6 +427,8 @@ export function createPostgresBackend(
     ...(options.preparedStatementCacheMax === undefined ?
       {}
     : { preparedStatementCacheMax: options.preparedStatementCacheMax }),
+    maxBindParameters:
+      capabilities.maxBindParameters ?? POSTGRES_MAX_BIND_PARAMETERS,
   };
   const executionAdapter = createPostgresExecutionAdapter(db, adapterOptions);
   const tableNames: ResolvedSqlTableNames = {
@@ -1476,24 +1517,9 @@ function createPostgresOperationBackend(
     });
   }
 
-  const batchConfig = {
-    checkUniqueBatchChunkSize: POSTGRES_CHECK_UNIQUE_BATCH_CHUNK_SIZE,
-    edgeInsertBatchSize: POSTGRES_EDGE_INSERT_BATCH_SIZE,
-    // Unlike the static siblings, the embedding upsert honors a runtime
-    // `maxBindParameters` override so its chunk size tracks the connection's
-    // actual bind budget.
-    embeddingUpsertBatchSize: Math.max(
-      1,
-      Math.floor(
-        (capabilities.maxBindParameters ?? POSTGRES_MAX_BIND_PARAMETERS) /
-          EMBEDDING_UPSERT_PARAM_COUNT,
-      ),
-    ),
-    getEdgesChunkSize: POSTGRES_GET_EDGES_ID_CHUNK_SIZE,
-    getNodesChunkSize: POSTGRES_GET_NODES_ID_CHUNK_SIZE,
-    nodeInsertBatchSize: POSTGRES_NODE_INSERT_BATCH_SIZE,
-    uniqueInsertBatchSize: POSTGRES_UNIQUE_INSERT_BATCH_SIZE,
-  };
+  const batchConfig = computePostgresBatchChunkSizes(
+    capabilities.maxBindParameters ?? POSTGRES_MAX_BIND_PARAMETERS,
+  );
 
   const commonBackend = createCommonOperationBackend({
     batchConfig,
@@ -1837,7 +1863,7 @@ function createPostgresOperationBackend(
       // batch inserts.
       for (const rows of chunkArray(
         params.rows,
-        POSTGRES_FULLTEXT_UPSERT_BATCH_SIZE,
+        batchConfig.fulltextUpsertBatchSize,
       )) {
         const statements = operationStrategy.buildUpsertFulltextBatch(
           { ...params, rows },
@@ -1855,7 +1881,7 @@ function createPostgresOperationBackend(
       if (params.nodeIds.length === 0) return;
       for (const nodeIds of chunkArray(
         params.nodeIds,
-        POSTGRES_FULLTEXT_DELETE_CHUNK_SIZE,
+        batchConfig.fulltextDeleteChunkSize,
       )) {
         const statements = operationStrategy.buildDeleteFulltextBatch({
           ...params,

--- a/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
@@ -23,8 +23,9 @@ import { drizzle } from "drizzle-orm/pglite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
-import { defineGraph, defineNode, embedding } from "../../../src";
+import { defineEdge, defineGraph, defineNode, embedding } from "../../../src";
 import { generatePostgresDDL } from "../../../src/backend/drizzle/ddl";
+import { PGLITE_MAX_BIND_PARAMETERS } from "../../../src/backend/drizzle/execution/postgres-execution";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import { createLocalPgliteBackend } from "../../../src/backend/postgres/pglite";
 import { createStore, createStoreWithSchema } from "../../../src/store";
@@ -46,6 +47,24 @@ const documentsGraph = defineGraph({
   id: "pglite_docs",
   nodes: { Doc: { type: Document } },
   edges: {},
+});
+
+const BatchNode = defineNode("BatchNode", {
+  schema: z.object({ name: z.string() }),
+});
+const batchRelation = defineEdge("batchRelation", {
+  schema: z.object({ index: z.number() }),
+});
+const batchGraph = defineGraph({
+  id: "pglite_bind_budget",
+  nodes: { BatchNode: { type: BatchNode } },
+  edges: {
+    batchRelation: {
+      type: batchRelation,
+      from: [BatchNode],
+      to: [BatchNode],
+    },
+  },
 });
 
 describe("PGlite backend", () => {
@@ -79,6 +98,58 @@ describe("PGlite backend", () => {
 
       expect(fetched).toBeDefined();
       expect(requireDefined(fetched).name).toBe("Alice");
+    });
+
+    it("chunks live edge inserts below PGlite's bind limit", async () => {
+      const { backend, client } = await createLocalPgliteBackend({
+        vector: false,
+      });
+      cleanups.push(() => backend.close());
+      expect(backend.capabilities.maxBindParameters).toBe(
+        PGLITE_MAX_BIND_PARAMETERS,
+      );
+      const store = createStore(batchGraph, backend);
+      const from = await store.nodes.BatchNode.create({ name: "from" });
+      const to = await store.nodes.BatchNode.create({ name: "to" });
+
+      const created = await store.edges.batchRelation.bulkCreate(
+        Array.from({ length: 2979 }, (_, index) => ({
+          from,
+          props: { index },
+          to,
+        })),
+      );
+
+      expect(created).toHaveLength(2979);
+      expect(await store.edges.batchRelation.count()).toBe(2979);
+      await expect(client.query("SELECT 1 AS value")).resolves.toMatchObject({
+        rows: [{ value: 1 }],
+      });
+    });
+
+    it("chunks recorded edge inserts below PGlite's bind limit", async () => {
+      const { backend, client } = await createLocalPgliteBackend({
+        vector: false,
+      });
+      cleanups.push(() => backend.close());
+      const store = createStore(batchGraph, backend, { history: true });
+      const from = await store.nodes.BatchNode.create({ name: "from" });
+      const to = await store.nodes.BatchNode.create({ name: "to" });
+
+      const created = await store.edges.batchRelation.bulkCreate(
+        Array.from({ length: 2048 }, (_, index) => ({
+          from,
+          props: { index },
+          to,
+        })),
+      );
+
+      expect(created).toHaveLength(2048);
+      expect(await store.edges.batchRelation.count()).toBe(2048);
+      expect(await store.recordedNow()).toBeDefined();
+      await expect(client.query("SELECT 1 AS value")).resolves.toMatchObject({
+        rows: [{ value: 1 }],
+      });
     });
   });
 

--- a/packages/typegraph/tests/execution-adapter.test.ts
+++ b/packages/typegraph/tests/execution-adapter.test.ts
@@ -362,6 +362,47 @@ describe("postgres execution adapter", () => {
     expect(compiled.params).toEqual([1]);
   });
 
+  it("rejects statements over the configured bind limit before dispatch", async () => {
+    const query = vi.fn(() =>
+      Promise.resolve({ rows: [] as readonly unknown[] }),
+    );
+    const db = {
+      $client: { query },
+      dialect: {
+        sqlToQuery() {
+          return {
+            params: [1, 2] as const,
+            sql: "SELECT $1, $2",
+          };
+        },
+      },
+      execute: vi.fn(() => Promise.resolve({ rows: [] as readonly unknown[] })),
+    } as unknown as AnyPgDatabase;
+    const adapter = createPostgresExecutionAdapter(db, {
+      maxBindParameters: 1,
+    });
+    const expectedError = {
+      code: "CONFIGURATION_ERROR",
+      details: {
+        capability: "maxBindParameters",
+        maxBindParameters: 1,
+        parameterCount: 2,
+      },
+    };
+
+    await expect(adapter.execute(sql`SELECT ${1}, ${2}`)).rejects.toMatchObject(
+      expectedError,
+    );
+    await expect(
+      adapter.executeCompiled?.({ params: [1, 2], sql: "SELECT $1, $2" }),
+    ).rejects.toMatchObject(expectedError);
+    await expect(
+      adapter.prepare?.("SELECT $1, $2").execute([1, 2]),
+    ).rejects.toMatchObject(expectedError);
+
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it("exposes executeCompiled and prepare when raw client is available", async () => {
     // The fast path now wraps the node-postgres client to use named
     // server-side prepared statements: it calls


### PR DESCRIPTION
- detect PGlite-backed Drizzle databases and clamp their advertised bind-parameter budget to 32,767
- derive every PostgreSQL batch/chunk size from the active backend capability
- reject over-budget compiled and prepared statements before driver dispatch
- cover the live-edge and recorded-edge PGlite failure boundaries

## Root cause

PGlite 0.5.x silently returns no rows and leaves the current connection producing false-empty reads when a statement reaches 32,768 binds. TypeGraph advertised PostgreSQL's 65,535-bind ceiling for PGlite and computed most PostgreSQL batch sizes from that static value, so large edge batches could cross PGlite's lower limit.

The fix keeps real PostgreSQL at 65,535, clamps PGlite to 32,767, makes batching capability-driven, and adds a final execution guard so future sizing mistakes fail loudly before reaching the driver.

## Impact

Large PGlite bulk writes are now split safely for both ordinary and history-enabled stores. The client remains queryable after the previously failing 2,979-live-edge and 2,048-recorded-edge cases.

Fixes #315
