### PR TITLE
Add changeset for PGlite bind-budget fix

### DIFF
--- a/.changeset/pglite-bind-budget.md
+++ b/.changeset/pglite-bind-budget.md
@@ -1,0 +1,8 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Prevent large PGlite bulk writes from silently leaving the connection unable
+to return rows. PGlite backends now advertise their safe 32,767-parameter
+limit, PostgreSQL batch sizes follow the active backend capability, and
+over-budget statements fail before driver dispatch.


### PR DESCRIPTION
Add the missing patch changeset for the PGlite bind-parameter fix merged in #316.

This schedules a patch bump for `@nicia-ai/typegraph` and documents that PGlite now advertises its safe 32,767-parameter limit, PostgreSQL batching follows backend capabilities, and oversized statements fail before dispatch.

