### PR TITLE
Add valid-time endpoint edge writes

### DIFF
--- a/.changeset/endpoint-edge-validity.md
+++ b/.changeset/endpoint-edge-validity.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Allow idempotent endpoint-based edge writes to set application-time validity.
+`getOrCreateByEndpoints` now accepts `validFrom` and `validTo`, while
+`bulkGetOrCreateByEndpoints` accepts them per item. Creation applies both
+fields, updates and resurrections apply `validTo`, and pure found results leave
+the existing window unchanged.

--- a/apps/docs/src/content/docs/data-sync.md
+++ b/apps/docs/src/content/docs/data-sync.md
@@ -147,10 +147,19 @@ const membership = await store.edges.memberOf.getOrCreateByEndpoints(
   user,
   org,
   { role: "admin", source: "sync" },
-  { matchOn: ["role"], ifExists: "update" }
+  {
+    matchOn: ["role"],
+    ifExists: "update",
+    validFrom: sourceMembership.startedAt,
+    validTo: sourceMembership.endedAt,
+  }
 );
 // membership.action: "created" | "found" | "updated" | "resurrected"
 ```
+
+For endpoint writes, `validFrom` applies only when a new edge is created.
+`validTo` also applies to the `"updated"` and `"resurrected"` branches. A
+`"found"` result performs no write and preserves the existing validity window.
 
 ### Edge Bulk Operations
 

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -74,6 +74,12 @@ value in a matched field, it no longer matches the earlier edge and you get a
 **second** edge instead of convergence. Reach for `matchOn` when the domain
 needs the extra edges, not as a reflex.
 
+Validity timestamps do not become part of this identity key. If the same
+endpoints can have multiple application-time periods, include a stable period
+or source-event identifier in the edge schema and in `matchOn`. This keeps a
+re-delivery of one period convergent without collapsing a later period into the
+same edge.
+
 ## Cursor Bookkeeping
 
 A cursor is application state: the last source offset you have safely processed.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1341,12 +1341,20 @@ store.edges.worksAt.getOrCreateByEndpoints(
   options?: {
     matchOn?: readonly ("role")[]; // Default: []
     ifExists?: "return" | "update"; // Default: "return"
+    validFrom?: string;
+    validTo?: string;
   }
 ): Promise<{
   edge: Edge<worksAt>;
   action: "created" | "found" | "updated" | "resurrected";
 }>;
 ```
+
+`validFrom` applies only when the operation creates the edge and otherwise
+leaves the existing start unchanged. `validTo` applies when the edge is
+created, updated, or resurrected. When `ifExists` is omitted or `"return"`, a
+live match produces the `"found"` action and neither temporal option changes
+the edge.
 
 #### `bulkGetOrCreateByEndpoints(items, options?)`
 
@@ -1358,6 +1366,8 @@ store.edges.worksAt.bulkGetOrCreateByEndpoints(
     from: NodeRef<Person>;
     to: NodeRef<Company>;
     props: { role: string };
+    validFrom?: string;
+    validTo?: string;
   }[],
   options?: {
     matchOn?: readonly ("role")[];
@@ -1370,6 +1380,10 @@ store.edges.worksAt.bulkGetOrCreateByEndpoints(
   }[]
 >;
 ```
+
+Temporal fields belong to each item so one batch can materialize relationships
+with different validity windows. Their create, update, and resurrection
+semantics match the single operation.
 
 #### `findByEndpoints(from, to, options?, temporal?)`
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1381,9 +1381,14 @@ store.edges.worksAt.bulkGetOrCreateByEndpoints(
 >;
 ```
 
-Temporal fields belong to each item so one batch can materialize relationships
-with different validity windows. Their create, update, and resurrection
-semantics match the single operation.
+Temporal fields belong to each item so identities with different endpoints or
+`matchOn` values can carry different validity windows in one batch. Items with
+the same endpoint-plus-`matchOn` identity are duplicates: the first item
+supplies the write values and later items return that edge with the `"found"`
+action. To represent multiple periods between the same endpoints, add a stable
+period or source-event field to the edge schema and include it in `matchOn`.
+Their create, update, and resurrection semantics otherwise match the single
+operation.
 
 #### `findByEndpoints(from, to, options?, temporal?)`
 

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -796,7 +796,9 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         from: NodeRef<From>;
         to: NodeRef<To>;
         props: z.input<E["schema"]>;
-    }>[], options?: EdgeGetOrCreateByEndpointsOptions<E>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
+        validFrom?: string;
+        validTo?: string;
+    }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public
@@ -841,6 +843,8 @@ type EdgeFromTypes<R extends EdgeRegistration> = R["from"] extends readonly (inf
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -632,7 +632,9 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         from: NodeRef<From>;
         to: NodeRef<To>;
         props: z.input<E["schema"]>;
-    }>[], options?: EdgeGetOrCreateByEndpointsOptions<E>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
+        validFrom?: string;
+        validTo?: string;
+    }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public
@@ -677,6 +679,8 @@ type EdgeFromTypes<R extends EdgeRegistration> = R["from"] extends readonly (inf
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -653,7 +653,9 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         from: NodeRef<From>;
         to: NodeRef<To>;
         props: z.input<E["schema"]>;
-    }>[], options?: EdgeGetOrCreateByEndpointsOptions<E>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
+        validFrom?: string;
+        validTo?: string;
+    }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public
@@ -698,6 +700,8 @@ type EdgeFromTypes<R extends EdgeRegistration> = R["from"] extends readonly (inf
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -631,7 +631,9 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         from: NodeRef<From>;
         to: NodeRef<To>;
         props: z.input<E["schema"]>;
-    }>[], options?: EdgeGetOrCreateByEndpointsOptions<E>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
+        validFrom?: string;
+        validTo?: string;
+    }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public
@@ -676,6 +678,8 @@ type EdgeFromTypes<R extends EdgeRegistration> = R["from"] extends readonly (inf
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -625,7 +625,9 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         from: NodeRef<From>;
         to: NodeRef<To>;
         props: z.input<E["schema"]>;
-    }>[], options?: EdgeGetOrCreateByEndpointsOptions<E>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
+        validFrom?: string;
+        validTo?: string;
+    }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public
@@ -670,6 +672,8 @@ type EdgeFromTypes<R extends EdgeRegistration> = R["from"] extends readonly (inf
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -656,7 +656,9 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         from: NodeRef<From>;
         to: NodeRef<To>;
         props: z.input<E["schema"]>;
-    }>[], options?: EdgeGetOrCreateByEndpointsOptions<E>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
+        validFrom?: string;
+        validTo?: string;
+    }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public
@@ -701,6 +703,8 @@ type EdgeFromTypes<R extends EdgeRegistration> = R["from"] extends readonly (inf
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -1271,7 +1271,9 @@ export type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeTy
         from: NodeRef<From>;
         to: NodeRef<To>;
         props: z.input<E["schema"]>;
-    }>[], options?: EdgeGetOrCreateByEndpointsOptions<E>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
+        validFrom?: string;
+        validTo?: string;
+    }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public
@@ -1319,6 +1321,8 @@ type EdgeFromTypes<R extends EdgeRegistration> = R["from"] extends readonly (inf
 export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
 }>;
 
 // @public

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -119,6 +119,8 @@ export type EdgeCollectionConfig = Readonly<{
     options?: Readonly<{
       matchOn?: readonly string[];
       ifExists?: IfExistsMode;
+      validFrom?: string;
+      validTo?: string;
     }>,
   ) => Promise<Readonly<{ edge: Edge; action: GetOrCreateAction }>>;
   executeBulkGetOrCreateByEndpoints: (
@@ -129,6 +131,8 @@ export type EdgeCollectionConfig = Readonly<{
       toKind: string;
       toId: string;
       props: Record<string, unknown>;
+      validFrom?: string;
+      validTo?: string;
     }>[],
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{
@@ -736,14 +740,18 @@ export function createEdgeCollection<
       props: z.input<E["schema"]>,
       options?: EdgeGetOrCreateByEndpointsOptions<E>,
     ): Promise<EdgeGetOrCreateByEndpointsResult<E>> {
-      const getOrCreateOptions: {
-        matchOn?: readonly string[];
-        ifExists?: IfExistsMode;
-      } = {};
-      if (options?.matchOn !== undefined)
-        getOrCreateOptions.matchOn = options.matchOn as readonly string[];
-      if (options?.ifExists !== undefined)
-        getOrCreateOptions.ifExists = options.ifExists;
+      const getOrCreateOptions = {
+        ...(options?.matchOn !== undefined && {
+          matchOn: options.matchOn as readonly string[],
+        }),
+        ...(options?.ifExists !== undefined && {
+          ifExists: options.ifExists,
+        }),
+        ...(options?.validFrom !== undefined && {
+          validFrom: options.validFrom,
+        }),
+        ...(options?.validTo !== undefined && { validTo: options.validTo }),
+      };
 
       const result = await config.executeGetOrCreateByEndpoints(
         kind,
@@ -763,8 +771,13 @@ export function createEdgeCollection<
         from: NodeRef;
         to: NodeRef;
         props: z.input<E["schema"]>;
+        validFrom?: string;
+        validTo?: string;
       }>[],
-      options?: EdgeGetOrCreateByEndpointsOptions<E>,
+      options?: Pick<
+        EdgeGetOrCreateByEndpointsOptions<E>,
+        "matchOn" | "ifExists"
+      >,
     ): Promise<EdgeGetOrCreateByEndpointsResult<E>[]> {
       if (items.length === 0) return [];
 
@@ -774,16 +787,18 @@ export function createEdgeCollection<
         toKind: item.to.kind,
         toId: item.to.id,
         props: item.props,
+        ...(item.validFrom !== undefined && { validFrom: item.validFrom }),
+        ...(item.validTo !== undefined && { validTo: item.validTo }),
       }));
 
-      const getOrCreateOptions: {
-        matchOn?: readonly string[];
-        ifExists?: IfExistsMode;
-      } = {};
-      if (options?.matchOn !== undefined)
-        getOrCreateOptions.matchOn = options.matchOn as readonly string[];
-      if (options?.ifExists !== undefined)
-        getOrCreateOptions.ifExists = options.ifExists;
+      const getOrCreateOptions = {
+        ...(options?.matchOn !== undefined && {
+          matchOn: options.matchOn as readonly string[],
+        }),
+        ...(options?.ifExists !== undefined && {
+          ifExists: options.ifExists,
+        }),
+      };
 
       const getOrCreateAll = async (
         target: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -1070,6 +1070,8 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
   options?: Readonly<{
     matchOn?: readonly string[];
     ifExists?: IfExistsMode;
+    validFrom?: string;
+    validTo?: string;
   }>,
 ): Promise<Readonly<{ edge: Edge; action: GetOrCreateAction }>> {
   const ifExists = options?.ifExists ?? "return";
@@ -1149,6 +1151,10 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
         toKind,
         toId,
         props: validatedProps,
+        ...(options?.validFrom !== undefined && {
+          validFrom: options.validFrom,
+        }),
+        ...(options?.validTo !== undefined && { validTo: options.validTo }),
       };
       const edge = await executeEdgeCreate(ctx, input, backend);
       return { edge, action: "created" };
@@ -1162,7 +1168,13 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       // ifExists === "update"
       const edge = await executeEdgeUpsertUpdate(
         ctx,
-        { id: liveRow.id, props: validatedProps },
+        {
+          id: liveRow.id,
+          props: validatedProps,
+          ...(options?.validTo !== undefined && {
+            validTo: options.validTo,
+          }),
+        },
         backend,
       );
       return { edge, action: "updated" };
@@ -1174,7 +1186,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       throw new Error("Expected deletedRow to be defined");
     }
     const matchedDeletedRow = deletedRow;
-    const effectiveValidTo = matchedDeletedRow.valid_to;
+    const effectiveValidTo = options?.validTo ?? matchedDeletedRow.valid_to;
     const constraintContext: ConstraintContext = {
       graphId: ctx.graphId,
       registry: ctx.registry,
@@ -1193,7 +1205,11 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
 
     const edge = await executeEdgeUpsertUpdate(
       ctx,
-      { id: matchedDeletedRow.id, props: validatedProps },
+      {
+        id: matchedDeletedRow.id,
+        props: validatedProps,
+        ...(options?.validTo !== undefined && { validTo: options.validTo }),
+      },
       backend,
       { clearDeleted: true },
     );
@@ -1220,6 +1236,8 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     toKind: string;
     toId: string;
     props: Record<string, unknown>;
+    validFrom?: string;
+    validTo?: string;
   }>[],
   backend: GraphBackend | TransactionBackend,
   options?: Readonly<{
@@ -1248,6 +1266,8 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     validatedProps: Record<string, unknown>;
     compositeKey: string;
     endpointKey: string;
+    validFrom?: string;
+    validTo?: string;
   }[] = [];
 
   for (const item of items) {
@@ -1279,6 +1299,8 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       validatedProps,
       compositeKey,
       endpointKey,
+      ...(item.validFrom !== undefined && { validFrom: item.validFrom }),
+      ...(item.validTo !== undefined && { validTo: item.validTo }),
     });
   }
 
@@ -1334,6 +1356,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     fromId: string;
     toKind: string;
     toId: string;
+    validTo?: string;
   }
   interface DuplicateEntry {
     index: number;
@@ -1383,6 +1406,10 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
             toKind: entry.toKind,
             toId: entry.toId,
             props: entry.validatedProps,
+            ...(entry.validFrom !== undefined && {
+              validFrom: entry.validFrom,
+            }),
+            ...(entry.validTo !== undefined && { validTo: entry.validTo }),
           },
         });
       } else {
@@ -1400,6 +1427,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
           fromId: entry.fromId,
           toKind: entry.toKind,
           toId: entry.toId,
+          ...(entry.validTo !== undefined && { validTo: entry.validTo }),
         });
       }
     }
@@ -1459,7 +1487,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     for (const entry of toFetch) {
       if (entry.isDeleted) {
         // Check cardinality before resurrect
-        const effectiveValidTo = entry.row.valid_to;
+        const effectiveValidTo = entry.validTo ?? entry.row.valid_to;
         const constraintContext: ConstraintContext = {
           graphId: ctx.graphId,
           registry: ctx.registry,
@@ -1478,7 +1506,11 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
 
         const edge = await executeEdgeUpsertUpdate(
           ctx,
-          { id: entry.row.id, props: entry.validatedProps },
+          {
+            id: entry.row.id,
+            props: entry.validatedProps,
+            ...(entry.validTo !== undefined && { validTo: entry.validTo }),
+          },
           target,
           { clearDeleted: true },
         );
@@ -1486,7 +1518,11 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       } else if (ifExists === "update") {
         const edge = await executeEdgeUpsertUpdate(
           ctx,
-          { id: entry.row.id, props: entry.validatedProps },
+          {
+            id: entry.row.id,
+            props: entry.validatedProps,
+            ...(entry.validTo !== undefined && { validTo: entry.validTo }),
+          },
           target,
         );
         results[entry.index] = { edge, action: "updated" };

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -1089,6 +1089,14 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
   // Validate matchOn fields
   validateMatchOnFields(edgeKind.schema, matchOn, kind);
 
+  // Validate temporal inputs before the read probe so validity of a call does
+  // not depend on whether its endpoint identity already exists.
+  const validFrom = validateOptionalCanonicalIsoDate(
+    options?.validFrom,
+    "validFrom",
+  );
+  const validTo = validateOptionalCanonicalIsoDate(options?.validTo, "validTo");
+
   // Probe outside the transaction: with ifExists "return", the common found
   // path performs no write, so it must not pay for a write transaction
   // (BEGIN IMMEDIATE on SQLite, the per-graph advisory lock under history).
@@ -1151,10 +1159,8 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
         toKind,
         toId,
         props: validatedProps,
-        ...(options?.validFrom !== undefined && {
-          validFrom: options.validFrom,
-        }),
-        ...(options?.validTo !== undefined && { validTo: options.validTo }),
+        ...(validFrom !== undefined && { validFrom }),
+        ...(validTo !== undefined && { validTo }),
       };
       const edge = await executeEdgeCreate(ctx, input, backend);
       return { edge, action: "created" };
@@ -1171,9 +1177,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
         {
           id: liveRow.id,
           props: validatedProps,
-          ...(options?.validTo !== undefined && {
-            validTo: options.validTo,
-          }),
+          ...(validTo !== undefined && { validTo }),
         },
         backend,
       );
@@ -1186,7 +1190,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       throw new Error("Expected deletedRow to be defined");
     }
     const matchedDeletedRow = deletedRow;
-    const effectiveValidTo = options?.validTo ?? matchedDeletedRow.valid_to;
+    const effectiveValidTo = validTo ?? matchedDeletedRow.valid_to;
     const constraintContext: ConstraintContext = {
       graphId: ctx.graphId,
       registry: ctx.registry,
@@ -1208,7 +1212,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       {
         id: matchedDeletedRow.id,
         props: validatedProps,
-        ...(options?.validTo !== undefined && { validTo: options.validTo }),
+        ...(validTo !== undefined && { validTo }),
       },
       backend,
       { clearDeleted: true },
@@ -1275,6 +1279,11 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       kind,
       operation: "create",
     });
+    const validFrom = validateOptionalCanonicalIsoDate(
+      item.validFrom,
+      "validFrom",
+    );
+    const validTo = validateOptionalCanonicalIsoDate(item.validTo, "validTo");
 
     const compositeKey = buildEdgeCompositeKey(
       item.fromKind,
@@ -1299,8 +1308,8 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       validatedProps,
       compositeKey,
       endpointKey,
-      ...(item.validFrom !== undefined && { validFrom: item.validFrom }),
-      ...(item.validTo !== undefined && { validTo: item.validTo }),
+      ...(validFrom !== undefined && { validFrom }),
+      ...(validTo !== undefined && { validTo }),
     });
   }
 

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -618,6 +618,16 @@ export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> =
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     /** Existing record behavior. Default: "return" */
     ifExists?: IfExistsMode;
+    /**
+     * Valid-time start for a newly created edge. Ignored when an edge is found,
+     * updated, or resurrected.
+     */
+    validFrom?: string;
+    /**
+     * Valid-time end for a created, updated, or resurrected edge. Ignored when
+     * the operation returns an existing edge without writing.
+     */
+    validTo?: string;
   }>;
 
 // ============================================================
@@ -1173,6 +1183,11 @@ export type EdgeCollection<
    * property fields, only edges whose properties match on those fields are considered.
    * Soft-deleted matches are resurrected when cardinality allows.
    *
+   * `validFrom` only applies on the create branch, defaulting to the
+   * operation's creation timestamp when omitted. `validTo` applies on create,
+   * update, and resurrection, but not when an existing edge is returned
+   * without a write.
+   *
    * @param from - Source node
    * @param to - Target node
    * @param props - Full properties for create, or merge source for update
@@ -1196,8 +1211,13 @@ export type EdgeCollection<
       from: NodeRef<From>;
       to: NodeRef<To>;
       props: z.input<E["schema"]>;
+      validFrom?: string;
+      validTo?: string;
     }>[],
-    options?: EdgeGetOrCreateByEndpointsOptions<E>,
+    options?: Pick<
+      EdgeGetOrCreateByEndpointsOptions<E>,
+      "matchOn" | "ifExists"
+    >,
   ) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 

--- a/packages/typegraph/tests/backends/integration/edge-operations.ts
+++ b/packages/typegraph/tests/backends/integration/edge-operations.ts
@@ -6,6 +6,11 @@ export function registerEdgeOperationIntegrationTests(
   context: IntegrationTestContext,
 ): void {
   describe("Edge Operations", () => {
+    const FIRST_VALID_FROM = "2019-03-01T00:00:00.000Z";
+    const FIRST_VALID_TO = "2021-08-31T23:59:59.999Z";
+    const SECOND_VALID_FROM = "2022-01-01T00:00:00.000Z";
+    const SECOND_VALID_TO = "2024-12-31T23:59:59.999Z";
+
     it("retrieves edge by ID", async () => {
       const store = context.getStore();
       const alice = await store.nodes.Person.create({ name: "Alice" });
@@ -64,6 +69,110 @@ export function registerEdgeOperationIntegrationTests(
 
       expect(edges).toHaveLength(1);
       expect(edges[0]?.role).toBe("Consultant");
+    });
+
+    it("sets valid time when creating by endpoints and preserves it when found", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      const created = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM, validTo: FIRST_VALID_TO },
+      );
+      const found = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Manager" },
+        { validFrom: SECOND_VALID_FROM, validTo: SECOND_VALID_TO },
+      );
+
+      expect(created.action).toBe("created");
+      expect(created.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(created.edge.meta.validTo).toBe(FIRST_VALID_TO);
+      expect(found.action).toBe("found");
+      expect(found.edge.id).toBe(created.edge.id);
+      expect(found.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(found.edge.meta.validTo).toBe(FIRST_VALID_TO);
+    });
+
+    it("updates validTo but preserves validFrom when updating by endpoints", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      const created = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM },
+      );
+      const updated = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Manager" },
+        {
+          ifExists: "update",
+          validFrom: SECOND_VALID_FROM,
+          validTo: SECOND_VALID_TO,
+        },
+      );
+
+      expect(updated.action).toBe("updated");
+      expect(updated.edge.id).toBe(created.edge.id);
+      expect(updated.edge.role).toBe("Manager");
+      expect(updated.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(updated.edge.meta.validTo).toBe(SECOND_VALID_TO);
+    });
+
+    it("sets distinct valid-time windows for bulk endpoint writes", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      const results = await store.edges.worksAt.bulkGetOrCreateByEndpoints([
+        {
+          from: alice,
+          to: acme,
+          props: { role: "Engineer" },
+          validFrom: FIRST_VALID_FROM,
+          validTo: FIRST_VALID_TO,
+        },
+        {
+          from: bob,
+          to: acme,
+          props: { role: "Manager" },
+          validFrom: SECOND_VALID_FROM,
+          validTo: SECOND_VALID_TO,
+        },
+      ]);
+
+      expect(results[0]?.action).toBe("created");
+      expect(results[0]?.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(results[0]?.edge.meta.validTo).toBe(FIRST_VALID_TO);
+      expect(results[1]?.action).toBe("created");
+      expect(results[1]?.edge.meta.validFrom).toBe(SECOND_VALID_FROM);
+      expect(results[1]?.edge.meta.validTo).toBe(SECOND_VALID_TO);
+
+      const [updated] = await store.edges.worksAt.bulkGetOrCreateByEndpoints(
+        [
+          {
+            from: alice,
+            to: acme,
+            props: { role: "Principal Engineer" },
+            validFrom: SECOND_VALID_FROM,
+            validTo: SECOND_VALID_TO,
+          },
+        ],
+        { ifExists: "update" },
+      );
+
+      expect(updated?.action).toBe("updated");
+      expect(updated?.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(updated?.edge.meta.validTo).toBe(SECOND_VALID_TO);
     });
   });
 }

--- a/packages/typegraph/tests/find-or-create.test.ts
+++ b/packages/typegraph/tests/find-or-create.test.ts
@@ -737,19 +737,10 @@ describe("store.edges.*.getOrCreateByEndpoints()", () => {
     expect(result.edge.meta.validTo).toBe("2024-12-31T23:59:59.999Z");
   });
 
-  it("validates temporal fields on the branches where they are applied", async () => {
+  it("validates temporal fields before resolving the operation branch", async () => {
     const store = createStore(edgeGraph, backend);
     const alice = await store.nodes.Person.create({ name: "Alice" });
     const acme = await store.nodes.Company.create({ name: "Acme" });
-
-    await expect(
-      store.edges.worksAt.getOrCreateByEndpoints(
-        alice,
-        acme,
-        { role: "eng" },
-        { validFrom: "not-a-date" },
-      ),
-    ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validFrom"/);
 
     await store.edges.worksAt.getOrCreateByEndpoints(alice, acme, {
       role: "eng",
@@ -760,7 +751,16 @@ describe("store.edges.*.getOrCreateByEndpoints()", () => {
         alice,
         acme,
         { role: "manager" },
-        { ifExists: "update", validTo: "not-a-date" },
+        { validFrom: "not-a-date" },
+      ),
+    ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validFrom"/);
+
+    await expect(
+      store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "manager" },
+        { validTo: "not-a-date" },
       ),
     ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validTo"/);
   });
@@ -844,6 +844,59 @@ describe("store.edges.*.bulkGetOrCreateByEndpoints()", () => {
     expect(requireDefined(results[1]).edge.id).toBe(
       requireDefined(results[0]).edge.id,
     );
+  });
+
+  it("collapses duplicate endpoint identities without treating validity as identity", async () => {
+    const store = createStore(edgeGraph, backend);
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({ name: "Acme" });
+
+    const results = await store.edges.worksAt.bulkGetOrCreateByEndpoints([
+      {
+        from: alice,
+        to: acme,
+        props: { role: "eng" },
+        validFrom: "2020-01-01T00:00:00.000Z",
+        validTo: "2021-01-01T00:00:00.000Z",
+      },
+      {
+        from: alice,
+        to: acme,
+        props: { role: "eng" },
+        validFrom: "2022-01-01T00:00:00.000Z",
+        validTo: "2023-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    expect(requireDefined(results[0]).action).toBe("created");
+    expect(requireDefined(results[1]).action).toBe("found");
+    expect(requireDefined(results[1]).edge.id).toBe(
+      requireDefined(results[0]).edge.id,
+    );
+    expect(requireDefined(results[1]).edge.meta.validFrom).toBe(
+      "2020-01-01T00:00:00.000Z",
+    );
+    expect(requireDefined(results[1]).edge.meta.validTo).toBe(
+      "2021-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("validates temporal fields on within-batch duplicates", async () => {
+    const store = createStore(edgeGraph, backend);
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({ name: "Acme" });
+
+    await expect(
+      store.edges.worksAt.bulkGetOrCreateByEndpoints([
+        { from: alice, to: acme, props: { role: "eng" } },
+        {
+          from: alice,
+          to: acme,
+          props: { role: "eng" },
+          validTo: "not-a-date",
+        },
+      ]),
+    ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validTo"/);
   });
 
   it("ifExists: update updates existing edges", async () => {

--- a/packages/typegraph/tests/find-or-create.test.ts
+++ b/packages/typegraph/tests/find-or-create.test.ts
@@ -710,6 +710,60 @@ describe("store.edges.*.getOrCreateByEndpoints()", () => {
       }),
     ).rejects.toThrow(CardinalityError);
   });
+
+  it("uses the resulting validTo when checking cardinality on resurrect", async () => {
+    const store = createStore(edgeGraph, backend);
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({ name: "Acme" });
+    const bigCo = await store.nodes.Company.create({ name: "BigCo" });
+
+    const endedEmployment = await store.edges.oneActiveEdge.create(
+      alice,
+      acme,
+      { label: "first" },
+    );
+    await store.edges.oneActiveEdge.delete(endedEmployment.id);
+    await store.edges.oneActiveEdge.create(alice, bigCo, { label: "second" });
+
+    const result = await store.edges.oneActiveEdge.getOrCreateByEndpoints(
+      alice,
+      acme,
+      { label: "first" },
+      { validTo: "2024-12-31T23:59:59.999Z" },
+    );
+
+    expect(result.action).toBe("resurrected");
+    expect(result.edge.id).toBe(endedEmployment.id);
+    expect(result.edge.meta.validTo).toBe("2024-12-31T23:59:59.999Z");
+  });
+
+  it("validates temporal fields on the branches where they are applied", async () => {
+    const store = createStore(edgeGraph, backend);
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({ name: "Acme" });
+
+    await expect(
+      store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "eng" },
+        { validFrom: "not-a-date" },
+      ),
+    ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validFrom"/);
+
+    await store.edges.worksAt.getOrCreateByEndpoints(alice, acme, {
+      role: "eng",
+    });
+
+    await expect(
+      store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "manager" },
+        { ifExists: "update", validTo: "not-a-date" },
+      ),
+    ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validTo"/);
+  });
 });
 
 // ============================================================
@@ -822,13 +876,21 @@ describe("store.edges.*.bulkGetOrCreateByEndpoints()", () => {
     await store.edges.worksAt.delete(first.id);
 
     const results = await store.edges.worksAt.bulkGetOrCreateByEndpoints([
-      { from: alice, to: acme, props: { role: "resurrected", since: 2025 } },
+      {
+        from: alice,
+        to: acme,
+        props: { role: "resurrected", since: 2025 },
+        validTo: "2025-12-31T23:59:59.999Z",
+      },
     ]);
 
     expect(results).toHaveLength(1);
     expect(requireDefined(results[0]).action).toBe("resurrected");
     expect(requireDefined(results[0]).edge.id).toBe(first.id);
     expect(requireDefined(results[0]).edge.role).toBe("resurrected");
+    expect(requireDefined(results[0]).edge.meta.validTo).toBe(
+      "2025-12-31T23:59:59.999Z",
+    );
     expect(requireDefined(results[0]).edge.meta.deletedAt).toBeUndefined();
   });
 


### PR DESCRIPTION
- allow `getOrCreateByEndpoints` to set `validFrom` and `validTo`
- accept temporal fields per item in `bulkGetOrCreateByEndpoints`
- keep validity outside endpoint identity and preserve existing behavior when fields are omitted
- validate every supplied temporal field before lookup or within-batch duplicate resolution
- document the semantics and update the checked-in API reports

## Semantics

| Result | `validFrom` | `validTo` |
| --- | --- | --- |
| `created` | applied | applied |
| `found` | ignored | ignored |
| `updated` | ignored | applied |
| `resurrected` | ignored | applied |

All supplied temporal values are validated before resolving the operation branch. Bulk temporal fields are item-scoped, but validity is not part of identity: distinct endpoint-plus-`matchOn` identities can materialize distinct windows, while duplicate identities use the first item's write values and later return `found`. Resurrection cardinality checks use the resulting `validTo`.

Closes #319