### PR TITLE
Say what store.batch() actually costs

### DIFF
--- a/.changeset/batch-round-trip-docs.md
+++ b/.changeset/batch-round-trip-docs.md
@@ -9,13 +9,17 @@ It is also not a snapshot: PostgreSQL's default read-committed isolation lets a
 later query in the batch observe a commit the earlier ones did not.
 
 The docstrings for `batch()`, `BatchableQuery`, `executeOn`, and the edge
-`batchFind*` methods now lead with that, and point at the alternatives whose
-cost is independent of N, described by what they actually do: `.traverse()`
-compiles a chain to one statement, `store.subgraph()` costs a fixed 2 statements
-on SQLite and 3 on PostgreSQL, `bulkFindByIndex()` costs a probe plus a
-hydration read, and `getByIds()` costs one statement where the backend exposes a
-batch read. The docs site is corrected to match, including claims that `batch()`
-"minimizes round-trips for reads", that `batchFind*` collapses N reads into "a
-single transactional round-trip", and that `subgraph()` is a single statement.
+`batchFind*` methods now lead with that, and point at the set-oriented and
+chunked alternatives, described by what they actually do: `.traverse()` compiles
+a chain to one statement, `store.subgraph()` costs 2 statements on SQLite and 3
+on PostgreSQL, `getByIds()` issues one statement per bind-limit chunk (falling
+back to one per distinct id where the backend exposes no batch read), and
+`bulkFindByIndex()` costs a probe plus that same chunked hydration.
+
+The docs site is corrected to match, including claims that `batch()` "minimizes
+round-trips for reads", that `batchFind*` collapses N reads into "a single
+transactional round-trip", and that `subgraph()` is a single statement. The
+changelog entry that shipped `batch()` carries a correction note rather than a
+silent rewrite.
 
 Behavior is unchanged.

--- a/.changeset/batch-round-trip-docs.md
+++ b/.changeset/batch-round-trip-docs.md
@@ -1,0 +1,12 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+State `store.batch()`'s real cost where callers see it. `batch()` issues
+`begin`, one statement per query, then `commit` — N queries are N+2 round trips
+— so it collapses connection acquisition, not latency, and will not fix an N+1.
+The docstrings for `batch()`, `BatchableQuery`, and the edge `batchFind*`
+methods now lead with that, and point at `.traverse()`, `store.subgraph()`, and
+`getByIds()` / `bulkFindByIndex()` as the round-trip-collapsing alternatives.
+The docs site claim that `batch()` "minimizes round-trips for reads" is
+corrected. Behavior is unchanged.

--- a/.changeset/batch-round-trip-docs.md
+++ b/.changeset/batch-round-trip-docs.md
@@ -3,23 +3,31 @@
 ---
 
 State `store.batch()`'s real cost where callers see it. `batch()` runs its
-queries in sequence — N query executions, one statement each, never one round
-trip — so it collapses connection acquisition at best and will not fix an N+1.
-It is also not a snapshot: PostgreSQL's default read-committed isolation lets a
-later query in the batch observe a commit the earlier ones did not.
+queries in sequence, keeping at most one in flight — at least one statement
+each, and two for a query whose selective-field mapping falls back after its
+statement has already executed. So it caps concurrency at best and will not fix
+an N+1. It is also not a snapshot: PostgreSQL's default read-committed isolation
+lets a later query in the batch observe a commit the earlier ones did not, and
+there is no public way to get one across fluent queries, since a transaction
+context exposes no query builder.
 
 The docstrings for `batch()`, `BatchableQuery`, `executeOn`, and the edge
 `batchFind*` methods now lead with that, and point at the set-oriented and
 chunked alternatives, described by what they actually do: `.traverse()` compiles
 a chain to one statement, `store.subgraph()` costs 2 statements on SQLite and 3
 on PostgreSQL, `getByIds()` issues one statement per bind-limit chunk (falling
-back to one per distinct id where the backend exposes no batch read), and
+back to concurrent per-id lookups where the backend exposes no batch read), and
 `bulkFindByIndex()` costs a probe plus that same chunked hydration.
 
 The docs site is corrected to match, including claims that `batch()` "minimizes
 round-trips for reads", that `batchFind*` collapses N reads into "a single
-transactional round-trip", and that `subgraph()` is a single statement. The
-changelog entry that shipped `batch()` carries a correction note rather than a
-silent rewrite.
+transactional round-trip", that `subgraph()` is a single statement, and that
+`getByIds()` is a single query. Transaction support no longer implies a
+transport shape anywhere: Durable Objects use an ambient transaction with no
+framing statements, and the non-transactional path may still reuse one client.
+The changelog entry that shipped `batch()` carries a correction note rather than
+a silent rewrite.
 
-Behavior is unchanged.
+Execution semantics are unchanged. One public diagnostic changes: the
+`ConfigurationError` message for a batch endpoint read on a read-only
+`StoreView` no longer calls `batch()` a "batch loader".

--- a/.changeset/batch-round-trip-docs.md
+++ b/.changeset/batch-round-trip-docs.md
@@ -2,11 +2,20 @@
 "@nicia-ai/typegraph": patch
 ---
 
-State `store.batch()`'s real cost where callers see it. `batch()` issues
-`begin`, one statement per query, then `commit` — N queries are N+2 round trips
-— so it collapses connection acquisition, not latency, and will not fix an N+1.
-The docstrings for `batch()`, `BatchableQuery`, and the edge `batchFind*`
-methods now lead with that, and point at `.traverse()`, `store.subgraph()`, and
-`getByIds()` / `bulkFindByIndex()` as the round-trip-collapsing alternatives.
-The docs site claim that `batch()` "minimizes round-trips for reads" is
-corrected. Behavior is unchanged.
+State `store.batch()`'s real cost where callers see it. `batch()` runs its
+queries in sequence — N query executions, one statement each, never one round
+trip — so it collapses connection acquisition at best and will not fix an N+1.
+It is also not a snapshot: PostgreSQL's default read-committed isolation lets a
+later query in the batch observe a commit the earlier ones did not.
+
+The docstrings for `batch()`, `BatchableQuery`, `executeOn`, and the edge
+`batchFind*` methods now lead with that, and point at the alternatives whose
+cost is independent of N, described by what they actually do: `.traverse()`
+compiles a chain to one statement, `store.subgraph()` costs a fixed 2 statements
+on SQLite and 3 on PostgreSQL, `bulkFindByIndex()` costs a probe plus a
+hydration read, and `getByIds()` costs one statement where the backend exposes a
+batch read. The docs site is corrected to match, including claims that `batch()`
+"minimizes round-trips for reads", that `batchFind*` collapses N reads into "a
+single transactional round-trip", and that `subgraph()` is a single statement.
+
+Behavior is unchanged.

--- a/apps/docs/src/content/docs/examples/product-catalog.md
+++ b/apps/docs/src/content/docs/examples/product-catalog.md
@@ -380,7 +380,7 @@ async function getProductDetails(sku: string): Promise<ProductDetails | undefine
   );
   if (!product) return undefined;
 
-  // `store.batch()` runs all three queries in sequence on one connection —
+  // `store.batch()` runs all three queries in sequence, one at a time —
   // still three statements, and read-committed isolation means a write can
   // land between them. It is the pool-pressure win, not a snapshot.
   const [categories, variants, related] = await store.batch(

--- a/apps/docs/src/content/docs/examples/product-catalog.md
+++ b/apps/docs/src/content/docs/examples/product-catalog.md
@@ -380,9 +380,9 @@ async function getProductDetails(sku: string): Promise<ProductDetails | undefine
   );
   if (!product) return undefined;
 
-  // `store.batch()` runs all three queries over a single connection with
-  // snapshot consistency — no interleaved writes between the category,
-  // variant, and related reads.
+  // `store.batch()` runs all three queries in sequence on one connection —
+  // still three statements, and read-committed isolation means a write can
+  // land between them. It is the pool-pressure win, not a snapshot.
   const [categories, variants, related] = await store.batch(
     store
       .query()

--- a/apps/docs/src/content/docs/examples/workflow-engine.md
+++ b/apps/docs/src/content/docs/examples/workflow-engine.md
@@ -794,8 +794,9 @@ interface TimelineEvent {
 async function getInstanceTimeline(instanceId: string): Promise<TimelineEvent[]> {
   const events: TimelineEvent[] = [];
 
-  // Run both history reads snapshot-consistent on a single connection so the
-  // state-change and task views can't observe interleaved writes.
+  // Run both history reads on one connection. Two statements, not one, and
+  // not a snapshot — under read-committed isolation the task view can observe
+  // a write the state-change view did not.
   const [stateHistory, tasks] = await store.batch(
     store
       .query()

--- a/apps/docs/src/content/docs/examples/workflow-engine.md
+++ b/apps/docs/src/content/docs/examples/workflow-engine.md
@@ -794,7 +794,7 @@ interface TimelineEvent {
 async function getInstanceTimeline(instanceId: string): Promise<TimelineEvent[]> {
   const events: TimelineEvent[] = [];
 
-  // Run both history reads on one connection. Two statements, not one, and
+  // Run both history reads in sequence. Two statements, not one, and
   // not a snapshot — under read-committed isolation the task view can observe
   // a write the state-change view did not.
   const [stateHistory, tasks] = await store.batch(

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -27,11 +27,16 @@ These backends report `capabilities.transactions: false`. On such backends,
 against the same backend used outside `transaction()`, sequentially —
 **but writes are applied as they happen and a thrown error inside the
 callback does not roll back earlier writes**. Likewise, `store.batch(...)`
-runs each query without a shared connection, so two queries in the same batch
-may observe different database states. Note this is a difference of degree,
-not of kind: on PostgreSQL, `batch()`'s implicit transaction runs at the
-default read-committed isolation, so queries there can also observe
-interleaved commits.
+runs each query with no enclosing transaction, so two queries in the same batch
+may observe different database states. (Whether they nonetheless reuse one
+connection is up to the adapter — the no-transaction path hands each query the
+same backend object.) Note this is a difference of degree, not of kind: on
+PostgreSQL, `batch()`'s implicit transaction runs at the default read-committed
+isolation, so queries there can also observe interleaved commits.
+
+These backends also ignore the `isolationLevel` option on
+`store.transaction(...)`, so the collection-read snapshot recipe documented
+elsewhere does nothing here.
 
 ```typescript
 // On D1 / neon-http: every successful create is persisted immediately.

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -27,8 +27,11 @@ These backends report `capabilities.transactions: false`. On such backends,
 against the same backend used outside `transaction()`, sequentially —
 **but writes are applied as they happen and a thrown error inside the
 callback does not roll back earlier writes**. Likewise, `store.batch(...)`
-runs each query over an independent connection, so two queries in the same
-batch may observe different database snapshots.
+runs each query without a shared connection, so two queries in the same batch
+may observe different database states. Note this is a difference of degree,
+not of kind: on PostgreSQL, `batch()`'s implicit transaction runs at the
+default read-committed isolation, so queries there can also observe
+interleaved commits.
 
 ```typescript
 // On D1 / neon-http: every successful create is persisted immediately.

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -236,10 +236,11 @@ statement. A pool of 10–20 connections handles most workloads. If you're runni
 parallel, size up accordingly.
 
 **Reducing pool pressure with `batch()`:** When loading multiple independent queries (e.g., a
-detail page with several relationship types), `Promise.all` acquires N connections simultaneously.
+detail page with several relationship types), `Promise.all` can acquire up to N connections
+simultaneously — fewer if the pool is undersized or saturated, in which case it queues instead.
 [`store.batch()`](/schemas-stores#batch-query-execution) runs all queries over a single connection
-within an implicit transaction, reducing peak connection use from N to 1. It does not reduce the
-statement count, and read-committed isolation means it is not a snapshot.
+within an implicit transaction, capping peak connection use at 1. It does not reduce the statement
+count, and read-committed isolation means it is not a snapshot.
 
 ### SQLite concurrency
 
@@ -393,8 +394,9 @@ See [Prepared Queries](/queries/execute#prepared-queries) for usage details.
 ### Subgraph extraction
 
 For the "load entity with all relationships" pattern, [`store.subgraph()`](/schemas-stores#subgraph-extraction)
-is the fastest strategy. It compiles to a single recursive CTE that fans out across all specified
-edge types in one round trip — no matter how many relationship kinds are involved. See
+is the fastest strategy. It compiles to a recursive CTE that fans out across all specified edge
+types in a fixed 2 statements on SQLite and 3 on PostgreSQL — no matter how many relationship kinds
+are involved, or how much it returns. See
 [Choosing a query strategy](/schemas-stores#choosing-a-query-strategy) for guidance on when to use
 `subgraph()` vs the fluent query builder vs manual `findFrom` calls.
 

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -15,8 +15,8 @@ your knowledge graph scales with your application.
 2. **Precomputed Ontology**: Transitive closures, subclass hierarchies, and edge implications are
    computed once at schema initialization, not during every query.
 3. **Batching & Transactions**: Bulk collection APIs minimize round-trips for writes. On the read
-   side that job belongs to the query compiler — `store.batch()` shares a connection and a
-   snapshot, it does not reduce round trips.
+   side that job belongs to the query compiler — `store.batch()` shares a connection and a snapshot
+   (on transactional backends), it does not reduce round trips.
 4. **Zero-Cost Abstractions**: Type safety and ontological reasoning add no measurable runtime overhead.
 
 ## N+1 Prevention
@@ -175,8 +175,10 @@ const [alice, bob] = await store.nodes.Person.getByIds([aliceId, bobId]);
 
 For multiple independent queries with different shapes and filters, use
 [`store.batch()`](/schemas-stores#batch-query-execution) to execute them over a single connection.
-Note the cost: it still issues one statement per query plus `begin`/`commit`, so N queries are N+2
-round trips. It buys one connection and one snapshot, not lower latency:
+Note the cost: on a transactional backend it still issues one statement per query plus
+`begin`/`commit`, so N queries are N+2 round trips; without transactions it is N statements on N
+connections. It buys a connection profile that never peaks at N — and, with transactions, one
+snapshot — not lower latency:
 
 ```typescript
 const [activeUsers, recentOrders] = await store.batch(
@@ -191,9 +193,10 @@ const [activeUsers, recentOrders] = await store.batch(
 ```
 
 Edge collection `batchFind*` methods (`batchFindFrom`, `batchFindTo`, `batchFindByEndpoints`) also
-participate in `store.batch()`. They move N `findFrom`/`findTo` calls onto one connection and one
-snapshot — the statement count is unchanged. If the round trips are what hurt, replace the calls
-with a traversal or `store.subgraph()` instead, which compile to one statement.
+participate in `store.batch()`. On a transactional backend they move N `findFrom`/`findTo` calls
+onto one connection and one snapshot — the statement count is unchanged either way. If the round
+trips are what hurt, replace the calls with a traversal or `store.subgraph()` instead, which
+compile to one statement.
 
 :::note[Operation hooks]
 Bulk operations (`bulkCreate`, `bulkInsert`, `bulkUpsertById`) skip per-item operation hooks for

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -15,8 +15,8 @@ your knowledge graph scales with your application.
 2. **Precomputed Ontology**: Transitive closures, subclass hierarchies, and edge implications are
    computed once at schema initialization, not during every query.
 3. **Batching & Transactions**: Bulk collection APIs minimize round-trips for writes. On the read
-   side that job belongs to the query compiler — `store.batch()` only shares a connection, it does
-   not reduce round trips and it is not a snapshot.
+   side that job belongs to the query compiler — `store.batch()` only caps concurrency at one query
+   in flight, it does not reduce round trips and it is not a snapshot.
 4. **Zero-Cost Abstractions**: Type safety and ontological reasoning add no measurable runtime overhead.
 
 ## N+1 Prevention
@@ -166,8 +166,9 @@ loop if per-call refreshes still dominate.
 
 ### Batch reads
 
-`getByIds()` on node and edge collections uses a single `SELECT ... WHERE id IN (...)` instead of N
-individual queries. Results are returned in input order with `undefined` for missing entries.
+`getByIds()` on node and edge collections uses `SELECT ... WHERE id IN (...)` — one statement per
+bind-limit chunk, so a single statement for id counts under the limit — instead of N individual
+queries. Results are returned in input order with `undefined` for missing entries.
 
 ```typescript
 const [alice, bob] = await store.nodes.Person.getByIds([aliceId, bobId]);
@@ -175,10 +176,10 @@ const [alice, bob] = await store.nodes.Person.getByIds([aliceId, bobId]);
 
 For multiple independent queries with different shapes and filters, use
 [`store.batch()`](/schemas-stores#batch-query-execution) to run them in sequence against one target.
-Note the cost: on a transactional backend it still issues one statement per query plus
-`begin`/`commit`, so N queries are N+2 round trips; without transactions there is no framing and no
-shared connection. It buys a connection profile that never peaks at N — not lower latency, and not
-a snapshot (PostgreSQL's default read-committed isolation lets a later query see a newer commit):
+Note the cost: on a transactional backend it still issues at least one statement per query plus
+`begin`/`commit`, so N queries are N+2 round trips at best; without transactions there is no
+framing. It buys a connection profile that never peaks at N — not lower latency, and not a snapshot
+(PostgreSQL's default read-committed isolation lets a later query see a newer commit):
 
 ```typescript
 const [activeUsers, recentOrders] = await store.batch(
@@ -194,7 +195,7 @@ const [activeUsers, recentOrders] = await store.batch(
 
 Edge collection `batchFind*` methods (`batchFindFrom`, `batchFindTo`, `batchFindByEndpoints`) also
 participate in `store.batch()`. On a transactional backend they move N `findFrom`/`findTo` calls
-onto one connection — the statement count is unchanged either way. If the round trips are what
+into one transaction — the statement count is unchanged either way. If the round trips are what
 hurt, replace the calls with a traversal (one statement) or `store.subgraph()` (a fixed 2 on
 SQLite, 3 on PostgreSQL, however large the result).
 

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -14,8 +14,9 @@ your knowledge graph scales with your application.
    single SQL statement. No N+1 queries by design.
 2. **Precomputed Ontology**: Transitive closures, subclass hierarchies, and edge implications are
    computed once at schema initialization, not during every query.
-3. **Batching & Transactions**: Bulk collection APIs minimize round-trips for writes;
-   `store.batch()` does the same for reads.
+3. **Batching & Transactions**: Bulk collection APIs minimize round-trips for writes. On the read
+   side that job belongs to the query compiler — `store.batch()` shares a connection and a
+   snapshot, it does not reduce round trips.
 4. **Zero-Cost Abstractions**: Type safety and ontological reasoning add no measurable runtime overhead.
 
 ## N+1 Prevention
@@ -173,7 +174,9 @@ const [alice, bob] = await store.nodes.Person.getByIds([aliceId, bobId]);
 ```
 
 For multiple independent queries with different shapes and filters, use
-[`store.batch()`](/schemas-stores#batch-query-execution) to execute them over a single connection:
+[`store.batch()`](/schemas-stores#batch-query-execution) to execute them over a single connection.
+Note the cost: it still issues one statement per query plus `begin`/`commit`, so N queries are N+2
+round trips. It buys one connection and one snapshot, not lower latency:
 
 ```typescript
 const [activeUsers, recentOrders] = await store.batch(
@@ -188,8 +191,9 @@ const [activeUsers, recentOrders] = await store.batch(
 ```
 
 Edge collection `batchFind*` methods (`batchFindFrom`, `batchFindTo`, `batchFindByEndpoints`) also
-participate in `store.batch()`, replacing N individual `findFrom`/`findTo` calls with a single
-transactional round-trip.
+participate in `store.batch()`. They move N `findFrom`/`findTo` calls onto one connection and one
+snapshot — the statement count is unchanged. If the round trips are what hurt, replace the calls
+with a traversal or `store.subgraph()` instead, which compile to one statement.
 
 :::note[Operation hooks]
 Bulk operations (`bulkCreate`, `bulkInsert`, `bulkUpsertById`) skip per-item operation hooks for

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -11,7 +11,9 @@ your knowledge graph scales with your application.
 ## Performance Philosophy
 
 1. **One Query, One Statement**: Every query — including multi-hop traversals — compiles to a
-   single SQL statement. No N+1 queries by design.
+   single SQL statement, so the statement count never grows with the size of the graph. No N+1
+   queries by design. (Compilation, not execution: a query whose selective-field mapping falls back
+   re-runs as a full fetch, costing a second statement. See [Batch reads](#batch-reads).)
 2. **Precomputed Ontology**: Transitive closures, subclass hierarchies, and edge implications are
    computed once at schema initialization, not during every query.
 3. **Batching & Transactions**: Bulk collection APIs minimize round-trips for writes. On the read
@@ -214,8 +216,10 @@ for the ownership matrix and shutdown examples.
 
 ### PostgreSQL pooling
 
-Always use a connection pool in production. TypeGraph issues one SQL statement per query, so pool
-utilization is straightforward — no long-held connections or multi-statement conversations.
+Always use a connection pool in production. TypeGraph holds a connection only for as long as a
+statement runs, so pool utilization is straightforward — no long-held connections. Most queries
+issue a single statement; a query whose selective-field mapping falls back issues a second, and
+`store.transaction()` holds one connection for the whole callback.
 
 ```typescript
 import { Pool } from "pg";

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -10,10 +10,12 @@ your knowledge graph scales with your application.
 
 ## Performance Philosophy
 
-1. **One Query, One Statement**: Every query — including multi-hop traversals — compiles to a
-   single SQL statement, so the statement count never grows with the size of the graph. No N+1
-   queries by design. (Compilation, not execution: a query whose selective-field mapping falls back
-   re-runs as a full fetch, costing a second statement. See [Batch reads](#batch-reads).)
+1. **One Fluent Query, One Statement**: Every fluent query — including multi-hop traversals —
+   compiles to a single SQL statement, so its statement count never grows with the size of the
+   graph. This prevents compiler-generated N+1 work inside that query; application code can still
+   create an N+1 by issuing separate reads in a loop. (Compilation, not execution: a query whose
+   selective-field mapping falls back re-runs as a full fetch, costing a second statement. See
+   [Batch reads](#batch-reads).)
 2. **Precomputed Ontology**: Transitive closures, subclass hierarchies, and edge implications are
    computed once at schema initialization, not during every query.
 3. **Batching & Transactions**: Bulk collection APIs minimize round-trips for writes. On the read
@@ -24,7 +26,9 @@ your knowledge graph scales with your application.
 ## N+1 Prevention
 
 A common performance problem in ORMs is the N+1 query: you fetch N entities, then issue one
-query per entity to load related data. TypeGraph eliminates this structurally.
+query per entity to load related data. TypeGraph's fluent query compiler eliminates that pattern
+inside one graph-shaped query; it cannot eliminate separate collection reads issued by application
+code.
 
 Every query — regardless of how many traversals it chains — compiles to a **single SQL statement**
 using Common Table Expressions (CTEs). Each traversal step becomes a CTE that joins against the
@@ -77,8 +81,10 @@ This holds for all query types:
 - Aggregations with traversals (CTEs + GROUP BY, 1 statement)
 - [Set operations](/queries/combine) (UNION/INTERSECT/EXCEPT of CTEs, 1 statement)
 
-There is no dataloader or batching layer because there is nothing to batch — the database handles
-the entire join graph in a single execution.
+The fluent query needs no dataloader for that joined read because the database handles its entire
+join graph in one execution. Separate reads can still form an N+1; use a traversal, `subgraph()`, or
+the chunked collection reads described below instead of looping them or wrapping them in
+`store.batch()`.
 
 ## Batch Write Patterns
 
@@ -106,8 +112,9 @@ maintain.
 
 ### PostgreSQL parameter limits
 
-PostgreSQL has a 65,535 bind parameter limit per statement. TypeGraph automatically chunks bulk
-operations to stay within this limit:
+PostgreSQL's protocol can encode 65,535 bind parameters, while TypeGraph uses a portable
+65,533-parameter budget across its bundled drivers. Bulk operations are automatically chunked to
+stay within that budget:
 
 - Node inserts: ~7,200 per chunk (9 params per node)
 - Edge inserts: ~5,400 per chunk (12 params per edge)
@@ -216,10 +223,10 @@ for the ownership matrix and shutdown examples.
 
 ### PostgreSQL pooling
 
-Always use a connection pool in production. TypeGraph holds a connection only for as long as a
-statement runs, so pool utilization is straightforward — no long-held connections. Most queries
-issue a single statement; a query whose selective-field mapping falls back issues a second, and
-`store.transaction()` holds one connection for the whole callback.
+Always use a connection pool in production. An individual query holds a connection only while each
+statement runs. Most queries issue a single statement; a query whose selective-field mapping falls
+back issues a second. `store.transaction()` holds one connection for the whole callback, and
+`store.batch()` does the same for its implicit transaction.
 
 ```typescript
 import { Pool } from "pg";

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -15,8 +15,8 @@ your knowledge graph scales with your application.
 2. **Precomputed Ontology**: Transitive closures, subclass hierarchies, and edge implications are
    computed once at schema initialization, not during every query.
 3. **Batching & Transactions**: Bulk collection APIs minimize round-trips for writes. On the read
-   side that job belongs to the query compiler — `store.batch()` shares a connection and a snapshot
-   (on transactional backends), it does not reduce round trips.
+   side that job belongs to the query compiler — `store.batch()` only shares a connection, it does
+   not reduce round trips and it is not a snapshot.
 4. **Zero-Cost Abstractions**: Type safety and ontological reasoning add no measurable runtime overhead.
 
 ## N+1 Prevention
@@ -174,11 +174,11 @@ const [alice, bob] = await store.nodes.Person.getByIds([aliceId, bobId]);
 ```
 
 For multiple independent queries with different shapes and filters, use
-[`store.batch()`](/schemas-stores#batch-query-execution) to execute them over a single connection.
+[`store.batch()`](/schemas-stores#batch-query-execution) to run them in sequence against one target.
 Note the cost: on a transactional backend it still issues one statement per query plus
-`begin`/`commit`, so N queries are N+2 round trips; without transactions it is N statements on N
-connections. It buys a connection profile that never peaks at N — and, with transactions, one
-snapshot — not lower latency:
+`begin`/`commit`, so N queries are N+2 round trips; without transactions there is no framing and no
+shared connection. It buys a connection profile that never peaks at N — not lower latency, and not
+a snapshot (PostgreSQL's default read-committed isolation lets a later query see a newer commit):
 
 ```typescript
 const [activeUsers, recentOrders] = await store.batch(
@@ -194,9 +194,9 @@ const [activeUsers, recentOrders] = await store.batch(
 
 Edge collection `batchFind*` methods (`batchFindFrom`, `batchFindTo`, `batchFindByEndpoints`) also
 participate in `store.batch()`. On a transactional backend they move N `findFrom`/`findTo` calls
-onto one connection and one snapshot — the statement count is unchanged either way. If the round
-trips are what hurt, replace the calls with a traversal or `store.subgraph()` instead, which
-compile to one statement.
+onto one connection — the statement count is unchanged either way. If the round trips are what
+hurt, replace the calls with a traversal (one statement) or `store.subgraph()` (a fixed 2 on
+SQLite, 3 on PostgreSQL, however large the result).
 
 :::note[Operation hooks]
 Bulk operations (`bulkCreate`, `bulkInsert`, `bulkUpsertById`) skip per-item operation hooks for
@@ -238,7 +238,8 @@ parallel, size up accordingly.
 **Reducing pool pressure with `batch()`:** When loading multiple independent queries (e.g., a
 detail page with several relationship types), `Promise.all` acquires N connections simultaneously.
 [`store.batch()`](/schemas-stores#batch-query-execution) runs all queries over a single connection
-within an implicit transaction, reducing N connections to 1 while guaranteeing snapshot consistency.
+within an implicit transaction, reducing peak connection use from N to 1. It does not reduce the
+statement count, and read-committed isolation means it is not a snapshot.
 
 ### SQLite concurrency
 

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -236,16 +236,18 @@ pool.on("error", (err) => {
 });
 ```
 
-**Sizing guidance:** Each concurrent query uses one connection for the duration of that single SQL
-statement. A pool of 10–20 connections handles most workloads. If you're running bulk imports in
-parallel, size up accordingly.
+**Sizing guidance:** Each concurrent query holds one connection for as long as its statement runs.
+A pool of 10–20 connections handles most workloads. If you're running bulk imports in parallel,
+size up accordingly.
 
 **Reducing pool pressure with `batch()`:** When loading multiple independent queries (e.g., a
 detail page with several relationship types), `Promise.all` can acquire up to N connections
 simultaneously — fewer if the pool is undersized or saturated, in which case it queues instead.
-[`store.batch()`](/schemas-stores#batch-query-execution) runs all queries over a single connection
-within an implicit transaction, capping peak connection use at 1. It does not reduce the statement
-count, and read-committed isolation means it is not a snapshot.
+[`store.batch()`](/schemas-stores#batch-query-execution) keeps at most one query in flight, so peak
+connection use is 1 — on a transactional backend that is literally one checked-out connection for
+the implicit transaction; elsewhere it is one at a time, and whether the adapter reuses the same
+client is its own business. It does not reduce the statement count, and read-committed isolation
+means it is not a snapshot.
 
 ### SQLite concurrency
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -247,10 +247,12 @@ async function exportAllUsers(): Promise<void> {
 When you need multiple independent queries with different result types, use `store.batch()` to
 execute them over a single connection with snapshot consistency.
 
-`batch()` does not batch round trips. It issues `begin`, one statement per query, then `commit` —
-N queries are N+2 round trips. It collapses connection acquisition, not latency, and it will not
-fix an N+1. For that, fold the work into one statement: a `.traverse()` chain, `store.subgraph()`,
-or `getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+`batch()` does not batch round trips. On a transactional backend it issues `begin`, one statement
+per query, then `commit` — N queries are N+2 round trips on one connection. Without transactions
+there is no `begin`/`commit` and no shared connection: N statements, each acquiring its own. Either
+way the queries are serialized, so `batch()` collapses connection acquisition at best, never
+latency, and it will not fix an N+1. For that, fold the work into one statement: a `.traverse()`
+chain, `store.subgraph()`, or `getByIds()` / `bulkFindByIndex()` for keyed fan-out.
 
 ```typescript
 const [people, companies] = await store.batch(
@@ -283,7 +285,9 @@ const [skills, employer] = await store.batch(
 );
 ```
 
-**vs `Promise.all`**: `batch()` uses 1 connection instead of N and guarantees snapshot consistency.
+**vs `Promise.all`**: `batch()` never holds N connections at once, and on a transactional backend
+uses exactly 1 with snapshot consistency — but it runs the queries serially, so on a networked
+backend it is slower.
 **vs `transaction()`**: Same consistency, but cleaner API — no callback, typed tuple return.
 
 See [Batch Query Execution](/schemas-stores#batch-query-execution) for full API reference.

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -247,19 +247,24 @@ async function exportAllUsers(): Promise<void> {
 When you need multiple independent queries with different result types, use `store.batch()` to run
 them in sequence against one target.
 
-`batch()` does not batch round trips. The portable guarantee is N serialized query executions. On a
-SQL backend with transactions it frames them with `begin`/`commit`, so a networked one sees N+2
-round trips on one connection; Durable Objects use an ambient storage transaction with no framing,
-and without transactions there is no framing at all. Either way it collapses connection acquisition
-at best, never latency, and it will not fix an N+1. For that, fold the work into one query: a
-`.traverse()` chain (one statement), `store.subgraph()` (2 statements on SQLite, 3 on PostgreSQL),
-or `getByIds()` / `bulkFindByIndex()`, which are chunked rather than fixed-cost.
+`batch()` does not batch round trips. The portable guarantee is that at most one query is in flight
+at a time — at least one statement each, and two for a query whose selective-field mapping falls
+back after its statement has already run. On a SQL backend with transactions it frames them with
+`begin`/`commit`, putting a networked one at N+2 round trips **at best**; Durable Objects use an
+ambient storage transaction with no framing, and without transactions there is no framing at all.
+Connection reuse is the adapter's business either way.
+
+It will not fix an N+1. For that, fold the work into one query: a `.traverse()` chain (one
+statement), `store.subgraph()` (2 statements on SQLite, 3 on PostgreSQL), or `getByIds()` /
+`bulkFindByIndex()`, which are chunked rather than fixed-cost.
 
 It is also **not** a snapshot: PostgreSQL defaults to read-committed isolation, so a later query can
 observe a commit the earlier ones did not. There is no way to fix that for fluent queries today —
 `store.transaction()` accepts an `isolationLevel`, but its context exposes only `nodes` / `edges`,
 so a query builder cannot run inside it. Collection reads can get a snapshot via
-`store.transaction(fn, { isolationLevel: "repeatable_read" })` and `tx.nodes` / `tx.edges`.
+`store.transaction(fn, { isolationLevel: "repeatable_read" })` and `tx.nodes` / `tx.edges` — but
+only where the backend has transactions (others ignore the option), and a history-enabled store on
+PostgreSQL additionally requires `accessMode: "read_only"` or the call throws.
 
 ```typescript
 const [people, companies] = await store.batch(
@@ -294,8 +299,9 @@ const [skills, employer] = await store.batch(
 
 **vs `Promise.all`**: workload- and adapter-dependent in both directions. `Promise.all` overlaps its
 queries against a pool with idle capacity, but it does not necessarily hold N connections, and
-against a single client or a saturated pool it queues. `batch()` pays the sum of its query
-latencies but only one acquisition, which can make it faster where acquisition dominates.
+against a single client or a saturated pool it queues. `batch()` keeps at most one query in flight,
+so it pays the sum of their latencies — but it can still come out ahead where connection
+acquisition dominates. Measure rather than assume.
 **vs `transaction()`**: same transaction, lighter API — no callback, typed tuple return. But
 `transaction()` is the only one that takes an `isolationLevel`, and it cannot run fluent queries.
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -247,16 +247,19 @@ async function exportAllUsers(): Promise<void> {
 When you need multiple independent queries with different result types, use `store.batch()` to run
 them in sequence against one target.
 
-`batch()` does not batch round trips. On a transactional backend it issues `begin`, one statement
-per query, then `commit` — N queries are N+2 round trips on one connection. Without transactions
-there is no framing and no shared connection; what each query costs there is up to the adapter.
-Either way it is N executions, serialized, so `batch()` collapses connection acquisition at best,
-never latency, and it will not fix an N+1. For that, fold the work into one query: a `.traverse()`
-chain, `store.subgraph()`, or `getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+`batch()` does not batch round trips. The portable guarantee is N serialized query executions. On a
+SQL backend with transactions it frames them with `begin`/`commit`, so a networked one sees N+2
+round trips on one connection; Durable Objects use an ambient storage transaction with no framing,
+and without transactions there is no framing at all. Either way it collapses connection acquisition
+at best, never latency, and it will not fix an N+1. For that, fold the work into one query: a
+`.traverse()` chain (one statement), `store.subgraph()` (2 statements on SQLite, 3 on PostgreSQL),
+or `getByIds()` / `bulkFindByIndex()`, which are chunked rather than fixed-cost.
 
 It is also **not** a snapshot: PostgreSQL defaults to read-committed isolation, so a later query can
-observe a commit the earlier ones did not. Use
-`store.transaction(fn, { isolationLevel: "repeatable_read" })` when you need one.
+observe a commit the earlier ones did not. There is no way to fix that for fluent queries today —
+`store.transaction()` accepts an `isolationLevel`, but its context exposes only `nodes` / `edges`,
+so a query builder cannot run inside it. Collection reads can get a snapshot via
+`store.transaction(fn, { isolationLevel: "repeatable_read" })` and `tx.nodes` / `tx.edges`.
 
 ```typescript
 const [people, companies] = await store.batch(
@@ -289,12 +292,12 @@ const [skills, employer] = await store.batch(
 );
 ```
 
-**vs `Promise.all`**: `batch()` never holds N connections at once, and on a transactional backend
-uses exactly 1. Which is faster depends on the workload — against a pool with idle capacity
-`Promise.all` overlaps its queries and wins on latency; against a single client or a saturated pool
-both serialize.
-**vs `transaction()`**: Same transaction, lighter API — no callback, typed tuple return. Use
-`transaction()` when you need an explicit `isolationLevel`.
+**vs `Promise.all`**: workload- and adapter-dependent in both directions. `Promise.all` overlaps its
+queries against a pool with idle capacity, but it does not necessarily hold N connections, and
+against a single client or a saturated pool it queues. `batch()` pays the sum of its query
+latencies but only one acquisition, which can make it faster where acquisition dominates.
+**vs `transaction()`**: same transaction, lighter API — no callback, typed tuple return. But
+`transaction()` is the only one that takes an `isolationLevel`, and it cannot run fluent queries.
 
 See [Batch Query Execution](/schemas-stores#batch-query-execution) for full API reference.
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -244,15 +244,19 @@ async function exportAllUsers(): Promise<void> {
 
 ## Batch Execution
 
-When you need multiple independent queries with different result types, use `store.batch()` to
-execute them over a single connection with snapshot consistency.
+When you need multiple independent queries with different result types, use `store.batch()` to run
+them in sequence against one target.
 
 `batch()` does not batch round trips. On a transactional backend it issues `begin`, one statement
 per query, then `commit` — N queries are N+2 round trips on one connection. Without transactions
-there is no `begin`/`commit` and no shared connection: N statements, each acquiring its own. Either
-way the queries are serialized, so `batch()` collapses connection acquisition at best, never
-latency, and it will not fix an N+1. For that, fold the work into one statement: a `.traverse()`
+there is no framing and no shared connection; what each query costs there is up to the adapter.
+Either way it is N executions, serialized, so `batch()` collapses connection acquisition at best,
+never latency, and it will not fix an N+1. For that, fold the work into one query: a `.traverse()`
 chain, `store.subgraph()`, or `getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+
+It is also **not** a snapshot: PostgreSQL defaults to read-committed isolation, so a later query can
+observe a commit the earlier ones did not. Use
+`store.transaction(fn, { isolationLevel: "repeatable_read" })` when you need one.
 
 ```typescript
 const [people, companies] = await store.batch(
@@ -286,9 +290,11 @@ const [skills, employer] = await store.batch(
 ```
 
 **vs `Promise.all`**: `batch()` never holds N connections at once, and on a transactional backend
-uses exactly 1 with snapshot consistency — but it runs the queries serially, so on a networked
-backend it is slower.
-**vs `transaction()`**: Same consistency, but cleaner API — no callback, typed tuple return.
+uses exactly 1. Which is faster depends on the workload — against a pool with idle capacity
+`Promise.all` overlaps its queries and wins on latency; against a single client or a saturated pool
+both serialize.
+**vs `transaction()`**: Same transaction, lighter API — no callback, typed tuple return. Use
+`transaction()` when you need an explicit `isolationLevel`.
 
 See [Batch Query Execution](/schemas-stores#batch-query-execution) for full API reference.
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -247,6 +247,11 @@ async function exportAllUsers(): Promise<void> {
 When you need multiple independent queries with different result types, use `store.batch()` to
 execute them over a single connection with snapshot consistency.
 
+`batch()` does not batch round trips. It issues `begin`, one statement per query, then `commit` —
+N queries are N+2 round trips. It collapses connection acquisition, not latency, and it will not
+fix an N+1. For that, fold the work into one statement: a `.traverse()` chain, `store.subgraph()`,
+or `getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+
 ```typescript
 const [people, companies] = await store.batch(
   store
@@ -268,7 +273,8 @@ const [people, companies] = await store.batch(
 Each query preserves its own projection, filtering, sorting, and pagination. Results are returned
 as a typed tuple matching the input order.
 
-Edge collection `batchFind*` methods also return `BatchableQuery` and can be mixed freely with fluent queries:
+Edge collection `batchFind*` methods also return `BatchableQuery` and can be mixed freely with
+fluent queries — each still costs its own statement:
 
 ```typescript
 const [skills, employer] = await store.batch(

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1970,7 +1970,7 @@ TypeGraph offers several ways to load related data. The right choice depends on 
 
 | Pattern | Best strategy | Why |
 |---------|--------------|-----|
-| Load entity with all relationships | `subgraph(maxDepth: 1)` | Fixed statement count — fans out across all edge types in one recursive CTE |
+| Load entity with all relationships | `subgraph(maxDepth: 1)` | Fixed 2 SQLite / 3 PostgreSQL statements — recursive traversal cost does not grow with edge count |
 | Load entity with deep chain | `subgraph(maxDepth: N)` | Recursive CTE handles multi-hop without extra round trips per hop |
 | Filter/sort within a relationship | `.query().traverse()` | Fluent query supports WHERE/ORDER/LIMIT on target nodes, in one statement |
 | Multiple independent queries with per-query control | `store.batch()` | Typed tuple results, at most one query in flight — still at least a statement per query, and not a snapshot |

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1185,9 +1185,10 @@ Deferred variants of `findFrom`, `findTo`, and `findByEndpoints` for use with
 executing immediately. `batchFindFrom` / `batchFindTo` accept the same temporal
 `options` as `findFrom` / `findTo`.
 
-Batching them does not merge the reads — each still costs its own statement, and they only share a
-connection and a snapshot when the backend supports transactions. To read edges for many sources in
-one statement, traverse from them in a single query.
+Batching them does not merge the reads — each still costs its own statement, and they share a
+connection only when the backend supports transactions. It is not a snapshot: PostgreSQL's default
+read-committed isolation lets a later read observe a commit the earlier ones did not. To read edges
+for many sources in one statement, traverse from them in a single query.
 
 ```typescript
 store.edges.worksAt.batchFindFrom(
@@ -1619,26 +1620,32 @@ order — N query executions, never one round trip. Accepts two or more queries 
 set operations, or edge collection `batchFind*` methods), each keeping its own projection,
 filtering, sorting, and pagination.
 
-**Cost.** With `backend.capabilities.transactions`, the queries run in one transaction on one
-connection; on a SQL backend that is `begin` + N + `commit`, so a networked one sees N+2 round
-trips. Without transactions there is no framing and no shared connection — whether each query costs
-a fresh pooled connection, an HTTP request, or a reuse of the same client is up to the adapter (see
-[Limitations](/limitations)). Either way it is N executions, serialized.
+**Cost.** With `backend.capabilities.transactions` the queries share one transaction; how that
+reaches the wire is the adapter's business. A SQL backend frames them with `begin`/`commit`, so a
+networked one sees N+2 round trips, while Durable Objects use an ambient storage transaction with
+no framing statements. Without transactions there is no framing, and the adapter may still reuse
+one client (see [Limitations](/limitations)). Count on the N executions, not on a transport shape.
 
-**Not a snapshot.** PostgreSQL defaults to read-committed isolation, so a later query in the batch
-can observe a commit the earlier ones did not. When you need a stable snapshot, use
-`store.transaction(fn, { isolationLevel: "repeatable_read" })`.
+**Not a snapshot — and there is no way to make it one.** PostgreSQL defaults to read-committed
+isolation, so a later query in the batch can observe a commit the earlier ones did not.
+`store.transaction()` takes an `isolationLevel`, but its context exposes only `nodes` / `edges`:
+there is no public way to run a fluent query or a batch inside a transaction, so a snapshot across
+fluent queries is **not available today**. Collection reads can have one —
+`store.transaction(fn, { isolationLevel: "repeatable_read" })` reading through `tx.nodes` /
+`tx.edges` (a history-enabled store on PostgreSQL additionally requires
+`accessMode: "read_only"`).
 
-**Will not fix an N+1.** Serializing N queries does not reduce their number. To make the cost
-independent of N, fold the work into one query: `.traverse()` compiles a whole chain to a single
-statement; [`store.subgraph()`](#subgraph-extraction) costs a fixed 2 statements on SQLite and 3 on
-PostgreSQL however large the result; `bulkFindByIndex()` costs one probe plus one hydration read;
-`getByIds()` costs one statement where the backend exposes a batch read, degrading to one per
-distinct id where it does not.
+**Will not fix an N+1.** Serializing N queries does not reduce their number. The alternatives are
+set-oriented or chunked rather than fixed-cost: `.traverse()` compiles a whole chain to one
+statement; [`store.subgraph()`](#subgraph-extraction) costs 2 statements on SQLite and 3 on
+PostgreSQL however large the result; `getByIds()` issues one statement per bind-limit chunk,
+falling back to one per distinct id where the backend exposes no batch read; `bulkFindByIndex()`
+costs one probe plus that same chunked hydration.
 
-**Versus `Promise.all`.** `batch()` never holds N connections at once. Which is faster depends on
-the workload: against a pool with idle capacity `Promise.all` overlaps its queries and wins on
-latency while `batch()` pays their sum; against a single client or a saturated pool both serialize.
+**Versus `Promise.all`.** Workload- and adapter-dependent in both directions. `Promise.all`
+overlaps its queries against a pool with idle capacity, but it does not necessarily hold N
+connections, and against a single client or a saturated pool it queues. `batch()` pays the sum of
+its query latencies but only one acquisition, which can make it faster where acquisition dominates.
 
 ```typescript
 store.batch<R1, R2, ...Rn>(
@@ -1742,7 +1749,7 @@ const [skills, employer, colleague] = await store.batch(
 |---------|-----|
 | Multiple queries with different shapes/filters | `store.batch()` |
 | Load entity with all relationships (uniform) | `store.subgraph()` |
-| Fixing an N+1 / reducing round trips | `.traverse()`, `store.subgraph()`, `getByIds()` — not `batch()` |
+| Fixing an N+1 / reducing round trips | `.traverse()` (one statement), `store.subgraph()` (2–3), `getByIds()` (chunked) — not `batch()` |
 | Single query | `.execute()` directly |
 | Writes interleaved with reads | `store.transaction()` |
 | Same-shape queries merged into one result | `.union()` / `.intersect()` / `.except()` |
@@ -1760,8 +1767,10 @@ Extracts a typed subgraph by performing a BFS traversal from a root node, follow
 the specified edge kinds. Returns an indexed result with adjacency maps for immediate
 traversal.
 
-Under the hood, this compiles to a single `WITH RECURSIVE` CTE — the traversal,
-filtering, and hydration all happen in the database.
+Under the hood the traversal is a `WITH RECURSIVE` CTE and all the filtering and
+hydration happen in the database. The cost is a fixed 2 statements on SQLite
+(nodes, edges — each embedding the CTE) and 3 on PostgreSQL (the closure ids
+once, then nodes and edges), independent of how much it returns.
 
 ```typescript
 store.subgraph<EK, NK>(
@@ -1949,7 +1958,7 @@ TypeGraph offers several ways to load related data. The right choice depends on 
 | Load entity with all relationships | `subgraph(maxDepth: 1)` | Fixed statement count — fans out across all edge types in one recursive CTE |
 | Load entity with deep chain | `subgraph(maxDepth: N)` | Recursive CTE handles multi-hop without extra round trips per hop |
 | Filter/sort within a relationship | `.query().traverse()` | Fluent query supports WHERE/ORDER/LIMIT on target nodes, in one statement |
-| Multiple independent queries with per-query control | `store.batch()` | One connection and typed tuple results — still one statement per query |
+| Multiple independent queries with per-query control | `store.batch()` | Typed tuple results, peak connection use capped at 1 — still one statement per query, and not a snapshot |
 | Check if an edge exists | `edges.X.findFrom()` | Lightweight — no node resolution needed; honors the graph's temporal mode by default |
 | Traverse + resolve one edge type | `edges.X.findFrom()` + `nodes.X.getByIds()` | Two queries, simple and explicit; pass `temporalMode` / `asOf` when reading history |
 | Shortest path, reachability, neighborhoods, degree | `store.algorithms.*` | Set-based BFS frontier or a single `COUNT` — see [Graph Algorithms](/graph-algorithms) |

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1185,9 +1185,9 @@ Deferred variants of `findFrom`, `findTo`, and `findByEndpoints` for use with
 executing immediately. `batchFindFrom` / `batchFindTo` accept the same temporal
 `options` as `findFrom` / `findTo`.
 
-Batching them shares a connection and a snapshot; it does not merge the reads — each still costs
-its own statement. To read edges for many sources in one statement, traverse from them in a single
-query.
+Batching them does not merge the reads — each still costs its own statement, and they only share a
+connection and a snapshot when the backend supports transactions. To read edges for many sources in
+one statement, traverse from them in a single query.
 
 ```typescript
 store.edges.worksAt.batchFindFrom(
@@ -1618,16 +1618,20 @@ Executes multiple independent queries over a single connection with snapshot con
 Accepts two or more queries (from `.select()`, set operations, or edge collection `batchFind*` methods)
 and returns a typed tuple of results preserving input order.
 
-**Cost: N queries are N+2 round trips** — `begin`, one statement per query, `commit`. `batch()`
-collapses connection acquisition, not latency; it does not pipeline and it will not fix an N+1.
-To collapse round trips, fold the work into one statement instead: a `.traverse()` chain,
-[`store.subgraph()`](#subgraph-extraction), or `getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+**Cost: on a transactional backend, N queries are N+2 round trips** — `begin`, one statement per
+query, `commit` — all on one checked-out connection, all seeing one snapshot. **Without
+transactions** there is no `begin`/`commit` and no shared connection: N statements, each acquiring
+its own, each free to observe writes the earlier ones did not (see [Limitations](/limitations)).
+Branch on `backend.capabilities.transactions` when the difference matters.
 
-What it does buy: one connection instead of N (removing the `Promise.all` pool pressure),
-per-query result types, and — when `backend.capabilities.transactions` is `true` — one database
-snapshot across every query, while each query keeps its own projection, filtering, sorting, and
-pagination. On backends without transactions each query runs on its own connection and may observe
-writes that landed between them; see [Limitations](/limitations).
+Either way the queries are serialized, so `batch()` collapses connection acquisition at best, never
+latency; it does not pipeline and it will not fix an N+1. To collapse round trips, fold the work
+into one statement instead: a `.traverse()` chain, [`store.subgraph()`](#subgraph-extraction), or
+`getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+
+What it does buy: per-query result types, and a connection profile that never peaks at N the way
+`Promise.all` does — at the cost of running serially, which on a networked backend is slower than
+`Promise.all`. Each query keeps its own projection, filtering, sorting, and pagination.
 
 ```typescript
 store.batch<R1, R2, ...Rn>(

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -695,8 +695,10 @@ write surfaces that mint or claim ids.
 
 #### `getByIds(ids)`
 
-Retrieves multiple nodes by ID in a single query. Returns results in input order,
-with `undefined` for missing IDs.
+Retrieves multiple nodes by ID, returning results in input order with `undefined`
+for missing IDs. Costs one statement per bind-limit chunk where the backend
+exposes a batch read; where it does not, it falls back to one lookup per distinct
+id, issued concurrently.
 
 ```typescript
 store.nodes.Person.getByIds(
@@ -705,8 +707,10 @@ store.nodes.Person.getByIds(
 ): Promise<readonly (Node<Person> | undefined)[]>;
 ```
 
-When the backend supports batch lookups (`getNodes`), this executes a single
-`SELECT ... WHERE id IN (...)` query. Otherwise it falls back to sequential lookups.
+When the backend supports batch lookups (`getNodes`), this executes
+`SELECT ... WHERE id IN (...)` once per bind-limit chunk — a single statement for
+id counts under the limit. Otherwise it falls back to one lookup per distinct id,
+issued concurrently rather than sequentially.
 
 ```typescript
 const [alice, bob, unknown] = await store.nodes.Person.getByIds([
@@ -1620,11 +1624,18 @@ order — N query executions, never one round trip. Accepts two or more queries 
 set operations, or edge collection `batchFind*` methods), each keeping its own projection,
 filtering, sorting, and pagination.
 
-**Cost.** With `backend.capabilities.transactions` the queries share one transaction; how that
-reaches the wire is the adapter's business. A SQL backend frames them with `begin`/`commit`, so a
-networked one sees N+2 round trips, while Durable Objects use an ambient storage transaction with
-no framing statements. Without transactions there is no framing, and the adapter may still reuse
-one client (see [Limitations](/limitations)). Count on the N executions, not on a transport shape.
+**Cost.** At least one statement per query, sometimes two: a query whose selective-field mapping
+falls back re-runs as a full fetch, and that fallback is detected *after* the selective statement
+has already executed. It clears the fast path, so a reused query instance pays the double only
+once — but the builder is immutable, so a query rebuilt per request pays it every request.
+
+With `backend.capabilities.transactions` the queries share one transaction; how that reaches the
+wire is the adapter's business. A SQL backend frames them with `begin`/`commit`, putting a networked
+one at N+2 round trips **at best**, while Durable Objects use an ambient storage transaction with no
+framing statements. Without transactions there is no framing. Connection reuse is a separate
+question from transaction support: the no-transaction path passes the same backend object, so an
+adapter may reuse one client there too (see [Limitations](/limitations)). The portable guarantee is
+only that at most one query is in flight at a time.
 
 **Not a snapshot — and there is no way to make it one.** PostgreSQL defaults to read-committed
 isolation, so a later query in the batch can observe a commit the earlier ones did not.
@@ -1632,8 +1643,9 @@ isolation, so a later query in the batch can observe a commit the earlier ones d
 there is no public way to run a fluent query or a batch inside a transaction, so a snapshot across
 fluent queries is **not available today**. Collection reads can have one —
 `store.transaction(fn, { isolationLevel: "repeatable_read" })` reading through `tx.nodes` /
-`tx.edges` (a history-enabled store on PostgreSQL additionally requires
-`accessMode: "read_only"`).
+`tx.edges` — but only where the backend has transactions (others ignore the option entirely), and a
+history-enabled store on PostgreSQL additionally requires `accessMode: "read_only"` or the call
+throws.
 
 **Will not fix an N+1.** Serializing N queries does not reduce their number. The alternatives are
 set-oriented or chunked rather than fixed-cost: `.traverse()` compiles a whole chain to one
@@ -1644,8 +1656,9 @@ costs one probe plus that same chunked hydration.
 
 **Versus `Promise.all`.** Workload- and adapter-dependent in both directions. `Promise.all`
 overlaps its queries against a pool with idle capacity, but it does not necessarily hold N
-connections, and against a single client or a saturated pool it queues. `batch()` pays the sum of
-its query latencies but only one acquisition, which can make it faster where acquisition dominates.
+connections, and against a single client or a saturated pool it queues. `batch()` keeps at most one
+query in flight, so it pays the sum of their latencies — but it can still come out ahead where
+connection acquisition dominates. Measure rather than assume.
 
 ```typescript
 store.batch<R1, R2, ...Rn>(
@@ -1958,7 +1971,7 @@ TypeGraph offers several ways to load related data. The right choice depends on 
 | Load entity with all relationships | `subgraph(maxDepth: 1)` | Fixed statement count — fans out across all edge types in one recursive CTE |
 | Load entity with deep chain | `subgraph(maxDepth: N)` | Recursive CTE handles multi-hop without extra round trips per hop |
 | Filter/sort within a relationship | `.query().traverse()` | Fluent query supports WHERE/ORDER/LIMIT on target nodes, in one statement |
-| Multiple independent queries with per-query control | `store.batch()` | Typed tuple results, peak connection use capped at 1 — still one statement per query, and not a snapshot |
+| Multiple independent queries with per-query control | `store.batch()` | Typed tuple results, at most one query in flight — still a statement per query, and not a snapshot |
 | Check if an edge exists | `edges.X.findFrom()` | Lightweight — no node resolution needed; honors the graph's temporal mode by default |
 | Traverse + resolve one edge type | `edges.X.findFrom()` + `nodes.X.getByIds()` | Two queries, simple and explicit; pass `temporalMode` / `asOf` when reading history |
 | Shortest path, reachability, neighborhoods, degree | `store.algorithms.*` | Set-based BFS frontier or a single `COUNT` — see [Graph Algorithms](/graph-algorithms) |
@@ -1971,7 +1984,7 @@ additional queries for node resolution. The gap widens as relationship count gro
 For the common "load an entity and everything it touches" pattern (detail pages, config hydration,
 template instantiation), `subgraph()` with `maxDepth: 1` is the fastest approach. When you need
 per-query filtering, sorting, or pagination across multiple independent queries, use
-[`store.batch()`](#batch-query-execution) — but note it still costs one statement per query, so it
+[`store.batch()`](#batch-query-execution) — but note it still costs a statement per query, so it
 does not narrow this gap. Reserve individual fluent queries for one-off operations.
 
 ### Graph Algorithms
@@ -2048,7 +2061,7 @@ const results = await store
 
 #### `store.batch(...queries)`
 
-Run several queries in sequence — one statement each, never one round trip. See
+Run several queries in sequence — a statement each, never one round trip. See
 [Batch Query Execution](#batch-query-execution).
 
 ### Dynamic Collection Access

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1130,8 +1130,10 @@ Edge write APIs that mint ids still accept plain strings.
 
 #### `getByIds(ids)`
 
-Retrieves multiple edges by ID in a single query. Returns results in input order,
-with `undefined` for missing IDs.
+Retrieves multiple edges by ID, returning results in input order with `undefined`
+for missing IDs. Costs one statement per bind-limit chunk where the backend
+exposes a batch read (`getEdges`); where it does not, it falls back to one lookup
+per distinct id, issued concurrently.
 
 ```typescript
 store.edges.worksAt.getByIds(
@@ -1971,7 +1973,7 @@ TypeGraph offers several ways to load related data. The right choice depends on 
 | Load entity with all relationships | `subgraph(maxDepth: 1)` | Fixed statement count — fans out across all edge types in one recursive CTE |
 | Load entity with deep chain | `subgraph(maxDepth: N)` | Recursive CTE handles multi-hop without extra round trips per hop |
 | Filter/sort within a relationship | `.query().traverse()` | Fluent query supports WHERE/ORDER/LIMIT on target nodes, in one statement |
-| Multiple independent queries with per-query control | `store.batch()` | Typed tuple results, at most one query in flight — still a statement per query, and not a snapshot |
+| Multiple independent queries with per-query control | `store.batch()` | Typed tuple results, at most one query in flight — still at least a statement per query, and not a snapshot |
 | Check if an edge exists | `edges.X.findFrom()` | Lightweight — no node resolution needed; honors the graph's temporal mode by default |
 | Traverse + resolve one edge type | `edges.X.findFrom()` + `nodes.X.getByIds()` | Two queries, simple and explicit; pass `temporalMode` / `asOf` when reading history |
 | Shortest path, reachability, neighborhoods, degree | `store.algorithms.*` | Set-based BFS frontier or a single `COUNT` — see [Graph Algorithms](/graph-algorithms) |
@@ -1984,7 +1986,7 @@ additional queries for node resolution. The gap widens as relationship count gro
 For the common "load an entity and everything it touches" pattern (detail pages, config hydration,
 template instantiation), `subgraph()` with `maxDepth: 1` is the fastest approach. When you need
 per-query filtering, sorting, or pagination across multiple independent queries, use
-[`store.batch()`](#batch-query-execution) — but note it still costs a statement per query, so it
+[`store.batch()`](#batch-query-execution) — but note it still costs at least a statement per query, so it
 does not narrow this gap. Reserve individual fluent queries for one-off operations.
 
 ### Graph Algorithms
@@ -2061,7 +2063,7 @@ const results = await store
 
 #### `store.batch(...queries)`
 
-Run several queries in sequence — a statement each, never one round trip. See
+Run several queries in sequence — at least a statement each, never one round trip. See
 [Batch Query Execution](#batch-query-execution).
 
 ### Dynamic Collection Access

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1206,7 +1206,7 @@ store.edges.worksAt.batchFindByEndpoints(
 ```
 
 ```typescript
-// Execute multiple edge lookups over a single connection
+// Execute multiple edge lookups in sequence — one statement each
 const [skills, employer] = await store.batch(
   store.edges.hasSkill.batchFindFrom(alice),
   store.edges.worksAt.batchFindFrom(alice),
@@ -1614,24 +1614,31 @@ const person = await store.nodes.Person.create({ name: "Alice" });
 
 #### `store.batch(...queries)`
 
-Executes multiple independent queries over a single connection with snapshot consistency.
-Accepts two or more queries (from `.select()`, set operations, or edge collection `batchFind*` methods)
-and returns a typed tuple of results preserving input order.
+Runs several independent queries in sequence and returns a typed tuple of results preserving input
+order — N query executions, never one round trip. Accepts two or more queries (from `.select()`,
+set operations, or edge collection `batchFind*` methods), each keeping its own projection,
+filtering, sorting, and pagination.
 
-**Cost: on a transactional backend, N queries are N+2 round trips** — `begin`, one statement per
-query, `commit` — all on one checked-out connection, all seeing one snapshot. **Without
-transactions** there is no `begin`/`commit` and no shared connection: N statements, each acquiring
-its own, each free to observe writes the earlier ones did not (see [Limitations](/limitations)).
-Branch on `backend.capabilities.transactions` when the difference matters.
+**Cost.** With `backend.capabilities.transactions`, the queries run in one transaction on one
+connection; on a SQL backend that is `begin` + N + `commit`, so a networked one sees N+2 round
+trips. Without transactions there is no framing and no shared connection — whether each query costs
+a fresh pooled connection, an HTTP request, or a reuse of the same client is up to the adapter (see
+[Limitations](/limitations)). Either way it is N executions, serialized.
 
-Either way the queries are serialized, so `batch()` collapses connection acquisition at best, never
-latency; it does not pipeline and it will not fix an N+1. To collapse round trips, fold the work
-into one statement instead: a `.traverse()` chain, [`store.subgraph()`](#subgraph-extraction), or
-`getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+**Not a snapshot.** PostgreSQL defaults to read-committed isolation, so a later query in the batch
+can observe a commit the earlier ones did not. When you need a stable snapshot, use
+`store.transaction(fn, { isolationLevel: "repeatable_read" })`.
 
-What it does buy: per-query result types, and a connection profile that never peaks at N the way
-`Promise.all` does — at the cost of running serially, which on a networked backend is slower than
-`Promise.all`. Each query keeps its own projection, filtering, sorting, and pagination.
+**Will not fix an N+1.** Serializing N queries does not reduce their number. To make the cost
+independent of N, fold the work into one query: `.traverse()` compiles a whole chain to a single
+statement; [`store.subgraph()`](#subgraph-extraction) costs a fixed 2 statements on SQLite and 3 on
+PostgreSQL however large the result; `bulkFindByIndex()` costs one probe plus one hydration read;
+`getByIds()` costs one statement where the backend exposes a batch read, degrading to one per
+distinct id where it does not.
+
+**Versus `Promise.all`.** `batch()` never holds N connections at once. Which is faster depends on
+the workload: against a pool with idle capacity `Promise.all` overlaps its queries and wins on
+latency while `batch()` pays their sum; against a single client or a saturated pool both serialize.
 
 ```typescript
 store.batch<R1, R2, ...Rn>(
@@ -1939,23 +1946,24 @@ TypeGraph offers several ways to load related data. The right choice depends on 
 
 | Pattern | Best strategy | Why |
 |---------|--------------|-----|
-| Load entity with all relationships | `subgraph(maxDepth: 1)` | Single SQL round trip — fans out across all edge types in one recursive CTE |
-| Load entity with deep chain | `subgraph(maxDepth: N)` | Recursive CTE handles multi-hop in one query |
-| Filter/sort within a relationship | `.query().traverse()` | Fluent query supports WHERE/ORDER/LIMIT on target nodes |
-| Multiple independent queries with per-query control | `store.batch()` | Single connection, snapshot consistency, typed tuple results |
+| Load entity with all relationships | `subgraph(maxDepth: 1)` | Fixed statement count — fans out across all edge types in one recursive CTE |
+| Load entity with deep chain | `subgraph(maxDepth: N)` | Recursive CTE handles multi-hop without extra round trips per hop |
+| Filter/sort within a relationship | `.query().traverse()` | Fluent query supports WHERE/ORDER/LIMIT on target nodes, in one statement |
+| Multiple independent queries with per-query control | `store.batch()` | One connection and typed tuple results — still one statement per query |
 | Check if an edge exists | `edges.X.findFrom()` | Lightweight — no node resolution needed; honors the graph's temporal mode by default |
 | Traverse + resolve one edge type | `edges.X.findFrom()` + `nodes.X.getByIds()` | Two queries, simple and explicit; pass `temporalMode` / `asOf` when reading history |
 | Shortest path, reachability, neighborhoods, degree | `store.algorithms.*` | Set-based BFS frontier or a single `COUNT` — see [Graph Algorithms](/graph-algorithms) |
 
-**Key insight:** `subgraph()` issues a single SQL statement regardless of how many edge types it
-traverses. Parallel `findFrom` calls scale linearly in round trips — one per edge type, plus
+**Key insight:** `subgraph()` costs a fixed number of statements — 2 on SQLite (nodes, edges) and 3
+on PostgreSQL (closure ids, then nodes and edges) — regardless of how many edge types it traverses
+or how much it returns. Parallel `findFrom` calls scale linearly instead: one per edge type, plus
 additional queries for node resolution. The gap widens as relationship count grows.
 
 For the common "load an entity and everything it touches" pattern (detail pages, config hydration,
 template instantiation), `subgraph()` with `maxDepth: 1` is the fastest approach. When you need
 per-query filtering, sorting, or pagination across multiple independent queries, use
-[`store.batch()`](#batch-query-execution) to run them over a single connection with snapshot
-consistency. Reserve individual fluent queries for one-off operations.
+[`store.batch()`](#batch-query-execution) — but note it still costs one statement per query, so it
+does not narrow this gap. Reserve individual fluent queries for one-off operations.
 
 ### Graph Algorithms
 
@@ -2031,7 +2039,7 @@ const results = await store
 
 #### `store.batch(...queries)`
 
-Execute multiple queries over a single connection — one statement each, not one round trip. See
+Run several queries in sequence — one statement each, never one round trip. See
 [Batch Query Execution](#batch-query-execution).
 
 ### Dynamic Collection Access

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1185,6 +1185,10 @@ Deferred variants of `findFrom`, `findTo`, and `findByEndpoints` for use with
 executing immediately. `batchFindFrom` / `batchFindTo` accept the same temporal
 `options` as `findFrom` / `findTo`.
 
+Batching them shares a connection and a snapshot; it does not merge the reads — each still costs
+its own statement. To read edges for many sources in one statement, traverse from them in a single
+query.
+
 ```typescript
 store.edges.worksAt.batchFindFrom(
   from: NodeRef<Person>,
@@ -1614,9 +1618,16 @@ Executes multiple independent queries over a single connection with snapshot con
 Accepts two or more queries (from `.select()`, set operations, or edge collection `batchFind*` methods)
 and returns a typed tuple of results preserving input order.
 
-All queries run within an implicit transaction — they see the same database snapshot.
-This avoids connection pool pressure from `Promise.all` patterns (N connections → 1) while
-giving each query independent projection, filtering, sorting, and pagination.
+**Cost: N queries are N+2 round trips** — `begin`, one statement per query, `commit`. `batch()`
+collapses connection acquisition, not latency; it does not pipeline and it will not fix an N+1.
+To collapse round trips, fold the work into one statement instead: a `.traverse()` chain,
+[`store.subgraph()`](#subgraph-extraction), or `getByIds()` / `bulkFindByIndex()` for keyed fan-out.
+
+What it does buy: one connection instead of N (removing the `Promise.all` pool pressure),
+per-query result types, and — when `backend.capabilities.transactions` is `true` — one database
+snapshot across every query, while each query keeps its own projection, filtering, sorting, and
+pagination. On backends without transactions each query runs on its own connection and may observe
+writes that landed between them; see [Limitations](/limitations).
 
 ```typescript
 store.batch<R1, R2, ...Rn>(
@@ -1720,6 +1731,7 @@ const [skills, employer, colleague] = await store.batch(
 |---------|-----|
 | Multiple queries with different shapes/filters | `store.batch()` |
 | Load entity with all relationships (uniform) | `store.subgraph()` |
+| Fixing an N+1 / reducing round trips | `.traverse()`, `store.subgraph()`, `getByIds()` — not `batch()` |
 | Single query | `.execute()` directly |
 | Writes interleaved with reads | `store.transaction()` |
 | Same-shape queries merged into one result | `.union()` / `.intersect()` / `.except()` |
@@ -2015,7 +2027,8 @@ const results = await store
 
 #### `store.batch(...queries)`
 
-Execute multiple queries over a single connection. See [Batch Query Execution](#batch-query-execution).
+Execute multiple queries over a single connection — one statement each, not one round trip. See
+[Batch Query Execution](#batch-query-execution).
 
 ### Dynamic Collection Access
 

--- a/packages/benchmarks/neo4j-compare/README.md
+++ b/packages/benchmarks/neo4j-compare/README.md
@@ -42,8 +42,9 @@ post rows with 4KB bodies.**
 
 - **Inverse-edge traversal** (`expand: "inverse"`): TypeGraph ontology
   feature without a direct Cypher analogue.
-- **Subgraph extraction** (`store.subgraph()`): TypeGraph's single-recursive-CTE
-  fan-out doesn't map cleanly to Cypher and would need a careful
+- **Subgraph extraction** (`store.subgraph()`): TypeGraph's recursive-CTE
+  fan-out uses two statements on this SQLite harness and doesn't map cleanly
+  to Cypher, so it would need a careful
   port; left out of the v1 harness.
 - **Write-path throughput**: seeding times are printed but the benchmark
   doesn't stress bulk writes under contention.

--- a/packages/typegraph/CHANGELOG.md
+++ b/packages/typegraph/CHANGELOG.md
@@ -3088,6 +3088,14 @@ should not need code changes.
   - **Single connection**: Acquires one connection via an implicit transaction, eliminating pool pressure from parallel `Promise.all` patterns (N connections → 1).
   - **Snapshot consistency**: All queries see the same database state — no interleaved writes between results.
   - **Typed tuple results**: Returns a mapped tuple preserving each query's independent result type, projection, filtering, sorting, and pagination.
+
+  > **Correction (see #325).** The "snapshot consistency" bullet above was never
+  > accurate and is retained only as the historical record. `batch()` opens its
+  > implicit transaction without an isolation option, so PostgreSQL runs it at the
+  > default read-committed isolation and a later query in the batch *can* observe a
+  > commit the earlier ones did not. The "single connection" bullet holds only where
+  > `capabilities.transactions` is true. `batch()` also never pipelined, despite the
+  > original issue specifying it.
   - **`BatchableQuery` interface**: Satisfied by both `ExecutableQuery` (from `.select()`) and `UnionableQuery` (from set operations like `.union()`, `.intersect()`). Exposes `executeOn()` for backend-delegated execution.
   - **Minimum 2 queries**: Enforced at the type level — single queries should use `.execute()` directly.
 

--- a/packages/typegraph/CHANGELOG.md
+++ b/packages/typegraph/CHANGELOG.md
@@ -3093,9 +3093,10 @@ should not need code changes.
   > accurate and is retained only as the historical record. `batch()` opens its
   > implicit transaction without an isolation option, so PostgreSQL runs it at the
   > default read-committed isolation and a later query in the batch *can* observe a
-  > commit the earlier ones did not. The "single connection" bullet holds only where
-  > `capabilities.transactions` is true. `batch()` also never pipelined, despite the
-  > original issue specifying it.
+  > commit the earlier ones did not. The "single connection" bullet describes the
+  > transactional path; connection reuse is otherwise the adapter's business, not a
+  > consequence of `capabilities.transactions`. `batch()` also never pipelined,
+  > despite the original issue specifying it.
   - **`BatchableQuery` interface**: Satisfied by both `ExecutableQuery` (from `.select()`) and `UnionableQuery` (from set operations like `.union()`, `.intersect()`). Exposes `executeOn()` for backend-delegated execution.
   - **Minimum 2 queries**: Enforced at the type level — single queries should use `.execute()` directly.
 

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -585,9 +585,13 @@ export class ExecutableQuery<
    *
    * Used by `store.batch()` to run several queries in sequence against one
    * target — a transaction on backends that have them, the backend itself
-   * otherwise. Still one statement per query either way. The full compile →
-   * execute → transform pipeline runs identically to `execute()`, but against
-   * the given backend.
+   * otherwise. The full compile → execute → transform pipeline runs
+   * identically to `execute()`, but against the given backend.
+   *
+   * Costs one statement, or two when the selective-field path runs and its
+   * mapping then falls back: `#tryOptimizedExecutionOn` detects that only
+   * after its statement has executed, and the caller re-runs the full fetch.
+   * The fallback clears the fast path for this instance.
    */
   async executeOn(
     backend: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -583,9 +583,11 @@ export class ExecutableQuery<
   /**
    * Executes the query against a provided backend.
    *
-   * Used by `store.batch()` to run multiple queries over a single connection
-   * (e.g., within a transaction). The full compile → execute → transform
-   * pipeline runs identically to `execute()`, but against the given backend.
+   * Used by `store.batch()` to run several queries in sequence against one
+   * target — a transaction on backends that have them, the backend itself
+   * otherwise. Still one statement per query either way. The full compile →
+   * execute → transform pipeline runs identically to `execute()`, but against
+   * the given backend.
    */
   async executeOn(
     backend: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -69,8 +69,10 @@ export type QueryCoordinateState = "open" | "sealed";
  * The result type `R` is preserved per-query in the batch return tuple.
  *
  * Deferring costs nothing and saves nothing on its own: `store.batch()` runs
- * each query as its own statement on a shared connection, so it does not fold
- * these into a single round trip. See `store.batch()` for the full cost model.
+ * each query as its own statement, so it does not fold these into a single
+ * round trip. Whether they share one connection depends on
+ * `backend.capabilities.transactions` — see `store.batch()` for the full cost
+ * model.
  */
 export type BatchableQuery<R = unknown> = Readonly<{
   executeOn: (

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -63,10 +63,14 @@ export type QueryCoordinateState = "open" | "sealed";
 // ============================================================
 
 /**
- * A query that can be executed within a `store.batch()` call.
+ * A query deferred for execution inside a `store.batch()` call.
  *
  * Both `ExecutableQuery` and `UnionableQuery` satisfy this interface.
  * The result type `R` is preserved per-query in the batch return tuple.
+ *
+ * Deferring costs nothing and saves nothing on its own: `store.batch()` runs
+ * each query as its own statement on a shared connection, so it does not fold
+ * these into a single round trip. See `store.batch()` for the full cost model.
  */
 export type BatchableQuery<R = unknown> = Readonly<{
   executeOn: (

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -69,8 +69,9 @@ export type QueryCoordinateState = "open" | "sealed";
  * The result type `R` is preserved per-query in the batch return tuple.
  *
  * Deferring costs nothing and saves nothing on its own: `store.batch()` runs
- * each query as its own statement, so it does not fold these into a single
- * round trip. Whether they share one connection depends on
+ * each query as its own statement (sometimes two — see `ExecutableQuery`'s
+ * `executeOn`), so it does not fold these into a single round trip. Whether
+ * they share one connection is up to the adapter, not to
  * `backend.capabilities.transactions` — see `store.batch()` for the full cost
  * model.
  */

--- a/packages/typegraph/src/query/builder/unionable-query.ts
+++ b/packages/typegraph/src/query/builder/unionable-query.ts
@@ -347,7 +347,9 @@ export class UnionableQuery<G extends GraphDef, R> {
    *
    * Used by `store.batch()` to run several queries in sequence against one
    * target — a transaction on backends that have them, the backend itself
-   * otherwise. Still one statement per query either way.
+   * otherwise. A set operation compiles to one statement; whether that target
+   * is a shared connection is the adapter's business, not a function of
+   * transaction support.
    */
   async executeOn(
     backend: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/query/builder/unionable-query.ts
+++ b/packages/typegraph/src/query/builder/unionable-query.ts
@@ -345,7 +345,9 @@ export class UnionableQuery<G extends GraphDef, R> {
   /**
    * Executes the combined query against a provided backend.
    *
-   * Used by `store.batch()` to run multiple queries over a single connection.
+   * Used by `store.batch()` to run several queries in sequence against one
+   * target — a transaction on backends that have them, the backend itself
+   * otherwise. Still one statement per query either way.
    */
   async executeOn(
     backend: GraphBackend | TransactionBackend,

--- a/packages/typegraph/src/store/store-view.ts
+++ b/packages/typegraph/src/store/store-view.ts
@@ -310,8 +310,8 @@ function createCurrentOnlyRefusal(
 /**
  * Returns a function that refuses a deferred edge batch read
  * ({@link EDGE_BATCH_READ_NAMES}) on a read-only view. These reads are *reads*,
- * not writes, but they resolve through `store.batch(...)` — a DataLoader context
- * a view does not expose — so the view cannot honor them. The refusal is
+ * not writes, but they only resolve through `store.batch(...)`, which a view
+ * does not expose — so the view cannot honor them. The refusal is
  * synchronous because the live method returns a `BatchableQuery` synchronously
  * (it is invoked, not awaited), so a misuse fail-louds at the call site instead
  * of being routed through the write-refusal fallthrough and mislabeled a write.
@@ -325,7 +325,7 @@ function createBatchReadRefusal(
     throw new ConfigurationError(
       `'${method}' is not available on a read-only StoreView (${describeCoordinate(coordinate)}). ` +
         `Batch endpoint reads resolve through store.batch(...), which a view does not expose — ` +
-        `use the live Store's batch loader, or the view's findFrom / findTo / findByEndpoints for single reads.`,
+        `use the live Store's batch(...), or the view's findFrom / findTo / findByEndpoints for single reads.`,
       {
         code: "STORE_VIEW_BATCH_UNAVAILABLE",
         entity,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1688,19 +1688,23 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   // === Batch Query Execution ===
 
   /**
-   * Executes multiple queries and returns a typed tuple of results.
+   * Runs several queries on one checked-out connection and returns a typed
+   * tuple of their results.
    *
-   * Each query preserves its own result type, projection, filtering, sorting,
-   * and pagination.
+   * **N queries cost N+2 statements** — `begin`, one per query, `commit` —
+   * each a separate round trip on a networked backend. This collapses
+   * connection acquisition, not latency: it does not pipeline, and it will
+   * not fix an N+1. To collapse round trips, fold the work into one
+   * statement instead — `store.subgraph()` for everything reachable from a
+   * root, `.traverse()` for a filtered or projected join, `getByIds` /
+   * `bulkFindByIndex` for a keyed fan-out.
    *
-   * **Snapshot consistency is conditional.** When
-   * `backend.capabilities.transactions` is `true`, queries run sequentially
-   * on a single connection inside an implicit transaction and observe the
-   * same database snapshot. When transactions are unavailable
-   * (Cloudflare D1, `drizzle-orm/neon-http`), queries run sequentially over
-   * independent connections and may observe writes that landed between them.
-   * Branch on `backend.capabilities.transactions` if you need a guaranteed
-   * snapshot.
+   * What it does buy: one pooled connection instead of N (the `Promise.all`
+   * pool-pressure problem), per-query result types, and — only when
+   * `backend.capabilities.transactions` is `true` — one database snapshot
+   * across all queries. Without transactions (Cloudflare D1,
+   * `drizzle-orm/neon-http`) each query runs on its own connection and may
+   * observe writes that landed between them.
    *
    * Read-only — use `bulkCreate`, `bulkInsert`, etc. for write batching.
    *

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1688,23 +1688,28 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   // === Batch Query Execution ===
 
   /**
-   * Runs several queries on one checked-out connection and returns a typed
-   * tuple of their results.
+   * Runs queries in sequence and returns a typed tuple of their results.
    *
-   * **N queries cost N+2 statements** — `begin`, one per query, `commit` —
-   * each a separate round trip on a networked backend. This collapses
-   * connection acquisition, not latency: it does not pipeline, and it will
+   * **On a transactional backend, N queries cost N+2 statements** — `begin`,
+   * one per query, `commit` — each a separate round trip on a networked
+   * backend, all on one checked-out connection, all seeing one snapshot.
+   * **Without transactions** (Cloudflare D1, `drizzle-orm/neon-http`) there
+   * is no `begin`/`commit` and no shared connection: N statements, each
+   * acquiring its own connection, each free to observe writes the earlier
+   * ones did not. Branch on `backend.capabilities.transactions` when the
+   * difference matters.
+   *
+   * Either way the queries are serialized, so this collapses connection
+   * acquisition at best, never latency: it does not pipeline, and it will
    * not fix an N+1. To collapse round trips, fold the work into one
    * statement instead — `store.subgraph()` for everything reachable from a
    * root, `.traverse()` for a filtered or projected join, `getByIds` /
    * `bulkFindByIndex` for a keyed fan-out.
    *
-   * What it does buy: one pooled connection instead of N (the `Promise.all`
-   * pool-pressure problem), per-query result types, and — only when
-   * `backend.capabilities.transactions` is `true` — one database snapshot
-   * across all queries. Without transactions (Cloudflare D1,
-   * `drizzle-orm/neon-http`) each query runs on its own connection and may
-   * observe writes that landed between them.
+   * Versus `Promise.all`: `batch()` never holds N connections at once, and on
+   * a transactional backend it acquires only one. That is the whole win — on
+   * a networked backend it is *slower* than `Promise.all`, which runs the
+   * same queries concurrently.
    *
    * Read-only — use `bulkCreate`, `bulkInsert`, etc. for write batching.
    *

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1688,28 +1688,35 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   // === Batch Query Execution ===
 
   /**
-   * Runs queries in sequence and returns a typed tuple of their results.
+   * Runs several queries in sequence, returning a typed tuple — N query
+   * executions, never one round trip.
    *
-   * **On a transactional backend, N queries cost N+2 statements** — `begin`,
-   * one per query, `commit` — each a separate round trip on a networked
-   * backend, all on one checked-out connection, all seeing one snapshot.
-   * **Without transactions** (Cloudflare D1, `drizzle-orm/neon-http`) there
-   * is no `begin`/`commit` and no shared connection: N statements, each
-   * acquiring its own connection, each free to observe writes the earlier
-   * ones did not. Branch on `backend.capabilities.transactions` when the
-   * difference matters.
+   * **Cost.** With `backend.capabilities.transactions`, the queries run in
+   * one transaction on one connection; on a SQL backend that is `begin` + N +
+   * `commit`, so a networked one sees N+2 round trips. Without transactions
+   * there is no framing and no shared connection — whether each query costs a
+   * fresh pooled connection, an HTTP request, or a reuse of the same client
+   * is up to the adapter. Either way it is N executions, serialized.
    *
-   * Either way the queries are serialized, so this collapses connection
-   * acquisition at best, never latency: it does not pipeline, and it will
-   * not fix an N+1. To collapse round trips, fold the work into one
-   * statement instead — `store.subgraph()` for everything reachable from a
-   * root, `.traverse()` for a filtered or projected join, `getByIds` /
-   * `bulkFindByIndex` for a keyed fan-out.
+   * **Not a snapshot.** PostgreSQL defaults to read-committed isolation, so a
+   * later query can observe a commit the earlier ones did not. When you need
+   * a stable snapshot, use
+   * `store.transaction(fn, { isolationLevel: "repeatable_read" })`.
    *
-   * Versus `Promise.all`: `batch()` never holds N connections at once, and on
-   * a transactional backend it acquires only one. That is the whole win — on
-   * a networked backend it is *slower* than `Promise.all`, which runs the
-   * same queries concurrently.
+   * **Will not fix an N+1.** Serializing N queries does not reduce their
+   * number. To make the cost independent of N, fold the work into one query:
+   * `.traverse()` compiles a whole chain to a single statement;
+   * `store.subgraph()` costs a fixed 2 statements on SQLite and 3 on
+   * PostgreSQL however large the result; `bulkFindByIndex()` costs one probe
+   * plus one hydration read; `getByIds()` costs one statement where the
+   * backend exposes a batch read, degrading to one per distinct id where it
+   * does not.
+   *
+   * **Versus `Promise.all`.** `batch()` never holds N connections at once.
+   * Which is faster depends on the workload: against a pool with idle
+   * capacity `Promise.all` overlaps its queries and wins on latency while
+   * `batch()` pays their sum; against a single client or a saturated pool
+   * both serialize.
    *
    * Read-only — use `bulkCreate`, `bulkInsert`, etc. for write batching.
    *

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1691,13 +1691,22 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * Runs several queries in sequence, returning a typed tuple. The portable
    * guarantee is N serialized query executions — never one round trip.
    *
-   * **Cost.** With `backend.capabilities.transactions` the queries share one
+   * **Cost.** At least one statement per query, sometimes two: a query whose
+   * selective-field mapping falls back re-runs as a full fetch, and that
+   * fallback is detected *after* the selective statement has already
+   * executed. It clears the fast path, so a reused query instance pays the
+   * double only once — but the builder is immutable, so a query rebuilt per
+   * request pays it every request.
+   *
+   * With `backend.capabilities.transactions` the queries share one
    * transaction; how that reaches the wire is the adapter's business. A SQL
-   * backend frames them with `begin`/`commit`, so a networked one sees N+2
-   * round trips, while Durable Objects use an ambient storage transaction
-   * with no framing statements. Without transactions there is no framing, and
-   * the adapter may still reuse one client. Count on the N executions, not on
-   * a transport shape.
+   * backend frames them with `begin`/`commit`, putting a networked one at
+   * N+2 round trips *at best*, while Durable Objects use an ambient storage
+   * transaction with no framing statements. Without transactions there is no
+   * framing. Connection reuse is a separate question from transaction
+   * support: the no-transaction path passes the same backend object, so an
+   * adapter may reuse one client there too. The portable guarantee is only
+   * that at most one query is in flight at a time.
    *
    * **Not a snapshot — and there is no way to make it one.** PostgreSQL
    * defaults to read-committed isolation, so a later query can observe a
@@ -1706,8 +1715,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * no public way to run a fluent query or a batch inside a transaction, so a
    * snapshot across fluent queries is not available today. Collection reads
    * can have one — `store.transaction(fn, { isolationLevel: "repeatable_read" })`
-   * reading through `tx.nodes` / `tx.edges` (a history-enabled store on
-   * PostgreSQL additionally requires `accessMode: "read_only"`).
+   * reading through `tx.nodes` / `tx.edges` — but only where the backend has
+   * transactions (others ignore the option entirely), and a history-enabled
+   * store on PostgreSQL additionally requires `accessMode: "read_only"` or the
+   * call throws.
    *
    * **Will not fix an N+1.** Serializing N queries does not reduce their
    * number. The alternatives are set-oriented or chunked rather than
@@ -1721,9 +1732,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * **Versus `Promise.all`.** Workload- and adapter-dependent in both
    * directions. `Promise.all` overlaps its queries against a pool with idle
    * capacity, but it does not necessarily hold N connections, and against a
-   * single client or a saturated pool it queues. `batch()` pays the sum of
-   * its query latencies but only one acquisition, which can make it the
-   * faster of the two where acquisition dominates.
+   * single client or a saturated pool it queues. `batch()` keeps at most one
+   * query in flight, so it pays the sum of their latencies — but it can still
+   * come out ahead where connection acquisition dominates. Measure rather
+   * than assume.
    *
    * Read-only — use `bulkCreate`, `bulkInsert`, etc. for write batching.
    *

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1688,35 +1688,42 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   // === Batch Query Execution ===
 
   /**
-   * Runs several queries in sequence, returning a typed tuple — N query
-   * executions, never one round trip.
+   * Runs several queries in sequence, returning a typed tuple. The portable
+   * guarantee is N serialized query executions — never one round trip.
    *
-   * **Cost.** With `backend.capabilities.transactions`, the queries run in
-   * one transaction on one connection; on a SQL backend that is `begin` + N +
-   * `commit`, so a networked one sees N+2 round trips. Without transactions
-   * there is no framing and no shared connection — whether each query costs a
-   * fresh pooled connection, an HTTP request, or a reuse of the same client
-   * is up to the adapter. Either way it is N executions, serialized.
+   * **Cost.** With `backend.capabilities.transactions` the queries share one
+   * transaction; how that reaches the wire is the adapter's business. A SQL
+   * backend frames them with `begin`/`commit`, so a networked one sees N+2
+   * round trips, while Durable Objects use an ambient storage transaction
+   * with no framing statements. Without transactions there is no framing, and
+   * the adapter may still reuse one client. Count on the N executions, not on
+   * a transport shape.
    *
-   * **Not a snapshot.** PostgreSQL defaults to read-committed isolation, so a
-   * later query can observe a commit the earlier ones did not. When you need
-   * a stable snapshot, use
-   * `store.transaction(fn, { isolationLevel: "repeatable_read" })`.
+   * **Not a snapshot — and there is no way to make it one.** PostgreSQL
+   * defaults to read-committed isolation, so a later query can observe a
+   * commit the earlier ones did not. `store.transaction()` takes an
+   * `isolationLevel`, but its context exposes only `nodes` / `edges`: there is
+   * no public way to run a fluent query or a batch inside a transaction, so a
+   * snapshot across fluent queries is not available today. Collection reads
+   * can have one — `store.transaction(fn, { isolationLevel: "repeatable_read" })`
+   * reading through `tx.nodes` / `tx.edges` (a history-enabled store on
+   * PostgreSQL additionally requires `accessMode: "read_only"`).
    *
    * **Will not fix an N+1.** Serializing N queries does not reduce their
-   * number. To make the cost independent of N, fold the work into one query:
-   * `.traverse()` compiles a whole chain to a single statement;
-   * `store.subgraph()` costs a fixed 2 statements on SQLite and 3 on
-   * PostgreSQL however large the result; `bulkFindByIndex()` costs one probe
-   * plus one hydration read; `getByIds()` costs one statement where the
-   * backend exposes a batch read, degrading to one per distinct id where it
-   * does not.
+   * number. The alternatives are set-oriented or chunked rather than
+   * fixed-cost: `.traverse()` compiles a whole chain to one statement;
+   * `store.subgraph()` costs 2 statements on SQLite and 3 on PostgreSQL
+   * however large the result; `getByIds()` issues one statement per
+   * bind-limit chunk, falling back to one per distinct id where the backend
+   * exposes no batch read; `bulkFindByIndex()` costs one probe plus that same
+   * chunked hydration.
    *
-   * **Versus `Promise.all`.** `batch()` never holds N connections at once.
-   * Which is faster depends on the workload: against a pool with idle
-   * capacity `Promise.all` overlaps its queries and wins on latency while
-   * `batch()` pays their sum; against a single client or a saturated pool
-   * both serialize.
+   * **Versus `Promise.all`.** Workload- and adapter-dependent in both
+   * directions. `Promise.all` overlaps its queries against a pool with idle
+   * capacity, but it does not necessarily hold N connections, and against a
+   * single client or a saturated pool it queues. `batch()` pays the sum of
+   * its query latencies but only one acquisition, which can make it the
+   * faster of the two where acquisition dominates.
    *
    * Read-only — use `bulkCreate`, `bulkInsert`, etc. for write batching.
    *

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -1024,9 +1024,11 @@ export type EdgeCollection<
    * the same temporal `options` as {@link EdgeCollection.findFrom}.
    *
    * Batching these still issues one statement per call — it does not merge
-   * the reads, and it only shares a connection and a snapshot when the
-   * backend supports transactions. To read edges for many sources in one
-   * statement, traverse from them in a single query.
+   * the reads, and it shares a connection only when the backend supports
+   * transactions. It is not a snapshot: PostgreSQL's default read-committed
+   * isolation lets a later read observe a commit the earlier ones did not. To
+   * read edges for many sources in one statement, traverse from them in a
+   * single query.
    */
   batchFindFrom: (
     from: NodeRef<From>,

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -1022,6 +1022,10 @@ export type EdgeCollection<
    *
    * Returns a `BatchableQuery` instead of executing immediately. Accepts
    * the same temporal `options` as {@link EdgeCollection.findFrom}.
+   *
+   * Batching these still issues one statement per call — it shares a
+   * connection and a snapshot, it does not merge the reads. To read edges for
+   * many sources in one statement, traverse from them in a single query.
    */
   batchFindFrom: (
     from: NodeRef<From>,
@@ -1032,7 +1036,8 @@ export type EdgeCollection<
    * Deferred variant of `findTo` for use with `store.batch()`.
    *
    * Returns a `BatchableQuery` instead of executing immediately. Accepts
-   * the same temporal `options` as {@link EdgeCollection.findTo}.
+   * the same temporal `options` as {@link EdgeCollection.findTo}. Costs one
+   * statement per call, like {@link EdgeCollection.batchFindFrom}.
    */
   batchFindTo: (
     to: NodeRef<To>,
@@ -1043,7 +1048,8 @@ export type EdgeCollection<
    * Deferred variant of `findByEndpoints` for use with `store.batch()`.
    *
    * Returns a `BatchableQuery` that yields a 0-or-1 element array
-   * (matching `findByEndpoints`' at-most-one semantics).
+   * (matching `findByEndpoints`' at-most-one semantics). Costs one statement
+   * per call, like {@link EdgeCollection.batchFindFrom}.
    */
   batchFindByEndpoints: (
     from: NodeRef<From>,

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -1023,9 +1023,10 @@ export type EdgeCollection<
    * Returns a `BatchableQuery` instead of executing immediately. Accepts
    * the same temporal `options` as {@link EdgeCollection.findFrom}.
    *
-   * Batching these still issues one statement per call — it shares a
-   * connection and a snapshot, it does not merge the reads. To read edges for
-   * many sources in one statement, traverse from them in a single query.
+   * Batching these still issues one statement per call — it does not merge
+   * the reads, and it only shares a connection and a snapshot when the
+   * backend supports transactions. To read edges for many sources in one
+   * statement, traverse from them in a single query.
    */
   batchFindFrom: (
     from: NodeRef<From>,

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -1024,11 +1024,10 @@ export type EdgeCollection<
    * the same temporal `options` as {@link EdgeCollection.findFrom}.
    *
    * Batching these still issues one statement per call — it does not merge
-   * the reads, and it shares a connection only when the backend supports
-   * transactions. It is not a snapshot: PostgreSQL's default read-committed
-   * isolation lets a later read observe a commit the earlier ones did not. To
-   * read edges for many sources in one statement, traverse from them in a
-   * single query.
+   * the reads, and whether they share a connection is up to the adapter. It
+   * is not a snapshot: PostgreSQL's default read-committed isolation lets a
+   * later read observe a commit the earlier ones did not. To read edges for
+   * many sources in one statement, traverse from them in a single query.
    */
   batchFindFrom: (
     from: NodeRef<From>,

--- a/packages/typegraph/tests/batch.test.ts
+++ b/packages/typegraph/tests/batch.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for store.batch() — pipelined query execution.
+ * Tests for store.batch() — several queries run in sequence against one
+ * target. Not pipelined: one statement per query, always.
  *
- * Verifies that multiple queries execute over a single connection
- * with typed tuple results, snapshot consistency, and correct
- * handling of projections, ordering, limits, and errors.
+ * Verifies typed tuple results and correct handling of projections,
+ * ordering, limits, and errors.
  */
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";

--- a/packages/typegraph/tests/batch.test.ts
+++ b/packages/typegraph/tests/batch.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for store.batch() — several queries run in sequence against one
- * target. Not pipelined: one statement per query, always.
+ * target. Not pipelined: at least one statement per query, and two when a
+ * query's selective-field mapping falls back after its statement has run.
  *
  * Verifies typed tuple results and correct handling of projections,
  * ordering, limits, and errors.


### PR DESCRIPTION
Closes #325

`store.batch()` runs its queries in sequence, keeping at most one in flight. It
does not pipeline, it is not a snapshot, and it will not fix an N+1 — but the
name reads as "these go over the wire together", and #47 (the issue it shipped
from) explicitly specified Postgres pipelining that was never delivered. The
docstring said "run sequentially on a single connection" and stopped there, so a
caller reaching for `batch()` to fix an N+1 had to measure to find out it
doesn't help.

Per the repo owner's decision, **pipelining is not being implemented**. This PR
is the second option from the issue: make the cost visible at the call site.

## What `batch()` actually costs

Established by reading the implementation, not by inference:

- **At least one statement per query, sometimes two.** `#tryOptimizedExecutionOn`
  executes the selective statement, and only then can `mapSelectiveResults` throw
  `MissingSelectiveFieldError` / `UnsupportedPredicateError`; the catch returns
  `undefined` and the caller re-runs the full fetch. So `N+2` on a SQL backend is
  a **best case, not an identity**. The fallback clears the fast path, so a reused
  query instance pays the double once — but the builder is immutable, so a query
  rebuilt per request pays it every request.
- **The portable guarantee is "at most one query in flight."** Transaction support
  governs transactions, not physical connection reuse: the non-transactional path
  hands every query the same backend object, and Durable Objects run an ambient
  storage transaction with no framing statements at all.
- **Not a snapshot, and there is no way to make it one.** `batch()` opens its
  implicit transaction with no isolation option, so PostgreSQL runs it at the
  default read-committed. `store.transaction()` does take an `isolationLevel`, but
  its context exposes only `nodes` / `edges` — verified against the type checker:
  `tx.query()` does not exist, and `q.executeOn(tx.backend)` fails because
  `TransactionReadBackend` is not assignable to `GraphBackend | TransactionBackend`.
  A snapshot across fluent queries is **not available today**. Collection reads can
  have one, with two conditions: transactionless backends ignore `isolationLevel`
  entirely, and a history-enabled store on PostgreSQL throws without
  `accessMode: "read_only"`.
- **Versus `Promise.all`:** workload- and adapter-dependent in *both* directions.
  `Promise.all` does not necessarily hold N connections, and queues against a
  single client or a saturated pool. `batch()` pays the sum of its query latencies
  but can still win where connection acquisition dominates.

## What the alternatives actually cost

The docs previously said "fold it into one statement" and named four things.
Only one of them is a single statement:

| | Real cost |
|---|---|
| `.traverse()` | One statement — the only true one-statement contract |
| `store.subgraph()` | 2 statements on SQLite, 3 on PostgreSQL (closure ids first), independent of result size |
| `getByIds()` | One statement per bind-limit chunk; falls back to **concurrent** per-id lookups where the backend exposes no batch read |
| `bulkFindByIndex()` | One probe plus that same chunked hydration |

Framed as **set-oriented or chunked**, not "cost independent of N" — an earlier
draft of that reframing was itself wrong.

## Corrections to claims that were already false

Beyond `batch()` itself, the sweep found and fixed:

- performance philosophy #3: "`store.batch()` does the same for reads" (re
  minimizing round trips) — it does not.
- `batchFind*` "replacing N `findFrom`/`findTo` calls with a single transactional
  round-trip" — the statement count is unchanged.
- "`subgraph()` issues a single SQL statement regardless of how many edge types it
  traverses", in three places — it is 2 or 3.
- "`getByIds()` retrieves multiple nodes in a single query" and "falls back to
  sequential lookups" — chunked, and the fallback is concurrent.
- `tests/batch.test.ts` described the feature as "pipelined query execution" — the
  #47 promise that never shipped, sitting in that feature's own test file.
- The `CHANGELOG.md` entry that shipped `batch()` promised "snapshot consistency"
  and "no interleaved writes". It keeps its original text with a **correction note
  appended** rather than a silent rewrite.

## Naming decision: keep `batch`, docs only

I evaluated an alias (`readOnOneConnection` / `readTogether`) with `batch` kept
working, and decided against it.

- **An alias does not fix the failure mode.** The caller who gets burned reaches
  for `batch()` while hunting an N+1 and reads no further. A second entry point
  does not reach them; a docstring whose first line states the cost does, as does
  the "not `batch()`" row in the decision table.
- **It would make discovery worse.** Two names for one behavior means two sets of
  docs and examples, an api-report entry each, and a reader working out whether
  they differ.
- **The name is not wrong under any established meaning.** "Batch" means "a group
  submitted together", not "one round trip" — JDBC's `executeBatch` issues
  per-statement round trips on plenty of drivers. What misled was our own docs
  promising round-trip reduction.

If pipelining ever lands, `batch()` becomes right retroactively with no
deprecation to unwind. Changeset is `patch`.

## For the reviewer

- Two-statement path: `packages/typegraph/src/query/builder/executable-query.ts`,
  `#tryOptimizedExecutionOn` — the `catch` returns `undefined` after `#fetchRows`
  has run; the caller falls through at line ~604.
- Transaction/connection seam: `runOptionallyInTransaction`
  (`packages/typegraph/src/backend/types.ts:2236`).
- `subgraph()` statement counts: `packages/typegraph/src/store/subgraph.ts` (the
  PostgreSQL branch fetches closure ids first; SQLite embeds the CTE in both).
- `getByIds()` chunking: `operation-backend-core.ts` `getNodes`, plus the
  `Promise.all` fallback in `packages/typegraph/src/store/row-fetch.ts`.
- `apps/docs/src/content/docs/changelog.md` is **gitignored and generated** from
  `packages/typegraph/CHANGELOG.md` — the source is the only edit that lands.
- I deliberately did **not** cite #323's bulk edge reads, which are unmerged.
  Every alternative named in the docs exists today.
