### PR TITLE
Export the committed-schema reads from the package root

### DIFF
--- a/.changeset/root-committed-schema-reads.md
+++ b/.changeset/root-committed-schema-reads.md
@@ -1,0 +1,11 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Export the committed-schema reads from the package root. `getActiveSchema`,
+`isSchemaInitialized`, and the `SerializedSchema` type now sit next to
+`getCommittedSchemaVersion` in `@nicia-ai/typegraph`, so answering "what kinds
+does this database already have?" no longer requires finding the
+`@nicia-ai/typegraph/schema` subpath or querying `typegraph_schema_versions`
+by hand. `getActiveSchema` and `getCommittedSchemaVersion` now cross-reference
+each other in their docstrings.

--- a/apps/docs/src/content/docs/architecture.md
+++ b/apps/docs/src/content/docs/architecture.md
@@ -205,6 +205,10 @@ SELECT schema_doc FROM typegraph_schema_versions
 WHERE graph_id = 'my_graph' AND is_active = TRUE;
 ```
 
+From TypeScript,
+[`getActiveSchema`](/schema-management#what-does-this-database-already-have)
+runs this query and parses the result into a typed `SerializedSchema`.
+
 The stored schema includes everything needed to understand the graph:
 
 ```typescript

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -271,24 +271,36 @@ to decide.
 
 ## Schema Introspection
 
-Query the stored schema at runtime:
+### What Does This Database Already Have?
+
+`getActiveSchema` returns the committed schema document — the same JSON stored
+in `typegraph_schema_versions.schema_doc`, parsed into a `SerializedSchema`.
+Read it instead of querying that table by hand:
 
 ```typescript
-import { getActiveSchema, isSchemaInitialized, getSchemaChanges } from "@nicia-ai/typegraph/schema";
+import { getActiveSchema, isSchemaInitialized, type SerializedSchema } from "@nicia-ai/typegraph";
 
-// Check if schema exists
+// Check whether this graph has been committed at all
 const initialized = await isSchemaInitialized(backend, "my_graph");
 
-// Get the current schema
-const schema = await getActiveSchema(backend, "my_graph");
+const schema: SerializedSchema | undefined = await getActiveSchema(backend, "my_graph");
 if (schema) {
-  console.log("Graph ID:", schema.graphId);
   console.log("Version:", schema.version);
-  console.log("Nodes:", Object.keys(schema.nodes));
-  console.log("Edges:", Object.keys(schema.edges));
+  console.log("Nodes:", Object.keys(schema.nodes)); // ["Person", "Company"]
+  console.log("Edges:", Object.keys(schema.edges)); // ["worksAt"]
 }
+```
 
-// Preview changes without applying
+These are exported from both the package root and the
+`@nicia-ai/typegraph/schema` subpath. Reach for `getCommittedSchemaVersion`
+instead when you only need the version number — for example, to invalidate a
+cached schema across isolates.
+
+### Previewing Pending Changes
+
+```typescript
+import { getSchemaChanges } from "@nicia-ai/typegraph/schema";
+
 const diff = await getSchemaChanges(backend, graph);
 if (diff?.hasChanges) {
   console.log("Pending changes:", diff.summary);

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -2030,6 +2030,9 @@ export type FulltextStrategy = Readonly<{
 export function generateId(): string;
 
 // @public
+export function getActiveSchema(backend: GraphBackend, graphId: string): Promise<SerializedSchema | undefined>;
+
+// @public
 export function getCommittedSchemaVersion(backend: GraphBackend, graphId: string): Promise<number | undefined>;
 
 // @public
@@ -2830,6 +2833,9 @@ export function isRecordedCaptureGuardError<C extends RecordedCaptureGuardCode>(
 
 // @public (undocumented)
 export function isRecordedCaptureGuardError(error: unknown): error is RecordedCaptureGuardError;
+
+// @public
+export function isSchemaInitialized(backend: GraphBackend, graphId: string): Promise<boolean>;
 
 // @public (undocumented)
 export function isSearchableSchema(value: unknown): value is SearchableSchema;
@@ -4701,7 +4707,7 @@ type SerializedOntologyRelation = Readonly<{
 }>;
 
 // @public
-type SerializedSchema = Readonly<{
+export type SerializedSchema = Readonly<{
     graphId: string;
     version: number;
     generatedAt: string;

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -44,8 +44,8 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  */
 const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   ".": {
-    count: 312,
-    sha256: "9c41137a0292a9ecb5f57ca6e677e73a90eb9096a200d4327970d4998a3952e0",
+    count: 311,
+    sha256: "396495e52a5b95facd91da1caa0948674fdbe749ddfd08a67be0292cb4d47425",
   },
   "./adapters/drizzle/indexes": {
     count: 24,

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -443,9 +443,15 @@ export {
   StoreSearch,
   StoreView,
 } from "./store";
-// The cross-isolate invalidation probe for a cached ReconciledSchema. Also
-// available from the "./schema" subpath alongside its schema-read siblings.
-export { getCommittedSchemaVersion } from "./schema";
+// Reads of the committed schema: the document, its version, and whether one
+// exists at all. Also available from the "./schema" subpath alongside the
+// migration machinery.
+export type { SerializedSchema } from "./schema";
+export {
+  getActiveSchema,
+  getCommittedSchemaVersion,
+  isSchemaInitialized,
+} from "./schema";
 export type {
   AlgorithmCyclePolicy,
   BaseTraversalOptions,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -756,7 +756,11 @@ export async function rollbackSchema(
 }
 
 /**
- * Gets the current active schema for a graph.
+ * Gets the current active schema for a graph — the committed document itself,
+ * with the `nodes` / `edges` / `ontology` maps the database actually holds.
+ *
+ * This is the answer to "what kinds does this database already have?". Use
+ * {@link getCommittedSchemaVersion} when only the version number is needed.
  *
  * @param backend - The database backend
  * @param graphId - The graph ID
@@ -855,6 +859,9 @@ export async function requiresMigration<G extends GraphDef>(
  * version is used. A version-only backend query would shrink the payload
  * further; it is a backward-compatible follow-up, not required for the
  * round-trip win above.
+ *
+ * Returns only the version; for the document it names, see
+ * {@link getActiveSchema}.
  *
  * @param backend - The database backend
  * @param graphId - The graph ID

--- a/packages/typegraph/tests/backends/integration/reconciled-schema.ts
+++ b/packages/typegraph/tests/backends/integration/reconciled-schema.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   createAdapterStore,
   createVerifiedAdapterStore,
+  getActiveSchema,
   getCommittedSchemaVersion,
+  isSchemaInitialized,
+  type SerializedSchema,
 } from "../../../src";
 import { defineGraphExtension } from "../../../src/graph-extension";
 import { requireDefined } from "../../../src/utils/presence";
@@ -15,8 +18,9 @@ import { type IntegrationTestContext } from "./test-context";
  * Cross-backend parity for the cacheable adapter-store path: a store built
  * from a cached {@link createVerifiedAdapterStore} snapshot must read and,
  * crucially, *validate writes against runtime-committed kinds* identically on
- * every backend — with no verify round-trip — and {@link getCommittedSchemaVersion}
- * must report the same committed version the snapshot recorded. These are the
+ * every backend — with no verify round-trip — and the root-exported committed
+ * schema reads ({@link getCommittedSchemaVersion}, {@link getActiveSchema},
+ * {@link isSchemaInitialized}) must agree with the snapshot. These are the
  * guarantees the §7 serverless per-request cache leans on, so they belong in
  * the shared suite rather than a per-dialect test.
  */
@@ -101,6 +105,39 @@ export function registerReconciledSchemaIntegrationTests(
       expect(
         await getCommittedSchemaVersion(backend, "never_committed_graph"),
       ).toBeUndefined();
+    });
+
+    it("getActiveSchema returns the committed document the version names", async () => {
+      const backend = context.getBackend();
+      const active: SerializedSchema = requireDefined(
+        await getActiveSchema(backend, integrationTestGraph.id),
+      );
+      const version = await getCommittedSchemaVersion(
+        backend,
+        integrationTestGraph.id,
+      );
+
+      expect(active.graphId).toBe(integrationTestGraph.id);
+      expect(active.version).toBe(version);
+      expect(Object.keys(active.nodes).toSorted()).toEqual(
+        Object.keys(integrationTestGraph.nodes).toSorted(),
+      );
+      expect(Object.keys(active.edges).toSorted()).toEqual(
+        Object.keys(integrationTestGraph.edges).toSorted(),
+      );
+    });
+
+    it("getActiveSchema and isSchemaInitialized agree on committed and uncommitted graphs", async () => {
+      const backend = context.getBackend();
+      expect(
+        await getActiveSchema(backend, "never_committed_graph"),
+      ).toBeUndefined();
+      expect(await isSchemaInitialized(backend, "never_committed_graph")).toBe(
+        false,
+      );
+      expect(await isSchemaInitialized(backend, integrationTestGraph.id)).toBe(
+        true,
+      );
     });
 
     it("createAdapterStore({ reconciled }) reads and writes an existing kind", async () => {


### PR DESCRIPTION
Closes #327

## Problem

`getActiveSchema(backend, graphId)` already answers "what kinds does this database already have?", but it was only reachable from the `@nicia-ai/typegraph/schema` subpath. The package root exported `getCommittedSchemaVersion` — a number — and nothing else from that family, so the natural search ("I have the version, where's the document?") came up empty and callers hand-wrote SQL against `typegraph_schema_versions`.

This is a reach problem, not a capability gap. No new function was added.

## Changes

**Root exports.** `getActiveSchema`, `isSchemaInitialized`, and the `SerializedSchema` return type now sit next to `getCommittedSchemaVersion` in `packages/typegraph/src/index.ts`. A returned type the caller cannot name is useless, so the type ships with the functions.

**Docstrings.** `getCommittedSchemaVersion` says it returns only the version and points at `getActiveSchema`; `getActiveSchema` names the question it answers and points back. One line each.

**Docs.** The existing `schema-management.md` "Schema Introspection" section now leads with the question, imports from the root, and separates "what's committed?" from "what's pending?". `architecture.md`, which teaches the raw `SELECT schema_doc` query, points at the typed equivalent.

**API report.** `SerializedSchema` moves from hoisted-but-unexported to exported, dropping the root entrypoint's api-extractor forgotten-export debt from 312 to 311. The baseline in `scripts/api-report.ts` is updated — a reduction, not a waiver.

## Tests

Two cases added to the shared cross-backend suite (`tests/backends/integration/reconciled-schema.ts`), which already exercises `getCommittedSchemaVersion` from the root: `getActiveSchema` returns the document the version names with the graph's `nodes`/`edges` keys, and the three reads agree on a committed vs. uncommitted graph. Importing them (and the `SerializedSchema` annotation) from `../../../src` is what asserts the root export exists.

## Scope

`SerializedSchema` is the only new type on the root surface; its referenced members (`SerializedNodeDef` and friends) stay hoisted-unexported, as they already were. Naming the return type is enough for the reported use case.

Changeset is `minor`.
