### PR TITLE
Fix migrateSchema() silently orphaning runtime-committed kinds

### DIFF
--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Fix `migrateSchema()` silently dropping runtime-committed kinds
+
+`migrateSchema(backend, graph, currentVersion)` committed `graph` verbatim. It
+did not fold the persisted graph extension, so kinds committed at runtime by
+`Store.evolve()` — which live in `schema_doc.extension`, not in the
+compile-time graph — were erased from the active schema document while their
+rows stayed in `typegraph_nodes` / `typegraph_edges`, reachable by nothing and
+with no `typegraph_kind_removals` row ever queued to clean them up.
+
+This was reachable by following the library's own advice: the `MigrationError`
+raised for a breaking change told callers to "use `getSchemaChanges()` to
+review, then `migrateSchema()` to apply", and doing so with the graph they
+passed to `createStoreWithSchema` destroyed every `evolve()`-committed kind.
+
+Two changes:
+
+- **The persisted graph extension is now folded in**, exactly as
+  `createStoreWithSchema` and `getSchemaChanges` already did. Callers pass the
+  graph they have; runtime-committed kinds survive.
+- **A commit that would drop kinds is refused** with a `MigrationError` whose
+  `details.reason` is the new `"kind-removal"` discriminant and whose
+  `details.droppedKinds` names them. `Store.removeKinds()` remains the removal
+  path — it queues the data-cleanup rows that make a removal reconcilable. Pass
+  `{ allowKindRemoval: true }` to accept the orphaning deliberately.
+
+Breaking property changes — the documented reason to reach for
+`migrateSchema()` — are unaffected.

--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -38,6 +38,22 @@ legal instead of being merely advisory. Live rows only, matching the
 Breaking property changes — the documented reason to reach for
 `migrateSchema()` — are unaffected.
 
+`MaterializeRemovalsEntry` gains a `"skipped"` variant, carrying
+`reason: "kind-is-live"`. `materializeRemovals()` returns it when a queued
+removal names a kind the active schema declares again, so the decline is
+reported rather than leaving the queue at a non-zero depth with nothing
+explaining why. Consumers that switch exhaustively on `status` must handle it.
+The type is now a discriminated union, so `"failed"` carries a required
+`error` and `"skipped"` a required `reason`.
+
+`Store.evolve()` refuses to re-add a kind whose data cleanup is still pending,
+with a `ConfigurationError` naming the kind and pointing at
+`materializeRemovals()`. Reads filter only by `(graph_id, kind)`, so re-adding
+before cleanup made the previous incarnation's rows visible alongside the new
+ones — and the cleanup was then declined because the kind was live, so they
+were never reclaimed. The documented cycle (remove → `materializeRemovals` →
+re-add) is unaffected.
+
 Two further corrections found while reviewing the above:
 
 - **A stale store can no longer resurrect a removed kind.** The fold now

--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -26,7 +26,8 @@ Two changes:
 - **A commit that would drop a kind still holding rows is refused** with a
   `MigrationError` whose `details.reason` is the new `"kind-removal"`
   discriminant and whose `details.droppedKinds` names them. Pass
-  `{ allowKindRemoval: true }` to accept the orphaning deliberately.
+  `{ discardDroppedKindRows: true }` if losing those rows is the intent — the
+  name says what the flag does, because the next reconcile deletes them.
 
 The guard fires on the actual harm — orphaned rows — not on kind removal as
 such. Dropping an *empty* kind is unaffected, so the documented three-deploy
@@ -37,3 +38,21 @@ legal instead of being merely advisory. Live rows only, matching the
 
 Breaking property changes — the documented reason to reach for
 `migrateSchema()` — are unaffected.
+
+Two further corrections found while reviewing the above:
+
+- **A stale store can no longer resurrect a removed kind.** The fold now
+  strips the supplied graph's own extension slice before applying the
+  persisted one, so the committed document is a function of the database
+  alone. Previously `migrateSchema(backend, store.graph, v)` — `store.graph`
+  is public and returns the merged graph — unioned a stale slice back in and
+  silently undid `Store.removeKinds()`, leaving a kind the schema called live
+  while its `typegraph_kind_removals` row stayed queued for a later
+  hard-delete. `Store.#catchUpToStored` has stripped for this exact reason;
+  the schema layer now matches it.
+- **`discardDroppedKindRows`'s documentation was wrong.** It claimed the dropped
+  kind's rows stay and that `materializeRemovals` "will never clean them up".
+  `materializeRemovals` re-derives removals by walking schema-version history,
+  so the next reconcile hard-deletes them regardless. The flag buys a
+  committed schema, not retained data; the docstring now says so and points
+  callers at copying the rows out first.

--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -8,9 +8,8 @@ Fix `migrateSchema()` silently dropping runtime-committed kinds
 did not fold the persisted graph extension, so kinds committed at runtime by
 `Store.evolve()` — which live in `schema_doc.extension`, not in the
 compile-time graph — were erased from the active schema document while their
-rows stayed in `typegraph_nodes` / `typegraph_edges`, reachable by nothing and
-with no `typegraph_kind_removals` row ever queued to clean them up. The
-persisted `deprecatedKinds` set was erased the same way.
+rows stayed in `typegraph_nodes` / `typegraph_edges`, reachable by nothing.
+The persisted `deprecatedKinds` set was erased the same way.
 
 This was reachable by following the library's own advice: the `MigrationError`
 raised for a breaking change told callers to "use `getSchemaChanges()` to
@@ -29,8 +28,8 @@ Two changes:
   `{ discardDroppedKindRows: true }` if losing those rows is the intent — the
   name says what the flag does, because the next reconcile deletes them.
 
-The guard fires on the actual harm — orphaned rows — not on kind removal as
-such. Dropping an *empty* kind is unaffected, so the documented three-deploy
+The guard fires on the actual harm — rows the next reconcile would delete —
+not on kind removal as such. Dropping an *empty* kind is unaffected, so the documented three-deploy
 removal flow (stop writing → delete the rows → drop from `defineGraph()` and
 migrate) still works exactly as written; Deploy 2 is now what makes Deploy 3
 legal instead of being merely advisory. Live rows only, matching the

--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -9,7 +9,8 @@ did not fold the persisted graph extension, so kinds committed at runtime by
 `Store.evolve()` — which live in `schema_doc.extension`, not in the
 compile-time graph — were erased from the active schema document while their
 rows stayed in `typegraph_nodes` / `typegraph_edges`, reachable by nothing and
-with no `typegraph_kind_removals` row ever queued to clean them up.
+with no `typegraph_kind_removals` row ever queued to clean them up. The
+persisted `deprecatedKinds` set was erased the same way.
 
 This was reachable by following the library's own advice: the `MigrationError`
 raised for a breaking change told callers to "use `getSchemaChanges()` to
@@ -18,14 +19,21 @@ passed to `createStoreWithSchema` destroyed every `evolve()`-committed kind.
 
 Two changes:
 
-- **The persisted graph extension is now folded in**, exactly as
-  `createStoreWithSchema` and `getSchemaChanges` already did. Callers pass the
-  graph they have; runtime-committed kinds survive.
-- **A commit that would drop kinds is refused** with a `MigrationError` whose
-  `details.reason` is the new `"kind-removal"` discriminant and whose
-  `details.droppedKinds` names them. `Store.removeKinds()` remains the removal
-  path — it queues the data-cleanup rows that make a removal reconcilable. Pass
+- **The persisted graph extension (and deprecated-kind set) is now folded in**,
+  exactly as `createStoreWithSchema` and `getSchemaChanges` already did.
+  `migrateSchema` was the last commit path that did not. Callers pass the graph
+  they have; runtime-committed kinds survive.
+- **A commit that would drop a kind still holding rows is refused** with a
+  `MigrationError` whose `details.reason` is the new `"kind-removal"`
+  discriminant and whose `details.droppedKinds` names them. Pass
   `{ allowKindRemoval: true }` to accept the orphaning deliberately.
+
+The guard fires on the actual harm — orphaned rows — not on kind removal as
+such. Dropping an *empty* kind is unaffected, so the documented three-deploy
+removal flow (stop writing → delete the rows → drop from `defineGraph()` and
+migrate) still works exactly as written; Deploy 2 is now what makes Deploy 3
+legal instead of being merely advisory. Live rows only, matching the
+`excludeDeleted` default of the equivalent probe in `Store.evolve()`.
 
 Breaking property changes — the documented reason to reach for
 `migrateSchema()` — are unaffected.

--- a/apps/docs/src/content/docs/schema-evolution.md
+++ b/apps/docs/src/content/docs/schema-evolution.md
@@ -261,7 +261,7 @@ Remove the node type from `defineGraph()` and force migrate. Deploy 2 is what
 makes this step legal: `migrateSchema()` refuses to drop a kind that still
 holds rows, so if any remain you will get a `MigrationError` with
 `details.reason === "kind-removal"` naming the kind and its row count rather
-than a silently orphaned table.
+than silent data loss.
 
 ### Changing a Property Type
 

--- a/apps/docs/src/content/docs/schema-evolution.md
+++ b/apps/docs/src/content/docs/schema-evolution.md
@@ -218,17 +218,20 @@ if (result.status === "breaking") {
 }
 ```
 
-`migrateSchema()` forces breaking **property** changes. It will not remove a
-**kind**: a commit that drops node or edge kinds the active schema carries is
-refused with a `MigrationError` whose `details.reason` is `"kind-removal"`,
-because the dropped kinds' rows would stay in the database with nothing able
-to read them. Use [`removeKinds()`](#removing-a-node-type) for that — it
-queues the cleanup rows that make the removal reconcilable.
+Two things `migrateSchema()` will not let you do by accident:
 
-You also do not need to know whether kinds were added at runtime by
-`evolve()`. `migrateSchema()` folds the persisted graph extension into the
-graph you hand it, the same way `createStoreWithSchema()` does, so passing
-your compile-time graph never erases runtime-committed kinds.
+- **Drop a kind that still holds rows.** The commit is refused with a
+  `MigrationError` whose `details.reason` is `"kind-removal"`, because those
+  rows would stay in the database with nothing able to read them. Delete the
+  rows first (see [Removing a Node Type](#removing-a-node-type)), or pass
+  `{ allowKindRemoval: true }` to accept the orphaning deliberately. Dropping
+  an *empty* kind needs no flag.
+- **Erase kinds added at runtime.** `migrateSchema()` folds the persisted
+  graph extension into the graph you hand it, the same way
+  `createStoreWithSchema()` does, so passing your compile-time graph never
+  drops a kind that `evolve()` committed. To remove one of those
+  deliberately, use `removeKinds()` — it queues the cleanup rows that make
+  the removal reconcilable.
 
 ### Removing a Node Type
 
@@ -252,7 +255,11 @@ for (const node of deprecated) {
 
 #### Deploy 3 — Remove from schema
 
-Remove the node type from `defineGraph()` and force migrate.
+Remove the node type from `defineGraph()` and force migrate. Deploy 2 is what
+makes this step legal: `migrateSchema()` refuses to drop a kind that still
+holds rows, so if any remain you will get a `MigrationError` with
+`details.reason === "kind-removal"` naming the kind and its row count rather
+than a silently orphaned table.
 
 ### Changing a Property Type
 

--- a/apps/docs/src/content/docs/schema-evolution.md
+++ b/apps/docs/src/content/docs/schema-evolution.md
@@ -218,6 +218,18 @@ if (result.status === "breaking") {
 }
 ```
 
+`migrateSchema()` forces breaking **property** changes. It will not remove a
+**kind**: a commit that drops node or edge kinds the active schema carries is
+refused with a `MigrationError` whose `details.reason` is `"kind-removal"`,
+because the dropped kinds' rows would stay in the database with nothing able
+to read them. Use [`removeKinds()`](#removing-a-node-type) for that — it
+queues the cleanup rows that make the removal reconcilable.
+
+You also do not need to know whether kinds were added at runtime by
+`evolve()`. `migrateSchema()` folds the persisted graph extension into the
+graph you hand it, the same way `createStoreWithSchema()` does, so passing
+your compile-time graph never erases runtime-committed kinds.
+
 ### Removing a Node Type
 
 #### Deploy 1 — Stop creating new instances

--- a/apps/docs/src/content/docs/schema-evolution.md
+++ b/apps/docs/src/content/docs/schema-evolution.md
@@ -221,10 +221,12 @@ if (result.status === "breaking") {
 Two things `migrateSchema()` will not let you do by accident:
 
 - **Drop a kind that still holds rows.** The commit is refused with a
-  `MigrationError` whose `details.reason` is `"kind-removal"`, because those
-  rows would stay in the database with nothing able to read them. Delete the
+  `MigrationError` whose `details.reason` is `"kind-removal"`. Committing
+  would make those rows unreachable, and the next `materializeRemovals()`
+  would delete them — it re-derives removals by walking schema history, so
+  the drop is not reversible by putting the kind back. Export or delete the
   rows first (see [Removing a Node Type](#removing-a-node-type)), or pass
-  `{ allowKindRemoval: true }` to accept the orphaning deliberately. Dropping
+  `{ discardDroppedKindRows: true }` if losing them is the intent. Dropping
   an *empty* kind needs no flag.
 - **Erase kinds added at runtime.** `migrateSchema()` folds the persisted
   graph extension into the graph you hand it, the same way

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -307,7 +307,10 @@ import { initializeSchema, migrateSchema, rollbackSchema, ensureSchema } from "@
 const row = await initializeSchema(backend, graph);
 console.log("Created version:", row.version);
 
-// Migrate to new version
+// Migrate to new version. Folds the persisted graph extension into `graph`
+// first, and refuses (MigrationError, reason "kind-removal") if the commit
+// would drop kinds the active schema carries — use store.removeKinds() for
+// that.
 const newVersion = await migrateSchema(backend, graph, currentVersion);
 console.log("Migrated to version:", newVersion);
 

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -309,8 +309,7 @@ console.log("Created version:", row.version);
 
 // Migrate to new version. Folds the persisted graph extension into `graph`
 // first, and refuses (MigrationError, reason "kind-removal") if the commit
-// would drop kinds the active schema carries — use store.removeKinds() for
-// that.
+// would drop a kind that still holds rows.
 const newVersion = await migrateSchema(backend, graph, currentVersion);
 console.log("Migrated to version:", newVersion);
 

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -258,6 +258,14 @@ try {
       case "breaking-change": {
         break;
       }
+      case "kind-removal": {
+        // The commit would drop a kind that still holds rows. Narrowing on
+        // `reason` makes `droppedKinds` non-optional — the details type is a
+        // discriminated union, so each reason carries exactly its own payload.
+        const { nodes, edges } = error.details.droppedKinds;
+        console.error("still populated:", [...nodes, ...edges]);
+        break;
+      }
       // "no-active-version" | "version-not-found"
     }
   }

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2128,8 +2128,9 @@ type MaterializeIndexesResult = Readonly<{
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed";
+    status: "removed" | "failed" | "skipped";
     error?: Error;
+    reason?: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2124,13 +2124,21 @@ type MaterializeIndexesResult = Readonly<{
     results: readonly MaterializeIndexesEntry[];
 }>;
 
-// @public (undocumented)
+// @public
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed" | "skipped";
-    error?: Error;
-    reason?: "kind-is-live";
+    status: "removed";
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "failed";
+    error: Error;
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "skipped";
+    reason: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -2200,13 +2200,21 @@ type MaterializeIndexesResult = Readonly<{
     results: readonly MaterializeIndexesEntry[];
 }>;
 
-// @public (undocumented)
+// @public
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed" | "skipped";
-    error?: Error;
-    reason?: "kind-is-live";
+    status: "removed";
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "failed";
+    error: Error;
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "skipped";
+    reason: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -2204,8 +2204,9 @@ type MaterializeIndexesResult = Readonly<{
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed";
+    status: "removed" | "failed" | "skipped";
     error?: Error;
+    reason?: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -1969,13 +1969,21 @@ type MaterializeIndexesResult = Readonly<{
     results: readonly MaterializeIndexesEntry[];
 }>;
 
-// @public (undocumented)
+// @public
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed" | "skipped";
-    error?: Error;
-    reason?: "kind-is-live";
+    status: "removed";
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "failed";
+    error: Error;
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "skipped";
+    reason: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -1973,8 +1973,9 @@ type MaterializeIndexesResult = Readonly<{
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed";
+    status: "removed" | "failed" | "skipped";
     error?: Error;
+    reason?: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -1928,8 +1928,9 @@ type MaterializeIndexesResult = Readonly<{
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed";
+    status: "removed" | "failed" | "skipped";
     error?: Error;
+    reason?: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -1924,13 +1924,21 @@ type MaterializeIndexesResult = Readonly<{
     results: readonly MaterializeIndexesEntry[];
 }>;
 
-// @public (undocumented)
+// @public
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed" | "skipped";
-    error?: Error;
-    reason?: "kind-is-live";
+    status: "removed";
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "failed";
+    error: Error;
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "skipped";
+    reason: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -1934,8 +1934,9 @@ type MaterializeIndexesResult = Readonly<{
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed";
+    status: "removed" | "failed" | "skipped";
     error?: Error;
+    reason?: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -1930,13 +1930,21 @@ type MaterializeIndexesResult = Readonly<{
     results: readonly MaterializeIndexesEntry[];
 }>;
 
-// @public (undocumented)
+// @public
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed" | "skipped";
-    error?: Error;
-    reason?: "kind-is-live";
+    status: "removed";
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "failed";
+    error: Error;
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "skipped";
+    reason: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -1165,7 +1165,12 @@ type MetaEdgeProperties = Readonly<{
 }>;
 
 // @public
-export function migrateSchema<G extends GraphDef>(backend: GraphBackend, graph: G, currentVersion: number): Promise<number>;
+export function migrateSchema<G extends GraphDef>(backend: GraphBackend, graph: G, currentVersion: number, options?: MigrateSchemaOptions): Promise<number>;
+
+// @public (undocumented)
+export type MigrateSchemaOptions = Readonly<{
+    allowKindRemoval?: boolean;
+}>;
 
 // @public
 export type MigrationHookContext = Readonly<{

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -1169,7 +1169,7 @@ export function migrateSchema<G extends GraphDef>(backend: GraphBackend, graph: 
 
 // @public (undocumented)
 export type MigrateSchemaOptions = Readonly<{
-    allowKindRemoval?: boolean;
+    discardDroppedKindRows?: boolean;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -1989,13 +1989,21 @@ type MaterializeIndexesResult = Readonly<{
     results: readonly MaterializeIndexesEntry[];
 }>;
 
-// @public (undocumented)
+// @public
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed" | "skipped";
-    error?: Error;
-    reason?: "kind-is-live";
+    status: "removed";
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "failed";
+    error: Error;
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "skipped";
+    reason: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -1993,8 +1993,9 @@ type MaterializeIndexesResult = Readonly<{
 type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed";
+    status: "removed" | "failed" | "skipped";
     error?: Error;
+    reason?: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -3141,13 +3141,21 @@ export type MaterializeIndexesResult = Readonly<{
     results: readonly MaterializeIndexesEntry[];
 }>;
 
-// @public (undocumented)
+// @public
 export type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed" | "skipped";
-    error?: Error;
-    reason?: "kind-is-live";
+    status: "removed";
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "failed";
+    error: Error;
+}> | Readonly<{
+    kind: string;
+    entity: KindEntity;
+    status: "skipped";
+    reason: "kind-is-live";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -3145,8 +3145,9 @@ export type MaterializeIndexesResult = Readonly<{
 export type MaterializeRemovalsEntry = Readonly<{
     kind: string;
     entity: KindEntity;
-    status: "removed" | "failed";
+    status: "removed" | "failed" | "skipped";
     error?: Error;
+    reason?: "kind-is-live";
 }>;
 
 // @public
@@ -3293,14 +3294,24 @@ export class MigrationError extends TypeGraphError {
     readonly details: MigrationErrorDetails;
 }
 
-// @public (undocumented)
+// @public
 export type MigrationErrorDetails = Readonly<{
     graphId: string;
     fromVersion: number;
     toVersion: number;
-    reason: MigrationFailureReason;
+    reason: "schema-behind" | "breaking-change";
     diff?: SchemaDiff;
-    droppedKinds?: Readonly<{
+}> | Readonly<{
+    graphId: string;
+    fromVersion: number;
+    toVersion: number;
+    reason: "no-active-version" | "version-not-found";
+}> | Readonly<{
+    graphId: string;
+    fromVersion: number;
+    toVersion: number;
+    reason: "kind-removal";
+    droppedKinds: Readonly<{
         nodes: readonly string[];
         edges: readonly string[];
     }>;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -3282,7 +3282,7 @@ export type MigrateRecordedAnchorOptions = Readonly<{
 }>;
 
 // @public
-export const MIGRATION_FAILURE_REASONS: readonly ["schema-behind", "breaking-change", "no-active-version", "version-not-found"];
+export const MIGRATION_FAILURE_REASONS: readonly ["schema-behind", "breaking-change", "no-active-version", "version-not-found", "kind-removal"];
 
 // @public
 export class MigrationError extends TypeGraphError {
@@ -3300,6 +3300,10 @@ export type MigrationErrorDetails = Readonly<{
     toVersion: number;
     reason: MigrationFailureReason;
     diff?: SchemaDiff;
+    droppedKinds?: Readonly<{
+        nodes: readonly string[];
+        edges: readonly string[];
+    }>;
 }>;
 
 // @public (undocumented)

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -721,11 +721,13 @@ export const MIGRATION_FAILURE_REASONS = [
   /** The requested schema version does not exist for the graph. */
   "version-not-found",
   /**
-   * The schema about to be committed drops node or edge kinds the active
-   * schema carries. Their rows would stay in the database, reachable by
-   * nothing. Inspect `details.droppedKinds` for the names. Use
-   * `Store.removeKinds()` — the removal path that queues data cleanup — or
-   * pass `allowKindRemoval` to `migrateSchema` to accept the orphaning.
+   * The schema about to be committed drops node or edge kinds that still
+   * hold rows. Committing would make those rows unreachable, and the next
+   * `materializeRemovals()` — which re-derives removals from schema history —
+   * would delete them. Inspect `details.droppedKinds` for the names. Use
+   * `Store.removeKinds()`, the removal path that queues cleanup explicitly,
+   * or pass `discardDroppedKindRows` to `migrateSchema` if losing the rows is
+   * the intent.
    */
   "kind-removal",
 ] as const;
@@ -746,8 +748,10 @@ export type MigrationErrorDetails = Readonly<{
    */
   diff?: SchemaDiff;
   /**
-   * The kind names the refused commit would have dropped (`kind-removal`).
-   * Both lists are sorted; at least one is non-empty.
+   * The dropped kinds that still held rows, and so caused the refusal
+   * (`kind-removal`). A kind the commit drops but that is already empty is
+   * permitted and does NOT appear here. Both lists are sorted; at least one
+   * is non-empty.
    */
   droppedKinds?: Readonly<{
     nodes: readonly string[];

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -720,6 +720,14 @@ export const MIGRATION_FAILURE_REASONS = [
   "no-active-version",
   /** The requested schema version does not exist for the graph. */
   "version-not-found",
+  /**
+   * The schema about to be committed drops node or edge kinds the active
+   * schema carries. Their rows would stay in the database, reachable by
+   * nothing. Inspect `details.droppedKinds` for the names. Use
+   * `Store.removeKinds()` — the removal path that queues data cleanup — or
+   * pass `allowKindRemoval` to `migrateSchema` to accept the orphaning.
+   */
+  "kind-removal",
 ] as const;
 
 export type MigrationFailureReason = (typeof MIGRATION_FAILURE_REASONS)[number];
@@ -737,6 +745,14 @@ export type MigrationErrorDetails = Readonly<{
    * "additive → proceed, incompatible → ask the user" without re-querying.
    */
   diff?: SchemaDiff;
+  /**
+   * The kind names the refused commit would have dropped (`kind-removal`).
+   * Both lists are sorted; at least one is non-empty.
+   */
+  droppedKinds?: Readonly<{
+    nodes: readonly string[];
+    edges: readonly string[];
+  }>;
 }>;
 
 /**

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -734,30 +734,53 @@ export const MIGRATION_FAILURE_REASONS = [
 
 export type MigrationFailureReason = (typeof MIGRATION_FAILURE_REASONS)[number];
 
-export type MigrationErrorDetails = Readonly<{
-  graphId: string;
-  fromVersion: number;
-  toVersion: number;
-  /** Stable discriminant for the failure — branch on this, not the message. */
-  reason: MigrationFailureReason;
-  /**
-   * The structured diff behind the failure, when one was computed
-   * (`schema-behind` and `breaking-change`). Carries per-change `severity`
-   * alongside `hasChanges` / `hasBreakingChanges`, so a caller can decide
-   * "additive → proceed, incompatible → ask the user" without re-querying.
-   */
-  diff?: SchemaDiff;
-  /**
-   * The dropped kinds that still held rows, and so caused the refusal
-   * (`kind-removal`). A kind the commit drops but that is already empty is
-   * permitted and does NOT appear here. Both lists are sorted; at least one
-   * is non-empty.
-   */
-  droppedKinds?: Readonly<{
-    nodes: readonly string[];
-    edges: readonly string[];
-  }>;
-}>;
+/**
+ * Structured context for a {@link MigrationError}, discriminated on `reason`.
+ *
+ * Modelled as a union rather than one shape with optional fields so the
+ * payload a reason promises is the payload it must carry: narrowing on
+ * `reason === "kind-removal"` gives you a non-optional `droppedKinds`, and the
+ * constructor cannot be handed a `kind-removal` without one.
+ *
+ * The common fields are repeated per member rather than factored into a shared
+ * base alias, which would be a hoisted-unexported symbol on the public
+ * entrypoint.
+ */
+export type MigrationErrorDetails =
+  | Readonly<{
+      graphId: string;
+      fromVersion: number;
+      toVersion: number;
+      /** Stable discriminant — branch on this, not the message. */
+      reason: "schema-behind" | "breaking-change";
+      /**
+       * The structured diff behind the failure. Carries per-change `severity`
+       * alongside `hasChanges` / `hasBreakingChanges`, so a caller can decide
+       * "additive → proceed, incompatible → ask the user" without re-querying.
+       */
+      diff?: SchemaDiff;
+    }>
+  | Readonly<{
+      graphId: string;
+      fromVersion: number;
+      toVersion: number;
+      reason: "no-active-version" | "version-not-found";
+    }>
+  | Readonly<{
+      graphId: string;
+      fromVersion: number;
+      toVersion: number;
+      reason: "kind-removal";
+      /**
+       * The dropped kinds that still held rows, and so caused the refusal. A
+       * kind the commit drops but that is already empty is permitted and does
+       * NOT appear here. Both lists are sorted; at least one is non-empty.
+       */
+      droppedKinds: Readonly<{
+        nodes: readonly string[];
+        edges: readonly string[];
+      }>;
+    }>;
 
 /**
  * Thrown when schema migration fails.

--- a/packages/typegraph/src/schema/index.ts
+++ b/packages/typegraph/src/schema/index.ts
@@ -46,6 +46,7 @@ export {
   loadActiveSchemaWithBootstrap,
   loadAndMergeGraphExtensionDocument,
   migrateSchema,
+  type MigrateSchemaOptions,
   type MigrationHookContext,
   parseSerializedSchema,
   requiresMigration,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -14,6 +14,7 @@ import {
   type GraphDef,
 } from "../core/define-graph";
 import { resolveGraphVectorSlots } from "../core/embedding";
+import { type KindEntity } from "../core/types";
 import {
   ConfigurationError,
   DatabaseOperationError,
@@ -419,12 +420,20 @@ export async function ensureSchema<G extends GraphDef>(
   const actions = getMigrationActions(diff);
 
   if (throwOnBreaking) {
+    // The kind-removal pointer is noise on the dominant case (a property
+    // change), so it appears only when the diff actually removes a kind —
+    // which is exactly when `migrateSchema()` would refuse the commit.
+    const removesKind = [...diff.nodes, ...diff.edges].some(
+      (change) => change.type === "removed",
+    );
     throw new MigrationError(
       `Schema migration required: ${diff.summary}. ` +
         `${actions.length} migration action(s) needed. ` +
-        `Use getSchemaChanges() to review, then migrateSchema() to apply. ` +
-        `To remove a kind, use Store.removeKinds() — migrateSchema() refuses ` +
-        `a commit that drops kinds so their rows cannot be orphaned.`,
+        `Use getSchemaChanges() to review, then migrateSchema() to apply.` +
+        (removesKind ?
+          ` To remove a kind, use Store.removeKinds() — migrateSchema() ` +
+          `refuses a commit that drops kinds so their rows cannot be orphaned.`
+        : ""),
       {
         graphId: graph.id,
         fromVersion: activeSchema.version,
@@ -664,15 +673,13 @@ export async function initializeSchema<G extends GraphDef>(
 
 export type MigrateSchemaOptions = Readonly<{
   /**
-   * Commit even when the resulting schema drops node or edge kinds the
-   * active schema carries. **This orphans data**: the dropped kinds' rows
-   * stay in `typegraph_nodes` / `typegraph_edges` and become reachable by
-   * nothing, and no `typegraph_kind_removals` row is queued, so
-   * `materializeRemovals` will never clean them up.
+   * Commit even when a dropped kind still holds rows. **This orphans that
+   * data**: the rows stay in `typegraph_nodes` / `typegraph_edges` and
+   * become reachable by nothing, and no `typegraph_kind_removals` row is
+   * queued, so `materializeRemovals` will never clean them up.
    *
-   * `Store.removeKinds()` is the reconcilable removal path and is what you
-   * almost certainly want. Reach for this flag only to reproduce the
-   * pre-guard behavior against a database you have separately accounted for.
+   * Dropping an *empty* kind needs no flag — it orphans nothing, and it is
+   * the last step of the documented three-deploy kind-removal flow.
    *
    * @defaultValue false
    */
@@ -689,21 +696,11 @@ export type MigrateSchemaOptions = Readonly<{
  * active version since `currentVersion` was read, this throws
  * `StaleVersionError`; the caller should refetch and retry.
  *
- * **The persisted graph extension is folded into `graph` first**, exactly as
- * `createStoreWithSchema` and `getSchemaChanges` do. Kinds committed at
- * runtime by `Store.evolve()` live in `schema_doc.extension`, not in the
- * compile-time graph, so committing the caller's graph verbatim would erase
- * them from the active document while leaving their rows behind. Callers
- * pass the same graph they pass everywhere else; they do not have to know
- * the extension exists.
- *
- * **A commit that would drop kinds is refused** with a `MigrationError`
- * whose `details.reason` is `"kind-removal"`. Dropping a kind is what
- * `Store.removeKinds()` is for — it queues the `typegraph_kind_removals`
- * rows that let `materializeRemovals` reconcile the data. A schema commit
- * must never do it as a side effect. Property-level breaking changes (the
- * documented "force the contract deploy" use for this function) are
- * unaffected.
+ * Folds the persisted graph extension into `graph` first, like every other
+ * commit path — kinds committed at runtime by `Store.evolve()` live in
+ * `schema_doc.extension`, so committing the caller's graph verbatim would
+ * erase them while leaving their rows behind. Property-level breaking
+ * changes (the documented "force the contract deploy" use) are unaffected.
  *
  * @param backend - The database backend
  * @param graph - The current graph definition
@@ -711,7 +708,7 @@ export type MigrateSchemaOptions = Readonly<{
  * @param options - See {@link MigrateSchemaOptions}
  * @returns The new version number
  * @throws MigrationError with `reason: "kind-removal"` when the commit would
- *   drop kinds the active schema carries and `allowKindRemoval` is not set.
+ *   drop a kind that still holds rows and `allowKindRemoval` is not set.
  */
 export async function migrateSchema<G extends GraphDef>(
   backend: GraphBackend,
@@ -719,24 +716,15 @@ export async function migrateSchema<G extends GraphDef>(
   currentVersion: number,
   options?: MigrateSchemaOptions,
 ): Promise<number> {
-  const activeRow = await backend.getActiveSchema(graph.id);
-  // No active row: nothing to fold and nothing to drop. `commitSchemaVersion`
-  // owns the "is `currentVersion` real?" question either way.
-  if (activeRow === undefined) {
-    const committed = await commitNewSchemaVersion(
+  const { graph: target, storedSchema } =
+    await loadAndMergeGraphExtensionDocument(backend, graph);
+  if (storedSchema !== undefined && options?.allowKindRemoval !== true) {
+    await assertNoPopulatedKindDropped(
       backend,
-      graph,
+      storedSchema,
+      target,
       currentVersion,
     );
-    return committed.version;
-  }
-
-  const { graph: target, storedSchema } = mergeStoredGraphExtension(
-    graph,
-    activeRow,
-  );
-  if (options?.allowKindRemoval !== true) {
-    assertNoKindRemoval(storedSchema, target, currentVersion);
   }
 
   const committed = await commitNewSchemaVersion(
@@ -748,42 +736,69 @@ export async function migrateSchema<G extends GraphDef>(
 }
 
 /**
- * Refuses a schema commit that would drop kinds the active document
- * carries.
+ * Refuses a schema commit that would orphan rows.
  *
- * Deliberately placed in the public `migrateSchema` rather than in
- * `commitNewSchemaVersion`: `Store.removeKinds` commits through that
- * primitive and drops kinds *by design*, having first queued the
- * `typegraph_kind_removals` rows that make the drop reconcilable. Guarding
- * the primitive would break the one path allowed to do this.
+ * The invariant is not "no kind is dropped" — it is "no *populated* kind is
+ * orphaned". Dropping an empty kind loses nothing and is the last step of
+ * the documented three-deploy removal flow (stop writing → delete the rows →
+ * drop from `defineGraph`). Dropping a kind that still holds rows strands
+ * them: they stay in the base relations, reachable by nothing, with no
+ * `typegraph_kind_removals` row queued for `materializeRemovals` to clean up.
+ *
+ * Mirrors the probe `Store.evolve` already runs for tightening changes, and
+ * lives in the public `migrateSchema` rather than in
+ * `commitNewSchemaVersion` because `Store.removeKinds` commits through that
+ * primitive and drops populated kinds *by design*, having queued their
+ * cleanup rows first.
  */
-function assertNoKindRemoval<G extends GraphDef>(
+async function assertNoPopulatedKindDropped(
+  backend: GraphBackend,
   storedSchema: SerializedSchema,
-  graph: G,
+  graph: GraphDef,
   currentVersion: number,
-): void {
-  const nodes = droppedKinds(storedSchema.nodes, getNodeKinds(graph));
-  const edges = droppedKinds(storedSchema.edges, getEdgeKinds(graph));
-  if (nodes.length === 0 && edges.length === 0) return;
+): Promise<void> {
+  const dropped = [
+    ...droppedKinds(storedSchema.nodes, getNodeKinds(graph), "node"),
+    ...droppedKinds(storedSchema.edges, getEdgeKinds(graph), "edge"),
+  ];
+  if (dropped.length === 0) return;
 
-  const named = [
-    ...nodes.map((name) => `node "${name}"`),
-    ...edges.map((name) => `edge "${name}"`),
-  ].join(", ");
+  const graphId = storedSchema.graphId;
+  const counted = await Promise.all(
+    dropped.map(async (entry) => {
+      const count =
+        entry.entity === "node" ?
+          await backend.countNodesByKind({ graphId, kind: entry.kind })
+        : await backend.countEdgesByKind({ graphId, kind: entry.kind });
+      return { ...entry, count };
+    }),
+  );
+  const populated = counted.filter((entry) => entry.count > 0);
+  if (populated.length === 0) return;
+
+  const named = populated
+    .map((entry) => `${entry.entity} "${entry.kind}" (${String(entry.count)})`)
+    .join(", ");
   throw new MigrationError(
-    `Refusing to commit a schema for graph "${storedSchema.graphId}" that ` +
-      `drops ${String(nodes.length + edges.length)} kind(s) the active ` +
-      `version carries: ${named}. Their rows would remain in the database, ` +
-      `reachable by nothing. Use Store.removeKinds() to remove a kind ` +
-      `together with the data-cleanup rows that make the removal ` +
-      `reconcilable, or pass { allowKindRemoval: true } to accept the ` +
-      `orphaning.`,
+    `Refusing to commit a schema for graph "${graphId}" that drops kinds ` +
+      `still holding rows: ${named}. Those rows would remain in the ` +
+      `database, reachable by nothing. Delete them first — or, for a kind ` +
+      `added at runtime by evolve(), use Store.removeKinds(), which queues ` +
+      `the cleanup rows that make the removal reconcilable. Pass ` +
+      `{ allowKindRemoval: true } to accept the orphaning.`,
     {
-      graphId: storedSchema.graphId,
+      graphId,
       fromVersion: currentVersion,
       toVersion: currentVersion + 1,
       reason: "kind-removal",
-      droppedKinds: { nodes, edges },
+      droppedKinds: {
+        nodes: populated
+          .filter((entry) => entry.entity === "node")
+          .map((entry) => entry.kind),
+        edges: populated
+          .filter((entry) => entry.entity === "edge")
+          .map((entry) => entry.kind),
+      },
     },
   );
 }
@@ -796,11 +811,13 @@ function assertNoKindRemoval<G extends GraphDef>(
 function droppedKinds(
   committed: Readonly<Record<string, unknown>>,
   present: readonly string[],
-): readonly string[] {
+  entity: KindEntity,
+): readonly Readonly<{ kind: string; entity: KindEntity }>[] {
   const kinds = new Set(present);
   return Object.keys(committed)
     .filter((name) => !kinds.has(name))
-    .toSorted();
+    .toSorted()
+    .map((kind) => ({ kind, entity }));
 }
 
 /**

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -817,6 +817,12 @@ export async function migrateSchema<G extends GraphDef>(
  * deletes them. The commit is the point of no return, which is why the
  * refusal happens here rather than being left to the reconciler.
  *
+ * The remedy is never `Store.removeKinds()`. The fold re-adds every
+ * extension kind before this runs, so a dropped kind is always a
+ * *compile-time* kind — exactly the class `removeKinds` rejects
+ * (`RemoveCompileTimeKindError`). Callers export or delete the rows and
+ * retry, or opt into the loss.
+ *
  * Mirrors the probe `Store.evolve` already runs for tightening changes, and
  * lives in the public `migrateSchema` rather than in
  * `commitNewSchemaVersion` because `Store.removeKinds` commits through that
@@ -863,10 +869,8 @@ async function assertNoPopulatedKindDropped(
     `Refusing to commit a schema for graph "${graphId}" that drops kinds ` +
       `still holding rows: ${named}. Committing would make those rows ` +
       `unreachable, and the next materializeRemovals() would delete them. ` +
-      `Export or delete them first — or, for a kind added at runtime by ` +
-      `evolve(), use Store.removeKinds(), which queues the cleanup ` +
-      `explicitly. Pass { discardDroppedKindRows: true } if losing them is ` +
-      `the intent.`,
+      `Export or delete those rows, then retry. Pass ` +
+      `{ discardDroppedKindRows: true } if losing them is the intent.`,
     {
       graphId,
       fromVersion: currentVersion,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -21,6 +21,7 @@ import {
   MigrationError,
 } from "../errors";
 import { mergeGraphExtension } from "../graph-extension/merge";
+import { stripGraphExtension } from "../graph-extension/remove";
 import { buildKindRegistry } from "../registry";
 import { freezeDeep } from "../utils/object";
 import { isMissingTableError } from "../utils/sql-errors";
@@ -177,16 +178,31 @@ export async function loadAndMergeGraphExtensionDocument<G extends GraphDef>(
  * persisted graph extension into the supplied graph without paying for a
  * second `getActiveSchema` round trip or going through the
  * bootstrap-capable loader.
+ *
+ * **The persisted document is the sole authority on extension kinds.** The
+ * supplied graph's own extension slice is stripped before the stored one is
+ * applied, so the result is a function of `activeRow` alone. Without this, a
+ * caller passing an already-merged graph — `store.graph` is public and
+ * returns one — resurrects extension kinds another writer has since removed:
+ * `unionDocuments` unions the local slice back in and the absent-from-stored
+ * kinds win. That silently undoes `Store.removeKinds` while its
+ * `typegraph_kind_removals` row stays queued, leaving a kind the schema calls
+ * live with a pending cleanup that later deletes its rows.
+ *
+ * A compile-time graph has no extension slice, so the strip is a no-op for
+ * the `createStoreWithSchema` / `assertSchemaCurrent` callers. Mirrors
+ * `Store.#catchUpToStored`, which has stripped for this exact reason.
  */
 function mergeStoredGraphExtension<G extends GraphDef>(
   graph: G,
   activeRow: SchemaVersionRow,
 ): Readonly<{ graph: G; storedSchema: SerializedSchema }> {
   const storedSchema = parseSerializedSchema(activeRow.schema_doc);
+  const compileTimeGraph = stripGraphExtension(graph);
   const merged =
     storedSchema.extension === undefined ?
-      graph
-    : mergeGraphExtension(graph, storedSchema.extension);
+      compileTimeGraph
+    : mergeGraphExtension(compileTimeGraph, storedSchema.extension);
   return {
     graph: applyDeprecatedKinds(merged, storedSchema.deprecatedKinds),
     storedSchema,
@@ -673,17 +689,25 @@ export async function initializeSchema<G extends GraphDef>(
 
 export type MigrateSchemaOptions = Readonly<{
   /**
-   * Commit even when a dropped kind still holds rows. **This orphans that
-   * data**: the rows stay in `typegraph_nodes` / `typegraph_edges` and
-   * become reachable by nothing, and no `typegraph_kind_removals` row is
-   * queued, so `materializeRemovals` will never clean them up.
+   * Commit even when a dropped kind still holds rows.
    *
-   * Dropping an *empty* kind needs no flag — it orphans nothing, and it is
+   * **This does not preserve those rows.** They are immediately unreachable —
+   * nothing references the kind any more — and they are not safe from
+   * deletion either: `materializeRemovals` re-derives removals by walking
+   * schema-version history, so the next reconcile finds the dropped kind and
+   * hard-deletes its rows, including soft-deleted ones. The flag buys a
+   * committed schema, not retained data.
+   *
+   * If you need the rows, copy them out **before** committing. If you want
+   * them removed, prefer `Store.removeKinds()`, which queues the cleanup
+   * explicitly instead of relying on history reconciliation.
+   *
+   * Dropping an *empty* kind needs no flag — it strands nothing, and it is
    * the last step of the documented three-deploy kind-removal flow.
    *
    * @defaultValue false
    */
-  allowKindRemoval?: boolean;
+  discardDroppedKindRows?: boolean;
 }>;
 
 /**
@@ -708,7 +732,7 @@ export type MigrateSchemaOptions = Readonly<{
  * @param options - See {@link MigrateSchemaOptions}
  * @returns The new version number
  * @throws MigrationError with `reason: "kind-removal"` when the commit would
- *   drop a kind that still holds rows and `allowKindRemoval` is not set.
+ *   drop a kind that still holds rows and `discardDroppedKindRows` is not set.
  */
 export async function migrateSchema<G extends GraphDef>(
   backend: GraphBackend,
@@ -718,15 +742,39 @@ export async function migrateSchema<G extends GraphDef>(
 ): Promise<number> {
   const { graph: target, storedSchema } =
     await loadAndMergeGraphExtensionDocument(backend, graph);
-  if (storedSchema !== undefined && options?.allowKindRemoval !== true) {
+  const dropped =
+    storedSchema === undefined ?
+      []
+    : [
+        ...droppedKinds(
+          storedSchema.nodes,
+          getNodeKinds(target),
+          "node",
+          storedSchema.graphId,
+        ),
+        ...droppedKinds(
+          storedSchema.edges,
+          getEdgeKinds(target),
+          "edge",
+          storedSchema.graphId,
+        ),
+      ];
+  if (dropped.length > 0 && options?.discardDroppedKindRows !== true) {
     await assertNoPopulatedKindDropped(
       backend,
-      storedSchema,
-      target,
+      dropped,
+      graph.id,
       currentVersion,
     );
   }
 
+  // No cleanup is queued here, deliberately. `materializeRemovals` derives
+  // removals by walking schema-version history (`reconcilePendingRemovals`),
+  // so a kind dropped by this commit is discovered and reclaimed on the next
+  // reconcile whether or not a `typegraph_kind_removals` row was written.
+  // Writing one would be redundant — and actively harmful on the
+  // `discardDroppedKindRows` path, where it hands a routine reconcile a mandate to
+  // hard-delete the live rows the caller deliberately kept.
   const committed = await commitNewSchemaVersion(
     backend,
     target,
@@ -750,20 +798,20 @@ export async function migrateSchema<G extends GraphDef>(
  * `commitNewSchemaVersion` because `Store.removeKinds` commits through that
  * primitive and drops populated kinds *by design*, having queued their
  * cleanup rows first.
+ *
+ * The probe and the commit are not atomic: the version CAS protects the
+ * schema row, not the row counts, so a concurrent insert can land after a
+ * kind reads as empty. `Store.evolve`'s tightening probe has the same window.
+ * The queued cleanup narrows the consequence — a row inserted into a
+ * just-dropped kind is reclaimed by `materializeRemovals` rather than
+ * stranded.
  */
 async function assertNoPopulatedKindDropped(
   backend: GraphBackend,
-  storedSchema: SerializedSchema,
-  graph: GraphDef,
+  dropped: readonly DroppedKind[],
+  graphId: string,
   currentVersion: number,
 ): Promise<void> {
-  const dropped = [
-    ...droppedKinds(storedSchema.nodes, getNodeKinds(graph), "node"),
-    ...droppedKinds(storedSchema.edges, getEdgeKinds(graph), "edge"),
-  ];
-  if (dropped.length === 0) return;
-
-  const graphId = storedSchema.graphId;
   const counted = await Promise.all(
     dropped.map(async (entry) => {
       const count =
@@ -781,11 +829,12 @@ async function assertNoPopulatedKindDropped(
     .join(", ");
   throw new MigrationError(
     `Refusing to commit a schema for graph "${graphId}" that drops kinds ` +
-      `still holding rows: ${named}. Those rows would remain in the ` +
-      `database, reachable by nothing. Delete them first — or, for a kind ` +
-      `added at runtime by evolve(), use Store.removeKinds(), which queues ` +
-      `the cleanup rows that make the removal reconcilable. Pass ` +
-      `{ allowKindRemoval: true } to accept the orphaning.`,
+      `still holding rows: ${named}. Committing would make those rows ` +
+      `unreachable, and the next materializeRemovals() would delete them. ` +
+      `Export or delete them first — or, for a kind added at runtime by ` +
+      `evolve(), use Store.removeKinds(), which queues the cleanup ` +
+      `explicitly. Pass { discardDroppedKindRows: true } if losing them is ` +
+      `the intent.`,
     {
       graphId,
       fromVersion: currentVersion,
@@ -803,6 +852,12 @@ async function assertNoPopulatedKindDropped(
   );
 }
 
+type DroppedKind = Readonly<{
+  graphId: string;
+  kind: string;
+  entity: KindEntity;
+}>;
+
 /**
  * Kind names present in a committed schema slice but absent from the graph
  * about to be committed. Sorted so the error message and
@@ -812,12 +867,13 @@ function droppedKinds(
   committed: Readonly<Record<string, unknown>>,
   present: readonly string[],
   entity: KindEntity,
-): readonly Readonly<{ kind: string; entity: KindEntity }>[] {
+  graphId: string,
+): readonly DroppedKind[] {
   const kinds = new Set(present);
   return Object.keys(committed)
     .filter((name) => !kinds.has(name))
     .toSorted()
-    .map((kind) => ({ kind, entity }));
+    .map((kind) => ({ graphId, kind, entity }));
 }
 
 /**

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -8,7 +8,11 @@
  * - Error reporting for breaking changes
  */
 import { type GraphBackend, type SchemaVersionRow } from "../backend/types";
-import { type GraphDef } from "../core/define-graph";
+import {
+  getEdgeKinds,
+  getNodeKinds,
+  type GraphDef,
+} from "../core/define-graph";
 import { resolveGraphVectorSlots } from "../core/embedding";
 import {
   ConfigurationError,
@@ -418,7 +422,9 @@ export async function ensureSchema<G extends GraphDef>(
     throw new MigrationError(
       `Schema migration required: ${diff.summary}. ` +
         `${actions.length} migration action(s) needed. ` +
-        `Use getSchemaChanges() to review, then migrateSchema() to apply.`,
+        `Use getSchemaChanges() to review, then migrateSchema() to apply. ` +
+        `To remove a kind, use Store.removeKinds() — migrateSchema() refuses ` +
+        `a commit that drops kinds so their rows cannot be orphaned.`,
       {
         graphId: graph.id,
         fromVersion: activeSchema.version,
@@ -656,6 +662,23 @@ export async function initializeSchema<G extends GraphDef>(
   });
 }
 
+export type MigrateSchemaOptions = Readonly<{
+  /**
+   * Commit even when the resulting schema drops node or edge kinds the
+   * active schema carries. **This orphans data**: the dropped kinds' rows
+   * stay in `typegraph_nodes` / `typegraph_edges` and become reachable by
+   * nothing, and no `typegraph_kind_removals` row is queued, so
+   * `materializeRemovals` will never clean them up.
+   *
+   * `Store.removeKinds()` is the reconcilable removal path and is what you
+   * almost certainly want. Reach for this flag only to reproduce the
+   * pre-guard behavior against a database you have separately accounted for.
+   *
+   * @defaultValue false
+   */
+  allowKindRemoval?: boolean;
+}>;
+
 /**
  * Migrates the schema to match the current graph definition.
  *
@@ -666,22 +689,118 @@ export async function initializeSchema<G extends GraphDef>(
  * active version since `currentVersion` was read, this throws
  * `StaleVersionError`; the caller should refetch and retry.
  *
+ * **The persisted graph extension is folded into `graph` first**, exactly as
+ * `createStoreWithSchema` and `getSchemaChanges` do. Kinds committed at
+ * runtime by `Store.evolve()` live in `schema_doc.extension`, not in the
+ * compile-time graph, so committing the caller's graph verbatim would erase
+ * them from the active document while leaving their rows behind. Callers
+ * pass the same graph they pass everywhere else; they do not have to know
+ * the extension exists.
+ *
+ * **A commit that would drop kinds is refused** with a `MigrationError`
+ * whose `details.reason` is `"kind-removal"`. Dropping a kind is what
+ * `Store.removeKinds()` is for — it queues the `typegraph_kind_removals`
+ * rows that let `materializeRemovals` reconcile the data. A schema commit
+ * must never do it as a side effect. Property-level breaking changes (the
+ * documented "force the contract deploy" use for this function) are
+ * unaffected.
+ *
  * @param backend - The database backend
  * @param graph - The current graph definition
  * @param currentVersion - The current active schema version
+ * @param options - See {@link MigrateSchemaOptions}
  * @returns The new version number
+ * @throws MigrationError with `reason: "kind-removal"` when the commit would
+ *   drop kinds the active schema carries and `allowKindRemoval` is not set.
  */
 export async function migrateSchema<G extends GraphDef>(
   backend: GraphBackend,
   graph: G,
   currentVersion: number,
+  options?: MigrateSchemaOptions,
 ): Promise<number> {
+  const activeRow = await backend.getActiveSchema(graph.id);
+  // No active row: nothing to fold and nothing to drop. `commitSchemaVersion`
+  // owns the "is `currentVersion` real?" question either way.
+  if (activeRow === undefined) {
+    const committed = await commitNewSchemaVersion(
+      backend,
+      graph,
+      currentVersion,
+    );
+    return committed.version;
+  }
+
+  const { graph: target, storedSchema } = mergeStoredGraphExtension(
+    graph,
+    activeRow,
+  );
+  if (options?.allowKindRemoval !== true) {
+    assertNoKindRemoval(storedSchema, target, currentVersion);
+  }
+
   const committed = await commitNewSchemaVersion(
     backend,
-    graph,
+    target,
     currentVersion,
   );
   return committed.version;
+}
+
+/**
+ * Refuses a schema commit that would drop kinds the active document
+ * carries.
+ *
+ * Deliberately placed in the public `migrateSchema` rather than in
+ * `commitNewSchemaVersion`: `Store.removeKinds` commits through that
+ * primitive and drops kinds *by design*, having first queued the
+ * `typegraph_kind_removals` rows that make the drop reconcilable. Guarding
+ * the primitive would break the one path allowed to do this.
+ */
+function assertNoKindRemoval<G extends GraphDef>(
+  storedSchema: SerializedSchema,
+  graph: G,
+  currentVersion: number,
+): void {
+  const nodes = droppedKinds(storedSchema.nodes, getNodeKinds(graph));
+  const edges = droppedKinds(storedSchema.edges, getEdgeKinds(graph));
+  if (nodes.length === 0 && edges.length === 0) return;
+
+  const named = [
+    ...nodes.map((name) => `node "${name}"`),
+    ...edges.map((name) => `edge "${name}"`),
+  ].join(", ");
+  throw new MigrationError(
+    `Refusing to commit a schema for graph "${storedSchema.graphId}" that ` +
+      `drops ${String(nodes.length + edges.length)} kind(s) the active ` +
+      `version carries: ${named}. Their rows would remain in the database, ` +
+      `reachable by nothing. Use Store.removeKinds() to remove a kind ` +
+      `together with the data-cleanup rows that make the removal ` +
+      `reconcilable, or pass { allowKindRemoval: true } to accept the ` +
+      `orphaning.`,
+    {
+      graphId: storedSchema.graphId,
+      fromVersion: currentVersion,
+      toVersion: currentVersion + 1,
+      reason: "kind-removal",
+      droppedKinds: { nodes, edges },
+    },
+  );
+}
+
+/**
+ * Kind names present in a committed schema slice but absent from the graph
+ * about to be committed. Sorted so the error message and
+ * `details.droppedKinds` are stable across object-key iteration order.
+ */
+function droppedKinds(
+  committed: Readonly<Record<string, unknown>>,
+  present: readonly string[],
+): readonly string[] {
+  const kinds = new Set(present);
+  return Object.keys(committed)
+    .filter((name) => !kinds.has(name))
+    .toSorted();
 }
 
 /**

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -19,6 +19,7 @@ import {
   ConfigurationError,
   DatabaseOperationError,
   MigrationError,
+  StaleVersionError,
 } from "../errors";
 import { mergeGraphExtension } from "../graph-extension/merge";
 import { stripGraphExtension } from "../graph-extension/remove";
@@ -439,6 +440,12 @@ export async function ensureSchema<G extends GraphDef>(
     // The kind-removal pointer is noise on the dominant case (a property
     // change), so it appears only when the diff actually removes a kind —
     // which is exactly when `migrateSchema()` would refuse the commit.
+    //
+    // It must NOT point at `Store.removeKinds()`. A kind missing from the
+    // *code graph* is a compile-time kind, and `removeKinds` rejects those by
+    // design (`RemoveCompileTimeKindError`) — they are removed by recompiling
+    // and redeploying. `removeKinds` is for runtime extension kinds, which
+    // cannot be the cause of this diff.
     const removesKind = [...diff.nodes, ...diff.edges].some(
       (change) => change.type === "removed",
     );
@@ -447,8 +454,9 @@ export async function ensureSchema<G extends GraphDef>(
         `${actions.length} migration action(s) needed. ` +
         `Use getSchemaChanges() to review, then migrateSchema() to apply.` +
         (removesKind ?
-          ` To remove a kind, use Store.removeKinds() — migrateSchema() ` +
-          `refuses a commit that would drop a kind still holding rows.`
+          ` This diff removes a kind: migrateSchema() refuses to drop one ` +
+          `that still holds rows, so export or delete those rows first and ` +
+          `retry.`
         : ""),
       {
         graphId: graph.id,
@@ -740,8 +748,27 @@ export async function migrateSchema<G extends GraphDef>(
   currentVersion: number,
   options?: MigrateSchemaOptions,
 ): Promise<number> {
-  const { graph: target, storedSchema } =
-    await loadAndMergeGraphExtensionDocument(backend, graph);
+  const {
+    graph: target,
+    storedSchema,
+    activeRow,
+  } = await loadAndMergeGraphExtensionDocument(backend, graph);
+
+  // Staleness first. The commit's CAS would catch this anyway, but only after
+  // the guard below has probed row counts against a baseline the caller never
+  // saw — so a stale caller dropping a populated kind would get a
+  // `kind-removal` MigrationError quoting versions that were never theirs,
+  // instead of the `StaleVersionError` the concurrency contract documents.
+  // Diagnose the caller's actual problem, and leave the CAS to catch writers
+  // that advance the version after this point.
+  if (activeRow !== undefined && activeRow.version !== currentVersion) {
+    throw new StaleVersionError({
+      graphId: graph.id,
+      expected: currentVersion,
+      actual: activeRow.version,
+    });
+  }
+
   const dropped =
     storedSchema === undefined ?
       []
@@ -796,12 +823,20 @@ export async function migrateSchema<G extends GraphDef>(
  * primitive and drops populated kinds *by design*, having queued their
  * cleanup rows first.
  *
- * The probe and the commit are not atomic: the version CAS protects the
- * schema row, not the row counts, so a concurrent insert can land after a
- * kind reads as empty. `Store.evolve`'s tightening probe has the same window.
- * The queued cleanup narrows the consequence — a row inserted into a
- * just-dropped kind is reclaimed by `materializeRemovals` rather than
- * stranded.
+ * **The probe and the commit are not atomic** (#336). The version CAS protects
+ * the schema row, not the row counts, so a concurrent insert can land after a
+ * kind reads as empty: it is written against a schema that still declares the
+ * kind, and is unreachable a moment later.
+ *
+ * Wrapping both in one transaction would not close this. Schema commits run
+ * under a dialect write-lock (`pg_advisory_xact_lock` on Postgres) that
+ * serializes schema writers against each other, but ordinary data writes do
+ * not take it, so the inserting session is neither holding nor blocked by the
+ * fence. Closing it properly means data writes participating in a shared lock
+ * keyed on the graph — a cost on every write, tracked separately.
+ *
+ * `Store.evolve`'s tightening probe has the identical window and predates
+ * this one.
  */
 async function assertNoPopulatedKindDropped(
   backend: GraphBackend,

--- a/packages/typegraph/src/schema/manager.ts
+++ b/packages/typegraph/src/schema/manager.ts
@@ -448,7 +448,7 @@ export async function ensureSchema<G extends GraphDef>(
         `Use getSchemaChanges() to review, then migrateSchema() to apply.` +
         (removesKind ?
           ` To remove a kind, use Store.removeKinds() — migrateSchema() ` +
-          `refuses a commit that drops kinds so their rows cannot be orphaned.`
+          `refuses a commit that would drop a kind still holding rows.`
         : ""),
       {
         graphId: graph.id,
@@ -746,18 +746,8 @@ export async function migrateSchema<G extends GraphDef>(
     storedSchema === undefined ?
       []
     : [
-        ...droppedKinds(
-          storedSchema.nodes,
-          getNodeKinds(target),
-          "node",
-          storedSchema.graphId,
-        ),
-        ...droppedKinds(
-          storedSchema.edges,
-          getEdgeKinds(target),
-          "edge",
-          storedSchema.graphId,
-        ),
+        ...droppedKinds(storedSchema.nodes, getNodeKinds(target), "node"),
+        ...droppedKinds(storedSchema.edges, getEdgeKinds(target), "edge"),
       ];
   if (dropped.length > 0 && options?.discardDroppedKindRows !== true) {
     await assertNoPopulatedKindDropped(
@@ -768,13 +758,18 @@ export async function migrateSchema<G extends GraphDef>(
     );
   }
 
-  // No cleanup is queued here, deliberately. `materializeRemovals` derives
-  // removals by walking schema-version history (`reconcilePendingRemovals`),
-  // so a kind dropped by this commit is discovered and reclaimed on the next
-  // reconcile whether or not a `typegraph_kind_removals` row was written.
-  // Writing one would be redundant — and actively harmful on the
-  // `discardDroppedKindRows` path, where it hands a routine reconcile a mandate to
-  // hard-delete the live rows the caller deliberately kept.
+  // No cleanup is queued here, deliberately, and redundancy is the whole
+  // reason. `materializeRemovals` derives removals by walking schema-version
+  // history (`reconcilePendingRemovals` diffs consecutive documents' kind
+  // sets), so a kind dropped by this commit is discovered and reclaimed on
+  // the next reconcile whether or not a `typegraph_kind_removals` row exists
+  // — on every path, `discardDroppedKindRows` included. Writing one would
+  // change nothing except adding a second source of truth.
+  //
+  // The walk is only as good as retained history: `reconcilePendingRemovals`
+  // stops at the first absent prior version, so a drop below a pruned or
+  // gapped range becomes undiscoverable. Callers who prune schema versions
+  // should run `materializeRemovals` before pruning.
   const committed = await commitNewSchemaVersion(
     backend,
     target,
@@ -784,14 +779,16 @@ export async function migrateSchema<G extends GraphDef>(
 }
 
 /**
- * Refuses a schema commit that would orphan rows.
+ * Refuses a schema commit that would destroy rows.
  *
  * The invariant is not "no kind is dropped" — it is "no *populated* kind is
- * orphaned". Dropping an empty kind loses nothing and is the last step of
- * the documented three-deploy removal flow (stop writing → delete the rows →
- * drop from `defineGraph`). Dropping a kind that still holds rows strands
- * them: they stay in the base relations, reachable by nothing, with no
- * `typegraph_kind_removals` row queued for `materializeRemovals` to clean up.
+ * destroyed by accident". Dropping an empty kind loses nothing and is the
+ * last step of the documented three-deploy removal flow (stop writing →
+ * delete the rows → drop from `defineGraph`). Dropping a kind that still
+ * holds rows makes them unreachable immediately, and the next
+ * `materializeRemovals` — which re-derives removals from schema history —
+ * deletes them. The commit is the point of no return, which is why the
+ * refusal happens here rather than being left to the reconciler.
  *
  * Mirrors the probe `Store.evolve` already runs for tightening changes, and
  * lives in the public `migrateSchema` rather than in
@@ -853,7 +850,6 @@ async function assertNoPopulatedKindDropped(
 }
 
 type DroppedKind = Readonly<{
-  graphId: string;
   kind: string;
   entity: KindEntity;
 }>;
@@ -867,13 +863,12 @@ function droppedKinds(
   committed: Readonly<Record<string, unknown>>,
   present: readonly string[],
   entity: KindEntity,
-  graphId: string,
 ): readonly DroppedKind[] {
   const kinds = new Set(present);
   return Object.keys(committed)
     .filter((name) => !kinds.has(name))
     .toSorted()
-    .map((kind) => ({ graphId, kind, entity }));
+    .map((kind) => ({ kind, entity }));
 }
 
 /**

--- a/packages/typegraph/src/store/materialize-removals.ts
+++ b/packages/typegraph/src/store/materialize-removals.ts
@@ -209,6 +209,11 @@ export async function materializeRemovals(
   // the health signal for this subsystem, and a silent skip gives it a
   // legitimate non-zero steady state that no output explains — an operator
   // could not tell "nothing pending" from "declined on purpose".
+  //
+  // `reclaimRemovedVectorFieldTables` above independently keys its orphan test
+  // on the same active schema, for the same reason. The two filters are
+  // written separately but must keep agreeing on that authority — see the
+  // note there.
   const liveKinds = liveKindNamesFrom(activeSchema);
 
   const kindFilter =
@@ -760,6 +765,17 @@ async function reclaimRemovedVectorFieldTables(
     }
   }
 
+  // Both clauses key on the ACTIVE schema, which is what keeps this pass from
+  // dropping storage for a kind that was removed and later re-added:
+  // `survivingKinds` requires the kind to be live now, so a re-added kind with
+  // its field re-declared is not an orphan, and a still-removed kind is left
+  // to the candidate loop in `materializeRemovals` instead.
+  //
+  // That is the same authority the live-kind guard there uses — two
+  // independently written filters agreeing on one source. Keep them agreeing:
+  // weakening either (e.g. keying this on schema *history* rather than the
+  // active document) reopens the re-add data-loss path from the other side,
+  // and no test spans both.
   const orphans = [...historical.values()].filter(
     (field) =>
       !activeVectorFields.has(vectorFieldKey(field.kind, field.fieldPath)) &&

--- a/packages/typegraph/src/store/materialize-removals.ts
+++ b/packages/typegraph/src/store/materialize-removals.ts
@@ -65,24 +65,40 @@ export type MaterializeRemovalsOptions = Readonly<{
   stopOnError?: boolean;
 }>;
 
-export type MaterializeRemovalsEntry = Readonly<{
-  kind: string;
-  entity: KindEntity;
-  /**
-   * `"skipped"` means the queued removal was declined because the active
-   * schema declares the kind again — it was dropped, then re-added, and
-   * deleting its rows now would destroy live data. The row stays pending, so
-   * a later removal of the same kind still reclaims it.
-   *
-   * Reported rather than silent: an empty `results` array would otherwise be
-   * indistinguishable from "nothing was pending", leaving the queue at a
-   * non-zero depth with nothing explaining why.
-   */
-  status: "removed" | "failed" | "skipped";
-  error?: Error;
-  /** Why a `"skipped"` entry was declined. */
-  reason?: "kind-is-live";
-}>;
+/**
+ * Outcome of one queued kind removal, discriminated on `status`.
+ *
+ * A union rather than one shape with optional fields, so each outcome carries
+ * exactly its own payload: `"failed"` always has an `error`, `"skipped"`
+ * always has a `reason`, and `"removed"` has neither. The flat form permitted
+ * impossible states — a `"skipped"` with no reason, or a `"removed"` carrying
+ * `reason: "kind-is-live"` — and narrowing on `status` still left both fields
+ * optional at the use site.
+ */
+export type MaterializeRemovalsEntry =
+  | Readonly<{ kind: string; entity: KindEntity; status: "removed" }>
+  | Readonly<{
+      kind: string;
+      entity: KindEntity;
+      status: "failed";
+      error: Error;
+    }>
+  | Readonly<{
+      kind: string;
+      entity: KindEntity;
+      status: "skipped";
+      /**
+       * `"kind-is-live"`: the active schema declares this kind again — it was
+       * dropped, then re-added — so deleting its rows would destroy live
+       * data. The queue row stays pending, so a later removal of the same
+       * kind still reclaims it.
+       *
+       * Reported rather than silent: an empty `results` array would otherwise
+       * be indistinguishable from "nothing was pending", leaving the queue at
+       * a non-zero depth with nothing explaining why.
+       */
+      reason: "kind-is-live";
+    }>;
 
 /**
  * Outcome of reclaiming one per-`(graphId, kind, field)` vector table that

--- a/packages/typegraph/src/store/materialize-removals.ts
+++ b/packages/typegraph/src/store/materialize-removals.ts
@@ -221,6 +221,15 @@ export async function materializeRemovals(
   // and leaving the row pending means a later removal of the same kind is
   // still reclaimed. Self-healing rather than sticky.
   //
+  // This is check-then-delete (#339): a re-add committing between this read
+  // and the DELETE below is not fenced. Closing it means re-reading and
+  // deleting while holding the schema-write lock — which a re-add contends
+  // for, unlike the plain data write in #336 — but the lock's transaction
+  // target cannot execute DDL, and cleanup drops per-kind vector tables.
+  // Deferring that DDL outside the lock would drop live storage for a kind
+  // that was re-added meanwhile, so the fix needs that target extended
+  // first.
+  //
   // The decline is REPORTED (`status: "skipped"`), not silent. Queue depth is
   // the health signal for this subsystem, and a silent skip gives it a
   // legitimate non-zero steady state that no output explains — an operator

--- a/packages/typegraph/src/store/materialize-removals.ts
+++ b/packages/typegraph/src/store/materialize-removals.ts
@@ -13,6 +13,7 @@ import {
   type GraphBackend,
   type KindRemovalRow,
   type RecordKindRemovalParams,
+  type SchemaVersionRow,
   type TransactionBackend,
 } from "../backend/types";
 import type { KindEntity } from "../core/types";
@@ -25,6 +26,7 @@ import type {
 import { sql } from "../query/sql-fragment";
 import { asCompiledStatementSql } from "../query/sql-intent";
 import { parseSerializedSchema } from "../schema/manager";
+import type { SerializedSchema } from "../schema/types";
 import { nowIso } from "../utils/date";
 import { requireDefined } from "../utils/presence";
 import { isMissingTableError } from "../utils/sql-errors";
@@ -66,8 +68,20 @@ export type MaterializeRemovalsOptions = Readonly<{
 export type MaterializeRemovalsEntry = Readonly<{
   kind: string;
   entity: KindEntity;
-  status: "removed" | "failed";
+  /**
+   * `"skipped"` means the queued removal was declined because the active
+   * schema declares the kind again — it was dropped, then re-added, and
+   * deleting its rows now would destroy live data. The row stays pending, so
+   * a later removal of the same kind still reclaims it.
+   *
+   * Reported rather than silent: an empty `results` array would otherwise be
+   * indistinguishable from "nothing was pending", leaving the queue at a
+   * non-zero depth with nothing explaining why.
+   */
+  status: "removed" | "failed" | "skipped";
   error?: Error;
+  /** Why a `"skipped"` entry was declined. */
+  reason?: "kind-is-live";
 }>;
 
 /**
@@ -161,17 +175,62 @@ export async function materializeRemovals(
   // The add-only `materializeIndexes` path never reclaims it and the
   // candidate loop below only handles whole kinds, so reclaim here before
   // the no-candidates short-circuit.
-  const reclaimedVectorFields = await reclaimRemovedVectorFieldTables(context);
+  // One read of the active schema, shared by the vector-reclaim pass and the
+  // live-kind guard below. Both need the same document and both key on the
+  // ACTIVE version — see `liveKindNamesFrom`.
+  const activeRow = await backend.getActiveSchema(graphId);
+  const activeSchema =
+    activeRow === undefined ? undefined : (
+      parseSerializedSchema(activeRow.schema_doc)
+    );
+
+  const reclaimedVectorFields = await reclaimRemovedVectorFieldTables(
+    context,
+    activeRow,
+  );
 
   const pending = await backend.getPendingKindRemovals(graphId);
 
+  // Never delete the rows of a kind the ACTIVE schema still declares.
+  //
+  // A pending removal only records that a kind was absent at some version. It
+  // does not mean the kind is absent *now*: a drop at v3 followed by a re-add
+  // at v4 leaves the v3 removal queued (and `reconcilePendingRemovals` keeps
+  // re-deriving it from history, since that walk compares each consecutive
+  // pair of documents and is blind to what happened later). Cleanup is an
+  // unconditional `DELETE ... WHERE kind = ?`, so acting on that row would
+  // destroy live data belonging to a kind applications are actively writing.
+  //
+  // Skipped rather than completed: the kind genuinely has not been cleaned up,
+  // and leaving the row pending means a later removal of the same kind is
+  // still reclaimed. Self-healing rather than sticky.
+  //
+  // The decline is REPORTED (`status: "skipped"`), not silent. Queue depth is
+  // the health signal for this subsystem, and a silent skip gives it a
+  // legitimate non-zero steady state that no output explains — an operator
+  // could not tell "nothing pending" from "declined on purpose".
+  const liveKinds = liveKindNamesFrom(activeSchema);
+
   const kindFilter =
     options.kinds === undefined ? undefined : new Set(options.kinds);
-  const candidates = pending.filter((row) =>
-    kindFilter === undefined ? true : kindFilter.has(row.kindName),
+  const selected = pending.filter(
+    (row) => kindFilter === undefined || kindFilter.has(row.kindName),
   );
+  const candidates = selected.filter(
+    (row) => !liveKinds[row.entity].has(row.kindName),
+  );
+  const skipped: readonly MaterializeRemovalsEntry[] = selected
+    .filter((row) => liveKinds[row.entity].has(row.kindName))
+    .map((row) => ({
+      kind: row.kindName,
+      entity: row.entity,
+      status: "skipped" as const,
+      reason: "kind-is-live" as const,
+    }));
 
-  if (candidates.length === 0) return { results: [], reclaimedVectorFields };
+  if (candidates.length === 0) {
+    return { results: skipped, reclaimedVectorFields };
+  }
 
   const tableNames = backend.tableNames;
   const nodesTable = tableNames?.nodes ?? "typegraph_nodes";
@@ -199,12 +258,12 @@ export async function materializeRemovals(
   // parallelizes round-trips across pool connections, SQLite serializes
   // writes at the engine level either way. `stopOnError` honors strict
   // sequential semantics; the first failure short-circuits the rest.
-  return {
-    results: await runMaterialization(candidates, options, (removal) =>
-      materializeOne(removal, ctx),
-    ),
-    reclaimedVectorFields,
-  };
+  const materialized = await runMaterialization(
+    candidates,
+    options,
+    (removal) => materializeOne(removal, ctx),
+  );
+  return { results: [...materialized, ...skipped], reclaimedVectorFields };
 }
 
 /**
@@ -342,6 +401,25 @@ async function reconcilePendingRemovals(
   if (backend.setReconciliationMarker !== undefined) {
     await backend.setReconciliationMarker(graphId, activeRow.version);
   }
+}
+
+/**
+ * Node and edge kind names the active schema declares, by entity.
+ *
+ * Used to refuse cleanup for a kind that has since been re-added. Returns
+ * empty sets when no schema is committed — nothing is live, so nothing is
+ * protected, and the pending rows proceed as before.
+ */
+function liveKindNamesFrom(
+  schema: SerializedSchema | undefined,
+): Readonly<Record<KindEntity, ReadonlySet<string>>> {
+  if (schema === undefined) {
+    return { node: new Set<string>(), edge: new Set<string>() };
+  }
+  return {
+    node: new Set(Object.keys(schema.nodes)),
+    edge: new Set(Object.keys(schema.edges)),
+  };
 }
 
 function kindRemovalKey(
@@ -624,13 +702,12 @@ type HistoricalVectorField = Readonly<{
  */
 async function reclaimRemovedVectorFieldTables(
   context: MaterializeRemovalsContext,
+  activeRow: SchemaVersionRow | undefined,
 ): Promise<readonly ReclaimedVectorFieldEntry[]> {
   const { backend, graphId } = context;
   const vectorStrategy = backend.vectorStrategy;
   const executeDdl = backend.executeDdl;
   if (vectorStrategy === undefined || executeDdl === undefined) return [];
-
-  const activeRow = await backend.getActiveSchema(graphId);
   if (activeRow === undefined) return [];
 
   // The orphan set is a pure function of (graphId, active version) over

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -2809,6 +2809,18 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     // promote to incompatible only when the kind has rows; genuinely
     // incompatible changes (REMOVE_PROPERTY, TYPE_CHANGE) are
     // rejected unconditionally.
+    // A kind cannot be re-added while its cleanup is still queued. The rows
+    // of the previous incarnation are still in the base relations, and reads
+    // filter only by (graph_id, kind) — there is no schema-generation
+    // boundary — so re-adding makes them visible again alongside whatever the
+    // new incarnation writes. Worse, `materializeRemovals` then declines the
+    // queued row (the kind is live), so those rows are never reclaimed.
+    //
+    // The documented cycle is remove -> materializeRemovals -> re-add, which
+    // this leaves untouched. Blocking here rather than at cleanup time keeps
+    // the diagnosis where the caller can act on it.
+    await this.#assertNoPendingRemovalFor(merged, baseline);
+
     const baselineDocument = baseline.extension ?? Object.freeze({});
     const classification = classifyModifications(baselineDocument, extension);
     if (classification.incompatible.length > 0) {
@@ -3470,6 +3482,50 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * would require `SELECT FOR UPDATE` on the rows table, too
    * heavyweight for a millisecond-budget operation.
    */
+  /**
+   * Refuses an evolve that re-adds a kind whose data cleanup is still pending.
+   *
+   * Returns silently on backends without the removal queue: they cannot have
+   * a pending row, so there is nothing to conflict with.
+   */
+  async #assertNoPendingRemovalFor(merged: G, baseline: G): Promise<void> {
+    const getPendingKindRemovals = this.#backend.getPendingKindRemovals;
+    if (getPendingKindRemovals === undefined) return;
+
+    const addedNodes = Object.keys(merged.nodes).filter(
+      (kind) => !(kind in baseline.nodes),
+    );
+    const addedEdges = Object.keys(merged.edges).filter(
+      (kind) => !(kind in baseline.edges),
+    );
+    if (addedNodes.length === 0 && addedEdges.length === 0) return;
+
+    const pending = await getPendingKindRemovals(this.graphId);
+    if (pending.length === 0) return;
+
+    const blocked = pending.filter((row) =>
+      row.entity === "node" ?
+        addedNodes.includes(row.kindName)
+      : addedEdges.includes(row.kindName),
+    );
+    if (blocked.length === 0) return;
+
+    const named = blocked
+      .map((row) => `${row.entity} "${row.kindName}"`)
+      .join(", ");
+    throw new ConfigurationError(
+      `Cannot re-add ${named} for graph "${this.graphId}": the previous ` +
+        `removal's data cleanup has not run, so the old rows are still in ` +
+        `the database and would become visible again alongside the new ` +
+        `ones. Run store.materializeRemovals() first, then evolve.`,
+      {
+        code: "KIND_READD_BLOCKED_BY_PENDING_REMOVAL",
+        graphId: this.graphId,
+        kinds: blocked.map((row) => row.kindName),
+      },
+    );
+  }
+
   async #probeEmptyKinds(
     requireEmpty: readonly RequireEmptyEntry[],
   ): Promise<Set<RequireEmptyEntry>> {

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -34,6 +34,7 @@ import {
   registerFulltextIntegrationTests,
   registerImportUniquenessIntegrationTests,
   registerLateMaterializationIntegrationTests,
+  registerMigrateSchemaKindIntegrationTests,
   registerOrderingIntegrationTests,
   registerPaginationIntegrationTests,
   registerPredicateIntegrationTests,
@@ -162,6 +163,7 @@ export function createIntegrationTestSuite<TNativeTransaction>(
     registerLateMaterializationIntegrationTests(context);
     registerTemporalIntegrationTests(context);
     registerTransactionReceiptIntegrationTests(context);
+    registerMigrateSchemaKindIntegrationTests(context);
     registerReconciledSchemaIntegrationTests(context);
     registerRecordedTimeIntegrationTests(context);
     registerRecordedReadBindingIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -12,6 +12,7 @@ export { integrationTestGraph } from "./fixtures";
 export { registerFulltextIntegrationTests } from "./fulltext";
 export { registerImportUniquenessIntegrationTests } from "./import-uniqueness";
 export { registerLateMaterializationIntegrationTests } from "./late-materialization";
+export { registerMigrateSchemaKindIntegrationTests } from "./migrate-schema-kinds";
 export { registerOrderingIntegrationTests } from "./ordering";
 export { registerPaginationIntegrationTests } from "./pagination";
 export { registerPredicateIntegrationTests } from "./predicates";

--- a/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
+++ b/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
@@ -150,28 +150,39 @@ export function registerMigrateSchemaKindIntegrationTests(
       ).toBe(0);
     });
 
-    it("never deletes rows of a kind that was dropped and re-added", async () => {
-      // History reconciliation re-derives the old removal forever; the cleanup
-      // is an unconditional kind-wide DELETE. Without the active-schema guard
-      // this destroys live data on both dialects.
+    it("refuses to re-add a kind whose cleanup is still pending", async () => {
+      // The old incarnation's rows are still in the base relations and reads
+      // filter only by (graph_id, kind), so re-adding would surface them
+      // alongside the new ones. Enforced identically on both dialects.
       const graph = graphFor("readd");
       const store = await context.createStore(graph);
       const evolved = await store.evolve(widgetExtension);
       await evolved.getNodeCollectionOrThrow("Widget").create({ label: "old" });
 
       const removed = await evolved.removeKinds(["Widget"]);
+      const error = await removed
+        .evolve(widgetExtension)
+        .catch((error_: unknown) => error_);
+
+      expect((error as Error).message).toContain("materializeRemovals");
+    });
+
+    it("carries no rows across a remove / cleanup / re-add cycle", async () => {
+      const graph = graphFor("readd_clean");
+      const store = await context.createStore(graph);
+      const evolved = await store.evolve(widgetExtension);
+      await evolved.getNodeCollectionOrThrow("Widget").create({ label: "old" });
+
+      const removed = await evolved.removeKinds(["Widget"]);
+      await removed.materializeRemovals();
+
       const readded = await removed.evolve(widgetExtension);
-      await readded
+      await readded.getNodeCollectionOrThrow("Widget").create({ label: "new" });
+
+      const rows = await readded
         .getNodeCollectionOrThrow("Widget")
-        .create({ label: "written after re-add" });
-
-      await readded.materializeRemovals();
-
-      expect(
-        await context
-          .getBackend()
-          .countNodesByKind({ graphId: graph.id, kind: "Widget" }),
-      ).toBeGreaterThan(0);
+        .find({ limit: 50 });
+      expect(rows.map((row) => row["label"])).toEqual(["new"]);
     });
   });
 }

--- a/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
+++ b/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { MigrationError } from "../../../src";
+import { defineGraph } from "../../../src/core/define-graph";
+import { defineNode } from "../../../src/core/node";
+import { defineGraphExtension } from "../../../src/graph-extension";
+import { getActiveSchema, migrateSchema } from "../../../src/schema";
+import { requireDefined } from "../../../src/utils/presence";
+import { type IntegrationTestContext } from "./test-context";
+
+async function activeVersion(
+  context: IntegrationTestContext,
+  id: string,
+): Promise<number> {
+  const active = await getActiveSchema(context.getBackend(), id);
+  return requireDefined(active, "active schema").version;
+}
+
+/**
+ * Cross-backend contract for `migrateSchema`'s kind handling.
+ *
+ * These are the guarantees that keep a schema commit from destroying data, and
+ * they are enforced with SQL the two dialects do not share — row-count probes,
+ * kind-wide deletes, and schema-history reconciliation. A SQLite-only test
+ * would happily certify a divergence, so the contract lives here.
+ */
+export function registerMigrateSchemaKindIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("migrateSchema kind handling", () => {
+    const Person = defineNode("Person", {
+      schema: z.object({ name: z.string() }),
+    });
+    const Company = defineNode("Company", {
+      schema: z.object({ name: z.string() }),
+    });
+
+    /** Distinct id per test so suites sharing one database cannot collide. */
+    function graphFor(suffix: string) {
+      return defineGraph({
+        id: `migrate_kinds_${suffix}`,
+        nodes: { Person: { type: Person }, Company: { type: Company } },
+        edges: {},
+      });
+    }
+
+    function withoutCompany(id: string) {
+      return defineGraph({
+        id,
+        nodes: { Person: { type: Person } },
+        edges: {},
+      });
+    }
+
+    const widgetExtension = defineGraphExtension({
+      nodes: { Widget: { properties: { label: { type: "string" } } } },
+    });
+
+    it("folds the persisted extension, preserving runtime kinds and their rows", async () => {
+      const graph = graphFor("fold");
+      const store = await context.createStore(graph);
+      const evolved = await store.evolve(widgetExtension);
+      const widget = await evolved
+        .getNodeCollectionOrThrow("Widget")
+        .create({ label: "kept" });
+
+      // The caller passes the compile-time graph; it does not know Widget exists.
+      await migrateSchema(
+        context.getBackend(),
+        graph,
+        await activeVersion(context, graph.id),
+      );
+
+      const active = requireDefined(
+        await getActiveSchema(context.getBackend(), graph.id),
+        "active schema",
+      );
+      expect(Object.keys(active.nodes)).toContain("Widget");
+
+      const reopened = await context.createStore(graph);
+      const found = await reopened
+        .getNodeCollectionOrThrow("Widget")
+        .getById(widget.id);
+      expect(found?.["label"]).toBe("kept");
+    });
+
+    it("refuses to drop a kind that still holds rows", async () => {
+      const graph = graphFor("refuse");
+      const store = await context.createStore(graph);
+      await store.nodes.Company.create({ name: "Initech" });
+
+      const error = await migrateSchema(
+        context.getBackend(),
+        withoutCompany(graph.id),
+        await activeVersion(context, graph.id),
+      ).catch((error_: unknown) => error_);
+
+      expect(error).toBeInstanceOf(MigrationError);
+      const details = (error as MigrationError).details;
+      if (details.reason !== "kind-removal") throw new Error("wrong reason");
+      expect(details.droppedKinds.nodes).toEqual(["Company"]);
+
+      // The refusal leaves the active version untouched.
+      const active = requireDefined(
+        await getActiveSchema(context.getBackend(), graph.id),
+        "active schema",
+      );
+      expect(Object.keys(active.nodes)).toContain("Company");
+    });
+
+    it("allows dropping an empty kind — the documented three-deploy flow", async () => {
+      const graph = graphFor("empty_drop");
+      await context.createStore(graph);
+
+      await migrateSchema(
+        context.getBackend(),
+        withoutCompany(graph.id),
+        await activeVersion(context, graph.id),
+      );
+
+      const active = requireDefined(
+        await getActiveSchema(context.getBackend(), graph.id),
+        "active schema",
+      );
+      expect(Object.keys(active.nodes)).not.toContain("Company");
+    });
+
+    it("discardDroppedKindRows commits, and the reconciler deletes the rows", async () => {
+      const graph = graphFor("discard");
+      const store = await context.createStore(graph);
+      await store.nodes.Company.create({ name: "Initech" });
+
+      await migrateSchema(
+        context.getBackend(),
+        withoutCompany(graph.id),
+        await activeVersion(context, graph.id),
+        { discardDroppedKindRows: true },
+      );
+
+      const reopened = await context.createStore(withoutCompany(graph.id));
+      await reopened.materializeRemovals();
+
+      expect(
+        await context.getBackend().countNodesByKind({
+          graphId: graph.id,
+          kind: "Company",
+          excludeDeleted: false,
+        }),
+      ).toBe(0);
+    });
+
+    it("never deletes rows of a kind that was dropped and re-added", async () => {
+      // History reconciliation re-derives the old removal forever; the cleanup
+      // is an unconditional kind-wide DELETE. Without the active-schema guard
+      // this destroys live data on both dialects.
+      const graph = graphFor("readd");
+      const store = await context.createStore(graph);
+      const evolved = await store.evolve(widgetExtension);
+      await evolved.getNodeCollectionOrThrow("Widget").create({ label: "old" });
+
+      const removed = await evolved.removeKinds(["Widget"]);
+      const readded = await removed.evolve(widgetExtension);
+      await readded
+        .getNodeCollectionOrThrow("Widget")
+        .create({ label: "written after re-add" });
+
+      await readded.materializeRemovals();
+
+      expect(
+        await context
+          .getBackend()
+          .countNodesByKind({ graphId: graph.id, kind: "Widget" }),
+      ).toBeGreaterThan(0);
+    });
+  });
+}

--- a/packages/typegraph/tests/kind-removal-readd-reconcile.test.ts
+++ b/packages/typegraph/tests/kind-removal-readd-reconcile.test.ts
@@ -1,24 +1,38 @@
 /**
- * A kind that is dropped and later re-added must not have its rows deleted by
- * a subsequent reconcile.
+ * Removing a kind and later re-adding it must not corrupt either incarnation.
  *
- * `materializeRemovals` re-derives removals by walking schema-version history,
- * comparing each consecutive pair of documents. That comparison is local to the
- * transition, so a kind removed at v3 is still discovered as "removed at v3"
- * even when v4 re-added it and applications have written new rows since. The
- * cleanup it queues is an unconditional `DELETE ... WHERE kind = ?`, so without
- * a guard the reconcile destroys live data belonging to a kind the active
- * schema declares.
+ * Two hazards, closed at different layers:
  *
- * The invariant: never delete rows of a kind the active schema still has.
+ * 1. **Re-add while cleanup is pending is refused.** The old rows are still in
+ *    the base relations and reads filter only by `(graph_id, kind)` — there is
+ *    no schema-generation boundary — so re-adding would make the previous
+ *    incarnation's rows visible alongside the new ones. `Store.evolve` refuses
+ *    until `materializeRemovals()` has run.
+ *
+ * 2. **Cleanup never deletes the rows of a live kind.** `materializeRemovals`
+ *    re-derives removals by walking schema history, comparing each consecutive
+ *    pair of documents, so a removal at v3 is still discovered after v4 re-added
+ *    the kind. Cleanup is an unconditional `DELETE ... WHERE kind = ?`, so
+ *    acting on it would destroy the new incarnation's data. The decline is
+ *    reported (`status: "skipped"`), not silent.
+ *
+ * The guard in (1) closes the common path. (2) still matters for a removal that
+ * never queued a row — a commit that dropped an empty kind, or a `removeKinds`
+ * that crashed before its queue write — where history reconciliation surfaces
+ * the removal only after the kind is live again.
  */
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import type { GraphBackend } from "../src/backend/types";
+import type { GraphDef } from "../src/core/define-graph";
 import { defineGraph } from "../src/core/define-graph";
 import { defineNode } from "../src/core/node";
+import { ConfigurationError } from "../src/errors";
 import { defineGraphExtension } from "../src/graph-extension";
+import { computeSchemaHash, serializeSchema } from "../src/schema/serializer";
 import { createStoreWithSchema } from "../src/store/store";
+import { requireDefined } from "../src/utils/presence";
 import { createTestBackend } from "./test-utils";
 
 const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
@@ -33,46 +47,97 @@ const widgetExtension = defineGraphExtension({
   nodes: { Widget: { properties: { label: { type: "string" } } } },
 });
 
+/**
+ * Commit a schema version directly, bypassing the removal queue — the state a
+ * `removeKinds()` crash leaves behind, and the one shape that can reach a live
+ * kind carrying a history-derived removal.
+ */
+async function commitWithoutQueueing<G extends GraphDef>(
+  backend: GraphBackend,
+  graph: G,
+  currentVersion: number,
+): Promise<void> {
+  const schema = serializeSchema(graph, currentVersion + 1);
+  await backend.commitSchemaVersion({
+    graphId: graph.id,
+    expected: { kind: "active", version: currentVersion },
+    version: currentVersion + 1,
+    schemaHash: await computeSchemaHash(schema),
+    schemaDoc: schema,
+  });
+}
+
 describe("removed-then-re-added kinds", () => {
-  it("does not delete rows written after a kind is re-added", async () => {
+  it("refuses to re-add a kind whose cleanup is still pending", async () => {
     const backend = createTestBackend();
     const [store] = await createStoreWithSchema(baseGraph, backend);
-
-    // Add the kind and write a row.
     const evolved = await store.evolve(widgetExtension);
     await evolved.getNodeCollectionOrThrow("Widget").create({ label: "old" });
 
-    // Remove it through the sanctioned path, which queues cleanup.
     const removed = await evolved.removeKinds(["Widget"]);
 
-    // Re-add it and write new data.
+    const error = await removed
+      .evolve(widgetExtension)
+      .catch((error_: unknown) => error_);
+
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect((error as ConfigurationError).message).toContain(
+      "materializeRemovals",
+    );
+  });
+
+  it("allows the re-add once cleanup has run, with no rows carried over", async () => {
+    // The documented cycle: remove -> materializeRemovals -> re-add.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(widgetExtension);
+    await evolved.getNodeCollectionOrThrow("Widget").create({ label: "old" });
+
+    const removed = await evolved.removeKinds(["Widget"]);
+    await removed.materializeRemovals();
+
     const readded = await removed.evolve(widgetExtension);
+    await readded.getNodeCollectionOrThrow("Widget").create({ label: "new" });
+
+    const rows = await readded
+      .getNodeCollectionOrThrow("Widget")
+      .find({ limit: 50 });
+    expect(rows.map((row) => row["label"])).toEqual(["new"]);
+  });
+
+  it("declines a history-derived removal for a kind that is live again", async () => {
+    // Reaches the guard the only way still open: a removal committed without a
+    // queue row, so nothing blocks the re-add and reconciliation surfaces the
+    // removal afterwards.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(widgetExtension);
+    await evolved.getNodeCollectionOrThrow("Widget").create({ label: "old" });
+
+    const activeVersion = requireDefined(
+      await backend.getActiveSchema(baseGraph.id),
+      "active schema",
+    ).version;
+    await commitWithoutQueueing(backend, baseGraph, activeVersion);
+
+    const [reopened] = await createStoreWithSchema(baseGraph, backend);
+    const readded = await reopened.evolve(widgetExtension);
     await readded
       .getNodeCollectionOrThrow("Widget")
       .create({ label: "written after re-add" });
 
-    // A routine reconcile must not touch the live kind — and must SAY it
-    // declined. A silent skip leaves the queue at a non-zero depth with
-    // nothing in the output explaining why, which an operator cannot tell
-    // apart from "nothing was pending".
     const result = await readded.materializeRemovals();
+
     const widgetEntry = result.results.find((entry) => entry.kind === "Widget");
-    // Narrowing on `status` is what makes `reason` reachable — the entry type
-    // is a union, so each outcome carries exactly its own payload.
     if (widgetEntry?.status !== "skipped") {
       throw new Error(`expected a skipped entry, got ${widgetEntry?.status}`);
     }
     expect(widgetEntry.reason).toBe("kind-is-live");
 
+    // The live incarnation's row survives — that is the point of the decline.
     expect(
       await backend.countNodesByKind({ graphId: baseGraph.id, kind: "Widget" }),
     ).toBeGreaterThan(0);
-    const survivors = await readded
-      .getNodeCollectionOrThrow("Widget")
-      .find({ limit: 10 });
-    expect(survivors.map((node) => node["label"])).toContain(
-      "written after re-add",
-    );
   });
 
   it("still cleans up a kind that stays removed", async () => {

--- a/packages/typegraph/tests/kind-removal-readd-reconcile.test.ts
+++ b/packages/typegraph/tests/kind-removal-readd-reconcile.test.ts
@@ -1,0 +1,92 @@
+/**
+ * A kind that is dropped and later re-added must not have its rows deleted by
+ * a subsequent reconcile.
+ *
+ * `materializeRemovals` re-derives removals by walking schema-version history,
+ * comparing each consecutive pair of documents. That comparison is local to the
+ * transition, so a kind removed at v3 is still discovered as "removed at v3"
+ * even when v4 re-added it and applications have written new rows since. The
+ * cleanup it queues is an unconditional `DELETE ... WHERE kind = ?`, so without
+ * a guard the reconcile destroys live data belonging to a kind the active
+ * schema declares.
+ *
+ * The invariant: never delete rows of a kind the active schema still has.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineGraph } from "../src/core/define-graph";
+import { defineNode } from "../src/core/node";
+import { defineGraphExtension } from "../src/graph-extension";
+import { createStoreWithSchema } from "../src/store/store";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
+
+const baseGraph = defineGraph({
+  id: "kind_readd_reconcile",
+  nodes: { Person: { type: Person } },
+  edges: {},
+});
+
+const widgetExtension = defineGraphExtension({
+  nodes: { Widget: { properties: { label: { type: "string" } } } },
+});
+
+describe("removed-then-re-added kinds", () => {
+  it("does not delete rows written after a kind is re-added", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+
+    // Add the kind and write a row.
+    const evolved = await store.evolve(widgetExtension);
+    await evolved.getNodeCollectionOrThrow("Widget").create({ label: "old" });
+
+    // Remove it through the sanctioned path, which queues cleanup.
+    const removed = await evolved.removeKinds(["Widget"]);
+
+    // Re-add it and write new data.
+    const readded = await removed.evolve(widgetExtension);
+    await readded
+      .getNodeCollectionOrThrow("Widget")
+      .create({ label: "written after re-add" });
+
+    // A routine reconcile must not touch the live kind — and must SAY it
+    // declined. A silent skip leaves the queue at a non-zero depth with
+    // nothing in the output explaining why, which an operator cannot tell
+    // apart from "nothing was pending".
+    const result = await readded.materializeRemovals();
+    const widgetEntry = result.results.find((entry) => entry.kind === "Widget");
+    expect(widgetEntry?.status).toBe("skipped");
+    expect(widgetEntry?.reason).toBe("kind-is-live");
+
+    expect(
+      await backend.countNodesByKind({ graphId: baseGraph.id, kind: "Widget" }),
+    ).toBeGreaterThan(0);
+    const survivors = await readded
+      .getNodeCollectionOrThrow("Widget")
+      .find({ limit: 10 });
+    expect(survivors.map((node) => node["label"])).toContain(
+      "written after re-add",
+    );
+  });
+
+  it("still cleans up a kind that stays removed", async () => {
+    // The guard must not disable legitimate cleanup.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(widgetExtension);
+    await evolved.getNodeCollectionOrThrow("Widget").create({ label: "gone" });
+
+    const removed = await evolved.removeKinds(["Widget"]);
+    await removed.materializeRemovals();
+
+    expect(
+      await backend.countNodesByKind({
+        graphId: baseGraph.id,
+        kind: "Widget",
+        excludeDeleted: false,
+      }),
+    ).toBe(0);
+  });
+});

--- a/packages/typegraph/tests/kind-removal-readd-reconcile.test.ts
+++ b/packages/typegraph/tests/kind-removal-readd-reconcile.test.ts
@@ -57,8 +57,12 @@ describe("removed-then-re-added kinds", () => {
     // apart from "nothing was pending".
     const result = await readded.materializeRemovals();
     const widgetEntry = result.results.find((entry) => entry.kind === "Widget");
-    expect(widgetEntry?.status).toBe("skipped");
-    expect(widgetEntry?.reason).toBe("kind-is-live");
+    // Narrowing on `status` is what makes `reason` reachable — the entry type
+    // is a union, so each outcome carries exactly its own payload.
+    if (widgetEntry?.status !== "skipped") {
+      throw new Error(`expected a skipped entry, got ${widgetEntry?.status}`);
+    }
+    expect(widgetEntry.reason).toBe("kind-is-live");
 
     expect(
       await backend.countNodesByKind({ graphId: baseGraph.id, kind: "Widget" }),

--- a/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
+++ b/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
@@ -1,0 +1,302 @@
+/**
+ * `migrateSchema` must never orphan data.
+ *
+ * Two guarantees, both regressions of a real data-loss incident (#322):
+ *
+ * 1. **Extension fold.** Kinds committed at runtime by `Store.evolve()` live
+ *    in `schema_doc.extension`, not in the caller's compile-time graph.
+ *    Committing the caller's graph verbatim erased them from the active
+ *    document while their rows stayed in `typegraph_nodes` — readable by
+ *    nothing, and with `typegraph_kind_removals` empty so no cleanup was ever
+ *    queued.
+ *
+ * 2. **Drop refusal.** Removing a kind is `Store.removeKinds()`'s job; it
+ *    queues the data-cleanup rows that make the removal reconcilable. A
+ *    schema commit must not do it as a side effect.
+ *
+ * The path that produced the incident is exercised end-to-end in
+ * "the reported incident": open → evolve → write → breaking change →
+ * `MigrationError` → follow the error's own advice.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { MigrationError } from "../src";
+import { defineGraph } from "../src/core/define-graph";
+import { defineEdge } from "../src/core/edge";
+import { defineNode } from "../src/core/node";
+import { defineGraphExtension } from "../src/graph-extension";
+import { getActiveSchema, migrateSchema } from "../src/schema";
+import type { SerializedSchema } from "../src/schema/types";
+import { createStoreWithSchema } from "../src/store/store";
+import { requireDefined } from "../src/utils/presence";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ since: z.string() }),
+});
+
+/** The compile-time graph, as an application would declare it. */
+const baseGraph = defineGraph({
+  id: "migrate_kind_preservation",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: { worksAt: { type: worksAt, from: [Person], to: [Company] } },
+});
+
+/**
+ * The same graph after a breaking property change — the documented reason to
+ * reach for `migrateSchema` ("force the contract deploy"). Removing a
+ * required property is breaking; removing a *kind* is not what this is.
+ */
+const baseGraphWithRenamedProperty = defineGraph({
+  id: baseGraph.id,
+  nodes: {
+    Person: {
+      type: defineNode("Person", {
+        schema: z.object({ fullName: z.string() }),
+      }),
+    },
+    Company: { type: Company },
+  },
+  edges: { worksAt: { type: worksAt, from: [Person], to: [Company] } },
+});
+
+const widgetExtension = defineGraphExtension({
+  nodes: {
+    Widget: { properties: { label: { type: "string" } } },
+  },
+});
+
+async function activeSchema(
+  backend: ReturnType<typeof createTestBackend>,
+): Promise<SerializedSchema> {
+  const active = await getActiveSchema(backend, baseGraph.id);
+  return requireDefined(active, "active schema");
+}
+
+async function activeKindNames(
+  backend: ReturnType<typeof createTestBackend>,
+): Promise<Readonly<{ nodes: readonly string[]; edges: readonly string[] }>> {
+  const active = await activeSchema(backend);
+  return {
+    nodes: Object.keys(active.nodes).toSorted(),
+    edges: Object.keys(active.edges).toSorted(),
+  };
+}
+
+async function activeVersion(
+  backend: ReturnType<typeof createTestBackend>,
+): Promise<number> {
+  const active = await activeSchema(backend);
+  return active.version;
+}
+
+describe("migrateSchema — graph-extension fold", () => {
+  it("preserves runtime-committed kinds when handed the compile-time graph", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    await store.evolve(widgetExtension);
+
+    // The caller passes the graph they have — the compile-time one. They do
+    // not know `Widget` exists; that is the whole point.
+    await migrateSchema(backend, baseGraph, await activeVersion(backend));
+
+    const kinds = await activeKindNames(backend);
+    expect(kinds.nodes).toContain("Widget");
+    // ...and the folded document still drives a working Store.
+    const [reopened] = await createStoreWithSchema(baseGraph, backend);
+    expect(reopened.registry.hasNodeType("Widget")).toBe(true);
+  });
+
+  it("keeps rows of a runtime-committed kind readable after the migration", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(widgetExtension);
+    const widget = await evolved
+      .getNodeCollectionOrThrow("Widget")
+      .create({ label: "left-handed" });
+
+    await migrateSchema(backend, baseGraph, await activeVersion(backend));
+
+    const [reopened] = await createStoreWithSchema(baseGraph, backend);
+    const found = await reopened
+      .getNodeCollectionOrThrow("Widget")
+      .getById(widget.id);
+    expect(found?.["label"]).toBe("left-handed");
+  });
+
+  it("the reported incident: MigrationError recovery no longer orphans kinds", async () => {
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(widgetExtension);
+    const widget = await evolved
+      .getNodeCollectionOrThrow("Widget")
+      .create({ label: "still here" });
+
+    // A breaking compile-time change: re-opening throws and points the
+    // caller at migrateSchema().
+    const error = await createStoreWithSchema(
+      baseGraphWithRenamedProperty,
+      backend,
+    ).catch((error_: unknown) => error_);
+    expect(error).toBeInstanceOf(MigrationError);
+    const fromVersion = (error as MigrationError).details.fromVersion;
+
+    // Do exactly what the error says.
+    await migrateSchema(backend, baseGraphWithRenamedProperty, fromVersion);
+
+    const kinds = await activeKindNames(backend);
+    expect(kinds.nodes).toContain("Widget");
+    const [reopened] = await createStoreWithSchema(
+      baseGraphWithRenamedProperty,
+      backend,
+    );
+    expect(
+      await reopened.getNodeCollectionOrThrow("Widget").getById(widget.id),
+    ).toBeDefined();
+  });
+});
+
+describe("migrateSchema — kind-drop refusal", () => {
+  /** The compile-time graph minus `Company` and the edge that needs it. */
+  const graphWithoutCompany = defineGraph({
+    id: baseGraph.id,
+    nodes: { Person: { type: Person } },
+    edges: {},
+  });
+
+  it("refuses a commit that drops a node kind, naming it", async () => {
+    const backend = createTestBackend();
+    await createStoreWithSchema(baseGraph, backend);
+
+    const error = await migrateSchema(backend, graphWithoutCompany, 1).catch(
+      (error_: unknown) => error_,
+    );
+
+    expect(error).toBeInstanceOf(MigrationError);
+    const details = (error as MigrationError).details;
+    expect(details.reason).toBe("kind-removal");
+    expect(details.droppedKinds).toEqual({
+      nodes: ["Company"],
+      edges: ["worksAt"],
+    });
+    expect((error as MigrationError).message).toContain('node "Company"');
+    expect((error as MigrationError).message).toContain("Store.removeKinds()");
+  });
+
+  it("leaves the active version untouched when it refuses", async () => {
+    const backend = createTestBackend();
+    await createStoreWithSchema(baseGraph, backend);
+
+    await expect(
+      migrateSchema(backend, graphWithoutCompany, 1),
+    ).rejects.toThrow(MigrationError);
+
+    const active = await getActiveSchema(backend, baseGraph.id);
+    expect(active?.version).toBe(1);
+    expect(Object.keys(requireDefined(active, "active").nodes)).toContain(
+      "Company",
+    );
+  });
+
+  it("refuses a commit that drops only an edge kind", async () => {
+    const backend = createTestBackend();
+    await createStoreWithSchema(baseGraph, backend);
+
+    const graphWithoutEdge = defineGraph({
+      id: baseGraph.id,
+      nodes: { Person: { type: Person }, Company: { type: Company } },
+      edges: {},
+    });
+
+    const error = await migrateSchema(backend, graphWithoutEdge, 1).catch(
+      (error_: unknown) => error_,
+    );
+    expect((error as MigrationError).details.droppedKinds).toEqual({
+      nodes: [],
+      edges: ["worksAt"],
+    });
+  });
+
+  it("refuses a commit that drops a runtime-committed kind the caller re-declared away", async () => {
+    // `allowKindRemoval` aside, the fold means a compile-time graph can never
+    // drop an extension kind by omission. It takes an explicit removal —
+    // which is `Store.removeKinds()`'s job.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(widgetExtension);
+    const afterRemoval = await evolved.removeKinds(["Widget"]);
+
+    expect(afterRemoval.registry.hasNodeType("Widget")).toBe(false);
+    const kinds = await activeKindNames(backend);
+    expect(kinds.nodes).not.toContain("Widget");
+  });
+
+  it("commits the drop when allowKindRemoval is set", async () => {
+    const backend = createTestBackend();
+    await createStoreWithSchema(baseGraph, backend);
+
+    const version = await migrateSchema(backend, graphWithoutCompany, 1, {
+      allowKindRemoval: true,
+    });
+
+    expect(version).toBe(2);
+    expect(await activeKindNames(backend)).toEqual({
+      nodes: ["Person"],
+      edges: [],
+    });
+  });
+});
+
+describe("migrateSchema — unaffected paths", () => {
+  it("still forces a breaking property change (the documented use)", async () => {
+    const backend = createTestBackend();
+    await createStoreWithSchema(baseGraph, backend);
+
+    const version = await migrateSchema(
+      backend,
+      baseGraphWithRenamedProperty,
+      1,
+    );
+
+    expect(version).toBe(2);
+    const active = await activeSchema(backend);
+    const personProperties = active.nodes["Person"]?.properties as
+      Readonly<{ properties?: Readonly<Record<string, unknown>> }> | undefined;
+    expect(Object.keys(personProperties?.properties ?? {})).toEqual([
+      "fullName",
+    ]);
+  });
+
+  it("commits an additive change without reading a kind as dropped", async () => {
+    const backend = createTestBackend();
+    await createStoreWithSchema(baseGraph, backend);
+
+    const graphWithExtraKind = defineGraph({
+      id: baseGraph.id,
+      nodes: {
+        Person: { type: Person },
+        Company: { type: Company },
+        Project: {
+          type: defineNode("Project", {
+            schema: z.object({ name: z.string() }),
+          }),
+        },
+      },
+      edges: { worksAt: { type: worksAt, from: [Person], to: [Company] } },
+    });
+
+    await migrateSchema(backend, graphWithExtraKind, 1);
+
+    const kinds = await activeKindNames(backend);
+    expect(kinds.nodes).toEqual(["Company", "Person", "Project"]);
+  });
+});

--- a/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
+++ b/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
@@ -100,23 +100,7 @@ async function activeVersion(
 }
 
 describe("migrateSchema — graph-extension fold", () => {
-  it("preserves runtime-committed kinds when handed the compile-time graph", async () => {
-    const backend = createTestBackend();
-    const [store] = await createStoreWithSchema(baseGraph, backend);
-    await store.evolve(widgetExtension);
-
-    // The caller passes the graph they have — the compile-time one. They do
-    // not know `Widget` exists; that is the whole point.
-    await migrateSchema(backend, baseGraph, await activeVersion(backend));
-
-    const kinds = await activeKindNames(backend);
-    expect(kinds.nodes).toContain("Widget");
-    // ...and the folded document still drives a working Store.
-    const [reopened] = await createStoreWithSchema(baseGraph, backend);
-    expect(reopened.registry.hasNodeType("Widget")).toBe(true);
-  });
-
-  it("keeps rows of a runtime-committed kind readable after the migration", async () => {
+  it("preserves runtime-committed kinds, and their rows, when handed the compile-time graph", async () => {
     const backend = createTestBackend();
     const [store] = await createStoreWithSchema(baseGraph, backend);
     const evolved = await store.evolve(widgetExtension);
@@ -124,13 +108,33 @@ describe("migrateSchema — graph-extension fold", () => {
       .getNodeCollectionOrThrow("Widget")
       .create({ label: "left-handed" });
 
+    // The caller passes the graph they have — the compile-time one. They do
+    // not know `Widget` exists; that is the whole point.
     await migrateSchema(backend, baseGraph, await activeVersion(backend));
 
+    const kinds = await activeKindNames(backend);
+    expect(kinds.nodes).toContain("Widget");
+
+    // ...and the folded document still drives a working Store whose rows read.
     const [reopened] = await createStoreWithSchema(baseGraph, backend);
+    expect(reopened.registry.hasNodeType("Widget")).toBe(true);
     const found = await reopened
       .getNodeCollectionOrThrow("Widget")
       .getById(widget.id);
     expect(found?.["label"]).toBe("left-handed");
+  });
+
+  it("preserves the persisted deprecated-kind set", async () => {
+    // `deprecatedKinds` rides the same stored document as the extension, so
+    // the verbatim commit erased it too.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    await store.deprecateKinds(["Company"]);
+
+    await migrateSchema(backend, baseGraph, await activeVersion(backend));
+
+    const active = await activeSchema(backend);
+    expect(active.deprecatedKinds).toEqual(["Company"]);
   });
 
   it("the reported incident: MigrationError recovery no longer orphans kinds", async () => {
@@ -165,7 +169,7 @@ describe("migrateSchema — graph-extension fold", () => {
   });
 });
 
-describe("migrateSchema — kind-drop refusal", () => {
+describe("migrateSchema — populated-kind-drop refusal", () => {
   /** The compile-time graph minus `Company` and the edge that needs it. */
   const graphWithoutCompany = defineGraph({
     id: baseGraph.id,
@@ -173,9 +177,17 @@ describe("migrateSchema — kind-drop refusal", () => {
     edges: {},
   });
 
-  it("refuses a commit that drops a node kind, naming it", async () => {
+  /** Give `Company` a row so dropping it would strand data. */
+  async function seedCompany(
+    backend: ReturnType<typeof createTestBackend>,
+  ): Promise<void> {
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    await store.nodes.Company.create({ name: "Initech" });
+  }
+
+  it("refuses a commit that drops a populated node kind, naming it and its row count", async () => {
     const backend = createTestBackend();
-    await createStoreWithSchema(baseGraph, backend);
+    await seedCompany(backend);
 
     const error = await migrateSchema(backend, graphWithoutCompany, 1).catch(
       (error_: unknown) => error_,
@@ -184,32 +196,22 @@ describe("migrateSchema — kind-drop refusal", () => {
     expect(error).toBeInstanceOf(MigrationError);
     const details = (error as MigrationError).details;
     expect(details.reason).toBe("kind-removal");
-    expect(details.droppedKinds).toEqual({
-      nodes: ["Company"],
-      edges: ["worksAt"],
-    });
-    expect((error as MigrationError).message).toContain('node "Company"');
-    expect((error as MigrationError).message).toContain("Store.removeKinds()");
+    // `worksAt` is dropped too, but it has no rows to strand.
+    expect(details.droppedKinds).toEqual({ nodes: ["Company"], edges: [] });
+    expect((error as MigrationError).message).toContain('node "Company" (1)');
+
+    // ...and the refusal leaves the active version untouched.
+    const active = await activeSchema(backend);
+    expect(active.version).toBe(1);
+    expect(Object.keys(active.nodes)).toContain("Company");
   });
 
-  it("leaves the active version untouched when it refuses", async () => {
+  it("refuses a commit that drops a populated edge kind", async () => {
     const backend = createTestBackend();
-    await createStoreWithSchema(baseGraph, backend);
-
-    await expect(
-      migrateSchema(backend, graphWithoutCompany, 1),
-    ).rejects.toThrow(MigrationError);
-
-    const active = await getActiveSchema(backend, baseGraph.id);
-    expect(active?.version).toBe(1);
-    expect(Object.keys(requireDefined(active, "active").nodes)).toContain(
-      "Company",
-    );
-  });
-
-  it("refuses a commit that drops only an edge kind", async () => {
-    const backend = createTestBackend();
-    await createStoreWithSchema(baseGraph, backend);
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const initech = await store.nodes.Company.create({ name: "Initech" });
+    await store.edges.worksAt.create(alice, initech, { since: "2024" });
 
     const graphWithoutEdge = defineGraph({
       id: baseGraph.id,
@@ -226,33 +228,48 @@ describe("migrateSchema — kind-drop refusal", () => {
     });
   });
 
-  it("refuses a commit that drops a runtime-committed kind the caller re-declared away", async () => {
-    // `allowKindRemoval` aside, the fold means a compile-time graph can never
-    // drop an extension kind by omission. It takes an explicit removal —
-    // which is `Store.removeKinds()`'s job.
-    const backend = createTestBackend();
-    const [store] = await createStoreWithSchema(baseGraph, backend);
-    const evolved = await store.evolve(widgetExtension);
-    const afterRemoval = await evolved.removeKinds(["Widget"]);
-
-    expect(afterRemoval.registry.hasNodeType("Widget")).toBe(false);
-    const kinds = await activeKindNames(backend);
-    expect(kinds.nodes).not.toContain("Widget");
-  });
-
-  it("commits the drop when allowKindRemoval is set", async () => {
+  it("allows dropping an EMPTY kind — the documented three-deploy removal", async () => {
+    // Deploy 2 deleted the rows; Deploy 3 drops the kind from defineGraph()
+    // and migrates. Nothing is stranded, so nothing is refused.
     const backend = createTestBackend();
     await createStoreWithSchema(baseGraph, backend);
+
+    const version = await migrateSchema(backend, graphWithoutCompany, 1);
+
+    expect(version).toBe(2);
+    const kinds = await activeKindNames(backend);
+    expect(kinds).toEqual({ nodes: ["Person"], edges: [] });
+  });
+
+  it("allows dropping a kind whose rows were deleted first", async () => {
+    // Deploy 2 of the documented flow. The probe counts live rows only —
+    // same `excludeDeleted` default `Store.evolve`'s tightening probe uses —
+    // so a soft delete is enough to unblock Deploy 3.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const initech = await store.nodes.Company.create({ name: "Initech" });
+    await expect(
+      migrateSchema(backend, graphWithoutCompany, 1),
+    ).rejects.toThrow(MigrationError);
+
+    await store.nodes.Company.delete(initech.id);
+
+    await expect(migrateSchema(backend, graphWithoutCompany, 1)).resolves.toBe(
+      2,
+    );
+  });
+
+  it("commits the orphaning drop when allowKindRemoval is set", async () => {
+    const backend = createTestBackend();
+    await seedCompany(backend);
 
     const version = await migrateSchema(backend, graphWithoutCompany, 1, {
       allowKindRemoval: true,
     });
 
     expect(version).toBe(2);
-    expect(await activeKindNames(backend)).toEqual({
-      nodes: ["Person"],
-      edges: [],
-    });
+    const kinds = await activeKindNames(backend);
+    expect(kinds).toEqual({ nodes: ["Person"], edges: [] });
   });
 });
 

--- a/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
+++ b/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
@@ -124,6 +124,31 @@ describe("migrateSchema — graph-extension fold", () => {
     expect(found?.["label"]).toBe("left-handed");
   });
 
+  it("a stale store's merged graph cannot resurrect a kind another writer removed", async () => {
+    // `store.graph` is public and returns the MERGED graph, so passing it to
+    // migrateSchema is a reachable call. If the fold unioned that stale
+    // extension slice back in, `removeKinds` would be silently undone — and
+    // worse, the resurrected kind would keep its queued `kind_removals` row,
+    // so the next `materializeRemovals` would delete the rows of a kind the
+    // active schema calls live. The persisted document is the sole authority.
+    const backend = createTestBackend();
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(widgetExtension);
+    await evolved.getNodeCollectionOrThrow("Widget").create({ label: "keep" });
+    const staleGraph = evolved.graph;
+
+    // Another writer removes the kind through the sanctioned path.
+    await evolved.removeKinds(["Widget"]);
+    const afterRemoval = await activeKindNames(backend);
+    expect(afterRemoval.nodes).not.toContain("Widget");
+
+    // The stale holder migrates using the graph it still has.
+    await migrateSchema(backend, staleGraph, await activeVersion(backend));
+
+    const final = await activeKindNames(backend);
+    expect(final.nodes).not.toContain("Widget");
+  });
+
   it("preserves the persisted deprecated-kind set", async () => {
     // `deprecatedKinds` rides the same stored document as the extension, so
     // the verbatim commit erased it too.
@@ -241,7 +266,7 @@ describe("migrateSchema — populated-kind-drop refusal", () => {
     expect(kinds).toEqual({ nodes: ["Person"], edges: [] });
   });
 
-  it("allows dropping a kind whose rows were deleted first", async () => {
+  it("allows dropping a kind whose rows were deleted first, and queues their cleanup", async () => {
     // Deploy 2 of the documented flow. The probe counts live rows only —
     // same `excludeDeleted` default `Store.evolve`'s tightening probe uses —
     // so a soft delete is enough to unblock Deploy 3.
@@ -257,14 +282,53 @@ describe("migrateSchema — populated-kind-drop refusal", () => {
     await expect(migrateSchema(backend, graphWithoutCompany, 1)).resolves.toBe(
       2,
     );
+
+    // The soft-deleted row survives the commit, and is reclaimable: no
+    // `typegraph_kind_removals` row is written here, but `materializeRemovals`
+    // re-derives removals by walking schema history, so the next reconcile
+    // finds the dropped kind and clears it. Permitting the drop does not
+    // strand the tombstone permanently.
+    const [reopened] = await createStoreWithSchema(
+      graphWithoutCompany,
+      backend,
+    );
+    const reclaimed = await reopened.materializeRemovals();
+    expect(
+      reclaimed.results.find((entry) => entry.kind === "Company")?.status,
+    ).toBe("removed");
+    expect(
+      await backend.countNodesByKind({
+        graphId: baseGraph.id,
+        kind: "Company",
+        excludeDeleted: false,
+      }),
+    ).toBe(0);
   });
 
-  it("commits the orphaning drop when allowKindRemoval is set", async () => {
+  it("discardDroppedKindRows does not fabricate a cleanup mandate", async () => {
+    // The flag means "commit anyway", not "queue a hard delete". Writing a
+    // removal row here would let a routine reconcile destroy live rows on a
+    // path whose whole purpose is the caller taking responsibility for them.
+    const backend = createTestBackend();
+    await seedCompany(backend);
+
+    await migrateSchema(backend, graphWithoutCompany, 1, {
+      discardDroppedKindRows: true,
+    });
+
+    const pending = await requireDefined(
+      backend.getPendingKindRemovals,
+      "getPendingKindRemovals",
+    )(baseGraph.id);
+    expect(pending.filter((row) => row.kindName === "Company")).toEqual([]);
+  });
+
+  it("commits the orphaning drop when discardDroppedKindRows is set", async () => {
     const backend = createTestBackend();
     await seedCompany(backend);
 
     const version = await migrateSchema(backend, graphWithoutCompany, 1, {
-      allowKindRemoval: true,
+      discardDroppedKindRows: true,
     });
 
     expect(version).toBe(2);

--- a/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
+++ b/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
@@ -223,7 +223,9 @@ describe("migrateSchema — populated-kind-drop refusal", () => {
 
     expect(error).toBeInstanceOf(MigrationError);
     const details = (error as MigrationError).details;
-    expect(details.reason).toBe("kind-removal");
+    // Narrowing on `reason` is what makes `droppedKinds` reachable — the
+    // details type is a discriminated union, not one shape with optionals.
+    if (details.reason !== "kind-removal") throw new Error("wrong reason");
     // `worksAt` is dropped too, but it has no rows to strand.
     expect(details.droppedKinds).toEqual({ nodes: ["Company"], edges: [] });
     expect((error as MigrationError).message).toContain('node "Company" (1)');
@@ -250,10 +252,9 @@ describe("migrateSchema — populated-kind-drop refusal", () => {
     const error = await migrateSchema(backend, graphWithoutEdge, 1).catch(
       (error_: unknown) => error_,
     );
-    expect((error as MigrationError).details.droppedKinds).toEqual({
-      nodes: [],
-      edges: ["worksAt"],
-    });
+    const edgeDetails = (error as MigrationError).details;
+    if (edgeDetails.reason !== "kind-removal") throw new Error("wrong reason");
+    expect(edgeDetails.droppedKinds).toEqual({ nodes: [], edges: ["worksAt"] });
   });
 
   it("allows dropping an EMPTY kind — the documented three-deploy removal", async () => {

--- a/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
+++ b/packages/typegraph/tests/migrate-schema-kind-preservation.test.ts
@@ -1,18 +1,21 @@
 /**
- * `migrateSchema` must never orphan data.
+ * `migrateSchema` must never destroy data as a side effect.
  *
  * Two guarantees, both regressions of a real data-loss incident (#322):
  *
  * 1. **Extension fold.** Kinds committed at runtime by `Store.evolve()` live
  *    in `schema_doc.extension`, not in the caller's compile-time graph.
  *    Committing the caller's graph verbatim erased them from the active
- *    document while their rows stayed in `typegraph_nodes` — readable by
- *    nothing, and with `typegraph_kind_removals` empty so no cleanup was ever
- *    queued.
+ *    document while their rows stayed in `typegraph_nodes`, readable by
+ *    nothing. The persisted document is the sole authority, so a *stale*
+ *    graph cannot resurrect a kind another writer removed either.
  *
- * 2. **Drop refusal.** Removing a kind is `Store.removeKinds()`'s job; it
- *    queues the data-cleanup rows that make the removal reconcilable. A
- *    schema commit must not do it as a side effect.
+ * 2. **Drop refusal.** A commit that drops a kind still holding rows is
+ *    refused. Committing makes those rows unreachable, and the next
+ *    `materializeRemovals` — which re-derives removals by walking schema
+ *    history — deletes them, so the commit is the point of no return.
+ *    Dropping an *empty* kind is permitted: that is Deploy 3 of the
+ *    documented three-deploy removal flow.
  *
  * The path that produced the incident is exercised end-to-end in
  * "the reported incident": open → evolve → write → breaking change →
@@ -266,7 +269,7 @@ describe("migrateSchema — populated-kind-drop refusal", () => {
     expect(kinds).toEqual({ nodes: ["Person"], edges: [] });
   });
 
-  it("allows dropping a kind whose rows were deleted first, and queues their cleanup", async () => {
+  it("allows dropping a kind whose rows were deleted first, and the reconciler reclaims the tombstones", async () => {
     // Deploy 2 of the documented flow. The probe counts live rows only —
     // same `excludeDeleted` default `Store.evolve`'s tightening probe uses —
     // so a soft delete is enough to unblock Deploy 3.
@@ -296,6 +299,33 @@ describe("migrateSchema — populated-kind-drop refusal", () => {
     expect(
       reclaimed.results.find((entry) => entry.kind === "Company")?.status,
     ).toBe("removed");
+    expect(
+      await backend.countNodesByKind({
+        graphId: baseGraph.id,
+        kind: "Company",
+        excludeDeleted: false,
+      }),
+    ).toBe(0);
+  });
+
+  it("discardDroppedKindRows: the rows really are deleted by the next reconcile", async () => {
+    // This is the claim the flag's name and its rewritten docs rest on, and
+    // an earlier revision of this PR asserted the opposite — so pin it.
+    // No `typegraph_kind_removals` row is written on this path; the reconciler
+    // re-derives the removal from schema history and deletes anyway.
+    const backend = createTestBackend();
+    await seedCompany(backend);
+
+    await migrateSchema(backend, graphWithoutCompany, 1, {
+      discardDroppedKindRows: true,
+    });
+
+    const [reopened] = await createStoreWithSchema(
+      graphWithoutCompany,
+      backend,
+    );
+    await reopened.materializeRemovals();
+
     expect(
       await backend.countNodesByKind({
         graphId: baseGraph.id,

--- a/packages/typegraph/tests/schema-preflight.test.ts
+++ b/packages/typegraph/tests/schema-preflight.test.ts
@@ -173,6 +173,12 @@ describe("MigrationError discriminant", () => {
 
     // The attached diff carries the additive-vs-incompatible decision, so a
     // caller never has to re-query or read the sentence.
+    if (
+      migrationError.details.reason !== "schema-behind" &&
+      migrationError.details.reason !== "breaking-change"
+    ) {
+      throw new Error(`unexpected reason: ${migrationError.details.reason}`);
+    }
     const diff = requireDefined(migrationError.details.diff);
     expect(diff.hasBreakingChanges).toBe(true);
     expect(classifySchemaChanges(diff)).toBe("incompatible");
@@ -193,6 +199,12 @@ describe("MigrationError discriminant", () => {
     const migrationError = thrown as MigrationError;
     // Same reason as the breaking case — the diff is what separates them.
     expect(migrationError.details.reason).toBe("schema-behind");
+    if (
+      migrationError.details.reason !== "schema-behind" &&
+      migrationError.details.reason !== "breaking-change"
+    ) {
+      throw new Error(`unexpected reason: ${migrationError.details.reason}`);
+    }
     const diff = requireDefined(migrationError.details.diff);
     expect(diff.hasBreakingChanges).toBe(false);
     expect(classifySchemaChanges(diff)).toBe("additive");

--- a/packages/typegraph/tests/store-remove-kinds.test.ts
+++ b/packages/typegraph/tests/store-remove-kinds.test.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 
 import { defineEdge, defineGraph, defineNode, KindNotFoundError } from "../src";
 import type { GraphBackend } from "../src/backend/types";
+import type { GraphDef } from "../src/core/define-graph";
 import { RECORDED_MAX_REVISION } from "../src/core/temporal";
 import {
   defineGraphExtension,
@@ -32,11 +33,37 @@ import { createSqlSchema } from "../src/query/compiler/schema";
 import { sql } from "../src/query/sql-fragment";
 import { asCompiledRowsSql } from "../src/query/sql-intent";
 import { migrateSchema } from "../src/schema/manager";
+import { computeSchemaHash, serializeSchema } from "../src/schema/serializer";
 import { createStoreWithSchema } from "../src/store/store";
 import { requireDefined } from "../src/utils/presence";
 import { createTestBackend } from "./test-utils";
 
 type CountRow = Readonly<{ count: unknown }>;
+
+/**
+ * Reproduce the `removeKinds()` crash window: the schema commit lands, the
+ * `typegraph_kind_removals` queue write does not.
+ *
+ * Goes through `backend.commitSchemaVersion` — the same primitive
+ * `removeKinds()` commits through — rather than `migrateSchema()`, which
+ * cannot express this state: it folds the persisted graph extension back
+ * into the supplied graph, so an extension kind can never be dropped through
+ * it, and refuses kind-dropping commits outright.
+ */
+async function commitCrashedRemoval<G extends GraphDef>(
+  backend: GraphBackend,
+  graph: G,
+  currentVersion: number,
+): Promise<void> {
+  const schema = serializeSchema(graph, currentVersion + 1);
+  await backend.commitSchemaVersion({
+    graphId: graph.id,
+    expected: { kind: "active", version: currentVersion },
+    version: currentVersion + 1,
+    schemaHash: await computeSchemaHash(schema),
+    schemaDoc: schema,
+  });
+}
 
 async function countOpenRecordedNodeRows(
   backend: GraphBackend,
@@ -459,15 +486,15 @@ describe("Store.materializeRemovals", () => {
     ).toBe(2);
 
     // Simulate the crash window: commit the schema diff (Tag removed)
-    // through `migrateSchema` directly, bypassing `removeKinds` and
-    // its queue write. baseGraph's compile-time slice has Person only;
+    // through the backend primitive, bypassing `removeKinds` and its
+    // queue write. baseGraph's compile-time slice has Person only;
     // committing it as the new active schema is structurally
     // equivalent to a successful Tag removal that crashed before the
     // queue insert.
     const evolvedVersion = requireDefined(
       await backend.getActiveSchema(baseGraph.id),
     ).version;
-    await migrateSchema(backend, baseGraph, evolvedVersion);
+    await commitCrashedRemoval(backend, baseGraph, evolvedVersion);
 
     // The queue is empty (the crash window). Tag rows are orphaned
     // because the schema doesn't reference Tag any more.
@@ -531,7 +558,7 @@ describe("Store.materializeRemovals", () => {
     const versionBeforeRemoveCrash = requireDefined(
       await backend.getActiveSchema(baseGraph.id),
     ).version;
-    await migrateSchema(backend, baseGraph, versionBeforeRemoveCrash);
+    await commitCrashedRemoval(backend, baseGraph, versionBeforeRemoveCrash);
 
     const pendingAfterCrash = await requireDefined(
       backend.getPendingKindRemovals,


### PR DESCRIPTION
Closes #322

## The bug

`migrateSchema(backend, graph, currentVersion)` committed `graph` verbatim — no persisted-graph-extension fold, no drop guard.

Kinds committed at runtime by `Store.evolve()` live in `schema_doc.extension`, not in the compile-time graph. So a caller passing the graph they hand to `createStoreWithSchema` erased every one of them from the active schema document while their rows stayed in `typegraph_nodes` / `typegraph_edges`, readable by nothing. The persisted `deprecatedKinds` set was erased the same way.

This was reachable by following the library's own advice. The `MigrationError` raised for a breaking change said:

> Use `getSchemaChanges()` to review, then `migrateSchema()` to apply.

Doing exactly that, with the graph you already have, destroyed the schema record of every `evolve()`-committed kind. Observed on a real database: seven runtime kinds present in versions 3–6, absent from v7 onward, no removal rows, 21 live nodes unreachable, and the product rendering the data as empty.

`migrateSchema` was the last commit path that did not fold the extension — `createStoreWithSchema`, `Store.evolve`, `Store.removeKinds`, and `getSchemaChanges` all already did.

## The fix

### 1. Fold the persisted graph extension

Reuses the existing `loadAndMergeGraphExtensionDocument`. Callers pass the graph they have and do not need to know the extension exists. This also carries `deprecatedKinds` through, a second silent loss nothing had covered.

The fold now strips the supplied graph's own extension slice before applying the stored one, so the committed document is a function of the database alone. Without that, `migrateSchema(backend, store.graph, v)` — `store.graph` is public and returns the merged graph — unions a stale slice back in and silently undoes another writer's `Store.removeKinds()`, leaving a kind the schema calls live while its `typegraph_kind_removals` row stays queued against an unconditional `DELETE ... WHERE kind = ?`. `Store.#catchUpToStored` has stripped for exactly this reason; the schema layer now matches it. Stripping is a no-op for compile-time graphs, so the other callers are unaffected.

### 2. Refuse a commit that would destroy rows

`MigrationError` with the `details.reason === "kind-removal"` discriminant and `details.droppedKinds` naming them, plus row counts in the message.

The guard targets the harm, not the syntactic operation: it refuses only when a dropped kind **still holds rows**, probed with `countNodesByKind` / `countEdgesByKind`, mirroring the probe `Store.evolve` already runs for tightening changes. Live rows only, matching that probe's `excludeDeleted` default. Dropping an empty kind is permitted — that is Deploy 3 of the documented three-deploy removal flow, and Deploy 2 (delete the rows) is now what makes it legal rather than merely advisory.

Refusing *any* kind drop would have been wrong in a way tests cannot catch: after the fold, `evolve()`-committed kinds are always re-added, so a blanket rule could only ever fire on a compile-time kind — and `Store.removeKinds()` rejects those by design (`RemoveCompileTimeKindError`), so the error would name a remedy that does not exist while breaking the documented flow.

The guard lives in the public `migrateSchema`, not in `commitNewSchemaVersion`: `Store.removeKinds` commits through that primitive and drops populated kinds by design, having first queued the cleanup rows. Guarding the primitive would break the one path allowed to do this.

### 3. `discardDroppedKindRows`

The escape hatch is named for what happens to the data rather than for the schema operation, because the error message hands out its own override and the pasted remedy needs to be self-describing.

It does **not** preserve the rows, and the previous documentation claiming otherwise was false independently of this change. `materializeRemovals` re-derives removals by walking schema-version history, so the next reconcile hard-deletes the dropped kind's rows including soft-deleted ones, whether or not a `typegraph_kind_removals` row was ever written. The flag buys a committed schema, not retained data; the docs now say so and tell callers to copy the rows out first.

For the same reason `migrateSchema` queues no cleanup row of its own — history reconciliation already covers it, and writing one would only add a second source of truth. That walk is only as good as retained history: `reconcilePendingRemovals` stops at the first absent prior version, so a drop below a pruned range becomes undiscoverable. Callers who prune schema versions should run `materializeRemovals` before pruning.

### 4. Never delete rows of a kind that is live again

`materializeRemovals` re-derives removals by walking schema-version history, comparing each *consecutive* pair of documents. That comparison is local to the transition, so a kind removed at v3 is still discovered as "removed at v3" even after v4 re-added it and applications have written new rows. Cleanup is an unconditional `DELETE ... WHERE kind = ?`, so the reconcile destroyed live data belonging to a kind the active schema declares.

Cleanup now skips any pending removal whose kind the **active schema** still has. That covers both history-derived removals and rows explicitly queued by `Store.removeKinds`. Skipped rather than completed: the kind genuinely has not been cleaned up, so the row stays pending and a later removal of the same kind is still reclaimed.

### 5. Staleness is diagnosed before the row probe

`migrateSchema` compares the active version against `currentVersion` and throws `StaleVersionError` before probing anything. Previously a stale caller dropping a populated kind got a `kind-removal` `MigrationError` quoting versions that were never theirs, instead of the concurrency signal the contract documents. The commit CAS still catches writers that advance the version after this point.

### 6. `MigrationErrorDetails` is a discriminated union

Modelled on `reason` rather than as one shape with optional fields, so the payload a reason promises is the payload it must carry: narrowing on `reason === "kind-removal"` yields a non-optional `droppedKinds`, and the constructor cannot be handed a `kind-removal` without one. The documented `switch` in `schema-management.md` gains the case.

## Known limitations

Two races are documented rather than closed, both on paths where the fix is a design change rather than a correction.

**The populated-kind probe is not atomic with the commit (#336).** The version CAS protects the schema row, not the row counts, so a concurrent insert can land after a kind reads as empty. A transaction does not close it: schema commits run under a dialect write-lock that ordinary data writes do not take, so the inserting session is neither holding nor blocked by it. `Store.evolve`'s tightening probe has the identical window and predates this one.

**The live-kind guard is check-then-delete (#339).** A re-add committing between the active-schema read and the kind-wide `DELETE` is not fenced. Unlike #336 this one *is* closable in principle — a re-add is a schema commit, so it contends for the schema-write lock that cleanup could also take. It is not a wiring change though: that lock's transaction target cannot execute DDL, and cleanup drops per-kind vector tables, so the drops cannot run inside the lock. Deferring them outside it would drop live storage for a kind re-added in the meantime — the same bug from the other side. Closing it requires extending the schema-write target to run DDL on both dialects, which changes Postgres advisory-lock duration and SQLite serialized-slot semantics.

Both are recorded at their call sites.

## Tests

Five cases live in the shared cross-backend integration suite (`tests/backends/integration/migrate-schema-kinds.ts`), so PostgreSQL enforces the same contract: the extension fold preserving runtime kinds and their rows, the populated-kind refusal, the empty-kind drop, `discardDroppedKindRows` followed by reconciliation, and the re-add guard. These are enforced with SQL the dialects do not share — row-count probes, kind-wide deletes, schema-history reconciliation — so a SQLite-only test would happily certify a divergence.

SQLite-specific cases (`tests/migrate-schema-kind-preservation.test.ts`, `tests/kind-removal-readd-reconcile.test.ts`) cover the rest: a stale store's merged graph cannot resurrect a removed kind; `deprecatedKinds` survives the commit; the reported incident end-to-end (open → `evolve` → write → breaking change → `MigrationError` → follow the error's own advice); refusal leaves the active version untouched and names row counts; rows deleted first make the drop legal and the reconciler reclaims the tombstones; `discardDroppedKindRows` writes no cleanup row and the rows are still deleted by the next reconcile; a breaking property change is still forced; an additive change is unaffected; and cleanup still runs for a kind that stays removed.

Two pre-existing `removeKinds` recovery tests used `migrateSchema` to simulate a crashed removal. That state is no longer reachable through it — by design — so they now commit through `backend.commitSchemaVersion`, which is both what `removeKinds` actually uses and a more faithful simulation.

Changeset is `minor`.

