### PR TITLE
Support list-valued parameters in in() / notIn()

### DIFF
--- a/.changeset/list-valued-in-parameters.md
+++ b/.changeset/list-valued-in-parameters.md
@@ -19,5 +19,16 @@ produced wrong results. It now throws `UnsupportedPredicateError` naming the
 supported form. A name used both as a list and as a scalar in one query is
 rejected at `prepare()`.
 
+List elements are validated against the field's type before binding, so
+`[1, "a"]` against a number field is rejected with a `ConfigurationError`
+rather than failing on PostgreSQL and silently matching nothing on SQLite.
+This matches the literal form, which already refuses a mixed list.
+
+Non-finite numbers (`NaN`, `±Infinity`) are now rejected in any parameter
+binding, list or scalar. `JSON.stringify` turns them into `null`, so a list
+binding became SQL NULL — `notIn(param("x"))` with `[NaN]` filtered out every
+row — and SQLite binds a scalar `NaN` as NULL, so `eq(param("x"))` with `NaN`
+quietly matched nothing. Both now throw.
+
 `DialectAdapter` gains two members, `inListParameter` and `packListValue`;
 custom dialect adapters must implement them.

--- a/.changeset/list-valued-in-parameters.md
+++ b/.changeset/list-valued-in-parameters.md
@@ -1,0 +1,23 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Support list-valued parameters in `in()` / `notIn()`
+
+`field.in(param("ids"))` now binds the whole list at
+`.prepare().execute({ ids: [...] })`, so the canonical "fetch these ids"
+query can finally be prepared. The list rides on a single bound parameter
+that the dialect unpacks (`json_each` on SQLite, `jsonb_array_elements_text`
+on PostgreSQL), which keeps arity out of the SQL text: one compiled statement
+serves every list length, and a list of any size costs one bound parameter
+instead of one per element. An empty list is valid — `in([])` matches nothing,
+`notIn([])` matches everything.
+
+A `ParameterRef` passed among the *elements* of a literal list
+(`in(["a", param("b")])`) was previously coerced to a literal and silently
+produced wrong results. It now throws `UnsupportedPredicateError` naming the
+supported form. A name used both as a list and as a scalar in one query is
+rejected at `prepare()`.
+
+`DialectAdapter` gains two members, `inListParameter` and `packListValue`;
+custom dialect adapters must implement them.

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -341,15 +341,19 @@ For application-specific indexes on JSON properties, see [Indexes](/performance/
 ### SQL Compilation
 
 Each builder method (`.where()`, `.limit()`, `.orderBy()`, etc.) returns a new immutable instance.
-`.execute()`/`.toSQL()`/`.compile()` compile fresh SQL from the AST on every call — this applies to
-standard queries, aggregate queries, and set-operation queries (`union`, `intersect`, `except`).
-Compilation is pure, in-memory string-building with no I/O, so recompiling is cheap; the query's
-actual database round-trip dominates the cost either way.
 
-This is deliberate, not just unoptimized: a "current" (live) read binds its temporal-validity filter
-to the instant it's compiled at. Caching compiled SQL across calls would freeze that instant at
-whichever call first triggered compilation, silently hiding any row created afterward from every
-later call on the same query instance.
+A reused query instance compiles **once**. The first `.execute()` builds a cached template and every
+later call reuses it — for standard queries, aggregate queries, set-operation queries (`union`,
+`intersect`, `except`), and prepared queries alike. Explicit `.toSQL()` / `.compile()` calls are the
+exception: they compile on demand every time, because producing the statement is the thing the
+caller asked for.
+
+The subtlety a cache like that has to survive is freshness. A "current" (live) read filters on
+temporal validity as of the instant it runs, so a template with a concrete "now" baked into it would
+freeze that instant for the query instance's whole lifetime, hiding every row created afterward. The
+template therefore reserves the read instant as a **placeholder** rather than a value, and each
+execution fills it with a fresh instant alongside that call's bindings. Nothing in the statement's
+text depends on either, so reuse costs no freshness.
 
 ```typescript
 const activeUsers = store
@@ -358,27 +362,42 @@ const activeUsers = store
   .whereNode("u", (u) => u.status.eq("active"))
   .select((ctx) => ctx.u);
 
-// Each call compiles AST → SQL fresh, so a user created between these two
-// calls is visible to the second one.
+// One compilation, two executions. The read instant is bound per call, so a
+// user created between these two is visible to the second one.
 await activeUsers.execute();
 await activeUsers.execute();
 ```
+
+Backends that cannot execute pre-compiled SQL text (a custom or async backend, i.e. one without
+`executeRaw`) fall back to compiling on every call — same results, without the cached-template fast
+path. Compilation is pure, in-memory string-building with no I/O, so that fallback is cheap; the
+query's database round-trip dominates either way.
 
 ### Prepared Queries
 
 For hot paths that execute the same query shape with different values, `.prepare()` builds and
 structurally validates the query AST once — a malformed query fails fast, before the first
-`.execute()`, instead of on first use. The AST itself carries no timestamp, so this validation is
-safe to do once and reuse. SQL text is still compiled fresh on every `.execute(bindings)` call, for
-the same reason as above: the compiled text is what carries the current-read instant, the bound
-parameter values, and the query's structure.
+`.execute()`, instead of on first use — and compiles the statement once into a cached template. Each
+`.execute(bindings)` fills that template's placeholders (a fresh read instant plus the call's own
+parameter values) and runs the cached text directly through `executeRaw`.
 
-When `executeRaw` is available (both SQLite and PostgreSQL backends), the freshly compiled SQL text
-is sent directly to the driver with the bindings substituted in.
+Because arity never reaches the SQL text, a list-valued parameter reuses the same template no matter
+how long the list is:
 
-Best for: validating a query shape once (fail fast on a malformed query) and reusing it with
-different parameter values — not for avoiding SQL compilation cost, which is negligible next to the
-database round-trip.
+```typescript
+const byIds = store
+  .query()
+  .from("Person", "p")
+  .whereNode("p", (p) => p.id.in(param("ids")))
+  .select((ctx) => ctx.p)
+  .prepare();
+
+await byIds.execute({ ids: ["a", "b", "c"] });
+await byIds.execute({ ids: ["d"] }); // same compiled statement
+```
+
+Best for: validating a query shape once, then reusing it with different parameter values. The saved
+compilation is real but small — the database round-trip still dominates.
 
 See [Prepared Queries](/queries/execute#prepared-queries) for usage details.
 

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -368,10 +368,22 @@ await activeUsers.execute();
 await activeUsers.execute();
 ```
 
-Backends that cannot execute pre-compiled SQL text (a custom or async backend, i.e. one without
-`executeRaw`) fall back to compiling on every call — same results, without the cached-template fast
-path. Compilation is pure, in-memory string-building with no I/O, so that fallback is cheap; the
-query's database round-trip dominates either way.
+Two things fall back to compiling on every call:
+
+- **Backends that cannot execute pre-compiled SQL text** — a custom or async backend, i.e. one
+  without `executeRaw`.
+- **Statements whose execution semantics ride on the compiled SQL object rather than its text**,
+  even on PostgreSQL with `executeRaw` fully available. Two query shapes do: **approximate vector
+  search** (`similarTo(..., { approximate: true })`, which carries the pgvector / `sqlite-vec`
+  iterative-scan wrapper) and **`store.subgraph()` on PostgreSQL**, whose id-array fetches are
+  marked to force a custom plan so the planner sizes them against the actual array rather than
+  reusing a generic one. Flattening either to cacheable text would silently drop the behavior it
+  depends on, so they are excluded deliberately — the trade is a template hit against correct
+  execution, and correctness wins.
+
+Compilation is pure, in-memory string-building with no I/O, so both fallbacks are cheap; the query's
+database round-trip dominates either way. Worth knowing if you are profiling a vector query and
+expecting the compile-once behavior described above — that is the one shape where it does not apply.
 
 ### Prepared Queries
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -367,10 +367,11 @@ not depend on the list's length: one statement serves every arity, and a list of
 still costs one bound parameter rather than blowing past the engine's bind limit. An empty list is
 valid — `in([])` matches nothing, `notIn([])` matches everything.
 
-Every element must be the field's type. A mixed list — `[1, "a"]` bound against a number field — is
-not rejected, because each element is individually a legal scalar, and the two backends disagree
-about it: PostgreSQL fails at execution, SQLite matches nothing for the offending element. Keep the
-list homogeneous.
+Every element must be the field's type, and numbers must be finite. A mixed list — `[1, "a"]` bound
+against a number field — is rejected with a `ConfigurationError` before it reaches the database, on
+every backend, as is `NaN` or `Infinity`. This matches the literal form, which already refuses a
+mixed list, and it is what keeps the two backends in step: left unchecked, PostgreSQL would fail
+casting while SQLite silently matched nothing.
 
 :::caution
 A `param()` sitting among the **elements** of a literal list — `p.name.in(["Alice", param("other")])` —

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -299,9 +299,9 @@ import { param } from "@nicia-ai/typegraph";
 ### `prepare()`
 
 Call `.prepare()` on an executable query to build and validate the AST once. Returns a
-`PreparedQuery<R>` that can be executed with different bindings; SQL text is compiled fresh on each
-`.execute()` call (see [Prepared query SQL compilation](#prepared-query-sql-compilation) below for
-why).
+`PreparedQuery<R>` that can be executed with different bindings. The statement is compiled once into
+a cached template and reused by every `.execute()` call — see
+[Prepared query SQL compilation](#prepared-query-sql-compilation) below for how that stays fresh.
 
 ```typescript
 const findByName = store

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -391,9 +391,16 @@ every row created after `.prepare()` from every subsequent call. The template th
 read instant as a **placeholder** rather than a value, and each `.execute()` fills it with a fresh
 instant alongside the call's own bindings. Nothing about the statement's text depends on either.
 
-When `executeRaw` is unavailable (a custom or async backend), the prepared query falls back to
-substituting parameters into the AST and compiling through the standard path on every call — same
-results and the same freshness guarantee, without the cached-template fast path.
+Two cases fall back to substituting parameters into the AST and compiling through the standard path
+on every call — same results and the same freshness guarantee, without the cached-template fast
+path:
+
+- `executeRaw` is unavailable (a custom or async backend).
+- The statement's execution semantics ride on the compiled SQL object rather than its text, which no
+  amount of `executeRaw` support changes. **Approximate vector search**
+  (`similarTo(..., { approximate: true })`) carries the engine's iterative-scan wrapper, and
+  `store.subgraph()` on PostgreSQL forces a custom plan for its id-array fetches. Flattening either
+  to cacheable text would drop the behavior it depends on, so both are excluded deliberately.
 
 ## Query Debugging
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -348,24 +348,46 @@ provided, and unknown binding keys are rejected.
 | `startsWith` / `endsWith`   | `p.name.startsWith(param("prefix"))`      |
 | `like` / `ilike`            | `p.email.like(param("pattern"))`          |
 
+`in()` and `notIn()` take a list-valued parameter — the **whole** list, not individual elements:
+
+```typescript
+const byIds = store
+  .query()
+  .from("Person", "p")
+  .whereNode("p", (p) => p.id.in(param("ids")))
+  .select((ctx) => ctx.p)
+  .prepare();
+
+await byIds.execute({ ids: ["a", "b", "c"] });
+await byIds.execute({ ids: ["d"] });
+```
+
+The list is bound as a single parameter that the database unpacks, so the compiled SQL text does
+not depend on the list's length: one statement serves every arity, and a list of ten thousand ids
+still costs one bound parameter rather than blowing past the engine's bind limit. An empty list is
+valid — `in([])` matches nothing, `notIn([])` matches everything.
+
 :::caution
-`param()` is **not** supported in `in()` / `notIn()` — the array length must be known at compile time.
+A `param()` sitting among the **elements** of a literal list — `p.name.in(["Alice", param("other")])` —
+is rejected with an `UnsupportedPredicateError`. Bind the whole list instead.
 :::
 
 ### Prepared Query SQL Compilation
 
-`.prepare()` builds and validates the AST once, but does **not** cache compiled SQL text across
-`.execute()` calls — each call recompiles fresh. This is deliberate: a "current" (live) read binds
-its temporal-validity filter to the instant it's compiled at. Caching the compiled text from
-`.prepare()` time would freeze that instant for the prepared query's entire lifetime, silently
-hiding any row created after `.prepare()` ran from every subsequent `.execute()` call — exactly the
-bug this behavior was fixed to avoid. Recompiling is pure, in-memory string-building with no I/O, so
-the cost is negligible next to the query's actual database round-trip.
+`.prepare()` builds and validates the AST once. On a backend that can compile and run raw SQL text
+(both the SQLite and PostgreSQL backends can), the statement is then compiled **once** into a cached
+template and reused by every `.execute()` call.
 
-When the backend supports `executeRaw` (both SQLite and PostgreSQL backends do), the freshly
-compiled SQL text is sent directly to the database driver with substituted parameter values. When
-`executeRaw` is unavailable, the prepared query substitutes parameters into the AST and compiles
-through the standard path instead — same freshness guarantee, different code path.
+The subtlety a cache like that has to survive is freshness: a "current" (live) read filters on
+temporal validity as of the instant it runs, so caching a compiled statement that had a concrete
+"now" baked into it would freeze that instant for the prepared query's entire lifetime — hiding
+every row created after `.prepare()` from every subsequent call. The template therefore reserves the
+read instant as a **placeholder** rather than a value, and each `.execute()` fills it with a fresh
+instant alongside the call's own bindings. Nothing about the statement's text depends on either.
+
+When `executeRaw` is unavailable (a custom or async backend), the prepared query falls back to
+substituting parameters into the AST and compiling through the standard path on every call — same
+results and the same freshness guarantee, without the cached-template fast path.
 
 ## Query Debugging
 

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -367,6 +367,11 @@ not depend on the list's length: one statement serves every arity, and a list of
 still costs one bound parameter rather than blowing past the engine's bind limit. An empty list is
 valid — `in([])` matches nothing, `notIn([])` matches everything.
 
+Every element must be the field's type. A mixed list — `[1, "a"]` bound against a number field — is
+not rejected, because each element is individually a legal scalar, and the two backends disagree
+about it: PostgreSQL fails at execution, SQLite matches nothing for the offending element. Keep the
+list homogeneous.
+
 :::caution
 A `param()` sitting among the **elements** of a literal list — `p.name.in(["Alice", param("other")])` —
 is rejected with an `UnsupportedPredicateError`. Bind the whole list instead.

--- a/apps/docs/src/content/docs/queries/predicates/index.md
+++ b/apps/docs/src/content/docs/queries/predicates/index.md
@@ -86,7 +86,8 @@ These predicates are available on **all** field types:
 | `isNotNull()` | Is not null | `IS NOT NULL` |
 
 `eq` and `neq` accept `param()` references for [prepared queries](/queries/execute#prepared-queries).
-`in` and `notIn` do **not** support `param()` because the array length must be known at compile time.
+`in` and `notIn` accept one in place of the **whole** list — `p.id.in(param("ids"))`, bound with
+`execute({ ids: [...] })` — but not in place of an individual element.
 
 ---
 
@@ -588,7 +589,8 @@ const results = await prepared.execute({ name: "Alice" });
 | Scalar comparisons (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`) | Yes | `p.age.gt(param("minAge"))` |
 | `between` bounds | Yes | `p.age.between(param("lo"), param("hi"))` |
 | String operations (`contains`, `startsWith`, `endsWith`, `like`, `ilike`) | Yes | `p.name.contains(param("search"))` |
-| `in` / `notIn` | No | Array length must be known at compile time |
+| `in` / `notIn` (whole list) | Yes | `p.id.in(param("ids"))` with `execute({ ids: [...] })` |
+| `in` / `notIn` (one element) | No | Bind the whole list instead |
 | Array predicates | No | — |
 | Subquery predicates | No | — |
 

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -280,6 +280,7 @@ export interface DialectAdapter {
     readonly ilike: (this: void, column: SqlFragment, pattern: SqlFragment | string) => SqlFragment;
     readonly initializePath: (this: void, nodeId: SqlFragment) => SqlFragment;
     readonly inList: (this: void, left: SqlFragment, values: readonly unknown[], negated: boolean) => SqlFragment;
+    readonly inListParameter: (this: void, left: SqlFragment, packedValues: SqlFragment, options: InListParameterOptions) => SqlFragment;
     readonly jsonArrayContains: (this: void, column: SqlFragment, value: unknown) => SqlFragment;
     readonly jsonArrayContainsAll: (this: void, column: SqlFragment, values: readonly unknown[]) => SqlFragment;
     readonly jsonArrayContainsAny: (this: void, column: SqlFragment, values: readonly unknown[]) => SqlFragment;
@@ -296,6 +297,7 @@ export interface DialectAdapter {
     readonly jsonPathIsNumber: (this: void, column: SqlFragment, pointer: JsonPointer) => SqlFragment;
     readonly name: SqlDialect;
     readonly nullSafeEquals: (this: void, left: SqlFragment, right: SqlFragment) => SqlFragment;
+    readonly packListValue: (this: void, values: readonly unknown[]) => unknown;
     readonly quoteIdentifier: (this: void, name: string) => string;
     readonly setTransactionWorkingMemory: (this: void, workingMemory: string) => SqlFragment | undefined;
     readonly supportsVectors: boolean;
@@ -923,6 +925,12 @@ export type IndexWhereOperand = Readonly<{
 
 // @public
 export type InferenceType = "subsumption" | "hierarchy" | "substitution" | "constraint" | "composition" | "association" | "none";
+
+// @public
+export type InListParameterOptions = Readonly<{
+    negated: boolean;
+    elementType: ValueType | undefined;
+}>;
 
 // @public
 export type InsertEdgeParams = Readonly<{

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -124,8 +124,8 @@ type BaseFieldAccessor = Readonly<{
     neq: (value: unknown) => Predicate;
     isNull: () => Predicate;
     isNotNull: () => Predicate;
-    in: (values: readonly unknown[]) => Predicate;
-    notIn: (values: readonly unknown[]) => Predicate;
+    in: (values: readonly unknown[] | ParameterRef) => Predicate;
+    notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -112,8 +112,8 @@ type BaseFieldAccessor = Readonly<{
     neq: (value: unknown) => Predicate;
     isNull: () => Predicate;
     isNotNull: () => Predicate;
-    in: (values: readonly unknown[]) => Predicate;
-    notIn: (values: readonly unknown[]) => Predicate;
+    in: (values: readonly unknown[] | ParameterRef) => Predicate;
+    notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -112,8 +112,8 @@ type BaseFieldAccessor = Readonly<{
     neq: (value: unknown) => Predicate;
     isNull: () => Predicate;
     isNotNull: () => Predicate;
-    in: (values: readonly unknown[]) => Predicate;
-    notIn: (values: readonly unknown[]) => Predicate;
+    in: (values: readonly unknown[] | ParameterRef) => Predicate;
+    notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 // @public (undocumented)

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -112,8 +112,8 @@ type BaseFieldAccessor = Readonly<{
     neq: (value: unknown) => Predicate;
     isNull: () => Predicate;
     isNotNull: () => Predicate;
-    in: (values: readonly unknown[]) => Predicate;
-    notIn: (values: readonly unknown[]) => Predicate;
+    in: (values: readonly unknown[] | ParameterRef) => Predicate;
+    notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -112,8 +112,8 @@ type BaseFieldAccessor = Readonly<{
     neq: (value: unknown) => Predicate;
     isNull: () => Predicate;
     isNotNull: () => Predicate;
-    in: (values: readonly unknown[]) => Predicate;
-    notIn: (values: readonly unknown[]) => Predicate;
+    in: (values: readonly unknown[] | ParameterRef) => Predicate;
+    notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -112,8 +112,8 @@ type BaseFieldAccessor = Readonly<{
     neq: (value: unknown) => Predicate;
     isNull: () => Predicate;
     isNotNull: () => Predicate;
-    in: (values: readonly unknown[]) => Predicate;
-    notIn: (values: readonly unknown[]) => Predicate;
+    in: (values: readonly unknown[] | ParameterRef) => Predicate;
+    notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 // @public (undocumented)

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -224,8 +224,8 @@ type BaseFieldAccessor = Readonly<{
     neq: (value: unknown) => Predicate;
     isNull: () => Predicate;
     isNotNull: () => Predicate;
-    in: (values: readonly unknown[]) => Predicate;
-    notIn: (values: readonly unknown[]) => Predicate;
+    in: (values: readonly unknown[] | ParameterRef) => Predicate;
+    notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 // @public (undocumented)

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -23,6 +23,7 @@ export type {
   DialectRecursiveQueryStrategy,
   DialectStandardQueryStrategy,
   DialectVectorPredicateStrategy,
+  InListParameterOptions,
   SqlDialect,
 } from "../query/dialect/types";
 export type {

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -378,7 +378,9 @@ export class ExecutableQuery<
    * validates the AST once (a malformed query fails fast, here, instead of on
    * first use); the prepared query then compiles once into a reusable template
    * and fills a fresh read instant per execute() — see PreparedQuery's class
-   * doc comment.
+   * doc comment, which also covers the two cases that recompile per call
+   * instead (no `executeRaw`, or a statement whose semantics ride on the SQL
+   * object rather than its text).
    *
    * Use `param("name")` in predicates to create parameterized slots,
    * then pass values via `prepared.execute({ name: "value" })`.

--- a/packages/typegraph/src/query/builder/prepared-query.ts
+++ b/packages/typegraph/src/query/builder/prepared-query.ts
@@ -22,6 +22,7 @@ import { type GraphBackend } from "../../backend/types";
 import { ConfigurationError, UnsupportedPredicateError } from "../../errors";
 import {
   type BetweenPredicate,
+  type ComparisonOp,
   type ComparisonPredicate,
   type ComposableQuery,
   type LiteralValue,
@@ -41,6 +42,7 @@ import {
 import { isParameterRef } from "../predicates";
 import { type SchemaIntrospector } from "../schema-introspector";
 import {
+  assertListBinding,
   buildQueryTemplate,
   type CompiledTemplate,
   fillTemplateParams,
@@ -81,6 +83,22 @@ function toLiteral(value: unknown): LiteralValue {
   );
 }
 
+/** Whether a comparison operator takes a list of values rather than a scalar. */
+function isListComparisonOp(op: ComparisonOp): boolean {
+  return op === "in" || op === "notIn";
+}
+
+/**
+ * Expands a list-valued binding into the literal array the compiler's
+ * non-parameterized `in`/`notIn` path expects. Used only on the fallback
+ * (no `executeRaw`) path — the fast path keeps the list packed behind a
+ * single placeholder.
+ */
+function toLiteralList(parameterName: string, value: unknown): LiteralValue[] {
+  assertListBinding(parameterName, value);
+  return value.map((element) => toLiteral(element));
+}
+
 /**
  * Walks a predicate expression tree and replaces ParameterRef nodes
  * with LiteralValue nodes using the provided bindings.
@@ -92,16 +110,13 @@ function substitutePredicateExpression(
   switch (expr.__type) {
     case "comparison": {
       if (isParameterRef(expr.right)) {
-        const value = bindings[expr.right.name];
-        if (value === undefined) {
-          throw new ConfigurationError(
-            `Missing binding for parameter "${expr.right.name}"`,
-            { parameterName: expr.right.name },
-          );
-        }
+        const value = resolveBinding(bindings, expr.right.name);
         return {
           ...expr,
-          right: toLiteral(value),
+          right:
+            isListComparisonOp(expr.op) ?
+              toLiteralList(expr.right.name, value)
+            : toLiteral(value),
         } satisfies ComparisonPredicate;
       }
       return expr;
@@ -297,6 +312,7 @@ export class PreparedQuery<R> {
     this.#selectFn = config.selectFn;
     this.#schemaIntrospector = config.schemaIntrospector;
     this.#parameterMetadata = collectParameterMetadata(this.#ast);
+    assertDistinctParameterRoles(this.#parameterMetadata);
   }
 
   /**
@@ -405,6 +421,7 @@ export class PreparedQuery<R> {
         template.params,
         bindings,
         this.#dialect,
+        this.#parameterMetadata.listParameters,
       );
       const rawRows = await executeRaw<Record<string, unknown>>(
         template.sql,
@@ -429,15 +446,49 @@ type ParameterMetadata = Readonly<{
   names: ReadonlySet<string>;
   /** Parameters used in string_op predicates (must receive string values). */
   stringOpParameters: ReadonlySet<string>;
+  /** Parameters used as the whole list of `in`/`notIn` (must receive arrays). */
+  listParameters: ReadonlySet<string>;
+  /** Parameters used in any position that binds a single scalar. */
+  scalarParameters: ReadonlySet<string>;
+}>;
+
+/** The mutable form {@link collectParameterMetadataFromAst} fills. */
+type ParameterMetadataAccumulator = Readonly<{
+  names: Set<string>;
+  stringOpParameters: Set<string>;
+  listParameters: Set<string>;
+  scalarParameters: Set<string>;
 }>;
 
 function collectParameterMetadata(ast: QueryAst): ParameterMetadata {
-  const names = new Set<string>();
-  const stringOpParameters = new Set<string>();
+  const accumulator: ParameterMetadataAccumulator = {
+    names: new Set<string>(),
+    stringOpParameters: new Set<string>(),
+    listParameters: new Set<string>(),
+    scalarParameters: new Set<string>(),
+  };
 
-  collectParameterMetadataFromAst(ast, names, stringOpParameters);
+  collectParameterMetadataFromAst(ast, accumulator);
 
-  return { names, stringOpParameters };
+  return accumulator;
+}
+
+/**
+ * A name used both as a whole list and as a scalar cannot be satisfied by one
+ * binding — the same value would have to be an array in one position and a
+ * scalar in the other. Called at prepare time so the query fails before its
+ * first execute() rather than on whichever binding happens to arrive.
+ */
+function assertDistinctParameterRoles(metadata: ParameterMetadata): void {
+  const conflicting = [...metadata.listParameters].filter((name) =>
+    metadata.scalarParameters.has(name),
+  );
+  if (conflicting.length === 0) return;
+
+  throw new ConfigurationError(
+    `Parameter${conflicting.length === 1 ? "" : "s"} ${conflicting.map((name) => `"${name}"`).join(", ")} used both as an in()/notIn() list and as a scalar value`,
+    { conflictingParameters: conflicting },
+  );
 }
 
 export function hasParameterReferences(ast: QueryAst): boolean {
@@ -458,70 +509,58 @@ export function composableQueryHasParameterReferences(
 
 function collectParameterMetadataFromAst(
   ast: QueryAst,
-  names: Set<string>,
-  stringOpParameters: Set<string>,
+  accumulator: ParameterMetadataAccumulator,
 ): void {
   for (const predicate of ast.predicates) {
-    collectParameterMetadataFromExpression(
-      predicate.expression,
-      names,
-      stringOpParameters,
-    );
+    collectParameterMetadataFromExpression(predicate.expression, accumulator);
   }
   if (ast.having !== undefined) {
-    collectParameterMetadataFromExpression(
-      ast.having,
-      names,
-      stringOpParameters,
-    );
+    collectParameterMetadataFromExpression(ast.having, accumulator);
   }
 }
 
 function collectParameterMetadataFromExpression(
   expression: PredicateExpression,
-  names: Set<string>,
-  stringOpParameters: Set<string>,
+  accumulator: ParameterMetadataAccumulator,
 ): void {
   switch (expression.__type) {
     case "comparison": {
       if (isParameterRef(expression.right)) {
-        names.add(expression.right.name);
+        accumulator.names.add(expression.right.name);
+        const role =
+          isListComparisonOp(expression.op) ?
+            accumulator.listParameters
+          : accumulator.scalarParameters;
+        role.add(expression.right.name);
       }
       return;
     }
     case "string_op": {
       if (isParameterRef(expression.pattern)) {
-        names.add(expression.pattern.name);
-        stringOpParameters.add(expression.pattern.name);
+        accumulator.names.add(expression.pattern.name);
+        accumulator.scalarParameters.add(expression.pattern.name);
+        accumulator.stringOpParameters.add(expression.pattern.name);
       }
       return;
     }
     case "between": {
-      if (isParameterRef(expression.lower)) {
-        names.add(expression.lower.name);
-      }
-      if (isParameterRef(expression.upper)) {
-        names.add(expression.upper.name);
+      for (const bound of [expression.lower, expression.upper]) {
+        if (isParameterRef(bound)) {
+          accumulator.names.add(bound.name);
+          accumulator.scalarParameters.add(bound.name);
+        }
       }
       return;
     }
     case "and":
     case "or": {
       for (const predicate of expression.predicates) {
-        collectParameterMetadataFromExpression(
-          predicate,
-          names,
-          stringOpParameters,
-        );
+        collectParameterMetadataFromExpression(predicate, accumulator);
       }
       return;
     }
     case "not": {
-      collectParameterMetadataFromExpression(
-        expression.predicate,
-        names,
-        stringOpParameters,
-      );
+      collectParameterMetadataFromExpression(expression.predicate, accumulator);
       return;
     }
     case "null_check":
@@ -532,20 +571,9 @@ function collectParameterMetadataFromExpression(
     case "fulltext_match": {
       return;
     }
-    case "exists": {
-      collectParameterMetadataFromAst(
-        expression.subquery,
-        names,
-        stringOpParameters,
-      );
-      return;
-    }
+    case "exists":
     case "in_subquery": {
-      collectParameterMetadataFromAst(
-        expression.subquery,
-        names,
-        stringOpParameters,
-      );
+      collectParameterMetadataFromAst(expression.subquery, accumulator);
       return;
     }
   }
@@ -555,7 +583,7 @@ function validateBindings(
   bindings: Readonly<Record<string, unknown>>,
   metadata: ParameterMetadata,
 ): void {
-  const { names: expectedNames, stringOpParameters } = metadata;
+  const { names: expectedNames, stringOpParameters, listParameters } = metadata;
 
   const missing: string[] = [];
   for (const name of expectedNames) {
@@ -585,7 +613,22 @@ function validateBindings(
   // fallback path (AST substitution) reject the same invalid inputs.
   for (const name of expectedNames) {
     const value = bindings[name];
+    if (listParameters.has(name)) {
+      validateListBinding(name, value);
+      continue;
+    }
     validateBindingValue(name, value, stringOpParameters.has(name));
+  }
+}
+
+/**
+ * Validates a list-valued binding is an array of scalars, so the packed
+ * parameter the dialect unpacks holds exactly what a literal list would.
+ */
+function validateListBinding(name: string, value: unknown): void {
+  assertListBinding(name, value);
+  for (const element of value) {
+    validateBindingValue(name, element, false);
   }
 }
 

--- a/packages/typegraph/src/query/builder/prepared-query.ts
+++ b/packages/typegraph/src/query/builder/prepared-query.ts
@@ -30,8 +30,10 @@ import {
   type QueryAst,
   type SelectiveField,
   type StringPredicate,
+  type ValueType,
 } from "../ast";
 import { compileQuery, type CompileQueryOptions } from "../compiler/index";
+import { resolveParameterValueType } from "../compiler/predicates";
 import { type SqlDialect } from "../dialect/types";
 import {
   mapResults,
@@ -446,26 +448,35 @@ type ParameterMetadata = Readonly<{
   names: ReadonlySet<string>;
   /** Parameters used in string_op predicates (must receive string values). */
   stringOpParameters: ReadonlySet<string>;
-  /** Parameters used as the whole list of `in`/`notIn` (must receive arrays). */
-  listParameters: ReadonlySet<string>;
+  /**
+   * Parameters used as the whole list of `in`/`notIn`, mapped to the element
+   * type their bindings must have. `undefined` means the schema declares
+   * nothing usable, so no element check applies.
+   */
+  listParameters: ReadonlyMap<string, ValueType | undefined>;
   /** Parameters used in any position that binds a single scalar. */
   scalarParameters: ReadonlySet<string>;
+  /** Names bound in two `in`/`notIn` positions with different element types. */
+  conflictingElementTypes: ReadonlySet<string>;
 }>;
 
 /** The mutable form {@link collectParameterMetadataFromAst} fills. */
 type ParameterMetadataAccumulator = Readonly<{
   names: Set<string>;
   stringOpParameters: Set<string>;
-  listParameters: Set<string>;
+  listParameters: Map<string, ValueType | undefined>;
   scalarParameters: Set<string>;
+  /** Names bound in two `in`/`notIn` positions with different element types. */
+  conflictingElementTypes: Set<string>;
 }>;
 
 function collectParameterMetadata(ast: QueryAst): ParameterMetadata {
   const accumulator: ParameterMetadataAccumulator = {
     names: new Set<string>(),
     stringOpParameters: new Set<string>(),
-    listParameters: new Set<string>(),
+    listParameters: new Map<string, ValueType | undefined>(),
     scalarParameters: new Set<string>(),
+    conflictingElementTypes: new Set<string>(),
   };
 
   collectParameterMetadataFromAst(ast, accumulator);
@@ -480,7 +491,15 @@ function collectParameterMetadata(ast: QueryAst): ParameterMetadata {
  * first execute() rather than on whichever binding happens to arrive.
  */
 function assertDistinctParameterRoles(metadata: ParameterMetadata): void {
-  const conflicting = [...metadata.listParameters].filter((name) =>
+  if (metadata.conflictingElementTypes.size > 0) {
+    const names = [...metadata.conflictingElementTypes];
+    throw new ConfigurationError(
+      `Parameter${names.length === 1 ? "" : "s"} ${names.map((name) => `"${name}"`).join(", ")} bound as an in()/notIn() list against fields of different types; one list cannot satisfy both`,
+      { conflictingParameters: names },
+    );
+  }
+
+  const conflicting = [...metadata.listParameters.keys()].filter((name) =>
     metadata.scalarParameters.has(name),
   );
   if (conflicting.length === 0) return;
@@ -489,6 +508,32 @@ function assertDistinctParameterRoles(metadata: ParameterMetadata): void {
     `Parameter${conflicting.length === 1 ? "" : "s"} ${conflicting.map((name) => `"${name}"`).join(", ")} used both as an in()/notIn() list and as a scalar value`,
     { conflictingParameters: conflicting },
   );
+}
+
+/**
+ * Records the element type a list parameter's bindings must have.
+ *
+ * A name reused across two `in()` positions keeps the declared type when only
+ * one side declares one; two *different* declared types are irreconcilable —
+ * one array cannot be both — so the name is flagged and `prepare()` rejects it.
+ */
+function recordListElementType(
+  accumulator: ParameterMetadataAccumulator,
+  name: string,
+  elementType: ValueType | undefined,
+): void {
+  if (!accumulator.listParameters.has(name)) {
+    accumulator.listParameters.set(name, elementType);
+    return;
+  }
+  const existing = accumulator.listParameters.get(name);
+  if (existing === undefined) {
+    accumulator.listParameters.set(name, elementType);
+    return;
+  }
+  if (elementType !== undefined && elementType !== existing) {
+    accumulator.conflictingElementTypes.add(name);
+  }
 }
 
 export function hasParameterReferences(ast: QueryAst): boolean {
@@ -526,12 +571,17 @@ function collectParameterMetadataFromExpression(
   switch (expression.__type) {
     case "comparison": {
       if (isParameterRef(expression.right)) {
-        accumulator.names.add(expression.right.name);
-        const role =
-          isListComparisonOp(expression.op) ?
-            accumulator.listParameters
-          : accumulator.scalarParameters;
-        role.add(expression.right.name);
+        const name = expression.right.name;
+        accumulator.names.add(name);
+        if (isListComparisonOp(expression.op)) {
+          recordListElementType(
+            accumulator,
+            name,
+            resolveParameterValueType(expression.left, expression.right),
+          );
+        } else {
+          accumulator.scalarParameters.add(name);
+        }
       }
       return;
     }
@@ -614,7 +664,7 @@ function validateBindings(
   for (const name of expectedNames) {
     const value = bindings[name];
     if (listParameters.has(name)) {
-      validateListBinding(name, value);
+      validateListBinding(name, value, listParameters.get(name));
       continue;
     }
     validateBindingValue(name, value, stringOpParameters.has(name));
@@ -622,14 +672,72 @@ function validateBindings(
 }
 
 /**
- * Validates a list-valued binding is an array of scalars, so the packed
- * parameter the dialect unpacks holds exactly what a literal list would.
+ * Validates a list-valued binding is an array of scalars of the field's type.
+ *
+ * The element-type check is what keeps the two backends in step. Without it
+ * `[1, "a"]` against a number field passes — each element is individually a
+ * legal scalar — and then PostgreSQL fails casting `"a"` to numeric while
+ * SQLite's dynamic typing silently matches nothing for that element: the same
+ * query, two behaviors. It also brings the parameterized form in line with the
+ * literal one, which already refuses a mixed list when it compiles ("Mixed
+ * literal value types are not supported in predicates") — the parameterized
+ * form has no literals to inspect, so it reaches the same verdict from the
+ * binding instead.
+ *
+ * The check rides the walk that was already validating every element, so it
+ * costs a comparison per element rather than a second pass.
  */
-function validateListBinding(name: string, value: unknown): void {
+function validateListBinding(
+  name: string,
+  value: unknown,
+  elementType: ValueType | undefined,
+): void {
   assertListBinding(name, value);
   for (const element of value) {
     validateBindingValue(name, element, false);
+    if (elementType === undefined) continue;
+    if (matchesElementType(element, elementType)) continue;
+    throw new ConfigurationError(
+      `Parameter "${name}" is bound against a ${elementType} field, so every ` +
+        `element must be a ${elementType}; got ${describeBindingType(element)}`,
+      { parameterName: name, valueType: elementType },
+    );
   }
+}
+
+/** Whether `value` can be bound as `elementType` in an `in()`/`notIn()` list. */
+function matchesElementType(value: unknown, elementType: ValueType): boolean {
+  switch (elementType) {
+    case "string": {
+      return typeof value === "string";
+    }
+    case "number": {
+      return typeof value === "number";
+    }
+    case "boolean": {
+      return typeof value === "boolean";
+    }
+    case "date": {
+      // Either a Date or the ISO text TypeGraph stores. Arbitrary strings are
+      // not parsed here: the literal form does not validate them either, and
+      // guessing which formats PostgreSQL accepts would reject valid input.
+      return value instanceof Date || typeof value === "string";
+    }
+    // No element cast is emitted for these, so there is no divergence to
+    // prevent — `array`/`object` are rejected earlier, at compile time.
+    case "array":
+    case "object":
+    case "embedding":
+    case "unknown": {
+      return true;
+    }
+  }
+}
+
+/** A binding's type as it should read in an error message. */
+function describeBindingType(value: unknown): string {
+  if (value instanceof Date) return "date";
+  return typeof value;
 }
 
 function validateBindingValue(
@@ -652,10 +760,23 @@ function validateBindingValue(
     }
     return;
   }
+  if (typeof value === "number") {
+    // JSON.stringify turns NaN and +/-Infinity into `null`, which the packed
+    // list form would bind as SQL NULL — silently poisoning the predicate
+    // (`NOT IN (NULL)` matches no row at all). The scalar form is no better:
+    // SQLite stores a bound NaN as NULL, so `eq(NaN)` quietly matches nothing.
+    // Neither is a value any comparison can mean, so reject both shapes here.
+    if (!Number.isFinite(value)) {
+      throw new ConfigurationError(
+        `Parameter "${name}" must be a finite number, got ${String(value)}`,
+        { parameterName: name, actualType: "number" },
+      );
+    }
+    return;
+  }
   if (
     value instanceof Date ||
     typeof value === "string" ||
-    typeof value === "number" ||
     typeof value === "boolean"
   ) {
     return;

--- a/packages/typegraph/src/query/builder/prepared-query.ts
+++ b/packages/typegraph/src/query/builder/prepared-query.ts
@@ -6,7 +6,8 @@
  * the first `execute()`).
  *
  * Fast path: when the backend can compile and run raw SQL (`compileSql` +
- * `executeRaw`), the statement is compiled ONCE into a cached template whose
+ * `executeRaw`) AND the statement is raw-executable, it is compiled ONCE
+ * into a cached template whose
  * "current" read instant and user `param()` refs are reserved placeholders
  * (see {@link buildReadInstantTemplate}). Every `execute()` fills those
  * placeholders — a fresh instant plus the call's bindings — and runs the
@@ -14,9 +15,14 @@
  * never freezes "now" the way a cached literal instant would (the #246
  * regression).
  *
- * Fallback: on a backend without raw execution (custom/async), substitutes
- * parameter refs into the AST, compiles fresh per call, and executes via the
- * standard `backend.execute` path.
+ * Fallback: substitutes parameter refs into the AST, compiles fresh per call,
+ * and executes via the standard `backend.execute` path. Taken in two cases —
+ * a backend without raw execution (custom/async), and a statement that is not
+ * raw-executable because its execution semantics ride on the compiled SQL
+ * OBJECT rather than its text (approximate vector search's iterative-scan
+ * wrapper, `subgraph()`'s force-custom-plan fetches). The second applies even
+ * on PostgreSQL with `executeRaw` available; `isRawExecutable` in
+ * `sql-intent.ts` is the predicate that decides it.
  */
 import { type GraphBackend } from "../../backend/types";
 import { ConfigurationError, UnsupportedPredicateError } from "../../errors";

--- a/packages/typegraph/src/query/builder/read-instant-template.ts
+++ b/packages/typegraph/src/query/builder/read-instant-template.ts
@@ -21,6 +21,7 @@ import { nowIso } from "../../utils/date";
 import { type ComposableQuery, type QueryAst } from "../ast";
 import { compileQuery, type CompileQueryOptions } from "../compiler/index";
 import { CURRENT_READ_INSTANT_PLACEHOLDER } from "../compiler/temporal";
+import { getDialect } from "../dialect";
 import { bindSqlValue } from "../dialect/profile";
 import { type SqlDialect } from "../dialect/types";
 import { isSqlPlaceholder, type SqlFragment } from "../sql-fragment";
@@ -155,6 +156,8 @@ export function buildQueryTemplate(
   });
 }
 
+const EMPTY_LIST_PARAMETERS: ReadonlySet<string> = new Set<string>();
+
 /**
  * Resolves a template's positional parameters for `executeRaw`, replacing
  * every {@link Placeholder} with a concrete value:
@@ -164,12 +167,16 @@ export function buildQueryTemplate(
  *   per statement" invariant the literal path guaranteed;
  * - a user `param()` placeholder → its binding, mapped the same way the
  *   compile path binds a literal (Date → ISO string; everything else through
- *   the dialect's `bindValue`).
+ *   the dialect's `bindValue`);
+ * - a list-valued `param()` placeholder (the whole right side of
+ *   `in()`/`notIn()`) → the dialect's packed representation of the array, so
+ *   the statement binds ONE value no matter how long the list is.
  */
 export function fillTemplateParams(
   params: readonly unknown[],
   bindings: Readonly<Record<string, unknown>>,
   dialect: SqlDialect,
+  listParameters: ReadonlySet<string> = EMPTY_LIST_PARAMETERS,
 ): unknown[] {
   let readInstant: string | undefined;
   return params.map((parameter) => {
@@ -187,6 +194,26 @@ export function fillTemplateParams(
         parameterName: name,
       });
     }
+    if (listParameters.has(name)) {
+      assertListBinding(name, value);
+      return getDialect(dialect).packListValue(value);
+    }
     return bindSqlValue(value, dialect);
   });
+}
+
+/**
+ * Narrows a binding destined for an `in()`/`notIn()` parameter to an array.
+ * An empty array is valid — it compiles to an empty relation, matching the
+ * literal `in([])` short circuit.
+ */
+export function assertListBinding(
+  name: string,
+  value: unknown,
+): asserts value is readonly unknown[] {
+  if (Array.isArray(value)) return;
+  throw new ConfigurationError(
+    `Parameter "${name}" must be an array for in()/notIn()`,
+    { parameterName: name, actualType: typeof value },
+  );
 }

--- a/packages/typegraph/src/query/builder/read-instant-template.ts
+++ b/packages/typegraph/src/query/builder/read-instant-template.ts
@@ -156,7 +156,7 @@ export function buildQueryTemplate(
   });
 }
 
-const EMPTY_LIST_PARAMETERS: ReadonlySet<string> = new Set<string>();
+const EMPTY_LIST_PARAMETERS: ReadonlyMap<string, unknown> = new Map();
 
 /**
  * Resolves a template's positional parameters for `executeRaw`, replacing
@@ -176,7 +176,7 @@ export function fillTemplateParams(
   params: readonly unknown[],
   bindings: Readonly<Record<string, unknown>>,
   dialect: SqlDialect,
-  listParameters: ReadonlySet<string> = EMPTY_LIST_PARAMETERS,
+  listParameters: ReadonlyMap<string, unknown> = EMPTY_LIST_PARAMETERS,
 ): unknown[] {
   let readInstant: string | undefined;
   return params.map((parameter) => {

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -254,8 +254,8 @@ export type BaseFieldAccessor = Readonly<{
   neq: (value: unknown) => Predicate;
   isNull: () => Predicate;
   isNotNull: () => Predicate;
-  in: (values: readonly unknown[]) => Predicate;
-  notIn: (values: readonly unknown[]) => Predicate;
+  in: (values: readonly unknown[] | ParameterRef) => Predicate;
+  notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 export type StringFieldAccessor = BaseFieldAccessor &

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -141,6 +141,24 @@ function normalizeValueType(
 }
 
 /**
+ * The value type a `param()` in a comparison binds as: the parameter's own
+ * declared type when it has one, else the field's.
+ *
+ * Shared so the two things that must agree about it cannot drift — the
+ * compiler picks the `jsonExtract*` variant (and, for a list parameter, the
+ * matching element cast) from this, and `PreparedQuery` validates the caller's
+ * bindings against the same answer.
+ */
+export function resolveParameterValueType(
+  left: FieldRef,
+  right: ParameterRef,
+): ValueType | undefined {
+  return (
+    normalizeValueType(right.valueType) ?? normalizeValueType(left.valueType)
+  );
+}
+
+/**
  * Compiles a field reference to SQL with appropriate type extraction.
  */
 export function compileFieldValue(
@@ -628,9 +646,7 @@ function compileComparisonPredicate(
 ): SqlFragment {
   // Handle ParameterRef on the right side
   if (isParameterRef(expr.right)) {
-    const parameterValueType =
-      normalizeValueType(expr.right.valueType) ??
-      normalizeValueType(expr.left.valueType);
+    const parameterValueType = resolveParameterValueType(expr.left, expr.right);
     const left = compileFieldValue(
       expr.left,
       dialect,

--- a/packages/typegraph/src/query/compiler/predicates.ts
+++ b/packages/typegraph/src/query/compiler/predicates.ts
@@ -639,6 +639,15 @@ function compileComparisonPredicate(
       undefined,
       cteColumnPrefix,
     );
+    if (expr.op === "in" || expr.op === "notIn") {
+      return compileListParameterPredicate(
+        left,
+        expr.right.name,
+        parameterValueType,
+        expr.op === "notIn",
+        dialect,
+      );
+    }
     const opSql = COMPARISON_OP_SQL[expr.op];
     if (!opSql) {
       throw new UnsupportedPredicateError(
@@ -691,6 +700,43 @@ function compileComparisonPredicate(
     );
   }
   return sql`${left} ${sql.raw(opSql)} ${convertedRight}`;
+}
+
+/**
+ * Compiles `field.in(param("ids"))` / `field.notIn(param("ids"))`.
+ *
+ * The whole list rides on ONE placeholder — the dialect unpacks it — so the
+ * emitted SQL text is independent of how many elements the caller eventually
+ * binds. That is what lets a prepared query compile once and serve every
+ * arity from the same cached template, including the empty list (which yields
+ * an empty relation, hence `IN` false / `NOT IN` true, matching the literal
+ * form's short circuit).
+ */
+function compileListParameterPredicate(
+  left: SqlFragment,
+  parameterName: string,
+  elementType: ValueType | undefined,
+  negated: boolean,
+  dialect: DialectAdapter,
+): SqlFragment {
+  if (
+    elementType === "array" ||
+    elementType === "object" ||
+    elementType === "embedding"
+  ) {
+    throw new UnsupportedPredicateError(
+      `IN/NOT IN is not supported for ${elementType} values`,
+      { valueType: elementType },
+      {
+        suggestion:
+          "Use scalar fields (string/number/boolean/date) in IN/NOT IN predicates.",
+      },
+    );
+  }
+  return dialect.inListParameter(left, sql.placeholder(parameterName), {
+    negated,
+    elementType,
+  });
 }
 
 /**

--- a/packages/typegraph/src/query/dialect/index.ts
+++ b/packages/typegraph/src/query/dialect/index.ts
@@ -20,6 +20,7 @@ export type {
   DialectRecursiveQueryStrategy,
   DialectStandardQueryStrategy,
   DialectVectorPredicateStrategy,
+  InListParameterOptions,
   SqlDialect,
 } from "./types";
 export {

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -4,11 +4,16 @@
  * Implements dialect-specific SQL generation for PostgreSQL databases.
  * Uses PostgreSQL's native JSONB operators for JSON operations.
  */
+import { type ValueType } from "../ast";
 import { type JsonPointer, parseJsonPointer } from "../json-pointer";
 import { sql, type SqlFragment } from "../sql-fragment";
 import { tsvectorStrategy } from "./fulltext-strategy";
 import { likeEscapeClause } from "./like-escape";
-import { getSqlDialectProfile, inlineSqlStringLiteral } from "./profile";
+import {
+  getSqlDialectProfile,
+  inlineSqlStringLiteral,
+  packSqlListValue,
+} from "./profile";
 import { type DialectAdapter } from "./types";
 
 /**
@@ -56,6 +61,36 @@ function toPostgresPath(pointer: JsonPointer): SqlFragment {
     .map((segment) => inlineSqlStringLiteral(segment, "postgres"))
     .join(", ");
   return sql.raw(`ARRAY[${escapedSegments}]`);
+}
+
+/**
+ * The cast that turns a text element of a list-valued `IN` parameter into the
+ * type its left operand was extracted as. Mirrors the `jsonExtract*` casts:
+ * `jsonExtractNumber` yields numeric, `jsonExtractBoolean` boolean,
+ * `jsonExtractDate` timestamptz, and everything else stays text.
+ */
+function postgresElementCast(elementType: ValueType | undefined): SqlFragment {
+  switch (elementType) {
+    case "number": {
+      return sql.raw("::numeric");
+    }
+    case "boolean": {
+      return sql.raw("::boolean");
+    }
+    case "date": {
+      return sql.raw("::timestamptz");
+    }
+    // `jsonExtractText` leaves these as text, so the elements must stay text
+    // too. The compiler rejects array/object/embedding before reaching here.
+    case "string":
+    case "array":
+    case "object":
+    case "embedding":
+    case "unknown":
+    case undefined: {
+      return sql.empty();
+    }
+  }
 }
 
 /**
@@ -217,6 +252,21 @@ export const postgresDialect: DialectAdapter = {
     const operator = negated ? sql.raw("NOT IN") : sql.raw("IN");
     const placeholders = values.map((value) => sql`${value}`);
     return sql`${left} ${operator} (${sql.join(placeholders, sql`, `)})`;
+  },
+
+  inListParameter(left, packedValues, { negated, elementType }) {
+    const operator = negated ? sql.raw("NOT IN") : sql.raw("IN");
+    // One placeholder for the whole list: the binding is JSON text, cast to
+    // jsonb and expanded into a one-column relation, so arity never reaches
+    // the SQL text. Elements arrive as text (`jsonb_array_elements_text`) and
+    // are cast to whatever type the left operand was extracted as, mirroring
+    // the jsonExtract* casts above.
+    const element = sql`in_list_element.value${postgresElementCast(elementType)}`;
+    return sql`${left} ${operator} (SELECT ${element} FROM jsonb_array_elements_text(${packedValues}::jsonb) AS in_list_element(value))`;
+  },
+
+  packListValue(values) {
+    return packSqlListValue(values, "postgres");
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/profile.ts
+++ b/packages/typegraph/src/query/dialect/profile.ts
@@ -44,6 +44,18 @@ export function bindSqlValue(value: unknown, dialect: SqlDialect): unknown {
   return getSqlDialectProfile(dialect).bindValue(value);
 }
 
+/**
+ * Packs a scalar list into the single JSON-text value that a list-valued `IN`
+ * parameter binds to. Every element is bound exactly as the literal form would
+ * bind it, so `field.in([...])` and `field.in(param(...))` agree row for row.
+ */
+export function packSqlListValue(
+  values: readonly unknown[],
+  dialect: SqlDialect,
+): string {
+  return JSON.stringify(values.map((value) => bindSqlValue(value, dialect)));
+}
+
 /** Renders one SQL string literal using the dialect's escaping rules. */
 export function inlineSqlStringLiteral(
   value: string,

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -8,7 +8,7 @@ import { type JsonPointer, parseJsonPointer } from "../json-pointer";
 import { sql } from "../sql-fragment";
 import { fts5Strategy } from "./fulltext-strategy";
 import { likeEscapeClause } from "./like-escape";
-import { getSqlDialectProfile } from "./profile";
+import { getSqlDialectProfile, packSqlListValue } from "./profile";
 import { type DialectAdapter } from "./types";
 
 /**
@@ -216,6 +216,19 @@ export const sqliteDialect: DialectAdapter = {
     const operator = negated ? sql.raw("NOT IN") : sql.raw("IN");
     const packedValues = JSON.stringify(values);
     return sql`${left} ${operator} (SELECT value FROM json_each(${packedValues}))`;
+  },
+
+  inListParameter(left, packedValues, { negated }) {
+    const operator = negated ? sql.raw("NOT IN") : sql.raw("IN");
+    // Same packed shape as the literal `inList` above, with the JSON text
+    // supplied by the caller's binding instead of baked in. SQLite's dynamic
+    // typing makes `json_each.value` compare correctly against every extracted
+    // column type, so the element type needs no cast here.
+    return sql`${left} ${operator} (SELECT value FROM json_each(${packedValues}))`;
+  },
+
+  packListValue(values) {
+    return packSqlListValue(values, "sqlite");
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -429,14 +429,12 @@ export interface DialectAdapter {
    * same rules a literal of that type would be (SQLite booleans as 0/1, dates
    * as ISO text), so the parameterized and literal forms match row for row.
    *
-   * A list whose elements are not all the field's type — `[1, "a"]` against a
-   * number field — is the one input where the dialects diverge, and it is not
-   * normalized here. Each element is individually a legal scalar, so binding
-   * validation accepts it; PostgreSQL then fails at execution casting `"a"` to
-   * the element type, while SQLite's dynamic typing simply matches nothing for
-   * that element. Left as-is deliberately: the list is already malformed at
-   * the call site, and per-element type checking would run on every execution
-   * of the hot path it exists to make fast.
+   * Every element is guaranteed to match the compiled element type, and to be
+   * a finite number when that type is numeric: `PreparedQuery` validates the
+   * binding before it reaches this method. Implementations therefore do not
+   * need to normalize or reject anything — and must not paper over a mismatch,
+   * since doing so is what would let one dialect quietly disagree with
+   * another.
    */
   readonly packListValue: (this: void, values: readonly unknown[]) => unknown;
 

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -6,6 +6,7 @@
  * implementing this interface.
  */
 import { type VectorMetric } from "../../backend/types";
+import { type ValueType } from "../ast";
 import { type JsonPointer } from "../json-pointer";
 import { type SqlFragment } from "../sql-fragment";
 import { type FulltextStrategy } from "./fulltext-strategy";
@@ -84,6 +85,19 @@ export type DialectCapabilities = Readonly<{
    * Whether the dialect supports fulltext MATCH predicates.
    */
   supportsFulltext: boolean;
+}>;
+
+/**
+ * Shape of a list-valued `IN` parameter, resolved at compile time.
+ */
+export type InListParameterOptions = Readonly<{
+  /** Whether the predicate is `notIn` rather than `in`. */
+  negated: boolean;
+  /**
+   * The value type the left operand was compiled for. `undefined` when the
+   * schema declares nothing usable, in which case the comparison is textual.
+   */
+  elementType: ValueType | undefined;
 }>;
 
 /**
@@ -382,6 +396,40 @@ export interface DialectAdapter {
     values: readonly unknown[],
     negated: boolean,
   ) => SqlFragment;
+
+  /**
+   * Tests scalar membership in a list supplied as a SINGLE bound parameter —
+   * the `field.in(param("ids"))` form.
+   *
+   * The emitted SQL must not depend on how many elements the list holds, so a
+   * prepared statement compiles once and serves every arity from the same
+   * cached template. Both bundled dialects therefore unpack a JSON-encoded
+   * array (produced by {@link DialectAdapter.packListValue}) into a one-column
+   * relation instead of emitting one placeholder per element.
+   *
+   * `elementType` is the value type the left operand was compiled for, so a
+   * dialect that extracts JSON as text can cast the unpacked elements to the
+   * same type; `undefined` means text.
+   *
+   * @example
+   * SQLite: left IN (SELECT value FROM json_each(?))
+   * PostgreSQL: left IN (SELECT e.value::numeric FROM jsonb_array_elements_text($1::jsonb) AS e(value))
+   */
+  readonly inListParameter: (
+    this: void,
+    left: SqlFragment,
+    packedValues: SqlFragment,
+    options: InListParameterOptions,
+  ) => SqlFragment;
+
+  /**
+   * Packs the scalar list bound to an `in()`/`notIn()` parameter into the
+   * single driver value {@link DialectAdapter.inListParameter} unpacks.
+   * Elements arrive as plain JavaScript scalars and must be bound with the
+   * same rules a literal of that type would be (SQLite booleans as 0/1, dates
+   * as ISO text), so the parameterized and literal forms match row for row.
+   */
+  readonly packListValue: (this: void, values: readonly unknown[]) => unknown;
 
   // ============================================================
   // String Operations

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -428,6 +428,15 @@ export interface DialectAdapter {
    * Elements arrive as plain JavaScript scalars and must be bound with the
    * same rules a literal of that type would be (SQLite booleans as 0/1, dates
    * as ISO text), so the parameterized and literal forms match row for row.
+   *
+   * A list whose elements are not all the field's type — `[1, "a"]` against a
+   * number field — is the one input where the dialects diverge, and it is not
+   * normalized here. Each element is individually a legal scalar, so binding
+   * validation accepts it; PostgreSQL then fails at execution casting `"a"` to
+   * the element type, while SQLite's dynamic typing simply matches nothing for
+   * that element. Left as-is deliberately: the list is already malformed at
+   * the call site, and per-element type checking would run on every execution
+   * of the hot path it exists to make fast.
    */
   readonly packListValue: (this: void, values: readonly unknown[]) => unknown;
 

--- a/packages/typegraph/src/query/predicates.ts
+++ b/packages/typegraph/src/query/predicates.ts
@@ -95,8 +95,10 @@ function predicate(expr: PredicateExpression): Predicate {
  * Creates a named parameter reference for prepared queries.
  *
  * Use with `query.prepare()` to create reusable parameterized queries.
- * Only supported in scalar comparison positions (eq, neq, gt, etc.),
- * string operations, and between bounds. Not supported in `in()`/`notIn()`.
+ * Supported in scalar comparison positions (eq, neq, gt, etc.), string
+ * operations, between bounds, and as the WHOLE list of `in()`/`notIn()` —
+ * `field.in(param("ids"))` bound to an array at execute time. A `param()`
+ * among the individual elements of a literal list is rejected.
  *
  * @example
  * ```typescript
@@ -107,6 +109,18 @@ function predicate(expr: PredicateExpression): Predicate {
  *   .prepare();
  *
  * const results = await prepared.execute({ name: "Alice" });
+ * ```
+ *
+ * @example List-valued parameter — one compiled statement, any list length.
+ * ```typescript
+ * const byIds = store.query()
+ *   .from("Person", "p")
+ *   .whereNode("p", (p) => p.id.in(param("ids")))
+ *   .select((ctx) => ctx.p)
+ *   .prepare();
+ *
+ * await byIds.execute({ ids: ["a", "b"] });
+ * await byIds.execute({ ids: ["c"] });
  * ```
  */
 // eslint-disable-next-line unicorn/name-replacements -- concise public API
@@ -156,8 +170,8 @@ type BaseFieldBuilder = Readonly<{
   neq: (value: unknown) => Predicate;
   isNull: () => Predicate;
   isNotNull: () => Predicate;
-  in: (values: readonly unknown[]) => Predicate;
-  notIn: (values: readonly unknown[]) => Predicate;
+  in: (values: readonly unknown[] | ParameterRef) => Predicate;
+  notIn: (values: readonly unknown[] | ParameterRef) => Predicate;
 }>;
 
 /**
@@ -489,13 +503,39 @@ function comparison(
 
 /**
  * Creates an IN comparison predicate.
+ *
+ * The whole list may be a single `param()` — bound at
+ * `.prepare().execute({ ids: [...] })` and compiled to one placeholder, so
+ * varying list lengths reuse one cached statement. A `param()` sitting among
+ * literal *elements* has no such representation (a placeholder cannot be one
+ * item of a list the compiler already inlined), so it is rejected rather than
+ * silently bound as a literal.
  */
 function inComparison(
   op: "in" | "notIn",
   field: FieldRef,
-  values: readonly unknown[],
+  values: readonly unknown[] | ParameterRef,
 ): Predicate {
-  const literals = values.map((value) => literal(coerceLiteralValue(value)));
+  if (isParameterRef(values)) {
+    return predicate({
+      __type: "comparison",
+      op,
+      left: field,
+      right: values,
+    } satisfies ComparisonPredicate);
+  }
+  const literals = values.map((value) => {
+    if (isParameterRef(value)) {
+      throw new UnsupportedPredicateError(
+        `param("${value.name}") is not supported as an element of the ${op}() list`,
+        { parameterName: value.name },
+        {
+          suggestion: `Bind the whole list instead: .${op}(param("${value.name}")) and execute({ ${value.name}: [...] }).`,
+        },
+      );
+    }
+    return literal(coerceLiteralValue(value));
+  });
   const expr: ComparisonPredicate = {
     __type: "comparison",
     op,

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -472,6 +472,70 @@ export function registerPredicateIntegrationTests(
       ).rejects.toThrow(/must not be null/);
     });
 
+    it("rejects a list element that is not the field's type", async () => {
+      const store = context.getStore();
+      const prepared = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.age.in(parameter("ages")))
+        .select((ctx) => ctx.p.name)
+        .prepare();
+
+      // Unchecked, this is the one input the two backends disagree about:
+      // PostgreSQL fails casting "a" to numeric, SQLite matches nothing for
+      // that element and returns the rest. Rejected on both instead.
+      await expect(prepared.execute({ ages: [30, "a"] })).rejects.toThrow(
+        /every element must be a number/,
+      );
+
+      // The literal form already refuses a mixed list when it compiles; the
+      // parameterized form, which has no literals to inspect at compile time,
+      // now reaches the same verdict from the binding.
+      await expect(
+        store
+          .query()
+          .from("Person", "p")
+          .whereNode("p", (p) => p.age.in([30, "a"]))
+          .select((ctx) => ctx.p.name)
+          .execute(),
+      ).rejects.toThrow(/Mixed literal value types/);
+    });
+
+    it("rejects non-finite numbers, which JSON would launder into NULL", async () => {
+      const store = context.getStore();
+      const prepared = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.age.notIn(parameter("ages")))
+        .select((ctx) => ctx.p.name)
+        .prepare();
+
+      // JSON.stringify turns these into `null`, so the packed list would bind
+      // SQL NULL: `NOT IN (NULL)` is NULL for every row and silently returns
+      // nothing at all — the same laundering the null-element check closes.
+      for (const value of [
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+      ]) {
+        await expect(prepared.execute({ ages: [value] })).rejects.toThrow(
+          /must be a finite number/,
+        );
+      }
+
+      // Same hole on the scalar path: SQLite binds NaN as NULL, so `eq(NaN)`
+      // quietly matched no rows rather than failing.
+      const scalar = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.age.eq(parameter("age")))
+        .select((ctx) => ctx.p.name)
+        .prepare();
+      await expect(scalar.execute({ age: Number.NaN })).rejects.toThrow(
+        /must be a finite number/,
+      );
+    });
+
     it("rejects one parameter used as both a list and a scalar", () => {
       const store = context.getStore();
       expect(() =>

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -178,6 +178,247 @@ export function registerPredicateIntegrationTests(
     });
   });
 
+  describe("List-Valued Parameters", () => {
+    beforeEach(async () => {
+      const store = context.getStore();
+      await seedPeopleForComplexPredicates(store);
+    });
+
+    it("reuses one prepared statement across different list lengths", async () => {
+      const store = context.getStore();
+      const prepared = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.in(parameter("names")))
+        .select((ctx) => ctx.p.name)
+        .prepare();
+
+      // The whole point of the packed binding: arity is not part of the SQL
+      // text, so the same compiled statement serves every list length.
+      const three = await prepared.execute({
+        names: ["Alice", "Charlie", "Eve"],
+      });
+      expect(three.toSorted()).toEqual(["Alice", "Charlie"]);
+
+      const one = await prepared.execute({ names: ["Bob"] });
+      expect(one.toSorted()).toEqual(["Bob"]);
+
+      const none = await prepared.execute({ names: [] });
+      expect(none).toEqual([]);
+
+      // ...and the third call still agrees with the first, proving nothing
+      // from an earlier arity was frozen into the cached template.
+      const threeAgain = await prepared.execute({
+        names: ["Alice", "Charlie", "Eve"],
+      });
+      expect(threeAgain.toSorted()).toEqual(["Alice", "Charlie"]);
+    });
+
+    it("agrees with the literal in() form", async () => {
+      const store = context.getStore();
+      const names = ["Alice", "Diana", "Nobody"];
+
+      const literal = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.in(names))
+        .select((ctx) => ctx.p.name)
+        .execute();
+
+      const parameterized = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.in(parameter("names")))
+        .select((ctx) => ctx.p.name)
+        .prepare()
+        .execute({ names });
+
+      expect(parameterized.toSorted()).toEqual(literal.toSorted());
+      expect(literal.toSorted()).toEqual(["Alice", "Diana"]);
+    });
+
+    it("binds a notIn list, including the empty list", async () => {
+      const store = context.getStore();
+      const prepared = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.notIn(parameter("names")))
+        .select((ctx) => ctx.p.name)
+        .prepare();
+
+      const excluded = await prepared.execute({ names: ["Alice", "Bob"] });
+      expect(excluded.toSorted()).toEqual(["Charlie", "Diana"]);
+
+      // Excluding nothing must keep everyone — the mirror of `in([])`.
+      const excludeNothing = await prepared.execute({ names: [] });
+      expect(excludeNothing.toSorted()).toEqual([
+        "Alice",
+        "Bob",
+        "Charlie",
+        "Diana",
+      ]);
+    });
+
+    it("binds a list far larger than the smallest bind budget", async () => {
+      const store = context.getStore();
+      // SQLite's conservative ceiling is 999 bound parameters and Durable
+      // Objects' is lower still; a packed list costs exactly one regardless.
+      const names = [
+        ...Array.from({ length: 5000 }, (_, index) => `missing-${index}`),
+        "Alice",
+        "Charlie",
+      ];
+
+      const results = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.in(parameter("names")))
+        .select((ctx) => ctx.p.name)
+        .prepare()
+        .execute({ names });
+
+      expect(results.toSorted()).toEqual(["Alice", "Charlie"]);
+    });
+
+    it("binds node ids — the canonical prepared id-set query", async () => {
+      const store = context.getStore();
+      const everyone = await store
+        .query()
+        .from("Person", "p")
+        .select((ctx) => ({ id: ctx.p.id, name: ctx.p.name }))
+        .execute();
+      const wanted = everyone.filter((person) =>
+        ["Alice", "Charlie"].includes(person.name),
+      );
+
+      const results = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.id.in(parameter("ids")))
+        .select((ctx) => ctx.p.name)
+        .prepare()
+        .execute({ ids: wanted.map((person) => person.id) });
+
+      expect(results.toSorted()).toEqual(["Alice", "Charlie"]);
+    });
+
+    it("binds number and boolean lists with the field's declared type", async () => {
+      const store = context.getStore();
+
+      const ages = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.age.in(parameter("ages")))
+        .select((ctx) => ctx.p.name)
+        .prepare()
+        .execute({ ages: [25, 35] });
+      expect(ages.toSorted()).toEqual(["Bob", "Charlie"]);
+
+      const flags = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.isActive.in(parameter("flags")))
+        .select((ctx) => ctx.p.name)
+        .prepare()
+        .execute({ flags: [false] });
+      expect(flags.toSorted()).toEqual(["Bob"]);
+    });
+
+    it("binds a date list", async () => {
+      const store = context.getStore();
+      const wanted = new Date("2024-03-01T00:00:00.000Z");
+      await store.nodes.Document.create({
+        title: "Dated",
+        publishedAt: wanted,
+      });
+      await store.nodes.Document.create({
+        title: "Other",
+        publishedAt: new Date("2024-09-09T00:00:00.000Z"),
+      });
+
+      const results = await store
+        .query()
+        .from("Document", "d")
+        .whereNode("d", (d) => d.publishedAt.in(parameter("dates")))
+        .select((ctx) => ctx.d.title)
+        .prepare()
+        .execute({ dates: [wanted] });
+
+      expect(results).toEqual(["Dated"]);
+    });
+
+    it("composes with a scalar parameter in the same query", async () => {
+      const store = context.getStore();
+      const prepared = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) =>
+          p.name.in(parameter("names")).and(p.age.gt(parameter("minAge"))),
+        )
+        .select((ctx) => ctx.p.name)
+        .prepare();
+
+      expect([...prepared.parameterNames].toSorted()).toEqual([
+        "minAge",
+        "names",
+      ]);
+
+      const older = await prepared.execute({
+        minAge: 29,
+        names: ["Alice", "Bob", "Charlie"],
+      });
+      expect(older.toSorted()).toEqual(["Alice", "Charlie"]);
+
+      const younger = await prepared.execute({
+        minAge: 20,
+        names: ["Bob"],
+      });
+      expect(younger.toSorted()).toEqual(["Bob"]);
+    });
+
+    it("rejects a param() among the elements of a literal list", () => {
+      const store = context.getStore();
+      expect(() =>
+        store
+          .query()
+          .from("Person", "p")
+          .whereNode("p", (p) => p.name.in(["Alice", parameter("other")])),
+      ).toThrow(/is not supported as an element of the in\(\) list/);
+    });
+
+    it("rejects a non-array binding for a list parameter", async () => {
+      const store = context.getStore();
+      const prepared = store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (p) => p.name.in(parameter("names")))
+        .select((ctx) => ctx.p.name)
+        .prepare();
+
+      await expect(prepared.execute({ names: "Alice" })).rejects.toThrow(
+        /must be an array for in\(\)\/notIn\(\)/,
+      );
+      await expect(
+        // eslint-disable-next-line unicorn/no-null -- null bindings are rejected everywhere
+        prepared.execute({ names: ["Alice", null] }),
+      ).rejects.toThrow(/must not be null/);
+    });
+
+    it("rejects one parameter used as both a list and a scalar", () => {
+      const store = context.getStore();
+      expect(() =>
+        store
+          .query()
+          .from("Person", "p")
+          .whereNode("p", (p) =>
+            p.name.in(parameter("value")).or(p.name.eq(parameter("value"))),
+          )
+          .select((ctx) => ctx.p.name)
+          .prepare(),
+      ).toThrow(/used both as an in\(\)\/notIn\(\) list and as a scalar value/);
+    });
+  });
+
   describe("Null predicates across stored value shapes", () => {
     it('isNull matches absent and JSON-null values but not the string "null"', async () => {
       const store = context.getStore();

--- a/packages/typegraph/tests/backends/integration/predicates.ts
+++ b/packages/typegraph/tests/backends/integration/predicates.ts
@@ -31,6 +31,27 @@ async function seedNullShapeEdges(store: IntegrationStore): Promise<void> {
   await store.edges.knows.create(anna, numeric, { weight: 7 });
 }
 
+/**
+ * Runs the same membership test as a literal list and as a bound list
+ * parameter, and asserts they agree.
+ *
+ * String is the element type that needs this least — it is the one Postgres
+ * does not cast. Number, boolean, and date each ride an element cast that has
+ * to mirror the `jsonExtract*` cast the left operand was compiled with, so
+ * those are the pairs where a drift shows up as wrong rows rather than as an
+ * error.
+ */
+async function expectAgreement(
+  literal: () => Promise<readonly string[]>,
+  parameterized: () => Promise<readonly string[]>,
+  expected: readonly string[],
+): Promise<void> {
+  const fromLiteral = await literal();
+  const fromParameter = await parameterized();
+  expect(fromParameter.toSorted()).toEqual(fromLiteral.toSorted());
+  expect(fromLiteral.toSorted()).toEqual(expected);
+}
+
 export function registerPredicateIntegrationTests(
   context: IntegrationTestContext,
 ): void {
@@ -214,27 +235,97 @@ export function registerPredicateIntegrationTests(
       expect(threeAgain.toSorted()).toEqual(["Alice", "Charlie"]);
     });
 
-    it("agrees with the literal in() form", async () => {
+    it("agrees with the literal in() form for every element type", async () => {
       const store = context.getStore();
+      const published = new Date("2024-03-01T00:00:00.000Z");
+      await store.nodes.Document.create({
+        title: "Dated",
+        publishedAt: published,
+      });
+      await store.nodes.Document.create({
+        title: "Other",
+        publishedAt: new Date("2024-09-09T00:00:00.000Z"),
+      });
+
       const names = ["Alice", "Diana", "Nobody"];
+      await expectAgreement(
+        () =>
+          store
+            .query()
+            .from("Person", "p")
+            .whereNode("p", (p) => p.name.in(names))
+            .select((ctx) => ctx.p.name)
+            .execute(),
+        () =>
+          store
+            .query()
+            .from("Person", "p")
+            .whereNode("p", (p) => p.name.in(parameter("names")))
+            .select((ctx) => ctx.p.name)
+            .prepare()
+            .execute({ names }),
+        ["Alice", "Diana"],
+      );
 
-      const literal = await store
-        .query()
-        .from("Person", "p")
-        .whereNode("p", (p) => p.name.in(names))
-        .select((ctx) => ctx.p.name)
-        .execute();
+      const ages = [25, 35, 99];
+      await expectAgreement(
+        () =>
+          store
+            .query()
+            .from("Person", "p")
+            .whereNode("p", (p) => p.age.in(ages))
+            .select((ctx) => ctx.p.name)
+            .execute(),
+        () =>
+          store
+            .query()
+            .from("Person", "p")
+            .whereNode("p", (p) => p.age.in(parameter("ages")))
+            .select((ctx) => ctx.p.name)
+            .prepare()
+            .execute({ ages }),
+        ["Bob", "Charlie"],
+      );
 
-      const parameterized = await store
-        .query()
-        .from("Person", "p")
-        .whereNode("p", (p) => p.name.in(parameter("names")))
-        .select((ctx) => ctx.p.name)
-        .prepare()
-        .execute({ names });
+      const flags = [false];
+      await expectAgreement(
+        () =>
+          store
+            .query()
+            .from("Person", "p")
+            .whereNode("p", (p) => p.isActive.in(flags))
+            .select((ctx) => ctx.p.name)
+            .execute(),
+        () =>
+          store
+            .query()
+            .from("Person", "p")
+            .whereNode("p", (p) => p.isActive.in(parameter("flags")))
+            .select((ctx) => ctx.p.name)
+            .prepare()
+            .execute({ flags }),
+        ["Bob"],
+      );
 
-      expect(parameterized.toSorted()).toEqual(literal.toSorted());
-      expect(literal.toSorted()).toEqual(["Alice", "Diana"]);
+      const dates = [published];
+      await expectAgreement(
+        () =>
+          store
+            .query()
+            .from("Document", "d")
+            .whereNode("d", (d) => d.publishedAt.in(dates))
+            .select((ctx) => ctx.d.title)
+            .execute(),
+        () =>
+          store
+            .query()
+            .from("Document", "d")
+            .whereNode("d", (d) => d.publishedAt.in(parameter("dates")))
+            .select((ctx) => ctx.d.title)
+            .prepare()
+            .execute({ dates }),
+        ["Dated"],
+      );
     });
 
     it("binds a notIn list, including the empty list", async () => {
@@ -322,29 +413,6 @@ export function registerPredicateIntegrationTests(
         .prepare()
         .execute({ flags: [false] });
       expect(flags.toSorted()).toEqual(["Bob"]);
-    });
-
-    it("binds a date list", async () => {
-      const store = context.getStore();
-      const wanted = new Date("2024-03-01T00:00:00.000Z");
-      await store.nodes.Document.create({
-        title: "Dated",
-        publishedAt: wanted,
-      });
-      await store.nodes.Document.create({
-        title: "Other",
-        publishedAt: new Date("2024-09-09T00:00:00.000Z"),
-      });
-
-      const results = await store
-        .query()
-        .from("Document", "d")
-        .whereNode("d", (d) => d.publishedAt.in(parameter("dates")))
-        .select((ctx) => ctx.d.title)
-        .prepare()
-        .execute({ dates: [wanted] });
-
-      expect(results).toEqual(["Dated"]);
     });
 
     it("composes with a scalar parameter in the same query", async () => {

--- a/packages/typegraph/tests/compiled-sql-template-cache.test.ts
+++ b/packages/typegraph/tests/compiled-sql-template-cache.test.ts
@@ -118,6 +118,54 @@ describe("compiled SQL template cache", () => {
     expect(counts.executeRaw).toBe(3);
   });
 
+  it("compiles a list-valued in() parameter once across differing list lengths", async () => {
+    const { backend, counts } = countingBackend(real);
+    const store = createStore(graph, backend);
+    await store.nodes.Person.create({ name: "Alice" });
+    await store.nodes.Person.create({ name: "Bob" });
+
+    const peopleByName = store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.name.in(parameter("names")))
+      .select((ctx) => ctx.p.name)
+      .prepare();
+
+    counts.compileSql = 0;
+    counts.executeRaw = 0;
+
+    expect(await peopleByName.execute({ names: ["Alice"] })).toEqual(["Alice"]);
+    const both = await peopleByName.execute({ names: ["Alice", "Bob"] });
+    expect(both.toSorted()).toEqual(["Alice", "Bob"]);
+    expect(await peopleByName.execute({ names: [] })).toEqual([]);
+
+    // The list rides on a single placeholder, so arity never reaches the SQL
+    // text — three different list lengths share one compiled statement.
+    expect(counts.compileSql).toBe(1);
+    expect(counts.executeRaw).toBe(3);
+  });
+
+  it("binds a list-valued in() parameter without executeRaw", async () => {
+    const backend = backendWithoutRawExecution(real);
+    const store = createStore(graph, backend);
+    await store.nodes.Person.create({ name: "Alice" });
+    await store.nodes.Person.create({ name: "Bob" });
+
+    // The fallback substitutes the binding into the AST as a literal list
+    // instead of packing it behind a placeholder; results must not differ.
+    const peopleByName = store
+      .query()
+      .from("Person", "p")
+      .whereNode("p", (p) => p.name.in(parameter("names")))
+      .select((ctx) => ctx.p.name)
+      .prepare();
+
+    const both = await peopleByName.execute({ names: ["Alice", "Bob"] });
+    expect(both.toSorted()).toEqual(["Alice", "Bob"]);
+    expect(await peopleByName.execute({ names: ["Bob"] })).toEqual(["Bob"]);
+    expect(await peopleByName.execute({ names: [] })).toEqual([]);
+  });
+
   it("compiles a reused ExecutableQuery instance once across executions", async () => {
     const { backend, counts } = countingBackend(real);
     const store = createStore(graph, backend);

--- a/packages/typegraph/vitest.config.ts
+++ b/packages/typegraph/vitest.config.ts
@@ -15,6 +15,8 @@ const GRAPH_MERGE_GLOBS = [
   ...(UNIT_SCOPE ? [] : ["tests/property/graph-merge/**/*.test.ts"]),
 ];
 
+const PGLITE_GLOBS = ["tests/backends/postgres/pglite-*.test.ts"];
+
 const SHARED_EXCLUDE = [
   ...configDefaults.exclude,
   // #140: workerd-only do-sqlite suite — runs via `test:do`
@@ -98,8 +100,24 @@ export default defineConfig({
           exclude: [
             ...SHARED_EXCLUDE,
             ...GRAPH_MERGE_GLOBS,
+            ...PGLITE_GLOBS,
             ...UNIT_PROPERTY_EXCLUDE,
           ],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "pglite",
+          include: PGLITE_GLOBS,
+          exclude: SHARED_EXCLUDE,
+          // These suites provision in-process Postgres instances and exercise
+          // persistence plus bulk-write paths. Keep their normal startup and
+          // teardown latency from competing with file-parallel unit tests or
+          // the default five-second budget.
+          fileParallelism: false,
+          testTimeout: 60_000,
+          hookTimeout: 60_000,
         },
       },
       {


### PR DESCRIPTION
Closes #326

> **Postgres lane: PENDING team-lead verification.** Treat this PR as
> having no authoritative Postgres result. The shared PG cluster
> (`max_connections = 100`, ~42 backends per lane) was contended by up to
> nine concurrent lanes today, so no PG number produced in that window is
> trustworthy. The team lead owns the PG queue and will run this lane in a
> dedicated slot and post the result here.
>
> For the record and explicitly *not* as the lane: I did complete a full
> `pnpm test:postgres` (73 files, 2256 passed, exit 0) before handing the
> queue over. I am reporting it because omitting it would be dishonest, not
> because it settles anything — it ran outside the queue and may have been
> concurrent with other lanes. Nothing in this PR was changed in response to
> any Postgres failure; every failure I saw was diagnosed as infrastructure
> (connection exhaustion, tmpfs `No space left on device`, a dropped
> database, and an unscoped `pkill` SIGTERM) and none produced a code edit.

`param()` could not be used inside `in()` / `notIn()`, so the canonical
hot query — "fetch these N ids" — could never be `prepare()`d. Worse,
`inComparison` coerced *every* element to a literal without checking
`isParameterRef` first (unlike `eq`, `gt`, and the string ops), so a
`ParameterRef` passed in was silently bound as a literal and produced
wrong results with no error.

This implements full list-valued parameter support:

```typescript
const byIds = store.query()
  .from("Person", "p")
  .whereNode("p", (p) => p.id.in(param("ids")))
  .select((ctx) => ctx.p)
  .prepare();

await byIds.execute({ ids: ["a", "b", "c"] });
await byIds.execute({ ids: ["d"] });   // same compiled statement
```

## Arity strategy: packed single-parameter binding (no bucketing)

The issue framed this as a tradeoff — Postgres can bind an array
(`= ANY($1)`), SQLite can't, so arity looks like part of the SQL text and
a varying-length list looks like it defeats a single cached template. It
turns out neither dialect needs arity in the text, so there is no
tradeoff to make.

The list is bound as **one** parameter holding a JSON-encoded array, and
the SQL unpacks it into a one-column relation:

| Dialect | Emitted SQL |
| --- | --- |
| SQLite | `left IN (SELECT value FROM json_each(?))` |
| PostgreSQL | `left IN (SELECT e.value::T FROM jsonb_array_elements_text($1::jsonb) AS e(value))` |

Consequences:

- **One cached template, forever.** The SQL text does not mention the
  list's length, so `.prepare()` compiles once and every `execute()` —
  1 element, 5000 elements, or 0 — reuses it. No bucketing, no padding,
  no per-arity cache entries, no wasted `IS NULL` slots.
- **Bind budget is a non-issue.** A list of any size costs exactly one
  bound parameter, well under SQLite's 999, D1's cap, and Postgres'
  65,535. This is strictly better than the literal `in([...])` form on
  Postgres, which still emits one placeholder per element.
- **Empty list needs no special case.** An empty JSON array unpacks to an
  empty relation, so `IN` is false and `NOT IN` is true — exactly what
  the literal path's `1=0` / `1=1` short circuit produces.
- **Driver-independent.** The bound value is always a JSON *string*, so
  nothing depends on how `pg`, `postgres.js`, or PGlite serializes a
  JavaScript array. (This is why I did not use `= ANY($1)`.)

SQLite already used this packed form for the literal `inList`, so the
parameterized path is the same shape with the JSON supplied by the
binding instead of baked in.

### Why not the alternatives

- **Bucketed arity + padding**: needs a cache per bucket, needs a padding
  value that can never collide with real data, and still recompiles when
  a list crosses a bucket boundary. Strictly worse than not putting arity
  in the text at all.
- **Dialect-capability split** (array binding on PG, per-arity on SQLite):
  would have given the two backends different caching behavior for the
  same query — exactly the parity divergence the repo's rules exist to
  prevent.

## Parity

The dialect difference is expressed only through two new
**`DialectAdapter` interface members** — no `=== "sqlite"` branching
anywhere under `src/query`:

- `inListParameter(left, packedValues, { negated, elementType })` — the
  SQL half.
- `packListValue(values)` — the binding half, so one dialect file owns
  both ends of its contract and they cannot drift.

`elementType` is the value type the *left* operand was compiled for, so
Postgres casts the unpacked text elements to match its `jsonExtract*`
casts (`::numeric`, `::boolean`, `::timestamptz`, else text). SQLite is
dynamically typed and needs no cast; booleans are packed as `0`/`1` via
the shared `packSqlListValue`, exactly as a literal would be bound.

All query-feature tests are in the shared cross-backend suite
(`tests/backends/integration/predicates.ts`), so they run on SQLite,
libSQL, Postgres, postgres.js, and PGlite.

## Typed rejection for what is not supported

A `ParameterRef` among the *elements* of a literal list —
`in(["Alice", param("other")])` — has no placeholder representation and
now throws `UnsupportedPredicateError` naming the supported form,
instead of silently coercing to a literal. A name used both as a list and
as a scalar in one query is rejected at `prepare()` (one binding cannot
be both an array and a scalar), as is a name bound as a list against two
fields of different types.

## Binding validation: closing a hole, not adding a restriction

Element types are validated against the field's type before binding, so
`[1, "a"]` against a number field is refused with a `ConfigurationError`.
Verified in-process before fixing: unchecked, SQLite returned `['Alice']`
(silently dropping the bad element) while PGlite threw `invalid input
syntax for type numeric: "a"` — the same query, two behaviors.

The framing that matters is not "add a restriction". **The literal form
already rejects this**: `resolveLiteralValueTypes` throws *"Mixed literal
value types are not supported in predicates"* when it compiles. So
`param()` was not merely diverging across backends, it was *more
permissive than the literal form of the same predicate*. The fix closes
that hole rather than inventing a rule — the spec was "reach the verdict
the compiler already reaches", from the binding instead of from literals
there are none of.

The expected type comes from a shared `resolveParameterValueType` used by
both the compiler — which picks the `jsonExtract*` variant and the
matching element cast from it — and the binding validator. One source, so
the check and the cast cannot drift, the same construction that keeps the
casts aligned.

Date fields accept a `Date` or a `string` without parsing the string.
Validating arbitrary date formats risks rejecting input PostgreSQL
accepts, and an unparseable date string diverges identically in the
literal form today — so it is not a divergence this change introduces.

**Non-finite numbers** (`NaN`, `±Infinity`) are rejected in any binding,
list *or* scalar. `JSON.stringify` turns them into `null`, so a packed
list bound SQL NULL and `notIn(param("x"))` with `[NaN]` filtered out
every row. The scalar path had the same hole from the other direction:
SQLite binds `NaN` as NULL, so `eq(param("x"))` with `NaN` quietly
matched nothing. Both confirmed empirically.

The scalar half is in this PR **deliberately**, not as scope creep. The
guard lives in `validateBindingValue` because that is the single seam
both execution paths — raw-execution and AST-substitution — already pass
through, so they reject identically; guarding at pack time would have
covered only the fast path. The list check calls that same validator per
element, so fixing *only* lists would have taken more code than fixing
both, and would have shipped a known silent-wrong-answer path next to its
fixed twin in a PR whose subject is that exact class of bug.

## Tests

`tests/backends/integration/predicates.ts` (all backends): different-length
lists on one prepared statement, empty list, single element, 5000-element
list, `notIn` (including `notIn([])` keeping everything), node-id sets,
number/boolean/date element typing, composition with a scalar param, parity
with the literal `in()` form across all four element types, mixed-type and
non-finite rejection (list and scalar), and the remaining rejection paths.

`tests/compiled-sql-template-cache.test.ts` pins the mechanism directly:
three differing arities produce `compileSql === 1` and `executeRaw === 3`,
plus the no-`executeRaw` fallback (AST substitution to a literal list)
returning identical results.

## For reviewers

- **Postgres plan shape changes for the parameterized form only** — the
  literal `in([...])` path is untouched (still `IN ($1, $2, …)`). Measured
  on PGlite (Postgres 18.3), 50k-row table, primary-key lookup, 200 calls
  per point:

  | list length | literal `in([...])` | packed `in(param)` | ratio |
  | --- | --- | --- | --- |
  | 1 | 0.130 ms | 0.155 ms | 1.19× |
  | 3 | 0.123 ms | 0.144 ms | 1.17× |
  | 10 | 0.137 ms | 0.156 ms | 1.14× |
  | 100 | 0.397 ms | 0.347 ms | 0.87× |
  | 1000 | 2.866 ms | 2.389 ms | 0.83× |

  Crossover sits between 10 and 100 elements. Below it the penalty is a
  flat ~20 µs — noise next to a network round trip, and callers reaching
  for `param()` are buying the prepared-statement win anyway.

  The important part is that **the packed form does not lose the index**.
  It plans as a `Nested Loop` with a `HashAggregate` over the unpacked
  elements driving index lookups on the inner side, rather than degrading
  to a sequential scan.

  **One caveat worth knowing:** `jsonb_array_elements_text` has
  `pg_proc.prorows = 100`, so the planner estimates 100 rows for the
  unpacked relation at *every* list length — the plan above reads
  `rows=100` whether the actual count is 1 or 1000. It picked the right
  plan at every size here, but that estimate is a constant, not a
  measurement, and it propagates into surrounding joins. If a composite
  query is ever mis-planned around a list parameter, this is the first
  thing to look at.

  Reproduction script (gitignored): `packages/typegraph/tmp/in-param-crossover.mjs`.
- **`assertListBinding` lives in `read-instant-template.ts`.** It is used
  by both the fast path (bind time) and the fallback path (AST
  substitution in `prepared-query.ts`); putting it in `prepared-query.ts`
  would have created an import cycle.
- **Drive-by doc fix.** `queries/execute.md`'s "Prepared Query SQL
  Compilation" section still claimed prepared queries do **not** cache
  compiled SQL and recompile every call — stale since #248 built the
  template cache. It now describes the placeholder-based cache. This
  matters here because the whole point of the feature is that a list
  param reuses that cache.
- API reports (`etc/*.api.md`) regenerated for the two new
  `DialectAdapter` members and the widened `in`/`notIn` signatures.
