### PR TITLE
Make documented query hooks observe submitted statements

### DIFF
--- a/.changeset/query-hooks-observe-statements.md
+++ b/.changeset/query-hooks-observe-statements.md
@@ -1,0 +1,8 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Make the documented store query hooks fire for query-builder statements,
+including prepared queries, batched queries, and selective-projection retries.
+Each submitted statement now reports its SQL, parameters, row count, duration,
+and failures through the existing `StoreHooks` callbacks.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -2346,6 +2346,10 @@ handle. See
 ## Observability Hooks
 
 TypeGraph supports observability hooks for monitoring and logging store operations.
+Query hooks describe SQL statements submitted by the query builder, not logical
+query-builder calls or backend-internal setup statements. A logical query that retries
+with a different projection therefore fires the query hooks once for each statement it
+submits.
 
 ### `StoreHooks`
 
@@ -2418,11 +2422,13 @@ const hooks: StoreHooks = {
 
 const store = createStore(graph, backend, { hooks });
 
-// Operations now trigger hooks
+// CRUD operations trigger operation hooks; query-builder statements trigger
+// query hooks.
 await store.nodes.Person.create({ name: "Alice" });
-// Logs:
+await store.query().from("Person", "p").select((ctx) => ctx.p).execute();
+// Logs include:
 // [op-abc123] create node:Person
-// [op-abc123] SQL: INSERT INTO ...
-// [op-abc123] 1 rows in 2ms
 // [op-abc123] Completed in 5ms
+// [query-def456] SQL: WITH ... SELECT ...
+// [query-def456] 1 rows in 2ms
 ```

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -93,6 +93,8 @@ import {
 import { getDialect } from "../query/dialect";
 import type { SqlDialect } from "../query/dialect/types";
 import { type VectorSlot } from "../query/dialect/vector-strategy";
+import { renderSql } from "../query/sql-fragment";
+import { type CompiledRowsSql } from "../query/sql-intent";
 import { buildKindRegistry, type KindRegistry } from "../registry";
 import {
   applyDeprecatedKinds,
@@ -230,6 +232,7 @@ import {
   type MeasurableTransactionContext,
   type Node,
   type OperationHookContext,
+  type QueryHookContext,
   type QueryOptions,
   type RecordedReadStoreOptions,
   type RecordedScanOptions,
@@ -1735,9 +1738,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     // scope — which demands executeStatement on the transaction target — for a
     // path that performs no writes and needs no capture.
     return runOptionallyInTransaction(this.#baseBackend, async (target) => {
+      const queryBackend = this.#createHookedQueryBackend(target);
       const results: unknown[] = [];
       for (const query of queries) {
-        const result = await query.executeOn(target);
+        const result = await query.executeOn(queryBackend);
         results.push(result);
       }
       return results as BatchResults<Queries>;
@@ -3572,6 +3576,78 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
 
   // === Internal: Hook Helpers ===
 
+  /**
+   * Decorates the query execution port so hooks observe each statement the
+   * query builder submits to the backend. A selective-projection retry
+   * therefore emits two independent start/end pairs with their actual SQL.
+   */
+  #createHookedQueryBackend(
+    backend: GraphBackend | TransactionBackend,
+  ): GraphBackend {
+    if (
+      this.#hooks.onQueryStart === undefined &&
+      this.#hooks.onQueryEnd === undefined &&
+      this.#hooks.onError === undefined
+    ) {
+      return backend as GraphBackend;
+    }
+
+    const executeRaw = backend.executeRaw;
+    const compileSql = backend.compileSql;
+    // Store backends may be frozen. Copy an allowlist projection so
+    // execute/executeRaw can be replaced without mutating the source.
+    const projected = createGraphBackendProjection(backend as GraphBackend);
+
+    return {
+      ...projected,
+      execute: <T>(query: CompiledRowsSql): Promise<readonly T[]> => {
+        const compiled =
+          compileSql === undefined ?
+            renderSql(query, backend.dialect)
+          : compileSql(query);
+        return this.#withQueryHooks(compiled.sql, compiled.params, () =>
+          backend.execute<T>(query),
+        );
+      },
+      ...(executeRaw === undefined ?
+        {}
+      : {
+          executeRaw: <T>(
+            sqlText: string,
+            params: readonly unknown[],
+          ): Promise<readonly T[]> =>
+            this.#withQueryHooks(sqlText, params, () =>
+              executeRaw<T>(sqlText, params),
+            ),
+        }),
+    } satisfies GraphBackend;
+  }
+
+  async #withQueryHooks<T>(
+    sql: string,
+    params: readonly unknown[],
+    execute: () => Promise<readonly T[]>,
+  ): Promise<readonly T[]> {
+    const ctx: QueryHookContext = {
+      ...this.#createHookContext(),
+      sql,
+      params,
+    };
+    this.#hooks.onQueryStart?.(ctx);
+    const startTime = Date.now();
+    try {
+      const rows = await execute();
+      this.#hooks.onQueryEnd?.(ctx, {
+        rowCount: rows.length,
+        durationMs: Date.now() - startTime,
+      });
+      return rows;
+    } catch (error) {
+      this.#hooks.onError?.(ctx, asError(error));
+      throw error;
+    }
+  }
+
   #createHookContext(): HookContext {
     return {
       operationId: generateId(),
@@ -3688,13 +3764,14 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     backend: GraphBackend | TransactionBackend,
     sealedCoordinate?: ReadCoordinate,
   ): InitialQueryBuilder<G, CoordinateState> {
+    const queryBackend = this.#createHookedQueryBackend(backend);
     return createInternalQueryBuilder<G, CoordinateState>(
       this.graphId,
       this.#registry,
       {
         // TransactionBackend omits transaction/close, but query execution only needs
         // the read-path/query capabilities shared with GraphBackend.
-        backend: backend as GraphBackend,
+        backend: queryBackend,
         dialect: backend.dialect,
         defaultTraversalExpansion: this.#defaultTraversalExpansion,
         ...(this.#schema !== undefined && { schema: this.#schema }),

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -222,11 +222,15 @@ export type HookContext = Readonly<{
 }>;
 
 /**
- * Query hook context with SQL information.
+ * Context for one SQL statement a query builder submits to the backend.
+ *
+ * A single logical query can emit more than one context, for example when a
+ * selective projection falls back to a full-row fetch. Backend-internal setup
+ * statements are not exposed as separate query-hook events.
  */
 export type QueryHookContext = HookContext &
   Readonly<{
-    /** The SQL query being executed */
+    /** The SQL statement being executed */
     sql: string;
     /** Query parameters */
     params: readonly unknown[];
@@ -272,9 +276,9 @@ export type OperationHookContext = HookContext &
  * ```
  */
 export type StoreHooks = Readonly<{
-  /** Called before a query is executed */
+  /** Called before each query-builder statement is submitted to the backend. */
   onQueryStart?: (ctx: QueryHookContext) => void;
-  /** Called after a query completes successfully */
+  /** Called after each submitted query-builder statement succeeds. */
   onQueryEnd?: (
     ctx: QueryHookContext,
     result: Readonly<{ rowCount: number; durationMs: number }>,

--- a/packages/typegraph/tests/backend-contracts.test.ts
+++ b/packages/typegraph/tests/backend-contracts.test.ts
@@ -19,8 +19,12 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  type HookContext,
+  type QueryHookContext,
   searchable,
 } from "../src";
+import { createGraphBackendProjection } from "../src/backend/graph-backend-projection";
+import { createBackendOverlay, type GraphBackend } from "../src/backend/types";
 import { dumpObservableState } from "./state-snapshot";
 import { createTestBackend } from "./test-utils";
 import {
@@ -319,4 +323,73 @@ describe("hook contract: success is reported only after COMMIT", () => {
       expect(after).toEqual(before);
     });
   }
+});
+
+describe("query hook contract: each submitted statement is observable", () => {
+  it("observes statements executed through store.batch()", async () => {
+    const starts: QueryHookContext[] = [];
+    const [store] = await createStoreWithSchema(graph, createTestBackend(), {
+      hooks: {
+        onQueryStart: (ctx) => {
+          starts.push(ctx);
+        },
+      },
+    });
+    await seedPair(store);
+
+    await store.batch(
+      store
+        .query()
+        .from("Person", "p")
+        .select((ctx) => ctx.p.id),
+      store
+        .query()
+        .from("Person", "p")
+        .select((ctx) => ctx.p.name),
+    );
+
+    expect(starts).toHaveLength(2);
+  });
+
+  it("reports statement failures through onError without firing onQueryEnd", async () => {
+    const backend = createTestBackend();
+    const projected = createGraphBackendProjection(backend);
+    const executeRaw = projected.executeRaw;
+    if (executeRaw === undefined)
+      throw new Error("SQLite must expose executeRaw");
+    const injectedFailure = new Error("injected query failure");
+    let failQueries = false;
+    const failingBackend: GraphBackend = createBackendOverlay(projected, {
+      executeRaw: <T>(sqlText: string, params: readonly unknown[]) =>
+        failQueries ?
+          Promise.reject(injectedFailure)
+        : executeRaw<T>(sqlText, params),
+    });
+    const errors: Readonly<{ ctx: HookContext; error: Error }>[] = [];
+    const ends: QueryHookContext[] = [];
+    const [store] = await createStoreWithSchema(graph, failingBackend, {
+      hooks: {
+        onQueryEnd: (ctx) => {
+          ends.push(ctx);
+        },
+        onError: (ctx, error) => {
+          errors.push({ ctx, error });
+        },
+      },
+    });
+    failQueries = true;
+
+    await expect(
+      store
+        .query()
+        .from("Person", "p")
+        .select((ctx) => ctx.p)
+        .execute(),
+    ).rejects.toBe(injectedFailure);
+
+    expect(ends).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.ctx.graphId).toBe(graph.id);
+    expect(errors[0]?.error).toBe(injectedFailure);
+  });
 });

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -38,6 +38,7 @@ import {
   registerPaginationIntegrationTests,
   registerPredicateIntegrationTests,
   registerProvenanceIntegrationTests,
+  registerQueryHookIntegrationTests,
   registerReconciledSchemaIntegrationTests,
   registerRecordedReadBindingIntegrationTests,
   registerRecordedTimeIntegrationTests,
@@ -158,6 +159,7 @@ export function createIntegrationTestSuite<TNativeTransaction>(
     registerCoalesceUpsertIntegrationTests(context);
     registerPredicateIntegrationTests(context);
     registerProvenanceIntegrationTests(context);
+    registerQueryHookIntegrationTests(context);
     registerOrderingIntegrationTests(context);
     registerLateMaterializationIntegrationTests(context);
     registerTemporalIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -16,6 +16,7 @@ export { registerOrderingIntegrationTests } from "./ordering";
 export { registerPaginationIntegrationTests } from "./pagination";
 export { registerPredicateIntegrationTests } from "./predicates";
 export { registerProvenanceIntegrationTests } from "./provenance";
+export { registerQueryHookIntegrationTests } from "./query-hooks";
 export { registerReconciledSchemaIntegrationTests } from "./reconciled-schema";
 export { registerRecordedReadBindingIntegrationTests } from "./recorded-read-binding";
 export { registerRecordedTimeIntegrationTests } from "./recorded-time";

--- a/packages/typegraph/tests/backends/integration/query-hooks.ts
+++ b/packages/typegraph/tests/backends/integration/query-hooks.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { type QueryHookContext } from "../../../src";
+import { integrationTestGraph } from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+export function registerQueryHookIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("query hooks", () => {
+    it("reports SQL, parameters, row count, and duration per submitted statement", async () => {
+      const starts: QueryHookContext[] = [];
+      const ends: Readonly<{
+        ctx: QueryHookContext;
+        result: Readonly<{ rowCount: number; durationMs: number }>;
+      }>[] = [];
+      const store = await context.createStore(integrationTestGraph, {
+        hooks: {
+          onQueryStart: (ctx) => {
+            starts.push(ctx);
+          },
+          onQueryEnd: (ctx, result) => {
+            ends.push({ ctx, result });
+          },
+        },
+      });
+      await store.nodes.Person.create({
+        name: "Hook Alice",
+        age: 30,
+        email: "hook-alice@example.com",
+      });
+
+      const rows = await store
+        .query()
+        .from("Person", "p")
+        .whereNode("p", (person) => person.name.eq("Hook Alice"))
+        .select((ctx) => ctx.p)
+        .execute();
+
+      expect(rows).toHaveLength(1);
+      expect(starts).toHaveLength(1);
+      expect(ends).toHaveLength(1);
+      expect(starts[0]?.sql).toContain("SELECT");
+      expect(starts[0]?.params.length).toBeGreaterThan(0);
+      expect(ends[0]?.ctx).toBe(starts[0]);
+      expect(ends[0]?.result.rowCount).toBe(1);
+      expect(ends[0]?.result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("fires once for each statement in a selective-projection fallback", async () => {
+      const starts: QueryHookContext[] = [];
+      const store = await context.createStore(integrationTestGraph, {
+        hooks: {
+          onQueryStart: (ctx) => {
+            starts.push(ctx);
+          },
+        },
+      });
+      await store.nodes.Person.create({
+        name: "Hook Adult",
+        email: "adult@example.com",
+      });
+      await store.nodes.Person.create({ name: "Hook Child", age: 10 });
+
+      const rows = await store
+        .query()
+        .from("Person", "p")
+        .orderBy("p", "name", "asc")
+        .select((ctx) =>
+          ctx.p.name === "Hook Adult" ? ctx.p.email : ctx.p.name,
+        )
+        .execute();
+
+      expect(rows).toEqual(["adult@example.com", "Hook Child"]);
+      expect(starts).toHaveLength(2);
+      expect(starts[0]?.operationId).not.toBe(starts[1]?.operationId);
+      expect(starts[0]?.sql).not.toBe(starts[1]?.sql);
+    });
+  });
+}


### PR DESCRIPTION
- fire beforeQuery and afterQuery for query-builder execution, prepared queries, batching, and selective retries
- report SQL, parameters, row counts, durations, and failures
- retain a zero-hook fast path
- document that hooks observe submitted query-builder statements

Closes #340