### PR TITLE
docs: clarify Store reuse after schema evolution

### DIFF
--- a/.changeset/store-evolution-lifetime-docs.md
+++ b/.changeset/store-evolution-lifetime-docs.md
@@ -1,0 +1,14 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Clarify that schema-managed Stores are immutable schema snapshots. After
+`evolve()` changes the schema, callers must use the returned Store or the
+updated `StoreRef.current` for subsequent work; a previously captured Store is
+not mutated and its managed writes are rejected by the schema-version fence.
+Document how long-lived caches detect schema commits from other processes with
+`getCommittedSchemaVersion()` and refresh through a verified Store open.
+
+Correct the `StoreRef` contract to say that the replacement is installed before
+a successful schema-changing call resolves, rather than claiming that the
+in-memory ref update is atomic with the persisted schema commit.

--- a/apps/docs/src/content/docs/graph-extensions.md
+++ b/apps/docs/src/content/docs/graph-extensions.md
@@ -257,26 +257,47 @@ const evolved = await store.evolve(extension, { eager: {} });
    `IncompatibleChangeError` (code `INCOMPATIBLE_CHANGE`).
 3. **Atomically commits** a new schema version via `commitSchemaVersion`
    (CAS on the active version).
-4. **Returns a new `Store<G>`** carrying the extended graph. The type
+4. **Returns the resulting `Store<G>`** carrying the extended graph. The type
    parameter `G` does NOT widen — see [Reaching extension
    kinds](#reaching-extension-kinds-from-the-type-system) below.
 
+:::caution[Use the returned Store]
+`Store` instances are immutable schema snapshots. After `evolve()` resolves,
+use its returned Store for **every subsequent Store operation in the same
+request**, not just operations involving newly added kinds. A Store captured
+before the commit remains pinned to the previous schema version, so its next
+managed write fails the schema-version fence.
+:::
+
 ### The `ref` pattern
 
-`Store<G>` is immutable by construction — `evolve()` returns a fresh
-instance. Long-lived consumer code that holds the store in a singleton
-needs a way to re-bind it atomically with the schema commit. Pass
-`options.ref: { current: store }` (a `StoreRef<Store<G>>`):
+`Store<G>` is immutable by construction — `evolve()` returns the Store for the
+resulting schema, using a fresh instance when the schema advances. Long-lived
+consumer code that holds the Store in a singleton needs a way to re-bind it
+atomically with the schema commit. Pass `options.ref: { current: store }` (a
+`StoreRef<Store<G>>`):
 
 ```ts
 const ref: StoreRef<Store<G>> = { current: store };
-await ref.current.evolve(extension, { ref });
-// `ref.current` now points to the new store.
+const evolved = await ref.current.evolve(extension, { ref });
+
+// `ref.current === evolved`; use either reference from here on.
+const papers = ref.current.getNodeCollectionOrThrow("Paper");
+await papers.create({ title: "...", doi: "...", year: 2024 });
 ```
 
-`StoreRef<T>` is just a type alias for `{ current: T }` — the library
-doesn't provide a factory because the consumer composes the handle
-themselves (could be a Vue ref, MobX observable, Zustand atom, etc.).
+Capture `ref.current` once at request entry only when that request will not
+change the schema. If it does call `evolve()`, switch to the returned Store or
+dereference `ref.current` again after the call. `StoreRef<T>` is structurally
+just `{ current: T }`; the library doesn't provide a factory because the
+consumer composes the handle themselves (it could be a Vue ref, MobX
+observable, Zustand atom, etc.).
+
+The ref covers schema changes made by calls that receive it. If another process
+or isolate can advance the schema, probe the committed version before reusing a
+cached Store and perform a verified open when it changes. See
+[Per-request connections: cache the verified Store](/integration#per-request-connections-cache-the-verified-store)
+for the complete `getCommittedSchemaVersion()` recipe.
 
 ### Eager materialization
 

--- a/apps/docs/src/content/docs/graph-extensions.md
+++ b/apps/docs/src/content/docs/graph-extensions.md
@@ -274,7 +274,7 @@ managed write fails the schema-version fence.
 `Store<G>` is immutable by construction — `evolve()` returns the Store for the
 resulting schema, using a fresh instance when the schema advances. Long-lived
 consumer code that holds the Store in a singleton needs a way to re-bind it
-atomically with the schema commit. Pass `options.ref: { current: store }` (a
+before the operation completes. Pass `options.ref: { current: store }` (a
 `StoreRef<Store<G>>`):
 
 ```ts

--- a/apps/docs/src/content/docs/integration.md
+++ b/apps/docs/src/content/docs/integration.md
@@ -792,8 +792,10 @@ returns an equivalent store bound to the new connection with no re-verify.
 The `getCommittedSchemaVersion` probe is your read-your-writes seam: one
 round-trip, far cheaper than the full verified open (which also reconciles the
 schema and checks index materialization), and re-verify only fires when the
-version actually moves. Skip the probe entirely (and accept bounded
-cross-isolate staleness) if your schema only changes on deploy.
+version actually moves. Skip the probe only if your schema changes exclusively
+during a deployment that also clears the cache. Otherwise reads may use the
+stale schema snapshot, and the write fence rejects managed writes until the
+cache is refreshed.
 
 ### Read Replica Separation
 

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -185,6 +185,40 @@ not participate in the fence. `store.clear()` deletes the graph's schema rows
 and resets that Store to the same raw state; reopen it through a managed factory
 before resuming writes when the versioned guarantee is required.
 
+### Store lifetime after a schema commit
+
+Managed Stores are immutable schema snapshots. A schema-changing operation such
+as `evolve()` returns the Store for the resulting schema; it does not update the
+instance on which it was called. Switch immediately to the returned Store for
+all subsequent work in the same request:
+
+```typescript
+const evolved = await store.evolve(extension);
+await evolved.getNodeCollectionOrThrow("Paper").create({ title: "..." });
+```
+
+For a long-lived local handle, pass a `StoreRef` and use either the return value
+or the updated `ref.current` after the call:
+
+```typescript
+import type { StoreRef } from "@nicia-ai/typegraph";
+
+const ref: StoreRef<typeof store> = { current: store };
+const evolved = await ref.current.evolve(extension, { ref });
+
+// `ref.current === evolved`; do not resume through the pre-evolve Store.
+await ref.current.getNodeCollectionOrThrow("Paper").create({ title: "..." });
+```
+
+Capturing `ref.current` once at request entry is safe only for requests that do
+not change the schema. The ref also cannot observe commits made by another
+process or isolate. Before reusing a cross-request cache, compare the cached
+Store's `introspect().schemaVersion` (or its reconciled snapshot version) with
+`getCommittedSchemaVersion()`, then run `createVerifiedStore()` or
+`createVerifiedAdapterStore()` when the version changes. The
+[per-request connection recipe](/integration#per-request-connections-cache-the-verified-store)
+shows the complete single-flight cache pattern.
+
 ## Schema Validation Results
 
 The validation result indicates what happened during store initialization:

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -628,6 +628,13 @@ closed when a managed write is attempted rather than racing. Raw Stores and
 direct backend writes remain available when the application deliberately owns
 schema/write coordination.
 
+Because a managed Store is pinned to the schema version it opened, use the
+Store returned by `evolve()` for every subsequent operation in that request. A
+Store captured before the commit is not updated, and its next managed write is
+rejected by this fence. See
+[Store lifetime after a schema commit](/schema-management#store-lifetime-after-a-schema-commit)
+for the `StoreRef` and cross-process cache patterns.
+
 ## Store Projection
 
 ### `StoreProjection<G, N, E>`

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1060,8 +1060,9 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * `KindNotFoundError` when the kind is not registered.
    *
    * The dominant graph-extension-kind access pattern: `await store.evolve(...)`
-   * returns a new store, the caller immediately operates on the new
-   * kind, and the null-check the optional variant requires is busywork.
+   * returns the Store for the resulting schema, the caller immediately
+   * operates on the new kind, and the null-check the optional variant requires
+   * is busywork.
    */
   getNodeCollectionOrThrow(kind: string): DynamicNodeCollection {
     const collection = this.getNodeCollection(kind);
@@ -2817,10 +2818,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    *
    * @param extension - Graph extension produced by
    *   `defineGraphExtension(...)`.
-   * @param options.ref - Optional handle whose `current` is overwritten
-   *   atomically with the schema commit. Code awaiting this call can use the
-   *   returned Store or `ref.current` immediately. A previously captured Store
-   *   is not mutated.
+   * @param options.ref - Optional handle whose `current` is overwritten with
+   *   the replacement before a successful call resolves. Code awaiting this
+   *   call can use the returned Store or `ref.current` immediately. A
+   *   previously captured Store is not mutated.
    *
    * @throws {GraphExtensionValidationError} when the extension is
    *   structurally invalid.
@@ -2994,8 +2995,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * kind that's already marked is a no-op (no version bump).
    *
    * @param names - Node or edge kind names to mark as deprecated.
-   * @param options.ref - Optional handle to be re-pointed atomically
-   *   with the schema commit, mirroring `evolve()`.
+   * @param options.ref - Optional handle to be re-pointed to the replacement
+   *   Store before a successful call resolves, mirroring `evolve()`.
    *
    * @throws {ConfigurationError} on `DEPRECATE_BEFORE_INITIALIZE` (no
    *   schema yet) or `DEPRECATE_UNKNOWN_KIND` (name not on the graph).
@@ -3020,8 +3021,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    *
    * @param names - Node or edge kind names to remove from the
    *   deprecated set.
-   * @param options.ref - Optional handle to be re-pointed atomically
-   *   with the schema commit.
+   * @param options.ref - Optional handle to be re-pointed to the replacement
+   *   Store before a successful call resolves.
    *
    * @throws {ConfigurationError} on `DEPRECATE_BEFORE_INITIALIZE`.
    * @throws {StaleVersionError} on a CAS race with another writer.

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -2792,12 +2792,14 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   /**
    * Evolves the graph at runtime by merging a graph extension into the
    * current schema, atomically committing a new schema version, and
-   * returning a fresh `Store` constructed against the merged graph.
+   * returning the `Store` for the merged graph.
    *
    * The `Store` is immutable — its registry, collections, and operation
-   * contexts close over the graph at construction time — so callers
-   * must use the returned store (or pass a `ref` to be re-pointed) for
-   * any work involving the new kinds.
+   * contexts close over the graph at construction time. After `evolve()`
+   * resolves, callers must use the returned Store (or the re-pointed
+   * `ref.current`) for every subsequent operation in the same request. A
+   * Store captured before the schema commit remains pinned to the old version,
+   * and its next managed write is rejected by the schema fence.
    *
    * **Cost for purely additive extensions is proportional to schema
    * document size, not row count.** The commit is a single CAS write.
@@ -2816,9 +2818,9 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * @param extension - Graph extension produced by
    *   `defineGraphExtension(...)`.
    * @param options.ref - Optional handle whose `current` is overwritten
-   *   atomically with the schema commit. Long-lived consumers
-   *   (request handlers, background workers) that dereference through
-   *   the ref see the new kinds on the *next* call.
+   *   atomically with the schema commit. Code awaiting this call can use the
+   *   returned Store or `ref.current` immediately. A previously captured Store
+   *   is not mutated.
    *
    * @throws {GraphExtensionValidationError} when the extension is
    *   structurally invalid.

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -456,17 +456,26 @@ export type StoreOptions = LiveStoreOptions | HistoryStoreOptions;
  * `evolve()` atomically with the schema commit when the ref is passed
  * via `evolve(extension, { ref })`.
  *
- * **Mid-request semantics.** `ref.current` flips on the *next* call
- * after evolve, not mid-handler. Dereference once at request entry and
- * reuse the captured `Store` for the duration:
+ * **Request semantics.** Dereference once at request entry only when that
+ * request will not change the schema. A schema-changing call such as
+ * `evolve()` returns the Store for the resulting schema and updates
+ * `ref.current`; a Store captured before that call remains pinned to the old
+ * schema. Use the returned Store (or dereference `ref.current` again) for every
+ * subsequent operation in the same request:
  *
  * ```ts
  * async function handleRequest(): Promise<void> {
- *   const store = ref.current; // capture once
- *   const tag = await store.nodes.Tag?.create({ label: "..." });
- *   // ...further work on the same `store`...
+ *   const store = ref.current;
+ *   const evolved = await store.evolve(extension, { ref });
+ *   await evolved.materializeIndexes();
+ *   // ref.current === evolved
  * }
  * ```
+ *
+ * A `StoreRef` tracks only schema changes made by calls that receive that ref.
+ * When another process or isolate can commit a schema version, compare
+ * `getCommittedSchemaVersion()` with the cached version before reuse and call
+ * `createVerifiedStore()` or `createVerifiedAdapterStore()` when it changes.
  *
  * Pure dereferenceable handle — no event/subscription machinery. If
  * consumers need eventing, they wrap the ref themselves.

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -452,9 +452,9 @@ export type StoreOptions = LiveStoreOptions | HistoryStoreOptions;
 /**
  * A mutable handle to the current `Store`, used by `store.evolve(...)`
  * so long-lived consumers can dereference through the ref and pick up
- * the new store after each evolve call. `current` is overwritten by
- * `evolve()` atomically with the schema commit when the ref is passed
- * via `evolve(extension, { ref })`.
+ * the new Store after each evolve call. When the ref is passed via
+ * `evolve(extension, { ref })`, `current` is overwritten with the replacement
+ * before a successful call resolves.
  *
  * **Request semantics.** Dereference once at request entry only when that
  * request will not change the schema. A schema-changing call such as

--- a/packages/typegraph/tests/store-evolve.test.ts
+++ b/packages/typegraph/tests/store-evolve.test.ts
@@ -535,9 +535,9 @@ describe("StoreRef pattern (consumer-composed)", () => {
   // The ref is a consumer pattern, not a library factory. Apps that need
   // many callers to share a stable handle (request handlers, background
   // workers, repeated schema-evolution loops) compose their own ref and
-  // pass it to evolve, which re-points it atomically with the schema
-  // commit. Apps with a single caller can skip the ref entirely and
-  // reassign the store from evolve's return value.
+  // pass it to evolve, which re-points it before the call completes. Apps with
+  // a single caller can skip the ref entirely and reassign the store from
+  // evolve's return value.
   it("evolve(ext, { ref }) re-points the consumer-composed ref", async () => {
     const backend = createTestBackend();
     const [store] = await createStoreWithSchema(baseGraph, backend);


### PR DESCRIPTION
Closes #349

- make the returned-Store requirement prominent across migration and integration docs
- document `StoreRef` as the cache-safe handoff for schema-changing operations
- clarify committed-version probing for long-lived Store caches
- align public TSDoc and evolve tests with the documented lifetime semantics
