### PR TITLE
fix: initialize kind removals before evolve preflight

### DIFF
--- a/.changeset/fix-evolve-kind-removal-bootstrap.md
+++ b/.changeset/fix-evolve-kind-removal-bootstrap.md
@@ -4,3 +4,5 @@
 
 Ensure the kind-removal status table before `evolve()` checks it, so databases
 created before TypeGraph 0.44 can evolve without manual backend initialization.
+Concurrent PostgreSQL focused-table ensures also retry the catalog uniqueness
+race that `CREATE TABLE IF NOT EXISTS` can surface during replica startup.

--- a/.changeset/fix-evolve-kind-removal-bootstrap.md
+++ b/.changeset/fix-evolve-kind-removal-bootstrap.md
@@ -1,0 +1,6 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Ensure the kind-removal status table before `evolve()` checks it, so databases
+created before TypeGraph 0.44 can evolve without manual backend initialization.

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -71,6 +71,7 @@ import { requireDefined } from "../../utils/presence";
 import {
   isInsufficientResourcesError,
   isMissingTableError,
+  isPostgresUniqueViolationError,
 } from "../../utils/sql-errors";
 import { FIND_EDGES_ENDPOINT_FIXED_PARAM_COUNT } from "../edge-endpoint-sets";
 import { buildLiveNodeCandidates } from "../live-node-candidates";
@@ -517,8 +518,25 @@ export function createPostgresBackend(
   // ensure through it instead of issuing DDL on the hot path.
   const matTable = tables.contributionMaterializations;
 
+  async function ensureTableWithConcurrentCreateRetry(
+    table: Parameters<typeof generatePgCreateTableSQL>[0],
+  ): Promise<void> {
+    const statement = sql.raw(generatePgCreateTableSQL(table));
+    try {
+      await db.execute(statement);
+    } catch (error) {
+      // PostgreSQL's IF NOT EXISTS check cannot see another session's
+      // uncommitted catalog row. The loser waits for the winner and may then
+      // receive 23505 from pg_type/pg_class instead of a harmless notice.
+      // Retrying after that wait observes the committed table. Any unrelated
+      // uniqueness failure remains loud if the retry cannot confirm it.
+      if (!isPostgresUniqueViolationError(error)) throw error;
+      await db.execute(statement);
+    }
+  }
+
   async function ensureContributionMaterializationsTableImpl(): Promise<void> {
-    await db.execute(sql.raw(generatePgCreateTableSQL(matTable)));
+    await ensureTableWithConcurrentCreateRetry(matTable);
   }
 
   async function getContributionMaterializationRow(
@@ -800,9 +818,7 @@ export function createPostgresBackend(
     },
 
     async ensureRevisionOriginsTable(): Promise<void> {
-      await db.execute(
-        sql.raw(generatePgCreateTableSQL(tables.revisionOrigins)),
-      );
+      await ensureTableWithConcurrentCreateRetry(tables.revisionOrigins);
     },
 
     // Every fulltext-touching method asserts the durable marker instead
@@ -820,9 +836,7 @@ export function createPostgresBackend(
     },
 
     async ensureIndexMaterializationsTable(): Promise<void> {
-      await db.execute(
-        sql.raw(generatePgCreateTableSQL(tables.indexMaterializations)),
-      );
+      await ensureTableWithConcurrentCreateRetry(tables.indexMaterializations);
       // Deployments created before the build-claim columns existed get
       // them additively; fresh installs already have them from the
       // CREATE TABLE above.
@@ -955,7 +969,7 @@ export function createPostgresBackend(
     },
 
     async ensureKindRemovalsTable(): Promise<void> {
-      await db.execute(sql.raw(generatePgCreateTableSQL(tables.kindRemovals)));
+      await ensureTableWithConcurrentCreateRetry(tables.kindRemovals);
     },
 
     async getPendingKindRemovals(
@@ -998,9 +1012,7 @@ export function createPostgresBackend(
     },
 
     async ensureReconciliationMarkersTable(): Promise<void> {
-      await db.execute(
-        sql.raw(generatePgCreateTableSQL(tables.reconciliationMarkers)),
-      );
+      await ensureTableWithConcurrentCreateRetry(tables.reconciliationMarkers);
     },
 
     async ensureRuntimeContributions(graphId: string): Promise<void> {
@@ -1126,10 +1138,8 @@ export function createPostgresBackend(
       params: CommitSchemaVersionParams,
       probes: readonly SchemaKindEmptinessProbe[],
     ): Promise<CommitSchemaVersionIfKindsEmptyResult> {
-      return runSchemaWriteTransaction(
-        params.graphId,
-        (target) =>
-          commitSchemaVersionIfKindsEmpty(target, params, probes),
+      return runSchemaWriteTransaction(params.graphId, (target) =>
+        commitSchemaVersionIfKindsEmpty(target, params, probes),
       );
     },
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1678,11 +1678,11 @@ export type GraphBackend = Readonly<{
 
   /**
    * Bootstraps the per-deployment `typegraph_kind_removals` table so
-   * `store.removeKinds()` and `store.materializeRemovals()` can persist
-   * removal status. Mirrors the focused-bootstrap rationale documented
-   * on `ensureIndexMaterializationsTable` — the full `bootstrapTables`
-   * touches every base table and risks Postgres SHARE-lock deadlock
-   * under concurrent replica startup.
+   * `store.evolve()` can check pending removals and the removal verbs can
+   * persist and materialize removal status. Mirrors the focused-bootstrap
+   * rationale documented on `ensureIndexMaterializationsTable` — the full
+   * `bootstrapTables` touches every base table and risks Postgres SHARE-lock
+   * deadlock under concurrent replica startup.
    */
   ensureKindRemovalsTable?: (this: void) => Promise<void>;
 

--- a/packages/typegraph/src/store/materialize-shared.ts
+++ b/packages/typegraph/src/store/materialize-shared.ts
@@ -15,9 +15,9 @@ import { type GraphBackend } from "../backend/types";
  * INDEX IF NOT EXISTS` statements covering every base table. Two
  * concurrent callers (e.g. two replicas of the same `schema_doc` both
  * starting up) deadlock on Postgres SHARE locks. Restricting the
- * ensure-step to a single table eliminates the cross-table race —
- * concurrent `CREATE TABLE IF NOT EXISTS` for one specific table is
- * well-behaved on Postgres.
+ * ensure-step to a single table eliminates the cross-table lock cycle.
+ * Backends still own any dialect-specific same-table race handling; the
+ * PostgreSQL focused ensures retry their catalog uniqueness race.
  */
 export async function ensureFocusedStatusTable(
   backend: GraphBackend,

--- a/packages/typegraph/src/store/materialize-shared.ts
+++ b/packages/typegraph/src/store/materialize-shared.ts
@@ -1,10 +1,8 @@
 /**
- * Shared building blocks for the materialize-* verbs (`materializeIndexes`
- * and `materializeRemovals`) and `Store.removeKinds`. Each verb owns a
- * per-deployment status table (`typegraph_index_materializations`,
- * `typegraph_kind_removals`) and bootstraps it lazily; this module
- * centralizes focused bootstrap dispatch plus the bucketed orchestration used
- * by index materialization.
+ * Shared building blocks for schema-management and materialization verbs.
+ * Each status-backed operation lazily bootstraps its per-deployment table;
+ * this module centralizes focused bootstrap dispatch plus the bucketed
+ * orchestration used by index materialization.
  */
 import { type GraphBackend } from "../backend/types";
 

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -148,6 +148,7 @@ import {
   type MaterializeRemovalsOptions,
   type MaterializeRemovalsResult,
 } from "./materialize-removals";
+import { ensureFocusedStatusTable } from "./materialize-shared";
 import {
   type EdgeOperationContext,
   edgeUpsertDirtyCheck,
@@ -3449,9 +3450,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     // store). Operators reconcile via materializeRemovals later.
     const recordKindRemoval = this.#backend.recordKindRemoval;
     if (recordKindRemoval !== undefined) {
-      if (this.#backend.ensureKindRemovalsTable !== undefined) {
-        await this.#backend.ensureKindRemovalsTable();
-      }
+      await ensureFocusedStatusTable(
+        this.#backend,
+        this.#backend.ensureKindRemovalsTable,
+      );
       const attemptedAt = nowIso();
       const newSchemaVersion = committedRow.version;
       const queue = (kindName: string, entity: KindEntity): Promise<void> =>
@@ -3645,6 +3647,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     );
     if (addedNodes.length === 0 && addedEdges.length === 0) return;
 
+    await ensureFocusedStatusTable(
+      this.#backend,
+      this.#backend.ensureKindRemovalsTable,
+    );
     const pending = await getPendingKindRemovals(this.graphId);
     if (pending.length === 0) return;
 

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -36,6 +36,7 @@ const POSTGRES_UNDEFINED_RELATION_PATTERN =
  * `.message` with the query text.
  */
 const POSTGRES_UNDEFINED_TABLE_CODE = "42P01";
+const POSTGRES_UNIQUE_VIOLATION_CODE = "23505";
 
 /**
  * Yields an error and each error reachable by following `.cause`,
@@ -179,6 +180,25 @@ export function isMissingTableError(error: unknown): boolean {
       }
     }
     if (!(link instanceof Error)) everyPriorLinkWasError = false;
+  }
+  return false;
+}
+
+/**
+ * Whether PostgreSQL reported a uniqueness violation anywhere in a driver's
+ * error-cause chain. `CREATE TABLE IF NOT EXISTS` can surface this code when
+ * two sessions concurrently insert the same internal catalog rows; callers
+ * handling that specific idempotent DDL race can retry once after the winner
+ * commits.
+ */
+export function isPostgresUniqueViolationError(error: unknown): boolean {
+  for (const link of errorChain(error)) {
+    if (
+      canReadProperty(link) &&
+      Reflect.get(link, "code") === POSTGRES_UNIQUE_VIOLATION_CODE
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
+++ b/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
@@ -57,6 +57,28 @@ export function registerMigrateSchemaKindIntegrationTests(
       nodes: { Widget: { properties: { label: { type: "string" } } } },
     });
 
+    it("bootstraps the kind-removal queue before evolve preflight", async () => {
+      const graph = graphFor("legacy_removal_queue");
+      const store = await context.createStore(graph);
+      const backend = context.getBackend();
+
+      // A pre-0.44 database has all established schema tables but not the
+      // newly-added removal queue. Evolve must initialize its own preflight
+      // dependency rather than requiring an out-of-band backend bootstrap.
+      await requireDefined(backend.executeDdl)(
+        'DROP TABLE IF EXISTS "typegraph_kind_removals"',
+      );
+
+      const evolved = await store.evolve(widgetExtension);
+
+      expect(evolved.introspect().kinds.map((kind) => kind.name)).toContain(
+        "Widget",
+      );
+      expect(
+        await requireDefined(backend.getPendingKindRemovals)(graph.id),
+      ).toEqual([]);
+    });
+
     it("folds the persisted extension, preserving runtime kinds and their rows", async () => {
       const graph = graphFor("fold");
       const store = await context.createStore(graph);

--- a/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
+++ b/packages/typegraph/tests/backends/integration/migrate-schema-kinds.ts
@@ -79,6 +79,24 @@ export function registerMigrateSchemaKindIntegrationTests(
       ).toEqual([]);
     });
 
+    it("keeps concurrent focused kind-removal bootstraps idempotent", async () => {
+      const backend = context.getBackend();
+      await requireDefined(backend.executeDdl)(
+        'DROP TABLE IF EXISTS "typegraph_kind_removals"',
+      );
+      const ensureKindRemovalsTable = requireDefined(
+        backend.ensureKindRemovalsTable,
+      );
+
+      await Promise.all([ensureKindRemovalsTable(), ensureKindRemovalsTable()]);
+
+      await expect(
+        requireDefined(backend.getPendingKindRemovals)(
+          graphFor("concurrent_removal_queue").id,
+        ),
+      ).resolves.toEqual([]);
+    });
+
     it("folds the persisted extension, preserving runtime kinds and their rows", async () => {
       const graph = graphFor("fold");
       const store = await context.createStore(graph);

--- a/packages/typegraph/tests/sql-errors.test.ts
+++ b/packages/typegraph/tests/sql-errors.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   isMissingTableError,
+  isPostgresUniqueViolationError,
   isSqliteNotAuthorizedError,
 } from "../src/utils/sql-errors";
 
@@ -254,6 +255,33 @@ describe("isMissingTableError", () => {
     (a as { cause?: unknown }).cause = b;
     (b as { cause?: unknown }).cause = a;
     expect(isMissingTableError(a)).toBe(false);
+  });
+});
+
+describe("isPostgresUniqueViolationError", () => {
+  it("detects direct and Drizzle-wrapped SQLSTATE 23505 errors", () => {
+    const direct = pgError("duplicate catalog row", "23505");
+    expect(isPostgresUniqueViolationError(direct)).toBe(true);
+    expect(
+      isPostgresUniqueViolationError(
+        drizzleQueryError(
+          "CREATE TABLE IF NOT EXISTS typegraph_kind_removals",
+          {
+            code: "23505",
+            message: "duplicate catalog row",
+          },
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated database failures", () => {
+    expect(
+      isPostgresUniqueViolationError(pgError("permission denied", "42501")),
+    ).toBe(false);
+    expect(
+      isPostgresUniqueViolationError(new Error("SQLITE_CONSTRAINT_UNIQUE")),
+    ).toBe(false);
   });
 });
 

--- a/packages/typegraph/tests/store-removals-fixes.test.ts
+++ b/packages/typegraph/tests/store-removals-fixes.test.ts
@@ -70,6 +70,81 @@ type GraphExtensionIndexInput = NonNullable<
   Parameters<typeof defineGraphExtension>[0]["indexes"]
 >[number];
 
+const tagExtension = defineGraphExtension({
+  nodes: { Tag: { properties: { label: { type: "string" } } } },
+});
+
+// ============================================================
+// 0. Evolve initializes kind-removal preflight dependencies
+// ============================================================
+
+describe("evolve against a DB missing typegraph_kind_removals", () => {
+  it("falls back to full bootstrap for custom backends", async () => {
+    const baseBackend = createTestBackend();
+    const {
+      ensureKindRemovalsTable: focusedEnsure,
+      ...backendWithoutFocusedEnsure
+    } = baseBackend;
+    expect(focusedEnsure).toBeDefined();
+    let bootstrapCalls = 0;
+    const backend: GraphBackend = {
+      ...backendWithoutFocusedEnsure,
+      async bootstrapTables() {
+        bootstrapCalls += 1;
+        await requireDefined(baseBackend.bootstrapTables)();
+      },
+    };
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    bootstrapCalls = 0;
+    await requireDefined(backend.executeDdl)(
+      "DROP TABLE IF EXISTS typegraph_kind_removals",
+    );
+
+    const evolved = await store.evolve(tagExtension);
+
+    expect(evolved.introspect().kinds.map((kind) => kind.name)).toContain(
+      "Tag",
+    );
+    expect(bootstrapCalls).toBe(1);
+
+    bootstrapCalls = 0;
+    await requireDefined(backend.executeDdl)(
+      "DROP TABLE IF EXISTS typegraph_kind_removals",
+    );
+    const removed = await evolved.removeKinds(["Tag"]);
+
+    expect(bootstrapCalls).toBe(1);
+    expect(
+      await requireDefined(backend.getPendingKindRemovals)(baseGraph.id),
+    ).toEqual([expect.objectContaining({ entity: "node", kindName: "Tag" })]);
+    expect(removed.introspect().kinds.map((kind) => kind.name)).not.toContain(
+      "Tag",
+    );
+  });
+
+  it("does not bootstrap the queue for a no-op evolve", async () => {
+    const baseBackend = createTestBackend();
+    let ensureCalls = 0;
+    const backend: GraphBackend = {
+      ...baseBackend,
+      async ensureKindRemovalsTable() {
+        ensureCalls += 1;
+        await requireDefined(baseBackend.ensureKindRemovalsTable)();
+      },
+    };
+    const [store] = await createStoreWithSchema(baseGraph, backend);
+    const evolved = await store.evolve(tagExtension);
+    ensureCalls = 0;
+
+    const repeated = await evolved.evolve(tagExtension);
+
+    expect(repeated.introspect().kinds.map((kind) => kind.name)).toContain(
+      "Tag",
+    );
+    expect(ensureCalls).toBe(0);
+  });
+});
+
 // ============================================================
 // 1. Legacy DB missing reconciliation_markers
 // ============================================================


### PR DESCRIPTION
Closes #348

- ensure the kind-removals table before any `evolve()` preflight read
- route `removeKinds()` through the same focused bootstrap/fallback path
- make all focused PostgreSQL status-table bootstraps safe under concurrent startup
- cover legacy databases, custom backends, no-op evolution, and concurrent PostgreSQL bootstraps
