### PR TITLE
feat: add safe contribution repair API

### DIFF
--- a/.changeset/repair-contributions.md
+++ b/.changeset/repair-contributions.md
@@ -1,0 +1,11 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `store.repairContributions()`, a privileged, idempotent repair pass for
+strategy-owned contribution storage. It re-audits declarations from the active
+persisted graph, non-destructively retries `missing-marker` and
+`failed-materialization` findings, reports `stale` and `orphaned-marker` as
+`requires-rebuild`, and returns a fresh post-repair diagnostic result. Repair
+targets remain backend-owned so callers do not need access to TypeGraph-managed
+tables, physical names, or DDL.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1081,7 +1081,9 @@ Check `store.introspect().schemaVersion !== undefined` at runtime. Calling
 `store.clear()` deletes the schema rows and resets that Store to raw semantics;
 reopen it through a managed factory before resuming version-fenced writes.
 
-- **`store.verifyContributions()` is the catalog-checking diagnostic.**
+- **`store.verifyContributions()` diagnoses contribution storage;
+  `store.repairContributions()` repairs safe findings under a privileged
+  role.**
   Every gate above trusts the marker row without probing the catalog, so
   a database whose strategy-owned tables were dropped out of band opens
   clean and fails at the first read. This method compares each contribution
@@ -1092,8 +1094,11 @@ reopen it through a managed factory before resuming version-fenced writes.
   only, no DDL) so the least-privilege role can run it, and it is deliberately
   not part of any open path. For a readiness check, construct the Store with
   `createVerifiedStore()` first and then run this diagnostic; otherwise use
-  it as an operator check. Repair is state-specific and one wrong choice
-  destroys embeddings, so follow the per-state tables in
+  it as an operator check. The repair method re-audits current declarations,
+  preserves data while repairing `missing-marker` and
+  `failed-materialization`, and reports `stale` or `orphaned-marker` as
+  `requires-rebuild`. Run repair through the DDL-capable migration role, not
+  the least-privilege runtime role. Follow the per-state table in
   [The store opens clean but a fulltext or vector read fails](/troubleshooting#the-store-opens-clean-but-a-fulltext-or-vector-read-fails)
   rather than applying one repair to every entry.
 

--- a/apps/docs/src/content/docs/troubleshooting.md
+++ b/apps/docs/src/content/docs/troubleshooting.md
@@ -433,111 +433,47 @@ table, no DDL and no writes — so it is safe on a live store under a
 least-privilege role. It is deliberately **not** a boot step; call it
 from a health check or an operator script.
 
-**Solution: the repair depends on the state, and picking the wrong one
-can destroy data.** There is no single loop that repairs every entry.
+**Solution:** Run `repairContributions()` on a Store backed by the privileged
+DDL-capable connection:
 
-### Repairing a vector slot
+```typescript
+const result = await adminStore.repairContributions();
 
-Entries with `kind` and `fieldPath` set are embedding slots.
+for (const entry of result.results) {
+  if (entry.status === "failed") {
+    console.error(entry.diagnostic, entry.error);
+  }
+  if (entry.status === "requires-rebuild") {
+    console.warn("manual rebuild required", entry.diagnostic);
+  }
+}
+```
 
-| `state` | Repair | Embeddings |
+The method performs its own fresh audit and resolves contribution declarations
+from the committed graph and the active backend strategies. It never accepts a
+diagnostic, physical table name, or DDL from the caller. This keeps repair safe
+when the Store was opened before another writer evolved the graph.
+
+| `state` | Result | Data behavior |
 | --- | --- | --- |
-| `missing-marker` | `ensureVectorSlotContribution(slot, { force: true })` | **Preserved** |
-| `failed-materialization` | `ensureVectorSlotContribution(slot, { force: true })` | None existed |
-| `orphaned-marker` | `reembedVectorField(kind, fieldPath, { embed })` | Already lost with the table |
-| `stale` | `reembedVectorField(kind, fieldPath, { embed })` | **Destroyed — repopulation required** |
+| `missing-marker` | `repaired` or `failed` | Runs idempotent DDL and re-stamps the marker; existing rows are preserved |
+| `failed-materialization` | `repaired` or `failed` | Retries the current idempotent contribution DDL |
+| `orphaned-marker` | `requires-rebuild` | The table and its data are already gone |
+| `stale` | `requires-rebuild` | The stored physical shape does not match the current declaration |
 
-The distinction matters. `reembedVectorField` drops and recreates
-storage; without an `embed` callback it returns with **zero
-embeddings**. For `missing-marker` the table is intact and only the
-marker is not, so reaching for `reembedVectorField` there would destroy
-perfectly good vectors to fix a bookkeeping problem. Use the
-force-ensure instead — its DDL is `CREATE ... IF NOT EXISTS` and never
-drops, so it re-stamps the marker and leaves every row in place:
+`remaining` is a fresh post-repair diagnostic pass. An empty `remaining` array
+means every finding from this audit was repaired, while a second successful
+call is idempotent and returns no results.
 
-```typescript
-import { resolveGraphVectorSlots } from "@nicia-ai/typegraph";
+For a vector `requires-rebuild` entry, use
+`reembedVectorField(kind, fieldPath, { embed })`. It drops and recreates the
+slot, so pass an `embed` callback or the field comes back with zero embeddings.
+A stale fulltext contribution requires an operator-planned rebuild; do not
+hand-edit the marker or run backend-owned DDL directly.
 
-const slots = resolveGraphVectorSlots(store.graph);
-
-for (const entry of await store.verifyContributions()) {
-  if (entry.kind === undefined || entry.fieldPath === undefined) continue;
-
-  if (entry.state === "missing-marker" || entry.state === "failed-materialization") {
-    // Non-destructive: re-stamps the marker, leaves storage untouched.
-    const slot = slots.find(
-      (candidate) =>
-        candidate.nodeKind === entry.kind &&
-        candidate.fieldPath === entry.fieldPath,
-    );
-    if (slot) await adminBackend.ensureVectorSlotContribution?.(slot, { force: true });
-  } else {
-    // orphaned-marker / stale: storage must be rebuilt. Pass `embed` or
-    // the field comes back empty and every vector query silently
-    // returns nothing.
-    await store.reembedVectorField(entry.kind, entry.fieldPath, {
-      embed: async (nodes) => new Map(/* recompute vectors here */),
-    });
-  }
-}
-```
-
-For `stale` the destruction is unavoidable rather than accidental: the
-stored vectors were written at a different dimension and are invalid
-under the new one, so they must be recomputed, not converted.
-
-### Repairing fulltext
-
-`ensureRuntimeContributions` does **not** force, and a fresh backend is
-not sufficient on its own. It short-circuits twice — once on a
-per-instance signature cache, and again if the durable marker row alone
-looks healthy. A fresh instance clears only the first. What repairs
-what:
-
-| `state` | Repair |
-| --- | --- |
-| `missing-marker`, `failed-materialization` | `ensureRuntimeContributions(graphId)` from a **fresh** privileged backend |
-| `orphaned-marker` | Re-run the contribution's own `createDdl` (below) |
-| `stale` | No supported automated repair — see the warning below |
-
-For `missing-marker` and `failed-materialization` the marker does not attest
-the contribution, so the ensure normally falls through and runs the DDL. Use a
-new backend instance defensively: a warm backend that cached an earlier healthy
-signature before the marker changed out of band can still return early. The
-diagnostic itself does not populate that cache, and missing or failed marker
-states are not cached.
-
-For `orphaned-marker` the marker still says `initialized`, so the
-ensure returns before any DDL no matter how fresh the backend is.
-Recreate the table from the declaration instead — the statements are
-idempotent, so this is safe to run against a table that turns out to
-still exist:
-
-```typescript
-const fulltextTable = adminBackend.tableNames.fulltext;
-for (const contribution of adminBackend.fulltextStrategy.ownedTables(fulltextTable)) {
-  for (const ddl of contribution.createDdl) {
-    await adminBackend.executeDdl?.(ddl);
-  }
-}
-```
-
-:::caution[`stale` fulltext has no supported repair path today]
-A `stale` fulltext contribution — the marker records a prior success at
-a different signature, which a library upgrade that changes the
-fulltext DDL can produce — cannot currently be repaired through the
-public API. Recreating the table does not help: the marker still
-carries the old signature, and re-stamping it is not exposed.
-
-Do **not** reach for `ensureRuntimeContributions` here. It throws on
-the drift guard, and on its way out it records the failure against the
-marker — which changes what the diagnostic reports next time from
-`stale` to `missing-marker`, with the drift-guard message in
-`lastError`. The underlying problem is unchanged; only its description
-moved. If you hit this, please open an issue with the reported
-`owner` / `logicalName` / `signature` rather than hand-editing the
-marker table.
-:::
+`repairContributions()` intentionally does not use the public diagnostic as an
+instruction list and does not force marker writes. A warm backend re-reads the
+marker, and the normal signature guard still refuses to bless stale storage.
 
 **An empty result does not mean everything was checked.** The diagnostic
 enumerates only current declarations. It ignores retired marker rows and treats

--- a/apps/docs/src/content/docs/troubleshooting.md
+++ b/apps/docs/src/content/docs/troubleshooting.md
@@ -451,8 +451,9 @@ for (const entry of result.results) {
 
 The method performs its own fresh audit and resolves contribution declarations
 from the committed graph and the active backend strategies. It never accepts a
-diagnostic, physical table name, or DDL from the caller. This keeps repair safe
-when the Store was opened before another writer evolved the graph.
+diagnostic, physical table name, or DDL from the caller. A Store opened before
+another writer evolved the graph catches up before enumerating vector slots
+instead of repairing from its stale in-memory graph snapshot.
 
 | `state` | Result | Data behavior |
 | --- | --- | --- |
@@ -462,8 +463,8 @@ when the Store was opened before another writer evolved the graph.
 | `stale` | `requires-rebuild` | The stored physical shape does not match the current declaration |
 
 `remaining` is a fresh post-repair diagnostic pass. An empty `remaining` array
-means every finding from this audit was repaired, while a second successful
-call is idempotent and returns no results.
+means no current declaration remains unhealthy after the pass. Once it is
+empty, a second call is idempotent and returns no results.
 
 For a vector `requires-rebuild` entry, use
 `reembedVectorField(kind, fieldPath, { embed })`. It drops and recreates the

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -142,6 +142,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 type CountEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -2706,6 +2725,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -139,6 +139,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 type CountEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -3073,6 +3092,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -135,6 +135,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 type CountEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -2713,6 +2732,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -134,6 +134,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 type CountEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -2715,6 +2734,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -133,6 +133,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 type CountEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -2973,6 +2992,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -172,6 +172,25 @@ export type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 export type CountEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -789,6 +808,7 @@ export type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -446,6 +446,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;
@@ -1548,6 +1567,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -3754,6 +3774,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -301,6 +301,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;
@@ -1407,6 +1426,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -3550,6 +3570,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -303,6 +303,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;
@@ -1388,6 +1407,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -3360,6 +3380,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -291,6 +291,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;
@@ -1366,6 +1385,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -3346,6 +3366,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -291,6 +291,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;
@@ -1366,6 +1385,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -3340,6 +3360,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -149,6 +149,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 type CountEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -789,6 +808,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -303,6 +303,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;
@@ -1391,6 +1410,7 @@ type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -3380,6 +3400,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -481,6 +481,25 @@ type ContributionMaterializationRow = Readonly<{
 }>;
 
 // @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;
@@ -2253,6 +2272,7 @@ export type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -5077,6 +5097,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;
@@ -5757,7 +5778,7 @@ type UniqueRow = Readonly<{
 }>;
 
 // @public (undocumented)
-type UnsafeHistoryStoreBackendMember = "clearGraph" | "executeDdl" | "executeRaw" | "executeStatement" | "schemaWriteTransaction" | "transaction" | "trustedImport";
+type UnsafeHistoryStoreBackendMember = "clearGraph" | "executeDdl" | "executeRaw" | "executeStatement" | "repairContributions" | "schemaWriteTransaction" | "transaction" | "trustedImport";
 
 // @public
 export class UnsupportedBackendCapabilityError extends TypeGraphError {

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -36,6 +36,8 @@ import {
   type ContributionDiagnosticState,
   type ContributionMaterializationIdentity,
   type ContributionMaterializationRow,
+  type ContributionRepairEntry,
+  type ContributionRepairResult,
   createBackendOverlay,
   type RecordContributionMaterializationParams,
   type TransactionBackend,
@@ -244,10 +246,11 @@ function evaluateContributionState(
  * - no marker row at all is genuinely silent: nothing has been
  *   attempted, and boot will provision it on the next privileged run.
  *
- * With the table PRESENT, `missing` and `failed` collapse to
- * `missing-marker`: both mean "storage exists but no marker attests
- * it", and both are repaired by re-running the ensure. `stale` stays
- * distinct because its repair is a shape change, not a re-stamp.
+ * With the table PRESENT, `missing` and same-signature `failed` collapse to
+ * `missing-marker`: both mean "storage exists but no marker attests it", and
+ * both are repaired by re-running the ensure. A prior success at another
+ * signature stays `stale` even when the latest attempt failed, because its
+ * repair is a shape change, not a re-stamp.
  */
 function diagnoseContribution(
   row: ContributionMaterializationRow | undefined,
@@ -258,6 +261,13 @@ function diagnoseContribution(
     if (row === undefined) return undefined;
     if (row.materializedAt !== undefined) return "orphaned-marker";
     return row.lastError === undefined ? undefined : "failed-materialization";
+  }
+  // A prior success at another signature means the existing table has the old
+  // physical shape. That remains `stale` even when a later failed attempt also
+  // recorded an error: classifying it as `missing-marker` would invite an
+  // idempotent CREATE + marker re-stamp to bless the unchanged stale table.
+  if (row?.materializedAt !== undefined && row.signature !== signature) {
+    return "stale";
   }
   const state = evaluateContributionState(row, signature);
   switch (state) {
@@ -515,6 +525,14 @@ export type ContributionMaterializer = Readonly<{
     graphId: string,
     vectorSlots: readonly VectorSlot[],
   ) => Promise<readonly ContributionDiagnostic[]>;
+  /**
+   * Privileged repair pass over declarations resolved inside this
+   * materializer. Only non-destructive states are repaired automatically.
+   */
+  repairContributions: (
+    graphId: string,
+    vectorSlots: readonly VectorSlot[],
+  ) => Promise<ContributionRepairResult>;
 }>;
 
 // NUL separator for the per-instance contribution cache key: collision-safe
@@ -756,9 +774,14 @@ export function createContributionMaterializer(
   async function ensureContributions(
     graphId: string,
     contributions: readonly StrategyTableContribution[],
-    options?: Readonly<{ force?: boolean; onDrift?: "throw" | "skip" }>,
+    options?: Readonly<{
+      force?: boolean;
+      onDrift?: "throw" | "skip";
+      bypassCache?: boolean;
+    }>,
   ): Promise<void> {
     const force = options?.force === true;
+    const bypassCache = options?.bypassCache === true;
     const entries = await Promise.all(
       contributions.map(async (contribution) => {
         const key = contributionKey(graphId, contribution);
@@ -772,7 +795,7 @@ export function createContributionMaterializer(
     // A cache hit requires the signature to match — a contribution whose
     // shape changed on this instance falls through to the drift-guard.
     const pending =
-      force ? entries : (
+      force || bypassCache ? entries : (
         entries.filter(
           (entry) =>
             uncacheableKeys.has(entry.key) ||
@@ -931,16 +954,14 @@ export function createContributionMaterializer(
     }
   }
 
-  async function verifyContributions(
+  function verificationTargetsByGraph(
     graphId: string,
     vectorSlots: readonly VectorSlot[],
-  ): Promise<readonly ContributionDiagnostic[]> {
-    // Vector slots carry their own graph id, exactly as `ensureVectorSlots`
-    // reads them, so the marker read stays one query per distinct graph.
-    const targetsByGraph = new Map<string, VerificationTarget[]>();
+  ): ReadonlyMap<string, readonly VerificationTarget[]> {
+    const targets = new Map<string, VerificationTarget[]>();
     function addTarget(id: string, target: VerificationTarget): void {
-      const existing = targetsByGraph.get(id);
-      if (existing === undefined) targetsByGraph.set(id, [target]);
+      const existing = targets.get(id);
+      if (existing === undefined) targets.set(id, [target]);
       else existing.push(target);
     }
 
@@ -959,6 +980,16 @@ export function createContributionMaterializer(
         }
       }
     }
+    return targets;
+  }
+
+  async function verifyContributions(
+    graphId: string,
+    vectorSlots: readonly VectorSlot[],
+  ): Promise<readonly ContributionDiagnostic[]> {
+    // Vector slots carry their own graph id, exactly as `ensureVectorSlots`
+    // reads them, so the marker read stays one query per distinct graph.
+    const targetsByGraph = verificationTargetsByGraph(graphId, vectorSlots);
 
     // One probe per distinct physical table, scoped to THIS call: a
     // strategy may own several contributions over one table, and paying a
@@ -1011,6 +1042,74 @@ export function createContributionMaterializer(
     return diagnostics;
   }
 
+  async function repairContributions(
+    graphId: string,
+    vectorSlots: readonly VectorSlot[],
+  ): Promise<ContributionRepairResult> {
+    const targets = new Map<string, StrategyTableContribution>();
+    for (const [id, graphTargets] of verificationTargetsByGraph(
+      graphId,
+      vectorSlots,
+    )) {
+      for (const target of graphTargets) {
+        targets.set(
+          contributionKey(id, target.contribution),
+          target.contribution,
+        );
+      }
+    }
+
+    const diagnostics = await verifyContributions(graphId, vectorSlots);
+    const results: ContributionRepairEntry[] = [];
+    for (const diagnostic of diagnostics) {
+      if (
+        diagnostic.state === "stale" ||
+        diagnostic.state === "orphaned-marker"
+      ) {
+        results.push({ diagnostic, status: "requires-rebuild" });
+        continue;
+      }
+
+      const identity = {
+        graphId,
+        logicalName: diagnostic.logicalName,
+        owner: diagnostic.owner,
+        tableName: diagnostic.physicalName,
+      };
+      const contribution = targets.get(contributionKey(graphId, identity));
+      if (contribution === undefined) {
+        results.push({
+          diagnostic,
+          status: "failed",
+          error: "The contribution is no longer declared by the active backend strategy.",
+        });
+        continue;
+      }
+
+      try {
+        // A repair must bypass the positive process-local cache because the
+        // marker may have been removed or failed after this backend cached a
+        // healthy signature. This is intentionally NOT `force`: the normal
+        // drift guard must still refuse to re-stamp stale physical storage.
+        await ensureContributions(graphId, [contribution], {
+          bypassCache: true,
+        });
+        results.push({ diagnostic, status: "repaired" });
+      } catch (error) {
+        results.push({
+          diagnostic,
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return {
+      results,
+      remaining: await verifyContributions(graphId, vectorSlots),
+    };
+  }
+
   function evictVectorSlot(slot: VectorSlot): void {
     if (deps.vectorStrategy === undefined) return;
     for (const contribution of deps.vectorStrategy.ownedTables(slot)) {
@@ -1045,5 +1144,6 @@ export function createContributionMaterializer(
     dropVectorSlot,
     evictVectorSlot,
     verifyContributions,
+    repairContributions,
   };
 }

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -298,6 +298,12 @@ type VerificationTarget = Readonly<{
   fieldPath?: string;
 }>;
 
+type DiagnosedContribution = Readonly<{
+  graphId: string;
+  contribution: StrategyTableContribution;
+  diagnostic: ContributionDiagnostic;
+}>;
+
 function identityOf(
   graphId: string,
   contribution: StrategyTableContribution,
@@ -792,6 +798,17 @@ export function createContributionMaterializer(
         };
       }),
     );
+    if (bypassCache) {
+      // Repair is invoked precisely when durable state may have changed behind
+      // this materializer's positive cache. Keep every touched key read-through
+      // from now on: deleting only the current entry would still let an assert
+      // that started before the repair repopulate stale success after a failed
+      // repair recorded the contribution as unusable.
+      for (const entry of entries) {
+        uncacheableKeys.add(entry.key);
+        initializedSignatures.delete(entry.key);
+      }
+    }
     // A cache hit requires the signature to match — a contribution whose
     // shape changed on this instance falls through to the drift-guard.
     const pending =
@@ -983,10 +1000,10 @@ export function createContributionMaterializer(
     return targets;
   }
 
-  async function verifyContributions(
+  async function diagnoseContributions(
     graphId: string,
     vectorSlots: readonly VectorSlot[],
-  ): Promise<readonly ContributionDiagnostic[]> {
+  ): Promise<readonly DiagnosedContribution[]> {
     // Vector slots carry their own graph id, exactly as `ensureVectorSlots`
     // reads them, so the marker read stays one query per distinct graph.
     const targetsByGraph = verificationTargetsByGraph(graphId, vectorSlots);
@@ -1006,7 +1023,7 @@ export function createContributionMaterializer(
       return probe;
     }
 
-    const diagnostics: ContributionDiagnostic[] = [];
+    const diagnosed: DiagnosedContribution[] = [];
     for (const [id, targets] of targetsByGraph) {
       // A never-bootstrapped marker table means no contribution is marked,
       // which the per-target verdict already models as an empty row set.
@@ -1024,44 +1041,46 @@ export function createContributionMaterializer(
           await tableExists(contribution.tableName),
         );
         if (state === undefined) continue;
-        diagnostics.push({
-          owner: contribution.owner,
-          logicalName: contribution.logicalName,
-          physicalName: contribution.tableName,
-          ...(kind === undefined ? {} : { kind }),
-          ...(fieldPath === undefined ? {} : { fieldPath }),
-          state,
-          // The recorded reason, carried through verbatim. `state` folds
-          // several marker verdicts together because they share a repair;
-          // this is what keeps the fold from also discarding the one thing
-          // the catalog can never tell the operator.
-          ...(row?.lastError === undefined ? {} : { lastError: row.lastError }),
+        diagnosed.push({
+          graphId: id,
+          contribution,
+          diagnostic: {
+            owner: contribution.owner,
+            logicalName: contribution.logicalName,
+            physicalName: contribution.tableName,
+            ...(kind === undefined ? {} : { kind }),
+            ...(fieldPath === undefined ? {} : { fieldPath }),
+            state,
+            // The recorded reason, carried through verbatim. `state` folds
+            // several marker verdicts together because they share a repair;
+            // this is what keeps the fold from also discarding the one thing
+            // the catalog can never tell the operator.
+            ...(row?.lastError === undefined ?
+              {}
+            : { lastError: row.lastError }),
+          },
         });
       }
     }
-    return diagnostics;
+    return diagnosed;
+  }
+
+  async function verifyContributions(
+    graphId: string,
+    vectorSlots: readonly VectorSlot[],
+  ): Promise<readonly ContributionDiagnostic[]> {
+    const diagnosed = await diagnoseContributions(graphId, vectorSlots);
+    return diagnosed.map((entry) => entry.diagnostic);
   }
 
   async function repairContributions(
     graphId: string,
     vectorSlots: readonly VectorSlot[],
   ): Promise<ContributionRepairResult> {
-    const targets = new Map<string, StrategyTableContribution>();
-    for (const [id, graphTargets] of verificationTargetsByGraph(
-      graphId,
-      vectorSlots,
-    )) {
-      for (const target of graphTargets) {
-        targets.set(
-          contributionKey(id, target.contribution),
-          target.contribution,
-        );
-      }
-    }
-
-    const diagnostics = await verifyContributions(graphId, vectorSlots);
+    const diagnosed = await diagnoseContributions(graphId, vectorSlots);
     const results: ContributionRepairEntry[] = [];
-    for (const diagnostic of diagnostics) {
+    for (const { graphId: targetGraphId, contribution, diagnostic } of
+      diagnosed) {
       if (
         diagnostic.state === "stale" ||
         diagnostic.state === "orphaned-marker"
@@ -1070,28 +1089,12 @@ export function createContributionMaterializer(
         continue;
       }
 
-      const identity = {
-        graphId,
-        logicalName: diagnostic.logicalName,
-        owner: diagnostic.owner,
-        tableName: diagnostic.physicalName,
-      };
-      const contribution = targets.get(contributionKey(graphId, identity));
-      if (contribution === undefined) {
-        results.push({
-          diagnostic,
-          status: "failed",
-          error: "The contribution is no longer declared by the active backend strategy.",
-        });
-        continue;
-      }
-
       try {
         // A repair must bypass the positive process-local cache because the
         // marker may have been removed or failed after this backend cached a
         // healthy signature. This is intentionally NOT `force`: the normal
         // drift guard must still refuse to re-stamp stale physical storage.
-        await ensureContributions(graphId, [contribution], {
+        await ensureContributions(targetGraphId, [contribution], {
           bypassCache: true,
         });
         results.push({ diagnostic, status: "repaired" });

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -92,6 +92,7 @@ import {
   type ContributionDiagnostic,
   type ContributionMaterializationIdentity,
   type ContributionMaterializationRow,
+  type ContributionRepairResult,
   createBackendOverlay,
   type CreateVectorIndexParams,
   type DeleteEmbeddingParams,
@@ -1021,6 +1022,13 @@ export function createPostgresBackend(
       vectorSlots: readonly VectorSlot[],
     ): Promise<readonly ContributionDiagnostic[]> {
       return contributionMaterializer.verifyContributions(graphId, vectorSlots);
+    },
+
+    async repairContributions(
+      graphId: string,
+      vectorSlots: readonly VectorSlot[],
+    ): Promise<ContributionRepairResult> {
+      return contributionMaterializer.repairContributions(graphId, vectorSlots);
     },
 
     // Vector counterparts of the runtime-contribution methods. Present

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -65,6 +65,7 @@ import {
   type ContributionDiagnostic,
   type ContributionMaterializationIdentity,
   type ContributionMaterializationRow,
+  type ContributionRepairResult,
   type CreateVectorIndexParams,
   type DeleteEmbeddingParams,
   type DeleteFulltextBatchParams,
@@ -1605,6 +1606,13 @@ export function createSqliteBackend(
       vectorSlots: readonly VectorSlot[],
     ): Promise<readonly ContributionDiagnostic[]> {
       return contributionMaterializer.verifyContributions(graphId, vectorSlots);
+    },
+
+    async repairContributions(
+      graphId: string,
+      vectorSlots: readonly VectorSlot[],
+    ): Promise<ContributionRepairResult> {
+      return contributionMaterializer.repairContributions(graphId, vectorSlots);
     },
 
     // Vector counterparts of the runtime-contribution methods. Present

--- a/packages/typegraph/src/backend/graph-backend-projection.ts
+++ b/packages/typegraph/src/backend/graph-backend-projection.ts
@@ -89,6 +89,7 @@ const GRAPH_BACKEND_PROJECTION_KEYS = [
   "assertVectorSlotsInitialized",
   "deleteVectorSlotContribution",
   "verifyContributions",
+  "repairContributions",
   "ensureFulltextTable",
   "getReconciliationMarker",
   "setReconciliationMarker",

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -106,6 +106,8 @@ export type {
   ContributionMaterializationBackend,
   ContributionMaterializationIdentity,
   ContributionMaterializationRow,
+  ContributionRepairEntry,
+  ContributionRepairResult,
   CountEdgesByKindParams,
   CountEdgesFromParams,
   CountNodesByKindParams,

--- a/packages/typegraph/src/backend/postgres/index.ts
+++ b/packages/typegraph/src/backend/postgres/index.ts
@@ -64,6 +64,8 @@ export {
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../types";
 
 // Schema: table definitions and factory options

--- a/packages/typegraph/src/backend/postgres/pglite-store.ts
+++ b/packages/typegraph/src/backend/postgres/pglite-store.ts
@@ -26,6 +26,8 @@ import { createLocalPgliteBackend } from "./pglite";
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../types";
 
 export type LocalPgliteStoreOptions<

--- a/packages/typegraph/src/backend/postgres/pglite.ts
+++ b/packages/typegraph/src/backend/postgres/pglite.ts
@@ -60,6 +60,8 @@ import {
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../types";
 
 // ============================================================

--- a/packages/typegraph/src/backend/sqlite/index.ts
+++ b/packages/typegraph/src/backend/sqlite/index.ts
@@ -35,6 +35,8 @@ export {
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../types";
 
 // Schema: table definitions and factory options

--- a/packages/typegraph/src/backend/sqlite/libsql.ts
+++ b/packages/typegraph/src/backend/sqlite/libsql.ts
@@ -42,6 +42,8 @@ import type { AdapterBackend } from "../types";
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../types";
 
 // ============================================================

--- a/packages/typegraph/src/backend/sqlite/local-store.ts
+++ b/packages/typegraph/src/backend/sqlite/local-store.ts
@@ -27,6 +27,8 @@ import { type LocalSqlitePragmaOptions } from "./local-options";
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../types";
 export {
   DEFAULT_LOCAL_SQLITE_PRAGMAS,

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -61,6 +61,8 @@ import {
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../types";
 
 const nodeRequire = createRequire(import.meta.url);

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1095,6 +1095,35 @@ export type ContributionDiagnostic = Readonly<{
   lastError?: string;
 }>;
 
+/**
+ * Outcome of one contribution considered by
+ * {@link GraphBackend.repairContributions}.
+ *
+ * Repair targets are always resolved from the backend's current strategy
+ * declarations. The diagnostic is returned for operator context only; callers
+ * never pass diagnostics or physical DDL back into the repair API.
+ */
+export type ContributionRepairEntry =
+  | Readonly<{
+      diagnostic: ContributionDiagnostic;
+      status: "repaired";
+    }>
+  | Readonly<{
+      diagnostic: ContributionDiagnostic;
+      status: "requires-rebuild";
+    }>
+  | Readonly<{
+      diagnostic: ContributionDiagnostic;
+      status: "failed";
+      error: string;
+    }>;
+
+/** Result of a contribution repair pass followed by a fresh verification. */
+export type ContributionRepairResult = Readonly<{
+  results: readonly ContributionRepairEntry[];
+  remaining: readonly ContributionDiagnostic[];
+}>;
+
 // ============================================================
 // Kind Removals (data-cleanup status)
 // ============================================================
@@ -1849,6 +1878,23 @@ export type GraphBackend = Readonly<{
     graphId: string,
     vectorSlots: readonly VectorSlot[],
   ) => Promise<readonly ContributionDiagnostic[]>;
+
+  /**
+   * Re-audit current contribution declarations and non-destructively repair
+   * `missing-marker` and `failed-materialization` findings. The backend must
+   * resolve every target itself; it must not accept caller-provided physical
+   * identities or DDL. `stale` and `orphaned-marker` findings are returned as
+   * `requires-rebuild` because repairing either can require destructive data
+   * reconstruction.
+   *
+   * Present only on backends that can both probe their catalog and run the
+   * strategy-owned contribution DDL.
+   */
+  repairContributions?: (
+    this: void,
+    graphId: string,
+    vectorSlots: readonly VectorSlot[],
+  ) => Promise<ContributionRepairResult>;
 
   /**
    * Bootstraps the fulltext storage table the active `FulltextStrategy`

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1058,13 +1058,11 @@ export type ContributionDiagnosticState =
  * storage, so applying it to a `missing-marker` — where the table is
  * intact and only the bookkeeping is wrong — discards every embedding
  * to fix a marker, and without an `embed` callback it leaves the field
- * empty. For `missing-marker` and `failed-materialization` prefer
- * `ensureVectorSlotContribution(slot, { force: true })`, whose DDL is
- * `CREATE ... IF NOT EXISTS` and never drops. Note also that
- * `ensureRuntimeContributions` does NOT repair a fulltext
- * `orphaned-marker`: it short-circuits on the marker, which still
- * reads as initialized. See the per-state repair tables in the
- * troubleshooting guide.
+ * empty. Prefer `store.repairContributions()` for `missing-marker` and
+ * `failed-materialization`; it resolves the current strategy declarations
+ * internally and keeps the normal signature-drift guard enabled. It reports
+ * `stale` and `orphaned-marker` as `requires-rebuild`. See the per-state
+ * repair table in the troubleshooting guide.
  */
 export type ContributionDiagnostic = Readonly<{
   /** Producing strategy, e.g. `"fts5"` / `"tsvector"` / `"pgvector"`. */

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -7,6 +7,8 @@
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../backend/types";
 export { computeBaseVersion } from "./base-version";
 export { branch } from "./branch";

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -126,6 +126,8 @@ export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
   ContributionMaterializationBackend,
+  ContributionRepairEntry,
+  ContributionRepairResult,
   DeleteFulltextBatchParams,
   EdgeEntityReadBackend,
   EdgeEntityWriteBackend,

--- a/packages/typegraph/src/interchange/index.ts
+++ b/packages/typegraph/src/interchange/index.ts
@@ -26,6 +26,8 @@
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../backend/types";
 
 // ============================================================

--- a/packages/typegraph/src/profiler/index.ts
+++ b/packages/typegraph/src/profiler/index.ts
@@ -56,6 +56,8 @@
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../backend/types";
 
 // ============================================================

--- a/packages/typegraph/src/provenance/index.ts
+++ b/packages/typegraph/src/provenance/index.ts
@@ -35,6 +35,8 @@ import { isPlainObject } from "../utils/object";
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../backend/types";
 
 const DEFAULT_RETRACTED_FIELD = "retracted";

--- a/packages/typegraph/src/schema/index.ts
+++ b/packages/typegraph/src/schema/index.ts
@@ -22,6 +22,8 @@
 export type {
   ContributionDiagnostic,
   ContributionDiagnosticState,
+  ContributionRepairEntry,
+  ContributionRepairResult,
 } from "../backend/types";
 
 // ============================================================

--- a/packages/typegraph/src/store/history-store-backend.ts
+++ b/packages/typegraph/src/store/history-store-backend.ts
@@ -107,6 +107,7 @@ type UnsafeHistoryStoreBackendMember =
   | "executeDdl"
   | "executeRaw"
   | "executeStatement"
+  | "repairContributions"
   | "schemaWriteTransaction"
   | "transaction"
   | "trustedImport";

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -3383,8 +3383,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * The repair re-audits inside the backend and resolves every declaration
    * from the committed schema. Callers do not supply diagnostics, physical
    * names, or DDL. A stale Store is caught up to the active persisted graph
-   * before its vector slots are enumerated, so repair cannot re-stamp a
-   * contribution retired or changed by another writer.
+   * before its vector slots are enumerated, so repair does not use declarations
+   * from the Store's stale in-memory graph snapshot.
    *
    * @throws {ConfigurationError} when no schema has been initialized or the
    *   backend cannot probe and repair strategy-owned contributions.

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -27,6 +27,7 @@ import {
   type AdapterBackend,
   type BackendCapabilities,
   type ContributionDiagnostic,
+  type ContributionRepairResult,
   createTransactionReadBackend,
   type GraphBackend,
   runOptionallyInTransaction,
@@ -260,7 +261,13 @@ const UNKNOWN_SCHEMA_METADATA: StoreSchemaMetadata = Object.freeze({
 });
 
 type CaughtUpVerb =
-  "evolve" | "materialize" | "deprecate" | "undeprecate" | "remove" | "reembed";
+  | "evolve"
+  | "materialize"
+  | "deprecate"
+  | "undeprecate"
+  | "remove"
+  | "reembed"
+  | "repair";
 
 /** Default page size for the {@link Store.reembedVectorField} re-embed loop. */
 const DEFAULT_REEMBED_BATCH_SIZE = 200;
@@ -285,6 +292,10 @@ const CAUGHT_UP_VERB_DETAILS: Readonly<
   reembed: {
     phrase: "re-embed a vector field on",
     code: "REEMBED_BEFORE_INITIALIZE",
+  },
+  repair: {
+    phrase: "repair contributions for",
+    code: "REPAIR_CONTRIBUTIONS_BEFORE_INITIALIZE",
   },
 };
 
@@ -496,6 +507,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     options?: ReembedVectorFieldOptions,
   ) => Promise<ReembedVectorFieldResult>;
   verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+  repairContributions: () => Promise<ContributionRepairResult>;
   materializeRemovals: (
     options?: MaterializeRemovalsOptions,
   ) => Promise<MaterializeRemovalsResult>;
@@ -3359,6 +3371,45 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         resolveGraphVectorSlots(this.#graph)
       : [];
     return verify(this.graphId, vectorSlots);
+  }
+
+  /**
+   * Non-destructively repairs contribution states whose physical storage can
+   * be preserved: `missing-marker` and `failed-materialization`.
+   * `orphaned-marker` and `stale` findings are returned as
+   * `requires-rebuild`; this method never drops contribution tables or
+   * fabricates the data needed to rebuild them.
+   *
+   * The repair re-audits inside the backend and resolves every declaration
+   * from the committed schema. Callers do not supply diagnostics, physical
+   * names, or DDL. A stale Store is caught up to the active persisted graph
+   * before its vector slots are enumerated, so repair cannot re-stamp a
+   * contribution retired or changed by another writer.
+   *
+   * @throws {ConfigurationError} when no schema has been initialized or the
+   *   backend cannot probe and repair strategy-owned contributions.
+   */
+  async repairContributions(): Promise<ContributionRepairResult> {
+    const backend = this.#baseBackend;
+    const repair = backend.repairContributions;
+    if (repair === undefined) {
+      throw new ConfigurationError(
+        "repairContributions requires a backend that can probe and repair " +
+          "strategy-owned contribution tables.",
+        {
+          backend: backend.dialect,
+          capability: "contributions",
+          operation: "repair",
+        },
+      );
+    }
+
+    const { baseline } = await this.#loadCaughtUp("repair");
+    const vectorSlots =
+      backend.capabilities.vector?.supported === true ?
+        resolveGraphVectorSlots(baseline)
+      : [];
+    return repair(this.graphId, vectorSlots);
   }
 
   /**

--- a/packages/typegraph/tests/backends/integration/contribution-diagnostics.ts
+++ b/packages/typegraph/tests/backends/integration/contribution-diagnostics.ts
@@ -227,11 +227,76 @@ export function registerContributionDiagnosticIntegrationTests(
       expect(entryFor(diagnostics, contribution.tableName)?.state).toBe(
         "stale",
       );
+
+      const repair = await store.repairContributions();
+      expect(repair.results).toMatchObject([
+        {
+          diagnostic: { physicalName: contribution.tableName, state: "stale" },
+          status: "requires-rebuild",
+        },
+      ]);
+      expect(entryFor(repair.remaining, contribution.tableName)?.state).toBe(
+        "stale",
+      );
+    });
+
+    it("repairs a missing marker on a warm Store without replacing its table", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const contribution = fulltextContribution();
+      const snapshot = requireDefined(
+        snapshots[0],
+        "boot must record the fulltext contribution marker",
+      );
+
+      // Warm the backend's positive signature cache before corrupting durable
+      // state. Repair must re-read the marker instead of trusting this cache.
+      expect(await store.verifyContributions()).toEqual([]);
+      await requireDefined(
+        backend.recordContributionMaterialization,
+        "backend must record contribution markers",
+      )({
+        graphId: snapshot.graphId,
+        logicalName: snapshot.logicalName,
+        owner: snapshot.owner,
+        tableName: snapshot.tableName,
+        signature: snapshot.signature,
+        attemptedAt: new Date().toISOString(),
+        materializedAt: undefined,
+        error: "simulated marker failure",
+      });
+
+      const result = await store.repairContributions();
+      expect(result.results).toMatchObject([
+        {
+          diagnostic: {
+            physicalName: contribution.tableName,
+            state: "missing-marker",
+            lastError: "simulated marker failure",
+          },
+          status: "repaired",
+        },
+      ]);
+      expect(result.remaining).toEqual([]);
+
+      // The same table remains usable and a second pass is a true no-op.
+      const created = await store.nodes.Person.create({ name: "Repaired" });
+      expect(await store.nodes.Person.getById(created.id)).toMatchObject({
+        name: "Repaired",
+      });
+      await expect(store.repairContributions()).resolves.toEqual({
+        results: [],
+        remaining: [],
+      });
     });
 
     it("reports a live table whose marker records no success as missing-marker", async () => {
       const store = context.getStore();
       const contribution = fulltextContribution();
+      const snapshot = requireDefined(
+        snapshots[0],
+        "boot must record the fulltext contribution marker",
+      );
 
       // Record a failed attempt: storage is present but the marker no
       // longer attests it, so every read is refused as uninitialized.
@@ -245,7 +310,7 @@ export function registerContributionDiagnosticIntegrationTests(
         logicalName: contribution.logicalName,
         owner: contribution.owner,
         tableName: contribution.tableName,
-        signature: IMPOSSIBLE_SIGNATURE,
+        signature: snapshot.signature,
         attemptedAt: new Date().toISOString(),
         materializedAt: undefined,
         error: "simulated materialization failure",

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -215,6 +215,11 @@ const SECOND_VECTOR_SLOT = {
   fieldPath: "summaryEmbedding",
 } as const;
 
+const OTHER_GRAPH_VECTOR_SLOT = {
+  ...VECTOR_SLOT,
+  graphId: "other-contrib-mat-unit",
+} as const;
+
 describe("#149 ensureRuntimeContributions is read-only when already materialized", () => {
   it("a fresh materializer over an already-materialized graph runs zero DDL", async () => {
     const markers = new Map<string, ContributionMaterializationRow>();
@@ -1301,6 +1306,46 @@ describe("repairContributions safely restores repairable declarations", () => {
     ).resolves.toEqual({ results: [], remaining: [] });
   });
 
+  it("repairs vector slots using each slot's graph id", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const existingTables = new Set([
+      ...runtimeTables(),
+      vectorTableOf(OTHER_GRAPH_VECTOR_SLOT),
+    ]);
+    const { materializer } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+      existingTables,
+    );
+    await materializer.ensureRuntimeContributions(GRAPH_ID);
+    await materializer.ensureVectorSlot(OTHER_GRAPH_VECTOR_SLOT);
+
+    const contribution = pgvectorStrategy.ownedTables(
+      OTHER_GRAPH_VECTOR_SLOT,
+    )[0];
+    if (contribution === undefined)
+      throw new Error("expected vector contribution");
+    markers.delete(
+      markerKey({
+        graphId: OTHER_GRAPH_VECTOR_SLOT.graphId,
+        ...contribution,
+      }),
+    );
+
+    const result = await materializer.repairContributions(GRAPH_ID, [
+      OTHER_GRAPH_VECTOR_SLOT,
+    ]);
+
+    expect(result.results).toMatchObject([
+      {
+        diagnostic: { state: "missing-marker" },
+        status: "repaired",
+      },
+    ]);
+    expect(result.remaining).toEqual([]);
+  });
+
   it("repairs safe findings without re-stamping a stale sibling", async () => {
     const markers = new Map<string, ContributionMaterializationRow>();
     const existingTables = new Set([
@@ -1384,5 +1429,45 @@ describe("repairContributions safely restores repairable declarations", () => {
     expect(result.remaining).toMatchObject([
       { state: "missing-marker", lastError: "permission denied" },
     ]);
+  });
+
+  it("invalidates a warm positive cache when repair fails", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const contribution = pgvectorStrategy.ownedTables(VECTOR_SLOT)[0];
+    if (contribution === undefined)
+      throw new Error("expected vector contribution");
+    const existingTables = new Set([
+      ...runtimeTables(),
+      contribution.tableName,
+    ]);
+    let failDdl = false;
+    const { materializer } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+      existingTables,
+      () =>
+        failDdl ?
+          Promise.reject(new Error("permission denied"))
+        : Promise.resolve(),
+    );
+    await materializer.ensureRuntimeContributions(GRAPH_ID);
+    await materializer.ensureVectorSlot(VECTOR_SLOT);
+
+    markers.delete(markerKey({ graphId: GRAPH_ID, ...contribution }));
+    failDdl = true;
+    const result = await materializer.repairContributions(GRAPH_ID, [
+      VECTOR_SLOT,
+    ]);
+
+    expect(result.results).toMatchObject([
+      { status: "failed", error: "permission denied" },
+    ]);
+    await expect(
+      materializer.assertVectorSlot(VECTOR_SLOT),
+    ).rejects.toMatchObject({
+      name: "StoreNotInitializedError",
+      details: { reason: "failed" },
+    });
   });
 });

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -108,10 +108,12 @@ function createMockMaterializer(
   // `undefined` means "every table exists" — the healthy state every
   // non-diagnostic test in this file assumes.
   existingTables?: ReadonlySet<string>,
+  execDdlOverride?: (statement: string) => Promise<void>,
 ) {
   const ensureMarkerTable = vi.fn((): Promise<void> => Promise.resolve());
-  const execDdl = vi.fn((_statement: string): Promise<void> =>
-    Promise.resolve(),
+  const execDdl = vi.fn(
+    execDdlOverride ??
+      ((_statement: string): Promise<void> => Promise.resolve()),
   );
   const getMarkers = vi.fn(
     getMarkersOverride ??
@@ -954,12 +956,17 @@ describe("verifyContributions audits currently declared contributions", () => {
       new Set([...runtimeTables(), vectorTableOf(VECTOR_SLOT)]),
     );
     for (const contribution of pgvectorStrategy.ownedTables(VECTOR_SLOT)) {
+      const existing = markers.get(
+        markerKey({ graphId: GRAPH_ID, ...contribution }),
+      );
+      if (existing === undefined)
+        throw new Error("expected provisioned marker");
       recordMarkerInto(markers, {
         graphId: GRAPH_ID,
         logicalName: contribution.logicalName,
         owner: contribution.owner,
         tableName: contribution.tableName,
-        signature: "unused-signature",
+        signature: existing.signature,
         attemptedAt: new Date().toISOString(),
         materializedAt: undefined,
         error: failure,
@@ -1015,6 +1022,43 @@ describe("verifyContributions audits currently declared contributions", () => {
     await expect(
       materializer.verifyContributions(GRAPH_ID, [changed]),
     ).resolves.toMatchObject([{ state: "stale" }]);
+  });
+
+  it("keeps prior successful shape drift stale after a failed retry", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    await provision(markers);
+    const contribution = pgvectorStrategy.ownedTables(VECTOR_SLOT)[0];
+    if (contribution === undefined)
+      throw new Error("expected vector contribution");
+    const identity = { graphId: GRAPH_ID, ...contribution };
+    const existing = markers.get(markerKey(identity));
+    if (existing === undefined) throw new Error("expected provisioned marker");
+    recordMarkerInto(markers, {
+      ...identity,
+      signature: existing.signature,
+      attemptedAt: new Date().toISOString(),
+      materializedAt: undefined,
+      error: "new shape could not be provisioned",
+    });
+
+    const changed = { ...VECTOR_SLOT, dimensions: 16 } as const;
+    const { materializer, spies } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+      new Set([...runtimeTables(), vectorTableOf(changed)]),
+    );
+
+    const first = await materializer.repairContributions(GRAPH_ID, [changed]);
+    const second = await materializer.repairContributions(GRAPH_ID, [changed]);
+    expect(first.results).toMatchObject([
+      { diagnostic: { state: "stale" }, status: "requires-rebuild" },
+    ]);
+    expect(second.results).toMatchObject([
+      { diagnostic: { state: "stale" }, status: "requires-rebuild" },
+    ]);
+    expect(spies.execDdl).not.toHaveBeenCalled();
+    expect(spies.recordMarker).not.toHaveBeenCalled();
   });
 
   it("reports a failed attempt that produced no table as failed-materialization", async () => {
@@ -1169,5 +1213,176 @@ describe("verifyContributions audits currently declared contributions", () => {
         (entry) => entry.physicalName === vectorTableOf(VECTOR_SLOT),
       ),
     ).toBe(false);
+  });
+});
+
+describe("repairContributions safely restores repairable declarations", () => {
+  it("repairs a missing vector marker even after the signature was cached", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const existingTables = new Set([
+      ...runtimeTables(),
+      vectorTableOf(VECTOR_SLOT),
+    ]);
+    const { materializer, spies } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+      existingTables,
+    );
+    await materializer.ensureRuntimeContributions(GRAPH_ID);
+    await materializer.ensureVectorSlot(VECTOR_SLOT);
+
+    const contribution = pgvectorStrategy.ownedTables(VECTOR_SLOT)[0];
+    if (contribution === undefined)
+      throw new Error("expected vector contribution");
+    markers.delete(markerKey({ graphId: GRAPH_ID, ...contribution }));
+    spies.execDdl.mockClear();
+
+    const result = await materializer.repairContributions(GRAPH_ID, [
+      VECTOR_SLOT,
+    ]);
+
+    expect(result.results).toMatchObject([
+      {
+        diagnostic: {
+          kind: VECTOR_SLOT.nodeKind,
+          fieldPath: VECTOR_SLOT.fieldPath,
+          state: "missing-marker",
+        },
+        status: "repaired",
+      },
+    ]);
+    expect(result.remaining).toEqual([]);
+    expect(spies.execDdl).toHaveBeenCalled();
+  });
+
+  it("retries a failed materialization and is idempotent after success", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    await provision(markers);
+    const contribution = pgvectorStrategy.ownedTables(VECTOR_SLOT)[0];
+    if (contribution === undefined)
+      throw new Error("expected vector contribution");
+    const identity = { graphId: GRAPH_ID, ...contribution };
+    const prior = markers.get(markerKey(identity));
+    if (prior === undefined) throw new Error("expected provisioned marker");
+    markers.delete(markerKey(identity));
+    recordMarkerInto(markers, {
+      ...identity,
+      signature: prior.signature,
+      attemptedAt: new Date().toISOString(),
+      materializedAt: undefined,
+      error: "simulated provisioning failure",
+    });
+    const existingTables = new Set(runtimeTables());
+    const { materializer } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+      existingTables,
+      () => {
+        existingTables.add(contribution.tableName);
+        return Promise.resolve();
+      },
+    );
+
+    const first = await materializer.repairContributions(GRAPH_ID, [
+      VECTOR_SLOT,
+    ]);
+    expect(first.results).toMatchObject([
+      {
+        diagnostic: { state: "failed-materialization" },
+        status: "repaired",
+      },
+    ]);
+    expect(first.remaining).toEqual([]);
+
+    await expect(
+      materializer.repairContributions(GRAPH_ID, [VECTOR_SLOT]),
+    ).resolves.toEqual({ results: [], remaining: [] });
+  });
+
+  it("repairs safe findings without re-stamping a stale sibling", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const existingTables = new Set([
+      ...runtimeTables(),
+      vectorTableOf(VECTOR_SLOT),
+      vectorTableOf(SECOND_VECTOR_SLOT),
+    ]);
+    await provision(markers);
+    const setup = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+      existingTables,
+    );
+    await setup.materializer.ensureVectorSlot(SECOND_VECTOR_SLOT);
+
+    const missing = pgvectorStrategy.ownedTables(VECTOR_SLOT)[0];
+    const stale = pgvectorStrategy.ownedTables(SECOND_VECTOR_SLOT)[0];
+    if (missing === undefined || stale === undefined) {
+      throw new Error("expected vector contributions");
+    }
+    markers.delete(markerKey({ graphId: GRAPH_ID, ...missing }));
+    const staleIdentity = { graphId: GRAPH_ID, ...stale };
+    const staleRow = markers.get(markerKey(staleIdentity));
+    if (staleRow === undefined) throw new Error("expected provisioned marker");
+    markers.set(markerKey(staleIdentity), {
+      ...staleRow,
+      signature: "stale-signature",
+    });
+    setup.spies.execDdl.mockClear();
+
+    const result = await setup.materializer.repairContributions(GRAPH_ID, [
+      VECTOR_SLOT,
+      SECOND_VECTOR_SLOT,
+    ]);
+
+    expect(
+      result.results.find(
+        (entry) => entry.diagnostic.fieldPath === VECTOR_SLOT.fieldPath,
+      ),
+    ).toMatchObject({ status: "repaired" });
+    expect(
+      result.results.find(
+        (entry) => entry.diagnostic.fieldPath === SECOND_VECTOR_SLOT.fieldPath,
+      ),
+    ).toMatchObject({
+      diagnostic: { state: "stale" },
+      status: "requires-rebuild",
+    });
+    expect(result.remaining).toMatchObject([
+      { fieldPath: SECOND_VECTOR_SLOT.fieldPath, state: "stale" },
+    ]);
+    expect(setup.spies.execDdl).toHaveBeenCalledTimes(missing.createDdl.length);
+  });
+
+  it("reports a failed repair and preserves the diagnostic for retry", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    await provision(markers);
+    const contribution = pgvectorStrategy.ownedTables(VECTOR_SLOT)[0];
+    if (contribution === undefined)
+      throw new Error("expected vector contribution");
+    markers.delete(markerKey({ graphId: GRAPH_ID, ...contribution }));
+    const existingTables = new Set([
+      ...runtimeTables(),
+      contribution.tableName,
+    ]);
+    const { materializer } = createMockMaterializer(
+      markers,
+      undefined,
+      pgvectorStrategy,
+      existingTables,
+      () => Promise.reject(new Error("permission denied")),
+    );
+
+    const result = await materializer.repairContributions(GRAPH_ID, [
+      VECTOR_SLOT,
+    ]);
+    expect(result.results).toMatchObject([
+      { status: "failed", error: "permission denied" },
+    ]);
+    expect(result.remaining).toMatchObject([
+      { state: "missing-marker", lastError: "permission denied" },
+    ]);
   });
 });

--- a/packages/typegraph/tests/store-evolve.test.ts
+++ b/packages/typegraph/tests/store-evolve.test.ts
@@ -18,9 +18,13 @@
  *   `SchemaContentConflictError` depending on which CAS check fired
  *   first.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
+import {
+  type ContributionRepairResult,
+  createBackendOverlay,
+} from "../src/backend/types";
 import { defineGraph } from "../src/core/define-graph";
 import { embedding } from "../src/core/embedding";
 import { defineNode } from "../src/core/node";
@@ -35,6 +39,7 @@ import {
   GraphExtensionValidationError,
   IncompatibleChangeError,
 } from "../src/graph-extension";
+import { pgvectorStrategy } from "../src/query/dialect/vector/pgvector-strategy";
 import {
   createAdapterStoreWithSchema,
   createStore,
@@ -693,6 +698,52 @@ describe("Store.evolve — runtime vector index derivation", () => {
     expect(personIndex?.origin).toBeUndefined();
     expect(paperIndex).toBeDefined();
     expect(paperIndex?.origin).toBe("runtime");
+  });
+
+  it("repairs contributions from the committed graph when called on a stale Store", async () => {
+    const baseBackend = createTestBackend();
+    const repairResult: ContributionRepairResult = {
+      results: [],
+      remaining: [],
+    };
+    const repairContributions = vi.fn(() => Promise.resolve(repairResult));
+    const backend = createBackendOverlay(baseBackend, {
+      capabilities: {
+        ...baseBackend.capabilities,
+        vector: pgvectorStrategy.capabilities,
+      },
+      vectorStrategy: pgvectorStrategy,
+      repairContributions,
+    });
+    const [staleStore] = await createStoreWithSchema(baseGraph, backend);
+
+    await staleStore.evolve(
+      defineGraphExtension({
+        nodes: {
+          Paper: {
+            properties: {
+              embedding: {
+                type: "array",
+                items: { type: "number" },
+                embedding: { dimensions: 384 },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await expect(staleStore.repairContributions()).resolves.toBe(repairResult);
+    expect(repairContributions).toHaveBeenCalledWith(
+      baseGraph.id,
+      expect.arrayContaining([
+        expect.objectContaining({
+          nodeKind: "Paper",
+          fieldPath: "embedding",
+          dimensions: 384,
+        }),
+      ]),
+    );
   });
 });
 

--- a/packages/typegraph/tests/transaction-surface-honesty.test.ts
+++ b/packages/typegraph/tests/transaction-surface-honesty.test.ts
@@ -219,6 +219,7 @@ describe("portable runtime capability boundaries", () => {
       "executeDdl",
       "executeRaw",
       "executeStatement",
+      "repairContributions",
       "schemaWriteTransaction",
       "transaction",
       "trustedImport",


### PR DESCRIPTION
- add `Store.repairContributions()` for safe, idempotent repair of missing markers and failed materializations
- keep stale definitions and orphaned markers report-only with explicit `requires-rebuild` outcomes
- re-audit declarations internally, respect contribution graph IDs, and harden cache invalidation after failed repairs
- document the repair workflow and public result shape
