### PR TITLE
feat(backend): add set-based node mutation substrate

### DIFF
--- a/.changeset/quiet-nodes-update.md
+++ b/.changeset/quiet-nodes-update.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add a cross-backend set-based node mutation primitive that applies top-level
+JSON property replacements to query-selected live rows and returns every
+updated row for history and secondary-index orchestration.

--- a/.changeset/quiet-nodes-update.md
+++ b/.changeset/quiet-nodes-update.md
@@ -4,4 +4,6 @@
 
 Add a cross-backend set-based node mutation primitive that applies top-level
 JSON property replacements to query-selected live rows and returns every
-updated row for history and secondary-index orchestration.
+updated after-image for history and secondary-index orchestration. Add batched,
+kind-scoped uniqueness cleanup so callers can rebuild reservations safely and
+prevent a hard delete from clearing same-id nodes of another kind.

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -99,6 +99,9 @@ type CommitSchemaVersionParams = Readonly<{
 type CompiledRowsSql = IntentSql<"rows">;
 
 // @public (undocumented)
+type CompiledSelectSql = CompiledRowsSql;
+
+// @public (undocumented)
 type CompiledStatementSql = IntentSql<"statement">;
 
 // @public (undocumented)
@@ -2643,6 +2646,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -3058,7 +3062,7 @@ type MetaEdgeName = (typeof ALL_META_EDGE_NAMES)[number];
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public (undocumented)
 type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
@@ -3414,6 +3418,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -2674,6 +2674,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -2803,6 +2804,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public
@@ -3384,7 +3392,7 @@ type TrustedImportSession = Readonly<{
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniquenessScope = "kind" | "kindWithSubClasses";

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -3041,6 +3041,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -3170,6 +3171,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public
@@ -6767,7 +6775,7 @@ type TrustedImportSession = Readonly<{
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniquenessScope = "kind" | "kindWithSubClasses";

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -96,6 +96,9 @@ type CommitSchemaVersionParams = Readonly<{
 type CompiledRowsSql = IntentSql<"rows">;
 
 // @public (undocumented)
+type CompiledSelectSql = CompiledRowsSql;
+
+// @public (undocumented)
 type CompiledStatementSql = IntentSql<"statement">;
 
 // @public (undocumented)
@@ -3010,6 +3013,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -3411,7 +3415,7 @@ type MetaEdgeName = (typeof ALL_META_EDGE_NAMES)[number];
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public (undocumented)
 type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
@@ -6925,6 +6929,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -2681,6 +2681,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -2810,6 +2811,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public
@@ -3388,7 +3396,7 @@ type TrustedImportSession = Readonly<{
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniquenessScope = "kind" | "kindWithSubClasses";

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -92,6 +92,9 @@ type CommitSchemaVersionParams = Readonly<{
 type CompiledRowsSql = IntentSql<"rows">;
 
 // @public (undocumented)
+type CompiledSelectSql = CompiledRowsSql;
+
+// @public (undocumented)
 type CompiledStatementSql = IntentSql<"statement">;
 
 // @public (undocumented)
@@ -2650,6 +2653,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -3062,7 +3066,7 @@ type MetaEdgeName = (typeof ALL_META_EDGE_NAMES)[number];
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public (undocumented)
 type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
@@ -3418,6 +3422,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -91,6 +91,9 @@ type CommitSchemaVersionParams = Readonly<{
 type CompiledRowsSql = IntentSql<"rows">;
 
 // @public (undocumented)
+type CompiledSelectSql = CompiledRowsSql;
+
+// @public (undocumented)
 type CompiledStatementSql = IntentSql<"statement">;
 
 // @public (undocumented)
@@ -2652,6 +2655,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -3083,7 +3087,7 @@ type MetaEdgeName = (typeof ALL_META_EDGE_NAMES)[number];
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public (undocumented)
 type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
@@ -3439,6 +3443,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -2683,6 +2683,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -2812,6 +2813,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public
@@ -3409,7 +3417,7 @@ type TrustedImportSession = Readonly<{
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniquenessScope = "kind" | "kindWithSubClasses";

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -90,6 +90,9 @@ type CommitSchemaVersionParams = Readonly<{
 type CompiledRowsSql = IntentSql<"rows">;
 
 // @public (undocumented)
+type CompiledSelectSql = CompiledRowsSql;
+
+// @public (undocumented)
 type CompiledStatementSql = IntentSql<"statement">;
 
 // @public (undocumented)
@@ -2910,6 +2913,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -3311,7 +3315,7 @@ type MetaEdgeName = (typeof ALL_META_EDGE_NAMES)[number];
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public (undocumented)
 type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
@@ -6951,6 +6955,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -2941,6 +2941,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -3070,6 +3071,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public
@@ -6779,7 +6787,7 @@ type TrustedImportSession = Readonly<{
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniquenessScope = "kind" | "kindWithSubClasses";

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -337,6 +337,7 @@ export interface DialectAdapter {
     readonly jsonPathIsNotNull: (this: void, column: SqlFragment, pointer: JsonPointer) => SqlFragment;
     readonly jsonPathIsNull: (this: void, column: SqlFragment, pointer: JsonPointer) => SqlFragment;
     readonly jsonPathIsNumber: (this: void, column: SqlFragment, pointer: JsonPointer) => SqlFragment;
+    readonly jsonSetProperties: (this: void, column: SqlFragment, patch: Readonly<Record<string, JsonValue>>) => SqlFragment;
     readonly name: SqlDialect;
     readonly nullSafeEquals: (this: void, left: SqlFragment, right: SqlFragment) => SqlFragment;
     readonly packListValue: (this: void, values: readonly unknown[]) => unknown;
@@ -726,6 +727,7 @@ export type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -1201,7 +1203,7 @@ export const MODERN_SQLITE_MAX_BIND_PARAMETERS = 32766;
 export type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-export type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+export type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public (undocumented)
 export type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
@@ -1653,6 +1655,21 @@ export type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+export type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+export type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -755,6 +755,7 @@ export type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -887,6 +888,13 @@ export type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+export type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public
@@ -1621,7 +1629,7 @@ export type TrustedImportSession = Readonly<{
 export const tsvectorStrategy: FulltextStrategy;
 
 // @public (undocumented)
-export type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+export type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 export type UniquenessScope = "kind" | "kindWithSubClasses";

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -1533,6 +1533,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -1713,6 +1714,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public (undocumented)
@@ -4331,7 +4339,7 @@ type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRa
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -1505,6 +1505,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -2543,7 +2544,7 @@ type NodeCurrentReads<N extends NodeType, CN extends string = string> = Pick<Nod
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public
 type NodeGetOrCreateByConstraintOptions = Readonly<{
@@ -4393,6 +4394,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -1392,6 +1392,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -1698,6 +1699,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public (undocumented)
@@ -4113,7 +4121,7 @@ type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRa
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -1364,6 +1364,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -2522,7 +2523,7 @@ type NodeCurrentReads<N extends NodeType, CN extends string = string> = Pick<Nod
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public
 type NodeGetOrCreateByConstraintOptions = Readonly<{
@@ -4182,6 +4183,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -1345,6 +1345,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -2299,7 +2300,7 @@ type NodeCurrentReads<N extends NodeType, CN extends string = string> = Pick<Nod
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public
 type NodeGetOrCreateByConstraintOptions = Readonly<{
@@ -3992,6 +3993,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -1373,6 +1373,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -1546,6 +1547,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public (undocumented)
@@ -3933,7 +3941,7 @@ type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRa
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -1351,6 +1351,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -1524,6 +1525,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public (undocumented)
@@ -3897,7 +3905,7 @@ type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRa
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -1323,6 +1323,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -2246,7 +2247,7 @@ type NodeCurrentReads<N extends NodeType, CN extends string = string> = Pick<Nod
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public
 type NodeGetOrCreateByConstraintOptions = Readonly<{
@@ -3956,6 +3957,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -1351,6 +1351,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -1524,6 +1525,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public (undocumented)
@@ -3897,7 +3905,7 @@ type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRa
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -1323,6 +1323,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -2252,7 +2253,7 @@ type NodeCurrentReads<N extends NodeType, CN extends string = string> = Pick<Nod
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public
 type NodeGetOrCreateByConstraintOptions = Readonly<{
@@ -3956,6 +3957,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -100,6 +100,9 @@ type CommitSchemaVersionParams = Readonly<{
 type CompiledRowsSql = IntentSql<"rows">;
 
 // @public (undocumented)
+type CompiledSelectSql = CompiledRowsSql;
+
+// @public (undocumented)
 type CompiledStatementSql = IntentSql<"statement">;
 
 // @public (undocumented)
@@ -726,6 +729,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -1294,7 +1298,7 @@ export type NodeChange = Readonly<{
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public (undocumented)
 type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
@@ -1792,6 +1796,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -757,6 +757,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -902,6 +903,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public
@@ -1737,7 +1745,7 @@ type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRa
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -1348,6 +1348,7 @@ type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -2319,7 +2320,7 @@ type NodeCurrentReads<N extends NodeType, CN extends string = string> = Pick<Nod
 type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public
 type NodeGetOrCreateByConstraintOptions = Readonly<{
@@ -4012,6 +4013,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -1376,6 +1376,7 @@ type GraphBackend = Readonly<{
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -1549,6 +1550,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public (undocumented)
@@ -3953,7 +3961,7 @@ type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRa
 }>;
 
 // @public (undocumented)
-type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -281,6 +281,26 @@ false
 export function buildVectorCapabilities(strategy: VectorStrategy): VectorCapabilities;
 
 // @public
+export type BulkEdgeSourceGroup<G extends GraphDef> = {
+    [K in NodeKinds<G>]: Readonly<{
+        kind: K;
+        ids: readonly NodeId<G["nodes"][K]["type"]>[];
+    }>;
+}[NodeKinds<G>];
+
+// @public
+export type BulkFindEdgesFromParams<G extends GraphDef, K extends EdgeKinds<G>> = Readonly<{
+    sources: readonly BulkEdgeSourceGroup<G>[];
+    edgeKinds: readonly K[];
+}>;
+
+// @public
+export type BulkFindEdgesFromResult<G extends GraphDef, K extends EdgeKinds<G>> = Readonly<{
+    source: GraphNodeReference<G>;
+    edges: readonly GraphEdgeForKinds<G, K>[];
+}>;
+
+// @public
 export type Cardinality = "many" | "one" | "unique" | "oneActive";
 
 // @public
@@ -478,6 +498,25 @@ type ContributionMaterializationRow = Readonly<{
     materializedAt: string | undefined;
     lastAttemptedAt: string;
     lastError: string | undefined;
+}>;
+
+// @public
+export type ContributionRepairEntry = Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "repaired";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "requires-rebuild";
+}> | Readonly<{
+    diagnostic: ContributionDiagnostic;
+    status: "failed";
+    error: string;
+}>;
+
+// @public
+export type ContributionRepairResult = Readonly<{
+    results: readonly ContributionRepairEntry[];
+    remaining: readonly ContributionDiagnostic[];
 }>;
 
 // @public
@@ -1326,7 +1365,7 @@ type EdgeCreateOptions = Readonly<{
 type EdgeEndpointSide = "from" | "to";
 
 // @public (undocumented)
-export type EdgeEntityReadBackend = Pick<GraphBackend, "getEdge" | "getEdges" | "countEdgesFrom" | "edgeExistsBetween" | "findEdgesConnectedTo" | "findEdgesByKind" | "findEdgesByEndpointSet" | "countEdgesByKind">;
+export type EdgeEntityReadBackend = Pick<GraphBackend, "getEdge" | "getEdges" | "countEdgesFrom" | "edgeExistsBetween" | "findEdgesConnectedTo" | "findEdgesByKind" | "findEdgesByEndpointSet" | "findEdgesByHeterogeneousEndpointSet" | "countEdgesByKind">;
 
 // @public (undocumented)
 export type EdgeEntityWriteBackend = Pick<GraphBackend, "insertEdge" | "insertEdgeNoReturn" | "insertEdgesBatch" | "insertEdgesBatchReturning" | "updateEdge" | "deleteEdge" | "deleteEdgesBatch" | "hardDeleteEdge" | "hardDeleteEdgesBatch">;
@@ -1937,6 +1976,21 @@ type FindEdgesByEndpointSetParams = Readonly<{
 }>;
 
 // @public
+export type FindEdgesByHeterogeneousEndpointSetParams = Readonly<{
+    graphId: string;
+    side: EdgeEndpointSide;
+    endpoints: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[];
+    edgeKinds: readonly string[];
+    limitPerEndpoint?: number;
+    excludeDeleted?: boolean;
+    temporalMode?: TemporalMode;
+    asOf?: string;
+}>;
+
+// @public
 type FindEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -2179,10 +2233,12 @@ export type GraphBackend = Readonly<{
     countNodesByKind: (this: void, params: CountNodesByKindParams) => Promise<number>;
     findEdgesByKind: (this: void, params: FindEdgesByKindParams) => Promise<readonly EdgeRow[]>;
     findEdgesByEndpointSet?: (this: void, params: FindEdgesByEndpointSetParams) => Promise<readonly EdgeRow[]>;
+    findEdgesByHeterogeneousEndpointSet?: (this: void, params: FindEdgesByHeterogeneousEndpointSetParams) => Promise<readonly EdgeRow[]>;
     countEdgesByKind: (this: void, params: CountEdgesByKindParams) => Promise<number>;
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
     deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+    hardDeleteUniquesByNodeIds?: (this: void, params: HardDeleteUniquesByNodeIdsParams) => Promise<void>;
     checkUnique: (this: void, params: CheckUniqueParams) => Promise<UniqueRow | undefined>;
     checkUniqueBatch?: (this: void, params: CheckUniqueBatchParams) => Promise<readonly UniqueRow[]>;
     getActiveSchema: (this: void, graphId: string) => Promise<SchemaVersionRow | undefined>;
@@ -2254,6 +2310,7 @@ export type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -2315,6 +2372,11 @@ type GraphDefConfig<TNodes extends Record<string, NodeRegistration>, TEdges exte
 export type GraphEdgeCollections<G extends GraphDef> = {
     [K in keyof G["edges"] & string]-?: TypedEdgeCollection<G["edges"][K]>;
 };
+
+// @public
+export type GraphEdgeForKinds<G extends GraphDef, K extends EdgeKinds<G>> = {
+    [P in K]: Edge<G["edges"][P]["type"], G["edges"][P]["from"][number], G["edges"][P]["to"][number]>;
+}[K];
 
 // @public (undocumented)
 export type GraphEntityReadBackend = NodeEntityReadBackend & EdgeEntityReadBackend;
@@ -2404,6 +2466,14 @@ export type GraphNodeCollections<G extends GraphDef> = {
 };
 
 // @public
+export type GraphNodeReference<G extends GraphDef> = {
+    [K in NodeKinds<G>]: Readonly<{
+        kind: K;
+        id: NodeId<G["nodes"][K]["type"]>;
+    }>;
+}[NodeKinds<G>];
+
+// @public
 type GroupBySpec = Readonly<{
     fields: readonly FieldRef[];
 }>;
@@ -2419,6 +2489,13 @@ type HardDeleteNodeParams = Readonly<{
     graphId: string;
     kind: string;
     id: string;
+}>;
+
+// @public
+export type HardDeleteUniquesByNodeIdsParams = Readonly<{
+    graphId: string;
+    concreteKind: string;
+    nodeIds: readonly string[];
 }>;
 
 // @public (undocumented)
@@ -2446,7 +2523,7 @@ export function havingLt(aggregate: AggregateExpr, value: number): AggregateComp
 export function havingLte(aggregate: AggregateExpr, value: number): AggregateComparisonPredicate;
 
 // @public
-const HISTORY_STORE_BACKEND_KEYS: readonly ["assertRuntimeContributionsInitialized", "assertVectorSlotInitialized", "assertVectorSlotsInitialized", "bootstrapTables", "capabilities", "checkUnique", "checkUniqueBatch", "claimIndexMaterialization", "close", "commitSchemaVersion", "commitSchemaVersionIfKindsEmpty", "lockSchemaVersionForWrite", "compileSql", "countEdgesByKind", "countEdgesFrom", "countNodesByKind", "createVectorIndex", "deleteEdge", "deleteEdgesBatch", "deleteEmbedding", "deleteFulltext", "deleteFulltextBatch", "deleteNode", "deleteUnique", "deleteVectorSlotContribution", "dialect", "dropVectorIndex", "edgeExistsBetween", "ensureContributionMaterializationsTable", "ensureFulltextTable", "ensureIndexMaterializationsTable", "ensureKindRemovalsTable", "ensureReconciliationMarkersTable", "ensureRevisionOriginsTable", "ensureRuntimeContributions", "ensureVectorSlotContribution", "ensureVectorSlotContributions", "execute", "executeTemporaryStatement", "findEdgesByKind", "findEdgesByEndpointSet", "findEdgesConnectedTo", "findNodesByKind", "fulltextSearch", "fulltextStrategy", "getActiveSchema", "getAllKindRemovals", "getContributionMaterialization", "getEdge", "getEdges", "getIndexMaterialization", "getIndexMaterializations", "getNode", "getNodes", "getPendingKindRemovals", "getReconciliationMarker", "getSchemaVersion", "hardDeleteEdge", "hardDeleteEdgesBatch", "hardDeleteNode", "hybridSearch", "insertEdge", "insertEdgeNoReturn", "insertEdgesBatch", "insertEdgesBatchReturning", "insertNode", "insertNodeNoReturn", "insertNodesBatch", "insertNodesBatchReturning", "insertUnique", "insertUniqueBatch", "recordContributionMaterialization", "recordIndexMaterialization", "recordKindRemoval", "refreshStatistics", "releaseIndexMaterializationClaim", "setActiveVersion", "setReconciliationMarker", "tableNames", "updateEdge", "updateNode", "updateNodeSet", "upsertEmbedding", "upsertEmbeddingBatch", "upsertFulltext", "upsertFulltextBatch", "vectorSearch", "vectorStrategy", "verifyContributions"];
+const HISTORY_STORE_BACKEND_KEYS: readonly ["assertRuntimeContributionsInitialized", "assertVectorSlotInitialized", "assertVectorSlotsInitialized", "bootstrapTables", "capabilities", "checkUnique", "checkUniqueBatch", "claimIndexMaterialization", "close", "commitSchemaVersion", "commitSchemaVersionIfKindsEmpty", "lockSchemaVersionForWrite", "compileSql", "countEdgesByKind", "countEdgesFrom", "countNodesByKind", "createVectorIndex", "deleteEdge", "deleteEdgesBatch", "deleteEmbedding", "deleteFulltext", "deleteFulltextBatch", "deleteNode", "deleteUnique", "deleteVectorSlotContribution", "dialect", "dropVectorIndex", "edgeExistsBetween", "ensureContributionMaterializationsTable", "ensureFulltextTable", "ensureIndexMaterializationsTable", "ensureKindRemovalsTable", "ensureReconciliationMarkersTable", "ensureRevisionOriginsTable", "ensureRuntimeContributions", "ensureVectorSlotContribution", "ensureVectorSlotContributions", "execute", "executeTemporaryStatement", "findEdgesByKind", "findEdgesByEndpointSet", "findEdgesByHeterogeneousEndpointSet", "findEdgesConnectedTo", "findNodesByKind", "fulltextSearch", "fulltextStrategy", "getActiveSchema", "getAllKindRemovals", "getContributionMaterialization", "getEdge", "getEdges", "getIndexMaterialization", "getIndexMaterializations", "getNode", "getNodes", "getPendingKindRemovals", "getReconciliationMarker", "getSchemaVersion", "hardDeleteEdge", "hardDeleteEdgesBatch", "hardDeleteNode", "hardDeleteUniquesByNodeIds", "hybridSearch", "insertEdge", "insertEdgeNoReturn", "insertEdgesBatch", "insertEdgesBatchReturning", "insertNode", "insertNodeNoReturn", "insertNodesBatch", "insertNodesBatchReturning", "insertUnique", "insertUniqueBatch", "recordContributionMaterialization", "recordIndexMaterialization", "recordKindRemoval", "refreshStatistics", "releaseIndexMaterializationClaim", "setActiveVersion", "setReconciliationMarker", "tableNames", "updateEdge", "updateNode", "updateNodeSet", "upsertEmbedding", "upsertEmbeddingBatch", "upsertFulltext", "upsertFulltextBatch", "vectorSearch", "vectorStrategy", "verifyContributions"];
 
 // @public (undocumented)
 export type HistoryStore<G extends GraphDef> = StoreCore<G> & StoreTransactions<G> & StoreEvolution<G, HistoryStore<G>> & Readonly<{
@@ -5071,6 +5148,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     BatchableQuery<unknown>,
     ...BatchableQuery<unknown>[]
     ]>(...queries: Queries) => Promise<BatchResults<Queries>>;
+    bulkFindEdgesFrom: <const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: EdgeBulkFindEndpointOptions) => Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     subgraph: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: SubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     clear: () => Promise<void>;
     refreshStatistics: () => Promise<void>;
@@ -5078,6 +5156,7 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
+    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;
@@ -5198,6 +5277,7 @@ type StoreTransactions<G extends GraphDef> = Readonly<{
 export class StoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: StoreViewCoordinate | ReadCoordinate);
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
+    bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
@@ -5697,7 +5777,7 @@ export type UniqueConstraint<S extends z.ZodObject<z.ZodRawShape> = z.ZodObject<
 }>;
 
 // @public (undocumented)
-export type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "checkUnique" | "checkUniqueBatch">;
+export type UniqueConstraintBackend = Pick<GraphBackend, "insertUnique" | "insertUniqueBatch" | "deleteUnique" | "hardDeleteUniquesByNodeIds" | "checkUnique" | "checkUniqueBatch">;
 
 // @public
 type UniqueConstraintField = Readonly<{
@@ -5758,7 +5838,7 @@ type UniqueRow = Readonly<{
 }>;
 
 // @public (undocumented)
-type UnsafeHistoryStoreBackendMember = "clearGraph" | "executeDdl" | "executeRaw" | "executeStatement" | "schemaWriteTransaction" | "transaction" | "trustedImport";
+type UnsafeHistoryStoreBackendMember = "clearGraph" | "executeDdl" | "executeRaw" | "executeStatement" | "repairContributions" | "schemaWriteTransaction" | "transaction" | "trustedImport";
 
 // @public
 export class UnsupportedBackendCapabilityError extends TypeGraphError {

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -281,26 +281,6 @@ false
 export function buildVectorCapabilities(strategy: VectorStrategy): VectorCapabilities;
 
 // @public
-export type BulkEdgeSourceGroup<G extends GraphDef> = {
-    [K in NodeKinds<G>]: Readonly<{
-        kind: K;
-        ids: readonly NodeId<G["nodes"][K]["type"]>[];
-    }>;
-}[NodeKinds<G>];
-
-// @public
-export type BulkFindEdgesFromParams<G extends GraphDef, K extends EdgeKinds<G>> = Readonly<{
-    sources: readonly BulkEdgeSourceGroup<G>[];
-    edgeKinds: readonly K[];
-}>;
-
-// @public
-export type BulkFindEdgesFromResult<G extends GraphDef, K extends EdgeKinds<G>> = Readonly<{
-    source: GraphNodeReference<G>;
-    edges: readonly GraphEdgeForKinds<G, K>[];
-}>;
-
-// @public
 export type Cardinality = "many" | "one" | "unique" | "oneActive";
 
 // @public
@@ -498,25 +478,6 @@ type ContributionMaterializationRow = Readonly<{
     materializedAt: string | undefined;
     lastAttemptedAt: string;
     lastError: string | undefined;
-}>;
-
-// @public
-export type ContributionRepairEntry = Readonly<{
-    diagnostic: ContributionDiagnostic;
-    status: "repaired";
-}> | Readonly<{
-    diagnostic: ContributionDiagnostic;
-    status: "requires-rebuild";
-}> | Readonly<{
-    diagnostic: ContributionDiagnostic;
-    status: "failed";
-    error: string;
-}>;
-
-// @public
-export type ContributionRepairResult = Readonly<{
-    results: readonly ContributionRepairEntry[];
-    remaining: readonly ContributionDiagnostic[];
 }>;
 
 // @public
@@ -1365,7 +1326,7 @@ type EdgeCreateOptions = Readonly<{
 type EdgeEndpointSide = "from" | "to";
 
 // @public (undocumented)
-export type EdgeEntityReadBackend = Pick<GraphBackend, "getEdge" | "getEdges" | "countEdgesFrom" | "edgeExistsBetween" | "findEdgesConnectedTo" | "findEdgesByKind" | "findEdgesByEndpointSet" | "findEdgesByHeterogeneousEndpointSet" | "countEdgesByKind">;
+export type EdgeEntityReadBackend = Pick<GraphBackend, "getEdge" | "getEdges" | "countEdgesFrom" | "edgeExistsBetween" | "findEdgesConnectedTo" | "findEdgesByKind" | "findEdgesByEndpointSet" | "countEdgesByKind">;
 
 // @public (undocumented)
 export type EdgeEntityWriteBackend = Pick<GraphBackend, "insertEdge" | "insertEdgeNoReturn" | "insertEdgesBatch" | "insertEdgesBatchReturning" | "updateEdge" | "deleteEdge" | "deleteEdgesBatch" | "hardDeleteEdge" | "hardDeleteEdgesBatch">;
@@ -1976,21 +1937,6 @@ type FindEdgesByEndpointSetParams = Readonly<{
 }>;
 
 // @public
-export type FindEdgesByHeterogeneousEndpointSetParams = Readonly<{
-    graphId: string;
-    side: EdgeEndpointSide;
-    endpoints: readonly Readonly<{
-        kind: string;
-        id: string;
-    }>[];
-    edgeKinds: readonly string[];
-    limitPerEndpoint?: number;
-    excludeDeleted?: boolean;
-    temporalMode?: TemporalMode;
-    asOf?: string;
-}>;
-
-// @public
 type FindEdgesByKindParams = Readonly<{
     graphId: string;
     kind: string;
@@ -2210,6 +2156,7 @@ export type GraphBackend = Readonly<{
     insertNodesBatch?: (this: void, params: readonly InsertNodeParams[]) => Promise<void>;
     insertNodesBatchReturning?: (this: void, params: readonly InsertNodeParams[]) => Promise<readonly NodeRow[]>;
     updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+    updateNodeSet?: (this: void, params: UpdateNodeSetParams) => Promise<UpdateNodeSetResult>;
     deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
     hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
     getNode: (this: void, graphId: string, kind: string, id: string) => Promise<NodeRow | undefined>;
@@ -2232,7 +2179,6 @@ export type GraphBackend = Readonly<{
     countNodesByKind: (this: void, params: CountNodesByKindParams) => Promise<number>;
     findEdgesByKind: (this: void, params: FindEdgesByKindParams) => Promise<readonly EdgeRow[]>;
     findEdgesByEndpointSet?: (this: void, params: FindEdgesByEndpointSetParams) => Promise<readonly EdgeRow[]>;
-    findEdgesByHeterogeneousEndpointSet?: (this: void, params: FindEdgesByHeterogeneousEndpointSetParams) => Promise<readonly EdgeRow[]>;
     countEdgesByKind: (this: void, params: CountEdgesByKindParams) => Promise<number>;
     insertUnique: (this: void, params: InsertUniqueParams) => Promise<void>;
     insertUniqueBatch?: (this: void, entries: readonly InsertUniqueParams[]) => Promise<void>;
@@ -2308,7 +2254,6 @@ export type GraphBackend = Readonly<{
     assertVectorSlotsInitialized?: (this: void, slots: readonly VectorSlot[]) => Promise<void>;
     deleteVectorSlotContribution?: (this: void, slot: VectorSlot) => Promise<void>;
     verifyContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<readonly ContributionDiagnostic[]>;
-    repairContributions?: (this: void, graphId: string, vectorSlots: readonly VectorSlot[]) => Promise<ContributionRepairResult>;
     ensureFulltextTable?: (this: void, graphId: string) => Promise<void>;
     getReconciliationMarker?: (this: void, graphId: string) => Promise<number | undefined>;
     setReconciliationMarker?: (this: void, graphId: string, version: number) => Promise<void>;
@@ -2370,11 +2315,6 @@ type GraphDefConfig<TNodes extends Record<string, NodeRegistration>, TEdges exte
 export type GraphEdgeCollections<G extends GraphDef> = {
     [K in keyof G["edges"] & string]-?: TypedEdgeCollection<G["edges"][K]>;
 };
-
-// @public
-export type GraphEdgeForKinds<G extends GraphDef, K extends EdgeKinds<G>> = {
-    [P in K]: Edge<G["edges"][P]["type"], G["edges"][P]["from"][number], G["edges"][P]["to"][number]>;
-}[K];
 
 // @public (undocumented)
 export type GraphEntityReadBackend = NodeEntityReadBackend & EdgeEntityReadBackend;
@@ -2464,14 +2404,6 @@ export type GraphNodeCollections<G extends GraphDef> = {
 };
 
 // @public
-export type GraphNodeReference<G extends GraphDef> = {
-    [K in NodeKinds<G>]: Readonly<{
-        kind: K;
-        id: NodeId<G["nodes"][K]["type"]>;
-    }>;
-}[NodeKinds<G>];
-
-// @public
 type GroupBySpec = Readonly<{
     fields: readonly FieldRef[];
 }>;
@@ -2514,7 +2446,7 @@ export function havingLt(aggregate: AggregateExpr, value: number): AggregateComp
 export function havingLte(aggregate: AggregateExpr, value: number): AggregateComparisonPredicate;
 
 // @public
-const HISTORY_STORE_BACKEND_KEYS: readonly ["assertRuntimeContributionsInitialized", "assertVectorSlotInitialized", "assertVectorSlotsInitialized", "bootstrapTables", "capabilities", "checkUnique", "checkUniqueBatch", "claimIndexMaterialization", "close", "commitSchemaVersion", "commitSchemaVersionIfKindsEmpty", "lockSchemaVersionForWrite", "compileSql", "countEdgesByKind", "countEdgesFrom", "countNodesByKind", "createVectorIndex", "deleteEdge", "deleteEdgesBatch", "deleteEmbedding", "deleteFulltext", "deleteFulltextBatch", "deleteNode", "deleteUnique", "deleteVectorSlotContribution", "dialect", "dropVectorIndex", "edgeExistsBetween", "ensureContributionMaterializationsTable", "ensureFulltextTable", "ensureIndexMaterializationsTable", "ensureKindRemovalsTable", "ensureReconciliationMarkersTable", "ensureRevisionOriginsTable", "ensureRuntimeContributions", "ensureVectorSlotContribution", "ensureVectorSlotContributions", "execute", "executeTemporaryStatement", "findEdgesByKind", "findEdgesByEndpointSet", "findEdgesByHeterogeneousEndpointSet", "findEdgesConnectedTo", "findNodesByKind", "fulltextSearch", "fulltextStrategy", "getActiveSchema", "getAllKindRemovals", "getContributionMaterialization", "getEdge", "getEdges", "getIndexMaterialization", "getIndexMaterializations", "getNode", "getNodes", "getPendingKindRemovals", "getReconciliationMarker", "getSchemaVersion", "hardDeleteEdge", "hardDeleteEdgesBatch", "hardDeleteNode", "hybridSearch", "insertEdge", "insertEdgeNoReturn", "insertEdgesBatch", "insertEdgesBatchReturning", "insertNode", "insertNodeNoReturn", "insertNodesBatch", "insertNodesBatchReturning", "insertUnique", "insertUniqueBatch", "recordContributionMaterialization", "recordIndexMaterialization", "recordKindRemoval", "refreshStatistics", "releaseIndexMaterializationClaim", "setActiveVersion", "setReconciliationMarker", "tableNames", "updateEdge", "updateNode", "upsertEmbedding", "upsertEmbeddingBatch", "upsertFulltext", "upsertFulltextBatch", "vectorSearch", "vectorStrategy", "verifyContributions"];
+const HISTORY_STORE_BACKEND_KEYS: readonly ["assertRuntimeContributionsInitialized", "assertVectorSlotInitialized", "assertVectorSlotsInitialized", "bootstrapTables", "capabilities", "checkUnique", "checkUniqueBatch", "claimIndexMaterialization", "close", "commitSchemaVersion", "commitSchemaVersionIfKindsEmpty", "lockSchemaVersionForWrite", "compileSql", "countEdgesByKind", "countEdgesFrom", "countNodesByKind", "createVectorIndex", "deleteEdge", "deleteEdgesBatch", "deleteEmbedding", "deleteFulltext", "deleteFulltextBatch", "deleteNode", "deleteUnique", "deleteVectorSlotContribution", "dialect", "dropVectorIndex", "edgeExistsBetween", "ensureContributionMaterializationsTable", "ensureFulltextTable", "ensureIndexMaterializationsTable", "ensureKindRemovalsTable", "ensureReconciliationMarkersTable", "ensureRevisionOriginsTable", "ensureRuntimeContributions", "ensureVectorSlotContribution", "ensureVectorSlotContributions", "execute", "executeTemporaryStatement", "findEdgesByKind", "findEdgesByEndpointSet", "findEdgesConnectedTo", "findNodesByKind", "fulltextSearch", "fulltextStrategy", "getActiveSchema", "getAllKindRemovals", "getContributionMaterialization", "getEdge", "getEdges", "getIndexMaterialization", "getIndexMaterializations", "getNode", "getNodes", "getPendingKindRemovals", "getReconciliationMarker", "getSchemaVersion", "hardDeleteEdge", "hardDeleteEdgesBatch", "hardDeleteNode", "hybridSearch", "insertEdge", "insertEdgeNoReturn", "insertEdgesBatch", "insertEdgesBatchReturning", "insertNode", "insertNodeNoReturn", "insertNodesBatch", "insertNodesBatchReturning", "insertUnique", "insertUniqueBatch", "recordContributionMaterialization", "recordIndexMaterialization", "recordKindRemoval", "refreshStatistics", "releaseIndexMaterializationClaim", "setActiveVersion", "setReconciliationMarker", "tableNames", "updateEdge", "updateNode", "updateNodeSet", "upsertEmbedding", "upsertEmbeddingBatch", "upsertFulltext", "upsertFulltextBatch", "vectorSearch", "vectorStrategy", "verifyContributions"];
 
 // @public (undocumented)
 export type HistoryStore<G extends GraphDef> = StoreCore<G> & StoreTransactions<G> & StoreEvolution<G, HistoryStore<G>> & Readonly<{
@@ -3643,7 +3575,7 @@ export type NodeCurrentReads<N extends NodeType, CN extends string = string> = P
 export type NodeEntityReadBackend = Pick<GraphBackend, "getNode" | "getNodes" | "findNodesByKind" | "countNodesByKind">;
 
 // @public (undocumented)
-export type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "deleteNode" | "hardDeleteNode">;
+export type NodeEntityWriteBackend = Pick<GraphBackend, "insertNode" | "insertNodeNoReturn" | "insertNodesBatch" | "insertNodesBatchReturning" | "updateNode" | "updateNodeSet" | "deleteNode" | "hardDeleteNode">;
 
 // @public
 export type NodeGetOrCreateByConstraintOptions = Readonly<{
@@ -5139,7 +5071,6 @@ type StoreCore<G extends GraphDef> = Readonly<{
     BatchableQuery<unknown>,
     ...BatchableQuery<unknown>[]
     ]>(...queries: Queries) => Promise<BatchResults<Queries>>;
-    bulkFindEdgesFrom: <const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: EdgeBulkFindEndpointOptions) => Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     subgraph: <const EK extends EdgeKinds<G>, const NK extends NodeKinds<G> = NodeKinds<G>, const P extends SubgraphProject<G, NK, EK> | undefined = undefined>(rootId: NodeId<AllNodeTypes<G>>, options: SubgraphOptions<G, EK, NK, P>) => Promise<SubgraphResult<G, NK, EK, P>>;
     clear: () => Promise<void>;
     refreshStatistics: () => Promise<void>;
@@ -5147,7 +5078,6 @@ type StoreCore<G extends GraphDef> = Readonly<{
     materializeSystemIndexes: (options?: MaterializeSystemIndexesOptions) => Promise<MaterializeIndexesResult>;
     reembedVectorField: (kind: string, fieldPath: string, options?: ReembedVectorFieldOptions) => Promise<ReembedVectorFieldResult>;
     verifyContributions: () => Promise<readonly ContributionDiagnostic[]>;
-    repairContributions: () => Promise<ContributionRepairResult>;
     materializeRemovals: (options?: MaterializeRemovalsOptions) => Promise<MaterializeRemovalsResult>;
     close: () => Promise<void>;
 }>;
@@ -5268,7 +5198,6 @@ type StoreTransactions<G extends GraphDef> = Readonly<{
 export class StoreView<G extends GraphDef> extends CoordinatePinnedView<G> {
     constructor(store: Store<G>, coordinate: StoreViewCoordinate | ReadCoordinate);
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
-    bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
@@ -5829,7 +5758,7 @@ type UniqueRow = Readonly<{
 }>;
 
 // @public (undocumented)
-type UnsafeHistoryStoreBackendMember = "clearGraph" | "executeDdl" | "executeRaw" | "executeStatement" | "repairContributions" | "schemaWriteTransaction" | "transaction" | "trustedImport";
+type UnsafeHistoryStoreBackendMember = "clearGraph" | "executeDdl" | "executeRaw" | "executeStatement" | "schemaWriteTransaction" | "transaction" | "trustedImport";
 
 // @public
 export class UnsupportedBackendCapabilityError extends TypeGraphError {
@@ -5877,6 +5806,21 @@ type UpdateNodeParams = Readonly<{
     validTo?: string;
     incrementVersion?: boolean;
     clearDeleted?: boolean;
+}>;
+
+// @public
+export type UpdateNodeSetParams = Readonly<{
+    graphId: string;
+    kind: string;
+    patch: Readonly<Record<string, JsonValue>>;
+    candidateIds: CompiledSelectSql;
+    candidateIdColumn: string;
+}>;
+
+// @public
+export type UpdateNodeSetResult = Readonly<{
+    affectedCount: number;
+    rows: readonly NodeRow[];
 }>;
 
 // @public

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -52,28 +52,28 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "6c11a8d2c13c886a2d6473f8af99d9c4988c7bbfe97545a6a6f748cdd18bf6d8",
   },
   "./adapters/drizzle/postgres": {
-    count: 174,
-    sha256: "e95c402a481bcfc7380e6904e312d2be77332284dbbb9feced9a3e21940690b7",
+    count: 176,
+    sha256: "68e1c3d055d4b08814791ca8f743d020817e7729fef5e4a5fa0dcb4fcce030a9",
   },
   "./adapters/drizzle/postgres/pglite": {
-    count: 178,
-    sha256: "1d091ae9dac9fc6f21dc77eee28c204b24525fcf562ab67395d0017dbfbd0b2b",
+    count: 180,
+    sha256: "d4b49bb80d5ca4faedab7715f2873dbf68535a1b64966e2912e891c54b46691a",
   },
   "./adapters/drizzle/sqlite": {
-    count: 175,
-    sha256: "67aafff67e25c9b2bb21624a30226f65957fea08327be485cee45731471fd428",
+    count: 177,
+    sha256: "48b872caf8420617a22bb2e35fea0438c31c93899a338677a5b9c4b4c3594022",
   },
   "./adapters/drizzle/sqlite/libsql": {
-    count: 178,
-    sha256: "fc5e8dd3511870bfbe4222ca6f90d41c4f0d3d4fd57f2119dade8f3a8a222836",
+    count: 180,
+    sha256: "794af7d47d68623803c740f42b71029a40dcb14a05369a3cfc38b7eb1eaa5d49",
   },
   "./adapters/drizzle/sqlite/local": {
-    count: 178,
-    sha256: "fc5e8dd3511870bfbe4222ca6f90d41c4f0d3d4fd57f2119dade8f3a8a222836",
+    count: 180,
+    sha256: "794af7d47d68623803c740f42b71029a40dcb14a05369a3cfc38b7eb1eaa5d49",
   },
   "./backend": {
-    count: 1,
-    sha256: "711e337fd05fa134a31d7d29661a8a2cb1fdd078d56cc1b869251934c0b5416e",
+    count: 2,
+    sha256: "941b8d91183140156edd12c59c95250482b074ac9bf4a69eff7ff45711a5b496",
   },
   "./core": {
     count: 72,
@@ -84,36 +84,36 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "0f36d8f84e9a9d75255b39940c5308ae4df2c3dbe1e0cb2683b00ee8cb974f73",
   },
   "./graph-merge": {
-    count: 541,
-    sha256: "9bf9617b775d0fc1365ecd4631f5a85e81ba4d0979ba4ae0e7c030cc99a12a5e",
+    count: 537,
+    sha256: "b7a1c23a6fed90202809869063824a0e2c145cabe2d7b9e02f6e2fabadfa7f0d",
   },
   "./indexes": {
     count: 43,
     sha256: "49144a0eeda76d83d8ebe63f533e25796e1b7d46fe521a4adc997fb58cb876bb",
   },
   "./interchange": {
-    count: 527,
-    sha256: "4fd8c66f582b9484d2993dec353e7467027baea14436281e2e4223b130d5133e",
+    count: 523,
+    sha256: "4a94ed7096858a228e59b20d20c24d970f252fbf328a796718420422a8baccc5",
   },
   "./postgres/pglite": {
-    count: 541,
-    sha256: "a74c357a33ecf7866b2889a4dcb3f3187028bcbdad97c35e1cdb3839bc894eba",
+    count: 537,
+    sha256: "9fdca798c4b850dcc27a89704d8b7049ad931b64b69d28bd4bf2dae658002258",
   },
   "./profiler": {
-    count: 529,
-    sha256: "b55da3c618a934bcc742920a7539851b7aded4a0a00a36057f1372300c2b68b0",
+    count: 525,
+    sha256: "8596a0fd35abb8bf012b78d4738a74d03422a57e513345d48e0378403b391d50",
   },
   "./provenance": {
-    count: 535,
-    sha256: "d320d4468afd5d90b7bdfe464c32f591a5c85dbccdad059470d635b08e04f1ab",
+    count: 531,
+    sha256: "dc1ec76325ef1d50d78c4f102d1ae2797bc6847fe14237833ad94f1ae4e9804b",
   },
   "./schema": {
-    count: 192,
-    sha256: "7c3c29a02e0e15a5b7cfb54cc383084d0c546d7417cf4e90fb5fd92dad202087",
+    count: 194,
+    sha256: "56a91fac1d9e9c625f85660c94d6e6752ea0076ce442f3483052254facdb791d",
   },
   "./sqlite/local": {
-    count: 541,
-    sha256: "a74c357a33ecf7866b2889a4dcb3f3187028bcbdad97c35e1cdb3839bc894eba",
+    count: 537,
+    sha256: "9fdca798c4b850dcc27a89704d8b7049ad931b64b69d28bd4bf2dae658002258",
   },
 };
 

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -52,28 +52,28 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "6c11a8d2c13c886a2d6473f8af99d9c4988c7bbfe97545a6a6f748cdd18bf6d8",
   },
   "./adapters/drizzle/postgres": {
-    count: 176,
-    sha256: "68e1c3d055d4b08814791ca8f743d020817e7729fef5e4a5fa0dcb4fcce030a9",
+    count: 178,
+    sha256: "9bc63419830cc88bd1e27b547edfac4da7b2601bc0734dad4b69a5f06753843d",
   },
   "./adapters/drizzle/postgres/pglite": {
-    count: 180,
-    sha256: "d4b49bb80d5ca4faedab7715f2873dbf68535a1b64966e2912e891c54b46691a",
+    count: 182,
+    sha256: "e13c00de2533db2d56907a683f5c7a57e2714c4fe5c0d95632fe12b938a7ffcf",
   },
   "./adapters/drizzle/sqlite": {
-    count: 177,
-    sha256: "48b872caf8420617a22bb2e35fea0438c31c93899a338677a5b9c4b4c3594022",
+    count: 179,
+    sha256: "188ec8ddfa046ba3c8ae6bd96a54a54203237eb9dd3b4f496a2686cbe4fbeb25",
   },
   "./adapters/drizzle/sqlite/libsql": {
-    count: 180,
-    sha256: "794af7d47d68623803c740f42b71029a40dcb14a05369a3cfc38b7eb1eaa5d49",
+    count: 182,
+    sha256: "9f05fa5bb8b2a9b4a91d6737e4e6c07cc36b95f2c8767f5e1d7a3bf862e51ea0",
   },
   "./adapters/drizzle/sqlite/local": {
-    count: 180,
-    sha256: "794af7d47d68623803c740f42b71029a40dcb14a05369a3cfc38b7eb1eaa5d49",
+    count: 182,
+    sha256: "9f05fa5bb8b2a9b4a91d6737e4e6c07cc36b95f2c8767f5e1d7a3bf862e51ea0",
   },
   "./backend": {
-    count: 2,
-    sha256: "941b8d91183140156edd12c59c95250482b074ac9bf4a69eff7ff45711a5b496",
+    count: 1,
+    sha256: "711e337fd05fa134a31d7d29661a8a2cb1fdd078d56cc1b869251934c0b5416e",
   },
   "./core": {
     count: 72,
@@ -84,36 +84,36 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "0f36d8f84e9a9d75255b39940c5308ae4df2c3dbe1e0cb2683b00ee8cb974f73",
   },
   "./graph-merge": {
-    count: 537,
-    sha256: "b7a1c23a6fed90202809869063824a0e2c145cabe2d7b9e02f6e2fabadfa7f0d",
+    count: 544,
+    sha256: "6f47f1a880062dbca2fd068cfed032b0ca6e6c85fc3f8e6d744530560470d804",
   },
   "./indexes": {
     count: 43,
     sha256: "49144a0eeda76d83d8ebe63f533e25796e1b7d46fe521a4adc997fb58cb876bb",
   },
   "./interchange": {
-    count: 523,
-    sha256: "4a94ed7096858a228e59b20d20c24d970f252fbf328a796718420422a8baccc5",
+    count: 530,
+    sha256: "47b78b73bd8c197321ffdd801936c10ca78b722bfe69c590778ed1ec02b77cd5",
   },
   "./postgres/pglite": {
-    count: 537,
-    sha256: "9fdca798c4b850dcc27a89704d8b7049ad931b64b69d28bd4bf2dae658002258",
+    count: 544,
+    sha256: "6dcfc23e0f48103916a0f62b5d5265cb4cf9ce75714bd79d7f40ca0137e94801",
   },
   "./profiler": {
-    count: 525,
-    sha256: "8596a0fd35abb8bf012b78d4738a74d03422a57e513345d48e0378403b391d50",
+    count: 532,
+    sha256: "734f96097e7f49bccd0173b9d1dbddad10863c653156c0bf5830b597f442ffd3",
   },
   "./provenance": {
-    count: 531,
-    sha256: "dc1ec76325ef1d50d78c4f102d1ae2797bc6847fe14237833ad94f1ae4e9804b",
+    count: 538,
+    sha256: "2165ac019bae5db49e60dbffb51cd7fac22e47655d3f2dcd0f8a79e644bef3b9",
   },
   "./schema": {
-    count: 194,
-    sha256: "56a91fac1d9e9c625f85660c94d6e6752ea0076ce442f3483052254facdb791d",
+    count: 196,
+    sha256: "9a5430988c8e53a4217c19b71b618d0a5fe4f2ddd33bf72fa527b2ffeaa055a1",
   },
   "./sqlite/local": {
-    count: 537,
-    sha256: "9fdca798c4b850dcc27a89704d8b7049ad931b64b69d28bd4bf2dae658002258",
+    count: 544,
+    sha256: "6dcfc23e0f48103916a0f62b5d5265cb4cf9ce75714bd79d7f40ca0137e94801",
   },
 };
 

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -43,6 +43,7 @@ import type {
   FindNodesByKindParams,
   HardDeleteEdgeParams,
   HardDeleteNodeParams,
+  HardDeleteUniquesByNodeIdsParams,
   InsertEdgeParams,
   InsertNodeParams,
   InsertUniqueParams,
@@ -101,6 +102,7 @@ export type CommonOperationBackend = Pick<
   | "hardDeleteEdge"
   | "hardDeleteEdgesBatch"
   | "hardDeleteNode"
+  | "hardDeleteUniquesByNodeIds"
   | "insertEdge"
   | "insertEdgeNoReturn"
   | "insertEdgesBatch"
@@ -181,6 +183,7 @@ type OperationBackendBatchConfig = Readonly<{
   getEdgesChunkSize: number;
   getNodesChunkSize: number;
   nodeInsertBatchSize: number;
+  uniqueDeleteChunkSize: number;
   uniqueInsertBatchSize: number;
 }>;
 
@@ -483,6 +486,7 @@ export function createCommonOperationBackend(
     async hardDeleteNode(params: HardDeleteNodeParams): Promise<void> {
       const deleteUniquesQuery = operationStrategy.buildHardDeleteUniquesByNode(
         params.graphId,
+        params.kind,
         params.id,
       );
       await execution.execRun(deleteUniquesQuery);
@@ -811,6 +815,22 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       const query = operationStrategy.buildDeleteUnique(params, timestamp);
       await execution.execRun(query);
+    },
+
+    async hardDeleteUniquesByNodeIds(
+      params: HardDeleteUniquesByNodeIdsParams,
+    ): Promise<void> {
+      const nodeIds = [...new Set(params.nodeIds)];
+      for (const chunk of chunkArray(
+        nodeIds,
+        batchConfig.uniqueDeleteChunkSize,
+      )) {
+        const query = operationStrategy.buildHardDeleteUniquesByNodeIds({
+          ...params,
+          nodeIds: chunk,
+        });
+        await execution.execRun(query);
+      }
     },
 
     async checkUnique(

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -55,6 +55,8 @@ import type {
   UniqueRow,
   UpdateEdgeParams,
   UpdateNodeParams,
+  UpdateNodeSetParams,
+  UpdateNodeSetResult,
 } from "../types";
 import { type ExecutableSql } from "./execution/types";
 import {
@@ -111,6 +113,7 @@ export type CommonOperationBackend = Pick<
   | "insertUniqueBatch"
   | "updateEdge"
   | "updateNode"
+  | "updateNodeSet"
 > &
   Readonly<{
     executeStatement: NonNullable<TransactionBackend["executeStatement"]>;
@@ -438,6 +441,28 @@ export function createCommonOperationBackend(
           { operation: "update", entity: "node" },
         );
       return rowMappers.toNodeRow(row);
+    },
+
+    async updateNodeSet(
+      params: UpdateNodeSetParams,
+    ): Promise<UpdateNodeSetResult> {
+      if (Object.keys(params.patch).length === 0) {
+        throw new ConfigurationError(
+          "Set-based node update requires at least one property",
+          { operation: "updateNodeSet", kind: params.kind },
+        );
+      }
+      if (params.candidateIdColumn.length === 0) {
+        throw new ConfigurationError(
+          "Set-based node update requires a candidate id column",
+          { operation: "updateNodeSet", kind: params.kind },
+        );
+      }
+      const timestamp = nowIso();
+      const query = operationStrategy.buildUpdateNodeSet(params, timestamp);
+      const rows = await execution.execAll<Record<string, unknown>>(query);
+      const updatedRows = rows.map((row) => rowMappers.toNodeRow(row));
+      return { affectedCount: updatedRows.length, rows: updatedRows };
     },
 
     async deleteNode(params: DeleteNodeParams): Promise<void> {

--- a/packages/typegraph/src/backend/drizzle/operations/nodes.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/nodes.ts
@@ -1,11 +1,15 @@
 import { type SQL, sql } from "drizzle-orm";
 
+import { getDialect } from "../../../query/dialect";
+import { sql as portableSql } from "../../../query/sql-fragment";
 import type {
   DeleteNodeParams,
   HardDeleteNodeParams,
   InsertNodeParams,
   UpdateNodeParams,
+  UpdateNodeSetParams,
 } from "../../types";
+import { toDrizzleSql } from "../execution/types";
 import {
   nodeColumnList,
   quotedColumn,
@@ -197,6 +201,48 @@ export function buildUpdateNode(
       AND ${nodes.kind} = ${params.kind}
       AND ${nodes.id} = ${params.id}
       AND ${nodes.deletedAt} IS NULL
+    RETURNING *
+  `;
+}
+
+/**
+ * Builds one set-based update over candidate ids selected by the shared query
+ * compiler. The outer graph/kind/live-row predicates are deliberate write
+ * fences and must not be delegated solely to the candidate subquery.
+ */
+export function buildUpdateNodeSet(
+  tables: Tables,
+  dialect: "sqlite" | "postgres",
+  params: UpdateNodeSetParams,
+  timestamp: string,
+): SQL {
+  const { nodes } = tables;
+  const adapter = getDialect(dialect);
+  const patchedProps = toDrizzleSql(
+    adapter.jsonSetProperties(
+      portableSql.identifier(nodes.props.name),
+      params.patch,
+    ),
+    dialect,
+  );
+  const candidateIds = toDrizzleSql(params.candidateIds, dialect);
+  const candidateIdColumn = toDrizzleSql(
+    portableSql.identifier(params.candidateIdColumn),
+    dialect,
+  );
+
+  return sql`
+    UPDATE ${nodes}
+    SET ${quotedColumn(nodes.props)} = ${patchedProps},
+        ${quotedColumn(nodes.updatedAt)} = ${timestamp},
+        ${quotedColumn(nodes.version)} = ${quotedColumn(nodes.version)} + 1
+    WHERE ${nodes.graphId} = ${params.graphId}
+      AND ${nodes.kind} = ${params.kind}
+      AND ${nodes.deletedAt} IS NULL
+      AND ${nodes.id} IN (
+        SELECT ${candidateIdColumn}
+        FROM (${candidateIds}) AS tg_set_candidates
+      )
     RETURNING *
   `;
 }

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -34,6 +34,7 @@ import type {
   SqlDialect,
   UpdateEdgeParams,
   UpdateNodeParams,
+  UpdateNodeSetParams,
   UpsertFulltextBatchParams,
   UpsertFulltextParams,
 } from "../../types";
@@ -78,6 +79,7 @@ import {
   buildInsertNodesBatch,
   buildInsertNodesBatchReturning,
   buildUpdateNode,
+  buildUpdateNodeSet,
 } from "./nodes";
 import {
   buildGetActiveSchema,
@@ -138,6 +140,7 @@ export type CommonOperationStrategy = Readonly<{
   buildGetNode: (graphId: string, kind: string, id: string) => SQL;
   buildGetNodes: (graphId: string, kind: string, ids: readonly string[]) => SQL;
   buildUpdateNode: (params: UpdateNodeParams, timestamp: string) => SQL;
+  buildUpdateNodeSet: (params: UpdateNodeSetParams, timestamp: string) => SQL;
   buildDeleteNode: (params: DeleteNodeParams, timestamp: string) => SQL;
   buildHardDeleteNode: (params: HardDeleteNodeParams) => SQL;
   buildInsertEdge: (params: InsertEdgeParams, timestamp: string) => SQL;
@@ -428,6 +431,9 @@ function createCommonOperationStrategy(
   return {
     ...tableOperations,
     ...fulltextBuilders,
+    buildUpdateNodeSet(params: UpdateNodeSetParams, timestamp: string): SQL {
+      return buildUpdateNodeSet(tables, dialect, params, timestamp);
+    },
     buildDeleteContributionMaterialization,
     buildInsertUnique(params: InsertUniqueParams): SQL {
       return buildInsertUnique(tables, dialect, params);

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -26,6 +26,7 @@ import type {
   FulltextSearchParams,
   HardDeleteEdgeParams,
   HardDeleteNodeParams,
+  HardDeleteUniquesByNodeIdsParams,
   HybridSearchParams,
   InsertEdgeParams,
   InsertNodeParams,
@@ -93,6 +94,7 @@ import {
   buildCheckUniqueBatch,
   buildDeleteUnique,
   buildHardDeleteUniquesByNode,
+  buildHardDeleteUniquesByNodeIds,
   buildInsertUnique,
   buildInsertUniqueBatch,
 } from "./uniques";
@@ -193,7 +195,14 @@ export type CommonOperationStrategy = Readonly<{
   buildInsertUnique: (params: InsertUniqueParams) => SQL;
   buildInsertUniqueBatch: (entries: readonly InsertUniqueParams[]) => SQL;
   buildDeleteUnique: (params: DeleteUniqueParams, timestamp: string) => SQL;
-  buildHardDeleteUniquesByNode: (graphId: string, nodeId: string) => SQL;
+  buildHardDeleteUniquesByNode: (
+    graphId: string,
+    concreteKind: string,
+    nodeId: string,
+  ) => SQL;
+  buildHardDeleteUniquesByNodeIds: (
+    params: HardDeleteUniquesByNodeIdsParams,
+  ) => SQL;
   buildCheckUnique: (params: CheckUniqueParams) => SQL;
   buildCheckUniqueBatch: (params: CheckUniqueBatchParams) => SQL;
   buildGetActiveSchema: (graphId: string) => SQL;
@@ -283,6 +292,7 @@ const COMMON_TABLE_OPERATION_BUILDERS = {
   buildCountEdgesByKind,
   buildDeleteUnique,
   buildHardDeleteUniquesByNode,
+  buildHardDeleteUniquesByNodeIds,
   buildCheckUnique,
   buildCheckUniqueBatch,
   buildGetSchemaVersion,

--- a/packages/typegraph/src/backend/drizzle/operations/uniques.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/uniques.ts
@@ -4,6 +4,7 @@ import type {
   CheckUniqueBatchParams,
   CheckUniqueParams,
   DeleteUniqueParams,
+  HardDeleteUniquesByNodeIdsParams,
   InsertUniqueParams,
   SqlDialect,
 } from "../../types";
@@ -247,14 +248,33 @@ export function buildDeleteUnique(
 export function buildHardDeleteUniquesByNode(
   tables: Tables,
   graphId: string,
+  concreteKind: string,
   nodeId: string,
+): SQL {
+  return buildHardDeleteUniquesByNodeIds(tables, {
+    graphId,
+    concreteKind,
+    nodeIds: [nodeId],
+  });
+}
+
+/**
+ * Builds a hard DELETE for every uniqueness entry owned by concrete nodes.
+ */
+export function buildHardDeleteUniquesByNodeIds(
+  tables: Tables,
+  params: HardDeleteUniquesByNodeIdsParams,
 ): SQL {
   const { uniques } = tables;
 
   return sql`
     DELETE FROM ${uniques}
-    WHERE ${uniques.graphId} = ${graphId}
-      AND ${uniques.nodeId} = ${nodeId}
+    WHERE ${uniques.graphId} = ${params.graphId}
+      AND ${uniques.concreteKind} = ${params.concreteKind}
+      AND ${uniques.nodeId} IN (${sql.join(
+        params.nodeIds.map((nodeId) => sql`${nodeId}`),
+        sql`, `,
+      )})
   `;
 }
 

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -284,6 +284,7 @@ const GET_EDGES_FIXED_PARAM_COUNT = 1;
 const FULLTEXT_UPSERT_PARAM_COUNT = 6;
 const FULLTEXT_DELETE_FIXED_PARAM_COUNT = 2;
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
+const UNIQUE_DELETE_FIXED_PARAM_COUNT = 2;
 const UNIQUE_INSERT_PARAM_COUNT = 6;
 
 type PostgresBatchChunkSizes = Readonly<{
@@ -296,6 +297,7 @@ type PostgresBatchChunkSizes = Readonly<{
   getEdgesChunkSize: number;
   getNodesChunkSize: number;
   nodeInsertBatchSize: number;
+  uniqueDeleteChunkSize: number;
   uniqueInsertBatchSize: number;
 }>;
 
@@ -338,6 +340,10 @@ function computePostgresBatchChunkSizes(
     nodeInsertBatchSize: Math.max(
       1,
       Math.floor(maxBindParameters / NODE_INSERT_PARAM_COUNT),
+    ),
+    uniqueDeleteChunkSize: Math.max(
+      1,
+      maxBindParameters - UNIQUE_DELETE_FIXED_PARAM_COUNT,
     ),
     uniqueInsertBatchSize: Math.max(
       1,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -225,6 +225,7 @@ const GET_EDGES_FIXED_PARAM_COUNT = 1;
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
 const FULLTEXT_UPSERT_PARAM_COUNT = 6;
 const FULLTEXT_DELETE_FIXED_PARAM_COUNT = 2;
+const UNIQUE_DELETE_FIXED_PARAM_COUNT = 2;
 const UNIQUE_INSERT_PARAM_COUNT = 6;
 
 /**
@@ -260,6 +261,8 @@ export type SqliteBatchChunkSizes = Readonly<{
   getEdgesChunkSize: number;
   getNodesChunkSize: number;
   nodeInsertBatchSize: number;
+  /** Node ids per uniqueness-sidecar hard delete. */
+  uniqueDeleteChunkSize: number;
   uniqueInsertBatchSize: number;
 }>;
 
@@ -308,6 +311,10 @@ export function computeSqliteBatchChunkSizes(
     nodeInsertBatchSize: Math.max(
       1,
       Math.floor(maxBindParameters / NODE_INSERT_PARAM_COUNT),
+    ),
+    uniqueDeleteChunkSize: Math.max(
+      1,
+      maxBindParameters - UNIQUE_DELETE_FIXED_PARAM_COUNT,
     ),
     uniqueInsertBatchSize: Math.max(
       1,

--- a/packages/typegraph/src/backend/graph-backend-projection.ts
+++ b/packages/typegraph/src/backend/graph-backend-projection.ts
@@ -47,6 +47,7 @@ const GRAPH_BACKEND_PROJECTION_KEYS = [
   "insertUnique",
   "insertUniqueBatch",
   "deleteUnique",
+  "hardDeleteUniquesByNodeIds",
   "checkUnique",
   "checkUniqueBatch",
   "getActiveSchema",

--- a/packages/typegraph/src/backend/graph-backend-projection.ts
+++ b/packages/typegraph/src/backend/graph-backend-projection.ts
@@ -19,6 +19,7 @@ const GRAPH_BACKEND_PROJECTION_KEYS = [
   "insertNodesBatch",
   "insertNodesBatchReturning",
   "updateNode",
+  "updateNodeSet",
   "deleteNode",
   "hardDeleteNode",
   "getNode",

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -145,6 +145,7 @@ export type {
   GraphReadBackend,
   HardDeleteEdgeParams,
   HardDeleteNodeParams,
+  HardDeleteUniquesByNodeIdsParams,
   HybridSearchParams,
   HybridSearchRow,
   IndexMaterializationBackend,

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -186,6 +186,8 @@ export type {
   UniqueRow,
   UpdateEdgeParams,
   UpdateNodeParams,
+  UpdateNodeSetParams,
+  UpdateNodeSetResult,
   UpsertEmbeddingBatchParams,
   UpsertEmbeddingBatchRow,
   UpsertEmbeddingParams,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -414,7 +414,9 @@ export type UpdateNodeParams = Readonly<{
  *
  * This is a storage primitive: callers that expose it as a graph mutation are
  * responsible for schema validation and for synchronizing uniqueness,
- * fulltext, and vector sidecars around the returned rows.
+ * fulltext, and vector sidecars. The result contains after-images only; callers
+ * that need previous property values must freeze the candidate set and retain
+ * its before-images in the same transaction before invoking this method.
  */
 export type UpdateNodeSetParams = Readonly<{
   graphId: string;
@@ -425,7 +427,7 @@ export type UpdateNodeSetParams = Readonly<{
   candidateIdColumn: string;
 }>;
 
-/** The rows changed by {@link GraphBackend.updateNodeSet}. */
+/** The after-images changed by {@link GraphBackend.updateNodeSet}. */
 export type UpdateNodeSetResult = Readonly<{
   affectedCount: number;
   rows: readonly NodeRow[];
@@ -1414,6 +1416,15 @@ export type GraphBackend = Readonly<{
     entries: readonly InsertUniqueParams[],
   ) => Promise<void>;
   deleteUnique: (this: void, params: DeleteUniqueParams) => Promise<void>;
+  /**
+   * Permanently removes every uniqueness sidecar owned by the specified
+   * concrete nodes. Optional capability used by set-based updates before they
+   * rebuild reservations from the returned node after-images.
+   */
+  hardDeleteUniquesByNodeIds?: (
+    this: void,
+    params: HardDeleteUniquesByNodeIdsParams,
+  ) => Promise<void>;
   checkUnique: (
     this: void,
     params: CheckUniqueParams,
@@ -2186,6 +2197,7 @@ export type UniqueConstraintBackend = Pick<
   | "insertUnique"
   | "insertUniqueBatch"
   | "deleteUnique"
+  | "hardDeleteUniquesByNodeIds"
   | "checkUnique"
   | "checkUniqueBatch"
 >;
@@ -2609,6 +2621,13 @@ export type DeleteUniqueParams = Readonly<{
   nodeKind: string;
   constraintName: string;
   key: string;
+}>;
+
+/** Parameters for permanently clearing uniqueness sidecars by node identity. */
+export type HardDeleteUniquesByNodeIdsParams = Readonly<{
+  graphId: string;
+  concreteKind: string;
+  nodeIds: readonly string[];
 }>;
 
 /**

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -6,6 +6,7 @@
  */
 import {
   type IndexEntity,
+  type JsonValue,
   type KindEntity,
   type TemporalMode,
 } from "../core/types";
@@ -18,6 +19,7 @@ import {
 import { type SqlFragment } from "../query/sql-fragment";
 import {
   type CompiledRowsSql,
+  type CompiledSelectSql,
   type CompiledStatementSql,
   type CompiledTemporaryStatementSql,
 } from "../query/sql-intent";
@@ -397,6 +399,36 @@ export type UpdateNodeParams = Readonly<{
   incrementVersion?: boolean;
   /** If true, clears deleted_at (un-deletes the node). Used by upsert. */
   clearDeleted?: boolean;
+}>;
+
+/**
+ * Parameters for updating a set of live nodes selected by a compiled
+ * TypeGraph query.
+ *
+ * The candidate query must expose the named node-id column from the same graph
+ * and kind. The backend independently fences the rows it writes to
+ * `graphId` and `kind`; constructing the matching candidate query remains the
+ * caller's responsibility.
+ * Property values replace top-level keys, including preserving an explicit
+ * JSON `null` value.
+ *
+ * This is a storage primitive: callers that expose it as a graph mutation are
+ * responsible for schema validation and for synchronizing uniqueness,
+ * fulltext, and vector sidecars around the returned rows.
+ */
+export type UpdateNodeSetParams = Readonly<{
+  graphId: string;
+  kind: string;
+  patch: Readonly<Record<string, JsonValue>>;
+  candidateIds: CompiledSelectSql;
+  /** Projected SQL column holding the candidate node id (for example `n_id`). */
+  candidateIdColumn: string;
+}>;
+
+/** The rows changed by {@link GraphBackend.updateNodeSet}. */
+export type UpdateNodeSetResult = Readonly<{
+  affectedCount: number;
+  rows: readonly NodeRow[];
 }>;
 
 /**
@@ -1249,6 +1281,10 @@ export type GraphBackend = Readonly<{
     params: readonly InsertNodeParams[],
   ) => Promise<readonly NodeRow[]>;
   updateNode: (this: void, params: UpdateNodeParams) => Promise<NodeRow>;
+  updateNodeSet?: (
+    this: void,
+    params: UpdateNodeSetParams,
+  ) => Promise<UpdateNodeSetResult>;
   deleteNode: (this: void, params: DeleteNodeParams) => Promise<void>;
   hardDeleteNode: (this: void, params: HardDeleteNodeParams) => Promise<void>;
   getNode: (
@@ -2108,6 +2144,7 @@ export type NodeEntityWriteBackend = Pick<
   | "insertNodesBatch"
   | "insertNodesBatchReturning"
   | "updateNode"
+  | "updateNodeSet"
   | "deleteNode"
   | "hardDeleteNode"
 >;

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -145,6 +145,7 @@ export type {
   GraphEntityReadBackend,
   GraphEntityWriteBackend,
   GraphLifecycleBackend,
+  HardDeleteUniquesByNodeIdsParams,
   IndexMaterializationBackend,
   LockSchemaVersionForWriteParams,
   NodeEntityReadBackend,

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -166,6 +166,8 @@ export type {
   TrustedImportOptions,
   TrustedImportSession,
   UniqueConstraintBackend,
+  UpdateNodeSetParams,
+  UpdateNodeSetResult,
   UpsertFulltextBatchParams,
   VectorCapabilities,
   VectorOperationBackend,

--- a/packages/typegraph/src/query/dialect/postgres.ts
+++ b/packages/typegraph/src/query/dialect/postgres.ts
@@ -240,6 +240,10 @@ export const postgresDialect: DialectAdapter = {
     return sql`COALESCE(jsonb_typeof(${column} #> ${path}) <> 'null', FALSE)`;
   },
 
+  jsonSetProperties(column, patch) {
+    return sql`${column} || ${JSON.stringify(patch)}::jsonb`;
+  },
+
   // ============================================================
   // Comparison Operations
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -4,7 +4,11 @@
  * Implements dialect-specific SQL generation for SQLite databases.
  * Uses SQLite's JSON1 extension for JSON operations.
  */
-import { type JsonPointer, parseJsonPointer } from "../json-pointer";
+import {
+  type JsonPointer,
+  jsonPointer,
+  parseJsonPointer,
+} from "../json-pointer";
 import { sql } from "../sql-fragment";
 import { fts5Strategy } from "./fulltext-strategy";
 import { likeEscapeClause } from "./like-escape";
@@ -200,6 +204,14 @@ export const sqliteDialect: DialectAdapter = {
     const path = toSqlitePath(pointer);
     const pathSql = sql.raw(escapeSqliteLiteral(path));
     return sql`COALESCE(json_type(${column}, ${pathSql}) <> 'null', 0)`;
+  },
+
+  jsonSetProperties(column, patch) {
+    const replacements = Object.entries(patch).flatMap(([property, value]) => [
+      sql.raw(escapeSqliteLiteral(toSqlitePath(jsonPointer([property])))),
+      sql`json(${JSON.stringify(value)})`,
+    ]);
+    return sql`json_set(${column}, ${sql.join(replacements, sql`, `)})`;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/sqlite.ts
+++ b/packages/typegraph/src/query/dialect/sqlite.ts
@@ -4,11 +4,7 @@
  * Implements dialect-specific SQL generation for SQLite databases.
  * Uses SQLite's JSON1 extension for JSON operations.
  */
-import {
-  type JsonPointer,
-  jsonPointer,
-  parseJsonPointer,
-} from "../json-pointer";
+import { type JsonPointer, parseJsonPointer } from "../json-pointer";
 import { sql } from "../sql-fragment";
 import { fts5Strategy } from "./fulltext-strategy";
 import { likeEscapeClause } from "./like-escape";
@@ -50,6 +46,22 @@ function toSqlitePath(pointer: JsonPointer): string {
 
   return parts.join("");
 }
+
+/**
+ * Returns a JSON path for an object property, even when the property name is a
+ * numeric string. `toSqlitePath()` interprets numeric pointer segments as
+ * array indexes, which is correct for query pointers but not for the
+ * top-level object keys accepted by set-based patches.
+ */
+function toSqliteObjectPropertyPath(property: string): string {
+  return `$.${JSON.stringify(property)}`;
+}
+
+// SQLite builds before 3.48 default to 127 function arguments. Each json_set
+// replacement consumes a path/value pair in addition to the input document, so
+// compose bounded calls instead of making schema breadth an engine-version
+// dependency.
+const JSON_SET_REPLACEMENTS_PER_CALL = 50;
 
 /**
  * Checks if a JSON pointer segment is an array index.
@@ -207,11 +219,22 @@ export const sqliteDialect: DialectAdapter = {
   },
 
   jsonSetProperties(column, patch) {
-    const replacements = Object.entries(patch).flatMap(([property, value]) => [
-      sql.raw(escapeSqliteLiteral(toSqlitePath(jsonPointer([property])))),
-      sql`json(${JSON.stringify(value)})`,
-    ]);
-    return sql`json_set(${column}, ${sql.join(replacements, sql`, `)})`;
+    const entries = Object.entries(patch);
+    let patchedColumn = column;
+    for (
+      let offset = 0;
+      offset < entries.length;
+      offset += JSON_SET_REPLACEMENTS_PER_CALL
+    ) {
+      const replacements = entries
+        .slice(offset, offset + JSON_SET_REPLACEMENTS_PER_CALL)
+        .flatMap(([property, value]) => [
+          sql.raw(escapeSqliteLiteral(toSqliteObjectPropertyPath(property))),
+          sql`json(${JSON.stringify(value)})`,
+        ]);
+      patchedColumn = sql`json_set(${patchedColumn}, ${sql.join(replacements, sql`, `)})`;
+    }
+    return patchedColumn;
   },
 
   // ============================================================

--- a/packages/typegraph/src/query/dialect/types.ts
+++ b/packages/typegraph/src/query/dialect/types.ts
@@ -6,6 +6,7 @@
  * implementing this interface.
  */
 import { type VectorMetric } from "../../backend/types";
+import { type JsonValue } from "../../core/types";
 import { type ValueType } from "../ast";
 import { type JsonPointer } from "../json-pointer";
 import { type SqlFragment } from "../sql-fragment";
@@ -358,6 +359,18 @@ export interface DialectAdapter {
     this: void,
     column: SqlFragment,
     pointer: JsonPointer,
+  ) => SqlFragment;
+
+  /**
+   * Replaces top-level JSON object properties while preserving explicit JSON
+   * null values. This is the token-level dialect seam used by set-based node
+   * mutation; callers validate the patch against the node schema before SQL
+   * compilation.
+   */
+  readonly jsonSetProperties: (
+    this: void,
+    column: SqlFragment,
+    patch: Readonly<Record<string, JsonValue>>,
   ) => SqlFragment;
 
   // ============================================================

--- a/packages/typegraph/src/store/history-store-backend.ts
+++ b/packages/typegraph/src/store/history-store-backend.ts
@@ -92,6 +92,7 @@ const HISTORY_STORE_BACKEND_KEYS = [
   "tableNames",
   "updateEdge",
   "updateNode",
+  "updateNodeSet",
   "upsertEmbedding",
   "upsertEmbeddingBatch",
   "upsertFulltext",

--- a/packages/typegraph/src/store/history-store-backend.ts
+++ b/packages/typegraph/src/store/history-store-backend.ts
@@ -71,6 +71,7 @@ const HISTORY_STORE_BACKEND_KEYS = [
   "hardDeleteEdge",
   "hardDeleteEdgesBatch",
   "hardDeleteNode",
+  "hardDeleteUniquesByNodeIds",
   "hybridSearch",
   "insertEdge",
   "insertEdgeNoReturn",

--- a/packages/typegraph/src/store/recorded-capture.ts
+++ b/packages/typegraph/src/store/recorded-capture.ts
@@ -395,6 +395,20 @@ function createRecordedTransactionBackend(
       return row;
     },
 
+    ...(target.updateNodeSet === undefined ?
+      {}
+    : {
+        async updateNodeSet(params) {
+          session.assertOpen();
+          await lockGraph(params.graphId);
+          const result = await requireDefined(target.updateNodeSet)(params);
+          for (const row of result.rows) {
+            session.touchNode(row.graph_id, row.kind, row.id, row);
+          }
+          return result;
+        },
+      }),
+
     async deleteNode(params) {
       session.assertOpen();
       await lockGraph(params.graphId);
@@ -632,6 +646,23 @@ export function createRecordedBackend(
     async updateNode(params) {
       return capture((target) => target.updateNode(params));
     },
+
+    ...(backend.updateNodeSet === undefined ?
+      {}
+    : {
+        async updateNodeSet(params) {
+          return capture((target) => {
+            const updateNodeSet = target.updateNodeSet;
+            if (updateNodeSet === undefined) {
+              throw new ConfigurationError(
+                "Recorded updateNodeSet capability disappeared inside a transaction",
+                { operation: "updateNodeSet" },
+              );
+            }
+            return updateNodeSet(params);
+          });
+        },
+      }),
 
     async deleteNode(params) {
       await capture((target) => target.deleteNode(params));

--- a/packages/typegraph/src/store/recorded-capture/write-surface.ts
+++ b/packages/typegraph/src/store/recorded-capture/write-surface.ts
@@ -10,6 +10,7 @@ import {
   type TransactionBackend,
   type UpdateEdgeParams,
   type UpdateNodeParams,
+  type UpdateNodeSetParams,
 } from "../../backend/types";
 import { type Assert, type Equal } from "../../utils/type-assert";
 
@@ -43,6 +44,7 @@ export const RECORDED_OPTIONAL_WRITE_METHODS = [
   "insertNodeNoReturn",
   "insertNodesBatch",
   "insertNodesBatchReturning",
+  "updateNodeSet",
   "insertEdgeNoReturn",
   "insertEdgesBatch",
   "insertEdgesBatchReturning",
@@ -74,6 +76,7 @@ type FunctionKeys<T> = {
 type GraphEntityWriteParam =
   | InsertNodeParams
   | UpdateNodeParams
+  | UpdateNodeSetParams
   | DeleteNodeParams
   | HardDeleteNodeParams
   | InsertEdgeParams

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -49,6 +49,7 @@ import {
   registerRecursiveIntegrationTests,
   registerRemovalMaterializationIntegrationTests,
   registerSelectiveRetryIntegrationTests,
+  registerSetNodeMutationIntegrationTests,
   registerSetOperationIntegrationTests,
   registerStoreViewIntegrationTests,
   registerSubgraphIntegrationTests,
@@ -179,6 +180,7 @@ export function createIntegrationTestSuite<TNativeTransaction>(
     registerRemovalMaterializationIntegrationTests(context);
     registerRecordedReadBindingIntegrationTests(context);
     registerSetOperationIntegrationTests(context);
+    registerSetNodeMutationIntegrationTests(context);
     registerSelectiveRetryIntegrationTests(context);
     registerEdgeOperationIntegrationTests(context);
     registerRecursiveIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -27,6 +27,7 @@ export { registerRecordedTimeIntegrationTests } from "./recorded-time";
 export { registerRecursiveIntegrationTests } from "./recursive";
 export { registerRemovalMaterializationIntegrationTests } from "./removal-materialization";
 export { registerSelectiveRetryIntegrationTests } from "./selective-retry";
+export { registerSetNodeMutationIntegrationTests } from "./set-node-mutation";
 export { registerSetOperationIntegrationTests } from "./set-operations";
 export { registerStoreViewIntegrationTests } from "./store-view";
 export { registerSubgraphIntegrationTests } from "./subgraph";

--- a/packages/typegraph/tests/backends/integration/set-node-mutation.ts
+++ b/packages/typegraph/tests/backends/integration/set-node-mutation.ts
@@ -118,6 +118,158 @@ export function registerSetNodeMutationIntegrationTests(
       ).not.toHaveProperty("isActive");
     });
 
+    it("fences colliding candidate ids to the requested graph and kind", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const sharedId = "shared-set-update-id";
+      await store.nodes.Person.create({ name: "Target" }, { id: sharedId });
+      await store.nodes.Company.create(
+        { name: "Same graph" },
+        { id: sharedId },
+      );
+      await backend.insertNode({
+        graphId: "other_graph",
+        kind: "Person",
+        id: sharedId,
+        props: { name: "Other graph" },
+      });
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Person", "person")
+          .whereNode("person", (person) => person.id.eq(sharedId))
+          .select((ctx) => ctx.person.id)
+          .toAst(),
+      );
+
+      const result = await updateNodeSet(backend, {
+        graphId: store.graphId,
+        kind: "Person",
+        patch: { isActive: true },
+        candidateIds,
+        candidateIdColumn: "person_id",
+      });
+
+      expect(result.affectedCount).toBe(1);
+      expect(
+        rowPropsToObject(
+          requireDefined(
+            await backend.getNode(store.graphId, "Person", sharedId),
+          ).props,
+        ),
+      ).toHaveProperty("isActive", true);
+      expect(
+        rowPropsToObject(
+          requireDefined(
+            await backend.getNode(store.graphId, "Company", sharedId),
+          ).props,
+        ),
+      ).not.toHaveProperty("isActive");
+      expect(
+        rowPropsToObject(
+          requireDefined(
+            await backend.getNode("other_graph", "Person", sharedId),
+          ).props,
+        ),
+      ).not.toHaveProperty("isActive");
+    });
+
+    it("keeps hard-delete uniqueness cleanup scoped to concrete node kind", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const sharedId = "shared-unique-owner-id";
+      const personKey = "person@example.test";
+      const companyKey = "company@example.test";
+      const person = await store.nodes.Person.create(
+        { name: "Person" },
+        { id: sharedId },
+      );
+      await store.nodes.Company.create({ name: "Company" }, { id: sharedId });
+      await backend.insertUnique({
+        graphId: store.graphId,
+        nodeKind: "Person",
+        constraintName: "identity",
+        key: personKey,
+        nodeId: sharedId,
+        concreteKind: "Person",
+      });
+      await backend.insertUnique({
+        graphId: store.graphId,
+        nodeKind: "Company",
+        constraintName: "identity",
+        key: companyKey,
+        nodeId: sharedId,
+        concreteKind: "Company",
+      });
+
+      await store.nodes.Person.hardDelete(person.id);
+
+      await expect(
+        backend.checkUnique({
+          graphId: store.graphId,
+          nodeKind: "Person",
+          constraintName: "identity",
+          key: personKey,
+          includeDeleted: true,
+        }),
+      ).resolves.toBeUndefined();
+      await expect(
+        backend.checkUnique({
+          graphId: store.graphId,
+          nodeKind: "Company",
+          constraintName: "identity",
+          key: companyKey,
+          includeDeleted: true,
+        }),
+      ).resolves.toMatchObject({
+        concrete_kind: "Company",
+        node_id: sharedId,
+      });
+    });
+
+    it("hard-deletes uniqueness sidecars for a set of concrete nodes", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const nodeIds = ["unique-owner-a", "unique-owner-b"];
+      for (const nodeId of nodeIds) {
+        await backend.insertUnique({
+          graphId: store.graphId,
+          nodeKind: "Person",
+          constraintName: "identity",
+          key: `${nodeId}@example.test`,
+          nodeId,
+          concreteKind: "Person",
+        });
+      }
+
+      await requireDefined(backend.hardDeleteUniquesByNodeIds)({
+        graphId: store.graphId,
+        concreteKind: "Person",
+        nodeIds: [...nodeIds, "unique-owner-a"],
+      });
+
+      for (const nodeId of nodeIds) {
+        await expect(
+          backend.checkUnique({
+            graphId: store.graphId,
+            nodeKind: "Person",
+            constraintName: "identity",
+            key: `${nodeId}@example.test`,
+            includeDeleted: true,
+          }),
+        ).resolves.toBeUndefined();
+      }
+      await expect(
+        requireDefined(backend.hardDeleteUniquesByNodeIds)({
+          graphId: store.graphId,
+          concreteKind: "Person",
+          nodeIds: [],
+        }),
+      ).resolves.toBeUndefined();
+    });
+
     it("replaces top-level values without deleting explicit JSON null", async () => {
       const store = context.getStore();
       const backend = context.getBackend();
@@ -160,6 +312,68 @@ export function registerSetNodeMutationIntegrationTests(
           reviewer: null,
           flags: { archived: true },
         },
+      });
+    });
+
+    it("treats numeric property names as object keys on every backend", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const document = await store.nodes.Document.create({ title: "Draft" });
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Document", "document")
+          .whereNode("document", (item) => item.id.eq(document.id))
+          .select((ctx) => ctx.document.id)
+          .toAst(),
+      );
+
+      const result = await updateNodeSet(backend, {
+        graphId: store.graphId,
+        kind: "Document",
+        patch: { "0": "zero", "01": "zero-one" },
+        candidateIds,
+        candidateIdColumn: "document_id",
+      });
+
+      expect(rowPropsToObject(requireDefined(result.rows[0]).props)).toEqual({
+        title: "Draft",
+        "0": "zero",
+        "01": "zero-one",
+      });
+    });
+
+    it("applies patches wider than SQLite's legacy function-argument limit", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const document = await store.nodes.Document.create({ title: "Draft" });
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Document", "document")
+          .whereNode("document", (item) => item.id.eq(document.id))
+          .select((ctx) => ctx.document.id)
+          .toAst(),
+      );
+      const patch = Object.fromEntries(
+        Array.from({ length: 70 }, (_, index) => [`field${index}`, index]),
+      );
+
+      const result = await updateNodeSet(backend, {
+        graphId: store.graphId,
+        kind: "Document",
+        patch,
+        candidateIds,
+        candidateIdColumn: "document_id",
+      });
+
+      expect(rowPropsToObject(requireDefined(result.rows[0]).props)).toEqual({
+        title: "Draft",
+        ...patch,
       });
     });
 

--- a/packages/typegraph/tests/backends/integration/set-node-mutation.ts
+++ b/packages/typegraph/tests/backends/integration/set-node-mutation.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import { ConfigurationError } from "../../../src";
+import type {
+  GraphBackend,
+  UpdateNodeSetParams,
+} from "../../../src/backend/types";
+import { rowPropsToObject } from "../../../src/backend/types";
+import type { QueryAst } from "../../../src/query/ast";
+import { compileQuery } from "../../../src/query/compiler";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { requireDefined } from "../../../src/utils/presence";
+import { integrationTestGraph } from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+function compileCandidateIds(
+  graphId: string,
+  backend: Pick<
+    GraphBackend,
+    | "capabilities"
+    | "dialect"
+    | "fulltextStrategy"
+    | "tableNames"
+    | "vectorStrategy"
+  >,
+  ast: QueryAst,
+) {
+  return compileQuery(ast, graphId, {
+    dialect: backend.dialect,
+    schema: createSqlSchema(backend.tableNames),
+    fulltextStrategy: backend.fulltextStrategy,
+    vectorStrategy: backend.vectorStrategy,
+    windowFunctions: backend.capabilities.windowFunctions,
+  });
+}
+
+async function updateNodeSet(
+  backend: Pick<GraphBackend, "updateNodeSet">,
+  params: UpdateNodeSetParams,
+) {
+  return requireDefined(backend.updateNodeSet)(params);
+}
+
+/**
+ * Shared SQLite/PostgreSQL coverage for the storage primitive that the public
+ * set-based Store mutation composes with validation and sidecar maintenance.
+ */
+export function registerSetNodeMutationIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("set-based node mutation substrate", () => {
+    it("updates nodes selected by property and relationship predicates", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const acme = await store.nodes.Company.create({
+        name: "Acme",
+        industry: "technology",
+      });
+      const bank = await store.nodes.Company.create({
+        name: "Bank",
+        industry: "finance",
+      });
+      const alice = await store.nodes.Person.create({ name: "Alice", age: 35 });
+      const bob = await store.nodes.Person.create({ name: "Bob", age: 35 });
+      const cara = await store.nodes.Person.create({ name: "Cara", age: 25 });
+      await store.edges.worksAt.create(alice, acme, { role: "engineer" });
+      await store.edges.worksAt.create(bob, bank, { role: "analyst" });
+      await store.edges.worksAt.create(cara, acme, { role: "designer" });
+
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Person", "person")
+          .whereNode("person", (person) => person.age.gte(30))
+          .traverse("worksAt", "employment")
+          .to("Company", "company")
+          .whereNode("company", (company) => company.industry.eq("technology"))
+          .select((ctx) => ctx.person.id)
+          .toAst(),
+      );
+
+      const result = await updateNodeSet(backend, {
+        graphId: store.graphId,
+        kind: "Person",
+        patch: { isActive: true },
+        candidateIds,
+        candidateIdColumn: "person_id",
+      });
+
+      expect(result.affectedCount).toBe(1);
+      expect(result.rows.map((row) => row.id)).toEqual([alice.id]);
+      expect(result.rows[0]?.version).toBe(2);
+      expect(
+        rowPropsToObject(
+          requireDefined(
+            await backend.getNode(store.graphId, "Person", alice.id),
+          ).props,
+        ),
+      ).toMatchObject({
+        name: "Alice",
+        age: 35,
+        isActive: true,
+      });
+      expect(
+        rowPropsToObject(
+          requireDefined(await backend.getNode(store.graphId, "Person", bob.id))
+            .props,
+        ),
+      ).not.toHaveProperty("isActive");
+      expect(
+        rowPropsToObject(
+          requireDefined(
+            await backend.getNode(store.graphId, "Person", cara.id),
+          ).props,
+        ),
+      ).not.toHaveProperty("isActive");
+    });
+
+    it("replaces top-level values without deleting explicit JSON null", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const document = await store.nodes.Document.create({
+        title: "Draft",
+        metadata: { author: "Ada", reviewer: "Grace" },
+      });
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Document", "document")
+          .whereNode("document", (item) => item.id.eq(document.id))
+          .select((ctx) => ctx.document.id)
+          .toAst(),
+      );
+
+      const result = await updateNodeSet(backend, {
+        graphId: store.graphId,
+        kind: "Document",
+        patch: {
+          metadata: {
+            author: "Ada",
+            // eslint-disable-next-line unicorn/no-null -- explicit JSON null is the behavior under test
+            reviewer: null,
+            flags: { archived: true },
+          },
+        },
+        candidateIds,
+        candidateIdColumn: "document_id",
+      });
+
+      expect(result.affectedCount).toBe(1);
+      expect(rowPropsToObject(requireDefined(result.rows[0]).props)).toEqual({
+        title: "Draft",
+        metadata: {
+          author: "Ada",
+          // eslint-disable-next-line unicorn/no-null -- explicit JSON null is the behavior under test
+          reviewer: null,
+          flags: { archived: true },
+        },
+      });
+    });
+
+    it("never resurrects tombstoned candidates", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const deleted = await store.nodes.Person.create({ name: "Deleted" });
+      await store.nodes.Person.delete(deleted.id);
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Person", "person")
+          .temporal("includeTombstones")
+          .whereNode("person", (person) => person.id.eq(deleted.id))
+          .select((ctx) => ctx.person.id)
+          .toAst(),
+      );
+
+      const result = await updateNodeSet(backend, {
+        graphId: store.graphId,
+        kind: "Person",
+        patch: { isActive: true },
+        candidateIds,
+        candidateIdColumn: "person_id",
+      });
+
+      expect(result).toEqual({ affectedCount: 0, rows: [] });
+      const row = requireDefined(
+        await backend.getNode(store.graphId, "Person", deleted.id),
+      );
+      expect(row.deleted_at).toBeDefined();
+      expect(row.version).toBe(1);
+    });
+
+    it("captures every affected row in recorded-time history", async () => {
+      const store = await context.createHistoryStore(integrationTestGraph);
+      const backend = store.backend;
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const beforeUpdate = requireDefined(await store.recordedNow());
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Person", "person")
+          .select((ctx) => ctx.person.id)
+          .toAst(),
+      );
+
+      const result = await updateNodeSet(backend, {
+        graphId: store.graphId,
+        kind: "Person",
+        patch: { isActive: true },
+        candidateIds,
+        candidateIdColumn: "person_id",
+      });
+      const afterUpdate = requireDefined(await store.recordedNow());
+
+      expect(result.affectedCount).toBe(2);
+      await expect(
+        store.asOfRecorded(beforeUpdate).nodes.Person.getById(alice.id),
+      ).resolves.not.toHaveProperty("isActive");
+      await expect(
+        store.asOfRecorded(afterUpdate).nodes.Person.getById(alice.id),
+      ).resolves.toHaveProperty("isActive", true);
+      await expect(
+        store.asOfRecorded(afterUpdate).nodes.Person.getById(bob.id),
+      ).resolves.toHaveProperty("isActive", true);
+    });
+
+    it("rejects an empty patch before executing SQL", async () => {
+      const store = context.getStore();
+      const backend = context.getBackend();
+      const candidateIds = compileCandidateIds(
+        store.graphId,
+        backend,
+        store
+          .query()
+          .from("Person", "person")
+          .select((ctx) => ctx.person.id)
+          .toAst(),
+      );
+
+      await expect(
+        updateNodeSet(backend, {
+          graphId: store.graphId,
+          kind: "Person",
+          patch: {},
+          candidateIds,
+          candidateIdColumn: "person_id",
+        }),
+      ).rejects.toBeInstanceOf(ConfigurationError);
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
@@ -128,6 +128,7 @@ describe("computeSqliteBatchChunkSizes", () => {
       getEdgesChunkSize: 998,
       getNodesChunkSize: 997,
       nodeInsertBatchSize: 111,
+      uniqueDeleteChunkSize: 997,
       uniqueInsertBatchSize: 166,
     });
   });
@@ -143,6 +144,7 @@ describe("computeSqliteBatchChunkSizes", () => {
       getEdgesChunkSize: 32_765,
       getNodesChunkSize: 32_764,
       nodeInsertBatchSize: 3640,
+      uniqueDeleteChunkSize: 32_764,
       uniqueInsertBatchSize: 5461,
     });
   });
@@ -165,6 +167,7 @@ describe("computeSqliteBatchChunkSizes", () => {
       getEdgesChunkSize: 1,
       getNodesChunkSize: 1,
       nodeInsertBatchSize: 1,
+      uniqueDeleteChunkSize: 1,
       uniqueInsertBatchSize: 1,
     });
   });

--- a/packages/typegraph/tests/sqlite-json-set-properties.test.ts
+++ b/packages/typegraph/tests/sqlite-json-set-properties.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { sqliteDialect } from "../src/query/dialect/sqlite";
+import { renderSql, sql } from "../src/query/sql-fragment";
+
+describe("SQLite JSON property replacement", () => {
+  it("quotes numeric names as object properties", () => {
+    const compiled = renderSql(
+      sqliteDialect.jsonSetProperties(sql.identifier("props"), {
+        "0": "zero",
+        "01": "zero-one",
+      }),
+      "sqlite",
+    );
+
+    expect(compiled.sql).toContain(`'$."0"'`);
+    expect(compiled.sql).toContain(`'$."01"'`);
+    expect(compiled.sql).not.toContain("$[0]");
+  });
+
+  it("bounds each json_set call below SQLite's legacy argument limit", () => {
+    const patch = Object.fromEntries(
+      Array.from({ length: 70 }, (_, index) => [`field${index}`, index]),
+    );
+    const compiled = renderSql(
+      sqliteDialect.jsonSetProperties(sql.identifier("props"), patch),
+      "sqlite",
+    );
+
+    expect(compiled.sql.match(/json_set\(/g)).toHaveLength(2);
+    expect(compiled.params).toHaveLength(70);
+  });
+});


### PR DESCRIPTION
- add a backend capability for set-based live-node updates from a compiled candidate query
- apply typed JSON patches with set/unset semantics, version increments, returned after-images, and recorded-history capture
- add bind-budgeted uniqueness cleanup for invariant-safe Store-layer batch repair
- fix cross-kind uniqueness cleanup during hard deletion
- harden SQLite numeric object keys and wide patches for legacy function-argument limits

## Stack

- depends on #352 and #353
- closes #354

