### PR TITLE
fix: type PostgreSQL TEMP capability failures

### DIFF
--- a/.changeset/soft-beans-fail.md
+++ b/.changeset/soft-beans-fail.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Translate PostgreSQL read-only and missing-`TEMP` failures at graph-analytics
+working-table creation into `UnsupportedBackendCapabilityError`, preserving the
+driver error as the cause.

--- a/.changeset/soft-beans-fail.md
+++ b/.changeset/soft-beans-fail.md
@@ -2,6 +2,8 @@
 "@nicia-ai/typegraph": patch
 ---
 
-Translate PostgreSQL read-only and missing-`TEMP` failures at graph-analytics
-working-table creation into `UnsupportedBackendCapabilityError`, preserving the
-driver error as the cause.
+Translate PostgreSQL read-only and missing-`TEMP` failures during graph
+analytics into `UnsupportedBackendCapabilityError`, preserving the driver error
+as the cause. Both refusal points are covered: a standby that rejects the
+read-write working-table transaction, and a role that cannot create the
+temporary table inside it.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -880,9 +880,16 @@ can inspect the same object as `backend.capabilities`. The shape is:
 | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `transactions`                                                             | Atomic transactions available (see note below)                                                      |
 | `windowFunctions`                                                          | SQL window functions such as `ROW_NUMBER()` are available                                           |
-| `graphAnalytics?.{supported,mathFunctions}`                                | Whole-graph temporary-table iteration, plus availability of deferred transcendental-math algorithms |
+| `graphAnalytics?.{supported,mathFunctions}`                                | Static support for whole-graph temporary-table iteration, plus availability of deferred transcendental-math algorithms |
 | `vector?.metrics` / `vector?.indexTypes` / `vector?.maxDimensions`         | Vector strategy capabilities (present once a vector strategy is configured)                         |
 | `fulltext?.{supported,languages,phraseQueries,prefixQueries,highlighting}` | Fulltext strategy capabilities                                                                      |
+
+`graphAnalytics.supported` describes the backend shape, not mutable PostgreSQL
+session state. A hot standby or a role without the database `TEMP` privilege can
+still reject working-table creation. WCC, label propagation, PageRank, and
+Personalized PageRank translate those execution-time failures to
+`UnsupportedBackendCapabilityError` while retaining the PostgreSQL error as its
+`cause`.
 
 ### SQLite ↔ PostgreSQL parity
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -886,10 +886,11 @@ can inspect the same object as `backend.capabilities`. The shape is:
 
 `graphAnalytics.supported` describes the backend shape, not mutable PostgreSQL
 session state. A hot standby or a role without the database `TEMP` privilege can
-still reject working-table creation. WCC, label propagation, PageRank, and
-Personalized PageRank translate those execution-time failures to
-`UnsupportedBackendCapabilityError` while retaining the PostgreSQL error as its
-`cause`.
+still reject the working-table transaction that the iterative graph algorithms
+open: a standby refuses the read-write transaction itself, and a role without
+`TEMP` refuses the `CREATE TEMP TABLE` inside it. Both refusals reach the caller
+as `UnsupportedBackendCapabilityError`, with the PostgreSQL error retained as
+its `cause`.
 
 ### SQLite ↔ PostgreSQL parity
 

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -425,8 +425,13 @@ requires `backend.capabilities.graphAnalytics?.supported === true`; built-in
 SQLite and PostgreSQL connections that permit temporary tables advertise
 support. Cloudflare D1, Durable Objects SQLite, `neon-http`, and other
 restricted backends throw `UnsupportedBackendCapabilityError` before temporary
-state is created. If propagation has not converged after `maxIterations`, TypeGraph throws
-`GraphAlgorithmConvergenceError` rather than returning a partial partition.
+state is created. PostgreSQL checks the execution environment again when it
+creates the working table because a read replica or a role without `TEMP` can
+reject it even when the backend's static capability is true. Those failures are
+also reported as `UnsupportedBackendCapabilityError`; its `cause` preserves the
+original database error. If propagation has not converged after
+`maxIterations`, TypeGraph throws `GraphAlgorithmConvergenceError` rather than
+returning a partial partition.
 
 Each round expands only the indexed frontier of nodes whose label changed in
 the previous round. Candidate labels remain staged until every edge-kind chunk

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -425,11 +425,12 @@ requires `backend.capabilities.graphAnalytics?.supported === true`; built-in
 SQLite and PostgreSQL connections that permit temporary tables advertise
 support. Cloudflare D1, Durable Objects SQLite, `neon-http`, and other
 restricted backends throw `UnsupportedBackendCapabilityError` before temporary
-state is created. PostgreSQL checks the execution environment again when it
-creates the working table because a read replica or a role without `TEMP` can
-reject it even when the backend's static capability is true. Those failures are
-also reported as `UnsupportedBackendCapabilityError`; its `cause` preserves the
-original database error. If propagation has not converged after
+state is created. PostgreSQL is checked again at execution time, because a read
+replica or a role without `TEMP` can reject the working-table transaction even
+when the backend's static capability is true: a replica refuses the read-write
+transaction itself, and a role without `TEMP` refuses the `CREATE TEMP TABLE`
+inside it. Both are reported as `UnsupportedBackendCapabilityError`; its `cause`
+preserves the original database error. If propagation has not converged after
 `maxIterations`, TypeGraph throws `GraphAlgorithmConvergenceError` rather than
 returning a partial partition.
 

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -28,7 +28,12 @@ import {
 import { compareCodePoints, compareStrings } from "../../utils/compare";
 import { generateId } from "../../utils/id";
 import { isPresent } from "../../utils/presence";
-import { postgresTemporaryTableUnavailableSqlState } from "../../utils/sql-errors";
+import {
+  type PostgresReadWriteRefusedSqlState,
+  postgresReadWriteRefusedSqlState,
+  type PostgresTemporaryTableUnavailableSqlState,
+  postgresTemporaryTableUnavailableSqlState,
+} from "../../utils/sql-errors";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
 import { resolveReadSchema, resolveTemporalOptions } from "./context";
 import type { PathNode, TraversalDirection } from "./types";
@@ -276,105 +281,142 @@ export async function runIterativeGraphOperation<
     temporaryWrites: INTERNAL_TEMPORARY_WRITES,
   } satisfies InternalTransactionOptions;
 
-  return ctx.backend.transaction(async (backend) => {
-    const temporaryBackend = requireTemporaryStatements(backend);
-    const runId = generateId();
-    const workingTable = sql.identifier(
-      `typegraph_iterative_${runId.replaceAll("-", "_")}`,
+  // A standby refuses the read-write access mode in the `BEGIN` itself, so on
+  // a replica the working-table seam below never executes. A failure raised
+  // before the callback started is that refusal and nothing else.
+  const rounds = { started: false };
+  try {
+    return await ctx.backend.transaction(async (backend) => {
+      rounds.started = true;
+      return runWorkingTableRounds(ctx, options, plan, backend);
+    }, transactionOptions);
+  } catch (error) {
+    if (rounds.started || ctx.backend.dialect !== "postgres") throw error;
+    const sqlState = postgresReadWriteRefusedSqlState(error);
+    if (sqlState === undefined) throw error;
+    throw temporaryTableCapabilityError(ctx, plan.algorithm, sqlState, error);
+  }
+}
+
+/**
+ * The typed failure for a PostgreSQL execution environment that refuses the
+ * transaction-local temporary tables its static `graphAnalytics` capability
+ * advertises — a replica, or a role without the database `TEMP` privilege.
+ */
+function temporaryTableCapabilityError(
+  ctx: AlgorithmContext,
+  algorithm: string,
+  sqlState:
+    | PostgresReadWriteRefusedSqlState
+    | PostgresTemporaryTableUnavailableSqlState,
+  cause: unknown,
+): UnsupportedBackendCapabilityError {
+  const error = new UnsupportedBackendCapabilityError(
+    algorithm,
+    "graphAnalytics",
+    {
+      dialect: ctx.backend.dialect,
+      supported: false,
+      requirement: "transaction-local temporary tables",
+      sqlState,
+    },
+    "Run graph analytics on a writable PostgreSQL primary with a role that has the TEMP privilege.",
+  );
+  // Match the non-enumerable Error.cause property created by the native
+  // Error constructor without widening the public capability-error API.
+  Object.defineProperty(error, "cause", {
+    configurable: true,
+    value: cause,
+    writable: true,
+  });
+  return error;
+}
+
+/** Runs the plan's rounds against a working table inside an open transaction. */
+async function runWorkingTableRounds<State extends IterativeGraphState, Result>(
+  ctx: AlgorithmContext,
+  options: InternalTraversalOptions,
+  plan: IterativeGraphPlan<State, Result>,
+  backend: TransactionBackend,
+): Promise<Result> {
+  const temporaryBackend = requireTemporaryStatements(backend);
+  const runId = generateId();
+  const workingTable = sql.identifier(
+    `typegraph_iterative_${runId.replaceAll("-", "_")}`,
+  );
+  const context: IterativeGraphRunContext = {
+    operation: createOperation(ctx, options, temporaryBackend),
+    backend: temporaryBackend,
+    workingTable,
+    graphId: ctx.graphId,
+    runId,
+    executeTemporary: async (query) => {
+      await temporaryBackend.executeTemporaryStatement(
+        asCompiledTemporaryStatementSql(query),
+      );
+    },
+  };
+
+  // Opt-in only: without an explicit workingMemory the rounds inherit
+  // the engine's configured setting. When requested, the override is
+  // transaction-scoped — `set_config(..., is_local => true)` reverts
+  // when this transaction ends, so the session/server setting is never
+  // touched. SQLite returns no statement here.
+  if (context.operation.workingMemory !== undefined) {
+    const workingMemoryStatement = ctx.dialect.setTransactionWorkingMemory(
+      context.operation.workingMemory,
     );
-    const context: IterativeGraphRunContext = {
-      operation: createOperation(ctx, options, temporaryBackend),
-      backend: temporaryBackend,
-      workingTable,
-      graphId: ctx.graphId,
-      runId,
-      executeTemporary: async (query) => {
-        await temporaryBackend.executeTemporaryStatement(
-          asCompiledTemporaryStatementSql(query),
+    if (workingMemoryStatement !== undefined) {
+      await context.executeTemporary(workingMemoryStatement);
+    }
+  }
+  try {
+    await context.executeTemporary(plan.createWorkingTable(context));
+  } catch (error) {
+    const sqlState =
+      ctx.backend.dialect === "postgres" ?
+        postgresTemporaryTableUnavailableSqlState(error)
+      : undefined;
+    if (sqlState === undefined) throw error;
+    throw temporaryTableCapabilityError(ctx, plan.algorithm, sqlState, error);
+  }
+  let operationFailure: CapturedFailure | undefined;
+  try {
+    let state = await plan.initialize(context);
+    let analyzedRowCount = await refreshWorkingTableStatistics(
+      context,
+      state.workingTableSize,
+    );
+    for (
+      let iteration = 1;
+      iteration <= plan.maxIterations && !plan.hasConverged(state);
+      iteration++
+    ) {
+      state = await plan.runRound(context, state, iteration);
+      // Statistics only pay off in a subsequent round: skip the refresh
+      // when the operation just converged or the iteration budget is
+      // spent — no further round will read the working table.
+      if (iteration < plan.maxIterations && !plan.hasConverged(state)) {
+        analyzedRowCount = await refreshWorkingTableStatistics(
+          context,
+          state.workingTableSize,
+          analyzedRowCount,
         );
-      },
-    };
-
-    // Opt-in only: without an explicit workingMemory the rounds inherit
-    // the engine's configured setting. When requested, the override is
-    // transaction-scoped — `set_config(..., is_local => true)` reverts
-    // when this transaction ends, so the session/server setting is never
-    // touched. SQLite returns no statement here.
-    if (context.operation.workingMemory !== undefined) {
-      const workingMemoryStatement = ctx.dialect.setTransactionWorkingMemory(
-        context.operation.workingMemory,
-      );
-      if (workingMemoryStatement !== undefined) {
-        await context.executeTemporary(workingMemoryStatement);
       }
     }
-    try {
-      await context.executeTemporary(plan.createWorkingTable(context));
-    } catch (error) {
-      const sqlState =
-        ctx.backend.dialect === "postgres" ?
-          postgresTemporaryTableUnavailableSqlState(error)
-        : undefined;
-      if (sqlState === undefined) throw error;
-
-      const capabilityError = new UnsupportedBackendCapabilityError(
+    if (!plan.hasConverged(state)) {
+      throw new GraphAlgorithmConvergenceError(
         plan.algorithm,
-        "graphAnalytics",
-        {
-          dialect: ctx.backend.dialect,
-          supported: false,
-          requirement: "transaction-local temporary tables",
-          sqlState,
-        },
-        "Run graph analytics on a writable PostgreSQL primary with a role that has the TEMP privilege.",
+        plan.maxIterations,
       );
-      // Match the non-enumerable Error.cause property created by the native
-      // Error constructor without widening the public capability-error API.
-      Object.defineProperty(capabilityError, "cause", {
-        configurable: true,
-        value: error,
-        writable: true,
-      });
-      throw capabilityError;
     }
-    let operationFailure: CapturedFailure | undefined;
-    try {
-      let state = await plan.initialize(context);
-      let analyzedRowCount = await refreshWorkingTableStatistics(
-        context,
-        state.workingTableSize,
-      );
-      for (
-        let iteration = 1;
-        iteration <= plan.maxIterations && !plan.hasConverged(state);
-        iteration++
-      ) {
-        state = await plan.runRound(context, state, iteration);
-        // Statistics only pay off in a subsequent round: skip the refresh
-        // when the operation just converged or the iteration budget is
-        // spent — no further round will read the working table.
-        if (iteration < plan.maxIterations && !plan.hasConverged(state)) {
-          analyzedRowCount = await refreshWorkingTableStatistics(
-            context,
-            state.workingTableSize,
-            analyzedRowCount,
-          );
-        }
-      }
-      if (!plan.hasConverged(state)) {
-        throw new GraphAlgorithmConvergenceError(
-          plan.algorithm,
-          plan.maxIterations,
-        );
-      }
-      return await plan.extractResult(context, state);
-    } catch (error) {
-      operationFailure = { error };
-      throw error;
-    } finally {
-      await cleanupWorkingTables(context, plan.cleanup, operationFailure);
-    }
-  }, transactionOptions);
+    return await plan.extractResult(context, state);
+  } catch (error) {
+    operationFailure = { error };
+    throw error;
+  } finally {
+    await cleanupWorkingTables(context, plan.cleanup, operationFailure);
+  }
 }
 
 export function shouldRefreshWorkingTableStatistics(

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -8,6 +8,7 @@ import {
   CompilerInvariantError,
   ConfigurationError,
   GraphAlgorithmConvergenceError,
+  UnsupportedBackendCapabilityError,
 } from "../../errors";
 import {
   compileKindFilter,
@@ -27,6 +28,7 @@ import {
 import { compareCodePoints, compareStrings } from "../../utils/compare";
 import { generateId } from "../../utils/id";
 import { isPresent } from "../../utils/presence";
+import { postgresTemporaryTableUnavailableSqlState } from "../../utils/sql-errors";
 import type { AlgorithmContext, InternalTraversalOptions } from "./context";
 import { resolveReadSchema, resolveTemporalOptions } from "./context";
 import type { PathNode, TraversalDirection } from "./types";
@@ -306,7 +308,35 @@ export async function runIterativeGraphOperation<
         await context.executeTemporary(workingMemoryStatement);
       }
     }
-    await context.executeTemporary(plan.createWorkingTable(context));
+    try {
+      await context.executeTemporary(plan.createWorkingTable(context));
+    } catch (error) {
+      const sqlState =
+        ctx.backend.dialect === "postgres" ?
+          postgresTemporaryTableUnavailableSqlState(error)
+        : undefined;
+      if (sqlState === undefined) throw error;
+
+      const capabilityError = new UnsupportedBackendCapabilityError(
+        plan.algorithm,
+        "graphAnalytics",
+        {
+          dialect: ctx.backend.dialect,
+          supported: false,
+          requirement: "transaction-local temporary tables",
+          sqlState,
+        },
+        "Run graph analytics on a writable PostgreSQL primary with a role that has the TEMP privilege.",
+      );
+      // Match the non-enumerable Error.cause property created by the native
+      // Error constructor without widening the public capability-error API.
+      Object.defineProperty(capabilityError, "cause", {
+        configurable: true,
+        value: error,
+        writable: true,
+      });
+      throw capabilityError;
+    }
     let operationFailure: CapturedFailure | undefined;
     try {
       let state = await plan.initialize(context);

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -38,14 +38,32 @@ const POSTGRES_UNDEFINED_RELATION_PATTERN =
 const POSTGRES_UNDEFINED_TABLE_CODE = "42P01";
 const POSTGRES_UNIQUE_VIOLATION_CODE = "23505";
 
-/** PostgreSQL failures that mean a temporary table cannot be created here. */
-export type PostgresTemporaryTableUnavailableSqlState = "25006" | "42501";
+/**
+ * PostgreSQL failures that mean a temporary table cannot be created here:
+ * `read_only_sql_transaction` (a replica or otherwise read-only execution
+ * context) and `insufficient_privilege` (a role without the database `TEMP`
+ * privilege).
+ */
+const POSTGRES_TEMPORARY_TABLE_UNAVAILABLE_SQL_STATES = [
+  "25006",
+  "42501",
+] as const;
 
-function isPostgresTemporaryTableUnavailableSqlState(
-  value: unknown,
-): value is PostgresTemporaryTableUnavailableSqlState {
-  return value === "25006" || value === "42501";
-}
+/**
+ * PostgreSQL failures that mean the read-write transaction hosting temporary
+ * tables cannot even start. A standby rejects the read-write access mode in
+ * the `BEGIN` itself with `feature_not_supported` ("cannot set transaction
+ * read-write mode during recovery"), so the failure never reaches a
+ * `CREATE TEMP TABLE`; a session pinned read-only by a proxy or by
+ * `default_transaction_read_only` reports `read_only_sql_transaction`.
+ */
+const POSTGRES_READ_WRITE_REFUSED_SQL_STATES = ["0A000", "25006"] as const;
+
+export type PostgresTemporaryTableUnavailableSqlState =
+  (typeof POSTGRES_TEMPORARY_TABLE_UNAVAILABLE_SQL_STATES)[number];
+
+export type PostgresReadWriteRefusedSqlState =
+  (typeof POSTGRES_READ_WRITE_REFUSED_SQL_STATES)[number];
 
 /**
  * Yields an error and each error reachable by following `.cause`,
@@ -212,23 +230,56 @@ export function isPostgresUniqueViolationError(error: unknown): boolean {
   return false;
 }
 
+function isSqlStateIn<SqlState extends string>(
+  code: unknown,
+  states: readonly SqlState[],
+): code is SqlState {
+  const known: readonly string[] = states;
+  return typeof code === "string" && known.includes(code);
+}
+
+/**
+ * The first SQLSTATE in the error's cause chain that belongs to `states`. The
+ * walk handles both direct driver errors and wrappers such as
+ * DrizzleQueryError, which keeps the SQLSTATE-bearing error on `.cause`.
+ */
+function matchSqlState<SqlState extends string>(
+  error: unknown,
+  states: readonly SqlState[],
+): SqlState | undefined {
+  for (const link of errorChain(error)) {
+    if (!canReadProperty(link)) continue;
+    const code: unknown = Reflect.get(link, "code");
+    if (isSqlStateIn(code, states)) return code;
+  }
+  return undefined;
+}
+
 /**
  * Returns the PostgreSQL SQLSTATE that prevented temporary-table creation.
  *
  * Callers must use this only at a `CREATE TEMP TABLE` execution seam: 42501
  * is otherwise a generic permission failure, and translating it elsewhere
- * would hide a different authorization problem. The cause walk handles both
- * direct driver errors and wrappers such as DrizzleQueryError.
+ * would hide a different authorization problem.
  */
 export function postgresTemporaryTableUnavailableSqlState(
   error: unknown,
 ): PostgresTemporaryTableUnavailableSqlState | undefined {
-  for (const link of errorChain(error)) {
-    if (!canReadProperty(link)) continue;
-    const code: unknown = Reflect.get(link, "code");
-    if (isPostgresTemporaryTableUnavailableSqlState(code)) return code;
-  }
-  return undefined;
+  return matchSqlState(error, POSTGRES_TEMPORARY_TABLE_UNAVAILABLE_SQL_STATES);
+}
+
+/**
+ * Returns the PostgreSQL SQLSTATE with which the server refused to open a
+ * read-write transaction.
+ *
+ * Callers must use this only for a failure raised while opening such a
+ * transaction — 0A000 is otherwise a generic "unsupported feature" report
+ * that any statement can raise.
+ */
+export function postgresReadWriteRefusedSqlState(
+  error: unknown,
+): PostgresReadWriteRefusedSqlState | undefined {
+  return matchSqlState(error, POSTGRES_READ_WRITE_REFUSED_SQL_STATES);
 }
 
 /**

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -38,6 +38,15 @@ const POSTGRES_UNDEFINED_RELATION_PATTERN =
 const POSTGRES_UNDEFINED_TABLE_CODE = "42P01";
 const POSTGRES_UNIQUE_VIOLATION_CODE = "23505";
 
+/** PostgreSQL failures that mean a temporary table cannot be created here. */
+export type PostgresTemporaryTableUnavailableSqlState = "25006" | "42501";
+
+function isPostgresTemporaryTableUnavailableSqlState(
+  value: unknown,
+): value is PostgresTemporaryTableUnavailableSqlState {
+  return value === "25006" || value === "42501";
+}
+
 /**
  * Yields an error and each error reachable by following `.cause`,
  * outermost first. `seen` guards the pathological cyclic-cause case so a
@@ -201,6 +210,25 @@ export function isPostgresUniqueViolationError(error: unknown): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Returns the PostgreSQL SQLSTATE that prevented temporary-table creation.
+ *
+ * Callers must use this only at a `CREATE TEMP TABLE` execution seam: 42501
+ * is otherwise a generic permission failure, and translating it elsewhere
+ * would hide a different authorization problem. The cause walk handles both
+ * direct driver errors and wrappers such as DrizzleQueryError.
+ */
+export function postgresTemporaryTableUnavailableSqlState(
+  error: unknown,
+): PostgresTemporaryTableUnavailableSqlState | undefined {
+  for (const link of errorChain(error)) {
+    if (!canReadProperty(link)) continue;
+    const code: unknown = Reflect.get(link, "code");
+    if (isPostgresTemporaryTableUnavailableSqlState(code)) return code;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -204,6 +204,35 @@ function createCountingBackend(
   };
 }
 
+function createPostgresTemporaryStatementFailureBackend(
+  backend: GraphBackend,
+  failure: Error,
+): GraphBackend {
+  return {
+    ...backend,
+    dialect: "postgres",
+    transaction<T>(
+      fn: (tx: TransactionBackend) => Promise<T>,
+      options?: TransactionOptions,
+    ): Promise<T> {
+      return backend.transaction(async (tx) => {
+        const failingTransaction: TransactionBackend = {
+          ...tx,
+          dialect: "postgres",
+          executeTemporaryStatement(): Promise<void> {
+            return Promise.reject(failure);
+          },
+        };
+        return fn(failingTransaction);
+      }, options);
+    },
+  };
+}
+
+function postgresError(message: string, code: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
 function personMembership(id: string, labelId: string) {
   return { id, kind: "Person", labelId, labelKind: "Person" };
 }
@@ -237,6 +266,134 @@ describe("store.algorithms", () => {
     backend = createTestBackend();
     store = createStore(testGraph, backend);
     ids = await seed(store);
+  });
+
+  describe("PostgreSQL temporary-table capability failures", () => {
+    const failureCases = [
+      {
+        environment: "read-only execution",
+        sqlState: "25006",
+        createFailure: () =>
+          postgresError(
+            "cannot execute CREATE TABLE in a read-only transaction",
+            "25006",
+          ),
+      },
+      {
+        environment: "read-only execution behind a driver wrapper",
+        sqlState: "25006",
+        createFailure: () =>
+          Object.assign(new Error("Failed query: CREATE TEMP TABLE"), {
+            cause: postgresError(
+              "cannot execute CREATE TABLE in a read-only transaction",
+              "25006",
+            ),
+          }),
+      },
+      {
+        environment: "a role without TEMP privilege",
+        sqlState: "42501",
+        createFailure: () =>
+          postgresError(
+            "permission denied to create temporary tables",
+            "42501",
+          ),
+      },
+      {
+        environment: "a role without TEMP privilege behind a driver wrapper",
+        sqlState: "42501",
+        createFailure: () =>
+          Object.assign(new Error("Failed query: CREATE TEMP TABLE"), {
+            cause: postgresError(
+              "permission denied to create temporary tables",
+              "42501",
+            ),
+          }),
+      },
+    ] as const;
+
+    const algorithmCases = [
+      {
+        operation: "weaklyConnectedComponents",
+        run: (target: Store<TestGraph>) =>
+          target.algorithms.weaklyConnectedComponents({ edges: ["knows"] }),
+      },
+      {
+        operation: "labelPropagation",
+        run: (target: Store<TestGraph>) =>
+          target.algorithms.labelPropagation({ edges: ["knows"] }),
+      },
+      {
+        operation: "pageRank",
+        run: (target: Store<TestGraph>) =>
+          target.algorithms.pageRank({ edges: ["knows"] }),
+      },
+      {
+        operation: "personalizedPageRank",
+        run: (target: Store<TestGraph>) =>
+          target.algorithms.personalizedPageRank({
+            edges: ["knows"],
+            seeds: [{ id: ids.alice, kind: "Person" }],
+          }),
+      },
+    ] as const;
+
+    for (const failureCase of failureCases) {
+      for (const algorithmCase of algorithmCases) {
+        it(`translates ${failureCase.environment} for ${algorithmCase.operation}`, async () => {
+          const failure = failureCase.createFailure();
+          const failingStore = createStore(
+            testGraph,
+            createPostgresTemporaryStatementFailureBackend(backend, failure),
+          );
+
+          await expect(algorithmCase.run(failingStore)).rejects.toMatchObject({
+            code: "UNSUPPORTED_BACKEND_CAPABILITY",
+            cause: failure,
+            details: {
+              operation: algorithmCase.operation,
+              capability: "graphAnalytics",
+              dialect: "postgres",
+              supported: false,
+              requirement: "transaction-local temporary tables",
+              sqlState: failureCase.sqlState,
+            },
+          });
+        });
+      }
+    }
+
+    it("preserves unrelated PostgreSQL failures during table creation", async () => {
+      const failure = postgresError("connection failure", "08006");
+      const failingStore = createStore(
+        testGraph,
+        createPostgresTemporaryStatementFailureBackend(backend, failure),
+      );
+
+      await expect(
+        failingStore.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+        }),
+      ).rejects.toBe(failure);
+    });
+
+    it("preserves permission failures outside table creation", async () => {
+      const failure = postgresError(
+        "permission denied to set parameter",
+        "42501",
+      );
+      const failingStore = createStore(
+        testGraph,
+        createPostgresTemporaryStatementFailureBackend(backend, failure),
+      );
+
+      await expect(
+        failingStore.algorithms.pageRank({
+          edges: ["knows"],
+          workingMemory: "64MB",
+        }),
+      ).rejects.toBe(failure);
+    });
   });
 
   // --------------------------------------------------------------

--- a/packages/typegraph/tests/algorithms.test.ts
+++ b/packages/typegraph/tests/algorithms.test.ts
@@ -229,6 +229,23 @@ function createPostgresTemporaryStatementFailureBackend(
   };
 }
 
+/**
+ * A standby rejects the read-write access mode in the `BEGIN` itself, so the
+ * transaction callback never runs and no temporary statement is ever issued.
+ */
+function createPostgresTransactionOpenFailureBackend(
+  backend: GraphBackend,
+  failure: Error,
+): GraphBackend {
+  return {
+    ...backend,
+    dialect: "postgres",
+    transaction<T>(): Promise<T> {
+      return Promise.reject(failure);
+    },
+  };
+}
+
 function postgresError(message: string, code: string): Error {
   return Object.assign(new Error(message), { code });
 }
@@ -391,6 +408,92 @@ describe("store.algorithms", () => {
         failingStore.algorithms.pageRank({
           edges: ["knows"],
           workingMemory: "64MB",
+        }),
+      ).rejects.toBe(failure);
+    });
+
+    const transactionOpenFailureCases = [
+      {
+        environment: "a standby refusing read-write mode",
+        sqlState: "0A000",
+        createFailure: () =>
+          postgresError(
+            "cannot set transaction read-write mode during recovery",
+            "0A000",
+          ),
+      },
+      {
+        environment:
+          "a standby refusing read-write mode behind a driver wrapper",
+        sqlState: "0A000",
+        createFailure: () =>
+          Object.assign(new Error("Failed query: begin"), {
+            cause: postgresError(
+              "cannot set transaction read-write mode during recovery",
+              "0A000",
+            ),
+          }),
+      },
+      {
+        environment: "a session pinned read-only",
+        sqlState: "25006",
+        createFailure: () =>
+          postgresError("cannot start a read-write transaction", "25006"),
+      },
+    ] as const;
+
+    for (const failureCase of transactionOpenFailureCases) {
+      for (const algorithmCase of algorithmCases) {
+        it(`translates ${failureCase.environment} for ${algorithmCase.operation}`, async () => {
+          const failure = failureCase.createFailure();
+          const failingStore = createStore(
+            testGraph,
+            createPostgresTransactionOpenFailureBackend(backend, failure),
+          );
+
+          await expect(algorithmCase.run(failingStore)).rejects.toMatchObject({
+            code: "UNSUPPORTED_BACKEND_CAPABILITY",
+            cause: failure,
+            details: {
+              operation: algorithmCase.operation,
+              capability: "graphAnalytics",
+              dialect: "postgres",
+              supported: false,
+              requirement: "transaction-local temporary tables",
+              sqlState: failureCase.sqlState,
+            },
+          });
+        });
+      }
+    }
+
+    it("preserves unrelated failures while opening the transaction", async () => {
+      const failure = postgresError("connection terminated", "08006");
+      const failingStore = createStore(
+        testGraph,
+        createPostgresTransactionOpenFailureBackend(backend, failure),
+      );
+
+      await expect(
+        failingStore.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+        }),
+      ).rejects.toBe(failure);
+    });
+
+    it("preserves unsupported-feature failures raised inside the transaction", async () => {
+      const failure = postgresError(
+        "RETURNING is not supported in this context",
+        "0A000",
+      );
+      const failingStore = createStore(
+        testGraph,
+        createPostgresTemporaryStatementFailureBackend(backend, failure),
+      );
+
+      await expect(
+        failingStore.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
         }),
       ).rejects.toBe(failure);
     });


### PR DESCRIPTION
- translate PostgreSQL `25006` and `42501` failures only at graph-analytics temporary-table creation
- surface `UnsupportedBackendCapabilityError` with stable capability details while preserving the original driver error as `cause`
- document the distinction between static backend support and execution-time PostgreSQL state
- cover WCC, label propagation, PageRank, and Personalized PageRank with direct and wrapped SQLSTATE failures

Closes #359.

