### PR TITLE
fix(algorithms): chunk node-kind initialization

### DIFF
--- a/.changeset/chunky-node-kind-initialization.md
+++ b/.changeset/chunky-node-kind-initialization.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Chunk iterative graph-algorithm node-kind initialization within each backend's bind-parameter budget.

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -10,7 +10,6 @@ import {
   ConfigurationError,
   UnsupportedBackendCapabilityError,
 } from "../../errors";
-import { compileKindFilter } from "../../query/compiler/predicate-utils";
 import { MAX_EXPLICIT_RECURSIVE_DEPTH } from "../../query/compiler/recursive";
 import {
   type RecordedReadBinding,
@@ -23,9 +22,7 @@ import {
   type TemporalFilterOptions,
 } from "../../query/compiler/temporal";
 import { type DialectAdapter } from "../../query/dialect/types";
-import { sql, type SqlFragment } from "../../query/sql-fragment";
 import { type KindRegistry } from "../../registry/kind-registry";
-import { compareCodePoints } from "../../utils/compare";
 import type { AlgorithmCyclePolicy, TraversalDirection } from "./types";
 
 export const DEFAULT_ALGORITHM_MAX_HOPS = 10;
@@ -210,30 +207,6 @@ export function assertEdgeKinds(edges: readonly string[]): void {
       { edges },
     );
   }
-}
-
-/**
- * Compiles the induced-subgraph node filter for a working-table seeding
- * statement over the nodes-table alias `n`; `undefined` selects every kind.
- */
-export function compileNodeKindSeedFilter(
-  nodeKinds: readonly string[] | undefined,
-): SqlFragment {
-  if (nodeKinds === undefined) return sql`TRUE`;
-  return compileKindFilter(sql.raw("n.kind"), nodeKinds);
-}
-
-/**
- * Deduplicates and code-point-sorts an induced-subgraph kind selection so
- * compiled kind filters are deterministic across call sites and backends.
- */
-export function normalizeNodeKinds(
-  nodeKinds: readonly string[] | undefined,
-): readonly string[] | undefined {
-  if (nodeKinds === undefined) return undefined;
-  return [...new Set(nodeKinds)].toSorted((left, right) =>
-    compareCodePoints(left, right),
-  );
 }
 
 export function assertGraphAnalyticsSupported(

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -155,10 +155,18 @@ export async function seedWorkingTableFromNodes(
     `;
   };
 
+  const fixedStatement = compileSeedStatement(sql`TRUE`);
+  const parameterLimit =
+    context.operation.backend.capabilities.maxBindParameters ??
+    DEFAULT_MAX_BIND_PARAMETERS;
+  const fixedParameterCount = countBindParameters(fixedStatement);
+  const kindChunkSize = parameterLimit - fixedParameterCount;
+
   if (nodeKinds === undefined) {
-    const statement = compileSeedStatement(sql`TRUE`);
-    assertStatementFitsBindBudget(context, statement);
-    await context.executeTemporary(statement);
+    if (kindChunkSize < 0) {
+      throw nodeKindBindBudgetError(fixedParameterCount, parameterLimit);
+    }
+    await context.executeTemporary(fixedStatement);
     return;
   }
 
@@ -166,18 +174,8 @@ export async function seedWorkingTableFromNodes(
     compareCodePoints(left, right),
   );
   if (normalizedKinds.length === 0) return;
-
-  const fixedStatement = compileSeedStatement(sql`TRUE`);
-  const parameterLimit =
-    context.operation.backend.capabilities.maxBindParameters ??
-    DEFAULT_MAX_BIND_PARAMETERS;
-  const fixedParameterCount = countBindParameters(fixedStatement);
-  const kindChunkSize = parameterLimit - fixedParameterCount;
   if (kindChunkSize < 1) {
-    throw new ConfigurationError(
-      "An iterative graph operation cannot fit its node-kind initialization within the backend bind-parameter limit.",
-      { fixedParameterCount, parameterLimit },
-    );
+    throw nodeKindBindBudgetError(fixedParameterCount, parameterLimit);
   }
 
   for (const kindChunk of chunkValues(normalizedKinds, kindChunkSize)) {
@@ -187,16 +185,11 @@ export async function seedWorkingTableFromNodes(
   }
 }
 
-function assertStatementFitsBindBudget(
-  context: IterativeGraphRunContext,
-  statement: SqlFragment,
-): void {
-  const parameterLimit =
-    context.operation.backend.capabilities.maxBindParameters ??
-    DEFAULT_MAX_BIND_PARAMETERS;
-  const fixedParameterCount = countBindParameters(statement);
-  if (fixedParameterCount <= parameterLimit) return;
-  throw new ConfigurationError(
+function nodeKindBindBudgetError(
+  fixedParameterCount: number,
+  parameterLimit: number,
+): ConfigurationError {
+  return new ConfigurationError(
     "An iterative graph operation cannot fit its node-kind initialization within the backend bind-parameter limit.",
     { fixedParameterCount, parameterLimit },
   );

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -100,6 +100,11 @@ export function frontierIndexIdentifier(
 
 type WorkingTableCountRow = Readonly<{ count: number | string }>;
 
+type WorkingTableNodeSeedColumn = Readonly<{
+  name: string;
+  value: SqlFragment;
+}>;
+
 /** Counts this run's working-table rows; drivers may deliver bigint text. */
 export async function countWorkingTableRows(
   context: IterativeGraphRunContext,
@@ -112,6 +117,98 @@ export async function countWorkingTableRows(
     `),
   );
   return Number(rows[0]?.count ?? 0);
+}
+
+/**
+ * Populates an iterative working table from the visible induced subgraph.
+ * Explicit node-kind scopes are deterministic and split against the exact
+ * statement budget; an omitted scope keeps the single full-graph statement.
+ */
+export async function seedWorkingTableFromNodes(
+  context: IterativeGraphRunContext,
+  nodeKinds: readonly string[] | undefined,
+  seedColumns: readonly WorkingTableNodeSeedColumn[],
+): Promise<void> {
+  const additionalColumns =
+    seedColumns.length === 0 ?
+      sql``
+    : sql`, ${sql.join(
+        seedColumns.map((column) => sql.identifier(column.name)),
+        sql`, `,
+      )}`;
+  const additionalValues =
+    seedColumns.length === 0 ?
+      sql``
+    : sql`, ${sql.join(
+        seedColumns.map((column) => column.value),
+        sql`, `,
+      )}`;
+  const compileSeedStatement = (nodeKindFilter: SqlFragment): SqlFragment => {
+    return sql`
+      INSERT INTO ${context.workingTable}
+        (graph_id, run_id, node_id, node_kind${additionalColumns})
+      SELECT ${context.graphId}, ${context.runId}, n.id, n.kind${additionalValues}
+      FROM ${context.operation.schema.nodesTable} n
+      WHERE n.graph_id = ${context.graphId}
+        AND ${nodeKindFilter}
+        AND ${context.operation.nodeTemporalFilter}
+    `;
+  };
+
+  if (nodeKinds === undefined) {
+    const statement = compileSeedStatement(sql`TRUE`);
+    assertStatementFitsBindBudget(context, statement);
+    await context.executeTemporary(statement);
+    return;
+  }
+
+  const normalizedKinds = [...new Set(nodeKinds)].toSorted((left, right) =>
+    compareCodePoints(left, right),
+  );
+  if (normalizedKinds.length === 0) return;
+
+  const fixedStatement = compileSeedStatement(sql`TRUE`);
+  const parameterLimit =
+    context.operation.backend.capabilities.maxBindParameters ??
+    DEFAULT_MAX_BIND_PARAMETERS;
+  const fixedParameterCount = countBindParameters(fixedStatement);
+  const kindChunkSize = parameterLimit - fixedParameterCount;
+  if (kindChunkSize < 1) {
+    throw new ConfigurationError(
+      "An iterative graph operation cannot fit its node-kind initialization within the backend bind-parameter limit.",
+      { fixedParameterCount, parameterLimit },
+    );
+  }
+
+  for (const kindChunk of chunkValues(normalizedKinds, kindChunkSize)) {
+    await context.executeTemporary(
+      compileSeedStatement(compileKindFilter(sql.raw("n.kind"), kindChunk)),
+    );
+  }
+}
+
+function assertStatementFitsBindBudget(
+  context: IterativeGraphRunContext,
+  statement: SqlFragment,
+): void {
+  const parameterLimit =
+    context.operation.backend.capabilities.maxBindParameters ??
+    DEFAULT_MAX_BIND_PARAMETERS;
+  const fixedParameterCount = countBindParameters(statement);
+  if (fixedParameterCount <= parameterLimit) return;
+  throw new ConfigurationError(
+    "An iterative graph operation cannot fit its node-kind initialization within the backend bind-parameter limit.",
+    { fixedParameterCount, parameterLimit },
+  );
+}
+
+function countBindParameters(fragment: SqlFragment): number {
+  return fragment.chunks.reduce(
+    (count, chunk) =>
+      count +
+      (chunk.kind === "parameter" || chunk.kind === "placeholder" ? 1 : 0),
+    0,
+  );
 }
 
 export type IterativeGraphPlan<

--- a/packages/typegraph/src/store/algorithms/label-propagation.ts
+++ b/packages/typegraph/src/store/algorithms/label-propagation.ts
@@ -6,9 +6,7 @@ import {
   type AlgorithmContext,
   assertEdgeKinds,
   assertGraphAnalyticsSupported,
-  compileNodeKindSeedFilter,
   type InternalTraversalOptions,
-  normalizeNodeKinds,
   pickTemporalOptions,
   resolveMaxIterations,
 } from "./context";
@@ -20,6 +18,7 @@ import {
   type NodeIdentityKey,
   nodeIdentityKey,
   runIterativeGraphOperation,
+  seedWorkingTableFromNodes,
 } from "./iterative-graph-operation";
 import type {
   InternalLabelPropagationOptions,
@@ -73,7 +72,6 @@ export async function executeLabelPropagation<G extends GraphDef>(
     DEFAULT_LABEL_PROPAGATION_MAX_ITERATIONS,
     "labelPropagation",
   );
-  const nodeKinds = normalizeNodeKinds(options.nodeKinds);
   const policy: RoundPolicy = {
     detector: createOscillationDetector(),
     maxIterations,
@@ -92,7 +90,8 @@ export async function executeLabelPropagation<G extends GraphDef>(
     algorithm: "labelPropagation",
     maxIterations,
     createWorkingTable,
-    initialize: (context) => initializeWorkingTables(context, nodeKinds),
+    initialize: (context) =>
+      initializeWorkingTables(context, options.nodeKinds),
     runRound: (context, state, iteration) =>
       runLabelPropagationRound(context, state, iteration, policy),
     hasConverged(state) {
@@ -184,26 +183,21 @@ async function initializeWorkingTables(
   context: IterativeGraphRunContext,
   nodeKinds: readonly string[] | undefined,
 ): Promise<IterationState> {
-  const { operation, workingTable, graphId, runId } = context;
-  const nodeKindFilter = compileNodeKindSeedFilter(nodeKinds);
-  await context.executeTemporary(sql`
-    INSERT INTO ${workingTable}
-      (graph_id, run_id, node_id, node_kind, label_id, label_kind,
-       next_label_id, next_label_kind, changed_round, active_round)
-    SELECT
-      ${graphId}, ${runId}, n.id, n.kind, n.id, n.kind, n.id, n.kind, 0, 1
-    FROM ${operation.schema.nodesTable} n
-    WHERE n.graph_id = ${graphId}
-      AND ${nodeKindFilter}
-      AND ${operation.nodeTemporalFilter}
-  `);
+  await seedWorkingTableFromNodes(context, nodeKinds, [
+    { name: "label_id", value: sql.raw("n.id") },
+    { name: "label_kind", value: sql.raw("n.kind") },
+    { name: "next_label_id", value: sql.raw("n.id") },
+    { name: "next_label_kind", value: sql.raw("n.kind") },
+    { name: "changed_round", value: sql.raw("0") },
+    { name: "active_round", value: sql.raw("1") },
+  ]);
   await context.executeTemporary(sql`
     CREATE INDEX ${frontierIndexIdentifier(context)}
-    ON ${workingTable} (graph_id, run_id, changed_round)
+    ON ${context.workingTable} (graph_id, run_id, changed_round)
   `);
   await context.executeTemporary(sql`
     CREATE INDEX ${activeIndexIdentifier(context)}
-    ON ${workingTable} (graph_id, run_id, active_round)
+    ON ${context.workingTable} (graph_id, run_id, active_round)
   `);
   const neighborTable = neighborTableIdentifier(context);
   await context.executeTemporary(sql`
@@ -215,11 +209,11 @@ async function initializeWorkingTables(
       PRIMARY KEY (target_kind, target_id, neighbor_kind, neighbor_id)
     )
   `);
-  for (const edgeKinds of operation.edgeKindChunks) {
+  for (const edgeKinds of context.operation.edgeKindChunks) {
     await materializeChunkNeighbors(context, edgeKinds);
   }
   const analyzeNeighbors =
-    operation.ctx.dialect.analyzeTemporaryTable(neighborTable);
+    context.operation.ctx.dialect.analyzeTemporaryTable(neighborTable);
   if (analyzeNeighbors !== undefined) {
     await context.executeTemporary(analyzeNeighbors);
   }

--- a/packages/typegraph/src/store/algorithms/page-rank.ts
+++ b/packages/typegraph/src/store/algorithms/page-rank.ts
@@ -6,9 +6,7 @@ import {
   type AlgorithmContext,
   assertEdgeKinds,
   assertGraphAnalyticsSupported,
-  compileNodeKindSeedFilter,
   type InternalTraversalOptions,
-  normalizeNodeKinds,
   pickTemporalOptions,
   resolveMaxIterations,
 } from "./context";
@@ -21,6 +19,7 @@ import {
   type NodeIdentityKey,
   nodeIdentityKey,
   runIterativeGraphOperation,
+  seedWorkingTableFromNodes,
 } from "./iterative-graph-operation";
 import type {
   InternalPageRankOptions,
@@ -151,7 +150,7 @@ function resolvePageRankOptions<G extends GraphDef>(
       DEFAULT_MAX_ITERATIONS,
       algorithm,
     ),
-    nodeKinds: normalizeNodeKinds(options.nodeKinds),
+    nodeKinds: options.nodeKinds,
   };
 }
 
@@ -246,17 +245,12 @@ async function initializeWorkingTable(
   seeds: readonly NormalizedSeed[] | undefined,
 ): Promise<IterationState> {
   const { operation, workingTable, graphId, runId } = context;
-  const nodeKindFilter = compileNodeKindSeedFilter(nodeKinds);
-  await context.executeTemporary(sql`
-    INSERT INTO ${workingTable}
-      (graph_id, run_id, node_id, node_kind, score, next_score,
-       personalization, out_weight)
-    SELECT ${graphId}, ${runId}, n.id, n.kind, 0.0, 0.0, 0.0, 0.0
-    FROM ${operation.schema.nodesTable} n
-    WHERE n.graph_id = ${graphId}
-      AND ${nodeKindFilter}
-      AND ${operation.nodeTemporalFilter}
-  `);
+  await seedWorkingTableFromNodes(context, nodeKinds, [
+    { name: "score", value: sql.raw("0.0") },
+    { name: "next_score", value: sql.raw("0.0") },
+    { name: "personalization", value: sql.raw("0.0") },
+    { name: "out_weight", value: sql.raw("0.0") },
+  ]);
 
   const workingTableSize = await countWorkingTableRows(context);
   if (workingTableSize === 0) {

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -5,9 +5,7 @@ import {
   type AlgorithmContext,
   assertEdgeKinds,
   assertGraphAnalyticsSupported,
-  compileNodeKindSeedFilter,
   type InternalTraversalOptions,
-  normalizeNodeKinds,
   pickTemporalOptions,
   resolveMaxIterations,
 } from "./context";
@@ -17,6 +15,7 @@ import {
   frontierIndexIdentifier,
   type IterativeGraphRunContext,
   runIterativeGraphOperation,
+  seedWorkingTableFromNodes,
 } from "./iterative-graph-operation";
 import type {
   InternalWeaklyConnectedComponentsOptions,
@@ -52,7 +51,6 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
     DEFAULT_WCC_MAX_ITERATIONS,
     "weaklyConnectedComponents",
   );
-  const nodeKinds = normalizeNodeKinds(options.nodeKinds);
   const traversalOptions: InternalTraversalOptions = {
     edges: options.edges,
     direction: "both",
@@ -66,7 +64,7 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
     algorithm: "weaklyConnectedComponents",
     maxIterations,
     createWorkingTable,
-    initialize: (context) => initializeWorkingTable(context, nodeKinds),
+    initialize: (context) => initializeWorkingTable(context, options.nodeKinds),
     runRound: runLabelPropagationRound,
     hasConverged(state) {
       return state.changedCount === 0;
@@ -96,22 +94,16 @@ async function initializeWorkingTable(
   context: IterativeGraphRunContext,
   nodeKinds: readonly string[] | undefined,
 ): Promise<IterationState> {
-  const { operation, workingTable, graphId, runId } = context;
-  const nodeKindFilter = compileNodeKindSeedFilter(nodeKinds);
-  await context.executeTemporary(sql`
-    INSERT INTO ${workingTable}
-      (graph_id, run_id, node_id, node_kind, label_id, label_kind,
-       next_label_id, next_label_kind, improved_round)
-    SELECT
-      ${graphId}, ${runId}, n.id, n.kind, n.id, n.kind, n.id, n.kind, 0
-    FROM ${operation.schema.nodesTable} n
-    WHERE n.graph_id = ${graphId}
-      AND ${nodeKindFilter}
-      AND ${operation.nodeTemporalFilter}
-  `);
+  await seedWorkingTableFromNodes(context, nodeKinds, [
+    { name: "label_id", value: sql.raw("n.id") },
+    { name: "label_kind", value: sql.raw("n.kind") },
+    { name: "next_label_id", value: sql.raw("n.id") },
+    { name: "next_label_kind", value: sql.raw("n.kind") },
+    { name: "improved_round", value: sql.raw("0") },
+  ]);
   await context.executeTemporary(sql`
     CREATE INDEX ${frontierIndexIdentifier(context)}
-    ON ${workingTable} (graph_id, run_id, improved_round)
+    ON ${context.workingTable} (graph_id, run_id, improved_round)
   `);
 
   const workingTableSize = await countWorkingTableRows(context);

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -8,8 +8,16 @@
  * generation all get exercised on each backend.
  */
 import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 
-import { createStore, GraphAlgorithmConvergenceError } from "../../../src";
+import {
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  GraphAlgorithmConvergenceError,
+  type Store,
+} from "../../../src";
 import type {
   GraphBackend,
   TransactionBackend,
@@ -32,6 +40,30 @@ type AlgorithmFixture = Readonly<{
   dianaId: string;
   eveId: string;
 }>;
+
+const NODE_KIND_INITIALIZATION_KIND_COUNT = 30;
+const nodeKindInitializationNodes = Object.fromEntries(
+  Array.from({ length: NODE_KIND_INITIALIZATION_KIND_COUNT }, (_, index) => {
+    const kind = `BindKind${String(index).padStart(2, "0")}`;
+    return [
+      kind,
+      {
+        type: defineNode(kind, {
+          schema: z.object({ name: z.string() }),
+        }),
+      },
+    ];
+  }),
+);
+const nodeKindInitializationGraph = defineGraph({
+  id: "algorithm_node_kind_bind_budget",
+  nodes: nodeKindInitializationNodes,
+  edges: { connects: defineEdge("connects") },
+});
+const nodeKindInitializationKinds = Object.keys(
+  nodeKindInitializationNodes,
+).toSorted();
+type NodeKindInitializationStore = Store<typeof nodeKindInitializationGraph>;
 
 async function resolveAlgorithmFixture(
   store: IntegrationStore,
@@ -106,7 +138,11 @@ async function seedWeightedTriangle(store: IntegrationStore) {
   return { anna, bruno, clara };
 }
 
-function withBindLimit(backend: GraphBackend, maxBindParameters: number) {
+function withBindLimit(
+  backend: GraphBackend,
+  maxBindParameters: number,
+  onTemporaryStatement?: (sqlText: string) => void,
+) {
   return {
     ...backend,
     capabilities: { ...backend.capabilities, maxBindParameters },
@@ -125,7 +161,12 @@ function withBindLimit(backend: GraphBackend, maxBindParameters: number) {
           async executeTemporaryStatement(
             query: CompiledTemporaryStatementSql,
           ): Promise<void> {
-            assertWithinBindLimit(backend, query, maxBindParameters);
+            const sqlText = assertWithinBindLimit(
+              backend,
+              query,
+              maxBindParameters,
+            );
+            onTemporaryStatement?.(sqlText);
             await requireDefined(tx.executeTemporaryStatement)(query);
           },
         };
@@ -139,13 +180,36 @@ function assertWithinBindLimit(
   backend: GraphBackend,
   query: CompiledRowsSql | CompiledTemporaryStatementSql,
   maxBindParameters: number,
-): void {
-  const parameterCount = requireDefined(backend.compileSql)(query).params
-    .length;
-  if (parameterCount <= maxBindParameters) return;
-  throw new Error(
-    `Statement used ${parameterCount} bind parameters; limit is ${maxBindParameters}.`,
+): string {
+  const compiled = requireDefined(backend.compileSql)(query);
+  if (compiled.params.length > maxBindParameters) {
+    throw new Error(
+      `Statement used ${compiled.params.length} bind parameters; limit is ${maxBindParameters}.`,
+    );
+  }
+  return compiled.sql;
+}
+
+async function expectChunkedNodeKindInitialization(
+  backend: GraphBackend,
+  run: (store: NodeKindInitializationStore) => Promise<unknown>,
+): Promise<void> {
+  let initializationStatementCount = 0;
+  const constrainedStore = createStore(
+    nodeKindInitializationGraph,
+    withBindLimit(backend, 28, (sqlText) => {
+      if (
+        /^\s*INSERT INTO "typegraph_iterative_[^"]+"\s+\(graph_id, run_id, node_id, node_kind/u.test(
+          sqlText,
+        )
+      ) {
+        initializationStatementCount += 1;
+      }
+    }),
   );
+
+  await run(constrainedStore);
+  expect(initializationStatementCount).toBeGreaterThan(1);
 }
 
 function withoutTemporaryStatements(backend: GraphBackend): GraphBackend {
@@ -158,6 +222,84 @@ export function registerAlgorithmIntegrationTests(
   context: IntegrationTestContext,
 ): void {
   describe("Graph Algorithms", () => {
+    it("chunks every iterative node-kind initializer within the bind budget", async () => {
+      const store = await context.createStore(nodeKindInitializationGraph);
+      const firstKind = requireDefined(nodeKindInitializationKinds[0]);
+      const lastKind = requireDefined(nodeKindInitializationKinds.at(-1));
+      const boundaryDuplicateKind = requireDefined(
+        nodeKindInitializationKinds[22],
+      );
+      const [firstNode] = await Promise.all([
+        requireDefined(store.nodes[firstKind]).create({ name: "First" }),
+        requireDefined(store.nodes[lastKind]).create({ name: "Last" }),
+      ]);
+
+      // With a 28-bind ceiling, the current initializer fits 23 kind binds.
+      // Repeating index 22 straddles that boundary unless normalization happens
+      // before chunking, which would violate the working table's primary key.
+      const selectedKinds = [
+        ...nodeKindInitializationKinds,
+        boundaryDuplicateKind,
+      ];
+      const expectedKinds = [firstKind, lastKind].toSorted();
+
+      await expectChunkedNodeKindInitialization(
+        store.backend,
+        async (scoped) => {
+          const memberships = await scoped.algorithms.weaklyConnectedComponents(
+            {
+              edges: ["connects"],
+              nodeKinds: selectedKinds,
+            },
+          );
+          expect(memberships.map((row) => row.kind).toSorted()).toEqual(
+            expectedKinds,
+          );
+        },
+      );
+
+      await expectChunkedNodeKindInitialization(
+        store.backend,
+        async (scoped) => {
+          const memberships = await scoped.algorithms.labelPropagation({
+            edges: ["connects"],
+            nodeKinds: selectedKinds,
+          });
+          expect(memberships.map((row) => row.kind).toSorted()).toEqual(
+            expectedKinds,
+          );
+        },
+      );
+
+      await expectChunkedNodeKindInitialization(
+        store.backend,
+        async (scoped) => {
+          const scores = await scoped.algorithms.pageRank({
+            edges: ["connects"],
+            nodeKinds: selectedKinds,
+          });
+          expect(scores.map((row) => row.kind).toSorted()).toEqual(
+            expectedKinds,
+          );
+        },
+      );
+
+      await expectChunkedNodeKindInitialization(
+        store.backend,
+        async (scoped) => {
+          const scores = await scoped.algorithms.personalizedPageRank({
+            dampingFactor: 0,
+            edges: ["connects"],
+            nodeKinds: selectedKinds,
+            seeds: [{ id: firstNode.id, kind: firstKind }],
+          });
+          expect(scores.map((row) => row.kind).toSorted()).toEqual(
+            expectedKinds,
+          );
+        },
+      );
+    });
+
     describe("core behaviors (seedKnowsChain: Alice→Bob→Charlie→Diana→Eve + Alice→Charlie)", () => {
       let ids: AlgorithmFixture;
 

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -63,7 +63,17 @@ const nodeKindInitializationGraph = defineGraph({
 const nodeKindInitializationKinds = Object.keys(
   nodeKindInitializationNodes,
 ).toSorted();
+const nodeKindInitializationKindSet = new Set(nodeKindInitializationKinds);
 type NodeKindInitializationStore = Store<typeof nodeKindInitializationGraph>;
+
+/**
+ * The seed statement binds three identifiers plus its two temporal bounds, so
+ * a 28-parameter ceiling leaves room for exactly 23 node kinds per statement.
+ */
+const NODE_KIND_INITIALIZATION_BIND_LIMIT = 28;
+const NODE_KIND_INITIALIZATION_CHUNK_SIZE = 23;
+const NODE_KIND_SEED_STATEMENT =
+  /^\s*INSERT INTO "typegraph_iterative_[^"]+"\s+\(graph_id, run_id, node_id, node_kind/u;
 
 async function resolveAlgorithmFixture(
   store: IntegrationStore,
@@ -138,10 +148,15 @@ async function seedWeightedTriangle(store: IntegrationStore) {
   return { anna, bruno, clara };
 }
 
+type CompiledStatement = Readonly<{
+  sql: string;
+  params: readonly unknown[];
+}>;
+
 function withBindLimit(
   backend: GraphBackend,
   maxBindParameters: number,
-  onTemporaryStatement?: (sqlText: string) => void,
+  onTemporaryStatement?: (statement: CompiledStatement) => void,
 ) {
   return {
     ...backend,
@@ -161,12 +176,12 @@ function withBindLimit(
           async executeTemporaryStatement(
             query: CompiledTemporaryStatementSql,
           ): Promise<void> {
-            const sqlText = assertWithinBindLimit(
+            const compiled = assertWithinBindLimit(
               backend,
               query,
               maxBindParameters,
             );
-            onTemporaryStatement?.(sqlText);
+            onTemporaryStatement?.(compiled);
             await requireDefined(tx.executeTemporaryStatement)(query);
           },
         };
@@ -180,36 +195,50 @@ function assertWithinBindLimit(
   backend: GraphBackend,
   query: CompiledRowsSql | CompiledTemporaryStatementSql,
   maxBindParameters: number,
-): string {
+): CompiledStatement {
   const compiled = requireDefined(backend.compileSql)(query);
   if (compiled.params.length > maxBindParameters) {
     throw new Error(
       `Statement used ${compiled.params.length} bind parameters; limit is ${maxBindParameters}.`,
     );
   }
-  return compiled.sql;
+  return compiled;
 }
 
+/**
+ * Runs one iterative algorithm under a bind ceiling that forces the node-kind
+ * initializer to split, and asserts both that it split and that the caller's
+ * duplicated kind still lands on the first chunk's boundary — the only
+ * arrangement in which the duplicate can prove that kinds are deduplicated
+ * before they are chunked.
+ */
 async function expectChunkedNodeKindInitialization(
   backend: GraphBackend,
+  boundaryKind: string,
   run: (store: NodeKindInitializationStore) => Promise<unknown>,
 ): Promise<void> {
-  let initializationStatementCount = 0;
+  const initializationChunks: (readonly string[])[] = [];
   const constrainedStore = createStore(
     nodeKindInitializationGraph,
-    withBindLimit(backend, 28, (sqlText) => {
-      if (
-        /^\s*INSERT INTO "typegraph_iterative_[^"]+"\s+\(graph_id, run_id, node_id, node_kind/u.test(
-          sqlText,
-        )
-      ) {
-        initializationStatementCount += 1;
-      }
+    withBindLimit(backend, NODE_KIND_INITIALIZATION_BIND_LIMIT, (statement) => {
+      if (!NODE_KIND_SEED_STATEMENT.test(statement.sql)) return;
+      initializationChunks.push(
+        statement.params.filter(
+          (parameter): parameter is string =>
+            typeof parameter === "string" &&
+            nodeKindInitializationKindSet.has(parameter),
+        ),
+      );
     }),
   );
 
   await run(constrainedStore);
-  expect(initializationStatementCount).toBeGreaterThan(1);
+
+  expect(initializationChunks.length).toBeGreaterThan(1);
+  expect(requireDefined(initializationChunks[0])).toHaveLength(
+    NODE_KIND_INITIALIZATION_CHUNK_SIZE,
+  );
+  expect(requireDefined(initializationChunks[0]).at(-1)).toBe(boundaryKind);
 }
 
 function withoutTemporaryStatements(backend: GraphBackend): GraphBackend {
@@ -227,24 +256,32 @@ export function registerAlgorithmIntegrationTests(
       const firstKind = requireDefined(nodeKindInitializationKinds[0]);
       const lastKind = requireDefined(nodeKindInitializationKinds.at(-1));
       const boundaryDuplicateKind = requireDefined(
-        nodeKindInitializationKinds[22],
+        nodeKindInitializationKinds[NODE_KIND_INITIALIZATION_CHUNK_SIZE - 1],
       );
       const [firstNode] = await Promise.all([
         requireDefined(store.nodes[firstKind]).create({ name: "First" }),
         requireDefined(store.nodes[lastKind]).create({ name: "Last" }),
+        requireDefined(store.nodes[boundaryDuplicateKind]).create({
+          name: "Boundary",
+        }),
       ]);
 
-      // With a 28-bind ceiling, the current initializer fits 23 kind binds.
-      // Repeating index 22 straddles that boundary unless normalization happens
-      // before chunking, which would violate the working table's primary key.
+      // The last kind of the first chunk is repeated, so without deduplication
+      // ahead of chunking it lands in two chunks and its node is seeded twice,
+      // violating the working table's primary key.
       const selectedKinds = [
         ...nodeKindInitializationKinds,
         boundaryDuplicateKind,
       ];
-      const expectedKinds = [firstKind, lastKind].toSorted();
+      const expectedKinds = [
+        firstKind,
+        lastKind,
+        boundaryDuplicateKind,
+      ].toSorted();
 
       await expectChunkedNodeKindInitialization(
         store.backend,
+        boundaryDuplicateKind,
         async (scoped) => {
           const memberships = await scoped.algorithms.weaklyConnectedComponents(
             {
@@ -260,6 +297,7 @@ export function registerAlgorithmIntegrationTests(
 
       await expectChunkedNodeKindInitialization(
         store.backend,
+        boundaryDuplicateKind,
         async (scoped) => {
           const memberships = await scoped.algorithms.labelPropagation({
             edges: ["connects"],
@@ -273,6 +311,7 @@ export function registerAlgorithmIntegrationTests(
 
       await expectChunkedNodeKindInitialization(
         store.backend,
+        boundaryDuplicateKind,
         async (scoped) => {
           const scores = await scoped.algorithms.pageRank({
             edges: ["connects"],
@@ -286,6 +325,7 @@ export function registerAlgorithmIntegrationTests(
 
       await expectChunkedNodeKindInitialization(
         store.backend,
+        boundaryDuplicateKind,
         async (scoped) => {
           const scores = await scoped.algorithms.personalizedPageRank({
             dampingFactor: 0,


### PR DESCRIPTION
- centralize iterative working-table node seeding for WCC, label propagation, PageRank, and Personalized PageRank
- normalize explicit node-kind scopes before chunking and keep every seed statement within the backend bind budget
- preserve omitted, empty, and duplicate `nodeKinds` behavior inside the existing repeatable-read transaction
- add shared SQLite/PostgreSQL integration coverage with a constrained bind budget that proves multi-statement initialization

Closes #358.

