### PR TITLE
feat(algorithms): bound whole-graph result extraction

### DIFF
--- a/.changeset/calm-graphs-bound.md
+++ b/.changeset/calm-graphs-bound.md
@@ -1,0 +1,6 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Add SQL-level `topK` extraction for PageRank and personalized PageRank, plus
+inclusive `minComponentSize` filtering for weakly connected components.

--- a/.changeset/calm-graphs-bound.md
+++ b/.changeset/calm-graphs-bound.md
@@ -1,6 +1,10 @@
 ---
-"@nicia-ai/typegraph": patch
+"@nicia-ai/typegraph": minor
 ---
 
-Add SQL-level `topK` extraction for PageRank and personalized PageRank, plus
-inclusive `minComponentSize` filtering for weakly connected components.
+Add optional `topK` to `pageRank()` and `personalizedPageRank()`, and optional
+`minComponentSize` to `weaklyConnectedComponents()`. Both bound only result
+extraction: the limit and the inclusive component-size filter are applied in
+extraction SQL after the existing deterministic ordering, so bounded rows never
+reach the driver. Default results and ordering are unchanged, and the graph
+computation itself still runs over the whole visible induced subgraph.

--- a/apps/docs/src/content/docs/graph-algorithms.md
+++ b/apps/docs/src/content/docs/graph-algorithms.md
@@ -290,6 +290,7 @@ const globalScores = await store.algorithms.pageRank({
   edges: ["knows", "cites"],
   nodeKinds: ["Person", "Paper"],
   direction: "out",
+  topK: 20,
 });
 
 const relatedToAlice = await store.algorithms.personalizedPageRank({
@@ -311,6 +312,7 @@ const relatedToAlice = await store.algorithms.personalizedPageRank({
 | `dampingFactor` | `number` in `[0, 1)` | `0.85` | Probability of following an edge rather than teleporting |
 | `tolerance` | positive finite `number` | `1e-8` | Maximum per-node score change accepted as convergence |
 | `maxIterations` | positive integer | `1000` | Power-iteration backstop; exceeding it throws |
+| `topK` | positive safe integer | all scores | Return the first K scores after deterministic ordering |
 | `workingMemory` | PostgreSQL memory string | inherited | Same transaction-scoped override described above |
 
 Personalized seeds are qualified by the full `(kind, id)` identity so same-ID
@@ -332,6 +334,12 @@ requested numerical tolerance rather than bit-for-bit. Exact score ties use
 portable binary `(id, kind)` ordering. As with WCC, an exhausted iteration
 budget throws `GraphAlgorithmConvergenceError`—partial scores are never
 returned.
+
+`topK` bounds only result extraction: TypeGraph applies the limit in SQL after
+ordering by descending score and the deterministic tie-breaker, so rows beyond
+K do not reach the driver. PageRank still initializes and iterates over the
+entire visible induced graph; `topK` does not make the graph computation itself
+partial.
 
 Convergence needs roughly `ln(1/tolerance) / ln(1/dampingFactor)` rounds in the
 worst case. With the default `tolerance` and `maxIterations`, damping factors
@@ -409,6 +417,7 @@ const memberships =
   await store.algorithms.weaklyConnectedComponents({
     edges: ["knows", "worksAt"],
     nodeKinds: ["Person", "Company"], // optional; all kinds by default
+    minComponentSize: 2, // optional; singleton components are omitted
     maxIterations: 1000, // default
   });
 // [{ id, kind, componentId, componentKind, size }, ...]
@@ -419,6 +428,13 @@ binary ordering. Results and representatives are therefore deterministic on
 SQLite and PostgreSQL even when the PostgreSQL database uses a linguistic
 default collation. Edges are always treated as undirected—WCC has no
 `direction` option.
+
+`minComponentSize` is an inclusive positive safe-integer filter: a value of
+`2` returns every member of components containing two or more nodes, while a
+value of `1` preserves the default result. TypeGraph computes component sizes
+and filters memberships in extraction SQL, before rows reach the driver. The
+full visible induced graph is still processed to convergence, so the option
+bounds result materialization rather than WCC computation.
 
 WCC is iterative and runs multiple SQL rounds in one repeatable snapshot. It
 requires `backend.capabilities.graphAnalytics?.supported === true`; built-in

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2923,6 +2923,7 @@ type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeM
     dampingFactor?: number;
     tolerance?: number;
     maxIterations?: number;
+    topK?: number;
 }>;
 
 // @public
@@ -4956,6 +4957,7 @@ type WeaklyConnectedComponentMembership = Readonly<{
 type WeaklyConnectedComponentsOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeMemoryOptions & Readonly<{
     edges: readonly EdgeKinds<G>[];
     nodeKinds?: readonly NodeKinds<G>[];
+    minComponentSize?: number;
     maxIterations?: number;
 }>;
 

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -2986,6 +2986,7 @@ type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeM
     dampingFactor?: number;
     tolerance?: number;
     maxIterations?: number;
+    topK?: number;
 }>;
 
 // @public
@@ -4857,6 +4858,7 @@ type WeaklyConnectedComponentMembership = Readonly<{
 type WeaklyConnectedComponentsOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeMemoryOptions & Readonly<{
     edges: readonly EdgeKinds<G>[];
     nodeKinds?: readonly NodeKinds<G>[];
+    minComponentSize?: number;
     maxIterations?: number;
 }>;
 

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -2638,6 +2638,7 @@ type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeM
     dampingFactor?: number;
     tolerance?: number;
     maxIterations?: number;
+    topK?: number;
 }>;
 
 // @public
@@ -4540,6 +4541,7 @@ type WeaklyConnectedComponentMembership = Readonly<{
 type WeaklyConnectedComponentsOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeMemoryOptions & Readonly<{
     edges: readonly EdgeKinds<G>[];
     nodeKinds?: readonly NodeKinds<G>[];
+    minComponentSize?: number;
     maxIterations?: number;
 }>;
 

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -2570,6 +2570,7 @@ type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeM
     dampingFactor?: number;
     tolerance?: number;
     maxIterations?: number;
+    topK?: number;
 }>;
 
 // @public
@@ -4494,6 +4495,7 @@ type WeaklyConnectedComponentMembership = Readonly<{
 type WeaklyConnectedComponentsOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeMemoryOptions & Readonly<{
     edges: readonly EdgeKinds<G>[];
     nodeKinds?: readonly NodeKinds<G>[];
+    minComponentSize?: number;
     maxIterations?: number;
 }>;
 

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -2579,6 +2579,7 @@ type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeM
     dampingFactor?: number;
     tolerance?: number;
     maxIterations?: number;
+    topK?: number;
 }>;
 
 // @public
@@ -4491,6 +4492,7 @@ type WeaklyConnectedComponentMembership = Readonly<{
 type WeaklyConnectedComponentsOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeMemoryOptions & Readonly<{
     edges: readonly EdgeKinds<G>[];
     nodeKinds?: readonly NodeKinds<G>[];
+    minComponentSize?: number;
     maxIterations?: number;
 }>;
 

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -2658,6 +2658,7 @@ type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeM
     dampingFactor?: number;
     tolerance?: number;
     maxIterations?: number;
+    topK?: number;
 }>;
 
 // @public
@@ -4560,6 +4561,7 @@ type WeaklyConnectedComponentMembership = Readonly<{
 type WeaklyConnectedComponentsOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeMemoryOptions & Readonly<{
     edges: readonly EdgeKinds<G>[];
     nodeKinds?: readonly NodeKinds<G>[];
+    minComponentSize?: number;
     maxIterations?: number;
 }>;
 

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -4123,6 +4123,7 @@ export type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions & Ite
     dampingFactor?: number;
     tolerance?: number;
     maxIterations?: number;
+    topK?: number;
 }>;
 
 // @public
@@ -6525,6 +6526,7 @@ export type WeaklyConnectedComponentMembership = Readonly<{
 export type WeaklyConnectedComponentsOptions<G extends GraphDef> = TemporalAlgorithmOptions & IterativeMemoryOptions & Readonly<{
     edges: readonly EdgeKinds<G>[];
     nodeKinds?: readonly NodeKinds<G>[];
+    minComponentSize?: number;
     maxIterations?: number;
 }>;
 

--- a/packages/typegraph/src/store/algorithms/context.ts
+++ b/packages/typegraph/src/store/algorithms/context.ts
@@ -191,13 +191,23 @@ export function resolveMaxIterations(
   algorithm: string,
 ): number {
   const maxIterations = value ?? fallback;
-  if (!Number.isSafeInteger(maxIterations) || maxIterations < 1) {
+  assertPositiveSafeIntegerOption(maxIterations, algorithm, "maxIterations");
+  return maxIterations;
+}
+
+/** Validates an optional positive safe-integer algorithm option. */
+export function assertPositiveSafeIntegerOption(
+  value: number | undefined,
+  algorithm: string,
+  optionName: string,
+): void {
+  if (value === undefined) return;
+  if (!Number.isSafeInteger(value) || value < 1) {
     throw new ConfigurationError(
-      `${algorithm} maxIterations must be a positive safe integer, got ${String(maxIterations)}.`,
-      { maxIterations },
+      `${algorithm} ${optionName} must be a positive safe integer, got ${String(value)}.`,
+      { [optionName]: value },
     );
   }
-  return maxIterations;
 }
 
 export function assertEdgeKinds(edges: readonly string[]): void {

--- a/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
+++ b/packages/typegraph/src/store/algorithms/iterative-graph-operation.ts
@@ -136,16 +136,17 @@ export async function seedWorkingTableFromNodes(
   nodeKinds: readonly string[] | undefined,
   seedColumns: readonly WorkingTableNodeSeedColumn[],
 ): Promise<void> {
+  if (nodeKinds?.length === 0) return;
   const additionalColumns =
     seedColumns.length === 0 ?
-      sql``
+      sql.empty()
     : sql`, ${sql.join(
         seedColumns.map((column) => sql.identifier(column.name)),
         sql`, `,
       )}`;
   const additionalValues =
     seedColumns.length === 0 ?
-      sql``
+      sql.empty()
     : sql`, ${sql.join(
         seedColumns.map((column) => column.value),
         sql`, `,
@@ -167,12 +168,17 @@ export async function seedWorkingTableFromNodes(
     context.operation.backend.capabilities.maxBindParameters ??
     DEFAULT_MAX_BIND_PARAMETERS;
   const fixedParameterCount = countBindParameters(fixedStatement);
-  const kindChunkSize = parameterLimit - fixedParameterCount;
+  // The full-graph seed carries no kind binds and only has to fit; a scoped
+  // seed also needs room for at least one kind bind before it can be chunked.
+  const kindBindBudget = parameterLimit - fixedParameterCount;
+  if (kindBindBudget < (nodeKinds === undefined ? 0 : 1)) {
+    throw new ConfigurationError(
+      "An iterative graph operation cannot fit its node-kind initialization within the backend bind-parameter limit.",
+      { fixedParameterCount, parameterLimit },
+    );
+  }
 
   if (nodeKinds === undefined) {
-    if (kindChunkSize < 0) {
-      throw nodeKindBindBudgetError(fixedParameterCount, parameterLimit);
-    }
     await context.executeTemporary(fixedStatement);
     return;
   }
@@ -180,26 +186,11 @@ export async function seedWorkingTableFromNodes(
   const normalizedKinds = [...new Set(nodeKinds)].toSorted((left, right) =>
     compareCodePoints(left, right),
   );
-  if (normalizedKinds.length === 0) return;
-  if (kindChunkSize < 1) {
-    throw nodeKindBindBudgetError(fixedParameterCount, parameterLimit);
-  }
-
-  for (const kindChunk of chunkValues(normalizedKinds, kindChunkSize)) {
+  for (const kindChunk of chunkValues(normalizedKinds, kindBindBudget)) {
     await context.executeTemporary(
       compileSeedStatement(compileKindFilter(sql.raw("n.kind"), kindChunk)),
     );
   }
-}
-
-function nodeKindBindBudgetError(
-  fixedParameterCount: number,
-  parameterLimit: number,
-): ConfigurationError {
-  return new ConfigurationError(
-    "An iterative graph operation cannot fit its node-kind initialization within the backend bind-parameter limit.",
-    { fixedParameterCount, parameterLimit },
-  );
 }
 
 function countBindParameters(fragment: SqlFragment): number {

--- a/packages/typegraph/src/store/algorithms/page-rank.ts
+++ b/packages/typegraph/src/store/algorithms/page-rank.ts
@@ -6,6 +6,7 @@ import {
   type AlgorithmContext,
   assertEdgeKinds,
   assertGraphAnalyticsSupported,
+  assertPositiveSafeIntegerOption,
   type InternalTraversalOptions,
   pickTemporalOptions,
   resolveMaxIterations,
@@ -42,6 +43,7 @@ type ResolvedPageRankOptions = Readonly<{
   tolerance: number;
   maxIterations: number;
   nodeKinds: readonly string[] | undefined;
+  topK: number | undefined;
 }>;
 
 type PageRankAlgorithm = "pageRank" | "personalizedPageRank";
@@ -114,7 +116,8 @@ function executePageRankOperation<G extends GraphDef>(
     hasConverged(state) {
       return state.maximumChange <= resolved.tolerance;
     },
-    extractResult: extractScores,
+    extractResult: (context, state) =>
+      extractScores(context, state, resolved.topK),
   });
 }
 
@@ -142,6 +145,8 @@ function resolvePageRankOptions<G extends GraphDef>(
     );
   }
 
+  assertPositiveSafeIntegerOption(options.topK, algorithm, "topK");
+
   return {
     dampingFactor,
     tolerance,
@@ -151,6 +156,7 @@ function resolvePageRankOptions<G extends GraphDef>(
       algorithm,
     ),
     nodeKinds: options.nodeKinds,
+    topK: options.topK,
   };
 }
 
@@ -542,16 +548,19 @@ async function readMaximumChange(
 async function extractScores(
   context: IterativeGraphRunContext,
   state: IterationState,
+  topK: number | undefined,
 ): Promise<readonly PageRankScore[]> {
   const score = sql.identifier(state.activeScoreColumn);
   const nodeId = context.operation.ctx.dialect.binaryText(sql`node_id`);
   const nodeKind = context.operation.ctx.dialect.binaryText(sql`node_kind`);
+  const limitClause = topK === undefined ? sql.empty() : sql`LIMIT ${topK}`;
   const rows = await context.backend.execute<ScoreRow>(
     asCompiledRowsSql(sql`
       SELECT node_id, node_kind, ${score} AS score
       FROM ${context.workingTable}
       WHERE graph_id = ${context.graphId} AND run_id = ${context.runId}
       ORDER BY ${score} DESC, ${nodeId}, ${nodeKind}
+      ${limitClause}
     `),
   );
   return rows.map((row) => ({

--- a/packages/typegraph/src/store/algorithms/types.ts
+++ b/packages/typegraph/src/store/algorithms/types.ts
@@ -282,6 +282,11 @@ export type WeaklyConnectedComponentsOptions<G extends GraphDef> =
       edges: readonly EdgeKinds<G>[];
       /** Optional node kinds defining the induced subgraph to analyze. */
       nodeKinds?: readonly NodeKinds<G>[];
+      /**
+       * Return only components containing at least this many nodes. Must be a
+       * positive safe integer.
+       */
+      minComponentSize?: number;
       /** Maximum label-propagation rounds before throwing. Defaults to 1000. */
       maxIterations?: number;
     }>;
@@ -363,6 +368,11 @@ export type PageRankOptions<G extends GraphDef> = TemporalAlgorithmOptions &
     tolerance?: number;
     /** Maximum power-iteration rounds before throwing. Defaults to `1000`. */
     maxIterations?: number;
+    /**
+     * Return only the first this many scores after deterministic ordering.
+     * Must be a positive safe integer.
+     */
+    topK?: number;
   }>;
 
 export type InternalPageRankOptions<G extends GraphDef> =

--- a/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
+++ b/packages/typegraph/src/store/algorithms/weakly-connected-components.ts
@@ -5,6 +5,7 @@ import {
   type AlgorithmContext,
   assertEdgeKinds,
   assertGraphAnalyticsSupported,
+  assertPositiveSafeIntegerOption,
   type InternalTraversalOptions,
   pickTemporalOptions,
   resolveMaxIterations,
@@ -51,6 +52,11 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
     DEFAULT_WCC_MAX_ITERATIONS,
     "weaklyConnectedComponents",
   );
+  assertPositiveSafeIntegerOption(
+    options.minComponentSize,
+    "weaklyConnectedComponents",
+    "minComponentSize",
+  );
   const traversalOptions: InternalTraversalOptions = {
     edges: options.edges,
     direction: "both",
@@ -69,7 +75,8 @@ export async function executeWeaklyConnectedComponents<G extends GraphDef>(
     hasConverged(state) {
       return state.changedCount === 0;
     },
-    extractResult: extractMemberships,
+    extractResult: (context) =>
+      extractMemberships(context, options.minComponentSize),
   });
 }
 
@@ -232,24 +239,36 @@ function applyNextLabels(
 
 async function extractMemberships(
   context: IterativeGraphRunContext,
+  minComponentSize: number | undefined,
 ): Promise<readonly WeaklyConnectedComponentMembership[]> {
   const { operation } = context;
-  const componentId = operation.ctx.dialect.binaryText(sql`label_id`);
-  const componentKind = operation.ctx.dialect.binaryText(sql`label_kind`);
+  const labelId = operation.ctx.dialect.binaryText(sql`label_id`);
+  const labelKind = operation.ctx.dialect.binaryText(sql`label_kind`);
+  const componentId = operation.ctx.dialect.binaryText(sql`component_id`);
+  const componentKind = operation.ctx.dialect.binaryText(sql`component_kind`);
   const nodeId = operation.ctx.dialect.binaryText(sql`node_id`);
   const nodeKind = operation.ctx.dialect.binaryText(sql`node_kind`);
+  const componentSizeFilter =
+    minComponentSize === undefined ?
+      sql.empty()
+    : sql`WHERE component_size >= ${minComponentSize}`;
   const rows = await context.backend.execute<MembershipRow>(
     asCompiledRowsSql(sql`
-      SELECT
-        node_id,
-        node_kind,
-        label_id AS component_id,
-        label_kind AS component_kind,
-        COUNT(*) OVER (
-          PARTITION BY ${componentKind}, ${componentId}
-        ) AS component_size
-      FROM ${context.workingTable}
-      WHERE graph_id = ${context.graphId} AND run_id = ${context.runId}
+      WITH memberships AS (
+        SELECT
+          node_id,
+          node_kind,
+          label_id AS component_id,
+          label_kind AS component_kind,
+          COUNT(*) OVER (
+            PARTITION BY ${labelKind}, ${labelId}
+          ) AS component_size
+        FROM ${context.workingTable}
+        WHERE graph_id = ${context.graphId} AND run_id = ${context.runId}
+      )
+      SELECT node_id, node_kind, component_id, component_kind, component_size
+      FROM memberships
+      ${componentSizeFilter}
       ORDER BY ${componentId}, ${componentKind}, ${nodeId}, ${nodeKind}
     `),
   );

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -889,6 +889,81 @@ export function registerAlgorithmIntegrationTests(
         ]);
       });
 
+      it("filters whole components at inclusive size boundaries", async () => {
+        const store = context.getStore();
+        const [largeA, largeB, largeC, pairA, pairB, singleton] =
+          await Promise.all([
+            store.nodes.Person.create(
+              { name: "Large component A" },
+              { id: "wcc-size-a" },
+            ),
+            store.nodes.Person.create(
+              { name: "Large component B" },
+              { id: "wcc-size-b" },
+            ),
+            store.nodes.Person.create(
+              { name: "Large component C" },
+              { id: "wcc-size-c" },
+            ),
+            store.nodes.Person.create(
+              { name: "Pair component A" },
+              { id: "wcc-size-d" },
+            ),
+            store.nodes.Person.create(
+              { name: "Pair component B" },
+              { id: "wcc-size-e" },
+            ),
+            store.nodes.Person.create(
+              { name: "Singleton component" },
+              { id: "wcc-size-f" },
+            ),
+          ]);
+        await Promise.all([
+          store.edges.knows.create(largeA, largeB, {}),
+          store.edges.knows.create(largeB, largeC, {}),
+          store.edges.knows.create(pairA, pairB, {}),
+        ]);
+
+        const filtered = await store.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+          nodeKinds: ["Person"],
+          minComponentSize: 2,
+        });
+        expect(filtered.map((row) => [row.id, row.size])).toEqual([
+          ["wcc-size-a", 3],
+          ["wcc-size-b", 3],
+          ["wcc-size-c", 3],
+          ["wcc-size-d", 2],
+          ["wcc-size-e", 2],
+        ]);
+
+        const unbounded = await store.algorithms.weaklyConnectedComponents({
+          edges: ["knows"],
+          nodeKinds: ["Person"],
+        });
+        expect(unbounded.at(-1)).toEqual({
+          id: singleton.id,
+          kind: "Person",
+          componentId: singleton.id,
+          componentKind: "Person",
+          size: 1,
+        });
+        await expect(
+          store.algorithms.weaklyConnectedComponents({
+            edges: ["knows"],
+            nodeKinds: ["Person"],
+            minComponentSize: 1,
+          }),
+        ).resolves.toEqual(unbounded);
+        await expect(
+          store.algorithms.weaklyConnectedComponents({
+            edges: ["knows"],
+            nodeKinds: ["Person"],
+            minComponentSize: Number.MAX_SAFE_INTEGER,
+          }),
+        ).resolves.toEqual([]);
+      });
+
       it("preserves synchronous convergence across edge-kind chunks", async () => {
         const store = context.getStore();
         const [alpha, beta, gamma] = await Promise.all([
@@ -1306,6 +1381,105 @@ export function registerAlgorithmIntegrationTests(
         expect(byId.get(alpha.id)).toBeCloseTo(1 / normalization, 10);
         expect(byId.get(beta.id)).toBeCloseTo(0.85 / normalization, 10);
         expect(byId.get(gamma.id)).toBeCloseTo(0.85 ** 2 / normalization, 10);
+      });
+
+      it("applies topK after deterministic tie ordering", async () => {
+        const store = context.getStore();
+        const [alpha, beta] = await Promise.all([
+          store.nodes.Person.create(
+            { name: "Rank tie alpha" },
+            { id: "rank-tie-a" },
+          ),
+          store.nodes.Person.create(
+            { name: "Rank tie beta" },
+            { id: "rank-tie-b" },
+          ),
+          store.nodes.Person.create(
+            { name: "Rank tie gamma" },
+            { id: "rank-tie-c" },
+          ),
+        ]);
+
+        const unbounded = await store.algorithms.pageRank({
+          edges: ["knows"],
+          nodeKinds: ["Person"],
+          dampingFactor: 0,
+        });
+        await expect(
+          store.algorithms.pageRank({
+            edges: ["knows"],
+            nodeKinds: ["Person"],
+            dampingFactor: 0,
+            topK: Number.MAX_SAFE_INTEGER,
+          }),
+        ).resolves.toEqual(unbounded);
+        const topTwo = await store.algorithms.pageRank({
+          edges: ["knows"],
+          nodeKinds: ["Person"],
+          dampingFactor: 0,
+          topK: 2,
+        });
+        expect(topTwo).toEqual(unbounded.slice(0, 2));
+        expect(topTwo.map((row) => row.id)).toEqual([
+          "rank-tie-a",
+          "rank-tie-b",
+        ]);
+
+        const personalized = await store.algorithms.personalizedPageRank({
+          edges: ["knows"],
+          nodeKinds: ["Person"],
+          dampingFactor: 0,
+          seeds: [
+            { id: alpha.id, kind: "Person" },
+            { id: beta.id, kind: "Person" },
+          ],
+          topK: 1,
+        });
+        expect(personalized).toEqual([
+          { id: alpha.id, kind: "Person", score: 0.5 },
+        ]);
+      });
+
+      it("rejects invalid bounded-result options with typed errors", async () => {
+        const store = context.getStore();
+        const invalidBounds = [
+          0,
+          -1,
+          1.5,
+          Number.NaN,
+          Number.POSITIVE_INFINITY,
+          Number.MAX_SAFE_INTEGER + 1,
+        ];
+
+        for (const topK of invalidBounds) {
+          await expect(
+            store.algorithms.pageRank({ edges: ["knows"], topK }),
+          ).rejects.toMatchObject({
+            code: "CONFIGURATION_ERROR",
+            details: { topK },
+          });
+          await expect(
+            store.algorithms.personalizedPageRank({
+              edges: ["knows"],
+              seeds: [{ id: "unused", kind: "Person" }],
+              topK,
+            }),
+          ).rejects.toMatchObject({
+            code: "CONFIGURATION_ERROR",
+            details: { topK },
+          });
+        }
+        for (const minComponentSize of invalidBounds) {
+          await expect(
+            store.algorithms.weaklyConnectedComponents({
+              edges: ["knows"],
+              minComponentSize,
+            }),
+          ).rejects.toMatchObject({
+            code: "CONFIGURATION_ERROR",
+            details: { minComponentSize },
+          });
+        }
       });
 
       it("preserves physical-edge and self-loop weights across chunking", async () => {

--- a/packages/typegraph/tests/backends/integration/algorithms.ts
+++ b/packages/typegraph/tests/backends/integration/algorithms.ts
@@ -258,6 +258,9 @@ export function registerAlgorithmIntegrationTests(
       const boundaryDuplicateKind = requireDefined(
         nodeKindInitializationKinds[NODE_KIND_INITIALIZATION_CHUNK_SIZE - 1],
       );
+      // The duplicated kind needs a node of its own: the straddling chunks
+      // only collide on the working table's primary key if the repeated kind
+      // actually selects a row.
       const [firstNode] = await Promise.all([
         requireDefined(store.nodes[firstKind]).create({ name: "First" }),
         requireDefined(store.nodes[lastKind]).create({ name: "Last" }),


### PR DESCRIPTION
- add positive-safe-integer `topK` to PageRank and Personalized PageRank
- add inclusive positive-safe-integer `minComponentSize` to weakly connected components
- apply both bounds in extraction SQL, preserving full-graph computation, existing row shapes, defaults, and deterministic ordering
- document the result-materialization boundary and add shared SQLite/PostgreSQL semantic coverage for ties, inclusive boundaries, defaults, and invalid values

Closes #360.
