### PR TITLE
feat(graph-merge): stage cascade retractions with their derived cause

### DIFF
--- a/.changeset/cascaded-retract-staging.md
+++ b/.changeset/cascaded-retract-staging.md
@@ -1,0 +1,25 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+graph-merge: stage cascade retractions with their cause instead of inferring intent
+
+A node soft-delete ends every open identity assertion touching the node, so a
+branch that deletes a node stages retractions it never asked for. The merge
+previously separated those cascade endings from a branch's own retraction with
+a conservative branch-level heuristic, which deliberately over-dropped the
+same-branch case: a branch that retracted an assertion and LATER deleted one of
+its endpoints looked exactly like a pure cascade, so its retraction was dropped
+whenever the deletion was overruled — silently keeping truth the branch had
+explicitly ended.
+
+The soft-delete cascade now ends assertions at the deleted node's own
+`deleted_at`, which makes the cause derivable: the state-diff compares each
+retracted assertion's end instant to the deletion instants of its endpoints and
+stages the retraction as either a cascade naming the deleted node or the
+branch's own act. The merge planner drops a retraction only when EVERY branch
+staged it as the cascade of a deletion that delete/modify resolution then
+overruled, so an explicit retraction survives even when it comes from the
+deleting branch. Two cases stay conservative because nothing distinguishes them
+at the stored resolution — a hard delete (which removes the assertion rows) and
+a retraction issued in the same millisecond as the delete that followed it.

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -260,11 +260,16 @@ Duplicate current assertions use the earliest `validFrom`, then the
 code-point-smallest assertion ID — unless one candidate is already committed
 on the target with the exact staged truth, which always wins: the applier is
 idempotent per semantic pair, so a challenger could never actually be
-written. A node deletion cascades into ending the assertions touching it;
-when a delete/modify conflict resolution keeps the node, cascaded
-retractions whose every contributing branch is explained by the overruled
-deletion are dropped with it (reported as `identity:deletion-overruled`),
-while a branch that retracted independently keeps its effect. `merge()` detects identity conflicts at plan
+written. A node deletion cascades into ending the assertions touching it, at
+the node's own deletion instant — so the diff can tell which endings that
+deletion caused and stages each one with its cause. When a delete/modify
+conflict resolution keeps the node, an ending is dropped along with the
+overruled deletion that caused it (reported as
+`identity:deletion-overruled`), while a retraction a branch made itself
+survives the deletion being overruled — including one the deleting branch
+made before deleting the node. A hard delete removes the assertion rows
+outright, leaving nothing to separate cause from intent, so those endings
+count as cascades. `merge()` detects identity conflicts at plan
 time and returns them as a typed `IdentityMergeConflictError` — direct
 opposing relations on one endpoint pair, transitive contradictions reached
 through a chain of `same` assertions no single branch wrote, retract/reassert

--- a/packages/typegraph/src/graph-merge/delete-modify.ts
+++ b/packages/typegraph/src/graph-merge/delete-modify.ts
@@ -39,7 +39,7 @@ import type {
   StagedModifiedNode,
   StagingSet,
 } from "./staging";
-import type { DeletedEdge, DeletedNode } from "./state-diff";
+import type { DeletedEdge } from "./state-diff";
 import type {
   EdgeId,
   GraphDef,
@@ -58,6 +58,8 @@ import type {
 
 /** A node id in its untyped (`NodeType`-default) branded form. */
 type AnyNodeId = NodeId<NodeType>;
+/** The `(kind, id)` of a node the delete/modify resolution finally deletes. */
+type DeletedNodeRef = Readonly<{ id: AnyNodeId; kind: string }>;
 type BranchTagged = Readonly<{ branchId: BranchId }>;
 
 /** Reason recorded on a {@link DroppedItem} for a finally-deleted node. */
@@ -74,6 +76,9 @@ export const DELETED_NODE_DROP_REASON = "delete-modify:deleteWins" as const;
  * - `nodeDeletions`: the AUTHORITATIVE set of inherited nodes that are finally
  *   deleted — pure deletions (no branch modified them) plus delete/modify
  *   conflicts resolved `"deleteWins"`. T9 reads this as the endpoint liveness.
+ *   Entries are the surviving deletion's `(kind, id)` only: a staged deletion
+ *   additionally records WHEN its branch removed the node, which is per-branch
+ *   evidence rather than a merge outcome.
  * - `conflicts`: one {@link DeleteModifyConflict} per inherited node that was
  *   both deleted and modified.
  * - `dropped`: a `{ kind: "node" }` {@link DroppedItem} for every finally-deleted
@@ -81,7 +86,7 @@ export const DELETED_NODE_DROP_REASON = "delete-modify:deleteWins" as const;
  */
 export type DeleteModifyResolution = Readonly<{
   survivingModifications: readonly StagedModifiedNode[];
-  nodeDeletions: readonly DeletedNode[];
+  nodeDeletions: readonly DeletedNodeRef[];
   conflicts: readonly DeleteModifyConflict[];
   dropped: readonly DroppedItem[];
 }>;

--- a/packages/typegraph/src/graph-merge/merge-identity.ts
+++ b/packages/typegraph/src/graph-merge/merge-identity.ts
@@ -271,13 +271,17 @@ export const RETRACTION_TARGET_MISMATCH_DROP_REASON =
   "identity:retraction-target-mismatch";
 
 /**
- * Reason recorded when a staged retraction touched a node whose deletion the
- * delete/modify resolution OVERRULED. A node soft-delete cascades — it ends
- * every open assertion touching the node — so the deleting branch's diff
- * stages those endings as retractions indistinguishable from intent. When the
- * modification wins and the node survives, applying the cascaded retraction
- * would end the resurrected node's assertions anyway; dropping it (visibly)
- * keeps the node's identity truth alongside the node.
+ * Reason recorded when EVERY branch that staged a retraction staged it as the
+ * cascade of a node deletion the delete/modify resolution then OVERRULED.
+ *
+ * A node soft-delete ends every open assertion touching the node, so the
+ * deleting branch's diff stages those endings as retractions — but it stages
+ * them with their derived cause (the deleted node), not as bare retractions.
+ * When the modification wins and the node survives, the cause is gone: applying
+ * the ending would strip the resurrected node's identity truth, so it is
+ * dropped (visibly) along with the deletion that caused it. A retraction any
+ * branch made EXPLICITLY, or whose cause deletion survived, is never dropped
+ * here.
  */
 export const RETRACTION_DELETION_OVERRULED_DROP_REASON =
   "identity:deletion-overruled";

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -126,6 +126,7 @@ import type {
   StagedModifiedNode,
   StagedNewEdge,
   StagedNewNode,
+  StagedRetraction,
   StagingSet,
 } from "./staging";
 import { stageBranches } from "./staging";
@@ -941,76 +942,55 @@ function planMerge<G extends GraphDef>(
     nodeDeletions.set(mergeKey(deletion.kind, deletion.id), deletion.kind);
   }
   // A node soft-delete CASCADES: it ends every open assertion touching the
-  // node, so the deleting branch's diff stages those endings as identity
-  // retractions with no marker distinguishing cascade from intent. When the
-  // delete/modify resolution OVERRULES the deletion ("flag"/"modifyWins"
-  // keep the modification), applying the cascaded retraction would end the
-  // resurrected node's assertions anyway — the losing deletion's side effect
-  // outliving the decision. Drop retractions touching an overruled deletion,
-  // visibly, so the node survives WITH its identity truth.
-  const overruledDeletions = new Set<MergeKey>(
-    staging.deletedNodes
-      .map((deletion) => mergeKey(deletion.node.kind, deletion.node.id))
-      .filter((key) => !nodeDeletions.has(key)),
+  // node, at the node's own deletion instant. The diff derives that cause and
+  // stages the ending as a `cascade` retraction naming the deleted node
+  // (StagedRetraction.cause); every other ending is the branch's own act and is
+  // staged `explicit`.
+  //
+  // A cascade's fate therefore belongs to the deletion that caused it. When the
+  // delete/modify resolution OVERRULES that deletion ("flag"/"modifyWins" keep
+  // the modification), applying the ending anyway would let the losing
+  // deletion's side effect outlive the decision and strip the resurrected
+  // node's identity truth — so the ending is dropped with its cause, visibly.
+  // A retraction survives as soon as ONE branch staged it explicitly, or one
+  // cause deletion survived: those are intents the deletion decision does not
+  // speak to.
+  const anyDeletionOverruled = staging.deletedNodes.some(
+    (deletion) =>
+      !nodeDeletions.has(mergeKey(deletion.node.kind, deletion.node.id)),
   );
-  // Provenance decides which retractions are cascade artifacts. A retraction
-  // is dropped ONLY when every branch that staged it can be explained as
-  // "cascade of an overruled deletion": that branch deleted an endpoint of
-  // the assertion, and every endpoint it deleted was overruled. A contributor
-  // that deleted NO endpoint retracted independently — its intent survives —
-  // and a contributor whose endpoint deletion SURVIVED has a legitimate
-  // cascade. (A branch that explicitly retracted and then deleted the same
-  // endpoint is indistinguishable from a pure cascade in a snapshot diff;
-  // the conservative drop-and-report stands for that narrower ambiguity.)
-  const deletionsByBranch = new Map<BranchId, Set<MergeKey>>();
-  for (const deletion of staging.deletedNodes) {
-    const key = mergeKey(deletion.node.kind, deletion.node.id);
-    const keys =
-      deletionsByBranch.get(deletion.branchId) ?? new Set<MergeKey>();
-    keys.add(key);
-    deletionsByBranch.set(deletion.branchId, keys);
-  }
-  const retractionContributors = new Map<string, Set<BranchId>>();
+  const stagedRetractionsById = new Map<string, StagedRetraction[]>();
   for (const staged of staging.retractedIdentityAssertions) {
-    const contributors =
-      retractionContributors.get(staged.assertion.id) ?? new Set<BranchId>();
-    contributors.add(staged.branchId);
-    retractionContributors.set(staged.assertion.id, contributors);
+    const contributions = stagedRetractionsById.get(staged.assertion.id) ?? [];
+    contributions.push(staged);
+    stagedRetractionsById.set(staged.assertion.id, contributions);
   }
   const overruledRetractionDrops: DroppedItem[] = [];
   const survivingRetractions =
-    overruledDeletions.size === 0 ?
-      identity.retractions
-    : identity.retractions.filter((retraction) => {
-        const endpointKeys = [
-          mergeKey(retraction.a.kind, retraction.a.id),
-          mergeKey(retraction.b.kind, retraction.b.id),
-        ];
-        if (!endpointKeys.some((key) => overruledDeletions.has(key))) {
-          return true;
-        }
-        const contributors = retractionContributors.get(retraction.id);
-        const cascadeOnly =
-          contributors !== undefined &&
-          [...contributors].every((branchId) => {
-            const deleted = deletionsByBranch.get(branchId);
-            if (deleted === undefined) return false;
-            const deletedEndpoints = endpointKeys.filter((key) =>
-              deleted.has(key),
-            );
-            return (
-              deletedEndpoints.length > 0 &&
-              deletedEndpoints.every((key) => !nodeDeletions.has(key))
-            );
-          });
-        if (!cascadeOnly) return true;
+    anyDeletionOverruled ?
+      identity.retractions.filter((retraction) => {
+        const contributions = stagedRetractionsById.get(retraction.id) ?? [];
+        const everyContributionOverruled =
+          contributions.length > 0 &&
+          contributions.every(
+            (staged) =>
+              staged.cause.kind === "cascade" &&
+              !nodeDeletions.has(
+                mergeKey(
+                  staged.cause.deletedNode.kind,
+                  staged.cause.deletedNode.id,
+                ),
+              ),
+          );
+        if (!everyContributionOverruled) return true;
         overruledRetractionDrops.push({
           kind: "identity",
           id: retraction.id,
           reason: RETRACTION_DELETION_OVERRULED_DROP_REASON,
         });
         return false;
-      });
+      })
+    : identity.retractions;
   for (const modification of deleteModify.survivingModifications) {
     recordProvenance(
       "node",

--- a/packages/typegraph/src/graph-merge/staging.ts
+++ b/packages/typegraph/src/graph-merge/staging.ts
@@ -35,6 +35,7 @@ import type {
   DeletedNode,
   ModifiedEdge,
   ModifiedNode,
+  RetractionCause,
 } from "./state-diff";
 import { diffAgainstBase } from "./state-diff";
 import type {
@@ -87,6 +88,19 @@ export type StagedIdentityAssertion = Readonly<{
 }>;
 
 /**
+ * A retracted assertion tagged with the branch that stopped asserting it AND
+ * with WHY it stopped ({@link RetractionCause}).
+ *
+ * A `cascade` entry is the staged form of "branch X's deletion of node N ended
+ * this assertion" — its fate belongs to that deletion, so delete/modify
+ * resolution decides it: applied when the deletion survives, dropped with the
+ * deletion when it is overruled. An `explicit` entry is the branch's own intent
+ * and outlives any deletion decision.
+ */
+export type StagedRetraction = StagedIdentityAssertion &
+  Readonly<{ cause: RetractionCause }>;
+
+/**
  * The provenance-tagged union of every branch's state-diff against the base.
  *
  * New items are bucketed by kind so downstream blocking/candidate-gen (T5/T6)
@@ -107,7 +121,7 @@ export type StagingSet = Readonly<{
   /** Deleted inherited edges (one entry per (id, branch) deletion). */
   deletedEdges: readonly StagedDeletedEdge[];
   newIdentityAssertions: readonly StagedIdentityAssertion[];
-  retractedIdentityAssertions: readonly StagedIdentityAssertion[];
+  retractedIdentityAssertions: readonly StagedRetraction[];
   /**
    * Every assertion CURRENT in the base store at staging time — the inherited
    * truth the branches forked from. Untagged (it belongs to no branch). The
@@ -220,7 +234,7 @@ export async function stageBranches<G extends GraphDef>(
     [];
   const deletedEdges: (StagedDeletedEdge & { kind: string; id: string })[] = [];
   const newIdentityAssertions: StagedIdentityAssertion[] = [];
-  const retractedIdentityAssertions: StagedIdentityAssertion[] = [];
+  const retractedIdentityAssertions: StagedRetraction[] = [];
 
   const baseIdentityAssertions =
     await storeRuntime(baseStore).readCurrentIdentityAssertions("state");
@@ -260,8 +274,12 @@ export async function stageBranches<G extends GraphDef>(
     for (const assertion of diff.identity.new) {
       newIdentityAssertions.push({ branchId, assertion });
     }
-    for (const assertion of diff.identity.retracted) {
-      retractedIdentityAssertions.push({ branchId, assertion });
+    for (const retraction of diff.identity.retracted) {
+      retractedIdentityAssertions.push({
+        branchId,
+        assertion: retraction.assertion,
+        cause: retraction.cause,
+      });
     }
   }
 

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -42,7 +42,11 @@ import type {
   Store,
   TransactionBackend,
 } from "./typegraph-internal";
-import { getEdgeKinds, getNodeKinds } from "./typegraph-internal";
+import {
+  canonicalizeDatabaseTimestamp,
+  getEdgeKinds,
+  getNodeKinds,
+} from "./typegraph-internal";
 import { storeBackend, storeRuntime } from "./typegraph-internal";
 
 /**
@@ -113,7 +117,57 @@ export type ChangedNode = Readonly<{
 export type DeletedNode = Readonly<{
   id: NodeId<NodeType>;
   kind: string;
+  /**
+   * The instant the fork soft-deleted the node, read from its own row, or
+   * `undefined` when the fork carries no row at all (a HARD delete, which
+   * removes the row rather than tombstoning it).
+   *
+   * This is the deleting event's instant, and the soft-delete cascade ends the
+   * node's open identity assertions at exactly it (see `detachIdentityForNode`),
+   * which is what lets {@link RetractionCause} tell a cascade ending apart from
+   * an explicit retraction.
+   */
+  deletedAt: string | undefined;
 }>;
+
+/** A node reference naming the endpoint whose deletion cascaded. */
+type CascadeCauseNode = Readonly<{ kind: string; id: string }>;
+
+/**
+ * Why an assertion stopped being current in the fork.
+ *
+ * `cascade` is DERIVED, not guessed: a node soft-delete ends every open
+ * assertion touching that node at the node's own `deleted_at`, so an ended
+ * assertion whose `valid_to` equals a deleted endpoint's `deleted_at` was ended
+ * BY that deletion. An assertion the fork retracted explicitly carries its own
+ * EARLIER end instant and does not match — including the same-branch
+ * retract-then-delete sequence, where the explicit retraction closed the row
+ * before the delete ran, so the cascade never touched it.
+ *
+ * Two cases are genuinely undecidable and resolve to `cascade`, the
+ * conservative side (a dropped ending keeps identity truth; a wrongly kept one
+ * destroys it):
+ *
+ *   - a HARD delete physically removes every assertion row touching the node,
+ *     erasing the end instant along with any earlier explicit retraction of the
+ *     same row — a hard delete is then the only thing that can have produced
+ *     the retraction;
+ *   - an explicit retraction in the SAME MILLISECOND as the delete that
+ *     followed it is indistinguishable from the cascade at the stored
+ *     timestamps' resolution.
+ */
+export type RetractionCause =
+  | Readonly<{ kind: "explicit" }>
+  | Readonly<{ kind: "cascade"; deletedNode: CascadeCauseNode }>;
+
+/** An assertion the fork stopped asserting, with the cause of its ending. */
+export type RetractedAssertion = Readonly<{
+  assertion: IdentityTransferAssertion;
+  cause: RetractionCause;
+}>;
+
+/** The `explicit` cause — a single shared value; the variant carries no data. */
+const EXPLICIT_RETRACTION: RetractionCause = { kind: "explicit" };
 
 /** An edge present and live only on one side of the diff. */
 export type ChangedEdge = Readonly<{
@@ -168,10 +222,14 @@ export type StateDiff = Readonly<{
    * the ledger's own {@link IdentityTransferAssertion} shape — the same
    * records the merge commit hands back to the identity import — so the diff
    * never re-declares (and can never drift from) the assertion contract.
+   *
+   * Each retraction additionally carries its {@link RetractionCause}, so the
+   * merge planner can tie a cascade ending's fate to the deletion that caused
+   * it instead of inferring intent from branch-level provenance.
    */
   identity: Readonly<{
     new: readonly IdentityTransferAssertion[];
-    retracted: readonly IdentityTransferAssertion[];
+    retracted: readonly RetractedAssertion[];
   }>;
   /**
    * `(kind, id) -> version` for every fork-store node observed during this diff
@@ -334,7 +392,14 @@ function diffNodeKind(
     }
     const forkRow = forkIndex.get(baseRow.id);
     if (forkRow === undefined || !isLive(forkRow)) {
-      deleted.push({ id: baseRow.id as NodeId<NodeType>, kind });
+      deleted.push({
+        id: baseRow.id as NodeId<NodeType>,
+        kind,
+        deletedAt:
+          forkRow === undefined ? undefined : (
+            canonicalizeDatabaseTimestamp(forkRow.deleted_at)
+          ),
+      });
     }
   }
 
@@ -407,6 +472,87 @@ function diffEdgeKind(
   }
 
   return { new: created, modified, deleted };
+}
+
+/**
+ * Classifies ONE retracted assertion against this fork's node deletions.
+ *
+ * The rule is the derivation documented on {@link RetractionCause}, evaluated
+ * endpoint-first in `(a, b)` order so a retraction whose BOTH endpoints were
+ * deleted at the same instant names a deterministic cause:
+ *
+ *   - a soft-deleted endpoint whose `deleted_at` equals the assertion's end
+ *     instant in the fork ended it — `cascade`. An end instant STRICTLY BEFORE
+ *     the deletion cannot have come from it, so it is the branch's own act;
+ *   - a hard-deleted endpoint (no fork row) with no surviving assertion row to
+ *     read an end instant from can only have ended it — `cascade`;
+ *   - anything else the fork did to the assertion was its own act —
+ *     `explicit`.
+ *
+ * @param forkEndInstants End instant per assertion id as stored in the FORK,
+ *   from the fork's archival ledger read. A missing entry means the fork has no
+ *   row for that id at all (hard-deleted, or replaced under the same id).
+ */
+function classifyRetraction(
+  assertion: IdentityTransferAssertion,
+  deletedByKey: ReadonlyMap<MergeKey, DeletedNode>,
+  forkEndInstants: ReadonlyMap<string, string | undefined>,
+): RetractionCause {
+  const forkEndInstant = forkEndInstants.get(assertion.id);
+  const hasForkRow = forkEndInstants.has(assertion.id);
+  for (const endpoint of [assertion.a, assertion.b]) {
+    const deletion = deletedByKey.get(mergeKey(endpoint.kind, endpoint.id));
+    if (deletion === undefined) {
+      continue;
+    }
+    const endedByThisDeletion =
+      deletion.deletedAt === undefined ?
+        !hasForkRow
+      : forkEndInstant === deletion.deletedAt;
+    if (endedByThisDeletion) {
+      return {
+        kind: "cascade",
+        deletedNode: { kind: deletion.kind, id: deletion.id },
+      };
+    }
+  }
+  return EXPLICIT_RETRACTION;
+}
+
+/**
+ * Classifies every retraction in one fork.
+ *
+ * The fork's ARCHIVAL ledger (current rows plus ended ones) is read only when a
+ * cascade is possible at all — a fork that deleted no node, or retracted
+ * nothing, cannot have produced one, and the read is a full table scan of the
+ * fork's assertions.
+ */
+async function classifyRetractions<G extends GraphDef>(
+  forkStore: Store<G>,
+  retracted: readonly IdentityTransferAssertion[],
+  deletedNodes: readonly DeletedNode[],
+): Promise<readonly RetractedAssertion[]> {
+  if (retracted.length === 0 || deletedNodes.length === 0) {
+    return retracted.map((assertion) => ({
+      assertion,
+      cause: EXPLICIT_RETRACTION,
+    }));
+  }
+  const deletedByKey = new Map<MergeKey, DeletedNode>(
+    deletedNodes.map((deletion) => [
+      mergeKey(deletion.kind, deletion.id),
+      deletion,
+    ]),
+  );
+  const forkArchival =
+    await storeRuntime(forkStore).readCurrentIdentityAssertions("archival");
+  const forkEndInstants = new Map<string, string | undefined>(
+    forkArchival.map((assertion) => [assertion.id, assertion.validTo]),
+  );
+  return retracted.map((assertion) => ({
+    assertion,
+    cause: classifyRetraction(assertion, deletedByKey, forkEndInstants),
+  }));
 }
 
 /** Stable id-ascending comparator over any `{ id: string }`. */
@@ -530,6 +676,28 @@ export async function diffAgainstBase<G extends GraphDef>(
     }
   }
 
+  // Ids present on BOTH sides are compared by COMPLETE truth, not presence: a
+  // fork can hard-delete an assertion's endpoint (physically removing the row),
+  // recreate it, and legally import the same id for different truth. Presence-
+  // only comparison would diff that replacement as empty and the merge would
+  // silently keep the base truth. A shared id with changed truth surfaces as
+  // BOTH retracted (the base row) and new (the fork row), so planning sees the
+  // replacement and can refuse unsupported id reuse as a typed conflict.
+  const retractedAssertions = baseIdentity
+    .filter((assertion) => {
+      const fork = forkIdentityById.get(assertion.id);
+      return (
+        fork === undefined ||
+        assertionTruthKey(fork) !== assertionTruthKey(assertion)
+      );
+    })
+    .toSorted((left, right) => compareStrings(left.id, right.id));
+  const classifiedRetractions = await classifyRetractions(
+    forkStore,
+    retractedAssertions,
+    deletedNodes,
+  );
+
   return {
     nodes: {
       new: newNodes.sort((left, right) => byId(left, right)),
@@ -559,15 +727,7 @@ export async function diffAgainstBase<G extends GraphDef>(
           );
         })
         .toSorted((left, right) => compareStrings(left.id, right.id)),
-      retracted: baseIdentity
-        .filter((assertion) => {
-          const fork = forkIdentityById.get(assertion.id);
-          return (
-            fork === undefined ||
-            assertionTruthKey(fork) !== assertionTruthKey(assertion)
-          );
-        })
-        .toSorted((left, right) => compareStrings(left.id, right.id)),
+      retracted: classifiedRetractions,
     },
     forkNodeVersions,
     forkEdgeSignatures,

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -161,7 +161,7 @@ export type RetractionCause =
   | Readonly<{ kind: "cascade"; deletedNode: CascadeCauseNode }>;
 
 /** An assertion the fork stopped asserting, with the cause of its ending. */
-export type RetractedAssertion = Readonly<{
+type RetractedAssertion = Readonly<{
   assertion: IdentityTransferAssertion;
   cause: RetractionCause;
 }>;

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -48,5 +48,6 @@ export type { Store } from "../store/store";
 export { createStoreWithSchema } from "../store/store";
 export { type Edge, type Node } from "../store/types";
 export { compareCodePoints } from "../utils/compare";
+export { canonicalizeDatabaseTimestamp } from "../utils/date";
 export { sha256Hex } from "../utils/hash";
 export { generateId } from "../utils/id";

--- a/packages/typegraph/src/identity/service.ts
+++ b/packages/typegraph/src/identity/service.ts
@@ -2805,6 +2805,41 @@ async function hasMaterializedIdentityClass(
   return rows.length > 0;
 }
 
+/**
+ * Reads the instant a node was soft-deleted, as stored on its own row.
+ *
+ * The soft-delete cascade ends the node's open assertions AT THIS INSTANT
+ * rather than at a second wall-clock read, which makes "this assertion ended
+ * because its endpoint died" a derivable fact: a consumer comparing an ended
+ * assertion's `valid_to` to the endpoint's `deleted_at` sees equality exactly
+ * for cascade endings (graph-merge's state-diff does precisely this to tell a
+ * cascade apart from an explicit retraction). Two `nowIso()` reads inside one
+ * transaction can straddle a millisecond boundary, so the equality has to come
+ * from the stored value, not from a fresh clock read.
+ *
+ * Returns `undefined` when the row is gone or still live; callers fall back to
+ * their own instant.
+ */
+async function readNodeDeletionInstant(
+  target: Backend,
+  schema: SqlSchema,
+  graphId: string,
+  ref: PlainNodeRef,
+): Promise<string | undefined> {
+  const rows = await target.execute<Readonly<{ deleted_at: unknown }>>(
+    asCompiledRowsSql(sql`
+      SELECT deleted_at
+      FROM ${schema.nodesTable}
+      WHERE graph_id = ${graphId}
+        AND kind = ${ref.kind}
+        AND id = ${ref.id}
+      LIMIT 1
+    `),
+  );
+  const row = rows.at(0);
+  return row === undefined ? undefined : optionalTimestamp(row.deleted_at);
+}
+
 export async function detachIdentityForNode(
   ctx: Pick<
     IdentityServiceContext<GraphDef>,
@@ -2856,6 +2891,20 @@ export async function detachIdentityForNode(
       return;
     }
     const now = nowIso();
+    // A soft delete ends its node's open assertions at the node's OWN deletion
+    // instant (see readNodeDeletionInstant): the caller has already written
+    // `deleted_at` inside this transaction, and reusing it is what makes a
+    // cascade ending distinguishable from an explicit retraction downstream.
+    // The read is skipped when there is nothing to end.
+    const cascadeInstant =
+      mode === "hard" || rows.length === 0 ?
+        now
+      : ((await readNodeDeletionInstant(
+          rawTarget,
+          ctx.schema,
+          ctx.graphId,
+          ref,
+        )) ?? now);
     for (const rawRow of rows) {
       const row = normalizeAssertionRow(rawRow);
       if (mode === "hard") {
@@ -2868,7 +2917,7 @@ export async function detachIdentityForNode(
         );
         touch(ctx.graphId, row.id);
       } else {
-        const validTo = clampValidTo(now, row.valid_from);
+        const validTo = clampValidTo(cascadeInstant, row.valid_from);
         const ended = { ...row, valid_to: validTo, updated_at: now };
         await executeStatement(
           rawTarget,

--- a/packages/typegraph/tests/graph-merge/cascade-retraction.test.ts
+++ b/packages/typegraph/tests/graph-merge/cascade-retraction.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Cascade retractions as first-class staged operations.
+ *
+ * A node soft-delete ENDS every open identity assertion touching the node, so a
+ * branch that deletes a node produces retractions it never asked for. The merge
+ * has to tell those cascade endings apart from a branch's own retraction,
+ * because their fates differ: a cascade belongs to its deletion (dropped when
+ * delete/modify resolution overrules the deletion, applied when it survives),
+ * while an explicit retraction is intent the deletion decision does not speak
+ * to.
+ *
+ * The distinction is DERIVED, not guessed: the cascade ends assertions at the
+ * node's own `deleted_at`, so an ended assertion's end instant identifies what
+ * ended it. These tests pin both halves — the state-diff's per-assertion cause
+ * and the planner decision built on it — including the same-branch
+ * retract-then-delete sequence, which a branch-level provenance heuristic
+ * cannot separate from a pure cascade and therefore over-drops.
+ */
+import type { GraphBackend } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { RETRACTION_DELETION_OVERRULED_DROP_REASON } from "../../src/graph-merge/merge-identity";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import { diffAgainstBase } from "../../src/graph-merge/state-diff";
+import { asBranchId } from "../../src/graph-merge/types";
+import { asIdentityAssertionId } from "../../src/identity/types";
+import { importGraph } from "../../src/interchange";
+import { storeRuntime } from "../../src/store/runtime-port";
+import { requireDefined } from "../../src/utils/presence";
+import { backendMatrix, identityAssertionDocument } from "./test-utils";
+
+const Anchor = defineNode("Anchor", {
+  schema: z.object({ name: z.string() }),
+});
+
+const anchoredGraph = defineGraph({
+  id: "cascade_retraction",
+  nodes: { Anchor: { type: Anchor } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+
+/**
+ * Waits until the wall clock has left the current millisecond.
+ *
+ * Assertion end instants are stored at millisecond resolution, so a retraction
+ * issued in the SAME millisecond as the delete that follows it is
+ * indistinguishable from that delete's cascade (documented on
+ * `RetractionCause`, which resolves the tie conservatively). A test that means
+ * "the branch retracted, and LATER deleted" has to make the two acts separable
+ * — real branch edits are, back-to-back statements in a test are not.
+ */
+function nextMillisecond(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 2);
+  });
+}
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+const BRANCH_C = asBranchId("branch-c");
+
+describe.each(backendMatrix())("cascade retraction [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[];
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    const outcomes = await Promise.allSettled(
+      cleanups.toReversed().map((cleanup) => cleanup()),
+    );
+    const rejection = outcomes.find(
+      (outcome): outcome is PromiseRejectedResult =>
+        outcome.status === "rejected",
+    );
+    if (rejection !== undefined) {
+      throw rejection.reason instanceof Error ?
+          rejection.reason
+        : new Error(String(rejection.reason));
+    }
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  /** A fork point holding anchors a..d and no assertions. */
+  async function anchoredForkPoint() {
+    const [forkPoint] = await createStoreWithSchema(
+      anchoredGraph,
+      await makeBackend(),
+    );
+    for (const id of ["a", "b", "c", "d"]) {
+      await forkPoint.nodes.Anchor.create({ name: id }, { id });
+    }
+    return forkPoint;
+  }
+
+  function assertionDocument(
+    id: string,
+    a: string,
+    b: string,
+  ): Parameters<typeof importGraph>[1] {
+    return identityAssertionDocument("Anchor", id, a, b);
+  }
+
+  it("derives the cause of every retraction in a fork's diff", async () => {
+    // One fork, three assertions on the deleted endpoint b:
+    //   explicit-id  — retracted by the branch, THEN b was deleted;
+    //   cascade-id   — ended only by the deletion of b;
+    //   untouched-id — not touching b at all, still current.
+    // The first two are indistinguishable by branch provenance (one branch,
+    // one deletion, two retractions) and separable only by end instant.
+    const forkPoint = await anchoredForkPoint();
+    for (const [id, a, b] of [
+      ["explicit-id", "a", "b"],
+      ["cascade-id", "b", "c"],
+      ["untouched-id", "a", "d"],
+    ] as const) {
+      const imported = await importGraph(
+        forkPoint,
+        assertionDocument(id, a, b),
+        { onConflict: "skip" },
+      );
+      expect(imported.success).toBe(true);
+    }
+    const forkBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+    );
+    await forkBranch.store.identity.retractAssertion(
+      asIdentityAssertionId("explicit-id"),
+    );
+    await nextMillisecond();
+    await forkBranch.store.nodes.Anchor.delete("b" as never);
+
+    const diff = await diffAgainstBase(forkPoint, forkBranch.store);
+
+    expect(diff.identity.retracted.map((entry) => entry.assertion.id)).toEqual([
+      "cascade-id",
+      "explicit-id",
+    ]);
+    const causeById = new Map(
+      diff.identity.retracted.map((entry) => [entry.assertion.id, entry.cause]),
+    );
+    expect(causeById.get("cascade-id")).toEqual({
+      kind: "cascade",
+      deletedNode: { kind: "Anchor", id: "b" },
+    });
+    expect(causeById.get("explicit-id")).toEqual({ kind: "explicit" });
+  });
+
+  it("derives a cascade cause from a hard delete, which leaves no end instant", async () => {
+    // A hard delete removes the assertion ROWS along with the node, so no end
+    // instant survives to compare. Nothing but that delete can have removed
+    // them, so the cause is still exact.
+    const forkPoint = await anchoredForkPoint();
+    const imported = await importGraph(
+      forkPoint,
+      assertionDocument("cascade-id", "a", "b"),
+      { onConflict: "skip" },
+    );
+    expect(imported.success).toBe(true);
+    const forkBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+    );
+    await forkBranch.store.nodes.Anchor.hardDelete("b" as never);
+
+    const diff = await diffAgainstBase(forkPoint, forkBranch.store);
+
+    expect(requireDefined(diff.identity.retracted[0])).toMatchObject({
+      assertion: { id: "cascade-id" },
+      cause: { kind: "cascade", deletedNode: { kind: "Anchor", id: "b" } },
+    });
+    expect(
+      requireDefined(diff.nodes.deleted.find((deletion) => deletion.id === "b"))
+        .deletedAt,
+    ).toBeUndefined();
+  });
+
+  it("keeps a retraction the deleting branch made before deleting the node", async () => {
+    // Branch A retracts cascade-id EXPLICITLY and then deletes endpoint b —
+    // one branch, both acts. Branch C modifies b, so the deletion is
+    // overruled and b survives. A's retraction is not the deletion's side
+    // effect (it closed the row before the delete ran, at its own instant),
+    // so it must survive the deletion being overruled.
+    //
+    // Branch-level provenance cannot see this: A is the only contributor and
+    // it did delete an overruled endpoint, so the pre-#367 heuristic
+    // classified the retraction as cascade-only and dropped it, keeping truth
+    // A had explicitly ended.
+    const forkPoint = await anchoredForkPoint();
+    const imported = await importGraph(
+      forkPoint,
+      assertionDocument("cascade-id", "a", "b"),
+      { onConflict: "skip" },
+    );
+    expect(imported.success).toBe(true);
+    const retractThenDelete = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+    );
+    await retractThenDelete.store.identity.retractAssertion(
+      asIdentityAssertionId("cascade-id"),
+    );
+    await nextMillisecond();
+    await retractThenDelete.store.nodes.Anchor.delete("b" as never);
+    const modifyBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_C }),
+    );
+    await modifyBranch.store.nodes.Anchor.update("b" as never, {
+      name: "b-modified",
+    });
+
+    const result = await merge(forkPoint, [retractThenDelete, modifyBranch], {
+      branchOrder: [BRANCH_A, BRANCH_C],
+    });
+    if (isErr(result)) throw result.error;
+    expect(isOk(result)).toBe(true);
+    expect(result.data.deleteModifyConflicts.length).toBeGreaterThan(0);
+    // The node survives the overruled deletion; A's explicit retraction
+    // survives with it.
+    expect(await forkPoint.nodes.Anchor.getById("b" as never)).toMatchObject({
+      name: "b-modified",
+    });
+    const rows = await storeRuntime(forkPoint).identityAssertionRowsByIds([
+      "cascade-id",
+    ]);
+    expect(rows.get("cascade-id")?.validTo).toBeDefined();
+    expect(result.data.dropped.some((item) => item.id === "cascade-id")).toBe(
+      false,
+    );
+  });
+
+  it("keeps one branch's explicit retraction against another branch's cascade", async () => {
+    // Cross-branch provenance: branch A retracts cascade-id explicitly and
+    // then deletes b; branch B only deletes b, so it stages the SAME id as a
+    // pure cascade. Branch C modifies b, overruling both deletions.
+    //
+    // The id therefore reaches the planner with two DIFFERENT causes. One
+    // branch's cascade dying with its overruled deletion must not carry away
+    // the other branch's intent, so the retraction is applied. Branch-level
+    // provenance saw both contributors as "deleted an overruled endpoint" and
+    // dropped it.
+    const forkPoint = await anchoredForkPoint();
+    const imported = await importGraph(
+      forkPoint,
+      assertionDocument("cascade-id", "a", "b"),
+      { onConflict: "skip" },
+    );
+    expect(imported.success).toBe(true);
+    const retractBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+    );
+    await retractBranch.store.identity.retractAssertion(
+      asIdentityAssertionId("cascade-id"),
+    );
+    await nextMillisecond();
+    await retractBranch.store.nodes.Anchor.delete("b" as never);
+    const deleteBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_B }),
+    );
+    await deleteBranch.store.nodes.Anchor.delete("b" as never);
+    const modifyBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_C }),
+    );
+    await modifyBranch.store.nodes.Anchor.update("b" as never, {
+      name: "b-modified",
+    });
+
+    const result = await merge(
+      forkPoint,
+      [retractBranch, deleteBranch, modifyBranch],
+      { branchOrder: [BRANCH_A, BRANCH_B, BRANCH_C] },
+    );
+    if (isErr(result)) throw result.error;
+    expect(isOk(result)).toBe(true);
+    const rows = await storeRuntime(forkPoint).identityAssertionRowsByIds([
+      "cascade-id",
+    ]);
+    expect(rows.get("cascade-id")?.validTo).toBeDefined();
+    expect(result.data.dropped.some((item) => item.id === "cascade-id")).toBe(
+      false,
+    );
+  });
+
+  it("drops a hard-delete cascade when the deletion is overruled", async () => {
+    // The undecidable end of the derivation: a hard delete leaves nothing to
+    // separate cascade from intent, so the retraction is classified as the
+    // cascade it must be and dropped with the overruled deletion — keeping
+    // the resurrected node's identity truth.
+    const forkPoint = await anchoredForkPoint();
+    const imported = await importGraph(
+      forkPoint,
+      assertionDocument("cascade-id", "a", "b"),
+      { onConflict: "skip" },
+    );
+    expect(imported.success).toBe(true);
+    const deleteBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+    );
+    await deleteBranch.store.nodes.Anchor.hardDelete("b" as never);
+    const modifyBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_B }),
+    );
+    await modifyBranch.store.nodes.Anchor.update("b" as never, {
+      name: "b-modified",
+    });
+
+    const result = await merge(forkPoint, [deleteBranch, modifyBranch], {
+      branchOrder: [BRANCH_A, BRANCH_B],
+    });
+    if (isErr(result)) throw result.error;
+    expect(isOk(result)).toBe(true);
+    expect(result.data.dropped).toContainEqual({
+      kind: "identity",
+      id: "cascade-id",
+      reason: RETRACTION_DELETION_OVERRULED_DROP_REASON,
+    });
+    const rows = await storeRuntime(forkPoint).identityAssertionRowsByIds([
+      "cascade-id",
+    ]);
+    expect(rows.get("cascade-id")?.validTo).toBeUndefined();
+  });
+
+  it("applies a cascade whose deletion survives the merge", async () => {
+    // The other half of tying a cascade to its cause: nothing contests the
+    // deletion, so the node dies and the ending it caused is applied.
+    const forkPoint = await anchoredForkPoint();
+    const imported = await importGraph(
+      forkPoint,
+      assertionDocument("cascade-id", "a", "b"),
+      { onConflict: "skip" },
+    );
+    expect(imported.success).toBe(true);
+    const deleteBranch = unwrap(
+      await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+    );
+    await deleteBranch.store.nodes.Anchor.delete("b" as never);
+
+    const result = await merge(forkPoint, [deleteBranch], {
+      branchOrder: [BRANCH_A],
+    });
+    if (isErr(result)) throw result.error;
+    expect(isOk(result)).toBe(true);
+    expect(await forkPoint.nodes.Anchor.getById("b" as never)).toBeUndefined();
+    const rows = await storeRuntime(forkPoint).identityAssertionRowsByIds([
+      "cascade-id",
+    ]);
+    expect(rows.get("cascade-id")?.validTo).toBeDefined();
+    expect(result.data.dropped.some((item) => item.id === "cascade-id")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/typegraph/tests/graph-merge/identity-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-merge.test.ts
@@ -695,7 +695,12 @@ function stagingWithIdentityChanges(
     modifiedEdges: [],
     deletedEdges: [],
     newIdentityAssertions: newAssertions,
-    retractedIdentityAssertions: retractedAssertions,
+    // These fixtures stage no node deletion, so every retraction in them is a
+    // branch's own act — the cause a real diff would derive for it.
+    retractedIdentityAssertions: retractedAssertions.map((staged) => ({
+      ...staged,
+      cause: { kind: "explicit" } as const,
+    })),
     baseIdentityAssertions: retractedAssertions.map(
       (staged) => staged.assertion,
     ),


### PR DESCRIPTION
A node soft-delete ends every open identity assertion touching the node, so a branch that deletes a node stages retractions it never asked for. The merge has to tell those cascade endings apart from a branch's own retraction, because their fates differ: a cascade belongs to the deletion that caused it, while an explicit retraction is intent the deletion decision does not speak to.

The planner separated them with a branch-level heuristic — drop a retraction only when every contributing branch had deleted an endpoint and every endpoint it deleted was overruled — which deliberately over-dropped the same-branch retract-then-delete case. That branch is the retraction's only contributor and did delete an overruled endpoint, so its explicit retraction was dropped and the truth it had ended stayed alive.

This PR replaces the heuristic with the derivation the issue describes: the cascade ends assertions at the deleting event's instant, so the diff can name what ended each assertion.

## How

- **identity** (`detachIdentityForNode`): the soft-delete cascade now ends assertions at the deleted node's OWN `deleted_at`, read back inside the same transaction, instead of at a second wall-clock read. Two `nowIso()` calls can straddle a millisecond boundary, so the equality that identifies a cascade must come from the stored value. The read is skipped when the node has no open assertions.
- **state-diff**: `DeletedNode` carries `deletedAt` (`undefined` for a hard delete, which leaves no row), and every retraction is classified against the fork's archival ledger into a `RetractionCause` — `cascade` naming the deleted node, or `explicit`. The archival read only happens for forks that both deleted a node and retracted something.
- **staging**: retractions stage as `StagedRetraction`, carrying that cause next to the branch tag — the `CascadedRetract(id, truth, cause)` shape from the issue, with the branch supplied by the existing tag.
- **merge**: `overruledDeletions` / `retractionContributors` / `cascadeOnly` collapse into "drop only when EVERY staged contribution is a cascade whose cause deletion was overruled". `DeleteModifyResolution.nodeDeletions` narrows to the surviving deletion's `(kind, id)`: when a node died is per-branch evidence, not a merge outcome.

Two cases stay conservative because nothing distinguishes them at the stored resolution, both documented on `RetractionCause`: a **hard delete** (removes the assertion rows outright, erasing any earlier explicit retraction with them) and a retraction issued in the **same millisecond** as the delete that followed it. Both classify as `cascade` — a dropped ending keeps identity truth, a wrongly kept one destroys it.

## Pinned behavior

No pin flipped in place. Both existing pins in `identity-universe-guards.test.ts` — "keeps identity truth when a modification overrules a deletion" and "keeps an explicit retraction when a third branch overrules the deletion" — pass unchanged: exact provenance reaches the same verdicts the heuristic reached for the cases it got right. The behavior change is the previously-dropped case becoming a keep, covered by new tests.

## Tests (`tests/graph-merge/cascade-retraction.test.ts`, SQLite + PGlite + Postgres)

Load-bearing (verified failing against the reverted planner block):

- *keeps a retraction the deleting branch made before deleting the node* — the false drop the issue documents.
- *keeps one branch's explicit retraction against another branch's cascade* — one id staged with two different causes; the overruled cascade dies without carrying away the other branch's intent.

Regression guards that hold under both rules:

- *drops a hard-delete cascade when the deletion is overruled* (both rules drop).
- *applies a cascade whose deletion survives the merge*.
- two diff-level tests pinning the derived cause directly, including the hard-delete arm.

The diff-level tests advance the clock past the current millisecond between retract and delete: back-to-back statements land in the same millisecond and would exercise the documented conservative tie rather than the case under test.


Closes #367
