### PR TITLE
feat(identity): assert affected-class consistency inside the merge commit transaction

### DIFF
--- a/.changeset/tricky-jars-repeat.md
+++ b/.changeset/tricky-jars-repeat.md
@@ -1,0 +1,30 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+**The merge commit proves its own identity result.** After a merge commit's
+identity DML, and inside the same transaction, the applier now re-derives the
+identity classes the merge TOUCHED and refuses a contradiction there — a class
+whose member kinds the ontology declares disjoint, or a current `different`
+assertion whose endpoints share a class. Both commit modes run it, seeded from
+the planned assertion and retraction endpoints plus (under
+`sameIdAcrossKinds: "fold"`) the node identities the commit writes, so the cost
+is proportional to the affected classes rather than the graph.
+
+This makes a committed identity ledger correct independently of the plan-time
+simulation, which reasons about state read before any write. The simulation and
+the commit-window fingerprints remain as the diagnosability layer: they refuse
+early, before anything is written, naming exactly what drifted.
+
+Because the scans resolve classes through the materialized closure — the same
+authority every current identity read uses — a closure that lags its ledger can
+hide a contradiction as easily as invent one. On any inconsistency the closure
+is rebuilt from the base relations inside the commit transaction and the scans
+re-run against it: a clean second pass means the closure was stale and is now
+repaired atomically with the merge, while a repeated contradiction aborts the
+whole merge. There is no partial commit either way.
+
+`IdentityContradictionErrorDetails.operation` gained a `"merge"` member for
+this refusal, which reaches callers as the existing
+`IdentityMergeConflictError` (`GRAPH_MERGE_IDENTITY_CONFLICT`) with the
+contradiction as its cause.

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -314,6 +314,15 @@ and the plan→commit window. The contract is by ID, on complete truth:
   whose row another writer already ended is accepted as a no-op, not drift.
   `MergeReport.merged.identity` reports the rows the applier actually
   created and ended; idempotent skips are excluded.
+- **The commit proves the result, not the plan.** After its identity writes,
+  and still inside the same transaction, a merge re-derives the identity
+  classes it touched from the written state and refuses a contradiction there
+  as `IdentityMergeConflictError` — so a plan validated against state that has
+  since moved cannot leave a contradictory ledger behind. The whole merge rolls
+  back; there is no partial commit. If the derived classes disagree with the
+  materialized closure, the closure is rebuilt inside the same transaction and
+  the check re-runs, which repairs a lagging closure atomically with a merge
+  that is otherwise sound.
 
 ## Operational notes
 

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -4156,6 +4156,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
         created: number;
         retracted: number;
     }>>;
+    assertIdentityClassesConsistentAtTarget: (target: GraphBackend | TransactionBackend, seeds: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[]) => Promise<void>;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -4064,6 +4064,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
         created: number;
         retracted: number;
     }>>;
+    assertIdentityClassesConsistentAtTarget: (target: GraphBackend | TransactionBackend, seeds: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[]) => Promise<void>;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -3764,6 +3764,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
         created: number;
         retracted: number;
     }>>;
+    assertIdentityClassesConsistentAtTarget: (target: GraphBackend | TransactionBackend, seeds: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[]) => Promise<void>;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -3720,6 +3720,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
         created: number;
         retracted: number;
     }>>;
+    assertIdentityClassesConsistentAtTarget: (target: GraphBackend | TransactionBackend, seeds: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[]) => Promise<void>;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -3714,6 +3714,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
         created: number;
         retracted: number;
     }>>;
+    assertIdentityClassesConsistentAtTarget: (target: GraphBackend | TransactionBackend, seeds: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[]) => Promise<void>;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -3784,6 +3784,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
         created: number;
         retracted: number;
     }>>;
+    assertIdentityClassesConsistentAtTarget: (target: GraphBackend | TransactionBackend, seeds: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[]) => Promise<void>;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -2731,7 +2731,7 @@ export class IdentityContradictionError extends TypeGraphError {
 
 // @public (undocumented)
 export type IdentityContradictionErrorDetails = Readonly<{
-    operation: "assertSame" | "assertDifferent" | "fold" | "import";
+    operation: "assertSame" | "assertDifferent" | "fold" | "import" | "merge";
     a: Readonly<{
         kind: string;
         id: string;
@@ -5559,6 +5559,10 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
         created: number;
         retracted: number;
     }>>;
+    assertIdentityClassesConsistentAtTarget: (target: GraphBackend | TransactionBackend, seeds: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[]) => Promise<void>;
 }>;
 
 // @public

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -591,7 +591,14 @@ export class DisjointError extends TypeGraphError {
 }
 
 export type IdentityContradictionErrorDetails = Readonly<{
-  operation: "assertSame" | "assertDifferent" | "fold" | "import";
+  /**
+   * The identity write that could not stand. `merge` is the post-write
+   * affected-class assertion a graph merge runs inside its commit
+   * transaction, which names the whole merge rather than a single assertion
+   * because the contradiction is a property of the state the merge would
+   * leave behind.
+   */
+  operation: "assertSame" | "assertDifferent" | "fold" | "import" | "merge";
   a: Readonly<{ kind: string; id: string }>;
   b: Readonly<{ kind: string; id: string }>;
   reason: "different-assertion" | "same-class" | "disjoint-kinds";

--- a/packages/typegraph/src/graph-merge/merge-identity.ts
+++ b/packages/typegraph/src/graph-merge/merge-identity.ts
@@ -9,19 +9,25 @@
  * {@link IdentityPlanSlice} — a structural subset of `MergePlan` — so this
  * module never names the full plan type.
  *
- * COMMIT-GUARD LAYERING. The in-transaction guard is deliberately redundant.
- * Correctness needs only two layers: the by-id freshness check
- * ({@link assertPlannedIdentityIdsFresh} — ended rows included, which no
- * ledger slice or class fingerprint can see) and the FULL simulation re-run
- * on transaction reads (re-deriving legality is the only complete window
- * guard), with the identity applier's own refusals — translated typed at the
- * apply boundary by {@link translateIdentityCommitError} — as the final
- * backstop. The earlier layers (direct-peer arrivals, per-seed
- * class/liveness fingerprints, the negative-ledger fingerprint) exist to
- * refuse EARLY with a message naming exactly what drifted; removing them
- * would lose diagnosability, not soundness. Never add a NEW invariant as a
- * fingerprint alone: make the simulation or the applier enforce it, then
- * fingerprint it for the error message if useful.
+ * COMMIT-GUARD LAYERING. Correctness rests on what runs INSIDE the commit
+ * transaction: the by-id freshness check ({@link assertPlannedIdentityIdsFresh}
+ * — ended rows included, which no ledger slice or class fingerprint can see),
+ * the identity applier's own refusals, and — after the identity DML — the
+ * post-write affected-class assertion
+ * ({@link assertMergedIdentityClassesConsistent}), which re-derives the
+ * touched identity classes from the state the merge just wrote and refuses a
+ * contradiction there. All of them translate typed at the apply boundary
+ * through {@link translateIdentityCommitError}.
+ *
+ * Every layer ABOVE that is diagnosability. The plan-time simulation
+ * ({@link assertNoContradictoryIdentityClosure}) and the window fingerprints
+ * (direct-peer arrivals, per-seed class/liveness fingerprints, the
+ * negative-ledger fingerprint, and the simulation re-run inside
+ * {@link assertIdentityPeersStable}) exist to refuse EARLY — before any write,
+ * with a message naming exactly what drifted — rather than to make the commit
+ * sound. Never add a NEW invariant as a fingerprint or a simulation arm alone:
+ * make the applier or the post-write assertion enforce it against real state,
+ * then simulate it for the error message if useful.
  */
 import { requireDefined } from "../utils/presence";
 import type { CanonicalEntity } from "./canonicalize";
@@ -587,9 +593,19 @@ export function assertIdentityEndpointsNotDeleted(
 }
 
 /**
- * Refuses a merge whose committed ledger would claim two nodes are BOTH the same
- * and different — including through a chain of `same` assertions no single branch
- * ever wrote.
+ * Refuses — BEFORE any write — a merge whose committed ledger would claim two
+ * nodes are BOTH the same and different, including through a chain of `same`
+ * assertions no single branch ever wrote.
+ *
+ * This is the DIAGNOSABILITY layer, not the correctness one. It simulates the
+ * post-merge ledger from reads taken before the commit, so it can name the
+ * exact branch assertion and identity class at fault while nothing has been
+ * written yet — but a target that moves between this simulation and the commit
+ * makes its verdict stale. What the committed state is actually held to is
+ * {@link assertMergedIdentityClassesConsistent}, which re-derives the affected
+ * classes from the written state inside the commit transaction. Keep the two
+ * in agreement: a simulation arm with no post-write counterpart is a message,
+ * not a guarantee.
  *
  * {@link assertNoOpposingIdentityRelations} only sees a DIRECT collision (one
  * endpoint pair carrying both relations). The common shape is transitive: base
@@ -1161,6 +1177,79 @@ export async function assertPlannedIdentityIdsFresh<G extends GraphDef>(
       );
     }
   }
+}
+
+/**
+ * The identity classes a commit can move, as the `(kind, id)` seeds the
+ * post-write assertion expands through the closure. Three sources, all minus
+ * the plan's node deletions (a deleted identity carries no class, and seeding
+ * one would ask the assertion to reason about a row the commit removed):
+ *
+ *  - both endpoints of every planned assertion — the classes the commit
+ *    MERGES, and the pairs it constrains;
+ *  - both endpoints of every planned retraction — the classes it SPLITS,
+ *    where the closure repair must have landed;
+ *  - under `sameIdAcrossKinds: "fold"`, every node identity the commit writes,
+ *    at the kind it is written under (the retype cascade's kind when the
+ *    ontology reconciled one). A written row folds with every live row sharing
+ *    its id, so a node write alone can move a class. Under `"ignore"` it
+ *    cannot: folding is off and a node write creates no assertion, so a
+ *    written identity that no planned assertion names stays a singleton.
+ */
+export function affectedIdentityClassSeeds(
+  plan: IdentityPlanSlice,
+  profile: "fold" | "ignore" | undefined,
+): readonly Readonly<{ kind: string; id: string }>[] {
+  const seedsByKey = new Map<
+    MergeKey,
+    Readonly<{ kind: string; id: string }>
+  >();
+  const addSeed = (kind: string, id: string): void => {
+    const key = mergeKey(kind, id);
+    if (plan.nodeDeletions.has(key)) return;
+    seedsByKey.set(key, { kind, id });
+  };
+  for (const assertion of [
+    ...plan.identityAssertions,
+    ...plan.identityRetractions,
+  ]) {
+    addSeed(assertion.a.kind, assertion.a.id);
+    addSeed(assertion.b.kind, assertion.b.id);
+  }
+  if (profile === "fold") {
+    for (const entity of plan.canonicalEntities) {
+      const sourceKey = mergeKey(entity.kind, entity.canonicalId);
+      if (plan.nodeDeletions.has(sourceKey)) continue;
+      addSeed(plan.retypeMap.get(sourceKey) ?? entity.kind, entity.canonicalId);
+    }
+  }
+  return [...seedsByKey.values()];
+}
+
+/**
+ * The correctness-bearing identity guard: after the commit's identity DML, the
+ * applier re-derives the affected identity classes FROM THE WRITTEN STATE and
+ * refuses a contradiction, inside the commit transaction. Every earlier
+ * identity guard reasons about a simulated post-merge universe assembled from
+ * reads taken before the writes; this one reads the database the merge is
+ * about to leave behind, so it holds whatever the plan assumed and however the
+ * target moved underneath it. A refusal aborts the transaction, so the merge
+ * is never partially applied.
+ *
+ * Shared by BOTH commit modes through {@link applyMergePlan}, and raised
+ * inside the identity-applier boundary so
+ * {@link translateIdentityCommitError} gives it the same typed conflict
+ * surface as the applier's own refusals.
+ */
+export async function assertMergedIdentityClassesConsistent<G extends GraphDef>(
+  target: Store<G>,
+  txBackend: TransactionBackend,
+  plan: IdentityPlanSlice,
+): Promise<void> {
+  await storeRuntime(target).assertIdentityClassesConsistentAtTarget(
+    txBackend,
+    affectedIdentityClassSeeds(plan, target.graph.identity?.sameIdAcrossKinds),
+  );
 }
 
 /**

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -78,6 +78,7 @@ import { BaseVersionMismatchError, describeCause, MergeError } from "./errors";
 import {
   assertIdentityEndpointsNotDeleted,
   assertIdentityPeersStable,
+  assertMergedIdentityClassesConsistent,
   assertNoContradictoryIdentityClosure,
   assertOneIdOneTruth,
   assertPlannedIdentityIdsFresh,
@@ -1482,6 +1483,13 @@ async function applyMergePlan<G extends GraphDef>(
   // identity statement by construction, so it is translated into the typed
   // conflict error here — the completeness backstop for applier invariants
   // the plan-time simulation does not (yet) mirror.
+  //
+  // The post-write assertion shares the boundary because it is the same kind
+  // of statement, made one step later: with every node, edge and identity
+  // write of this merge in place, the affected identity classes must carry no
+  // contradiction. It is what makes the committed ledger correct independently
+  // of the plan-time simulation, and it runs for BOTH commit modes because
+  // both commit through here.
   let appliedIdentity: Readonly<{ created: number; retracted: number }>;
   try {
     appliedIdentity = await storeRuntime(target).applyIdentityMergeAtTarget(
@@ -1489,6 +1497,7 @@ async function applyMergePlan<G extends GraphDef>(
       plan.identityRetractions.map((retraction) => retraction.id),
       plan.identityAssertions,
     );
+    await assertMergedIdentityClassesConsistent(target, txBackend, plan);
   } catch (error) {
     throw translateIdentityCommitError(error);
   }

--- a/packages/typegraph/src/identity/service.ts
+++ b/packages/typegraph/src/identity/service.ts
@@ -2494,6 +2494,269 @@ export async function validateIdentityForContext<G extends GraphDef>(
 }
 
 /**
+ * The context slice the affected-class assertion reads. Narrower than the full
+ * {@link IdentityServiceContext} because the assertion runs inside a
+ * caller-owned write transaction and therefore takes its target explicitly
+ * instead of opening one from `backend`.
+ */
+export type IdentityConsistencyContext<G extends GraphDef> = Pick<
+  IdentityServiceContext<G>,
+  "graphId" | "registry" | "schema" | "sameIdAcrossKinds"
+>;
+
+/** The affected identity classes, indexed for the assertion's three scans. */
+type AffectedIdentityClasses = Readonly<{
+  /** Each distinct affected class, keyed by its code-point-least member. */
+  byClassKey: ReadonlyMap<string, readonly PlainNodeRef[]>;
+  /** The class key of every affected member, for endpoint lookups. */
+  classKeyByMember: ReadonlyMap<string, string>;
+  /** Every member of every affected class, deduplicated. */
+  members: readonly PlainNodeRef[];
+}>;
+
+/**
+ * The identity classes the seeds belong to, read through the SAME materialized
+ * closure every current identity read resolves through
+ * ({@link loadCurrentStructuralClasses}), so the assertion judges the state
+ * readers will actually see rather than a private reconstruction of it.
+ */
+async function loadAffectedIdentityClasses<G extends GraphDef>(
+  ctx: IdentityConsistencyContext<G>,
+  target: Backend,
+  seeds: readonly PlainNodeRef[],
+): Promise<AffectedIdentityClasses> {
+  const classes = await loadCurrentStructuralClasses(
+    target,
+    ctx.schema,
+    ctx.graphId,
+    seeds,
+  );
+  const byClassKey = new Map<string, readonly PlainNodeRef[]>();
+  const classKeyByMember = new Map<string, string>();
+  const members = new Map<string, PlainNodeRef>();
+  for (const classMembers of classes.values()) {
+    // Members come back in {@link compareReferences} order, so the first is
+    // the class's code-point-least member — the same canonical label
+    // {@link insertClosureComponents} writes, which makes two seeds of one
+    // class collapse onto one entry here.
+    const classKey = refKey(requireDefined(classMembers[0]));
+    byClassKey.set(classKey, classMembers);
+    for (const member of classMembers) {
+      const memberKey = refKey(member);
+      classKeyByMember.set(memberKey, classKey);
+      members.set(memberKey, member);
+    }
+  }
+  return { byClassKey, classKeyByMember, members: [...members.values()] };
+}
+
+/**
+ * What an affected-class scan found: a genuine identity contradiction, or
+ * evidence that the materialized closure lags the ledger it is derived from.
+ * The two are indistinguishable to a caller reading a stale closure, which is
+ * why {@link assertAffectedIdentityClassesConsistent} rebuilds before it
+ * believes either.
+ */
+type AffectedClassInconsistency =
+  | Readonly<{ kind: "contradiction"; error: IdentityContradictionError }>
+  | Readonly<{
+      kind: "stale-closure";
+      detail: Readonly<Record<string, unknown>>;
+    }>;
+
+function firstMemberOfKind(
+  members: readonly PlainNodeRef[],
+  kind: string,
+): PlainNodeRef {
+  return requireDefined(
+    members.find((member) => member.kind === kind),
+    `Identity class carries no ${kind} member`,
+  );
+}
+
+/**
+ * The first inconsistency in the affected classes, or `undefined` when they
+ * are consistent. Three scans, all scoped to the affected members:
+ *
+ *  - a class whose member kinds the ontology declares disjoint;
+ *  - a CURRENT `different` assertion whose endpoints share one class;
+ *  - closure lag, as a current `same` assertion (or, under `"fold"`, a live
+ *    same-id row) whose endpoints the closure has NOT merged — the one shape
+ *    that could hide a contradiction from the two scans above, because both
+ *    resolve classes through that same closure.
+ */
+async function findAffectedClassInconsistency<G extends GraphDef>(
+  ctx: IdentityConsistencyContext<G>,
+  target: Backend,
+  seeds: readonly PlainNodeRef[],
+): Promise<AffectedClassInconsistency | undefined> {
+  const classes = await loadAffectedIdentityClasses(ctx, target, seeds);
+  for (const members of classes.byClassKey.values()) {
+    // Self-pairs are safe: `areDisjoint(kind, kind)` is false by construction.
+    const conflictingKinds = classHasDisjointKinds(
+      ctx.registry,
+      members,
+      members,
+    );
+    if (conflictingKinds === undefined) continue;
+    const [leftKind, rightKind] = conflictingKinds;
+    return {
+      kind: "contradiction",
+      error: new IdentityContradictionError({
+        operation: "merge",
+        a: firstMemberOfKind(members, leftKind),
+        b: firstMemberOfKind(members, rightKind),
+        reason: "disjoint-kinds",
+        conflictingKinds,
+      }),
+    };
+  }
+
+  const assertions = await loadAssertionsTouching(
+    target,
+    ctx.schema,
+    ctx.graphId,
+    classes.members,
+    undefined,
+  );
+  // Current `same` rows the closure has NOT merged into one class. An endpoint
+  // outside every affected class is only evidence of lag when its node is
+  // live — a class legitimately excludes a deleted member — so the liveness of
+  // those endpoints is read once, after the scan, instead of per row.
+  const unmerged: Readonly<{
+    assertionId: string;
+    a: PlainNodeRef;
+    b: PlainNodeRef;
+    outside: PlainNodeRef;
+  }>[] = [];
+  for (const assertion of assertions) {
+    const a = { kind: assertion.a_kind, id: assertion.a_id };
+    const b = { kind: assertion.b_kind, id: assertion.b_id };
+    const aClassKey = classes.classKeyByMember.get(refKey(a));
+    const bClassKey = classes.classKeyByMember.get(refKey(b));
+    if (assertion.rel === "different") {
+      if (aClassKey === undefined || aClassKey !== bClassKey) continue;
+      return {
+        kind: "contradiction",
+        error: new IdentityContradictionError({
+          operation: "merge",
+          a,
+          b,
+          reason: "same-class",
+          conflictingAssertionId: assertion.id,
+        }),
+      };
+    }
+    if (aClassKey !== undefined && bClassKey !== undefined) {
+      if (aClassKey === bClassKey) continue;
+      return {
+        kind: "stale-closure",
+        detail: { assertionId: assertion.id, a, b },
+      };
+    }
+    // The row reached this scan by touching an affected member, so exactly one
+    // endpoint can be outside the affected classes.
+    unmerged.push({
+      assertionId: assertion.id,
+      a,
+      b,
+      outside: aClassKey === undefined ? a : b,
+    });
+  }
+  if (unmerged.length > 0) {
+    const liveOutside = await loadLiveReferences(
+      target,
+      ctx.schema,
+      ctx.graphId,
+      unmerged.map((row) => row.outside),
+    );
+    const liveKeys = new Set(liveOutside.map((ref) => refKey(ref)));
+    const lagging = unmerged.find((row) => liveKeys.has(refKey(row.outside)));
+    if (lagging !== undefined) {
+      return {
+        kind: "stale-closure",
+        detail: {
+          assertionId: lagging.assertionId,
+          a: lagging.a,
+          b: lagging.b,
+        },
+      };
+    }
+  }
+
+  if (ctx.sameIdAcrossKinds !== "fold") return undefined;
+  // The structural half of closure truth: under `"fold"` every live row
+  // sharing an affected member's id belongs to that member's class. A row the
+  // closure never folded reads as `undefined` here, which is the lag this
+  // scan exists to catch.
+  const liveKindsById = await liveNodeKindsSharingIds(
+    ctx,
+    target,
+    classes.members.map((member) => member.id),
+  );
+  for (const [id, kinds] of liveKindsById) {
+    const classKeys = new Set<string | undefined>();
+    for (const kind of kinds) {
+      classKeys.add(classes.classKeyByMember.get(refKey({ kind, id })));
+    }
+    if (classKeys.size > 1) {
+      return {
+        kind: "stale-closure",
+        detail: { sharedId: id, kinds: [...kinds] },
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Asserts that the identity classes a write TOUCHED are contradiction-free, in
+ * the caller's write transaction and against the state the write just left
+ * behind. Scoped to the affected classes — the seeds plus everything the
+ * closure links them to — so the cost is O(affected classes), not O(graph).
+ *
+ * This is the applier-owned half of identity correctness: unlike a caller's
+ * plan-time simulation, it reads the post-write database, so a plan validated
+ * against state that has since moved cannot commit a contradictory ledger. Any
+ * refusal propagates out of the caller's transaction, which rolls the whole
+ * write back — there is no partial commit.
+ *
+ * Both failure kinds go through ONE rebuild-and-recheck: the scans resolve
+ * classes through the materialized closure, so a lagging closure can invent a
+ * contradiction as easily as it can hide one. On any inconsistency the closure
+ * is rebuilt from the base relations INSIDE the caller's transaction and the
+ * scans re-run against it. A clean second pass means the closure was stale and
+ * is now repaired (atomically with the caller's write); a repeated
+ * contradiction is real and aborts; a repeated lag means the closure and the
+ * ledger disagree in a way a rebuild cannot fix, which is corruption.
+ */
+export async function assertAffectedIdentityClassesConsistent<
+  G extends GraphDef,
+>(
+  ctx: IdentityConsistencyContext<G>,
+  target: Backend,
+  seeds: readonly PlainNodeRef[],
+): Promise<void> {
+  if (seeds.length === 0) return;
+  await lockIdentityGraph(target, ctx.graphId);
+  const observed = await findAffectedClassInconsistency(ctx, target, seeds);
+  if (observed === undefined) return;
+  await withRecordedIdentityMutationTarget(target, async (rawTarget) => {
+    await replaceClosure(
+      rawTarget,
+      ctx.schema,
+      ctx.graphId,
+      new Set(ctx.registry.nodeKinds.keys()),
+      ctx.sameIdAcrossKinds,
+    );
+  });
+  const rebuilt = await findAffectedClassInconsistency(ctx, target, seeds);
+  if (rebuilt === undefined) return;
+  if (rebuilt.kind === "contradiction") throw rebuilt.error;
+  throw closureMismatchError(ctx.graphId, rebuilt.detail);
+}
+
+/**
  * Hard-deletes every assertion row (current AND ended) touching any of the
  * given node kinds, touching each removed row for recorded capture. Shared by
  * {@link removeIdentityKindsForContext} (Store.removeKinds) and the schema

--- a/packages/typegraph/src/store/runtime-port.ts
+++ b/packages/typegraph/src/store/runtime-port.ts
@@ -195,6 +195,17 @@ export type StoreRuntime<G extends GraphDef> = Readonly<{
       validTo?: string | undefined;
     }>[],
   ) => Promise<Readonly<{ created: number; retracted: number }>>;
+  /**
+   * Proves the identity classes of `seeds` carry no contradiction in the state
+   * the caller's transaction has just written — the post-write half of
+   * graph-merge's identity correctness, scoped to the classes the merge
+   * touched. A refusal aborts the caller's transaction; identity-disabled
+   * graphs resolve immediately.
+   */
+  assertIdentityClassesConsistentAtTarget: (
+    target: GraphBackend | TransactionBackend,
+    seeds: readonly Readonly<{ kind: string; id: string }>[],
+  ) => Promise<void>;
 }>;
 
 export function storeRuntime<G extends GraphDef>(

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -85,6 +85,7 @@ import {
 } from "../identity/schema-transition";
 import {
   applyIdentityChangesForContext,
+  assertAffectedIdentityClassesConsistent,
   createIdentityFacade,
   createIdentityReadFacade,
   detachIdentityForNode,
@@ -1018,6 +1019,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         this.importIdentityAssertionsAtTarget(target, assertions, mode),
       applyIdentityMergeAtTarget: (target, retractionIds, assertions) =>
         this.applyIdentityMergeAtTarget(target, retractionIds, assertions),
+      assertIdentityClassesConsistentAtTarget: (target, seeds) =>
+        this.assertIdentityClassesConsistentAtTarget(target, seeds),
     };
     Object.defineProperty(this, STORE_RUNTIME, {
       configurable: false,
@@ -1253,6 +1256,25 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       target,
       assertions,
       mode,
+    );
+  }
+
+  /**
+   * @internal Post-write identity validation for a graph-merge commit: proves
+   * the identity classes the merge touched carry no contradiction in the state
+   * the merge just wrote, inside the merge's own transaction.
+   */
+  assertIdentityClassesConsistentAtTarget(
+    target: GraphBackend | TransactionBackend,
+    seeds: readonly Readonly<{ kind: string; id: string }>[],
+  ): Promise<void> {
+    if (this.#graph.identity === undefined || seeds.length === 0) {
+      return Promise.resolve();
+    }
+    return assertAffectedIdentityClassesConsistent(
+      this.#identityContext(target),
+      target,
+      seeds,
     );
   }
 

--- a/packages/typegraph/tests/graph-merge/identity-commit-closure.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-commit-closure.test.ts
@@ -1,0 +1,405 @@
+/**
+ * The post-write affected-class assertion: after a merge commit's identity
+ * DML, the applier re-derives the identity classes the merge touched FROM THE
+ * WRITTEN STATE, inside the same transaction, and refuses a contradiction
+ * there.
+ *
+ * What every case below has in common is a materialized identity closure that
+ * lags the ledger it summarizes. That matters because the closure is what the
+ * applier's own per-assertion validation resolves classes through, so while it
+ * lags, a legal identity write can be talked into a contradiction and the
+ * writes that follow are validated against a class shape that no longer
+ * exists. The plan-time simulation cannot see it either: it reasons about the
+ * ledger, and the ledger alone does not say which class a same-id fold puts a
+ * node in. Only re-deriving the affected classes after the writes — and
+ * rebuilding the closure when they do not agree with the ledger — catches it.
+ */
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  disjointWith,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { IdentityMergeConflictError } from "../../src/graph-merge/errors";
+import type { MergePlan } from "../../src/graph-merge/merge";
+import { commitPlan, mergeIncremental } from "../../src/graph-merge/merge";
+import { affectedIdentityClassSeeds } from "../../src/graph-merge/merge-identity";
+import { mergeKey } from "../../src/graph-merge/node-key";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import { asBranchId } from "../../src/graph-merge/types";
+import { importGraph } from "../../src/interchange";
+import { sql } from "../../src/query/sql-fragment";
+import { asCompiledStatementSql } from "../../src/query/sql-intent";
+import { storeRuntime } from "../../src/store/runtime-port";
+import {
+  backendMatrix,
+  getStoreBackend,
+  identityAssertionDocument,
+} from "./test-utils";
+
+const Anchor = defineNode("Anchor", {
+  schema: z.object({ name: z.string() }),
+});
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const Robot = defineNode("Robot", {
+  schema: z.object({ name: z.string() }),
+});
+
+/**
+ * Same-id folding on, with a disjoint pair a fold can pull into one class —
+ * the contradiction the ledger alone never states.
+ */
+const foldGraph = defineGraph({
+  id: "identity_commit_closure_fold",
+  nodes: {
+    Anchor: { type: Anchor },
+    Person: { type: Person },
+    Robot: { type: Robot },
+  },
+  edges: {},
+  ontology: [disjointWith(Person, Robot)],
+  identity: { sameIdAcrossKinds: "fold" },
+});
+type FoldGraph = typeof foldGraph;
+
+/** Assertion-only identity, for the closure-repair case. */
+const ledgerGraph = defineGraph({
+  id: "identity_commit_closure_ledger",
+  nodes: { Anchor: { type: Anchor } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+
+const BRANCH_A = asBranchId("branch-a");
+const TARGET_CLONE = asBranchId("target-clone");
+
+/** An empty plan; the commit tests override only the identity slice. */
+function emptyFoldPlan(): MergePlan<FoldGraph> {
+  return {
+    canonicalEntities: [],
+    survivingModifications: [],
+    nodeDeletions: new Map(),
+    edgeDeletions: new Map(),
+    mergedEdges: [],
+    inheritedEdgeBaseProps: new Map(),
+    retypeMap: new Map(),
+    resolutions: [],
+    propertyConflicts: [],
+    deleteModifyConflicts: [],
+    typeReconciliations: [],
+    dropped: [],
+    baseAmbiguities: [],
+    provenanceRecords: [],
+    warnings: [],
+    identityAssertions: [],
+    identityRetractions: [],
+    canonicalOf: new Map(),
+  };
+}
+
+/**
+ * Empties the materialized identity closure behind the store's back — the
+ * state a lagging or never-run incremental repair leaves behind, and the one
+ * `rebuildIdentityClosure()` exists to get a store out of.
+ */
+async function dropMaterializedClosure(backend: GraphBackend): Promise<void> {
+  const executeStatement = backend.executeStatement;
+  if (executeStatement === undefined) {
+    throw new Error("matrix backend must support statement execution");
+  }
+  await executeStatement(
+    asCompiledStatementSql(sql`DELETE FROM typegraph_identity_closure`),
+  );
+}
+
+describe.each(backendMatrix())(
+  "identity commit-transaction closure assertion [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    beforeEach(() => {
+      cleanups = [];
+    });
+
+    afterEach(async () => {
+      const outcomes = await Promise.allSettled(
+        cleanups.toReversed().map((cleanup) => cleanup()),
+      );
+      const rejection = outcomes.find(
+        (outcome): outcome is PromiseRejectedResult =>
+          outcome.status === "rejected",
+      );
+      if (rejection !== undefined) {
+        throw rejection.reason instanceof Error ?
+            rejection.reason
+          : new Error(String(rejection.reason));
+      }
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    /**
+     * The fixture both contradiction tests commit onto.
+     *
+     * `Anchor:k` and `Robot:k` are one class by same-id folding, and
+     * `same(z, k)` joins `Anchor:z` to it — all legal, all materialized. The
+     * closure is then dropped, and `assertSame(p, z)` is accepted precisely
+     * BECAUSE of the lag: it reads `Anchor:z` and `Person:p` as singletons
+     * instead of seeing that z's real class already contains a `Robot`, which
+     * the ontology declares disjoint with `Person`.
+     *
+     * Nothing in the ledger states that contradiction — it takes the fold at
+     * id `k` to see it — so no ledger-level guard, at plan time or in the
+     * commit window, can refuse what follows.
+     */
+    async function corruptedFoldTarget(): Promise<
+      Readonly<{ forkPoint: Store<FoldGraph>; target: Store<FoldGraph> }>
+    > {
+      const [forkPoint] = await createStoreWithSchema(
+        foldGraph,
+        await makeBackend(),
+      );
+      for (const id of ["z", "k", "w"]) {
+        await forkPoint.nodes.Anchor.create({ name: id }, { id });
+      }
+      await forkPoint.nodes.Robot.create({ name: "k" }, { id: "k" });
+      await forkPoint.nodes.Person.create({ name: "p" }, { id: "p" });
+      await forkPoint.identity.assertSame(
+        { kind: "Anchor", id: "z" },
+        { kind: "Anchor", id: "k" },
+      );
+      // Cloned BEFORE the corruption: a working copy is a faithful
+      // re-import, which would refuse the contradictory assertion.
+      const target = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
+      ).store;
+      await dropMaterializedClosure(getStoreBackend(target));
+      await target.identity.assertSame(
+        { kind: "Person", id: "p" },
+        { kind: "Anchor", id: "z" },
+      );
+      return { forkPoint, target };
+    }
+
+    /** The class the commit must refuse to extend, and what it holds. */
+    async function expectUnextendedClass(
+      target: Store<FoldGraph>,
+    ): Promise<void> {
+      const rows = await storeRuntime(target).identityAssertionRowsByIds([
+        "same-wz",
+      ]);
+      expect(rows.get("same-wz")).toBeUndefined();
+      expect(
+        await target.identity.areSame(
+          { kind: "Anchor", id: "w" },
+          { kind: "Anchor", id: "z" },
+        ),
+      ).toBe(false);
+    }
+
+    it("refuses the contradiction the lagging closure hid (snapshot commit)", async () => {
+      // `commitPlan` is the snapshot commit path with no plan-time simulation
+      // in front of it at all — the plan arrives resolved. Only the guards
+      // inside its transaction stand between it and the ledger.
+      const { target } = await corruptedFoldTarget();
+      const plan: MergePlan<FoldGraph> = {
+        ...emptyFoldPlan(),
+        identityAssertions: [
+          {
+            id: "same-wz",
+            relation: "same",
+            a: { kind: "Anchor", id: "w" },
+            b: { kind: "Anchor", id: "z" },
+            validFrom: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+      };
+
+      await expect(commitPlan(target, plan)).rejects.toThrow(
+        IdentityMergeConflictError,
+      );
+      await expectUnextendedClass(target);
+    });
+
+    it("refuses the contradiction the lagging closure hid (incremental commit)", async () => {
+      const { forkPoint, target } = await corruptedFoldTarget();
+      const assertBranch = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+      );
+      const branchImport = await importGraph(
+        assertBranch.store,
+        identityAssertionDocument("Anchor", "same-wz", "w", "z"),
+        { onConflict: "skip" },
+      );
+      expect(branchImport.success).toBe(true);
+
+      const result = await mergeIncremental({
+        forkPoint,
+        target,
+        branches: [assertBranch],
+        options: { branchOrder: [BRANCH_A] },
+      });
+      expect(isErr(result)).toBe(true);
+      if (isOk(result)) throw new Error("Expected identity merge conflict");
+      expect(result.error).toBeInstanceOf(IdentityMergeConflictError);
+      expect(result.error.code).toBe("GRAPH_MERGE_IDENTITY_CONFLICT");
+      expect(result.error.details["identityCode"]).toBe(
+        "IDENTITY_CONTRADICTION",
+      );
+      await expectUnextendedClass(target);
+    });
+
+    it("repairs a lagging closure inside the commit and lets the merge stand", async () => {
+      // The same lag with no contradiction underneath it. The merge must
+      // succeed — and must not leave the closure it validated against still
+      // broken, because the rebuild runs in the merge's own transaction.
+      const [forkPoint] = await createStoreWithSchema(
+        ledgerGraph,
+        await makeBackend(),
+      );
+      for (const id of ["a", "b", "c"]) {
+        await forkPoint.nodes.Anchor.create({ name: id }, { id });
+      }
+      await forkPoint.identity.assertSame(
+        { kind: "Anchor", id: "a" },
+        { kind: "Anchor", id: "b" },
+      );
+      const target = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
+      ).store;
+      const assertBranch = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+      );
+      const branchImport = await importGraph(
+        assertBranch.store,
+        identityAssertionDocument("Anchor", "same-bc", "b", "c"),
+        { onConflict: "skip" },
+      );
+      expect(branchImport.success).toBe(true);
+      await dropMaterializedClosure(getStoreBackend(target));
+
+      const result = await mergeIncremental({
+        forkPoint,
+        target,
+        branches: [assertBranch],
+        options: { branchOrder: [BRANCH_A] },
+      });
+      if (isErr(result)) throw result.error;
+      expect(isOk(result)).toBe(true);
+
+      // The merge's own pair AND the pre-existing one the drop hid: both read
+      // as one class again, and the store's own validation agrees.
+      expect(
+        await target.identity.areSame(
+          { kind: "Anchor", id: "b" },
+          { kind: "Anchor", id: "c" },
+        ),
+      ).toBe(true);
+      expect(
+        await target.identity.areSame(
+          { kind: "Anchor", id: "a" },
+          { kind: "Anchor", id: "b" },
+        ),
+      ).toBe(true);
+      await expect(
+        storeRuntime(target).validateIdentity(),
+      ).resolves.toBeUndefined();
+    });
+  },
+);
+
+describe("affectedIdentityClassSeeds", () => {
+  const emptyPlan = {
+    canonicalEntities: [],
+    identityAssertions: [],
+    identityRetractions: [],
+    nodeDeletions: new Map<string, string>(),
+    retypeMap: new Map<string, string>(),
+    canonicalOf: new Map<string, string>(),
+  } as unknown as Parameters<typeof affectedIdentityClassSeeds>[0];
+
+  type PlanAssertion = (typeof emptyPlan)["identityAssertions"][number];
+
+  function assertion(
+    id: string,
+    a: Readonly<{ kind: string; id: string }>,
+    b: Readonly<{ kind: string; id: string }>,
+  ): PlanAssertion {
+    return {
+      id,
+      relation: "same",
+      a,
+      b,
+      validFrom: "2024-01-01T00:00:00.000Z",
+    } as unknown as PlanAssertion;
+  }
+
+  it("seeds both endpoints of assertions and retractions", () => {
+    const plan = {
+      ...emptyPlan,
+      identityAssertions: [
+        assertion(
+          "x",
+          { kind: "Anchor", id: "a" },
+          { kind: "Anchor", id: "b" },
+        ),
+      ],
+      identityRetractions: [
+        assertion(
+          "y",
+          { kind: "Anchor", id: "c" },
+          { kind: "Person", id: "d" },
+        ),
+      ],
+    };
+    expect(affectedIdentityClassSeeds(plan, "ignore")).toEqual([
+      { kind: "Anchor", id: "a" },
+      { kind: "Anchor", id: "b" },
+      { kind: "Anchor", id: "c" },
+      { kind: "Person", id: "d" },
+    ]);
+  });
+
+  it("adds written node identities only under the fold profile", () => {
+    // The commit writes a reconciled survivor under its RETYPED kind, so that
+    // is the identity whose class a fold can move.
+    const plan = {
+      ...emptyPlan,
+      canonicalEntities: [{ kind: "Staff", canonicalId: "s", props: {} }],
+      retypeMap: new Map([[mergeKey("Staff", "s"), "Employee"]]),
+    } as unknown as typeof emptyPlan;
+    expect(affectedIdentityClassSeeds(plan, "fold")).toEqual([
+      { kind: "Employee", id: "s" },
+    ]);
+    expect(affectedIdentityClassSeeds(plan, "ignore")).toEqual([]);
+  });
+
+  it("never seeds an identity the plan deletes", () => {
+    const plan = {
+      ...emptyPlan,
+      identityAssertions: [
+        assertion(
+          "x",
+          { kind: "Anchor", id: "a" },
+          { kind: "Anchor", id: "gone" },
+        ),
+      ],
+      canonicalEntities: [{ kind: "Anchor", canonicalId: "gone", props: {} }],
+      nodeDeletions: new Map([[mergeKey("Anchor", "gone"), "Anchor"]]),
+    } as unknown as typeof emptyPlan;
+    expect(affectedIdentityClassSeeds(plan, "fold")).toEqual([
+      { kind: "Anchor", id: "a" },
+    ]);
+  });
+});


### PR DESCRIPTION
A merge's identity result was only ever proven *before* it was written. The plan-time simulation (`assertNoContradictoryIdentityClosure`) reasons about a post-merge universe assembled from reads taken outside the commit, and the applier's own per-assertion validation resolves classes through the **materialized closure** — so a closure that lags its ledger hides exactly the contradiction that validation exists to catch, and every write validated against it goes in.

The applier now proves the result. After the commit's identity DML, and inside the same transaction, it re-derives the identity classes the merge **touched** and refuses a contradiction there:

- a class whose member kinds the ontology declares disjoint;
- a current `different` assertion whose endpoints share a class.

The refusal propagates out of the commit transaction, so the whole merge rolls back — never a partial commit.

## Affected-class seeding

Scope is the affected classes, not the graph (`affectedIdentityClassSeeds`):

| source | when |
| --- | --- |
| both endpoints of every planned assertion | always — the classes the commit merges and the pairs it constrains |
| both endpoints of every planned retraction | always — the classes it splits, where the closure repair must have landed |
| every node identity the commit writes, at the kind it is written under (retype cascade included) | `sameIdAcrossKinds: "fold"` only |

Identities the plan deletes are excluded from all three. Under `"ignore"` a node write cannot move a class (folding is off and a node write creates no assertion), so it contributes no seeds.

The scans reuse the existing seeded reads — `loadCurrentStructuralClasses`, `loadAssertionsTouching`, `loadLiveReferences`, `liveNodeKindsSharingIds` — and the existing contradiction predicates `classHasDisjointKinds` / `IdentityContradictionError`. No new SQL, one shared query path, no dialect branching.

## Non-convergence: rebuild in-transaction, then re-validate

Both failure kinds go through **one** rebuild-and-recheck, because the scans resolve classes through the same closure that can invent a contradiction as easily as hide one. On any inconsistency the closure is rebuilt from the base relations *inside* the caller's transaction and the scans re-run:

- clean second pass → the closure was stale and is now repaired, atomically with the merge;
- repeated contradiction → real, aborts the merge;
- repeated lag → corruption a rebuild cannot fix, raises the existing closure-mismatch error.

A third scan exists purely to make the lag detectable: a current `same` row (or, under `"fold"`, a live same-id row) whose endpoints the closure has *not* merged. That is the one shape that could hide a contradiction from the two scans above. An endpoint outside every affected class only counts as lag when its node is live, so a class legitimately excluding a deleted member never triggers a rebuild.

## Both commit modes, one call site

`commitPlan` (snapshot) and `commitIncrementalPlan` both commit through `applyMergePlan`, where the assertion sits inside the identity-applier boundary — so `translateIdentityCommitError` gives it the same typed `IdentityMergeConflictError` (`GRAPH_MERGE_IDENTITY_CONFLICT`, `details.identityCode === "IDENTITY_CONTRADICTION"`) as the applier's own refusals.

## The pre-commit simulation stays

Not deleted — re-scoped in its docs to what it is: the diagnosability layer that refuses **early**, before any write, naming exactly what drifted. The module's `COMMIT-GUARD LAYERING` note now separates the correctness-bearing in-transaction layers from the message-producing ones, and says never to add a new invariant as a simulation arm or fingerprint alone.

## Tests

`tests/graph-merge/identity-commit-closure.test.ts`, on the shared merge backend matrix (SQLite + PGlite, and server Postgres when `POSTGRES_URL` is set). All three integration cases were **verified failing with the call site removed** (6 failures across the two default backends).

The fixture builds a contradiction no ledger-level guard can see. `Anchor:k` and `Robot:k` are one class by same-id folding and `same(z, k)` joins `Anchor:z` to it — all legal, all materialized. The closure is then dropped, and `assertSame(p, z)` is *accepted* precisely because of the lag: it reads z and p as singletons instead of seeing that z's real class already holds a `Robot`, disjoint with `Person`. Nothing in the ledger states that — it takes the fold at id `k` — so the plan-time simulation and the commit-window fingerprints all pass.

- **snapshot commit** — `commitPlan` with a resolved plan and no simulation in front of it at all: refused, and the assertion never lands.
- **incremental commit** — full `mergeIncremental`: refused with the exact typed error shape, and the target's class is unextended.
- **repair** — the same lag with no contradiction underneath: the merge succeeds, and the pre-existing pair the drop hid reads as one class again with `validateIdentity()` clean (pre-change the closure stays broken).
- **seeding** — unit tests for the deletion, retype-kind, and profile rules.

Changeset: minor (`IdentityContradictionErrorDetails.operation` gains `"merge"`, and the committed-ledger guarantee strengthens).

Closes #368