### PR TITLE
identity: probe the separation relation for current different-ness reads

### DIFF
--- a/.changeset/probing-separations.md
+++ b/.changeset/probing-separations.md
@@ -15,6 +15,7 @@ conflicting assertion in the typed error it is already about to throw.
 
 Results and typed errors are unchanged. Reads at a valid-time `asOf` or a
 recorded coordinate still reconstruct from the ledger, since the separation
-relation projects current assertions onto current classes. A probe that cannot
-read the relation refuses with `IDENTITY_STORAGE_MISSING` rather than answering
-"not separated".
+relation projects current assertions onto current classes. A probe never
+answers "not separated" when it could not read: a missing relation refuses with
+`IDENTITY_STORAGE_MISSING`, and any other driver failure propagates unchanged so
+transient conflicts stay classifiable.

--- a/.changeset/probing-separations.md
+++ b/.changeset/probing-separations.md
@@ -1,0 +1,20 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+identity: answer current different-ness with one probe on the separation relation
+
+`identity.areDifferent()` and the `assertSame` contradiction precheck resolved
+both identity classes and then loaded every current `different` assertion
+touching one of them, scanning in JS for one that spanned the pair. That scan
+grew with class size and, past the backend's bind budget, took more than one
+statement. Both now probe the derived separation relation on its primary key
+`(graph_id, class_key_low, class_key_high)` instead: `areDifferent` reads the
+assertion ledger not at all, and the precheck reads it only to name the
+conflicting assertion in the typed error it is already about to throw.
+
+Results and typed errors are unchanged. Reads at a valid-time `asOf` or a
+recorded coordinate still reconstruct from the ledger, since the separation
+relation projects current assertions onto current classes. A probe that cannot
+read the relation refuses with `IDENTITY_STORAGE_MISSING` rather than answering
+"not separated".

--- a/packages/typegraph/src/graph-merge/merge-identity.ts
+++ b/packages/typegraph/src/graph-merge/merge-identity.ts
@@ -1275,9 +1275,11 @@ const IDENTITY_ENVIRONMENT_CODES: ReadonlySet<string> = new Set([
   "IDENTITY_REQUIRES_ATOMIC_BACKEND",
   "IDENTITY_REQUIRES_STATEMENT_EXECUTION",
   "IDENTITY_BIND_BUDGET_TOO_SMALL",
-  // Unreachable from the applier today, but environment/corruption
-  // statements all the same — translating one into "re-plan against the
-  // current target" would be advice that can never succeed.
+  // Environment/corruption statements — translating one into "re-plan against
+  // the current target" would be advice that can never succeed. The applier
+  // reaches the last two through the current different-ness probe (see
+  // `identity/separation`), which refuses rather than guessing when the derived
+  // separation relation is missing or disagrees with the ledger.
   "IDENTITY_NOT_ENABLED",
   "IDENTITY_STORAGE_MISSING",
   "IDENTITY_SCHEMA_CONTRADICTION",

--- a/packages/typegraph/src/identity/separation.ts
+++ b/packages/typegraph/src/identity/separation.ts
@@ -35,6 +35,7 @@ import { sql } from "../query/sql-fragment";
 import { asCompiledRowsSql } from "../query/sql-intent";
 import { chunk } from "../utils/array";
 import { compareCodePoints } from "../utils/compare";
+import { isMissingTableError } from "../utils/sql-errors";
 import {
   executeIdentityStatement,
   identityChunkSize,
@@ -190,8 +191,12 @@ type RawSeparationRow = Readonly<{
  * onto CURRENT classes, so a valid-time or recorded coordinate has to
  * reconstruct from the ledger instead.
  *
- * @throws {ConfigurationError} `IDENTITY_STORAGE_MISSING` when the probe cannot
- * be answered.
+ * Never answers "not separated" when it could not read: a missing relation
+ * raises `IDENTITY_STORAGE_MISSING` and any other driver failure propagates
+ * unchanged.
+ *
+ * @throws {ConfigurationError} `IDENTITY_STORAGE_MISSING` when the relation the
+ * probe reads does not exist.
  */
 export async function isSeparated(
   target: IdentityTarget,
@@ -230,13 +235,19 @@ async function probeSeparationPair(
       `),
     );
   } catch (error) {
-    // Never degrade to "not separated". A caller that cannot read the relation
+    // Never degrade to "not separated": a caller that cannot read the relation
     // has no basis for an answer, and the wrong answer here is the one that
-    // lets a contradiction through. Any failure of a single-table equality
-    // probe on an identity-enabled graph means the relation is unreadable;
-    // rather than pattern-match each driver's wording for a missing table —
-    // which silently degrades the moment a driver rephrases it — every failure
-    // is reported as such, with the driver error preserved as the cause.
+    // lets a contradiction through. Both branches below therefore throw.
+    //
+    // A missing relation is the one failure this seam can describe better than
+    // the driver can, so it is translated — through the shared structural
+    // classifier (SQLSTATE 42P01, SQLite `no such table`), never this module's
+    // own wording match. Everything else — a deadlock, a serialization failure,
+    // a lock timeout, a dropped connection — is transient or unrelated, and
+    // relabelling it "storage missing" would send an operator to rebuild a
+    // relation that is intact and would hide a retryable conflict from callers
+    // that classify it (graph-merge's commit retry reads the driver SQLSTATE).
+    if (!isMissingTableError(error)) throw error;
     throw separationUnreadableError(graphId, schema, error);
   }
 }

--- a/packages/typegraph/src/identity/separation.ts
+++ b/packages/typegraph/src/identity/separation.ts
@@ -177,6 +177,106 @@ type RawSeparationRow = Readonly<{
   class_key_high: string;
 }>;
 
+/**
+ * Whether the relation records two CURRENT classes as separated.
+ *
+ * One primary-key probe against `(graph_id, class_key_low, class_key_high)`,
+ * standing in for resolving both classes' `different` assertions out of the
+ * ledger and scanning them for one that spans the pair. Callers pass the class
+ * keys in any order; putting them in the relation's `low < high` order is this
+ * module's business, since it is the same ordering the writer applies.
+ *
+ * Valid only for a current-mode read: the relation projects CURRENT assertions
+ * onto CURRENT classes, so a valid-time or recorded coordinate has to
+ * reconstruct from the ledger instead.
+ *
+ * @throws {ConfigurationError} `IDENTITY_STORAGE_MISSING` when the probe cannot
+ * be answered.
+ */
+export async function isSeparated(
+  target: IdentityTarget,
+  schema: SqlSchema,
+  graphId: string,
+  firstClassKey: string,
+  secondClassKey: string,
+): Promise<boolean> {
+  // A class is never separated from itself: `low = high` is what the relation's
+  // CHECK exists to reject, so the probe is a guaranteed miss and the round
+  // trip buys nothing.
+  if (firstClassKey === secondClassKey) return false;
+  const rows = await probeSeparationPair(
+    target,
+    schema,
+    graphId,
+    orderedPair(firstClassKey, secondClassKey),
+  );
+  return rows.length > 0;
+}
+
+async function probeSeparationPair(
+  target: IdentityTarget,
+  schema: SqlSchema,
+  graphId: string,
+  pair: SeparationPair,
+): Promise<readonly RawSeparationRow[]> {
+  try {
+    return await target.execute<RawSeparationRow>(
+      asCompiledRowsSql(sql`
+        SELECT class_key_low, class_key_high
+        FROM ${schema.identitySeparationTable}
+        WHERE graph_id = ${graphId}
+          AND class_key_low = ${pair.low}
+          AND class_key_high = ${pair.high}
+      `),
+    );
+  } catch (error) {
+    // Never degrade to "not separated". A caller that cannot read the relation
+    // has no basis for an answer, and the wrong answer here is the one that
+    // lets a contradiction through. Any failure of a single-table equality
+    // probe on an identity-enabled graph means the relation is unreadable;
+    // rather than pattern-match each driver's wording for a missing table —
+    // which silently degrades the moment a driver rephrases it — every failure
+    // is reported as such, with the driver error preserved as the cause.
+    throw separationUnreadableError(graphId, schema, error);
+  }
+}
+
+function separationUnreadableError(
+  graphId: string,
+  schema: SqlSchema,
+  cause: unknown,
+): ConfigurationError {
+  return new ConfigurationError(
+    "Operational Identity could not read the materialized separation relation.",
+    {
+      code: "IDENTITY_STORAGE_MISSING",
+      graphId,
+      tables: [schema.tables.identitySeparation],
+    },
+    {
+      cause,
+      suggestion:
+        "Recreate the identity separation relation with the standard TypeGraph DDL, open the Store, and run rebuildIdentityClosure(store) before serving traffic.",
+    },
+  );
+}
+
+/**
+ * The persisted relation holds a separated pair the assertion ledger does not
+ * project — the same `rebuild != recompute(ledger)` divergence
+ * {@link assertSeparationMatchesProjection} refuses, discovered by a probe
+ * whose answer the ledger could not corroborate.
+ */
+export function unexpectedSeparationError(
+  graphId: string,
+  firstClassKey: string,
+  secondClassKey: string,
+): ConfigurationError {
+  return separationMismatchError(graphId, {
+    unexpected: orderedPair(firstClassKey, secondClassKey),
+  });
+}
+
 /** Every persisted separation pair for the graph. */
 export async function readSeparationForGraph(
   target: IdentityTarget,

--- a/packages/typegraph/src/identity/service.ts
+++ b/packages/typegraph/src/identity/service.ts
@@ -35,7 +35,9 @@ import {
   deleteSeparationForGraph,
   identityClassKey,
   insertSeparationRows,
+  isSeparated,
   readSeparationForGraph,
+  unexpectedSeparationError,
 } from "./separation";
 import {
   executeIdentityStatement,
@@ -1328,14 +1330,25 @@ async function validateCurrentRelation(
     });
   }
 
-  const different = await loadSpanningDifferentAssertion(
-    target,
-    ctx.schema,
-    ctx.graphId,
-    aClass,
-    bClass,
-  );
-  if (different !== undefined) {
+  // Whether the two classes are held apart is a single index probe on the
+  // derived separation relation. Every caller reaches here with the relation in
+  // step with the ledger: each one repairs it inside the same transaction as
+  // the write it validates, before the next validation runs.
+  const aKey = currentClassKey(aClass);
+  const bKey = currentClassKey(bClass);
+  if (await isSeparated(target, ctx.schema, ctx.graphId, aKey, bKey)) {
+    // The relation records THAT the classes are separated, not which assertion
+    // separates them, and the typed error names one — so the ledger answers
+    // that single question, on the refusal path only.
+    const different = await loadSpanningDifferentAssertion(
+      target,
+      ctx.schema,
+      ctx.graphId,
+      aClass,
+      bClass,
+    );
+    if (different === undefined)
+      throw unexpectedSeparationError(ctx.graphId, aKey, bKey);
     throw new IdentityContradictionError({
       operation,
       a,
@@ -1541,6 +1554,21 @@ async function loadCurrentClassAnchors(
     }
   }
   return anchors;
+}
+
+/**
+ * The separation class key of an already-RESOLVED current class.
+ *
+ * A class is labelled by its code-point-least member: `insertClosureComponents`
+ * and `mergeCurrentClasses` both anchor a class on the first member of its
+ * `compareReferences` ordering, and {@link loadCurrentStructuralClasses}
+ * returns members in that same ordering — so `members[0]` is the anchor
+ * {@link loadCurrentClassAnchors} hands the separation writer, without a second
+ * round trip to fetch it. {@link snapshotClassKey} reads a snapshot the same
+ * way.
+ */
+function currentClassKey(members: readonly PlainNodeRef[]): string {
+  return identityClassKey(requireDefined(members[0]));
 }
 
 /** The class key a full snapshot assigns to a reference. */
@@ -2352,15 +2380,18 @@ export function createIdentityReadFacade<G extends GraphDef>(
         );
         const firstClass = requireDefined(classes.get(refKey(first)));
         const secondClass = requireDefined(classes.get(refKey(second)));
-        const different = await loadSpanningDifferentAssertion(
+        // A boolean is the whole answer here, and the separation relation holds
+        // exactly that boolean for a pair of current classes — no assertion has
+        // to be named, so the ledger is not read at all.
+        const separated = await isSeparated(
           ctx.backend,
           ctx.schema,
           ctx.graphId,
-          firstClass,
-          secondClass,
+          currentClassKey(firstClass),
+          currentClassKey(secondClass),
         );
         return (
-          different !== undefined ||
+          separated ||
           classHasDisjointKinds(ctx.registry, firstClass, secondClass) !==
             undefined
         );

--- a/packages/typegraph/tests/backends/integration/identity-separation.ts
+++ b/packages/typegraph/tests/backends/integration/identity-separation.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from "vitest";
 import { type GraphBackend } from "../../../src";
 import { IdentitySeparationViolationError } from "../../../src/errors";
 import { identityClassKey } from "../../../src/identity/separation";
+import {
+  loadCurrentStructuralClasses,
+  refKey,
+} from "../../../src/identity/service";
 import { createSqlSchema } from "../../../src/query/compiler/schema";
 import { sql } from "../../../src/query/sql-fragment";
 import {
@@ -98,6 +102,62 @@ async function readSeparationRows(
     class_key_low: row.class_key_low,
     class_key_high: row.class_key_high,
   }));
+}
+
+type RawLedgerAssertionRow = Readonly<{
+  id: string;
+  a_kind: string;
+  a_id: string;
+  b_kind: string;
+  b_id: string;
+}>;
+
+/**
+ * The computation the separation probe replaced, rebuilt here from the ledger:
+ * every CURRENT `different` assertion, scanned for one whose endpoints land on
+ * opposite sides of the two nodes' identity classes.
+ *
+ * It reads the assertion table and the closure and never touches the separation
+ * relation, so it is an independent oracle for what the probe now answers.
+ */
+async function ledgerSeparatingAssertionIds(
+  store: IntegrationStoreLike,
+  first: Ref,
+  second: Ref,
+): Promise<readonly string[]> {
+  const schema = createSqlSchema(store.backend.tableNames);
+  const classes = await loadCurrentStructuralClasses(
+    store.backend,
+    schema,
+    store.graphId,
+    [first, second],
+  );
+  const memberKeys = (ref: Ref): ReadonlySet<string> =>
+    new Set(
+      requireDefined(classes.get(refKey(ref))).map((member) => refKey(member)),
+    );
+  const firstKeys = memberKeys(first);
+  const secondKeys = memberKeys(second);
+  const rows = await store.backend.execute<RawLedgerAssertionRow>(
+    asCompiledRowsSql(sql`
+      SELECT id, a_kind, a_id, b_kind, b_id
+      FROM ${schema.identityAssertionsTable}
+      WHERE graph_id = ${store.graphId}
+        AND rel = ${"different"}
+        AND valid_to IS NULL
+        AND deleted_at IS NULL
+    `),
+  );
+  return rows
+    .filter((row) => {
+      const a = refKey({ kind: row.a_kind, id: row.a_id });
+      const b = refKey({ kind: row.b_kind, id: row.b_id });
+      return (
+        (firstKeys.has(a) && secondKeys.has(b)) ||
+        (firstKeys.has(b) && secondKeys.has(a))
+      );
+    })
+    .map((row) => row.id);
 }
 
 function separationPairOf(low: Ref, high: Ref): RawSeparationRow {
@@ -314,6 +374,160 @@ export function registerIdentitySeparationIntegrationTests(
       await storeRuntime(store).rebuildIdentityClosure();
 
       expect(await readSeparationRows(store)).toEqual(expected);
+      await expect(
+        storeRuntime(store).validateIdentity(),
+      ).resolves.toBeUndefined();
+    });
+
+    it("answers current different-ness from the relation, agreeing with the ledger throughout a lifecycle", async () => {
+      const store = context.getStore();
+      // `sameIdAcrossKinds: "fold"` makes the shared id a structural same
+      // assertion nobody wrote, so the walk below covers class formation by
+      // fold as well as by assertion.
+      const alice = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "shared" },
+      );
+      const acme = await store.nodes.Company.create(
+        { name: "Acme" },
+        { id: "shared" },
+      );
+      const bob = await store.nodes.Person.create({ name: "Bob" }, { id: "b" });
+      const carol = await store.nodes.Person.create(
+        { name: "Carol" },
+        { id: "c" },
+      );
+      const dave = await store.nodes.Person.create(
+        { name: "Dave" },
+        { id: "d" },
+      );
+      const references = [
+        { kind: "Person", id: "shared" },
+        { kind: "Company", id: "shared" },
+        { kind: "Person", id: "b" },
+        { kind: "Person", id: "c" },
+        { kind: "Person", id: "d" },
+      ] as const satisfies readonly Ref[];
+
+      async function expectProbeAgreesWithLedger(
+        live: readonly (typeof references)[number][],
+      ): Promise<void> {
+        for (const [index, first] of live.entries()) {
+          for (const second of live.slice(index + 1)) {
+            const separating = await ledgerSeparatingAssertionIds(
+              store,
+              first,
+              second,
+            );
+            expect({
+              first,
+              second,
+              different: await store.identity.areDifferent(first, second),
+            }).toEqual({ first, second, different: separating.length > 0 });
+          }
+        }
+      }
+
+      await expectProbeAgreesWithLedger(references);
+
+      const { assertion: separation } = await store.identity.assertDifferent(
+        alice,
+        bob,
+      );
+      await expectProbeAgreesWithLedger(references);
+
+      // The fused class inherits the separation: `acme` shares `alice`'s class
+      // through the fold, and `carol` joins it by assertion.
+      await store.identity.assertSame(alice, carol);
+      await expectProbeAgreesWithLedger(references);
+
+      // The precheck must refuse exactly what the ledger says it should, with
+      // the assertion the ledger names.
+      const conflict = await store.identity
+        .assertSame(acme, bob)
+        .catch((error: unknown) => error);
+      expect(conflict).toMatchObject({
+        details: {
+          operation: "assertSame",
+          reason: "different-assertion",
+          conflictingAssertionId: separation.id,
+        },
+      });
+      expect(
+        await ledgerSeparatingAssertionIds(store, acme, bob),
+      ).toStrictEqual([separation.id]);
+
+      // A second witness for the same class pair: the relation records one row
+      // for both, so retracting one must not clear the separation.
+      const { assertion: second } = await store.identity.assertDifferent(
+        carol,
+        bob,
+      );
+      await expectProbeAgreesWithLedger(references);
+      await store.identity.retractAssertion(second.id);
+      await expectProbeAgreesWithLedger(references);
+
+      await store.identity.retractAssertion(separation.id);
+      await expectProbeAgreesWithLedger(references);
+
+      // Deleting an endpoint retires the assertion and the relation row with it.
+      await store.identity.assertDifferent(dave, bob);
+      await expectProbeAgreesWithLedger(references);
+      await store.nodes.Person.delete(dave.id);
+      await expectProbeAgreesWithLedger(
+        references.filter((ref) => ref.id !== dave.id),
+      );
+
+      await expect(
+        storeRuntime(store).validateIdentity(),
+      ).resolves.toBeUndefined();
+    });
+
+    it("refuses a different-ness read when the separation relation is gone", async () => {
+      const store = context.getStore();
+      const schema = createSqlSchema(store.backend.tableNames);
+      const executeStatement = requireStatementBackend(store.backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      await store.identity.assertDifferent(alice, bob);
+
+      // Renamed rather than dropped, and put back in a `finally`: backends
+      // whose harness resets by TRUNCATE over a fixed table list cannot recover
+      // from a relation this test destroyed.
+      const stashed = `${schema.tables.identitySeparation}_stashed`;
+      await executeStatement(
+        asCompiledStatementSql(sql`
+          ALTER TABLE ${schema.identitySeparationTable}
+          RENAME TO ${sql.identifier(stashed)}
+        `),
+      );
+      try {
+        // Not `false`. The ledger still says these two are held apart, and a
+        // read that cannot consult the relation has no basis for any answer.
+        const missing = {
+          details: {
+            code: "IDENTITY_STORAGE_MISSING",
+            graphId: store.graphId,
+            tables: [schema.tables.identitySeparation],
+          },
+        };
+        await expect(
+          store.identity.areDifferent(alice, bob),
+        ).rejects.toMatchObject(missing);
+        await expect(
+          store.identity.assertSame(alice, bob),
+        ).rejects.toMatchObject(missing);
+      } finally {
+        await executeStatement(
+          asCompiledStatementSql(sql`
+            ALTER TABLE ${sql.identifier(stashed)}
+            RENAME TO ${schema.identitySeparationTable}
+          `),
+        );
+      }
+
+      // Restored, and the refused write left nothing behind.
+      expect(await store.identity.areDifferent(alice, bob)).toBe(true);
       await expect(
         storeRuntime(store).validateIdentity(),
       ).resolves.toBeUndefined();

--- a/packages/typegraph/tests/identity-import-hardening.test.ts
+++ b/packages/typegraph/tests/identity-import-hardening.test.ts
@@ -884,6 +884,72 @@ describe("importGraph identity failure reporting", () => {
     ).toBe(true);
   });
 
+  it("refuses a same assertion that an earlier assertion in the same batch forbids", async () => {
+    // The import applies a batch inside ONE transaction, repairing the derived
+    // identity relations after each accepted assertion so the next one
+    // validates against the batch's own effects. Both effects are load-bearing
+    // here: the fuse RE-KEYS the class onto `aaron` (the code-point-least
+    // member), and the separation that follows is recorded under that new key —
+    // so the third assertion is refused only if the validation reads both.
+    const store = await createInitializedStore(graph, createTestBackend());
+    const aaron = { kind: "Person", id: "batch-aaron" } as const;
+    const alice = { kind: "Person", id: "batch-alice" } as const;
+    const rival = { kind: "Person", id: "batch-rival" } as const;
+    const [fuseA, fuseB] = orderPair(alice, aaron);
+    const [separatorA, separatorB] = orderPair(alice, rival);
+    const [forbiddenA, forbiddenB] = orderPair(aaron, rival);
+
+    for (const ref of [aaron, alice, rival]) {
+      await store.nodes.Person.create({ name: ref.id }, { id: ref.id });
+    }
+
+    await expect(
+      storeRuntime(store).importIdentityAssertionsAtTarget(
+        store.backend,
+        [
+          {
+            id: "batch-fuse",
+            relation: "same",
+            a: fuseA,
+            b: fuseB,
+            validFrom: CANONICAL_TIMESTAMP,
+          },
+          {
+            id: "batch-separate",
+            relation: "different",
+            a: separatorA,
+            b: separatorB,
+            validFrom: CANONICAL_TIMESTAMP,
+          },
+          {
+            // `aaron` and `rival` carry no assertion between them; they are
+            // held apart only through the class `aaron` was fused into, so the
+            // refusal has to name the separation the batch itself wrote.
+            id: "batch-forbidden",
+            relation: "same",
+            a: forbiddenA,
+            b: forbiddenB,
+            validFrom: CANONICAL_TIMESTAMP,
+          },
+        ],
+        "state",
+      ),
+    ).rejects.toMatchObject({
+      name: "IdentityContradictionError",
+      details: {
+        operation: "import",
+        reason: "different-assertion",
+        conflictingAssertionId: "batch-separate",
+      },
+    });
+
+    expect(await store.identity.areSame(aaron, alice)).toBe(true);
+    expect(await store.identity.areDifferent(aaron, rival)).toBe(true);
+    await expect(
+      storeRuntime(store).validateIdentity(),
+    ).resolves.toBeUndefined();
+  });
+
   it("attributes a missing endpoint to the open assertion that required it", async () => {
     const store = await createInitializedStore(graph, createTestBackend());
     const present = await store.nodes.Person.create(

--- a/packages/typegraph/tests/identity-separation-probe-cost.test.ts
+++ b/packages/typegraph/tests/identity-separation-probe-cost.test.ts
@@ -1,0 +1,152 @@
+/**
+ * What the separation probe costs, counted rather than claimed.
+ *
+ * The read it replaced resolved both identity classes and then loaded every
+ * current `different` assertion touching the first one — a scan whose statement
+ * count grows with class size, because the endpoint list is chunked to fit the
+ * backend's bind budget. The probe is one equality lookup on the relation's
+ * primary key, so the ledger is not read at all and the count does not move
+ * when the class grows.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+  type TransactionBackend,
+} from "../src";
+import { MAX_REFERENCE_CHUNK_SIZE } from "../src/identity/sql-target";
+import { createSqlSchema } from "../src/query/compiler/schema";
+import { type SqlFragment } from "../src/query/sql-fragment";
+import { requireDefined } from "../src/utils/presence";
+import { createInitializedStore, createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "identity_probe_cost",
+  nodes: { Person: { type: Person } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "fold" },
+});
+
+interface RelationCounts {
+  assertionStatements: number;
+  separationStatements: number;
+}
+
+// Table names arrive as identifier chunks, not literal SQL text.
+function fragmentText(compiled: SqlFragment): string {
+  return compiled.chunks
+    .map((chunk) =>
+      chunk.kind === "text" || chunk.kind === "identifier" ? chunk.value : "",
+    )
+    .join(" ");
+}
+
+function relationCountingBackend(): Readonly<{
+  backend: GraphBackend;
+  counts: RelationCounts;
+  reset: () => void;
+}> {
+  const base = createTestBackend();
+  const tables = createSqlSchema(base.tableNames).tables;
+  const counts = { assertionStatements: 0, separationStatements: 0 };
+
+  function count(compiled: SqlFragment): void {
+    const text = fragmentText(compiled);
+    // The separation table name contains the assertions table name in neither
+    // direction, so a plain substring test attributes each statement once.
+    if (text.includes(tables.identityAssertions)) {
+      counts.assertionStatements += 1;
+    }
+    if (text.includes(tables.identitySeparation)) {
+      counts.separationStatements += 1;
+    }
+  }
+
+  // A Proxy rather than a spread: transaction targets carry methods on a
+  // prototype that spreading would drop.
+  function countStatements<T extends GraphBackend | TransactionBackend>(
+    target: T,
+  ): T {
+    return new Proxy(target, {
+      get(source, property, receiver) {
+        const value: unknown = Reflect.get(source, property, receiver);
+        if (typeof value !== "function") return value;
+        const method = value as (...args: unknown[]) => unknown;
+        if (property !== "execute" && property !== "executeStatement") {
+          return value;
+        }
+        return (...args: unknown[]) => {
+          count(args[0] as SqlFragment);
+          return method.apply(source, args);
+        };
+      },
+    });
+  }
+
+  const backend: GraphBackend = countStatements({
+    ...base,
+    transaction: (fn, options) =>
+      base.transaction((tx) => fn(countStatements(tx)), options),
+  } satisfies GraphBackend);
+
+  return {
+    backend,
+    counts,
+    reset: () => {
+      counts.assertionStatements = 0;
+      counts.separationStatements = 0;
+    },
+  };
+}
+
+describe("cost of a current different-ness read", () => {
+  it("probes the relation once and never reads the ledger, whatever the class size", async () => {
+    const { backend, counts, reset } = relationCountingBackend();
+    const store = await createInitializedStore(graph, backend);
+
+    // One class large enough that the replaced ledger scan could not have named
+    // its members in a single statement, and a peer held apart from it.
+    const memberCount = MAX_REFERENCE_CHUNK_SIZE + 50;
+    const members = [];
+    for (let index = 0; index < memberCount; index += 1) {
+      members.push(
+        await store.nodes.Person.create(
+          { name: `member-${index}` },
+          { id: `member-${String(index).padStart(4, "0")}` },
+        ),
+      );
+    }
+    const peer = await store.nodes.Person.create({ name: "Peer" });
+    const anchor = requireDefined(members[0]);
+    await store.identity.bulkAssertSame(
+      members.slice(1).map((member) => ({ a: anchor, b: member })),
+    );
+    await store.identity.assertDifferent(anchor, peer);
+    expect(await store.identity.membersOf(anchor)).toHaveLength(memberCount);
+
+    reset();
+    expect(await store.identity.areDifferent(anchor, peer)).toBe(true);
+    expect(counts).toEqual({
+      assertionStatements: 0,
+      separationStatements: 1,
+    });
+
+    // The negative answer costs the same probe, and so does the answer for a
+    // singleton class: the cost is a property of the relation's index, not of
+    // how much identity state the classes carry.
+    const stranger = await store.nodes.Person.create({ name: "Stranger" });
+    reset();
+    expect(await store.identity.areDifferent(anchor, stranger)).toBe(false);
+    expect(counts).toEqual({
+      assertionStatements: 0,
+      separationStatements: 1,
+    });
+  });
+});

--- a/packages/typegraph/tests/property/identity-separation-probe.test.ts
+++ b/packages/typegraph/tests/property/identity-separation-probe.test.ts
@@ -31,8 +31,11 @@ import {
 import { type PlainNodeRef } from "../../src/identity/sql-target";
 import { asIdentityAssertionId } from "../../src/identity/types";
 import { createSqlSchema } from "../../src/query/compiler/schema";
-import { sql } from "../../src/query/sql-fragment";
-import { asCompiledRowsSql } from "../../src/query/sql-intent";
+import { sql, type SqlFragment } from "../../src/query/sql-fragment";
+import {
+  asCompiledRowsSql,
+  type CompiledRowsSql,
+} from "../../src/query/sql-intent";
 import { storeRuntime } from "../../src/store/runtime-port";
 import { type Store } from "../../src/store/store";
 import { compareCodePoints } from "../../src/utils/compare";
@@ -415,5 +418,97 @@ describe("separation probe versus the assertion ledger", () => {
       { type: "retract", index: 0 },
       { type: "delete", ref: personTwo },
     ]);
+  });
+});
+
+/**
+ * A driver error the probe raised, whose SQLSTATE says what it was.
+ *
+ * `40001` is a serialization failure — transient, and the code graph-merge's
+ * commit retry looks for. `42P01` is `undefined_table`, the one failure the
+ * probe can describe better than the driver can.
+ */
+function driverFailure(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+/** Fails the separation probe — and only the separation probe — with `error`. */
+function probeFailingBackend(error: Error): Readonly<{
+  backend: GraphBackend;
+  arm: () => void;
+}> {
+  const base = createTestBackend();
+  const table = createSqlSchema(base.tableNames).tables.identitySeparation;
+  let armed = false;
+  const namesSeparation = (compiled: CompiledRowsSql): boolean =>
+    (compiled as SqlFragment).chunks.some(
+      (chunk) => chunk.kind === "identifier" && chunk.value === table,
+    );
+  return {
+    backend: {
+      ...base,
+      execute: async <T>(query: CompiledRowsSql): Promise<readonly T[]> => {
+        if (armed && namesSeparation(query)) throw error;
+        return base.execute<T>(query);
+      },
+    },
+    arm: () => {
+      armed = true;
+    },
+  };
+}
+
+describe("a separation probe that cannot read the relation", () => {
+  it("translates a missing relation and passes every other failure through", async () => {
+    const missing = driverFailure(
+      "42P01",
+      'relation "typegraph_identity_separation" does not exist',
+    );
+    const missingProbe = probeFailingBackend(missing);
+    const missingStore = await createInitializedStore(
+      graph,
+      missingProbe.backend,
+    );
+    const first = await missingStore.nodes.Person.create(
+      { name: "First" },
+      { id: "n0" },
+    );
+    const second = await missingStore.nodes.Person.create(
+      { name: "Second" },
+      { id: "n1" },
+    );
+    missingProbe.arm();
+    await expect(
+      missingStore.identity.areDifferent(first, second),
+    ).rejects.toMatchObject({
+      details: { code: "IDENTITY_STORAGE_MISSING" },
+      cause: missing,
+    });
+
+    // A serialization failure is neither missing storage nor corruption: it is
+    // the transaction asking to be re-run, and relabelling it would both send
+    // an operator to rebuild an intact relation and hide the SQLSTATE from the
+    // callers that retry on it.
+    const conflict = driverFailure(
+      "40001",
+      "could not serialize access due to read/write dependencies among transactions",
+    );
+    const conflictProbe = probeFailingBackend(conflict);
+    const conflictStore = await createInitializedStore(
+      graph,
+      conflictProbe.backend,
+    );
+    const third = await conflictStore.nodes.Person.create(
+      { name: "Third" },
+      { id: "n0" },
+    );
+    const fourth = await conflictStore.nodes.Person.create(
+      { name: "Fourth" },
+      { id: "n1" },
+    );
+    conflictProbe.arm();
+    await expect(
+      conflictStore.identity.areDifferent(third, fourth),
+    ).rejects.toBe(conflict);
   });
 });

--- a/packages/typegraph/tests/property/identity-separation-probe.test.ts
+++ b/packages/typegraph/tests/property/identity-separation-probe.test.ts
@@ -1,0 +1,419 @@
+/**
+ * The separation probe against the ledger it derives from.
+ *
+ * `areDifferent` and the `assertSame` contradiction precheck answer current
+ * different-ness with one index probe on `typegraph_identity_separation`
+ * instead of resolving both identity classes and scanning their `different`
+ * assertions. The probe is only correct while the relation stays in step with
+ * the ledger through every operation that can move a class — so this walks
+ * generated assert / bulk-assert / retract / delete sequences and, after each
+ * step, requires the probe's answer to equal the same answer recomputed from
+ * the assertion ledger and the closure alone.
+ *
+ * The oracle here reads the assertion table and the closure and never the
+ * separation relation, so breaking the probe cannot break the oracle with it.
+ */
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  asNodeId,
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+} from "../../src";
+import { IdentityContradictionError } from "../../src/errors";
+import {
+  loadCurrentStructuralClasses,
+  refKey,
+} from "../../src/identity/service";
+import { type PlainNodeRef } from "../../src/identity/sql-target";
+import { asIdentityAssertionId } from "../../src/identity/types";
+import { createSqlSchema } from "../../src/query/compiler/schema";
+import { sql } from "../../src/query/sql-fragment";
+import { asCompiledRowsSql } from "../../src/query/sql-intent";
+import { storeRuntime } from "../../src/store/runtime-port";
+import { type Store } from "../../src/store/store";
+import { compareCodePoints } from "../../src/utils/compare";
+import { requireDefined } from "../../src/utils/presence";
+import { createInitializedStore, createTestBackend } from "../test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Alias = defineNode("Alias", {
+  schema: z.object({ name: z.string() }),
+});
+
+// No disjoint kinds anywhere in this graph: `areDifferent` is then driven by
+// the separation answer alone, so a broken probe cannot be masked by the
+// disjointness half of the same expression.
+const graph = defineGraph({
+  id: "identity_separation_probe",
+  nodes: { Person: { type: Person }, Alias: { type: Alias } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "fold" },
+});
+
+/** A store plus the raw backend the ledger oracle reads through. */
+type Probe = Readonly<{
+  store: Store<typeof graph>;
+  backend: GraphBackend;
+  graphId: string;
+}>;
+
+type Ref = Readonly<{ kind: "Person" | "Alias"; id: string }>;
+
+const NODE_IDS = ["n0", "n1", "n2"] as const;
+const KINDS = ["Person", "Alias"] as const;
+
+const ALL_REFS: readonly Ref[] = KINDS.flatMap((kind) =>
+  NODE_IDS.map((id) => ({ kind, id })),
+);
+
+type Pair = readonly [Ref, Ref];
+
+type Operation =
+  | Readonly<{ type: "assertSame"; pair: Pair }>
+  | Readonly<{ type: "assertDifferent"; pair: Pair }>
+  | Readonly<{ type: "bulkAssertSame"; pairs: readonly Pair[] }>
+  | Readonly<{ type: "retract"; index: number }>
+  | Readonly<{ type: "delete"; ref: Ref }>;
+
+const refArbitrary: fc.Arbitrary<Ref> = fc.constantFrom(...ALL_REFS);
+
+const pairArbitrary: fc.Arbitrary<Pair> = fc
+  .tuple(refArbitrary, refArbitrary)
+  .filter(([first, second]) => refKey(first) !== refKey(second));
+
+const operationArbitrary: fc.Arbitrary<Operation> = fc.oneof(
+  pairArbitrary.map((pair) => ({ type: "assertSame", pair }) as const),
+  pairArbitrary.map((pair) => ({ type: "assertDifferent", pair }) as const),
+  fc
+    .array(pairArbitrary, { minLength: 1, maxLength: 3 })
+    .map((pairs) => ({ type: "bulkAssertSame", pairs }) as const),
+  fc.nat({ max: 15 }).map((index) => ({ type: "retract", index }) as const),
+  refArbitrary.map((ref) => ({ type: "delete", ref }) as const),
+);
+
+type RawAssertionRow = Readonly<{
+  id: string;
+  rel: string;
+  a_kind: string;
+  a_id: string;
+  b_kind: string;
+  b_id: string;
+}>;
+
+/** Every assertion the ledger currently holds open, in a stable order. */
+async function currentLedgerAssertions(
+  probe: Probe,
+): Promise<readonly RawAssertionRow[]> {
+  const schema = createSqlSchema(probe.backend.tableNames);
+  const rows = await probe.backend.execute<RawAssertionRow>(
+    asCompiledRowsSql(sql`
+      SELECT id, rel, a_kind, a_id, b_kind, b_id
+      FROM ${schema.identityAssertionsTable}
+      WHERE graph_id = ${probe.graphId}
+        AND valid_to IS NULL
+        AND deleted_at IS NULL
+    `),
+  );
+  return rows.toSorted((left, right) => compareCodePoints(left.id, right.id));
+}
+
+/** The current identity class of each reference, straight from the closure. */
+async function currentClassMembers(
+  probe: Probe,
+  references: readonly Ref[],
+): Promise<(reference: Ref) => ReadonlySet<string>> {
+  const classes = await loadCurrentStructuralClasses(
+    probe.backend,
+    createSqlSchema(probe.backend.tableNames),
+    probe.graphId,
+    references,
+  );
+  return (reference: Ref) =>
+    new Set(
+      requireDefined(classes.get(refKey(reference))).map(
+        (member: PlainNodeRef) => refKey(member),
+      ),
+    );
+}
+
+/**
+ * The computation the probe replaced: the ids of every current `different`
+ * assertion whose endpoints straddle the two references' identity classes.
+ */
+async function ledgerSeparatingAssertionIds(
+  probe: Probe,
+  first: Ref,
+  second: Ref,
+): Promise<readonly string[]> {
+  const membersOf = await currentClassMembers(probe, [first, second]);
+  const firstMembers = membersOf(first);
+  const secondMembers = membersOf(second);
+  const assertions = await currentLedgerAssertions(probe);
+  return assertions
+    .filter((assertion) => {
+      if (assertion.rel !== "different") return false;
+      const a = refKey({ kind: assertion.a_kind, id: assertion.a_id });
+      const b = refKey({ kind: assertion.b_kind, id: assertion.b_id });
+      return (
+        (firstMembers.has(a) && secondMembers.has(b)) ||
+        (firstMembers.has(b) && secondMembers.has(a))
+      );
+    })
+    .map((assertion) => assertion.id);
+}
+
+async function shareCurrentClass(
+  probe: Probe,
+  first: Ref,
+  second: Ref,
+): Promise<boolean> {
+  const membersOf = await currentClassMembers(probe, [first, second]);
+  return membersOf(first).has(refKey(second));
+}
+
+function currentAssertionFor(
+  assertions: readonly RawAssertionRow[],
+  relation: "same" | "different",
+  first: Ref,
+  second: Ref,
+): RawAssertionRow | undefined {
+  const firstKey = refKey(first);
+  const secondKey = refKey(second);
+  return assertions.find((assertion) => {
+    if (assertion.rel !== relation) return false;
+    const a = refKey({ kind: assertion.a_kind, id: assertion.a_id });
+    const b = refKey({ kind: assertion.b_kind, id: assertion.b_id });
+    return (
+      (a === firstKey && b === secondKey) || (a === secondKey && b === firstKey)
+    );
+  });
+}
+
+type Outcome =
+  Readonly<{ action: "created" | "existing" }> | Readonly<{ error: unknown }>;
+
+async function attemptAssertion(
+  attempt: () => Promise<Readonly<{ action: "created" | "existing" }>>,
+): Promise<Outcome> {
+  try {
+    const result = await attempt();
+    return { action: result.action };
+  } catch (error) {
+    return { error };
+  }
+}
+
+function contradictionIn(outcome: Outcome): IdentityContradictionError {
+  if ("action" in outcome) {
+    throw new Error(
+      `Expected an identity contradiction; the write was ${outcome.action}.`,
+    );
+  }
+  // Anything else is rethrown untouched, so an unexpected failure reports
+  // itself rather than being flattened into "not a contradiction".
+  if (!(outcome.error instanceof IdentityContradictionError))
+    throw outcome.error;
+  return outcome.error;
+}
+
+/**
+ * The `assertSame` precheck, differentially: predict the outcome from the
+ * ledger, then require the write to produce exactly that outcome.
+ */
+async function expectAssertSameMatchesLedger(
+  probe: Probe,
+  [first, second]: Pair,
+): Promise<void> {
+  const assertions = await currentLedgerAssertions(probe);
+  const existing = currentAssertionFor(assertions, "same", first, second);
+  const separating = await ledgerSeparatingAssertionIds(probe, first, second);
+  const outcome = await attemptAssertion(() =>
+    probe.store.identity.assertSame(first, second),
+  );
+
+  if (existing !== undefined) {
+    expect(outcome).toEqual({ action: "existing" });
+    return;
+  }
+  if (separating.length === 0) {
+    expect(outcome).toEqual({ action: "created" });
+    return;
+  }
+  const error = contradictionIn(outcome);
+  expect(error.details.reason).toBe("different-assertion");
+  // Which witness the refusal names is the ledger's row order, not something
+  // the oracle can pin; that it names one of the separating assertions is.
+  expect(separating).toContain(error.details.conflictingAssertionId);
+}
+
+/** The unchanged `assertDifferent` branch, held to the same standard. */
+async function expectAssertDifferentMatchesLedger(
+  probe: Probe,
+  [first, second]: Pair,
+): Promise<void> {
+  const assertions = await currentLedgerAssertions(probe);
+  const existing = currentAssertionFor(assertions, "different", first, second);
+  const shared = await shareCurrentClass(probe, first, second);
+  const outcome = await attemptAssertion(() =>
+    probe.store.identity.assertDifferent(first, second),
+  );
+
+  if (existing !== undefined) {
+    expect(outcome).toEqual({ action: "existing" });
+    return;
+  }
+  if (!shared) {
+    expect(outcome).toEqual({ action: "created" });
+    return;
+  }
+  expect(contradictionIn(outcome).details.reason).toBe("same-class");
+}
+
+async function expectProbeAgreesWithLedger(
+  probe: Probe,
+  live: readonly Ref[],
+): Promise<void> {
+  for (const [index, first] of live.entries()) {
+    for (const second of live.slice(index + 1)) {
+      const separating = await ledgerSeparatingAssertionIds(
+        probe,
+        first,
+        second,
+      );
+      // Compared as one object so a failure names the pair it disagreed on.
+      expect({
+        first,
+        second,
+        areDifferent: await probe.store.identity.areDifferent(first, second),
+      }).toEqual({ first, second, areDifferent: separating.length > 0 });
+    }
+  }
+}
+
+function collectionFor(probe: Probe, ref: Ref) {
+  return ref.kind === "Person" ?
+      probe.store.nodes.Person
+    : probe.store.nodes.Alias;
+}
+
+async function applyOperation(
+  probe: Probe,
+  operation: Operation,
+  live: Set<string>,
+): Promise<void> {
+  switch (operation.type) {
+    case "assertSame": {
+      if (!operation.pair.every((ref) => live.has(refKey(ref)))) return;
+      await expectAssertSameMatchesLedger(probe, operation.pair);
+      return;
+    }
+    case "assertDifferent": {
+      if (!operation.pair.every((ref) => live.has(refKey(ref)))) return;
+      await expectAssertDifferentMatchesLedger(probe, operation.pair);
+      return;
+    }
+    case "bulkAssertSame": {
+      // Bulk writes validate against an in-memory simulation rather than the
+      // probe. They are here as a state builder: their closure repair is what
+      // has to leave the separation relation correct for the next probe.
+      const pairs = operation.pairs.filter((pair) =>
+        pair.every((ref) => live.has(refKey(ref))),
+      );
+      if (pairs.length === 0) return;
+      try {
+        await probe.store.identity.bulkAssertSame(
+          pairs.map(([a, b]) => ({ a, b })),
+        );
+      } catch (error) {
+        if (!(error instanceof IdentityContradictionError)) throw error;
+      }
+      return;
+    }
+    case "retract": {
+      const assertions = await currentLedgerAssertions(probe);
+      if (assertions.length === 0) return;
+      const target = requireDefined(
+        assertions[operation.index % assertions.length],
+      );
+      await probe.store.identity.retractAssertion(
+        asIdentityAssertionId(target.id),
+      );
+      return;
+    }
+    case "delete": {
+      const key = refKey(operation.ref);
+      if (!live.has(key)) return;
+      await collectionFor(probe, operation.ref).delete(
+        asNodeId(operation.ref.id),
+      );
+      live.delete(key);
+      return;
+    }
+  }
+}
+
+async function runScenario(operations: readonly Operation[]): Promise<void> {
+  const backend = createTestBackend();
+  const store = await createInitializedStore(graph, backend);
+  const probe: Probe = { store, backend, graphId: store.graphId };
+  for (const ref of ALL_REFS) {
+    await collectionFor(probe, ref).create(
+      { name: `${ref.kind}-${ref.id}` },
+      { id: ref.id },
+    );
+  }
+  const live = new Set(ALL_REFS.map((ref) => refKey(ref)));
+  const liveReferences = (): readonly Ref[] =>
+    ALL_REFS.filter((ref) => live.has(refKey(ref)));
+
+  await expectProbeAgreesWithLedger(probe, liveReferences());
+  for (const operation of operations) {
+    await applyOperation(probe, operation, live);
+    await expectProbeAgreesWithLedger(probe, liveReferences());
+  }
+
+  // The relation must still equal the ledger's projection at the end: an
+  // agreeing probe over a relation that drifted with the ledger would be a
+  // pair of matching wrong answers.
+  await expect(storeRuntime(store).validateIdentity()).resolves.toBeUndefined();
+}
+
+describe("separation probe versus the assertion ledger", () => {
+  it("answers every current different-ness read exactly as the ledger does", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(operationArbitrary, { minLength: 1, maxLength: 8 }),
+        async (operations) => {
+          await runScenario(operations);
+        },
+      ),
+      { numRuns: 40 },
+    );
+  });
+
+  it("keeps the probe correct across a fold, a fusion and a retraction", async () => {
+    // A scenario the generator would only reach by luck: the same-id fold puts
+    // Person/n0 and Alias/n0 in one class before any assertion exists, a
+    // separation is asserted against that class, both sides then grow, an
+    // assertion is retracted out from under them, and an endpoint leaves.
+    const personZero = { kind: "Person", id: "n0" } as const;
+    const aliasZero = { kind: "Alias", id: "n0" } as const;
+    const aliasTwo = { kind: "Alias", id: "n2" } as const;
+    const personOne = { kind: "Person", id: "n1" } as const;
+    const personTwo = { kind: "Person", id: "n2" } as const;
+    await runScenario([
+      { type: "assertDifferent", pair: [personZero, personOne] },
+      { type: "assertSame", pair: [personOne, personTwo] },
+      { type: "assertSame", pair: [aliasZero, aliasTwo] },
+      { type: "retract", index: 0 },
+      { type: "delete", ref: personTwo },
+    ]);
+  });
+});


### PR DESCRIPTION
`identity.areDifferent()` and the `assertSame` contradiction precheck both ask the same question — are these two identity classes held apart? — and both answered it by resolving the classes, loading every current `different` assertion touching one of them, and scanning in JS for one whose endpoints straddled the pair. That scan reads rows proportional to the class's assertion neighbourhood, and past the backend's bind budget it is not even one statement: `loadAssertionsTouching` chunks the endpoint list at `MAX_REFERENCE_CHUNK_SIZE`.

The separation relation from #376 already holds exactly that answer — one row per separated class pair, under the primary key `(graph_id, class_key_low, class_key_high)`. Both reads now probe it.

`areDifferent` needs a boolean and nothing else, so it stops there and does not read the ledger at all. The precheck still has to name the conflicting assertion in `IdentityContradictionError`, which the relation deliberately does not record — it stores *that* a separation exists, not its witnesses — so it keeps the scan on the refusal path only, where a contradiction is about to abort the write anyway.

Counted rather than claimed: against a class of `MAX_REFERENCE_CHUNK_SIZE + 50` members, `areDifferent` now issues **0** statements against the assertion ledger and exactly **1** against the separation relation.

## Caller classification

Every read that can reach a different-ness answer, and what it does now.

### Rewired — current mode

| Caller | Why it is current mode |
| --- | --- |
| `Store.identity.areDifferent()` | The facade is built with `coordinate: undefined`. |
| `store.asOf(…)` / `store.view({…})` → `areDifferent`, **when the coordinate pins current valid time and no recorded instant** | `identityAtCoordinate` resolves `recordedReadSchemaFor(schema, undefined, …)` to the base schema and keeps `#backend`, so the separation relation it probes is the same one the writers maintain. The existing `isCurrentClosureCoordinate(coordinate)` branch is the gate; only that branch changed. |
| `validateCurrentRelation("same", …)` from `assertPair` (`assertSame` / `assertDifferent`) | Validates, inserts, then repairs (`mergeCurrentClasses` / `replaceSeparationForReferences`) — all in one transaction, so the next validation sees a repaired relation. |
| `validateCurrentRelation("same", "fold", …)` from `foldIdentityForCreatedNodes` | The fold writes no assertions, so the ledger scan and the probe read equally stale state inside its per-peer loop; the closure repair runs once at the end, as before. |
| `validateCurrentRelation(…, "import", …)` from `importIdentityAssertionsIntoTarget` | Repairs after each accepted assertion. Its archival branch (`validTo !== undefined`) inserts an already-ended row, which neither the current projection nor a current ledger scan sees. |

### Untouched — coordinate reads

| Caller | Why the ledger path stays |
| --- | --- |
| `areDifferent` at a valid-time `asOf` / `between`, or at any recorded coordinate | The relation projects **current** assertions onto **current** classes. These keep `loadHistoricalClasses` + `loadSpanningDifferentAssertion(coordinate)`. |

### Untouched — not a current-mode pairwise probe

| Caller | Why |
| --- | --- |
| `bulkAssertPairs` | Its precheck is an in-memory union-find simulation over the affected neighbourhood, because it must see the effect of earlier pairs *in the same batch* that are not persisted yet. No probe of persisted state can answer for it. |
| `assertAffectedIdentityClassesConsistent` / `findAffectedClassInconsistency` | Whole-class consistency assertions after a merge, not pairwise different-ness reads. |
| graph-merge's plan-time contradiction simulation (`src/graph-merge/merge-identity.ts`) | Simulates a post-merge state that does not exist yet. |
| `wrapTransactionIdentity` (`store/transaction-receipt.ts`), `IDENTITY_READ_NAMES` (`store/collection-surface.ts`) | Pure delegation and a name list; neither carries a coordinate. |

## A missing relation is an error, not a `false`

`isSeparated` never degrades to "not separated" — that is precisely the wrong answer, the one that lets a contradiction commit. A probe that cannot be answered raises the existing `IDENTITY_STORAGE_MISSING` `ConfigurationError` naming the separation table, with the driver error as its cause.

Pattern-matching each driver's wording for a missing relation was rejected: it degrades silently the moment a driver rephrases the message, and silent degradation is the failure mode being guarded against.

If the probe reports a separation the ledger cannot corroborate, that is the `rebuild != recompute(ledger)` divergence `assertSeparationMatchesProjection` already refuses, so it raises the same `IDENTITY_SCHEMA_CONTRADICTION` rather than inventing a code.

## Class keys

`currentClassKey` reads the label off an already-resolved class instead of a second round trip for the anchor: a class is anchored on the first member of its `compareReferences` ordering (`insertClosureComponents`, `mergeCurrentClasses`), and `loadCurrentStructuralClasses` returns members in that ordering — the same label `loadCurrentClassAnchors` hands the separation writer, and the same one `snapshotClassKey` derives from a snapshot.

Ordering a pair into the relation's `low < high` form stays inside `separation.ts`, which owns the encoding, so no caller can order a probe differently from the writer. Nothing under `src/query` changed and no dialect branching was introduced.

## Differential test design

The existing suites are the oracle for "no behavior change", but none of them can tell a correct probe from one that happens to agree on the states they build.

**`tests/property/identity-separation-probe.test.ts`** generates assert / bulk-assert / retract / delete sequences (fast-check, 40 runs, up to 8 operations) over six nodes — three ids across two kinds, so `sameIdAcrossKinds: "fold"` forms classes before any assertion exists. After **every** step it requires `areDifferent` for every live pair to equal the answer recomputed from the ledger and the closure alone.

The oracle reads the assertion table and `loadCurrentStructuralClasses`, and never touches the separation relation — so breaking the probe cannot break the oracle with it.

`assertSame` is differential too: the outcome is predicted from the ledger *before* the write (existing / created / contradiction, and for a contradiction that the named `conflictingAssertionId` is one of the assertions actually separating the pair), then compared with what the write did. Which witness a refusal names is the ledger's row order rather than something an oracle can pin, so membership is what is asserted — the probe does not change it, since the refusal path calls the same `loadSpanningDifferentAssertion` with the same arguments. `assertDifferent` is held to its unchanged same-class rule alongside it. Each run ends on `validateIdentity()`, so a relation that drifted *in step with* a broken probe still fails.

The graph declares no disjoint kinds, so `areDifferent` is driven by the separation answer alone and a broken probe cannot be masked by the disjointness half of the same expression.

**Verified load-bearing both ways.** With `isSeparated` forced to `false`, and again forced to `true`, both property cases and both new cross-backend cases fail.

Cross-backend cases live in `tests/backends/integration/identity-separation.ts` and run on every backend: a deterministic lifecycle (fold, separation, fusion, a second witness for one class pair, two retractions, an endpoint deleted) checked against the ledger at each step, and the missing-relation refusal. That one renames the relation away rather than dropping it, and renames it back in a `finally` — the PGlite harness resets by TRUNCATE over a fixed table list and cannot recover from a relation a test destroyed.

Changeset: patch.

Closes #379
