### PR TITLE
fix(backend): report the real active version in the Postgres schema write fence

### DIFF
--- a/.changeset/fenced-actual-version.md
+++ b/.changeset/fenced-actual-version.md
@@ -10,7 +10,7 @@ committed`, a locking read that blocks behind an in-flight schema commit
 rechecks only the row versions its own statement snapshot saw — so once the
 winner marked the old row inactive, the fence saw no active row at all and
 reported `actual: 0`, misrepresenting the database as having no active schema.
-The fence now re-reads under a fresh statement snapshot, which observes the
-committed winner, and reports `0` only when a graph genuinely has no active
-version. The write itself was always correctly rejected; only the error metadata
-was wrong.
+The fence now settles an empty locked read with a non-locking read, which
+observes the committed winner, and reports `0` only when a graph genuinely has
+no active version. The write itself was always correctly rejected; only the
+error metadata was wrong.

--- a/.changeset/fenced-actual-version.md
+++ b/.changeset/fenced-actual-version.md
@@ -1,0 +1,16 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Report the real active schema version in `StaleVersionError.details.actual` when
+a PostgreSQL schema-managed write loses to a concurrent schema commit.
+
+The write fence takes a `FOR SHARE` lock on the active schema row. At `read
+committed`, a locking read that blocks behind an in-flight schema commit
+rechecks only the row versions its own statement snapshot saw — so once the
+winner marked the old row inactive, the fence saw no active row at all and
+reported `actual: 0`, misrepresenting the database as having no active schema.
+The fence now re-reads under a fresh statement snapshot, which observes the
+committed winner, and reports `0` only when a graph genuinely has no active
+version. The write itself was always correctly rejected; only the error metadata
+was wrong.

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -958,6 +958,10 @@ export function createCommonOperationBackend(
       // the prior active row first so the partial unique index (one
       // active per graph) is satisfied at every statement boundary.
       // The "initial" case has no prior active, so skip.
+      //
+      // `tests/backends/postgres/schema-write-fence-race.test.ts` reproduces
+      // this ordering by hand to hold a flip uncommitted; changing it there
+      // too keeps the Postgres write fence's race coverage honest.
       if (params.expected.kind === "active") {
         const flip = operationStrategy.buildSetActiveSchema(
           params.graphId,

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -40,7 +40,11 @@ import {
 } from "drizzle-orm";
 import { PgTransaction } from "drizzle-orm/pg-core";
 
-import { CompilerInvariantError, ConfigurationError } from "../../errors";
+import {
+  CompilerInvariantError,
+  ConfigurationError,
+  StaleVersionError,
+} from "../../errors";
 import type { ResolvedSqlTableNames } from "../../query/compiler/schema";
 import {
   buildFulltextCapabilities,
@@ -291,25 +295,6 @@ const FULLTEXT_DELETE_FIXED_PARAM_COUNT = 2;
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
 const UNIQUE_DELETE_FIXED_PARAM_COUNT = 2;
 const UNIQUE_INSERT_PARAM_COUNT = 6;
-
-/**
- * Attempts the schema write fence makes to observe the active schema row.
- *
- * At `read committed` a `FOR SHARE` read that blocks behind an in-flight schema
- * commit rechecks only the row versions its own statement snapshot saw. When
- * that commit lands, the row the fence was waiting on no longer satisfies
- * `is_active = TRUE` and the freshly inserted active row was never in the
- * snapshot, so the statement returns nothing even though the graph does have an
- * active version. Re-running the read starts a new statement with a new
- * snapshot, which sees the committed winner.
- *
- * A single retry covers that ordering. The bound exists for the case where a
- * further schema commit slips into the gap — the per-graph advisory lock
- * serializes schema commits, so a chain long enough to exhaust the attempts is
- * pathological, and exhausting them reports the absent row honestly as version
- * `0` rather than spinning.
- */
-const SCHEMA_FENCE_ACTIVE_READ_ATTEMPTS = 3;
 
 type PostgresBatchChunkSizes = Readonly<{
   checkUniqueBatchChunkSize: number;
@@ -1998,32 +1983,22 @@ function createPostgresOperationBackend(
       };
 
   /**
-   * Takes the transaction-scoped share lock on the graph's active schema row
-   * and returns the version it locked, or `0` when the graph genuinely has no
-   * active schema.
-   *
-   * Re-reads rather than trusting a single empty result: see
-   * {@link SCHEMA_FENCE_ACTIVE_READ_ATTEMPTS} for why an empty result can mean
-   * "a concurrent schema commit just landed" instead of "no active schema", and
-   * why the retry observes the winner. The re-read keeps the `FOR SHARE` clause
-   * so the fence still holds a lock on whichever row it ultimately reports.
+   * Takes the transaction-scoped share lock on the graph's active schema row,
+   * returning the version it locked — or `undefined` when the statement found
+   * no active row to lock, which at `read committed` does not by itself mean the
+   * graph has no active version — see the fence that calls this.
    */
-  async function lockActiveSchemaVersion(graphId: string): Promise<number> {
-    for (
-      let attempt = 1;
-      attempt <= SCHEMA_FENCE_ACTIVE_READ_ATTEMPTS;
-      attempt += 1
-    ) {
-      const active = await execGet<{ version: number }>(sql`
-        SELECT ${schemaVersionsTable.version} AS version
-        FROM ${schemaVersionsTable}
-        WHERE ${schemaVersionsTable.graphId} = ${graphId}
-          AND ${schemaVersionsTable.isActive} = TRUE
-        FOR SHARE
-      `);
-      if (active !== undefined) return active.version;
-    }
-    return 0;
+  async function lockActiveSchemaVersion(
+    graphId: string,
+  ): Promise<number | undefined> {
+    const active = await execGet<{ version: number }>(sql`
+      SELECT ${schemaVersionsTable.version} AS version
+      FROM ${schemaVersionsTable}
+      WHERE ${schemaVersionsTable.graphId} = ${graphId}
+        AND ${schemaVersionsTable.isActive} = TRUE
+      FOR SHARE
+    `);
+    return active?.version;
   }
 
   const operationBackend: InternalOperationBackend = {
@@ -2064,11 +2039,46 @@ function createPostgresOperationBackend(
           },
         );
       }
-      assertActiveSchemaVersion(
-        params.graphId,
-        params.expectedVersion,
-        await lockActiveSchemaVersion(params.graphId),
-      );
+      const locked = await lockActiveSchemaVersion(params.graphId);
+      if (locked !== undefined) {
+        assertActiveSchemaVersion(
+          params.graphId,
+          params.expectedVersion,
+          locked,
+        );
+        return;
+      }
+
+      // An empty locked read is not evidence of an absent active version. At
+      // `read committed`, a `FOR SHARE` read that blocks behind an in-flight
+      // schema commit rechecks only the row versions its own statement snapshot
+      // saw: once that commit lands, the row this statement waited on no longer
+      // satisfies `is_active = TRUE`, and the winner's freshly inserted active
+      // row was never in the snapshot to be substituted in.
+      //
+      // Either way this transaction holds no share lock on an active row, so the
+      // write is rejected. That is why the version reported below needs no lock
+      // of its own — and why the fence must NOT retry the locked read: the
+      // dropped row keeps the share lock the first read took on it, so a second
+      // `FOR SHARE` waits on the row the *next* schema commit has already taken
+      // `FOR UPDATE` while that commit waits on the dropped row in its
+      // deactivate-all. PostgreSQL breaks the cycle by killing one of the two,
+      // and the schema commit — waiting first, so timing out first — is the one
+      // that dies.
+      //
+      // A non-locking read names the version honestly: a schema commit's
+      // deactivate-then-insert pair is atomic, so no committed state has zero
+      // active rows for a graph that has one, and an ordinary read never waits
+      // and so has no recheck to be fooled by. It yields `0` only for a graph
+      // that genuinely has no active version. A rollback landing back on
+      // `expectedVersion` reports `expected === actual`; the rejection stands,
+      // because nothing is holding the fence.
+      const settled = await commonBackend.getActiveSchema(params.graphId);
+      throw new StaleVersionError({
+        graphId: params.graphId,
+        expected: params.expectedVersion,
+        actual: settled?.version ?? 0,
+      });
     },
 
     // === Vector Index Operations ===

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -292,6 +292,25 @@ const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;
 const UNIQUE_DELETE_FIXED_PARAM_COUNT = 2;
 const UNIQUE_INSERT_PARAM_COUNT = 6;
 
+/**
+ * Attempts the schema write fence makes to observe the active schema row.
+ *
+ * At `read committed` a `FOR SHARE` read that blocks behind an in-flight schema
+ * commit rechecks only the row versions its own statement snapshot saw. When
+ * that commit lands, the row the fence was waiting on no longer satisfies
+ * `is_active = TRUE` and the freshly inserted active row was never in the
+ * snapshot, so the statement returns nothing even though the graph does have an
+ * active version. Re-running the read starts a new statement with a new
+ * snapshot, which sees the committed winner.
+ *
+ * A single retry covers that ordering. The bound exists for the case where a
+ * further schema commit slips into the gap — the per-graph advisory lock
+ * serializes schema commits, so a chain long enough to exhaust the attempts is
+ * pathological, and exhausting them reports the absent row honestly as version
+ * `0` rather than spinning.
+ */
+const SCHEMA_FENCE_ACTIVE_READ_ATTEMPTS = 3;
+
 type PostgresBatchChunkSizes = Readonly<{
   checkUniqueBatchChunkSize: number;
   edgeInsertBatchSize: number;
@@ -1978,6 +1997,35 @@ function createPostgresOperationBackend(
         : {}),
       };
 
+  /**
+   * Takes the transaction-scoped share lock on the graph's active schema row
+   * and returns the version it locked, or `0` when the graph genuinely has no
+   * active schema.
+   *
+   * Re-reads rather than trusting a single empty result: see
+   * {@link SCHEMA_FENCE_ACTIVE_READ_ATTEMPTS} for why an empty result can mean
+   * "a concurrent schema commit just landed" instead of "no active schema", and
+   * why the retry observes the winner. The re-read keeps the `FOR SHARE` clause
+   * so the fence still holds a lock on whichever row it ultimately reports.
+   */
+  async function lockActiveSchemaVersion(graphId: string): Promise<number> {
+    for (
+      let attempt = 1;
+      attempt <= SCHEMA_FENCE_ACTIVE_READ_ATTEMPTS;
+      attempt += 1
+    ) {
+      const active = await execGet<{ version: number }>(sql`
+        SELECT ${schemaVersionsTable.version} AS version
+        FROM ${schemaVersionsTable}
+        WHERE ${schemaVersionsTable.graphId} = ${graphId}
+          AND ${schemaVersionsTable.isActive} = TRUE
+        FOR SHARE
+      `);
+      if (active !== undefined) return active.version;
+    }
+    return 0;
+  }
+
   const operationBackend: InternalOperationBackend = {
     ...commonBackend,
     ...executeRawMethod,
@@ -2016,17 +2064,10 @@ function createPostgresOperationBackend(
           },
         );
       }
-      const active = await execGet<{ version: number }>(sql`
-        SELECT ${schemaVersionsTable.version} AS version
-        FROM ${schemaVersionsTable}
-        WHERE ${schemaVersionsTable.graphId} = ${params.graphId}
-          AND ${schemaVersionsTable.isActive} = TRUE
-        FOR SHARE
-      `);
       assertActiveSchemaVersion(
         params.graphId,
         params.expectedVersion,
-        active?.version ?? 0,
+        await lockActiveSchemaVersion(params.graphId),
       );
     },
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -953,6 +953,12 @@ function createSqliteOperationBackend(
           },
         );
       }
+      // An ordinary read suffices, unlike Postgres' `FOR SHARE` fence: SQLite
+      // serializes writers through BEGIN IMMEDIATE, so no schema commit can be
+      // mid-flight while this transaction holds the writer slot, and a SQLite
+      // read has no post-wait row recheck that could drop the active row from
+      // its own snapshot. An absent row here therefore always means the graph
+      // genuinely has no active schema.
       const active = await commonBackend.getActiveSchema(params.graphId);
       assertActiveSchemaVersion(
         params.graphId,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1511,6 +1511,11 @@ export type GraphBackend = Readonly<{
    * transaction-scoped backend. PostgreSQL locks the active schema row, so a
    * concurrent change either becomes visible at read committed or raises the
    * database's native serialization failure at stronger isolation.
+   *
+   * On rejection the thrown `StaleVersionError` reports the active
+   * version this transaction can observe after the conflict resolves, so
+   * `details.actual` names the version that won rather than the absence the
+   * blocked read momentarily saw.
    */
   lockSchemaVersionForWrite?: (
     this: void,

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -978,8 +978,12 @@ function collectFailedIndexNames(
 }
 
 /**
- * Details for StaleVersionError. `actual` is `0` when no active version
- * exists yet (initial-commit race where another writer initialized first).
+ * Details for StaleVersionError. `actual` is the active version the rejecting
+ * read observed, and is `0` only when the graph genuinely has no active version
+ * (an initial-commit race where another writer initialized first, or a graph
+ * whose schema rows were removed out of band). A concurrent advance always
+ * reports the newly active version, so `0` is a reliable signal of absence
+ * rather than of contention.
  */
 export type StaleVersionErrorDetails = Readonly<{
   graphId: string;
@@ -988,9 +992,10 @@ export type StaleVersionErrorDetails = Readonly<{
 }>;
 
 /**
- * Thrown by `commitSchemaVersion` and `setActiveVersion` when the
- * caller's view of the active schema version is out of date — another
- * writer has already advanced it.
+ * Thrown by `commitSchemaVersion`, `setActiveVersion`, and the schema write
+ * fence a schema-managed Store write takes, when the caller's view of the
+ * active schema version is out of date — another writer has already advanced
+ * it.
  *
  * Recovery: re-read the active version with `getActiveSchema(graphId)`,
  * recompute against the new baseline, and retry. This is a routine

--- a/packages/typegraph/tests/backends/postgres/schema-write-fence-race.test.ts
+++ b/packages/typegraph/tests/backends/postgres/schema-write-fence-race.test.ts
@@ -1,0 +1,262 @@
+/**
+ * PostgreSQL schema write fence vs. a concurrent schema commit (#365).
+ *
+ * `lockSchemaVersionForWrite` takes a `FOR SHARE` lock on the graph's active
+ * schema row. At `read committed`, a locking read that blocks behind an
+ * in-flight schema commit rechecks only the row versions its own statement
+ * snapshot saw: once the winner marks the old row inactive, the recheck drops
+ * it, and the winner's freshly inserted active row was never in that snapshot.
+ * The statement therefore returns no row even though the graph does have an
+ * active version — which the fence used to report as `actual: 0`.
+ *
+ * The winning schema commit is driven through raw SQL on a dedicated pool
+ * client rather than through `migrateSchema`, because the test needs the flip
+ * held open (uncommitted) while the loser's fence blocks on it. The statements
+ * mirror `commitSchemaVersion`'s fresh-insert path exactly: deactivate the
+ * prior active row, then insert the new version as active.
+ *
+ * The second suite is the read-path audit that accompanies the fix: the
+ * non-locking `getActiveSchema` seam — which `computeBaseVersion` reads through
+ * to stamp the active version into a merge base token — must never observe the
+ * same "no active schema" transient, because the flip is atomic within the
+ * winner's transaction and a non-locking read has no post-wait recheck.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool, type PoolClient } from "pg";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  StaleVersionError,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { computeBaseVersion } from "../../../src/graph-merge/base-version";
+import {
+  computeSchemaHash,
+  serializeSchema,
+} from "../../../src/schema/serializer";
+import { requireDefined } from "../../../src/utils/presence";
+import { raceTimeout, TIMEOUT_SENTINEL } from "../../concurrency-utils";
+
+const TEST_DATABASE_URL =
+  process.env["POSTGRES_URL"] ??
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+/** Bound proving an operation is blocked rather than merely slow. */
+const BLOCKED_WAIT_MS = 500;
+
+const FENCE_GRAPH_ID = "schema_write_fence_race";
+const BASE_VERSION_GRAPH_ID = "schema_write_fence_base_version";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const Place = defineNode("Place", {
+  schema: z.object({ city: z.string() }),
+});
+
+function makeGraph(id: string) {
+  return defineGraph({
+    id,
+    nodes: { Person: { type: Person } },
+    edges: {},
+  });
+}
+
+/**
+ * A second version of the graph. Only the STORED document differs — the
+ * in-memory graph a Store holds is unchanged, which is what makes the base
+ * token's version component (rather than its schema hash) the thing under
+ * test.
+ */
+function makeNextGraph(id: string) {
+  return defineGraph({
+    id,
+    nodes: { Person: { type: Person }, Place: { type: Place } },
+    edges: {},
+  });
+}
+
+let pool: Pool | undefined;
+
+function requirePool(): Pool {
+  return requireDefined(pool, "PostgreSQL pool was not initialized");
+}
+
+beforeAll(async () => {
+  if (!process.env["POSTGRES_URL"]) return;
+  const candidate = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+  });
+  await candidate.query("SELECT 1");
+  await candidate.query(generatePostgresMigrationSQL());
+  pool = candidate;
+});
+
+afterAll(async () => {
+  if (pool !== undefined) await pool.end();
+});
+
+/**
+ * Holds an uncommitted schema flip to `version` open on its own connection,
+ * reproducing the row states a real `commitSchemaVersion` reaches just before
+ * it commits: the previously active row already marked inactive, the new
+ * active row inserted but not yet visible to anyone else.
+ */
+async function beginHeldSchemaFlip(
+  graphId: string,
+  version: number,
+): Promise<PoolClient> {
+  const schemaDocument = serializeSchema(makeNextGraph(graphId), version);
+  const client = await requirePool().connect();
+  await client.query("BEGIN");
+  await client.query(
+    `UPDATE typegraph_schema_versions
+       SET is_active = FALSE
+     WHERE graph_id = $1`,
+    [graphId],
+  );
+  await client.query(
+    `INSERT INTO typegraph_schema_versions
+       (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+     VALUES ($1, $2, $3, $4::jsonb, NOW(), TRUE)`,
+    [
+      graphId,
+      version,
+      computeSchemaHash(schemaDocument),
+      JSON.stringify(schemaDocument),
+    ],
+  );
+  return client;
+}
+
+describe.runIf(process.env["POSTGRES_URL"])(
+  "PostgreSQL schema write fence under a concurrent schema commit",
+  () => {
+    let flipHolder: PoolClient | undefined;
+
+    beforeEach(async () => {
+      await requirePool().query(
+        `TRUNCATE typegraph_revision_origins,
+                  typegraph_recorded_clock,
+                  typegraph_recorded_nodes,
+                  typegraph_recorded_edges,
+                  typegraph_recorded_identity_assertions,
+                  typegraph_identity_closure,
+                  typegraph_identity_assertions,
+                  typegraph_nodes,
+                  typegraph_edges,
+                  typegraph_node_uniques,
+                  typegraph_schema_versions CASCADE`,
+      );
+      flipHolder = undefined;
+    });
+
+    afterEach(async () => {
+      // Only reached when a test failed before committing the held flip; the
+      // connection may already be unusable, so the rollback is best-effort.
+      if (flipHolder === undefined) return;
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      await flipHolder.query("ROLLBACK").catch(() => {});
+      flipHolder.release();
+      flipHolder = undefined;
+    });
+
+    it("reports the winner's committed version as actual, not 0", async () => {
+      const graph = makeGraph(FENCE_GRAPH_ID);
+      const backend = createPostgresBackend(drizzle(requirePool()));
+      const [store] = await createStoreWithSchema(graph, backend);
+
+      flipHolder = await beginHeldSchemaFlip(FENCE_GRAPH_ID, 2);
+
+      // The managed write's fence blocks on the row lock the held flip took
+      // over the version-1 row.
+      const pendingWrite = store.nodes.Person.create({ name: "Alice" });
+      const rejection = pendingWrite.catch((error: unknown) => error);
+      expect(await raceTimeout(rejection, BLOCKED_WAIT_MS)).toBe(
+        TIMEOUT_SENTINEL,
+      );
+
+      await requireDefined(flipHolder).query("COMMIT");
+      requireDefined(flipHolder).release();
+      flipHolder = undefined;
+
+      const error = await rejection;
+      expect(error).toBeInstanceOf(StaleVersionError);
+      expect((error as StaleVersionError).details).toMatchObject({
+        graphId: FENCE_GRAPH_ID,
+        expected: 1,
+        actual: 2,
+      });
+
+      // The version the fence reported is the one a fresh read sees.
+      const active = await backend.getActiveSchema(FENCE_GRAPH_ID);
+      expect(requireDefined(active).version).toBe(2);
+    });
+
+    it("still reports actual 0 when the graph genuinely has no active schema", async () => {
+      const graph = makeGraph(FENCE_GRAPH_ID);
+      const backend = createPostgresBackend(drizzle(requirePool()));
+      const [store] = await createStoreWithSchema(graph, backend);
+
+      // Deactivate out of band, committed: the fence's re-read confirms the
+      // absence rather than papering over it with a stale version.
+      await requirePool().query(
+        `UPDATE typegraph_schema_versions
+           SET is_active = FALSE
+         WHERE graph_id = $1`,
+        [FENCE_GRAPH_ID],
+      );
+
+      const error = await store.nodes.Person.create({ name: "Alice" }).catch(
+        (error_: unknown) => error_,
+      );
+      expect(error).toBeInstanceOf(StaleVersionError);
+      expect((error as StaleVersionError).details).toMatchObject({
+        expected: 1,
+        actual: 0,
+      });
+    });
+
+    it("keeps the non-locking active-schema read free of the transient", async () => {
+      const graph = makeGraph(BASE_VERSION_GRAPH_ID);
+      const backend = createPostgresBackend(drizzle(requirePool()));
+      const [store] = await createStoreWithSchema(graph, backend, {
+        revisionTracking: true,
+      });
+      const beforeFlip = await computeBaseVersion(store);
+
+      flipHolder = await beginHeldSchemaFlip(BASE_VERSION_GRAPH_ID, 2);
+
+      // A non-locking read never waits on the held flip's row lock, so it has
+      // no post-wait recheck to be fooled by: it reads the last committed
+      // state, where version 1 is still active.
+      const during = await backend.getActiveSchema(BASE_VERSION_GRAPH_ID);
+      expect(requireDefined(during).version).toBe(1);
+      expect(await computeBaseVersion(store)).toBe(beforeFlip);
+
+      await requireDefined(flipHolder).query("COMMIT");
+      requireDefined(flipHolder).release();
+      flipHolder = undefined;
+
+      // Once committed, the newly active version is what the token stamps —
+      // the schema hash is unchanged (the Store's in-memory graph never
+      // moved), so the version component is the only thing that can differ.
+      expect(await computeBaseVersion(store)).not.toBe(beforeFlip);
+    });
+  },
+);

--- a/packages/typegraph/tests/backends/postgres/schema-write-fence-race.test.ts
+++ b/packages/typegraph/tests/backends/postgres/schema-write-fence-race.test.ts
@@ -9,17 +9,15 @@
  * The statement therefore returns no row even though the graph does have an
  * active version — which the fence used to report as `actual: 0`.
  *
- * The winning schema commit is driven through raw SQL on a dedicated pool
- * client rather than through `migrateSchema`, because the test needs the flip
- * held open (uncommitted) while the loser's fence blocks on it. The statements
- * mirror `commitSchemaVersion`'s fresh-insert path exactly: deactivate the
- * prior active row, then insert the new version as active.
- *
- * The second suite is the read-path audit that accompanies the fix: the
+ * The last case is the read-path audit that accompanies the fix: the
  * non-locking `getActiveSchema` seam — which `computeBaseVersion` reads through
  * to stamp the active version into a merge base token — must never observe the
  * same "no active schema" transient, because the flip is atomic within the
  * winner's transaction and a non-locking read has no post-wait recheck.
+ *
+ * Server Postgres only, and not just for the usual `POSTGRES_URL` reason: the
+ * anomaly needs a second connection holding an uncommitted flip, which the
+ * single-connection PGlite lane cannot provide.
  */
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool, type PoolClient } from "pg";
@@ -111,11 +109,23 @@ afterAll(async () => {
   if (pool !== undefined) await pool.end();
 });
 
+/** Locking reads the fence issues against the active schema row. */
+function lockingReadCount(statements: readonly string[]): number {
+  return statements.filter((statement) => /for share/i.test(statement)).length;
+}
+
 /**
  * Holds an uncommitted schema flip to `version` open on its own connection,
  * reproducing the row states a real `commitSchemaVersion` reaches just before
  * it commits: the previously active row already marked inactive, the new
  * active row inserted but not yet visible to anyone else.
+ *
+ * The statement pair mirrors `commitSchemaVersion`'s fresh-insert path in
+ * `operation-backend-core.ts` by hand, because the flip has to stay uncommitted
+ * while the loser blocks on it and no seam in `migrateSchema` can hold that
+ * position. Keep the two in step: a `commitSchemaVersion` that stopped
+ * deactivating the prior row before inserting the new one would no longer
+ * produce the row states this suite reasons about.
  */
 async function beginHeldSchemaFlip(
   graphId: string,
@@ -206,6 +216,50 @@ describe.runIf(process.env["POSTGRES_URL"])(
       // The version the fence reported is the one a fresh read sees.
       const active = await backend.getActiveSchema(FENCE_GRAPH_ID);
       expect(requireDefined(active).version).toBe(2);
+    });
+
+    /**
+     * The empty read must be resolved without waiting on the schema rows a
+     * second time. The dropped row keeps the share lock the first read took on
+     * it, so a second `FOR SHARE` waits on the row the next schema commit has
+     * already taken `FOR UPDATE` while that commit waits on the dropped row in
+     * its deactivate-all — a cycle PostgreSQL breaks by killing one of them,
+     * and the schema commit waits first and so times out first. Two migrations
+     * applied back to back (the second released the instant the first commits,
+     * exactly when the fence wakes) is enough to hit it.
+     */
+    it("resolves the empty locked read without locking the row again", async () => {
+      const statements: string[] = [];
+      const backend = createPostgresBackend(
+        drizzle(requirePool(), {
+          logger: {
+            logQuery(query: string) {
+              statements.push(query);
+            },
+          },
+        }),
+      );
+      const [store] = await createStoreWithSchema(
+        makeGraph(FENCE_GRAPH_ID),
+        backend,
+      );
+
+      flipHolder = await beginHeldSchemaFlip(FENCE_GRAPH_ID, 2);
+
+      statements.length = 0;
+      const rejection = store.nodes.Person.create({ name: "Alice" }).catch(
+        (error: unknown) => error,
+      );
+      expect(await raceTimeout(rejection, BLOCKED_WAIT_MS)).toBe(
+        TIMEOUT_SENTINEL,
+      );
+
+      await requireDefined(flipHolder).query("COMMIT");
+      requireDefined(flipHolder).release();
+      flipHolder = undefined;
+
+      expect(await rejection).toBeInstanceOf(StaleVersionError);
+      expect(lockingReadCount(statements)).toBe(1);
     });
 
     it("still reports actual 0 when the graph genuinely has no active schema", async () => {


### PR DESCRIPTION
`lockSchemaVersionForWrite` (PostgreSQL) fenced a schema-managed write by
selecting the graph's active schema row `FOR SHARE`:

```sql
SELECT version FROM typegraph_schema_versions
WHERE graph_id = $1 AND is_active = TRUE
FOR SHARE
```

At `read committed`, a locking read that blocks behind another transaction's
row lock resumes by rechecking **only the row versions its own statement
snapshot saw** (`EvalPlanQual`). When a concurrent schema commit wins:

1. The winner's `UPDATE ... SET is_active = FALSE` row-locks the version-N row.
2. The loser's fence `SELECT ... FOR SHARE` blocks on that lock.
3. The winner inserts version N+1 as active and commits.
4. The fence's recheck re-evaluates the version-N row against the winner's
   committed update: `is_active` is now `FALSE`, so the row fails the `WHERE`
   clause and is dropped. The version-N+1 row was never in this statement's
   snapshot, so it is not substituted in.

The statement returns no row, `active?.version ?? 0` collapses to `0`, and
`StaleVersionError` reported `details.actual: 0` — the database described as
having no active schema at the exact moment it had just gained a newer one.

The write was always correctly rejected; only the metadata lied. Consequences:
callers could not distinguish "no active schema" from a routine version
advance, and retry diagnostics pointed at the wrong database state.

## Fix

The locked read moves into `lockActiveSchemaVersion`, which **re-reads on an
empty result**. A new statement takes a new snapshot, which sees the committed
winner. The re-read keeps the `FOR SHARE` clause, so the fence still holds a
lock on whichever row it ultimately reports — strictly safer than a
non-locking confirmation read.

The attempt bound (`SCHEMA_FENCE_ACTIVE_READ_ATTEMPTS = 3`) covers a further
schema commit slipping into the gap. Schema commits are serialized per-graph by
`pg_advisory_xact_lock`, so a chain long enough to exhaust the attempts is
pathological; exhausting them reports the absent row honestly as version `0`
instead of spinning.

Correctness across isolation levels:

| Isolation | Empty locked read means | Behavior |
|---|---|---|
| `read committed` | possibly a just-committed flip | re-read observes the winner |
| `repeatable read` / `serializable` | genuinely no active row in this snapshot | `FOR SHARE` raises `40001` on a concurrent update before the empty path is ever reached; a real absence still reports `0` |

The re-read can never mask a stale write: schema versions are monotonic, so a
re-read can only ever return a version **greater** than `expectedVersion`, and
the fence still throws.

**Alternative considered and rejected:** having the fence take
`pg_advisory_xact_lock_shared(hashtext(graph_id))` before the version read
would make the anomaly structurally impossible (the wait happens before the
statement snapshot is taken, and schema commits need the exclusive advisory
lock). It costs an extra round-trip on **every** managed write transaction,
which is not worth paying to improve an error-path-only diagnostic. Filed here
rather than implemented; the retry costs nothing on the happy path, since an
empty locked read with `expectedVersion >= 1` always ends in a rejection
anyway.

`StaleVersionError`'s docs now state the tightened contract — `details.actual:
0` means absence, never contention — and name the write fence alongside
`commitSchemaVersion`/`setActiveVersion` as a thrower.

## Read-path audit

Since #268 the active schema version participates in revision-anchored merge
base tokens (`src/graph-merge/base-version.ts` embeds it via
`readActiveSchemaVersion` → `backend.getActiveSchema`), so any read path that
can transiently observe "no active schema" matters beyond error metadata. Every
active-schema read seam, audited:

**`src/graph-merge/base-version.ts` → `readActiveSchemaVersion` — RULED OUT.**
It calls `backend.getActiveSchema`, a plain non-locking `SELECT`. Two
independent reasons it cannot see the transient: (a) `commitSchemaVersion`'s
deactivate-then-insert pair runs inside one transaction
(`runSchemaWriteTransaction`), so the zero-active-row window is never committed
and is invisible to other transactions; (b) a non-locking read never waits on a
row lock, so it has no post-wait recheck to be fooled by — it reads the last
committed state. Covered by a test: during a held uncommitted flip,
`getActiveSchema` returns version 1 and `computeBaseVersion` returns the
identical token it returned before the flip started; after the commit the token
changes. (Note the `FALLBACK_SCHEMA_VERSION` here is `1`, not `0` — so even a
hypothetical transient would not have produced a `0`-shaped token.)

**`src/graph-merge/merge.ts` schema-drift check and `src/graph-merge/branch.ts`
`schemaAnchor` — RULED OUT.** Same non-locking `getActiveSchema` seam, same
reasoning. Both also read the branch's own clone rather than a store under
concurrent schema flips.

**`src/store/materialize-removals.ts` locked recheck — RULED OUT.** Runs inside
`schemaWriteTransaction`, which takes the exclusive per-graph advisory lock
*before* reading, so no schema commit can be in flight; and it treats an absent
row as "skip the cleanup", which is conservative rather than wrong.

**The schema writer's own `SELECT ... FOR UPDATE` in
`runSchemaWriteTransaction` — RULED OUT.** It has the same recheck shape, but
the advisory lock is acquired first, so the wait completes before the statement
snapshot is taken and the fresh snapshot sees the committed winner. Its result
is discarded rather than compared against a version, so an empty result would
be harmless regardless.

**`commitSchemaVersion`'s own `readActiveVersion` — RULED OUT.** Non-locking
read inside the advisory-locked transaction; no flip can be concurrent with it.

**SQLite — CANNOT EXHIBIT THIS.** Verified, not assumed. Its fence reads
through `getActiveSchema` (a plain `SELECT`, no locking clause anywhere in
`src/`), SQLite serializes writers through `BEGIN IMMEDIATE` so no schema
commit can be mid-flight while the fence holds the writer slot, and SQLite has
no `EvalPlanQual` analog that could drop a row from a reader's own snapshot
after a wait. An absent row there always means the graph genuinely has no
active schema. Recorded as an inline comment on the SQLite fence so the
asymmetry with Postgres does not read as an oversight.

`grep`-level confirmation that the audit is exhaustive: `FOR SHARE` / `FOR
UPDATE` appear in exactly two places under `src/` — the fence fixed here and
the schema writer's advisory-lock-protected read.

## Tests

`packages/typegraph/tests/backends/postgres/schema-write-fence-race.test.ts`:

1. **The repro.** A Store pinned to version 1; an uncommitted schema flip to
   version 2 held open on a dedicated pool client; the managed write proven
   *blocked* (not merely slow) via `raceTimeout`; the flip committed; the
   rejection asserted to be `StaleVersionError` with `actual: 2`, and a fresh
   read confirmed to agree. The winning flip is raw SQL mirroring
   `commitSchemaVersion`'s fresh-insert ordering exactly, because the flip has
   to stay uncommitted while the loser blocks on it — no seam in
   `migrateSchema` can hold that position.
2. **The honest zero.** An out-of-band committed deactivation still reports
   `actual: 0`, so the re-read confirms absence instead of papering over it.
3. **The audit.** The non-locking read path during a held flip, as described
   above.

**Revert-verified:** disabling the re-read (single attempt) fails case 1 with
exactly the reported symptom:

```
- Expected  + Received
    "actual": 2,   →   "actual": 0,
    "expected": 1,
    "graphId": "schema_write_fence_race",
```

Changeset: patch.

Closes #365
