### PR TITLE
test(postgres): give each suite its own database (#382)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,12 @@ backend tests are **skipped** unless `POSTGRES_URL` is set. Always run
 changes that touch backend, store, or collection code. The script handles
 Docker lifecycle automatically — no manual setup required.
 
+Each server-PostgreSQL suite runs against its own database, provisioned from
+`POSTGRES_URL` by `tests/postgres-test-database.ts`. A new suite therefore
+resolves its URL with `await provisionPostgresTestDatabase(import.meta.url)`
+and creates its own tables in `beforeAll` — it cannot inherit them from
+another suite. See [Per-suite PostgreSQL databases](docs/TESTING.md#per-suite-postgresql-databases).
+
 # Core Principles
 
 - **TypeScript strict mode** with readonly types by default

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -112,6 +112,51 @@ pnpm test:coverage
 PostgreSQL example runner intentionally uses `POSTGRES_URL` so it can exercise
 the same caller-supplied connection configuration shown to users.
 
+### Per-suite PostgreSQL databases
+
+Every server-PostgreSQL suite owns the graph tables it operates on: `beforeEach`
+hooks `TRUNCATE` them, `beforeAll` hooks re-run the migration SQL, and a few
+suites `DROP` them outright. To make that ownership true rather than assumed,
+each test *file* runs against its own database, named after the file and
+recreated on demand from the `POSTGRES_URL` database:
+
+```text
+POSTGRES_URL=…/typegraph_test  ->  typegraph_test__postgres_backend
+                                   typegraph_test__identity_enablement_lock
+                                   …
+```
+
+Suites opt in by resolving their connection URL through the shared helper
+instead of reading `POSTGRES_URL` directly:
+
+```typescript
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
+
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+```
+
+Consequences worth knowing:
+
+- **A new PostgreSQL suite must bootstrap its own tables** (usually
+  `await pool.query(generatePostgresMigrationSQL())` in `beforeAll`). It cannot
+  inherit them from whichever suite happened to run first.
+- **The `POSTGRES_URL` role needs `CREATEDB`.** Set
+  `TYPEGRAPH_TEST_SHARED_DATABASE=1` to opt out and run every suite against the
+  base database — the pre-isolation behaviour, including its cross-suite
+  `TRUNCATE`/`DROP` hazards.
+- **One vitest invocation at a time per `POSTGRES_URL`.** Two invocations
+  resolve the same suite to the same database name, and provisioning drops it
+  with `WITH (FORCE)`. Concurrent lanes (for example one per worktree) must use
+  separate base databases.
+- The per-suite databases are deliberately left behind so a failure stays
+  inspectable; the next run recreates them. The Docker lane is ephemeral, so
+  this only accumulates on a long-lived external server.
+
+`scripts/test-postgres.sh` still passes `--no-file-parallelism`, now purely for
+the connection budget (`max_connections` is 100 and each worker holds pools),
+not for isolation. Reproducing a single failure with a parallel invocation of a
+few files is safe.
+
 ## Coverage
 
 We use [@vitest/coverage-v8](https://vitest.dev/guide/coverage) for coverage reporting.

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -28,12 +28,17 @@ fi
 
 # Run all postgres tests (backend-specific, integration, and graph-merge).
 #
-# `--no-file-parallelism` serializes test-file execution: every PG test
-# suite targets the same `typegraph_test` database, and several files'
-# `beforeAll` hooks run schema-destructive DDL (DROP TABLE). Running
-# files in parallel is a recipe for flaky mid-test table disappearance.
-# (Graph-merge fixtures isolate per-fixture schemas, but each shard still keeps
-# its own database lane serialized for the same connection-budget reasons.)
+# Each suite provisions its own database off this URL (see
+# `tests/postgres-test-database.ts`), so the schema-destructive DDL in their
+# `beforeAll`/`beforeEach` hooks can no longer reach another suite's tables.
+# Isolation therefore holds by construction, and running any subset of these
+# files in parallel — the usual way to reproduce one failure — is safe.
+#
+# `--no-file-parallelism` stays for the CONNECTION BUDGET, not for isolation:
+# every worker holds at least one pool against the same server, the
+# graph-merge property fixtures keep several backends alive at once, and
+# `max_connections` is 100 ("sorry, too many clients already"). Graph-merge
+# fixtures additionally isolate per-fixture schemas.
 #
 # With POSTGRES_URL set, the graph-merge backendMatrix() gains its
 # server-Postgres entry, so those suites run on SQLite, PGlite, AND the

--- a/packages/typegraph/tests/backends/l2-score-scale-parity.test.ts
+++ b/packages/typegraph/tests/backends/l2-score-scale-parity.test.ts
@@ -33,6 +33,7 @@ import { type GraphBackend } from "../../src/backend/types";
 import { embedding } from "../../src/core/embedding";
 import { createStoreWithSchema } from "../../src/store";
 import { requireDefined } from "../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../postgres-test-database";
 
 const GRAPH_ID = "l2_score_scale_parity";
 const FIELD_PATH = "embedding";
@@ -114,10 +115,17 @@ async function collectSqliteVec(): Promise<BackendResult> {
   }
 }
 
+// Resolving this suite's own Postgres database needs a top-level await, so it
+// lives at module scope and the suite body closes over it. `undefined` keeps
+// the "Postgres not configured" leg of the matrix reporting a skip.
+const TEST_DATABASE_URL =
+  process.env["POSTGRES_URL"] ?
+    await provisionPostgresTestDatabase(import.meta.url)
+  : undefined;
+
 describe("cross-backend l2 score-scale parity", () => {
   const temporaryDir = mkdtempSync(path.join(tmpdir(), "tg-l2-parity-"));
 
-  const TEST_DATABASE_URL = process.env["POSTGRES_URL"];
   let postgresPool: Pool | undefined;
 
   beforeAll(async () => {

--- a/packages/typegraph/tests/backends/postgres/exact-vector-scan.test.ts
+++ b/packages/typegraph/tests/backends/postgres/exact-vector-scan.test.ts
@@ -34,10 +34,9 @@ import {
 } from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/filtered-ann-recall.test.ts
+++ b/packages/typegraph/tests/backends/postgres/filtered-ann-recall.test.ts
@@ -32,10 +32,9 @@ import { embedding } from "../../../src/core/embedding";
 import { defineGraph, defineNode } from "../../../src/index";
 import { createStoreWithSchema } from "../../../src/store";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const GRAPH_ID = "filtered_ann_recall";
 const FAN_SIZE = 200;

--- a/packages/typegraph/tests/backends/postgres/fulltext-gin-language.test.ts
+++ b/packages/typegraph/tests/backends/postgres/fulltext-gin-language.test.ts
@@ -50,10 +50,9 @@ import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
 import { type GraphBackend } from "../../../src/backend/types";
 import { tsvectorStrategy } from "../../../src/query/dialect";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/hybrid-tiebreak-parity.test.ts
+++ b/packages/typegraph/tests/backends/postgres/hybrid-tiebreak-parity.test.ts
@@ -32,10 +32,9 @@ import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import { type GraphBackend } from "../../../src/backend/types";
 import { embedding } from "../../../src/core/embedding";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const EMBEDDING_DIMENSIONS = 3;
 const TIED_EMBEDDING: readonly number[] = [1, 0, 0];

--- a/packages/typegraph/tests/backends/postgres/identity-enablement-lock.test.ts
+++ b/packages/typegraph/tests/backends/postgres/identity-enablement-lock.test.ts
@@ -16,10 +16,9 @@ import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import { requireDefined } from "../../../src/utils/presence";
 import { raceTimeout, TIMEOUT_SENTINEL } from "../../concurrency-utils";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),

--- a/packages/typegraph/tests/backends/postgres/inline-ann-gucs.test.ts
+++ b/packages/typegraph/tests/backends/postgres/inline-ann-gucs.test.ts
@@ -30,10 +30,9 @@ import {
 } from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/iterative-working-memory.test.ts
+++ b/packages/typegraph/tests/backends/postgres/iterative-working-memory.test.ts
@@ -39,10 +39,9 @@ import type {
   CompiledTemporaryStatementSql,
 } from "../../../src/query/sql-intent";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
+++ b/packages/typegraph/tests/backends/postgres/materialize-indexes.test.ts
@@ -22,10 +22,9 @@ import { createPostgresBackend } from "../../../src/backend/postgres";
 import { defineEdgeIndex, defineNodeIndex } from "../../../src/indexes";
 import { createStoreWithSchema } from "../../../src/store";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let sharedPool: Pool | undefined;
 let sharedDb: NodePgDatabase | undefined;

--- a/packages/typegraph/tests/backends/postgres/materialize-vector-indexes.test.ts
+++ b/packages/typegraph/tests/backends/postgres/materialize-vector-indexes.test.ts
@@ -17,10 +17,9 @@ import { createPostgresBackend } from "../../../src/backend/postgres";
 import { embedding } from "../../../src/core/embedding";
 import { createStoreWithSchema } from "../../../src/store";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let sharedPool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/migrate-recorded-time.test.ts
+++ b/packages/typegraph/tests/backends/postgres/migrate-recorded-time.test.ts
@@ -12,10 +12,9 @@ import {
   createPostgresBackend,
   createPostgresTables,
 } from "../../../src/backend/postgres";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 const RECORDED_NODES = "tg_mrt_recorded_nodes";
 const RECORDED_EDGES = "tg_mrt_recorded_edges";
 const RECORDED_CLOCK = "tg_mrt_recorded_clock";

--- a/packages/typegraph/tests/backends/postgres/migrate-vectors.test.ts
+++ b/packages/typegraph/tests/backends/postgres/migrate-vectors.test.ts
@@ -12,15 +12,15 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { migrateLegacyEmbeddings } from "../../../src/backend/migrate-vectors";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import { type GraphBackend } from "../../../src/backend/types";
 import { requireDefined } from "../../../src/utils/presence";
 import { isMissingTableError } from "../../../src/utils/sql-errors";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const LEGACY_TABLE = "typegraph_node_embeddings";
 
@@ -43,7 +43,12 @@ beforeAll(async () => {
   });
   try {
     await pool.query("SELECT 1");
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    // This suite owns its database, so it creates the base graph tables
+    // itself rather than inheriting them from whichever suite ran first:
+    // `seedLegacy` inserts live `typegraph_nodes` rows, and the migration
+    // SQL also enables pgvector for the legacy table's native `vector`
+    // column.
+    await pool.query(generatePostgresMigrationSQL());
     sharedPool = pool;
     isPostgresAvailable = true;
   } catch {
@@ -68,9 +73,9 @@ beforeEach(async () => {
   // Drop the durable contribution markers (#135) in lockstep with the per-
   // field tables above: `migrateLegacyEmbeddings` now provisions each slot via
   // `ensureVectorSlotContribution`, which trusts the marker and skips the
-  // CREATE when one already exists. On this shared, long-lived database a
-  // marker left over from a prior run would outlive the dropped table and the
-  // migration's first write would hit a missing relation.
+  // CREATE when one already exists. The database outlives each test, so a
+  // marker left over from an earlier one would outlive the dropped table and
+  // the migration's first write would hit a missing relation.
   await sharedPool.query(
     `DROP TABLE IF EXISTS "typegraph_contribution_materializations" CASCADE`,
   );

--- a/packages/typegraph/tests/backends/postgres/pgvector-strategy.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pgvector-strategy.test.ts
@@ -22,10 +22,9 @@ import {
   type SqlFragment,
 } from "../../../src/query/sql-fragment";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const GRAPH = "g1";
 const TS = "2026-06-01T00:00:00.000Z";

--- a/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-backend.test.ts
@@ -52,6 +52,7 @@ import {
   raceTimeout,
   TIMEOUT_SENTINEL,
 } from "../../concurrency-utils";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
 
@@ -60,9 +61,7 @@ import { createIntegrationTestSuite } from "../integration-test-suite";
 // ============================================================
 
 // Use 127.0.0.1 instead of localhost to avoid IPv6 resolution issues
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 // ============================================================
 // Connection State
@@ -194,7 +193,7 @@ async function clearTestData(): Promise<void> {
   // each test starts genuinely un-provisioned and the integration suite's
   // per-test createStoreWithSchema re-materializes every per-field vector
   // table + marker in lockstep. Otherwise a marker could outlive a dropped
-  // table on this shared database and a later boot would skip the CREATE.
+  // table and a later boot in this database would skip the CREATE.
   await sharedPool.query(
     `TRUNCATE typegraph_index_materializations,
               typegraph_contribution_materializations,
@@ -244,8 +243,7 @@ beforeAll(async () => {
   // Only attempt to connect when POSTGRES_URL is explicitly set (i.e. via
   // `scripts/test-postgres.sh`). Without the gate, a developer with a
   // stray Docker Postgres container running would trigger the
-  // DROP+CREATE schema setup below during `pnpm test:unit` and race with
-  // other postgres test files sharing the same database.
+  // DROP+CREATE schema setup below during `pnpm test:unit`.
   if (!process.env["POSTGRES_URL"]) return;
   isPostgresAvailable = await initializePostgres();
   if (isPostgresAvailable) {

--- a/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-cross-store-transaction.test.ts
@@ -33,10 +33,9 @@ import {
   tables as defaultTables,
 } from "../../../src/backend/postgres";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let db: NodePgDatabase | undefined;

--- a/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-fulltext-bootstrap.test.ts
@@ -46,10 +46,9 @@ import {
   tables as defaultTables,
 } from "../../../src/backend/postgres";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let postgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/postgres-fulltext.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-fulltext.test.ts
@@ -16,10 +16,9 @@ import type { createStore } from "../../../src/store";
 import { createStoreWithSchema } from "../../../src/store";
 import { type FulltextSearchHit } from "../../../src/store/search";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const Document = defineNode("Document", {
   schema: z.object({
@@ -54,11 +53,9 @@ let pool: Pool | undefined;
 let postgresAvailable = false;
 
 beforeAll(async () => {
-  // NOTE: do not DROP tables here — `postgres-backend.test.ts` runs in
-  // parallel against the same database and also owns the schema. The
-  // generated migration SQL uses `CREATE TABLE IF NOT EXISTS` so it's
-  // safe to run alongside; per-test isolation is handled by TRUNCATE in
-  // `beforeEach` below.
+  // The generated migration SQL uses `CREATE TABLE IF NOT EXISTS`, so it
+  // brings this suite's own database up to shape without dropping anything;
+  // per-test isolation is handled by TRUNCATE in `beforeEach` below.
   //
   // Gated on POSTGRES_URL so `pnpm test:unit` doesn't try to attach to a
   // stray Docker Postgres and race other postgres files.

--- a/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-backend.test.ts
@@ -7,10 +7,9 @@
  * driver-agnostic behavior end-to-end.
  *
  * Skipped automatically unless `POSTGRES_URL` is set (or the
- * `scripts/test-postgres.sh` harness is used). Targets the same database
- * as `postgres-backend.test.ts`; both files use `CREATE TABLE IF NOT
- * EXISTS` DDL and per-test TRUNCATE, and the harness runs files
- * serially.
+ * `scripts/test-postgres.sh` harness is used). Runs against its own
+ * database (see `tests/postgres-test-database.ts`), so its schema setup
+ * cannot collide with `postgres-backend.test.ts`.
  */
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres, { type Sql } from "postgres";
@@ -32,12 +31,11 @@ import {
 } from "../../../src/query/sql-intent";
 import { createStore } from "../../../src/store";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 import { createAdapterTestSuite } from "../adapter-test-suite";
 import { createIntegrationTestSuite } from "../integration-test-suite";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let sharedSql: Sql | undefined;
 let sharedDb: PostgresJsDatabase | undefined;

--- a/packages/typegraph/tests/backends/postgres/postgres-js-custom-plan.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-js-custom-plan.test.ts
@@ -26,10 +26,9 @@ import {
 } from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let bootstrap: Sql | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/postgres-vector-ef-search.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-vector-ef-search.test.ts
@@ -36,10 +36,9 @@ import { sql } from "../../../src/query/sql-fragment";
 import { asCompiledRowsSql } from "../../../src/query/sql-intent";
 import { createStoreWithSchema } from "../../../src/store";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let sharedPool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/postgres-vector-least-privilege.test.ts
+++ b/packages/typegraph/tests/backends/postgres/postgres-vector-least-privilege.test.ts
@@ -42,10 +42,9 @@ import {
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const LEAST_PRIV_ROLE = `tg_vec_lp_runtime_${randomUUID().replaceAll("-", "")}`;
 const LEAST_PRIV_ROLE_IDENTIFIER = `"${LEAST_PRIV_ROLE}"`;
@@ -93,7 +92,7 @@ beforeAll(async () => {
   if (!process.env["POSTGRES_URL"]) return;
   ownerPool = new Pool({ connectionString: TEST_DATABASE_URL });
   await ownerPool.query("SELECT 1");
-  // Base typegraph_* tables for the shared test database.
+  // Base typegraph_* tables for this suite's database.
   await ownerPool.query(generatePostgresMigrationSQL());
 
   // The role name is unique per test process because PostgreSQL roles are
@@ -146,8 +145,8 @@ afterAll(async () => {
   if (leastPrivPool) await leastPrivPool.end();
   if (ownerPool) {
     if (publicCreateRevoked) {
-      // Restore PUBLIC's CREATE so we don't leave the shared test database
-      // more restrictive than other suites expect.
+      // Restore PUBLIC's CREATE so the database is left as provisioned, in
+      // case an operator inspects or reuses it after the run.
       await ownerPool.query(`GRANT CREATE ON SCHEMA public TO PUBLIC`);
     }
     if (leastPrivRoleCreated) {

--- a/packages/typegraph/tests/backends/postgres/provenance-advisory-lock.test.ts
+++ b/packages/typegraph/tests/backends/postgres/provenance-advisory-lock.test.ts
@@ -47,10 +47,9 @@ import {
   raceTimeout,
   TIMEOUT_SENTINEL,
 } from "../../concurrency-utils";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/reclaim-removed-vector-fields.test.ts
+++ b/packages/typegraph/tests/backends/postgres/reclaim-removed-vector-fields.test.ts
@@ -18,10 +18,9 @@ import { createBackendOverlay } from "../../../src/backend/types";
 import { defineGraphExtension } from "../../../src/graph-extension";
 import { createStoreWithSchema } from "../../../src/store";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const GRAPH_ID = "reclaim_vec_pg";
 
@@ -69,7 +68,7 @@ beforeEach(async () => {
   if (sharedPool === undefined) return;
   // Clear the durable contribution markers (#135) alongside dropping the
   // per-field tables below: this suite drops `tg_vec_*` tables directly
-  // (bypassing reclaim), so a marker left behind on this shared database
+  // (bypassing reclaim), so a marker left behind by an earlier test
   // would outlive its table and make a later evolve()/createStoreWithSchema
   // trust the marker and skip re-creating the table.
   await sharedPool.query(

--- a/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
+++ b/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
@@ -21,10 +21,9 @@ import { z } from "zod";
 import { createStoreWithSchema, defineGraph, defineNode } from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 const GRAPH_WRITE_NAMESPACE = "typegraph:recorded-graph-write";
 

--- a/packages/typegraph/tests/backends/postgres/subgraph-shared-traversal.test.ts
+++ b/packages/typegraph/tests/backends/postgres/subgraph-shared-traversal.test.ts
@@ -35,10 +35,9 @@ import {
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import type { GraphBackend } from "../../../src/backend/types";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/backends/postgres/transaction-statement-serialization.test.ts
+++ b/packages/typegraph/tests/backends/postgres/transaction-statement-serialization.test.ts
@@ -36,10 +36,9 @@ import {
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
 import { requireDefined } from "../../../src/utils/presence";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 /**
  * Tracks queries in flight **per physical connection**. Two queries running

--- a/packages/typegraph/tests/backends/postgres/vector-index-serial-retry.test.ts
+++ b/packages/typegraph/tests/backends/postgres/vector-index-serial-retry.test.ts
@@ -28,10 +28,9 @@ import {
 } from "../../../src";
 import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
 import { createPostgresBackend } from "../../../src/backend/postgres";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
 
-const TEST_DATABASE_URL =
-  process.env["POSTGRES_URL"] ??
-  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
 
 let pool: Pool | undefined;
 let isPostgresAvailable = false;

--- a/packages/typegraph/tests/hybrid-single-statement.test.ts
+++ b/packages/typegraph/tests/hybrid-single-statement.test.ts
@@ -37,6 +37,7 @@ import { embedding } from "../src/core/embedding";
 import { createStoreWithSchema } from "../src/store";
 import { type HybridSearchHit } from "../src/store/search";
 import { requireDefined } from "../src/utils/presence";
+import { provisionPostgresTestDatabase } from "./postgres-test-database";
 
 const GRAPH_ID = "hybrid_single_stmt";
 const FIELD_PATH = "embedding";
@@ -266,12 +267,13 @@ function pickActiveFulltextMinScore(scores: readonly number[]): number {
   return (min + max) / 2;
 }
 
+// Resolving this suite's own Postgres database needs a top-level await, so it
+// lives at module scope and the suite body closes over it.
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+
 describe("single-statement hybrid search", () => {
   const libsql = libsqlDescriptor();
 
-  const TEST_DATABASE_URL =
-    process.env["POSTGRES_URL"] ??
-    "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
   let postgresPool: Pool | undefined;
 
   beforeAll(async () => {
@@ -301,6 +303,11 @@ describe("single-statement hybrid search", () => {
       const pool = requireDefined(postgresPool);
       await pool.query(`
         DROP TABLE IF EXISTS typegraph_index_materializations CASCADE;
+        -- The durable contribution markers (#135) go with the per-field
+        -- vector tables dropped below: a marker that outlives its table makes
+        -- the next store boot trust it and skip the CREATE, so the first
+        -- embedding write hits a missing relation.
+        DROP TABLE IF EXISTS typegraph_contribution_materializations CASCADE;
         DROP TABLE IF EXISTS typegraph_node_embeddings CASCADE;
         DROP TABLE IF EXISTS typegraph_node_uniques CASCADE;
         DROP TABLE IF EXISTS typegraph_node_fulltext CASCADE;

--- a/packages/typegraph/tests/postgres-test-database.ts
+++ b/packages/typegraph/tests/postgres-test-database.ts
@@ -1,0 +1,279 @@
+/**
+ * Per-suite PostgreSQL database provisioning.
+ *
+ * Every server-Postgres suite in this package assumes it owns the graph
+ * tables it operates on: `beforeEach` hooks `TRUNCATE` them, `beforeAll`
+ * hooks re-run the migration SQL, and a few suites `DROP` them outright.
+ * Those assumptions hold in CI, where each job gets a private database, but
+ * they do not hold when several suites share one database — the second suite's
+ * `TRUNCATE`/`DROP` lands in the middle of the first suite's test. That is a
+ * harness defect rather than a product defect, and the fix is to make
+ * exclusive ownership true by construction: each test *file* gets its own
+ * database, derived from its filename and created fresh on demand.
+ *
+ * Isolation is per database rather than per schema because ~30 assertions in
+ * these suites read catalog views filtered on `schemaname = 'public'`, and
+ * because `search_path` fall-through to a populated `public` schema silently
+ * defeats the lazy DDL bootstrap (see `createServerPostgresMergeBackend`).
+ * A separate database keeps `public` meaningful and needs no changes to the
+ * suites' SQL.
+ *
+ * Usage — replace the ad-hoc URL constant at the top of a suite:
+ *
+ * ```ts
+ * const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+ * ```
+ *
+ * When `POSTGRES_URL` is unset (the SQLite lane) nothing connects and the
+ * documented default URL is returned unchanged, so the `describe.runIf`
+ * gates behave exactly as before.
+ *
+ * Operational notes:
+ *
+ * - The database is dropped and recreated, so a suite never inherits residue
+ *   from an earlier run. It is deliberately *not* dropped afterwards: the
+ *   Docker lane is ephemeral anyway, and keeping it around makes a failure
+ *   inspectable.
+ * - One vitest invocation at a time per `POSTGRES_URL`. Concurrent lanes must
+ *   use separate base databases — two invocations of the same suite resolve to
+ *   the same isolated database name and the loser gets its connections
+ *   terminated by `DROP DATABASE ... WITH (FORCE)`.
+ * - The role behind `POSTGRES_URL` needs `CREATEDB`. Set
+ *   `TYPEGRAPH_TEST_SHARED_DATABASE=1` to opt out and run every suite against
+ *   the base database (the pre-isolation behaviour, hazards included).
+ */
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Pool } from "pg";
+
+/**
+ * Connection URL used when `POSTGRES_URL` is unset. Nothing connects to it —
+ * the suites are gated on `POSTGRES_URL` — but it documents what
+ * `docker-compose.yml` publishes. 127.0.0.1 rather than localhost avoids IPv6
+ * resolution issues.
+ */
+const DEFAULT_POSTGRES_TEST_URL =
+  "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
+
+/** Escape hatch for roles without `CREATEDB`; see the module comment. */
+const SHARED_DATABASE_ENV = "TYPEGRAPH_TEST_SHARED_DATABASE";
+
+/** `NAMEDATALEN - 1`: PostgreSQL truncates identifiers beyond this. */
+const MAX_IDENTIFIER_LENGTH = 63;
+
+const HASH_SUFFIX_LENGTH = 8;
+
+const ADMIN_CONNECT_TIMEOUT_MS = 5000;
+
+/** PostgreSQL `insufficient_privilege`. */
+const INSUFFICIENT_PRIVILEGE = "42501";
+
+/**
+ * `pg_database` columns that decide how text sorts and compares. The isolated
+ * database must agree with the base database on every one of them, or a
+ * suite's `ORDER BY` assertions would be testing a different collation than
+ * the operator configured. Names vary across major versions (`daticulocale`
+ * became `datlocale` in 18), so the comparison uses whichever of these keys
+ * the server actually reports.
+ */
+const LOCALE_KEYS = [
+  "encoding",
+  "datcollate",
+  "datctype",
+  "datlocprovider",
+  "datlocale",
+  "daticulocale",
+  "daticurules",
+] as const;
+
+type DatabaseRow = Readonly<Record<string, unknown>>;
+
+/**
+ * Creates (or recreates) a database dedicated to one test file and returns its
+ * connection URL.
+ *
+ * @param testFileUrl - The caller's `import.meta.url`; names the database.
+ */
+export async function provisionPostgresTestDatabase(
+  testFileUrl: string,
+): Promise<string> {
+  const configuredUrl = process.env["POSTGRES_URL"];
+  if (configuredUrl === undefined || configuredUrl === "")
+    return DEFAULT_POSTGRES_TEST_URL;
+  if (process.env[SHARED_DATABASE_ENV] === "1") return configuredUrl;
+
+  const baseDatabase = databaseNameFromUrl(configuredUrl);
+  const isolatedDatabase = isolatedDatabaseName(
+    baseDatabase,
+    suiteSlug(testFileUrl),
+  );
+  await recreateDatabase(configuredUrl, baseDatabase, isolatedDatabase);
+
+  const isolatedUrl = new URL(configuredUrl);
+  isolatedUrl.pathname = `/${encodeURIComponent(isolatedDatabase)}`;
+  return isolatedUrl.toString();
+}
+
+function databaseNameFromUrl(connectionUrl: string): string {
+  const { pathname } = new URL(connectionUrl);
+  const name = decodeURIComponent(pathname.replace(/^\//, ""));
+  if (name === "")
+    throw new Error(
+      `POSTGRES_URL must name a database (got "${connectionUrl}")`,
+    );
+  return name;
+}
+
+/** `identity-enablement-lock.test.ts` -> `identity_enablement_lock`. */
+function suiteSlug(testFileUrl: string): string {
+  const fileName = path
+    .basename(fileURLToPath(testFileUrl))
+    .replace(/\.(test\.)?ts$/, "");
+  return fileName.replaceAll(/[^a-z0-9]+/gi, "_").toLowerCase();
+}
+
+function isolatedDatabaseName(baseDatabase: string, slug: string): string {
+  const preferred = `${baseDatabase}__${slug}`;
+  if (preferred.length <= MAX_IDENTIFIER_LENGTH) return preferred;
+  // Truncation alone could collide two long suite names into one database.
+  const digest = createHash("sha256")
+    .update(preferred)
+    .digest("hex")
+    .slice(0, HASH_SUFFIX_LENGTH);
+  const head = preferred.slice(0, MAX_IDENTIFIER_LENGTH - digest.length - 1);
+  return `${head}_${digest}`;
+}
+
+/**
+ * Drops and recreates `isolatedDatabase` through a single-connection admin
+ * pool on the base database, copying the base database's encoding and
+ * collation so the two sort text identically.
+ */
+async function recreateDatabase(
+  adminUrl: string,
+  baseDatabase: string,
+  isolatedDatabase: string,
+): Promise<void> {
+  const admin = new Pool({
+    connectionString: adminUrl,
+    max: 1,
+    connectionTimeoutMillis: ADMIN_CONNECT_TIMEOUT_MS,
+  });
+  try {
+    const base = await readDatabaseLocale(admin, baseDatabase);
+    const quoted = quoteIdentifier(isolatedDatabase);
+    await admin.query(`DROP DATABASE IF EXISTS ${quoted} WITH (FORCE)`);
+    await admin.query(
+      `CREATE DATABASE ${quoted} TEMPLATE template0` +
+        ` ENCODING ${quoteLiteral(base.encoding)}` +
+        ` LC_COLLATE ${quoteLiteral(base.datcollate)}` +
+        ` LC_CTYPE ${quoteLiteral(base.datctype)}`,
+    );
+    await assertLocaleMatches(admin, baseDatabase, isolatedDatabase);
+  } catch (error) {
+    throw provisioningError(error, isolatedDatabase, baseDatabase);
+  } finally {
+    await admin.end();
+  }
+}
+
+function provisioningError(
+  cause: unknown,
+  isolatedDatabase: string,
+  baseDatabase: string,
+): Error {
+  const detail =
+    hasSqlState(cause) && cause.code === INSUFFICIENT_PRIVILEGE ?
+      `. The POSTGRES_URL role needs CREATEDB; grant it, or set ` +
+      `${SHARED_DATABASE_ENV}=1 to share "${baseDatabase}" across suites ` +
+      `(no isolation).`
+    : "";
+  return new Error(
+    `Failed to provision the isolated test database "${isolatedDatabase}"${detail}`,
+    { cause },
+  );
+}
+
+function hasSqlState(error: unknown): error is { readonly code: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+  );
+}
+
+type DatabaseLocale = Readonly<{
+  encoding: string;
+  datcollate: string;
+  datctype: string;
+}>;
+
+/** Reads the `CREATE DATABASE` locale arguments of an existing database. */
+async function readDatabaseLocale(
+  admin: Pool,
+  databaseName: string,
+): Promise<DatabaseLocale> {
+  const result = await admin.query<DatabaseLocale>(
+    `SELECT pg_encoding_to_char(encoding) AS encoding, datcollate, datctype
+       FROM pg_database
+      WHERE datname = $1`,
+    [databaseName],
+  );
+  const locale = result.rows[0];
+  if (locale === undefined)
+    throw new Error(`Database "${databaseName}" not found in pg_database`);
+  return locale;
+}
+
+async function readDatabaseRow(
+  admin: Pool,
+  databaseName: string,
+): Promise<DatabaseRow> {
+  const result = await admin.query<{ database: DatabaseRow }>(
+    `SELECT row_to_json(entry) AS database
+       FROM pg_database AS entry
+      WHERE datname = $1`,
+    [databaseName],
+  );
+  const row = result.rows[0]?.database;
+  if (row === undefined)
+    throw new Error(`Database "${databaseName}" not found in pg_database`);
+  return row;
+}
+
+async function assertLocaleMatches(
+  admin: Pool,
+  baseDatabase: string,
+  isolatedDatabase: string,
+): Promise<void> {
+  const baseRow = await readDatabaseRow(admin, baseDatabase);
+  const isolatedRow = await readDatabaseRow(admin, isolatedDatabase);
+  const divergent = LOCALE_KEYS.filter(
+    (key) =>
+      key in baseRow &&
+      key in isolatedRow &&
+      JSON.stringify(baseRow[key]) !== JSON.stringify(isolatedRow[key]),
+  );
+  if (divergent.length === 0) return;
+
+  const describeKey = (key: string): string =>
+    `${key}: ${JSON.stringify(baseRow[key])} vs ${JSON.stringify(isolatedRow[key])}`;
+  throw new Error(
+    `Isolated database "${isolatedDatabase}" does not match the collation of ` +
+      `"${baseDatabase}" (${divergent.map((key) => describeKey(key)).join(", ")}). ` +
+      `Text ordering would differ from the configured database. Recreate ` +
+      `"${baseDatabase}" with the cluster default locale, or set ` +
+      `${SHARED_DATABASE_ENV}=1 to share it across suites (no isolation).`,
+  );
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function quoteLiteral(literal: string): string {
+  return `'${literal.replaceAll("'", "''")}'`;
+}

--- a/packages/typegraph/tests/search-filter-pushdown.test.ts
+++ b/packages/typegraph/tests/search-filter-pushdown.test.ts
@@ -39,6 +39,7 @@ import { embedding } from "../src/core/embedding";
 import { createStoreWithSchema } from "../src/store";
 import { type VectorSearchOptions } from "../src/store/search";
 import { requireDefined } from "../src/utils/presence";
+import { provisionPostgresTestDatabase } from "./postgres-test-database";
 
 const GRAPH_ID = "search_pushdown";
 const FIELD_PATH = "embedding";
@@ -278,12 +279,13 @@ async function assertFilteredLegs(store: Store): Promise<void> {
 // Suite
 // ============================================================
 
+// Resolving this suite's own Postgres database needs a top-level await, so it
+// lives at module scope and the suite body closes over it.
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+
 describe("facade search filter pushdown", () => {
   const libsql = libsqlDescriptor();
 
-  const TEST_DATABASE_URL =
-    process.env["POSTGRES_URL"] ??
-    "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
   let postgresPool: Pool | undefined;
 
   beforeAll(async () => {

--- a/packages/typegraph/tests/search-liveness.test.ts
+++ b/packages/typegraph/tests/search-liveness.test.ts
@@ -39,6 +39,7 @@ import { type GraphBackend } from "../src/backend/types";
 import { embedding } from "../src/core/embedding";
 import { createStoreWithSchema } from "../src/store";
 import { requireDefined } from "../src/utils/presence";
+import { provisionPostgresTestDatabase } from "./postgres-test-database";
 
 const GRAPH_ID = "search_liveness";
 const FIELD_PATH = "embedding";
@@ -247,12 +248,13 @@ function expectFullLiveResults(
 // Suite
 // ============================================================
 
+// Resolving this suite's own Postgres database needs a top-level await, so it
+// lives at module scope and the suite body closes over it.
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+
 describe("facade search liveness under index drift", () => {
   const libsql = libsqlDescriptor();
 
-  const TEST_DATABASE_URL =
-    process.env["POSTGRES_URL"] ??
-    "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
   let postgresPool: Pool | undefined;
 
   beforeAll(async () => {

--- a/packages/typegraph/tests/similar-to-approximate.test.ts
+++ b/packages/typegraph/tests/similar-to-approximate.test.ts
@@ -35,6 +35,7 @@ import { type GraphBackend } from "../src/backend/types";
 import { embedding } from "../src/core/embedding";
 import { createStoreWithSchema } from "../src/store";
 import { requireDefined } from "../src/utils/presence";
+import { provisionPostgresTestDatabase } from "./postgres-test-database";
 
 const GRAPH_ID = "similar_to_ann";
 const EMBEDDING_DIMENSIONS = 3;
@@ -353,12 +354,13 @@ async function runScenario(created: CreatedBackend): Promise<void> {
   }
 }
 
+// Resolving this suite's own Postgres database needs a top-level await, so it
+// lives at module scope and the suite body closes over it.
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+
 describe("similarTo approximate opt-in", () => {
   const libsql = libsqlDescriptor();
 
-  const TEST_DATABASE_URL =
-    process.env["POSTGRES_URL"] ??
-    "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
   let postgresPool: Pool | undefined;
 
   beforeAll(async () => {

--- a/packages/typegraph/tests/vector-cross-backend-parity.test.ts
+++ b/packages/typegraph/tests/vector-cross-backend-parity.test.ts
@@ -47,6 +47,7 @@ import { type GraphBackend } from "../src/backend/types";
 import { embedding } from "../src/core/embedding";
 import { createStoreWithSchema } from "../src/store";
 import { requireDefined } from "../src/utils/presence";
+import { provisionPostgresTestDatabase } from "./postgres-test-database";
 
 // ============================================================
 // Scenario graph & fixed corpus
@@ -313,15 +314,16 @@ async function runParityScenario(
 // Suite
 // ============================================================
 
+// Resolving this suite's own Postgres database needs a top-level await, so it
+// lives at module scope and the suite body closes over it.
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+
 describe("cross-backend vector + hybrid parity", () => {
   const libsql = libsqlDescriptor();
 
   // Postgres joins the matrix only when POSTGRES_URL is set, mirroring
   // the other Postgres suites. The pool is opened once and the
   // descriptor's create() resets schema + per-field tables per use.
-  const TEST_DATABASE_URL =
-    process.env["POSTGRES_URL"] ??
-    "postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test";
   let postgresPool: Pool | undefined;
 
   beforeAll(async () => {


### PR DESCRIPTION
## What

Test infrastructure only — **no production code changes, no changeset**.

Every server-Postgres suite in `packages/typegraph` assumes it owns the graph
tables it operates on: `beforeEach` hooks `TRUNCATE` them, `beforeAll` hooks
re-run the migration SQL, and a few suites `DROP` them outright. That holds in
CI, where each job gets a private database, but not locally when suites share
one — which is how both of #382's reproductions happen.

This takes the issue's preferred option: **each test file gets its own
database**, so exclusive ownership holds by construction.

```typescript
// tests/backends/postgres/identity-enablement-lock.test.ts
const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
// -> postgresql://…/typegraph_test__identity_enablement_lock
```

`tests/postgres-test-database.ts` drops and recreates a database named after the
calling file, off the `POSTGRES_URL` database. With `POSTGRES_URL` unset nothing
connects and the documented default URL is returned unchanged, so the
`describe.runIf` gates behave exactly as before and the SQLite lane is untouched.

## Why per database, not per schema

- ~30 assertions in these suites read catalog views filtered on
  `schemaname = 'public'`. Schema isolation would mean rewriting all of them.
- `search_path` fall-through to a populated `public` schema silently defeats the
  lazy DDL bootstrap — the hazard `createServerPostgresMergeBackend` already
  documents at length.

A separate database keeps `public` meaningful and needs **no changes to the
suites' SQL**. It is also cheap: `CREATE DATABASE` plus the pgvector extension
measured at ~60ms per suite on the Docker lane.

The provisioner copies the base database's encoding and collation, then verifies
the two agree on every locale column `pg_database` reports, so a suite's
`ORDER BY` assertions cannot silently start testing a different collation. Both
operator-facing paths are verified by hand:

- role without `CREATEDB` →
  `Failed to provision the isolated test database "typegraph_test__identity_enablement_lock". The POSTGRES_URL role needs CREATEDB; grant it, or set TYPEGRAPH_TEST_SHARED_DATABASE=1 to share "typegraph_test" across suites (no isolation).`
- `TYPEGRAPH_TEST_SHARED_DATABASE=1` → suite green, zero per-suite databases
  created (pre-isolation behaviour, hazards included).

## Latent free-rides this exposed

Two suites were relying on tables another suite happened to create:

- `migrate-vectors.test.ts` never ran the migration SQL; it inherited
  `typegraph_nodes` from whichever suite ran first. It now bootstraps itself.
- `hybrid-single-statement.test.ts` dropped every `tg_vec_*` table between
  scenarios but not the contribution markers guarding them, so the second
  scenario trusted a marker whose table was gone. **Pre-existing on `main`** —
  this file is not in the `test:postgres` globs, so its Postgres leg only runs
  when someone sets `POSTGRES_URL` and runs the main suite, and nobody had.
  Verified failing at bab07521 and passing here.

## Proof

The issue's reproduction pair, one **parallel** vitest invocation:

| | `postgres-backend` + `identity-enablement-lock`, parallel |
| --- | --- |
| `main` @ bab07521 | 2 tests failed on 3 of 3 runs (`relation "typegraph_nodes" does not exist`) |
| this branch | 685 passed on 3 of 3 runs |

Stronger: the **whole** `tests/backends/postgres/` directory in one fully
parallel invocation — 33 files, 2076 passed / 3 skipped in 82s (141s with
`--no-file-parallelism`). Plus the six mixed-backend files whose Postgres legs
only run under `POSTGRES_URL` (`search-liveness`, `similar-to-approximate`,
`search-filter-pushdown`, `vector-cross-backend-parity`,
`hybrid-single-statement`, `l2-score-scale-parity`): 6 files, 21 passed.

## Gates

- `pnpm test:postgres` (canonical lane, Docker lifecycle): 81 files, 2906 passed
  / 3 skipped
- Full SQLite suite (`vitest run`): 285 files, 6210 passed / 1432 skipped
- `pnpm typecheck` pass · `pnpm fix` exit 0 · `pnpm test:unused` (knip) pass

## Runner and CI

`scripts/test-postgres.sh` keeps `--no-file-parallelism`, but the reason changed:
isolation now holds by construction, so serialization is purely about the
connection budget (`max_connections` is 100, every worker holds pools, and the
graph-merge property fixtures keep several backends alive at once). Reproducing a
failure with a parallel invocation of a few files is now safe. Unshackling the
whole lane is worth ~1.7× and is left as a follow-up, since it needs the pool
sizes bounded first.

CI is unchanged: both shards still run `pnpm --filter @nicia-ai/typegraph
test:postgres` against their own service container, whose `typegraph` superuser
has `CREATEDB`.

Closes #382
