### PR TITLE
test(postgres): run the mixed-backend suites' PostgreSQL legs

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -140,6 +140,15 @@ Consequences worth knowing:
 - **A new PostgreSQL suite must bootstrap its own tables** (usually
   `await pool.query(generatePostgresMigrationSQL())` in `beforeAll`). It cannot
   inherit them from whichever suite happened to run first.
+- **A suite outside `tests/backends/postgres/` must be named in
+  `scripts/test-postgres.sh`.** The lane picks up that directory wholesale, but
+  mixed-backend suites — the SQLite family in the default lane plus a
+  PostgreSQL leg when `POSTGRES_URL` is set — live elsewhere and are listed
+  file by file. Forgetting one is invisible: the default lane skips the
+  PostgreSQL leg for want of `POSTGRES_URL` and the PostgreSQL lane never loads
+  the file, so the leg runs nowhere and the suite still reports green.
+  `tests/postgres-lane-coverage.test.ts` fails when a suite that imports
+  `provisionPostgresTestDatabase` is missing from the script.
 - **The `POSTGRES_URL` role needs `CREATEDB`.** Set
   `TYPEGRAPH_TEST_SHARED_DATABASE=1` to opt out and run every suite against the
   base database — the pre-isolation behaviour, including its cross-suite

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -58,6 +58,18 @@ vitest_args+=(
   tests/backends/integration/
   tests/graph-merge/
   tests/property/graph-merge/
+  # Mixed-backend suites. These run the SQLite family in the default lane and
+  # ADD a server-Postgres leg when POSTGRES_URL is set, so they live outside
+  # tests/backends/postgres/ and have to be named one by one. Omitting one
+  # costs nothing visible — its Postgres leg just never executes anywhere
+  # (#386) — so `tests/postgres-lane-coverage.test.ts` fails when a suite that
+  # resolves its URL through `provisionPostgresTestDatabase` is missing here.
+  tests/backends/l2-score-scale-parity.test.ts
+  tests/hybrid-single-statement.test.ts
+  tests/search-filter-pushdown.test.ts
+  tests/search-liveness.test.ts
+  tests/similar-to-approximate.test.ts
+  tests/vector-cross-backend-parity.test.ts
 )
 
 POSTGRES_URL="$POSTGRES_URL" vitest "${vitest_args[@]}"

--- a/packages/typegraph/tests/postgres-lane-coverage.test.ts
+++ b/packages/typegraph/tests/postgres-lane-coverage.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Guards the `test:postgres` lane against silent coverage loss.
+ *
+ * A suite declares a server-PostgreSQL leg by resolving its connection URL
+ * through `provisionPostgresTestDatabase`. Most of those suites live under
+ * `tests/backends/postgres/`, which `scripts/test-postgres.sh` picks up by
+ * directory. The mixed-backend ones — SQLite family in the default lane, plus
+ * a Postgres leg when `POSTGRES_URL` is set — live outside that directory and
+ * have to be named in the script individually.
+ *
+ * Forgetting one is invisible: the default lane skips the Postgres leg because
+ * `POSTGRES_URL` is unset, and the Postgres lane never loads the file, so the
+ * leg runs in no lane at all and the suite still reports green (#386). This
+ * suite turns that omission into a failing test instead.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { requireDefined } from "../src/utils/presence";
+
+const PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const LANE_SCRIPT_RELATIVE_PATH = "scripts/test-postgres.sh";
+const TESTS_DIRECTORY_NAME = "tests";
+
+/** Importing this module is what marks a suite as needing a real server. */
+const PROVISIONER_MODULE = "postgres-test-database";
+
+/**
+ * Matches the import rather than any mention of the module name, so a file
+ * that merely talks about the provisioner (this one) is not mistaken for a
+ * suite that uses it.
+ */
+const PROVISIONER_IMPORT_PATTERN = new RegExp(
+  String.raw`from\s+"[^"]*/${PROVISIONER_MODULE}"`,
+);
+
+/**
+ * Lane arguments as the script lists them: one `tests/…` path per line, either
+ * a directory (trailing slash) or a single file. Comment lines are excluded by
+ * the character class rather than skipped, so a commented-out entry does not
+ * count as coverage.
+ */
+const LANE_TARGET_PATTERN = /^[^\S\n]*(tests\/[^\s#]+)[^\S\n]*$/gm;
+
+function readLaneTargets(): readonly string[] {
+  const script = readFileSync(
+    path.join(PACKAGE_ROOT, LANE_SCRIPT_RELATIVE_PATH),
+    "utf8",
+  );
+  return [...script.matchAll(LANE_TARGET_PATTERN)].map((match) =>
+    requireDefined(
+      match[1],
+      `Lane target pattern matched without a path: ${match[0]}`,
+    ),
+  );
+}
+
+/** Package-relative POSIX paths of every `*.test.ts` file under `tests/`. */
+function listTestFiles(): readonly string[] {
+  const entries = readdirSync(path.join(PACKAGE_ROOT, TESTS_DIRECTORY_NAME), {
+    recursive: true,
+    withFileTypes: true,
+  });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".test.ts"))
+    .map((entry) =>
+      path
+        .relative(PACKAGE_ROOT, path.join(entry.parentPath, entry.name))
+        .split(path.sep)
+        .join("/"),
+    );
+}
+
+function suitesWithPostgresLeg(): readonly string[] {
+  return listTestFiles()
+    .filter((file) =>
+      PROVISIONER_IMPORT_PATTERN.test(
+        readFileSync(path.join(PACKAGE_ROOT, file), "utf8"),
+      ),
+    )
+    .toSorted();
+}
+
+/**
+ * Vitest treats each positional argument as a path filter, so a directory
+ * target covers everything beneath it and a file target covers only itself.
+ */
+function isCoveredByLane(
+  file: string,
+  laneTargets: readonly string[],
+): boolean {
+  return laneTargets.some((target) =>
+    target.endsWith("/") ? file.startsWith(target) : file === target,
+  );
+}
+
+describe("test:postgres lane coverage", () => {
+  it("runs every suite that provisions a PostgreSQL database", () => {
+    const laneTargets = readLaneTargets();
+    const suites = suitesWithPostgresLeg();
+
+    // Non-vacuity: a broken discovery step must not read as "all covered".
+    expect(suites.length).toBeGreaterThan(0);
+
+    const uncovered = suites.filter(
+      (suite) => !isCoveredByLane(suite, laneTargets),
+    );
+    expect(
+      uncovered,
+      `These suites resolve a database through ${PROVISIONER_MODULE} but ${LANE_SCRIPT_RELATIVE_PATH} never loads them, so their PostgreSQL legs run in no lane. Add each one to the script's vitest arguments.`,
+    ).toEqual([]);
+  });
+
+  it("names only paths that still exist", () => {
+    const testFiles = new Set(listTestFiles());
+    const missing = readLaneTargets().filter((target) =>
+      target.endsWith("/") ?
+        !existsSync(path.join(PACKAGE_ROOT, target))
+      : !testFiles.has(target),
+    );
+    expect(
+      missing,
+      `${LANE_SCRIPT_RELATIVE_PATH} names paths that no longer exist. Vitest silently matches nothing for a stale filter, so the lane would quietly shrink.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Six mixed-backend suites resolve a PostgreSQL database and gate a server-Postgres leg on `POSTGRES_URL`, but none of them were named in the `test:postgres` lane's vitest arguments. The default lane skips their Postgres leg because `POSTGRES_URL` is unset there, and the Postgres lane never loaded the files at all, so those legs ran in no lane — locally or in CI — while the suites still reported green.

## Files that joined the lane

Each one runs the SQLite family (local sqlite-vec, libSQL) in the default lane and adds a Postgres/pgvector leg when `POSTGRES_URL` is set. They live outside `tests/backends/postgres/`, which the lane picks up wholesale, so they have to be named individually:

- `tests/backends/l2-score-scale-parity.test.ts`
- `tests/hybrid-single-statement.test.ts`
- `tests/search-filter-pushdown.test.ts`
- `tests/search-liveness.test.ts`
- `tests/similar-to-approximate.test.ts`
- `tests/vector-cross-backend-parity.test.ts`

The sweep that found them looked for imports of `provisionPostgresTestDatabase` rather than for mentions of `POSTGRES_URL`: importing the provisioner is precisely what declares "this suite needs a real server". It came out at exactly the six files the issue named, and all six already resolve their URL through the provisioner, so none needed the per-suite database provisioning added. The lane grows from 82 to 88 files and by roughly six seconds.

## Fallout

Nothing left to fix. The known failure — `hybrid-single-statement.test.ts` dropping every `tg_vec_*` table between scenarios while leaving the durable contribution markers that guard them, so the next store boot trusted a marker whose table was gone and the first embedding write hit a missing relation — was already repaired in #385, which added the `typegraph_contribution_materializations` drop while giving each suite its own database. Running all six suites' Postgres legs against a real pgvector server confirms they pass as written, and the widened lane is green end to end twice with no order or state dependence among the newly joined files.

## Keeping it from drifting again

`tests/postgres-lane-coverage.test.ts` fails when a suite that imports `provisionPostgresTestDatabase` is not covered by a path in `scripts/test-postgres.sh`, and when the script names a path that no longer exists — vitest silently matches nothing for a stale filter, so the lane would quietly shrink. It runs in the default lane, needs no database, and does not count a commented-out entry as coverage. `docs/TESTING.md` gains the corresponding rule alongside the existing per-suite-database notes.

CI needs no change: both PostgreSQL shards invoke `scripts/test-postgres.sh`, so they pick up the widened list automatically.

Closes #386
