### PR TITLE
chore(test): drop the vestigial integration-directory filter from the postgres lane

### DIFF
--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -53,9 +53,11 @@ if [[ -n "${VITEST_SHARD:-}" ]]; then
   vitest_args+=("--shard=$VITEST_SHARD")
 fi
 
+# tests/backends/integration/ is deliberately absent: it holds suite
+# definitions registered via createIntegrationTestSuite, not *.test.ts files,
+# so listing it matches nothing and reads as coverage that is not there.
 vitest_args+=(
   tests/backends/postgres/
-  tests/backends/integration/
   tests/graph-merge/
   tests/property/graph-merge/
   # Mixed-backend suites. These run the SQLite family in the default lane and


### PR DESCRIPTION
`scripts/test-postgres.sh` passed `tests/backends/integration/` to vitest, but that directory holds suite *definitions* registered via `createIntegrationTestSuite` from per-backend files — no `*.test.ts` matches, so the filter silently contributed nothing while reading as coverage. This is exactly the stale-filter shape the #386 drift guard exists to catch elsewhere. Removed, with a comment recording why the directory is deliberately absent so it does not get re-added. Noticed during #386; no behavior change to the lane's collected files.