### PR TITLE
perf(query): evaluate historical identity classes once per query, not per candidate edge

### DIFF
--- a/.changeset/hoisted-historical-identity-classes.md
+++ b/.changeset/hoisted-historical-identity-classes.md
@@ -1,0 +1,27 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Evaluate the historical identity-class reconstruction once per query instead of
+once per candidate edge
+
+An identity-expanded traversal hop under a historical coordinate (`asOf`,
+`asOfRecorded`, or a non-current `view()`) has no materialized closure to read,
+so it rebuilds classes from the assertion ledger. That rebuild used to sit inside
+the correlated edge predicate, where SQLite re-materialized it for every
+candidate *(source row, edge)* pair, and under `sameIdAcrossKinds: "fold"` each
+rebuild also scanned the structural same-id relation across the graph — a
+quadratic term that quadrupled per doubling of graph size.
+
+The reconstruction is now a single materialized query-level relation of
+`(seed_kind, seed_id, kind, id)` rows, seeded by the nodes that have identity
+peers rather than by the frontier, so it depends on nothing a traversal step
+carries and is built once for the whole statement. Each step widens its frontier
+onto that relation with an outer join, which turns the candidate-edge lookup into
+the same ordinary indexed equality a traversal without identity expansion uses.
+On the narrow-edge fixture (SQLite, all *n* nodes acting as source rows) the hop
+drops from 122/486/1984/8261 ms at *n* = 250/500/1000/2000 to 7/7/14/28 ms, and
+grows linearly rather than quadratically.
+
+Results are unchanged at every coordinate. Current-coordinate traversal still
+reads the materialized closure through its existing correlated predicate.

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -228,23 +228,47 @@ traversal supports the same option.
 TypeGraph does not perform automatic graph-wide expansion and collection reads
 such as `getById` have no identity option.
 
+The two coordinates reach membership differently, and they cost differently.
+
 At the current coordinate the hop reads the materialized closure through its
-indexes, but the edge join remains a correlated predicate. On broad edge kinds,
-the planner may scan matching edges per source row; track that optimization in
-[typegraph#270](https://github.com/nicia-ai/typegraph/issues/270). A
-**historical** hop — one under `asOf`, `asOfRecorded`, or a non-current `view()`
-— cannot use the materialized closure, because it represents only the present.
-It instead embeds a recursive class rebuild inside the correlated edge
-predicate. Under `sameIdAcrossKinds: "fold"` that rebuild also has to
-consider the structural same-id relation, which is proportional to the number
-of live nodes in the graph. On the narrow-edge fixture used to isolate this
-term, a historical expanded hop costs roughly *source rows × graph size*:
-SQLite end-to-end query time was 45 ms at *n* = 250, 172 ms at 500, 671 ms at
-1000 and 2.8 s at 2000 — quadratic. Broad edge kinds additionally pay the
-candidate-edge correlation tracked in #270. Keep identity-expanded traversals
-narrowly filtered until the current and historical planner work tracked in
-[typegraph#270](https://github.com/nicia-ai/typegraph/issues/270) and
-[typegraph#310](https://github.com/nicia-ai/typegraph/issues/310) lands.
+indexes, but it does so from inside a correlated predicate, so the edge join
+stays correlated too. On broad edge kinds the planner may scan matching edges
+per source row; keep current-coordinate expanded traversals narrowly filtered
+until the de-correlation tracked in
+[typegraph#270](https://github.com/nicia-ai/typegraph/issues/270) lands.
+
+A **historical** hop — one under `asOf`, `asOfRecorded`, or a non-current
+`view()` — cannot use the materialized closure, because the closure represents
+only the present. It rebuilds identity classes from the assertion ledger, and
+under `sameIdAcrossKinds: "fold"` that rebuild also has to consider the
+structural same-id relation, which is proportional to the number of live nodes
+in the graph. That rebuild is now hoisted to a single materialized relation
+evaluated **once per query** — keyed by the nodes that have identity peers at
+all, not by the frontier — which each traversal step joins. The cost is
+therefore one reconstruction plus an ordinary indexed edge join per expanded
+member, rather than a reconstruction per candidate *(source row, edge)* pair.
+Measured on the narrow-edge fixture that isolates the term (SQLite, *n* Person
+nodes each folded with a Company peer, all *n* acting as source rows, fan-out 1):
+
+| *n* | before | after |
+| --- | --- | --- |
+| 250 | 122 ms | 7 ms |
+| 500 | 486 ms | 7 ms |
+| 1000 | 1984 ms | 14 ms |
+| 2000 | 8261 ms | 28 ms |
+
+Growth is linear in graph size where it used to quadruple per doubling. Because
+the step now joins the class relation instead of testing membership per
+candidate row, a historical hop no longer pays the correlated candidate-edge
+scan either — that residual cost applies to the current coordinate only, and
+remains #270's subject.
+
+One caveat is worth planning around: the hoisted relation is built for the whole
+graph at that coordinate, so a historical expanded traversal from a handful of
+nodes still pays for one reconstruction over the identity ledger and the
+folded-id population. It is cheap in absolute terms on small and mid-sized
+graphs and no longer grows with the number of source rows, but it is not
+proportional to how little you asked for.
 
 ## Interchange and branch merge
 

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -72,6 +72,9 @@ vitest_args+=(
   tests/search-liveness.test.ts
   tests/similar-to-approximate.test.ts
   tests/vector-cross-backend-parity.test.ts
+  # Self-skips unless TYPEGRAPH_PERF=1, so it costs the lane nothing by
+  # default; listed so its Postgres leg has a lane when perf runs are enabled.
+  tests/perf/identity-historical-traversal-scaling.test.ts
 )
 
 POSTGRES_URL="$POSTGRES_URL" vitest "${vitest_args[@]}"

--- a/packages/typegraph/src/identity/historical-sql.ts
+++ b/packages/typegraph/src/identity/historical-sql.ts
@@ -207,10 +207,10 @@ export function historicalIdentityReconstructionCtes(
           AND ${structuralFoldVisibilitySql(input.coordinate, "right_node")}
       `
     : sql``;
+  // `seeds` is declared after `identity_edges` so a seed source may itself read
+  // the edge relation (see {@link historicalIdentityPeerClassQuery}); every
+  // entry still references only entries declared before it.
   return sql`
-    seeds(seed_kind, seed_id) AS (
-      ${input.seedSource}
-    ),
     node_snapshot(kind, id, valid_from, valid_to, created_at, deleted_at) AS (
       ${nodes}
     ),
@@ -222,6 +222,9 @@ export function historicalIdentityReconstructionCtes(
       UNION ALL
       SELECT b_kind, b_id, a_kind, a_id FROM same_assertions
       ${sameIdEdges}
+    ),
+    seeds(seed_kind, seed_id) AS (
+      ${input.seedSource}
     ),
     identity_members(seed_kind, seed_id, kind, id) AS (
       SELECT seeds.seed_kind, seeds.seed_id, seeds.seed_kind, seeds.seed_id
@@ -236,5 +239,59 @@ export function historicalIdentityReconstructionCtes(
         ON edge.a_kind = member.kind
        AND edge.a_id = member.id
     )
+  `;
+}
+
+/**
+ * Column contract of the peer-class relation built by
+ * {@link historicalIdentityPeerClassQuery}, in projection order. A consumer names
+ * the relation itself, so it declares these columns on the name it chooses.
+ */
+export const IDENTITY_PEER_CLASS_COLUMNS: SqlFragment = sql.raw(
+  ["seed_kind", "seed_id", "kind", "id"].join(", "),
+);
+
+/**
+ * A self-contained query for the *visible* identity classes of every node that
+ * has at least one identity peer at `coordinate`, as
+ * `(seed_kind, seed_id, kind, id)` rows.
+ *
+ * Unlike {@link historicalIdentityReconstructionCtes}, nothing here depends on
+ * which nodes a caller is asking about: the seeds are the endpoints of the
+ * identity-edge relation itself. That is what makes the result hoistable to a
+ * query-level CTE evaluated once, rather than a correlated subquery a planner
+ * may re-evaluate per candidate row (typegraph#310). Nodes with no peer are
+ * absent by construction, leaving the "member is the seed itself" case to the
+ * consumer; that is what keeps this relation proportional to the identity ledger
+ * and the folded-id population rather than to the whole graph.
+ *
+ * Members are filtered to those visible at `coordinate`, matching the
+ * point-in-time node check a membership consumer would otherwise apply itself.
+ * The filter sits in the projection, not in the recursion, so a class may still
+ * be held together through a member that is not visible.
+ *
+ * The returned fragment is a complete `SELECT` carrying its own
+ * `WITH RECURSIVE`, so the inner relation names stay scoped to it and multiple
+ * consumers in one statement cannot collide.
+ */
+export function historicalIdentityPeerClassQuery(
+  input: Readonly<{
+    schema: SqlSchema;
+    graphId: string;
+    coordinate: HistoricalIdentitySqlCoordinate;
+    sameIdAcrossKinds: "fold" | "ignore";
+  }>,
+): SqlFragment {
+  const reconstruction = historicalIdentityReconstructionCtes({
+    ...input,
+    seedSource: sql`SELECT DISTINCT a_kind, a_id FROM identity_edges`,
+  });
+  return sql`
+    WITH RECURSIVE
+    ${reconstruction}
+    SELECT member.seed_kind, member.seed_id, member.kind, member.id
+    FROM identity_members member
+    JOIN node_snapshot n ON n.kind = member.kind AND n.id = member.id
+    WHERE ${identityNodeVisibilitySql(input.coordinate, "n")}
   `;
 }

--- a/packages/typegraph/src/query/compiler/emitter/recursive.ts
+++ b/packages/typegraph/src/query/compiler/emitter/recursive.ts
@@ -8,6 +8,11 @@ export type RecursiveQueryEmitterInput = Readonly<{
   limitOffset?: SqlFragment;
   logicalPlan: LogicalPlan;
   orderBy?: SqlFragment;
+  /**
+   * Non-recursive CTE definitions the recursive CTE reads, in dependency order.
+   * They join the same `WITH RECURSIVE` list — both dialects accept a mix.
+   */
+  precedingCtes?: readonly SqlFragment[];
   projection: SqlFragment;
   recursiveCte: SqlFragment;
 }>;
@@ -48,9 +53,13 @@ export function emitRecursiveQuerySql(
 ): SqlFragment {
   assertRecursiveEmitterClauseAlignment(input.logicalPlan, input);
 
+  const cteList = sql.join(
+    [...(input.precedingCtes ?? []), input.recursiveCte],
+    sql`, `,
+  );
   const parts: SqlFragment[] = [
     sql`WITH RECURSIVE`,
-    input.recursiveCte,
+    cteList,
     sql`SELECT ${input.projection}`,
     sql`FROM recursive_cte`,
     input.depthFilter,

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -18,7 +18,10 @@ import {
   vectorScoreExpression,
 } from "../../dialect/vector-strategy";
 import { sql, type SqlFragment } from "../../sql-fragment";
-import { compileIdentitySourcePredicate } from "../identity-traversal";
+import {
+  compileIdentitySourcePredicate,
+  planHistoricalIdentityFrontierExpansion,
+} from "../identity-traversal";
 import { type TemporalFilterPass } from "../passes";
 import {
   compileKindFilter,
@@ -382,6 +385,55 @@ export function buildStandardTraversalCte(
     : ctx.dialect.capabilities.emitNotMaterializedHint ? sql`NOT MATERIALIZED `
     : sql``;
 
+  const previousIdColumn = sql`cte_${sql.raw(previousAlias)}.${sql.raw(`${previousAlias}_id`)}`;
+  const previousKindColumn = sql`cte_${sql.raw(previousAlias)}.${sql.raw(`${previousAlias}_kind`)}`;
+  const identityFrontierExpansion =
+    traversal.includeIdentityMembers === true ?
+      planHistoricalIdentityFrontierExpansion({
+        ast,
+        previousId: previousIdColumn,
+        previousKind: previousKindColumn,
+        temporalFilterPass,
+      })
+    : undefined;
+
+  /**
+   * Connects a candidate edge to the frontier. A widened frontier and a plain
+   * one join the edge the same way — on the frontier row's (kind, id) or on the
+   * class member's — leaving the correlated membership test to the current
+   * coordinate alone.
+   */
+  function compileSourceJoin(
+    branch: Readonly<{
+      joinField: "from_id" | "to_id";
+      joinKindField: "from_kind" | "to_kind";
+    }>,
+  ): SqlFragment {
+    const edgeId = sql`e.${sql.raw(branch.joinField)}`;
+    const edgeKind = sql`e.${sql.raw(branch.joinKindField)}`;
+    if (identityFrontierExpansion !== undefined) {
+      return sql`
+        ${identityFrontierExpansion.memberId} = ${edgeId}
+        AND ${identityFrontierExpansion.memberKind} = ${edgeKind}
+      `;
+    }
+    if (traversal.includeIdentityMembers === true) {
+      return compileIdentitySourcePredicate({
+        ctx,
+        edgeId,
+        edgeKind,
+        graphId,
+        previousId: previousIdColumn,
+        previousKind: previousKindColumn,
+        temporalFilterPass,
+      });
+    }
+    return sql`
+      ${previousIdColumn} = ${edgeId}
+      AND ${previousKindColumn} = ${edgeKind}
+    `;
+  }
+
   function compileTraversalBranch(
     branch: Readonly<{
       duplicateGuard?: SqlFragment | undefined;
@@ -411,26 +463,16 @@ export function buildStandardTraversalCte(
       whereClauses.push(branch.duplicateGuard);
     }
 
-    const sourceJoin =
-      traversal.includeIdentityMembers === true ?
-        compileIdentitySourcePredicate({
-          ast,
-          ctx,
-          edgeId: sql`e.${sql.raw(branch.joinField)}`,
-          edgeKind: sql`e.${sql.raw(branch.joinKindField)}`,
-          graphId,
-          previousId: sql`cte_${sql.raw(previousAlias)}.${sql.raw(`${previousAlias}_id`)}`,
-          previousKind: sql`cte_${sql.raw(previousAlias)}.${sql.raw(`${previousAlias}_kind`)}`,
-          temporalFilterPass,
-        })
-      : sql`
-        cte_${sql.raw(previousAlias)}.${sql.raw(`${previousAlias}_id`)} = e.${sql.raw(branch.joinField)}
-        AND cte_${sql.raw(previousAlias)}.${sql.raw(`${previousAlias}_kind`)} = e.${sql.raw(branch.joinKindField)}
-      `;
+    const sourceJoin = compileSourceJoin(branch);
+    const frontierJoins = sql.join(
+      identityFrontierExpansion?.joins ?? [],
+      sql` `,
+    );
 
     return sql`
       SELECT ${sql.join(selectColumns, sql`, `)}
       FROM cte_${sql.raw(previousAlias)}
+      ${frontierJoins}
       JOIN ${ctx.schema.edgesTable} e ON ${sourceJoin}
       JOIN ${ctx.schema.nodesTable} n ON n.graph_id = e.graph_id
         AND n.id = e.${sql.raw(branch.targetField)}

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -464,15 +464,12 @@ export function buildStandardTraversalCte(
     }
 
     const sourceJoin = compileSourceJoin(branch);
-    const frontierJoins = sql.join(
-      identityFrontierExpansion?.joins ?? [],
-      sql` `,
-    );
+    const frontierJoin = identityFrontierExpansion?.frontierJoin ?? sql``;
 
     return sql`
       SELECT ${sql.join(selectColumns, sql`, `)}
       FROM cte_${sql.raw(previousAlias)}
-      ${frontierJoins}
+      ${frontierJoin}
       JOIN ${ctx.schema.edgesTable} e ON ${sourceJoin}
       JOIN ${ctx.schema.nodesTable} n ON n.graph_id = e.graph_id
         AND n.id = e.${sql.raw(branch.targetField)}

--- a/packages/typegraph/src/query/compiler/identity-traversal.ts
+++ b/packages/typegraph/src/query/compiler/identity-traversal.ts
@@ -95,13 +95,13 @@ export function compileHistoricalIdentityClassCte(
 /**
  * How a traversal step reaches the identity class of its frontier rows.
  *
- * `joins` widens the step's FROM list from "the frontier" to "the frontier's
- * class members"; `memberKind`/`memberId` then name the member a candidate edge
- * must attach to, so the edge join is an ordinary equality — the same shape a
- * traversal without identity expansion uses.
+ * `frontierJoin` widens the step's FROM list from "the frontier" to "the
+ * frontier's class members"; `memberKind`/`memberId` then name the member a
+ * candidate edge must attach to, so the edge join is an ordinary equality — the
+ * same shape a traversal without identity expansion uses.
  */
 export type IdentityFrontierExpansion = Readonly<{
-  joins: readonly SqlFragment[];
+  frontierJoin: SqlFragment;
   memberId: SqlFragment;
   memberKind: SqlFragment;
 }>;
@@ -138,13 +138,11 @@ export function planHistoricalIdentityFrontierExpansion(
   }
   const peer = sql.identifier(PEER_CLASS_ALIAS);
   return {
-    joins: [
-      sql`
-        LEFT JOIN ${sql.identifier(HISTORICAL_IDENTITY_CLASS_CTE_ALIAS)} ${peer}
-          ON ${peer}.seed_kind = ${previousKind}
-         AND ${peer}.seed_id = ${previousId}
-      `,
-    ],
+    frontierJoin: sql`
+      LEFT JOIN ${sql.identifier(HISTORICAL_IDENTITY_CLASS_CTE_ALIAS)} ${peer}
+        ON ${peer}.seed_kind = ${previousKind}
+       AND ${peer}.seed_id = ${previousId}
+    `,
     memberId: sql`COALESCE(${peer}.id, ${previousId})`,
     memberKind: sql`COALESCE(${peer}.kind, ${previousKind})`,
   };

--- a/packages/typegraph/src/query/compiler/identity-traversal.ts
+++ b/packages/typegraph/src/query/compiler/identity-traversal.ts
@@ -1,16 +1,167 @@
 import { optionalRecordedInstantParts } from "../../core/temporal";
 import {
-  historicalIdentityReconstructionCtes,
+  historicalIdentityPeerClassQuery,
   type HistoricalIdentitySqlCoordinate,
+  IDENTITY_PEER_CLASS_COLUMNS,
 } from "../../identity/historical-sql";
 import { type QueryAst } from "../ast";
 import { sql, type SqlFragment } from "../sql-fragment";
 import { type TemporalFilterPass } from "./passes";
 import { type PredicateCompilerContext } from "./predicates";
 
-export function compileIdentitySourcePredicate(
+/**
+ * Name of the query-level relation holding reconstructed identity classes for a
+ * historical read. One per statement: the relation depends only on the graph,
+ * the read coordinate and the identity profile, so every traversal step of a
+ * query shares it.
+ */
+export const HISTORICAL_IDENTITY_CLASS_CTE_ALIAS = "identity_peer_class";
+
+/** Alias the frontier expansion gives that relation inside a traversal step. */
+const PEER_CLASS_ALIAS = "identity_peer";
+
+type IdentityCoordinateInput = Readonly<{
+  ast: QueryAst;
+  temporalFilterPass: TemporalFilterPass;
+}>;
+
+/**
+ * Resolves the read coordinate an identity reconstruction must be evaluated at,
+ * or `undefined` when the query reads the present and can therefore use the
+ * materialized closure instead.
+ */
+function historicalCoordinate(
+  input: IdentityCoordinateInput,
+): HistoricalIdentitySqlCoordinate | undefined {
+  const { ast, temporalFilterPass } = input;
+  const recorded = optionalRecordedInstantParts(
+    ast.recordedAsOf,
+    "recordedAsOf",
+  );
+  if (recorded === undefined && ast.temporalMode.mode === "current") {
+    return undefined;
+  }
+  return {
+    validMode: ast.temporalMode.mode,
+    validAsOf: ast.temporalMode.asOf,
+    recorded,
+    currentInstant: temporalFilterPass.currentInstant,
+  };
+}
+
+/**
+ * Emits the query-level CTE definition backing identity expansion under a
+ * historical coordinate, or `undefined` when the query needs no such relation
+ * (no identity-expanded traversal, or a current-coordinate read).
+ *
+ * Callers must place the definition ahead of the traversal relations that read
+ * it. It depends on no other CTE, so the head of the `WITH` list is always
+ * valid.
+ */
+export function compileHistoricalIdentityClassCte(
   input: Readonly<{
     ast: QueryAst;
+    ctx: PredicateCompilerContext;
+    graphId: string;
+    temporalFilterPass: TemporalFilterPass;
+  }>,
+): SqlFragment | undefined {
+  const { ast, ctx, graphId, temporalFilterPass } = input;
+  const expandsIdentity = ast.traversals.some(
+    (traversal) => traversal.includeIdentityMembers === true,
+  );
+  if (!expandsIdentity) return undefined;
+  const coordinate = historicalCoordinate({ ast, temporalFilterPass });
+  if (coordinate === undefined) return undefined;
+
+  const peerClasses = historicalIdentityPeerClassQuery({
+    schema: ctx.schema,
+    graphId,
+    coordinate,
+    sameIdAcrossKinds: ctx.identitySameIdAcrossKinds ?? "fold",
+  });
+  // MATERIALIZED is load-bearing, not a hint. Left inlinable, SQLite pushes the
+  // reconstruction down to each reference site; a reference inside a correlated
+  // subquery is then rebuilt per candidate (source row, edge) pair, which is the
+  // quadratic term typegraph#310 removes. The expansion below reads it from an
+  // uncorrelated join for the same reason.
+  return sql`
+    ${sql.identifier(HISTORICAL_IDENTITY_CLASS_CTE_ALIAS)}(${IDENTITY_PEER_CLASS_COLUMNS}) AS MATERIALIZED (
+      ${peerClasses}
+    )
+  `;
+}
+
+/**
+ * How a traversal step reaches the identity class of its frontier rows.
+ *
+ * `joins` widens the step's FROM list from "the frontier" to "the frontier's
+ * class members"; `memberKind`/`memberId` then name the member a candidate edge
+ * must attach to, so the edge join is an ordinary equality — the same shape a
+ * traversal without identity expansion uses.
+ */
+export type IdentityFrontierExpansion = Readonly<{
+  joins: readonly SqlFragment[];
+  memberId: SqlFragment;
+  memberKind: SqlFragment;
+}>;
+
+/**
+ * Plans the frontier widening for an identity-expanded traversal step under a
+ * historical coordinate, or returns `undefined` at a current coordinate (which
+ * reads the materialized closure through {@link compileIdentitySourcePredicate}
+ * instead).
+ *
+ * The widening is an outer join against the hoisted class relation. That
+ * relation holds only nodes that have at least one peer, so the `COALESCE` pair
+ * supplies the frontier row itself both when it has no peers at all and,
+ * redundantly, as its own class member. A frontier row is always visible at the
+ * read coordinate — the relation it comes from filters on the same coordinate —
+ * so the self case needs no separate visibility check, and peers carry theirs
+ * inside the relation.
+ *
+ * This is the seam typegraph#270 extends: giving the current coordinate a peer
+ * relation of the same `(seed_kind, seed_id, kind, id)` shape lets it reuse this
+ * widening verbatim and drop its own correlated candidate-edge scan.
+ */
+export function planHistoricalIdentityFrontierExpansion(
+  input: Readonly<{
+    ast: QueryAst;
+    previousId: SqlFragment;
+    previousKind: SqlFragment;
+    temporalFilterPass: TemporalFilterPass;
+  }>,
+): IdentityFrontierExpansion | undefined {
+  const { ast, previousId, previousKind, temporalFilterPass } = input;
+  if (historicalCoordinate({ ast, temporalFilterPass }) === undefined) {
+    return undefined;
+  }
+  const peer = sql.identifier(PEER_CLASS_ALIAS);
+  return {
+    joins: [
+      sql`
+        LEFT JOIN ${sql.identifier(HISTORICAL_IDENTITY_CLASS_CTE_ALIAS)} ${peer}
+          ON ${peer}.seed_kind = ${previousKind}
+         AND ${peer}.seed_id = ${previousId}
+      `,
+    ],
+    memberId: sql`COALESCE(${peer}.id, ${previousId})`,
+    memberKind: sql`COALESCE(${peer}.kind, ${previousKind})`,
+  };
+}
+
+/**
+ * Compiles the correlated membership predicate used by identity expansion at the
+ * **current** coordinate: the candidate edge endpoint must be the frontier node
+ * itself or a visible member of its class in the materialized closure.
+ *
+ * A historical read does not reach here — it widens the frontier up front (see
+ * {@link planHistoricalIdentityFrontierExpansion}) because the reconstruction it
+ * needs cannot be re-evaluated per candidate row affordably. Removing the
+ * remaining correlation here is typegraph#270.
+ */
+export function compileIdentitySourcePredicate(
+  input: Readonly<{
     ctx: PredicateCompilerContext;
     edgeId: SqlFragment;
     edgeKind: SqlFragment;
@@ -21,7 +172,6 @@ export function compileIdentitySourcePredicate(
   }>,
 ): SqlFragment {
   const {
-    ast,
     ctx,
     edgeId,
     edgeKind,
@@ -31,87 +181,31 @@ export function compileIdentitySourcePredicate(
     temporalFilterPass,
   } = input;
   const memberVisibility = temporalFilterPass.forAlias("im");
-  const recorded = optionalRecordedInstantParts(
-    ast.recordedAsOf,
-    "recordedAsOf",
-  );
-  const historical =
-    recorded !== undefined || ast.temporalMode.mode !== "current";
-
-  if (!historical) {
-    return sql`
-      EXISTS (
-        SELECT 1
-        FROM ${ctx.schema.nodesTable} im
-        WHERE im.graph_id = ${graphId}
-          AND im.kind = ${edgeKind}
-          AND im.id = ${edgeId}
-          AND ${memberVisibility}
-          AND (
-            (im.kind = ${previousKind} AND im.id = ${previousId})
-            OR EXISTS (
-              SELECT 1
-              FROM ${ctx.schema.identityClosureTable} seed_class
-              JOIN ${ctx.schema.identityClosureTable} member_class
-                ON member_class.graph_id = seed_class.graph_id
-               AND member_class.class_kind = seed_class.class_kind
-               AND member_class.class_id = seed_class.class_id
-              WHERE seed_class.graph_id = ${graphId}
-                AND seed_class.member_kind = ${previousKind}
-                AND seed_class.member_id = ${previousId}
-                AND member_class.member_kind = im.kind
-                AND member_class.member_id = im.id
-            )
-          )
-      )
-    `;
-  }
-
-  const coordinate: HistoricalIdentitySqlCoordinate = {
-    validMode: ast.temporalMode.mode,
-    validAsOf: ast.temporalMode.asOf,
-    recorded,
-    currentInstant: temporalFilterPass.currentInstant,
-  };
-  // COST: this whole block sits inside the correlated edge predicate, so a
-  // planner may evaluate it per candidate (source row, edge) pair. Under
-  // "fold", its structural relation also spans every live node in the graph.
-  // A narrow-edge fixture isolates a ~(source rows × graph size) reconstruction
-  // term and measures clean quadratic growth (SQLite, n nodes all acting as
-  // source rows: 45ms at n=250, 172ms at 500, 671ms at 1000, 2.8s at 2000).
-  // The current-coordinate branch avoids that reconstruction term and seeks
-  // the present-only materialized closure, but its enclosing edge join remains
-  // correlated and is tracked separately in typegraph#270.
-  //
-  // Seeding the structural relation from the queried refs instead was measured
-  // and REJECTED: restricting it to (seed id + assertion endpoint ids) is
-  // closure-equivalent, but it makes the relation correlated on the seed, so
-  // the engine re-materializes it per source row instead of hoisting one scan.
-  // That was 5-7x SLOWER on the same benchmark (931ms-1.16s vs 172ms at
-  // n=500). Removing the quadratic term needs the closure hoisted to a
-  // query-level CTE keyed by all seeds, not a narrower per-seed relation.
-  // Tracked in typegraph#310.
-  const reconstruction = historicalIdentityReconstructionCtes({
-    schema: ctx.schema,
-    graphId,
-    coordinate,
-    seedSource: sql`SELECT ${previousKind}, ${previousId}`,
-    sameIdAcrossKinds: ctx.identitySameIdAcrossKinds ?? "fold",
-  });
 
   return sql`
     EXISTS (
-      WITH RECURSIVE
-      ${reconstruction}
       SELECT 1
-      FROM identity_members identity_member
-      JOIN ${ctx.schema.nodesTable} im
-        ON im.graph_id = ${graphId}
-       AND im.kind = identity_member.kind
-       AND im.id = identity_member.id
-      WHERE im.kind = ${edgeKind}
+      FROM ${ctx.schema.nodesTable} im
+      WHERE im.graph_id = ${graphId}
+        AND im.kind = ${edgeKind}
         AND im.id = ${edgeId}
         AND ${memberVisibility}
+        AND (
+          (im.kind = ${previousKind} AND im.id = ${previousId})
+          OR EXISTS (
+            SELECT 1
+            FROM ${ctx.schema.identityClosureTable} seed_class
+            JOIN ${ctx.schema.identityClosureTable} member_class
+              ON member_class.graph_id = seed_class.graph_id
+             AND member_class.class_kind = seed_class.class_kind
+             AND member_class.class_id = seed_class.class_id
+            WHERE seed_class.graph_id = ${graphId}
+              AND seed_class.member_kind = ${previousKind}
+              AND seed_class.member_id = ${previousId}
+              AND member_class.member_kind = im.kind
+              AND member_class.member_id = im.id
+          )
+        )
     )
   `;
 }

--- a/packages/typegraph/src/query/compiler/index.ts
+++ b/packages/typegraph/src/query/compiler/index.ts
@@ -96,6 +96,7 @@ import {
   lateMaterializedPhysicalAlias,
   lateMaterializedProjectedNodeAliases,
 } from "./emitter";
+import { compileHistoricalIdentityClassCte } from "./identity-traversal";
 import { type TemporalFilterPass } from "./passes";
 import { type LogicalPlan, type LogicalPlanNode } from "./plan";
 import {
@@ -889,9 +890,10 @@ function stripLimitOffsetFromPlanNode(node: LogicalPlanNode): LogicalPlanNode {
 }
 
 /**
- * The start CTE followed by one CTE per traversal — the candidate-set prefix
- * shared by the flat plan and the late-materialization plan (which feeds it a
- * lean AST/column set and no per-traversal limit).
+ * The historical identity-class relation (when the query needs one), the start
+ * CTE, then one CTE per traversal — the candidate-set prefix shared by the flat
+ * plan and the late-materialization plan (which feeds it a lean AST/column set
+ * and no per-traversal limit).
  */
 function buildStandardStartAndTraversalCtes(
   input: Readonly<{
@@ -915,7 +917,14 @@ function buildStandardStartAndTraversalCtes(
     temporalFilterPass,
     traversalLimit,
   } = input;
+  const historicalIdentityCte = compileHistoricalIdentityClassCte({
+    ast,
+    ctx,
+    graphId,
+    temporalFilterPass,
+  });
   const ctes: SqlFragment[] = [
+    ...(historicalIdentityCte === undefined ? [] : [historicalIdentityCte]),
     buildStandardStartCte({
       ast,
       ctx,

--- a/packages/typegraph/src/query/compiler/recursive.ts
+++ b/packages/typegraph/src/query/compiler/recursive.ts
@@ -16,7 +16,11 @@ import {
 } from "../dialect";
 import { sql, type SqlFragment } from "../sql-fragment";
 import { emitRecursiveQuerySql } from "./emitter";
-import { compileIdentitySourcePredicate } from "./identity-traversal";
+import {
+  compileHistoricalIdentityClassCte,
+  compileIdentitySourcePredicate,
+  planHistoricalIdentityFrontierExpansion,
+} from "./identity-traversal";
 import {
   createTemporalFilterPass,
   runCompilerPass,
@@ -270,6 +274,16 @@ function compileVariableLengthQueryWithRecursiveCteStrategy(
     temporalFilterPass,
   );
 
+  // Identity expansion under a historical coordinate reads a reconstruction
+  // relation hoisted out of the recursive term, so it is evaluated once for the
+  // whole traversal rather than per expanded (frontier row, edge) pair.
+  const historicalIdentityCte = compileHistoricalIdentityClassCte({
+    ast,
+    ctx,
+    graphId,
+    temporalFilterPass,
+  });
+
   // Build projection
   const projection = compileRecursiveProjection(ast, vlTraversal, dialect);
 
@@ -287,6 +301,9 @@ function compileVariableLengthQueryWithRecursiveCteStrategy(
     ...(limitOffset === undefined ? {} : { limitOffset }),
     logicalPlan,
     ...(orderBy === undefined ? {} : { orderBy }),
+    ...(historicalIdentityCte === undefined ?
+      {}
+    : { precedingCtes: [historicalIdentityCte] }),
     projection,
     recursiveCte,
   });
@@ -442,6 +459,18 @@ function compileRecursiveCte(
     ...startPredicates,
   ];
 
+  const previousIdColumn = sql`r.${sql.raw(nodeAlias)}_id`;
+  const previousKindColumn = sql`r.${sql.raw(nodeAlias)}_kind`;
+  const identityFrontierExpansion =
+    traversal.includeIdentityMembers === true ?
+      planHistoricalIdentityFrontierExpansion({
+        ast,
+        previousId: previousIdColumn,
+        previousKind: previousKindColumn,
+        temporalFilterPass,
+      })
+    : undefined;
+
   const recursiveBaseWhereClauses: SqlFragment[] = [
     sql`e.graph_id = ${graphId}`,
     nodeKindFilter,
@@ -453,6 +482,46 @@ function compileRecursiveCte(
     recursiveBaseWhereClauses.push(cycleCheck);
   }
   recursiveBaseWhereClauses.push(...edgePredicates, ...targetNodePredicates);
+
+  /**
+   * Connects a candidate edge to the row the worktable is expanding from. A
+   * widened frontier and a plain one join the edge the same way — on the
+   * worktable row's (kind, id) or on the class member's — leaving the correlated
+   * membership test to the current coordinate alone.
+   */
+  function compileWorktableJoinClauses(
+    branch: Readonly<{
+      joinField: "from_id" | "to_id";
+      joinKindField: "from_kind" | "to_kind";
+    }>,
+  ): SqlFragment[] {
+    const edgeId = sql`e.${sql.raw(branch.joinField)}`;
+    const edgeKind = sql`e.${sql.raw(branch.joinKindField)}`;
+    if (identityFrontierExpansion !== undefined) {
+      return [
+        sql`${edgeId} = ${identityFrontierExpansion.memberId}`,
+        sql`${edgeKind} = ${identityFrontierExpansion.memberKind}`,
+      ];
+    }
+    if (traversal.includeIdentityMembers === true) {
+      return [
+        compileIdentitySourcePredicate({
+          ctx,
+          edgeId,
+          edgeKind,
+          graphId,
+          previousId: previousIdColumn,
+          previousKind: previousKindColumn,
+          temporalFilterPass,
+        }),
+      ];
+    }
+    const clauses = [sql`${edgeId} = ${previousIdColumn}`];
+    if (previousNodeKinds.length > 1) {
+      clauses.push(sql`${edgeKind} = ${previousKindColumn}`);
+    }
+    return clauses;
+  }
 
   function compileRecursiveBranch(
     branch: Readonly<{
@@ -487,29 +556,12 @@ function compileRecursiveCte(
     if (pathExtension !== undefined) {
       recursiveSelectColumns.push(sql`${pathExtension} AS path`);
     }
-    const recursiveJoinClauses: SqlFragment[] =
-      traversal.includeIdentityMembers === true ?
-        [
-          compileIdentitySourcePredicate({
-            ast,
-            ctx,
-            edgeId: sql`e.${sql.raw(branch.joinField)}`,
-            edgeKind: sql`e.${sql.raw(branch.joinKindField)}`,
-            graphId,
-            previousId: sql`r.${sql.raw(nodeAlias)}_id`,
-            previousKind: sql`r.${sql.raw(nodeAlias)}_kind`,
-            temporalFilterPass,
-          }),
-        ]
-      : [sql`e.${sql.raw(branch.joinField)} = r.${sql.raw(nodeAlias)}_id`];
-    if (
-      traversal.includeIdentityMembers !== true &&
-      previousNodeKinds.length > 1
-    ) {
-      recursiveJoinClauses.push(
-        sql`e.${sql.raw(branch.joinKindField)} = r.${sql.raw(nodeAlias)}_kind`,
-      );
-    }
+    const recursiveJoinClauses = compileWorktableJoinClauses(branch);
+
+    const frontierJoins = sql.join(
+      identityFrontierExpansion?.joins ?? [],
+      sql` `,
+    );
 
     if (forceWorktableOuterJoinOrder) {
       const recursiveWhereClauses = [
@@ -520,6 +572,7 @@ function compileRecursiveCte(
       return sql`
         SELECT ${sql.join(recursiveSelectColumns, sql`, `)}
         FROM recursive_cte r
+        ${frontierJoins}
         CROSS JOIN ${ctx.schema.edgesTable} e
         JOIN ${ctx.schema.nodesTable} n ON n.graph_id = e.graph_id
           AND n.id = e.${sql.raw(branch.targetField)}
@@ -531,6 +584,7 @@ function compileRecursiveCte(
     return sql`
       SELECT ${sql.join(recursiveSelectColumns, sql`, `)}
       FROM recursive_cte r
+      ${frontierJoins}
       JOIN ${ctx.schema.edgesTable} e ON ${sql.join(recursiveJoinClauses, sql` AND `)}
       JOIN ${ctx.schema.nodesTable} n ON n.graph_id = e.graph_id
         AND n.id = e.${sql.raw(branch.targetField)}

--- a/packages/typegraph/src/query/compiler/recursive.ts
+++ b/packages/typegraph/src/query/compiler/recursive.ts
@@ -557,11 +557,7 @@ function compileRecursiveCte(
       recursiveSelectColumns.push(sql`${pathExtension} AS path`);
     }
     const recursiveJoinClauses = compileWorktableJoinClauses(branch);
-
-    const frontierJoins = sql.join(
-      identityFrontierExpansion?.joins ?? [],
-      sql` `,
-    );
+    const frontierJoin = identityFrontierExpansion?.frontierJoin ?? sql``;
 
     if (forceWorktableOuterJoinOrder) {
       const recursiveWhereClauses = [
@@ -572,7 +568,7 @@ function compileRecursiveCte(
       return sql`
         SELECT ${sql.join(recursiveSelectColumns, sql`, `)}
         FROM recursive_cte r
-        ${frontierJoins}
+        ${frontierJoin}
         CROSS JOIN ${ctx.schema.edgesTable} e
         JOIN ${ctx.schema.nodesTable} n ON n.graph_id = e.graph_id
           AND n.id = e.${sql.raw(branch.targetField)}
@@ -584,7 +580,7 @@ function compileRecursiveCte(
     return sql`
       SELECT ${sql.join(recursiveSelectColumns, sql`, `)}
       FROM recursive_cte r
-      ${frontierJoins}
+      ${frontierJoin}
       JOIN ${ctx.schema.edgesTable} e ON ${sql.join(recursiveJoinClauses, sql` AND `)}
       JOIN ${ctx.schema.nodesTable} n ON n.graph_id = e.graph_id
         AND n.id = e.${sql.raw(branch.targetField)}

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -35,6 +35,7 @@ import {
   registerEdgeOperationIntegrationTests,
   registerEdgePropertyIntegrationTests,
   registerFulltextIntegrationTests,
+  registerHistoricalIdentityTraversalTests,
   registerIdentityImportIntegrationTests,
   registerIdentityIntegrationTests,
   registerIdentitySeparationIntegrationTests,
@@ -199,6 +200,7 @@ export function createIntegrationTestSuite<TNativeTransaction>(
     registerImportUniquenessIntegrationTests(context);
     registerIdentityIntegrationTests(context);
     registerIdentityImportIntegrationTests(context);
+    registerHistoricalIdentityTraversalTests(context);
     registerIdentitySeparationIntegrationTests(context);
     registerEdgeCaseIntegrationTests(context);
     registerCrossBackendConsistencyTests(context);

--- a/packages/typegraph/tests/backends/integration/identity-historical-traversal.ts
+++ b/packages/typegraph/tests/backends/integration/identity-historical-traversal.ts
@@ -23,6 +23,8 @@
  *   same-id fold together at an instant before its deletion;
  * - an assertion that is valid at some coordinates and retracted at later ones;
  * - two start rows that share one class, which must not duplicate a step;
+ * - a cyclic class, and two of its members carrying an edge to the same target,
+ *   the two shapes where a hop could multiply rows per identity path;
  * - a two-hop chain and a recursive traversal, where the frontier — and so the
  *   set of classes to reconstruct — changes per step.
  */
@@ -497,6 +499,15 @@ async function provisionHistoricalFixture(
   const ghostClaimPerson = await person("ghost-claim", {
     validTo: timeline.late,
   });
+  // A cyclic class whose members share one target. Two rules that each look
+  // right in isolation can still multiply rows here: the class walk reaches
+  // `cycle-c` both directly and the long way round, and two distinct members
+  // carry an edge to the *same* physical target. An expanded hop must yield one
+  // row per traversed edge — not one per identity path, and not one per member
+  // pairing.
+  const cycleA = await person("cycle-a");
+  const cycleB = await person("cycle-b");
+  const cycleC = await person("cycle-c");
   // Windowed nodes: ended by `late`, and not yet valid at `early`.
   const endedPerson = await person("ended", { validTo: timeline.late });
   const latePerson = await person("late", { validFrom: timeline.late });
@@ -526,6 +537,9 @@ async function provisionHistoricalFixture(
   await link(ghostClaimPerson, targetB, "ghost-claim-b");
   // A direct edge that needs no expansion at all, as a control.
   await link(sharedPerson, targetC, "shared-person-c");
+  // Two members of the cyclic class, one shared target.
+  await link(cycleB, targetA, "cycle-b-a");
+  await link(cycleC, targetA, "cycle-c-a");
 
   const coordinates: Readonly<{ asOf: string; label: string }>[] = [
     {
@@ -545,6 +559,9 @@ async function provisionHistoricalFixture(
   await store.identity.assertSame(chainPerson, bridgePerson);
   await store.identity.assertSame(twinPerson, ghostClaimPerson);
   await store.identity.assertSame(ghostPerson, ghostCompany);
+  await store.identity.assertSame(cycleA, cycleB);
+  await store.identity.assertSame(cycleB, cycleC);
+  await store.identity.assertSame(cycleC, cycleA);
   await settle();
   sample("assertions in force");
   await settle();
@@ -701,5 +718,51 @@ export function registerHistoricalIdentityTraversalTests(
         });
       });
     }
+
+    /**
+     * `includeEnded` and `includeTombstones` drop node validity but keep
+     * assertion validity, so the class relation still binds the "current" read
+     * instant — for the assertion window alone. That is the one historical mode
+     * where the reconstruction depends on the wall clock, and the compiled
+     * template cache's freshness guard does not cover it: the guard only fires
+     * for `mode: "current"` reads, so nothing but this test stands between the
+     * relation and the frozen-`now` regression of typegraph#246. Re-executing a
+     * reused query has to see an assertion made after the first execution.
+     */
+    it("binds a fresh read instant per execution under includeEnded", async () => {
+      const store = await context.createStore(IGNORE_GRAPH);
+      const alice = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "instant-alice" },
+      );
+      const peer = await store.nodes.Person.create(
+        { name: "Peer" },
+        { id: "instant-peer" },
+      );
+      const target = await store.nodes.Person.create(
+        { name: "Target" },
+        { id: "instant-target" },
+      );
+      // The edge leaves the peer, so only the expansion can reach the target.
+      await store.edges.link.create(peer, target, {}, { id: "instant-peer-t" });
+
+      const query = store
+        .view({ mode: "includeEnded" })
+        .query()
+        .from("Person", "person")
+        .whereNode("person", (node) => node.name.eq("Alice"))
+        .traverse("link", "edge", {
+          expand: "none",
+          includeIdentityMembers: true,
+        })
+        .to("Person", "friend")
+        .select((queryContext) => queryContext.friend.id);
+
+      expect(await query.execute()).toEqual([]);
+      await settle();
+      await store.identity.assertSame(alice, peer);
+      await settle();
+      expect(await query.execute()).toEqual([target.id]);
+    });
   });
 }

--- a/packages/typegraph/tests/backends/integration/identity-historical-traversal.ts
+++ b/packages/typegraph/tests/backends/integration/identity-historical-traversal.ts
@@ -1,0 +1,705 @@
+/**
+ * Equivalence coverage for identity-expanded traversal under a **historical**
+ * read coordinate.
+ *
+ * The compiler reaches identity membership two different ways: a current read
+ * seeks the materialized closure, a historical read reconstructs classes from
+ * the assertion ledger through a hoisted relation (typegraph#310). The second
+ * path has no closure table to check itself against, so this suite checks it
+ * against the identity semantics directly: it reads the raw node, edge and
+ * assertion rows back out of the backend and re-derives, in TypeScript, the rows
+ * an identity-expanded hop must return at a given instant. A divergence in the
+ * SQL — a lost class member, a duplicated row, a stale coordinate, a missed
+ * visibility rule — shows up as a mismatch against a model that shares no code
+ * with the compiler.
+ *
+ * The fixture deliberately spans the cases where the reconstruction rules stop
+ * agreeing with each other:
+ *
+ * - both identity profiles, `"fold"` and `"ignore"`;
+ * - a node whose validity window has ended at the coordinate, and one whose
+ *   window has not begun;
+ * - a soft-deleted node, which is never a visible *member* yet still holds a
+ *   same-id fold together at an instant before its deletion;
+ * - an assertion that is valid at some coordinates and retracted at later ones;
+ * - two start rows that share one class, which must not duplicate a step;
+ * - a two-hop chain and a recursive traversal, where the frontier — and so the
+ *   set of classes to reconstruct — changes per step.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  defineEdge,
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+} from "../../../src";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { sql } from "../../../src/query/sql-fragment";
+import { asCompiledRowsSql } from "../../../src/query/sql-intent";
+import { compareStrings } from "../../../src/utils/compare";
+import { type IntegrationTestContext } from "./test-context";
+
+const HistPerson = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const HistCompany = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+const histLink = defineEdge("link", { schema: z.object({}) });
+
+function historicalIdentityGraph(sameIdAcrossKinds: "fold" | "ignore") {
+  return defineGraph({
+    id: `identity_historical_${sameIdAcrossKinds}`,
+    nodes: { Company: { type: HistCompany }, Person: { type: HistPerson } },
+    edges: {
+      link: {
+        type: histLink,
+        from: [HistPerson, HistCompany],
+        to: [HistPerson, HistCompany],
+      },
+    },
+    identity: { sameIdAcrossKinds },
+  });
+}
+
+const FOLD_GRAPH = historicalIdentityGraph("fold");
+const IGNORE_GRAPH = historicalIdentityGraph("ignore");
+
+// ============================================================
+// Ledger snapshot
+// ============================================================
+
+type RawTimestamp = string | Date | null;
+
+type LedgerNode = Readonly<{
+  kind: string;
+  id: string;
+  valid_from: RawTimestamp;
+  valid_to: RawTimestamp;
+  created_at: RawTimestamp;
+  deleted_at: RawTimestamp;
+}>;
+
+type LedgerEdge = Readonly<{
+  id: string;
+  kind: string;
+  from_kind: string;
+  from_id: string;
+  to_kind: string;
+  to_id: string;
+  valid_from: RawTimestamp;
+  valid_to: RawTimestamp;
+  deleted_at: RawTimestamp;
+}>;
+
+type LedgerAssertion = Readonly<{
+  rel: string;
+  a_kind: string;
+  a_id: string;
+  b_kind: string;
+  b_id: string;
+  valid_from: RawTimestamp;
+  valid_to: RawTimestamp;
+  deleted_at: RawTimestamp;
+}>;
+
+type Ledger = Readonly<{
+  assertions: readonly LedgerAssertion[];
+  edges: readonly LedgerEdge[];
+  nodes: readonly LedgerNode[];
+}>;
+
+type NodeRef = Readonly<{ kind: string; id: string }>;
+
+/**
+ * Reads the stored rows the identity semantics are defined over. The model
+ * derives everything from these rather than from the timestamps the test
+ * happened to pass in, so it stays honest about what was actually persisted.
+ */
+async function readLedger(
+  store: Readonly<{ backend: GraphBackend; graphId: string }>,
+): Promise<Ledger> {
+  const schema = createSqlSchema(store.backend.tableNames);
+  const nodes = await store.backend.execute<LedgerNode>(
+    asCompiledRowsSql(sql`
+      SELECT kind, id, valid_from, valid_to, created_at, deleted_at
+      FROM ${schema.nodesTable}
+      WHERE graph_id = ${store.graphId}
+    `),
+  );
+  const edges = await store.backend.execute<LedgerEdge>(
+    asCompiledRowsSql(sql`
+      SELECT id, kind, from_kind, from_id, to_kind, to_id,
+             valid_from, valid_to, deleted_at
+      FROM ${schema.edgesTable}
+      WHERE graph_id = ${store.graphId}
+    `),
+  );
+  const assertions = await store.backend.execute<LedgerAssertion>(
+    asCompiledRowsSql(sql`
+      SELECT rel, a_kind, a_id, b_kind, b_id, valid_from, valid_to, deleted_at
+      FROM ${schema.identityAssertionsTable}
+      WHERE graph_id = ${store.graphId}
+    `),
+  );
+  return { assertions, edges, nodes };
+}
+
+// ============================================================
+// Identity semantics, re-derived
+// ============================================================
+
+/** Normalizes a stored instant to epoch milliseconds; `undefined` means unset. */
+function instantOf(value: RawTimestamp): number | undefined {
+  if (value === null) return undefined;
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+/** Separator for composite `(kind, id)` map keys; no id can contain it. */
+const REF_KEY_SEPARATOR = "\u0000";
+
+function refKey(ref: NodeRef): string {
+  return `${ref.kind}${REF_KEY_SEPARATOR}${ref.id}`;
+}
+
+/** The point-in-time visibility every read applies to a node or edge row. */
+function visibleAt(
+  row: Readonly<{
+    valid_from: RawTimestamp;
+    valid_to: RawTimestamp;
+    deleted_at: RawTimestamp;
+  }>,
+  instant: number,
+): boolean {
+  if (instantOf(row.deleted_at) !== undefined) return false;
+  const from = instantOf(row.valid_from);
+  const to = instantOf(row.valid_to);
+  if (from !== undefined && from > instant) return false;
+  if (to !== undefined && to <= instant) return false;
+  return true;
+}
+
+/**
+ * Lifecycle rule for an implicit same-id fold, which is deliberately *not* node
+ * visibility: a node soft-deleted after the coordinate still folded with its
+ * peer then, even though it is not itself a visible member.
+ */
+function existedAt(node: LedgerNode, instant: number): boolean {
+  const created = instantOf(node.created_at);
+  const deleted = instantOf(node.deleted_at);
+  if (created !== undefined && created > instant) return false;
+  return deleted === undefined || deleted > instant;
+}
+
+function assertionHoldsAt(
+  assertion: LedgerAssertion,
+  instant: number,
+): boolean {
+  if (assertion.rel !== "same") return false;
+  if (instantOf(assertion.deleted_at) !== undefined) return false;
+  const from = instantOf(assertion.valid_from);
+  const to = instantOf(assertion.valid_to);
+  if (from !== undefined && from > instant) return false;
+  return to === undefined || to > instant;
+}
+
+/** Undirected identity adjacency at `instant`: assertions plus same-id folds. */
+function identityAdjacencyAt(
+  ledger: Ledger,
+  instant: number,
+  fold: boolean,
+): ReadonlyMap<string, readonly NodeRef[]> {
+  const adjacency = new Map<string, NodeRef[]>();
+  const connect = (left: NodeRef, right: NodeRef): void => {
+    const peers = adjacency.get(refKey(left)) ?? [];
+    peers.push(right);
+    adjacency.set(refKey(left), peers);
+  };
+  for (const assertion of ledger.assertions) {
+    if (!assertionHoldsAt(assertion, instant)) continue;
+    const left = { kind: assertion.a_kind, id: assertion.a_id };
+    const right = { kind: assertion.b_kind, id: assertion.b_id };
+    connect(left, right);
+    connect(right, left);
+  }
+  if (fold) {
+    const present = ledger.nodes.filter((node) => existedAt(node, instant));
+    for (const left of present) {
+      for (const right of present) {
+        if (left.id !== right.id || left.kind === right.kind) continue;
+        connect(
+          { kind: left.kind, id: left.id },
+          { kind: right.kind, id: right.id },
+        );
+      }
+    }
+  }
+  return adjacency;
+}
+
+/**
+ * The visible identity class of `seed` at `instant`.
+ *
+ * The walk itself ignores member visibility — a class can be held together
+ * through a member that is not visible — and the result is filtered to visible
+ * members afterwards, which is how the reconstruction SQL is layered. A seed
+ * that is not visible has no class at all.
+ */
+function visibleClassAt(
+  ledger: Ledger,
+  seed: NodeRef,
+  instant: number,
+  fold: boolean,
+): readonly NodeRef[] {
+  const nodesByKey = new Map(
+    ledger.nodes.map((node) => [
+      refKey({ kind: node.kind, id: node.id }),
+      node,
+    ]),
+  );
+  const seedNode = nodesByKey.get(refKey(seed));
+  if (seedNode === undefined || !visibleAt(seedNode, instant)) return [];
+  const adjacency = identityAdjacencyAt(ledger, instant, fold);
+  const reached = new Map<string, NodeRef>([[refKey(seed), seed]]);
+  const pending: NodeRef[] = [seed];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined) break;
+    for (const peer of adjacency.get(refKey(current)) ?? []) {
+      if (reached.has(refKey(peer))) continue;
+      reached.set(refKey(peer), peer);
+      pending.push(peer);
+    }
+  }
+  return [...reached.values()].filter((member) => {
+    const node = nodesByKey.get(refKey(member));
+    return node !== undefined && visibleAt(node, instant);
+  });
+}
+
+function visibleNodesOfKind(
+  ledger: Ledger,
+  kind: string,
+  instant: number,
+): readonly LedgerNode[] {
+  return ledger.nodes.filter(
+    (node) => node.kind === kind && visibleAt(node, instant),
+  );
+}
+
+/**
+ * Outgoing `link` edges an identity-expanded hop can follow from `source`, with
+ * the target restricted to visible `Person` nodes — the shape every query below
+ * traverses.
+ */
+function expandedHopsFrom(
+  ledger: Ledger,
+  source: NodeRef,
+  instant: number,
+  fold: boolean,
+): readonly Readonly<{ edgeId: string; target: NodeRef }>[] {
+  const nodesByKey = new Map(
+    ledger.nodes.map((node) => [
+      refKey({ kind: node.kind, id: node.id }),
+      node,
+    ]),
+  );
+  const hops: Readonly<{ edgeId: string; target: NodeRef }>[] = [];
+  for (const member of visibleClassAt(ledger, source, instant, fold)) {
+    for (const edge of ledger.edges) {
+      if (edge.kind !== "link") continue;
+      if (edge.from_kind !== member.kind || edge.from_id !== member.id)
+        continue;
+      if (!visibleAt(edge, instant)) continue;
+      if (edge.to_kind !== "Person") continue;
+      const target = { kind: edge.to_kind, id: edge.to_id };
+      const targetNode = nodesByKey.get(refKey(target));
+      if (targetNode === undefined || !visibleAt(targetNode, instant)) continue;
+      hops.push({ edgeId: edge.id, target });
+    }
+  }
+  return hops;
+}
+
+/** Expected `(start, edge, target)` triples for a single expanded hop. */
+function expectedOneHopRows(
+  ledger: Ledger,
+  instant: number,
+  fold: boolean,
+): readonly string[] {
+  const rows: string[] = [];
+  for (const start of visibleNodesOfKind(ledger, "Person", instant)) {
+    const startRef = { kind: start.kind, id: start.id };
+    for (const hop of expandedHopsFrom(ledger, startRef, instant, fold)) {
+      rows.push(`${start.id}|${hop.edgeId}|${hop.target.id}`);
+    }
+  }
+  return rows.toSorted((left, right) => compareStrings(left, right));
+}
+
+/** Expected `(start, edge1, edge2, target)` rows for a two-hop chain. */
+function expectedTwoHopRows(
+  ledger: Ledger,
+  instant: number,
+  fold: boolean,
+): readonly string[] {
+  const rows: string[] = [];
+  for (const start of visibleNodesOfKind(ledger, "Person", instant)) {
+    const startRef = { kind: start.kind, id: start.id };
+    for (const first of expandedHopsFrom(ledger, startRef, instant, fold)) {
+      for (const second of expandedHopsFrom(
+        ledger,
+        first.target,
+        instant,
+        fold,
+      )) {
+        rows.push(
+          `${start.id}|${first.edgeId}|${second.edgeId}|${second.target.id}`,
+        );
+      }
+    }
+  }
+  return rows.toSorted((left, right) => compareStrings(left, right));
+}
+
+/**
+ * Expected `(start, target)` rows for a recursive expanded traversal of up to
+ * `maxHops` steps under the default `cyclePolicy: "prevent"` — a path may not
+ * revisit a node, and node identity under expansion is the composite
+ * `(kind, id)`, so two folded peers are distinct waypoints.
+ */
+function expectedRecursiveRows(
+  ledger: Ledger,
+  instant: number,
+  fold: boolean,
+  maxHops: number,
+): readonly string[] {
+  const rows: string[] = [];
+  const walk = (
+    start: NodeRef,
+    current: NodeRef,
+    visited: readonly string[],
+    depth: number,
+  ): void => {
+    if (depth >= maxHops) return;
+    for (const hop of expandedHopsFrom(ledger, current, instant, fold)) {
+      if (visited.includes(refKey(hop.target))) continue;
+      rows.push(`${start.id}|${hop.target.id}`);
+      walk(start, hop.target, [...visited, refKey(hop.target)], depth + 1);
+    }
+  };
+  for (const start of visibleNodesOfKind(ledger, "Person", instant)) {
+    const startRef = { kind: start.kind, id: start.id };
+    walk(startRef, startRef, [refKey(startRef)], 0);
+  }
+  return rows.toSorted((left, right) => compareStrings(left, right));
+}
+
+// ============================================================
+// Fixture
+// ============================================================
+
+/** Instants the fixture pins its node and edge validity windows to. */
+type Timeline = Readonly<{
+  /** Everything the fixture creates is valid from here. */
+  origin: string;
+  /** Inside the ended node's window; before the late node's window. */
+  early: string;
+  /** After the ended node's window; inside the late node's window. */
+  late: string;
+}>;
+
+/**
+ * Separates two wall-clock samples, so the assertion timeline's coordinates
+ * cannot collapse onto one millisecond.
+ */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 5);
+  });
+}
+
+function buildTimeline(): Timeline {
+  const anchor = Date.now();
+  return {
+    origin: new Date(anchor - 60_000).toISOString(),
+    early: new Date(anchor - 45_000).toISOString(),
+    late: new Date(anchor - 15_000).toISOString(),
+  };
+}
+
+/**
+ * Builds the fixture graph and returns the coordinates to check it at.
+ *
+ * Node and edge windows are pinned to synthetic past instants so `early`/`late`
+ * exercise ended and not-yet-valid rows deterministically. Assertions carry
+ * wall-clock validity — the identity service stamps them itself — so the
+ * assertion timeline is sampled as it happens.
+ */
+async function provisionHistoricalFixture(
+  context: IntegrationTestContext,
+  profile: "fold" | "ignore",
+) {
+  const store = await context.createStore(
+    profile === "fold" ? FOLD_GRAPH : IGNORE_GRAPH,
+  );
+  const timeline = buildTimeline();
+  const { origin } = timeline;
+
+  const person = async (
+    id: string,
+    extra?: Readonly<{ validFrom?: string; validTo?: string }>,
+  ) =>
+    store.nodes.Person.create(
+      { name: `Person ${id}` },
+      {
+        id,
+        validFrom: extra?.validFrom ?? origin,
+        ...(extra?.validTo === undefined ? {} : { validTo: extra.validTo }),
+      },
+    );
+  const company = async (id: string, extra?: Readonly<{ validTo?: string }>) =>
+    store.nodes.Company.create(
+      { name: `Company ${id}` },
+      {
+        id,
+        validFrom: origin,
+        ...(extra?.validTo === undefined ? {} : { validTo: extra.validTo }),
+      },
+    );
+
+  // A folded pair: same id under two kinds.
+  const sharedPerson = await person("shared");
+  const sharedCompany = await company("shared");
+  // A three-node class whose middle member is soft-deleted at the end of the
+  // fixture: `chain` is asserted same as Person `bridge`, which folds with
+  // Company `bridge`. Once Person `bridge` is deleted it is never a visible
+  // member again, yet at an instant before the deletion it still holds the fold
+  // together — so `chain` reaches Company `bridge`'s edge through a member the
+  // read cannot see.
+  const chainPerson = await person("chain");
+  const bridgePerson = await person("bridge");
+  const bridgeCompany = await company("bridge");
+  // Distinct ids joined by an assertion, so the class is ledger-derived only.
+  const claimPerson = await person("claim-person");
+  const claimCompany = await company("claim-company");
+  // A second Person in the same class as claimPerson: two start rows, one class.
+  const twinPerson = await person("twin-person");
+  // Class members that stop being *visible* while their outgoing edge stays
+  // valid, so only the member-visibility rule can exclude them: a folded peer
+  // whose window ends at `late`, and an asserted peer likewise. Their windows
+  // end rather than being deleted, which keeps the class connected — the walk
+  // still reaches them, and the visibility filter must drop them.
+  const ghostPerson = await person("ghost");
+  const ghostCompany = await company("ghost", { validTo: timeline.late });
+  const ghostClaimPerson = await person("ghost-claim", {
+    validTo: timeline.late,
+  });
+  // Windowed nodes: ended by `late`, and not yet valid at `early`.
+  const endedPerson = await person("ended", { validTo: timeline.late });
+  const latePerson = await person("late", { validFrom: timeline.late });
+  // Plain targets.
+  const targetA = await person("target-a");
+  const targetB = await person("target-b");
+  const targetC = await person("target-c");
+
+  const link = async (
+    from: Readonly<{ kind: "Company" | "Person"; id: string }>,
+    to: Readonly<{ kind: "Company" | "Person"; id: string }>,
+    id: string,
+  ) => store.edges.link.create(from, to, {}, { id, validFrom: origin });
+
+  // Reachable only by expanding the Person frontier onto its Company peer.
+  await link(sharedCompany, targetA, "shared-company-a");
+  await link(bridgeCompany, targetB, "bridge-company-b");
+  await link(claimCompany, targetC, "claim-company-c");
+  // A second hop out of a target, for the chained and recursive cases.
+  await link(targetA, targetB, "target-a-b");
+  await link(targetB, latePerson, "target-b-late");
+  // Windowed source and target.
+  await link(endedPerson, targetA, "ended-a");
+  // Edges out of the members that lose visibility at `late`. The edges stay
+  // valid, so a read past `late` must drop them for lack of a visible member.
+  await link(ghostCompany, targetC, "ghost-company-c");
+  await link(ghostClaimPerson, targetB, "ghost-claim-b");
+  // A direct edge that needs no expansion at all, as a control.
+  await link(sharedPerson, targetC, "shared-person-c");
+
+  const coordinates: Readonly<{ asOf: string; label: string }>[] = [
+    {
+      asOf: timeline.early,
+      label: "early (ended node live, late node unborn)",
+    },
+    { asOf: timeline.late, label: "late (ended node ended, late node live)" },
+  ];
+
+  const sample = (label: string) => {
+    coordinates.push({ asOf: new Date().toISOString(), label });
+  };
+  sample("before any assertion");
+  await settle();
+  await store.identity.assertSame(claimPerson, claimCompany);
+  await store.identity.assertSame(claimPerson, twinPerson);
+  await store.identity.assertSame(chainPerson, bridgePerson);
+  await store.identity.assertSame(twinPerson, ghostClaimPerson);
+  await store.identity.assertSame(ghostPerson, ghostCompany);
+  await settle();
+  sample("assertions in force");
+  await settle();
+  await store.identity.retractSameAssertion(claimPerson, claimCompany);
+  await settle();
+  sample("one assertion retracted");
+  await settle();
+  await store.nodes.Person.delete(bridgePerson.id);
+  await settle();
+  sample("class intermediary soft-deleted");
+
+  return { coordinates, store };
+}
+
+// ============================================================
+// Suite
+// ============================================================
+
+export function registerHistoricalIdentityTraversalTests(
+  context: IntegrationTestContext,
+): void {
+  describe("historical identity-expanded traversal equivalence", () => {
+    for (const profile of ["fold", "ignore"] as const) {
+      describe(`sameIdAcrossKinds: "${profile}"`, () => {
+        const fold = profile === "fold";
+
+        it("matches the identity semantics for a single hop at every coordinate", async () => {
+          const { coordinates, store } = await provisionHistoricalFixture(
+            context,
+            profile,
+          );
+          const ledger = await readLedger(store);
+
+          for (const coordinate of coordinates) {
+            const rows = await store
+              .asOf(coordinate.asOf)
+              .query()
+              .from("Person", "person")
+              .traverse("link", "edge", {
+                expand: "none",
+                includeIdentityMembers: true,
+              })
+              .to("Person", "friend")
+              .select((queryContext) => ({
+                edge: queryContext.edge.id,
+                friend: queryContext.friend.id,
+                start: queryContext.person.id,
+              }))
+              .execute();
+            const actual = rows
+              .map((row) => `${row.start}|${row.edge}|${row.friend}`)
+              .toSorted((left, right) => compareStrings(left, right));
+            const expected = expectedOneHopRows(
+              ledger,
+              new Date(coordinate.asOf).getTime(),
+              fold,
+            );
+
+            expect(
+              actual,
+              `single hop at ${coordinate.label} (${coordinate.asOf})`,
+            ).toEqual(expected);
+            expect(expected.length).toBeGreaterThan(0);
+          }
+        });
+
+        it("matches the identity semantics across a two-hop chain", async () => {
+          const { coordinates, store } = await provisionHistoricalFixture(
+            context,
+            profile,
+          );
+          const ledger = await readLedger(store);
+
+          for (const coordinate of coordinates) {
+            const rows = await store
+              .asOf(coordinate.asOf)
+              .query()
+              .from("Person", "person")
+              .traverse("link", "first", {
+                expand: "none",
+                includeIdentityMembers: true,
+              })
+              .to("Person", "middle")
+              .traverse("link", "second", {
+                expand: "none",
+                includeIdentityMembers: true,
+              })
+              .to("Person", "friend")
+              .select((queryContext) => ({
+                first: queryContext.first.id,
+                friend: queryContext.friend.id,
+                second: queryContext.second.id,
+                start: queryContext.person.id,
+              }))
+              .execute();
+            const actual = rows
+              .map(
+                (row) =>
+                  `${row.start}|${row.first}|${row.second}|${row.friend}`,
+              )
+              .toSorted((left, right) => compareStrings(left, right));
+            const expected = expectedTwoHopRows(
+              ledger,
+              new Date(coordinate.asOf).getTime(),
+              fold,
+            );
+
+            expect(
+              actual,
+              `two-hop chain at ${coordinate.label} (${coordinate.asOf})`,
+            ).toEqual(expected);
+          }
+        });
+
+        it("matches the identity semantics across a recursive traversal", async () => {
+          const { coordinates, store } = await provisionHistoricalFixture(
+            context,
+            profile,
+          );
+          const ledger = await readLedger(store);
+          const maxHops = 3;
+
+          for (const coordinate of coordinates) {
+            const rows = await store
+              .asOf(coordinate.asOf)
+              .query()
+              .from("Person", "person")
+              .traverse("link", "edge", {
+                expand: "none",
+                includeIdentityMembers: true,
+              })
+              .recursive({ maxHops })
+              .to("Person", "friend")
+              .select((queryContext) => ({
+                friend: queryContext.friend.id,
+                start: queryContext.person.id,
+              }))
+              .execute();
+            const actual = rows
+              .map((row) => `${row.start}|${row.friend}`)
+              .toSorted((left, right) => compareStrings(left, right));
+            const expected = expectedRecursiveRows(
+              ledger,
+              new Date(coordinate.asOf).getTime(),
+              fold,
+              maxHops,
+            );
+
+            expect(
+              actual,
+              `recursive traversal at ${coordinate.label} (${coordinate.asOf})`,
+            ).toEqual(expected);
+          }
+        });
+      });
+    }
+  });
+}

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -14,6 +14,7 @@ export type { IntegrationStore } from "./fixtures";
 export { integrationTestGraph } from "./fixtures";
 export { registerFulltextIntegrationTests } from "./fulltext";
 export { registerIdentityIntegrationTests } from "./identity";
+export { registerHistoricalIdentityTraversalTests } from "./identity-historical-traversal";
 export { registerIdentityImportIntegrationTests } from "./identity-import";
 export { registerIdentitySeparationIntegrationTests } from "./identity-separation";
 export { registerImportUniquenessIntegrationTests } from "./import-uniqueness";

--- a/packages/typegraph/tests/identity-historical-traversal-sql.test.ts
+++ b/packages/typegraph/tests/identity-historical-traversal-sql.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Structural guards on the SQL an identity-expanded traversal compiles to.
+ *
+ * The performance property #310 asks for is not "the reconstruction is fast" but
+ * "the reconstruction is emitted once, from a position a planner cannot
+ * re-evaluate per row". Timings drift with machine and data; the shape does not,
+ * so it is pinned here — and pinned for both dialects, because a single compiler
+ * path is what keeps the two backends equivalent.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineEdge, defineGraph, defineNode } from "../src";
+import { type QueryAst } from "../src/query/ast";
+import { createQueryBuilder } from "../src/query/builder";
+import { compileQuery, type CompileQueryOptions } from "../src/query/compiler";
+import { HISTORICAL_IDENTITY_CLASS_CTE_ALIAS } from "../src/query/compiler/identity-traversal";
+import { buildKindRegistry } from "../src/registry";
+import { toSqlString } from "./sql-test-utils";
+
+const SqlPerson = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const SqlCompany = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+const sqlLink = defineEdge("link", { schema: z.object({}) });
+
+const SqlGraph = defineGraph({
+  id: "identity_traversal_sql",
+  nodes: { Company: { type: SqlCompany }, Person: { type: SqlPerson } },
+  edges: {
+    link: { type: sqlLink, from: [SqlPerson, SqlCompany], to: [SqlPerson] },
+  },
+  identity: { sameIdAcrossKinds: "fold" },
+});
+
+const DIALECTS = ["sqlite", "postgres"] as const;
+const AS_OF = "2026-01-01T00:00:00.000Z";
+
+function builder() {
+  return createQueryBuilder<typeof SqlGraph>(
+    SqlGraph.id,
+    buildKindRegistry(SqlGraph),
+  );
+}
+
+type TraversalShape = "chained" | "recursive" | "single";
+
+function compileIdentityTraversalSql(
+  input: Readonly<{
+    asOf?: string;
+    dialect: (typeof DIALECTS)[number];
+    shape: TraversalShape;
+  }>,
+): string {
+  const identityOptions = {
+    expand: "none",
+    includeIdentityMembers: true,
+  } as const;
+  const base = builder().from("Person", "person");
+  const query =
+    input.shape === "single" ?
+      base
+        .traverse("link", "edge", identityOptions)
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.id)
+    : input.shape === "chained" ?
+      base
+        .traverse("link", "first", identityOptions)
+        .to("Person", "middle")
+        .traverse("link", "second", identityOptions)
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.id)
+    : base
+        .traverse("link", "edge", identityOptions)
+        .recursive({ maxHops: 3 })
+        .to("Person", "friend")
+        .select((ctx) => ctx.friend.id);
+  const options: CompileQueryOptions = {
+    dialect: input.dialect,
+    identitySameIdAcrossKinds: "fold",
+  };
+  return toSqlString(
+    compileQuery(atCoordinate(query.toAst(), input.asOf), SqlGraph.id, options),
+    input.dialect,
+  );
+}
+
+/** Repoints a compiled AST at a valid-time coordinate. */
+function atCoordinate(ast: QueryAst, asOf: string | undefined): QueryAst {
+  if (asOf === undefined) return ast;
+  return { ...ast, temporalMode: { mode: "asOf", asOf } };
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("historical identity traversal SQL shape", () => {
+  for (const dialect of DIALECTS) {
+    describe(`${dialect} dialect`, () => {
+      for (const shape of ["single", "chained", "recursive"] as const) {
+        it(`emits one materialized class relation for a ${shape} historical traversal`, () => {
+          const sqlText = compileIdentityTraversalSql({
+            asOf: AS_OF,
+            dialect,
+            shape,
+          });
+
+          // Exactly one reconstruction, declared as a materialized CTE.
+          expect(countOccurrences(sqlText, "WITH RECURSIVE")).toBe(
+            shape === "recursive" ? 2 : 1,
+          );
+          expect(sqlText).toContain(
+            `"${HISTORICAL_IDENTITY_CLASS_CTE_ALIAS}"(seed_kind, seed_id, kind, id) AS MATERIALIZED (`,
+          );
+          expect(
+            countOccurrences(sqlText, "seeds(seed_kind, seed_id) AS ("),
+          ).toBe(1);
+
+          // The step reads it through an outer join, not a correlated subquery:
+          // a reference inside EXISTS is what SQLite rebuilds per candidate row.
+          const references = countOccurrences(
+            sqlText,
+            `LEFT JOIN "${HISTORICAL_IDENTITY_CLASS_CTE_ALIAS}" "identity_peer"`,
+          );
+          expect(references).toBe(shape === "chained" ? 2 : 1);
+          expect(sqlText).not.toMatch(/EXISTS \([^)]*identity_peer_class/);
+        });
+      }
+
+      it("leaves a current-coordinate traversal on the closure path", () => {
+        const sqlText = compileIdentityTraversalSql({
+          dialect,
+          shape: "single",
+        });
+
+        expect(sqlText).not.toContain(HISTORICAL_IDENTITY_CLASS_CTE_ALIAS);
+        expect(sqlText).not.toContain("WITH RECURSIVE");
+        expect(sqlText).toContain("typegraph_identity_closure");
+      });
+
+      it("emits no class relation when a historical query does not expand identity", () => {
+        const sqlText = toSqlString(
+          compileQuery(
+            atCoordinate(
+              builder()
+                .from("Person", "person")
+                .traverse("link", "edge", { expand: "none" })
+                .to("Person", "friend")
+                .select((ctx) => ctx.friend.id)
+                .toAst(),
+              AS_OF,
+            ),
+            SqlGraph.id,
+            { dialect, identitySameIdAcrossKinds: "fold" },
+          ),
+          dialect,
+        );
+
+        expect(sqlText).not.toContain(HISTORICAL_IDENTITY_CLASS_CTE_ALIAS);
+      });
+    });
+  }
+});

--- a/packages/typegraph/tests/perf/identity-historical-traversal-scaling.test.ts
+++ b/packages/typegraph/tests/perf/identity-historical-traversal-scaling.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Scaling fixture for identity-expanded traversal under a historical
+ * coordinate (typegraph#310).
+ *
+ * The measurement is the acceptance criterion for #310, so the fixture lives in
+ * the repository rather than in a scratch script. It is opt-in — set
+ * `TYPEGRAPH_PERF=1` — because it provisions graphs up to a few thousand nodes
+ * and reports timings rather than asserting behavior.
+ *
+ * ```bash
+ * TYPEGRAPH_PERF=1 pnpm vitest run tests/perf/identity-historical-traversal-scaling.test.ts
+ * # PostgreSQL spot-check (two sizes):
+ * POSTGRES_URL=... TYPEGRAPH_PERF=1 pnpm vitest run tests/perf/identity-historical-traversal-scaling.test.ts
+ * ```
+ *
+ * Two edge shapes are measured separately so the historical-reconstruction cost
+ * this issue removes is not conflated with the correlated candidate-edge scan
+ * tracked in typegraph#270:
+ *
+ * - **narrow** — fan-out 1: exactly one candidate `link` edge per source row.
+ *   The per-source candidate-edge scan is trivial, so the wall time isolates the
+ *   identity-reconstruction term. This is the fixture whose quadratic scaling
+ *   #310 reports.
+ * - **broad** — fan-out {@link BROAD_FAN_OUT}: the correlated candidate-edge
+ *   scan of #270 dominates and is expected to remain after this fix.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+} from "../../src";
+import { generatePostgresMigrationSQL } from "../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../src/backend/postgres";
+import { createLocalSqliteBackend } from "../../src/backend/sqlite/local";
+import { provisionPostgresTestDatabase } from "../postgres-test-database";
+
+const PERF_ENABLED = process.env["TYPEGRAPH_PERF"] === "1";
+const NARROW_SIZES = [250, 500, 1000, 2000] as const;
+const BROAD_SIZES = [250, 500, 1000] as const;
+const POSTGRES_NARROW_SIZES = [250, 500] as const;
+const POSTGRES_BROAD_SIZES = [125, 250] as const;
+const BROAD_FAN_OUT = 8;
+
+const PerfPerson = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const PerfCompany = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+const perfLink = defineEdge("link", { schema: z.object({}) });
+
+const perfGraph = defineGraph({
+  id: "identity_historical_scaling",
+  nodes: { Company: { type: PerfCompany }, Person: { type: PerfPerson } },
+  edges: {
+    link: {
+      type: perfLink,
+      from: [PerfPerson, PerfCompany],
+      to: [PerfPerson, PerfCompany],
+    },
+  },
+  identity: { sameIdAcrossKinds: "fold" },
+});
+
+type EdgeShape = "broad" | "narrow";
+
+/**
+ * Builds the fixture: `size` Person nodes, all of which act as source rows, plus
+ * a Company peer per Person sharing its id so the `"fold"` structural same-id
+ * relation actually spans the graph (an all-distinct-id graph folds nothing and
+ * would measure an empty relation).
+ *
+ * Every `link` edge leaves the *Company* peer, so reaching any target at all
+ * requires the identity expansion — no row is reachable through the plain edge
+ * join. Fan-out is 1 for the narrow shape and {@link BROAD_FAN_OUT} for the
+ * broad shape.
+ *
+ * Planner statistics are refreshed explicitly so every size is measured against
+ * fresh statistics; otherwise the bulk-write auto-ANALYZE threshold kicks in
+ * partway up the scale and the plan changes between measurements.
+ */
+async function provisionFixture(
+  backend: GraphBackend,
+  size: number,
+  shape: EdgeShape,
+): Promise<{ asOf: string; store: Awaited<ReturnType<typeof openStore>> }> {
+  const store = await openStore(backend);
+  await store.nodes.Person.bulkCreate(
+    Array.from({ length: size }, (unused, index) => ({
+      id: `node-${index}`,
+      props: { name: `Person ${index}` },
+    })),
+  );
+  await store.nodes.Company.bulkCreate(
+    Array.from({ length: size }, (unused, index) => ({
+      id: `node-${index}`,
+      props: { name: `Company ${index}` },
+    })),
+  );
+  const fanOut = shape === "narrow" ? 1 : BROAD_FAN_OUT;
+  await store.edges.link.bulkCreate(
+    Array.from({ length: size * fanOut }, (unused, index) => {
+      const source = Math.floor(index / fanOut);
+      return {
+        from: { id: `node-${source}`, kind: "Company" as const },
+        id: `link-${index}`,
+        props: {},
+        to: { id: `node-${(index + 1) % size}`, kind: "Person" as const },
+      };
+    }),
+  );
+  await store.refreshStatistics();
+  return { asOf: new Date().toISOString(), store };
+}
+
+async function openStore(backend: GraphBackend) {
+  const [store] = await createStoreWithSchema(perfGraph, backend);
+  return store;
+}
+
+async function measure(
+  store: Awaited<ReturnType<typeof openStore>>,
+  asOf: string,
+): Promise<{ milliseconds: number; rows: number }> {
+  const started = performance.now();
+  const rows = await store
+    .asOf(asOf)
+    .query()
+    .from("Person", "person")
+    .traverse("link", "edge", {
+      expand: "none",
+      includeIdentityMembers: true,
+    })
+    .to("Person", "friend")
+    .select((queryContext) => queryContext.friend.id)
+    .execute();
+  return { milliseconds: performance.now() - started, rows: rows.length };
+}
+
+function reportRow(
+  label: string,
+  size: number,
+  result: Readonly<{ milliseconds: number; rows: number }>,
+): void {
+  console.log(
+    `${label} n=${String(size).padStart(5)} ` +
+      `time=${result.milliseconds.toFixed(0).padStart(6)}ms ` +
+      `rows=${result.rows}`,
+  );
+}
+
+describe.runIf(PERF_ENABLED)("historical identity traversal scaling", () => {
+  describe("sqlite", () => {
+    for (const shape of ["narrow", "broad"] satisfies EdgeShape[]) {
+      it(`${shape} edges`, async () => {
+        for (const size of shape === "narrow" ? NARROW_SIZES : BROAD_SIZES) {
+          const { backend } = createLocalSqliteBackend();
+          try {
+            const fixture = await provisionFixture(backend, size, shape);
+            reportRow(
+              `sqlite ${shape.padEnd(6)}`,
+              size,
+              await measure(fixture.store, fixture.asOf),
+            );
+          } finally {
+            await backend.close();
+          }
+        }
+      }, 600_000);
+    }
+  });
+
+  describe("postgres", () => {
+    const databaseUrl = process.env["POSTGRES_URL"];
+    let pool: Pool | undefined;
+
+    beforeAll(async () => {
+      if (databaseUrl === undefined) return;
+      const url = await provisionPostgresTestDatabase(import.meta.url);
+      const candidate = new Pool({
+        connectionString: url,
+        connectionTimeoutMillis: 5000,
+      });
+      await candidate.query("SELECT 1");
+      await candidate.query(generatePostgresMigrationSQL());
+      pool = candidate;
+    }, 120_000);
+
+    afterAll(async () => {
+      if (pool !== undefined) await pool.end();
+    });
+
+    for (const shape of ["narrow", "broad"] satisfies EdgeShape[]) {
+      it.runIf(databaseUrl !== undefined)(
+        `${shape} edges`,
+        async () => {
+          const activePool = pool;
+          if (activePool === undefined) return;
+          const sizes =
+            shape === "narrow" ? POSTGRES_NARROW_SIZES : POSTGRES_BROAD_SIZES;
+          for (const size of sizes) {
+            const backend = createPostgresBackend(drizzle(activePool));
+            const fixture = await provisionFixture(backend, size, shape);
+            reportRow(
+              `postgres ${shape.padEnd(6)}`,
+              size,
+              await measure(fixture.store, fixture.asOf),
+            );
+            await activePool.query(
+              "TRUNCATE typegraph_nodes, typegraph_edges, typegraph_identity_assertions, typegraph_identity_closure",
+            );
+          }
+        },
+        600_000,
+      );
+    }
+  });
+});


### PR DESCRIPTION
An identity-expanded traversal hop under a historical coordinate (`asOf`, `asOfRecorded`, or a non-current `view()`) has no materialized closure to read, so it reconstructs identity classes from the assertion ledger. That reconstruction used to be built inside the correlated edge predicate, seeded by the frontier row, and SQLite's plan showed exactly what that costs — `MATERIALIZE identity_peer_class` nested two `CORRELATED SCALAR SUBQUERY` levels deep, rebuilt for every candidate *(source row, edge)* pair. Under `sameIdAcrossKinds: "fold"` each rebuild also scanned the structural same-id relation across the whole graph, which is the quadratic term #310 measures.

## The fix

Seeding on the frontier is what forces the correlation, so the seed is dropped. `historicalIdentityPeerClassQuery` seeds the recursion from the endpoints of the identity-edge relation itself and filters members to those visible at the coordinate. Nothing in it depends on which nodes a caller is asking about, so it is emitted once per statement as a `MATERIALIZED` CTE of `(seed_kind, seed_id, kind, id)` rows named `identity_peer_class`. Because it covers only nodes that have a peer at all, its size tracks the identity ledger and the folded-id population rather than the whole graph.

Hoisting the *definition* alone is not enough, and this is the part worth flagging for review: a CTE referenced only from inside a correlated subquery is materialized at that reference site, once per invocation. Hoisting the definition while keeping the `EXISTS` reference measured 3.4× faster and still perfectly quadratic (44/163/681/2871 ms at *n* = 250/500/1000/2000). So the reference had to move too. `planHistoricalIdentityFrontierExpansion` widens the traversal step's `FROM` list with a `LEFT JOIN` onto the relation, and the candidate edge then joins on the class member's `(kind, id)` — the same ordinary indexed equality a traversal without identity expansion uses. The relation omits peerless nodes, so a `COALESCE` pair falls back to the frontier row itself; that row is always visible at the coordinate, because the relation it came from filtered on the same coordinate.

Both compilers take the same shape. The standard chain emits the CTE at the head of its `WITH` list — it depends on no other CTE — and each expanding step joins it. The variable-length compiler passes it as a preceding entry of the existing `WITH RECURSIVE` list, which is what lets the recursive term read a relation it could never have seeded from the worktable. One reconstruction serves every step of a query, because it depends only on the graph, the coordinate and the identity profile.

Current-coordinate traversal is deliberately untouched: it still tests membership against the materialized closure through its correlated predicate. The widening is left as the seam #270 extends — hand it a peer relation of the same `(seed_kind, seed_id, kind, id)` shape and the current coordinate reuses it verbatim, dropping its own correlated candidate-edge scan.

## Measurements

Fixture (`tests/perf/identity-historical-traversal-scaling.test.ts`, opt-in via `TYPEGRAPH_PERF=1`): *n* `Person` nodes, each folded with a same-id `Company` peer, `sameIdAcrossKinds: "fold"`, all *n* Person rows acting as source rows, a single `asOf` hop, planner statistics refreshed before each measurement. Every `link` edge leaves the Company peer, so nothing is reachable without the expansion. Before-numbers come from a clean worktree at `origin/main` running the identical fixture.

**Narrow edges (fan-out 1 — isolates the reconstruction term). SQLite:**

| *n* | before | after | speedup |
| --- | --- | --- | --- |
| 250 | 122 ms | 7 ms | 17× |
| 500 | 486 ms | 7 ms | 69× |
| 1000 | 1984 ms | 14 ms | 142× |
| 2000 | 8261 ms | 28 ms | 295× |

Before quadruples per doubling (4.0×, 4.1×, 4.2×); after roughly doubles (1.0×, 2.0×, 2.0×) — linear in graph size.

**Broad edges (fan-out 8 — where #270's correlated candidate-edge scan showed up). SQLite:**

| *n* | before | after | speedup |
| --- | --- | --- | --- |
| 250 | 941 ms | 5 ms | 188× |
| 500 | 3852 ms | 9 ms | 428× |
| 1000 | 15890 ms | 19 ms | 836× |

Reported separately as #310 asks, and the result is worth stating plainly rather than folding into the headline: because the step now joins the class relation instead of testing membership per candidate row, a *historical* hop no longer pays the correlated candidate-edge scan either. Broad-edge growth is linear too. #270's remaining subject is the current coordinate, which this PR does not touch.

**PostgreSQL spot-check** (two sizes each, confirming the win is not a SQLite planner accident):

| shape | *n* | before | after |
| --- | --- | --- | --- |
| narrow | 250 | 9636 ms | 7 ms |
| narrow | 500 | 76144 ms | 5 ms |
| broad (fan-out 8) | 125 | 9582 ms | 4 ms |
| broad (fan-out 8) | 250 | 75782 ms | 7 ms |

PostgreSQL was in worse shape than SQLite before this change — roughly 7.9× per doubling, not 4× — which is consistent with it re-planning the correlated reconstruction rather than caching an automatic index for it.

## Correctness

The historical membership path has no closure table to check itself against, so `tests/backends/integration/identity-historical-traversal.ts` (cross-backend suite) checks it against the identity semantics directly. It reads the raw node, edge and assertion rows back out of the backend and re-derives, in TypeScript, the rows an identity-expanded hop must return at an instant: point-in-time visibility, the same-id fold lifecycle (which is deliberately *not* node visibility), assertion windows, the class walk, and path multiplicity. The model shares no code with the compiler, and it passes unchanged on `main` — so it is an equivalence check against the semantics, not a restatement of whatever the SQL happens to do.

The fixture spans the cases where the reconstruction rules stop agreeing with one another: both identity profiles; a node whose validity window has ended at the coordinate and one whose window has not begun; a three-node class held together through a soft-deleted intermediary that is itself never a visible member; class members that lose visibility while their outgoing edge stays valid; an assertion valid at some coordinates and retracted at later ones; two start rows sharing one class; and a two-hop chain plus a recursive traversal, where the frontier — and so the set of classes involved — changes per step.

Three deliberate breaks confirm the suite bites: dropping the `COALESCE` self fallback, dropping member visibility from the class relation, and turning the outer join inner each fail it. The member-visibility break initially passed, which is why the losing-visibility members are in the fixture at all.

`tests/identity-historical-traversal-sql.test.ts` pins the structural property the performance work rests on, for both dialects: exactly one reconstruction per statement, declared `MATERIALIZED`, read through an outer join rather than from inside an `EXISTS`; a current-coordinate traversal still on the closure path; and no class relation emitted for a historical query that does not expand identity. Timings drift with machine and data, the shape does not.

## Caveat

The hoisted relation is built for the whole graph at that coordinate, so a historical expanded traversal from a handful of nodes still pays for one reconstruction over the identity ledger and the folded-id population. It is cheap in absolute terms and no longer grows with the number of source rows, but it is not proportional to how little was asked for. `apps/docs/src/content/docs/identity.md` says so alongside the new cost model.

Closes #310
