### PR TITLE
fix(graph-merge): scope the edge repoint/dedupe fold to repoint-induced collisions

### DIFF
--- a/.changeset/parallel-edge-fold-scope.md
+++ b/.changeset/parallel-edge-fold-scope.md
@@ -12,14 +12,20 @@ each group onto its lowest-sorting edge id, so a branch that created a parallel
 edge lost one of the two rows — and *which* one it lost depended on how the
 branch-created id happened to sort against the existing one.
 
-The fold is now restricted to what it was designed for: a group whose members did
-not all name the same endpoints before repointing, i.e. a collision the
-canonicalization itself induced (`x → a` and `x → b` both becoming `x → c*`). Those
-groups keep the existing min-id-survivor, property-reconciliation, and
-end-of-validity behavior. Staged edges that already shared their endpoints are no
-longer folded together: each distinct edge id commits as its own parallel row, and
-a valid-time end lands on the row whose author claimed it rather than migrating to
-an unrelated survivor.
+The fold is now restricted to what it was designed for. It groups staged edges by
+the endpoint pair they named **before** repointing, and collapses one row per pair —
+so a collision the canonicalization itself induced (`x → a` and `x → b` both becoming
+`x → c*`) still folds to a single edge, keeping the existing min-id-survivor,
+property-reconciliation, and end-of-validity behavior. Edges that already shared
+their endpoints are no longer folded together: each distinct edge id commits as its
+own parallel row, and a valid-time end lands on the row whose author claimed it
+rather than migrating to an unrelated survivor.
+
+A group that mixes the two folds only **across** the pairs. A repointed `x → b`
+joining two parallel `x → a` rows merges into one of them, and the other row still
+commits with the edit its author made — repointing said nothing about the rows that
+were already there. Previously the whole group collapsed, which dropped that edit
+silently: a folded-away row is never rewritten.
 
 What makes two staged edges "the same row" is their **edge id**, not equal
 properties. One inherited edge staged by several branches still folds into a single

--- a/.changeset/parallel-edge-fold-scope.md
+++ b/.changeset/parallel-edge-fold-scope.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+graph-merge: scope the edge repoint/dedupe fold to collisions repointing caused
+
+A TypeGraph store is a multigraph: nothing enforces uniqueness on
+`(from, kind, to)`, `create()` makes a parallel edge, and
+`getOrCreateByEndpoints()` is the opt-in set-semantics accessor. The merge's edge
+fold nevertheless grouped **every** staged edge by `(from, kind, to)` and collapsed
+each group onto its lowest-sorting edge id, so a branch that created a parallel
+edge lost one of the two rows — and *which* one it lost depended on how the
+branch-created id happened to sort against the existing one.
+
+The fold is now restricted to what it was designed for: a group whose members did
+not all name the same endpoints before repointing, i.e. a collision the
+canonicalization itself induced (`x → a` and `x → b` both becoming `x → c*`). Those
+groups keep the existing min-id-survivor, property-reconciliation, and
+end-of-validity behavior. Staged edges that already shared their endpoints are no
+longer folded together: each distinct edge id commits as its own parallel row, and
+a valid-time end lands on the row whose author claimed it rather than migrating to
+an unrelated survivor.
+
+What makes two staged edges "the same row" is their **edge id**, not equal
+properties. One inherited edge staged by several branches still folds into a single
+write with its property disagreements reconciled; a branch-created edge is a new
+parallel row even when its properties coincide with an existing one's.
+
+Merges that previously collapsed parallel edges will now commit both, and the
+spurious `PropertyConflict` those collapses reported between two rows that were
+never the same row is gone.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -336,11 +336,14 @@ When nodes collapse, their edges must too. After clustering, Graph Merge:
 4. **Reconciles** edges that collapse that way but disagree on properties, via
    the same conflict policy as nodes.
 
-Steps 3 and 4 are scoped to collisions **repointing caused**. A TypeGraph store is
-a multigraph — nothing enforces uniqueness on `(from, kind, to)`, `create()` makes
-a parallel edge, and `getOrCreateByEndpoints()` is the opt-in set-semantics
-accessor — so a branch that created a parallel edge merges as a parallel edge, and
-a window claim lands on the row its author touched. What makes two staged edges
+Steps 3 and 4 are scoped to collisions **repointing caused**: edges are grouped by
+the endpoint pair they named *before* repointing, and one row per pair collapses. A
+TypeGraph store is a multigraph — nothing enforces uniqueness on `(from, kind, to)`,
+`create()` makes a parallel edge, and `getOrCreateByEndpoints()` is the opt-in
+set-semantics accessor — so a branch that created a parallel edge merges as a
+parallel edge, and a window claim lands on the row its author touched. A repointed
+edge landing on endpoints that already have several parallel rows merges into one of
+them; the rest keep their own properties and windows. What makes two staged edges
 "the same row" is their **edge id**, not equal properties: one inherited edge
 staged by several branches folds into a single write, while a branch-created edge
 is a new row even when its properties happen to match an existing one's.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -330,10 +330,20 @@ When nodes collapse, their edges must too. After clustering, Graph Merge:
 
 1. **Repoints** every edge endpoint onto its cluster's canonical survivor.
 2. **Drops** any edge whose endpoint was finally deleted (recorded in `dropped`).
-3. **Dedupes** edges as a pure set keyed by `(from, type, to, props)`, so two
-   branches' "same" edge collapses to one.
-4. **Reconciles** edges that collapse to the same `(from, type, to)` but
-   disagree on properties, via the same conflict policy as nodes.
+3. **Dedupes** edges that repointing brought together, as a pure set keyed by
+   `(from, type, to, props)` — so `x → a` and `x → b` both landing on `x → c*`
+   collapse to one edge.
+4. **Reconciles** edges that collapse that way but disagree on properties, via
+   the same conflict policy as nodes.
+
+Steps 3 and 4 are scoped to collisions **repointing caused**. A TypeGraph store is
+a multigraph — nothing enforces uniqueness on `(from, kind, to)`, `create()` makes
+a parallel edge, and `getOrCreateByEndpoints()` is the opt-in set-semantics
+accessor — so a branch that created a parallel edge merges as a parallel edge, and
+a window claim lands on the row its author touched. What makes two staged edges
+"the same row" is their **edge id**, not equal properties: one inherited edge
+staged by several branches folds into a single write, while a branch-created edge
+is a new row even when its properties happen to match an existing one's.
 
 Inherited edges that a branch **deleted** are removed from the target, and
 inherited edges **modified** by multiple branches go through the same base-aware

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -23,23 +23,27 @@ import { requireDefined } from "../utils/presence";
  *      whose `entityId` is the surviving edge's id.
  *
  * SCOPE OF THE FOLD (issue #393). Steps 3 and 4 apply ONLY to a collision the
- * repointing INDUCED — a group whose members did not all start from the same
- * `(from, to)` endpoint pair, so two originally-distinct relationships became one
- * identity. The store is a MULTIGRAPH: nothing enforces uniqueness on
+ * repointing INDUCED. The store is a MULTIGRAPH: nothing enforces uniqueness on
  * `(from, type, to)`, `create()` makes a parallel edge, and
- * `getOrCreateByEndpoints()` is the opt-in set-semantics accessor. Folding an
- * ALREADY-colliding pair would therefore destroy authored multigraph intent and
- * break branch-effect commutativity — a merge must produce what the operation
- * would have produced applied directly to the target, and `create(x, y, props)`
- * on the target yields a parallel edge.
+ * `getOrCreateByEndpoints()` is the opt-in set-semantics accessor. Folding edges
+ * that ALREADY named the same endpoints would therefore destroy authored
+ * multigraph intent and break branch-effect commutativity — a merge must produce
+ * what the operation would have produced applied directly to the target, and
+ * `create(x, y, props)` on the target yields a parallel edge.
  *
- * So when every member of a group named the same endpoints before repointing, the
- * group is partitioned by EDGE ID and each id commits as its own row. Keying on
- * ID rather than props is the deciding line: re-staging one INHERITED row from
- * several branches is the same row (it folds, so concurrent property edits still
- * reconcile into one write), while a branch-CREATED row carries a fresh id and is
- * a new parallel edge even when its props happen to coincide with an inherited
- * one's. Consequently a window claim lands on the row its author touched.
+ * So the fold groups by PRE-REPOINT endpoint pair ({@link foldSets}): one row per
+ * pair collapses into a single set — that is the `x → a` / `x → b` case above —
+ * and every further row a pair authored commits as its own parallel row. A group
+ * that MIXES the two folds only across the pairs: a repointed `x → b` joining two
+ * parallel `x → a` rows collapses into the lower-id one of them and the other
+ * still commits, because repointing said nothing about the rows already there.
+ *
+ * What makes two staged edges one ROW is their EDGE ID, not equal props:
+ * re-staging one INHERITED row from several branches is the same row (it folds, so
+ * concurrent property edits still reconcile into one write), while a
+ * branch-CREATED row carries a fresh id and is a new parallel edge even when its
+ * props happen to coincide with an inherited one's. Consequently a window claim
+ * lands on the row its author touched.
  *
  * Determinism: the dedupe is a pure function of the (unordered) staged-edge SET.
  * Group membership derives only from the staged endpoints and {@link canonicalOf} —
@@ -133,7 +137,7 @@ export type StagedEdge = Readonly<{
 
 /**
  * A surviving merged edge after repoint + dedupe. `id` is the canonical survivor
- * of its collision group (the lexicographically-minimal contributing edge id);
+ * of its fold set (the lexicographically-minimal contributing edge id);
  * `mergedIds` is every staged edge id that collapsed into it (always includes
  * `id`), so the commit phase (T11) knows which inherited edges to fold away.
  */
@@ -230,12 +234,13 @@ function groupKey(fromKey: MergeKey, type: string, toKey: MergeKey): string {
 }
 
 /**
- * The PRE-repoint endpoint identity pair of a staged edge. Comparing these across a
- * collision group is what distinguishes a repoint-INDUCED collapse (members started
- * from different pairs) from ordinary multigraph multiplicity (they did not) — see
- * the module header. Direction-sensitive, so the reversed intra-cluster pair
- * `a → b` / `b → a` reads as two source pairs and still folds once `{a, b}` collapse.
- * JSON-encoded (see {@link dedupeKey}) so a separator-bearing id cannot fuse pairs.
+ * The PRE-repoint endpoint identity pair of a staged edge — the relationship the
+ * author named. {@link foldSets} partitions a collision group by it: distinct pairs
+ * are distinct relationships that repointing collapsed (so they fold), one pair is
+ * ordinary multigraph multiplicity (so it does not). Direction-sensitive, so the
+ * reversed intra-cluster pair `a → b` / `b → a` reads as two source pairs and still
+ * folds once `{a, b}` collapse. JSON-encoded (see {@link dedupeKey}) so a
+ * separator-bearing id cannot fuse pairs.
  */
 function sourcePairKey(fromKey: MergeKey, toKey: MergeKey): string {
   return JSON.stringify([fromKey, toKey]);
@@ -258,44 +263,105 @@ type RepointedEdge = Readonly<{
 }>;
 
 /**
+ * Groups a collision group's members into ROWS: one row per edge id, holding every
+ * staged copy of it. Two branches that both staged one inherited edge contribute two
+ * members of the SAME row — the id is what makes them the same row.
+ */
+function rowsById(
+  groupEdges: readonly RepointedEdge[],
+): ReadonlyMap<EdgeId, readonly RepointedEdge[]> {
+  const rows = new Map<EdgeId, RepointedEdge[]>();
+  for (const edge of groupEdges) {
+    const row = rows.get(edge.staged.id);
+    if (row === undefined) {
+      rows.set(edge.staged.id, [edge]);
+    } else {
+      row.push(edge);
+    }
+  }
+  return rows;
+}
+
+/**
+ * The pre-repoint relationship of each ROW: the minimal {@link sourcePairKey} its
+ * members named. A row normally names exactly one pair; the minimum keeps the choice
+ * total (and order-independent) for the chosen-id case where two branches staged the
+ * same edge id from different endpoints, which is still ONE row and so must land in
+ * exactly one fold set.
+ */
+function sourcePairByRow(
+  rows: ReadonlyMap<EdgeId, readonly RepointedEdge[]>,
+): ReadonlyMap<EdgeId, string> {
+  const pairs = new Map<EdgeId, string>();
+  for (const [id, members] of rows) {
+    const sorted = members
+      .map((member) => member.sourcePair)
+      .sort((left, right) => compareStrings(left, right));
+    pairs.set(id, requireDefined(sorted[0]));
+  }
+  return pairs;
+}
+
+/**
  * Partitions one `(from', type, to')` collision group into the member sets that each
  * commit as a SINGLE row.
  *
- * The whole group is one set when repointing induced the collision — its members do
- * not all share a pre-repoint endpoint pair, so originally-distinct relationships
- * became one identity and the §6.3 set-collapse applies. (A group that gains a
- * repointed member folds in FULL, including any member that was already there: once
- * repointing defines the group's identity, that identity is the collapsed one.)
+ * Two staged edges are the same ROW when they share an edge id; two rows are the same
+ * pre-repoint RELATIONSHIP when they named the same `(from, to)` pair before
+ * repointing. Repointing can collapse distinct relationships onto one identity, and
+ * that is the collision the §6.3 set-collapse exists for — so ONE row per pre-repoint
+ * pair (its minimum-id row, mirroring the min-id survivor rule) folds into a single
+ * set. Every FURTHER row a pair authored is ordinary multigraph multiplicity and
+ * commits as its own parallel row: nothing enforces uniqueness on `(from, type, to)`,
+ * so a merge that collapsed them would destroy multiplicity the branch author's
+ * operation would have produced applied straight to the target.
  *
- * Otherwise the members already named the same endpoints, so the collision is
- * multigraph multiplicity and the partition is by EDGE ID. Ids are returned in
- * lexicographic order for a stable emission order; neither the partition itself nor
- * the survivor within a set depends on input order.
+ * The two ends of that rule are the cases the module exists to get right:
+ *   - `x → a` and `x → b` both landing on `x → c*` are two pairs of one row each, so
+ *     they fold to one edge as before;
+ *   - two parallel `x → y` edges are one pair of two rows, so neither is folded away.
+ *
+ * A group that mixes them folds only ACROSS the pairs: a repointed `x → b` joining two
+ * parallel `x → a` rows collapses into the lower-id one of them and the other still
+ * commits, because repointing said nothing about the rows that were already there.
+ *
+ * Determinism: the partition derives only from the staged ids and their pre-repoint
+ * pairs — never from input order — and the sets are emitted in id order.
  */
 function foldSets(
   groupEdges: readonly RepointedEdge[],
 ): readonly (readonly RepointedEdge[])[] {
-  const sourcePairs = new Set(groupEdges.map((edge) => edge.sourcePair));
-  if (sourcePairs.size > 1) {
-    return [groupEdges];
-  }
-
-  const byId = new Map<EdgeId, RepointedEdge[]>();
-  for (const edge of groupEdges) {
-    const bucket = byId.get(edge.staged.id);
-    if (bucket === undefined) {
-      byId.set(edge.staged.id, [edge]);
-    } else {
-      bucket.push(edge);
+  const rows = rowsById(groupEdges);
+  const sourcePairs = sourcePairByRow(rows);
+  const representatives = new Map<string, EdgeId>();
+  for (const [id, pair] of sourcePairs) {
+    const representative = representatives.get(pair);
+    if (
+      representative === undefined ||
+      compareStrings(id, representative) < 0
+    ) {
+      representatives.set(pair, id);
     }
   }
-  return [...byId.keys()]
-    .sort((left, right) => compareStrings(left, right))
-    .map((id) => requireDefined(byId.get(id)));
+
+  const collapsed: RepointedEdge[] = [];
+  const parallel: (readonly RepointedEdge[])[] = [];
+  for (const id of [...rows.keys()].sort((left, right) =>
+    compareStrings(left, right),
+  )) {
+    const members = requireDefined(rows.get(id));
+    const pair = requireDefined(sourcePairs.get(id));
+    if (representatives.get(pair) === id) {
+      collapsed.push(...members);
+    } else {
+      parallel.push(members);
+    }
+  }
+  return [collapsed, ...parallel];
 }
 
 /**
- * Picks the canonical survivor edge of a collision group: the member with the
+ * Picks the canonical survivor edge of a fold set: the member with the
  * lexicographically-minimal edge id. Mirrors the node min-id canonical rule (T8)
  * so the surviving id is independent of input edge order. (`generateId()` is
  * nanoid — random, not time-prefixed — so min-id never leaks creation order.)
@@ -319,7 +385,7 @@ function pickSurvivor(
 }
 
 /**
- * Unions the props of one collision group's edges, resolving any per-property
+ * Unions the props of one fold set's edges, resolving any per-property
  * disagreement via the shared T8 conflict policy. Returns the surviving prop bag
  * plus an edge-level {@link PropertyConflict} for every property that genuinely
  * differed (its `entityId` is the surviving edge id).
@@ -504,14 +570,14 @@ function foldEdgeSet(
  * repointing brought together as a pure set operation keyed by
  * `(from' | type | to' | propsKey)`.
  *
- * Within a REPOINT-INDUCED collision group sharing `(from', type, to')` — one whose
- * members did not all name the same endpoints before repointing:
+ * Within each folded set — one row per PRE-REPOINT endpoint pair of a group sharing
+ * `(from', type, to')`:
  *   - identical props collapse silently to one edge,
  *   - DIFFERING props are reconciled by `policy` on the captured `branchRank`,
  *     recording one edge-level {@link PropertyConflict} per disagreeing property.
  *
- * Edges that already shared their endpoints are NOT folded together: the store is a
- * multigraph, so each distinct edge id commits as its own parallel row (see the
+ * The parallel rows a pair authored beyond that one are NOT folded together: the store
+ * is a multigraph, so each of them commits as its own row (see {@link foldSets} and the
  * module header for the full rule and why identity, not props equality, decides it).
  *
  * The surviving edge of every folded set is the lexicographically-minimal
@@ -581,8 +647,8 @@ export function repointEdges<G extends GraphDef = GraphDef>(
   }
 
   // Phase 2: partition every `(from', type, to')` group into the sets that commit as
-  // one row ({@link foldSets} — a repoint-induced collapse folds whole, ordinary
-  // multigraph multiplicity splits per edge id) and fold each set onto its survivor.
+  // one row ({@link foldSets} — one row per pre-repoint endpoint pair collapses,
+  // further parallel rows commit on their own) and fold each set onto its survivor.
   // A set whose members share one dedupe key is an exact-equal collapse (no conflict
   // is possible); several dedupe keys means props differ, so the union runs the
   // conflict policy.

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -11,23 +11,45 @@ import { requireDefined } from "../utils/presence";
  *   2. DROPPED — any edge whose (repointed) `from` or `to` is a finally-deleted
  *      node (per T8a, NOT resurrected) is removed, recorded as a
  *      {@link DroppedItem} with reason {@link ENDPOINT_DELETED_DROP_REASON}.
- *   3. DEDUPED — repointing can make two distinct edges identical. Edges are
- *      collapsed as a pure SET operation keyed by
+ *   3. DEDUPED — repointing can make two distinct edges identical. Edges brought
+ *      together THAT WAY are collapsed as a pure SET operation keyed by
  *      `(fromCanonical | type | toCanonical | propsKey)`, where `propsKey` is the
  *      T2 canonical serializer over PARSED props. So `x → a` and `x → b` (both
  *      repointed to `x → c*`) with equal props yield a SINGLE `x → c*`.
- *   4. RECONCILED — when two edges collapse to the same `(from, type, to)` but
- *      carry DIFFERING props, the per-property disagreement is resolved by the
+ *   4. RECONCILED — when two such edges collapse to the same `(from, type, to)`
+ *      but carry DIFFERING props, the per-property disagreement is resolved by the
  *      shared T8 conflict policy ({@link resolvePropertyUnion}) on the captured,
  *      non-wall-clock branch order, recording an edge-level {@link PropertyConflict}
  *      whose `entityId` is the surviving edge's id.
  *
+ * SCOPE OF THE FOLD (issue #393). Steps 3 and 4 apply ONLY to a collision the
+ * repointing INDUCED — a group whose members did not all start from the same
+ * `(from, to)` endpoint pair, so two originally-distinct relationships became one
+ * identity. The store is a MULTIGRAPH: nothing enforces uniqueness on
+ * `(from, type, to)`, `create()` makes a parallel edge, and
+ * `getOrCreateByEndpoints()` is the opt-in set-semantics accessor. Folding an
+ * ALREADY-colliding pair would therefore destroy authored multigraph intent and
+ * break branch-effect commutativity — a merge must produce what the operation
+ * would have produced applied directly to the target, and `create(x, y, props)`
+ * on the target yields a parallel edge.
+ *
+ * So when every member of a group named the same endpoints before repointing, the
+ * group is partitioned by EDGE ID and each id commits as its own row. Keying on
+ * ID rather than props is the deciding line: re-staging one INHERITED row from
+ * several branches is the same row (it folds, so concurrent property edits still
+ * reconcile into one write), while a branch-CREATED row carries a fresh id and is
+ * a new parallel edge even when its props happen to coincide with an inherited
+ * one's. Consequently a window claim lands on the row its author touched.
+ *
  * Determinism: the dedupe is a pure function of the (unordered) staged-edge SET.
- * Within a collision group the surviving edge id is the lexicographically-minimal
- * member id, property resolution uses only the captured `branchRank`, and the
- * output is sorted by dedupe key — so shuffling the input edges yields an
- * identical result. Clusters are computed once upstream (T8) and passed in as
- * {@link canonicalOf}; this module never re-clusters.
+ * Group membership derives only from the staged endpoints and {@link canonicalOf} —
+ * never from id sort order. Within a folded group the surviving edge id is the
+ * lexicographically-minimal member id, property resolution uses only the captured
+ * `branchRank`, and the output is sorted by dedupe key with the edge id as the
+ * final tiebreaker (parallel edges can share every other component) — so
+ * shuffling the input edges yields an identical result. Clusters are computed once
+ * upstream (T8) and passed in as {@link canonicalOf}; this module never
+ * re-clusters.
  */
 import { canonicalizeProps } from "./canonical-props";
 import type { ClusterResult } from "./clustering";
@@ -208,16 +230,69 @@ function groupKey(fromKey: MergeKey, type: string, toKey: MergeKey): string {
 }
 
 /**
+ * The PRE-repoint endpoint identity pair of a staged edge. Comparing these across a
+ * collision group is what distinguishes a repoint-INDUCED collapse (members started
+ * from different pairs) from ordinary multigraph multiplicity (they did not) — see
+ * the module header. Direction-sensitive, so the reversed intra-cluster pair
+ * `a → b` / `b → a` reads as two source pairs and still folds once `{a, b}` collapse.
+ * JSON-encoded (see {@link dedupeKey}) so a separator-bearing id cannot fuse pairs.
+ */
+function sourcePairKey(fromKey: MergeKey, toKey: MergeKey): string {
+  return JSON.stringify([fromKey, toKey]);
+}
+
+/**
  * A repointed staged edge plus both endpoints already mapped to their canonical
  * IDENTITY key (`(kind, id)`). The composite keys carry the canonical node's kind, so
  * the surviving edge's bare `fromId`/`toId` and `fromKind`/`toKind` are read off
  * `idOf`/`kindOf` of these keys — never the (possibly different-kind) staged endpoint.
+ * `sourcePair` and `dedupeKey` are computed during the single repoint pass so the
+ * fold partition and the props-identity check never recanonicalize props.
  */
 type RepointedEdge = Readonly<{
   staged: StagedEdge;
   fromKey: MergeKey;
   toKey: MergeKey;
+  sourcePair: string;
+  dedupeKey: string;
 }>;
+
+/**
+ * Partitions one `(from', type, to')` collision group into the member sets that each
+ * commit as a SINGLE row.
+ *
+ * The whole group is one set when repointing induced the collision — its members do
+ * not all share a pre-repoint endpoint pair, so originally-distinct relationships
+ * became one identity and the §6.3 set-collapse applies. (A group that gains a
+ * repointed member folds in FULL, including any member that was already there: once
+ * repointing defines the group's identity, that identity is the collapsed one.)
+ *
+ * Otherwise the members already named the same endpoints, so the collision is
+ * multigraph multiplicity and the partition is by EDGE ID. Ids are returned in
+ * lexicographic order for a stable emission order; neither the partition itself nor
+ * the survivor within a set depends on input order.
+ */
+function foldSets(
+  groupEdges: readonly RepointedEdge[],
+): readonly (readonly RepointedEdge[])[] {
+  const sourcePairs = new Set(groupEdges.map((edge) => edge.sourcePair));
+  if (sourcePairs.size > 1) {
+    return [groupEdges];
+  }
+
+  const byId = new Map<EdgeId, RepointedEdge[]>();
+  for (const edge of groupEdges) {
+    const bucket = byId.get(edge.staged.id);
+    if (bucket === undefined) {
+      byId.set(edge.staged.id, [edge]);
+    } else {
+      bucket.push(edge);
+    }
+  }
+  return [...byId.keys()]
+    .sort((left, right) => compareStrings(left, right))
+    .map((id) => requireDefined(byId.get(id)));
+}
 
 /**
  * Picks the canonical survivor edge of a collision group: the member with the
@@ -316,18 +391,133 @@ function unionEdgeProps(
 }
 
 /**
- * Repoints every staged edge onto its cluster canonical, drops edges whose
- * (repointed) endpoints are finally deleted, and dedupes the survivors as a pure
- * set operation keyed by `(from' | type | to' | propsKey)`.
+ * Folds one set of staged edges (a {@link foldSets} partition) onto the single row the
+ * commit will write, resolving props and the valid-time window across its members.
  *
- * Within a collision group sharing `(from', type, to')`:
+ * @param foldSet Non-empty. Every member shares the same repointed `(from, type, to)`.
+ */
+function foldEdgeSet(
+  foldSet: readonly RepointedEdge[],
+  context: ResolutionContext<GraphDef>,
+  branchRank: ReadonlyMap<BranchId, number>,
+  preferredBranchId?: BranchId,
+): Readonly<{ edge: MergedEdge; conflicts: readonly PropertyConflict[] }> {
+  const survivor = pickSurvivor(foldSet, preferredBranchId);
+  const survivorId = survivor.staged.id;
+  const mergedIds = foldSet
+    .map((edge) => edge.staged.id)
+    .sort((left, right) => compareStrings(left, right));
+
+  // Endpoint ids AND kinds come from the canonical IDENTITY keys, so a repointed
+  // edge always names the canonical node's own kind (the commit then applies any
+  // retype cascade), never a staged endpoint that merely shared the id string.
+  const fromId = idOf(survivor.fromKey);
+  const fromKind = kindOf(survivor.fromKey);
+  const toId = idOf(survivor.toKey);
+  const toKind = kindOf(survivor.toKey);
+  // The survivor's lower bound rides along unchanged — a `validFrom` is the
+  // branch's authored start for the row we commit, and the set's members are
+  // the same edge as seen by different branches.
+  //
+  // The END is folded across the set. When repoint/dedupe collapses several
+  // DISTINCT edges into one survivor, an end claimed by a non-survivor would
+  // otherwise be discarded by the arbitrary min-id pick — a silent window
+  // loss — so the earliest claimed end wins, the same least-claim rule the
+  // inherited-window reconciler uses.
+  //
+  // A survivor from the PREFERRED branch keeps its own end verbatim when it
+  // HAS one: that member is the live incremental target's row, and a user
+  // branch never re-windows what the target already holds. When it has none
+  // there is no target window to protect, so the fold still resolves across
+  // the set — otherwise a preferred survivor would silently swallow the
+  // only end any branch claimed.
+  const preferredSurvivorEnd =
+    survivor.staged.branchId === preferredBranchId ?
+      survivor.staged.validTo
+    : undefined;
+  const foldedEnd =
+    preferredSurvivorEnd ??
+    resolveEndClaims(
+      foldSet
+        .filter((edge) => edge.staged.validTo !== undefined)
+        .map((edge) => ({
+          branchId: edge.staged.branchId,
+          validTo: requireDefined(edge.staged.validTo),
+        })),
+      preferredBranchId,
+    );
+  const window = {
+    ...(survivor.staged.validFrom === undefined ?
+      {}
+    : { validFrom: survivor.staged.validFrom }),
+    ...(foldedEnd === undefined ? {} : { validTo: foldedEnd }),
+  };
+
+  const contentKeys = new Set(foldSet.map((edge) => edge.dedupeKey));
+  if (contentKeys.size === 1) {
+    // Exact-equal collapse: every member shares identical props, so no
+    // conflict is possible — keep the survivor's props verbatim.
+    return {
+      edge: {
+        id: survivorId,
+        kind: survivor.staged.kind,
+        fromId,
+        toId,
+        fromKind,
+        toKind,
+        props: survivor.staged.props,
+        mergedIds,
+        ...window,
+      },
+      conflicts: [],
+    };
+  }
+
+  const { props, conflicts } = unionEdgeProps(
+    survivorId,
+    survivor.staged.kind,
+    survivor,
+    foldSet,
+    context,
+    branchRank,
+    preferredBranchId,
+  );
+  return {
+    edge: {
+      id: survivorId,
+      kind: survivor.staged.kind,
+      fromId,
+      toId,
+      fromKind,
+      toKind,
+      props,
+      mergedIds,
+      ...window,
+    },
+    conflicts,
+  };
+}
+
+/**
+ * Repoints every staged edge onto its cluster canonical, drops edges whose
+ * (repointed) endpoints are finally deleted, and dedupes the survivors that
+ * repointing brought together as a pure set operation keyed by
+ * `(from' | type | to' | propsKey)`.
+ *
+ * Within a REPOINT-INDUCED collision group sharing `(from', type, to')` — one whose
+ * members did not all name the same endpoints before repointing:
  *   - identical props collapse silently to one edge,
  *   - DIFFERING props are reconciled by `policy` on the captured `branchRank`,
  *     recording one edge-level {@link PropertyConflict} per disagreeing property.
  *
- * The surviving edge of every group is the lexicographically-minimal contributing
- * edge id; its `mergedIds` lists every collapsed edge id. Output is sorted by the
- * full dedupe key, so the result is a pure function of the unordered input set.
+ * Edges that already shared their endpoints are NOT folded together: the store is a
+ * multigraph, so each distinct edge id commits as its own parallel row (see the
+ * module header for the full rule and why identity, not props equality, decides it).
+ *
+ * The surviving edge of every folded set is the lexicographically-minimal
+ * contributing edge id; its `mergedIds` lists every collapsed edge id. Output is
+ * sorted by the full dedupe key plus the edge id, so the result is a pure function
+ * of the unordered input set.
  *
  * @param stagedEdges The new + surviving-inherited edges to merge. Order does not
  *   affect the result. Props MUST already be parsed objects.
@@ -351,21 +541,19 @@ export function repointEdges<G extends GraphDef = GraphDef>(
   preferredBranchId?: BranchId,
 ): EdgeRepointResult<G> {
   const dropped: DroppedEdge[] = [];
-  const liveByDedupeKey = new Map<string, RepointedEdge[]>();
-  // Per `(from', type, to')` group → the SET of distinct dedupe keys seen for it.
-  // Insertion order is irrelevant: Phase 2 re-derives the survivor and sorts the
-  // output explicitly, so the set carries membership only.
-  const dedupeKeyByGroup = new Map<string, Set<string>>();
+  // Per `(from', type, to')` group → its members. Insertion order is irrelevant:
+  // Phase 2 partitions the group, re-derives each survivor, and sorts the output
+  // explicitly, so the bucket carries membership only.
+  const liveByGroup = new Map<string, RepointedEdge[]>();
 
   // Phase 1: repoint endpoints (by their `(kind, id)` identity, so a cross-kind id
   // collision can never repoint two unrelated edges onto one survivor), drop edges to
-  // deleted nodes, and bucket the survivors by their full dedupe key.
+  // deleted nodes, and bucket the survivors by their post-repoint endpoint group.
   for (const staged of stagedEdges) {
-    const fromKey = repoint(
-      mergeKey(staged.fromKind, staged.fromId),
-      canonicalOf,
-    );
-    const toKey = repoint(mergeKey(staged.toKind, staged.toId), canonicalOf);
+    const sourceFromKey = mergeKey(staged.fromKind, staged.fromId);
+    const sourceToKey = mergeKey(staged.toKind, staged.toId);
+    const fromKey = repoint(sourceFromKey, canonicalOf);
+    const toKey = repoint(sourceToKey, canonicalOf);
 
     if (deletedNodeIds.has(fromKey) || deletedNodeIds.has(toKey)) {
       dropped.push({
@@ -376,28 +564,28 @@ export function repointEdges<G extends GraphDef = GraphDef>(
       continue;
     }
 
-    const repointed: RepointedEdge = { staged, fromKey, toKey };
-    const key = dedupeKey(fromKey, staged.kind, toKey, staged.props);
-    const bucket = liveByDedupeKey.get(key);
+    const repointed: RepointedEdge = {
+      staged,
+      fromKey,
+      toKey,
+      sourcePair: sourcePairKey(sourceFromKey, sourceToKey),
+      dedupeKey: dedupeKey(fromKey, staged.kind, toKey, staged.props),
+    };
+    const group = groupKey(fromKey, staged.kind, toKey);
+    const bucket = liveByGroup.get(group);
     if (bucket === undefined) {
-      liveByDedupeKey.set(key, [repointed]);
+      liveByGroup.set(group, [repointed]);
     } else {
       bucket.push(repointed);
     }
-
-    const group = groupKey(fromKey, staged.kind, toKey);
-    const keysForGroup = dedupeKeyByGroup.get(group);
-    if (keysForGroup === undefined) {
-      dedupeKeyByGroup.set(group, new Set([key]));
-    } else {
-      keysForGroup.add(key);
-    }
   }
 
-  // Phase 2: per `(from', type, to')` group, fold the per-dedupe-key buckets into
-  // one survivor. A group with a single dedupe key is an exact-equal collapse (no
-  // conflict); a group with several dedupe keys means props differ, so the union
-  // runs the conflict policy.
+  // Phase 2: partition every `(from', type, to')` group into the sets that commit as
+  // one row ({@link foldSets} — a repoint-induced collapse folds whole, ordinary
+  // multigraph multiplicity splits per edge id) and fold each set onto its survivor.
+  // A set whose members share one dedupe key is an exact-equal collapse (no conflict
+  // is possible); several dedupe keys means props differ, so the union runs the
+  // conflict policy.
   const context: ResolutionContext<GraphDef> = {
     policy: policy as PropertyConflictPolicy<GraphDef>,
     ...(weights === undefined ? {} : { weights }),
@@ -406,123 +594,43 @@ export function repointEdges<G extends GraphDef = GraphDef>(
   const merged: MergedEdge[] = [];
   const conflicts: PropertyConflict<G>[] = [];
 
-  const sortedGroups = [...dedupeKeyByGroup.keys()].sort((left, right) =>
+  const sortedGroups = [...liveByGroup.keys()].sort((left, right) =>
     compareStrings(left, right),
   );
 
   for (const group of sortedGroups) {
-    const dedupeKeys = [...requireDefined(dedupeKeyByGroup.get(group))];
-    const groupEdges: RepointedEdge[] = [];
-    for (const key of dedupeKeys) {
-      for (const edge of requireDefined(liveByDedupeKey.get(key))) {
-        groupEdges.push(edge);
-      }
-    }
-
-    const survivor = pickSurvivor(groupEdges, preferredBranchId);
-    const survivorId = survivor.staged.id;
-    const mergedIds = [...groupEdges]
-      .map((edge) => edge.staged.id)
-      .sort((left, right) => compareStrings(left, right));
-
-    // Endpoint ids AND kinds come from the canonical IDENTITY keys, so a repointed
-    // edge always names the canonical node's own kind (the commit then applies any
-    // retype cascade), never a staged endpoint that merely shared the id string.
-    const fromId = idOf(survivor.fromKey);
-    const fromKind = kindOf(survivor.fromKey);
-    const toId = idOf(survivor.toKey);
-    const toKind = kindOf(survivor.toKey);
-    // The survivor's lower bound rides along unchanged — a `validFrom` is the
-    // branch's authored start for the row we commit, and the group's members are
-    // the same edge as seen by different branches.
-    //
-    // The END is folded across the group. When repoint/dedupe collapses several
-    // DISTINCT edges into one survivor, an end claimed by a non-survivor would
-    // otherwise be discarded by the arbitrary min-id pick — a silent window
-    // loss — so the earliest claimed end wins, the same least-claim rule the
-    // inherited-window reconciler uses.
-    //
-    // A survivor from the PREFERRED branch keeps its own end verbatim when it
-    // HAS one: that member is the live incremental target's row, and a user
-    // branch never re-windows what the target already holds. When it has none
-    // there is no target window to protect, so the fold still resolves across
-    // the group — otherwise a preferred survivor would silently swallow the
-    // only end any branch claimed.
-    const preferredSurvivorEnd =
-      survivor.staged.branchId === preferredBranchId ?
-        survivor.staged.validTo
-      : undefined;
-    const foldedEnd =
-      preferredSurvivorEnd ??
-      resolveEndClaims(
-        groupEdges
-          .filter((edge) => edge.staged.validTo !== undefined)
-          .map((edge) => ({
-            branchId: edge.staged.branchId,
-            validTo: requireDefined(edge.staged.validTo),
-          })),
+    const groupEdges = requireDefined(liveByGroup.get(group));
+    for (const foldSet of foldSets(groupEdges)) {
+      const folded = foldEdgeSet(
+        foldSet,
+        context,
+        branchRank,
         preferredBranchId,
       );
-    const window = {
-      ...(survivor.staged.validFrom === undefined ?
-        {}
-      : { validFrom: survivor.staged.validFrom }),
-      ...(foldedEnd === undefined ? {} : { validTo: foldedEnd }),
-    };
-
-    if (dedupeKeys.length === 1) {
-      // Exact-equal collapse: every member shares identical props, so no
-      // conflict is possible — keep the survivor's props verbatim.
-      merged.push({
-        id: survivorId,
-        kind: survivor.staged.kind,
-        fromId,
-        toId,
-        fromKind,
-        toKind,
-        props: survivor.staged.props,
-        mergedIds,
-        ...window,
-      });
-      continue;
+      merged.push(folded.edge);
+      for (const conflict of folded.conflicts) {
+        conflicts.push(conflict as PropertyConflict<G>);
+      }
     }
-
-    const { props, conflicts: groupConflicts } = unionEdgeProps(
-      survivorId,
-      survivor.staged.kind,
-      survivor,
-      groupEdges,
-      context,
-      branchRank,
-      preferredBranchId,
-    );
-    for (const conflict of groupConflicts) {
-      conflicts.push(conflict as PropertyConflict<G>);
-    }
-    merged.push({
-      id: survivorId,
-      kind: survivor.staged.kind,
-      fromId,
-      toId,
-      fromKind,
-      toKind,
-      props,
-      mergedIds,
-      ...window,
-    });
   }
 
-  // Sort on a PRECOMPUTED dedupe key per edge (Schwartzian) so `canonicalizeProps` +
-  // serialization run once per edge, not twice on every comparison.
+  // Sort on a PRECOMPUTED key per edge (Schwartzian) so `canonicalizeProps` +
+  // serialization run once per edge, not twice on every comparison. The edge id is
+  // the final component: parallel edges on one endpoint pair can agree on every
+  // other one, and a non-total key would leave their order dependent on the stable
+  // sort's view of input order.
   const sortedEdges = merged
     .map((edge) => ({
       edge,
-      sortKey: dedupeKey(
-        mergeKey(edge.fromKind, edge.fromId),
-        edge.kind,
-        mergeKey(edge.toKind, edge.toId),
-        edge.props,
-      ),
+      sortKey: JSON.stringify([
+        dedupeKey(
+          mergeKey(edge.fromKind, edge.fromId),
+          edge.kind,
+          mergeKey(edge.toKind, edge.toId),
+          edge.props,
+        ),
+        edge.id,
+      ]),
     }))
     .sort((left, right) => compareStrings(left.sortKey, right.sortKey))
     .map(({ edge }) => edge);

--- a/packages/typegraph/src/graph-merge/valid-window.ts
+++ b/packages/typegraph/src/graph-merge/valid-window.ts
@@ -120,8 +120,10 @@ function earliestEnd(claims: readonly EndClaim[]): string | undefined {
 
 /**
  * Applies rule 3 to a set of end claims: the preferred branch's claim if it made
- * one, else {@link earliestEnd}. Order-independent — the preferred-branch lookup
- * is a set query and the fallback is a `min`.
+ * one, else {@link earliestEnd}. Order-independent — the preferred branch's claims
+ * are selected as a SET and reduced by the same `min`, so a fold set holding several
+ * preferred rows (distinct edges the repoint collapsed) cannot resolve on which of
+ * them the caller happened to list first.
  *
  * Only the edge FOLD needs this form. The inherited-row reconciler never sees a
  * preferred claim (the committed target's own end is already stored, so it is
@@ -132,10 +134,10 @@ export function resolveEndClaims(
   claims: readonly EndClaim[],
   preferredBranchId: BranchId | undefined,
 ): string | undefined {
-  const preferred = claims.find(
+  const preferred = claims.filter(
     (claim) => claim.branchId === preferredBranchId,
   );
-  return preferred === undefined ? earliestEnd(claims) : preferred.validTo;
+  return earliestEnd(preferred.length > 0 ? preferred : claims);
 }
 
 /** The claiming branches of a resolved end, deduped and sorted. */

--- a/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
@@ -35,6 +35,7 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  defineNodeIndex,
 } from "@nicia-ai/typegraph";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -42,10 +43,10 @@ import { z } from "zod";
 import { rowPropsToObject } from "../../src/backend/types";
 import { asEdgeId } from "../../src/core/types";
 import { branch } from "../../src/graph-merge/branch";
-import { merge } from "../../src/graph-merge/merge";
+import { merge, mergeIncremental } from "../../src/graph-merge/merge";
 import { unwrap } from "../../src/graph-merge/result";
 import { enumerateAllEdges } from "../../src/graph-merge/state-diff";
-import type { GraphBranch } from "../../src/graph-merge/types";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
 import { asBranchId } from "../../src/graph-merge/types";
 import { canonicalizeDatabaseTimestamp } from "../../src/utils/date";
 import { backendMatrix, getStoreBackend } from "./test-utils";
@@ -54,12 +55,22 @@ const Patient = defineNode("Patient", {
   schema: z.object({ name: z.string() }),
 });
 const Encounter = defineNode("Encounter", {
-  schema: z.object({ reason: z.string() }),
+  schema: z.object({ reason: z.string(), code: z.string() }),
 });
 const hadEncounter = defineEdge("hadEncounter", {
   schema: z.object({ on: z.string() }),
   from: [Patient],
   to: [Encounter],
+});
+
+/**
+ * The new-vs-base block key the MIXED case resolves on: a declared, non-unique index
+ * over `code`, so a branch may stage a near-duplicate encounter carrying the committed
+ * one's code (a unique constraint would refuse it in the branch store itself).
+ */
+const encounterCode = defineNodeIndex(Encounter, {
+  name: "encounter_code_idx",
+  fields: ["code"],
 });
 
 const careGraph = defineGraph({
@@ -68,26 +79,62 @@ const careGraph = defineGraph({
   edges: {
     hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
   },
+  indexes: [encounterCode],
 });
 type CareGraph = typeof careGraph;
 type CareStore = Store<CareGraph>;
 
 const PATIENT = { kind: "Patient", id: "pat-1" } as const;
 const ENCOUNTER = { kind: "Encounter", id: "enc-1" } as const;
+/** The near-duplicate encounter a branch stages in the MIXED case. */
+const DUPLICATE_ENCOUNTER = { kind: "Encounter", id: "enc-2" } as const;
 /** The inherited edge present at the fork point. */
 const INHERITED_EDGE = "edge-5";
 const INHERITED = asEdgeId<typeof hadEncounter>(INHERITED_EDGE);
+/** A SECOND inherited edge on the same endpoints, for the MIXED case. */
+const SECOND_INHERITED_EDGE = "edge-7";
+const SECOND_INHERITED = asEdgeId<typeof hadEncounter>(SECOND_INHERITED_EDGE);
 const BRANCH_A = asBranchId("parallel-branch-a");
+const TARGET_BRANCH = asBranchId("parallel-target");
 const BRANCH_ORDER = [BRANCH_A];
 
+/** The committed encounter's block key + reason, and the branch's near-duplicate of
+ *  it (Dice trigram ≈ 0.96 ≥ the case's threshold, so the two resolve as one). */
+const ENCOUNTER_CODE = "code-1";
+const ENCOUNTER_REASON = "routine annual physical examination";
+const DUPLICATE_REASON = "routine annual physical examinations";
+
 const INHERITED_DATE = "2026-01-05";
+/** What the SECOND inherited edge says at the fork point. */
+const SECOND_INHERITED_DATE = "2026-01-19";
 /** What a branch edits the INHERITED edge's `on` to. */
 const EDITED_DATE = "2026-02-02";
+/** What a branch edits the SECOND inherited edge's `on` to. */
+const SECOND_EDITED_DATE = "2026-02-16";
 /** What a branch's own, newly created parallel edge says. */
 const BRANCH_DATE = "2026-03-11";
 /** In the FUTURE: a row's `validFrom` defaults to creation, and an inverted
  *  window is refused, so an authorable end must be after that instant. */
 const END = "2100-01-01T00:00:00.000Z";
+
+/**
+ * Merge options for the MIXED case: the branch's near-duplicate encounter resolves
+ * against the committed one through the declared block index, so its edge repoints
+ * onto endpoints the inherited parallel rows already occupy.
+ */
+function resolveDuplicateEncounters(): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Encounter: {
+        blockIndex: "encounter_code_idx",
+        similarity: { kind: "fulltext", fields: ["reason"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: BRANCH_ORDER,
+  };
+}
 
 /** One committed `hadEncounter` row, reduced to what multiplicity cases assert. */
 type CommittedEdge = Readonly<{
@@ -121,7 +168,10 @@ describe.each(backendMatrix())("merging parallel edges [$name]", (entry) => {
   async function seededForkPoint(): Promise<CareStore> {
     const [store] = await createStoreWithSchema(careGraph, await makeBackend());
     await store.nodes.Patient.create({ name: "Ana Rivera" }, { id: "pat-1" });
-    await store.nodes.Encounter.create({ reason: "checkup" }, { id: "enc-1" });
+    await store.nodes.Encounter.create(
+      { reason: ENCOUNTER_REASON, code: ENCOUNTER_CODE },
+      { id: "enc-1" },
+    );
     await store.edges.hadEncounter.create(
       PATIENT,
       ENCOUNTER,
@@ -131,9 +181,12 @@ describe.each(backendMatrix())("merging parallel edges [$name]", (entry) => {
     return store;
   }
 
-  async function forkOf(forkPoint: CareStore): Promise<GraphBranch<CareGraph>> {
+  async function forkOf(
+    forkPoint: CareStore,
+    id = BRANCH_A,
+  ): Promise<GraphBranch<CareGraph>> {
     return unwrap(
-      await branch<CareGraph>(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+      await branch<CareGraph>(forkPoint, () => makeBackend(), { id }),
     );
   }
 
@@ -272,7 +325,9 @@ describe.each(backendMatrix())("merging parallel edges [$name]", (entry) => {
       { id: "edge-1" },
     );
 
-    unwrap(await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }));
+    const report = unwrap(
+      await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }),
+    );
 
     expect(
       (await liveEdges(forkPoint)).map((edge) => ({
@@ -282,6 +337,87 @@ describe.each(backendMatrix())("merging parallel edges [$name]", (entry) => {
     ).toEqual([
       { id: "edge-1", validTo: undefined },
       { id: INHERITED_EDGE, validTo: END },
+    ]);
+    // The report describes the same two rows: the window resolution names the row it
+    // landed on, and each parallel row counts once.
+    expect(
+      report.validityEnds.map((resolution) => ({
+        id: resolution.id,
+        validTo: resolution.validTo,
+      })),
+    ).toEqual([{ id: INHERITED_EDGE, validTo: END }]);
+    expect(report.merged.edges).toBe(2);
+  });
+
+  it("keeps a parallel row's own edit when a repointed edge joins its endpoints", async () => {
+    // The MIXED group: identity resolution collapses the branch's near-duplicate
+    // encounter onto the committed one, so the branch's edge repoints onto endpoints
+    // two parallel rows already occupy. The collapse is ACROSS the pre-repoint pairs —
+    // it merges the repointed edge into ONE of those rows — and says nothing about the
+    // rows that were already there. Folding the whole group instead left the other
+    // row's edit unwritten (a folded-away committed row is never rewritten) and
+    // reported a property conflict between rows that were never the same row.
+    const forkPoint = await seededForkPoint();
+    await forkPoint.edges.hadEncounter.create(
+      PATIENT,
+      ENCOUNTER,
+      { on: SECOND_INHERITED_DATE },
+      { id: SECOND_INHERITED_EDGE },
+    );
+    const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
+    const branchA = await forkOf(forkPoint);
+    await branchA.store.edges.hadEncounter.update(INHERITED, {
+      on: EDITED_DATE,
+    });
+    await branchA.store.edges.hadEncounter.update(SECOND_INHERITED, {
+      on: SECOND_EDITED_DATE,
+    });
+    await branchA.store.nodes.Encounter.create(
+      { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
+      { id: DUPLICATE_ENCOUNTER.id },
+    );
+    await branchA.store.edges.hadEncounter.create(
+      PATIENT,
+      DUPLICATE_ENCOUNTER,
+      { on: BRANCH_DATE },
+      { id: "edge-9" },
+    );
+
+    const report = unwrap(
+      await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [branchA],
+        options: resolveDuplicateEncounters(),
+      }),
+    );
+
+    // The duplicate encounter resolved onto the committed one...
+    expect(
+      report.resolutions.map((resolution) => resolution.canonicalId),
+    ).toEqual(["enc-1"]);
+    // ...the repointed edge folded into the min-id row of the pair it landed on, and
+    // the other row committed the edit its author made.
+    expect(
+      (await liveEdges(target)).map((edge) => ({
+        id: edge.id,
+        toId: edge.toId,
+        on: edge.on,
+      })),
+    ).toEqual([
+      { id: INHERITED_EDGE, toId: "enc-1", on: EDITED_DATE },
+      { id: SECOND_INHERITED_EDGE, toId: "enc-1", on: SECOND_EDITED_DATE },
+    ]);
+    // The only edge-level disagreement is between the two rows the collapse merged.
+    expect(
+      report.conflicts
+        .filter((conflict) => conflict.kind === "hadEncounter")
+        .map((conflict) => ({
+          entityId: conflict.entityId,
+          values: conflict.values.map((value) => value.value),
+        })),
+    ).toEqual([
+      { entityId: INHERITED_EDGE, values: [EDITED_DATE, BRANCH_DATE] },
     ]);
   });
 

--- a/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
@@ -1,0 +1,327 @@
+/**
+ * End-to-end contract for PARALLEL edges through a merge (issue #393).
+ *
+ * The store is a multigraph: nothing enforces uniqueness on `(from, kind, to)`,
+ * `create()` makes a second edge between endpoints that already have one, and
+ * `getOrCreateByEndpoints()` is the opt-in set-semantics accessor. A merge must
+ * therefore produce what the branch's operation would have produced applied
+ * straight to the target — so a branch that created a parallel edge merges as a
+ * parallel edge.
+ *
+ * The repoint/dedupe fold used to group EVERY staged edge by `(from, kind, to)` and
+ * collapse the group onto its min-id survivor. That destroyed the authored
+ * multiplicity, and it did so unstably: whether the scenario ended with one edge or
+ * two depended on how a branch-created id happened to sort against the inherited
+ * one. These cases pin both halves of the replacement:
+ *
+ *   1. a branch-created parallel edge survives, with its OWN props, and raises no
+ *      property conflict against the row it merely sits beside;
+ *   2. that holds for both id orderings — the survivor pick can no longer decide
+ *      the outcome;
+ *   3. EDGE ID, not props equality, is what makes two staged edges "the same row":
+ *      a new id is a new parallel edge even when its props coincide;
+ *   4. a window claim lands on the row its author touched.
+ *
+ * A genuine repoint-induced collapse still folds — that fold is what the dedupe
+ * exists for. Its end-to-end contract is `self-edge-collapse.test.ts` and
+ * `valid-window-merge.test.ts`; its mechanics are `edge-repoint.test.ts`.
+ *
+ * Runs on every backend in the matrix: edge multiplicity is asserted through the
+ * committed rows, and a per-dialect test would happily certify a divergence.
+ */
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { rowPropsToObject } from "../../src/backend/types";
+import { asEdgeId } from "../../src/core/types";
+import { branch } from "../../src/graph-merge/branch";
+import { merge } from "../../src/graph-merge/merge";
+import { unwrap } from "../../src/graph-merge/result";
+import { enumerateAllEdges } from "../../src/graph-merge/state-diff";
+import type { GraphBranch } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { canonicalizeDatabaseTimestamp } from "../../src/utils/date";
+import { backendMatrix, getStoreBackend } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string() }),
+});
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string() }),
+});
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+const careGraph = defineGraph({
+  id: "parallel-edge-care",
+  nodes: { Patient: { type: Patient }, Encounter: { type: Encounter } },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+});
+type CareGraph = typeof careGraph;
+type CareStore = Store<CareGraph>;
+
+const PATIENT = { kind: "Patient", id: "pat-1" } as const;
+const ENCOUNTER = { kind: "Encounter", id: "enc-1" } as const;
+/** The inherited edge present at the fork point. */
+const INHERITED_EDGE = "edge-5";
+const INHERITED = asEdgeId<typeof hadEncounter>(INHERITED_EDGE);
+const BRANCH_A = asBranchId("parallel-branch-a");
+const BRANCH_ORDER = [BRANCH_A];
+
+const INHERITED_DATE = "2026-01-05";
+/** What a branch edits the INHERITED edge's `on` to. */
+const EDITED_DATE = "2026-02-02";
+/** What a branch's own, newly created parallel edge says. */
+const BRANCH_DATE = "2026-03-11";
+/** In the FUTURE: a row's `validFrom` defaults to creation, and an inverted
+ *  window is refused, so an authorable end must be after that instant. */
+const END = "2100-01-01T00:00:00.000Z";
+
+/** One committed `hadEncounter` row, reduced to what multiplicity cases assert. */
+type CommittedEdge = Readonly<{
+  id: string;
+  fromId: string;
+  toId: string;
+  on: unknown;
+  validTo: string | undefined;
+}>;
+
+describe.each(backendMatrix())("merging parallel edges [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[] = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.reverse()) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  /**
+   * A fork point holding one patient, one encounter, and ONE edge joining them —
+   * so every additional edge a case commits is the merge's own doing.
+   */
+  async function seededForkPoint(): Promise<CareStore> {
+    const [store] = await createStoreWithSchema(careGraph, await makeBackend());
+    await store.nodes.Patient.create({ name: "Ana Rivera" }, { id: "pat-1" });
+    await store.nodes.Encounter.create({ reason: "checkup" }, { id: "enc-1" });
+    await store.edges.hadEncounter.create(
+      PATIENT,
+      ENCOUNTER,
+      { on: INHERITED_DATE },
+      { id: INHERITED_EDGE },
+    );
+    return store;
+  }
+
+  async function forkOf(forkPoint: CareStore): Promise<GraphBranch<CareGraph>> {
+    return unwrap(
+      await branch<CareGraph>(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+    );
+  }
+
+  /** Every LIVE `hadEncounter` row, id-sorted. */
+  async function liveEdges(
+    store: CareStore,
+  ): Promise<readonly CommittedEdge[]> {
+    const rows = await enumerateAllEdges(
+      getStoreBackend(store),
+      store.graphId,
+      "hadEncounter",
+    );
+    return rows
+      .filter((row) => row.deleted_at === undefined)
+      .map((row) => ({
+        id: row.id,
+        fromId: row.from_id,
+        toId: row.to_id,
+        on: rowPropsToObject(row.props)["on"],
+        validTo: canonicalizeDatabaseTimestamp(row.valid_to),
+      }))
+      .sort((left, right) =>
+        left.id < right.id ? -1
+        : left.id > right.id ? 1
+        : 0,
+      );
+  }
+
+  /** `liveEdges` is id-sorted, so every expectation is sorted the same way. */
+  function byId<T extends Readonly<{ id: string }>>(rows: readonly T[]): T[] {
+    return [...rows].sort((left, right) =>
+      left.id < right.id ? -1
+      : left.id > right.id ? 1
+      : 0,
+    );
+  }
+
+  // Both orderings of the branch-created id against the inherited "edge-5". The
+  // branch also edits the inherited edge, which is what puts BOTH rows in front of
+  // the fold — an untouched inherited edge is never staged, so the collision only
+  // arises once some branch has something to say about it.
+  //
+  // On main the LOW branch id won the min-id pick, so the edit meant for the
+  // inherited row landed on the branch's row and the inherited row kept its stale
+  // props; the HIGH id kept the inherited row and dropped the branch's row
+  // entirely. Both shapes lost an authored fact, and which one you got depended on
+  // an id sort — the instability the adjudication called undependable.
+  describe.each([
+    { position: "sorts BEFORE", branchEdgeId: "edge-1" },
+    { position: "sorts AFTER", branchEdgeId: "edge-9" },
+  ])(
+    "a branch-created parallel edge whose id $position the inherited one",
+    ({ branchEdgeId }) => {
+      it("commits beside the inherited edge, each carrying its own props", async () => {
+        const forkPoint = await seededForkPoint();
+        const branchA = await forkOf(forkPoint);
+        await branchA.store.edges.hadEncounter.update(INHERITED, {
+          on: EDITED_DATE,
+        });
+        await branchA.store.edges.hadEncounter.create(
+          PATIENT,
+          ENCOUNTER,
+          { on: BRANCH_DATE },
+          { id: branchEdgeId },
+        );
+
+        const report = unwrap(
+          await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }),
+        );
+
+        expect(
+          (await liveEdges(forkPoint)).map((edge) => ({
+            id: edge.id,
+            on: edge.on,
+          })),
+        ).toEqual(
+          byId([
+            { id: INHERITED_EDGE, on: EDITED_DATE },
+            { id: branchEdgeId, on: BRANCH_DATE },
+          ]),
+        );
+        // Two distinct rows sitting beside each other never disagree about a
+        // property; the old fold reported a conflict it had itself manufactured.
+        expect(report.conflicts).toEqual([]);
+        expect(report.dropped).toEqual([]);
+      });
+    },
+  );
+
+  it("keeps a branch-created parallel edge whose props MATCH the inherited one", async () => {
+    // Identity, not props equality, decides what counts as the same row: a fresh
+    // id is a new relationship instance even when it says exactly the same thing.
+    // On main the two shared a dedupe key, so this was the "exact-equal collapse"
+    // fast path and the second row silently disappeared.
+    const forkPoint = await seededForkPoint();
+    const branchA = await forkOf(forkPoint);
+    await branchA.store.edges.hadEncounter.update(INHERITED, {
+      on: EDITED_DATE,
+    });
+    await branchA.store.edges.hadEncounter.create(
+      PATIENT,
+      ENCOUNTER,
+      { on: EDITED_DATE },
+      { id: "edge-1" },
+    );
+
+    unwrap(await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }));
+
+    const edges = await liveEdges(forkPoint);
+    expect(edges.map((edge) => edge.id)).toEqual(["edge-1", INHERITED_EDGE]);
+    for (const edge of edges) {
+      expect(edge.on).toBe(EDITED_DATE);
+      expect(edge.fromId).toBe("pat-1");
+      expect(edge.toId).toBe("enc-1");
+    }
+  });
+
+  it("lands a window claim on the inherited row the branch ended", async () => {
+    // The branch ends the inherited edge and, separately, adds a parallel one. On
+    // main the end migrated to the min-id survivor — the branch's brand-new row —
+    // and the row the author actually ended stayed open. This is the issue's
+    // second symptom.
+    const forkPoint = await seededForkPoint();
+    const branchA = await forkOf(forkPoint);
+    await branchA.store.edges.hadEncounter.update(
+      INHERITED,
+      {},
+      {
+        validTo: END,
+      },
+    );
+    await branchA.store.edges.hadEncounter.create(
+      PATIENT,
+      ENCOUNTER,
+      { on: BRANCH_DATE },
+      { id: "edge-1" },
+    );
+
+    unwrap(await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }));
+
+    expect(
+      (await liveEdges(forkPoint)).map((edge) => ({
+        id: edge.id,
+        validTo: edge.validTo,
+      })),
+    ).toEqual([
+      { id: "edge-1", validTo: undefined },
+      { id: INHERITED_EDGE, validTo: END },
+    ]);
+  });
+
+  it("resolves two INHERITED parallel edges independently", async () => {
+    // Both rows exist at the fork point and the branch touches each differently:
+    // it ends one and edits the other's props. Neither claim may cross over.
+    const forkPoint = await seededForkPoint();
+    await forkPoint.edges.hadEncounter.create(
+      PATIENT,
+      ENCOUNTER,
+      { on: BRANCH_DATE },
+      { id: "edge-1" },
+    );
+    const branchA = await forkOf(forkPoint);
+    await branchA.store.edges.hadEncounter.update(
+      INHERITED,
+      {},
+      {
+        validTo: END,
+      },
+    );
+    await branchA.store.edges.hadEncounter.update(
+      asEdgeId<typeof hadEncounter>("edge-1"),
+      { on: EDITED_DATE },
+    );
+
+    const report = unwrap(
+      await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }),
+    );
+
+    expect(
+      (await liveEdges(forkPoint)).map((edge) => ({
+        id: edge.id,
+        on: edge.on,
+        validTo: edge.validTo,
+      })),
+    ).toEqual([
+      { id: "edge-1", on: EDITED_DATE, validTo: undefined },
+      { id: INHERITED_EDGE, on: INHERITED_DATE, validTo: END },
+    ]);
+    expect(report.conflicts).toEqual([]);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -624,21 +624,88 @@ describe("repointEdges fold scope (#393)", () => {
     expect(result.conflicts[0]?.property).toBe("weight");
   });
 
-  it("still folds a group repointing INDUCED even when a parallel edge is in it", () => {
-    // A repointed member (x→b, with {a,b} collapsed) joins a group that already
-    // held two parallel x→a edges. Repointing defines this group's identity, so the
-    // documented §6.3 set-collapse applies to the whole group — the conservative
-    // reading, and the only one under which the collapsed relationship is a set.
+  it("folds a repointed member into ONE row of a pair that has parallel rows", () => {
+    // A repointed member (x→b, with {a,b} collapsed) joins a group that already held
+    // two parallel x→a rows. The collapse is ACROSS the pre-repoint pairs — x→b and
+    // x→a became one relationship — and says nothing about the two rows that were
+    // already there, so it folds into the first of them and the second still commits.
+    // Folding the pair's own rows together would destroy the authored multiplicity
+    // this module exists to stop destroying (and would silently drop `edge-2`'s
+    // property edit, since a folded-away committed row is never rewritten).
     const staged = [
       stagedEdge({ id: "edge-1", from: "x", to: "a", props: { weight: 1 } }),
-      stagedEdge({ id: "edge-2", from: "x", to: "a", props: { weight: 1 } }),
+      stagedEdge({ id: "edge-2", from: "x", to: "a", props: { weight: 2 } }),
       stagedEdge({
         id: "edge-3",
         from: "x",
         to: "b",
-        props: { weight: 1 },
+        props: { weight: 3 },
         branchId: BRANCH_B,
       }),
+    ];
+
+    const reference = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(
+      reference.edges.map((edge) => ({
+        id: edge.id,
+        toId: edge.toId,
+        weight: edge.props["weight"],
+        mergedIds: edge.mergedIds.map((id) => id as string),
+      })),
+    ).toEqual([
+      // "flag" keeps the survivor's value, so the collapse reports its disagreement
+      // with the repointed member rather than resolving it.
+      {
+        id: "edge-1",
+        toId: "a",
+        weight: 1,
+        mergedIds: ["edge-1", "edge-3"],
+      },
+      { id: "edge-2", toId: "a", weight: 2, mergedIds: ["edge-2"] },
+    ]);
+    // The only reported disagreement is between the two rows the collapse merged.
+    expect(
+      reference.conflicts.map((conflict) => ({
+        entityId: conflict.entityId,
+        values: conflict.values.map((value) => value.value),
+      })),
+    ).toEqual([{ entityId: "edge-1", values: [1, 3] }]);
+
+    // Which row the repointed member joins is derived from the ids and the
+    // pre-repoint pairs, never from input order.
+    for (let seed = 1; seed <= 6; seed += 1) {
+      const result = repointEdges(
+        shuffled(staged, seed),
+        collapse,
+        new Set<MergeKey>(),
+        "flag",
+        rank(),
+      );
+      expect(projectEdges(result.edges)).toEqual(projectEdges(reference.edges));
+    }
+  });
+
+  it("keeps ONE row for an edge id two branches staged from different endpoints", () => {
+    // A chosen-id import can have two branches create the SAME edge id; if they name
+    // different endpoints that repointing then unifies, it is still one row and must
+    // commit once — emitting the id twice would plan two conflicting writes for it.
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "a", props: { weight: 1 } }),
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+      stagedEdge({ id: "edge-2", from: "x", to: "a", props: { weight: 3 } }),
     ];
 
     const result = repointEdges(
@@ -649,13 +716,38 @@ describe("repointEdges fold scope (#393)", () => {
       rank(),
     );
 
-    expect(result.edges).toHaveLength(1);
-    const edge = requireDefined(result.edges[0]);
-    expect(edge.id).toBe("edge-1");
-    expect(edge.mergedIds.map((id) => id as string)).toEqual([
-      "edge-1",
-      "edge-2",
-      "edge-3",
+    expect(
+      result.edges.map((edge) => ({
+        id: edge.id,
+        mergedIds: edge.mergedIds.map((id) => id as string),
+      })),
+    ).toEqual([
+      { id: "edge-1", mergedIds: ["edge-1", "edge-1"] },
+      { id: "edge-2", mergedIds: ["edge-2"] },
+    ]);
+  });
+
+  it("drops EVERY parallel edge to a deleted endpoint, not just one", () => {
+    // The drop is per staged edge and runs before any grouping, so parallel rows are
+    // each recorded — a group representative standing in for the rest would leave a
+    // dangling row behind.
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "y", props: { n: 1 } }),
+      stagedEdge({ id: "edge-2", from: "x", to: "y", props: { n: 1 } }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      noRepoint,
+      new Set<MergeKey>([key("y")]),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toEqual([]);
+    expect(result.dropped).toEqual([
+      { kind: "edge", id: "edge-1", reason: ENDPOINT_DELETED_DROP_REASON },
+      { kind: "edge", id: "edge-2", reason: ENDPOINT_DELETED_DROP_REASON },
     ]);
   });
 
@@ -772,6 +864,46 @@ describe("repointEdges fold scope (#393)", () => {
 
     expect(result.edges).toHaveLength(1);
     expect(result.edges[0]?.validTo).toBe("2100-06-01T00:00:00.000Z");
+  });
+
+  it("takes the preferred branch's EARLIEST end when a fold merged several of its rows", () => {
+    // The survivor is the preferred branch's row but claims no end, so the fold
+    // resolves across the set — and the preferred branch itself claimed two ends, on
+    // two rows the collapse merged. The least-claim rule decides, not whichever of
+    // its rows sorts first: an end nobody withdrew must not be discarded.
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "a", branchId: BRANCH_A }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        branchId: BRANCH_A,
+        validTo: "2100-06-01T00:00:00.000Z",
+      }),
+      stagedEdge({
+        id: "edge-3",
+        from: "x",
+        to: "c",
+        branchId: BRANCH_A,
+        validTo: "2100-01-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      buildCanonicalMap([clusterOf("a", "b", "c")], (cluster) =>
+        minIdCanonical(cluster),
+      ),
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+      undefined,
+      BRANCH_A,
+    );
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]?.id).toBe("edge-1");
+    expect(result.edges[0]?.validTo).toBe("2100-01-01T00:00:00.000Z");
   });
 
   it("produces an identical result across shuffled input for parallel edges", () => {

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -64,6 +64,8 @@ function stagedEdge(
     kind?: string;
     props?: Readonly<Record<string, JsonValue>>;
     branchId?: typeof BRANCH_A;
+    validFrom?: string;
+    validTo?: string;
   }>,
 ): StagedEdge {
   return {
@@ -75,6 +77,8 @@ function stagedEdge(
     toKind: "Doc",
     props: args.props ?? {},
     branchId: args.branchId ?? BRANCH_A,
+    ...(args.validFrom === undefined ? {} : { validFrom: args.validFrom }),
+    ...(args.validTo === undefined ? {} : { validTo: args.validTo }),
   };
 }
 
@@ -122,6 +126,8 @@ type MergedEdgeShape = Readonly<{
   toId: string;
   props: Readonly<Record<string, JsonValue>>;
   mergedIds: readonly string[];
+  validFrom: string | undefined;
+  validTo: string | undefined;
 }>;
 
 function projectEdges(
@@ -134,6 +140,8 @@ function projectEdges(
     toId: edge.toId,
     props: edge.props,
     mergedIds: edge.mergedIds.map((id) => id as string),
+    validFrom: edge.validFrom,
+    validTo: edge.validTo,
   }));
 }
 
@@ -482,6 +490,325 @@ describe("repointEdges", () => {
         })),
       };
       expect(shape).toEqual(referenceShape);
+    }
+  });
+});
+
+/**
+ * The fold's SCOPE (issue #393): only a collision repointing INDUCED is folded.
+ * Staged edges that already shared their endpoints are ordinary multigraph
+ * multiplicity — `create()` makes a parallel edge and nothing enforces uniqueness on
+ * `(from, type, to)`, so a merge must commit them as parallel rows to produce what
+ * the branch's operation would have produced applied straight to the target.
+ *
+ * Every case below pins one half of that line: what still folds, what no longer does,
+ * and that EDGE ID (not props equality) decides which.
+ */
+describe("repointEdges fold scope (#393)", () => {
+  // No clustering at all: every endpoint maps to itself, so nothing is repointed.
+  const noRepoint = new Map<MergeKey, MergeKey>();
+  // {a, b} collapse to canonical "a" (min id) — the repoint-induced case.
+  const collapse = buildCanonicalMap([clusterOf("a", "b")], (cluster) =>
+    minIdCanonical(cluster),
+  );
+
+  it("keeps two same-endpoint edges with DIFFERING props as parallel edges", () => {
+    // On main these folded onto the min-id survivor and raised a bogus property
+    // conflict between two rows that were never the same row.
+    const staged = [
+      stagedEdge({
+        id: "edge-inherited",
+        from: "x",
+        to: "y",
+        props: { weight: 1 },
+        branchId: BRANCH_A,
+      }),
+      stagedEdge({
+        id: "edge-new",
+        from: "x",
+        to: "y",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      noRepoint,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(2);
+    expect(
+      result.edges.map((edge) => ({
+        id: edge.id,
+        weight: edge.props["weight"],
+        mergedIds: edge.mergedIds.map((id) => id as string),
+      })),
+    ).toEqual([
+      { id: "edge-inherited", weight: 1, mergedIds: ["edge-inherited"] },
+      { id: "edge-new", weight: 2, mergedIds: ["edge-new"] },
+    ]);
+    // Two distinct rows never disagree about a property — the disagreement the old
+    // fold reported was an artifact of merging them.
+    expect(result.conflicts).toEqual([]);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it("keeps two same-endpoint edges with IDENTICAL props as parallel edges", () => {
+    // The id-keyed ruling: a distinct id is a distinct row even when its props
+    // coincide, because `create()` on the target would have made a second row.
+    const staged = [
+      stagedEdge({ id: "edge-inherited", from: "x", to: "y", props: { n: 1 } }),
+      stagedEdge({
+        id: "edge-new",
+        from: "x",
+        to: "y",
+        props: { n: 1 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      noRepoint,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges.map((edge) => edge.id as string)).toEqual([
+      "edge-inherited",
+      "edge-new",
+    ]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("folds the SAME edge id staged by several branches into one row", () => {
+    // The other half of the id-keyed ruling: one inherited row modified by two
+    // branches is still ONE row, so it must fold and its property disagreement
+    // must be reconciled rather than committed twice.
+    const staged = [
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "y",
+        props: { weight: 1 },
+        branchId: BRANCH_A,
+      }),
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "y",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      noRepoint,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(1);
+    const edge = requireDefined(result.edges[0]);
+    expect(edge.id).toBe("edge-1");
+    expect(edge.props["weight"]).toBe(1);
+    expect(result.conflicts).toHaveLength(1);
+    expect(`${result.conflicts[0]?.entityId}`).toBe("edge-1");
+    expect(result.conflicts[0]?.property).toBe("weight");
+  });
+
+  it("still folds a group repointing INDUCED even when a parallel edge is in it", () => {
+    // A repointed member (x→b, with {a,b} collapsed) joins a group that already
+    // held two parallel x→a edges. Repointing defines this group's identity, so the
+    // documented §6.3 set-collapse applies to the whole group — the conservative
+    // reading, and the only one under which the collapsed relationship is a set.
+    const staged = [
+      stagedEdge({ id: "edge-1", from: "x", to: "a", props: { weight: 1 } }),
+      stagedEdge({ id: "edge-2", from: "x", to: "a", props: { weight: 1 } }),
+      stagedEdge({
+        id: "edge-3",
+        from: "x",
+        to: "b",
+        props: { weight: 1 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(1);
+    const edge = requireDefined(result.edges[0]);
+    expect(edge.id).toBe("edge-1");
+    expect(edge.mergedIds.map((id) => id as string)).toEqual([
+      "edge-1",
+      "edge-2",
+      "edge-3",
+    ]);
+  });
+
+  it("gives each parallel edge its own valid-time window", () => {
+    // The window-landing consequence: an end claimed on one row stays on that row
+    // instead of migrating to an unrelated min-id survivor.
+    const staged = [
+      stagedEdge({
+        id: "edge-inherited",
+        from: "x",
+        to: "y",
+        validTo: "2100-06-01T00:00:00.000Z",
+      }),
+      stagedEdge({
+        id: "edge-new",
+        from: "x",
+        to: "y",
+        branchId: BRANCH_B,
+        validFrom: "2026-01-01T00:00:00.000Z",
+        validTo: "2100-01-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      noRepoint,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(
+      result.edges.map((edge) => ({
+        id: edge.id,
+        validFrom: edge.validFrom,
+        validTo: edge.validTo,
+      })),
+    ).toEqual([
+      {
+        id: "edge-inherited",
+        validFrom: undefined,
+        validTo: "2100-06-01T00:00:00.000Z",
+      },
+      {
+        id: "edge-new",
+        validFrom: "2026-01-01T00:00:00.000Z",
+        validTo: "2100-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("takes the EARLIEST end across a repoint-induced fold (#383)", () => {
+    // The window fold still applies where the fold itself does: the end claimed on
+    // the folded-away x→b must not be lost to the arbitrary min-id survivor pick.
+    const staged = [
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "a",
+        validTo: "2100-06-01T00:00:00.000Z",
+      }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        branchId: BRANCH_B,
+        validTo: "2100-01-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(1);
+    const edge = requireDefined(result.edges[0]);
+    expect(edge.id).toBe("edge-1");
+    expect(edge.validTo).toBe("2100-01-01T00:00:00.000Z");
+  });
+
+  it("lets a preferred-branch survivor of a repoint-induced fold keep its own end", () => {
+    // The incremental rule: the preferred branch IS the committed target, and a
+    // user branch never re-windows a row the target already ended.
+    const staged = [
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "a",
+        branchId: BRANCH_A,
+        validTo: "2100-06-01T00:00:00.000Z",
+      }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        branchId: BRANCH_B,
+        validTo: "2100-01-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+      undefined,
+      BRANCH_A,
+    );
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]?.validTo).toBe("2100-06-01T00:00:00.000Z");
+  });
+
+  it("produces an identical result across shuffled input for parallel edges", () => {
+    // Parallel edges agree on endpoints, type AND props, so the output sort must
+    // break the tie on edge id — a stable sort over a non-total key would leak
+    // input order into the result.
+    const staged = [
+      stagedEdge({ id: "edge-3", from: "x", to: "y", props: { n: 1 } }),
+      stagedEdge({ id: "edge-1", from: "x", to: "y", props: { n: 1 } }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "y",
+        props: { n: 1 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const reference = projectEdges(
+      repointEdges(staged, noRepoint, new Set<MergeKey>(), "flag", rank())
+        .edges,
+    );
+    expect(reference.map((edge) => edge.id)).toEqual([
+      "edge-1",
+      "edge-2",
+      "edge-3",
+    ]);
+
+    for (let seed = 1; seed <= 6; seed += 1) {
+      const result = repointEdges(
+        shuffled(staged, seed),
+        noRepoint,
+        new Set<MergeKey>(),
+        "flag",
+        rank(),
+      );
+      expect(projectEdges(result.edges)).toEqual(reference);
     }
   });
 });

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -14,8 +14,14 @@
  *   6. the incremental target's own end wins over a branch's;
  *   7. re-writing the end the target already holds is not a write at all;
  *   8. a fork `validFrom` divergence is reported unapplicable, not applied;
- *   9. two inherited edges folded by repoint/dedupe take the earliest end;
+ *   9. PARALLEL edges of one kind each take the end claimed on THAT row;
  *  10. a single branch may EXTEND an end to a later instant.
+ *
+ * Case 9 is the window half of issue #393: the repoint/dedupe fold is scoped to
+ * collisions repointing INDUCED, so a window claim can no longer migrate between two
+ * rows that merely share endpoints. The window rules of the fold ITSELF — earliest
+ * end across a folded set, and a preferred-branch survivor keeping its own end —
+ * are pinned in `edge-repoint.test.ts`, which can construct a cluster directly.
  *
  * Runs on every backend in the matrix — SQLite and PGlite always, real server
  * Postgres under `POSTGRES_URL`. That is load-bearing rather than incidental:
@@ -442,10 +448,12 @@ describe.each(backendMatrix())(
       ).toBe(beforeFrom);
     });
 
-    it("takes the earliest end across edges folded by repoint/dedupe", async () => {
+    it("gives PARALLEL edges of one kind their own ends", async () => {
       const forkPoint = await seededForkPoint();
-      // A SECOND inherited edge with identical endpoints and props: repoint/dedupe
-      // folds the two into one survivor, so the fold must not lose either end.
+      // A SECOND inherited edge with identical endpoints and props. The store is a
+      // multigraph, so these are two rows, not one: each branch's end lands on the
+      // row that branch touched. Until #393 the repoint/dedupe fold grouped them by
+      // `(from, kind, to)` and moved both ends onto the min-id survivor.
       await forkPoint.edges.hadEncounter.create(
         { kind: "Patient", id: "pat-1" },
         { kind: "Encounter", id: "enc-1" },
@@ -471,12 +479,11 @@ describe.each(backendMatrix())(
         }),
       );
 
-      // "edge-1" is the min-id survivor of the fold; the end claimed on the
-      // folded-away "edge-2" must not silently outlive its row unresolved.
       expect(await edgeEnd(forkPoint, "edge-1")).toBe(EARLY);
+      expect(await edgeEnd(forkPoint, "edge-2")).toBe(LATE);
     });
 
-    it("keeps a folded-away edge's end when the target's edge survives", async () => {
+    it("keeps a parallel edge's end off the row the target edited", async () => {
       const forkPoint = await seededForkPoint();
       await forkPoint.edges.hadEncounter.create(
         { kind: "Patient", id: "pat-1" },
@@ -487,8 +494,9 @@ describe.each(backendMatrix())(
       const target = (await forkOf(forkPoint, asBranchId("window-target")))
         .store;
       const branchA = await forkOf(forkPoint, BRANCH_A);
-      // The target edits the SURVIVING edge's props and claims no end at all;
-      // the branch ends the other edge of the same dedupe group.
+      // The target edits one parallel edge's props and claims no end; the branch
+      // ends the OTHER one. On main "edge-1" was the min-id survivor of the fold,
+      // so it absorbed an end nobody had claimed on it.
       await target.edges.hadEncounter.update(EDGE_1, { on: "2026-02-02" });
       await branchA.store.edges.hadEncounter.update(
         EDGE_2,
@@ -505,10 +513,8 @@ describe.each(backendMatrix())(
         }),
       );
 
-      // A survivor from the preferred branch keeps its own end verbatim, but it
-      // has none here — so there is no committed-target window to protect, and
-      // swallowing the only claimed end would be a silent window loss.
-      expect(await edgeEnd(target, "edge-1")).toBe(EARLY);
+      expect(await edgeEnd(target, "edge-2")).toBe(EARLY);
+      expect(await edgeEnd(target, "edge-1")).toBeUndefined();
     });
 
     it("lets a single branch extend an end to a later instant", async () => {

--- a/packages/typegraph/tests/property/graph-merge/identity-laws.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/identity-laws.test.ts
@@ -137,8 +137,8 @@ const NODE_IDS = ["n1", "n2", "n3", "n4"] as const;
  * reconciliation only ever sees a row live in BOTH the base and the fork, so the
  * edges the window laws quantify over must exist before the branches are cut.
  *
- * Their endpoint pairs are what {@link EDGE_CREATE_OP} keeps clear of: three
- * distinct pairs, each the sole occupant of its `(from, kind, to)` dedupe group.
+ * Three distinct pairs, which {@link EDGE_CREATE_OP} is free to create edges onto:
+ * a branch edge sharing a seeded pair is a parallel row, not a fold partner.
  */
 const SEED_EDGES = [
   { id: "seed-e1", from: 0, to: 1 },
@@ -292,30 +292,25 @@ const HARD_DELETE_OP: WeightedOp = {
   ),
 };
 
-/** The directed endpoint pairs the seeded edges already occupy. */
-const SEEDED_EDGE_PAIRS = new Set(
-  SEED_EDGES.map((edge) => `${edge.from}-${edge.to}`),
-);
-
 /**
  * Edge creation, held OUT of the incremental lane's BRANCH alphabet for exactly
  * the reason {@link HARD_DELETE_OP} is: a branch row staged onto an id the target
  * already committed is refused by the incremental existing-id write guard — a
  * legitimate but non-identity refusal that would only add noise to these laws.
  *
- * The endpoint pair is never one a SEEDED edge occupies. Repoint/dedupe groups
- * staged edges by `(from, kind, to)` — differing props make a property conflict,
- * NOT a separate group — so a branch edge onto a seeded pair folds with the
- * seeded row and the min-id survivor absorbs its claimed end. That relocation is
- * real behavior, pinned by the deterministic suite's fold cases; the window laws
- * below judge the row a claim was MADE on, so the generator keeps the two apart
- * rather than guarding after the fact.
+ * The endpoint pair is unconstrained, INCLUDING the pairs the seeded edges occupy.
+ * That is the regression marker for #393: the store is a multigraph, so a branch
+ * edge onto a seeded pair is a parallel row rather than a member of the seeded
+ * row's dedupe group, and the window laws below — which judge the row a claim was
+ * MADE on — hold without keeping the two apart. While the fold grouped every
+ * staged edge by `(from, kind, to)`, such an edge folded with the seeded row and
+ * the min-id survivor absorbed its claimed end.
  */
 const EDGE_CREATE_OP: WeightedOp = {
   weight: 2,
-  arbitrary: pairArb
-    .filter(([from, to]) => !SEEDED_EDGE_PAIRS.has(`${from}-${to}`))
-    .map(([from, to]) => ({ op: "createEdge", from, to }) as const),
+  arbitrary: pairArb.map(
+    ([from, to]) => ({ op: "createEdge", from, to }) as const,
+  ),
 };
 
 const ROBOT_OPS: readonly WeightedOp[] = [


### PR DESCRIPTION
Edge repoint/dedupe grouped **every** staged edge by `(from, kind, to)` and collapsed each group onto its lowest-sorting edge id. That is right for the case the module exists for — `x → a` and `x → b` becoming one `x → c*` once `{a, b}` cluster — and wrong for edges that already shared their endpoints.

A TypeGraph store is a multigraph. Nothing enforces uniqueness on `(from, kind, to)`, `create()` makes a parallel edge, and `getOrCreateByEndpoints()` is the opt-in set-semantics accessor. Folding an already-colliding pair therefore destroyed authored multiplicity and broke branch-effect commutativity: a merge must produce what the branch's operation would have produced applied straight to the target, and `create(x, y, props)` on the target yields a parallel edge. It also did so unstably — whether the merge left one row or two depended on how a branch-created id happened to sort against the existing one, so the old behavior was not something a caller could depend on in the first place.

## The grouping restriction

`foldSets` partitions each `(from', type, to')` collision group by the endpoint pair its members named **before** repointing, and collapses one row per pair.

Two staged edges are the same *row* when they share an edge id; two rows are the same *relationship* when they named the same pre-repoint pair. Repointing can turn distinct relationships into one identity, and that — nothing else — is the collision the §6.3 set-collapse exists for. So the minimum-id row of each pre-repoint pair folds into a single set, keeping the min-id survivor, `resolvePropertyUnion` reconciliation, and the end-of-validity fold from #383 exactly as before: `x → a` and `x → b` landing on `x → c*` are two pairs of one row each, so they still collapse to one edge.

Every further row a pair authored is ordinary multigraph multiplicity and commits as its own parallel row. A window claim consequently lands on the row its author touched rather than migrating to an unrelated survivor.

A group that mixes the two folds only **across** the pairs. A repointed `x → b` joining two parallel `x → a` rows merges into the lower-id one of them, and the other row still commits the edit its author made — repointing said nothing about the rows that were already there. Collapsing the whole group instead dropped that edit silently: a folded-away row is never rewritten, so the edit reached neither row, while the report carried a `PropertyConflict` mixing the values of rows that were never the same row.

Determinism holds by construction: group membership derives only from the staged endpoints and `canonicalOf`, and the partition from those plus intrinsic ids — never from input or id sort order. An edge id two branches staged from different pre-repoint pairs (a chosen-id import) stays one row, so no id can be planned twice.

## Identity, not props equality

What makes two staged edges "the same row" is their edge id. One inherited row staged by several branches is the same row: it folds, so concurrent property edits still reconcile into a single write with their disagreements reported. A branch-created row carries a fresh id and is a new parallel edge even when its props coincide with an existing one's — `create()` on the target would have made a second row regardless of what it said. Documented in the module header.

Three supporting changes fall out. The per-group fold body moved into `foldEdgeSet`, since a group can now emit several rows. The output sort key gained the edge id as its final component: parallel edges agree on endpoints, type and props, so the previous key was no longer total and a stable sort would have leaked input order into the result. And `resolveEndClaims` now reduces the preferred branch's claims with the same least-claim `min` it applies to every other claim set — it returned the first claim it found, so a fold set holding several of the preferred branch's rows resolved the survivor's end on whichever came first, discarding an earlier end nobody had withdrawn.

## Behavior change

Merges that previously collapsed parallel edges now commit both, and the spurious `PropertyConflict` those collapses reported between two rows that were never the same row is gone. Released as a minor.

## Notes

The two `valid-window-merge` cases added in #383 exercised the fold through two **inherited** parallel edges — the shape this issue calls wrong — so they now assert the adjudicated landing spot. The fold's own window rules (earliest end across a folded set, preferred-branch survivor keeping its own end) are pinned at unit level instead, where a cluster can be constructed directly.

The issue's original framing — folded-away rows are never deleted — is resolved by scoping the grouping rather than by adding deletes; full set semantics would require deleting a live target row the branch never touched. One residual is unchanged: a genuine collapse merges props and windows onto its survivor without ending the other rows, so when the survivor is a branch-created row and a *committed* row folds into it, that committed row stays live beside the new one and the edit staged for it is never written. Its root cause is the survivor rule rather than the grouping — the fold takes the minimum edge id where the node path enforces base-id-wins (§6.4-C) — so it is a separate ruling on edge survivor selection and stays out of this PR.

The issue's designated regression test is here now that #392 has landed: the property law suite's `createEdge` generator no longer keeps clear of the seeded edges' endpoint pairs. That constraint existed because a branch edge onto a seeded pair used to fold with the seeded row and relocate its window claim, which is the bug itself; with the fold scoped, the identity and window laws hold over branch edges that land on seeded pairs, and they do not hold under the old grouping.

Closes #393
