### PR TITLE
fix(graph-merge): fold an edge set onto the row the target already holds

### DIFF
--- a/.changeset/edge-fold-inherited-survivor.md
+++ b/.changeset/edge-fold-inherited-survivor.md
@@ -1,0 +1,21 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Graph Merge now keeps the **inherited** edge when a repoint-induced collapse folds a
+committed row together with a branch-created one, instead of keeping the
+lexicographically-minimal edge id.
+
+Previously the survivor of such a collapse was whichever edge id sorted lowest. A
+collapse rewrites the row it keeps and ends none of the rows folded into it, so when a
+branch-created id sorted below the committed one, the merge wrote the branch's row as a
+new edge and left the committed edge live beside it at its pre-merge properties — two
+live rows for one folded relationship, the edit staged for the committed row never
+written, and `merged.edges` counting one of them. Which of the two you got depended on
+an id sort, so it was not behavior a caller could depend on.
+
+The surviving edge id reported in `PropertyConflict.entityId`, window resolutions and
+provenance is consequently the inherited row's id whenever the collapse involved one.
+That is the id of the row that actually persists, and it no longer moves with
+branch-created id lexicographics. Collapses among branch-created edges alone are
+unchanged, as is the property/window reconciliation applied to the survivor.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -348,6 +348,14 @@ them; the rest keep their own properties and windows. What makes two staged edge
 staged by several branches folds into a single write, while a branch-created edge
 is a new row even when its properties happen to match an existing one's.
 
+When such a collapse mixes an **inherited** edge with a branch-created one, the
+inherited row is the one kept: a collapse rewrites the row it keeps and does not end
+the rows folded into it, so writing onto the row the target already holds is what
+keeps a committed edge from being left beside the row that replaced it. This mirrors
+the node rule below, and it is also what the surviving edge id in `PropertyConflict`,
+window resolutions, and provenance names. A collapse of branch-created edges alone
+keeps the lexicographically-minimal edge id.
+
 Inherited edges that a branch **deleted** are removed from the target, and
 inherited edges **modified** by multiple branches go through the same base-aware
 three-way merge as nodes — so an edge's `since` edited by one branch and `note`

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -117,15 +117,19 @@ export const INHERITED_EDGE_ORIGIN = "inherited" as const;
 export const BRANCH_CREATED_EDGE_ORIGIN = "branch-created" as const;
 
 /**
- * Whether a staged edge's ROW already exists in the merge base, or was created on a
- * branch. It is the diff BUCKET the staging phase (T7) put the edge in — a modified
- * or re-windowed inherited edge is {@link INHERITED_EDGE_ORIGIN}, a new fork edge is
- * {@link BRANCH_CREATED_EDGE_ORIGIN} — threaded through as data because nothing about
- * an edge id reveals its origin (ids are opaque and may be caller-chosen, so
- * re-deriving one from the id is not possible, not merely unwise).
+ * Whether a staged edge's ROW already existed at the fork point its branch diffed
+ * against, or was created after it. It is the diff BUCKET the staging phase (T7) put the
+ * edge in — a modified or re-windowed inherited edge is {@link INHERITED_EDGE_ORIGIN}, a
+ * new fork edge is {@link BRANCH_CREATED_EDGE_ORIGIN} — threaded through as data because
+ * nothing about an edge id reveals its origin (ids are opaque and may be caller-chosen,
+ * so re-deriving one from the id is not possible, not merely unwise).
  *
- * Survivor selection is the consumer: an inherited row is one the merge target
- * already holds, and a fold must land on it (see {@link pickSurvivor}).
+ * Survivor selection is the consumer: an inherited row is one the merge target already
+ * holds, so a fold must land on it (see {@link pickSurvivor}). Note this is not a
+ * liveness dichotomy — an incremental target's OWN new edge is
+ * {@link BRANCH_CREATED_EDGE_ORIGIN} while being a live committed row of the target too,
+ * which is why the order between the two is a decision {@link pickSurvivor} has to make
+ * rather than a tautology.
  */
 type StagedEdgeOrigin =
   typeof INHERITED_EDGE_ORIGIN | typeof BRANCH_CREATED_EDGE_ORIGIN;
@@ -171,8 +175,10 @@ export type StagedEdge = Readonly<{
  * A surviving merged edge after repoint + dedupe. `id` is the canonical survivor
  * of its fold set (its inherited member, else its minimum contributing edge id — see
  * {@link pickSurvivor}); `mergedIds` is every staged edge id that collapsed into it
- * (always includes `id`), so the commit phase (T11) knows which inherited edges to
- * fold away.
+ * (always includes `id`), which is how the commit phase (T11) records each contributing
+ * branch's provenance against the row that actually persists. Nothing ENDS a folded-away
+ * row — that is precisely why `id` is a commit-correctness choice and not a preference
+ * (see the module header's survivor rule).
  */
 export type MergedEdge = Readonly<{
   id: EdgeId;
@@ -400,13 +406,14 @@ function foldSets(
  * Orders two members of one fold set for the survivor pick: by edge id, then toward
  * the preferred branch, then by branch id.
  *
- * Members that tie on the edge id are the SAME ROW staged by several branches, so the
- * row that survives is settled either way and the remaining choice is only WHICH
- * branch's staged copy of it the fold reads its kind, window and survivor prop values
- * from. Preferring the preferred branch's copy is what lets {@link foldEdgeSet}
- * recognize a survivor as the incremental target's own row and keep its end verbatim;
- * the branch id then makes the order total, so the pick cannot depend on which copy
- * the caller listed first.
+ * Members that tie on the edge id are the SAME ROW staged by several branches (two
+ * branches creating one caller-chosen id), so the row that survives is settled either
+ * way and the remaining choice is only WHICH branch's staged copy of it the fold reads
+ * its kind, window and survivor prop values from. It goes to the preferred branch,
+ * agreeing with {@link pickSurvivor}'s candidate preference — which is where a
+ * preferred-branch copy is normally selected, so this clause only ever breaks a tie
+ * INSIDE a candidate class. The branch id then makes the order total, so the pick cannot
+ * depend on which copy the caller listed first.
  */
 function compareMembers(
   left: RepointedEdge,
@@ -579,8 +586,10 @@ function foldEdgeSet(
   // reconciler uses.
   //
   // A survivor from the PREFERRED branch keeps its own end verbatim when it
-  // HAS one: that member is the live incremental target's row, and a user
-  // branch never re-windows what the target already holds. When it has none
+  // HAS one: that member is the live incremental target's row — or, when the
+  // target also staged the inherited survivor, the end already reconciled FOR
+  // that row — and a user branch never re-windows what the target already
+  // holds, so neither is the fold's to move. When the survivor has none
   // there is no target window to protect, so the fold still resolves across
   // the set — otherwise a preferred survivor would silently swallow the
   // only end any branch claimed.

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -45,15 +45,25 @@ import { requireDefined } from "../utils/presence";
  * props happen to coincide with an inherited one's. Consequently a window claim
  * lands on the row its author touched.
  *
+ * SURVIVOR OF A FOLD (issue #395). A fold REWRITES the row it keeps and never
+ * deletes the rows that folded into it, so which member survives is a matter of
+ * commit correctness rather than taste: a survivor the target does not already hold
+ * would leave every committed member of the set live BESIDE its own replacement,
+ * carrying the props it had before the merge and never receiving the edit staged for
+ * it. So an INHERITED member wins survivorship whenever the set holds one — the edge
+ * analog of the node path's base-id-wins (design §6.4-C) — and only a set that is
+ * entirely branch-created falls back to the minimum edge id (see
+ * {@link pickSurvivor}). This is why {@link StagedEdge} carries its
+ * {@link StagedEdgeOrigin}.
+ *
  * Determinism: the dedupe is a pure function of the (unordered) staged-edge SET.
  * Group membership derives only from the staged endpoints and {@link canonicalOf} —
- * never from id sort order. Within a folded group the surviving edge id is the
- * lexicographically-minimal member id, property resolution uses only the captured
- * `branchRank`, and the output is sorted by dedupe key with the edge id as the
- * final tiebreaker (parallel edges can share every other component) — so
- * shuffling the input edges yields an identical result. Clusters are computed once
- * upstream (T8) and passed in as {@link canonicalOf}; this module never
- * re-clusters.
+ * never from id sort order. Within a folded group the survivor is chosen by origin
+ * and edge id alone, property resolution uses only the captured `branchRank`, and
+ * the output is sorted by dedupe key with the edge id as the final tiebreaker
+ * (parallel edges can share every other component) — so shuffling the input edges
+ * yields an identical result. Clusters are computed once upstream (T8) and passed in
+ * as {@link canonicalOf}; this module never re-clusters.
  */
 import { canonicalizeProps } from "./canonical-props";
 import type { ClusterResult } from "./clustering";
@@ -100,12 +110,33 @@ type DroppedEdge = Readonly<{
   reason: string;
 }>;
 
+/** {@link StagedEdgeOrigin} of a row the merge base already holds. */
+export const INHERITED_EDGE_ORIGIN = "inherited" as const;
+
+/** {@link StagedEdgeOrigin} of a row a branch created after the fork point. */
+export const BRANCH_CREATED_EDGE_ORIGIN = "branch-created" as const;
+
+/**
+ * Whether a staged edge's ROW already exists in the merge base, or was created on a
+ * branch. It is the diff BUCKET the staging phase (T7) put the edge in — a modified
+ * or re-windowed inherited edge is {@link INHERITED_EDGE_ORIGIN}, a new fork edge is
+ * {@link BRANCH_CREATED_EDGE_ORIGIN} — threaded through as data because nothing about
+ * an edge id reveals its origin (ids are opaque and may be caller-chosen, so
+ * re-deriving one from the id is not possible, not merely unwise).
+ *
+ * Survivor selection is the consumer: an inherited row is one the merge target
+ * already holds, and a fold must land on it (see {@link pickSurvivor}).
+ */
+type StagedEdgeOrigin =
+  typeof INHERITED_EDGE_ORIGIN | typeof BRANCH_CREATED_EDGE_ORIGIN;
+
 /**
  * One staged edge fed into the repoint phase: a new fork edge or a surviving
  * inherited edge. Carries the parsed props (NOT a JSON string) so the dedupe key
- * and the conflict union both operate on the canonical structure, and the
+ * and the conflict union both operate on the canonical structure, the
  * {@link BranchId} that contributed it so edge-property conflicts resolve on the
- * same stable branch order as node-property conflicts.
+ * same stable branch order as node-property conflicts, and its
+ * {@link StagedEdgeOrigin} so a fold survives onto a row the target already holds.
  *
  * The orchestrator (T11) builds these from `StagedNewEdge` / surviving
  * `StagedModifiedEdge` items (T7); this module needs no knowledge of the diff
@@ -114,6 +145,7 @@ type DroppedEdge = Readonly<{
 export type StagedEdge = Readonly<{
   id: EdgeId;
   kind: string;
+  origin: StagedEdgeOrigin;
   fromId: AnyNodeId;
   toId: AnyNodeId;
   fromKind: string;
@@ -129,7 +161,7 @@ export type StagedEdge = Readonly<{
    * Windows take no part in the dedupe key or the conflict union. `validFrom`
    * rides along with whichever edge survives a fold; `validTo` is instead
    * resolved across the folded set (see {@link repointEdges}), because an end is
-   * a monotone claim that must not be lost to an arbitrary min-id survivor pick.
+   * a monotone claim that must not be lost to the survivor pick.
    */
   validFrom?: string;
   validTo?: string;
@@ -137,9 +169,10 @@ export type StagedEdge = Readonly<{
 
 /**
  * A surviving merged edge after repoint + dedupe. `id` is the canonical survivor
- * of its fold set (the lexicographically-minimal contributing edge id);
- * `mergedIds` is every staged edge id that collapsed into it (always includes
- * `id`), so the commit phase (T11) knows which inherited edges to fold away.
+ * of its fold set (its inherited member, else its minimum contributing edge id — see
+ * {@link pickSurvivor}); `mergedIds` is every staged edge id that collapsed into it
+ * (always includes `id`), so the commit phase (T11) knows which inherited edges to
+ * fold away.
  */
 export type MergedEdge = Readonly<{
   id: EdgeId;
@@ -310,8 +343,11 @@ function sourcePairByRow(
  * pre-repoint RELATIONSHIP when they named the same `(from, to)` pair before
  * repointing. Repointing can collapse distinct relationships onto one identity, and
  * that is the collision the §6.3 set-collapse exists for — so ONE row per pre-repoint
- * pair (its minimum-id row, mirroring the min-id survivor rule) folds into a single
- * set. Every FURTHER row a pair authored is ordinary multigraph multiplicity and
+ * pair (its minimum-id row: which of a pair's rows REPRESENTS it needs only to be
+ * total and order-independent, since every row a pair authored commits either way)
+ * folds into a single set. Whether that set then lands on a committed row is
+ * {@link pickSurvivor}'s decision, not this partition's. Every FURTHER row a pair
+ * authored is ordinary multigraph multiplicity and
  * commits as its own parallel row: nothing enforces uniqueness on `(from, type, to)`,
  * so a merge that collapsed them would destroy multiplicity the branch author's
  * operation would have produced applied straight to the target.
@@ -361,27 +397,76 @@ function foldSets(
 }
 
 /**
- * Picks the canonical survivor edge of a fold set: the member with the
- * lexicographically-minimal edge id. Mirrors the node min-id canonical rule (T8)
- * so the surviving id is independent of input edge order. (`generateId()` is
- * nanoid — random, not time-prefixed — so min-id never leaks creation order.)
+ * Orders two members of one fold set for the survivor pick: by edge id, then toward
+ * the preferred branch, then by branch id.
+ *
+ * Members that tie on the edge id are the SAME ROW staged by several branches, so the
+ * row that survives is settled either way and the remaining choice is only WHICH
+ * branch's staged copy of it the fold reads its kind, window and survivor prop values
+ * from. Preferring the preferred branch's copy is what lets {@link foldEdgeSet}
+ * recognize a survivor as the incremental target's own row and keep its end verbatim;
+ * the branch id then makes the order total, so the pick cannot depend on which copy
+ * the caller listed first.
+ */
+function compareMembers(
+  left: RepointedEdge,
+  right: RepointedEdge,
+  preferredBranchId: BranchId | undefined,
+): number {
+  const byId = compareStrings(left.staged.id, right.staged.id);
+  if (byId !== 0) {
+    return byId;
+  }
+  const leftPreferred = left.staged.branchId === preferredBranchId;
+  const rightPreferred = right.staged.branchId === preferredBranchId;
+  if (leftPreferred !== rightPreferred) {
+    return leftPreferred ? -1 : 1;
+  }
+  return compareStrings(left.staged.branchId, right.staged.branchId);
+}
+
+/**
+ * Picks the canonical survivor edge of a fold set, enforcing INHERITED-WINS (issue
+ * #395) — the edge analog of the node path's base-id-wins (§6.4-C,
+ * `pickClusterSurvivor`), and a commit-correctness invariant for the same reason.
+ *
+ *   - an INHERITED member wins outright (the minimum-id one, for the rare set the
+ *     repoint built from several committed rows). A fold rewrites its survivor and
+ *     ends none of the rows folded into it, so a survivor the target does not hold
+ *     would leave the committed row live beside the new one that was meant to replace
+ *     it, with the edit staged for that committed row never written. Writing onto the
+ *     row the target already holds is what makes that outcome unreachable, so this
+ *     outranks the preferred-branch pick below: the incremental target's own new row
+ *     is equally live, but preferring it is precisely what let a committed row lose.
+ *   - otherwise every member is branch-created, nothing committed can be stranded,
+ *     and the minimum edge id survives — restricted to the preferred (incremental
+ *     target) branch's members when the set has any, so an incremental merge still
+ *     writes onto the target's row rather than beside it.
+ *
+ * Order-independent: origin and edge id are intrinsic to the staged set, and
+ * {@link compareMembers} is total. (`generateId()` is nanoid — random, not
+ * time-prefixed — so min-id never leaks creation order.)
  */
 function pickSurvivor(
   edges: readonly RepointedEdge[],
   preferredBranchId?: BranchId,
 ): RepointedEdge {
+  const inherited = edges.filter(
+    (edge) => edge.staged.origin === INHERITED_EDGE_ORIGIN,
+  );
   const preferred =
     preferredBranchId === undefined ?
       []
     : edges.filter((edge) => edge.staged.branchId === preferredBranchId);
-  const candidates = preferred.length > 0 ? preferred : edges;
-  let survivor = requireDefined(candidates[0]);
-  for (const candidate of candidates.slice(1)) {
-    if (candidate.staged.id < survivor.staged.id) {
-      survivor = candidate;
-    }
-  }
-  return survivor;
+  const candidates =
+    inherited.length > 0 ? inherited
+    : preferred.length > 0 ? preferred
+    : edges;
+  return requireDefined(
+    [...candidates].sort((left, right) =>
+      compareMembers(left, right, preferredBranchId),
+    )[0],
+  );
 }
 
 /**
@@ -482,14 +567,16 @@ function foldEdgeSet(
   const toId = idOf(survivor.toKey);
   const toKind = kindOf(survivor.toKey);
   // The survivor's lower bound rides along unchanged — a `validFrom` is the
-  // branch's authored start for the row we commit, and the set's members are
-  // the same edge as seen by different branches.
+  // branch's authored start for the row we commit. An INHERITED survivor carries
+  // none (its start is already committed and a merge never restates it), so a
+  // branch-created member's authored start does not migrate onto the committed row
+  // the fold lands on; only its END does, below.
   //
   // The END is folded across the set. When repoint/dedupe collapses several
   // DISTINCT edges into one survivor, an end claimed by a non-survivor would
-  // otherwise be discarded by the arbitrary min-id pick — a silent window
-  // loss — so the earliest claimed end wins, the same least-claim rule the
-  // inherited-window reconciler uses.
+  // otherwise be discarded by the survivor pick — a silent window loss — so the
+  // earliest claimed end wins, the same least-claim rule the inherited-window
+  // reconciler uses.
   //
   // A survivor from the PREFERRED branch keeps its own end verbatim when it
   // HAS one: that member is the live incremental target's row, and a user
@@ -580,10 +667,12 @@ function foldEdgeSet(
  * is a multigraph, so each of them commits as its own row (see {@link foldSets} and the
  * module header for the full rule and why identity, not props equality, decides it).
  *
- * The surviving edge of every folded set is the lexicographically-minimal
- * contributing edge id; its `mergedIds` lists every collapsed edge id. Output is
- * sorted by the full dedupe key plus the edge id, so the result is a pure function
- * of the unordered input set.
+ * The surviving edge of every folded set is its INHERITED member — the row the target
+ * already holds, so the fold writes onto it instead of beside it — falling back to the
+ * lexicographically-minimal contributing edge id for a set that is entirely
+ * branch-created ({@link pickSurvivor}). Its `mergedIds` lists every collapsed edge id.
+ * Output is sorted by the full dedupe key plus the edge id, so the result is a pure
+ * function of the unordered input set.
  *
  * @param stagedEdges The new + surviving-inherited edges to merge. Order does not
  *   affect the result. Props MUST already be parsed objects.

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -73,7 +73,12 @@ import {
   resolveEdgeDeleteModify,
 } from "./delete-modify";
 import type { MergedEdge, StagedEdge } from "./edge-repoint";
-import { buildCanonicalMap, repointEdges } from "./edge-repoint";
+import {
+  BRANCH_CREATED_EDGE_ORIGIN,
+  buildCanonicalMap,
+  INHERITED_EDGE_ORIGIN,
+  repointEdges,
+} from "./edge-repoint";
 import { BaseVersionMismatchError, describeCause, MergeError } from "./errors";
 import {
   assertIdentityEndpointsNotDeleted,
@@ -595,6 +600,13 @@ function indexNewNodesById(
  * `staging.modifiedEdges`. Staging each branch's full fork props separately would
  * make the repoint union treat unchanged-from-base fields as conflicts, dropping a
  * disjoint edit by another branch.
+ *
+ * Each edge's diff bucket is carried through as its staged ORIGIN
+ * ({@link INHERITED_EDGE_ORIGIN} / {@link BRANCH_CREATED_EDGE_ORIGIN}): the modified
+ * and re-windowed buckets hold rows the base already has, the new bucket holds rows a
+ * branch created. This is the ONLY place that distinction is known — the repoint phase
+ * needs it to fold onto a row the target holds, and an edge id says nothing about
+ * where the row came from.
  */
 function buildStagedEdges(
   staging: StagingSet,
@@ -616,6 +628,7 @@ function buildStagedEdges(
     staged.push({
       id: item.edge.id,
       kind: item.edge.kind,
+      origin: INHERITED_EDGE_ORIGIN,
       fromId: item.edge.fromId,
       toId: item.edge.toId,
       fromKind: item.edge.fromKind,
@@ -644,6 +657,7 @@ function buildStagedEdges(
     staged.push({
       id: item.edge.id,
       kind: item.edge.kind,
+      origin: INHERITED_EDGE_ORIGIN,
       fromId: item.edge.fromId,
       toId: item.edge.toId,
       fromKind: item.edge.fromKind,
@@ -668,6 +682,7 @@ function toStagedEdge(branchId: BranchId, item: StagedNewEdge): StagedEdge {
   return {
     id: item.edge.id,
     kind: item.edge.kind,
+    origin: BRANCH_CREATED_EDGE_ORIGIN,
     fromId: item.edge.fromId,
     toId: item.edge.toId,
     fromKind: item.edge.fromKind,

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -8,8 +8,10 @@ import type {
   StagedEdge,
 } from "../../src/graph-merge/edge-repoint";
 import {
+  BRANCH_CREATED_EDGE_ORIGIN,
   buildCanonicalMap,
   ENDPOINT_DELETED_DROP_REASON,
+  INHERITED_EDGE_ORIGIN,
   repointEdges,
 } from "../../src/graph-merge/edge-repoint";
 import {
@@ -55,7 +57,11 @@ function rank(): ReadonlyMap<typeof BRANCH_A, number> {
   return buildBranchRank([BRANCH_A, BRANCH_B], [BRANCH_A, BRANCH_B]);
 }
 
-/** Builds a staged edge with parsed props; defaults keep the call sites terse. */
+/**
+ * Builds a staged edge with parsed props; defaults keep the call sites terse. The
+ * origin defaults to BRANCH-CREATED, so a case says `inherited: true` exactly when the
+ * committed-row survivor rule is what it is about.
+ */
 function stagedEdge(
   args: Readonly<{
     id: string;
@@ -64,6 +70,7 @@ function stagedEdge(
     kind?: string;
     props?: Readonly<Record<string, JsonValue>>;
     branchId?: typeof BRANCH_A;
+    inherited?: boolean;
     validFrom?: string;
     validTo?: string;
   }>,
@@ -71,6 +78,10 @@ function stagedEdge(
   return {
     id: edgeId(args.id),
     kind: args.kind ?? "references",
+    origin:
+      args.inherited === true ?
+        INHERITED_EDGE_ORIGIN
+      : BRANCH_CREATED_EDGE_ORIGIN,
     fromId: nodeId(args.from),
     toId: nodeId(args.to),
     fromKind: "Doc",
@@ -941,6 +952,319 @@ describe("repointEdges fold scope (#393)", () => {
         rank(),
       );
       expect(projectEdges(result.edges)).toEqual(reference);
+    }
+  });
+});
+
+/**
+ * The survivor rule (issue #395): a fold lands on the row the merge TARGET already
+ * holds. A fold rewrites its survivor and ends none of the members that folded into
+ * it, so a survivor the target does not hold leaves every committed member live beside
+ * the row meant to replace it, still carrying its pre-merge props.
+ */
+describe("repointEdges survivor rule (#395)", () => {
+  // {a, b} collapse to canonical "a" (min id): the repoint-induced fold.
+  const collapse = buildCanonicalMap([clusterOf("a", "b")], (cluster) =>
+    minIdCanonical(cluster),
+  );
+
+  // Both orderings of the branch-created id against the inherited one. The min-id rule
+  // agreed with inherited-wins only in the second, so the LOW case is the regression
+  // and the HIGH case pins that the two orders now produce the same survivor.
+  describe.each([
+    { position: "BELOW", inheritedId: "edge-5", createdId: "edge-1" },
+    { position: "ABOVE", inheritedId: "edge-1", createdId: "edge-9" },
+  ])(
+    "a branch-created member whose id sorts $position the inherited one",
+    ({ inheritedId, createdId }) => {
+      it("folds onto the inherited row", () => {
+        const staged = [
+          stagedEdge({
+            id: inheritedId,
+            from: "x",
+            to: "a",
+            props: { weight: 1 },
+            inherited: true,
+          }),
+          stagedEdge({
+            id: createdId,
+            from: "x",
+            to: "b",
+            props: { weight: 2 },
+            branchId: BRANCH_B,
+          }),
+        ];
+
+        const result = repointEdges(
+          staged,
+          collapse,
+          new Set<MergeKey>(),
+          "flag",
+          rank(),
+        );
+
+        expect(
+          result.edges.map((edge) => ({
+            id: edge.id,
+            weight: edge.props["weight"],
+            mergedIds: edge.mergedIds.map((id) => id as string),
+          })),
+        ).toEqual([
+          {
+            id: inheritedId,
+            // "flag" keeps the survivor's value — now the committed row's edit.
+            weight: 1,
+            mergedIds: [inheritedId, createdId].sort((left, right) =>
+              lexicographic(left, right),
+            ),
+          },
+        ]);
+        // The report names the row that actually persists.
+        expect(
+          result.conflicts.map((conflict) => ({
+            entityId: conflict.entityId,
+            values: conflict.values.map((value) => value.value),
+          })),
+        ).toEqual([{ entityId: inheritedId, values: [1, 2] }]);
+      });
+    },
+  );
+
+  it("prefers an inherited row over the PREFERRED branch's own new row", () => {
+    // The incremental target's new row is live too, so the preferred-branch pick was
+    // never wrong about liveness — but it can only ever protect ONE of the two rows,
+    // and choosing it strands the committed one WITH the edit staged for it. So
+    // inherited-wins outranks it; the target's row folds in and keeps existing.
+    const staged = [
+      stagedEdge({
+        id: "edge-5",
+        from: "x",
+        to: "a",
+        props: { weight: 1 },
+        branchId: BRANCH_B,
+        inherited: true,
+      }),
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        branchId: BRANCH_A,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+      undefined,
+      BRANCH_A,
+    );
+
+    expect(result.edges.map((edge) => edge.id)).toEqual(["edge-5"]);
+    // The preferred branch still wins the PROPERTY it disagrees on: survivorship
+    // decides which row is written, the conflict policy what is written to it.
+    expect(result.edges[0]?.props["weight"]).toBe(2);
+  });
+
+  it("picks the minimum-id INHERITED member when the repoint folded several committed rows", () => {
+    // Three pre-repoint pairs, two of them committed rows. Only one row can be written
+    // per folded set, so the other committed row stays live — the residual the node
+    // path has too (§6.4-A keeps a cluster to ≤1 base member for exactly this reason).
+    // What the rule fixes is that the survivor is never the row nobody holds yet.
+    const staged = [
+      stagedEdge({
+        id: "edge-5",
+        from: "x",
+        to: "a",
+        props: { weight: 1 },
+        inherited: true,
+      }),
+      stagedEdge({
+        id: "edge-3",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        inherited: true,
+      }),
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "c",
+        props: { weight: 3 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      buildCanonicalMap([clusterOf("a", "b", "c")], (cluster) =>
+        minIdCanonical(cluster),
+      ),
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(
+      result.edges.map((edge) => ({
+        id: edge.id,
+        mergedIds: edge.mergedIds.map((id) => id as string),
+      })),
+    ).toEqual([{ id: "edge-3", mergedIds: ["edge-1", "edge-3", "edge-5"] }]);
+  });
+
+  it("keeps the minimum edge id when NO member is inherited", () => {
+    // Nothing committed is at stake, so the fallback is the unchanged min-id rule.
+    const staged = [
+      stagedEdge({ id: "edge-9", from: "x", to: "a", props: { weight: 1 } }),
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges.map((edge) => edge.id)).toEqual(["edge-2"]);
+    expect(result.conflicts.map((conflict) => conflict.entityId)).toEqual([
+      "edge-2",
+    ]);
+  });
+
+  it("lands a folded END on the inherited survivor and leaves its own start alone", () => {
+    // The end is a monotone claim and folds across the set either way; what changes is
+    // WHERE it lands. A branch-created member's authored START does not travel with it:
+    // the committed row already has the correct `validFrom` and a merge never restates
+    // one (the previous survivor, being a fresh row, needed it written).
+    const staged = [
+      stagedEdge({
+        id: "edge-5",
+        from: "x",
+        to: "a",
+        props: { weight: 1 },
+        inherited: true,
+      }),
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "b",
+        props: { weight: 1 },
+        branchId: BRANCH_B,
+        validFrom: "2020-01-01T00:00:00.000Z",
+        validTo: "2100-01-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]?.id).toBe("edge-5");
+    expect(result.edges[0]?.validFrom).toBeUndefined();
+    expect(result.edges[0]?.validTo).toBe("2100-01-01T00:00:00.000Z");
+  });
+
+  it("produces an identical result across shuffled input for mixed-origin groups", () => {
+    // Origin is intrinsic to the staged set, so a group holding both buckets — folded
+    // and parallel, one row staged by two branches — resolves identically whatever
+    // order the edges arrive in.
+    const staged = [
+      // One INHERITED row staged by both branches — the same row seen twice.
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "a",
+        props: { weight: 1 },
+        inherited: true,
+      }),
+      stagedEdge({
+        id: "edge-1",
+        from: "x",
+        to: "a",
+        props: { weight: 9 },
+        branchId: BRANCH_B,
+        inherited: true,
+      }),
+      // A branch-created parallel row on the same pair: multiplicity, not a fold.
+      stagedEdge({ id: "edge-4", from: "x", to: "a", props: { weight: 4 } }),
+      // A branch-created row the repoint brought onto those endpoints: this is the
+      // fold, and it lands on the inherited row.
+      stagedEdge({
+        id: "edge-2",
+        from: "x",
+        to: "b",
+        props: { weight: 2 },
+        branchId: BRANCH_B,
+      }),
+    ];
+
+    const reference = repointEdges(
+      staged,
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rank(),
+    );
+    expect(
+      reference.edges.map((edge) => ({
+        id: edge.id,
+        weight: edge.props["weight"],
+        mergedIds: edge.mergedIds.map((id) => id as string),
+      })),
+    ).toEqual([
+      {
+        id: "edge-1",
+        weight: 1,
+        mergedIds: ["edge-1", "edge-1", "edge-2"],
+      },
+      { id: "edge-4", weight: 4, mergedIds: ["edge-4"] },
+    ]);
+    expect(
+      reference.conflicts.map((conflict) => ({
+        entityId: conflict.entityId,
+        resolution: conflict.resolution,
+      })),
+    ).toEqual([{ entityId: "edge-1", resolution: 1 }]);
+
+    for (let seed = 1; seed <= 6; seed += 1) {
+      const result = repointEdges(
+        shuffled(staged, seed),
+        collapse,
+        new Set<MergeKey>(),
+        "flag",
+        rank(),
+      );
+      expect(projectEdges(result.edges)).toEqual(projectEdges(reference.edges));
+      expect(
+        result.conflicts.map((conflict) => ({
+          entityId: conflict.entityId,
+          property: conflict.property,
+          resolution: conflict.resolution,
+        })),
+      ).toEqual(
+        reference.conflicts.map((conflict) => ({
+          entityId: conflict.entityId,
+          property: conflict.property,
+          resolution: conflict.resolution,
+        })),
+      );
     }
   });
 });

--- a/packages/typegraph/tests/graph-merge/edge-survivor-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-survivor-merge.test.ts
@@ -61,7 +61,9 @@ const Encounter = defineNode("Encounter", {
   schema: z.object({ reason: z.string(), code: z.string() }),
 });
 const hadEncounter = defineEdge("hadEncounter", {
-  schema: z.object({ on: z.string() }),
+  // `note` is OPTIONAL so a fork can DELETE it: the commit resolves a folded inherited
+  // row against that row's base props, which only happens when the fold lands on it.
+  schema: z.object({ on: z.string(), note: z.string().optional() }),
   from: [Patient],
   to: [Encounter],
 });
@@ -104,6 +106,8 @@ const ENCOUNTER_REASON = "routine annual physical examination";
 const DUPLICATE_REASON = "routine annual physical examinations";
 
 const INHERITED_DATE = "2026-01-05";
+/** A base-only property, seeded when a case is about the fork DELETING one. */
+const BASE_NOTE = "seen at reception";
 /** What the branch edits the INHERITED edge's `on` to. */
 const EDITED_DATE = "2026-02-02";
 /** What the branch's own repointed edge says. */
@@ -137,6 +141,7 @@ type CommittedEdge = Readonly<{
   fromId: string;
   toId: string;
   on: unknown;
+  note: unknown;
   validTo: string | undefined;
 }>;
 
@@ -158,9 +163,10 @@ describe.each(backendMatrix())("edge fold survivorship [$name]", (entry) => {
 
   /**
    * A fork point holding one patient, one encounter, and ONE edge joining them — so
-   * every additional row a case ends up with is the merge's own doing.
+   * every additional row a case ends up with is the merge's own doing. `baseNote` seeds
+   * the optional edge property a fork can delete.
    */
-  async function seededForkPoint(): Promise<CareStore> {
+  async function seededForkPoint(baseNote?: string): Promise<CareStore> {
     const [store] = await createStoreWithSchema(careGraph, await makeBackend());
     await store.nodes.Patient.create({ name: "Ana Rivera" }, { id: "pat-1" });
     await store.nodes.Encounter.create(
@@ -170,7 +176,10 @@ describe.each(backendMatrix())("edge fold survivorship [$name]", (entry) => {
     await store.edges.hadEncounter.create(
       PATIENT,
       ENCOUNTER,
-      { on: INHERITED_DATE },
+      {
+        on: INHERITED_DATE,
+        ...(baseNote === undefined ? {} : { note: baseNote }),
+      },
       { id: INHERITED_EDGE },
     );
     return store;
@@ -201,6 +210,7 @@ describe.each(backendMatrix())("edge fold survivorship [$name]", (entry) => {
         fromId: row.from_id,
         toId: row.to_id,
         on: rowPropsToObject(row.props)["on"],
+        note: rowPropsToObject(row.props)["note"],
         validTo: canonicalizeDatabaseTimestamp(row.valid_to),
       }))
       .sort((left, right) =>
@@ -317,6 +327,48 @@ describe.each(backendMatrix())("edge fold survivorship [$name]", (entry) => {
       });
     },
   );
+
+  it("honors a fork's property DELETION on the committed row it folds onto", async () => {
+    // Edges are written with PATCH semantics, so a removed key only disappears when the
+    // commit resolves the write against the row's BASE props — which it looks up by the
+    // surviving edge id. A survivor the target did not hold has no such entry, so the
+    // deletion used to be dropped together with the row it was staged for; landing the
+    // fold on the inherited row is what makes it reachable.
+    const forkPoint = await seededForkPoint(BASE_NOTE);
+    const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
+    const branchA = await forkOf(forkPoint);
+    await branchA.store.edges.hadEncounter.update(INHERITED, {
+      on: EDITED_DATE,
+      note: undefined,
+    });
+    await branchA.store.nodes.Encounter.create(
+      { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
+      { id: DUPLICATE_ENCOUNTER.id },
+    );
+    await branchA.store.edges.hadEncounter.create(
+      PATIENT,
+      DUPLICATE_ENCOUNTER,
+      { on: BRANCH_DATE },
+      { id: "edge-1" },
+    );
+
+    unwrap(
+      await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [branchA],
+        options: resolveDuplicateEncounters(),
+      }),
+    );
+
+    expect(
+      (await liveEdges(target)).map((edge) => ({
+        id: edge.id,
+        on: edge.on,
+        note: edge.note,
+      })),
+    ).toEqual([{ id: INHERITED_EDGE, on: EDITED_DATE, note: undefined }]);
+  });
 
   it("lands a folded END on the committed row the branch ended", async () => {
     // The branch ends the inherited edge and authors a repointed edge that folds with

--- a/packages/typegraph/tests/graph-merge/edge-survivor-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-survivor-merge.test.ts
@@ -1,0 +1,370 @@
+/**
+ * End-to-end contract for EDGE FOLD SURVIVORSHIP through a merge (issue #395).
+ *
+ * A repoint-induced fold rewrites the one row it keeps and ends none of the rows that
+ * folded into it. Which member it keeps therefore decides whether the merge writes
+ * ONTO a row the target already holds or BESIDE it: with the survivor picked by
+ * minimum edge id, a branch-created row that happened to sort lower won, so the target
+ * ended up holding the committed row at its pre-merge props AND a new row carrying the
+ * merged result — two live rows for one folded relationship, with the edit staged for
+ * the committed row never written and `merged.edges` counting one.
+ *
+ * The rule is now inherited-wins, the edge analog of the node path's base-id-wins
+ * (design §6.4-C). These cases pin it end-to-end:
+ *
+ *   1. the inherited row survives whichever way the branch-created id sorts, so the
+ *      outcome no longer depends on id lexicographics;
+ *   2. the branch's edit lands on that row and no stale row is left beside it;
+ *   3. the report agrees with the store — `merged.edges`, the property conflict's
+ *      `entityId`, and the window resolution all name the row that persists;
+ *   4. it holds with and without a preferred branch, so it does not ride on the
+ *      incremental target's own survivor preference.
+ *
+ * Every case resolves a branch node against a COMMITTED one, because that is the only
+ * way a fold set can hold an inherited row: clustering under the public snapshot
+ * `merge()` runs over staged NEW nodes alone, so no committed endpoint is ever
+ * repointed there and an inherited edge only ever meets a branch edge that already
+ * named its endpoints — parallel rows, which #393 keeps apart.
+ *
+ * Runs on every backend in the matrix: what is asserted is the set of committed rows,
+ * and a per-dialect test would happily certify a divergence.
+ */
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  defineNodeIndex,
+} from "@nicia-ai/typegraph";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { rowPropsToObject } from "../../src/backend/types";
+import { asEdgeId } from "../../src/core/types";
+import { branch } from "../../src/graph-merge/branch";
+import {
+  mergeAgainstBase,
+  mergeIncremental,
+} from "../../src/graph-merge/merge";
+import { unwrap } from "../../src/graph-merge/result";
+import { enumerateAllEdges } from "../../src/graph-merge/state-diff";
+import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { canonicalizeDatabaseTimestamp } from "../../src/utils/date";
+import { backendMatrix, getStoreBackend } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string() }),
+});
+const Encounter = defineNode("Encounter", {
+  schema: z.object({ reason: z.string(), code: z.string() }),
+});
+const hadEncounter = defineEdge("hadEncounter", {
+  schema: z.object({ on: z.string() }),
+  from: [Patient],
+  to: [Encounter],
+});
+
+/**
+ * The block key identity resolution works over: a declared, NON-unique index on
+ * `code`, so a branch may stage a near-duplicate encounter carrying the committed
+ * one's code (a unique constraint would refuse it in the branch store itself).
+ */
+const encounterCode = defineNodeIndex(Encounter, {
+  name: "encounter_code_idx",
+  fields: ["code"],
+});
+
+const careGraph = defineGraph({
+  id: "edge-survivor-care",
+  nodes: { Patient: { type: Patient }, Encounter: { type: Encounter } },
+  edges: {
+    hadEncounter: { type: hadEncounter, from: [Patient], to: [Encounter] },
+  },
+  indexes: [encounterCode],
+});
+type CareGraph = typeof careGraph;
+type CareStore = Store<CareGraph>;
+
+const PATIENT = { kind: "Patient", id: "pat-1" } as const;
+const ENCOUNTER = { kind: "Encounter", id: "enc-1" } as const;
+/** The near-duplicate encounter a branch stages; it resolves onto `enc-1`. */
+const DUPLICATE_ENCOUNTER = { kind: "Encounter", id: "enc-2" } as const;
+/** The inherited edge present at the fork point — the row the target holds. */
+const INHERITED_EDGE = "edge-5";
+const INHERITED = asEdgeId<typeof hadEncounter>(INHERITED_EDGE);
+const BRANCH_A = asBranchId("survivor-branch-a");
+const TARGET_BRANCH = asBranchId("survivor-target");
+const BRANCH_ORDER = [BRANCH_A];
+
+const ENCOUNTER_CODE = "code-1";
+const ENCOUNTER_REASON = "routine annual physical examination";
+/** Dice trigram ≈ 0.96 against `ENCOUNTER_REASON`, so the two resolve as one. */
+const DUPLICATE_REASON = "routine annual physical examinations";
+
+const INHERITED_DATE = "2026-01-05";
+/** What the branch edits the INHERITED edge's `on` to. */
+const EDITED_DATE = "2026-02-02";
+/** What the branch's own repointed edge says. */
+const BRANCH_DATE = "2026-03-11";
+/** In the FUTURE: `validFrom` defaults to creation and an inverted window is
+ *  refused, so an authorable end must be after that instant. */
+const END = "2100-01-01T00:00:00.000Z";
+
+/**
+ * The identity resolution every case needs: the branch's near-duplicate encounter
+ * resolves against the committed one through the declared block index, so the edge
+ * the branch authored onto it repoints onto the endpoints the inherited edge holds.
+ */
+function resolveDuplicateEncounters(): MergeOptions<CareGraph> {
+  return {
+    resolve: {
+      Encounter: {
+        blockIndex: "encounter_code_idx",
+        similarity: { kind: "fulltext", fields: ["reason"] },
+        threshold: 0.85,
+      },
+    },
+    onPropertyConflict: "flag",
+    branchOrder: BRANCH_ORDER,
+  };
+}
+
+/** One committed `hadEncounter` row, reduced to what these cases assert. */
+type CommittedEdge = Readonly<{
+  id: string;
+  fromId: string;
+  toId: string;
+  on: unknown;
+  validTo: string | undefined;
+}>;
+
+describe.each(backendMatrix())("edge fold survivorship [$name]", (entry) => {
+  let cleanups: (() => Promise<void>)[] = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.reverse()) {
+      await cleanup();
+    }
+    cleanups = [];
+  });
+
+  async function makeBackend(): Promise<GraphBackend> {
+    const fixture = await entry.make();
+    cleanups.push(fixture.cleanup);
+    return fixture.backend;
+  }
+
+  /**
+   * A fork point holding one patient, one encounter, and ONE edge joining them — so
+   * every additional row a case ends up with is the merge's own doing.
+   */
+  async function seededForkPoint(): Promise<CareStore> {
+    const [store] = await createStoreWithSchema(careGraph, await makeBackend());
+    await store.nodes.Patient.create({ name: "Ana Rivera" }, { id: "pat-1" });
+    await store.nodes.Encounter.create(
+      { reason: ENCOUNTER_REASON, code: ENCOUNTER_CODE },
+      { id: "enc-1" },
+    );
+    await store.edges.hadEncounter.create(
+      PATIENT,
+      ENCOUNTER,
+      { on: INHERITED_DATE },
+      { id: INHERITED_EDGE },
+    );
+    return store;
+  }
+
+  async function forkOf(
+    forkPoint: CareStore,
+    id = BRANCH_A,
+  ): Promise<GraphBranch<CareGraph>> {
+    return unwrap(
+      await branch<CareGraph>(forkPoint, () => makeBackend(), { id }),
+    );
+  }
+
+  /** Every LIVE `hadEncounter` row, id-sorted. */
+  async function liveEdges(
+    store: CareStore,
+  ): Promise<readonly CommittedEdge[]> {
+    const rows = await enumerateAllEdges(
+      getStoreBackend(store),
+      store.graphId,
+      "hadEncounter",
+    );
+    return rows
+      .filter((row) => row.deleted_at === undefined)
+      .map((row) => ({
+        id: row.id,
+        fromId: row.from_id,
+        toId: row.to_id,
+        on: rowPropsToObject(row.props)["on"],
+        validTo: canonicalizeDatabaseTimestamp(row.valid_to),
+      }))
+      .sort((left, right) =>
+        left.id < right.id ? -1
+        : left.id > right.id ? 1
+        : 0,
+      );
+  }
+
+  // Both orderings of the branch-created id against the inherited "edge-5". The
+  // min-id rule agreed with inherited-wins only in the second, so the LOW id is the
+  // issue's reproduction and the HIGH id — which passed by luck — pins that the two
+  // orders now agree.
+  describe.each([
+    { position: "sorts BEFORE", branchEdgeId: "edge-1" },
+    { position: "sorts AFTER", branchEdgeId: "edge-9" },
+  ])(
+    "a repointed branch edge whose id $position the inherited one",
+    ({ branchEdgeId }) => {
+      /**
+       * The branch edits the inherited edge and, separately, authors an edge onto a
+       * near-duplicate encounter that resolves onto the inherited edge's endpoint. The
+       * two edges become one relationship, so the merge folds them.
+       */
+      async function stageFoldOnto(
+        forkPoint: CareStore,
+      ): Promise<GraphBranch<CareGraph>> {
+        const branchA = await forkOf(forkPoint);
+        await branchA.store.edges.hadEncounter.update(INHERITED, {
+          on: EDITED_DATE,
+        });
+        await branchA.store.nodes.Encounter.create(
+          { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
+          { id: DUPLICATE_ENCOUNTER.id },
+        );
+        await branchA.store.edges.hadEncounter.create(
+          PATIENT,
+          DUPLICATE_ENCOUNTER,
+          { on: BRANCH_DATE },
+          { id: branchEdgeId },
+        );
+        return branchA;
+      }
+
+      it("folds onto the committed row, leaving no row beside it", async () => {
+        const forkPoint = await seededForkPoint();
+        const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
+        const branchA = await stageFoldOnto(forkPoint);
+
+        const report = unwrap(
+          await mergeIncremental<CareGraph>({
+            forkPoint,
+            target,
+            branches: [branchA],
+            options: resolveDuplicateEncounters(),
+          }),
+        );
+
+        expect(
+          report.resolutions.map((resolution) => resolution.canonicalId),
+        ).toEqual(["enc-1"]);
+        // ONE row: the committed one, at the props the merge resolved. With the
+        // branch-created id sorting lower this used to be two rows — the committed
+        // edge still at INHERITED_DATE beside a new row holding the merged result.
+        expect(
+          (await liveEdges(target)).map((edge) => ({
+            id: edge.id,
+            toId: edge.toId,
+            on: edge.on,
+          })),
+        ).toEqual([{ id: INHERITED_EDGE, toId: "enc-1", on: EDITED_DATE }]);
+        // ...and the report describes exactly that row.
+        expect(report.merged.edges).toBe(1);
+        expect(
+          report.conflicts
+            .filter((conflict) => conflict.kind === "hadEncounter")
+            .map((conflict) => ({
+              entityId: conflict.entityId,
+              property: conflict.property,
+              values: conflict.values.map((value) => value.value),
+            })),
+        ).toEqual([
+          {
+            entityId: INHERITED_EDGE,
+            property: "on",
+            values: [EDITED_DATE, BRANCH_DATE],
+          },
+        ]);
+      });
+
+      it("folds onto the committed row with no preferred branch", async () => {
+        // The same fold through the new-vs-base scope, whose target is the fork point
+        // itself and which names no preferred branch. Nothing about inherited-wins
+        // rides on the preferred-branch pick, so the outcome is the same one.
+        const forkPoint = await seededForkPoint();
+        const branchA = await stageFoldOnto(forkPoint);
+
+        const report = unwrap(
+          await mergeAgainstBase(
+            forkPoint,
+            [branchA],
+            resolveDuplicateEncounters(),
+          ),
+        );
+
+        expect(
+          (await liveEdges(forkPoint)).map((edge) => ({
+            id: edge.id,
+            toId: edge.toId,
+            on: edge.on,
+          })),
+        ).toEqual([{ id: INHERITED_EDGE, toId: "enc-1", on: EDITED_DATE }]);
+        expect(report.merged.edges).toBe(1);
+      });
+    },
+  );
+
+  it("lands a folded END on the committed row the branch ended", async () => {
+    // The branch ends the inherited edge and authors a repointed edge that folds with
+    // it. The end is resolved across the fold set either way; what the survivor rule
+    // decides is WHICH row receives it. Picking the branch-created row put the end on
+    // a brand-new row and left the ended one open — and the report said otherwise.
+    const forkPoint = await seededForkPoint();
+    const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
+    const branchA = await forkOf(forkPoint);
+    await branchA.store.edges.hadEncounter.update(
+      INHERITED,
+      {},
+      {
+        validTo: END,
+      },
+    );
+    await branchA.store.nodes.Encounter.create(
+      { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
+      { id: DUPLICATE_ENCOUNTER.id },
+    );
+    await branchA.store.edges.hadEncounter.create(
+      PATIENT,
+      DUPLICATE_ENCOUNTER,
+      { on: BRANCH_DATE },
+      { id: "edge-1" },
+    );
+
+    const report = unwrap(
+      await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [branchA],
+        options: resolveDuplicateEncounters(),
+      }),
+    );
+
+    expect(
+      (await liveEdges(target)).map((edge) => ({
+        id: edge.id,
+        validTo: edge.validTo,
+      })),
+    ).toEqual([{ id: INHERITED_EDGE, validTo: END }]);
+    // The window resolution named the inherited row all along — now the store agrees.
+    expect(
+      report.validityEnds.map((resolution) => ({
+        id: resolution.id,
+        validTo: resolution.validTo,
+      })),
+    ).toEqual([{ id: INHERITED_EDGE, validTo: END }]);
+  });
+});


### PR DESCRIPTION
The repoint/dedupe fold picked its survivor by minimum edge id. A fold **rewrites** the row it keeps and ends none of the rows folded into it, so when a branch-created id sorted below a committed one, the merge wrote the branch's row as a new edge and left the committed edge live beside it at its pre-merge props — two live rows for one folded relationship, the edit staged for the committed row never written, and `merged.edges` counting one of them. Which of the two a caller got depended on an id sort, so it was not behavior anyone could depend on in the first place.

Survivorship is now **inherited-wins**: a fold set holding a row the target already holds lands on it, and only a wholly branch-created set falls back to the minimum edge id. This is the edge analog of the node path's base-id-wins (§6.4-C) and it is a commit-correctness invariant for the same reason — writing onto the row that is already there is what makes "a new row beside the live committed row it was supposed to replace" unreachable by construction, rather than something a later cleanup pass has to notice. Per #393's adjudication the fix is survivor preference only; nothing deletes a live target row.

## Why it outranks the preferred branch

The incremental target's own new row is equally live, so the existing preferred-branch pick was never wrong about liveness — but it can only ever protect *one* row of a mixed set, and choosing it strands the committed one together with the edit staged for it. So inherited-wins sits above it: the target's row folds in and keeps existing, and the preferred branch still wins the property values it disagrees on. Survivorship decides which row is written; the conflict policy decides what is written to it.

A set can hold several inherited members only where the repoint brought two *committed* rows onto one identity — the minimum-id one survives and the other stays live, the same residual the node path avoids by keeping a cluster to at most one base member (§6.4-A). Because that guard also means no committed endpoint is ever repointed, reaching it takes a fork that re-pointed an edge id onto an endpoint the merge then resolves onto another committed row's; the residual is unchanged by this PR. What the rule removes is the case where the survivor is a row nobody holds yet.

## How origin reaches the fold

Each staged edge carries its diff bucket as an origin: `modified` and re-windowed are inherited, `new` is branch-created. `buildStagedEdges` is the only place that distinction exists, and an edge id is opaque and may be caller-chosen, so it is threaded as data rather than re-derived downstream.

## Identity in reports and provenance

The surviving edge id in `PropertyConflict.entityId`, window reports and provenance is consequently the inherited row's id whenever a fold involved one. That is deliberate and strictly better on both counts: it names the row that actually persists, and it no longer moves with branch-created id lexicographics. Everything reading the survivor id follows automatically — provenance records are keyed off `mergedIds`, the window resolution was already keyed on the inherited identity (the store now agrees with it), and `inheritedEdgeBaseProps` now finds the survivor, so a fork's property *deletions* on a folded inherited row are honored where they used to be dropped with the row.

## Determinism

Origin and edge id are intrinsic to the staged set, so group outcomes stay a pure function of the unordered input plus `canonicalOf`. The member order within a set is also now total: members tying on the edge id are the same row staged by several branches (two of them creating one caller-chosen id), and the tie breaks toward the preferred branch — agreeing with the candidate preference that normally selects it — and then by branch id, so which staged copy the fold reads its kind, window and survivor prop values from no longer depends on input order.

## Window

An inherited survivor carries no `validFrom`: the committed row's start is already correct and a merge never restates it, so a branch-created member's authored start does not migrate onto the row the fold lands on. The end still folds across the set as before, which is the point — the row the branch actually ended is now the row that receives the end.

The end travelling without the start does mean a folded-away member whose window was entirely historical can hand the committed row an end that precedes its start. That state is already reachable from a plain `update(id, {}, { validTo })` — the write layer does not order `validFrom` against `validTo` at all — so the fold is a new route to it rather than a new state, and the guard belongs at the write layer where every route passes.

## Behavior change

Released as a minor. Merges whose fold mixed a committed row with a branch-created one now update that committed row instead of inserting a second one beside it, and the surviving edge id they report changes accordingly.

Closes #395

