### PR TITLE
fix(graph-merge): record each provenance contribution once, so the persisted count is the rows written

### DIFF
--- a/.changeset/distinct-provenance-contributions.md
+++ b/.changeset/distinct-provenance-contributions.md
@@ -13,9 +13,11 @@ staged copy — so a row staged by several branches re-offered each of its
 branches once per copy. The tuple is exactly the sidecar row's identity, so
 those re-observations were never new information: they inflated
 `provenancePersisted.count`, and because a single `bulkUpsertById` batch cannot
-create the same id twice, a merge that touched an inherited edge failed the
-whole best-effort persist and reported the failure as a warning with no rows
-written.
+create the same id twice, the over-count was the milder half: with
+`persistProvenance: true`, a merge in which a single branch modified one
+inherited edge failed the whole best-effort persist, so `provenancePersisted`
+came back absent, a `provenance persistence failed …` warning was reported, and
+NO provenance rows were written at all.
 
 Contributions are now collapsed at the single recording funnel, so the record
 list, the in-memory `provenance.byBranch` index and the reported count all

--- a/.changeset/distinct-provenance-contributions.md
+++ b/.changeset/distinct-provenance-contributions.md
@@ -1,0 +1,25 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+graph-merge: record each provenance contribution once, so the persisted count is
+the rows actually written
+
+Several planning phases legitimately observe the same
+`(role, canonical, branch, source)` contribution. An inherited edge is credited
+once when its modification survives delete/modify and again when the repoint
+fold reads it as a source, and a fold set's `mergedIds` carries one entry per
+staged copy — so a row staged by several branches re-offered each of its
+branches once per copy. The tuple is exactly the sidecar row's identity, so
+those re-observations were never new information: they inflated
+`provenancePersisted.count`, and because a single `bulkUpsertById` batch cannot
+create the same id twice, a merge that touched an inherited edge failed the
+whole best-effort persist and reported the failure as a warning with no rows
+written.
+
+Contributions are now collapsed at the single recording funnel, so the record
+list, the in-memory `provenance.byBranch` index and the reported count all
+speak about distinct contributions. `persistProvenanceRecords` additionally
+collapses records that hash to one id before the batch, which makes its
+documented "row count written" true for any caller's record list. Every
+genuinely distinct contributing branch is still credited.

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -104,6 +104,7 @@ import {
 import type { NormalizedMergeOptions } from "./options";
 import { normalizeMergeOptions } from "./options";
 import {
+  contributionKey,
   openProvenanceStore,
   persistProvenanceRecords,
   provenanceGraphId,
@@ -819,17 +820,17 @@ function planMerge<G extends GraphDef>(
 ): MergePlan<G> {
   const identity = planIdentityChanges(staging, storedIdentityRowsById);
   const provenanceRecords: ProvenanceRecord[] = [];
-  // The contribution tuples already recorded. Several phases legitimately observe
-  // the SAME contribution: an inherited edge is credited once when its
-  // modification survives delete/modify and again when the repoint folds it, and a
-  // fold set's `mergedIds` lists one entry per staged COPY, so a row staged by
-  // several branches re-offers each of its branches once per copy. The tuple below
-  // is exactly the sidecar's node identity (`provenanceNodeId`), so re-recording it
-  // is never new information — it is the same row written twice, which inflates
-  // `provenancePersisted.count` (and, because `bulkUpsertById` cannot create the
-  // same id twice in one batch, fails the whole best-effort persist). Collapsing at
-  // this single funnel keeps the record list, the in-memory index and the reported
-  // count all speaking about DISTINCT contributions.
+  // The contributions already recorded, keyed by `contributionKey` — the sidecar
+  // row's own identity, so a repeat is the same row written twice and never new
+  // information. Several phases legitimately observe the SAME contribution: an
+  // inherited edge is credited once when its modification survives delete/modify
+  // and again when the repoint folds it, and a fold set's `mergedIds` lists one
+  // entry per staged COPY, so a row staged by several branches re-offers each of
+  // its branches once per copy. Repeats inflate `provenancePersisted.count` and,
+  // because `bulkUpsertById` cannot create the same id twice in one batch, fail the
+  // whole best-effort persist. Collapsing at this single funnel keeps the record
+  // list, the in-memory index and the reported count all speaking about DISTINCT
+  // contributions.
   const recordedContributions = new Set<string>();
   // Per-branch trust weights for the `"provenanceWeighted"` policy, or empty when
   // the caller supplied none (then the policy falls back to the stable branch order).
@@ -846,24 +847,19 @@ function planMerge<G extends GraphDef>(
     if (branchId === preferredBranchId) {
       return;
     }
-    const contribution = JSON.stringify([
+    const record: ProvenanceRecord = {
       role,
-      canonicalKind,
       canonicalId,
+      canonicalKind,
       branchId,
       sourceId,
-    ]);
-    if (recordedContributions.has(contribution)) {
+    };
+    const key = contributionKey(record);
+    if (recordedContributions.has(key)) {
       return;
     }
-    recordedContributions.add(contribution);
-    provenanceRecords.push({
-      role,
-      canonicalId,
-      canonicalKind,
-      branchId,
-      sourceId,
-    });
+    recordedContributions.add(key);
+    provenanceRecords.push(record);
   };
 
   // (4) cluster over every staged new-node id + every base member id (so a forced

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -819,6 +819,18 @@ function planMerge<G extends GraphDef>(
 ): MergePlan<G> {
   const identity = planIdentityChanges(staging, storedIdentityRowsById);
   const provenanceRecords: ProvenanceRecord[] = [];
+  // The contribution tuples already recorded. Several phases legitimately observe
+  // the SAME contribution: an inherited edge is credited once when its
+  // modification survives delete/modify and again when the repoint folds it, and a
+  // fold set's `mergedIds` lists one entry per staged COPY, so a row staged by
+  // several branches re-offers each of its branches once per copy. The tuple below
+  // is exactly the sidecar's node identity (`provenanceNodeId`), so re-recording it
+  // is never new information — it is the same row written twice, which inflates
+  // `provenancePersisted.count` (and, because `bulkUpsertById` cannot create the
+  // same id twice in one batch, fails the whole best-effort persist). Collapsing at
+  // this single funnel keeps the record list, the in-memory index and the reported
+  // count all speaking about DISTINCT contributions.
+  const recordedContributions = new Set<string>();
   // Per-branch trust weights for the `"provenanceWeighted"` policy, or empty when
   // the caller supplied none (then the policy falls back to the stable branch order).
   const weights = options.provenanceWeights ?? EMPTY_WEIGHTS;
@@ -834,6 +846,17 @@ function planMerge<G extends GraphDef>(
     if (branchId === preferredBranchId) {
       return;
     }
+    const contribution = JSON.stringify([
+      role,
+      canonicalKind,
+      canonicalId,
+      branchId,
+      sourceId,
+    ]);
+    if (recordedContributions.has(contribution)) {
+      return;
+    }
+    recordedContributions.add(contribution);
     provenanceRecords.push({
       role,
       canonicalId,

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -136,6 +136,12 @@ export async function provenanceNodeId(
  * deterministic id (re-running the same merge is a no-op upsert, never a
  * duplicate). Returns the row count written. The caller wraps this for best-effort
  * behavior — a failure here must not fail an already-committed merge.
+ *
+ * Records that hash to the SAME id are collapsed before the batch: the id is the
+ * contribution's identity, so they are one row by definition — and a single
+ * `bulkUpsertById` batch cannot create the same id twice. Collapsing here is what
+ * makes the returned number the rows actually written for ANY caller, whatever
+ * shape its record list arrived in.
  */
 export async function persistProvenanceRecords(
   store: Store<ProvenanceGraph>,
@@ -145,7 +151,7 @@ export async function persistProvenanceRecords(
   if (records.length === 0) {
     return 0;
   }
-  const items = await Promise.all(
+  const identified = await Promise.all(
     records.map(async (record) => ({
       id: await provenanceNodeId(targetGraphId, record),
       props: {
@@ -158,6 +164,11 @@ export async function persistProvenanceRecords(
       },
     })),
   );
+  const itemsById = new Map<string, (typeof identified)[number]>();
+  for (const item of identified) {
+    itemsById.set(item.id, item);
+  }
+  const items = [...itemsById.values()];
   await store.nodes.Provenance.bulkUpsertById(items);
   return items.length;
 }

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -104,6 +104,24 @@ const ID_SEPARATOR = "\0";
 const ID_DIGEST_BYTES = 16;
 
 /**
+ * The tuple that IDENTIFIES a contribution: everything {@link provenanceNodeId}
+ * hashes except the target graph id, which is fixed for one merge. Two records
+ * agreeing on it are one sidecar row by definition, so a caller that collapses on
+ * this key collapses exactly what the row identity would have collapsed —
+ * `canonicalKind` is part of it because two same-id canonicals of different kinds
+ * are different entities under the `(kind, id)` identity model.
+ */
+export function contributionKey(record: ProvenanceRecord): string {
+  return [
+    record.role,
+    record.canonicalKind,
+    record.canonicalId,
+    record.branchId,
+    record.sourceId,
+  ].join(ID_SEPARATOR);
+}
+
+/**
  * Deterministic provenance node id: a hash of the contribution tuple, so
  * re-persisting the same contribution UPSERTS the same row (idempotent re-runs).
  *
@@ -116,17 +134,7 @@ export async function provenanceNodeId(
   targetGraphId: string,
   record: ProvenanceRecord,
 ): Promise<string> {
-  const tuple = [
-    targetGraphId,
-    record.role,
-    // canonicalKind is part of node identity: two contributions to different-kind
-    // canonicals that share a bare id (e.g. base Patient:x and Encounter:x) must NOT
-    // hash to the same sidecar row and clobber each other (the (kind,id) identity model).
-    record.canonicalKind,
-    record.canonicalId,
-    record.branchId,
-    record.sourceId,
-  ].join(ID_SEPARATOR);
+  const tuple = [targetGraphId, contributionKey(record)].join(ID_SEPARATOR);
   const digest = await sha256Hex(tuple, ID_DIGEST_BYTES);
   return `prov_${digest}`;
 }

--- a/packages/typegraph/tests/graph-merge/provenance-store.test.ts
+++ b/packages/typegraph/tests/graph-merge/provenance-store.test.ts
@@ -10,7 +10,12 @@
  *      (with the original fork-local `sourceId`s);
  *   3. edges are tagged too (`role: "edge"`);
  *   4. re-persisting is idempotent (deterministic ids → upsert, no duplicates);
- *   5. it is OFF by default (no `provenancePersisted`, no rows).
+ *   5. it is OFF by default (no `provenancePersisted`, no rows);
+ *   6. a contribution the pipeline observes SEVERAL times (an edge id staged by two
+ *      branches, an inherited edge modification seen by both delete/modify and the
+ *      repoint fold) is persisted and counted ONCE per distinct
+ *      `(role, canonical, branch, source)` — while every genuinely distinct
+ *      contributing branch is still credited.
  */
 import type { GraphBackend, Store } from "@nicia-ai/typegraph";
 import {
@@ -22,8 +27,10 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { asEdgeId } from "../../src/core/types";
 import { branch } from "../../src/graph-merge/branch";
 import { merge } from "../../src/graph-merge/merge";
+import type { ProvenanceNode } from "../../src/graph-merge/provenance-store";
 import {
   openProvenanceStore,
   persistProvenanceRecords,
@@ -58,6 +65,46 @@ type CareGraph = typeof careGraph;
 
 const BRANCH_A = asBranchId("provider-a");
 const BRANCH_B = asBranchId("provider-b");
+
+/** Committed endpoints both branches fork with, so their edges share an identity. */
+const COMMITTED_PATIENT = "pat-committed";
+const COMMITTED_ENCOUNTER = "enc-committed";
+const COMMITTED_BIRTH_DATE = "1961-11-02";
+const SHARED_EDGE = "edge-shared";
+const SHARED_EDGE_ID = asEdgeId<typeof hadEncounter>(SHARED_EDGE);
+
+/**
+ * The contribution identity a persisted row stands for — the exact tuple
+ * {@link provenanceNodeId} hashes into the row's id. Two rows agreeing on it are
+ * the same contribution, so a duplicate is what an over-count is MADE of.
+ */
+function contributionOf(node: ProvenanceNode): string {
+  return JSON.stringify([
+    node.role,
+    node.canonicalKind,
+    node.canonicalId,
+    node.branchId,
+    node.sourceId,
+  ]);
+}
+
+/** Edge contributions in a stable, readable order (persisted ids are hashes). */
+function edgeContributions(
+  nodes: readonly ProvenanceNode[],
+): readonly Readonly<{
+  branchId: string;
+  canonicalId: string;
+  sourceId: string;
+}>[] {
+  return nodes
+    .filter((node) => node.role === "edge")
+    .map((node) => ({
+      branchId: node.branchId,
+      canonicalId: node.canonicalId,
+      sourceId: node.sourceId,
+    }))
+    .sort((left, right) => left.branchId.localeCompare(right.branchId));
+}
 
 /** Fulltext name match (no embedder): "Anna Rivera" ~ "Ana Rivera" clears 0.85. */
 function provMergeOptions(persistProvenance: boolean): MergeOptions<CareGraph> {
@@ -147,6 +194,148 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
 
     return { backend, base, branches: [branchA, branchB] };
   }
+
+  /**
+   * A base holding the Patient and Encounter both branches fork with, so every
+   * `hadEncounter` edge they stage lands on the SAME committed endpoints and
+   * therefore in one repoint fold set. With `withEdge` the joining edge is
+   * committed too, so both branches INHERIT it instead of authoring it.
+   */
+  async function materializeSharedEndpoints(
+    withEdge: boolean,
+  ): Promise<Fixture> {
+    const backend = await makeBackend();
+    const [base] = await createStoreWithSchema(careGraph, backend);
+    await base.nodes.Patient.bulkCreate([
+      {
+        id: COMMITTED_PATIENT,
+        props: { name: "Nadia Okonkwo", birthDate: COMMITTED_BIRTH_DATE },
+      },
+    ]);
+    await base.nodes.Encounter.bulkCreate([
+      { id: COMMITTED_ENCOUNTER, props: { reason: "intake" } },
+    ]);
+    if (withEdge) {
+      await base.edges.hadEncounter.bulkCreate([
+        {
+          id: SHARED_EDGE,
+          from: { kind: "Patient", id: COMMITTED_PATIENT },
+          to: { kind: "Encounter", id: COMMITTED_ENCOUNTER },
+          props: { on: "2024-01-01" },
+        },
+      ]);
+    }
+    const branchA = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_A }),
+    );
+    const branchB = unwrap(
+      await branch<CareGraph>(base, () => makeBackend(), { id: BRANCH_B }),
+    );
+    return { backend, base, branches: [branchA, branchB] };
+  }
+
+  it("counts an edge id staged by two branches once per branch, not once per staged copy", async () => {
+    cleanups = [];
+    const { base, branches } = await materializeSharedEndpoints(false);
+    const [branchA, branchB] = branches;
+
+    // Both branches author the SAME caller-chosen edge id between the same
+    // committed endpoints, so the fold set holds one member per branch and its
+    // `mergedIds` names that id TWICE. Each member re-offers the id's full branch
+    // set, so the recording loop sees all FOUR (branch, source) pairs though only
+    // two contributions exist.
+    for (const [contributor, on] of [
+      [requireDefined(branchA), "2024-02-01"],
+      [requireDefined(branchB), "2024-02-02"],
+    ] as const) {
+      await contributor.store.edges.hadEncounter.bulkCreate([
+        {
+          id: SHARED_EDGE,
+          from: { kind: "Patient", id: COMMITTED_PATIENT },
+          to: { kind: "Encounter", id: COMMITTED_ENCOUNTER },
+          props: { on },
+        },
+      ]);
+    }
+
+    const report = unwrap(
+      await merge<CareGraph>(base, branches, provMergeOptions(true)),
+    );
+    expect(report.warnings).toEqual([]);
+
+    // Read the sidecar back — the count is only meaningful against the rows that
+    // actually landed, never against the report's own arithmetic.
+    const persisted = await (
+      await openProvenanceStore(base)
+    ).nodes.Provenance.find();
+    expect(new Set(persisted.map((node) => contributionOf(node))).size).toBe(
+      persisted.length,
+    );
+    expect(report.provenancePersisted?.count).toBe(persisted.length);
+
+    // Both branches are still credited: the collapse drops re-observations of one
+    // contribution, never a second contributor.
+    expect(edgeContributions(persisted)).toEqual([
+      {
+        branchId: BRANCH_A,
+        canonicalId: SHARED_EDGE,
+        sourceId: SHARED_EDGE,
+      },
+      {
+        branchId: BRANCH_B,
+        canonicalId: SHARED_EDGE,
+        sourceId: SHARED_EDGE,
+      },
+    ]);
+  });
+
+  it("counts an inherited edge modified by two branches once per branch", async () => {
+    cleanups = [];
+    const { base, branches } = await materializeSharedEndpoints(true);
+    const [branchA, branchB] = branches;
+
+    // An inherited edge modification is observed TWICE: once as a surviving
+    // delete/modify contribution (per branch) and again as the repoint fold's
+    // source (for the branch reconcile kept). The reconcile winner is therefore
+    // offered to the recording loop twice.
+    await requireDefined(branchA).store.edges.hadEncounter.update(
+      SHARED_EDGE_ID,
+      {
+        on: "2024-03-01",
+      },
+    );
+    await requireDefined(branchB).store.edges.hadEncounter.update(
+      SHARED_EDGE_ID,
+      {
+        on: "2024-03-02",
+      },
+    );
+
+    const report = unwrap(
+      await merge<CareGraph>(base, branches, provMergeOptions(true)),
+    );
+    expect(report.warnings).toEqual([]);
+
+    const persisted = await (
+      await openProvenanceStore(base)
+    ).nodes.Provenance.find();
+    expect(new Set(persisted.map((node) => contributionOf(node))).size).toBe(
+      persisted.length,
+    );
+    expect(report.provenancePersisted?.count).toBe(persisted.length);
+    expect(edgeContributions(persisted)).toEqual([
+      {
+        branchId: BRANCH_A,
+        canonicalId: SHARED_EDGE,
+        sourceId: SHARED_EDGE,
+      },
+      {
+        branchId: BRANCH_B,
+        canonicalId: SHARED_EDGE,
+        sourceId: SHARED_EDGE,
+      },
+    ]);
+  });
 
   it("opens from a backend and graph id without the target GraphDef", async () => {
     cleanups = [];

--- a/packages/typegraph/tests/graph-merge/provenance-store.test.ts
+++ b/packages/typegraph/tests/graph-merge/provenance-store.test.ts
@@ -13,9 +13,15 @@
  *   5. it is OFF by default (no `provenancePersisted`, no rows);
  *   6. a contribution the pipeline observes SEVERAL times (an edge id staged by two
  *      branches, an inherited edge modification seen by both delete/modify and the
- *      repoint fold) is persisted and counted ONCE per distinct
- *      `(role, canonical, branch, source)` — while every genuinely distinct
- *      contributing branch is still credited.
+ *      repoint fold — with two contributing branches or just one) is persisted and
+ *      counted ONCE per distinct `(role, canonical, branch, source)` — while every
+ *      genuinely distinct contributing branch is still credited;
+ *   7. `persistProvenanceRecords` collapses hash-identical records for callers that
+ *      reach it without going through a merge.
+ *
+ * A final backend-independent block pins the row identity itself: the literal id a
+ * contribution hashes to, and that no identifying field is missing from the key
+ * every collapse is keyed on.
  */
 import type { GraphBackend, Store } from "@nicia-ai/typegraph";
 import {
@@ -32,9 +38,11 @@ import { branch } from "../../src/graph-merge/branch";
 import { merge } from "../../src/graph-merge/merge";
 import type { ProvenanceNode } from "../../src/graph-merge/provenance-store";
 import {
+  contributionKey,
   openProvenanceStore,
   persistProvenanceRecords,
   provenanceGraphId,
+  provenanceNodeId,
 } from "../../src/graph-merge/provenance-store";
 import { isOk, unwrap } from "../../src/graph-merge/result";
 import type { GraphBranch, MergeOptions } from "../../src/graph-merge/types";
@@ -337,6 +345,67 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
     ]);
   });
 
+  it("credits a lone branch's inherited-edge modification once, seen by two phases", async () => {
+    cleanups = [];
+    const { base, branches } = await materializeSharedEndpoints(true);
+    const onlyBranch = requireDefined(branches[0]);
+
+    // The MINIMAL trigger, and the one a single-contributor merge hits in ordinary
+    // use: no second branch is needed for the same contribution to be observed
+    // twice — delete/modify credits the modification, then the repoint fold reads
+    // it as a source. One contribution, so one row and a count of one.
+    await onlyBranch.store.edges.hadEncounter.update(SHARED_EDGE_ID, {
+      on: "2024-04-04",
+    });
+
+    const report = unwrap(
+      await merge<CareGraph>(base, [onlyBranch], provMergeOptions(true)),
+    );
+    expect(report.warnings).toEqual([]);
+
+    const persisted = await (
+      await openProvenanceStore(base)
+    ).nodes.Provenance.find();
+    expect(new Set(persisted.map((node) => contributionOf(node))).size).toBe(
+      persisted.length,
+    );
+    expect(report.provenancePersisted?.count).toBe(persisted.length);
+    expect(edgeContributions(persisted)).toEqual([
+      {
+        branchId: BRANCH_A,
+        canonicalId: SHARED_EDGE,
+        sourceId: SHARED_EDGE,
+      },
+    ]);
+  });
+
+  it("collapses hash-identical records offered to persistProvenanceRecords directly", async () => {
+    cleanups = [];
+    const backend = await makeBackend();
+    const [base] = await createStoreWithSchema(careGraph, backend);
+    const provStore = await openProvenanceStore(base);
+
+    // The exported helper takes ANY record list, so a caller reaching it without
+    // going through a merge can offer one contribution twice as two objects. They
+    // hash to a single id, and a `bulkUpsertById` batch cannot CREATE the same id
+    // twice — so the helper must collapse them into the one row it reports rather
+    // than throw on a sidecar that does not hold the row yet.
+    const record = {
+      role: "node",
+      canonicalId: COMMITTED_PATIENT,
+      canonicalKind: "Patient",
+      branchId: BRANCH_A,
+      sourceId: "pat-fork-local",
+    } as const;
+    const written = await persistProvenanceRecords(provStore, base.graphId, [
+      record,
+      { ...record },
+    ]);
+
+    expect(written).toBe(1);
+    expect(await provStore.nodes.Provenance.find()).toHaveLength(1);
+  });
+
   it("opens from a backend and graph id without the target GraphDef", async () => {
     cleanups = [];
     const { backend, base, branches } = await materialize();
@@ -444,5 +513,38 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
 
     const provStore = await openProvenanceStore(base);
     expect(await provStore.nodes.Provenance.find()).toHaveLength(0);
+  });
+});
+
+describe("provenance row identity", () => {
+  const record = {
+    role: "node",
+    canonicalId: "pat-canonical",
+    canonicalKind: "Patient",
+    branchId: BRANCH_A,
+    sourceId: "pat-fork",
+  } as const;
+
+  it("hashes a contribution to a stable id across versions", async () => {
+    // Pinned as a literal because the id is a CROSS-VERSION contract: rows in a
+    // sidecar written by an earlier release are re-upserted rather than orphaned
+    // and duplicated only while the same contribution keeps hashing to this id.
+    expect(await provenanceNodeId("care-graph", record)).toBe(
+      "prov_4d724f22030e40e5603682bd44f6ca0d",
+    );
+  });
+
+  it("keeps every identifying field in the key collapses are keyed on", () => {
+    // A key NARROWER than the row identity would silently merge two genuinely
+    // distinct contributions, which is the one way a collapse can lose data.
+    const keys = new Set([
+      contributionKey(record),
+      contributionKey({ ...record, role: "edge" }),
+      contributionKey({ ...record, canonicalKind: "Encounter" }),
+      contributionKey({ ...record, canonicalId: "other-canonical" }),
+      contributionKey({ ...record, branchId: BRANCH_B }),
+      contributionKey({ ...record, sourceId: "other-fork" }),
+    ]);
+    expect(keys.size).toBe(6);
   });
 });


### PR DESCRIPTION
`provenancePersisted.count` was derived from the plan's record list, and the planning phases legitimately observe the same `(role, canonical, branch, source)` contribution more than once. An inherited edge is credited when its modification survives delete/modify and again when the repoint fold reads it as a source; and a fold set's `mergedIds` carries one entry per staged **copy**, so a row staged by several branches re-offered each of its branches once per copy. A two-branch fold set therefore produced four records for two contributions.

## It was not only the count

The issue reasoned that the deterministic sidecar id plus `bulkUpsertById` collapsed the duplicates, leaving stored provenance correct. It does not: a single `bulkUpsertById` batch cannot **create** the same id twice (the batch's repeated-id handling registers a running value only on the update path, so a repeated id for a not-yet-existing row queues two creates). The duplicates made the whole best-effort persist throw, so a merge that so much as modified one inherited edge came back with `provenancePersisted` absent, a `provenance persistence failed …` warning, and **zero** rows written.

One branch modifying one inherited edge is enough — no second contributor is required — which is why the count was the milder half of this. That is what the new tests fail with before the fix; the over-count itself is 4 records for 2 contributions in one case and 3 for 2 in the other, measured with the throw removed.

## The fix

Contributions are collapsed at `recordProvenance` — the single funnel every phase already went through — keyed on exactly the tuple `provenanceNodeId` hashes. So the plan's record list, the in-memory `provenance.byBranch` index and the reported count all speak about distinct contributions, and no phase has to know which other phase already saw one. Deduping at the source rather than counting post-collapse also means the duplicate hashing and the duplicate upsert payload never happen, and it fixes the one number the issue names along with the record list every future consumer of it will read. The in-memory index was already set-collapsed, so it is unchanged.

"Keyed on exactly the tuple `provenanceNodeId` hashes" holds by construction rather than by inspection: that tuple lives in one place, `contributionKey`, called by both the id hash and the dedupe. A field added to `ProvenanceRecord` can no longer reach the row id without reaching the collapse key — a key narrower than the row identity being the one way a collapse can lose data. The joined string is byte-identical to the previous flat join, so persisted ids are unchanged.

`persistProvenanceRecords` additionally collapses records that hash to one id before the batch. That is not belt-and-braces for the merge (whose list is now duplicate-free) but the contract of an exported helper callers reach without going through the merge at all: it documents its return as the row count written, and its ids exist to make re-persisting an upsert rather than a throw.

## Tests

Both duplicate sources are pinned on the cross-backend merge matrix, in `tests/graph-merge/provenance-store.test.ts`: an edge id staged by two branches, an inherited edge modified by two branches, and a lone branch modifying one inherited edge — the minimal trigger, and the case an ordinary single-contributor merge hits. Each asserts the reported count against a fresh read of the sidecar rows rather than the report's own arithmetic, that no two rows carry the same contribution tuple, and the exact contribution set — so a collapse that silently dropped a genuine second contributor fails them just as the duplicate did.

Two further cases pin what a merge cannot reach on its own. `persistProvenanceRecords` is fed one contribution twice as two objects on a sidecar that does not hold the row yet — the create path that throws, and the only case that pins the helper's collapse by itself, since the staged-copy tests above still pass with the funnel dedupe removed. And the row identity is pinned directly: the literal id a contribution hashes to (a cross-version contract — an existing sidecar's rows are re-upserted rather than orphaned only while that id is stable), plus a check that no identifying field is missing from the key the collapse is keyed on.

## Two gaps found in passing, not fixed here

- `bulkUpsertById` throwing `Node already exists` for a repeated id whose row does not exist yet contradicts the batch-local last-write-wins its own comments describe for repeated ids. It is a store-layer defect worth its own change; this PR only removes the merge's exposure to it.
- A branch whose only change to an inherited edge is its valid-window end receives no provenance credit at all — `buildStagedEdges` skips its copy because another branch already staged the identity, even though the end it authored is what gets committed. A coverage gap rather than an over-count, so out of scope here.

Closes #399
