### PR TITLE
fix(graph-merge): credit the branch that authored a merged row's end-of-validity

### DIFF
--- a/.changeset/window-author-provenance-credit.md
+++ b/.changeset/window-author-provenance-credit.md
@@ -17,7 +17,13 @@ The credit now comes from the window resolution itself, which is the only phase
 that knows whose claim was committed. It credits exactly the branches whose claim
 IS the resolved end — a claim that lost the least-claim rule contributed nothing
 to the committed row, and remains visible in `MergeReport.validityEnds` under
-`claimedBy` — and the staged carrier for a window-only edge is now chosen from
-those authors, so the row can no longer be credited to a branch whose later end
-the merge discarded. A branch that both edited a row's properties and moved its
-window stays one contribution.
+`claimedBy`. A branch that both edited a row's properties and moved its window
+stays one contribution.
+
+The staged copy that carries a window-only ending is no longer credited for
+carrying it: that copy exists only to give the ending a row to write, its
+properties are the base's, and the branch holding it is whichever sorted first —
+possibly one whose claim the merge discarded. Which branch carries the row is
+left exactly as it was, because that branch also labels the base's properties in
+the repoint fold's property union, where a relabelled contribution can change
+which value a fold commits. Merge outcomes are unchanged; only the provenance is.

--- a/.changeset/window-author-provenance-credit.md
+++ b/.changeset/window-author-provenance-credit.md
@@ -1,0 +1,23 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+graph-merge: credit the branch that authored a merged row's end-of-validity
+
+Ending a row's validity is authored state, but a branch whose only change to a
+row was its window could contribute the instant the merge committed and still be
+absent from the merge's provenance. An identity is staged once, so a branch that
+merely moved an inherited edge's window had its staged copy skipped whenever
+another branch's property edit already staged that edge — and the provenance for
+edges is derived from the staged copies. Nodes were worse: a window change had no
+provenance path at all, so a window-only node ending was credited to nobody even
+when no other branch touched the row.
+
+The credit now comes from the window resolution itself, which is the only phase
+that knows whose claim was committed. It credits exactly the branches whose claim
+IS the resolved end — a claim that lost the least-claim rule contributed nothing
+to the committed row, and remains visible in `MergeReport.validityEnds` under
+`claimedBy` — and the staged carrier for a window-only edge is now chosen from
+those authors, so the row can no longer be credited to a branch whose later end
+the merge discarded. A branch that both edited a row's properties and moved its
+window stays one contribution.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -595,7 +595,8 @@ authored state, so its author is a contributor to that row in
 the only thing that branch changed. Credit follows the *committed* end: when
 several branches end a row differently, only the branches whose claim equals the
 written instant are credited, while `validityEnds[].claimedBy` still names every
-claimant, winning or not.
+claimant, winning or not. An ending a deletion absorbed commits nothing, so it
+credits nobody.
 
 Because an ending is not a modification, `onDeleteModifyConflict` never sees
 one: a row whose *only* change is its window loses to a concurrent deletion even

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -446,7 +446,10 @@ A typical operator loop: auto-apply when `conflicts` and
 
 ## Provenance
 
-Provenance answers *which branch contributed each merged node and edge*.
+Provenance answers *which branch contributed each merged node and edge*. A
+contribution is anything a branch authored into the committed row — the
+properties it staged, the modification that survived, or the end-of-validity the
+merge applied.
 
 - **Report-only (default, `provenance: true`)** — `report.provenance.byBranch(id)`
   returns the `{ nodeIds, edgeIds }` that branch contributed. In-memory; it
@@ -585,6 +588,14 @@ explains the whole contract:
 The earliest-end rule is fixed, not a policy knob: it is commutative and
 associative, so the merge stays order-independent, and `onPropertyConflict`
 never sees a property your schema does not have.
+
+**The branch that authored the committed end is credited.** An ending is
+authored state, so its author is a contributor to that row in
+`report.provenance` and in the durable sidecar — even when moving the window is
+the only thing that branch changed. Credit follows the *committed* end: when
+several branches end a row differently, only the branches whose claim equals the
+written instant are credited, while `validityEnds[].claimedBy` still names every
+claimant, winning or not.
 
 Because an ending is not a modification, `onDeleteModifyConflict` never sees
 one: a row whose *only* change is its window loses to a concurrent deletion even

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -608,16 +608,23 @@ function indexNewNodesById(
  * branch created. This is the ONLY place that distinction is known — the repoint phase
  * needs it to fold onto a row the target holds, and an edge id says nothing about
  * where the row came from.
+ *
+ * `windowOnlyCarried` names the identities staged ONLY to carry an ending. Their
+ * `branchId` is a write vehicle rather than a contribution (see the loop below),
+ * which the provenance fold must know so it does not credit it.
  */
 function buildStagedEdges(
   staging: StagingSet,
   modifiedEdges: readonly StagedModifiedEdge[],
   edgeValidityEnds: ReadonlyMap<MergeKey, string>,
-  edgeWindowCredits: ReadonlyMap<MergeKey, readonly BranchId[]>,
   edgeDeletions: ReadonlyMap<MergeKey, string>,
-): readonly StagedEdge[] {
+): Readonly<{
+  edges: readonly StagedEdge[];
+  windowOnlyCarried: ReadonlySet<MergeKey>;
+}> {
   const staged: StagedEdge[] = [];
   const stagedIdentities = new Set<MergeKey>();
+  const windowOnlyCarried = new Set<MergeKey>();
   for (const items of staging.newEdgesByKind.values()) {
     for (const item of items) {
       staged.push(toStagedEdge(item.branchId, item));
@@ -646,24 +653,25 @@ function buildStagedEdges(
   // construction — the write carries the window and leaves the row's content
   // alone. Finally-deleted edges are excluded: deletion absorbs the ending.
   //
-  // Only a branch that AUTHORED the resolved end may carry the row: the staged
-  // copy's `branchId` is what the repoint fold credits as the edge's contributing
-  // branch, so letting a branch whose later claim LOST the least-claim rule carry
-  // it would credit a branch whose statement the merge discarded. One winner
-  // always exists (the end is some branch's claim), and the staging order is
-  // `(kind, id, branch)`, so which winner carries the row is deterministic.
+  // WHICH branch's copy carries it is arbitrary — the first in the staging order,
+  // `(kind, id, branch)` — and deliberately stays that way. That `branchId` is an
+  // input to the repoint fold's PROPERTY union, where the copy contributes the
+  // base's props under its label, so choosing the carrier by anything else (the
+  // authored ending, say) silently moves which value a fold commits. It is
+  // therefore recorded as window-only carried instead, and the ending's author is
+  // credited from the resolution rather than from whoever carried the row.
   for (const item of staging.windowedEdges) {
     const identity = mergeKeyOf(item.edge);
     const validTo = edgeValidityEnds.get(identity);
     if (
       validTo === undefined ||
       stagedIdentities.has(identity) ||
-      edgeDeletions.has(identity) ||
-      !(edgeWindowCredits.get(identity) ?? []).includes(item.branchId)
+      edgeDeletions.has(identity)
     ) {
       continue;
     }
     stagedIdentities.add(identity);
+    windowOnlyCarried.add(identity);
     staged.push({
       id: item.edge.id,
       kind: item.edge.kind,
@@ -677,7 +685,7 @@ function buildStagedEdges(
       validTo,
     });
   }
-  return staged;
+  return { edges: staged, windowOnlyCarried };
 }
 
 /**
@@ -1264,11 +1272,10 @@ function planMerge<G extends GraphDef>(
     identityContext,
     identityNodeUniverse,
   );
-  const stagedEdges = buildStagedEdges(
+  const { edges: stagedEdges, windowOnlyCarried } = buildStagedEdges(
     staging,
     reconciledEdgeModifications.survivingModifications,
     validWindows.edgeEnds,
-    validWindows.edgeCredits,
     edgeDeletions,
   );
   // An edge id can be staged by MORE THAN ONE branch (e.g. an inherited edge
@@ -1283,12 +1290,20 @@ function planMerge<G extends GraphDef>(
   // edge the repoint decides, exactly as a modifying branch is credited, and a
   // `Set` keeps a branch that both edited props and moved the window one
   // contributor.
+  //
+  // A WINDOW-ONLY CARRIER is the exception: that copy exists only to give the
+  // ending a row to ride on, its props are the base's, and the branch holding it
+  // is whichever sorted first — possibly one whose later claim the merge
+  // discarded. Crediting it would name a branch that put nothing in the committed
+  // row, so the row's credit comes from the resolution alone.
   const stagedEdgeBranches = new Map<string, Set<BranchId>>();
   for (const staged of stagedEdges) {
+    const identity = mergeKeyOf(staged);
     const branches = stagedEdgeBranches.get(staged.id) ?? new Set<BranchId>();
-    branches.add(staged.branchId);
-    for (const branchId of validWindows.edgeCredits.get(mergeKeyOf(staged)) ??
-      []) {
+    if (!windowOnlyCarried.has(identity)) {
+      branches.add(staged.branchId);
+    }
+    for (const branchId of validWindows.edgeCredits.get(identity) ?? []) {
       branches.add(branchId);
     }
     stagedEdgeBranches.set(staged.id, branches);

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -613,6 +613,7 @@ function buildStagedEdges(
   staging: StagingSet,
   modifiedEdges: readonly StagedModifiedEdge[],
   edgeValidityEnds: ReadonlyMap<MergeKey, string>,
+  edgeWindowCredits: ReadonlyMap<MergeKey, readonly BranchId[]>,
   edgeDeletions: ReadonlyMap<MergeKey, string>,
 ): readonly StagedEdge[] {
   const staged: StagedEdge[] = [];
@@ -644,13 +645,21 @@ function buildStagedEdges(
   // have nothing to ride on. Its props are the fork's, which equal the base's by
   // construction — the write carries the window and leaves the row's content
   // alone. Finally-deleted edges are excluded: deletion absorbs the ending.
+  //
+  // Only a branch that AUTHORED the resolved end may carry the row: the staged
+  // copy's `branchId` is what the repoint fold credits as the edge's contributing
+  // branch, so letting a branch whose later claim LOST the least-claim rule carry
+  // it would credit a branch whose statement the merge discarded. One winner
+  // always exists (the end is some branch's claim), and the staging order is
+  // `(kind, id, branch)`, so which winner carries the row is deterministic.
   for (const item of staging.windowedEdges) {
     const identity = mergeKeyOf(item.edge);
     const validTo = edgeValidityEnds.get(identity);
     if (
       validTo === undefined ||
       stagedIdentities.has(identity) ||
-      edgeDeletions.has(identity)
+      edgeDeletions.has(identity) ||
+      !(edgeWindowCredits.get(identity) ?? []).includes(item.branchId)
     ) {
       continue;
     }
@@ -1150,6 +1159,45 @@ function planMerge<G extends GraphDef>(
     preferredBranchId,
   );
 
+  // (6-window provenance) credit the branches that AUTHORED a committed node
+  // ending. Ending a row is authored state, but a branch whose only change to a
+  // node is its window is neither a cluster member nor a surviving modification,
+  // and the write that carries the ending names no branch — so without this the
+  // branch whose claim the commit applied is absent from the provenance sidecar
+  // entirely (issue #402). The credit comes from the resolution because only the
+  // resolution knows whose claim won; a claim that LOST the least-claim rule is
+  // not in `nodeCredits` and is not credited, since provenance records
+  // contribution to COMMITTED state.
+  //
+  // Edges take the same credit through `stagedEdgeBranches` below, where the
+  // repoint's surviving edge id is known.
+  //
+  // A branch that edited the node's props AND moved its window is already
+  // credited with this exact record by the modification loop above; re-recording
+  // it would count one sidecar row twice. A record whose `sourceId` differs from
+  // its canonical is a DIFFERENT contribution (a fork id folded into a survivor)
+  // and never stands in for the in-place one.
+  const creditedNodeIdentities = new Map<MergeKey, Set<BranchId>>();
+  for (const record of provenanceRecords) {
+    if (record.role !== "node" || record.sourceId !== record.canonicalId) {
+      continue;
+    }
+    const identity = mergeKey(record.canonicalKind, record.canonicalId);
+    const credited =
+      creditedNodeIdentities.get(identity) ?? new Set<BranchId>();
+    credited.add(record.branchId);
+    creditedNodeIdentities.set(identity, credited);
+  }
+  for (const [identity, branchIds] of validWindows.nodeCredits) {
+    for (const branchId of branchIds) {
+      if (creditedNodeIdentities.get(identity)?.has(branchId) === true) {
+        continue;
+      }
+      const id = idOf(identity);
+      recordProvenance("node", branchId, id, kindOf(identity), id);
+    }
+  }
+
   // (7) opt-in ontology type reconciliation over the public-closure glue. Inputs
   // (incl. base member kinds) were collected per cluster in the canonicalize loop.
   const reconciliation = reconcileTypes(
@@ -1220,19 +1268,30 @@ function planMerge<G extends GraphDef>(
     staging,
     reconciledEdgeModifications.survivingModifications,
     validWindows.edgeEnds,
+    validWindows.edgeCredits,
     edgeDeletions,
   );
   // An edge id can be staged by MORE THAN ONE branch (e.g. an inherited edge
   // modified by two branches), so map each id to the SET of contributing branches.
   // A plain last-write Map would credit only one branch's provenance.
+  //
+  // A branch that authored the row's committed END is a contributor too, and the
+  // staged copy cannot name it: an identity is staged ONCE, so a branch whose only
+  // change is the window has no copy of its own whenever another branch's props
+  // edit already staged the row (issue #402). Folding the window authors in here —
+  // from the resolution that chose the end — credits them against the SURVIVING
+  // edge the repoint decides, exactly as a modifying branch is credited, and a
+  // `Set` keeps a branch that both edited props and moved the window one
+  // contributor.
   const stagedEdgeBranches = new Map<string, Set<BranchId>>();
   for (const staged of stagedEdges) {
-    const branches = stagedEdgeBranches.get(staged.id);
-    if (branches === undefined) {
-      stagedEdgeBranches.set(staged.id, new Set([staged.branchId]));
-    } else {
-      branches.add(staged.branchId);
+    const branches = stagedEdgeBranches.get(staged.id) ?? new Set<BranchId>();
+    branches.add(staged.branchId);
+    for (const branchId of validWindows.edgeCredits.get(mergeKeyOf(staged)) ??
+      []) {
+      branches.add(branchId);
     }
+    stagedEdgeBranches.set(staged.id, branches);
   }
   const deletedNodeIdSet = new Set<MergeKey>(nodeDeletions.keys());
   const repoint = repointEdges<G>(

--- a/packages/typegraph/src/graph-merge/valid-window.ts
+++ b/packages/typegraph/src/graph-merge/valid-window.ts
@@ -59,6 +59,24 @@
  * — deleting and ending are both "no longer true", and the stronger statement
  * wins. The callers pass the finally-deleted identity sets so the ending is
  * dropped with the row.
+ *
+ * WHO GETS PROVENANCE CREDIT
+ *
+ * An ending is authored state, so the branch that authored it contributed to the
+ * committed row and must appear in the merge's provenance — even when the ending
+ * is its ONLY change to that row (issue #402). This module is the authority on
+ * that: it decided which claim was committed, so it also emits the credit
+ * ({@link ValidWindowResolution.nodeCredits} / `edgeCredits`), rather than leaving
+ * the commit to re-derive it from staging and lose the claim that won.
+ *
+ * Credit goes to exactly the branches whose claim IS the resolved end — the `min`
+ * winner and anyone who tied with it. Provenance records contribution to
+ * COMMITTED state, and a branch whose later end lost the least-claim rule
+ * contributed none of it; its claim is still visible in the report
+ * (`ValidityEndResolution.claimedBy` names every claimant, winning or not), which
+ * is where "who asked for what" belongs. The alternative — crediting every
+ * claimant — would make provenance answer "who spoke about this row" instead, a
+ * different question that the report already answers.
  */
 import { requireDefined } from "../utils/presence";
 import {
@@ -92,6 +110,16 @@ export type ValidWindowResolution = Readonly<{
   nodeEnds: ReadonlyMap<MergeKey, string>;
   /** `(kind, id) -> validTo` for every inherited EDGE the commit must end. */
   edgeEnds: ReadonlyMap<MergeKey, string>;
+  /**
+   * `(kind, id) -> the branches that AUTHORED the resolved node end`: the
+   * claimants whose claim equals {@link ValidWindowResolution.nodeEnds}, sorted
+   * and deduped. The provenance credit for a window change, keyed identically to
+   * `nodeEnds` so the two are read together. Never empty for an identity present
+   * in `nodeEnds` — an end exists only because some branch claimed it.
+   */
+  nodeCredits: ReadonlyMap<MergeKey, readonly BranchId[]>;
+  /** The edge half of {@link ValidWindowResolution.nodeCredits}. */
+  edgeCredits: ReadonlyMap<MergeKey, readonly BranchId[]>;
   resolutions: readonly ValidityEndResolution[];
   dropped: readonly DroppedItem[];
 }>;
@@ -188,6 +216,7 @@ function resolvePopulation(
   dropItem: (id: string) => DroppedItem,
 ): Readonly<{
   ends: ReadonlyMap<MergeKey, string>;
+  credits: ReadonlyMap<MergeKey, readonly BranchId[]>;
   resolutions: readonly ValidityEndResolution[];
   dropped: readonly DroppedItem[];
 }> {
@@ -206,6 +235,7 @@ function resolvePopulation(
   }
 
   const ends = new Map<MergeKey, string>();
+  const credits = new Map<MergeKey, readonly BranchId[]>();
   const resolutions: ValidityEndResolution[] = [];
   const dropped: DroppedItem[] = [];
 
@@ -245,6 +275,14 @@ function resolvePopulation(
       continue;
     }
     ends.set(identity, resolved);
+    // The AUTHORS of the committed end: every branch whose claim is the resolved
+    // instant, including the ones that tied with it. A later claim lost the
+    // least-claim rule and put nothing into the committed row, so it earns no
+    // credit — it stays visible as a claimant in the resolution below.
+    credits.set(
+      identity,
+      claimingBranches(claims.filter((claim) => claim.validTo === resolved)),
+    );
     const first = requireDefined(group[0]);
     resolutions.push({
       entity,
@@ -260,6 +298,7 @@ function resolvePopulation(
   // would not be a total order and the output would depend on insertion order.
   return {
     ends,
+    credits,
     resolutions: resolutions.sort((left, right) =>
       compareMergeKeys(
         mergeKey(left.kind, left.id),
@@ -331,6 +370,8 @@ export function resolveValidWindows(
   return {
     nodeEnds: nodes.ends,
     edgeEnds: edges.ends,
+    nodeCredits: nodes.credits,
+    edgeCredits: edges.credits,
     resolutions: [...nodes.resolutions, ...edges.resolutions],
     dropped: [...nodes.dropped, ...edges.dropped],
   };

--- a/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
@@ -24,7 +24,11 @@
  *
  * A genuine repoint-induced collapse still folds — that fold is what the dedupe
  * exists for. Its end-to-end contract is `self-edge-collapse.test.ts` and
- * `valid-window-merge.test.ts`; its mechanics are `edge-repoint.test.ts`.
+ * `valid-window-merge.test.ts`; its mechanics are `edge-repoint.test.ts`. One
+ * property of that fold is pinned here because only this fixture reaches it: the
+ * staged copy carrying a window-only ending votes in the fold's property union
+ * under its branch's label, so which branch carries the row must stay independent
+ * of who authored the ending (issue #402).
  *
  * Runs on every backend in the matrix: edge multiplicity is asserted through the
  * committed rows, and a per-dialect test would happily certify a divergence.
@@ -97,6 +101,20 @@ const SECOND_INHERITED = asEdgeId<typeof hadEncounter>(SECOND_INHERITED_EDGE);
 const BRANCH_A = asBranchId("parallel-branch-a");
 const TARGET_BRANCH = asBranchId("parallel-target");
 const BRANCH_ORDER = [BRANCH_A];
+/** Ends the inherited edge LATER, so the least-claim rule discards its claim. */
+const WINDOW_CLAIMANT_LATE = asBranchId("parallel-window-b-late");
+/** Ends it EARLIER, so its claim is the one committed. Sorts AFTER the loser. */
+const WINDOW_CLAIMANT_EARLY = asBranchId("parallel-window-c-early");
+/**
+ * Branch rank INVERTED against the branch-id sort: the losing claimant carries
+ * the row (it sorts first in staging) while ranking last, so a carrier chosen by
+ * authorship instead would resolve a rank-based property policy differently.
+ */
+const RANK_INVERTED_ORDER = [
+  WINDOW_CLAIMANT_EARLY,
+  BRANCH_A,
+  WINDOW_CLAIMANT_LATE,
+];
 
 /** The committed encounter's block key + reason, and the branch's near-duplicate of
  *  it (Dice trigram ≈ 0.96 ≥ the case's threshold, so the two resolve as one). */
@@ -116,6 +134,8 @@ const BRANCH_DATE = "2026-03-11";
 /** In the FUTURE: a row's `validFrom` defaults to creation, and an inverted
  *  window is refused, so an authorable end must be after that instant. */
 const END = "2100-01-01T00:00:00.000Z";
+/** A LATER authorable end, for the claim the least-claim rule discards. */
+const LATER_END = "2101-01-01T00:00:00.000Z";
 
 /**
  * Merge options for the MIXED case: the branch's near-duplicate encounter resolves
@@ -459,5 +479,80 @@ describe.each(backendMatrix())("merging parallel edges [$name]", (entry) => {
       { id: INHERITED_EDGE, on: INHERITED_DATE, validTo: END },
     ]);
     expect(report.conflicts).toEqual([]);
+  });
+
+  it("does not let a window-only carrier outvote a folded edge's props", async () => {
+    // An inherited edge whose only change is its ending still needs a staged copy
+    // to ride on, and that copy contributes the BASE's props under the carrying
+    // branch's label. So when a repoint folds a branch's own edge onto that row,
+    // the carrier is a voter in the property union — which makes WHICH branch
+    // carries the row a merge outcome, not just a provenance detail.
+    //
+    // The carrier therefore stays the staging order's first claimant, and the
+    // ending's author is credited from the window resolution instead (issue #402).
+    // Choosing the carrier by authorship moves the committed props: here it would
+    // hand the base's stale `on` a rank high enough to beat the value the props
+    // branch actually authored.
+    const forkPoint = await seededForkPoint();
+    const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
+    const propsBranch = await forkOf(forkPoint, BRANCH_A);
+    // Two window claimants whose id order is INVERTED against their branch rank,
+    // so the carrier and the credited author are provably different branches.
+    const losingClaimant = await forkOf(forkPoint, WINDOW_CLAIMANT_LATE);
+    const winningClaimant = await forkOf(forkPoint, WINDOW_CLAIMANT_EARLY);
+
+    await propsBranch.store.nodes.Encounter.create(
+      { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
+      { id: DUPLICATE_ENCOUNTER.id },
+    );
+    await propsBranch.store.edges.hadEncounter.create(
+      PATIENT,
+      DUPLICATE_ENCOUNTER,
+      { on: BRANCH_DATE },
+      { id: "edge-9" },
+    );
+    await losingClaimant.store.edges.hadEncounter.update(
+      INHERITED,
+      {},
+      { validTo: LATER_END },
+    );
+    await winningClaimant.store.edges.hadEncounter.update(
+      INHERITED,
+      {},
+      { validTo: END },
+    );
+
+    const report = unwrap(
+      await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [propsBranch, losingClaimant, winningClaimant],
+        options: {
+          ...resolveDuplicateEncounters(),
+          // Rank-sensitive: the winner is the highest-priority CONTRIBUTING
+          // branch, so a relabelled carrier changes the value that survives.
+          onPropertyConflict: "lastWriteWins",
+          branchOrder: RANK_INVERTED_ORDER,
+        },
+      }),
+    );
+
+    // The fold committed the props branch's authored value, and the earliest
+    // claimed ending — neither decided by who happened to carry the row.
+    expect(
+      (await liveEdges(target)).map((edge) => ({
+        id: edge.id,
+        on: edge.on,
+        validTo: edge.validTo,
+      })),
+    ).toEqual([{ id: INHERITED_EDGE, on: BRANCH_DATE, validTo: END }]);
+    // Only the branch whose claim IS the committed ending is credited; the
+    // carrier's own label buys it nothing.
+    expect(report.provenance.byBranch(WINDOW_CLAIMANT_EARLY).edgeIds).toContain(
+      INHERITED_EDGE,
+    );
+    expect(report.provenance.byBranch(WINDOW_CLAIMANT_LATE).edgeIds).toEqual(
+      [],
+    );
   });
 });

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -698,14 +698,20 @@ describe.each(backendMatrix())(
         const forkPoint = await seededForkPoint();
         const branchA = await forkOf(forkPoint, BRANCH_A);
         const branchB = await forkOf(forkPoint, BRANCH_B);
-        // NODES only: an inherited EDGE modification is observed by two planning
-        // phases as the same contribution, and until that duplicate is collapsed
-        // (issue #399) the whole best-effort persist fails. The edge half of the
-        // credit is asserted through the in-memory index above, which is built
-        // from the identical record list.
+        // Nodes and edges both: the inherited-edge duplicate that used to fail
+        // the whole best-effort persist is collapsed since #400, so the edge
+        // credit is asserted against the durable sidecar alongside the node's.
         await branchA.store.nodes.Patient.update(PATIENT, { note: "flagged" });
+        await branchA.store.edges.hadEncounter.update(EDGE_1, {
+          on: "2026-04-04",
+        });
         await branchB.store.nodes.Patient.update(
           PATIENT,
+          {},
+          { validTo: LATE },
+        );
+        await branchB.store.edges.hadEncounter.update(
+          EDGE_1,
           {},
           { validTo: LATE },
         );
@@ -723,13 +729,21 @@ describe.each(backendMatrix())(
           branchId: BRANCH_B,
         });
         expect(
-          persisted.map((row) => ({
-            role: row.role,
-            canonicalKind: row.canonicalKind,
-            canonicalId: row.canonicalId,
-            sourceId: row.sourceId,
-          })),
+          persisted
+            .map((row) => ({
+              role: row.role,
+              canonicalKind: row.canonicalKind,
+              canonicalId: row.canonicalId,
+              sourceId: row.sourceId,
+            }))
+            .toSorted((left, right) => left.role.localeCompare(right.role)),
         ).toEqual([
+          {
+            role: "edge",
+            canonicalKind: "hadEncounter",
+            canonicalId: "edge-1",
+            sourceId: "edge-1",
+          },
           {
             role: "node",
             canonicalKind: "Patient",

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -17,8 +17,9 @@
  *   9. PARALLEL edges of one kind each take the end claimed on THAT row;
  *  10. a single branch may EXTEND an end to a later instant;
  *  11. the branch that AUTHORED the committed end is credited in provenance —
- *      including when it authored nothing else on the row (issue #402) — and a
- *      branch whose claim lost the least-claim rule is not.
+ *      including when it authored nothing else on the row (issue #402), and
+ *      including every branch that tied on that end — while a branch whose claim
+ *      lost the least-claim rule, or whose ending a deletion absorbed, is not.
  *
  * Case 9 is the window half of issue #393: the repoint/dedupe fold is scoped to
  * collisions repointing INDUCED, so a window claim can no longer migrate between two
@@ -628,10 +629,10 @@ describe.each(backendMatrix())(
           await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }),
         );
 
-        // The edge rides its own staged copy here (nothing else claimed the
-        // identity), which is how it was already credited; the node's ending is
-        // carried by a write that names no branch, so its credit exists only
-        // because the resolution supplies it.
+        // Neither credit comes from a staged copy: the node's ending is carried
+        // by a write that names no branch, and the edge's copy is a window-only
+        // carrier, whose branch is a write vehicle rather than a contributor. Both
+        // exist only because the resolution supplies them.
         expect(report.provenance.byBranch(BRANCH_A).nodeIds).toContain("pat-1");
         expect(report.provenance.byBranch(BRANCH_A).edgeIds).toContain(
           "edge-1",
@@ -740,6 +741,70 @@ describe.each(backendMatrix())(
         // one contribution, not a second copy of the props author's.
         const all = await readProvenance(provenanceStore);
         expect(report.provenancePersisted?.count).toBe(all.length);
+      });
+
+      it("credits every branch that tied on the committed end", async () => {
+        // Two branches claiming the SAME instant both authored the committed end,
+        // so neither is the "loser" the least-claim rule discards. The edge is
+        // carried by one staged copy, which must not narrow the credit to whoever
+        // happened to carry it.
+        const forkPoint = await seededForkPoint();
+        const branchA = await forkOf(forkPoint, BRANCH_A);
+        const branchB = await forkOf(forkPoint, BRANCH_B);
+        for (const contributor of [branchA, branchB]) {
+          await contributor.store.nodes.Patient.update(
+            PATIENT,
+            {},
+            { validTo: LATE },
+          );
+          await contributor.store.edges.hadEncounter.update(
+            EDGE_1,
+            {},
+            { validTo: LATE },
+          );
+        }
+
+        const report = unwrap(
+          await merge(forkPoint, [branchA, branchB], {
+            branchOrder: BRANCH_ORDER,
+          }),
+        );
+
+        expect(await nodeEnd(forkPoint, "Patient", "pat-1")).toBe(LATE);
+        expect(await edgeEnd(forkPoint, "edge-1")).toBe(LATE);
+        for (const contributor of [BRANCH_A, BRANCH_B]) {
+          expect(report.provenance.byBranch(contributor).nodeIds).toContain(
+            "pat-1",
+          );
+          expect(report.provenance.byBranch(contributor).edgeIds).toContain(
+            "edge-1",
+          );
+        }
+      });
+
+      it("credits nobody for an ending a deletion absorbed", async () => {
+        // Deletion is the stronger statement, so no end is committed at all — and
+        // the branch that only asked for one contributed nothing to the row that
+        // remains. Credit follows the COMMITTED state, which here is the deletion.
+        const forkPoint = await seededForkPoint();
+        const branchA = await forkOf(forkPoint, BRANCH_A);
+        const branchB = await forkOf(forkPoint, BRANCH_B);
+        await branchA.store.nodes.Patient.update(
+          LONE_PATIENT,
+          {},
+          { validTo: LATE },
+        );
+        await branchB.store.nodes.Patient.delete(LONE_PATIENT);
+
+        const report = unwrap(
+          await merge(forkPoint, [branchA, branchB], {
+            branchOrder: BRANCH_ORDER,
+          }),
+        );
+
+        expect(report.validityEnds).toEqual([]);
+        // The ending was branch A's only act, so it contributed nothing at all.
+        expect(report.provenance.byBranch(BRANCH_A).nodeIds).toEqual([]);
       });
     });
 

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -15,7 +15,10 @@
  *   7. re-writing the end the target already holds is not a write at all;
  *   8. a fork `validFrom` divergence is reported unapplicable, not applied;
  *   9. PARALLEL edges of one kind each take the end claimed on THAT row;
- *  10. a single branch may EXTEND an end to a later instant.
+ *  10. a single branch may EXTEND an end to a later instant;
+ *  11. the branch that AUTHORED the committed end is credited in provenance —
+ *      including when it authored nothing else on the row (issue #402) — and a
+ *      branch whose claim lost the least-claim rule is not.
  *
  * Case 9 is the window half of issue #393: the repoint/dedupe fold is scoped to
  * collisions repointing INDUCED, so a window claim can no longer migrate between two
@@ -42,6 +45,10 @@ import { z } from "zod";
 import { asEdgeId, asNodeId } from "../../src/core/types";
 import { branch } from "../../src/graph-merge/branch";
 import { merge, mergeIncremental } from "../../src/graph-merge/merge";
+import {
+  openProvenanceStore,
+  readProvenance,
+} from "../../src/graph-merge/provenance-store";
 import { unwrap } from "../../src/graph-merge/result";
 import type { GraphBranch, MergeReport } from "../../src/graph-merge/types";
 import { asBranchId } from "../../src/graph-merge/types";
@@ -550,6 +557,190 @@ describe.each(backendMatrix())(
       // compat anchor for every merge that predates window reconciliation.
       expect(await nodeEnd(forkPoint, "Patient", "pat-1")).toBe(LATE);
       expect(report.validityEnds).toEqual([]);
+    });
+
+    /**
+     * Ending a row is authored state, so the branch that authored the COMMITTED
+     * end contributed to it and must appear in provenance — even when the ending
+     * is the only thing it changed (issue #402). The credit is asserted through
+     * `report.provenance.byBranch`, which is built from the same record list the
+     * sidecar persists; the sidecar itself is exercised once below.
+     */
+    describe("provenance credit for a window author", () => {
+      it("credits the window author alongside another branch's props edit", async () => {
+        const forkPoint = await seededForkPoint();
+        const branchA = await forkOf(forkPoint, BRANCH_A);
+        const branchB = await forkOf(forkPoint, BRANCH_B);
+        await branchA.store.nodes.Patient.update(PATIENT, { note: "flagged" });
+        await branchA.store.edges.hadEncounter.update(EDGE_1, {
+          on: "2026-02-02",
+        });
+        await branchB.store.nodes.Patient.update(
+          PATIENT,
+          {},
+          { validTo: LATE },
+        );
+        await branchB.store.edges.hadEncounter.update(
+          EDGE_1,
+          {},
+          { validTo: LATE },
+        );
+
+        const report = unwrap(
+          await merge(forkPoint, [branchA, branchB], {
+            branchOrder: BRANCH_ORDER,
+          }),
+        );
+
+        // Branch B's end is what the target now carries, so B is a contributor to
+        // both rows. Its window-only staged copy is dropped by the identity that
+        // A's props edit already staged, which is exactly how the credit went
+        // missing before the resolution started supplying it.
+        expect(await nodeEnd(forkPoint, "Patient", "pat-1")).toBe(LATE);
+        expect(await edgeEnd(forkPoint, "edge-1")).toBe(LATE);
+        expect(report.provenance.byBranch(BRANCH_B).nodeIds).toContain("pat-1");
+        expect(report.provenance.byBranch(BRANCH_B).edgeIds).toContain(
+          "edge-1",
+        );
+        // The props author keeps its own credit — the window credit adds to the
+        // contributor set, it does not replace it.
+        expect(report.provenance.byBranch(BRANCH_A).nodeIds).toContain("pat-1");
+        expect(report.provenance.byBranch(BRANCH_A).edgeIds).toContain(
+          "edge-1",
+        );
+      });
+
+      it("credits a window-only change no other branch touched", async () => {
+        const forkPoint = await seededForkPoint();
+        const branchA = await forkOf(forkPoint, BRANCH_A);
+        await branchA.store.nodes.Patient.update(
+          PATIENT,
+          {},
+          { validTo: LATE },
+        );
+        await branchA.store.edges.hadEncounter.update(
+          EDGE_1,
+          {},
+          { validTo: LATE },
+        );
+
+        const report = unwrap(
+          await merge(forkPoint, [branchA], { branchOrder: BRANCH_ORDER }),
+        );
+
+        // The edge rides its own staged copy here (nothing else claimed the
+        // identity), which is how it was already credited; the node's ending is
+        // carried by a write that names no branch, so its credit exists only
+        // because the resolution supplies it.
+        expect(report.provenance.byBranch(BRANCH_A).nodeIds).toContain("pat-1");
+        expect(report.provenance.byBranch(BRANCH_A).edgeIds).toContain(
+          "edge-1",
+        );
+      });
+
+      it("credits only the branch whose claim IS the resolved end", async () => {
+        const forkPoint = await seededForkPoint();
+        const branchA = await forkOf(forkPoint, BRANCH_A);
+        const branchB = await forkOf(forkPoint, BRANCH_B);
+        // A claims the LATER end, so the least-claim rule commits B's.
+        await branchA.store.nodes.Patient.update(
+          PATIENT,
+          {},
+          { validTo: LATE },
+        );
+        await branchA.store.edges.hadEncounter.update(
+          EDGE_1,
+          {},
+          { validTo: LATE },
+        );
+        await branchB.store.nodes.Patient.update(
+          PATIENT,
+          {},
+          { validTo: EARLY },
+        );
+        await branchB.store.edges.hadEncounter.update(
+          EDGE_1,
+          {},
+          { validTo: EARLY },
+        );
+
+        const report = unwrap(
+          await merge(forkPoint, [branchA, branchB], {
+            branchOrder: BRANCH_ORDER,
+          }),
+        );
+
+        expect(await nodeEnd(forkPoint, "Patient", "pat-1")).toBe(EARLY);
+        expect(await edgeEnd(forkPoint, "edge-1")).toBe(EARLY);
+        // Provenance records contribution to COMMITTED state: A's later claim was
+        // discarded, so A contributed nothing to either row. That A ASKED for a
+        // different end is reported instead, under `claimedBy`.
+        expect(report.provenance.byBranch(BRANCH_B).nodeIds).toContain("pat-1");
+        expect(report.provenance.byBranch(BRANCH_B).edgeIds).toContain(
+          "edge-1",
+        );
+        expect(report.provenance.byBranch(BRANCH_A).nodeIds).not.toContain(
+          "pat-1",
+        );
+        expect(report.provenance.byBranch(BRANCH_A).edgeIds).not.toContain(
+          "edge-1",
+        );
+        expect(
+          report.validityEnds.map((end) => [end.entity, end.claimedBy]),
+        ).toEqual([
+          ["node", [BRANCH_A, BRANCH_B]],
+          ["edge", [BRANCH_A, BRANCH_B]],
+        ]);
+      });
+
+      it("persists the window author's contribution to the sidecar", async () => {
+        const forkPoint = await seededForkPoint();
+        const branchA = await forkOf(forkPoint, BRANCH_A);
+        const branchB = await forkOf(forkPoint, BRANCH_B);
+        // NODES only: an inherited EDGE modification is observed by two planning
+        // phases as the same contribution, and until that duplicate is collapsed
+        // (issue #399) the whole best-effort persist fails. The edge half of the
+        // credit is asserted through the in-memory index above, which is built
+        // from the identical record list.
+        await branchA.store.nodes.Patient.update(PATIENT, { note: "flagged" });
+        await branchB.store.nodes.Patient.update(
+          PATIENT,
+          {},
+          { validTo: LATE },
+        );
+
+        const report = unwrap(
+          await merge(forkPoint, [branchA, branchB], {
+            branchOrder: BRANCH_ORDER,
+            persistProvenance: true,
+          }),
+        );
+        expect(report.warnings).toEqual([]);
+
+        const provenanceStore = await openProvenanceStore(forkPoint);
+        const persisted = await readProvenance(provenanceStore, {
+          branchId: BRANCH_B,
+        });
+        expect(
+          persisted.map((row) => ({
+            role: row.role,
+            canonicalKind: row.canonicalKind,
+            canonicalId: row.canonicalId,
+            sourceId: row.sourceId,
+          })),
+        ).toEqual([
+          {
+            role: "node",
+            canonicalKind: "Patient",
+            canonicalId: "pat-1",
+            sourceId: "pat-1",
+          },
+        ]);
+        // The reported count is the rows a fresh read finds: the window credit is
+        // one contribution, not a second copy of the props author's.
+        const all = await readProvenance(provenanceStore);
+        expect(report.provenancePersisted?.count).toBe(all.length);
+      });
     });
 
     it("does not rewrite an unchanged row when nothing changed at all", async () => {


### PR DESCRIPTION
Ending a row's validity is authored state, but a branch whose only change to a row was its window could author the instant the merge committed and still be absent from the merge's provenance.

An identity is staged once. A branch that moved an inherited edge's window therefore had its staged copy skipped whenever another branch's property edit already staged that edge, and edge provenance is derived from the staged copies — so the branch whose end actually got committed was credited to nobody. Nodes had a wider gap than the report described: a window change had no provenance path at all, so even a solo window-only ending, with no other branch touching the row, was uncredited. Both are fixed here; the node half is the same bug reached by a different route, and splitting it would have left the subsystem half-credited.

## The credit rule

The credit comes from the window resolution, the only phase that knows whose claim was committed. `resolveValidWindows` now emits `nodeCredits` / `edgeCredits` alongside the ends it already returned, keyed identically, holding exactly the branches whose claim **is** the resolved end — the least-claim winner and anyone who tied with it.

A branch whose later end lost the least-claim rule is deliberately **not** credited: provenance records contribution to committed state, and that branch put none of it there. Its claim stays visible in `MergeReport.validityEnds[].claimedBy`, which names every claimant, winning or not. The alternative — crediting every claimant — would quietly redefine provenance as "who spoke about this row", a question the report already answers. An ending a deletion absorbed is committed as nothing at all, so it credits nobody either.

## Where the credit lands

Nodes take it directly, deduped against the modification credit so a branch that edited properties *and* moved the window stays one contribution: one sidecar row, counted once.

Edges take it through `stagedEdgeBranches`, so the window author is credited against the surviving edge the repoint decides, exactly as a modifying branch is. What is no longer credited there is the staged copy that *carries* the ending. An identity is staged once, so that copy belongs to whichever claimant sorted first under `(kind, id, branch)` — possibly one whose later claim the merge discarded — and it exists only to give the ending a row to write, with the base's properties for content. `buildStagedEdges` reports those identities as window-only carried and the credit for them comes from the resolution alone.

Which branch carries the row is left exactly as it was, and that is the load-bearing half. The carrier's `branchId` is not provenance-only: it is also a contribution label in the repoint fold's property union, so choosing the carrier by authorship moves which value a fold commits. In a repoint-induced collision between a window-only inherited row and a branch's own edge, under a rank-based `onPropertyConflict`, the difference is the committed property — the base's untouched value winning against the value the other branch authored. That union has no base to compare against, which is what lets an untouched value compete at all; the hazard predates this change and this change deliberately does not move it.

## Composition with #399 / #400

Nothing here depends on the duplicate-contribution collapse in #400, and nothing conflicts with it: the node credit skips a record the modification loop already made, and the edge credit goes through a `Set`, so a window credit reaching that funnel is already distinct. Once #400 lands, that node-level skip is subsumed by the collapse at `recordProvenance` and can go.

The durable-persistence test is node-only for the same reason. An inherited *edge* modification is re-observed as the same contribution by two planning phases, which fails the whole best-effort persist until that duplicate is collapsed — orthogonal to this fix, so the edge half of the credit is asserted through the in-memory index, built from the identical record list.

Closes #402
