### PR TITLE
fix(store): apply a repeated id in one bulkUpsertById batch as create-then-update

### DIFF
--- a/.changeset/repeated-new-id-bulk-upsert.md
+++ b/.changeset/repeated-new-id-bulk-upsert.md
@@ -1,0 +1,28 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fix `bulkUpsertById` throwing on a repeated id whose row does not exist yet.
+
+`bulkUpsertById` applies items in order, so a repeated id in one batch is
+last-write-wins — but that only held for an id that already existed. The create
+branch queued its create without registering the id in the batch-local pending
+map, so a second copy of a **new** id queued a second create and the batch failed
+with `Node already exists` / `Edge already exists` (a unique-constraint violation
+on some paths). Callers feeding a batch straight from a stream or a changeset,
+where a key can legitimately appear twice, hit this on first delivery of a key.
+
+A queued create is now registered like a queued update: a later copy of the id
+takes the update path over the queued create, which runs after the batch's
+creates, so the final row is exactly what the equivalent sequence of `upsertById`
+calls produces — the later copy's props merged over the created row, one version
+bump per real write, and the created row's validity lower bound. With
+`coalesceUnchangedUpserts` enabled, a value-identical second copy of a new id now
+coalesces against the queued create instead of writing a second time. Nodes and
+edges are both fixed; for edges, as for an id that already existed, a later
+copy's `from` / `to` are ignored because an update never repoints an edge.
+
+Two smaller consequences of routing every queued write through the same state: a
+repeated id whose dirty check rejected an earlier item's props no longer reports
+the wrong error, and no later copy can coalesce against a stale prefetched row
+after an earlier item queued a write.

--- a/apps/docs/src/content/docs/data-sync.md
+++ b/apps/docs/src/content/docs/data-sync.md
@@ -119,6 +119,15 @@ const synced = await store.nodes.Document.bulkUpsertById(
 );
 ```
 
+A feed can deliver the same key twice in one page, so items are applied in
+order: the first item for an id creates or updates the row, and every later copy
+is an update over the value the earlier item wrote. The batch ends in the same
+state the equivalent sequence of `upsertById` calls would leave, whether or not
+the row existed before the batch. Because a later copy is an update, it merges
+over the earlier value — a field the last copy omits keeps what an earlier copy
+set. Edges follow the same rule, except that an update never repoints an edge:
+the endpoints of the first write stand.
+
 ### bulkDelete
 
 Deletes multiple nodes by ID. Silently ignores IDs that don't exist:

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -34,6 +34,26 @@ export type UpsertDirtyCheckFunction = (
 ) => UpsertDirtyCheck;
 
 /**
+ * The ids that appear more than once in one bulk-upsert batch.
+ *
+ * A repeated id is the only case where a queued write's batch-local running
+ * value is ever read, and computing a queued CREATE's running value costs a Zod
+ * parse the insert will repeat. Batches with all-distinct ids — the common case —
+ * skip that parse entirely.
+ */
+export function findRepeatedUpsertIds(
+  items: readonly Readonly<{ id: string }>[],
+): Set<string> {
+  const seen = new Set<string>();
+  const repeated = new Set<string>();
+  for (const item of items) {
+    if (seen.has(item.id)) repeated.add(item.id);
+    seen.add(item.id);
+  }
+  return repeated;
+}
+
+/**
  * Whether one requested window endpoint differs from the stored one, compared as
  * instants rather than as driver text. An omitted request never changes anything.
  *

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -766,7 +766,12 @@ export function createEdgeCollection<
         >();
         const deferred: { index: number; sourceIndex: number }[] = [];
 
-        const repeatedIds = findRepeatedUpsertIds(items);
+        // See the node collection: only a coalescing store reads a running
+        // value, so only it needs the repeated-id set.
+        const repeatedIds =
+          config.upsertDirtyCheck === undefined ?
+            new Set<string>()
+          : findRepeatedUpsertIds(items);
 
         /** See the node collection's runDirtyCheck. */
         function runDirtyCheck(

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -39,6 +39,7 @@ import {
   type QueryOptions,
 } from "../types";
 import {
+  findRepeatedUpsertIds,
   type UpsertDirtyCheck,
   type UpsertDirtyCheckFunction,
 } from "./coalesce";
@@ -755,12 +756,37 @@ export function createEdgeCollection<
 
         // Batch-local running state per id so a repeated id coalesces against
         // the value earlier items in this batch would write, preserving
-        // last-write-wins. See the node collection for the full rationale.
+        // last-write-wins — and so a repeated id whose edge does not exist yet
+        // queues ONE create plus an update over it rather than two creates the
+        // create batch rejects as "already exists". See the node collection for
+        // the full rationale, including why `props` may be undefined.
         const pending = new Map<
           string,
-          { props: Record<string, unknown>; sourceIndex: number }
+          { props: Record<string, unknown> | undefined; sourceIndex: number }
         >();
         const deferred: { index: number; sourceIndex: number }[] = [];
+
+        const repeatedIds = findRepeatedUpsertIds(items);
+
+        /** See the node collection's runDirtyCheck. */
+        function runDirtyCheck(
+          edgeKind: string,
+          id: string,
+          currentProps: Record<string, unknown>,
+          inputProps: Record<string, unknown>,
+        ): UpsertDirtyCheck | undefined {
+          if (config.upsertDirtyCheck === undefined) return undefined;
+          try {
+            return config.upsertDirtyCheck(
+              edgeKind,
+              id,
+              currentProps,
+              inputProps,
+            );
+          } catch {
+            return undefined;
+          }
+        }
 
         let itemIndex = 0;
         for (const item of items) {
@@ -779,6 +805,16 @@ export function createEdgeCollection<
                 item,
               ),
             });
+            // A create merges over nothing, so the dirty check run against an
+            // EMPTY base is exactly the validated props the insert will store —
+            // needed only when a later copy of this id will compare against it.
+            pending.set(item.id, {
+              props:
+                repeatedIds.has(item.id) ?
+                  runDirtyCheck(kind, item.id, {}, inputProps)?.validatedProps
+                : undefined,
+              sourceIndex: itemIndex,
+            });
             itemIndex++;
             continue;
           }
@@ -788,30 +824,30 @@ export function createEdgeCollection<
               requireDefined(original).deleted_at
             : undefined;
 
-          let dirty: UpsertDirtyCheck | undefined;
-          if (config.upsertDirtyCheck !== undefined) {
-            const currentProps =
-              pendingEntry?.props ??
-              rowPropsToObject(requireDefined(original).props);
-            try {
-              // The fetched edge carries the authoritative kind (an id may
-              // resolve to a different edge kind than this collection).
-              dirty = config.upsertDirtyCheck(
+          const currentProps =
+            pendingEntry === undefined ?
+              rowPropsToObject(requireDefined(original).props)
+            : pendingEntry.props;
+          // The fetched edge carries the authoritative kind (an id may resolve
+          // to a different edge kind than this collection); a queued create is
+          // this collection's kind by construction.
+          const dirty =
+            currentProps === undefined ? undefined : (
+              runDirtyCheck(
                 original?.kind ?? kind,
                 item.id,
                 currentProps,
                 inputProps,
-              );
-            } catch {
-              dirty = undefined;
-            }
-          }
+              )
+            );
 
           // An explicit window blocks coalescing ONLY when it would change
           // the stored window: merge commits pass the staged survivor's
           // window on every edge write, so a target edge staged back at
           // itself (identical props AND identical window) must still
-          // coalesce instead of rewriting history and revision state.
+          // coalesce instead of rewriting history and revision state. Against
+          // a QUEUED create there is no stored window to match yet, so any
+          // explicit bound counts as a change and the write happens.
           const windowChanges =
             (item.validFrom !== undefined &&
               item.validFrom !== original?.valid_from) ||
@@ -838,12 +874,10 @@ export function createEdgeCollection<
               input: buildUpsertUpdateEdgeInput(item.id, inputProps, item),
               clearDeleted: deletedAt !== undefined,
             });
-            if (dirty !== undefined) {
-              pending.set(item.id, {
-                props: dirty.validatedProps,
-                sourceIndex: itemIndex,
-              });
-            }
+            pending.set(item.id, {
+              props: dirty?.validatedProps,
+              sourceIndex: itemIndex,
+            });
           }
           itemIndex++;
         }
@@ -867,7 +901,8 @@ export function createEdgeCollection<
         }
 
         // Items that coalesced against an in-batch write take that write's
-        // result (now filled). Its sourceIndex is always a write slot.
+        // result (now filled). Its sourceIndex is always a write slot — a
+        // queued create or a queued update, both filled above.
         for (const { index, sourceIndex } of deferred) {
           results[index] = requireDefined(results[sourceIndex]);
         }

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -684,7 +684,12 @@ export function createNodeCollection<
         // write's result (filled once the writes run), not a fabricated row.
         const deferred: { index: number; sourceIndex: number }[] = [];
 
-        const repeatedIds = findRepeatedUpsertIds(items);
+        // A running value exists only to be dirty-checked, so a store without
+        // coalescing never needs to know which ids repeat.
+        const repeatedIds =
+          config.upsertDirtyCheck === undefined ?
+            new Set<string>()
+          : findRepeatedUpsertIds(items);
 
         /**
          * The dirty check for one item, or undefined when coalescing is off or

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -41,6 +41,7 @@ import {
   type UpdateNodeInput,
 } from "../types";
 import {
+  findRepeatedUpsertIds,
   shouldCoalesceUpsert,
   type UpsertDirtyCheck,
   type UpsertDirtyCheckFunction,
@@ -662,13 +663,47 @@ export function createNodeCollection<
         // once-prefetched row — otherwise [{x:B},{x:A}] on a row holding A would
         // coalesce the second item against the stale prefetched A and drop the
         // first item's write, breaking last-write-wins.
+        //
+        // A QUEUED CREATE is registered here too. Leaving it out queued a SECOND
+        // create for a repeated id whose row does not exist yet, and the create
+        // batch rejected it as "already exists". Registered, the later copy
+        // takes the update path against the queued create — creates run before
+        // updates, so the row is there by then — producing exactly the row that
+        // sequential `upsertById` calls produce.
+        //
+        // `props` is the running value the dirty check compares against. It is
+        // undefined when no value could be computed (coalescing off, or the
+        // check rejected the input): presence of the ENTRY is what routes a
+        // later copy away from a second create, while the props only decide
+        // coalescing, and an unknown running value simply never coalesces.
         const pending = new Map<
           string,
-          { props: Record<string, unknown>; sourceIndex: number }
+          { props: Record<string, unknown> | undefined; sourceIndex: number }
         >();
         // A coalesced item that matched an in-batch write resolves to that
         // write's result (filled once the writes run), not a fabricated row.
         const deferred: { index: number; sourceIndex: number }[] = [];
+
+        const repeatedIds = findRepeatedUpsertIds(items);
+
+        /**
+         * The dirty check for one item, or undefined when coalescing is off or
+         * the check rejected the input — a validation error must surface from
+         * the hooked write path, which re-validates and rejects the batch
+         * (matching flag-off), not from here.
+         */
+        function runDirtyCheck(
+          id: string,
+          currentProps: Record<string, unknown>,
+          inputProps: Record<string, unknown>,
+        ): UpsertDirtyCheck | undefined {
+          if (config.upsertDirtyCheck === undefined) return undefined;
+          try {
+            return config.upsertDirtyCheck(kind, id, currentProps, inputProps);
+          } catch {
+            return undefined;
+          }
+        }
 
         let itemIndex = 0;
         for (const item of items) {
@@ -679,6 +714,17 @@ export function createNodeCollection<
             toCreate.push({
               index: itemIndex,
               input: buildCreateInput(kind, item.props, item),
+            });
+            // A create merges over nothing, so the dirty check run against an
+            // EMPTY base is exactly the validated props the insert will store —
+            // the running value a later copy of this id compares against, and
+            // needed only when there IS a later copy.
+            pending.set(item.id, {
+              props:
+                repeatedIds.has(item.id) ?
+                  runDirtyCheck(item.id, {}, item.props)?.validatedProps
+                : undefined,
+              sourceIndex: itemIndex,
             });
             itemIndex++;
             continue;
@@ -691,24 +737,14 @@ export function createNodeCollection<
               requireDefined(original).deleted_at
             : undefined;
 
-          let dirty: UpsertDirtyCheck | undefined;
-          if (config.upsertDirtyCheck !== undefined) {
-            const currentProps =
-              pendingEntry?.props ??
-              rowPropsToObject(requireDefined(original).props);
-            try {
-              dirty = config.upsertDirtyCheck(
-                kind,
-                item.id,
-                currentProps,
-                item.props,
-              );
-            } catch {
-              // Validation error → fall through to the write path, which
-              // re-validates and rejects the batch (matching flag-off).
-              dirty = undefined;
-            }
-          }
+          const currentProps =
+            pendingEntry === undefined ?
+              rowPropsToObject(requireDefined(original).props)
+            : pendingEntry.props;
+          const dirty =
+            currentProps === undefined ? undefined : (
+              runDirtyCheck(item.id, currentProps, item.props)
+            );
 
           const coalesce =
             dirty?.unchanged === true &&
@@ -733,12 +769,10 @@ export function createNodeCollection<
               input: buildUpsertUpdateInput(kind, item.id, item.props, item),
               clearDeleted: deletedAt !== undefined,
             });
-            if (dirty !== undefined) {
-              pending.set(item.id, {
-                props: dirty.validatedProps,
-                sourceIndex: itemIndex,
-              });
-            }
+            pending.set(item.id, {
+              props: dirty?.validatedProps,
+              sourceIndex: itemIndex,
+            });
           }
           itemIndex++;
         }
@@ -762,7 +796,8 @@ export function createNodeCollection<
         }
 
         // Items that coalesced against an in-batch write take that write's
-        // result (now filled). Its sourceIndex is always a write slot.
+        // result (now filled). Its sourceIndex is always a write slot — a
+        // queued create or a queued update, both filled above.
         for (const { index, sourceIndex } of deferred) {
           results[index] = requireDefined(results[sourceIndex]);
         }

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -417,7 +417,9 @@ export type BaseStoreOptions = Readonly<{
    *
    * A write is coalesced only when **all** of the following hold; otherwise the
    * normal write happens:
-   *   1. An existing row is found for the id (else it is a create).
+   *   1. A value to compare against is known for the id: an existing row, or —
+   *      for a repeated id in one bulk batch — the value an earlier item in that
+   *      batch already queued (a create or an update). Otherwise it is a create.
    *   2. That row is not soft-deleted (a deleted row resurrects — a real
    *      change — and is never coalesced).
    *   3. The caller passed no explicit `validFrom` / `validTo` (an explicit
@@ -909,6 +911,12 @@ export type NodeCollection<
    * For each item, if a node with the given ID exists, updates it.
    * Otherwise, creates a new node with that ID.
    *
+   * Items are applied in order, so a **repeated id** within one batch is
+   * last-write-wins: the first item creates or updates the row, and every later
+   * copy is an update over the value the earlier item wrote — the same final row
+   * the equivalent sequence of `upsertById` calls produces. This holds whether
+   * or not the row existed before the batch.
+   *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
    * operation's timestamp when omitted. It has no effect on an update to a live
@@ -1296,6 +1304,13 @@ export type EdgeCollection<
    *
    * For each item, if an edge with the given ID exists, updates it.
    * Otherwise, creates a new edge with that ID.
+   *
+   * Items are applied in order, so a **repeated id** within one batch is
+   * last-write-wins: the first item creates or updates the edge, and every later
+   * copy is an update over the value the earlier item wrote. This holds whether
+   * or not the edge existed before the batch. An update never repoints an edge,
+   * so the endpoints of the first write stand — a later copy's `from` / `to` are
+   * ignored exactly as they are for an id that already existed.
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -419,7 +419,7 @@ export type BaseStoreOptions = Readonly<{
    * normal write happens:
    *   1. A value to compare against is known for the id: an existing row, or —
    *      for a repeated id in one bulk batch — the value an earlier item in that
-   *      batch already queued (a create or an update). Otherwise it is a create.
+   *      batch already queued (a create or an update).
    *   2. That row is not soft-deleted (a deleted row resurrects — a real
    *      change — and is never coalesced).
    *   3. The caller passed no explicit `validFrom` / `validTo` (an explicit

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -28,6 +28,7 @@ import {
   registerBulkFindByIndexIntegrationTests,
   registerBulkFindEndpointIntegrationTests,
   registerBulkFindHeterogeneousIntegrationTests,
+  registerBulkUpsertRepeatedIdIntegrationTests,
   registerCoalesceUpsertIntegrationTests,
   registerContributionDiagnosticIntegrationTests,
   registerCrossBackendConsistencyTests,
@@ -171,6 +172,7 @@ export function createIntegrationTestSuite<TNativeTransaction>(
     registerBulkFindByIndexIntegrationTests(context);
     registerBulkFindEndpointIntegrationTests(context);
     registerBulkFindHeterogeneousIntegrationTests(context);
+    registerBulkUpsertRepeatedIdIntegrationTests(context);
     registerCoalesceUpsertIntegrationTests(context);
     registerContributionDiagnosticIntegrationTests(context);
     registerPredicateIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/bulk-upsert-repeated-ids.ts
+++ b/packages/typegraph/tests/backends/integration/bulk-upsert-repeated-ids.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
-import { asEdgeId, asNodeId, type EdgeId, type NodeId } from "../../../src";
+import {
+  asEdgeId,
+  asNodeId,
+  defineGraph,
+  defineNode,
+  type EdgeId,
+  type NodeId,
+} from "../../../src";
+import { UniquenessError } from "../../../src/errors";
 import { createSqlSchema } from "../../../src/query/compiler/schema";
 import { sql } from "../../../src/query/sql-fragment";
 import { asCompiledRowsSql } from "../../../src/query/sql-intent";
@@ -22,6 +31,11 @@ import { type IntegrationTestContext } from "./test-context";
  * id in the batch-local pending map, so a repeated new id queued two creates and
  * the batch threw "Node already exists" (issue #401).
  *
+ * Because the later copy is a real update rather than a rewritten create, the
+ * sidecars it maintains have to land on the final value too: the uniqueness
+ * reservation the create took must move, and the fulltext projection must hold
+ * the last copy's text.
+ *
  * These cases run against every backend because they are query/write semantics,
  * not backend wiring. Both coalescing states are covered: the defect was in the
  * create/update bucketing, which runs with `coalesceUnchangedUpserts` off as
@@ -40,6 +54,48 @@ function knowsId(
 }
 
 type PersonShape = Readonly<{ name?: string; age?: number }>;
+
+/**
+ * A kind whose props reach the row through a uniqueness reservation, a schema
+ * default, and a transform — the three things a queued create's running value
+ * has to agree with. `email` is reserved per kind, `status` is absent from every
+ * input, and `slug` is stored upper-cased, so a running value taken straight
+ * from the raw input instead of from the validated create would disagree with
+ * the row the insert actually writes.
+ */
+const Account = defineNode("Account", {
+  schema: z.object({
+    email: z.string(),
+    label: z.string().optional(),
+    status: z.string().default("active"),
+    slug: z
+      .string()
+      .optional()
+      .transform((value) => value?.toUpperCase()),
+  }),
+});
+
+const accountGraph = defineGraph({
+  id: "bulk_upsert_repeated_accounts",
+  nodes: {
+    Account: {
+      type: Account,
+      unique: [
+        {
+          name: "account_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+
+function accountId(id: string): NodeId<typeof Account> {
+  return asNodeId(id);
+}
 
 /** The row state the sequential-equivalence oracle compares. */
 type ComparableNode = Readonly<{
@@ -329,6 +385,70 @@ export function registerBulkUpsertRepeatedIdIntegrationTests(
         );
         expect((sequential as { since?: string }).since).toBe("B");
       });
+
+      it("leaves ONE uniqueness reservation, on the final value", async () => {
+        const store = await context.createStore(accountGraph);
+
+        // The create reserves "first@example.com"; the update over it must
+        // release that key and reserve "second@example.com" instead. A create
+        // whose reservation outlived the batch would pin BOTH values.
+        await store.nodes.Account.bulkUpsertById([
+          { id: "uniq-rep", props: { email: "first@example.com" } },
+          { id: "uniq-rep", props: { email: "second@example.com" } },
+        ]);
+
+        // The key the create reserved is free again.
+        const reuse = await store.nodes.Account.create({
+          email: "first@example.com",
+        });
+        expect(reuse.id).not.toBe("uniq-rep");
+
+        // The final value is the one that is reserved.
+        await expect(
+          store.nodes.Account.create({ email: "second@example.com" }),
+        ).rejects.toThrow(UniquenessError);
+      });
+
+      it("leaves the fulltext projection holding the final text", async (ctx) => {
+        const store = context.getStore();
+        if (store.backend.capabilities.fulltext?.supported !== true) {
+          ctx.skip();
+        }
+
+        await store.nodes.Article.bulkUpsertById([
+          {
+            id: "ft-rep",
+            props: {
+              title: "Perovskite tandem cells",
+              body: "First body.",
+              category: "science",
+              published: true,
+            },
+          },
+          {
+            id: "ft-rep",
+            props: {
+              title: "Thermoelectric harvesting",
+              body: "Second body.",
+              category: "science",
+              published: true,
+            },
+          },
+        ]);
+
+        // The update re-syncs the projection, so only the last copy's text is
+        // findable: a stale row from the create would leave both terms hitting.
+        const superseded = await store.search.fulltext("Article", {
+          query: "perovskite",
+          limit: 10,
+        });
+        expect(superseded).toHaveLength(0);
+        const current = await store.search.fulltext("Article", {
+          query: "thermoelectric",
+          limit: 10,
+        });
+        expect(current.map((hit) => hit.node.id)).toEqual(["ft-rep"]);
+      });
     });
 
     describe("with coalescing on", () => {
@@ -353,6 +473,27 @@ export function registerBulkUpsertRepeatedIdIntegrationTests(
           deletedAt: undefined,
           validTo: undefined,
         });
+      });
+
+      it("compares a later copy against the props the create VALIDATED, not the raw input", async () => {
+        const store = await context.createStore(accountGraph, {
+          coalesceUnchangedUpserts: true,
+        });
+
+        const results = await store.nodes.Account.bulkUpsertById([
+          { id: "coal-derived", props: { email: "a@example.com", slug: "ab" } },
+          { id: "coal-derived", props: { email: "a@example.com", slug: "ab" } },
+        ]);
+
+        // The create stores `status: "active"` (a schema default the input never
+        // carried) and `slug: "AB"` (transformed). A running value taken from
+        // the raw input would miss both, so the second copy would look changed
+        // and write again. It must coalesce to the create's own result.
+        expect(results[1]).toBe(results[0]);
+        expect(results[0]?.meta.version).toBe(1);
+        expect(
+          await store.nodes.Account.getById(accountId("coal-derived")),
+        ).toMatchObject({ status: "active", slug: "AB" });
       });
 
       it("coalesces only the copies that match the running value", async () => {

--- a/packages/typegraph/tests/backends/integration/bulk-upsert-repeated-ids.ts
+++ b/packages/typegraph/tests/backends/integration/bulk-upsert-repeated-ids.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from "vitest";
+
+import { asEdgeId, asNodeId, type EdgeId, type NodeId } from "../../../src";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { sql } from "../../../src/query/sql-fragment";
+import { asCompiledRowsSql } from "../../../src/query/sql-intent";
+import { STORE_RUNTIME } from "../../../src/store/runtime-port";
+import {
+  type HistoryIntegrationStore,
+  type IntegrationStore,
+  integrationTestGraph,
+} from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+/**
+ * Repeated ids in one `bulkUpsertById` batch, for an id whose row does NOT
+ * exist yet.
+ *
+ * The batch is contractually equivalent to the same items applied as sequential
+ * `upsertById` calls: the first item creates, every later copy updates over the
+ * value the earlier item wrote. The create branch used to skip registering its
+ * id in the batch-local pending map, so a repeated new id queued two creates and
+ * the batch threw "Node already exists" (issue #401).
+ *
+ * These cases run against every backend because they are query/write semantics,
+ * not backend wiring. Both coalescing states are covered: the defect was in the
+ * create/update bucketing, which runs with `coalesceUnchangedUpserts` off as
+ * well.
+ */
+function personId(
+  id: string,
+): NodeId<typeof integrationTestGraph.nodes.Person.type> {
+  return asNodeId(id);
+}
+
+function knowsId(
+  id: string,
+): EdgeId<typeof integrationTestGraph.edges.knows.type> {
+  return asEdgeId(id);
+}
+
+type PersonShape = Readonly<{ name?: string; age?: number }>;
+
+/** The row state the sequential-equivalence oracle compares. */
+type ComparableNode = Readonly<{
+  name: string | undefined;
+  age: number | undefined;
+  version: number;
+  deletedAt: string | undefined;
+  validTo: string | undefined;
+}>;
+
+async function readComparableNode(
+  store: IntegrationStore | HistoryIntegrationStore,
+  id: string,
+): Promise<ComparableNode> {
+  const node = await store.nodes.Person.getById(personId(id));
+  if (node === undefined) {
+    throw new Error(`expected Person "${id}" to exist`);
+  }
+  const shape = node as PersonShape;
+  return {
+    name: shape.name,
+    age: shape.age,
+    version: node.meta.version,
+    deletedAt: node.meta.deletedAt,
+    validTo: node.meta.validTo,
+  };
+}
+
+type RecordedRow = Readonly<{ op: string; version: unknown; props: unknown }>;
+
+/** One captured revision, reduced to the fields these cases assert. */
+type RecordedRevision = Readonly<{
+  op: string;
+  version: number;
+  props: unknown;
+}>;
+
+/**
+ * The recorded revisions captured for a node id, oldest first. Capture is
+ * per-transaction: every write a single transaction makes to one row collapses
+ * into ONE revision holding that transaction's final state, so a repeated id is
+ * one revision — not one per item.
+ */
+async function readRecordedRevisions(
+  store: HistoryIntegrationStore,
+  kind: string,
+  id: string,
+): Promise<RecordedRevision[]> {
+  const backend = store[STORE_RUNTIME].backend;
+  const table = createSqlSchema(backend.tableNames).recordedNodesTable;
+  const rows = await backend.execute<RecordedRow>(
+    asCompiledRowsSql(sql`
+      SELECT op, version, props
+      FROM ${table}
+      WHERE graph_id = ${store.graphId}
+        AND kind = ${kind}
+        AND id = ${id}
+      ORDER BY recorded_from ASC
+    `),
+  );
+  return rows.map((row) => ({
+    op: row.op,
+    version: Number(row.version),
+    props: parseRecordedProps(row.props),
+  }));
+}
+
+/** SQLite stores props as JSON text; a Postgres driver returns parsed jsonb. */
+function parseRecordedProps(props: unknown): unknown {
+  return typeof props === "string" ? (JSON.parse(props) as unknown) : props;
+}
+
+export function registerBulkUpsertRepeatedIdIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("bulkUpsertById with repeated ids", () => {
+    describe("with coalescing off (default)", () => {
+      it("creates once then updates for a repeated NEW id, matching sequential upserts", async () => {
+        const store = context.getStore();
+
+        // Pre-fix this threw NodeAlreadyExistsError: both items queued a create.
+        const results = await store.nodes.Person.bulkUpsertById([
+          { id: "rep-new", props: { name: "A", age: 1 } },
+          { id: "rep-new", props: { name: "B" } },
+        ]);
+
+        // Each position returns the row as of its own item.
+        expect(results).toHaveLength(2);
+        expect((results[0] as PersonShape).name).toBe("A");
+        expect(results[0]?.meta.version).toBe(1);
+        expect((results[1] as PersonShape).name).toBe("B");
+        expect(results[1]?.meta.version).toBe(2);
+
+        // The second copy is an update, so it MERGES over the queued create:
+        // `age` survives because the second item omits it. A second create (or a
+        // replace) would have dropped it.
+        const batched = await readComparableNode(store, "rep-new");
+        expect(batched).toEqual({
+          name: "B",
+          age: 1,
+          version: 2,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+
+        // Sequential-equivalence oracle: the same items applied one at a time.
+        await store.nodes.Person.upsertById("rep-seq", { name: "A", age: 1 });
+        await store.nodes.Person.upsertById("rep-seq", { name: "B" });
+        expect(batched).toEqual(await readComparableNode(store, "rep-seq"));
+      });
+
+      it("applies three copies of a new id in order", async () => {
+        const store = context.getStore();
+
+        const results = await store.nodes.Person.bulkUpsertById([
+          { id: "rep3", props: { name: "A", age: 1 } },
+          { id: "rep3", props: { name: "B", age: 2 } },
+          { id: "rep3", props: { name: "C" } },
+        ]);
+
+        expect(results.map((node) => (node as PersonShape).name)).toEqual([
+          "A",
+          "B",
+          "C",
+        ]);
+
+        const batched = await readComparableNode(store, "rep3");
+        expect(batched).toEqual({
+          name: "C",
+          age: 2,
+          version: 3,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+
+        await store.nodes.Person.upsertById("rep3-seq", { name: "A", age: 1 });
+        await store.nodes.Person.upsertById("rep3-seq", { name: "B", age: 2 });
+        await store.nodes.Person.upsertById("rep3-seq", { name: "C" });
+        expect(batched).toEqual(await readComparableNode(store, "rep3-seq"));
+      });
+
+      it("mixes a repeated new id with an existing id in one batch, preserving order", async () => {
+        const store = context.getStore();
+        await store.nodes.Person.upsertById("mix-existing", {
+          name: "Seed",
+          age: 9,
+        });
+
+        const results = await store.nodes.Person.bulkUpsertById([
+          { id: "mix-new", props: { name: "New1" } },
+          { id: "mix-existing", props: { name: "Updated" } },
+          { id: "mix-new", props: { name: "New2" } },
+          { id: "mix-other", props: { name: "Other" } },
+        ]);
+
+        expect(results.map((node) => node.id)).toEqual([
+          "mix-new",
+          "mix-existing",
+          "mix-new",
+          "mix-other",
+        ]);
+        expect(results.map((node) => (node as PersonShape).name)).toEqual([
+          "New1",
+          "Updated",
+          "New2",
+          "Other",
+        ]);
+
+        expect(await readComparableNode(store, "mix-new")).toEqual({
+          name: "New2",
+          age: undefined,
+          version: 2,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+        expect(await readComparableNode(store, "mix-existing")).toEqual({
+          name: "Updated",
+          age: 9,
+          version: 2,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+        expect(await readComparableNode(store, "mix-other")).toEqual({
+          name: "Other",
+          age: undefined,
+          version: 1,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+      });
+
+      it("keeps the working path working for a repeated id whose row exists", async () => {
+        const store = context.getStore();
+        const seed = await store.nodes.Person.upsertById("rep-existing", {
+          name: "Seed",
+          age: 5,
+        });
+        expect(seed.meta.version).toBe(1);
+
+        // Two updates over an existing row: the pre-fix path already handled
+        // this, and it must stay unchanged.
+        await store.nodes.Person.bulkUpsertById([
+          { id: "rep-existing", props: { name: "B" } },
+          { id: "rep-existing", props: { name: "A" } },
+        ]);
+
+        expect(await readComparableNode(store, "rep-existing")).toEqual({
+          name: "A",
+          age: 5,
+          version: 3,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+      });
+
+      it("carries a repeated new id's validTo through the later copy", async () => {
+        const store = context.getStore();
+        const validTo = "2099-01-01T00:00:00.000Z";
+
+        await store.nodes.Person.bulkUpsertById([
+          { id: "rep-window", props: { name: "A" } },
+          { id: "rep-window", props: { name: "B" }, validTo },
+        ]);
+
+        const batched = await readComparableNode(store, "rep-window");
+        expect(batched.validTo).toBe(validTo);
+
+        // The lower bound comes from the CREATED row, not from the second item:
+        // an update to a live row never rewrites validFrom, so the window stays
+        // ordered exactly as the sequential pair produces it.
+        await store.nodes.Person.upsertById("rep-window-seq", { name: "A" });
+        await store.nodes.Person.upsertById(
+          "rep-window-seq",
+          { name: "B" },
+          { validTo },
+        );
+        expect(batched).toEqual(
+          await readComparableNode(store, "rep-window-seq"),
+        );
+      });
+
+      it("creates once and updates for a repeated NEW edge id, last-write-wins", async () => {
+        const store = context.getStore();
+        const [alice, bob] = await store.nodes.Person.bulkCreate([
+          { props: { name: "A" }, id: "rep-e-alice" },
+          { props: { name: "B" }, id: "rep-e-bob" },
+        ]);
+        if (alice === undefined || bob === undefined) {
+          throw new Error("expected both people to be created");
+        }
+
+        // Pre-fix this threw EdgeAlreadyExistsError.
+        const results = await store.edges.knows.bulkUpsertById([
+          { id: knowsId("rep-e"), from: alice, to: bob, props: { since: "A" } },
+          { id: knowsId("rep-e"), from: alice, to: bob, props: { since: "B" } },
+        ]);
+
+        expect(
+          results.map((edge) => (edge as { since?: string }).since),
+        ).toEqual(["A", "B"]);
+
+        const final = await store.edges.knows.getById(knowsId("rep-e"));
+        expect((final as { since?: string }).since).toBe("B");
+        // The create's endpoints stand: an update never repoints an edge.
+        expect(final?.fromId).toBe("rep-e-alice");
+        expect(final?.toId).toBe("rep-e-bob");
+
+        // Sequential equivalence: the same items as two single-item batches.
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("rep-e-seq"),
+            from: alice,
+            to: bob,
+            props: { since: "A" },
+          },
+        ]);
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("rep-e-seq"),
+            from: alice,
+            to: bob,
+            props: { since: "B" },
+          },
+        ]);
+        const sequential = await store.edges.knows.getById(
+          knowsId("rep-e-seq"),
+        );
+        expect((sequential as { since?: string }).since).toBe("B");
+      });
+    });
+
+    describe("with coalescing on", () => {
+      it("creates once and coalesces a value-identical copy of a new id", async () => {
+        const store = await context.createStore(integrationTestGraph, {
+          coalesceUnchangedUpserts: true,
+        });
+
+        const results = await store.nodes.Person.bulkUpsertById([
+          { id: "coal-new", props: { name: "A", age: 1 } },
+          { id: "coal-new", props: { name: "A", age: 1 } },
+        ]);
+
+        // One create, no update: the second copy resolves to the create's
+        // result — the same object — and the row stays at version 1.
+        expect(results[1]).toBe(results[0]);
+        expect(results[0]?.meta.version).toBe(1);
+        expect(await readComparableNode(store, "coal-new")).toEqual({
+          name: "A",
+          age: 1,
+          version: 1,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+      });
+
+      it("coalesces only the copies that match the running value", async () => {
+        const store = await context.createStore(integrationTestGraph, {
+          coalesceUnchangedUpserts: true,
+        });
+
+        // create A, coalesce A, update B, coalesce B → one create, one update.
+        const results = await store.nodes.Person.bulkUpsertById([
+          { id: "coal-run", props: { name: "A" } },
+          { id: "coal-run", props: { name: "A" } },
+          { id: "coal-run", props: { name: "B" } },
+          { id: "coal-run", props: { name: "B" } },
+        ]);
+
+        expect(results.map((node) => (node as PersonShape).name)).toEqual([
+          "A",
+          "A",
+          "B",
+          "B",
+        ]);
+        expect(results[1]).toBe(results[0]);
+        expect(results[3]).toBe(results[2]);
+        expect(await readComparableNode(store, "coal-run")).toEqual({
+          name: "B",
+          age: undefined,
+          version: 2,
+          deletedAt: undefined,
+          validTo: undefined,
+        });
+      });
+
+      it("coalesces a value-identical copy of a new edge id", async () => {
+        const store = await context.createStore(integrationTestGraph, {
+          coalesceUnchangedUpserts: true,
+        });
+        const [alice, bob] = await store.nodes.Person.bulkCreate([
+          { props: { name: "A" }, id: "coal-e-alice" },
+          { props: { name: "B" }, id: "coal-e-bob" },
+        ]);
+        if (alice === undefined || bob === undefined) {
+          throw new Error("expected both people to be created");
+        }
+
+        const results = await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("coal-e"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+          },
+          {
+            id: knowsId("coal-e"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+          },
+        ]);
+
+        // Edges carry no version counter; the coalesced copy resolving to the
+        // create's own result object is the signal that no update ran.
+        expect(results[1]).toBe(results[0]);
+        const final = await store.edges.knows.getById(knowsId("coal-e"));
+        expect((final as { since?: string }).since).toBe("2020");
+        expect(final?.meta.updatedAt).toBe(results[0]?.meta.updatedAt);
+      });
+    });
+
+    describe("with history capture", () => {
+      it("records a repeated new id as one created revision holding the final state", async () => {
+        const store = await context.createHistoryStore(integrationTestGraph);
+
+        await store.nodes.Person.bulkUpsertById([
+          { id: "hist-rep", props: { name: "A", age: 1 } },
+          { id: "hist-rep", props: { name: "B" } },
+        ]);
+
+        // The batch runs in one transaction, and capture is per-transaction, so
+        // the create and the update over it collapse into ONE revision: op
+        // "create" (the row did not exist before this transaction) holding the
+        // final merged state at the final version. Two creates — the defect's
+        // shape — could not produce this: they threw before capture.
+        expect(
+          await readRecordedRevisions(store, "Person", "hist-rep"),
+        ).toEqual([{ op: "create", version: 2, props: { name: "B", age: 1 } }]);
+
+        // Same collapse for a repeated id whose row already existed: the two
+        // updates in one transaction become one "update" revision. The new
+        // create path plugs into that machinery unchanged.
+        await store.nodes.Person.upsertById("hist-existing", { name: "S" });
+        await store.nodes.Person.bulkUpsertById([
+          { id: "hist-existing", props: { name: "B" } },
+          { id: "hist-existing", props: { name: "A" } },
+        ]);
+        expect(
+          await readRecordedRevisions(store, "Person", "hist-existing"),
+        ).toEqual([
+          { op: "create", version: 1, props: { name: "S" } },
+          { op: "update", version: 3, props: { name: "A" } },
+        ]);
+
+        // The sequential oracle spans two transactions, so it captures two
+        // revisions — same final state, one revision per transaction.
+        await store.nodes.Person.upsertById("hist-seq", { name: "A", age: 1 });
+        await store.nodes.Person.upsertById("hist-seq", { name: "B" });
+        expect(
+          await readRecordedRevisions(store, "Person", "hist-seq"),
+        ).toEqual([
+          { op: "create", version: 1, props: { name: "A", age: 1 } },
+          { op: "update", version: 2, props: { name: "B", age: 1 } },
+        ]);
+      });
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -3,6 +3,7 @@ export { registerAlgorithmIntegrationTests } from "./algorithms";
 export { registerBulkFindByIndexIntegrationTests } from "./bulk-find-by-index";
 export { registerBulkFindEndpointIntegrationTests } from "./bulk-find-endpoints";
 export { registerBulkFindHeterogeneousIntegrationTests } from "./bulk-find-heterogeneous";
+export { registerBulkUpsertRepeatedIdIntegrationTests } from "./bulk-upsert-repeated-ids";
 export { registerCoalesceUpsertIntegrationTests } from "./coalesce-upserts";
 export { registerContributionDiagnosticIntegrationTests } from "./contribution-diagnostics";
 export { registerCrossBackendConsistencyTests } from "./cross-backend";


### PR DESCRIPTION
`bulkUpsertById` applies items in order, so a repeated id in one batch is last-write-wins. That only held for an id whose row already existed: the create branch pushed to `toCreate` and continued WITHOUT registering the id in the batch-local `pending` map, so a second copy of a **new** id was bucketed as another create and the batch failed — `Node already exists` for nodes, and for edges either `Edge already exists` or a raw unique-constraint violation depending on the path. Any caller feeding a batch from a stream or a changeset, where a key can legitimately repeat, hit this on the first delivery of that key.

A queued create is now registered in `pending` exactly like a queued update, so a later copy of the id takes the update path against the queued create. Creates run before the updates in the same batch, and the update path re-reads its target row, so the later copy merges over the row the create actually wrote and inherits its validity lower bound — the final row is what the equivalent sequence of `upsertById` calls produces, with one version bump per real write. With `coalesceUnchangedUpserts` enabled, a value-identical second copy of a new id coalesces against the queued create instead of writing twice, and resolves to the create's own result. Under history capture nothing new is needed: capture is per-transaction, so the create and the update over it collapse into one `create` revision holding the batch's final state — the same collapse two updates in one batch already got.

The edge collection carried the identical defect and is fixed symmetrically. One asymmetry is inherent rather than introduced: an update never repoints an edge, so a later copy's `from` / `to` are ignored, exactly as they are for an id that already existed. That is now stated on the method's contract, along with the repeated-id rule itself, which was described only in internal comments before.

Two smaller consequences of routing every queued write through the same state, both in the same family as the reported bug. A repeated id whose dirty check rejected an earlier item's props now reports the validation error rather than a spurious "already exists", and no later copy can coalesce against the stale prefetched row after an earlier item queued a write. `pending` entries therefore carry a running value that may be undefined: presence of the entry is what routes a later copy away from a second create, while the props only decide coalescing, and an unknown running value simply never coalesces.

A queued create's running value costs a Zod parse that the insert repeats, and it is read only when the id actually appears again, so the new `findRepeatedUpsertIds` in the shared `coalesce` module computes it only for ids that repeat in the batch. Batches with all-distinct ids — the common case — pay one extra pass over the items and no extra validation.

Closes #401


Because the later copy is a real update rather than a rewritten create, the
state the update maintains beside the row is pinned too: the uniqueness
reservation the create took has to move to the final value (leaving the earlier
key reusable), and the fulltext projection has to hold the last copy's text. A
third case pins the running value itself against a kind whose schema carries a
default the input never sets and a transform that rewrites a field — taking the
running value from the raw item instead of the validated create makes a
value-identical second copy write again.

The repeated-id scan runs only for a store that enabled
`coalesceUnchangedUpserts`. The running value exists only to be dirty-checked,
so a default-configured batch no longer builds the id sets at all.
