### PR TITLE
fix(store): refuse valid-time windows of negative width

### DIFF
--- a/.changeset/refuse-inverted-validity-windows.md
+++ b/.changeset/refuse-inverted-validity-windows.md
@@ -1,0 +1,34 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Refuse valid-time windows of negative width. A write whose `validTo` precedes
+the row's effective `validFrom` describes a row that stopped being true before
+it started — observable at no `asOf` coordinate, and unrepairable by any later
+write — and it used to be accepted silently on every path except a node update.
+It now raises a `ValidationError` whose issue carries the new exported code
+`INVERTED_VALIDITY_WINDOW`.
+
+This is a behavior change: writes that previously succeeded now fail. Two shapes
+refuse where they did not before.
+
+- A stated `validFrom` / `validTo` PAIR must be ordered, on node and edge
+  `create`, `upsertById`, `bulkUpsertById`, `getOrCreateByEndpoints` and its bulk
+  form, and on an imported document. `getOrCreateByEndpoints` judges the pair
+  before its existence probe, so whether a call is valid no longer depends on
+  whether the edge happens to exist yet.
+- An in-place UPDATE's lone `validTo` must not precede the row's stored
+  `valid_from`. Nodes already enforced this; edges did not, which is how a graph
+  merge could hand a committed edge an end predating its start and still report
+  success.
+
+Interchange import records the refusal as a per-row error prefixed with
+`INVERTED_VALIDITY_WINDOW`, so one bad row does not abort the import. Trusted
+import refuses the whole stream with reason `invalid_stream`.
+
+Two shapes stay legal, deliberately. A ZERO-width window
+(`validTo === validFrom`) is what a same-instant retraction produces at
+millisecond precision, so the store's own output still round-trips. An INSERT
+carrying a lone historical `validTo` still means "born already ended": the write
+instant stamped as `valid_from` is a storage convention rather than a caller
+assertion, and such a row is read back through `includeEnded`.

--- a/.changeset/refuse-inverted-validity-windows.md
+++ b/.changeset/refuse-inverted-validity-windows.md
@@ -17,14 +17,28 @@ refuse where they did not before.
   form, and on an imported document. `getOrCreateByEndpoints` judges the pair
   before its existence probe, so whether a call is valid no longer depends on
   whether the edge happens to exist yet.
-- An in-place UPDATE's lone `validTo` must not precede the row's stored
-  `valid_from`. Nodes already enforced this; edges did not, which is how a graph
-  merge could hand a committed edge an end predating its start and still report
-  success.
+- An UPDATE's lone `validTo` must not precede the lower bound the row carries.
+  Nodes already enforced this; edges did not, which is how a graph merge could
+  hand a committed edge an end predating its start and still report success. This
+  covers a resurrecting write too: an edge RETAINS its `valid_from` across
+  resurrection, so reviving one into a window that closed before it began now
+  means restating the start — pass `validFrom` alongside `validTo`. Landing a
+  revived edge in the ENDED state is otherwise unchanged.
+
+`getOrCreateByEndpoints` and its bulk form now honor `validFrom` on the
+`"resurrected"` branch, where they previously accepted it and silently dropped
+it — which is what left the refusal above with no way to satisfy it. As the
+backend has always documented for a resurrecting write, naming `validFrom`
+asserts the COMPLETE window, so an accompanying `validTo` is applied and an
+omitted one REOPENS the revived row rather than leaving the tombstoned
+incarnation's end in place. A `"found"` or `"updated"` live edge is unaffected:
+its stored lower bound is history and still stays put.
 
 Interchange import records the refusal as a per-row error prefixed with
-`INVERTED_VALIDITY_WINDOW`, so one bad row does not abort the import. Trusted
-import refuses the whole stream with reason `invalid_stream`.
+`INVERTED_VALIDITY_WINDOW`, so one bad row does not abort the import; its
+`onConflict: "update"` legs are held to the existing row's `valid_from` exactly
+as a direct `update` is. Trusted import refuses the whole stream with reason
+`invalid_stream`.
 
 Two shapes stay legal, deliberately. A ZERO-width window
 (`validTo === validFrom`) is what a same-instant retraction produces at

--- a/apps/docs/src/content/docs/data-sync.md
+++ b/apps/docs/src/content/docs/data-sync.md
@@ -166,9 +166,13 @@ const membership = await store.edges.memberOf.getOrCreateByEndpoints(
 // membership.action: "created" | "found" | "updated" | "resurrected"
 ```
 
-For endpoint writes, `validFrom` applies only when a new edge is created.
-`validTo` also applies to the `"updated"` and `"resurrected"` branches. A
-`"found"` result performs no write and preserves the existing validity window.
+For endpoint writes, `validFrom` applies when a new edge is created and on the
+`"resurrected"` branch, where it restates the revived row's whole window; an
+`"updated"` live edge keeps its stored lower bound, which is history. `validTo`
+applies to both the `"updated"` and `"resurrected"` branches. A `"found"` result
+performs no write and preserves the existing validity window. An end that
+precedes the row's effective start is refused — see
+[Inverted validity windows](/errors/#inverted_validity_window).
 
 ### Edge Bulk Operations
 

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -120,6 +120,36 @@ try {
 }
 ```
 
+#### `INVERTED_VALIDITY_WINDOW`
+
+A `ValidationError` whose issue carries the exported code
+`INVERTED_VALIDITY_WINDOW` refused a valid-time window of negative width: the
+write's `validTo` precedes the row's effective `validFrom`, so the row would have
+stopped being true before it started and no `asOf` coordinate could observe it.
+Branch on the code rather than on the message.
+
+```typescript
+import { INVERTED_VALIDITY_WINDOW_CODE, ValidationError } from "@nicia-ai/typegraph";
+
+try {
+  // The stored validFrom is later than this end.
+  await store.edges.worksAt.update(edgeId, {}, { validTo: "2020-01-01T00:00:00.000Z" });
+} catch (error) {
+  if (
+    error instanceof ValidationError &&
+    error.details.issues.some((issue) => issue.code === INVERTED_VALIDITY_WINDOW_CODE)
+  ) {
+    // Supply an explicit validFrom for a historical window, or drop validTo.
+  }
+}
+```
+
+Interchange import records the same refusal as a per-row error prefixed with the
+code, so one bad row does not abort the import; trusted import refuses the whole
+stream with `TrustedImportError` reason `invalid_stream`. A zero-width window
+(`validTo === validFrom`) is legal and never raises this, and so is a create
+carrying only a historical `validTo`.
+
 ### `DisjointError`
 
 Thrown when attempting to create a node that violates a disjointness constraint.

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -128,7 +128,9 @@ historical `validTo` is refused as a `ValidationError` rather than
 persisting a window that ends before it begins; pass both bounds for a
 historical window. (Edge resurrection instead keeps its stored lower bound,
 so `getOrCreateByEndpoints` can resurrect an edge directly into the ended
-state.) This graph-wide rule does not depend on the
+state — but the end it names is held to that retained bound, so reviving
+an edge into a window that closed before the edge began likewise means
+passing both.) This graph-wide rule does not depend on the
 identity profile. Resurrection does not revive ended assertions, but folding
 runs again over the resurrected node when configured. Kind removal
 cascades assertion and closure rows for the removed kinds. Tightening ontology

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1527,11 +1527,16 @@ store.edges.worksAt.getOrCreateByEndpoints(
 }>;
 ```
 
-`validFrom` applies only when the operation creates the edge and otherwise
-leaves the existing start unchanged. `validTo` applies when the edge is
-created, updated, or resurrected. When `ifExists` is omitted or `"return"`, a
-live match produces the `"found"` action and neither temporal option changes
-the edge.
+`validFrom` applies when the operation creates the edge and when it resurrects
+one; an `"updated"` live match leaves the existing start unchanged, because a
+live row's lower bound is history. On a resurrection, naming `validFrom` asserts
+the COMPLETE window: an accompanying `validTo` is applied, and an omitted one
+reopens the revived row rather than keeping the tombstoned incarnation's end.
+`validTo` applies when the edge is created, updated, or resurrected, and may not
+precede the row's effective start — see
+[Inverted validity windows](/errors/#inverted_validity_window). When `ifExists`
+is omitted or `"return"`, a live match produces the `"found"` action and neither
+temporal option changes the edge.
 
 #### `bulkGetOrCreateByEndpoints(items, options?)`
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -695,6 +695,15 @@ Every write method below that accepts a `validFrom` option (`create`,
 that operation's own creation timestamp when omitted — `validFrom` is never
 left open-ended. `validTo` remains optional and open-ended until set.
 
+A window may not have negative width. Stating both endpoints out of order, or
+updating a row with a `validTo` that precedes its stored `validFrom`, raises a
+`ValidationError` whose issue carries the code `INVERTED_VALIDITY_WINDOW` — such
+a row stopped being true before it started, so no `asOf` coordinate could ever
+observe it. Two related shapes are legal: a ZERO-width window
+(`validTo === validFrom`), which is what a same-instant retraction produces; and
+a create carrying only a historical `validTo`, which means "born already ended"
+and is read back with the `includeEnded` temporal mode.
+
 ### Node Collections
 
 Each node type has a collection with these methods:

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -3185,6 +3185,9 @@ export function inverseOf(edgeA: EdgeType, edgeB: EdgeType): OntologyRelation;
 export function invertClosure(closure: ReadonlyMap<string, ReadonlySet<string>>): ReadonlyMap<string, ReadonlySet<string>>;
 
 // @public
+export const INVERTED_VALIDITY_WINDOW_CODE = "INVERTED_VALIDITY_WINDOW";
+
+// @public
 export function isConstraintError(error: unknown): boolean;
 
 // @public (undocumented)

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -179,6 +179,20 @@ export type ValidationIssue = Readonly<{
 }>;
 
 /**
+ * The stable {@link ValidationIssue.code} every inverted-validity-window
+ * refusal carries, so a caller can recognize that specific failure without
+ * matching on the message. `ValidationError`'s own code is the family-wide
+ * `VALIDATION_ERROR`, so the discriminator lives on the issue — mirroring the
+ * identity-import window refusal (`IDENTITY_IMPORT_INVALID_WINDOW`).
+ *
+ * A write carrying it was refused because `validTo` precedes the row's
+ * effective `validFrom`: the row would have stopped being true before it
+ * started, observable at no `asOf` coordinate at all. Zero-width windows
+ * (`validTo === validFrom`) are legal and never raise it.
+ */
+export const INVERTED_VALIDITY_WINDOW_CODE = "INVERTED_VALIDITY_WINDOW";
+
+/**
  * Details for ValidationError.
  */
 export type ValidationErrorDetails = Readonly<{

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -371,6 +371,7 @@ export {
   IdentityContradictionError,
   IdentitySeparationViolationError,
   InvalidEdgeWeightError,
+  INVERTED_VALIDITY_WINDOW_CODE,
   isConstraintError,
   isRecordedCaptureGuardError,
   isSystemError,

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -22,6 +22,7 @@ import { type EdgeRegistration, type NodeRegistration } from "../core/types";
 import {
   ConfigurationError,
   IdentityContradictionError,
+  INVERTED_VALIDITY_WINDOW_CODE,
   NodeNotFoundError,
   UniquenessError,
   ValidationError,
@@ -43,7 +44,10 @@ import { type GraphWriteLock } from "../store/recorded-capture/clock";
 import { storeBackend, storeRuntime } from "../store/runtime-port";
 import { type Store } from "../store/store";
 import { checkUniquenessConstraints } from "../store/uniqueness";
-import { validateOptionalCanonicalIsoDate } from "../utils/date";
+import {
+  assertOrderedValidityWindow,
+  validateOptionalCanonicalIsoDate,
+} from "../utils/date";
 import {
   type GraphData,
   type GraphDataHeader,
@@ -1075,18 +1079,27 @@ async function catchUniquenessError<T>(
 }
 
 /**
- * Validates an entity's validity-window timestamps against the canonical
- * fixed-width UTC ISO-8601 contract that `create` / `update` enforce, so no
- * import write path can persist a non-canonical `valid_from` / `valid_to` that
- * later mis-sorts as text against an `asOf` read coordinate. The interchange
- * schema enforces the same contract at the parse boundary, but `importGraph`
- * accepts a pre-typed `GraphData` and does not re-parse it, so this is the
- * guarantee for callers that bypass the schema. Returns a per-row error message
- * (recorded in the import result) instead of throwing, so one malformed row
- * does not abort the whole import.
+ * Validates an entity's validity window against the two contracts `create` /
+ * `update` enforce: canonical fixed-width UTC ISO-8601 timestamps, so no import
+ * write path can persist a `valid_from` / `valid_to` that later mis-sorts as
+ * text against an `asOf` read coordinate, and non-negative window WIDTH, so no
+ * import document can persist a row that stopped being true before it started.
+ * Import writes straight to the backend rather than through the store
+ * operations layer, so it carries its own copy of both — this is the only place
+ * the guarantee exists for an imported row.
+ *
+ * The interchange schema enforces the timestamp contract at the parse boundary,
+ * but `importGraph` accepts a pre-typed `GraphData` and does not re-parse it, so
+ * this is also the guarantee for callers that bypass the schema. Returns a
+ * per-row error message (recorded in the import result) instead of throwing, so
+ * one malformed row does not abort the whole import; an inverted window's
+ * message is prefixed with {@link INVERTED_VALIDITY_WINDOW_CODE} so the refusal
+ * is recognizable without parsing prose.
  */
 function validateValidityWindow(
   entity: Readonly<{
+    kind: string;
+    id: string;
     validFrom?: string | null | undefined;
     validTo?: string | undefined;
   }>,
@@ -1100,8 +1113,25 @@ function validateValidityWindow(
       "validFrom",
     );
     validateOptionalCanonicalIsoDate(entity.validTo, "validTo");
+    // Import INSERTS, so only a stated pair is judged — a lone historical
+    // validTo means "born already ended", exactly as it does on `create` (see
+    // assertWritableValidityWindow). `null` is a confirmed open-left window and
+    // is not a lower bound at all.
+    assertOrderedValidityWindow(
+      `${entity.kind} "${entity.id}"`,
+      entity.validFrom ?? undefined,
+      entity.validTo,
+    );
     return undefined;
   } catch (error) {
+    if (
+      error instanceof ValidationError &&
+      error.details.issues.some(
+        (issue) => issue.code === INVERTED_VALIDITY_WINDOW_CODE,
+      )
+    ) {
+      return `${INVERTED_VALIDITY_WINDOW_CODE}: ${error.message}`;
+    }
     return error instanceof Error ? error.message : String(error);
   }
 }

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -46,6 +46,7 @@ import { type Store } from "../store/store";
 import { checkUniquenessConstraints } from "../store/uniqueness";
 import {
   assertOrderedValidityWindow,
+  assertWritableValidityWindow,
   validateOptionalCanonicalIsoDate,
 } from "../utils/date";
 import {
@@ -917,6 +918,14 @@ async function processNodeSlice(
             record(node, { status: "skipped", liveTarget: false });
             break;
           }
+          const updateWindowError = validateUpdateValidityWindow(
+            node,
+            existing.valid_from,
+          );
+          if (updateWindowError !== undefined) {
+            record(node, { status: "error", error: updateWindowError });
+            break;
+          }
           const updateResult = await catchUniquenessError(() =>
             applyNodeUpdate(
               writeContext,
@@ -1079,49 +1088,15 @@ async function catchUniquenessError<T>(
 }
 
 /**
- * Validates an entity's validity window against the two contracts `create` /
- * `update` enforce: canonical fixed-width UTC ISO-8601 timestamps, so no import
- * write path can persist a `valid_from` / `valid_to` that later mis-sorts as
- * text against an `asOf` read coordinate, and non-negative window WIDTH, so no
- * import document can persist a row that stopped being true before it started.
- * Import writes straight to the backend rather than through the store
- * operations layer, so it carries its own copy of both — this is the only place
- * the guarantee exists for an imported row.
- *
- * The interchange schema enforces the timestamp contract at the parse boundary,
- * but `importGraph` accepts a pre-typed `GraphData` and does not re-parse it, so
- * this is also the guarantee for callers that bypass the schema. Returns a
- * per-row error message (recorded in the import result) instead of throwing, so
- * one malformed row does not abort the whole import; an inverted window's
- * message is prefixed with {@link INVERTED_VALIDITY_WINDOW_CODE} so the refusal
- * is recognizable without parsing prose.
+ * Runs a window assertion and reports its refusal as a per-row error message
+ * (recorded in the import result) instead of throwing, so one malformed row does
+ * not abort the whole import. An inverted window's message is prefixed with
+ * {@link INVERTED_VALIDITY_WINDOW_CODE} so the refusal is recognizable without
+ * parsing prose.
  */
-function validateValidityWindow(
-  entity: Readonly<{
-    kind: string;
-    id: string;
-    validFrom?: string | null | undefined;
-    validTo?: string | undefined;
-  }>,
-): string | undefined {
+function windowErrorOf(assert: () => void): string | undefined {
   try {
-    // null is a confirmed open-left window (see InterchangeNodeSchema's
-    // validFrom doc), not a value to format-check — treat it like
-    // "not provided" here, same as the canonical-date validator does.
-    validateOptionalCanonicalIsoDate(
-      entity.validFrom ?? undefined,
-      "validFrom",
-    );
-    validateOptionalCanonicalIsoDate(entity.validTo, "validTo");
-    // Import INSERTS, so only a stated pair is judged — a lone historical
-    // validTo means "born already ended", exactly as it does on `create` (see
-    // assertWritableValidityWindow). `null` is a confirmed open-left window and
-    // is not a lower bound at all.
-    assertOrderedValidityWindow(
-      `${entity.kind} "${entity.id}"`,
-      entity.validFrom ?? undefined,
-      entity.validTo,
-    );
+    assert();
     return undefined;
   } catch (error) {
     if (
@@ -1134,6 +1109,81 @@ function validateValidityWindow(
     }
     return error instanceof Error ? error.message : String(error);
   }
+}
+
+/**
+ * Validates an entity's validity window against the two contracts `create` /
+ * `update` enforce: canonical fixed-width UTC ISO-8601 timestamps, so no import
+ * write path can persist a `valid_from` / `valid_to` that later mis-sorts as
+ * text against an `asOf` read coordinate, and non-negative window WIDTH, so no
+ * import document can persist a row that stopped being true before it started.
+ * Import writes straight to the backend rather than through the store
+ * operations layer, so it carries its own copy of both — this is the only place
+ * the guarantee exists for an imported row.
+ *
+ * The interchange schema enforces the timestamp contract at the parse boundary,
+ * but `importGraph` accepts a pre-typed `GraphData` and does not re-parse it, so
+ * this is also the guarantee for callers that bypass the schema.
+ *
+ * This is the INSERT-shaped half, judged before the existence probe so a
+ * malformed document is refused whether or not the row already exists. The
+ * update legs additionally call {@link validateUpdateValidityWindow}, which
+ * needs the row.
+ */
+function validateValidityWindow(
+  entity: Readonly<{
+    kind: string;
+    id: string;
+    validFrom?: string | null | undefined;
+    validTo?: string | undefined;
+  }>,
+): string | undefined {
+  return windowErrorOf(() => {
+    // null is a confirmed open-left window (see InterchangeNodeSchema's
+    // validFrom doc), not a value to format-check — treat it like
+    // "not provided" here, same as the canonical-date validator does.
+    validateOptionalCanonicalIsoDate(
+      entity.validFrom ?? undefined,
+      "validFrom",
+    );
+    validateOptionalCanonicalIsoDate(entity.validTo, "validTo");
+    // On an INSERT only a stated pair is judged — a lone historical validTo
+    // means "born already ended", exactly as it does on `create` (see
+    // assertWritableValidityWindow). `null` is a confirmed open-left window and
+    // is not a lower bound at all.
+    assertOrderedValidityWindow(
+      `${entity.kind} "${entity.id}"`,
+      entity.validFrom ?? undefined,
+      entity.validTo,
+    );
+  });
+}
+
+/**
+ * The UPDATE-shaped half, for `onConflict: "update"` against a row that already
+ * exists. All four update legs — batched and sequential, nodes and edges — send
+ * the document's `validTo` to an in-place update of a LIVE row while its stored
+ * `valid_from` stays put, so the document's end is held to that bound exactly as
+ * `store.nodes.*.update` holds a caller's. Without this an import could still
+ * write the inverted row the direct update path refuses, and the insert-shaped
+ * check above cannot see it: such a document states no `validFrom` at all.
+ */
+function validateUpdateValidityWindow(
+  entity: Readonly<{
+    kind: string;
+    id: string;
+    validTo?: string | undefined;
+  }>,
+  storedValidFrom: string | undefined,
+): string | undefined {
+  return windowErrorOf(() => {
+    assertWritableValidityWindow(
+      `${entity.kind} "${entity.id}"`,
+      undefined,
+      storedValidFrom,
+      entity.validTo,
+    );
+  });
 }
 
 async function processNode(
@@ -1193,6 +1243,13 @@ async function processNode(
           // stays invisible — a uniqueness reservation held by a tombstoned
           // node would block live creates of the same value.
           return { status: "skipped", liveTarget: false };
+        }
+        const updateWindowError = validateUpdateValidityWindow(
+          node,
+          existing.valid_from,
+        );
+        if (updateWindowError !== undefined) {
+          return { status: "error", error: updateWindowError };
         }
         // Route through the shared write step so the update maintains
         // uniqueness entries, embeddings, and fulltext — the collection API's
@@ -1518,6 +1575,14 @@ async function processEdgeSlice(
             record(edge, { status: "skipped", liveTarget: false });
             break;
           }
+          const updateWindowError = validateUpdateValidityWindow(
+            edge,
+            existing.valid_from,
+          );
+          if (updateWindowError !== undefined) {
+            record(edge, { status: "error", error: updateWindowError });
+            break;
+          }
           await backend.updateEdge({
             graphId,
             id: edge.id,
@@ -1688,6 +1753,13 @@ async function processEdge(
         // the backend's update targets live rows only.
         if (existing.deleted_at !== undefined) {
           return { status: "skipped", liveTarget: false };
+        }
+        const updateWindowError = validateUpdateValidityWindow(
+          edge,
+          existing.valid_from,
+        );
+        if (updateWindowError !== undefined) {
+          return { status: "error", error: updateWindowError };
         }
         await backend.updateEdge({
           graphId,

--- a/packages/typegraph/src/interchange/trusted-import.ts
+++ b/packages/typegraph/src/interchange/trusted-import.ts
@@ -10,6 +10,7 @@ import { getSearchableFields } from "../core/searchable";
 import { TrustedImportError } from "../errors";
 import { storeBackend } from "../store/runtime-port";
 import type { Store } from "../store/store";
+import { isInvertedValidityWindow } from "../utils/date";
 import type {
   GraphData,
   GraphInterchangeChunk,
@@ -88,6 +89,27 @@ function rejectUnsupportedStoreFeatures<G extends GraphDef>(
 
 function invalidStream(message: string): TrustedImportError {
   return new TrustedImportError(message, "invalid_stream");
+}
+
+/**
+ * An entity whose stated window has negative width. Trusted import writes
+ * straight to SQL and skips schema validation for throughput, but a row that
+ * stopped being true before it started is a stream SHAPE fault rather than a
+ * policy check: it is unobservable at every `asOf` coordinate, and no later
+ * write repairs it. `null` validFrom is a confirmed open-left window, so there
+ * is no lower bound to invert against; zero width is legal (see
+ * {@link isInvertedValidityWindow}).
+ */
+function hasInvertedWindow(
+  entity: Readonly<{
+    validFrom?: string | null | undefined;
+    validTo?: string | undefined;
+  }>,
+): boolean {
+  return isInvertedValidityWindow(
+    entity.validFrom ?? undefined,
+    entity.validTo,
+  );
 }
 
 function nodeParams(graphId: string, node: InterchangeNode): InsertNodeParams {
@@ -173,6 +195,15 @@ async function consumeTrustedChunks<G extends GraphDef>(
             `Unknown node kind in trusted import: ${unknownKind}`,
           );
         }
+        const invertedNode = chunk.nodes.find((node) =>
+          hasInvertedWindow(node),
+        );
+        if (invertedNode !== undefined) {
+          throw invalidStream(
+            `Inverted validity window in trusted import: ${invertedNode.kind} "${invertedNode.id}" ends at ` +
+              `"${String(invertedNode.validTo)}", before its validFrom "${String(invertedNode.validFrom)}".`,
+          );
+        }
         await session.insertNodes(
           chunk.nodes.map((node) => nodeParams(store.graphId, node)),
         );
@@ -195,6 +226,15 @@ async function consumeTrustedChunks<G extends GraphDef>(
         if (invalidEdge !== undefined) {
           throw invalidStream(
             `Unknown edge or endpoint kind in trusted import: ${invalidEdge.kind}`,
+          );
+        }
+        const invertedEdge = chunk.edges.find((edge) =>
+          hasInvertedWindow(edge),
+        );
+        if (invertedEdge !== undefined) {
+          throw invalidStream(
+            `Inverted validity window in trusted import: ${invertedEdge.kind} edge "${invertedEdge.id}" ends at ` +
+              `"${String(invertedEdge.validTo)}", before its validFrom "${String(invertedEdge.validFrom)}".`,
           );
         }
         await session.insertEdges(

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -736,25 +736,22 @@ async function performEdgeUpdate<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
-  // An IN-PLACE update is held to the row's stored lower bound: the row
-  // demonstrably began at `valid_from`, so an end before it is incoherent, and
-  // this is the ordering hole the edge write path used to have (nodes have
-  // always been checked here).
+  // The row's stored lower bound is the effective one on EVERY edge update,
+  // in-place or resurrecting: an edge RETAINS `valid_from` unless the
+  // resurrection names a new one (see UpdateEdgeParams), so a lone `validTo`
+  // is always measured against the bound the row already carries. This is the
+  // ordering hole the edge write path used to have; nodes have always been
+  // checked here, and the two now agree.
   //
-  // A RESURRECTION is not. Edges RETAIN their stored lower bound unless the
-  // resurrection names a new one (see UpdateEdgeParams), and reviving one
-  // straight into the ENDED state is sanctioned public behavior —
-  // `getOrCreateByEndpoints` does exactly that to an ended employment and counts
-  // it against cardinality accordingly — so its lone `validTo` is a statement
-  // about the revived row's end, not a claim about its start. Nodes differ only
-  // because their resurrection RESETS `valid_from` to the write instant, which
-  // an unaccompanied historical `validTo` really would invert.
-  const resurrecting =
-    options?.clearDeleted === true && existing.deleted_at !== undefined;
+  // Resurrecting an edge straight into the ENDED state stays available — that is
+  // what `getOrCreateByEndpoints` does to an ended employment, counting it
+  // against cardinality as inactive — but the end it names must not precede the
+  // window it is ending. Reviving a row into a window that closed before the row
+  // began means restating the start, so pass `validFrom` alongside `validTo`.
   assertWritableValidityWindow(
     `edge "${id}"`,
     validFrom,
-    resurrecting ? undefined : existing.valid_from,
+    existing.valid_from,
     validTo,
   );
 
@@ -1246,11 +1243,18 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       effectiveValidTo,
     );
 
+    // A resurrection forwards `validFrom` as the create leg does: naming it
+    // restates the revived row's WHOLE window (the backend rewrites both
+    // endpoints together), which is the only way to revive a row into a window
+    // that closed before the row originally began. Dropping it here silently
+    // ignored a stated lower bound and left the caller no way to satisfy the
+    // window-ordering guard.
     const edge = await executeEdgeUpsertUpdate(
       ctx,
       {
         id: matchedDeletedRow.id,
         props: validatedProps,
+        ...(validFrom !== undefined && { validFrom }),
         ...(validTo !== undefined && { validTo }),
       },
       backend,
@@ -1411,6 +1415,8 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     fromId: string;
     toKind: string;
     toId: string;
+    /** Reaches the write only on a RESURRECTION, which rewrites both endpoints. */
+    validFrom?: string;
     validTo?: string;
   }
   interface DuplicateEntry {
@@ -1482,6 +1488,9 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
           fromId: entry.fromId,
           toKind: entry.toKind,
           toId: entry.toId,
+          ...(entry.validFrom !== undefined && {
+            validFrom: entry.validFrom,
+          }),
           ...(entry.validTo !== undefined && { validTo: entry.validTo }),
         });
       }
@@ -1559,11 +1568,16 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
           effectiveValidTo,
         );
 
+        // As in the single-item path: a resurrection forwards `validFrom` so a
+        // stated lower bound restates the revived row's whole window.
         const edge = await executeEdgeUpsertUpdate(
           ctx,
           {
             id: entry.row.id,
             props: entry.validatedProps,
+            ...(entry.validFrom !== undefined && {
+              validFrom: entry.validFrom,
+            }),
             ...(entry.validTo !== undefined && { validTo: entry.validTo }),
           },
           target,

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -33,6 +33,7 @@ import { type KindRegistry } from "../../registry/kind-registry";
 import { canonicalEqual } from "../../schema/canonical";
 import {
   assertOrderedValidityWindow,
+  assertWritableValidityWindow,
   validateOptionalCanonicalIsoDate,
 } from "../../utils/date";
 import { generateId } from "../../utils/id";
@@ -386,6 +387,11 @@ async function validateAndPrepareEdgeCreate<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
+  // A stated pair must be ordered. A lone historical validTo is NOT an error on
+  // an insert — it means "born already ended" (see
+  // assertWritableValidityWindow). Both create paths (single and batch) prepare
+  // through here, so this is the only insert-side check needed.
+  assertOrderedValidityWindow(`edge "${id}"`, validFrom, validTo);
 
   // Check cardinality constraints
   const cardinality = registration.cardinality ?? "many";
@@ -730,13 +736,27 @@ async function performEdgeUpdate<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
-  assertOrderedValidityWindow(`edge "${id}"`, validFrom, validTo);
-  // Deliberately NO effective-lower-bound check here (nodes have one): edge
-  // resurrection with a lone past `validTo` is sanctioned public behavior —
-  // `getOrCreateByEndpoints` resurrects an ended employment directly into the
-  // inactive state and counts it against cardinality accordingly. Edges also
-  // RETAIN their stored lower bound on resurrection, so the "born inverted"
-  // corruption the node check closes cannot silently arise from a merge here.
+  // An IN-PLACE update is held to the row's stored lower bound: the row
+  // demonstrably began at `valid_from`, so an end before it is incoherent, and
+  // this is the ordering hole the edge write path used to have (nodes have
+  // always been checked here).
+  //
+  // A RESURRECTION is not. Edges RETAIN their stored lower bound unless the
+  // resurrection names a new one (see UpdateEdgeParams), and reviving one
+  // straight into the ENDED state is sanctioned public behavior —
+  // `getOrCreateByEndpoints` does exactly that to an ended employment and counts
+  // it against cardinality accordingly — so its lone `validTo` is a statement
+  // about the revived row's end, not a claim about its start. Nodes differ only
+  // because their resurrection RESETS `valid_from` to the write instant, which
+  // an unaccompanied historical `validTo` really would invert.
+  const resurrecting =
+    options?.clearDeleted === true && existing.deleted_at !== undefined;
+  assertWritableValidityWindow(
+    `edge "${id}"`,
+    validFrom,
+    resurrecting ? undefined : existing.valid_from,
+    validTo,
+  );
 
   // `validFrom` reaches the backend only through a resurrecting write (see
   // UpdateEdgeParams): a live edge's lower bound is history and stays put.
@@ -1102,12 +1122,19 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
   validateMatchOnFields(edgeKind.schema, matchOn, kind);
 
   // Validate temporal inputs before the read probe so validity of a call does
-  // not depend on whether its endpoint identity already exists.
+  // not depend on whether its endpoint identity already exists. Only the
+  // endpoint PAIR can be judged here — the effective lower bound of a lone
+  // `validTo` belongs to the row the write leg resolves to, and is checked there.
   const validFrom = validateOptionalCanonicalIsoDate(
     options?.validFrom,
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(options?.validTo, "validTo");
+  assertOrderedValidityWindow(
+    `${kind} edge between ${fromKind} "${fromId}" and ${toKind} "${toId}"`,
+    validFrom,
+    validTo,
+  );
 
   // Probe outside the transaction: with ifExists "return", the common found
   // path performs no write, so it must not pay for a write transaction
@@ -1296,6 +1323,13 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       "validFrom",
     );
     const validTo = validateOptionalCanonicalIsoDate(item.validTo, "validTo");
+    // As in the single-item path: the endpoint pair is judged up front so a
+    // batch's validity does not depend on which items already exist.
+    assertOrderedValidityWindow(
+      `${kind} edge between ${item.fromKind} "${item.fromId}" and ${item.toKind} "${item.toId}"`,
+      validFrom,
+      validTo,
+    );
 
     const compositeKey = buildEdgeCompositeKey(
       item.fromKind,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -59,8 +59,8 @@ import { asCompiledRowsSql } from "../../query/sql-intent";
 import { type KindRegistry } from "../../registry/kind-registry";
 import { canonicalEqual } from "../../schema/canonical";
 import {
-  assertEffectiveValidityLowerBound,
   assertOrderedValidityWindow,
+  assertWritableValidityWindow,
   nowIso,
   validateOptionalCanonicalIsoDate,
 } from "../../utils/date";
@@ -589,6 +589,17 @@ function draftNodeCreate<G extends GraphDef>(
         operation: "create",
       });
 
+  const validFrom = validateOptionalCanonicalIsoDate(
+    input.validFrom,
+    "validFrom",
+  );
+  const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
+  // A stated pair must be ordered. A lone historical validTo is NOT an error on
+  // an insert — it means "born already ended" (see
+  // assertWritableValidityWindow). Both create paths (single and batch) draft
+  // through here, so this is the only insert-side check needed.
+  assertOrderedValidityWindow(`${kind} "${id}"`, validFrom, validTo);
+
   return {
     kind,
     id,
@@ -596,8 +607,8 @@ function draftNodeCreate<G extends GraphDef>(
     nodeKind,
     uniqueConstraints: registration.unique ?? [],
     validatedProps,
-    validFrom: validateOptionalCanonicalIsoDate(input.validFrom, "validFrom"),
-    validTo: validateOptionalCanonicalIsoDate(input.validTo, "validTo"),
+    validFrom,
+    validTo,
   };
 }
 
@@ -835,16 +846,15 @@ async function performNodeUpdate<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
-  assertOrderedValidityWindow(`${kind} "${id}"`, validFrom, validTo);
-  // The EFFECTIVE lower bound: an explicit validFrom, else — resurrection —
-  // the write instant the backend will stamp, else the live row's stored
-  // bound. A lone past validTo must not be born inverted.
-  assertEffectiveValidityLowerBound(
+  // Without an explicit validFrom the effective lower bound is the write
+  // instant the backend stamps on a resurrection (it rewrites valid_from), and
+  // the live row's stored bound otherwise.
+  assertWritableValidityWindow(
     `${kind} "${id}"`,
-    validFrom ??
-      (options?.clearDeleted && existing.deleted_at !== undefined ?
-        nowIso()
-      : existing.valid_from),
+    validFrom,
+    options?.clearDeleted && existing.deleted_at !== undefined ?
+      nowIso()
+    : existing.valid_from,
     validTo,
   );
 

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -729,13 +729,16 @@ export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> =
     /** Existing record behavior. Default: "return" */
     ifExists?: IfExistsMode;
     /**
-     * Valid-time start for a newly created edge. Ignored when an edge is found,
-     * updated, or resurrected.
+     * Valid-time start for a created or RESURRECTED edge — on a resurrection it
+     * asserts the complete window, so an omitted `validTo` reopens the revived
+     * row. Ignored when an edge is found or updated in place, whose stored lower
+     * bound is history.
      */
     validFrom?: string;
     /**
      * Valid-time end for a created, updated, or resurrected edge. Ignored when
-     * the operation returns an existing edge without writing.
+     * the operation returns an existing edge without writing. May not precede
+     * the row's effective start; see `INVERTED_VALIDITY_WINDOW_CODE`.
      */
     validTo?: string;
   }>;

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -200,8 +200,15 @@ export function validateOptionalCanonicalIsoDate(
  * being true before it started. The one comparison every window refusal is
  * built on, so paths that must report the fault through their own error type
  * (trusted import) decide it identically to the ones that throw a
- * `ValidationError`. Both endpoints are canonical ISO 8601 by the time they get
- * here, so a lexicographic compare is a chronological compare.
+ * `ValidationError`.
+ *
+ * PRECONDITION: both endpoints are canonical fixed-width UTC ISO 8601, which is
+ * what makes a lexicographic compare a chronological one. Every caller that
+ * throws reaches this through {@link validateOptionalCanonicalIsoDate} first,
+ * and rows read back from either backend are canonicalized by the row mappers.
+ * Trusted import is the exception: it trusts its stream's timestamps wholesale,
+ * so a non-canonical instant there mis-compares here — the same way it already
+ * mis-sorts against an `asOf` read coordinate once stored.
  *
  * ZERO width (`validFrom === validTo`) is not inverted: it is what a
  * same-instant retraction produces at millisecond precision, and the store's own

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -7,7 +7,7 @@
  * - Sorts correctly as strings
  */
 
-import { ValidationError } from "../errors";
+import { INVERTED_VALIDITY_WINDOW_CODE, ValidationError } from "../errors";
 
 /**
  * ISO 8601 datetime pattern.
@@ -196,39 +196,54 @@ export function validateOptionalCanonicalIsoDate(
 }
 
 /**
- * Rejects an inverted validity window. `validFrom > validTo` describes a row
- * that stopped being true before it started, so NO `asOf` coordinate can ever
- * observe it — the write succeeds and the row is then invisible everywhere,
- * which reads as data loss rather than as the error it is. Call this wherever
- * both endpoints are supplied together; both are canonical ISO 8601 by then, so
- * a lexicographic compare is a chronological compare.
+ * Whether a stated validity window has NEGATIVE width — a row that stopped
+ * being true before it started. The one comparison every window refusal is
+ * built on, so paths that must report the fault through their own error type
+ * (trusted import) decide it identically to the ones that throw a
+ * `ValidationError`. Both endpoints are canonical ISO 8601 by the time they get
+ * here, so a lexicographic compare is a chronological compare.
  *
- * @param subject - Human-readable identification of the row, for the message
- *   (e.g. `Person "01H..."`).
- * @throws ValidationError if both endpoints are present and out of order
+ * ZERO width (`validFrom === validTo`) is not inverted: it is what a
+ * same-instant retraction produces at millisecond precision, and the store's own
+ * output must round-trip.
  */
+export function isInvertedValidityWindow(
+  validFrom: string | undefined,
+  validTo: string | undefined,
+): boolean {
+  if (validFrom === undefined || validTo === undefined) return false;
+  return validFrom > validTo;
+}
+
 /**
- * Refuses a `validTo` whose EFFECTIVE lower bound would invert the window.
- * On a resurrecting write the backend stamps the write instant as the new
- * lower bound when no `validFrom` accompanies the write, so a lone past
- * `validTo` would be born inverted — permanently invisible at every
- * coordinate. On a live-row update the stored lower bound is the effective
- * one and must stay <= the new `validTo`.
+ * Refuses a `validTo` whose EFFECTIVE lower bound would invert the window. On an
+ * in-place update the row's stored lower bound is the effective one and must stay
+ * <= the new `validTo`; on a resurrection that RESETS `valid_from` it is the
+ * write instant, so a lone past `validTo` would be born inverted.
+ *
+ * A ZERO-width window (`validTo === effectiveValidFrom`) is legal and stays
+ * legal: it is what a same-instant retraction produces at millisecond
+ * precision, and the identity-import window check sanctions it for the same
+ * reason. Only NEGATIVE width refuses.
+ *
+ * Reached through {@link assertWritableValidityWindow} rather than called
+ * directly, so no writer can check the effective bound without also checking a
+ * stated pair.
  */
-export function assertEffectiveValidityLowerBound(
+function assertEffectiveValidityLowerBound(
   subject: string,
   effectiveValidFrom: string | undefined,
   validTo: string | undefined,
 ): void {
-  if (validTo === undefined || effectiveValidFrom === undefined) return;
-  if (effectiveValidFrom <= validTo) return;
+  if (!isInvertedValidityWindow(effectiveValidFrom, validTo)) return;
   throw new ValidationError(
     `Inverted validity window for ${subject}: the effective validFrom "${effectiveValidFrom}" is after validTo "${validTo}".`,
     {
       issues: [
         {
           path: "validTo",
-          message: `Expected the effective validFrom <= validTo, got "${effectiveValidFrom}" > "${validTo}". On a resurrecting write, pass an explicit validFrom alongside a historical validTo.`,
+          code: INVERTED_VALIDITY_WINDOW_CODE,
+          message: `Expected the effective validFrom <= validTo, got "${effectiveValidFrom}" > "${validTo}". The effective validFrom is the row's stored lower bound, or the write instant where the write stamps one.`,
         },
       ],
     },
@@ -239,19 +254,32 @@ export function assertEffectiveValidityLowerBound(
   );
 }
 
+/**
+ * Rejects an inverted validity window. `validFrom > validTo` describes a row
+ * that stopped being true before it started, so no current-mode or `asOf` read
+ * can ever observe it — the write succeeds and the row is then reachable only
+ * through `includeEnded`, which reads as data loss rather than as the error it
+ * is. Call this wherever both endpoints are supplied together; both are
+ * canonical ISO 8601 by then, so a lexicographic compare is a chronological
+ * compare.
+ *
+ * @param subject - Human-readable identification of the row, for the message
+ *   (e.g. `Person "01H..."`).
+ * @throws ValidationError if both endpoints are present and out of order
+ */
 export function assertOrderedValidityWindow(
   subject: string,
   validFrom: string | undefined,
   validTo: string | undefined,
 ): void {
-  if (validFrom === undefined || validTo === undefined) return;
-  if (validFrom <= validTo) return;
+  if (!isInvertedValidityWindow(validFrom, validTo)) return;
   throw new ValidationError(
     `Inverted validity window for ${subject}: validFrom "${validFrom}" is after validTo "${validTo}".`,
     {
       issues: [
         {
           path: "validFrom",
+          code: INVERTED_VALIDITY_WINDOW_CODE,
           message: `Expected validFrom <= validTo, got "${validFrom}" > "${validTo}"`,
         },
       ],
@@ -260,6 +288,47 @@ export function assertOrderedValidityWindow(
       suggestion:
         "Pass a validFrom at or before validTo, or omit validTo to leave the window open.",
     },
+  );
+}
+
+/**
+ * THE window-ordering guard a valid-time UPDATE goes through, identically for
+ * nodes and edges. Refuses a window of negative width — a row that stopped
+ * being true before it started — whether the caller states both endpoints or
+ * only the new end.
+ *
+ * Two checks, because the two failures deserve different messages: the caller
+ * who supplied both endpoints out of order gets told about the pair, and the
+ * caller whose lone `validTo` inverts against the bound the row will actually
+ * carry gets told which bound that is.
+ *
+ * INSERTS use {@link assertOrderedValidityWindow} alone. An insert carrying a
+ * lone historical `validTo` means "born already ended", and the write instant
+ * the backend stamps as `valid_from` is a storage convention rather than a
+ * caller assertion — the row is deliberately not current and is read back
+ * through `includeEnded`. Only an UPDATE has a lower bound the caller can be
+ * held to.
+ *
+ * @param subject - Human-readable identification of the row, for the message
+ *   (e.g. `Person "01H..."`).
+ * @param validFrom - The caller's explicit lower bound, if any.
+ * @param fallbackValidFrom - The lower bound the row carries when the caller
+ *   supplies none: the stored `valid_from` for an in-place update, the write
+ *   instant for a resurrection that resets it, `undefined` where there is no
+ *   bound to invert against.
+ * @throws ValidationError with issue code {@link INVERTED_VALIDITY_WINDOW_CODE}
+ */
+export function assertWritableValidityWindow(
+  subject: string,
+  validFrom: string | undefined,
+  fallbackValidFrom: string | undefined,
+  validTo: string | undefined,
+): void {
+  assertOrderedValidityWindow(subject, validFrom, validTo);
+  assertEffectiveValidityLowerBound(
+    subject,
+    validFrom ?? fallbackValidFrom,
+    validTo,
   );
 }
 

--- a/packages/typegraph/tests/find-or-create.test.ts
+++ b/packages/typegraph/tests/find-or-create.test.ts
@@ -8,6 +8,7 @@ import { defineEdge, defineGraph, defineNode } from "../src";
 import type { GraphBackend } from "../src/backend/types";
 import {
   CardinalityError,
+  INVERTED_VALIDITY_WINDOW_CODE,
   NodeConstraintNotFoundError,
   UniquenessError,
   ValidationError,
@@ -29,6 +30,15 @@ const Entity = defineNode("Entity", {
 });
 
 const relatedTo = defineEdge("relatedTo");
+
+/**
+ * The resurrect cases' window, stated as two fixed ORDERED instants in the past.
+ * Both endpoints are explicit on purpose: a resurrect that names only its end
+ * takes the row's creation instant as the start, so a hardcoded end silently
+ * becomes a negative-width window once the wall clock passes it.
+ */
+const RESURRECT_VALID_FROM = "2023-01-01T00:00:00.000Z";
+const RESURRECT_VALID_TO = "2024-12-31T23:59:59.999Z";
 
 const graph = defineGraph({
   id: "find_or_create_test",
@@ -717,10 +727,16 @@ describe("store.edges.*.getOrCreateByEndpoints()", () => {
     const acme = await store.nodes.Company.create({ name: "Acme" });
     const bigCo = await store.nodes.Company.create({ name: "BigCo" });
 
+    // The employment states its own historical START. Without one it would take
+    // the creation instant, and this case's fixed 2024 end — in the future when
+    // this test was written — has since drifted into the past, which stored a
+    // window of NEGATIVE width. An explicit validFrom keeps the resurrected
+    // window ordered no matter when the suite runs.
     const endedEmployment = await store.edges.oneActiveEdge.create(
       alice,
       acme,
       { label: "first" },
+      { validFrom: RESURRECT_VALID_FROM },
     );
     await store.edges.oneActiveEdge.delete(endedEmployment.id);
     await store.edges.oneActiveEdge.create(alice, bigCo, { label: "second" });
@@ -729,12 +745,48 @@ describe("store.edges.*.getOrCreateByEndpoints()", () => {
       alice,
       acme,
       { label: "first" },
-      { validTo: "2024-12-31T23:59:59.999Z" },
+      { validTo: RESURRECT_VALID_TO },
     );
 
     expect(result.action).toBe("resurrected");
     expect(result.edge.id).toBe(endedEmployment.id);
-    expect(result.edge.meta.validTo).toBe("2024-12-31T23:59:59.999Z");
+    expect(result.edge.meta.validFrom).toBe(RESURRECT_VALID_FROM);
+    expect(result.edge.meta.validTo).toBe(RESURRECT_VALID_TO);
+  });
+
+  it("refuses a resurrect whose validTo precedes the stated validFrom", async () => {
+    // The companion of the case above: resurrecting straight into the ended
+    // state is sanctioned, but the pair must still be ordered. Without this the
+    // drift that case used to carry could return as accepted behavior.
+    const store = createStore(edgeGraph, backend);
+    const alice = await store.nodes.Person.create({ name: "Alice" });
+    const acme = await store.nodes.Company.create({ name: "Acme" });
+
+    const endedEmployment = await store.edges.oneActiveEdge.create(
+      alice,
+      acme,
+      { label: "first" },
+      { validFrom: RESURRECT_VALID_FROM },
+    );
+    await store.edges.oneActiveEdge.delete(endedEmployment.id);
+
+    const revive = (): Promise<unknown> =>
+      store.edges.oneActiveEdge.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { label: "first" },
+        { validFrom: RESURRECT_VALID_TO, validTo: RESURRECT_VALID_FROM },
+      );
+
+    await expect(revive()).rejects.toThrow(ValidationError);
+    const rejection = await revive().catch((error: unknown) => error);
+    expect(
+      (rejection as ValidationError).details.issues.map((issue) => issue.code),
+    ).toContain(INVERTED_VALIDITY_WINDOW_CODE);
+
+    // Refused before any write: the tombstone is still a tombstone.
+    const stored = await store.edges.oneActiveEdge.getById(endedEmployment.id);
+    expect(stored).toBeUndefined();
   });
 
   it("validates temporal fields before resolving the operation branch", async () => {
@@ -922,10 +974,18 @@ describe("store.edges.*.bulkGetOrCreateByEndpoints()", () => {
     const alice = await store.nodes.Person.create({ name: "Alice" });
     const acme = await store.nodes.Company.create({ name: "Acme" });
 
-    const first = await store.edges.worksAt.create(alice, acme, {
-      role: "eng",
-      since: 2020,
-    });
+    // Both endpoints stated, for the reason RESURRECT_VALID_FROM documents: a
+    // hardcoded end with no stated start is measured against the creation
+    // instant, so it becomes a negative-width window as the clock passes it.
+    const first = await store.edges.worksAt.create(
+      alice,
+      acme,
+      {
+        role: "eng",
+        since: 2020,
+      },
+      { validFrom: RESURRECT_VALID_FROM },
+    );
     await store.edges.worksAt.delete(first.id);
 
     const results = await store.edges.worksAt.bulkGetOrCreateByEndpoints([
@@ -933,7 +993,7 @@ describe("store.edges.*.bulkGetOrCreateByEndpoints()", () => {
         from: alice,
         to: acme,
         props: { role: "resurrected", since: 2025 },
-        validTo: "2025-12-31T23:59:59.999Z",
+        validTo: RESURRECT_VALID_TO,
       },
     ]);
 
@@ -941,8 +1001,11 @@ describe("store.edges.*.bulkGetOrCreateByEndpoints()", () => {
     expect(requireDefined(results[0]).action).toBe("resurrected");
     expect(requireDefined(results[0]).edge.id).toBe(first.id);
     expect(requireDefined(results[0]).edge.role).toBe("resurrected");
+    expect(requireDefined(results[0]).edge.meta.validFrom).toBe(
+      RESURRECT_VALID_FROM,
+    );
     expect(requireDefined(results[0]).edge.meta.validTo).toBe(
-      "2025-12-31T23:59:59.999Z",
+      RESURRECT_VALID_TO,
     );
     expect(requireDefined(results[0]).edge.meta.deletedAt).toBeUndefined();
   });

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -19,7 +19,12 @@
  *  11. the branch that AUTHORED the committed end is credited in provenance —
  *      including when it authored nothing else on the row (issue #402), and
  *      including every branch that tied on that end — while a branch whose claim
- *      lost the least-claim rule, or whose ending a deletion absorbed, is not.
+ *      lost the least-claim rule, or whose ending a deletion absorbed, is not;
+ *  12. an ending that predates the TARGET row's start is refused, not committed.
+ *
+ * Case 12 is issue #398: an ending legal against the row a branch holds can still
+ * invert against a target that moved on underneath it, and the write layer now
+ * refuses rather than committing a row observable at no coordinate.
  *
  * Case 9 is the window half of issue #393: the repoint/dedupe fold is scoped to
  * collisions repointing INDUCED, so a window claim can no longer migrate between two
@@ -39,18 +44,21 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
+  INVERTED_VALIDITY_WINDOW_CODE,
+  ValidationError,
 } from "@nicia-ai/typegraph";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { asEdgeId, asNodeId } from "../../src/core/types";
 import { branch } from "../../src/graph-merge/branch";
+import { MergeError } from "../../src/graph-merge/errors";
 import { merge, mergeIncremental } from "../../src/graph-merge/merge";
 import {
   openProvenanceStore,
   readProvenance,
 } from "../../src/graph-merge/provenance-store";
-import { unwrap } from "../../src/graph-merge/result";
+import { isErr, unwrap } from "../../src/graph-merge/result";
 import type { GraphBranch, MergeReport } from "../../src/graph-merge/types";
 import { asBranchId } from "../../src/graph-merge/types";
 import { WINDOW_NOT_APPLICABLE_DROP_REASON } from "../../src/graph-merge/valid-window";
@@ -839,6 +847,56 @@ describe.each(backendMatrix())(
       expect((await nodeRow(forkPoint, "Patient", "pat-1")).version).toBe(
         versionBefore,
       );
+    });
+
+    it("refuses to commit an ending that predates the target row's start", async () => {
+      // Issue #398. A branch's ending is legal against the row the BRANCH holds,
+      // but an incremental target moves on underneath it: here the target
+      // replaces its edge with one that starts LATER than the branch's end.
+      // Committing the ending anyway leaves `valid_to` < `valid_from` — a row
+      // observable at no coordinate at all — which is exactly what the edge write
+      // path used to do while the merge reported success. The write must refuse
+      // and the merge must leave the target untouched.
+      const forkPoint = await seededForkPoint();
+      const target = (await forkOf(forkPoint, asBranchId("window-target")))
+        .store;
+      const branchA = await forkOf(forkPoint, BRANCH_A);
+      await branchA.store.edges.hadEncounter.update(
+        EDGE_1,
+        {},
+        { validTo: LATE },
+      );
+
+      await target.edges.hadEncounter.hardDelete(EDGE_1);
+      await target.edges.hadEncounter.create(
+        { kind: "Patient", id: "pat-1" },
+        { kind: "Encounter", id: "enc-1" },
+        { on: "2026-01-05" },
+        { id: EDGE_1, validFrom: LATEST },
+      );
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [branchA],
+        options: { branchOrder: BRANCH_ORDER },
+      });
+
+      // A typed merge failure carrying the write's typed refusal as its cause —
+      // not a raw driver error, and emphatically not a reported success.
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) return;
+      expect(result.error).toBeInstanceOf(MergeError);
+      const cause = result.error.cause;
+      expect(cause).toBeInstanceOf(ValidationError);
+      expect(
+        (cause as ValidationError).details.issues.map((issue) => issue.code),
+      ).toContain(INVERTED_VALIDITY_WINDOW_CODE);
+
+      // The target keeps the window it had, with no end at all.
+      const row = await edgeRow(target, "edge-1");
+      expect(canonicalizeDatabaseTimestamp(row.valid_from)).toBe(LATEST);
+      expect(await edgeEnd(target, "edge-1")).toBeUndefined();
     });
   },
 );

--- a/packages/typegraph/tests/inverted-validity-window.test.ts
+++ b/packages/typegraph/tests/inverted-validity-window.test.ts
@@ -14,9 +14,8 @@
  *   4. "born already ended" — an INSERT carrying a lone historical `validTo` —
  *      stays legal: the stamped `valid_from` is a storage convention, not a
  *      caller assertion, and the row is read back through `includeEnded`;
- *   5. resurrecting an EDGE straight into the ended state stays legal, because
- *      an edge retains its stored lower bound (a node's resurrection resets it,
- *      which is why the node path refuses the same shape);
+ *   5. resurrecting an edge into the ended state stays legal, but the end it
+ *      names is held to the bound the row RETAINS across resurrection;
  *   6. import refuses an inverted document per row, carrying the stable code.
  *
  * Trusted import carries the same refusal through its own typed stream error;
@@ -31,6 +30,7 @@ import { z } from "zod";
 
 import type { GraphBackend } from "../src";
 import {
+  asEdgeId,
   asNodeId,
   createStore,
   defineEdge,
@@ -42,6 +42,7 @@ import {
 import type { GraphData } from "../src/interchange";
 import {
   exportGraph,
+  FORMAT_VERSION,
   importGraph,
   ImportOptionsSchema,
 } from "../src/interchange";
@@ -375,10 +376,10 @@ describe("inverted valid-time windows", () => {
 
       // An ended employment, revived by endpoint identity with only its end
       // stated. An edge RETAINS its stored lower bound across resurrection, so
-      // the lone validTo is a statement about the revived row's end, not a claim
-      // about its start — `getOrCreateByEndpoints` counts it against cardinality
-      // as an inactive row. The node path refuses this same shape because a
-      // node's resurrection resets `valid_from` to the write instant.
+      // the lone validTo lands the row in the inactive state with its original
+      // start intact — `getOrCreateByEndpoints` counts it against cardinality as
+      // inactive. The end still has to sit at or after that start; see the case
+      // below.
       const ended = await store.edges.oneActiveJob.create(
         alice,
         acme,
@@ -397,7 +398,126 @@ describe("inverted valid-time windows", () => {
 
       expect(revived.action).toBe("resurrected");
       expect(revived.edge.id).toBe(ended.id);
+      expect(revived.edge.meta.validFrom).toBe(START);
       expect(revived.edge.meta.validTo).toBe(LATER);
+    });
+  });
+
+  describe("a resurrection is held to the bound it retains", () => {
+    it("refuses a resurrecting upsertById whose lone validTo precedes the stored start", async () => {
+      // An edge resurrection retains `valid_from`, so a lone earlier `validTo`
+      // is measured against it exactly as an in-place update's is. `upsertById`
+      // carries no resurrect-as-ended semantics of its own, so there is nothing
+      // here to exempt.
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: LATER },
+      );
+      await store.edges.worksAt.delete(edge.id);
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.bulkUpsertById([
+          {
+            id: edge.id,
+            from: alice,
+            to: acme,
+            props: { role: "Revived" },
+            validTo: START,
+          },
+        ]),
+      );
+    });
+
+    it("refuses a resurrecting getOrCreateByEndpoints whose lone validTo precedes the stored start", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: LATER },
+      );
+      await store.edges.worksAt.delete(edge.id);
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.getOrCreateByEndpoints(
+          alice,
+          acme,
+          { role: "Engineer" },
+          { validTo: START },
+        ),
+      );
+
+      // Refused before the write: the tombstone is untouched, so no inverted row
+      // was persisted and then hidden behind `deleted_at`.
+      const raw = requireDefined(await backend.getEdge(graph.id, edge.id));
+      expect(raw.valid_to).toBeUndefined();
+      expect(raw.deleted_at).toBeDefined();
+    });
+
+    it("accepts a resurrection that restates the whole historical window", async () => {
+      // The sanctioned way to revive a row into a window that closed before the
+      // row originally began: name both endpoints, and the resurrection rewrites
+      // them together.
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: LATER },
+      );
+      await store.edges.worksAt.delete(edge.id);
+
+      const revived = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: EARLIER, validTo: START },
+      );
+
+      expect(revived.action).toBe("resurrected");
+      expect(revived.edge.meta.validFrom).toBe(EARLIER);
+      expect(revived.edge.meta.validTo).toBe(START);
+    });
+
+    it("accepts a bulk resurrection that restates the whole historical window", async () => {
+      // The bulk companion. Both resurrect legs must FORWARD a stated
+      // `validFrom` — dropping it silently ignored the caller's lower bound and
+      // left the guard unsatisfiable, since the retained bound was the only one
+      // the write could be measured against.
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: LATER },
+      );
+      await store.edges.worksAt.delete(edge.id);
+
+      const [revived] = await store.edges.worksAt.bulkGetOrCreateByEndpoints([
+        {
+          from: alice,
+          to: acme,
+          props: { role: "Engineer" },
+          validFrom: EARLIER,
+          validTo: START,
+        },
+      ]);
+
+      expect(requireDefined(revived).action).toBe("resurrected");
+      expect(requireDefined(revived).edge.id).toBe(edge.id);
+      expect(requireDefined(revived).edge.meta.validFrom).toBe(EARLIER);
+      expect(requireDefined(revived).edge.meta.validTo).toBe(START);
     });
   });
 
@@ -429,6 +549,129 @@ describe("inverted valid-time windows", () => {
       expect(
         await target.nodes.Person.getById(asNodeId<typeof Person>("person-1")),
       ).toBeUndefined();
+    });
+
+    it("refuses an end before the existing row's start under onConflict update", async () => {
+      // `onConflict: "update"` sends the document's validTo to an IN-PLACE
+      // update of a live row whose stored validFrom stays put, so the document
+      // is held to that bound exactly as a direct `update` call would be. The
+      // insert-shaped pair check cannot see this: the document states no
+      // validFrom at all.
+      const target = createStore(graph, backend);
+      await target.nodes.Person.create(
+        { name: "Alice" },
+        { id: "person-1", validFrom: LATER },
+      );
+      await target.nodes.Person.create({ name: "Bob" }, { id: "person-2" });
+
+      const result = await importGraph(
+        target,
+        await documentWithWindow({ validFrom: undefined, validTo: START }),
+        ImportOptionsSchema.parse({ onConflict: "update" }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(requireDefined(result.errors[0]).id).toBe("person-1");
+      expect(requireDefined(result.errors[0]).error).toContain(
+        INVERTED_VALIDITY_WINDOW_CODE,
+      );
+
+      // The refused row keeps its window and its props.
+      const stored = requireDefined(
+        await target.nodes.Person.getById(asNodeId<typeof Person>("person-1")),
+      );
+      expect(stored.meta.validFrom).toBe(LATER);
+      expect(stored.meta.validTo).toBeUndefined();
+      expect(stored.name).toBe("Alice");
+    });
+
+    it("refuses on the duplicate-id leg as well as the batched one", async () => {
+      // A repeated id is deferred past the batch flush and re-run through the
+      // sequential row path, which is a second update leg with its own copy of
+      // the check. Both occurrences must refuse, or the guard covers only the
+      // leg the batch size happened to pick.
+      const target = createStore(graph, backend);
+      await target.nodes.Person.create(
+        { name: "Alice" },
+        { id: "person-1", validFrom: LATER },
+      );
+      await target.nodes.Person.create({ name: "Bob" }, { id: "person-2" });
+
+      const document = await documentWithWindow({
+        validFrom: undefined,
+        validTo: START,
+      });
+      const withDuplicate: GraphData = {
+        ...document,
+        nodes: [
+          ...document.nodes,
+          requireDefined(document.nodes.find((node) => node.id === "person-1")),
+        ],
+      };
+
+      const result = await importGraph(
+        target,
+        withDuplicate,
+        ImportOptionsSchema.parse({ onConflict: "update" }),
+      );
+
+      expect(result.errors).toHaveLength(2);
+      for (const error of result.errors) {
+        expect(error.id).toBe("person-1");
+        expect(error.error).toContain(INVERTED_VALIDITY_WINDOW_CODE);
+      }
+    });
+
+    it("refuses an edge end before the existing edge's start under onConflict update", async () => {
+      const target = createStore(graph, backend);
+      const alice = await target.nodes.Person.create(
+        { name: "Alice" },
+        { id: "person-1" },
+      );
+      const acme = await target.nodes.Company.create(
+        { name: "Acme" },
+        { id: "company-1" },
+      );
+      await target.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { id: "edge-1", validFrom: LATER },
+      );
+
+      const result = await importGraph(
+        target,
+        {
+          formatVersion: FORMAT_VERSION,
+          exportedAt: START,
+          source: { type: "external", description: "inverted window test" },
+          nodes: [],
+          edges: [
+            {
+              kind: "worksAt",
+              id: "edge-1",
+              from: { kind: "Person", id: "person-1" },
+              to: { kind: "Company", id: "company-1" },
+              properties: { role: "Manager" },
+              validTo: START,
+            },
+          ],
+        },
+        ImportOptionsSchema.parse({ onConflict: "update" }),
+      );
+
+      expect(result.errors).toHaveLength(1);
+      expect(requireDefined(result.errors[0]).error).toContain(
+        INVERTED_VALIDITY_WINDOW_CODE,
+      );
+
+      const stored = requireDefined(
+        await target.edges.worksAt.getById(asEdgeId<typeof worksAt>("edge-1")),
+      );
+      expect(stored.meta.validFrom).toBe(LATER);
+      expect(stored.meta.validTo).toBeUndefined();
+      expect(stored.role).toBe("Engineer");
     });
 
     it("accepts a zero-width and a born-ended window", async () => {

--- a/packages/typegraph/tests/inverted-validity-window.test.ts
+++ b/packages/typegraph/tests/inverted-validity-window.test.ts
@@ -1,0 +1,457 @@
+/**
+ * The write layer's refusal of INVERTED valid-time windows (issue #398).
+ *
+ * A window of negative width — `validTo` strictly before the row's effective
+ * `validFrom` — describes a row that stopped being true before it started. No
+ * `asOf` coordinate can observe it, and no later write repairs it, so accepting
+ * one is silent data loss dressed as a successful write. These cases pin where
+ * the refusal applies and, just as load-bearing, where it deliberately does not:
+ *
+ *   1. a stated PAIR must be ordered, on every node and edge write path;
+ *   2. an in-place UPDATE's lone `validTo` must not precede the row's stored
+ *      `valid_from` — the hole the edge path used to have;
+ *   3. ZERO width stays legal, on creates and on updates;
+ *   4. "born already ended" — an INSERT carrying a lone historical `validTo` —
+ *      stays legal: the stamped `valid_from` is a storage convention, not a
+ *      caller assertion, and the row is read back through `includeEnded`;
+ *   5. resurrecting an EDGE straight into the ended state stays legal, because
+ *      an edge retains its stored lower bound (a node's resurrection resets it,
+ *      which is why the node path refuses the same shape);
+ *   6. import refuses an inverted document per row, carrying the stable code.
+ *
+ * Trusted import carries the same refusal through its own typed stream error;
+ * those cases live with the rest of its stream-shape suite in
+ * `trusted-import.test.ts`.
+ *
+ * Every refusal carries {@link INVERTED_VALIDITY_WINDOW_CODE} on its issue, so
+ * callers branch on the code rather than on prose.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { GraphBackend } from "../src";
+import {
+  asNodeId,
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  INVERTED_VALIDITY_WINDOW_CODE,
+  ValidationError,
+} from "../src";
+import type { GraphData } from "../src/interchange";
+import {
+  exportGraph,
+  importGraph,
+  ImportOptionsSchema,
+} from "../src/interchange";
+import { requireDefined } from "../src/utils/presence";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string() }),
+  from: [Person],
+  to: [Company],
+});
+/** One LIVE job per person, so a resurrect counts against cardinality. */
+const oneActiveJob = defineEdge("oneActiveJob", {
+  schema: z.object({ role: z.string() }),
+  from: [Person],
+  to: [Company],
+});
+
+const graph = defineGraph({
+  id: "inverted-window",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    worksAt: { type: worksAt, from: [Person], to: [Company] },
+    oneActiveJob: {
+      type: oneActiveJob,
+      from: [Person],
+      to: [Company],
+      cardinality: "oneActive",
+    },
+  },
+});
+
+/**
+ * Fixed instants, ordered. Windows are stated explicitly rather than left to the
+ * write clock so a case means the same thing on every future test run — the
+ * `find-or-create` resurrect case aged into producing an inverted window by
+ * hardcoding a date that the wall clock eventually passed.
+ */
+const EARLIER = "2020-01-01T00:00:00.000Z";
+const START = "2021-01-01T00:00:00.000Z";
+const LATER = "2022-01-01T00:00:00.000Z";
+
+/**
+ * A two-node export whose `person-1` row carries `window` — which REPLACES both
+ * endpoints, so passing `validFrom: undefined` states the born-ended shape
+ * rather than inheriting the exported creation instant.
+ */
+async function documentWithWindow(
+  window: Readonly<{
+    validFrom: string | undefined;
+    validTo: string | undefined;
+  }>,
+): Promise<GraphData> {
+  const source = createStore(graph, createTestBackend());
+  await source.nodes.Person.create({ name: "Alice" }, { id: "person-1" });
+  await source.nodes.Person.create({ name: "Bob" }, { id: "person-2" });
+  const exported = await exportGraph(source, { includeTemporal: true });
+  return {
+    ...exported,
+    nodes: exported.nodes.map((node) =>
+      node.id === "person-1" ? { ...node, ...window } : node,
+    ),
+  };
+}
+
+/**
+ * Asserts a rejection is the inverted-window refusal, identified by its stable
+ * issue code rather than by message text.
+ */
+async function expectInvertedWindowRefusal(
+  operation: Promise<unknown>,
+): Promise<void> {
+  await expect(operation).rejects.toThrow(ValidationError);
+  const error = await operation.catch((error_: unknown) => error_);
+  expect(
+    (error as ValidationError).details.issues.map((issue) => issue.code),
+  ).toContain(INVERTED_VALIDITY_WINDOW_CODE);
+}
+
+describe("inverted valid-time windows", () => {
+  let backend: GraphBackend;
+
+  beforeEach(() => {
+    backend = createTestBackend();
+  });
+
+  describe("a stated pair must be ordered", () => {
+    it("refuses an inverted window on node create", async () => {
+      const store = createStore(graph, backend);
+
+      await expectInvertedWindowRefusal(
+        store.nodes.Person.create(
+          { name: "Alice" },
+          { validFrom: LATER, validTo: START },
+        ),
+      );
+    });
+
+    it("refuses an inverted window on edge create", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.create(
+          alice,
+          acme,
+          { role: "Engineer" },
+          { validFrom: LATER, validTo: START },
+        ),
+      );
+    });
+
+    it("refuses an inverted window on node upsertById", async () => {
+      const store = createStore(graph, backend);
+      await store.nodes.Person.create({ name: "Alice" }, { id: "person-1" });
+
+      await expectInvertedWindowRefusal(
+        store.nodes.Person.upsertByIdFromRecord(
+          "person-1",
+          { name: "Alice II" },
+          { validFrom: LATER, validTo: START },
+        ),
+      );
+    });
+
+    it("refuses an inverted window on edge bulkUpsertById", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(alice, acme, {
+        role: "Engineer",
+      });
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.bulkUpsertById([
+          {
+            id: edge.id,
+            from: alice,
+            to: acme,
+            props: { role: "Manager" },
+            validFrom: LATER,
+            validTo: START,
+          },
+        ]),
+      );
+    });
+
+    it("refuses an inverted window on getOrCreateByEndpoints even when the edge already exists", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      // The edge already exists, so this call resolves to the no-write "found"
+      // leg. The window is still judged: whether a call is valid must not depend
+      // on whether its endpoint identity happens to exist yet.
+      await store.edges.worksAt.create(alice, acme, { role: "Engineer" });
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.getOrCreateByEndpoints(
+          alice,
+          acme,
+          { role: "Engineer" },
+          { validFrom: LATER, validTo: START },
+        ),
+      );
+    });
+
+    it("refuses an inverted window on bulkGetOrCreateByEndpoints", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.bulkGetOrCreateByEndpoints([
+          { from: alice, to: acme, props: { role: "Engineer" } },
+          {
+            from: alice,
+            to: acme,
+            props: { role: "Manager" },
+            validFrom: LATER,
+            validTo: START,
+          },
+        ]),
+      );
+    });
+  });
+
+  describe("an update's lone validTo must not precede the stored start", () => {
+    it("refuses an end before the stored validFrom on a node", async () => {
+      const store = createStore(graph, backend);
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { validFrom: START },
+      );
+
+      await expectInvertedWindowRefusal(
+        store.nodes.Person.update(person.id, {}, { validTo: EARLIER }),
+      );
+    });
+
+    it("refuses an end before the stored validFrom on an edge", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: START },
+      );
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.update(edge.id, {}, { validTo: EARLIER }),
+      );
+    });
+
+    it("leaves the stored window untouched when the update is refused", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: START },
+      );
+
+      await expectInvertedWindowRefusal(
+        store.edges.worksAt.update(
+          edge.id,
+          { role: "Manager" },
+          {
+            validTo: EARLIER,
+          },
+        ),
+      );
+
+      // The refusal precedes the write, so neither the window nor the props of
+      // the same statement landed.
+      const stored = requireDefined(await store.edges.worksAt.getById(edge.id));
+      expect(stored.meta.validFrom).toBe(START);
+      expect(stored.meta.validTo).toBeUndefined();
+      expect(stored.role).toBe("Engineer");
+    });
+  });
+
+  describe("zero width stays legal", () => {
+    it("accepts validTo === validFrom on node and edge create", async () => {
+      const store = createStore(graph, backend);
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { validFrom: START, validTo: START },
+      );
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        person,
+        acme,
+        { role: "Engineer" },
+        { validFrom: START, validTo: START },
+      );
+
+      expect(person.meta.validFrom).toBe(START);
+      expect(person.meta.validTo).toBe(START);
+      expect(edge.meta.validFrom).toBe(START);
+      expect(edge.meta.validTo).toBe(START);
+    });
+
+    it("accepts an end exactly at the stored validFrom on update", async () => {
+      const store = createStore(graph, backend);
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { validFrom: START },
+      );
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        person,
+        acme,
+        { role: "Engineer" },
+        { validFrom: START },
+      );
+
+      const endedNode = await store.nodes.Person.update(
+        person.id,
+        {},
+        { validTo: START },
+      );
+      const endedEdge = await store.edges.worksAt.update(
+        edge.id,
+        {},
+        { validTo: START },
+      );
+
+      expect(endedNode.meta.validTo).toBe(START);
+      expect(endedEdge.meta.validTo).toBe(START);
+    });
+  });
+
+  describe("born already ended stays legal", () => {
+    it("accepts a lone historical validTo on node and edge create", async () => {
+      const store = createStore(graph, backend);
+      // No validFrom: the backend stamps the write instant. The row is
+      // deliberately not current, and `includeEnded` is how it is read back —
+      // an established idiom across the temporal, search and provenance suites.
+      const person = await store.nodes.Person.create(
+        { name: "Former" },
+        { validTo: START },
+      );
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const edge = await store.edges.worksAt.create(
+        person,
+        acme,
+        { role: "Former Employee" },
+        { validTo: START },
+      );
+
+      expect(person.meta.validTo).toBe(START);
+      expect(edge.meta.validTo).toBe(START);
+    });
+
+    it("accepts resurrecting an edge straight into the ended state", async () => {
+      const store = createStore(graph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const bigCo = await store.nodes.Company.create({ name: "BigCo" });
+
+      // An ended employment, revived by endpoint identity with only its end
+      // stated. An edge RETAINS its stored lower bound across resurrection, so
+      // the lone validTo is a statement about the revived row's end, not a claim
+      // about its start — `getOrCreateByEndpoints` counts it against cardinality
+      // as an inactive row. The node path refuses this same shape because a
+      // node's resurrection resets `valid_from` to the write instant.
+      const ended = await store.edges.oneActiveJob.create(
+        alice,
+        acme,
+        { role: "Intern" },
+        { validFrom: START },
+      );
+      await store.edges.oneActiveJob.delete(ended.id);
+      await store.edges.oneActiveJob.create(alice, bigCo, { role: "Engineer" });
+
+      const revived = await store.edges.oneActiveJob.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Intern" },
+        { validTo: LATER },
+      );
+
+      expect(revived.action).toBe("resurrected");
+      expect(revived.edge.id).toBe(ended.id);
+      expect(revived.edge.meta.validTo).toBe(LATER);
+    });
+  });
+
+  describe("import", () => {
+    it("refuses an inverted node window per row, carrying the stable code", async () => {
+      const document = await documentWithWindow({
+        validFrom: LATER,
+        validTo: START,
+      });
+      const target = createStore(graph, backend);
+
+      const result = await importGraph(
+        target,
+        document,
+        ImportOptionsSchema.parse({ onConflict: "skip" }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(requireDefined(result.errors[0]).id).toBe("person-1");
+      expect(requireDefined(result.errors[0]).error).toContain(
+        INVERTED_VALIDITY_WINDOW_CODE,
+      );
+      // One bad row does not abort the import: the sound row still lands.
+      expect(result.nodes.created).toBe(1);
+      expect(
+        await target.nodes.Person.getById(asNodeId<typeof Person>("person-2")),
+      ).toBeDefined();
+      expect(
+        await target.nodes.Person.getById(asNodeId<typeof Person>("person-1")),
+      ).toBeUndefined();
+    });
+
+    it("accepts a zero-width and a born-ended window", async () => {
+      const zeroWidth = await documentWithWindow({
+        validFrom: START,
+        validTo: START,
+      });
+      const bornEnded = await documentWithWindow({
+        validFrom: undefined,
+        validTo: START,
+      });
+
+      for (const document of [zeroWidth, bornEnded]) {
+        const target = createStore(graph, createTestBackend());
+        const result = await importGraph(
+          target,
+          document,
+          ImportOptionsSchema.parse({ onConflict: "skip" }),
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.success).toBe(true);
+        expect(result.nodes.created).toBe(2);
+      }
+    });
+  });
+});

--- a/packages/typegraph/tests/property/store-view.test.ts
+++ b/packages/typegraph/tests/property/store-view.test.ts
@@ -42,24 +42,27 @@ function dayTimestamp(day: number): string {
   return new Date(BASE_MS + day * DAY_MS).toISOString();
 }
 
-const timestampArb = fc
-  .integer({ min: 0, max: 20 })
-  .map((day) => dayTimestamp(day));
-const optionalTimestampArb = fc.option(timestampArb, { nil: undefined });
+const dayArb = fc.integer({ min: 0, max: 20 });
+const timestampArb = dayArb.map((day) => dayTimestamp(day));
 
 // `validFrom` is always set so the chosen `asOf` actually discriminates;
-// `validTo` is optional.
-const nodeSpecArb = fc.record({
-  validFrom: timestampArb,
-  validTo: optionalTimestampArb,
-});
+// `validTo` is optional and, when present, never precedes it. A window is
+// generated as a start plus a non-negative WIDTH rather than two independent
+// instants: the write layer refuses negative width, so an unordered pair would
+// only ever exercise that refusal instead of the view equivalence under test.
+// Zero width stays reachable (width 0) — it is legal and worth covering.
+const windowArb = fc
+  .tuple(dayArb, fc.option(fc.integer({ min: 0, max: 20 }), { nil: undefined }))
+  .map(([startDay, width]) => ({
+    validFrom: dayTimestamp(startDay),
+    validTo: width === undefined ? undefined : dayTimestamp(startDay + width),
+  }));
 
-const edgeSpecArb = fc.record({
-  from: fc.nat(),
-  to: fc.nat(),
-  validFrom: timestampArb,
-  validTo: optionalTimestampArb,
-});
+const nodeSpecArb = windowArb;
+
+const edgeSpecArb = fc
+  .tuple(fc.nat(), fc.nat(), windowArb)
+  .map(([from, to, window]) => ({ from, to, ...window }));
 
 const scenarioArb = fc.record({
   nodes: fc.array(nodeSpecArb, { minLength: 1, maxLength: 8 }),

--- a/packages/typegraph/tests/trusted-import.test.ts
+++ b/packages/typegraph/tests/trusted-import.test.ts
@@ -260,6 +260,95 @@ describe("trusted import", () => {
     ).toBeUndefined();
   });
 
+  it("refuses a node whose validity window is inverted", async () => {
+    // The trusted path skips schema validation for throughput, but a window of
+    // negative width is a stream SHAPE fault: the row would be observable at no
+    // `asOf` coordinate at all, and no later write repairs it (issue #398).
+    const store = createStore(trustedGraph, createTestBackend());
+
+    await expect(
+      trustedImportGraph(
+        store,
+        graphData([
+          {
+            kind: "TrustedPerson",
+            id: "alice",
+            properties: { name: "Alice" },
+            validFrom: "2026-01-01T00:00:00.000Z",
+            validTo: "2021-01-01T00:00:00.000Z",
+          },
+        ]),
+      ),
+    ).rejects.toEqual(expectReason("invalid_stream"));
+
+    expect(
+      await store.nodes.TrustedPerson.getById(asNodeId<typeof Person>("alice")),
+    ).toBeUndefined();
+  });
+
+  it("refuses an edge whose validity window is inverted", async () => {
+    const store = createStore(trustedGraph, createTestBackend());
+
+    await expect(
+      trustedImportGraph(
+        store,
+        graphData(
+          [
+            {
+              kind: "TrustedPerson",
+              id: "alice",
+              properties: { name: "Alice" },
+            },
+            { kind: "TrustedPerson", id: "bob", properties: { name: "Bob" } },
+          ],
+          [
+            {
+              kind: "trustedKnows",
+              id: "edge-1",
+              from: { kind: "TrustedPerson", id: "alice" },
+              to: { kind: "TrustedPerson", id: "bob" },
+              properties: { since: 2020 },
+              validFrom: "2026-01-01T00:00:00.000Z",
+              validTo: "2021-01-01T00:00:00.000Z",
+            },
+          ],
+        ),
+      ),
+    ).rejects.toEqual(expectReason("invalid_stream"));
+
+    expect(
+      await store.edges.trustedKnows.getById(asEdgeId<typeof knows>("edge-1")),
+    ).toBeUndefined();
+  });
+
+  it("accepts a zero-width and a born-ended window", async () => {
+    // Both round-trip the store's own output: a same-instant retraction emits
+    // zero width, and a row created with only a `validTo` carries a stamped
+    // lower bound it never asserted.
+    const store = createStore(trustedGraph, createTestBackend());
+
+    const result = await trustedImportGraph(
+      store,
+      graphData([
+        {
+          kind: "TrustedPerson",
+          id: "zero-width",
+          properties: { name: "Zero" },
+          validFrom: "2021-01-01T00:00:00.000Z",
+          validTo: "2021-01-01T00:00:00.000Z",
+        },
+        {
+          kind: "TrustedPerson",
+          id: "born-ended",
+          properties: { name: "Ended" },
+          validTo: "2021-01-01T00:00:00.000Z",
+        },
+      ]),
+    );
+
+    expect(result.nodes).toBe(2);
+  });
+
   it("refuses identity-enabled targets even when the input has no assertions", async () => {
     const store = createStore(identityTrustedGraph, createTestBackend());
 

--- a/packages/typegraph/tests/trusted-import.test.ts
+++ b/packages/typegraph/tests/trusted-import.test.ts
@@ -319,6 +319,12 @@ describe("trusted import", () => {
     expect(
       await store.edges.trustedKnows.getById(asEdgeId<typeof knows>("edge-1")),
     ).toBeUndefined();
+    // The WHOLE stream is refused, not just the offending chunk: the nodes
+    // streamed before the bad edge roll back with it, since the session runs
+    // inside one transaction.
+    expect(
+      await store.nodes.TrustedPerson.getById(asNodeId<typeof Person>("alice")),
+    ).toBeUndefined();
   });
 
   it("accepts a zero-width and a born-ended window", async () => {


### PR DESCRIPTION
A valid-time window whose `validTo` precedes the row's effective `validFrom` describes a row that stopped being true before it started. No `asOf` coordinate can observe it and no later write repairs it, so accepting one is silent data loss wearing the clothes of a successful write. Every write path except a node update accepted it.

## What now refuses

**A stated `validFrom` / `validTo` pair must be ordered.** Both node create paths fan into `draftNodeCreate` and both edge create paths into `validateAndPrepareEdgeCreate`, so one call each covers the single and batch writes. `getOrCreateByEndpoints` and its bulk form judge the pair before the existence probe, preserving the rule that already governs their temporal validation: whether a call is valid must not depend on whether its endpoint identity happens to exist yet.

**An update's lone `validTo` must not precede the lower bound the row carries.** Nodes already enforced this through the #240/#242 effective-bound machinery. Edges did not, which is the issue's headline reproduction and also how a graph merge could hand a committed edge an end predating its start and still report success — reproduced end to end before the fix, with the merge committing `valid_from` 2100-09-01 alongside `valid_to` 2100-06-01 and returning success.

This holds on a resurrecting write too, not just an in-place one. An edge *retains* its `valid_from` across resurrection, so a lone earlier `validTo` inverts against the bound the row already has, whichever path performs the revival — `upsertById` and `bulkUpsertById` carry no resurrect-as-ended semantics that would justify exempting them. Landing a revived edge in the ended state is unchanged; naming an end that precedes the row's own start now means restating the start. Nodes and edges therefore agree here, with no asymmetry left to explain.

**`getOrCreateByEndpoints` and `bulkGetOrCreateByEndpoints` now forward `validFrom` on the `"resurrected"` branch**, where it previously accepted the option and silently dropped it — the option docs even said so. That is what made the refusal above satisfiable: the backend has always documented that naming `validFrom` on a resurrecting write asserts the COMPLETE window, so the escape hatch existed and the option simply was not reaching it. An omitted `validTo` alongside a stated `validFrom` therefore reopens the revived row rather than leaving the tombstoned incarnation's end in place. A `"found"` or `"updated"` live edge is unaffected: its stored lower bound is history and still stays put.

Every refusal is a `ValidationError` whose issue carries the new exported code `INVERTED_VALIDITY_WINDOW`, so callers branch on the code rather than parsing prose. The discriminator sits on the issue because `ValidationError`'s own code is the family-wide `VALIDATION_ERROR` — the same shape the identity-import window refusal already uses for `IDENTITY_IMPORT_INVALID_WINDOW`.

## What deliberately stays legal

**Zero width.** `validTo === validFrom` is what a same-instant retraction produces at millisecond precision, and the store's own output has to round-trip. Only negative width refuses.

**"Born already ended" on an insert.** A create carrying a lone historical `validTo` still succeeds. The write instant the backend stamps as `valid_from` is a storage convention rather than a caller assertion, and such a row is deliberately not current — it is read back through `includeEnded`. This is not a concession: the idiom is load-bearing across the temporal, search, provenance, algorithm and count-edges suites, and an earlier draft that refused it broke 17 tests in 10 files. Holding inserts to the ordered pair alone is what the issue asks for; refusing the born-ended shape would be a much larger semantic change, and the cleaner version of it is to stop stamping `valid_from` at all in that case, which belongs in its own change.

## Where each writer is guarded

| Writer | Reaches | Guard |
| --- | --- | --- |
| `create` / `createFromRecord`, `bulkCreate` / `bulkInsert` (nodes) | `draftNodeCreate` | ordered pair |
| `create`, `bulkCreate` / `bulkInsert` (edges) | `validateAndPrepareEdgeCreate` | ordered pair |
| `update`, `upsertById`, `bulkUpsertById` (nodes) | `performNodeUpdate` | pair + effective bound (stored `valid_from`, or the write instant on a resurrection) |
| `update`, `upsertById`, `bulkUpsertById` (edges) | `performEdgeUpdate` | pair + effective bound (stored `valid_from`, in place and resurrecting alike) |
| `getOrCreateByEndpoints`, `bulkGetOrCreateByEndpoints` | own pre-probe validation, then the create/update legs | ordered pair up front; effective bound in the leg |
| `updateWhere` (set-based nodes) | — | not a window writer; takes props only |
| Merge-applied writes (`nodeValidityEnds` / `edgeValidityEnds`, `EdgeUpsert`) | `upsertByIdFromRecord` and `bulkUpsertById`, i.e. the operations layer | inherited; surfaces as a typed `MergeError` whose cause is the `ValidationError` |
| Interchange import, insert legs | `backend.insertNode` / `insertEdge` directly, bypassing the operations layer | own copy in `validateValidityWindow`, judged before the existence probe, recorded as a per-row error prefixed with the code so sound rows still land |
| Interchange import, `onConflict: "update"` legs (four: batched and sequential, nodes and edges) | `applyNodeUpdate` / `backend.updateEdge` | `validateUpdateValidityWindow` against the existing row's `valid_from` — the insert-shaped check cannot see this, since such a document states no `validFrom` at all |
| Trusted import | `session.insertNodes` / `insertEdges` | own copy, sharing the single `isInvertedValidityWindow` comparison, refusing the stream with reason `invalid_stream` |
| Identity detach / cascade | the identity-assertions relation only, never node or edge `valid_to` | out of scope, and already clamps to `valid_from` rather than minting a negative window |

The guard itself is one seam, `assertWritableValidityWindow`, over a single comparison in `isInvertedValidityWindow` — so the paths that must report the fault through their own error type decide it identically to the ones that throw.

## Incidental fixes

The `store-view` property generator produced `validFrom` and `validTo` as two independent instants, so roughly one scenario in four asserted that an inverted window is storable. It now generates a start plus a non-negative width, keeping zero width reachable.

Two resurrect fixtures in `find-or-create.test.ts` produced negative-width windows before this change, and the reason is worth recording: both create an edge with no explicit window and revive it with `validTo: "2024-12-31"`. That date was in the future when they were written, so the windows were ordered and the tests made their points without inverting anything — they became inverted only as the wall clock passed the fixture date. Both now state a historical `validFrom`, so their windows stay ordered permanently, and each has a companion case pinning that the same call with an end before the start refuses. Every new case states its window explicitly for the same reason. A sweep for the same pattern elsewhere (a hardcoded future `validTo` written with no `validFrom`) found no other fixture at risk.

## Composition with #404's repeated-id routing

`bulkUpsertById([{id: NEW, validTo: historical}])` is accepted (the born-ended create idiom), while `bulkUpsertById([{id: NEW}, {id: NEW, validTo: historical}])` refuses with the inverted-window code: #404 routes the repeated copy to the update path against the row the create just wrote, and updates hold a lone `validTo` to the effective lower bound. This matches both PRs' contracts — the equivalent sequential `upsertById` calls refuse identically — and it fails safe: no row is written at all. Stated here because repeating an id in a batch is now observable as the difference between a legal born-ended write and a refusal.

Closes #398
