### PR TITLE
fix: refuse non-canonical trusted-import timestamps; state the bulk-upsert handoff limitation

### DIFF
--- a/.changeset/canonical-trusted-import-windows.md
+++ b/.changeset/canonical-trusted-import-windows.md
@@ -1,5 +1,5 @@
 ---
-"@nicia-ai/typegraph": patch
+"@nicia-ai/typegraph": minor
 ---
 
 Refuse non-canonical validity-window timestamps in trusted import.

--- a/.changeset/canonical-trusted-import-windows.md
+++ b/.changeset/canonical-trusted-import-windows.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Refuse non-canonical validity-window timestamps in trusted import.
+
+`trustedImportGraph` / `trustedImportGraphStream` accept a pre-typed stream and
+never re-parse it, so a `validFrom` / `validTo` that TypeScript types as `string`
+but is not canonical fixed-width UTC ISO 8601 used to flow straight to SQL. Every
+temporal filter compares those values AS TEXT against an `asOf` coordinate, so a
+stored `"2021-01-01"`, `"...T00:00:00Z"`, `"...:00.1Z"` or `"...+01:00"` mis-sorts
+and silently includes or excludes the wrong rows — and it mis-decided the
+negative-width window check that the same path performs on the way in.
+
+Both window fields of every streamed node and edge are now format-checked with
+the same `isCanonicalIsoDate` decision the untrusted import schema and the store's
+own writes make. A violation refuses the WHOLE stream with a `TrustedImportError`
+carrying the existing reason `invalid_stream`, naming the offending field, row and
+value; the session's transaction rolls back, so chunks already streamed are not
+left behind. This is a behavior change: a stream that previously imported and
+stored an unsortable timestamp now fails loudly. Convert such values with
+`new Date(value).toISOString()`. The check is format-only — trusted import still
+skips property, reference and conflict validation — and it leaves an absent field
+and an explicitly `null` (confirmed open-left) `validFrom` untouched.
+
+Also documents a pre-existing bulk-API limitation, with no behavior change:
+`bulkUpsertById` groups every create ahead of every update, so one batch cannot
+hand a constrained value from one row to another (releasing a `unique` value or a
+`oneActive` edge slot and claiming it in the same batch throws `UniquenessError` /
+`CardinalityError`, where the equivalent sequential upserts succeed). The
+workaround is two batches, or sequential upserts.

--- a/apps/docs/src/content/docs/data-sync.md
+++ b/apps/docs/src/content/docs/data-sync.md
@@ -128,6 +128,50 @@ over the earlier value — a field the last copy omits keeps what an earlier cop
 set. Edges follow the same rule, except that an update never repoints an edge:
 the endpoints of the first write stand.
 
+#### One batch cannot hand a unique value from one row to another
+
+Item order settles which value each id ends up with, but the writes themselves
+are grouped: every create in the batch runs before every update. A batch where
+one item **releases** a `unique` constraint value and a later item **claims** it
+therefore fails, even though the same operations applied one at a time succeed:
+
+```typescript
+// "alice@example.com" is currently held by person_a.
+await store.nodes.Person.bulkUpsertById([
+  { id: "person_a", props: { email: "moved@example.com" } }, // releases it
+  { id: "person_b", props: { email: "alice@example.com" } }, // claims it
+]);
+// ✗ UniquenessError: person_b's create is checked while person_a still holds
+//   the value. On a backend with transactions nothing is written at all.
+```
+
+Edges have the same limitation for a `cardinality` slot: a batch that ends the
+lone `oneActive` edge from a source while creating its replacement fails with a
+`CardinalityError`, because the replacement's create is checked before the
+update that frees the slot.
+
+This is a stated property of the bulk APIs rather than a bug to work around
+blindly. A batch describes the **set** of rows you want, not a script to reach
+them by, and grouping the creates apart from the updates is what makes a batch a
+couple of statements instead of one per item. The failure is loud and typed —
+never a silently dropped write.
+
+Two workarounds, both exact:
+
+- **Split the handoff across two batches**: one carrying the items that release
+  the value, then one carrying the items that claim it. Reordering items
+  *within* a single batch does not help, since the grouping ignores that order.
+  This keeps bulk throughput for everything else.
+- **Apply the conflicting items as sequential `upsertById` calls** (for edges,
+  as `update` then `create`), which frees the value before the claim is checked.
+
+If a sync feed can legitimately swap unique values between records, the
+two-batch shape is the reliable one: send one `bulkUpsertById` for the ids that
+already exist, then a second for the new ones. The interchange importer
+(`importGraph` with `onConflict: "update"`) is the other option that handles it
+directly — it applies each row in document order regardless of batch size, at the
+cost of the per-row validation and reporting that a bulk write skips.
+
 ### bulkDelete
 
 Deletes multiple nodes by ID. Silently ignores IDs that don't exist:

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -284,6 +284,28 @@ for (let i = 0; i < items.length; i += BATCH_SIZE) {
 }
 ```
 
+### One `bulkUpsertById` batch cannot hand a constrained value between rows
+
+`bulkUpsertById` applies items in order for the purpose of deciding each row's
+final props, but it groups the writes: every create in the batch runs before
+every update. A batch where one item **releases** a constrained value and a later
+item **claims** it therefore fails, where the same operations applied one at a
+time succeed.
+
+- Nodes: releasing and re-claiming a `unique` constraint value in one batch
+  throws `UniquenessError` — the claiming create is checked while the releasing
+  row still reserves the value.
+- Edges: ending the lone `oneActive` edge from a source while creating its
+  replacement throws `CardinalityError`, for the same reason.
+
+Bulk semantics are set-like, not scripted — a batch states the rows you want,
+not an order to reach them in — so this is a stated limitation rather than a
+pending fix. It always surfaces as a typed error, never as a dropped write.
+Split the handoff across two batches (release, then claim), or apply the
+conflicting items as sequential `upsertById` calls. See
+[Data Sync](/data-sync#one-batch-cannot-hand-a-unique-value-from-one-row-to-another)
+for the worked example.
+
 ## Graph Analytics Limits
 
 TypeGraph ships focused algorithms on `store.algorithms.*` — shortest path

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -302,7 +302,8 @@ Bulk semantics are set-like, not scripted — a batch states the rows you want,
 not an order to reach them in — so this is a stated limitation rather than a
 pending fix. It always surfaces as a typed error, never as a dropped write.
 Split the handoff across two batches (release, then claim), or apply the
-conflicting items as sequential `upsertById` calls. See
+conflicting items one at a time — as sequential `upsertById` calls for nodes,
+and as `update` then `create` for edges, which have no single-item upsert. See
 [Data Sync](/data-sync#one-batch-cannot-hand-a-unique-value-from-one-row-to-another)
 for the worked example.
 

--- a/packages/typegraph/src/interchange/trusted-import.ts
+++ b/packages/typegraph/src/interchange/trusted-import.ts
@@ -10,7 +10,7 @@ import { getSearchableFields } from "../core/searchable";
 import { TrustedImportError } from "../errors";
 import { storeBackend } from "../store/runtime-port";
 import type { Store } from "../store/store";
-import { isInvertedValidityWindow } from "../utils/date";
+import { isCanonicalIsoDate, isInvertedValidityWindow } from "../utils/date";
 import type {
   GraphData,
   GraphInterchangeChunk,
@@ -91,6 +91,73 @@ function invalidStream(message: string): TrustedImportError {
   return new TrustedImportError(message, "invalid_stream");
 }
 
+/** The stated validity window of a streamed node or edge. */
+type StatedValidityWindow = Readonly<{
+  validFrom?: string | null | undefined;
+  validTo?: string | undefined;
+}>;
+
+const VALIDITY_WINDOW_FIELDS = ["validFrom", "validTo"] as const;
+
+type ValidityWindowField = (typeof VALIDITY_WINDOW_FIELDS)[number];
+
+/**
+ * The first window field of `entity` stating a timestamp that is not canonical
+ * fixed-width UTC ISO 8601, or `undefined` when every stated one is.
+ *
+ * A trusted stream is never re-parsed, so this is the only place its timestamps
+ * are held to the format the rest of the system assumes. It is deliberately
+ * format-ONLY — the same {@link isCanonicalIsoDate} decision the untrusted
+ * path's schema and the store's own write validation make, and nothing more —
+ * because a non-canonical instant is not merely ugly: every temporal filter
+ * compares these values AS TEXT against an `asOf` coordinate, so a variable-width
+ * one (`...:00.1Z`, an offset, date-only) mis-sorts and silently includes or
+ * excludes the wrong rows once stored, and it would mis-decide the negative-width
+ * check below on the way in. Two field tests per row costs about a microsecond
+ * against the ~4µs an in-memory SQLite row already costs — the price of the
+ * stream's ordering claims meaning anything.
+ *
+ * An absent field states nothing, and a `null` validFrom is a confirmed
+ * open-left window (see {@link nodeParams}) — neither is a timestamp to check.
+ */
+function nonCanonicalWindowField(
+  entity: StatedValidityWindow,
+): ValidityWindowField | undefined {
+  return VALIDITY_WINDOW_FIELDS.find((field) => {
+    const stated = entity[field];
+    return typeof stated === "string" && !isCanonicalIsoDate(stated);
+  });
+}
+
+/**
+ * The first entity in `entities` stating a non-canonical window timestamp, with
+ * the offending field. Allocates only on the failing path, so a clean chunk pays
+ * one predicate per stated timestamp and nothing else.
+ */
+function findNonCanonicalWindow<Entity extends StatedValidityWindow>(
+  entities: readonly Entity[],
+): Readonly<{ entity: Entity; field: ValidityWindowField }> | undefined {
+  for (const entity of entities) {
+    const field = nonCanonicalWindowField(entity);
+    if (field !== undefined) return { entity, field };
+  }
+  return undefined;
+}
+
+/** The refusal message for a non-canonical window timestamp on `subject`. */
+function nonCanonicalWindowMessage(
+  subject: string,
+  field: ValidityWindowField,
+  value: string | null | undefined,
+): string {
+  return (
+    `Non-canonical ${field} in trusted import: ${subject} states "${String(value)}". ` +
+    `Expected canonical fixed-width UTC ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ), ` +
+    `which is what makes a stored timestamp sort chronologically against an asOf ` +
+    `coordinate. Convert with new Date(value).toISOString().`
+  );
+}
+
 /**
  * An entity whose stated window has negative width. Trusted import writes
  * straight to SQL and skips schema validation for throughput, but a row that
@@ -99,13 +166,12 @@ function invalidStream(message: string): TrustedImportError {
  * write repairs it. `null` validFrom is a confirmed open-left window, so there
  * is no lower bound to invert against; zero width is legal (see
  * {@link isInvertedValidityWindow}).
+ *
+ * Only ever reached for a chunk whose timestamps {@link findNonCanonicalWindow}
+ * has already accepted, which is what makes the lexicographic compare inside a
+ * chronological one.
  */
-function hasInvertedWindow(
-  entity: Readonly<{
-    validFrom?: string | null | undefined;
-    validTo?: string | undefined;
-  }>,
-): boolean {
+function hasInvertedWindow(entity: StatedValidityWindow): boolean {
   return isInvertedValidityWindow(
     entity.validFrom ?? undefined,
     entity.validTo,
@@ -195,6 +261,17 @@ async function consumeTrustedChunks<G extends GraphDef>(
             `Unknown node kind in trusted import: ${unknownKind}`,
           );
         }
+        const nonCanonicalNode = findNonCanonicalWindow(chunk.nodes);
+        if (nonCanonicalNode !== undefined) {
+          const { entity, field } = nonCanonicalNode;
+          throw invalidStream(
+            nonCanonicalWindowMessage(
+              `${entity.kind} "${entity.id}"`,
+              field,
+              entity[field],
+            ),
+          );
+        }
         const invertedNode = chunk.nodes.find((node) =>
           hasInvertedWindow(node),
         );
@@ -226,6 +303,17 @@ async function consumeTrustedChunks<G extends GraphDef>(
         if (invalidEdge !== undefined) {
           throw invalidStream(
             `Unknown edge or endpoint kind in trusted import: ${invalidEdge.kind}`,
+          );
+        }
+        const nonCanonicalEdge = findNonCanonicalWindow(chunk.edges);
+        if (nonCanonicalEdge !== undefined) {
+          const { entity, field } = nonCanonicalEdge;
+          throw invalidStream(
+            nonCanonicalWindowMessage(
+              `${entity.kind} edge "${entity.id}"`,
+              field,
+              entity[field],
+            ),
           );
         }
         const invertedEdge = chunk.edges.find((edge) =>

--- a/packages/typegraph/src/interchange/trusted-import.ts
+++ b/packages/typegraph/src/interchange/trusted-import.ts
@@ -97,13 +97,18 @@ type StatedValidityWindow = Readonly<{
   validTo?: string | undefined;
 }>;
 
-const VALIDITY_WINDOW_FIELDS = ["validFrom", "validTo"] as const;
+type ValidityWindowField = "validFrom" | "validTo";
 
-type ValidityWindowField = (typeof VALIDITY_WINDOW_FIELDS)[number];
+/** A stated window field that is not canonical, with the offending value. */
+type NonCanonicalWindow = Readonly<{
+  field: ValidityWindowField;
+  value: string;
+}>;
 
 /**
  * The first window field of `entity` stating a timestamp that is not canonical
- * fixed-width UTC ISO 8601, or `undefined` when every stated one is.
+ * fixed-width UTC ISO 8601 — with the offending value — or `undefined` when
+ * every stated one is canonical.
  *
  * A trusted stream is never re-parsed, so this is the only place its timestamps
  * are held to the format the rest of the system assumes. It is deliberately
@@ -120,26 +125,30 @@ type ValidityWindowField = (typeof VALIDITY_WINDOW_FIELDS)[number];
  * An absent field states nothing, and a `null` validFrom is a confirmed
  * open-left window (see {@link nodeParams}) — neither is a timestamp to check.
  */
-function nonCanonicalWindowField(
+function nonCanonicalWindowOf(
   entity: StatedValidityWindow,
-): ValidityWindowField | undefined {
-  return VALIDITY_WINDOW_FIELDS.find((field) => {
-    const stated = entity[field];
-    return typeof stated === "string" && !isCanonicalIsoDate(stated);
-  });
+): NonCanonicalWindow | undefined {
+  const { validFrom, validTo } = entity;
+  if (typeof validFrom === "string" && !isCanonicalIsoDate(validFrom)) {
+    return { field: "validFrom", value: validFrom };
+  }
+  if (typeof validTo === "string" && !isCanonicalIsoDate(validTo)) {
+    return { field: "validTo", value: validTo };
+  }
+  return undefined;
 }
 
 /**
  * The first entity in `entities` stating a non-canonical window timestamp, with
- * the offending field. Allocates only on the failing path, so a clean chunk pays
- * one predicate per stated timestamp and nothing else.
+ * the offending field and value. Allocates only on the failing path, so a clean
+ * chunk pays one predicate per stated timestamp and nothing else.
  */
 function findNonCanonicalWindow<Entity extends StatedValidityWindow>(
   entities: readonly Entity[],
-): Readonly<{ entity: Entity; field: ValidityWindowField }> | undefined {
+): (NonCanonicalWindow & Readonly<{ entity: Entity }>) | undefined {
   for (const entity of entities) {
-    const field = nonCanonicalWindowField(entity);
-    if (field !== undefined) return { entity, field };
+    const nonCanonical = nonCanonicalWindowOf(entity);
+    if (nonCanonical !== undefined) return { entity, ...nonCanonical };
   }
   return undefined;
 }
@@ -148,10 +157,10 @@ function findNonCanonicalWindow<Entity extends StatedValidityWindow>(
 function nonCanonicalWindowMessage(
   subject: string,
   field: ValidityWindowField,
-  value: string | null | undefined,
+  value: string,
 ): string {
   return (
-    `Non-canonical ${field} in trusted import: ${subject} states "${String(value)}". ` +
+    `Non-canonical ${field} in trusted import: ${subject} states "${value}". ` +
     `Expected canonical fixed-width UTC ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ), ` +
     `which is what makes a stored timestamp sort chronologically against an asOf ` +
     `coordinate. Convert with new Date(value).toISOString().`
@@ -263,12 +272,12 @@ async function consumeTrustedChunks<G extends GraphDef>(
         }
         const nonCanonicalNode = findNonCanonicalWindow(chunk.nodes);
         if (nonCanonicalNode !== undefined) {
-          const { entity, field } = nonCanonicalNode;
+          const { entity, field, value } = nonCanonicalNode;
           throw invalidStream(
             nonCanonicalWindowMessage(
               `${entity.kind} "${entity.id}"`,
               field,
-              entity[field],
+              value,
             ),
           );
         }
@@ -307,12 +316,12 @@ async function consumeTrustedChunks<G extends GraphDef>(
         }
         const nonCanonicalEdge = findNonCanonicalWindow(chunk.edges);
         if (nonCanonicalEdge !== undefined) {
-          const { entity, field } = nonCanonicalEdge;
+          const { entity, field, value } = nonCanonicalEdge;
           throw invalidStream(
             nonCanonicalWindowMessage(
               `${entity.kind} edge "${entity.id}"`,
               field,
-              entity[field],
+              value,
             ),
           );
         }

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -924,6 +924,19 @@ export type NodeCollection<
    * a tombstoned one — both write a fresh validity window — defaulting to the
    * operation's timestamp when omitted. It has no effect on an update to a live
    * row, whose lower bound is already history.
+   *
+   * **Limitation — a batch cannot hand a unique value from one row to
+   * another.** Item order settles which value each id ends up with, but the
+   * writes themselves are grouped: every create runs before every update. So a
+   * batch where one item RELEASES a `unique` constraint value and a later item
+   * CLAIMS it — `[{ id: "a", props: { email: "moved@x" } }, { id: "b", props:
+   * { email: "shared@x" } }]` where `a` currently holds `"shared@x"` and `b` is
+   * new — checks `b`'s create while `a` still reserves the value, and the whole
+   * batch fails with a `UniquenessError`. The equivalent sequence of
+   * single `upsertById` calls succeeds. A batch states the set of rows it wants,
+   * not a script to reach them by; the failure is loud rather than silent, and
+   * the workaround is to split the handoff across two batches (release, then
+   * claim) or to apply those items as sequential `upsertById` calls.
    */
   bulkUpsertById: (
     items: readonly Readonly<{
@@ -1319,6 +1332,18 @@ export type EdgeCollection<
    * a tombstoned one — both write a fresh validity window — defaulting to the
    * operation's timestamp when omitted. It has no effect on an update to a live
    * row, whose lower bound is already history.
+   *
+   * **Limitation — a batch cannot hand a constrained slot from one edge to
+   * another.** Item order settles the final props, but the writes are grouped:
+   * every create runs before every update. So a batch where one item frees the
+   * slot a `cardinality` constraint allows and a later item claims it — ending
+   * the lone `oneActive` edge from a source while creating its replacement —
+   * checks the create while the old edge is still active, and the whole batch
+   * fails with a `CardinalityError`. Applying the update first, as
+   * separate `update` / `create` calls, succeeds. A batch states the set of
+   * edges it wants, not a script to reach them by; the failure is loud rather
+   * than silent, and the workaround is to split the handoff across two batches
+   * (free the slot, then claim it) or to apply those items individually.
    */
   bulkUpsertById: (
     items: readonly Readonly<{

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -203,12 +203,14 @@ export function validateOptionalCanonicalIsoDate(
  * `ValidationError`.
  *
  * PRECONDITION: both endpoints are canonical fixed-width UTC ISO 8601, which is
- * what makes a lexicographic compare a chronological one. Every caller that
- * throws reaches this through {@link validateOptionalCanonicalIsoDate} first,
- * and rows read back from either backend are canonicalized by the row mappers.
- * Trusted import is the exception: it trusts its stream's timestamps wholesale,
- * so a non-canonical instant there mis-compares here — the same way it already
- * mis-sorts against an `asOf` read coordinate once stored.
+ * what makes a lexicographic compare a chronological one. Every caller
+ * establishes that before comparing, with no exception: the paths that throw a
+ * `ValidationError` reach this through {@link validateOptionalCanonicalIsoDate},
+ * rows read back from either backend are canonicalized by the row mappers, and
+ * trusted import — which skips schema validation for throughput — format-checks
+ * the stated window fields of every streamed row against
+ * {@link isCanonicalIsoDate} before reaching here. So no caller can compare a
+ * value that would mis-sort, here or later against an `asOf` coordinate.
  *
  * ZERO width (`validFrom === validTo`) is not inverted: it is what a
  * same-instant retraction produces at millisecond precision, and the store's own

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -206,11 +206,14 @@ export function validateOptionalCanonicalIsoDate(
  * what makes a lexicographic compare a chronological one. Every caller
  * establishes that before comparing, with no exception: the paths that throw a
  * `ValidationError` reach this through {@link validateOptionalCanonicalIsoDate},
- * rows read back from either backend are canonicalized by the row mappers, and
- * trusted import — which skips schema validation for throughput — format-checks
- * the stated window fields of every streamed row against
- * {@link isCanonicalIsoDate} before reaching here. So no caller can compare a
- * value that would mis-sort, here or later against an `asOf` coordinate.
+ * and trusted import — which skips schema validation for throughput —
+ * format-checks the stated window fields of every streamed row against
+ * {@link isCanonicalIsoDate} before reaching here. A bound read back from a row
+ * needs no check of its own: it is canonical because the write that stored it
+ * was held to this same contract — SQLite hands that text back verbatim, and the
+ * PostgreSQL row mapper normalizes the driver's shape back to it. So no caller
+ * can compare a value that would mis-sort, here or later against an `asOf`
+ * coordinate.
  *
  * ZERO width (`validFrom === validTo`) is not inverted: it is what a
  * same-instant retraction produces at millisecond precision, and the store's own

--- a/packages/typegraph/tests/bulk-upsert-constraint-handoff.test.ts
+++ b/packages/typegraph/tests/bulk-upsert-constraint-handoff.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The bulk-upsert BATCH-ORDER limitation (issue #411).
+ *
+ * `bulkUpsertById` groups every create ahead of every update, so a batch that
+ * hands a constrained value from one row to another — the earlier item frees it,
+ * a later item claims it — is refused even though the same operations applied as
+ * sequential `upsertById` calls succeed. Bulk semantics are set-like, not
+ * scripted: a batch states the rows it wants, not an order to reach them in.
+ *
+ * These cases pin the limitation as CONTRACTUAL rather than accidental. Each
+ * asserts both halves — the batch throws the typed error, and the identical
+ * sequence of single upserts succeeds — because only the pair distinguishes an
+ * ordering limitation from a constraint that simply cannot be satisfied. They
+ * therefore pass against the pre-#411 tree too; the change #411 landed is the
+ * documented contract in `store/types.ts` and the data-sync guide.
+ *
+ * Both constrained shapes a batch can hand off are covered:
+ *   - nodes: a `unique` constraint value ({@link UniquenessError});
+ *   - edges: the lone active edge a `oneActive` cardinality allows
+ *     ({@link CardinalityError}).
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { GraphBackend } from "../src";
+import {
+  asEdgeId,
+  asNodeId,
+  CardinalityError,
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  UniquenessError,
+} from "../src";
+import { requireDefined } from "../src/utils/presence";
+import { createTestBackend } from "./test-utils";
+
+const SHARED_EMAIL = "shared@example.com";
+const MOVED_EMAIL = "moved@example.com";
+const JOB_STARTED_AT = "2025-01-01T00:00:00.000Z";
+const JOB_ENDED_AT = "2026-01-01T00:00:00.000Z";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), email: z.string() }),
+});
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+/** One LIVE job per person, so freeing the slot is a prerequisite for a new one. */
+const oneActiveJob = defineEdge("oneActiveJob", {
+  schema: z.object({ role: z.string() }),
+  from: [Person],
+  to: [Company],
+});
+
+const graph = defineGraph({
+  id: "bulk-upsert-handoff",
+  nodes: {
+    Person: {
+      type: Person,
+      unique: [
+        {
+          name: "person_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Company: { type: Company },
+  },
+  edges: {
+    oneActiveJob: {
+      type: oneActiveJob,
+      from: [Person],
+      to: [Company],
+      cardinality: "oneActive",
+    },
+  },
+});
+
+describe("bulkUpsertById constraint handoff within one batch", () => {
+  let backend: GraphBackend;
+
+  beforeEach(() => {
+    backend = createTestBackend();
+  });
+
+  it("refuses a node batch that moves a unique value from one row to another", async () => {
+    const store = createStore(graph, backend);
+    await store.nodes.Person.upsertById("holder", {
+      name: "holder",
+      email: SHARED_EMAIL,
+    });
+
+    // `holder` releases SHARED_EMAIL and `claimant` takes it. Creates run
+    // first, so the create of `claimant` is checked while `holder` still
+    // reserves the value.
+    const rejection = await store.nodes.Person.bulkUpsertById([
+      { id: "holder", props: { name: "holder", email: MOVED_EMAIL } },
+      { id: "claimant", props: { name: "claimant", email: SHARED_EMAIL } },
+    ]).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(UniquenessError);
+    expect((rejection as UniquenessError).details).toMatchObject({
+      kind: "Person",
+      constraintName: "person_email",
+    });
+    // The refused batch left the graph untouched.
+    const holderAfterRejection = requireDefined(
+      await store.nodes.Person.getById(asNodeId<typeof Person>("holder")),
+    );
+    expect(holderAfterRejection.email).toBe(SHARED_EMAIL);
+    expect(
+      await store.nodes.Person.getById(asNodeId<typeof Person>("claimant")),
+    ).toBeUndefined();
+
+    // The same two writes, applied in the stated order, succeed: the
+    // limitation is the batch's ordering, not the constraint.
+    await store.nodes.Person.upsertById("holder", {
+      name: "holder",
+      email: MOVED_EMAIL,
+    });
+    await store.nodes.Person.upsertById("claimant", {
+      name: "claimant",
+      email: SHARED_EMAIL,
+    });
+    const claimant = requireDefined(
+      await store.nodes.Person.getById(asNodeId<typeof Person>("claimant")),
+    );
+    expect(claimant.email).toBe(SHARED_EMAIL);
+  });
+
+  it("refuses an edge batch that ends the one active edge a new edge needs", async () => {
+    const store = createStore(graph, backend);
+    const person = await store.nodes.Person.create({
+      name: "worker",
+      email: "worker@example.com",
+    });
+    const previousEmployer = await store.nodes.Company.create({
+      name: "previous",
+    });
+    const nextEmployer = await store.nodes.Company.create({ name: "next" });
+    const currentJob = await store.edges.oneActiveJob.create(
+      { kind: "Person", id: person.id },
+      { kind: "Company", id: previousEmployer.id },
+      { role: "old" },
+      { validFrom: JOB_STARTED_AT },
+    );
+
+    const endCurrentJob = {
+      id: currentJob.id,
+      from: { kind: "Person", id: person.id } as const,
+      to: { kind: "Company", id: previousEmployer.id } as const,
+      props: { role: "old" },
+      validTo: JOB_ENDED_AT,
+    };
+    const startNextJob = {
+      id: asEdgeId<typeof oneActiveJob>("next-job"),
+      from: { kind: "Person", id: person.id } as const,
+      to: { kind: "Company", id: nextEmployer.id } as const,
+      props: { role: "new" },
+    };
+
+    // Ending the current job frees the person's single active-job slot, but
+    // the create of the next job is checked before that update runs.
+    const rejection = await store.edges.oneActiveJob
+      .bulkUpsertById([endCurrentJob, startNextJob])
+      .catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(CardinalityError);
+    expect((rejection as CardinalityError).details).toMatchObject({
+      edgeKind: "oneActiveJob",
+      cardinality: "oneActive",
+    });
+    // The refused batch left the graph untouched.
+    expect(await store.edges.oneActiveJob.count()).toBe(1);
+    expect(
+      await store.edges.oneActiveJob.getById(startNextJob.id),
+    ).toBeUndefined();
+
+    // Applied in the stated order the same handoff succeeds. Edges have no
+    // single-item upsert, so the sequential equivalent is the update the first
+    // item would perform followed by the create the second one would.
+    await store.edges.oneActiveJob.update(
+      endCurrentJob.id,
+      endCurrentJob.props,
+      { validTo: endCurrentJob.validTo },
+    );
+    await store.edges.oneActiveJob.create(
+      startNextJob.from,
+      startNextJob.to,
+      startNextJob.props,
+      { id: startNextJob.id },
+    );
+    const nextJob = requireDefined(
+      await store.edges.oneActiveJob.getById(startNextJob.id),
+    );
+    expect(nextJob.role).toBe("new");
+  });
+
+  it("accepts the same handoff split across two batches", async () => {
+    const store = createStore(graph, backend);
+    await store.nodes.Person.upsertById("holder", {
+      name: "holder",
+      email: SHARED_EMAIL,
+    });
+
+    // The documented workaround: release in one batch, claim in the next.
+    await store.nodes.Person.bulkUpsertById([
+      { id: "holder", props: { name: "holder", email: MOVED_EMAIL } },
+    ]);
+    await store.nodes.Person.bulkUpsertById([
+      { id: "claimant", props: { name: "claimant", email: SHARED_EMAIL } },
+    ]);
+
+    const holder = requireDefined(
+      await store.nodes.Person.getById(asNodeId<typeof Person>("holder")),
+    );
+    const claimant = requireDefined(
+      await store.nodes.Person.getById(asNodeId<typeof Person>("claimant")),
+    );
+    expect(holder.email).toBe(MOVED_EMAIL);
+    expect(claimant.email).toBe(SHARED_EMAIL);
+  });
+});

--- a/packages/typegraph/tests/trusted-import.test.ts
+++ b/packages/typegraph/tests/trusted-import.test.ts
@@ -361,25 +361,35 @@ describe("trusted import", () => {
     ).toBeUndefined();
   });
 
-  it("names the offending field, row, and value in the refusal", async () => {
-    const store = createStore(trustedGraph, createTestBackend());
+  it.each([
+    { field: "validFrom" as const, value: "2021-01-01" },
+    { field: "validTo" as const, value: "2021-01-01T00:00:00Z" },
+  ])(
+    "names the offending $field, row, and value in the refusal",
+    async ({ field, value }) => {
+      // Each window field must report ITS OWN value, so a refusal points at the
+      // timestamp to convert rather than at the row's other endpoint.
+      const store = createStore(trustedGraph, createTestBackend());
 
-    await expect(
-      trustedImportGraph(
-        store,
-        graphData([
-          {
-            kind: "TrustedPerson",
-            id: "alice",
-            properties: { name: "Alice" },
-            validTo: "2021-01-01T00:00:00Z",
-          },
-        ]),
-      ),
-    ).rejects.toThrow(
-      /Non-canonical validTo in trusted import: TrustedPerson "alice" states "2021-01-01T00:00:00Z"/,
-    );
-  });
+      await expect(
+        trustedImportGraph(
+          store,
+          graphData([
+            {
+              kind: "TrustedPerson",
+              id: "alice",
+              properties: { name: "Alice" },
+              ...(field === "validFrom" ?
+                { validFrom: value }
+              : { validTo: value }),
+            },
+          ]),
+        ),
+      ).rejects.toThrow(
+        `Non-canonical ${field} in trusted import: TrustedPerson "alice" states "${value}"`,
+      );
+    },
+  );
 
   it("refuses a non-canonical edge window and rolls back the nodes already streamed", async () => {
     const store = createStore(trustedGraph, createTestBackend());

--- a/packages/typegraph/tests/trusted-import.test.ts
+++ b/packages/typegraph/tests/trusted-import.test.ts
@@ -327,6 +327,126 @@ describe("trusted import", () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    { name: "a missing millisecond field", validFrom: "2021-01-01T00:00:00Z" },
+    {
+      name: "a variable-width millisecond field",
+      validFrom: "2021-01-01T00:00:00.1Z",
+    },
+    { name: "a non-UTC offset", validFrom: "2021-01-01T00:00:00.000+01:00" },
+    { name: "a date-only value", validFrom: "2021-01-01" },
+  ])("refuses a node whose validFrom states $name", async ({ validFrom }) => {
+    // Trusted import never re-parses its stream, so this format check is the
+    // only thing holding its timestamps to the shape everything downstream
+    // assumes (issue #414). All four shapes pass `z.iso.datetime()`-style
+    // leniency yet sort wrongly as TEXT against an `asOf` coordinate.
+    const store = createStore(trustedGraph, createTestBackend());
+
+    await expect(
+      trustedImportGraph(
+        store,
+        graphData([
+          {
+            kind: "TrustedPerson",
+            id: "alice",
+            properties: { name: "Alice" },
+            validFrom,
+          },
+        ]),
+      ),
+    ).rejects.toEqual(expectReason("invalid_stream"));
+
+    expect(
+      await store.nodes.TrustedPerson.getById(asNodeId<typeof Person>("alice")),
+    ).toBeUndefined();
+  });
+
+  it("names the offending field, row, and value in the refusal", async () => {
+    const store = createStore(trustedGraph, createTestBackend());
+
+    await expect(
+      trustedImportGraph(
+        store,
+        graphData([
+          {
+            kind: "TrustedPerson",
+            id: "alice",
+            properties: { name: "Alice" },
+            validTo: "2021-01-01T00:00:00Z",
+          },
+        ]),
+      ),
+    ).rejects.toThrow(
+      /Non-canonical validTo in trusted import: TrustedPerson "alice" states "2021-01-01T00:00:00Z"/,
+    );
+  });
+
+  it("refuses a non-canonical edge window and rolls back the nodes already streamed", async () => {
+    const store = createStore(trustedGraph, createTestBackend());
+
+    await expect(
+      trustedImportGraph(
+        store,
+        graphData(
+          [
+            {
+              kind: "TrustedPerson",
+              id: "alice",
+              properties: { name: "Alice" },
+            },
+            { kind: "TrustedPerson", id: "bob", properties: { name: "Bob" } },
+          ],
+          [
+            {
+              kind: "trustedKnows",
+              id: "edge-1",
+              from: { kind: "TrustedPerson", id: "alice" },
+              to: { kind: "TrustedPerson", id: "bob" },
+              properties: { since: 2020 },
+              validFrom: "2020-06-01T12:00:00.000Z",
+              validTo: "2021-01-01T00:00:00Z",
+            },
+          ],
+        ),
+      ),
+    ).rejects.toEqual(expectReason("invalid_stream"));
+
+    // The WHOLE stream is refused: the nodes chunk that already committed
+    // inside the session's transaction rolls back with the bad edge.
+    expect(
+      await store.edges.trustedKnows.getById(asEdgeId<typeof knows>("edge-1")),
+    ).toBeUndefined();
+    expect(
+      await store.nodes.TrustedPerson.getById(asNodeId<typeof Person>("alice")),
+    ).toBeUndefined();
+    expect(
+      await store.nodes.TrustedPerson.getById(asNodeId<typeof Person>("bob")),
+    ).toBeUndefined();
+  });
+
+  it("accepts an absent and an explicitly open-left window", async () => {
+    // `null` validFrom is a confirmed open-left window, not a timestamp, so the
+    // canonical-format check must let it through untouched.
+    const store = createStore(trustedGraph, createTestBackend());
+
+    const result = await trustedImportGraph(
+      store,
+      graphData([
+        { kind: "TrustedPerson", id: "absent", properties: { name: "Absent" } },
+        {
+          kind: "TrustedPerson",
+          id: "open-left",
+          properties: { name: "Open" },
+          // eslint-disable-next-line unicorn/no-null -- the interchange format states an open-left window as null
+          validFrom: null,
+          validTo: "2021-01-01T00:00:00.000Z",
+        },
+      ]),
+    );
+
+    expect(result.nodes).toBe(2);
+  });
+
   it("accepts a zero-width and a born-ended window", async () => {
     // Both round-trip the store's own output: a same-instant retraction emits
     // zero width, and a row created with only a `validTo` carries a stamped


### PR DESCRIPTION
Two pre-release contract hardenings, both found in earlier reviews and both bounded.

## #414 — trusted import performs no timestamp canonicalization

`trustedImportGraph` / `trustedImportGraphStream` accept a pre-typed stream and never re-parse it, so a `validFrom` / `validTo` that TypeScript types as `string` but is not canonical fixed-width UTC ISO 8601 flowed straight to SQL. That is unsound twice over. Every temporal filter compares those values **as text** against an `asOf` coordinate, so a stored `"2021-01-01"`, `"...T00:00:00Z"`, `"...:00.1Z"` or `"...+01:00"` mis-sorts and silently includes or excludes the wrong rows. And the negative-width window check this same path performs on the way in is itself a lexicographic compare, which a variable-width value mis-decides. Checked against the pre-fix code: all four shapes imported clean and were stored verbatim, the offset one landing an hour away from any UTC comparison.

Both window fields of every streamed node and edge are now checked with `isCanonicalIsoDate` — the same decision the untrusted import schema and the store's own write validation make, so "canonical" means one thing on every path. The check is deliberately format-only: no Zod re-parse of rows, and no ordering check beyond the one already there. It runs *before* the negative-width check, which is what turns canonical endpoints from an exception `isInvertedValidityWindow` had to name into a precondition it can rely on; that doc is reworded accordingly, since trusted import was the hole in it. The rewording also corrects where canonicality actually comes from: every WRITE path validates it, so a bound read back from a row needs no check of its own — the previous text credited the row mappers, and SQLite hands stored text back verbatim.

The refusal reuses the existing `invalid_stream` reason rather than adding a union member. The message carries the field, kind, id, offending value and the conversion to apply, so a new reason bought nothing — and the public API report is unchanged. The whole stream is refused inside the session's transaction, so chunks already streamed roll back with it. This is a behavior change: a stream that previously imported and stored an unsortable timestamp now fails loudly. It ships as a MINOR bump for that reason, matching the refusal that #406 landed in this same release train — the changelog's Minor Changes section is where a consumer looks for "will my writes still be accepted".

Cost, measured rather than assumed, on a 50k-node all-windows import:

| | per field | per row | share of import |
|---|---|---|---|
| format check (as landed) | ~510 ns | ~1.0 µs | ~26% |
| regex alone | ~26 ns | ~52 ns | ~1% |
| in-memory SQLite import | — | ~3.9 µs | 100% |

In-memory SQLite is the fastest conceivable target, so ~26% is the worst-case relative figure and any real target dilutes it. Of the check's cost the regex is 26 ns and the `Date` round-trip inside `isCanonicalIsoDate` is the other 95%; making that shared primitive cheaper would speed up every write path that validates a timestamp, but it is a change to shared validation with its own risk surface and does not belong in this PR. A per-chunk memo of already-accepted timestamps was tried and is *slower* on distinct values, so it was dropped.

## #411 — bulk upsert batches creates before updates

Ruled as **option 1: a documented limitation**, with no behavior change.

`bulkUpsertById` decides each row's final props in item order, but it groups the writes — every create runs before every update. A batch that hands a constrained value from one row to another therefore fails where the same operations applied one at a time succeed: for nodes, releasing a `unique` value and claiming it in one batch throws `UniquenessError` because the claiming create is checked while the releasing row still reserves the value; for edges, ending the lone `oneActive` edge from a source while creating its replacement throws `CardinalityError` for the same reason.

Bulk semantics are set-like, not scripted — a batch states the rows it wants, not an order to reach them in — and grouping creates apart from updates is what makes a batch a couple of statements instead of one per item. The failure is loud and typed, never a dropped write. Options 2 and 3 from the issue (dependency ordering, deferred uniqueness) would buy scripted semantics the API does not claim; the interchange importer already serves callers who need them, at the per-row validation cost a bulk write exists to skip, and that route is now named in the docs.

The limitation is stated on both `bulkUpsertById` contracts in `store/types.ts`, in the data-sync guide's bulk section (with the failing batch, the two exact workarounds, and why reordering items *inside* one batch does not help), and as an entry under limitations' bulk section. The accompanying cases pin it as contractual rather than accidental: each asserts both halves — the batch throws the typed error and leaves the graph untouched, and the identical sequence of single writes succeeds — since only the pair distinguishes an ordering limitation from a constraint that cannot be satisfied. They pass against `main` as well; what this PR adds for #411 is the stated contract.

Closes #411
Closes #414

