### PR TITLE
fix(graph-merge): base-aware edge fold property union, and report target-precedence window discards

### DIFF
--- a/.changeset/base-aware-edge-fold-union.md
+++ b/.changeset/base-aware-edge-fold-union.md
@@ -1,0 +1,37 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+graph-merge: judge the edge fold's property union against base, and report a
+target-precedence window discard
+
+Two adjacent gaps in the edge repoint/window path. One is a bug fix, the other
+adds an optional field to a report type, so this ships at the higher `minor`
+bump and covers both.
+
+The repoint fold's property union had no base to compare against, unlike the
+node path's three-way merge, so a staged copy of an INHERITED edge contributed
+its whole fork property bag as first-class `(branch, value)` claims — including
+the values it never touched. Under any rank-based `onPropertyConflict` an
+untouched base value could therefore outvote a value a branch actually authored,
+decided by whichever branch label happened to ride on the untouched copy. The
+window-only carrier made it observable: an inherited row whose only change is
+its end-of-validity is staged solely to give that ending somewhere to ride, its
+properties ARE the base's, and its branch is merely whichever sorted first in
+staging. The union now filters every contributor to the properties it CHANGED
+from its own base — a branch-created edge has no base, so everything it carries
+stays a full claim — which means a carrier contributes no claim and raises no
+conflict at any rank. Genuine disagreements are unaffected: two members that
+changed one property differently still conflict, over their real values alone.
+
+`MergeReport.validityEnds` now also reports the window claims that target
+precedence discards. When the incremental target had already moved an inherited
+row's end, the reconciler took the row out of the resolution and the branch
+claims vanished from the report entirely — less visible than a claim that merely
+lost the least-claim rule, which stays named in `claimedBy`. Such a row now gets
+a resolution naming the target's own committed instant, its discarded claimants,
+and the new optional `ValidityEndResolution.precedence` field set to the
+exported `VALIDITY_END_TARGET_PRECEDENCE`. The field is absent on every entry
+the merge itself decided, so existing consumers read what they always read; no
+write is staged and no provenance credit is minted for such a row, and a row no
+branch claimed still produces no entry at all.

--- a/.changeset/base-aware-edge-fold-union.md
+++ b/.changeset/base-aware-edge-fold-union.md
@@ -24,6 +24,12 @@ stays a full claim — which means a carrier contributes no claim and raises no
 conflict at any rank. Genuine disagreements are unaffected: two members that
 changed one property differently still conflict, over their real values alone.
 
+Filtering claims does not erase content: the folded row commits the same property
+set as before, and a key only a non-survivor carries keeps the value held by the
+member with the minimum edge ID — the row, never the branch label riding on it,
+since for these keys no branch claimed anything and an arbitrary label deciding
+the committed value is the very thing being fixed.
+
 `MergeReport.validityEnds` now also reports the window claims that target
 precedence discards. When the incremental target had already moved an inherited
 row's end, the reconciler took the row out of the resolution and the branch

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -334,7 +334,9 @@ When nodes collapse, their edges must too. After clustering, Graph Merge:
    `(from, type, to, props)` — so `x → a` and `x → b` both landing on `x → c*`
    collapse to one edge.
 4. **Reconciles** edges that collapse that way but disagree on properties, via
-   the same conflict policy as nodes.
+   the same conflict policy as nodes — over the properties each side actually
+   *changed*, so an inherited row's untouched value never competes with (or
+   outvotes) a value some branch authored.
 
 Steps 3 and 4 are scoped to collisions **repointing caused**: edges are grouped by
 the endpoint pair they named *before* repointing, and one row per pair collapses. A
@@ -359,7 +361,11 @@ keeps the lexicographically-minimal edge id.
 Inherited edges that a branch **deleted** are removed from the target, and
 inherited edges **modified** by multiple branches go through the same base-aware
 three-way merge as nodes — so an edge's `since` edited by one branch and `note`
-edited by another keep *both* edits.
+edited by another keep *both* edits. The collapse in step 4 is base-aware for the
+same reason: a staged copy of an inherited row carries that row's whole property
+bag, and only the values it *changed* count as claims. The clearest case is a row
+staged solely to carry an end-of-validity — it authored no property, so it
+contributes no claim and raises no conflict, whatever its branch's rank.
 
 ## Ontology type reconciliation
 
@@ -432,7 +438,9 @@ type MergeReport = {
   // identity:retraction-target-mismatch, identity:deletion-overruled), and
   // window deltas the commit cannot apply (window-not-applicable)
   dropped: DroppedItem[];
-  validityEnds: ValidityEndResolution[]; // inherited rows the merge ended, and who claimed each end
+  // Inherited rows whose end-of-validity the merge resolved, and who claimed each
+  // end; precedence: "target" marks a row the incremental target had already ended
+  validityEnds: ValidityEndResolution[];
   baseAmbiguities: BaseAmbiguity[]; // new-vs-base matches that spanned >= 2 committed entities
   provenance: ProvenanceIndex; // byBranch(id) -> { nodeIds, edgeIds }
   warnings: string[]; // non-fatal advisories (ceiling skips, provenance-persist failures)
@@ -580,7 +588,7 @@ explains the whole contract:
 | --------- | ------- |
 | One branch ends the row | That end is written — including a *later* end, which extends the window. |
 | Several branches end it differently | No conflict. The **earliest** end wins, and `report.validityEnds` names every claiming branch. |
-| The incremental target already ended it | The target's end stands. A branch never re-windows a row the target itself windowed, and the row is left out of the merge's writes entirely. |
+| The incremental target already ended it | The target's end stands. A branch never re-windows a row the target itself windowed, and the row is left out of the merge's writes entirely — but the discarded claims are still reported, as an entry carrying `precedence: "target"` and the target's own instant. |
 | One branch ends it, another deletes it | Deleted, with **no** `DeleteModifyConflict` — the stronger statement absorbs the weaker one. |
 | A branch re-states the end the target holds | No write at all — nothing is staged, so there is no version bump or history row even with `coalesceUnchangedUpserts` off. |
 | No branch touched the window | Untouched. A properties-only edit never passes a window, so the committed one stands. |
@@ -596,7 +604,16 @@ the only thing that branch changed. Credit follows the *committed* end: when
 several branches end a row differently, only the branches whose claim equals the
 written instant are credited, while `validityEnds[].claimedBy` still names every
 claimant, winning or not. An ending a deletion absorbed commits nothing, so it
-credits nobody.
+credits nobody, and neither does an entry marked `precedence: "target"` — the
+merge committed none of that end.
+
+**Every claim the merge observed is visible in `validityEnds`, applied or not.**
+An entry with no `precedence` is one the merge *decided*: `validTo` is the
+instant it wrote. An entry with `precedence: "target"` is one it did **not** —
+the incremental target had already moved that end, so `validTo` is the instant
+the target already held, `claimedBy` names the branch claims that were thrown
+away, and nothing was written or credited for the row. A row no branch claimed
+at all produces no entry, since there was nothing to discard.
 
 Because an ending is not a modification, `onDeleteModifyConflict` never sees
 one: a row whose *only* change is its window loses to a concurrent deletion even

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -4846,12 +4846,16 @@ type UpsertFulltextParams = Readonly<{
 type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"][number]["kind"] : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
+export const VALIDITY_END_TARGET_PRECEDENCE: "target";
+
+// @public
 export type ValidityEndResolution = Readonly<{
     entity: "node" | "edge";
     kind: string;
     id: string;
     validTo: string;
     claimedBy: readonly BranchId[];
+    precedence?: typeof VALIDITY_END_TARGET_PRECEDENCE;
 }>;
 
 // @public

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -523,6 +523,40 @@ function authoredProperty(edge: RepointedEdge, property: string): boolean {
 }
 
 /**
+ * The value a fold set carries for a property NO member authored — used for a key the
+ * survivor's own bag lacks, so filtering out unauthored CLAIMS never erases the row's
+ * content. Every carrier holds its own row's base value here (that is what unauthored
+ * means), so which one is taken is a choice between untouched inherited values.
+ *
+ * Taken from the minimum staged EDGE ID, never from the branch label riding on it.
+ * Which branch a staged copy of an inherited row belongs to is arbitrary — for a
+ * window-only carrier it is merely whichever branch sorted first in staging — so
+ * choosing by label would reinstate, for exactly these keys, the label sensitivity the
+ * authored-claims filter removes (issue #408). The edge id is the fold's ordering
+ * authority everywhere else ({@link pickSurvivor}, `mergedIds`), and the canonical
+ * value breaks a tie between two staged copies of ONE row so the order stays total.
+ *
+ * @param edges The fold set. At least one member must carry `property`.
+ */
+function unauthoredValue(
+  property: string,
+  edges: readonly RepointedEdge[],
+): JsonValue {
+  const carriers = edges
+    .filter((edge) => property in edge.staged.props)
+    .sort((left, right) => {
+      const byId = compareStrings(left.staged.id, right.staged.id);
+      return byId === 0 ?
+          compareStrings(
+            canonicalValueKey(left.staged.props[property] as JsonValue),
+            canonicalValueKey(right.staged.props[property] as JsonValue),
+          )
+        : byId;
+    });
+  return requireDefined(carriers[0]).staged.props[property] as JsonValue;
+}
+
+/**
  * Unions the props of one fold set's edges, resolving any per-property
  * disagreement via the shared T8 conflict policy. Returns the surviving prop bag
  * plus an edge-level {@link PropertyConflict} for every property that genuinely
@@ -556,13 +590,11 @@ function unionEdgeProps(
   const props: Record<string, JsonValue> = {};
   const conflicts: PropertyConflict[] = [];
 
-  // The staged record of each edge IS a `(branchId, props)` contribution, so the
-  // shared node/edge collector consumes it directly.
-  const contributions = edges.map((edge) => edge.staged);
-
   for (const property of [...propertyNames].sort((left, right) =>
     compareStrings(left, right),
   )) {
+    // The staged record of an authoring edge IS a `(branchId, props)` contribution,
+    // so the shared node/edge collector consumes it directly.
     const claimants = edges
       .filter((edge) => authoredProperty(edge, property))
       .map((edge) => edge.staged);
@@ -570,16 +602,12 @@ function unionEdgeProps(
     if (values.length === 0) {
       // No member of the set authored this property, so nothing competes for it:
       // the value the survivor already holds stands, and no conflict is possible.
-      // For a property the survivor's own bag lacks — carried, unchanged, by
-      // another member — the first CARRIER in the collector's stable
-      // `(branchId, value)` order keeps the key in the committed row, exactly as
-      // the pre-filter union did. Filtering out unauthored claims must not erase
-      // the row's content.
+      // Filtering claims must not shrink the row, so a key only a NON-survivor
+      // carries keeps a value too — see {@link unauthoredValue}.
       props[property] =
         property in survivor.staged.props ?
           (survivor.staged.props[property] as JsonValue)
-        : requireDefined(collectConflictingValues(property, contributions)[0])
-            .value;
+        : unauthoredValue(property, edges);
       continue;
     }
     const survivorValue =

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -20,7 +20,10 @@ import { requireDefined } from "../utils/presence";
  *      but carry DIFFERING props, the per-property disagreement is resolved by the
  *      shared T8 conflict policy ({@link resolvePropertyUnion}) on the captured,
  *      non-wall-clock branch order, recording an edge-level {@link PropertyConflict}
- *      whose `entityId` is the surviving edge's id.
+ *      whose `entityId` is the surviving edge's id. Only the members that AUTHORED a
+ *      property — changed it from their own base — compete for it, so an untouched
+ *      inherited value never outvotes a real edit (issue #408; see
+ *      {@link authoredProperty}).
  *
  * SCOPE OF THE FOLD (issue #393). Steps 3 and 4 apply ONLY to a collision the
  * repointing INDUCED. The store is a MULTIGRAPH: nothing enforces uniqueness on
@@ -65,7 +68,7 @@ import { requireDefined } from "../utils/presence";
  * yields an identical result. Clusters are computed once upstream (T8) and passed in
  * as {@link canonicalOf}; this module never re-clusters.
  */
-import { canonicalizeProps } from "./canonical-props";
+import { canonicalizeProps, canonicalValueKey } from "./canonical-props";
 import type { ClusterResult } from "./clustering";
 import type { ProvenanceWeights, ResolutionContext } from "./conflict-policy";
 import {
@@ -155,6 +158,18 @@ export type StagedEdge = Readonly<{
   fromKind: string;
   toKind: string;
   props: Readonly<Record<string, JsonValue>>;
+  /**
+   * The props the MERGE BASE holds for this row — present on an INHERITED edge,
+   * absent on a branch-created one (nothing preceded it).
+   *
+   * The property union compares each member's {@link StagedEdge.props} against it
+   * so only the properties a member actually AUTHORED compete (issue #408, and the
+   * edge analog of the node path's 3-way merge). Without a base, a staged copy of
+   * an inherited row contributes its whole fork bag, so an untouched base value
+   * enters the union as a first-class claim and can outvote a real edit under any
+   * rank-based policy — see {@link authoredProperty}.
+   */
+  baseProps?: Readonly<Record<string, JsonValue>>;
   branchId: BranchId;
   /**
    * The valid-time window the commit must write. A NEW edge carries the branch's
@@ -477,10 +492,47 @@ function pickSurvivor(
 }
 
 /**
+ * Whether one fold member AUTHORED a value for `property` — it carries the
+ * property AND its value differs from the one that member's own merge base holds.
+ * A BRANCH-CREATED member has no base, so everything it carries is authored.
+ *
+ * This is the changed-props filter of {@link unionEdgeProps} (issue #408), the edge
+ * analog of the node path's 3-way merge (`threeWayMergeProps`): a staged copy of an
+ * inherited row contributes its FULL fork bag, so without it an UNTOUCHED base
+ * value competes as a first-class claim and can outvote a real edit under any
+ * rank-based policy — which branch's label happened to ride on the untouched copy
+ * would then decide the committed value.
+ *
+ * The window-only carrier is the case that makes it observable: that staged copy
+ * exists only to give an end-of-validity a row to ride on, its props ARE the base's,
+ * and the branch labelling it is merely whichever sorted first. It authors no
+ * property at all, and so contributes no claim and raises no conflict.
+ */
+function authoredProperty(edge: RepointedEdge, property: string): boolean {
+  const { props, baseProps } = edge.staged;
+  if (!(property in props)) {
+    return false;
+  }
+  if (baseProps === undefined || !(property in baseProps)) {
+    return true;
+  }
+  return (
+    canonicalValueKey(props[property] as JsonValue) !==
+    canonicalValueKey(baseProps[property] as JsonValue)
+  );
+}
+
+/**
  * Unions the props of one fold set's edges, resolving any per-property
  * disagreement via the shared T8 conflict policy. Returns the surviving prop bag
  * plus an edge-level {@link PropertyConflict} for every property that genuinely
  * differed (its `entityId` is the surviving edge id).
+ *
+ * Only the members that AUTHORED a property compete for it ({@link
+ * authoredProperty}). A property no member changed is not contested at all, so the
+ * value the survivor already holds stands and no conflict is recorded; a property
+ * two members changed differently is a genuine disagreement and resolves — and is
+ * reported — exactly as before, over their real values alone.
  */
 function unionEdgeProps(
   survivorId: EdgeId,
@@ -511,8 +563,23 @@ function unionEdgeProps(
   for (const property of [...propertyNames].sort((left, right) =>
     compareStrings(left, right),
   )) {
-    const values = collectConflictingValues(property, contributions);
+    const claimants = edges
+      .filter((edge) => authoredProperty(edge, property))
+      .map((edge) => edge.staged);
+    const values = collectConflictingValues(property, claimants);
     if (values.length === 0) {
+      // No member of the set authored this property, so nothing competes for it:
+      // the value the survivor already holds stands, and no conflict is possible.
+      // For a property the survivor's own bag lacks — carried, unchanged, by
+      // another member — the first CARRIER in the collector's stable
+      // `(branchId, value)` order keeps the key in the committed row, exactly as
+      // the pre-filter union did. Filtering out unauthored claims must not erase
+      // the row's content.
+      props[property] =
+        property in survivor.staged.props ?
+          (survivor.staged.props[property] as JsonValue)
+        : requireDefined(collectConflictingValues(property, contributions)[0])
+            .value;
       continue;
     }
     const survivorValue =

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -73,6 +73,10 @@ export type {
   TypeReconciliation,
   ValidityEndResolution,
 } from "./types";
-export { asBaseVersion, asBranchId } from "./types";
+export {
+  asBaseVersion,
+  asBranchId,
+  VALIDITY_END_TARGET_PRECEDENCE,
+} from "./types";
 export type { MakeBackend, WorkingCopyStrategy } from "./working-copy";
 export { cloneWorkingCopyStrategy } from "./working-copy";

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -598,9 +598,15 @@ function indexNewNodesById(
  *
  * The modified inherited edges are the RECONCILED ones (one per id, 3-way merged
  * against base by {@link reconcileEdgeModifications}) — NOT the raw per-branch
- * `staging.modifiedEdges`. Staging each branch's full fork props separately would
- * make the repoint union treat unchanged-from-base fields as conflicts, dropping a
- * disjoint edit by another branch.
+ * `staging.modifiedEdges`. That reconciler is the authority on a row several
+ * branches modified: it survived delete/modify resolution, merged the props, and
+ * already recorded any {@link PropertyConflict} the disagreement raised. Staging
+ * each branch's copy separately would put the same row through a second
+ * arbitration in the repoint fold and report the same conflict twice.
+ *
+ * Every inherited edge is staged WITH the base props it was diffed against, which is
+ * what lets the fold's property union tell an authored value from an untouched one
+ * (issue #408). A branch-created edge carries none — nothing preceded it.
  *
  * Each edge's diff bucket is carried through as its staged ORIGIN
  * ({@link INHERITED_EDGE_ORIGIN} / {@link BRANCH_CREATED_EDGE_ORIGIN}): the modified
@@ -643,6 +649,7 @@ function buildStagedEdges(
       fromKind: item.edge.fromKind,
       toKind: item.edge.toKind,
       props: item.edge.forkProps as Readonly<Record<string, JsonValue>>,
+      baseProps: item.edge.baseProps as Readonly<Record<string, JsonValue>>,
       branchId: item.branchId,
       ...(validTo === undefined ? {} : { validTo }),
     });
@@ -654,12 +661,12 @@ function buildStagedEdges(
   // alone. Finally-deleted edges are excluded: deletion absorbs the ending.
   //
   // WHICH branch's copy carries it is arbitrary — the first in the staging order,
-  // `(kind, id, branch)` — and deliberately stays that way. That `branchId` is an
-  // input to the repoint fold's PROPERTY union, where the copy contributes the
-  // base's props under its label, so choosing the carrier by anything else (the
-  // authored ending, say) silently moves which value a fold commits. It is
-  // therefore recorded as window-only carried instead, and the ending's author is
-  // credited from the resolution rather than from whoever carried the row.
+  // `(kind, id, branch)` — and stays that way. The copy is staged WITH the base it
+  // was diffed against, so the repoint fold's property union sees that it authored
+  // nothing and it contributes no claim under any label (issue #408); the carrier's
+  // `branchId` is then a write vehicle only. It is still recorded as window-only
+  // carried, because provenance reads the staged copies too and the ending's author
+  // is credited from the resolution rather than from whoever carried the row.
   for (const item of staging.windowedEdges) {
     const identity = mergeKeyOf(item.edge);
     const validTo = edgeValidityEnds.get(identity);
@@ -681,6 +688,7 @@ function buildStagedEdges(
       fromKind: item.edge.fromKind,
       toKind: item.edge.toKind,
       props: item.edge.props as Readonly<Record<string, JsonValue>>,
+      baseProps: item.edge.baseProps as Readonly<Record<string, JsonValue>>,
       branchId: item.branchId,
       validTo,
     });

--- a/packages/typegraph/src/graph-merge/state-diff.ts
+++ b/packages/typegraph/src/graph-merge/state-diff.ts
@@ -231,6 +231,13 @@ export type WindowedNode = Readonly<{
  * parsed props too, because an inherited edge whose ONLY change is its window is
  * not otherwise staged — the repoint phase needs the full record to carry the
  * ending through to the commit.
+ *
+ * `baseProps` is the same record {@link ModifiedEdge} carries, and for the same
+ * consumer: the repoint fold judges each contributor's property values against
+ * its own base, so an untouched value never enters the union as an authored claim
+ * (issue #408). A window-only fork's `props` happen to equal its `baseProps`,
+ * which is exactly what makes such a copy contribute nothing — but that equality
+ * is a fact about the fork, not something the fold should have to assume.
  */
 export type WindowedEdge = Readonly<{
   id: EdgeId;
@@ -240,6 +247,7 @@ export type WindowedEdge = Readonly<{
   fromKind: string;
   toKind: string;
   props: Readonly<Record<string, unknown>>;
+  baseProps: Readonly<Record<string, unknown>>;
   base: ValidWindow;
   fork: ValidWindow;
 }>;
@@ -550,6 +558,7 @@ function diffEdgeKind(
         fromKind: forkRow.from_kind,
         toKind: forkRow.to_kind,
         props: forkProps,
+        baseProps,
         base: baseWindow,
         fork: forkWindow,
       });

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -435,9 +435,16 @@ export type DroppedItem =
   | Readonly<{ kind: "identity"; id: string; reason: string }>;
 
 /**
- * One inherited row whose end-of-validity the merge changed: the instant it
- * applied and every branch that claimed an end for that row (including the ones
- * whose claim lost the least-claim tie-break).
+ * The {@link ValidityEndResolution.precedence} of an entry the INCREMENTAL TARGET
+ * decided rather than the merge: the destination had already moved this row's end
+ * before the merge ran, so every branch claim was discarded and no write was staged.
+ */
+export const VALIDITY_END_TARGET_PRECEDENCE = "target" as const;
+
+/**
+ * One inherited row whose end-of-validity the merge RESOLVED: the instant that
+ * stands and every branch that claimed an end for the row (including the ones whose
+ * claim lost the least-claim tie-break).
  *
  * `id` is bare because `entity` + `kind` already disambiguate it — a node and an
  * edge, or two kinds, that share an id string are distinct entries.
@@ -446,10 +453,25 @@ export type ValidityEndResolution = Readonly<{
   entity: "node" | "edge";
   kind: string;
   id: string;
-  /** The instant the commit wrote, as a canonical UTC ISO 8601 string. */
+  /**
+   * The row's end-of-validity as a canonical UTC ISO 8601 string: the instant the
+   * commit WROTE, or — under {@link VALIDITY_END_TARGET_PRECEDENCE} — the instant
+   * the target already held and the merge left alone.
+   */
   validTo: string;
   /** Every branch that claimed an end, sorted; length > 1 means arbitration. */
   claimedBy: readonly BranchId[];
+  /**
+   * Present only as {@link VALIDITY_END_TARGET_PRECEDENCE}, marking an entry the
+   * merge did NOT decide: the incremental target had already moved this end, so
+   * `validTo` is the target's own committed instant, every claim in `claimedBy` was
+   * discarded, and nothing was written or credited for the row.
+   *
+   * ABSENT means the merge decided the end — `validTo` is the instant it wrote and
+   * `claimedBy` names the claims it arbitrated between. A consumer that ignores the
+   * field therefore keeps reading the entries it always read.
+   */
+  precedence?: typeof VALIDITY_END_TARGET_PRECEDENCE;
 }>;
 
 /**
@@ -541,15 +563,18 @@ export type MergeReport<G extends GraphDef = GraphDef> = Readonly<{
   typeReconciliations: readonly TypeReconciliation[];
   dropped: readonly DroppedItem[];
   /**
-   * Every inherited row whose END-OF-VALIDITY the merge changed, with the instant
-   * applied and the branches that claimed an end.
+   * Every inherited row whose END-OF-VALIDITY the merge resolved, with the instant
+   * that stands and the branches that claimed an end.
    *
    * Reported because the resolution is silent by design: two branches ending the
    * same row at different instants are not in conflict (an ending is a monotone
    * claim, like a deletion), so the earliest end is taken without a
    * `PropertyConflict`. This list is how a caller sees that arbitration happened.
-   * Window deltas the commit CANNOT apply appear in {@link MergeReport.dropped}
-   * instead, with reason `"window-not-applicable"`.
+   * It includes the rows where the arbitration discarded EVERY claim because the
+   * incremental target had already moved the end — those carry
+   * `precedence: "target"` and staged no write. Window deltas the commit CANNOT
+   * apply appear in {@link MergeReport.dropped} instead, with reason
+   * `"window-not-applicable"`.
    */
   validityEnds: readonly ValidityEndResolution[];
   /**

--- a/packages/typegraph/src/graph-merge/valid-window.ts
+++ b/packages/typegraph/src/graph-merge/valid-window.ts
@@ -49,7 +49,17 @@
  * committed target itself, so its own end is already the stored one. Resolving
  * to it would write the row back at itself and report an end the merge never
  * decided, which is why a target that moved the end takes this row out of the
- * resolution entirely.
+ * WRITES entirely.
+ *
+ * It does not take it out of the REPORT (issue #409). Discarding a claim is an
+ * arbitration outcome, and the merge report's honesty principle is that every
+ * observable-but-unapplied delta is visible: the claim that merely LOST the
+ * least-claim rule already appears in `ValidityEndResolution.claimedBy`, so a claim
+ * target precedence threw away must not be less visible than that. Such a row gets a
+ * resolution naming the TARGET's own instant, its discarded claimants, and
+ * `precedence: {@link VALIDITY_END_TARGET_PRECEDENCE}` — the discriminator that keeps
+ * "the merge wrote this end" and "the target already held this end" distinguishable.
+ * A row NO branch claimed produces no entry at all: there was nothing to discard.
  *
  * DELETION ABSORBS AN ENDING
  *
@@ -77,6 +87,9 @@
  * is where "who asked for what" belongs. The alternative — crediting every
  * claimant — would make provenance answer "who spoke about this row" instead, a
  * different question that the report already answers.
+ *
+ * By the same rule a target-precedence row credits NOBODY: the merge committed none
+ * of that end, so its resolution is report-only and mints no credit.
  */
 import { requireDefined } from "../utils/presence";
 import {
@@ -89,6 +102,7 @@ import type { StagedWindowedEdge, StagedWindowedNode } from "./staging";
 import type { ValidWindow } from "./state-diff";
 import type { EdgeId, NodeId, NodeType } from "./typegraph-internal";
 import type { BranchId, DroppedItem, ValidityEndResolution } from "./types";
+import { VALIDITY_END_TARGET_PRECEDENCE } from "./types";
 
 /** A node id in its untyped (`NodeType`-default) branded form. */
 type AnyNodeId = NodeId<NodeType>;
@@ -120,6 +134,12 @@ export type ValidWindowResolution = Readonly<{
   nodeCredits: ReadonlyMap<MergeKey, readonly BranchId[]>;
   /** The edge half of {@link ValidWindowResolution.nodeCredits}. */
   edgeCredits: ReadonlyMap<MergeKey, readonly BranchId[]>;
+  /**
+   * Every row whose end this phase RESOLVED, nodes then edges — a superset of the
+   * ends above: a row target precedence decided appears here (marked
+   * {@link VALIDITY_END_TARGET_PRECEDENCE}) with no entry in `nodeEnds`/`edgeEnds`
+   * and none in the credits.
+   */
   resolutions: readonly ValidityEndResolution[];
   dropped: readonly DroppedItem[];
 }>;
@@ -207,6 +227,10 @@ type WindowDelta = Readonly<{
 /**
  * Reconciles one entity population (nodes or edges), skipping identities the
  * merge finally deletes — deletion absorbs an ending, with no conflict recorded.
+ *
+ * `ends` and `credits` cover only the rows the commit must WRITE; `resolutions`
+ * additionally reports the rows target precedence decided, so a discarded claim is
+ * visible without being staged.
  */
 function resolvePopulation(
   entity: "node" | "edge",
@@ -242,7 +266,7 @@ function resolvePopulation(
   for (const [identity, group] of byIdentity) {
     const claims: EndClaim[] = [];
     let reportedUnapplicable = false;
-    let targetMovedEnd = false;
+    let targetEnd: string | undefined;
     for (const delta of group) {
       const { applicableEnd, unapplicable } = classifyDelta(
         delta.base,
@@ -252,11 +276,13 @@ function resolvePopulation(
       // describes the DESTINATION's own row, not a claim staged against it. A
       // target that already moved this end leaves the merge nothing to apply —
       // that is rule 3's committed-target precedence, reached without writing
-      // the row back at itself or reporting an end the merge did not decide.
+      // the row back at itself. The instant is kept rather than a flag, because
+      // the report has to name the end that actually stands (a group holds at
+      // most one delta per branch, so the `??=` records that one delta's end).
       // A target-side unapplicable delta is likewise not something the merge
       // failed to carry: it is where the merge writes.
       if (delta.branchId === preferredBranchId) {
-        targetMovedEnd ||= applicableEnd !== undefined;
+        targetEnd ??= applicableEnd;
         continue;
       }
       if (applicableEnd !== undefined) {
@@ -270,7 +296,29 @@ function resolvePopulation(
         dropped.push(dropItem(delta.id));
       }
     }
-    const resolved = targetMovedEnd ? undefined : earliestEnd(claims);
+    const first = requireDefined(group[0]);
+    if (targetEnd !== undefined) {
+      // Target precedence: the committed target already moved this end, so the
+      // merge applies nothing and every branch claim is discarded. Say so
+      // (issue #409) — a claim the merge observed and did not apply is exactly what
+      // the report exists to make visible, and the least-claim LOSER is already
+      // visible in `claimedBy`, so a discarded claim must not be less visible than
+      // an out-arbitrated one. The entry names the target's own instant and is
+      // marked so a consumer can tell it from an end the merge decided. No end is
+      // staged and no credit is minted: nothing here was committed by a branch.
+      if (claims.length > 0) {
+        resolutions.push({
+          entity,
+          kind: first.kind,
+          id: first.id,
+          validTo: targetEnd,
+          claimedBy: claimingBranches(claims),
+          precedence: VALIDITY_END_TARGET_PRECEDENCE,
+        });
+      }
+      continue;
+    }
+    const resolved = earliestEnd(claims);
     if (resolved === undefined) {
       continue;
     }
@@ -283,7 +331,6 @@ function resolvePopulation(
       identity,
       claimingBranches(claims.filter((claim) => claim.validTo === resolved)),
     );
-    const first = requireDefined(group[0]);
     resolutions.push({
       entity,
       kind: first.kind,
@@ -319,9 +366,10 @@ function resolvePopulation(
  * @param staging The provenance-tagged union staging set (T7).
  * @param nodeDeletions The AUTHORITATIVE finally-deleted node identities.
  * @param edgeDeletions The AUTHORITATIVE finally-deleted edge identities.
- * @param preferredBranchId The incremental merge's committed-target branch,
- *   whose own end already stands and so takes its row out of the resolution
- *   (rule 3's preferred half). Absent on the snapshot path.
+ * @param preferredBranchId The incremental merge's committed-target branch, whose
+ *   own end already stands and so takes its row out of the ENDS the commit writes
+ *   (rule 3's preferred half) while still reporting the claims it discarded.
+ *   Absent on the snapshot path.
  */
 export function resolveValidWindows(
   staging: Readonly<{

--- a/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-parallel-merge.test.ts
@@ -25,10 +25,11 @@
  * A genuine repoint-induced collapse still folds — that fold is what the dedupe
  * exists for. Its end-to-end contract is `self-edge-collapse.test.ts` and
  * `valid-window-merge.test.ts`; its mechanics are `edge-repoint.test.ts`. One
- * property of that fold is pinned here because only this fixture reaches it: the
- * staged copy carrying a window-only ending votes in the fold's property union
- * under its branch's label, so which branch carries the row must stay independent
- * of who authored the ending (issue #402).
+ * property of that fold is pinned here because only this fixture reaches it end to
+ * end: the staged copy carrying a window-only ending belongs to an arbitrary branch
+ * (the staging order's first claimant, credited nothing — issue #402), and it must
+ * therefore contribute NOTHING to the fold's property union, at any rank, since it
+ * authored nothing (issue #408).
  *
  * Runs on every backend in the matrix: edge multiplicity is asserted through the
  * committed rows, and a per-dialect test would happily certify a divergence.
@@ -106,14 +107,26 @@ const WINDOW_CLAIMANT_LATE = asBranchId("parallel-window-b-late");
 /** Ends it EARLIER, so its claim is the one committed. Sorts AFTER the loser. */
 const WINDOW_CLAIMANT_EARLY = asBranchId("parallel-window-c-early");
 /**
- * Branch rank INVERTED against the branch-id sort: the losing claimant carries
- * the row (it sorts first in staging) while ranking last, so a carrier chosen by
- * authorship instead would resolve a rank-based property policy differently.
+ * The two branch orders the carrier case runs under. In both, the row is carried by
+ * `WINDOW_CLAIMANT_LATE` — it sorts first in staging, and its own claim is the one the
+ * least-claim rule discards — so the carrier and the credited author are provably
+ * different branches either way. What differs is the carrier's RANK against the branch
+ * that authored the folded edge's props: below it, then above it.
+ *
+ * That must not matter, and it used to (issue #408). The carrier contributed the base's
+ * untouched props as a first-class claim, so ranking it above the author handed a stale
+ * value the priority to win a `lastWriteWins` union — the same fold with the same
+ * members committing different props because of a label.
  */
-const RANK_INVERTED_ORDER = [
+const CARRIER_RANKED_BELOW_AUTHOR = [
   WINDOW_CLAIMANT_EARLY,
   BRANCH_A,
   WINDOW_CLAIMANT_LATE,
+];
+const CARRIER_RANKED_ABOVE_AUTHOR = [
+  WINDOW_CLAIMANT_LATE,
+  WINDOW_CLAIMANT_EARLY,
+  BRANCH_A,
 ];
 
 /** The committed encounter's block key + reason, and the branch's near-duplicate of
@@ -481,78 +494,92 @@ describe.each(backendMatrix())("merging parallel edges [$name]", (entry) => {
     expect(report.conflicts).toEqual([]);
   });
 
-  it("does not let a window-only carrier outvote a folded edge's props", async () => {
-    // An inherited edge whose only change is its ending still needs a staged copy
-    // to ride on, and that copy contributes the BASE's props under the carrying
-    // branch's label. So when a repoint folds a branch's own edge onto that row,
-    // the carrier is a voter in the property union — which makes WHICH branch
-    // carries the row a merge outcome, not just a provenance detail.
-    //
-    // The carrier therefore stays the staging order's first claimant, and the
-    // ending's author is credited from the window resolution instead (issue #402).
-    // Choosing the carrier by authorship moves the committed props: here it would
-    // hand the base's stale `on` a rank high enough to beat the value the props
-    // branch actually authored.
-    const forkPoint = await seededForkPoint();
-    const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
-    const propsBranch = await forkOf(forkPoint, BRANCH_A);
-    // Two window claimants whose id order is INVERTED against their branch rank,
-    // so the carrier and the credited author are provably different branches.
-    const losingClaimant = await forkOf(forkPoint, WINDOW_CLAIMANT_LATE);
-    const winningClaimant = await forkOf(forkPoint, WINDOW_CLAIMANT_EARLY);
+  describe.each([
+    { position: "BELOW", branchOrder: CARRIER_RANKED_BELOW_AUTHOR },
+    { position: "ABOVE", branchOrder: CARRIER_RANKED_ABOVE_AUTHOR },
+  ])(
+    "a window-only carrier ranked $position the props author",
+    ({ branchOrder }) => {
+      it("does not outvote the folded edge's props", async () => {
+        // An inherited edge whose only change is its ending still needs a staged copy
+        // to ride on, and WHICH branch carries it is arbitrary: the staging order's
+        // first claimant, possibly one whose own claim the merge discarded (#402).
+        //
+        // That copy used to contribute the BASE's props under the carrying branch's
+        // label, making the carrier a voter in the fold's property union — so the
+        // arbitrary label decided the committed properties under a rank-based policy
+        // (#408). The union now judges every contributor against its own base, and a
+        // carrier authored nothing, so it contributes no claim at any rank.
+        const forkPoint = await seededForkPoint();
+        const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
+        const propsBranch = await forkOf(forkPoint, BRANCH_A);
+        const losingClaimant = await forkOf(forkPoint, WINDOW_CLAIMANT_LATE);
+        const winningClaimant = await forkOf(forkPoint, WINDOW_CLAIMANT_EARLY);
 
-    await propsBranch.store.nodes.Encounter.create(
-      { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
-      { id: DUPLICATE_ENCOUNTER.id },
-    );
-    await propsBranch.store.edges.hadEncounter.create(
-      PATIENT,
-      DUPLICATE_ENCOUNTER,
-      { on: BRANCH_DATE },
-      { id: "edge-9" },
-    );
-    await losingClaimant.store.edges.hadEncounter.update(
-      INHERITED,
-      {},
-      { validTo: LATER_END },
-    );
-    await winningClaimant.store.edges.hadEncounter.update(
-      INHERITED,
-      {},
-      { validTo: END },
-    );
+        await propsBranch.store.nodes.Encounter.create(
+          { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
+          { id: DUPLICATE_ENCOUNTER.id },
+        );
+        await propsBranch.store.edges.hadEncounter.create(
+          PATIENT,
+          DUPLICATE_ENCOUNTER,
+          { on: BRANCH_DATE },
+          { id: "edge-9" },
+        );
+        await losingClaimant.store.edges.hadEncounter.update(
+          INHERITED,
+          {},
+          { validTo: LATER_END },
+        );
+        await winningClaimant.store.edges.hadEncounter.update(
+          INHERITED,
+          {},
+          { validTo: END },
+        );
 
-    const report = unwrap(
-      await mergeIncremental<CareGraph>({
-        forkPoint,
-        target,
-        branches: [propsBranch, losingClaimant, winningClaimant],
-        options: {
-          ...resolveDuplicateEncounters(),
-          // Rank-sensitive: the winner is the highest-priority CONTRIBUTING
-          // branch, so a relabelled carrier changes the value that survives.
-          onPropertyConflict: "lastWriteWins",
-          branchOrder: RANK_INVERTED_ORDER,
-        },
-      }),
-    );
+        const report = unwrap(
+          await mergeIncremental<CareGraph>({
+            forkPoint,
+            target,
+            branches: [propsBranch, losingClaimant, winningClaimant],
+            options: {
+              ...resolveDuplicateEncounters(),
+              // Rank-sensitive: the winner is the highest-priority CONTRIBUTING
+              // branch, so an untouched value that still counted as a contribution
+              // would change the value that survives.
+              onPropertyConflict: "lastWriteWins",
+              branchOrder,
+            },
+          }),
+        );
 
-    // The fold committed the props branch's authored value, and the earliest
-    // claimed ending — neither decided by who happened to carry the row.
-    expect(
-      (await liveEdges(target)).map((edge) => ({
-        id: edge.id,
-        on: edge.on,
-        validTo: edge.validTo,
-      })),
-    ).toEqual([{ id: INHERITED_EDGE, on: BRANCH_DATE, validTo: END }]);
-    // Only the branch whose claim IS the committed ending is credited; the
-    // carrier's own label buys it nothing.
-    expect(report.provenance.byBranch(WINDOW_CLAIMANT_EARLY).edgeIds).toContain(
-      INHERITED_EDGE,
-    );
-    expect(report.provenance.byBranch(WINDOW_CLAIMANT_LATE).edgeIds).toEqual(
-      [],
-    );
-  });
+        // The fold committed the props branch's authored value, and the earliest
+        // claimed ending — neither decided by who happened to carry the row.
+        expect(
+          (await liveEdges(target)).map((edge) => ({
+            id: edge.id,
+            on: edge.on,
+            validTo: edge.validTo,
+          })),
+        ).toEqual([{ id: INHERITED_EDGE, on: BRANCH_DATE, validTo: END }]);
+        // And nothing about the EDGE disagreed: one authored value against an
+        // untouched one is not a property conflict, so the report no longer invents
+        // one. (The Encounter cluster's own `reason` conflict is the identity
+        // resolution's, and stands.)
+        expect(
+          report.conflicts.filter(
+            (conflict) => conflict.kind === "hadEncounter",
+          ),
+        ).toEqual([]);
+        // Only the branch whose claim IS the committed ending is credited; the
+        // carrier's own label buys it nothing.
+        expect(
+          report.provenance.byBranch(WINDOW_CLAIMANT_EARLY).edgeIds,
+        ).toContain(INHERITED_EDGE);
+        expect(
+          report.provenance.byBranch(WINDOW_CLAIMANT_LATE).edgeIds,
+        ).toEqual([]);
+      });
+    },
+  );
 });

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -1498,6 +1498,64 @@ describe("repointEdges base-aware property union (#408)", () => {
     });
     expect(result.conflicts).toEqual([]);
   });
+
+  // Which branch a staged copy of an inherited row belongs to is arbitrary, so the
+  // value kept for a key nobody authored must come from the ROW, not the label. Both
+  // assignments below hold the same three rows; only the labels on the two `note`
+  // carriers swap. Ordering the carriers by branch id instead flips the committed
+  // value between them, which is the label sensitivity #408 is about.
+  describe.each([
+    { labelling: "in id order", second: BRANCH_B, third: BRANCH_C },
+    { labelling: "SWAPPED", second: BRANCH_C, third: BRANCH_B },
+  ])(
+    "two unauthored carriers of a key the survivor lacks, labelled $labelling",
+    ({ second, third }) => {
+      it("keeps the value of the minimum-id row", () => {
+        const result = repointEdges(
+          [
+            // The survivor: min-id inherited, and it carries no `note` at all.
+            stagedEdge({
+              id: "edge-1",
+              from: "x",
+              to: "a",
+              inherited: true,
+              props: { on: "base-a" },
+              baseProps: { on: "base-a" },
+              branchId: BRANCH_A,
+            }),
+            stagedEdge({
+              id: "edge-2",
+              from: "x",
+              to: "b",
+              inherited: true,
+              props: { note: "from-edge-2" },
+              baseProps: { note: "from-edge-2" },
+              branchId: second,
+            }),
+            stagedEdge({
+              id: "edge-3",
+              from: "x",
+              to: "c",
+              inherited: true,
+              props: { note: "from-edge-3" },
+              baseProps: { note: "from-edge-3" },
+              branchId: third,
+            }),
+          ],
+          collapse,
+          new Set<MergeKey>(),
+          "lastWriteWins",
+          rankABC(),
+        );
+
+        expect(requireDefined(result.edges[0]).props).toEqual({
+          on: "base-a",
+          note: "from-edge-2",
+        });
+        expect(result.conflicts).toEqual([]);
+      });
+    },
+  );
 });
 
 describe("repointEdges dedupe-key delimiter safety (F13)", () => {

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -61,6 +61,10 @@ function rank(): ReadonlyMap<typeof BRANCH_A, number> {
  * Builds a staged edge with parsed props; defaults keep the call sites terse. The
  * origin defaults to BRANCH-CREATED, so a case says `inherited: true` exactly when the
  * committed-row survivor rule is what it is about.
+ *
+ * `baseProps` is what the merge base holds for an INHERITED row, so a case supplies it
+ * exactly when it is about which values the property union treats as AUTHORED. A
+ * branch-created edge never carries one.
  */
 function stagedEdge(
   args: Readonly<{
@@ -69,6 +73,7 @@ function stagedEdge(
     to: string;
     kind?: string;
     props?: Readonly<Record<string, JsonValue>>;
+    baseProps?: Readonly<Record<string, JsonValue>>;
     branchId?: typeof BRANCH_A;
     inherited?: boolean;
     validFrom?: string;
@@ -87,6 +92,7 @@ function stagedEdge(
     fromKind: "Doc",
     toKind: "Doc",
     props: args.props ?? {},
+    ...(args.baseProps === undefined ? {} : { baseProps: args.baseProps }),
     branchId: args.branchId ?? BRANCH_A,
     ...(args.validFrom === undefined ? {} : { validFrom: args.validFrom }),
     ...(args.validTo === undefined ? {} : { validTo: args.validTo }),
@@ -1266,6 +1272,231 @@ describe("repointEdges survivor rule (#395)", () => {
         })),
       );
     }
+  });
+});
+
+/**
+ * The fold's property union is BASE-AWARE (issue #408): only a member that CHANGED a
+ * property from its own base competes for it.
+ *
+ * Without that filter a staged copy of an inherited row contributed its whole fork
+ * bag, so an UNTOUCHED base value entered the union as a first-class `(branch, value)`
+ * claim. Under any rank-based policy the branch label riding on that untouched copy
+ * then decided the committed value — and for a WINDOW-ONLY carrier, whose props are
+ * the base's and whose label is merely whichever branch sorted first, that meant an
+ * arbitrary label could outvote a real edit.
+ *
+ * These cases pin the filter and its edges: a real edit wins over an untouched value
+ * whichever way the ranks fall, a genuine disagreement still conflicts over its REAL
+ * values only, and a property nobody authored keeps the value it had rather than
+ * disappearing with the claim.
+ */
+describe("repointEdges base-aware property union (#408)", () => {
+  const collapse = buildCanonicalMap([clusterOf("a", "b", "c")], (cluster) =>
+    minIdCanonical(cluster),
+  );
+  const BRANCH_C = asBranchId("branch-c");
+
+  /** [a, b, c] — so branch-a outranks branch-b outranks branch-c. */
+  function rankABC(): ReadonlyMap<typeof BRANCH_A, number> {
+    return buildBranchRank(
+      [BRANCH_A, BRANCH_B, BRANCH_C],
+      [BRANCH_A, BRANCH_B, BRANCH_C],
+    );
+  }
+
+  // The carrier's rank against the authoring branch's, both ways round. Ranked
+  // BELOW, the old union happened to commit the authored value; ranked ABOVE, it
+  // committed the base's stale one — the same fold with the same members, decided by
+  // a label. Both orders must now agree.
+  describe.each([
+    { position: "BELOW", carrier: BRANCH_B, author: BRANCH_A },
+    { position: "ABOVE", carrier: BRANCH_A, author: BRANCH_B },
+  ])(
+    "a window-only carrier ranked $position the authoring branch",
+    ({ carrier, author }) => {
+      it("contributes no claim, so the authored value is committed", () => {
+        const result = repointEdges(
+          [
+            // The carrier: an inherited row staged ONLY to carry an ending, so its
+            // props ARE its base props and it authored nothing.
+            stagedEdge({
+              id: "edge-1",
+              from: "x",
+              to: "a",
+              inherited: true,
+              props: { on: "base" },
+              baseProps: { on: "base" },
+              branchId: carrier,
+              validTo: "2100-01-01T00:00:00.000Z",
+            }),
+            stagedEdge({
+              id: "edge-2",
+              from: "x",
+              to: "b",
+              props: { on: "authored" },
+              branchId: author,
+            }),
+          ],
+          collapse,
+          new Set<MergeKey>(),
+          "lastWriteWins",
+          rankABC(),
+        );
+
+        expect(projectEdges(result.edges)).toEqual([
+          {
+            id: "edge-1",
+            kind: "references",
+            fromId: "x",
+            toId: "a",
+            props: { on: "authored" },
+            mergedIds: ["edge-1", "edge-2"],
+            validFrom: undefined,
+            validTo: "2100-01-01T00:00:00.000Z",
+          },
+        ]);
+        // One claim is not a disagreement: the carrier contributes no value, so
+        // there is nothing for the authored one to conflict WITH.
+        expect(result.conflicts).toEqual([]);
+      });
+    },
+  );
+
+  it("still conflicts over two genuinely changed values, naming only those", () => {
+    const result = repointEdges(
+      [
+        stagedEdge({
+          id: "edge-1",
+          from: "x",
+          to: "a",
+          inherited: true,
+          props: { on: "base" },
+          baseProps: { on: "base" },
+          branchId: BRANCH_A,
+        }),
+        stagedEdge({
+          id: "edge-2",
+          from: "x",
+          to: "b",
+          props: { on: "edit-b" },
+          branchId: BRANCH_B,
+        }),
+        stagedEdge({
+          id: "edge-3",
+          from: "x",
+          to: "c",
+          props: { on: "edit-c" },
+          branchId: BRANCH_C,
+        }),
+      ],
+      collapse,
+      new Set<MergeKey>(),
+      "lastWriteWins",
+      rankABC(),
+    );
+
+    // The disagreement is real and reported — over the two AUTHORED values alone.
+    // The carrier's untouched "base" is absent from `values`, so the resolution can
+    // only ever name a value some branch actually asked for.
+    expect(
+      result.conflicts.map((conflict) => ({
+        entityId: conflict.entityId,
+        property: conflict.property,
+        values: conflict.values.map((value) => [
+          value.branchId as string,
+          value.value,
+        ]),
+        resolution: conflict.resolution,
+      })),
+    ).toEqual([
+      {
+        entityId: "edge-1",
+        property: "on",
+        values: [
+          [BRANCH_B as string, "edit-b"],
+          [BRANCH_C as string, "edit-c"],
+        ],
+        resolution: "edit-b",
+      },
+    ]);
+    expect(requireDefined(result.edges[0]).props).toEqual({ on: "edit-b" });
+  });
+
+  it("keeps an unchanged inherited value that no member authored", () => {
+    // Filtering out unauthored CLAIMS must not erase unauthored VALUES: the fold
+    // still commits a full prop bag, so a property nobody touched keeps the value the
+    // survivor holds.
+    const result = repointEdges(
+      [
+        stagedEdge({
+          id: "edge-1",
+          from: "x",
+          to: "a",
+          inherited: true,
+          props: { on: "base" },
+          baseProps: { on: "base" },
+          branchId: BRANCH_A,
+        }),
+        // A branch-created member that says nothing about `on` at all, so the two
+        // members differ on content and the union (not the exact-equal collapse)
+        // decides the result.
+        stagedEdge({
+          id: "edge-2",
+          from: "x",
+          to: "b",
+          props: {},
+          branchId: BRANCH_B,
+        }),
+      ],
+      collapse,
+      new Set<MergeKey>(),
+      "lastWriteWins",
+      rankABC(),
+    );
+
+    expect(requireDefined(result.edges[0]).props).toEqual({ on: "base" });
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("keeps an unauthored property the SURVIVOR's own bag lacks", () => {
+    // Two committed rows the repoint folded together — the survivor is the min-id
+    // inherited one, and the other member's untouched property has no claim behind
+    // it. It is still part of the folded row's content, so the key survives with the
+    // value that member carried.
+    const result = repointEdges(
+      [
+        stagedEdge({
+          id: "edge-1",
+          from: "x",
+          to: "a",
+          inherited: true,
+          props: { on: "base-a" },
+          baseProps: { on: "base-a" },
+          branchId: BRANCH_A,
+        }),
+        stagedEdge({
+          id: "edge-2",
+          from: "x",
+          to: "b",
+          inherited: true,
+          props: { note: "base-b" },
+          baseProps: { note: "base-b" },
+          branchId: BRANCH_B,
+        }),
+      ],
+      collapse,
+      new Set<MergeKey>(),
+      "lastWriteWins",
+      rankABC(),
+    );
+
+    expect(requireDefined(result.edges[0]).id).toBe("edge-1");
+    expect(requireDefined(result.edges[0]).props).toEqual({
+      on: "base-a",
+      note: "base-b",
+    });
+    expect(result.conflicts).toEqual([]);
   });
 });
 

--- a/packages/typegraph/tests/graph-merge/edge-survivor-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-survivor-merge.test.ts
@@ -97,6 +97,9 @@ const DUPLICATE_ENCOUNTER = { kind: "Encounter", id: "enc-2" } as const;
 const INHERITED_EDGE = "edge-5";
 const INHERITED = asEdgeId<typeof hadEncounter>(INHERITED_EDGE);
 const BRANCH_A = asBranchId("survivor-branch-a");
+/** Two further contributing branches, for the cases where a fold set spans branches. */
+const BRANCH_B = asBranchId("survivor-branch-b");
+const BRANCH_C = asBranchId("survivor-branch-c");
 const TARGET_BRANCH = asBranchId("survivor-target");
 const BRANCH_ORDER = [BRANCH_A];
 
@@ -108,6 +111,8 @@ const DUPLICATE_REASON = "routine annual physical examinations";
 const INHERITED_DATE = "2026-01-05";
 /** A base-only property, seeded when a case is about the fork DELETING one. */
 const BASE_NOTE = "seen at reception";
+/** What a branch's own repointed edge says about that property, having authored it. */
+const BRANCH_NOTE = "arrived by ambulance";
 /** What the branch edits the INHERITED edge's `on` to. */
 const EDITED_DATE = "2026-02-02";
 /** What the branch's own repointed edge says. */
@@ -368,6 +373,81 @@ describe.each(backendMatrix())("edge fold survivorship [$name]", (entry) => {
         note: edge.note,
       })),
     ).toEqual([{ id: INHERITED_EDGE, on: EDITED_DATE, note: undefined }]);
+  });
+
+  // The companion of the window-only carrier case in `edge-parallel-merge.test.ts`, on
+  // the other bucket the fold's property union reads from: a row a branch MODIFIED is
+  // staged with the base it was diffed against, so the properties that edit left alone
+  // contribute no claim either (issue #408).
+  //
+  // Once with one editor, once with two — the second reaches the row through the 3-way
+  // modification reconciler, which REBUILDS the record it stages, so it is the case
+  // that pins the base surviving that rebuild rather than only the diff.
+  describe.each([
+    { editors: "ONE branch", alsoEditedByB: false },
+    { editors: "TWO branches, 3-way reconciled", alsoEditedByB: true },
+  ])("an inherited row edited by $editors", ({ alsoEditedByB }) => {
+    it("does not let its untouched property outvote another member's", async () => {
+      // The editors change `on` and never mention `note`, so they carry the base's
+      // note. Branch C authors both on its own repointed row, and ranks LAST — so
+      // under `lastWriteWins` an untouched note counted as a contribution wins `note`
+      // outright, and the report records a conflict for a disagreement one side never
+      // had. That is what makes the base-awareness observable here.
+      const forkPoint = await seededForkPoint(BASE_NOTE);
+      const target = (await forkOf(forkPoint, TARGET_BRANCH)).store;
+      const branchA = await forkOf(forkPoint, BRANCH_A);
+      const branchB = await forkOf(forkPoint, BRANCH_B);
+      const branchC = await forkOf(forkPoint, BRANCH_C);
+
+      await branchA.store.edges.hadEncounter.update(INHERITED, {
+        on: EDITED_DATE,
+      });
+      if (alsoEditedByB) {
+        // The SAME edit, so the two agree and the reconciler's own property union
+        // raises nothing — the fold's is the only arbitration under test.
+        await branchB.store.edges.hadEncounter.update(INHERITED, {
+          on: EDITED_DATE,
+        });
+      }
+      await branchC.store.nodes.Encounter.create(
+        { reason: DUPLICATE_REASON, code: ENCOUNTER_CODE },
+        { id: DUPLICATE_ENCOUNTER.id },
+      );
+      await branchC.store.edges.hadEncounter.create(
+        PATIENT,
+        DUPLICATE_ENCOUNTER,
+        { on: BRANCH_DATE, note: BRANCH_NOTE },
+        { id: "edge-9" },
+      );
+
+      const report = unwrap(
+        await mergeIncremental<CareGraph>({
+          forkPoint,
+          target,
+          branches: [branchA, branchB, branchC],
+          options: {
+            ...resolveDuplicateEncounters(),
+            onPropertyConflict: "lastWriteWins",
+            branchOrder: [BRANCH_A, BRANCH_B, BRANCH_C],
+          },
+        }),
+      );
+
+      // `on` is a real disagreement and the editors win it on rank; `note` is not
+      // contested at all, so the only value anybody authored for it stands.
+      expect(
+        (await liveEdges(target)).map((edge) => ({
+          id: edge.id,
+          on: edge.on,
+          note: edge.note,
+        })),
+      ).toEqual([{ id: INHERITED_EDGE, on: EDITED_DATE, note: BRANCH_NOTE }]);
+      expect(
+        report.conflicts
+          .filter((conflict) => conflict.kind === "hadEncounter")
+          .map((conflict) => conflict.property),
+      ).toEqual(["on"]);
+    });
   });
 
   it("lands a folded END on the committed row the branch ended", async () => {

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -361,6 +361,7 @@ describe.each(backendMatrix())(
         .store;
       const branchA = await forkOf(forkPoint, BRANCH_A);
       await target.nodes.Patient.update(PATIENT, {}, { validTo: LATE });
+      const versionBefore = (await nodeRow(target, "Patient", "pat-1")).version;
       await branchA.store.nodes.Patient.update(PATIENT, {}, { validTo: EARLY });
 
       const report = unwrap(
@@ -375,6 +376,14 @@ describe.each(backendMatrix())(
       // The committed target already windowed this row; a user branch never
       // re-windows it, even with an EARLIER (otherwise winning) claim.
       expect(await nodeEnd(target, "Patient", "pat-1")).toBe(LATE);
+      // Reporting the discard stages NO write: resolving to the end the target
+      // already holds would write the row back at itself, bumping the version, the
+      // history row and the recorded-time entry of a row the merge decided nothing
+      // about. Asserting the committed instant alone cannot see that, because the
+      // instant written back would be the one already there.
+      expect((await nodeRow(target, "Patient", "pat-1")).version).toBe(
+        versionBefore,
+      );
       // Discarding a claim is an arbitration outcome, so it is reported: the entry
       // names the TARGET's own instant, the claim thrown away, and the
       // `precedence` discriminator that keeps it from reading as an end the merge

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -11,7 +11,10 @@
  *   3. disjoint edits across branches all survive;
  *   4. two branches ending differently resolve to the EARLIEST end, reported;
  *   5. a deletion ABSORBS another branch's ending — no delete/modify conflict;
- *   6. the incremental target's own end wins over a branch's;
+ *   6. the incremental target's own end wins over a branch's — and the claims that
+ *      loses are REPORTED against the target's instant, marked
+ *      `precedence: "target"` and credited to nobody (issue #409), so a discarded
+ *      claim is no less visible than one that merely lost the least-claim rule;
  *   7. re-writing the end the target already holds is not a write at all;
  *   8. a fork `validFrom` divergence is reported unapplicable, not applied;
  *   9. PARALLEL edges of one kind each take the end claimed on THAT row;
@@ -60,7 +63,10 @@ import {
 } from "../../src/graph-merge/provenance-store";
 import { isErr, unwrap } from "../../src/graph-merge/result";
 import type { GraphBranch, MergeReport } from "../../src/graph-merge/types";
-import { asBranchId } from "../../src/graph-merge/types";
+import {
+  asBranchId,
+  VALIDITY_END_TARGET_PRECEDENCE,
+} from "../../src/graph-merge/types";
 import { WINDOW_NOT_APPLICABLE_DROP_REASON } from "../../src/graph-merge/valid-window";
 import { canonicalizeDatabaseTimestamp } from "../../src/utils/date";
 import { requireDefined } from "../../src/utils/presence";
@@ -349,7 +355,7 @@ describe.each(backendMatrix())(
       expect(report.validityEnds).toEqual([]);
     });
 
-    it("keeps the incremental target's own end over a branch's", async () => {
+    it("keeps the incremental target's own end over a branch's, and reports the discard", async () => {
       const forkPoint = await seededForkPoint();
       const target = (await forkOf(forkPoint, asBranchId("window-target")))
         .store;
@@ -357,7 +363,7 @@ describe.each(backendMatrix())(
       await target.nodes.Patient.update(PATIENT, {}, { validTo: LATE });
       await branchA.store.nodes.Patient.update(PATIENT, {}, { validTo: EARLY });
 
-      unwrap(
+      const report = unwrap(
         await mergeIncremental<CareGraph>({
           forkPoint,
           target,
@@ -369,6 +375,62 @@ describe.each(backendMatrix())(
       // The committed target already windowed this row; a user branch never
       // re-windows it, even with an EARLIER (otherwise winning) claim.
       expect(await nodeEnd(target, "Patient", "pat-1")).toBe(LATE);
+      // Discarding a claim is an arbitration outcome, so it is reported: the entry
+      // names the TARGET's own instant, the claim thrown away, and the
+      // `precedence` discriminator that keeps it from reading as an end the merge
+      // decided.
+      expect(report.validityEnds).toEqual([
+        {
+          entity: "node",
+          kind: "Patient",
+          id: "pat-1",
+          validTo: LATE,
+          claimedBy: [BRANCH_A],
+          precedence: VALIDITY_END_TARGET_PRECEDENCE,
+        },
+      ]);
+      // Nothing was committed from a branch, so nothing is credited.
+      expect(report.provenance.byBranch(BRANCH_A).nodeIds).toEqual([]);
+    });
+
+    it("reports both discarded claims when TWO branches claimed differing ends", async () => {
+      const forkPoint = await seededForkPoint();
+      const target = (await forkOf(forkPoint, asBranchId("window-target")))
+        .store;
+      const branchA = await forkOf(forkPoint, BRANCH_A);
+      const branchB = await forkOf(forkPoint, BRANCH_B);
+      // The target's own end is the LATEST, so neither branch claim wins on the
+      // least-claim rule either — only target precedence explains the outcome.
+      await target.nodes.Patient.update(PATIENT, {}, { validTo: LATEST });
+      await branchA.store.nodes.Patient.update(PATIENT, {}, { validTo: EARLY });
+      await branchB.store.nodes.Patient.update(PATIENT, {}, { validTo: LATE });
+
+      const report = unwrap(
+        await mergeIncremental<CareGraph>({
+          forkPoint,
+          target,
+          branches: [branchA, branchB],
+          options: { branchOrder: BRANCH_ORDER },
+        }),
+      );
+
+      expect(await nodeEnd(target, "Patient", "pat-1")).toBe(LATEST);
+      // ONE entry for the row, naming BOTH discarded claimants — the same
+      // per-row shape a merge-decided arbitration produces, so a consumer reads
+      // the two the same way apart from `precedence`.
+      expect(report.validityEnds).toEqual([
+        {
+          entity: "node",
+          kind: "Patient",
+          id: "pat-1",
+          validTo: LATEST,
+          claimedBy: [BRANCH_A, BRANCH_B],
+          precedence: VALIDITY_END_TARGET_PRECEDENCE,
+        },
+      ]);
+      expect(report.conflicts).toEqual([]);
+      expect(report.provenance.byBranch(BRANCH_A).nodeIds).toEqual([]);
+      expect(report.provenance.byBranch(BRANCH_B).nodeIds).toEqual([]);
     });
 
     it("leaves a row the TARGET alone windowed out of the merge entirely", async () => {

--- a/packages/typegraph/tests/property/graph-merge/identity-laws.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/identity-laws.test.ts
@@ -86,7 +86,10 @@ import {
 } from "../../../src/graph-merge/merge-identity";
 import { isErr, unwrap } from "../../../src/graph-merge/result";
 import type { BranchId, MergeReport } from "../../../src/graph-merge/types";
-import { asBranchId } from "../../../src/graph-merge/types";
+import {
+  asBranchId,
+  VALIDITY_END_TARGET_PRECEDENCE,
+} from "../../../src/graph-merge/types";
 import { asIdentityAssertionId } from "../../../src/identity/types";
 import { importGraph } from "../../../src/interchange";
 import { storeBackend, storeRuntime } from "../../../src/store/runtime-port";
@@ -979,8 +982,9 @@ const WINDOW_POPULATIONS: readonly WindowPopulation[] = [
  *   - NO UNASKED SHORTENING: when NO branch claimed an end, the target's window
  *     is exactly the one it already held, and the report names no end.
  *   - COMMITTED-TARGET PRECEDENCE: when the incremental target moved the end
- *     ITSELF, its own end stands over every branch claim, and the merge reports
- *     nothing — it decided nothing.
+ *     ITSELF, its own end stands over every branch claim — and the discarded
+ *     claims are reported against the target's own instant, marked
+ *     `precedence: "target"` so nothing reads as an end the merge decided.
  *   - LEAST CLAIM, NO SILENT LOSS: otherwise the EARLIEST branch claim is what
  *     the merge commits — including a lone claim that EXTENDS the ancestor's end
  *     to a later instant — and it is reported with every claiming branch named.
@@ -1060,10 +1064,24 @@ async function expectLawfulWindows(args: {
           postEnd,
           `${label}: a branch re-windowed an end the committed target itself moved`,
         ).toBe(targetEnd);
+        // Target precedence DISCARDS every claim, and a discarded claim is still
+        // reported (issue #409): the least-claim loser is visible in `claimedBy`, so
+        // a claim thrown away wholesale must not be less visible than one that was
+        // merely out-arbitrated. The entry names the TARGET's own instant and carries
+        // the discriminator, so it can never be read as an end the merge wrote.
         expect(
           reported,
-          `${label}: reported an end the merge never decided`,
-        ).toBeUndefined();
+          `${label}: the discarded claims were not reported faithfully`,
+        ).toEqual({
+          entity: population.entity,
+          kind: population.kind,
+          id,
+          validTo: targetEnd,
+          claimedBy: claimants
+            .map((entry) => entry.id as string)
+            .toSorted((left, right) => compareStrings(left, right)),
+          precedence: VALIDITY_END_TARGET_PRECEDENCE,
+        });
       } else if (heldLiveEverywhere) {
         const earliest = requireDefined(claims[0]);
         expect(

--- a/packages/typegraph/tests/property/graph-merge/normalize.ts
+++ b/packages/typegraph/tests/property/graph-merge/normalize.ts
@@ -106,13 +106,19 @@ type NormalizedDropped = Readonly<{
   reason: string;
 }>;
 
-/** A resolved end-of-validity in canonical form. */
+/**
+ * A resolved end-of-validity in canonical form. `precedence` is COMPARED, not
+ * stripped: it is the difference between an end the merge wrote and one the
+ * incremental target already held, so two orderings that disagree about which
+ * happened must fail the gate rather than compare equal on the instant alone.
+ */
 type NormalizedValidityEnd = Readonly<{
   entity: string;
   kind: string;
   id: string;
   validTo: string;
   claimedBy: readonly string[];
+  precedence: string | undefined;
 }>;
 
 /** Per-branch provenance materialized from the report closure, sorted. */
@@ -276,6 +282,7 @@ export function normalizeReport<G extends GraphDef>(
       claimedBy: [...entry.claimedBy]
         .map((branchId) => branchId as string)
         .sort((left, right) => compareStrings(left, right)),
+      precedence: entry.precedence,
     }))
     .sort((left, right) =>
       compareStrings(


### PR DESCRIPTION
Two adjacent gaps in the edge repoint / valid-window path, both pre-existing on main and both surfaced by PR #403's review.

## The edge fold's property union had no base (#408)

`unionEdgeProps` unioned the properties of a fold set by treating every member's staged property bag as a set of first-class `(branch, value)` claims. Unlike `threeWayMergeProps` on the node path, it had no base to compare against — so the values a member never touched competed as if authored, and under any rank-based `onPropertyConflict` an untouched inherited value could outvote a value a branch actually wrote. Which branch label happened to ride on the untouched copy decided the committed properties.

The window-only carrier is what makes that observable, and it is why the hazard is structural rather than exotic. An inherited row whose only change is its end-of-validity is in neither the new nor the modified diff bucket, so it is staged solely to give the ending somewhere to ride; its properties *are* the base's, and the branch carrying it is merely whichever sorted first in `(kind, id, branch)` — possibly one whose own end claim the merge then discarded. A repoint-induced fold between such a row and a branch's own edge had that arbitrary label voting on the result, and the report recorded a `PropertyConflict` for a disagreement nobody had. PR #403 removed the sensitivity to *which* branch the carrier label named; this removes the vote.

`unionEdgeProps` now filters each fold member to the properties it CHANGED from its own base (`authoredProperty`), mirroring the node path. A branch-created member has no base — nothing preceded it — so everything it carries stays a full claim. `StagedEdge` gains the `baseProps` its member was diffed against, threaded from the reconciled modification and, via a new `WindowedEdge.baseProps`, from the window-only carrier: a window-only fork's properties do equal its base's, but that is a fact about the fork rather than something the fold should have to assume.

Filtering claims does not erase content. A property no member authored keeps the value the survivor already holds, and for a key the survivor's own bag lacks it keeps the one held by the member with the minimum edge ID — so the folded row commits the same property *set* it did before, and the commit's base-props deletion handling is unaffected. That fallback orders by the ROW, not by the branch label riding on it: no branch claimed anything for such a key, so ordering by label would reinstate for exactly those keys the sensitivity this PR removes, and it is observable — two folded rows carrying differing base values for a key the survivor lacks committed a different value when the carriers' labels swapped, with no conflict recorded either way. Genuine disagreements are untouched: two members that changed one property differently still conflict, and the conflict's `values` name only their real values, so a resolution can never name a value no branch asked for.

## Target precedence discarded window claims silently (#409)

When the incremental target had already moved an inherited row's end, `resolvePopulation` took the row out of the resolution entirely — it `continue`d before `resolutions.push`, so the branch claims it discarded produced no `ValidityEndResolution` at all. They were invisible in `report.validityEnds`, not merely uncredited, which is backwards: a claim that merely *loses* the least-claim rule stays named in `claimedBy`, so a claim thrown away wholesale was the less visible of the two.

Such a row now gets a resolution naming the target's own committed instant, its discarded claimants in `claimedBy`, and the new optional `ValidityEndResolution.precedence` field set to the exported `VALIDITY_END_TARGET_PRECEDENCE`.

| `precedence` | `validTo` is | staged | credited |
| ------------ | ------------ | ------ | -------- |
| absent | the instant the merge WROTE | yes | the branches whose claim is that instant |
| `"target"` | the instant the target already HELD | no | nobody |

The field is absent on every entry the merge itself decided, so the shape is additive and a consumer that ignores it reads exactly the entries it always read. Nothing changes on the write side — `nodeEnds` / `edgeEnds` are untouched, so the target's row is still not written back at itself — and no provenance credit is minted, since the merge committed none of that end. A row NO branch claimed still produces no entry: there was nothing to discard.

The determinism normalizer COMPARES the new field rather than stripping it. It is the difference between an end the merge wrote and one the target already held, so two branch orderings that disagree about which happened must fail rather than compare equal on the instant alone. That is a guard for the future rather than live coverage today: every determinism gate runs the *snapshot* path, which names no preferred branch and so never produces a target-precedence entry. What does cover this end to end is the valid-window law in the identity property suite, which runs target-advanced incremental histories and now states the reporting shape as a law, replacing its "reports nothing" arm.

## Bump

One changeset at `minor`, covering both: #408 alone is a patch-level bug fix, but #409 adds a field to a public report type, so the pair ships at the higher bump.

Closes #408
Closes #409

## Review follow-ups

Three findings from an adversarial pass, fixed in `112c4cc4`:

1. **The unauthored fallback was still label-ordered.** Described above: the same class of hazard as #408, in the one path the filter hands off to. Now ordered by staged edge ID, pinned by a case that holds the rows fixed and swaps only the labels on the two carriers (the old fallback flips the committed value).
2. **The MODIFIED-edge half of the `baseProps` threading had no test.** Deleting `baseProps` from that staging call — or from the 3-way reconciler's rebuild spread, which carries it for the commit's property-deletion handling too — left the whole `tests/graph-merge` and property suites green. Pinned end to end in `edge-survivor-merge.test.ts`, once with one editor and once with two (the two-editor case is the one that goes through the rebuild).
3. **"No write is staged" was unasserted for a target-precedence row.** Staging the discarded row's end into `nodeEnds` was invisible to every test, because the instant written back is the one the assertion already expected. Now asserted by version, matching how the no-claim case next to it is pinned.
