### PR TITLE
fix(store): coalesce a bulk upsert that re-states a row's own validity window

### DIFF
--- a/.changeset/bulk-upsert-window-coalesce.md
+++ b/.changeset/bulk-upsert-window-coalesce.md
@@ -1,0 +1,31 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+store: coalesce a bulk upsert that re-states a row's own validity window
+
+`bulkUpsertById` now decides whether a requested `validFrom` / `validTo` is a
+change the same way `upsertById` does, through one shared comparison, so a batch
+and the same items applied one at a time write the same rows.
+
+Two defects met in that comparison. The node bulk path refused to coalesce
+whenever an item named a bound AT ALL, so any caller that re-stated a row
+together with the window it already holds — a merge commit, or any
+read-modify-write loop that round-trips `meta.validFrom` — bumped the row's
+version and wrote a history and revision entry for a row that did not change.
+The edge bulk path did compare, but compared the bounds as DRIVER TEXT: a
+Postgres driver that renders `timestamptz` as a zoned string rather than a
+`Date` yields text that is equivalent to the caller's canonical ISO bound
+without being identical to it, so the same batch could coalesce on one backend
+and write on another. Both paths now compare INSTANTS, and an unrepresentable
+bound still counts as a change so the write path raises the `ValidationError`
+the caller is owed rather than coalescing it away.
+
+The bulk paths also track the window each queued write leaves behind, so a
+repeated id in one batch is compared against the batch's own pending state
+rather than the once-prefetched row. Previously an edge item that re-stated the
+window the row held BEFORE the batch was read as unchanged and skipped, dropping
+a write the sequential path performs. A later copy that re-states the window a
+queued write established coalesces; one that names a bound the backend was left
+to stamp (an omitted `validFrom` on a create) writes, since that instant is not
+knowable batch-locally.

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -54,6 +54,30 @@ export function findRepeatedUpsertIds(
 }
 
 /**
+ * A validity window as a row carries it, in the column names a backend returns —
+ * so a prefetched row is comparable without being reshaped.
+ *
+ * `undefined` means BOTH "no bound" (an open window) and "a bound this layer
+ * cannot know", and the two need no distinguishing: an absent bound never equals
+ * a requested one, so an item naming a bound against either always writes. That
+ * is what makes {@link windowAfterUpsertCreate} safe to leave `undefined` where
+ * the backend will stamp the write instant.
+ */
+export type UpsertWindow = Readonly<{
+  valid_from: string | undefined;
+  valid_to: string | undefined;
+}>;
+
+/** The window bounds an upsert item may request. */
+type RequestedWindow = Readonly<{ validFrom?: string; validTo?: string }>;
+
+/** A window to compare against — a row, or an {@link UpsertWindow}. */
+type CurrentWindow = Readonly<{
+  valid_from?: string | undefined;
+  valid_to?: string | undefined;
+}>;
+
+/**
  * Whether one requested window endpoint differs from the stored one, compared as
  * instants rather than as driver text. An omitted request never changes anything.
  *
@@ -75,6 +99,61 @@ function windowFieldChanges(
     return true;
   }
   return canonicalRequested !== canonicalizeDatabaseTimestamp(stored);
+}
+
+/**
+ * Whether an upsert item's requested window differs from the one its target
+ * already holds.
+ *
+ * THE window comparison: `upsertById` and both `bulkUpsertById` paths call this
+ * one function, so a re-stated window coalesces identically whether it arrives
+ * alone or inside a batch. Comparing as INSTANTS is what keeps one backend from
+ * writing where the other coalesces — the stored value arrives as the driver
+ * rendered it, and the dialects do not render a timestamp the same way (SQLite
+ * returns the written text; a Postgres driver renders `timestamptz` its own way,
+ * and one that hands back a zoned string rather than a `Date` hands back text
+ * that is equivalent to the canonical form without being identical to it).
+ */
+export function upsertWindowChanges(
+  requested: RequestedWindow | undefined,
+  current: CurrentWindow,
+): boolean {
+  return (
+    windowFieldChanges(requested?.validFrom, current.valid_from) ||
+    windowFieldChanges(requested?.validTo, current.valid_to)
+  );
+}
+
+/**
+ * The window a queued upsert CREATE — or a resurrection, which asserts a
+ * COMPLETE window — leaves the row holding, for a later item with the same id in
+ * the same batch to compare against.
+ *
+ * An omitted `validFrom` is stamped with the write instant by the backend, a
+ * value this layer cannot know, so it stays `undefined`. A later copy naming a
+ * lower bound therefore counts as a change and writes, rather than coalescing
+ * against a guess: the bulk path may spend a write the sequential path would
+ * skip, but it never skips one the sequential path makes.
+ */
+export function windowAfterUpsertCreate(
+  requested: RequestedWindow,
+): UpsertWindow {
+  return { valid_from: requested.validFrom, valid_to: requested.validTo };
+}
+
+/**
+ * The window a queued upsert UPDATE over a live row leaves it holding: the lower
+ * bound is history and never moves (only a resurrection rewrites `valid_from`),
+ * and the upper bound moves only when the item names one.
+ */
+export function windowAfterUpsertUpdate(
+  current: UpsertWindow,
+  requested: RequestedWindow,
+): UpsertWindow {
+  return {
+    valid_from: current.valid_from,
+    valid_to: requested.validTo ?? current.valid_to,
+  };
 }
 
 /**
@@ -105,15 +184,7 @@ export function shouldCoalesceUpsert(
   // reconciled end-of-validity, so a row written back with the window it
   // already holds (identical props AND identical window) must still coalesce
   // instead of rewriting version, history, and revision state.
-  //
-  // Both sides are canonicalized before comparison. The stored value reaches
-  // here as the driver rendered it, and the two dialects do not store a
-  // timestamp the same way (SQLite keeps the written text; a Postgres driver
-  // renders `timestamptz` its own way), so comparing as INSTANTS is what keeps
-  // one backend from writing where the other coalesces.
-  const windowChanges =
-    windowFieldChanges(options?.validFrom, existing.valid_from) ||
-    windowFieldChanges(options?.validTo, existing.valid_to);
+  const windowChanges = upsertWindowChanges(options, existing);
   if (
     runDirtyCheck === undefined ||
     existing.deleted_at !== undefined ||

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -42,6 +42,10 @@ import {
   findRepeatedUpsertIds,
   type UpsertDirtyCheck,
   type UpsertDirtyCheckFunction,
+  type UpsertWindow,
+  upsertWindowChanges,
+  windowAfterUpsertCreate,
+  windowAfterUpsertUpdate,
 } from "./coalesce";
 import {
   resolveTemporalReadParams,
@@ -755,14 +759,19 @@ export function createEdgeCollection<
         }[] = [];
 
         // Batch-local running state per id so a repeated id coalesces against
-        // the value earlier items in this batch would write, preserving
-        // last-write-wins — and so a repeated id whose edge does not exist yet
-        // queues ONE create plus an update over it rather than two creates the
-        // create batch rejects as "already exists". See the node collection for
-        // the full rationale, including why `props` may be undefined.
+        // the props AND validity window earlier items in this batch would write,
+        // preserving last-write-wins — and so a repeated id whose edge does not
+        // exist yet queues ONE create plus an update over it rather than two
+        // creates the create batch rejects as "already exists". See the node
+        // collection for the full rationale, including why `props` may be
+        // undefined while `window` is always computed.
         const pending = new Map<
           string,
-          { props: Record<string, unknown> | undefined; sourceIndex: number }
+          {
+            props: Record<string, unknown> | undefined;
+            window: UpsertWindow;
+            sourceIndex: number;
+          }
         >();
         const deferred: { index: number; sourceIndex: number }[] = [];
 
@@ -818,6 +827,7 @@ export function createEdgeCollection<
                 repeatedIds.has(item.id) ?
                   runDirtyCheck(kind, item.id, {}, inputProps)?.validatedProps
                 : undefined,
+              window: windowAfterUpsertCreate(item),
               sourceIndex: itemIndex,
             });
             itemIndex++;
@@ -846,21 +856,29 @@ export function createEdgeCollection<
               )
             );
 
-          // An explicit window blocks coalescing ONLY when it would change
-          // the stored window: merge commits pass the staged survivor's
-          // window on every edge write, so a target edge staged back at
-          // itself (identical props AND identical window) must still
-          // coalesce instead of rewriting history and revision state. Against
-          // a QUEUED create there is no stored window to match yet, so any
-          // explicit bound counts as a change and the write happens.
-          const windowChanges =
-            (item.validFrom !== undefined &&
-              item.validFrom !== original?.valid_from) ||
-            (item.validTo !== undefined && item.validTo !== original?.valid_to);
+          // The window the edge holds going into this item: the prefetched row's,
+          // or the one the batch's last queued write for this id leaves behind.
+          const currentWindow: UpsertWindow =
+            pendingEntry === undefined ?
+              {
+                valid_from: requireDefined(original).valid_from,
+                valid_to: requireDefined(original).valid_to,
+              }
+            : pendingEntry.window;
+
+          // An explicit window blocks coalescing ONLY when it would change the
+          // window already held: merge commits pass the staged survivor's window
+          // on every edge write, so a target edge staged back at itself
+          // (identical props AND identical window) must still coalesce instead of
+          // rewriting history and revision state. The comparison is
+          // shouldCoalesceUpsert's own, which reads both sides as INSTANTS —
+          // comparing the driver's text directly (what this path used to do) let
+          // an identical re-stated window coalesce on one dialect and write on
+          // another.
           const coalesce =
             dirty?.unchanged === true &&
             deletedAt === undefined &&
-            !windowChanges;
+            !upsertWindowChanges(item, currentWindow);
 
           if (coalesce) {
             if (pendingEntry === undefined) {
@@ -881,6 +899,13 @@ export function createEdgeCollection<
             });
             pending.set(item.id, {
               props: dirty?.validatedProps,
+              // A resurrection rewrites both bounds only when it NAMES the lower
+              // one (buildUpdateEdge's clearDeleted leg); omitting `validFrom`
+              // keeps the stored window, exactly like a live-row update.
+              window:
+                deletedAt !== undefined && item.validFrom !== undefined ?
+                  windowAfterUpsertCreate(item)
+                : windowAfterUpsertUpdate(currentWindow, item),
               sourceIndex: itemIndex,
             });
           }

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -45,6 +45,10 @@ import {
   shouldCoalesceUpsert,
   type UpsertDirtyCheck,
   type UpsertDirtyCheckFunction,
+  type UpsertWindow,
+  upsertWindowChanges,
+  windowAfterUpsertCreate,
+  windowAfterUpsertUpdate,
 } from "./coalesce";
 import {
   resolveTemporalReadParams,
@@ -657,12 +661,15 @@ export function createNodeCollection<
           clearDeleted: boolean;
         }[] = [];
 
-        // Batch-local running state per id: the props the row would hold after
-        // the writes queued so far, and the item index that queued that write.
-        // A later same-id item coalesces against this running value, not the
-        // once-prefetched row — otherwise [{x:B},{x:A}] on a row holding A would
-        // coalesce the second item against the stale prefetched A and drop the
-        // first item's write, breaking last-write-wins.
+        // Batch-local running state per id: the props AND validity window the
+        // row would hold after the writes queued so far, and the item index that
+        // queued that write. A later same-id item coalesces against this running
+        // value, not the once-prefetched row — otherwise [{x:B},{x:A}] on a row
+        // holding A would coalesce the second item against the stale prefetched
+        // A and drop the first item's write, breaking last-write-wins. The same
+        // staleness applies to the window: a copy re-stating the bound the
+        // prefetched row held, after an earlier copy already moved it, must
+        // write it back rather than coalesce.
         //
         // A QUEUED CREATE is registered here too. Leaving it out queued a SECOND
         // create for a repeated id whose row does not exist yet, and the create
@@ -676,9 +683,14 @@ export function createNodeCollection<
         // check rejected the input): presence of the ENTRY is what routes a
         // later copy away from a second create, while the props only decide
         // coalescing, and an unknown running value simply never coalesces.
+        // `window` is always computed — unlike the props it costs no Zod parse.
         const pending = new Map<
           string,
-          { props: Record<string, unknown> | undefined; sourceIndex: number }
+          {
+            props: Record<string, unknown> | undefined;
+            window: UpsertWindow;
+            sourceIndex: number;
+          }
         >();
         // A coalesced item that matched an in-batch write resolves to that
         // write's result (filled once the writes run), not a fabricated row.
@@ -729,6 +741,7 @@ export function createNodeCollection<
                 repeatedIds.has(item.id) ?
                   runDirtyCheck(item.id, {}, item.props)?.validatedProps
                 : undefined,
+              window: windowAfterUpsertCreate(item),
               sourceIndex: itemIndex,
             });
             itemIndex++;
@@ -751,11 +764,26 @@ export function createNodeCollection<
               runDirtyCheck(item.id, currentProps, item.props)
             );
 
+          // The window the row holds going into this item: the prefetched row's,
+          // or the one the batch's last queued write for this id leaves behind.
+          const currentWindow: UpsertWindow =
+            pendingEntry === undefined ?
+              {
+                valid_from: requireDefined(original).valid_from,
+                valid_to: requireDefined(original).valid_to,
+              }
+            : pendingEntry.window;
+
+          // An explicit window blocks coalescing ONLY when it would change the
+          // window already held — the same rule, through the same comparison,
+          // that shouldCoalesceUpsert applies to a single upsert. Blocking on the
+          // mere PRESENCE of a bound (what this path used to do) rewrote version,
+          // history, and revision state for every re-stated row a caller happened
+          // to hand its own current window.
           const coalesce =
             dirty?.unchanged === true &&
             deletedAt === undefined &&
-            item.validFrom === undefined &&
-            item.validTo === undefined;
+            !upsertWindowChanges(item, currentWindow);
 
           if (coalesce) {
             if (pendingEntry === undefined) {
@@ -776,6 +804,13 @@ export function createNodeCollection<
             });
             pending.set(item.id, {
               props: dirty?.validatedProps,
+              // A resurrecting update rewrites BOTH bounds (buildUpdateNode's
+              // clearDeleted leg stamps `valid_from` and reopens `valid_to`);
+              // a live-row update moves only `valid_to`.
+              window:
+                deletedAt === undefined ?
+                  windowAfterUpsertUpdate(currentWindow, item)
+                : windowAfterUpsertCreate(item),
               sourceIndex: itemIndex,
             });
           }

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -11,17 +11,16 @@ import {
   type Store,
   ValidationError,
 } from "../../../src";
-import {
-  type TransactionBackend,
-  type TransactionOptions,
-} from "../../../src/backend/types";
 import { createSqlSchema } from "../../../src/query/compiler/schema";
 import { sql } from "../../../src/query/sql-fragment";
 import { asCompiledRowsSql } from "../../../src/query/sql-intent";
 import { STORE_RUNTIME } from "../../../src/store/runtime-port";
 import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
 import { requireDefined } from "../../../src/utils/presence";
-import { withZonedValidityWindowText } from "../../test-utils";
+import {
+  withEdgeUpdateCounting,
+  withZonedValidityWindowText,
+} from "../../test-utils";
 import {
   type HistoryIntegrationStore,
   type IntegrationStore,
@@ -92,43 +91,6 @@ async function countRecordedNodeRows(
     `),
   );
   return Number(rows[0]?.cnt ?? 0);
-}
-
-type EdgeWriteCounter = Readonly<{
-  backend: GraphBackend;
-  updates: () => number;
-}>;
-
-/**
- * Wraps a backend — and every transaction-scoped backend it hands out — so
- * each `updateEdge` call is counted. Edges carry no version counter, so the
- * duplicate-id probe matrix needs an exact write count that survives the
- * transaction the bulk-upsert path opens.
- */
-function withEdgeUpdateCounting(base: GraphBackend): EdgeWriteCounter {
-  let updates = 0;
-  function countingUpdateEdge(
-    target: Pick<GraphBackend, "updateEdge">,
-  ): GraphBackend["updateEdge"] {
-    return (params) => {
-      updates += 1;
-      return target.updateEdge(params);
-    };
-  }
-  const backend: GraphBackend = {
-    ...base,
-    updateEdge: countingUpdateEdge(base),
-    transaction: <T>(
-      fn: (tx: TransactionBackend) => Promise<T>,
-      options?: TransactionOptions,
-    ) =>
-      base.transaction<T>(
-        (txBackend) =>
-          fn({ ...txBackend, updateEdge: countingUpdateEdge(txBackend) }),
-        options,
-      ),
-  };
-  return { backend, updates: () => updates };
 }
 
 /**
@@ -1183,7 +1145,7 @@ export function registerCoalesceUpsertIntegrationTests(
         );
       });
 
-      it("writes for a repeated NEW id whose later copy names a lower bound the create left implicit", async () => {
+      it("writes for a repeated NEW id whose later copy bounds a window the create left OPEN", async () => {
         const store = await createCoalesceStore(context);
 
         const results = await store.nodes.Person.bulkUpsertById([
@@ -1195,10 +1157,10 @@ export function registerCoalesceUpsertIntegrationTests(
           },
         ]);
 
-        // The create left `validFrom` to the backend's write instant, which the
-        // batch cannot know, so a later bound is compared against an unknown and
-        // counts as a change. Deliberately conservative: the bulk path may spend a
-        // write the sequential path skips, never skip one it makes.
+        // The queued create leaves the upper bound open, and an open bound is
+        // KNOWN — so naming one is a real change and the same decision the
+        // sequential path reaches. (The lower bound is the unknowable one; that
+        // rule is the case below.)
         expect(results[1]).not.toBe(results[0]);
         expect(results[1]?.meta.version).toBe(2);
         const after = await store.nodes.Person.getById(
@@ -1207,6 +1169,111 @@ export function registerCoalesceUpsertIntegrationTests(
         expect(canonicalizeDatabaseTimestamp(after?.meta.validTo)).toBe(
           WINDOW_END,
         );
+      });
+
+      it("writes for a repeated NEW id whose later copy names the lower bound the BACKEND stamped", async () => {
+        const store = await createCoalesceStore(context);
+
+        // A create that omits `validFrom` is stamped with the write instant, which
+        // the batch cannot know. Freezing the clock is what lets the second copy
+        // name that exact instant — the one input for which a batch-local GUESS
+        // (the write instant is right there in `nowIso()`) would look correct and
+        // coalesce, skipping a write. Leaving the bound unknown is what refuses it.
+        const stamped = "2020-05-05T00:00:00.000Z";
+        vi.useFakeTimers({ toFake: ["Date"] });
+        vi.setSystemTime(new Date(stamped));
+        const batched = await store.nodes.Person.bulkUpsertById([
+          { id: "bw-new-stamped", props: { name: "Win", age: 1 } },
+          {
+            id: "bw-new-stamped",
+            props: { name: "Win", age: 1 },
+            validFrom: stamped,
+          },
+        ]).finally(() => {
+          vi.useRealTimers();
+        });
+
+        expect(batched[1]).not.toBe(batched[0]);
+        expect(batched[1]?.meta.version).toBe(2);
+
+        // The oracle for the OTHER side of the asymmetry: applied one at a time
+        // the second call compares against a bound that is on the row by then, so
+        // it coalesces. The bulk path may spend a write the sequential path skips;
+        // it never skips one the sequential path makes.
+        const created = await store.nodes.Person.upsertById("bw-seq-stamped", {
+          name: "Win",
+          age: 1,
+        });
+        const restated = await store.nodes.Person.upsertById(
+          "bw-seq-stamped",
+          { name: "Win", age: 1 },
+          {
+            validFrom: requireDefined(
+              canonicalizeDatabaseTimestamp(created.meta.validFrom),
+            ),
+          },
+        );
+        expect(restated.meta.version).toBe(created.meta.version);
+      });
+
+      it("carries a queued update's untouched LOWER bound into the next copy's comparison", async () => {
+        const store = await createCoalesceStore(context);
+        const seeded = await seedWindowedPerson(store, "bw-node-carry");
+
+        // Item 1 moves only the end; an in-place update never rewrites
+        // `valid_from`, so the bound the row keeps is the seeded one. The copies
+        // behind it re-state the whole window, and each must be compared against
+        // the state its predecessor leaves — one write for three items.
+        const restated = {
+          props: { name: "Win", age: 1 },
+          validFrom: seeded.validFrom,
+          validTo: LATER_WINDOW_END,
+        } as const;
+        await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-node-carry",
+            props: { name: "Win", age: 1 },
+            validTo: LATER_WINDOW_END,
+          },
+          { id: "bw-node-carry", ...restated },
+          { id: "bw-node-carry", ...restated },
+        ]);
+
+        const after = await store.nodes.Person.getById(
+          personId("bw-node-carry"),
+        );
+        expect(after?.meta.version).toBe(seeded.version + 1);
+        expect(canonicalizeDatabaseTimestamp(after?.meta.validTo)).toBe(
+          LATER_WINDOW_END,
+        );
+      });
+
+      it("rolls the whole batch back when a later item's bound is unrepresentable", async () => {
+        const store = await createCoalesceStore(context);
+        const seeded = await seedWindowedPerson(store, "bw-atomic-live");
+
+        // Creates run BEFORE updates, so the first item is already inserted when
+        // the second one's bound is refused: only the batch's transaction can keep
+        // it from surviving. The bulk contract is all-or-nothing — no per-item
+        // error accumulation.
+        await expect(
+          store.nodes.Person.bulkUpsertById([
+            { id: "bw-atomic-created", props: { name: "Win", age: 1 } },
+            {
+              id: "bw-atomic-live",
+              props: { name: "Win", age: 2 },
+              validTo: "not-a-date",
+            },
+          ]),
+        ).rejects.toBeInstanceOf(ValidationError);
+
+        await expect(
+          store.nodes.Person.getById(personId("bw-atomic-created")),
+        ).resolves.toBeUndefined();
+        const live = await store.nodes.Person.getById(
+          personId("bw-atomic-live"),
+        );
+        expect(live?.meta.version).toBe(seeded.version);
       });
     });
   });

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -6,7 +6,10 @@ import {
   createStoreWithSchema,
   type EdgeId,
   type GraphBackend,
+  type Node,
   type NodeId,
+  type Store,
+  ValidationError,
 } from "../../../src";
 import {
   type TransactionBackend,
@@ -16,7 +19,9 @@ import { createSqlSchema } from "../../../src/query/compiler/schema";
 import { sql } from "../../../src/query/sql-fragment";
 import { asCompiledRowsSql } from "../../../src/query/sql-intent";
 import { STORE_RUNTIME } from "../../../src/store/runtime-port";
+import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
 import { requireDefined } from "../../../src/utils/presence";
+import { withZonedValidityWindowText } from "../../test-utils";
 import {
   type HistoryIntegrationStore,
   type IntegrationStore,
@@ -53,6 +58,11 @@ function personId(
 ): NodeId<typeof integrationTestGraph.nodes.Person.type> {
   return asNodeId(id);
 }
+
+type PersonNode = Node<typeof integrationTestGraph.nodes.Person.type>;
+
+/** Any store over the integration graph — history, backend-bearing, or plain. */
+type CoalesceTestStore = Store<typeof integrationTestGraph>;
 
 function knowsId(
   id: string,
@@ -119,6 +129,63 @@ function withEdgeUpdateCounting(base: GraphBackend): EdgeWriteCounter {
       ),
   };
   return { backend, updates: () => updates };
+}
+
+/**
+ * A future instant and a later one. Every re-stated window in these cases has to
+ * be a window the store would accept as a fresh write too, and a bound before the
+ * row's own `validFrom` (its creation instant) is refused as inverted.
+ */
+const WINDOW_END = "2100-06-01T00:00:00.000Z";
+const LATER_WINDOW_END = "2100-09-01T00:00:00.000Z";
+
+/**
+ * A PAST lower bound, for the cases that name `validFrom` on a CREATE and then
+ * read the row back: a row whose window starts in 2100 is not current yet, so a
+ * plain `getById` could not see it at all.
+ */
+const WINDOW_START = "2000-01-01T00:00:00.000Z";
+
+/** Seeds a Person at version 1 whose window ends at {@link WINDOW_END}. */
+async function seedWindowedPerson(
+  store: CoalesceTestStore,
+  id: string,
+): Promise<Readonly<{ validFrom: string; version: number }>> {
+  const created = await store.nodes.Person.upsertById(
+    id,
+    { name: "Win", age: 1 },
+    { validTo: WINDOW_END },
+  );
+  expect(created.meta.version).toBe(1);
+  return {
+    validFrom: requireDefined(created.meta.validFrom),
+    version: created.meta.version,
+  };
+}
+
+/** A coalescing store on a wrapped backend, plus the edge write counter. */
+async function createCountingStore(
+  base: GraphBackend,
+): Promise<Readonly<{ store: CoalesceTestStore; edgeUpdates: () => number }>> {
+  const counter = withEdgeUpdateCounting(base);
+  const [store] = await createStoreWithSchema(
+    integrationTestGraph,
+    counter.backend,
+    { coalesceUnchangedUpserts: true },
+  );
+  return { store, edgeUpdates: counter.updates };
+}
+
+/** Creates two people and returns them as edge endpoints. */
+async function seedEndpoints(
+  store: CoalesceTestStore,
+  prefix: string,
+): Promise<readonly [PersonNode, PersonNode]> {
+  const [alice, bob] = await store.nodes.Person.bulkCreate([
+    { props: { name: "A" }, id: `${prefix}-a` },
+    { props: { name: "B" }, id: `${prefix}-b` },
+  ]);
+  return [requireDefined(alice), requireDefined(bob)];
 }
 
 export function registerCoalesceUpsertIntegrationTests(
@@ -688,6 +755,458 @@ export function registerCoalesceUpsertIntegrationTests(
           { id: "s3", props: { name: "S3" } },
         ]);
         expect(refreshCalls).toBe(1);
+      });
+    });
+
+    /**
+     * The bulk paths compare a requested window against the one its target
+     * already holds, exactly as `shouldCoalesceUpsert` does for a single item —
+     * through the same function, so the two can never drift.
+     *
+     * Two defects met here. The node bulk path refused to coalesce whenever an
+     * item named a bound AT ALL (issue #405), so any caller that re-stated a row
+     * together with its own window — what a merge commit and any
+     * read-modify-write loop does — rewrote version, history, and revision state
+     * for a row that did not change. The edge bulk path did compare, but compared
+     * DRIVER TEXT (issue #412), so an identical re-stated window could coalesce on
+     * one dialect and write on another, and — on every dialect — a repeated id
+     * compared against the once-prefetched row instead of the window the batch had
+     * already queued, which could drop a write the sequential path performs.
+     */
+    describe("bulk window comparison (#405, #412)", () => {
+      it("coalesces a bulk item that re-states an unchanged node and its own window", async () => {
+        const store = await createCoalesceStore(context);
+        const seeded = await seedWindowedPerson(store, "bw-node-same");
+
+        const results = await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-node-same",
+            props: { name: "Win", age: 1 },
+            validFrom: seeded.validFrom,
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        // Nothing would change, so nothing is written. Pre-fix the presence of a
+        // bound alone forced the update and the version reached 2.
+        expect(results[0]?.meta.version).toBe(seeded.version);
+        const after = await store.nodes.Person.getById(
+          personId("bw-node-same"),
+        );
+        expect(after?.meta.version).toBe(seeded.version);
+        expect(canonicalizeDatabaseTimestamp(after?.meta.validTo)).toBe(
+          WINDOW_END,
+        );
+      });
+
+      it("captures no history for a bulk re-statement of a node and its window", async () => {
+        const store = await createCoalesceStore(context, { history: true });
+        const seeded = await seedWindowedPerson(store, "bw-node-hist");
+        const recordedBefore = await countRecordedNodeRows(
+          store,
+          "Person",
+          "bw-node-hist",
+        );
+
+        await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-node-hist",
+            props: { name: "Win", age: 1 },
+            validFrom: seeded.validFrom,
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        expect(
+          await countRecordedNodeRows(store, "Person", "bw-node-hist"),
+        ).toBe(recordedBefore);
+      });
+
+      it("coalesces a bulk item that re-states an unchanged edge and its own window", async () => {
+        const { store, edgeUpdates } = await createCountingStore(
+          context.getStore().backend,
+        );
+        const [alice, bob] = await seedEndpoints(store, "bw-edge-same");
+
+        const [seeded] = await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("bw-edge-same"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+            validTo: WINDOW_END,
+          },
+        ]);
+        const updatesBefore = edgeUpdates();
+
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("bw-edge-same"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+            validFrom: requireDefined(seeded?.meta.validFrom),
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        expect(edgeUpdates()).toBe(updatesBefore);
+        const after = await store.edges.knows.getById(knowsId("bw-edge-same"));
+        expect(after?.meta.updatedAt).toBe(seeded?.meta.updatedAt);
+      });
+
+      it("coalesces a node whose stored window is rendered as an equivalent instant in another text form", async () => {
+        const [store] = await createStoreWithSchema(
+          integrationTestGraph,
+          withZonedValidityWindowText(context.getStore().backend),
+          { coalesceUnchangedUpserts: true },
+        );
+        const seeded = await seedWindowedPerson(store, "bw-zoned-node");
+
+        // The bounds the caller re-states are canonical; the ones the collection
+        // reads back are the same instants written `+00:00`. Comparing them as
+        // TEXT reports a change that does not exist.
+        const results = await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-zoned-node",
+            props: { name: "Win", age: 1 },
+            validFrom: seeded.validFrom,
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        expect(results[0]?.meta.version).toBe(seeded.version);
+      });
+
+      it("coalesces an edge whose stored window is rendered as an equivalent instant in another text form", async () => {
+        const { store, edgeUpdates } = await createCountingStore(
+          withZonedValidityWindowText(context.getStore().backend),
+        );
+        const [alice, bob] = await seedEndpoints(store, "bw-zoned-edge");
+
+        const [seeded] = await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("bw-zoned-edge"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+            validTo: WINDOW_END,
+          },
+        ]);
+        const updatesBefore = edgeUpdates();
+
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("bw-zoned-edge"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+            validFrom: requireDefined(
+              canonicalizeDatabaseTimestamp(seeded?.meta.validFrom),
+            ),
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        expect(edgeUpdates()).toBe(updatesBefore);
+      });
+
+      it("writes when a bulk item moves the window of an otherwise unchanged row", async () => {
+        const store = await createCoalesceStore(context);
+        const seeded = await seedWindowedPerson(store, "bw-node-move");
+
+        const results = await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-node-move",
+            props: { name: "Win", age: 1 },
+            validFrom: seeded.validFrom,
+            validTo: LATER_WINDOW_END,
+          },
+        ]);
+
+        expect(results[0]?.meta.version).toBe(seeded.version + 1);
+        const after = await store.nodes.Person.getById(
+          personId("bw-node-move"),
+        );
+        expect(canonicalizeDatabaseTimestamp(after?.meta.validTo)).toBe(
+          LATER_WINDOW_END,
+        );
+      });
+
+      it("writes when a bulk edge item moves the window of an otherwise unchanged edge", async () => {
+        const { store, edgeUpdates } = await createCountingStore(
+          context.getStore().backend,
+        );
+        const [alice, bob] = await seedEndpoints(store, "bw-edge-move");
+
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("bw-edge-move"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+            validTo: WINDOW_END,
+          },
+        ]);
+        const updatesBefore = edgeUpdates();
+
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("bw-edge-move"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+            validTo: LATER_WINDOW_END,
+          },
+        ]);
+
+        expect(edgeUpdates()).toBe(updatesBefore + 1);
+        const after = await store.edges.knows.getById(knowsId("bw-edge-move"));
+        expect(canonicalizeDatabaseTimestamp(after?.meta.validTo)).toBe(
+          LATER_WINDOW_END,
+        );
+      });
+
+      it("refuses an unrepresentable bound from a bulk item with the single path's own error", async () => {
+        const store = await createCoalesceStore(context);
+        await seedWindowedPerson(store, "bw-unrepresentable");
+
+        // An unparseable bound has no instant, and neither has an absent one, so
+        // canonicalizing both sides would report "no change" and coalesce the
+        // write — swallowing the error the caller is owed. The rule that keeps
+        // that from happening lives in the shared comparison, so the bulk path
+        // must now raise exactly what the single path raises for the same item.
+        const item = {
+          props: { name: "Win", age: 1 },
+          validTo: "not-a-date",
+        } as const;
+        // A resolved value is not a ValidationError, so a path that fails to
+        // reject fails the assertion below just as loudly as a wrong error would.
+        const singleError: unknown = await store.nodes.Person.upsertById(
+          "bw-unrepresentable",
+          item.props,
+          {
+            validTo: item.validTo,
+          },
+        ).catch((error: unknown) => error);
+        const bulkError: unknown = await store.nodes.Person.bulkUpsertById([
+          { id: "bw-unrepresentable", ...item },
+        ]).catch((error: unknown) => error);
+
+        expect(singleError).toBeInstanceOf(ValidationError);
+        expect(bulkError).toBeInstanceOf(ValidationError);
+        expect((bulkError as Error).message).toBe(
+          (singleError as Error).message,
+        );
+      });
+
+      it("refuses an unrepresentable bound from a bulk EDGE item", async () => {
+        const store = await createCoalesceStore(context);
+        const [alice, bob] = await seedEndpoints(store, "bw-edge-bad");
+        await store.edges.knows.bulkUpsertById([
+          {
+            id: knowsId("bw-edge-bad"),
+            from: alice,
+            to: bob,
+            props: { since: "2020" },
+          },
+        ]);
+
+        await expect(
+          store.edges.knows.bulkUpsertById([
+            {
+              id: knowsId("bw-edge-bad"),
+              from: alice,
+              to: bob,
+              props: { since: "2020" },
+              validTo: "not-a-date",
+            },
+          ]),
+        ).rejects.toThrow(/validTo/);
+      });
+
+      it("compares a repeated node id against the window the batch QUEUED, not the prefetched one", async () => {
+        const store = await createCoalesceStore(context);
+        const seeded = await seedWindowedPerson(store, "bw-node-queued");
+
+        // Item 1 moves the end; item 2 re-states the end the row held BEFORE the
+        // batch. Against the queued window that is a change, so it writes — and
+        // it must, or the batch would end at item 1's window while the same items
+        // applied one at a time end at item 2's.
+        await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-node-queued",
+            props: { name: "Win", age: 1 },
+            validTo: LATER_WINDOW_END,
+          },
+          {
+            id: "bw-node-queued",
+            props: { name: "Win", age: 1 },
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        const batched = await store.nodes.Person.getById(
+          personId("bw-node-queued"),
+        );
+        expect(batched?.meta.version).toBe(seeded.version + 2);
+        expect(canonicalizeDatabaseTimestamp(batched?.meta.validTo)).toBe(
+          WINDOW_END,
+        );
+
+        // Sequential-equivalence oracle: the same items, one at a time.
+        const sequentialSeed = await seedWindowedPerson(store, "bw-node-seq");
+        await store.nodes.Person.upsertById(
+          "bw-node-seq",
+          { name: "Win", age: 1 },
+          { validTo: LATER_WINDOW_END },
+        );
+        await store.nodes.Person.upsertById(
+          "bw-node-seq",
+          { name: "Win", age: 1 },
+          { validTo: WINDOW_END },
+        );
+        const sequential = await store.nodes.Person.getById(
+          personId("bw-node-seq"),
+        );
+        expect(sequential?.meta.version).toBe(sequentialSeed.version + 2);
+        expect(canonicalizeDatabaseTimestamp(sequential?.meta.validTo)).toBe(
+          canonicalizeDatabaseTimestamp(batched?.meta.validTo),
+        );
+      });
+
+      it("coalesces a repeated node id that re-states the window the batch QUEUED", async () => {
+        const store = await createCoalesceStore(context);
+        const seeded = await seedWindowedPerson(store, "bw-node-restate");
+
+        // Item 1 moves the end, item 2 re-states item 1's window: one write.
+        await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-node-restate",
+            props: { name: "Win", age: 1 },
+            validTo: LATER_WINDOW_END,
+          },
+          {
+            id: "bw-node-restate",
+            props: { name: "Win", age: 1 },
+            validTo: LATER_WINDOW_END,
+          },
+        ]);
+
+        const after = await store.nodes.Person.getById(
+          personId("bw-node-restate"),
+        );
+        expect(after?.meta.version).toBe(seeded.version + 1);
+        expect(canonicalizeDatabaseTimestamp(after?.meta.validTo)).toBe(
+          LATER_WINDOW_END,
+        );
+      });
+
+      it("compares a repeated EDGE id against the window the batch QUEUED", async () => {
+        const { store, edgeUpdates } = await createCountingStore(
+          context.getStore().backend,
+        );
+        const [alice, bob] = await seedEndpoints(store, "bw-edge-queued");
+        const base = {
+          from: alice,
+          to: bob,
+          props: { since: "2020" },
+        } as const;
+
+        await store.edges.knows.bulkUpsertById([
+          { id: knowsId("bw-edge-queued"), ...base, validTo: WINDOW_END },
+        ]);
+        const updatesBefore = edgeUpdates();
+
+        await store.edges.knows.bulkUpsertById([
+          { id: knowsId("bw-edge-queued"), ...base, validTo: LATER_WINDOW_END },
+          { id: knowsId("bw-edge-queued"), ...base, validTo: WINDOW_END },
+        ]);
+
+        // Pre-fix the second item compared against the PREFETCHED row, whose end
+        // was still WINDOW_END, called it unchanged and coalesced — leaving the
+        // edge at item 1's end and silently diverging from the sequential result.
+        expect(edgeUpdates()).toBe(updatesBefore + 2);
+        const batched = await store.edges.knows.getById(
+          knowsId("bw-edge-queued"),
+        );
+        expect(canonicalizeDatabaseTimestamp(batched?.meta.validTo)).toBe(
+          WINDOW_END,
+        );
+
+        // Sequential-equivalence oracle: the same items as two batches of one.
+        await store.edges.knows.bulkUpsertById([
+          { id: knowsId("bw-edge-seq"), ...base, validTo: WINDOW_END },
+        ]);
+        await store.edges.knows.bulkUpsertById([
+          { id: knowsId("bw-edge-seq"), ...base, validTo: LATER_WINDOW_END },
+        ]);
+        await store.edges.knows.bulkUpsertById([
+          { id: knowsId("bw-edge-seq"), ...base, validTo: WINDOW_END },
+        ]);
+        const sequential = await store.edges.knows.getById(
+          knowsId("bw-edge-seq"),
+        );
+        expect(canonicalizeDatabaseTimestamp(sequential?.meta.validTo)).toBe(
+          canonicalizeDatabaseTimestamp(batched?.meta.validTo),
+        );
+      });
+
+      it("coalesces a repeated NEW id whose later copy re-states the queued CREATE's window", async () => {
+        const store = await createCoalesceStore(context);
+
+        // The create names both bounds, so the queued window is fully known and a
+        // copy re-stating it changes nothing: one create, no update.
+        const results = await store.nodes.Person.bulkUpsertById([
+          {
+            id: "bw-new-restate",
+            props: { name: "Win", age: 1 },
+            validFrom: WINDOW_START,
+            validTo: WINDOW_END,
+          },
+          {
+            id: "bw-new-restate",
+            props: { name: "Win", age: 1 },
+            validFrom: WINDOW_START,
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        expect(results[1]).toBe(results[0]);
+        expect(results[0]?.meta.version).toBe(1);
+        const after = await store.nodes.Person.getById(
+          personId("bw-new-restate"),
+        );
+        expect(after?.meta.version).toBe(1);
+        expect(canonicalizeDatabaseTimestamp(after?.meta.validFrom)).toBe(
+          WINDOW_START,
+        );
+      });
+
+      it("writes for a repeated NEW id whose later copy names a lower bound the create left implicit", async () => {
+        const store = await createCoalesceStore(context);
+
+        const results = await store.nodes.Person.bulkUpsertById([
+          { id: "bw-new-implicit", props: { name: "Win", age: 1 } },
+          {
+            id: "bw-new-implicit",
+            props: { name: "Win", age: 1 },
+            validTo: WINDOW_END,
+          },
+        ]);
+
+        // The create left `validFrom` to the backend's write instant, which the
+        // batch cannot know, so a later bound is compared against an unknown and
+        // counts as a change. Deliberately conservative: the bulk path may spend a
+        // write the sequential path skips, never skip one it makes.
+        expect(results[1]).not.toBe(results[0]);
+        expect(results[1]?.meta.version).toBe(2);
+        const after = await store.nodes.Person.getById(
+          personId("bw-new-implicit"),
+        );
+        expect(canonicalizeDatabaseTimestamp(after?.meta.validTo)).toBe(
+          WINDOW_END,
+        );
       });
     });
   });

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -64,6 +64,7 @@ import { asBranchId } from "../../src/graph-merge/types";
 import { WINDOW_NOT_APPLICABLE_DROP_REASON } from "../../src/graph-merge/valid-window";
 import { canonicalizeDatabaseTimestamp } from "../../src/utils/date";
 import { requireDefined } from "../../src/utils/presence";
+import { withZonedValidityWindowText } from "../test-utils";
 import { backendMatrix, getStoreBackend } from "./test-utils";
 
 const Patient = defineNode("Patient", {
@@ -828,6 +829,113 @@ describe.each(backendMatrix())(
         // The ending was branch A's only act, so it contributed nothing at all.
         expect(report.provenance.byBranch(BRANCH_A).nodeIds).toEqual([]);
       });
+    });
+
+    /**
+     * A backend that counts `updateEdge` calls, through transactions too. Edges
+     * carry no version counter, so a merge that must write NOTHING can only be
+     * pinned by the write count itself — `updated_at` collides within a
+     * millisecond, which is exactly the resolution a repeated merge runs at.
+     */
+    function withEdgeUpdateCounting(
+      base: GraphBackend,
+    ): Readonly<{ backend: GraphBackend; updates: () => number }> {
+      let updates = 0;
+      function counting(
+        target: Pick<GraphBackend, "updateEdge">,
+      ): GraphBackend["updateEdge"] {
+        return (params) => {
+          updates += 1;
+          return target.updateEdge(params);
+        };
+      }
+      return {
+        backend: {
+          ...base,
+          updateEdge: counting(base),
+          transaction: (fn, options) =>
+            base.transaction(
+              (txBackend) =>
+                fn({ ...txBackend, updateEdge: counting(txBackend) }),
+              options,
+            ),
+        },
+        updates: () => updates,
+      };
+    }
+
+    /**
+     * The coalesce contract for merge commits, end to end.
+     *
+     * A branch-created edge carries its OWN validity window into the commit, and
+     * the commit writes every survivor through `bulkUpsertById`. So a re-delivered
+     * merge re-states that edge against a target that already holds exactly that
+     * window — the shape an at-least-once merge pipeline produces. If the bulk path
+     * treats the re-statement as a change, an idempotent merge rewrites history and
+     * revision state for every edge it carried.
+     *
+     * `wrapTarget` decides how the target's backend renders the stored window,
+     * which makes this the end-to-end pin for issue #412: comparing an equivalent
+     * instant in a different text form must reach the same decision, or a merge is
+     * a no-op on one driver and a full rewrite on another.
+     */
+    async function assertRedeliveryWritesNothing(
+      wrapTarget: (backend: GraphBackend) => GraphBackend,
+    ): Promise<void> {
+      const forkPoint = await seededForkPoint();
+      const counter = withEdgeUpdateCounting(wrapTarget(await makeBackend()));
+      const [targetStore] = await createStoreWithSchema(
+        careGraph,
+        counter.backend,
+        { coalesceUnchangedUpserts: true },
+      );
+      const target = await seed(targetStore);
+
+      const branchA = await forkOf(forkPoint, BRANCH_A);
+      await branchA.store.nodes.Patient.update(PATIENT, { note: "seen" });
+      await branchA.store.edges.hadEncounter.create(
+        { kind: "Patient", id: "pat-2" },
+        { kind: "Encounter", id: "enc-1" },
+        { on: "2026-03-03" },
+        { id: "edge-authored", validTo: LATE },
+      );
+
+      async function deliver(): Promise<void> {
+        unwrap(
+          await mergeIncremental<CareGraph>({
+            forkPoint,
+            target,
+            branches: [branchA],
+            options: { branchOrder: BRANCH_ORDER },
+          }),
+        );
+      }
+
+      await deliver();
+      const nodeAfterFirst = await nodeRow(target, "Patient", "pat-1");
+      const updatesAfterFirst = counter.updates();
+      expect(await edgeEnd(target, "edge-authored")).toBe(LATE);
+
+      await deliver();
+
+      // Nothing changed between the two deliveries, so the second is not a write
+      // at all: no edge update, no node version bump, and the authored window
+      // still stands.
+      expect(counter.updates()).toBe(updatesAfterFirst);
+      const nodeAfterSecond = await nodeRow(target, "Patient", "pat-1");
+      expect(nodeAfterSecond.version).toBe(nodeAfterFirst.version);
+      expect(nodeAfterSecond.updated_at).toBe(nodeAfterFirst.updated_at);
+      expect(await edgeEnd(target, "edge-authored")).toBe(LATE);
+    }
+
+    it("re-delivering an already-merged branch writes nothing at all", async () => {
+      await assertRedeliveryWritesNothing((backend) => backend);
+    });
+
+    it("re-delivers as a no-op when the driver renders the window as a zoned string", async () => {
+      await assertRedeliveryWritesNothing((backend) =>
+        withZonedValidityWindowText(backend),
+      );
     });
 
     it("does not rewrite an unchanged row when nothing changed at all", async () => {

--- a/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/valid-window-merge.test.ts
@@ -64,7 +64,10 @@ import { asBranchId } from "../../src/graph-merge/types";
 import { WINDOW_NOT_APPLICABLE_DROP_REASON } from "../../src/graph-merge/valid-window";
 import { canonicalizeDatabaseTimestamp } from "../../src/utils/date";
 import { requireDefined } from "../../src/utils/presence";
-import { withZonedValidityWindowText } from "../test-utils";
+import {
+  withEdgeUpdateCounting,
+  withZonedValidityWindowText,
+} from "../test-utils";
 import { backendMatrix, getStoreBackend } from "./test-utils";
 
 const Patient = defineNode("Patient", {
@@ -407,11 +410,13 @@ describe.each(backendMatrix())(
 
     it("does not write when a branch re-states the end the target holds", async () => {
       const forkPoint = await seededForkPoint();
-      // A hand-seeded target with coalescing on: `branch()` clones do not inherit
-      // store options, and the option is only meaningful on the WRITE side.
-      const target = await seed(
-        await newStore({ coalesceUnchangedUpserts: true }),
-      );
+      // Coalescing OFF, like the two cases above: the committed target moved this
+      // end, which takes the row out of window resolution entirely, so a branch
+      // re-stating that same end is never staged and only the PLAN can keep the
+      // write from happening. The coalesce check's half of this shape — a
+      // re-stated end that IS staged, because the target holds it from an earlier
+      // delivery rather than from its own update — is the re-delivery pin below.
+      const target = await seed(await newStore());
       await target.nodes.Patient.update(PATIENT, {}, { validTo: LATE });
       const versionBefore = (await nodeRow(target, "Patient", "pat-1")).version;
 
@@ -427,10 +432,8 @@ describe.each(backendMatrix())(
         }),
       );
 
-      // The reconciled end differs from BASE (so it IS passed to the upsert) but
-      // equals the committed one, so the coalesce check sees no window change and
-      // skips the write entirely — no version bump, no history row, no revision
-      // churn.
+      // Nothing reaches the write path at all — the version is the proof, since
+      // every node update bumps it — and the end the target authored still stands.
       expect((await nodeRow(target, "Patient", "pat-1")).version).toBe(
         versionBefore,
       );
@@ -830,39 +833,6 @@ describe.each(backendMatrix())(
         expect(report.provenance.byBranch(BRANCH_A).nodeIds).toEqual([]);
       });
     });
-
-    /**
-     * A backend that counts `updateEdge` calls, through transactions too. Edges
-     * carry no version counter, so a merge that must write NOTHING can only be
-     * pinned by the write count itself — `updated_at` collides within a
-     * millisecond, which is exactly the resolution a repeated merge runs at.
-     */
-    function withEdgeUpdateCounting(
-      base: GraphBackend,
-    ): Readonly<{ backend: GraphBackend; updates: () => number }> {
-      let updates = 0;
-      function counting(
-        target: Pick<GraphBackend, "updateEdge">,
-      ): GraphBackend["updateEdge"] {
-        return (params) => {
-          updates += 1;
-          return target.updateEdge(params);
-        };
-      }
-      return {
-        backend: {
-          ...base,
-          updateEdge: counting(base),
-          transaction: (fn, options) =>
-            base.transaction(
-              (txBackend) =>
-                fn({ ...txBackend, updateEdge: counting(txBackend) }),
-              options,
-            ),
-        },
-        updates: () => updates,
-      };
-    }
 
     /**
      * The coalesce contract for merge commits, end to end.

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -18,7 +18,12 @@ import {
 import type { AnySqliteDatabase } from "../src/backend/drizzle/execution";
 import type { SqliteTables } from "../src/backend/sqlite";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
-import type { AdapterBackend, GraphBackend } from "../src/backend/types";
+import type {
+  AdapterBackend,
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../src/backend/types";
 import {
   createRecordedInstant,
   type RecordedInstant,
@@ -27,6 +32,16 @@ import {
 import { requireDefined } from "../src/utils/presence";
 
 const backendsToClose: GraphBackend[] = [];
+
+/** A row carrying a validity window, as the backend returns it. */
+type ValidityWindowRow = Readonly<{
+  valid_from: string | undefined;
+  valid_to: string | undefined;
+}>;
+
+/** The id-keyed reads whose rows carry a validity window. */
+type ValidityWindowReads = Pick<GraphBackend, "getNode" | "getEdge"> &
+  Partial<Pick<GraphBackend, "getNodes" | "getEdges">>;
 
 export function recordedRevisionFromDriver(value: unknown): number {
   const revision =
@@ -281,6 +296,90 @@ export function disableTransactions(backend: GraphBackend): GraphBackend {
           ),
       }
     : {}),
+  };
+}
+
+/**
+ * The same instant in a different text form: `...T00:00:00.000+00:00` for
+ * `...T00:00:00.000Z`.
+ */
+function toZonedTimestampText(value: string | undefined): string | undefined {
+  if (!value?.endsWith("Z")) return value;
+  return `${value.slice(0, -1)}+00:00`;
+}
+
+function withZonedWindow<T extends ValidityWindowRow>(row: T): T {
+  return {
+    ...row,
+    valid_from: toZonedTimestampText(row.valid_from),
+    valid_to: toZonedTimestampText(row.valid_to),
+  };
+}
+
+/** Re-renders the validity window of every row the four id-keyed reads return. */
+function withZonedWindowReads<T extends ValidityWindowReads>(target: T): T {
+  return {
+    ...target,
+    getNode: async (graphId: string, kind: string, id: string) => {
+      const row = await target.getNode(graphId, kind, id);
+      return row === undefined ? undefined : withZonedWindow(row);
+    },
+    getEdge: async (graphId: string, id: string) => {
+      const row = await target.getEdge(graphId, id);
+      return row === undefined ? undefined : withZonedWindow(row);
+    },
+    ...(target.getNodes === undefined ?
+      {}
+    : {
+        getNodes: async (
+          graphId: string,
+          kind: string,
+          ids: readonly string[],
+        ) => {
+          const rows = await requireDefined(target.getNodes)(
+            graphId,
+            kind,
+            ids,
+          );
+          return rows.map((row) => withZonedWindow(row));
+        },
+      }),
+    ...(target.getEdges === undefined ?
+      {}
+    : {
+        getEdges: async (graphId: string, ids: readonly string[]) => {
+          const rows = await requireDefined(target.getEdges)(graphId, ids);
+          return rows.map((row) => withZonedWindow(row));
+        },
+      }),
+  };
+}
+
+/**
+ * Wraps a backend — and every transaction-scoped backend it hands out — so a
+ * stored validity window reaches the store as an EQUIVALENT INSTANT IN A
+ * DIFFERENT TEXT FORM.
+ *
+ * That is the shape a Postgres driver which returns a zoned string rather than a
+ * `Date` produces: `formatPostgresTimestamp` passes any "T"-bearing string
+ * through verbatim, so a window comparison ends up reading the caller's canonical
+ * bound against driver text. Every driver in the matrix normalizes `timestamptz`
+ * to a `Date` today, which is why comparing that text directly looked harmless —
+ * it agreed with the canonical comparison by luck. Simulating the other rendering
+ * is what turns the cross-dialect rule into something every backend can assert
+ * (issue #412).
+ */
+export function withZonedValidityWindowText(base: GraphBackend): GraphBackend {
+  return {
+    ...withZonedWindowReads(base),
+    transaction: <T>(
+      fn: (tx: TransactionBackend) => Promise<T>,
+      options?: TransactionOptions,
+    ) =>
+      base.transaction<T>(
+        (txBackend) => fn(withZonedWindowReads(txBackend)),
+        options,
+      ),
   };
 }
 

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -300,6 +300,45 @@ export function disableTransactions(backend: GraphBackend): GraphBackend {
 }
 
 /**
+ * Wraps a backend — and every transaction-scoped backend it hands out — so each
+ * `updateEdge` call is counted.
+ *
+ * Edges carry no version counter and `updated_at` collides within a millisecond,
+ * which is the resolution a repeated write runs at, so an exact write count is
+ * the only way to assert that an edge write did NOT happen. Wrapping the
+ * transaction too is what makes the count survive the one `bulkUpsertById` opens.
+ */
+export function withEdgeUpdateCounting(
+  base: GraphBackend,
+): Readonly<{ backend: GraphBackend; updates: () => number }> {
+  let updates = 0;
+  function countingUpdateEdge(
+    target: Pick<GraphBackend, "updateEdge">,
+  ): GraphBackend["updateEdge"] {
+    return (params) => {
+      updates += 1;
+      return target.updateEdge(params);
+    };
+  }
+  return {
+    backend: {
+      ...base,
+      updateEdge: countingUpdateEdge(base),
+      transaction: <T>(
+        fn: (tx: TransactionBackend) => Promise<T>,
+        options?: TransactionOptions,
+      ) =>
+        base.transaction<T>(
+          (txBackend) =>
+            fn({ ...txBackend, updateEdge: countingUpdateEdge(txBackend) }),
+          options,
+        ),
+    },
+    updates: () => updates,
+  };
+}
+
+/**
  * The same instant in a different text form: `...T00:00:00.000+00:00` for
  * `...T00:00:00.000Z`.
  */


### PR DESCRIPTION
`bulkUpsertById` decided whether a requested `validFrom` / `validTo` counted as a change differently from `upsertById`, in two different wrong ways. Both bulk paths now route the decision through the one comparison `shouldCoalesceUpsert` already used, so a batch and the same items applied one at a time write the same rows.

## The node path blocked on presence, not on change (#405)

It refused to coalesce whenever an item named a bound at all. Any caller that re-stated a row together with the window it already holds — a merge commit, or any read-modify-write loop that round-trips `meta.validFrom` — bumped the version and wrote a history and revision entry for a row that had not changed, while the single-item path skipped the write entirely. The blanket block is replaced by the `windowChanges` comparison against the row the batch prefetched.

## The edge path compared driver text, not instants (#412)

It compared `item.validFrom !== original?.valid_from` as raw strings. `formatPostgresTimestamp` passes any "T"-bearing string through verbatim, so a Postgres driver that renders `timestamptz` as a zoned string hands back text equivalent to the caller's canonical ISO bound without being identical to it — and the same batch coalesces on one backend while writing on another. Every driver in the matrix (`pg`, `postgres-js`, PGlite) normalizes `timestamptz` to a `Date` today, which is exactly why the raw comparison looked harmless: it agreed with the canonical one by luck, not by construction. `withZonedValidityWindowText` in the shared test utils re-renders the reads so the rule can be asserted rather than assumed.

The shared `upsertWindowChanges` canonicalizes both sides and keeps the #383 rule that an unrepresentable bound counts as a change, so the write path still raises the `ValidationError` the caller is owed instead of coalescing it away — a rule that was previously unreachable from bulk.

## Repeated ids compared against a stale window

The edge path compared a repeated id's window against the once-prefetched row rather than the write the batch had already queued. An item re-stating the window the row held *before* the batch therefore read as unchanged and was skipped, dropping a write the sequential path performs — a silent divergence from the sequential-equivalence contract #404 established, on every backend.

Both paths now carry the window each queued write leaves behind in the batch-local pending state, beside the props already tracked there. Two builders name the two write shapes: `windowAfterUpsertCreate` for a create or a resurrection asserting a complete window, `windowAfterUpsertUpdate` for an in-place update whose lower bound is history and whose upper bound moves only when named. A node resurrection always rewrites both bounds while an edge resurrection does so only when it names `validFrom`, and each call site states its own rule.

## The queued-create rule

A later copy of a repeated new id that re-states a window the create **named** coalesces. One that names a bound the backend was left to stamp — an omitted `validFrom`, whose instant is the write instant — writes, because that value is not knowable batch-locally and guessing it is the one mistake with teeth. The bulk path may therefore spend a write the sequential path would skip; it never skips one the sequential path makes.

## Scope note

For nodes the merge commit path was never affected: it writes canonical nodes through the single `upsertById`, and the provenance sidecar's `bulkUpsertById` passes no window. The merge exposure was on the edge side, where a branch-created edge carries its own window into every canonical write.

Closes #405
Closes #412
