### PR TITLE
fix(store): typed duplicate-identity refusal and an honest resurrection bound

### DIFF
--- a/.changeset/typed-duplicate-identity-and-resurrection-bound.md
+++ b/.changeset/typed-duplicate-identity-and-resurrection-bound.md
@@ -1,0 +1,65 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Harden two failures at the operations/backend boundary: a create the engine
+refuses now reports the condition it actually hit, and the last write path that
+could store an inverted valid-time window no longer can.
+
+**A create refused by the engine reports "already exists", not a raw driver
+error.** A create learns an id is taken either from its own existence probe or
+from the engine refusing the INSERT, and the second used to escape as a
+`DrizzleQueryError` whose `.message` is the raw INSERT text. One condition
+therefore surfaced as a typed user error down one path and an opaque system error
+down the other, and callers could not branch on it at all. The engine's report is
+now classified structurally and both routes raise the same `ValidationError`, on
+the single and batch create paths for nodes and edges alike.
+
+Two things reach the engine's path. A NODE create probes first, but the probe and
+the INSERT are two statements and PostgreSQL's default READ COMMITTED does not
+serialize the two write transactions, so a concurrent create of the same new id
+can commit in between — the issue's reproduction. An EDGE create has no existence
+probe at all, so the engine's refusal is its only report of a taken id, on every
+backend and with no race involved.
+
+Classification is structural, never message text: SQLSTATE 23505 plus the
+PostgreSQL protocol's own constraint and relation fields, and SQLite's extended
+result code, which distinguishes a primary-key duplicate (1555) from any other
+unique-index duplicate (2067) in the code itself.
+
+Every such refusal, from either route, now carries the new exported issue code
+`ENTITY_ALREADY_EXISTS`, so a caller can recognize it without matching on the
+message. `details.entityType` and `details.kind` say what was refused;
+`details.id` names the taken id, and is absent only when a BATCH insert lost the
+race, because the engine reports that the batch collided without saying which
+row did.
+
+The classification is scoped to the primary key on purpose. A `unique: true`
+index declaration materializes a UNIQUE INDEX on the same relation, and violating
+that is a declared-uniqueness failure about the row's VALUES rather than a
+duplicate identity — PostgreSQL reports it under the index's own name and SQLite
+under a different extended code, so it never matches and is unaffected. Neither is
+a declared `unique` constraint conflict, which still raises `UniquenessError`.
+
+SQLite never reached the node race: `BEGIN IMMEDIATE` gives the writer slot to
+one transaction at a time, so a second create cannot sit between its probe and its
+INSERT while the first commits. Its probe is authoritative there, and the refusal
+was already the typed error — it now carries the code too. A duplicate EDGE id on
+SQLite did surface as a raw `SqliteError`, and now raises the same error as it
+does on PostgreSQL.
+
+**A node resurrection stores the bound its window guard measured against.** A
+resurrection rewrites `valid_from` rather than retaining it, so the guard that
+refuses inverted windows has no stored bound to check and used the write instant
+instead — sampled in the operations layer, while the backend went on to stamp its
+own, strictly later, sample. A `validTo` at the guard's instant passed as
+zero-width and committed as NEGATIVE width a millisecond later, the exact shape
+the previous release exists to refuse. The operations layer now passes the
+instant it validated against explicitly, so the bound that is checked is the
+bound that is stored. Stating both endpoints is unaffected; the only change to a
+successful write is that a resurrection's `valid_from` is the operations layer's
+instant rather than the backend's, a difference of well under a millisecond.
+
+Edge resurrection was never exposed: an edge RETAINS its stored `valid_from`
+unless the write names a new one, so its guard measures against a value already
+on disk and predicts nothing.

--- a/.changeset/typed-duplicate-identity-and-resurrection-bound.md
+++ b/.changeset/typed-duplicate-identity-and-resurrection-bound.md
@@ -3,7 +3,7 @@
 ---
 
 Harden two failures at the operations/backend boundary: a create the engine
-refuses now reports the condition it actually hit, and the last write path that
+refuses now reports the condition it actually hit, and the last UPDATE path that
 could store an inverted valid-time window no longer can.
 
 **A create refused by the engine reports "already exists", not a raw driver
@@ -30,9 +30,11 @@ unique-index duplicate (2067) in the code itself.
 Every such refusal, from either route, now carries the new exported issue code
 `ENTITY_ALREADY_EXISTS`, so a caller can recognize it without matching on the
 message. `details.entityType` and `details.kind` say what was refused;
-`details.id` names the taken id, and is absent only when a BATCH insert lost the
-race, because the engine reports that the batch collided without saying which
-row did.
+`details.id` names the taken id, and is absent only when the refused statement
+inserted more than one row, because the engine reports that the statement
+collided without saying which row did. No race is needed to reach that: a bulk
+create of edges, whose ids the caller supplied and which nothing probes, is
+refused this way on every backend.
 
 The classification is scoped to the primary key on purpose. A `unique: true`
 index declaration materializes a UNIQUE INDEX on the same relation, and violating
@@ -58,7 +60,8 @@ the previous release exists to refuse. The operations layer now passes the
 instant it validated against explicitly, so the bound that is checked is the
 bound that is stored. Stating both endpoints is unaffected; the only change to a
 successful write is that a resurrection's `valid_from` is the operations layer's
-instant rather than the backend's, a difference of well under a millisecond.
+instant rather than the backend's — sampled a moment earlier inside the same
+locked write, before the uniqueness entries it re-checks and re-inserts.
 
 Edge resurrection was never exposed: an edge RETAINS its stored `valid_from`
 unless the write names a new one, so its guard measures against a value already

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -183,10 +183,12 @@ the engine's refusal is always what reports a taken edge id. All of these raise 
 same error, so a caller retrying a generated id needs one branch, not several.
 
 `details.id` names the taken id, and is present for every single-entity create.
-It is absent only when a BATCH create lost that race: the engine reports that the
-batch collided without saying which row did, and its transaction is already
-aborted, so there is nothing left to probe. Treat `details.id` as optional if you
-create in bulk.
+It is absent only when the refused statement inserted more than one row: the
+engine reports that the statement collided without saying which row did, and its
+transaction is already aborted, so there is nothing left to probe. No race is
+needed to reach that — a bulk create of edges, whose ids you supplied and which
+nothing probes, is refused this way on every backend. Treat `details.id` as
+optional if you create in bulk.
 
 This is about identity, not values. A conflict on a declared `unique` constraint
 raises `UniquenessError` instead, and a violated `unique: true` index declaration

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -150,6 +150,48 @@ stream with `TrustedImportError` reason `invalid_stream`. A zero-width window
 (`validTo === validFrom`) is legal and never raises this, and so is a create
 carrying only a historical `validTo`.
 
+#### `ENTITY_ALREADY_EXISTS`
+
+A `ValidationError` whose issue carries the exported code
+`ENTITY_ALREADY_EXISTS` refused a create because the id is already taken.
+`details.entityType` says whether a node or an edge was refused and
+`details.kind` names its kind.
+
+```typescript
+import { ENTITY_ALREADY_EXISTS_CODE, ValidationError } from "@nicia-ai/typegraph";
+
+try {
+  await store.nodes.Person.create({ name: "Alice" }, { id: takenId });
+} catch (error) {
+  if (
+    error instanceof ValidationError &&
+    error.details.issues.some((issue) => issue.code === ENTITY_ALREADY_EXISTS_CODE)
+  ) {
+    // Use a different id, or update the existing entity.
+  }
+}
+```
+
+The code is the same whichever layer noticed, on either backend. A node create
+finds out from its own existence probe — but the probe and the INSERT are two
+statements, and PostgreSQL does not serialize two write transactions under its
+default READ COMMITTED isolation, so a concurrent create of the same NEW id can
+commit in between and the engine refuses the INSERT instead. (SQLite's
+`BEGIN IMMEDIATE` gives the writer slot to one transaction at a time, so its probe
+always sees the winner's row.) An edge create has no existence probe at all, so
+the engine's refusal is always what reports a taken edge id. All of these raise the
+same error, so a caller retrying a generated id needs one branch, not several.
+
+`details.id` names the taken id, and is present for every single-entity create.
+It is absent only when a BATCH create lost that race: the engine reports that the
+batch collided without saying which row did, and its transaction is already
+aborted, so there is nothing left to probe. Treat `details.id` as optional if you
+create in bulk.
+
+This is about identity, not values. A conflict on a declared `unique` constraint
+raises `UniquenessError` instead, and a violated `unique: true` index declaration
+surfaces as the engine's own failure — neither is reshaped into this error.
+
 ### `DisjointError`
 
 Thrown when attempting to create a node that violates a disjointness constraint.

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -1018,7 +1018,11 @@ export class DatabaseOperationError extends TypeGraphError {
 export type DatabaseOperationErrorDetails = Readonly<{
     operation: string;
     entity: string;
-    reason?: "no_row_returned";
+    reason?: "no_row_returned" | "duplicate_key";
+    attempted?: readonly Readonly<{
+        kind: string;
+        id: string;
+    }>[];
 }>;
 
 // @public (undocumented)
@@ -1749,6 +1753,9 @@ export type EndpointNotFoundErrorDetails = Readonly<{
     nodeKind: string;
     nodeId: string;
 }>;
+
+// @public
+export const ENTITY_ALREADY_EXISTS_CODE = "ENTITY_ALREADY_EXISTS";
 
 // @public
 export function equivalentTo(kindA: NodeType, kindBOrIri: NodeType | string): OntologyRelation;

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -254,14 +254,12 @@ async function withDuplicateKeyClassification<T>(
   }
 }
 
-function attemptedNodes(
-  params: readonly InsertNodeParams[],
-): readonly AttemptedInsert[] {
-  return params.map((item) => ({ kind: item.kind, id: item.id }));
-}
-
-function attemptedEdges(
-  params: readonly InsertEdgeParams[],
+/**
+ * The entity refs of an insert's rows, copied out of the insert params so the
+ * error carries identity alone and never the props alongside it.
+ */
+function attemptedInserts(
+  params: readonly AttemptedInsert[],
 ): readonly AttemptedInsert[] {
   return params.map((item) => ({ kind: item.kind, id: item.id }));
 }
@@ -428,7 +426,7 @@ export function createCommonOperationBackend(
         {
           entity: "node",
           relation: operationStrategy.primaryKeyConstraints.nodes,
-          attempted: attemptedNodes([params]),
+          attempted: attemptedInserts([params]),
         },
       );
       if (!row)
@@ -452,7 +450,7 @@ export function createCommonOperationBackend(
       await withDuplicateKeyClassification(() => execution.execRun(query), {
         entity: "node",
         relation: operationStrategy.primaryKeyConstraints.nodes,
-        attempted: attemptedNodes([params]),
+        attempted: attemptedInserts([params]),
       });
     },
 
@@ -466,7 +464,7 @@ export function createCommonOperationBackend(
         await withDuplicateKeyClassification(() => execution.execRun(query), {
           entity: "node",
           relation: operationStrategy.primaryKeyConstraints.nodes,
-          attempted: attemptedNodes(chunk),
+          attempted: attemptedInserts(chunk),
         });
       }
     },
@@ -489,7 +487,7 @@ export function createCommonOperationBackend(
           {
             entity: "node",
             relation: operationStrategy.primaryKeyConstraints.nodes,
-            attempted: attemptedNodes(chunk),
+            attempted: attemptedInserts(chunk),
           },
         );
         allRows.push(...rows.map((row) => rowMappers.toNodeRow(row)));
@@ -615,7 +613,7 @@ export function createCommonOperationBackend(
         {
           entity: "edge",
           relation: operationStrategy.primaryKeyConstraints.edges,
-          attempted: attemptedEdges([params]),
+          attempted: attemptedInserts([params]),
         },
       );
       if (!row)
@@ -639,7 +637,7 @@ export function createCommonOperationBackend(
       await withDuplicateKeyClassification(() => execution.execRun(query), {
         entity: "edge",
         relation: operationStrategy.primaryKeyConstraints.edges,
-        attempted: attemptedEdges([params]),
+        attempted: attemptedInserts([params]),
       });
     },
 
@@ -653,7 +651,7 @@ export function createCommonOperationBackend(
         await withDuplicateKeyClassification(() => execution.execRun(query), {
           entity: "edge",
           relation: operationStrategy.primaryKeyConstraints.edges,
-          attempted: attemptedEdges(chunk),
+          attempted: attemptedInserts(chunk),
         });
       }
     },
@@ -676,7 +674,7 @@ export function createCommonOperationBackend(
           {
             entity: "edge",
             relation: operationStrategy.primaryKeyConstraints.edges,
-            attempted: attemptedEdges(chunk),
+            attempted: attemptedInserts(chunk),
           },
         );
         allRows.push(...rows.map((row) => rowMappers.toEdgeRow(row)));

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -18,6 +18,10 @@ import type {
 import { asCompiledStatementSql } from "../../query/sql-intent";
 import { chunk as chunkArray } from "../../utils/array";
 import {
+  isDuplicatePrimaryKeyError,
+  type PrimaryKeyRelation,
+} from "../../utils/sql-errors";
+import {
   resolveEdgeEndpointIds,
   resolveHeterogeneousEdgeRead,
 } from "../edge-endpoint-sets";
@@ -204,6 +208,64 @@ type CreateCommonOperationBackendOptions = Readonly<{
   tableExistenceCache?: TableExistenceCacheOptions | undefined;
 }>;
 
+/**
+ * The entity refs a duplicate-key classification reports back. Nodes carry a
+ * kind of their own; an edge's `kind` is its edge kind, which the insert params
+ * also carry.
+ */
+type AttemptedInsert = Readonly<{ kind: string; id: string }>;
+
+/**
+ * Runs an insert and converts a PRIMARY KEY duplicate-key refusal into a
+ * classified {@link DatabaseOperationError} carrying the rows it attempted.
+ *
+ * The translation stops here rather than reaching for the store's "already
+ * exists" error because that is a store-level judgement: the backend's job is to
+ * say *what the engine refused and why* in terms callers can branch on, instead
+ * of letting a `DrizzleQueryError` whose `.message` is the raw INSERT text
+ * escape as the operation's outcome (issue #410). The create paths translate it
+ * onward; every other caller sees a system error, exactly as before.
+ *
+ * Any other failure — including a 23505 from a declared `unique: true` index on
+ * the same relation — propagates untouched.
+ */
+async function withDuplicateKeyClassification<T>(
+  run: () => Promise<T>,
+  context: Readonly<{
+    entity: "node" | "edge";
+    relation: PrimaryKeyRelation;
+    attempted: readonly AttemptedInsert[];
+  }>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (!isDuplicatePrimaryKeyError(error, context.relation)) throw error;
+    throw new DatabaseOperationError(
+      `Insert ${context.entity} failed: a row with this identity already exists`,
+      {
+        operation: "insert",
+        entity: context.entity,
+        reason: "duplicate_key",
+        attempted: context.attempted,
+      },
+      { cause: error },
+    );
+  }
+}
+
+function attemptedNodes(
+  params: readonly InsertNodeParams[],
+): readonly AttemptedInsert[] {
+  return params.map((item) => ({ kind: item.kind, id: item.id }));
+}
+
+function attemptedEdges(
+  params: readonly InsertEdgeParams[],
+): readonly AttemptedInsert[] {
+  return params.map((item) => ({ kind: item.kind, id: item.id }));
+}
+
 function verifyExpectedActiveVersion(
   graphId: string,
   expected: CommitSchemaVersionParams["expected"],
@@ -361,7 +423,14 @@ export function createCommonOperationBackend(
     async insertNode(params: InsertNodeParams): Promise<NodeRow> {
       const timestamp = nowIso();
       const query = operationStrategy.buildInsertNode(params, timestamp);
-      const row = await execution.execGet<Record<string, unknown>>(query);
+      const row = await withDuplicateKeyClassification(
+        () => execution.execGet<Record<string, unknown>>(query),
+        {
+          entity: "node",
+          relation: operationStrategy.primaryKeyConstraints.nodes,
+          attempted: attemptedNodes([params]),
+        },
+      );
       if (!row)
         throw new DatabaseOperationError(
           "Insert node failed: no row returned",
@@ -380,7 +449,11 @@ export function createCommonOperationBackend(
         params,
         timestamp,
       );
-      await execution.execRun(query);
+      await withDuplicateKeyClassification(() => execution.execRun(query), {
+        entity: "node",
+        relation: operationStrategy.primaryKeyConstraints.nodes,
+        attempted: attemptedNodes([params]),
+      });
     },
 
     async insertNodesBatch(params: readonly InsertNodeParams[]): Promise<void> {
@@ -390,7 +463,11 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       for (const chunk of chunkArray(params, batchConfig.nodeInsertBatchSize)) {
         const query = operationStrategy.buildInsertNodesBatch(chunk, timestamp);
-        await execution.execRun(query);
+        await withDuplicateKeyClassification(() => execution.execRun(query), {
+          entity: "node",
+          relation: operationStrategy.primaryKeyConstraints.nodes,
+          attempted: attemptedNodes(chunk),
+        });
       }
     },
 
@@ -407,7 +484,14 @@ export function createCommonOperationBackend(
           chunk,
           timestamp,
         );
-        const rows = await execution.execAll<Record<string, unknown>>(query);
+        const rows = await withDuplicateKeyClassification(
+          () => execution.execAll<Record<string, unknown>>(query),
+          {
+            entity: "node",
+            relation: operationStrategy.primaryKeyConstraints.nodes,
+            attempted: attemptedNodes(chunk),
+          },
+        );
         allRows.push(...rows.map((row) => rowMappers.toNodeRow(row)));
       }
       return allRows;
@@ -526,7 +610,14 @@ export function createCommonOperationBackend(
     async insertEdge(params: InsertEdgeParams): Promise<EdgeRow> {
       const timestamp = nowIso();
       const query = operationStrategy.buildInsertEdge(params, timestamp);
-      const row = await execution.execGet<Record<string, unknown>>(query);
+      const row = await withDuplicateKeyClassification(
+        () => execution.execGet<Record<string, unknown>>(query),
+        {
+          entity: "edge",
+          relation: operationStrategy.primaryKeyConstraints.edges,
+          attempted: attemptedEdges([params]),
+        },
+      );
       if (!row)
         throw new DatabaseOperationError(
           "Insert edge failed: no row returned",
@@ -545,7 +636,11 @@ export function createCommonOperationBackend(
         params,
         timestamp,
       );
-      await execution.execRun(query);
+      await withDuplicateKeyClassification(() => execution.execRun(query), {
+        entity: "edge",
+        relation: operationStrategy.primaryKeyConstraints.edges,
+        attempted: attemptedEdges([params]),
+      });
     },
 
     async insertEdgesBatch(params: readonly InsertEdgeParams[]): Promise<void> {
@@ -555,7 +650,11 @@ export function createCommonOperationBackend(
       const timestamp = nowIso();
       for (const chunk of chunkArray(params, batchConfig.edgeInsertBatchSize)) {
         const query = operationStrategy.buildInsertEdgesBatch(chunk, timestamp);
-        await execution.execRun(query);
+        await withDuplicateKeyClassification(() => execution.execRun(query), {
+          entity: "edge",
+          relation: operationStrategy.primaryKeyConstraints.edges,
+          attempted: attemptedEdges(chunk),
+        });
       }
     },
 
@@ -572,7 +671,14 @@ export function createCommonOperationBackend(
           chunk,
           timestamp,
         );
-        const rows = await execution.execAll<Record<string, unknown>>(query);
+        const rows = await withDuplicateKeyClassification(
+          () => execution.execAll<Record<string, unknown>>(query),
+          {
+            entity: "edge",
+            relation: operationStrategy.primaryKeyConstraints.edges,
+            attempted: attemptedEdges(chunk),
+          },
+        );
         allRows.push(...rows.map((row) => rowMappers.toEdgeRow(row)));
       }
       return allRows;

--- a/packages/typegraph/src/backend/drizzle/operations/nodes.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/nodes.ts
@@ -173,6 +173,13 @@ export function buildUpdateNode(
     );
   }
 
+  // A resurrection RESETS the window: `valid_from` is rewritten rather than
+  // retained (an edge retains it — see `buildUpdateEdge`). `timestamp` is only
+  // the fallback: the operations layer passes the instant its inverted-window
+  // guard measured against as an explicit `validFrom`, so the bound this stores
+  // is the bound that was checked. Falling back to a locally sampled instant
+  // would store a bound strictly later than the one the guard approved (issue
+  // #413).
   if (params.clearDeleted) {
     setParts.push(
       sql`${quotedColumn(nodes.validFrom)} = ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}`,

--- a/packages/typegraph/src/backend/drizzle/operations/shared.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/shared.ts
@@ -27,6 +27,14 @@ export function sqlNull(value: string | undefined): SQL | string {
  *    fix without narrowing its validity window on re-import (e.g. via a
  *    `branch()` clone).
  *  - a string: passed through unchanged.
+ *
+ * The `timestamp` fallback is a storage convention, not an assertion the caller
+ * can be held to, so a write whose validity window is GUARDED against the
+ * resulting lower bound must supply that bound explicitly instead of relying on
+ * it: this function samples nothing, but its caller's `timestamp` comes from a
+ * later clock read than the guard's, and the difference is a window of negative
+ * width (issue #413). The node resurrection path therefore passes the instant it
+ * validated against; see `buildUpdateNode` and `performNodeUpdate`.
  */
 export function resolveValidFrom(
   validFrom: string | null | undefined,

--- a/packages/typegraph/src/backend/drizzle/operations/shared.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/shared.ts
@@ -1,10 +1,71 @@
-import { type SQL, sql } from "drizzle-orm";
+import { getTableName, type SQL, sql } from "drizzle-orm";
 
+import type { PrimaryKeyRelation } from "../../../utils/sql-errors";
 import type { SqlDialect } from "../../types";
 import type { PostgresTables } from "../schema/postgres";
 import type { SqliteTables } from "../schema/sqlite";
 
 export type Tables = SqliteTables | PostgresTables;
+
+/**
+ * The names a relation's PRIMARY KEY constraint can carry, given the relation
+ * name and its key columns.
+ *
+ * Two, because TypeGraph supports two provisioning paths for the same schema
+ * and they name the constraint differently:
+ *
+ *  - TypeGraph's own DDL (`generatePostgresCreateTableSQL`) emits an UNNAMED
+ *    `PRIMARY KEY (...)` clause, which PostgreSQL names `<relation>_pkey`;
+ *  - `drizzle-kit` renders the Drizzle `primaryKey({ columns })` builder with
+ *    its explicit name, `<relation>_<column>_..._pk`.
+ *
+ * Both are derived rather than hardcoded so a custom table name is covered
+ * too. Accepting only these two — never
+ * an arbitrary unique constraint on the relation — is what keeps a declared
+ * `unique: true` index violation out of the duplicate-identity classification.
+ */
+function primaryKeyConstraintNames(
+  relation: string,
+  keyColumns: readonly string[],
+): readonly string[] {
+  return [`${relation}_pkey`, `${relation}_${keyColumns.join("_")}_pk`];
+}
+
+/**
+ * The nodes relation's identity constraint: `(graph_id, kind, id)`, the tuple
+ * every node read also filters on.
+ */
+export function nodePrimaryKeyConstraint(
+  nodes: Tables["nodes"],
+): PrimaryKeyRelation {
+  const relation = getTableName(nodes);
+  return {
+    table: relation,
+    constraintNames: primaryKeyConstraintNames(relation, [
+      nodes.graphId.name,
+      nodes.kind.name,
+      nodes.id.name,
+    ]),
+  };
+}
+
+/**
+ * The edges relation's identity constraint: `(graph_id, id)`. An edge id is
+ * unique per graph without its kind, so the key is one column shorter than a
+ * node's.
+ */
+export function edgePrimaryKeyConstraint(
+  edges: Tables["edges"],
+): PrimaryKeyRelation {
+  const relation = getTableName(edges);
+  return {
+    table: relation,
+    constraintNames: primaryKeyConstraintNames(relation, [
+      edges.graphId.name,
+      edges.id.name,
+    ]),
+  };
+}
 
 /**
  * Converts undefined to SQL NULL for use in template literals.

--- a/packages/typegraph/src/backend/drizzle/operations/shared.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/shared.ts
@@ -23,6 +23,13 @@ export type Tables = SqliteTables | PostgresTables;
  * too. Accepting only these two — never
  * an arbitrary unique constraint on the relation — is what keeps a declared
  * `unique: true` index violation out of the duplicate-identity classification.
+ *
+ * One declared bound: PostgreSQL clips every identifier to 63 bytes, and clips
+ * the RELATION part to make room for the `_pkey` it appends, so a custom
+ * relation name long enough to overflow that (58+ bytes) is named something
+ * neither of these matches. Classification then simply does not happen and the
+ * driver failure surfaces as it did before — no misattribution, just no
+ * translation.
  */
 function primaryKeyConstraintNames(
   relation: string,

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -3,6 +3,7 @@ import { type SQL, sql } from "drizzle-orm";
 import type { FulltextStrategy } from "../../../query/dialect/fulltext-strategy";
 import { isSqlFragment } from "../../../query/sql-fragment";
 import { isPresent } from "../../../utils/presence";
+import type { PrimaryKeyRelation } from "../../../utils/sql-errors";
 import { nowIso } from "../../row-mappers";
 import type {
   CheckUniqueBatchParams,
@@ -89,7 +90,12 @@ import {
   buildInsertSchema,
   buildSetActiveSchema,
 } from "./schema";
-import { liveNodeIdsSubquery, type Tables } from "./shared";
+import {
+  edgePrimaryKeyConstraint,
+  liveNodeIdsSubquery,
+  nodePrimaryKeyConstraint,
+  type Tables,
+} from "./shared";
 import {
   buildCheckUnique,
   buildCheckUniqueBatch,
@@ -110,6 +116,20 @@ function nullableText(value: string | undefined): SQL {
 }
 
 export type CommonOperationStrategy = Readonly<{
+  /**
+   * The nodes and edges PRIMARY KEY constraints, as the engine names them — the
+   * only scope in which a driver duplicate-key failure means "this identity is
+   * already taken" rather than "these values collide with another row's".
+   *
+   * Data rather than SQL, and a member of this interface rather than a lookup at
+   * the classification site, so it is derived once from the same `tables` the
+   * insert builders render and every dialect is forced by the type checker to
+   * supply it.
+   */
+  primaryKeyConstraints: Readonly<{
+    nodes: PrimaryKeyRelation;
+    edges: PrimaryKeyRelation;
+  }>;
   buildUpsertFulltext: (
     params: UpsertFulltextParams,
     timestamp: string,
@@ -502,6 +522,10 @@ function createCommonOperationStrategy(
   return {
     ...tableOperations,
     ...fulltextBuilders,
+    primaryKeyConstraints: {
+      nodes: nodePrimaryKeyConstraint(tables.nodes),
+      edges: edgePrimaryKeyConstraint(tables.edges),
+    },
     buildUpdateNodeSet(params: UpdateNodeSetParams, timestamp: string): SQL {
       return buildUpdateNodeSet(tables, dialect, params, timestamp);
     },

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -195,15 +195,14 @@ export const INVERTED_VALIDITY_WINDOW_CODE = "INVERTED_VALIDITY_WINDOW";
 /**
  * The stable {@link ValidationIssue.code} every "this id is already taken"
  * create refusal carries, whichever way the create found out: its own existence
- * probe, or the engine refusing the INSERT because a concurrent writer took the
- * id first. `ValidationError`'s own code is the family-wide `VALIDATION_ERROR`,
- * so the discriminator lives on the issue — mirroring
- * {@link INVERTED_VALIDITY_WINDOW_CODE}.
+ * probe, or the engine refusing the INSERT. `ValidationError`'s own code is the
+ * family-wide `VALIDATION_ERROR`, so the discriminator lives on the issue —
+ * mirroring {@link INVERTED_VALIDITY_WINDOW_CODE}.
  *
  * `details.entityType` says whether a node or an edge was refused and
  * `details.kind` names its kind. `details.id` names the taken id, and is absent
- * only when a BATCH insert lost the race: the engine reports that the batch
- * collided without saying which row did.
+ * only when the refused statement inserted MORE THAN ONE row: the engine reports
+ * that the statement collided without saying which row did.
  */
 export const ENTITY_ALREADY_EXISTS_CODE = "ENTITY_ALREADY_EXISTS";
 

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -193,6 +193,21 @@ export type ValidationIssue = Readonly<{
 export const INVERTED_VALIDITY_WINDOW_CODE = "INVERTED_VALIDITY_WINDOW";
 
 /**
+ * The stable {@link ValidationIssue.code} every "this id is already taken"
+ * create refusal carries, whichever way the create found out: its own existence
+ * probe, or the engine refusing the INSERT because a concurrent writer took the
+ * id first. `ValidationError`'s own code is the family-wide `VALIDATION_ERROR`,
+ * so the discriminator lives on the issue — mirroring
+ * {@link INVERTED_VALIDITY_WINDOW_CODE}.
+ *
+ * `details.entityType` says whether a node or an edge was refused and
+ * `details.kind` names its kind. `details.id` names the taken id, and is absent
+ * only when a BATCH insert lost the race: the engine reports that the batch
+ * collided without saying which row did.
+ */
+export const ENTITY_ALREADY_EXISTS_CODE = "ENTITY_ALREADY_EXISTS";
+
+/**
  * Details for ValidationError.
  */
 export type ValidationErrorDetails = Readonly<{
@@ -1595,7 +1610,22 @@ function storageLabelFromLogicalName(logicalName: unknown): string {
 export type DatabaseOperationErrorDetails = Readonly<{
   operation: string;
   entity: string;
-  reason?: "no_row_returned";
+  /**
+   * `"duplicate_key"` means the engine refused the write because the entity's
+   * identity is already taken — the shape a concurrent create of the same new id
+   * produces on an engine that does not serialize the two writers. It is a
+   * *classified* driver failure, so callers that own a better error for the
+   * condition (the create paths, which report it as "already exists") translate
+   * it rather than surfacing it.
+   */
+  reason?: "no_row_returned" | "duplicate_key";
+  /**
+   * The entities the failed statement tried to insert, carried structurally so a
+   * translating caller never has to parse the driver's message for them. One
+   * element for a single insert; for a batch, every row in the failing chunk —
+   * the engine reports the collision without saying which row lost.
+   */
+  attempted?: readonly Readonly<{ kind: string; id: string }>[];
 }>;
 
 /**

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -365,6 +365,7 @@ export {
   EmbeddingDimensionChangedError,
   EndpointError,
   EndpointNotFoundError,
+  ENTITY_ALREADY_EXISTS_CODE,
   // Error utility functions
   getErrorSuggestion,
   GraphAlgorithmConvergenceError,

--- a/packages/typegraph/src/store/operations/already-exists.ts
+++ b/packages/typegraph/src/store/operations/already-exists.ts
@@ -16,8 +16,10 @@
  *    PostgreSQL under its default READ COMMITTED does not serialize two write
  *    transactions, so both can probe an absent row and both can then insert it,
  *    and the loser finds out from the INSERT. SQLite cannot reach this shape:
- *    `BEGIN IMMEDIATE` gives the writer slot to one transaction at a time, so the
- *    loser's probe runs after the winner committed and its verdict stands.
+ *    `BEGIN IMMEDIATE` gives the writer slot to one transaction at a time (pinned
+ *    by the business-transaction write-lock cases in
+ *    `tests/backends/sqlite/sqlite-backend.test.ts`), so the loser's probe runs
+ *    after the winner committed and its verdict stands.
  *  - An EDGE create has no existence probe at all — its id is caller-supplied or
  *    freshly generated — so the engine's refusal is the ONLY report on EVERY
  *    backend, race or no race. That is why the classification covers both

--- a/packages/typegraph/src/store/operations/already-exists.ts
+++ b/packages/typegraph/src/store/operations/already-exists.ts
@@ -1,0 +1,150 @@
+/**
+ * The create API's "this identity is already taken" refusal, and the one
+ * translation that turns a driver's duplicate-key report into it.
+ *
+ * A create learns an id is taken one of two ways: its own existence probe sees
+ * the row, or the engine refuses the INSERT. The engine's report used to escape
+ * as a `DrizzleQueryError` whose `.message` is the raw SQL text (issue #410), so
+ * one condition surfaced as a typed user error down one path and an opaque system
+ * error down the other, and a caller could not branch on it at all. Both paths
+ * now raise the SAME error, carrying {@link ENTITY_ALREADY_EXISTS_CODE} on its
+ * issue.
+ *
+ * The engine's path is reached two ways, and the second is not a race:
+ *
+ *  - A NODE create probes first, but the probe and the INSERT are two statements.
+ *    PostgreSQL under its default READ COMMITTED does not serialize two write
+ *    transactions, so both can probe an absent row and both can then insert it,
+ *    and the loser finds out from the INSERT. SQLite cannot reach this shape:
+ *    `BEGIN IMMEDIATE` gives the writer slot to one transaction at a time, so the
+ *    loser's probe runs after the winner committed and its verdict stands.
+ *  - An EDGE create has no existence probe at all — its id is caller-supplied or
+ *    freshly generated — so the engine's refusal is the ONLY report on EVERY
+ *    backend, race or no race. That is why the classification covers both
+ *    dialects and not just PostgreSQL.
+ *
+ * The backend does the classification (it owns the relation and constraint names
+ * the engine reports); this module owns the store-level judgement of what that
+ * classification means to a caller.
+ */
+import { type KindEntity } from "../../core/types";
+import {
+  DatabaseOperationError,
+  ENTITY_ALREADY_EXISTS_CODE,
+  ValidationError,
+} from "../../errors";
+
+/** An entity the refused statement tried to create. */
+type AttemptedCreate = Readonly<{ kind: string; id: string }>;
+
+/** Sentence-initial and mid-sentence names for each entity. */
+const ENTITY_LABELS = {
+  node: { title: "Node", article: "A node" },
+  edge: { title: "Edge", article: "An edge" },
+} as const satisfies Record<
+  KindEntity,
+  Readonly<{ title: string; article: string }>
+>;
+
+function alreadyExistsError(
+  entity: KindEntity,
+  kind: string,
+  id: string | undefined,
+  detail: string,
+  cause: unknown,
+): ValidationError {
+  const label = ENTITY_LABELS[entity];
+  return new ValidationError(
+    `${label.title} already exists: ${detail}`,
+    {
+      entityType: entity,
+      kind,
+      operation: "create",
+      ...(id === undefined ? {} : { id }),
+      issues: [
+        {
+          path: "id",
+          code: ENTITY_ALREADY_EXISTS_CODE,
+          message: `${label.article} with this ID already exists`,
+        },
+      ],
+    },
+    {
+      suggestion: `Use a different ID or update the existing ${entity}.`,
+      ...(cause === undefined ? {} : { cause }),
+    },
+  );
+}
+
+/**
+ * The refusal a create raises for a taken id: the probe path's error, and the
+ * target of the driver-report translation below.
+ */
+export function createAlreadyExistsError(
+  entity: KindEntity,
+  kind: string,
+  id: string,
+): ValidationError {
+  return alreadyExistsError(entity, kind, id, `${kind}/${id}`, undefined);
+}
+
+function isDuplicateKeyInsertError(
+  error: unknown,
+  entity: KindEntity,
+): error is DatabaseOperationError {
+  return (
+    error instanceof DatabaseOperationError &&
+    error.details.operation === "insert" &&
+    error.details.entity === entity &&
+    error.details.reason === "duplicate_key"
+  );
+}
+
+/**
+ * Rethrows a classified duplicate-key insert as {@link createAlreadyExistsError},
+ * and anything else untouched.
+ *
+ * A single insert names the row it lost on exactly. A batch cannot: the engine
+ * reports that the chunk collided without saying which row did, and the
+ * transaction is already aborted, so there is nothing left to probe. The refusal
+ * then names the chunk instead of inventing an attribution — same error type,
+ * same issue code, `details.id` simply absent. Every batch here comes from one
+ * collection, so the kind is always known.
+ */
+function rethrowAsAlreadyExists(error: unknown, entity: KindEntity): never {
+  if (!isDuplicateKeyInsertError(error, entity)) throw error;
+  const attempted: readonly AttemptedCreate[] = error.details.attempted ?? [];
+  const first = attempted[0];
+  if (first === undefined) throw error;
+  if (attempted.length === 1) {
+    throw alreadyExistsError(
+      entity,
+      first.kind,
+      first.id,
+      `${first.kind}/${first.id}`,
+      error,
+    );
+  }
+  throw alreadyExistsError(
+    entity,
+    first.kind,
+    undefined,
+    `one of the ${attempted.length} ${first.kind} ids written in this batch`,
+    error,
+  );
+}
+
+/**
+ * Runs an insert (or a group of inserts issued as one unit) and converts a
+ * duplicate-key refusal into the create API's already-exists error.
+ */
+export async function withAlreadyExistsTranslation<T>(
+  entity: KindEntity,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    rethrowAsAlreadyExists(error, entity);
+  }
+}

--- a/packages/typegraph/src/store/operations/already-exists.ts
+++ b/packages/typegraph/src/store/operations/already-exists.ts
@@ -106,12 +106,14 @@ function isDuplicateKeyInsertError(
  * Rethrows a classified duplicate-key insert as {@link createAlreadyExistsError},
  * and anything else untouched.
  *
- * A single insert names the row it lost on exactly. A batch cannot: the engine
- * reports that the chunk collided without saying which row did, and the
- * transaction is already aborted, so there is nothing left to probe. The refusal
- * then names the chunk instead of inventing an attribution — same error type,
- * same issue code, `details.id` simply absent. Every batch here comes from one
- * collection, so the kind is always known.
+ * A single insert names the row it lost on exactly. A multi-row one cannot: the
+ * engine reports that the statement collided without saying which row did, and
+ * the transaction is already aborted, so there is nothing left to probe. The
+ * refusal then names the statement instead of inventing an attribution — same
+ * error type, same issue code, `details.id` simply absent. The count is the
+ * refused STATEMENT's rows, which is the caller's batch only until the backend
+ * chunks it, so the message claims no more than that. Every batch here comes
+ * from one collection, so the kind is always known.
  */
 function rethrowAsAlreadyExists(error: unknown, entity: KindEntity): never {
   if (!isDuplicateKeyInsertError(error, entity)) throw error;
@@ -131,7 +133,7 @@ function rethrowAsAlreadyExists(error: unknown, entity: KindEntity): never {
     entity,
     first.kind,
     undefined,
-    `one of the ${attempted.length} ${first.kind} ids written in this batch`,
+    `one of the ${attempted.length} ${first.kind} ids in the refused insert`,
     error,
   );
 }

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -58,6 +58,7 @@ import {
   type IfExistsMode,
   type OperationHookContext,
 } from "../types";
+import { withAlreadyExistsTranslation } from "./already-exists";
 import {
   runHookedWriteOperation,
   runInWriteTransaction,
@@ -449,15 +450,18 @@ async function executeEdgeCreateInternal<G extends GraphDef>(
   return runHookedWriteOperation(ctx, opContext, backend, async (target) => {
     const prepared = await validateAndPrepareEdgeCreate(ctx, input, id, target);
 
-    let row: BackendEdgeRow | undefined;
-    if (shouldReturnRow) {
-      row = await target.insertEdge(prepared.insertParams);
-    } else {
+    // An edge create has no existence probe at all — its id is either
+    // caller-supplied or freshly generated — so the engine's refusal is the ONLY
+    // report that the id is taken. Translated here, that report is the same
+    // already-exists error a node create raises.
+    const row = await withAlreadyExistsTranslation("edge", async () => {
+      if (shouldReturnRow) return target.insertEdge(prepared.insertParams);
       await runInsertNoReturn(
         edgeInsertDispatch(target),
         prepared.insertParams,
       );
-    }
+      return;
+    });
 
     if (row === undefined) return;
     return rowToEdge(row);
@@ -603,7 +607,9 @@ export async function executeEdgeCreateNoReturnBatch<G extends GraphDef>(
       inputs,
       target,
     );
-    await runInsertBatch(edgeInsertDispatch(target), batchInsertParams);
+    await withAlreadyExistsTranslation("edge", () =>
+      runInsertBatch(edgeInsertDispatch(target), batchInsertParams),
+    );
   });
 }
 
@@ -632,9 +638,8 @@ export async function executeEdgeCreateBatch<G extends GraphDef>(
       target,
     );
 
-    const rows = await runInsertBatchReturning(
-      edgeInsertDispatch(target),
-      batchInsertParams,
+    const rows = await withAlreadyExistsTranslation("edge", () =>
+      runInsertBatchReturning(edgeInsertDispatch(target), batchInsertParams),
     );
 
     return rows.map((row) => rowToEdge(row));

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -846,26 +846,35 @@ async function performNodeUpdate<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
-  // Without an explicit validFrom the effective lower bound is the write
-  // instant the backend stamps on a resurrection (it rewrites valid_from), and
-  // the live row's stored bound otherwise.
+  // A node resurrection RESETS `valid_from` (see `buildUpdateNode`), so the
+  // effective lower bound is the write instant rather than the row's stored
+  // one. That instant is sampled HERE and then travels to the backend as an
+  // explicit `validFrom`, because the guard has to measure the bound the write
+  // will actually store: left to default, `resolveValidFrom` would stamp the
+  // backend's own, strictly later, sample, and a `validTo` at this instant
+  // would pass the guard as zero-width and land as negative width a
+  // millisecond later (issue #413). An in-place update keeps the row's stored
+  // bound, which no write rewrites and so needs no prediction.
+  const resurrectionInstant =
+    options?.clearDeleted === true && existing.deleted_at !== undefined ?
+      nowIso()
+    : undefined;
   assertWritableValidityWindow(
     `${kind} "${id}"`,
     validFrom,
-    options?.clearDeleted && existing.deleted_at !== undefined ?
-      nowIso()
-    : existing.valid_from,
+    resurrectionInstant ?? existing.valid_from,
     validTo,
   );
 
   const writeContext = createNodeWriteContext(ctx.graphId, ctx.registry, lock);
   // `validFrom` reaches the backend only through a resurrecting write (see
   // UpdateNodeParams): a live row's lower bound is history and stays put.
+  const effectiveValidFrom = validFrom ?? resurrectionInstant;
   const shared = {
     schema: nodeKind.schema,
     validatedProps,
     uniqueConstraints: registration.unique ?? [],
-    ...(validFrom !== undefined && { validFrom }),
+    ...(effectiveValidFrom !== undefined && { validFrom: effectiveValidFrom }),
     ...(validTo !== undefined && { validTo }),
   };
 

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -98,6 +98,10 @@ import {
   createUniquenessContext,
 } from "../uniqueness";
 import {
+  createAlreadyExistsError,
+  withAlreadyExistsTranslation,
+} from "./already-exists";
+import {
   applyNodeHardDelete,
   applyNodeInsertSideEffects,
   applyNodeInsertSideEffectsBatch,
@@ -204,23 +208,6 @@ function buildUniqueCacheKey(
   key: string,
 ): string {
   return `${graphId}${CACHE_KEY_SEPARATOR}${nodeKind}${CACHE_KEY_SEPARATOR}${constraintName}${CACHE_KEY_SEPARATOR}${key}`;
-}
-
-function createNodeAlreadyExistsError(
-  kind: string,
-  id: string,
-): ValidationError {
-  return new ValidationError(
-    `Node already exists: ${kind}/${id}`,
-    {
-      entityType: "node",
-      kind,
-      operation: "create",
-      id,
-      issues: [{ path: "id", message: "A node with this ID already exists" }],
-    },
-    { suggestion: `Use a different ID or update the existing node.` },
-  );
 }
 
 function buildInsertNodeParams(
@@ -631,7 +618,7 @@ async function finishNodeCreatePreparation<G extends GraphDef>(
   // before the update because the row can change while constraints are checked.
   const existingNode = await backend.getNode(ctx.graphId, kind, id);
   if (existingNode && !existingNode.deleted_at) {
-    throw createNodeAlreadyExistsError(kind, id);
+    throw createAlreadyExistsError("node", kind, id);
   }
 
   const constraintContext: ConstraintContext = {
@@ -1124,7 +1111,7 @@ async function resurrectPreparedNode<G extends GraphDef>(
     );
   }
   if (current.deleted_at === undefined) {
-    throw createNodeAlreadyExistsError(prepared.kind, prepared.id);
+    throw createAlreadyExistsError("node", prepared.kind, prepared.id);
   }
   try {
     return await applyNodeUpdate(
@@ -1155,7 +1142,7 @@ async function resurrectPreparedNode<G extends GraphDef>(
       prepared.id,
     );
     if (afterFailure !== undefined && afterFailure.deleted_at === undefined) {
-      throw createNodeAlreadyExistsError(prepared.kind, prepared.id);
+      throw createAlreadyExistsError("node", prepared.kind, prepared.id);
     }
     throw error;
   }
@@ -1286,15 +1273,18 @@ async function executeNodeCreateInternal<G extends GraphDef>(
         return shouldReturnRow ? rowToNode(resurrected) : undefined;
       }
 
-      let row: BackendNodeRow | undefined;
-      if (shouldReturnRow) {
-        row = await target.insertNode(prepared.insertParams);
-      } else {
+      // The existence probe above is not the last word: on an engine that does
+      // not serialize the two writers, a concurrent create of the same new id
+      // can commit between the probe and this INSERT, and only the engine's
+      // refusal reports it. Both routes to that conclusion raise the same error.
+      const row = await withAlreadyExistsTranslation("node", async () => {
+        if (shouldReturnRow) return target.insertNode(prepared.insertParams);
         await runInsertNoReturn(
           nodeInsertDispatch(target),
           prepared.insertParams,
         );
-      }
+        return;
+      });
 
       await finalizeNodeCreate(ctx, prepared, target, lock);
       if (identity !== undefined) {
@@ -1353,9 +1343,11 @@ export async function executeNodeCreateNoReturnBatch<G extends GraphDef>(
     const preparedCreates = await prepareBatchCreates(ctx, inputs, target);
 
     const partition = partitionCreates(preparedCreates);
-    await runInsertBatch(
-      nodeInsertDispatch(target),
-      partition.inserts.map((prepared) => prepared.insertParams),
+    await withAlreadyExistsTranslation("node", () =>
+      runInsertBatch(
+        nodeInsertDispatch(target),
+        partition.inserts.map((prepared) => prepared.insertParams),
+      ),
     );
     for (const prepared of partition.resurrections) {
       await resurrectPreparedNode(ctx, target, lock, prepared);
@@ -1395,9 +1387,11 @@ export async function executeNodeCreateBatch<G extends GraphDef>(
     );
 
     const partition = partitionCreates(preparedCreates);
-    const inserted = await runInsertBatchReturning(
-      nodeInsertDispatch(target),
-      partition.inserts.map((prepared) => prepared.insertParams),
+    const inserted = await withAlreadyExistsTranslation("node", () =>
+      runInsertBatchReturning(
+        nodeInsertDispatch(target),
+        partition.inserts.map((prepared) => prepared.insertParams),
+      ),
     );
     const resurrected: BackendNodeRow[] = [];
     for (const prepared of partition.resurrections) {

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -230,6 +230,133 @@ export function isPostgresUniqueViolationError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * The PostgreSQL error fields naming the violated constraint and its relation.
+ * Both spellings are read because the drivers disagree: node-postgres and
+ * PGlite expose the protocol fields as `constraint` / `table`, while
+ * postgres-js exposes them as `constraint_name` / `table_name`. Reading only
+ * one spelling would silently classify nothing on the other driver.
+ */
+const POSTGRES_CONSTRAINT_FIELDS = ["constraint", "constraint_name"] as const;
+const POSTGRES_RELATION_FIELDS = ["table", "table_name"] as const;
+
+/**
+ * SQLite's EXTENDED result code for a primary-key duplicate, in both spellings a
+ * driver reports it: the symbolic name (better-sqlite3 `code`, and the
+ * `SqliteError` the libSQL client nests on its own error's `.cause`) and the
+ * numeric value (libSQL `rawCode` / `extendedCode`, the only form a remote
+ * connection surfaces).
+ *
+ * The extended code — not the base `SQLITE_CONSTRAINT` — is what makes the
+ * classification possible at all: SQLite distinguishes a PRIMARY KEY duplicate
+ * (1555) from any other unique-index duplicate (`SQLITE_CONSTRAINT_UNIQUE`,
+ * 2067) in the code itself, so nothing has to read the message, which names the
+ * columns rather than the constraint.
+ */
+const SQLITE_PRIMARY_KEY_VIOLATION_CODE = "SQLITE_CONSTRAINT_PRIMARYKEY";
+const SQLITE_PRIMARY_KEY_VIOLATION_EXTENDED_CODE = 1555;
+const SQLITE_EXTENDED_CODE_FIELDS = ["rawCode", "extendedCode"] as const;
+
+/**
+ * A relation plus the names its PRIMARY KEY constraint can carry — how far a
+ * duplicate-key classification is allowed to reach on an engine that reports the
+ * violated constraint by name. See {@link isDuplicatePrimaryKeyError}.
+ */
+export type PrimaryKeyRelation = Readonly<{
+  table: string;
+  constraintNames: readonly string[];
+}>;
+
+function firstStringField(
+  link: object,
+  fields: readonly string[],
+): string | undefined {
+  for (const field of fields) {
+    const value: unknown = Reflect.get(link, field);
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
+/**
+ * Whether PostgreSQL reported this link as a duplicate of `relation`'s PRIMARY
+ * KEY: SQLSTATE, relation, and constraint name must all agree on the SAME link
+ * (the driver error), so a 23505 raised by an unrelated statement deeper in the
+ * chain cannot be attributed to this relation.
+ */
+function isPostgresPrimaryKeyViolation(
+  link: object,
+  relation: PrimaryKeyRelation,
+): boolean {
+  if (Reflect.get(link, "code") !== POSTGRES_UNIQUE_VIOLATION_CODE)
+    return false;
+  if (firstStringField(link, POSTGRES_RELATION_FIELDS) !== relation.table) {
+    return false;
+  }
+  const constraint = firstStringField(link, POSTGRES_CONSTRAINT_FIELDS);
+  return (
+    constraint !== undefined && relation.constraintNames.includes(constraint)
+  );
+}
+
+/**
+ * Whether SQLite reported this link as a PRIMARY KEY duplicate. The relation is
+ * not checked because SQLite does not report one — see
+ * {@link isDuplicatePrimaryKeyError} for why the call site supplies that scope.
+ */
+function isSqlitePrimaryKeyViolation(link: object): boolean {
+  if (Reflect.get(link, "code") === SQLITE_PRIMARY_KEY_VIOLATION_CODE) {
+    return true;
+  }
+  for (const field of SQLITE_EXTENDED_CODE_FIELDS) {
+    const value: unknown = Reflect.get(link, field);
+    if (
+      typeof value === "number" &&
+      value === SQLITE_PRIMARY_KEY_VIOLATION_EXTENDED_CODE
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether the engine refused a statement because it duplicated a PRIMARY KEY —
+ * on PostgreSQL, `relation`'s specifically.
+ *
+ * Classification is structural: SQLSTATE and SQLite extended result codes, plus
+ * the PostgreSQL protocol's own constraint and relation fields. Never message
+ * text, which is translated under a non-English `lc_messages`, is overwritten
+ * with the query string by Drizzle's wrapper, and on SQLite names the key's
+ * COLUMNS rather than the constraint. The `.cause` chain is walked because every
+ * driver here nests the real error under at least one wrapper.
+ *
+ * Narrowing to the primary key is the whole point. A `unique: true` index
+ * declaration materializes a UNIQUE INDEX on the same relation, and violating
+ * THAT is a declared-uniqueness failure about the row's VALUES, not a duplicate
+ * identity. PostgreSQL reports it under the index's own name and SQLite under a
+ * different extended code, so it never matches here and keeps surfacing as it
+ * did before.
+ *
+ * `relation` scopes the PostgreSQL arm, which is the one that can see a
+ * constraint name. SQLite reports no relation at all, so its scope comes from
+ * the CALL SITE instead: callers must invoke this only for a statement that
+ * writes exactly one relation — the node or edge insert — where a primary-key
+ * duplicate can only be that relation's. Applying it to a multi-relation
+ * statement would attribute the wrong table's collision.
+ */
+export function isDuplicatePrimaryKeyError(
+  error: unknown,
+  relation: PrimaryKeyRelation,
+): boolean {
+  for (const link of errorChain(error)) {
+    if (!canReadProperty(link)) continue;
+    if (isPostgresPrimaryKeyViolation(link, relation)) return true;
+    if (isSqlitePrimaryKeyViolation(link)) return true;
+  }
+  return false;
+}
+
 function isSqlStateIn<SqlState extends string>(
   code: unknown,
   states: readonly SqlState[],

--- a/packages/typegraph/tests/backends/integration/edge-cases.ts
+++ b/packages/typegraph/tests/backends/integration/edge-cases.ts
@@ -9,7 +9,15 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { avg, count, max, min, sum } from "../../../src";
+import {
+  avg,
+  count,
+  ENTITY_ALREADY_EXISTS_CODE,
+  max,
+  min,
+  sum,
+  ValidationError,
+} from "../../../src";
 import { requireDefined } from "../../../src/utils/presence";
 import type { IntegrationTestContext } from "./test-context";
 
@@ -328,6 +336,91 @@ function registerConcurrencyTests(context: IntegrationTestContext): void {
 }
 
 // ============================================================
+// Duplicate Identity Tests
+// ============================================================
+
+/**
+ * A create refused because the id is taken carries
+ * {@link ENTITY_ALREADY_EXISTS_CODE}, on EVERY backend and whichever layer
+ * noticed.
+ *
+ * The two cases below deliberately reach the refusal through DIFFERENT layers,
+ * and must still be indistinguishable to a caller. A node create probes for the
+ * id first, so its own probe refuses. An edge create has no probe — its id is
+ * caller-supplied or freshly generated — so the ENGINE refuses and the failure is
+ * classified back into this error.
+ *
+ * Running both on every backend is the point: the engine leg is where the two
+ * dialects could drift, since PostgreSQL and SQLite report a duplicate primary
+ * key through entirely different structures. Losing a genuine race to the engine
+ * (PostgreSQL only — SQLite serializes writers at `BEGIN IMMEDIATE`) is covered
+ * by `tests/backends/postgres/concurrent-create-duplicate-key.test.ts` (#410).
+ */
+/**
+ * Asserts a rejection is the already-exists refusal, identified by its stable
+ * issue code rather than by message text, and naming the id it lost on.
+ */
+async function expectAlreadyExists(
+  operation: Promise<unknown>,
+  expected: Readonly<{
+    entityType: "node" | "edge";
+    kind: string;
+    id: string;
+  }>,
+): Promise<void> {
+  const error = await operation.catch((error_: unknown) => error_);
+  expect(error).toBeInstanceOf(ValidationError);
+  const validation = error as ValidationError;
+  expect(validation.details.issues.map((issue) => issue.code)).toContain(
+    ENTITY_ALREADY_EXISTS_CODE,
+  );
+  expect(validation.details.entityType).toBe(expected.entityType);
+  expect(validation.details.kind).toBe(expected.kind);
+  expect(validation.details.id).toBe(expected.id);
+  expect(validation.details.operation).toBe("create");
+}
+
+function registerDuplicateIdentityTests(context: IntegrationTestContext): void {
+  describe("Duplicate Identity", () => {
+    it("refuses a node create on a taken id with the stable code", async () => {
+      const store = context.getStore();
+      const created = await store.nodes.Product.create({
+        name: "Taken",
+        price: 1,
+        category: "A",
+      });
+
+      await expectAlreadyExists(
+        store.nodes.Product.create(
+          { name: "Second", price: 2, category: "A" },
+          { id: created.id },
+        ),
+        { entityType: "node", kind: "Product", id: created.id },
+      );
+    });
+
+    it("refuses an edge create on a taken id with the stable code", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const created = await store.edges.knows.create(alice, bob, {
+        since: "first",
+      });
+
+      await expectAlreadyExists(
+        store.edges.knows.create(
+          alice,
+          bob,
+          { since: "second" },
+          { id: created.id },
+        ),
+        { entityType: "edge", kind: "knows", id: created.id },
+      );
+    });
+  });
+}
+
+// ============================================================
 // Combined Registration
 // ============================================================
 
@@ -338,4 +431,5 @@ export function registerEdgeCaseIntegrationTests(
   registerNullHandlingTests(context);
   registerBoundaryTests(context);
   registerConcurrencyTests(context);
+  registerDuplicateIdentityTests(context);
 }

--- a/packages/typegraph/tests/backends/integration/edge-cases.ts
+++ b/packages/typegraph/tests/backends/integration/edge-cases.ts
@@ -417,6 +417,37 @@ function registerDuplicateIdentityTests(context: IntegrationTestContext): void {
         { entityType: "edge", kind: "knows", id: created.id },
       );
     });
+
+    it("names the refused insert, not a row, when it wrote more than one edge", async () => {
+      // The one shape whose `details.id` is absent, and it needs no race: a bulk
+      // edge create writes several rows in ONE statement, nothing probes the
+      // caller-supplied ids, and the engine reports that the statement collided
+      // without saying which row did. Same error, same code, `id` omitted rather
+      // than guessed.
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const taken = await store.edges.knows.create(alice, bob, {
+        since: "first",
+      });
+
+      const refused = store.edges.knows.bulkCreate([
+        { from: alice, to: bob, props: { since: "fresh" }, id: "bulk-fresh" },
+        { from: alice, to: bob, props: { since: "clash" }, id: taken.id },
+      ]);
+
+      const error = await refused.catch((error_: unknown) => error_);
+      expect(error).toBeInstanceOf(ValidationError);
+      const validation = error as ValidationError;
+      expect(validation.details.issues.map((issue) => issue.code)).toContain(
+        ENTITY_ALREADY_EXISTS_CODE,
+      );
+      expect(validation.details.entityType).toBe("edge");
+      expect(validation.details.kind).toBe("knows");
+      expect(validation.details.operation).toBe("create");
+      expect(validation.details.id).toBeUndefined();
+      expect(validation.message).toContain("one of the 2 knows ids");
+    });
   });
 }
 

--- a/packages/typegraph/tests/backends/postgres/concurrent-create-duplicate-key.test.ts
+++ b/packages/typegraph/tests/backends/postgres/concurrent-create-duplicate-key.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Issue #410: a concurrent create of the same NEW id must lose with the create
+ * API's already-exists error, not with a raw driver failure.
+ *
+ * A create probes for the id and then inserts it — two statements. PostgreSQL's
+ * default READ COMMITTED does not serialize the two write transactions, so both
+ * probes can see an absent row and both can then insert it; the loser learns the
+ * truth only from the INSERT. That report used to escape as a
+ * `DrizzleQueryError` whose `.message` is the raw SQL text, so the identical
+ * condition surfaced as a typed user error when the probe caught it and as an
+ * opaque system error when the engine did.
+ *
+ * The interleaving here is forced, not raced: the losing store is held at its
+ * INSERT until the winner has committed, so the case means the same thing every
+ * run instead of depending on scheduling.
+ *
+ * SQLite cannot reach this shape. `BEGIN IMMEDIATE` hands the writer slot to one
+ * transaction at a time, so a node create cannot be between its probe and its
+ * INSERT while another commits — the probe is authoritative, and the refusal is
+ * the probe's own error. Staging the overlap there is not merely unnecessary but
+ * impossible in-process: better-sqlite3 is synchronous, so a second writer's
+ * blocked `BEGIN IMMEDIATE` blocks the event loop the holder needs to reach
+ * COMMIT, and the attempt ends in `SQLITE_BUSY: database is locked` after the
+ * full `busy_timeout` — never in a duplicate-key report.
+ *
+ * The translation itself is NOT Postgres-only, though: an edge create has no
+ * existence probe at all, so the engine's refusal is its only report of a taken
+ * id on every backend. That both backends answer with the same error is pinned by
+ * the shared `Duplicate Identity` cases in
+ * `tests/backends/integration/edge-cases.ts`; what is Postgres-only, and what
+ * this file covers, is reaching that refusal by losing a race.
+ *
+ * The scoping matters as much as the translation: SQLSTATE 23505 also reports a
+ * violated `unique: true` INDEX on the same relation, which is a
+ * declared-uniqueness failure about the row's VALUES, not a duplicate identity.
+ * The last two cases pin that both of those keep their own errors.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { GraphBackend, TransactionBackend } from "../../../src";
+import {
+  asEdgeId,
+  asNodeId,
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  ENTITY_ALREADY_EXISTS_CODE,
+  UniquenessError,
+  ValidationError,
+} from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { createGate, type Gate } from "../../concurrency-utils";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
+
+const TEST_DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+
+const Person = defineNode("Person", {
+  schema: z.object({
+    name: z.string(),
+    email: z.string().optional(),
+    tag: z.string().optional(),
+  }),
+});
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+  from: [Person],
+  to: [Person],
+});
+
+const graph = defineGraph({
+  id: "concurrent-create",
+  nodes: {
+    Person: {
+      type: Person,
+      unique: [
+        {
+          name: "byEmail",
+          fields: ["email"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+/**
+ * A props-expression UNIQUE INDEX over `tag` — a field NO declared uniqueness
+ * constraint covers, so nothing pre-checks it and the index is what refuses the
+ * second write.
+ */
+const TAG_UNIQUE_INDEX = "person_tag_unique_probe_idx";
+
+let pool: Pool | undefined;
+let db: NodePgDatabase | undefined;
+let isPostgresAvailable = false;
+
+function requirePostgres(ctx: { skip: () => void }): Readonly<{
+  pool: Pool;
+  db: NodePgDatabase;
+}> {
+  if (!isPostgresAvailable || pool === undefined || db === undefined) {
+    ctx.skip();
+    throw new Error("unreachable");
+  }
+  return { pool, db };
+}
+
+beforeAll(async () => {
+  if (!process.env["POSTGRES_URL"]) return;
+  // Four connections: the held loser transaction, the winner's, and headroom
+  // for the setup/assertion queries that run alongside them.
+  const candidate = new Pool({
+    connectionString: TEST_DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+    max: 6,
+  });
+  try {
+    await candidate.query("SELECT 1");
+    await candidate.query(generatePostgresMigrationSQL());
+    pool = candidate;
+    db = drizzle(candidate);
+    isPostgresAvailable = true;
+  } catch (error) {
+    console.error(
+      "concurrent-create-duplicate-key: Postgres setup failed; skipping suite.",
+      error,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    await candidate.end().catch(() => {});
+  }
+});
+
+afterAll(async () => {
+  if (pool !== undefined) await pool.end();
+});
+
+beforeEach(async () => {
+  if (pool === undefined) return;
+  await pool.query(`DROP INDEX IF EXISTS ${TAG_UNIQUE_INDEX}`);
+  await pool.query(
+    "TRUNCATE typegraph_node_uniques, typegraph_edges, typegraph_nodes",
+  );
+});
+
+/** Insert members whose call must be held until the winner has committed. */
+const GATED_INSERT_METHODS = new Set([
+  "insertNode",
+  "insertNodeNoReturn",
+  "insertNodesBatch",
+  "insertNodesBatchReturning",
+  "insertEdge",
+  "insertEdgeNoReturn",
+  "insertEdgesBatch",
+  "insertEdgesBatchReturning",
+]);
+
+/**
+ * A backend whose FIRST insert inside a transaction waits on `gate` before
+ * reaching the engine. Everything before it — including the create's existence
+ * probe — has already run, so opening the gate resumes a transaction that
+ * decided the id was free.
+ *
+ * Interception is on the TRANSACTION target: the write runs against the backend
+ * `runInWriteTransaction` yields, not against the outer object.
+ */
+function gatedAtFirstInsert(base: GraphBackend, gate: Gate): GraphBackend {
+  return {
+    ...base,
+    transaction: (fn, options) =>
+      base.transaction((transactionTarget) => {
+        let held = false;
+        const gatedTarget = new Proxy(transactionTarget, {
+          get(source, property, receiver) {
+            const value: unknown = Reflect.get(source, property, receiver);
+            if (
+              typeof property !== "string" ||
+              typeof value !== "function" ||
+              !GATED_INSERT_METHODS.has(property)
+            ) {
+              return value;
+            }
+            const method = value as (...args: unknown[]) => Promise<unknown>;
+            return async (...args: unknown[]) => {
+              if (!held) {
+                held = true;
+                await gate.opened;
+              }
+              return method.apply(source, args);
+            };
+          },
+        }) as TransactionBackend;
+        return fn(gatedTarget);
+      }, options),
+  } satisfies GraphBackend;
+}
+
+/**
+ * Asserts a rejection is the already-exists refusal, identified by its stable
+ * issue code rather than by message text, and reports the id it lost on.
+ */
+async function expectAlreadyExists(
+  operation: Promise<unknown>,
+  expected: Readonly<{ entityType: "node" | "edge"; kind: string; id: string }>,
+): Promise<void> {
+  const error = await operation.catch((error_: unknown) => error_);
+  expect(error).toBeInstanceOf(ValidationError);
+  const validation = error as ValidationError;
+  expect(validation.details.issues.map((issue) => issue.code)).toContain(
+    ENTITY_ALREADY_EXISTS_CODE,
+  );
+  expect(validation.details.entityType).toBe(expected.entityType);
+  expect(validation.details.kind).toBe(expected.kind);
+  expect(validation.details.id).toBe(expected.id);
+  expect(validation.details.operation).toBe("create");
+}
+
+describe.runIf(process.env["POSTGRES_URL"])(
+  "concurrent create of the same new id (PostgreSQL)",
+  () => {
+    it("reports the losing node batch as already exists, not a driver error", async (ctx) => {
+      const live = requirePostgres(ctx);
+      const gate = createGate();
+      const winner = createStore(graph, createPostgresBackend(live.db));
+      const loser = createStore(
+        graph,
+        gatedAtFirstInsert(createPostgresBackend(live.db), gate),
+      );
+
+      // The loser probes `contended`, finds nothing, and stops at its INSERT.
+      const losing = loser.nodes.Person.bulkUpsertById([
+        { id: asNodeId("contended"), props: { name: "Loser" } },
+      ]);
+      await winner.nodes.Person.bulkUpsertById([
+        { id: asNodeId("contended"), props: { name: "Winner" } },
+      ]);
+      gate.open();
+
+      await expectAlreadyExists(losing, {
+        entityType: "node",
+        kind: "Person",
+        id: "contended",
+      });
+
+      // The winner's row stands, uncorrupted by the rolled-back loser.
+      const survivor = await winner.nodes.Person.getById(asNodeId("contended"));
+      expect(survivor?.name).toBe("Winner");
+    });
+
+    it("reports the losing edge batch as already exists, not a driver error", async (ctx) => {
+      const live = requirePostgres(ctx);
+      const setup = createStore(graph, createPostgresBackend(live.db));
+      // Distinct emails: the declared `byEmail` constraint treats a shared absent
+      // value as one key, which is a different conflict than this case is about.
+      const alice = await setup.nodes.Person.create(
+        { name: "Alice", email: "alice@example.com" },
+        { id: "edge-alice" },
+      );
+      const bob = await setup.nodes.Person.create(
+        { name: "Bob", email: "bob@example.com" },
+        { id: "edge-bob" },
+      );
+
+      const gate = createGate();
+      const winner = createStore(graph, createPostgresBackend(live.db));
+      const loser = createStore(
+        graph,
+        gatedAtFirstInsert(createPostgresBackend(live.db), gate),
+      );
+
+      const losing = loser.edges.knows.bulkUpsertById([
+        {
+          id: asEdgeId("contended-edge"),
+          from: alice,
+          to: bob,
+          props: { since: "loser" },
+        },
+      ]);
+      await winner.edges.knows.bulkUpsertById([
+        {
+          id: asEdgeId("contended-edge"),
+          from: alice,
+          to: bob,
+          props: { since: "winner" },
+        },
+      ]);
+      gate.open();
+
+      await expectAlreadyExists(losing, {
+        entityType: "edge",
+        kind: "knows",
+        id: "contended-edge",
+      });
+
+      const survivor = await winner.edges.knows.getById(
+        asEdgeId("contended-edge"),
+      );
+      expect((survivor as { since?: string } | undefined)?.since).toBe(
+        "winner",
+      );
+    });
+
+    it("reports a losing single node create as already exists too", async (ctx) => {
+      // Same seam, non-batch path: `create` inserts one row rather than a chunk.
+      const live = requirePostgres(ctx);
+      const gate = createGate();
+      const winner = createStore(graph, createPostgresBackend(live.db));
+      const loser = createStore(
+        graph,
+        gatedAtFirstInsert(createPostgresBackend(live.db), gate),
+      );
+
+      const losing = loser.nodes.Person.create(
+        { name: "Loser" },
+        { id: "contended-single" },
+      );
+      await winner.nodes.Person.create(
+        { name: "Winner" },
+        { id: "contended-single" },
+      );
+      gate.open();
+
+      await expectAlreadyExists(losing, {
+        entityType: "node",
+        kind: "Person",
+        id: "contended-single",
+      });
+    });
+
+    it("still reports a DECLARED uniqueness conflict as UniquenessError", async (ctx) => {
+      // Two DIFFERENT ids claiming one unique key: no primary-key collision at
+      // all. The conflict surfaces from the uniqueness relation, and must not be
+      // reshaped into a duplicate-identity error by the new translation.
+      const live = requirePostgres(ctx);
+      const gate = createGate();
+      const winner = createStore(graph, createPostgresBackend(live.db));
+      const loser = createStore(
+        graph,
+        gatedAtFirstInsert(createPostgresBackend(live.db), gate),
+      );
+
+      const losing = loser.nodes.Person.create(
+        { name: "Loser", email: "shared@example.com" },
+        { id: "unique-loser" },
+      );
+      await winner.nodes.Person.create(
+        { name: "Winner", email: "shared@example.com" },
+        { id: "unique-winner" },
+      );
+      gate.open();
+
+      await expect(losing).rejects.toThrow(UniquenessError);
+      const error = await losing.catch((error_: unknown) => error_);
+      expect((error as UniquenessError).details.constraintName).toBe("byEmail");
+    });
+
+    it("does not translate a violated unique INDEX into already exists", async (ctx) => {
+      // A `unique: true` index declaration materializes a UNIQUE INDEX on the
+      // nodes relation, so violating it raises the SAME SQLSTATE (23505) on the
+      // SAME table as a duplicate id. It carries the index's own name rather
+      // than the relation's primary key, which is exactly why the classification
+      // is scoped to the primary key: this must keep surfacing as the driver
+      // failure it was, never as "this id already exists".
+      const live = requirePostgres(ctx);
+      await live.pool.query(
+        `CREATE UNIQUE INDEX ${TAG_UNIQUE_INDEX}
+           ON typegraph_nodes ((props->>'tag'))
+           WHERE kind = 'Person'`,
+      );
+      const store = createStore(graph, createPostgresBackend(live.db));
+
+      await store.nodes.Person.create(
+        { name: "First", tag: "shared-tag" },
+        { id: asNodeId("index-first") },
+      );
+      const refused = store.nodes.Person.create(
+        { name: "Second", tag: "shared-tag" },
+        { id: asNodeId("index-second") },
+      );
+
+      const error = await refused.catch((error_: unknown) => error_);
+      expect(error).toBeInstanceOf(Error);
+      const alreadyExists =
+        error instanceof ValidationError &&
+        error.details.issues.some(
+          (issue) => issue.code === ENTITY_ALREADY_EXISTS_CODE,
+        );
+      expect(alreadyExists).toBe(false);
+    });
+  },
+);

--- a/packages/typegraph/tests/backends/postgres/concurrent-create-duplicate-key.test.ts
+++ b/packages/typegraph/tests/backends/postgres/concurrent-create-duplicate-key.test.ts
@@ -17,11 +17,16 @@
  * SQLite cannot reach this shape. `BEGIN IMMEDIATE` hands the writer slot to one
  * transaction at a time, so a node create cannot be between its probe and its
  * INSERT while another commits — the probe is authoritative, and the refusal is
- * the probe's own error. Staging the overlap there is not merely unnecessary but
- * impossible in-process: better-sqlite3 is synchronous, so a second writer's
- * blocked `BEGIN IMMEDIATE` blocks the event loop the holder needs to reach
- * COMMIT, and the attempt ends in `SQLITE_BUSY: database is locked` after the
- * full `busy_timeout` — never in a duplicate-key report.
+ * the probe's own error. That serialization is already pinned, by the
+ * `SQLite Backend - business transaction write lock` cases in
+ * `tests/backends/sqlite/sqlite-backend.test.ts`: a second connection cannot take
+ * the write lock while a business transaction holds it.
+ *
+ * Staging the overlap there is therefore not merely unnecessary but impossible
+ * in-process: better-sqlite3 is synchronous, so a second writer's blocked
+ * `BEGIN IMMEDIATE` blocks the event loop the holder needs to reach COMMIT, and
+ * the attempt ends in `SQLITE_BUSY: database is locked` once the 5s default
+ * `busyTimeoutMs` elapses — never in a duplicate-key report.
  *
  * The translation itself is NOT Postgres-only, though: an edge create has no
  * existence probe at all, so the engine's refusal is its only report of a taken

--- a/packages/typegraph/tests/inverted-validity-window.test.ts
+++ b/packages/typegraph/tests/inverted-validity-window.test.ts
@@ -16,7 +16,10 @@
  *      caller assertion, and the row is read back through `includeEnded`;
  *   5. resurrecting an edge into the ended state stays legal, but the end it
  *      names is held to the bound the row RETAINS across resurrection;
- *   6. import refuses an inverted document per row, carrying the stable code.
+ *   6. import refuses an inverted document per row, carrying the stable code;
+ *   7. a node resurrection — which RESETS `valid_from` and so has no stored
+ *      bound to measure against — stores the very instant its guard measured
+ *      against, instead of a later one the guard never saw.
  *
  * Trusted import carries the same refusal through its own typed stream error;
  * those cases live with the rest of its stream-shape suite in
@@ -25,7 +28,7 @@
  * Every refusal carries {@link INVERTED_VALIDITY_WINDOW_CODE} on its issue, so
  * callers branch on the code rather than on prose.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import type { GraphBackend } from "../src";
@@ -695,6 +698,150 @@ describe("inverted valid-time windows", () => {
         expect(result.success).toBe(true);
         expect(result.nodes.created).toBe(2);
       }
+    });
+  });
+
+  describe("a node resurrection stores the bound it was measured against", () => {
+    /**
+     * A node resurrection REWRITES `valid_from`, so its guard has no stored bound
+     * to measure against and uses the write instant instead. The operations layer
+     * and the backend read the same clock at two different moments, so the bound
+     * the guard approved was not the bound the write stored: a `validTo` at the
+     * guard's instant passed as zero-width and landed as NEGATIVE width once the
+     * backend's later sample became `valid_from` (issue #413).
+     *
+     * The fix makes the guard's instant the stored one by passing it to the
+     * backend explicitly. These cases step the clock at the operations/backend
+     * boundary — the real ordering, made deterministic — so the gap is one
+     * millisecond every run instead of whatever the machine happened to produce.
+     */
+    const GUARD_INSTANT = "2031-01-01T00:00:00.000Z";
+    const BACKEND_INSTANT = "2031-01-01T00:00:00.001Z";
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /**
+     * A backend whose resurrecting node UPDATE observes a clock one millisecond
+     * ahead of the one the operations layer sampled. Interception has to happen
+     * on the TRANSACTION target: the write runs against the backend
+     * `runInWriteTransaction` yields, not against the outer object.
+     */
+    function clockSteppingBackend(): GraphBackend {
+      const base = createTestBackend();
+      return {
+        ...base,
+        transaction: (fn, options) =>
+          base.transaction((transactionTarget) => {
+            const steppingTarget = new Proxy(transactionTarget, {
+              get(source, property, receiver) {
+                const value: unknown = Reflect.get(source, property, receiver);
+                if (property !== "updateNode" || typeof value !== "function") {
+                  return value;
+                }
+                const updateNode = value as (
+                  params: Parameters<GraphBackend["updateNode"]>[0],
+                ) => ReturnType<GraphBackend["updateNode"]>;
+                return async (
+                  params: Parameters<GraphBackend["updateNode"]>[0],
+                ) => {
+                  if (params.clearDeleted === true) {
+                    vi.setSystemTime(new Date(BACKEND_INSTANT));
+                  }
+                  return updateNode.call(source, params);
+                };
+              },
+            });
+            return fn(steppingTarget);
+          }, options),
+      } satisfies GraphBackend;
+    }
+
+    it("stores zero width when a resurrecting upsertById ends at the guard's own instant", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(GUARD_INSTANT));
+      const stepping = clockSteppingBackend();
+      const store = createStore(graph, stepping);
+
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "resurrect-now" },
+      );
+      await store.nodes.Person.delete(person.id);
+
+      // `validTo` at the instant the guard samples: zero width, so the guard
+      // admits it. Pre-fix the backend then stamped BACKEND_INSTANT as
+      // `valid_from` and the committed row was one millisecond wide backwards.
+      const revived = await store.nodes.Person.upsertById(
+        person.id,
+        { name: "Alice" },
+        { validTo: GUARD_INSTANT },
+      );
+
+      expect(revived.meta.validFrom).toBe(GUARD_INSTANT);
+      expect(revived.meta.validTo).toBe(GUARD_INSTANT);
+
+      const raw = requireDefined(
+        await stepping.getNode(graph.id, "Person", person.id),
+      );
+      expect(raw.deleted_at).toBeUndefined();
+      expect(
+        requireDefined(raw.valid_from) <= requireDefined(raw.valid_to),
+      ).toBe(true);
+      expect(raw.valid_from).toBe(GUARD_INSTANT);
+      expect(raw.valid_to).toBe(GUARD_INSTANT);
+    });
+
+    it("stores zero width when a resurrecting bulkUpsertById ends at the guard's own instant", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(GUARD_INSTANT));
+      const stepping = clockSteppingBackend();
+      const store = createStore(graph, stepping);
+
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "resurrect-now-bulk" },
+      );
+      await store.nodes.Person.delete(person.id);
+
+      await store.nodes.Person.bulkUpsertById([
+        { id: person.id, props: { name: "Alice" }, validTo: GUARD_INSTANT },
+      ]);
+
+      const raw = requireDefined(
+        await stepping.getNode(graph.id, "Person", person.id),
+      );
+      expect(
+        requireDefined(raw.valid_from) <= requireDefined(raw.valid_to),
+      ).toBe(true);
+      expect(raw.valid_from).toBe(GUARD_INSTANT);
+      expect(raw.valid_to).toBe(GUARD_INSTANT);
+    });
+
+    it("leaves an explicitly stated resurrection window untouched", async () => {
+      // The stated-pair path is unaffected: an explicit validFrom still wins
+      // over the sampled instant, so restating the whole historical window
+      // behaves exactly as before.
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(GUARD_INSTANT));
+      const stepping = clockSteppingBackend();
+      const store = createStore(graph, stepping);
+
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "resurrect-stated" },
+      );
+      await store.nodes.Person.delete(person.id);
+
+      const revived = await store.nodes.Person.upsertById(
+        person.id,
+        { name: "Alice" },
+        { validFrom: EARLIER, validTo: START },
+      );
+
+      expect(revived.meta.validFrom).toBe(EARLIER);
+      expect(revived.meta.validTo).toBe(START);
     });
   });
 });

--- a/packages/typegraph/tests/sql-errors.test.ts
+++ b/packages/typegraph/tests/sql-errors.test.ts
@@ -16,6 +16,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  edgePrimaryKeyConstraint,
+  nodePrimaryKeyConstraint,
+} from "../src/backend/drizzle/operations/shared";
+import { tables as sqliteTables } from "../src/backend/drizzle/sqlite";
+import {
+  isDuplicatePrimaryKeyError,
   isMissingTableError,
   isPostgresUniqueViolationError,
   isSqliteNotAuthorizedError,
@@ -321,5 +327,190 @@ describe("isSqliteNotAuthorizedError", () => {
         new Error("request not authorized by application policy"),
       ),
     ).toBe(false);
+  });
+});
+
+/**
+ * `isDuplicatePrimaryKeyError` decides whether a create lost its id or merely
+ * collided on a value (issue #410), so it has to be right about two things at
+ * once: every driver's way of REPORTING a duplicate key, and the difference
+ * between the relation's PRIMARY KEY and any other unique index on it.
+ *
+ * These cases carry the driver shapes end-to-end tests cannot reach from this
+ * suite — postgres-js's `*_name` field spellings, and a remote libSQL connection
+ * that surfaces only the numeric extended result code with no nested
+ * `SqliteError` to read a symbolic one from.
+ */
+/** Mirrors a node-postgres / PGlite `DatabaseError` for a 23505. */
+function pgDuplicate(
+  constraint: string,
+  table: string,
+): Error & Readonly<{ code: string }> {
+  return Object.assign(
+    new Error(`duplicate key value violates unique constraint "${constraint}"`),
+    { code: "23505", constraint, table, schema: "public" },
+  );
+}
+
+/** Mirrors a postgres-js `PostgresError`: a plain object, `*_name` fields. */
+function postgresJsDuplicate(
+  constraint: string,
+  table: string,
+): Readonly<Record<string, string>> {
+  return {
+    code: "23505",
+    message: `duplicate key value violates unique constraint "${constraint}"`,
+    constraint_name: constraint,
+    table_name: table,
+    schema_name: "public",
+  };
+}
+
+describe("isDuplicatePrimaryKeyError", () => {
+  const nodes = nodePrimaryKeyConstraint(sqliteTables.nodes);
+  const edges = edgePrimaryKeyConstraint(sqliteTables.edges);
+
+  it("derives both constraint names a PRIMARY KEY can carry", () => {
+    // TypeGraph's own DDL emits an unnamed `PRIMARY KEY (...)`, which the server
+    // names `<relation>_pkey`; drizzle-kit renders the Drizzle builder's own
+    // `<relation>_<column>_..._pk`. Provisioning either way must classify.
+    expect(nodes.table).toBe("typegraph_nodes");
+    expect([...nodes.constraintNames]).toEqual([
+      "typegraph_nodes_pkey",
+      "typegraph_nodes_graph_id_kind_id_pk",
+    ]);
+    expect([...edges.constraintNames]).toEqual([
+      "typegraph_edges_pkey",
+      "typegraph_edges_graph_id_id_pk",
+    ]);
+  });
+
+  it("detects a Postgres primary-key duplicate through the Drizzle wrapper", () => {
+    for (const name of nodes.constraintNames) {
+      expect(
+        isDuplicatePrimaryKeyError(
+          drizzleQueryError(
+            "INSERT INTO typegraph_nodes ...",
+            pgDuplicate(name, "typegraph_nodes"),
+          ),
+          nodes,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("detects a postgres-js shaped duplicate reached through a plain-object cause", () => {
+    expect(
+      isDuplicatePrimaryKeyError(
+        drizzleQueryError(
+          "INSERT INTO typegraph_edges ...",
+          postgresJsDuplicate("typegraph_edges_pkey", "typegraph_edges"),
+        ),
+        edges,
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT classify a violated unique INDEX on the same relation", () => {
+    // Declared uniqueness: same SQLSTATE, same table, the user's index name.
+    // Reshaping this into "already exists" would report a value collision as an
+    // identity collision.
+    expect(
+      isDuplicatePrimaryKeyError(
+        drizzleQueryError(
+          "INSERT INTO typegraph_nodes ...",
+          pgDuplicate("person_email_unique_idx", "typegraph_nodes"),
+        ),
+        nodes,
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT classify a primary-key duplicate on a DIFFERENT relation", () => {
+    expect(
+      isDuplicatePrimaryKeyError(
+        pgDuplicate("typegraph_node_uniques_pkey", "typegraph_node_uniques"),
+        nodes,
+      ),
+    ).toBe(false);
+    // The edges primary key is not the nodes primary key, and vice versa.
+    const edgeDuplicate = pgDuplicate(
+      "typegraph_edges_pkey",
+      "typegraph_edges",
+    );
+    expect(isDuplicatePrimaryKeyError(edgeDuplicate, nodes)).toBe(false);
+    expect(isDuplicatePrimaryKeyError(edgeDuplicate, edges)).toBe(true);
+  });
+
+  it("detects SQLite's primary-key extended code, symbolic and numeric", () => {
+    // better-sqlite3 (and the SqliteError libSQL nests): symbolic `code`.
+    expect(
+      isDuplicatePrimaryKeyError(
+        drizzleQueryError(
+          "INSERT INTO typegraph_nodes ...",
+          Object.assign(
+            new Error("UNIQUE constraint failed: typegraph_nodes.graph_id"),
+            { code: "SQLITE_CONSTRAINT_PRIMARYKEY", rawCode: 1555 },
+          ),
+        ),
+        nodes,
+      ),
+    ).toBe(true);
+
+    // A remote libSQL connection surfaces only the generic symbolic code plus
+    // the numeric extended one, with no nested SqliteError to read.
+    expect(
+      isDuplicatePrimaryKeyError(
+        drizzleQueryError(
+          "INSERT INTO typegraph_edges ...",
+          Object.assign(
+            new Error("SQLITE_CONSTRAINT: UNIQUE constraint failed"),
+            { code: "SQLITE_CONSTRAINT", rawCode: 1555, extendedCode: 1555 },
+          ),
+        ),
+        edges,
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT classify SQLite's non-primary-key unique violation", () => {
+    // 2067 is SQLITE_CONSTRAINT_UNIQUE: a unique index, not the primary key.
+    expect(
+      isDuplicatePrimaryKeyError(
+        Object.assign(
+          new Error("UNIQUE constraint failed: typegraph_nodes.x"),
+          {
+            code: "SQLITE_CONSTRAINT_UNIQUE",
+            rawCode: 2067,
+          },
+        ),
+        nodes,
+      ),
+    ).toBe(false);
+    expect(
+      isDuplicatePrimaryKeyError(
+        Object.assign(
+          new Error("SQLITE_CONSTRAINT: UNIQUE constraint failed"),
+          {
+            code: "SQLITE_CONSTRAINT",
+            rawCode: 2067,
+          },
+        ),
+        nodes,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not classify unrelated failures", () => {
+    expect(
+      isDuplicatePrimaryKeyError(
+        pgError('relation "typegraph_nodes" does not exist', "42P01"),
+        nodes,
+      ),
+    ).toBe(false);
+    expect(
+      isDuplicatePrimaryKeyError(new Error("connection reset"), nodes),
+    ).toBe(false);
+    expect(isDuplicatePrimaryKeyError(undefined, nodes)).toBe(false);
   });
 });


### PR DESCRIPTION
Two failures at the operations/backend boundary, both pre-release for 0.46.0. A
create the engine refuses now reports the condition it actually hit, and the last
UPDATE path that could store an inverted valid-time window no longer can.

## #410 — a duplicate identity is refused as "already exists", not as a driver error

A create learns its id is taken either from its own existence probe or from the
engine refusing the INSERT. The second used to escape as a `DrizzleQueryError`
whose `.message` is the raw INSERT text, so one condition surfaced as a typed user
error down one path and an opaque system error down the other, and a caller could
not branch on it at all.

Two things reach the engine's path, and only the first is a race:

- A **node** create probes first, but the probe and the INSERT are two
  statements. PostgreSQL's default READ COMMITTED does not serialize the two write
  transactions, so both can probe an absent row and both can then insert it — the
  issue's reproduction, two concurrent single-item batches on one new id.
- An **edge** create has no existence probe at all (its id is caller-supplied or
  freshly generated), so the engine's refusal is its only report of a taken id, on
  every backend and with no race involved. Investigating #410 surfaced this as a
  live cross-backend divergence in its own right: `edges.knows.create(..., { id:
  takenId })` raised a raw `SqliteError` on SQLite and a raw `DrizzleQueryError` on
  PostgreSQL. Both now raise the same typed error, which is why the fix covers both
  dialects rather than only PostgreSQL.

### The classification

Structural, following the `isMissingTableError` precedent — a `.cause`-chain walk
over the drivers' own fields, with no message matching anywhere. Message text is
translated under a non-English `lc_messages`, is overwritten with the query string
by Drizzle's wrapper, and on SQLite names the key's *columns* rather than the
constraint.

`isDuplicatePrimaryKeyError(error, relation)` in `src/utils/sql-errors.ts` requires
**one link** of the chain to satisfy every part of its dialect's test, so a
duplicate-key report from an unrelated statement deeper in the chain cannot be
attributed here:

- **PostgreSQL** — SQLSTATE `23505`, plus the protocol's relation and constraint
  fields, read in both driver spellings: node-postgres and PGlite expose
  `constraint` / `table`, postgres-js exposes `constraint_name` / `table_name`.
  Reading one spelling would silently classify nothing on the other driver.
- **SQLite** — the *extended* result code, which distinguishes a primary-key
  duplicate (`SQLITE_CONSTRAINT_PRIMARYKEY` / 1555) from any other unique-index
  duplicate (`SQLITE_CONSTRAINT_UNIQUE` / 2067) in the code itself. Both spellings
  are accepted: the symbolic name (better-sqlite3, and the `SqliteError` the libSQL
  client nests on its own error's `.cause`) and the numeric value (libSQL
  `rawCode` / `extendedCode`, the only form a remote connection surfaces).

**Scoping to the primary key** is the whole point, and the two dialects scope it
differently. PostgreSQL names the violated constraint, so the accepted names are
derived from the Drizzle table — `<relation>_pkey` for TypeGraph's own unnamed
`PRIMARY KEY (...)` DDL, and `<relation>_<column>_..._pk` for a schema provisioned
by drizzle-kit — rather than hardcoded, so a custom table name is covered too
(verified end to end on both dialects against `app_nodes` / `app_edges`, which
PostgreSQL names `app_nodes_pkey` / `app_edges_pkey`). One bound is declared rather
than hidden: PostgreSQL clips every identifier to 63 bytes, and clips the RELATION
part to make room for the `_pkey` it appends, so a custom relation name of 58+
bytes carries a name neither derivation matches — classification then simply does
not happen and the driver failure surfaces as it did before, with no
misattribution. SQLite reports no relation at all, so its scope comes from the **call site**: the
helper is invoked only for a statement that writes exactly one relation. A
`unique: true` index declaration on the same relation therefore never matches on
either dialect, and neither does a declared `unique` constraint conflict, which
still raises `UniquenessError`.

### Layering

The backend classifies, because it owns the relation and constraint names the
engine reports; the store judges what that classification means to a caller.

- `src/utils/sql-errors.ts` — the structural predicate, alongside the existing
  `isMissingTableError` / `isPostgresUniqueViolationError` family.
- `src/backend/drizzle/operations/shared.ts` — derives each relation's primary-key
  constraint names from its Drizzle table.
- `CommonOperationStrategy.primaryKeyConstraints` — the derivation as an interface
  member rather than a lookup at the classification site, so it is computed once
  from the same `tables` the insert builders render and every dialect is forced by
  the type checker to supply it.
- `operation-backend-core.ts` — all eight insert members convert a classified
  refusal into `DatabaseOperationError` with `reason: "duplicate_key"` and the
  `attempted` rows. This is the single implementation every backend (SQLite,
  PostgreSQL, PGlite, libSQL) is built from.
- `src/store/operations/already-exists.ts` — the typed refusal and the translation
  into it. Both node and edge operations route their single and batch inserts
  through it.

### The error surface

Every already-exists refusal, from either route, now carries the new exported issue
code `ENTITY_ALREADY_EXISTS`. `details.entityType` and `details.kind` say what was
refused. `details.id` names the taken id and is present for every single-entity
create; it is absent only when the refused **statement inserted more than one
row**, because the engine reports that the statement collided without saying which
row did and the transaction is already aborted, so there is nothing left to probe.
Rather than invent an attribution, the refusal names the statement — same error
type, same issue code, `details.id` simply absent.

No race is needed to reach that, which is the same oversight this PR corrects for
the single edge create: a bulk create of edges supplies its own ids and nothing
probes them, so the engine refuses the multi-row statement on every backend. The
count it names is the refused statement's rows, which is the caller's batch only
until the backend chunks it, so the message claims no more than that. Documented in
`errors.md` and in the changeset, and pinned in the shared cross-backend suite.

### SQLite verdict

The **node** race does not exist on SQLite: `BEGIN IMMEDIATE` gives the writer slot
to one transaction at a time, so a second create cannot sit between its probe and
its INSERT while the first commits. Its probe is authoritative and its refusal was
already the typed error (it now carries the code too). That serialization is not
taken on faith — the repo already pins it, in the `SQLite Backend - business
transaction write lock` cases, which hold a TypeGraph transaction open and show a
second connection cannot take the write lock. Both new sites cite it.

Measured while checking this: two genuinely concurrent creates of one new id
through two connections to one file database do not interleave at all —
better-sqlite3 is synchronous, so the second writer's blocked `BEGIN IMMEDIATE`
blocks the event loop the holder needs to reach COMMIT, and the attempt ends in
`SQLITE_BUSY: database is locked` once the 5s default `busyTimeoutMs` elapses,
never in a duplicate-key report.

So there is no staged-overlap test on SQLite: the shape is unreachable in-process,
a second copy of it would only re-pin a driver property the existing cases already
cover, and the thing that actually holds if the premise ever changes is the
classifier's SQLite arm — which every backend exercises through the probe-less edge
create path.

## #413 — a node resurrection stores the bound its guard measured against

A resurrection rewrites `valid_from` rather than retaining it, so the guard has no
stored bound to check and used the write instant instead — sampled in the
operations layer, while the backend went on to stamp its own, strictly later,
sample via `resolveValidFrom(params.validFrom, timestamp)`. A `validTo` at the
guard's instant passed as zero-width and committed as **negative** width a
millisecond later: the exact shape #406 exists to refuse.

**Chose option (a): the operations layer passes an explicit `validFrom` on
resurrection.** It samples the instant once, measures the window against it, and
sends it to the backend, so the bound that is checked is the bound that is stored.

**Rejected option (b), clamping at the backend** (`valid_from = min(timestamp,
validTo)`, mirroring identity's `clampValidTo`). It prevents the bad *outcome*
without making the guard *honest*: the value the guard approves would still not be
the value the write stores, so the next writer to reason about that bound inherits
the same trap. It also only covers the lone-`validTo` shape, and the bound it
would store — `validTo`, an instant *earlier* than the write — is a larger semantic
departure than (a)'s sub-millisecond one. (a) keeps one sample of one clock as the
single source of truth for the whole operation.

The cost of (a) is stated plainly at both sites: a resurrection's stored
`valid_from` is the operations layer's instant rather than the backend's — sampled
a moment earlier inside the same locked write, before the uniqueness entries that
write re-checks and re-inserts. It is therefore at or before the row's `created_at`
/ `updated_at` and never after, and no consumer compares the two.
`identity.md`'s "`validFrom` becomes the resurrection instant" becomes more
literally true rather than less, so it needed no edit. The ruling is documented at
`performNodeUpdate`, at `buildUpdateNode`'s `clearDeleted` branch, and on
`resolveValidFrom` itself.

**The claim is scoped to UPDATE paths.** A create carrying a lone historical
`validTo` still stores `valid_from` after it — on a fresh id and on a tombstone
alike, since a create-on-tombstone resets the whole window and is guarded by the
insert-side ordering check only. That is the deliberate "born already ended"
convention #406 pinned, not a remaining hole.

**Edge resurrection has no analogous race:** `buildUpdateEdge` rewrites
`valid_from` only when the write explicitly names one (`params.clearDeleted &&
params.validFrom !== undefined`), so the edge guard measures against the retained
stored bound — a value already on disk — and predicts nothing.

## Tests (revert-verified)

`tests/backends/postgres/concurrent-create-duplicate-key.test.ts` — the
two-connection race on real PostgreSQL, forced rather than raced: the losing store
is held at its INSERT by a transaction-target proxy until the winner has committed,
so the interleaving is identical every run. Node batch, edge batch, and single node
create assert the typed error with its code, entity type, kind and id. **All three
fail on the parent commit** with `Error: Failed query: …`. Two regression pins in
the same file — a declared `unique` constraint conflict still raising
`UniquenessError`, and a violated `unique: true` index *not* being translated —
pass before and after, which is what makes them pins.

`tests/backends/integration/edge-cases.ts` — a `Duplicate Identity` block in the
shared cross-backend suite, so it runs on every backend. The node case is refused
by the probe and the edge case by the engine, and the two must be indistinguishable
to a caller; the engine leg is where the dialects could drift. A third case pins
the one shape whose `details.id` is absent — a bulk edge create writing several rows
in one statement — which needs no race and so belongs here rather than in the
PostgreSQL file. **Both edge cases fail on the parent commit** (raw `SqliteError` on
both SQLite drivers, raw `DrizzleQueryError` on PostgreSQL).

`tests/sql-errors.test.ts` — driver shapes this suite cannot reach end to end:
postgres-js's `*_name` spellings on a plain-object cause, and a remote libSQL error
carrying only the numeric extended code. Plus a pin on the two derived primary-key
constraint names, and negative cases for a unique index on the same relation, a
primary key on a different relation, and SQLite's 2067.

`tests/inverted-validity-window.test.ts` — a #413 block that steps the clock at the
operations/backend boundary (fake timers plus a proxy that advances the system time
by 1ms when it sees the resurrecting `updateNode`), so the gap is exactly one
millisecond every run rather than whatever the machine produced. It asserts the
committed row directly: `valid_from <= valid_to`, both equal to the guard's
instant. **Both new cases fail on the parent commit**, the bulk one showing the
stored row with `valid_from` after `valid_to`. A third case pins that an explicitly
stated resurrection window is unaffected.

## Gates

`tsc --noEmit` clean · full SQLite `vitest run` green (291 files / 6493 tests) ·
`tests/backends/postgres` plus the window and sql-error files green on a scratch
database with `--no-file-parallelism` (37 files / 2281 tests) · `knip` clean ·
`pnpm fix` exit 0 · `api-report:update` committed — the `reason` union widened,
`attempted` added, `ENTITY_ALREADY_EXISTS_CODE` exported.

Closes #410
Closes #413

