### PR TITLE
fix: ask props bags for own keys, not inherited ones

### DIFF
--- a/.changeset/own-key-props-membership.md
+++ b/.changeset/own-key-props-membership.md
@@ -1,0 +1,52 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Ask props bags whether they carry a key with `Object.hasOwn` rather than `in`.
+
+A props bag is data: its keys come from a JSON column, so a schema may declare a
+field named after an `Object.prototype` member — `toString`, `constructor`,
+`valueOf` — and such a field is ordinary data that survives Zod validation and
+the JSON round-trip untouched. `in` cannot answer "does this row carry this
+property" for such a bag, because `"toString" in {}` is `true`: a row that does
+not carry the key reads as though it does, and the read that follows yields the
+inherited prototype member instead of stored data.
+
+This is a lost-write fix, not only hardening. In a graph merge, a fork's bag is
+its full intended state, so a base property absent from it was deleted by that
+fork. Under `in` that deletion was never detected for a prototype-named field:
+no deletion tombstone was written and the base value survived the merge, silently
+discarding the fork's write. The same misclassification credited a branch that
+does not carry such a property with the inherited prototype member as if it were
+a stored value, letting an invented claim compete in conflict resolution and be
+reported to the caller as that branch's value. A schema diff also reported a
+removed prototype-named property as an incompatible schema change rather than a
+removal, because the absent field resolved to a function that was then compared
+as though it were the field's new schema.
+
+The edge fold was affected in the same way, and worse: a member that says NOTHING
+about a prototype-named field counted as having AUTHORED a value it never wrote,
+so an inherited function entered the property union as a first-class claim and
+displaced the surviving row's real value.
+
+Two guards were quietly weakened rather than corrupted. Graph-extension validation
+accepted a unique constraint on an undeclared field named after a prototype
+member — it answered "declared" against the prototype — and went on to index a
+field that does not exist. The evolve guard that refuses re-adding a kind whose
+data cleanup is still pending never counted such a kind as added, so it skipped
+the refusal.
+
+The convention now has one owner, `hasOwnKey`, applied across graph-merge node and
+edge property resolution, schema-diff property classification, schema-removal
+reconciliation, interchange unknown-property stripping, graph-extension document
+validation, and the evolve pending-removal guard. `in` remains correct, and still
+in use, where the key set is statically known: a discriminated union's tag, a
+capability probe, a brand check, and the deliberate `Object.prototype` lookup in
+selective projection.
+
+`__proto__`, the case originally reported, is the NARROW variant and is already
+blocked several times over — Zod drops an own `__proto__` key, `branch()` clones
+through the validating interchange import, the base@V fingerprint refuses a base
+mutated after the fork, and `bag["__proto__"] = value` assigns a prototype rather
+than creating a key, so assignment-built result bags cannot carry one either.
+Recorded here so it is not "fixed" again as though it were the reachable case.

--- a/.changeset/own-key-props-membership.md
+++ b/.changeset/own-key-props-membership.md
@@ -24,10 +24,17 @@ removed prototype-named property as an incompatible schema change rather than a
 removal, because the absent field resolved to a function that was then compared
 as though it were the field's new schema.
 
-The edge fold was affected in the same way, and worse: a member that says NOTHING
-about a prototype-named field counted as having AUTHORED a value it never wrote,
-so an inherited function entered the property union as a first-class claim and
-displaced the surviving row's real value.
+The edge fold and the node cluster union were affected in the same way, and their
+worst outcome was a committed function. For a property the SURVIVING row does not
+carry, both ask that row's bag for the value to keep, so under `in` they took the
+inherited `Object.prototype` member and wrote that function into the merged row
+instead of the value a member actually carried. The cluster union additionally
+routed such a property through the separate base-property-conflict policy on the
+strength of a base member that does not carry it, so the wrong policy decided the
+committed value. The edge fold's claim filter separately counted a member that says
+NOTHING about such a field as having AUTHORED it; the shared value collector
+discarded that phantom claim, so the two agreed only by one absorbing the other's
+mistake.
 
 Two guards were quietly weakened rather than corrupted. Graph-extension validation
 accepted a unique constraint on an undeclared field named after a prototype
@@ -44,9 +51,11 @@ in use, where the key set is statically known: a discriminated union's tag, a
 capability probe, a brand check, and the deliberate `Object.prototype` lookup in
 selective projection.
 
-`__proto__`, the case originally reported, is the NARROW variant and is already
-blocked several times over — Zod drops an own `__proto__` key, `branch()` clones
-through the validating interchange import, the base@V fingerprint refuses a base
-mutated after the fork, and `bag["__proto__"] = value` assigns a prototype rather
-than creating a key, so assignment-built result bags cannot carry one either.
-Recorded here so it is not "fixed" again as though it were the reachable case.
+`__proto__`, the case originally reported, is the NARROW variant. Every VALIDATED
+write path blocks it: Zod drops an own `__proto__` key, and `bag["__proto__"] = value`
+assigns a prototype rather than creating a key, so an assignment-built bag cannot
+carry one either. It is still reachable through `trustedImportGraph`, which by
+contract does not validate properties and writes a caller's bag verbatim — the
+stored JSON parses back with `__proto__` as an own key on both dialects. Recorded
+here so the two are not confused: a prototype-named field needs nothing unusual at
+all, while `__proto__` needs the trusted path.

--- a/packages/typegraph/src/graph-extension/validation.ts
+++ b/packages/typegraph/src/graph-extension/validation.ts
@@ -19,7 +19,12 @@ import { ALL_META_EDGE_NAMES, type MetaEdgeName } from "../ontology/constants";
 import { validateOntologyRelations } from "../ontology/validation";
 import { encodeJsonPointerSegment } from "../query/json-pointer";
 import { RESERVED_EDGE_KEYS, RESERVED_NODE_KEYS } from "../store/reserved-keys";
-import { compactUndefined, freezeDeep, isPlainObject } from "../utils/object";
+import {
+  compactUndefined,
+  freezeDeep,
+  hasOwnKey,
+  isPlainObject,
+} from "../utils/object";
 import { err, ok, type Result } from "../utils/result";
 import {
   type GraphExtensionIssue,
@@ -1770,7 +1775,7 @@ function validateUniqueConstraints(
         fieldsValid = false;
         break;
       }
-      if (!(field in properties)) {
+      if (!hasOwnKey(properties, field)) {
         issues.push({
           path: `${constraintPath}/fields/${fieldIndex}`,
           message: `Unique constraint field "${field}" is not declared on this kind.`,
@@ -1867,7 +1872,7 @@ function validateUniqueWhere(
     });
     return undefined;
   }
-  if (!(field in properties)) {
+  if (!hasOwnKey(properties, field)) {
     issues.push({
       path: `${path}/field`,
       message: `Unique \`where.field\` "${field}" is not declared on this kind.`,

--- a/packages/typegraph/src/graph-merge/canonicalize.ts
+++ b/packages/typegraph/src/graph-merge/canonicalize.ts
@@ -1,3 +1,4 @@
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 /**
  * Canonical survivor selection + commutative property union (design §6.4 rule 3
@@ -224,7 +225,8 @@ function findPreferredMember(
   }
   return members.find(
     (member) =>
-      member.branchId === preferredBranchId && property in member.props,
+      member.branchId === preferredBranchId &&
+      hasOwnKey(member.props, property),
   );
 }
 
@@ -232,7 +234,7 @@ function memberPropertyValue(
   member: ClusterMember,
   property: string,
 ): JsonValue | undefined {
-  if (!(property in member.props)) {
+  if (!hasOwnKey(member.props, property)) {
     return undefined;
   }
   return member.props[property];
@@ -326,7 +328,8 @@ function unionProperties(
     const baseInvolved =
       hasBaseMember &&
       members.some(
-        (member) => member.origin === "base" && property in member.props,
+        (member) =>
+          member.origin === "base" && hasOwnKey(member.props, property),
       );
 
     // Resolution math sees the FULL contributions (including the base value, so the

--- a/packages/typegraph/src/graph-merge/conflict-policy.ts
+++ b/packages/typegraph/src/graph-merge/conflict-policy.ts
@@ -1,3 +1,4 @@
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 /**
  * The centralized property-conflict resolution rule (design §6.4 rule 4 / §7.3,
@@ -217,7 +218,7 @@ export function collectConflictingValues(
   const seen = new Set<string>();
   const values: ConflictingValue[] = [];
   for (const { branchId, props } of contributions) {
-    if (!(property in props)) {
+    if (!hasOwnKey(props, property)) {
       continue;
     }
     const value = props[property] as JsonValue;

--- a/packages/typegraph/src/graph-merge/delete-modify.ts
+++ b/packages/typegraph/src/graph-merge/delete-modify.ts
@@ -1,3 +1,4 @@
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 /**
  * Node-level delete/modify conflict resolution (design §6.2, T8a).
@@ -481,7 +482,7 @@ function threeWayMergeProps(
   }
 
   for (const property of [...propertyNames].sort(compareStrings)) {
-    const baseHas = property in baseProps;
+    const baseHas = hasOwnKey(baseProps, property);
     const baseKey =
       baseHas ?
         canonicalValueKey(requireDefined(baseProps[property]))
@@ -493,7 +494,7 @@ function threeWayMergeProps(
     // of conflict gathering, with the canonical NUL-separated dedupe key.
     const changed = contributions
       .filter((contribution) => {
-        if (!(property in contribution.forkProps)) {
+        if (!hasOwnKey(contribution.forkProps, property)) {
           return false; // absent — a deletion (handled below), never a change
         }
         const value = contribution.forkProps[property] as JsonValue;
@@ -512,7 +513,7 @@ function threeWayMergeProps(
       const deletedByFork =
         baseHas &&
         contributions.some(
-          (contribution) => !(property in contribution.forkProps),
+          (contribution) => !hasOwnKey(contribution.forkProps, property),
         );
       if (baseHas && !deletedByFork) {
         merged[property] = requireDefined(baseProps[property]);

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -1,3 +1,4 @@
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 /**
  * Edge repoint to canonical + set-dedupe cascade (design §6.3 / §6.4 rule 5, T9).
@@ -510,10 +511,10 @@ function pickSurvivor(
  */
 function authoredProperty(edge: RepointedEdge, property: string): boolean {
   const { props, baseProps } = edge.staged;
-  if (!(property in props)) {
+  if (!hasOwnKey(props, property)) {
     return false;
   }
-  if (baseProps === undefined || !(property in baseProps)) {
+  if (baseProps === undefined || !hasOwnKey(baseProps, property)) {
     return true;
   }
   return (
@@ -543,7 +544,7 @@ function unauthoredValue(
   edges: readonly RepointedEdge[],
 ): JsonValue {
   const carriers = edges
-    .filter((edge) => property in edge.staged.props)
+    .filter((edge) => hasOwnKey(edge.staged.props, property))
     .sort((left, right) => {
       const byId = compareStrings(left.staged.id, right.staged.id);
       return byId === 0 ?
@@ -605,13 +606,13 @@ function unionEdgeProps(
       // Filtering claims must not shrink the row, so a key only a NON-survivor
       // carries keeps a value too — see {@link unauthoredValue}.
       props[property] =
-        property in survivor.staged.props ?
+        hasOwnKey(survivor.staged.props, property) ?
           (survivor.staged.props[property] as JsonValue)
         : unauthoredValue(property, edges);
       continue;
     }
     const survivorValue =
-      property in survivor.staged.props ?
+      hasOwnKey(survivor.staged.props, property) ?
         (survivor.staged.props[property] as JsonValue)
       : requireDefined(values[0]).value;
     const canonicalValue: JsonValue =

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -1,3 +1,4 @@
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 /**
  * `merge()` orchestrator (design §7.2, T11).
@@ -1463,7 +1464,7 @@ function commitModificationProps(
 ): Record<string, unknown> {
   const props: Record<string, unknown> = { ...forkProps };
   for (const key of Object.keys(baseProps)) {
-    if (!(key in forkProps)) {
+    if (!hasOwnKey(forkProps, key)) {
       props[key] = undefined;
     }
   }

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -49,6 +49,7 @@ import {
   assertWritableValidityWindow,
   validateOptionalCanonicalIsoDate,
 } from "../utils/date";
+import { hasOwnKey } from "../utils/object";
 import {
   type GraphData,
   type GraphDataHeader,
@@ -1823,7 +1824,7 @@ function validateProperties(
           // Remove unknown properties
           const stripped: Record<string, unknown> = {};
           for (const key of knownKeys) {
-            if (key in properties) {
+            if (hasOwnKey(properties, key)) {
               stripped[key] = properties[key];
             }
           }

--- a/packages/typegraph/src/query/execution/selective-result-mapper.ts
+++ b/packages/typegraph/src/query/execution/selective-result-mapper.ts
@@ -7,7 +7,7 @@
  */
 
 import type { KindEntity } from "../../core/types";
-import { compareStrings, normalizePath } from "../../utils";
+import { compareStrings, hasOwnKey, normalizePath } from "../../utils";
 import { mergeEdgeKinds, type SelectiveField, type Traversal } from "../ast";
 import type {
   AliasMap,
@@ -369,10 +369,17 @@ function createGuardedProxy(
         return;
       }
 
-      if (property in object) {
+      // Own keys only: the projected row's keys are data, so `in` here would
+      // answer for `Object.prototype` members the row does not carry. Behavior
+      // is unchanged — such a key falls through to the prototype branch below
+      // and resolves the same way — but the two cases are now distinct.
+      if (hasOwnKey(object, property)) {
         return Reflect.get(object, property, receiver);
       }
 
+      // Deliberately `in`, NOT hasOwnKey: this branch's whole purpose is to
+      // reach inherited `Object.prototype` members (`toString`, `valueOf`, …) so
+      // a projected row still behaves like an object. Leave it alone.
       if (property in Object.prototype) {
         return Reflect.get(Object.prototype, property, receiver) as unknown;
       }

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -7,6 +7,7 @@
 import { type IndexEntity } from "../core/types";
 import { type IndexDeclaration } from "../indexes/types";
 import { compareStrings } from "../utils/compare";
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 import { canonicalEqual, sortedReplacer } from "./canonical";
 import {
@@ -696,7 +697,7 @@ function isBreakingObjectSchemaChange(
   const afterRequired = new Set(after.required);
 
   for (const key of Object.keys(beforeProps)) {
-    if (!(key in afterProps)) return true; // nested property removed
+    if (!hasOwnKey(afterProps, key)) return true; // nested property removed
   }
   for (const key of afterRequired) {
     if (!beforeRequired.has(key)) return true; // nested property newly required
@@ -743,8 +744,12 @@ function classifyPropertyChanges(
   const beforeRequired = new Set(before.required);
   const afterRequired = new Set(after.required);
 
-  const removed = Object.keys(beforeProps).filter((p) => !(p in afterProps));
-  const added = Object.keys(afterProps).filter((p) => !(p in beforeProps));
+  const removed = Object.keys(beforeProps).filter(
+    (property) => !hasOwnKey(afterProps, property),
+  );
+  const added = Object.keys(afterProps).filter(
+    (property) => !hasOwnKey(beforeProps, property),
+  );
   const newRequired = [...afterRequired].filter((p) => !beforeRequired.has(p));
 
   // A shared property whose schema changed in a way that can invalidate existing

--- a/packages/typegraph/src/schema/migration.ts
+++ b/packages/typegraph/src/schema/migration.ts
@@ -750,7 +750,9 @@ function classifyPropertyChanges(
   const added = Object.keys(afterProps).filter(
     (property) => !hasOwnKey(beforeProps, property),
   );
-  const newRequired = [...afterRequired].filter((p) => !beforeRequired.has(p));
+  const newRequired = [...afterRequired].filter(
+    (property) => !beforeRequired.has(property),
+  );
 
   // A shared property whose schema changed in a way that can invalidate existing
   // rows (type/shape change, a breaking nested/array/enum/constraint change).

--- a/packages/typegraph/src/store/materialize-removals.ts
+++ b/packages/typegraph/src/store/materialize-removals.ts
@@ -29,6 +29,7 @@ import { asCompiledStatementSql } from "../query/sql-intent";
 import { parseSerializedSchema } from "../schema/manager";
 import type { SerializedSchema } from "../schema/types";
 import { nowIso } from "../utils/date";
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 import { isMissingTableError } from "../utils/sql-errors";
 import { ensureFocusedStatusTable } from "./materialize-shared";
@@ -381,7 +382,7 @@ async function reconcilePendingRemovals(
       const currentEntries =
         currentSchema[entity === "node" ? "nodes" : "edges"];
       for (const kindName of Object.keys(priorEntries)) {
-        if (kindName in currentEntries) continue;
+        if (hasOwnKey(currentEntries, kindName)) continue;
         if (
           recorded.has(kindRemovalKey(entity, kindName, currentRow.version))
         ) {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -164,6 +164,7 @@ import { serializeSchema } from "../schema/serializer";
 import { type SerializedSchema } from "../schema/types";
 import { nowIso } from "../utils/date";
 import { generateId } from "../utils/id";
+import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
 import {
   createGraphAlgorithms,
@@ -4683,10 +4684,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     // named after an `Object.prototype` member would otherwise always look
     // still-present and skip the pending-removal refusal this guard exists for.
     const addedNodes = Object.keys(merged.nodes).filter(
-      (kind) => !Object.hasOwn(baseline.nodes, kind),
+      (kind) => !hasOwnKey(baseline.nodes, kind),
     );
     const addedEdges = Object.keys(merged.edges).filter(
-      (kind) => !Object.hasOwn(baseline.edges, kind),
+      (kind) => !hasOwnKey(baseline.edges, kind),
     );
     if (addedNodes.length === 0 && addedEdges.length === 0) return;
 

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -4679,11 +4679,14 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     const getPendingKindRemovals = this.#backend.getPendingKindRemovals;
     if (getPendingKindRemovals === undefined) return;
 
+    // Own keys only: `baseline` is rebuilt from the PARSED stored schema, so a kind
+    // named after an `Object.prototype` member would otherwise always look
+    // still-present and skip the pending-removal refusal this guard exists for.
     const addedNodes = Object.keys(merged.nodes).filter(
-      (kind) => !(kind in baseline.nodes),
+      (kind) => !Object.hasOwn(baseline.nodes, kind),
     );
     const addedEdges = Object.keys(merged.edges).filter(
-      (kind) => !(kind in baseline.edges),
+      (kind) => !Object.hasOwn(baseline.edges, kind),
     );
     if (addedNodes.length === 0 && addedEdges.length === 0) return;
 

--- a/packages/typegraph/src/utils/index.ts
+++ b/packages/typegraph/src/utils/index.ts
@@ -2,7 +2,12 @@ export { compareStrings } from "./compare";
 export { decodeDate, encodeDate, nowIso } from "./date";
 export { sha256Hex } from "./hash";
 export { generateId, type IdConfig, type IdGenerator } from "./id";
-export { compactUndefined, freezeDeep, isPlainObject } from "./object";
+export {
+  compactUndefined,
+  freezeDeep,
+  hasOwnKey,
+  isPlainObject,
+} from "./object";
 export { isSqlitePath, normalizePath, parseSqlitePath } from "./path";
 export {
   err,

--- a/packages/typegraph/src/utils/object.ts
+++ b/packages/typegraph/src/utils/object.ts
@@ -13,6 +13,35 @@ export function isPlainObject(
 }
 
 /**
+ * Own-key membership for a bag whose KEYS ARE DATA — a props record parsed out
+ * of a JSON column, a JSON-Schema `properties` map, a serialized-schema kind
+ * table. The single owner of that question; every path asking it calls here.
+ *
+ * `in` is the wrong operator for these bags because it also finds inherited
+ * members: `"toString" in {}` is `true`, as are `"constructor"`, `"valueOf"`,
+ * `"__proto__"`, and the rest of `Object.prototype`. A bag that does NOT carry
+ * the key therefore reads as if it does, and the `bag[key]` read that follows
+ * yields the inherited member instead of stored data.
+ *
+ * Reachable, and not through anything exotic: a schema may DECLARE a field named
+ * after a prototype member — `z.object({ toString: z.string() })` is an ordinary
+ * schema — and such a field survives validation, storage, and the JSON round-trip
+ * as normal data. (`__proto__` is the weak case, not the dangerous one: Zod drops
+ * an own `__proto__` key, and `bag["__proto__"] = value` assigns a prototype
+ * rather than creating a key, so it struggles to exist in the first place.)
+ *
+ * `in` remains correct — and stays in use — where the key set is statically
+ * known: a discriminated union's tag, a capability probe, a brand check. The
+ * distinction is whether the key came from data or from the code.
+ */
+export function hasOwnKey(
+  bag: Readonly<Record<string, unknown>>,
+  key: string,
+): boolean {
+  return Object.hasOwn(bag, key);
+}
+
+/**
  * Builds an object dropping any keys whose value is `undefined`.
  *
  * Lets callers construct discriminated-union members and `defineNode` /

--- a/packages/typegraph/src/utils/object.ts
+++ b/packages/typegraph/src/utils/object.ts
@@ -26,9 +26,10 @@ export function isPlainObject(
  * Reachable, and not through anything exotic: a schema may DECLARE a field named
  * after a prototype member — `z.object({ toString: z.string() })` is an ordinary
  * schema — and such a field survives validation, storage, and the JSON round-trip
- * as normal data. (`__proto__` is the weak case, not the dangerous one: Zod drops
- * an own `__proto__` key, and `bag["__proto__"] = value` assigns a prototype
- * rather than creating a key, so it struggles to exist in the first place.)
+ * as normal data. (`__proto__` is the narrower case: Zod drops an own `__proto__`
+ * key and `bag["__proto__"] = value` assigns a prototype rather than creating one,
+ * so no validated write produces it — but the unvalidated trusted import writes a
+ * caller's bag verbatim, and JSON parses `__proto__` back as an own key.)
  *
  * `in` remains correct — and stays in use — where the key set is statically
  * known: a discriminated union's tag, a capability probe, a brand check. The

--- a/packages/typegraph/tests/graph-extension.test.ts
+++ b/packages/typegraph/tests/graph-extension.test.ts
@@ -1132,6 +1132,28 @@ describe("validation failures", () => {
     );
   });
 
+  /**
+   * The extension document's `properties` map is parsed JSON, so declared-field
+   * membership must be an OWN-key question. Under `in`, a field named after an
+   * `Object.prototype` member answers "declared" against the prototype, so a
+   * constraint on an undeclared `toString` was silently accepted and went on to
+   * index a field that does not exist.
+   */
+  it("rejects a unique constraint on an undeclared field named after a prototype member", () => {
+    expectInvalid(
+      () =>
+        defineGraphExtension({
+          nodes: {
+            N: {
+              properties: { id: { type: "string" } },
+              unique: [{ name: "by_to_string", fields: ["toString"] }],
+            },
+          },
+        }),
+      "UNKNOWN_UNIQUE_FIELD",
+    );
+  });
+
   it("rejects unique where predicates with unsupported ops", () => {
     expectInvalid(
       () =>

--- a/packages/typegraph/tests/graph-merge/canonicalize.test.ts
+++ b/packages/typegraph/tests/graph-merge/canonicalize.test.ts
@@ -358,3 +358,71 @@ describe("ClusterMember origin discriminator (step 1)", () => {
     expect(entity.props["name"]).toBe("Branch"); // value overwritten by opt-in
   });
 });
+
+/**
+ * A cluster member's props bag is data — its keys come out of a JSON column — so a
+ * schema may declare a field named after an `Object.prototype` member and the union
+ * must ask each bag for OWN keys (issue #422). Under `in` a member that carries no such
+ * property answers as though it does, and the read that follows yields the inherited
+ * function instead of stored data.
+ */
+describe("prototype-named property membership (#422)", () => {
+  function rank(order: readonly BranchId[]): ReadonlyMap<BranchId, number> {
+    return buildBranchRank(order, [b1, b2, b3]);
+  }
+
+  it("does not take a canonical member's inherited prototype member as its value", () => {
+    // The canonical member carries no `toString`, so the contested value falls back to
+    // the first real claim. Under `in` it "carries" one, and the function on
+    // `Object.prototype` is committed as the property's value.
+    const cluster = clusterOf("node-a", "node-b", "node-c");
+    const members: readonly ClusterMember[] = [
+      member("node-a", b1, { name: "Anna" }),
+      member("node-b", b2, { name: "Anna", toString: "from-b" }),
+      member("node-c", b3, { name: "Anna", toString: "from-c" }),
+    ];
+
+    const entity = canonicalizeCluster(
+      cluster,
+      members,
+      "flag",
+      rank([b1, b2, b3]),
+    );
+
+    expect(entity.canonicalId).toBe("node-a");
+    // The whole bag is compared rather than the one key because TypeScript resolves
+    // `props.toString` to `Object`'s method signature, not the record's index
+    // signature — the shadowing under test, one level up in the type system.
+    expect(entity.props).toEqual({ name: "Anna", toString: "from-b" });
+    expect(requireDefined(entity.conflicts[0]).resolution).toBe("from-b");
+  });
+
+  it("does not treat a base member that lacks a prototype-named property as involved", () => {
+    // A property the BASE does not carry is a staged-vs-staged gap fill and is governed
+    // by the staged policy — here `lastWriteWins`, which takes the highest-ranked
+    // branch's value. Under `in` the base "carries" it, so the separate base policy
+    // (default `flag`) governs instead and commits the canonical value.
+    const cluster = clusterOf("a-new", "b-new", "z-base");
+    const members: readonly ClusterMember[] = [
+      {
+        origin: "base",
+        id: nodeId("z-base"),
+        kind: "Patient",
+        branchId: BASE_PROVENANCE_BRANCH,
+        props: { name: "Committed" },
+      },
+      member("a-new", b1, { name: "Committed", toString: "from-b1" }),
+      member("b-new", b2, { name: "Committed", toString: "from-b2" }),
+    ];
+
+    const entity = canonicalizeCluster(
+      cluster,
+      members,
+      "lastWriteWins",
+      rank([b2, b1]),
+    );
+
+    expect(entity.canonicalId).toBe("z-base");
+    expect(entity.props).toEqual({ name: "Committed", toString: "from-b2" });
+  });
+});

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -1459,6 +1459,56 @@ describe("repointEdges base-aware property union (#408)", () => {
     expect(result.conflicts).toEqual([]);
   });
 
+  /**
+   * The property union asks each staged bag whether it CARRIES a property, and a
+   * props bag is data: an edge schema may declare a field named after an
+   * `Object.prototype` member, and such a field survives validation and the JSON
+   * round-trip as ordinary data (issue #422). Membership must therefore be an
+   * OWN-key question.
+   *
+   * Under `in`, the branch-created member below "carries" `toString` despite saying
+   * nothing about it, so it is counted as having AUTHORED a value it never wrote,
+   * that inherited function enters the union as a claim, and it displaces the
+   * survivor's real value. The authored-claims filter this describe block exists to
+   * pin is defeated for exactly these field names.
+   */
+  it("does not treat a prototype-named property as authored by a member that lacks it", () => {
+    const result = repointEdges(
+      [
+        stagedEdge({
+          id: "edge-1",
+          from: "x",
+          to: "a",
+          inherited: true,
+          props: { on: "base", toString: "base-owned" },
+          baseProps: { on: "base", toString: "base-owned" },
+          branchId: BRANCH_A,
+        }),
+        // Authors `on` and says nothing whatsoever about `toString`.
+        stagedEdge({
+          id: "edge-2",
+          from: "x",
+          to: "b",
+          props: { on: "authored" },
+          branchId: BRANCH_B,
+        }),
+      ],
+      collapse,
+      new Set<MergeKey>(),
+      "lastWriteWins",
+      rankABC(),
+    );
+
+    expect(requireDefined(result.edges[0]).props).toEqual({
+      on: "authored",
+      toString: "base-owned",
+    });
+    // No member authored `toString`, so there is nothing for it to conflict over.
+    expect(
+      result.conflicts.filter((conflict) => conflict.property === "toString"),
+    ).toEqual([]);
+  });
+
   it("keeps an unauthored property the SURVIVOR's own bag lacks", () => {
     // Two committed rows the repoint folded together — the survivor is the min-id
     // inherited one, and the other member's untouched property has no claim behind

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -1467,10 +1467,11 @@ describe("repointEdges base-aware property union (#408)", () => {
    * OWN-key question.
    *
    * Under `in`, the branch-created member below "carries" `toString` despite saying
-   * nothing about it, so it is counted as having AUTHORED a value it never wrote,
-   * that inherited function enters the union as a claim, and it displaces the
-   * survivor's real value. The authored-claims filter this describe block exists to
-   * pin is defeated for exactly these field names.
+   * nothing about it, so it is counted as having AUTHORED a value it never wrote. The
+   * authored-claims filter this describe block exists to pin is defeated for exactly
+   * these field names, and the fold's claim filter and the shared value collector must
+   * agree that a member which does not carry a property has no claim on it: whichever
+   * of the two asks with `in` reintroduces a phantom claimant.
    */
   it("does not treat a prototype-named property as authored by a member that lacks it", () => {
     const result = repointEdges(
@@ -1547,6 +1548,98 @@ describe("repointEdges base-aware property union (#408)", () => {
       note: "base-b",
     });
     expect(result.conflicts).toEqual([]);
+  });
+
+  /**
+   * The same fold, with the carried key named after an `Object.prototype` member
+   * (issue #422). This path asks the SURVIVOR's bag whether the fold already holds a
+   * value for the key, and a props bag is data: under `in` a survivor that carries no
+   * `toString` answers yes, so the committed row takes `Object.prototype.toString` — a
+   * FUNCTION — as the property's value instead of the value the other member carries.
+   */
+  it("keeps a prototype-named unauthored property the SURVIVOR's own bag lacks", () => {
+    const result = repointEdges(
+      [
+        stagedEdge({
+          id: "edge-1",
+          from: "x",
+          to: "a",
+          inherited: true,
+          props: { on: "base-a" },
+          baseProps: { on: "base-a" },
+          branchId: BRANCH_A,
+        }),
+        stagedEdge({
+          id: "edge-2",
+          from: "x",
+          to: "b",
+          inherited: true,
+          props: { toString: "base-b" },
+          baseProps: { toString: "base-b" },
+          branchId: BRANCH_B,
+        }),
+      ],
+      collapse,
+      new Set<MergeKey>(),
+      "lastWriteWins",
+      rankABC(),
+    );
+
+    expect(requireDefined(result.edges[0]).id).toBe("edge-1");
+    expect(requireDefined(result.edges[0]).props).toEqual({
+      on: "base-a",
+      toString: "base-b",
+    });
+    expect(result.conflicts).toEqual([]);
+  });
+
+  /**
+   * The survivor-lacks-the-key read on the CONTESTED path: `"flag"` commits the
+   * canonical value, which for a key the survivor does not carry is the first real
+   * claim. Under `in` the survivor's bag supplies `Object.prototype.toString` instead,
+   * so a function is committed as the merged property value.
+   *
+   * The whole bag is compared rather than the one key because TypeScript resolves
+   * `props["toString"]` to `Object`'s method signature, not the record's index
+   * signature — the shadowing this file is about, one level up in the type system.
+   */
+  it("resolves a contested prototype-named property the SURVIVOR lacks from real claims", () => {
+    const result = repointEdges(
+      [
+        stagedEdge({
+          id: "edge-1",
+          from: "x",
+          to: "a",
+          inherited: true,
+          props: { on: "base-a" },
+          baseProps: { on: "base-a" },
+          branchId: BRANCH_A,
+        }),
+        stagedEdge({
+          id: "edge-2",
+          from: "x",
+          to: "b",
+          props: { toString: "from-b" },
+          branchId: BRANCH_B,
+        }),
+        stagedEdge({
+          id: "edge-3",
+          from: "x",
+          to: "c",
+          props: { toString: "from-c" },
+          branchId: BRANCH_C,
+        }),
+      ],
+      collapse,
+      new Set<MergeKey>(),
+      "flag",
+      rankABC(),
+    );
+
+    expect(requireDefined(result.edges[0]).props).toEqual({
+      on: "base-a",
+      toString: "from-b",
+    });
   });
 
   // Which branch a staged copy of an inherited row belongs to is arbitrary, so the

--- a/packages/typegraph/tests/graph-merge/prototype-named-props.test.ts
+++ b/packages/typegraph/tests/graph-merge/prototype-named-props.test.ts
@@ -13,8 +13,11 @@
  * through the VALIDATING interchange import, the base@V content fingerprint
  * refuses a base mutated after the fork, and — decisively — `bag["__proto__"] =
  * value` sets a PROTOTYPE rather than creating a key, so the merge's own
- * assignment-built result bags cannot carry one either. Every layer independently
- * blocks it.
+ * assignment-built result bags cannot carry one either. Every VALIDATED layer blocks
+ * it; what remains is `trustedImportGraph`, which by contract does not validate
+ * properties, so a caller's bag reaches the column verbatim and parses back with
+ * `__proto__` as an own key. Hence the unit tests at the bottom of this file, which
+ * hold the predicate to that shape directly.
  *
  * The live ammunition is the rest of `Object.prototype`: `toString`,
  * `constructor`, `valueOf`, `hasOwnProperty`. A schema may legitimately DECLARE a

--- a/packages/typegraph/tests/graph-merge/prototype-named-props.test.ts
+++ b/packages/typegraph/tests/graph-merge/prototype-named-props.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Props-key membership is an OWN-key question (issue #422).
+ *
+ * A props bag is data: its keys come from a JSON column, so a key may name an
+ * `Object.prototype` member. `in` cannot answer "does this row carry this
+ * property" for such a bag — `"toString" in {}` is `true` — so a row that does NOT
+ * carry the key reads as though it does, and the `bag[key]` read that follows
+ * yields the inherited prototype member instead of stored data.
+ *
+ * WHICH KEY MAKES THIS REACHABLE. Issue #422 named `__proto__`, but that is the
+ * hardest case to reach and the least severe: Zod 4 drops an own `__proto__` key
+ * (`looseObject` and `.passthrough()` alike), `branch()` clones the working copy
+ * through the VALIDATING interchange import, the base@V content fingerprint
+ * refuses a base mutated after the fork, and — decisively — `bag["__proto__"] =
+ * value` sets a PROTOTYPE rather than creating a key, so the merge's own
+ * assignment-built result bags cannot carry one either. Every layer independently
+ * blocks it.
+ *
+ * The live ammunition is the rest of `Object.prototype`: `toString`,
+ * `constructor`, `valueOf`, `hasOwnProperty`. A schema may legitimately DECLARE a
+ * field with one of those names — `z.object({ toString: z.string() })` is an
+ * ordinary schema — and such a field survives Zod, the JSON round-trip, and plain
+ * assignment as completely normal data. `in` misclassifies it exactly the same
+ * way, with no exotic input and nothing bypassed. That is what these tests pin.
+ */
+
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { rowPropsToObject } from "../../src/backend/types";
+import { branch } from "../../src/graph-merge/branch";
+import { collectConflictingValues } from "../../src/graph-merge/conflict-policy";
+import { merge } from "../../src/graph-merge/merge";
+import { isOk, unwrap } from "../../src/graph-merge/result";
+import { enumerateAllNodes } from "../../src/graph-merge/state-diff";
+import type { BranchId, GraphBranch } from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { requireDefined } from "../../src/utils/presence";
+import { backendMatrix, getStoreBackend } from "./test-utils";
+
+/**
+ * The declared field whose name shadows an `Object.prototype` member. Ordinary
+ * data in every respect — the name is the entire point.
+ */
+const SHADOWING_FIELD = "toString";
+
+/** The key issue #422 named; see the module docblock for why it is the weak case. */
+const PROTO_KEY = "__proto__";
+
+const PATIENT_KIND = "Patient";
+
+const Patient = defineNode(PATIENT_KIND, {
+  schema: z.object({
+    name: z.string(),
+    // A field named after a prototype member. `z.object({ toString: ... })` builds
+    // an ordinary own key — `toString` has none of `__proto__`'s assignment magic.
+    toString: z.string().optional(),
+  }),
+});
+
+const graph = defineGraph({
+  id: "prototype-named-props",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
+});
+type G = typeof graph;
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+describe.each(backendMatrix())(
+  "props keyed by a prototype member name [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    beforeEach(() => {
+      cleanups = [];
+    });
+
+    afterEach(async () => {
+      for (const cleanup of cleanups) {
+        await cleanup();
+      }
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function makeBranch(
+      baseStore: Store<G>,
+      id: BranchId,
+    ): Promise<GraphBranch<G>> {
+      return unwrap(await branch<G>(baseStore, () => makeBackend(), { id }));
+    }
+
+    /**
+     * The row's props as actually stored. Read raw rather than through the
+     * collection: a missing `toString` key would resolve to the inherited method
+     * on a mapped object, which is the very confusion under test.
+     */
+    async function readStoredProps(
+      store: Store<G>,
+      id: string,
+    ): Promise<Record<string, unknown>> {
+      const rows = await enumerateAllNodes(
+        getStoreBackend(store),
+        store.graphId,
+        PATIENT_KIND,
+      );
+      const row = requireDefined(rows.find((candidate) => candidate.id === id));
+      return rowPropsToObject(row.props);
+    }
+
+    it("applies a fork's deletion of a property whose name shadows a prototype member", async () => {
+      const [baseStore] = await createStoreWithSchema(
+        graph,
+        await makeBackend(),
+      );
+      const alice = await baseStore.nodes.Patient.create({
+        name: "Alice",
+        [SHADOWING_FIELD]: "base-owned",
+      });
+      const stored = await readStoredProps(baseStore, alice.id);
+      // FIXTURE SANITY: an ordinary validated write really did store the key.
+      expect(Object.hasOwn(stored, SHADOWING_FIELD)).toBe(true);
+
+      const branchA = await makeBranch(baseStore, BRANCH_A);
+      // The fork removes the optional field on the inherited node.
+      await branchA.store.nodes.Patient.update(alice.id, {
+        [SHADOWING_FIELD]: undefined,
+      });
+
+      const result = await merge<G>(baseStore, [branchA], {
+        branchOrder: [BRANCH_A],
+      });
+      expect(isOk(result)).toBe(true);
+
+      const merged = await readStoredProps(baseStore, alice.id);
+      console.info(
+        `[${entry.name}] stored keys after the fork's deletion:`,
+        Object.keys(merged),
+      );
+      // A fork's bag is its FULL intended state, so a base key absent from it was
+      // deleted by that fork. Under `in`, `"toString" in forkProps` is true even
+      // though the fork dropped it, so no deletion tombstone is written and the
+      // base value survives the merge — the fork's write is lost.
+      expect(Object.hasOwn(merged, SHADOWING_FIELD)).toBe(false);
+      expect(merged["name"]).toBe("Alice");
+    });
+
+    it("honors that deletion while a concurrent branch edits a different property", async () => {
+      const [baseStore] = await createStoreWithSchema(
+        graph,
+        await makeBackend(),
+      );
+      const alice = await baseStore.nodes.Patient.create({
+        name: "Alice",
+        [SHADOWING_FIELD]: "base-owned",
+      });
+
+      const branchA = await makeBranch(baseStore, BRANCH_A);
+      const branchB = await makeBranch(baseStore, BRANCH_B);
+      await branchA.store.nodes.Patient.update(alice.id, {
+        [SHADOWING_FIELD]: undefined,
+      });
+      // Restates the base value rather than passing a bare `{ name }` literal: with
+      // a field declared as `toString: string`, TypeScript rejects any object
+      // literal, because the literal's INHERITED `toString` (`() => string`) is
+      // matched against the declared type. The name collision bites at the type
+      // level too — so this branch keeps the field and edits only `name`.
+      await branchB.store.nodes.Patient.update(alice.id, {
+        name: "Alicia",
+        [SHADOWING_FIELD]: "base-owned",
+      });
+
+      const result = await merge<G>(baseStore, [branchA, branchB], {
+        branchOrder: [BRANCH_A, BRANCH_B],
+      });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) {
+        return;
+      }
+
+      const merged = await readStoredProps(baseStore, alice.id);
+      console.info(
+        `[${entry.name}] three-way merge stored keys:`,
+        Object.keys(merged),
+        `| conflicts:`,
+        result.data.conflicts.length,
+      );
+      // Disjoint edits: one branch deletes the shadowing field, the other renames.
+      // Both must land, and the deletion is not a conflict.
+      expect(Object.hasOwn(merged, SHADOWING_FIELD)).toBe(false);
+      expect(merged["name"]).toBe("Alicia");
+      expect(
+        result.data.conflicts.filter(
+          (conflict) => conflict.property === SHADOWING_FIELD,
+        ),
+      ).toEqual([]);
+    });
+  },
+);
+
+describe("collectConflictingValues own-key contract", () => {
+  /**
+   * A props bag carrying a REAL own `__proto__` data property.
+   *
+   * The JSON parse is load-bearing and must not be "simplified" into an object
+   * literal or an assignment: both `{ __proto__: value }` and `bag[PROTO_KEY] =
+   * value` set the bag's PROTOTYPE and leave it with no own key at all, which
+   * would make the assertion vacuous. Only `JSON.parse` — and the JSON columns
+   * props are stored in — mint `__proto__` as ordinary own data.
+   */
+  function propsWithOwnProtoKey(taint: string): Record<string, unknown> {
+    const bag = JSON.parse(
+      `{"name": "carries", "${PROTO_KEY}": {"tainted": ${JSON.stringify(taint)}}}`,
+    ) as Record<string, unknown>;
+    expect(Object.hasOwn(bag, PROTO_KEY)).toBe(true);
+    return bag;
+  }
+
+  it("skips a contribution that lacks a property named after a prototype member", () => {
+    const values = collectConflictingValues(SHADOWING_FIELD, [
+      { branchId: asBranchId("lacking"), props: { name: "lacks" } },
+      {
+        branchId: asBranchId("carrying"),
+        props: { name: "carries", [SHADOWING_FIELD]: "real" },
+      },
+    ]);
+
+    // Under `in`, the "lacking" branch is credited with a value it never stored —
+    // `Object.prototype.toString`, a function — which then competes in conflict
+    // resolution and is reported back to the caller as that branch's value.
+    expect(values.map((candidate) => candidate.branchId)).toEqual([
+      asBranchId("carrying"),
+    ]);
+    expect(values.map((candidate) => candidate.value)).toEqual(["real"]);
+  });
+
+  it("does not credit a bag lacking __proto__ with Object.prototype as its value", () => {
+    const lacks = JSON.parse(`{"name": "lacks"}`) as Record<string, unknown>;
+    expect(Object.hasOwn(lacks, PROTO_KEY)).toBe(false);
+
+    const values = collectConflictingValues(PROTO_KEY, [
+      { branchId: asBranchId("lacking"), props: lacks as never },
+      {
+        branchId: asBranchId("carrying"),
+        props: propsWithOwnProtoKey("real") as never,
+      },
+    ]);
+
+    expect(values.map((candidate) => candidate.branchId)).toEqual([
+      asBranchId("carrying"),
+    ]);
+    expect(
+      values.some(
+        (candidate) => (candidate.value as unknown) === Object.prototype,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/typegraph/tests/migration-diff.test.ts
+++ b/packages/typegraph/tests/migration-diff.test.ts
@@ -307,6 +307,69 @@ describe("computeSchemaDiff", () => {
       expect(requireDefined(diff.nodes[0]).details).toContain("removed");
     });
 
+    /**
+     * A schema's `properties` map is parsed JSON, so a declared field may be named
+     * after an `Object.prototype` member, and membership must be an OWN-key
+     * question. Under `in`, `"toString" in afterProperties` is true even though the
+     * field is gone, so the field never reaches the removal list; instead
+     * `afterProperties["toString"]` resolves to `Object.prototype.toString` — a
+     * FUNCTION — which is then compared as though it were this field's new schema.
+     *
+     * The severity survives that by luck (comparing a schema against a function
+     * reports SOME incompatibility, so the change still lands as breaking), which is
+     * why this pin asserts the REASON: the operator is told the property's schema
+     * changed incompatibly when the property was in fact removed, and the migration
+     * actions that follow from those two diagnoses differ.
+     */
+    it("detects removal of a property named after a prototype member as breaking", () => {
+      const before = createSchema({
+        version: 1,
+        nodes: {
+          Person: {
+            kind: "Person",
+            properties: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                toString: { type: "string" },
+              },
+              required: ["name"],
+            },
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+          },
+        },
+      });
+      const after = createSchema({
+        version: 2,
+        nodes: {
+          Person: {
+            kind: "Person",
+            properties: {
+              type: "object",
+              properties: { name: { type: "string" } },
+              required: ["name"],
+            },
+            uniqueConstraints: [],
+            onDelete: "restrict",
+            description: undefined,
+          },
+        },
+      });
+
+      const diff = computeSchemaDiff(before, after);
+
+      expect(diff.hasBreakingChanges).toBe(true);
+      expect(diff.nodes[0]).toMatchObject({
+        type: "modified",
+        kind: "Person",
+        severity: "breaking",
+      });
+      expect(requireDefined(diff.nodes[0]).details).toContain("toString");
+      expect(requireDefined(diff.nodes[0]).details).toContain("removed");
+    });
+
     it("detects new required property as breaking change", () => {
       const before = createSchema({
         version: 1,


### PR DESCRIPTION
Props bags are data: their keys come from a JSON column, so a schema may declare a field named after an `Object.prototype` member — `toString`, `constructor`, `valueOf` — and such a field is ordinary data that survives Zod validation and the JSON round-trip untouched. The `in` operator cannot answer "does this row carry this property" for such a bag, because `"toString" in {}` is `true`: a row that does not carry the key reads as though it does, and the read that follows yields the inherited prototype member instead of stored data.

This is a lost-write fix, not only hardening. In a graph merge a fork's bag is its full intended state, so a base property absent from it was deleted by that fork — and under `in` that deletion was never detected for a prototype-named field, so no tombstone was written and the base value survived, silently discarding the fork's write. The same misclassification let a branch that carries no such property contribute the inherited prototype member as if it were a stored value, competing in conflict resolution and being reported to the caller as that branch's value. In the edge fold and the cluster union the worst outcome was a committed function: for a property the surviving row does not carry, both ask that row's bag for the value to keep, so `in` handed them the inherited `Object.prototype` member to write into the merged row instead of the value a member actually carried; the cluster union additionally routed such a property through the separate base-conflict policy on the strength of a base member that does not carry it. A schema diff reported a removed prototype-named property as an incompatible change rather than a removal. Two guards were quietly weakened: graph-extension validation accepted a unique constraint on an undeclared prototype-named field, and the evolve guard that refuses re-adding a kind with pending data cleanup never counted such a kind as added.

The convention now has one owner, `hasOwnKey` in `src/utils/object.ts`, applied across graph-merge node and edge property resolution, schema-diff property classification, schema-removal reconciliation, interchange unknown-property stripping, graph-extension document validation, and the evolve pending-removal guard. `in` remains correct and in use where the key set is statically known: a discriminated union's tag, a capability probe, a brand check, and the deliberate `Object.prototype` lookup in selective projection (comment-guarded against a future reader of this sweep). Three of the converted sites — the two checks inside the edge fold's claim filter and the cluster union's preferred-member lookup — are behavior-neutral on their own, because a sibling own-key check further along the same path already discards the phantom claim they would admit; they are converted anyway so that no site depends on another absorbing its mistake.

`__proto__`, the case originally reported in the issue, is the NARROW variant. Every validated write path blocks it: Zod 4 drops an own `__proto__` key, and `bag["__proto__"] = value` assigns a prototype rather than creating a key, so an assignment-built bag cannot carry one either. It remains reachable through `trustedImportGraph`, which by contract does not validate properties and writes a caller's bag verbatim — the stored JSON parses back with `__proto__` as an own key on both dialects. Recorded so the two are not confused: a prototype-named field needs nothing unusual at all, while `__proto__` needs the trusted path.

Validation-permissiveness sites where a user-supplied key is tested against a statically-known Zod shape are deliberately left to #424 — a distinct, weaker class (over-acceptance at validation time rather than misread data).

Closes #422
