### PR TITLE
fix(store): refuse a validity bound the write will not apply

### DIFF
--- a/.changeset/immutable-validity-lower-bound.md
+++ b/.changeset/immutable-validity-lower-bound.md
@@ -1,0 +1,36 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Refuse a `validFrom` that a live row's update cannot store, instead of accepting
+it and writing without it.
+
+An in-place update never rewrites `valid_from`; only a resurrection does. Stating
+a bound that named a different instant used to block coalescing, so the upsert
+wrote — bumping the version and capturing a history row — while the bound itself
+was dropped at the SQL builder and the row's window never moved. It now raises a
+`ValidationError` whose issue carries the new exported code
+`IMMUTABLE_VALIDITY_LOWER_BOUND`, naming both the stated instant and the one the
+row holds so the caller can restate it without a second read.
+
+This reaches every path that accepts `validFrom` against a live row: `upsertById`
+and `bulkUpsertById` (nodes and edges, including a repeated id in one batch, which
+is judged against the row the batch just queued), `getOrCreateByEndpoints` and
+`bulkGetOrCreateByEndpoints` with `ifExists: "update"` — which previously dropped
+the option before it reached any guard — and interchange import's
+`onConflict: "update"` legs, where it is recorded as a per-row error prefixed with
+the code rather than aborting the import.
+
+What stays legal: restating the bound a row already holds (nothing to apply, so
+nothing is ignored); a create or a resurrection, both of which store a stated
+bound and are the way to give a row a different one; zero-width windows; and
+`getOrCreateByEndpoints` returning an existing edge, which performs no write at
+all.
+
+Previously-accepted writes now refuse, so this is a MINOR bump — the same
+precedent as the window refusals in the two releases before it.
+
+Note for temporal imports: replaying an `includeTemporal: true` export over rows
+that were created separately now reports those rows instead of updating their
+props under a lower bound it ignored. Omit `validFrom` from the update document,
+export with `includeTemporal: false`, or import into a fresh graph.

--- a/.changeset/non-canonical-bound-reports.md
+++ b/.changeset/non-canonical-bound-reports.md
@@ -1,0 +1,19 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Report a non-canonical validity bound whether or not `coalesceUnchangedUpserts`
+is on.
+
+A parseable-but-non-canonical bound equal to the stored instant —
+`"2100-06-01T00:00:00Z"` against a stored `"2100-06-01T00:00:00.000Z"` — compared
+as "unchanged" with coalescing on, so the write was skipped and the
+`ValidationError` the same call raises with coalescing off was swallowed. An
+unrelated performance flag decided whether malformed input was reported.
+
+A non-canonical REQUESTED bound now counts as a window change, so it reaches the
+write path and raises identically either way. Re-stating a window in canonical
+form still coalesces, including against a driver that renders the stored value as
+an equivalent zoned string: only the stored side needs canonicalizing, because
+the requested side is held to canonical form by the write validation this no
+longer hides.

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -150,6 +150,50 @@ stream with `TrustedImportError` reason `invalid_stream`. A zero-width window
 (`validTo === validFrom`) is legal and never raises this, and so is a create
 carrying only a historical `validTo`.
 
+#### `IMMUTABLE_VALIDITY_LOWER_BOUND`
+
+A `ValidationError` whose issue carries the exported code
+`IMMUTABLE_VALIDITY_LOWER_BOUND` refused a `validFrom` the write could not apply.
+A live row's lower bound is history: an in-place update never rewrites
+`valid_from`, so a bound naming a different instant is refused rather than
+accepted and silently dropped. The message names both instants — the one stated
+and the one the row stores — so you can restate the stored bound without a
+second read.
+
+```typescript
+import { IMMUTABLE_VALIDITY_LOWER_BOUND_CODE, ValidationError } from "@nicia-ai/typegraph";
+
+try {
+  // The row is live and started at some other instant.
+  await store.nodes.Person.upsertById(id, props, { validFrom: "2020-01-01T00:00:00.000Z" });
+} catch (error) {
+  if (
+    error instanceof ValidationError &&
+    error.details.issues.some(
+      (issue) => issue.code === IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+    )
+  ) {
+    // Omit validFrom, or restate the bound the row already holds.
+  }
+}
+```
+
+What deliberately does not raise it:
+
+- **Restating the stored bound.** Naming the instant the row already holds is
+  accepted; there is nothing to apply and nothing being ignored.
+- **A create, or a resurrection.** Both write a fresh window, so a stated
+  `validFrom` is stored — that is the way to give a row a different lower bound.
+- **`getOrCreateByEndpoints` returning an existing edge.** That branch performs
+  no write, so its window options describe the row to create if none is found.
+
+It reaches every path that accepts `validFrom` against a live row: `upsertById`,
+`bulkUpsertById` (including a repeated id in one batch, judged against the row
+the batch just queued), `getOrCreateByEndpoints` / `bulkGetOrCreateByEndpoints`
+with `ifExists: "update"`, and interchange import's `onConflict: "update"` legs —
+where, as with the inverted-window refusal, it is recorded as a per-row error
+prefixed with the code rather than aborting the import.
+
 #### `ENTITY_ALREADY_EXISTS`
 
 A `ValidationError` whose issue carries the exported code

--- a/apps/docs/src/content/docs/interchange.md
+++ b/apps/docs/src/content/docs/interchange.md
@@ -202,6 +202,19 @@ from import time forward. Pass `includeTemporal: true` on export when the
 clone needs to match the source's `asOf` behavior exactly (this is what
 `branch()` does internally).
 
+**`includeTemporal: true` with `onConflict: "update"`:** an update leg sends the
+document's `validTo` and never its `validFrom`, because a live row's lower bound
+is history. A document whose `validFrom` names a different instant than the
+target row holds is therefore stating a bound the import will not apply, and that
+row is reported as a per-row error carrying
+[`IMMUTABLE_VALIDITY_LOWER_BOUND`](/errors/#immutable_validity_lower_bound)
+rather than updated under a bound it ignored. This is reachable whenever a
+temporal export is replayed over rows that were created separately — the same
+document imported into a fresh graph creates those rows with their stated bounds
+and is unaffected. To update props over existing rows from a temporal export,
+either omit `validFrom` from the update document, export with
+`includeTemporal: false`, or import into a fresh graph and swap it in.
+
 ## Importing Data
 
 Use `importGraph` to load data into a store:

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -939,8 +939,14 @@ advance, and no `update` operation hooks — and resolves with the existing node
 at-least-once / replay materializers, where a byte-identical re-delivery would
 otherwise rewrite every row and grow recorded history by one per delivery. A
 write still happens (never coalesced) when the row is soft-deleted (an upsert
-resurrects it), when an explicit `validFrom` / `validTo` is passed, or when any
-prop differs after Zod normalization. The default is off, because some
+resurrects it), when an explicit `validFrom` / `validTo` MOVES the window the row
+already holds, or when any prop differs after Zod normalization. Re-stating the
+window a row already holds coalesces like any other unchanged value, and a
+`validFrom` naming a bound a live row does not hold is refused rather than
+written (see
+[Immutable validity lower bounds](/errors/#immutable_validity_lower_bound)) —
+with this option on or off, because coalescing must not decide whether an
+unappliable or malformed bound is reported. The default is off, because some
 consumers want an audit row per re-delivery as proof the event was reprocessed.
 In a receipt, a coalesced upsert still counts as one write intent
 (`writes.total`) but captures nothing (`recorded` stays `undefined`) — the same
@@ -1528,8 +1534,12 @@ store.edges.worksAt.getOrCreateByEndpoints(
 ```
 
 `validFrom` applies when the operation creates the edge and when it resurrects
-one; an `"updated"` live match leaves the existing start unchanged, because a
-live row's lower bound is history. On a resurrection, naming `validFrom` asserts
+one. An `"updated"` live match leaves the existing start unchanged, because a
+live row's lower bound is history — so a `validFrom` naming a different instant
+is refused rather than ignored, see
+[Immutable validity lower bounds](/errors/#immutable_validity_lower_bound);
+restating the bound the edge already holds is accepted. On a resurrection, naming
+`validFrom` asserts
 the COMPLETE window: an accompanying `validTo` is applied, and an omitted one
 reopens the revived row rather than keeping the tombstoned incarnation's end.
 `validTo` applies when the edge is created, updated, or resurrected, and may not

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -2898,6 +2898,9 @@ export type IdGenerator = () => string;
 export type IfExistsMode = "return" | "update";
 
 // @public
+export const IMMUTABLE_VALIDITY_LOWER_BOUND_CODE = "IMMUTABLE_VALIDITY_LOWER_BOUND";
+
+// @public
 export function implies(edgeA: EdgeType, edgeB: EdgeType): OntologyRelation;
 
 // @public

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -193,6 +193,25 @@ export type ValidationIssue = Readonly<{
 export const INVERTED_VALIDITY_WINDOW_CODE = "INVERTED_VALIDITY_WINDOW";
 
 /**
+ * The stable {@link ValidationIssue.code} carried by a refusal to accept a
+ * `validFrom` the write cannot apply: the target row is LIVE, and an in-place
+ * update never rewrites a live row's lower bound — that bound is history.
+ * `ValidationError`'s own code is the family-wide `VALIDATION_ERROR`, so the
+ * discriminator lives on the issue — mirroring
+ * {@link INVERTED_VALIDITY_WINDOW_CODE}.
+ *
+ * Only a bound naming a DIFFERENT instant than the row already stores raises it.
+ * Restating the stored bound is legal and writes nothing new, and a resurrection
+ * — which does rewrite `valid_from` — applies a stated bound rather than
+ * refusing it.
+ *
+ * The message names both instants: the one stated and the one the row stores, so
+ * the caller can restate the stored bound without a second read.
+ */
+export const IMMUTABLE_VALIDITY_LOWER_BOUND_CODE =
+  "IMMUTABLE_VALIDITY_LOWER_BOUND";
+
+/**
  * The stable {@link ValidationIssue.code} every "this id is already taken"
  * create refusal carries, whichever way the create found out: its own existence
  * probe, or the engine refusing the INSERT. `ValidationError`'s own code is the

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -371,6 +371,7 @@ export {
   GraphAlgorithmConvergenceError,
   IdentityContradictionError,
   IdentitySeparationViolationError,
+  IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
   InvalidEdgeWeightError,
   INVERTED_VALIDITY_WINDOW_CODE,
   isConstraintError,

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -22,6 +22,7 @@ import { type EdgeRegistration, type NodeRegistration } from "../core/types";
 import {
   ConfigurationError,
   IdentityContradictionError,
+  IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
   INVERTED_VALIDITY_WINDOW_CODE,
   NodeNotFoundError,
   UniquenessError,
@@ -1090,22 +1091,23 @@ async function catchUniquenessError<T>(
 /**
  * Runs a window assertion and reports its refusal as a per-row error message
  * (recorded in the import result) instead of throwing, so one malformed row does
- * not abort the whole import. An inverted window's message is prefixed with
- * {@link INVERTED_VALIDITY_WINDOW_CODE} so the refusal is recognizable without
- * parsing prose.
+ * not abort the whole import. A window refusal that carries a stable issue code —
+ * {@link INVERTED_VALIDITY_WINDOW_CODE} or
+ * {@link IMMUTABLE_VALIDITY_LOWER_BOUND_CODE} — is prefixed with it, so the
+ * refusal is recognizable without parsing prose.
  */
 function windowErrorOf(assert: () => void): string | undefined {
   try {
     assert();
     return undefined;
   } catch (error) {
-    if (
-      error instanceof ValidationError &&
-      error.details.issues.some(
-        (issue) => issue.code === INVERTED_VALIDITY_WINDOW_CODE,
-      )
-    ) {
-      return `${INVERTED_VALIDITY_WINDOW_CODE}: ${error.message}`;
+    if (error instanceof ValidationError) {
+      const coded = error.details.issues.find(
+        (issue) =>
+          issue.code === INVERTED_VALIDITY_WINDOW_CODE ||
+          issue.code === IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+      );
+      if (coded !== undefined) return `${coded.code}: ${error.message}`;
     }
     return error instanceof Error ? error.message : String(error);
   }
@@ -1166,12 +1168,22 @@ function validateValidityWindow(
  * `valid_from` stays put, so the document's end is held to that bound exactly as
  * `store.nodes.*.update` holds a caller's. Without this an import could still
  * write the inverted row the direct update path refuses, and the insert-shaped
- * check above cannot see it: such a document states no `validFrom` at all.
+ * check above cannot see it: such a document may state no `validFrom` at all.
+ *
+ * The document's `validFrom` is judged here for the same reason: import never
+ * sends it on an update, so a document stating a bound that differs from the
+ * row's is stating one the write will not apply. That is refused per row —
+ * `onConflict: "update"` re-importing a document whose rows were created at a
+ * different instant now reports those rows instead of silently updating their
+ * props under a bound it ignored. `null` is a confirmed open-left window rather
+ * than a stated bound (see `InterchangeNodeSchema`'s `validFrom`) and asserts
+ * nothing.
  */
 function validateUpdateValidityWindow(
   entity: Readonly<{
     kind: string;
     id: string;
+    validFrom?: string | null | undefined;
     validTo?: string | undefined;
   }>,
   storedValidFrom: string | undefined,
@@ -1179,8 +1191,8 @@ function validateUpdateValidityWindow(
   return windowErrorOf(() => {
     assertWritableValidityWindow(
       `${entity.kind} "${entity.id}"`,
-      undefined,
-      storedValidFrom,
+      entity.validFrom ?? undefined,
+      { effectiveValidFrom: storedValidFrom, appliesStatedValidFrom: false },
       entity.validTo,
     );
   });

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -1,4 +1,4 @@
-import { canonicalizeDatabaseTimestamp } from "../../utils/date";
+import { isCanonicalIsoDate, statedBoundMatchesStored } from "../../utils/date";
 
 /**
  * Coalesce dirty-check shared by `upsertById` / `bulkUpsertById`.
@@ -81,11 +81,18 @@ type CurrentWindow = Readonly<{
  * Whether one requested window endpoint differs from the stored one, compared as
  * instants rather than as driver text. An omitted request never changes anything.
  *
- * An UNREPRESENTABLE request always counts as a change, so it reaches the write
- * path that rejects it. Canonicalization maps both an unparseable string and an
- * absent value to `undefined`, so comparing the canonical forms would read a
- * garbage bound against an open window as "no change" and coalesce the write —
- * swallowing a `ValidationError` the caller must see.
+ * A NON-CANONICAL request always counts as a change, so it reaches the write path
+ * that rejects it. Coalescing must not decide whether malformed input is
+ * reported: a bound the write path refuses has to be refused whether or not this
+ * store happens to coalesce, or the flag silently turns a `ValidationError` into
+ * a no-op. That covers the unparseable string and the merely non-canonical one
+ * alike — `"2100-06-01T00:00:00Z"` names the same instant as the stored
+ * `"2100-06-01T00:00:00.000Z"` and is still refused by every write path, because
+ * a variable-width bound mis-sorts against an `asOf` coordinate.
+ *
+ * Counting it as a change is also what lets the comparison canonicalize the
+ * STORED side only ({@link statedBoundMatchesStored}): past this guard the
+ * requested value is known canonical.
  */
 function windowFieldChanges(
   requested: string | undefined,
@@ -94,11 +101,10 @@ function windowFieldChanges(
   if (requested === undefined) {
     return false;
   }
-  const canonicalRequested = canonicalizeDatabaseTimestamp(requested);
-  if (canonicalRequested === undefined) {
+  if (!isCanonicalIsoDate(requested)) {
     return true;
   }
-  return canonicalRequested !== canonicalizeDatabaseTimestamp(stored);
+  return !statedBoundMatchesStored(requested, stored);
 }
 
 /**

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -753,10 +753,21 @@ async function performEdgeUpdate<G extends GraphDef>(
   // against cardinality as inactive — but the end it names must not precede the
   // window it is ending. Reviving a row into a window that closed before the row
   // began means restating the start, so pass `validFrom` alongside `validTo`.
+  //
+  // A stated `validFrom` is STORED only on the resurrecting leg, which
+  // `buildUpdateEdge` selects on `clearDeleted` ALONE — its UPDATE carries no
+  // `deleted_at` predicate, so the leg is taken (and the bound applied) even
+  // where a concurrent writer revived the row between the caller's probe and
+  // this re-read. A plain in-place update stores no lower bound at all, so one
+  // that differs from the bound the row holds is refused rather than accepted
+  // and dropped.
   assertWritableValidityWindow(
     `edge "${id}"`,
     validFrom,
-    existing.valid_from,
+    {
+      effectiveValidFrom: existing.valid_from,
+      appliesStatedValidFrom: options?.clearDeleted === true,
+    },
     validTo,
   );
 
@@ -1212,12 +1223,16 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       if (ifExists === "return") {
         return { edge: rowToEdge(liveRow), action: "found" };
       }
-      // ifExists === "update"
+      // ifExists === "update". `validFrom` is forwarded even though an in-place
+      // update stores no lower bound: the shared write guard is what judges it,
+      // refusing a bound that differs from the one the live row holds instead of
+      // dropping it here where the caller would never hear about it.
       const edge = await executeEdgeUpsertUpdate(
         ctx,
         {
           id: liveRow.id,
           props: validatedProps,
+          ...(validFrom !== undefined && { validFrom }),
           ...(validTo !== undefined && { validTo }),
         },
         backend,
@@ -1420,7 +1435,11 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     fromId: string;
     toKind: string;
     toId: string;
-    /** Reaches the write only on a RESURRECTION, which rewrites both endpoints. */
+    /**
+     * STORED only on a RESURRECTION, which rewrites both endpoints. It is
+     * forwarded on the live-update leg too, where the write guard refuses a
+     * bound that differs from the one the row already holds.
+     */
     validFrom?: string;
     validTo?: string;
   }
@@ -1590,11 +1609,17 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
         );
         results[entry.index] = { edge, action: "resurrected" };
       } else if (ifExists === "update") {
+        // As in the single-item path: `validFrom` is forwarded so the shared
+        // write guard refuses a bound the in-place update cannot store, rather
+        // than dropping it silently here.
         const edge = await executeEdgeUpsertUpdate(
           ctx,
           {
             id: entry.row.id,
             props: entry.validatedProps,
+            ...(entry.validFrom !== undefined && {
+              validFrom: entry.validFrom,
+            }),
             ...(entry.validTo !== undefined && { validTo: entry.validTo }),
           },
           target,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -846,10 +846,18 @@ async function performNodeUpdate<G extends GraphDef>(
     options?.clearDeleted === true && existing.deleted_at !== undefined ?
       nowIso()
     : undefined;
+  // A resurrection STORES a stated `validFrom` (it rewrites the whole window);
+  // an in-place update never does, so one that differs from the row's stored
+  // bound is refused rather than accepted and dropped.
   assertWritableValidityWindow(
     `${kind} "${id}"`,
     validFrom,
-    resurrectionInstant ?? existing.valid_from,
+    resurrectionInstant === undefined ?
+      {
+        effectiveValidFrom: existing.valid_from,
+        appliesStatedValidFrom: false,
+      }
+    : { effectiveValidFrom: resurrectionInstant, appliesStatedValidFrom: true },
     validTo,
   );
 
@@ -901,8 +909,10 @@ async function performNodeUpdateWithResurrectionRecovery<G extends GraphDef>(
     // Upsert still owns the requested properties, so converge by re-reading
     // the now-live row and applying an ordinary update instead of exposing
     // the resurrection UPDATE's internal zero-row sentinel. The peer owns the
-    // new validity window: this late writer updates its props without replacing
-    // the peer's validFrom, matching upsert's documented update semantics.
+    // new validity window: this late writer updates its props and leaves the
+    // peer's validFrom alone, matching upsert's documented update semantics —
+    // so a caller that STATED a lower bound for the resurrection it lost is
+    // refused here rather than silently updated without it.
     const current = await target.getNode(ctx.graphId, input.kind, input.id);
     if (current === undefined || current.deleted_at !== undefined) throw error;
     return performNodeUpdate(ctx, input, target, lock);

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -731,8 +731,14 @@ export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> =
     /**
      * Valid-time start for a created or RESURRECTED edge — on a resurrection it
      * asserts the complete window, so an omitted `validTo` reopens the revived
-     * row. Ignored when an edge is found or updated in place, whose stored lower
-     * bound is history.
+     * row.
+     *
+     * A live edge's stored lower bound is history, so an in-place update
+     * (`ifExists: "update"`) cannot store this: one naming a different instant is
+     * REFUSED with `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`, and one restating the
+     * bound the edge holds is accepted. Ignored when an existing edge is returned
+     * (`ifExists: "return"`), which writes nothing at all — there the window
+     * describes the edge to create if none is found.
      */
     validFrom?: string;
     /**
@@ -864,8 +870,11 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. It has no effect on an update to a live
-   * row, whose lower bound is already history.
+   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * bound, because that row's is already history, so one naming a different
+   * instant is REFUSED (`ValidationError` carrying
+   * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
+   * bound the row already holds is accepted and changes nothing.
    */
   upsertById: (
     id: string,
@@ -882,8 +891,11 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. It has no effect on an update to a live
-   * row, whose lower bound is already history.
+   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * bound, because that row's is already history, so one naming a different
+   * instant is REFUSED (`ValidationError` carrying
+   * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
+   * bound the row already holds is accepted and changes nothing.
    */
   upsertByIdFromRecord: (
     id: string,
@@ -922,8 +934,11 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. It has no effect on an update to a live
-   * row, whose lower bound is already history.
+   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * bound, because that row's is already history, so one naming a different
+   * instant is REFUSED (`ValidationError` carrying
+   * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
+   * bound the row already holds is accepted and changes nothing.
    *
    * **Limitation — a batch cannot hand a unique value from one row to
    * another.** Item order settles which value each id ends up with, but the
@@ -1330,8 +1345,11 @@ export type EdgeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. It has no effect on an update to a live
-   * row, whose lower bound is already history.
+   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * bound, because that row's is already history, so one naming a different
+   * instant is REFUSED (`ValidationError` carrying
+   * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
+   * bound the row already holds is accepted and changes nothing.
    *
    * **Limitation — a batch cannot hand a constrained slot from one edge to
    * another.** Item order settles the final props, but the writes are grouped:
@@ -1414,10 +1432,15 @@ export type EdgeCollection<
    * property fields, only edges whose properties match on those fields are considered.
    * Soft-deleted matches are resurrected when cardinality allows.
    *
-   * `validFrom` only applies on the create branch, defaulting to the
-   * operation's creation timestamp when omitted. `validTo` applies on create,
-   * update, and resurrection, but not when an existing edge is returned
-   * without a write.
+   * `validFrom` applies on the create and RESURRECT branches, defaulting to the
+   * operation's creation timestamp when omitted. On the `ifExists: "update"`
+   * branch a live edge's lower bound is history and cannot be stored, so a
+   * `validFrom` naming a different instant is REFUSED (`ValidationError`
+   * carrying `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`); restating the bound the
+   * edge holds is accepted. A returned existing edge (`ifExists: "return"`)
+   * writes nothing and judges nothing — the window options describe the row to
+   * create if none is found. `validTo` applies on create, update, and
+   * resurrection, but not when an existing edge is returned without a write.
    *
    * @param from - Source node
    * @param to - Target node

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -7,7 +7,11 @@
  * - Sorts correctly as strings
  */
 
-import { INVERTED_VALIDITY_WINDOW_CODE, ValidationError } from "../errors";
+import {
+  IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+  INVERTED_VALIDITY_WINDOW_CODE,
+  ValidationError,
+} from "../errors";
 
 /**
  * ISO 8601 datetime pattern.
@@ -196,6 +200,32 @@ export function validateOptionalCanonicalIsoDate(
 }
 
 /**
+ * Whether a CANONICAL stated bound names the same instant a row already stores.
+ *
+ * The one comparison of a caller's bound against a stored one, so the coalesce
+ * dirty check ("would this write move the window?") and the write guard ("can
+ * this stated bound be applied?") can never disagree about what "the same bound"
+ * means. Two copies of it did disagree — one comparing driver text, one
+ * comparing instants — which is how a re-stated window wrote on one backend and
+ * coalesced on the other.
+ *
+ * Only the STORED side is canonicalized. It arrives as the driver rendered it,
+ * and the dialects do not render a timestamp the same way (SQLite returns the
+ * written text; a Postgres driver may hand back a zoned string equivalent to the
+ * canonical form without being identical to it). The stated side needs no
+ * canonicalization because every write path validates it as canonical first —
+ * which is a PRECONDITION here, not an assumption: a non-canonical stated bound
+ * would compare unequal to an equivalent stored instant and must be rejected by
+ * {@link validateCanonicalIsoDate} rather than silently treated as a mismatch.
+ */
+export function statedBoundMatchesStored(
+  stated: string,
+  stored: string | undefined,
+): boolean {
+  return stated === canonicalizeDatabaseTimestamp(stored);
+}
+
+/**
  * Whether a stated validity window has NEGATIVE width — a row that stopped
  * being true before it started. The one comparison every window refusal is
  * built on, so paths that must report the fault through their own error type
@@ -304,15 +334,93 @@ export function assertOrderedValidityWindow(
 }
 
 /**
+ * What an UPDATE will do with the row's validity lower bound — the two facts the
+ * write guard needs, stated by the writer that knows them.
+ *
+ * Every update path must decide `appliesStatedValidFrom` explicitly, because the
+ * answer is not a property of the guard's other arguments: the same
+ * `(validFrom, storedBound, validTo)` triple is a legal window restatement on a
+ * resurrection and an unappliable bound on an in-place update.
+ */
+export type UpdateValidityLowerBound = Readonly<{
+  /**
+   * The bound the row will hold when the caller states no `validFrom`: the
+   * stored `valid_from` for an in-place update, the write instant for a
+   * resurrection that stamps a new one, `undefined` where there is no bound to
+   * invert against.
+   */
+  effectiveValidFrom: string | undefined;
+  /**
+   * Whether the write STORES a stated `validFrom`. False for an in-place update
+   * of a live row — `buildUpdateNode` / `buildUpdateEdge` rewrite `valid_from`
+   * only on a resurrection — which is what makes a differing stated bound a
+   * refusal rather than a silent drop.
+   */
+  appliesStatedValidFrom: boolean;
+}>;
+
+/**
+ * Refuses a stated `validFrom` the write would not apply.
+ *
+ * A live row's lower bound is HISTORY: it records when the row started being
+ * true, and an in-place update never moves it. Accepting a bound that names a
+ * different instant and then dropping it is the API lying — the caller's stated
+ * window silently is not the stored one, while the write still spends a version
+ * bump and a history row moving nothing. Restating the bound the row already
+ * holds stays legal, so a caller that echoes a row's own window back (a merge
+ * commit, a re-delivered upsert) is unaffected.
+ *
+ * Reached through {@link assertWritableValidityWindow} rather than called
+ * directly, so no writer can accept a lower bound without declaring whether it
+ * applies one.
+ */
+function assertStatedLowerBoundIsApplicable(
+  subject: string,
+  statedValidFrom: string,
+  storedValidFrom: string | undefined,
+): void {
+  if (statedBoundMatchesStored(statedValidFrom, storedValidFrom)) return;
+  const storedDescription =
+    storedValidFrom === undefined ?
+      "the row has no lower bound"
+    : `the row's stored lower bound is "${storedValidFrom}"`;
+  throw new ValidationError(
+    `Unappliable validFrom for ${subject}: stated "${statedValidFrom}", but ${storedDescription} and the row is live.`,
+    {
+      issues: [
+        {
+          path: "validFrom",
+          code: IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+          message: `A live row's lower bound is history and an in-place update never rewrites it, so "${statedValidFrom}" could not be applied.`,
+        },
+      ],
+    },
+    {
+      suggestion:
+        storedValidFrom === undefined ?
+          "Omit validFrom: this row has no lower bound to restate, and only a resurrection can give it one."
+        : `Restate the stored bound ("${storedValidFrom}") or omit validFrom.`,
+    },
+  );
+}
+
+/**
  * THE window-ordering guard a valid-time UPDATE goes through, identically for
  * nodes and edges. Refuses a window of negative width — a row that stopped
  * being true before it started — whether the caller states both endpoints or
- * only the new end.
+ * only the new end. Also refuses a stated lower bound the write cannot apply,
+ * so no update accepts a `validFrom` it will ignore.
  *
- * Two checks, because the two failures deserve different messages: the caller
- * who supplied both endpoints out of order gets told about the pair, and the
- * caller whose lone `validTo` inverts against the bound the row will actually
- * carry gets told which bound that is.
+ * Three checks, because the failures deserve different messages: the caller who
+ * supplied both endpoints out of order gets told about the pair, the caller who
+ * stated a lower bound this write cannot store gets told which bound the row
+ * holds, and the caller whose lone `validTo` inverts against the bound the row
+ * will actually carry gets told which bound that is.
+ *
+ * The stated pair is judged FIRST — an inverted pair is wrong whatever the row
+ * holds — and the applicability of the lower bound before the effective-bound
+ * check, so a caller is told their bound will not be stored rather than being
+ * told about a bound they did not name.
  *
  * INSERTS use {@link assertOrderedValidityWindow} alone. An insert carrying a
  * lone historical `validTo` means "born already ended", and the write instant
@@ -324,22 +432,28 @@ export function assertOrderedValidityWindow(
  * @param subject - Human-readable identification of the row, for the message
  *   (e.g. `Person "01H..."`).
  * @param validFrom - The caller's explicit lower bound, if any.
- * @param fallbackValidFrom - The lower bound the row carries when the caller
- *   supplies none: the stored `valid_from` for an in-place update, the write
- *   instant for a resurrection that resets it, `undefined` where there is no
- *   bound to invert against.
+ * @param lowerBound - What the write will do with the row's lower bound; see
+ *   {@link UpdateValidityLowerBound}.
  * @throws ValidationError with issue code {@link INVERTED_VALIDITY_WINDOW_CODE}
+ *   or {@link IMMUTABLE_VALIDITY_LOWER_BOUND_CODE}
  */
 export function assertWritableValidityWindow(
   subject: string,
   validFrom: string | undefined,
-  fallbackValidFrom: string | undefined,
+  lowerBound: UpdateValidityLowerBound,
   validTo: string | undefined,
 ): void {
   assertOrderedValidityWindow(subject, validFrom, validTo);
+  if (validFrom !== undefined && !lowerBound.appliesStatedValidFrom) {
+    assertStatedLowerBoundIsApplicable(
+      subject,
+      validFrom,
+      lowerBound.effectiveValidFrom,
+    );
+  }
   assertEffectiveValidityLowerBound(
     subject,
-    validFrom ?? fallbackValidFrom,
+    validFrom ?? lowerBound.effectiveValidFrom,
     validTo,
   );
 }

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -63,6 +63,7 @@ import {
   registerTransactionReceiptIntegrationTests,
   registerTraversalIntegrationTests,
   registerTrustedImportIntegrationTests,
+  registerValidityLowerBoundIntegrationTests,
 } from "./integration";
 import type { InspectableHistoryStore } from "./integration/test-context";
 
@@ -174,6 +175,7 @@ export function createIntegrationTestSuite<TNativeTransaction>(
     registerBulkFindHeterogeneousIntegrationTests(context);
     registerBulkUpsertRepeatedIdIntegrationTests(context);
     registerCoalesceUpsertIntegrationTests(context);
+    registerValidityLowerBoundIntegrationTests(context);
     registerContributionDiagnosticIntegrationTests(context);
     registerPredicateIntegrationTests(context);
     registerProvenanceIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
+++ b/packages/typegraph/tests/backends/integration/coalesce-upserts.ts
@@ -18,6 +18,7 @@ import { STORE_RUNTIME } from "../../../src/store/runtime-port";
 import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
 import { requireDefined } from "../../../src/utils/presence";
 import {
+  expectImmutableLowerBoundRefusal,
   withEdgeUpdateCounting,
   withZonedValidityWindowText,
 } from "../../test-utils";
@@ -102,6 +103,14 @@ const WINDOW_END = "2100-06-01T00:00:00.000Z";
 const LATER_WINDOW_END = "2100-09-01T00:00:00.000Z";
 
 /**
+ * {@link WINDOW_END} as a PARSEABLE but non-canonical string: the same instant
+ * without the fixed-width milliseconds. Every write path refuses it — a
+ * variable-width bound mis-sorts against an `asOf` coordinate — so coalescing
+ * must not be able to swallow that refusal by reading it as "unchanged".
+ */
+const NON_CANONICAL_WINDOW_END = "2100-06-01T00:00:00Z";
+
+/**
  * A PAST lower bound, for the cases that name `validFrom` on a CREATE and then
  * read the row back: a row whose window starts in 2100 is not current yet, so a
  * plain `getById` could not see it at all.
@@ -148,6 +157,44 @@ async function seedEndpoints(
     { props: { name: "B" }, id: `${prefix}-b` },
   ]);
   return [requireDefined(alice), requireDefined(bob)];
+}
+
+/**
+ * Runs `attempt` against a coalescing and a non-coalescing store, returning what
+ * each produced (the error, or `undefined` when it resolved).
+ *
+ * The two stores share the suite's one backend — hence the `label` every attempt
+ * must work into its ids, so the second run seeds its own rows instead of
+ * colliding with the first's.
+ */
+async function errorsWithFlagOnAndOff(
+  context: IntegrationTestContext,
+  attempt: (store: CoalesceTestStore, label: string) => Promise<unknown>,
+): Promise<readonly [unknown, unknown]> {
+  const coalescing = await context.createStore(integrationTestGraph, {
+    coalesceUnchangedUpserts: true,
+  });
+  const plain = await context.createStore(integrationTestGraph, {});
+  const withFlagOn: unknown = await attempt(coalescing, "on").catch(
+    (error: unknown) => error,
+  );
+  const withFlagOff: unknown = await attempt(plain, "off").catch(
+    (error: unknown) => error,
+  );
+  return [withFlagOn, withFlagOff];
+}
+
+/**
+ * Asserts both flag states refused with the SAME message. Equality is the
+ * assertion, not merely that each threw: a flag that reported a DIFFERENT
+ * failure would still be the flag changing what the caller is told.
+ */
+function expectSameRefusal(errors: readonly [unknown, unknown]): void {
+  const [withFlagOn, withFlagOff] = errors;
+  expect(withFlagOff).toBeInstanceOf(ValidationError);
+  expect(withFlagOn).toBeInstanceOf(ValidationError);
+  expect((withFlagOn as Error).message).toBe((withFlagOff as Error).message);
+  expect((withFlagOn as Error).message).toMatch(/validTo/);
 }
 
 export function registerCoalesceUpsertIntegrationTests(
@@ -238,7 +285,7 @@ export function registerCoalesceUpsertIntegrationTests(
       ).resolves.toBeDefined();
     });
 
-    it("writes when an explicit validFrom / validTo override is passed", async () => {
+    it("writes when an explicit validTo override is passed", async () => {
       const store = await createCoalesceStore(context);
 
       const created = await store.nodes.Person.upsertById("p4", {
@@ -249,10 +296,63 @@ export function registerCoalesceUpsertIntegrationTests(
       const overridden = await store.nodes.Person.upsertById(
         "p4",
         { name: "Dana", age: 25 },
-        { validFrom: "2020-01-01T00:00:00.000Z" },
+        { validTo: WINDOW_END },
       );
 
       expect(overridden.meta.version).toBe(created.meta.version + 1);
+    });
+
+    it("refuses an explicit validFrom the live row does not hold, rather than writing without it", async () => {
+      // This case asserted the opposite until the honesty rule landed: a
+      // differing `validFrom` blocked coalescing, so the upsert wrote — bumping
+      // the version and capturing history while `buildUpdateNode` left
+      // `valid_from` alone, because only a resurrection rewrites it. The bound
+      // was accepted and dropped; now it is refused.
+      const store = await createCoalesceStore(context);
+
+      const created = await store.nodes.Person.upsertById("p4-immutable", {
+        name: "Dana",
+        age: 25,
+      });
+
+      await expectImmutableLowerBoundRefusal(
+        store.nodes.Person.upsertById(
+          "p4-immutable",
+          { name: "Dana", age: 26 },
+          { validFrom: "2020-01-01T00:00:00.000Z" },
+        ),
+      );
+
+      // Refused whole: no version bump, and the props the caller sent are not
+      // half-applied.
+      const stored = await store.nodes.Person.getById(personId("p4-immutable"));
+      expect(stored?.meta.version).toBe(created.meta.version);
+      expect(stored?.age).toBe(25);
+      expect(canonicalizeDatabaseTimestamp(stored?.meta.validFrom)).toBe(
+        canonicalizeDatabaseTimestamp(created.meta.validFrom),
+      );
+    });
+
+    it("accepts an explicit validFrom that restates the bound the live row holds", async () => {
+      const store = await createCoalesceStore(context);
+
+      const created = await store.nodes.Person.upsertById("p4-restated", {
+        name: "Dana",
+        age: 25,
+      });
+      const storedValidFrom = requireDefined(created.meta.validFrom);
+
+      const updated = await store.nodes.Person.upsertById(
+        "p4-restated",
+        { name: "Dana", age: 26 },
+        { validFrom: storedValidFrom },
+      );
+
+      expect(updated.meta.version).toBe(created.meta.version + 1);
+      expect(updated.age).toBe(26);
+      expect(canonicalizeDatabaseTimestamp(updated.meta.validFrom)).toBe(
+        canonicalizeDatabaseTimestamp(storedValidFrom),
+      );
     });
 
     it("rejects an unrepresentable validTo instead of coalescing it away", async () => {
@@ -960,6 +1060,77 @@ export function registerCoalesceUpsertIntegrationTests(
         expect((bulkError as Error).message).toBe(
           (singleError as Error).message,
         );
+      });
+
+      describe("a non-canonical requested bound reports either way (#421)", () => {
+        // `NON_CANONICAL_WINDOW_END` names the same INSTANT as the stored
+        // `WINDOW_END`, so a comparison that canonicalized the requested side
+        // read it as "no change" and coalesced — with the flag off the same call
+        // reached the write path and raised. The flag decided whether malformed
+        // input was reported at all. Now the requested side must be canonical to
+        // count as unchanged, so both flag states raise the SAME error.
+        //
+        // Equality of the two messages is the assertion, not merely that each
+        // throws: a flag that reports a DIFFERENT failure would still be the flag
+        // changing what the caller is told.
+        it("on a single node upsert", async () => {
+          expectSameRefusal(
+            await errorsWithFlagOnAndOff(context, async (store, label) => {
+              await store.nodes.Person.upsertById(
+                `nc-node-single-${label}`,
+                { name: "Win", age: 1 },
+                { validTo: WINDOW_END },
+              );
+              return store.nodes.Person.upsertById(
+                `nc-node-single-${label}`,
+                { name: "Win", age: 1 },
+                { validTo: NON_CANONICAL_WINDOW_END },
+              );
+            }),
+          );
+        });
+
+        it("on a bulk node upsert", async () => {
+          expectSameRefusal(
+            await errorsWithFlagOnAndOff(context, async (store, label) => {
+              await store.nodes.Person.upsertById(
+                `nc-node-bulk-${label}`,
+                { name: "Win", age: 1 },
+                { validTo: WINDOW_END },
+              );
+              return store.nodes.Person.bulkUpsertById([
+                {
+                  id: `nc-node-bulk-${label}`,
+                  props: { name: "Win", age: 1 },
+                  validTo: NON_CANONICAL_WINDOW_END,
+                },
+              ]);
+            }),
+          );
+        });
+
+        it("on a bulk edge upsert", async () => {
+          expectSameRefusal(
+            await errorsWithFlagOnAndOff(context, async (store, label) => {
+              const [alice, bob] = await seedEndpoints(
+                store,
+                `nc-edge-${label}`,
+              );
+              const item = {
+                id: knowsId(`nc-edge-${label}`),
+                from: alice,
+                to: bob,
+                props: { since: "2020" },
+              } as const;
+              await store.edges.knows.bulkUpsertById([
+                { ...item, validTo: WINDOW_END },
+              ]);
+              return store.edges.knows.bulkUpsertById([
+                { ...item, validTo: NON_CANONICAL_WINDOW_END },
+              ]);
+            }),
+          );
+        });
       });
 
       it("refuses an unrepresentable bound from a bulk EDGE item", async () => {

--- a/packages/typegraph/tests/backends/integration/edge-operations.ts
+++ b/packages/typegraph/tests/backends/integration/edge-operations.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { requireDefined } from "../../../src/utils/presence";
+import { expectImmutableLowerBoundRefusal } from "../../test-utils";
 import { type IntegrationTestContext } from "./test-context";
 
 export function registerEdgeOperationIntegrationTests(
@@ -109,19 +111,79 @@ export function registerEdgeOperationIntegrationTests(
         { role: "Engineer" },
         { validFrom: FIRST_VALID_FROM },
       );
+      // The update states no lower bound: a live edge's is history, so moving
+      // only the end is the whole of what this leg can do. Naming a DIFFERENT
+      // one is refused by the case below rather than silently preserving this
+      // one, which is what this case used to assert.
+      const updated = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Manager" },
+        { ifExists: "update", validTo: SECOND_VALID_TO },
+      );
+
+      expect(updated.action).toBe("updated");
+      expect(updated.edge.id).toBe(created.edge.id);
+      expect(updated.edge.role).toBe("Manager");
+      expect(updated.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(updated.edge.meta.validTo).toBe(SECOND_VALID_TO);
+    });
+
+    it("refuses an endpoint update that states a validFrom the live edge does not hold", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      const created = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM },
+      );
+
+      await expectImmutableLowerBoundRefusal(
+        store.edges.worksAt.getOrCreateByEndpoints(
+          alice,
+          acme,
+          { role: "Manager" },
+          {
+            ifExists: "update",
+            validFrom: SECOND_VALID_FROM,
+            validTo: SECOND_VALID_TO,
+          },
+        ),
+      );
+
+      // Refused whole: neither the props nor the end moved.
+      const stored = await store.edges.worksAt.getById(created.edge.id);
+      expect(stored?.role).toBe("Engineer");
+      expect(stored?.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(stored?.meta.validTo).toBeUndefined();
+    });
+
+    it("restating the bound a live edge already holds is accepted", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM },
+      );
       const updated = await store.edges.worksAt.getOrCreateByEndpoints(
         alice,
         acme,
         { role: "Manager" },
         {
           ifExists: "update",
-          validFrom: SECOND_VALID_FROM,
+          validFrom: FIRST_VALID_FROM,
           validTo: SECOND_VALID_TO,
         },
       );
 
       expect(updated.action).toBe("updated");
-      expect(updated.edge.id).toBe(created.edge.id);
       expect(updated.edge.role).toBe("Manager");
       expect(updated.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
       expect(updated.edge.meta.validTo).toBe(SECOND_VALID_TO);
@@ -157,13 +219,14 @@ export function registerEdgeOperationIntegrationTests(
       expect(results[1]?.edge.meta.validFrom).toBe(SECOND_VALID_FROM);
       expect(results[1]?.edge.meta.validTo).toBe(SECOND_VALID_TO);
 
+      // As on the single path: the update states no lower bound, because a live
+      // edge's is history.
       const [updated] = await store.edges.worksAt.bulkGetOrCreateByEndpoints(
         [
           {
             from: alice,
             to: acme,
             props: { role: "Principal Engineer" },
-            validFrom: SECOND_VALID_FROM,
             validTo: SECOND_VALID_TO,
           },
         ],
@@ -173,6 +236,44 @@ export function registerEdgeOperationIntegrationTests(
       expect(updated?.action).toBe("updated");
       expect(updated?.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
       expect(updated?.edge.meta.validTo).toBe(SECOND_VALID_TO);
+    });
+
+    it("refuses a bulk endpoint update that states a validFrom the live edge does not hold", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      // Left OPEN so the refused row is readable in current mode afterwards.
+      const [created] = await store.edges.worksAt.bulkGetOrCreateByEndpoints([
+        {
+          from: alice,
+          to: acme,
+          props: { role: "Engineer" },
+          validFrom: FIRST_VALID_FROM,
+        },
+      ]);
+
+      await expectImmutableLowerBoundRefusal(
+        store.edges.worksAt.bulkGetOrCreateByEndpoints(
+          [
+            {
+              from: alice,
+              to: acme,
+              props: { role: "Principal Engineer" },
+              validFrom: SECOND_VALID_FROM,
+              validTo: SECOND_VALID_TO,
+            },
+          ],
+          { ifExists: "update" },
+        ),
+      );
+
+      const stored = await store.edges.worksAt.getById(
+        requireDefined(created).edge.id,
+      );
+      expect(stored?.role).toBe("Engineer");
+      expect(stored?.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(stored?.meta.validTo).toBeUndefined();
     });
   });
 }

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -42,3 +42,4 @@ export type { IntegrationTestContext } from "./test-context";
 export { registerTransactionReceiptIntegrationTests } from "./transaction-receipt";
 export { registerTraversalIntegrationTests } from "./traversals";
 export { registerTrustedImportIntegrationTests } from "./trusted-import";
+export { registerValidityLowerBoundIntegrationTests } from "./validity-lower-bound";

--- a/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
+++ b/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
@@ -1,0 +1,474 @@
+/**
+ * A stated `validFrom` is applied or refused — never accepted and ignored.
+ *
+ * An in-place update never rewrites a live row's `valid_from` (only a
+ * resurrection does), so every write path that accepts `validFrom` refuses one
+ * that names an instant the row does not already hold. These cases run on every
+ * backend because the comparison reads a STORED bound as the driver rendered it:
+ * a per-dialect copy would certify a divergence rather than catch it.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  asEdgeId,
+  asNodeId,
+  type EdgeId,
+  IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+  type Node,
+  type NodeId,
+  type Store,
+} from "../../../src";
+import {
+  FORMAT_VERSION,
+  type GraphData,
+  importGraph,
+  type ImportOptions,
+} from "../../../src/interchange";
+import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
+import { requireDefined } from "../../../src/utils/presence";
+import { expectImmutableLowerBoundRefusal } from "../../test-utils";
+import { integrationTestGraph } from "./fixtures";
+import { type IntegrationTestContext } from "./test-context";
+
+/** A bound no row under test can hold: the store stamps creation instants. */
+const FOREIGN_VALID_FROM = "2000-01-01T00:00:00.000Z";
+const OTHER_FOREIGN_VALID_FROM = "2001-01-01T00:00:00.000Z";
+/** A past window for the resurrection cases, ordered and permanently so. */
+const REVIVED_VALID_FROM = "2023-01-01T00:00:00.000Z";
+const REVIVED_VALID_TO = "2024-12-31T23:59:59.999Z";
+
+type PersonNode = Node<typeof integrationTestGraph.nodes.Person.type>;
+
+/** Any store over the integration graph. */
+type LowerBoundTestStore = Store<typeof integrationTestGraph>;
+
+function personId(
+  id: string,
+): NodeId<typeof integrationTestGraph.nodes.Person.type> {
+  return asNodeId(id);
+}
+
+function knowsId(
+  id: string,
+): EdgeId<typeof integrationTestGraph.edges.knows.type> {
+  return asEdgeId(id);
+}
+
+/** Seeds a live Person whose lower bound is the store's own creation instant. */
+function seedPerson(
+  store: LowerBoundTestStore,
+  id: string,
+): Promise<PersonNode> {
+  return store.nodes.Person.upsertById(id, { name: "Win", age: 1 });
+}
+
+/** An interchange document carrying exactly the rows a case is about. */
+function payload(
+  nodes: GraphData["nodes"],
+  edges: GraphData["edges"] = [],
+): GraphData {
+  return {
+    formatVersion: FORMAT_VERSION,
+    exportedAt: new Date().toISOString(),
+    source: { type: "external", description: "validity lower bound" },
+    nodes,
+    edges,
+  };
+}
+
+/**
+ * Import options at a given batch size. Batched and sequential are separate
+ * update legs, so every import case runs at both sizes: a check present on one
+ * leg is silently absent from the other, and which leg runs is a function of
+ * `batchSize` rather than of the caller's intent.
+ */
+function importOptions(batchSize: number): ImportOptions {
+  return {
+    onConflict: "update",
+    onUnknownProperty: "error",
+    validateReferences: true,
+    batchSize,
+    refreshStatistics: false,
+  };
+}
+
+/** The batch sizes that select import's sequential and batched update legs. */
+const IMPORT_BATCH_SIZES = [1, 100] as const;
+
+export function registerValidityLowerBoundIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("a stated validFrom is applied or refused", () => {
+    /**
+     * Registers the refusal cases against one `coalesceUnchangedUpserts` state.
+     * Both are exercised, because the refusal is a property of the WRITE path:
+     * coalescing decides whether an unchanged replay writes at all, and must not
+     * decide whether a bound the write cannot apply is reported.
+     */
+    function registerFlagCases(coalesceUnchangedUpserts: boolean): void {
+      {
+        it("refuses a differing validFrom on a single node upsert", async () => {
+          const store = await context.createStore(integrationTestGraph, {
+            coalesceUnchangedUpserts,
+          });
+          const id = `vlb-single-${String(coalesceUnchangedUpserts)}`;
+          const seeded = await seedPerson(store, id);
+
+          await expectImmutableLowerBoundRefusal(
+            store.nodes.Person.upsertById(
+              id,
+              { name: "Win", age: 2 },
+              { validFrom: FOREIGN_VALID_FROM },
+            ),
+          );
+
+          const stored = await store.nodes.Person.getById(personId(id));
+          expect(stored?.meta.version).toBe(seeded.meta.version);
+          expect(stored?.age).toBe(1);
+        });
+
+        it("refuses a differing validFrom on a bulk node upsert", async () => {
+          const store = await context.createStore(integrationTestGraph, {
+            coalesceUnchangedUpserts,
+          });
+          const id = `vlb-bulk-${String(coalesceUnchangedUpserts)}`;
+          const seeded = await seedPerson(store, id);
+
+          await expectImmutableLowerBoundRefusal(
+            store.nodes.Person.bulkUpsertById([
+              {
+                id,
+                props: { name: "Win", age: 2 },
+                validFrom: FOREIGN_VALID_FROM,
+              },
+            ]),
+          );
+
+          const stored = await store.nodes.Person.getById(personId(id));
+          expect(stored?.meta.version).toBe(seeded.meta.version);
+          expect(stored?.age).toBe(1);
+        });
+
+        it("refuses a differing validFrom on a bulk edge upsert", async () => {
+          const store = await context.createStore(integrationTestGraph, {
+            coalesceUnchangedUpserts,
+          });
+          const suffix = String(coalesceUnchangedUpserts);
+          const [alice, bob] = await store.nodes.Person.bulkCreate([
+            { props: { name: "A" }, id: `vlb-edge-a-${suffix}` },
+            { props: { name: "B" }, id: `vlb-edge-b-${suffix}` },
+          ]);
+          const edgeId = knowsId(`vlb-edge-${suffix}`);
+          await store.edges.knows.bulkUpsertById([
+            {
+              id: edgeId,
+              from: requireDefined(alice),
+              to: requireDefined(bob),
+              props: { since: "first" },
+            },
+          ]);
+
+          await expectImmutableLowerBoundRefusal(
+            store.edges.knows.bulkUpsertById([
+              {
+                id: edgeId,
+                from: requireDefined(alice),
+                to: requireDefined(bob),
+                props: { since: "second" },
+                validFrom: FOREIGN_VALID_FROM,
+              },
+            ]),
+          );
+
+          const stored = await store.edges.knows.getById(edgeId);
+          expect(stored?.since).toBe("first");
+        });
+      }
+    }
+
+    describe("coalescing on", () => {
+      registerFlagCases(true);
+    });
+
+    describe("coalescing off", () => {
+      registerFlagCases(false);
+    });
+
+    it("accepts a validFrom that restates the bound a live row holds", async () => {
+      const store = await context.createStore(integrationTestGraph, {});
+      const seeded = await seedPerson(store, "vlb-restated");
+      const storedValidFrom = requireDefined(seeded.meta.validFrom);
+
+      const updated = await store.nodes.Person.upsertById(
+        "vlb-restated",
+        { name: "Win", age: 2 },
+        { validFrom: storedValidFrom },
+      );
+
+      expect(updated.age).toBe(2);
+      expect(canonicalizeDatabaseTimestamp(updated.meta.validFrom)).toBe(
+        canonicalizeDatabaseTimestamp(storedValidFrom),
+      );
+    });
+
+    it("still applies an explicit validFrom when the upsert RESURRECTS a node", async () => {
+      // The resurrection leg rewrites the whole window, so the bound IS stored
+      // and no refusal may arise on it — the escape hatch the refusal leaves
+      // open (issues #406 / #420).
+      const store = await context.createStore(integrationTestGraph, {});
+      const created = await seedPerson(store, "vlb-revived");
+      await store.nodes.Person.delete(created.id);
+
+      const revived = await store.nodes.Person.upsertById(
+        "vlb-revived",
+        { name: "Win", age: 3 },
+        { validFrom: REVIVED_VALID_FROM, validTo: REVIVED_VALID_TO },
+      );
+
+      expect(canonicalizeDatabaseTimestamp(revived.meta.validFrom)).toBe(
+        REVIVED_VALID_FROM,
+      );
+      expect(canonicalizeDatabaseTimestamp(revived.meta.validTo)).toBe(
+        REVIVED_VALID_TO,
+      );
+    });
+
+    it("still applies an explicit validFrom when a BULK upsert resurrects a node", async () => {
+      const store = await context.createStore(integrationTestGraph, {});
+      const created = await seedPerson(store, "vlb-revived-bulk");
+      await store.nodes.Person.delete(created.id);
+
+      const [revived] = await store.nodes.Person.bulkUpsertById([
+        {
+          id: "vlb-revived-bulk",
+          props: { name: "Win", age: 3 },
+          validFrom: REVIVED_VALID_FROM,
+          validTo: REVIVED_VALID_TO,
+        },
+      ]);
+
+      expect(
+        canonicalizeDatabaseTimestamp(requireDefined(revived).meta.validFrom),
+      ).toBe(REVIVED_VALID_FROM);
+    });
+
+    describe("a repeated id in one batch", () => {
+      // #404 routes a repeated id to the update path against the row the batch
+      // just queued. The bound that update is judged against is the one the row
+      // ACTUALLY holds when the update runs — creates run before updates, so it
+      // is readable by then — which is what keeps this rule identical to the
+      // sequential one.
+      it("refuses a later copy that differs from the queued create's NAMED bound", async () => {
+        const store = await context.createStore(integrationTestGraph, {
+          coalesceUnchangedUpserts: true,
+        });
+
+        await expectImmutableLowerBoundRefusal(
+          store.nodes.Person.bulkUpsertById([
+            {
+              id: "vlb-queued-named",
+              props: { name: "Win", age: 1 },
+              validFrom: FOREIGN_VALID_FROM,
+            },
+            {
+              id: "vlb-queued-named",
+              props: { name: "Win", age: 2 },
+              validFrom: OTHER_FOREIGN_VALID_FROM,
+            },
+          ]),
+        );
+
+        // All or nothing: the create rolls back with the refused update.
+        expect(
+          await store.nodes.Person.getById(personId("vlb-queued-named")),
+        ).toBeUndefined();
+      });
+
+      it("accepts a later copy that restates the queued create's NAMED bound", async () => {
+        const store = await context.createStore(integrationTestGraph, {
+          coalesceUnchangedUpserts: true,
+        });
+
+        const results = await store.nodes.Person.bulkUpsertById([
+          {
+            id: "vlb-queued-restated",
+            props: { name: "Win", age: 1 },
+            validFrom: FOREIGN_VALID_FROM,
+          },
+          {
+            id: "vlb-queued-restated",
+            props: { name: "Win", age: 2 },
+            validFrom: FOREIGN_VALID_FROM,
+          },
+        ]);
+
+        expect(requireDefined(results[1]).age).toBe(2);
+        expect(
+          canonicalizeDatabaseTimestamp(
+            requireDefined(results[1]).meta.validFrom,
+          ),
+        ).toBe(FOREIGN_VALID_FROM);
+      });
+
+      it("refuses a later copy that differs from the bound the BACKEND stamped", async () => {
+        // The queued create omitted `validFrom`, so the batch cannot know the
+        // bound the row will hold and treats any stated one as a change — it
+        // does not guess. The write it therefore performs is what reaches the
+        // guard, and the guard judges against the bound the row really holds.
+        // A copy naming an instant that is not that bound is refused there,
+        // which is why the batch-local "unknowable" rule costs no honesty: the
+        // deferral ends at a check that can see the truth. (Its companion —
+        // naming the stamped instant EXACTLY, which is accepted and writes —
+        // is pinned in the bulk window cases.)
+        const store = await context.createStore(integrationTestGraph, {
+          coalesceUnchangedUpserts: true,
+        });
+
+        await expectImmutableLowerBoundRefusal(
+          store.nodes.Person.bulkUpsertById([
+            { id: "vlb-queued-stamped", props: { name: "Win", age: 1 } },
+            {
+              id: "vlb-queued-stamped",
+              props: { name: "Win", age: 2 },
+              validFrom: FOREIGN_VALID_FROM,
+            },
+          ]),
+        );
+
+        expect(
+          await store.nodes.Person.getById(personId("vlb-queued-stamped")),
+        ).toBeUndefined();
+      });
+    });
+
+    describe("interchange import under onConflict update", () => {
+      // Import's update legs send the document's `validTo` and never its
+      // `validFrom`, so a document stating a bound the target row does not hold
+      // is stating one the write will ignore. It is reported PER ROW — one
+      // refused row does not abort the import — which is the same shape #406 gave
+      // the inverted-window refusal here.
+      //
+      // Both batch sizes, because batched and sequential are separate update
+      // legs: a check on one leg is silently absent from the other, and which
+      // leg runs is a function of `batchSize` rather than of the caller's intent.
+      // On both backends, because the bound this compares against is read back as
+      // the DRIVER rendered it.
+      it("reports a node whose document states a bound the live row does not hold", async () => {
+        for (const batchSize of IMPORT_BATCH_SIZES) {
+          const store = await context.createStore(integrationTestGraph, {});
+          const id = `vlb-import-${String(batchSize)}`;
+          const seeded = await store.nodes.Person.upsertById(id, {
+            name: "Win",
+            age: 1,
+          });
+
+          const result = await importGraph(
+            store,
+            payload([
+              {
+                kind: "Person",
+                id,
+                properties: { name: "Changed", age: 2 },
+                validFrom: FOREIGN_VALID_FROM,
+              },
+            ]),
+            importOptions(batchSize),
+          );
+
+          expect(result.errors).toHaveLength(1);
+          expect(requireDefined(result.errors[0]).id).toBe(id);
+          expect(requireDefined(result.errors[0]).error).toContain(
+            IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+          );
+          expect(result.nodes.updated).toBe(0);
+
+          // The refused row keeps its props AND its bound: reporting it is not a
+          // partial write.
+          const stored = await store.nodes.Person.getById(personId(id));
+          expect(stored?.name).toBe("Win");
+          expect(canonicalizeDatabaseTimestamp(stored?.meta.validFrom)).toBe(
+            canonicalizeDatabaseTimestamp(seeded.meta.validFrom),
+          );
+        }
+      });
+
+      it("accepts a node document that restates the bound the live row holds", async () => {
+        for (const batchSize of IMPORT_BATCH_SIZES) {
+          const store = await context.createStore(integrationTestGraph, {});
+          const id = `vlb-import-ok-${String(batchSize)}`;
+          const seeded = await store.nodes.Person.upsertById(id, {
+            name: "Win",
+            age: 1,
+          });
+
+          const result = await importGraph(
+            store,
+            payload([
+              {
+                kind: "Person",
+                id,
+                properties: { name: "Changed", age: 2 },
+                validFrom: canonicalizeDatabaseTimestamp(seeded.meta.validFrom),
+              },
+            ]),
+            importOptions(batchSize),
+          );
+
+          expect(result.errors).toEqual([]);
+          expect(result.nodes.updated).toBe(1);
+          const updated = await store.nodes.Person.getById(personId(id));
+          expect(updated?.name).toBe("Changed");
+        }
+      });
+
+      it("reports an edge whose document states a bound the live edge does not hold", async () => {
+        for (const batchSize of IMPORT_BATCH_SIZES) {
+          const store = await context.createStore(integrationTestGraph, {});
+          const suffix = String(batchSize);
+          const [alice, bob] = await store.nodes.Person.bulkCreate([
+            { props: { name: "A" }, id: `vlb-import-edge-a-${suffix}` },
+            { props: { name: "B" }, id: `vlb-import-edge-b-${suffix}` },
+          ]);
+          const edgeId = `vlb-import-edge-${suffix}`;
+          await store.edges.knows.bulkUpsertById([
+            {
+              id: knowsId(edgeId),
+              from: requireDefined(alice),
+              to: requireDefined(bob),
+              props: { since: "first" },
+            },
+          ]);
+
+          const result = await importGraph(
+            store,
+            payload(
+              [],
+              [
+                {
+                  kind: "knows",
+                  id: edgeId,
+                  from: {
+                    kind: "Person",
+                    id: `vlb-import-edge-a-${suffix}`,
+                  },
+                  to: { kind: "Person", id: `vlb-import-edge-b-${suffix}` },
+                  properties: { since: "second" },
+                  validFrom: FOREIGN_VALID_FROM,
+                },
+              ],
+            ),
+            importOptions(batchSize),
+          );
+
+          expect(result.errors).toHaveLength(1);
+          expect(requireDefined(result.errors[0]).error).toContain(
+            IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+          );
+          expect(result.edges.updated).toBe(0);
+          const storedEdge = await store.edges.knows.getById(knowsId(edgeId));
+          expect(storedEdge?.since).toBe("first");
+        }
+      });
+    });
+  });
+}

--- a/packages/typegraph/tests/create-round-trips.test.ts
+++ b/packages/typegraph/tests/create-round-trips.test.ts
@@ -9,7 +9,11 @@ import {
   type TransactionBackend,
 } from "../src";
 import { type SqlFragment } from "../src/query/sql-fragment";
-import { createInitializedStore, createTestBackend } from "./test-utils";
+import {
+  createInitializedStore,
+  createTestBackend,
+  expectImmutableLowerBoundRefusal,
+} from "./test-utils";
 
 const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
 const Author = defineNode("Author", {
@@ -231,14 +235,45 @@ describe("create-path round trips", () => {
     );
     await store.nodes.Person.delete(original.id);
 
-    const revived = await store.nodes.Person.upsertById(
-      "contended-upsert",
-      { name: "Late writer" },
-      { validFrom: "2025-01-01T00:00:00.000Z" },
-    );
+    // No stated lower bound, so the recovery re-run is an ordinary update: the
+    // peer owns the revived row's window and this writer owns its props.
+    const revived = await store.nodes.Person.upsertById("contended-upsert", {
+      name: "Late writer",
+    });
 
     expect(revived.name).toBe("Late writer");
     expect(revived.meta.validFrom).toBe(PEER_RESURRECTION_VALID_FROM);
+  });
+
+  it("refuses an upsert that loses a resurrection race while stating its own validFrom", async () => {
+    // The recovery path converts a lost resurrection into an ordinary update of
+    // the peer's now-live row, and an ordinary update cannot store a lower
+    // bound. This case asserted that the stated bound was dropped and the props
+    // applied anyway; the write now refuses instead of quietly landing under a
+    // window the caller did not ask for.
+    const store = await createInitializedStore(
+      plainGraph,
+      peerResurrectionBackend("contended-refused"),
+    );
+    const original = await store.nodes.Person.create(
+      { name: "Original" },
+      { id: "contended-refused" },
+    );
+    await store.nodes.Person.delete(original.id);
+
+    await expectImmutableLowerBoundRefusal(
+      store.nodes.Person.upsertById(
+        "contended-refused",
+        { name: "Late writer" },
+        { validFrom: "2025-01-01T00:00:00.000Z" },
+      ),
+    );
+
+    // Nothing landed. The refusal rolls its transaction back, and the simulated
+    // peer's resurrection is injected INSIDE that transaction, so the row is
+    // left tombstoned rather than revived — which is also the proof the late
+    // writer's props did not half-apply.
+    expect(await store.nodes.Person.getById(original.id)).toBeUndefined();
   });
 
   it("skips the identity fold probe for generated ids", async () => {

--- a/packages/typegraph/tests/inverted-validity-window.test.ts
+++ b/packages/typegraph/tests/inverted-validity-window.test.ts
@@ -98,6 +98,13 @@ const LATER = "2022-01-01T00:00:00.000Z";
  * A two-node export whose `person-1` row carries `window` — which REPLACES both
  * endpoints, so passing `validFrom: undefined` states the born-ended shape
  * rather than inheriting the exported creation instant.
+ *
+ * Every OTHER row is stripped of its exported `validFrom`. An exported bound
+ * names the SOURCE store's creation instant, and importing it over a target row
+ * created separately states a lower bound the update cannot apply — refused with
+ * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`. These fixtures isolate the
+ * inverted-window refusal, so the rows they are not about must not raise a
+ * second, unrelated one.
  */
 async function documentWithWindow(
   window: Readonly<{
@@ -112,7 +119,9 @@ async function documentWithWindow(
   return {
     ...exported,
     nodes: exported.nodes.map((node) =>
-      node.id === "person-1" ? { ...node, ...window } : node,
+      node.id === "person-1" ?
+        { ...node, ...window }
+      : { ...node, validFrom: undefined },
     ),
   };
 }

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -14,6 +14,8 @@ import {
   createAdapterStoreWithSchema,
   createStore,
   createStoreWithSchema,
+  IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+  ValidationError,
 } from "../src";
 import type { AnySqliteDatabase } from "../src/backend/drizzle/execution";
 import type { SqliteTables } from "../src/backend/sqlite";
@@ -420,6 +422,25 @@ export function withZonedValidityWindowText(base: GraphBackend): GraphBackend {
         options,
       ),
   };
+}
+
+/**
+ * Asserts an operation was refused for stating a `validFrom` the write could not
+ * apply, identified by its stable issue code rather than by message text.
+ *
+ * One helper for every path, because the point of the refusal is that it is the
+ * SAME refusal wherever a stated lower bound meets a live row — a per-file copy
+ * asserting "some ValidationError" would let one path drift to a different
+ * failure and still pass.
+ */
+export async function expectImmutableLowerBoundRefusal(
+  operation: Promise<unknown>,
+): Promise<void> {
+  await expect(operation).rejects.toThrow(ValidationError);
+  const error = await operation.catch((error_: unknown) => error_);
+  expect(
+    (error as ValidationError).details.issues.map((issue) => issue.code),
+  ).toContain(IMMUTABLE_VALIDITY_LOWER_BOUND_CODE);
 }
 
 export { generateSqliteDDL } from "../src/backend/drizzle/ddl";


### PR DESCRIPTION
Two validity-window inputs the write layer accepted and then did not honor. Both are the same fault — a stated value silently dropped — and both live in the comparison seam #418 unified, so they land together.

## #419 — a stated `validFrom` against a LIVE row

`buildUpdateNode` / `buildUpdateEdge` rewrite `valid_from` only on a resurrection, so an in-place update stores no lower bound at all. Naming one that differed from the row's blocked coalescing, so the upsert WROTE — version bump, history row — while the bound went nowhere. Reproduced before changing anything, on every path: the write landed, `valid_from` was untouched, and `version` went 1 → 2.

It now raises a `ValidationError` carrying the new exported issue code `IMMUTABLE_VALIDITY_LOWER_BOUND`, naming both the stated instant and the stored one so the caller can restate it without a second read.

### Where the refusal lives

In `assertWritableValidityWindow` — the guard every valid-time update already goes through — so single and bulk share it by construction rather than by two checks agreeing. Its `fallbackValidFrom` parameter becomes an `UpdateValidityLowerBound` record whose `appliesStatedValidFrom` each writer must state, because the answer is not derivable from the other arguments: the same `(validFrom, storedBound, validTo)` triple is a legal window restatement on a resurrection and an unappliable bound on an in-place update. Making it a required field means a new writer cannot be added without deciding.

The two dialect answers differ, and both follow the SQL rather than an assumption:

| Writer | `appliesStatedValidFrom` | Why |
| --- | --- | --- |
| node update | `clearDeleted && row was tombstoned` | `buildUpdateNode`'s resurrecting leg carries `AND deleted_at IS NOT NULL`, so a `clearDeleted` update of a live row cannot land at all |
| edge update | `clearDeleted` alone | `buildUpdateEdge`'s resurrecting leg has NO `deleted_at` predicate, so it is taken — and the bound applied — even where a peer revived the row between the probe and the re-read |

A node upsert that loses a resurrection race is the case that makes the node answer load-bearing: the resurrecting UPDATE matches nothing, `performNodeUpdateWithResurrectionRecovery` re-reads and retries as an ordinary update, and the stated bound is refused there rather than quietly dropped.

### Two paths never reached the guard

- **`getOrCreateByEndpoints` and its bulk twin** dropped `validFrom` on the `ifExists: "update"` leg before any guard ran. Both now forward it. The write still ignores it exactly as before; the guard is what refuses a differing one.
- **Interchange import's four update legs** send only `validTo`, so a document stating a bound the target row does not hold was stating one import would not apply. `validateUpdateValidityWindow` now judges it, reported per row like the inverted-window refusal beside it — one bad row does not abort the import. `null` stays a confirmed open-left window, not a stated bound.

### The queued-state reconciliation (#404 / #418)

The bulk path needs no check of its own, and that is the point rather than an omission. Traced end to end: `bulkUpsertById` routes each update through `executeNodeUpsertUpdate` / `executeEdgeUpsertUpdate`, which land in the same `performNodeUpdate` / `performEdgeUpdate` the single path uses. So the two rules compose without either being weakened:

- A batch **cannot** know the bound a queued create leaves behind when the create omitted one — the backend stamps it — so `windowAfterUpsertCreate` leaves it `undefined` and the batch-local comparison treats any stated bound as a change. It writes rather than guessing (#418's rule, unchanged).
- That write then reaches the operations-layer guard, which re-reads the row and judges against the bound it ACTUALLY holds.

So the deferral costs no honesty: the check it defers to can see the truth. A later copy naming the stamped instant exactly is accepted and writes — #418's frozen-clock pin, still green untouched — and one naming anything else is refused there. Where the queued create NAMED its bound, the bound is knowable and a differing later copy refuses. All three are pinned.

## #421 — a non-canonical requested bound

With coalescing on, `"2100-06-01T00:00:00Z"` against a stored `"2100-06-01T00:00:00.000Z"` canonicalized to the same instant, compared as unchanged, and skipped the write — swallowing the `ValidationError` the same call raises with the flag off. An unrelated performance flag decided whether malformed input was reported.

`windowFieldChanges` now counts a non-canonical REQUESTED bound as a change, so it reaches the write path and raises identically either way. That also simplifies the comparison to what it should always have been: only the STORED side is canonicalized, since past that guard the requested side is known canonical.

The new `statedBoundMatchesStored` is the single owner of that comparison, shared by the coalesce dirty check and the write guard — the "one predicate, one owner" rule applied to the exact drift it names, raw-text versus canonical-instant window compares, which is what made a re-stated window write on one backend and coalesce on the other.

#418's zoned-stored pins stay green untouched: those state CANONICAL bounds against zoned STORED text, and the stored side still canonicalizes.

## Load-bearing tests

Every guarding case fails with its fix reverted, verified one mechanism at a time so none rides on a neighbour:

| Reverted | Failing cases |
| --- | --- |
| the refusal in `assertWritableValidityWindow` | 14 |
| `windowFieldChanges`' non-canonical rule | 3 (and only those) |
| `getOrCreateByEndpoints` forwarding `validFrom` | 2 (and only those) |
| import passing the document's `validFrom` | 2 (and only those) |

`tests/backends/integration/validity-lower-bound.ts` runs in the shared suite, so both dialects certify the same outcome — the comparison reads a stored bound as the driver rendered it, which is precisely what a per-dialect test would certify a divergence in. It covers single and bulk upsert × nodes and edges × coalescing ON and OFF, the repeated-id cases, and import at both batch sizes (batched and sequential are separate update legs). Regression pins hold the escape hatch open: an explicit `validFrom` is still STORED when an upsert resurrects a node, single and bulk.

The #421 cases assert the flag-on and flag-off errors are the SAME message, not merely that each throws — a flag reporting a DIFFERENT failure would still be the flag changing what the caller is told.

## Four pins flipped, deliberately

Each asserted the behavior the ruling refuses, so each now asserts the refusal with the honest half of its original purpose kept as a companion case. Called out explicitly because a flipped assertion is the kind of change that should never pass unnoticed:

- **`writes when an explicit validFrom / validTo override is passed`** — the churn without movement itself. Split into a `validTo` case that still writes and a refusal that also shows no version bump and no half-applied props.
- **`updates validTo but preserves validFrom when updating by endpoints`** and its bulk twin — they named a DIFFERENT bound and asserted the stored one survived. Now they state no lower bound, which is the whole of what that leg can do, with the differing bound refused alongside and a third case accepting a restated one.
- **`lets an upsert overwrite a peer resurrection without replacing its validity window`** — a caller that loses a resurrection race while STATING a bound is refused rather than landing under the peer's window. The no-bound case still converges, so the recovery path stays pinned.

`documentWithWindow` also strips the exported `validFrom` from the rows its cases are not about: an exported bound names the SOURCE store's creation instant, so importing it over a separately created target row now raises the new refusal, which would have added an unrelated second error to fixtures that pin one thing.

## What deliberately stays legal

- **Restating the bound a row already holds** — nothing to apply, so nothing is ignored. A merge commit or a re-delivered upsert that echoes a row's own window back is unaffected, and `tests/graph-merge` is green on both backends without a single change: `edge-repoint` already omits an inherited survivor's `validFrom`, and `canonicalize` sources a committed row's window from the committed row.
- **A create or a resurrection** — both store a stated bound, and are how a row gets a different lower bound.
- **Zero-width windows.**
- **`getOrCreateByEndpoints` returning an existing edge** — it performs no write, so it judges nothing; its window options describe the row to create if absent.

## Caveat worth reading before merge

Replaying an `includeTemporal: true` export over rows that were created separately now reports those rows instead of updating their props under a lower bound it ignored. That is the honest outcome — the imported graph would not have matched the document — but it is a real behavior change for cross-graph sync, so it is documented in `interchange.md` with the three ways out (omit `validFrom` from the update document, export with `includeTemporal: false`, or import into a fresh graph) and called out in the changeset. Note the scope: only a bound that DIFFERS from the target row's stored one reports, so a replay whose documents restate the target's own bounds, or omit them, is unaffected.

Two changesets, both minor — previously-accepted writes now refuse, the same precedent as the window refusals in this release train. #421 gets its own, as its issue asked.

Closes #419
Closes #421
