### PR TITLE
ci: mutate a pull request's changed lines, not its whole files

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,101 @@
+name: Mutation
+
+on:
+  pull_request:
+    paths:
+      - "packages/typegraph/src/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutation-diff:
+    name: Mutation (changed lines)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Compute changed-line mutation scope
+        id: scope
+        working-directory: packages/typegraph
+        env:
+          MUTATION_BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          scope="$(node --import tsx scripts/mutation-diff.ts --csv)"
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+
+      - name: Report empty scope
+        if: steps.scope.outputs.scope == ''
+        run: |
+          {
+            echo "## Changed-line mutation testing"
+            echo
+            echo "No mutable changes: this pull request changes no mutable lines under \`packages/typegraph/src\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report mutation scope
+        if: steps.scope.outputs.scope != ''
+        env:
+          MUTATION_SCOPE: ${{ steps.scope.outputs.scope }}
+        run: |
+          {
+            echo "## Changed-line mutation scope"
+            echo
+            echo '```text'
+            tr ',' '\n' <<<"$MUTATION_SCOPE"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Restore Stryker incremental cache
+        if: steps.scope.outputs.scope != ''
+        uses: actions/cache@v4
+        with:
+          path: packages/typegraph/.stryker-cache
+          key: stryker-diff-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.head_ref }}
+          restore-keys: |
+            stryker-diff-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      # Stryker drives vitest through its runner plugin, which bypasses the
+      # package's `pretest` hook, so the native addon check runs explicitly.
+      - name: Ensure native SQLite bindings
+        if: steps.scope.outputs.scope != ''
+        working-directory: packages/typegraph
+        run: node --import tsx scripts/ensure-native-sqlite.ts
+
+      - name: Run mutation testing on changed lines
+        if: steps.scope.outputs.scope != ''
+        working-directory: packages/typegraph
+        env:
+          MUTATION_SCOPE: ${{ steps.scope.outputs.scope }}
+        run: pnpm exec stryker run stryker.diff.config.json --mutate "$MUTATION_SCOPE"
+
+      - name: Summarize mutation results
+        if: ${{ always() && steps.scope.outputs.scope != '' }}
+        working-directory: packages/typegraph
+        run: node --import tsx scripts/mutation-summary.ts reports/mutation-diff/mutation.json
+
+      - name: Upload mutation report
+        if: ${{ always() && steps.scope.outputs.scope != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-diff-report
+          path: packages/typegraph/reports/mutation-diff/mutation.json
+          if-no-files-found: warn

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -268,6 +268,58 @@ Key options:
 - `incremental: true` - Caches results between runs for faster iteration
 - `coverageAnalysis: "perTest"` - Only runs relevant tests per mutant
 
+### Changed-Line Mutation Testing on Pull Requests
+
+[`.github/workflows/mutation.yml`](../.github/workflows/mutation.yml) runs Stryker on every pull request
+that touches `packages/typegraph/src`, mutating **only the lines that pull request changed**. It computes
+the scope from the diff, runs `stryker.diff.config.json` against it, and writes the changed-line mutation
+score, the per-status counts, and the location of every survived mutant to the job summary. The full JSON
+report is attached as a workflow artifact.
+
+Why changed lines rather than whole files: a whole-file run over the files a typical pull request touches
+takes hours, which is unaffordable per pull request, while the same run restricted to the changed line
+ranges finishes in minutes. Scoping to the diff also keeps the signal actionable — every survivor it
+reports is a mutant in code this pull request wrote, not pre-existing debt in a file it happened to open.
+
+The scope script and the config it feeds:
+
+```bash
+cd packages/typegraph
+
+# List the changed-line ranges this branch would mutate
+pnpm test:mutation:diff
+
+# Run Stryker against exactly those ranges
+npx stryker run stryker.diff.config.json --mutate "$(node --import tsx scripts/mutation-diff.ts --csv)"
+```
+
+`scripts/mutation-diff.ts` diffs `$MUTATION_BASE_REF...HEAD` (default base: `origin/main`, three-dot, so
+only this branch's own commits count) over `packages/typegraph/src/**/*.ts`, skipping `.d.ts` files,
+deleted files, and files with deletions only. Ranges separated by fewer than ten unchanged lines merge
+into one entry. It emits `src/<path>.ts:<start>-<end>` entries — one per line by default, comma-joined
+with `--csv`, or a JSON array with `--json` — and exits 0 with no entries when nothing is mutable, which
+is the signal CI uses to skip the run entirely.
+
+`stryker.diff.config.json` runs the default vitest config, so the dry run executes the whole suite
+(roughly 25 minutes) before any mutant is tested; per-mutant runs are cheap after that because
+`coverageAnalysis: "perTest"` narrows each mutant to the tests that actually cover it. That trade is
+deliberate: a narrower dry-run scope is faster but risks attributing a mutant's survival to a test file
+the scoped config never loaded. `ignoreStatic: true` drops mutants that only execute while a module
+loads — killing those requires reloading the environment and re-running everything, and they say little
+about the changed behavior. The incremental cache (`.stryker-cache/incremental-diff.json`) is restored
+across runs on the same branch, so a follow-up push only retests what moved.
+
+The threshold is `break: null`: surviving mutants annotate the pull request but do not fail it. Making
+the job blocking is a one-line change to that field once the signal is quiet across the fleet.
+
+**Triage discipline.** A survived mutant on a changed line gets one of two things before the pull request
+merges: a test that kills it, or a written justification in the pull request description explaining why
+the mutation is not observable behavior (an unreachable defensive branch, a log message that is not part
+of any contract). Survivors on lines the pull request did not change are pre-existing debt and are out of
+scope for that review — the job never reports them. This is the mechanical enforcement of the
+[Load-Bearing Tests](../AGENTS.md#load-bearing-tests) rule: a test that cannot fail when the behavior it
+guards breaks is coverage theater, and a surviving mutant is the machine finding exactly that.
+
 ## Writing Tests
 
 ### Test Structure
@@ -386,7 +438,11 @@ tests). The jobs are:
 
 A separate [release workflow](../.github/workflows/release.yml) packs the npm
 tarball after CI passes and smoke-imports every public subpath (ESM + CJS)
-before publishing.
+before publishing. A separate
+[mutation workflow](../.github/workflows/mutation.yml) runs changed-line
+mutation testing on pull requests that touch `packages/typegraph/src`; it
+annotates the pull request but does not gate it (see
+[Changed-Line Mutation Testing on Pull Requests](#changed-line-mutation-testing-on-pull-requests)).
 
 To reproduce the core gate locally before pushing, run `pnpm fix && pnpm
 typecheck && pnpm test`, then `pnpm test:postgres` (Docker-backed) for any

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -134,7 +134,8 @@
     "test:coverage": "vitest run --coverage",
     "test:coverage:merge": "vitest run --merge-reports=.vitest-reports --coverage",
     "test:mutation": "stryker run",
-    "test:mutation:critical": "stryker run stryker.critical.config.json"
+    "test:mutation:critical": "stryker run stryker.critical.config.json",
+    "test:mutation:diff": "node --import tsx scripts/mutation-diff.ts"
   },
   "keywords": [
     "graph",

--- a/packages/typegraph/scripts/mutation-diff.ts
+++ b/packages/typegraph/scripts/mutation-diff.ts
@@ -1,0 +1,247 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Computes the Stryker `--mutate` scope for a branch: the line ranges it
+ * changed under `packages/typegraph/src`, emitted as
+ * `src/<path>.ts:<start>-<end>` entries relative to the package directory
+ * (Stryker runs from there).
+ *
+ * The base ref comes from `MUTATION_BASE_REF` (default `origin/main`) and the
+ * diff uses three-dot semantics, so only the branch's own commits count — not
+ * whatever landed on the base since it forked.
+ *
+ * Output modes:
+ *
+ * - (no flag) one entry per line, for reading
+ * - `--csv` entries joined by commas, for `stryker run --mutate "$(...)"`
+ * - `--json` a JSON array, for tooling
+ *
+ * An empty scope is not a failure: `--json` prints `[]`, the other modes print
+ * nothing, and every mode exits 0 so callers can skip the mutation run.
+ */
+
+type LineRange = Readonly<{ start: number; end: number }>;
+type FileScope = Readonly<{ file: string; ranges: readonly LineRange[] }>;
+type OutputMode = "csv" | "json" | "lines";
+
+const DEFAULT_BASE_REF = "origin/main";
+
+/**
+ * Two changed regions separated by fewer than this many unchanged lines merge
+ * into a single entry. Mutating a handful of untouched lines between two edits
+ * costs little and keeps the `--mutate` argument short.
+ */
+const RANGE_MERGE_GAP = 10;
+
+const HUNK_HEADER_PATTERN = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+function runGit(repositoryRoot: string, args: readonly string[]): string {
+  return execFileSync("git", [...args], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+}
+
+function parseOutputMode(args: readonly string[]): OutputMode {
+  if (args.length === 0) return "lines";
+  if (args.length === 1) {
+    if (args[0] === "--json") return "json";
+    if (args[0] === "--csv") return "csv";
+  }
+  throw new Error(
+    `Unknown arguments: ${args.join(" ")}. Pass --json, --csv, or nothing.`,
+  );
+}
+
+function resolveBaseRef(): string {
+  const configured = process.env["MUTATION_BASE_REF"];
+  if (configured === undefined || configured.trim() === "") {
+    return DEFAULT_BASE_REF;
+  }
+  return configured.trim();
+}
+
+function assertBaseRefIsResolvable(repositoryRoot: string, ref: string): void {
+  try {
+    runGit(repositoryRoot, [
+      "rev-parse",
+      "--verify",
+      "--quiet",
+      `${ref}^{commit}`,
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Base ref "${ref}" is not available locally. Fetch it (git fetch origin) or set MUTATION_BASE_REF.`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Reads the post-image path out of a `+++ ` diff header. Returns undefined for
+ * `/dev/null`, which is how git spells a deleted file — deletions leave no
+ * lines to mutate. Renames report their new path here, which is the path
+ * Stryker must be given.
+ */
+function readTargetPath(headerLine: string): string | undefined {
+  const target = headerLine.slice("+++ ".length);
+  if (target === "/dev/null") return undefined;
+  const unquoted =
+    target.startsWith('"') && target.endsWith('"') ?
+      (JSON.parse(target) as string)
+    : target;
+  return unquoted.startsWith("b/") ? unquoted.slice(2) : unquoted;
+}
+
+function isMutableSourceFile(
+  repositoryPath: string,
+  sourcePrefix: string,
+): boolean {
+  if (!repositoryPath.startsWith(sourcePrefix)) return false;
+  if (!repositoryPath.endsWith(".ts")) return false;
+  return !repositoryPath.endsWith(".d.ts");
+}
+
+/**
+ * Parses a `--unified=0` diff into the added/modified line ranges per file.
+ * `+++` is only honored in a file header (between `diff --git` and the first
+ * hunk) so that added source lines beginning with `++ ` cannot be mistaken for
+ * one.
+ */
+function parseChangedRanges(
+  diff: string,
+  sourcePrefix: string,
+): readonly FileScope[] {
+  const rangesByFile = new Map<string, LineRange[]>();
+  let currentFile: string | undefined;
+  let inFileHeader = false;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      currentFile = undefined;
+      inFileHeader = true;
+      continue;
+    }
+
+    if (inFileHeader && line.startsWith("+++ ")) {
+      currentFile = readTargetPath(line);
+      continue;
+    }
+
+    const hunk = HUNK_HEADER_PATTERN.exec(line);
+    if (hunk === null) continue;
+    inFileHeader = false;
+
+    if (currentFile === undefined) continue;
+    if (!isMutableSourceFile(currentFile, sourcePrefix)) continue;
+
+    const start = Number(hunk[1]);
+    // A hunk with a post-image count of 0 removed lines without adding any.
+    const addedLineCount = hunk[2] === undefined ? 1 : Number(hunk[2]);
+    if (addedLineCount === 0) continue;
+
+    const ranges = rangesByFile.get(currentFile) ?? [];
+    ranges.push({ start, end: start + addedLineCount - 1 });
+    rangesByFile.set(currentFile, ranges);
+  }
+
+  return [...rangesByFile].map(([file, ranges]) => ({
+    file,
+    ranges: mergeRanges(ranges),
+  }));
+}
+
+function mergeRanges(ranges: readonly LineRange[]): readonly LineRange[] {
+  const sorted = ranges.toSorted((left, right) => left.start - right.start);
+  const merged: LineRange[] = [];
+
+  for (const range of sorted) {
+    const previous = merged.at(-1);
+    if (
+      previous === undefined ||
+      range.start - previous.end - 1 >= RANGE_MERGE_GAP
+    ) {
+      merged.push(range);
+      continue;
+    }
+    merged[merged.length - 1] = {
+      start: previous.start,
+      end: Math.max(previous.end, range.end),
+    };
+  }
+
+  return merged;
+}
+
+function formatEntries(
+  scopes: readonly FileScope[],
+  packagePrefix: string,
+): readonly string[] {
+  return scopes.flatMap((scope) => {
+    const packageRelativeFile = path.posix.relative(packagePrefix, scope.file);
+    return scope.ranges.map(
+      (range) => `${packageRelativeFile}:${range.start}-${range.end}`,
+    );
+  });
+}
+
+function printEntries(entries: readonly string[], mode: OutputMode): void {
+  switch (mode) {
+    case "json": {
+      console.log(JSON.stringify(entries));
+      return;
+    }
+    case "csv": {
+      if (entries.length > 0) console.log(entries.join(","));
+      return;
+    }
+    case "lines": {
+      for (const entry of entries) console.log(entry);
+      return;
+    }
+  }
+}
+
+function main(): void {
+  const mode = parseOutputMode(process.argv.slice(2));
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const packageDirectory = path.dirname(scriptDirectory);
+  const repositoryRoot = runGit(packageDirectory, [
+    "rev-parse",
+    "--show-toplevel",
+  ]).trim();
+  const packagePrefix = path
+    .relative(repositoryRoot, packageDirectory)
+    .replaceAll(path.sep, "/");
+  const sourcePrefix = `${packagePrefix}/src/`;
+  const baseRef = resolveBaseRef();
+
+  assertBaseRefIsResolvable(repositoryRoot, baseRef);
+
+  const diff = runGit(repositoryRoot, [
+    "-c",
+    "core.quotePath=false",
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--no-relative",
+    `${baseRef}...HEAD`,
+    "--",
+    `${packagePrefix}/src`,
+  ]);
+
+  printEntries(
+    formatEntries(parseChangedRanges(diff, sourcePrefix), packagePrefix),
+    mode,
+  );
+}
+
+try {
+  main();
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/typegraph/scripts/mutation-summary.ts
+++ b/packages/typegraph/scripts/mutation-summary.ts
@@ -1,0 +1,204 @@
+import { appendFile, readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Renders a Stryker JSON report as a markdown summary: the mutation score, the
+ * per-status counts, and every survived mutant with its location. Written to
+ * `$GITHUB_STEP_SUMMARY` when that is set, otherwise to stdout.
+ *
+ * A missing report is reported, not thrown: the mutation run that should have
+ * produced it has already failed the job on its own, and a second failure here
+ * would only bury the real error.
+ */
+
+type MutantLocation = Readonly<{
+  start: Readonly<{ line: number; column: number }>;
+}>;
+
+type Mutant = Readonly<{
+  mutatorName: string;
+  status: string;
+  replacement?: string;
+  location: MutantLocation;
+}>;
+
+type MutationReport = Readonly<{
+  files?: Readonly<Record<string, Readonly<{ mutants?: readonly Mutant[] }>>>;
+}>;
+
+type Survivor = Readonly<{
+  file: string;
+  line: number;
+  column: number;
+  mutatorName: string;
+  replacement: string;
+}>;
+
+const DEFAULT_REPORT_PATH = "reports/mutation-diff/mutation.json";
+const MAXIMUM_LISTED_SURVIVORS = 50;
+const MAXIMUM_REPLACEMENT_LENGTH = 80;
+
+function countByStatus(report: MutationReport): ReadonlyMap<string, number> {
+  const counts = new Map<string, number>();
+  for (const file of Object.values(report.files ?? {})) {
+    for (const mutant of file.mutants ?? []) {
+      counts.set(mutant.status, (counts.get(mutant.status) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+/**
+ * Stryker reports file keys relative to the project root, but a plugin is free
+ * to report an absolute path. Shorten those to a project-relative path only
+ * when they actually live under it; anything else stays verbatim rather than
+ * becoming a wall of `../`.
+ */
+function displayPath(file: string): string {
+  if (!path.isAbsolute(file)) return file;
+  const relative = path.relative(process.cwd(), file);
+  return relative.startsWith("..") ? file : relative;
+}
+
+function compareSurvivors(left: Survivor, right: Survivor): number {
+  if (left.file !== right.file) return left.file < right.file ? -1 : 1;
+  if (left.line !== right.line) return left.line - right.line;
+  return left.column - right.column;
+}
+
+function collectSurvivors(report: MutationReport): readonly Survivor[] {
+  const survivors = Object.entries(report.files ?? {}).flatMap(
+    ([file, fileResult]) =>
+      (fileResult.mutants ?? [])
+        .filter((mutant) => mutant.status === "Survived")
+        .map((mutant) => ({
+          file: displayPath(file),
+          line: mutant.location.start.line,
+          column: mutant.location.start.column,
+          mutatorName: mutant.mutatorName,
+          replacement: formatReplacement(mutant.replacement),
+        })),
+  );
+  return survivors.toSorted((left, right) => compareSurvivors(left, right));
+}
+
+function formatReplacement(replacement: string | undefined): string {
+  if (replacement === undefined) return "";
+  const singleLine = replacement.replaceAll(/\s+/g, " ").trim();
+  const truncated =
+    singleLine.length > MAXIMUM_REPLACEMENT_LENGTH ?
+      `${singleLine.slice(0, MAXIMUM_REPLACEMENT_LENGTH)}…`
+    : singleLine;
+  return truncated.replaceAll("|", String.raw`\|`).replaceAll("`", "'");
+}
+
+function formatScore(counts: ReadonlyMap<string, number>): string {
+  const detected = (counts.get("Killed") ?? 0) + (counts.get("Timeout") ?? 0);
+  const undetected =
+    (counts.get("Survived") ?? 0) + (counts.get("NoCoverage") ?? 0);
+  const valid = detected + undetected;
+  if (valid === 0) return "No mutants were generated for the changed lines.";
+  const score = ((detected / valid) * 100).toFixed(2);
+  return `Mutation score on changed lines: **${score}%** (${detected} of ${valid} mutants detected).`;
+}
+
+function renderSurvivorTable(
+  survivors: readonly Survivor[],
+): readonly string[] {
+  if (survivors.length === 0) {
+    return ["No survived mutants on the changed lines."];
+  }
+
+  const listed = survivors.slice(0, MAXIMUM_LISTED_SURVIVORS);
+  const rows = listed.map(
+    (survivor) =>
+      `| \`${survivor.file}:${survivor.line}:${survivor.column}\` | ${survivor.mutatorName} | \`${survivor.replacement}\` |`,
+  );
+  const overflow =
+    survivors.length > listed.length ?
+      [
+        "",
+        `…and ${survivors.length - listed.length} more. The full report is attached as a workflow artifact.`,
+      ]
+    : [];
+
+  return [
+    `### Survived mutants (${survivors.length})`,
+    "",
+    "| Location | Mutator | Replacement |",
+    "| --- | --- | --- |",
+    ...rows,
+    ...overflow,
+    "",
+    "Each survivor on a changed line needs a test that kills it or a written justification in the pull request description.",
+  ];
+}
+
+function renderSummary(report: MutationReport): string {
+  const counts = countByStatus(report);
+  const statuses = [
+    "Killed",
+    "Survived",
+    "Timeout",
+    "NoCoverage",
+    "CompileError",
+    "RuntimeError",
+    "Ignored",
+  ] as const;
+
+  return [
+    "## Changed-line mutation testing",
+    "",
+    formatScore(counts),
+    "",
+    `| ${statuses.join(" | ")} |`,
+    `| ${statuses.map(() => "---").join(" | ")} |`,
+    `| ${statuses.map((status) => counts.get(status) ?? 0).join(" | ")} |`,
+    "",
+    ...renderSurvivorTable(collectSurvivors(report)),
+  ].join("\n");
+}
+
+async function readReport(
+  reportPath: string,
+): Promise<MutationReport | undefined> {
+  try {
+    return JSON.parse(await readFile(reportPath, "utf8")) as MutationReport;
+  } catch {
+    return undefined;
+  }
+}
+
+async function emit(markdown: string): Promise<void> {
+  const summaryPath = process.env["GITHUB_STEP_SUMMARY"];
+  if (summaryPath === undefined || summaryPath === "") {
+    console.log(markdown);
+    return;
+  }
+  await appendFile(summaryPath, `${markdown}\n`);
+}
+
+async function main(): Promise<void> {
+  const reportPath = process.argv[2] ?? DEFAULT_REPORT_PATH;
+  const report = await readReport(reportPath);
+
+  if (report === undefined) {
+    await emit(
+      [
+        "## Changed-line mutation testing",
+        "",
+        `No mutation report was found at \`${reportPath}\`; the mutation run did not complete.`,
+      ].join("\n"),
+    );
+    return;
+  }
+
+  await emit(renderSummary(report));
+}
+
+try {
+  await main();
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/typegraph/stryker.diff.config.json
+++ b/packages/typegraph/stryker.diff.config.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/core/schema/stryker-schema.json",
+  "packageManager": "pnpm",
+  "testRunner": "vitest",
+  "plugins": ["@stryker-mutator/vitest-runner"],
+  "ignorePatterns": ["dist", "node_modules"],
+  "reporters": ["clear-text", "json", "progress"],
+  "jsonReporter": {
+    "fileName": "reports/mutation-diff/mutation.json"
+  },
+  "thresholds": {
+    "high": 90,
+    "low": 80,
+    "break": null
+  },
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 45,
+  "concurrency": 4,
+  "coverageAnalysis": "perTest",
+  "ignoreStatic": true,
+  "incremental": true,
+  "incrementalFile": ".stryker-cache/incremental-diff.json"
+}


### PR DESCRIPTION
Three review rounds on the 0.46.0 release each surfaced defects of the same shape: tautological tests, assertions that hold for every value, and new code with no mutant-killing test at all. Scoped mutation testing finds all three mechanically, but only if it is cheap enough to run per pull request — the 0.46.0 batches took roughly two hours as whole-file runs, and 5-25 minutes once the mutants were restricted to the lines the branch actually changed. This adds that second thing to CI.

`packages/typegraph/scripts/mutation-diff.ts` computes the scope. It diffs `$MUTATION_BASE_REF...HEAD` (default `origin/main`, three-dot so only the branch's own commits count, not whatever landed on the base since it forked) with `--unified=0` over `packages/typegraph/src/**/*.ts`, skips `.d.ts` files, deleted files, and deletion-only hunks, follows renames to their new path, merges ranges separated by fewer than ten unchanged lines, and emits `src/<path>.ts:<start>-<end>` entries relative to the package directory Stryker runs from. Entries print one per line by default, comma-joined with `--csv`, or as a JSON array with `--json`; an empty scope exits 0 with no entries, which is how the workflow decides to skip the run entirely. Locally: `pnpm test:mutation:diff` to see the scope, `npx stryker run stryker.diff.config.json --mutate "$(node --import tsx scripts/mutation-diff.ts --csv)"` to act on it.

`stryker.diff.config.json` pairs that scope with `coverageAnalysis: perTest`, `ignoreStatic: true`, and an incremental cache keyed per branch. It deliberately uses the default vitest config rather than a narrowed one: the whole-suite dry run costs about 25 minutes and dominates the wall clock, but a narrower dry-run scope risks attributing a mutant's survival to a test file that was never loaded, and per-mutant runs are cheap once coverage is known. A scoped run is worth having only if its verdicts are true.

`.github/workflows/mutation.yml` runs on pull requests touching `packages/typegraph/src` and mirrors the CI workflow's setup. It writes the changed-line mutation score, the per-status counts, and the file:line of every survived mutant to the job summary, and uploads the JSON report as an artifact. The threshold is `break: null`, so survivors annotate a pull request without blocking it; the path to making the job blocking is flipping that one field once the signal is quiet across the fleet.

The triage discipline the job assumes, documented in `docs/TESTING.md`: a survived mutant on a changed line gets either a test that kills it or a written justification in the pull request description. Survivors on unchanged lines are pre-existing debt, out of scope for that review, and the job never reports them.