### PR TITLE
perf(test): run the PostgreSQL lane file-parallel with an explicit connection budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,11 @@ jobs:
           # Use 127.0.0.1 instead of localhost to avoid IPv6 resolution issues
           POSTGRES_URL: postgresql://typegraph:typegraph@127.0.0.1:5432/typegraph_test
           VITEST_SHARD: ${{ matrix.shard }}
+          # An externally supplied POSTGRES_URL defaults to ONE worker because
+          # the script cannot know the server's connection budget. This job
+          # raised max_connections to 400 in the step above, so it states the
+          # cap that budget affords (the runners have 4 cores).
+          TYPEGRAPH_PG_MAX_WORKERS: 4
 
       - name: Run PostgreSQL perf sanity
         if: ${{ matrix.shard == '1/2' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The lane runs its suites file-parallel and budgets connections for
+      # it (see scripts/test-postgres.sh). The bundled docker-compose.yml
+      # raises max_connections at container start, but GitHub service
+      # containers accept no command override, so this step raises it the
+      # only way available: ALTER SYSTEM, restart, and prove the setting
+      # took before any test connects.
+      - name: Raise PostgreSQL connection budget for parallel suites
+        run: |
+          set -euo pipefail
+          container='${{ job.services.postgres.id }}'
+          docker exec "$container" psql -U typegraph -d typegraph_test -c "ALTER SYSTEM SET max_connections = 400"
+          docker restart "$container"
+          for _ in {1..30}; do
+            if docker exec "$container" pg_isready -U typegraph -d typegraph_test >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+          applied="$(docker exec "$container" psql -U typegraph -d typegraph_test -tAc 'SHOW max_connections')"
+          if [[ "$applied" != "400" ]]; then
+            echo "max_connections is $applied, expected 400" >&2
+            exit 1
+          fi
+
       - name: Run PostgreSQL integration tests
         run: pnpm --filter @nicia-ai/typegraph test:postgres
         env:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -158,13 +158,34 @@ Consequences worth knowing:
   with `WITH (FORCE)`. Concurrent lanes (for example one per worktree) must use
   separate base databases.
 - The per-suite databases are deliberately left behind so a failure stays
-  inspectable; the next run recreates them. The Docker lane is ephemeral, so
-  this only accumulates on a long-lived external server.
+  inspectable; the next run recreates them. The Docker container is also left
+  running between runs (`up -d --wait` reuses it idempotently), both to skip
+  the start/stop cycle and so one invocation's exit cannot tear the server out
+  from under a concurrent invocation. Set `TYPEGRAPH_POSTGRES_DOWN=1` to
+  restore teardown-on-exit, or stop it manually with
+  `docker compose -f packages/typegraph/docker-compose.yml down`. A warm
+  server carries no state a run depends on — the per-suite databases are
+  dropped and recreated — but leftovers from inspection do accumulate until
+  the container is recreated.
 
-`scripts/test-postgres.sh` still passes `--no-file-parallelism`, now purely for
-the connection budget (`max_connections` is 100 and each worker holds pools),
-not for isolation. Reproducing a single failure with a parallel invocation of a
-few files is safe.
+The lane runs its suites **file-parallel**, and the worker count follows who
+provisioned the server. The bundled `docker-compose.yml` starts PostgreSQL
+with `max_connections=400`, which affords `min(6, cores)` workers (each worker
+holds at least one pool, and graph-merge property fixtures keep several
+backends alive at once). An externally supplied `POSTGRES_URL` has an unknown
+connection budget, so it defaults to **one** worker — the pre-parallel
+behaviour — until you state a cap explicitly with `TYPEGRAPH_PG_MAX_WORKERS`
+after budgeting your server the same way (CI does exactly this: it raises
+`max_connections` on its service container, then sets the cap beside that
+step). "sorry, too many clients already" mid-suite is the symptom of a cap
+your server cannot fund. The graph-merge and pglite vitest projects, which
+serialize their files in the default SQLite lane, opt back into parallelism
+only when the lane actually runs multi-worker. Reproducing a single failure
+with a parallel invocation of a few files remains safe at any worker count —
+isolation comes from the per-suite databases, never from serialization. The
+one-invocation-per-`POSTGRES_URL` restriction above still applies: worker
+parallelism is *within* an invocation, and concurrent invocations still race
+on database names.
 
 ## Coverage
 

--- a/packages/typegraph/docker-compose.yml
+++ b/packages/typegraph/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       POSTGRES_USER: typegraph
       POSTGRES_PASSWORD: typegraph
       POSTGRES_DB: typegraph_test
+    # The test lane runs suites file-parallel, and every worker holds at
+    # least one pool (graph-merge property fixtures hold several). The
+    # default max_connections=100 is what previously forced the lane
+    # serial; 400 gives 6 workers headroom without approaching memory
+    # limits on a tmpfs-backed throwaway server.
+    command: postgres -c max_connections=400
     ports:
       - "5432:5432"
     healthcheck:

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -9,8 +9,10 @@ PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
 DEFAULT_POSTGRES_URL="postgresql://typegraph:typegraph@localhost:5432/typegraph_test"
 
 # If POSTGRES_URL is already set (e.g., in CI), use the existing database
+EXTERNAL_POSTGRES=0
 if [[ -n "$POSTGRES_URL" ]]; then
   echo "Using existing PostgreSQL at $POSTGRES_URL"
+  EXTERNAL_POSTGRES=1
 else
   # Start PostgreSQL locally. `up -d --wait` is idempotent, so a container
   # left warm by a previous run is reused as-is, and the container is left
@@ -44,24 +46,42 @@ fi
 #
 # The worker cap exists for the CONNECTION BUDGET, not for isolation: every
 # worker holds at least one pool against the same server, and the graph-merge
-# property fixtures keep several backends alive at once. The bundled
-# docker-compose.yml raises max_connections to 400, which gives 6 workers
-# comfortable headroom; an externally supplied POSTGRES_URL (CI) must budget
-# its own server the same way or lower the cap ("sorry, too many clients
-# already" is the symptom of getting this wrong). Graph-merge fixtures
-# additionally isolate per-fixture schemas.
+# property fixtures keep several backends alive at once. Parallelism is
+# therefore tied to WHO provisioned the server:
+#
+# - The bundled docker-compose.yml raises max_connections to 400, which gives
+#   6 workers comfortable headroom, so the compose path defaults to
+#   min(6, cores).
+# - An externally supplied POSTGRES_URL has an UNKNOWN budget — a stock
+#   server's max_connections=100 cannot absorb six workers' pools, and "sorry,
+#   too many clients already" mid-suite is the failure mode — so it defaults
+#   to the pre-parallel behaviour of ONE worker. An owner who has budgeted
+#   their server states the cap explicitly via TYPEGRAPH_PG_MAX_WORKERS
+#   (CI does: it raises max_connections on its service container first, and
+#   the workflow sets the cap beside that step).
+#
+# Graph-merge fixtures additionally isolate per-fixture schemas.
 #
 # With POSTGRES_URL set, the graph-merge backendMatrix() gains its
 # server-Postgres entry, so those suites run on SQLite, PGlite, AND the
 # production pg driver in this lane.
 CORES="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
-MAX_WORKERS="${TYPEGRAPH_PG_MAX_WORKERS:-$(( CORES < 6 ? CORES : 6 ))}"
+if [[ -n "${TYPEGRAPH_PG_MAX_WORKERS:-}" ]]; then
+  MAX_WORKERS="$TYPEGRAPH_PG_MAX_WORKERS"
+elif [[ "$EXTERNAL_POSTGRES" == "1" ]]; then
+  MAX_WORKERS=1
+else
+  MAX_WORKERS=$(( CORES < 6 ? CORES : 6 ))
+fi
 
 # The graph-merge and pglite vitest projects serialize their files by
 # default to keep PGlite startup latency out of the default lane; this
-# lane provisions the connection budget those files need to run
-# file-parallel, so it opts them back in (see vitest.config.ts).
-export TYPEGRAPH_HEAVY_FILE_PARALLELISM=1
+# lane opts them back in only when it actually runs multi-worker (see
+# vitest.config.ts) — with one worker the opt-in would change nothing but
+# still advertise a parallelism the connection budget never approved.
+if [[ "$MAX_WORKERS" -gt 1 ]]; then
+  export TYPEGRAPH_HEAVY_FILE_PARALLELISM=1
+fi
 
 echo "Running PostgreSQL tests ($MAX_WORKERS workers)..."
 vitest_args=(

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -12,16 +12,25 @@ DEFAULT_POSTGRES_URL="postgresql://typegraph:typegraph@localhost:5432/typegraph_
 if [[ -n "$POSTGRES_URL" ]]; then
   echo "Using existing PostgreSQL at $POSTGRES_URL"
 else
-  # Start PostgreSQL locally
-  echo "Starting PostgreSQL..."
+  # Start PostgreSQL locally. `up -d --wait` is idempotent, so a container
+  # left warm by a previous run is reused as-is, and the container is left
+  # running afterwards: repeat runs skip the start/stop cycle, and one
+  # invocation's exit can no longer tear the server out from under a
+  # concurrent invocation (which shows up as a wall of ECONNREFUSED
+  # failures that reads as a code regression). Per-suite databases are
+  # dropped and recreated by each run, so a warm server carries no state
+  # between runs. Set TYPEGRAPH_POSTGRES_DOWN=1 to restore teardown, or
+  # stop it manually: docker compose -f packages/typegraph/docker-compose.yml down
+  echo "Starting PostgreSQL (reused if already running)..."
   docker compose -f "$PACKAGE_DIR/docker-compose.yml" up -d --wait
 
-  # Ensure cleanup on exit (success or failure)
-  cleanup() {
-    echo "Stopping PostgreSQL..."
-    docker compose -f "$PACKAGE_DIR/docker-compose.yml" down
-  }
-  trap cleanup EXIT
+  if [[ "${TYPEGRAPH_POSTGRES_DOWN:-}" == "1" ]]; then
+    cleanup() {
+      echo "Stopping PostgreSQL..."
+      docker compose -f "$PACKAGE_DIR/docker-compose.yml" down
+    }
+    trap cleanup EXIT
+  fi
 
   POSTGRES_URL="$DEFAULT_POSTGRES_URL"
 fi
@@ -31,22 +40,33 @@ fi
 # Each suite provisions its own database off this URL (see
 # `tests/postgres-test-database.ts`), so the schema-destructive DDL in their
 # `beforeAll`/`beforeEach` hooks can no longer reach another suite's tables.
-# Isolation therefore holds by construction, and running any subset of these
-# files in parallel — the usual way to reproduce one failure — is safe.
+# Isolation therefore holds by construction, and the suites run file-parallel.
 #
-# `--no-file-parallelism` stays for the CONNECTION BUDGET, not for isolation:
-# every worker holds at least one pool against the same server, the
-# graph-merge property fixtures keep several backends alive at once, and
-# `max_connections` is 100 ("sorry, too many clients already"). Graph-merge
-# fixtures additionally isolate per-fixture schemas.
+# The worker cap exists for the CONNECTION BUDGET, not for isolation: every
+# worker holds at least one pool against the same server, and the graph-merge
+# property fixtures keep several backends alive at once. The bundled
+# docker-compose.yml raises max_connections to 400, which gives 6 workers
+# comfortable headroom; an externally supplied POSTGRES_URL (CI) must budget
+# its own server the same way or lower the cap ("sorry, too many clients
+# already" is the symptom of getting this wrong). Graph-merge fixtures
+# additionally isolate per-fixture schemas.
 #
 # With POSTGRES_URL set, the graph-merge backendMatrix() gains its
 # server-Postgres entry, so those suites run on SQLite, PGlite, AND the
 # production pg driver in this lane.
-echo "Running PostgreSQL tests..."
+CORES="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+MAX_WORKERS="${TYPEGRAPH_PG_MAX_WORKERS:-$(( CORES < 6 ? CORES : 6 ))}"
+
+# The graph-merge and pglite vitest projects serialize their files by
+# default to keep PGlite startup latency out of the default lane; this
+# lane provisions the connection budget those files need to run
+# file-parallel, so it opts them back in (see vitest.config.ts).
+export TYPEGRAPH_HEAVY_FILE_PARALLELISM=1
+
+echo "Running PostgreSQL tests ($MAX_WORKERS workers)..."
 vitest_args=(
   run
-  --no-file-parallelism
+  --maxWorkers="$MAX_WORKERS"
 )
 
 if [[ -n "${VITEST_SHARD:-}" ]]; then

--- a/packages/typegraph/vitest.config.ts
+++ b/packages/typegraph/vitest.config.ts
@@ -114,8 +114,11 @@ export default defineConfig({
           // These suites provision in-process Postgres instances and exercise
           // persistence plus bulk-write paths. Keep their normal startup and
           // teardown latency from competing with file-parallel unit tests or
-          // the default five-second budget.
-          fileParallelism: false,
+          // the default five-second budget. The PostgreSQL lane opts back in:
+          // it provisions an explicit server connection budget for parallel
+          // files (scripts/test-postgres.sh), and the 60s budgets below
+          // already absorb concurrent PGlite startup latency.
+          fileParallelism: process.env.TYPEGRAPH_HEAVY_FILE_PARALLELISM === "1",
           testTimeout: 60_000,
           hookTimeout: 60_000,
         },
@@ -130,7 +133,8 @@ export default defineConfig({
           // use generous budgets so normal PGlite startup/cleanup latency does
           // not masquerade as a correctness failure. Scoped to this project so
           // the rest of the package keeps default parallelism + fast timeouts.
-          fileParallelism: false,
+          // The PostgreSQL lane opts back in (see the pglite project note).
+          fileParallelism: process.env.TYPEGRAPH_HEAVY_FILE_PARALLELISM === "1",
           testTimeout: 60_000,
           hookTimeout: 60_000,
         },


### PR DESCRIPTION
The PostgreSQL lane ran its ~100 files strictly serially — 27 minutes wall — for two stated reasons, neither of which was isolation (per-suite databases make parallel files safe by construction): the server's default `max_connections=100`, and PGlite startup latency in the graph-merge/pglite vitest projects.

Both constraints are now provisioned instead of worked around, and the worker count follows who provisioned the server. The bundled compose file raises `max_connections` to 400 with the budget math in a comment, so the compose path runs `min(6, nproc)` workers. An externally supplied `POSTGRES_URL` has an unknown budget a stock server cannot fund six workers against, so it keeps the pre-parallel single worker until its owner states a cap with `TYPEGRAPH_PG_MAX_WORKERS`. CI does exactly that: service containers accept no command override, so the workflow raises the budget the only way available — `ALTER SYSTEM`, restart, and prove the setting took before any test connects — and states `TYPEGRAPH_PG_MAX_WORKERS: 4` beside that step. The heavy vitest projects (graph-merge, pglite) opt back into file parallelism only when the lane actually runs multi-worker, so the default `pnpm test` lane is unchanged and the projects' existing 60s budgets absorb concurrent PGlite startup.

The lane also stops tearing the container down on exit: `up -d --wait` reuses a warm server idempotently, repeat runs skip the start/stop cycle, and one invocation's exit can no longer kill a concurrent invocation's server mid-run — which presents as a wall of ECONNREFUSED failures indistinguishable from a code regression, and did exactly that during 0.46.0 development. Per-suite databases are dropped and recreated by each run, so a warm server carries no state between runs. `TYPEGRAPH_POSTGRES_DOWN=1` restores teardown. `docs/TESTING.md` describes the new lifecycle, the provisioning-tied worker defaults, and the unchanged one-invocation-per-`POSTGRES_URL` restriction (worker parallelism is within an invocation; concurrent invocations still race on database names).

Measured on a 16-core box shared with other workloads, running the full lane at `release/0.46.0-hardening` (a superset of main's suites): 1633s serial before; 481s and 553s on consecutive runs after, ~5× effective file parallelism, three consecutive fully green runs (100 files, 3,505 tests) with the 400-connection budget confirmed applied and no connection exhaustion. All three worker-default paths verified behaviorally: external URL with no cap → 1 worker, external with an explicit cap → that cap, compose path → 6.

No changeset: this changes developer and CI tooling only, not the published package.
