### PR TITLE
fix: preserve event-time bounds on endpoint edge upserts

### DIFF
--- a/.changeset/preserve-edge-lower-bounds.md
+++ b/.changeset/preserve-edge-lower-bounds.md
@@ -1,0 +1,10 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Extend `onImmutableLowerBound: "preserve"` to endpoint-matched edge writes.
+`getOrCreateByEndpoints` accepts the policy in its options, and
+`bulkGetOrCreateByEndpoints` accepts it per item alongside `validFrom` and
+`validTo`. The policy applies a stated `validFrom` on create or resurrection,
+while a live `ifExists: "update"` preserves the stored lower bound and still
+applies properties and `validTo`. Strict refusal remains the default.

--- a/apps/docs/src/content/docs/data-sync.md
+++ b/apps/docs/src/content/docs/data-sync.md
@@ -205,17 +205,19 @@ const membership = await store.edges.memberOf.getOrCreateByEndpoints(
     ifExists: "update",
     validFrom: sourceMembership.startedAt,
     validTo: sourceMembership.endedAt,
+    onImmutableLowerBound: "preserve",
   }
 );
 // membership.action: "created" | "found" | "updated" | "resurrected"
 ```
 
 For endpoint writes, `validFrom` applies when a new edge is created and on the
-`"resurrected"` branch, where it restates the revived row's whole window; an
-`"updated"` live edge keeps its stored lower bound, which is history. `validTo`
-applies to both the `"updated"` and `"resurrected"` branches. A `"found"` result
-performs no write and preserves the existing validity window. An end that
-precedes the row's effective start is refused — see
+`"resurrected"` branch, where it restates the revived row's whole window. With
+`onImmutableLowerBound: "preserve"`, an `"updated"` live edge keeps its stored
+lower bound while still applying props and `validTo`; the default `"refuse"`
+policy instead refuses a different stated start. A `"found"` result performs no
+write and preserves the existing validity window. An end that precedes the
+row's effective start is refused — see
 [Inverted validity windows](/errors/#inverted_validity_window).
 
 ### Edge Bulk Operations

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -186,15 +186,18 @@ What deliberately does not raise it:
   `validFrom` is stored — that is the way to give a row a different lower bound.
 - **`getOrCreateByEndpoints` returning an existing edge.** That branch performs
   no write, so its window options describe the row to create if none is found.
-- **A node upsert with `onImmutableLowerBound: "preserve"`.** This explicitly
-  treats `validFrom` as create/resurrection-only input. A live-row update keeps
-  its stored lower bound while still applying props and `validTo`; the default
-  remains `"refuse"` so an unqualified bound is never silently dropped.
+- **A node upsert or endpoint-matched edge update with
+  `onImmutableLowerBound: "preserve"`.** This explicitly treats `validFrom` as
+  create/resurrection-only input. A live-row update keeps its stored lower
+  bound while still applying props and `validTo`; the default remains
+  `"refuse"` so an unqualified bound is never silently dropped. Edge updates
+  use the policy with `ifExists: "update"`; the bulk edge form sets it per item.
 
-It reaches every path that accepts `validFrom` against a live row: `upsertById`,
-`bulkUpsertById` (including a repeated id in one batch, judged against the row
-the batch just queued), `getOrCreateByEndpoints` / `bulkGetOrCreateByEndpoints`
-with `ifExists: "update"`, and interchange import's `onConflict: "update"` legs —
+Under the default `"refuse"` policy, it reaches every path that accepts
+`validFrom` against a live row: `upsertById`, `bulkUpsertById` (including a
+repeated id in one batch, judged against the row the batch just queued),
+`getOrCreateByEndpoints` / `bulkGetOrCreateByEndpoints` with
+`ifExists: "update"`, and interchange import's `onConflict: "update"` legs —
 where, as with the inverted-window refusal, it is recorded as a per-row error
 prefixed with the code rather than aborting the import.
 

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -64,6 +64,7 @@ async function projectChange(
       ifExists: "update",
       validFrom: change.relationshipValidFrom,
       validTo: change.relationshipValidTo,
+      onImmutableLowerBound: "preserve",
     },
   );
 }
@@ -72,15 +73,13 @@ async function projectChange(
 The important rule is that the second delivery of the same change takes the same
 code path and reaches the same row identities.
 
-The node's `"preserve"` policy makes `validFrom` create/resurrection-only input:
-a later revision updates props without trying to rewrite the live row's start.
-Without it, the default `"refuse"` policy raises
-`IMMUTABLE_VALIDITY_LOWER_BOUND` when a revision states a different start. The
-edge explicitly selects `ifExists: "update"`; the default is `"return"`, which
-is right for create-once relationships but writes neither revised props nor a
-closing `validTo` when the edge already exists. The decoder supplies
-`relationshipValidFrom` only on the event that creates the relationship; later
-live-edge revisions omit it unless they restate the stored bound exactly.
+The `"preserve"` policy makes `validFrom` create/resurrection-only input for
+both node and edge writes: a later revision updates props and `validTo` without
+trying to rewrite the live row's start. Without it, the default `"refuse"`
+policy raises `IMMUTABLE_VALIDITY_LOWER_BOUND` when a revision states a
+different start. The edge also explicitly selects `ifExists: "update"`; the
+default is `"return"`, which is right for create-once relationships but writes
+neither revised props nor a closing `validTo` when the edge already exists.
 
 ### `matchOn` widens the identity key — don't reach for it by default
 
@@ -273,8 +272,9 @@ store creates a row without a stated `validFrom`, TypeGraph uses the ingest
 instant. A later replayed event whose historical `validTo` precedes that ingest
 instant is therefore an `INVERTED_VALIDITY_WINDOW`, even if the source timeline
 itself was ordered. An event-time decoder must emit `validFrom` on the event
-that first creates each row; `onImmutableLowerBound: "preserve"` then lets later
-revisions carry their source bound without trying to move the stored start.
+that first creates each node or edge; `onImmutableLowerBound: "preserve"` then
+lets later revisions carry their source bound without trying to move the stored
+start.
 
 ### In-graph cursors and the receipt
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1543,6 +1543,7 @@ store.edges.worksAt.getOrCreateByEndpoints(
     ifExists?: "return" | "update"; // Default: "return"
     validFrom?: string;
     validTo?: string;
+    onImmutableLowerBound?: "refuse" | "preserve"; // Default: "refuse"
   }
 ): Promise<{
   edge: Edge<worksAt>;
@@ -1550,17 +1551,18 @@ store.edges.worksAt.getOrCreateByEndpoints(
 }>;
 ```
 
-`validFrom` applies when the operation creates the edge and when it resurrects
-one. An `"updated"` live match leaves the existing start unchanged, because a
-live row's lower bound is history — so a `validFrom` naming a different instant
-is refused rather than ignored, see
-[Immutable validity lower bounds](/errors/#immutable_validity_lower_bound);
-restating the bound the edge already holds is accepted. On a resurrection, naming
-`validFrom` asserts
-the COMPLETE window: an accompanying `validTo` is applied, and an omitted one
-reopens the revived row rather than keeping the tombstoned incarnation's end.
-`validTo` applies when the edge is created, updated, or resurrected, and may not
-precede the row's effective start — see
+`validFrom` applies when the operation creates or resurrects the edge. On an
+`"updated"` live match, `onImmutableLowerBound: "preserve"` treats it as
+create/resurrection-only input: the stored start remains unchanged while props
+and `validTo` are applied. The default `"refuse"` policy instead refuses a
+`validFrom` naming a different instant; restating the bound the edge already
+holds is accepted. See
+[Immutable validity lower bounds](/errors/#immutable_validity_lower_bound).
+On a resurrection, naming `validFrom` asserts the COMPLETE window: an
+accompanying `validTo` is applied, and an omitted one reopens the revived row
+rather than keeping the tombstoned incarnation's end. `validTo` applies when
+the edge is created, updated, or resurrected, and may not precede the row's
+effective start — see
 [Inverted validity windows](/errors/#inverted_validity_window). When `ifExists`
 is omitted or `"return"`, a live match produces the `"found"` action and neither
 temporal option changes the edge.
@@ -1577,6 +1579,7 @@ store.edges.worksAt.bulkGetOrCreateByEndpoints(
     props: { role: string };
     validFrom?: string;
     validTo?: string;
+    onImmutableLowerBound?: "refuse" | "preserve";
   }[],
   options?: {
     matchOn?: readonly ("role")[];
@@ -1590,14 +1593,14 @@ store.edges.worksAt.bulkGetOrCreateByEndpoints(
 >;
 ```
 
-Temporal fields belong to each item so identities with different endpoints or
-`matchOn` values can carry different validity windows in one batch. Items with
-the same endpoint-plus-`matchOn` identity are duplicates: the first item
-supplies the write values and later items return that edge with the `"found"`
-action. To represent multiple periods between the same endpoints, add a stable
-period or source-event field to the edge schema and include it in `matchOn`.
-Their create, update, and resurrection semantics otherwise match the single
-operation.
+Temporal fields and `onImmutableLowerBound` belong to each item so identities
+with different endpoints or `matchOn` values can carry independent validity
+windows and lower-bound policies in one batch. Items with the same
+endpoint-plus-`matchOn` identity are duplicates: the first item supplies the
+write values and later items return that edge with the `"found"` action. To
+represent multiple periods between the same endpoints, add a stable period or
+source-event field to the edge schema and include it in `matchOn`. Their create,
+update, and resurrection semantics otherwise match the single operation.
 
 #### `findByEndpoints(from, to, options?, temporal?)`
 

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -920,6 +920,7 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
     }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
@@ -969,6 +970,7 @@ type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
     validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
     validTo?: string;
 }>;
 

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -747,6 +747,7 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
     }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
@@ -796,6 +797,7 @@ type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
     validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
     validTo?: string;
 }>;
 

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -775,6 +775,7 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
     }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
@@ -824,6 +825,7 @@ type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
     validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
     validTo?: string;
 }>;
 

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -746,6 +746,7 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
     }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
@@ -795,6 +796,7 @@ type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
     validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
     validTo?: string;
 }>;
 

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -740,6 +740,7 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
     }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
@@ -789,6 +790,7 @@ type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
     validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
     validTo?: string;
 }>;
 

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -778,6 +778,7 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
     }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
@@ -827,6 +828,7 @@ type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
     validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
     validTo?: string;
 }>;
 

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -1427,6 +1427,7 @@ export type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeTy
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
     }>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
@@ -1479,6 +1480,7 @@ export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
     validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
     validTo?: string;
 }>;
 

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -208,6 +208,9 @@ export type EdgeOperations = Readonly<{
     options?: Readonly<{
       matchOn?: readonly string[];
       ifExists?: IfExistsMode;
+      validFrom?: string;
+      validTo?: string;
+      onImmutableLowerBound?: "preserve" | "refuse";
     }>,
   ) => Promise<Readonly<{ edge: Edge; action: GetOrCreateAction }>>;
   executeBulkGetOrCreateByEndpoints: (
@@ -218,6 +221,9 @@ export type EdgeOperations = Readonly<{
       toKind: string;
       toId: string;
       props: Record<string, unknown>;
+      validFrom?: string;
+      validTo?: string;
+      onImmutableLowerBound?: "preserve" | "refuse";
     }>[],
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -145,6 +145,7 @@ export type EdgeCollectionConfig = Readonly<{
       ifExists?: IfExistsMode;
       validFrom?: string;
       validTo?: string;
+      onImmutableLowerBound?: "preserve" | "refuse";
     }>,
   ) => Promise<Readonly<{ edge: Edge; action: GetOrCreateAction }>>;
   executeBulkGetOrCreateByEndpoints: (
@@ -157,6 +158,7 @@ export type EdgeCollectionConfig = Readonly<{
       props: Record<string, unknown>;
       validFrom?: string;
       validTo?: string;
+      onImmutableLowerBound?: "preserve" | "refuse";
     }>[],
     backend: GraphBackend | TransactionBackend,
     options?: Readonly<{
@@ -234,11 +236,15 @@ type EdgeUpdateInput = Readonly<{
  *
  * The public `update()` API cannot reach this member: its options type exposes
  * `validTo` only, and it builds its input through {@link buildUpdateEdgeInput}.
- * Only `bulkUpsertById`, which accepts `validFrom` by contract, routes through
- * {@link buildUpsertUpdateEdgeInput}.
+ * `bulkUpsertById` and endpoint-matched upserts route through this input because
+ * both may accept `validFrom`; only the endpoint surface currently exposes the
+ * create/resurrection-only policy.
  */
 export type UpsertUpdateEdgeInput = EdgeUpdateInput &
-  Readonly<{ validFrom?: string }>;
+  Readonly<{
+    validFrom?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
+  }>;
 
 function buildUpdateEdgeInput(
   kind: string,
@@ -1096,6 +1102,9 @@ export function createEdgeCollection<
           validFrom: options.validFrom,
         }),
         ...(options?.validTo !== undefined && { validTo: options.validTo }),
+        ...(options?.onImmutableLowerBound !== undefined && {
+          onImmutableLowerBound: options.onImmutableLowerBound,
+        }),
       };
 
       const result = await config.executeGetOrCreateByEndpoints(
@@ -1118,6 +1127,7 @@ export function createEdgeCollection<
         props: z.input<E["schema"]>;
         validFrom?: string;
         validTo?: string;
+        onImmutableLowerBound?: "preserve" | "refuse";
       }>[],
       options?: Pick<
         EdgeGetOrCreateByEndpointsOptions<E>,
@@ -1134,6 +1144,9 @@ export function createEdgeCollection<
         props: item.props,
         ...(item.validFrom !== undefined && { validFrom: item.validFrom }),
         ...(item.validTo !== undefined && { validTo: item.validTo }),
+        ...(item.onImmutableLowerBound !== undefined && {
+          onImmutableLowerBound: item.onImmutableLowerBound,
+        }),
       }));
 
       const getOrCreateOptions = {

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -105,6 +105,7 @@ import { canonicalEqual } from "../../schema/canonical";
 import {
   assertOrderedValidityWindow,
   assertWritableValidityWindow,
+  preservesImmutableLowerBound,
   validateOptionalCanonicalIsoDate,
 } from "../../utils/date";
 import { generateId } from "../../utils/id";
@@ -967,10 +968,14 @@ async function performEdgeUpdate<G extends GraphDef>(
 
   const { validatedProps } = resolveEdgeUpdateProps(ctx, existing, input.props);
 
-  const validFrom = validateOptionalCanonicalIsoDate(
+  const statedValidFrom = validateOptionalCanonicalIsoDate(
     input.validFrom,
     "validFrom",
   );
+  const preservesLiveLowerBound =
+    options?.clearDeleted !== true &&
+    preservesImmutableLowerBound(input.onImmutableLowerBound);
+  const validFrom = preservesLiveLowerBound ? undefined : statedValidFrom;
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
   // The row's stored lower bound is the effective one on EVERY edge update,
   // in-place or resurrecting: an edge RETAINS `valid_from` unless the
@@ -1646,6 +1651,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
     ifExists?: IfExistsMode;
     validFrom?: string;
     validTo?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
   }>,
 ): Promise<Readonly<{ edge: Edge; action: GetOrCreateAction }>> {
   const ifExists = options?.ifExists ?? "return";
@@ -1663,20 +1669,26 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
   // Validate matchOn fields
   validateMatchOnFields(edgeKind.schema, matchOn, kind);
 
-  // Validate temporal inputs before the read probe so validity of a call does
-  // not depend on whether its endpoint identity already exists. Only the
-  // endpoint PAIR can be judged here — the effective lower bound of a lone
-  // `validTo` belongs to the row the write leg resolves to, and is checked there.
+  // Canonical form is validated before the read probe so malformed input is
+  // always refused. Strict writes and return-mode calls also judge the stated
+  // pair here. A preserve-mode update defers ordering until its write leg has
+  // resolved whether it will create/resurrect (and apply the stated start) or
+  // update a live row (and retain the stored start).
   const validFrom = validateOptionalCanonicalIsoDate(
     options?.validFrom,
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(options?.validTo, "validTo");
-  assertOrderedValidityWindow(
-    `${kind} edge between ${fromKind} "${fromId}" and ${toKind} "${toId}"`,
-    validFrom,
-    validTo,
-  );
+  if (
+    ifExists !== "update" ||
+    !preservesImmutableLowerBound(options?.onImmutableLowerBound)
+  ) {
+    assertOrderedValidityWindow(
+      `${kind} edge between ${fromKind} "${fromId}" and ${toKind} "${toId}"`,
+      validFrom,
+      validTo,
+    );
+  }
 
   // Probe outside the transaction: with ifExists "return", the common found
   // path performs no write, so it must not pay for a write transaction
@@ -1782,6 +1794,9 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
           props: validatedProps,
           ...(validFrom !== undefined && { validFrom }),
           ...(validTo !== undefined && { validTo }),
+          ...(options?.onImmutableLowerBound !== undefined && {
+            onImmutableLowerBound: options.onImmutableLowerBound,
+          }),
         },
         backend,
       );
@@ -1812,6 +1827,9 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
         props: validatedProps,
         ...(validFrom !== undefined && { validFrom }),
         ...(validTo !== undefined && { validTo }),
+        ...(options?.onImmutableLowerBound !== undefined && {
+          onImmutableLowerBound: options.onImmutableLowerBound,
+        }),
       },
       backend,
       {
@@ -1886,6 +1904,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     props: Record<string, unknown>;
     validFrom?: string;
     validTo?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
   }>[],
   backend: GraphBackend | TransactionBackend,
   options?: Readonly<{
@@ -1916,6 +1935,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     endpointKey: string;
     validFrom?: string;
     validTo?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
   }[] = [];
 
   for (const item of items) {
@@ -1928,13 +1948,18 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       "validFrom",
     );
     const validTo = validateOptionalCanonicalIsoDate(item.validTo, "validTo");
-    // As in the single-item path: the endpoint pair is judged up front so a
-    // batch's validity does not depend on which items already exist.
-    assertOrderedValidityWindow(
-      `${kind} edge between ${item.fromKind} "${item.fromId}" and ${item.toKind} "${item.toId}"`,
-      validFrom,
-      validTo,
-    );
+    // As in the single-item path, canonical form is always judged up front.
+    // Preserve-mode updates defer ordering until the target row is resolved.
+    if (
+      ifExists !== "update" ||
+      !preservesImmutableLowerBound(item.onImmutableLowerBound)
+    ) {
+      assertOrderedValidityWindow(
+        `${kind} edge between ${item.fromKind} "${item.fromId}" and ${item.toKind} "${item.toId}"`,
+        validFrom,
+        validTo,
+      );
+    }
 
     const compositeKey = buildEdgeCompositeKey(
       item.fromKind,
@@ -1961,6 +1986,9 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       endpointKey,
       ...(validFrom !== undefined && { validFrom }),
       ...(validTo !== undefined && { validTo }),
+      ...(item.onImmutableLowerBound !== undefined && {
+        onImmutableLowerBound: item.onImmutableLowerBound,
+      }),
     });
   }
 
@@ -2023,6 +2051,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
      */
     validFrom?: string;
     validTo?: string;
+    onImmutableLowerBound?: "preserve" | "refuse";
   }
   interface DuplicateEntry {
     index: number;
@@ -2050,6 +2079,16 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       // Check within-batch duplicate
       const previousIndex = seenKeys.get(entry.compositeKey);
       if (previousIndex !== undefined) {
+        // A duplicate is a found/no-write result, so there is no stored target
+        // window against which preserve mode can defer this decision. Keep the
+        // existing return-mode contract: its stated pair must be ordered.
+        if (preservesImmutableLowerBound(entry.onImmutableLowerBound)) {
+          assertOrderedValidityWindow(
+            `${kind} edge between ${entry.fromKind} "${entry.fromId}" and ${entry.toKind} "${entry.toId}"`,
+            entry.validFrom,
+            entry.validTo,
+          );
+        }
         duplicateOf.push({ index, sourceIndex: previousIndex });
         continue;
       }
@@ -2097,6 +2136,9 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
             validFrom: entry.validFrom,
           }),
           ...(entry.validTo !== undefined && { validTo: entry.validTo }),
+          ...(entry.onImmutableLowerBound !== undefined && {
+            onImmutableLowerBound: entry.onImmutableLowerBound,
+          }),
         });
       }
     }
@@ -2183,6 +2225,9 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
                   validFrom: entry.validFrom,
                 }),
                 ...(entry.validTo !== undefined && { validTo: entry.validTo }),
+                ...(entry.onImmutableLowerBound !== undefined && {
+                  onImmutableLowerBound: entry.onImmutableLowerBound,
+                }),
               },
               target,
               {
@@ -2218,6 +2263,9 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
                   validFrom: entry.validFrom,
                 }),
                 ...(entry.validTo !== undefined && { validTo: entry.validTo }),
+                ...(entry.onImmutableLowerBound !== undefined && {
+                  onImmutableLowerBound: entry.onImmutableLowerBound,
+                }),
               },
               target,
             );

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -975,7 +975,8 @@ async function performEdgeUpdate<G extends GraphDef>(
   const preservesLiveLowerBound =
     options?.clearDeleted !== true &&
     preservesImmutableLowerBound(input.onImmutableLowerBound);
-  const validFrom = preservesLiveLowerBound ? undefined : statedValidFrom;
+  const appliedValidFrom =
+    preservesLiveLowerBound ? undefined : statedValidFrom;
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
   // The row's stored lower bound is the effective one on EVERY edge update,
   // in-place or resurrecting: an edge RETAINS `valid_from` unless the
@@ -999,7 +1000,7 @@ async function performEdgeUpdate<G extends GraphDef>(
   // and dropped.
   const windowVerdict = assertWritableValidityWindow(
     `edge "${id}"`,
-    validFrom,
+    appliedValidFrom,
     {
       effectiveValidFrom: existing.valid_from,
       appliesStatedValidFrom: options?.clearDeleted === true,
@@ -1011,8 +1012,8 @@ async function performEdgeUpdate<G extends GraphDef>(
     validTo,
   );
 
-  // `validFrom` reaches the backend only through a resurrecting write (see
-  // UpdateEdgeParams): a live edge's lower bound is history and stays put.
+  // `appliedValidFrom` reaches the backend only through a resurrecting write
+  // (see UpdateEdgeParams): a live edge's lower bound is history and stays put.
   //
   // `kind` makes the UPDATE self-verifying: the re-read above computed the
   // merged props and the effective window, and the same predicate that
@@ -1061,7 +1062,9 @@ async function performEdgeUpdate<G extends GraphDef>(
   if (input.identity.toId !== undefined) {
     updateParams.toId = input.identity.toId;
   }
-  if (validFrom !== undefined) updateParams.validFrom = validFrom;
+  if (appliedValidFrom !== undefined) {
+    updateParams.validFrom = appliedValidFrom;
+  }
   if (validTo !== undefined) updateParams.validTo = validTo;
   if (options?.clearDeleted) updateParams.clearDeleted = true;
 
@@ -1634,6 +1637,15 @@ export async function executeEdgeFindByEndpoints<G extends GraphDef>(
   return liveRow === undefined ? undefined : rowToEdge(liveRow);
 }
 
+function defersEndpointWindowOrdering(
+  ifExists: IfExistsMode,
+  onImmutableLowerBound: "preserve" | "refuse" | undefined,
+): boolean {
+  return (
+    ifExists === "update" && preservesImmutableLowerBound(onImmutableLowerBound)
+  );
+}
+
 /**
  * Executes a single getOrCreateByEndpoints operation.
  */
@@ -1679,10 +1691,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(options?.validTo, "validTo");
-  if (
-    ifExists !== "update" ||
-    !preservesImmutableLowerBound(options?.onImmutableLowerBound)
-  ) {
+  if (!defersEndpointWindowOrdering(ifExists, options?.onImmutableLowerBound)) {
     assertOrderedValidityWindow(
       `${kind} edge between ${fromKind} "${fromId}" and ${toKind} "${toId}"`,
       validFrom,
@@ -1950,10 +1959,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     const validTo = validateOptionalCanonicalIsoDate(item.validTo, "validTo");
     // As in the single-item path, canonical form is always judged up front.
     // Preserve-mode updates defer ordering until the target row is resolved.
-    if (
-      ifExists !== "update" ||
-      !preservesImmutableLowerBound(item.onImmutableLowerBound)
-    ) {
+    if (!defersEndpointWindowOrdering(ifExists, item.onImmutableLowerBound)) {
       assertOrderedValidityWindow(
         `${kind} edge between ${item.fromKind} "${item.fromId}" and ${item.toKind} "${item.toId}"`,
         validFrom,

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -750,6 +750,15 @@ export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> =
      */
     validFrom?: string;
     /**
+     * How an `ifExists: "update"` write treats a stated `validFrom` that differs
+     * from the live edge's stored lower bound. Default: `"refuse"`.
+     *
+     * `"preserve"` makes `validFrom` create/resurrection-only input: it is still
+     * validated, but a live update keeps the stored lower bound while applying
+     * properties and `validTo`.
+     */
+    onImmutableLowerBound?: "preserve" | "refuse";
+    /**
      * Valid-time end for a created, updated, or resurrected edge. Ignored when
      * the operation returns an existing edge without writing. May not precede
      * the row's effective start; see `INVERTED_VALIDITY_WINDOW_CODE`.
@@ -1498,6 +1507,7 @@ export type EdgeCollection<
       props: z.input<E["schema"]>;
       validFrom?: string;
       validTo?: string;
+      onImmutableLowerBound?: "preserve" | "refuse";
     }>[],
     options?: Pick<
       EdgeGetOrCreateByEndpointsOptions<E>,

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -416,7 +416,7 @@ export type ValidityWindowVerdict = Readonly<{
 }>;
 
 /**
- * Whether a node upsert explicitly treats its stated lower bound as
+ * Whether an upsert explicitly treats its stated lower bound as
  * create/resurrection-only input.
  *
  * This predicate owns the policy decision for both write execution and

--- a/packages/typegraph/tests/backends/integration/edge-operations.ts
+++ b/packages/typegraph/tests/backends/integration/edge-operations.ts
@@ -459,6 +459,117 @@ export function registerEdgeOperationIntegrationTests(
       expect(stored?.meta.validTo).toBeUndefined();
     });
 
+    it("preserves a live edge lower bound when an endpoint update opts in", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      const created = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM },
+      );
+      const updated = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Manager" },
+        {
+          ifExists: "update",
+          validFrom: SECOND_VALID_FROM,
+          // The source pair is inverted, but the effective stored window is
+          // ordered. Preserve mode must judge the window the write will keep.
+          validTo: FIRST_VALID_TO,
+          onImmutableLowerBound: "preserve",
+        },
+      );
+
+      expect(updated.action).toBe("updated");
+      expect(updated.edge.id).toBe(created.edge.id);
+      expect(updated.edge.role).toBe("Manager");
+      expect(updated.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(updated.edge.meta.validTo).toBe(FIRST_VALID_TO);
+    });
+
+    it("still validates a preserved endpoint lower bound", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+      await store.edges.worksAt.create(alice, acme, { role: "Engineer" });
+
+      await expect(
+        store.edges.worksAt.getOrCreateByEndpoints(
+          alice,
+          acme,
+          { role: "Manager" },
+          {
+            ifExists: "update",
+            validFrom: "not-a-date",
+            onImmutableLowerBound: "preserve",
+          },
+        ),
+      ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validFrom"/);
+    });
+
+    it("still refuses an effectively inverted preserved endpoint window", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+      await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM },
+      );
+
+      await expect(
+        store.edges.worksAt.getOrCreateByEndpoints(
+          alice,
+          acme,
+          { role: "Manager" },
+          {
+            ifExists: "update",
+            validFrom: "2017-01-01T00:00:00.000Z",
+            validTo: "2018-01-01T00:00:00.000Z",
+            onImmutableLowerBound: "preserve",
+          },
+        ),
+      ).rejects.toThrow(/Inverted validity window/);
+    });
+
+    it("applies a preserved lower bound on create and resurrection", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      const created = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Engineer" },
+        {
+          validFrom: FIRST_VALID_FROM,
+          onImmutableLowerBound: "preserve",
+        },
+      );
+      expect(created.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+
+      await store.edges.worksAt.delete(created.edge.id);
+      const resurrected = await store.edges.worksAt.getOrCreateByEndpoints(
+        alice,
+        acme,
+        { role: "Manager" },
+        {
+          validFrom: SECOND_VALID_FROM,
+          validTo: SECOND_VALID_TO,
+          onImmutableLowerBound: "preserve",
+        },
+      );
+
+      expect(resurrected.action).toBe("resurrected");
+      expect(resurrected.edge.meta.validFrom).toBe(SECOND_VALID_FROM);
+      expect(resurrected.edge.meta.validTo).toBe(SECOND_VALID_TO);
+    });
+
     it("restating the bound a live edge already holds is accepted", async () => {
       const store = context.getStore();
       const alice = await store.nodes.Person.create({ name: "Alice" });
@@ -613,6 +724,72 @@ export function registerEdgeOperationIntegrationTests(
       expect(stored?.role).toBe("Engineer");
       expect(stored?.meta.validFrom).toBe(FIRST_VALID_FROM);
       expect(stored?.meta.validTo).toBeUndefined();
+    });
+
+    it("applies per-item lower-bound policy across bulk update, resurrection, and create", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const charlie = await store.nodes.Person.create({ name: "Charlie" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+
+      const live = await store.edges.worksAt.create(
+        alice,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM },
+      );
+      const deleted = await store.edges.worksAt.create(
+        bob,
+        acme,
+        { role: "Engineer" },
+        { validFrom: FIRST_VALID_FROM },
+      );
+      await store.edges.worksAt.delete(deleted.id);
+
+      const results = await store.edges.worksAt.bulkGetOrCreateByEndpoints(
+        [
+          {
+            from: alice,
+            to: acme,
+            props: { role: "Manager" },
+            validFrom: SECOND_VALID_FROM,
+            validTo: FIRST_VALID_TO,
+            onImmutableLowerBound: "preserve",
+          },
+          {
+            from: bob,
+            to: acme,
+            props: { role: "Director" },
+            validFrom: SECOND_VALID_FROM,
+            validTo: SECOND_VALID_TO,
+            onImmutableLowerBound: "preserve",
+          },
+          {
+            from: charlie,
+            to: acme,
+            props: { role: "Analyst" },
+            validFrom: SECOND_VALID_FROM,
+            validTo: SECOND_VALID_TO,
+            onImmutableLowerBound: "preserve",
+          },
+        ],
+        { ifExists: "update" },
+      );
+
+      expect(results.map((result) => result.action)).toEqual([
+        "updated",
+        "resurrected",
+        "created",
+      ]);
+      expect(results[0]?.edge.id).toBe(live.id);
+      expect(results[0]?.edge.meta.validFrom).toBe(FIRST_VALID_FROM);
+      expect(results[0]?.edge.meta.validTo).toBe(FIRST_VALID_TO);
+      expect(results[1]?.edge.id).toBe(deleted.id);
+      expect(results[1]?.edge.meta.validFrom).toBe(SECOND_VALID_FROM);
+      expect(results[1]?.edge.meta.validTo).toBe(SECOND_VALID_TO);
+      expect(results[2]?.edge.meta.validFrom).toBe(SECOND_VALID_FROM);
+      expect(results[2]?.edge.meta.validTo).toBe(SECOND_VALID_TO);
     });
   });
 }

--- a/packages/typegraph/tests/backends/integration/edge-operations.ts
+++ b/packages/typegraph/tests/backends/integration/edge-operations.ts
@@ -791,5 +791,105 @@ export function registerEdgeOperationIntegrationTests(
       expect(results[2]?.edge.meta.validFrom).toBe(SECOND_VALID_FROM);
       expect(results[2]?.edge.meta.validTo).toBe(SECOND_VALID_TO);
     });
+
+    it("keeps strict and preserve policies isolated in an atomic bulk update", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+      const [aliceEdge, bobEdge] = await store.edges.worksAt.bulkCreate([
+        {
+          from: alice,
+          to: acme,
+          props: { role: "Engineer" },
+          validFrom: FIRST_VALID_FROM,
+        },
+        {
+          from: bob,
+          to: acme,
+          props: { role: "Engineer" },
+          validFrom: FIRST_VALID_FROM,
+        },
+      ]);
+
+      await expectImmutableLowerBoundRefusal(
+        store.edges.worksAt.bulkGetOrCreateByEndpoints(
+          [
+            {
+              from: alice,
+              to: acme,
+              props: { role: "Manager" },
+              validFrom: SECOND_VALID_FROM,
+              onImmutableLowerBound: "preserve",
+            },
+            {
+              from: bob,
+              to: acme,
+              props: { role: "Director" },
+              validFrom: SECOND_VALID_FROM,
+              onImmutableLowerBound: "refuse",
+            },
+          ],
+          { ifExists: "update" },
+        ),
+      );
+
+      const storedAliceEdge = await store.edges.worksAt.getById(
+        requireDefined(aliceEdge).id,
+      );
+      const storedBobEdge = await store.edges.worksAt.getById(
+        requireDefined(bobEdge).id,
+      );
+      expect(storedAliceEdge?.role).toBe("Engineer");
+      expect(storedBobEdge?.role).toBe("Engineer");
+    });
+
+    it("rejects malformed per-item preserve input before applying a bulk update", async () => {
+      const store = context.getStore();
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const acme = await store.nodes.Company.create({ name: "Acme Corp" });
+      const [aliceEdge] = await store.edges.worksAt.bulkCreate([
+        {
+          from: alice,
+          to: acme,
+          props: { role: "Engineer" },
+          validFrom: FIRST_VALID_FROM,
+        },
+        {
+          from: bob,
+          to: acme,
+          props: { role: "Engineer" },
+          validFrom: FIRST_VALID_FROM,
+        },
+      ]);
+
+      await expect(
+        store.edges.worksAt.bulkGetOrCreateByEndpoints(
+          [
+            {
+              from: alice,
+              to: acme,
+              props: { role: "Manager" },
+              validFrom: SECOND_VALID_FROM,
+              onImmutableLowerBound: "preserve",
+            },
+            {
+              from: bob,
+              to: acme,
+              props: { role: "Director" },
+              validFrom: "not-a-date",
+              onImmutableLowerBound: "preserve",
+            },
+          ],
+          { ifExists: "update" },
+        ),
+      ).rejects.toThrow(/Invalid canonical ISO 8601 datetime for "validFrom"/);
+
+      const storedAliceEdge = await store.edges.worksAt.getById(
+        requireDefined(aliceEdge).id,
+      );
+      expect(storedAliceEdge?.role).toBe("Engineer");
+    });
   });
 }


### PR DESCRIPTION
Extends `onImmutableLowerBound: "preserve"` to `getOrCreateByEndpoints` and to individual `bulkGetOrCreateByEndpoints` items. Strict refusal remains the default; preserve mode validates the source bound, applies it on create or resurrection, and retains the stored lower bound on a live update while still applying properties and `validTo`.

Moves validity ordering to the resolved write leg for preserve-mode updates. A live update is judged against the lower bound it will retain, while create and resurrection are judged against the source bound they will apply. Canonical timestamp validation still runs before lookup, so malformed input cannot be hidden by the policy.

Keeps bulk policy per item alongside each validity window. Mixed strict and preserve items remain isolated, and any refusal or malformed item rolls back the entire batch.

Updates event-log and data-sync examples to use the same one-statement policy for relationships, expands the store and error reference, regenerates public API reports, and adds a patch changeset.

The shared cross-backend suite covers live updates, create, resurrection, malformed and effectively inverted windows, per-item bulk behavior, and atomic mixed-policy refusal. The load-bearing mutation check confirmed the single and bulk preserve tests fail when the shared policy decision is disabled.

Closes #458