### PR TITLE
fix: type degraded fulltext failures

### DIFF
--- a/.changeset/typed-orphaned-fulltext.md
+++ b/.changeset/typed-orphaned-fulltext.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Surface lost fulltext contribution storage on gated operations as a typed `ContributionUnavailableError` with `state: "physical-storage-missing"` and rebuild guidance. Healthy operations retain the cached marker fast path; the error path translates only a missing-relation failure whose same driver error names the declared fulltext table.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1154,7 +1154,7 @@ reopen it through a managed factory before resuming version-fenced writes.
   role.**
   Every gate above trusts the marker row without probing the catalog, so
   a database whose strategy-owned tables were dropped out of band opens
-  clean and fails at the first read. This method compares each contribution
+  clean and fails at the first dependent read or write. This method compares each contribution
   currently expected by the active graph and backend strategies with its
   marker and the catalog. It does not audit retired marker rows, and a
   never-attempted contribution with neither marker nor table is omitted, so

--- a/apps/docs/src/content/docs/fulltext-search.md
+++ b/apps/docs/src/content/docs/fulltext-search.md
@@ -803,6 +803,15 @@ the recorded shape no longer matches the active strategy/DDL: migrate or
 drop the fulltext table and re-run the boot, or restore the original
 strategy.
 
+`ContributionUnavailableError` with `state: "physical-storage-missing"` is
+different: the physical fulltext table disappeared after initialization. Gated
+fulltext searches and searchable node writes raise this typed error; compiled
+query-builder predicates can still surface the engine's missing-relation error.
+Run `store.rebuildContribution("fulltext")`; rerunning ordinary initialization
+cannot reconstruct the missing indexed content. Use `probeContributions()` at
+startup when an application must detect this out-of-band catalog damage before
+the first dependent read or write.
+
 ### `Cannot call .$fulltext.matches() on alias "x"`
 
 `$fulltext` is exposed on every node accessor at the type level, but

--- a/apps/docs/src/content/docs/troubleshooting.md
+++ b/apps/docs/src/content/docs/troubleshooting.md
@@ -388,6 +388,16 @@ created. Boot deliberately leaves such a slot untouched (with a console
 warning); run `store.reembedVectorField(kind, fieldPath)` to recreate the
 storage at the new shape and re-embed.
 
+**`ContributionUnavailableError`** with `state: "physical-storage-missing"`
+means the physical fulltext table disappeared after initialization. Gated
+fulltext operations preserve the driver error as `cause`, and transactional
+backends roll back failed searchable writes. Query-builder fulltext predicates
+compile directly to SQL and can still surface the engine's missing-relation
+error. Run `store.rebuildContribution("fulltext")` to recreate the table and
+repopulate it from the graph's nodes. A verified attach checks markers rather
+than the physical catalog; use `probeContributions()` when startup must detect
+out-of-band table loss.
+
 **Solution:** Run `createStoreWithSchema(graph, adminBackend)` once
 under the privileged role before the runtime attaches (it writes the
 contribution markers that `createStore` / `createVerifiedStore` only
@@ -419,7 +429,7 @@ strategy-owned tables. Nothing on the open path probes the catalog:
 boot and the runtime asserts short-circuit on a per-instance signature
 cache and then on the marker row alone, which keeps the hot path free
 of catalog round trips. The cost is that this database opens
-completely clean and fails at the first read of the affected slot.
+completely clean and fails at the first read or write that depends on the affected slot.
 
 **Diagnosis:** `store.verifyContributions()` reports detected drift or a
 recorded failed attempt among contributions currently expected by the active

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -591,6 +591,23 @@ export type ContributionRepopulationStats = Readonly<{
 }>;
 
 // @public
+export class ContributionUnavailableError extends TypeGraphError {
+    constructor(graphId: string, physicalName: string, options?: Readonly<{
+        cause?: unknown;
+    }>);
+    // (undocumented)
+    readonly details: ContributionUnavailableErrorDetails;
+}
+
+// @public
+export type ContributionUnavailableErrorDetails = Readonly<{
+    graphId: string;
+    logicalName: "fulltext";
+    physicalName: string;
+    state: "physical-storage-missing";
+}>;
+
+// @public
 abstract class CoordinatePinnedView<G extends GraphDef> {
     constructor(store: Store<G>, coordinate: ReadCoordinate);
     get algorithms(): StoreViewGraphAlgorithms<G>;

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -19,6 +19,7 @@ import { sql } from "drizzle-orm";
 import {
   ConfigurationError,
   ContributionRebuildUnsupportedError,
+  ContributionUnavailableError,
   StoreNotInitializedError,
   type StoreNotInitializedReason,
 } from "../../errors";
@@ -39,7 +40,7 @@ import {
 } from "../../query/sql-intent";
 import { sortedReplacer } from "../../schema/canonical";
 import { sha256Hex } from "../../utils/hash";
-import { isMissingTableError } from "../../utils/sql-errors";
+import { errorChain, isMissingTableError } from "../../utils/sql-errors";
 import { formatPostgresTimestamp, nowIso } from "../row-mappers";
 import type { StrategyTableContribution } from "../table-contribution";
 import {
@@ -229,9 +230,6 @@ function contributionSignatureInput(
  * - `initialized`: signature matches, a successful `materializedAt` is
  *   recorded, and the last attempt did not error.
  */
-// The non-initialized states are exactly `StoreNotInitializedError`'s
-// reasons — derive the union so the two cannot drift apart and the
-// assert can pass the state straight through as the error reason.
 type ContributionMaterializationState =
   "initialized" | StoreNotInitializedReason;
 
@@ -394,6 +392,48 @@ export type GatableFulltextBackend = Pick<
   | "hardDeleteNode"
 >;
 
+type RefuseUnavailableFulltext = (
+  graphId: string,
+  error: unknown,
+) => Promise<never>;
+
+function missingTableErrorNames(error: unknown, tableName: string): boolean {
+  const quotedTableName = `"${tableName.replaceAll('"', '""')}"`;
+  for (const link of errorChain(error)) {
+    const message =
+      typeof link === "string" ?
+        link
+      : typeof link === "object" && link !== null ?
+        Reflect.get(link, "message")
+      : undefined;
+    if (typeof message !== "string") continue;
+
+    const sqliteMatch = /\bno such table:\s*([^\s;]+)/i.exec(message);
+    const sqliteName = sqliteMatch?.[1]?.replaceAll(/^["'`\[]|["'`\]]$/g, "");
+    if (sqliteName === tableName) return true;
+
+    const namesPostgresTable =
+      message.includes(`relation ${quotedTableName} does not exist`) ||
+      message.includes(`table ${quotedTableName} does not exist`);
+    if (namesPostgresTable) return true;
+  }
+  return false;
+}
+
+async function executeGatedFulltext<T>(
+  graphId: string,
+  assert: (graphId: string) => Promise<void>,
+  refuseUnavailable: RefuseUnavailableFulltext,
+  execute: () => Promise<T>,
+): Promise<T> {
+  await assert(graphId);
+  try {
+    return await execute();
+  } catch (error) {
+    return refuseUnavailable(graphId, error);
+  }
+}
+
 /**
  * The fulltext point-of-use gate, as the wrapped overrides only. Each
  * method asserts the durable contribution marker before delegating; an
@@ -405,6 +445,7 @@ export type GatableFulltextBackend = Pick<
 export function gateFulltextMethods(
   source: GatableFulltextBackend,
   assert: (graphId: string) => Promise<void>,
+  refuseUnavailable: RefuseUnavailableFulltext,
 ): Partial<GatableFulltextBackend> {
   // Only assign an override when the raw method exists, so the "wrap
   // only what's defined" rule stays obvious instead of hiding behind
@@ -416,15 +457,17 @@ export function gateFulltextMethods(
   if (source.upsertFulltext) {
     const raw = source.upsertFulltext;
     gated.upsertFulltext = async (params) => {
-      await assert(params.graphId);
-      await raw(params);
+      await executeGatedFulltext(params.graphId, assert, refuseUnavailable, () =>
+        raw(params),
+      );
     };
   }
   if (source.deleteFulltext) {
     const raw = source.deleteFulltext;
     gated.deleteFulltext = async (params) => {
-      await assert(params.graphId);
-      await raw(params);
+      await executeGatedFulltext(params.graphId, assert, refuseUnavailable, () =>
+        raw(params),
+      );
     };
   }
   if (source.upsertFulltextBatch) {
@@ -433,31 +476,38 @@ export function gateFulltextMethods(
       // A genuine no-op call asserts nothing — the "empty input is
       // harmless" contract.
       if (params.rows.length === 0) return;
-      await assert(params.graphId);
-      await raw(params);
+      await executeGatedFulltext(params.graphId, assert, refuseUnavailable, () =>
+        raw(params),
+      );
     };
   }
   if (source.deleteFulltextBatch) {
     const raw = source.deleteFulltextBatch;
     gated.deleteFulltextBatch = async (params) => {
       if (params.nodeIds.length === 0) return;
-      await assert(params.graphId);
-      await raw(params);
+      await executeGatedFulltext(params.graphId, assert, refuseUnavailable, () =>
+        raw(params),
+      );
     };
   }
   if (source.fulltextSearch) {
     const raw = source.fulltextSearch;
     gated.fulltextSearch = async (params) => {
-      await assert(params.graphId);
-      return raw(params);
+      return executeGatedFulltext(
+        params.graphId,
+        assert,
+        refuseUnavailable,
+        () => raw(params),
+      );
     };
   }
   // Unconditional: the hard-delete cascade deletes from the fulltext
   // table even for graphs that declare no `searchable()` fields.
   const rawHardDelete = source.hardDeleteNode;
   gated.hardDeleteNode = async (params) => {
-    await assert(params.graphId);
-    await rawHardDelete(params);
+    await executeGatedFulltext(params.graphId, assert, refuseUnavailable, () =>
+      rawHardDelete(params),
+    );
   };
   return gated;
 }
@@ -472,10 +522,11 @@ export function gateFulltextMethods(
 export function gateFulltext(
   tx: TransactionBackend,
   assert: (graphId: string) => Promise<void>,
+  refuseUnavailable: RefuseUnavailableFulltext,
 ): TransactionBackend {
   return createBackendOverlay<TransactionBackend>(
     tx,
-    gateFulltextMethods(tx, assert),
+    gateFulltextMethods(tx, assert, refuseUnavailable),
   );
 }
 
@@ -554,6 +605,12 @@ export type ContributionMaterializer = Readonly<{
    * the first missing/stale/failed contribution. Zero DDL, zero writes.
    */
   assertInitialized: (graphId: string) => Promise<void>;
+  /**
+   * Error-path classification for a gated fulltext operation. Translates only
+   * a missing-relation failure that names the declared fulltext table; every
+   * other failure is rethrown unchanged.
+   */
+  refuseUnavailableFulltext: RefuseUnavailableFulltext;
   /**
    * Privileged materializer for one vector slot's `ownedTables`
    * contribution(s): creates the per-`(kind, field)` table and records
@@ -1068,6 +1125,33 @@ export function createContributionMaterializer(
 
   async function assertInitialized(graphId: string): Promise<void> {
     await assertContributions(graphId, runtimeContributions());
+  }
+
+  async function refuseUnavailableFulltext(
+    graphId: string,
+    error: unknown,
+  ): Promise<never> {
+    if (!isMissingTableError(error)) throw error;
+
+    // A failed transaction cannot run the uncached catalog audit on every
+    // backend (Postgres marks it aborted; PGlite shares that one session).
+    // The failed statement still names the missing physical table. Combined
+    // That is transaction-safe proof that the declared physical storage is
+    // missing and avoids any healthy-path query. It does not prove the marker
+    // still exists because the preceding assertion may have hit its cache.
+    const missingContribution = runtimeContributions().find(
+      (contribution) =>
+        contribution.logicalName === "fulltext" &&
+        missingTableErrorNames(error, contribution.tableName),
+    );
+    if (missingContribution !== undefined) {
+      throw new ContributionUnavailableError(
+        graphId,
+        missingContribution.tableName,
+        { cause: error },
+      );
+    }
+    throw error;
   }
 
   async function ensureVectorSlot(
@@ -1653,6 +1737,7 @@ export function createContributionMaterializer(
   return {
     ensureRuntimeContributions,
     assertInitialized,
+    refuseUnavailableFulltext,
     ensureVectorSlot,
     ensureVectorSlots,
     assertVectorSlot,

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -400,16 +400,11 @@ type RefuseUnavailableFulltext = (
 function missingTableErrorNames(error: unknown, tableName: string): boolean {
   const quotedTableName = `"${tableName.replaceAll('"', '""')}"`;
   for (const link of errorChain(error)) {
-    const message =
-      typeof link === "string" ?
-        link
-      : typeof link === "object" && link !== null ?
-        Reflect.get(link, "message")
-      : undefined;
+    const message = errorMessage(link);
     if (typeof message !== "string") continue;
 
     const sqliteMatch = /\bno such table:\s*([^\s;]+)/i.exec(message);
-    const sqliteName = sqliteMatch?.[1]?.replaceAll(/^["'`\[]|["'`\]]$/g, "");
+    const sqliteName = unquoteSqliteIdentifier(sqliteMatch?.[1]);
     if (sqliteName === tableName) return true;
 
     const namesPostgresTable =
@@ -418,6 +413,27 @@ function missingTableErrorNames(error: unknown, tableName: string): boolean {
     if (namesPostgresTable) return true;
   }
   return false;
+}
+
+function errorMessage(error: unknown): string | undefined {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return undefined;
+  }
+  return typeof error.message === "string" ? error.message : undefined;
+}
+
+function unquoteSqliteIdentifier(identifier: string | undefined): string | undefined {
+  if (identifier === undefined) return undefined;
+  const first = identifier.at(0);
+  const last = identifier.at(-1);
+  const isQuoted =
+    (first === '"' && last === '"') ||
+    (first === "'" && last === "'") ||
+    (first === "`" && last === "`") ||
+    (first === "[" && last === "]");
+  return isQuoted ? identifier.slice(1, -1) : identifier;
 }
 
 async function executeGatedFulltext<T>(
@@ -1131,12 +1147,13 @@ export function createContributionMaterializer(
     graphId: string,
     error: unknown,
   ): Promise<never> {
+    await Promise.resolve();
     if (!isMissingTableError(error)) throw error;
 
     // A failed transaction cannot run the uncached catalog audit on every
     // backend (Postgres marks it aborted; PGlite shares that one session).
-    // The failed statement still names the missing physical table. Combined
-    // That is transaction-safe proof that the declared physical storage is
+    // The failed statement still names the missing physical table. That is
+    // transaction-safe proof that the declared physical storage is
     // missing and avoids any healthy-path query. It does not prove the marker
     // still exists because the preceding assertion may have hit its cache.
     const missingContribution = runtimeContributions().find(

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -883,6 +883,7 @@ export function createPostgresBackend(
       backend: gateFulltext(
         backend,
         contributionMaterializer.assertInitialized,
+        contributionMaterializer.refuseUnavailableFulltext,
       ),
       drainAndClose,
     };
@@ -1007,6 +1008,7 @@ export function createPostgresBackend(
     ...gateFulltextMethods(
       operations,
       contributionMaterializer.assertInitialized,
+      contributionMaterializer.refuseUnavailableFulltext,
     ),
 
     async executeDdl(ddl: string): Promise<void> {

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1717,7 +1717,11 @@ export function createSqliteBackend(
       vectorStrategy,
       contributionMaterializer,
     });
-    return gateFulltext(txBackend, contributionMaterializer.assertInitialized);
+    return gateFulltext(
+      txBackend,
+      contributionMaterializer.assertInitialized,
+      contributionMaterializer.refuseUnavailableFulltext,
+    );
   }
 
   const backend: AdapterBackend<AnySqliteDatabase> = {
@@ -1814,6 +1818,7 @@ export function createSqliteBackend(
     ...gateFulltextMethods(
       operations,
       contributionMaterializer.assertInitialized,
+      contributionMaterializer.refuseUnavailableFulltext,
     ),
 
     async executeDdl(ddl: string): Promise<void> {
@@ -2212,6 +2217,7 @@ export function createSqliteBackend(
               gateFulltext(
                 txBackend,
                 contributionMaterializer.assertInitialized,
+                contributionMaterializer.refuseUnavailableFulltext,
               ),
               db,
             );

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -1248,7 +1248,7 @@ export type RecordContributionMaterializationParams = Readonly<{
  *   `DROP`, a schema-scoped restore that missed the contribution
  *   tables). The state {@link GraphBackend.verifyContributions} exists
  *   to surface: nothing on the open path probes the catalog, so this
- *   database opens clean and fails at the first read of the slot.
+ *   database opens clean and fails at the first dependent read or write.
  * - `missing-marker` — the physical table exists but no marker attests
  *   it as initialized (no row, no recorded success, or a recorded
  *   failure). Reads and writes are refused with
@@ -1384,9 +1384,10 @@ export type ContributionProbeContribution = "fulltext" | "vector";
  *   its durable marker and present in the catalog. Not a promise about
  *   future coherence: a write that lands after the probe returns is
  *   outside what any assessment can cover.
- * - `degraded` — at least one contribution is unusable. Queries against
- *   this projection will be refused (`StoreNotInitializedError`) or will
- *   read incomplete storage.
+ * - `degraded` — at least one contribution is unusable. Dependent operations
+ *   may be refused with a typed contribution error, fail at the engine boundary
+ *   when compiled SQL directly references missing storage, or observe
+ *   incomplete storage.
  *   {@link ContributionProbeEntry.detail} says which and why.
  * - `building` — **reserved.** No shipped path publishes it. Recording
  *   an in-flight marker would need a fifth
@@ -2360,8 +2361,8 @@ export type GraphBackend = Readonly<{
    * per-instance signature cache and then on the marker row alone, which
    * is the right default for a hot path but leaves a database whose
    * contribution tables were dropped out of band opening clean and
-   * failing at the first read. This method is the explicit, operator-
-   * invoked catalog probe that fills that gap: it issues one uncached
+   * failing at the first dependent read or write. This method is the explicit,
+   * operator-invoked catalog probe that fills that gap: it issues one uncached
    * existence query per distinct physical table and performs ZERO DDL
    * and ZERO writes, so it is safe under a least-privilege runtime role.
    *

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -1666,6 +1666,49 @@ function storeNotInitializedAction(
   );
 }
 
+/** Details for a runtime contribution whose durable marker outlived storage. */
+export type ContributionUnavailableErrorDetails = Readonly<{
+  graphId: string;
+  logicalName: "fulltext";
+  physicalName: string;
+  state: "physical-storage-missing";
+}>;
+
+/**
+ * Thrown when a gated fulltext operation discovers that materialized storage
+ * disappeared after its durable marker recorded successful initialization.
+ */
+export class ContributionUnavailableError extends TypeGraphError {
+  declare readonly details: ContributionUnavailableErrorDetails;
+
+  constructor(
+    graphId: string,
+    physicalName: string,
+    options?: Readonly<{ cause?: unknown }>,
+  ) {
+    const suggestion =
+      'Run store.rebuildContribution("fulltext") to recreate the lost ' +
+      "storage and repopulate it from the graph's nodes.";
+    super(
+      `Fulltext storage "${physicalName}" for graph "${graphId}" ` +
+        `disappeared after initialization. ${suggestion}`,
+      "CONTRIBUTION_UNAVAILABLE",
+      {
+        details: {
+          graphId,
+          logicalName: "fulltext",
+          physicalName,
+          state: "physical-storage-missing",
+        },
+        category: "user",
+        suggestion,
+        cause: options?.cause,
+      },
+    );
+    this.name = "ContributionUnavailableError";
+  }
+}
+
 /**
  * Human label for the un-materialized storage, derived from the
  * contribution `logicalName`: fulltext keeps "fulltext storage"; a vector

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -319,6 +319,7 @@ export {
 export type {
   CardinalityErrorDetails,
   ContributionRebuildRefusal,
+  ContributionUnavailableErrorDetails,
   DatabaseOperationErrorDetails,
   DisjointErrorDetails,
   EagerMaterializationErrorDetails,
@@ -359,6 +360,7 @@ export {
   CompilerInvariantError,
   ConfigurationError,
   ContributionRebuildUnsupportedError,
+  ContributionUnavailableError,
   DatabaseOperationError,
   DisjointError,
   EagerMaterializationError,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -4156,8 +4156,9 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * path. The cost is that a database whose contribution tables were dropped
    * out of band (a partial restore, a hand-run `DROP`, a schema-scoped
    * restore that missed them) opens completely clean and then fails at the
-   * first read of the affected slot. This is the explicit, operator-invoked
-   * check for that state; it is not, and should not become, a boot step.
+   * first read or write that depends on the affected slot. This is the
+   * explicit, operator-invoked check for that state; it is not, and should not
+   * become, a boot step.
    *
    * Purely read-only: one existence query per distinct contribution table
    * plus one marker read per graph, no DDL and no writes, so it is safe to
@@ -4246,8 +4247,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   }
 
   /**
-   * Read-only readiness check for the search projections: is search
-   * coherent with the graph right now, or is a query about to hit a
+   * Read-only readiness check for the search projections: are dependent reads
+   * and writes coherent with the graph right now, or are they about to hit a
    * degraded index?
    *
    * The read-only half of {@link Store.repairContributions}, and the

--- a/packages/typegraph/tests/backends/integration/contribution-diagnostics.ts
+++ b/packages/typegraph/tests/backends/integration/contribution-diagnostics.ts
@@ -706,6 +706,9 @@ export function registerContributionDiagnosticIntegrationTests(
         );
 
         expect(error).toBeInstanceOf(ContributionUnavailableError);
+        if (!(error instanceof ContributionUnavailableError)) {
+          throw new Error("Expected ContributionUnavailableError");
+        }
         expect(error).toMatchObject({
           code: "CONTRIBUTION_UNAVAILABLE",
           details: {
@@ -714,8 +717,8 @@ export function registerContributionDiagnosticIntegrationTests(
             physicalName: contribution.tableName,
             state: "physical-storage-missing",
           },
-          cause: expect.anything(),
         });
+        expect(error.cause).toBeDefined();
         expect(
           await store.nodes.Article.getById(nodeId as never),
         ).toBeUndefined();
@@ -743,6 +746,9 @@ export function registerContributionDiagnosticIntegrationTests(
         );
 
         expect(error).toBeInstanceOf(ContributionUnavailableError);
+        if (!(error instanceof ContributionUnavailableError)) {
+          throw new Error("Expected ContributionUnavailableError");
+        }
         expect(error).toMatchObject({
           code: "CONTRIBUTION_UNAVAILABLE",
           details: {
@@ -751,8 +757,8 @@ export function registerContributionDiagnosticIntegrationTests(
             physicalName: contribution.tableName,
             state: "physical-storage-missing",
           },
-          cause: expect.anything(),
         });
+        expect(error.cause).toBeDefined();
       });
 
       it("escalates a dropped fulltext table through repair to rebuild", async (ctx) => {

--- a/packages/typegraph/tests/backends/integration/contribution-diagnostics.ts
+++ b/packages/typegraph/tests/backends/integration/contribution-diagnostics.ts
@@ -33,6 +33,7 @@ import { z } from "zod";
 
 import {
   ContributionRebuildUnsupportedError,
+  ContributionUnavailableError,
   defineGraph,
   defineNode,
   resolveGraphVectorSlots,
@@ -680,6 +681,78 @@ export function registerContributionDiagnosticIntegrationTests(
             ]
           : [{ contribution: "fulltext", state: "ready" }];
         expect(result.entries).toEqual(expected);
+      });
+
+      it("refuses a searchable write with a typed error after fulltext storage disappears", async () => {
+        const store = context.getStore();
+        const contribution = fulltextContribution();
+        const nodeId = "orphaned-fulltext-write";
+
+        await executeDdl(
+          context.getBackend(),
+          `DROP TABLE IF EXISTS ${contribution.tableName}`,
+        );
+
+        const error = await captureRejection(
+          store.nodes.Article.create(
+            {
+              title: "Orphaned write",
+              body: "This node insert must roll back.",
+              category: "health",
+              published: true,
+            },
+            { id: nodeId },
+          ),
+        );
+
+        expect(error).toBeInstanceOf(ContributionUnavailableError);
+        expect(error).toMatchObject({
+          code: "CONTRIBUTION_UNAVAILABLE",
+          details: {
+            graphId: integrationTestGraph.id,
+            logicalName: "fulltext",
+            physicalName: contribution.tableName,
+            state: "physical-storage-missing",
+          },
+          cause: expect.anything(),
+        });
+        expect(
+          await store.nodes.Article.getById(nodeId as never),
+        ).toBeUndefined();
+      });
+
+      it("refuses fulltext search with a typed error after its storage disappears", async () => {
+        const store = context.getStore();
+        const contribution = fulltextContribution();
+        await store.nodes.Article.create({
+          title: "Orphaned search",
+          body: "Warm the fulltext write path before dropping its storage.",
+          category: "health",
+          published: true,
+        });
+        await executeDdl(
+          context.getBackend(),
+          `DROP TABLE IF EXISTS ${contribution.tableName}`,
+        );
+
+        const error = await captureRejection(
+          store.search.fulltext("Article", {
+            query: "orphaned",
+            limit: 10,
+          }),
+        );
+
+        expect(error).toBeInstanceOf(ContributionUnavailableError);
+        expect(error).toMatchObject({
+          code: "CONTRIBUTION_UNAVAILABLE",
+          details: {
+            graphId: integrationTestGraph.id,
+            logicalName: "fulltext",
+            physicalName: contribution.tableName,
+            state: "physical-storage-missing",
+          },
+          cause: expect.anything(),
+        });
       });
 
       it("escalates a dropped fulltext table through repair to rebuild", async (ctx) => {

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  ContributionUnavailableError,
   fts5Strategy,
   pgvectorStrategy,
   StoreNotInitializedError,
@@ -60,6 +61,15 @@ const POSTGRES_MISSING_MARKER_TABLE_ERROR = Object.assign(
     ),
   },
 );
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
 
 function markerKey(identity: ContributionMaterializationIdentity): string {
   return [
@@ -174,6 +184,86 @@ function vectorTableOf(slot: VectorSlot): string {
     slot.fieldPath,
   );
 }
+
+describe("refuseUnavailableFulltext", () => {
+  it("translates a named missing fulltext table without a catalog query", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer, spies } = createMockMaterializer(markers);
+    await materializer.ensureRuntimeContributions(GRAPH_ID);
+    spies.tableExists.mockClear();
+    const cause = new Error(`no such table: ${FULLTEXT_TABLE}`);
+
+    const error = await captureRejection(
+      materializer.refuseUnavailableFulltext(GRAPH_ID, cause),
+    );
+
+    expect(error).toBeInstanceOf(ContributionUnavailableError);
+    expect(error).toMatchObject({
+      code: "CONTRIBUTION_UNAVAILABLE",
+      details: {
+        graphId: GRAPH_ID,
+        logicalName: "fulltext",
+        physicalName: FULLTEXT_TABLE,
+        state: "physical-storage-missing",
+      },
+      cause,
+    });
+    expect(spies.tableExists).not.toHaveBeenCalled();
+  });
+
+  it("rethrows unrelated failures without probing the catalog", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer, spies } = createMockMaterializer(markers);
+    const cause = new Error("permission denied");
+
+    await expect(
+      materializer.refuseUnavailableFulltext(GRAPH_ID, cause),
+    ).rejects.toBe(cause);
+    expect(spies.tableExists).not.toHaveBeenCalled();
+  });
+
+  it("rethrows a missing-relation failure that names another table", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer, spies } = createMockMaterializer(markers);
+    await materializer.ensureRuntimeContributions(GRAPH_ID);
+    spies.tableExists.mockClear();
+    const cause = new Error("no such table: unrelated_table");
+
+    await expect(
+      materializer.refuseUnavailableFulltext(GRAPH_ID, cause),
+    ).rejects.toBe(cause);
+    expect(spies.tableExists).not.toHaveBeenCalled();
+  });
+
+  it("does not combine an outer fulltext query with another missing relation", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer } = createMockMaterializer(markers);
+    await materializer.ensureRuntimeContributions(GRAPH_ID);
+    const cause = Object.assign(
+      new Error('relation "unrelated_table" does not exist'),
+      { code: "42P01" },
+    );
+    const wrapped = Object.assign(
+      new Error(`Failed query: DELETE FROM "${FULLTEXT_TABLE}"`),
+      { cause },
+    );
+
+    await expect(
+      materializer.refuseUnavailableFulltext(GRAPH_ID, wrapped),
+    ).rejects.toBe(wrapped);
+  });
+
+  it("does not mistake a shadow-table prefix for the declared table", async () => {
+    const markers = new Map<string, ContributionMaterializationRow>();
+    const { materializer } = createMockMaterializer(markers);
+    await materializer.ensureRuntimeContributions(GRAPH_ID);
+    const cause = new Error(`no such table: ${FULLTEXT_TABLE}_shadow`);
+
+    await expect(
+      materializer.refuseUnavailableFulltext(GRAPH_ID, cause),
+    ).rejects.toBe(cause);
+  });
+});
 
 /**
  * Provision a graph at both a fulltext and a vector contribution — the

--- a/packages/typegraph/tests/errors.test.ts
+++ b/packages/typegraph/tests/errors.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 import type {
   CardinalityErrorDetails,
+  ContributionUnavailableErrorDetails,
   DatabaseOperationErrorDetails,
   DisjointErrorDetails,
   EagerMaterializationErrorDetails,
@@ -30,6 +31,7 @@ import {
   CardinalityError,
   CompilerInvariantError,
   ConfigurationError,
+  ContributionUnavailableError,
   DatabaseOperationError,
   DisjointError,
   EagerMaterializationError,
@@ -936,6 +938,31 @@ describe("StoreNotInitializedError", () => {
       reason: "stale",
       logicalName: "vector:summary",
     });
+  });
+});
+
+describe("ContributionUnavailableError", () => {
+  it("directs orphaned fulltext storage to a rebuild", () => {
+    const cause = new Error("no such table: typegraph_node_fulltext");
+    const error = new ContributionUnavailableError(
+      "lib",
+      "typegraph_node_fulltext",
+      { cause },
+    );
+
+    expect(error.message).toContain("disappeared after initialization");
+    expect(error.message).toContain('rebuildContribution("fulltext")');
+    expect(error.suggestion).toContain('rebuildContribution("fulltext")');
+    expect(error.cause).toBe(cause);
+    expect(error.details).toEqual({
+      graphId: "lib",
+      logicalName: "fulltext",
+      physicalName: "typegraph_node_fulltext",
+      state: "physical-storage-missing",
+    });
+    expectTypeOf(
+      error.details,
+    ).toEqualTypeOf<ContributionUnavailableErrorDetails>();
   });
 });
 

--- a/packages/typegraph/tests/store-internal-helpers.test.ts
+++ b/packages/typegraph/tests/store-internal-helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { gateFulltext } from "../src/backend/drizzle/contribution-materializations";
+import {
+  type GatableFulltextBackend,
+  gateFulltext,
+  gateFulltextMethods,
+} from "../src/backend/drizzle/contribution-materializations";
 import {
   closeAfterFailure,
   createBackendOverlay,
@@ -620,6 +624,7 @@ describe("backend overlay wrappers", () => {
         assertedGraphIds.push(graphId);
         return Promise.resolve();
       },
+      (graphId, error) => Promise.reject(error),
     );
 
     await gated.execute(asCompiledRowsSql(sql`SELECT 1`));
@@ -634,6 +639,88 @@ describe("backend overlay wrappers", () => {
       "execute:prototype",
       "hardDeleteNode:prototype:person-1",
     ]);
+  });
+
+  it("routes every fulltext method failure through one refusal handler", async () => {
+    const rawError = new Error("raw fulltext failure");
+    const translatedError = new Error("typed fulltext failure");
+    const rejectRaw = vi.fn((): Promise<never> => Promise.reject(rawError));
+    const source = {
+      upsertFulltext: rejectRaw,
+      deleteFulltext: rejectRaw,
+      upsertFulltextBatch: rejectRaw,
+      deleteFulltextBatch: rejectRaw,
+      fulltextSearch: rejectRaw,
+      hardDeleteNode: rejectRaw,
+    } satisfies GatableFulltextBackend;
+    const assert = vi.fn((): Promise<void> => Promise.resolve());
+    const refuseUnavailable = vi.fn(
+      (_graphId: string, _error: unknown): Promise<never> =>
+        Promise.reject(translatedError),
+    );
+    const gated = gateFulltextMethods(source, assert, refuseUnavailable);
+
+    const calls: readonly (() => Promise<unknown>)[] = [
+      () =>
+        requireDefined(gated.upsertFulltext)({
+          graphId: "graph",
+          nodeKind: "Person",
+          nodeId: "person-1",
+          content: "Ada",
+          language: "english",
+        }),
+      () =>
+        requireDefined(gated.deleteFulltext)({
+          graphId: "graph",
+          nodeKind: "Person",
+          nodeId: "person-1",
+        }),
+      () =>
+        requireDefined(gated.upsertFulltextBatch)({
+          graphId: "graph",
+          nodeKind: "Person",
+          rows: [{ nodeId: "person-1", content: "Ada", language: "english" }],
+        }),
+      () =>
+        requireDefined(gated.deleteFulltextBatch)({
+          graphId: "graph",
+          nodeKind: "Person",
+          nodeIds: ["person-1"],
+        }),
+      () =>
+        requireDefined(gated.fulltextSearch)({
+          graphId: "graph",
+          nodeKind: "Person",
+          query: "Ada",
+          limit: 10,
+        }),
+      () =>
+        requireDefined(gated.hardDeleteNode)({
+          graphId: "graph",
+          kind: "Person",
+          id: "person-1",
+        }),
+    ];
+
+    for (const call of calls) {
+      await expect(call()).rejects.toBe(translatedError);
+    }
+    expect(assert).toHaveBeenCalledTimes(calls.length);
+    expect(refuseUnavailable).toHaveBeenCalledTimes(calls.length);
+    expect(refuseUnavailable).toHaveBeenCalledWith("graph", rawError);
+
+    await requireDefined(gated.upsertFulltextBatch)({
+      graphId: "graph",
+      nodeKind: "Person",
+      rows: [],
+    });
+    await requireDefined(gated.deleteFulltextBatch)({
+      graphId: "graph",
+      nodeKind: "Person",
+      nodeIds: [],
+    });
+    expect(assert).toHaveBeenCalledTimes(calls.length);
+    expect(refuseUnavailable).toHaveBeenCalledTimes(calls.length);
   });
 });
 

--- a/packages/typegraph/tests/store-internal-helpers.test.ts
+++ b/packages/typegraph/tests/store-internal-helpers.test.ts
@@ -624,7 +624,7 @@ describe("backend overlay wrappers", () => {
         assertedGraphIds.push(graphId);
         return Promise.resolve();
       },
-      (graphId, error) => Promise.reject(error),
+      () => Promise.reject(new Error("Unexpected unavailable fulltext")),
     );
 
     await gated.execute(asCompiledRowsSql(sql`SELECT 1`));


### PR DESCRIPTION
Fulltext contribution markers are cached after boot, so out-of-band storage loss previously passed the runtime gate and leaked an untyped driver error from searchable writes and the fulltext search facade. Gated fulltext operations now translate only a missing-relation failure that names the exact declared storage table on the same driver error into `ContributionUnavailableError`, preserving the original cause and pointing callers to `rebuildContribution("fulltext")`. Healthy operations retain the cached fast path, and unrelated database errors are rethrown unchanged.

The error reports `state: "physical-storage-missing"` rather than claiming the marker is currently orphaned, because a warm gate may have been satisfied from cache. Searchable writes remain transactional where the backend supports transactions, and the documentation now distinguishes gated operations from query-builder predicates that compile directly to SQL.

The regression coverage is load-bearing: removing the translation restores the raw driver error, while attempting catalog diagnosis inside the failed transaction breaks PGlite. Exact-name negatives also protect against cross-cause Drizzle wrappers and similarly prefixed SQLite tables.