### PR TITLE
fix: store no lower bound for a born-ended write, and repair inverted windows

### DIFF
--- a/.changeset/born-ended-validity-windows.md
+++ b/.changeset/born-ended-validity-windows.md
@@ -24,3 +24,9 @@ Three consequences worth naming:
 
 Rows already stored with an inverted window are not rewritten; they stay
 invisible at every coordinate until repaired.
+
+Custom `GraphBackend` implementations should route node/edge insert stamping
+and node resurrection stamping through `resolveStampedValidityLowerBound`, now
+exported from `@nicia-ai/typegraph/backend`, so adapter-specific builders cannot
+drift from the shared validity-window contract. Edge resurrection retains its
+stored lower bound and therefore does not stamp one.

--- a/.changeset/born-ended-validity-windows.md
+++ b/.changeset/born-ended-validity-windows.md
@@ -1,0 +1,26 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Store no validity lower bound for a write that would otherwise be born already
+ended. A write that stamps a `valid_from` the caller did not state now stores
+the write instant only when doing so leaves a window some coordinate can read:
+if a stated `validTo` falls at or before that instant, the row is stored with no
+lower bound at all — "ended at T, start unknown" — and reads back at every `asOf`
+before its end instead of at none (#407). The decision lives in the SQL builders,
+so it holds for every `GraphBackend` caller, including interchange import and
+trusted import, not only for the store paths.
+
+Three consequences worth naming:
+
+- `meta.validFrom` is `undefined` for such a row, where it used to be an instant
+  no query could match.
+- A resurrecting `upsertById` / `bulkUpsertById` that names a lone historical
+  `validTo` on a tombstoned node **no longer refuses**: it reaches the same
+  stored shape a `create` on the same id reaches. One stated window, one outcome,
+  whichever entry point resets the window.
+- A `validTo` in the future is unchanged — it still stamps the write instant, so
+  a scheduled-end row stays invisible before it existed.
+
+Rows already stored with an inverted window are not rewritten; they stay
+invisible at every coordinate until repaired.

--- a/.changeset/repair-inverted-validity-windows.md
+++ b/.changeset/repair-inverted-validity-windows.md
@@ -1,0 +1,28 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `repairInvertedValidityWindows`, the explicit operator action that makes
+rows an older version stored with a backwards window (`valid_from > valid_to`)
+observable again. Such a row is readable at no coordinate at all; upgrading
+deliberately rewrites nothing, so repairing is a decision an operator takes
+rather than a side effect of a deploy.
+
+`mode: "report"` counts and writes nothing — it reads through `execute`, a
+required backend member, so detection works on every backend including a
+history-capturing one and one with no statement-execution support.
+`mode: "apply"` normalizes the rows it counted to no lower bound ("ended at T,
+start unknown"), the shape today's write paths store, and is idempotent and
+convergent. `relations` is required and takes `"live"` or `"live-and-recorded"`;
+`"live-and-recorded"` is recommended, because repairing only the live axis
+leaves the recorded twin inverted and re-materializes the invisible row at any
+`asOfRecorded` coordinate.
+
+The repair mints no revision, bumps no `version` and does not move `updated_at`:
+it normalizes storage for rows that were never observable, so it is not a
+logical write. Run it with writers stopped, and re-baseline outstanding merge
+branches afterwards — `valid_from` is part of the `base@V` content fingerprint.
+`apply` refuses rather than guessing on the states it cannot honor: a backend
+without statement execution, a recorded-capture backend, and (on SQLite, where
+bounds compare as text) a relation holding non-canonical bounds it cannot
+classify.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -682,6 +682,26 @@ Application code can continue importing the complete portable Store API from
 application deliberately owns a Drizzle connection or needs native transaction
 interop.
 
+Custom insert builders must apply the same born-ended validity rule as the
+built-in adapters. Import its public owner instead of duplicating the bound
+comparison:
+
+```typescript
+import { resolveStampedValidityLowerBound } from "@nicia-ai/typegraph/backend";
+
+const validFrom = resolveStampedValidityLowerBound(
+  params.validFrom,
+  params.validTo,
+  writeInstant,
+);
+```
+
+Use the same `writeInstant` for the decision and the row's creation/update
+stamp. This keeps custom node and edge inserts, plus node resurrection paths
+that reset the validity window, aligned with Store and interchange semantics at
+the zero-width boundary. Edge resurrection retains its stored lower bound and
+does not use this stamping helper.
+
 ## Managed Store Entrypoints
 
 For local applications that do not need direct database access, TypeGraph can

--- a/apps/docs/src/content/docs/core-concepts.md
+++ b/apps/docs/src/content/docs/core-concepts.md
@@ -122,7 +122,9 @@ const alice = await store.nodes.Person.create({ name: "Alice", email: "a@example
 //     createdAt: "2024-01-15T10:30:00.000Z",
 //     updatedAt: "2024-01-15T10:30:00.000Z",
 //     deletedAt: undefined,
-//     validFrom: "2024-01-15T10:30:00.000Z", // defaults to createdAt when omitted
+//     validFrom: "2024-01-15T10:30:00.000Z", // defaults to createdAt when omitted,
+//                                            // unless a stated past validTo makes
+//                                            // the row "born already ended" (undefined)
 //     validTo: undefined,
 //   }
 // }

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -147,8 +147,11 @@ try {
 Interchange import records the same refusal as a per-row error prefixed with the
 code, so one bad row does not abort the import; trusted import refuses the whole
 stream with `TrustedImportError` reason `invalid_stream`. A zero-width window
-(`validTo === validFrom`) is legal and never raises this, and so is a create
-carrying only a historical `validTo`.
+(`validTo === validFrom`) is legal and never raises this, and neither is a write
+that STAMPS its own start while carrying only a historical `validTo`: any create,
+and a node resurrection through `upsertById` / `bulkUpsertById`. Both store no
+lower bound instead. An edge resurrection RETAINS the bound the row already
+holds, so a `validTo` before that bound still raises this.
 
 #### `IMMUTABLE_VALIDITY_LOWER_BOUND`
 

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -173,13 +173,17 @@ its properties are replaced and its validity window is reset, so `validFrom`
 becomes the resurrection instant — unless the write carries an explicit
 window, which is honored as given (this is how merge preserves
 branch-authored windows). A resurrecting node write that supplies only a
-historical `validTo` is refused as a `ValidationError` rather than
-persisting a window that ends before it begins; pass both bounds for a
-historical window. (Edge resurrection instead keeps its stored lower bound,
-so `getOrCreateByEndpoints` can resurrect an edge directly into the ended
-state — but the end it names is held to that retained bound, so reviving
-an edge into a window that closed before the edge began likewise means
-passing both.) This graph-wide rule does not depend on the
+historical `validTo` takes the same **born-already-ended** exception a create
+takes: no lower bound is stored ("ended at T, start unknown") rather than a
+start after its own end, so the row reads back at every `asOf` before that end
+and `meta.validFrom` is `undefined`. One stated window reaches one stored shape
+whichever node path resets it — `create()` on a fresh id, `create()` on a
+tombstone, or a resurrecting `upsertById()`. (Edge resurrection instead keeps
+its stored lower bound, so `getOrCreateByEndpoints` can resurrect an edge
+directly into the ended state — but the end it names is held to that retained
+bound, so reviving an edge into a window that closed before the edge began is
+refused as a `ValidationError`, and means passing both bounds.) This graph-wide
+rule does not depend on the
 identity profile. Resurrection does not revive ended assertions, but folding
 runs again over the resurrected node when configured. Kind removal
 cascades assertion and closure rows for the removed kinds. Tightening ontology

--- a/apps/docs/src/content/docs/interchange.md
+++ b/apps/docs/src/content/docs/interchange.md
@@ -216,6 +216,13 @@ fields on, because assertion windows cannot be validated against endpoints
 without the endpoint bounds. Explicit `includeTemporal: false` is refused for
 those graphs.
 
+**Repair a legacy graph before exporting it.** A row an older library version
+stored with a backwards window (`valid_from > valid_to`) exports as it is stored
+and is then refused **per row** on re-import, because the import validates the
+stated pair — so an unrepaired graph does not round-trip. Run
+[`repairInvertedValidityWindows`](/schema-management#repairing-inverted-validity-windows)
+first; it normalizes those rows to the open-left shape import accepts.
+
 **`includeTemporal: true` with `onConflict: "update"`:** an update leg sends the
 document's `validTo` and never its `validFrom`, because a live row's lower bound
 is history. A document whose `validFrom` names a different instant than the

--- a/apps/docs/src/content/docs/interchange.md
+++ b/apps/docs/src/content/docs/interchange.md
@@ -96,10 +96,12 @@ interface GraphData {
 
 `validFrom` has three states: the key **absent** means it wasn't requested
 (`includeTemporal: false`, the default) — import defaults it to the
-import's own creation timestamp. An **explicit `null`** means the source
-row is confirmed to have no lower bound (open-left validity) — import
-preserves that instead of re-stamping it. A **string** is an explicit
-value, carried through unchanged.
+import's own creation timestamp, unless the record also states a `validTo`
+at or before that instant, in which case it is imported with no lower bound
+("ended at T, start unknown") rather than one past its own end. An
+**explicit `null`** means the source row is confirmed to have no lower bound
+(open-left validity) — import preserves that instead of re-stamping it. A
+**string** is an explicit value, carried through unchanged.
 
 ### Format Version Compatibility
 
@@ -201,7 +203,8 @@ next chunk, so a slow database read does not count as consumer idleness.
 
 **Round-trip caveat:** with the default `includeTemporal: false`, exported
 records carry no `validFrom`/`validTo`. On import, an omitted `validFrom`
-defaults to the *import's own* creation timestamp — so a plain
+defaults to the *import's own* creation timestamp (a born-already-ended record
+is the exception noted above, and keeps no lower bound) — so a plain
 `exportGraph` + `importGraph` round trip does **not** reproduce the
 source's original valid-time window; every imported record becomes valid
 from import time forward. Pass `includeTemporal: true` on export when the

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -349,6 +349,12 @@ Temporal queries (`asOf`, `includeEnded`) work correctly but have some constrain
   means "still valid". A record written with a `validTo` at or before its own creation instant
   is "born already ended" and stores no lower bound instead, so it reads back at every `asOf`
   before that end
+- Rows an **older library version** stored with a backwards window
+  (`valid_from > valid_to`) are readable at no coordinate, and upgrading does not rewrite
+  them. Making them observable is an explicit operator action: run
+  `repairInvertedValidityWindows({ relations: "live-and-recorded", mode: "apply" })` while
+  writers are stopped, then re-baseline any outstanding merge branches. See
+  [Repairing inverted validity windows](/schema-management#repairing-inverted-validity-windows)
 - Clock skew between application servers can affect temporal accuracy
 
 ### Recorded / system time (`history: true`)

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -346,7 +346,9 @@ Temporal queries (`asOf`, `includeEnded`) work correctly but have some constrain
 - Point-in-time queries cannot be combined with streaming (`.stream()`)
 - `validFrom` defaults to the record's own creation timestamp when omitted, so `asOf` queries
   work out of the box; an end boundary still requires an explicit `validTo` — an open `validTo`
-  means "still valid"
+  means "still valid". A record written with a `validTo` at or before its own creation instant
+  is "born already ended" and stores no lower bound instead, so it reads back at every `asOf`
+  before that end
 - Clock skew between application servers can affect temporal accuracy
 
 ### Recorded / system time (`history: true`)

--- a/apps/docs/src/content/docs/queries/temporal.md
+++ b/apps/docs/src/content/docs/queries/temporal.md
@@ -546,6 +546,20 @@ every instant at or before its `validTo`. Two writes produce one:
   `bulkUpsertById` and `getOrCreateByEndpoints` — RETAIN the bound the row
   carries and judge the stated `validTo` against it.
 
+#### Rows written by older versions
+
+Before that rule existed, a born-already-ended write stored the write instant as
+`valid_from`, leaving a window that runs backwards — a row readable at **no**
+coordinate at all. Upgrading does not rewrite such rows; they keep their window
+and stay invisible until an operator repairs them explicitly with
+`repairInvertedValidityWindows`, which normalizes them to the open-left shape
+above. Prefer `relations: "live-and-recorded"`: repairing only the live axis
+leaves the recorded twin inverted, so `asOfRecorded` reads keep returning the
+invisible shape. See
+[Repairing inverted validity windows](/schema-management#repairing-inverted-validity-windows)
+for the operator checklist — run it with writers stopped, and re-baseline merge
+branches afterwards.
+
 ```typescript
 .select((ctx) => ({
   ...ctx.a,                     // All node properties

--- a/apps/docs/src/content/docs/queries/temporal.md
+++ b/apps/docs/src/content/docs/queries/temporal.md
@@ -533,18 +533,18 @@ every instant at or before its `validTo`. Two writes produce one:
 
 - an interchange record stating `validFrom: null` — a source row confirmed to
   have no lower bound, round-tripped rather than re-stamped;
-- a **born-already-ended** write: one that CREATES a row while stating a
-  `validTo` at or before its own instant and no `validFrom`. The row's start is
-  unknown rather than after its end, so no bound is stored and the row reads back
-  at every `asOf` before that end. A `validTo` in the *future* is unaffected — it
-  still stamps the creation instant, so the row stays invisible at instants
-  before it existed. A **node** create whose id names a tombstone resurrects
-  that row and still qualifies — same stored shape as a fresh id; an edge create
-  never lands on a tombstone (a taken id raises `Edge already exists`). A
-  resurrecting *upsert* does not: on a tombstoned node, `upsertById` /
-  `bulkUpsertById` judge the stated `validTo` against the resurrection instant;
-  on a tombstoned edge, `bulkUpsertById` and `getOrCreateByEndpoints` judge it
-  against the bound the row retains.
+- a **born-already-ended** write: one that CREATES a row, or RESETS its window,
+  while stating a `validTo` at or before its own instant and no `validFrom`. The
+  row's start is unknown rather than after its end, so no bound is stored and the
+  row reads back at every `asOf` before that end. A `validTo` in the *future* is
+  unaffected — it still stamps the write instant, so the row stays invisible at
+  instants before it existed. Every **node** path that resets the window
+  qualifies, and reaches the same stored shape: a create on a fresh id, a create
+  on a tombstoned one, and a resurrecting `upsertById` / `bulkUpsertById`. An
+  **edge** never does: an edge create cannot land on a tombstone (a taken id
+  raises `Edge already exists`), and the two paths that resurrect one —
+  `bulkUpsertById` and `getOrCreateByEndpoints` — RETAIN the bound the row
+  carries and judge the stated `validTo` against it.
 
 ```typescript
 .select((ctx) => ({

--- a/apps/docs/src/content/docs/queries/temporal.md
+++ b/apps/docs/src/content/docs/queries/temporal.md
@@ -518,12 +518,33 @@ When querying with temporal context, these fields are available:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `validFrom` | `string \| undefined` | When this version became valid |
+| `validFrom` | `string \| undefined` | When this version became valid (`undefined` on an **open-left** row — see below) |
 | `validTo` | `string \| undefined` | When this version was superseded (undefined if current) |
 | `createdAt` | `string` | When the node was first created |
 | `updatedAt` | `string` | When this version was written |
 | `deletedAt` | `string \| undefined` | Soft-delete timestamp (undefined if not deleted) |
 | `version` | `number` | Optimistic concurrency version number |
+
+### Open-left rows (`validFrom` is `undefined`)
+
+A row may have **no lower bound at all**, which means "valid since forever, as
+far as this store knows". `asOf` and `current` treat such a row as valid at
+every instant at or before its `validTo`. Two writes produce one:
+
+- an interchange record stating `validFrom: null` — a source row confirmed to
+  have no lower bound, round-tripped rather than re-stamped;
+- a **born-already-ended** write: one that CREATES a row while stating a
+  `validTo` at or before its own instant and no `validFrom`. The row's start is
+  unknown rather than after its end, so no bound is stored and the row reads back
+  at every `asOf` before that end. A `validTo` in the *future* is unaffected — it
+  still stamps the creation instant, so the row stays invisible at instants
+  before it existed. A **node** create whose id names a tombstone resurrects
+  that row and still qualifies — same stored shape as a fresh id; an edge create
+  never lands on a tombstone (a taken id raises `Edge already exists`). A
+  resurrecting *upsert* does not: on a tombstoned node, `upsertById` /
+  `bulkUpsertById` judge the stated `validTo` against the resurrection instant;
+  on a tombstoned edge, `bulkUpsertById` and `getOrCreateByEndpoints` judge it
+  against the bound the row retains.
 
 ```typescript
 .select((ctx) => ({

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -549,6 +549,10 @@ await repairInvertedValidityWindows({
 });
 ```
 
+If `tableNames` is supplied, it patches `backend.tableNames`; unstated relation
+names keep the backend's configured values. A partial override never sends the
+other relations back to TypeGraph's built-in defaults.
+
 `relations` is **required**, and `"live-and-recorded"` is the recommended scope.
 Repairing only the live axis leaves the recorded twin carrying the inverted
 window, which re-materializes the invisible row at any `asOfRecorded`
@@ -561,14 +565,14 @@ historical `asOfRecorded` reads keep returning the invisible shape.
 What an operator must know before running it:
 
 1. **Run `apply` with writers stopped**, the same guidance
-   `migrateLegacyRecordedTime()` carries. A concurrent update fences its write
-   on the validity lower bound it read, so a repair landing in between makes the
-   peer's `UPDATE` match no row: a store write surfaces a not-found refusal that
-   is safe to retry, and an interchange import reports that row as accepted but
-   not written. `report` needs no quiescing: it scans in a read-only transaction
+   `migrateLegacyRecordedTime()` carries. A concurrent window-bearing update
+   may fence its write on the validity lower bound it read, so a repair landing
+   in between can make the peer's first `UPDATE` match no row. Store node and
+   edge updates re-read and re-judge against the repaired bound; interchange
+   records a per-row target-changed error instead of claiming the row was
+   written. `report` needs no quiescing: it scans in a read-only transaction
    (`BEGIN` rather than SQLite's writer-reserving `BEGIN IMMEDIATE`, and
-   `BEGIN … READ ONLY` on PostgreSQL), so it neither blocks a live writer nor
-   can write itself.
+   `BEGIN … READ ONLY` on PostgreSQL), so it cannot write itself.
 2. **Repaired rows become visible** at `asOf` coordinates before their end. That
    is the point, and it is a read-visibility change to historical queries.
 3. **Outstanding `base@V` merge tokens are invalidated** for repaired rows —

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -508,6 +508,98 @@ been translated. `dropWhenEmpty: true` atomically drops the mapping table when
 the deleted graph was the final one. Without that option, the empty table is
 retained intentionally and can be dropped by your normal migration tooling.
 
+## Repairing Inverted Validity Windows
+
+Older library versions could store a row whose validity window runs backwards
+(`valid_from > valid_to`). Such a row is readable at **no** coordinate at all:
+`asOf(t)` needs `valid_from <= t < valid_to`, and backwards bounds admit no `t`.
+The write paths no longer produce one — a write that stamps a lower bound the
+caller did not state now stores no bound rather than an inverting one, see
+[Open-left rows](/queries/temporal#open-left-rows-validfrom-is-undefined) — but
+**upgrading rewrites nothing**. Rows already stored that way keep their window
+and stay invisible until an operator repairs them, which is deliberate: an
+upgrade that silently made previously-invisible rows appear in historical
+queries would be the worse surprise.
+
+`repairInvertedValidityWindows` is that explicit action. It has two modes:
+`report` counts and writes nothing, `apply` normalizes the rows it counted to
+`valid_from = NULL` ("ended at T, start unknown").
+
+```typescript
+import { repairInvertedValidityWindows } from "@nicia-ai/typegraph";
+
+// Diagnose. `report` reads through `execute`, a required backend member, so it
+// runs against ANY backend — including a history-capturing one and one with no
+// statement-execution support.
+const report = await repairInvertedValidityWindows({
+  backend: anyBackend,
+  relations: "live-and-recorded",
+  mode: "report",
+});
+// report.counts.recordedNodes === undefined means NOT SCANNED, never "clean".
+// report.atomic === false means the counts came from per-relation snapshots.
+
+// Repair, with writers stopped. On a history-enabled store pass the RAW backend
+// you constructed it from: the repair mints no revision by design, and the
+// capture wrapper refuses raw statements.
+await repairInvertedValidityWindows({
+  backend: rawBackend,
+  relations: "live-and-recorded",
+  mode: "apply",
+});
+```
+
+`relations` is **required**, and `"live-and-recorded"` is the recommended scope.
+Repairing only the live axis leaves the recorded twin carrying the inverted
+window, which re-materializes the invisible row at any `asOfRecorded`
+coordinate — the same defect one axis over. `"live"` is right in exactly two
+cases: the store captures no history and the `recorded_*` tables do not exist
+(scanning them is then an error, not a no-op), or you are deliberately keeping
+the recorded axis as an audit record of the pre-repair state and accept that
+historical `asOfRecorded` reads keep returning the invisible shape.
+
+What an operator must know before running it:
+
+1. **Run `apply` with writers stopped**, the same guidance
+   `migrateLegacyRecordedTime()` carries. A concurrent update fences its write
+   on the validity lower bound it read, so a repair landing in between makes the
+   peer's `UPDATE` match no row: a store write surfaces a not-found refusal that
+   is safe to retry, and an interchange import reports that row as accepted but
+   not written. `report` needs no quiescing: it scans in a read-only transaction
+   (`BEGIN` rather than SQLite's writer-reserving `BEGIN IMMEDIATE`, and
+   `BEGIN … READ ONLY` on PostgreSQL), so it neither blocks a live writer nor
+   can write itself.
+2. **Repaired rows become visible** at `asOf` coordinates before their end. That
+   is the point, and it is a read-visibility change to historical queries.
+3. **Outstanding `base@V` merge tokens are invalidated** for repaired rows —
+   `valid_from` is part of the base content fingerprint, so a merge whose base
+   token predates the repair fails its precondition afterwards. Quiesce merges,
+   repair, then re-baseline branches.
+4. **The repair mints no revision and bumps no `version`**, and does not move
+   `updated_at`. It normalizes a storage convention for rows that were never
+   observable at any coordinate; it is not a logical write. That is why `apply`
+   is run against the raw backend, and why bypassing recorded-time capture here
+   is intended rather than a workaround.
+5. **`apply` refuses when a scanned relation stores non-canonical bounds**
+   (SQLite only — PostgreSQL stores `timestamptz`, so a scanned relation always
+   reports `nonCanonical: 0`). SQLite compares the bounds as text, so a
+   non-canonical value cannot be classified without a timestamp semantics this
+   repair does not own. The refusal is total: the whole call is rejected before
+   any row is updated, so `apply` never repairs the rows it understood and skips
+   the rest. `report` still counts them, in `nonCanonical` — normalize those
+   bounds, or narrow the call with `graphId`, and re-run.
+6. **On a backend without transactions the call still runs**, per relation, and
+   says so with `report.atomic === false`: the counts may span snapshots, and a
+   crash mid-`apply` can leave the live axis repaired and the recorded axis not.
+   Re-run — each statement is idempotent and convergent, and a later `report`
+   proves it converged.
+7. **Repair before exporting a legacy graph.** An exported inverted row is
+   refused per row on re-import, so an unrepaired graph does not round-trip.
+
+The statement touches only rows the library mis-stored, so it is empty on a
+healthy graph and needs no batching. If a report returns a count large enough to
+worry about, narrow the call with `graphId` and run it per graph.
+
 ## Schema Serialization
 
 Schemas are stored as JSON documents with computed hashes for fast comparison:

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -692,8 +692,29 @@ The store provides typed node and edge collections via `store.nodes.*` and `stor
 Every write method below that accepts a `validFrom` option (`create`,
 `createFromRecord`, `upsertById`, `upsertByIdFromRecord`, `bulkCreate`,
 `bulkInsert`, `bulkUpsertById`, and their edge equivalents) defaults it to
-that operation's own creation timestamp when omitted — `validFrom` is never
-left open-ended. `validTo` remains optional and open-ended until set.
+that operation's own creation timestamp when omitted. `validTo` remains
+optional and open-ended until set.
+
+The one exception is a row **born already ended**: a write that CREATES a row
+while stating a `validTo` at or before its own instant and no `validFrom` stores
+**no lower bound** ("ended at T, start unknown") rather than a start after its
+own end, and `meta.validFrom` reads back as `undefined`. Such a row is visible at
+every `asOf` coordinate before its end and at none after it. A `validTo` in the
+future is unaffected — it still stamps the creation timestamp, so the row is
+invisible at instants before it existed.
+
+The exception follows the API, not the row's prior state. Every **node** create
+path takes it, including a `create`, `bulkCreate`, or `bulkInsert` whose id names
+a tombstone: that call resurrects the row and reaches the same stored shape a
+fresh id would — no lower bound, `meta.validFrom` back as `undefined`. An edge
+create never lands on a tombstone — a taken id raises `Edge already exists`, and
+a tombstoned edge is reachable again only through `bulkUpsertById` or
+`getOrCreateByEndpoints`. A **resurrecting upsert** does not take it. `upsertById` / `bulkUpsertById` on a tombstoned node
+resets the window and judges a lone historical `validTo` against the resurrection
+instant, refusing it; `bulkUpsertById` and `getOrCreateByEndpoints` on a
+tombstoned edge retain the bound that row already carries and judge the stated
+`validTo` against that. Pass `validFrom` alongside a historical `validTo` when an
+upsert may land on a tombstone.
 
 Writes that accept a validity-end mutation have three explicit states: omit both
 fields to preserve the stored end, pass `{ validTo }` to set or move it, or pass
@@ -709,7 +730,8 @@ a row stopped being true before it started, so no `asOf` coordinate could ever
 observe it. Two related shapes are legal: a ZERO-width window
 (`validTo === validFrom`), which is what a same-instant retraction produces; and
 a create carrying only a historical `validTo`, which means "born already ended"
-and is read back with the `includeEnded` temporal mode.
+and is read back at any `asOf` coordinate before that end, or through the
+`includeEnded` temporal mode.
 
 ### Node Collections
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -695,26 +695,25 @@ Every write method below that accepts a `validFrom` option (`create`,
 that operation's own creation timestamp when omitted. `validTo` remains
 optional and open-ended until set.
 
-The one exception is a row **born already ended**: a write that CREATES a row
-while stating a `validTo` at or before its own instant and no `validFrom` stores
-**no lower bound** ("ended at T, start unknown") rather than a start after its
-own end, and `meta.validFrom` reads back as `undefined`. Such a row is visible at
-every `asOf` coordinate before its end and at none after it. A `validTo` in the
-future is unaffected — it still stamps the creation timestamp, so the row is
-invisible at instants before it existed.
+The one exception is a row **born already ended**: a write that CREATES or
+RESETS a row's window while stating a `validTo` at or before its own instant and
+no `validFrom` stores **no lower bound** ("ended at T, start unknown") rather
+than a start after its own end, and `meta.validFrom` reads back as `undefined`.
+Such a row is visible at every `asOf` coordinate before its end and at none after
+it. A `validTo` in the future is unaffected — it still stamps the creation
+timestamp, so the row is invisible at instants before it existed.
 
-The exception follows the API, not the row's prior state. Every **node** create
-path takes it, including a `create`, `bulkCreate`, or `bulkInsert` whose id names
-a tombstone: that call resurrects the row and reaches the same stored shape a
-fresh id would — no lower bound, `meta.validFrom` back as `undefined`. An edge
-create never lands on a tombstone — a taken id raises `Edge already exists`, and
-a tombstoned edge is reachable again only through `bulkUpsertById` or
-`getOrCreateByEndpoints`. A **resurrecting upsert** does not take it. `upsertById` / `bulkUpsertById` on a tombstoned node
-resets the window and judges a lone historical `validTo` against the resurrection
-instant, refusing it; `bulkUpsertById` and `getOrCreateByEndpoints` on a
-tombstoned edge retain the bound that row already carries and judge the stated
-`validTo` against that. Pass `validFrom` alongside a historical `validTo` when an
-upsert may land on a tombstone.
+One stated window reaches one stored shape. Every **node** write that resets the
+window takes the exception: `create`, `bulkCreate` and `bulkInsert` on a fresh id
+or on one naming a tombstone, and `upsertById` / `bulkUpsertById` resurrecting a
+tombstoned node — all of them store no lower bound for a lone historical
+`validTo`, and `meta.validFrom` reads back as `undefined` in every case. An
+**edge** is different, and deliberately: an edge create never lands on a
+tombstone (a taken id raises `Edge already exists`), and a tombstoned edge is
+reachable again only through `bulkUpsertById` or `getOrCreateByEndpoints`, both
+of which RETAIN the bound that row already carries and judge the stated `validTo`
+against it — so a `validTo` before that bound is refused. Pass `validFrom`
+alongside a historical `validTo` when an edge upsert may land on a tombstone.
 
 Writes that accept a validity-end mutation have three explicit states: omit both
 fields to preserve the stored end, pass `{ validTo }` to set or move it, or pass

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -107,18 +107,21 @@ A model earns the name by three properties, and all three are load-bearing:
    requested one is checked against what it stored rather than flaking.
 3. **It passes unchanged on `main`.** A model that only passes after the fix it
    accompanies is a restatement of the fix. Where the tree is knowingly wrong,
-   the model declares the cell (`KNOWN_CONTRACT_GAPS`), withholds the op shape
-   that reaches it from the generator, and carries a still-reproduces test — and
-   each entry is deleted by the diff that measurably closes it, never later.
+   the model declares the cell in a gap table, withholds the op shape that
+   reaches it from the generator, and carries a still-reproduces test — and each
+   entry is deleted by the diff that measurably closes it, never later, with its
+   reproduction turned around into a gap-CLOSED test running the same script.
+   The temporal model carried three such entries and now carries none; its
+   `closed contract gaps` block is what that discipline leaves behind.
 
 `tests/temporal-oracle-imports.test.ts` ratchets the temporal model's
 independence: exact set equality over its import specifiers, a named-import
 check on `src/utils/date` so the window guards stay out, and an assertion that
 the barrel import is `import type`, so it cannot carry a value however the
-barrel grows. It also ratchets the gap table's plumbing by **sampling the
-history generator's own arbitrary**: a declared restriction is only real if the
-generator honors it, and comparing one spelling of the withheld set against
-another cannot show that.
+barrel grows. It also ratchets the op vocabulary by **sampling the history
+generator's own arbitrary**: a shape the script claims to cover is only covered
+if the generator can draw it, and comparing one spelling of the declared list
+against another cannot show that.
 
 The oracle properties run at a smoke-gate iteration count by default and take a
 run-count knob for deep runs:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,6 +80,54 @@ import { createAdapterTestSuite } from "./adapter-test-suite";
 createAdapterTestSuite("SQLite", () => createTestBackend());
 ```
 
+### Oracle suites
+
+Some semantics have more than one implementation inside the library — the same
+question answered by the SQL compiler, by a collection predicate, and by an
+in-memory row filter. Checking those against each other proves nothing: any
+three of them agreeing is the failure mode, not the evidence. An **oracle
+suite** answers the question a fourth time, independently, and checks every path
+against that.
+
+Two exist today, both registered in the shared cross-backend suite so they run
+on every backend in the matrix:
+
+| Model | Suite | Question it re-derives |
+| --- | --- | --- |
+| `tests/backends/integration/identity-traversal-model.ts` | `identity-current-traversal.ts`, `identity-historical-traversal.ts` | Which rows an identity-expanded hop must return at an instant. |
+| `tests/backends/integration/temporal-oracle-model.ts` | `temporal-oracle.ts` | Which rows a bitemporal coordinate must return, and which validity windows a write may store. |
+
+A model earns the name by three properties, and all three are load-bearing:
+
+1. **It is a second implementation, not a restatement.** The temporal model
+   formulates visibility as interval membership over epoch milliseconds; the
+   library formulates it as a column predicate over `TEXT` or `timestamptz`.
+2. **It derives its expectations from the rows that were actually persisted**,
+   never from the write calls, so a write whose stored shape differs from the
+   requested one is checked against what it stored rather than flaking.
+3. **It passes unchanged on `main`.** A model that only passes after the fix it
+   accompanies is a restatement of the fix. Where the tree is knowingly wrong,
+   the model declares the cell (`KNOWN_CONTRACT_GAPS`), withholds the op shape
+   that reaches it from the generator, and carries a still-reproduces test — and
+   each entry is deleted by the diff that measurably closes it, never later.
+
+`tests/temporal-oracle-imports.test.ts` ratchets the temporal model's
+independence: exact set equality over its import specifiers, a named-import
+check on `src/utils/date` so the window guards stay out, and an assertion that
+the barrel import is `import type`, so it cannot carry a value however the
+barrel grows. It also ratchets the gap table's plumbing by **sampling the
+history generator's own arbitrary**: a declared restriction is only real if the
+generator honors it, and comparing one spelling of the withheld set against
+another cannot show that.
+
+The oracle properties run at a smoke-gate iteration count by default and take a
+run-count knob for deep runs:
+
+```bash
+# Deep run of the temporal oracle on every backend in the default lane
+TYPEGRAPH_ORACLE_RUNS=100 pnpm test
+```
+
 ## Running Tests
 
 ```bash

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -1430,6 +1430,32 @@ export function renderSqlInline(fragment: SqlFragment, dialect: SqlDialect): str
 // @public
 export function renderSqlite(fragment: SqlFragment, bindings?: Readonly<Record<string, unknown>>): RenderedSql;
 
+// @public
+export function repairInvertedValidityWindows(options: RepairInvertedWindowsOptions): Promise<RepairInvertedWindowsReport>;
+
+// @public (undocumented)
+export type RepairInvertedWindowsOptions = Readonly<{
+    backend: GraphBackend;
+    graphId?: string | undefined;
+    relations: RepairRelationScope;
+    mode: "report" | "apply";
+    tableNames?: Partial<SqlTableNames> | undefined;
+}>;
+
+// @public (undocumented)
+export type RepairInvertedWindowsReport = Readonly<{
+    relations: RepairRelationScope;
+    counts: Readonly<Record<RepairRelation, number | undefined>>;
+    nonCanonical: Readonly<Record<RepairRelation, number | undefined>>;
+    atomic: boolean;
+}>;
+
+// @public
+export type RepairRelation = "nodes" | "edges" | "recordedNodes" | "recordedEdges";
+
+// @public
+export type RepairRelationScope = "live" | "live-and-recorded";
+
 // @public (undocumented)
 export type ResolvedSqlTableNames = Readonly<{
     nodes: string;

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -1456,9 +1456,6 @@ export type RepairRelation = "nodes" | "edges" | "recordedNodes" | "recordedEdge
 // @public
 export type RepairRelationScope = "live" | "live-and-recorded";
 
-// @public
-export function resolveStampedValidityLowerBound(statedValidFrom: string | null | undefined, validTo: string | undefined, writeInstant: string): string | undefined;
-
 // @public (undocumented)
 export type ResolvedSqlTableNames = Readonly<{
     nodes: string;
@@ -1474,6 +1471,9 @@ export type ResolvedSqlTableNames = Readonly<{
     fulltext: string;
     uniques: string;
 }>;
+
+// @public
+export function resolveStampedValidityLowerBound(statedValidFrom: string | null | undefined, validTo: string | undefined, writeInstant: string): string | undefined;
 
 // @public
 export type RowProps = string | Readonly<Record<string, unknown>>;

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -1433,7 +1433,7 @@ export function renderSqlite(fragment: SqlFragment, bindings?: Readonly<Record<s
 // @public
 export function repairInvertedValidityWindows(options: RepairInvertedWindowsOptions): Promise<RepairInvertedWindowsReport>;
 
-// @public (undocumented)
+// @public
 export type RepairInvertedWindowsOptions = Readonly<{
     backend: GraphBackend;
     graphId?: string | undefined;
@@ -1442,7 +1442,7 @@ export type RepairInvertedWindowsOptions = Readonly<{
     tableNames?: Partial<SqlTableNames> | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 export type RepairInvertedWindowsReport = Readonly<{
     relations: RepairRelationScope;
     counts: Readonly<Record<RepairRelation, number | undefined>>;
@@ -1455,6 +1455,9 @@ export type RepairRelation = "nodes" | "edges" | "recordedNodes" | "recordedEdge
 
 // @public
 export type RepairRelationScope = "live" | "live-and-recorded";
+
+// @public
+export function resolveStampedValidityLowerBound(statedValidFrom: string | null | undefined, validTo: string | undefined, writeInstant: string): string | undefined;
 
 // @public (undocumented)
 export type ResolvedSqlTableNames = Readonly<{

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -4941,6 +4941,32 @@ export function renderSqlInline(fragment: SqlFragment, dialect: SqlDialect): str
 export function renderSqlite(fragment: SqlFragment, bindings?: Readonly<Record<string, unknown>>): RenderedSql;
 
 // @public
+export function repairInvertedValidityWindows(options: RepairInvertedWindowsOptions): Promise<RepairInvertedWindowsReport>;
+
+// @public (undocumented)
+export type RepairInvertedWindowsOptions = Readonly<{
+    backend: GraphBackend;
+    graphId?: string | undefined;
+    relations: RepairRelationScope;
+    mode: "report" | "apply";
+    tableNames?: Partial<SqlTableNames> | undefined;
+}>;
+
+// @public (undocumented)
+export type RepairInvertedWindowsReport = Readonly<{
+    relations: RepairRelationScope;
+    counts: Readonly<Record<RepairRelation, number | undefined>>;
+    nonCanonical: Readonly<Record<RepairRelation, number | undefined>>;
+    atomic: boolean;
+}>;
+
+// @public
+export type RepairRelation = "nodes" | "edges" | "recordedNodes" | "recordedEdges";
+
+// @public
+export type RepairRelationScope = "live" | "live-and-recorded";
+
+// @public
 type ResolvedEmbeddingIndex = Readonly<{
     metric: EmbeddingMetric;
     indexType: EmbeddingIndexType;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -4943,7 +4943,7 @@ export function renderSqlite(fragment: SqlFragment, bindings?: Readonly<Record<s
 // @public
 export function repairInvertedValidityWindows(options: RepairInvertedWindowsOptions): Promise<RepairInvertedWindowsReport>;
 
-// @public (undocumented)
+// @public
 export type RepairInvertedWindowsOptions = Readonly<{
     backend: GraphBackend;
     graphId?: string | undefined;
@@ -4952,7 +4952,7 @@ export type RepairInvertedWindowsOptions = Readonly<{
     tableNames?: Partial<SqlTableNames> | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 export type RepairInvertedWindowsReport = Readonly<{
     relations: RepairRelationScope;
     counts: Readonly<Record<RepairRelation, number | undefined>>;

--- a/packages/typegraph/src/backend/drizzle/operations/edges.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/edges.ts
@@ -1,5 +1,9 @@
 import { type SQL, sql } from "drizzle-orm";
 
+import {
+  resolveStampedValidityLowerBound,
+  resolveStatedValidityLowerBound,
+} from "../../../utils/date";
 import type {
   CountEdgesFromParams,
   DeleteEdgeParams,
@@ -14,7 +18,6 @@ import {
   edgeColumnList,
   expectedValidFromPredicate,
   quotedColumn,
-  resolveValidFrom,
   sqlNull,
   type Tables,
 } from "./shared";
@@ -22,6 +25,11 @@ import {
 /**
  * Builds an INSERT query for an edge.
  * Uses raw column names in the column list (required by SQL syntax).
+ *
+ * As for nodes, the stored lower bound is decided by
+ * {@link resolveStampedValidityLowerBound} against the very `timestamp` this
+ * statement binds into `created_at` / `updated_at` — see `buildInsertNode` for
+ * why the decision lives in the builder rather than above it.
  */
 export function buildInsertEdge(
   tables: Tables,
@@ -37,7 +45,7 @@ export function buildInsertEdge(
     VALUES (
       ${params.graphId}, ${params.id}, ${params.kind},
       ${params.fromKind}, ${params.fromId}, ${params.toKind}, ${params.toId},
-      ${propsJson}, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
+      ${propsJson}, ${sqlNull(resolveStampedValidityLowerBound(params.validFrom, params.validTo, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
     RETURNING *
@@ -61,7 +69,7 @@ export function buildInsertEdgeNoReturn(
     VALUES (
       ${params.graphId}, ${params.id}, ${params.kind},
       ${params.fromKind}, ${params.fromId}, ${params.toKind}, ${params.toId},
-      ${propsJson}, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
+      ${propsJson}, ${sqlNull(resolveStampedValidityLowerBound(params.validFrom, params.validTo, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
   `;
@@ -79,7 +87,7 @@ export function buildInsertEdgesBatch(
   const columns = edgeColumnList(edges);
   const values = params.map((edgeParams) => {
     const propsJson = JSON.stringify(edgeParams.props);
-    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(resolveValidFrom(edgeParams.validFrom, timestamp))}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(resolveStampedValidityLowerBound(edgeParams.validFrom, edgeParams.validTo, timestamp))}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -100,7 +108,7 @@ export function buildInsertEdgesBatchReturning(
   const columns = edgeColumnList(edges);
   const values = params.map((edgeParams) => {
     const propsJson = JSON.stringify(edgeParams.props);
-    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(resolveValidFrom(edgeParams.validFrom, timestamp))}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${edgeParams.graphId}, ${edgeParams.id}, ${edgeParams.kind}, ${edgeParams.fromKind}, ${edgeParams.fromId}, ${edgeParams.toKind}, ${edgeParams.toId}, ${propsJson}, ${sqlNull(resolveStampedValidityLowerBound(edgeParams.validFrom, edgeParams.validTo, timestamp))}, ${sqlNull(edgeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -225,9 +233,16 @@ export function buildUpdateEdge(
   // window (only an explicit `valid_to` moves), which is what
   // `getOrCreateByEndpoints` relies on when it cardinality-checks the
   // tombstone's own `valid_to`.
+  //
+  // So this is the one window-writing site in the backend that does NOT stamp:
+  // the gate above guarantees the caller named a bound, and there is no instant
+  // to judge. It therefore passes the stated value through
+  // (`resolveStatedValidityLowerBound`) rather than routing through the stamping
+  // owner, which would silently turn "the caller said this" into "the write
+  // chose this" on a path where nothing was chosen.
   if (params.clearDeleted && params.validFrom !== undefined) {
     setParts.push(
-      sql`${quotedColumn(edges.validFrom)} = ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}`,
+      sql`${quotedColumn(edges.validFrom)} = ${sqlNull(resolveStatedValidityLowerBound(params.validFrom))}`,
       sql`${quotedColumn(edges.validTo)} = ${sqlNull(params.validTo)}`,
     );
   } else if (params.clearValidTo === true) {

--- a/packages/typegraph/src/backend/drizzle/operations/nodes.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/nodes.ts
@@ -2,6 +2,7 @@ import { type SQL, sql } from "drizzle-orm";
 
 import { getDialect } from "../../../query/dialect";
 import { sql as portableSql } from "../../../query/sql-fragment";
+import { resolveStampedValidityLowerBound } from "../../../utils/date";
 import type {
   DeleteNodeParams,
   HardDeleteNodeParams,
@@ -14,7 +15,6 @@ import {
   expectedValidFromPredicate,
   nodeColumnList,
   quotedColumn,
-  resolveValidFrom,
   sqlNull,
   type Tables,
 } from "./shared";
@@ -22,6 +22,14 @@ import {
 /**
  * Builds an INSERT query for a node.
  * Uses raw column names in the column list (required by SQL syntax).
+ *
+ * The stored lower bound is decided by {@link resolveStampedValidityLowerBound}
+ * against the very `timestamp` this statement binds into `created_at` /
+ * `updated_at`, so a row cannot be stamped with a bound that disagrees with the
+ * instant it was created at. Deciding it HERE — below the store, below
+ * interchange, below trusted import — is what makes "no write stores a window
+ * readable at no coordinate" hold for every `GraphBackend` caller rather than for
+ * the store paths one reviewer enumerated.
  */
 export function buildInsertNode(
   tables: Tables,
@@ -36,7 +44,7 @@ export function buildInsertNode(
     INSERT INTO ${nodes} (${columns})
     VALUES (
       ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
-      1, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
+      1, ${sqlNull(resolveStampedValidityLowerBound(params.validFrom, params.validTo, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
     RETURNING *
@@ -59,7 +67,7 @@ export function buildInsertNodeNoReturn(
     INSERT INTO ${nodes} (${columns})
     VALUES (
       ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
-      1, ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}, ${sqlNull(params.validTo)},
+      1, ${sqlNull(resolveStampedValidityLowerBound(params.validFrom, params.validTo, timestamp))}, ${sqlNull(params.validTo)},
       ${timestamp}, ${timestamp}
     )
   `;
@@ -77,7 +85,7 @@ export function buildInsertNodesBatch(
   const columns = nodeColumnList(nodes);
   const values = params.map((nodeParams) => {
     const propsJson = JSON.stringify(nodeParams.props);
-    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(resolveValidFrom(nodeParams.validFrom, timestamp))}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(resolveStampedValidityLowerBound(nodeParams.validFrom, nodeParams.validTo, timestamp))}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -98,7 +106,7 @@ export function buildInsertNodesBatchReturning(
   const columns = nodeColumnList(nodes);
   const values = params.map((nodeParams) => {
     const propsJson = JSON.stringify(nodeParams.props);
-    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(resolveValidFrom(nodeParams.validFrom, timestamp))}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
+    return sql`(${nodeParams.graphId}, ${nodeParams.kind}, ${nodeParams.id}, ${propsJson}, 1, ${sqlNull(resolveStampedValidityLowerBound(nodeParams.validFrom, nodeParams.validTo, timestamp))}, ${sqlNull(nodeParams.validTo)}, ${timestamp}, ${timestamp})`;
   });
 
   return sql`
@@ -175,15 +183,19 @@ export function buildUpdateNode(
   }
 
   // A resurrection RESETS the window: `valid_from` is rewritten rather than
-  // retained (an edge retains it — see `buildUpdateEdge`). `timestamp` is only
-  // the fallback: the operations layer passes the instant its inverted-window
-  // guard measured against as an explicit `validFrom`, so the bound this stores
-  // is the bound that was checked. Falling back to a locally sampled instant
-  // would store a bound strictly later than the one the guard approved (issue
-  // #413).
+  // retained (an edge retains it — see `buildUpdateEdge`), so this leg STAMPS a
+  // bound when the caller states none, and it makes that choice through the same
+  // owner every insert builder uses. Two consequences, both load-bearing. A
+  // resurrection carrying only a past `validTo` — which `create` on a tombstoned
+  // id reaches with nothing stated — stores NO lower bound instead of a window
+  // readable at no coordinate, whoever called the backend (issue #407). And
+  // `timestamp` remains only the fallback: the operations layer passes the
+  // instant its inverted-window guard measured against as an explicit
+  // `validFrom`, so the bound this stores is the bound that was checked rather
+  // than a strictly later sample the guard never saw (issue #413).
   if (params.clearDeleted) {
     setParts.push(
-      sql`${quotedColumn(nodes.validFrom)} = ${sqlNull(resolveValidFrom(params.validFrom, timestamp))}`,
+      sql`${quotedColumn(nodes.validFrom)} = ${sqlNull(resolveStampedValidityLowerBound(params.validFrom, params.validTo, timestamp))}`,
       sql`${quotedColumn(nodes.validTo)} = ${sqlNull(params.validTo)}`,
     );
   } else if (params.clearValidTo === true) {

--- a/packages/typegraph/src/backend/drizzle/operations/shared.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/shared.ts
@@ -88,36 +88,6 @@ export function sqlNull(value: string | undefined): SQL | string {
 }
 
 /**
- * Resolves a `validFrom` insert value against the row's creation timestamp.
- * Three states, matching {@link InsertNodeParams.validFrom} /
- * {@link InsertEdgeParams.validFrom}:
- *  - `undefined` (omitted): defaults to `timestamp` — every insert path
- *    (single, batch, returning/non-returning) agrees that "no validFrom"
- *    means "valid from creation", not open-left NULL (see issue #240).
- *  - `null`: preserves an explicit open-left window — returned as
- *    `undefined` here so the caller's {@link sqlNull} wrap emits SQL NULL,
- *    letting interchange import round-trip a row that predates the #240
- *    fix without narrowing its validity window on re-import (e.g. via a
- *    `branch()` clone).
- *  - a string: passed through unchanged.
- *
- * The `timestamp` fallback is a storage convention, not an assertion the caller
- * can be held to, so a write whose validity window is GUARDED against the
- * resulting lower bound must supply that bound explicitly instead of relying on
- * it: this function samples nothing, but its caller's `timestamp` comes from a
- * later clock read than the guard's, and the difference is a window of negative
- * width (issue #413). The node resurrection path therefore passes the instant it
- * validated against; see `buildUpdateNode` and `performNodeUpdate`.
- */
-export function resolveValidFrom(
-  validFrom: string | null | undefined,
-  timestamp: string,
-): string | undefined {
-  if (validFrom === null) return undefined;
-  return validFrom ?? timestamp;
-}
-
-/**
  * The `AND valid_from …` conjunction a write carries when its caller ASSERTED
  * the lower bound the target row already holds (see
  * {@link UpdateNodeParams.expectedValidFrom} /

--- a/packages/typegraph/src/backend/drizzle/trusted-import.ts
+++ b/packages/typegraph/src/backend/drizzle/trusted-import.ts
@@ -1,6 +1,7 @@
 import { TrustedImportError } from "../../errors";
 import { sql } from "../../query/sql-fragment";
 import { asCompiledStatementSql } from "../../query/sql-intent";
+import { resolveStampedValidityLowerBound } from "../../utils/date";
 import type {
   InsertEdgeParams,
   InsertNodeParams,
@@ -191,13 +192,6 @@ export async function analyzeImportedTables(
   );
 }
 
-function resolvedValidFrom(
-  validFrom: string | null | undefined,
-  timestamp: string,
-): string | null {
-  return validFrom === undefined ? timestamp : validFrom;
-}
-
 /**
  * Encodes one-dimensional Postgres arrays as text accepted by an explicit
  * `::text[]` / `::timestamptz[]` cast. postgres.js's raw `unsafe` parameters
@@ -214,6 +208,17 @@ function postgresArray(values: readonly (string | null)[]): string {
     .join(",")}}`;
 }
 
+/**
+ * Both sessions below decide their stored lower bound through
+ * {@link resolveStampedValidityLowerBound}, the same owner the Drizzle insert
+ * builders use, mapping "no bound" to an explicit SQL NULL. Trusted import
+ * bypasses those builders for throughput, so a private copy of the decision here
+ * would keep minting rows readable at no coordinate long after the builders
+ * stopped — which is exactly what it did before issue #407 was closed. Its
+ * canonicality precondition is established per chunk by the stream's own format
+ * check (`src/interchange/trusted-import.ts`), which is what makes the
+ * lexicographic comparison inside the owner a chronological one here too.
+ */
 export function createSqliteTrustedImportSession(
   executionAdapter: SqliteExecutionAdapter,
   tableNames: TrustedImportTableNames,
@@ -244,7 +249,8 @@ export function createSqliteTrustedImportSession(
           item.kind,
           item.id,
           JSON.stringify(item.props),
-          resolvedValidFrom(item.validFrom, timestamp),
+          resolveStampedValidityLowerBound(item.validFrom, item.validTo, timestamp) ??
+            DATABASE_NULL,
           item.validTo ?? DATABASE_NULL,
           timestamp,
           timestamp,
@@ -265,7 +271,8 @@ export function createSqliteTrustedImportSession(
           item.toKind,
           item.toId,
           JSON.stringify(item.props),
-          resolvedValidFrom(item.validFrom, timestamp),
+          resolveStampedValidityLowerBound(item.validFrom, item.validTo, timestamp) ??
+            DATABASE_NULL,
           item.validTo ?? DATABASE_NULL,
           timestamp,
           timestamp,
@@ -310,7 +317,11 @@ export function createPostgresTrustedImportSession(
         postgresArray(params.map((item) => item.id)),
         postgresArray(params.map((item) => JSON.stringify(item.props))),
         postgresArray(
-          params.map((item) => resolvedValidFrom(item.validFrom, timestamp)),
+          params.map(
+            (item) =>
+              resolveStampedValidityLowerBound(item.validFrom, item.validTo, timestamp) ??
+              DATABASE_NULL,
+          ),
         ),
         postgresArray(params.map((item) => item.validTo ?? DATABASE_NULL)),
         postgresArray(params.map(() => timestamp)),
@@ -329,7 +340,11 @@ export function createPostgresTrustedImportSession(
         postgresArray(params.map((item) => item.toId)),
         postgresArray(params.map((item) => JSON.stringify(item.props))),
         postgresArray(
-          params.map((item) => resolvedValidFrom(item.validFrom, timestamp)),
+          params.map(
+            (item) =>
+              resolveStampedValidityLowerBound(item.validFrom, item.validTo, timestamp) ??
+              DATABASE_NULL,
+          ),
         ),
         postgresArray(params.map((item) => item.validTo ?? DATABASE_NULL)),
         postgresArray(params.map(() => timestamp)),

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -79,6 +79,13 @@ export {
   migrateRecordedAnchor,
   type MigrateRecordedAnchorOptions,
 } from "./migrate-recorded-time";
+export {
+  repairInvertedValidityWindows,
+  type RepairInvertedWindowsOptions,
+  type RepairInvertedWindowsReport,
+  type RepairRelation,
+  type RepairRelationScope,
+} from "./repair-validity-windows";
 export type {
   StrategyTableContribution,
   TableContribution,

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -70,6 +70,7 @@ export type {
   IntentSql,
   SqlIntent,
 } from "../query/sql-intent";
+export { resolveStampedValidityLowerBound } from "../utils/date";
 export {
   deleteLegacyRecordedAnchorMap,
   type DeleteLegacyRecordedAnchorMapOptions,

--- a/packages/typegraph/src/backend/migrate-recorded-time.ts
+++ b/packages/typegraph/src/backend/migrate-recorded-time.ts
@@ -22,6 +22,7 @@ import { canonicalizeDatabaseTimestamp } from "../utils/date";
 import { postgresContributions, sqliteContributions } from "./drizzle/ddl";
 import { createPostgresTables } from "./drizzle/schema/postgres";
 import { createSqliteTables } from "./drizzle/schema/sqlite";
+import { resolvedTableNames } from "./table-names";
 import { type GraphBackend, type TransactionBackend } from "./types";
 
 const LEGACY_RECORDED_MAX = "9999-12-31T23:59:59.999Z";
@@ -125,13 +126,6 @@ export type DeleteLegacyRecordedAnchorMapOptions = Readonly<{
   /** Drop the mapping table when this deletion leaves it empty. */
   dropWhenEmpty?: boolean | undefined;
 }>;
-
-function resolvedTableNames(
-  backend: Pick<GraphBackend, "tableNames">,
-  override: Partial<SqlTableNames> | undefined,
-): ResolvedSqlTableNames {
-  return createSqlSchema(override ?? backend.tableNames ?? {}).tables;
-}
 
 function shortenedIdentifier(value: string): string {
   if (value.length <= 63) return value;

--- a/packages/typegraph/src/backend/migrate-recorded-time.ts
+++ b/packages/typegraph/src/backend/migrate-recorded-time.ts
@@ -90,7 +90,7 @@ type ColumnRow = Readonly<{ name: unknown }>;
 
 export type MigrateLegacyRecordedTimeOptions = Readonly<{
   backend: GraphBackend;
-  /** Override the backend's recorded table names. */
+  /** Patch selected backend table names; unstated names remain configured. */
   tableNames?: Partial<SqlTableNames> | undefined;
   /** Override the durable legacy-anchor mapping table name. */
   mappingTableName?: string | undefined;
@@ -111,6 +111,7 @@ export type MigrateRecordedAnchorOptions = Readonly<{
   backend: Pick<GraphBackend, "dialect" | "execute" | "tableNames">;
   graphId: string;
   anchor: string;
+  /** Patch selected backend table names; unstated names remain configured. */
   tableNames?: Partial<SqlTableNames> | undefined;
   mappingTableName?: string | undefined;
 }>;
@@ -121,6 +122,7 @@ export type DeleteLegacyRecordedAnchorMapOptions = Readonly<{
     "dialect" | "execute" | "executeStatement" | "tableNames" | "transaction"
   >;
   graphId: string;
+  /** Patch selected backend table names; unstated names remain configured. */
   tableNames?: Partial<SqlTableNames> | undefined;
   mappingTableName?: string | undefined;
   /** Drop the mapping table when this deletion leaves it empty. */

--- a/packages/typegraph/src/backend/repair-validity-windows.ts
+++ b/packages/typegraph/src/backend/repair-validity-windows.ts
@@ -1,0 +1,469 @@
+/**
+ * Offline repair for validity windows that older library versions stored
+ * inverted (`valid_from > valid_to`).
+ *
+ * Such a row is readable at no coordinate at all: `asOf(t)` needs
+ * `valid_from <= t < valid_to`, and no `t` satisfies both when the bounds are
+ * backwards. The library no longer mints them — a write that stamps a lower
+ * bound the caller did not state stores no bound rather than an inverting one —
+ * but deploying that fix rewrites nothing, so rows written by an older version
+ * (or by direct SQL) stay invisible until an operator repairs them.
+ *
+ * The repair normalizes those rows to "ended at T, start unknown"
+ * (`valid_from = NULL`), which is the shape the current write paths store. It
+ * deliberately does **not** bump `version`, touch `updated_at`, or mint a
+ * recorded revision: it normalizes a storage convention for rows that were
+ * never observable at any coordinate, so it is not a logical write — and
+ * minting a revision would make the pre-repair recorded state re-materialize
+ * the inverted shape at `asOfRecorded` coordinates.
+ *
+ * Operator consequences, all of them stated in the docs as well:
+ *
+ * 1. **Run `"apply"` with writers stopped.** A concurrent update fences its
+ *    write on the validity lower bound it read, so a repair that lands in
+ *    between makes the peer's `UPDATE` match no row: a store write surfaces
+ *    `NodeNotFound` (retryable) and an interchange import reports that row as
+ *    accepted but not written. `"report"` needs no quiescing — it scans in a
+ *    read-only transaction, so it neither blocks a live writer nor can write.
+ * 2. **Repaired rows become visible** at `asOf` coordinates before their end.
+ *    That is the point, and it is a read-visibility change to historical
+ *    queries.
+ * 3. **Outstanding `base@V` merge tokens are invalidated** for repaired rows —
+ *    `valid_from` is part of the base content fingerprint. Quiesce merges,
+ *    repair, then re-baseline branches.
+ * 4. **Prefer `relations: "live-and-recorded"`.** Repairing only the live axis
+ *    leaves the recorded twin carrying the inverted window, which
+ *    re-materializes the invisible row at any `asOfRecorded` coordinate.
+ */
+import { ConfigurationError } from "../errors";
+import type {
+  ResolvedSqlTableNames,
+  SqlTableNames,
+} from "../query/compiler/schema";
+import { sql, type SqlFragment } from "../query/sql-fragment";
+import { asCompiledRowsSql, asCompiledStatementSql } from "../query/sql-intent";
+import { resolvedTableNames } from "./table-names";
+import {
+  type GraphBackend,
+  runOptionallyInTransaction,
+  type RunOptionallyInTransactionOptions,
+  type TransactionBackend,
+} from "./types";
+
+/** A relation whose rows carry a validity window this repair can normalize. */
+export type RepairRelation =
+  "nodes" | "edges" | "recordedNodes" | "recordedEdges";
+
+/**
+ * Which relations one call scans.
+ *
+ * `"live-and-recorded"` is the recommended scope. `"live"` is correct in
+ * exactly two cases: the store captures no history and the `recorded_*` tables
+ * do not exist, or the operator is deliberately preserving the recorded axis as
+ * an audit record of what was stored before the repair — and accepts that
+ * historical `asOfRecorded` reads keep returning the invisible shape.
+ */
+export type RepairRelationScope = "live" | "live-and-recorded";
+
+export type RepairInvertedWindowsOptions = Readonly<{
+  backend: GraphBackend;
+  /** Omit to sweep every graph in the database. */
+  graphId?: string | undefined;
+  /** Required: the scope is a decision, not a default. */
+  relations: RepairRelationScope;
+  /**
+   * `"report"` counts and writes nothing; `"apply"` counts and then normalizes
+   * the rows it counted.
+   */
+  mode: "report" | "apply";
+  /**
+   * Override the backend's table names, exactly as migrate-recorded-time does —
+   * through the same owner, so the REPLACE-don't-merge policy is one rule. See
+   * {@link resolvedTableNames}.
+   */
+  tableNames?: Partial<SqlTableNames> | undefined;
+}>;
+
+export type RepairInvertedWindowsReport = Readonly<{
+  /** Echoes the scope actually scanned — a count of 0 and "not scanned" are different facts. */
+  relations: RepairRelationScope;
+  /**
+   * Rows whose stored window is inverted: found in `"report"` mode, repaired in
+   * `"apply"` mode. `undefined` means NOT SCANNED, never "clean".
+   */
+  counts: Readonly<Record<RepairRelation, number | undefined>>;
+  /**
+   * Rows whose stored bounds are not canonical ISO and were therefore not
+   * classified. SQLite only in substance: on PostgreSQL the columns are
+   * `timestamptz`, so a scanned relation always reports `0` (never `undefined`
+   * — that value is reserved for "not scanned", on both dialects).
+   *
+   * `"apply"` refuses while any scanned relation reports a non-zero count:
+   * classifying those rows needs a timestamp semantics this repair does not
+   * own, and skipping them silently would be an accepted option ignored.
+   */
+  nonCanonical: Readonly<Record<RepairRelation, number | undefined>>;
+  /**
+   * Whether every statement of this call ran in ONE transaction. `false` on a
+   * backend that reports `capabilities.transactions === false`, where the call
+   * degrades to per-relation statements.
+   *
+   * Reported by the seam, not re-derived beside it: the flag is set inside
+   * {@link runOptionallyInTransaction}'s callback from the target it was handed
+   * (`target !== backend`), so it states what happened rather than restating
+   * the seam's own predicate. "One snapshot" and "four snapshots" are different
+   * facts about a report, and the report must not guess which.
+   *
+   * When `false`, a `"report"`'s counts may come from different snapshots and a
+   * crash mid-`"apply"` can leave the live axis repaired and the recorded axis
+   * not. Both are survivable the same way: each relation's statement is
+   * idempotent and convergent, so a re-run finishes the job and a later
+   * `"report"` proves it.
+   */
+  atomic: boolean;
+}>;
+
+const LIVE_RELATIONS = [
+  "nodes",
+  "edges",
+] as const satisfies readonly RepairRelation[];
+
+const RECORDED_RELATIONS = [
+  "recordedNodes",
+  "recordedEdges",
+] as const satisfies readonly RepairRelation[];
+
+/**
+ * Canonical fixed-width UTC ISO 8601, as a SQLite `GLOB` pattern.
+ *
+ * SQLite stores the bounds as `TEXT` and compares them lexicographically, which
+ * equals chronological order only for canonical values. This repair exists to
+ * clean up rows written by older paths and by direct SQL, so it cannot assume
+ * canonicality — it establishes it per row instead.
+ */
+const CANONICAL_INSTANT_GLOB =
+  "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9].[0-9][0-9][0-9]Z";
+
+type RepairTarget = GraphBackend | TransactionBackend;
+
+type CountRow = Readonly<{ matches: unknown }>;
+
+function scopedRelations(
+  scope: RepairRelationScope,
+): readonly RepairRelation[] {
+  return scope === "live" ? LIVE_RELATIONS : (
+      [...LIVE_RELATIONS, ...RECORDED_RELATIONS]
+    );
+}
+
+function relationTable(
+  tables: ResolvedSqlTableNames,
+  relation: RepairRelation,
+): string {
+  switch (relation) {
+    case "nodes": {
+      return tables.nodes;
+    }
+    case "edges": {
+      return tables.edges;
+    }
+    case "recordedNodes": {
+      return tables.recordedNodes;
+    }
+    case "recordedEdges": {
+      return tables.recordedEdges;
+    }
+  }
+}
+
+function graphScopeClauses(
+  graphId: string | undefined,
+): readonly SqlFragment[] {
+  return graphId === undefined ? [] : [sql`graph_id = ${graphId}`];
+}
+
+function canonicalBoundsClauses(
+  dialect: GraphBackend["dialect"],
+): readonly SqlFragment[] {
+  if (dialect !== "sqlite") return [];
+  return [
+    sql`valid_from GLOB ${CANONICAL_INSTANT_GLOB}`,
+    sql`valid_to GLOB ${CANONICAL_INSTANT_GLOB}`,
+  ];
+}
+
+/**
+ * The one spelling of "this stored window is inverted".
+ *
+ * Both modes compile it: `"report"` into `SELECT COUNT(*) … WHERE <this>` and
+ * `"apply"` into `UPDATE … SET valid_from = NULL WHERE <this>`, so the count
+ * and the repair cannot disagree about which rows are in scope.
+ *
+ * The comparison is strict (`>`). A stored zero-width window is a legal shape a
+ * caller may have stated in full, and this repair does not second-guess it.
+ */
+export function invertedValidityWindowPredicate(
+  options: Readonly<{
+    dialect: GraphBackend["dialect"];
+    graphId?: string | undefined;
+  }>,
+): SqlFragment {
+  return sql.join(
+    [
+      sql`valid_from IS NOT NULL`,
+      sql`valid_to IS NOT NULL`,
+      ...canonicalBoundsClauses(options.dialect),
+      sql`valid_from > valid_to`,
+      ...graphScopeClauses(options.graphId),
+    ],
+    sql` AND `,
+  );
+}
+
+/**
+ * Rows carrying both bounds where either one is not canonical, and which the
+ * inverted predicate therefore refuses to classify. SQLite only: PostgreSQL
+ * stores `timestamptz`, where every stored value compares chronologically.
+ */
+function nonCanonicalWindowPredicate(graphId: string | undefined): SqlFragment {
+  return sql.join(
+    [
+      sql`valid_from IS NOT NULL`,
+      sql`valid_to IS NOT NULL`,
+      sql`(valid_from NOT GLOB ${CANONICAL_INSTANT_GLOB} OR valid_to NOT GLOB ${CANONICAL_INSTANT_GLOB})`,
+      ...graphScopeClauses(graphId),
+    ],
+    sql` AND `,
+  );
+}
+
+function safeCount(value: unknown, table: string): number {
+  const count = Number(value);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new ConfigurationError(
+      "Validity-window repair returned an invalid row count.",
+      { table, value },
+    );
+  }
+  return count;
+}
+
+async function countMatching(
+  target: RepairTarget,
+  table: string,
+  predicate: SqlFragment,
+): Promise<number> {
+  const rows = await target.execute<CountRow>(
+    asCompiledRowsSql(sql`
+      SELECT COUNT(*) AS matches
+      FROM ${sql.identifier(table)}
+      WHERE ${predicate}
+    `),
+  );
+  return safeCount(rows[0]?.matches, table);
+}
+
+/**
+ * `"apply"` writes, so it needs the optional non-row-returning statement path.
+ * `"report"` deliberately does not: `execute` is a required member, so
+ * detection stays available on every backend even where repair is not.
+ */
+function requireStatements(
+  target: Pick<RepairTarget, "dialect" | "executeStatement">,
+): NonNullable<RepairTarget["executeStatement"]> {
+  if (target.executeStatement === undefined) {
+    throw new ConfigurationError(
+      "Repairing inverted validity windows requires executeStatement support.",
+      { dialect: target.dialect, mode: "apply" },
+      {
+        suggestion:
+          'Use a built-in SQLite or PostgreSQL backend to apply the repair. Detection needs no such support: call this with mode: "report" to count the affected rows on any backend.',
+      },
+    );
+  }
+  return target.executeStatement;
+}
+
+/**
+ * Translates the recorded-capture wrapper's refusal instead of swallowing it.
+ *
+ * A history-enabled store replaces `executeStatement` with a rejecting stub, so
+ * `"apply"` against that backend fails with a message about raw SQL rather than
+ * about this repair. The remedy is specific enough to be worth naming: hand the
+ * repair the raw backend the history store was constructed from. Bypassing
+ * capture is the intended behavior here, not a workaround — the repair mints no
+ * revision by design.
+ */
+function translatedCaptureRefusal(error: unknown): unknown {
+  if (
+    !(error instanceof ConfigurationError) ||
+    error.details["code"] !== "RECORDED_CAPTURE_RAW_SQL_DISABLED"
+  ) {
+    return error;
+  }
+  return new ConfigurationError(
+    "Repairing inverted validity windows cannot run against a history-capturing backend.",
+    { code: "RECORDED_CAPTURE_RAW_SQL_DISABLED", mode: "apply" },
+    {
+      cause: error,
+      suggestion:
+        'Pass the raw backend you constructed the history store from. The repair deliberately mints no revision — it normalizes storage for rows that were never visible at any coordinate — so bypassing recorded-time capture is the intended behavior, not a workaround. mode: "report" needs no such care: it runs against the capture-wrapped backend.',
+    },
+  );
+}
+
+async function repairRelation(
+  target: RepairTarget,
+  table: string,
+  predicate: SqlFragment,
+): Promise<void> {
+  try {
+    await requireStatements(target)(
+      asCompiledStatementSql(sql`
+        UPDATE ${sql.identifier(table)}
+        SET valid_from = NULL
+        WHERE ${predicate}
+      `),
+    );
+  } catch (error) {
+    throw translatedCaptureRefusal(error);
+  }
+}
+
+function assertClassifiableBounds(
+  nonCanonical: ReadonlyMap<RepairRelation, number>,
+): void {
+  const unclassified = [...nonCanonical].filter(([, count]) => count > 0);
+  if (unclassified.length === 0) return;
+  throw new ConfigurationError(
+    "Refusing to repair validity windows: some scanned rows store non-canonical bounds.",
+    { nonCanonical: Object.fromEntries(unclassified) },
+    {
+      suggestion:
+        'Normalize those bounds to canonical UTC ISO 8601 (YYYY-MM-DDTHH:MM:SS.mmmZ) and re-run, or narrow the call with graphId. Classifying them here would need a timestamp semantics this repair does not own, and skipping them silently would report a repair it did not make. mode: "report" still counts them.',
+    },
+  );
+}
+
+/**
+ * Declares `"report"`'s read-only-ness to the ENGINE rather than only to the
+ * reader of this file.
+ *
+ * The docs send an operator to diagnose against the live store's backend and
+ * require quiescing only for `"apply"`, so the scan must not behave like a
+ * writer: on SQLite a default transaction is `BEGIN IMMEDIATE`, which reserves
+ * the single writer slot for the duration of up to four full-table `COUNT(*)`
+ * scans and can fail `SQLITE_BUSY` against an active writer; `read_only` issues
+ * a plain `BEGIN` instead. On PostgreSQL it issues `BEGIN … READ ONLY`, which
+ * makes "report writes nothing" enforced by the engine and not merely asserted
+ * by a test.
+ *
+ * `"apply"` writes, so it takes the default read-write transaction.
+ */
+function transactionOptionsFor(
+  mode: RepairInvertedWindowsOptions["mode"],
+): RunOptionallyInTransactionOptions | undefined {
+  return mode === "report" ?
+      { transaction: { accessMode: "read_only" } }
+    : undefined;
+}
+
+function relationRecord(
+  counts: ReadonlyMap<RepairRelation, number>,
+): Readonly<Record<RepairRelation, number | undefined>> {
+  return {
+    nodes: counts.get("nodes"),
+    edges: counts.get("edges"),
+    recordedNodes: counts.get("recordedNodes"),
+    recordedEdges: counts.get("recordedEdges"),
+  };
+}
+
+/**
+ * Counts — and, in `"apply"` mode, normalizes — rows whose stored validity
+ * window is inverted.
+ *
+ * ```typescript
+ * // Diagnose with the store's backend: `report` reads only, so it runs
+ * // anywhere, including a capture-wrapped or statement-less backend.
+ * const report = await repairInvertedValidityWindows({
+ *   backend: anyBackend,
+ *   relations: "live-and-recorded",
+ *   mode: "report",
+ * });
+ *
+ * // Repair with the raw one, while writers are stopped.
+ * await repairInvertedValidityWindows({
+ *   backend: rawBackend,
+ *   relations: "live-and-recorded",
+ *   mode: "apply",
+ * });
+ * ```
+ *
+ * Idempotent and convergent: a second `"apply"` reports zero, because the rows
+ * the first one repaired no longer match the predicate.
+ *
+ * No batching, deliberately. Unlike the recorded-time migration, which rewrites
+ * every row, this statement touches only rows the library mis-stored — an empty
+ * set on a healthy graph. A deployment that reports a count large enough to
+ * worry about should run it per `graphId`.
+ *
+ * @throws ConfigurationError in `"apply"` mode when the backend cannot execute
+ *   statements, when the backend is a recorded-capture wrapper, or when any
+ *   scanned relation stores non-canonical bounds.
+ */
+export async function repairInvertedValidityWindows(
+  options: RepairInvertedWindowsOptions,
+): Promise<RepairInvertedWindowsReport> {
+  const tables = resolvedTableNames(options.backend, options.tableNames);
+  const relations = scopedRelations(options.relations);
+  // Refuse before opening a transaction: a backend with no statement path can
+  // never apply, whatever the scan finds.
+  if (options.mode === "apply") requireStatements(options.backend);
+
+  return runOptionallyInTransaction(
+    options.backend,
+    async (target) => {
+      const atomic = target !== options.backend;
+      const predicate = invertedValidityWindowPredicate({
+        dialect: target.dialect,
+        graphId: options.graphId,
+      });
+      const inverted = new Map<RepairRelation, number>();
+      const nonCanonical = new Map<RepairRelation, number>();
+      for (const relation of relations) {
+        const table = relationTable(tables, relation);
+        nonCanonical.set(
+          relation,
+          target.dialect === "sqlite" ?
+            await countMatching(
+              target,
+              table,
+              nonCanonicalWindowPredicate(options.graphId),
+            )
+          : 0,
+        );
+        inverted.set(relation, await countMatching(target, table, predicate));
+      }
+
+      if (options.mode === "apply") {
+        assertClassifiableBounds(nonCanonical);
+        for (const relation of relations) {
+          await repairRelation(
+            target,
+            relationTable(tables, relation),
+            predicate,
+          );
+        }
+      }
+
+      return {
+        relations: options.relations,
+        counts: relationRecord(inverted),
+        nonCanonical: relationRecord(nonCanonical),
+        atomic,
+      };
+    },
+    transactionOptionsFor(options.mode),
+  );
+}

--- a/packages/typegraph/src/backend/repair-validity-windows.ts
+++ b/packages/typegraph/src/backend/repair-validity-windows.ts
@@ -19,12 +19,13 @@
  *
  * Operator consequences, all of them stated in the docs as well:
  *
- * 1. **Run `"apply"` with writers stopped.** A concurrent update fences its
- *    write on the validity lower bound it read, so a repair that lands in
- *    between makes the peer's `UPDATE` match no row: a store write surfaces
- *    `NodeNotFound` (retryable) and an interchange import reports that row as
- *    accepted but not written. `"report"` needs no quiescing — it scans in a
- *    read-only transaction, so it neither blocks a live writer nor can write.
+ * 1. **Run `"apply"` with writers stopped.** A concurrent window-bearing update
+ *    may fence its write on the validity lower bound it read, so a repair that
+ *    lands in between can make the peer's first `UPDATE` match no row. Store
+ *    node/edge updates re-read and re-judge against the repaired bound; an
+ *    interchange update records a per-row target-changed error instead of
+ *    claiming the row was written. `"report"` needs no quiescing — it scans in
+ *    a read-only transaction, so it cannot write.
  * 2. **Repaired rows become visible** at `asOf` coordinates before their end.
  *    That is the point, and it is a read-visibility change to historical
  *    queries.
@@ -65,6 +66,7 @@ export type RepairRelation =
  */
 export type RepairRelationScope = "live" | "live-and-recorded";
 
+/** Inputs for detecting or repairing legacy inverted validity windows. */
 export type RepairInvertedWindowsOptions = Readonly<{
   backend: GraphBackend;
   /** Omit to sweep every graph in the database. */
@@ -77,13 +79,14 @@ export type RepairInvertedWindowsOptions = Readonly<{
    */
   mode: "report" | "apply";
   /**
-   * Override the backend's table names, exactly as migrate-recorded-time does —
-   * through the same owner, so the REPLACE-don't-merge policy is one rule. See
+   * Patch selected backend table names, exactly as migrate-recorded-time does.
+   * Unstated names continue to come from `backend.tableNames`; see
    * {@link resolvedTableNames}.
    */
   tableNames?: Partial<SqlTableNames> | undefined;
 }>;
 
+/** Counts and execution guarantees observed by one repair/report call. */
 export type RepairInvertedWindowsReport = Readonly<{
   /** Echoes the scope actually scanned — a count of 0 and "not scanned" are different facts. */
   relations: RepairRelationScope;
@@ -108,11 +111,11 @@ export type RepairInvertedWindowsReport = Readonly<{
    * backend that reports `capabilities.transactions === false`, where the call
    * degrades to per-relation statements.
    *
-   * Reported by the seam, not re-derived beside it: the flag is set inside
-   * {@link runOptionallyInTransaction}'s callback from the target it was handed
-   * (`target !== backend`), so it states what happened rather than restating
-   * the seam's own predicate. "One snapshot" and "four snapshots" are different
-   * facts about a report, and the report must not guess which.
+   * Reported by the seam, not inferred from backend object identity:
+   * {@link runOptionallyInTransaction} explicitly tells its callback whether it
+   * opened a transaction. "One snapshot" and "four snapshots" are different
+   * facts about a report, and the report must state which occurred even when a
+   * custom backend passes the same object into its transaction callback.
    *
    * When `false`, a `"report"`'s counts may come from different snapshots and a
    * crash mid-`"apply"` can leave the live axis repaired and the recorded axis
@@ -423,8 +426,7 @@ export async function repairInvertedValidityWindows(
 
   return runOptionallyInTransaction(
     options.backend,
-    async (target) => {
-      const atomic = target !== options.backend;
+    async (target, execution) => {
       const predicate = invertedValidityWindowPredicate({
         dialect: target.dialect,
         graphId: options.graphId,
@@ -461,7 +463,7 @@ export async function repairInvertedValidityWindows(
         relations: options.relations,
         counts: relationRecord(inverted),
         nonCanonical: relationRecord(nonCanonical),
-        atomic,
+        atomic: execution.atomic,
       };
     },
     transactionOptionsFor(options.mode),

--- a/packages/typegraph/src/backend/table-names.ts
+++ b/packages/typegraph/src/backend/table-names.ts
@@ -9,19 +9,31 @@ import {
 } from "../query/compiler/schema";
 import type { GraphBackend } from "./types";
 
+function definedTableNameOverrides(
+  override: Partial<SqlTableNames> | undefined,
+): Partial<SqlTableNames> {
+  if (override === undefined) return {};
+  return Object.fromEntries(
+    Object.entries(override).filter(([, tableName]) => tableName !== undefined),
+  ) as Partial<SqlTableNames>;
+}
+
 /**
  * Resolves the relations an offline maintenance call targets.
  *
- * The policy is REPLACEMENT, not merge: a stated `override` is the whole
- * naming, so a partial one leaves every relation it does not mention on the
- * built-in default rather than on the backend's own name. That is a decision a
- * caller can be surprised by, which is exactly why it has a single owner —
- * `migrateLegacyRecordedTime` and `repairInvertedValidityWindows` document the
- * same rule and must not be able to drift into two rules.
+ * An override is a PATCH over the backend's own names. This matches the
+ * `Partial<SqlTableNames>` input contract: naming only `nodes`, for example,
+ * must not silently retarget edges and recorded relations to the built-in
+ * defaults. `migrateLegacyRecordedTime` and
+ * `repairInvertedValidityWindows` share this owner so an offline write can never
+ * resolve the same partial override two different ways.
  */
 export function resolvedTableNames(
   backend: Pick<GraphBackend, "tableNames">,
   override: Partial<SqlTableNames> | undefined,
 ): ResolvedSqlTableNames {
-  return createSqlSchema(override ?? backend.tableNames ?? {}).tables;
+  return createSqlSchema({
+    ...(backend.tableNames ?? {}),
+    ...definedTableNameOverrides(override),
+  }).tables;
 }

--- a/packages/typegraph/src/backend/table-names.ts
+++ b/packages/typegraph/src/backend/table-names.ts
@@ -15,7 +15,7 @@ function definedTableNameOverrides(
   if (override === undefined) return {};
   return Object.fromEntries(
     Object.entries(override).filter(([, tableName]) => tableName !== undefined),
-  ) as Partial<SqlTableNames>;
+  );
 }
 
 /**
@@ -33,7 +33,7 @@ export function resolvedTableNames(
   override: Partial<SqlTableNames> | undefined,
 ): ResolvedSqlTableNames {
   return createSqlSchema({
-    ...(backend.tableNames ?? {}),
+    ...backend.tableNames,
     ...definedTableNameOverrides(override),
   }).tables;
 }

--- a/packages/typegraph/src/backend/table-names.ts
+++ b/packages/typegraph/src/backend/table-names.ts
@@ -1,0 +1,27 @@
+/**
+ * The one owner of "which physical relations does this offline operation
+ * touch?" for the maintenance entrypoints that accept a `tableNames` override.
+ */
+import {
+  createSqlSchema,
+  type ResolvedSqlTableNames,
+  type SqlTableNames,
+} from "../query/compiler/schema";
+import type { GraphBackend } from "./types";
+
+/**
+ * Resolves the relations an offline maintenance call targets.
+ *
+ * The policy is REPLACEMENT, not merge: a stated `override` is the whole
+ * naming, so a partial one leaves every relation it does not mention on the
+ * built-in default rather than on the backend's own name. That is a decision a
+ * caller can be surprised by, which is exactly why it has a single owner —
+ * `migrateLegacyRecordedTime` and `repairInvertedValidityWindows` document the
+ * same rule and must not be able to drift into two rules.
+ */
+export function resolvedTableNames(
+  backend: Pick<GraphBackend, "tableNames">,
+  override: Partial<SqlTableNames> | undefined,
+): ResolvedSqlTableNames {
+  return createSqlSchema(override ?? backend.tableNames ?? {}).tables;
+}

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -3150,6 +3150,31 @@ export async function closeAfterFailure(
   throw provisioningError;
 }
 
+/** Options for {@link runOptionallyInTransaction}. */
+export type RunOptionallyInTransactionOptions = Readonly<{
+  /**
+   * Pass only when the toplevel backend method would recurse — pass the
+   * operation-level backend so the no-transaction path doesn't loop back
+   * through the same toplevel method.
+   */
+  fallback?: GraphBackend | TransactionBackend;
+  /**
+   * Options for the transaction this opens — most usefully
+   * `accessMode: "read_only"`, which lets a multi-statement READ declare itself
+   * to the engine instead of only promising it (SQLite issues `BEGIN` rather
+   * than reserving the single writer slot with `BEGIN IMMEDIATE`; PostgreSQL
+   * issues `BEGIN … READ ONLY`).
+   *
+   * Scopes the transaction and nothing else, so it is not honored on the
+   * fallthrough path: a backend reporting `transactions: false` opens no
+   * transaction to configure. That is visible to the callback rather than
+   * silent — it receives `backend` (or `fallback`) itself, not a transaction
+   * target — and callers that surface atomicity, such as
+   * `repairInvertedValidityWindows`, report it from exactly that fact.
+   */
+  transaction?: TransactionOptions;
+}>;
+
 /**
  * Runs `fn` inside a transaction when given a top-level backend that supports
  * one, falling through to a direct invocation otherwise. Lets call sites benefit
@@ -3159,20 +3184,16 @@ export async function closeAfterFailure(
  * transaction-scoped backend. The single-statement race window is already
  * implicit on any backend that reports `transactions: false`; callers that
  * cannot tolerate it must branch on the capability themselves.
- *
- * Pass `fallback` only when the toplevel backend method would recurse
- * — pass the operation-level backend so the no-tx path doesn't loop
- * back through the same toplevel method.
  */
 export async function runOptionallyInTransaction<T>(
   backend: GraphBackend | TransactionBackend,
   fn: (target: GraphBackend | TransactionBackend) => Promise<T>,
-  fallback?: GraphBackend | TransactionBackend,
+  options?: RunOptionallyInTransactionOptions,
 ): Promise<T> {
   if ("transaction" in backend && backend.capabilities.transactions) {
-    return backend.transaction((tx) => fn(tx));
+    return backend.transaction((tx) => fn(tx), options?.transaction);
   }
-  return fn(fallback ?? backend);
+  return fn(options?.fallback ?? backend);
 }
 
 // ============================================================

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -491,7 +491,8 @@ export type InsertNodeParams = Readonly<{
    * window readable at no coordinate, in which case the row is stored with no
    * lower bound ("ended at T, start unknown"). See
    * `resolveStampedValidityLowerBound`, which every insert builder decides
-   * through.
+   * through. Custom backend implementations can import that owner from
+   * `@nicia-ai/typegraph/backend` rather than reimplementing the rule.
    * `null`: preserves an explicit open-left validity window (no lower
    * bound) — used by interchange import to round-trip a row that was
    * already NULL, instead of re-stamping it to the import's own timestamp.
@@ -621,7 +622,8 @@ export type InsertEdgeParams = Readonly<{
    * window readable at no coordinate, in which case the row is stored with no
    * lower bound ("ended at T, start unknown"). See
    * `resolveStampedValidityLowerBound`, which every insert builder decides
-   * through.
+   * through. Custom backend implementations can import that owner from
+   * `@nicia-ai/typegraph/backend` rather than reimplementing the rule.
    * `null`: preserves an explicit open-left validity window (no lower
    * bound) — used by interchange import to round-trip a row that was
    * already NULL, instead of re-stamping it to the import's own timestamp.
@@ -3167,12 +3169,17 @@ export type RunOptionallyInTransactionOptions = Readonly<{
    *
    * Scopes the transaction and nothing else, so it is not honored on the
    * fallthrough path: a backend reporting `transactions: false` opens no
-   * transaction to configure. That is visible to the callback rather than
-   * silent — it receives `backend` (or `fallback`) itself, not a transaction
-   * target — and callers that surface atomicity, such as
-   * `repairInvertedValidityWindows`, report it from exactly that fact.
+   * transaction to configure. The callback receives an explicit execution
+   * context stating whether a transaction was opened, so callers never infer
+   * atomicity from backend object identity.
    */
   transaction?: TransactionOptions;
+}>;
+
+/** What {@link runOptionallyInTransaction} actually did for this invocation. */
+export type OptionalTransactionExecution = Readonly<{
+  /** True only when the helper opened a transaction around the callback. */
+  atomic: boolean;
 }>;
 
 /**
@@ -3187,13 +3194,19 @@ export type RunOptionallyInTransactionOptions = Readonly<{
  */
 export async function runOptionallyInTransaction<T>(
   backend: GraphBackend | TransactionBackend,
-  fn: (target: GraphBackend | TransactionBackend) => Promise<T>,
+  fn: (
+    target: GraphBackend | TransactionBackend,
+    execution: OptionalTransactionExecution,
+  ) => Promise<T>,
   options?: RunOptionallyInTransactionOptions,
 ): Promise<T> {
   if ("transaction" in backend && backend.capabilities.transactions) {
-    return backend.transaction((tx) => fn(tx), options?.transaction);
+    return backend.transaction(
+      (tx) => fn(tx, { atomic: true }),
+      options?.transaction,
+    );
   }
-  return fn(options?.fallback ?? backend);
+  return fn(options?.fallback ?? backend, { atomic: false });
 }
 
 // ============================================================

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -521,6 +521,13 @@ export type UpdateNodeParams = Readonly<{
    * would leave the row readable at no coordinate, in which case the
    * resurrection stores no lower bound. Same rule, same owner, as an insert:
    * `resolveStampedValidityLowerBound`.
+   *
+   * The store's own resurrection paths never omit it. Their window guard has to
+   * judge the bound the write will STORE, so they resolve it through that owner
+   * against the instant they sampled and pass the result — `null` included,
+   * which is how "store no lower bound" is spelled here. Omission is for callers
+   * with no such verdict to honor; it lets this builder decide against its own,
+   * strictly later sample.
    */
   validFrom?: string | null;
   /**

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -486,7 +486,12 @@ export type InsertNodeParams = Readonly<{
   id: string;
   props: Readonly<Record<string, unknown>>;
   /**
-   * Omitted (`undefined`): defaults to the insert's creation timestamp.
+   * Omitted (`undefined`): the insert stamps its own creation timestamp —
+   * UNLESS a stated `validTo` at or before that instant would make the stored
+   * window readable at no coordinate, in which case the row is stored with no
+   * lower bound ("ended at T, start unknown"). See
+   * `resolveStampedValidityLowerBound`, which every insert builder decides
+   * through.
    * `null`: preserves an explicit open-left validity window (no lower
    * bound) — used by interchange import to round-trip a row that was
    * already NULL, instead of re-stamping it to the import's own timestamp.
@@ -510,7 +515,13 @@ export type UpdateNodeParams = Readonly<{
   kind: string;
   id: string;
   props: Readonly<Record<string, unknown>>;
-  /** Applied when resurrecting a tombstone; omitted means the resurrection instant. */
+  /**
+   * Applied when resurrecting a tombstone, which RESETS the window. Omitted
+   * means the resurrection instant — unless a stated `validTo` at or before it
+   * would leave the row readable at no coordinate, in which case the
+   * resurrection stores no lower bound. Same rule, same owner, as an insert:
+   * `resolveStampedValidityLowerBound`.
+   */
   validFrom?: string | null;
   /**
    * The effective `valid_from` this write ASSERTS the target row already
@@ -598,7 +609,12 @@ export type InsertEdgeParams = Readonly<{
   toId: string;
   props: Readonly<Record<string, unknown>>;
   /**
-   * Omitted (`undefined`): defaults to the insert's creation timestamp.
+   * Omitted (`undefined`): the insert stamps its own creation timestamp —
+   * UNLESS a stated `validTo` at or before that instant would make the stored
+   * window readable at no coordinate, in which case the row is stored with no
+   * lower bound ("ended at T, start unknown"). See
+   * `resolveStampedValidityLowerBound`, which every insert builder decides
+   * through.
    * `null`: preserves an explicit open-left validity window (no lower
    * bound) — used by interchange import to round-trip a row that was
    * already NULL, instead of re-stamping it to the import's own timestamp.

--- a/packages/typegraph/src/graph-merge/working-copy.ts
+++ b/packages/typegraph/src/graph-merge/working-copy.ts
@@ -24,9 +24,11 @@
  * `includeTemporal: true` carries `validFrom`/`validTo` through unchanged,
  * preserving the base's exact valid-time window on the clone: create-time
  * paths default an omitted `validFrom` to the row's own creation instant
- * (see #240), and export/import round-trip a still-open-left `valid_from`
- * (e.g. a row that predates the #240 fix) as an explicit `null` rather than
- * silently dropping it — see `InterchangeNodeSchema.validFrom`'s doc.
+ * (see #240) — except for a BORN-ENDED row, whose stated `validTo` at or before
+ * the write instant leaves it with no lower bound at all (see #407) — and
+ * export/import round-trip a still-open-left `valid_from` (a born-ended row, or
+ * one that predates the #240 fix) as an explicit `null` rather than silently
+ * dropping it — see `InterchangeNodeSchema.validFrom`'s doc.
  * Without either half of this, the clone's re-import would re-stamp the
  * affected base rows to the CLONE's creation instant instead — narrowing
  * their validity window and making `asOf` reads on the fork diverge from

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -247,6 +247,13 @@ export {
   type MigrateLegacyEmbeddingsOptions,
   type MigrateLegacyEmbeddingsResult,
 } from "./backend/migrate-vectors";
+export {
+  repairInvertedValidityWindows,
+  type RepairInvertedWindowsOptions,
+  type RepairInvertedWindowsReport,
+  type RepairRelation,
+  type RepairRelationScope,
+} from "./backend/repair-validity-windows";
 
 // ============================================================
 // Core Types

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -1782,8 +1782,11 @@ function validateValidityWindow(
     validateOptionalCanonicalIsoDate(entity.validTo, "validTo");
     // On an INSERT only a stated pair is judged — a lone historical validTo
     // means "born already ended", exactly as it does on `create` (see
-    // assertWritableValidityWindow). `null` is a confirmed open-left window and
-    // is not a lower bound at all.
+    // assertWritableValidityWindow) — and that is the WHOLE rule, not a partial
+    // one: the insert path this feeds stamps NO lower bound for such a row
+    // (`resolveStampedValidityLowerBound`), so a document accepted here cannot
+    // become a row readable at no coordinate. `null` is a confirmed open-left
+    // window and is not a lower bound at all.
     assertOrderedValidityWindow(
       `${entity.kind} "${entity.id}"`,
       entity.validFrom ?? undefined,

--- a/packages/typegraph/src/interchange/types.ts
+++ b/packages/typegraph/src/interchange/types.ts
@@ -68,10 +68,13 @@ export const InterchangeNodeSchema = z.object({
   properties: z.record(z.string(), z.unknown()),
   /**
    * `undefined` (key absent): not requested (`includeTemporal: false`) —
-   * import defaults it to the import's own creation timestamp. `null`:
-   * requested and confirmed the row has no lower bound (e.g. a legacy row
-   * predating the "omitted validFrom defaults to creation time" fix) —
-   * import preserves that open-left validity instead of re-stamping it.
+   * import defaults it to the import's own creation timestamp, UNLESS the
+   * record states a `validTo` at or before that instant, in which case the row
+   * is imported with no lower bound ("ended at T, start unknown") rather than
+   * one after its own end (issue #407). `null`: requested and confirmed the row
+   * has no lower bound (e.g. a legacy row predating the "omitted validFrom
+   * defaults to creation time" fix) — import preserves that open-left validity
+   * instead of re-stamping it.
    */
   validFrom: ValidityTimestampSchema.nullable().optional(),
   validTo: ValidityTimestampSchema.optional(),

--- a/packages/typegraph/src/provenance/index.ts
+++ b/packages/typegraph/src/provenance/index.ts
@@ -452,11 +452,7 @@ async function findNodeRows(
       orderBy: "id",
     });
     return rows.filter((row) =>
-      validityWindowContainsInstant(
-        row.valid_from,
-        row.valid_to,
-        options.asOf,
-      ),
+      validityWindowContainsInstant(row.valid_from, row.valid_to, options.asOf),
     );
   }
   return backend.findNodesByKind({

--- a/packages/typegraph/src/provenance/index.ts
+++ b/packages/typegraph/src/provenance/index.ts
@@ -29,7 +29,7 @@ import {
   type TransactionContext,
 } from "../store/types";
 import { compareStrings } from "../utils/compare";
-import { nowIso } from "../utils/date";
+import { nowIso, validityWindowContainsInstant } from "../utils/date";
 import { isPlainObject } from "../utils/object";
 
 export type {
@@ -429,22 +429,6 @@ function assertEdgeEndpoints<G extends GraphDef>(
 }
 
 /**
- * Whether a row's validity window contains `asOf`. The JS mirror of the SQL
- * `"current"`-mode predicate, for role reads that must include tombstoned
- * rows (which `"current"` cannot express) yet still respect validity.
- * Canonical fixed-width UTC ISO strings compare correctly as text.
- */
-function isValidAt(
-  row: Pick<NodeRow, "valid_from" | "valid_to">,
-  asOf: string,
-): boolean {
-  return (
-    (row.valid_from === undefined || row.valid_from <= asOf) &&
-    (row.valid_to === undefined || row.valid_to > asOf)
-  );
-}
-
-/**
  * Provenance reads follow the store's currency semantics: a source,
  * justification, or support edge counts only while currently valid (the
  * default `"current"` read mode), so a validity-expired source no longer
@@ -467,7 +451,13 @@ async function findNodeRows(
       temporalMode: "includeTombstones",
       orderBy: "id",
     });
-    return rows.filter((row) => isValidAt(row, options.asOf));
+    return rows.filter((row) =>
+      validityWindowContainsInstant(
+        row.valid_from,
+        row.valid_to,
+        options.asOf,
+      ),
+    );
   }
   return backend.findNodesByKind({
     graphId,

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -163,11 +163,17 @@ export function upsertWindowChanges(
  * COMPLETE window — leaves the row holding, for a later item with the same id in
  * the same batch to compare against.
  *
- * An omitted `validFrom` is stamped with the write instant by the backend, a
- * value this layer cannot know, so it stays `undefined`. A later copy naming a
- * lower bound therefore counts as a change and writes, rather than coalescing
- * against a guess: the bulk path may spend a write the sequential path would
- * skip, but it never skips one the sequential path makes.
+ * An omitted `validFrom` is left `undefined`, and that prediction is now EXACT in
+ * one case and conservative in the other:
+ *
+ *  - BORN-ENDED (a stated `validTo` at or before the write instant): the backend
+ *    stamps no lower bound at all, so `undefined` is precisely what the row will
+ *    hold, and a later copy restating that shape coalesces correctly;
+ *  - every other create: the backend stamps its own write instant, a value this
+ *    layer cannot know, so `undefined` remains a deliberate under-approximation.
+ *    A later copy naming a lower bound counts as a change and writes, rather than
+ *    coalescing against a guess — the bulk path may spend a write the sequential
+ *    path would skip, but it never skips one the sequential path makes.
  */
 export function windowAfterUpsertCreate(
   requested: RequestedWindow,

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -143,9 +143,13 @@ function evaluateNodePredicate<N extends NodeType>(
  * Update input for the internal upsert path, which owns the WHOLE validity
  * window: a resurrecting upsert rewrites both endpoints, so it must be able to
  * carry `validFrom` as well as `validTo`. Dropping `validFrom` here would leave
- * the backend defaulting the lower bound to the resurrection instant while the
- * caller's (possibly already past) `validTo` stayed — an inverted window that
- * no read coordinate can observe.
+ * a stated lower bound unreachable by the only node write that stores one: a
+ * resurrection rewrites `valid_from` whether or not the caller named it, so the
+ * caller's bound would be replaced by the instant that write stamps rather than
+ * honored. It would no longer INVERT the window — a resurrection stating only a
+ * historical `validTo` stores no lower bound at all — which is why the sibling
+ * note on `UpsertUpdateEdgeInput` still reads in terms of inversion and this one
+ * does not: an edge resurrection RETAINS its stored bound.
  *
  * The public `update()` API cannot reach this member: its options type exposes
  * `validTo` only, and it builds its input through {@link buildUpdateInput}. Only

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -489,9 +489,11 @@ async function validateAndPrepareEdgeCreate<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
-  // A stated pair must be ordered. A lone historical validTo is NOT an error on
-  // an insert — it means "born already ended" (see
-  // assertWritableValidityWindow). Both create paths (single and batch) prepare
+  // A stated pair must be ordered, and on an insert that is the COMPLETE rule.
+  // A lone historical validTo is NOT an error — it means "born already ended"
+  // (see assertWritableValidityWindow), and the insert stores no lower bound for
+  // it rather than one past the stated end, so there is no effective bound left
+  // for this layer to judge. Both create paths (single and batch) prepare
   // through here, so this is the only insert-side check needed.
   assertOrderedValidityWindow(`edge "${id}"`, validFrom, validTo);
 

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -683,10 +683,12 @@ function draftNodeCreate<G extends GraphDef>(
     "validFrom",
   );
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
-  // A stated pair must be ordered. A lone historical validTo is NOT an error on
-  // an insert — it means "born already ended" (see
-  // assertWritableValidityWindow). Both create paths (single and batch) draft
-  // through here, so this is the only insert-side check needed.
+  // A stated pair must be ordered, and on an insert that is the COMPLETE rule.
+  // A lone historical validTo is NOT an error — it means "born already ended"
+  // (see assertWritableValidityWindow), and the insert stores no lower bound for
+  // it rather than one past the stated end, so there is no effective bound left
+  // for this layer to judge. Both create paths (single and batch) draft through
+  // here, so this is the only insert-side check needed.
   assertOrderedValidityWindow(`${kind} "${id}"`, validFrom, validTo);
 
   return {
@@ -937,11 +939,12 @@ async function performNodeUpdate<G extends GraphDef>(
   // effective lower bound is the write instant rather than the row's stored
   // one. That instant is sampled HERE and then travels to the backend as an
   // explicit `validFrom`, because the guard has to measure the bound the write
-  // will actually store: left to default, `resolveValidFrom` would stamp the
-  // backend's own, strictly later, sample, and a `validTo` at this instant
-  // would pass the guard as zero-width and land as negative width a
-  // millisecond later (issue #413). An in-place update keeps the row's stored
-  // bound, which no write rewrites and so needs no prediction.
+  // will actually store: left to default, the builder's own
+  // `resolveStampedValidityLowerBound` call would judge the backend's strictly
+  // later sample, and a `validTo` at this instant would pass the guard as
+  // zero-width and land as a different shape a millisecond later (issue #413).
+  // An in-place update keeps the row's stored bound, which no write rewrites and
+  // so needs no prediction.
   const resurrectionInstant =
     options?.clearDeleted === true && existing.deleted_at !== undefined ?
       nowIso()

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -104,6 +104,7 @@ import {
   assertWritableValidityWindow,
   nowIso,
   preservesImmutableLowerBound,
+  resolveStampedValidityLowerBound,
   validateOptionalCanonicalIsoDate,
 } from "../../utils/date";
 import { generateId } from "../../utils/id";
@@ -935,11 +936,11 @@ async function performNodeUpdate<G extends GraphDef>(
   const nodeKind = registration.type;
 
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
-  // A node resurrection RESETS `valid_from` (see `buildUpdateNode`), so the
-  // effective lower bound is the write instant rather than the row's stored
-  // one. That instant is sampled HERE and then travels to the backend as an
-  // explicit `validFrom`, because the guard has to measure the bound the write
-  // will actually store: left to default, the builder's own
+  // A node resurrection RESETS `valid_from` (see `buildUpdateNode`), so its
+  // effective lower bound is one this write stamps rather than the row's stored
+  // one. The instant is sampled HERE and the bound resolved from it travels to
+  // the backend as an explicit `validFrom`, because the guard has to measure
+  // the bound the write will actually store: left to default, the builder's own
   // `resolveStampedValidityLowerBound` call would judge the backend's strictly
   // later sample, and a `validTo` at this instant would pass the guard as
   // zero-width and land as a different shape a millisecond later (issue #413).
@@ -962,6 +963,18 @@ async function performNodeUpdate<G extends GraphDef>(
     "validFrom",
   );
   const validFrom = preservesLiveLowerBound ? undefined : statedValidFrom;
+  // The bound this resurrection will STORE, decided by the same owner every
+  // insert builder decides through, against the instant sampled above. Asking
+  // the owner rather than assuming `resurrectionInstant` is what makes a
+  // resurrection carrying only a historical `validTo` reach the shape a create
+  // reaches — no lower bound, "ended at T, start unknown" — instead of being
+  // refused for inverting against an instant the write would never have stored
+  // (I12). `undefined` here means "no bound", which is nothing to invert
+  // against, so the verdict below judges exactly what lands.
+  const resurrectionBound =
+    resurrectionInstant === undefined ? undefined : (
+      resolveStampedValidityLowerBound(validFrom, validTo, resurrectionInstant)
+    );
   // A resurrection STORES a stated `validFrom` (it rewrites the whole window);
   // an in-place update never does, so one that differs from the row's stored
   // bound is refused rather than accepted and dropped.
@@ -975,23 +988,19 @@ async function performNodeUpdate<G extends GraphDef>(
         effectiveBoundIsStored: true,
       }
     : {
-        effectiveValidFrom: resurrectionInstant,
+        effectiveValidFrom: resurrectionBound,
         appliesStatedValidFrom: true,
-        // The instant this write is about to stamp, not a bound the row holds.
+        // The bound this write is about to stamp, not one the row holds.
         effectiveBoundIsStored: false,
       },
     validTo,
   );
 
   const writeContext = createNodeWriteContext(ctx.graphId, ctx.registry, lock);
-  // `validFrom` reaches the backend only through a resurrecting write (see
-  // UpdateNodeParams): a live row's lower bound is history and stays put.
-  const effectiveValidFrom = validFrom ?? resurrectionInstant;
   const shared = {
     schema: nodeKind.schema,
     validatedProps,
     uniqueConstraints: registration.unique ?? [],
-    ...(effectiveValidFrom !== undefined && { validFrom: effectiveValidFrom }),
     ...(validTo !== undefined && { validTo }),
     ...(input.clearValidTo === true && { clearValidTo: true as const }),
     // The bound the verdict above READ, carried into the UPDATE's own `WHERE`
@@ -1010,9 +1019,31 @@ async function performNodeUpdate<G extends GraphDef>(
   // A resurrecting upsert (clearDeleted) may target a tombstoned row; a plain
   // update must prove the row live — see NodeUpdateTarget.
   if (options?.clearDeleted) {
+    // Keyed on the SAME condition the verdict was, because only that condition
+    // produces a verdict to state. With `resurrectionInstant` defined this is
+    // the DECISION, never an absence: omitting the key would let
+    // `buildUpdateNode` re-derive the bound against the backend's own, strictly
+    // later `timestamp`, so the two layers would agree only while the two clocks
+    // do — the #413 hazard, one layer out. `null` is how `UpdateNodeParams`
+    // spells "store no lower bound", which is what this decision resolves to for
+    // a resurrection that ends at or before the instant it judged.
+    //
+    // With it UNDEFINED this read found the row live — a peer resurrected it
+    // between the collection's probe and here — so the verdict judged the row's
+    // stored bound and stamped nothing. There is no decision to state, and
+    // stating one anyway would write away a `validFrom` the guard just ACCEPTED
+    // as equal to that stored bound. The statement usually matches no row
+    // (`deleted_at IS NOT NULL`) and the recovery below re-reads, but a peer that
+    // re-tombstones before the UPDATE makes it match, so this leg carries the
+    // stated bound exactly as the in-place leg does.
+    const resurrectionLowerBound =
+      resurrectionInstant === undefined ?
+        validFrom !== undefined && { validFrom }
+        // eslint-disable-next-line unicorn/no-null -- `validFrom: null` means "store NULL"; omitting the key means "decide for me", and this path has already decided. See UpdateNodeParams.validFrom.
+      : { validFrom: resurrectionBound ?? null };
     const row = await applyNodeUpdate(
       writeContext,
-      { ...shared, existing, clearDeleted: true },
+      { ...shared, existing, clearDeleted: true, ...resurrectionLowerBound },
       backend,
     );
     return rowToNode(row);
@@ -1021,7 +1052,11 @@ async function performNodeUpdate<G extends GraphDef>(
   if (!isLiveNodeRow(existing)) throw new NodeNotFoundError(kind, id);
   const row = await applyNodeUpdate(
     writeContext,
-    { ...shared, existing },
+    // An in-place update must not rewrite the stored bound, so it keeps the
+    // conditional spread: `buildUpdateNode` ignores `validFrom` off the
+    // resurrection leg, and stating one here would claim a rewrite that no
+    // statement performs.
+    { ...shared, existing, ...(validFrom !== undefined && { validFrom }) },
     backend,
   );
   return rowToNode(row);
@@ -1332,6 +1367,20 @@ async function resurrectPreparedNode<G extends GraphDef>(
   if (current.deleted_at === undefined) {
     throw createAlreadyExistsError("node", prepared.kind, prepared.id);
   }
+  // A create landing on a tombstone RESETS the window, so this leg stamps a
+  // bound whenever the caller stated none — and it decides which one through
+  // the same owner `performNodeUpdate`'s resurrection leg and every insert
+  // builder use, against an instant sampled HERE. Two consequences. The stored
+  // bound is the one this layer judged rather than the backend's strictly later
+  // sample, so one write has one instant (issue #413). And a create carrying
+  // only a historical `validTo` reaches the same stored shape on a tombstoned
+  // id as on a fresh one — no lower bound (I12).
+  const resurrectionInstant = nowIso();
+  const resurrectionBound = resolveStampedValidityLowerBound(
+    prepared.insertParams.validFrom,
+    prepared.insertParams.validTo,
+    resurrectionInstant,
+  );
   try {
     return await applyNodeUpdate(
       createNodeWriteContext(ctx.graphId, ctx.registry, lock),
@@ -1341,9 +1390,10 @@ async function resurrectPreparedNode<G extends GraphDef>(
         schema: prepared.nodeKind.schema,
         validatedProps: prepared.validatedProps,
         uniqueConstraints: prepared.uniqueConstraints,
-        ...(prepared.insertParams.validFrom === undefined ?
-          {}
-        : { validFrom: prepared.insertParams.validFrom }),
+        // The decision itself, never an absence — see the same spelling on
+        // `performNodeUpdate`'s resurrection leg.
+        // eslint-disable-next-line unicorn/no-null -- `validFrom: null` means "store NULL"; omitting the key means "decide for me", and this path has already decided. See UpdateNodeParams.validFrom.
+        validFrom: resurrectionBound ?? null,
         ...(prepared.insertParams.validTo === undefined ?
           {}
         : { validTo: prepared.insertParams.validTo }),

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -166,7 +166,7 @@ import {
 import { type SchemaDiff } from "../schema/migration";
 import { serializeSchema } from "../schema/serializer";
 import { type SerializedSchema } from "../schema/types";
-import { nowIso } from "../utils/date";
+import { nowIso, validityWindowContainsInstant } from "../utils/date";
 import { generateId } from "../utils/id";
 import { hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
@@ -5184,12 +5184,12 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         case "current":
         case "asOf": {
           // resolveTemporalReadParams always resolves an instant for these modes.
-          if (row.deleted_at) return false;
-          if (asOf !== undefined && row.valid_from && asOf < row.valid_from)
-            return false;
-          if (asOf !== undefined && row.valid_to && asOf >= row.valid_to)
-            return false;
-          return true;
+          if (row.deleted_at || asOf === undefined) return false;
+          return validityWindowContainsInstant(
+            row.valid_from,
+            row.valid_to,
+            asOf,
+          );
         }
         case "includeEnded": {
           return !row.deleted_at;

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -915,14 +915,12 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. On the CREATE branch that default is
-   * dropped when a stated `validTo` at or before the write instant would leave
-   * the row readable at no coordinate: NO lower bound is stored ("ended at T,
-   * start unknown") and `meta.validFrom` reads back as `undefined`. A
-   * RESURRECTION does not take that exception: it judges the stated `validTo`
-   * against the resurrection instant, so one strictly earlier is REFUSED and one
-   * landing exactly on it stores a zero-width window. State `validFrom`
-   * alongside a historical `validTo` when the id may name a tombstone. An update to a LIVE row stores no lower
+   * operation's timestamp when omitted. That default is dropped when a stated
+   * `validTo` at or before the write instant would leave the row readable at no
+   * coordinate: NO lower bound is stored ("ended at T, start unknown") and
+   * `meta.validFrom` reads back as `undefined`. A RESURRECTION takes the same
+   * exception, decided against the instant it samples, so one stated window
+   * reaches ONE stored shape whether the id is fresh or names a tombstone. An update to a LIVE row stores no lower
    * bound, because that row's is already history, so one naming a different
    * instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
@@ -950,14 +948,12 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. On the CREATE branch that default is
-   * dropped when a stated `validTo` at or before the write instant would leave
-   * the row readable at no coordinate: NO lower bound is stored ("ended at T,
-   * start unknown") and `meta.validFrom` reads back as `undefined`. A
-   * RESURRECTION does not take that exception: it judges the stated `validTo`
-   * against the resurrection instant, so one strictly earlier is REFUSED and one
-   * landing exactly on it stores a zero-width window. State `validFrom`
-   * alongside a historical `validTo` when the id may name a tombstone. An update to a LIVE row stores no lower
+   * operation's timestamp when omitted. That default is dropped when a stated
+   * `validTo` at or before the write instant would leave the row readable at no
+   * coordinate: NO lower bound is stored ("ended at T, start unknown") and
+   * `meta.validFrom` reads back as `undefined`. A RESURRECTION takes the same
+   * exception, decided against the instant it samples, so one stated window
+   * reaches ONE stored shape whether the id is fresh or names a tombstone. An update to a LIVE row stores no lower
    * bound, because that row's is already history, so one naming a different
    * instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
@@ -1009,14 +1005,12 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. On the CREATE branch that default is
-   * dropped when a stated `validTo` at or before the write instant would leave
-   * the row readable at no coordinate: NO lower bound is stored ("ended at T,
-   * start unknown") and `meta.validFrom` reads back as `undefined`. A
-   * RESURRECTION does not take that exception: it judges the stated `validTo`
-   * against the resurrection instant, so one strictly earlier is REFUSED and one
-   * landing exactly on it stores a zero-width window. State `validFrom`
-   * alongside a historical `validTo` when the id may name a tombstone. An update to a LIVE row stores no lower
+   * operation's timestamp when omitted. That default is dropped when a stated
+   * `validTo` at or before the write instant would leave the row readable at no
+   * coordinate: NO lower bound is stored ("ended at T, start unknown") and
+   * `meta.validFrom` reads back as `undefined`. A RESURRECTION takes the same
+   * exception, decided against the instant it samples, so one stated window
+   * reaches ONE stored shape whether the id is fresh or names a tombstone. An update to a LIVE row stores no lower
    * bound, because that row's is already history, so one naming a different
    * instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -799,7 +799,11 @@ export type NodeCollection<
   /**
    * Create a new node.
    *
-   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   * `validFrom` defaults to the operation's creation timestamp when omitted —
+   * unless a stated `validTo` at or before that instant would leave the row
+   * readable at no coordinate, in which case the row is stored with NO lower
+   * bound ("ended at T, start unknown") and `meta.validFrom` reads back as
+   * `undefined`. A future `validTo` is unaffected.
    */
   create: (
     props: z.input<N["schema"]>,
@@ -892,7 +896,11 @@ export type NodeCollection<
    * the data shape is determined at runtime, not compile time.
    * The return type is fully typed — only the input gate is relaxed.
    *
-   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   * `validFrom` defaults to the operation's creation timestamp when omitted —
+   * unless a stated `validTo` at or before that instant would leave the row
+   * readable at no coordinate, in which case the row is stored with NO lower
+   * bound ("ended at T, start unknown") and `meta.validFrom` reads back as
+   * `undefined`. A future `validTo` is unaffected.
    */
   createFromRecord: (
     data: Record<string, unknown>,
@@ -907,7 +915,14 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * operation's timestamp when omitted. On the CREATE branch that default is
+   * dropped when a stated `validTo` at or before the write instant would leave
+   * the row readable at no coordinate: NO lower bound is stored ("ended at T,
+   * start unknown") and `meta.validFrom` reads back as `undefined`. A
+   * RESURRECTION does not take that exception: it judges the stated `validTo`
+   * against the resurrection instant, so one strictly earlier is REFUSED and one
+   * landing exactly on it stores a zero-width window. State `validFrom`
+   * alongside a historical `validTo` when the id may name a tombstone. An update to a LIVE row stores no lower
    * bound, because that row's is already history, so one naming a different
    * instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
@@ -935,7 +950,14 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * operation's timestamp when omitted. On the CREATE branch that default is
+   * dropped when a stated `validTo` at or before the write instant would leave
+   * the row readable at no coordinate: NO lower bound is stored ("ended at T,
+   * start unknown") and `meta.validFrom` reads back as `undefined`. A
+   * RESURRECTION does not take that exception: it judges the stated `validTo`
+   * against the resurrection instant, so one strictly earlier is REFUSED and one
+   * landing exactly on it stores a zero-width window. State `validFrom`
+   * alongside a historical `validTo` when the id may name a tombstone. An update to a LIVE row stores no lower
    * bound, because that row's is already history, so one naming a different
    * instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
@@ -958,7 +980,11 @@ export type NodeCollection<
    * More efficient than calling create() multiple times.
    * Use `bulkInsert` for the dedicated fast path that skips returning results.
    *
-   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   * `validFrom` defaults to the operation's creation timestamp when omitted —
+   * unless a stated `validTo` at or before that instant would leave the row
+   * readable at no coordinate, in which case the row is stored with NO lower
+   * bound ("ended at T, start unknown") and `meta.validFrom` reads back as
+   * `undefined`. A future `validTo` is unaffected.
    */
   bulkCreate: (
     items: readonly Readonly<{
@@ -983,7 +1009,14 @@ export type NodeCollection<
    *
    * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
    * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * operation's timestamp when omitted. On the CREATE branch that default is
+   * dropped when a stated `validTo` at or before the write instant would leave
+   * the row readable at no coordinate: NO lower bound is stored ("ended at T,
+   * start unknown") and `meta.validFrom` reads back as `undefined`. A
+   * RESURRECTION does not take that exception: it judges the stated `validTo`
+   * against the resurrection instant, so one strictly earlier is REFUSED and one
+   * landing exactly on it stores a zero-width window. State `validFrom`
+   * alongside a historical `validTo` when the id may name a tombstone. An update to a LIVE row stores no lower
    * bound, because that row's is already history, so one naming a different
    * instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
@@ -1021,7 +1054,11 @@ export type NodeCollection<
    * with `returnResults: false`, the intent is unambiguous: no results
    * are returned and the operation is wrapped in a transaction.
    *
-   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   * `validFrom` defaults to the operation's creation timestamp when omitted —
+   * unless a stated `validTo` at or before that instant would leave the row
+   * readable at no coordinate, in which case the row is stored with NO lower
+   * bound ("ended at T, start unknown") and `meta.validFrom` reads back as
+   * `undefined`. A future `validTo` is unaffected.
    */
   bulkInsert: (
     items: readonly Readonly<{
@@ -1190,7 +1227,11 @@ export type EdgeCollection<
   /**
    * Create a new edge.
    *
-   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   * `validFrom` defaults to the operation's creation timestamp when omitted —
+   * unless a stated `validTo` at or before that instant would leave the row
+   * readable at no coordinate, in which case the row is stored with NO lower
+   * bound ("ended at T, start unknown") and `meta.validFrom` reads back as
+   * `undefined`. A future `validTo` is unaffected.
    *
    * @param from - Source node (must be one of the allowed 'from' types)
    * @param to - Target node (must be one of the allowed 'to' types)
@@ -1372,7 +1413,11 @@ export type EdgeCollection<
    * More efficient than calling create() multiple times.
    * Use `bulkInsert` for the dedicated fast path that skips returning results.
    *
-   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   * `validFrom` defaults to the operation's creation timestamp when omitted —
+   * unless a stated `validTo` at or before that instant would leave the row
+   * readable at no coordinate, in which case the row is stored with NO lower
+   * bound ("ended at T, start unknown") and `meta.validFrom` reads back as
+   * `undefined`. A future `validTo` is unaffected.
    */
   bulkCreate: (
     items: readonly Readonly<{
@@ -1400,9 +1445,15 @@ export type EdgeCollection<
    * is refused with `ValidationError` carrying
    * `EDGE_IDENTITY_MISMATCH_CODE`; it is never silently ignored.
    *
-   * `validFrom` applies when the upsert CREATES the row and when it RESURRECTS
-   * a tombstoned one — both write a fresh validity window — defaulting to the
-   * operation's timestamp when omitted. An update to a LIVE row stores no lower
+   * `validFrom` applies when the upsert CREATES the edge and when it RESURRECTS
+   * a tombstoned one. A create writes a fresh validity window, defaulting to the
+   * operation's timestamp when omitted — unless a stated `validTo` at or before
+   * that instant would leave the row readable at no coordinate, in which case NO
+   * lower bound is stored ("ended at T, start unknown") and `meta.validFrom`
+   * reads back as `undefined`. A resurrection stamps nothing: an edge RETAINS
+   * its stored lower bound unless the item names a new one, so a `validTo`
+   * before the retained bound is REFUSED rather than stamped over. An update to
+   * a LIVE row stores no lower
    * bound, because that row's is already history, so one naming a different
    * instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
@@ -1438,7 +1489,11 @@ export type EdgeCollection<
    * with `returnResults: false`, the intent is unambiguous: no results
    * are returned and the operation is wrapped in a transaction.
    *
-   * `validFrom` defaults to the operation's creation timestamp when omitted.
+   * `validFrom` defaults to the operation's creation timestamp when omitted —
+   * unless a stated `validTo` at or before that instant would leave the row
+   * readable at no coordinate, in which case the row is stored with NO lower
+   * bound ("ended at T, start unknown") and `meta.validFrom` reads back as
+   * `undefined`. A future `validTo` is unaffected.
    */
   bulkInsert: (
     items: readonly Readonly<{
@@ -1495,8 +1550,13 @@ export type EdgeCollection<
    * property fields, only edges whose properties match on those fields are considered.
    * Soft-deleted matches are resurrected when cardinality allows.
    *
-   * `validFrom` applies on the create and RESURRECT branches, defaulting to the
-   * operation's creation timestamp when omitted. On the `ifExists: "update"`
+   * `validFrom` applies on the create and RESURRECT branches. A create defaults
+   * it to the operation's creation timestamp when omitted — unless a stated
+   * `validTo` at or before that instant would leave the row readable at no
+   * coordinate, in which case no lower bound is stored ("ended at T, start
+   * unknown"). A resurrection stamps nothing: an edge RETAINS its stored lower
+   * bound unless the call names a new one, so a `validTo` before the retained
+   * bound is REFUSED rather than stamped over. On the `ifExists: "update"`
    * branch a live edge's lower bound is history and cannot be stored, so a
    * `validFrom` naming a different instant is REFUSED (`ValidationError`
    * carrying `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`); restating the bound the

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -920,9 +920,10 @@ export type NodeCollection<
    * coordinate: NO lower bound is stored ("ended at T, start unknown") and
    * `meta.validFrom` reads back as `undefined`. A RESURRECTION takes the same
    * exception, decided against the instant it samples, so one stated window
-   * reaches ONE stored shape whether the id is fresh or names a tombstone. An update to a LIVE row stores no lower
-   * bound, because that row's is already history, so one naming a different
-   * instant is REFUSED (`ValidationError` carrying
+   * reaches ONE stored shape whether the id is fresh or names a tombstone. An
+   * update to a LIVE row stores no lower bound, because that row's is already
+   * history, so one naming a different instant is REFUSED (`ValidationError`
+   * carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
    * bound the row already holds is accepted and changes nothing. Set
    * `onImmutableLowerBound: "preserve"` for event materializers whose
@@ -953,9 +954,10 @@ export type NodeCollection<
    * coordinate: NO lower bound is stored ("ended at T, start unknown") and
    * `meta.validFrom` reads back as `undefined`. A RESURRECTION takes the same
    * exception, decided against the instant it samples, so one stated window
-   * reaches ONE stored shape whether the id is fresh or names a tombstone. An update to a LIVE row stores no lower
-   * bound, because that row's is already history, so one naming a different
-   * instant is REFUSED (`ValidationError` carrying
+   * reaches ONE stored shape whether the id is fresh or names a tombstone. An
+   * update to a LIVE row stores no lower bound, because that row's is already
+   * history, so one naming a different instant is REFUSED (`ValidationError`
+   * carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
    * bound the row already holds is accepted and changes nothing. Set
    * `onImmutableLowerBound: "preserve"` for create/resurrection-only input.
@@ -1447,9 +1449,8 @@ export type EdgeCollection<
    * reads back as `undefined`. A resurrection stamps nothing: an edge RETAINS
    * its stored lower bound unless the item names a new one, so a `validTo`
    * before the retained bound is REFUSED rather than stamped over. An update to
-   * a LIVE row stores no lower
-   * bound, because that row's is already history, so one naming a different
-   * instant is REFUSED (`ValidationError` carrying
+   * a LIVE row stores no lower bound, because that row's is already history, so
+   * one naming a different instant is REFUSED (`ValidationError` carrying
    * `IMMUTABLE_VALIDITY_LOWER_BOUND_CODE`) rather than ignored. Restating the
    * bound the row already holds is accepted and changes nothing.
    *

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -285,6 +285,24 @@ export function isEmptyValidityWindow(
 }
 
 /**
+ * Whether a canonical instant belongs to the half-open validity interval
+ * `[validFrom, validTo)`. An omitted bound is unbounded on that side.
+ *
+ * This is the single JavaScript owner of validity-window membership. SQL read
+ * paths express the same decision through the shared temporal compiler.
+ */
+export function validityWindowContainsInstant(
+  validFrom: string | undefined,
+  validTo: string | undefined,
+  instant: string,
+): boolean {
+  return (
+    (validFrom === undefined || validFrom <= instant) &&
+    (validTo === undefined || instant < validTo)
+  );
+}
+
+/**
  * THE lower bound a write that STAMPS its own start stores, decided against the
  * instant it is about to stamp. One owner for every such write, so no two of them
  * can spell the decision differently. Three inputs, three outcomes:

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -258,6 +258,97 @@ export function isInvertedValidityWindow(
 }
 
 /**
+ * Whether a validity window is readable at NO instant — inverted OR zero width.
+ * The CHOICE predicate, sibling to {@link isInvertedValidityWindow}'s REFUSAL
+ * predicate, and the two answer different questions on purpose:
+ *
+ *  - a window a caller STATED in full is refused only when it is inverted, because
+ *    zero width is what a same-instant retraction produces and the store's own
+ *    output must round-trip;
+ *  - a bound a write CHOOSES for a caller who stated none must never satisfy this
+ *    one, because a row nobody can read at any coordinate is not a window the
+ *    caller asked for.
+ *
+ * `inverted ⇒ empty`, and `empty ∧ ¬inverted ⟺ zero width`. That law is a
+ * property in `tests/property/temporal-window.test.ts`, so the pair cannot drift
+ * into disagreeing about anything but the boundary they deliberately differ on.
+ *
+ * PRECONDITION: as {@link isInvertedValidityWindow} — both endpoints canonical
+ * fixed-width UTC ISO 8601, so the lexicographic compare is a chronological one.
+ */
+export function isEmptyValidityWindow(
+  validFrom: string | undefined,
+  validTo: string | undefined,
+): boolean {
+  if (validFrom === undefined || validTo === undefined) return false;
+  return validFrom >= validTo;
+}
+
+/**
+ * THE lower bound a write that STAMPS its own start stores, decided against the
+ * instant it is about to stamp. One owner for every such write, so no two of them
+ * can spell the decision differently. Three inputs, three outcomes:
+ *
+ *  - a stated `null`   → no lower bound (a CONFIRMED open-left window, which is
+ *                        how interchange round-trips a row that has none);
+ *  - a stated string   → that bound, the caller's own assertion, verbatim;
+ *  - nothing stated    → the write instant, UNLESS stamping it would leave the
+ *                        window readable at no instant. A row carrying only a
+ *                        `validTo` at or before the write instant is "born already
+ *                        ended": its start is UNKNOWN, not at-or-after its end, so
+ *                        it stores no lower bound and reads back at every `asOf`
+ *                        before that end (issue #407).
+ *
+ * The comparison against `validTo` is NON-STRICT: `validTo === writeInstant`
+ * stores no bound too. A stamped `[T, T)` is a successful write no coordinate can
+ * observe, and the millisecond of skew between a caller's own `Date.now()` and the
+ * backend's sample is enough to land there — so the rule is total, and there is no
+ * input for which a stamped bound yields an empty window.
+ *
+ * The write instant is a PARAMETER, not a clock read: the caller passes the very
+ * value it binds into `created_at`/`updated_at` (or, for a resurrection, the
+ * instant its guard judged), so the decision and the stamp cannot come from two
+ * different samples (issue #413's failure mode). This function has no way to
+ * sample a clock, which is what makes that structural rather than tested.
+ *
+ * PRECONDITION: as {@link isEmptyValidityWindow}. This is called BELOW the
+ * validation boundary, on a public `GraphBackend` surface, so canonicality is
+ * established by whoever reached the backend: store paths through
+ * {@link validateOptionalCanonicalIsoDate}, interchange import through its own
+ * window validator, trusted import through its per-chunk format check. A direct
+ * `GraphBackend` caller establishes it itself — a pre-existing property of that
+ * surface, written down here rather than left implicit.
+ */
+export function resolveStampedValidityLowerBound(
+  statedValidFrom: string | null | undefined,
+  validTo: string | undefined,
+  writeInstant: string,
+): string | undefined {
+  if (statedValidFrom === null) return undefined;
+  if (statedValidFrom !== undefined) return statedValidFrom;
+  return isEmptyValidityWindow(writeInstant, validTo) ? undefined : (
+      writeInstant
+    );
+}
+
+/**
+ * The lower bound a write that PASSES THROUGH a stated one stores: `null` — the
+ * interchange spelling of a confirmed open-left window — becomes "no bound", and
+ * a string is stored verbatim.
+ *
+ * Separate from {@link resolveStampedValidityLowerBound} because it answers a
+ * different question. Its one caller (`buildUpdateEdge`'s resurrection leg) writes
+ * the window only when the caller NAMED a lower bound; an edge resurrection that
+ * names none RETAINS the stored window rather than choosing a new one, so there is
+ * no instant to judge and none is offered.
+ */
+export function resolveStatedValidityLowerBound(
+  validFrom: string | null,
+): string | undefined {
+  return validFrom ?? undefined;
+}
+
+/**
  * Refuses a `validTo` whose EFFECTIVE lower bound would invert the window. On an
  * in-place update the row's stored lower bound is the effective one and must stay
  * <= the new `validTo`; on a resurrection that RESETS `valid_from` it is the
@@ -492,11 +583,15 @@ function assertStatedLowerBoundIsApplicable(
  * check, so a caller is told their bound will not be stored rather than being
  * told about a bound they did not name.
  *
- * INSERTS use {@link assertOrderedValidityWindow} alone. An insert carrying a
- * lone historical `validTo` means "born already ended", and the write instant
- * the backend stamps as `valid_from` is a storage convention rather than a
- * caller assertion — the row is deliberately not current and is read back
- * through `includeEnded`. Only an UPDATE has a lower bound the caller can be
+ * INSERTS use {@link assertOrderedValidityWindow} alone, and that is now the
+ * COMPLETE stated-pair rule rather than a partial one. An insert carrying a lone
+ * historical `validTo` means "born already ended", and there is no bound to hold
+ * the caller to because the write stamps none:
+ * {@link resolveStampedValidityLowerBound} stores no lower bound whenever the
+ * instant it would stamp cannot precede the stated end (I1b). So no insert path
+ * can store a window readable at no coordinate, on any `GraphBackend` caller —
+ * the decision lives in the SQL builders, below the store, below interchange and
+ * below trusted import (I5). Only an UPDATE has a lower bound the caller can be
  * held to.
  *
  * @param subject - Human-readable identification of the row, for the message

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -61,6 +61,7 @@ import {
   registerStoreViewIntegrationTests,
   registerSubgraphIntegrationTests,
   registerTemporalIntegrationTests,
+  registerTemporalOracleIntegrationTests,
   registerTransactionReceiptIntegrationTests,
   registerTraversalIntegrationTests,
   registerTrustedImportIntegrationTests,
@@ -207,6 +208,7 @@ export function createIntegrationTestSuite<
     registerOrderingIntegrationTests(context);
     registerLateMaterializationIntegrationTests(context);
     registerTemporalIntegrationTests(context);
+    registerTemporalOracleIntegrationTests(context);
     registerTransactionReceiptIntegrationTests(context);
     registerMigrateSchemaKindIntegrationTests(context);
     registerReconciledSchemaIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -39,6 +39,7 @@ export { registerSetOperationIntegrationTests } from "./set-operations";
 export { registerStoreViewIntegrationTests } from "./store-view";
 export { registerSubgraphIntegrationTests } from "./subgraph";
 export { registerTemporalIntegrationTests } from "./temporal";
+export { registerTemporalOracleIntegrationTests } from "./temporal-oracle";
 export type { IntegrationTestContext } from "./test-context";
 export { registerTransactionReceiptIntegrationTests } from "./transaction-receipt";
 export { registerTraversalIntegrationTests } from "./traversals";

--- a/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
@@ -2,12 +2,13 @@
  * The valid-time semantics every TypeGraph read path must obey, re-derived in
  * TypeScript from the rows the backend actually persisted.
  *
- * TypeGraph spells the visibility decision in three places this suite drives —
+ * TypeGraph spells the visibility decision in three paths this suite drives —
  * the SQL compiler (`src/query/compiler/temporal.ts`), the collections
- * predicate (`src/backend/drizzle/operations/collections.ts`) and the in-memory
- * `#temporalRowMatcher` that `getById`/`getByIds` use instead of SQL filtering
- * (`src/store/store.ts`). Two of those agreeing is not evidence, so none of them
- * is checked against another: all are checked against this model, which
+ * predicate (`src/backend/drizzle/operations/collections.ts`) and the shared
+ * JavaScript owner used by the in-memory `#temporalRowMatcher` behind
+ * `getById`/`getByIds` (`src/utils/date.ts`). Two paths agreeing is not
+ * evidence, so none of them is checked against another: all are checked against
+ * this model, which
  * formulates visibility as INTERVAL MEMBERSHIP over epoch milliseconds rather
  * than as a column predicate over text or `timestamptz`. Model plus those three
  * is what invariant I7 calls the four-way check. The model shares no code with
@@ -15,12 +16,10 @@
  * against the semantics rather than a restatement of whatever the SQL happens
  * to do.
  *
- * OUT OF SCOPE, STATED. There is a further mirror of the same decision in
- * `isValidAt` (`src/provenance/index.ts`), and this suite does NOT exercise it:
- * it is module-private and reachable only through provenance role reads, which
- * are a different store surface with their own fixtures. Binding it wants its
- * own property against this model; until one exists, nothing here should be
- * read as covering it.
+ * OUT OF SCOPE, STATED. Provenance role reads also consume the shared JavaScript
+ * owner, but this suite does NOT exercise that store surface; provenance has its
+ * own fixtures. The implementation can no longer drift by re-spelling the
+ * predicate, while behavioral coverage of that surface remains separate.
  *
  * It reads the ledger — `nodes`, `edges`, and (for a history store)
  * `recorded_nodes` / `recorded_edges` — back out of the backend and derives:
@@ -488,16 +487,22 @@ export const TEMPORAL_OP_SHAPES = [
   "create-on-tombstone-born-ended",
   "update-props",
   "update-scheduled-end",
+  "update-reopen",
   "soft-delete",
   "upsert-resurrect",
   "upsert-resurrect-born-ended",
   "upsert-unchanged",
+  "upsert-reopen",
+  "upsert-resurrect-reopen",
   "bulk-create",
   "bulk-upsert-repeated-id",
   "edge-create-open",
   "edge-create-stated-window",
   "edge-create-scheduled-end",
   "edge-create-born-ended",
+  "edge-update-reopen",
+  "edge-endpoint-upsert-reopen",
+  "edge-endpoint-resurrect-reopen",
   "edge-soft-delete",
 ] as const;
 

--- a/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
@@ -31,8 +31,8 @@
  *   ({@link expectedStoredLowerBound} — the only place the model encodes that
  *   rule, and consumed by the PURE window-algebra property rather than by any
  *   database property in this suite; see its own doc block for why);
- * - the cells where the tree is known to violate an invariant this workstream
- *   states ({@link KNOWN_CONTRACT_GAPS}).
+ * - the vocabulary of write shapes the history generator draws from
+ *   ({@link TEMPORAL_OP_SHAPES}).
  *
  * IMPORT DISCIPLINE. The model's independence is a property of what it may
  * import, and that is ratcheted by `tests/temporal-oracle-imports.test.ts`
@@ -458,13 +458,26 @@ export function expectedStoredLowerBound(
 }
 
 // ============================================================
-// Known contract gaps
+// The op vocabulary
 // ============================================================
 
 /**
- * The op shapes the history generator can emit. A gap entry removes shapes from
- * this vocabulary; deleting the entry puts them back, in the same diff that
- * closes the cell.
+ * The op shapes the history generator can emit — ALL of them, now that no
+ * declared contract gap withholds any.
+ *
+ * A `KNOWN_CONTRACT_GAPS` table stood beside this list while the tree still
+ * violated invariants this workstream states. Each entry named the invariant it
+ * excused, withheld from this vocabulary exactly the op shapes that reached its
+ * cell, and carried a still-reproduces test; each was deleted by the diff that
+ * measurably closed it, never later. The last of them — one stated window
+ * reaching two outcomes across `create` and `upsertById` on a tombstoned id
+ * (I12) — went with the resurrection contract, so the table is empty and gone.
+ *
+ * What keeps this list honest without it is
+ * `tests/temporal-oracle-imports.test.ts`, which SAMPLES the generator's own
+ * arbitrary and asserts the shapes it can draw are exactly this list. A shape
+ * that quietly stops being emitted is a test failure rather than silent
+ * thinning of the script.
  */
 export const TEMPORAL_OP_SHAPES = [
   "create-open",
@@ -489,66 +502,3 @@ export const TEMPORAL_OP_SHAPES = [
 ] as const;
 
 export type TemporalOpShape = (typeof TEMPORAL_OP_SHAPES)[number];
-
-/**
- * One cell where the tree is known to violate an invariant this workstream
- * states. Each entry does three things: it NAMES the invariant it excuses, it
- * REMOVES the op shapes that reach the cell from the generator so the script
- * cannot hit it, and it carries a STILL-REPRODUCES test.
- *
- * Each entry is deleted by the diff that measurably closes it — never later —
- * and `closedBy` records which diff that is.
- */
-export type KnownContractGap = Readonly<{
-  id: string;
-  /** The invariants this cell violates, so the table names the whole excuse. */
-  invariants: readonly string[];
-  closedBy: "batch-2" | "batch-3";
-  /**
-   * The op shapes withheld from the generator while this gap stands. Stated
-   * over what the script SAYS, never over what it observes, so the restriction
-   * is deterministic rather than outcome-dependent.
-   */
-  restrictedOpShapes: readonly TemporalOpShape[];
-  /** The title of the deterministic example test that still reproduces it. */
-  reproducedBy: string;
-}>;
-
-/**
- * Restriction R-C removes the resurrecting `upsertById` that names a lone
- * non-future `validTo`. R-A and R-B — the born-ended CREATE on a fresh id and the
- * same shape on a tombstoned id, both stated for nodes and edges alike — are
- * GONE: the seam that routes every stamping site through
- * `resolveStampedValidityLowerBound` closed both cells, so their op shapes are
- * emittable again and P1/P1b quantify over them like any other write.
- *
- * With the born-ended shapes back, the `validTo == write instant` cell is
- * reachable again too (a `validTo` drawn from the run's own write instants), and
- * it is now a covered case rather than an excused one: the stamping rule's
- * non-strict comparison stores no bound there.
- */
-export const KNOWN_CONTRACT_GAPS = [
-  {
-    id: "resurrection-refusal-gap",
-    invariants: ["I12"],
-    closedBy: "batch-3",
-    restrictedOpShapes: ["upsert-resurrect-born-ended"],
-    reproducedBy:
-      "still reproduces: one stated window, two outcomes — create succeeds on a tombstone where upsertById refuses",
-  },
-] as const satisfies readonly KnownContractGap[];
-
-export type KnownContractGapId = (typeof KNOWN_CONTRACT_GAPS)[number]["id"];
-
-/** Every op shape some standing gap withholds from the generator. */
-export function restrictedOpShapes(): ReadonlySet<TemporalOpShape> {
-  return new Set(
-    KNOWN_CONTRACT_GAPS.flatMap((gap) => [...gap.restrictedOpShapes]),
-  );
-}
-
-/** The op shapes the generator may emit against this tree. */
-export function emittableOpShapes(): readonly TemporalOpShape[] {
-  const withheld = restrictedOpShapes();
-  return TEMPORAL_OP_SHAPES.filter((shape) => !withheld.has(shape));
-}

--- a/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
@@ -1,0 +1,554 @@
+/**
+ * The valid-time semantics every TypeGraph read path must obey, re-derived in
+ * TypeScript from the rows the backend actually persisted.
+ *
+ * TypeGraph spells the visibility decision in three places this suite drives —
+ * the SQL compiler (`src/query/compiler/temporal.ts`), the collections
+ * predicate (`src/backend/drizzle/operations/collections.ts`) and the in-memory
+ * `#temporalRowMatcher` that `getById`/`getByIds` use instead of SQL filtering
+ * (`src/store/store.ts`). Two of those agreeing is not evidence, so none of them
+ * is checked against another: all are checked against this model, which
+ * formulates visibility as INTERVAL MEMBERSHIP over epoch milliseconds rather
+ * than as a column predicate over text or `timestamptz`. Model plus those three
+ * is what invariant I7 calls the four-way check. The model shares no code with
+ * any of them and passes unchanged on `main`, so it is an equivalence check
+ * against the semantics rather than a restatement of whatever the SQL happens
+ * to do.
+ *
+ * OUT OF SCOPE, STATED. There is a further mirror of the same decision in
+ * `isValidAt` (`src/provenance/index.ts`), and this suite does NOT exercise it:
+ * it is module-private and reachable only through provenance role reads, which
+ * are a different store surface with their own fixtures. Binding it wants its
+ * own property against this model; until one exists, nothing here should be
+ * read as covering it.
+ *
+ * It reads the ledger — `nodes`, `edges`, and (for a history store)
+ * `recorded_nodes` / `recorded_edges` — back out of the backend and derives:
+ *
+ * - the interval a stored row is readable over, `NULL` bound = unbounded;
+ * - which rows a bitemporal coordinate must return;
+ * - the lower bound a write that resolves its own start is expected to store
+ *   ({@link expectedStoredLowerBound} — the ONE function the #407 contract
+ *   change edits);
+ * - the cells where the tree is known to violate an invariant this workstream
+ *   states ({@link KNOWN_CONTRACT_GAPS}).
+ *
+ * IMPORT DISCIPLINE. The model's independence is a property of what it may
+ * import, and that is ratcheted by `tests/temporal-oracle-imports.test.ts`
+ * (exact set equality over the import specifiers, a named-import check on
+ * `src/utils/date`, and an assertion that the barrel import is `import type` so
+ * it cannot carry a value however the barrel grows). Adding an import here
+ * without adding it there is a test failure, deliberately.
+ */
+import type { GraphBackend } from "../../../src";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { sql } from "../../../src/query/sql-fragment";
+import { asCompiledRowsSql } from "../../../src/query/sql-intent";
+import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
+
+// ============================================================
+// Ledger snapshot
+// ============================================================
+
+/** A canonical fixed-width UTC ISO 8601 instant. */
+export type Instant = string;
+
+/** The four relations invariant I1 quantifies over. */
+export type LedgerRelation =
+  "nodes" | "edges" | "recordedNodes" | "recordedEdges";
+
+/**
+ * One stored row, normalized off the driver's raw representation (SQLite hands
+ * back `TEXT`, PostgreSQL a `Date`) so the model compares the same values on
+ * every backend.
+ */
+export type LedgerRow = Readonly<{
+  relation: LedgerRelation;
+  kind: string;
+  id: string;
+  validFrom: Instant | undefined;
+  validTo: Instant | undefined;
+  createdAt: Instant;
+  updatedAt: Instant;
+  deletedAt: Instant | undefined;
+  /** `undefined` on edges, whose relation carries no `version` column. */
+  version: number | undefined;
+  /** Endpoints; `undefined` on the node relations. */
+  fromKey: RowKey | undefined;
+  toKey: RowKey | undefined;
+  /** Recorded-axis bounds; `undefined` on the live relations. */
+  recordedFrom: number | undefined;
+  recordedTo: number | undefined;
+}>;
+
+export type TemporalLedger = Readonly<
+  Record<LedgerRelation, readonly LedgerRow[]>
+>;
+
+/** A `(kind, id)` identity, flattened for set comparison. */
+export type RowKey = string;
+
+/** Separator for composite `(kind, id)` keys; no kind can contain it. */
+const ROW_KEY_SEPARATOR = "\u0000";
+
+export function rowKeyOf(row: Readonly<{ kind: string; id: string }>): RowKey {
+  return `${row.kind}${ROW_KEY_SEPARATOR}${row.id}`;
+}
+
+type RawRow = Readonly<Record<string, unknown>>;
+
+/** A column the schema declares NOT NULL and textual, read back off the driver. */
+function asText(value: unknown): string {
+  if (typeof value === "string") return value;
+  throw new TypeError(
+    `Ledger carried a non-string identifier: ${JSON.stringify(value)}`,
+  );
+}
+
+function optionalInstant(value: unknown): Instant | undefined {
+  if (value === null || value === undefined) return undefined;
+  const canonical = canonicalizeDatabaseTimestamp(value);
+  if (canonical === undefined) {
+    throw new Error(
+      `Ledger carried a non-canonical instant: ${JSON.stringify(value)}`,
+    );
+  }
+  return canonical;
+}
+
+function requiredInstant(value: unknown): Instant {
+  const instant = optionalInstant(value);
+  if (instant === undefined) {
+    throw new Error("Ledger carried a NULL where an instant is NOT NULL");
+  }
+  return instant;
+}
+
+function optionalCount(value: unknown): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  const count =
+    typeof value === "bigint" ? Number(value)
+    : typeof value === "string" ? Number(value)
+    : value;
+  if (typeof count !== "number" || !Number.isSafeInteger(count)) {
+    throw new TypeError(
+      `Ledger carried a non-integer count: ${JSON.stringify(value)}`,
+    );
+  }
+  return count;
+}
+
+function optionalEndpoint(kind: unknown, id: unknown): RowKey | undefined {
+  if (kind === null || kind === undefined) return undefined;
+  return rowKeyOf({ kind: asText(kind), id: asText(id) });
+}
+
+function toLedgerRow(relation: LedgerRelation, raw: RawRow): LedgerRow {
+  return {
+    relation,
+    kind: asText(raw["kind"]),
+    id: asText(raw["id"]),
+    validFrom: optionalInstant(raw["valid_from"]),
+    validTo: optionalInstant(raw["valid_to"]),
+    createdAt: requiredInstant(raw["created_at"]),
+    updatedAt: requiredInstant(raw["updated_at"]),
+    deletedAt: optionalInstant(raw["deleted_at"]),
+    version: optionalCount(raw["version"]),
+    fromKey: optionalEndpoint(raw["from_kind"], raw["from_id"]),
+    toKey: optionalEndpoint(raw["to_kind"], raw["to_id"]),
+    recordedFrom: optionalCount(raw["recorded_from"]),
+    recordedTo: optionalCount(raw["recorded_to"]),
+  };
+}
+
+/** The store handle the ledger reader needs — a backend and a graph fence. */
+export type LedgerSource = Readonly<{
+  backend: GraphBackend;
+  graphId: string;
+}>;
+
+/**
+ * Reads every stored row the valid-time contract is defined over.
+ *
+ * Live rows are read with a raw `SELECT` rather than through a collection read,
+ * because the collection reads are among the paths under test: the model must
+ * see the tombstoned, the ended and the never-visible rows too.
+ */
+export async function readTemporalLedger(
+  source: LedgerSource,
+  options: Readonly<{ includeRecorded: boolean }>,
+): Promise<TemporalLedger> {
+  const schema = createSqlSchema(source.backend.tableNames);
+  const nodes = await source.backend.execute<RawRow>(
+    asCompiledRowsSql(sql`
+      SELECT kind, id, valid_from, valid_to, created_at, updated_at,
+             deleted_at, version
+      FROM ${schema.nodesTable}
+      WHERE graph_id = ${source.graphId}
+    `),
+  );
+  const edges = await source.backend.execute<RawRow>(
+    asCompiledRowsSql(sql`
+      SELECT kind, id, from_kind, from_id, to_kind, to_id,
+             valid_from, valid_to, created_at, updated_at, deleted_at
+      FROM ${schema.edgesTable}
+      WHERE graph_id = ${source.graphId}
+    `),
+  );
+  const recordedNodes =
+    options.includeRecorded ?
+      await source.backend.execute<RawRow>(
+        asCompiledRowsSql(sql`
+          SELECT kind, id, valid_from, valid_to, created_at, updated_at,
+                 deleted_at, version, recorded_from, recorded_to
+          FROM ${schema.recordedNodesTable}
+          WHERE graph_id = ${source.graphId}
+        `),
+      )
+    : [];
+  const recordedEdges =
+    options.includeRecorded ?
+      await source.backend.execute<RawRow>(
+        asCompiledRowsSql(sql`
+          SELECT kind, id, valid_from, valid_to, created_at, updated_at,
+                 deleted_at, recorded_from, recorded_to
+          FROM ${schema.recordedEdgesTable}
+          WHERE graph_id = ${source.graphId}
+        `),
+      )
+    : [];
+  return {
+    nodes: nodes.map((raw) => toLedgerRow("nodes", raw)),
+    edges: edges.map((raw) => toLedgerRow("edges", raw)),
+    recordedNodes: recordedNodes.map((raw) =>
+      toLedgerRow("recordedNodes", raw),
+    ),
+    recordedEdges: recordedEdges.map((raw) =>
+      toLedgerRow("recordedEdges", raw),
+    ),
+  };
+}
+
+/**
+ * Every live row, nodes then edges — the scope of the read-side properties,
+ * which quantify over what a live read can return. The STORAGE invariants I1
+ * and I1b are stated over {@link allLedgerRows} instead: `recorded_nodes` /
+ * `recorded_edges` are bound by an independent binder of the same columns
+ * (`src/store/recorded-capture/relations.ts`), so leaving them out would check
+ * one of the two write paths I1 quantifies over.
+ */
+export function liveLedgerRows(ledger: TemporalLedger): readonly LedgerRow[] {
+  return [...ledger.nodes, ...ledger.edges];
+}
+
+/** Every row this library wrote, live and recorded — invariant I1's full scope. */
+export function allLedgerRows(ledger: TemporalLedger): readonly LedgerRow[] {
+  return [
+    ...ledger.nodes,
+    ...ledger.edges,
+    ...ledger.recordedNodes,
+    ...ledger.recordedEdges,
+  ];
+}
+
+// ============================================================
+// Interval algebra — visibility as membership, not as a predicate
+// ============================================================
+
+/**
+ * An unbounded endpoint: the column stored `NULL`. A symbol rather than a
+ * string, so `Instant | Unbounded` stays a real union — an `Instant` IS a
+ * string, and any string sentinel would be absorbed by it.
+ */
+export const UNBOUNDED: unique symbol = Symbol("unbounded");
+
+export type Unbounded = typeof UNBOUNDED;
+
+export type VisibilityInterval = Readonly<{
+  lower: Instant | Unbounded;
+  upper: Instant | Unbounded;
+}>;
+
+function epochOf(instant: Instant): number {
+  const milliseconds = new Date(instant).getTime();
+  if (Number.isNaN(milliseconds)) {
+    throw new TypeError(`Not an instant: ${instant}`);
+  }
+  return milliseconds;
+}
+
+function lowerEpoch(interval: VisibilityInterval): number {
+  return interval.lower === UNBOUNDED ?
+      Number.NEGATIVE_INFINITY
+    : epochOf(interval.lower);
+}
+
+function upperEpoch(interval: VisibilityInterval): number {
+  return interval.upper === UNBOUNDED ?
+      Number.POSITIVE_INFINITY
+    : epochOf(interval.upper);
+}
+
+/** The half-open interval `[valid_from, valid_to)` a stored row is readable over. */
+export function intervalOf(
+  row: Readonly<{
+    validFrom: Instant | undefined;
+    validTo: Instant | undefined;
+  }>,
+): VisibilityInterval {
+  return {
+    lower: row.validFrom ?? UNBOUNDED,
+    upper: row.validTo ?? UNBOUNDED,
+  };
+}
+
+/** Whether `at` falls inside the half-open interval. */
+export function intervalContains(
+  interval: VisibilityInterval,
+  at: Instant,
+): boolean {
+  const instant = epochOf(at);
+  return lowerEpoch(interval) <= instant && instant < upperEpoch(interval);
+}
+
+/**
+ * Whether the interval is readable at NO instant — inverted OR zero width.
+ * This is the model's own emptiness decision; the library's future
+ * `isEmptyValidityWindow` is checked AGAINST it rather than shared with it.
+ */
+export function intervalIsEmpty(interval: VisibilityInterval): boolean {
+  return lowerEpoch(interval) >= upperEpoch(interval);
+}
+
+/** Whether the interval is backwards — the strict refusal shape. */
+export function intervalIsInverted(interval: VisibilityInterval): boolean {
+  return lowerEpoch(interval) > upperEpoch(interval);
+}
+
+/**
+ * Invariant I1, per row: no stored window is backwards. Stated over the
+ * interval rather than over the columns so a `NULL` bound is unbounded by
+ * construction rather than by a special case.
+ */
+export function rowSatisfiesOrderedWindow(row: LedgerRow): boolean {
+  return !intervalIsInverted(intervalOf(row));
+}
+
+/**
+ * A bitemporal read coordinate. `revision` pins the recorded axis; the mode and
+ * `asOf` pin the valid axis, exactly as `compileTemporalFilter` splits them.
+ */
+export type TemporalCoordinate =
+  | Readonly<{ mode: "asOf"; asOf: Instant; revision?: number }>
+  | Readonly<{ mode: "includeEnded"; revision?: number }>
+  | Readonly<{ mode: "includeTombstones"; revision?: number }>;
+
+/** Whether one stored row must be returned at `coordinate`. */
+export function rowVisibleAt(
+  row: LedgerRow,
+  coordinate: TemporalCoordinate,
+): boolean {
+  if (coordinate.revision !== undefined) {
+    const { recordedFrom, recordedTo } = row;
+    if (recordedFrom === undefined || recordedTo === undefined) return false;
+    if (recordedFrom > coordinate.revision) return false;
+    if (coordinate.revision >= recordedTo) return false;
+  }
+  switch (coordinate.mode) {
+    case "includeTombstones": {
+      return true;
+    }
+    case "includeEnded": {
+      return row.deletedAt === undefined;
+    }
+    case "asOf": {
+      if (row.deletedAt !== undefined) return false;
+      return intervalContains(intervalOf(row), coordinate.asOf);
+    }
+  }
+}
+
+/** The identities a read at `coordinate` must return, sorted for comparison. */
+export function visibleAt(
+  rows: readonly LedgerRow[],
+  coordinate: TemporalCoordinate,
+): readonly RowKey[] {
+  return rows
+    .filter((row) => rowVisibleAt(row, coordinate))
+    .map((row) => rowKeyOf(row))
+    .toSorted();
+}
+
+/**
+ * The edges a one-hop traversal must return at `coordinate`: the edge visible
+ * AND both endpoints visible. A compiled traversal applies the same temporal
+ * filter to the edge and to both node CTEs, so the model states the conjunction
+ * rather than the edge alone — which is what lets the traversal be compared
+ * against the collection reads, whose filter is the edge row alone.
+ */
+export function traversableEdgesAt(
+  ledger: TemporalLedger,
+  coordinate: TemporalCoordinate,
+): readonly RowKey[] {
+  const visibleNodes = new Set(visibleAt(ledger.nodes, coordinate));
+  return ledger.edges
+    .filter(
+      (edge) =>
+        rowVisibleAt(edge, coordinate) &&
+        edge.fromKey !== undefined &&
+        edge.toKey !== undefined &&
+        visibleNodes.has(edge.fromKey) &&
+        visibleNodes.has(edge.toKey),
+    )
+    .map((edge) => rowKeyOf(edge))
+    .toSorted();
+}
+
+// ============================================================
+// The stored lower bound
+// ============================================================
+
+/**
+ * The lower bound a write that STAMPS its own start is expected to store.
+ *
+ * TODAY'S CONTRACT, as `resolveValidFrom`
+ * (`src/backend/drizzle/operations/shared.ts`) and its private twin in
+ * `src/backend/drizzle/trusted-import.ts` implement it:
+ *
+ *  - a stated `null`  → no lower bound (a confirmed open-left window);
+ *  - a stated string  → that bound, the caller's own assertion;
+ *  - nothing stated   → the write instant, UNCONDITIONALLY.
+ *
+ * That last cell is issue #407: with a stated `validTo` at or before the write
+ * instant it stores a window readable at no coordinate. This function is the
+ * ONE place the model encodes it, so the #407 contract change is a one-function
+ * edit here — and the cells it is currently wrong about are declared in
+ * {@link KNOWN_CONTRACT_GAPS} rather than smoothed over.
+ *
+ * The write instant is a PARAMETER, never a clock read, which is what lets a
+ * caller check the decision against the instant the row actually carries.
+ */
+export function expectedStoredLowerBound(
+  statedValidFrom: Instant | null | undefined,
+
+  // ignores the upper bound; the A2' rule this becomes consults it, and the
+  // parameter is stated now so the signature does not change with the contract.
+  _statedValidTo: Instant | undefined,
+  writeInstant: Instant,
+): Instant | undefined {
+  if (statedValidFrom === null) return undefined;
+  if (statedValidFrom !== undefined) return statedValidFrom;
+  return writeInstant;
+}
+
+// ============================================================
+// Known contract gaps
+// ============================================================
+
+/**
+ * The op shapes the history generator can emit. A gap entry removes shapes from
+ * this vocabulary; deleting the entry puts them back, in the same diff that
+ * closes the cell.
+ */
+export const TEMPORAL_OP_SHAPES = [
+  "create-open",
+  "create-stated-window",
+  "create-scheduled-end",
+  "create-born-ended",
+  "create-on-tombstone",
+  "create-on-tombstone-born-ended",
+  "update-props",
+  "update-scheduled-end",
+  "soft-delete",
+  "upsert-resurrect",
+  "upsert-resurrect-born-ended",
+  "upsert-unchanged",
+  "bulk-create",
+  "bulk-upsert-repeated-id",
+  "edge-create-open",
+  "edge-create-stated-window",
+  "edge-create-scheduled-end",
+  "edge-create-born-ended",
+  "edge-soft-delete",
+] as const;
+
+export type TemporalOpShape = (typeof TEMPORAL_OP_SHAPES)[number];
+
+/**
+ * One cell where the tree is known to violate an invariant this workstream
+ * states. Each entry does three things: it NAMES the invariant it excuses, it
+ * REMOVES the op shapes that reach the cell from the generator so the script
+ * cannot hit it, and it carries a STILL-REPRODUCES test.
+ *
+ * Each entry is deleted by the diff that measurably closes it — never later —
+ * and `closedBy` records which diff that is.
+ */
+export type KnownContractGap = Readonly<{
+  id: string;
+  /** The invariants this cell violates, so the table names the whole excuse. */
+  invariants: readonly string[];
+  closedBy: "batch-2" | "batch-3";
+  /**
+   * The op shapes withheld from the generator while this gap stands. Stated
+   * over what the script SAYS, never over what it observes, so the restriction
+   * is deterministic rather than outcome-dependent.
+   */
+  restrictedOpShapes: readonly TemporalOpShape[];
+  /** The title of the deterministic example test that still reproduces it. */
+  reproducedBy: string;
+}>;
+
+/**
+ * Restriction R-A removes the born-ended CREATE on a fresh id, R-B the same
+ * shape on a tombstoned id, R-C the resurrecting `upsertById` that names a lone
+ * non-future `validTo`. R-A and R-B are stated for NODES AND EDGES alike: the
+ * same insert builders stamp both relations, so leaving the edge shape emittable
+ * would make P1 red for a cell the table claims to excuse.
+ *
+ * Because every exclusion is over an op SHAPE, the `validTo == write instant`
+ * cell (which stores a zero-width window today — satisfying I1, violating I1b)
+ * cannot be emitted either: a `validTo` drawn from the run's own write instants
+ * is part of the same withheld shape. That is why two entries suffice for the
+ * born-ended cell and no fake-timer machinery is needed inside the property.
+ */
+export const KNOWN_CONTRACT_GAPS = [
+  {
+    id: "born-ended-insert",
+    invariants: ["I1", "I1b"],
+    closedBy: "batch-2",
+    restrictedOpShapes: ["create-born-ended", "edge-create-born-ended"],
+    reproducedBy:
+      "still reproduces: a born-ended create on a fresh id stores a window readable at no coordinate",
+  },
+  {
+    id: "born-ended-on-tombstone",
+    invariants: ["I1", "I1b"],
+    closedBy: "batch-2",
+    restrictedOpShapes: ["create-on-tombstone-born-ended"],
+    reproducedBy:
+      "still reproduces: a born-ended create on a tombstoned id stores a window readable at no coordinate",
+  },
+  {
+    id: "resurrection-refusal-gap",
+    invariants: ["I12"],
+    closedBy: "batch-3",
+    restrictedOpShapes: ["upsert-resurrect-born-ended"],
+    reproducedBy:
+      "still reproduces: one stated window, two outcomes — create succeeds on a tombstone where upsertById refuses",
+  },
+] as const satisfies readonly KnownContractGap[];
+
+export type KnownContractGapId = (typeof KNOWN_CONTRACT_GAPS)[number]["id"];
+
+/** Every op shape some standing gap withholds from the generator. */
+export function restrictedOpShapes(): ReadonlySet<TemporalOpShape> {
+  return new Set(
+    KNOWN_CONTRACT_GAPS.flatMap((gap) => [...gap.restrictedOpShapes]),
+  );
+}
+
+/** The op shapes the generator may emit against this tree. */
+export function emittableOpShapes(): readonly TemporalOpShape[] {
+  const withheld = restrictedOpShapes();
+  return TEMPORAL_OP_SHAPES.filter((shape) => !withheld.has(shape));
+}

--- a/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle-model.ts
@@ -28,8 +28,9 @@
  * - the interval a stored row is readable over, `NULL` bound = unbounded;
  * - which rows a bitemporal coordinate must return;
  * - the lower bound a write that resolves its own start is expected to store
- *   ({@link expectedStoredLowerBound} — the ONE function the #407 contract
- *   change edits);
+ *   ({@link expectedStoredLowerBound} — the only place the model encodes that
+ *   rule, and consumed by the PURE window-algebra property rather than by any
+ *   database property in this suite; see its own doc block for why);
  * - the cells where the tree is known to violate an invariant this workstream
  *   states ({@link KNOWN_CONTRACT_GAPS}).
  *
@@ -411,34 +412,49 @@ export function traversableEdgesAt(
 /**
  * The lower bound a write that STAMPS its own start is expected to store.
  *
- * TODAY'S CONTRACT, as `resolveValidFrom`
- * (`src/backend/drizzle/operations/shared.ts`) and its private twin in
- * `src/backend/drizzle/trusted-import.ts` implement it:
+ * THE CONTRACT, as the eight insert builders, the node resurrection leg and the
+ * four trusted-import legs implement it through their one owner
+ * (`resolveStampedValidityLowerBound`, `src/utils/date.ts`):
  *
  *  - a stated `null`  → no lower bound (a confirmed open-left window);
  *  - a stated string  → that bound, the caller's own assertion;
- *  - nothing stated   → the write instant, UNCONDITIONALLY.
+ *  - nothing stated   → the write instant, UNLESS stamping it would leave the
+ *                       window readable at no instant, in which case no lower
+ *                       bound at all — a row "born already ended", whose start is
+ *                       UNKNOWN rather than after its own end (issue #407).
  *
- * That last cell is issue #407: with a stated `validTo` at or before the write
- * instant it stores a window readable at no coordinate. This function is the
- * ONE place the model encodes it, so the #407 contract change is a one-function
- * edit here — and the cells it is currently wrong about are declared in
- * {@link KNOWN_CONTRACT_GAPS} rather than smoothed over.
+ * That last clause asks the model's OWN emptiness owner ({@link intervalIsEmpty})
+ * rather than re-spelling a bound comparison here, so "readable at no instant"
+ * has one answer across the property that checks stamped bounds and the property
+ * that checks visibility. The comparison is non-strict for the same reason the
+ * library's is: a `validTo` landing in the write instant's own millisecond would
+ * otherwise store `[T, T)`, a successful write no coordinate can observe.
  *
  * The write instant is a PARAMETER, never a clock read, which is what lets a
  * caller check the decision against the instant the row actually carries.
+ *
+ * WHO CONSUMES THIS, STATED. Only `tests/property/temporal-window.test.ts`,
+ * which quantifies every stamping law over BOTH encodings — this one and the
+ * library owner — so the two cannot drift. No database property predicts a
+ * stored bound with it: a DB property would have to know which instant the
+ * backend sampled, and the ledger cannot see that, so the suite's stamped-bound
+ * check (P1b) asserts the weaker, clock-free fact that no unstated bound left an
+ * EMPTY window, through {@link intervalIsEmpty} directly. This function is
+ * therefore an independent restatement bound at numRuns in a pure file, not a
+ * dependency of the oracle's database properties.
  */
 export function expectedStoredLowerBound(
   statedValidFrom: Instant | null | undefined,
-
-  // ignores the upper bound; the A2' rule this becomes consults it, and the
-  // parameter is stated now so the signature does not change with the contract.
-  _statedValidTo: Instant | undefined,
+  statedValidTo: Instant | undefined,
   writeInstant: Instant,
 ): Instant | undefined {
   if (statedValidFrom === null) return undefined;
   if (statedValidFrom !== undefined) return statedValidFrom;
-  return writeInstant;
+  const stamped = intervalOf({
+    validFrom: writeInstant,
+    validTo: statedValidTo,
+  });
+  return intervalIsEmpty(stamped) ? undefined : writeInstant;
 }
 
 // ============================================================
@@ -499,35 +515,19 @@ export type KnownContractGap = Readonly<{
 }>;
 
 /**
- * Restriction R-A removes the born-ended CREATE on a fresh id, R-B the same
- * shape on a tombstoned id, R-C the resurrecting `upsertById` that names a lone
- * non-future `validTo`. R-A and R-B are stated for NODES AND EDGES alike: the
- * same insert builders stamp both relations, so leaving the edge shape emittable
- * would make P1 red for a cell the table claims to excuse.
+ * Restriction R-C removes the resurrecting `upsertById` that names a lone
+ * non-future `validTo`. R-A and R-B — the born-ended CREATE on a fresh id and the
+ * same shape on a tombstoned id, both stated for nodes and edges alike — are
+ * GONE: the seam that routes every stamping site through
+ * `resolveStampedValidityLowerBound` closed both cells, so their op shapes are
+ * emittable again and P1/P1b quantify over them like any other write.
  *
- * Because every exclusion is over an op SHAPE, the `validTo == write instant`
- * cell (which stores a zero-width window today — satisfying I1, violating I1b)
- * cannot be emitted either: a `validTo` drawn from the run's own write instants
- * is part of the same withheld shape. That is why two entries suffice for the
- * born-ended cell and no fake-timer machinery is needed inside the property.
+ * With the born-ended shapes back, the `validTo == write instant` cell is
+ * reachable again too (a `validTo` drawn from the run's own write instants), and
+ * it is now a covered case rather than an excused one: the stamping rule's
+ * non-strict comparison stores no bound there.
  */
 export const KNOWN_CONTRACT_GAPS = [
-  {
-    id: "born-ended-insert",
-    invariants: ["I1", "I1b"],
-    closedBy: "batch-2",
-    restrictedOpShapes: ["create-born-ended", "edge-create-born-ended"],
-    reproducedBy:
-      "still reproduces: a born-ended create on a fresh id stores a window readable at no coordinate",
-  },
-  {
-    id: "born-ended-on-tombstone",
-    invariants: ["I1", "I1b"],
-    closedBy: "batch-2",
-    restrictedOpShapes: ["create-on-tombstone-born-ended"],
-    reproducedBy:
-      "still reproduces: a born-ended create on a tombstoned id stores a window readable at no coordinate",
-  },
   {
     id: "resurrection-refusal-gap",
     invariants: ["I12"],

--- a/packages/typegraph/tests/backends/integration/temporal-oracle.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle.ts
@@ -49,13 +49,16 @@
  * already carries, so the query under test is the query users write — no
  * id-prefix predicate is bolted onto it — and shrinking stays hermetic.
  *
- * KNOWN CONTRACT GAPS. The model encodes TODAY'S contract, so this suite passes
+ * CLOSED CONTRACT GAPS. The model encodes TODAY'S contract, so this suite passed
  * unchanged on `main`; that is the evidence it is an equivalence check rather
  * than a restatement of behavior a later batch introduces. The three cells where
- * the tree violates an invariant this workstream states are declared in
- * `KNOWN_CONTRACT_GAPS`, which withholds their op shapes from the generator and
- * carries one still-reproduces test each. Each entry — and its restriction —
- * dies in the diff that measurably closes it.
+ * the tree violated an invariant this workstream states were declared in a
+ * `KNOWN_CONTRACT_GAPS` table that withheld their op shapes from the generator
+ * and carried one still-reproduces test each. All three are now closed, each in
+ * the diff that measurably closed it, and the table is gone. What replaces it is
+ * the `closed contract gaps` block below: the SAME scripts those reproductions
+ * ran, with every assertion turned around. The generator draws from the whole
+ * op vocabulary again.
  */
 import fc from "fast-check";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -68,10 +71,8 @@ import {
   defineEdge,
   defineGraph,
   defineNode,
-  INVERTED_VALIDITY_WINDOW_CODE,
   type Node,
   type RecordedInstant,
-  ValidationError,
 } from "../../../src";
 import type { GraphBackend } from "../../../src/backend/types";
 import {
@@ -99,18 +100,16 @@ import { requireDefined } from "../../../src/utils/presence";
 import { recordedInstantFromDriver } from "../../test-utils";
 import {
   allLedgerRows,
-  emittableOpShapes,
   type Instant,
   intervalIsEmpty,
   intervalOf,
-  KNOWN_CONTRACT_GAPS,
-  type KnownContractGapId,
   type LedgerRow,
   liveLedgerRows,
   readTemporalLedger,
   type RowKey,
   rowKeyOf,
   rowSatisfiesOrderedWindow,
+  TEMPORAL_OP_SHAPES,
   type TemporalCoordinate,
   type TemporalLedger,
   type TemporalOpShape,
@@ -310,14 +309,15 @@ type GeneratedOp = Readonly<{
 
 /**
  * Exported for `tests/temporal-oracle-imports.test.ts`, which SAMPLES it to
- * assert the shapes it can draw are exactly the ones the standing gaps leave
- * emittable. Comparing `emittableOpShapes()` against a re-spelling of its own
- * body proves nothing; only the generator's own draws can show a restriction is
- * honored end-to-end.
+ * assert the shapes it can draw are exactly the declared vocabulary. Comparing
+ * one spelling of that vocabulary against another proves nothing; only the
+ * generator's own draws can show the script really covers what the list claims.
+ * This is what stood behind the gap table's restrictions while it existed, and
+ * it is what keeps the reopened shapes genuinely emitted now that it is gone.
  */
 export function generatedOpArb(): fc.Arbitrary<GeneratedOp> {
   return fc.record({
-    shape: fc.constantFrom(...emittableOpShapes()),
+    shape: fc.constantFrom(...TEMPORAL_OP_SHAPES),
     lowerPick: fc.nat({ max: 7 }),
     upperPick: fc.nat({ max: 7 }),
     targetPick: fc.nat({ max: 31 }),
@@ -1030,11 +1030,8 @@ async function assertProjectionParity(
 }
 
 // ============================================================
-// The still-reproduces tests, one per declared gap, and the gap-CLOSED tests
-// that replaced the two the seam closed
+// The gap-CLOSED tests, one per cell the gap table used to declare
 // ============================================================
-
-type GapReproduction = (context: IntegrationTestContext) => Promise<void>;
 
 async function storedRow(
   backend: GraphBackend,
@@ -1051,62 +1048,32 @@ async function storedRow(
   );
 }
 
-/* eslint-disable vitest/no-standalone-expect -- these are the bodies of the
-   still-reproduces tests, registered one per KNOWN_CONTRACT_GAPS entry below.
-   Keying them off the gap table is what makes deleting an entry delete its test
-   (the `satisfies Record<KnownContractGapId, ...>` turns a leftover into a
-   compile error), and that structure is worth more than inlining the expects
-   into literal `it` bodies. */
-const GAP_REPRODUCTIONS = {
-  "resurrection-refusal-gap": async (context) => {
-    const store = freshStore(context.getBackend(), "gap_refusal");
-    for (const id of ["c1", "u1"]) {
-      await store.nodes.OraclePerson.create({ name: "first" }, { id });
-      await store.nodes.OraclePerson.delete(asNodeId<typeof OraclePerson>(id));
-    }
-    // One stated window, two entry points, two outcomes. This assertion says
-    // nothing about the STORED shape, so it survives the batch that changes the
-    // shape and dies only with the refusal itself.
-    await expect(
-      store.nodes.OraclePerson.create(
-        { name: "revived" },
-        { id: "c1", validTo: FIRST_PAST_ANCHOR },
-      ),
-    ).resolves.toBeDefined();
-
-    const refusal: unknown = await store.nodes.OraclePerson.upsertById(
-      "u1",
-      { name: "revived" },
-      { validTo: FIRST_PAST_ANCHOR },
-    ).then(
-      (node) => node,
-      (error: unknown) => error,
-    );
-    expect(refusal).toBeInstanceOf(ValidationError);
-    const issues = (refusal as ValidationError).details.issues;
-    expect(issues.map((issue) => issue.code)).toContain(
-      INVERTED_VALIDITY_WINDOW_CODE,
-    );
-  },
-} as const satisfies Record<KnownContractGapId, GapReproduction>;
-
 /**
- * What the two born-ended entries used to excuse, restated as what the tree now
- * does. These are the SAME two scripts their reproductions ran — a lone past
- * `validTo` on a fresh id and on a tombstoned id — with every assertion turned
- * around: no lower bound instead of a stamped one, an ordered window instead of a
- * backwards one, and a row readable before its end instead of at no coordinate at
- * all. Keeping the scripts and inverting the expectations is what makes the pair
- * a closure record rather than two unrelated tests that happen to be green.
+ * What the three gap entries used to excuse, restated as what the tree now does.
+ * These are the SAME scripts their reproductions ran — a lone past `validTo` on
+ * a fresh id, on a tombstoned id, and through the resurrecting `upsertById` that
+ * used to REFUSE it — with every assertion turned around: no lower bound instead
+ * of a stamped one, an ordered window instead of a backwards one, a row readable
+ * before its end instead of at no coordinate at all, and an accepted write
+ * instead of a `ValidationError`. Keeping the scripts and inverting the
+ * expectations is what makes these a closure record rather than three unrelated
+ * tests that happen to be green.
  *
- * Both variants assert the SAME stored shape, which is the create half of I12:
- * one stated window through two entry points reaches one outcome. The tombstoned
- * variant is the one that fails if `buildUpdateNode`'s resurrection leg is left
- * on the old resolver while the eight insert builders are rewired.
+ * All three variants assert the SAME stored shape, which is I12 itself: one
+ * stated window through three entry points reaches one outcome. The tombstoned
+ * `create` is the one that fails if `buildUpdateNode`'s resurrection leg is left
+ * on the old resolver while the eight insert builders are rewired; the
+ * `upsertById` variant is the one that fails if `performNodeUpdate`'s
+ * resurrection leg judges the raw instant instead of the bound the write stores.
  */
-async function assertBornEndedCreateStoresNoLowerBound(
+async function assertBornEndedWriteStoresNoLowerBound(
   context: IntegrationTestContext,
-  variant: Readonly<{ label: string; id: string; tombstoneFirst: boolean }>,
+  variant: Readonly<{
+    label: string;
+    id: string;
+    tombstoneFirst: boolean;
+    entryPoint: "create" | "upsertById";
+  }>,
 ): Promise<void> {
   const backend = context.getBackend();
   const store = freshStore(backend, variant.label);
@@ -1119,10 +1086,17 @@ async function assertBornEndedCreateStoresNoLowerBound(
     await store.nodes.OraclePerson.delete(nodeId);
   }
 
-  const created = await store.nodes.OraclePerson.create(
-    { name: "born ended" },
-    { id: variant.id, validTo: FIRST_PAST_ANCHOR },
-  );
+  const created =
+    variant.entryPoint === "create" ?
+      await store.nodes.OraclePerson.create(
+        { name: "born ended" },
+        { id: variant.id, validTo: FIRST_PAST_ANCHOR },
+      )
+    : await store.nodes.OraclePerson.upsertById(
+        variant.id,
+        { name: "born ended" },
+        { validTo: FIRST_PAST_ANCHOR },
+      );
   expect(created.meta.validFrom).toBeUndefined();
   expect(created.meta.validTo).toBe(FIRST_PAST_ANCHOR);
 
@@ -1152,7 +1126,6 @@ async function assertBornEndedCreateStoresNoLowerBound(
     ).resolves.toBeUndefined();
   }
 }
-/* eslint-enable vitest/no-standalone-expect */
 
 // ============================================================
 // The recorded axis
@@ -1238,29 +1211,31 @@ export function registerTemporalOracleIntegrationTests(
       expect(FUTURE_ANCHORS.every((anchor) => anchor > now)).toBe(true);
     });
 
-    describe("known contract gaps", () => {
-      for (const gap of KNOWN_CONTRACT_GAPS) {
-        // eslint-disable-next-line vitest/valid-title -- the title IS the gap entry's own `reproducedBy`, so deleting the entry deletes the test
-        it(gap.reproducedBy, async () => {
-          await GAP_REPRODUCTIONS[gap.id](context);
-        });
-      }
-    });
-
     describe("closed contract gaps", () => {
       it("closed: a born-ended create on a fresh id stores no lower bound and reads back before its end", async () => {
-        await assertBornEndedCreateStoresNoLowerBound(context, {
+        await assertBornEndedWriteStoresNoLowerBound(context, {
           label: "closed_insert",
           id: "f1",
           tombstoneFirst: false,
+          entryPoint: "create",
         });
       });
 
       it("closed: a born-ended create on a tombstoned id stores the same shape as on a fresh id", async () => {
-        await assertBornEndedCreateStoresNoLowerBound(context, {
+        await assertBornEndedWriteStoresNoLowerBound(context, {
           label: "closed_tombstone",
           id: "t1",
           tombstoneFirst: true,
+          entryPoint: "create",
+        });
+      });
+
+      it("closed: a born-ended upsertById on a tombstoned id stores that shape too, instead of refusing", async () => {
+        await assertBornEndedWriteStoresNoLowerBound(context, {
+          label: "closed_resurrect",
+          id: "u1",
+          tombstoneFirst: true,
+          entryPoint: "upsertById",
         });
       });
     });

--- a/packages/typegraph/tests/backends/integration/temporal-oracle.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle.ts
@@ -171,11 +171,14 @@ function nextRunGraphId(label: string): string {
 }
 
 function freshStore(backend: GraphBackend, label: string): OracleStore {
-  return createStore(oracleGraph(nextRunGraphId(label)), backend);
+  return createStore(oracleGraph(nextRunGraphId(label)), backend, {
+    coalesceUnchangedUpserts: true,
+  });
 }
 
 function freshHistoryStore(backend: GraphBackend, label: string): OracleStore {
   return createStore(oracleGraph(nextRunGraphId(label)), backend, {
+    coalesceUnchangedUpserts: true,
     history: true,
   });
 }
@@ -423,6 +426,15 @@ function trackCreatedNode(
   if (!state.liveNodes.includes(node.id)) state.liveNodes.push(node.id);
 }
 
+function pickLiveNode(
+  state: ScriptState,
+  pick: number,
+): Node<typeof OraclePerson> | undefined {
+  const id = pickFrom(state.liveNodes, pick);
+  if (id === undefined) return undefined;
+  return state.nodesById.get(id);
+}
+
 function dropNode(state: ScriptState, id: string): void {
   state.liveNodes = state.liveNodes.filter((candidate) => candidate !== id);
   state.tombstonedNodes.push(id);
@@ -560,6 +572,23 @@ async function applyNodeOp(
       );
       return true;
     }
+    case "update-reopen": {
+      const id = nextId(state, "n");
+      const name = `update-reopen-${id}`;
+      await store.nodes.OraclePerson.create(
+        { name },
+        { id, validTo: futureAnchor(op.upperPick) },
+      );
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.update(
+          asNodeId<typeof OraclePerson>(id),
+          {},
+          { clearValidTo: true },
+        ),
+      );
+      return true;
+    }
     case "soft-delete": {
       const id = pickFrom(state.liveNodes, op.targetPick);
       if (id === undefined) return true;
@@ -588,6 +617,41 @@ async function applyNodeOp(
       if (id === undefined) return true;
       const name = requireDefined(state.namesById.get(id), "tracked name");
       await store.nodes.OraclePerson.upsertById(id, { name });
+      return true;
+    }
+    case "upsert-reopen": {
+      const id = nextId(state, "n");
+      const name = `upsert-reopen-${id}`;
+      await store.nodes.OraclePerson.create(
+        { name },
+        { id, validTo: futureAnchor(op.upperPick) },
+      );
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.upsertById(
+          id,
+          { name },
+          { clearValidTo: true },
+        ),
+      );
+      return true;
+    }
+    case "upsert-resurrect-reopen": {
+      const id = nextId(state, "n");
+      const name = `upsert-resurrect-reopen-${id}`;
+      const created = await store.nodes.OraclePerson.create(
+        { name },
+        { id, validTo: futureAnchor(op.upperPick) },
+      );
+      await store.nodes.OraclePerson.delete(created.id);
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.upsertById(
+          id,
+          { name },
+          { clearValidTo: true },
+        ),
+      );
       return true;
     }
     case "bulk-create": {
@@ -621,17 +685,17 @@ async function applyNodeOp(
     case "edge-create-stated-window":
     case "edge-create-scheduled-end":
     case "edge-create-born-ended":
+    case "edge-update-reopen":
+    case "edge-endpoint-upsert-reopen":
+    case "edge-endpoint-resurrect-reopen":
     case "edge-soft-delete": {
       return false;
     }
   }
 }
 
-/** The edge-create shapes, i.e. every edge shape but the soft delete. */
-type EdgeCreateShape = Exclude<
-  Extract<TemporalOpShape, `edge-${string}`>,
-  "edge-soft-delete"
->;
+/** The edge shapes that create one row without a follow-up mutation. */
+type EdgeCreateShape = Extract<TemporalOpShape, `edge-create-${string}`>;
 
 function edgeWindowOptions(
   state: ScriptState,
@@ -674,18 +738,53 @@ async function applyEdgeOp(
     state.liveEdges = state.liveEdges.filter((candidate) => candidate !== id);
     return;
   }
+  if (
+    op.shape === "edge-update-reopen" ||
+    op.shape === "edge-endpoint-upsert-reopen" ||
+    op.shape === "edge-endpoint-resurrect-reopen"
+  ) {
+    if (state.liveNodes.length < 2) return;
+    const from = pickLiveNode(state, op.targetPick);
+    const to = pickLiveNode(state, op.targetPick + 1);
+    if (from === undefined || to === undefined) return;
+    const id = nextId(state, "e");
+    const since = `reopen-${id}`;
+    const created = await store.edges.oracleKnows.create(
+      from,
+      to,
+      { since },
+      { id, validTo: futureAnchor(op.upperPick) },
+    );
+    if (op.shape === "edge-endpoint-resurrect-reopen") {
+      await store.edges.oracleKnows.delete(created.id);
+    }
+    if (op.shape === "edge-update-reopen") {
+      await store.edges.oracleKnows.update(
+        created.id,
+        {},
+        { clearValidTo: true },
+      );
+    } else {
+      await store.edges.oracleKnows.getOrCreateByEndpoints(
+        from,
+        to,
+        { since },
+        {
+          matchOn: ["since"],
+          ifExists: "update",
+          clearValidTo: true,
+        },
+      );
+    }
+    state.allEdges.push(id);
+    state.liveEdges.push(id);
+    state.edgeEndpoints.set(id, { from: from.id, to: to.id });
+    return;
+  }
   if (!isEdgeCreateOp(op)) return;
   if (state.liveNodes.length < 2) return;
-  const fromId = requireDefined(
-    pickFrom(state.liveNodes, op.targetPick),
-    "edge source",
-  );
-  const toId = requireDefined(
-    pickFrom(state.liveNodes, op.targetPick + 1),
-    "edge target",
-  );
-  const from = state.nodesById.get(fromId);
-  const to = state.nodesById.get(toId);
+  const from = pickLiveNode(state, op.targetPick);
+  const to = pickLiveNode(state, op.targetPick + 1);
   if (from === undefined || to === undefined) return;
   const id = nextId(state, "e");
   const options = edgeWindowOptions(state, id, op);
@@ -697,7 +796,7 @@ async function applyEdgeOp(
   );
   state.allEdges.push(id);
   state.liveEdges.push(id);
-  state.edgeEndpoints.set(id, { from: fromId, to: toId });
+  state.edgeEndpoints.set(id, { from: from.id, to: to.id });
 }
 
 async function runHistory(

--- a/packages/typegraph/tests/backends/integration/temporal-oracle.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle.ts
@@ -1030,7 +1030,8 @@ async function assertProjectionParity(
 }
 
 // ============================================================
-// The still-reproduces tests, one per declared gap
+// The still-reproduces tests, one per declared gap, and the gap-CLOSED tests
+// that replaced the two the seam closed
 // ============================================================
 
 type GapReproduction = (context: IntegrationTestContext) => Promise<void>;
@@ -1057,45 +1058,6 @@ async function storedRow(
    compile error), and that structure is worth more than inlining the expects
    into literal `it` bodies. */
 const GAP_REPRODUCTIONS = {
-  "born-ended-insert": async (context) => {
-    const backend = context.getBackend();
-    const store = freshStore(backend, "gap_insert");
-    await store.nodes.OraclePerson.create(
-      { name: "born ended" },
-      { id: "f1", validTo: FIRST_PAST_ANCHOR },
-    );
-    const row = await storedRow(backend, store, "f1");
-    // The gap: a bound nobody stated is stamped past the stated end.
-    expect(row.validTo).toBe(FIRST_PAST_ANCHOR);
-    expect(row.validFrom).toBeDefined();
-    expect(rowSatisfiesOrderedWindow(row)).toBe(false);
-    // ...so the row is readable at no coordinate at all.
-    for (const at of [
-      "2019-01-01T00:00:00.000Z",
-      FIRST_PAST_ANCHOR,
-      LAST_FUTURE_ANCHOR,
-    ]) {
-      const seen = await store.nodes.OraclePerson.getById(
-        asNodeId<typeof OraclePerson>("f1"),
-        { temporalMode: "asOf", asOf: at },
-      );
-      expect(seen).toBeUndefined();
-    }
-  },
-  "born-ended-on-tombstone": async (context) => {
-    const backend = context.getBackend();
-    const store = freshStore(backend, "gap_tombstone");
-    await store.nodes.OraclePerson.create({ name: "first" }, { id: "t1" });
-    await store.nodes.OraclePerson.delete(asNodeId<typeof OraclePerson>("t1"));
-    await store.nodes.OraclePerson.create(
-      { name: "born ended on tombstone" },
-      { id: "t1", validTo: FIRST_PAST_ANCHOR },
-    );
-    const row = await storedRow(backend, store, "t1");
-    expect(row.validTo).toBe(FIRST_PAST_ANCHOR);
-    expect(row.validFrom).toBeDefined();
-    expect(rowSatisfiesOrderedWindow(row)).toBe(false);
-  },
   "resurrection-refusal-gap": async (context) => {
     const store = freshStore(context.getBackend(), "gap_refusal");
     for (const id of ["c1", "u1"]) {
@@ -1127,6 +1089,69 @@ const GAP_REPRODUCTIONS = {
     );
   },
 } as const satisfies Record<KnownContractGapId, GapReproduction>;
+
+/**
+ * What the two born-ended entries used to excuse, restated as what the tree now
+ * does. These are the SAME two scripts their reproductions ran — a lone past
+ * `validTo` on a fresh id and on a tombstoned id — with every assertion turned
+ * around: no lower bound instead of a stamped one, an ordered window instead of a
+ * backwards one, and a row readable before its end instead of at no coordinate at
+ * all. Keeping the scripts and inverting the expectations is what makes the pair
+ * a closure record rather than two unrelated tests that happen to be green.
+ *
+ * Both variants assert the SAME stored shape, which is the create half of I12:
+ * one stated window through two entry points reaches one outcome. The tombstoned
+ * variant is the one that fails if `buildUpdateNode`'s resurrection leg is left
+ * on the old resolver while the eight insert builders are rewired.
+ */
+async function assertBornEndedCreateStoresNoLowerBound(
+  context: IntegrationTestContext,
+  variant: Readonly<{ label: string; id: string; tombstoneFirst: boolean }>,
+): Promise<void> {
+  const backend = context.getBackend();
+  const store = freshStore(backend, variant.label);
+  const nodeId = asNodeId<typeof OraclePerson>(variant.id);
+  if (variant.tombstoneFirst) {
+    await store.nodes.OraclePerson.create(
+      { name: "first" },
+      { id: variant.id },
+    );
+    await store.nodes.OraclePerson.delete(nodeId);
+  }
+
+  const created = await store.nodes.OraclePerson.create(
+    { name: "born ended" },
+    { id: variant.id, validTo: FIRST_PAST_ANCHOR },
+  );
+  expect(created.meta.validFrom).toBeUndefined();
+  expect(created.meta.validTo).toBe(FIRST_PAST_ANCHOR);
+
+  const row = await storedRow(backend, store, variant.id);
+  expect(row.validTo).toBe(FIRST_PAST_ANCHOR);
+  expect(row.validFrom).toBeUndefined();
+  expect(rowSatisfiesOrderedWindow(row)).toBe(true);
+  expect(intervalIsEmpty(intervalOf(row))).toBe(false);
+
+  // "Ended at T, start unknown": readable at every coordinate before its end,
+  // at none from its end onward. The upper bound is half-open, so the end
+  // instant itself is already outside.
+  for (const at of ["2019-01-01T00:00:00.000Z", "2019-12-31T23:59:59.999Z"]) {
+    await expect(
+      store.nodes.OraclePerson.getById(nodeId, {
+        temporalMode: "asOf",
+        asOf: at,
+      }),
+    ).resolves.toBeDefined();
+  }
+  for (const at of [FIRST_PAST_ANCHOR, LAST_FUTURE_ANCHOR]) {
+    await expect(
+      store.nodes.OraclePerson.getById(nodeId, {
+        temporalMode: "asOf",
+        asOf: at,
+      }),
+    ).resolves.toBeUndefined();
+  }
+}
 /* eslint-enable vitest/no-standalone-expect */
 
 // ============================================================
@@ -1220,6 +1245,24 @@ export function registerTemporalOracleIntegrationTests(
           await GAP_REPRODUCTIONS[gap.id](context);
         });
       }
+    });
+
+    describe("closed contract gaps", () => {
+      it("closed: a born-ended create on a fresh id stores no lower bound and reads back before its end", async () => {
+        await assertBornEndedCreateStoresNoLowerBound(context, {
+          label: "closed_insert",
+          id: "f1",
+          tombstoneFirst: false,
+        });
+      });
+
+      it("closed: a born-ended create on a tombstoned id stores the same shape as on a fresh id", async () => {
+        await assertBornEndedCreateStoresNoLowerBound(context, {
+          label: "closed_tombstone",
+          id: "t1",
+          tombstoneFirst: true,
+        });
+      });
     });
 
     it("stores no window readable at no coordinate, and stamps no bound it did not judge (P1/P1b/P2)", async () => {

--- a/packages/typegraph/tests/backends/integration/temporal-oracle.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle.ts
@@ -1,0 +1,1505 @@
+/**
+ * The temporal ORACLE suite: randomized bitemporal histories, replayed against
+ * an independent TypeScript model of the valid-time semantics
+ * (`./temporal-oracle-model`) on every backend in the integration matrix.
+ *
+ * WHAT IT CHECKS, AND WHY EACH PROPERTY EXISTS
+ *
+ * - **P1 / P1b — storage invariants.** No row this library writes carries a
+ *   window readable at no coordinate (I1), and no write that STAMPS a bound the
+ *   caller did not state produces one (I1b). No read-side test can express
+ *   these: an invisible row is invisible to every read. Both halves of I1's
+ *   scope are checked — the live relations in P1's own property, and the
+ *   `recorded_*` relations (an independent binder of the same columns) inside
+ *   P5, the only property whose store writes them.
+ * - **P2 — bound provenance (I2).** Scoped to what the ledger can prove. Its
+ *   never-updated clause is an EQUALITY (`valid_from === created_at` for a bound
+ *   nobody stated), which is the only ledger-visible detector for an insert
+ *   builder that samples its own clock instead of binding the `timestamp` it
+ *   also stamps into `created_at`.
+ * - **P3 — four-way visibility equality (I3/I4/I6/I7).** The compiled query, the
+ *   SQL-filtered collection read, the in-memory `#temporalRowMatcher` behind
+ *   `getByIds`, and the model. Any three agreeing is not evidence.
+ * - **P4' — projection parity.** `valid_from` has two normalization owners:
+ *   `src/backend/row-mappers.ts` (through `formatTimestamp`) and
+ *   `src/query/execution/result-mapper.ts` (a bare `nullToUndefined`). This
+ *   binds them on every driver in the matrix — on which bounds exist, on which
+ *   instant each names, and on the runtime type of a present bound. Their
+ *   RENDERING already diverges on postgres.js; that is issue #463.
+ * - **P5 — the bitemporal grid.** `asOfRecorded(r) x asOf(t)` against the model
+ *   derived from the `recorded_*` rows, plus the current-mode recorded pin —
+ *   and I1/I1b over those same rows, which is where the recorded half of the
+ *   storage invariants is checked.
+ * - **P6 — interchange round-trip (I8).** `(valid_from, valid_to)` survives
+ *   export/import exactly, `NULL` included.
+ * - **P7 — merge window laws (I11).** Order-independence of the least-claim
+ *   rule, deletion absorbing an ending, and a `validFrom` divergence being
+ *   reported rather than dropped.
+ *
+ * EVERY GENERATED HISTORY CARRIES AN EXPLICITLY OPEN-LEFT ITEM. An interchange
+ * import stating `validFrom: null` is, on this tree, the only store-level path
+ * that produces `valid_from = NULL`. Without it, deleting the
+ * `valid_from IS NULL OR` disjunct from the SQL — or inverting the in-memory
+ * matcher's `valid_from` branch — changes no outcome, and the four-way check
+ * would certify nothing for the very shape it was widened to cover.
+ *
+ * ISOLATION. Each fast-check run builds a FRESH graph id over the already
+ * provisioned backend and a bare `createStore` (a plain constructor: it issues
+ * no DDL). `graph_id` is a fence every compiled query and every collection read
+ * already carries, so the query under test is the query users write — no
+ * id-prefix predicate is bolted onto it — and shrinking stays hermetic.
+ *
+ * KNOWN CONTRACT GAPS. The model encodes TODAY'S contract, so this suite passes
+ * unchanged on `main`; that is the evidence it is an equivalence check rather
+ * than a restatement of behavior a later batch introduces. The three cells where
+ * the tree violates an invariant this workstream states are declared in
+ * `KNOWN_CONTRACT_GAPS`, which withholds their op shapes from the generator and
+ * carries one still-reproduces test each. Each entry — and its restriction —
+ * dies in the diff that measurably closes it.
+ */
+import fc from "fast-check";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  asEdgeId,
+  asNodeId,
+  createStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  INVERTED_VALIDITY_WINDOW_CODE,
+  type Node,
+  type RecordedInstant,
+  ValidationError,
+} from "../../../src";
+import type { GraphBackend } from "../../../src/backend/types";
+import {
+  recordedInstantRevision,
+  recordedInstantWallTime,
+} from "../../../src/core/temporal";
+import { mergeKey } from "../../../src/graph-merge/node-key";
+import { asBranchId, type BranchId } from "../../../src/graph-merge/types";
+import {
+  resolveEndClaims,
+  resolveValidWindows,
+  WINDOW_NOT_APPLICABLE_DROP_REASON,
+} from "../../../src/graph-merge/valid-window";
+import {
+  exportGraph,
+  FORMAT_VERSION,
+  type GraphData,
+  importGraph,
+} from "../../../src/interchange";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { sql } from "../../../src/query/sql-fragment";
+import { asCompiledRowsSql } from "../../../src/query/sql-intent";
+import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
+import { requireDefined } from "../../../src/utils/presence";
+import { recordedInstantFromDriver } from "../../test-utils";
+import {
+  allLedgerRows,
+  emittableOpShapes,
+  type Instant,
+  intervalIsEmpty,
+  intervalOf,
+  KNOWN_CONTRACT_GAPS,
+  type KnownContractGapId,
+  type LedgerRow,
+  liveLedgerRows,
+  readTemporalLedger,
+  type RowKey,
+  rowKeyOf,
+  rowSatisfiesOrderedWindow,
+  type TemporalCoordinate,
+  type TemporalLedger,
+  type TemporalOpShape,
+  traversableEdgesAt,
+  visibleAt,
+} from "./temporal-oracle-model";
+import { type IntegrationTestContext } from "./test-context";
+
+// ============================================================
+// The graph under test
+// ============================================================
+
+const OraclePerson = defineNode("OraclePerson", {
+  schema: z.object({ name: z.string() }),
+});
+
+const oracleKnows = defineEdge("oracleKnows", {
+  schema: z.object({ since: z.string() }),
+});
+
+/**
+ * "Confirmed open-left", the one interchange value that stores
+ * `valid_from = NULL`. Hoisted to a constant so the rule waiver sits on a line
+ * of its own that the formatter will not reflow into the object literal.
+ */
+// eslint-disable-next-line unicorn/no-null -- the interchange wire value
+const CONFIRMED_OPEN_LEFT = null;
+
+const NODE_KIND = "OraclePerson";
+const EDGE_KIND = "oracleKnows";
+
+function oracleGraph(id: string) {
+  return defineGraph({
+    id,
+    // Cascade, so a soft-deleted node takes its edges with it. The default
+    // (`restrict`) would make `soft-delete` refuse whenever the generator had
+    // already attached an edge, silently thinning the op vocabulary.
+    nodes: { OraclePerson: { type: OraclePerson, onDelete: "cascade" } },
+    edges: {
+      oracleKnows: {
+        type: oracleKnows,
+        from: [OraclePerson],
+        to: [OraclePerson],
+        cardinality: "many",
+      },
+    },
+  });
+}
+
+type OracleGraph = ReturnType<typeof oracleGraph>;
+type OracleStore = ReturnType<typeof createStore<OracleGraph>>;
+
+/** Per-process run counter: each fast-check run gets its own `graph_id` fence. */
+let runSequence = 0;
+
+function nextRunGraphId(label: string): string {
+  runSequence += 1;
+  return `temporal_oracle_${label}_${runSequence}`;
+}
+
+function freshStore(backend: GraphBackend, label: string): OracleStore {
+  return createStore(oracleGraph(nextRunGraphId(label)), backend);
+}
+
+function freshHistoryStore(backend: GraphBackend, label: string): OracleStore {
+  return createStore(oracleGraph(nextRunGraphId(label)), backend, {
+    history: true,
+  });
+}
+
+// ============================================================
+// Budget
+// ============================================================
+
+/**
+ * The one owner of the run budget. At the default this suite is honestly a SMOKE
+ * gate — the boundary-heavy coordinate generator is what finds bugs, not the run
+ * count — and a deep run is `TYPEGRAPH_ORACLE_RUNS=100 pnpm test`.
+ *
+ * Bracket access because `noPropertyAccessFromIndexSignature` is on.
+ */
+function oracleRunConfig(): fc.Parameters<unknown> {
+  return {
+    numRuns: Number(process.env["TYPEGRAPH_ORACLE_RUNS"] ?? 8),
+    endOnFailure: true,
+  };
+}
+
+// ============================================================
+// The instant lattice
+// ============================================================
+
+/**
+ * Eight canonical anchors spanning 2020 -> 2100, four strictly before any write
+ * this suite makes and four strictly after. The split is what lets "a lone
+ * `validTo` in the past" and "a lone `validTo` in the future" be op SHAPES
+ * rather than observed outcomes, which is what makes the gap restrictions
+ * deterministic.
+ */
+const PAST_ANCHORS = [
+  "2020-01-01T00:00:00.000Z",
+  "2021-06-01T00:00:00.000Z",
+  "2022-01-01T00:00:00.000Z",
+  "2024-03-01T00:00:00.000Z",
+] as const;
+
+const FUTURE_ANCHORS = [
+  "2060-01-01T00:00:00.000Z",
+  "2070-06-01T00:00:00.000Z",
+  "2080-01-01T00:00:00.000Z",
+  "2100-01-01T00:00:00.000Z",
+] as const;
+
+const ANCHORS: readonly Instant[] = [...PAST_ANCHORS, ...FUTURE_ANCHORS];
+
+const FIRST_PAST_ANCHOR = requireDefined(PAST_ANCHORS[0], "past anchor");
+const LAST_FUTURE_ANCHOR = requireDefined(FUTURE_ANCHORS[3], "future anchor");
+
+function pastAnchor(pick: number): Instant {
+  return requireDefined(
+    PAST_ANCHORS[pick % PAST_ANCHORS.length],
+    "past anchor",
+  );
+}
+
+function futureAnchor(pick: number): Instant {
+  return requireDefined(
+    FUTURE_ANCHORS[pick % FUTURE_ANCHORS.length],
+    "future anchor",
+  );
+}
+
+/** A stated window whose endpoints are ordered and never zero width. */
+function statedWindow(
+  lowerPick: number,
+  upperPick: number,
+): Readonly<{ validFrom: Instant; validTo: Instant }> {
+  const validFrom = pastAnchor(lowerPick);
+  const candidates = ANCHORS.filter((anchor) => anchor > validFrom);
+  const validTo = requireDefined(
+    candidates[upperPick % candidates.length],
+    "upper anchor",
+  );
+  return { validFrom, validTo };
+}
+
+function shiftedInstant(instant: Instant, milliseconds: number): Instant {
+  return new Date(new Date(instant).getTime() + milliseconds).toISOString();
+}
+
+/**
+ * Boundary-heavy coordinates: the lattice, every bound the run actually stored,
+ * one millisecond either side of each, and now. Derived from the LEDGER rather
+ * than from the write calls, so a write whose stored shape differs from the one
+ * the script asked for is still checked against what it stored.
+ */
+function candidateCoordinates(ledger: TemporalLedger): readonly Instant[] {
+  const bounds = allLedgerRows(ledger).flatMap((row) =>
+    [row.validFrom, row.validTo].filter(
+      (bound): bound is Instant => bound !== undefined,
+    ),
+  );
+  const around = bounds.flatMap((bound) => [
+    bound,
+    shiftedInstant(bound, -1),
+    shiftedInstant(bound, 1),
+  ]);
+  return [
+    ...new Set([...ANCHORS, ...around, new Date().toISOString()]),
+  ].toSorted();
+}
+
+function pickCoordinates(
+  ledger: TemporalLedger,
+  picks: readonly number[],
+): readonly Instant[] {
+  const candidates = candidateCoordinates(ledger);
+  return [
+    ...new Set(
+      picks.map((pick) =>
+        requireDefined(candidates[pick % candidates.length], "coordinate"),
+      ),
+    ),
+  ];
+}
+
+// ============================================================
+// The history generator
+// ============================================================
+
+type GeneratedOp = Readonly<{
+  shape: TemporalOpShape;
+  lowerPick: number;
+  upperPick: number;
+  targetPick: number;
+}>;
+
+/**
+ * Exported for `tests/temporal-oracle-imports.test.ts`, which SAMPLES it to
+ * assert the shapes it can draw are exactly the ones the standing gaps leave
+ * emittable. Comparing `emittableOpShapes()` against a re-spelling of its own
+ * body proves nothing; only the generator's own draws can show a restriction is
+ * honored end-to-end.
+ */
+export function generatedOpArb(): fc.Arbitrary<GeneratedOp> {
+  return fc.record({
+    shape: fc.constantFrom(...emittableOpShapes()),
+    lowerPick: fc.nat({ max: 7 }),
+    upperPick: fc.nat({ max: 7 }),
+    targetPick: fc.nat({ max: 31 }),
+  });
+}
+
+type GeneratedHistory = Readonly<{
+  ops: readonly GeneratedOp[];
+  coordinatePicks: readonly number[];
+}>;
+
+function generatedHistoryArb(maxOps: number): fc.Arbitrary<GeneratedHistory> {
+  return fc.record({
+    ops: fc.array(generatedOpArb(), { minLength: 4, maxLength: maxOps }),
+    coordinatePicks: fc.array(fc.nat({ max: 255 }), {
+      minLength: 8,
+      maxLength: 8,
+    }),
+  });
+}
+
+/**
+ * What the SCRIPT said, as opposed to what the clock did — the only knowledge
+ * the oracle keeps outside the ledger, and the only kind that cannot flake: it
+ * is what the test asked for, never what a write instant happened to be.
+ */
+type ScriptFacts = Readonly<{
+  /** `(kind, id)` -> the lower bounds some write STATED as a string. */
+  statedLowerBounds: ReadonlyMap<RowKey, ReadonlySet<Instant>>;
+  /** `(kind, id)` for which some write stated a lower bound at all, `null` included. */
+  boundWasStated: ReadonlySet<RowKey>;
+  nodeIds: readonly string[];
+  edgeIds: readonly string[];
+}>;
+
+interface ScriptState {
+  liveNodes: string[];
+  tombstonedNodes: string[];
+  allNodes: string[];
+  liveEdges: string[];
+  allEdges: string[];
+  edgeEndpoints: Map<string, Readonly<{ from: string; to: string }>>;
+  nodesById: Map<string, Node<typeof OraclePerson>>;
+  namesById: Map<string, string>;
+  statedLowerBounds: Map<RowKey, Set<Instant>>;
+  boundWasStated: Set<RowKey>;
+  sequence: number;
+}
+
+function newScriptState(): ScriptState {
+  return {
+    liveNodes: [],
+    tombstonedNodes: [],
+    allNodes: [],
+    liveEdges: [],
+    allEdges: [],
+    edgeEndpoints: new Map(),
+    nodesById: new Map(),
+    namesById: new Map(),
+    statedLowerBounds: new Map(),
+    boundWasStated: new Set(),
+    sequence: 0,
+  };
+}
+
+function noteStatedLowerBound(
+  state: ScriptState,
+  kind: string,
+  id: string,
+  validFrom: Instant | undefined,
+): void {
+  const key = rowKeyOf({ kind, id });
+  state.boundWasStated.add(key);
+  if (validFrom === undefined) return;
+  const bounds = state.statedLowerBounds.get(key) ?? new Set<Instant>();
+  bounds.add(validFrom);
+  state.statedLowerBounds.set(key, bounds);
+}
+
+function pickFrom(pool: readonly string[], pick: number): string | undefined {
+  return pool.length === 0 ? undefined : pool[pick % pool.length];
+}
+
+function takeTombstoned(state: ScriptState, pick: number): string | undefined {
+  if (state.tombstonedNodes.length === 0) return undefined;
+  const index = pick % state.tombstonedNodes.length;
+  const [id] = state.tombstonedNodes.splice(index, 1);
+  return id;
+}
+
+function nextId(state: ScriptState, prefix: string): string {
+  state.sequence += 1;
+  return `${prefix}${state.sequence}`;
+}
+
+function trackCreatedNode(
+  state: ScriptState,
+  node: Node<typeof OraclePerson>,
+): void {
+  state.nodesById.set(node.id, node);
+  state.namesById.set(node.id, node.name);
+  if (!state.allNodes.includes(node.id)) state.allNodes.push(node.id);
+  if (!state.liveNodes.includes(node.id)) state.liveNodes.push(node.id);
+}
+
+function dropNode(state: ScriptState, id: string): void {
+  state.liveNodes = state.liveNodes.filter((candidate) => candidate !== id);
+  state.tombstonedNodes.push(id);
+  // `onDelete: "cascade"` takes the incident edges with the node.
+  state.liveEdges = state.liveEdges.filter((edgeId) => {
+    const endpoints = state.edgeEndpoints.get(edgeId);
+    return (
+      endpoints !== undefined && endpoints.from !== id && endpoints.to !== id
+    );
+  });
+}
+
+/**
+ * The open-left item every history carries. Interchange is the one store-level
+ * path that can state "no lower bound", and a `valid_from = NULL` row is what
+ * makes the NULL-handling half of every read path load-bearing.
+ *
+ * It is deliberately WITHHELD from the op target pool (`liveNodes`): a history
+ * that soft-deleted it would take the run's only `valid_from = NULL` row with
+ * it, and with it P3's NULL-branch coverage and P6's precondition — silently,
+ * on some seeds and not others. It stays in `allNodes`, so every read path and
+ * the model still see it.
+ */
+async function importOpenLeftItem(
+  store: OracleStore,
+  state: ScriptState,
+  upperPick: number,
+): Promise<void> {
+  const id = nextId(state, "n");
+  const name = `open-left-${id}`;
+  const data: GraphData = {
+    formatVersion: FORMAT_VERSION,
+    exportedAt: new Date().toISOString(),
+    source: { type: "external", description: "temporal oracle open-left item" },
+    nodes: [
+      {
+        kind: NODE_KIND,
+        id,
+        properties: { name },
+        validFrom: CONFIRMED_OPEN_LEFT,
+        validTo: pastAnchor(upperPick),
+      },
+    ],
+    edges: [],
+  };
+  await importGraph(store, data, { onConflict: "error" });
+  noteStatedLowerBound(state, NODE_KIND, id, undefined);
+  state.namesById.set(id, name);
+  state.allNodes.push(id);
+}
+
+async function applyNodeOp(
+  store: OracleStore,
+  state: ScriptState,
+  op: GeneratedOp,
+): Promise<boolean> {
+  switch (op.shape) {
+    case "create-open": {
+      const id = nextId(state, "n");
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.create({ name: `open-${id}` }, { id }),
+      );
+      return true;
+    }
+    case "create-stated-window": {
+      const id = nextId(state, "n");
+      const window = statedWindow(op.lowerPick, op.upperPick);
+      noteStatedLowerBound(state, NODE_KIND, id, window.validFrom);
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.create(
+          { name: `stated-${id}` },
+          { id, ...window },
+        ),
+      );
+      return true;
+    }
+    case "create-scheduled-end": {
+      const id = nextId(state, "n");
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.create(
+          { name: `scheduled-${id}` },
+          { id, validTo: futureAnchor(op.upperPick) },
+        ),
+      );
+      return true;
+    }
+    case "create-born-ended": {
+      const id = nextId(state, "n");
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.create(
+          { name: `born-ended-${id}` },
+          { id, validTo: pastAnchor(op.upperPick) },
+        ),
+      );
+      return true;
+    }
+    case "create-on-tombstone":
+    case "create-on-tombstone-born-ended": {
+      const id = takeTombstoned(state, op.targetPick);
+      if (id === undefined) return true;
+      const validTo =
+        op.shape === "create-on-tombstone-born-ended" ?
+          { validTo: pastAnchor(op.upperPick) }
+        : {};
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.create(
+          { name: `revived-${id}` },
+          { id, ...validTo },
+        ),
+      );
+      return true;
+    }
+    case "update-props": {
+      const id = pickFrom(state.liveNodes, op.targetPick);
+      if (id === undefined) return true;
+      const name = `updated-${id}-${state.sequence}`;
+      state.namesById.set(id, name);
+      await store.nodes.OraclePerson.update(asNodeId<typeof OraclePerson>(id), {
+        name,
+      });
+      return true;
+    }
+    case "update-scheduled-end": {
+      const id = pickFrom(state.liveNodes, op.targetPick);
+      if (id === undefined) return true;
+      await store.nodes.OraclePerson.update(
+        asNodeId<typeof OraclePerson>(id),
+        {},
+        { validTo: futureAnchor(op.upperPick) },
+      );
+      return true;
+    }
+    case "soft-delete": {
+      const id = pickFrom(state.liveNodes, op.targetPick);
+      if (id === undefined) return true;
+      await store.nodes.OraclePerson.delete(asNodeId<typeof OraclePerson>(id));
+      dropNode(state, id);
+      return true;
+    }
+    case "upsert-resurrect":
+    case "upsert-resurrect-born-ended": {
+      const id = takeTombstoned(state, op.targetPick);
+      if (id === undefined) return true;
+      const name = `resurrected-${id}`;
+      state.namesById.set(id, name);
+      const options =
+        op.shape === "upsert-resurrect-born-ended" ?
+          { validTo: pastAnchor(op.upperPick) }
+        : {};
+      trackCreatedNode(
+        state,
+        await store.nodes.OraclePerson.upsertById(id, { name }, options),
+      );
+      return true;
+    }
+    case "upsert-unchanged": {
+      const id = pickFrom(state.liveNodes, op.targetPick);
+      if (id === undefined) return true;
+      const name = requireDefined(state.namesById.get(id), "tracked name");
+      await store.nodes.OraclePerson.upsertById(id, { name });
+      return true;
+    }
+    case "bulk-create": {
+      const first = nextId(state, "n");
+      const second = nextId(state, "n");
+      const created = await store.nodes.OraclePerson.bulkCreate([
+        { props: { name: `bulk-${first}` }, id: first },
+        {
+          props: { name: `bulk-${second}` },
+          id: second,
+          validTo: futureAnchor(op.upperPick),
+        },
+      ]);
+      for (const node of created) trackCreatedNode(state, node);
+      return true;
+    }
+    case "bulk-upsert-repeated-id": {
+      const id = nextId(state, "n");
+      const name = `repeated-${id}-final`;
+      state.namesById.set(id, name);
+      const upserted = await store.nodes.OraclePerson.bulkUpsertById([
+        { id, props: { name: `repeated-${id}-first` } },
+        { id, props: { name } },
+      ]);
+      for (const node of upserted) trackCreatedNode(state, node);
+      return true;
+    }
+    // The edge half of the vocabulary, handled by `applyEdgeOp`. Named rather
+    // than defaulted so a new shape is a compile error here, not a silent no-op.
+    case "edge-create-open":
+    case "edge-create-stated-window":
+    case "edge-create-scheduled-end":
+    case "edge-create-born-ended":
+    case "edge-soft-delete": {
+      return false;
+    }
+  }
+}
+
+/** The edge-create shapes, i.e. every edge shape but the soft delete. */
+type EdgeCreateShape = Exclude<
+  Extract<TemporalOpShape, `edge-${string}`>,
+  "edge-soft-delete"
+>;
+
+function edgeWindowOptions(
+  state: ScriptState,
+  id: string,
+  op: GeneratedOp & Readonly<{ shape: EdgeCreateShape }>,
+): Readonly<{ validFrom?: Instant; validTo?: Instant }> {
+  switch (op.shape) {
+    case "edge-create-stated-window": {
+      const window = statedWindow(op.lowerPick, op.upperPick);
+      noteStatedLowerBound(state, EDGE_KIND, id, window.validFrom);
+      return window;
+    }
+    case "edge-create-scheduled-end": {
+      return { validTo: futureAnchor(op.upperPick) };
+    }
+    case "edge-create-born-ended": {
+      return { validTo: pastAnchor(op.upperPick) };
+    }
+    case "edge-create-open": {
+      return {};
+    }
+  }
+}
+
+function isEdgeCreateOp(
+  op: GeneratedOp,
+): op is GeneratedOp & Readonly<{ shape: EdgeCreateShape }> {
+  return op.shape.startsWith("edge-create-");
+}
+
+async function applyEdgeOp(
+  store: OracleStore,
+  state: ScriptState,
+  op: GeneratedOp,
+): Promise<void> {
+  if (op.shape === "edge-soft-delete") {
+    const id = pickFrom(state.liveEdges, op.targetPick);
+    if (id === undefined) return;
+    await store.edges.oracleKnows.delete(asEdgeId<typeof oracleKnows>(id));
+    state.liveEdges = state.liveEdges.filter((candidate) => candidate !== id);
+    return;
+  }
+  if (!isEdgeCreateOp(op)) return;
+  if (state.liveNodes.length < 2) return;
+  const fromId = requireDefined(
+    pickFrom(state.liveNodes, op.targetPick),
+    "edge source",
+  );
+  const toId = requireDefined(
+    pickFrom(state.liveNodes, op.targetPick + 1),
+    "edge target",
+  );
+  const from = state.nodesById.get(fromId);
+  const to = state.nodesById.get(toId);
+  if (from === undefined || to === undefined) return;
+  const id = nextId(state, "e");
+  const options = edgeWindowOptions(state, id, op);
+  await store.edges.oracleKnows.create(
+    from,
+    to,
+    { since: `since-${id}` },
+    { id, ...options },
+  );
+  state.allEdges.push(id);
+  state.liveEdges.push(id);
+  state.edgeEndpoints.set(id, { from: fromId, to: toId });
+}
+
+async function runHistory(
+  store: OracleStore,
+  history: GeneratedHistory,
+  afterOp?: () => Promise<void>,
+): Promise<ScriptFacts> {
+  const state = newScriptState();
+  await importOpenLeftItem(store, state, history.ops.length);
+  await afterOp?.();
+  // Three ordinary creates seed the history so the generated script has
+  // something to act on. Without them a run whose ops all need an existing row
+  // degenerates to the open-left item alone: the edge shapes never fire, and the
+  // STAMPED lower bound — the shape P2's equality clause is about — is absent
+  // from the run entirely.
+  //
+  // The FIRST is pinned out of the op target pool for the same reason the
+  // open-left item is: between them the two guarantee the export carries one row
+  // of each lower-bound shape (`NULL` and stamped), so P6's preconditions are
+  // properties of the harness rather than of the seed fast-check happened to
+  // draw. The other two are ordinary targets.
+  for (const [index, seed] of ["pinned", "seed-a", "seed-b"].entries()) {
+    const id = nextId(state, "n");
+    const node = await store.nodes.OraclePerson.create(
+      { name: `${seed}-${id}` },
+      { id },
+    );
+    if (index === 0) {
+      state.nodesById.set(node.id, node);
+      state.namesById.set(node.id, node.name);
+      state.allNodes.push(node.id);
+    } else {
+      trackCreatedNode(state, node);
+    }
+    await afterOp?.();
+  }
+  for (const op of history.ops) {
+    const handled = await applyNodeOp(store, state, op);
+    if (!handled) await applyEdgeOp(store, state, op);
+    await afterOp?.();
+  }
+  return {
+    statedLowerBounds: state.statedLowerBounds,
+    boundWasStated: state.boundWasStated,
+    nodeIds: state.allNodes,
+    edgeIds: state.allEdges,
+  };
+}
+
+// ============================================================
+// Assertions
+// ============================================================
+
+function describeRow(row: LedgerRow): string {
+  return `${row.relation} ${rowKeyOf(row)} [${row.validFrom ?? "NULL"}, ${row.validTo ?? "NULL"})`;
+}
+
+/**
+ * P1 (I1): no stored window is backwards, on any of the four relations.
+ *
+ * Quantified over `allLedgerRows`, so the caller decides the scope by deciding
+ * what it read. The `recorded_*` half is NOT decoration: those columns have
+ * their own binder (`recordedCommonCells` in
+ * `src/store/recorded-capture/relations.ts`), i.e. the second of the two write
+ * paths I1 covers, and a live store has no such rows to read. That is why this
+ * runs in the P5 property too, over a history store's full ledger.
+ */
+function assertOrderedWindows(ledger: TemporalLedger): void {
+  const violations = allLedgerRows(ledger)
+    .filter((row) => !rowSatisfiesOrderedWindow(row))
+    .map((row) => describeRow(row));
+  expect(violations).toEqual([]);
+}
+
+/**
+ * P1b (I1b): a bound nobody stated never yields a window empty at every instant.
+ *
+ * Emptiness is the MODEL's decision (`intervalIsEmpty`), never a second
+ * comparison spelled here: this assertion's inputs change shape in the batch
+ * that lifts the born-ended restrictions, and a private copy would be edited on
+ * its own exactly then. Same scope as {@link assertOrderedWindows}, for the
+ * same reason.
+ */
+function assertStampedBoundsAreNonEmpty(
+  ledger: TemporalLedger,
+  facts: ScriptFacts,
+): void {
+  const violations = allLedgerRows(ledger)
+    .filter((row) => !facts.boundWasStated.has(rowKeyOf(row)))
+    .filter((row) => intervalIsEmpty(intervalOf(row)))
+    .map((row) => describeRow(row));
+  expect(violations).toEqual([]);
+}
+
+/**
+ * P2 (I2): bound provenance, scoped to what the ledger can classify.
+ *
+ * The never-updated clause is an EQUALITY, not a range: it is the ledger's only
+ * detector for an insert builder that reads its own clock instead of binding the
+ * timestamp it stamps into `created_at`. The reset-by-resurrection clause admits
+ * the bounds the SCRIPT stated — script knowledge, not clock knowledge — because
+ * a resurrection writes a stated bound verbatim and it may legitimately precede
+ * `created_at`.
+ */
+function assertBoundProvenance(
+  ledger: TemporalLedger,
+  facts: ScriptFacts,
+): void {
+  const violations: string[] = [];
+  for (const row of liveLedgerRows(ledger)) {
+    if (row.validFrom === undefined) continue;
+    const stated =
+      facts.statedLowerBounds.get(rowKeyOf(row)) ?? new Set<Instant>();
+    if (stated.has(row.validFrom)) continue;
+    const neverUpdated =
+      (row.version === undefined || row.version === 1) &&
+      row.createdAt === row.updatedAt &&
+      row.deletedAt === undefined;
+    if (neverUpdated) {
+      if (row.validFrom !== row.createdAt) {
+        violations.push(
+          `${describeRow(row)} valid_from != created_at ${row.createdAt}`,
+        );
+      }
+      continue;
+    }
+    if (row.validFrom < row.createdAt || row.validFrom > row.updatedAt) {
+      violations.push(
+        `${describeRow(row)} outside [${row.createdAt}, ${row.updatedAt}]`,
+      );
+    }
+  }
+  expect(violations).toEqual([]);
+}
+
+function nodeKeys(ids: readonly string[]): readonly RowKey[] {
+  return ids.map((id) => rowKeyOf({ kind: NODE_KIND, id })).toSorted();
+}
+
+function edgeKeys(ids: readonly string[]): readonly RowKey[] {
+  return ids.map((id) => rowKeyOf({ kind: EDGE_KIND, id })).toSorted();
+}
+
+function definedIds(
+  rows: readonly (Readonly<{ id: string }> | undefined)[],
+): readonly string[] {
+  return rows
+    .filter((row) => row !== undefined)
+    .map((row) => requireDefined(row, "row").id);
+}
+
+/** P3 (I3/I4/I6/I7): the four-way visibility equality at one coordinate. */
+async function assertVisibilityAgreesAt(
+  store: OracleStore,
+  ledger: TemporalLedger,
+  facts: ScriptFacts,
+  asOf: Instant,
+): Promise<void> {
+  const coordinate: TemporalCoordinate = { mode: "asOf", asOf };
+  const options = { temporalMode: "asOf", asOf } as const;
+
+  const compiled = await store
+    .query()
+    .from("OraclePerson", "p")
+    .temporal("asOf", asOf)
+    .select((ctx) => ctx.p.id)
+    .execute();
+  const collection = await store.nodes.OraclePerson.find(
+    { limit: 500 },
+    options,
+  );
+  const byIds = await store.nodes.OraclePerson.getByIds(
+    facts.nodeIds.map((id) => asNodeId<typeof OraclePerson>(id)),
+    options,
+  );
+
+  const expectedNodes = visibleAt(ledger.nodes, coordinate);
+  expect({
+    at: asOf,
+    compiled: nodeKeys(compiled),
+    collection: nodeKeys(collection.map((node) => node.id)),
+    byIds: nodeKeys(definedIds(byIds)),
+  }).toEqual({
+    at: asOf,
+    compiled: expectedNodes,
+    collection: expectedNodes,
+    byIds: expectedNodes,
+  });
+
+  const edgeCollection = await store.edges.oracleKnows.find(
+    { limit: 500 },
+    options,
+  );
+  const edgeByIds = await store.edges.oracleKnows.getByIds(
+    facts.edgeIds.map((id) => asEdgeId<typeof oracleKnows>(id)),
+    options,
+  );
+  const traversed = await store
+    .query()
+    .from("OraclePerson", "p")
+    .temporal("asOf", asOf)
+    .traverse("oracleKnows", "e")
+    .to("OraclePerson", "q")
+    .select((ctx) => ctx.e.id)
+    .execute();
+
+  const expectedEdges = visibleAt(ledger.edges, coordinate);
+  expect({
+    at: asOf,
+    collection: edgeKeys(edgeCollection.map((edge) => edge.id)),
+    byIds: edgeKeys(definedIds(edgeByIds)),
+    traversed: edgeKeys([...new Set(traversed)]),
+  }).toEqual({
+    at: asOf,
+    collection: expectedEdges,
+    byIds: expectedEdges,
+    traversed: traversableEdgesAt(ledger, coordinate),
+  });
+}
+
+type WindowedRow = Readonly<{
+  id: string;
+  meta: Readonly<{
+    validFrom: string | undefined;
+    validTo: string | undefined;
+  }>;
+}>;
+
+/**
+ * A projected window reduced to the two facts both normalization owners are
+ * required to agree on: WHICH BOUNDS EXIST, byte-exactly (an `undefined` bound
+ * and a `null` one are different answers), and WHICH INSTANT each names.
+ *
+ * The third fact — how the instant is RENDERED — is deliberately not compared,
+ * because it measurably differs today. This is a declared divergence tracked as
+ * issue #463, not an oversight, and it was found by this property:
+ *
+ *   postgres.js, `store.query().select((ctx) => ctx.p)`
+ *     meta.validFrom = "2026-08-09 10:36:26.73+00"     (raw driver text)
+ *   postgres.js, `store.nodes.Kind.getByIds(...)`
+ *     meta.validFrom = "2026-08-09T10:36:26.730Z"      (canonical ISO)
+ *
+ * The store path routes every metadata timestamp through `formatTimestamp`
+ * (`src/backend/row-mappers.ts`); the query path casts the driver's value
+ * straight through (`src/query/execution/result-mapper.ts`). better-sqlite3,
+ * libsql, PGlite and node-postgres all hand back a value that is already
+ * canonical, so the two owners agree there and the divergence is invisible —
+ * which is exactly why it needed a property run on EVERY driver to surface.
+ *
+ * Filed as #463 for its own fix: it is a pre-existing defect in the query path's
+ * normalization, not in the temporal contract this workstream changes, and
+ * making the query path canonical is an observable change to what a compiled
+ * query returns on postgres.js, so it needs its own changeset.
+ *
+ * What is NOT waived while #463 stands is the SHAPE of the divergence, which
+ * {@link assertBoundsAreStrings} pins: the query path asserts `as string | null`
+ * over a value it never normalizes, so a driver handing back `Date` objects
+ * would widen "different text for the same instant" into "a different type",
+ * silently — this canonicalizing comparison would not notice, and the pin is
+ * what does.
+ */
+function windowsById(rows: readonly WindowedRow[]) {
+  return rows
+    .map((row) => ({
+      id: row.id,
+      hasLowerBound: row.meta.validFrom !== undefined,
+      hasUpperBound: row.meta.validTo !== undefined,
+      lowerInstant: canonicalizeDatabaseTimestamp(row.meta.validFrom),
+      upperInstant: canonicalizeDatabaseTimestamp(row.meta.validTo),
+    }))
+    .toSorted((left, right) => (left.id < right.id ? -1 : 1));
+}
+
+/**
+ * Every present bound is a `string` at RUNTIME, on both owners.
+ *
+ * `result-mapper.ts` asserts `as string | null` over a driver value it never
+ * normalizes, so this is a check against a type lie, not a restatement of the
+ * type: on a PostgreSQL `TIMESTAMPTZ` column a driver is free to hand back a
+ * `Date`, and today none of the five in the matrix does. It is stated
+ * absolutely rather than as an equality between the two owners, because two
+ * owners that BOTH started returning `Date` would satisfy an equality.
+ */
+function assertBoundsAreStrings(
+  label: string,
+  rows: readonly WindowedRow[],
+): void {
+  const types = new Set<string>();
+  for (const row of rows) {
+    for (const bound of [row.meta.validFrom, row.meta.validTo]) {
+      if (bound !== undefined) types.add(typeof bound);
+    }
+  }
+  // Set, not per-row: a failure names the type, and every history stores at
+  // least one bound of each kind, so an empty set would be a harness bug.
+  expect({ label, types: [...types].toSorted() }).toEqual({
+    label,
+    types: ["string"],
+  });
+}
+
+/**
+ * P4': the window a compiled query projects names the same bounds, and the same
+ * instants, as the window a store read returns — `undefined` included.
+ * `valid_from` has two normalization owners and only one of them routes through
+ * `formatTimestamp`; see {@link windowsById} for what that costs today (#463)
+ * and {@link assertBoundsAreStrings} for the part of it that is still pinned.
+ */
+async function assertProjectionParity(
+  store: OracleStore,
+  facts: ScriptFacts,
+): Promise<void> {
+  const projected = await store
+    .query()
+    .from("OraclePerson", "p")
+    .temporal("includeTombstones")
+    .select((ctx) => ctx.p)
+    .execute();
+  const read = await store.nodes.OraclePerson.getByIds(
+    facts.nodeIds.map((id) => asNodeId<typeof OraclePerson>(id)),
+    { temporalMode: "includeTombstones" },
+  );
+  const readRows = read
+    .filter((node) => node !== undefined)
+    .map((node) => requireDefined(node, "node"));
+
+  assertBoundsAreStrings("compiled query", projected);
+  assertBoundsAreStrings("store read", readRows);
+  expect(windowsById(projected)).toStrictEqual(windowsById(readRows));
+}
+
+// ============================================================
+// The still-reproduces tests, one per declared gap
+// ============================================================
+
+type GapReproduction = (context: IntegrationTestContext) => Promise<void>;
+
+async function storedRow(
+  backend: GraphBackend,
+  store: OracleStore,
+  id: string,
+): Promise<LedgerRow> {
+  const ledger = await readTemporalLedger(
+    { backend, graphId: store.graphId },
+    { includeRecorded: false },
+  );
+  return requireDefined(
+    ledger.nodes.find((row) => row.id === id),
+    `stored row ${id}`,
+  );
+}
+
+/* eslint-disable vitest/no-standalone-expect -- these are the bodies of the
+   still-reproduces tests, registered one per KNOWN_CONTRACT_GAPS entry below.
+   Keying them off the gap table is what makes deleting an entry delete its test
+   (the `satisfies Record<KnownContractGapId, ...>` turns a leftover into a
+   compile error), and that structure is worth more than inlining the expects
+   into literal `it` bodies. */
+const GAP_REPRODUCTIONS = {
+  "born-ended-insert": async (context) => {
+    const backend = context.getBackend();
+    const store = freshStore(backend, "gap_insert");
+    await store.nodes.OraclePerson.create(
+      { name: "born ended" },
+      { id: "f1", validTo: FIRST_PAST_ANCHOR },
+    );
+    const row = await storedRow(backend, store, "f1");
+    // The gap: a bound nobody stated is stamped past the stated end.
+    expect(row.validTo).toBe(FIRST_PAST_ANCHOR);
+    expect(row.validFrom).toBeDefined();
+    expect(rowSatisfiesOrderedWindow(row)).toBe(false);
+    // ...so the row is readable at no coordinate at all.
+    for (const at of [
+      "2019-01-01T00:00:00.000Z",
+      FIRST_PAST_ANCHOR,
+      LAST_FUTURE_ANCHOR,
+    ]) {
+      const seen = await store.nodes.OraclePerson.getById(
+        asNodeId<typeof OraclePerson>("f1"),
+        { temporalMode: "asOf", asOf: at },
+      );
+      expect(seen).toBeUndefined();
+    }
+  },
+  "born-ended-on-tombstone": async (context) => {
+    const backend = context.getBackend();
+    const store = freshStore(backend, "gap_tombstone");
+    await store.nodes.OraclePerson.create({ name: "first" }, { id: "t1" });
+    await store.nodes.OraclePerson.delete(asNodeId<typeof OraclePerson>("t1"));
+    await store.nodes.OraclePerson.create(
+      { name: "born ended on tombstone" },
+      { id: "t1", validTo: FIRST_PAST_ANCHOR },
+    );
+    const row = await storedRow(backend, store, "t1");
+    expect(row.validTo).toBe(FIRST_PAST_ANCHOR);
+    expect(row.validFrom).toBeDefined();
+    expect(rowSatisfiesOrderedWindow(row)).toBe(false);
+  },
+  "resurrection-refusal-gap": async (context) => {
+    const store = freshStore(context.getBackend(), "gap_refusal");
+    for (const id of ["c1", "u1"]) {
+      await store.nodes.OraclePerson.create({ name: "first" }, { id });
+      await store.nodes.OraclePerson.delete(asNodeId<typeof OraclePerson>(id));
+    }
+    // One stated window, two entry points, two outcomes. This assertion says
+    // nothing about the STORED shape, so it survives the batch that changes the
+    // shape and dies only with the refusal itself.
+    await expect(
+      store.nodes.OraclePerson.create(
+        { name: "revived" },
+        { id: "c1", validTo: FIRST_PAST_ANCHOR },
+      ),
+    ).resolves.toBeDefined();
+
+    const refusal: unknown = await store.nodes.OraclePerson.upsertById(
+      "u1",
+      { name: "revived" },
+      { validTo: FIRST_PAST_ANCHOR },
+    ).then(
+      (node) => node,
+      (error: unknown) => error,
+    );
+    expect(refusal).toBeInstanceOf(ValidationError);
+    const issues = (refusal as ValidationError).details.issues;
+    expect(issues.map((issue) => issue.code)).toContain(
+      INVERTED_VALIDITY_WINDOW_CODE,
+    );
+  },
+} as const satisfies Record<KnownContractGapId, GapReproduction>;
+/* eslint-enable vitest/no-standalone-expect */
+
+// ============================================================
+// The recorded axis
+// ============================================================
+
+type ClockRow = Readonly<{ recorded_at: unknown; revision: unknown }>;
+
+async function readRecordedClock(
+  backend: GraphBackend,
+  graphId: string,
+): Promise<RecordedInstant | undefined> {
+  const schema = createSqlSchema(backend.tableNames);
+  const rows = await backend.execute<ClockRow>(
+    asCompiledRowsSql(sql`
+      SELECT revision, recorded_at
+      FROM ${schema.recordedClockTable}
+      WHERE graph_id = ${graphId}
+    `),
+  );
+  const row = rows[0];
+  if (row === undefined) return undefined;
+  return recordedInstantFromDriver(row.revision, row.recorded_at);
+}
+
+/**
+ * P5: the bitemporal grid. Two assertions per cell, because they exercise
+ * different halves of `compileTemporalFilter`: an explicit valid coordinate, and
+ * `current` mode pinned to the recorded instant (which must mean "valid-current
+ * as of THAT instant", not "as of the wall clock at read time").
+ */
+async function assertRecordedGridAgrees(
+  store: OracleStore,
+  ledger: TemporalLedger,
+  facts: ScriptFacts,
+  recorded: RecordedInstant,
+  coordinates: readonly Instant[],
+): Promise<void> {
+  const revision = recordedInstantRevision(recorded);
+  const ids = facts.nodeIds.map((id) => asNodeId<typeof OraclePerson>(id));
+
+  for (const at of coordinates) {
+    const seen = await store
+      .asOf(at)
+      .asOfRecorded(recorded)
+      .nodes.OraclePerson.getByIds(ids);
+    expect({ at, seen: nodeKeys(definedIds(seen)) }).toEqual({
+      at,
+      seen: visibleAt(ledger.recordedNodes, {
+        mode: "asOf",
+        asOf: at,
+        revision,
+      }),
+    });
+  }
+
+  const pinned = await store
+    .view({ mode: "current" })
+    .asOfRecorded(recorded)
+    .nodes.OraclePerson.getByIds(ids);
+  expect(nodeKeys(definedIds(pinned))).toEqual(
+    visibleAt(ledger.recordedNodes, {
+      mode: "asOf",
+      asOf: recordedInstantWallTime(recorded),
+      revision,
+    }),
+  );
+}
+
+// ============================================================
+// Registration
+// ============================================================
+
+export function registerTemporalOracleIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("Temporal oracle", () => {
+    it("brackets every write instant with the anchor lattice", () => {
+      // The generator's op SHAPES are defined by "past" and "future" relative to
+      // the run's own writes. If the wall clock ever leaves the bracket, say so
+      // here rather than through a mystifying property failure.
+      const now = new Date().toISOString();
+      expect(PAST_ANCHORS.every((anchor) => anchor < now)).toBe(true);
+      expect(FUTURE_ANCHORS.every((anchor) => anchor > now)).toBe(true);
+    });
+
+    describe("known contract gaps", () => {
+      for (const gap of KNOWN_CONTRACT_GAPS) {
+        // eslint-disable-next-line vitest/valid-title -- the title IS the gap entry's own `reproducedBy`, so deleting the entry deletes the test
+        it(gap.reproducedBy, async () => {
+          await GAP_REPRODUCTIONS[gap.id](context);
+        });
+      }
+    });
+
+    it("stores no window readable at no coordinate, and stamps no bound it did not judge (P1/P1b/P2)", async () => {
+      await fc.assert(
+        fc.asyncProperty(generatedHistoryArb(12), async (history) => {
+          const backend = context.getBackend();
+          const store = freshStore(backend, "ledger");
+          const facts = await runHistory(store, history);
+          const ledger = await readTemporalLedger(
+            { backend, graphId: store.graphId },
+            { includeRecorded: false },
+          );
+          assertOrderedWindows(ledger);
+          assertStampedBoundsAreNonEmpty(ledger, facts);
+          assertBoundProvenance(ledger, facts);
+        }),
+        oracleRunConfig(),
+      );
+    });
+
+    it("returns the same rows through the compiler, the collection filter, the in-memory matcher and the model (P3/P4')", async () => {
+      await fc.assert(
+        fc.asyncProperty(generatedHistoryArb(12), async (history) => {
+          const backend = context.getBackend();
+          const store = freshStore(backend, "visibility");
+          const facts = await runHistory(store, history);
+          const ledger = await readTemporalLedger(
+            { backend, graphId: store.graphId },
+            { includeRecorded: false },
+          );
+          for (const at of pickCoordinates(ledger, history.coordinatePicks)) {
+            await assertVisibilityAgreesAt(store, ledger, facts, at);
+          }
+          await assertProjectionParity(store, facts);
+        }),
+        oracleRunConfig(),
+      );
+    });
+
+    describe("bitemporal grid", () => {
+      beforeEach(async () => {
+        // Provisions the recorded relations over THIS test's backend. It must be
+        // a nested `beforeEach`, not `beforeAll`: the suite assigns its backend
+        // in its own `beforeEach`, and `createHistoryStore` throws while that is
+        // still undefined. Every run below then uses a BARE history store over
+        // these already-provisioned tables.
+        await context.createHistoryStore(
+          oracleGraph(nextRunGraphId("recorded_provisioning")),
+        );
+      });
+
+      it("pins a current-mode recorded read to the instant it was recorded, not the wall clock (P5)", async () => {
+        // The grid property below cannot reach this cell: its coordinates come
+        // off an anchor lattice decades away from the run's own instants, so
+        // "the recorded wall time" and "the wall clock at read time" pick the
+        // same rows however the current branch resolves its instant. The cell
+        // needs a row whose window ENDS between the two, which needs the clock.
+        //
+        // Only `Date` is faked (driver timers keep running), the shape
+        // `recorded-time.ts` already uses on every backend in this matrix.
+        vi.useFakeTimers({ toFake: ["Date"] });
+        try {
+          vi.setSystemTime(new Date("2000-06-01T12:00:00.000Z"));
+          const backend = context.getBackend();
+          const store = freshHistoryStore(backend, "recorded_pin");
+          const node = await store.nodes.OraclePerson.create(
+            { name: "valid when recorded" },
+            {
+              id: "pinned",
+              validFrom: "2000-01-01T00:00:00.000Z",
+              validTo: "2000-06-01T12:00:01.000Z",
+            },
+          );
+          const recorded = requireDefined(
+            await readRecordedClock(backend, store.graphId),
+            "recorded clock",
+          );
+          // Precondition: the row was genuinely valid-current when recorded.
+          expect(
+            recordedInstantWallTime(recorded) < "2000-06-01T12:00:01.000Z",
+          ).toBe(true);
+
+          // The wall clock moves past the row's end. A current-mode read pinned
+          // to the recorded instant must still reconstruct the row as it was
+          // THEN; a read that resolved "now" from the wall clock would drop it.
+          vi.setSystemTime(new Date("2000-06-01T12:00:02.000Z"));
+
+          const ledger = await readTemporalLedger(
+            { backend, graphId: store.graphId },
+            { includeRecorded: true },
+          );
+          const pinned = await store
+            .view({ mode: "current" })
+            .asOfRecorded(recorded)
+            .nodes.OraclePerson.getByIds([node.id]);
+          expect(nodeKeys(definedIds(pinned))).toEqual(
+            visibleAt(ledger.recordedNodes, {
+              mode: "asOf",
+              asOf: recordedInstantWallTime(recorded),
+              revision: recordedInstantRevision(recorded),
+            }),
+          );
+          expect(nodeKeys(definedIds(pinned))).toEqual([
+            rowKeyOf({ kind: NODE_KIND, id: "pinned" }),
+          ]);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("agrees with the model on the asOfRecorded x asOf grid, and stores no unreadable window on the recorded relations (P5/P1/P1b)", async () => {
+        await fc.assert(
+          fc.asyncProperty(generatedHistoryArb(6), async (history) => {
+            const backend = context.getBackend();
+            const store = freshHistoryStore(backend, "recorded");
+            const revisions: RecordedInstant[] = [];
+            const facts = await runHistory(store, history, async () => {
+              const instant = await readRecordedClock(backend, store.graphId);
+              if (instant !== undefined) revisions.push(instant);
+            });
+            const ledger = await readTemporalLedger(
+              { backend, graphId: store.graphId },
+              { includeRecorded: true },
+            );
+            // I1/I1b over the RECORDED relations, which no other property can
+            // reach: `recorded_nodes` / `recorded_edges` are written by their
+            // own column binder and only a history store has any. Asserted
+            // here rather than in P5's equality below, because that equality
+            // derives its expectation from these same rows and so cannot see a
+            // storage violation in them.
+            assertOrderedWindows(ledger);
+            assertStampedBoundsAreNonEmpty(ledger, facts);
+            const coordinates = pickCoordinates(
+              ledger,
+              history.coordinatePicks.slice(0, 3),
+            );
+            const sampled = new Map(
+              revisions.map((instant) => [
+                recordedInstantRevision(instant),
+                instant,
+              ]),
+            );
+            for (const recorded of sampled.values()) {
+              await assertRecordedGridAgrees(
+                store,
+                ledger,
+                facts,
+                recorded,
+                coordinates,
+              );
+            }
+          }),
+          oracleRunConfig(),
+        );
+      });
+    });
+
+    it("round-trips every stored window through interchange, NULL included (P6)", async () => {
+      await fc.assert(
+        fc.asyncProperty(generatedHistoryArb(8), async (history) => {
+          const backend = context.getBackend();
+          const source = freshStore(backend, "roundtrip_source");
+          await runHistory(source, history);
+          const exported = await exportGraph(source, { includeTemporal: true });
+
+          // Precondition, not decoration: `validFrom` is emitted only under
+          // `includeTemporal`, so without this the comparison below could be
+          // vacuously true.
+          expect(exported.nodes.some((node) => node.validFrom === null)).toBe(
+            true,
+          );
+          expect(
+            exported.nodes.some((node) => typeof node.validFrom === "string"),
+          ).toBe(true);
+
+          const target = freshStore(backend, "roundtrip_target");
+          await importGraph(target, exported, { onConflict: "error" });
+          const targetLedger = await readTemporalLedger(
+            { backend, graphId: target.graphId },
+            { includeRecorded: false },
+          );
+          const stored = new Map(
+            targetLedger.nodes.map((row) => [row.id, row]),
+          );
+          const roundTripped = exported.nodes.map((node) => {
+            const row = requireDefined(
+              stored.get(node.id),
+              `round-tripped ${node.id}`,
+            );
+            return {
+              id: node.id,
+              validFrom: row.validFrom,
+              validTo: row.validTo,
+            };
+          });
+          expect(roundTripped).toStrictEqual(
+            exported.nodes.map((node) => ({
+              id: node.id,
+              validFrom: node.validFrom ?? undefined,
+              validTo: node.validTo,
+            })),
+          );
+        }),
+        oracleRunConfig(),
+      );
+    });
+
+    describe("merge window laws (P7)", () => {
+      it("resolves an end-claim set independently of its order", () => {
+        fc.assert(
+          fc.property(
+            fc.array(
+              fc.record({
+                branchId: fc.constantFrom("a", "b", "c"),
+                validTo: fc.constantFrom(...ANCHORS),
+              }),
+              { minLength: 1, maxLength: 6 },
+            ),
+            fc.option(fc.constantFrom("a", "b", "c"), { nil: undefined }),
+            (rawClaims, rawPreferred) => {
+              const claims = rawClaims.map((claim) => ({
+                branchId: asBranchId(claim.branchId),
+                validTo: claim.validTo,
+              }));
+              const preferred: BranchId | undefined =
+                rawPreferred === undefined ? undefined : (
+                  asBranchId(rawPreferred)
+                );
+              expect(resolveEndClaims(claims.toReversed(), preferred)).toBe(
+                resolveEndClaims(claims, preferred),
+              );
+            },
+          ),
+          { numRuns: 100 },
+        );
+      });
+
+      it("lets a deletion absorb an ending and reports an unapplicable validFrom divergence", () => {
+        const branchId = asBranchId("fork");
+        const windowedNode = (
+          id: string,
+          fork: Readonly<{ validFrom: Instant; validTo?: Instant }>,
+        ) => ({
+          branchId,
+          node: {
+            id: asNodeId<typeof OraclePerson>(id),
+            kind: NODE_KIND,
+            base: { validFrom: FIRST_PAST_ANCHOR, validTo: undefined },
+            fork: { validFrom: fork.validFrom, validTo: fork.validTo },
+          },
+        });
+
+        const resolution = resolveValidWindows(
+          {
+            windowedNodes: [
+              windowedNode("absorbed", {
+                validFrom: FIRST_PAST_ANCHOR,
+                validTo: LAST_FUTURE_ANCHOR,
+              }),
+              windowedNode("diverged", { validFrom: pastAnchor(1) }),
+            ],
+            windowedEdges: [],
+          },
+          new Set([mergeKey(NODE_KIND, "absorbed")]),
+          new Set(),
+        );
+
+        // Deletion absorbs the ending: the row the merge finally deletes gets no
+        // end to write, and no conflict.
+        expect([...resolution.nodeEnds.keys()]).toEqual([]);
+        // A `validFrom` divergence the commit cannot apply is REPORTED.
+        expect(
+          resolution.dropped.map((item) => ({
+            id: String(item.id),
+            reason: item.reason,
+          })),
+        ).toEqual([
+          { id: "diverged", reason: WINDOW_NOT_APPLICABLE_DROP_REASON },
+        ]);
+      });
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/temporal-oracle.ts
+++ b/packages/typegraph/tests/backends/integration/temporal-oracle.ts
@@ -82,6 +82,7 @@ import {
 import { mergeKey } from "../../../src/graph-merge/node-key";
 import { asBranchId, type BranchId } from "../../../src/graph-merge/types";
 import {
+  type EndClaim,
   resolveEndClaims,
   resolveValidWindows,
   WINDOW_NOT_APPLICABLE_DROP_REASON,
@@ -1551,7 +1552,13 @@ export function registerTemporalOracleIntegrationTests(
             fc.array(
               fc.record({
                 branchId: fc.constantFrom("a", "b", "c"),
-                validTo: fc.constantFrom(...ANCHORS),
+                change: fc.oneof(
+                  fc.record({
+                    kind: fc.constant("set"),
+                    validTo: fc.constantFrom(...ANCHORS),
+                  }),
+                  fc.constant({ kind: "clear" } as const),
+                ),
               }),
               { minLength: 1, maxLength: 6 },
             ),
@@ -1559,15 +1566,15 @@ export function registerTemporalOracleIntegrationTests(
             (rawClaims, rawPreferred) => {
               const claims = rawClaims.map((claim) => ({
                 branchId: asBranchId(claim.branchId),
-                validTo: claim.validTo,
-              }));
+                change: claim.change,
+              })) satisfies readonly EndClaim[];
               const preferred: BranchId | undefined =
                 rawPreferred === undefined ? undefined : (
                   asBranchId(rawPreferred)
                 );
-              expect(resolveEndClaims(claims.toReversed(), preferred)).toBe(
-                resolveEndClaims(claims, preferred),
-              );
+              expect(
+                resolveEndClaims(claims.toReversed(), preferred),
+              ).toStrictEqual(resolveEndClaims(claims, preferred));
             },
           ),
           { numRuns: 100 },

--- a/packages/typegraph/tests/backends/integration/temporal.ts
+++ b/packages/typegraph/tests/backends/integration/temporal.ts
@@ -307,6 +307,41 @@ export function registerTemporalIntegrationTests(
       expect(pastNode).toBeUndefined();
     });
 
+    it("still stamps the create timestamp when a FUTURE validTo is stated alone", async () => {
+      // The sibling of the #240 test above, and the standing guard against the
+      // naive reading of #407. A lone `validTo` leaves the row with no lower
+      // bound only when stamping one would make the window readable at no
+      // coordinate — that is, when the end is at or before the write instant. A
+      // SCHEDULED end means "valid from now until then", so the create instant
+      // is still stamped and the row is still invisible before it existed. A
+      // rule that dropped the bound whenever a `validTo` was named would make
+      // this row visible at `asOf(2020)`, widening a window the caller narrowed.
+      const { PAST } = TEMPORAL_ANCHORS;
+      const scheduledEnd = new Date(Date.now() + 3_600_000).toISOString();
+      const store = context.getStore();
+
+      const alice = await store.nodes.Person.create(
+        { name: "Alice" },
+        { validTo: scheduledEnd },
+      );
+
+      expect(alice.meta.validFrom).toBeDefined();
+      expect(alice.meta.validTo).toBe(scheduledEnd);
+
+      const pastNode = await store.nodes.Person.getById(alice.id, {
+        temporalMode: "asOf",
+        asOf: PAST,
+      });
+      expect(pastNode).toBeUndefined();
+
+      // ...and it is current right now, so the stamped bound is a real bound
+      // rather than a value that happens to sort before every coordinate.
+      const currentNode = await store.nodes.Person.getById(alice.id, {
+        temporalMode: "current",
+      });
+      expect(currentNode?.id).toBe(alice.id);
+    });
+
     it("defaults an omitted edge validFrom to the create timestamp, even when both endpoints predate it", async () => {
       // Regression test for #240's "test gap": pair the implicit-validFrom
       // edge with endpoints that are ALREADY valid at the historical asOf,

--- a/packages/typegraph/tests/backends/integration/trusted-import.ts
+++ b/packages/typegraph/tests/backends/integration/trusted-import.ts
@@ -39,6 +39,10 @@ const graph = defineGraph({
 
 const SPECIAL_NAME = 'Alice "quoted" \\ path, {braces}\nand newline';
 
+/** A historical end, so a row stating it alone is BORN ALREADY ENDED. */
+const ENDED_AT = "2021-01-01T00:00:00.000Z";
+const BEFORE_ENDED_AT = "2020-01-01T00:00:00.000Z";
+
 function payload(): GraphData {
   return {
     formatVersion: FORMAT_VERSION,
@@ -106,6 +110,48 @@ export function registerTrustedImportIntegrationTests(
       );
       expect(alice?.name).toBe(isSupported ? SPECIAL_NAME : undefined);
       expect(edge?.since).toBe(isSupported ? 2020 : undefined);
+    });
+
+    it("stores no lower bound for a born-ended streamed row", async () => {
+      // Trusted import bypasses the Drizzle insert builders entirely — it binds
+      // its own INSERT per dialect for throughput — so it is the one write path
+      // that can keep minting rows readable at no coordinate after the builders
+      // stop. It carried a private copy of the lower-bound resolver until #407;
+      // this is the only test that fails if that copy comes back.
+      if (context.getStore().backend.trustedImport === undefined) return;
+      const store = await context.createStore(graph);
+
+      const data = payload();
+      await trustedImportGraph(store, {
+        ...data,
+        nodes: data.nodes.map((node) =>
+          node.id === "alice" ? { ...node, validTo: ENDED_AT } : node,
+        ),
+        edges: data.edges.map((edge) => ({ ...edge, validTo: ENDED_AT })),
+      });
+
+      const alice = await store.nodes.CrossBackendTrustedPerson.getById(
+        asNodeId<typeof TrustedPerson>("alice"),
+        { temporalMode: "includeEnded" },
+      );
+      expect(alice?.meta.validFrom).toBeUndefined();
+      expect(alice?.meta.validTo).toBe(ENDED_AT);
+
+      const edge = await store.edges.crossBackendTrustedKnows.getById(
+        asEdgeId<typeof TrustedKnows>("alice-knows-bob"),
+        { temporalMode: "includeEnded" },
+      );
+      expect(edge?.meta.validFrom).toBeUndefined();
+      expect(edge?.meta.validTo).toBe(ENDED_AT);
+
+      // The point of storing no bound rather than the write instant: the row
+      // reads back before its end instead of at no coordinate at all.
+      await expect(
+        store.nodes.CrossBackendTrustedPerson.getById(
+          asNodeId<typeof TrustedPerson>("alice"),
+          { temporalMode: "asOf", asOf: BEFORE_ENDED_AT },
+        ),
+      ).resolves.toBeDefined();
     });
 
     it("rolls back earlier chunks when the stream fails", async () => {

--- a/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
+++ b/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
@@ -12,12 +12,14 @@ import { describe, expect, it } from "vitest";
 import {
   asEdgeId,
   asNodeId,
+  createStore,
   type EdgeId,
   IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
   type Node,
   type NodeId,
   type Store,
 } from "../../../src";
+import { createBackendOverlay } from "../../../src/backend/types";
 import {
   FORMAT_VERSION,
   type GraphData,
@@ -26,7 +28,10 @@ import {
 } from "../../../src/interchange";
 import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
 import { requireDefined } from "../../../src/utils/presence";
-import { expectImmutableLowerBoundRefusal } from "../../test-utils";
+import {
+  expectImmutableLowerBoundRefusal,
+  expectInvertedWindowRefusal,
+} from "../../test-utils";
 import { integrationTestGraph } from "./fixtures";
 import { type IntegrationTestContext } from "./test-context";
 
@@ -61,6 +66,24 @@ function seedPerson(
   id: string,
 ): Promise<PersonNode> {
   return store.nodes.Person.upsertById(id, { name: "Win", age: 1 });
+}
+
+/**
+ * Seeds a LIVE Person with NO lower bound: born already ended, which is the
+ * only write shape that reaches that state without interchange. The absence is
+ * asserted here rather than in each case, so a regression in the born-ended
+ * contract fails the seed instead of leaving the cases below vacuously green.
+ */
+async function seedBornEndedPerson(
+  store: LowerBoundTestStore,
+  id: string,
+): Promise<PersonNode> {
+  const created = await store.nodes.Person.create(
+    { name: "Win", age: 1 },
+    { id, validTo: REVIVED_VALID_TO },
+  );
+  expect(created.meta.validFrom).toBeUndefined();
+  return created;
 }
 
 /** An interchange document carrying exactly the rows a case is about. */
@@ -616,6 +639,143 @@ export function registerValidityLowerBoundIntegrationTests(
           expect(storedEdge?.since).toBe("first");
         }
       });
+    });
+  });
+
+  /**
+   * The ABSENT lower bound, which the born-ended contract made an ordinary shape
+   * for a live row rather than an interchange-only curiosity. "No bound" is a
+   * reading of the row like any other: a write whose verdict depends on it must
+   * assert it, and a caller who states one against it is stating one the write
+   * will not apply.
+   */
+  describe("a live row with no lower bound", () => {
+    /** Where the concurrent writer puts the bound the update never read. */
+    const RECREATED_VALID_FROM = REVIVED_VALID_FROM;
+
+    it("accepts a lone validTo against the absent bound", async () => {
+      // Nothing to invert against, so the end is free to move — including into
+      // the future, which makes the row open-left AND current.
+      const store = await context.createStore(integrationTestGraph, {});
+      const id = "vlb-born-ended-accepts";
+      await seedBornEndedPerson(store, id);
+
+      const updated = await store.nodes.Person.update(
+        personId(id),
+        {},
+        { validTo: FUTURE_VALID_TO },
+      );
+
+      expect(updated.meta.validFrom).toBeUndefined();
+      expect(canonicalizeDatabaseTimestamp(updated.meta.validTo)).toBe(
+        FUTURE_VALID_TO,
+      );
+      const current = await store.nodes.Person.getById(personId(id));
+      expect(current?.meta.validFrom).toBeUndefined();
+    });
+
+    it("refuses a stated validFrom on the live row, because no bound is there to restate", async () => {
+      // The row has nothing to match, so every stated bound differs from what it
+      // holds. Accepting one and dropping it would be the API lying about a
+      // window the caller named — the same refusal a row WITH a bound gets, on
+      // the branch where the stored value is absent.
+      const store = await context.createStore(integrationTestGraph, {});
+      const id = "vlb-born-ended-refuses";
+      await seedBornEndedPerson(store, id);
+
+      await expectImmutableLowerBoundRefusal(
+        store.nodes.Person.upsertById(
+          id,
+          { name: "Win", age: 2 },
+          { validFrom: FOREIGN_VALID_FROM },
+        ),
+      );
+
+      // `includeEnded`: the row is live but its window has closed, which is the
+      // whole shape under test.
+      const stored = await store.nodes.Person.getById(personId(id), {
+        temporalMode: "includeEnded",
+      });
+      expect(stored?.age).toBe(1);
+      expect(stored?.meta.validFrom).toBeUndefined();
+    });
+
+    it("fences the lone validTo on IS NULL, so a row that gained a bound between the probe and the write is not written over", async () => {
+      // The verdict READ "this row has no lower bound" and accepted the end on
+      // that basis, so the write must assert it. A peer that deletes and
+      // resurrects the row with a real bound between the two statements changes
+      // the answer, and the fenced UPDATE has to match nothing rather than
+      // persist an end below a start nobody judged it against.
+      //
+      // Driven deterministically at the operations/backend boundary, on the
+      // TRANSACTION target: the write runs against the backend
+      // `runInWriteTransaction` yields, not against the outer object. The peer's
+      // two statements run on that same target, so they need no second
+      // connection and cannot deadlock on any driver in the matrix — and they
+      // share this write's fate, so a refusal rolls them back too. That is why
+      // the stored-state assertion below is "the row is untouched" rather than
+      // "the peer's bound survived": what the fence has to prevent is this
+      // caller's `valid_to` landing under a `valid_from` nobody judged it
+      // against, and unfenced it commits exactly that.
+      const backend = context.getBackend();
+      const id = "vlb-born-ended-fenced";
+      let interceptions = 0;
+
+      const racingBackend = createBackendOverlay(backend, {
+        transaction: (fn, options) =>
+          backend.transaction((transactionTarget) => {
+            const racingTarget = createBackendOverlay(transactionTarget, {
+              updateNode: async (params) => {
+                if (
+                  params.id === id &&
+                  params.clearDeleted !== true &&
+                  interceptions === 0
+                ) {
+                  interceptions += 1;
+                  await transactionTarget.deleteNode({
+                    graphId: params.graphId,
+                    kind: params.kind,
+                    id: params.id,
+                  });
+                  await transactionTarget.updateNode({
+                    graphId: params.graphId,
+                    kind: params.kind,
+                    id: params.id,
+                    props: { name: "Peer", age: 9 },
+                    clearDeleted: true,
+                    validFrom: RECREATED_VALID_FROM,
+                  });
+                }
+                return transactionTarget.updateNode(params);
+              },
+            });
+            return fn(racingTarget);
+          }, options),
+      });
+
+      const store = createStore(integrationTestGraph, racingBackend);
+      await seedBornEndedPerson(store, id);
+
+      // `FOREIGN_VALID_FROM` is before the bound the peer installs, so the
+      // update the fence forces this caller to re-derive is one the row's real
+      // window refuses. Unfenced, it would have committed `valid_to` below
+      // `valid_from` — a row readable at no coordinate.
+      await expectInvertedWindowRefusal(
+        store.nodes.Person.update(
+          personId(id),
+          {},
+          { validTo: FOREIGN_VALID_FROM },
+        ),
+      );
+      expect(interceptions).toBe(1);
+
+      const stored = await store.nodes.Person.getById(personId(id), {
+        temporalMode: "includeEnded",
+      });
+      expect(stored?.meta.validFrom).toBeUndefined();
+      expect(canonicalizeDatabaseTimestamp(stored?.meta.validTo)).toBe(
+        REVIVED_VALID_TO,
+      );
     });
   });
 }

--- a/packages/typegraph/tests/backends/postgres/repair-validity-windows.test.ts
+++ b/packages/typegraph/tests/backends/postgres/repair-validity-windows.test.ts
@@ -1,0 +1,284 @@
+/**
+ * PostgreSQL parity for the inverted-validity-window repair (design §C, T7).
+ *
+ * The predicate text is identical on both dialects; the *semantics* are not,
+ * and that is why this suite exists rather than a shared cross-backend one:
+ *
+ * - SQLite stores the bounds as `TEXT` and compares them lexicographically, so
+ *   the repair carries a canonicality `GLOB` guard and counts the rows it could
+ *   not classify.
+ * - PostgreSQL stores `timestamptz`, where `>` is always a chronological
+ *   compare. A scanned relation therefore reports `nonCanonical: 0` — never
+ *   `undefined`, which stays reserved for "not scanned" on both dialects — and
+ *   `apply` has nothing to refuse.
+ * - `report` opens a `READ ONLY` transaction, which only this engine can be
+ *   asked to confirm (`SHOW transaction_read_only`). That makes "report writes
+ *   nothing" enforced here rather than merely compiled; the SQLite suite pins
+ *   the same decision at the seam, where `BEGIN` vs `BEGIN IMMEDIATE` is not
+ *   observable from a single connection.
+ *
+ * Skipped automatically when `POSTGRES_URL` is unset.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { repairInvertedValidityWindows } from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import type {
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../../../src/backend/types";
+import { sql } from "../../../src/query/sql-fragment";
+import { asCompiledRowsSql } from "../../../src/query/sql-intent";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
+import { runServerSuiteSetup } from "./server-suite-setup";
+
+const DATABASE_URL = await provisionPostgresTestDatabase(import.meta.url);
+
+const GRAPH_ID = "pg_repair_windows";
+const EARLY = "2020-01-01T00:00:00.000Z";
+const MIDDLE = "2022-01-01T00:00:00.000Z";
+const LATE = "2024-01-01T00:00:00.000Z";
+
+let pool: Pool | undefined;
+
+/**
+ * The suite is gated on `POSTGRES_URL` and its setup fails rather than skips,
+ * so an unpublished handle means setup reported success without publishing one.
+ */
+function requirePool(): Pool {
+  if (pool === undefined) {
+    throw new Error(
+      "repair-validity-windows: PostgreSQL connections are unavailable after setup reported success.",
+    );
+  }
+  return pool;
+}
+
+beforeAll(async () => {
+  if (!process.env["POSTGRES_URL"]) return;
+  const candidate = new Pool({
+    connectionString: DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+    max: 4,
+  });
+  await runServerSuiteSetup(
+    "repair-validity-windows",
+    [candidate],
+    async () => {
+      await candidate.query("SELECT 1");
+      await candidate.query(generatePostgresMigrationSQL());
+      pool = candidate;
+    },
+  );
+});
+
+afterAll(async () => {
+  await pool?.end();
+});
+
+beforeEach(async () => {
+  if (pool === undefined) return;
+  await pool.query(
+    "TRUNCATE typegraph_recorded_nodes, typegraph_edges, typegraph_nodes",
+  );
+});
+
+/**
+ * Rows written straight into the relation: the store API can no longer produce
+ * an inverted window, which is the whole reason the repair exists.
+ */
+async function seedRows(target: Pool): Promise<void> {
+  await target.query(
+    `INSERT INTO typegraph_nodes (
+       graph_id, kind, id, props, version, valid_from, valid_to,
+       created_at, updated_at
+     ) VALUES
+       ($1, 'Person', 'inverted',  '{"name":"inverted"}',  1, $4, $2, $2, $2),
+       ($1, 'Person', 'zeroWidth', '{"name":"zeroWidth"}', 1, $3, $3, $2, $2),
+       ($1, 'Person', 'ordered',   '{"name":"ordered"}',   1, $2, $4, $2, $2),
+       ($1, 'Person', 'openLeft',  '{"name":"openLeft"}',  1, NULL, $4, $2, $2)`,
+    [GRAPH_ID, EARLY, MIDDLE, LATE],
+  );
+  await target.query(
+    `INSERT INTO typegraph_recorded_nodes (
+       history_id, graph_id, kind, id, props, version, valid_from, valid_to,
+       created_at, updated_at, recorded_from, recorded_to, op, meta
+     ) VALUES
+       ('h1', $1, 'Person', 'inverted', '{"name":"inverted"}', 1, $3, $2,
+        $2, $2, 1, 2, 'create', '{}')`,
+    [GRAPH_ID, EARLY, LATE],
+  );
+}
+
+type StoredWindow = Readonly<{
+  validFrom: string | undefined;
+  validTo: string | undefined;
+}>;
+
+/** `timestamptz` reaches the driver as a `Date`; compare instants, not renderings. */
+function instant(value: unknown): string | undefined {
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" ? new Date(value).toISOString() : undefined;
+}
+
+async function readWindow(
+  target: Pool,
+  table: string,
+  id: string,
+): Promise<StoredWindow> {
+  const result = await target.query<Readonly<Record<string, unknown>>>(
+    `SELECT valid_from, valid_to FROM ${table} WHERE id = $1`,
+    [id],
+  );
+  const row = result.rows[0] ?? {};
+  return {
+    validFrom: instant(row["valid_from"]),
+    validTo: instant(row["valid_to"]),
+  };
+}
+
+function backendFor(target: Pool): GraphBackend {
+  return createPostgresBackend(drizzle(target));
+}
+
+describe.runIf(process.env["POSTGRES_URL"])(
+  "repairInvertedValidityWindows on PostgreSQL",
+  () => {
+    it("reports without writing, and never reports a scanned relation as unclassified", async () => {
+      const target = requirePool();
+      await seedRows(target);
+      const backend = backendFor(target);
+
+      const report = await repairInvertedValidityWindows({
+        backend,
+        graphId: GRAPH_ID,
+        relations: "live-and-recorded",
+        mode: "report",
+      });
+
+      expect(report.counts.nodes).toBe(1);
+      expect(report.counts.recordedNodes).toBe(1);
+      expect(report.atomic).toBe(true);
+      // timestamptz: every stored value compares chronologically, so a scanned
+      // relation is classified in full. `undefined` stays reserved for "not
+      // scanned" — which is what `edges` would be under `relations: "live"`.
+      expect(report.nonCanonical).toEqual({
+        nodes: 0,
+        edges: 0,
+        recordedNodes: 0,
+        recordedEdges: 0,
+      });
+      expect(await readWindow(target, "typegraph_nodes", "inverted")).toEqual({
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+    });
+
+    it("scans inside a READ ONLY transaction and applies inside a writing one", async () => {
+      const target = requirePool();
+      await seedRows(target);
+      const raw = backendFor(target);
+      const engineVerdicts: (string | undefined)[] = [];
+      // The engine's own answer, not the library's. `report` writes nothing
+      // because PostgreSQL would refuse to let it, which is a stronger claim
+      // than "no UPDATE was compiled" — and it is the reason the docs let an
+      // operator diagnose against a live store without quiescing writers.
+      const backend: GraphBackend = {
+        ...raw,
+        transaction: async <T>(
+          fn: (tx: TransactionBackend) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> =>
+          raw.transaction(async (tx) => {
+            const rows = await tx.execute<
+              Readonly<{ transaction_read_only: unknown }>
+            >(asCompiledRowsSql(sql`SHOW transaction_read_only`));
+            engineVerdicts.push(rows[0]?.transaction_read_only as string);
+            return fn(tx);
+          }, options),
+      };
+
+      await repairInvertedValidityWindows({
+        backend,
+        graphId: GRAPH_ID,
+        relations: "live",
+        mode: "report",
+      });
+      await repairInvertedValidityWindows({
+        backend,
+        graphId: GRAPH_ID,
+        relations: "live",
+        mode: "apply",
+      });
+
+      expect(engineVerdicts).toEqual(["on", "off"]);
+    });
+
+    it("repairs only inverted rows, on both axes, and converges", async () => {
+      const target = requirePool();
+      await seedRows(target);
+      const backend = backendFor(target);
+
+      const applied = await repairInvertedValidityWindows({
+        backend,
+        graphId: GRAPH_ID,
+        relations: "live-and-recorded",
+        mode: "apply",
+      });
+      expect(applied.counts.nodes).toBe(1);
+      expect(applied.counts.recordedNodes).toBe(1);
+
+      expect(await readWindow(target, "typegraph_nodes", "inverted")).toEqual({
+        validFrom: undefined,
+        validTo: EARLY,
+      });
+      expect(
+        await readWindow(target, "typegraph_recorded_nodes", "inverted"),
+      ).toEqual({ validFrom: undefined, validTo: EARLY });
+      // A stated zero-width window is legal; the repair does not second-guess it.
+      expect(await readWindow(target, "typegraph_nodes", "zeroWidth")).toEqual({
+        validFrom: MIDDLE,
+        validTo: MIDDLE,
+      });
+      expect(await readWindow(target, "typegraph_nodes", "ordered")).toEqual({
+        validFrom: EARLY,
+        validTo: LATE,
+      });
+
+      const second = await repairInvertedValidityWindows({
+        backend,
+        graphId: GRAPH_ID,
+        relations: "live-and-recorded",
+        mode: "apply",
+      });
+      expect(second.counts).toEqual({
+        nodes: 0,
+        edges: 0,
+        recordedNodes: 0,
+        recordedEdges: 0,
+      });
+    });
+
+    it("scopes to one graph", async () => {
+      const target = requirePool();
+      await seedRows(target);
+      const backend = backendFor(target);
+
+      const report = await repairInvertedValidityWindows({
+        backend,
+        graphId: "another_graph",
+        relations: "live",
+        mode: "apply",
+      });
+      expect(report.counts.nodes).toBe(0);
+      expect(await readWindow(target, "typegraph_nodes", "inverted")).toEqual({
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+    });
+  },
+);

--- a/packages/typegraph/tests/collection-api.test.ts
+++ b/packages/typegraph/tests/collection-api.test.ts
@@ -950,26 +950,33 @@ describe("Bulk Operations (SQLite)", () => {
       expect(resurrected.meta.deletedAt).toBeUndefined();
     });
 
-    it("refuses a lone past validTo on a resurrecting upsert", async () => {
-      // A resurrection resets the lower bound to the write instant when no
-      // validFrom accompanies it, so a lone historical validTo would be born
-      // INVERTED — permanently invisible at every coordinate. The effective
-      // window is validated instead of silently persisting the corruption.
+    it("stores no lower bound for a lone past validTo on a resurrecting upsert", async () => {
+      // A resurrection RESETS the window, so with no `validFrom` accompanying a
+      // historical `validTo` there is no bound to invert against: the write
+      // stamps none, and the row means "ended at T, start unknown" — the same
+      // stored shape a create reaches for the same stated window.
+      //
+      // This case used to REFUSE, on the reasoning that the reset bound was the
+      // write instant. The write no longer chooses an instant that would leave
+      // the row readable at no coordinate, so there is nothing left to refuse.
       const person = await store.nodes.Person.createFromRecord(
         { name: "Windowed" },
         { id: "person-window" },
       );
       await store.nodes.Person.delete(person.id);
 
-      await expect(
-        store.nodes.Person.upsertByIdFromRecord(
-          "person-window",
-          { name: "Windowed Reborn" },
-          { validTo: "2021-01-01T00:00:00.000Z" },
-        ),
-      ).rejects.toThrow(ValidationError);
+      const reborn = await store.nodes.Person.upsertByIdFromRecord(
+        "person-window",
+        { name: "Windowed Reborn" },
+        { validTo: "2021-01-01T00:00:00.000Z" },
+      );
+      expect(reborn.meta.validFrom).toBeUndefined();
+      expect(reborn.meta.validTo).toBe("2021-01-01T00:00:00.000Z");
 
-      // The full historical window is the sanctioned form.
+      // Naming the full historical window still stores it verbatim. Tombstoned
+      // again first: the accepted upsert above left the row LIVE, and a live
+      // row's lower bound is history — only a resurrection writes one.
+      await store.nodes.Person.delete(person.id);
       const resurrected = await store.nodes.Person.upsertByIdFromRecord(
         "person-window",
         { name: "Windowed Reborn" },
@@ -979,6 +986,7 @@ describe("Bulk Operations (SQLite)", () => {
         },
       );
       expect(resurrected.id).toBe("person-window");
+      expect(resurrected.meta.validFrom).toBe("2020-01-01T00:00:00.000Z");
     });
 
     it("rejects invalid data at runtime via Zod validation", async () => {

--- a/packages/typegraph/tests/create-round-trips.test.ts
+++ b/packages/typegraph/tests/create-round-trips.test.ts
@@ -8,6 +8,7 @@ import {
   type GraphBackend,
   type TransactionBackend,
 } from "../src";
+import type { UpdateNodeParams } from "../src/backend/types";
 import { type SqlFragment } from "../src/query/sql-fragment";
 import {
   createInitializedStore,
@@ -43,6 +44,7 @@ const identityGraph = defineGraph({
 });
 
 const PEER_RESURRECTION_VALID_FROM = "2024-01-01T00:00:00.000Z";
+const RACED_RESURRECTION_VALID_FROM = "2023-06-01T00:00:00.000Z";
 
 type ReadCounts = Readonly<{
   /** `getNode` probes issued for the node being created. */
@@ -174,6 +176,82 @@ function peerResurrectionBackend(targetId: string): GraphBackend {
   } satisfies GraphBackend;
 }
 
+/**
+ * A backend whose transaction target loses TWO races, in the one order that
+ * makes a resurrecting upsert's `clearDeleted` statement match a row its own
+ * read judged LIVE:
+ *
+ *  1. a peer resurrects the tombstone between the collection's probe and
+ *     `performNodeUpdate`'s read, stamping the window itself, so that read finds
+ *     a live row and the window guard measures the row's STORED lower bound;
+ *  2. the peer re-tombstones it before the UPDATE, so `deleted_at IS NOT NULL`
+ *     matches after all instead of affecting zero rows and falling through to
+ *     the resurrection recovery.
+ *
+ * Both peer writes are real calls against the same target — the state
+ * transitions a competitor would commit, not a masked read.
+ */
+function resurrectThenRetombstoneBackend(targetId: string): GraphBackend {
+  const base = createTestBackend();
+  return {
+    ...base,
+    transaction: (fn, options) =>
+      base.transaction((transactionTarget) => {
+        let peerResurrected = false;
+        let peerReTombstoned = false;
+        const racingTarget = new Proxy(transactionTarget, {
+          get(source, property, receiver) {
+            const value: unknown = Reflect.get(source, property, receiver);
+            if (typeof value !== "function") return value;
+            if (property === "getNode") {
+              const getNode = value as TransactionBackend["getNode"];
+              return async (graphId: string, kind: string, id: string) => {
+                const row = await getNode(graphId, kind, id);
+                if (
+                  peerResurrected ||
+                  id !== targetId ||
+                  row?.deleted_at === undefined
+                ) {
+                  return row;
+                }
+                peerResurrected = true;
+                await transactionTarget.updateNode({
+                  graphId,
+                  kind,
+                  id,
+                  props: { name: "Peer" },
+                  clearDeleted: true,
+                  validFrom: RACED_RESURRECTION_VALID_FROM,
+                });
+                return getNode(graphId, kind, id);
+              };
+            }
+            if (property === "updateNode") {
+              const updateNode = value as TransactionBackend["updateNode"];
+              return async (params: UpdateNodeParams) => {
+                if (
+                  !peerReTombstoned &&
+                  params.id === targetId &&
+                  params.clearDeleted === true
+                ) {
+                  peerReTombstoned = true;
+                  await transactionTarget.deleteNode({
+                    graphId: params.graphId,
+                    kind: params.kind,
+                    id: params.id,
+                  });
+                }
+                return updateNode(params);
+              };
+            }
+            return value;
+          },
+        });
+        return fn(racingTarget);
+      }, options),
+  } satisfies GraphBackend;
+}
+
 describe("create-path round trips", () => {
   it("reads the created id exactly once on a plain graph", async () => {
     const { backend, counts, reset } = countingBackend("solo");
@@ -274,6 +352,32 @@ describe("create-path round trips", () => {
     // left tombstoned rather than revived — which is also the proof the late
     // writer's props did not half-apply.
     expect(await store.nodes.Person.getById(original.id)).toBeUndefined();
+  });
+
+  it("keeps the bound it accepted when the resurrection target is read live", async () => {
+    const store = await createInitializedStore(
+      plainGraph,
+      resurrectThenRetombstoneBackend("raced-resurrection"),
+    );
+    const original = await store.nodes.Person.create(
+      { name: "Original" },
+      { id: "raced-resurrection" },
+    );
+    await store.nodes.Person.delete(original.id);
+
+    // The peer's bound restated verbatim: the guard sees a live row, compares
+    // the stated bound against the stored one, and ACCEPTS it. An accepted
+    // option is applied, so the row must come back carrying it — the leg cannot
+    // state a resurrection decision it never reached and write the bound away
+    // as SQL NULL.
+    const revived = await store.nodes.Person.upsertById(
+      "raced-resurrection",
+      { name: "Late writer" },
+      { validFrom: RACED_RESURRECTION_VALID_FROM },
+    );
+
+    expect(revived.name).toBe("Late writer");
+    expect(revived.meta.validFrom).toBe(RACED_RESURRECTION_VALID_FROM);
   });
 
   it("skips the identity fold probe for generated ids", async () => {

--- a/packages/typegraph/tests/inverted-validity-window.test.ts
+++ b/packages/typegraph/tests/inverted-validity-window.test.ts
@@ -10,7 +10,10 @@
  *   1. a stated PAIR must be ordered, on every node and edge write path;
  *   2. an in-place UPDATE's lone `validTo` must not precede the row's stored
  *      `valid_from` — the hole the edge path used to have;
- *   3. ZERO width stays legal, on creates and on updates;
+ *   3. ZERO width stays legal, on creates and on updates — but only when the
+ *      caller STATES both endpoints: a write that stamps a bound the caller did
+ *      not name never chooses one that makes the window zero width, because
+ *      `[T, T)` is readable at no coordinate either (I1b);
  *   4. "born already ended" — a create carrying a lone historical `validTo` —
  *      stays legal, and stores NO lower bound (issue #407): the row states where
  *      it ended, not where it began, so nothing is stamped after its own end and
@@ -20,8 +23,11 @@
  *      names is held to the bound the row RETAINS across resurrection;
  *   6. import refuses an inverted document per row, carrying the stable code;
  *   7. a node resurrection — which RESETS `valid_from` and so has no stored
- *      bound to measure against — stores the very instant its guard measured
- *      against, instead of a later one the guard never saw.
+ *      bound to measure against — stores the very DECISION its guard reached
+ *      against the instant it sampled, instead of one re-derived from a later
+ *      sample the guard never saw. That decision is "no lower bound" whenever
+ *      the stated end is at or before that instant, so a resurrection reaches
+ *      the same stored shape a create does for the same stated window (I12).
  *
  * Trusted import carries the same refusal through its own typed stream error;
  * those cases live with the rest of its stream-shape suite in
@@ -42,7 +48,6 @@ import {
   defineGraph,
   defineNode,
   INVERTED_VALIDITY_WINDOW_CODE,
-  ValidationError,
 } from "../src";
 import type { GraphData } from "../src/interchange";
 import {
@@ -52,7 +57,7 @@ import {
   ImportOptionsSchema,
 } from "../src/interchange";
 import { requireDefined } from "../src/utils/presence";
-import { createTestBackend } from "./test-utils";
+import { createTestBackend, expectInvertedWindowRefusal } from "./test-utils";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -126,20 +131,6 @@ async function documentWithWindow(
       : { ...node, validFrom: undefined },
     ),
   };
-}
-
-/**
- * Asserts a rejection is the inverted-window refusal, identified by its stable
- * issue code rather than by message text.
- */
-async function expectInvertedWindowRefusal(
-  operation: Promise<unknown>,
-): Promise<void> {
-  await expect(operation).rejects.toThrow(ValidationError);
-  const error = await operation.catch((error_: unknown) => error_);
-  expect(
-    (error as ValidationError).details.issues.map((issue) => issue.code),
-  ).toContain(INVERTED_VALIDITY_WINDOW_CODE);
 }
 
 /**
@@ -792,19 +783,30 @@ describe("inverted valid-time windows", () => {
   describe("a node resurrection stores the bound it was measured against", () => {
     /**
      * A node resurrection REWRITES `valid_from`, so its guard has no stored bound
-     * to measure against and uses the write instant instead. The operations layer
-     * and the backend read the same clock at two different moments, so the bound
-     * the guard approved was not the bound the write stored: a `validTo` at the
-     * guard's instant passed as zero-width and landed as NEGATIVE width once the
-     * backend's later sample became `valid_from` (issue #413).
+     * to measure against and decides one against the write instant instead. The
+     * operations layer and the backend read the same clock at two different
+     * moments, so the bound the guard approved was not the bound the write
+     * stored: a `validTo` at the guard's instant passed as zero-width and landed
+     * as NEGATIVE width once the backend's later sample became `valid_from`
+     * (issue #413).
      *
-     * The fix makes the guard's instant the stored one by passing it to the
-     * backend explicitly. These cases step the clock at the operations/backend
+     * The fix makes the guard's DECISION the stored one by passing it to the
+     * backend explicitly — as a value, including the `null` that means "no lower
+     * bound", never as an omission the builder would re-derive against its own
+     * later sample. These cases step the clock at the operations/backend
      * boundary — the real ordering, made deterministic — so the gap is one
      * millisecond every run instead of whatever the machine happened to produce.
+     *
+     * `GUARD_PLUS_TWO` is where the #413 guard now bites. The stamping rule
+     * stores NO bound whenever the instant it would stamp cannot precede the
+     * stated end, so at `validTo === GUARD_INSTANT` both the guard's instant and
+     * the backend's later one resolve to "no bound" and the two clocks cannot be
+     * told apart. Two milliseconds out, they resolve to different stored values
+     * and the difference is observable again.
      */
     const GUARD_INSTANT = "2031-01-01T00:00:00.000Z";
     const BACKEND_INSTANT = "2031-01-01T00:00:00.001Z";
+    const GUARD_PLUS_TWO = "2031-01-01T00:00:00.002Z";
 
     afterEach(() => {
       vi.useRealTimers();
@@ -846,7 +848,21 @@ describe("inverted valid-time windows", () => {
       } satisfies GraphBackend;
     }
 
-    it("stores zero width when a resurrecting upsertById ends at the guard's own instant", async () => {
+    /**
+     * These two cases were `"stores zero width when a resurrecting upsertById /
+     * bulkUpsertById ends at the guard's own instant"` — the #413 record, kept
+     * here as documentation of the boundary rule they used to pin. Under the
+     * stamping rule's non-strict comparison a resurrection whose stated end
+     * lands exactly on the instant it judged stores NO lower bound instead of a
+     * zero-width window: `[T, T)` is readable at no coordinate, and a bound
+     * nobody stated must never be chosen so as to produce one.
+     *
+     * They are no longer load-bearing for #413 — the rule absorbs the one-
+     * millisecond skew at exactly this boundary, so the guard's instant and the
+     * backend's resolve alike — and the guard itself is pinned two milliseconds
+     * out, below.
+     */
+    it("stores no lower bound when a resurrecting upsertById ends at the guard's own instant", async () => {
       vi.useFakeTimers({ toFake: ["Date"] });
       vi.setSystemTime(new Date(GUARD_INSTANT));
       const stepping = clockSteppingBackend();
@@ -858,30 +874,28 @@ describe("inverted valid-time windows", () => {
       );
       await store.nodes.Person.delete(person.id);
 
-      // `validTo` at the instant the guard samples: zero width, so the guard
-      // admits it. Pre-fix the backend then stamped BACKEND_INSTANT as
-      // `valid_from` and the committed row was one millisecond wide backwards.
+      // `validTo` at the instant the guard samples. Pre-#413 the backend then
+      // stamped BACKEND_INSTANT as `valid_from` and the committed row was one
+      // millisecond wide backwards; pre-#407 the guard's own instant landed and
+      // the row was zero width, readable nowhere.
       const revived = await store.nodes.Person.upsertById(
         person.id,
         { name: "Alice" },
         { validTo: GUARD_INSTANT },
       );
 
-      expect(revived.meta.validFrom).toBe(GUARD_INSTANT);
+      expect(revived.meta.validFrom).toBeUndefined();
       expect(revived.meta.validTo).toBe(GUARD_INSTANT);
 
       const raw = requireDefined(
         await stepping.getNode(graph.id, "Person", person.id),
       );
       expect(raw.deleted_at).toBeUndefined();
-      expect(
-        requireDefined(raw.valid_from) <= requireDefined(raw.valid_to),
-      ).toBe(true);
-      expect(raw.valid_from).toBe(GUARD_INSTANT);
+      expect(raw.valid_from).toBeUndefined();
       expect(raw.valid_to).toBe(GUARD_INSTANT);
     });
 
-    it("stores zero width when a resurrecting bulkUpsertById ends at the guard's own instant", async () => {
+    it("stores no lower bound when a resurrecting bulkUpsertById ends at the guard's own instant", async () => {
       vi.useFakeTimers({ toFake: ["Date"] });
       vi.setSystemTime(new Date(GUARD_INSTANT));
       const stepping = clockSteppingBackend();
@@ -900,11 +914,117 @@ describe("inverted valid-time windows", () => {
       const raw = requireDefined(
         await stepping.getNode(graph.id, "Person", person.id),
       );
-      expect(
-        requireDefined(raw.valid_from) <= requireDefined(raw.valid_to),
-      ).toBe(true);
-      expect(raw.valid_from).toBe(GUARD_INSTANT);
+      expect(raw.valid_from).toBeUndefined();
       expect(raw.valid_to).toBe(GUARD_INSTANT);
+    });
+
+    it("stores the bound the guard judged, not the backend's later sample", async () => {
+      // The #413 guard, relocated off the zero-width boundary. `validTo` two
+      // milliseconds after the guard's instant leaves BOTH candidate bounds
+      // storable, so which one lands is observable: the guard's, because the
+      // store hands the backend its decision instead of letting the builder
+      // re-derive one against a clock the guard never read.
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(GUARD_INSTANT));
+      const stepping = clockSteppingBackend();
+      const store = createStore(graph, stepping);
+
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "resurrect-guard-plus-two" },
+      );
+      await store.nodes.Person.delete(person.id);
+
+      const revived = await store.nodes.Person.upsertById(
+        person.id,
+        { name: "Alice" },
+        { validTo: GUARD_PLUS_TWO },
+      );
+
+      expect(revived.meta.validFrom).toBe(GUARD_INSTANT);
+      expect(revived.meta.validTo).toBe(GUARD_PLUS_TWO);
+
+      const raw = requireDefined(
+        await stepping.getNode(graph.id, "Person", person.id),
+      );
+      expect(raw.valid_from).toBe(GUARD_INSTANT);
+      expect(raw.valid_from).not.toBe(BACKEND_INSTANT);
+      expect(raw.valid_to).toBe(GUARD_PLUS_TWO);
+    });
+
+    /**
+     * I12, the half this batch closes: ONE stated window, one outcome, whichever
+     * entry point resets the tombstoned row's window. `create` on a tombstone
+     * reaches `resurrectPreparedNode`; `upsertById` reaches
+     * `performNodeUpdate`'s resurrection leg. Before this batch the first stored
+     * `(NULL, T)` while the second REFUSED the same call outright.
+     */
+    it("reaches one stored shape from both resurrection entry points", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(GUARD_INSTANT));
+      const stepping = clockSteppingBackend();
+      const store = createStore(graph, stepping);
+
+      for (const id of ["i12-create", "i12-upsert"]) {
+        await store.nodes.Person.create({ name: "Alice" }, { id });
+        await store.nodes.Person.delete(asNodeId<typeof Person>(id));
+      }
+
+      const created = await store.nodes.Person.create(
+        { name: "Revived" },
+        { id: "i12-create", validTo: START },
+      );
+      const upserted = await store.nodes.Person.upsertById(
+        "i12-upsert",
+        { name: "Revived" },
+        { validTo: START },
+      );
+
+      // A lone historical `validTo`: no lower bound, through either door.
+      expect(created.meta.validFrom).toBeUndefined();
+      expect(upserted.meta.validFrom).toBeUndefined();
+      for (const id of ["i12-create", "i12-upsert"]) {
+        const raw = requireDefined(
+          await stepping.getNode(graph.id, "Person", id),
+        );
+        expect(raw.valid_from).toBeUndefined();
+        expect(raw.valid_to).toBe(START);
+      }
+    });
+
+    it("stamps the instant the store judged when a create lands on a tombstone", async () => {
+      // The other half of the resurrection contract, and the one a lone
+      // historical `validTo` cannot see: with NO window stated there is a bound
+      // to stamp, so which clock owns it is observable. `resurrectPreparedNode`
+      // samples the instant and resolves the bound from it, and the backend's
+      // stepped sample one millisecond later never reaches the row.
+      //
+      // One resurrection per case: the harness steps the clock forward and never
+      // back, so a second one in the same test would find the two instants
+      // already collapsed onto BACKEND_INSTANT.
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(GUARD_INSTANT));
+      const stepping = clockSteppingBackend();
+      const store = createStore(graph, stepping);
+
+      const person = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "resurrect-open-create" },
+      );
+      await store.nodes.Person.delete(person.id);
+
+      const revived = await store.nodes.Person.create(
+        { name: "Revived" },
+        { id: "resurrect-open-create" },
+      );
+
+      expect(revived.meta.validFrom).toBe(GUARD_INSTANT);
+      const raw = requireDefined(
+        await stepping.getNode(graph.id, "Person", "resurrect-open-create"),
+      );
+      expect(raw.valid_from).toBe(GUARD_INSTANT);
+      expect(raw.valid_from).not.toBe(BACKEND_INSTANT);
+      expect(raw.valid_to).toBeUndefined();
     });
 
     it("leaves an explicitly stated resurrection window untouched", async () => {

--- a/packages/typegraph/tests/inverted-validity-window.test.ts
+++ b/packages/typegraph/tests/inverted-validity-window.test.ts
@@ -11,9 +11,11 @@
  *   2. an in-place UPDATE's lone `validTo` must not precede the row's stored
  *      `valid_from` — the hole the edge path used to have;
  *   3. ZERO width stays legal, on creates and on updates;
- *   4. "born already ended" — an INSERT carrying a lone historical `validTo` —
- *      stays legal: the stamped `valid_from` is a storage convention, not a
- *      caller assertion, and the row is read back through `includeEnded`;
+ *   4. "born already ended" — a create carrying a lone historical `validTo` —
+ *      stays legal, and stores NO lower bound (issue #407): the row states where
+ *      it ended, not where it began, so nothing is stamped after its own end and
+ *      it reads back at every `asOf` coordinate before that end. This holds on a
+ *      fresh id and on one naming a tombstone, which take different write paths;
  *   5. resurrecting an edge into the ended state stays legal, but the end it
  *      names is held to the bound the row RETAINS across resurrection;
  *   6. import refuses an inverted document per row, carrying the stable code;
@@ -138,6 +140,47 @@ async function expectInvertedWindowRefusal(
   expect(
     (error as ValidationError).details.issues.map((issue) => issue.code),
   ).toContain(INVERTED_VALIDITY_WINDOW_CODE);
+}
+
+/**
+ * THE canonical statement of the born-ended contract (issue #407).
+ *
+ * A create naming only a `validTo` at or before its own write instant states
+ * "this ended at T"; it does not state where it started. Stamping the write
+ * instant as `valid_from` would answer a question nobody asked, and answer it
+ * with a window no `asOf` coordinate can observe — a successful write that
+ * stores an unreadable row. So no bound is stored at all, and the row means
+ * what it says: ended at T, start unknown.
+ *
+ * The assertion is the STORED shape and the READ, not just the accepted
+ * call: `meta.validTo` alone passed before the fix and after it.
+ */
+async function assertBornEndedNodeShape(
+  backend: GraphBackend,
+  store: ReturnType<typeof createStore<typeof graph>>,
+  id: string,
+): Promise<void> {
+  const raw = requireDefined(await backend.getNode(graph.id, "Person", id));
+  expect(raw.valid_from).toBeUndefined();
+  expect(raw.valid_to).toBe(START);
+
+  // Readable at every coordinate before its end, at none from its end on —
+  // the upper bound is half-open, so the end instant itself is outside.
+  const nodeId = asNodeId<typeof Person>(id);
+  await expect(
+    store.nodes.Person.getById(nodeId, {
+      temporalMode: "asOf",
+      asOf: EARLIER,
+    }),
+  ).resolves.toBeDefined();
+  for (const at of [START, LATER]) {
+    await expect(
+      store.nodes.Person.getById(nodeId, {
+        temporalMode: "asOf",
+        asOf: at,
+      }),
+    ).resolves.toBeUndefined();
+  }
 }
 
 describe("inverted valid-time windows", () => {
@@ -359,14 +402,11 @@ describe("inverted valid-time windows", () => {
   });
 
   describe("born already ended stays legal", () => {
-    it("accepts a lone historical validTo on node and edge create", async () => {
+    it("stores no lower bound for a lone historical validTo on node and edge create", async () => {
       const store = createStore(graph, backend);
-      // No validFrom: the backend stamps the write instant. The row is
-      // deliberately not current, and `includeEnded` is how it is read back —
-      // an established idiom across the temporal, search and provenance suites.
       const person = await store.nodes.Person.create(
         { name: "Former" },
-        { validTo: START },
+        { id: "born-ended-fresh", validTo: START },
       );
       const acme = await store.nodes.Company.create({ name: "Acme" });
       const edge = await store.edges.worksAt.create(
@@ -377,7 +417,46 @@ describe("inverted valid-time windows", () => {
       );
 
       expect(person.meta.validTo).toBe(START);
+      expect(person.meta.validFrom).toBeUndefined();
       expect(edge.meta.validTo).toBe(START);
+      expect(edge.meta.validFrom).toBeUndefined();
+
+      await assertBornEndedNodeShape(backend, store, "born-ended-fresh");
+
+      // Edges take the same route through the same insert builders, so the same
+      // shape has to reach the edges relation — asserted on the row, not
+      // inferred from the node's.
+      const rawEdge = requireDefined(await backend.getEdge(graph.id, edge.id));
+      expect(rawEdge.valid_from).toBeUndefined();
+      expect(rawEdge.valid_to).toBe(START);
+      const beforeEnd = await store.edges.worksAt.getById(edge.id, {
+        temporalMode: "asOf",
+        asOf: EARLIER,
+      });
+      expect(beforeEnd?.id).toBe(edge.id);
+    });
+
+    it("stores the same shape when the create lands on a tombstoned id", async () => {
+      // A create whose id names an existing tombstone RESURRECTS it, reaching
+      // `buildUpdateNode`'s window-reset leg instead of an insert builder — a
+      // second write path for one user-visible operation. It stamps its bound
+      // through the same owner, so one stated window has one outcome whichever
+      // path it takes (invariant I12's create legs).
+      const store = createStore(graph, backend);
+      const person = await store.nodes.Person.create(
+        { name: "First" },
+        { id: "born-ended-tombstone" },
+      );
+      await store.nodes.Person.delete(person.id);
+
+      const revived = await store.nodes.Person.create(
+        { name: "Former" },
+        { id: "born-ended-tombstone", validTo: START },
+      );
+
+      expect(revived.meta.validTo).toBe(START);
+      expect(revived.meta.validFrom).toBeUndefined();
+      await assertBornEndedNodeShape(backend, store, "born-ended-tombstone");
     });
 
     it("accepts resurrecting an edge straight into the ended state", async () => {

--- a/packages/typegraph/tests/property/temporal-window.test.ts
+++ b/packages/typegraph/tests/property/temporal-window.test.ts
@@ -8,22 +8,29 @@
  * width, inverted, unbounded on either side — are exactly the ones a DB-backed
  * property can only reach by getting lucky with a clock.
  *
- * WHAT IS AND IS NOT STATED HERE, AND WHY.
- * `isInvertedValidityWindow` (`src/utils/date.ts`) is the library's REFUSAL
- * predicate and exists today, so its relation to the model's own emptiness
- * decision is a law now. The CHOICE predicate (`isEmptyValidityWindow`) and the
- * stamping owner (`resolveStampedValidityLowerBound`) land with the seam, and
- * the laws that quantify over them land in the same diff. Until then the
- * stamping law is stated over {@link expectedStoredLowerBound} — the model's
- * encoding of today's contract — RESTRICTED away from the cell
- * `KNOWN_CONTRACT_GAPS` declares, exactly as P1/P1b are restricted at the
- * database level. A law that quantified over the excused cell would be red on
- * `main`, which is the one thing this batch may not be.
+ * WHAT IS STATED HERE, AND OVER WHAT.
+ * Three owners meet in this file, all in `src/utils/date.ts`:
+ * `isInvertedValidityWindow` is the REFUSAL predicate (strict `>`),
+ * `isEmptyValidityWindow` the CHOICE predicate (non-strict `>=`), and
+ * `resolveStampedValidityLowerBound` the one function every write that stamps a
+ * bound its caller did not state decides through. The oracle model's
+ * `expectedStoredLowerBound` is a second, independent encoding of that same
+ * rule, and the laws below quantify over BOTH, so neither can drift into a
+ * contract the other does not hold.
+ *
+ * The stamping law is TOTAL: no input makes a stamped bound yield a window
+ * readable at no instant. It was restricted to the shapes outside the born-ended
+ * cell while `KNOWN_CONTRACT_GAPS` still excused that cell; the seam closed it,
+ * so the arbitrary draws the whole space and the guard is gone.
  */
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
-import { isInvertedValidityWindow } from "../../src/utils/date";
+import {
+  isEmptyValidityWindow,
+  isInvertedValidityWindow,
+  resolveStampedValidityLowerBound,
+} from "../../src/utils/date";
 import { requireDefined } from "../../src/utils/presence";
 import {
   expectedStoredLowerBound,
@@ -118,11 +125,16 @@ describe("validity window algebra", () => {
           window.validFrom,
           window.validTo,
         );
+        const empty = isEmptyValidityWindow(window.validFrom, window.validTo);
         // The refusal predicate implies the choice predicate. It is strictly
         // stronger: the two differ on, and only on, the zero-width boundary.
-        expect(!inverted || intervalIsEmpty(interval)).toBe(true);
+        expect(!inverted || empty).toBe(true);
+        // ...and the library's two predicates say what the model's interval
+        // algebra says, which is what lets the database properties ask the model
+        // and the write paths ask the library without the two disagreeing.
+        expect(empty).toBe(intervalIsEmpty(interval));
         expect(intervalIsInverted(interval)).toBe(inverted);
-        expect(intervalIsEmpty(interval) && !inverted).toBe(
+        expect(empty && !inverted).toBe(
           window.validFrom !== undefined &&
             window.validTo !== undefined &&
             window.validFrom === window.validTo,
@@ -190,85 +202,113 @@ function orderedPairArb(): fc.Arbitrary<readonly [Instant, Instant]> {
     });
 }
 
-describe("the stored lower bound", () => {
-  it("returns a stated bound verbatim and a stated null as no bound", () => {
-    fc.assert(
-      fc.property(
-        instantArb(),
-        optionalInstantArb(),
-        instantArb(),
-        (statedValidFrom, validTo, writeInstant) => {
-          expect(
-            expectedStoredLowerBound(statedValidFrom, validTo, writeInstant),
-          ).toBe(statedValidFrom);
-          expect(
-            expectedStoredLowerBound(
-              CONFIRMED_OPEN_LEFT,
-              validTo,
-              writeInstant,
-            ),
-          ).toBeUndefined();
-        },
-      ),
-      RUNS,
-    );
-  });
+/**
+ * Both encodings of the stamping rule, so every law below is stated once and
+ * checked against each: the library owner every write path calls, and the oracle
+ * model's independent restatement the database properties predict with.
+ */
+const STAMPING_OWNERS = [
+  ["resolveStampedValidityLowerBound", resolveStampedValidityLowerBound],
+  ["expectedStoredLowerBound", expectedStoredLowerBound],
+] as const satisfies readonly (readonly [
+  string,
+  (
+    statedValidFrom: Instant | null | undefined,
+    validTo: Instant | undefined,
+    writeInstant: Instant,
+  ) => Instant | undefined,
+])[];
 
-  it("stamps the write instant it was handed, never a clock it sampled", () => {
-    fc.assert(
-      fc.property(instantArb(), (writeInstant) => {
-        expect(
-          expectedStoredLowerBound(undefined, undefined, writeInstant),
-        ).toBe(writeInstant);
-      }),
-      RUNS,
-    );
-  });
-
-  it("never yields a window readable at no instant, outside the cell KNOWN_CONTRACT_GAPS declares", () => {
-    // The excused cell is R-A/R-B's pure-level twin: "nothing stated, and a
-    // `validTo` at or before the write instant". It is withheld by the
-    // ARBITRARY rather than by a guard inside the property, for the same reason
-    // the database-level restrictions are stated over op shapes — a guard that
-    // stopped matching would silently stop asserting.
-    fc.assert(
-      fc.property(
-        fc.oneof(
-          // A stated, strictly ordered pair against any write instant. This is
-          // where dropping the stated pass-through bites: the write instant is
-          // unrelated to the pair and lands past `validTo` roughly half the time.
-          orderedPairArb().chain(([validFrom, validTo]) =>
-            instantArb().map((writeInstant) => ({
-              statedValidFrom: validFrom,
-              validTo,
-              writeInstant,
-            })),
-          ),
-          // Nothing stated at all.
-          instantArb().map((writeInstant) => ({
-            statedValidFrom: undefined,
-            validTo: undefined,
-            writeInstant,
-          })),
-          // Nothing stated, and a scheduled end strictly after the write instant.
-          orderedPairArb().map(([writeInstant, validTo]) => ({
-            statedValidFrom: undefined,
-            validTo,
-            writeInstant,
-          })),
+describe.each(STAMPING_OWNERS)(
+  "the stored lower bound (%s)",
+  (_name, resolve) => {
+    it("returns a stated bound verbatim and a stated null as no bound", () => {
+      fc.assert(
+        fc.property(
+          instantArb(),
+          optionalInstantArb(),
+          instantArb(),
+          (statedValidFrom, validTo, writeInstant) => {
+            expect(resolve(statedValidFrom, validTo, writeInstant)).toBe(
+              statedValidFrom,
+            );
+            expect(
+              resolve(CONFIRMED_OPEN_LEFT, validTo, writeInstant),
+            ).toBeUndefined();
+          },
         ),
-        ({ statedValidFrom, validTo, writeInstant }) => {
-          const stored = expectedStoredLowerBound(
-            statedValidFrom,
-            validTo,
+        RUNS,
+      );
+    });
+
+    it("stamps the write instant it was handed, never a clock it sampled", () => {
+      fc.assert(
+        fc.property(instantArb(), (writeInstant) => {
+          expect(resolve(undefined, undefined, writeInstant)).toBe(
             writeInstant,
           );
-          expect(
-            intervalIsEmpty(intervalOf({ validFrom: stored, validTo })),
-          ).toBe(false);
-        },
-      ),
-      RUNS,
-    );
-  });
-});
+        }),
+        RUNS,
+      );
+    });
+
+    it("never yields a window readable at no instant", () => {
+      // TOTAL, over the whole input space: the born-ended cell this used to be
+      // restricted away from is the one the seam closed, so it is drawn here like
+      // any other. `windowArb` covers "nothing stated with a `validTo` at or
+      // before the write instant" — including the exact zero-width boundary,
+      // which `instantArb` reaches by drawing the same instant twice — and that is
+      // the cell a strict `>` comparison inside the rule would fail.
+      fc.assert(
+        fc.property(
+          fc.oneof(optionalInstantArb(), fc.constant(CONFIRMED_OPEN_LEFT)),
+          optionalInstantArb(),
+          instantArb(),
+          (statedValidFrom, validTo, writeInstant) => {
+            const stored = resolve(statedValidFrom, validTo, writeInstant);
+            // A window the caller STATED in full may legitimately be zero width,
+            // and an inverted stated pair is refused above this layer rather than
+            // here — so the law binds the cell where the WRITE chose the bound.
+            const chosen = statedValidFrom === undefined;
+            expect(
+              !chosen ||
+                !intervalIsEmpty(intervalOf({ validFrom: stored, validTo })),
+            ).toBe(true);
+          },
+        ),
+        RUNS,
+      );
+    });
+
+    it("stamps the write instant exactly when it leaves the window readable somewhere", () => {
+      // The boundary itself, stated as an equivalence rather than as an example:
+      // a stated end at or before the write instant means no bound, a strictly
+      // later one means the instant. `orderedPairArb` supplies the strictly-later
+      // half and the shared-instant draw the equal one.
+      fc.assert(
+        fc.property(
+          fc.oneof(
+            orderedPairArb().map(([writeInstant, validTo]) => ({
+              writeInstant,
+              validTo,
+            })),
+            orderedPairArb().map(([validTo, writeInstant]) => ({
+              writeInstant,
+              validTo,
+            })),
+            instantArb().map((instant) => ({
+              writeInstant: instant,
+              validTo: instant,
+            })),
+          ),
+          ({ writeInstant, validTo }) => {
+            expect(resolve(undefined, validTo, writeInstant)).toBe(
+              writeInstant < validTo ? writeInstant : undefined,
+            );
+          },
+        ),
+        RUNS,
+      );
+    });
+  },
+);

--- a/packages/typegraph/tests/property/temporal-window.test.ts
+++ b/packages/typegraph/tests/property/temporal-window.test.ts
@@ -9,9 +9,11 @@
  * property can only reach by getting lucky with a clock.
  *
  * WHAT IS STATED HERE, AND OVER WHAT.
- * Three owners meet in this file, all in `src/utils/date.ts`:
+ * Four owners meet in this file, all in `src/utils/date.ts`:
  * `isInvertedValidityWindow` is the REFUSAL predicate (strict `>`),
  * `isEmptyValidityWindow` the CHOICE predicate (non-strict `>=`), and
+ * `validityWindowContainsInstant` the JavaScript membership predicate shared
+ * by store and provenance reads. Finally,
  * `resolveStampedValidityLowerBound` the one function every write that stamps a
  * bound its caller did not state decides through. The oracle model's
  * `expectedStoredLowerBound` is a second, independent encoding of that same
@@ -30,6 +32,7 @@ import {
   isEmptyValidityWindow,
   isInvertedValidityWindow,
   resolveStampedValidityLowerBound,
+  validityWindowContainsInstant,
 } from "../../src/utils/date";
 import { requireDefined } from "../../src/utils/presence";
 import {
@@ -85,6 +88,21 @@ function orderedTripleArb(): fc.Arbitrary<
 }
 
 describe("validity window algebra", () => {
+  it("the shared JavaScript predicate agrees with the independent interval model", () => {
+    fc.assert(
+      fc.property(windowArb(), instantArb(), (window, instant) => {
+        expect(
+          validityWindowContainsInstant(
+            window.validFrom,
+            window.validTo,
+            instant,
+          ),
+        ).toBe(intervalContains(intervalOf(window), instant));
+      }),
+      RUNS,
+    );
+  });
+
   it("membership is an interval: anything between two contained instants is contained", () => {
     fc.assert(
       fc.property(

--- a/packages/typegraph/tests/property/temporal-window.test.ts
+++ b/packages/typegraph/tests/property/temporal-window.test.ts
@@ -1,0 +1,274 @@
+/**
+ * The pure, dialect-free window algebra the temporal oracle is built on.
+ *
+ * No database, no store, no driver: these are laws about the interval semantics
+ * of a validity window and about the decision a write makes when it stamps a
+ * lower bound the caller did not state. They run at a high iteration count
+ * because they are cheap, and because the boundary cases they cover — zero
+ * width, inverted, unbounded on either side — are exactly the ones a DB-backed
+ * property can only reach by getting lucky with a clock.
+ *
+ * WHAT IS AND IS NOT STATED HERE, AND WHY.
+ * `isInvertedValidityWindow` (`src/utils/date.ts`) is the library's REFUSAL
+ * predicate and exists today, so its relation to the model's own emptiness
+ * decision is a law now. The CHOICE predicate (`isEmptyValidityWindow`) and the
+ * stamping owner (`resolveStampedValidityLowerBound`) land with the seam, and
+ * the laws that quantify over them land in the same diff. Until then the
+ * stamping law is stated over {@link expectedStoredLowerBound} — the model's
+ * encoding of today's contract — RESTRICTED away from the cell
+ * `KNOWN_CONTRACT_GAPS` declares, exactly as P1/P1b are restricted at the
+ * database level. A law that quantified over the excused cell would be red on
+ * `main`, which is the one thing this batch may not be.
+ */
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { isInvertedValidityWindow } from "../../src/utils/date";
+import { requireDefined } from "../../src/utils/presence";
+import {
+  expectedStoredLowerBound,
+  type Instant,
+  intervalContains,
+  intervalIsEmpty,
+  intervalIsInverted,
+  intervalOf,
+} from "../backends/integration/temporal-oracle-model";
+
+const RUNS = { numRuns: 300 } as const;
+
+/** Interchange's "confirmed open-left" wire value — the input under test here. */
+// eslint-disable-next-line unicorn/no-null -- the interchange wire value
+const CONFIRMED_OPEN_LEFT = null;
+
+const LATTICE_START = new Date("2000-01-01T00:00:00.000Z");
+const LATTICE_END = new Date("2100-01-01T00:00:00.000Z");
+
+/** Canonical fixed-width UTC ISO 8601, which is what every stored bound is. */
+function instantArb(): fc.Arbitrary<Instant> {
+  return fc
+    .date({ min: LATTICE_START, max: LATTICE_END, noInvalidDate: true })
+    .map((value) => value.toISOString());
+}
+
+function optionalInstantArb(): fc.Arbitrary<Instant | undefined> {
+  return fc.option(instantArb(), { nil: undefined });
+}
+
+function windowArb(): fc.Arbitrary<
+  Readonly<{ validFrom: Instant | undefined; validTo: Instant | undefined }>
+> {
+  return fc.record({
+    validFrom: optionalInstantArb(),
+    validTo: optionalInstantArb(),
+  });
+}
+
+/** Three instants in non-decreasing order, as a real tuple. */
+function orderedTripleArb(): fc.Arbitrary<
+  readonly [Instant, Instant, Instant]
+> {
+  return fc.tuple(instantArb(), instantArb(), instantArb()).map((instants) => {
+    const sorted = instants.toSorted();
+    return [
+      requireDefined(sorted[0], "low"),
+      requireDefined(sorted[1], "middle"),
+      requireDefined(sorted[2], "high"),
+    ] as const;
+  });
+}
+
+describe("validity window algebra", () => {
+  it("membership is an interval: anything between two contained instants is contained", () => {
+    fc.assert(
+      fc.property(
+        windowArb(),
+        orderedTripleArb(),
+        (window, [low, middle, high]) => {
+          const interval = intervalOf(window);
+          const endpointsContained =
+            intervalContains(interval, low) && intervalContains(interval, high);
+          // Stated as an implication rather than a guarded assertion: a
+          // conditional `expect` can silently stop asserting anything.
+          expect(
+            !endpointsContained || intervalContains(interval, middle),
+          ).toBe(true);
+        },
+      ),
+      RUNS,
+    );
+  });
+
+  it("a zero-width window contains nothing", () => {
+    fc.assert(
+      fc.property(instantArb(), instantArb(), (bound, probe) => {
+        const interval = intervalOf({ validFrom: bound, validTo: bound });
+        expect(intervalIsEmpty(interval)).toBe(true);
+        expect(intervalIsInverted(interval)).toBe(false);
+        expect(intervalContains(interval, probe)).toBe(false);
+      }),
+      RUNS,
+    );
+  });
+
+  it("an inverted window is empty, and empty-but-not-inverted is exactly zero width", () => {
+    fc.assert(
+      fc.property(windowArb(), (window) => {
+        const interval = intervalOf(window);
+        const inverted = isInvertedValidityWindow(
+          window.validFrom,
+          window.validTo,
+        );
+        // The refusal predicate implies the choice predicate. It is strictly
+        // stronger: the two differ on, and only on, the zero-width boundary.
+        expect(!inverted || intervalIsEmpty(interval)).toBe(true);
+        expect(intervalIsInverted(interval)).toBe(inverted);
+        expect(intervalIsEmpty(interval) && !inverted).toBe(
+          window.validFrom !== undefined &&
+            window.validTo !== undefined &&
+            window.validFrom === window.validTo,
+        );
+      }),
+      RUNS,
+    );
+  });
+
+  it("an unbounded endpoint is unbounded, never a coincidence of ordering", () => {
+    fc.assert(
+      fc.property(instantArb(), instantArb(), (bound, probe) => {
+        expect(
+          intervalContains(
+            intervalOf({ validFrom: undefined, validTo: undefined }),
+            probe,
+          ),
+        ).toBe(true);
+        expect(
+          intervalContains(
+            intervalOf({ validFrom: undefined, validTo: bound }),
+            probe,
+          ),
+        ).toBe(probe < bound);
+        expect(
+          intervalContains(
+            intervalOf({ validFrom: bound, validTo: undefined }),
+            probe,
+          ),
+        ).toBe(probe >= bound);
+      }),
+      RUNS,
+    );
+  });
+
+  it("canonical ISO 8601 sorts chronologically as text", () => {
+    fc.assert(
+      fc.property(instantArb(), instantArb(), (left, right) => {
+        const textual =
+          left < right ? -1
+          : left > right ? 1
+          : 0;
+        const chronological =
+          new Date(left).getTime() < new Date(right).getTime() ? -1
+          : new Date(left).getTime() > new Date(right).getTime() ? 1
+          : 0;
+        expect(textual).toBe(chronological);
+      }),
+      RUNS,
+    );
+  });
+});
+
+/** Two DISTINCT instants in increasing order — never zero width. */
+function orderedPairArb(): fc.Arbitrary<readonly [Instant, Instant]> {
+  return fc
+    .tuple(instantArb(), instantArb())
+    .filter((instants) => instants[0] !== instants[1])
+    .map((instants) => {
+      const sorted = instants.toSorted();
+      return [
+        requireDefined(sorted[0], "lower"),
+        requireDefined(sorted[1], "upper"),
+      ] as const;
+    });
+}
+
+describe("the stored lower bound", () => {
+  it("returns a stated bound verbatim and a stated null as no bound", () => {
+    fc.assert(
+      fc.property(
+        instantArb(),
+        optionalInstantArb(),
+        instantArb(),
+        (statedValidFrom, validTo, writeInstant) => {
+          expect(
+            expectedStoredLowerBound(statedValidFrom, validTo, writeInstant),
+          ).toBe(statedValidFrom);
+          expect(
+            expectedStoredLowerBound(
+              CONFIRMED_OPEN_LEFT,
+              validTo,
+              writeInstant,
+            ),
+          ).toBeUndefined();
+        },
+      ),
+      RUNS,
+    );
+  });
+
+  it("stamps the write instant it was handed, never a clock it sampled", () => {
+    fc.assert(
+      fc.property(instantArb(), (writeInstant) => {
+        expect(
+          expectedStoredLowerBound(undefined, undefined, writeInstant),
+        ).toBe(writeInstant);
+      }),
+      RUNS,
+    );
+  });
+
+  it("never yields a window readable at no instant, outside the cell KNOWN_CONTRACT_GAPS declares", () => {
+    // The excused cell is R-A/R-B's pure-level twin: "nothing stated, and a
+    // `validTo` at or before the write instant". It is withheld by the
+    // ARBITRARY rather than by a guard inside the property, for the same reason
+    // the database-level restrictions are stated over op shapes — a guard that
+    // stopped matching would silently stop asserting.
+    fc.assert(
+      fc.property(
+        fc.oneof(
+          // A stated, strictly ordered pair against any write instant. This is
+          // where dropping the stated pass-through bites: the write instant is
+          // unrelated to the pair and lands past `validTo` roughly half the time.
+          orderedPairArb().chain(([validFrom, validTo]) =>
+            instantArb().map((writeInstant) => ({
+              statedValidFrom: validFrom,
+              validTo,
+              writeInstant,
+            })),
+          ),
+          // Nothing stated at all.
+          instantArb().map((writeInstant) => ({
+            statedValidFrom: undefined,
+            validTo: undefined,
+            writeInstant,
+          })),
+          // Nothing stated, and a scheduled end strictly after the write instant.
+          orderedPairArb().map(([writeInstant, validTo]) => ({
+            statedValidFrom: undefined,
+            validTo,
+            writeInstant,
+          })),
+        ),
+        ({ statedValidFrom, validTo, writeInstant }) => {
+          const stored = expectedStoredLowerBound(
+            statedValidFrom,
+            validTo,
+            writeInstant,
+          );
+          expect(
+            intervalIsEmpty(intervalOf({ validFrom: stored, validTo })),
+          ).toBe(false);
+        },
+      ),
+      RUNS,
+    );
+  });
+});

--- a/packages/typegraph/tests/temporal-builder-inventory.test.ts
+++ b/packages/typegraph/tests/temporal-builder-inventory.test.ts
@@ -19,7 +19,7 @@
  *      WITHOUT calling an owner, which is precisely how the duplicate resolver
  *      in `trusted-import.ts` survived the last two rounds of review.
  *  (c) FILE SET — the set of files under `src/backend/**` that name the column at
- *      all equals the twelve declared here, each with the role that earns it. (a)
+ *      all equals the thirteen declared here, each with the role that earns it. (a)
  *      and (b) only see three files; a NEW file that binds `valid_from` would be
  *      invisible to them, and I5 is quantified over the whole directory.
  *
@@ -123,6 +123,11 @@ const BACKEND_COLUMN_FILES: Readonly<Record<string, string>> = {
   "drizzle/schema/sqlite.ts": "column declaration",
   "drizzle/schema/postgres.ts": "column declaration",
   "migrate-recorded-time.ts": "copy list naming the column",
+  // Not a stamping site and never a fourteenth: the repair only CLEARS a bound
+  // that was already stored inverted (`SET valid_from = NULL`), so it chooses
+  // no instant and has nothing to route through an owner.
+  "repair-validity-windows.ts":
+    "offline repair — clears an inverted stored bound",
   "types.ts": "parameter types",
 };
 
@@ -211,6 +216,6 @@ describe("the stamping-site inventory (I5)", () => {
     for (const role of Object.values(BACKEND_COLUMN_FILES)) {
       expect(role.length).toBeGreaterThan(0);
     }
-    expect(Object.keys(BACKEND_COLUMN_FILES)).toHaveLength(12);
+    expect(Object.keys(BACKEND_COLUMN_FILES)).toHaveLength(13);
   });
 });

--- a/packages/typegraph/tests/temporal-builder-inventory.test.ts
+++ b/packages/typegraph/tests/temporal-builder-inventory.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The stamping-site inventory, ratcheted over source text (invariant I5).
+ *
+ * "No write path stamps a validity bound it did not judge" is a claim about a
+ * SET of call sites, and no behavioral test can state it: a fourteenth site
+ * added tomorrow with its own `?? timestamp` would leave every existing test
+ * green while re-opening issue #407 on whatever path it serves. The claim is
+ * structural, so the guard is too.
+ *
+ * Three parts, each an EQUALITY rather than a denylist, because a denylist only
+ * catches the spellings someone already thought of:
+ *
+ *  (a) INVENTORY — the number of owner call sites in each writer file is exactly
+ *      what this file declares. Reverting a site drops a count; adding one
+ *      raises it.
+ *  (b) LEAK CHECK — inside those files, every non-comment line that names the
+ *      column either contains an owner call or is on a declared allowlist of
+ *      read/forward lines. This is what catches a site that binds the column
+ *      WITHOUT calling an owner, which is precisely how the duplicate resolver
+ *      in `trusted-import.ts` survived the last two rounds of review.
+ *  (c) FILE SET — the set of files under `src/backend/**` that name the column at
+ *      all equals the twelve declared here, each with the role that earns it. (a)
+ *      and (b) only see three files; a NEW file that binds `valid_from` would be
+ *      invisible to them, and I5 is quantified over the whole directory.
+ *
+ * The rule this defends is A2': a write that stamps a lower bound its caller did
+ * not state stores the write instant, unless that instant would leave the window
+ * readable at no coordinate, in which case it stores none. One owner
+ * (`resolveStampedValidityLowerBound`) decides it everywhere; one pass-through
+ * owner (`resolveStatedValidityLowerBound`) serves the single site that writes a
+ * bound the caller DID state and therefore chooses nothing.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const BACKEND_DIR = fileURLToPath(new URL("../src/backend/", import.meta.url));
+
+const STAMPING_OWNER = "resolveStampedValidityLowerBound";
+const STATED_OWNER = "resolveStatedValidityLowerBound";
+
+/** Every way the column can be named in source: the property and the column. */
+const COLUMN_MENTION = /validFrom|valid_from/;
+
+/**
+ * The writer files, with the exact number of call sites of each owner.
+ *
+ * `operations/nodes.ts` has five stamping sites, not four: `buildUpdateNode`'s
+ * `clearDeleted` leg RESETS the window rather than retaining it, so it chooses a
+ * bound exactly as an insert does — and it is reachable unguarded from a `create`
+ * whose id names an existing tombstone.
+ *
+ * `operations/edges.ts` has four and ONE pass-through: an edge resurrection that
+ * names no `validFrom` retains the stored window instead of stamping, so its
+ * window-writing leg only runs when the caller stated a bound.
+ */
+const WRITER_INVENTORY = {
+  "drizzle/operations/nodes.ts": { stamping: 5, stated: 0 },
+  "drizzle/operations/edges.ts": { stamping: 4, stated: 1 },
+  "drizzle/trusted-import.ts": { stamping: 4, stated: 0 },
+} as const satisfies Readonly<
+  Record<string, Readonly<{ stamping: number; stated: number }>>
+>;
+
+/**
+ * Lines inside the writer files that may name the column without calling an
+ * owner, because they READ or FORWARD it rather than deciding it. Exact trimmed
+ * source text: a new line that names the column fails until it is either routed
+ * through an owner or declared here with a reason.
+ *
+ * The check is LINE-oriented, which has one consequence worth knowing before
+ * reading a failure: an owner call whose arguments are split across lines leaves
+ * `item.validFrom,` on a line of its own, and that line fails. The fix is to keep
+ * the call and its arguments on one line, not to widen this allowlist — a line
+ * that names the column and does not say what decides it is exactly what this
+ * guard exists to notice, and no reader can tell the two cases apart from the
+ * line alone either.
+ */
+const LEAK_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
+  "drizzle/operations/nodes.ts": [
+    // The compare-and-set fence's column argument — a READ of the bound the
+    // caller asserted, never a choice about what to store.
+    "nodes.validFrom,",
+  ],
+  "drizzle/operations/edges.ts": [
+    // The gate that makes the site below a pass-through: it runs only when the
+    // caller named a bound.
+    "if (params.clearDeleted && params.validFrom !== undefined) {",
+    // The fence's column argument, as for nodes.
+    "edges.validFrom,",
+  ],
+  "drizzle/trusted-import.ts": [
+    // Column lists and projections in the two dialects' INSERT text. They name
+    // the column positionally; the VALUES bound into it are the owner calls.
+    "(graph_id, kind, id, props, version, valid_from, valid_to, created_at, updated_at)",
+    "(graph_id, id, kind, from_kind, from_id, to_kind, to_id, props, valid_from, valid_to, created_at, updated_at)",
+    "SELECT graph_id, kind, id, props::jsonb, 1, valid_from, valid_to, created_at, created_at",
+    ") AS imported(graph_id, kind, id, props, valid_from, valid_to, created_at)`;",
+    "SELECT graph_id, id, kind, from_kind, from_id, to_kind, to_id, props::jsonb,",
+    "valid_from, valid_to, created_at, created_at",
+    "valid_from, valid_to, created_at",
+  ],
+};
+
+/**
+ * Every file under `src/backend/**` that names the column, and why it may.
+ * Equality: a new one fails this test whether or not it writes anything.
+ */
+const BACKEND_COLUMN_FILES: Readonly<Record<string, string>> = {
+  "drizzle/operations/nodes.ts": "writer — five stamping sites",
+  "drizzle/operations/edges.ts":
+    "writer — four stamping sites, one pass-through",
+  "drizzle/trusted-import.ts":
+    "writer — four stamping sites (native per-dialect INSERT)",
+  "drizzle/operations/shared.ts":
+    "expectedValidFromPredicate — the NULL-safe fence",
+  "drizzle/operations/collections.ts": "read predicate",
+  "live-node-candidates.ts": "read predicate (search currency)",
+  "drizzle/operations/hybrid.ts": "projection into the hybrid-search statement",
+  "row-mappers.ts": "row mapper — NULL to undefined",
+  "drizzle/schema/sqlite.ts": "column declaration",
+  "drizzle/schema/postgres.ts": "column declaration",
+  "migrate-recorded-time.ts": "copy list naming the column",
+  "types.ts": "parameter types",
+};
+
+function backendSource(relativePath: string): string {
+  return readFileSync(path.join(BACKEND_DIR, relativePath), "utf8");
+}
+
+/**
+ * The source with comments removed, so a mention inside a doc block or a `//`
+ * note is not mistaken for a call site — and, just as important, so a call site
+ * cannot be forged by writing one inside a comment.
+ */
+function withoutComments(source: string): string {
+  return source.replaceAll(/\/\*[\s\S]*?\*\//g, "").replaceAll(/\/\/.*$/gm, "");
+}
+
+function countCalls(source: string, owner: string): number {
+  return withoutComments(source).split(`${owner}(`).length - 1;
+}
+
+function columnLines(source: string): readonly string[] {
+  return withoutComments(source)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => COLUMN_MENTION.test(line));
+}
+
+/** Every `.ts` file under `src/backend/**`, relative to that directory. */
+function backendFiles(directory: string, prefix: string): readonly string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const absolute = path.join(directory, entry);
+    const relative = prefix === "" ? entry : `${prefix}/${entry}`;
+    if (statSync(absolute).isDirectory())
+      return backendFiles(absolute, relative);
+    return entry.endsWith(".ts") ? [relative] : [];
+  });
+}
+
+describe("the stamping-site inventory (I5)", () => {
+  it("has exactly the declared number of owner call sites per writer file", () => {
+    const counted = Object.fromEntries(
+      Object.keys(WRITER_INVENTORY).map((relativePath) => {
+        const source = backendSource(relativePath);
+        return [
+          relativePath,
+          {
+            stamping: countCalls(source, STAMPING_OWNER),
+            stated: countCalls(source, STATED_OWNER),
+          },
+        ];
+      }),
+    );
+    // Equality over the whole map, so a site MOVING between files fails too.
+    expect(counted).toStrictEqual({ ...WRITER_INVENTORY });
+  });
+
+  it("routes every line that names the column through an owner or a declared read", () => {
+    for (const [relativePath, allowed] of Object.entries(LEAK_ALLOWLIST)) {
+      const undeclared = columnLines(backendSource(relativePath)).filter(
+        (line) =>
+          !line.includes(`${STAMPING_OWNER}(`) &&
+          !line.includes(`${STATED_OWNER}(`) &&
+          !allowed.includes(line),
+      );
+      expect({ file: relativePath, undeclared }).toStrictEqual({
+        file: relativePath,
+        undeclared: [],
+      });
+    }
+  });
+
+  it("names the column in exactly the declared files under src/backend", () => {
+    const mentioning = backendFiles(BACKEND_DIR, "")
+      .filter((relativePath) =>
+        COLUMN_MENTION.test(backendSource(relativePath)),
+      )
+      .toSorted();
+    expect(mentioning).toStrictEqual(
+      Object.keys(BACKEND_COLUMN_FILES).toSorted(),
+    );
+  });
+
+  it("declares a role for every file it admits", () => {
+    // The role strings are the point of the previous assertion: a file added to
+    // the set without one would pass set equality while documenting nothing.
+    for (const role of Object.values(BACKEND_COLUMN_FILES)) {
+      expect(role.length).toBeGreaterThan(0);
+    }
+    expect(Object.keys(BACKEND_COLUMN_FILES)).toHaveLength(12);
+  });
+});

--- a/packages/typegraph/tests/temporal-oracle-imports.test.ts
+++ b/packages/typegraph/tests/temporal-oracle-imports.test.ts
@@ -31,8 +31,6 @@ import { describe, expect, it } from "vitest";
 
 import { generatedOpArb } from "./backends/integration/temporal-oracle";
 import {
-  emittableOpShapes,
-  KNOWN_CONTRACT_GAPS,
   TEMPORAL_OP_SHAPES,
   type TemporalOpShape,
 } from "./backends/integration/temporal-oracle-model";
@@ -125,15 +123,17 @@ describe("temporal oracle model independence", () => {
   });
 });
 
-describe("temporal oracle gap plumbing", () => {
-  it("draws op shapes from exactly the vocabulary the standing gaps leave emittable", () => {
-    // The assertion that matters is over the GENERATOR, not over
-    // `emittableOpShapes()`: comparing that function against a re-spelling of
-    // its own body can only fail if someone edits that one filter, whereas
-    // swapping `fc.constantFrom(...emittableOpShapes())` for
-    // `fc.constantFrom(...TEMPORAL_OP_SHAPES)` bypasses every restriction and
-    // would leave such a comparison green while the properties go red on `main`
-    // for a cell the gap table claims to excuse.
+describe("temporal oracle op vocabulary", () => {
+  it("draws every declared op shape, so the script covers what the vocabulary claims", () => {
+    // The assertion that matters is over the GENERATOR, not over a re-spelling
+    // of the declared list: comparing one spelling against another can only
+    // fail if someone edits that one expression, whereas narrowing what
+    // `generatedOpArb` draws from — which is exactly how the deleted
+    // `KNOWN_CONTRACT_GAPS` table withheld the shapes it excused — would leave
+    // such a comparison green while the script silently stopped exercising a
+    // cell. With no gap standing, the drawn set must be the WHOLE vocabulary:
+    // this is the ratchet that keeps the reopened born-ended and resurrection
+    // shapes genuinely emitted.
     //
     // Sampled with a fixed seed, so it is deterministic; 2000 draws over a
     // vocabulary this size hits every constant of a uniform `constantFrom`.
@@ -142,23 +142,14 @@ describe("temporal oracle gap plumbing", () => {
         .sample(generatedOpArb(), { numRuns: 2000, seed: 20_260_809 })
         .map((op) => op.shape),
     );
-    expect([...drawn].toSorted()).toEqual([...emittableOpShapes()].toSorted());
-    // ...and the vocabulary it draws from is genuinely narrowed: every standing
-    // gap withholds at least one shape (an entry restricting nothing would
-    // leave its cell reachable), and every withheld shape is really withheld.
-    for (const gap of KNOWN_CONTRACT_GAPS) {
-      expect(gap.restrictedOpShapes.length).toBeGreaterThan(0);
-      for (const shape of gap.restrictedOpShapes) {
-        expect(TEMPORAL_OP_SHAPES).toContain(shape);
-        expect([...drawn]).not.toContain(shape);
-      }
-    }
+    expect([...drawn].toSorted()).toEqual([...TEMPORAL_OP_SHAPES].toSorted());
   });
 
   it("implements every declared op shape", () => {
     // A shape declared but never executed is a silent no-op in the generator:
-    // the vocabulary would claim coverage the script does not have. Lifting a
-    // restriction in a later batch must therefore find its shape already wired.
+    // the vocabulary would claim coverage the script does not have. This is what
+    // kept each restricted shape wired while its gap stood, so lifting the
+    // restriction found an implementation waiting rather than a stub.
     const oracle = readFileSync(ORACLE_PATH, "utf8");
     const unimplemented = TEMPORAL_OP_SHAPES.filter(
       (shape) => !oracle.includes(`"${shape}"`),

--- a/packages/typegraph/tests/temporal-oracle-imports.test.ts
+++ b/packages/typegraph/tests/temporal-oracle-imports.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The temporal oracle model's independence, ratcheted.
+ *
+ * The model is only evidence if it is a SECOND implementation. Nothing stops a
+ * future edit from importing the very predicate under test and turning the
+ * oracle into a tautology, and ESLint cannot close that: `no-restricted-imports`
+ * matches the specifier string, so a ban is defeated by reaching through the
+ * `src` barrel, and the rule is not configured in this package at all.
+ *
+ * So the guard is exact-set equality over the model's own import specifiers,
+ * plus two clauses the set alone does not carry:
+ *
+ * - the `src/utils/date` import is checked at the NAMED-import level, so the
+ *   window guards (`isInvertedValidityWindow`, and the `isEmptyValidityWindow` /
+ *   `resolveStampedValidityLowerBound` pair that lands with the seam) stay out
+ *   while the timestamp normalizer stays in;
+ * - the barrel import is asserted to be an `import type` declaration. Specifier
+ *   equality alone leaves the barrel a live hole: it is closed today only by
+ *   what `src/index.ts` happens to re-export, which is not a property anyone
+ *   maintains on the model's behalf. `import type` cannot carry a value however
+ *   the barrel grows.
+ *
+ * Adding an import to the model without adding it here is a test failure,
+ * deliberately: it is the moment to ask whether the model is still independent.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { generatedOpArb } from "./backends/integration/temporal-oracle";
+import {
+  emittableOpShapes,
+  KNOWN_CONTRACT_GAPS,
+  TEMPORAL_OP_SHAPES,
+  type TemporalOpShape,
+} from "./backends/integration/temporal-oracle-model";
+
+const MODEL_PATH = fileURLToPath(
+  new URL("backends/integration/temporal-oracle-model.ts", import.meta.url),
+);
+const ORACLE_PATH = fileURLToPath(
+  new URL("backends/integration/temporal-oracle.ts", import.meta.url),
+);
+
+/**
+ * Every specifier the model may import, with the role that earns it. Equality,
+ * not a denylist: a new specifier fails whether or not anyone thought to ban it.
+ */
+const ALLOWED_MODEL_IMPORTS = {
+  // Row and backend TYPES only — asserted `import type` below.
+  "../../../src": {},
+  // SQL plumbing for the raw ledger read: table-name resolution and the
+  // fragment/intent pair. None of it decides visibility.
+  "../../../src/query/compiler/schema": {},
+  "../../../src/query/sql-fragment": {},
+  "../../../src/query/sql-intent": {},
+  // Driver normalization ONLY. The window guards live in this module too, which
+  // is why this entry is checked at the named-import level.
+  "../../../src/utils/date": { named: ["canonicalizeDatabaseTimestamp"] },
+} as const satisfies Readonly<
+  Record<string, Readonly<{ named?: readonly string[] }>>
+>;
+
+type ParsedImport = Readonly<{
+  specifier: string;
+  clause: string;
+  typeOnly: boolean;
+}>;
+
+function parseImports(source: string): readonly ParsedImport[] {
+  const pattern = /^import\s+([\s\S]*?)\s+from\s+"([^"]+)";$/gm;
+  const parsed: ParsedImport[] = [];
+  for (const match of source.matchAll(pattern)) {
+    const clause = match[1] ?? "";
+    parsed.push({
+      specifier: match[2] ?? "",
+      clause,
+      typeOnly: clause.startsWith("type "),
+    });
+  }
+  return parsed;
+}
+
+/** The names a clause binds, `type` markers stripped, aliases resolved to source names. */
+function namedBindings(clause: string): readonly string[] {
+  const braces = /\{([\s\S]*)\}/.exec(clause);
+  if (braces === null) return [];
+  return (braces[1] ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => entry.replace(/^type\s+/, "").split(/\s+as\s+/)[0] ?? "")
+    .toSorted();
+}
+
+describe("temporal oracle model independence", () => {
+  const source = readFileSync(MODEL_PATH, "utf8");
+  const imports = parseImports(source);
+
+  it("imports exactly the declared specifiers, no more and no fewer", () => {
+    expect(imports.map((entry) => entry.specifier).toSorted()).toEqual(
+      Object.keys(ALLOWED_MODEL_IMPORTS).toSorted(),
+    );
+  });
+
+  it("reaches the barrel by type only, so it cannot carry a value", () => {
+    const barrel = imports.find((entry) => entry.specifier === "../../../src");
+    expect(barrel?.typeOnly).toBe(true);
+  });
+
+  it("takes only the timestamp normalizer from the module that owns the window guards", () => {
+    const dateImport = imports.find(
+      (entry) => entry.specifier === "../../../src/utils/date",
+    );
+    expect(namedBindings(dateImport?.clause ?? "")).toEqual([
+      ...ALLOWED_MODEL_IMPORTS["../../../src/utils/date"].named,
+    ]);
+  });
+
+  it("loads nothing dynamically, which the specifier scan would not see", () => {
+    expect(/\bimport\s*\(/.test(source)).toBe(false);
+    expect(/\brequire\s*\(/.test(source)).toBe(false);
+  });
+});
+
+describe("temporal oracle gap plumbing", () => {
+  it("draws op shapes from exactly the vocabulary the standing gaps leave emittable", () => {
+    // The assertion that matters is over the GENERATOR, not over
+    // `emittableOpShapes()`: comparing that function against a re-spelling of
+    // its own body can only fail if someone edits that one filter, whereas
+    // swapping `fc.constantFrom(...emittableOpShapes())` for
+    // `fc.constantFrom(...TEMPORAL_OP_SHAPES)` bypasses every restriction and
+    // would leave such a comparison green while the properties go red on `main`
+    // for a cell the gap table claims to excuse.
+    //
+    // Sampled with a fixed seed, so it is deterministic; 2000 draws over a
+    // vocabulary this size hits every constant of a uniform `constantFrom`.
+    const drawn = new Set<TemporalOpShape>(
+      fc
+        .sample(generatedOpArb(), { numRuns: 2000, seed: 20_260_809 })
+        .map((op) => op.shape),
+    );
+    expect([...drawn].toSorted()).toEqual([...emittableOpShapes()].toSorted());
+    // ...and the vocabulary it draws from is genuinely narrowed: every standing
+    // gap withholds at least one shape (an entry restricting nothing would
+    // leave its cell reachable), and every withheld shape is really withheld.
+    for (const gap of KNOWN_CONTRACT_GAPS) {
+      expect(gap.restrictedOpShapes.length).toBeGreaterThan(0);
+      for (const shape of gap.restrictedOpShapes) {
+        expect(TEMPORAL_OP_SHAPES).toContain(shape);
+        expect([...drawn]).not.toContain(shape);
+      }
+    }
+  });
+
+  it("implements every declared op shape", () => {
+    // A shape declared but never executed is a silent no-op in the generator:
+    // the vocabulary would claim coverage the script does not have. Lifting a
+    // restriction in a later batch must therefore find its shape already wired.
+    const oracle = readFileSync(ORACLE_PATH, "utf8");
+    const unimplemented = TEMPORAL_OP_SHAPES.filter(
+      (shape) => !oracle.includes(`"${shape}"`),
+    );
+    expect(unimplemented).toEqual([]);
+  });
+});

--- a/packages/typegraph/tests/temporal-oracle-imports.test.ts
+++ b/packages/typegraph/tests/temporal-oracle-imports.test.ts
@@ -11,9 +11,9 @@
  * plus two clauses the set alone does not carry:
  *
  * - the `src/utils/date` import is checked at the NAMED-import level, so the
- *   window guards (`isInvertedValidityWindow`, and the `isEmptyValidityWindow` /
- *   `resolveStampedValidityLowerBound` pair that lands with the seam) stay out
- *   while the timestamp normalizer stays in;
+ *   window guards (`isInvertedValidityWindow`, `isEmptyValidityWindow` and the
+ *   stamping owner `resolveStampedValidityLowerBound`) stay out while the
+ *   timestamp normalizer stays in;
  * - the barrel import is asserted to be an `import type` declaration. Specifier
  *   equality alone leaves the barrel a live hole: it is closed today only by
  *   what `src/index.ts` happens to re-export, which is not a property anyone

--- a/packages/typegraph/tests/temporal-repair.test.ts
+++ b/packages/typegraph/tests/temporal-repair.test.ts
@@ -22,14 +22,16 @@
  * - **T7** `apply` is convergent and idempotent, and changes only inverted
  *   rows — a stated zero-width window is a legal shape and is left alone.
  * - **T7b** the three deployment shapes, each scoped per mode: custom table
- *   names are APPLIED in both modes; a backend without `executeStatement` and a
- *   recorded-capture backend both REPORT successfully and REFUSE `apply` with a
- *   typed error naming the state. The capture case carries T6's "writes
+ *   names, including partial patches, are APPLIED in both modes; a backend
+ *   without `executeStatement` and a recorded-capture backend both REPORT
+ *   successfully and REFUSE `apply` with a typed error naming the state. The
+ *   capture case carries T6's "writes
  *   nothing" onto the RECORDED axis — clock included — because that backend's
  *   `transaction` is the one read path that opens a capture scope.
  * - **T7c** `report` distinguishes "not scanned" (`undefined`) from "zero".
- * - **T7d** a backend without transactions still runs both modes, and says so
- *   with `report.atomic === false`.
+ * - **T7d** atomicity is reported from the transaction seam rather than object
+ *   identity; a backend without transactions still runs both modes and reports
+ *   `atomic === false`.
  */
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -44,10 +46,11 @@ import {
 } from "../src";
 import { createSqliteTables } from "../src/backend/drizzle/schema/sqlite";
 import { invertedValidityWindowPredicate } from "../src/backend/repair-validity-windows";
-import type {
-  GraphBackend,
-  TransactionBackend,
-  TransactionOptions,
+import {
+  createBackendOverlay,
+  type GraphBackend,
+  type TransactionBackend,
+  type TransactionOptions,
 } from "../src/backend/types";
 import { asNodeId } from "../src/core";
 import { renderSql, sql } from "../src/query/sql-fragment";
@@ -566,6 +569,25 @@ describe("repairInvertedValidityWindows", () => {
       expect(report.counts.nodes).toBe(1);
     });
 
+    it("merges a partial tableNames override over the backend's own", async () => {
+      const custom = await seedCustomTables();
+
+      const report = await repairInvertedValidityWindows({
+        backend: custom,
+        relations: "live-and-recorded",
+        mode: "report",
+        tableNames: {
+          nodes: CUSTOM_NAMES.nodes,
+          recordedNodes: undefined,
+        },
+      });
+
+      expect(report.counts.nodes).toBe(1);
+      expect(report.counts.edges).toBe(0);
+      expect(report.counts.recordedNodes).toBe(0);
+      expect(report.counts.recordedEdges).toBe(0);
+    });
+
     it("reports on a backend without executeStatement and refuses to apply", async () => {
       await seedGraph(backend);
       const { executeStatement, ...rest } = backend;
@@ -729,6 +751,29 @@ describe("repairInvertedValidityWindows", () => {
         relations: "live",
         mode: "report",
       });
+      expect(report.atomic).toBe(true);
+    });
+
+    it("reports the transaction seam rather than inferring from object identity", async () => {
+      await seedGraph(backend);
+      let sameIdentityBackend: GraphBackend;
+      sameIdentityBackend = createBackendOverlay(backend, {
+        transaction: <T>(
+          fn: (tx: TransactionBackend) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> =>
+          backend.transaction(
+            () => fn(sameIdentityBackend as TransactionBackend),
+            options,
+          ),
+      });
+
+      const report = await repairInvertedValidityWindows({
+        backend: sameIdentityBackend,
+        relations: "live",
+        mode: "report",
+      });
+
       expect(report.atomic).toBe(true);
     });
   });

--- a/packages/typegraph/tests/temporal-repair.test.ts
+++ b/packages/typegraph/tests/temporal-repair.test.ts
@@ -756,16 +756,16 @@ describe("repairInvertedValidityWindows", () => {
 
     it("reports the transaction seam rather than inferring from object identity", async () => {
       await seedGraph(backend);
-      let sameIdentityBackend: GraphBackend;
-      sameIdentityBackend = createBackendOverlay(backend, {
-        transaction: <T>(
-          fn: (tx: TransactionBackend) => Promise<T>,
-          options?: TransactionOptions,
-        ): Promise<T> =>
-          backend.transaction(
-            () => fn(sameIdentityBackend as TransactionBackend),
-            options,
-          ),
+      function sameIdentityTransaction<T>(
+        fn: (tx: TransactionBackend) => Promise<T>,
+      ): Promise<T> {
+        return fn(sameIdentityBackend);
+      }
+      const sameIdentityBackend: GraphBackend = createBackendOverlay(backend, {
+        // A custom backend may expose the same object as its transaction
+        // context. The helper must report that it invoked the transaction seam
+        // without trying to infer that fact from callback-target identity.
+        transaction: sameIdentityTransaction,
       });
 
       const report = await repairInvertedValidityWindows({

--- a/packages/typegraph/tests/temporal-repair.test.ts
+++ b/packages/typegraph/tests/temporal-repair.test.ts
@@ -1,0 +1,735 @@
+/**
+ * The repair story for validity windows an older library version stored
+ * inverted (`valid_from > valid_to`), design §C.
+ *
+ * Such a row is readable at NO coordinate: `asOf(t)` needs
+ * `valid_from <= t < valid_to`, and backwards bounds admit no `t`. Current
+ * write paths cannot mint one — a write that stamps a lower bound the caller
+ * did not state stores none rather than an inverting one — but deploying that
+ * fix rewrites nothing, so a legacy row stays invisible until an operator runs
+ * `repairInvertedValidityWindows`.
+ *
+ * That is also why every row here is seeded with raw SQL: the store API can no
+ * longer produce the shape under test, and a suite that seeded through it would
+ * be testing a state the repair does not exist for.
+ *
+ * Covered here (SQLite; the PostgreSQL parity suite is
+ * `tests/backends/postgres/repair-validity-windows.test.ts`):
+ *
+ * - **T6** `report` finds the row and writes NOTHING — and says so to the
+ *   engine, opening its scan in a read-only transaction so a diagnostic pointed
+ *   at a live store neither writes nor reserves SQLite's single writer slot.
+ * - **T7** `apply` is convergent and idempotent, and changes only inverted
+ *   rows — a stated zero-width window is a legal shape and is left alone.
+ * - **T7b** the three deployment shapes, each scoped per mode: custom table
+ *   names are APPLIED in both modes; a backend without `executeStatement` and a
+ *   recorded-capture backend both REPORT successfully and REFUSE `apply` with a
+ *   typed error naming the state. The capture case carries T6's "writes
+ *   nothing" onto the RECORDED axis — clock included — because that backend's
+ *   `transaction` is the one read path that opens a capture scope.
+ * - **T7c** `report` distinguishes "not scanned" (`undefined`) from "zero".
+ * - **T7d** a backend without transactions still runs both modes, and says so
+ *   with `report.atomic === false`.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import type { Store } from "../src";
+import {
+  ConfigurationError,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  repairInvertedValidityWindows,
+} from "../src";
+import { createSqliteTables } from "../src/backend/drizzle/schema/sqlite";
+import { invertedValidityWindowPredicate } from "../src/backend/repair-validity-windows";
+import type {
+  GraphBackend,
+  TransactionBackend,
+  TransactionOptions,
+} from "../src/backend/types";
+import { asNodeId } from "../src/core";
+import { renderSql, sql } from "../src/query/sql-fragment";
+import {
+  asCompiledRowsSql,
+  asCompiledStatementSql,
+} from "../src/query/sql-intent";
+import { createRecordedBackend } from "../src/store/recorded-capture";
+import { requireDefined } from "../src/utils/presence";
+import { createInitializedStore, createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const knows = defineEdge("knows", {
+  schema: z.object({ since: z.string() }),
+});
+
+const graph = defineGraph({
+  id: "temporal_repair",
+  nodes: { Person: { type: Person } },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+const NODES = "typegraph_nodes";
+const EDGES = "typegraph_edges";
+const RECORDED_NODES = "typegraph_recorded_nodes";
+const RECORDED_EDGES = "typegraph_recorded_edges";
+const RECORDED_CLOCK = "typegraph_recorded_clock";
+
+const EARLY = "2020-01-01T00:00:00.000Z";
+const MIDDLE = "2022-01-01T00:00:00.000Z";
+const LATE = "2024-01-01T00:00:00.000Z";
+
+type RawRow = Readonly<Record<string, unknown>>;
+
+/**
+ * Writes a window straight into the relation, bypassing every guard — the only
+ * way to reach a shape the library refuses to write.
+ */
+async function seedWindow(
+  backend: GraphBackend,
+  table: string,
+  id: string,
+  window: Readonly<{ validFrom: string | undefined; validTo: string }>,
+): Promise<void> {
+  const lowerBound =
+    window.validFrom === undefined ? sql`NULL` : sql`${window.validFrom}`;
+  await requireDefined(backend.executeStatement)(
+    asCompiledStatementSql(sql`
+      UPDATE ${sql.identifier(table)}
+      SET valid_from = ${lowerBound}, valid_to = ${window.validTo}
+      WHERE id = ${id}
+    `),
+  );
+}
+
+/**
+ * A recorded row carrying the pre-fix shape, seeded the same way a legacy
+ * capture would have left it. Raw SQL for the same reason the live seeds are: a
+ * history store can no more mint an inverted recorded window than the live
+ * store can.
+ */
+async function seedRecordedNode(
+  backend: GraphBackend,
+  id: string,
+  window: Readonly<{ validFrom: string; validTo: string }>,
+): Promise<void> {
+  await requireDefined(backend.executeStatement)(
+    asCompiledStatementSql(sql`
+      INSERT INTO ${sql.identifier(RECORDED_NODES)} (
+        history_id, graph_id, kind, id, props, version,
+        valid_from, valid_to, created_at, updated_at,
+        recorded_from, recorded_to, op, meta
+      ) VALUES (
+        ${`h_${id}`}, ${graph.id}, 'Person', ${id},
+        ${JSON.stringify({ name: id })}, 1,
+        ${window.validFrom}, ${window.validTo}, ${EARLY}, ${EARLY},
+        1, 2, 'create', '{}'
+      )
+    `),
+  );
+}
+
+/**
+ * A per-graph recorded clock standing where a history-enabled deployment's
+ * would. Seeded rather than left empty so that "the repair advanced the clock"
+ * is a visible difference and not just a row appearing.
+ */
+async function seedRecordedClock(
+  backend: GraphBackend,
+  revision: number,
+): Promise<void> {
+  await requireDefined(backend.executeStatement)(
+    asCompiledStatementSql(sql`
+      INSERT INTO ${sql.identifier(RECORDED_CLOCK)}
+        (graph_id, revision, recorded_at)
+      VALUES (${graph.id}, ${revision}, ${EARLY})
+    `),
+  );
+}
+
+/**
+ * Every column of every row, ordered — the byte-identity witness for T6.
+ *
+ * `orderBy` names the relation's own stable key: the ledgers order by `id`, the
+ * recorded clock has one row per `graph_id` and no `id` column at all.
+ */
+async function readRelation(
+  backend: GraphBackend,
+  table: string,
+  orderBy = "id",
+): Promise<readonly RawRow[]> {
+  return backend.execute<RawRow>(
+    asCompiledRowsSql(sql`
+      SELECT * FROM ${sql.identifier(table)} ORDER BY ${sql.identifier(orderBy)}
+    `),
+  );
+}
+
+/**
+ * The whole recorded axis: both recorded ledgers and the clock that mints
+ * revisions over them. What a `"report"` must leave untouched — not only the
+ * rows, but the clock, because minting a revision is how a capture-wrapped
+ * backend would write while storing no row of its own.
+ */
+async function readRecordedAxis(
+  backend: GraphBackend,
+): Promise<Readonly<Record<string, readonly RawRow[]>>> {
+  return {
+    recordedNodes: await readRelation(backend, RECORDED_NODES),
+    recordedEdges: await readRelation(backend, RECORDED_EDGES),
+    recordedClock: await readRelation(backend, RECORDED_CLOCK, "graph_id"),
+  };
+}
+
+/**
+ * The stored window, with SQL NULL mapped to `undefined` — the shape the row
+ * mappers hand the rest of the library, and the one this suite asserts.
+ */
+async function readWindow(
+  backend: GraphBackend,
+  table: string,
+  id: string,
+): Promise<
+  Readonly<{ validFrom: string | undefined; validTo: string | undefined }>
+> {
+  const rows = await backend.execute<
+    Readonly<{ valid_from: unknown; valid_to: unknown }>
+  >(
+    asCompiledRowsSql(sql`
+      SELECT valid_from, valid_to FROM ${sql.identifier(table)} WHERE id = ${id}
+    `),
+  );
+  const row = requireDefined(rows[0]);
+  return {
+    validFrom: typeof row.valid_from === "string" ? row.valid_from : undefined,
+    validTo: typeof row.valid_to === "string" ? row.valid_to : undefined,
+  };
+}
+
+/**
+ * One graph holding every window shape the repair must tell apart:
+ *
+ * - `inverted` — the defect: backwards bounds, readable nowhere.
+ * - `zeroWidth` — legal: a caller may state `[a, a)` in full, and the repair
+ *   does not second-guess a window nobody stamped.
+ * - `ordered` — an ordinary bounded row.
+ * - `openLeft` — already the shape the repair normalizes to.
+ */
+async function seedGraph(backend: GraphBackend): Promise<Store<typeof graph>> {
+  const store = await createInitializedStore(graph, backend);
+  for (const id of ["inverted", "zeroWidth", "ordered", "openLeft"]) {
+    await store.nodes.Person.create({ name: id }, { id });
+  }
+  await store.edges.knows.create(
+    { kind: "Person", id: "inverted" },
+    { kind: "Person", id: "ordered" },
+    { since: EARLY },
+    { id: "invertedEdge" },
+  );
+  await seedWindow(backend, NODES, "inverted", {
+    validFrom: LATE,
+    validTo: EARLY,
+  });
+  await seedWindow(backend, NODES, "zeroWidth", {
+    validFrom: MIDDLE,
+    validTo: MIDDLE,
+  });
+  await seedWindow(backend, NODES, "ordered", {
+    validFrom: EARLY,
+    validTo: LATE,
+  });
+  await seedWindow(backend, NODES, "openLeft", {
+    validFrom: undefined,
+    validTo: LATE,
+  });
+  await seedWindow(backend, EDGES, "invertedEdge", {
+    validFrom: LATE,
+    validTo: EARLY,
+  });
+  return store;
+}
+
+describe("repairInvertedValidityWindows", () => {
+  let backend: GraphBackend;
+
+  beforeEach(() => {
+    backend = createTestBackend();
+  });
+
+  describe("T6 — report mode", () => {
+    it("finds a seeded legacy inverted row and writes nothing", async () => {
+      await seedGraph(backend);
+      const before = {
+        nodes: await readRelation(backend, NODES),
+        edges: await readRelation(backend, EDGES),
+      };
+
+      const report = await repairInvertedValidityWindows({
+        backend,
+        relations: "live-and-recorded",
+        mode: "report",
+      });
+
+      expect(report.counts).toEqual({
+        nodes: 1,
+        edges: 1,
+        recordedNodes: 0,
+        recordedEdges: 0,
+      });
+      // Byte identity over EVERY column, not just the window: a report that
+      // ran the apply statement would change `valid_from` here, and one that
+      // touched `version`/`updated_at` would change those.
+      expect({
+        nodes: await readRelation(backend, NODES),
+        edges: await readRelation(backend, EDGES),
+      }).toEqual(before);
+    });
+
+    it("opens a read-only transaction to scan, and a writing one to apply", async () => {
+      await seedGraph(backend);
+      const accessModes: (TransactionOptions["accessMode"] | undefined)[] = [];
+      // White-box on purpose: the engine effect this pins — `BEGIN` instead of
+      // the writer-slot-reserving `BEGIN IMMEDIATE` — is invisible from the one
+      // connection a test holds. What IS observable is the decision itself, and
+      // that is what the docs promise operators when they say a `report` may be
+      // pointed at a live store without quiescing it. The PostgreSQL suite
+      // asserts the engine's own verdict (`SHOW transaction_read_only`).
+      const observed: GraphBackend = {
+        ...backend,
+        transaction: async <T>(
+          fn: (tx: TransactionBackend) => Promise<T>,
+          options?: TransactionOptions,
+        ): Promise<T> => {
+          accessModes.push(options?.accessMode);
+          return backend.transaction((tx) => fn(tx), options);
+        },
+      };
+
+      await repairInvertedValidityWindows({
+        backend: observed,
+        relations: "live-and-recorded",
+        mode: "report",
+      });
+      await repairInvertedValidityWindows({
+        backend: observed,
+        relations: "live",
+        mode: "apply",
+      });
+
+      expect(accessModes).toEqual(["read_only", undefined]);
+    });
+
+    it("reports the same counts twice, because it changes nothing", async () => {
+      await seedGraph(backend);
+      const first = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "report",
+      });
+      const second = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "report",
+      });
+      expect(second.counts).toEqual(first.counts);
+      expect(first.counts.nodes).toBe(1);
+    });
+  });
+
+  describe("T7 — apply mode", () => {
+    it("repairs only inverted rows and converges", async () => {
+      const store = await seedGraph(backend);
+
+      const applied = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "apply",
+      });
+      expect(applied.counts.nodes).toBe(1);
+      expect(applied.counts.edges).toBe(1);
+      expect(applied.atomic).toBe(true);
+
+      expect(await readWindow(backend, NODES, "inverted")).toEqual({
+        validFrom: undefined,
+        validTo: EARLY,
+      });
+      expect(await readWindow(backend, EDGES, "invertedEdge")).toEqual({
+        validFrom: undefined,
+        validTo: EARLY,
+      });
+      // A stated zero-width window is legal and is NOT the defect: it is
+      // readable at no instant because its author said so.
+      expect(await readWindow(backend, NODES, "zeroWidth")).toEqual({
+        validFrom: MIDDLE,
+        validTo: MIDDLE,
+      });
+      expect(await readWindow(backend, NODES, "ordered")).toEqual({
+        validFrom: EARLY,
+        validTo: LATE,
+      });
+
+      // The point of the repair: the row is now readable before its end.
+      await expect(
+        store.nodes.Person.getById(asNodeId<typeof Person>("inverted"), {
+          temporalMode: "asOf",
+          asOf: "2019-01-01T00:00:00.000Z",
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it("is idempotent: a second run reports zero and changes nothing", async () => {
+      await seedGraph(backend);
+      await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "apply",
+      });
+      const after = {
+        nodes: await readRelation(backend, NODES),
+        edges: await readRelation(backend, EDGES),
+      };
+
+      const second = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "apply",
+      });
+      expect(second.counts.nodes).toBe(0);
+      expect(second.counts.edges).toBe(0);
+      expect({
+        nodes: await readRelation(backend, NODES),
+        edges: await readRelation(backend, EDGES),
+      }).toEqual(after);
+
+      const report = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "report",
+      });
+      expect(report.counts.nodes).toBe(0);
+      expect(report.counts.edges).toBe(0);
+    });
+
+    it("leaves a row whose bounds it cannot classify alone, and refuses", async () => {
+      await seedGraph(backend);
+      // SQLite compares TEXT lexicographically, so a non-canonical bound cannot
+      // be classified without a semantics this repair does not own.
+      await seedWindow(backend, NODES, "ordered", {
+        validFrom: "2024",
+        validTo: EARLY,
+      });
+
+      const report = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "report",
+      });
+      expect(report.nonCanonical.nodes).toBe(1);
+      expect(report.nonCanonical.edges).toBe(0);
+      // Not classified, so not counted as inverted either.
+      expect(report.counts.nodes).toBe(1);
+
+      await expect(
+        repairInvertedValidityWindows({
+          backend,
+          relations: "live",
+          mode: "apply",
+        }),
+      ).rejects.toThrow(/non-canonical bounds/);
+      // The refusal is total for the call: nothing was repaired.
+      expect(await readWindow(backend, NODES, "inverted")).toEqual({
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+    });
+
+    it("narrows to one graph when graphId is given", async () => {
+      await seedGraph(backend);
+      const report = await repairInvertedValidityWindows({
+        backend,
+        graphId: "some_other_graph",
+        relations: "live",
+        mode: "apply",
+      });
+      expect(report.counts.nodes).toBe(0);
+      expect(await readWindow(backend, NODES, "inverted")).toEqual({
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+    });
+
+    it("establishes canonicality before comparing, on SQLite only", () => {
+      // The predicate TEXT is one owner; its SEMANTICS are not dialect-neutral.
+      // SQLite compares the bounds as TEXT, so `>` is chronological only for
+      // canonical values — which is exactly what a relation holding legacy rows
+      // cannot be assumed to hold. PostgreSQL stores `timestamptz`, where the
+      // comparison is chronological unconditionally.
+      const sqlite = renderSql(
+        invertedValidityWindowPredicate({ dialect: "sqlite" }),
+        "sqlite",
+      ).sql;
+      const postgres = renderSql(
+        invertedValidityWindowPredicate({ dialect: "postgres" }),
+        "postgres",
+      ).sql;
+      expect(sqlite).toContain("GLOB");
+      expect(postgres).not.toContain("GLOB");
+      for (const rendered of [sqlite, postgres]) {
+        expect(rendered).toContain("valid_from > valid_to");
+        expect(rendered).not.toContain("graph_id");
+      }
+      expect(
+        renderSql(
+          invertedValidityWindowPredicate({
+            dialect: "postgres",
+            graphId: "g",
+          }),
+          "postgres",
+        ).sql,
+      ).toContain("graph_id");
+    });
+  });
+
+  describe("T7b — the three deployment shapes, per mode", () => {
+    const CUSTOM_NAMES = {
+      nodes: "app_nodes",
+      edges: "app_edges",
+      recordedNodes: "app_recorded_nodes",
+      recordedEdges: "app_recorded_edges",
+      recordedClock: "app_recorded_clock",
+      revisionOrigins: "app_revision_origins",
+      fulltext: "app_fulltext",
+      uniques: "app_uniques",
+      identityAssertions: "app_identity_assertions",
+      recordedIdentityAssertions: "app_recorded_identity_assertions",
+      identityClosure: "app_identity_closure",
+      identitySeparation: "app_identity_separation",
+    } as const;
+
+    async function seedCustomTables(): Promise<GraphBackend> {
+      const custom = createTestBackend(createSqliteTables(CUSTOM_NAMES));
+      const store = await createInitializedStore(graph, custom);
+      await store.nodes.Person.create({ name: "inverted" }, { id: "inverted" });
+      await seedWindow(custom, CUSTOM_NAMES.nodes, "inverted", {
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+      return custom;
+    }
+
+    it("threads the backend's table names into both modes", async () => {
+      const custom = await seedCustomTables();
+
+      const report = await repairInvertedValidityWindows({
+        backend: custom,
+        relations: "live",
+        mode: "report",
+      });
+      expect(report.counts.nodes).toBe(1);
+
+      await repairInvertedValidityWindows({
+        backend: custom,
+        relations: "live",
+        mode: "apply",
+      });
+      expect(await readWindow(custom, CUSTOM_NAMES.nodes, "inverted")).toEqual({
+        validFrom: undefined,
+        validTo: EARLY,
+      });
+    });
+
+    it("applies an explicit tableNames override over the backend's own", async () => {
+      const custom = await seedCustomTables();
+      // A backend that names no tables resolves the built-in defaults, which do
+      // not exist here — the shape a repair that ignored `tableNames` would hit.
+      const { tableNames, ...unnamed } = custom;
+      const defaulted = unnamed as GraphBackend;
+
+      await expect(
+        repairInvertedValidityWindows({
+          backend: defaulted,
+          relations: "live",
+          mode: "report",
+        }),
+      ).rejects.toThrow(/typegraph_nodes/);
+
+      const report = await repairInvertedValidityWindows({
+        backend: defaulted,
+        relations: "live",
+        mode: "report",
+        tableNames: CUSTOM_NAMES,
+      });
+      expect(report.counts.nodes).toBe(1);
+    });
+
+    it("reports on a backend without executeStatement and refuses to apply", async () => {
+      await seedGraph(backend);
+      const { executeStatement, ...rest } = backend;
+      const readOnly = rest as GraphBackend;
+
+      const report = await repairInvertedValidityWindows({
+        backend: readOnly,
+        relations: "live",
+        mode: "report",
+      });
+      expect(report.counts.nodes).toBe(1);
+
+      const refusal = await repairInvertedValidityWindows({
+        backend: readOnly,
+        relations: "live",
+        mode: "apply",
+      }).catch((error: unknown) => error);
+      expect(refusal).toBeInstanceOf(ConfigurationError);
+      expect((refusal as ConfigurationError).message).toMatch(
+        /requires executeStatement support/,
+      );
+    });
+
+    it("reports through a recorded-capture backend and refuses to apply", async () => {
+      await seedGraph(backend);
+      await seedRecordedNode(backend, "kept", {
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+      await seedRecordedClock(backend, 3);
+      const captured = createRecordedBackend(backend);
+      const before = await readRecordedAxis(backend);
+
+      const report = await repairInvertedValidityWindows({
+        backend: captured,
+        relations: "live-and-recorded",
+        mode: "report",
+      });
+      expect(report.counts.nodes).toBe(1);
+      expect(report.counts.recordedNodes).toBe(1);
+      // The one path where "report writes nothing" is genuinely at risk: this
+      // backend's `transaction` opens a CAPTURED scope and flushes it, so the
+      // report runs inside recorded-time capture. Byte identity over both
+      // recorded ledgers AND the clock is the witness — a scope that minted a
+      // revision would leave no recorded row behind but would still bump
+      // `typegraph_recorded_clock`, which is a write by any reading of the
+      // contract. `accessMode: "read_only"` is what tells the wrapper the scope
+      // owns no write lock, and on PostgreSQL what makes the engine enforce it.
+      expect(await readRecordedAxis(backend)).toEqual(before);
+
+      const refusal = await repairInvertedValidityWindows({
+        backend: captured,
+        relations: "live",
+        mode: "apply",
+      }).catch((error: unknown) => error);
+      expect(refusal).toBeInstanceOf(ConfigurationError);
+      expect((refusal as ConfigurationError).message).toMatch(
+        /history-capturing backend/,
+      );
+      expect((refusal as ConfigurationError).details["code"]).toBe(
+        "RECORDED_CAPTURE_RAW_SQL_DISABLED",
+      );
+      // Refused, not half-done.
+      expect(await readWindow(backend, NODES, "inverted")).toEqual({
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+    });
+  });
+
+  describe("T7c — not scanned is not zero", () => {
+    it("leaves unscanned relations undefined rather than 0", async () => {
+      await seedGraph(backend);
+      const live = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "report",
+      });
+      expect(live.relations).toBe("live");
+      expect(live.counts.recordedNodes).toBeUndefined();
+      expect(live.counts.recordedEdges).toBeUndefined();
+      expect(live.nonCanonical.recordedNodes).toBeUndefined();
+      expect(live.counts.nodes).toBe(1);
+
+      const both = await repairInvertedValidityWindows({
+        backend,
+        relations: "live-and-recorded",
+        mode: "report",
+      });
+      expect(both.relations).toBe("live-and-recorded");
+      expect(both.counts.recordedNodes).toBe(0);
+      expect(both.counts.recordedEdges).toBe(0);
+      expect(both.nonCanonical.recordedNodes).toBe(0);
+    });
+
+    it("repairs the recorded axis when it is in scope", async () => {
+      const store = await createInitializedStore(graph, backend);
+      await store.nodes.Person.create({ name: "kept" }, { id: "kept" });
+      await seedRecordedNode(backend, "kept", {
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+
+      const live = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "apply",
+      });
+      expect(live.counts.recordedNodes).toBeUndefined();
+      expect(await readWindow(backend, RECORDED_NODES, "kept")).toEqual({
+        validFrom: LATE,
+        validTo: EARLY,
+      });
+
+      const both = await repairInvertedValidityWindows({
+        backend,
+        relations: "live-and-recorded",
+        mode: "apply",
+      });
+      expect(both.counts.recordedNodes).toBe(1);
+      expect(await readWindow(backend, RECORDED_NODES, "kept")).toEqual({
+        validFrom: undefined,
+        validTo: EARLY,
+      });
+    });
+  });
+
+  describe("T7d — a backend without transactions", () => {
+    it("runs both modes and says the call was not atomic", async () => {
+      await seedGraph(backend);
+      const nonTransactional: GraphBackend = {
+        ...backend,
+        capabilities: { ...backend.capabilities, transactions: false },
+      };
+
+      const report = await repairInvertedValidityWindows({
+        backend: nonTransactional,
+        relations: "live",
+        mode: "report",
+      });
+      expect(report.atomic).toBe(false);
+      expect(report.counts.nodes).toBe(1);
+
+      const applied = await repairInvertedValidityWindows({
+        backend: nonTransactional,
+        relations: "live",
+        mode: "apply",
+      });
+      expect(applied.atomic).toBe(false);
+      expect(applied.counts.nodes).toBe(1);
+      expect(await readWindow(backend, NODES, "inverted")).toEqual({
+        validFrom: undefined,
+        validTo: EARLY,
+      });
+    });
+
+    it("reports atomic on a backend that has transactions", async () => {
+      await seedGraph(backend);
+      const report = await repairInvertedValidityWindows({
+        backend,
+        relations: "live",
+        mode: "report",
+      });
+      expect(report.atomic).toBe(true);
+    });
+  });
+});

--- a/packages/typegraph/tests/test-utils.ts
+++ b/packages/typegraph/tests/test-utils.ts
@@ -15,6 +15,7 @@ import {
   createStore,
   createStoreWithSchema,
   IMMUTABLE_VALIDITY_LOWER_BOUND_CODE,
+  INVERTED_VALIDITY_WINDOW_CODE,
   ValidationError,
 } from "../src";
 import type { AnySqliteDatabase } from "../src/backend/drizzle/execution";
@@ -459,6 +460,24 @@ export async function expectImmutableLowerBoundRefusal(
   expect(
     (error as ValidationError).details.issues.map((issue) => issue.code),
   ).toContain(IMMUTABLE_VALIDITY_LOWER_BOUND_CODE);
+}
+
+/**
+ * Asserts an operation was refused for naming a window of negative width,
+ * identified by its stable issue code rather than by message text.
+ *
+ * Sibling of {@link expectImmutableLowerBoundRefusal}, and here for the same
+ * reason: the refusal is one refusal wherever an end lands before a start, so
+ * every path that expects it asserts it the same way.
+ */
+export async function expectInvertedWindowRefusal(
+  operation: Promise<unknown>,
+): Promise<void> {
+  await expect(operation).rejects.toThrow(ValidationError);
+  const error = await operation.catch((error_: unknown) => error_);
+  expect(
+    (error as ValidationError).details.issues.map((issue) => issue.code),
+  ).toContain(INVERTED_VALIDITY_WINDOW_CODE);
 }
 
 export { generateSqliteDDL } from "../src/backend/drizzle/ddl";

--- a/packages/typegraph/type-smoke/strict-local-consumers.ts
+++ b/packages/typegraph/type-smoke/strict-local-consumers.ts
@@ -11,6 +11,7 @@ import {
   fts5Strategy,
   type InsertNodeParams,
   type NodeRow,
+  resolveStampedValidityLowerBound,
   sql as backendSql,
   type SqlIdentifierChunk,
   type SqlParameterChunk,
@@ -87,6 +88,11 @@ const backendNodeRow: NodeRow = {
 const publicTransactionOptions: BackendTransactionOptions = {
   accessMode: "read_only",
 };
+const backendResolvedLowerBound = resolveStampedValidityLowerBound(
+  undefined,
+  "2026-01-01T00:00:01.000Z",
+  "2026-01-01T00:00:00.000Z",
+);
 const rootTransactionOptions: TransactionOptions = publicTransactionOptions;
 if (false) {
   const privilegedOptions: BackendTransactionOptions = {
@@ -97,6 +103,7 @@ if (false) {
 }
 void backendNodeParams;
 void backendNodeRow;
+void backendResolvedLowerBound;
 void backendSqlTag;
 void rootTransactionOptions;
 void builtInStrategy;


### PR DESCRIPTION
A create stating only a historical `validTo` had its `valid_from` stamped with the write instant, storing a window that runs backwards—a legal write producing a row invisible at every `asOf` coordinate (#407). This PR closes that class at the storage contract, ships an operator repair for rows older versions left behind, and lands a permanent cross-backend temporal oracle so the window invariants are guarded by an independent model rather than example tests alone.

**The contract.** A write that stamps a lower bound the caller did not state now stores the write instant only when doing so leaves a window some coordinate can read. If a stated `validTo` falls at or before that instant, the row stores no lower bound—"ended at T, start unknown"—and reads back at every `asOf` before its end instead of at none. A future `validTo` still stamps the write instant, so a scheduled-end row remains invisible before it existed. The decision has one owner, `resolveStampedValidityLowerBound`, exported from `@nicia-ai/typegraph/backend` for custom `GraphBackend` implementations and used by the built-in node and edge insert builders, trusted import, and node resurrection paths. Edge resurrection deliberately retains its stored lower bound. `meta.validFrom` reads back as `undefined` for a born-ended row.

**The repair.** Existing inverted rows are not rewritten automatically. `repairInvertedValidityWindows` provides explicit `"report"` and `"apply"` modes, requires callers to choose `"live"` or `"live-and-recorded"`, and uses one shared predicate for counting and updating. A strict comparison preserves legal zero-width windows. Partial `tableNames` values patch the backend's configured names, including when an optional property is explicitly `undefined`, rather than retargeting unstated relations to built-in defaults. Unsupported apply paths refuse with typed errors, report mode requests a read-only transaction, and the result's `atomic` field comes directly from the optional-transaction seam instead of object-identity inference. Operators should quiesce writers for apply: store updates re-read and re-judge after a lost fence, while interchange reports a per-row target-changed error.

**The oracle and visibility contract.** The shared integration suite drives randomized bitemporal histories through every backend and checks four answers against one another: an independent interval-algebra model, compiled queries, SQL-filtered collection reads, and the in-memory `getById`/`getByIds` path. The model's deliberately narrow infrastructure imports are pinned by an exact import ratchet. The generated histories cover born-ended inserts, scheduled ends, reopen operations, unchanged-upsert coalescing, node resurrection, edge endpoint resurrection, history capture, and interchange round trips. Store and provenance JavaScript reads now consume one `validityWindowContainsInstant` predicate, with its semantics checked against the independent interval model, so those consumers cannot drift by re-spelling the comparison.

**Compatibility.** Rows already stored with inverted windows remain unchanged until repaired. Born-ended writes now expose `meta.validFrom` as `undefined`, and node resurrection accepts the same born-ended shape as node creation. These are the disclosed behavior changes and the changeset remains a minor release.

Closes #407
