### PR TITLE
feat(graph-merge): add constraint-aware ingestion branches

### DIFF
--- a/.changeset/honest-ingestion-branches.md
+++ b/.changeset/honest-ingestion-branches.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add constraint-aware ingestion branches that defer node uniqueness during staging and validate the resolved merge write set atomically.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -823,6 +823,74 @@ operations mutate rows through their own preflights, and projecting the side
 effects into a merge would detach them from the schema change that caused
 them. Apply schema changes to the target first (or re-fork), then merge.
 
+### Constraint-aware ingestion branches
+
+Use `ingestionBranch()` when an untrusted ingestion batch may contain aliases
+that deliberately repeat a canonical node's unique key. An ordinary `branch()`
+keeps the complete graph schema and rejects the duplicate during staging,
+before entity resolution can review and collapse it. An ingestion branch
+materializes an honest working-copy schema with only node uniqueness deferred;
+schema validation, edge endpoint checks, disjointness, and edge cardinality
+still apply immediately.
+
+```typescript
+import {
+  applyMergePlan,
+  asBranchId,
+  ingestionBranch,
+  planMergeIncremental,
+  unwrap,
+} from "@nicia-ai/typegraph/graph-merge";
+
+const incoming = unwrap(
+  await ingestionBranch(base, makeBackend, {
+    id: asBranchId("provider-a"),
+  }),
+);
+
+await incoming.nodes.Patient.create(
+  { name: "Ana Rivera", cohort: "C1", mrn: "MRN-123" },
+  { id: "incoming-patient" },
+);
+
+const plan = unwrap(
+  await planMergeIncremental({
+    forkPoint: base,
+    target: base,
+    branches: [incoming],
+    options: {
+      onBasePropertyConflict: "flag",
+      resolve: {
+        Patient: {
+          blockIndex: "patient_mrn_candidates",
+          similarity: { kind: "fulltext", fields: ["name"] },
+          threshold: 0.9,
+        },
+      },
+    },
+  }),
+);
+const applied = unwrap(await applyMergePlan(base, plan));
+await incoming.close();
+```
+
+The returned handle exposes ingestion collections, not the branch's underlying
+`Store`, so callers cannot bypass the deferred-constraint contract or run schema
+operations on the derived working copy. The original graph definition remains
+the merge contract: `applyMergePlan()` validates node uniqueness against the
+entire resolved write set in the target transaction. Valid key handoffs and
+swaps are accepted as one set. If reviewed resolution leaves two live owners of
+the same unique key, the merge returns `MergeConstraintConflictError` and
+commits no graph or provenance writes.
+
+The derived schema is persisted on the working-copy backend, so the relaxed
+contract is auditable and an explicit reattachment with an equivalent graph
+definition verifies the same constraint behavior. `ingestionBranch()` does not
+expose a general reopen/resume API. Deferral is not an in-memory flag and does
+not disable database constraints ad hoc. Ingestion branches require a backend
+with the batch uniqueness operations needed for atomic final validation.
+Unsupported backends are refused rather than falling back to sequential checks.
+
 ## Valid-time windows
 
 **A new row's window travels with the merge.** A branch-authored node or edge
@@ -955,7 +1023,7 @@ subclass you can branch on:
 
 | Error                        | When                                                                                                                                                                                                                                                                          |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BranchError`                | `branch()` could not materialize a working copy.                                                                                                                                                                                                                              |
+| `BranchError`                | `branch()` or `ingestionBranch()` could not materialize a working copy.                                                                                                                                                                                                        |
 | `BaseVersionMismatchError`   | A branch forked from a different `base@V` than the target now has (snapshot `merge()`). Also the typed replan error `mergeIncremental()`'s in-transaction guards raise, and the by-ID freshness check both commit modes run, when the target moved in the plan→commit window. |
 | `IdentityMergeConflictError` | Code `GRAPH_MERGE_IDENTITY_CONFLICT`. Thrown by both `merge()` and `mergeIncremental()` for identity contradictions, assertion-ID collisions, and retract/reassert races. See the [identity guide](/identity/#interchange-and-branch-merge).                                  |
 | `MergeConstraintConflictError` | Code `GRAPH_MERGE_CONSTRAINT_CONFLICT`. The resolved plan would violate a deterministic store constraint, such as edge cardinality or node uniqueness. Its category is `constraint`, its `cause` is the original typed store error, and its details expose the original constraint fields. No graph or provenance writes commit. |

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2200,6 +2200,27 @@ type IndexWhereOperand = Readonly<{
 // @public
 type InferenceType = "subsumption" | "hierarchy" | "substitution" | "constraint" | "composition" | "association" | "none";
 
+// @public (undocumented)
+const INGESTION_BRANCH_BRAND: unique symbol;
+
+// @public
+export type IngestionBranch<G extends GraphDef> = Readonly<{
+    [INGESTION_BRANCH_BRAND]: true;
+    id: BranchId;
+    base: BaseVersion;
+    nodes: IngestionNodeCollections<G>;
+    edges: Store<G>["edges"];
+    close: () => Promise<void>;
+}>;
+
+// @public
+export function ingestionBranch<G extends GraphDef>(baseStore: GraphBranch<G>["store"], makeBackend: MakeBackend, options?: BranchOptions): Promise<Result<IngestionBranch<G>, BranchError>>;
+
+// @public
+export type IngestionNodeCollections<G extends GraphDef> = Readonly<{
+    [K in keyof Store<G>["nodes"]]-?: Pick<Store<G>["nodes"][K], "create" | "getById" | "getByIds" | "update" | "updateWhere" | "delete" | "hardDelete" | "find" | "count" | "createFromRecord" | "upsertById" | "upsertByIdFromRecord" | "bulkCreate" | "bulkUpsertById" | "bulkInsert" | "bulkDelete" | "bulkFindByIndex">;
+}>;
+
 // @public
 type InitialQueryBuilder<G extends GraphDef, CoordinateState extends QueryCoordinateState = "open"> = QueryBuilder<G, EmptyAliasMap, EmptyEdgeAliasMap, EmptyRecursiveAliasMap, CoordinateState>;
 
@@ -2674,7 +2695,7 @@ type MeasurableTransactionContext<G extends GraphDef> = TransactionContext<G> & 
 }>;
 
 // @public
-export function merge<G extends GraphDef>(store: Store<G>, branches: readonly GraphBranch<G>[], optionsInput?: MergeOptions<G>): Promise<Result<MergeReport<G>, MergeError>>;
+export function merge<G extends GraphDef>(store: Store<G>, branchInputs: readonly MergeBranch<G>[], optionsInput?: MergeOptions<G>): Promise<Result<MergeReport<G>, MergeError>>;
 
 // @public
 export const MERGE_ERROR_CODES: {
@@ -2715,6 +2736,9 @@ export const MERGE_PLAN_DIGEST_ALGORITHM: "sha256";
 
 // @public (undocumented)
 export const MERGE_PLAN_FORMAT_VERSION: 1;
+
+// @public
+export type MergeBranch<G extends GraphDef> = GraphBranch<G> | IngestionBranch<G>;
 
 // @public
 export class MergeConflictError extends MergeError {
@@ -2777,7 +2801,7 @@ export function mergeIncremental<G extends GraphDef>(args: MergeIncrementalArgs<
 export type MergeIncrementalArgs<G extends GraphDef = GraphDef> = Readonly<{
     forkPoint: Store<G>;
     target: Store<G>;
-    branches: readonly GraphBranch<G>[];
+    branches: readonly MergeBranch<G>[];
     options?: Omit<MergeOptions<G>, "target">;
 }>;
 
@@ -3590,7 +3614,7 @@ class Placeholder {
 }
 
 // @public
-export function planMerge<G extends GraphDef>(store: Store<G>, branches: readonly GraphBranch<G>[], optionsInput?: MergeOptions<G>): Promise<Result<MergePlanArtifact, MergeError>>;
+export function planMerge<G extends GraphDef>(store: Store<G>, branchInputs: readonly MergeBranch<G>[], optionsInput?: MergeOptions<G>): Promise<Result<MergePlanArtifact, MergeError>>;
 
 // @public
 export function planMergeIncremental<G extends GraphDef>(args: MergeIncrementalArgs<G>): Promise<Result<MergePlanArtifact, MergeError>>;
@@ -4696,6 +4720,17 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     identityAtCoordinate: (coordinate: ReadCoordinate) => IdentityReadFacade<G>;
     rebuildIdentityClosure: () => Promise<void>;
     validateIdentity: () => Promise<void>;
+    applyResolvedNodeUniqueness: <Output>(target: TransactionBackend, writes: Readonly<{
+        upserts: readonly Readonly<{
+            kind: string;
+            id: string;
+            props: Readonly<Record<string, unknown>>;
+        }>[];
+        releases: readonly Readonly<{
+            kind: string;
+            id: string;
+        }>[];
+    }>, apply: () => Promise<Output>) => Promise<Output>;
     readCurrentIdentityAssertions: (mode: "state" | "archival", options?: Readonly<{
         nodeKinds?: readonly string[];
         includeDeleted?: boolean;

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -4095,6 +4095,17 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     identityAtCoordinate: (coordinate: ReadCoordinate) => IdentityReadFacade<G>;
     rebuildIdentityClosure: () => Promise<void>;
     validateIdentity: () => Promise<void>;
+    applyResolvedNodeUniqueness: <Output>(target: TransactionBackend, writes: Readonly<{
+        upserts: readonly Readonly<{
+            kind: string;
+            id: string;
+            props: Readonly<Record<string, unknown>>;
+        }>[];
+        releases: readonly Readonly<{
+            kind: string;
+            id: string;
+        }>[];
+    }>, apply: () => Promise<Output>) => Promise<Output>;
     readCurrentIdentityAssertions: (mode: "state" | "archival", options?: Readonly<{
         nodeKinds?: readonly string[];
         includeDeleted?: boolean;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -3776,6 +3776,17 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     identityAtCoordinate: (coordinate: ReadCoordinate) => IdentityReadFacade<G>;
     rebuildIdentityClosure: () => Promise<void>;
     validateIdentity: () => Promise<void>;
+    applyResolvedNodeUniqueness: <Output>(target: TransactionBackend, writes: Readonly<{
+        upserts: readonly Readonly<{
+            kind: string;
+            id: string;
+            props: Readonly<Record<string, unknown>>;
+        }>[];
+        releases: readonly Readonly<{
+            kind: string;
+            id: string;
+        }>[];
+    }>, apply: () => Promise<Output>) => Promise<Output>;
     readCurrentIdentityAssertions: (mode: "state" | "archival", options?: Readonly<{
         nodeKinds?: readonly string[];
         includeDeleted?: boolean;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -3732,6 +3732,17 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     identityAtCoordinate: (coordinate: ReadCoordinate) => IdentityReadFacade<G>;
     rebuildIdentityClosure: () => Promise<void>;
     validateIdentity: () => Promise<void>;
+    applyResolvedNodeUniqueness: <Output>(target: TransactionBackend, writes: Readonly<{
+        upserts: readonly Readonly<{
+            kind: string;
+            id: string;
+            props: Readonly<Record<string, unknown>>;
+        }>[];
+        releases: readonly Readonly<{
+            kind: string;
+            id: string;
+        }>[];
+    }>, apply: () => Promise<Output>) => Promise<Output>;
     readCurrentIdentityAssertions: (mode: "state" | "archival", options?: Readonly<{
         nodeKinds?: readonly string[];
         includeDeleted?: boolean;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -3726,6 +3726,17 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     identityAtCoordinate: (coordinate: ReadCoordinate) => IdentityReadFacade<G>;
     rebuildIdentityClosure: () => Promise<void>;
     validateIdentity: () => Promise<void>;
+    applyResolvedNodeUniqueness: <Output>(target: TransactionBackend, writes: Readonly<{
+        upserts: readonly Readonly<{
+            kind: string;
+            id: string;
+            props: Readonly<Record<string, unknown>>;
+        }>[];
+        releases: readonly Readonly<{
+            kind: string;
+            id: string;
+        }>[];
+    }>, apply: () => Promise<Output>) => Promise<Output>;
     readCurrentIdentityAssertions: (mode: "state" | "archival", options?: Readonly<{
         nodeKinds?: readonly string[];
         includeDeleted?: boolean;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -3796,6 +3796,17 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     identityAtCoordinate: (coordinate: ReadCoordinate) => IdentityReadFacade<G>;
     rebuildIdentityClosure: () => Promise<void>;
     validateIdentity: () => Promise<void>;
+    applyResolvedNodeUniqueness: <Output>(target: TransactionBackend, writes: Readonly<{
+        upserts: readonly Readonly<{
+            kind: string;
+            id: string;
+            props: Readonly<Record<string, unknown>>;
+        }>[];
+        releases: readonly Readonly<{
+            kind: string;
+            id: string;
+        }>[];
+    }>, apply: () => Promise<Output>) => Promise<Output>;
     readCurrentIdentityAssertions: (mode: "state" | "archival", options?: Readonly<{
         nodeKinds?: readonly string[];
         includeDeleted?: boolean;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -5693,6 +5693,17 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
     identityAtCoordinate: (coordinate: ReadCoordinate) => IdentityReadFacade<G>;
     rebuildIdentityClosure: () => Promise<void>;
     validateIdentity: () => Promise<void>;
+    applyResolvedNodeUniqueness: <Output>(target: TransactionBackend, writes: Readonly<{
+        upserts: readonly Readonly<{
+            kind: string;
+            id: string;
+            props: Readonly<Record<string, unknown>>;
+        }>[];
+        releases: readonly Readonly<{
+            kind: string;
+            id: string;
+        }>[];
+    }>, apply: () => Promise<Output>) => Promise<Output>;
     readCurrentIdentityAssertions: (mode: "state" | "archival", options?: Readonly<{
         nodeKinds?: readonly string[];
         includeDeleted?: boolean;

--- a/packages/typegraph/src/graph-merge/branch.ts
+++ b/packages/typegraph/src/graph-merge/branch.ts
@@ -95,7 +95,7 @@ export async function branch<G extends GraphDef>(
  * `getActiveSchema` rejects would leak the engine the strategy just opened. A
  * close failure must not mask the original error.
  */
-export async function captureBranchSchemaAnchor<G extends GraphDef>(
+async function captureBranchSchemaAnchor<G extends GraphDef>(
   store: GraphBranch<G>["store"],
 ): Promise<Readonly<{ version: number; hash: string }> | undefined> {
   try {

--- a/packages/typegraph/src/graph-merge/branch.ts
+++ b/packages/typegraph/src/graph-merge/branch.ts
@@ -63,10 +63,10 @@ export async function branch<G extends GraphDef>(
     // closes it only on its own failures, and "only the success path hands the
     // backend to the caller, who then owns its lifecycle" (see
     // `cloneWorkingCopyStrategy`). Everything after this line therefore runs
-    // inside `readSchemaAnchor`, which closes it before failing — a `branch()`
-    // that returned `err(...)` from here would drop the only handle to a live
+    // inside `captureBranchSchemaAnchor`, which closes it before failing — a
+    // `branch()` that returned `err(...)` from here would drop the only handle to a live
     // engine (a PGlite instance, a file handle, a connection pool).
-    const schemaAnchor = await readSchemaAnchor(store);
+    const schemaAnchor = await captureBranchSchemaAnchor(store);
     return ok({
       id,
       base,
@@ -95,7 +95,7 @@ export async function branch<G extends GraphDef>(
  * `getActiveSchema` rejects would leak the engine the strategy just opened. A
  * close failure must not mask the original error.
  */
-async function readSchemaAnchor<G extends GraphDef>(
+export async function captureBranchSchemaAnchor<G extends GraphDef>(
   store: GraphBranch<G>["store"],
 ): Promise<Readonly<{ version: number; hash: string }> | undefined> {
   try {

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -43,6 +43,7 @@ export type {
   MatchSource,
   MatchStrategy,
 } from "./evidence";
+export { ingestionBranch } from "./ingestion-branch";
 export {
   applyMergePlan,
   merge,
@@ -121,6 +122,9 @@ export type {
   Embedder,
   EntityResolution,
   GraphBranch,
+  IngestionBranch,
+  IngestionNodeCollections,
+  MergeBranch,
   MergedCounts,
   MergeIncrementalArgs,
   MergeOptions,

--- a/packages/typegraph/src/graph-merge/ingestion-branch.ts
+++ b/packages/typegraph/src/graph-merge/ingestion-branch.ts
@@ -1,0 +1,92 @@
+/**
+ * Constraint-aware working copies for untrusted ingestion.
+ *
+ * An ingestion branch persists a mechanically-derived schema with node
+ * uniqueness declarations removed. That lets aliases reach merge planning,
+ * where canonical candidate generation and final resolved-write validation use
+ * the canonical graph's constraints. Every other working-copy constraint stays
+ * active during staging.
+ */
+
+import { branch } from "./branch";
+import { BranchError } from "./errors";
+import type { Result } from "./result";
+import { err, isErr, ok } from "./result";
+import type { GraphDef } from "./typegraph-internal";
+import { storeBackend } from "./typegraph-internal";
+import type {
+  BranchOptions,
+  GraphBranch,
+  IngestionBranch,
+  MergeBranch,
+} from "./types";
+import type { MakeBackend } from "./working-copy";
+import { cloneIngestionWorkingCopyStrategy } from "./working-copy";
+
+const PRIVATE_BRANCHES = new WeakMap<object, unknown>();
+
+/**
+ * Creates an isolated ingestion branch whose node uniqueness constraints are
+ * deferred until the resolved merge write set is applied.
+ *
+ * The returned handle deliberately exposes no ordinary Store. Its typed node
+ * and edge collections are sufficient to stage and inspect incoming data, and
+ * merge entrypoints accept the handle directly. Call `close()` when the working
+ * copy is no longer needed.
+ */
+export async function ingestionBranch<G extends GraphDef>(
+  baseStore: GraphBranch<G>["store"],
+  makeBackend: MakeBackend,
+  options?: BranchOptions,
+): Promise<Result<IngestionBranch<G>, BranchError>> {
+  try {
+    const created = await branch(
+      baseStore,
+      makeBackend,
+      options,
+      cloneIngestionWorkingCopyStrategy<G>(makeBackend),
+    );
+    if (isErr(created)) {
+      return err(
+        new BranchError("Failed to create constraint-aware ingestion branch", {
+          cause: created.error,
+        }),
+      );
+    }
+    const privateBranch = created.data;
+    const { base, id, store } = privateBranch;
+    const handle = Object.freeze({
+      id,
+      base,
+      nodes: store.nodes,
+      edges: store.edges,
+      close: async (): Promise<void> => storeBackend(store).close(),
+    }) as unknown as IngestionBranch<G>;
+    PRIVATE_BRANCHES.set(handle, privateBranch);
+    return ok(handle);
+  } catch (error) {
+    return err(
+      new BranchError("Failed to create constraint-aware ingestion branch", {
+        cause: error,
+      }),
+    );
+  }
+}
+
+/** Resolves an opaque ingestion handle to its private planner-facing branch. */
+export function unwrapMergeBranch<G extends GraphDef>(
+  input: MergeBranch<G>,
+): GraphBranch<G> {
+  const privateBranch = PRIVATE_BRANCHES.get(input);
+  if (privateBranch !== undefined) {
+    return privateBranch as GraphBranch<G>;
+  }
+  return input as GraphBranch<G>;
+}
+
+/** Resolves all public branch inputs once at a merge entrypoint boundary. */
+export function unwrapMergeBranches<G extends GraphDef>(
+  inputs: readonly MergeBranch<G>[],
+): readonly GraphBranch<G>[] {
+  return inputs.map((input) => unwrapMergeBranch(input));
+}

--- a/packages/typegraph/src/graph-merge/ingestion-branch.ts
+++ b/packages/typegraph/src/graph-merge/ingestion-branch.ts
@@ -74,7 +74,7 @@ export async function ingestionBranch<G extends GraphDef>(
 }
 
 /** Resolves an opaque ingestion handle to its private planner-facing branch. */
-export function unwrapMergeBranch<G extends GraphDef>(
+function unwrapMergeBranch<G extends GraphDef>(
   input: MergeBranch<G>,
 ): GraphBranch<G> {
   const privateBranch = PRIVATE_BRANCHES.get(input);

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -101,6 +101,7 @@ import {
 } from "./errors";
 import type { CandidateDiagnostic, CandidateDiagnostics } from "./evidence";
 import { compareMatchEvidence } from "./evidence";
+import { unwrapMergeBranches } from "./ingestion-branch";
 import {
   assertIdentityEndpointsNotDeleted,
   assertIdentityPeersStable,
@@ -214,6 +215,7 @@ import type {
   Embedder,
   EntityResolution,
   GraphBranch,
+  MergeBranch,
   MergedCounts,
   MergeIncrementalArgs as MergeIncrementalArguments,
   MergeOptions,
@@ -1891,24 +1893,75 @@ type MechanicalEdgeWrite = Readonly<{
   item: EdgeUpsert;
 }>;
 
-async function applyNodeRows(
+async function applyNodeRows<G extends GraphDef>(
+  target: Store<G>,
+  txBackend: TransactionBackend,
   nodesApi: TxNodes,
   deletions: readonly MergePlanEntityRef[],
   upserts: readonly MechanicalNodeWrite[],
 ): Promise<number> {
-  for (const deletion of deletions) {
-    await nodeCollection(nodesApi, deletion.kind).delete(deletion.id);
-  }
-  const committed = new Set<MergeKey>();
+  const afterImages = new Map<MergeKey, Readonly<Record<string, unknown>>>();
+  const upsertsByKind = new Map<string, MechanicalNodeWrite[]>();
   for (const upsert of upserts) {
-    await nodeCollection(nodesApi, upsert.kind).upsertByIdFromRecord(
-      upsert.id,
-      upsert.props,
-      nodeWriteWindowOptions(upsert),
-    );
-    committed.add(mergeKey(upsert.kind, upsert.id));
+    const items = upsertsByKind.get(upsert.kind);
+    if (items === undefined) upsertsByKind.set(upsert.kind, [upsert]);
+    else items.push(upsert);
   }
-  return committed.size;
+  for (const [kind, items] of upsertsByKind) {
+    const currentRows = await nodeCollection(nodesApi, kind).getByIds(
+      items.map((item) => item.id),
+      INCLUDE_TOMBSTONES,
+    );
+    const currentById = new Map<string, Readonly<Record<string, unknown>>>();
+    for (const node of currentRows) {
+      if (node !== undefined) currentById.set(node.id, nodeProps(node));
+    }
+    for (const item of items) {
+      const props = createDataKeyedBag<unknown>();
+      const unset = new Set(
+        Object.entries(item.props)
+          .filter(([, value]) => value === undefined)
+          .map(([key]) => key),
+      );
+      for (const [key, value] of Object.entries(
+        currentById.get(item.id) ?? {},
+      )) {
+        if (!unset.has(key)) props[key] = value;
+      }
+      for (const [key, value] of Object.entries(item.props)) {
+        if (value !== undefined) props[key] = value;
+      }
+      afterImages.set(mergeKey(kind, item.id), props);
+    }
+  }
+  return storeRuntime(target).applyResolvedNodeUniqueness(
+    txBackend,
+    {
+      upserts: upserts.map((upsert) => ({
+        kind: upsert.kind,
+        id: upsert.id,
+        props: requireDefined(
+          afterImages.get(mergeKey(upsert.kind, upsert.id)),
+        ),
+      })),
+      releases: deletions,
+    },
+    async () => {
+      for (const deletion of deletions) {
+        await nodeCollection(nodesApi, deletion.kind).delete(deletion.id);
+      }
+      const committed = new Set<MergeKey>();
+      for (const upsert of upserts) {
+        await nodeCollection(nodesApi, upsert.kind).upsertByIdFromRecord(
+          upsert.id,
+          upsert.props,
+          nodeWriteWindowOptions(upsert),
+        );
+        committed.add(mergeKey(upsert.kind, upsert.id));
+      }
+      return committed.size;
+    },
+  );
 }
 
 async function applyEdgeRows(
@@ -1998,7 +2051,13 @@ async function applyInternalMergePlan<G extends GraphDef>(
   );
   let committedNodes: number;
   try {
-    committedNodes = await applyNodeRows(nodesApi, nodeDeletions, nodeUpserts);
+    committedNodes = await applyNodeRows(
+      target,
+      txBackend,
+      nodesApi,
+      nodeDeletions,
+      nodeUpserts,
+    );
   } catch (error) {
     throw error instanceof IdentityEndpointValidityError ?
         translateIdentityCommitError(error)
@@ -3075,9 +3134,10 @@ function incrementalSchemaError(): MergeError {
 /** Builds a durable, reviewable snapshot merge plan without mutating the target. */
 export async function planMerge<G extends GraphDef>(
   store: Store<G>,
-  branches: readonly GraphBranch<G>[],
+  branchInputs: readonly MergeBranch<G>[],
   optionsInput: MergeOptions<G> = {},
 ): Promise<Result<MergePlanArtifact, MergeError>> {
+  const branches = unwrapMergeBranches(branchInputs);
   const normalized = tryNormalize(optionsInput);
   if (isErr(normalized)) return err(normalized.error);
   const options = normalized.data;
@@ -3126,7 +3186,8 @@ export async function planMerge<G extends GraphDef>(
 export async function planMergeIncremental<G extends GraphDef>(
   args: MergeIncrementalArguments<G>,
 ): Promise<Result<MergePlanArtifact, MergeError>> {
-  const { forkPoint, target, branches } = args;
+  const { forkPoint, target } = args;
+  const branches = unwrapMergeBranches(args.branches);
   const normalized = tryNormalize(args.options ?? {}, ["target"]);
   if (isErr(normalized)) return err(normalized.error);
   const options = normalized.data;
@@ -3644,6 +3705,8 @@ async function applyWireMergeWrites<G extends GraphDef>(
   artifact: MergePlanArtifactV1,
 ): Promise<MergedCounts> {
   const committedNodes = await applyNodeRows(
+    target,
+    txBackend,
     nodesApi,
     artifact.writes.nodeDeletes,
     artifact.writes.nodeUpserts.map((upsert) => ({
@@ -3884,9 +3947,10 @@ export async function applyMergePlan<G extends GraphDef>(
  */
 export async function merge<G extends GraphDef>(
   store: Store<G>,
-  branches: readonly GraphBranch<G>[],
+  branchInputs: readonly MergeBranch<G>[],
   optionsInput: MergeOptions<G> = {},
 ): Promise<Result<MergeReport<G>, MergeError>> {
+  const branches = unwrapMergeBranches(branchInputs);
   const normalized = tryNormalize(optionsInput);
   if (isErr(normalized)) {
     return err(normalized.error);
@@ -3931,9 +3995,10 @@ export async function merge<G extends GraphDef>(
  */
 export async function mergeAgainstBase<G extends GraphDef>(
   store: Store<G>,
-  branches: readonly GraphBranch<G>[],
+  branchInputs: readonly MergeBranch<G>[],
   optionsInput: MergeOptions<G> = {},
 ): Promise<Result<MergeReport<G>, MergeError>> {
+  const branches = unwrapMergeBranches(branchInputs);
   const normalized = tryNormalize(optionsInput);
   if (isErr(normalized)) {
     return err(normalized.error);
@@ -4860,7 +4925,8 @@ async function commitIncrementalPlan<G extends GraphDef>(
 export async function mergeIncremental<G extends GraphDef>(
   args: MergeIncrementalArguments<G>,
 ): Promise<Result<MergeReport<G>, MergeError>> {
-  const { forkPoint, target, branches } = args;
+  const { forkPoint, target } = args;
+  const branches = unwrapMergeBranches(args.branches);
 
   const normalized = tryNormalize(args.options ?? {}, ["target"]);
   if (isErr(normalized)) {

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -79,6 +79,57 @@ export type GraphBranch<G extends GraphDef> = Readonly<{
   schemaAnchor?: Readonly<{ version: number; hash: string }> | undefined;
 }>;
 
+declare const INGESTION_BRANCH_BRAND: unique symbol;
+
+/**
+ * Node collections exposed by an {@link IngestionBranch}. They retain normal
+ * validation, reads, and staging writes, but omit APIs that claim a declared
+ * uniqueness constraint exists on the relaxed physical working copy.
+ */
+export type IngestionNodeCollections<G extends GraphDef> = Readonly<{
+  [K in keyof Store<G>["nodes"]]-?: Pick<
+    Store<G>["nodes"][K],
+    | "create"
+    | "getById"
+    | "getByIds"
+    | "update"
+    | "updateWhere"
+    | "delete"
+    | "hardDelete"
+    | "find"
+    | "count"
+    | "createFromRecord"
+    | "upsertById"
+    | "upsertByIdFromRecord"
+    | "bulkCreate"
+    | "bulkUpsertById"
+    | "bulkInsert"
+    | "bulkDelete"
+    | "bulkFindByIndex"
+  >;
+}>;
+
+/**
+ * Opaque handle for an untrusted ingestion working copy.
+ *
+ * The ordinary {@link Store} is intentionally absent: callers may stage and
+ * inspect graph data through the typed collections, then pass this handle to
+ * merge planning, but cannot access schema evolution, transactions, or runtime
+ * internals. `close()` releases the private working-copy backend.
+ */
+export type IngestionBranch<G extends GraphDef> = Readonly<{
+  [INGESTION_BRANCH_BRAND]: true;
+  id: BranchId;
+  base: BaseVersion;
+  nodes: IngestionNodeCollections<G>;
+  edges: Store<G>["edges"];
+  close: () => Promise<void>;
+}>;
+
+/** A normal branch or an opaque ingestion branch accepted by merge entrypoints. */
+export type MergeBranch<G extends GraphDef> =
+  GraphBranch<G> | IngestionBranch<G>;
+
 /**
  * Options for {@link GraphBranch} creation. `id` is optional — when omitted a
  * fresh id is generated.
@@ -374,7 +425,7 @@ export type MergeOptions<G extends GraphDef = GraphDef> = Readonly<{
 export type MergeIncrementalArgs<G extends GraphDef = GraphDef> = Readonly<{
   forkPoint: Store<G>;
   target: Store<G>;
-  branches: readonly GraphBranch<G>[];
+  branches: readonly MergeBranch<G>[];
   options?: Omit<MergeOptions<G>, "target">;
 }>;
 

--- a/packages/typegraph/src/graph-merge/working-copy.ts
+++ b/packages/typegraph/src/graph-merge/working-copy.ts
@@ -123,12 +123,38 @@ export type MakeBackend = () => Promise<GraphBackend>;
 export function cloneWorkingCopyStrategy<G extends GraphDef>(
   makeBackend: MakeBackend,
 ): WorkingCopyStrategy<G> {
+  return cloneWorkingCopyWithGraphStrategy(
+    makeBackend,
+    (baseStore) => baseStore.graph,
+  );
+}
+
+/**
+ * Working-copy strategy used by {@link ingestionBranch}. The clone is backed by
+ * a mechanically-derived graph that omits node uniqueness declarations while
+ * preserving every other graph contract, including lookup indexes.
+ *
+ * This strategy is deliberately not part of the public barrel. The opaque
+ * ingestion handle is the only supported owner of a relaxed working copy.
+ */
+export function cloneIngestionWorkingCopyStrategy<G extends GraphDef>(
+  makeBackend: MakeBackend,
+): WorkingCopyStrategy<G> {
+  return cloneWorkingCopyWithGraphStrategy(makeBackend, (baseStore) =>
+    graphWithoutNodeUniqueness(baseStore.graph),
+  );
+}
+
+function cloneWorkingCopyWithGraphStrategy<G extends GraphDef>(
+  makeBackend: MakeBackend,
+  graphForClone: (baseStore: Store<G>) => G,
+): WorkingCopyStrategy<G> {
   return {
     create: async (baseStore: Store<G>): Promise<Store<G>> => {
       const backend = await makeBackend();
       try {
         const [freshStore] = await createStoreWithSchema(
-          baseStore.graph,
+          graphForClone(baseStore),
           backend,
           {
             // Keep descendants branchable with the same O(1) anchor contract,
@@ -189,4 +215,46 @@ export function cloneWorkingCopyStrategy<G extends GraphDef>(
       }
     },
   };
+}
+
+/**
+ * Derives the honest persisted schema for an ingestion working copy.
+ *
+ * The graph's node and edge types are unchanged, so retaining `G` is sound for
+ * collection inputs and outputs. Only the registrations' node uniqueness slice
+ * is removed. Extension documents are rewritten too: they are the durable
+ * source used to reconstruct extension kinds on reload, so leaving their
+ * declarations intact would silently restore uniqueness after a restart.
+ */
+function graphWithoutNodeUniqueness<G extends GraphDef>(graph: G): G {
+  const nodes = Object.fromEntries(
+    Object.entries(graph.nodes).map(([name, registration]) => {
+      const { unique: _omitted, ...withoutUnique } = registration;
+      return [name, Object.freeze(withoutUnique)] as const;
+    }),
+  );
+  const extension =
+    graph.extension?.nodes === undefined ?
+      graph.extension
+    : Object.freeze({
+        ...graph.extension,
+        nodes: Object.freeze(
+          Object.fromEntries(
+            Object.entries(graph.extension.nodes).map(([name, node]) => {
+              const { unique: _omitted, ...withoutUnique } = node;
+              return [name, Object.freeze(withoutUnique)] as const;
+            }),
+          ),
+        ),
+      });
+
+  // `G`'s data types are unchanged. Its registration-level constraint-name
+  // phantom is intentionally retained so branch nodes remain assignable to the
+  // canonical graph's merge types; the ingestion handle omits constraint lookup
+  // methods whose declarations no longer exist physically.
+  return Object.freeze({
+    ...graph,
+    nodes: Object.freeze(nodes),
+    extension,
+  });
 }

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -142,6 +142,7 @@ import {
 import {
   checkUniquenessConstraints,
   createUniquenessContext,
+  validateResolvedNodeUniqueness,
 } from "../uniqueness";
 import {
   assertClearValidToSupported,
@@ -1942,60 +1943,15 @@ export async function executeNodeUpdateWhere<G extends GraphDef>(
         });
 
         if (uniqueConstraints.length > 0) {
-          const affectedIds = new Set(result.rows.map((row) => row.id));
-          for (const constraint of uniqueConstraints) {
-            const keyToId = new Map<string, string>();
-            for (const item of sidecarItems) {
-              if (!checkWherePredicate(constraint, item.props)) continue;
-              const key = computeUniqueKey(
-                item.props,
-                constraint.fields,
-                constraint.collation,
-              );
-              const priorId = keyToId.get(key);
-              if (priorId !== undefined && priorId !== item.id) {
-                throw new UniquenessError({
-                  constraintName: constraint.name,
-                  kind,
-                  existingId: priorId,
-                  newId: item.id,
-                  fields: constraint.fields,
-                });
-              }
-              keyToId.set(key, item.id);
-            }
-            const keys = [...keyToId.keys()];
-            if (keys.length === 0) continue;
-            for (const kindToCheck of getKindsForUniquenessCheck(
-              kind,
-              constraint.scope,
-              ctx.registry,
-            )) {
-              const existingRows = await requireDefined(
-                target.checkUniqueBatch,
-              )({
-                graphId: ctx.graphId,
-                nodeKind: kindToCheck,
-                constraintName: constraint.name,
-                keys,
-              });
-              for (const existing of existingRows) {
-                if (
-                  existing.concrete_kind === kind &&
-                  affectedIds.has(existing.node_id)
-                ) {
-                  continue;
-                }
-                throw new UniquenessError({
-                  constraintName: constraint.name,
-                  kind: kindToCheck,
-                  existingId: existing.node_id,
-                  newId: requireDefined(keyToId.get(existing.key)),
-                  fields: constraint.fields,
-                });
-              }
-            }
-          }
+          await validateResolvedNodeUniqueness(
+            createUniquenessContext(ctx.graphId, ctx.registry, target),
+            sidecarItems.map((item) => ({
+              kind: item.kind,
+              id: item.id,
+              props: item.props,
+              constraints: item.uniqueConstraints,
+            })),
+          );
           await requireDefined(hardDeleteUniquesByNodeIds)({
             graphId: ctx.graphId,
             concreteKind: kind,

--- a/packages/typegraph/src/store/runtime-port.ts
+++ b/packages/typegraph/src/store/runtime-port.ts
@@ -86,6 +86,23 @@ export type StoreRuntime<G extends GraphDef> = Readonly<{
   rebuildIdentityClosure: () => Promise<void>;
   validateIdentity: () => Promise<void>;
   /**
+   * Validates one final resolved node write set, then clears the affected
+   * uniqueness sidecars so its upserts may claim their approved keys in any
+   * order. The caller must supply a transaction-bound backend.
+   */
+  applyResolvedNodeUniqueness: <Output>(
+    target: TransactionBackend,
+    writes: Readonly<{
+      upserts: readonly Readonly<{
+        kind: string;
+        id: string;
+        props: Readonly<Record<string, unknown>>;
+      }>[];
+      releases: readonly Readonly<{ kind: string; id: string }>[];
+    }>,
+    apply: () => Promise<Output>,
+  ) => Promise<Output>;
+  /**
    * @internal Reads the graph's identity assertions in transfer shape, honoring
    * this store's SQL binding. Used by interchange export, base-version
    * fingerprinting, and merge staging/diff.

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -319,6 +319,10 @@ import {
   type TransactionOutcome,
   type UnboundLiveStoreOptions,
 } from "./types";
+import {
+  applyResolvedNodeUniqueness,
+  createUniquenessContext,
+} from "./uniqueness";
 
 type StoreSchemaMetadata = Readonly<{
   schemaVersion: number | undefined;
@@ -1005,6 +1009,52 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         this.identityAtCoordinate(coordinate),
       rebuildIdentityClosure: () => this.rebuildIdentityClosure(),
       validateIdentity: () => this.validateIdentity(),
+      applyResolvedNodeUniqueness: async (target, writes, apply) => {
+        const upserts = writes.upserts.map((upsert) => {
+          if (!hasOwnKey(this.#graph.nodes, upsert.kind)) {
+            throw new KindNotFoundError(upsert.kind, "node", {
+              graphId: this.graphId,
+            });
+          }
+          const registration = this.#graph.nodes[upsert.kind];
+          if (registration === undefined) {
+            throw new KindNotFoundError(upsert.kind, "node", {
+              graphId: this.graphId,
+            });
+          }
+          return {
+            ...upsert,
+            constraints: registration.unique ?? [],
+          };
+        });
+        const constrainedKinds = new Set(
+          Object.entries(this.#graph.nodes)
+            .filter(
+              ([, registration]) => (registration.unique ?? []).length > 0,
+            )
+            .map(([kind]) => kind),
+        );
+        const releases = writes.releases.filter((release) => {
+          if (!Object.hasOwn(this.#graph.nodes, release.kind)) {
+            throw new KindNotFoundError(release.kind, "node", {
+              graphId: this.graphId,
+            });
+          }
+          return constrainedKinds.has(release.kind);
+        });
+        if (
+          upserts.every((upsert) => upsert.constraints.length === 0) &&
+          releases.length === 0
+        ) {
+          return apply();
+        }
+        return applyResolvedNodeUniqueness(
+          createUniquenessContext(this.graphId, this.#registry, target),
+          upserts,
+          releases,
+          apply,
+        );
+      },
       liveNodesSharingIds: async (ids, target) => {
         const backend = target ?? this.#baseBackend;
         const liveKindsById = await liveNodeKindsSharingIds(

--- a/packages/typegraph/src/store/uniqueness.ts
+++ b/packages/typegraph/src/store/uniqueness.ts
@@ -251,7 +251,7 @@ export async function validateResolvedNodeUniqueness(
  * node's old sidecars are batch-cleared so later per-node upserts can claim the
  * validated final keys in any order (including swaps and handoffs).
  */
-export async function prepareResolvedNodeUniqueness(
+async function prepareResolvedNodeUniqueness(
   ctx: UniquenessContext,
   upserts: readonly ResolvedNodeUniquenessUpsert[],
   releases: readonly ResolvedNodeUniquenessRelease[],

--- a/packages/typegraph/src/store/uniqueness.ts
+++ b/packages/typegraph/src/store/uniqueness.ts
@@ -14,8 +14,9 @@ import {
   getKindsForUniquenessCheck,
 } from "../constraints";
 import { type UniqueConstraint } from "../core/types";
-import { UniquenessError } from "../errors";
+import { ConfigurationError, UniquenessError } from "../errors";
 import { type KindRegistry } from "../registry/kind-registry";
+import { encodeTupleKey } from "../utils/tuple-key";
 
 /**
  * Context for uniqueness operations.
@@ -33,6 +34,276 @@ export function createUniquenessContext(
   backend: GraphBackend | TransactionBackend,
 ): UniquenessContext {
   return { graphId, registry, backend };
+}
+
+/** A complete node after-image whose uniqueness claims belong to one resolved write set. */
+export type ResolvedNodeUniquenessUpsert = Readonly<{
+  kind: string;
+  id: string;
+  props: Readonly<Record<string, unknown>>;
+  constraints: readonly UniqueConstraint[];
+}>;
+
+/** A node whose current uniqueness claims the resolved write set releases. */
+export type ResolvedNodeUniquenessRelease = Readonly<{
+  kind: string;
+  id: string;
+}>;
+
+type ProposedUniqueClaim = Readonly<{
+  kind: string;
+  id: string;
+  constraint: UniqueConstraint;
+  key: string;
+  kindsToCheck: readonly string[];
+}>;
+
+function nodeIdentityKey(reference: ResolvedNodeUniquenessRelease): string {
+  return encodeTupleKey([reference.kind, reference.id]);
+}
+
+function proposedUniqueClaims(
+  ctx: UniquenessContext,
+  upserts: readonly ResolvedNodeUniquenessUpsert[],
+): readonly ProposedUniqueClaim[] {
+  const claims: ProposedUniqueClaim[] = [];
+  const claimsByCheckedKind = new Map<string, ProposedUniqueClaim[]>();
+  const claimsByOwnKind = new Map<string, ProposedUniqueClaim[]>();
+  const orderedConstraints: UniqueConstraint[] = [];
+  const seenConstraints = new Set<UniqueConstraint>();
+  for (const upsert of upserts) {
+    for (const constraint of upsert.constraints) {
+      if (seenConstraints.has(constraint)) continue;
+      seenConstraints.add(constraint);
+      orderedConstraints.push(constraint);
+    }
+  }
+  for (const constraint of orderedConstraints) {
+    for (const upsert of upserts) {
+      if (!upsert.constraints.includes(constraint)) continue;
+      if (!checkWherePredicate(constraint, upsert.props)) continue;
+      const claim = {
+        kind: upsert.kind,
+        id: upsert.id,
+        constraint,
+        key: computeUniqueKey(
+          upsert.props,
+          constraint.fields,
+          constraint.collation,
+        ),
+        kindsToCheck: getKindsForUniquenessCheck(
+          upsert.kind,
+          constraint.scope,
+          ctx.registry,
+        ),
+      } satisfies ProposedUniqueClaim;
+      const identity = nodeIdentityKey(claim);
+      const candidateGroups = [
+        claimsByCheckedKind.get(
+          encodeTupleKey([constraint.name, claim.key, claim.kind]),
+        ) ?? [],
+        ...claim.kindsToCheck.map(
+          (kind) =>
+            claimsByOwnKind.get(
+              encodeTupleKey([constraint.name, claim.key, kind]),
+            ) ?? [],
+        ),
+      ];
+      const collision = candidateGroups
+        .flat()
+        .find((existing) => nodeIdentityKey(existing) !== identity);
+      if (collision !== undefined) {
+        throw new UniquenessError({
+          constraintName: constraint.name,
+          kind: collision.kind,
+          existingId: collision.id,
+          newId: upsert.id,
+          fields: constraint.fields,
+        });
+      }
+      claims.push(claim);
+      const ownKindKey = encodeTupleKey([
+        constraint.name,
+        claim.key,
+        claim.kind,
+      ]);
+      const sameKindClaims = claimsByOwnKind.get(ownKindKey);
+      if (sameKindClaims === undefined) {
+        claimsByOwnKind.set(ownKindKey, [claim]);
+      } else {
+        sameKindClaims.push(claim);
+      }
+      for (const kind of claim.kindsToCheck) {
+        const checkedKindKey = encodeTupleKey([
+          constraint.name,
+          claim.key,
+          kind,
+        ]);
+        const sameDomainClaims = claimsByCheckedKind.get(checkedKindKey);
+        if (sameDomainClaims === undefined) {
+          claimsByCheckedKind.set(checkedKindKey, [claim]);
+        } else {
+          sameDomainClaims.push(claim);
+        }
+      }
+    }
+  }
+  return claims;
+}
+
+type UniqueProbeGroup = Readonly<{
+  nodeKind: string;
+  constraintName: string;
+  claimsByKey: ReadonlyMap<string, ProposedUniqueClaim>;
+}>;
+
+function groupUniqueClaimsForBatchProbe(
+  claims: readonly ProposedUniqueClaim[],
+): readonly UniqueProbeGroup[] {
+  const groups = new Map<
+    string,
+    {
+      nodeKind: string;
+      constraintName: string;
+      claimsByKey: Map<string, ProposedUniqueClaim>;
+    }
+  >();
+  for (const claim of claims) {
+    for (const nodeKind of claim.kindsToCheck) {
+      const groupKey = encodeTupleKey([nodeKind, claim.constraint.name]);
+      const existing = groups.get(groupKey);
+      if (existing === undefined) {
+        groups.set(groupKey, {
+          nodeKind,
+          constraintName: claim.constraint.name,
+          claimsByKey: new Map([[claim.key, claim]]),
+        });
+        continue;
+      }
+      existing.claimsByKey.set(claim.key, claim);
+    }
+  }
+  return [...groups.values()];
+}
+
+/**
+ * Validates node uniqueness against the FINAL state of a resolved write set.
+ *
+ * All proposed after-images are compared together before persisted sidecars
+ * are consulted. Persisted owners released or replaced by this same set are
+ * ignored, which permits atomic swaps and handoffs while still refusing every
+ * owner outside the set. The backend probe is batch-only by contract: callers
+ * that need this set semantic must not quietly degrade to sequential checks.
+ */
+export async function validateResolvedNodeUniqueness(
+  ctx: UniquenessContext,
+  upserts: readonly ResolvedNodeUniquenessUpsert[],
+  releases: readonly ResolvedNodeUniquenessRelease[] = [],
+): Promise<void> {
+  const checkUniqueBatch = ctx.backend.checkUniqueBatch;
+  if (checkUniqueBatch === undefined) {
+    throw new ConfigurationError(
+      "Resolved node writes require batched uniqueness probes",
+      { code: "RESOLVED_NODE_UNIQUENESS_UNSUPPORTED" },
+    );
+  }
+  const claims = proposedUniqueClaims(ctx, upserts);
+  if (claims.length === 0) return;
+
+  const affectedOwners = new Set(
+    [...upserts, ...releases].map((reference) => nodeIdentityKey(reference)),
+  );
+  for (const group of groupUniqueClaimsForBatchProbe(claims)) {
+    const existingRows = await checkUniqueBatch({
+      graphId: ctx.graphId,
+      nodeKind: group.nodeKind,
+      constraintName: group.constraintName,
+      keys: [...group.claimsByKey.keys()],
+    });
+    for (const existing of existingRows) {
+      if (
+        affectedOwners.has(
+          nodeIdentityKey({
+            kind: existing.concrete_kind,
+            id: existing.node_id,
+          }),
+        )
+      ) {
+        continue;
+      }
+      const claim = group.claimsByKey.get(existing.key);
+      if (claim === undefined) continue;
+      throw new UniquenessError({
+        constraintName: group.constraintName,
+        kind: group.nodeKind,
+        existingId: existing.node_id,
+        newId: claim.id,
+        fields: claim.constraint.fields,
+      });
+    }
+  }
+}
+
+/**
+ * Prepares a transaction to apply a resolved node write set sequentially.
+ *
+ * Validation happens before any mutation. Once it succeeds, every affected
+ * node's old sidecars are batch-cleared so later per-node upserts can claim the
+ * validated final keys in any order (including swaps and handoffs).
+ */
+export async function prepareResolvedNodeUniqueness(
+  ctx: UniquenessContext,
+  upserts: readonly ResolvedNodeUniquenessUpsert[],
+  releases: readonly ResolvedNodeUniquenessRelease[],
+): Promise<void> {
+  const hardDeleteUniquesByNodeIds = ctx.backend.hardDeleteUniquesByNodeIds;
+  if (
+    ctx.backend.checkUniqueBatch === undefined ||
+    ctx.backend.insertUniqueBatch === undefined ||
+    hardDeleteUniquesByNodeIds === undefined
+  ) {
+    throw new ConfigurationError(
+      "Resolved node writes require batched uniqueness operations",
+      { code: "RESOLVED_NODE_UNIQUENESS_UNSUPPORTED" },
+    );
+  }
+  await validateResolvedNodeUniqueness(ctx, upserts, releases);
+
+  const idsByKind = new Map<string, Set<string>>();
+  for (const reference of [...upserts, ...releases]) {
+    const ids = idsByKind.get(reference.kind) ?? new Set<string>();
+    ids.add(reference.id);
+    idsByKind.set(reference.kind, ids);
+  }
+  for (const [concreteKind, nodeIds] of idsByKind) {
+    await hardDeleteUniquesByNodeIds({
+      graphId: ctx.graphId,
+      concreteKind,
+      nodeIds: [...nodeIds],
+    });
+  }
+}
+
+/**
+ * Applies writes between the resolved-set preflight and one final batch
+ * sidecar rebuild.
+ *
+ * The rebuild is required even though ordinary upserts claim their own keys:
+ * an unchanged upsert may be coalesced and skip all of its normal side effects
+ * after preparation cleared the old reservation. Re-inserting every approved
+ * claim is idempotent and makes the resolved-set transition independent of
+ * whether individual writes were coalesced.
+ */
+export async function applyResolvedNodeUniqueness<Output>(
+  ctx: UniquenessContext,
+  upserts: readonly ResolvedNodeUniquenessUpsert[],
+  releases: readonly ResolvedNodeUniquenessRelease[],
+  apply: () => Promise<Output>,
+): Promise<Output> {
+  await prepareResolvedNodeUniqueness(ctx, upserts, releases);
+  const result = await apply();
+  await insertUniquenessEntriesBatch(ctx, upserts);
+  return result;
 }
 
 /**

--- a/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
@@ -1,0 +1,784 @@
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  asEdgeId,
+  asNodeId,
+  CardinalityError,
+  ConfigurationError,
+  createStoreWithSchema,
+  createVerifiedStore,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  defineNodeIndex,
+  DisjointError,
+  disjointWith,
+  EndpointNotFoundError,
+  subClassOf,
+  UniquenessError,
+} from "@nicia-ai/typegraph";
+import fc from "fast-check";
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod";
+
+import type { TransactionBackend } from "../../src/backend/types";
+import { ingestionBranch } from "../../src/graph-merge";
+import { branch } from "../../src/graph-merge/branch";
+import { MergeConstraintConflictError } from "../../src/graph-merge/errors";
+import {
+  applyMergePlan,
+  planMergeIncremental,
+} from "../../src/graph-merge/merge";
+import { isErr, unwrap } from "../../src/graph-merge/result";
+import type {
+  BranchId,
+  GraphBranch,
+  IngestionBranch,
+} from "../../src/graph-merge/types";
+import { asBranchId } from "../../src/graph-merge/types";
+import { parseSerializedSchema } from "../../src/schema";
+import { requireDefined } from "../../src/utils/presence";
+import { backendMatrix, createSqliteMergeBackend } from "./test-utils";
+
+const Patient = defineNode("Patient", {
+  schema: z.object({ name: z.string(), mrn: z.string() }),
+});
+
+const ClinicalEntity = defineNode("ClinicalEntity", {
+  schema: z.object({ name: z.string(), mrn: z.string() }),
+});
+
+const Practitioner = defineNode("Practitioner", {
+  schema: z.object({ name: z.string(), mrn: z.string() }),
+});
+
+const AdministrativeRecord = defineNode("AdministrativeRecord", {
+  schema: z.object({ label: z.string() }),
+});
+
+const Facility = defineNode("Facility", {
+  schema: z.object({ name: z.string() }),
+});
+
+const primaryFacility = defineEdge("primaryFacility", {
+  schema: z.object({ source: z.string() }),
+  from: [Patient],
+  to: [Facility],
+});
+
+const patientMrnCandidates = defineNodeIndex(Patient, {
+  name: "patient_mrn_candidates",
+  fields: ["mrn"],
+});
+
+const ingestionGraph = defineGraph({
+  id: "constraint-aware-ingestion",
+  nodes: {
+    ClinicalEntity: {
+      type: ClinicalEntity,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kindWithSubClasses",
+          collation: "binary",
+        },
+      ],
+    },
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kindWithSubClasses",
+          collation: "binary",
+        },
+      ],
+    },
+    Practitioner: {
+      type: Practitioner,
+      unique: [
+        {
+          name: "mrn_unique",
+          fields: ["mrn"],
+          scope: "kindWithSubClasses",
+          collation: "binary",
+        },
+      ],
+    },
+    AdministrativeRecord: { type: AdministrativeRecord },
+    Facility: { type: Facility },
+  },
+  edges: {
+    primaryFacility: {
+      type: primaryFacility,
+      from: [Patient],
+      to: [Facility],
+      cardinality: "oneActive",
+    },
+  },
+  indexes: [patientMrnCandidates],
+  ontology: [
+    subClassOf(Patient, ClinicalEntity),
+    subClassOf(Practitioner, ClinicalEntity),
+    disjointWith(Patient, AdministrativeRecord),
+  ],
+});
+
+const relaxedIngestionGraph = defineGraph({
+  id: "constraint-aware-ingestion",
+  nodes: {
+    ClinicalEntity: { type: ClinicalEntity },
+    Patient: { type: Patient },
+    Practitioner: { type: Practitioner },
+    AdministrativeRecord: { type: AdministrativeRecord },
+    Facility: { type: Facility },
+  },
+  edges: ingestionGraph.edges,
+  indexes: [patientMrnCandidates],
+  ontology: ingestionGraph.ontology,
+});
+
+type IngestionGraph = typeof ingestionGraph;
+type IngestionStore = Store<IngestionGraph>;
+
+const INCOMING = asBranchId("incoming");
+
+const RESOLVED_BATCH_METHODS = new Set<PropertyKey>([
+  "checkUniqueBatch",
+  "insertUniqueBatch",
+  "hardDeleteUniquesByNodeIds",
+]);
+
+function withoutResolvedBatchMethods(
+  transaction: TransactionBackend,
+): TransactionBackend {
+  return new Proxy(transaction, {
+    get(target, property, receiver) {
+      return RESOLVED_BATCH_METHODS.has(property) ? undefined : (
+          (Reflect.get(target, property, receiver) as unknown)
+        );
+    },
+  });
+}
+
+function withoutResolvedBatchTransaction(backend: GraphBackend): GraphBackend {
+  const transaction: GraphBackend["transaction"] = async (fn, options) =>
+    backend.transaction(
+      async (tx) => fn(withoutResolvedBatchMethods(tx)),
+      options,
+    );
+  return new Proxy(backend, {
+    get(target, property, receiver) {
+      return property === "transaction" ? transaction : (
+          (Reflect.get(target, property, receiver) as unknown)
+        );
+    },
+  });
+}
+
+function incrementalOptions() {
+  return {
+    resolve: {
+      Patient: {
+        blockIndex: "patient_mrn_candidates",
+        similarity: { kind: "fulltext" as const, fields: ["name"] },
+        threshold: 0.8,
+      },
+    },
+    onBasePropertyConflict: "flag" as const,
+    branchOrder: [INCOMING],
+  };
+}
+
+describe.each(backendMatrix())(
+  "constraint-aware ingestion branch [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    afterEach(async () => {
+      for (const cleanup of cleanups ?? []) await cleanup();
+      cleanups = [];
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function makeStore(
+      options: Readonly<{ coalesceUnchangedUpserts?: boolean }> = {},
+    ): Promise<IngestionStore> {
+      const [store] = await createStoreWithSchema(
+        ingestionGraph,
+        await makeBackend(),
+        { revisionTracking: true, ...options },
+      );
+      return store;
+    }
+
+    async function cloneStore(
+      source: IngestionStore,
+      id: BranchId,
+    ): Promise<GraphBranch<IngestionGraph>> {
+      return unwrap(
+        await branch(source, () => makeBackend(), {
+          id,
+        }),
+      );
+    }
+
+    async function makeIngestion(
+      source: IngestionStore,
+      id: BranchId = INCOMING,
+    ): Promise<IngestionBranch<IngestionGraph>> {
+      return unwrap(
+        await ingestionBranch(source, () => makeBackend(), {
+          id,
+        }),
+      );
+    }
+
+    async function seedCanonical(store: IngestionStore): Promise<void> {
+      await store.nodes.Patient.create(
+        { name: "Ana Rivera", mrn: "MRN-123" },
+        { id: "patient-canonical" },
+      );
+      await store.nodes.Facility.create(
+        { name: "General Hospital" },
+        { id: "facility-1" },
+      );
+    }
+
+    it("stages a repeated canonical key, recalls it through blockIndex, and repoints its edge on reviewed apply", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      await seedCanonical(forkPoint);
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("persistent-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+
+      await incoming.nodes.Patient.create(
+        { name: "Anna Rivera", mrn: "MRN-123" },
+        { id: "patient-alias" },
+      );
+      await incoming.edges.primaryFacility.create(
+        { kind: "Patient", id: "patient-alias" },
+        { kind: "Facility", id: "facility-1" },
+        { source: "provider-a" },
+        { id: "edge-from-alias" },
+      );
+
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: incrementalOptions(),
+        }),
+      );
+      expect(
+        plan.review.resolutions.some(
+          (resolution) =>
+            resolution.canonicalId === "patient-canonical" &&
+            resolution.memberIds.includes(asNodeId("patient-alias")) &&
+            resolution.memberIds.includes(asNodeId("patient-canonical")),
+        ),
+      ).toBe(true);
+
+      unwrap(await applyMergePlan(targetClone.store, plan));
+
+      const patients = await targetClone.store.nodes.Patient.find();
+      expect(patients.map((patient) => patient.id)).toEqual([
+        "patient-canonical",
+      ]);
+      const edge = requireDefined(
+        await targetClone.store.edges.primaryFacility.getById(
+          asEdgeId<typeof primaryFacility>("edge-from-alias"),
+        ),
+      );
+      expect(edge.fromId).toBe("patient-canonical");
+      expect(edge.toId).toBe("facility-1");
+    });
+
+    it("keeps ordinary branch uniqueness immediate", async () => {
+      cleanups = [];
+      const base = await makeStore();
+      await seedCanonical(base);
+      const ordinary = await cloneStore(base, asBranchId("ordinary"));
+
+      await expect(
+        ordinary.store.nodes.Patient.create(
+          { name: "Anna Rivera", mrn: "MRN-123" },
+          { id: "patient-alias" },
+        ),
+      ).rejects.toThrow(UniquenessError);
+    });
+
+    it("validates the resolved write set as a set so unique-key swaps succeed", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      await forkPoint.nodes.Patient.bulkCreate([
+        {
+          id: "patient-a",
+          props: { name: "Patient A", mrn: "MRN-A" },
+        },
+        {
+          id: "patient-b",
+          props: { name: "Patient B", mrn: "MRN-B" },
+        },
+      ]);
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("persistent-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+
+      await incoming.nodes.Patient.update(asNodeId("patient-a"), {
+        mrn: "MRN-B",
+      });
+      await incoming.nodes.Patient.update(asNodeId("patient-b"), {
+        mrn: "MRN-A",
+      });
+
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: { onBasePropertyConflict: "flag" },
+        }),
+      );
+      unwrap(await applyMergePlan(targetClone.store, plan));
+
+      expect(
+        await targetClone.store.nodes.Patient.getById(asNodeId("patient-a")),
+      ).toMatchObject({ mrn: "MRN-B" });
+      expect(
+        await targetClone.store.nodes.Patient.getById(asNodeId("patient-b")),
+      ).toMatchObject({ mrn: "MRN-A" });
+    });
+
+    it("allows one resolved row to release a unique key while another claims it", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      await forkPoint.nodes.Patient.create(
+        { name: "Previous holder", mrn: "MRN-SHARED" },
+        { id: "previous-holder" },
+      );
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("persistent-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+      await incoming.nodes.Patient.update(asNodeId("previous-holder"), {
+        mrn: "MRN-MOVED",
+      });
+      await incoming.nodes.Patient.create(
+        { name: "New holder", mrn: "MRN-SHARED" },
+        { id: "new-holder" },
+      );
+
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: { onBasePropertyConflict: "flag" },
+        }),
+      );
+      unwrap(await applyMergePlan(targetClone.store, plan));
+
+      expect(
+        await targetClone.store.nodes.Patient.getById(
+          asNodeId("previous-holder"),
+        ),
+      ).toMatchObject({ mrn: "MRN-MOVED" });
+      expect(
+        await targetClone.store.nodes.Patient.getById(asNodeId("new-holder")),
+      ).toMatchObject({ mrn: "MRN-SHARED" });
+    });
+
+    it("validates modification-only writes from their complete after-images", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      await forkPoint.nodes.Patient.bulkCreate([
+        {
+          id: "patient-a",
+          props: { name: "Patient A", mrn: "MRN-A" },
+        },
+        {
+          id: "patient-b",
+          props: { name: "Patient B", mrn: "MRN-B" },
+        },
+      ]);
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("persistent-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+      await incoming.nodes.Patient.update(asNodeId("patient-a"), {
+        name: "Updated A",
+      });
+      await incoming.nodes.Patient.update(asNodeId("patient-b"), {
+        name: "Updated B",
+      });
+
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: { onBasePropertyConflict: "flag" },
+        }),
+      );
+      unwrap(await applyMergePlan(targetClone.store, plan));
+
+      expect(
+        await targetClone.store.nodes.Patient.getById(asNodeId("patient-a")),
+      ).toMatchObject({ name: "Updated A", mrn: "MRN-A" });
+      expect(
+        await targetClone.store.nodes.Patient.getById(asNodeId("patient-b")),
+      ).toMatchObject({ name: "Updated B", mrn: "MRN-B" });
+      await expect(
+        targetClone.store.nodes.Patient.create({
+          name: "Duplicate",
+          mrn: "MRN-A",
+        }),
+      ).rejects.toThrow(UniquenessError);
+    });
+
+    it("rebuilds uniqueness sidecars when an unchanged canonical upsert is coalesced", async () => {
+      cleanups = [];
+      const base = await makeStore({ coalesceUnchangedUpserts: true });
+      await seedCanonical(base);
+      const incoming = await makeIngestion(base);
+      await incoming.nodes.Patient.create(
+        { name: "Ana Rivera", mrn: "MRN-123" },
+        { id: "patient-alias" },
+      );
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint: base,
+          target: base,
+          branches: [incoming],
+          options: incrementalOptions(),
+        }),
+      );
+
+      unwrap(await applyMergePlan(base, plan));
+
+      await expect(
+        base.nodes.Patient.create({
+          name: "Duplicate",
+          mrn: "MRN-123",
+        }),
+      ).rejects.toThrow(UniquenessError);
+    });
+
+    it("produces the same canonical result for either alias ingestion order", async () => {
+      cleanups = [];
+
+      async function applyOrder(order: readonly string[]) {
+        const forkPoint = await makeStore();
+        await seedCanonical(forkPoint);
+        const targetClone = await cloneStore(
+          forkPoint,
+          asBranchId(`target-${order.join("-")}`),
+        );
+        const incoming = await makeIngestion(forkPoint);
+        await incoming.nodes.Patient.bulkCreate(
+          order.map((id) => ({
+            id,
+            props: { name: "Anna Rivera", mrn: "MRN-123" },
+          })),
+        );
+
+        const plan = unwrap(
+          await planMergeIncremental({
+            forkPoint,
+            target: targetClone.store,
+            branches: [incoming],
+            options: incrementalOptions(),
+          }),
+        );
+        unwrap(await applyMergePlan(targetClone.store, plan));
+        return {
+          patientIds: (await targetClone.store.nodes.Patient.find()).map(
+            (patient) => patient.id,
+          ),
+          resolutions: plan.review.resolutions.map((resolution) => ({
+            canonicalId: resolution.canonicalId,
+            memberIds: [...resolution.memberIds].sort(),
+          })),
+        };
+      }
+
+      const forward = await applyOrder(["alias-a", "alias-b"]);
+      const reverse = await applyOrder(["alias-b", "alias-a"]);
+      expect(reverse).toEqual(forward);
+      expect(forward.patientIds).toEqual(["patient-canonical"]);
+    });
+
+    it("still enforces endpoint, cardinality, and disjointness constraints while staging", async () => {
+      cleanups = [];
+      const base = await makeStore();
+      const incoming = await makeIngestion(base);
+      expectTypeOf(incoming.nodes.Patient).not.toHaveProperty(
+        "findByConstraint",
+      );
+      await expect(
+        incoming.nodes.Patient.create({
+          name: "Invalid patient",
+          mrn: 42 as unknown as string,
+        }),
+      ).rejects.toThrow();
+      await incoming.nodes.Patient.create(
+        { name: "Ana Rivera", mrn: "MRN-123" },
+        { id: "patient-1" },
+      );
+      await incoming.nodes.Facility.create(
+        { name: "General Hospital" },
+        { id: "facility-1" },
+      );
+      await incoming.nodes.Facility.create(
+        { name: "Specialty Clinic" },
+        { id: "facility-2" },
+      );
+
+      await expect(
+        incoming.edges.primaryFacility.create(
+          { kind: "Patient", id: "missing-patient" },
+          { kind: "Facility", id: "facility-1" },
+          { source: "provider-a" },
+        ),
+      ).rejects.toThrow(EndpointNotFoundError);
+
+      await incoming.edges.primaryFacility.create(
+        { kind: "Patient", id: "patient-1" },
+        { kind: "Facility", id: "facility-1" },
+        { source: "provider-a" },
+      );
+      await expect(
+        incoming.edges.primaryFacility.create(
+          { kind: "Patient", id: "patient-1" },
+          { kind: "Facility", id: "facility-2" },
+          { source: "provider-a" },
+        ),
+      ).rejects.toThrow(CardinalityError);
+
+      await expect(
+        incoming.nodes.AdministrativeRecord.create(
+          { label: "Patient billing record" },
+          { id: "patient-1" },
+        ),
+      ).rejects.toThrow(DisjointError);
+    });
+
+    it("persists the derived schema and exposes no Store escape hatch", async () => {
+      cleanups = [];
+      const base = await makeStore();
+      let ingestionBackend: GraphBackend | undefined;
+      const incoming = unwrap(
+        await ingestionBranch(
+          base,
+          async () => {
+            ingestionBackend = await makeBackend();
+            return ingestionBackend;
+          },
+          { id: INCOMING },
+        ),
+      );
+
+      expect("store" in incoming).toBe(false);
+      expectTypeOf(incoming).not.toHaveProperty("store");
+      const activeSchema = requireDefined(
+        await requireDefined(ingestionBackend).getActiveSchema(base.graphId),
+      );
+      const persisted = parseSerializedSchema(activeSchema.schema_doc);
+      expect(persisted.nodes["Patient"]?.uniqueConstraints).toEqual([]);
+      expect(persisted.nodes["Practitioner"]?.uniqueConstraints).toEqual([]);
+      expect(persisted.edges["primaryFacility"]?.cardinality).toBe("oneActive");
+      expect(persisted.indexes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "patient_mrn_candidates" }),
+        ]),
+      );
+
+      const [reloaded] = await createVerifiedStore(
+        relaxedIngestionGraph,
+        requireDefined(ingestionBackend),
+        { revisionTracking: true },
+      );
+      await reloaded.nodes.Patient.bulkCreate([
+        {
+          id: "reloaded-a",
+          props: { name: "Reloaded A", mrn: "MRN-RELOADED" },
+        },
+        {
+          id: "reloaded-b",
+          props: { name: "Reloaded B", mrn: "MRN-RELOADED" },
+        },
+      ]);
+      expect(await reloaded.nodes.Patient.count()).toBe(2);
+    });
+
+    it("refuses final validation when the target transaction lacks batch uniqueness operations", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      const targetClone = unwrap(
+        await branch(
+          forkPoint,
+          async () => withoutResolvedBatchTransaction(await makeBackend()),
+          { id: asBranchId("limited-target") },
+        ),
+      );
+      const incoming = await makeIngestion(forkPoint);
+      await incoming.nodes.Patient.create(
+        { name: "New patient", mrn: "MRN-NEW" },
+        { id: "patient-new" },
+      );
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: { onBasePropertyConflict: "flag" },
+        }),
+      );
+
+      const result = await applyMergePlan(targetClone.store, plan);
+
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) return;
+      expect(result.error.cause).toBeInstanceOf(ConfigurationError);
+      expect((result.error.cause as ConfigurationError).details).toMatchObject({
+        code: "RESOLVED_NODE_UNIQUENESS_UNSUPPORTED",
+      });
+      expect(await targetClone.store.nodes.Patient.find()).toEqual([]);
+    });
+
+    it("returns an atomic MergeConstraintConflictError when cross-kind duplicates remain unresolved", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("persistent-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+      await incoming.nodes.Patient.create(
+        { name: "Ana Rivera", mrn: "SHARED-1" },
+        { id: "shared-entity" },
+      );
+      await incoming.nodes.Practitioner.create(
+        { name: "A. Rivera", mrn: "SHARED-1" },
+        { id: "shared-entity" },
+      );
+
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: { onBasePropertyConflict: "flag" },
+        }),
+      );
+      const result = await applyMergePlan(targetClone.store, plan);
+
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) return;
+      expect(result.error).toBeInstanceOf(MergeConstraintConflictError);
+      expect(result.error.cause).toBeInstanceOf(UniquenessError);
+      expect(await targetClone.store.nodes.Patient.find()).toEqual([]);
+      expect(await targetClone.store.nodes.Practitioner.find()).toEqual([]);
+    });
+  },
+);
+
+describe("resolved ingestion uniqueness properties", () => {
+  it("preserves unique-key swaps for arbitrary distinct keys and either staging order", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .tuple(
+            fc.string({ minLength: 1, maxLength: 12 }),
+            fc.string({ minLength: 1, maxLength: 12 }),
+          )
+          .filter(([left, right]) => left !== right),
+        fc.boolean(),
+        async ([leftKey, rightKey], reverseOrder) => {
+          const fixtures: (() => Promise<void>)[] = [];
+          async function makeBackend(): Promise<GraphBackend> {
+            const fixture = createSqliteMergeBackend();
+            fixtures.push(fixture.cleanup);
+            return fixture.backend;
+          }
+
+          try {
+            const [forkPoint] = await createStoreWithSchema(
+              ingestionGraph,
+              await makeBackend(),
+              { revisionTracking: true },
+            );
+            await forkPoint.nodes.Patient.bulkCreate([
+              {
+                id: "patient-left",
+                props: { name: "Left", mrn: leftKey },
+              },
+              {
+                id: "patient-right",
+                props: { name: "Right", mrn: rightKey },
+              },
+            ]);
+            const target = unwrap(
+              await branch(forkPoint, () => makeBackend(), {
+                id: asBranchId("property-target"),
+              }),
+            );
+            const incoming = unwrap(
+              await ingestionBranch(forkPoint, () => makeBackend(), {
+                id: INCOMING,
+              }),
+            );
+            const updates = [
+              { id: "patient-left", mrn: rightKey },
+              { id: "patient-right", mrn: leftKey },
+            ];
+            for (const update of reverseOrder ?
+              updates.toReversed()
+            : updates) {
+              await incoming.nodes.Patient.update(asNodeId(update.id), {
+                mrn: update.mrn,
+              });
+            }
+
+            const plan = unwrap(
+              await planMergeIncremental({
+                forkPoint,
+                target: target.store,
+                branches: [incoming],
+                options: { onBasePropertyConflict: "flag" },
+              }),
+            );
+            unwrap(await applyMergePlan(target.store, plan));
+
+            const finalRows = (await target.store.nodes.Patient.find()).sort(
+              (left, right) => left.id.localeCompare(right.id),
+            );
+            expect(finalRows.map((row) => row.mrn)).toEqual([
+              rightKey,
+              leftKey,
+            ]);
+            expect(new Set(finalRows.map((row) => row.mrn)).size).toBe(2);
+          } finally {
+            for (const cleanup of fixtures.toReversed()) await cleanup();
+          }
+        },
+      ),
+      { numRuns: 10 },
+    );
+  });
+});

--- a/packages/typegraph/tests/graph-merge/merge-rollback.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-rollback.test.ts
@@ -17,11 +17,13 @@
 
 import type { GraphBackend, Store } from "@nicia-ai/typegraph";
 import {
+  asNodeId,
   CardinalityError,
   createStoreWithSchema,
   defineEdge,
   defineGraph,
   defineNode,
+  UniquenessError,
 } from "@nicia-ai/typegraph";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -59,7 +61,17 @@ const primaryEncounter = defineEdge("primaryEncounter", {
 const rollbackGraph = defineGraph({
   id: "merge-rollback-graph",
   nodes: {
-    Patient: { type: Patient },
+    Patient: {
+      type: Patient,
+      unique: [
+        {
+          name: "patient_name_unique",
+          fields: ["name"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
     Encounter: { type: Encounter },
   },
   edges: {
@@ -149,6 +161,9 @@ describe.each(backendMatrix())(
 
       const branchA = await makeBranch(baseStore, BRANCH_A);
       const branchB = await makeBranch(baseStore, BRANCH_B);
+      await branchA.store.nodes.Patient.update(asNodeId("pat-1"), {
+        name: "Robert Updated",
+      });
 
       // Each branch adds ONE primary encounter for pat-1 — valid per branch
       // (cardinality "oneActive" holds inside each fork), violated by their union.
@@ -198,6 +213,15 @@ describe.each(backendMatrix())(
       expect(await liveNodeIds(baseStore, "Patient")).toEqual(["pat-1"]);
       expect(await liveNodeIds(baseStore, "Encounter")).toEqual([]);
       expect(await liveEdgeIds(baseStore, "primaryEncounter")).toEqual([]);
+      await expect(
+        baseStore.nodes.Patient.create({ name: "Robert Smith" }),
+      ).rejects.toThrow(UniquenessError);
+      await expect(
+        baseStore.nodes.Patient.create(
+          { name: "Robert Updated" },
+          { id: "pat-2" },
+        ),
+      ).resolves.toMatchObject({ id: "pat-2" });
       expect(
         await readProvenance(await openProvenanceStore(baseStore)),
       ).toEqual([]);


### PR DESCRIPTION
## Summary

- Add an opaque `ingestionBranch()` handle that exposes typed node and edge staging without leaking an ordinary `Store` or its schema, transaction, query, and runtime surfaces.
- Derive and persist an honest ingestion schema that removes only node uniqueness declarations while retaining schema validation, indexes, endpoint checks, edge cardinality, disjointness, ontology, identity, defaults, and deprecations.
- Let snapshot and incremental merge entrypoints consume ingestion branches while canonical candidate lookup remains anchored to the target store, including `blockIndex` recall for reviewed incremental resolution.
- Validate the complete resolved node write set transactionally before applying it, allowing swaps and key handoffs, rebuilding uniqueness sidecars after coalesced writes, and returning `MergeConstraintConflictError` when duplicates remain.
- Refuse backends without the required batch uniqueness capabilities, update the public API reports, document the workflow and persistence contract, and add a minor Changeset.

The load-bearing regression coverage was mutation-checked: restoring canonical uniqueness on the ingestion clone rejects repeated aliases during staging, reducing ownership identity to raw IDs misses cross-kind conflicts, and removing the final sidecar rebuild permits a duplicate after a coalesced upsert. Each mutation failed the targeted suite before the implementation was restored.

Closes #478
