### PR TITLE
perf(ci): shorten the coverage critical path

### DIFF
--- a/.github/scripts/is-release-metadata-only.sh
+++ b/.github/scripts/is-release-metadata-only.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: $0 <base-sha> <head-sha>" >&2
+  exit 2
+fi
+
+base_sha="$1"
+head_sha="$2"
+has_changed_file=false
+is_release_metadata_only=true
+
+function package_change_is_version_only() {
+  local package_path="$1"
+  local base_package
+  local head_package
+
+  if ! base_package="$(git show "$base_sha:$package_path" | jq -cS 'del(.version)')"; then
+    return 1
+  fi
+
+  if ! head_package="$(git show "$head_sha:$package_path" | jq -cS 'del(.version)')"; then
+    return 1
+  fi
+
+  [[ "$base_package" == "$head_package" ]]
+}
+
+while IFS= read -r changed_file; do
+  if [[ -z "$changed_file" ]]; then
+    continue
+  fi
+
+  has_changed_file=true
+
+  case "$changed_file" in
+    .changeset/*.md | CHANGELOG.md | */CHANGELOG.md) ;;
+    packages/typegraph/package.json)
+      if ! package_change_is_version_only "$changed_file"; then
+        is_release_metadata_only=false
+        break
+      fi
+      ;;
+    *)
+      is_release_metadata_only=false
+      break
+      ;;
+  esac
+done < <(git diff --name-only "$base_sha" "$head_sha")
+
+if [[ "$has_changed_file" != "true" ]]; then
+  is_release_metadata_only=false
+fi
+
+echo "$is_release_metadata_only"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,56 +18,46 @@ jobs:
     name: Detect release metadata push
     runs-on: ubuntu-24.04
     outputs:
-      skip_push_ci: ${{ steps.detect.outputs.skip_push_ci }}
+      skip_heavy_ci: ${{ steps.detect.outputs.skip_heavy_ci }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Detect release metadata-only push
+      - name: Detect release metadata-only change
         id: detect
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.event_name }}" != "push" ]]; then
-            echo "skip_push_ci=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          base_sha="${{ github.event.before }}"
-          head_sha="${{ github.sha }}"
+          case "${{ github.event_name }}" in
+            push)
+              base_sha="${{ github.event.before }}"
+              head_sha="${{ github.sha }}"
+              ;;
+            pull_request)
+              base_sha="${{ github.event.pull_request.base.sha }}"
+              head_sha="${{ github.event.pull_request.head.sha }}"
+              ;;
+            *)
+              echo "skip_heavy_ci=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
 
           if [[ "$base_sha" == "0000000000000000000000000000000000000000" ]]; then
-            echo "skip_push_ci=false" >> "$GITHUB_OUTPUT"
+            echo "skip_heavy_ci=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          mapfile -t changed_files < <(git diff --name-only "$base_sha" "$head_sha")
-
-          if [[ "${#changed_files[@]}" -eq 0 ]]; then
-            echo "skip_push_ci=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          skip_push_ci=true
-          for changed_file in "${changed_files[@]}"; do
-            case "$changed_file" in
-              .changeset/*.md | CHANGELOG.md | */CHANGELOG.md | packages/typegraph/package.json) ;;
-              *)
-                skip_push_ci=false
-                break
-                ;;
-            esac
-          done
-
-          echo "skip_push_ci=$skip_push_ci" >> "$GITHUB_OUTPUT"
+          skip_heavy_ci="$(.github/scripts/is-release-metadata-only.sh "$base_sha" "$head_sha")"
+          echo "skip_heavy_ci=$skip_heavy_ci" >> "$GITHUB_OUTPUT"
 
   lint-and-check:
     name: Lint & Type Check
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -104,7 +94,7 @@ jobs:
     name: Test Unit (SQLite, Node 22, shard ${{ matrix.shard }})
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -130,7 +120,7 @@ jobs:
     name: Test Property (SQLite, Node 24)
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -152,7 +142,7 @@ jobs:
     name: Test Smoke (SQLite, Node 24)
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -177,7 +167,7 @@ jobs:
     name: Test Strict Packed Consumers (TypeScript 5 and 6)
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -199,16 +189,20 @@ jobs:
     name: Coverage shard ${{ matrix.shard }}
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
-    timeout-minutes: 20
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - shard: "1/2"
+          - shard: "1/4"
             artifact: coverage-blob-1
-          - shard: "2/2"
+          - shard: "2/4"
             artifact: coverage-blob-2
+          - shard: "3/4"
+            artifact: coverage-blob-3
+          - shard: "4/4"
+            artifact: coverage-blob-4
     steps:
       - uses: actions/checkout@v6
 
@@ -250,7 +244,7 @@ jobs:
     if: >-
       ${{
         always() &&
-        needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' &&
+        needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' &&
         needs.test-coverage.result != 'skipped'
       }}
     timeout-minutes: 10
@@ -287,7 +281,7 @@ jobs:
     name: Type Tests (TS ${{ matrix.typescript-version }})
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -319,7 +313,7 @@ jobs:
     name: Test (PostgreSQL, shard ${{ matrix.shard }})
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -406,7 +400,7 @@ jobs:
     name: Test (Durable Objects SQLite)
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -424,22 +418,12 @@ jobs:
       - name: Run Durable Objects SQLite tests (workerd)
         run: pnpm --filter @nicia-ai/typegraph test:do
 
-  build:
-    name: Build
+  build-artifacts:
+    name: Build artifacts
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs:
-      - detect-release-metadata-push
-      - lint-and-check
-      - test-sqlite-unit
-      - test-sqlite-property
-      - test-sqlite-smoke
-      - test-strict-local-consumers
-      - test-coverage-merge
-      - test-typescript-compat
-      - test-postgres
-      - test-durable-objects
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci != 'true' }}
+    needs: [detect-release-metadata-push]
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -459,11 +443,42 @@ jobs:
           NICIA_EMAIL_LIST_API_URL: ${{ secrets.NICIA_EMAIL_LIST_API_URL }}
           NICIA_EMAIL_LIST_API_KEY: ${{ secrets.NICIA_EMAIL_LIST_API_KEY }}
 
+  build:
+    name: Build
+    runs-on: ubuntu-24.04
+    needs:
+      - build-artifacts
+      - detect-release-metadata-push
+      - lint-and-check
+      - test-sqlite-unit
+      - test-sqlite-property
+      - test-sqlite-smoke
+      - test-strict-local-consumers
+      - test-coverage-merge
+      - test-typescript-compat
+      - test-postgres
+      - test-durable-objects
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.detect-release-metadata-push.outputs.skip_heavy_ci != 'true'
+      }}
+    steps:
+      - name: Confirm required jobs passed
+        env:
+          REQUIRED_JOBS: ${{ toJSON(needs) }}
+        run: |
+          failed_jobs="$(jq -r '[to_entries[] | select(.value.result != "success") | .key] | join(", ")' <<< "$REQUIRED_JOBS")"
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required CI jobs did not pass: $failed_jobs" >&2
+            exit 1
+          fi
+
   release-metadata-push:
     name: Release metadata push check
     runs-on: ubuntu-24.04
     needs: [detect-release-metadata-push]
-    if: ${{ needs.detect-release-metadata-push.outputs.skip_push_ci == 'true' }}
+    if: ${{ needs.detect-release-metadata-push.outputs.skip_heavy_ci == 'true' }}
     steps:
-      - name: Skip heavy CI on release metadata-only push
-        run: echo "Skipping heavy CI for release metadata-only push to main."
+      - name: Skip heavy CI on release metadata-only change
+        run: echo "Skipping heavy CI because only release metadata changed."

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -29,8 +29,8 @@ changelog generation, npm publishing, and GitHub Releases.
 
 ## Pre-release Verification
 
-CI must pass the complete release surface before the Version Packages PR is
-merged:
+Code-changing PRs must pass the complete release surface before their
+changesets reach `main`:
 
 - formatting, lint, typechecking, and the SQLite/PGlite test suite;
 - the PostgreSQL integration suite;
@@ -38,6 +38,13 @@ merged:
 - the documentation build, rendered internal links and anchors, and TypeGraph
   imports extracted from current documentation code blocks;
 - strict packed-consumer tests and API-report checks.
+
+The generated Version Packages PR only changes release metadata, so CI skips
+those heavy jobs after verifying that its changes are limited to changesets,
+changelogs, and the package version. Any other package manifest or source
+change runs the complete gate. After the Version Packages PR merges, the
+release workflow still builds and smoke-imports the npm tarball before
+publishing.
 
 The corresponding local commands are:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -390,20 +390,23 @@ it("closure is transitive", () => {
 
 ## CI Integration
 
-Every pull request to `main` must pass the full gate defined in
-[`.github/workflows/ci.yml`](../.github/workflows/ci.yml). It is much broader
-than the local `pnpm test` default (which runs only SQLite unit/property
-tests). The jobs are:
+Every code-changing pull request to `main` must pass the full gate defined in
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml). Release changes that
+only update changesets, changelogs, and the package version skip the heavy jobs;
+the parsed package manifest must otherwise be identical.
+The full gate is much broader than the local `pnpm test` default (which runs
+only SQLite unit/property tests). The jobs are:
 
 | Job | What it runs |
 |-----|--------------|
 | **Lint & Type Check** | `typecheck`, `lint` (ESLint), `prettier`, `test:docs` (markdownlint), `test:unused` (knip) |
-| **Test (SQLite)** | `test:unit` + `test:property` on Node 22 and 24, plus a SQLite perf sanity check and an example smoke test |
-| **Test (Coverage)** | `test:coverage` — enforces the coverage thresholds |
-| **Type Tests** | `test:types` against TypeScript 5.9.3 and 6.0.2 |
+| **Test (SQLite)** | Two `test:unit` shards on Node 22, `test:property` on Node 24, plus a SQLite perf sanity check and example smoke tests |
+| **Test (Coverage)** | Four V8 coverage shards on Node 24; a merge job combines their blob reports and enforces the coverage thresholds |
+| **Type Tests** | `test:types` against TypeScript 5.9.3 and 6.0.3 |
 | **Test (PostgreSQL)** | `test:postgres` against `pgvector/pgvector:pg18` (PostgreSQL + pgvector), plus a PostgreSQL perf sanity check |
 | **Test (Durable Objects SQLite)** | `test:do` — the workerd / Cloudflare Durable Objects SQLite lane |
-| **Build** | `turbo run build` — gated on every job above |
+| **Build artifacts** | `turbo run build` in parallel with the test jobs |
+| **Build** | Final required gate that succeeds only after the build and every test job above pass |
 
 A separate [release workflow](../.github/workflows/release.yml) packs the npm
 tarball after CI passes and smoke-imports every public subpath (ESM + CJS)

--- a/packages/typegraph/tests/ci-workflow-contract.test.ts
+++ b/packages/typegraph/tests/ci-workflow-contract.test.ts
@@ -1,0 +1,247 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const WORKFLOW_PATH = fileURLToPath(
+  new URL("../../../.github/workflows/ci.yml", import.meta.url),
+);
+const METADATA_PREDICATE_PATH = fileURLToPath(
+  new URL(
+    "../../../.github/scripts/is-release-metadata-only.sh",
+    import.meta.url,
+  ),
+);
+
+function runGit(fixtureDirectory: string, args: readonly string[]): string {
+  return execFileSync("git", args, {
+    cwd: fixtureDirectory,
+    encoding: "utf8",
+  }).trim();
+}
+
+function writeFixtureFile(
+  fixtureDirectory: string,
+  relativePath: string,
+  content: string,
+): void {
+  const absolutePath = path.join(fixtureDirectory, relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+}
+
+function commitFixture(fixtureDirectory: string, message: string): string {
+  runGit(fixtureDirectory, ["add", "."]);
+  runGit(fixtureDirectory, ["commit", "-m", message]);
+  return runGit(fixtureDirectory, ["rev-parse", "HEAD"]);
+}
+
+function classifyCommitRange(
+  fixtureDirectory: string,
+  baseSha: string,
+  headSha: string,
+): string {
+  return execFileSync(METADATA_PREDICATE_PATH, [baseSha, headSha], {
+    cwd: fixtureDirectory,
+    encoding: "utf8",
+  }).trim();
+}
+
+describe("CI workflow contract", () => {
+  let fixtureDirectory: string;
+
+  beforeEach(() => {
+    fixtureDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-ci-contract-"),
+    );
+    runGit(fixtureDirectory, ["init"]);
+    runGit(fixtureDirectory, ["config", "user.name", "CI Contract Test"]);
+    runGit(fixtureDirectory, [
+      "config",
+      "user.email",
+      "ci-contract@example.com",
+    ]);
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/package.json",
+      `${JSON.stringify({ name: "typegraph", scripts: { test: "vitest" }, version: "1.0.0" }, undefined, 2)}\n`,
+    );
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/CHANGELOG.md",
+      "# Changelog\n",
+    );
+    commitFixture(fixtureDirectory, "initial fixture");
+  });
+
+  afterEach(() => {
+    rmSync(fixtureDirectory, { force: true, recursive: true });
+  });
+
+  it("runs four coverage shards with timeout headroom", () => {
+    const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+    for (const [index, shard] of ["1/4", "2/4", "3/4", "4/4"].entries()) {
+      expect(workflow).toContain(`shard: "${shard}"`);
+      expect(workflow).toContain(`artifact: coverage-blob-${index + 1}`);
+    }
+
+    expect(workflow).toMatch(
+      /test-coverage:[\s\S]*?timeout-minutes: 30[\s\S]*?strategy:/,
+    );
+  });
+
+  it("detects metadata-only changes on pushes and pull requests", () => {
+    const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+    const baseSha = runGit(fixtureDirectory, ["rev-parse", "HEAD"]);
+
+    expect(workflow).toContain('base_sha="${{ github.event.before }}"');
+    expect(workflow).toContain('head_sha="${{ github.sha }}"');
+    expect(workflow).toContain("github.event.pull_request.base.sha");
+    expect(workflow).toContain("github.event.pull_request.head.sha");
+    expect(workflow).toContain(
+      'if [[ "$base_sha" == "0000000000000000000000000000000000000000" ]]',
+    );
+    expect(workflow).toContain('echo "skip_heavy_ci=false"');
+    expect(workflow).toContain("skip_heavy_ci");
+
+    writeFixtureFile(
+      fixtureDirectory,
+      ".changeset/release.md",
+      '---\n"typegraph": patch\n---\n',
+    );
+    const changesetSha = commitFixture(fixtureDirectory, "add changeset");
+    expect(classifyCommitRange(fixtureDirectory, baseSha, changesetSha)).toBe(
+      "true",
+    );
+
+    writeFixtureFile(fixtureDirectory, "CHANGELOG.md", "# Workspace changes\n");
+    const rootChangelogSha = commitFixture(
+      fixtureDirectory,
+      "update root changelog",
+    );
+    expect(
+      classifyCommitRange(fixtureDirectory, changesetSha, rootChangelogSha),
+    ).toBe("true");
+
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/package.json",
+      `${JSON.stringify({ name: "typegraph", scripts: { test: "vitest" }, version: "1.0.1" }, undefined, 2)}\n`,
+    );
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/CHANGELOG.md",
+      "# Changelog\n\n## 1.0.1\n",
+    );
+    const metadataSha = commitFixture(fixtureDirectory, "release metadata");
+
+    expect(
+      classifyCommitRange(fixtureDirectory, rootChangelogSha, metadataSha),
+    ).toBe("true");
+
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/package.json",
+      `${JSON.stringify({ name: "typegraph", scripts: { test: "vitest --run" }, version: "1.0.2" }, undefined, 2)}\n`,
+    );
+    const scriptChangeSha = commitFixture(
+      fixtureDirectory,
+      "change package script",
+    );
+    expect(
+      classifyCommitRange(fixtureDirectory, metadataSha, scriptChangeSha),
+    ).toBe("false");
+
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/src/index.ts",
+      "export const changed = true;\n",
+    );
+    const sourceChangeSha = commitFixture(fixtureDirectory, "change source");
+    expect(
+      classifyCommitRange(fixtureDirectory, scriptChangeSha, sourceChangeSha),
+    ).toBe("false");
+    expect(
+      classifyCommitRange(fixtureDirectory, sourceChangeSha, sourceChangeSha),
+    ).toBe("false");
+
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/package.json",
+      "{ invalid json\n",
+    );
+    const invalidPackageSha = commitFixture(
+      fixtureDirectory,
+      "malform package manifest",
+    );
+    expect(
+      classifyCommitRange(fixtureDirectory, sourceChangeSha, invalidPackageSha),
+    ).toBe("false");
+
+    writeFixtureFile(
+      fixtureDirectory,
+      "packages/typegraph/package.json",
+      `${JSON.stringify({ name: "typegraph", scripts: { test: "vitest --run" }, version: "1.0.3" }, undefined, 2)}\n`,
+    );
+    const restoredPackageSha = commitFixture(
+      fixtureDirectory,
+      "restore package manifest",
+    );
+    expect(
+      classifyCommitRange(
+        fixtureDirectory,
+        invalidPackageSha,
+        restoredPackageSha,
+      ),
+    ).toBe("false");
+  });
+
+  it("rejects invalid metadata predicate invocations", () => {
+    const result = spawnSync(METADATA_PREDICATE_PATH, [], {
+      cwd: fixtureDirectory,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("Usage:");
+  });
+
+  it("builds in parallel and preserves Build as the final required gate", () => {
+    const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toMatch(
+      /build-artifacts:[\s\S]*?needs: \[detect-release-metadata-push\][\s\S]*?pnpm turbo run build/,
+    );
+    expect(workflow).toMatch(
+      /\n {2}build:\n[\s\S]*?name: Build[\s\S]*?- build-artifacts[\s\S]*?toJSON\(needs\)/,
+    );
+    for (const requiredJob of [
+      "build-artifacts",
+      "lint-and-check",
+      "test-sqlite-unit",
+      "test-sqlite-property",
+      "test-sqlite-smoke",
+      "test-strict-local-consumers",
+      "test-coverage-merge",
+      "test-typescript-compat",
+      "test-postgres",
+      "test-durable-objects",
+    ]) {
+      expect(workflow).toMatch(
+        new RegExp(String.raw`\n {6}- ${requiredJob}(?:\n|$)`),
+      );
+    }
+    expect(workflow).toContain('.value.result != "success"');
+    expect(workflow).toContain("!cancelled()");
+  });
+});


### PR DESCRIPTION
- Split V8 coverage from two shards to four and raise the per-shard timeout from 20 to 30 minutes, reducing the slow serialized graph-merge workload while leaving its in-process concurrency limits intact.
- Run artifact builds in parallel with tests, then preserve `Build` as the final required gate that verifies every dependency succeeded.
- Skip heavy jobs for validated release-metadata-only pushes and pull requests. Package manifest changes qualify only when `version` is the sole semantic difference.
- Add executable CI workflow contract coverage and align the testing and release documentation with the new pipeline.

## Measured impact

| Metric | Before | This PR | Change |
|--------|--------|---------|--------|
| End-to-end PR CI | 21:04 | 16:04 | 5:00 faster (24%) |
| Slowest coverage shard | 18:13 | 10:05 | 8:08 faster (45%) |
| Coverage shard outcomes | A recent post-merge shard timed out and required reruns | 8:10, 9:20, 10:05, and 5:44; all passed first attempt | No shard approached the old 20-minute cutoff |
| Artifact build | Ran after every test dependency | 1:26 in parallel; final required `Build` gate completed in 3s | Removed build work from the post-test critical path |

GitHub runner availability staggered the four coverage starts over roughly five and a half minutes, so the end-to-end result includes queue pressure rather than assuming unlimited concurrency. Coverage is no longer the longest lane; the next bottleneck is SQLite unit shard 1 at 13:30.
