### PR TITLE
fix: stop publishing private ESLint config

### DIFF
--- a/.changeset/clean-published-manifest.md
+++ b/.changeset/clean-published-manifest.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Stop publishing a private workspace ESLint config in package metadata, preventing lockfile-refreshing pnpm installs from resolving an unpublished package.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
+    "@typegraph/eslint-config": "workspace:*",
     "knip": "^6.24.0",
     "markdownlint-cli2": "^0.23.0",
     "npm-run-all2": "^9.0.2",

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -209,7 +209,6 @@
     "@neondatabase/serverless": "^1.1.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
-    "@typegraph/eslint-config": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.13.2",
     "@types/pg": "^8.20.0",

--- a/packages/typegraph/tests/package-manifest.test.ts
+++ b/packages/typegraph/tests/package-manifest.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+const packageManifestSchema = z.object({
+  devDependencies: z.record(z.string(), z.string()).optional(),
+});
+
+describe("published package manifest", () => {
+  it("does not reference the private workspace ESLint config", () => {
+    const packageManifest = packageManifestSchema.parse(
+      JSON.parse(
+        readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+      ),
+    );
+
+    expect(packageManifest.devDependencies).not.toHaveProperty(
+      "@typegraph/eslint-config",
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.0.3)
+      '@typegraph/eslint-config':
+        specifier: workspace:*
+        version: link:packages/eslint-config
       knip:
         specifier: ^6.24.0
         version: 6.24.0
@@ -197,9 +200,6 @@ importers:
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
         version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.13.2))(vitest@4.1.9)
-      '@typegraph/eslint-config':
-        specifier: workspace:*
-        version: link:../eslint-config
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13


### PR DESCRIPTION
## Summary

Move the private workspace ESLint configuration dependency from the publishable `@nicia-ai/typegraph` package to the monorepo root. pnpm rewrites `workspace:*` references during publishing, so keeping this dependency in the package manifest exposed `@typegraph/eslint-config@0.1.0` in registry metadata even though that private package does not exist on npm; lockfile-refreshing installs could then fail with a 404.

Add a manifest regression guard and a patch changeset so future releases keep the private lint dependency out of published metadata.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nicia-ai/codesmith/typegraph/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788992343&installation_model_id=431915&pr_number=485&repository=nicia-ai%2Ftypegraph&return_to=https%3A%2F%2Fgithub.com%2Fnicia-ai%2Ftypegraph%2Fpull%2F485&signature=16be0b8710dcaf7f900016595f58ce6ccb3c644ae9fa973f952ea16e91c795c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->