### PR TITLE
feat(graph-merge): stage identity assertions on ingestion branches

### DIFF
--- a/.changeset/warm-ingestion-identities.md
+++ b/.changeset/warm-ingestion-identities.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Let constraint-aware ingestion branches stage Operational Identity same and different assertions through a conditional assertion-only facade, so duplicate unique aliases and their identity evidence can reach merge planning together.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -851,10 +851,14 @@ const incoming = unwrap(
   }),
 );
 
-await incoming.nodes.Patient.create(
+const alias = await incoming.nodes.Patient.create(
   { name: "Ana Rivera", cohort: "C1", mrn: "MRN-123" },
   { id: "incoming-patient" },
 );
+
+// `canonicalPatient` is an existing Patient read from the base before forking.
+// The repeated MRN and its identity evidence can be staged together.
+await incoming.identity.assertSame(canonicalPatient, alias);
 
 const plan = unwrap(
   await planMergeIncremental({
@@ -877,14 +881,27 @@ const applied = unwrap(await applyMergePlan(base, plan));
 await incoming.close();
 ```
 
-The returned handle exposes ingestion collections, not the branch's underlying
-`Store`, so callers cannot bypass the deferred-constraint contract or run schema
-operations on the derived working copy. The original graph definition remains
-the merge contract: `applyMergePlan()` validates node uniqueness against the
-entire resolved write set in the target transaction. Valid key handoffs and
-swaps are accepted as one set. If reviewed resolution leaves two live owners of
-the same unique key, the merge returns `MergeConstraintConflictError` and
-commits no graph or provenance writes.
+On an identity-enabled graph, the handle also exposes an assertion-only
+`IdentityAssertionWriteFacade` as `identity`: `assertSame`, `assertDifferent`,
+`bulkAssertSame`, and `bulkAssertDifferent`. This lets a batch stage aliases
+that repeat unique keys and the explicit identity evidence needed to reconcile
+them before merge-time constraint validation. Assertion contradictions and
+invalid endpoints are still refused while staging; only node uniqueness is
+deferred.
+
+The returned handle exposes those ingestion collections and identity assertion
+writes, not the branch's underlying `Store`. Identity reads and retractions,
+schema operations, transactions, and runtime internals remain unavailable, so
+callers cannot bypass the deferred-constraint contract. As with `Store`, the
+`identity` property is absent at the type level when the graph does not enable
+Operational Identity.
+
+The original graph definition remains the merge contract:
+`applyMergePlan()` validates node uniqueness against the entire resolved write
+set in the target transaction. Valid key handoffs and swaps are accepted as one
+set. If reviewed resolution leaves two live owners of the same unique key, the
+merge returns `MergeConstraintConflictError` and commits no graph or provenance
+writes.
 
 The derived schema is persisted on the working-copy backend, so the relaxed
 contract is auditable and an explicit reattachment with an equivalent graph

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -21,15 +21,22 @@ const graph = defineGraph({
 });
 ```
 
-The option is serialized with the schema. Enabled graph types expose
-`store.identity`, `tx.identity`, read-only `StoreView.identity`, and the
-identity traversal option. All three use the same conditional-**presence**
-encoding: on an identity-disabled graph type, `identity` does not exist on
-`Store`, `TransactionContext`, or the read-only views at all — reaching for it
-is a compile error, not a `never`-typed property. A runtime `ConfigurationError`
-with details code `IDENTITY_NOT_ENABLED` backs every one of those getters too,
-for the widened or `any`-typed handles TypeScript can't check (a JavaScript
-caller, or a store handle that lost its precise graph type).
+The option is serialized with the schema. Enabled graph types expose the full
+facade as `store.identity` and `tx.identity`, a read-only facade as
+`StoreView.identity`, and the identity traversal option. These surfaces use
+conditional **presence**: on an identity-disabled graph type, `identity` does
+not exist on `Store`, `TransactionContext`, or the read-only views at all —
+reaching for it is a compile error, not a `never`-typed property. A runtime
+`ConfigurationError` with details code `IDENTITY_NOT_ENABLED` backs those
+getters too, for widened or `any`-typed handles TypeScript can't check (a
+JavaScript caller, or a store handle that lost its precise graph type).
+
+Constraint-aware `IngestionBranch` handles follow the same conditional-presence
+contract, but expose only `assertSame`, `assertDifferent`, and their bulk forms.
+Reads and retractions stay unavailable so untrusted batches can stage identity
+evidence without gaining the full operational surface. See
+[Constraint-aware ingestion branches](/graph-merge/#constraint-aware-ingestion-branches)
+for the staging and merge workflow.
 
 At runtime, a disabled graph does no identity work: no identity locks, probes,
 closure computation, or identity SQL run. That guarantee is scoped to runtime

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2000,6 +2000,9 @@ type IdentityAssertionResult<G extends GraphDef> = Readonly<{
 }>;
 
 // @public
+export type IdentityAssertionWriteFacade<G extends GraphDef> = Pick<IdentityFacade<G>, "assertSame" | "assertDifferent" | "bulkAssertSame" | "bulkAssertDifferent">;
+
+// @public
 type IdentityChange = Readonly<{
     type: ChangeType;
     severity: ChangeSeverity;
@@ -2211,7 +2214,9 @@ export type IngestionBranch<G extends GraphDef> = Readonly<{
     nodes: IngestionNodeCollections<G>;
     edges: Store<G>["edges"];
     close: () => Promise<void>;
-}>;
+}> & ("identity" extends keyof Store<G> ? Readonly<{
+    identity: IdentityAssertionWriteFacade<G>;
+}> : Readonly<Record<never, never>>);
 
 // @public
 export function ingestionBranch<G extends GraphDef>(baseStore: GraphBranch<G>["store"], makeBackend: MakeBackend, options?: BranchOptions): Promise<Result<IngestionBranch<G>, BranchError>>;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -2838,6 +2838,9 @@ export type IdentityAssertionResult<G extends GraphDef> = Readonly<{
 }>;
 
 // @public
+export type IdentityAssertionWriteFacade<G extends GraphDef> = Pick<IdentityFacade<G>, "assertSame" | "assertDifferent" | "bulkAssertSame" | "bulkAssertDifferent">;
+
+// @public
 export type IdentityChange = Readonly<{
     type: ChangeType;
     severity: ChangeSeverity;

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -107,6 +107,7 @@ export type {
   KeylessConfig,
   SourceScope,
 } from "./sources";
+export type { IdentityAssertionWriteFacade } from "./typegraph-internal";
 export type {
   BaseAmbiguity,
   BaseVersion,

--- a/packages/typegraph/src/graph-merge/ingestion-branch.ts
+++ b/packages/typegraph/src/graph-merge/ingestion-branch.ts
@@ -12,7 +12,11 @@ import { branch } from "./branch";
 import { BranchError } from "./errors";
 import type { Result } from "./result";
 import { err, isErr, ok } from "./result";
-import type { GraphDef } from "./typegraph-internal";
+import type {
+  GraphDef,
+  IdentityAssertionWriteFacade,
+  IdentityFacade,
+} from "./typegraph-internal";
 import { storeBackend } from "./typegraph-internal";
 import type {
   BranchOptions,
@@ -24,6 +28,26 @@ import type { MakeBackend } from "./working-copy";
 import { cloneIngestionWorkingCopyStrategy } from "./working-copy";
 
 const PRIVATE_BRANCHES = new WeakMap<object, unknown>();
+
+/** Restricts a full identity facade to the assertions accepted during ingestion. */
+function createIngestionIdentityFacade<G extends GraphDef>(
+  identity: IdentityFacade<G>,
+): IdentityAssertionWriteFacade<G> {
+  return Object.freeze({
+    assertSame(a, b, window) {
+      return identity.assertSame(a, b, window);
+    },
+    assertDifferent(a, b, window) {
+      return identity.assertDifferent(a, b, window);
+    },
+    bulkAssertSame(pairs) {
+      return identity.bulkAssertSame(pairs);
+    },
+    bulkAssertDifferent(pairs) {
+      return identity.bulkAssertDifferent(pairs);
+    },
+  });
+}
 
 /**
  * Creates an isolated ingestion branch whose node uniqueness constraints are
@@ -55,11 +79,21 @@ export async function ingestionBranch<G extends GraphDef>(
     }
     const privateBranch = created.data;
     const { base, id, store } = privateBranch;
+    const identityAccess =
+      store.graph.identity === undefined ?
+        {}
+      : {
+          identity: createIngestionIdentityFacade(
+            (store as typeof store & Readonly<{ identity: IdentityFacade<G> }>)
+              .identity,
+          ),
+        };
     const handle = Object.freeze({
       id,
       base,
       nodes: store.nodes,
       edges: store.edges,
+      ...identityAccess,
       close: async (): Promise<void> => storeBackend(store).close(),
     }) as unknown as IngestionBranch<G>;
     PRIVATE_BRANCHES.set(handle, privateBranch);

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -24,6 +24,10 @@ export {
   type TypeGraphErrorOptions,
 } from "../errors";
 export type { IdentityTransferAssertion } from "../identity/service";
+export type {
+  IdentityAssertionWriteFacade,
+  IdentityFacade,
+} from "../identity/types";
 export { exportGraph, exportGraphStream } from "../interchange/export";
 export { importGraph, importGraphStream } from "../interchange/import";
 export { computeTransitiveClosure, isReachable } from "../ontology/closures";

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -17,6 +17,7 @@ import type {
   EdgeId,
   GetNodeType,
   GraphDef,
+  IdentityAssertionWriteFacade,
   JsonValue,
   Node,
   NodeId,
@@ -124,7 +125,10 @@ export type IngestionBranch<G extends GraphDef> = Readonly<{
   nodes: IngestionNodeCollections<G>;
   edges: Store<G>["edges"];
   close: () => Promise<void>;
-}>;
+}> &
+  ("identity" extends keyof Store<G> ?
+    Readonly<{ identity: IdentityAssertionWriteFacade<G> }>
+  : Readonly<Record<never, never>>);
 
 /** A normal branch or an opaque ingestion branch accepted by merge entrypoints. */
 export type MergeBranch<G extends GraphDef> =

--- a/packages/typegraph/src/identity/index.ts
+++ b/packages/typegraph/src/identity/index.ts
@@ -3,6 +3,7 @@ export type {
   IdentityAssertion,
   IdentityAssertionId,
   IdentityAssertionResult,
+  IdentityAssertionWriteFacade,
   IdentityFacade,
   IdentityNode,
   IdentityNodeReference,

--- a/packages/typegraph/src/identity/types.ts
+++ b/packages/typegraph/src/identity/types.ts
@@ -192,6 +192,18 @@ export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> &
   }>;
 
 /**
+ * The assertion-only write surface of the TypeGraph Identity Profile.
+ *
+ * This deliberately excludes reads and retractions so constrained staging
+ * handles can accept incoming identity claims without exposing the broader
+ * operational identity surface.
+ */
+export type IdentityAssertionWriteFacade<G extends GraphDef> = Pick<
+  IdentityFacade<G>,
+  "assertSame" | "assertDifferent" | "bulkAssertSame" | "bulkAssertDifferent"
+>;
+
+/**
  * Per-transaction identity write counts carried by a transaction receipt.
  * `total` is the sum of the three preceding counters.
  */

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -114,6 +114,7 @@ export {
   type IdentityAssertion,
   type IdentityAssertionId,
   type IdentityAssertionResult,
+  type IdentityAssertionWriteFacade,
   type IdentityFacade,
   type IdentityNode,
   type IdentityNodeReference,

--- a/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
@@ -457,6 +457,7 @@ describe.each(backendMatrix())(
         ].map((id) => ({
           id,
           props: { name: id, mrn: `MRN-${id}` },
+          validFrom: "2020-01-01T00:00:00.000Z",
         })),
       );
       const singleSameLeft = requireDefined(created[0]);

--- a/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
@@ -436,6 +436,116 @@ describe.each(backendMatrix())(
       ).toBe(true);
     });
 
+    it("preserves validity windows from single and bulk identity assertions", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("identity-validity-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+      const created = await incoming.nodes.Patient.bulkCreate(
+        [
+          "single-same-left",
+          "single-same-right",
+          "single-different-left",
+          "single-different-right",
+          "bulk-same-left",
+          "bulk-same-right",
+          "bulk-different-left",
+          "bulk-different-right",
+        ].map((id) => ({
+          id,
+          props: { name: id, mrn: `MRN-${id}` },
+        })),
+      );
+      const singleSameLeft = requireDefined(created[0]);
+      const singleSameRight = requireDefined(created[1]);
+      const singleDifferentLeft = requireDefined(created[2]);
+      const singleDifferentRight = requireDefined(created[3]);
+      const bulkSameLeft = requireDefined(created[4]);
+      const bulkSameRight = requireDefined(created[5]);
+      const bulkDifferentLeft = requireDefined(created[6]);
+      const bulkDifferentRight = requireDefined(created[7]);
+      const singleSame = await incoming.identity.assertSame(
+        singleSameLeft,
+        singleSameRight,
+        {
+          validFrom: "2020-01-01T00:00:00.000Z",
+          validTo: "2021-01-01T00:00:00.000Z",
+        },
+      );
+      const singleDifferent = await incoming.identity.assertDifferent(
+        singleDifferentLeft,
+        singleDifferentRight,
+        {
+          validFrom: "2021-01-01T00:00:00.000Z",
+          validTo: "2022-01-01T00:00:00.000Z",
+        },
+      );
+      const [bulkSame] = await incoming.identity.bulkAssertSame([
+        {
+          a: bulkSameLeft,
+          b: bulkSameRight,
+          validFrom: "2022-01-01T00:00:00.000Z",
+          validTo: "2023-01-01T00:00:00.000Z",
+        },
+      ]);
+      const [bulkDifferent] = await incoming.identity.bulkAssertDifferent([
+        {
+          a: bulkDifferentLeft,
+          b: bulkDifferentRight,
+          validFrom: "2023-01-01T00:00:00.000Z",
+          validTo: "2024-01-01T00:00:00.000Z",
+        },
+      ]);
+      const expectedAssertions = [
+        [singleSameLeft, singleSame.assertion],
+        [singleDifferentLeft, singleDifferent.assertion],
+        [bulkSameLeft, requireDefined(bulkSame).assertion],
+        [bulkDifferentLeft, requireDefined(bulkDifferent).assertion],
+      ] as const;
+
+      expect(
+        expectedAssertions.map(([, assertion]) => ({
+          validFrom: assertion.validFrom,
+          validTo: assertion.validTo,
+        })),
+      ).toEqual([
+        {
+          validFrom: "2020-01-01T00:00:00.000Z",
+          validTo: "2021-01-01T00:00:00.000Z",
+        },
+        {
+          validFrom: "2021-01-01T00:00:00.000Z",
+          validTo: "2022-01-01T00:00:00.000Z",
+        },
+        {
+          validFrom: "2022-01-01T00:00:00.000Z",
+          validTo: "2023-01-01T00:00:00.000Z",
+        },
+        {
+          validFrom: "2023-01-01T00:00:00.000Z",
+          validTo: "2024-01-01T00:00:00.000Z",
+        },
+      ]);
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: { onBasePropertyConflict: "flag" },
+        }),
+      );
+      unwrap(await applyMergePlan(targetClone.store, plan));
+
+      for (const [ref, assertion] of expectedAssertions) {
+        expect(await targetClone.store.identity.assertionsOf(ref)).toEqual([
+          assertion,
+        ]);
+      }
+    });
+
     it("stages and merges a duplicate unique alias asserted as the same identity", async () => {
       cleanups = [];
       const forkPoint = await makeStore();

--- a/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
@@ -501,10 +501,22 @@ describe.each(backendMatrix())(
         },
       ]);
       const expectedAssertions = [
-        [singleSameLeft, singleSame.assertion],
-        [singleDifferentLeft, singleDifferent.assertion],
-        [bulkSameLeft, requireDefined(bulkSame).assertion],
-        [bulkDifferentLeft, requireDefined(bulkDifferent).assertion],
+        [singleSameLeft, singleSame.assertion, "2020-06-01T00:00:00.000Z"],
+        [
+          singleDifferentLeft,
+          singleDifferent.assertion,
+          "2021-06-01T00:00:00.000Z",
+        ],
+        [
+          bulkSameLeft,
+          requireDefined(bulkSame).assertion,
+          "2022-06-01T00:00:00.000Z",
+        ],
+        [
+          bulkDifferentLeft,
+          requireDefined(bulkDifferent).assertion,
+          "2023-06-01T00:00:00.000Z",
+        ],
       ] as const;
 
       expect(
@@ -540,10 +552,10 @@ describe.each(backendMatrix())(
       );
       unwrap(await applyMergePlan(targetClone.store, plan));
 
-      for (const [ref, assertion] of expectedAssertions) {
-        expect(await targetClone.store.identity.assertionsOf(ref)).toEqual([
-          assertion,
-        ]);
+      for (const [ref, assertion, asOf] of expectedAssertions) {
+        expect(
+          await targetClone.store.asOf(asOf).identity.assertionsOf(ref),
+        ).toEqual([assertion]);
       }
     });
 

--- a/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
@@ -23,7 +23,10 @@ import { z } from "zod";
 import type { TransactionBackend } from "../../src/backend/types";
 import { ingestionBranch } from "../../src/graph-merge";
 import { branch } from "../../src/graph-merge/branch";
-import { MergeConstraintConflictError } from "../../src/graph-merge/errors";
+import {
+  IdentityMergeConflictError,
+  MergeConstraintConflictError,
+} from "../../src/graph-merge/errors";
 import {
   applyMergePlan,
   planMergeIncremental,
@@ -123,6 +126,7 @@ const ingestionGraph = defineGraph({
     subClassOf(Practitioner, ClinicalEntity),
     disjointWith(Patient, AdministrativeRecord),
   ],
+  identity: { sameIdAcrossKinds: "ignore" },
 });
 
 const relaxedIngestionGraph = defineGraph({
@@ -137,6 +141,13 @@ const relaxedIngestionGraph = defineGraph({
   edges: ingestionGraph.edges,
   indexes: [patientMrnCandidates],
   ontology: ingestionGraph.ontology,
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+
+const identityDisabledGraph = defineGraph({
+  id: "constraint-aware-ingestion-without-identity",
+  nodes: { Patient: { type: Patient } },
+  edges: {},
 });
 
 type IngestionGraph = typeof ingestionGraph;
@@ -316,6 +327,183 @@ describe.each(backendMatrix())(
           { id: "patient-alias" },
         ),
       ).rejects.toThrow(UniquenessError);
+    });
+
+    it("exposes identity writes without exposing identity reads", async () => {
+      cleanups = [];
+      const base = await makeStore();
+      const incoming = await makeIngestion(base);
+
+      expect("identity" in incoming).toBe(true);
+      expectTypeOf(incoming).toHaveProperty("identity");
+      expectTypeOf(incoming.identity).toHaveProperty("assertSame");
+      expectTypeOf(incoming.identity).toHaveProperty("assertDifferent");
+      expectTypeOf(incoming.identity).not.toHaveProperty("areSame");
+      expectTypeOf(incoming.identity).not.toHaveProperty("membersOf");
+      expectTypeOf(incoming.identity).not.toHaveProperty("retractAssertion");
+      expectTypeOf(incoming.identity).not.toHaveProperty(
+        "retractSameAssertion",
+      );
+      expectTypeOf(incoming.identity).not.toHaveProperty(
+        "retractDifferentAssertion",
+      );
+      expectTypeOf(incoming.identity).not.toHaveProperty(
+        "bulkRetractAssertions",
+      );
+      expect("areSame" in incoming.identity).toBe(false);
+      expect("membersOf" in incoming.identity).toBe(false);
+      expect("assertionsOf" in incoming.identity).toBe(false);
+      expect("retractAssertion" in incoming.identity).toBe(false);
+      expect("retractSameAssertion" in incoming.identity).toBe(false);
+      expect("retractDifferentAssertion" in incoming.identity).toBe(false);
+      expect("bulkRetractAssertions" in incoming.identity).toBe(false);
+    });
+
+    it("omits identity for identity-disabled graphs", async () => {
+      cleanups = [];
+      const [base] = await createStoreWithSchema(
+        identityDisabledGraph,
+        await makeBackend(),
+        { revisionTracking: true },
+      );
+      const incoming = unwrap(
+        await ingestionBranch(base, () => makeBackend(), { id: INCOMING }),
+      );
+
+      expectTypeOf(incoming).not.toHaveProperty("identity");
+      expect("identity" in incoming).toBe(false);
+    });
+
+    it("stages bulk same and different assertions through the narrow facade", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("bulk-identity-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+      const created = await incoming.nodes.Patient.bulkCreate([
+        {
+          id: "same-left",
+          props: { name: "Same left", mrn: "MRN-SAME-LEFT" },
+        },
+        {
+          id: "same-right",
+          props: { name: "Same right", mrn: "MRN-SAME-RIGHT" },
+        },
+        {
+          id: "different-left",
+          props: { name: "Different left", mrn: "MRN-DIFFERENT-LEFT" },
+        },
+        {
+          id: "different-right",
+          props: { name: "Different right", mrn: "MRN-DIFFERENT-RIGHT" },
+        },
+      ]);
+      const sameLeft = requireDefined(created[0]);
+      const sameRight = requireDefined(created[1]);
+      const differentLeft = requireDefined(created[2]);
+      const differentRight = requireDefined(created[3]);
+      const sameResults = await incoming.identity.bulkAssertSame([
+        { a: sameLeft, b: sameRight },
+      ]);
+      const differentResults = await incoming.identity.bulkAssertDifferent([
+        { a: differentLeft, b: differentRight },
+      ]);
+
+      expect(sameResults.map((result) => result.action)).toEqual(["created"]);
+      expect(differentResults.map((result) => result.action)).toEqual([
+        "created",
+      ]);
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: { onBasePropertyConflict: "flag" },
+        }),
+      );
+      unwrap(await applyMergePlan(targetClone.store, plan));
+
+      expect(
+        await targetClone.store.identity.areSame(sameLeft, sameRight),
+      ).toBe(true);
+      expect(
+        await targetClone.store.identity.areDifferent(
+          differentLeft,
+          differentRight,
+        ),
+      ).toBe(true);
+    });
+
+    it("stages and merges a duplicate unique alias asserted as the same identity", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      await seedCanonical(forkPoint);
+      const canonical = requireDefined(
+        await forkPoint.nodes.Patient.getById(asNodeId("patient-canonical")),
+      );
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("identity-same-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+
+      const alias = await incoming.nodes.Patient.create(
+        { name: "Anna Rivera", mrn: "MRN-123" },
+        { id: "patient-alias" },
+      );
+      const assertion = await incoming.identity.assertSame(canonical, alias);
+
+      expect(assertion.action).toBe("created");
+      const plan = unwrap(
+        await planMergeIncremental({
+          forkPoint,
+          target: targetClone.store,
+          branches: [incoming],
+          options: incrementalOptions(),
+        }),
+      );
+      unwrap(await applyMergePlan(targetClone.store, plan));
+
+      expect(
+        (await targetClone.store.nodes.Patient.find()).map((node) => node.id),
+      ).toEqual(["patient-canonical"]);
+    });
+
+    it("stages a duplicate unique alias asserted as different and reports a merge conflict", async () => {
+      cleanups = [];
+      const forkPoint = await makeStore();
+      await seedCanonical(forkPoint);
+      const canonical = requireDefined(
+        await forkPoint.nodes.Patient.getById(asNodeId("patient-canonical")),
+      );
+      const targetClone = await cloneStore(
+        forkPoint,
+        asBranchId("identity-different-target"),
+      );
+      const incoming = await makeIngestion(forkPoint);
+
+      const alias = await incoming.nodes.Patient.create(
+        { name: "Anna Rivera", mrn: "MRN-123" },
+        { id: "patient-alias" },
+      );
+      const assertion = await incoming.identity.assertDifferent(
+        canonical,
+        alias,
+      );
+
+      expect(assertion.action).toBe("created");
+      const result = await planMergeIncremental({
+        forkPoint,
+        target: targetClone.store,
+        branches: [incoming],
+        options: incrementalOptions(),
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) return;
+      expect(result.error).toBeInstanceOf(IdentityMergeConflictError);
     });
 
     it("validates the resolved write set as a set so unique-key swaps succeed", async () => {


### PR DESCRIPTION
Constraint-aware ingestion branches now expose a conditional, assertion-only Operational Identity facade, allowing duplicate unique aliases and explicit `same`/`different` evidence to be staged together and resolved at merge time.

The facade reuses the ordinary identity assertion signatures while withholding reads and retractions at both the typed and runtime surfaces. Identity-disabled graphs omit the property entirely.

Regression coverage demonstrates that duplicate aliases plus `same` canonicalize successfully, duplicate aliases plus `different` reach the typed merge-conflict path, bulk assertions delegate correctly, and ordinary branch uniqueness remains immediate.

Closes #484

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nicia-ai/codesmith/typegraph/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788993738&installation_model_id=431915&pr_number=486&repository=nicia-ai%2Ftypegraph&return_to=https%3A%2F%2Fgithub.com%2Fnicia-ai%2Ftypegraph%2Fpull%2F486&signature=3b4e7dbb852109755980f0e5b0f77c28b28615fe4f3c85ea2838c7190ec4dc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->