### PR TITLE
feat(graph-merge): import interchange into ingestion branches

### DIFF
--- a/.changeset/stage-ingestion-interchange.md
+++ b/.changeset/stage-ingestion-interchange.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Allow `importGraph` and `importGraphStream` to stage interchange data directly into an opaque ingestion branch while preserving its deferred-uniqueness boundary.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -844,6 +844,7 @@ import {
   planMergeIncremental,
   unwrap,
 } from "@nicia-ai/typegraph/graph-merge";
+import { importGraph } from "@nicia-ai/typegraph/interchange";
 
 const incoming = unwrap(
   await ingestionBranch(base, makeBackend, {
@@ -851,10 +852,11 @@ const incoming = unwrap(
   }),
 );
 
-await incoming.nodes.Patient.create(
-  { name: "Ana Rivera", cohort: "C1", mrn: "MRN-123" },
-  { id: "incoming-patient" },
-);
+const imported = await importGraph(incoming, providerDocument, {
+  onConflict: "error",
+  onUnknownProperty: "error",
+});
+if (!imported.success) throw new Error("Provider import was rejected");
 
 const plan = unwrap(
   await planMergeIncremental({
@@ -877,11 +879,15 @@ const applied = unwrap(await applyMergePlan(base, plan));
 await incoming.close();
 ```
 
-The returned handle exposes ingestion collections, not the branch's underlying
-`Store`, so callers cannot bypass the deferred-constraint contract or run schema
-operations on the derived working copy. The original graph definition remains
-the merge contract: `applyMergePlan()` validates node uniqueness against the
-entire resolved write set in the target transaction. Valid key handoffs and
+Both `importGraph()` and `importGraphStream()` accept the returned handle, so an
+interchange document can be staged without a hand-written collection copy loop.
+Import remains the single owner of node-first ordering, validity windows, edge
+endpoint order and reference validation. The handle also exposes ingestion
+collections, but not the branch's underlying `Store`, so callers cannot bypass
+the deferred-constraint contract or run schema operations on the derived working
+copy. The original graph definition remains the merge contract:
+`applyMergePlan()` validates node uniqueness against the entire resolved write
+set in the target transaction. Valid key handoffs and
 swaps are accepted as one set. If reviewed resolution leaves two live owners of
 the same unique key, the merge returns `MergeConstraintConflictError` and
 commits no graph or provenance writes.

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2204,7 +2204,10 @@ type InferenceType = "subsumption" | "hierarchy" | "substitution" | "constraint"
 const INGESTION_BRANCH_BRAND: unique symbol;
 
 // @public
-export type IngestionBranch<G extends GraphDef> = Readonly<{
+const INGESTION_IMPORT_TARGET_BRAND: unique symbol;
+
+// @public
+export type IngestionBranch<G extends GraphDef> = IngestionImportTarget<G> & Readonly<{
     [INGESTION_BRANCH_BRAND]: true;
     id: BranchId;
     base: BaseVersion;
@@ -2215,6 +2218,11 @@ export type IngestionBranch<G extends GraphDef> = Readonly<{
 
 // @public
 export function ingestionBranch<G extends GraphDef>(baseStore: GraphBranch<G>["store"], makeBackend: MakeBackend, options?: BranchOptions): Promise<Result<IngestionBranch<G>, BranchError>>;
+
+// @public
+type IngestionImportTarget<G extends GraphDef> = Readonly<{
+    [INGESTION_IMPORT_TARGET_BRAND]: G;
+}>;
 
 // @public
 export type IngestionNodeCollections<G extends GraphDef> = Readonly<{

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -2220,7 +2220,7 @@ export type IngestionBranch<G extends GraphDef> = IngestionImportTarget<G> & Rea
 export function ingestionBranch<G extends GraphDef>(baseStore: GraphBranch<G>["store"], makeBackend: MakeBackend, options?: BranchOptions): Promise<Result<IngestionBranch<G>, BranchError>>;
 
 // @public
-type IngestionImportTarget<G extends GraphDef> = Readonly<{
+export type IngestionImportTarget<G extends GraphDef> = Readonly<{
     [INGESTION_IMPORT_TARGET_BRAND]: G;
 }>;
 

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -2106,10 +2106,10 @@ export const ImportErrorSchema: z.ZodObject<{
 }, z.core.$strip>;
 
 // @public
-export function importGraph<G extends GraphDef>(store: Store<G>, data: GraphData, rawOptions: ImportOptions): Promise<ImportResult>;
+export function importGraph<G extends GraphDef>(target: ImportTarget<G>, data: GraphData, rawOptions: ImportOptions): Promise<ImportResult>;
 
 // @public
-export function importGraphStream<G extends GraphDef>(store: Store<G>, chunks: AsyncIterable<GraphInterchangeChunk>, rawOptions: ImportOptions): Promise<ImportResult>;
+export function importGraphStream<G extends GraphDef>(target: ImportTarget<G>, chunks: AsyncIterable<GraphInterchangeChunk>, rawOptions: ImportOptions): Promise<ImportResult>;
 
 // @public
 export type ImportOptions = z.input<typeof ImportOptionsSchema>;
@@ -2166,6 +2166,9 @@ export const ImportResultSchema: z.ZodObject<{
         error: z.ZodString;
     }, z.core.$strip>>;
 }, z.core.$strip>;
+
+// @public
+export type ImportTarget<G extends GraphDef> = Store<G> | IngestionImportTarget<G>;
 
 // @public
 type IndexChange = Readonly<{
@@ -2279,6 +2282,14 @@ type IndexWhereOperand = Readonly<{
 
 // @public
 type InferenceType = "subsumption" | "hierarchy" | "substitution" | "constraint" | "composition" | "association" | "none";
+
+// @public
+const INGESTION_IMPORT_TARGET_BRAND: unique symbol;
+
+// @public
+export type IngestionImportTarget<G extends GraphDef> = Readonly<{
+    [INGESTION_IMPORT_TARGET_BRAND]: G;
+}>;
 
 // @public
 type InitialQueryBuilder<G extends GraphDef, CoordinateState extends QueryCoordinateState = "open"> = QueryBuilder<G, EmptyAliasMap, EmptyEdgeAliasMap, EmptyRecursiveAliasMap, CoordinateState>;

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -10,6 +10,7 @@ export type {
   ContributionRepairEntry,
   ContributionRepairResult,
 } from "../backend/types";
+export type { IngestionImportTarget } from "../interchange/ingestion-import-target";
 export { computeBaseVersion } from "./base-version";
 export { branch } from "./branch";
 export type { MergeConstraintConflictErrorDetails } from "./errors";

--- a/packages/typegraph/src/graph-merge/ingestion-branch.ts
+++ b/packages/typegraph/src/graph-merge/ingestion-branch.ts
@@ -8,6 +8,7 @@
  * active during staging.
  */
 
+import { registerIngestionImportTarget } from "../interchange/ingestion-import-target";
 import { branch } from "./branch";
 import { BranchError } from "./errors";
 import type { Result } from "./result";
@@ -63,6 +64,7 @@ export async function ingestionBranch<G extends GraphDef>(
       close: async (): Promise<void> => storeBackend(store).close(),
     }) as unknown as IngestionBranch<G>;
     PRIVATE_BRANCHES.set(handle, privateBranch);
+    registerIngestionImportTarget(handle, store);
     return ok(handle);
   } catch (error) {
     return err(

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -12,8 +12,8 @@
  * runtime merge logic.
  */
 
-import type { CandidateDiagnostics, MatchEvidence } from "./evidence";
 import type { IngestionImportTarget } from "../interchange/ingestion-import-target";
+import type { CandidateDiagnostics, MatchEvidence } from "./evidence";
 import type {
   EdgeId,
   GetNodeType,

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -13,6 +13,7 @@
  */
 
 import type { CandidateDiagnostics, MatchEvidence } from "./evidence";
+import type { IngestionImportTarget } from "../interchange/ingestion-import-target";
 import type {
   EdgeId,
   GetNodeType,
@@ -117,14 +118,15 @@ export type IngestionNodeCollections<G extends GraphDef> = Readonly<{
  * merge planning, but cannot access schema evolution, transactions, or runtime
  * internals. `close()` releases the private working-copy backend.
  */
-export type IngestionBranch<G extends GraphDef> = Readonly<{
-  [INGESTION_BRANCH_BRAND]: true;
-  id: BranchId;
-  base: BaseVersion;
-  nodes: IngestionNodeCollections<G>;
-  edges: Store<G>["edges"];
-  close: () => Promise<void>;
-}>;
+export type IngestionBranch<G extends GraphDef> = IngestionImportTarget<G> &
+  Readonly<{
+    [INGESTION_BRANCH_BRAND]: true;
+    id: BranchId;
+    base: BaseVersion;
+    nodes: IngestionNodeCollections<G>;
+    edges: Store<G>["edges"];
+    close: () => Promise<void>;
+  }>;
 
 /** A normal branch or an opaque ingestion branch accepted by merge entrypoints. */
 export type MergeBranch<G extends GraphDef> =

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -137,8 +137,7 @@ import {
 
 /** A normal Store or an opaque ingestion branch that interchange may stage. */
 export type ImportTarget<G extends GraphDef> =
-  | Store<G>
-  | IngestionImportTarget<G>;
+  Store<G> | IngestionImportTarget<G>;
 
 /**
  * Import graph data into a store or opaque ingestion branch.

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -109,6 +109,10 @@ import {
 } from "../utils/date";
 import { createDataKeyedBag, hasOwnKey } from "../utils/object";
 import { encodeTupleKey } from "../utils/tuple-key";
+import {
+  type IngestionImportTarget,
+  resolveIngestionImportTarget,
+} from "./ingestion-import-target";
 import { exportStreamBackend } from "./stream-source";
 import {
   type GraphData,
@@ -131,8 +135,13 @@ import {
 // Import Function
 // ============================================================
 
+/** A normal Store or an opaque ingestion branch that interchange may stage. */
+export type ImportTarget<G extends GraphDef> =
+  | Store<G>
+  | IngestionImportTarget<G>;
+
 /**
- * Import graph data into a store.
+ * Import graph data into a store or opaque ingestion branch.
  *
  * Nodes are imported first to satisfy edge reference validation.
  * The import runs within a transaction for atomicity when supported.
@@ -145,7 +154,7 @@ import {
  * connection is therefore refused on the first chunk instead of nesting a write
  * transaction inside the export's open snapshot.
  *
- * @param store - The graph store to import into
+ * @param target - The graph store or ingestion branch to import into
  * @param data - Graph data in interchange format
  * @param options - Import configuration
  * @returns Import statistics and any errors
@@ -161,10 +170,11 @@ import {
  * ```
  */
 export async function importGraph<G extends GraphDef>(
-  store: Store<G>,
+  target: ImportTarget<G>,
   data: GraphData,
   rawOptions: ImportOptions,
 ): Promise<ImportResult> {
+  const store = resolveIngestionImportTarget<G>(target);
   // Parse ONCE at the public boundary: schema defaults (batchSize, ...)
   // only exist after parsing, and every internal stage reads them
   // directly.
@@ -357,10 +367,11 @@ async function importGraphData<G extends GraphDef>(
  * `backend/transaction-resource.ts`.
  */
 export async function importGraphStream<G extends GraphDef>(
-  store: Store<G>,
+  target: ImportTarget<G>,
   chunks: AsyncIterable<GraphInterchangeChunk>,
   rawOptions: ImportOptions,
 ): Promise<ImportResult> {
+  const store = resolveIngestionImportTarget<G>(target);
   const options = ImportOptionsSchema.parse(rawOptions);
   const sourceBackend = exportStreamBackend(chunks);
   const targetBackend = storeBackend(store);

--- a/packages/typegraph/src/interchange/index.ts
+++ b/packages/typegraph/src/interchange/index.ts
@@ -79,11 +79,7 @@ export {
 // ============================================================
 
 export { exportGraph, exportGraphStream } from "./export";
-export {
-  importGraph,
-  importGraphStream,
-  type ImportTarget,
-} from "./import";
+export { importGraph, importGraphStream, type ImportTarget } from "./import";
 export type { IngestionImportTarget } from "./ingestion-import-target";
 export {
   trustedImportGraph,

--- a/packages/typegraph/src/interchange/index.ts
+++ b/packages/typegraph/src/interchange/index.ts
@@ -79,7 +79,12 @@ export {
 // ============================================================
 
 export { exportGraph, exportGraphStream } from "./export";
-export { importGraph, importGraphStream } from "./import";
+export {
+  importGraph,
+  importGraphStream,
+  type ImportTarget,
+} from "./import";
+export type { IngestionImportTarget } from "./ingestion-import-target";
 export {
   trustedImportGraph,
   trustedImportGraphStream,

--- a/packages/typegraph/src/interchange/ingestion-import-target.ts
+++ b/packages/typegraph/src/interchange/ingestion-import-target.ts
@@ -1,0 +1,46 @@
+/**
+ * Private capability bridge from an opaque ingestion branch to interchange.
+ *
+ * The branch handle must not expose its relaxed-schema Store, but interchange
+ * still needs the real Store so it can reuse the one import implementation that
+ * owns validation, temporal windows, edge endpoints, and stream leases.
+ */
+
+import type { GraphDef } from "../core/define-graph";
+import { ConfigurationError } from "../errors";
+import { STORE_RUNTIME } from "../store/runtime-port";
+import type { Store } from "../store/store";
+
+declare const INGESTION_IMPORT_TARGET_BRAND: unique symbol;
+
+/** Opaque capability implemented by ingestion branches accepted by import. */
+export type IngestionImportTarget<G extends GraphDef> = Readonly<{
+  [INGESTION_IMPORT_TARGET_BRAND]: G;
+}>;
+
+const INGESTION_IMPORT_TARGETS = new WeakMap<object, unknown>();
+
+/** Registers the private Store represented by an opaque ingestion handle. */
+export function registerIngestionImportTarget<G extends GraphDef>(
+  handle: object,
+  store: Store<G>,
+): void {
+  INGESTION_IMPORT_TARGETS.set(handle, store);
+}
+
+/** Resolves an import target without making the hidden Store public. */
+export function resolveIngestionImportTarget<G extends GraphDef>(
+  target: Store<G> | object,
+): Store<G> {
+  const registeredStore = INGESTION_IMPORT_TARGETS.get(target);
+  if (registeredStore !== undefined) return registeredStore as Store<G>;
+  if (STORE_RUNTIME in target) return target as Store<G>;
+  throw new ConfigurationError(
+    "Interchange import received an unrecognized ingestion target",
+    { target: "unregistered-ingestion-target" },
+    {
+      suggestion:
+        "Pass a Store or the exact handle returned by ingestionBranch() from this TypeGraph installation.",
+    },
+  );
+}

--- a/packages/typegraph/src/interchange/ingestion-import-target.ts
+++ b/packages/typegraph/src/interchange/ingestion-import-target.ts
@@ -8,7 +8,7 @@
 
 import type { GraphDef } from "../core/define-graph";
 import { ConfigurationError } from "../errors";
-import { STORE_RUNTIME } from "../store/runtime-port";
+import { storeBackend } from "../store/runtime-port";
 import type { Store } from "../store/store";
 
 declare const INGESTION_IMPORT_TARGET_BRAND: unique symbol;
@@ -34,13 +34,18 @@ export function resolveIngestionImportTarget<G extends GraphDef>(
 ): Store<G> {
   const registeredStore = INGESTION_IMPORT_TARGETS.get(target);
   if (registeredStore !== undefined) return registeredStore as Store<G>;
-  if (STORE_RUNTIME in target) return target as Store<G>;
-  throw new ConfigurationError(
-    "Interchange import received an unrecognized ingestion target",
-    { target: "unregistered-ingestion-target" },
-    {
-      suggestion:
-        "Pass a Store or the exact handle returned by ingestionBranch() from this TypeGraph installation.",
-    },
-  );
+  try {
+    storeBackend(target);
+    return target as Store<G>;
+  } catch (error) {
+    throw new ConfigurationError(
+      "Interchange import received an unrecognized ingestion target",
+      { target: "unregistered-ingestion-target" },
+      {
+        cause: error,
+        suggestion:
+          "Pass a Store or the exact handle returned by ingestionBranch() from this TypeGraph installation.",
+      },
+    );
+  }
 }

--- a/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/ingestion-branch.test.ts
@@ -35,6 +35,12 @@ import type {
   IngestionBranch,
 } from "../../src/graph-merge/types";
 import { asBranchId } from "../../src/graph-merge/types";
+import {
+  type GraphData,
+  type GraphInterchangeChunk,
+  importGraph,
+  importGraphStream,
+} from "../../src/interchange";
 import { parseSerializedSchema } from "../../src/schema";
 import { requireDefined } from "../../src/utils/presence";
 import { backendMatrix, createSqliteMergeBackend } from "./test-utils";
@@ -143,6 +149,15 @@ type IngestionGraph = typeof ingestionGraph;
 type IngestionStore = Store<IngestionGraph>;
 
 const INCOMING = asBranchId("incoming");
+
+async function* interchangeChunks(
+  chunks: readonly GraphInterchangeChunk[],
+): AsyncIterable<GraphInterchangeChunk> {
+  for (const chunk of chunks) {
+    await Promise.resolve();
+    yield chunk;
+  }
+}
 
 const RESOLVED_BATCH_METHODS = new Set<PropertyKey>([
   "checkUniqueBatch",
@@ -302,6 +317,118 @@ describe.each(backendMatrix())(
       );
       expect(edge.fromId).toBe("patient-canonical");
       expect(edge.toId).toBe("facility-1");
+    });
+
+    it("accepts a complete interchange document as an ingestion target", async () => {
+      cleanups = [];
+      const base = await makeStore();
+      await seedCanonical(base);
+      const incoming = await makeIngestion(base);
+      const validFrom = "2025-01-01T00:00:00.000Z";
+      const validTo = "2030-01-01T00:00:00.000Z";
+      const document = {
+        formatVersion: "2.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        source: { type: "external", description: "provider-a" },
+        nodes: [
+          {
+            kind: "Patient",
+            id: "patient-imported",
+            properties: { name: "Anna Rivera", mrn: "MRN-123" },
+            validFrom,
+            validTo,
+          },
+        ],
+        edges: [
+          {
+            kind: "primaryFacility",
+            id: "edge-imported",
+            from: { kind: "Patient", id: "patient-imported" },
+            to: { kind: "Facility", id: "facility-1" },
+            properties: { source: "provider-a" },
+            validFrom,
+            validTo,
+          },
+        ],
+      } satisfies GraphData;
+
+      const result = await importGraph(incoming, document, {
+        onConflict: "error",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.nodes.created).toBe(1);
+      expect(result.edges.created).toBe(1);
+      expect(
+        await incoming.nodes.Patient.getById(asNodeId("patient-imported"), {
+          temporalMode: "includeEnded",
+        }),
+      ).toMatchObject({
+        id: "patient-imported",
+        meta: { validFrom, validTo },
+      });
+      expect(
+        await incoming.edges.primaryFacility.getById(
+          asEdgeId<typeof primaryFacility>("edge-imported"),
+          { temporalMode: "includeEnded" },
+        ),
+      ).toMatchObject({
+        fromId: "patient-imported",
+        toId: "facility-1",
+        meta: { validFrom, validTo },
+      });
+    });
+
+    it("accepts an interchange stream as an ingestion target", async () => {
+      cleanups = [];
+      const base = await makeStore();
+      await seedCanonical(base);
+      const incoming = await makeIngestion(base);
+      const header = {
+        formatVersion: "2.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        source: { type: "external", description: "provider-b" },
+      } as const;
+
+      const result = await importGraphStream(
+        incoming,
+        interchangeChunks([
+          { type: "header", header },
+          {
+            type: "nodes",
+            nodes: [
+              {
+                kind: "Patient",
+                id: "patient-streamed",
+                properties: { name: "Ana R.", mrn: "MRN-123" },
+              },
+            ],
+          },
+          {
+            type: "edges",
+            edges: [
+              {
+                kind: "primaryFacility",
+                id: "edge-streamed",
+                from: { kind: "Patient", id: "patient-streamed" },
+                to: { kind: "Facility", id: "facility-1" },
+                properties: { source: "provider-b" },
+              },
+            ],
+          },
+        ]),
+        { onConflict: "error" },
+      );
+
+      expect(result.success).toBe(true);
+      expect(
+        await incoming.edges.primaryFacility.getById(
+          asEdgeId<typeof primaryFacility>("edge-streamed"),
+        ),
+      ).toMatchObject({
+        fromId: "patient-streamed",
+        toId: "facility-1",
+      });
     });
 
     it("keeps ordinary branch uniqueness immediate", async () => {
@@ -697,6 +824,24 @@ describe.each(backendMatrix())(
     });
   },
 );
+
+it("refuses an unregistered ingestion import capability at the boundary", async () => {
+  const forgedTarget = {} as unknown as IngestionBranch<IngestionGraph>;
+  const emptyDocument = {
+    formatVersion: "2.0",
+    exportedAt: "2026-01-01T00:00:00.000Z",
+    source: { type: "external", description: "forged-target" },
+    nodes: [],
+    edges: [],
+  } satisfies GraphData;
+
+  await expect(
+    importGraph(forgedTarget, emptyDocument, { onConflict: "error" }),
+  ).rejects.toMatchObject({
+    name: "ConfigurationError",
+    details: { target: "unregistered-ingestion-target" },
+  });
+});
 
 describe("resolved ingestion uniqueness properties", () => {
   it("preserves unique-key swaps for arbitrary distinct keys and either staging order", async () => {

--- a/packages/typegraph/tests/property/schema-serialization.test.ts
+++ b/packages/typegraph/tests/property/schema-serialization.test.ts
@@ -81,18 +81,26 @@ const descriptionArb = fc.option(fc.string({ minLength: 1, maxLength: 100 }), {
 const annotationsKeyArb = fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9_]{0,7}$/);
 
 /**
- * A JSON-escape sequence in an OBJECT KEY (a `"`, a `\`, or a control
- * character — the characters `JSON.stringify` escapes) triggers an upstream
- * V8 `JSON.parse` data-corruption bug on Node >= 23: parsing an object whose
- * key needs escaping poisons an internal shape-keyed cache, so a LATER
- * same-shaped object with a DIFFERENT escaped key at the same position gets
- * the earlier object's key string back. It is not a TypeGraph defect and has
- * no clean parse-level workaround (the correct key is already gone once
- * `JSON.parse` returns). Upstream, open/assigned: V8
+ * Two object-key shapes cannot make the byte-identical round-trip this
+ * property covers:
+ *
+ * - A JSON-escape sequence in an OBJECT KEY (a `"`, a `\`, or a control
+ *   character — the characters `JSON.stringify` escapes) triggers an upstream
+ *   V8 `JSON.parse` data-corruption bug on Node >= 23: parsing an object whose
+ *   key needs escaping poisons an internal shape-keyed cache, so a LATER
+ *   same-shaped object with a DIFFERENT escaped key at the same position gets
+ *   the earlier object's key string back. It is not a TypeGraph defect and has
+ *   no clean parse-level workaround (the correct key is already gone once
+ *   `JSON.parse` returns). Upstream, open/assigned: V8
  * https://issues.chromium.org/issues/521080746 and Node
- * https://github.com/nodejs/node/issues/63785. This filter keeps the
- * arbitrary broad (all other Unicode, nesting, and value shapes) while
- * excluding only the region V8 cannot round-trip;
+ * https://github.com/nodejs/node/issues/63785.
+ * - Zod's JSON record parser deliberately discards an own `__proto__` key to
+ *   prevent prototype-pollution assignments while rebuilding objects. The
+ *   serialized-schema boundary relies on that behavior, so the round-trip is
+ *   intentionally not byte-identical for that key.
+ *
+ * This filter keeps the arbitrary broad (all other Unicode, nesting, and
+ * value shapes) while excluding only the regions the boundary cannot preserve;
  * `escaped-key-round-trip.test.ts` pins the bug so we notice when a Node
  * release fixes it and can drop this guard.
  */
@@ -101,13 +109,13 @@ const annotationsKeyArb = fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9_]{0,7}$/);
 // eslint-disable-next-line no-control-regex
 const KEY_ESCAPE_PATTERN = /["\\\u0000-\u001F]/;
 
-function hasEscapedObjectKey(value: unknown): boolean {
+function hasNonRoundTrippableObjectKey(value: unknown): boolean {
   if (Array.isArray(value))
-    return value.some((item) => hasEscapedObjectKey(item));
+    return value.some((item) => hasNonRoundTrippableObjectKey(item));
   if (value !== null && typeof value === "object") {
     for (const [key, nested] of Object.entries(value)) {
-      if (KEY_ESCAPE_PATTERN.test(key)) return true;
-      if (hasEscapedObjectKey(nested)) return true;
+      if (key === "__proto__" || KEY_ESCAPE_PATTERN.test(key)) return true;
+      if (hasNonRoundTrippableObjectKey(nested)) return true;
     }
   }
   return false;
@@ -115,7 +123,7 @@ function hasEscapedObjectKey(value: unknown): boolean {
 
 const safeJsonValueArb = fc
   .jsonValue()
-  .filter((value) => !hasEscapedObjectKey(value));
+  .filter((value) => !hasNonRoundTrippableObjectKey(value));
 
 // fc.jsonValue() produces values that are valid JSON at runtime, but its
 // TypeScript type is wider than our KindAnnotations type. Cast the arbitrary


### PR DESCRIPTION
Allow `importGraph` and `importGraphStream` to target the opaque handle returned by `ingestionBranch`, so untrusted interchange data can use the existing importer before review and merge instead of a hand-written collection copy loop.

The handle still withholds its relaxed-schema `Store`: a nominal capability resolves through a private registry, and unregistered or cross-installation handles are rejected with a typed configuration error. Import remains the single owner of node-first ordering, validity windows, edge endpoint order, reference validation, and serialized-resource guards.

Update the Graph Merge guide and generated API reports, add a minor changeset, and cover complete imports (including identity evidence), streaming imports, and forged-target rejection. The registration guard is load-bearing: removing handle registration makes the ingestion import cases fail.

