### PR TITLE
fix(ci): give release declaration builds enough heap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ permissions:
   id-token: write
   pull-requests: write
 
+# Declaration bundling traverses the full public backend and store type graph.
+# Keep its worker above Node's default old-space ceiling as that API grows.
+env:
+  NODE_OPTIONS: --max-old-space-size=6144
+
 jobs:
   release:
     name: Changesets

--- a/packages/typegraph/tests/ci-workflow-contract.test.ts
+++ b/packages/typegraph/tests/ci-workflow-contract.test.ts
@@ -15,6 +15,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 const WORKFLOW_PATH = fileURLToPath(
   new URL("../../../.github/workflows/ci.yml", import.meta.url),
 );
+const RELEASE_WORKFLOW_PATH = fileURLToPath(
+  new URL("../../../.github/workflows/release.yml", import.meta.url),
+);
 const METADATA_PREDICATE_PATH = fileURLToPath(
   new URL(
     "../../../.github/scripts/is-release-metadata-only.sh",
@@ -98,6 +101,14 @@ describe("CI workflow contract", () => {
     expect(workflow).toMatch(
       /test-coverage:[\s\S]*?timeout-minutes: 30[\s\S]*?strategy:/,
     );
+  });
+
+  it("gives CI and release declaration builds enough worker heap", () => {
+    for (const workflowPath of [WORKFLOW_PATH, RELEASE_WORKFLOW_PATH]) {
+      expect(readFileSync(workflowPath, "utf8")).toContain(
+        "NODE_OPTIONS: --max-old-space-size=6144",
+      );
+    }
   });
 
   it("detects metadata-only changes on pushes and pull requests", () => {


### PR DESCRIPTION
The release tarball smoke rebuilds the package declaration bundle, but unlike the main CI workflow it ran under Node's default worker heap. The expanded public type graph now exhausts that default before the tarball is created, so the release never reaches its package smoke assertions.

Apply CI's existing 6144 MB declaration-build heap to the release workflow and extend the workflow contract test to require the setting on both paths.