### PR TITLE
fix(ci): install Drizzle in release smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,16 +52,16 @@ jobs:
           mkdir -p .tmp-release
           PACK_OUTPUT="$(pnpm --filter @nicia-ai/typegraph pack --json --pack-destination .tmp-release)"
           TARBALL_PATH="$(echo "$PACK_OUTPUT" | node -e 'const fs = require("node:fs"); const input = fs.readFileSync(0, "utf8"); const data = JSON.parse(input); const filename = Array.isArray(data) ? data[0]?.filename : data?.filename; if (!filename) process.exit(1); process.stdout.write(filename);')"
-          # Backend subpaths (sqlite/local, sqlite/libsql, postgres/pglite) load a
-          # driver at import time. Pin those optional peers to the exact ranges the
-          # repo validates against — PGlite's is tight (>=0.5.0 <0.6.0) — so the
-          # smoke can import every public subpath, not just the driver-agnostic ones.
-          DRIVER_SPECS="$(node -e 'const dev = require("./packages/typegraph/package.json").devDependencies; const names = ["better-sqlite3", "@libsql/client", "@electric-sql/pglite"]; process.stdout.write(names.map((name) => `${name}@${dev[name]}`).join(" "));')"
+          # Adapter subpaths load Drizzle and a database driver at import time. Pin
+          # those optional peers to the exact ranges the repo validates against —
+          # PGlite's is tight (>=0.5.0 <0.6.0) — so the smoke can import every public
+          # subpath, not just the driver-agnostic ones.
+          OPTIONAL_PEER_SPECS="$(node -e 'const dev = require("./packages/typegraph/package.json").devDependencies; const names = ["drizzle-orm", "better-sqlite3", "@libsql/client", "@electric-sql/pglite"]; process.stdout.write(names.map((name) => `${name}@${dev[name]}`).join(" "));')"
           mkdir -p .tmp-release/smoke
           cp packages/typegraph/scripts/smoke-exports.mjs .tmp-release/smoke/
           cd .tmp-release/smoke
           npm init -y >/dev/null
-          npm install "$TARBALL_PATH" $DRIVER_SPECS >/dev/null
+          npm install "$TARBALL_PATH" $OPTIONAL_PEER_SPECS >/dev/null
           node smoke-exports.mjs
 
       - name: Create release PR or publish

--- a/packages/typegraph/tests/ci-workflow-contract.test.ts
+++ b/packages/typegraph/tests/ci-workflow-contract.test.ts
@@ -114,6 +114,22 @@ describe("CI workflow contract", () => {
     }
   });
 
+  it("installs every optional peer required by the release export smoke test", () => {
+    const workflow = readFileSync(RELEASE_WORKFLOW_PATH, "utf8");
+    const optionalPeerNamesMatch = /const names = (\[[^;]+\]);/.exec(workflow);
+
+    expect(optionalPeerNamesMatch).not.toBeNull();
+    expect(JSON.parse(optionalPeerNamesMatch?.[1] ?? "[]")).toEqual([
+      "drizzle-orm",
+      "better-sqlite3",
+      "@libsql/client",
+      "@electric-sql/pglite",
+    ]);
+    expect(workflow).toContain(
+      'npm install "$TARBALL_PATH" $OPTIONAL_PEER_SPECS >/dev/null',
+    );
+  });
+
   it("detects metadata-only changes on pushes and pull requests", () => {
     const workflow = readFileSync(WORKFLOW_PATH, "utf8");
     const baseSha = runGit(fixtureDirectory, ["rev-parse", "HEAD"]);


### PR DESCRIPTION
## Summary

The release tarball smoke test now installs `drizzle-orm` explicitly alongside its optional database drivers. This keeps the isolated consumer aligned with the package's optional-peer contract and lets every Drizzle adapter subpath load before Changesets creates a release PR or publishes.

A workflow contract test pins both the complete optional-peer install set and its handoff to `npm install`, preventing future peer changes from silently breaking the release job.
