### PR TITLE
fix(schema): default omitted unique constraint fields

### DIFF
--- a/.changeset/read-unique-constraint-defaults.md
+++ b/.changeset/read-unique-constraint-defaults.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Read persisted unique constraints that omit `scope` or `collation` by applying the documented `"kind"` and `"binary"` defaults. Schema-management APIs can now inspect databases written with those omitted fields instead of reporting a malformed schema document.

--- a/packages/typegraph/src/schema/types.ts
+++ b/packages/typegraph/src/schema/types.ts
@@ -541,8 +541,8 @@ export const serializedSchemaZod = z.object({
                 name: z.string(),
                 fields: z.array(z.string()),
                 where: z.string().optional(),
-                scope: uniquenessScopeZod,
-                collation: collationZod,
+                scope: uniquenessScopeZod.default("kind"),
+                collation: collationZod.default("binary"),
               })
               .loose(),
           ),

--- a/packages/typegraph/tests/schema-parse-validation.test.ts
+++ b/packages/typegraph/tests/schema-parse-validation.test.ts
@@ -97,6 +97,36 @@ describe("serializedSchemaZod", () => {
       expect(result.success).toBe(true);
     });
 
+    it("defaults omitted unique constraint scope and collation", () => {
+      const document = {
+        ...createValidSchemaDocument(),
+        nodes: {
+          Person: {
+            kind: "Person",
+            properties: {},
+            uniqueConstraints: [
+              {
+                name: "email_unique",
+                fields: ["email"],
+              },
+            ],
+            onDelete: "restrict",
+          },
+        },
+      };
+
+      const parsed = parseSerializedSchema(JSON.stringify(document));
+
+      expect(parsed.nodes["Person"]?.uniqueConstraints).toEqual([
+        {
+          name: "email_unique",
+          fields: ["email"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ]);
+    });
+
     it("accepts extra fields on nested objects (forward compatibility)", () => {
       const document = createValidSchemaDocument();
       const withExtra = {


### PR DESCRIPTION
- Default missing persisted unique-constraint `scope` and `collation` fields during schema parsing so existing databases remain readable.
- Normalize omitted values to the documented `"kind"` and `"binary"` defaults while preserving strict validation for invalid enum values.
- Add a load-bearing regression test and a patch changeset.

TypeGraph could persist schema documents without these default-valued fields, but its reader required both fields to be present. Applying the defaults at the shared parse boundary repairs existing stored documents for every schema-management consumer instead of only changing future writes.

Closes #525
