### PR TITLE
docs(store): document root-handle transaction hazard

### DIFF
--- a/apps/docs/src/content/docs/recipes.md
+++ b/apps/docs/src/content/docs/recipes.md
@@ -604,6 +604,17 @@ The caller owns the transaction boundary; TypeGraph adopts that exact
 connection, so a failure rolls back both layers — no stray relational row, no
 graph node with a dangling foreign reference.
 
+:::caution[Do not use the root store inside a caller-owned transaction]
+Inside `db.transaction(async (sqlTx) => ...)`, do not call a managed write on
+the root `store` (for example, `store.nodes.Document.create(...)`). On a
+single-connection PostgreSQL handle, Drizzle starts that root-store write with
+`BEGIN` and finishes it with `COMMIT`; PostgreSQL treats the nested `BEGIN` as
+a warning and the `COMMIT` ends the caller's transaction. Use
+`store.withTransaction(sqlTx)` and make every graph write through the returned
+transaction context instead. For a history-enabled store, use
+`store.withRecordedTransaction(sqlTx, async (tx) => ...)`.
+:::
+
 This is the explicit adapter surface: create the store with
 `createAdapterStore` or `createAdapterStoreWithSchema`. The portable
 `createStore` factories intentionally do not expose native handles or

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -3143,6 +3143,15 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * transaction — the caller's transaction is the single commit/rollback
    * boundary.
    *
+   * Do not call a managed write on this root Store from inside the caller's
+   * `db.transaction(...)` callback. On a single-connection PostgreSQL handle,
+   * a root-store write opens its own `BEGIN` / `COMMIT`; PostgreSQL accepts the
+   * nested `BEGIN` with a warning, then that `COMMIT` closes the caller's
+   * transaction. Build this adopted context from the callback's `externalTx`
+   * and use its collections for every graph write instead. History-enabled
+   * stores use {@link withRecordedTransaction}, which adopts the same handle
+   * and flushes capture before the caller commits.
+   *
    * `withTransaction` is driver-agnostic; how the caller opens the
    * transaction is not. **Async drivers** (node-postgres,
    * `neon-serverless` Pool, libsql) use `db.transaction(async …)`.

--- a/packages/typegraph/tests/root-handle-transaction-hazard.test.ts
+++ b/packages/typegraph/tests/root-handle-transaction-hazard.test.ts
@@ -1,0 +1,47 @@
+/**
+ * #528: Drizzle's root `db.transaction()` does not nest through the transaction
+ * handle the caller received. A managed write through a root TypeGraph Store
+ * consequently emits BEGIN/COMMIT on a single PostgreSQL connection and the
+ * COMMIT ends the caller's frame. PostgreSQL exposes no complete, non-mutating
+ * SQL probe for an already-open but not-yet-written transaction, so this is a
+ * documented adoption contract rather than a partial runtime detector.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const STORE_SOURCE = path.join(PACKAGE_ROOT, "src", "store", "store.ts");
+const RECIPES_DOCUMENT = path.resolve(
+  PACKAGE_ROOT,
+  "..",
+  "..",
+  "apps",
+  "docs",
+  "src",
+  "content",
+  "docs",
+  "recipes.md",
+);
+
+describe("caller-owned Drizzle transaction adoption (#528)", () => {
+  it("warns that root-store writes can commit a caller-owned PostgreSQL transaction", () => {
+    const recipes = fs.readFileSync(RECIPES_DOCUMENT, "utf8");
+    const storeSource = fs.readFileSync(STORE_SOURCE, "utf8");
+
+    expect(recipes).toContain(
+      ":::caution[Do not use the root store inside a caller-owned transaction]",
+    );
+    expect(recipes).toContain("store.withTransaction(sqlTx)");
+    expect(recipes).toContain("the `COMMIT` ends the caller's transaction");
+    expect(storeSource).toContain(
+      "Do not call a managed write on this root Store from inside the caller's",
+    );
+    expect(storeSource).toContain("withRecordedTransaction");
+  });
+});


### PR DESCRIPTION
Document that root-store managed writes inside caller-owned PostgreSQL transactions can issue a nested BEGIN/COMMIT and prematurely commit the caller transaction.

Add adoption guidance for withTransaction and withRecordedTransaction, plus a contract test keeping the warning visible at both the API and recipe surfaces.

Closes #528