### PR TITLE
test(postgres): guard prepared-statement name invariance

### DIFF
--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -542,10 +542,12 @@ const backend = createPostgresBackend(db, {
 });
 ```
 
-The cache that maps SQL text → statement name is LRU-bounded (default 256
-entries, override via `preparedStatementCacheMax`). Worst-case server-side
-footprint is roughly `cap × pool size` prepared statements across all pooled
-connections.
+The in-process cache that maps SQL text → statement name is LRU-bounded
+(default 256 entries, override via `preparedStatementCacheMax`). Eviction
+never recycles a name, because a live connection may still retain that name for
+its original SQL. Therefore this setting does not bound server-side prepared
+statement memory. For a high-cardinality stream of SQL text, use
+`prepareStatements: false` instead.
 
 ### Connection Pooling
 

--- a/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/postgres-execution.ts
@@ -245,7 +245,9 @@ export function isNeonHttpClient(db: AnyPgDatabase): boolean {
  * variable-length IN-list expansions, generated aliases, custom
  * `backend.execute()` calls — would otherwise grow this map (and the
  * matching per-session prepared-statement memory inside PostgreSQL)
- * without bound.
+ * without bound. The LRU bounds only TypeGraph's in-process SQL-to-name
+ * lookup; safe names are never recycled, so it cannot bound prepared
+ * statements retained by a live PostgreSQL connection.
  */
 const DEFAULT_POSTGRES_STATEMENT_CACHE_MAX = 256;
 
@@ -543,12 +545,11 @@ function createPgPreparedStatement(
  *   `prepareStatements: false`. Named statements registered on one
  *   pooled backend connection aren't visible to the next, so the
  *   server-side prepared-statement cache must be off.
- * - **High-cardinality SQL text.** If the application emits many
- *   distinct compiled SQL strings (variable-length IN-list expansions,
- *   custom `backend.execute()` calls, generated aliases), tune
- *   `preparedStatementCacheMax` down to bound per-session memory more
- *   aggressively, or up if memory is plentiful and you want fewer
- *   re-PREPAREs.
+ * - **High-cardinality SQL text.** If the application emits many distinct
+ *   compiled SQL strings (variable-length IN-list expansions, custom
+ *   `backend.execute()` calls, generated aliases), set
+ *   `prepareStatements: false` to avoid retaining one prepared statement per
+ *   distinct SQL text on every live connection.
  */
 export type PostgresExecutionAdapterOptions = Readonly<{
   /**
@@ -560,9 +561,11 @@ export type PostgresExecutionAdapterOptions = Readonly<{
    */
   prepareStatements?: boolean;
   /**
-   * Maximum number of distinct SQL strings tracked for prepared-
-   * statement naming. Defaults to `DEFAULT_POSTGRES_STATEMENT_CACHE_MAX`
-   * (256). Ignored when `prepareStatements` is `false`.
+   * Maximum number of distinct SQL strings retained in TypeGraph's in-process
+   * SQL-to-name lookup. Defaults to `DEFAULT_POSTGRES_STATEMENT_CACHE_MAX`
+   * (256). Eviction never reuses a name, so it does not deallocate or bound
+   * prepared statements retained by live PostgreSQL connections. Ignored when
+   * `prepareStatements` is `false`.
    */
   preparedStatementCacheMax?: number;
   /**

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -295,15 +295,12 @@ export type PostgresBackendOptions = Readonly<{
    */
   prepareStatements?: boolean;
   /**
-   * Cap on the number of distinct SQL strings tracked for
-   * prepared-statement naming. Defaults to 256. The cache is LRU-
-   * bounded so high-cardinality SQL text (variable-length IN-lists,
-   * generated aliases, `backend.execute()` calls with one-off SQL)
-   * doesn't grow unbounded in either the Node process or in
-   * PostgreSQL's per-session prepared-statement memory. Worst-case
-   * server-side footprint is roughly `cap × pool size` statements
-   * across all pooled connections. Ignored when
-   * `prepareStatements` is `false`.
+   * Cap on the number of distinct SQL strings retained in TypeGraph's
+   * in-process SQL-to-statement-name lookup. Defaults to 256. Eviction never
+   * reuses a name, so this does not deallocate or bound prepared statements
+   * retained on live PostgreSQL connections. Set `prepareStatements: false`
+   * for high-cardinality SQL text when server-side statement retention is not
+   * acceptable. Ignored when `prepareStatements` is `false`.
    */
   preparedStatementCacheMax?: number;
   /**

--- a/packages/typegraph/tests/drizzle-claim-sites.test.ts
+++ b/packages/typegraph/tests/drizzle-claim-sites.test.ts
@@ -49,7 +49,7 @@ const RECORDED_CLAIM_SITES: readonly Readonly<{
   },
   {
     file: "apps/docs/src/content/docs/backend-setup.md",
-    line: 668,
+    line: 670,
     text: "## " + CLAIM_WORD + "-Free Entrypoints",
   },
   {

--- a/packages/typegraph/tests/execution-adapter.test.ts
+++ b/packages/typegraph/tests/execution-adapter.test.ts
@@ -544,28 +544,58 @@ describe("postgres execution adapter", () => {
       expect(new Set(namesUsed).size).toBe(3);
     });
 
-    it("never recycles statement names after eviction", async () => {
+    it("keeps names unique after eviction on a connection that remembers prepared SQL", async () => {
       resetStatementNameCacheForTests();
       const { db, query } = makeMockPgDb();
+      // node-postgres remembers each prepared statement's SQL text for the
+      // lifetime of a connection and rejects a name paired with different
+      // text. Model that contract here rather than only counting generated
+      // names: a name-reuse regression fails at the same second eviction that
+      // reaches a real long-lived connection.
+      const preparedSqlByName = new Map<string, string>();
+      query.mockImplementation((configOrSql) => {
+        if (typeof configOrSql === "string") {
+          return Promise.resolve({ rows: [] });
+        }
+        const config = configOrSql as Readonly<{
+          name: string;
+          text: string;
+        }>;
+        const existingSql = preparedSqlByName.get(config.name);
+        if (existingSql !== undefined && existingSql !== config.text) {
+          return Promise.reject(
+            new Error(
+              `Prepared statements must be unique - '${config.name}' was used for a different statement`,
+            ),
+          );
+        }
+        preparedSqlByName.set(config.name, config.text);
+        return Promise.resolve({ rows: [{ sqlText: config.text }] });
+      });
       const adapter = createPostgresExecutionAdapter(db, {
         preparedStatementCacheMax: 2,
       });
 
-      await adapter.execute(sql`q1`);
-      const firstName = (query.mock.calls[0]?.[0] as { name: string }).name;
-
-      await adapter.execute(sql`q2`);
-      await adapter.execute(sql`q3`); // evicts q1
-      await adapter.execute(sql`q4`); // evicts q2
+      // Four distinct statements exceed a two-entry LRU twice. A cache that
+      // recycled either evicted name would be rejected by the modeled pg
+      // connection instead of safely preparing the new SQL text.
+      const executedSql = await Promise.all(
+        [sql`q1`, sql`q2`, sql`q3`, sql`q4`].map(async (statement) => {
+          const rows = await adapter.execute<{ sqlText: string }>(statement);
+          return rows[0]?.sqlText;
+        }),
+      );
 
       const namesUsed = query.mock.calls.map(
         (call) => (call[0] as { name: string }).name,
       );
-      // After two evictions, four distinct names must have been issued —
-      // recycling firstName for q3 or q4 would collide with the still-
-      // prepared statement on a long-lived pg connection.
+      expect(executedSql).toEqual([
+        "SELECT 1 AS x",
+        "SELECT 2 AS x",
+        "SELECT 3 AS x",
+        "SELECT 4 AS x",
+      ]);
       expect(new Set(namesUsed).size).toBe(4);
-      expect(namesUsed.slice(1)).not.toContain(firstName);
     });
 
     it("promotes recently-used entries so they are not evicted next", async () => {


### PR DESCRIPTION
Strengthen PostgreSQL execution coverage by modeling the driver permanent name-to-SQL binding across LRU eviction, and correct the documentation so preparedStatementCacheMax is not presented as a server-memory bound.

The existing monotonic allocator remains unchanged. This makes its safety contract executable and documents prepareStatements: false for high-cardinality workloads.

Closes #529