### PR TITLE
fix(store): fence endpoint get-or-create reads against stale transports

### DIFF
--- a/.changeset/transactional-edge-match-reads.md
+++ b/.changeset/transactional-edge-match-reads.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Keep edge get-or-create match decisions inside their write transaction.

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -88,8 +88,8 @@ import {
   type GraphReadBackend,
   type InsertEdgeParams,
   rowPropsToObject,
-  type TransactionBackend,
   runOptionallyInTransaction,
+  type TransactionBackend,
 } from "../../backend/types";
 import { validateEdgeEndpoints } from "../../constraints";
 import { type GraphDef } from "../../core/define-graph";

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -89,6 +89,7 @@ import {
   type InsertEdgeParams,
   rowPropsToObject,
   type TransactionBackend,
+  runOptionallyInTransaction,
 } from "../../backend/types";
 import { validateEdgeEndpoints } from "../../constraints";
 import { type GraphDef } from "../../core/define-graph";
@@ -452,12 +453,31 @@ type EdgeConvergenceGuard = Readonly<{
  * this.
  */
 class EdgeConvergenceRaced extends Error {
-  constructor(kind: string) {
+  readonly row: BackendEdgeRow;
+
+  constructor(kind: string, row: BackendEdgeRow) {
     super(
       `A competing writer claimed the ${kind} match key; re-resolving it. ` +
         `This is internal to getOrCreateByEndpoints and is never returned to a caller.`,
     );
     this.name = "EdgeConvergenceRaced";
+    this.row = row;
+  }
+}
+
+/**
+ * The dispatcher selected an edge by a match key that no longer describes the
+ * row when the update transaction re-read it. The caller must re-dispatch from
+ * a transaction-owned match-key read rather than applying the update to the
+ * stale id.
+ */
+class EdgeMatchKeyMoved extends Error {
+  constructor(kind: string, id: string) {
+    super(
+      `The ${kind} edge "${id}" no longer has the requested match key; ` +
+        "re-resolving it. This is internal and is never returned to a caller.",
+    );
+    this.name = "EdgeMatchKeyMoved";
   }
 }
 
@@ -508,8 +528,9 @@ async function executeEdgeCreateInternal<G extends GraphDef>(
           convergeOn.matchOn,
           convergeOn.props,
         );
-        if (liveRow !== undefined || deletedRow !== undefined) {
-          throw new EdgeConvergenceRaced(kind);
+        const matchedRow = liveRow ?? deletedRow;
+        if (matchedRow !== undefined) {
+          throw new EdgeConvergenceRaced(kind, matchedRow);
         }
       }
 
@@ -841,7 +862,11 @@ async function performEdgeUpdate<G extends GraphDef>(
   input: UpsertUpdateEdgeInput,
   session: EdgeWriteSession,
   target: WriteTarget,
-  options?: Readonly<{ clearDeleted?: boolean }>,
+  options?: Readonly<{
+    clearDeleted?: boolean;
+    matchOn?: readonly string[];
+    matchProps?: Record<string, unknown>;
+  }>,
 ): Promise<Edge> {
   const id = input.id;
 
@@ -861,6 +886,9 @@ async function performEdgeUpdate<G extends GraphDef>(
     edgeIdentityFromRow(existing),
     "update",
   );
+  if (options?.matchOn !== undefined && options.matchProps !== undefined) {
+    assertEdgeMatchKey(existing, options.matchOn, options.matchProps);
+  }
 
   const { validatedProps } = resolveEdgeUpdateProps(ctx, existing, input.props);
 
@@ -1050,7 +1078,11 @@ async function performEdgeUpdateConverging<G extends GraphDef>(
   input: UpsertUpdateEdgeInput,
   session: EdgeWriteSession,
   target: WriteTarget,
-  options?: Readonly<{ clearDeleted?: boolean }>,
+  options?: Readonly<{
+    clearDeleted?: boolean;
+    matchOn?: readonly string[];
+    matchProps?: Record<string, unknown>;
+  }>,
 ): Promise<Edge> {
   for (let attempt = 1; attempt <= EDGE_UPDATE_ATTEMPTS; attempt += 1) {
     try {
@@ -1151,6 +1183,8 @@ async function executeEdgeUpsertUpdateWithOutcome<G extends GraphDef>(
     clearDeleted?: boolean;
     coalesceUnchanged?: boolean;
     coalesceCandidate?: BackendEdgeRow;
+    matchOn?: readonly string[];
+    matchProps?: Record<string, unknown>;
   }>,
 ): Promise<EdgeUpsertUpdateOutcome> {
   if (input.clearValidTo === true) {
@@ -1173,8 +1207,10 @@ async function executeEdgeUpsertUpdateWithOutcome<G extends GraphDef>(
     async (session, target) => {
       if (options?.coalesceUnchanged === true && !options.clearDeleted) {
         const existing =
-          options.coalesceCandidate ??
-          (await target.getEdge(ctx.graphId, input.id));
+          options.matchOn !== undefined && options.matchProps !== undefined ?
+            await target.getEdge(ctx.graphId, input.id)
+          : (options.coalesceCandidate ??
+            (await target.getEdge(ctx.graphId, input.id)));
         if (existing !== undefined && existing.deleted_at === undefined) {
           assertEdgeIdentityMatches(
             input.id,
@@ -1182,6 +1218,12 @@ async function executeEdgeUpsertUpdateWithOutcome<G extends GraphDef>(
             edgeIdentityFromRow(existing),
             "update",
           );
+          if (
+            options.matchOn !== undefined &&
+            options.matchProps !== undefined
+          ) {
+            assertEdgeMatchKey(existing, options.matchOn, options.matchProps);
+          }
           const runDirtyCheck = () =>
             edgeUpsertDirtyCheck(
               ctx,
@@ -1219,7 +1261,11 @@ export async function executeEdgeUpsertUpdate<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
   input: UpsertUpdateEdgeInput,
   backend: GraphBackend | TransactionBackend,
-  options?: Readonly<{ clearDeleted?: boolean }>,
+  options?: Readonly<{
+    clearDeleted?: boolean;
+    matchOn?: readonly string[];
+    matchProps?: Record<string, unknown>;
+  }>,
 ): Promise<Edge> {
   const outcome = await executeEdgeUpsertUpdateWithOutcome(
     ctx,
@@ -1508,6 +1554,22 @@ function findMatchingEdge(
 }
 
 /**
+ * Rechecks the match key against a row selected for an endpoint upsert.
+ * Returning a stale coalesced candidate would otherwise bypass the normal
+ * update-body validation entirely.
+ */
+function assertEdgeMatchKey(
+  row: BackendEdgeRow,
+  matchOn: readonly string[],
+  matchProps: Record<string, unknown>,
+): void {
+  const match = findMatchingEdge([row], matchOn, matchProps);
+  if (match.liveRow === undefined && match.deletedRow === undefined) {
+    throw new EdgeMatchKeyMoved(row.kind, row.id);
+  }
+}
+
+/**
  * Executes a single findByEndpoints operation.
  *
  * Looks up an edge by endpoints and optional matchOn fields, honoring the
@@ -1649,13 +1711,10 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
     );
   }
 
-  // Probe outside the transaction: with ifExists "return", the common found
-  // path performs no write, so it must not pay for a write transaction
-  // (BEGIN IMMEDIATE on SQLite, the per-graph advisory lock under history).
-  // The transactional body re-queries, so a concurrent create between this
-  // probe and the write lock is still handled correctly.
-  if (ifExists === "return") {
-    const probeRows = await backend.findEdgesByKind({
+  const findCandidates = async (
+    target: GraphBackend | TransactionBackend,
+  ): Promise<readonly BackendEdgeRow[]> =>
+    target.findEdgesByKind({
       graphId: ctx.graphId,
       kind,
       fromKind,
@@ -1665,14 +1724,38 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       excludeDeleted: false,
       temporalMode: "includeTombstones",
     });
+
+  async function findCandidatesInTransaction(): Promise<
+    readonly BackendEdgeRow[]
+  > {
+    return runOptionallyInTransaction(
+      backend,
+      (target) => findCandidates(target),
+      { transaction: { accessMode: "read_only" } },
+    );
+  }
+
+  // Keep the cheap root probe for the common found path, but never return its
+  // row directly. A positive root result is only a hint; the transaction read
+  // below owns the match decision and can reject a stale cache entry.
+  if (ifExists === "return") {
+    const probeRows = await findCandidates(backend);
     const { liveRow: probedLiveRow } = findMatchingEdge(
       probeRows,
       matchOn,
       validatedProps,
     );
     if (probedLiveRow !== undefined) {
-      assertEndpointClearCanApply(ifExists, options?.clearValidTo, kind);
-      return { edge: rowToEdge(probedLiveRow), action: "found" };
+      const currentRows = await findCandidatesInTransaction();
+      const { liveRow: currentLiveRow } = findMatchingEdge(
+        currentRows,
+        matchOn,
+        validatedProps,
+      );
+      if (currentLiveRow !== undefined) {
+        assertEndpointClearCanApply(ifExists, options?.clearValidTo, kind);
+        return { edge: rowToEdge(currentLiveRow), action: "found" };
+      }
     }
   }
 
@@ -1691,26 +1774,114 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
   // in-transaction re-read and its endpoint-predicated UPDATE are what make
   // that write land on the row this lookup meant, not a re-derivation of the
   // dispatcher's choice.
-  async function attempt(): Promise<
-    Readonly<{ edge: Edge; action: GetOrCreateAction }>
-  > {
-    // Query all edges of this kind between (from, to) including tombstones
-    const candidateRows = await backend.findEdgesByKind({
-      graphId: ctx.graphId,
-      kind,
-      fromKind,
-      fromId,
-      toKind,
-      toId,
-      excludeDeleted: false,
-      temporalMode: "includeTombstones",
-    });
+  async function resolveMatchedRow(
+    matchedRow: BackendEdgeRow,
+    isDeleted: boolean,
+  ): Promise<Readonly<{ edge: Edge; action: GetOrCreateAction }>> {
+    if (!isDeleted) {
+      if (ifExists === "return") {
+        assertEndpointClearCanApply(ifExists, options?.clearValidTo, kind);
+        return { edge: rowToEdge(matchedRow), action: "found" };
+      }
+      // ifExists === "update". `validFrom` is forwarded even though an
+      // in-place update stores no lower bound: the shared write guard judges
+      // it and refuses a different bound instead of silently dropping it.
+      const outcome = await executeEdgeUpsertUpdateWithOutcome(
+        ctx,
+        {
+          id: matchedRow.id,
+          identity: { kind, fromKind, fromId, toKind, toId },
+          props: validatedProps,
+          ...(validFrom !== undefined && { validFrom }),
+          ...(validTo !== undefined && { validTo }),
+          ...(options?.clearValidTo === true && {
+            clearValidTo: true as const,
+          }),
+          ...(options?.onImmutableLowerBound !== undefined && {
+            onImmutableLowerBound: options.onImmutableLowerBound,
+          }),
+        },
+        backend,
+        {
+          coalesceUnchanged:
+            ctx.coalesceUnchangedUpsertsEnabled &&
+            shouldCoalesceUpsert(matchedRow, options, () =>
+              edgeUpsertDirtyCheck(
+                ctx,
+                matchedRow.kind,
+                matchedRow.id,
+                rowPropsToObject(matchedRow.props),
+                validatedProps,
+              ),
+            ),
+          matchOn,
+          matchProps: validatedProps,
+        },
+      );
+      return {
+        edge: outcome.edge,
+        action: outcome.wrote ? "updated" : "found",
+      };
+    }
 
-    const { liveRow, deletedRow } = findMatchingEdge(
+    // A resurrection forwards `validFrom` as the create leg does: naming it
+    // restates the revived row's WHOLE window. The shared update path derives
+    // the resulting live state and re-checks cardinality in its transaction.
+    const edge = await executeEdgeUpsertUpdate(
+      ctx,
+      {
+        id: matchedRow.id,
+        identity: { kind, fromKind, fromId, toKind, toId },
+        props: validatedProps,
+        ...(validFrom !== undefined && { validFrom }),
+        ...(validTo !== undefined && { validTo }),
+        ...(options?.clearValidTo === true && {
+          clearValidTo: true as const,
+        }),
+        ...(options?.onImmutableLowerBound !== undefined && {
+          onImmutableLowerBound: options.onImmutableLowerBound,
+        }),
+      },
+      backend,
+      {
+        clearDeleted: true,
+        matchOn,
+        matchProps: validatedProps,
+      },
+    );
+    return { edge, action: "resurrected" };
+  }
+
+  async function attempt(
+    forceTransactionRead: boolean,
+  ): Promise<Readonly<{ edge: Edge; action: GetOrCreateAction }>> {
+    // Query all edges of this kind between (from, to) including tombstones
+    const candidateRows =
+      forceTransactionRead ?
+        await findCandidatesInTransaction()
+      : await findCandidates(backend);
+
+    let { liveRow, deletedRow } = findMatchingEdge(
       candidateRows,
       matchOn,
       validatedProps,
     );
+
+    // A root read is only a dispatcher hint. Once it reports a match, confirm
+    // that match through the transaction target before returning it or using
+    // its id for an update/resurrection. Caching transports can replay a stale
+    // positive just as they can replay a stale empty result.
+    if (
+      !forceTransactionRead &&
+      (liveRow !== undefined || deletedRow !== undefined)
+    ) {
+      const currentRows = await findCandidatesInTransaction();
+      ({ liveRow, deletedRow } = findMatchingEdge(
+        currentRows,
+        matchOn,
+        validatedProps,
+      ));
+    }
 
     // No match → create new edge
     if (liveRow === undefined && deletedRow === undefined) {
@@ -1737,121 +1908,54 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
       return { edge: created, action: "created" };
     }
 
-    // Live match found
-    if (liveRow !== undefined) {
-      if (ifExists === "return") {
-        assertEndpointClearCanApply(ifExists, options?.clearValidTo, kind);
-        return { edge: rowToEdge(liveRow), action: "found" };
-      }
-      // ifExists === "update". `validFrom` is forwarded even though an in-place
-      // update stores no lower bound: the shared write guard is what judges it,
-      // refusing a bound that differs from the one the live row holds instead of
-      // dropping it here where the caller would never hear about it.
-      const outcome = await executeEdgeUpsertUpdateWithOutcome(
-        ctx,
-        {
-          id: liveRow.id,
-          identity: { kind, fromKind, fromId, toKind, toId },
-          props: validatedProps,
-          ...(validFrom !== undefined && { validFrom }),
-          ...(validTo !== undefined && { validTo }),
-          ...(options?.clearValidTo === true && {
-            clearValidTo: true as const,
-          }),
-          ...(options?.onImmutableLowerBound !== undefined && {
-            onImmutableLowerBound: options.onImmutableLowerBound,
-          }),
-        },
-        backend,
-        {
-          coalesceUnchanged:
-            ctx.coalesceUnchangedUpsertsEnabled &&
-            shouldCoalesceUpsert(liveRow, options, () =>
-              edgeUpsertDirtyCheck(
-                ctx,
-                liveRow.kind,
-                liveRow.id,
-                rowPropsToObject(liveRow.props),
-                validatedProps,
-              ),
-            ),
-        },
-      );
-      return {
-        edge: outcome.edge,
-        action: outcome.wrote ? "updated" : "found",
-      };
-    }
-
-    // Deleted match only → resurrect. The shared update path derives the
-    // resulting live/active state and re-checks cardinality under the same
-    // transaction fence as the revival it authorizes.
-    if (deletedRow === undefined) {
-      throw new Error("Expected deletedRow to be defined");
-    }
-    const matchedDeletedRow = deletedRow;
-
-    // A resurrection forwards `validFrom` as the create leg does: naming it
-    // restates the revived row's WHOLE window (the backend rewrites both
-    // endpoints together), which is the only way to revive a row into a window
-    // that closed before the row originally began. Dropping it here silently
-    // ignored a stated lower bound and left the caller no way to satisfy the
-    // window-ordering guard.
-    const edge = await executeEdgeUpsertUpdate(
-      ctx,
-      {
-        id: matchedDeletedRow.id,
-        identity: { kind, fromKind, fromId, toKind, toId },
-        props: validatedProps,
-        ...(validFrom !== undefined && { validFrom }),
-        ...(validTo !== undefined && { validTo }),
-        ...(options?.clearValidTo === true && {
-          clearValidTo: true as const,
-        }),
-        ...(options?.onImmutableLowerBound !== undefined && {
-          onImmutableLowerBound: options.onImmutableLowerBound,
-        }),
-      },
-      backend,
-      { clearDeleted: true },
-    );
-    return { edge, action: "resurrected" };
+    if (liveRow !== undefined) return resolveMatchedRow(liveRow, false);
+    return resolveMatchedRow(requireDefined(deletedRow), true);
   }
 
   // Convergence loop. Under the fence a losing writer learns about the winner
   // from its own in-transaction lookup ({@link EdgeConvergenceRaced}) rather
-  // than from a constraint violation, so the ordinary path is one re-dispatch
-  // that finds the winner's edge. The `CardinalityError` arm remains the
-  // backstop for the paths the fence cannot cover — a competitor whose write is
-  // not a `getOrCreateByEndpoints` at all.
+  // than from a constraint violation. That signal carries the authoritative
+  // row so the caller converges without re-dispatching through a possibly stale
+  // root read. The `CardinalityError` arm remains the backstop for the paths the
+  // fence cannot cover — a competitor whose write is not a
+  // `getOrCreateByEndpoints` at all.
   //
-  // ATTEMPT_LIMIT bounds a pathological ping-pong (a competitor that creates
-  // and hard-deletes the same match key repeatedly) rather than spinning; the
-  // last attempt would otherwise be indistinguishable from a livelock. On the
-  // FINAL attempt a retryable signal is no longer retryable, so it is reported:
-  // a `CardinalityError` as itself (the caller's own constraint is what failed),
-  // and an exhausted convergence race as the terminal error below, which names
-  // the interference rather than leaking an internal signal.
+  // ATTEMPT_LIMIT bounds repeated cardinality conflicts rather than spinning.
+  // On the final attempt the caller's own constraint error is reported as
+  // itself; the internal convergence signal never escapes this function.
   const ATTEMPT_LIMIT = 3;
+  let forceTransactionRead = false;
   for (let remaining = ATTEMPT_LIMIT; remaining > 0; remaining -= 1) {
     try {
-      return await attempt();
+      return await attempt(forceTransactionRead);
     } catch (error) {
-      const retryable =
-        error instanceof CardinalityError ||
-        error instanceof EdgeConvergenceRaced;
-      if (!retryable || remaining === 1) {
-        if (!(error instanceof EdgeConvergenceRaced)) throw error;
-        throw new DatabaseOperationError(
-          `getOrCreateByEndpoints for ${kind} between ${fromKind} "${fromId}" ` +
-            `and ${toKind} "${toId}" lost its match key to a competing writer ` +
-            `${String(ATTEMPT_LIMIT)} times without converging. A concurrent ` +
-            `writer is repeatedly creating and removing this edge; serialize ` +
-            `those callers or retry the operation.`,
-          { operation: "insert", entity: "edge" },
-          { cause: error },
-        );
+      if (error instanceof EdgeConvergenceRaced) {
+        // The create guard found this row through the transaction target. That
+        // is the authoritative read-own-writes observation. Re-dispatching via
+        // the root backend can replay a caching transport's stale empty probe,
+        // so converge directly from the row the fenced lookup just proved.
+        return resolveMatchedRow(error.row, error.row.deleted_at !== undefined);
       }
+      if (error instanceof EdgeMatchKeyMoved) {
+        if (remaining === 1) {
+          throw new DatabaseOperationError(
+            `getOrCreateByEndpoints for ${kind} between ${fromKind} "${fromId}" ` +
+              `and ${toKind} "${toId}" could not resolve a stable match key ` +
+              `after ${ATTEMPT_LIMIT} attempts. Either a concurrent writer is ` +
+              "changing the matching properties, or the transaction transport " +
+              "is returning stale rows. Serialize competing writers, use a " +
+              "transaction-affine non-caching connection, or retry.",
+            { operation: "insert", entity: "edge" },
+            { cause: error },
+          );
+        }
+        // The previous update was selected from a row whose match key changed
+        // before its write. The next dispatch must not consult the root cache
+        // again, or it could select that same stale id indefinitely.
+        forceTransactionRead = true;
+        continue;
+      }
+      if (!(error instanceof CardinalityError) || remaining === 1) throw error;
     }
   }
   // Unreachable: the loop either returns or throws on its final iteration.
@@ -2005,6 +2109,16 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     return rowsByEndpoint;
   }
 
+  async function fetchRowsByEndpointInTransaction(): Promise<
+    ReadonlyMap<string, readonly BackendEdgeRow[]>
+  > {
+    return runOptionallyInTransaction(
+      backend,
+      (target) => fetchRowsByEndpoint(target),
+      { transaction: { accessMode: "read_only" } },
+    );
+  }
+
   interface CreateEntry {
     index: number;
     input: CreateEdgeInput;
@@ -2124,30 +2238,42 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     return { toCreate, toFetch, duplicateOf };
   }
 
-  // Probe outside the transaction: with ifExists "return" and every entry
-  // matching a live edge, the whole call performs no write, so it must not
-  // pay for a write transaction (BEGIN IMMEDIATE on SQLite, the per-graph
-  // advisory lock under history). The transactional body re-queries, so a
-  // concurrent write between this probe and the write lock is still handled
-  // correctly.
+  // Probe outside the write transaction: with ifExists "return" and every
+  // entry matching a live edge, the whole call performs no write. A matching
+  // probe is nevertheless confirmed through a read-only transaction before
+  // returning, so a cached positive cannot become a stale result.
   if (ifExists === "return") {
     const probe = partitionEntries(await fetchRowsByEndpoint(backend));
     const allFoundLive =
       probe.toCreate.length === 0 &&
       probe.toFetch.every((entry) => !entry.isDeleted);
     if (allFoundLive) {
-      const found: Result[] = Array.from({ length: items.length });
-      for (const entry of probe.toFetch) {
-        assertEndpointClearCanApply(ifExists, entry.clearValidTo, kind);
-        found[entry.index] = { edge: rowToEdge(entry.row), action: "found" };
+      // The root partition is only a fast-path hint. Re-partition through the
+      // transaction target before returning rows, because a caching transport
+      // can replay a stale positive match just as it can replay an empty one.
+      const confirmed = partitionEntries(
+        await fetchRowsByEndpointInTransaction(),
+      );
+      const confirmedAllFoundLive =
+        confirmed.toCreate.length === 0 &&
+        confirmed.toFetch.every((entry) => !entry.isDeleted);
+      if (confirmedAllFoundLive) {
+        const found: Result[] = Array.from({ length: items.length });
+        for (const entry of confirmed.toFetch) {
+          assertEndpointClearCanApply(ifExists, entry.clearValidTo, kind);
+          found[entry.index] = {
+            edge: rowToEdge(entry.row),
+            action: "found",
+          };
+        }
+        for (const { index, sourceIndex } of confirmed.duplicateOf) {
+          found[index] = {
+            edge: requireDefined(found[sourceIndex]).edge,
+            action: "found",
+          };
+        }
+        return found;
       }
-      for (const { index, sourceIndex } of probe.duplicateOf) {
-        found[index] = {
-          edge: requireDefined(found[sourceIndex]).edge,
-          action: "found",
-        };
-      }
-      return found;
     }
   }
 
@@ -2232,7 +2358,11 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
                 }),
               },
               rawTarget,
-              { clearDeleted: true },
+              {
+                clearDeleted: true,
+                matchOn,
+                matchProps: entry.validatedProps,
+              },
             );
             results[entry.index] = { edge, action: "resurrected" };
             writes += 1;
@@ -2267,6 +2397,8 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
               {
                 coalesceUnchanged: ctx.coalesceUnchangedUpsertsEnabled,
                 coalesceCandidate: entry.row,
+                matchOn,
+                matchProps: entry.validatedProps,
               },
             );
             results[entry.index] = {
@@ -2299,7 +2431,16 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
         return { results, writes };
       },
       { didWrite: (outcome) => outcome.writes > 0 },
-    );
+    ).catch((error: unknown) => {
+      if (!(error instanceof EdgeMatchKeyMoved)) throw error;
+      throw new DatabaseOperationError(
+        `bulk getOrCreateByEndpoints for ${kind} could not resolve a stable ` +
+          "match key because a concurrent writer changed it during the batch; " +
+          "retry the operation.",
+        { operation: "update", entity: "edge" },
+        { cause: error },
+      );
+    });
   }
 
   async function runBatchResults(): Promise<Result[]> {

--- a/packages/typegraph/tests/backend-contracts.test.ts
+++ b/packages/typegraph/tests/backend-contracts.test.ts
@@ -2,8 +2,9 @@
  * Backend-interaction contracts, asserted by tracing WHERE work happens
  * rather than only what state results:
  *
- * - Read-path contract: the found path of every getOrCreate never opens a
- *   write transaction and never calls a write method.
+ * - Read-path contract: the found path of every getOrCreate never calls a
+ *   write method. Endpoint getOrCreate also confirms its match in a read-only
+ *   transaction so a cached positive cannot become a stale write decision.
  * - Atomicity contract: every mutation's row and sidecar writes (uniques,
  *   fulltext) happen inside a transaction, never on the root connection.
  * - Hook contract: an operation whose transaction fails at COMMIT reports
@@ -1232,7 +1233,7 @@ describe("read-path contract: found paths perform no write work", () => {
     expect(writeCalls(trace.calls)).toEqual([]);
   });
 
-  it("edge getOrCreateByEndpoints found path opens no transaction", async () => {
+  it("edge getOrCreateByEndpoints found path confirms its match in a read transaction", async () => {
     const trace = createTracingBackend(createTestBackend());
     const [store] = await createStoreWithSchema(graph, trace.backend);
     await seedPair(store);
@@ -1249,9 +1250,9 @@ describe("read-path contract: found paths perform no write work", () => {
       { weight: 1 },
     );
     expect(found.action).toBe("found");
-    expect(trace.calls.filter((call) => call.includes("transaction"))).toEqual(
-      [],
-    );
+    expect(
+      trace.calls.filter((call) => call.includes("transaction")),
+    ).not.toEqual([]);
     expect(writeCalls(trace.calls)).toEqual([]);
   });
 });

--- a/packages/typegraph/tests/get-or-create-convergence.test.ts
+++ b/packages/typegraph/tests/get-or-create-convergence.test.ts
@@ -501,11 +501,10 @@ describe("getOrCreateByEndpoints convergence", () => {
 
     expect(result.action).toBe("created");
     expect(result.edge.since).toBe("original");
-    expect(await setup.edges.knows.findFrom(alice)).toHaveLength(2);
+    const storedEdges = await setup.edges.knows.findFrom(alice);
+    expect(storedEdges).toHaveLength(2);
     expect(
-      (await setup.edges.knows.findFrom(alice)).find(
-        (edge) => edge.id === original.id,
-      )?.since,
+      storedEdges.find((edge) => edge.id === original.id)?.since,
     ).toBe("changed");
   });
 
@@ -600,7 +599,8 @@ describe("getOrCreateByEndpoints convergence", () => {
 
     expect(results[0]?.action).toBe("updated");
     expect(results[0]?.edge.note).toBe("old");
-    expect((await setup.edges.knows.findFrom(alice))[0]?.note).toBe("old");
+    const storedEdges = await setup.edges.knows.findFrom(alice);
+    expect(storedEdges[0]?.note).toBe("old");
   });
 
   it("leaves the uncontended paths on their existing verdicts", async () => {

--- a/packages/typegraph/tests/get-or-create-convergence.test.ts
+++ b/packages/typegraph/tests/get-or-create-convergence.test.ts
@@ -503,9 +503,9 @@ describe("getOrCreateByEndpoints convergence", () => {
     expect(result.edge.since).toBe("original");
     const storedEdges = await setup.edges.knows.findFrom(alice);
     expect(storedEdges).toHaveLength(2);
-    expect(
-      storedEdges.find((edge) => edge.id === original.id)?.since,
-    ).toBe("changed");
+    expect(storedEdges.find((edge) => edge.id === original.id)?.since).toBe(
+      "changed",
+    );
   });
 
   it("reports stale transaction reads honestly when convergence cannot stabilize", async () => {

--- a/packages/typegraph/tests/get-or-create-convergence.test.ts
+++ b/packages/typegraph/tests/get-or-create-convergence.test.ts
@@ -36,7 +36,10 @@ const Person = defineNode("Person", {
 });
 
 const knows = defineEdge("knows", {
-  schema: z.object({ since: z.string().default("2024") }),
+  schema: z.object({
+    since: z.string().default("2024"),
+    note: z.string().optional(),
+  }),
 });
 
 const reportsTo = defineEdge("reportsTo", { schema: z.object({}) });
@@ -358,12 +361,12 @@ describe("getOrCreateByEndpoints convergence", () => {
     expect(await setup.revisionNow()).toBe(afterCompetitor);
   });
 
-  it("reports a terminal error when the match key never settles", async () => {
-    // The convergence loop is bounded: a competitor that keeps claiming and
-    // releasing the same match key would otherwise spin forever. Injected here
-    // by making the create leg's in-transaction guard ALWAYS see a competitor
-    // while the dispatcher's own lookup sees none — a permanent version of the
-    // real interleaving.
+  it("converges from the transaction read when root reads stay stale", async () => {
+    // Caching transports may replay the root probe's empty result while
+    // bypassing their cache inside an explicit transaction. The guarded create
+    // therefore sees the committed row even though every root lookup still
+    // reports nothing. The transaction's row is authoritative: throwing it
+    // away and retrying the root lookup used to fail after three phantom races.
     const setup = createStore(graph, raw);
     const alice = await setup.nodes.Person.create({ name: "Alice" });
     const bob = await setup.nodes.Person.create({ name: "Bob" });
@@ -392,11 +395,11 @@ describe("getOrCreateByEndpoints convergence", () => {
             (target) =>
               fn({
                 ...target,
-                // The guard reads through the transaction and always sees a
-                // competitor, so every attempt aborts.
-                findEdgesByKind: () => {
+                // Transaction reads bypass the simulated root cache and see
+                // the row's current live/tombstoned state.
+                findEdgesByKind: (params) => {
                   attempts += 1;
-                  return Promise.resolve([phantom]);
+                  return target.findEdgesByKind(params);
                 },
               }),
             options,
@@ -404,11 +407,200 @@ describe("getOrCreateByEndpoints convergence", () => {
       }),
     );
 
-    await expect(
-      store.edges.knows.getOrCreateByEndpoints(alice, bob, { since: "x" }),
-    ).rejects.toThrow(/lost its match key/u);
-    // Bounded, and it really did use every attempt before giving up.
+    const result = await store.edges.knows.getOrCreateByEndpoints(alice, bob, {
+      since: "x",
+    });
+
+    expect(result.action).toBe("found");
+    expect(result.edge.id).toBe(phantom.id);
+    // No retry through the stale root read: one in-transaction observation is
+    // enough to converge on the database's actual row.
+    expect(attempts).toBe(1);
+
+    const updated = await store.edges.knows.getOrCreateByEndpoints(
+      alice,
+      bob,
+      { since: "updated" },
+      { ifExists: "update" },
+    );
+    expect(updated.action).toBe("updated");
+    expect(updated.edge.since).toBe("updated");
+
+    await setup.edges.knows.delete(updated.edge.id);
+    const resurrected = await store.edges.knows.getOrCreateByEndpoints(
+      alice,
+      bob,
+      { since: "revived" },
+      { ifExists: "update" },
+    );
+    expect(resurrected.action).toBe("resurrected");
+    expect(resurrected.edge.id).toBe(phantom.id);
+    expect(resurrected.edge.since).toBe("revived");
     expect(attempts).toBe(3);
+  });
+
+  it("does not return a stale positive match from the root read", async () => {
+    const setup = createStore(graph, raw);
+    const alice = await setup.nodes.Person.create({ name: "Alice" });
+    const bob = await setup.nodes.Person.create({ name: "Bob" });
+    const stale = await setup.edges.knows.create(alice, bob, {
+      since: "stale",
+    });
+    const staleRow = requireDefined(await raw.getEdge(graph.id, stale.id));
+    await setup.edges.knows.hardDelete(stale.id);
+    await setup.edges.knows.create(alice, bob, { since: "current" });
+
+    const store = createStore(
+      graph,
+      deriveBackend(raw, {
+        // The root transport replays the old live row, while the transaction
+        // target sees the committed replacement.
+        findEdgesByKind: () => Promise.resolve([staleRow]),
+      }),
+    );
+
+    const result = await store.edges.knows.getOrCreateByEndpoints(
+      alice,
+      bob,
+      { since: "stale" },
+      { matchOn: ["since"] },
+    );
+
+    expect(result.action).toBe("created");
+    expect(result.edge.since).toBe("stale");
+    expect(await setup.edges.knows.findFrom(alice)).toHaveLength(2);
+  });
+
+  it("does not update an id after its match key changed", async () => {
+    const setup = createStore(graph, raw);
+    const alice = await setup.nodes.Person.create({ name: "Alice" });
+    const bob = await setup.nodes.Person.create({ name: "Bob" });
+    const original = await setup.edges.knows.create(alice, bob, {
+      since: "original",
+    });
+    const originalRow = requireDefined(
+      await raw.getEdge(graph.id, original.id),
+    );
+    await setup.edges.knows.update(original.id, { since: "changed" });
+
+    const store = createStore(
+      graph,
+      deriveBackend(raw, {
+        // The dispatcher sees the row before its match key changed. The
+        // transaction-owned read must refuse to apply the update by id.
+        findEdgesByKind: () => Promise.resolve([originalRow]),
+      }),
+    );
+
+    const result = await store.edges.knows.getOrCreateByEndpoints(
+      alice,
+      bob,
+      { since: "original" },
+      { matchOn: ["since"], ifExists: "update" },
+    );
+
+    expect(result.action).toBe("created");
+    expect(result.edge.since).toBe("original");
+    expect(await setup.edges.knows.findFrom(alice)).toHaveLength(2);
+    expect(
+      (await setup.edges.knows.findFrom(alice)).find(
+        (edge) => edge.id === original.id,
+      )?.since,
+    ).toBe("changed");
+  });
+
+  it("reports stale transaction reads honestly when convergence cannot stabilize", async () => {
+    const setup = createStore(graph, raw);
+    const alice = await setup.nodes.Person.create({ name: "Alice" });
+    const bob = await setup.nodes.Person.create({ name: "Bob" });
+    const original = await setup.edges.knows.create(alice, bob, {
+      since: "original",
+    });
+    const staleRow = requireDefined(await raw.getEdge(graph.id, original.id));
+    await setup.edges.knows.update(original.id, { since: "changed" });
+
+    const store = createStore(
+      graph,
+      deriveBackend(raw, {
+        findEdgesByKind: () => Promise.resolve([staleRow]),
+        transaction: (fn, options) =>
+          raw.transaction(
+            (target) =>
+              fn(
+                deriveBackend(target, {
+                  findEdgesByKind: () => Promise.resolve([staleRow]),
+                }),
+              ),
+            options,
+          ),
+      }),
+    );
+
+    await expect(
+      store.edges.knows.getOrCreateByEndpoints(
+        alice,
+        bob,
+        { since: "original" },
+        { matchOn: ["since"], ifExists: "update" },
+      ),
+    ).rejects.toThrow(/transaction transport is returning stale rows/u);
+  });
+
+  it("re-reads instead of coalescing a stale bulk candidate", async () => {
+    const setup = createStore(graph, raw);
+    const alice = await setup.nodes.Person.create({ name: "Alice" });
+    const bob = await setup.nodes.Person.create({ name: "Bob" });
+    const original = await setup.edges.knows.create(alice, bob, {
+      since: "same-key",
+      note: "old",
+    });
+    let interposed = false;
+    const backend = deriveBackend(raw, {
+      transaction: (fn, options) =>
+        raw.transaction(
+          (target) =>
+            fn(
+              deriveBackend(target, {
+                findEdgesByKind: async (params) => {
+                  const rows = await target.findEdgesByKind(params);
+                  if (!interposed) {
+                    interposed = true;
+                    await target.updateEdge({
+                      graphId: graph.id,
+                      id: original.id,
+                      kind: "knows",
+                      fromKind: "Person",
+                      fromId: alice.id,
+                      toKind: "Person",
+                      toId: bob.id,
+                      props: { since: "same-key", note: "new" },
+                    });
+                  }
+                  return rows;
+                },
+              }),
+            ),
+          options,
+        ),
+    });
+    const store = createStore(graph, backend, {
+      coalesceUnchangedUpserts: true,
+    });
+
+    const results = await store.edges.knows.bulkGetOrCreateByEndpoints(
+      [
+        {
+          from: alice,
+          to: bob,
+          props: { since: "same-key", note: "old" },
+        },
+      ],
+      { matchOn: ["since"], ifExists: "update" },
+    );
+
+    expect(results[0]?.action).toBe("updated");
+    expect(results[0]?.edge.note).toBe("old");
+    expect((await setup.edges.knows.findFrom(alice))[0]?.note).toBe("old");
   });
 
   it("leaves the uncontended paths on their existing verdicts", async () => {


### PR DESCRIPTION
Make getOrCreateByEndpoints derive match decisions from transaction-owned reads and converge directly from the authoritative row found by the write fence.

This prevents caching transports from replaying stale empty or positive matches, protects update, resurrection, and bulk paths from stale candidates, and reports both concurrent-writer and stale-transaction-read causes when convergence cannot be established.

Closes #530