### PR TITLE
fix(query): prevent integer division in fluent hybrid RRF

### DIFF
--- a/.changeset/floating-point-rrf-scores.md
+++ b/.changeset/floating-point-rrf-scores.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Compute reciprocal-rank-fusion scores with floating-point division.

--- a/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
+++ b/packages/typegraph/src/query/compiler/emitter/standard-builders.ts
@@ -1626,9 +1626,12 @@ export function buildStandardHybridRrfOrderBy(
   // non-finite / negative values before we reach here. sql.raw on these
   // numeric constants is deliberate — they're schema-level config, not
   // user-bindable.
+  // `* 1.0` is also deliberate: PostgreSQL otherwise performs integer
+  // division when the default weight and rank constant are integers. Keep
+  // this promotion in lockstep with the backend hybrid statement emitter.
   const rrfOrder = sql.raw(
-    `(COALESCE(${vectorWeight} / (${k} + ${EMBEDDINGS_CTE_ALIAS}.ord), 0) + ` +
-      `COALESCE(${fulltextWeight} / (${k} + ${FULLTEXT_CTE_ALIAS}.ord), 0)) DESC`,
+    `(COALESCE((${vectorWeight} * 1.0) / (${k} + ${EMBEDDINGS_CTE_ALIAS}.ord), 0) + ` +
+      `COALESCE((${fulltextWeight} * 1.0) / (${k} + ${FULLTEXT_CTE_ALIAS}.ord), 0)) DESC`,
   );
   // Deterministic tiebreak on the CTE-projected node_id. At least one of
   // the two CTEs always has a non-NULL node_id for any row returned by

--- a/packages/typegraph/tests/backends/integration/fulltext.ts
+++ b/packages/typegraph/tests/backends/integration/fulltext.ts
@@ -55,6 +55,20 @@ async function seedArticles(
   };
 }
 
+function skipIfHybridUnsupported(
+  context: IntegrationTestContext,
+  ctx: { skip: () => void },
+): IntegrationStore {
+  const backend = context.getStore().backend;
+  if (
+    backend.capabilities.fulltext?.supported !== true ||
+    backend.capabilities.vector?.supported !== true
+  ) {
+    ctx.skip();
+  }
+  return context.getStore();
+}
+
 export function registerFulltextIntegrationTests(
   context: IntegrationTestContext,
 ): void {
@@ -319,6 +333,63 @@ export function registerFulltextIntegrationTests(
           .select((c) => ({ id: (c.a as unknown as { id: string }).id }))
           .execute(),
       ).rejects.toThrow(/cannot be nested under OR or NOT/i);
+    });
+
+    it("keeps distinct RRF ranks distinct in the SQL query-builder order", async (ctx) => {
+      const store = skipIfHybridUnsupported(context, ctx);
+
+      // Deliberately make the vector order the reverse of lexical id order,
+      // then let only `alpha` match fulltext. With k=60 the expected fused
+      // order is alpha (vector rank 3 + fulltext rank 1), zeta (vector rank
+      // 1), beta (vector rank 2). If either RRF division is integer division,
+      // every contribution becomes zero and the id tiebreak returns alpha,
+      // beta, zeta instead — this assertion therefore exercises the actual
+      // score/order contract rather than only inspecting emitted SQL.
+      await store.nodes.Article.create(
+        {
+          title: "Zeta vector candidate",
+          body: "ordinary corpus text",
+          category: "rrf",
+          published: true,
+          embedding: [1, 0, 0, 0],
+        },
+        { id: "zeta" },
+      );
+      await store.nodes.Article.create(
+        {
+          title: "Beta vector candidate",
+          body: "ordinary corpus text",
+          category: "rrf",
+          published: true,
+          embedding: [0.9, 0.1, 0, 0],
+        },
+        { id: "beta" },
+      );
+      await store.nodes.Article.create(
+        {
+          title: "Alpha fulltext candidate",
+          body: "exclusive rrf match",
+          category: "rrf",
+          published: true,
+          embedding: [0, 1, 0, 0],
+        },
+        { id: "alpha" },
+      );
+
+      const rows = await store
+        .query()
+        .from("Article", "article")
+        .whereNode("article", (article) =>
+          article.$fulltext
+            .matches("exclusive", 3)
+            .and(article.embedding.similarTo([1, 0, 0, 0], 3)),
+        )
+        .select((ctx) => ({
+          id: (ctx.article as unknown as { id: string }).id,
+        }))
+        .execute();
+
+      expect(rows.map((row) => row.id)).toEqual(["alpha", "zeta", "beta"]);
     });
 
     // ================================================================

--- a/packages/typegraph/tests/fuse-with.test.ts
+++ b/packages/typegraph/tests/fuse-with.test.ts
@@ -82,18 +82,30 @@ function makeBuilder(): ReturnType<
 }
 
 describe(".fuseWith()", () => {
+  it("forces floating-point arithmetic for the SQL-layer RRF score", () => {
+    const compiled = buildHybridQuery();
+    const sqlText = toSqlString(compiled);
+
+    // PostgreSQL performs integer division when both the configured weight
+    // and the rank denominator are integers. The default RRF contribution
+    // would therefore be zero for every row unless the emitter promotes the
+    // numerator to a floating-point value.
+    expect(sqlText).toMatch(/\(1 \* 1\.0\) \/ \(60 \+ cte_embeddings\.ord\)/);
+    expect(sqlText).toMatch(/\(1 \* 1\.0\) \/ \(60 \+ cte_fulltext\.ord\)/);
+  });
+
   it("threads a custom k into the compiled RRF ORDER BY", () => {
     const compiled = buildHybridQuery({ k: 30 });
     const sqlText = toSqlString(compiled);
-    expect(sqlText).toMatch(/1 \/ \(30 \+ cte_embeddings\.ord\)/);
-    expect(sqlText).toMatch(/1 \/ \(30 \+ cte_fulltext\.ord\)/);
+    expect(sqlText).toMatch(/\(1 \* 1\.0\) \/ \(30 \+ cte_embeddings\.ord\)/);
+    expect(sqlText).toMatch(/\(1 \* 1\.0\) \/ \(30 \+ cte_fulltext\.ord\)/);
   });
 
   it("threads fulltext weight into the compiled RRF ORDER BY", () => {
     const compiled = buildHybridQuery({ weights: { fulltext: 2 } });
     const sqlText = toSqlString(compiled);
-    expect(sqlText).toMatch(/2 \/ \(60 \+ cte_fulltext\.ord\)/);
-    expect(sqlText).toMatch(/1 \/ \(60 \+ cte_embeddings\.ord\)/);
+    expect(sqlText).toMatch(/\(2 \* 1\.0\) \/ \(60 \+ cte_fulltext\.ord\)/);
+    expect(sqlText).toMatch(/\(1 \* 1\.0\) \/ \(60 \+ cte_embeddings\.ord\)/);
   });
 
   it("threads vector weight and k together", () => {
@@ -102,8 +114,10 @@ describe(".fuseWith()", () => {
       weights: { vector: 1.3, fulltext: 0.7 },
     });
     const sqlText = toSqlString(compiled);
-    expect(sqlText).toMatch(/1\.3 \/ \(42 \+ cte_embeddings\.ord\)/);
-    expect(sqlText).toMatch(/0\.7 \/ \(42 \+ cte_fulltext\.ord\)/);
+    expect(sqlText).toMatch(
+      /\(1\.3 \* 1\.0\) \/ \(42 \+ cte_embeddings\.ord\)/,
+    );
+    expect(sqlText).toMatch(/\(0\.7 \* 1\.0\) \/ \(42 \+ cte_fulltext\.ord\)/);
   });
 
   it("rejects hybrid relevance ranking when window functions are unavailable", () => {


### PR DESCRIPTION
Promote fluent hybrid RRF numerators to floating-point SQL so PostgreSQL does not integer-divide default or custom integer weights to zero.

Keep the emitted expression aligned with the backend hybrid statement and cover default and custom k and weight values in compiler coverage.

Closes #531