### PR TITLE
perf(store): reuse negative endpoint probe

### DIFF
--- a/.changeset/reuse-negative-edge-probe.md
+++ b/.changeset/reuse-negative-edge-probe.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Reuse the initial negative endpoint probe during edge get-or-create writes so no-match calls avoid a duplicate root round trip before their transaction-fenced create check.

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -88,8 +88,8 @@ import {
   type GraphReadBackend,
   type InsertEdgeParams,
   rowPropsToObject,
-  type TransactionBackend,
   runOptionallyInTransaction,
+  type TransactionBackend,
 } from "../../backend/types";
 import { validateEdgeEndpoints } from "../../constraints";
 import { type GraphDef } from "../../core/define-graph";
@@ -1735,16 +1735,18 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
     );
   }
 
+  // The return-mode probe is also the dispatcher read for a create. Keep a
+  // negative result so a no-match call does not pay for the same root lookup
+  // twice before the create transaction performs its authoritative check.
+  let initialNegativeRootCandidates: readonly BackendEdgeRow[] | undefined;
+
   // Keep the cheap root probe for the common found path, but never return its
   // row directly. A positive root result is only a hint; the transaction read
   // below owns the match decision and can reject a stale cache entry.
   if (ifExists === "return") {
     const probeRows = await findCandidates(backend);
-    const { liveRow: probedLiveRow } = findMatchingEdge(
-      probeRows,
-      matchOn,
-      validatedProps,
-    );
+    const { liveRow: probedLiveRow, deletedRow: probedDeletedRow } =
+      findMatchingEdge(probeRows, matchOn, validatedProps);
     if (probedLiveRow !== undefined) {
       const currentRows = await findCandidatesInTransaction();
       const { liveRow: currentLiveRow } = findMatchingEdge(
@@ -1756,6 +1758,8 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
         assertEndpointClearCanApply(ifExists, options?.clearValidTo, kind);
         return { edge: rowToEdge(currentLiveRow), action: "found" };
       }
+    } else if (probedDeletedRow === undefined) {
+      initialNegativeRootCandidates = probeRows;
     }
   }
 
@@ -1859,7 +1863,8 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
     const candidateRows =
       forceTransactionRead ?
         await findCandidatesInTransaction()
-      : await findCandidates(backend);
+      : (initialNegativeRootCandidates ?? (await findCandidates(backend)));
+    initialNegativeRootCandidates = undefined;
 
     let { liveRow, deletedRow } = findMatchingEdge(
       candidateRows,

--- a/packages/typegraph/tests/get-or-create-convergence.test.ts
+++ b/packages/typegraph/tests/get-or-create-convergence.test.ts
@@ -93,8 +93,8 @@ const cardinalGraph = defineGraph({
  * The interception is on the TOP-LEVEL backend, so the create leg's own
  * in-transaction lookup (the convergence guard) is not intercepted and sees the
  * competitor as ordinary committed state. `afterCall` selects which lookup to
- * follow: with `ifExists: "return"` the first is the found-fast-path probe and
- * the second is the dispatcher's, so racing the dispatcher means `afterCall: 2`.
+ * follow. In return mode the initial root probe is also the dispatcher read on
+ * a no-match path, so racing that decision uses `afterCall: 1`.
  */
 function racingBackend(
   base: GraphBackend,
@@ -123,6 +123,44 @@ describe("getOrCreateByEndpoints convergence", () => {
     ({ backend: raw } = createLocalSqliteBackend());
   });
 
+  it("reuses a negative root probe before the fenced create check", async () => {
+    const setup = createStore(graph, raw);
+    const alice = await setup.nodes.Person.create({ name: "Alice" });
+    const bob = await setup.nodes.Person.create({ name: "Bob" });
+    let endpointReads = 0;
+
+    const counted = deriveBackend(raw, {
+      findEdgesByKind: async (params) => {
+        endpointReads += 1;
+        return raw.findEdgesByKind(params);
+      },
+      transaction: (fn, options) =>
+        raw.transaction(
+          (target) =>
+            fn(
+              deriveBackend(target, {
+                findEdgesByKind: async (params) => {
+                  endpointReads += 1;
+                  return target.findEdgesByKind(params);
+                },
+              }),
+            ),
+          options,
+        ),
+    });
+
+    const result = await createStore(
+      graph,
+      counted,
+    ).edges.knows.getOrCreateByEndpoints(alice, bob, { since: "2024" });
+
+    expect(result.action).toBe("created");
+    // One root dispatcher read plus the create transaction's authoritative
+    // convergence read. Before the optimization the root dispatcher was read
+    // twice, making this three.
+    expect(endpointReads).toBe(2);
+  });
+
   it("resolves to the competitor's edge instead of inserting a second one", async () => {
     const setup = createStore(graph, raw);
     const alice = await setup.nodes.Person.create({ name: "Alice" });
@@ -131,7 +169,7 @@ describe("getOrCreateByEndpoints convergence", () => {
     const competitor = createStore(graph, raw);
     const store = createStore(
       graph,
-      racingBackend(raw, 2, async () => {
+      racingBackend(raw, 1, async () => {
         await competitor.edges.knows.create(alice, bob, { since: "winner" });
       }),
     );
@@ -155,7 +193,7 @@ describe("getOrCreateByEndpoints convergence", () => {
     const competitor = createStore(graph, raw);
     const store = createStore(
       graph,
-      racingBackend(raw, 2, async () => {
+      racingBackend(raw, 1, async () => {
         await competitor.edges.knows.create(alice, bob, { since: "2020" });
       }),
     );
@@ -180,7 +218,7 @@ describe("getOrCreateByEndpoints convergence", () => {
     const competitor = createStore(graph, raw);
     const store = createStore(
       graph,
-      racingBackend(raw, 2, async () => {
+      racingBackend(raw, 1, async () => {
         await competitor.edges.knows.create(alice, bob, { since: "1999" });
       }),
     );
@@ -298,7 +336,7 @@ describe("getOrCreateByEndpoints convergence", () => {
     const competitor = createStore(graph, raw);
     const store = createStore(
       graph,
-      racingBackend(raw, 2, async () => {
+      racingBackend(raw, 1, async () => {
         await competitor.edges.knows.create(alice, bob, { since: "winner" });
       }),
       {
@@ -345,7 +383,7 @@ describe("getOrCreateByEndpoints convergence", () => {
     let afterCompetitor: string | undefined;
     const store = createStore(
       graph,
-      racingBackend(raw, 2, async () => {
+      racingBackend(raw, 1, async () => {
         await competitor.edges.knows.create(alice, bob, { since: "winner" });
         afterCompetitor = await competitor.revisionNow();
       }),


### PR DESCRIPTION
Reuse the initial negative root lookup in `getOrCreateByEndpoints` as the dispatcher result for the create path. The authoritative in-transaction match-key read remains unchanged, preserving convergence and stale/caching-transport correctness while reducing the common no-match path from three endpoint-match reads to two.

The statement-count regression test failed at three reads when the reuse was deliberately removed and passes at two with the optimization restored.

Part of #533.