### PR TITLE
perf(store): skip generated-id existence probes

### DIFF
--- a/.changeset/generated-id-skip-existence-probes.md
+++ b/.changeset/generated-id-skip-existence-probes.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Skip duplicate and disjointness reads for TypeGraph-generated node IDs.

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -828,9 +828,11 @@ async function finishNodeCreatePreparation<G extends GraphDef>(
 ): Promise<NodeCreatePrepared> {
   const { kind, id, validatedProps, uniqueConstraints } = draft;
 
-  // This is the fast-path existence gate. Resurrection repeats it immediately
-  // before the update because the row can change while constraints are checked.
-  const existingNode = await backend.getNode(ctx.graphId, kind, id);
+  // A generated id is fresh by construction, so probing it for a duplicate or
+  // tombstone can only report absence. Caller-supplied ids retain the probe:
+  // they may name either a live duplicate or a tombstone to resurrect.
+  const existingNode =
+    draft.idProvided ? await backend.getNode(ctx.graphId, kind, id) : undefined;
   if (existingNode && !existingNode.deleted_at) {
     throw createAlreadyExistsError("node", kind, id);
   }
@@ -840,7 +842,12 @@ async function finishNodeCreatePreparation<G extends GraphDef>(
     registry: ctx.registry,
     backend,
   };
-  await checkDisjointnessConstraint(constraintContext, kind, id);
+  // Disjointness is also keyed by the id. A generated id cannot already be
+  // present under a disjoint kind, so its cross-kind reads are the same pure
+  // cost as the same-kind existence probe above.
+  if (draft.idProvided) {
+    await checkDisjointnessConstraint(constraintContext, kind, id);
+  }
 
   await checkUniquenessConstraints(
     createUniquenessContext(

--- a/packages/typegraph/tests/create-round-trips.test.ts
+++ b/packages/typegraph/tests/create-round-trips.test.ts
@@ -50,6 +50,8 @@ const PEER_RESURRECTION_VALID_FROM = "2024-01-01T00:00:00.000Z";
 const RACED_RESURRECTION_VALID_FROM = "2023-06-01T00:00:00.000Z";
 
 type ReadCounts = Readonly<{
+  /** All `getNode` probes, including generated ids unknown to the test. */
+  allNodeReads: number;
   /** `getNode` probes issued for the node being created. */
   targetNodeReads: number;
   /** Bare-id cross-kind fold probes issued by identity. */
@@ -79,7 +81,7 @@ function countingBackend(targetId: string): Readonly<{
   reset: () => void;
 }> {
   const base = createTestBackend();
-  const counts = { targetNodeReads: 0, foldProbes: 0 };
+  const counts = { allNodeReads: 0, targetNodeReads: 0, foldProbes: 0 };
 
   function countTransactionReads(
     target: TransactionBackend,
@@ -95,6 +97,7 @@ function countingBackend(targetId: string): Readonly<{
         const method = value as (...args: unknown[]) => unknown;
         if (property === "getNode") {
           return (...args: unknown[]) => {
+            counts.allNodeReads += 1;
             if (args[2] === targetId) counts.targetNodeReads += 1;
             return method.apply(source, args);
           };
@@ -116,6 +119,7 @@ function countingBackend(targetId: string): Readonly<{
   // `deriveBackend` just carried — exactly the loss the spread had.
   const backend: GraphBackend = deriveBackend(base, {
     getNode: (graphId: string, kind: string, id: string) => {
+      counts.allNodeReads += 1;
       if (id === targetId) counts.targetNodeReads += 1;
       return base.getNode(graphId, kind, id);
     },
@@ -131,6 +135,7 @@ function countingBackend(targetId: string): Readonly<{
     backend,
     counts,
     reset: () => {
+      counts.allNodeReads = 0;
       counts.targetNodeReads = 0;
       counts.foldProbes = 0;
     },
@@ -414,7 +419,9 @@ describe("create-path round trips", () => {
     await store.nodes.Person.create({ name: "Generated" });
 
     // A generated id cannot already exist under another kind, so there is
-    // nothing to fold against and the probe is pure cost.
+    // nothing to find under the same or another kind. Both probes are pure
+    // network cost on the successful create path.
+    expect(counts.allNodeReads).toBe(0);
     expect(counts.foldProbes).toBe(0);
   });
 


### PR DESCRIPTION
Generated node IDs now bypass same-kind duplicate/tombstone reads and cross-kind disjointness reads, while caller-supplied IDs retain the existing checks and resurrection behavior. Combined with the preceding identity fast path, a successful generated-ID node create now performs zero `getNode` or identity-fold probes before insertion.

The statement-count test asserts zero reads; deliberately restoring the probes made it fail with one read, and restoring the optimization returns it to zero.

Part of #533.