### PR TITLE
perf(store): lease schema fences within transactions

### DIFF
--- a/.changeset/transaction-schema-fence-lease.md
+++ b/.changeset/transaction-schema-fence-lease.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Reduce schema-fence round trips for multi-write transactions created through the portable Store API while preserving per-write fencing for adapter and adopted transactions that can use caller-controlled savepoints.

--- a/packages/typegraph/src/backend/capabilities/write-fence.ts
+++ b/packages/typegraph/src/backend/capabilities/write-fence.ts
@@ -81,6 +81,20 @@ export function markFirstPartyFactory<T extends object>(target: T): T {
 }
 
 /**
+ * Whether `target` came from one of TypeGraph's bundled backend factories.
+ *
+ * This stays an out-of-band, unforgeable fact for the same reason as
+ * {@link markFirstPartyFactory}: an arbitrary backend that happens to report
+ * the same dialect cannot thereby opt into an optimization whose transaction
+ * lifetime TypeGraph has not audited.
+ *
+ * @internal
+ */
+export function isFirstPartyFactory(target: object): boolean {
+  return FIRST_PARTY_FACTORY_BACKENDS.has(target);
+}
+
+/**
  * Carries the first-party mark from a source object onto one derived from
  * it, so a factory backend projected or decorated for a transaction still
  * resolves the SAME plan its source would — a lost mark would otherwise

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -2929,22 +2929,24 @@ function createTransactionBackend(
   // only ASSERTS the durable marker (SELECT, never DDL) and can't poison
   // anything on rollback. The shared per-instance cache means a slot
   // confirmed once stays a pure `Set.has` inside every later transaction.
-  const backend = createPostgresOperationBackend({
-    db: options.db,
-    executionAdapter: txExecutionAdapter,
-    adapterOptions: options.adapterOptions,
-    operationStrategy: options.operationStrategy,
-    tableNames: options.tableNames,
-    capabilities: options.capabilities,
-    fulltextStrategy: options.fulltextStrategy,
-    vectorStrategy: options.vectorStrategy,
-    contributionMaterializer: options.contributionMaterializer,
-    // The probe is process-wide truth, so the outer instance's is reused
-    // rather than a fresh one per transaction.
-    iterativeScanProbe: options.iterativeScanProbe,
-    schemaVersionsTable: options.schemaVersionsTable,
-    transactionScoped: true,
-  });
+  const backend = markFirstPartyFactory(
+    createPostgresOperationBackend({
+      db: options.db,
+      executionAdapter: txExecutionAdapter,
+      adapterOptions: options.adapterOptions,
+      operationStrategy: options.operationStrategy,
+      tableNames: options.tableNames,
+      capabilities: options.capabilities,
+      fulltextStrategy: options.fulltextStrategy,
+      vectorStrategy: options.vectorStrategy,
+      contributionMaterializer: options.contributionMaterializer,
+      // The probe is process-wide truth, so the outer instance's is reused
+      // rather than a fresh one per transaction.
+      iterativeScanProbe: options.iterativeScanProbe,
+      schemaVersionsTable: options.schemaVersionsTable,
+      transactionScoped: true,
+    }),
+  );
 
   return { backend, drainAndClose: txExecutionAdapter.drainAndClose };
 }

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -2404,17 +2404,19 @@ function createTransactionBackend(
   // only ASSERTS the durable marker (SELECT, never DDL) and can't poison
   // anything on rollback. The shared per-instance cache means a slot
   // confirmed once stays a pure `Set.has` inside every later transaction.
-  return createSqliteOperationBackend({
-    capabilities: options.capabilities,
-    db: options.db,
-    executionAdapter: txExecutionAdapter,
-    operationStrategy: options.operationStrategy,
-    tableNames: options.tableNames,
-    fulltextStrategy: options.fulltextStrategy,
-    vectorStrategy: options.vectorStrategy,
-    contributionMaterializer: options.contributionMaterializer,
-    transactionScoped: true,
-  });
+  return markFirstPartyFactory(
+    createSqliteOperationBackend({
+      capabilities: options.capabilities,
+      db: options.db,
+      executionAdapter: txExecutionAdapter,
+      operationStrategy: options.operationStrategy,
+      tableNames: options.tableNames,
+      fulltextStrategy: options.fulltextStrategy,
+      vectorStrategy: options.vectorStrategy,
+      contributionMaterializer: options.contributionMaterializer,
+      transactionScoped: true,
+    }),
+  );
 }
 
 // Re-export schema utilities

--- a/packages/typegraph/src/store/operations/write-transaction.ts
+++ b/packages/typegraph/src/store/operations/write-transaction.ts
@@ -56,6 +56,7 @@
  * would make the claim above false wherever it matters most. Unconstrained
  * writes assert nothing and keep working on those backends.
  */
+import { isFirstPartyFactory } from "../../backend/capabilities/write-fence";
 import {
   type GraphBackend,
   runOptionallyInTransaction,
@@ -93,6 +94,51 @@ interface WriteTransactionSession {
 }
 
 const writeTransactionSessions = new WeakMap<object, WriteTransactionSession>();
+
+/**
+ * Schema fences deliberately do not normally memoize: PostgreSQL releases a
+ * lock acquired after a savepoint when a caller rolls back to that savepoint.
+ * The one safe exception is a TypeGraph-owned Store transaction whose public
+ * surface has no native SQL handle. Its first managed write therefore cannot
+ * follow a caller-controlled savepoint; once that write acquires the fence,
+ * subsequent managed writes can reuse it until the outer transaction ends.
+ *
+ * The key includes the expected version rather than only the graph id. A
+ * transaction target is also the cache owner, never the root backend, so a
+ * pooled connection cannot inherit a prior transaction's success.
+ */
+const leasedSchemaFences = new WeakMap<object, Map<string, Promise<void>>>();
+
+function schemaFenceLeaseKey(graphId: string, expectedVersion: number): string {
+  return `${graphId}\u0000${expectedVersion}`;
+}
+
+/**
+ * Marks a TypeGraph-owned transaction as eligible for lazy schema-fence
+ * leasing. The first managed write acquires the fence; read-only transactions
+ * pay nothing and retain their existing visibility/locking behavior.
+ *
+ * Custom transaction backends deliberately take the callback unchanged: their
+ * savepoint/connection lifetime has not been audited by TypeGraph, so their
+ * managed writes retain the conservative per-call fence behavior.
+ */
+export async function withTransactionSchemaFenceLease<T>(
+  ctx: Pick<WriteTransactionContext, "graphId" | "schemaVersion">,
+  target: TransactionBackend,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const expectedVersion = ctx.schemaVersion;
+  if (expectedVersion === undefined || !isFirstPartyFactory(target)) {
+    return fn();
+  }
+
+  leasedSchemaFences.set(target, new Map());
+  try {
+    return await fn();
+  } finally {
+    leasedSchemaFences.delete(target);
+  }
+}
 
 /** Forces the enclosing managed Store transaction to consume one revision. */
 export function forceWriteTransactionRevision(
@@ -156,6 +202,28 @@ export async function withWriteTransactionSession<T>(
  * without a live fence.
  */
 export async function lockSchemaVersionForStoreWrite(
+  ctx: Pick<WriteTransactionContext, "graphId" | "schemaVersion">,
+  backend: GraphBackend | TransactionBackend,
+): Promise<void> {
+  const expectedVersion = ctx.schemaVersion;
+  if (expectedVersion === undefined) return;
+
+  const leases = leasedSchemaFences.get(backend);
+  const leaseKey = schemaFenceLeaseKey(ctx.graphId, expectedVersion);
+  const existingLease = leases?.get(leaseKey);
+  if (existingLease !== undefined) return existingLease;
+
+  const acquisition = lockSchemaVersionForStoreWriteUncached(ctx, backend);
+  leases?.set(leaseKey, acquisition);
+  try {
+    await acquisition;
+  } catch (error) {
+    if (leases?.get(leaseKey) === acquisition) leases.delete(leaseKey);
+    throw error;
+  }
+}
+
+async function lockSchemaVersionForStoreWriteUncached(
   ctx: Pick<WriteTransactionContext, "graphId" | "schemaVersion">,
   backend: GraphBackend | TransactionBackend,
 ): Promise<void> {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -273,6 +273,7 @@ import {
 } from "./operations";
 import {
   runInWriteTransaction,
+  withTransactionSchemaFenceLease,
   withWriteTransactionSession,
 } from "./operations/write-transaction";
 import {
@@ -3046,14 +3047,19 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     // never touches fulltext requires no fulltext initialization.
     //
     // A schema-version fence is acquired and validated at every managed write
-    // when this Store came from schema reconciliation. Rechecking is required
-    // because adapter-native SQL can roll back a savepoint and release a
-    // PostgreSQL row lock acquired after it. Snapshot-isolated transactions
-    // retain their normal serialization-failure semantics rather than
-    // validating a stale version after a concurrent commit. The separate
-    // recorded graph lock is still taken at each write boundary; callers that
-    // need read-before-write serialization for graph data acquire that lock
-    // explicitly.
+    // when this Store came from schema reconciliation. A TypeGraph-owned Store
+    // transaction on a bundled backend is the narrow exception: its first
+    // managed write acquires the fence and leases that success to later
+    // managed writes. Such a callback has neither a nested transaction runner
+    // nor a native SQL handle, so no savepoint can predate that acquisition;
+    // adapter-native and caller-adopted transactions retain the per-write
+    // check because their raw SQL can roll back a savepoint and release a
+    // PostgreSQL row lock acquired after it.
+    // Snapshot-isolated transactions retain their normal serialization-failure
+    // semantics rather than validating a stale version after a concurrent
+    // commit. The separate recorded graph lock is still taken at each write
+    // boundary; callers that need read-before-write serialization for graph
+    // data acquire that lock explicitly.
     //
     // Operation hooks inside the callback run BUFFERED: an operation nested
     // in this transaction completes only when the transaction commits, so its
@@ -3085,8 +3091,19 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
               runBulkHooks,
             ),
           );
+        const invokeWithSchemaFenceLease = (): Promise<T> =>
+          this.#adapterBackend === undefined ?
+            withTransactionSchemaFenceLease(
+              {
+                graphId: this.graphId,
+                schemaVersion: this.#schemaMetadata.schemaVersion,
+              },
+              txBackend,
+              invokeTransaction,
+            )
+          : invokeTransaction();
         if (!this.#captureEnabled && !this.#revisionTrackingEnabled) {
-          return invokeTransaction();
+          return invokeWithSchemaFenceLease();
         }
         return withWriteTransactionSession(
           txBackend,
@@ -3097,7 +3114,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
             revisionTrackingEnabled: this.#revisionTrackingEnabled,
             revisionSchema: this.#sqlSchema(),
           },
-          invokeTransaction,
+          invokeWithSchemaFenceLease,
         );
       };
       const result =

--- a/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
@@ -747,6 +747,45 @@ describe("PGlite backend", () => {
       expect(await store.nodes.Person.getById(result.bob.id)).toBeDefined();
     });
 
+    it("leases the schema fence once for a TypeGraph-owned transaction", async () => {
+      const client = await PGlite.create();
+      cleanups.push(() => client.close());
+      await client.exec(generatePostgresDDL().join("\n\n"));
+      const statements: string[] = [];
+      const backend = createPostgresBackend(
+        drizzle(client, {
+          logger: {
+            logQuery(query: string) {
+              statements.push(query);
+            },
+          },
+        }),
+        { vector: false },
+      );
+      const [store] = await createStoreWithSchema(peopleGraph, backend);
+
+      statements.length = 0;
+      await store.transaction((tx) => tx.nodes.Person.count());
+
+      // Merely opening a portable transaction stays read-only: eligibility is
+      // registered before the callback, but its schema fence is lazy.
+      expect(
+        statements.filter((statement) => /for share/i.test(statement)),
+      ).toHaveLength(0);
+
+      statements.length = 0;
+      await store.transaction(async (tx) => {
+        await tx.nodes.Person.create({ name: "Alice" }, { id: "alice" });
+        await tx.nodes.Person.create({ name: "Bob" }, { id: "bob" });
+      });
+
+      // Replacing the leased-fence fast path with the ordinary per-write
+      // fence makes this count 2.
+      expect(
+        statements.filter((statement) => /for share/i.test(statement)),
+      ).toHaveLength(1);
+    });
+
     it("disables vector with vector: false (no extension, CRUD still works)", async () => {
       const { backend } = await createLocalPgliteBackend({ vector: false });
       cleanups.push(() => backend.close());

--- a/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
+++ b/packages/typegraph/tests/backends/postgres/recorded-lock-churn.test.ts
@@ -92,7 +92,53 @@ function graphWriteLockCount(statements: readonly LoggedStatement[]): number {
   ).length;
 }
 
+function schemaFenceLockCount(statements: readonly LoggedStatement[]): number {
+  return statements.filter((statement) => /for share/i.test(statement.query))
+    .length;
+}
+
 describe("recorded graph-write advisory lock churn", () => {
+  it("leases one schema fence to every write in a TypeGraph-owned transaction", async (ctx) => {
+    const activePool = requirePostgres(ctx);
+    const statements: LoggedStatement[] = [];
+    const backend = createPostgresBackend(
+      drizzle(activePool, {
+        logger: {
+          logQuery(query: string, params: unknown[]) {
+            statements.push({ query, params });
+          },
+        },
+      }),
+    );
+    // `createStoreWithSchema`, rather than `createAdapterStoreWithSchema`,
+    // deliberately exposes the portable Store transaction surface. It has no
+    // `tx.sql`, so the fence acquired before its callback cannot have been
+    // acquired after a caller-controlled savepoint.
+    const [store] = await createStoreWithSchema(
+      buildGraph("schema_fence_lease_churn"),
+      backend,
+    );
+
+    statements.length = 0;
+    await store.transaction(async (tx) => {
+      await tx.nodes.Person.create({ name: "first" }, { id: "first" });
+      await tx.nodes.Person.create({ name: "second" }, { id: "second" });
+    });
+
+    // Removing the transaction-local lease makes this 2: each create calls
+    // the same `lockSchemaVersionForWrite` fence independently.
+    expect(schemaFenceLockCount(statements)).toBe(1);
+
+    statements.length = 0;
+    await store.transaction(async (tx) => {
+      await tx.nodes.Person.create({ name: "third" }, { id: "third" });
+    });
+
+    // The lease belongs to the transaction target, never the pool/root
+    // backend, so a new transaction always validates again.
+    expect(schemaFenceLockCount(statements)).toBe(1);
+  });
+
   it("acquires the lock once per transaction, not once per write", async (ctx) => {
     const activePool = requirePostgres(ctx);
     const statements: LoggedStatement[] = [];

--- a/packages/typegraph/tests/create-round-trips.test.ts
+++ b/packages/typegraph/tests/create-round-trips.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import {
   type CompiledRowsSql,
+  createStoreWithSchema,
   DatabaseOperationError,
   defineGraph,
   defineNode,
@@ -135,6 +136,47 @@ function countingBackend(targetId: string): Readonly<{
       counts.foldProbes = 0;
     },
   };
+}
+
+/**
+ * A transaction wrapper TypeGraph did not create. Its target is intentionally
+ * not first-party marked, so schema-fence leasing must keep the conservative
+ * per-write behavior rather than inferring savepoint lifetime from the outer
+ * backend's dialect.
+ */
+function customTransactionFenceBackend(): Readonly<{
+  backend: GraphBackend;
+  schemaFenceCalls: () => number;
+}> {
+  const base = createTestBackend();
+  let calls = 0;
+  const backend: GraphBackend = deriveBackend(base, {
+    transaction: (fn, options) =>
+      base.transaction((target) => {
+        const customTarget = new Proxy(target, {
+          get(source, property, receiver) {
+            const value: unknown = Reflect.get(source, property, receiver);
+            if (
+              property !== "lockSchemaVersionForWrite" ||
+              typeof value !== "function"
+            ) {
+              return value;
+            }
+            const lockSchemaVersionForWrite = value as NonNullable<
+              TransactionBackend["lockSchemaVersionForWrite"]
+            >;
+            return (
+              params: Parameters<typeof lockSchemaVersionForWrite>[0],
+            ) => {
+              calls += 1;
+              return lockSchemaVersionForWrite(params);
+            };
+          },
+        });
+        return fn(customTarget);
+      }, options),
+  });
+  return { backend, schemaFenceCalls: () => calls };
 }
 
 function peerResurrectionBackend(targetId: string): GraphBackend {
@@ -278,7 +320,34 @@ describe("the read-counting double itself", () => {
   });
 });
 
+describe("transaction-scoped backend contract", () => {
+  it("does not expose a nested transaction runner", async () => {
+    const backend = createTestBackend();
+    await backend.transaction((target) => {
+      // `runInWriteTransaction` receives this target. Without a top-level
+      // transaction runner, `runOptionallyInTransaction` cannot open an
+      // internal savepoint before the lazy schema-fence acquisition.
+      expect("transaction" in target).toBe(false);
+      return Promise.resolve();
+    });
+  });
+});
+
 describe("create-path round trips", () => {
+  it("keeps schema fencing per-write for a custom transaction target", async () => {
+    const observed = customTransactionFenceBackend();
+    const [store] = await createStoreWithSchema(plainGraph, observed.backend);
+
+    await store.transaction(async (tx) => {
+      await tx.nodes.Person.create({ name: "First" }, { id: "first" });
+      await tx.nodes.Person.create({ name: "Second" }, { id: "second" });
+    });
+
+    // The target's unmarked wrapper could implement arbitrary savepoint
+    // semantics, so it must not borrow the bundled backend's lease.
+    expect(observed.schemaFenceCalls()).toBe(2);
+  });
+
   it("reads the created id exactly once on a plain graph", async () => {
     const { backend, counts, reset } = countingBackend("solo");
     const store = await createInitializedStore(plainGraph, backend);


### PR DESCRIPTION
Portable `Store.transaction()` callbacks on bundled backends now acquire the schema-version fence lazily on their first managed write and reuse it for later writes on that exact transaction target and expected version. Read-only transactions add no fence, while adapter/adopted and custom transaction targets retain conservative per-write fencing.

The scope is intentionally transaction-local: no Store, backend, pool-connection, or cross-transaction cache is introduced. Portable transaction targets expose neither native SQL nor nested `transaction()`, so no savepoint can predate the leased lock; the existing raw-savepoint regression remains on the per-write path. Two writes now emit one fence instead of two, and disabling reuse makes the load-bearing count test fail.

Part of #533.