### PR TITLE
perf(store): autocommit atomic single-statement writes

### DIFF
--- a/.changeset/autocommit-single-statement-writes.md
+++ b/.changeset/autocommit-single-statement-writes.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Avoid explicit transaction framing for bundled-backend schema-managed generated node and unconstrained edge creates when their complete write contract is one fused SQL statement.

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -3137,12 +3137,12 @@ export const UNBUNDLED_OPTIONAL_MEMBERS: {
     readonly insertNodeWithSchemaFence: {
         readonly kind: "reasoned";
         readonly reason: "Same first-party schema-fenced node insert family; generated ids use it only when no earlier lock-bearing work is required.";
-        readonly accesses: 6;
+        readonly accesses: 7;
     };
     readonly insertEdgeIfEndpointsLiveWithSchemaFence: {
         readonly kind: "reasoned";
         readonly reason: "First-party schema-fenced endpoint insert fast path; custom backends retain the existing endpoint-read and ordinary schema-fence path.";
-        readonly accesses: 7;
+        readonly accesses: 8;
     };
     readonly insertEdgeIfEndpointsLive: {
         readonly kind: "reasoned";

--- a/packages/typegraph/src/backend/capabilities/autocommit-single-statement.ts
+++ b/packages/typegraph/src/backend/capabilities/autocommit-single-statement.ts
@@ -1,0 +1,26 @@
+/**
+ * Origin evidence for the managed single-statement autocommit fast path.
+ *
+ * This is intentionally narrower than schema-fenced-insert eligibility. The
+ * latter follows bundled transaction targets and derived wrappers because its
+ * statement still runs inside an explicit transaction. Here, omitting that
+ * transaction is the optimization, so only the literal root objects produced
+ * by the bundled factories may opt in. In particular, this evidence is never
+ * carried through `deriveBackend`, an owned transaction, or adoption of a
+ * caller-owned transaction.
+ */
+
+const BUNDLED_ROOT_AUTOCOMMIT_BACKENDS = new WeakSet<object>();
+
+/** @internal Called only by bundled factories after their root backend exists. */
+export function markBundledRootAutocommitEligible<T extends object>(
+  target: T,
+): T {
+  BUNDLED_ROOT_AUTOCOMMIT_BACKENDS.add(target);
+  return target;
+}
+
+/** Whether this is the exact root backend a bundled factory created. */
+export function isBundledRootAutocommitEligible(target: object): boolean {
+  return BUNDLED_ROOT_AUTOCOMMIT_BACKENDS.has(target);
+}

--- a/packages/typegraph/src/backend/capabilities/bundle-registry.ts
+++ b/packages/typegraph/src/backend/capabilities/bundle-registry.ts
@@ -840,13 +840,13 @@ export const UNBUNDLED_OPTIONAL_MEMBERS = {
     kind: "reasoned",
     reason:
       "Same first-party schema-fenced node insert family; generated ids use it only when no earlier lock-bearing work is required.",
-    accesses: 6,
+    accesses: 7,
   },
   insertEdgeIfEndpointsLiveWithSchemaFence: {
     kind: "reasoned",
     reason:
       "First-party schema-fenced endpoint insert fast path; custom backends retain the existing endpoint-read and ordinary schema-fence path.",
-    accesses: 7,
+    accesses: 8,
   },
   insertEdgeIfEndpointsLive: {
     kind: "reasoned",

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -79,6 +79,7 @@ import {
   isMissingTableError,
   isPostgresConcurrentDdlRaceError,
 } from "../../utils/sql-errors";
+import { markBundledRootAutocommitEligible } from "../capabilities/autocommit-single-statement";
 import { assertBundledCapabilityDeclarations } from "../capabilities/declarations";
 import { markSchemaFencedInsertEligible } from "../capabilities/schema-fenced-insert";
 import { markFirstPartyFactory } from "../capabilities/write-fence";
@@ -1840,6 +1841,7 @@ export function createPostgresBackend(
   // declared capabilities while still carrying this mark.
   markFirstPartyFactory(backend);
   markSchemaFencedInsertEligible(backend);
+  markBundledRootAutocommitEligible(backend);
   return backend;
 }
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -57,6 +57,7 @@ import {
   isMissingTableError,
   isSqliteNotAuthorizedError,
 } from "../../utils/sql-errors";
+import { markBundledRootAutocommitEligible } from "../capabilities/autocommit-single-statement";
 import { assertBundledCapabilityDeclarations } from "../capabilities/declarations";
 import { markSchemaFencedInsertEligible } from "../capabilities/schema-fenced-insert";
 import { markFirstPartyFactory } from "../capabilities/write-fence";
@@ -2394,6 +2395,7 @@ export function createSqliteBackend(
   // declared capabilities while still carrying this mark.
   markFirstPartyFactory(backend);
   markSchemaFencedInsertEligible(backend);
+  markBundledRootAutocommitEligible(backend);
 
   return backend;
 }

--- a/packages/typegraph/src/backend/postgres/pglite.ts
+++ b/packages/typegraph/src/backend/postgres/pglite.ts
@@ -41,6 +41,7 @@ import { type Extension, PGlite } from "@electric-sql/pglite";
 import { drizzle, type PgliteDatabase } from "drizzle-orm/pglite";
 
 import { ConfigurationError } from "../../errors";
+import { markBundledRootAutocommitEligible } from "../capabilities/autocommit-single-statement";
 import { wrapWithManagedClose } from "../derive-backend";
 export type { GraphIdentityConfig } from "../../core/define-graph";
 import {
@@ -210,7 +211,11 @@ export async function createLocalPgliteBackend(
       await client.close();
     });
 
-    return { backend: managedBackend, db, client };
+    return {
+      backend: markBundledRootAutocommitEligible(managedBackend),
+      db,
+      client,
+    };
   } catch (error) {
     return closeAfterFailure(client, error);
   }

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -31,6 +31,7 @@ import {
 
 import { ConfigurationError } from "../../errors";
 import { sqliteVecStrategy } from "../../query/dialect/vector/sqlite-vec-strategy";
+import { markBundledRootAutocommitEligible } from "../capabilities/autocommit-single-statement";
 import { wrapWithManagedClose } from "../derive-backend";
 import { generateSqliteDDL } from "../drizzle/ddl";
 import { type AnySqliteDatabase } from "../drizzle/execution";
@@ -365,7 +366,7 @@ export function createLocalSqliteBackend(
       sqlite.close();
     });
 
-    return { backend: managedBackend, db };
+    return { backend: markBundledRootAutocommitEligible(managedBackend), db };
   } catch (error) {
     try {
       sqlite.close();

--- a/packages/typegraph/src/store/operations/autocommit-single-statement.ts
+++ b/packages/typegraph/src/store/operations/autocommit-single-statement.ts
@@ -1,0 +1,97 @@
+/**
+ * The sole classifier for managed writes that may omit an explicit transaction.
+ *
+ * A qualifying operation has exactly one stateful SQL statement. Its schema
+ * fence, and (for edges) endpoint verdict, live inside that statement. Every
+ * other managed-write shape retains `runInWriteTransaction`: an option here is
+ * either applied by that one statement or this classifier refuses the path.
+ */
+import { type z } from "zod";
+
+import { isBundledRootAutocommitEligible } from "../../backend/capabilities/autocommit-single-statement";
+import { type GraphBackend } from "../../backend/types";
+import { getEmbeddingFields } from "../embedding-sync";
+import { getSearchableFields } from "../fulltext-sync";
+
+export type NodeAutocommitSingleStatementCandidate = Readonly<{
+  backend: GraphBackend;
+  schemaVersion: number | undefined;
+  historyEnabled: boolean;
+  revisionTrackingEnabled: boolean;
+  identityEnabled: boolean;
+  idGenerated: boolean;
+  kindRegistered: boolean;
+  uniqueConstraintCount: number;
+  disjointKindCount: number;
+  schema: z.ZodType;
+}>;
+
+export type EdgeAutocommitSingleStatementCandidate = Readonly<{
+  backend: GraphBackend;
+  schemaVersion: number | undefined;
+  historyEnabled: boolean;
+  revisionTrackingEnabled: boolean;
+  idGenerated: boolean;
+  kindRegistered: boolean;
+  convergesOnMatchKey: boolean;
+  cardinality: "many" | "one" | "unique" | "oneActive";
+}>;
+
+export type AutocommitSingleStatementCandidate =
+  | Readonly<{
+      kind: "node";
+      candidate: NodeAutocommitSingleStatementCandidate;
+    }>
+  | Readonly<{
+      kind: "edge";
+      candidate: EdgeAutocommitSingleStatementCandidate;
+    }>;
+
+/**
+ * Returns true only for a bundled root's fully fused, one-statement write.
+ *
+ * This deliberately does not infer an opt-in from capability names or from a
+ * custom backend implementing the fused members: a custom proxy can introduce
+ * arbitrary work around a member call. The private root provenance is the
+ * contract that makes direct autocommit safe.
+ */
+export function isAutocommitSingleStatementWrite(
+  input: AutocommitSingleStatementCandidate,
+): boolean {
+  switch (input.kind) {
+    case "node": {
+      const candidate = input.candidate;
+      return (
+        candidate.schemaVersion !== undefined &&
+        candidate.backend.capabilities.transactions &&
+        isBundledRootAutocommitEligible(candidate.backend) &&
+        !candidate.historyEnabled &&
+        !candidate.revisionTrackingEnabled &&
+        !candidate.identityEnabled &&
+        candidate.idGenerated &&
+        candidate.kindRegistered &&
+        candidate.uniqueConstraintCount === 0 &&
+        candidate.disjointKindCount === 0 &&
+        getEmbeddingFields(candidate.schema).length === 0 &&
+        getSearchableFields(candidate.schema).length === 0 &&
+        candidate.backend.insertNodeWithSchemaFence !== undefined
+      );
+    }
+
+    case "edge": {
+      const candidate = input.candidate;
+      return (
+        candidate.schemaVersion !== undefined &&
+        candidate.backend.capabilities.transactions &&
+        isBundledRootAutocommitEligible(candidate.backend) &&
+        !candidate.historyEnabled &&
+        !candidate.revisionTrackingEnabled &&
+        candidate.idGenerated &&
+        candidate.kindRegistered &&
+        !candidate.convergesOnMatchKey &&
+        candidate.cardinality === "many" &&
+        candidate.backend.insertEdgeIfEndpointsLiveWithSchemaFence !== undefined
+      );
+    }
+  }
+}

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -150,6 +150,7 @@ import {
   validityEndAfterMutation,
 } from "../validity-end";
 import { withAlreadyExistsTranslation } from "./already-exists";
+import { isAutocommitSingleStatementWrite } from "./autocommit-single-statement";
 import { createEdgeBatchValidationBackend } from "./edge-batch-validation";
 import {
   assertEdgeIdentityMatches,
@@ -161,7 +162,11 @@ import {
   withUnmatchedEdgeUpdateRefusal,
 } from "./edge-write-fences";
 import { type EdgeUpdateWork } from "./edge-write-pipeline";
-import { runHookedWritePlan, runWritePlan } from "./write-executor";
+import {
+  runAutocommitSingleStatementWritePlan,
+  runHookedWritePlan,
+  runWritePlan,
+} from "./write-executor";
 import {
   assertsStoredWindowState,
   type EdgeUpdateFences,
@@ -527,128 +532,145 @@ async function executeEdgeCreateInternal<G extends GraphDef>(
     convergeOn === undefined &&
     edgeCardinality(ctx, kind) === "many" &&
     backend.insertEdgeIfEndpointsLiveWithSchemaFence !== undefined;
-
-  return runHookedWritePlan(
-    ctx,
-    opContext,
-    // A create that runs a cardinality probe, or one converging on a match
-    // key, decides something the write must not have invalidated. A plain
-    // `many` create decides nothing and takes no lock.
-    edgeWritePlan(
-      convergeOn === undefined ?
-        edgeWriteNeedsConstraintFence(edgeCardinality(ctx, kind))
-      : "edgeMatchKeyConvergence",
-    ),
-    backend,
-    async (session, target): Promise<Edge | undefined> => {
-      // See node create's matching receiver check: a custom transaction
-      // wrapper may replace the marked outer backend with an unmarked target.
-      // Fall back to the ordinary fence before any row work in that case.
-      const targetBackend = unfencedTarget(target);
-      const fuseSchemaFenceInFirstWrite =
-        schemaFenceInFirstWrite && isSchemaFencedInsertEligible(targetBackend);
-      if (schemaFenceInFirstWrite && !fuseSchemaFenceInFirstWrite) {
-        await lockSchemaVersionForStoreWrite(ctx, targetBackend);
-      }
-      if (convergeOn !== undefined) {
-        const candidateRows = await target.findEdgesByKind({
-          graphId: ctx.graphId,
-          kind,
-          fromKind: input.fromKind,
-          fromId: input.fromId,
-          toKind: input.toKind,
-          toId: input.toId,
-          excludeDeleted: false,
-          temporalMode: "includeTombstones",
-        });
-        const { liveRow, deletedRow } = findMatchingEdge(
-          candidateRows,
-          convergeOn.matchOn,
-          convergeOn.props,
-        );
-        if (liveRow !== undefined || deletedRow !== undefined) {
-          throw new EdgeConvergenceRaced(kind);
-        }
-      }
-
-      const declaredCardinality = edgeCardinality(ctx, kind);
-      const usesGuardedCardinalityClaim =
-        declaredCardinality !== "many" &&
-        edgeCardinalityClaimMode(target, ctx.claimsVerdict()).kind ===
-          "guarded";
-      const canFuseEndpointCheck =
-        input.id === undefined &&
-        convergeOn === undefined &&
-        (declaredCardinality === "many" || usesGuardedCardinalityClaim) &&
-        (target.insertEdgeIfEndpointsLive !== undefined ||
-          (fuseSchemaFenceInFirstWrite &&
-            target.insertEdgeIfEndpointsLiveWithSchemaFence !== undefined));
-      let prepared = await validateAndPrepareEdgeCreate(
-        ctx,
-        input,
-        id,
-        target,
-        {
-          validateEndpoints: !canFuseEndpointCheck,
-          validateCardinality: !usesGuardedCardinalityClaim,
-        },
-      );
-
-      // A plain, generated-id `many` edge owes no cardinality claim and no
-      // sidecar. Its only pre-insert database reads were endpoint existence
-      // probes, so first-party backends can make their live-node predicates
-      // part of the INSERT ... SELECT itself. Do not infer an endpoint error
-      // from an empty RETURNING result: retry the ordinary ordered validation
-      // below, which preserves source-before-target typed refusals and handles
-      // a concurrent endpoint revival before we report anything.
-      if (canFuseEndpointCheck) {
-        const fusedWork = edgeInsertWork(prepared);
-        const fusedRow = await withAlreadyExistsTranslation("edge", () =>
-          fuseSchemaFenceInFirstWrite ?
-            session.createEdgeIfEndpointsLiveWithSchemaFence(
-              prepared.insertParams,
-              {
-                graphId: ctx.graphId,
-                expectedVersion: requireDefined(ctx.schemaVersion),
-              },
-            )
-          : session.createEdgeIfEndpointsLive(fusedWork),
-        );
-        if (fusedRow !== undefined) return rowToEdge(fusedRow);
-
-        if (fuseSchemaFenceInFirstWrite) {
-          await diagnoseFusedSchemaFenceNoRow(ctx, targetBackend);
-        }
-
-        prepared = await validateAndPrepareEdgeCreate(ctx, input, id, target, {
-          validateCardinality: !usesGuardedCardinalityClaim,
-        });
-      }
-
-      // An edge create has no existence probe at all — its id is either
-      // caller-supplied or freshly generated — so the engine's refusal is the ONLY
-      // report that the id is taken. Translated here, that report is the same
-      // already-exists error a node create raises. The translation spans the fused
-      // unit — the claim and the row — which is inert for the claim half: a
-      // contended claim raises a `CardinalityError`, never a duplicate-key insert
-      // report.
-      //
-      // The claim is DECIDED here (a pure function of the cardinality this
-      // preparation resolved) and ISSUED by the session, before the row it gates:
-      // the probe above read a population no key fences, so the claim row is what
-      // stops a concurrent writer that read the same population from also
-      // committing, and a refusal there has written no edge row.
-      const work = edgeInsertWork(prepared);
-      const row = await withAlreadyExistsTranslation("edge", async () => {
-        if (shouldReturnRow) return session.createEdge(work);
-        await session.createEdgeNoReturn(work);
-        return;
-      });
-
-      return row === undefined ? undefined : rowToEdge(row);
-    },
-    { schemaFenceInFirstWrite },
+  const autocommitBackend = "transaction" in backend ? backend : undefined;
+  const autocommitSingleStatement =
+    autocommitBackend !== undefined &&
+    hasOwnKey(ctx.graph.edges, kind) &&
+    isAutocommitSingleStatementWrite({
+      kind: "edge",
+      candidate: {
+        backend: autocommitBackend,
+        schemaVersion: ctx.schemaVersion,
+        historyEnabled: ctx.historyEnabled,
+        revisionTrackingEnabled: ctx.revisionTrackingEnabled,
+        idGenerated: input.id === undefined,
+        kindRegistered: true,
+        convergesOnMatchKey: convergeOn !== undefined,
+        cardinality: edgeCardinality(ctx, kind),
+      },
+    });
+  const plan = edgeWritePlan(
+    convergeOn === undefined ?
+      edgeWriteNeedsConstraintFence(edgeCardinality(ctx, kind))
+    : "edgeMatchKeyConvergence",
   );
+
+  const rowWork = async (
+    session: EdgeWriteSession,
+    target: WriteTarget,
+  ): Promise<Edge | undefined> => {
+    // See node create's matching receiver check: a custom transaction
+    // wrapper may replace the marked outer backend with an unmarked target.
+    // Fall back to the ordinary fence before any row work in that case.
+    const targetBackend = unfencedTarget(target);
+    const fuseSchemaFenceInFirstWrite =
+      schemaFenceInFirstWrite && isSchemaFencedInsertEligible(targetBackend);
+    if (schemaFenceInFirstWrite && !fuseSchemaFenceInFirstWrite) {
+      await lockSchemaVersionForStoreWrite(ctx, targetBackend);
+    }
+    if (convergeOn !== undefined) {
+      const candidateRows = await target.findEdgesByKind({
+        graphId: ctx.graphId,
+        kind,
+        fromKind: input.fromKind,
+        fromId: input.fromId,
+        toKind: input.toKind,
+        toId: input.toId,
+        excludeDeleted: false,
+        temporalMode: "includeTombstones",
+      });
+      const { liveRow, deletedRow } = findMatchingEdge(
+        candidateRows,
+        convergeOn.matchOn,
+        convergeOn.props,
+      );
+      if (liveRow !== undefined || deletedRow !== undefined) {
+        throw new EdgeConvergenceRaced(kind);
+      }
+    }
+
+    const declaredCardinality = edgeCardinality(ctx, kind);
+    const usesGuardedCardinalityClaim =
+      declaredCardinality !== "many" &&
+      edgeCardinalityClaimMode(target, ctx.claimsVerdict()).kind === "guarded";
+    const canFuseEndpointCheck =
+      input.id === undefined &&
+      convergeOn === undefined &&
+      (declaredCardinality === "many" || usesGuardedCardinalityClaim) &&
+      (target.insertEdgeIfEndpointsLive !== undefined ||
+        (fuseSchemaFenceInFirstWrite &&
+          target.insertEdgeIfEndpointsLiveWithSchemaFence !== undefined));
+    let prepared = await validateAndPrepareEdgeCreate(ctx, input, id, target, {
+      validateEndpoints: !canFuseEndpointCheck,
+      validateCardinality: !usesGuardedCardinalityClaim,
+    });
+
+    // A plain, generated-id `many` edge owes no cardinality claim and no
+    // sidecar. Its only pre-insert database reads were endpoint existence
+    // probes, so first-party backends can make their live-node predicates
+    // part of the INSERT ... SELECT itself. Do not infer an endpoint error
+    // from an empty RETURNING result: retry the ordinary ordered validation
+    // below, which preserves source-before-target typed refusals and handles
+    // a concurrent endpoint revival before we report anything.
+    if (canFuseEndpointCheck) {
+      const fusedWork = edgeInsertWork(prepared);
+      const fusedRow = await withAlreadyExistsTranslation("edge", () =>
+        fuseSchemaFenceInFirstWrite ?
+          session.createEdgeIfEndpointsLiveWithSchemaFence(
+            prepared.insertParams,
+            {
+              graphId: ctx.graphId,
+              expectedVersion: requireDefined(ctx.schemaVersion),
+            },
+          )
+        : session.createEdgeIfEndpointsLive(fusedWork),
+      );
+      if (fusedRow !== undefined) return rowToEdge(fusedRow);
+
+      if (fuseSchemaFenceInFirstWrite) {
+        await diagnoseFusedSchemaFenceNoRow(ctx, targetBackend);
+      }
+
+      prepared = await validateAndPrepareEdgeCreate(ctx, input, id, target, {
+        validateCardinality: !usesGuardedCardinalityClaim,
+      });
+    }
+
+    // An edge create has no existence probe at all — its id is either
+    // caller-supplied or freshly generated — so the engine's refusal is the ONLY
+    // report that the id is taken. Translated here, that report is the same
+    // already-exists error a node create raises. The translation spans the fused
+    // unit — the claim and the row — which is inert for the claim half: a
+    // contended claim raises a `CardinalityError`, never a duplicate-key insert
+    // report.
+    //
+    // The claim is DECIDED here (a pure function of the cardinality this
+    // preparation resolved) and ISSUED by the session, before the row it gates:
+    // the probe above read a population no key fences, so the claim row is what
+    // stops a concurrent writer that read the same population from also
+    // committing, and a refusal there has written no edge row.
+    const work = edgeInsertWork(prepared);
+    const row = await withAlreadyExistsTranslation("edge", async () => {
+      if (shouldReturnRow) return session.createEdge(work);
+      await session.createEdgeNoReturn(work);
+      return;
+    });
+
+    return row === undefined ? undefined : rowToEdge(row);
+  };
+
+  if (autocommitSingleStatement) {
+    return runAutocommitSingleStatementWritePlan(
+      ctx,
+      opContext,
+      plan,
+      autocommitBackend,
+      rowWork,
+    );
+  }
+  return runHookedWritePlan(ctx, opContext, plan, backend, rowWork, {
+    schemaFenceInFirstWrite,
+  });
 }
 
 /**

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -156,9 +156,11 @@ import {
   createAlreadyExistsError,
   withAlreadyExistsTranslation,
 } from "./already-exists";
+import { isAutocommitSingleStatementWrite } from "./autocommit-single-statement";
 import { type NodeInsertSyncItem } from "./node-write-pipeline";
 import {
   type HookedWritePlanContext,
+  runAutocommitSingleStatementWritePlan,
   runHookedWritePlan,
   runWritePlan,
 } from "./write-executor";
@@ -1773,145 +1775,183 @@ async function executeNodeCreateInternal<G extends GraphDef>(
     input,
     backend,
   );
+  const autocommitBackend = "transaction" in backend ? backend : undefined;
+  const registeredKind =
+    hasOwnKey(ctx.graph.nodes, kind) ?
+      getNodeRegistration(ctx.graph, kind)
+    : undefined;
+  const autocommitSingleStatement =
+    autocommitBackend !== undefined &&
+    registeredKind !== undefined &&
+    isAutocommitSingleStatementWrite({
+      kind: "node",
+      candidate: {
+        backend: autocommitBackend,
+        schemaVersion: ctx.schemaVersion,
+        historyEnabled: ctx.historyEnabled,
+        revisionTrackingEnabled: ctx.revisionTrackingEnabled,
+        identityEnabled: ctx.identity !== undefined,
+        idGenerated: input.id === undefined,
+        kindRegistered: true,
+        uniqueConstraintCount: registeredKind.unique?.length ?? 0,
+        disjointKindCount: ctx.registry.getDisjointKinds(kind).length,
+        schema: registeredKind.type.schema,
+      },
+    });
+  const plan = nodeWritePlan(
+    nodeFencesConstraintProbe(ctx, kind, "create"),
+    nodeCreateRequiresIdentityLock(ctx, input),
+  );
 
-  return runHookedWritePlan(
-    nodeWritePlanContext(ctx),
-    opContext,
-    nodeWritePlan(
-      nodeFencesConstraintProbe(ctx, kind, "create"),
-      nodeCreateRequiresIdentityLock(ctx, input),
-    ),
-    backend,
-    async (session, target) => {
-      // The outer backend's mark chooses the optimistic plan, but a custom
-      // transaction wrapper can replace its callback target. Re-check the
-      // factory-owned origin at the actual write receiver before letting that
-      // receiver carry the schema fence; otherwise a wrapper that dropped the
-      // ordinary diagnostic fence could silently write a verified store.
-      const targetBackend = unfencedTarget(target);
-      const fuseSchemaFenceInFirstWrite =
-        schemaFenceInFirstWrite && isSchemaFencedInsertEligible(targetBackend);
-      if (schemaFenceInFirstWrite && !fuseSchemaFenceInFirstWrite) {
-        await lockSchemaVersionForStoreWrite(ctx, targetBackend);
-      }
-      const identity = ctx.identity;
-      const prepared = await validateAndPrepareNodeCreate(
+  const rowWork = async (
+    session: NodeWriteSession,
+    target: WriteTarget,
+  ): Promise<Node | undefined> => {
+    // The outer backend's mark chooses the optimistic plan, but a custom
+    // transaction wrapper can replace its callback target. Re-check the
+    // factory-owned origin at the actual write receiver before letting that
+    // receiver carry the schema fence; otherwise a wrapper that dropped the
+    // ordinary diagnostic fence could silently write a verified store.
+    const targetBackend = unfencedTarget(target);
+    const fuseSchemaFenceInFirstWrite =
+      schemaFenceInFirstWrite && isSchemaFencedInsertEligible(targetBackend);
+    if (schemaFenceInFirstWrite && !fuseSchemaFenceInFirstWrite) {
+      await lockSchemaVersionForStoreWrite(ctx, targetBackend);
+    }
+    const identity = ctx.identity;
+    const prepared = await validateAndPrepareNodeCreate(
+      ctx,
+      input,
+      id,
+      target,
+      options,
+    );
+
+    const existing = prepared.tombstone;
+    if (existing !== undefined) {
+      const resurrected = await resurrectPreparedNode(
         ctx,
-        input,
-        id,
+        session,
         target,
-        options,
+        prepared,
       );
-
-      const existing = prepared.tombstone;
-      if (existing !== undefined) {
-        const resurrected = await resurrectPreparedNode(
-          ctx,
-          session,
-          target,
-          prepared,
-        );
-        if (identity !== undefined) {
-          await identity.foldCreated(target, foldReferences([prepared]));
-        }
-        return shouldReturnRow ? rowToNode(resurrected) : undefined;
-      }
-
-      if (fuseSchemaFenceInFirstWrite) {
-        const schemaFence = {
-          graphId: ctx.graphId,
-          expectedVersion: requireDefined(ctx.schemaVersion),
-        };
-        const work = nodeInsertWork(prepared);
-        const inserted =
-          prepared.insertIfAbsent ?
-            await session.createNodeIfAbsentWithSchemaFence(work, schemaFence)
-          : await session.createNodeWithSchemaFence(work, schemaFence);
-        if (inserted !== undefined) {
-          return shouldReturnRow ? rowToNode(inserted) : undefined;
-        }
-
-        // The fused statement's empty result is intentionally ambiguous. Its
-        // ordinary active-schema diagnostic preserves the settled version in
-        // StaleVersionError.details.actual without a second PostgreSQL lock.
-        await diagnoseFusedSchemaFenceNoRow(ctx, targetBackend);
-        if (!prepared.insertIfAbsent) {
-          throw new DatabaseOperationError(
-            `Fresh node insert returned no row: ${prepared.kind} ${prepared.id}`,
-            { operation: "insert", entity: "node" },
-          );
-        }
-      }
-
-      if (prepared.insertIfAbsent) {
-        const inserted =
-          fuseSchemaFenceInFirstWrite ? undefined : (
-            await session.createNodeIfAbsent(nodeInsertWork(prepared))
-          );
-        if (inserted !== undefined) {
-          if (identity !== undefined) {
-            await identity.foldCreated(target, foldReferences([prepared]));
-          }
-          return shouldReturnRow ? rowToNode(inserted) : undefined;
-        }
-
-        // `ON CONFLICT DO NOTHING` leaves PostgreSQL's transaction usable. A
-        // single read now classifies the occupied slot, rather than paying it
-        // on every successful caller-supplied-id create.
-        const occupied = await target.getNode(
-          ctx.graphId,
-          prepared.kind,
-          prepared.id,
-        );
-        if (occupied === undefined) {
-          throw new DatabaseOperationError(
-            `Node disappeared after insert-if-absent conflict: ${prepared.kind} ${prepared.id}`,
-            { operation: "insert", entity: "node" },
-          );
-        }
-        if (occupied.deleted_at === undefined) {
-          throw createAlreadyExistsError("node", prepared.kind, prepared.id);
-        }
-        const resurrected = await resurrectPreparedNode(
-          ctx,
-          session,
-          target,
-          prepared,
-        );
-        if (identity !== undefined) {
-          await identity.foldCreated(target, foldReferences([prepared]));
-        }
-        return shouldReturnRow ? rowToNode(resurrected) : undefined;
-      }
-
-      // The existence probe above is not the last word: on an engine that does
-      // not serialize the two writers, a concurrent create of the same new id
-      // can commit between the probe and this INSERT, and only the engine's
-      // refusal reports it. Both routes to that conclusion raise the same error.
-      //
-      // The claims are the session's, at their declared placements: the
-      // pre-insert group gates the row and is compensated away if it does not
-      // land, the post-insert group follows it. The translation spans the fused
-      // unit — claims, row AND sidecars — because the session applies them
-      // together. That widening is inert: `isDuplicateKeyInsertError` fires only
-      // on a classified node-INSERT duplicate, which no claim, fulltext or
-      // embedding write raises. The alternative — the session owning the
-      // translation — would change import's create-leg error type on a lost
-      // race, which it must not.
-      const row = await withAlreadyExistsTranslation("node", async () => {
-        const work = nodeInsertWork(prepared);
-        if (shouldReturnRow) return session.createNode(work);
-        await session.createNodeNoReturn(work);
-        return;
-      });
-
       if (identity !== undefined) {
         await identity.foldCreated(target, foldReferences([prepared]));
       }
+      return shouldReturnRow ? rowToNode(resurrected) : undefined;
+    }
 
-      if (row === undefined) return;
-      return rowToNode(row);
-    },
+    if (fuseSchemaFenceInFirstWrite) {
+      const schemaFence = {
+        graphId: ctx.graphId,
+        expectedVersion: requireDefined(ctx.schemaVersion),
+      };
+      const work = nodeInsertWork(prepared);
+      const inserted =
+        prepared.insertIfAbsent ?
+          await session.createNodeIfAbsentWithSchemaFence(work, schemaFence)
+        : await session.createNodeWithSchemaFence(work, schemaFence);
+      if (inserted !== undefined) {
+        return shouldReturnRow ? rowToNode(inserted) : undefined;
+      }
+
+      // The fused statement's empty result is intentionally ambiguous. Its
+      // ordinary active-schema diagnostic preserves the settled version in
+      // StaleVersionError.details.actual without a second PostgreSQL lock.
+      await diagnoseFusedSchemaFenceNoRow(ctx, targetBackend);
+      if (!prepared.insertIfAbsent) {
+        throw new DatabaseOperationError(
+          `Fresh node insert returned no row: ${prepared.kind} ${prepared.id}`,
+          { operation: "insert", entity: "node" },
+        );
+      }
+    }
+
+    if (prepared.insertIfAbsent) {
+      const inserted =
+        fuseSchemaFenceInFirstWrite ? undefined : (
+          await session.createNodeIfAbsent(nodeInsertWork(prepared))
+        );
+      if (inserted !== undefined) {
+        if (identity !== undefined) {
+          await identity.foldCreated(target, foldReferences([prepared]));
+        }
+        return shouldReturnRow ? rowToNode(inserted) : undefined;
+      }
+
+      // `ON CONFLICT DO NOTHING` leaves PostgreSQL's transaction usable. A
+      // single read now classifies the occupied slot, rather than paying it
+      // on every successful caller-supplied-id create.
+      const occupied = await target.getNode(
+        ctx.graphId,
+        prepared.kind,
+        prepared.id,
+      );
+      if (occupied === undefined) {
+        throw new DatabaseOperationError(
+          `Node disappeared after insert-if-absent conflict: ${prepared.kind} ${prepared.id}`,
+          { operation: "insert", entity: "node" },
+        );
+      }
+      if (occupied.deleted_at === undefined) {
+        throw createAlreadyExistsError("node", prepared.kind, prepared.id);
+      }
+      const resurrected = await resurrectPreparedNode(
+        ctx,
+        session,
+        target,
+        prepared,
+      );
+      if (identity !== undefined) {
+        await identity.foldCreated(target, foldReferences([prepared]));
+      }
+      return shouldReturnRow ? rowToNode(resurrected) : undefined;
+    }
+
+    // The existence probe above is not the last word: on an engine that does
+    // not serialize the two writers, a concurrent create of the same new id
+    // can commit between the probe and this INSERT, and only the engine's
+    // refusal reports it. Both routes to that conclusion raise the same error.
+    //
+    // The claims are the session's, at their declared placements: the
+    // pre-insert group gates the row and is compensated away if it does not
+    // land, the post-insert group follows it. The translation spans the fused
+    // unit — claims, row AND sidecars — because the session applies them
+    // together. That widening is inert: `isDuplicateKeyInsertError` fires only
+    // on a classified node-INSERT duplicate, which no claim, fulltext or
+    // embedding write raises. The alternative — the session owning the
+    // translation — would change import's create-leg error type on a lost
+    // race, which it must not.
+    const row = await withAlreadyExistsTranslation("node", async () => {
+      const work = nodeInsertWork(prepared);
+      if (shouldReturnRow) return session.createNode(work);
+      await session.createNodeNoReturn(work);
+      return;
+    });
+
+    if (identity !== undefined) {
+      await identity.foldCreated(target, foldReferences([prepared]));
+    }
+
+    if (row === undefined) return;
+    return rowToNode(row);
+  };
+
+  if (autocommitSingleStatement) {
+    return runAutocommitSingleStatementWritePlan(
+      nodeWritePlanContext(ctx),
+      opContext,
+      plan,
+      autocommitBackend,
+      rowWork,
+    );
+  }
+  return runHookedWritePlan(
+    nodeWritePlanContext(ctx),
+    opContext,
+    plan,
+    backend,
+    rowWork,
     { schemaFenceInFirstWrite },
   );
 }

--- a/packages/typegraph/src/store/operations/write-executor.ts
+++ b/packages/typegraph/src/store/operations/write-executor.ts
@@ -20,7 +20,10 @@ import {
   type TransactionBackend,
 } from "../../backend/types";
 import { requireDefined } from "../../utils/presence";
-import { type GraphWriteLock } from "../recorded-capture/clock";
+import {
+  type GraphWriteLock,
+  uncapturedGraphWriteLock,
+} from "../recorded-capture/clock";
 import { type OperationHookContext } from "../types";
 import { type RowWorkKind, type WritePlan } from "./write-plan";
 import {
@@ -213,5 +216,27 @@ export function runHookedWritePlan<K extends RowWorkKind, T>(
     backend,
     planFrame(ctx, plan, rowWork),
     planTransactionOptions(plan, options),
+  );
+}
+
+/**
+ * Runs a proven single-statement write directly on a bundled root backend.
+ *
+ * The eligibility classifier is deliberately outside this generic executor:
+ * it owns the operation-specific proof that row work has no claim, sidecar,
+ * identity, capture, revision, or recovery statement. This helper owns only
+ * the resulting execution shape — no `BEGIN` / `COMMIT` and no transaction
+ * target — while preserving the ordinary hook boundary. A completed SQL
+ * statement is already durably committed, so `onOperationEnd` remains truthful.
+ */
+export function runAutocommitSingleStatementWritePlan<K extends RowWorkKind, T>(
+  ctx: HookedWritePlanContext,
+  opContext: OperationHookContext,
+  plan: WritePlan<K>,
+  backend: GraphBackend,
+  rowWork: WriteRowWork<K, T>,
+): Promise<T> {
+  return ctx.withOperationHooks(opContext, () =>
+    planFrame(ctx, plan, rowWork)(backend, uncapturedGraphWriteLock()),
   );
 }

--- a/packages/typegraph/tests/backends/postgres/schema-write-fence-race.test.ts
+++ b/packages/typegraph/tests/backends/postgres/schema-write-fence-race.test.ts
@@ -29,6 +29,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "vitest";
 import { z } from "zod";
 
@@ -177,6 +178,7 @@ describe.runIf(process.env["POSTGRES_URL"])(
     });
 
     afterEach(async () => {
+      vi.restoreAllMocks();
       // Only reached when a test failed before committing the held flip; the
       // connection may already be unusable, so the rollback is best-effort.
       if (flipHolder === undefined) return;
@@ -229,16 +231,8 @@ describe.runIf(process.env["POSTGRES_URL"])(
      * exactly when the fence wakes) is enough to hit it.
      */
     it("resolves the empty locked read without locking the row again", async () => {
-      const statements: string[] = [];
-      const backend = createPostgresBackend(
-        drizzle(requirePool(), {
-          logger: {
-            logQuery(query: string) {
-              statements.push(query);
-            },
-          },
-        }),
-      );
+      const querySpy = vi.spyOn(requirePool(), "query");
+      const backend = createPostgresBackend(drizzle(requirePool()));
       const [store] = await createStoreWithSchema(
         makeGraph(FENCE_GRAPH_ID),
         backend,
@@ -246,7 +240,7 @@ describe.runIf(process.env["POSTGRES_URL"])(
 
       flipHolder = await beginHeldSchemaFlip(FENCE_GRAPH_ID, 2);
 
-      statements.length = 0;
+      querySpy.mockClear();
       const rejection = store.nodes.Person.create({ name: "Alice" }).catch(
         (error: unknown) => error,
       );
@@ -259,6 +253,20 @@ describe.runIf(process.env["POSTGRES_URL"])(
       flipHolder = undefined;
 
       expect(await rejection).toBeInstanceOf(StaleVersionError);
+      const statements = querySpy.mock.calls.flatMap((call) => {
+        const query: unknown = call[0];
+        if (typeof query === "string") return [query];
+        if (
+          typeof query === "object" &&
+          query !== null &&
+          "text" in query &&
+          typeof query.text === "string"
+        ) {
+          return [query.text];
+        }
+        return [];
+      });
+      querySpy.mockRestore();
       expect(lockingReadCount(statements)).toBe(1);
     });
 

--- a/packages/typegraph/tests/bundle-member-access.test.ts
+++ b/packages/typegraph/tests/bundle-member-access.test.ts
@@ -33,11 +33,11 @@ const PILOT_COUNT = 0;
 const ANNOTATED_RESIDUE_COUNT = 7;
 const ANNOTATED_RESIDUE_PAIR_COUNT = 3;
 const STATICALLY_REQUIRED_COUNT = 2;
-const REASONED_FLOOR = 87;
+const REASONED_FLOOR = 89;
 const DEFERRED_LIVE_TOTAL = 194;
 const DEFERRED_DECLARED_TOTAL = 197;
 const EXCLUDED_COUNT = 4;
-const TOTAL_ROW_COUNT = 294;
+const TOTAL_ROW_COUNT = 296;
 
 function rowKey(
   row: Readonly<{ file: string; line: number; member: string }>,
@@ -170,7 +170,7 @@ describe("live bundle member access scan (I6, T21)", () => {
     expect(scan.byClass.deferred).toBe(DEFERRED_LIVE_TOTAL);
   });
 
-  it("the class partition covers every scanned row (total 294)", () => {
+  it("the class partition covers every scanned row (total 296)", () => {
     // STATICALLY_REQUIRED_SITES asserted positively: each must appear in the
     // scan output, so an arm-(b) regression that stops resolving them fails
     // loudly here rather than silently shrinking the bucket.

--- a/packages/typegraph/tests/capability-bundle-totality.test.ts
+++ b/packages/typegraph/tests/capability-bundle-totality.test.ts
@@ -108,7 +108,7 @@ describe("capability bundle totality (T9)", () => {
     }
   });
 
-  it("25 reasoned entries sum to 87 accesses; 48 deferred entries sum to 197", () => {
+  it("25 reasoned entries sum to 89 accesses; 48 deferred entries sum to 197", () => {
     const entries = Object.values(UNBUNDLED_OPTIONAL_MEMBERS);
     const reasoned = entries.filter((entry) => entry.kind === "reasoned");
     const deferred = entries.filter((entry) => entry.kind === "deferred");
@@ -124,7 +124,7 @@ describe("capability bundle totality (T9)", () => {
     // transaction and autocommit factories, adding the scanner's twelve
     // receiver-scoped accesses. The registry remains the source of truth;
     // this totality test is its deliberately visible sum.
-    expect(reasoned.reduce((sum, entry) => sum + entry.accesses, 0)).toBe(87);
+    expect(reasoned.reduce((sum, entry) => sum + entry.accesses, 0)).toBe(89);
     expect(deferred.reduce((sum, entry) => sum + entry.ceiling, 0)).toBe(197);
   });
 });

--- a/packages/typegraph/tests/schema-fused-insert.test.ts
+++ b/packages/typegraph/tests/schema-fused-insert.test.ts
@@ -33,6 +33,13 @@ import type {
   GraphBackend,
   TransactionBackend,
 } from "../src/backend/types";
+import { embedding } from "../src/core/embedding";
+import { searchable } from "../src/core/searchable";
+import {
+  type EdgeAutocommitSingleStatementCandidate,
+  isAutocommitSingleStatementWrite,
+  type NodeAutocommitSingleStatementCandidate,
+} from "../src/store/operations/autocommit-single-statement";
 import { requireDefined } from "../src/utils/presence";
 
 const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
@@ -82,24 +89,33 @@ function expectFusedWriteExecution(
   ).toHaveLength(1);
 }
 
+/** A root-autocommit fast path must emit only its fused INSERT. */
+function expectOneAutocommitWriteCommand(statements: readonly string[]): void {
+  expect(statements).toHaveLength(1);
+  expect(statements[0]?.toLowerCase()).toContain("insert into");
+  expect(statements[0]?.toLowerCase()).not.toContain("begin");
+  expect(statements[0]?.toLowerCase()).not.toContain("commit");
+}
+
 async function createRecordedPgliteBackend(): Promise<RecordedSqlBackend> {
   const client = await PGlite.create();
   await client.exec(generatePostgresDDL().join("\n\n"));
   const statements: string[] = [];
-  const backend = createPostgresBackend(
-    drizzlePglite(client, {
-      logger: {
-        logQuery(query: string): void {
-          statements.push(query);
-        },
-      },
-    }),
-    { vector: false },
-  );
+  const query = client.query.bind(client);
+  const querySpy = vi.spyOn(client, "query").mockImplementation((...args) => {
+    statements.push(args[0]);
+    return query(...args);
+  });
+  const backend = createPostgresBackend(drizzlePglite(client), {
+    vector: false,
+  });
 
   return {
     backend,
-    close: () => client.close(),
+    async close(): Promise<void> {
+      querySpy.mockRestore();
+      await client.close();
+    },
     reset: () => {
       statements.splice(0);
     },
@@ -346,11 +362,13 @@ describe("schema-fenced insert budget", () => {
       statements.splice(0);
       const alice = await store.nodes.Person.create({ name: "Alice" });
       expectFusedWriteExecution(statements, "typegraph_nodes");
+      expectOneAutocommitWriteCommand(statements);
 
       const bob = await store.nodes.Person.create({ name: "Bob" });
       statements.splice(0);
       await store.edges.knows.create(alice, bob, {});
       expectFusedWriteExecution(statements, "typegraph_edges");
+      expectOneAutocommitWriteCommand(statements);
     } finally {
       prepareSpy.mockRestore();
       await backend.close();
@@ -368,11 +386,13 @@ describe("schema-fenced insert budget", () => {
       recorded.reset();
       const alice = await store.nodes.Person.create({ name: "Alice" });
       expectFusedWriteExecution(recorded.statements, "typegraph_nodes");
+      expectOneAutocommitWriteCommand(recorded.statements);
 
       const bob = await store.nodes.Person.create({ name: "Bob" });
       recorded.reset();
       await store.edges.knows.create(alice, bob, {});
       expectFusedWriteExecution(recorded.statements, "typegraph_edges");
+      expectOneAutocommitWriteCommand(recorded.statements);
     } finally {
       await recorded.close();
     }
@@ -523,6 +543,94 @@ describe("schema-fenced insert budget", () => {
         backend,
         "schema_fused_continue_postgres",
       );
+    } finally {
+      await backend.close();
+    }
+  });
+});
+
+describe("single-statement autocommit eligibility", () => {
+  it("refuses every node guard and does not trust derived backends", async () => {
+    const { backend } = createLocalSqliteBackend();
+    const plainSchema = z.object({ name: z.string() });
+    const candidate: NodeAutocommitSingleStatementCandidate = {
+      backend,
+      schemaVersion: 1,
+      historyEnabled: false,
+      revisionTrackingEnabled: false,
+      identityEnabled: false,
+      idGenerated: true,
+      kindRegistered: true,
+      uniqueConstraintCount: 0,
+      disjointKindCount: 0,
+      schema: plainSchema,
+    };
+    const eligible = (
+      overrides: Partial<
+        Omit<NodeAutocommitSingleStatementCandidate, "schemaVersion">
+      > &
+        Readonly<{ schemaVersion?: number | undefined }> = {},
+    ) =>
+      isAutocommitSingleStatementWrite({
+        kind: "node",
+        candidate: { ...candidate, ...overrides },
+      });
+
+    try {
+      expect(eligible()).toBe(true);
+      expect(eligible({ schemaVersion: undefined })).toBe(false);
+      expect(eligible({ historyEnabled: true })).toBe(false);
+      expect(eligible({ revisionTrackingEnabled: true })).toBe(false);
+      expect(eligible({ identityEnabled: true })).toBe(false);
+      expect(eligible({ idGenerated: false })).toBe(false);
+      expect(eligible({ kindRegistered: false })).toBe(false);
+      expect(eligible({ uniqueConstraintCount: 1 })).toBe(false);
+      expect(eligible({ disjointKindCount: 1 })).toBe(false);
+      expect(eligible({ schema: z.object({ name: searchable() }) })).toBe(
+        false,
+      );
+      expect(eligible({ schema: z.object({ vector: embedding(2) }) })).toBe(
+        false,
+      );
+      expect(eligible({ backend: deriveBackend(backend, {}) })).toBe(false);
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("refuses every edge guard and only accepts a plain many-edge create", async () => {
+    const { backend } = createLocalSqliteBackend();
+    const candidate: EdgeAutocommitSingleStatementCandidate = {
+      backend,
+      schemaVersion: 1,
+      historyEnabled: false,
+      revisionTrackingEnabled: false,
+      idGenerated: true,
+      kindRegistered: true,
+      convergesOnMatchKey: false,
+      cardinality: "many" as const,
+    };
+    const eligible = (
+      overrides: Partial<
+        Omit<EdgeAutocommitSingleStatementCandidate, "schemaVersion">
+      > &
+        Readonly<{ schemaVersion?: number | undefined }> = {},
+    ) =>
+      isAutocommitSingleStatementWrite({
+        kind: "edge",
+        candidate: { ...candidate, ...overrides },
+      });
+
+    try {
+      expect(eligible()).toBe(true);
+      expect(eligible({ schemaVersion: undefined })).toBe(false);
+      expect(eligible({ historyEnabled: true })).toBe(false);
+      expect(eligible({ revisionTrackingEnabled: true })).toBe(false);
+      expect(eligible({ idGenerated: false })).toBe(false);
+      expect(eligible({ kindRegistered: false })).toBe(false);
+      expect(eligible({ convergesOnMatchKey: true })).toBe(false);
+      expect(eligible({ cardinality: "one" })).toBe(false);
+      expect(eligible({ backend: deriveBackend(backend, {}) })).toBe(false);
     } finally {
       await backend.close();
     }

--- a/packages/typegraph/tests/write-plan-statement-order.test.ts
+++ b/packages/typegraph/tests/write-plan-statement-order.test.ts
@@ -38,14 +38,24 @@
  * call sites above run through the executor; the executor case below is what
  * makes them bite at B0 as well.
  *
- * PGlite plus drizzle's `logger`, following `constraint-write-fence.test.ts`.
+ * PGlite's driver query boundary plus drizzle's logger. The driver boundary
+ * sees prepared root executions while the logger sees transaction-scoped
+ * executions, which PGlite routes through a separate transaction client.
  * ONE instance and ONE store for the whole table: instance creation plus DDL
  * costs about a second and the table is 20 cases wide, so it is paid once and
  * the statement log is cleared per case.
  */
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { z } from "zod";
 
 import {
@@ -167,13 +177,21 @@ const BULK_EDGE = asEdgeId<typeof knows>("edge-bulk");
 
 beforeAll(async () => {
   const client = await PGlite.create();
-  closeClient = () => client.close();
+  const query = client.query.bind(client);
+  const querySpy = vi.spyOn(client, "query").mockImplementation((...args) => {
+    statements.push({ query: args[0], params: args[1] ?? [] });
+    return query(...args);
+  });
+  closeClient = async () => {
+    querySpy.mockRestore();
+    await client.close();
+  };
   await client.exec(generatePostgresDDL().join("\n\n"));
   backend = createPostgresBackend(
     drizzle(client, {
       logger: {
-        logQuery(query: string, params: unknown[]): void {
-          statements.push({ query, params });
+        logQuery(queryText: string, params: unknown[]): void {
+          statements.push({ query: queryText, params });
         },
       },
     }),


### PR DESCRIPTION
Eligible schema-managed generated-ID node and unconstrained edge creates now execute as one autocommit SQL statement instead of BEGIN, fused INSERT, COMMIT. On high-RTT PostgreSQL links this removes two more sequential round trips from the successful path.

The selector is deliberately narrow: only exact bundled root backends may opt in, and node writes with identity, uniqueness/disjoint claims, searchable or embedding sidecars, history, or revision tracking remain transactional. Edges must be generated-ID cardinality-many creates with no convergence. Caller transactions, adopted handles, derived/custom backends, supplied IDs, batches, and all multi-statement plans retain the existing transaction path.

Driver-level statement assertions prove eligible SQLite and PostgreSQL/PGlite writes emit exactly one INSERT and no BEGIN or COMMIT. Inverting the generated-ID guard makes both the trace and selector tests fail, demonstrating that the fast-path boundary is load-bearing.

Part of #533.