### PR TITLE
perf(store): fuse node constraint claims

### DIFF
--- a/.changeset/fuse-node-claim-write.md
+++ b/.changeset/fuse-node-claim-write.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fuse PostgreSQL node uniqueness and disjointness claims into the planned node insert, reducing constrained single-node writes by one round trip per claim while preserving portable backend fallbacks.

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -36,6 +36,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -4108,6 +4109,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -4118,6 +4127,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -33,6 +33,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -4555,6 +4556,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -4565,6 +4574,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -29,6 +29,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -4202,6 +4203,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -4212,6 +4221,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -28,6 +28,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -4223,6 +4224,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -4233,6 +4242,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -27,6 +27,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -4555,6 +4556,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -4565,6 +4574,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -44,6 +44,7 @@ export type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -2379,6 +2380,14 @@ export type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+export type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 export type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -2389,6 +2398,7 @@ export type NodeInsertMode = Readonly<{
 // @public
 export type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 
@@ -3194,7 +3204,7 @@ export const UNBUNDLED_OPTIONAL_MEMBERS: {
     };
     readonly insertNodeWithProjections: {
         readonly kind: "reasoned";
-        readonly reason: "A bundled PostgreSQL/PGlite node-plus-projections statement selected only when every requested strategy proves one-statement sync; other backends retain the ordinary node then sidecar path.";
+        readonly reason: "A bundled PostgreSQL/PGlite planned node statement selected only when every requested claim/projection step proves one-statement support; other backends retain the ordinary node then sidecar path.";
         readonly accesses: 6;
     };
     readonly insertEdgeIfEndpointsLiveWithSchemaFence: {

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -112,6 +112,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -3764,6 +3765,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -3774,6 +3783,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -103,6 +103,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -3334,6 +3335,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -3344,6 +3353,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -103,6 +103,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -2948,6 +2949,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -2958,6 +2967,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -103,6 +103,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -2888,6 +2889,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -2898,6 +2907,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -103,6 +103,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -2894,6 +2895,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -2904,6 +2913,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -28,6 +28,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -1513,6 +1514,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -1523,6 +1532,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -103,6 +103,7 @@ type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -2968,6 +2969,14 @@ type NodeIndexDeclaration = IndexDeclarationBase & Readonly<{
 }>;
 
 // @public
+type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -2978,6 +2987,7 @@ type NodeInsertMode = Readonly<{
 // @public
 type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -202,6 +202,7 @@ export type BackendCapabilities = Readonly<{
     returning?: boolean;
     maxBindParameters?: number;
     readonly constraintClaims?: boolean;
+    readonly atomicNodeInsertClaims?: boolean;
     vector?: VectorCapabilities | undefined;
     fulltext?: FulltextCapabilities | undefined;
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
@@ -4511,6 +4512,14 @@ export type NodeIndexWhereBuilder<N extends NodeType> = Readonly<{
 }>;
 
 // @public
+export type NodeInsertClaim = Readonly<{
+    axis: string;
+    constraintName: string;
+    key: string;
+    placement: "pre-insert" | "post-insert";
+}>;
+
+// @public
 export type NodeInsertMode = Readonly<{
     kind: "ordinary";
 }> | Readonly<{
@@ -4521,6 +4530,7 @@ export type NodeInsertMode = Readonly<{
 // @public
 export type NodeInsertPlan = Readonly<{
     mode: NodeInsertMode;
+    claims?: readonly NodeInsertClaim[];
     projections: readonly NodeInsertProjection[];
 }>;
 

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -165,6 +165,8 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * through the 12 entrypoints which render `GraphBackend` without exporting
  * those backend-authoring types directly (+3 each). `.` and `./backend`
  * export all three names, so their forgotten-export debt is unchanged.
+ * Extending that plan with `NodeInsertClaim` adds that one name to the same
+ * 12 rendering entrypoints (+1 each); `.` and `./backend` export it directly.
  */
 const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   ".": {
@@ -176,24 +178,24 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "6c11a8d2c13c886a2d6473f8af99d9c4988c7bbfe97545a6a6f748cdd18bf6d8",
   },
   "./adapters/drizzle/postgres": {
-    count: 211,
-    sha256: "984e911321776526b657167ebd13c4294a2987c5e16eb360f2e48aa686a2cbc3",
+    count: 212,
+    sha256: "0531047813381d351d15a9e7de9d0b64684c02324eb39d089cafd4618ef5c144",
   },
   "./adapters/drizzle/postgres/pglite": {
-    count: 215,
-    sha256: "a8fefce432e6387ce3901cbec21539700c52647ce9bfcbfc686359deb534d437",
+    count: 216,
+    sha256: "df47b705107e58c6380d0e3deea38902ccd58040452f359814105fa779a1c9bd",
   },
   "./adapters/drizzle/sqlite": {
-    count: 212,
-    sha256: "6d8f49c49400333d3348fe268318c3d2f12becc14f08e867d2254db159a2389e",
+    count: 213,
+    sha256: "1738fbd18f3b524700b3c799e57225bdae5a271c4ec18deb3b095e2a76325c18",
   },
   "./adapters/drizzle/sqlite/libsql": {
-    count: 215,
-    sha256: "37d09a193a00e65c7e0c1e4fe7815fdc51808f575ef82d6cf1b959ccad8fda44",
+    count: 216,
+    sha256: "1cd0229016b50c35ab3a1d2b2c8114cdc2c20f5b86a8256d1fd8067d17bb8b90",
   },
   "./adapters/drizzle/sqlite/local": {
-    count: 215,
-    sha256: "37d09a193a00e65c7e0c1e4fe7815fdc51808f575ef82d6cf1b959ccad8fda44",
+    count: 216,
+    sha256: "1cd0229016b50c35ab3a1d2b2c8114cdc2c20f5b86a8256d1fd8067d17bb8b90",
   },
   "./backend": {
     count: 12,
@@ -208,36 +210,36 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "0f36d8f84e9a9d75255b39940c5308ae4df2c3dbe1e0cb2683b00ee8cb974f73",
   },
   "./graph-merge": {
-    count: 627,
-    sha256: "09ccac6dc7b2d6f11b8c7523cee100e7a763eef4d1c2eb54ef79ec4321d25dc2",
+    count: 628,
+    sha256: "4a5dc3c29b84a9a02bf852791ba1eb80c3778e5c821559303493a755711a64b6",
   },
   "./indexes": {
     count: 43,
     sha256: "49144a0eeda76d83d8ebe63f533e25796e1b7d46fe521a4adc997fb58cb876bb",
   },
   "./interchange": {
-    count: 613,
-    sha256: "8f6948f4d1d3a8e7cf11f33121106c73b9b6b42f4a6152d883c7f52a2240371d",
+    count: 614,
+    sha256: "a1a60ee8bd8fb0222c8396d55907a51b24c30d99c6cc70f1488430345ba9abb9",
   },
   "./postgres/pglite": {
-    count: 617,
-    sha256: "9f76aea1b0ffede41efb2658f7db4bacb455039c2f0ff0754bf0b25c8375f87f",
+    count: 618,
+    sha256: "a8ac35934cb1cb2dc1f6cfd5779656b032a99c600e849d9dfce7eb72caa01ce7",
   },
   "./profiler": {
-    count: 615,
-    sha256: "eeacc19bd15300115060b32cc1a541cd8fca0c9f154a67c704054225e2e4c7b5",
+    count: 616,
+    sha256: "8408e9c2332b8ec878b7a97e38b8c86de03e99ff25a48b922f542d53c37a1d38",
   },
   "./provenance": {
-    count: 621,
-    sha256: "42a57f31396a679655e4a5818be185f6cc9ba25dd8d39794d7e158c981ed852c",
+    count: 622,
+    sha256: "f066e539b8ab673449454c71096bc8f0fad71fce6983636f97eb242ae27d7fcb",
   },
   "./schema": {
-    count: 232,
-    sha256: "afb404126b93ad9d34519972754d5b66b32c4baccc0757e56adf9e752f207648",
+    count: 233,
+    sha256: "4c67d83edb38f9be1fd38925584445b7065fb12be42c940dbf4e87ba19f346a3",
   },
   "./sqlite/local": {
-    count: 617,
-    sha256: "9f76aea1b0ffede41efb2658f7db4bacb455039c2f0ff0754bf0b25c8375f87f",
+    count: 618,
+    sha256: "a8ac35934cb1cb2dc1f6cfd5779656b032a99c600e849d9dfce7eb72caa01ce7",
   },
 };
 

--- a/packages/typegraph/src/backend/capabilities/bundle-registry.ts
+++ b/packages/typegraph/src/backend/capabilities/bundle-registry.ts
@@ -845,7 +845,7 @@ export const UNBUNDLED_OPTIONAL_MEMBERS = {
   insertNodeWithProjections: {
     kind: "reasoned",
     reason:
-      "A bundled PostgreSQL/PGlite node-plus-projections statement selected only when every requested strategy proves one-statement sync; other backends retain the ordinary node then sidecar path.",
+      "A bundled PostgreSQL/PGlite planned node statement selected only when every requested claim/projection step proves one-statement support; other backends retain the ordinary node then sidecar path.",
     accesses: 6,
   },
   insertEdgeIfEndpointsLiveWithSchemaFence: {

--- a/packages/typegraph/src/backend/capabilities/node-insert-projections.ts
+++ b/packages/typegraph/src/backend/capabilities/node-insert-projections.ts
@@ -1,6 +1,7 @@
 import type {
   BackendIdentity,
   GraphBackend,
+  NodeInsertClaim,
   NodeInsertProjection,
 } from "../types";
 
@@ -44,4 +45,33 @@ export function supportsNodeInsertProjections(
       (projection) => projection.kind === "embedding",
     ),
   });
+}
+
+/** Whether the receiver can lower this complete insert plan atomically. */
+export function supportsNodeInsertPlan(
+  target: NodeProjectionInsertTarget,
+  input: Readonly<{
+    claims: readonly NodeInsertClaim[];
+    projections: readonly NodeInsertProjection[];
+  }>,
+): boolean {
+  if (input.claims.length === 0) {
+    return supportsNodeInsertProjections(target, input.projections);
+  }
+  // A claim refusal is discovered from the data-modifying statement's result,
+  // so the caller-owned transaction is the rollback boundary. Root graph
+  // backends expose `transaction`; transaction-scoped operation backends do
+  // not. Keep this exported predicate aligned with the execution contract.
+  if ("transaction" in target) return false;
+  return (
+    target.capabilities.atomicNodeInsertClaims === true &&
+    supportsNodeInsertProjectionRequirements(target, {
+      fulltext: input.projections.some(
+        (projection) => projection.kind === "fulltext",
+      ),
+      embedding: input.projections.some(
+        (projection) => projection.kind === "embedding",
+      ),
+    })
+  );
 }

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -296,6 +296,8 @@ type CreateCommonOperationBackendOptions = Readonly<{
   edgeCardinalityInsertFusion?: boolean | undefined;
   /** Present only for bundled projection-aware operation backends. */
   nodeProjectionInsertFusion?: boolean | undefined;
+  /** Claim plans require a caller-owned transaction to roll back refusals. */
+  nodeClaimInsertFusion?: boolean | undefined;
   /** Read-only prerequisite gate run before a fused projection statement. */
   beforeNodeProjectionInsert?:
     | ((params: InsertNodeParams, plan: NodeInsertPlan) => Promise<void>)
@@ -765,6 +767,32 @@ export function createCommonOperationBackend(
         params: InsertNodeParams,
         plan: NodeInsertPlan,
       ): Promise<NodeRow | undefined> {
+        const plannedClaims = plan.claims ?? [];
+        if (plannedClaims.length > 0 && options.nodeClaimInsertFusion !== true) {
+          throw new ConfigurationError(
+            "A node insert plan carrying uniqueness claims requires a transaction-scoped backend.",
+            {
+              capability: "insertNodeWithProjections",
+              graphId: params.graphId,
+              kind: params.kind,
+              id: params.id,
+            },
+          );
+        }
+        if (
+          plannedClaims.length > 0 &&
+          plan.mode.kind === "schema-fenced"
+        ) {
+          throw new ConfigurationError(
+            "A schema-fenced node insert plan cannot carry uniqueness claims.",
+            {
+              capability: "insertNodeWithProjections",
+              graphId: params.graphId,
+              kind: params.kind,
+              id: params.id,
+            },
+          );
+        }
         if (
           plan.mode.kind === "schema-fenced" &&
           plan.mode.schemaFence.graphId !== params.graphId
@@ -812,6 +840,35 @@ export function createCommonOperationBackend(
             throw error;
           }
         })();
+        if (row?.["write_discriminator"] === "claim_conflict") {
+          const constraintName = row["claim_constraint_name"];
+          const holderKind = row["claim_holder_kind"];
+          const holderId = row["claim_holder_id"];
+          const axis = row["claim_axis"];
+          if (
+            typeof constraintName !== "string" ||
+            typeof holderKind !== "string" ||
+            typeof holderId !== "string" ||
+            typeof axis !== "string"
+          ) {
+            throw new CompilerInvariantError(
+              "A planned node claim refusal returned incomplete conflict metadata.",
+              {
+                graphId: params.graphId,
+                kind: params.kind,
+                id: params.id,
+              },
+            );
+          }
+          throw new UniquenessError({
+            constraintName,
+            kind: holderKind,
+            existingId: holderId,
+            newId: params.id,
+            fields: [],
+            axis,
+          });
+        }
         if (row === undefined && plan.mode.kind === "ordinary") {
           throw new DatabaseOperationError(
             "Fused node projection insert failed: no row returned",

--- a/packages/typegraph/src/backend/drizzle/operations/node-projections.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/node-projections.ts
@@ -3,16 +3,16 @@ import { type SQL, sql } from "drizzle-orm";
 import type { FulltextStrategy } from "../../../query/dialect/fulltext-strategy";
 import type { SqlDialect } from "../../../query/dialect/types";
 import type { VectorStrategy } from "../../../query/dialect/vector-strategy";
+import { resolveStampedValidityLowerBound } from "../../../utils/date";
 import type {
   InsertNodeParams,
+  NodeInsertClaim,
   NodeInsertPlan,
 } from "../../types";
 import { toDrizzleSql } from "../execution/types";
-import {
-  buildInsertNode,
-  buildInsertNodeWithSchemaFence,
-} from "./nodes";
-import type { Tables } from "./shared";
+import { buildInsertNode, buildInsertNodeWithSchemaFence } from "./nodes";
+import { nodeColumnList, sqlNull, type Tables } from "./shared";
+import { buildInsertUniqueFromSource } from "./uniques";
 
 /** The fixed alias shared by the node CTE and all projection strategies. */
 export const INSERTED_NODE_PROJECTION_CTE_ALIAS = "inserted_node";
@@ -61,12 +61,116 @@ function buildNodeAndProjections(
   `;
 }
 
-/**
- * Builds one PostgreSQL/PGlite node insert with every requested projection.
- * Returning `undefined` is the all-or-nothing capability result: callers must
- * use the ordinary node-plus-sidecar path rather than partially fusing.
- */
-export function buildInsertNodeWithProjections(
+const CLAIM_INPUT_COLUMNS = [
+  "ordinal",
+  "graph_id",
+  "axis",
+  "constraint_name",
+  "key",
+  "node_id",
+  "concrete_kind",
+] as const;
+
+function claimInputCte(
+  alias: string,
+  claims: readonly NodeInsertClaim[],
+  params: InsertNodeParams,
+): SQL {
+  const values = sql.join(
+    claims.map(
+      (claim, ordinal) =>
+        sql`(${ordinal}, ${params.graphId}, ${claim.axis}, ${claim.constraintName}, ${claim.key}, ${params.id}, ${params.kind})`,
+    ),
+    sql`, `,
+  );
+  const columns = sql.join(
+    CLAIM_INPUT_COLUMNS.map((column) => sql.identifier(column)),
+    sql`, `,
+  );
+  return sql`${sql.identifier(alias)} (${columns}) AS (VALUES ${values})`;
+}
+
+function claimVerdictCte(
+  alias: string,
+  inputAlias: string,
+  claimedAlias: string,
+): SQL {
+  const input = sql.identifier(inputAlias);
+  const claimed = sql.identifier(claimedAlias);
+  return sql`
+    ${sql.identifier(alias)} AS (
+      SELECT
+        ${input}.${sql.identifier("ordinal")} AS ordinal,
+        ${input}.${sql.identifier("axis")} AS axis,
+        ${input}.${sql.identifier("constraint_name")} AS constraint_name,
+        ${input}.${sql.identifier("key")} AS key,
+        ${input}.${sql.identifier("node_id")} AS new_node_id,
+        ${input}.${sql.identifier("concrete_kind")} AS new_concrete_kind,
+        ${claimed}.${sql.identifier("node_id")} AS holder_id,
+        ${claimed}.${sql.identifier("concrete_kind")} AS holder_kind,
+        ${claimed}.${sql.identifier("node_id")} = ${input}.${sql.identifier("node_id")}
+          AND ${claimed}.${sql.identifier("concrete_kind")} = ${input}.${sql.identifier("concrete_kind")} AS accepted
+      FROM ${input}
+      JOIN ${claimed}
+        ON ${claimed}.${sql.identifier("axis")} = ${input}.${sql.identifier("axis")}
+       AND ${claimed}.${sql.identifier("constraint_name")} = ${input}.${sql.identifier("constraint_name")}
+       AND ${claimed}.${sql.identifier("key")} = ${input}.${sql.identifier("key")}
+    )
+  `;
+}
+
+function buildGatedNodeInsert(
+  tables: Tables,
+  params: InsertNodeParams,
+  plan: NodeInsertPlan,
+  timestamp: string,
+  gateAlias: string,
+  schemaLockClause: SQL | undefined,
+): SQL | undefined {
+  const { nodes, schemaVersions } = tables;
+  const propsJson = JSON.stringify(params.props);
+  const columns = nodeColumnList(nodes);
+  const gate = sql.identifier(gateAlias);
+
+  switch (plan.mode.kind) {
+    case "ordinary": {
+      return sql`
+        INSERT INTO ${nodes} (${columns})
+        SELECT
+          ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
+          1, ${sqlNull(resolveStampedValidityLowerBound(params.validFrom, params.validTo, timestamp))}, ${sqlNull(params.validTo)},
+          ${timestamp}, ${timestamp}
+        FROM ${gate}
+        RETURNING *
+      `;
+    }
+    case "schema-fenced": {
+      if (schemaLockClause === undefined) return;
+      return sql`
+        INSERT INTO ${nodes} (${columns})
+        SELECT
+          ${params.graphId}, ${params.kind}, ${params.id}, ${propsJson},
+          1, ${sqlNull(resolveStampedValidityLowerBound(params.validFrom, params.validTo, timestamp))}, ${sqlNull(params.validTo)},
+          ${timestamp}, ${timestamp}
+        FROM (
+          SELECT ${schemaVersions.version}
+          FROM ${schemaVersions}
+          WHERE ${schemaVersions.graphId} = ${plan.mode.schemaFence.graphId}
+            AND ${schemaVersions.version} = ${plan.mode.schemaFence.expectedVersion}
+            AND ${schemaVersions.isActive} = TRUE
+          ${schemaLockClause}
+        ) AS "schema_fence"
+        CROSS JOIN ${gate}
+        RETURNING *
+      `;
+    }
+    default: {
+      return plan.mode satisfies never;
+    }
+  }
+}
+
+function buildNodeClaimsAndProjections(
   tables: Tables,
   params: InsertNodeParams,
   plan: NodeInsertPlan,
@@ -75,8 +179,188 @@ export function buildInsertNodeWithProjections(
   fulltextTableName: string,
   fulltextStrategy: FulltextStrategy,
   vectorStrategy: VectorStrategy | undefined,
-  schemaLockClause?: SQL,
+  schemaLockClause: SQL | undefined,
 ): SQL | undefined {
+  const claims = plan.claims ?? [];
+  const preClaims = claims.filter(
+    (claim) => claim.placement === "pre-insert",
+  );
+  const postClaims = claims.filter(
+    (claim) => claim.placement === "post-insert",
+  );
+  const ctes: SQL[] = [];
+  const preInputAlias = "node_pre_claim_input";
+  const preClaimedAlias = "node_pre_claimed";
+  const preVerdictAlias = "node_pre_claim_verdict";
+
+  if (preClaims.length > 0) {
+    ctes.push(
+      claimInputCte(preInputAlias, preClaims, params),
+      sql`${sql.identifier(preClaimedAlias)} AS (${buildInsertUniqueFromSource(tables, dialect, preInputAlias)})`,
+      claimVerdictCte(preVerdictAlias, preInputAlias, preClaimedAlias),
+    );
+  }
+
+  const preGateAlias = "node_pre_gate";
+  ctes.push(
+    preClaims.length === 0 ?
+      sql`${sql.identifier(preGateAlias)} AS (SELECT 1 AS gate)`
+    : sql`
+      ${sql.identifier(preGateAlias)} AS (
+        SELECT 1 AS gate
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM ${sql.identifier(preVerdictAlias)}
+          WHERE accepted = FALSE
+        )
+      )
+    `,
+  );
+
+  const nodeInsert = buildGatedNodeInsert(
+    tables,
+    params,
+    plan,
+    timestamp,
+    preGateAlias,
+    schemaLockClause,
+  );
+  if (nodeInsert === undefined) return;
+  const nodeInsertedAlias = "node_inserted";
+  ctes.push(
+    sql`${sql.identifier(nodeInsertedAlias)} AS MATERIALIZED (${nodeInsert})`,
+  );
+
+  const postInputAlias = "node_post_claim_input";
+  const postClaimedAlias = "node_post_claimed";
+  const postVerdictAlias = "node_post_claim_verdict";
+  if (postClaims.length > 0) {
+    const postValuesAlias = "node_post_claim_values";
+    ctes.push(claimInputCte(postValuesAlias, postClaims, params));
+    const postValues = sql.identifier(postValuesAlias);
+    const nodeInserted = sql.identifier(nodeInsertedAlias);
+    const columns = sql.join(
+      CLAIM_INPUT_COLUMNS.map((column) => sql.identifier(column)),
+      sql`, `,
+    );
+    const qualifiedColumns = sql.join(
+      CLAIM_INPUT_COLUMNS.map(
+        (column) => sql`${postValues}.${sql.identifier(column)}`,
+      ),
+      sql`, `,
+    );
+    ctes.push(
+      sql`
+        ${sql.identifier(postInputAlias)} (${columns}) AS (
+          SELECT ${qualifiedColumns}
+          FROM ${postValues}
+          CROSS JOIN ${nodeInserted}
+        )
+      `,
+      sql`${sql.identifier(postClaimedAlias)} AS (${buildInsertUniqueFromSource(tables, dialect, postInputAlias)})`,
+      claimVerdictCte(postVerdictAlias, postInputAlias, postClaimedAlias),
+    );
+  }
+
+  const insertedNodeAlias = INSERTED_NODE_PROJECTION_CTE_ALIAS;
+  const nodeInserted = sql.identifier(nodeInsertedAlias);
+  ctes.push(
+    postClaims.length === 0 ?
+      sql`${sql.identifier(insertedNodeAlias)} AS MATERIALIZED (SELECT * FROM ${nodeInserted})`
+    : sql`
+      ${sql.identifier(insertedNodeAlias)} AS MATERIALIZED (
+        SELECT *
+        FROM ${nodeInserted}
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM ${sql.identifier(postVerdictAlias)}
+          WHERE accepted = FALSE
+        )
+      )
+    `,
+  );
+
+  const projectionSql = buildProjectionSql(
+    params,
+    plan,
+    timestamp,
+    dialect,
+    fulltextTableName,
+    fulltextStrategy,
+    vectorStrategy,
+  );
+  if (projectionSql === undefined) return;
+  ctes.push(...projectionSql.map((projection, index) =>
+    sql`${sql.identifier(`node_projection_${index}`)} AS (${projection})`,
+  ));
+
+  const conflictQueries: SQL[] = [];
+  if (preClaims.length > 0) {
+    conflictQueries.push(
+      sql`SELECT ordinal, 0 AS phase, axis, constraint_name, key, holder_id, holder_kind FROM ${sql.identifier(preVerdictAlias)} WHERE accepted = FALSE`,
+    );
+  }
+  if (postClaims.length > 0) {
+    conflictQueries.push(
+      sql`SELECT ordinal, 1 AS phase, axis, constraint_name, key, holder_id, holder_kind FROM ${sql.identifier(postVerdictAlias)} WHERE accepted = FALSE`,
+    );
+  }
+  const conflictAlias = "node_claim_conflicts";
+  if (conflictQueries.length === 0) {
+    ctes.push(
+      sql`${sql.identifier(conflictAlias)} AS (SELECT NULL::integer AS ordinal, NULL::integer AS phase, NULL::text AS axis, NULL::text AS constraint_name, NULL::text AS key, NULL::text AS holder_id, NULL::text AS holder_kind WHERE FALSE)`,
+    );
+  } else {
+    ctes.push(
+      sql`${sql.identifier(conflictAlias)} AS (${sql.join(conflictQueries, sql` UNION ALL `)})`,
+    );
+  }
+  const conflicts = sql.identifier(conflictAlias);
+  const firstConflict = sql.identifier("first_claim_conflict");
+  const outcomeAlias = "node_claim_outcome";
+  ctes.push(sql`
+    ${sql.identifier(outcomeAlias)} AS (
+      SELECT
+        CASE WHEN ${firstConflict}.${sql.identifier("axis")} IS NULL
+          THEN 'node_inserted' ELSE 'claim_conflict' END AS write_discriminator,
+        ${firstConflict}.${sql.identifier("axis")} AS claim_axis,
+        ${firstConflict}.${sql.identifier("constraint_name")} AS claim_constraint_name,
+        ${firstConflict}.${sql.identifier("key")} AS claim_key,
+        ${firstConflict}.${sql.identifier("holder_id")} AS claim_holder_id,
+        ${firstConflict}.${sql.identifier("holder_kind")} AS claim_holder_kind
+      FROM (SELECT 1 AS sentinel) AS "outcome_sentinel"
+      LEFT JOIN LATERAL (
+        SELECT *
+        FROM ${conflicts}
+        ORDER BY phase, ordinal
+        LIMIT 1
+      ) AS ${firstConflict} ON TRUE
+    )
+  `);
+
+  return sql`
+    WITH ${sql.join(ctes, sql`, `)}
+    SELECT ${sql.identifier(insertedNodeAlias)}.*,
+      ${sql.identifier(outcomeAlias)}.write_discriminator,
+      ${sql.identifier(outcomeAlias)}.claim_axis,
+      ${sql.identifier(outcomeAlias)}.claim_constraint_name,
+      ${sql.identifier(outcomeAlias)}.claim_key,
+      ${sql.identifier(outcomeAlias)}.claim_holder_id,
+      ${sql.identifier(outcomeAlias)}.claim_holder_kind
+    FROM ${sql.identifier(outcomeAlias)}
+    LEFT JOIN ${sql.identifier(insertedNodeAlias)} ON TRUE
+  `;
+}
+
+function buildProjectionSql(
+  params: InsertNodeParams,
+  plan: NodeInsertPlan,
+  timestamp: string,
+  dialect: SqlDialect,
+  fulltextTableName: string,
+  fulltextStrategy: FulltextStrategy,
+  vectorStrategy: VectorStrategy | undefined,
+): readonly SQL[] | undefined {
   const projectionSql: SQL[] = [];
   const fulltextBuilder = fulltextStrategy.buildSyncFromInsertedNode;
   const vectorBuilder = vectorStrategy?.buildUpsertFromInsertedNode;
@@ -99,9 +383,7 @@ export function buildInsertNodeWithProjections(
         break;
       }
       case "embedding": {
-        if (vectorStrategy === undefined || vectorBuilder === undefined) {
-          return;
-        }
+        if (vectorStrategy === undefined || vectorBuilder === undefined) return;
         projectionSql.push(
           toDrizzleSql(
             vectorBuilder(
@@ -127,6 +409,49 @@ export function buildInsertNodeWithProjections(
       }
     }
   }
+  return projectionSql;
+}
+
+/**
+ * Builds one PostgreSQL/PGlite node insert with every requested plan step.
+ * Returning `undefined` is the all-or-nothing capability result: callers must
+ * use the ordinary node-plus-sidecar path rather than partially fusing.
+ */
+export function buildInsertNodeWithProjections(
+  tables: Tables,
+  params: InsertNodeParams,
+  plan: NodeInsertPlan,
+  timestamp: string,
+  dialect: SqlDialect,
+  fulltextTableName: string,
+  fulltextStrategy: FulltextStrategy,
+  vectorStrategy: VectorStrategy | undefined,
+  schemaLockClause?: SQL,
+): SQL | undefined {
+  if ((plan.claims?.length ?? 0) > 0) {
+    return buildNodeClaimsAndProjections(
+      tables,
+      params,
+      plan,
+      timestamp,
+      dialect,
+      fulltextTableName,
+      fulltextStrategy,
+      vectorStrategy,
+      schemaLockClause,
+    );
+  }
+
+  const projectionSql = buildProjectionSql(
+    params,
+    plan,
+    timestamp,
+    dialect,
+    fulltextTableName,
+    fulltextStrategy,
+    vectorStrategy,
+  );
+  if (projectionSql === undefined) return;
 
   const nodeInsert = buildNodeInsert(
     tables,

--- a/packages/typegraph/src/backend/drizzle/operations/uniques.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/uniques.ts
@@ -307,6 +307,87 @@ export function buildInsertUniqueBatch(
 }
 
 /**
+ * Builds the claim upsert used by the PostgreSQL node-write fusion CTE.
+ *
+ * The source relation is a backend-owned CTE with the fixed columns
+ * `(graph_id, axis, constraint_name, key, node_id, concrete_kind)`. Keeping
+ * this rendering beside the ordinary claim builders is important: the fused
+ * path must make exactly the same owner/tombstone decision as
+ * `buildInsertUnique` and `buildInsertUniqueBatch`.
+ */
+export function buildInsertUniqueFromSource(
+  tables: Tables,
+  dialect: SqlDialect,
+  sourceAlias: string,
+): SQL {
+  const { uniques } = tables;
+  const source = sql.identifier(sourceAlias);
+  const sourceColumn = (name: string): SQL =>
+    sql`${source}.${quotedColumn({ name })}`;
+  const columns = sql.raw(
+    `"${uniques.graphId.name}", "${uniques.nodeKind.name}", "${uniques.constraintName.name}", "${uniques.key.name}", "${uniques.nodeId.name}", "${uniques.concreteKind.name}", "${uniques.deletedAt.name}"`,
+  );
+  const conflictColumns = sql.raw(
+    `"${uniques.graphId.name}", "${uniques.nodeKind.name}", "${uniques.constraintName.name}", "${uniques.key.name}"`,
+  );
+  const tableName = getTableName(uniques);
+  const existingColumnByName = (columnName: string): SQL => {
+    switch (dialect) {
+      case "postgres": {
+        return sql`${quotedTableName(tableName)}.${quotedColumn({ name: columnName })}`;
+      }
+      case "sqlite": {
+        return quotedColumn({ name: columnName });
+      }
+      default: {
+        return dialect satisfies never;
+      }
+    }
+  };
+  const ownerMatches = claimOwnerMatchesSql(
+    drizzleSqlTag,
+    (columnName) => existingColumnByName(columnName),
+    (columnName) => excludedColumnByName(columnName),
+    ownerColumnNames(uniques),
+  );
+  const existingColumn = (column: Readonly<{ name: string }>) =>
+    existingColumnByName(column.name);
+
+  return sql`
+    INSERT INTO ${uniques} (${columns})
+    SELECT
+      ${sourceColumn("graph_id")}, ${sourceColumn("axis")},
+      ${sourceColumn("constraint_name")}, ${sourceColumn("key")},
+      ${sourceColumn("node_id")}, ${sourceColumn("concrete_kind")},
+      ${sql.raw("NULL")}
+    FROM ${source}
+    ON CONFLICT (${conflictColumns})
+    DO UPDATE SET
+      ${quotedColumn(uniques.nodeId)} = CASE
+        WHEN ${ownerMatches} THEN ${excludedColumn(uniques.nodeId)}
+        WHEN ${existingColumn(uniques.deletedAt)} IS NOT NULL THEN ${excludedColumn(uniques.nodeId)}
+        ELSE ${existingColumn(uniques.nodeId)}
+      END,
+      ${quotedColumn(uniques.concreteKind)} = CASE
+        WHEN ${ownerMatches} THEN ${excludedColumn(uniques.concreteKind)}
+        WHEN ${existingColumn(uniques.deletedAt)} IS NOT NULL THEN ${excludedColumn(uniques.concreteKind)}
+        ELSE ${existingColumn(uniques.concreteKind)}
+      END,
+      ${quotedColumn(uniques.deletedAt)} = CASE
+        WHEN ${ownerMatches} THEN NULL
+        WHEN ${existingColumn(uniques.deletedAt)} IS NOT NULL THEN NULL
+        ELSE ${existingColumn(uniques.deletedAt)}
+      END
+    RETURNING
+      ${quotedColumn(uniques.nodeKind)} AS axis,
+      ${quotedColumn(uniques.constraintName)} AS constraint_name,
+      ${quotedColumn(uniques.key)} AS key,
+      ${quotedColumn(uniques.nodeId)} AS node_id,
+      ${quotedColumn(uniques.concreteKind)} AS concrete_kind
+  `;
+}
+
+/**
  * Builds the owner-scoped soft DELETE that releases a uniqueness claim.
  * Uses raw column name in SET clause.
  *

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -2438,6 +2438,7 @@ function createPostgresOperationBackend(
         schemaGraphWriteLockNamespace:
           RECORDED_GRAPH_WRITE_ADVISORY_LOCK_NAMESPACE,
         edgeCardinalityInsertFusion: true,
+        nodeClaimInsertFusion: true,
       }
     : {}),
     tableExistenceCache: { cacheExisting: false },

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -255,6 +255,7 @@ export type {
   NodeEntityReadBackend,
   NodeEntityWriteBackend,
   NodeFulltextSync,
+  NodeInsertClaim,
   NodeInsertMode,
   NodeInsertPlan,
   NodeInsertProjection,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -336,6 +336,13 @@ export type BackendCapabilities = Readonly<{
    * whose declaration and surface disagree in either direction.
    */
   readonly constraintClaims?: boolean;
+  /**
+   * Whether `insertNodeWithProjections` can atomically apply the claim portion
+   * of a {@link NodeInsertPlan}. Absent means projection-only: method presence
+   * alone is not evidence that a custom backend understands the newer plan
+   * field, so the store retains the standalone claim fallback.
+   */
+  readonly atomicNodeInsertClaims?: boolean;
   /** Vector search capabilities (undefined if not configured) */
   vector?: VectorCapabilities | undefined;
   /** Fulltext search capabilities (undefined if not configured) */
@@ -877,7 +884,22 @@ export type NodeInsertProjection =
       action: "delete";
     }>;
 
-/** The two atomic node-insert shapes supported by a projection-aware backend. */
+/**
+ * A uniqueness-relation claim carried by an atomic node-insert plan.
+ *
+ * Node identity is deliberately absent: the backend derives the owner pair
+ * from the node insert parameters, so the claim cannot name a different row.
+ * Placement is decided by the store's claim-site owner and preserved by the
+ * SQL compiler as an explicit dependency around the node insert.
+ */
+export type NodeInsertClaim = Readonly<{
+  axis: string;
+  constraintName: string;
+  key: string;
+  placement: "pre-insert" | "post-insert";
+}>;
+
+/** The two atomic node-insert shapes supported by a planned-write backend. */
 export type NodeInsertMode =
   | Readonly<{ kind: "ordinary" }>
   | Readonly<{
@@ -886,12 +908,14 @@ export type NodeInsertMode =
     }>;
 
 /**
- * Complete plan for a projection-aware node insert. The insert params carry
- * row identity; this plan carries only the projections and whether the node
- * statement must acquire the active-schema fence.
+ * Complete plan for an atomic node insert. The insert params carry row
+ * identity; this plan carries its constraint claims, generated projections,
+ * and whether the statement must acquire the active-schema fence.
  */
 export type NodeInsertPlan = Readonly<{
   mode: NodeInsertMode;
+  /** Omitted by projection-only callers written before claim planning. */
+  claims?: readonly NodeInsertClaim[];
   projections: readonly NodeInsertProjection[];
 }>;
 
@@ -1893,9 +1917,9 @@ export type GraphBackend = Readonly<{
     schemaFence: SchemaWriteFenceParams,
   ) => Promise<NodeRow | undefined>;
   /**
-   * Optional atomic projection-aware insert. The backend must either apply
-   * every requested projection in the same statement as the node insert or
-   * omit this member; the store never partially fuses a plan.
+   * Optional atomic planned insert. The backend must apply every requested
+   * claim and projection in the same statement as the node insert, or refuse
+   * the plan; the store never partially fuses one.
    */
   insertNodeWithProjections?: (
     this: void,
@@ -4087,6 +4111,7 @@ export const POSTGRES_CAPABILITIES: BackendCapabilities = Object.freeze({
   // The bundled schema ships both claim relations and the shared operation
   // backend implements every claim member.
   constraintClaims: true,
+  atomicNodeInsertClaims: true,
   maxBindParameters: POSTGRES_MAX_BIND_PARAMETERS,
   graphAnalytics: Object.freeze({ supported: true, mathFunctions: true }),
   recursiveTraversal: Object.freeze({ supported: true }),

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -184,6 +184,7 @@ export type {
   NodeEntityReadBackend,
   NodeEntityWriteBackend,
   NodeFulltextSync,
+  NodeInsertClaim,
   NodeInsertMode,
   NodeInsertPlan,
   NodeInsertProjection,

--- a/packages/typegraph/src/store/claims/node-claims.ts
+++ b/packages/typegraph/src/store/claims/node-claims.ts
@@ -22,6 +22,7 @@ import {
 import {
   type GraphBackend,
   type InsertUniqueParams,
+  type NodeInsertClaim,
   type TransactionBackend,
   type UniqueConstraintBackend,
 } from "../../backend/types";
@@ -250,6 +251,15 @@ function mapClaimRefusal(
   );
 }
 
+/** Re-raises a planned claim failure through the claim family's typed error. */
+export function refuseNodeCreateClaimError(
+  error: unknown,
+  entries: readonly NodeClaimEntry[],
+): never {
+  if (error instanceof UniquenessError) mapClaimRefusal(error, entries);
+  throw error;
+}
+
 /**
  * Runs a claim statement, re-raising a foreign owner as the declared refusal of
  * whichever family owed the claim.
@@ -469,6 +479,12 @@ type PlacedClaim = Readonly<{
   target: ClaimTarget;
 }>;
 
+/** The complete, canonically ordered claim portion of one node insert plan. */
+export type NodeCreateClaimPlan = Readonly<{
+  entries: readonly NodeClaimEntry[];
+  claims: readonly NodeInsertClaim[];
+}>;
+
 /**
  * How one placement group.s statements are issued.
  *
@@ -504,6 +520,52 @@ function claimInsertParams(
     key: claim.entry.key,
     nodeId: claim.item.id,
     concreteKind: claim.item.kind,
+  };
+}
+
+function placedNodeCreateClaims(
+  ctx: Pick<NodeClaimContext, "graphId" | "registry">,
+  items: readonly NodeClaimItem[],
+): readonly PlacedClaim[] {
+  return items.flatMap((item) =>
+    nodeClaimEntries(
+      ctx.registry,
+      item.kind,
+      item.id,
+      item.props,
+      item.constraints,
+      "create",
+    ).map((entry) => ({
+      item,
+      entry,
+      target: claimTarget(ctx.graphId, entry),
+    })),
+  );
+}
+
+/**
+ * Resolves one create's claims once for either the atomic plan or fallback
+ * seam. The returned list preserves the claim-site placement decision and the
+ * same canonical target order standalone claim statements use.
+ */
+export function planNodeCreateClaims(
+  ctx: Pick<NodeClaimContext, "graphId" | "registry">,
+  item: NodeClaimItem,
+): NodeCreateClaimPlan {
+  const placed = placedNodeCreateClaims(ctx, [item]).toSorted((left, right) => {
+    if (left.entry.placement !== right.entry.placement) {
+      return left.entry.placement === "pre-insert" ? -1 : 1;
+    }
+    return compareClaimTargets(left.target, right.target);
+  });
+  return {
+    entries: placed.map((claim) => claim.entry),
+    claims: placed.map((claim) => ({
+      axis: claim.entry.axis,
+      constraintName: claim.entry.constraintName,
+      key: claim.entry.key,
+      placement: claim.entry.placement,
+    })),
   };
 }
 
@@ -627,20 +689,7 @@ async function withNodeCreateClaimsIssuedBy<T>(
     backend,
     ctx.uniqueSidecarBatch,
   );
-  const claims = items.flatMap((item) =>
-    nodeClaimEntries(
-      ctx.registry,
-      item.kind,
-      item.id,
-      item.props,
-      item.constraints,
-      "create",
-    ).map((entry) => ({
-      item,
-      entry,
-      target: claimTarget(ctx.graphId, entry),
-    })),
-  );
+  const claims = placedNodeCreateClaims(ctx, items);
 
   const refusal = claimFenceRefusal(
     ctx,

--- a/packages/typegraph/src/store/operations/write-session.ts
+++ b/packages/typegraph/src/store/operations/write-session.ts
@@ -39,7 +39,10 @@
 import { type z } from "zod";
 
 import { type UNIQUE_SIDECAR_BATCH } from "../../backend/capabilities/bundle-registry";
-import { supportsNodeInsertProjections } from "../../backend/capabilities/node-insert-projections";
+import {
+  supportsNodeInsertPlan,
+  supportsNodeInsertProjections,
+} from "../../backend/capabilities/node-insert-projections";
 import {
   type BundleVerdictOf,
   type ClaimsVerdictThunk,
@@ -79,6 +82,8 @@ import {
 } from "../claims/edge-claims";
 import {
   type NodeClaimItem,
+  planNodeCreateClaims,
+  refuseNodeCreateClaimError,
   withNodeCreateClaims,
   withNodeCreateClaimsBatch,
 } from "../claims/node-claims";
@@ -423,43 +428,48 @@ export function createWriteSession(
     // seam owns the two groups and the compensation between them; this surface
     // owns only "the row write it gates is THIS one".
     createNode: async (work) => {
-      const projectionsFused = supportsNodeInsertProjections(
-        target,
-        work.projections,
-      );
-      const row = await withNodeCreateClaims(
-        writeContext,
-        work.claim,
-        target,
-        () => {
-          const insert = target.insertNodeWithProjections;
-          if (!projectionsFused || insert === undefined) {
-            return dispatch.one(work.params);
-          }
+      const claimPlan = planNodeCreateClaims(writeContext, work.claim);
+      const insertPlanFused = supportsNodeInsertPlan(target, {
+        claims: claimPlan.claims,
+        projections: work.projections,
+      });
+      const insertPlannedNode = async (): Promise<NodeRow> => {
+        const insert = target.insertNodeWithProjections;
+        if (!insertPlanFused || insert === undefined) {
+          return withNodeCreateClaims(writeContext, work.claim, target, () =>
+            dispatch.one(work.params),
+          );
+        }
+        try {
           const plan: NodeInsertPlan = {
             mode: { kind: "ordinary" },
+            claims: claimPlan.claims,
             projections: work.projections,
           };
-          return insert(work.params, plan).then((row) => {
-            if (row === undefined) {
-              throw new CompilerInvariantError(
-                "An ordinary projection-aware node insert returned no row.",
-                {
-                  graphId: work.params.graphId,
-                  kind: work.params.kind,
-                  id: work.params.id,
-                },
-              );
-            }
-            return row;
-          });
-        },
-      );
+          const row = await insert(work.params, plan);
+          if (row === undefined) {
+            throw new CompilerInvariantError(
+              "An ordinary planned node insert returned no row.",
+              {
+                graphId: work.params.graphId,
+                kind: work.params.kind,
+                id: work.params.id,
+              },
+            );
+          }
+          return row;
+        } catch (error) {
+          refuseNodeCreateClaimError(error, claimPlan.entries);
+        }
+      };
+      const row = await insertPlannedNode();
       await applyNodeInsertSyncFans(
         writeContext,
         {
           ...work.sideEffects,
-          ...(projectionsFused ? { projectionsFused: true } : {}),
+          ...(insertPlanFused && work.projections.length > 0 ?
+            { projectionsFused: true }
+          : {}),
         },
         target,
       );
@@ -503,6 +513,7 @@ export function createWriteSession(
           if (insert === undefined) return;
           const plan: NodeInsertPlan = {
             mode: { kind: "schema-fenced", schemaFence },
+            claims: [],
             projections: work.projections,
           };
           return withNodeCreateClaims(writeContext, work.claim, target, () =>

--- a/packages/typegraph/tests/backends/integration/claim-compensation.ts
+++ b/packages/typegraph/tests/backends/integration/claim-compensation.ts
@@ -83,12 +83,20 @@ function backendFailingOneInsert(backend: GraphBackend): GraphBackend {
   // frozen, and a decoration Proxy cannot shadow a non-configurable member.
   // `projectGraphBackend` is the audited way to get an unfrozen copy.
   return deriveBackend(projectGraphBackend(backend), {
+    capabilities: {
+      ...backend.capabilities,
+      atomicNodeInsertClaims: false,
+    },
     insertNode: failingInsertNode((params) => backend.insertNode(params)),
     transaction: (run, options) =>
       backend.transaction(
         (target) =>
           run(
             deriveBackend(target, {
+              capabilities: {
+                ...target.capabilities,
+                atomicNodeInsertClaims: false,
+              },
               insertNode: failingInsertNode((params) =>
                 target.insertNode(params),
               ),

--- a/packages/typegraph/tests/backends/integration/recorded-time.ts
+++ b/packages/typegraph/tests/backends/integration/recorded-time.ts
@@ -428,6 +428,10 @@ function rejectUniqueFinalization(): Promise<never> {
 
 function withFailingUniqueFinalization(backend: GraphBackend): GraphBackend {
   return deriveBackend(unfrozenSeamCopy(backend), {
+    capabilities: {
+      ...backend.capabilities,
+      atomicNodeInsertClaims: false,
+    },
     insertUnique(): Promise<void> {
       return rejectUniqueFinalization();
     },
@@ -435,6 +439,10 @@ function withFailingUniqueFinalization(backend: GraphBackend): GraphBackend {
       return backend.transaction((target) => {
         const failingTarget: TransactionBackend = {
           ...target,
+          capabilities: {
+            ...target.capabilities,
+            atomicNodeInsertClaims: false,
+          },
           insertUnique(): Promise<void> {
             return rejectUniqueFinalization();
           },

--- a/packages/typegraph/tests/backends/postgres/concurrent-claim-fence.test.ts
+++ b/packages/typegraph/tests/backends/postgres/concurrent-claim-fence.test.ts
@@ -480,6 +480,10 @@ function backendPausingAfterFirstClaim(
         let claimsIssued = 0;
         return run(
           deriveBackend(target, {
+            capabilities: {
+              ...target.capabilities,
+              atomicNodeInsertClaims: false,
+            },
             insertUnique: async (params) => {
               await target.insertUnique(params);
               claimsIssued += 1;
@@ -515,6 +519,10 @@ function backendPausingBeforeClaim(
         const insertUniqueBatch = target.insertUniqueBatch;
         return run(
           deriveBackend(target, {
+            capabilities: {
+              ...target.capabilities,
+              atomicNodeInsertClaims: false,
+            },
             insertUnique: async (params) => {
               await pause();
               return target.insertUnique(params);

--- a/packages/typegraph/tests/backends/postgres/concurrent-create-duplicate-key.test.ts
+++ b/packages/typegraph/tests/backends/postgres/concurrent-create-duplicate-key.test.ts
@@ -167,6 +167,7 @@ beforeEach(async () => {
 const GATED_INSERT_METHODS = new Set([
   "insertNode",
   "insertNodeNoReturn",
+  "insertNodeWithProjections",
   "insertNodesBatch",
   "insertNodesBatchReturning",
   "insertEdge",

--- a/packages/typegraph/tests/constraint-write-fence.test.ts
+++ b/packages/typegraph/tests/constraint-write-fence.test.ts
@@ -615,7 +615,7 @@ describe("a create issues each claim on the side of the row its placement names"
       handle: z.string(),
     }),
   });
-  /** One claim in each group: the shape that emits TWO claim statements. */
+  /** One claim in each group: the shape that exercises both claim phases. */
   const BothLeaf = defineNode("BothLeaf", {
     schema: z.object({
       email: z.string(),
@@ -648,7 +648,7 @@ describe("a create issues each claim on the side of the row its placement names"
     ],
   });
 
-  it("keeps an own-kind claim AFTER the row, which is the order it ships in", async () => {
+  it("keeps an own-kind claim AFTER the row within the fused statement", async () => {
     const { store, statements, reset } =
       await createRecordedPostgresStore(placementGraph);
 
@@ -657,10 +657,15 @@ describe("a create issues each claim on the side of the row its placement names"
 
     const claims = claimIndexes(statements);
     expect(claims).toHaveLength(1);
-    expect(nodeInsertIndex(statements)).toBeLessThan(claims[0] ?? -1);
+    expect(nodeInsertIndex(statements)).toBe(claims[0]);
+    const statement = statements[claims[0] ?? 0];
+    expect(statement?.query).toMatch(/node_inserted/iu);
+    expect(statement?.query.indexOf('"node_inserted"')).toBeLessThan(
+      statement?.query.indexOf('"node_post_claimed"') ?? -1,
+    );
   });
 
-  it("issues a cross-kind claim BEFORE the row it gates", async () => {
+  it("issues cross-kind claims BEFORE the row they gate within one statement", async () => {
     const { store, statements, reset } =
       await createRecordedPostgresStore(placementGraph);
 
@@ -675,15 +680,21 @@ describe("a create issues each claim on the side of the row its placement names"
     // in canonical order (by constraint name, the axis being equal), not in the
     // order the schema lists them.
     const claims = claimIndexes(statements);
-    expect(claims).toHaveLength(2);
-    expect(claims[1] ?? -1).toBeLessThan(nodeInsertIndex(statements));
-    expect(claims.map((index) => statements[index]?.params[2])).toEqual([
-      "placement_alias",
-      "placement_email",
-    ]);
+    expect(claims).toHaveLength(1);
+    expect(nodeInsertIndex(statements)).toBe(claims[0]);
+    const statement = statements[claims[0] ?? 0];
+    expect(statement?.query.indexOf('"node_pre_claimed"')).toBeLessThan(
+      statement?.query.indexOf('"node_inserted"') ?? -1,
+    );
+    expect(
+      statement?.params.filter(
+        (parameter): parameter is string =>
+          parameter === "placement_alias" || parameter === "placement_email",
+      ),
+    ).toEqual(["placement_alias", "placement_email"]);
   });
 
-  it("splits a kind owing both into two statements, one on each side of the row", async () => {
+  it("keeps claims on both sides of the row within one statement", async () => {
     const { store, statements, reset } =
       await createRecordedPostgresStore(placementGraph);
 
@@ -696,12 +707,22 @@ describe("a create issues each claim on the side of the row its placement names"
 
     const claims = claimIndexes(statements);
     const insertIndex = nodeInsertIndex(statements);
-    expect(claims).toHaveLength(2);
-    expect(claims[0] ?? -1).toBeLessThan(insertIndex);
-    expect(insertIndex).toBeLessThan(claims[1] ?? -1);
+    expect(claims).toHaveLength(1);
+    expect(insertIndex).toBe(claims[0]);
+    const statement = statements[claims[0] ?? 0];
+    expect(statement?.query.indexOf('"node_pre_claimed"')).toBeLessThan(
+      statement?.query.indexOf('"node_inserted"') ?? -1,
+    );
+    expect(statement?.query.indexOf('"node_inserted"')).toBeLessThan(
+      statement?.query.indexOf('"node_post_claimed"') ?? -1,
+    );
 
-    expect(statements[claims[0] ?? 0]?.params[2]).toBe("placement_email");
-    expect(statements[claims[1] ?? 0]?.params[2]).toBe("placement_handle");
+    expect(
+      statement?.params.filter(
+        (parameter): parameter is string =>
+          parameter === "placement_email" || parameter === "placement_handle",
+      ),
+    ).toEqual(["placement_email", "placement_handle"]);
   });
 
   it("sorts one batch statement's claims canonically, whatever order the rows arrive in", async () => {

--- a/packages/typegraph/tests/node-claim-write-fusion.test.ts
+++ b/packages/typegraph/tests/node-claim-write-fusion.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  defineGraph,
+  defineNode,
+  disjointWith,
+  searchable,
+  subClassOf,
+} from "../src";
+import { supportsNodeInsertPlan } from "../src/backend/capabilities/node-insert-projections";
+import {
+  deriveBackend,
+  projectBackendWithout,
+} from "../src/backend/derive-backend";
+import type { GraphBackend, TransactionBackend } from "../src/backend/types";
+import { createStore, createStoreWithSchema } from "../src/store";
+import { requireDefined } from "../src/utils/presence";
+import {
+  createRecordedPostgresStore,
+  type LoggedStatement,
+} from "./statement-recorder";
+
+const SAME_KIND_UNIQUE = {
+  name: "same_kind_email",
+  fields: ["email"],
+  scope: "kind",
+  collation: "binary",
+} as const;
+
+const SHARED_UNIQUE = {
+  name: "shared_email",
+  fields: ["email"],
+  scope: "kindWithSubClasses",
+  collation: "binary",
+} as const;
+
+const UniqueNode = defineNode("UniqueNode", {
+  schema: z.object({ email: z.string() }),
+});
+const SharedRoot = defineNode("SharedRoot", {
+  schema: z.object({ email: z.string() }),
+});
+const SharedLeaf = defineNode("SharedLeaf", {
+  schema: z.object({ email: z.string() }),
+});
+const Person = defineNode("ClaimPerson", {
+  schema: z.object({ name: z.string() }),
+});
+const Company = defineNode("ClaimCompany", {
+  schema: z.object({ name: z.string() }),
+});
+const MixedLeaf = defineNode("MixedLeaf", {
+  schema: z.object({ email: z.string(), handle: z.string() }),
+});
+const SearchableUnique = defineNode("SearchableUnique", {
+  schema: z.object({
+    email: z.string(),
+    title: searchable({ language: "english" }),
+  }),
+});
+const graph = defineGraph({
+  id: "node_claim_write_fusion",
+  nodes: {
+    UniqueNode: { type: UniqueNode, unique: [SAME_KIND_UNIQUE] },
+    SharedRoot: { type: SharedRoot, unique: [SHARED_UNIQUE] },
+    SharedLeaf: { type: SharedLeaf, unique: [SHARED_UNIQUE] },
+    ClaimPerson: { type: Person },
+    ClaimCompany: { type: Company },
+    MixedLeaf: {
+      type: MixedLeaf,
+      unique: [SHARED_UNIQUE, SAME_KIND_UNIQUE],
+    },
+    SearchableUnique: {
+      type: SearchableUnique,
+      unique: [SAME_KIND_UNIQUE],
+    },
+  },
+  edges: {},
+  ontology: [subClassOf(SharedLeaf, SharedRoot), disjointWith(Person, Company)],
+});
+
+function hasNodeInsert(statement: LoggedStatement): boolean {
+  return /insert\s+into\s+"typegraph_nodes"/iu.test(statement.query);
+}
+
+function hasUniqueClaim(statement: LoggedStatement): boolean {
+  return /insert\s+into\s+"typegraph_node_uniques"/iu.test(statement.query);
+}
+
+function nodeWrite(statements: readonly LoggedStatement[]): LoggedStatement {
+  return requireDefined(
+    statements.find((statement) => hasNodeInsert(statement)),
+    "node write statement",
+  );
+}
+
+function claimNames(
+  statement: LoggedStatement,
+  names: readonly string[],
+): string[] {
+  return statement.params.filter(
+    (parameter): parameter is string =>
+      typeof parameter === "string" && names.includes(parameter),
+  );
+}
+
+function expectFusedClaimAndNode(statement: LoggedStatement): void {
+  expect(hasNodeInsert(statement)).toBe(true);
+  expect(hasUniqueClaim(statement)).toBe(true);
+  expect(statement.query).toMatch(/node_inserted/iu);
+}
+
+describe("node claim write fusion", () => {
+  it("refuses a claim plan on the root backend without a rollback boundary", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+    const claimPlan = {
+      claims: [
+        {
+          axis: "UniqueNode",
+          constraintName: SAME_KIND_UNIQUE.name,
+          key: "root@example.com",
+          placement: "post-insert" as const,
+        },
+      ],
+      projections: [],
+    };
+
+    expect(supportsNodeInsertPlan(fixture.backend, claimPlan)).toBe(false);
+
+    await expect(
+      requireDefined(
+        fixture.backend.insertNodeWithProjections,
+        "planned node insert",
+      )(
+        {
+          graphId: graph.id,
+          kind: "UniqueNode",
+          id: "root-claim-plan",
+          props: { email: "root@example.com" },
+        },
+        {
+          mode: { kind: "ordinary" },
+          ...claimPlan,
+        },
+      ),
+    ).rejects.toThrow("requires a transaction-scoped backend");
+  });
+
+  it("refuses claims on schema-fenced plans before executing them", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+
+    await expect(
+      fixture.backend.transaction(async (tx) =>
+        requireDefined(tx.insertNodeWithProjections)(
+          {
+            graphId: graph.id,
+            kind: "UniqueNode",
+            id: "schema-claim-plan",
+            props: { email: "schema@example.com" },
+          },
+          {
+            mode: {
+              kind: "schema-fenced",
+              schemaFence: { graphId: graph.id, expectedVersion: 1 },
+            },
+            claims: [
+              {
+                axis: "UniqueNode",
+                constraintName: SAME_KIND_UNIQUE.name,
+                key: "schema@example.com",
+                placement: "post-insert",
+              },
+            ],
+            projections: [],
+          },
+        ),
+      ),
+    ).rejects.toThrow("cannot carry uniqueness claims");
+    expect(
+      await fixture.backend.checkUnique({
+        graphId: graph.id,
+        nodeKind: "UniqueNode",
+        constraintName: SAME_KIND_UNIQUE.name,
+        key: "schema@example.com",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("fuses a generated same-kind unique claim with the node insert", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+    const store = fixture.store;
+
+    fixture.reset();
+    await store.nodes.UniqueNode.create({ email: "same@example.com" });
+
+    const statement = nodeWrite(fixture.statements);
+    expectFusedClaimAndNode(statement);
+    expect(claimNames(statement, [SAME_KIND_UNIQUE.name])).toEqual([
+      SAME_KIND_UNIQUE.name,
+    ]);
+    expect(statement.query.indexOf('"node_inserted"')).toBeLessThan(
+      statement.query.indexOf('"node_post_claimed"'),
+    );
+  });
+
+  it("fuses a shared-scope unique claim before the generated node insert", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+
+    fixture.reset();
+    await fixture.store.nodes.SharedLeaf.create({
+      email: "shared@example.com",
+    });
+
+    const statement = nodeWrite(fixture.statements);
+    expectFusedClaimAndNode(statement);
+    expect(statement.query).toMatch(/node_pre_claimed/iu);
+    expect(statement.query.indexOf('"node_pre_claimed"')).toBeLessThan(
+      statement.query.indexOf('"node_inserted"'),
+    );
+    expect(claimNames(statement, [SHARED_UNIQUE.name])).toEqual([
+      SHARED_UNIQUE.name,
+    ]);
+  });
+
+  it("fuses a disjointness claim before a generated node insert", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+
+    fixture.reset();
+    await fixture.store.nodes.ClaimPerson.create({ name: "person" });
+
+    const statement = nodeWrite(fixture.statements);
+    expectFusedClaimAndNode(statement);
+    expect(statement.query).toMatch(/node_pre_claimed/iu);
+    expect(statement.query).not.toMatch(/node_post_claimed/iu);
+  });
+
+  it("keeps multiple mixed claims in their canonical pre/post phases", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+
+    fixture.reset();
+    await fixture.store.nodes.MixedLeaf.create({
+      email: "mixed@example.com",
+      handle: "mixed-handle",
+    });
+
+    const statement = nodeWrite(fixture.statements);
+    expectFusedClaimAndNode(statement);
+    expect(statement.query.indexOf('"node_pre_claimed"')).toBeLessThan(
+      statement.query.indexOf('"node_inserted"'),
+    );
+    expect(statement.query.indexOf('"node_inserted"')).toBeLessThan(
+      statement.query.indexOf('"node_post_claimed"'),
+    );
+    expect(
+      claimNames(statement, [SHARED_UNIQUE.name, SAME_KIND_UNIQUE.name]),
+    ).toEqual([SAME_KIND_UNIQUE.name, SHARED_UNIQUE.name]);
+  });
+
+  it("falls back to separate claim and node statements when the member is projected away", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+    const projected: GraphBackend = deriveBackend(fixture.backend, {
+      async transaction<T>(
+        fn: (tx: TransactionBackend) => Promise<T>,
+        options?: Parameters<NonNullable<GraphBackend["transaction"]>>[1],
+      ): Promise<T> {
+        return fixture.backend.transaction(
+          (tx) => fn(projectBackendWithout(tx, ["insertNodeWithProjections"])),
+          options,
+        );
+      },
+    });
+    const store = createStore(graph, projected);
+
+    fixture.reset();
+    await store.nodes.UniqueNode.create({ email: "fallback@example.com" });
+
+    const entityStatements = fixture.statements.filter(
+      (statement) => hasNodeInsert(statement) || hasUniqueClaim(statement),
+    );
+    expect(entityStatements.some((statement) => hasNodeInsert(statement))).toBe(
+      true,
+    );
+    expect(
+      entityStatements.some(
+        (statement) => hasNodeInsert(statement) && hasUniqueClaim(statement),
+      ),
+    ).toBe(false);
+  });
+
+  it("fuses claims and fulltext projection side effects in one statement", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+    const [store] = await createStoreWithSchema(graph, fixture.backend);
+
+    fixture.reset();
+    await store.nodes.SearchableUnique.create({
+      email: "search@example.com",
+      title: "one planned write",
+    });
+
+    const statement = nodeWrite(fixture.statements);
+    expectFusedClaimAndNode(statement);
+    expect(statement.query).toMatch(/typegraph_node_fulltext/iu);
+    expect(statement.query).toMatch(/node_post_claimed/iu);
+  }, 5000);
+
+  it("rolls back a post-insert claim conflict without leaking the node", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+    const holder = await fixture.store.nodes.UniqueNode.create(
+      { email: "post-conflict@example.com" },
+      { id: "post-holder" },
+    );
+
+    await expect(
+      fixture.backend.transaction(async (tx) =>
+        requireDefined(tx.insertNodeWithProjections)(
+          {
+            graphId: graph.id,
+            kind: "UniqueNode",
+            id: "post-loser",
+            props: { email: "post-conflict@example.com" },
+          },
+          {
+            mode: { kind: "ordinary" },
+            claims: [
+              {
+                axis: "UniqueNode",
+                constraintName: SAME_KIND_UNIQUE.name,
+                key: "post-conflict@example.com",
+                placement: "post-insert",
+              },
+            ],
+            projections: [],
+          },
+        ),
+      ),
+    ).rejects.toThrow();
+
+    expect(
+      await fixture.store.nodes.UniqueNode.getById("post-loser" as never),
+    ).toBeUndefined();
+    expect(
+      await fixture.backend.checkUnique({
+        graphId: graph.id,
+        nodeKind: "UniqueNode",
+        constraintName: SAME_KIND_UNIQUE.name,
+        key: "post-conflict@example.com",
+      }),
+    ).toMatchObject({ node_id: holder.id, concrete_kind: "UniqueNode" });
+  });
+
+  it("rolls back a pre-insert claim conflict without leaking a claim", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+    const holder = await fixture.store.nodes.SharedRoot.create(
+      { email: "pre-conflict@example.com" },
+      { id: "pre-holder" },
+    );
+
+    await expect(
+      fixture.backend.transaction(async (tx) =>
+        requireDefined(tx.insertNodeWithProjections)(
+          {
+            graphId: graph.id,
+            kind: "SharedLeaf",
+            id: "pre-loser",
+            props: { email: "pre-conflict@example.com" },
+          },
+          {
+            mode: { kind: "ordinary" },
+            claims: [
+              {
+                axis: "SharedLeaf",
+                constraintName: SHARED_UNIQUE.name,
+                key: "pre-conflict@example.com",
+                placement: "pre-insert",
+              },
+            ],
+            projections: [],
+          },
+        ),
+      ),
+    ).rejects.toThrow();
+
+    expect(
+      await fixture.store.nodes.SharedLeaf.getById("pre-loser" as never),
+    ).toBeUndefined();
+    expect(
+      await fixture.backend.checkUnique({
+        graphId: graph.id,
+        nodeKind: "SharedLeaf",
+        constraintName: SHARED_UNIQUE.name,
+        key: "pre-conflict@example.com",
+      }),
+    ).toMatchObject({ node_id: holder.id, concrete_kind: "SharedRoot" });
+  });
+});

--- a/packages/typegraph/tests/node-fulltext-write-fusion.test.ts
+++ b/packages/typegraph/tests/node-fulltext-write-fusion.test.ts
@@ -65,6 +65,7 @@ function fulltextProjection(fulltext: NodeFulltextSync): NodeInsertProjection {
 function ordinaryPlan(fulltext: NodeFulltextSync): NodeInsertPlan {
   return {
     mode: { kind: "ordinary" },
+    claims: [],
     projections: [fulltextProjection(fulltext)],
   };
 }
@@ -75,6 +76,7 @@ function schemaFencedPlan(
 ): NodeInsertPlan {
   return {
     mode: { kind: "schema-fenced", schemaFence },
+    claims: [],
     projections: [fulltextProjection(fulltext)],
   };
 }

--- a/packages/typegraph/tests/node-vector-write-fusion.test.ts
+++ b/packages/typegraph/tests/node-vector-write-fusion.test.ts
@@ -239,6 +239,7 @@ describe("fresh node + vector write fusion", () => {
           },
           {
             mode: { kind: "ordinary" },
+            claims: [],
             projections: [
               {
                 kind: "embedding",

--- a/packages/typegraph/tests/temporal-builder-inventory.test.ts
+++ b/packages/typegraph/tests/temporal-builder-inventory.test.ts
@@ -61,6 +61,7 @@ const COLUMN_MENTION = /validFrom|valid_from/;
  */
 const WRITER_INVENTORY = {
   "drizzle/operations/nodes.ts": { stamping: 8, stated: 0 },
+  "drizzle/operations/node-projections.ts": { stamping: 2, stated: 0 },
   "drizzle/operations/edges.ts": { stamping: 6, stated: 1 },
   "drizzle/operations/edge-claims.ts": { stamping: 1, stated: 0 },
   "drizzle/trusted-import.ts": { stamping: 4, stated: 0 },
@@ -84,6 +85,7 @@ const WRITER_INVENTORY = {
  */
 const LEAK_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
   "drizzle/operations/edge-claims.ts": [],
+  "drizzle/operations/node-projections.ts": [],
   "drizzle/operations/nodes.ts": [
     // The compare-and-set fence's column argument — a READ of the bound the
     // caller asserted, never a choice about what to store.
@@ -117,6 +119,8 @@ const BACKEND_COLUMN_FILES: Readonly<Record<string, string>> = {
   "drizzle/operations/edge-claims.ts":
     "writer — fused cardinality claim and edge insert",
   "drizzle/operations/nodes.ts": "writer — five stamping sites",
+  "drizzle/operations/node-projections.ts":
+    "writer — planned node insert in ordinary and schema-fenced modes",
   "drizzle/operations/edges.ts":
     "writer — four stamping sites, one pass-through",
   "drizzle/trusted-import.ts":
@@ -223,6 +227,6 @@ describe("the stamping-site inventory (I5)", () => {
     for (const role of Object.values(BACKEND_COLUMN_FILES)) {
       expect(role.length).toBeGreaterThan(0);
     }
-    expect(Object.keys(BACKEND_COLUMN_FILES)).toHaveLength(14);
+    expect(Object.keys(BACKEND_COLUMN_FILES)).toHaveLength(15);
   });
 });

--- a/packages/typegraph/tests/write-plan-statement-order.test.ts
+++ b/packages/typegraph/tests/write-plan-statement-order.test.ts
@@ -152,18 +152,6 @@ const graph = defineGraph({
 
 const statements: LoggedStatement[] = [];
 
-/**
- * The relation names the claim-placement matchers below look for, read from the
- * same schema builder the store uses rather than spelled as literals: a
- * configured table prefix would silently make a substring matcher match nothing,
- * and a matcher that matches nothing passes every "before" comparison it is not
- * guarded against.
- */
-const SCHEMA_TABLES = {
-  nodes: "typegraph_nodes",
-  nodeUniques: "typegraph_node_uniques",
-} as const;
-
 let store: Store<typeof graph>;
 let backend: GraphBackend;
 let closeClient: () => Promise<void>;
@@ -646,19 +634,15 @@ describe("unconstrained edge endpoint fusion", () => {
  * covers uniqueness and disjointness alike.
  */
 function indexOfClaimStatement(): number {
-  return statements.findIndex(
-    (statement) =>
-      /^\s*insert/i.test(statement.query) &&
-      statement.query.includes(SCHEMA_TABLES.nodeUniques),
+  return statements.findIndex((statement) =>
+    /insert\s+into\s+"typegraph_node_uniques"/iu.test(statement.query),
   );
 }
 
 /** The first statement that writes the node row itself. */
 function indexOfNodeRowStatement(): number {
-  return statements.findIndex(
-    (statement) =>
-      /^\s*insert/i.test(statement.query) &&
-      statement.query.includes(SCHEMA_TABLES.nodes),
+  return statements.findIndex((statement) =>
+    /insert\s+into\s+"typegraph_nodes"/iu.test(statement.query),
   );
 }
 
@@ -676,10 +660,9 @@ function indexOfNodeRowStatement(): number {
  * fence, and a sync fan issued before the row can write derived data for a row
  * that never landed.
  *
- * Named mutation, verified to bite: invert the placement partition in
- * `withNodeCreateClaimsIssuedBy` (`claims/node-claims.ts`) so the post-insert
- * group is issued first → this case fails, because the claim then follows the
- * row it is supposed to gate.
+ * Named mutation, verified to bite: omit the claim list at the session-to-
+ * backend plan boundary → the fused statement no longer contains the claim
+ * relation and this case fails.
  *
  * The other half of the pinned order — the sync fans FOLLOW the row — is pinned
  * in `session-sidecar-completeness.test.ts`, whose fixture actually declares a
@@ -687,7 +670,7 @@ function indexOfNodeRowStatement(): number {
  * case here would assert against a statement that is never emitted.
  */
 describe("claims and row work keep their pinned order", () => {
-  it("issues a pre-insert claim BEFORE the row it gates", async () => {
+  it("issues a pre-insert claim before the row it gates in one statement", async () => {
     // A `kindWithSubClasses` scope: the axis spans sibling kinds no single
     // primary key backs, which is exactly the claim that must precede its row.
     await store.nodes.Employee.create({
@@ -699,7 +682,11 @@ describe("claims and row work keep their pinned order", () => {
     const row = indexOfNodeRowStatement();
     expect(claim).toBeGreaterThanOrEqual(0);
     expect(row).toBeGreaterThanOrEqual(0);
-    expect(claim).toBeLessThan(row);
+    expect(claim).toBe(row);
+    const query = statements[claim]?.query ?? "";
+    expect(query.indexOf('"node_pre_claimed"')).toBeLessThan(
+      query.indexOf('"node_inserted"'),
+    );
   });
 });
 

--- a/packages/typegraph/vitest.config.ts
+++ b/packages/typegraph/vitest.config.ts
@@ -30,6 +30,7 @@ const PGLITE_GLOBS = [
   "tests/constraint-write-fence.test.ts",
   "tests/contribution-rebuild-lock.test.ts",
   "tests/materialize-trigram-extension.test.ts",
+  "tests/node-claim-write-fusion.test.ts",
   // T15/T16 (B10): each posture in `tests/lock-fence-test-utils.ts`'s
   // `createLoggedPostgresBackend` boots its own in-process PGlite instance —
   // several per file — so these belong here for the same reason the


### PR DESCRIPTION
## Summary

Extend the declarative node insert plan so one PostgreSQL statement can apply canonical pre-insert and post-insert uniqueness/disjointness claims together with the node row and any fulltext or vector projections. This removes one stateful round trip per claim while preserving the existing read probes for the next optimization batch.

The store computes claim placement and ordering once, then either lowers the complete plan through a transaction-scoped PostgreSQL backend or uses the existing portable standalone-claim fallback. An explicit atomic-claim capability prevents projected and third-party backends from silently accepting plan fields they do not implement.

Claim conflicts return structured holder metadata from the statement and preserve the existing UniquenessError and DisjointError contracts. Claim-bearing plans are refused on root autocommit handles and schema-fenced plans because their rollback boundaries cannot safely honor a post-DML refusal. The public claims field remains optional for source compatibility with projection-only plan callers.

The generated SQL dependency-links pre-claims, the node insert, post-claims, and projections. Runtime regressions cover successful mixed plans, fulltext composition, portable fallback, root and schema-fence refusal, and rollback after both pre-claim and post-claim conflicts. As a load-bearing mutation check, removing claims from the plan made the fused-statement regression fail on the missing uniqueness relation; restoring the plan returned it to green.

Part of #533.