### PR TITLE
perf: execute constrained edge batches as atomic write programs

### DIFF
--- a/.changeset/constrained-edge-batch-programs.md
+++ b/.changeset/constrained-edge-batch-programs.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Execute eligible durable-match and cardinality-constrained `edges.bulkInsert` and `edges.bulkCreate` calls as one schema-fenced atomic exchange on bundled Neon HTTP, Cloudflare D1, and libSQL roots. The program maintains stale-claim takeover and legacy-incumbent detection, preserves typed endpoint, match-identity, and cardinality refusals, and rolls back every edge row when any constraint sidecar fails.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -645,13 +645,15 @@ catch-all:
   transactionless path for eligible durable edge `matchIdentity` convergence;
   it is not a promise that every command or side effect can be fused.
 
-Operational Identity, claim/cardinality checks, and undeclared dynamic
-`matchOn` convergence remain interactive-transaction contracts. A custom or
-non-transactional backend must refuse those dimensions rather than silently
-falling through to a sequence of independent statements. A declared durable
-edge `matchIdentity` is different: its canonical key has a database arbiter,
-so the eligible root create/found command can be authoritative in one
-statement.
+Operational Identity, single-edge claim/cardinality checks, and undeclared
+dynamic `matchOn` convergence remain interactive-transaction contracts. A
+custom or non-transactional backend must refuse those dimensions rather than
+silently falling through to a sequence of independent statements. Eligible
+direct edge batches on bundled roots are a narrower static-program contract:
+the insert and cardinality sidecars execute in one native atomic exchange. A
+declared durable edge `matchIdentity` is different for endpoint convergence:
+its canonical key has a database arbiter, so the eligible root create/found
+command can be authoritative in one statement.
 
 ### Connection Pooling
 
@@ -1423,7 +1425,7 @@ TypeGraph choosing separate query semantics per backend:
 | Managed node projection fusion                        | ✗ portable transactional fallback                    | ✓ PostgreSQL/PGlite                        | SQLite writes the node and fulltext/vector sidecars through the portable transaction path. PostgreSQL can compile them into one managed statement when every active strategy supplies an inserted-node builder |
 | Managed node claim fusion (`capabilities.atomicNodeInsertClaims`) | ✗ portable transactional fallback             | ✓ PostgreSQL/PGlite                        | SQLite keeps claim acquisition and insertion in the portable transaction. PostgreSQL transaction receivers fuse supported claim plans; a root non-transactional receiver is limited to exactly one generated-id, same-kind uniqueness claim with no other side effects |
 | Managed edge cardinality fusion                       | ✗ portable transactional fallback                    | ✓ PostgreSQL/PGlite transaction receivers | SQLite keeps its guarded claim and edge insert in the portable transaction. PostgreSQL can combine endpoint liveness, one cardinality claim, and the insert in one statement after any required graph lock |
-| Eligible bundled-root managed autocommit              | ✓ bundled SQLite roots, including D1 and libSQL     | ✓ bundled PostgreSQL roots, including neon-http | Eligible singleton generated-ID nodes and `cardinality: "many"` edges use one authoritative statement. Projection-free node `bulkInsert` batches with generated IDs and no claims, Operational Identity, history, or revision work can additionally use one schema-fenced native atomic exchange. Derived wrappers, adopted caller transactions, caller-supplied batch IDs, custom backends, and other managed writes retain the existing path |
+| Eligible bundled-root managed autocommit              | ✓ bundled SQLite roots, including D1 and libSQL     | ✓ bundled PostgreSQL roots, including neon-http | Eligible singleton generated-ID nodes and `cardinality: "many"` edges use one authoritative statement. Projection-free generated-ID node batches and direct edge batches without history/revision capture use one schema-fenced native atomic exchange; edge programs also maintain durable match identity and cardinality claims. Derived wrappers, adopted caller transactions, caller-supplied node batch IDs, custom backends, and other managed writes retain the existing path |
 | Typed constraint error above READ COMMITTED            | n/a (no such isolation mode)                      | ✗ at `REPEATABLE READ` / `SERIALIZABLE`    | PostgreSQL raises `40001` from the claim's upsert instead of resolving the conflict, so the loser retries a serialization failure rather than reading `UniquenessError` |
 | Claim row lock released before end of transaction      | ✗                                                 | ✗                                          | Held to commit/rollback on both dialects, refusal included — a caller that catches a constraint error blocks other writers of that axis for the rest of its transaction |
 | Recursive traversal (`capabilities.recursiveTraversal`) | ✓                                                 | ✓                                          | Identical on both bundled backends. A third-party backend declaring `{ supported: false, reason }` refuses the five recursion-dependent operations with `ConfigurationError` code `RECURSIVE_TRAVERSAL_UNSUPPORTED`; `weightedShortestPath` degrades to a predecessor walk instead — see above. Unweighted `shortestPath` is unaffected — it never emits a recursive CTE |

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -82,9 +82,12 @@ calls atomic. An authoritative command is a single `commands.execute` write
 whose database statement returns the decision it made. It can provide a safe
 transactionless create/found path only when the backend has a durable arbiter.
 
-Operational Identity, claim/cardinality enforcement, and undeclared dynamic
-`matchOn` convergence still require an interactive transaction and fail closed
-on a backend that cannot provide one. A declared edge `matchIdentity` persists
+Operational Identity, single-edge claim/cardinality enforcement, and
+undeclared dynamic `matchOn` convergence still require an interactive
+transaction and fail closed on a backend that cannot provide one. Eligible
+direct edge batches on bundled roots are the narrow exception: their closed
+native program carries the claim sidecars inside one atomic exchange. A
+declared edge `matchIdentity` persists
 a canonical endpoint/property key and has a unique database arbiter; eligible
 root `getOrCreateByEndpoints` calls can therefore use the authoritative
 one-statement command. The durable identity does not make unrelated Store
@@ -314,6 +317,14 @@ API. Caller-supplied IDs and unsupported shapes retain the existing
 transaction or fallback behavior. Generated-ID node bulk operations also avoid
 the guaranteed-empty existence-priming read; caller-supplied IDs still perform
 their existence checks.
+
+Direct `edges.bulkInsert()` and `edges.bulkCreate()` calls on those same roots
+use one schema-fenced native exchange when history and revision capture are
+disabled. Declared durable match identities and `one`, `unique`, or
+`oneActive` cardinality are maintained inside that exchange; any endpoint,
+identity, or cardinality refusal rolls the whole call back. Transaction-scoped
+stores, derived/custom backends, and dynamic get-or-create convergence retain
+the interactive path.
 
 ### One `bulkUpsertById` batch cannot hand a constrained value between rows
 

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -124,9 +124,11 @@ PostgreSQL implementation performs a no-op conflict update: it takes a row lock
 and can create write amplification, so it is not a substitute for a hot read
 cache.
 
-Dynamic call-level `matchOn`, constrained cardinalities, history/revision
+Dynamic call-level `matchOn`, constrained single-edge writes, history/revision
 stores, caller-owned transactions, and custom backends retain the transactional
-path required by their additional contracts. Bulk endpoint convergence still
+path required by their additional contracts. Eligible direct edge batches can
+instead carry their cardinality claims inside the native atomic program
+described below. Bulk endpoint convergence still
 uses one transaction in this release, but bundled backends discover exact
 directed endpoint pairs in set-oriented bind-budget chunks instead of issuing a
 candidate read per item. See
@@ -151,22 +153,25 @@ Generated-ID node batches also skip the guaranteed-empty existence-priming
 read; caller-supplied IDs retain their existence and resurrection checks.
 
 Both `edges.bulkInsert(items)` and `edges.bulkCreate(items)` use one
-schema-fenced atomic exchange when every edge has unconstrained `many`
-cardinality, no durable `matchIdentity`, and the store has no history or
-revision capture. The program validates live endpoints at the write boundary,
-rolls back the whole call when any bind-budget chunk fails, and restores
-`bulkCreate()` results to input order. At the data-statement layer, its success
-path changes from one endpoint read per referenced node kind plus one insert
-per bind-budget chunk to one exchange for the entire call. For a one-chunk
-batch this is commonly 2 → 1 data exchanges when both endpoints share a kind
-or 3 → 1 when they use two kinds. The previous path can additionally pay a
-schema-fence statement and transaction framing, depending on the driver, so
-the full-call reduction may be larger.
+schema-fenced atomic exchange when the store has no history or revision
+capture. The program validates live endpoints, arbitrates declared durable
+`matchIdentity`, and maintains `one`, `unique`, and `oneActive` cardinality
+claims at the write boundary. It rolls back the whole call when any
+bind-budget chunk or constraint sidecar fails and restores `bulkCreate()`
+results to input order.
+
+Measured at the libSQL transport boundary, a one-chunk unconstrained edge
+batch remains 1 exchange, a durable-match batch drops from 6 transport
+submissions to 1 atomic exchange, and a cardinality-constrained batch drops
+from 8 transport submissions to 1 atomic exchange. The native exchange still
+contains the SQL statements needed for inserts and sidecars; it submits them as
+one transaction so they do not each pay network latency. The exact previous
+count varies by driver and endpoint shape.
 
 These are internal execution optimizations, not a public Store batch API.
-Constrained cardinality, durable identity, history/revision capture,
-caller-owned transactions, derived or custom backends, and other unsupported
-shapes retain their transaction or fallback behavior.
+History/revision capture, caller-owned transactions, derived or custom
+backends, dynamic get-or-create convergence, and other unsupported shapes
+retain their transaction or fallback behavior.
 
 ### Single vs bulk operations
 
@@ -197,19 +202,19 @@ PostgreSQL's protocol can encode 65,535 bind parameters, while TypeGraph uses a 
 stay within that budget:
 
 - Node inserts: ~7,200 per chunk (9 params per node)
-- Edge inserts: ~5,400 per chunk (12 params per edge)
+- Edge inserts: ~4,680 per chunk (budgeted at 14 params per durable edge)
 
 You don't need to chunk manually — pass arrays of any size and TypeGraph handles the rest.
 
 ### Transaction wrapping
 
 On a transaction-capable backend, each bulk method call is atomic across all of its bind-budget
-chunks. Eligible generated-ID `nodes.bulkInsert()` and unconstrained `edges.bulkInsert()` /
+chunks. Eligible generated-ID `nodes.bulkInsert()` and direct `edges.bulkInsert()` /
 `edges.bulkCreate()` calls also provide whole-call atomicity on bundled transactionless roots through
-one native atomic exchange. Other bulk shapes on a transactionless root either refuse when their
-contract requires a fence or use sequential fallback, which can leave earlier chunks committed if a
-later one fails. `store.transaction()` cannot add atomicity to a backend that does not support
-transactions.
+one native atomic exchange, including durable-match and cardinality-constrained edge batches. Other
+bulk shapes on a transactionless root either refuse when their contract requires a fence or use
+sequential fallback, which can leave earlier chunks committed if a later one fails.
+`store.transaction()` cannot add atomicity to a backend that does not support transactions.
 
 To commit several bulk calls as one unit on a transaction-capable backend, wrap them in a
 transaction:

--- a/packages/typegraph/src/backend/capabilities/atomic-edge-batch.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-edge-batch.ts
@@ -7,6 +7,7 @@
  * program whose atomicity contract belongs to the bundled root.
  */
 import type {
+  ClaimEdgeCardinalityParams,
   EdgeRow,
   GraphBackend,
   InsertEdgeParams,
@@ -15,12 +16,14 @@ import type {
 } from "../types";
 
 export type AtomicEdgeBatchCountInput = Readonly<{
+  claims: readonly ClaimEdgeCardinalityParams[];
   params: readonly InsertEdgeParams[];
   resultMode: "count";
   schemaFence: SchemaWriteFenceParams;
 }>;
 
 export type AtomicEdgeBatchRowsInput = Readonly<{
+  claims: readonly ClaimEdgeCardinalityParams[];
   params: readonly InsertEdgeParams[];
   resultMode: "rows";
   schemaFence: SchemaWriteFenceParams;
@@ -41,6 +44,14 @@ export class AtomicEdgeBatchEndpointRefusalError extends Error {
   constructor(cause: unknown) {
     super("Atomic edge batch endpoint validation failed", { cause });
     this.name = "AtomicEdgeBatchEndpointRefusalError";
+  }
+}
+
+/** Internal proof that the closed SQL program refused a cardinality claim. */
+export class AtomicEdgeBatchCardinalityRefusalError extends Error {
+  constructor(cause: unknown) {
+    super("Atomic edge batch cardinality validation failed", { cause });
+    this.name = "AtomicEdgeBatchCardinalityRefusalError";
   }
 }
 

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -34,6 +34,7 @@ import {
   isNotNullColumnViolation,
   type PrimaryKeyRelation,
 } from "../../utils/sql-errors";
+import { encodeTupleKey } from "../../utils/tuple-key";
 import {
   AtomicEdgeBatchCardinalityRefusalError,
   type AtomicEdgeBatchCountInput,
@@ -129,10 +130,11 @@ import {
 } from "./operations/strategy";
 
 // The set-based claim acquisition is the widest sidecar statement: five row
-// values plus the inserted-edge and competing-holder predicates. Keep a
-// conservative ceiling so every dialect remains below its declared bind
-// budget even for `unique`, whose axis includes both endpoints.
-const ATOMIC_EDGE_CLAIM_PARAM_COUNT = 16;
+// values, both endpoint probes, and the competing-holder predicate. `unique`
+// is the widest cardinality because that predicate binds both destination
+// fields as well as the source fields. Chunk every cardinality to that ceiling
+// so a mixed batch cannot cross the driver's per-statement bind budget.
+const ATOMIC_EDGE_CLAIM_PARAM_COUNT = 18;
 
 function assertMatchingFusedEdgeClaim(
   params: InsertEdgeParams,
@@ -489,17 +491,12 @@ async function withDuplicateKeyClassification<T>(
 
 async function withAtomicEdgeEndpointRefusalClassification<T>(
   run: () => Promise<T>,
-  relation: PrimaryKeyRelation,
+  constraint: Readonly<{ table: string; column: string }>,
 ): Promise<T> {
   try {
     return await run();
   } catch (error) {
-    if (
-      isNotNullColumnViolation(error, {
-        table: relation.table,
-        column: "id",
-      })
-    ) {
+    if (isNotNullColumnViolation(error, constraint)) {
       throw new AtomicEdgeBatchEndpointRefusalError(error);
     }
     throw error;
@@ -508,17 +505,12 @@ async function withAtomicEdgeEndpointRefusalClassification<T>(
 
 async function withAtomicEdgeCardinalityRefusalClassification<T>(
   run: () => Promise<T>,
-  edgeClaimsTableName: string,
+  constraint: Readonly<{ table: string; column: string }>,
 ): Promise<T> {
   try {
     return await run();
   } catch (error) {
-    if (
-      isNotNullColumnViolation(error, {
-        table: edgeClaimsTableName,
-        column: "axis",
-      })
-    ) {
+    if (isNotNullColumnViolation(error, constraint)) {
       throw new AtomicEdgeBatchCardinalityRefusalError(error);
     }
     throw error;
@@ -528,6 +520,7 @@ async function withAtomicEdgeCardinalityRefusalClassification<T>(
 async function withAtomicEdgeDurableRefusalClassification<T>(
   run: () => Promise<T>,
   relation: PrimaryKeyRelation,
+  constraint: Readonly<{ table: string; column: string }>,
   attempted: readonly AttemptedEdgeMatchIdentity[] | undefined,
 ): Promise<T> {
   try {
@@ -535,10 +528,7 @@ async function withAtomicEdgeDurableRefusalClassification<T>(
   } catch (error) {
     if (
       attempted !== undefined &&
-      isNotNullColumnViolation(error, {
-        table: relation.table,
-        column: "created_at",
-      })
+      isNotNullColumnViolation(error, constraint)
     ) {
       throw new EdgeMatchIdentityConflictError(
         { attempted },
@@ -575,7 +565,7 @@ async function executeClassifiedAtomicEdgeBatch<TSlot, TResult>(
   atomicExecutor: AtomicSqlProgramExecutor,
   program: AtomicSqlProgram<TSlot, TResult>,
   relation: PrimaryKeyRelation,
-  edgeClaimsTableName: string,
+  refusalConstraints: CommonOperationStrategy["atomicEdgeRefusalConstraints"],
   params: readonly InsertEdgeParams[],
   claims: readonly ClaimEdgeCardinalityParams[],
 ): Promise<TResult> {
@@ -590,11 +580,12 @@ async function executeClassifiedAtomicEdgeBatch<TSlot, TResult>(
                 withAtomicEdgeDurableRefusalClassification(
                   () => atomicExecutor.execute(program),
                   relation,
+                  refusalConstraints.durableIdentity,
                   matchIdentities,
                 ),
-              edgeClaimsTableName,
+              refusalConstraints.cardinality,
             ),
-          relation,
+          refusalConstraints.endpoint,
         ),
       {
         entity: "edge",
@@ -618,7 +609,10 @@ async function executeClassifiedAtomicEdgeBatch<TSlot, TResult>(
       );
     }
     if (claims.length > 0 && isMissingTableError(error)) {
-      throw edgeClaimRelationMissing(requireDefined(params[0]).graphId, error);
+      throw edgeClaimRelationMissing(
+        requireDefined(params[0]).graphId,
+        error,
+      );
     }
     throw error;
   }
@@ -1051,10 +1045,15 @@ export function createCommonOperationBackend(
             return input.resultMode === "count" ? 0 : [];
           }
           assertMatchingEdgeSchemaFences(input.params, input.schemaFence);
+          const paramsByGraphAndId = new Map(
+            input.params.map((params) => [
+              encodeTupleKey([params.graphId, params.id]),
+              params,
+            ]),
+          );
           for (const claim of input.claims) {
-            const params = input.params.find(
-              (item) =>
-                item.graphId === claim.graphId && item.id === claim.edgeId,
+            const params = paramsByGraphAndId.get(
+              encodeTupleKey([claim.graphId, claim.edgeId]),
             );
             if (params === undefined) {
               throw new CompilerInvariantError(
@@ -1162,7 +1161,7 @@ export function createCommonOperationBackend(
               atomicExecutor,
               program,
               operationStrategy.primaryKeyConstraints.edges,
-              operationStrategy.edgeClaimsTableName,
+              operationStrategy.atomicEdgeRefusalConstraints,
               input.params,
               input.claims,
             );
@@ -1234,7 +1233,7 @@ export function createCommonOperationBackend(
             atomicExecutor,
             program,
             operationStrategy.primaryKeyConstraints.edges,
-            operationStrategy.edgeClaimsTableName,
+            operationStrategy.atomicEdgeRefusalConstraints,
             input.params,
             input.claims,
           );

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -22,6 +22,7 @@ import { type ClaimOwner, isSameClaimOwner } from "../../store/claims/axis";
 import {
   type ConstrainedCardinality,
   edgeCardinalityClaimTarget,
+  edgeClaimRelationMissing,
 } from "../../store/claims/edge-claims";
 import { chunk as chunkArray } from "../../utils/array";
 import { requireDefined } from "../../utils/presence";
@@ -29,10 +30,12 @@ import {
   isDuplicatePrimaryKeyError,
   isDuplicateUniqueIndexError,
   isEdgeMatchIdentityStorageUnavailableError,
+  isMissingTableError,
   isNotNullColumnViolation,
   type PrimaryKeyRelation,
 } from "../../utils/sql-errors";
 import {
+  AtomicEdgeBatchCardinalityRefusalError,
   type AtomicEdgeBatchCountInput,
   AtomicEdgeBatchEndpointRefusalError,
   type AtomicEdgeBatchExecutor,
@@ -124,6 +127,12 @@ import {
   createCachedTableExistence,
   type TableExistenceCacheOptions,
 } from "./operations/strategy";
+
+// The set-based claim acquisition is the widest sidecar statement: five row
+// values plus the inserted-edge and competing-holder predicates. Keep a
+// conservative ceiling so every dialect remains below its declared bind
+// budget even for `unique`, whose axis includes both endpoints.
+const ATOMIC_EDGE_CLAIM_PARAM_COUNT = 16;
 
 function assertMatchingFusedEdgeClaim(
   params: InsertEdgeParams,
@@ -497,6 +506,49 @@ async function withAtomicEdgeEndpointRefusalClassification<T>(
   }
 }
 
+async function withAtomicEdgeCardinalityRefusalClassification<T>(
+  run: () => Promise<T>,
+  edgeClaimsTableName: string,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (
+      isNotNullColumnViolation(error, {
+        table: edgeClaimsTableName,
+        column: "axis",
+      })
+    ) {
+      throw new AtomicEdgeBatchCardinalityRefusalError(error);
+    }
+    throw error;
+  }
+}
+
+async function withAtomicEdgeDurableRefusalClassification<T>(
+  run: () => Promise<T>,
+  relation: PrimaryKeyRelation,
+  attempted: readonly AttemptedEdgeMatchIdentity[] | undefined,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (
+      attempted !== undefined &&
+      isNotNullColumnViolation(error, {
+        table: relation.table,
+        column: "created_at",
+      })
+    ) {
+      throw new EdgeMatchIdentityConflictError(
+        { attempted },
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
 function assertCompleteAtomicEdgeChunks(
   actualCounts: readonly number[],
   expectedChunks: readonly (readonly unknown[])[],
@@ -515,20 +567,61 @@ function assertCompleteAtomicEdgeChunks(
   );
 }
 
+function decodeNoEdgeRows(): readonly EdgeRow[] {
+  return [];
+}
+
 async function executeClassifiedAtomicEdgeBatch<TSlot, TResult>(
   atomicExecutor: AtomicSqlProgramExecutor,
   program: AtomicSqlProgram<TSlot, TResult>,
   relation: PrimaryKeyRelation,
-  attempted: readonly AttemptedInsert[],
+  edgeClaimsTableName: string,
+  params: readonly InsertEdgeParams[],
+  claims: readonly ClaimEdgeCardinalityParams[],
 ): Promise<TResult> {
-  return withDuplicateKeyClassification(
-    () =>
-      withAtomicEdgeEndpointRefusalClassification(
-        () => atomicExecutor.execute(program),
+  const matchIdentities = attemptedEdgeMatchIdentities(params);
+  try {
+    return await withDuplicateKeyClassification(
+      () =>
+        withAtomicEdgeEndpointRefusalClassification(
+          () =>
+            withAtomicEdgeCardinalityRefusalClassification(
+              () =>
+                withAtomicEdgeDurableRefusalClassification(
+                  () => atomicExecutor.execute(program),
+                  relation,
+                  matchIdentities,
+                ),
+              edgeClaimsTableName,
+            ),
+          relation,
+        ),
+      {
+        entity: "edge",
         relation,
-      ),
-    { entity: "edge", relation, attempted },
-  );
+        attempted: attemptedInserts(params),
+        matchIdentities,
+      },
+    );
+  } catch (error) {
+    const durableParams = params.find(
+      (item) => item.matchIdentity !== undefined,
+    );
+    if (
+      durableParams !== undefined &&
+      isEdgeMatchIdentityStorageUnavailableError(error)
+    ) {
+      throwDurableIdentityStorageUnavailable(
+        error,
+        durableParams,
+        requireDefined(durableParams.matchIdentity).name,
+      );
+    }
+    if (claims.length > 0 && isMissingTableError(error)) {
+      throw edgeClaimRelationMissing(requireDefined(params[0]).graphId, error);
+    }
+    throw error;
+  }
 }
 
 function attemptedEdgeMatchIdentities(
@@ -958,15 +1051,90 @@ export function createCommonOperationBackend(
             return input.resultMode === "count" ? 0 : [];
           }
           assertMatchingEdgeSchemaFences(input.params, input.schemaFence);
+          for (const claim of input.claims) {
+            const params = input.params.find(
+              (item) =>
+                item.graphId === claim.graphId && item.id === claim.edgeId,
+            );
+            if (params === undefined) {
+              throw new CompilerInvariantError(
+                "An atomic edge batch claim has no matching input row.",
+                { graphId: claim.graphId, edgeId: claim.edgeId },
+              );
+            }
+            assertMatchingFusedEdgeClaim(params, claim);
+          }
 
           const timestamp = nowIso();
           const chunks = chunkArray(
             input.params,
             batchConfig.edgeSchemaFencedInsertBatchSize,
           );
+          const atomicEdgeClaimBatchSize = Math.max(
+            1,
+            Math.floor(
+              (maxBindParameters - 2) / ATOMIC_EDGE_CLAIM_PARAM_COUNT,
+            ),
+          );
+          function appendClaimSlots<TResult>(
+            slots: AtomicSqlProgram<TResult, unknown>["slots"][number][],
+            claims: readonly ClaimEdgeCardinalityParams[],
+            decode: AtomicSqlProgram<
+              TResult,
+              unknown
+            >["slots"][number]["decode"],
+          ): void {
+            for (const claimChunk of chunkArray(
+              claims,
+              atomicEdgeClaimBatchSize,
+            )) {
+              slots.push(
+                {
+                  statement: execution.compile(
+                    operationStrategy.buildDeleteStaleAtomicEdgeClaims(
+                      claimChunk,
+                      input.schemaFence,
+                      atomicSchemaFenceLockClause,
+                    ),
+                  ),
+                  cardinality: "none",
+                  decode,
+                },
+                {
+                  statement: execution.compile(
+                    operationStrategy.buildAcquireAtomicEdgeClaims(
+                      claimChunk,
+                      timestamp,
+                      input.schemaFence,
+                      atomicSchemaFenceLockClause,
+                    ),
+                  ),
+                  cardinality: "none",
+                  decode,
+                },
+                {
+                  statement: execution.compile(
+                    operationStrategy.buildAssertAtomicEdgeClaimsOwned(
+                      claimChunk,
+                      timestamp,
+                      input.schemaFence,
+                      atomicSchemaFenceLockClause,
+                    ),
+                  ),
+                  cardinality: "none",
+                  decode,
+                },
+              );
+            }
+          }
           if (input.resultMode === "count") {
-            const program = {
-              slots: chunks.map((chunk) => ({
+            const edgeSlotIndexes: number[] = [];
+            const slots: AtomicSqlProgram<number, number>["slots"][number][] =
+              [];
+            appendClaimSlots(slots, input.claims, (rows) => rows.length);
+            for (const chunk of chunks) {
+              edgeSlotIndexes.push(slots.length);
+              slots.push({
                 statement: execution.compile(
                   operationStrategy.buildInsertEdgesBatchWithSchemaFence(
                     chunk,
@@ -975,11 +1143,16 @@ export function createCommonOperationBackend(
                     atomicSchemaFenceLockClause,
                   ),
                 ),
-                cardinality: "many" as const,
-                decode: (rows: readonly Readonly<Record<string, unknown>>[]) =>
-                  rows.length,
-              })),
-              assemble(counts: readonly number[]): number {
+                cardinality: "many",
+                decode: (rows) => rows.length,
+              });
+            }
+            const program = {
+              slots,
+              assemble(slotCounts: readonly number[]): number {
+                const counts = edgeSlotIndexes.map((index) =>
+                  requireDefined(slotCounts[index]),
+                );
                 if (counts.every((count) => count === 0)) return 0;
                 assertCompleteAtomicEdgeChunks(counts, chunks);
                 return counts.reduce((total, count) => total + count, 0);
@@ -989,12 +1162,21 @@ export function createCommonOperationBackend(
               atomicExecutor,
               program,
               operationStrategy.primaryKeyConstraints.edges,
-              attemptedInserts(input.params),
+              operationStrategy.edgeClaimsTableName,
+              input.params,
+              input.claims,
             );
           }
 
-          const program = {
-            slots: chunks.map((chunk) => ({
+          const edgeSlotIndexes: number[] = [];
+          const slots: AtomicSqlProgram<
+            readonly EdgeRow[],
+            readonly EdgeRow[]
+          >["slots"][number][] = [];
+          appendClaimSlots(slots, input.claims, decodeNoEdgeRows);
+          for (const chunk of chunks) {
+            edgeSlotIndexes.push(slots.length);
+            slots.push({
               statement: execution.compile(
                 operationStrategy.buildInsertEdgesBatchReturningWithSchemaFence(
                   chunk,
@@ -1003,13 +1185,19 @@ export function createCommonOperationBackend(
                   atomicSchemaFenceLockClause,
                 ),
               ),
-              cardinality: "many" as const,
-              decode: (rows: readonly Readonly<Record<string, unknown>>[]) =>
+              cardinality: "many",
+              decode: (rows) =>
                 rows.map((row) => rowMappers.toEdgeRow(row)),
-            })),
+            });
+          }
+          const program = {
+            slots,
             assemble(
-              rowChunks: readonly (readonly EdgeRow[])[],
+              slotRows: readonly (readonly EdgeRow[])[],
             ): readonly EdgeRow[] {
+              const rowChunks = edgeSlotIndexes.map((index) =>
+                requireDefined(slotRows[index]),
+              );
               if (rowChunks.every((rows) => rows.length === 0)) return [];
               assertCompleteAtomicEdgeChunks(
                 rowChunks.map((rows) => rows.length),
@@ -1046,7 +1234,9 @@ export function createCommonOperationBackend(
             atomicExecutor,
             program,
             operationStrategy.primaryKeyConstraints.edges,
-            attemptedInserts(input.params),
+            operationStrategy.edgeClaimsTableName,
+            input.params,
+            input.claims,
           );
         }
 

--- a/packages/typegraph/src/backend/drizzle/operations/edge-claims.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/edge-claims.ts
@@ -9,8 +9,10 @@ import type {
   ClaimEdgeCardinalityParams,
   InsertEdgeParams,
   PurgeEdgeClaimsParams,
+  SchemaWriteFenceParams,
 } from "../../types";
 import {
+  castBoundValueForColumn,
   edgeColumnList,
   quotedColumn,
   quotedTableName,
@@ -63,6 +65,196 @@ function competingLiveEdgePredicate(
       AND ${qualified(edgesName, edges.kind)} = ${params.edgeKind}
       AND ${qualified(edgesName, edges.fromKind)} = ${params.fromKind}
       AND ${qualified(edgesName, edges.fromId)} = ${params.fromId}${toEndpointTerms}${activeTerm}
+  `;
+}
+
+function proposedEndpointsLivePredicate(
+  tables: Tables,
+  params: ClaimEdgeCardinalityParams,
+): SQL {
+  const { nodes } = tables;
+  return sql`
+    EXISTS (
+      SELECT 1 FROM ${nodes} AS "from_node"
+      WHERE ${qualifiedAlias("from_node", nodes.graphId)} = ${params.graphId}
+        AND ${qualifiedAlias("from_node", nodes.kind)} = ${params.fromKind}
+        AND ${qualifiedAlias("from_node", nodes.id)} = ${params.fromId}
+        AND ${qualifiedAlias("from_node", nodes.deletedAt)} IS NULL
+    )
+    AND EXISTS (
+      SELECT 1 FROM ${nodes} AS "to_node"
+      WHERE ${qualifiedAlias("to_node", nodes.graphId)} = ${params.graphId}
+        AND ${qualifiedAlias("to_node", nodes.kind)} = ${params.toKind}
+        AND ${qualifiedAlias("to_node", nodes.id)} = ${params.toId}
+        AND ${qualifiedAlias("to_node", nodes.deletedAt)} IS NULL
+    )
+  `;
+}
+
+function schemaFenceCte(
+  tables: Tables,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { schemaVersions } = tables;
+  return sql`
+    "schema_fence" AS (
+      SELECT ${schemaVersions.version}
+      FROM ${schemaVersions}
+      WHERE ${schemaVersions.graphId} = ${schemaFence.graphId}
+        AND ${schemaVersions.version} = ${schemaFence.expectedVersion}
+        AND ${schemaVersions.isActive} = TRUE
+      ${schemaLockClause}
+    )
+  `;
+}
+
+function recordedClaimHolderIsLivePredicate(
+  tables: Tables,
+  params: ClaimEdgeCardinalityParams,
+): SQL {
+  const { edgeClaims, edges } = tables;
+  const claimsName = getTableName(edgeClaims);
+  const edgesName = getTableName(edges);
+  const spec = EDGE_CARDINALITY_SPECS[params.cardinality];
+  const toEndpointTerms =
+    spec.keyShape === "fromAndTo" ?
+      sql` AND ${qualified(edgesName, edges.toKind)} = ${params.toKind} AND ${qualified(edgesName, edges.toId)} = ${params.toId}`
+    : sql``;
+  const activeTerm =
+    spec.holderLiveness === "liveAndActive" ?
+      sql` AND ${qualified(edgesName, edges.validTo)} IS NULL`
+    : sql``;
+  return sql`
+    ${qualified(edgesName, edges.graphId)} = ${qualified(claimsName, edgeClaims.graphId)}
+      AND ${qualified(edgesName, edges.id)} = ${qualified(claimsName, edgeClaims.edgeId)}
+      AND ${qualified(edgesName, edges.deletedAt)} IS NULL
+      AND ${qualified(edgesName, edges.kind)} = ${params.edgeKind}
+      AND ${qualified(edgesName, edges.fromKind)} = ${params.fromKind}
+      AND ${qualified(edgesName, edges.fromId)} = ${params.fromId}${toEndpointTerms}${activeTerm}
+  `;
+}
+
+/**
+ * Removes stale foreign holders before the guarded edge rows are inserted.
+ * The schema and endpoint gates ensure a stale fence remains a side-effect-free
+ * no-op; a later edge refusal rolls this mutation back with the whole program.
+ */
+export function buildDeleteStaleAtomicEdgeClaims(
+  tables: Tables,
+  entries: readonly ClaimEdgeCardinalityParams[],
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { edgeClaims, edges } = tables;
+  const claimsName = getTableName(edgeClaims);
+  const conditions = entries.map((entry) => {
+    const target = edgeCardinalityClaimTarget(entry);
+    return sql`
+      (
+            ${qualified(claimsName, edgeClaims.graphId)} = ${entry.graphId}
+            AND ${qualified(claimsName, edgeClaims.axis)} = ${target.axis}
+            AND ${qualified(claimsName, edgeClaims.key)} = ${target.key}
+            AND ${qualified(claimsName, edgeClaims.edgeId)} <> ${entry.edgeId}
+            AND EXISTS (SELECT 1 FROM "schema_fence")
+            AND ${proposedEndpointsLivePredicate(tables, entry)}
+            AND NOT EXISTS (
+              SELECT 1 FROM ${edges}
+              WHERE ${recordedClaimHolderIsLivePredicate(tables, entry)}
+            )
+          )
+    `;
+  });
+  return sql`
+    WITH ${schemaFenceCte(tables, schemaFence, schemaLockClause)}
+    DELETE FROM ${edgeClaims}
+    WHERE ${sql.join(conditions, sql` OR `)}
+  `;
+}
+
+/** Acquires every still-unowned axis before inserting the guarded edge rows. */
+export function buildAcquireAtomicEdgeClaims(
+  tables: Tables,
+  entries: readonly ClaimEdgeCardinalityParams[],
+  timestamp: string,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { edgeClaims, edges } = tables;
+  const columns = sql.raw(
+    `"${edgeClaims.graphId.name}", "${edgeClaims.axis.name}", "${edgeClaims.key.name}", "${edgeClaims.edgeId.name}", "${edgeClaims.updatedAt.name}"`,
+  );
+  const conflictColumns = sql.raw(
+    `"${edgeClaims.graphId.name}", "${edgeClaims.axis.name}", "${edgeClaims.key.name}"`,
+  );
+  const rows = entries.map((entry) => {
+    const target = edgeCardinalityClaimTarget(entry);
+    return sql`
+      SELECT
+        ${castBoundValueForColumn(edgeClaims.graphId, entry.graphId)},
+        ${castBoundValueForColumn(edgeClaims.axis, target.axis)},
+        ${castBoundValueForColumn(edgeClaims.key, target.key)},
+        ${castBoundValueForColumn(edgeClaims.edgeId, entry.edgeId)},
+        ${castBoundValueForColumn(edgeClaims.updatedAt, timestamp)}
+      FROM "schema_fence"
+      WHERE ${proposedEndpointsLivePredicate(tables, entry)}
+      AND NOT EXISTS (
+        SELECT 1 FROM ${edges}
+        WHERE ${competingLiveEdgePredicate(tables, entry)}
+      )
+    `;
+  });
+  return sql`
+    WITH ${schemaFenceCte(tables, schemaFence, schemaLockClause)}
+    INSERT INTO ${edgeClaims} (${columns})
+    ${sql.join(rows, sql` UNION ALL `)}
+    ON CONFLICT (${conflictColumns}) DO NOTHING
+  `;
+}
+
+/**
+ * Aborts the atomic transport when any proposed edge does not own its declared
+ * axis. The NULL axis is an internal sentinel classified at the backend seam;
+ * the surrounding native transaction rolls the earlier claim mutations back.
+ */
+export function buildAssertAtomicEdgeClaimsOwned(
+  tables: Tables,
+  entries: readonly ClaimEdgeCardinalityParams[],
+  timestamp: string,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { edgeClaims } = tables;
+  const claimsName = getTableName(edgeClaims);
+  const columns = sql.raw(
+    `"${edgeClaims.graphId.name}", "${edgeClaims.axis.name}", "${edgeClaims.key.name}", "${edgeClaims.edgeId.name}", "${edgeClaims.updatedAt.name}"`,
+  );
+  const refusals = entries.map((entry) => {
+    const target = edgeCardinalityClaimTarget(entry);
+    return sql`
+      SELECT
+        ${castBoundValueForColumn(edgeClaims.graphId, entry.graphId)} AS graph_id,
+        ${castBoundValueForColumn(edgeClaims.axis, sql.raw("NULL"))} AS axis,
+        ${castBoundValueForColumn(edgeClaims.key, target.key)} AS key,
+        ${castBoundValueForColumn(edgeClaims.edgeId, entry.edgeId)} AS edge_id,
+        ${castBoundValueForColumn(edgeClaims.updatedAt, timestamp)} AS updated_at
+      FROM "schema_fence"
+      WHERE ${proposedEndpointsLivePredicate(tables, entry)}
+      AND NOT EXISTS (
+        SELECT 1 FROM ${edgeClaims}
+        WHERE ${qualified(claimsName, edgeClaims.graphId)} = ${entry.graphId}
+          AND ${qualified(claimsName, edgeClaims.axis)} = ${target.axis}
+          AND ${qualified(claimsName, edgeClaims.key)} = ${target.key}
+          AND ${qualified(claimsName, edgeClaims.edgeId)} = ${entry.edgeId}
+      )
+    `;
+  });
+  return sql`
+    WITH ${schemaFenceCte(tables, schemaFence, schemaLockClause)}
+    INSERT INTO ${edgeClaims} (${columns})
+    SELECT graph_id, axis, key, edge_id, updated_at
+    FROM (${sql.join(refusals, sql` UNION ALL `)}) AS refused_claims
+    LIMIT 1
   `;
 }
 

--- a/packages/typegraph/src/backend/drizzle/operations/edges.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/edges.ts
@@ -1,5 +1,6 @@
 import { getTableName, type SQL, sql } from "drizzle-orm";
 
+import { CompilerInvariantError } from "../../../errors";
 import {
   resolveStampedValidityLowerBound,
   resolveStatedValidityLowerBound,
@@ -450,6 +451,25 @@ function buildInsertEdgesBatchWithSchemaFenceStatement(
           )
     `;
   });
+  const durableRowCount = params.filter(
+    (edgeParams) => edgeParams.matchIdentity !== undefined,
+  ).length;
+  if (durableRowCount !== 0 && durableRowCount !== params.length) {
+    throw new CompilerInvariantError(
+      "An atomic edge batch cannot mix durable and ordinary rows.",
+    );
+  }
+  const durableConflictRefusal =
+    durableRowCount === 0 ?
+      sql``
+    : sql`
+      ON CONFLICT (
+        ${sql.identifier(edges.graphId.name)},
+        ${sql.identifier(edges.kind.name)},
+        ${sql.identifier(edges.matchIdentityName.name)},
+        ${sql.identifier(edges.matchIdentityKey.name)}
+      ) DO UPDATE SET ${sql.identifier(edges.createdAt.name)} = NULL
+    `;
   const result = returning ? sql`RETURNING *` : sql`RETURNING 1 AS "inserted"`;
 
   // The invalid-endpoint arm deliberately inserts a NULL primary-key id. It
@@ -502,6 +522,7 @@ function buildInsertEdgesBatchWithSchemaFenceStatement(
     FROM "input_rows"
     CROSS JOIN "invalid_endpoint"
     LIMIT (SELECT COUNT(*) FROM "valid_rows") + (SELECT COUNT(*) FROM "invalid_endpoint")
+    ${durableConflictRefusal}
     ${result}
   `;
 }

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -153,7 +153,16 @@ function nullableText(value: string | undefined): SQL {
 }
 
 export type CommonOperationStrategy = Readonly<{
-  edgeClaimsTableName: string;
+  /**
+   * The exact NOT NULL sentinels emitted by the closed edge-batch program.
+   * Derive them from the same table definitions as the SQL so error
+   * classification cannot drift when a physical column is renamed.
+   */
+  atomicEdgeRefusalConstraints: Readonly<{
+    cardinality: Readonly<{ table: string; column: string }>;
+    durableIdentity: Readonly<{ table: string; column: string }>;
+    endpoint: Readonly<{ table: string; column: string }>;
+  }>;
   /**
    * The nodes and edges PRIMARY KEY constraints, as the engine names them — the
    * only scope in which a driver duplicate-key failure means "this identity is
@@ -706,7 +715,20 @@ function createCommonOperationStrategy(
     buildInsertEdgesDurableBatchReturning: (params, timestamp) =>
       buildInsertEdgesDurableBatchReturning(tables, params, timestamp),
     dynamicEdgeConvergence: dialect === "postgres",
-    edgeClaimsTableName: getTableName(tables.edgeClaims),
+    atomicEdgeRefusalConstraints: {
+      cardinality: {
+        table: getTableName(tables.edgeClaims),
+        column: tables.edgeClaims.axis.name,
+      },
+      durableIdentity: {
+        table: getTableName(tables.edges),
+        column: tables.edges.createdAt.name,
+      },
+      endpoint: {
+        table: getTableName(tables.edges),
+        column: tables.edges.id.name,
+      },
+    },
     buildDeleteStaleAtomicEdgeClaims: (
       entries,
       schemaFence,

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -66,6 +66,9 @@ import {
   buildDisjointOverlapAudit,
 } from "./constraint-fence-audit";
 import {
+  buildAcquireAtomicEdgeClaims,
+  buildAssertAtomicEdgeClaimsOwned,
+  buildDeleteStaleAtomicEdgeClaims,
   buildInsertEdgeIfEndpointsLiveWithCardinalityClaim,
   buildLockEdgeClaimGuarded,
   buildLockEdgeClaims,
@@ -150,6 +153,7 @@ function nullableText(value: string | undefined): SQL {
 }
 
 export type CommonOperationStrategy = Readonly<{
+  edgeClaimsTableName: string;
   /**
    * The nodes and edges PRIMARY KEY constraints, as the engine names them — the
    * only scope in which a driver duplicate-key failure means "this identity is
@@ -254,6 +258,23 @@ export type CommonOperationStrategy = Readonly<{
     params: InsertEdgeParams,
     claim: ClaimEdgeCardinalityParams,
     timestamp: string,
+  ) => SQL;
+  buildDeleteStaleAtomicEdgeClaims: (
+    entries: readonly ClaimEdgeCardinalityParams[],
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+  ) => SQL;
+  buildAcquireAtomicEdgeClaims: (
+    entries: readonly ClaimEdgeCardinalityParams[],
+    timestamp: string,
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+  ) => SQL;
+  buildAssertAtomicEdgeClaimsOwned: (
+    entries: readonly ClaimEdgeCardinalityParams[],
+    timestamp: string,
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
   ) => SQL;
   buildInsertEdgeNoReturn: (params: InsertEdgeParams, timestamp: string) => SQL;
   buildInsertEdgesBatch: (
@@ -685,6 +706,44 @@ function createCommonOperationStrategy(
     buildInsertEdgesDurableBatchReturning: (params, timestamp) =>
       buildInsertEdgesDurableBatchReturning(tables, params, timestamp),
     dynamicEdgeConvergence: dialect === "postgres",
+    edgeClaimsTableName: getTableName(tables.edgeClaims),
+    buildDeleteStaleAtomicEdgeClaims: (
+      entries,
+      schemaFence,
+      schemaLockClause,
+    ) =>
+      buildDeleteStaleAtomicEdgeClaims(
+        tables,
+        entries,
+        schemaFence,
+        schemaLockClause,
+      ),
+    buildAcquireAtomicEdgeClaims: (
+      entries,
+      timestamp,
+      schemaFence,
+      schemaLockClause,
+    ) =>
+      buildAcquireAtomicEdgeClaims(
+        tables,
+        entries,
+        timestamp,
+        schemaFence,
+        schemaLockClause,
+      ),
+    buildAssertAtomicEdgeClaimsOwned: (
+      entries,
+      timestamp,
+      schemaFence,
+      schemaLockClause,
+    ) =>
+      buildAssertAtomicEdgeClaimsOwned(
+        tables,
+        entries,
+        timestamp,
+        schemaFence,
+        schemaLockClause,
+      ),
     primaryKeyConstraints: {
       nodes: nodePrimaryKeyConstraint(tables.nodes),
       edges: edgePrimaryKeyConstraint(tables.edges),

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -336,7 +336,10 @@ export type PostgresBackendOptions = Readonly<{
 
 const NODE_INSERT_PARAM_COUNT = 9;
 const SCHEMA_FENCE_PARAM_COUNT = 2;
-const EDGE_INSERT_PARAM_COUNT = 12;
+// Durable edge rows bind match-identity name and key in addition to the
+// ordinary edge shape. Budget for the widest supported row so native batches
+// never cross the driver's parameter ceiling.
+const EDGE_INSERT_PARAM_COUNT = 14;
 const GET_NODES_FIXED_PARAM_COUNT = 2;
 const GET_EDGES_FIXED_PARAM_COUNT = 1;
 const FULLTEXT_UPSERT_PARAM_COUNT = 6;

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -274,7 +274,10 @@ export type SqliteBackendOptions = Readonly<{
 
 const NODE_INSERT_PARAM_COUNT = 9;
 const SCHEMA_FENCE_PARAM_COUNT = 2;
-const EDGE_INSERT_PARAM_COUNT = 12;
+// Durable edge rows bind match-identity name and key in addition to the
+// ordinary edge shape. Budget for the widest supported row so native batches
+// never cross the driver's parameter ceiling.
+const EDGE_INSERT_PARAM_COUNT = 14;
 const GET_NODES_FIXED_PARAM_COUNT = 2;
 const GET_EDGES_FIXED_PARAM_COUNT = 1;
 const CHECK_UNIQUE_BATCH_FIXED_PARAM_COUNT = 3;

--- a/packages/typegraph/src/store/claims/edge-claims.ts
+++ b/packages/typegraph/src/store/claims/edge-claims.ts
@@ -170,7 +170,7 @@ export function edgeCardinalityClaim(
  * owner. Keeping the translation here prevents a backend result discriminator
  * from growing a second spelling of the same typed error.
  */
-function edgeClaimRefusal(
+export function edgeCardinalityClaimRefusal(
   params: ClaimEdgeCardinalityParams,
 ): CardinalityError {
   const error =
@@ -216,6 +216,27 @@ function edgeClaimRefusal(
  * relation existed reaches it here, on the first constrained edge write, with
  * an error that says what to run instead of an opaque driver failure.
  */
+export function edgeClaimRelationMissing(
+  graphId: string,
+  cause: unknown,
+): ConfigurationError {
+  return new ConfigurationError(
+    "Enforcing a declared edge cardinality needs the edge claim relation " +
+      "(typegraph_edge_claims), and this database does not have it. " +
+      "Databases initialized before this relation existed were never sent " +
+      "its CREATE TABLE, because the bootstrap DDL runs only on first boot.",
+    { code: "EDGE_CLAIM_RELATION_MISSING", graphId },
+    {
+      cause,
+      suggestion:
+        "Run the generated migration SQL (generatePostgresMigrationSQL / " +
+        "generateSqliteMigrationSQL) against this database, or declare the " +
+        'edge kind `cardinality: "many"` and enforce the limit in ' +
+        "application code.",
+    },
+  );
+}
+
 async function withEdgeClaimRelationPrecondition<T>(
   graphId: string,
   issue: () => Promise<T>,
@@ -224,21 +245,7 @@ async function withEdgeClaimRelationPrecondition<T>(
     return await issue();
   } catch (error) {
     if (!isMissingTableError(error)) throw error;
-    throw new ConfigurationError(
-      "Enforcing a declared edge cardinality needs the edge claim relation " +
-        "(typegraph_edge_claims), and this database does not have it. " +
-        "Databases initialized before this relation existed were never sent " +
-        "its CREATE TABLE, because the bootstrap DDL runs only on first boot.",
-      { code: "EDGE_CLAIM_RELATION_MISSING", graphId },
-      {
-        cause: error,
-        suggestion:
-          "Run the generated migration SQL (generatePostgresMigrationSQL / " +
-          "generateSqliteMigrationSQL) against this database, or declare the " +
-          'edge kind `cardinality: "many"` and enforce the limit in ' +
-          "application code.",
-      },
-    );
+    throw edgeClaimRelationMissing(graphId, error);
   }
 }
 
@@ -299,7 +306,9 @@ export async function claimEdgeCardinality(
     const outcome = await withEdgeClaimRelationPrecondition(claim.graphId, () =>
       mode.claim(claim),
     );
-    if (outcome.status === "refused") throw edgeClaimRefusal(claim);
+    if (outcome.status === "refused") {
+      throw edgeCardinalityClaimRefusal(claim);
+    }
     return;
   }
   const support = mode.support;
@@ -307,7 +316,7 @@ export async function claimEdgeCardinality(
   const outcome = await withEdgeClaimRelationPrecondition(claim.graphId, () =>
     support.claims.claimEdgeCardinality(claim),
   );
-  if (outcome.status === "refused") throw edgeClaimRefusal(claim);
+  if (outcome.status === "refused") throw edgeCardinalityClaimRefusal(claim);
 }
 
 /**
@@ -340,7 +349,7 @@ export async function claimEdgeCardinalityBatch(
   for (const [index, outcome] of outcomes.entries()) {
     const entry = ordered[index];
     if (entry !== undefined && outcome.status === "refused") {
-      throw edgeClaimRefusal(entry.claim);
+      throw edgeCardinalityClaimRefusal(entry.claim);
     }
   }
 }

--- a/packages/typegraph/src/store/operations/atomic-edge-batch.ts
+++ b/packages/typegraph/src/store/operations/atomic-edge-batch.ts
@@ -27,11 +27,11 @@ export type AtomicEdgeBatchExecutor = BackendAtomicEdgeBatchExecutor;
 /**
  * The one owner of the store proof for a native edge batch.
  *
- * The program currently covers unconstrained, non-durable edge creates. It
- * has no claim sidecar or convergence arbitration to fold into its statement;
- * those shapes remain on the ordinary write-session path. The exact-root
- * marker is checked after the portable predicates so an unmarked or derived
- * backend always fails closed.
+ * The program covers direct edge batches whose endpoint, durable identity and
+ * cardinality decisions can all be enforced by the native atomic program.
+ * Dynamic get-or-create convergence is a separate API and never reaches this
+ * classifier. The exact-root marker is checked after the portable predicates
+ * so an unmarked or derived backend always fails closed.
  */
 export function resolveAtomicEdgeBatchExecutor(
   input: AtomicEdgeBatchEligibilityInput,
@@ -54,8 +54,7 @@ export function resolveAtomicEdgeBatchExecutor(
     if (!hasOwnKey(graph.edges, item.kind)) return false;
     const registration = graph.edges[item.kind];
     if (registration === undefined) return false;
-    if ((registration.cardinality ?? "many") !== "many") return false;
-    return registration.matchIdentity === undefined;
+    return true;
   });
   if (!eligible) return;
 

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -72,7 +72,10 @@
  *    `oneActive` population — asserted only for that decision; other
  *    cardinalities do not turn an unconditional clear into a stale-value CAS.
  */
-import { AtomicEdgeBatchEndpointRefusalError } from "../../backend/capabilities/atomic-edge-batch";
+import {
+  AtomicEdgeBatchCardinalityRefusalError,
+  AtomicEdgeBatchEndpointRefusalError,
+} from "../../backend/capabilities/atomic-edge-batch";
 import { isBundledRootAutocommitEligible } from "../../backend/capabilities/autocommit-single-statement";
 import { bindExtraIfReachable } from "../../backend/capabilities/bind";
 import {
@@ -133,10 +136,13 @@ import { generateId } from "../../utils/id";
 import { hasOwnKey, readOwnProperty } from "../../utils/object";
 import { requireDefined } from "../../utils/presence";
 import { encodeTupleKey } from "../../utils/tuple-key";
+import { compareClaimTargets } from "../claims/axis";
 import {
   claimEdgeCardinality,
   edgeCardinalityClaim,
   edgeCardinalityClaimMode,
+  edgeCardinalityClaimRefusal,
+  edgeCardinalityClaimTarget,
 } from "../claims/edge-claims";
 import {
   shouldCoalesceUpsert,
@@ -1193,28 +1199,52 @@ async function prepareEdgeBatchCreates<G extends GraphDef>(
 
 /**
  * Prepares the closed input to the native edge batch program without issuing
- * reads. Eligibility has already proved that no cardinality or durable-match
- * decision is required; the SQL program owns live-endpoint and schema-fence
- * enforcement at the authoritative write boundary.
+ * reads. The SQL program owns endpoint, schema-fence, durable-identity and
+ * cardinality enforcement at the authoritative write boundary. The only
+ * client-side constraint decision is the closed input's own duplicate axes,
+ * which need no database state and must refuse before dispatch.
  */
+type AtomicEdgeBatchPreparation = Readonly<{
+  claims: readonly ClaimEdgeCardinalityParams[];
+  preparedCreates: readonly EdgeCreatePrepared[];
+}>;
+
 async function prepareAtomicEdgeBatchCreates<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
   inputs: readonly CreateEdgeInput[],
   backend: WriteTarget,
-): Promise<readonly EdgeCreatePrepared[]> {
+): Promise<AtomicEdgeBatchPreparation> {
   const preparedCreates: EdgeCreatePrepared[] = [];
+  const claims: ClaimEdgeCardinalityParams[] = [];
+  const claimedTargets = new Set<string>();
   for (const input of inputs) {
-    preparedCreates.push(
-      await validateAndPrepareEdgeCreate(
-        ctx,
-        input,
-        input.id ?? generateId(),
-        backend,
-        { validateEndpoints: false, validateCardinality: false },
-      ),
+    const prepared = await validateAndPrepareEdgeCreate(
+      ctx,
+      input,
+      input.id ?? generateId(),
+      backend,
+      { validateEndpoints: false, validateCardinality: false },
     );
+    preparedCreates.push(prepared);
+    const claim = edgeInsertWork(prepared).claim;
+    if (claim === undefined) continue;
+    const target = edgeCardinalityClaimTarget(claim);
+    const targetKey = `${target.axis}\u0000${target.key}`;
+    if (claimedTargets.has(targetKey)) {
+      throw edgeCardinalityClaimRefusal(claim);
+    }
+    claimedTargets.add(targetKey);
+    claims.push(claim);
   }
-  return preparedCreates;
+  return {
+    claims: claims.toSorted((left, right) =>
+      compareClaimTargets(
+        edgeCardinalityClaimTarget(left),
+        edgeCardinalityClaimTarget(right),
+      ),
+    ),
+    preparedCreates,
+  };
 }
 
 /**
@@ -1241,10 +1271,34 @@ async function assertAtomicEdgeBatchEndpoints<G extends GraphDef>(
   }
 }
 
+async function assertAtomicEdgeBatchCardinality<G extends GraphDef>(
+  ctx: EdgeOperationContext<G>,
+  inputs: readonly CreateEdgeInput[],
+  backend: WriteTarget,
+): Promise<void> {
+  const constraintContext: ConstraintContext = {
+    graphId: ctx.graphId,
+    registry: ctx.registry,
+    backend,
+  };
+  for (const input of inputs) {
+    await checkCardinalityConstraint(
+      constraintContext,
+      input.kind,
+      edgeCardinality(ctx, input.kind),
+      input.fromKind,
+      input.fromId,
+      input.toKind,
+      input.toId,
+      input.validTo,
+    );
+  }
+}
+
 async function runAtomicEdgeBatchProgram<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
   inputs: readonly CreateEdgeInput[],
-  preparedCreates: readonly EdgeCreatePrepared[],
+  preparation: AtomicEdgeBatchPreparation,
   backend: GraphBackend | TransactionBackend,
   atomicExecutor: AtomicEdgeBatchExecutor,
   resultMode: "count",
@@ -1252,7 +1306,7 @@ async function runAtomicEdgeBatchProgram<G extends GraphDef>(
 async function runAtomicEdgeBatchProgram<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
   inputs: readonly CreateEdgeInput[],
-  preparedCreates: readonly EdgeCreatePrepared[],
+  preparation: AtomicEdgeBatchPreparation,
   backend: GraphBackend | TransactionBackend,
   atomicExecutor: AtomicEdgeBatchExecutor,
   resultMode: "rows",
@@ -1261,12 +1315,14 @@ async function runAtomicEdgeBatchProgram<G extends GraphDef>(
 async function runAtomicEdgeBatchProgram<G extends GraphDef>(
   ctx: EdgeOperationContext<G>,
   inputs: readonly CreateEdgeInput[],
-  preparedCreates: readonly EdgeCreatePrepared[],
+  preparation: AtomicEdgeBatchPreparation,
   backend: GraphBackend | TransactionBackend,
   atomicExecutor: AtomicEdgeBatchExecutor,
   resultMode: "count" | "rows",
 ): Promise<number | readonly BackendEdgeRow[]> {
-  const params = preparedCreates.map((prepared) => prepared.insertParams);
+  const params = preparation.preparedCreates.map(
+    (prepared) => prepared.insertParams,
+  );
   const schemaFence = {
     graphId: ctx.graphId,
     expectedVersion: requireDefined(ctx.schemaVersion),
@@ -1274,13 +1330,35 @@ async function runAtomicEdgeBatchProgram<G extends GraphDef>(
   const result = await withAlreadyExistsTranslation("edge", async () => {
     try {
       if (resultMode === "count") {
-        return await atomicExecutor({ params, resultMode, schemaFence });
+        return await atomicExecutor({
+          claims: preparation.claims,
+          params,
+          resultMode,
+          schemaFence,
+        });
       }
-      return await atomicExecutor({ params, resultMode, schemaFence });
+      return await atomicExecutor({
+        claims: preparation.claims,
+        params,
+        resultMode,
+        schemaFence,
+      });
     } catch (error) {
       if (error instanceof AtomicEdgeBatchEndpointRefusalError) {
         await assertAtomicEdgeBatchEndpoints(ctx, inputs, backend);
         throw error.cause;
+      }
+      if (error instanceof AtomicEdgeBatchCardinalityRefusalError) {
+        await assertAtomicEdgeBatchCardinality(ctx, inputs, backend);
+        throw new DatabaseOperationError(
+          "Atomic edge batch refused a cardinality claim, but no current " +
+            "competing edge could be diagnosed.",
+          {
+            operation: "insert",
+            entity: "edge",
+          },
+          { cause: error.cause },
+        );
       }
       throw error;
     }
@@ -1354,7 +1432,7 @@ export async function executeEdgeCreateNoReturnBatch<G extends GraphDef>(
     revisionTrackingEnabled: ctx.revisionTrackingEnabled,
   });
   if (atomicExecutor !== undefined) {
-    const preparedCreates = await prepareAtomicEdgeBatchCreates(
+    const preparation = await prepareAtomicEdgeBatchCreates(
       ctx,
       inputs,
       backend,
@@ -1362,7 +1440,7 @@ export async function executeEdgeCreateNoReturnBatch<G extends GraphDef>(
     await runAtomicEdgeBatchProgram(
       ctx,
       inputs,
-      preparedCreates,
+      preparation,
       backend,
       atomicExecutor,
       "count",
@@ -1441,7 +1519,7 @@ export async function executeEdgeCreateBatch<G extends GraphDef>(
     revisionTrackingEnabled: ctx.revisionTrackingEnabled,
   });
   if (atomicExecutor !== undefined) {
-    const preparedCreates = await prepareAtomicEdgeBatchCreates(
+    const preparation = await prepareAtomicEdgeBatchCreates(
       ctx,
       inputs,
       backend,
@@ -1449,7 +1527,7 @@ export async function executeEdgeCreateBatch<G extends GraphDef>(
     const rows = await runAtomicEdgeBatchProgram(
       ctx,
       inputs,
-      preparedCreates,
+      preparation,
       backend,
       atomicExecutor,
       "rows",

--- a/packages/typegraph/tests/atomic-generated-edge-batch-backend.test.ts
+++ b/packages/typegraph/tests/atomic-generated-edge-batch-backend.test.ts
@@ -13,6 +13,7 @@ import {
   D1_MAX_BIND_PARAMETERS,
   type InsertEdgeParams,
 } from "../src/backend/types";
+import type { ConstrainedCardinality } from "../src/store/claims/edge-claims";
 import { requireDefined } from "../src/utils/presence";
 
 const schemaFence = { graphId: "graph-1", expectedVersion: 1 } as const;
@@ -30,10 +31,13 @@ function edgeParams(prefix: string, count: number) {
   }));
 }
 
-function edgeClaim(params: InsertEdgeParams): ClaimEdgeCardinalityParams {
+function edgeClaim(
+  params: InsertEdgeParams,
+  cardinality: ConstrainedCardinality = "one",
+): ClaimEdgeCardinalityParams {
   return {
     graphId: params.graphId,
-    cardinality: "one",
+    cardinality,
     edgeKind: params.kind,
     edgeId: params.id,
     fromKind: params.fromKind,
@@ -82,6 +86,58 @@ function makeNeonDatabase(rows: NeonRows): Readonly<{
     execute: vi.fn(),
   } as unknown as AnyPgDatabase;
   return { db, query, transaction };
+}
+
+type BoundD1Statement = Readonly<{
+  sql: string;
+  params: readonly unknown[];
+}>;
+
+function makeD1Database(): Readonly<{
+  batch: ReturnType<typeof vi.fn>;
+  boundStatements: BoundD1Statement[];
+  db: AnySqliteDatabase;
+}> {
+  const boundStatements: BoundD1Statement[] = [];
+  const prepare = vi.fn((sqlText: string) => ({
+    bind(...params: readonly unknown[]) {
+      const statement = { sql: sqlText, params };
+      boundStatements.push(statement);
+      return statement;
+    },
+  }));
+  const batch = vi.fn((statements: readonly BoundD1Statement[]) =>
+    Promise.resolve(
+      statements.map((statement) => ({
+        results:
+          statement.sql.includes('RETURNING 1 AS "inserted"') ?
+            Array.from(
+              {
+                length: statement.params.filter(
+                  (value) =>
+                    typeof value === "string" && value.includes("-edge-"),
+                ).length,
+              },
+              () => ({ inserted: 1 }),
+            )
+          : [],
+      })),
+    ),
+  );
+  const dialect = new SQLiteSyncDialect();
+  const db = {
+    $client: { batch, prepare },
+    session: { constructor: { name: "SQLiteD1Session" } },
+    dialect: {
+      sqlToQuery(query: SQL) {
+        return dialect.sqlToQuery(query);
+      },
+    },
+    all: vi.fn(() => Promise.resolve([])),
+    get: vi.fn(() => Promise.resolve(undefined)),
+    run: vi.fn(() => Promise.resolve()),
+  } as unknown as AnySqliteDatabase;
+  return { batch, boundStatements, db };
 }
 
 describe("bundled root atomic edge batch", () => {
@@ -198,51 +254,7 @@ describe("bundled root atomic edge batch", () => {
   });
 
   it("uses one D1 batch while keeping every fenced chunk within its bind limit", async () => {
-    const boundStatements: Readonly<{
-      sql: string;
-      params: readonly unknown[];
-    }>[] = [];
-    const prepare = vi.fn((sqlText: string) => ({
-      bind(...params: readonly unknown[]) {
-        const statement = { sql: sqlText, params };
-        boundStatements.push(statement);
-        return statement;
-      },
-    }));
-    const batch = vi.fn(
-      (
-        statements: readonly Readonly<{
-          sql: string;
-          params: readonly unknown[];
-        }>[],
-      ) =>
-        Promise.resolve(
-          statements.map((statement) => ({
-            results: Array.from(
-              {
-                length: statement.params.filter(
-                  (value) =>
-                    typeof value === "string" && value.includes("-edge-"),
-                ).length,
-              },
-              () => ({ inserted: 1 }),
-            ),
-          })),
-        ),
-    );
-    const dialect = new SQLiteSyncDialect();
-    const db = {
-      $client: { batch, prepare },
-      session: { constructor: { name: "SQLiteD1Session" } },
-      dialect: {
-        sqlToQuery(query: SQL) {
-          return dialect.sqlToQuery(query);
-        },
-      },
-      all: vi.fn(() => Promise.resolve([])),
-      get: vi.fn(() => Promise.resolve(undefined)),
-      run: vi.fn(() => Promise.resolve()),
-    } as unknown as AnySqliteDatabase;
+    const { batch, boundStatements, db } = makeD1Database();
     const backend = createSqliteBackend(db);
     const executeAtomicEdgeBatch = resolveBundledRootAtomicEdgeBatch(backend);
     if (executeAtomicEdgeBatch === undefined) {
@@ -276,93 +288,49 @@ describe("bundled root atomic edge batch", () => {
     }
   });
 
-  it("dispatches a constrained edge program through one D1 batch", async () => {
-    const boundStatements: Readonly<{
-      sql: string;
-      params: readonly unknown[];
-    }>[] = [];
-    const prepare = vi.fn((sqlText: string) => ({
-      bind(...params: readonly unknown[]) {
-        const statement = { sql: sqlText, params };
-        boundStatements.push(statement);
-        return statement;
-      },
-    }));
-    const batch = vi.fn(
-      (
-        statements: readonly Readonly<{
-          sql: string;
-          params: readonly unknown[];
-        }>[],
-      ) =>
-        Promise.resolve(
-          statements.map((statement) => ({
-            results:
-              statement.sql.includes('RETURNING 1 AS "inserted"') ?
-                Array.from(
-                  {
-                    length: statement.params.filter(
-                      (value) =>
-                        typeof value === "string" && value.includes("-edge-"),
-                    ).length,
-                  },
-                  () => ({ inserted: 1 }),
-                )
-              : [],
-          })),
+  it.each(["one", "unique", "oneActive"] as const)(
+    "dispatches a %s edge program through one D1 batch within its bind budget",
+    async (cardinality) => {
+      const { batch, boundStatements, db } = makeD1Database();
+      const backend = createSqliteBackend(db);
+      const executeAtomicEdgeBatch = resolveBundledRootAtomicEdgeBatch(backend);
+      if (executeAtomicEdgeBatch === undefined) {
+        throw new Error("Expected D1 atomic edge batch capability");
+      }
+      const params = edgeParams("d1-claimed", 20).map((item, index) => ({
+        ...item,
+        matchIdentity: { name: "role", key: `role-${index}` },
+      }));
+
+      await expect(
+        executeAtomicEdgeBatch({
+          claims: params.map((item) => edgeClaim(item, cardinality)),
+          params,
+          schemaFence,
+          resultMode: "count",
+        }),
+      ).resolves.toBe(20);
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(boundStatements.length).toBeGreaterThan(4);
+      expect(
+        boundStatements.some((statement) =>
+          statement.sql.includes("DELETE FROM"),
         ),
-    );
-    const dialect = new SQLiteSyncDialect();
-    const db = {
-      $client: { batch, prepare },
-      session: { constructor: { name: "SQLiteD1Session" } },
-      dialect: {
-        sqlToQuery(query: SQL) {
-          return dialect.sqlToQuery(query);
-        },
-      },
-      all: vi.fn(() => Promise.resolve([])),
-      get: vi.fn(() => Promise.resolve(undefined)),
-      run: vi.fn(() => Promise.resolve()),
-    } as unknown as AnySqliteDatabase;
-    const backend = createSqliteBackend(db);
-    const executeAtomicEdgeBatch = resolveBundledRootAtomicEdgeBatch(backend);
-    if (executeAtomicEdgeBatch === undefined) {
-      throw new Error("Expected D1 atomic edge batch capability");
-    }
-    const params = edgeParams("d1-claimed", 20).map((item, index) => ({
-      ...item,
-      matchIdentity: { name: "role", key: `role-${index}` },
-    }));
-
-    await expect(
-      executeAtomicEdgeBatch({
-        claims: params.map((item) => edgeClaim(item)),
-        params,
-        schemaFence,
-        resultMode: "count",
-      }),
-    ).resolves.toBe(20);
-
-    expect(batch).toHaveBeenCalledOnce();
-    expect(boundStatements.length).toBeGreaterThan(4);
-    expect(
-      boundStatements.some((statement) =>
-        statement.sql.includes("DELETE FROM"),
-      ),
-    ).toBe(true);
-    expect(
-      boundStatements.some((statement) =>
-        statement.sql.includes("ON CONFLICT"),
-      ),
-    ).toBe(true);
-    expect(
-      boundStatements.some((statement) => statement.sql.includes("AS axis")),
-    ).toBe(true);
-    for (const statement of boundStatements) {
-      expect(statement.params.length).toBeLessThanOrEqual(
-        D1_MAX_BIND_PARAMETERS,
-      );
-    }
-  });
+      ).toBe(true);
+      expect(
+        boundStatements.some((statement) =>
+          statement.sql.includes("ON CONFLICT"),
+        ),
+      ).toBe(true);
+      expect(
+        boundStatements.some((statement) => statement.sql.includes("AS axis")),
+      ).toBe(true);
+      for (const statement of boundStatements) {
+        expect(statement.params.length).toBeLessThanOrEqual(
+          D1_MAX_BIND_PARAMETERS,
+        );
+      }
+    },
+  );
 });

--- a/packages/typegraph/tests/atomic-generated-edge-batch-backend.test.ts
+++ b/packages/typegraph/tests/atomic-generated-edge-batch-backend.test.ts
@@ -357,9 +357,7 @@ describe("bundled root atomic edge batch", () => {
       ),
     ).toBe(true);
     expect(
-      boundStatements.some((statement) =>
-        statement.sql.includes("AS axis"),
-      ),
+      boundStatements.some((statement) => statement.sql.includes("AS axis")),
     ).toBe(true);
     for (const statement of boundStatements) {
       expect(statement.params.length).toBeLessThanOrEqual(

--- a/packages/typegraph/tests/atomic-generated-edge-batch-backend.test.ts
+++ b/packages/typegraph/tests/atomic-generated-edge-batch-backend.test.ts
@@ -8,7 +8,12 @@ import type { AnyPgDatabase } from "../src/backend/drizzle/execution/postgres-ex
 import type { AnySqliteDatabase } from "../src/backend/drizzle/execution/sqlite-execution";
 import { createPostgresBackend } from "../src/backend/drizzle/postgres";
 import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
-import { D1_MAX_BIND_PARAMETERS } from "../src/backend/types";
+import {
+  type ClaimEdgeCardinalityParams,
+  D1_MAX_BIND_PARAMETERS,
+  type InsertEdgeParams,
+} from "../src/backend/types";
+import { requireDefined } from "../src/utils/presence";
 
 const schemaFence = { graphId: "graph-1", expectedVersion: 1 } as const;
 
@@ -23,6 +28,19 @@ function edgeParams(prefix: string, count: number) {
     toId: `${prefix}-company-${index}`,
     props: { role: `Role ${index}` },
   }));
+}
+
+function edgeClaim(params: InsertEdgeParams): ClaimEdgeCardinalityParams {
+  return {
+    graphId: params.graphId,
+    cardinality: "one",
+    edgeKind: params.kind,
+    edgeId: params.id,
+    fromKind: params.fromKind,
+    fromId: params.fromId,
+    toKind: params.toKind,
+    toId: params.toId,
+  };
 }
 
 type NeonRows =
@@ -82,6 +100,7 @@ describe("bundled root atomic edge batch", () => {
 
     await expect(
       executeAtomicEdgeBatch({
+        claims: [],
         params: edgeParams("first", 2),
         schemaFence,
         resultMode: "count",
@@ -102,12 +121,43 @@ describe("bundled root atomic edge batch", () => {
 
     await expect(
       executeAtomicEdgeBatch({
+        claims: [],
         params: edgeParams("stale", 1),
         schemaFence: { graphId: "graph-1", expectedVersion: 99 },
         resultMode: "count",
       }),
     ).resolves.toBe(0);
     expect(query).toHaveBeenCalledOnce();
+  });
+
+  it("dispatches edge rows and cardinality sidecars in one Neon exchange", async () => {
+    const params = edgeParams("claimed", 1);
+    const { db, query, transaction } = makeNeonDatabase((sqlText) =>
+      sqlText.includes('RETURNING 1 AS "inserted"') ? [{ inserted: 1 }] : [],
+    );
+    const backend = createPostgresBackend(db, { vector: false });
+    const executeAtomicEdgeBatch = resolveBundledRootAtomicEdgeBatch(backend);
+    if (executeAtomicEdgeBatch === undefined) {
+      throw new Error("Expected atomic edge batch capability");
+    }
+
+    await expect(
+      executeAtomicEdgeBatch({
+        claims: [edgeClaim(requireDefined(params[0]))],
+        params,
+        schemaFence,
+        resultMode: "count",
+      }),
+    ).resolves.toBe(1);
+
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(query).toHaveBeenCalledTimes(4);
+    expect(query.mock.calls.map(([sqlText]) => sqlText)).toEqual([
+      expect.stringContaining("DELETE FROM"),
+      expect.stringContaining("ON CONFLICT"),
+      expect.stringContaining("AS axis"),
+      expect.stringContaining("INSERT INTO"),
+    ]);
   });
 
   it("keeps every PostgreSQL fenced chunk inside its bind limit", async () => {
@@ -133,6 +183,7 @@ describe("bundled root atomic edge batch", () => {
 
     await expect(
       executeAtomicEdgeBatch({
+        claims: [],
         params: edgeParams("chunk", 9),
         schemaFence,
         resultMode: "count",
@@ -202,6 +253,7 @@ describe("bundled root atomic edge batch", () => {
     expect(backend.capabilities.maxBindParameters).toBe(D1_MAX_BIND_PARAMETERS);
     await expect(
       executeAtomicEdgeBatch({
+        claims: [],
         params: edgeParams("d1", 20),
         schemaFence,
         resultMode: "count",
@@ -220,6 +272,98 @@ describe("bundled root atomic edge batch", () => {
       );
       expect(statement.sql.toLowerCase()).toContain(
         'returning 1 as "inserted"',
+      );
+    }
+  });
+
+  it("dispatches a constrained edge program through one D1 batch", async () => {
+    const boundStatements: Readonly<{
+      sql: string;
+      params: readonly unknown[];
+    }>[] = [];
+    const prepare = vi.fn((sqlText: string) => ({
+      bind(...params: readonly unknown[]) {
+        const statement = { sql: sqlText, params };
+        boundStatements.push(statement);
+        return statement;
+      },
+    }));
+    const batch = vi.fn(
+      (
+        statements: readonly Readonly<{
+          sql: string;
+          params: readonly unknown[];
+        }>[],
+      ) =>
+        Promise.resolve(
+          statements.map((statement) => ({
+            results:
+              statement.sql.includes('RETURNING 1 AS "inserted"') ?
+                Array.from(
+                  {
+                    length: statement.params.filter(
+                      (value) =>
+                        typeof value === "string" && value.includes("-edge-"),
+                    ).length,
+                  },
+                  () => ({ inserted: 1 }),
+                )
+              : [],
+          })),
+        ),
+    );
+    const dialect = new SQLiteSyncDialect();
+    const db = {
+      $client: { batch, prepare },
+      session: { constructor: { name: "SQLiteD1Session" } },
+      dialect: {
+        sqlToQuery(query: SQL) {
+          return dialect.sqlToQuery(query);
+        },
+      },
+      all: vi.fn(() => Promise.resolve([])),
+      get: vi.fn(() => Promise.resolve(undefined)),
+      run: vi.fn(() => Promise.resolve()),
+    } as unknown as AnySqliteDatabase;
+    const backend = createSqliteBackend(db);
+    const executeAtomicEdgeBatch = resolveBundledRootAtomicEdgeBatch(backend);
+    if (executeAtomicEdgeBatch === undefined) {
+      throw new Error("Expected D1 atomic edge batch capability");
+    }
+    const params = edgeParams("d1-claimed", 20).map((item, index) => ({
+      ...item,
+      matchIdentity: { name: "role", key: `role-${index}` },
+    }));
+
+    await expect(
+      executeAtomicEdgeBatch({
+        claims: params.map((item) => edgeClaim(item)),
+        params,
+        schemaFence,
+        resultMode: "count",
+      }),
+    ).resolves.toBe(20);
+
+    expect(batch).toHaveBeenCalledOnce();
+    expect(boundStatements.length).toBeGreaterThan(4);
+    expect(
+      boundStatements.some((statement) =>
+        statement.sql.includes("DELETE FROM"),
+      ),
+    ).toBe(true);
+    expect(
+      boundStatements.some((statement) =>
+        statement.sql.includes("ON CONFLICT"),
+      ),
+    ).toBe(true);
+    expect(
+      boundStatements.some((statement) =>
+        statement.sql.includes("AS axis"),
+      ),
+    ).toBe(true);
+    for (const statement of boundStatements) {
+      expect(statement.params.length).toBeLessThanOrEqual(
+        D1_MAX_BIND_PARAMETERS,
       );
     }
   });

--- a/packages/typegraph/tests/atomic-generated-edge-batch-pglite.test.ts
+++ b/packages/typegraph/tests/atomic-generated-edge-batch-pglite.test.ts
@@ -4,6 +4,11 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  buildAcquireAtomicEdgeClaims,
+  buildAssertAtomicEdgeClaimsOwned,
+  buildDeleteStaleAtomicEdgeClaims,
+} from "../src/backend/drizzle/operations/edge-claims";
+import {
   buildInsertEdgesBatchReturningWithSchemaFence,
   buildInsertEdgesBatchWithSchemaFence,
 } from "../src/backend/drizzle/operations/edges";
@@ -12,6 +17,8 @@ import { tables } from "../src/backend/drizzle/schema/postgres";
 import { createLocalPgliteBackend } from "../src/backend/postgres/pglite";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
 import { createStoreWithSchema } from "../src/store";
+import { edgeCardinalityClaim } from "../src/store/claims/edge-claims";
+import { requireDefined } from "../src/utils/presence";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -27,12 +34,103 @@ const graph = defineGraph({
   nodes: { Person: { type: Person }, Company: { type: Company } },
   edges: { worksAt: { type: worksAt, from: [Person], to: [Company] } },
 });
+const cardinalityGraph = defineGraph({
+  id: "atomic-cardinality-edge-batch-pglite",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "one",
+    },
+  },
+});
 
 function compile(query: SQL) {
   return new PgDialect().sqlToQuery(query);
 }
 
 describe("schema-fenced edge batches on a real PostgreSQL engine", () => {
+  it("executes and rolls back cardinality sidecars on real PostgreSQL", async () => {
+    const { backend, client } = await createLocalPgliteBackend({
+      vector: false,
+    });
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const beta = await store.nodes.Company.create({ name: "Beta" });
+      const schemaFence = {
+        graphId: cardinalityGraph.id,
+        expectedVersion: 1,
+      } as const;
+      const timestamp = "2026-08-25T00:00:00.000Z";
+
+      async function executeProgram(id: string, toId: string): Promise<void> {
+        const params = {
+          graphId: cardinalityGraph.id,
+          id,
+          kind: "worksAt",
+          fromKind: from.kind,
+          fromId: from.id,
+          toKind: "Company",
+          toId,
+          props: { role: id },
+        } as const;
+        const claim = requireDefined(edgeCardinalityClaim("one", params));
+        const statements = [
+          buildDeleteStaleAtomicEdgeClaims(
+            tables,
+            [claim],
+            schemaFence,
+            drizzleSql`FOR SHARE`,
+          ),
+          buildAcquireAtomicEdgeClaims(
+            tables,
+            [claim],
+            timestamp,
+            schemaFence,
+            drizzleSql`FOR SHARE`,
+          ),
+          buildAssertAtomicEdgeClaimsOwned(
+            tables,
+            [claim],
+            timestamp,
+            schemaFence,
+            drizzleSql`FOR SHARE`,
+          ),
+          buildInsertEdgesBatchWithSchemaFence(
+            tables,
+            [params],
+            timestamp,
+            schemaFence,
+            drizzleSql`FOR SHARE`,
+          ),
+        ].map((statement) => compile(statement));
+
+        await client.exec("BEGIN");
+        try {
+          for (const statement of statements) {
+            await client.query(statement.sql, statement.params);
+          }
+          await client.exec("COMMIT");
+        } catch (error) {
+          await client.exec("ROLLBACK");
+          throw error;
+        }
+      }
+
+      await executeProgram("first-edge", acme.id);
+      await expect(executeProgram("conflicting-edge", beta.id)).rejects.toThrow(
+        /null value|not-null/i,
+      );
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
+    } finally {
+      await backend.close();
+    }
+  });
+
   it("executes the Store fallback path against real PostgreSQL", async () => {
     const { backend } = await createLocalPgliteBackend({ vector: false });
     try {

--- a/packages/typegraph/tests/atomic-generated-edge-batch.test.ts
+++ b/packages/typegraph/tests/atomic-generated-edge-batch.test.ts
@@ -6,13 +6,18 @@ import { createClient } from "@libsql/client";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
-import { StaleVersionError } from "../src";
+import {
+  CardinalityError,
+  EdgeMatchIdentityConflictError,
+  StaleVersionError,
+} from "../src";
 import {
   type AtomicEdgeBatchExecutor,
   markBundledRootAtomicEdgeBatch,
 } from "../src/backend/capabilities/atomic-edge-batch";
 import { markBundledRootAutocommitEligible } from "../src/backend/capabilities/autocommit-single-statement";
 import { deriveBackend } from "../src/backend/derive-backend";
+import { edgeMatchIdentityUniqueIndexName } from "../src/backend/drizzle/ddl";
 import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
@@ -61,6 +66,19 @@ const matchIdentityGraph = defineGraph({
     },
   },
 });
+const constrainedMatchIdentityGraph = defineGraph({
+  id: "atomic-generated-edge-batch-cardinality-identity",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "one",
+      matchIdentity: { name: "role", fields: ["role"] },
+    },
+  },
+});
 const evolvedGraph = defineGraph({
   id: graph.id,
   nodes: {
@@ -72,6 +90,18 @@ const evolvedGraph = defineGraph({
     Company: { type: Company },
   },
   edges: { worksAt: { type: worksAt, from: [Person], to: [Company] } },
+});
+const evolvedCardinalityGraph = defineGraph({
+  id: cardinalityGraph.id,
+  nodes: {
+    Person: {
+      type: defineNode("Person", {
+        schema: z.object({ name: z.string(), nickname: z.string().optional() }),
+      }),
+    },
+    Company: { type: Company },
+  },
+  edges: cardinalityGraph.edges,
 });
 
 async function createEndpoints(store: Store<typeof graph>) {
@@ -156,34 +186,37 @@ describe("generated edge batch store consumer", () => {
   it.each([
     ["cardinality constraints", cardinalityGraph],
     ["durable match identity", matchIdentityGraph],
-  ] as const)("falls back for %s", (_label, constrainedGraph) => {
-    const backend = { capabilities: { transactions: false } } as GraphBackend;
-    const executor = vi.fn(() =>
-      Promise.resolve(1),
-    ) as unknown as AtomicEdgeBatchExecutor;
-    markBundledRootAutocommitEligible(backend);
-    markBundledRootAtomicEdgeBatch(backend, executor);
+  ] as const)(
+    "selects the atomic executor for %s",
+    (_label, constrainedGraph) => {
+      const backend = { capabilities: { transactions: false } } as GraphBackend;
+      const executor = vi.fn(() =>
+        Promise.resolve(1),
+      ) as unknown as AtomicEdgeBatchExecutor;
+      markBundledRootAutocommitEligible(backend);
+      markBundledRootAtomicEdgeBatch(backend, executor);
 
-    expect(
-      resolveAtomicEdgeBatchExecutor({
-        backend,
-        graph: constrainedGraph,
-        inputs: [
-          {
-            kind: "worksAt",
-            fromKind: "Person",
-            fromId: "person-1",
-            toKind: "Company",
-            toId: "company-1",
-            props: { role: "Engineer" },
-          },
-        ],
-        schemaVersion: 1,
-        historyEnabled: false,
-        revisionTrackingEnabled: false,
-      }),
-    ).toBeUndefined();
-  });
+      expect(
+        resolveAtomicEdgeBatchExecutor({
+          backend,
+          graph: constrainedGraph,
+          inputs: [
+            {
+              kind: "worksAt",
+              fromKind: "Person",
+              fromId: "person-1",
+              toKind: "Company",
+              toId: "company-1",
+              props: { role: "Engineer" },
+            },
+          ],
+          schemaVersion: 1,
+          historyEnabled: false,
+          revisionTrackingEnabled: false,
+        }),
+      ).toBe(executor);
+    },
+  );
 
   it("uses one real libSQL exchange for bulkInsert and returns no edge payload", async () => {
     const temporaryDirectory = mkdtempSync(
@@ -237,6 +270,334 @@ describe("generated edge batch store consumer", () => {
       expect(batch).toHaveBeenCalledOnce();
       expect(edges.map((edge) => edge.role)).toEqual(["Designer", "Engineer"]);
       expect(edges.map((edge) => edge.fromId)).toEqual([bob.id, alice.id]);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("executes a cardinality-constrained batch in one libSQL exchange", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-edge-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const to = await store.nodes.Company.create({ name: "Acme" });
+      const batch = vi.spyOn(client, "batch");
+
+      await store.edges.worksAt.bulkInsert([
+        { from, to, props: { role: "Engineer" } },
+      ]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("returns rows from a cardinality-constrained bulkCreate program", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-create-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const beta = await store.nodes.Company.create({ name: "Beta" });
+      const batch = vi.spyOn(client, "batch");
+
+      const edges = await store.edges.worksAt.bulkCreate([
+        { from: bob, to: beta, props: { role: "Designer" } },
+        { from: alice, to: acme, props: { role: "Engineer" } },
+      ]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(edges.map((edge) => edge.role)).toEqual(["Designer", "Engineer"]);
+      expect(edges.map((edge) => edge.fromId)).toEqual([bob.id, alice.id]);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("combines durable match identity and cardinality in one native program", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-identity-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(
+        constrainedMatchIdentityGraph,
+        backend,
+      );
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const beta = await store.nodes.Company.create({ name: "Beta" });
+      const batch = vi.spyOn(client, "batch");
+
+      const edges = await store.edges.worksAt.bulkCreate([
+        { from: alice, to: acme, props: { role: "Engineer" } },
+        { from: bob, to: beta, props: { role: "Designer" } },
+      ]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(edges.map((edge) => edge.role)).toEqual([
+        "Engineer",
+        "Designer",
+      ]);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back nonconflicting rows when a cardinality claim refuses", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-rollback-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const beta = await store.nodes.Company.create({ name: "Beta" });
+      await store.edges.worksAt.create(alice, acme, { role: "Incumbent" });
+      const batch = vi.spyOn(client, "batch");
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from: bob, to: beta, props: { role: "Would succeed" } },
+          { from: alice, to: beta, props: { role: "Conflicts" } },
+        ]),
+      ).rejects.toBeInstanceOf(CardinalityError);
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses duplicate cardinality axes before native dispatch", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-input-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const beta = await store.nodes.Company.create({ name: "Beta" });
+      const batch = vi.spyOn(client, "batch");
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from, to: acme, props: { role: "First" } },
+          { from, to: beta, props: { role: "Second" } },
+        ]),
+      ).rejects.toBeInstanceOf(CardinalityError);
+
+      expect(batch).not.toHaveBeenCalled();
+      await expect(store.edges.worksAt.count()).resolves.toBe(0);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("takes over a stale cardinality claim inside the native program", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-takeover-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const beta = await store.nodes.Company.create({ name: "Beta" });
+      const stale = await store.edges.worksAt.create(from, acme, {
+        role: "Former",
+      });
+      await store.edges.worksAt.delete(stale.id);
+      const batch = vi.spyOn(client, "batch");
+
+      await store.edges.worksAt.bulkInsert([
+        { from, to: beta, props: { role: "Current" } },
+      ]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a claimless legacy incumbent and rolls the attempted edge back", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-legacy-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      const beta = await store.nodes.Company.create({ name: "Beta" });
+      await backend.insertEdge({
+        graphId: cardinalityGraph.id,
+        id: "legacy-edge",
+        kind: "worksAt",
+        fromKind: from.kind,
+        fromId: from.id,
+        toKind: acme.kind,
+        toId: acme.id,
+        props: { role: "Legacy" },
+      });
+      const batch = vi.spyOn(client, "batch");
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from, to: beta, props: { role: "Conflicts" } },
+        ]),
+      ).rejects.toBeInstanceOf(CardinalityError);
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the typed precondition when native claim storage is missing", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-storage-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const to = await store.nodes.Company.create({ name: "Acme" });
+      await client.execute("DROP TABLE typegraph_edge_claims");
+      const batch = vi.spyOn(client, "batch");
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from, to, props: { role: "Engineer" } },
+        ]),
+      ).rejects.toMatchObject({
+        details: { code: "EDGE_CLAIM_RELATION_MISSING" },
+      });
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(0);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back a durable batch when one match identity conflicts", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-durable-rollback-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(matchIdentityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const to = await store.nodes.Company.create({ name: "Acme" });
+      await store.edges.worksAt.create(from, to, { role: "Existing" });
+      const batch = vi.spyOn(client, "batch");
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from, to, props: { role: "New" } },
+          { from, to, props: { role: "Existing" } },
+        ]),
+      ).rejects.toBeInstanceOf(EdgeMatchIdentityConflictError);
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when a native root has lost its durable identity arbiter", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-durable-storage-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(matchIdentityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const to = await store.nodes.Company.create({ name: "Acme" });
+      await store.edges.worksAt.create(from, to, { role: "Existing" });
+      await client.execute(
+        `DROP INDEX "${edgeMatchIdentityUniqueIndexName("typegraph_edges")}"`,
+      );
+      const batch = vi.spyOn(client, "batch");
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from, to, props: { role: "New" } },
+        ]),
+      ).rejects.toMatchObject({
+        details: { code: "EDGE_MATCH_IDENTITY_STORAGE_UNAVAILABLE" },
+      });
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
     } finally {
       await backend.close();
       client.close();
@@ -335,6 +696,56 @@ describe("generated edge batch store consumer", () => {
       expect(batch).toHaveBeenCalledOnce();
       expect(batch.mock.calls[0]?.[0].length).toBeGreaterThan(1);
       await expect(store.edges.worksAt.count()).resolves.toBe(0);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back earlier constrained chunks when a later claim refuses", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-chunk-rollback-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const backend = await createChunkedLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const people = await store.nodes.Person.bulkCreate(
+        Array.from({ length: 20 }, (_, index) => ({
+          props: { name: `Person ${index}` },
+        })),
+      );
+      const companies = await store.nodes.Company.bulkCreate(
+        Array.from({ length: 21 }, (_, index) => ({
+          props: { name: `Company ${index}` },
+        })),
+      );
+      const conflictingPerson = people[19];
+      const incumbentCompany = companies[20];
+      if (conflictingPerson === undefined || incumbentCompany === undefined) {
+        throw new Error("Expected generated endpoints for chunk rollback test.");
+      }
+      await store.edges.worksAt.create(conflictingPerson, incumbentCompany, {
+        role: "Incumbent",
+      });
+      const batch = vi.spyOn(client, "batch");
+      const items = people.map((from, index) => ({
+        id: `constrained-edge-${index}`,
+        from,
+        to: companies[index] ?? incumbentCompany,
+        props: { role: `Role ${index}` },
+      }));
+
+      await expect(store.edges.worksAt.bulkInsert(items)).rejects.toBeInstanceOf(
+        CardinalityError,
+      );
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(batch.mock.calls[0]?.[0].length).toBeGreaterThan(4);
+      await expect(store.edges.worksAt.count()).resolves.toBe(1);
     } finally {
       await backend.close();
       client.close();
@@ -442,6 +853,40 @@ describe("generated edge batch store consumer", () => {
       await expect(store.edges.worksAt.count()).resolves.toBe(0);
     } finally {
       await backend.close();
+    }
+  });
+
+  it("leaves no cardinality claim when a native schema fence is stale", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-atomic-cardinality-stale-fence-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(cardinalityGraph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const to = await store.nodes.Company.create({ name: "Acme" });
+      await migrateSchema(backend, evolvedCardinalityGraph, 1);
+      const batch = vi.spyOn(client, "batch");
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from, to, props: { role: "Engineer" } },
+        ]),
+      ).rejects.toBeInstanceOf(StaleVersionError);
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(store.edges.worksAt.count()).resolves.toBe(0);
+      const claims = await client.execute(
+        "SELECT COUNT(*) AS count FROM typegraph_edge_claims",
+      );
+      expect(claims.rows[0]?.["count"]).toBe(0);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
     }
   });
 

--- a/packages/typegraph/tests/atomic-generated-edge-batch.test.ts
+++ b/packages/typegraph/tests/atomic-generated-edge-batch.test.ts
@@ -360,10 +360,7 @@ describe("generated edge batch store consumer", () => {
       ]);
 
       expect(batch).toHaveBeenCalledOnce();
-      expect(edges.map((edge) => edge.role)).toEqual([
-        "Engineer",
-        "Designer",
-      ]);
+      expect(edges.map((edge) => edge.role)).toEqual(["Engineer", "Designer"]);
     } finally {
       await backend.close();
       client.close();
@@ -589,9 +586,7 @@ describe("generated edge batch store consumer", () => {
       const batch = vi.spyOn(client, "batch");
 
       await expect(
-        store.edges.worksAt.bulkInsert([
-          { from, to, props: { role: "New" } },
-        ]),
+        store.edges.worksAt.bulkInsert([{ from, to, props: { role: "New" } }]),
       ).rejects.toMatchObject({
         details: { code: "EDGE_MATCH_IDENTITY_STORAGE_UNAVAILABLE" },
       });
@@ -726,7 +721,9 @@ describe("generated edge batch store consumer", () => {
       const conflictingPerson = people[19];
       const incumbentCompany = companies[20];
       if (conflictingPerson === undefined || incumbentCompany === undefined) {
-        throw new Error("Expected generated endpoints for chunk rollback test.");
+        throw new Error(
+          "Expected generated endpoints for chunk rollback test.",
+        );
       }
       await store.edges.worksAt.create(conflictingPerson, incumbentCompany, {
         role: "Incumbent",
@@ -739,9 +736,9 @@ describe("generated edge batch store consumer", () => {
         props: { role: `Role ${index}` },
       }));
 
-      await expect(store.edges.worksAt.bulkInsert(items)).rejects.toBeInstanceOf(
-        CardinalityError,
-      );
+      await expect(
+        store.edges.worksAt.bulkInsert(items),
+      ).rejects.toBeInstanceOf(CardinalityError);
 
       expect(batch).toHaveBeenCalledOnce();
       expect(batch.mock.calls[0]?.[0].length).toBeGreaterThan(4);

--- a/packages/typegraph/tests/atomic-generated-edge-batch.test.ts
+++ b/packages/typegraph/tests/atomic-generated-edge-batch.test.ts
@@ -54,6 +54,30 @@ const cardinalityGraph = defineGraph({
     },
   },
 });
+const uniqueCardinalityGraph = defineGraph({
+  id: "atomic-generated-edge-batch-unique-cardinality",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "unique",
+    },
+  },
+});
+const oneActiveCardinalityGraph = defineGraph({
+  id: "atomic-generated-edge-batch-one-active-cardinality",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "oneActive",
+    },
+  },
+});
 const matchIdentityGraph = defineGraph({
   id: "atomic-generated-edge-batch-identity",
   nodes: { Person: { type: Person }, Company: { type: Company } },
@@ -184,7 +208,9 @@ describe("generated edge batch store consumer", () => {
   });
 
   it.each([
-    ["cardinality constraints", cardinalityGraph],
+    ["one cardinality", cardinalityGraph],
+    ["unique cardinality", uniqueCardinalityGraph],
+    ["oneActive cardinality", oneActiveCardinalityGraph],
     ["durable match identity", matchIdentityGraph],
   ] as const)(
     "selects the atomic executor for %s",

--- a/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/bind-parameter-budget.test.ts
@@ -121,8 +121,8 @@ describe("computeSqliteBatchChunkSizes", () => {
     expect(computeSqliteBatchChunkSizes(999)).toEqual({
       checkUniqueBatchChunkSize: 996,
       embeddingUpsertBatchSize: 199,
-      edgeInsertBatchSize: 83,
-      edgeSchemaFencedInsertBatchSize: 83,
+      edgeInsertBatchSize: 71,
+      edgeSchemaFencedInsertBatchSize: 71,
       fulltextUpsertBatchSize: 166,
       findEdgesEndpointChunkSize: 993,
       fulltextDeleteChunkSize: 997,
@@ -139,8 +139,8 @@ describe("computeSqliteBatchChunkSizes", () => {
     expect(computeSqliteBatchChunkSizes(MODERN_BETTER_SQLITE3_BUDGET)).toEqual({
       checkUniqueBatchChunkSize: 32_763,
       embeddingUpsertBatchSize: 6553,
-      edgeInsertBatchSize: 2730,
-      edgeSchemaFencedInsertBatchSize: 2730,
+      edgeInsertBatchSize: 2340,
+      edgeSchemaFencedInsertBatchSize: 2340,
       fulltextUpsertBatchSize: 5461,
       findEdgesEndpointChunkSize: 32_760,
       fulltextDeleteChunkSize: 32_764,

--- a/packages/typegraph/tests/drizzle-claim-sites.test.ts
+++ b/packages/typegraph/tests/drizzle-claim-sites.test.ts
@@ -49,7 +49,7 @@ const RECORDED_CLAIM_SITES: readonly Readonly<{
   },
   {
     file: "apps/docs/src/content/docs/backend-setup.md",
-    line: 841,
+    line: 843,
     text: "## " + CLAIM_WORD + "-Free Entrypoints",
   },
   {

--- a/packages/typegraph/tests/write-exchange-inventory.test.ts
+++ b/packages/typegraph/tests/write-exchange-inventory.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createClient } from "@libsql/client";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
+import { defineEdge, defineGraph, defineNode } from "../src/core";
+import { createStoreWithSchema } from "../src/store";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string() }),
+});
+const graph = defineGraph({
+  id: "write-exchange-inventory",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    unconstrained: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+    },
+    constrained: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "one",
+    },
+    durable: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      matchIdentity: { name: "role", fields: ["role"] },
+    },
+  },
+});
+
+describe("managed write exchange inventory", () => {
+  it("records current libSQL transport calls by bulk shape", async () => {
+    const temporaryDirectory = mkdtempSync(
+      path.join(tmpdir(), "typegraph-write-exchanges-"),
+    );
+    const client = createClient({
+      url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+    });
+    const { backend } = await createLibsqlBackend(client);
+    try {
+      const [store] = await createStoreWithSchema(graph, backend);
+      const from = await store.nodes.Person.create({ name: "Alice" });
+      const to = await store.nodes.Company.create({ name: "Acme" });
+      const execute = vi.spyOn(client, "execute");
+      const batch = vi.spyOn(client, "batch");
+
+      async function measure(name: string, fn: () => Promise<unknown>) {
+        execute.mockClear();
+        batch.mockClear();
+        await fn();
+        return {
+          name,
+          execute: execute.mock.calls.length,
+          batch: batch.mock.calls.length,
+        };
+      }
+
+      const measurements = [
+        await measure("generated-node-batch", () =>
+          store.nodes.Person.bulkInsert([
+            { props: { name: "Generated A" } },
+            { props: { name: "Generated B" } },
+          ]),
+        ),
+        await measure("caller-id-node-batch", () =>
+          store.nodes.Person.bulkInsert([
+            { id: "caller-a", props: { name: "Caller A" } },
+            { id: "caller-b", props: { name: "Caller B" } },
+          ]),
+        ),
+        await measure("unconstrained-edge-batch", () =>
+          store.edges.unconstrained.bulkInsert([
+            { from, to, props: { role: "U1" } },
+            { from, to, props: { role: "U2" } },
+          ]),
+        ),
+        await measure("constrained-edge-batch", () =>
+          store.edges.constrained.bulkInsert([
+            { from, to, props: { role: "C1" } },
+          ]),
+        ),
+        await measure("durable-edge-batch", () =>
+          store.edges.durable.bulkInsert([
+            { from, to, props: { role: "D1" } },
+            { from, to, props: { role: "D2" } },
+          ]),
+        ),
+      ];
+
+      expect(measurements).toMatchInlineSnapshot(`
+        [
+          {
+            "batch": 1,
+            "execute": 0,
+            "name": "generated-node-batch",
+          },
+          {
+            "batch": 0,
+            "execute": 5,
+            "name": "caller-id-node-batch",
+          },
+          {
+            "batch": 1,
+            "execute": 0,
+            "name": "unconstrained-edge-batch",
+          },
+          {
+            "batch": 1,
+            "execute": 0,
+            "name": "constrained-edge-batch",
+          },
+          {
+            "batch": 1,
+            "execute": 0,
+            "name": "durable-edge-batch",
+          },
+        ]
+      `);
+    } finally {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
This completes the direct edge-batch family on the exact-root atomic write-program architecture introduced by #558-#560. Eligible `edges.bulkInsert()` and `edges.bulkCreate()` calls now keep durable match arbitration, `one` / `unique` / `oneActive` claims, endpoint validation, schema fencing, and bind-budget chunking inside one native transport transaction on Neon HTTP, Cloudflare D1, and libSQL.

The program is deliberately closed and fail-closed. Derived backends, transaction handles, history/revision stores, custom roots, and dynamic convergence retain their existing transaction or fallback paths.

## Measured transport impact

Measurements use a real local libSQL client at the transport boundary, counting `execute()` and `batch()` submissions rather than SQL statements inside the native transaction.

| Managed bulk shape | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Unconstrained edge batch | 1 | 1 | unchanged |
| Durable-match edge batch | 6 | 1 | 83% |
| Cardinality-constrained edge batch | 8 | 1 | 87.5% |

The remaining measured high-RTT bulk shape is caller-ID node insertion at 5 transport submissions; generated-ID node and all eligible direct edge batches are now at one.

## Execution and concurrency model

Cardinality claims are prepared without database reads, sorted by the existing canonical claim-target comparator, and acquired before edge rows, matching the lock order of every interactive fallback path. Each claim statement is independently gated by the exact schema fence and live endpoints, so a stale fence remains a side-effect-free no-op while a later endpoint, duplicate, or identity refusal rolls every earlier claim mutation back.

Durable rows name the physical match-identity conflict target on every native execution. A dropped arbiter therefore fails with `EDGE_MATCH_IDENTITY_STORAGE_UNAVAILABLE` instead of silently accepting duplicates, while an actual identity conflict triggers an in-statement NOT NULL sentinel and rolls back before the transport commits. The edge bind budget reserves the two durable identity values. Claim chunking reserves fence binds and uses the widest reachable shape—18 binds for `unique`—for every cardinality so mixed batches remain inside each driver's statement budget.

Missing claim storage retains `EDGE_CLAIM_RELATION_MISSING`; external cardinality conflicts retain the existing public error owner; and a disappearing race produces an honest database diagnostic rather than inventing a competing writer. Sentinel classification uses table and column identities derived from the same schema definitions as the emitted SQL, preventing physical-column renames from silently degrading typed diagnostics.

## Load-bearing evidence

Removing the durable conflict-target clause made the dropped-arbiter regression test resolve successfully, demonstrating the exact silent-corruption mode; restoring the clause made both missing-arbiter and durable-conflict rollback cases pass. Reducing the claim budget back to 16 made the full `unique` D1 case compile a 110-bind statement against D1's 100-bind limit; the 18-bind ceiling keeps all `one`, `unique`, and `oneActive` statements within budget. Real libSQL coverage proves constrained `bulkCreate`, mixed durable-plus-cardinality operation, stale-claim takeover, legacy claimless-incumbent refusal, missing storage, stale-fence no-side-effects, and later-chunk rollback. Real PGlite coverage executes the shared PostgreSQL lowering, including the destination-column casts required for timestamp claim values.

## Documentation

The performance guide now distinguishes transport submissions from SQL statements inside an atomic exchange, records the measured reductions, documents the direct edge-batch eligibility boundary, and updates the portable edge bind budget. Backend and limitation guidance now distinguishes interactive single-write claim enforcement from the narrow static edge-program exception.
