### PR TITLE
fix: make graph templates serverless safe

### DIFF
--- a/.changeset/graph-template-serverless-runtime.md
+++ b/.changeset/graph-template-serverless-runtime.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Make graph-template registration DML-only after normal TypeGraph bootstrap, allow embedding-bearing templates on backends configured with `vector: false`, and clone durable runtime-contribution markers during instantiation so targets can be reopened through verified stores from a later serverless isolate. Vector-enabled backends continue to refuse schema-only templates that would require graph-scoped vector storage.

--- a/apps/docs/src/content/docs/graph-extensions.md
+++ b/apps/docs/src/content/docs/graph-extensions.md
@@ -142,17 +142,20 @@ const store = createAdapterStore(tenantGraph, runtimeBackend, {
 Instantiation is idempotent for the same template and target. A target already
 initialized with a different schema is refused. On PostgreSQL the clone
 statement takes the same graph advisory-lock key as schema commits; SQLite's
-single write statement is serialized by its writer lock.
+schema and marker writes are serialized by its writer lock.
 
-Templates are currently **schema-only**: they do not seed graph rows or create
-runtime-contribution markers. The returned snapshot is therefore for an
-unverified, zero-RTT `createAdapterStore` attach; a target cannot be reopened
-with `createVerifiedStore` until the normal privileged
-`createStoreWithSchema()` boot path has materialized its markers. This matters
-even without `searchable()` fields because verified opens always assert the
-runtime-contribution marker. Templates containing embedding fields are refused
-because their vector storage is graph-scoped and cannot safely be cloned by a
-schema-only statement.
+Templates clone the source graph's durable runtime-contribution markers along
+with its schema row. A target can therefore be reopened with
+`createVerifiedStore` or `createVerifiedAdapterStore` from a later serverless
+isolate without another schema reconciliation or provisioning DDL step.
+Registration and instantiation are DML-only; provision the graph-template table
+through the normal privileged bootstrap or migration before handing runtime
+requests to a DML-only role.
+
+Template eligibility follows the backend's capabilities. Embedding declarations
+are allowed when the backend is configured with `vector: false`, because that
+backend has no graph-scoped vector storage to clone. A vector-enabled backend
+continues to refuse embedding-bearing schema-only templates.
 
 ## The graph extension
 

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -153,11 +153,14 @@ the same `SchemaValidationResult` or throws the same errors.
 :::note[Database privileges]
 Only `createStoreWithSchema()` runs DDL. `createStore()` is a
 synchronous zero-I/O attach; `createVerifiedStore()` is a SELECT-only
-attach (zero DDL — reads the active schema row and contribution
-markers, nothing else). To run the application under a least-privilege,
-DML-only role, do the privileged migration step once with
-`createStoreWithSchema(graph, adminBackend)` and use
-`createVerifiedStore()` at runtime. See
+attach (zero DDL — reads the active schema row and contribution markers,
+nothing else). Graph-template registration and instantiation are also DML-only;
+instantiation copies the source graph's durable contribution markers so a
+target can be reopened by `createVerifiedStore()` from a later serverless
+isolate. To run the application under a least-privilege, DML-only role, do the
+privileged migration step once with `createStoreWithSchema(graph, adminBackend)`
+and preprovision the graph-template table before using the template APIs at
+runtime. See
 [Database roles & least privilege](/backend-setup#database-roles--least-privilege)
 for the canonical breakdown.
 :::

--- a/packages/typegraph/src/backend/drizzle/graph-template-sql.ts
+++ b/packages/typegraph/src/backend/drizzle/graph-template-sql.ts
@@ -1,6 +1,9 @@
 import type { SqlDialect } from "../../query/dialect/types";
 import { sql, type SqlFragment } from "../../query/sql-fragment";
-import { asCompiledRowsSql } from "../../query/sql-intent";
+import {
+  asCompiledRowsSql,
+  type CompiledRowsSql,
+} from "../../query/sql-intent";
 
 type InstantiateGraphTemplateSqlParams = Readonly<{
   dialect: SqlDialect;
@@ -8,17 +11,30 @@ type InstantiateGraphTemplateSqlParams = Readonly<{
   schemaHash: string;
   schemaVersionsTableName: string;
   templatesTableName: string;
+  contributionMaterializationsTableName: string;
+  templateId: string;
+  templateSchemaHash: string;
+}>;
+
+type CopyGraphTemplateContributionMarkersSqlParams = Readonly<{
+  graphId: string;
+  schemaHash: string;
+  schemaVersionsTableName: string;
+  templatesTableName: string;
+  contributionMaterializationsTableName: string;
   templateId: string;
   templateSchemaHash: string;
 }>;
 
 /**
- * The one-statement template clone. PostgreSQL acquires the exact bigint
- * advisory-key family schema commits use inside the CTE; SQLite's INSERT is a
- * single writer-serialized statement. A matching active v1 is returned for an
- * idempotent retry; a missing template and every incompatible target yield no
- * row. SQLite cannot return a classified zero-row outcome from INSERT without
- * a second statement, so callers surface that deliberately broad refusal.
+ * The schema-row template clone. PostgreSQL acquires the exact bigint
+ * advisory-key family schema commits use inside the CTE and copies contribution
+ * markers in the same exchange; SQLite's schema INSERT is a writer-serialized
+ * statement followed by a marker-copy DML statement. A matching active v1 is
+ * returned for an idempotent retry; a missing template and every incompatible
+ * target yield no row. SQLite cannot return a classified zero-row outcome from
+ * INSERT without a second statement, so callers surface that deliberately broad
+ * refusal.
  */
 export function instantiateGraphTemplateSql(
   params: InstantiateGraphTemplateSqlParams,
@@ -26,15 +42,61 @@ export function instantiateGraphTemplateSql(
   return asCompiledRowsSql(instantiateGraphTemplateStatement(params));
 }
 
-/** The exact one-statement payload used by both bundled backends. */
+/** The schema-row payload used by both bundled backends. */
 export function instantiateGraphTemplateStatement(
   params: InstantiateGraphTemplateSqlParams,
 ): SqlFragment {
   const schemaVersions = sql.identifier(params.schemaVersionsTableName);
   const templates = sql.identifier(params.templatesTableName);
+  const contributions = sql.identifier(
+    params.contributionMaterializationsTableName,
+  );
   return params.dialect === "postgres" ?
-      postgresInstantiateSql(params, schemaVersions, templates)
+      postgresInstantiateSql(params, schemaVersions, templates, contributions)
     : sqliteInstantiateSql(params, schemaVersions, templates);
+}
+
+/**
+ * SQLite cannot put a data-modifying CTE beside the schema INSERT. The
+ * marker copy therefore runs as a second DML statement after the schema row
+ * has returned. It still carries only identifiers and hashes over the wire;
+ * the source document and marker values remain server-resident.
+ */
+export function copyGraphTemplateContributionMarkersStatement(
+  params: CopyGraphTemplateContributionMarkersSqlParams,
+): CompiledRowsSql {
+  const schemaVersions = sql.identifier(params.schemaVersionsTableName);
+  const templates = sql.identifier(params.templatesTableName);
+  const contributions = sql.identifier(
+    params.contributionMaterializationsTableName,
+  );
+  return asCompiledRowsSql(sql`
+    INSERT INTO ${contributions} (
+      graph_id, logical_name, owner, table_name, signature,
+      materialized_at, last_attempted_at, last_error
+    )
+    SELECT ${params.graphId}, source.logical_name, source.owner, source.table_name,
+      source.signature, source.materialized_at, source.last_attempted_at,
+      source.last_error
+    FROM ${templates} AS template
+    JOIN ${contributions} AS source
+      ON source.graph_id = json_extract(template.schema_doc, '$.graphId')
+    WHERE template.template_id = ${params.templateId}
+      AND template.schema_hash = ${params.templateSchemaHash}
+      AND EXISTS (
+        SELECT 1 FROM ${schemaVersions}
+        WHERE graph_id = ${params.graphId}
+          AND version = 1
+          AND schema_hash = ${params.schemaHash}
+          AND is_active = 1
+      )
+    ON CONFLICT(graph_id, logical_name, owner, table_name) DO UPDATE SET
+      signature = excluded.signature,
+      materialized_at = excluded.materialized_at,
+      last_attempted_at = excluded.last_attempted_at,
+      last_error = excluded.last_error
+    RETURNING graph_id
+  `);
 }
 
 function sqliteInstantiateSql(
@@ -65,6 +127,7 @@ function postgresInstantiateSql(
   params: InstantiateGraphTemplateSqlParams,
   schemaVersions: SqlFragment,
   templates: SqlFragment,
+  contributions: SqlFragment,
 ) {
   return sql`
     WITH locked AS (
@@ -73,19 +136,38 @@ function postgresInstantiateSql(
       SELECT schema_hash, schema_doc FROM ${templates}
       WHERE template_id = ${params.templateId}
         AND schema_hash = ${params.templateSchemaHash}
+    ), inserted AS (
+      INSERT INTO ${schemaVersions} (graph_id, version, schema_hash, schema_doc, created_at, is_active)
+      SELECT ${params.graphId}, 1, ${params.schemaHash},
+        jsonb_set(jsonb_set(jsonb_set(template.schema_doc, '{graphId}', to_jsonb(${params.graphId}::text), true), '{version}', '1'::jsonb, true), '{generatedAt}', to_jsonb(to_char(clock_timestamp() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), true),
+        clock_timestamp(), TRUE
+      FROM template, locked
+      WHERE NOT EXISTS (
+        SELECT 1 FROM ${schemaVersions}
+        WHERE graph_id = ${params.graphId}
+          AND (version != 1 OR schema_hash != ${params.schemaHash} OR is_active != TRUE)
+      )
+      ON CONFLICT(graph_id, version) DO UPDATE SET schema_hash = EXCLUDED.schema_hash
+      WHERE ${schemaVersions}.schema_hash = EXCLUDED.schema_hash AND ${schemaVersions}.is_active = TRUE
+      RETURNING *
+    ), markers AS (
+      INSERT INTO ${contributions} (
+        graph_id, logical_name, owner, table_name, signature,
+        materialized_at, last_attempted_at, last_error
+      )
+      SELECT ${params.graphId}, source.logical_name, source.owner, source.table_name,
+        source.signature, source.materialized_at, source.last_attempted_at,
+        source.last_error
+      FROM template
+      CROSS JOIN inserted
+      JOIN ${contributions} AS source
+        ON source.graph_id = (template.schema_doc ->> 'graphId')
+      ON CONFLICT (graph_id, logical_name, owner, table_name) DO UPDATE SET
+        signature = EXCLUDED.signature,
+        materialized_at = EXCLUDED.materialized_at,
+        last_attempted_at = EXCLUDED.last_attempted_at,
+        last_error = EXCLUDED.last_error
     )
-    INSERT INTO ${schemaVersions} (graph_id, version, schema_hash, schema_doc, created_at, is_active)
-    SELECT ${params.graphId}, 1, ${params.schemaHash},
-      jsonb_set(jsonb_set(jsonb_set(template.schema_doc, '{graphId}', to_jsonb(${params.graphId}::text), true), '{version}', '1'::jsonb, true), '{generatedAt}', to_jsonb(to_char(clock_timestamp() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')), true),
-      clock_timestamp(), TRUE
-    FROM template, locked
-    WHERE NOT EXISTS (
-      SELECT 1 FROM ${schemaVersions}
-      WHERE graph_id = ${params.graphId}
-        AND (version != 1 OR schema_hash != ${params.schemaHash} OR is_active != TRUE)
-    )
-    ON CONFLICT(graph_id, version) DO UPDATE SET schema_hash = EXCLUDED.schema_hash
-    WHERE ${schemaVersions}.schema_hash = EXCLUDED.schema_hash AND ${schemaVersions}.is_active = TRUE
-    RETURNING *
+    SELECT * FROM inserted
   `;
 }

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -1354,9 +1354,6 @@ export function createPostgresBackend(
     },
 
     async registerGraphTemplate(params): Promise<GraphTemplateRow> {
-      await executeConcurrentCreateDdl(
-        generatePgCreateTableSQL(tables.graphTemplates),
-      );
       const t = tables.graphTemplates;
       await db
         .insert(t)
@@ -1397,6 +1394,9 @@ export function createPostgresBackend(
           schemaHash: params.schemaHash,
           schemaVersionsTableName: getTableName(tables.schemaVersions),
           templatesTableName: getTableName(tables.graphTemplates),
+          contributionMaterializationsTableName: getTableName(
+            tables.contributionMaterializations,
+          ),
           templateId: params.templateId,
           templateSchemaHash: params.templateSchemaHash,
         }),

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -135,7 +135,10 @@ import {
   type SqliteExecutionProfileHints,
 } from "./execution/sqlite-execution";
 import { type ExecutableSql, toDrizzleSql } from "./execution/types";
-import { instantiateGraphTemplateSql } from "./graph-template-sql";
+import {
+  copyGraphTemplateContributionMarkersStatement,
+  instantiateGraphTemplateSql,
+} from "./graph-template-sql";
 import { isLocalLibsqlClient } from "./libsql-client";
 import {
   EMBEDDING_UPSERT_PARAM_COUNT,
@@ -1917,9 +1920,6 @@ export function createSqliteBackend(
     },
 
     async registerGraphTemplate(params): Promise<GraphTemplateRow> {
-      await db.run(
-        sql.raw(generateSqliteCreateTableSQL(tables.graphTemplates)),
-      );
       const t = tables.graphTemplates;
       await db
         .insert(t)
@@ -1960,12 +1960,28 @@ export function createSqliteBackend(
           schemaHash: params.schemaHash,
           schemaVersionsTableName: getTableName(tables.schemaVersions),
           templatesTableName: getTableName(tables.graphTemplates),
+          contributionMaterializationsTableName: getTableName(
+            tables.contributionMaterializations,
+          ),
           templateId: params.templateId,
           templateSchemaHash: params.templateSchemaHash,
         }),
       );
       const row = rows[0];
       if (row === undefined) return { status: "refused" } as const;
+      await operations.execute<Record<string, unknown>>(
+        copyGraphTemplateContributionMarkersStatement({
+          graphId: params.graphId,
+          schemaHash: params.schemaHash,
+          schemaVersionsTableName: getTableName(tables.schemaVersions),
+          templatesTableName: getTableName(tables.graphTemplates),
+          contributionMaterializationsTableName: getTableName(
+            tables.contributionMaterializations,
+          ),
+          templateId: params.templateId,
+          templateSchemaHash: params.templateSchemaHash,
+        }),
+      );
       return { status: "ready", row: toSchemaVersionRow(row) } as const;
     },
 

--- a/packages/typegraph/src/schema/graph-templates.ts
+++ b/packages/typegraph/src/schema/graph-templates.ts
@@ -36,7 +36,10 @@ export async function registerGraphTemplate<G extends GraphDef>(
       { code: "GRAPH_TEMPLATE_REQUIRES_RECONCILED_SCHEMA" },
     );
   }
-  if (resolveGraphVectorSlots(reconciled.graph).length > 0) {
+  if (
+    resolveGraphVectorSlots(reconciled.graph).length > 0 &&
+    backend.capabilities.vector?.supported === true
+  ) {
     throw new ConfigurationError(
       "Graph templates do not support embedding fields because vector storage is graph-scoped and cannot be instantiated schema-only.",
       {

--- a/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-backend.test.ts
@@ -50,6 +50,7 @@ import {
   createAdapterStoreWithSchema,
   createStore,
   createStoreWithSchema,
+  createVerifiedAdapterStore,
   type Store,
 } from "../../../src/store";
 import { requireDefined } from "../../../src/utils/presence";
@@ -317,9 +318,10 @@ describe("PGlite backend", () => {
   });
 
   it("instantiates a durable graph template through the PostgreSQL dialect", async () => {
-    const { backend } = await createLocalPgliteBackend({ vector: false });
+    const { backend, db } = await createLocalPgliteBackend({ vector: false });
     cleanups.push(() => backend.close());
     const [source] = await createAdapterStoreWithSchema(peopleGraph, backend);
+    const executeDdl = vi.spyOn(backend, "executeDdl");
     const template = await registerGraphTemplate(backend, {
       templateId: "pglite-people-v1",
       reconciled: source.reconciledSchema,
@@ -341,6 +343,59 @@ describe("PGlite backend", () => {
       version: 1,
       hash: first.schema.schema_hash,
     });
+    expect(executeDdl).not.toHaveBeenCalled();
+
+    const runtimeBackend = createPostgresBackend(db, {
+      vector: false,
+    });
+    const targetGraph = defineGraph({
+      id: "pglite-template-target",
+      nodes: { Person: { type: Person } },
+      edges: {},
+    });
+    await expect(
+      createVerifiedAdapterStore(targetGraph, runtimeBackend),
+    ).resolves.toBeDefined();
+  });
+
+  it("still refuses vector-enabled schema-only templates", async () => {
+    const { backend } = await createLocalPgliteBackend();
+    cleanups.push(() => backend.close());
+    const [source] = await createAdapterStoreWithSchema(
+      documentsGraph,
+      backend,
+    );
+
+    await expect(
+      registerGraphTemplate(backend, {
+        templateId: "pglite-vector-template",
+        reconciled: source.reconciledSchema,
+      }),
+    ).rejects.toMatchObject({
+      details: { code: "GRAPH_TEMPLATE_VECTOR_UNSUPPORTED" },
+    });
+  });
+
+  it("registers and instantiates embedding templates when vector storage is disabled", async () => {
+    const { backend } = await createLocalPgliteBackend({ vector: false });
+    cleanups.push(() => backend.close());
+    const [source] = await createAdapterStoreWithSchema(
+      documentsGraph,
+      backend,
+    );
+    const executeDdl = vi.spyOn(backend, "executeDdl");
+    const template = await registerGraphTemplate(backend, {
+      templateId: "pglite-vector-disabled-template",
+      reconciled: source.reconciledSchema,
+    });
+
+    await expect(
+      instantiateGraphTemplate(backend, {
+        template,
+        graphId: "pglite-vector-disabled-target",
+      }),
+    ).resolves.toMatchObject({ status: "ready" });
+    expect(executeDdl).not.toHaveBeenCalled();
   });
 
   describe("serialized transaction resource ownership", () => {

--- a/packages/typegraph/tests/graph-templates.test.ts
+++ b/packages/typegraph/tests/graph-templates.test.ts
@@ -29,7 +29,6 @@ const templateGraph = defineGraph({
   nodes: { Person: { type: Person } },
   edges: {},
 });
-
 describe("graph templates", () => {
   it("uses one schema-document-free SQLite statement for instantiation", () => {
     const rendered = renderSqlite(
@@ -39,6 +38,8 @@ describe("graph templates", () => {
         schemaHash: "target-hash",
         schemaVersionsTableName: "typegraph_schema_versions",
         templatesTableName: "typegraph_graph_templates",
+        contributionMaterializationsTableName:
+          "typegraph_contribution_materializations",
         templateId: "people-v1",
         templateSchemaHash: "source-hash",
       }),
@@ -57,7 +58,7 @@ describe("graph templates", () => {
     ]);
   });
 
-  it("executes exactly one SQLite statement when instantiating", async () => {
+  it("executes the schema and marker SQLite statements when instantiating", async () => {
     const { backend, db } = createLocalSqliteBackend();
     const client = (db as unknown as Readonly<{ $client: Database.Database }>)
       .$client;
@@ -84,9 +85,12 @@ describe("graph templates", () => {
         graphId: "tenant-one-statement",
       });
 
-      expect(preparedStatements).toHaveLength(1);
+      expect(preparedStatements).toHaveLength(2);
       expect(preparedStatements[0]).toContain("INSERT INTO");
       expect(preparedStatements[0]).not.toContain("schema_doc = ?");
+      expect(preparedStatements[1]).toContain(
+        "typegraph_contribution_materializations",
+      );
     } finally {
       await backend.close();
     }
@@ -134,7 +138,9 @@ describe("graph templates", () => {
     expect(targetStore.reconciledSchema).toStrictEqual(first.reconciled);
     await expect(
       createVerifiedAdapterStore(targetGraph, backend),
-    ).rejects.toMatchObject({ name: "StoreNotInitializedError" });
+    ).resolves.toMatchObject({
+      0: { reconciledSchema: first.reconciled },
+    });
   });
 
   it("refuses a stale template handle before consulting the backend registry", async () => {


### PR DESCRIPTION
Graph template registration and instantiation are now safe for least-privilege serverless runtimes. Registration no longer performs template-table DDL, so the table can be provisioned once by the privileged bootstrap/migration path and runtime requests can use a DML-only role. Embedding-bearing templates are eligible when the backend is configured with vector:false; vector-enabled backends retain the schema-only refusal.

Instantiation copies durable runtime-contribution markers from the registered source graph. PostgreSQL performs the schema clone and marker copy in one CTE-backed exchange under the existing advisory lock, allowing a target to reopen through createVerifiedAdapterStore from a fresh backend wrapper. SQLite uses its writer-serialized schema DML followed by the marker-copy DML because SQLite does not support data-modifying CTEs. Hash checks, idempotent convergence, and conflicting-target refusal remain unchanged.

The acceptance tests cover vector:false embedding registration/instantiation, vector-enabled refusal, no registration DDL, idempotent PostgreSQL instantiation, verified reopen through a separate backend instance, SQLite marker propagation, and schema-document-free SQL. Load-bearing mutation checks were performed by restoring unconditional vector rejection (the vector:false test failed) and suppressing the PostgreSQL marker CTE (verified reopen failed with StoreNotInitializedError); both mutations were restored and the focused suite passed.