### PR TITLE
fix: complete generated base schema installation

### DIFF
--- a/.changeset/repair-preprovisioned-edge-storage.md
+++ b/.changeset/repair-preprovisioned-edge-storage.md
@@ -5,3 +5,5 @@
 Existing databases must be opened once through privileged `createStoreWithSchema` / `createAdapterStoreWithSchema`, or receive the published base-schema migration, before zero-DDL verified and graph-template runtime paths are used. Those paths now fail early with `BaseSchemaMigrationError` until deployment-wide base storage is stamped at version 1.
 
 Version deployment-wide base storage independently of per-graph schemas. A privileged open adopts the graph-template table and durable edge match-identity storage once, then stamps the marker; later warm opens perform only one marker read. This repairs externally provisioned 0.51 databases even when their graph schema is unchanged. Plain edge writes also classify legacy missing-column failures as `EDGE_MATCH_IDENTITY_STORAGE_UNAVAILABLE` instead of leaking driver errors.
+
+Fresh SQLite and PostgreSQL installation SQL now publishes the current base-schema marker as its final statement, so zero-DDL verified stores and graph-template APIs can attach immediately after applying TypeGraph's generated migration. Concurrent adoption accepts a marker already advanced beyond the step it completed and never downgrades it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,12 @@ jobs:
         run: |
           set -euo pipefail
           container='${{ job.services.postgres.id }}'
-          docker exec "$container" psql -U typegraph -d typegraph_test -c "ALTER SYSTEM SET max_connections = 400"
+          docker exec -i "$container" psql -U typegraph -d typegraph_test <<'SQL'
+          ALTER SYSTEM SET max_connections = 400;
+          ALTER SYSTEM SET client_min_messages = 'warning';
+          ALTER SYSTEM SET log_min_messages = 'fatal';
+          ALTER SYSTEM SET log_min_error_statement = 'fatal';
+          SQL
           docker restart "$container"
           for _ in {1..30}; do
             if docker exec "$container" pg_isready -U typegraph -d typegraph_test >/dev/null 2>&1; then

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -89,7 +89,8 @@ sqlite.exec(generateSqliteMigrationSQL());
 const store = createStore(graph, backend);
 ```
 
-The generated script is complete installation DDL, not an incremental upgrade
+The generated script is complete installation DDL and stamps the current
+deployment-wide base-schema marker last; it is not an incremental upgrade
 planner. Existing databases attached only through the zero-DDL runtime
 factories must apply release-specific additive migrations through their
 migration tool. See
@@ -203,7 +204,8 @@ function createSqliteBackend(
 
 #### `generateSqliteMigrationSQL()`
 
-Returns SQL for creating TypeGraph tables in SQLite.
+Returns complete fresh-installation SQL for creating TypeGraph tables and
+stamping the current deployment-wide base-schema marker in SQLite.
 
 ```typescript
 function generateSqliteMigrationSQL(): string;
@@ -759,10 +761,16 @@ async function createLocalPgliteBackend(options?: {
 
 #### `generatePostgresMigrationSQL()`
 
-Returns SQL for creating TypeGraph tables in PostgreSQL, including the pgvector extension.
+Returns complete fresh-installation SQL for creating TypeGraph tables and
+stamping the current deployment-wide base-schema marker in PostgreSQL. It
+includes the pgvector extension. The vector-disabled local PGlite factory uses
+the same installation builder internally while omitting only that extension.
 
 ```typescript
-function generatePostgresMigrationSQL(): string;
+function generatePostgresMigrationSQL(
+  tables?: PostgresTables,
+  fulltextStrategy?: FulltextStrategy,
+): string;
 ```
 
 #### `generatePostgresDDL(tables?)`

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -89,6 +89,14 @@ vitest_args=(
   --maxWorkers="$MAX_WORKERS"
 )
 
+# GitHub's non-TTY default reporter prints every successful test, and expected
+# negative-path PostgreSQL errors can add hundreds of thousands of log lines.
+# Keep local runs unchanged, but make CI compact while retaining console output
+# for failed tests and Vitest's full failure diagnostics.
+if [[ -n "${CI:-}" ]]; then
+  vitest_args+=(--reporter=dot --silent=passed-only)
+fi
+
 if [[ -n "${VITEST_SHARD:-}" ]]; then
   vitest_args+=("--shard=$VITEST_SHARD")
 fi

--- a/packages/typegraph/src/backend/drizzle/base-schema.ts
+++ b/packages/typegraph/src/backend/drizzle/base-schema.ts
@@ -1,6 +1,6 @@
 import { BaseSchemaMigrationError, CompilerInvariantError } from "../../errors";
 
-const CURRENT_BASE_SCHEMA_VERSION = 1;
+export const CURRENT_BASE_SCHEMA_VERSION = 1;
 
 export type BaseSchemaLifecycle = Readonly<{
   adopt(): Promise<void>;
@@ -38,10 +38,16 @@ function migrationError(
   installedVersion: number | undefined,
 ): BaseSchemaMigrationError {
   const state = classifyVersion(installedVersion);
+  if (state === "current") {
+    throw new CompilerInvariantError(
+      "A current base schema version cannot require migration.",
+      { installedVersion, requiredVersion: CURRENT_BASE_SCHEMA_VERSION },
+    );
+  }
   return new BaseSchemaMigrationError({
     installedVersion,
     requiredVersion: CURRENT_BASE_SCHEMA_VERSION,
-    reason: state === "current" ? "stale" : state,
+    reason: state,
   });
 }
 

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -29,6 +29,7 @@ import {
   type StrategyTableContribution,
   type TableContribution,
 } from "../table-contribution";
+import { CURRENT_BASE_SCHEMA_VERSION } from "./base-schema";
 import {
   type PostgresTables,
   tables as postgresTables,
@@ -49,6 +50,14 @@ const EDGE_MATCH_IDENTITY_KEY_COLUMN = "match_identity_key";
 
 function quoteDdlIdentifier(identifier: string): string {
   return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+/** Publishes the lifecycle version owned by a complete installation script. */
+function generateBaseSchemaVersionMarkerSQL(tableName: string): string {
+  const table = quoteDdlIdentifier(tableName);
+  return `INSERT INTO ${table} ("installation", "version", "updated_at")
+VALUES (1, ${String(CURRENT_BASE_SCHEMA_VERSION)}, CURRENT_TIMESTAMP)
+ON CONFLICT ("installation") DO NOTHING;`;
 }
 
 /** Identifier-preserving text accepted by PostgreSQL's `regclass` input. */
@@ -417,7 +426,11 @@ export function generateSqliteMigrationSQL(
   tables: SqliteTables = sqliteTables,
   fulltextStrategy: FulltextStrategy = fts5Strategy,
 ): string {
-  return generateSqliteDDL(tables, fulltextStrategy).join("\n\n");
+  const ddlSql = generateSqliteDDL(tables, fulltextStrategy).join("\n\n");
+  const markerSql = generateBaseSchemaVersionMarkerSQL(
+    getSqliteTableConfig(tables.baseSchemaVersions).name,
+  );
+  return `${ddlSql}\n\n${markerSql}`;
 }
 
 // ============================================================
@@ -624,6 +637,26 @@ export function generatePostgresDDL(
   );
 }
 
+/** Builds complete PostgreSQL installation SQL for a bundled factory profile. */
+function generatePostgresInstallationSQL(
+  tables: PostgresTables = postgresTables,
+  fulltextStrategy: FulltextStrategy = tsvectorStrategy,
+  includeVectorExtension: boolean,
+): string {
+  // pgvector extension is required for the per-field embedding tables
+  const extensionSql =
+    includeVectorExtension ?
+      "-- Enable pgvector extension for vector similarity search\nCREATE EXTENSION IF NOT EXISTS vector;"
+    : undefined;
+  const ddlSql = generatePostgresDDL(tables, fulltextStrategy).join("\n\n");
+  const markerSql = generateBaseSchemaVersionMarkerSQL(
+    getPgTableConfig(tables.baseSchemaVersions).name,
+  );
+  return [extensionSql, ddlSql, markerSql]
+    .filter((statement) => statement !== undefined)
+    .join("\n\n");
+}
+
 /**
  * Generates complete PostgreSQL installation DDL for a fresh database.
  * This is not an incremental upgrade planner.
@@ -636,9 +669,13 @@ export function generatePostgresMigrationSQL(
   tables: PostgresTables = postgresTables,
   fulltextStrategy: FulltextStrategy = tsvectorStrategy,
 ): string {
-  // pgvector extension is required for the per-field embedding tables
-  const extensionSql =
-    "-- Enable pgvector extension for vector similarity search\nCREATE EXTENSION IF NOT EXISTS vector;";
-  const ddlSql = generatePostgresDDL(tables, fulltextStrategy).join("\n\n");
-  return `${extensionSql}\n\n${ddlSql}`;
+  return generatePostgresInstallationSQL(tables, fulltextStrategy, true);
+}
+
+/** @internal Complete installation SQL for the vector-disabled PGlite factory. */
+export function generateVectorlessPostgresMigrationSQL(
+  tables: PostgresTables = postgresTables,
+  fulltextStrategy: FulltextStrategy = tsvectorStrategy,
+): string {
+  return generatePostgresInstallationSQL(tables, fulltextStrategy, false);
 }

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -1346,7 +1346,10 @@ export function createPostgresBackend(
         set: { version, updatedAt: timestamp },
         setWhere: lte(marker.version, version),
       });
-    return (await readBaseSchemaVersion()) === version;
+    // Read back on this backend's primary connection: remote adapters do not
+    // all support RETURNING, and a concurrent adopter may already be ahead.
+    const installedVersion = await readBaseSchemaVersion();
+    return installedVersion !== undefined && installedVersion >= version;
   }
 
   async function ensureGraphTemplatesTable(): Promise<void> {

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1907,7 +1907,10 @@ export function createSqliteBackend(
         set: { version, updatedAt: timestamp },
         setWhere: lte(marker.version, version),
       });
-    return (await readBaseSchemaVersion()) === version;
+    // Read back on this backend's primary connection: remote adapters do not
+    // all support RETURNING, and a concurrent adopter may already be ahead.
+    const installedVersion = await readBaseSchemaVersion();
+    return installedVersion !== undefined && installedVersion >= version;
   }
 
   async function ensureGraphTemplatesTable(): Promise<void> {

--- a/packages/typegraph/src/backend/postgres/pglite.ts
+++ b/packages/typegraph/src/backend/postgres/pglite.ts
@@ -45,8 +45,8 @@ import { markBundledRootAutocommitEligible } from "../capabilities/autocommit-si
 import { wrapWithManagedClose } from "../derive-backend";
 export type { GraphIdentityConfig } from "../../core/define-graph";
 import {
-  generatePostgresDDL,
   generatePostgresMigrationSQL,
+  generateVectorlessPostgresMigrationSQL,
 } from "../drizzle/ddl";
 import { type AnyPgTransaction } from "../drizzle/execution";
 export type { AnyPgDatabase, AnyPgTransaction } from "../drizzle/execution";
@@ -199,7 +199,7 @@ export async function createLocalPgliteBackend(
     const migrationSql =
       vectorEnabled ?
         generatePostgresMigrationSQL(tables)
-      : generatePostgresDDL(tables).join("\n\n");
+      : generateVectorlessPostgresMigrationSQL(tables);
     await client.exec(migrationSql);
 
     const db = drizzle(client);

--- a/packages/typegraph/tests/backends/integration/capability-bundle-no-throw.ts
+++ b/packages/typegraph/tests/backends/integration/capability-bundle-no-throw.ts
@@ -8,10 +8,10 @@
  * `ConfigurationError` whose `code` the registry declares on the override
  * rows.
  *
- * Construction only — no query runs — so a `drizzle-orm/sqlite-proxy` stub
- * suffices for SQLite and one shared PGlite client (no Docker lane) for
- * PostgreSQL, chosen off `context.getBackend().dialect`. The precedent and
- * its justification are `tests/capability-declaration-validation.test.ts:1-38`.
+ * Construction only — no query runs — so the Drizzle SQLite and PostgreSQL
+ * proxy adapters suffice. Using a live PGlite client here made this pure
+ * capability test inherit database startup latency in every host integration
+ * suite that registers it.
  *
  * SCOPE NOTE: the `vector` dimension is fixed at each dialect's DEFAULT
  * (unset for SQLite, `pgvectorStrategy` for PostgreSQL) rather than swept —
@@ -19,8 +19,7 @@
  * SQLite lane would exercise the strategy's own shape rather than the bundle
  * model this test targets, and no pilot bundle reads `capabilities.vector`.
  */
-import { PGlite } from "@electric-sql/pglite";
-import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { drizzle as drizzlePgProxy } from "drizzle-orm/pg-proxy";
 import { drizzle as drizzleSqliteProxy } from "drizzle-orm/sqlite-proxy";
 import { describe, expect, it } from "vitest";
 
@@ -118,7 +117,7 @@ function buildSqliteBackends(): readonly Readonly<{
   return rows;
 }
 
-function buildPostgresBackends(pgliteClient: PGlite): readonly Readonly<{
+function buildPostgresBackends(): readonly Readonly<{
   label: string;
   overrideKey: CapabilityOverrideKey;
   backend: GraphBackend;
@@ -131,10 +130,13 @@ function buildPostgresBackends(pgliteClient: PGlite): readonly Readonly<{
   for (const fulltext of [undefined, tsvectorStrategy]) {
     for (const windowFunctions of [true, false]) {
       for (const overrideKey of OVERRIDES) {
-        const base = createPostgresBackend(drizzlePglite(pgliteClient), {
-          vector: false,
-          ...(fulltext === undefined ? {} : { fulltext }),
-        });
+        const base = createPostgresBackend(
+          drizzlePgProxy(() => Promise.resolve({ rows: [] })),
+          {
+            vector: false,
+            ...(fulltext === undefined ? {} : { fulltext }),
+          },
+        );
         const capabilities = {
           ...base.capabilities,
           windowFunctions,
@@ -169,19 +171,10 @@ export function registerCapabilityBundleNoThrowIntegrationTests(
   context: IntegrationTestContext,
 ): void {
   describe("capability bundle construction never throws unexpectedly (T9b)", () => {
-    it("resolves all six bundles against the factory matrix", async () => {
+    it("resolves all six bundles against the factory matrix", () => {
       const dialect = context.getBackend().dialect;
       const rows =
-        dialect === "sqlite" ?
-          buildSqliteBackends()
-        : await (async () => {
-            const pgliteClient = await PGlite.create();
-            try {
-              return buildPostgresBackends(pgliteClient);
-            } finally {
-              await pgliteClient.close();
-            }
-          })();
+        dialect === "sqlite" ? buildSqliteBackends() : buildPostgresBackends();
 
       const decisions: Readonly<{ label: string; outcome: string }>[] = [];
       for (const row of rows) {

--- a/packages/typegraph/tests/base-schema-adoption.test.ts
+++ b/packages/typegraph/tests/base-schema-adoption.test.ts
@@ -1,5 +1,7 @@
 import { PGlite } from "@electric-sql/pglite";
-import type Database from "better-sqlite3";
+import { vector as pgvectorExtension } from "@electric-sql/pglite-pgvector";
+import Database from "better-sqlite3";
+import { drizzle as drizzleBetterSqlite3 } from "drizzle-orm/better-sqlite3";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
@@ -19,13 +21,17 @@ import {
   edgeMatchIdentityPairCheckName,
   edgeMatchIdentityUniqueIndexName,
   generatePostgresDDL,
+  generatePostgresMigrationSQL,
+  generateSqliteMigrationSQL,
 } from "../src/backend/drizzle/ddl";
 import {
   createPostgresBackend,
   createPostgresTables,
 } from "../src/backend/postgres";
-import { createSqliteTables } from "../src/backend/sqlite";
+import { createLocalPgliteBackend } from "../src/backend/postgres/pglite";
+import { createSqliteBackend, createSqliteTables } from "../src/backend/sqlite";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { requireDefined } from "../src/utils/presence";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -106,6 +112,60 @@ function reconciledSurface(
 
 describe("deployment-wide base-schema adoption", () => {
   afterEach(() => vi.restoreAllMocks());
+
+  it("publishes the current marker in generated SQLite installation SQL", async () => {
+    const tableNames = {
+      baseSchemaVersions: "generated_base_schema_versions",
+    } as const;
+    const tables = createSqliteTables(tableNames);
+    const client = new Database(":memory:");
+    client.exec(generateSqliteMigrationSQL(tables));
+    const backend = createSqliteBackend(drizzleBetterSqlite3(client), {
+      executionProfile: { isSync: true },
+      tables,
+    });
+    try {
+      await requireDefined(backend.assertBaseSchemaCurrent)();
+      expect(markerVersion(client, tableNames.baseSchemaVersions)).toBe(1);
+    } finally {
+      await backend.close();
+      client.close();
+    }
+  });
+
+  it("publishes the current marker in generated PostgreSQL installation SQL", async () => {
+    const tableNames = {
+      baseSchemaVersions: "generated_base_schema_versions",
+    } as const;
+    const tables = createPostgresTables(tableNames);
+    const client = await PGlite.create({
+      extensions: { vector: pgvectorExtension },
+    });
+    await client.exec(generatePostgresMigrationSQL(tables));
+    const backend = createPostgresBackend(drizzlePglite(client), {
+      tables,
+      vector: false,
+    });
+    try {
+      await requireDefined(backend.assertBaseSchemaCurrent)();
+      const marker = await client.query<{ version: number }>(
+        `SELECT version FROM "${tableNames.baseSchemaVersions}" WHERE installation = 1`,
+      );
+      expect(marker.rows).toEqual([{ version: 1 }]);
+    } finally {
+      await backend.close();
+      await client.close();
+    }
+  });
+
+  it("publishes the current marker for vector-disabled local PGlite", async () => {
+    const { backend } = await createLocalPgliteBackend({ vector: false });
+    try {
+      await requireDefined(backend.assertBaseSchemaCurrent)();
+    } finally {
+      await backend.close();
+    }
+  });
 
   it("adopts a legacy SQLite installation and registers templates", async () => {
     const tableNames = {
@@ -378,11 +438,7 @@ describe("deployment-wide base-schema adoption", () => {
         return prepare(source);
       });
 
-      await expect(backend.bootstrapTables?.()).rejects.toSatisfy(
-        (error: unknown) =>
-          error instanceof BaseSchemaMigrationError &&
-          error.details.reason === "newer",
-      );
+      await expect(backend.bootstrapTables?.()).resolves.toBeUndefined();
       expect(publishedNewerMarker).toBe(true);
       expect(markerVersion(client, "typegraph_base_schema_versions")).toBe(2);
     } finally {

--- a/packages/typegraph/tests/drizzle-claim-sites.test.ts
+++ b/packages/typegraph/tests/drizzle-claim-sites.test.ts
@@ -49,7 +49,7 @@ const RECORDED_CLAIM_SITES: readonly Readonly<{
   },
   {
     file: "apps/docs/src/content/docs/backend-setup.md",
-    line: 905,
+    line: 913,
     text: "## " + CLAIM_WORD + "-Free Entrypoints",
   },
   {

--- a/packages/typegraph/tests/lock-fence-test-utils.ts
+++ b/packages/typegraph/tests/lock-fence-test-utils.ts
@@ -23,12 +23,13 @@
  * declared-advisory-only declaration).
  */
 import { PGlite, type QueryOptions } from "@electric-sql/pglite";
+import { vector as pgvectorExtension } from "@electric-sql/pglite-pgvector";
 import Database from "better-sqlite3";
 import { drizzle as drizzleBetterSqlite3 } from "drizzle-orm/better-sqlite3";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 
 import {
-  generatePostgresDDL,
+  generatePostgresMigrationSQL,
   generateSqliteMigrationSQL,
 } from "../src/backend/drizzle/ddl";
 import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
@@ -66,11 +67,10 @@ export type LoggedBackend = Readonly<{
 export async function createLoggedPostgresBackend(
   capabilities?: Partial<BackendCapabilities>,
 ): Promise<LoggedBackend> {
-  const client = await PGlite.create();
-  await client.exec(generatePostgresDDL().join("\n\n"));
-  await client.exec(
-    "INSERT INTO typegraph_base_schema_versions (installation, version, updated_at) VALUES (1, 1, NOW())",
-  );
+  const client = await PGlite.create({
+    extensions: { vector: pgvectorExtension },
+  });
+  await client.exec(generatePostgresMigrationSQL());
   const statements: LoggedStatement[] = [];
   const originalQuery = client.query.bind(client);
   client.query = (<T>(
@@ -118,9 +118,6 @@ export function createLoggedSqliteBackend(
 ): LoggedBackend {
   const client = new Database(":memory:");
   client.exec(generateSqliteMigrationSQL());
-  client.exec(
-    "INSERT INTO typegraph_base_schema_versions (installation, version, updated_at) VALUES (1, 1, CURRENT_TIMESTAMP)",
-  );
   const statements: LoggedStatement[] = [];
   const originalPrepare = client.prepare.bind(client);
   client.prepare = ((sqlText: string) => {

--- a/packages/typegraph/tests/postgres-concurrent-create-ddl.test.ts
+++ b/packages/typegraph/tests/postgres-concurrent-create-ddl.test.ts
@@ -118,6 +118,8 @@ function stubPostgresDatabase(
     insert: () => ({
       values: (values: Readonly<Record<string, unknown>>) => ({
         onConflictDoUpdate: () => {
+          // This DDL-retry stub is not the marker-protocol specification;
+          // base-schema-adoption.test.ts owns monotonic race coverage.
           if (
             values["installation"] === 1 &&
             typeof values["version"] === "number"


### PR DESCRIPTION
Complete the deployment-wide base-schema lifecycle for fresh installations. `generateSqliteMigrationSQL()` and `generatePostgresMigrationSQL()` now publish the current singleton marker as their final statement, including custom table names, so zero-DDL verified stores and graph-template APIs can attach immediately after applying TypeGraph’s own generated installation SQL.

Keep vector-disabled local PGlite on the same complete-installation path through an internal PostgreSQL installation builder that omits only the pgvector extension statement while retaining table DDL and marker publication; the public migration-generator signature remains unchanged.

Treat a marker observed at or beyond the step just completed as a successful monotonic adoption. Marker upserts remain downgrade-safe, use authoritative primary readback for adapters that cannot support `RETURNING`, and no longer fail when another adopter advances the database concurrently.

Keep the capability-bundle factory matrix construction-only by using Drizzle proxy adapters instead of booting PGlite inside every PostgreSQL host suite. The PostgreSQL CI lane now uses a compact reporter, retains console output for failed tests, and suppresses expected negative-path server statements that previously expanded a single failure into hundreds of thousands of log lines.

Generated-installation and concurrent-adoption regressions cover SQLite, PostgreSQL/PGlite, custom table names, vector-disabled PGlite, and the fixture paths that previously hand-stamped the marker.