### PR TITLE
fix: harden base schema lifecycle and provisioning

### DIFF
--- a/.changeset/harden-base-schema-lifecycle.md
+++ b/.changeset/harden-base-schema-lifecycle.md
@@ -2,4 +2,4 @@
 "@nicia-ai/typegraph": patch
 ---
 
-Harden deployment-wide base-schema adoption under concurrent upgrades, make the managed SQLite and libSQL factories publish complete installation markers and repair pre-0.52 edge storage, and add ratchets that bind physical base-table changes and every supported provisioning path to the numbered lifecycle.
+Harden deployment-wide base-schema adoption under concurrent upgrades, make managed SQLite and libSQL installations repair pre-0.52 edge storage without bypassing numbered lifecycle steps, and add ratchets that bind ordered physical DDL and supported provisioning paths to executable match-identity storage rather than trusting the version marker alone.

--- a/.changeset/harden-base-schema-lifecycle.md
+++ b/.changeset/harden-base-schema-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Harden deployment-wide base-schema adoption under concurrent upgrades, make the managed SQLite and libSQL factories publish complete installation markers and repair pre-0.52 edge storage, and add ratchets that bind physical base-table changes and every supported provisioning path to the numbered lifecycle.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -159,7 +159,11 @@ const store = createStore(graph, backend);
 execution profile automatically. It returns both the `backend` and the underlying
 Drizzle `db` instance for direct SQL access. The caller retains ownership of the
 client and is responsible for closing it when done — this allows sharing a single
-client across TypeGraph and other libraries.
+client across TypeGraph and other libraries. Its installation is complete: the
+factory publishes the deployment-wide base-schema marker, and when it encounters
+a pre-0.52 edge table it applies the focused match-identity storage adoption
+before retrying the idempotent installation script. The local SQLite factory has
+the same behavior.
 
 The libsql backend has native vector and hybrid search, wired automatically via `libsqlVectorStrategy` — no
 extension to load. It uses libSQL's built-in engine (`F32_BLOB(N)` storage, `vector_distance_cos` /
@@ -210,6 +214,12 @@ stamping the current deployment-wide base-schema marker in SQLite.
 ```typescript
 function generateSqliteMigrationSQL(): string;
 ```
+
+`generateSqliteDDL()` is the lower-level table/index statement array used by
+backend bootstrap. It deliberately omits the deployment-wide marker row and is
+therefore not a complete installation script. Use `generateSqliteMigrationSQL()`
+when the resulting database will be opened through `createVerifiedStore()` or
+the DML-only graph-template APIs.
 
 #### `createLibsqlBackend(client, options?)`
 
@@ -777,7 +787,10 @@ function generatePostgresMigrationSQL(
 
 Returns individual DDL statements (CREATE TABLE, CREATE INDEX) as an array. Useful when you
 need per-statement control, for example to execute them in separate transactions or log them
-individually.
+individually. This low-level array deliberately omits the deployment-wide
+marker row, so joining it does not produce a complete installation. Use
+`generatePostgresMigrationSQL()` for a database that will be opened through
+`createVerifiedStore()` or the DML-only graph-template APIs.
 
 ```typescript
 function generatePostgresDDL(tables?: PostgresTables): string[];
@@ -839,7 +852,8 @@ INSERT INTO "typegraph_base_schema_versions"
 VALUES (1, 1, CURRENT_TIMESTAMP)
 ON CONFLICT ("installation") DO UPDATE SET
   "version" = excluded."version",
-  "updated_at" = excluded."updated_at";
+  "updated_at" = excluded."updated_at"
+WHERE "typegraph_base_schema_versions"."version" <= excluded."version";
 ```
 
 For PostgreSQL, the adoption statements are idempotent:
@@ -892,8 +906,15 @@ INSERT INTO "typegraph_base_schema_versions"
 VALUES (1, 1, NOW())
 ON CONFLICT ("installation") DO UPDATE SET
   "version" = excluded."version",
-  "updated_at" = excluded."updated_at";
+  "updated_at" = excluded."updated_at"
+WHERE "typegraph_base_schema_versions"."version" <= excluded."version";
 ```
+
+The conditional update makes marker publication monotonic: replaying an older
+migration can never claim that storage prepared by a newer TypeGraph release is
+older. The fresh-installation generators use `DO NOTHING` instead because they
+are not upgrade planners; an existing stale marker remains stale until the
+numbered privileged adoption lifecycle runs.
 
 `createVerifiedStore`, `assertSchemaCurrent`, and the DML-only graph-template
 APIs read this marker and throw `BaseSchemaMigrationError` when it is missing,

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -3382,8 +3382,8 @@ export const UNBUNDLED_OPTIONAL_MEMBERS: {
     };
     readonly assertBaseSchemaCurrent: {
         readonly kind: "reasoned";
-        readonly reason: "SELECT-only sibling of base adoption, consulted by verified and graph-template entry points so DML-only roles fail before their first write. Custom backends may omit it only when they own base-schema compatibility themselves; omission intentionally preserves the legacy no-gate contract.";
-        readonly accesses: 3;
+        readonly reason: "SELECT-only sibling of base adoption, consulted by verified and graph-template entry points plus the managed libSQL installation postcondition so incompatible storage fails before use. Custom backends may omit it only when they own base-schema compatibility themselves; omission intentionally preserves the legacy no-gate contract.";
+        readonly accesses: 4;
     };
     readonly ensureEdgeMatchIdentityStorage: {
         readonly kind: "reasoned";
@@ -3407,8 +3407,8 @@ export const UNBUNDLED_OPTIONAL_MEMBERS: {
     };
     readonly bootstrapTables: {
         readonly kind: "reasoned";
-        readonly reason: "One-shot provisioning hook consulted by createStore before any capability question exists; it has no operation that could refuse or degrade.";
-        readonly accesses: 3;
+        readonly reason: "One-shot provisioning hook consulted by createStore and the managed libSQL legacy fallback before any capability question exists; it has no operation that could refuse or degrade.";
+        readonly accesses: 4;
     };
     readonly tableNames: {
         readonly kind: "reasoned";

--- a/packages/typegraph/src/backend/capabilities/bundle-registry.ts
+++ b/packages/typegraph/src/backend/capabilities/bundle-registry.ts
@@ -833,8 +833,8 @@ export const UNBUNDLED_OPTIONAL_MEMBERS = {
   assertBaseSchemaCurrent: {
     kind: "reasoned",
     reason:
-      "SELECT-only sibling of base adoption, consulted by verified and graph-template entry points so DML-only roles fail before their first write. Custom backends may omit it only when they own base-schema compatibility themselves; omission intentionally preserves the legacy no-gate contract.",
-    accesses: 3,
+      "SELECT-only sibling of base adoption, consulted by verified and graph-template entry points plus the managed libSQL installation postcondition so incompatible storage fails before use. Custom backends may omit it only when they own base-schema compatibility themselves; omission intentionally preserves the legacy no-gate contract.",
+    accesses: 4,
   },
   ensureEdgeMatchIdentityStorage: {
     kind: "reasoned",
@@ -863,8 +863,8 @@ export const UNBUNDLED_OPTIONAL_MEMBERS = {
   bootstrapTables: {
     kind: "reasoned",
     reason:
-      "One-shot provisioning hook consulted by createStore before any capability question exists; it has no operation that could refuse or degrade.",
-    accesses: 3,
+      "One-shot provisioning hook consulted by createStore and the managed libSQL legacy fallback before any capability question exists; it has no operation that could refuse or degrade.",
+    accesses: 4,
   },
   tableNames: {
     kind: "reasoned",

--- a/packages/typegraph/src/backend/drizzle/base-schema.ts
+++ b/packages/typegraph/src/backend/drizzle/base-schema.ts
@@ -5,19 +5,19 @@ import { BaseSchemaMigrationError, CompilerInvariantError } from "../../errors";
  *
  * A new base-table shape replaces neither an older entry nor its digests: add
  * the next version here and add the corresponding adoption step to every
- * bundled backend. The shape ratchet tests compare the latest entry with the
- * generated base DDL, while the lifecycle refuses a backend whose step
+ * bundled backend. The ordered-shape ratchet tests compare the latest entry
+ * with generated base DDL, while the lifecycle refuses a backend whose step
  * registry does not reach the same version.
  */
 export const BASE_SCHEMA_RELEASES = [
   {
     version: 1,
     id: "versioned-base-storage",
-    shapeDigests: {
+    orderedShapeDigests: {
       postgres:
-        "c9c81dcb1e7b8a1a8ccf43fe48aebb9677d211b734be0d24a94ecb3b148ebd60",
+        "b8f25c291cc75a36102ba7160c25923926f263f61ed1d3d05619708936d0246f",
       sqlite:
-        "0f5a64c5efd432fad2b93bb13353d20e37d57a845bacfb28c8cc604e1ae99b6f",
+        "68363b5bf1c91c5f3e7528ebd255b542a1cd26677a01c7b2271e100e08a1e354",
     },
   },
 ] as const;
@@ -45,11 +45,16 @@ export type BaseSchemaLifecycle = Readonly<{
   assertCurrent(): Promise<void>;
 }>;
 
+type BaseSchemaBootstrapStrategy =
+  | Readonly<{ phase: "covered-by-generated-ddl" }>
+  | Readonly<{ phase: "before"; adopt(): Promise<void> }>
+  | Readonly<{ phase: "after"; adopt(): Promise<void> }>;
+
 type BaseSchemaStep = Readonly<{
   version: number;
+  /** Steps may be retried or raced by concurrent adopters and must be idempotent. */
   adopt(): Promise<void>;
-  adoptBeforeBootstrap?(): Promise<void>;
-  adoptAfterBootstrap?(): Promise<void>;
+  bootstrap: BaseSchemaBootstrapStrategy;
 }>;
 
 type BaseSchemaLifecycleOptions = Readonly<{
@@ -182,17 +187,16 @@ export function createBaseSchemaLifecycle(
   async function adoptAfterBootstrap(
     startingVersion: number | undefined,
   ): Promise<void> {
-    // Full generated DDL already created every current base relation. A step's
-    // bootstrap hook therefore owns only upgrades CREATE TABLE cannot apply to
-    // a pre-existing relation, avoiding duplicate cold-start CREATEs.
+    // Generated DDL owns explicitly covered steps. Before/after strategies own
+    // only upgrades that CREATE TABLE cannot apply to a pre-existing relation.
     const state = classifyVersion(startingVersion, currentVersion);
     if (state === "current") return;
     if (state === "newer") {
       throw migrationError(startingVersion, currentVersion, state);
     }
-    await runSteps(startingVersion ?? 0, (step) =>
-      step.adoptAfterBootstrap?.() ?? Promise.resolve(),
-    );
+    await runSteps(startingVersion ?? 0, async (step) => {
+      if (step.bootstrap.phase === "after") await step.bootstrap.adopt();
+    });
   }
 
   async function adoptBeforeBootstrap(
@@ -204,7 +208,7 @@ export function createBaseSchemaLifecycle(
     }
     for (const step of steps) {
       if (step.version <= startingVersion) continue;
-      await step.adoptBeforeBootstrap?.();
+      if (step.bootstrap.phase === "before") await step.bootstrap.adopt();
     }
   }
 

--- a/packages/typegraph/src/backend/drizzle/base-schema.ts
+++ b/packages/typegraph/src/backend/drizzle/base-schema.ts
@@ -1,11 +1,45 @@
 import { BaseSchemaMigrationError, CompilerInvariantError } from "../../errors";
 
-export const CURRENT_BASE_SCHEMA_VERSION = 1;
+/**
+ * Immutable release ledger for TypeGraph-owned physical storage.
+ *
+ * A new base-table shape replaces neither an older entry nor its digests: add
+ * the next version here and add the corresponding adoption step to every
+ * bundled backend. The shape ratchet tests compare the latest entry with the
+ * generated base DDL, while the lifecycle refuses a backend whose step
+ * registry does not reach the same version.
+ */
+export const BASE_SCHEMA_RELEASES = [
+  {
+    version: 1,
+    id: "versioned-base-storage",
+    shapeDigests: {
+      postgres:
+        "c9c81dcb1e7b8a1a8ccf43fe48aebb9677d211b734be0d24a94ecb3b148ebd60",
+      sqlite:
+        "0f5a64c5efd432fad2b93bb13353d20e37d57a845bacfb28c8cc604e1ae99b6f",
+    },
+  },
+] as const;
+
+function currentBaseSchemaVersion(): number {
+  const release = BASE_SCHEMA_RELEASES.at(-1);
+  if (release === undefined) {
+    throw new CompilerInvariantError(
+      "The base schema release ledger must not be empty.",
+    );
+  }
+  return release.version;
+}
+
+export const CURRENT_BASE_SCHEMA_VERSION = currentBaseSchemaVersion();
 
 export type BaseSchemaLifecycle = Readonly<{
   adopt(): Promise<void>;
   /** Read and refuse a newer marker before bootstrap emits any DDL. */
   prepareBootstrap(): Promise<number | undefined>;
+  /** Repair existing relations before bootstrap creates dependent indexes. */
+  adoptBeforeBootstrap(startingVersion: number | undefined): Promise<void>;
   /** Complete adoption after the adapter's full current-schema DDL ran. */
   adoptAfterBootstrap(startingVersion: number | undefined): Promise<void>;
   assertCurrent(): Promise<void>;
@@ -14,40 +48,39 @@ export type BaseSchemaLifecycle = Readonly<{
 type BaseSchemaStep = Readonly<{
   version: number;
   adopt(): Promise<void>;
+  adoptBeforeBootstrap?(): Promise<void>;
   adoptAfterBootstrap?(): Promise<void>;
 }>;
 
 type BaseSchemaLifecycleOptions = Readonly<{
+  /** Override only for isolated state-machine tests. Bundled backends omit it. */
+  currentVersion?: number;
   readVersion(): Promise<number | undefined>;
   ensureVersionTable(): Promise<void>;
-  /** Monotonically stamp `version`; false means a newer marker won the race. */
-  writeVersion(version: number): Promise<boolean>;
+  /** Monotonically stamp `version` and return the version observed afterward. */
+  writeVersion(version: number): Promise<number | undefined>;
   steps: readonly BaseSchemaStep[];
 }>;
 
 function classifyVersion(
   installedVersion: number | undefined,
+  currentVersion: number,
 ): "current" | "missing" | "newer" | "stale" {
   if (installedVersion === undefined) return "missing";
-  if (installedVersion === CURRENT_BASE_SCHEMA_VERSION) return "current";
-  if (installedVersion > CURRENT_BASE_SCHEMA_VERSION) return "newer";
+  if (installedVersion === currentVersion) return "current";
+  if (installedVersion > currentVersion) return "newer";
   return "stale";
 }
 
 function migrationError(
   installedVersion: number | undefined,
+  requiredVersion: number,
+  reason: "missing" | "newer" | "stale",
 ): BaseSchemaMigrationError {
-  const state = classifyVersion(installedVersion);
-  if (state === "current") {
-    throw new CompilerInvariantError(
-      "A current base schema version cannot require migration.",
-      { installedVersion, requiredVersion: CURRENT_BASE_SCHEMA_VERSION },
-    );
-  }
   return new BaseSchemaMigrationError({
     installedVersion,
-    requiredVersion: CURRENT_BASE_SCHEMA_VERSION,
-    reason: state,
+    requiredVersion,
+    reason,
   });
 }
 
@@ -63,6 +96,13 @@ function migrationError(
 export function createBaseSchemaLifecycle(
   options: BaseSchemaLifecycleOptions,
 ): BaseSchemaLifecycle {
+  const currentVersion = options.currentVersion ?? CURRENT_BASE_SCHEMA_VERSION;
+  if (!Number.isSafeInteger(currentVersion) || currentVersion < 1) {
+    throw new CompilerInvariantError(
+      "The current base schema version must be a positive safe integer.",
+      { currentVersion },
+    );
+  }
   const steps = options.steps.toSorted(
     (left, right) => left.version - right.version,
   );
@@ -74,46 +114,67 @@ export function createBaseSchemaLifecycle(
       );
     }
   }
-  if (steps.length !== CURRENT_BASE_SCHEMA_VERSION) {
+  if (steps.length !== currentVersion) {
     throw new CompilerInvariantError(
-      "The base schema adoption registry must end at CURRENT_BASE_SCHEMA_VERSION.",
+      "The base schema adoption registry must end at the current version.",
       {
-        currentVersion: CURRENT_BASE_SCHEMA_VERSION,
+        currentVersion,
         registeredSteps: steps.length,
       },
     );
   }
 
-  async function assertCurrent(): Promise<void> {
-    const installedVersion = await options.readVersion();
-    if (classifyVersion(installedVersion) === "current") return;
-    throw migrationError(installedVersion);
+  function requireCurrent(installedVersion: number | undefined): void {
+    const state = classifyVersion(installedVersion, currentVersion);
+    if (state === "current") return;
+    throw migrationError(installedVersion, currentVersion, state);
   }
 
-  async function writeVersion(version: number): Promise<void> {
-    if (await options.writeVersion(version)) return;
-    throw migrationError(await options.readVersion());
+  async function assertCurrent(): Promise<void> {
+    requireCurrent(await options.readVersion());
+  }
+
+  async function writeVersion(version: number): Promise<number> {
+    const observedVersion = await options.writeVersion(version);
+    if (observedVersion === undefined) {
+      throw migrationError(observedVersion, currentVersion, "missing");
+    }
+    if (observedVersion < version) {
+      throw migrationError(observedVersion, currentVersion, "stale");
+    }
+    return observedVersion;
+  }
+
+  async function runSteps(
+    startingVersion: number,
+    adoptStep: (step: BaseSchemaStep) => Promise<void>,
+  ): Promise<void> {
+    let observedVersion = startingVersion;
+    for (const step of steps) {
+      if (step.version <= observedVersion) continue;
+      await adoptStep(step);
+      observedVersion = await writeVersion(step.version);
+    }
+    requireCurrent(observedVersion);
   }
 
   async function adopt(): Promise<void> {
     const installedVersion = await options.readVersion();
-    const state = classifyVersion(installedVersion);
+    const state = classifyVersion(installedVersion, currentVersion);
     if (state === "current") return;
-    if (state === "newer") throw migrationError(installedVersion);
+    if (state === "newer") {
+      throw migrationError(installedVersion, currentVersion, state);
+    }
 
     if (installedVersion === undefined) await options.ensureVersionTable();
-    const startingVersion = installedVersion ?? 0;
-    for (const step of steps) {
-      if (step.version <= startingVersion) continue;
-      await step.adopt();
-      await writeVersion(step.version);
-    }
+    await runSteps(installedVersion ?? 0, async (step) => step.adopt());
   }
 
   async function prepareBootstrap(): Promise<number | undefined> {
     const installedVersion = await options.readVersion();
-    if (classifyVersion(installedVersion) === "newer") {
-      throw migrationError(installedVersion);
+    const state = classifyVersion(installedVersion, currentVersion);
+    if (state === "newer") {
+      throw migrationError(installedVersion, currentVersion, state);
     }
     return installedVersion;
   }
@@ -124,17 +185,34 @@ export function createBaseSchemaLifecycle(
     // Full generated DDL already created every current base relation. A step's
     // bootstrap hook therefore owns only upgrades CREATE TABLE cannot apply to
     // a pre-existing relation, avoiding duplicate cold-start CREATEs.
-    const state = classifyVersion(startingVersion);
+    const state = classifyVersion(startingVersion, currentVersion);
     if (state === "current") return;
-    if (state === "newer") throw migrationError(startingVersion);
+    if (state === "newer") {
+      throw migrationError(startingVersion, currentVersion, state);
+    }
+    await runSteps(startingVersion ?? 0, (step) =>
+      step.adoptAfterBootstrap?.() ?? Promise.resolve(),
+    );
+  }
 
-    const completedVersion = startingVersion ?? 0;
+  async function adoptBeforeBootstrap(
+    startingVersion: number | undefined = 0,
+  ): Promise<void> {
+    const state = classifyVersion(startingVersion, currentVersion);
+    if (state === "newer") {
+      throw migrationError(startingVersion, currentVersion, state);
+    }
     for (const step of steps) {
-      if (step.version <= completedVersion) continue;
-      await (step.adoptAfterBootstrap ?? step.adopt)();
-      await writeVersion(step.version);
+      if (step.version <= startingVersion) continue;
+      await step.adoptBeforeBootstrap?.();
     }
   }
 
-  return { adopt, prepareBootstrap, adoptAfterBootstrap, assertCurrent };
+  return {
+    adopt,
+    prepareBootstrap,
+    adoptBeforeBootstrap,
+    adoptAfterBootstrap,
+    assertCurrent,
+  };
 }

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -143,6 +143,8 @@ export function planSqliteEdgeMatchIdentityAdoption(
   tableName: string,
   existingColumns: ReadonlySet<string>,
 ): readonly string[] {
+  // A real SQLite table always has at least one column; an empty PRAGMA result
+  // means the edge table does not exist and current generated DDL will create it.
   if (existingColumns.size === 0) return [];
   const nameMissing = !existingColumns.has(EDGE_MATCH_IDENTITY_NAME_COLUMN);
   const keyMissing = !existingColumns.has(EDGE_MATCH_IDENTITY_KEY_COLUMN);

--- a/packages/typegraph/src/backend/drizzle/ddl.ts
+++ b/packages/typegraph/src/backend/drizzle/ddl.ts
@@ -48,16 +48,31 @@ type CustomColumnType = Readonly<{
 const EDGE_MATCH_IDENTITY_NAME_COLUMN = "match_identity_name";
 const EDGE_MATCH_IDENTITY_KEY_COLUMN = "match_identity_key";
 
-function quoteDdlIdentifier(identifier: string): string {
+export function quoteDdlIdentifier(identifier: string): string {
   return `"${identifier.replaceAll('"', '""')}"`;
 }
 
-/** Publishes the lifecycle version owned by a complete installation script. */
-function generateBaseSchemaVersionMarkerSQL(tableName: string): string {
+type BaseSchemaVersionMarkerTable = Readonly<{
+  installation: Readonly<{ name: string }>;
+  updatedAt: Readonly<{ name: string }>;
+  version: Readonly<{ name: string }>;
+}>;
+
+/** Publishes the lifecycle version owned by a complete fresh installation. */
+function generateBaseSchemaVersionMarkerSQL(
+  tableName: string,
+  columns: BaseSchemaVersionMarkerTable,
+): string {
   const table = quoteDdlIdentifier(tableName);
-  return `INSERT INTO ${table} ("installation", "version", "updated_at")
+  const installation = quoteDdlIdentifier(columns.installation.name);
+  const version = quoteDdlIdentifier(columns.version.name);
+  const updatedAt = quoteDdlIdentifier(columns.updatedAt.name);
+  // DO NOTHING is deliberate: this generator is a fresh-installation tool,
+  // not an upgrade planner. Replaying it must never advance a stale marker
+  // without running the numbered adoption steps that marker certifies.
+  return `INSERT INTO ${table} (${installation}, ${version}, ${updatedAt})
 VALUES (1, ${String(CURRENT_BASE_SCHEMA_VERSION)}, CURRENT_TIMESTAMP)
-ON CONFLICT ("installation") DO NOTHING;`;
+ON CONFLICT (${installation}) DO NOTHING;`;
 }
 
 /** Identifier-preserving text accepted by PostgreSQL's `regclass` input. */
@@ -101,7 +116,7 @@ export function generatePostgresEdgeMatchIdentityUpgradeDDL(
  * second added column so old edge tables receive the invariant without a
  * destructive table rebuild.
  */
-export function generateSqliteEdgeMatchIdentityColumnDDL(
+function generateSqliteEdgeMatchIdentityColumnDDL(
   tableName: string,
   column: "match_identity_name" | "match_identity_key",
   withPairCheck = false,
@@ -113,10 +128,44 @@ export function generateSqliteEdgeMatchIdentityColumnDDL(
   return `ALTER TABLE ${quoteDdlIdentifier(tableName)} ADD COLUMN ${quoteDdlIdentifier(column)} TEXT${pairCheck};`;
 }
 
-export function generateSqliteEdgeMatchIdentityIndexDDL(
+function generateSqliteEdgeMatchIdentityIndexDDL(
   tableName: string,
 ): string {
   return `CREATE UNIQUE INDEX IF NOT EXISTS ${quoteDdlIdentifier(edgeMatchIdentityUniqueIndexName(tableName))} ON ${quoteDdlIdentifier(tableName)} (${quoteDdlIdentifier("graph_id")}, ${quoteDdlIdentifier("kind")}, ${quoteDdlIdentifier(EDGE_MATCH_IDENTITY_NAME_COLUMN)}, ${quoteDdlIdentifier(EDGE_MATCH_IDENTITY_KEY_COLUMN)});`;
+}
+
+/**
+ * Plans the focused SQLite v1 adoption from one authoritative column
+ * inventory. Factories and backend lifecycle hooks share this owner so a
+ * bootstrap retry cannot drift from privileged adoption.
+ */
+export function planSqliteEdgeMatchIdentityAdoption(
+  tableName: string,
+  existingColumns: ReadonlySet<string>,
+): readonly string[] {
+  if (existingColumns.size === 0) return [];
+  const nameMissing = !existingColumns.has(EDGE_MATCH_IDENTITY_NAME_COLUMN);
+  const keyMissing = !existingColumns.has(EDGE_MATCH_IDENTITY_KEY_COLUMN);
+  const columnStatements = [
+    nameMissing ?
+      generateSqliteEdgeMatchIdentityColumnDDL(
+        tableName,
+        EDGE_MATCH_IDENTITY_NAME_COLUMN,
+        !keyMissing,
+      )
+    : undefined,
+    keyMissing ?
+      generateSqliteEdgeMatchIdentityColumnDDL(
+        tableName,
+        EDGE_MATCH_IDENTITY_KEY_COLUMN,
+        true,
+      )
+    : undefined,
+  ].filter((statement): statement is string => statement !== undefined);
+  return [
+    ...columnStatements,
+    generateSqliteEdgeMatchIdentityIndexDDL(tableName),
+  ];
 }
 
 // ============================================================
@@ -407,7 +456,9 @@ export function sqliteContributions(
  * Iterates the unified contribution set (#129) — base tables first,
  * then strategy-owned tables. Per-contribution ordering is
  * table-then-its-own-indexes; safe because TypeGraph's tables carry no
- * cross-table foreign keys.
+ * cross-table foreign keys. This low-level array deliberately omits the
+ * deployment-wide version marker; use generateSqliteMigrationSQL for a
+ * complete fresh installation.
  */
 export function generateSqliteDDL(
   tables: SqliteTables = sqliteTables,
@@ -429,6 +480,7 @@ export function generateSqliteMigrationSQL(
   const ddlSql = generateSqliteDDL(tables, fulltextStrategy).join("\n\n");
   const markerSql = generateBaseSchemaVersionMarkerSQL(
     getSqliteTableConfig(tables.baseSchemaVersions).name,
+    tables.baseSchemaVersions,
   );
   return `${ddlSql}\n\n${markerSql}`;
 }
@@ -626,7 +678,9 @@ export function postgresContributions(
  * Iterates the unified contribution set (#129) — base tables first,
  * then strategy-owned tables. Per-contribution ordering is
  * table-then-its-own-indexes; safe because TypeGraph's tables carry no
- * cross-table foreign keys.
+ * cross-table foreign keys. This low-level array deliberately omits the
+ * deployment-wide version marker; use generatePostgresMigrationSQL for a
+ * complete fresh installation.
  */
 export function generatePostgresDDL(
   tables: PostgresTables = postgresTables,
@@ -651,6 +705,7 @@ function generatePostgresInstallationSQL(
   const ddlSql = generatePostgresDDL(tables, fulltextStrategy).join("\n\n");
   const markerSql = generateBaseSchemaVersionMarkerSQL(
     getPgTableConfig(tables.baseSchemaVersions).name,
+    tables.baseSchemaVersions,
   );
   return [extensionSql, ddlSql, markerSql]
     .filter((statement) => statement !== undefined)

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -1371,7 +1371,10 @@ export function createPostgresBackend(
           await ensureGraphTemplatesTable();
           await ensureEdgeMatchIdentityStorage();
         },
-        adoptBeforeBootstrap: ensureEdgeMatchIdentityStorage,
+        bootstrap: {
+          phase: "before",
+          adopt: ensureEdgeMatchIdentityStorage,
+        },
       },
     ],
   });

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -1335,7 +1335,9 @@ export function createPostgresBackend(
     );
   }
 
-  async function writeBaseSchemaVersion(version: number): Promise<boolean> {
+  async function writeBaseSchemaVersion(
+    version: number,
+  ): Promise<number | undefined> {
     const marker = tables.baseSchemaVersions;
     const timestamp = new Date();
     await db
@@ -1347,9 +1349,9 @@ export function createPostgresBackend(
         setWhere: lte(marker.version, version),
       });
     // Read back on this backend's primary connection: remote adapters do not
-    // all support RETURNING, and a concurrent adopter may already be ahead.
-    const installedVersion = await readBaseSchemaVersion();
-    return installedVersion !== undefined && installedVersion >= version;
+    // all support RETURNING. The monotonic upsert plus same-primary read makes
+    // this two-statement observation safe when a concurrent adopter is ahead.
+    return readBaseSchemaVersion();
   }
 
   async function ensureGraphTemplatesTable(): Promise<void> {
@@ -1369,7 +1371,7 @@ export function createPostgresBackend(
           await ensureGraphTemplatesTable();
           await ensureEdgeMatchIdentityStorage();
         },
-        adoptAfterBootstrap: ensureEdgeMatchIdentityStorage,
+        adoptBeforeBootstrap: ensureEdgeMatchIdentityStorage,
       },
     ],
   });
@@ -1434,6 +1436,9 @@ export function createPostgresBackend(
     async bootstrapTables(): Promise<void> {
       const startingBaseSchemaVersion =
         await baseSchemaLifecycle.prepareBootstrap();
+      await baseSchemaLifecycle.adoptBeforeBootstrap(
+        startingBaseSchemaVersion,
+      );
       const statements = generatePostgresDDL(tables, fulltextStrategy);
       for (const statement of statements) {
         // Cold boot is the single most contended DDL path there is — two

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -31,7 +31,11 @@ import {
 } from "drizzle-orm";
 import { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
-import { BackendDisposedError, ConfigurationError } from "../../errors";
+import {
+  BackendDisposedError,
+  CompilerInvariantError,
+  ConfigurationError,
+} from "../../errors";
 import type { ResolvedSqlTableNames } from "../../query/compiler/schema";
 import {
   buildFulltextCapabilities,
@@ -1867,6 +1871,9 @@ export function createSqliteBackend(
         }
       }
     }
+    throw new CompilerInvariantError(
+      "SQLite match-identity adoption exhausted its retry loop without returning or throwing.",
+    );
   }
 
   async function readBaseSchemaVersion(): Promise<number | undefined> {
@@ -1971,9 +1978,7 @@ export function createSqliteBackend(
     async bootstrapTables(): Promise<void> {
       const startingBaseSchemaVersion =
         await baseSchemaLifecycle.prepareBootstrap();
-      await baseSchemaLifecycle.adoptBeforeBootstrap(
-        startingBaseSchemaVersion,
-      );
+      await baseSchemaLifecycle.adoptBeforeBootstrap(startingBaseSchemaVersion);
       const statements = generateSqliteDDL(tables, fulltextStrategy);
       for (const statement of statements) {
         await db.run(sql.raw(statement));

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -56,6 +56,7 @@ import { chunk as chunkArray } from "../../utils/array";
 import { requireDefined } from "../../utils/presence";
 import {
   isMissingTableError,
+  isSqliteDuplicateEdgeMatchIdentityColumnError,
   isSqliteNotAuthorizedError,
 } from "../../utils/sql-errors";
 import { markBundledRootAtomicEdgeBatch } from "../capabilities/atomic-edge-batch";
@@ -1837,19 +1838,34 @@ export function createSqliteBackend(
 
   async function ensureEdgeMatchIdentityStorage(): Promise<void> {
     const edgeTableName = getTableName(tables.edges);
-    const columnRows = await executionAdapter.execute<{
-      name?: unknown;
-    }>(sql`PRAGMA table_info(${sql.identifier(edgeTableName)})`);
-    const columns = new Set(
-      columnRows.flatMap((row) =>
-        typeof row.name === "string" ? [row.name] : [],
-      ),
-    );
-    for (const statement of planSqliteEdgeMatchIdentityAdoption(
-      edgeTableName,
-      columns,
-    )) {
-      await db.run(sql.raw(statement));
+    // SQLite has no ADD COLUMN IF NOT EXISTS. Re-read and re-plan after each
+    // precisely classified duplicate-column race; two retries cover the two
+    // additive columns even when concurrent cold starts interleave both.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const columnRows = await executionAdapter.execute<{
+        name?: unknown;
+      }>(sql`PRAGMA table_info(${sql.identifier(edgeTableName)})`);
+      const columns = new Set(
+        columnRows.flatMap((row) =>
+          typeof row.name === "string" ? [row.name] : [],
+        ),
+      );
+      try {
+        for (const statement of planSqliteEdgeMatchIdentityAdoption(
+          edgeTableName,
+          columns,
+        )) {
+          await db.run(sql.raw(statement));
+        }
+        return;
+      } catch (error) {
+        if (
+          attempt === 2 ||
+          !isSqliteDuplicateEdgeMatchIdentityColumnError(error)
+        ) {
+          throw error;
+        }
+      }
     }
   }
 
@@ -1906,7 +1922,10 @@ export function createSqliteBackend(
           await ensureGraphTemplatesTable();
           await ensureEdgeMatchIdentityStorage();
         },
-        adoptBeforeBootstrap: ensureEdgeMatchIdentityStorage,
+        bootstrap: {
+          phase: "before",
+          adopt: ensureEdgeMatchIdentityStorage,
+        },
       },
     ],
   });

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -178,8 +178,7 @@ import {
 import {
   generateSqliteCreateTableSQL,
   generateSqliteDDL,
-  generateSqliteEdgeMatchIdentityColumnDDL,
-  generateSqliteEdgeMatchIdentityIndexDDL,
+  planSqliteEdgeMatchIdentityAdoption,
   sqliteContributions,
 } from "./ddl";
 import {
@@ -1846,34 +1845,11 @@ export function createSqliteBackend(
         typeof row.name === "string" ? [row.name] : [],
       ),
     );
-    const nameMissing = !columns.has("match_identity_name");
-    const keyMissing = !columns.has("match_identity_key");
-    if (columnRows.length > 0 && nameMissing) {
-      await db.run(
-        sql.raw(
-          generateSqliteEdgeMatchIdentityColumnDDL(
-            edgeTableName,
-            "match_identity_name",
-            !keyMissing,
-          ),
-        ),
-      );
-    }
-    if (columnRows.length > 0 && keyMissing) {
-      await db.run(
-        sql.raw(
-          generateSqliteEdgeMatchIdentityColumnDDL(
-            edgeTableName,
-            "match_identity_key",
-            true,
-          ),
-        ),
-      );
-    }
-    if (columnRows.length > 0) {
-      await db.run(
-        sql.raw(generateSqliteEdgeMatchIdentityIndexDDL(edgeTableName)),
-      );
+    for (const statement of planSqliteEdgeMatchIdentityAdoption(
+      edgeTableName,
+      columns,
+    )) {
+      await db.run(sql.raw(statement));
     }
   }
 
@@ -1896,7 +1872,9 @@ export function createSqliteBackend(
     );
   }
 
-  async function writeBaseSchemaVersion(version: number): Promise<boolean> {
+  async function writeBaseSchemaVersion(
+    version: number,
+  ): Promise<number | undefined> {
     const marker = tables.baseSchemaVersions;
     const timestamp = nowIso();
     await db
@@ -1908,9 +1886,9 @@ export function createSqliteBackend(
         setWhere: lte(marker.version, version),
       });
     // Read back on this backend's primary connection: remote adapters do not
-    // all support RETURNING, and a concurrent adopter may already be ahead.
-    const installedVersion = await readBaseSchemaVersion();
-    return installedVersion !== undefined && installedVersion >= version;
+    // all support RETURNING. The monotonic upsert plus same-primary read makes
+    // this two-statement observation safe when a concurrent adopter is ahead.
+    return readBaseSchemaVersion();
   }
 
   async function ensureGraphTemplatesTable(): Promise<void> {
@@ -1928,7 +1906,7 @@ export function createSqliteBackend(
           await ensureGraphTemplatesTable();
           await ensureEdgeMatchIdentityStorage();
         },
-        adoptAfterBootstrap: ensureEdgeMatchIdentityStorage,
+        adoptBeforeBootstrap: ensureEdgeMatchIdentityStorage,
       },
     ],
   });
@@ -1974,6 +1952,9 @@ export function createSqliteBackend(
     async bootstrapTables(): Promise<void> {
       const startingBaseSchemaVersion =
         await baseSchemaLifecycle.prepareBootstrap();
+      await baseSchemaLifecycle.adoptBeforeBootstrap(
+        startingBaseSchemaVersion,
+      );
       const statements = generateSqliteDDL(tables, fulltextStrategy);
       for (const statement of statements) {
         await db.run(sql.raw(statement));

--- a/packages/typegraph/src/backend/sqlite/libsql.ts
+++ b/packages/typegraph/src/backend/sqlite/libsql.ts
@@ -26,10 +26,16 @@
  * ```
  */
 import type { Client } from "@libsql/client";
+import { getTableName } from "drizzle-orm";
 import { drizzle, type LibSQLDatabase } from "drizzle-orm/libsql";
 
 import { libsqlVectorStrategy } from "../../query/dialect/vector/libsql-strategy";
-import { generateSqliteDDL } from "../drizzle/ddl";
+import { isEdgeMatchIdentityStorageUnavailableError } from "../../utils/sql-errors";
+import {
+  generateSqliteMigrationSQL,
+  planSqliteEdgeMatchIdentityAdoption,
+  quoteDdlIdentifier,
+} from "../drizzle/ddl";
 import { type AnySqliteDatabase } from "../drizzle/execution";
 export type { AnySqliteDatabase } from "../drizzle/execution";
 import {
@@ -46,6 +52,33 @@ export type {
   ContributionRepairEntry,
   ContributionRepairResult,
 } from "../types";
+
+async function installLibsqlBaseSchema(
+  client: Client,
+  tables: SqliteTables,
+): Promise<void> {
+  const installationSql = generateSqliteMigrationSQL(tables);
+  try {
+    await client.executeMultiple(installationSql);
+  } catch (error) {
+    if (!isEdgeMatchIdentityStorageUnavailableError(error)) throw error;
+    const edgeTableName = getTableName(tables.edges);
+    const result = await client.execute(
+      `PRAGMA table_info(${quoteDdlIdentifier(edgeTableName)})`,
+    );
+    const columns = new Set(
+      result.rows.flatMap((row) =>
+        typeof row["name"] === "string" ? [row["name"]] : [],
+      ),
+    );
+    const adoptionSql = planSqliteEdgeMatchIdentityAdoption(
+      edgeTableName,
+      columns,
+    );
+    if (adoptionSql.length === 0) throw error;
+    await client.executeMultiple([...adoptionSql, installationSql].join("\n"));
+  }
+}
 
 // ============================================================
 // Types
@@ -123,8 +156,7 @@ export async function createLibsqlBackend(
   const tables = options.tables ?? defaultTables;
   const db = drizzle(client);
 
-  const ddlStatements = generateSqliteDDL(tables);
-  await client.executeMultiple(ddlStatements.join(";\n"));
+  await installLibsqlBaseSchema(client, tables);
 
   const backend = createSqliteBackend(db, {
     executionProfile: {

--- a/packages/typegraph/src/backend/sqlite/libsql.ts
+++ b/packages/typegraph/src/backend/sqlite/libsql.ts
@@ -67,7 +67,9 @@ async function installLibsqlBaseSchema(
     if (!requiresLifecycleAdoption) throw error;
     // The fast script is fresh-installation DDL, not an upgrade planner. A
     // legacy or stale database must re-enter the numbered lifecycle so future
-    // releases cannot be stamped without every missing adoption step.
+    // releases cannot be stamped without every missing adoption step. The
+    // marker-error arm is intentionally dormant at v1: it becomes reachable
+    // when a later release can observe a missing or stale older marker.
     await requireDefined(backend.bootstrapTables)();
   }
 }

--- a/packages/typegraph/src/backend/sqlite/libsql.ts
+++ b/packages/typegraph/src/backend/sqlite/libsql.ts
@@ -26,16 +26,13 @@
  * ```
  */
 import type { Client } from "@libsql/client";
-import { getTableName } from "drizzle-orm";
 import { drizzle, type LibSQLDatabase } from "drizzle-orm/libsql";
 
+import { BaseSchemaMigrationError } from "../../errors";
 import { libsqlVectorStrategy } from "../../query/dialect/vector/libsql-strategy";
-import { isEdgeMatchIdentityStorageUnavailableError } from "../../utils/sql-errors";
-import {
-  generateSqliteMigrationSQL,
-  planSqliteEdgeMatchIdentityAdoption,
-  quoteDdlIdentifier,
-} from "../drizzle/ddl";
+import { requireDefined } from "../../utils/presence";
+import { isSqliteMissingEdgeMatchIdentityColumnError } from "../../utils/sql-errors";
+import { generateSqliteMigrationSQL } from "../drizzle/ddl";
 import { type AnySqliteDatabase } from "../drizzle/execution";
 export type { AnySqliteDatabase } from "../drizzle/execution";
 import {
@@ -56,27 +53,22 @@ export type {
 async function installLibsqlBaseSchema(
   client: Client,
   tables: SqliteTables,
+  backend: AdapterBackend<AnySqliteDatabase>,
 ): Promise<void> {
   const installationSql = generateSqliteMigrationSQL(tables);
   try {
     await client.executeMultiple(installationSql);
+    await requireDefined(backend.assertBaseSchemaCurrent)();
   } catch (error) {
-    if (!isEdgeMatchIdentityStorageUnavailableError(error)) throw error;
-    const edgeTableName = getTableName(tables.edges);
-    const result = await client.execute(
-      `PRAGMA table_info(${quoteDdlIdentifier(edgeTableName)})`,
-    );
-    const columns = new Set(
-      result.rows.flatMap((row) =>
-        typeof row["name"] === "string" ? [row["name"]] : [],
-      ),
-    );
-    const adoptionSql = planSqliteEdgeMatchIdentityAdoption(
-      edgeTableName,
-      columns,
-    );
-    if (adoptionSql.length === 0) throw error;
-    await client.executeMultiple([...adoptionSql, installationSql].join("\n"));
+    const requiresLifecycleAdoption =
+      isSqliteMissingEdgeMatchIdentityColumnError(error) ||
+      (error instanceof BaseSchemaMigrationError &&
+        error.details.reason !== "newer");
+    if (!requiresLifecycleAdoption) throw error;
+    // The fast script is fresh-installation DDL, not an upgrade planner. A
+    // legacy or stale database must re-enter the numbered lifecycle so future
+    // releases cannot be stamped without every missing adoption step.
+    await requireDefined(backend.bootstrapTables)();
   }
 }
 
@@ -155,9 +147,6 @@ export async function createLibsqlBackend(
 ): Promise<LibsqlBackendResult> {
   const tables = options.tables ?? defaultTables;
   const db = drizzle(client);
-
-  await installLibsqlBaseSchema(client, tables);
-
   const backend = createSqliteBackend(db, {
     executionProfile: {
       isSync: false,
@@ -168,6 +157,8 @@ export async function createLibsqlBackend(
     // so the strategy is wired unconditionally.
     vector: libsqlVectorStrategy,
   });
+
+  await installLibsqlBaseSchema(client, tables, backend);
 
   return { backend, db };
 }

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -24,6 +24,7 @@
 import { createRequire } from "node:module";
 
 import Database from "better-sqlite3";
+import { getTableName } from "drizzle-orm";
 import {
   type BetterSQLite3Database,
   drizzle,
@@ -31,9 +32,14 @@ import {
 
 import { ConfigurationError } from "../../errors";
 import { sqliteVecStrategy } from "../../query/dialect/vector/sqlite-vec-strategy";
+import { isEdgeMatchIdentityStorageUnavailableError } from "../../utils/sql-errors";
 import { markBundledRootAutocommitEligible } from "../capabilities/autocommit-single-statement";
 import { wrapWithManagedClose } from "../derive-backend";
-import { generateSqliteDDL } from "../drizzle/ddl";
+import {
+  generateSqliteMigrationSQL,
+  planSqliteEdgeMatchIdentityAdoption,
+  quoteDdlIdentifier,
+} from "../drizzle/ddl";
 import { type AnySqliteDatabase } from "../drizzle/execution";
 export type { AnySqliteDatabase } from "../drizzle/execution";
 import {
@@ -64,6 +70,31 @@ export type {
 } from "../types";
 
 const nodeRequire = createRequire(import.meta.url);
+
+function installLocalSqliteBaseSchema(
+  sqlite: Database.Database,
+  tables: SqliteTables,
+): void {
+  const installationSql = generateSqliteMigrationSQL(tables);
+  try {
+    sqlite.exec(installationSql);
+  } catch (error) {
+    if (!isEdgeMatchIdentityStorageUnavailableError(error)) throw error;
+    const edgeTableName = getTableName(tables.edges);
+    const rows = sqlite
+      .prepare(`PRAGMA table_info(${quoteDdlIdentifier(edgeTableName)})`)
+      .all() as readonly Readonly<{ name?: unknown }>[];
+    const columns = new Set(
+      rows.flatMap((row) => (typeof row.name === "string" ? [row.name] : [])),
+    );
+    const adoptionSql = planSqliteEdgeMatchIdentityAdoption(
+      edgeTableName,
+      columns,
+    );
+    if (adoptionSql.length === 0) throw error;
+    sqlite.exec([...adoptionSql, installationSql].join("\n"));
+  }
+}
 
 // ============================================================
 // Native Addon Helpers
@@ -339,11 +370,10 @@ export function createLocalSqliteBackend(
 
     const db = drizzle(sqlite);
 
-    // Generate and execute DDL from schema
-    const ddlStatements = generateSqliteDDL(tables);
-    for (const statement of ddlStatements) {
-      sqlite.exec(statement);
-    }
+    // The managed factory owns a complete fresh installation, including the
+    // deployment-wide base-schema marker consumed by verified/runtime-only
+    // entrypoints. Raw generateSqliteDDL intentionally omits that marker.
+    installLocalSqliteBaseSchema(sqlite, tables);
 
     const backend = createSqliteBackend(db, {
       executionProfile: {

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -30,11 +30,15 @@ import {
   drizzle,
 } from "drizzle-orm/better-sqlite3";
 
-import { ConfigurationError } from "../../errors";
+import { CompilerInvariantError, ConfigurationError } from "../../errors";
 import { sqliteVecStrategy } from "../../query/dialect/vector/sqlite-vec-strategy";
-import { isEdgeMatchIdentityStorageUnavailableError } from "../../utils/sql-errors";
+import {
+  isSqliteDuplicateEdgeMatchIdentityColumnError,
+  isSqliteMissingEdgeMatchIdentityColumnError,
+} from "../../utils/sql-errors";
 import { markBundledRootAutocommitEligible } from "../capabilities/autocommit-single-statement";
 import { wrapWithManagedClose } from "../derive-backend";
+import { CURRENT_BASE_SCHEMA_VERSION } from "../drizzle/base-schema";
 import {
   generateSqliteMigrationSQL,
   planSqliteEdgeMatchIdentityAdoption,
@@ -75,24 +79,41 @@ function installLocalSqliteBaseSchema(
   sqlite: Database.Database,
   tables: SqliteTables,
 ): void {
+  if (CURRENT_BASE_SCHEMA_VERSION !== 1) {
+    throw new CompilerInvariantError(
+      "The synchronous managed SQLite installation path only implements base-schema v1 adoption.",
+      { currentVersion: CURRENT_BASE_SCHEMA_VERSION },
+    );
+  }
   const installationSql = generateSqliteMigrationSQL(tables);
   try {
     sqlite.exec(installationSql);
   } catch (error) {
-    if (!isEdgeMatchIdentityStorageUnavailableError(error)) throw error;
+    if (!isSqliteMissingEdgeMatchIdentityColumnError(error)) throw error;
     const edgeTableName = getTableName(tables.edges);
-    const rows = sqlite
-      .prepare(`PRAGMA table_info(${quoteDdlIdentifier(edgeTableName)})`)
-      .all() as readonly Readonly<{ name?: unknown }>[];
-    const columns = new Set(
-      rows.flatMap((row) => (typeof row.name === "string" ? [row.name] : [])),
-    );
-    const adoptionSql = planSqliteEdgeMatchIdentityAdoption(
-      edgeTableName,
-      columns,
-    );
-    if (adoptionSql.length === 0) throw error;
-    sqlite.exec([...adoptionSql, installationSql].join("\n"));
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const rows = sqlite
+        .prepare(`PRAGMA table_info(${quoteDdlIdentifier(edgeTableName)})`)
+        .all() as readonly Readonly<{ name?: unknown }>[];
+      const columns = new Set(
+        rows.flatMap((row) => (typeof row.name === "string" ? [row.name] : [])),
+      );
+      const adoptionSql = planSqliteEdgeMatchIdentityAdoption(
+        edgeTableName,
+        columns,
+      );
+      try {
+        sqlite.exec([...adoptionSql, installationSql].join("\n"));
+        return;
+      } catch (repairError) {
+        if (
+          attempt === 2 ||
+          !isSqliteDuplicateEdgeMatchIdentityColumnError(repairError)
+        ) {
+          throw repairError;
+        }
+      }
+    }
   }
 }
 

--- a/packages/typegraph/src/backend/sqlite/local.ts
+++ b/packages/typegraph/src/backend/sqlite/local.ts
@@ -114,6 +114,9 @@ function installLocalSqliteBaseSchema(
         }
       }
     }
+    throw new CompilerInvariantError(
+      "Local SQLite match-identity adoption exhausted its retry loop without returning or throwing.",
+    );
   }
 }
 

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -556,19 +556,57 @@ export function isDuplicateUniqueIndexError(
   return false;
 }
 
+/** Whether SQLite DDL named one of the two absent match-identity columns. */
+export function isSqliteMissingEdgeMatchIdentityColumnError(
+  error: unknown,
+): boolean {
+  for (const link of errorChain(error)) {
+    if (!canReadProperty(link)) continue;
+    const code: unknown = Reflect.get(link, "code");
+    const message = sqliteErrorMessage(link);
+    if (
+      code === "SQLITE_ERROR" &&
+      typeof message === "string" &&
+      /^(?:no such column: (?:[^.]+\.)?|table .+ has no column named |no column named )"?match_identity_(?:name|key)"?(?: - should this be a string literal in single-quotes\?)?$/.test(
+        message,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Whether a concurrent SQLite adopter already added the column we planned. */
+export function isSqliteDuplicateEdgeMatchIdentityColumnError(
+  error: unknown,
+): boolean {
+  for (const link of errorChain(error)) {
+    if (!canReadProperty(link)) continue;
+    if (Reflect.get(link, "code") !== "SQLITE_ERROR") continue;
+    const message = sqliteErrorMessage(link);
+    if (
+      message === "duplicate column name: match_identity_name" ||
+      message === "duplicate column name: match_identity_key"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Whether a durable convergence statement proved that the adapter's static
  * capability declaration has not been provisioned in this database yet.
  *
- * This predicate is intentionally consumed only by the durable convergence
- * command, whose conflict target and two identity columns are known. SQLSTATE
- * 42P10 structurally identifies a missing PostgreSQL conflict arbiter; the
- * remaining messages are SQLite's only structured-enough reports for the same
- * missing index/column states.
+ * This runtime-DML classifier deliberately includes missing conflict arbiters
+ * as well as missing columns. Provisioning code must instead use the narrower
+ * SQLite column predicate above before it performs any DDL.
  */
 export function isEdgeMatchIdentityStorageUnavailableError(
   error: unknown,
 ): boolean {
+  if (isSqliteMissingEdgeMatchIdentityColumnError(error)) return true;
   for (const link of errorChain(error)) {
     if (!canReadProperty(link)) continue;
     const code: unknown = Reflect.get(link, "code");
@@ -586,19 +624,10 @@ export function isEdgeMatchIdentityStorageUnavailableError(
         return true;
       }
     }
-    if (typeof message !== "string") continue;
     if (
       code === "SQLITE_ERROR" &&
       message ===
         "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"
-    ) {
-      return true;
-    }
-    if (
-      code === "SQLITE_ERROR" &&
-      /^(?:no such column: (?:[^.]+\.)?|table .+ has no column named |no column named )"?match_identity_(?:name|key)"?(?: - should this be a string literal in single-quotes\?)?$/.test(
-        message,
-      )
     ) {
       return true;
     }

--- a/packages/typegraph/src/utils/sql-errors.ts
+++ b/packages/typegraph/src/utils/sql-errors.ts
@@ -596,7 +596,7 @@ export function isEdgeMatchIdentityStorageUnavailableError(
     }
     if (
       code === "SQLITE_ERROR" &&
-      /^(?:no such column: (?:[^.]+\.)?|table .+ has no column named |no column named )match_identity_(?:name|key)$/.test(
+      /^(?:no such column: (?:[^.]+\.)?|table .+ has no column named |no column named )"?match_identity_(?:name|key)"?(?: - should this be a string literal in single-quotes\?)?$/.test(
         message,
       )
     ) {

--- a/packages/typegraph/tests/base-schema-adoption.test.ts
+++ b/packages/typegraph/tests/base-schema-adoption.test.ts
@@ -38,6 +38,7 @@ import { createSqliteBackend, createSqliteTables } from "../src/backend/sqlite";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import { requireDefined } from "../src/utils/presence";
+import { isSqliteMissingEdgeMatchIdentityColumnError } from "../src/utils/sql-errors";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -138,6 +139,9 @@ async function assertTemplatesWork<G extends typeof graph>(
 }
 
 async function assertMatchIdentityWrite(backend: GraphBackend): Promise<void> {
+  // createStoreWithSchema is privileged, but a current marker makes adoption
+  // return before DDL. A false-stamped installation therefore reaches this
+  // real edge write unchanged and still fails on its missing physical storage.
   const [store] = await createStoreWithSchema(graph, backend);
   const source = await store.nodes.Person.create({ name: "source" });
   const target = await store.nodes.Person.create({ name: "target" });
@@ -357,11 +361,19 @@ describe("deployment-wide base-schema adoption", () => {
     },
   );
 
-  it("refuses to false-stamp a legacy database through fresh-installation SQL", () => {
+  it("refuses to false-stamp a legacy SQLite database through fresh-installation SQL", () => {
     const client = new Database(":memory:");
     try {
       client.exec(LEGACY_EDGE_TABLE_SQL);
-      expect(() => client.exec(generateSqliteMigrationSQL())).toThrow();
+      let installationError: unknown;
+      try {
+        client.exec(generateSqliteMigrationSQL());
+      } catch (error) {
+        installationError = error;
+      }
+      expect(
+        isSqliteMissingEdgeMatchIdentityColumnError(installationError),
+      ).toBe(true);
       const markerTable = client
         .prepare(
           "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'typegraph_base_schema_versions'",
@@ -378,6 +390,87 @@ describe("deployment-wide base-schema adoption", () => {
       expect(marker).toBeUndefined();
     } finally {
       client.close();
+    }
+  });
+
+  it("refuses to false-stamp a legacy PostgreSQL database through fresh-installation SQL", async () => {
+    const client = await PGlite.create({
+      extensions: { vector: pgvectorExtension },
+    });
+    try {
+      await client.exec(LEGACY_EDGE_TABLE_SQL);
+      await expect(
+        client.exec(generatePostgresMigrationSQL()),
+      ).rejects.toMatchObject({ code: "42703" });
+      const markerRelation = await client.query<{ exists: boolean }>(
+        "SELECT to_regclass('typegraph_base_schema_versions') IS NOT NULL AS exists",
+      );
+      const markerResult =
+        markerRelation.rows[0]?.exists === true ?
+          await client.query<{ version: number }>(
+            'SELECT version FROM "typegraph_base_schema_versions" WHERE installation = 1',
+          )
+        : { rows: [] };
+      const markerRows = markerResult.rows;
+      expect(markerRows).toEqual([]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("re-plans both local SQLite column races before publishing the marker", async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "typegraph-base-race-"));
+    const databasePath = path.join(directory, "legacy.sqlite");
+    const legacy = new Database(databasePath);
+    legacy.exec(LEGACY_EDGE_TABLE_SQL);
+    legacy.close();
+    const competitor = new Database(databasePath);
+    // The unbound method is intentional: the spy must invoke the native method
+    // against both the factory-owned connection and the competitor connection.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalExec = Database.prototype.exec;
+    const racedColumns = new Set<string>();
+    const execSpy = vi
+      .spyOn(Database.prototype, "exec")
+      .mockImplementation(function (
+        this: Database.Database,
+        source,
+      ): Database.Database {
+        for (const column of ["match_identity_name", "match_identity_key"]) {
+          if (
+            racedColumns.has(column) ||
+            !source.includes(`ADD COLUMN "${column}"`)
+          ) {
+            continue;
+          }
+          const statement = source
+            .split(";")
+            .find((part) => part.includes(`ADD COLUMN "${column}"`));
+          if (statement !== undefined) {
+            originalExec.call(competitor, statement);
+            racedColumns.add(column);
+          }
+          break;
+        }
+        return originalExec.call(this, source);
+      });
+    try {
+      const { backend } = createLocalSqliteBackend({ path: databasePath });
+      await backend.close();
+      expect([...racedColumns]).toEqual([
+        "match_identity_name",
+        "match_identity_key",
+      ]);
+      const marker = competitor
+        .prepare(
+          'SELECT version FROM "typegraph_base_schema_versions" WHERE installation = 1',
+        )
+        .get();
+      expect(marker).toEqual({ version: 1 });
+    } finally {
+      execSpy.mockRestore();
+      competitor.close();
+      rmSync(directory, { force: true, recursive: true });
     }
   });
 

--- a/packages/typegraph/tests/base-schema-adoption.test.ts
+++ b/packages/typegraph/tests/base-schema-adoption.test.ts
@@ -50,7 +50,14 @@ const knows = defineEdge("knows", {
 const graph = defineGraph({
   id: "base_schema_adoption",
   nodes: { Person: { type: Person } },
-  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+  edges: {
+    knows: {
+      type: knows,
+      from: [Person],
+      to: [Person],
+      matchIdentity: { name: "knows-label", fields: ["label"] },
+    },
+  },
 });
 
 type SqliteClient = Database.Database;
@@ -128,6 +135,13 @@ async function assertTemplatesWork<G extends typeof graph>(
     graphId: "base_schema_adoption_target",
   });
   expect(instantiated.status).toBe("ready");
+}
+
+async function assertMatchIdentityWrite(backend: GraphBackend): Promise<void> {
+  const [store] = await createStoreWithSchema(graph, backend);
+  const source = await store.nodes.Person.create({ name: "source" });
+  const target = await store.nodes.Person.create({ name: "target" });
+  await store.edges.knows.create(source, target, { label: "provisioned" });
 }
 
 function reconciledSurface(
@@ -283,10 +297,7 @@ async function provisionLegacyPostgresBootstrap(): Promise<ProvisionedInstallati
   }
 }
 
-/**
- * Closed registry of every factory/script that claims to finish base-schema
- * installation without a later privileged adoption call.
- */
+/** Covered complete-installation entry points; bring-your-own factories omit DDL. */
 const PROVISIONING_PATHS = [
   {
     id: "generated-postgres-installation",
@@ -326,6 +337,7 @@ describe("deployment-wide base-schema adoption", () => {
       const installation = await provision();
       try {
         await requireDefined(installation.backend.assertBaseSchemaCurrent)();
+        await assertMatchIdentityWrite(installation.backend);
       } finally {
         await installation.close();
       }
@@ -338,11 +350,36 @@ describe("deployment-wide base-schema adoption", () => {
       const installation = await provision();
       try {
         await requireDefined(installation.backend.assertBaseSchemaCurrent)();
+        await assertMatchIdentityWrite(installation.backend);
       } finally {
         await installation.close();
       }
     },
   );
+
+  it("refuses to false-stamp a legacy database through fresh-installation SQL", () => {
+    const client = new Database(":memory:");
+    try {
+      client.exec(LEGACY_EDGE_TABLE_SQL);
+      expect(() => client.exec(generateSqliteMigrationSQL())).toThrow();
+      const markerTable = client
+        .prepare(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'typegraph_base_schema_versions'",
+        )
+        .get();
+      const marker =
+        markerTable === undefined ? undefined : (
+          client
+            .prepare(
+              'SELECT version FROM "typegraph_base_schema_versions" WHERE installation = 1',
+            )
+            .get()
+        );
+      expect(marker).toBeUndefined();
+    } finally {
+      client.close();
+    }
+  });
 
   it("adopts a legacy SQLite installation and registers templates", async () => {
     const tableNames = {

--- a/packages/typegraph/tests/base-schema-adoption.test.ts
+++ b/packages/typegraph/tests/base-schema-adoption.test.ts
@@ -1,5 +1,10 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { PGlite } from "@electric-sql/pglite";
 import { vector as pgvectorExtension } from "@electric-sql/pglite-pgvector";
+import { createClient } from "@libsql/client";
 import Database from "better-sqlite3";
 import { drizzle as drizzleBetterSqlite3 } from "drizzle-orm/better-sqlite3";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
@@ -30,6 +35,7 @@ import {
 } from "../src/backend/postgres";
 import { createLocalPgliteBackend } from "../src/backend/postgres/pglite";
 import { createSqliteBackend, createSqliteTables } from "../src/backend/sqlite";
+import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
 import { requireDefined } from "../src/utils/presence";
 
@@ -48,6 +54,28 @@ const graph = defineGraph({
 });
 
 type SqliteClient = Database.Database;
+
+type ProvisionedInstallation = Readonly<{
+  backend: GraphBackend;
+  close(): Promise<void>;
+}>;
+
+const LEGACY_EDGE_TABLE_SQL = `CREATE TABLE "typegraph_edges" (
+  "graph_id" TEXT NOT NULL,
+  "id" TEXT NOT NULL,
+  "kind" TEXT NOT NULL,
+  "from_kind" TEXT NOT NULL,
+  "from_id" TEXT NOT NULL,
+  "to_kind" TEXT NOT NULL,
+  "to_id" TEXT NOT NULL,
+  "props" TEXT NOT NULL,
+  "valid_from" TEXT,
+  "valid_to" TEXT,
+  "created_at" TEXT NOT NULL,
+  "updated_at" TEXT NOT NULL,
+  "deleted_at" TEXT,
+  PRIMARY KEY ("graph_id", "id")
+);`;
 
 function sqliteClient(db: unknown): SqliteClient {
   return (db as { $client: SqliteClient }).$client;
@@ -110,62 +138,211 @@ function reconciledSurface(
   }>;
 }
 
+function provisionGeneratedSqlite(): Promise<ProvisionedInstallation> {
+  const tables = createSqliteTables({
+    baseSchemaVersions: "generated_base_schema_versions",
+  });
+  const client = new Database(":memory:");
+  client.exec(generateSqliteMigrationSQL(tables));
+  const backend = createSqliteBackend(drizzleBetterSqlite3(client), {
+    executionProfile: { isSync: true },
+    tables,
+  });
+  return Promise.resolve({
+    backend,
+    async close(): Promise<void> {
+      await backend.close();
+      client.close();
+    },
+  });
+}
+
+async function provisionGeneratedPostgres(): Promise<ProvisionedInstallation> {
+  const tables = createPostgresTables({
+    baseSchemaVersions: "generated_base_schema_versions",
+  });
+  const client = await PGlite.create({
+    extensions: { vector: pgvectorExtension },
+  });
+  await client.exec(generatePostgresMigrationSQL(tables));
+  const backend = createPostgresBackend(drizzlePglite(client), {
+    tables,
+    vector: false,
+  });
+  return {
+    backend,
+    async close(): Promise<void> {
+      await backend.close();
+      await client.close();
+    },
+  };
+}
+
+async function provisionVectorlessPglite(): Promise<ProvisionedInstallation> {
+  const { backend } = await createLocalPgliteBackend({ vector: false });
+  return { backend, close: async () => backend.close() };
+}
+
+function provisionLocalSqlite(): Promise<ProvisionedInstallation> {
+  const { backend } = createLocalSqliteBackend();
+  return Promise.resolve({ backend, close: () => backend.close() });
+}
+
+async function provisionLibsql(): Promise<ProvisionedInstallation> {
+  const client = createClient({ url: ":memory:" });
+  const { backend } = await createLibsqlBackend(client);
+  return {
+    backend,
+    async close(): Promise<void> {
+      await backend.close();
+      client.close();
+    },
+  };
+}
+
+function provisionLegacyLocalSqlite(): Promise<ProvisionedInstallation> {
+  const directory = mkdtempSync(path.join(tmpdir(), "typegraph-base-schema-"));
+  const databasePath = path.join(directory, "legacy.sqlite");
+  const legacy = new Database(databasePath);
+  legacy.exec(LEGACY_EDGE_TABLE_SQL);
+  legacy.close();
+  try {
+    const { backend } = createLocalSqliteBackend({ path: databasePath });
+    return Promise.resolve({
+      backend,
+      async close(): Promise<void> {
+        await backend.close();
+        rmSync(directory, { force: true, recursive: true });
+      },
+    });
+  } catch (error) {
+    rmSync(directory, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+async function provisionLegacyLibsql(): Promise<ProvisionedInstallation> {
+  const client = createClient({ url: ":memory:" });
+  await client.executeMultiple(LEGACY_EDGE_TABLE_SQL);
+  try {
+    const { backend } = await createLibsqlBackend(client);
+    return {
+      backend,
+      async close(): Promise<void> {
+        await backend.close();
+        client.close();
+      },
+    };
+  } catch (error) {
+    client.close();
+    throw error;
+  }
+}
+
+async function provisionLegacySqliteBootstrap(): Promise<ProvisionedInstallation> {
+  const client = new Database(":memory:");
+  client.exec(LEGACY_EDGE_TABLE_SQL);
+  const backend = createSqliteBackend(drizzleBetterSqlite3(client), {
+    executionProfile: { isSync: true },
+  });
+  try {
+    await requireDefined(backend.bootstrapTables)();
+    return {
+      backend,
+      async close(): Promise<void> {
+        await backend.close();
+        client.close();
+      },
+    };
+  } catch (error) {
+    await backend.close();
+    client.close();
+    throw error;
+  }
+}
+
+async function provisionLegacyPostgresBootstrap(): Promise<ProvisionedInstallation> {
+  const client = await PGlite.create();
+  await client.exec(LEGACY_EDGE_TABLE_SQL);
+  const backend = createPostgresBackend(drizzlePglite(client), {
+    vector: false,
+  });
+  try {
+    await requireDefined(backend.bootstrapTables)();
+    return {
+      backend,
+      async close(): Promise<void> {
+        await backend.close();
+        await client.close();
+      },
+    };
+  } catch (error) {
+    await backend.close();
+    await client.close();
+    throw error;
+  }
+}
+
+/**
+ * Closed registry of every factory/script that claims to finish base-schema
+ * installation without a later privileged adoption call.
+ */
+const PROVISIONING_PATHS = [
+  {
+    id: "generated-postgres-installation",
+    provision: provisionGeneratedPostgres,
+  },
+  { id: "generated-sqlite-installation", provision: provisionGeneratedSqlite },
+  { id: "libsql-managed-installation", provision: provisionLibsql },
+  {
+    id: "local-pglite-vectorless-installation",
+    provision: provisionVectorlessPglite,
+  },
+  { id: "local-sqlite-managed-installation", provision: provisionLocalSqlite },
+] as const;
+
+const LEGACY_FACTORY_ADOPTION_PATHS = [
+  { id: "libsql-managed-upgrade", provision: provisionLegacyLibsql },
+  {
+    id: "local-sqlite-managed-upgrade",
+    provision: provisionLegacyLocalSqlite,
+  },
+  {
+    id: "postgres-backend-bootstrap-upgrade",
+    provision: provisionLegacyPostgresBootstrap,
+  },
+  {
+    id: "sqlite-backend-bootstrap-upgrade",
+    provision: provisionLegacySqliteBootstrap,
+  },
+] as const;
+
 describe("deployment-wide base-schema adoption", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("publishes the current marker in generated SQLite installation SQL", async () => {
-    const tableNames = {
-      baseSchemaVersions: "generated_base_schema_versions",
-    } as const;
-    const tables = createSqliteTables(tableNames);
-    const client = new Database(":memory:");
-    client.exec(generateSqliteMigrationSQL(tables));
-    const backend = createSqliteBackend(drizzleBetterSqlite3(client), {
-      executionProfile: { isSync: true },
-      tables,
-    });
-    try {
-      await requireDefined(backend.assertBaseSchemaCurrent)();
-      expect(markerVersion(client, tableNames.baseSchemaVersions)).toBe(1);
-    } finally {
-      await backend.close();
-      client.close();
-    }
-  });
+  it.each(PROVISIONING_PATHS)(
+    "$id satisfies the base-schema gate",
+    async ({ provision }) => {
+      const installation = await provision();
+      try {
+        await requireDefined(installation.backend.assertBaseSchemaCurrent)();
+      } finally {
+        await installation.close();
+      }
+    },
+  );
 
-  it("publishes the current marker in generated PostgreSQL installation SQL", async () => {
-    const tableNames = {
-      baseSchemaVersions: "generated_base_schema_versions",
-    } as const;
-    const tables = createPostgresTables(tableNames);
-    const client = await PGlite.create({
-      extensions: { vector: pgvectorExtension },
-    });
-    await client.exec(generatePostgresMigrationSQL(tables));
-    const backend = createPostgresBackend(drizzlePglite(client), {
-      tables,
-      vector: false,
-    });
-    try {
-      await requireDefined(backend.assertBaseSchemaCurrent)();
-      const marker = await client.query<{ version: number }>(
-        `SELECT version FROM "${tableNames.baseSchemaVersions}" WHERE installation = 1`,
-      );
-      expect(marker.rows).toEqual([{ version: 1 }]);
-    } finally {
-      await backend.close();
-      await client.close();
-    }
-  });
-
-  it("publishes the current marker for vector-disabled local PGlite", async () => {
-    const { backend } = await createLocalPgliteBackend({ vector: false });
-    try {
-      await requireDefined(backend.assertBaseSchemaCurrent)();
-    } finally {
-      await backend.close();
-    }
-  });
+  it.each(LEGACY_FACTORY_ADOPTION_PATHS)(
+    "$id repairs v0.51 edge storage before completing installation",
+    async ({ provision }) => {
+      const installation = await provision();
+      try {
+        await requireDefined(installation.backend.assertBaseSchemaCurrent)();
+      } finally {
+        await installation.close();
+      }
+    },
+  );
 
   it("adopts a legacy SQLite installation and registers templates", async () => {
     const tableNames = {
@@ -417,7 +594,7 @@ describe("deployment-wide base-schema adoption", () => {
     }
   });
 
-  it("keeps a concurrently published newer marker during bootstrap", async () => {
+  it("keeps and refuses a concurrently published newer marker during bootstrap", async () => {
     const { backend, db } = createLocalSqliteBackend();
     const client = sqliteClient(db);
     try {
@@ -438,7 +615,11 @@ describe("deployment-wide base-schema adoption", () => {
         return prepare(source);
       });
 
-      await expect(backend.bootstrapTables?.()).resolves.toBeUndefined();
+      await expect(backend.bootstrapTables?.()).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof BaseSchemaMigrationError &&
+          error.details.reason === "newer",
+      );
       expect(publishedNewerMarker).toBe(true);
       expect(markerVersion(client, "typegraph_base_schema_versions")).toBe(2);
     } finally {

--- a/packages/typegraph/tests/base-schema-lifecycle.test.ts
+++ b/packages/typegraph/tests/base-schema-lifecycle.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BaseSchemaMigrationError, CompilerInvariantError } from "../src";
+import { createBaseSchemaLifecycle } from "../src/backend/drizzle/base-schema";
+
+function migrationReason(error: unknown): string | undefined {
+  return error instanceof BaseSchemaMigrationError ?
+      error.details.reason
+    : undefined;
+}
+
+function resolvedVoid(): Promise<void> {
+  return Promise.resolve();
+}
+
+describe("base schema lifecycle state machine", () => {
+  it.each([0, 1.5])("refuses invalid current version %s", (currentVersion) => {
+    expect(() =>
+      createBaseSchemaLifecycle({
+        currentVersion,
+        readVersion: () => Promise.resolve(0),
+        ensureVersionTable: resolvedVoid,
+        writeVersion: (version) => Promise.resolve(version),
+        steps: [],
+      }),
+    ).toThrow(CompilerInvariantError);
+  });
+
+  it("requires one contiguous adoption step per version", () => {
+    expect(() =>
+      createBaseSchemaLifecycle({
+        currentVersion: 3,
+        readVersion: () => Promise.resolve(0),
+        ensureVersionTable: resolvedVoid,
+        writeVersion: (version) => Promise.resolve(version),
+        steps: [
+          { version: 1, adopt: resolvedVoid },
+          { version: 3, adopt: resolvedVoid },
+        ],
+      }),
+    ).toThrow(CompilerInvariantError);
+  });
+
+  it("requires the adoption registry to reach the current version", () => {
+    expect(() =>
+      createBaseSchemaLifecycle({
+        currentVersion: 2,
+        readVersion: () => Promise.resolve(0),
+        ensureVersionTable: resolvedVoid,
+        writeVersion: (version) => Promise.resolve(version),
+        steps: [{ version: 1, adopt: resolvedVoid }],
+      }),
+    ).toThrow(CompilerInvariantError);
+  });
+
+  it.each([
+    [undefined, "missing"],
+    [1, "stale"],
+    [4, "newer"],
+  ] as const)("assertCurrent classifies %s as %s", async (version, reason) => {
+    const lifecycle = createBaseSchemaLifecycle({
+      currentVersion: 3,
+      readVersion: () => Promise.resolve(version),
+      ensureVersionTable: resolvedVoid,
+      writeVersion: (writtenVersion) => Promise.resolve(writtenVersion),
+      steps: [1, 2, 3].map((stepVersion) => ({
+        version: stepVersion,
+        adopt: resolvedVoid,
+      })),
+    });
+
+    await expect(lifecycle.assertCurrent()).rejects.toSatisfy(
+      (error: unknown) => migrationReason(error) === reason,
+    );
+  });
+
+  it("runs every missing step in order and publishes each completed version", async () => {
+    let installedVersion = 0;
+    const adopted: number[] = [];
+    const published: number[] = [];
+    const lifecycle = createBaseSchemaLifecycle({
+      currentVersion: 3,
+      readVersion: () => Promise.resolve(installedVersion),
+      ensureVersionTable: resolvedVoid,
+      writeVersion: (version) => {
+        published.push(version);
+        installedVersion = version;
+        return Promise.resolve(installedVersion);
+      },
+      steps: [1, 2, 3].map((version) => ({
+        version,
+        adopt: () => {
+          adopted.push(version);
+          return Promise.resolve();
+        },
+      })),
+    });
+
+    await lifecycle.adopt();
+
+    expect(adopted).toEqual([1, 2, 3]);
+    expect(published).toEqual([1, 2, 3]);
+  });
+
+  it("accepts a concurrent adopter that reaches this release and skips superseded work", async () => {
+    const adopted: number[] = [];
+    const lifecycle = createBaseSchemaLifecycle({
+      currentVersion: 3,
+      readVersion: () => Promise.resolve(0),
+      ensureVersionTable: resolvedVoid,
+      writeVersion: () => Promise.resolve(3),
+      steps: [1, 2, 3].map((version) => ({
+        version,
+        adopt: () => {
+          adopted.push(version);
+          return Promise.resolve();
+        },
+      })),
+    });
+
+    await lifecycle.adopt();
+
+    expect(adopted).toEqual([1]);
+  });
+
+  it("refuses a concurrent adopter from a newer release without a diagnostic reread", async () => {
+    const readVersion = vi.fn(() => Promise.resolve(0));
+    const lifecycle = createBaseSchemaLifecycle({
+      currentVersion: 3,
+      readVersion,
+      ensureVersionTable: resolvedVoid,
+      writeVersion: () => Promise.resolve(4),
+      steps: [1, 2, 3].map((version) => ({
+        version,
+        adopt: resolvedVoid,
+      })),
+    });
+
+    await expect(lifecycle.adopt()).rejects.toSatisfy(
+      (error: unknown) => migrationReason(error) === "newer",
+    );
+    expect(readVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [undefined, "missing"],
+    [0, "stale"],
+  ] as const)(
+    "refuses a step publication that observes %s as %s",
+    async (observedVersion, reason) => {
+      const lifecycle = createBaseSchemaLifecycle({
+        currentVersion: 1,
+        readVersion: () => Promise.resolve(0),
+        ensureVersionTable: resolvedVoid,
+        writeVersion: () => Promise.resolve(observedVersion),
+        steps: [{ version: 1, adopt: resolvedVoid }],
+      });
+
+      await expect(lifecycle.adopt()).rejects.toSatisfy(
+        (error: unknown) => migrationReason(error) === reason,
+      );
+    },
+  );
+
+  it("uses bootstrap-specific adoption while preserving the final-version gate", async () => {
+    const beforeBootstrapAdopt = vi.fn(resolvedVoid);
+    const regularAdopt = vi.fn(resolvedVoid);
+    const bootstrapAdopt = vi.fn(resolvedVoid);
+    const lifecycle = createBaseSchemaLifecycle({
+      currentVersion: 2,
+      readVersion: () => Promise.resolve(0),
+      ensureVersionTable: resolvedVoid,
+      writeVersion: (version) => Promise.resolve(version),
+      steps: [
+        {
+          version: 1,
+          adopt: regularAdopt,
+          adoptBeforeBootstrap: beforeBootstrapAdopt,
+          adoptAfterBootstrap: bootstrapAdopt,
+        },
+        {
+          version: 2,
+          adopt: regularAdopt,
+          adoptBeforeBootstrap: beforeBootstrapAdopt,
+          adoptAfterBootstrap: bootstrapAdopt,
+        },
+      ],
+    });
+
+    await lifecycle.adoptBeforeBootstrap(0);
+    await lifecycle.adoptAfterBootstrap(0);
+
+    expect(regularAdopt).not.toHaveBeenCalled();
+    expect(beforeBootstrapAdopt).toHaveBeenCalledTimes(2);
+    expect(bootstrapAdopt).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/typegraph/tests/base-schema-lifecycle.test.ts
+++ b/packages/typegraph/tests/base-schema-lifecycle.test.ts
@@ -13,6 +13,14 @@ function resolvedVoid(): Promise<void> {
   return Promise.resolve();
 }
 
+function coveredStep(version: number) {
+  return {
+    version,
+    adopt: resolvedVoid,
+    bootstrap: { phase: "covered-by-generated-ddl" as const },
+  };
+}
+
 describe("base schema lifecycle state machine", () => {
   it.each([0, 1.5])("refuses invalid current version %s", (currentVersion) => {
     expect(() =>
@@ -33,10 +41,7 @@ describe("base schema lifecycle state machine", () => {
         readVersion: () => Promise.resolve(0),
         ensureVersionTable: resolvedVoid,
         writeVersion: (version) => Promise.resolve(version),
-        steps: [
-          { version: 1, adopt: resolvedVoid },
-          { version: 3, adopt: resolvedVoid },
-        ],
+        steps: [coveredStep(1), coveredStep(3)],
       }),
     ).toThrow(CompilerInvariantError);
   });
@@ -48,7 +53,7 @@ describe("base schema lifecycle state machine", () => {
         readVersion: () => Promise.resolve(0),
         ensureVersionTable: resolvedVoid,
         writeVersion: (version) => Promise.resolve(version),
-        steps: [{ version: 1, adopt: resolvedVoid }],
+        steps: [coveredStep(1)],
       }),
     ).toThrow(CompilerInvariantError);
   });
@@ -63,10 +68,7 @@ describe("base schema lifecycle state machine", () => {
       readVersion: () => Promise.resolve(version),
       ensureVersionTable: resolvedVoid,
       writeVersion: (writtenVersion) => Promise.resolve(writtenVersion),
-      steps: [1, 2, 3].map((stepVersion) => ({
-        version: stepVersion,
-        adopt: resolvedVoid,
-      })),
+      steps: [1, 2, 3].map((stepVersion) => coveredStep(stepVersion)),
     });
 
     await expect(lifecycle.assertCurrent()).rejects.toSatisfy(
@@ -93,6 +95,7 @@ describe("base schema lifecycle state machine", () => {
           adopted.push(version);
           return Promise.resolve();
         },
+        bootstrap: { phase: "covered-by-generated-ddl" },
       })),
     });
 
@@ -115,6 +118,7 @@ describe("base schema lifecycle state machine", () => {
           adopted.push(version);
           return Promise.resolve();
         },
+        bootstrap: { phase: "covered-by-generated-ddl" },
       })),
     });
 
@@ -130,10 +134,7 @@ describe("base schema lifecycle state machine", () => {
       readVersion,
       ensureVersionTable: resolvedVoid,
       writeVersion: () => Promise.resolve(4),
-      steps: [1, 2, 3].map((version) => ({
-        version,
-        adopt: resolvedVoid,
-      })),
+      steps: [1, 2, 3].map((version) => coveredStep(version)),
     });
 
     await expect(lifecycle.adopt()).rejects.toSatisfy(
@@ -153,7 +154,7 @@ describe("base schema lifecycle state machine", () => {
         readVersion: () => Promise.resolve(0),
         ensureVersionTable: resolvedVoid,
         writeVersion: () => Promise.resolve(observedVersion),
-        steps: [{ version: 1, adopt: resolvedVoid }],
+        steps: [coveredStep(1)],
       });
 
       await expect(lifecycle.adopt()).rejects.toSatisfy(
@@ -165,7 +166,7 @@ describe("base schema lifecycle state machine", () => {
   it("uses bootstrap-specific adoption while preserving the final-version gate", async () => {
     const beforeBootstrapAdopt = vi.fn(resolvedVoid);
     const regularAdopt = vi.fn(resolvedVoid);
-    const bootstrapAdopt = vi.fn(resolvedVoid);
+    const afterBootstrapAdopt = vi.fn(resolvedVoid);
     const lifecycle = createBaseSchemaLifecycle({
       currentVersion: 2,
       readVersion: () => Promise.resolve(0),
@@ -175,14 +176,12 @@ describe("base schema lifecycle state machine", () => {
         {
           version: 1,
           adopt: regularAdopt,
-          adoptBeforeBootstrap: beforeBootstrapAdopt,
-          adoptAfterBootstrap: bootstrapAdopt,
+          bootstrap: { phase: "before", adopt: beforeBootstrapAdopt },
         },
         {
           version: 2,
           adopt: regularAdopt,
-          adoptBeforeBootstrap: beforeBootstrapAdopt,
-          adoptAfterBootstrap: bootstrapAdopt,
+          bootstrap: { phase: "after", adopt: afterBootstrapAdopt },
         },
       ],
     });
@@ -191,7 +190,7 @@ describe("base schema lifecycle state machine", () => {
     await lifecycle.adoptAfterBootstrap(0);
 
     expect(regularAdopt).not.toHaveBeenCalled();
-    expect(beforeBootstrapAdopt).toHaveBeenCalledTimes(2);
-    expect(bootstrapAdopt).toHaveBeenCalledTimes(2);
+    expect(beforeBootstrapAdopt).toHaveBeenCalledTimes(1);
+    expect(afterBootstrapAdopt).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/typegraph/tests/base-schema-shape-ratchet.test.ts
+++ b/packages/typegraph/tests/base-schema-shape-ratchet.test.ts
@@ -5,7 +5,9 @@
  * excluding strategy-owned runtime contributions. A shape change must add a
  * new immutable BASE_SCHEMA_RELEASES entry. Advancing that ledger also raises
  * CURRENT_BASE_SCHEMA_VERSION, so both bundled backend constructors refuse to
- * start until they register the matching adoption step.
+ * start until they register the matching adoption step. Statement order is
+ * part of the digest because bootstrap executes the array sequentially and an
+ * index must never move ahead of the columns it references.
  */
 import { createHash } from "node:crypto";
 
@@ -30,7 +32,6 @@ function shapeDigest(
     .filter((contribution) => contribution.owner === BASE_CONTRIBUTION_OWNER)
     .flatMap((contribution) => [...contribution.createDdl])
     .map((statement) => statement.replaceAll(/\s+/g, " ").trim())
-    .toSorted()
     .join("\n");
   return createHash("sha256").update(canonicalDdl).digest("hex");
 }
@@ -46,14 +47,16 @@ describe("base schema shape ratchet", () => {
   });
 
   it("binds current SQLite base DDL to the latest adoption release", () => {
-    expect(shapeDigest(sqliteContributions())).toBe(
-      BASE_SCHEMA_RELEASES.at(-1)?.shapeDigests.sqlite,
-    );
+    expect(
+      shapeDigest(sqliteContributions()),
+      "Base SQLite DDL changed. Add a new immutable BASE_SCHEMA_RELEASES entry and its adoption step; never edit an existing release digest.",
+    ).toBe(BASE_SCHEMA_RELEASES.at(-1)?.orderedShapeDigests.sqlite);
   });
 
   it("binds current PostgreSQL base DDL to the latest adoption release", () => {
-    expect(shapeDigest(postgresContributions())).toBe(
-      BASE_SCHEMA_RELEASES.at(-1)?.shapeDigests.postgres,
-    );
+    expect(
+      shapeDigest(postgresContributions()),
+      "Base PostgreSQL DDL changed. Add a new immutable BASE_SCHEMA_RELEASES entry and its adoption step; never edit an existing release digest.",
+    ).toBe(BASE_SCHEMA_RELEASES.at(-1)?.orderedShapeDigests.postgres);
   });
 });

--- a/packages/typegraph/tests/base-schema-shape-ratchet.test.ts
+++ b/packages/typegraph/tests/base-schema-shape-ratchet.test.ts
@@ -1,0 +1,59 @@
+/**
+ * A physical TypeGraph relation cannot change invisibly.
+ *
+ * These digests cover every base-owned CREATE TABLE / CREATE INDEX statement,
+ * excluding strategy-owned runtime contributions. A shape change must add a
+ * new immutable BASE_SCHEMA_RELEASES entry. Advancing that ledger also raises
+ * CURRENT_BASE_SCHEMA_VERSION, so both bundled backend constructors refuse to
+ * start until they register the matching adoption step.
+ */
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BASE_SCHEMA_RELEASES,
+  CURRENT_BASE_SCHEMA_VERSION,
+} from "../src/backend/drizzle/base-schema";
+import {
+  postgresContributions,
+  sqliteContributions,
+} from "../src/backend/drizzle/ddl";
+import { BASE_CONTRIBUTION_OWNER } from "../src/backend/table-contribution";
+
+function shapeDigest(
+  contributions: ReturnType<
+    typeof postgresContributions | typeof sqliteContributions
+  >,
+): string {
+  const canonicalDdl = contributions
+    .filter((contribution) => contribution.owner === BASE_CONTRIBUTION_OWNER)
+    .flatMap((contribution) => [...contribution.createDdl])
+    .map((statement) => statement.replaceAll(/\s+/g, " ").trim())
+    .toSorted()
+    .join("\n");
+  return createHash("sha256").update(canonicalDdl).digest("hex");
+}
+
+describe("base schema shape ratchet", () => {
+  it("keeps the immutable release ledger contiguous", () => {
+    expect(BASE_SCHEMA_RELEASES.map((release) => release.version)).toEqual(
+      BASE_SCHEMA_RELEASES.map((_, index) => index + 1),
+    );
+    expect(BASE_SCHEMA_RELEASES.at(-1)?.version).toBe(
+      CURRENT_BASE_SCHEMA_VERSION,
+    );
+  });
+
+  it("binds current SQLite base DDL to the latest adoption release", () => {
+    expect(shapeDigest(sqliteContributions())).toBe(
+      BASE_SCHEMA_RELEASES.at(-1)?.shapeDigests.sqlite,
+    );
+  });
+
+  it("binds current PostgreSQL base DDL to the latest adoption release", () => {
+    expect(shapeDigest(postgresContributions())).toBe(
+      BASE_SCHEMA_RELEASES.at(-1)?.shapeDigests.postgres,
+    );
+  });
+});

--- a/packages/typegraph/tests/bundle-member-access.test.ts
+++ b/packages/typegraph/tests/bundle-member-access.test.ts
@@ -33,11 +33,11 @@ const PILOT_COUNT = 0;
 const ANNOTATED_RESIDUE_COUNT = 7;
 const ANNOTATED_RESIDUE_PAIR_COUNT = 3;
 const STATICALLY_REQUIRED_COUNT = 2;
-const REASONED_FLOOR = 86;
+const REASONED_FLOOR = 88;
 const DEFERRED_LIVE_TOTAL = 204;
 const DEFERRED_DECLARED_TOTAL = 207;
 const EXCLUDED_COUNT = 4;
-const TOTAL_ROW_COUNT = 303;
+const TOTAL_ROW_COUNT = 305;
 const ANNOTATED_RESIDUE_KEYS = [
   "backend/migrate-recorded-time.ts:160#executeStatement",
   "backend/migrate-recorded-time.ts:167#executeStatement",

--- a/packages/typegraph/tests/capability-bundle-totality.test.ts
+++ b/packages/typegraph/tests/capability-bundle-totality.test.ts
@@ -108,7 +108,7 @@ describe("capability bundle totality (T9)", () => {
     }
   });
 
-  it("29 reasoned entries sum to 86 accesses; 49 deferred entries sum to 207", () => {
+  it("29 reasoned entries sum to 88 accesses; 49 deferred entries sum to 207", () => {
     const entries = Object.values(UNBUNDLED_OPTIONAL_MEMBERS);
     const reasoned = entries.filter((entry) => entry.kind === "reasoned");
     const deferred = entries.filter((entry) => entry.kind === "deferred");
@@ -122,7 +122,7 @@ describe("capability bundle totality (T9)", () => {
     // one live `recordedTableDdl` access. The required command port no longer
     // belongs in this optional-member inventory. Durable identity adoption
     // adds one empty-kind fence and one optional preflight selection.
-    expect(reasoned.reduce((sum, entry) => sum + entry.accesses, 0)).toBe(86);
+    expect(reasoned.reduce((sum, entry) => sum + entry.accesses, 0)).toBe(88);
     expect(deferred.reduce((sum, entry) => sum + entry.ceiling, 0)).toBe(207);
   });
 });

--- a/packages/typegraph/tests/drizzle-claim-sites.test.ts
+++ b/packages/typegraph/tests/drizzle-claim-sites.test.ts
@@ -20,11 +20,13 @@ import { scanClaimSites } from "../scripts/drizzle-claim-inventory";
 const CLAIM_WORD = "Drizzle";
 
 /** Derived by `node --import tsx scripts/drizzle-claim-inventory.ts`. */
-const RECORDED_CLAIM_SITES: readonly Readonly<{
+type RecordedClaimSite = Readonly<{
   file: string;
-  line: number;
   text: string;
-}>[] = [
+}> &
+  (Readonly<{ line: number }> | Readonly<{ anchor: "exact-text-in-file" }>);
+
+const RECORDED_CLAIM_SITES: readonly RecordedClaimSite[] = [
   {
     file: "README.md",
     line: 118,
@@ -49,7 +51,7 @@ const RECORDED_CLAIM_SITES: readonly Readonly<{
   },
   {
     file: "apps/docs/src/content/docs/backend-setup.md",
-    line: 913,
+    anchor: "exact-text-in-file",
     text: "## " + CLAIM_WORD + "-Free Entrypoints",
   },
   {
@@ -120,6 +122,15 @@ const RECORDED_CLAIM_SITES: readonly Readonly<{
   },
 ];
 
+function matchesRecordedSite(
+  scanned: Readonly<{ file: string; line: number; text: string }>,
+  recorded: RecordedClaimSite,
+): boolean {
+  if (scanned.file !== recorded.file) return false;
+  if ("line" in recorded) return scanned.line === recorded.line;
+  return scanned.text === recorded.text;
+}
+
 describe("drizzle claim-site inventory", () => {
   it("has the recorded shape: 13 occurrences across 11 files", () => {
     expect(RECORDED_CLAIM_SITES.length).toBe(13);
@@ -134,33 +145,27 @@ describe("drizzle claim-site inventory", () => {
     expect(scanned.length).toBe(13);
     expect(new Set(scanned.map((site) => site.file)).size).toBe(11);
 
-    const recordedKeys = new Set(
-      RECORDED_CLAIM_SITES.map((site) => `${site.file}:${site.line}`),
-    );
     for (const site of scanned) {
       expect(
-        recordedKeys.has(`${site.file}:${site.line}`),
+        RECORDED_CLAIM_SITES.some((recorded) =>
+          matchesRecordedSite(site, recorded),
+        ),
         `claim site not in the recorded inventory: ${site.file}:${site.line}`,
       ).toBe(true);
     }
 
-    const scannedKeys = new Set(
-      scanned.map((site) => `${site.file}:${site.line}`),
-    );
     for (const recorded of RECORDED_CLAIM_SITES) {
       expect(
-        scannedKeys.has(`${recorded.file}:${recorded.line}`),
-        `recorded claim site no longer exists: ${recorded.file}:${recorded.line}`,
+        scanned.some((site) => matchesRecordedSite(site, recorded)),
+        `recorded claim site no longer exists: ${recorded.file}`,
       ).toBe(true);
     }
 
     for (const recorded of RECORDED_CLAIM_SITES) {
-      const scannedSite = scanned.find(
-        (site) => site.file === recorded.file && site.line === recorded.line,
+      const scannedSite = scanned.find((site) =>
+        matchesRecordedSite(site, recorded),
       );
-      expect(scannedSite?.text, `${recorded.file}:${recorded.line}`).toBe(
-        recorded.text,
-      );
+      expect(scannedSite?.text).toBe(recorded.text);
     }
   });
 

--- a/packages/typegraph/tests/edge-match-identity-ddl.test.ts
+++ b/packages/typegraph/tests/edge-match-identity-ddl.test.ts
@@ -102,17 +102,24 @@ describe("durable edge-match identity DDL", () => {
         ),
       );
       const prepare = client.prepare.bind(client);
-      let injectedRace = false;
+      const racedColumns = new Set<string>();
       const prepareSpy = vi
         .spyOn(client, "prepare")
         .mockImplementation((source) => {
-          if (
-            !injectedRace &&
-            typeof source === "string" &&
-            source.includes('ADD COLUMN "match_identity_name"')
-          ) {
-            injectedRace = true;
-            prepare(source).run();
+          if (typeof source === "string") {
+            for (const column of [
+              "match_identity_name",
+              "match_identity_key",
+            ]) {
+              if (
+                !racedColumns.has(column) &&
+                source.includes(`ADD COLUMN "${column}"`)
+              ) {
+                racedColumns.add(column);
+                prepare(source).run();
+                break;
+              }
+            }
           }
           return prepare(source);
         });
@@ -120,13 +127,57 @@ describe("durable edge-match identity DDL", () => {
       await expect(
         backend.ensureEdgeMatchIdentityStorage?.(),
       ).resolves.toBeUndefined();
-      expect(injectedRace).toBe(true);
+      expect([...racedColumns]).toEqual([
+        "match_identity_name",
+        "match_identity_key",
+      ]);
       const columns = prepare(
         `PRAGMA table_info("${tableName}")`,
       ).all() as readonly Readonly<{ name: string }>[];
       expect(columns.map((column) => column.name)).toEqual(
         expect.arrayContaining(["match_identity_name", "match_identity_key"]),
       );
+      prepareSpy.mockRestore();
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("stops after three duplicate-column race retries", async () => {
+    const tableName = "retry_limited_edges";
+    const { backend, db } = createLocalSqliteBackend({
+      tables: createSqliteTables({ edges: tableName }),
+    });
+    const client = (db as unknown as { $client: Database.Database }).$client;
+    const duplicateRace = Object.assign(
+      new Error("duplicate column name: match_identity_name"),
+      { code: "SQLITE_ERROR" },
+    );
+    try {
+      db.run(sql.raw(`DROP TABLE "${tableName}"`));
+      db.run(
+        sql.raw(
+          `CREATE TABLE "${tableName}" ("graph_id" TEXT NOT NULL, "id" TEXT NOT NULL, "kind" TEXT NOT NULL, "from_kind" TEXT NOT NULL, "from_id" TEXT NOT NULL, "to_kind" TEXT NOT NULL, "to_id" TEXT NOT NULL, "props" TEXT NOT NULL, "created_at" TEXT NOT NULL, "updated_at" TEXT NOT NULL, PRIMARY KEY ("graph_id", "id"))`,
+        ),
+      );
+      const prepare = client.prepare.bind(client);
+      let attempts = 0;
+      const prepareSpy = vi
+        .spyOn(client, "prepare")
+        .mockImplementation((source) => {
+          if (
+            typeof source === "string" &&
+            source.includes('ADD COLUMN "match_identity_name"')
+          ) {
+            attempts += 1;
+            throw duplicateRace;
+          }
+          return prepare(source);
+        });
+      await expect(
+        backend.ensureEdgeMatchIdentityStorage?.(),
+      ).rejects.toMatchObject({ cause: duplicateRace });
+      expect(attempts).toBe(3);
       prepareSpy.mockRestore();
     } finally {
       await backend.close();

--- a/packages/typegraph/tests/edge-match-identity-ddl.test.ts
+++ b/packages/typegraph/tests/edge-match-identity-ddl.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import type Database from "better-sqlite3";
 import { sql } from "drizzle-orm";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { describe, expect, it, vi } from "vitest";
@@ -82,6 +83,51 @@ describe("durable edge-match identity DDL", () => {
       expect(() => insert("e2", "identity", "same")).toThrow();
       expect(() => insert("e3", "identity", undefined)).toThrow();
       expect(() => insert("e4", "NULL", "different")).toThrow();
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("re-plans when a concurrent SQLite adopter wins an ADD COLUMN race", async () => {
+    const tableName = "raced_edges";
+    const { backend, db } = createLocalSqliteBackend({
+      tables: createSqliteTables({ edges: tableName }),
+    });
+    const client = (db as unknown as { $client: Database.Database }).$client;
+    try {
+      db.run(sql.raw(`DROP TABLE "${tableName}"`));
+      db.run(
+        sql.raw(
+          `CREATE TABLE "${tableName}" ("graph_id" TEXT NOT NULL, "id" TEXT NOT NULL, "kind" TEXT NOT NULL, "from_kind" TEXT NOT NULL, "from_id" TEXT NOT NULL, "to_kind" TEXT NOT NULL, "to_id" TEXT NOT NULL, "props" TEXT NOT NULL, "created_at" TEXT NOT NULL, "updated_at" TEXT NOT NULL, PRIMARY KEY ("graph_id", "id"))`,
+        ),
+      );
+      const prepare = client.prepare.bind(client);
+      let injectedRace = false;
+      const prepareSpy = vi
+        .spyOn(client, "prepare")
+        .mockImplementation((source) => {
+          if (
+            !injectedRace &&
+            typeof source === "string" &&
+            source.includes('ADD COLUMN "match_identity_name"')
+          ) {
+            injectedRace = true;
+            prepare(source).run();
+          }
+          return prepare(source);
+        });
+
+      await expect(
+        backend.ensureEdgeMatchIdentityStorage?.(),
+      ).resolves.toBeUndefined();
+      expect(injectedRace).toBe(true);
+      const columns = prepare(
+        `PRAGMA table_info("${tableName}")`,
+      ).all() as readonly Readonly<{ name: string }>[];
+      expect(columns.map((column) => column.name)).toEqual(
+        expect.arrayContaining(["match_identity_name", "match_identity_key"]),
+      );
+      prepareSpy.mockRestore();
     } finally {
       await backend.close();
     }

--- a/packages/typegraph/tests/sql-errors.test.ts
+++ b/packages/typegraph/tests/sql-errors.test.ts
@@ -850,6 +850,16 @@ describe("isEdgeMatchIdentityStorageUnavailableError", () => {
       isEdgeMatchIdentityStorageUnavailableError(
         Object.assign(
           new Error(
+            'no such column: "match_identity_name" - should this be a string literal in single-quotes?',
+          ),
+          { code: "SQLITE_ERROR" },
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isEdgeMatchIdentityStorageUnavailableError(
+        Object.assign(
+          new Error(
             "UNIQUE constraint failed: typegraph_edges.match_identity_name",
           ),
           { code: "SQLITE_ERROR" },

--- a/packages/typegraph/tests/sql-errors.test.ts
+++ b/packages/typegraph/tests/sql-errors.test.ts
@@ -29,6 +29,8 @@ import {
   isMissingTableError,
   isNotNullColumnViolation,
   isPostgresConcurrentDdlRaceError,
+  isSqliteDuplicateEdgeMatchIdentityColumnError,
+  isSqliteMissingEdgeMatchIdentityColumnError,
   isSqliteNotAuthorizedError,
   isSqliteStaleSnapshotError,
 } from "../src/utils/sql-errors";
@@ -864,6 +866,45 @@ describe("isEdgeMatchIdentityStorageUnavailableError", () => {
           ),
           { code: "SQLITE_ERROR" },
         ),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("edge match-identity provisioning error classifiers", () => {
+  it("restricts automatic DDL to SQLite missing-column failures", () => {
+    const missingColumn = Object.assign(
+      new Error("no such column: match_identity_name"),
+      { code: "SQLITE_ERROR" },
+    );
+    const missingArbiter = Object.assign(
+      new Error(
+        "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint",
+      ),
+      { code: "SQLITE_ERROR" },
+    );
+
+    expect(isSqliteMissingEdgeMatchIdentityColumnError(missingColumn)).toBe(
+      true,
+    );
+    expect(isSqliteMissingEdgeMatchIdentityColumnError(missingArbiter)).toBe(
+      false,
+    );
+  });
+
+  it("recognizes only the two duplicate-column adoption races", () => {
+    expect(
+      isSqliteDuplicateEdgeMatchIdentityColumnError(
+        Object.assign(new Error("duplicate column name: match_identity_key"), {
+          code: "SQLITE_ERROR",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isSqliteDuplicateEdgeMatchIdentityColumnError(
+        Object.assign(new Error("duplicate column name: props"), {
+          code: "SQLITE_ERROR",
+        }),
       ),
     ).toBe(false);
   });


### PR DESCRIPTION
This follow-up makes the deployment-wide base-schema lifecycle the single owner of physical-storage evolution instead of relying on each provisioning path to remember release-added artifacts.

- Adds an immutable, contiguous base-schema release ledger with per-dialect ordered-shape digests. Any TypeGraph-owned table, index, or statement-order change now requires a numbered adoption release, and bundled backends cannot start with a lifecycle registry that does not reach the declared current version.
- Makes every adoption step declare a total bootstrap strategy: generated DDL coverage, pre-DDL adoption, or post-DDL adoption. Bootstrap can no longer silently skip a missing optional hook and then publish the step as complete.
- Makes marker publication report the version actually observed on the primary. Concurrent adopters can safely skip superseded work, while a newer release winning the race is retained and refused instead of being downgraded or misclassified.
- Repairs legacy edge storage before generated indexes reference its match-identity columns, then publishes the marker only after the complete current schema exists. SQLite adoption re-reads and re-plans after precisely classified duplicate-column races from concurrent cold starts.
- Bounds SQLite adoption retries on both asynchronous and synchronous adapters and treats impossible loop exhaustion as a compiler invariant failure. Regression coverage exercises two consecutive column races and proves the third precise duplicate-column failure propagates rather than being hidden or looping indefinitely.
- Keeps libSQL's batched fresh-installation script as the fast path, verifies its marker postcondition, and delegates legacy or stale installations to the same numbered backend lifecycle. The synchronous local SQLite path is explicitly locked to lifecycle version 1 so a future release cannot silently inherit its unavoidable synchronous implementation.
- Separates the narrow SQLite missing-column and concurrent-DDL classifiers used by automatic provisioning from the broader runtime DML diagnostic, preventing missing-conflict-arbiter errors from authorizing schema mutation.
- Covers generated PostgreSQL/SQLite scripts, managed libSQL/local SQLite, vector-disabled PGlite, and both backend bootstrap paths with executable match-identity writes rather than marker-only assertions. Applying a fresh-installation script to an unsupported legacy schema is pinned to fail without publishing the marker on both SQLite and PostgreSQL.
- Keeps optional-backend capability accounting and the public API report synchronized with the lifecycle consumers, and documents the complete-installation entry points without claiming that bring-your-own backend factories perform DDL.

The load-bearing checks were mutation-validated: disabling duplicate-column race recognition reproduced the losing-adopter failure; reducing the retry allowance made the synchronous and asynchronous two-race cases fail; moving marker publication ahead of remaining DDL made the legacy-script test detect a false stamp; removing the final current-version gate made concurrent-newer lifecycle tests fail; and changing generated base DDL trips the ordered release digest. This establishes a mechanical path for the next base-storage change rather than another release-specific provisioning fix.
