### PR TITLE
perf: execute resolved upsert updates as atomic sets

### DIFF
--- a/.changeset/resolved-upsert-update-sets.md
+++ b/.changeset/resolved-upsert-update-sets.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Reduce eligible update-only node and edge `bulkUpsertById()` calls on bundled serverless backends to one batched preimage read plus one guarded atomic set update. Consolidate fallback updates under one write plan and batch their authoritative reads when transaction semantics allow it.

--- a/apps/docs/src/content/docs/architecture.md
+++ b/apps/docs/src/content/docs/architecture.md
@@ -609,9 +609,12 @@ submitted:
 - A **resolved mutation set** requires an authoritative database preimage and
   application computation before its writes are known. `bulkUpsertById()` is
   the canonical example: stored props are merged and Zod-validated, temporal
-  decisions are derived, and repeated IDs observe earlier batch items. These
-  operations resolve and execute inside one transaction and may use set-based
-  backend ports, but they are not mislabeled as read-free programs.
+  decisions are derived, and repeated IDs observe earlier batch items. An
+  eligible distinct-ID, update-only set can cross the exact-root boundary after
+  resolution: its guarded SQL carries the node versions or complete edge
+  preimages that justified the after-images and updates every member or none.
+  Complex sets resolve and execute inside one interactive transaction. Neither
+  shape is mislabeled as a read-free program.
 
 This boundary keeps transport optimization subordinate to Store semantics. A
 new bulk optimization must either prove its mutation is closed or name the

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -343,9 +343,13 @@ Direct edge `bulkDelete()` calls use the same exact-root exchange and refuse a
 foreign-kind ID atomically. Plain node `bulkDelete()` qualifies when no unique,
 disjointness, identity, projection, history, revision, cascade, or disconnect
 work is owed; the program enforces `restrict` against live connected edges in
-SQL. Other delete shapes retain their transaction path. This eligibility is
-intentionally separate from `bulkUpsertById()`: upsert must resolve and
-schema-validate a database preimage before its write set is known.
+SQL. Other delete shapes retain their transaction path. `bulkUpsertById()`
+remains a resolved mutation set because it must read and schema-validate a
+database preimage before its writes are known. Bundled serverless roots can
+submit an eligible distinct-ID, live-row, update-only resolved set as one
+guarded atomic update after that read; repeated IDs, creates, temporal changes,
+sidecars, history/revision capture, and caller transactions use the interactive
+path.
 
 ### One `bulkUpsertById` batch cannot hand a constrained value between rows
 

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -348,8 +348,11 @@ remains a resolved mutation set because it must read and schema-validate a
 database preimage before its writes are known. Bundled serverless roots can
 submit an eligible distinct-ID, live-row, update-only resolved set as one
 guarded atomic update after that read; repeated IDs, creates, temporal changes,
-sidecars, history/revision capture, and caller transactions use the interactive
-path.
+sidecars (including durable edge match identity), history/revision capture, and
+caller transactions use the interactive path. On D1's 100-parameter budget the
+native ceiling is 17 node updates or 6 edge updates; larger batches return to
+the interactive path rather than splitting the all-or-nothing guard across
+autocommit statements.
 
 ### One `bulkUpsertById` batch cannot hand a constrained value between rows
 

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -177,9 +177,14 @@ the interactive path.
 These operations are registered through one exact-root mutation execution
 profile. Create and delete are **closed programs**: validation and arbitration
 can be expressed by the submitted SQL itself. `bulkUpsertById()` is deliberately
-different. It must read authoritative stored properties, merge and validate
-them, and preserve repeated-ID ordering before its write set is known, so it
-remains a resolved mutation set on the interactive path.
+different. It first reads authoritative stored properties, then merges and
+validates them before its write set is known. On bundled serverless roots, an
+update-only batch of distinct live IDs with no claims, projections, Operational
+Identity, temporal mutation, history, or revision capture submits that resolved
+set as one guarded atomic update. The preimage version (nodes) or complete
+mutable preimage (edges) is part of the SQL gate, so every row updates or none
+do. Repeated IDs, creates, resurrections, temporal changes, sidecars, and caller
+transactions retain the consolidated interactive path.
 
 Measured at the libSQL transport boundary, eligible plain node
 `bulkInsert()` and `bulkCreate()` calls each submit one exchange for generated,
@@ -190,7 +195,9 @@ from 8 transport submissions to 1 atomic exchange. Eligible one-chunk node and
 edge `bulkDelete()` calls likewise submit 1 atomic exchange instead of a
 transaction plus per-row probes/writes. On the portable edge path, one batched
 authoritative read plus one set-based soft delete replaces the former two
-statements per input. The native exchange still
+statements per input. Eligible update-only node and edge `bulkUpsertById()`
+calls submit 2 exchanges regardless of row count within the bind budget: one
+batched preimage read and one atomic set update. The native exchange still
 contains the SQL statements needed for inserts and sidecars; it submits them as
 one transaction so they do not each pay network latency. The exact previous
 count varies by driver and endpoint shape.

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -180,11 +180,12 @@ can be expressed by the submitted SQL itself. `bulkUpsertById()` is deliberately
 different. It first reads authoritative stored properties, then merges and
 validates them before its write set is known. On bundled serverless roots, an
 update-only batch of distinct live IDs with no claims, projections, Operational
-Identity, temporal mutation, history, or revision capture submits that resolved
-set as one guarded atomic update. The preimage version (nodes) or complete
-mutable preimage (edges) is part of the SQL gate, so every row updates or none
-do. Repeated IDs, creates, resurrections, temporal changes, sidecars, and caller
-transactions retain the consolidated interactive path.
+Identity, durable edge match identity, temporal mutation, history, or revision
+capture submits that resolved set as one guarded atomic update. The preimage
+version (nodes) or complete mutable preimage (edges) is part of the SQL gate, so
+every row updates or none do. Repeated IDs, creates, resurrections, temporal
+changes, sidecars, and caller transactions retain the consolidated interactive
+path.
 
 Measured at the libSQL transport boundary, eligible plain node
 `bulkInsert()` and `bulkCreate()` calls each submit one exchange for generated,
@@ -197,7 +198,12 @@ transaction plus per-row probes/writes. On the portable edge path, one batched
 authoritative read plus one set-based soft delete replaces the former two
 statements per input. Eligible update-only node and edge `bulkUpsertById()`
 calls submit 2 exchanges regardless of row count within the bind budget: one
-batched preimage read and one atomic set update. The native exchange still
+batched preimage read and one atomic set update. The D1 100-parameter budget
+admits at most 17 node updates or 6 edge updates in that shape. The ceiling is
+all-or-nothing rather than chunked: a larger batch returns to the consolidated
+interactive path because separate autocommit statements could not preserve the
+set's atomic guard. Other backends derive their ceiling from their declared
+parameter budget. The native exchange still
 contains the SQL statements needed for inserts and sidecars; it submits them as
 one transaction so they do not each pay network latency. The exact previous
 count varies by driver and endpoint shape.

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -92,6 +92,39 @@ export type AtomicNodeDeleteBatchExecutor = (
   input: AtomicNodeDeleteBatchInput,
 ) => Promise<AtomicDeleteBatchResult>;
 
+export type AtomicNodeResolvedUpdateEntry = Readonly<{
+  graphId: string;
+  kind: string;
+  id: string;
+  props: Readonly<Record<string, unknown>>;
+  expectedVersion: number;
+}>;
+
+export interface AtomicNodeResolvedUpdateBatchExecutor {
+  readonly maxEntries: number;
+  (
+    input: Readonly<{
+      entries: readonly AtomicNodeResolvedUpdateEntry[];
+      schemaFence: SchemaWriteFenceParams;
+    }>,
+  ): Promise<readonly NodeRow[]>;
+}
+
+export type AtomicEdgeResolvedUpdateEntry = Readonly<{
+  existing: EdgeRow;
+  props: Readonly<Record<string, unknown>>;
+}>;
+
+export interface AtomicEdgeResolvedUpdateBatchExecutor {
+  readonly maxEntries: number;
+  (
+    input: Readonly<{
+      entries: readonly AtomicEdgeResolvedUpdateEntry[];
+      schemaFence: SchemaWriteFenceParams;
+    }>,
+  ): Promise<readonly EdgeRow[]>;
+}
+
 /** Internal proof that the closed SQL program rejected a missing endpoint. */
 export class AtomicEdgeBatchEndpointRefusalError extends Error {
   constructor(cause: unknown) {
@@ -133,6 +166,8 @@ export type AtomicMutationProgramExecutor = Readonly<{
   createEdges?: AtomicEdgeBatchExecutor;
   deleteNodes?: AtomicNodeDeleteBatchExecutor;
   deleteEdges?: AtomicEdgeDeleteBatchExecutor;
+  updateNodes?: AtomicNodeResolvedUpdateBatchExecutor;
+  updateEdges?: AtomicEdgeResolvedUpdateBatchExecutor;
 }>;
 
 const ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS = new WeakMap<
@@ -148,6 +183,8 @@ export function markBundledRootAtomicMutationPrograms<T extends object>(
     createEdges?: AtomicEdgeBatchExecutor | undefined;
     deleteNodes?: AtomicNodeDeleteBatchExecutor | undefined;
     deleteEdges?: AtomicEdgeDeleteBatchExecutor | undefined;
+    updateNodes?: AtomicNodeResolvedUpdateBatchExecutor | undefined;
+    updateEdges?: AtomicEdgeResolvedUpdateBatchExecutor | undefined;
   }>,
 ): T {
   ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.set(target, {
@@ -171,6 +208,12 @@ export function markBundledRootAtomicMutationPrograms<T extends object>(
     : {
         deleteEdges: executor.deleteEdges,
       }),
+    ...(executor.updateNodes === undefined ?
+      {}
+    : { updateNodes: executor.updateNodes }),
+    ...(executor.updateEdges === undefined ?
+      {}
+    : { updateEdges: executor.updateEdges }),
   });
   return target;
 }

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -49,12 +49,16 @@ import {
   type AtomicEdgeDeleteBatchExecutor,
   type AtomicEdgeDeleteBatchInput,
   AtomicEdgeDeleteIdentityRefusalError,
+  type AtomicEdgeResolvedUpdateBatchExecutor,
+  type AtomicEdgeResolvedUpdateEntry,
   type AtomicNodeBatchEntry,
   type AtomicNodeBatchExecutor,
   type AtomicNodeBatchInput,
   type AtomicNodeDeleteBatchExecutor,
   type AtomicNodeDeleteBatchInput,
   AtomicNodeDeleteRestrictedRefusalError,
+  type AtomicNodeResolvedUpdateBatchExecutor,
+  type AtomicNodeResolvedUpdateEntry,
 } from "../capabilities/atomic-mutation-program";
 import type {
   AtomicSqlProgram,
@@ -239,6 +243,63 @@ function assertMatchingEdgeSchemaFences(
   }
 }
 
+function assertResolvedNodeUpdateBatchInput(
+  entries: readonly AtomicNodeResolvedUpdateEntry[],
+  schemaFence: SchemaWriteFenceParams,
+): void {
+  const first = entries[0];
+  if (first === undefined) return;
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    if (
+      entry.graphId !== first.graphId ||
+      entry.kind !== first.kind ||
+      entry.graphId !== schemaFence.graphId ||
+      ids.has(entry.id)
+    ) {
+      throw new CompilerInvariantError(
+        "An atomic resolved node update requires distinct ids from one fenced graph and kind.",
+        {
+          expected: {
+            graphId: first.graphId,
+            kind: first.kind,
+            fenceGraphId: schemaFence.graphId,
+          },
+          actual: { graphId: entry.graphId, kind: entry.kind, id: entry.id },
+        },
+      );
+    }
+    ids.add(entry.id);
+  }
+}
+
+function assertResolvedEdgeUpdateBatchInput(
+  entries: readonly AtomicEdgeResolvedUpdateEntry[],
+  schemaFence: SchemaWriteFenceParams,
+): void {
+  const first = entries[0];
+  if (first === undefined) return;
+  const graphId = first.existing.graph_id;
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    const existing = entry.existing;
+    if (
+      existing.graph_id !== graphId ||
+      existing.graph_id !== schemaFence.graphId ||
+      ids.has(existing.id)
+    ) {
+      throw new CompilerInvariantError(
+        "An atomic resolved edge update requires distinct ids from one fenced graph.",
+        {
+          expected: { graphId, fenceGraphId: schemaFence.graphId },
+          actual: { graphId: existing.graph_id, id: existing.id },
+        },
+      );
+    }
+    ids.add(existing.id);
+  }
+}
+
 /**
  * The owner a claim write proposes. Reading it off the params in one place is
  * what keeps the accept/refuse test comparing the same pair the SQL arms do.
@@ -311,8 +372,10 @@ export type CommonOperationBackend = Pick<
   Readonly<{
     executeAtomicNodeBatch?: AtomicNodeBatchExecutor;
     executeAtomicNodeDeleteBatch?: AtomicNodeDeleteBatchExecutor;
+    executeAtomicNodeResolvedUpdateBatch?: AtomicNodeResolvedUpdateBatchExecutor;
     executeAtomicEdgeBatch?: AtomicEdgeBatchExecutor;
     executeAtomicEdgeDeleteBatch?: AtomicEdgeDeleteBatchExecutor;
+    executeAtomicEdgeResolvedUpdateBatch?: AtomicEdgeResolvedUpdateBatchExecutor;
     /**
      * The read-only fence audit. Not a `TransactionBackend` member — it is a
      * diagnostic the store runs at the top-level backend, and nothing inside a
@@ -1864,6 +1927,65 @@ export function createCommonOperationBackend(
         }>;
       })();
 
+  const atomicNodeResolvedUpdateBatchMembers =
+    (
+      atomicSqlProgramExecutor === undefined ||
+      schemaFenceLockClause === undefined
+    ) ?
+      {}
+    : (() => {
+        const atomicExecutor = requireDefined(atomicSqlProgramExecutor);
+        const atomicSchemaFenceLockClause = requireDefined(
+          schemaFenceLockClause,
+        );
+        // Each member binds its id in CASE, membership and preimage predicates,
+        // plus props and version. Leave a conservative fixed allowance for the
+        // graph/kind/fence/timestamp/count binds.
+        const maxEntries = Math.max(
+          1,
+          Math.floor((maxBindParameters - 12) / 5),
+        );
+
+        const executeAtomicNodeResolvedUpdateBatch = Object.assign(
+          async (input: Parameters<AtomicNodeResolvedUpdateBatchExecutor>[0]) => {
+            if (input.entries.length === 0) return [];
+            assertResolvedNodeUpdateBatchInput(
+              input.entries,
+              input.schemaFence,
+            );
+            if (input.entries.length > maxEntries) {
+              throw new CompilerInvariantError(
+                "Atomic resolved node update exceeded its declared bind budget.",
+                { entries: input.entries.length, maxEntries },
+              );
+            }
+            const query =
+              operationStrategy.buildAtomicNodeResolvedUpdateBatch(
+                input.entries,
+                nowIso(),
+                input.schemaFence,
+                atomicSchemaFenceLockClause,
+              );
+            const program = {
+              slots: [
+                {
+                  statement: execution.compile(query),
+                  cardinality: "many" as const,
+                  decode: (rows: readonly Readonly<Record<string, unknown>>[]) =>
+                    rows.map((row) => rowMappers.toNodeRow(row)),
+                },
+              ],
+              assemble: (results: readonly (readonly NodeRow[])[]) =>
+                results[0] ?? [],
+            } satisfies AtomicSqlProgram<readonly NodeRow[], readonly NodeRow[]>;
+            return atomicExecutor.execute(program);
+          },
+          { maxEntries },
+        ) satisfies AtomicNodeResolvedUpdateBatchExecutor;
+
+        return { executeAtomicNodeResolvedUpdateBatch };
+      })();
+
   const atomicEdgeDeleteBatchMembers =
     (
       atomicSqlProgramExecutor === undefined ||
@@ -1939,6 +2061,61 @@ export function createCommonOperationBackend(
         return { executeAtomicEdgeDeleteBatch } satisfies Readonly<{
           executeAtomicEdgeDeleteBatch: AtomicEdgeDeleteBatchExecutor;
         }>;
+      })();
+
+  const atomicEdgeResolvedUpdateBatchMembers =
+    (
+      atomicSqlProgramExecutor === undefined ||
+      schemaFenceLockClause === undefined
+    ) ?
+      {}
+    : (() => {
+        const atomicExecutor = requireDefined(atomicSqlProgramExecutor);
+        const atomicSchemaFenceLockClause = requireDefined(
+          schemaFenceLockClause,
+        );
+
+        const maxEntries = Math.max(
+          1,
+          Math.floor((maxBindParameters - 12) / 14),
+        );
+        const executeAtomicEdgeResolvedUpdateBatch = Object.assign(
+          async (input: Parameters<AtomicEdgeResolvedUpdateBatchExecutor>[0]) => {
+            if (input.entries.length === 0) return [];
+            assertResolvedEdgeUpdateBatchInput(
+              input.entries,
+              input.schemaFence,
+            );
+            if (input.entries.length > maxEntries) {
+              throw new CompilerInvariantError(
+                "Atomic resolved edge update exceeded its declared bind budget.",
+                { entries: input.entries.length, maxEntries },
+              );
+            }
+            const query = operationStrategy.buildAtomicEdgeResolvedUpdateBatch(
+              input.entries,
+              nowIso(),
+              input.schemaFence,
+              atomicSchemaFenceLockClause,
+            );
+            const program = {
+              slots: [
+                {
+                  statement: execution.compile(query),
+                  cardinality: "many" as const,
+                  decode: (rows: readonly Readonly<Record<string, unknown>>[]) =>
+                    rows.map((row) => rowMappers.toEdgeRow(row)),
+                },
+              ],
+              assemble: (results: readonly (readonly EdgeRow[])[]) =>
+                results[0] ?? [],
+            } satisfies AtomicSqlProgram<readonly EdgeRow[], readonly EdgeRow[]>;
+            return atomicExecutor.execute(program);
+          },
+          { maxEntries },
+        ) satisfies AtomicEdgeResolvedUpdateBatchExecutor;
+
+        return { executeAtomicEdgeResolvedUpdateBatch };
       })();
 
   const schemaGraphWriteLockNamespace = options.schemaGraphWriteLockNamespace;
@@ -2476,7 +2653,9 @@ export function createCommonOperationBackend(
     ...atomicNodeBatchMembers,
     ...atomicEdgeBatchMembers,
     ...atomicNodeDeleteBatchMembers,
+    ...atomicNodeResolvedUpdateBatchMembers,
     ...atomicEdgeDeleteBatchMembers,
+    ...atomicEdgeResolvedUpdateBatchMembers,
     ...schemaGraphWriteFenceMembers,
     commands: commandsPort,
 

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -280,19 +280,25 @@ function assertResolvedEdgeUpdateBatchInput(
   const first = entries[0];
   if (first === undefined) return;
   const graphId = first.existing.graph_id;
+  const kind = first.existing.kind;
   const ids = new Set<string>();
   for (const entry of entries) {
     const existing = entry.existing;
     if (
       existing.graph_id !== graphId ||
       existing.graph_id !== schemaFence.graphId ||
+      existing.kind !== kind ||
       ids.has(existing.id)
     ) {
       throw new CompilerInvariantError(
-        "An atomic resolved edge update requires distinct ids from one fenced graph.",
+        "An atomic resolved edge update requires distinct ids from one fenced graph and kind.",
         {
-          expected: { graphId, fenceGraphId: schemaFence.graphId },
-          actual: { graphId: existing.graph_id, id: existing.id },
+          expected: { graphId, kind, fenceGraphId: schemaFence.graphId },
+          actual: {
+            graphId: existing.graph_id,
+            kind: existing.kind,
+            id: existing.id,
+          },
         },
       );
     }
@@ -1947,7 +1953,9 @@ export function createCommonOperationBackend(
         );
 
         const executeAtomicNodeResolvedUpdateBatch = Object.assign(
-          async (input: Parameters<AtomicNodeResolvedUpdateBatchExecutor>[0]) => {
+          async (
+            input: Parameters<AtomicNodeResolvedUpdateBatchExecutor>[0],
+          ) => {
             if (input.entries.length === 0) return [];
             assertResolvedNodeUpdateBatchInput(
               input.entries,
@@ -1959,25 +1967,28 @@ export function createCommonOperationBackend(
                 { entries: input.entries.length, maxEntries },
               );
             }
-            const query =
-              operationStrategy.buildAtomicNodeResolvedUpdateBatch(
-                input.entries,
-                nowIso(),
-                input.schemaFence,
-                atomicSchemaFenceLockClause,
-              );
+            const query = operationStrategy.buildAtomicNodeResolvedUpdateBatch(
+              input.entries,
+              nowIso(),
+              input.schemaFence,
+              atomicSchemaFenceLockClause,
+            );
             const program = {
               slots: [
                 {
                   statement: execution.compile(query),
                   cardinality: "many" as const,
-                  decode: (rows: readonly Readonly<Record<string, unknown>>[]) =>
-                    rows.map((row) => rowMappers.toNodeRow(row)),
+                  decode: (
+                    rows: readonly Readonly<Record<string, unknown>>[],
+                  ) => rows.map((row) => rowMappers.toNodeRow(row)),
                 },
               ],
               assemble: (results: readonly (readonly NodeRow[])[]) =>
                 results[0] ?? [],
-            } satisfies AtomicSqlProgram<readonly NodeRow[], readonly NodeRow[]>;
+            } satisfies AtomicSqlProgram<
+              readonly NodeRow[],
+              readonly NodeRow[]
+            >;
             return atomicExecutor.execute(program);
           },
           { maxEntries },
@@ -2080,7 +2091,9 @@ export function createCommonOperationBackend(
           Math.floor((maxBindParameters - 12) / 14),
         );
         const executeAtomicEdgeResolvedUpdateBatch = Object.assign(
-          async (input: Parameters<AtomicEdgeResolvedUpdateBatchExecutor>[0]) => {
+          async (
+            input: Parameters<AtomicEdgeResolvedUpdateBatchExecutor>[0],
+          ) => {
             if (input.entries.length === 0) return [];
             assertResolvedEdgeUpdateBatchInput(
               input.entries,
@@ -2103,13 +2116,17 @@ export function createCommonOperationBackend(
                 {
                   statement: execution.compile(query),
                   cardinality: "many" as const,
-                  decode: (rows: readonly Readonly<Record<string, unknown>>[]) =>
-                    rows.map((row) => rowMappers.toEdgeRow(row)),
+                  decode: (
+                    rows: readonly Readonly<Record<string, unknown>>[],
+                  ) => rows.map((row) => rowMappers.toEdgeRow(row)),
                 },
               ],
               assemble: (results: readonly (readonly EdgeRow[])[]) =>
                 results[0] ?? [],
-            } satisfies AtomicSqlProgram<readonly EdgeRow[], readonly EdgeRow[]>;
+            } satisfies AtomicSqlProgram<
+              readonly EdgeRow[],
+              readonly EdgeRow[]
+            >;
             return atomicExecutor.execute(program);
           },
           { maxEntries },

--- a/packages/typegraph/src/backend/drizzle/operations/edges.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/edges.ts
@@ -5,7 +5,10 @@ import {
   resolveStampedValidityLowerBound,
   resolveStatedValidityLowerBound,
 } from "../../../utils/date";
-import type { AtomicEdgeDeleteBatchInput } from "../../capabilities/atomic-mutation-program";
+import type {
+  AtomicEdgeDeleteBatchInput,
+  AtomicEdgeResolvedUpdateEntry,
+} from "../../capabilities/atomic-mutation-program";
 import type {
   CountEdgesFromParams,
   DeleteEdgeParams,
@@ -18,6 +21,7 @@ import type {
   SchemaWriteFenceParams,
   UpdateEdgeParams,
 } from "../../types";
+import { rowPropsToJsonText } from "../../types";
 import {
   castBoundValueForColumn,
   edgeColumnList,
@@ -764,6 +768,69 @@ export function buildUpdateEdge(
     WHERE ${edges.graphId} = ${params.graphId}
       AND ${edges.id} = ${params.id}${expectedIdentity}${expectedValidFrom}${expectedValidTo}
       AND ${edges.deletedAt} IS NULL
+    RETURNING *
+  `;
+}
+
+/** One guarded set update for distinct, live edge after-images. */
+export function buildAtomicEdgeResolvedUpdateBatch(
+  tables: Tables,
+  entries: readonly AtomicEdgeResolvedUpdateEntry[],
+  timestamp: string,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { edges, schemaVersions } = tables;
+  const first = entries[0];
+  if (first === undefined) return sql`SELECT 1 WHERE FALSE`;
+  const propsCases = entries.map(
+    (entry) =>
+      sql`WHEN ${entry.existing.id} THEN ${castBoundValueForColumn(edges.props, JSON.stringify(entry.props))}`,
+  );
+  const expectedRows = entries.map((entry) => {
+    const existing = entry.existing;
+    return sql`
+      (
+            ${edges.id} = ${existing.id}
+            AND ${edges.kind} = ${existing.kind}
+            AND ${edges.fromKind} = ${existing.from_kind}
+            AND ${edges.fromId} = ${existing.from_id}
+            AND ${edges.toKind} = ${existing.to_kind}
+            AND ${edges.toId} = ${existing.to_id}
+            AND ${edges.updatedAt} = ${existing.updated_at}
+            AND ${edges.props} = ${castBoundValueForColumn(edges.props, rowPropsToJsonText(existing.props))}
+            ${expectedValidFromPredicate(edges.validFrom, existing.valid_from)}
+            ${expectedValidFromPredicate(edges.validTo, existing.valid_to)}
+          )
+    `;
+  });
+
+  return sql`
+    WITH "schema_fence" AS (
+      SELECT ${schemaVersions.version}
+      FROM ${schemaVersions}
+      WHERE ${schemaVersions.graphId} = ${schemaFence.graphId}
+        AND ${schemaVersions.version} = ${schemaFence.expectedVersion}
+        AND ${schemaVersions.isActive} = TRUE
+      ${schemaLockClause}
+    )
+    UPDATE ${edges}
+    SET ${quotedColumn(edges.props)} = CASE ${edges.id}
+          ${sql.join(propsCases, sql` `)}
+          ELSE ${edges.props}
+        END,
+        ${quotedColumn(edges.updatedAt)} = ${timestamp}
+    WHERE ${edges.graphId} = ${first.existing.graph_id}
+      AND ${edges.deletedAt} IS NULL
+      AND ${edges.id} IN (${sql.join(entries.map((entry) => sql`${entry.existing.id}`), sql`, `)})
+      AND (
+        SELECT COUNT(*)
+        FROM ${edges}
+        CROSS JOIN "schema_fence"
+        WHERE ${edges.graphId} = ${first.existing.graph_id}
+          AND ${edges.deletedAt} IS NULL
+          AND (${sql.join(expectedRows, sql` OR `)})
+      ) = ${entries.length}
     RETURNING *
   `;
 }

--- a/packages/typegraph/src/backend/drizzle/operations/edges.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/edges.ts
@@ -32,6 +32,11 @@ import {
   type Tables,
 } from "./shared";
 
+// EdgeRow follows the public no-null convention, while the SQL predicate's
+// three-state input uses null to mean "assert the stored column is SQL NULL."
+// eslint-disable-next-line unicorn/no-null
+const EXPECTED_SQL_NULL = null;
+
 /**
  * Inputs for the dialect-specific edge convergence statement.
  *
@@ -799,8 +804,8 @@ export function buildAtomicEdgeResolvedUpdateBatch(
             AND ${edges.toId} = ${existing.to_id}
             AND ${edges.updatedAt} = ${existing.updated_at}
             AND ${edges.props} = ${castBoundValueForColumn(edges.props, rowPropsToJsonText(existing.props))}
-            ${expectedValidFromPredicate(edges.validFrom, existing.valid_from)}
-            ${expectedValidFromPredicate(edges.validTo, existing.valid_to)}
+            ${expectedValidFromPredicate(edges.validFrom, existing.valid_from ?? EXPECTED_SQL_NULL)}
+            ${expectedValidFromPredicate(edges.validTo, existing.valid_to ?? EXPECTED_SQL_NULL)}
           )
     `;
   });
@@ -821,6 +826,7 @@ export function buildAtomicEdgeResolvedUpdateBatch(
         END,
         ${quotedColumn(edges.updatedAt)} = ${timestamp}
     WHERE ${edges.graphId} = ${first.existing.graph_id}
+      AND ${edges.kind} = ${first.existing.kind}
       AND ${edges.deletedAt} IS NULL
       AND ${edges.id} IN (${sql.join(entries.map((entry) => sql`${entry.existing.id}`), sql`, `)})
       AND (

--- a/packages/typegraph/src/backend/drizzle/operations/nodes.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/nodes.ts
@@ -8,6 +8,7 @@ import type {
   AtomicNodeBatchEntry,
   AtomicNodeBatchResultMode,
   AtomicNodeDeleteBatchInput,
+  AtomicNodeResolvedUpdateEntry,
 } from "../../capabilities/atomic-mutation-program";
 import type {
   DeleteNodeParams,
@@ -576,6 +577,63 @@ export function buildUpdateNode(
       AND ${nodes.kind} = ${params.kind}
       AND ${nodes.id} = ${params.id}${expectedValidFrom}
       AND ${nodes.deletedAt} IS NULL
+    RETURNING *
+  `;
+}
+
+/**
+ * Builds one guarded set update for distinct, live node after-images.
+ * The preimage version predicates are evaluated as one count gate, so either
+ * every resolved row still matches or the statement updates none of them.
+ */
+export function buildAtomicNodeResolvedUpdateBatch(
+  tables: Tables,
+  entries: readonly AtomicNodeResolvedUpdateEntry[],
+  timestamp: string,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { nodes, schemaVersions } = tables;
+  const first = entries[0];
+  if (first === undefined) return sql`SELECT 1 WHERE FALSE`;
+  const propsCases = entries.map(
+    (entry) =>
+      sql`WHEN ${entry.id} THEN ${castBoundValueForColumn(nodes.props, JSON.stringify(entry.props))}`,
+  );
+  const expectedRows = entries.map(
+    (entry) =>
+      sql`(${nodes.id} = ${entry.id} AND ${nodes.version} = ${entry.expectedVersion})`,
+  );
+
+  return sql`
+    WITH "schema_fence" AS (
+      SELECT ${schemaVersions.version}
+      FROM ${schemaVersions}
+      WHERE ${schemaVersions.graphId} = ${schemaFence.graphId}
+        AND ${schemaVersions.version} = ${schemaFence.expectedVersion}
+        AND ${schemaVersions.isActive} = TRUE
+      ${schemaLockClause}
+    )
+    UPDATE ${nodes}
+    SET ${quotedColumn(nodes.props)} = CASE ${nodes.id}
+          ${sql.join(propsCases, sql` `)}
+          ELSE ${nodes.props}
+        END,
+        ${quotedColumn(nodes.updatedAt)} = ${timestamp},
+        ${quotedColumn(nodes.version)} = ${nodes.version} + 1
+    WHERE ${nodes.graphId} = ${first.graphId}
+      AND ${nodes.kind} = ${first.kind}
+      AND ${nodes.deletedAt} IS NULL
+      AND ${nodes.id} IN (${sql.join(entries.map((entry) => sql`${entry.id}`), sql`, `)})
+      AND (
+        SELECT COUNT(*)
+        FROM ${nodes}
+        CROSS JOIN "schema_fence"
+        WHERE ${nodes.graphId} = ${first.graphId}
+          AND ${nodes.kind} = ${first.kind}
+          AND ${nodes.deletedAt} IS NULL
+          AND (${sql.join(expectedRows, sql` OR `)})
+      ) = ${entries.length}
     RETURNING *
   `;
 }

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -8,9 +8,11 @@ import { isPresent } from "../../../utils/presence";
 import type { PrimaryKeyRelation } from "../../../utils/sql-errors";
 import type {
   AtomicEdgeDeleteBatchInput,
+  AtomicEdgeResolvedUpdateEntry,
   AtomicNodeBatchEntry,
   AtomicNodeBatchResultMode,
   AtomicNodeDeleteBatchInput,
+  AtomicNodeResolvedUpdateEntry,
 } from "../../capabilities/atomic-mutation-program";
 import { nowIso } from "../../row-mappers";
 import type {
@@ -91,6 +93,7 @@ import {
 import type { ConvergeEdgeCreateParams } from "./edges";
 import {
   buildAtomicEdgeDeleteBatchWithSchemaFence,
+  buildAtomicEdgeResolvedUpdateBatch,
   buildConvergeEdgeCreate,
   buildCountEdgesFrom,
   buildDeleteEdge,
@@ -119,6 +122,7 @@ import { buildInsertNodeWithProjections } from "./node-projections";
 import {
   buildAtomicNodeBatchWithSchemaFence,
   buildAtomicNodeDeleteBatchWithSchemaFence,
+  buildAtomicNodeResolvedUpdateBatch,
   buildDeleteNode,
   buildGetNode,
   buildGetNodes,
@@ -288,6 +292,12 @@ export type CommonOperationStrategy = Readonly<{
   buildGetNode: (graphId: string, kind: string, id: string) => SQL;
   buildGetNodes: (graphId: string, kind: string, ids: readonly string[]) => SQL;
   buildUpdateNode: (params: UpdateNodeParams, timestamp: string) => SQL;
+  buildAtomicNodeResolvedUpdateBatch: (
+    entries: readonly AtomicNodeResolvedUpdateEntry[],
+    timestamp: string,
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+  ) => SQL;
   buildUpdateNodeSet: (params: UpdateNodeSetParams, timestamp: string) => SQL;
   buildDeleteNode: (params: DeleteNodeParams, timestamp: string) => SQL;
   buildAtomicNodeDeleteBatchWithSchemaFence: (
@@ -366,6 +376,12 @@ export type CommonOperationStrategy = Readonly<{
   buildGetEdge: (graphId: string, id: string) => SQL;
   buildGetEdges: (graphId: string, ids: readonly string[]) => SQL;
   buildUpdateEdge: (params: UpdateEdgeParams, timestamp: string) => SQL;
+  buildAtomicEdgeResolvedUpdateBatch: (
+    entries: readonly AtomicEdgeResolvedUpdateEntry[],
+    timestamp: string,
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+  ) => SQL;
   buildDeleteEdge: (params: DeleteEdgeParams, timestamp: string) => SQL;
   buildDeleteEdgesBatch: (
     params: DeleteEdgesBatchParams,
@@ -548,6 +564,7 @@ const COMMON_TABLE_OPERATION_BUILDERS = {
   buildGetNode,
   buildGetNodes,
   buildUpdateNode,
+  buildAtomicNodeResolvedUpdateBatch,
   buildDeleteNode,
   buildHardDeleteNode,
   buildInsertEdge,
@@ -561,6 +578,7 @@ const COMMON_TABLE_OPERATION_BUILDERS = {
   buildGetEdge,
   buildGetEdges,
   buildUpdateEdge,
+  buildAtomicEdgeResolvedUpdateBatch,
   buildDeleteEdge,
   buildDeleteEdgesBatch,
   buildHardDeleteEdge,
@@ -808,6 +826,19 @@ function createCommonOperationStrategy(
         timestamp,
         schemaLockClause,
       ),
+    buildAtomicEdgeResolvedUpdateBatch: (
+      entries,
+      timestamp,
+      schemaFence,
+      schemaLockClause,
+    ) =>
+      buildAtomicEdgeResolvedUpdateBatch(
+        tables,
+        entries,
+        timestamp,
+        schemaFence,
+        schemaLockClause,
+      ),
     atomicNodeRefusalConstraints: {
       deleteRestricted: nodePropsNotNullConstraint,
       liveIdentity: nodePropsNotNullConstraint,
@@ -821,6 +852,19 @@ function createCommonOperationStrategy(
         tables,
         input,
         timestamp,
+        schemaLockClause,
+      ),
+    buildAtomicNodeResolvedUpdateBatch: (
+      entries,
+      timestamp,
+      schemaFence,
+      schemaLockClause,
+    ) =>
+      buildAtomicNodeResolvedUpdateBatch(
+        tables,
+        entries,
+        timestamp,
+        schemaFence,
         schemaLockClause,
       ),
     buildSchemaFenceProbe: (params, schemaLockClause) =>

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -2097,6 +2097,8 @@ export function createPostgresBackend(
     createEdges: operations.executeAtomicEdgeBatch,
     deleteNodes: operations.executeAtomicNodeDeleteBatch,
     deleteEdges: operations.executeAtomicEdgeDeleteBatch,
+    updateNodes: operations.executeAtomicNodeResolvedUpdateBatch,
+    updateEdges: operations.executeAtomicEdgeResolvedUpdateBatch,
   });
   return backend;
 }

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -2623,6 +2623,8 @@ export function createSqliteBackend(
     createEdges: operations.executeAtomicEdgeBatch,
     deleteNodes: operations.executeAtomicNodeDeleteBatch,
     deleteEdges: operations.executeAtomicEdgeDeleteBatch,
+    updateNodes: operations.executeAtomicNodeResolvedUpdateBatch,
+    updateEdges: operations.executeAtomicEdgeResolvedUpdateBatch,
   });
 
   return backend;

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -15,8 +15,11 @@ import type { CompiledSelectSql } from "../query/sql-intent";
 import { type KindRegistry } from "../registry/kind-registry";
 import { createEdgeCollection, createNodeCollection } from "./collections";
 import { type UpsertDirtyCheckFunction } from "./collections/coalesce";
-import { type UpsertUpdateEdgeInput } from "./collections/edge-collection";
-import { type UpsertUpdateNodeInput } from "./collections/node-collection";
+import { type EdgeUpsertUpdateBatchEntry } from "./collections/edge-collection";
+import {
+  type NodeUpsertUpdateBatchEntry,
+  type UpsertUpdateNodeInput,
+} from "./collections/node-collection";
 import { type EdgeRow, type NodeRow } from "./row-mappers";
 import {
   type CreateEdgeInput,
@@ -69,11 +72,10 @@ export type NodeOperations = Readonly<{
     candidateIdColumn: string,
     backend: GraphBackend | TransactionBackend,
   ) => Promise<Readonly<{ affectedCount: number }>>;
-  executeUpsertUpdate: (
-    input: UpsertUpdateNodeInput,
+  executeUpsertUpdateBatch: (
+    entries: readonly NodeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
-    options?: Readonly<{ clearDeleted?: boolean }>,
-  ) => Promise<Node>;
+  ) => Promise<readonly Node[]>;
   /**
    * Coalesce dirty-check for `upsertById` / `bulkUpsertById`. Present only when
    * the store was created with `coalesceUnchangedUpserts: true`; its absence is
@@ -172,11 +174,10 @@ export type EdgeOperations = Readonly<{
     },
     backend: GraphBackend | TransactionBackend,
   ) => Promise<Edge>;
-  executeUpsertUpdate: (
-    input: UpsertUpdateEdgeInput,
+  executeUpsertUpdateBatch: (
+    entries: readonly EdgeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
-    options?: Readonly<{ clearDeleted?: boolean }>,
-  ) => Promise<Edge>;
+  ) => Promise<readonly Edge[]>;
   /**
    * Coalesce dirty-check for `bulkUpsertById` (props only — endpoints are the
    * edge's identity). Present only when the store was created with

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -9,6 +9,7 @@ import { type BATCH_POINT_READ } from "../../backend/capabilities/bundle-registr
 import { type BundleVerdictOf } from "../../backend/capabilities/resolve";
 import {
   type EdgeEndpointSide,
+  type EdgeRow as BackendEdgeRow,
   type FindEdgesByKindParams,
   type GraphBackend,
   rowPropsToObject,
@@ -118,11 +119,10 @@ export type EdgeCollectionConfig = Readonly<{
     },
     backend: GraphBackend | TransactionBackend,
   ) => Promise<Edge>;
-  executeUpsertUpdate: (
-    input: UpsertUpdateEdgeInput,
+  executeUpsertUpdateBatch: (
+    entries: readonly EdgeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
-    options?: Readonly<{ clearDeleted?: boolean }>,
-  ) => Promise<Edge>;
+  ) => Promise<readonly Edge[]>;
   /** See EdgeOperations.upsertDirtyCheck. */
   upsertDirtyCheck?: UpsertDirtyCheckFunction;
   executeDelete: (
@@ -258,6 +258,12 @@ export type UpsertUpdateEdgeInput = EdgeUpdateInput &
     validFrom?: string;
     onImmutableLowerBound?: "preserve" | "refuse";
   }>;
+
+export type EdgeUpsertUpdateBatchEntry = Readonly<{
+  input: UpsertUpdateEdgeInput;
+  clearDeleted: boolean;
+  existing?: BackendEdgeRow;
+}>;
 
 function buildUpdateEdgeInput(
   kind: string,
@@ -405,7 +411,7 @@ export function createEdgeCollection<
     executeCreateNoReturnBatch: executeEdgeCreateNoReturnBatch,
     executeCreateBatch: executeEdgeCreateBatch,
     executeUpdate: executeEdgeUpdate,
-    executeUpsertUpdate: executeEdgeUpsertUpdate,
+    executeUpsertUpdateBatch: executeEdgeUpsertUpdateBatch,
     executeDelete: executeEdgeDelete,
     executeDeleteBatch: executeEdgeDeleteBatch,
     executeHardDelete: executeEdgeHardDelete,
@@ -832,6 +838,7 @@ export function createEdgeCollection<
           index: number;
           input: UpsertUpdateEdgeInput;
           clearDeleted: boolean;
+          existing?: BackendEdgeRow;
         }[] = [];
 
         // Batch-local running state per id so a repeated id coalesces against
@@ -1005,6 +1012,9 @@ export function createEdgeCollection<
                 item,
               ),
               clearDeleted: deletedAt !== undefined,
+              ...(pendingEntry === undefined && original !== undefined ?
+                { existing: original }
+              : {}),
             });
             pending.set(item.id, {
               identity: actualIdentity,
@@ -1032,12 +1042,21 @@ export function createEdgeCollection<
           }
         }
 
-        // Hookless individual updates (executeEdgeUpsertUpdate is already hookless)
-        for (const entry of toUpdate) {
-          const result = await executeEdgeUpsertUpdate(entry.input, target, {
-            clearDeleted: entry.clearDeleted,
-          });
-          results[entry.index] = narrowEdge<E>(result);
+        if (toUpdate.length > 0) {
+          const updated = await executeEdgeUpsertUpdateBatch(
+            toUpdate.map((entry) => ({
+              input: entry.input,
+              clearDeleted: entry.clearDeleted,
+              ...(entry.existing === undefined ?
+                {}
+              : { existing: entry.existing }),
+            })),
+            target,
+          );
+          for (const [updateIndex, entry] of toUpdate.entries()) {
+            const result = requireDefined(updated[updateIndex]);
+            results[entry.index] = narrowEdge<E>(result);
+          }
         }
 
         // Items that coalesced against an in-batch write take that write's

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -10,6 +10,7 @@ import { BATCH_POINT_READ } from "../../backend/capabilities/bundle-registry";
 import { type BundleVerdictOf } from "../../backend/capabilities/resolve";
 import {
   type GraphBackend,
+  type NodeRow as BackendNodeRow,
   rowPropsToObject,
   runOptionallyInTransaction,
   type TransactionBackend,
@@ -165,6 +166,12 @@ export type UpsertUpdateNodeInput = UpdateNodeInput &
     onImmutableLowerBound?: OnImmutableLowerBound;
   }>;
 
+export type NodeUpsertUpdateBatchEntry = Readonly<{
+  input: UpsertUpdateNodeInput;
+  clearDeleted: boolean;
+  existing?: BackendNodeRow;
+}>;
+
 /**
  * Config for creating a NodeCollection.
  */
@@ -203,11 +210,10 @@ export type NodeCollectionConfig = Readonly<{
     candidateIdColumn: string,
     backend: GraphBackend | TransactionBackend,
   ) => Promise<Readonly<{ affectedCount: number }>>;
-  executeUpsertUpdate: (
-    input: UpsertUpdateNodeInput,
+  executeUpsertUpdateBatch: (
+    entries: readonly NodeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
-    options?: Readonly<{ clearDeleted?: boolean }>,
-  ) => Promise<Node>;
+  ) => Promise<readonly Node[]>;
   /** See NodeOperations.upsertDirtyCheck. */
   upsertDirtyCheck?: UpsertDirtyCheckFunction;
   executeDelete: (
@@ -361,7 +367,7 @@ export function createNodeCollection<
     executeCreateBatch: executeNodeCreateBatch,
     executeUpdate: executeNodeUpdate,
     executeUpdateWhere: executeNodeUpdateWhere,
-    executeUpsertUpdate: executeNodeUpsertUpdate,
+    executeUpsertUpdateBatch: executeNodeUpsertUpdateBatch,
     executeDelete: executeNodeDelete,
     executeDeleteBatch: executeNodeDeleteBatch,
     executeHardDelete: executeNodeHardDelete,
@@ -755,7 +761,7 @@ export function createNodeCollection<
         const ids = items.map((item) => item.id);
         // Full existing rows: the coalesce dirty-check needs their stored
         // props, not just deleted_at.
-        const existingMap = new Map<string, NodeRow>();
+        const existingMap = new Map<string, BackendNodeRow>();
 
         const boundGetNodes = bindExtraIfReachable(
           target,
@@ -787,6 +793,7 @@ export function createNodeCollection<
           index: number;
           input: UpsertUpdateNodeInput;
           clearDeleted: boolean;
+          existing?: BackendNodeRow;
         }[] = [];
 
         // Batch-local running state per id: the props AND validity window the
@@ -929,6 +936,9 @@ export function createNodeCollection<
               index: itemIndex,
               input: buildUpsertUpdateInput(kind, item.id, item.props, item),
               clearDeleted: deletedAt !== undefined,
+              ...(pendingEntry === undefined && original !== undefined ?
+                { existing: original }
+              : {}),
             });
             pending.set(item.id, {
               props: dirty?.validatedProps,
@@ -955,12 +965,21 @@ export function createNodeCollection<
           }
         }
 
-        // Hookless individual updates
-        for (const entry of toUpdate) {
-          const result = await executeNodeUpsertUpdate(entry.input, target, {
-            clearDeleted: entry.clearDeleted,
-          });
-          results[entry.index] = narrowNode<N>(result);
+        if (toUpdate.length > 0) {
+          const updated = await executeNodeUpsertUpdateBatch(
+            toUpdate.map((entry) => ({
+              input: entry.input,
+              clearDeleted: entry.clearDeleted,
+              ...(entry.existing === undefined ?
+                {}
+              : { existing: entry.existing }),
+            })),
+            target,
+          );
+          for (const [updateIndex, entry] of toUpdate.entries()) {
+            const result = requireDefined(updated[updateIndex]);
+            results[entry.index] = narrowNode<N>(result);
+          }
         }
 
         // Items that coalesced against an in-batch write take that write's

--- a/packages/typegraph/src/store/node-fetch.ts
+++ b/packages/typegraph/src/store/node-fetch.ts
@@ -13,7 +13,6 @@ import { type BundleVerdictOf } from "../backend/capabilities/resolve";
 import {
   type GraphBackend,
   type NodeRow as BackendNodeRow,
-  type TransactionBackend,
 } from "../backend/types";
 import { getRowsByIds } from "./row-fetch";
 
@@ -25,7 +24,7 @@ import { getRowsByIds } from "./row-fetch";
  * off `backend`, the port the call executes on, never re-resolved here.
  */
 export async function getNodeRowsByIds(
-  backend: GraphBackend | TransactionBackend,
+  backend: Readonly<Pick<GraphBackend, "getNode" | "getNodes">>,
   verdict: BundleVerdictOf<typeof BATCH_POINT_READ>,
   graphId: string,
   kind: string,

--- a/packages/typegraph/src/store/operations/atomic-mutation-program.ts
+++ b/packages/typegraph/src/store/operations/atomic-mutation-program.ts
@@ -8,8 +8,10 @@
 import {
   type AtomicEdgeBatchExecutor as BackendAtomicEdgeBatchExecutor,
   type AtomicEdgeDeleteBatchExecutor,
+  type AtomicEdgeResolvedUpdateBatchExecutor,
   type AtomicNodeBatchExecutor as BackendAtomicNodeBatchExecutor,
   type AtomicNodeDeleteBatchExecutor,
+  type AtomicNodeResolvedUpdateBatchExecutor,
   resolveBundledRootAtomicMutationPrograms,
 } from "../../backend/capabilities/atomic-mutation-program";
 import { isBundledRootAutocommitEligible } from "../../backend/capabilities/autocommit-single-statement";
@@ -178,4 +180,52 @@ export function resolveAtomicNodeDeleteBatchExecutor(
   if (getSearchableFields(registration.type.schema).length > 0) return;
   if (getEmbeddingFields(registration.type.schema).length > 0) return;
   return resolveAtomicMutationProfile(input)?.deleteNodes;
+}
+
+export type AtomicNodeResolvedUpdateEligibilityInput =
+  CommonAtomicMutationEligibility &
+    Readonly<{
+      kind: string;
+      entryCount: number;
+      identityEnabled: boolean;
+      registry: KindRegistry;
+    }>;
+
+/** The one owner of the static proof for resolved live-node set updates. */
+export function resolveAtomicNodeResolvedUpdateBatchExecutor(
+  input: AtomicNodeResolvedUpdateEligibilityInput,
+): AtomicNodeResolvedUpdateBatchExecutor | undefined {
+  if (input.entryCount === 0 || input.identityEnabled) return;
+  if (!hasOwnKey(input.graph.nodes, input.kind)) return;
+  const registration = input.graph.nodes[input.kind];
+  if (registration === undefined) return;
+  if (input.registry.getDisjointKinds(input.kind).length > 0) return;
+  if ((registration.unique ?? []).length > 0) return;
+  if (getSearchableFields(registration.type.schema).length > 0) return;
+  if (getEmbeddingFields(registration.type.schema).length > 0) return;
+  const executor = resolveAtomicMutationProfile(input)?.updateNodes;
+  if (executor === undefined || input.entryCount > executor.maxEntries) return;
+  return executor;
+}
+
+export type AtomicEdgeResolvedUpdateEligibilityInput =
+  CommonAtomicMutationEligibility &
+    Readonly<{ kind: string; entryCount: number }>;
+
+/** The one owner of the static proof for resolved live-edge set updates. */
+export function resolveAtomicEdgeResolvedUpdateBatchExecutor(
+  input: AtomicEdgeResolvedUpdateEligibilityInput,
+): AtomicEdgeResolvedUpdateBatchExecutor | undefined {
+  if (input.entryCount === 0) return;
+  if (!hasOwnKey(input.graph.edges, input.kind)) return;
+  const registration = input.graph.edges[input.kind];
+  if (
+    registration === undefined ||
+    (registration.cardinality ?? "many") !== "many"
+  ) {
+    return;
+  }
+  const executor = resolveAtomicMutationProfile(input)?.updateEdges;
+  if (executor === undefined || input.entryCount > executor.maxEntries) return;
+  return executor;
 }

--- a/packages/typegraph/src/store/operations/atomic-mutation-program.ts
+++ b/packages/typegraph/src/store/operations/atomic-mutation-program.ts
@@ -221,7 +221,8 @@ export function resolveAtomicEdgeResolvedUpdateBatchExecutor(
   const registration = input.graph.edges[input.kind];
   if (
     registration === undefined ||
-    (registration.cardinality ?? "many") !== "many"
+    (registration.cardinality ?? "many") !== "many" ||
+    registration.matchIdentity !== undefined
   ) {
     return;
   }

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -2189,6 +2189,10 @@ export async function executeEdgeUpsertUpdateBatch<G extends GraphDef>(
         return row === undefined || row.deleted_at !== undefined;
       });
       if (missing !== undefined) {
+        // This update-only partition was resolved from live rows. Once a
+        // refreshed preimage is absent or tombstoned, the requested update
+        // target no longer exists; do not reinterpret it as a create or fall
+        // through to a transactionless portable write.
         throw new EdgeNotFoundError(
           first.input.identity.kind,
           missing.input.id,

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -149,7 +149,10 @@ import {
   shouldCoalesceUpsert,
   type UpsertDirtyCheck,
 } from "../collections/coalesce";
-import { type UpsertUpdateEdgeInput } from "../collections/edge-collection";
+import {
+  type EdgeUpsertUpdateBatchEntry,
+  type UpsertUpdateEdgeInput,
+} from "../collections/edge-collection";
 import {
   checkCardinalityConstraint,
   type ConstraintContext,
@@ -185,6 +188,7 @@ import {
   type AtomicEdgeBatchExecutor,
   resolveAtomicEdgeBatchExecutor,
   resolveAtomicEdgeDeleteBatchExecutor,
+  resolveAtomicEdgeResolvedUpdateBatchExecutor,
 } from "./atomic-mutation-program";
 import {
   AutocommitWriteRequiresTransaction,
@@ -1710,6 +1714,7 @@ async function performEdgeUpdate<G extends GraphDef>(
     matchOn?: readonly string[];
     matchProps?: Record<string, unknown>;
   }>,
+  resolvedExisting?: BackendEdgeRow,
 ): Promise<Edge> {
   const id = input.id;
 
@@ -1719,7 +1724,7 @@ async function performEdgeUpdate<G extends GraphDef>(
     id,
   });
 
-  const existing = await target.getEdge(ctx.graphId, id);
+  const existing = resolvedExisting ?? (await target.getEdge(ctx.graphId, id));
   if (!existing || (!options?.clearDeleted && existing.deleted_at)) {
     throw new EdgeNotFoundError(input.identity.kind, id);
   }
@@ -1926,10 +1931,18 @@ async function performEdgeUpdateConverging<G extends GraphDef>(
     matchOn?: readonly string[];
     matchProps?: Record<string, unknown>;
   }>,
+  resolvedExisting?: BackendEdgeRow,
 ): Promise<Edge> {
   for (let attempt = 1; attempt <= EDGE_UPDATE_ATTEMPTS; attempt += 1) {
     try {
-      return await performEdgeUpdate(ctx, input, session, target, options);
+      return await performEdgeUpdate(
+        ctx,
+        input,
+        session,
+        target,
+        options,
+        attempt === 1 ? resolvedExisting : undefined,
+      );
     } catch (error) {
       if (!(error instanceof EdgeUpdateTargetMoved)) throw error;
       if (attempt === EDGE_UPDATE_ATTEMPTS) {
@@ -2118,6 +2131,168 @@ export async function executeEdgeUpsertUpdate<G extends GraphDef>(
     options,
   );
   return outcome.edge;
+}
+
+/**
+ * Executes an already-resolved set of edge upsert updates under one write plan.
+ * The collection owns ordering and repeated-id resolution; this boundary keeps
+ * the complete set under one graph fence and one write session.
+ */
+export async function executeEdgeUpsertUpdateBatch<G extends GraphDef>(
+  ctx: EdgeOperationContext<G>,
+  entries: readonly EdgeUpsertUpdateBatchEntry[],
+  backend: GraphBackend | TransactionBackend,
+): Promise<readonly Edge[]> {
+  if (entries.length === 0) return [];
+  for (const entry of entries) {
+    if (entry.input.clearValidTo === true) {
+      assertClearValidToSupported(backend, "edge");
+    }
+  }
+
+  const first = requireDefined(entries[0]);
+  const distinctIds = new Set(entries.map((entry) => entry.input.id));
+  const atomicExecutor = resolveAtomicEdgeResolvedUpdateBatchExecutor({
+    backend,
+    graph: ctx.graph,
+    schemaVersion: ctx.schemaVersion,
+    historyEnabled: ctx.historyEnabled,
+    revisionTrackingEnabled: ctx.revisionTrackingEnabled,
+    kind: first.input.identity.kind,
+    entryCount: entries.length,
+  });
+  const atomicShape =
+    atomicExecutor !== undefined &&
+    distinctIds.size === entries.length &&
+    entries.every(
+      (entry) =>
+        !entry.clearDeleted &&
+        entry.input.validFrom === undefined &&
+        entry.input.validTo === undefined &&
+        entry.input.clearValidTo !== true,
+    );
+  if (atomicShape) {
+    const supplied = entries.flatMap((entry) =>
+      entry.existing === undefined ? [] : [entry.existing],
+    );
+    const fetched =
+      supplied.length === entries.length ?
+        undefined
+      : await getEdgeRowsByIds(backend, ctx.batchPointRead, ctx.graphId, [
+          ...distinctIds,
+        ]);
+    let existing = fetched === undefined ? supplied : [...fetched.values()];
+    for (let attempt = 1; attempt <= EDGE_UPDATE_ATTEMPTS; attempt += 1) {
+      const byId = new Map(existing.map((row) => [row.id, row]));
+      const missing = entries.find((entry) => {
+        const row = byId.get(entry.input.id);
+        return row === undefined || row.deleted_at !== undefined;
+      });
+      if (missing !== undefined) {
+        throw new EdgeNotFoundError(
+          first.input.identity.kind,
+          missing.input.id,
+        );
+      }
+      const resolved = entries.map((entry) => {
+        const row = requireDefined(byId.get(entry.input.id));
+        assertEdgeIdentityMatches(
+          entry.input.id,
+          entry.input.identity,
+          edgeIdentityFromRow(row),
+          "update",
+        );
+        const { validatedProps } = resolveEdgeUpdateProps(
+          ctx,
+          row,
+          entry.input.props,
+        );
+        return { existing: row, props: validatedProps };
+      });
+      const rows = await atomicExecutor({
+        entries: resolved,
+        schemaFence: {
+          graphId: ctx.graphId,
+          expectedVersion: requireDefined(ctx.schemaVersion),
+        },
+      });
+      if (rows.length === entries.length) {
+        memoizeLeasedSchemaFence(ctx, backend);
+        const returned = new Map(rows.map((row) => [row.id, row]));
+        return entries.map((entry) =>
+          rowToEdge(requireDefined(returned.get(entry.input.id))),
+        );
+      }
+      if (rows.length > 0) {
+        throw new CompilerInvariantError(
+          "Atomic resolved edge update returned a partial result.",
+          { expected: entries.length, actual: rows.length },
+        );
+      }
+      await diagnoseFusedSchemaFenceNoRow(ctx, backend);
+      if (attempt === EDGE_UPDATE_ATTEMPTS) {
+        throw new DatabaseOperationError(
+          `Atomic edge upsert batch could not be applied to stable rows after ${EDGE_UPDATE_ATTEMPTS} attempts.`,
+          {
+            operation: "update",
+            entity: "edge",
+            attempted: entries.map((entry) => ({
+              kind: entry.input.identity.kind,
+              id: entry.input.id,
+            })),
+          },
+        );
+      }
+      const refreshed = await getEdgeRowsByIds(
+        backend,
+        ctx.batchPointRead,
+        ctx.graphId,
+        [...distinctIds],
+      );
+      existing = [...refreshed.values()];
+    }
+  }
+
+  const needsConstraintFence = entries.some(
+    (entry) => entry.clearDeleted || entry.input.clearValidTo === true,
+  );
+  return runWritePlan(
+    ctx,
+    edgeWritePlan(
+      needsConstraintFence ?
+        edgeWriteNeedsConstraintFence(
+          edgeCardinality(ctx, first.input.identity.kind),
+        )
+      : undefined,
+    ),
+    backend,
+    async (session, target) => {
+      const resolvedRows =
+        (
+          target.capabilities.transactions &&
+          distinctIds.size === entries.length
+        ) ?
+          await getEdgeRowsByIds(target, ctx.batchPointRead, ctx.graphId, [
+            ...distinctIds,
+          ])
+        : undefined;
+      const edges: Edge[] = [];
+      for (const entry of entries) {
+        edges.push(
+          await performEdgeUpdateConverging(
+            ctx,
+            entry.input,
+            session,
+            target,
+            entry.clearDeleted ? { clearDeleted: true } : undefined,
+            resolvedRows?.get(entry.input.id),
+          ),
+        );
+      }
+      return edges;
+    },
+    { didWrite: writeResultAlwaysChanges },
+  );
 }
 
 /**

--- a/packages/typegraph/src/store/operations/index.ts
+++ b/packages/typegraph/src/store/operations/index.ts
@@ -33,6 +33,7 @@ export {
   executeEdgeHardDelete,
   executeEdgeUpdate,
   executeEdgeUpsertUpdate,
+  executeEdgeUpsertUpdateBatch,
 } from "./edge-operations";
 export {
   executeNodeBulkFindByConstraint,
@@ -50,6 +51,7 @@ export {
   executeNodeUpdate,
   executeNodeUpdateWhere,
   executeNodeUpsertUpdate,
+  executeNodeUpsertUpdateBatch,
   type NodeOperationContext,
   nodeUpsertDirtyCheck,
 } from "./node-operations";

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -145,7 +145,10 @@ import {
   planNodeCreateClaims,
 } from "../claims/node-claims";
 import { type UpsertDirtyCheck } from "../collections/coalesce";
-import { type UpsertUpdateNodeInput } from "../collections/node-collection";
+import {
+  type NodeUpsertUpdateBatchEntry,
+  type UpsertUpdateNodeInput,
+} from "../collections/node-collection";
 import {
   checkDisjointnessConstraint,
   type ConstraintContext,
@@ -185,6 +188,7 @@ import {
   assertAtomicDeleteSchemaFenceMatched,
   resolveAtomicNodeBatchExecutor,
   resolveAtomicNodeDeleteBatchExecutor,
+  resolveAtomicNodeResolvedUpdateBatchExecutor,
 } from "./atomic-mutation-program";
 import {
   AutocommitWriteRequiresTransaction,
@@ -1153,12 +1157,14 @@ async function performNodeUpdate<G extends GraphDef>(
   session: NodeWriteSession,
   target: WriteTarget,
   options?: Readonly<{ clearDeleted?: boolean }>,
+  resolvedExisting?: BackendNodeRow,
 ): Promise<Node> {
   const { kind, id } = input;
 
   assertValidityEndMutation(input, { entityType: "node", kind, id });
 
-  const existing = await target.getNode(ctx.graphId, kind, id);
+  const existing =
+    resolvedExisting ?? (await target.getNode(ctx.graphId, kind, id));
   if (!existing) throw new NodeNotFoundError(kind, id);
 
   const { registration, validatedProps } = resolveNodeUpdateProps(
@@ -1345,6 +1351,7 @@ async function performNodeUpdateWithResurrectionRecovery<G extends GraphDef>(
   session: NodeWriteSession,
   target: WriteTarget,
   options?: Readonly<{ clearDeleted?: boolean }>,
+  resolvedExisting?: BackendNodeRow,
 ): Promise<Node> {
   for (let attempt = 1; attempt <= NODE_UPDATE_ATTEMPTS; attempt += 1) {
     try {
@@ -1356,6 +1363,7 @@ async function performNodeUpdateWithResurrectionRecovery<G extends GraphDef>(
         session,
         target,
         attempt === 1 ? options : undefined,
+        attempt === 1 ? resolvedExisting : undefined,
       );
     } catch (error) {
       if (!isNodeUpdateNoRowError(error) || attempt === NODE_UPDATE_ATTEMPTS) {
@@ -2793,6 +2801,180 @@ export async function executeNodeUpsertUpdate<G extends GraphDef>(
         ]);
       }
       return node;
+    },
+    { didWrite: writeResultAlwaysChanges },
+  );
+}
+
+/**
+ * Executes an already-resolved set of node upsert updates under one write plan.
+ *
+ * Collection-level resolution still owns input order, repeated-id running
+ * state, and create/update partitioning. This boundary owns the database work:
+ * one graph fence and one write session cover the complete update set instead
+ * of opening a managed frame for every member.
+ */
+export async function executeNodeUpsertUpdateBatch<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  entries: readonly NodeUpsertUpdateBatchEntry[],
+  backend: GraphBackend | TransactionBackend,
+): Promise<readonly Node[]> {
+  if (entries.length === 0) return [];
+  for (const entry of entries) {
+    if (entry.input.clearValidTo === true) {
+      assertClearValidToSupported(backend, "node");
+    }
+  }
+
+  const first = requireDefined(entries[0]);
+  const distinctIds = new Set(entries.map((entry) => entry.input.id));
+  const atomicExecutor = resolveAtomicNodeResolvedUpdateBatchExecutor({
+    backend,
+    graph: ctx.graph,
+    schemaVersion: ctx.schemaVersion,
+    historyEnabled: ctx.historyEnabled,
+    revisionTrackingEnabled: ctx.revisionTrackingEnabled,
+    kind: first.input.kind,
+    entryCount: entries.length,
+    identityEnabled: ctx.identity !== undefined,
+    registry: ctx.registry,
+  });
+  const atomicShape =
+    atomicExecutor !== undefined &&
+    distinctIds.size === entries.length &&
+    entries.every(
+      (entry) =>
+        !entry.clearDeleted &&
+        entry.input.validFrom === undefined &&
+        entry.input.validTo === undefined &&
+        entry.input.clearValidTo !== true,
+    );
+  if (atomicShape) {
+    const supplied = entries.flatMap((entry) =>
+      entry.existing === undefined ? [] : [entry.existing],
+    );
+    const fetched =
+      supplied.length === entries.length ?
+        undefined
+      : await getNodeRowsByIds(
+          backend,
+          ctx.batchPointRead,
+          ctx.graphId,
+          first.input.kind,
+          [...distinctIds],
+        );
+    let existing = fetched === undefined ? supplied : [...fetched.values()];
+    for (let attempt = 1; attempt <= NODE_UPDATE_ATTEMPTS; attempt += 1) {
+      const byId = new Map(existing.map((row) => [row.id, row]));
+      const missing = entries.find((entry) => {
+        const row = byId.get(entry.input.id);
+        return row === undefined || row.deleted_at !== undefined;
+      });
+      if (missing !== undefined) {
+        throw new NodeNotFoundError(first.input.kind, missing.input.id);
+      }
+      const resolved = entries.map((entry) => {
+        const row = requireDefined(byId.get(entry.input.id));
+        const { validatedProps } = resolveNodeUpdateProps(
+          ctx,
+          row,
+          entry.input.props,
+        );
+        return {
+          graphId: ctx.graphId,
+          kind: entry.input.kind,
+          id: entry.input.id,
+          props: validatedProps,
+          expectedVersion: row.version,
+        };
+      });
+      const rows = await atomicExecutor({
+        entries: resolved,
+        schemaFence: {
+          graphId: ctx.graphId,
+          expectedVersion: requireDefined(ctx.schemaVersion),
+        },
+      });
+      if (rows.length === entries.length) {
+        memoizeLeasedSchemaFence(ctx, backend);
+        const returned = new Map(rows.map((row) => [row.id, row]));
+        return entries.map((entry) =>
+          rowToNode(requireDefined(returned.get(entry.input.id))),
+        );
+      }
+      if (rows.length > 0) {
+        throw new CompilerInvariantError(
+          "Atomic resolved node update returned a partial result.",
+          { expected: entries.length, actual: rows.length },
+        );
+      }
+      await diagnoseFusedSchemaFenceNoRow(ctx, backend);
+      if (attempt === NODE_UPDATE_ATTEMPTS) {
+        throw new DatabaseOperationError(
+          `Atomic node upsert batch could not be applied to stable rows after ${NODE_UPDATE_ATTEMPTS} attempts.`,
+          {
+            operation: "update",
+            entity: "node",
+            attempted: entries.map((entry) => ({
+              kind: entry.input.kind,
+              id: entry.input.id,
+            })),
+          },
+        );
+      }
+      const refreshed = await getNodeRowsByIds(
+        backend,
+        ctx.batchPointRead,
+        ctx.graphId,
+        first.input.kind,
+        [...distinctIds],
+      );
+      existing = [...refreshed.values()];
+    }
+  }
+
+  return runWritePlan(
+    nodeWritePlanContext(ctx),
+    nodeWritePlan(
+      nodeFencesConstraintProbe(ctx, first.input.kind, "update"),
+      entries.some(
+        (entry) => entry.clearDeleted || entry.input.validTo !== undefined,
+      ) && nodeRequiresIdentityLock(ctx),
+    ),
+    backend,
+    async (session, target) => {
+      const resolvedRows =
+        (
+          target.capabilities.transactions &&
+          distinctIds.size === entries.length
+        ) ?
+          await getNodeRowsByIds(
+            target,
+            ctx.batchPointRead,
+            ctx.graphId,
+            first.input.kind,
+            [...distinctIds],
+          )
+        : undefined;
+      const nodes: Node[] = [];
+      for (const entry of entries) {
+        nodes.push(
+          await performNodeUpdateWithResurrectionRecovery(
+            ctx,
+            entry.input,
+            session,
+            target,
+            entry.clearDeleted ? { clearDeleted: true } : undefined,
+            resolvedRows?.get(entry.input.id),
+          ),
+        );
+        if (entry.clearDeleted && ctx.identity !== undefined) {
+          await ctx.identity.foldCreated(target, [
+            { kind: entry.input.kind, id: entry.input.id },
+          ]);
+        }
+      }
+      return nodes;
     },
     { didWrite: writeResultAlwaysChanges },
   );

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -2871,6 +2871,10 @@ export async function executeNodeUpsertUpdateBatch<G extends GraphDef>(
         return row === undefined || row.deleted_at !== undefined;
       });
       if (missing !== undefined) {
+        // This update-only partition was resolved from live rows. Once a
+        // refreshed preimage is absent or tombstoned, the requested update
+        // target no longer exists; do not reinterpret it as a create or fall
+        // through to a transactionless portable write.
         throw new NodeNotFoundError(first.input.kind, missing.input.id);
       }
       const resolved = entries.map((entry) => {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -253,7 +253,7 @@ import {
   executeEdgeGetOrCreateByEndpoints,
   executeEdgeHardDelete,
   executeEdgeUpdate,
-  executeEdgeUpsertUpdate,
+  executeEdgeUpsertUpdateBatch,
   executeNodeBulkFindByConstraint,
   executeNodeBulkFindByIndex,
   executeNodeBulkGetOrCreateByConstraint,
@@ -267,7 +267,7 @@ import {
   executeNodeHardDelete,
   executeNodeUpdate,
   executeNodeUpdateWhere,
-  executeNodeUpsertUpdate,
+  executeNodeUpsertUpdateBatch,
   lockSchemaVersionForStoreWrite,
   type NodeOperationContext,
   nodeUpsertDirtyCheck,
@@ -1964,13 +1964,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
           candidateIdColumn,
           backend,
         ),
-      executeUpsertUpdate: (input, backend, options) =>
-        executeNodeUpsertUpdate(
-          ctx,
-          { ...input, id: input.id },
-          backend,
-          options,
-        ),
+      executeUpsertUpdateBatch: (entries, backend) =>
+        executeNodeUpsertUpdateBatch(ctx, entries, backend),
       // Present only when opted in; its absence is the coalesce off switch.
       ...(ctx.coalesceUnchangedUpsertsEnabled && {
         upsertDirtyCheck: (kind, id, existingProps, inputProps) =>
@@ -2055,8 +2050,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       executeCreateNoReturnBatch: (inputs, backend) =>
         executeEdgeCreateNoReturnBatch(ctx, inputs, backend),
       executeUpdate: (input, backend) => executeEdgeUpdate(ctx, input, backend),
-      executeUpsertUpdate: (input, backend, options) =>
-        executeEdgeUpsertUpdate(ctx, input, backend, options),
+      executeUpsertUpdateBatch: (entries, backend) =>
+        executeEdgeUpsertUpdateBatch(ctx, entries, backend),
       // Present only when opted in; its absence is the coalesce off switch.
       ...(ctx.coalesceUnchangedUpsertsEnabled && {
         upsertDirtyCheck: (kind, id, existingProps, inputProps) =>

--- a/packages/typegraph/tests/atomic-resolved-update-batch-pglite.test.ts
+++ b/packages/typegraph/tests/atomic-resolved-update-batch-pglite.test.ts
@@ -1,0 +1,115 @@
+import { type SQL, sql as drizzleSql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { buildAtomicEdgeResolvedUpdateBatch } from "../src/backend/drizzle/operations/edges";
+import { buildAtomicNodeResolvedUpdateBatch } from "../src/backend/drizzle/operations/nodes";
+import { tables } from "../src/backend/drizzle/schema/postgres";
+import { createLocalPgliteBackend } from "../src/backend/postgres/pglite";
+import { rowPropsToObject } from "../src/backend/types";
+import { defineEdge, defineGraph, defineNode } from "../src/core";
+import { createStoreWithSchema } from "../src/store";
+import { requireDefined } from "../src/utils/presence";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), score: z.number() }),
+});
+const knows = defineEdge("knows", {
+  schema: z.object({ label: z.string() }),
+});
+const graph = defineGraph({
+  id: "atomic-resolved-update-batch-pglite",
+  nodes: { Person: { type: Person } },
+  edges: { knows: { type: knows, from: [Person], to: [Person] } },
+});
+
+function compile(query: SQL) {
+  return new PgDialect().sqlToQuery(query);
+}
+
+describe("resolved update sets on a real PostgreSQL engine", () => {
+  it("executes guarded node and edge set updates", async () => {
+    const local = await createLocalPgliteBackend({ vector: false });
+    try {
+      const [store] = await createStoreWithSchema(graph, local.backend);
+      const nodes = await store.nodes.Person.bulkCreate([
+        { id: "a", props: { name: "A", score: 1 } },
+        { id: "b", props: { name: "B", score: 2 } },
+      ]);
+      const edges = await store.edges.knows.bulkCreate([
+        {
+          id: "first",
+          from: requireDefined(nodes[0]),
+          to: requireDefined(nodes[1]),
+          props: { label: "First" },
+        },
+        {
+          id: "second",
+          from: requireDefined(nodes[1]),
+          to: requireDefined(nodes[0]),
+          props: { label: "Second" },
+        },
+      ]);
+      const nodeRows = await requireDefined(local.backend.getNodes)(
+        graph.id,
+        Person.kind,
+        nodes.map((node) => node.id),
+      );
+      const edgeRows = await requireDefined(local.backend.getEdges)(
+        graph.id,
+        edges.map((edge) => edge.id),
+      );
+      const schemaFence = { graphId: graph.id, expectedVersion: 1 } as const;
+      const timestamp = "2026-08-27T00:00:00.000Z";
+
+      const nodeUpdate = compile(
+        buildAtomicNodeResolvedUpdateBatch(
+          tables,
+          nodeRows.map((row) => ({
+            graphId: row.graph_id,
+            kind: row.kind,
+            id: row.id,
+            props: { ...rowPropsToObject(row.props), score: 10 },
+            expectedVersion: row.version,
+          })),
+          timestamp,
+          schemaFence,
+          drizzleSql`FOR SHARE`,
+        ),
+      );
+      const edgeUpdate = compile(
+        buildAtomicEdgeResolvedUpdateBatch(
+          tables,
+          edgeRows.map((existing) => ({
+            existing,
+            props: {
+              label: `${String(rowPropsToObject(existing.props)["label"])} updated`,
+            },
+          })),
+          timestamp,
+          schemaFence,
+          drizzleSql`FOR SHARE`,
+        ),
+      );
+      await local.client.query(nodeUpdate.sql, nodeUpdate.params);
+      await local.client.query(edgeUpdate.sql, edgeUpdate.params);
+
+      const updatedNodes = await store.nodes.Person.getByIds(
+        nodes.map((node) => node.id),
+      );
+      const updatedEdges = await store.edges.knows.getByIds(
+        edges.map((edge) => edge.id),
+      );
+      expect(updatedNodes.map((node) => requireDefined(node).score)).toEqual([
+        10, 10,
+      ]);
+      expect(updatedEdges.map((edge) => requireDefined(edge).label)).toEqual([
+        "First updated",
+        "Second updated",
+      ]);
+    } finally {
+      await local.backend.close();
+    }
+  });
+});

--- a/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
+++ b/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
@@ -157,6 +157,47 @@ describe("atomic resolved update batches", () => {
     ).rejects.toBeInstanceOf(CompilerInvariantError);
   });
 
+  it("refuses a resolved edge set with mixed kinds at the executor seam", async () => {
+    const { backend, profile, store } = await fixture();
+    const [from, to] = await store.nodes.Person.bulkCreate([
+      { id: "from", props: { name: "From", score: 1 } },
+      { id: "to", props: { name: "To", score: 2 } },
+    ]);
+    const edges = await store.edges.relates.bulkCreate([
+      {
+        id: "a",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "A" },
+      },
+      {
+        id: "b",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "B" },
+      },
+    ]);
+    const rows = await requireDefined(backend.getEdges)(
+      graph.id,
+      edges.map((edge) => edge.id),
+    );
+    const first = requireDefined(rows[0]);
+    const second = requireDefined(rows[1]);
+
+    await expect(
+      requireDefined(profile.updateEdges)({
+        entries: [
+          { existing: first, props: { label: "resolved" } },
+          {
+            existing: { ...second, kind: "another-kind" },
+            props: { label: "resolved" },
+          },
+        ],
+        schemaFence: { graphId: graph.id, expectedVersion: 1 },
+      }),
+    ).rejects.toBeInstanceOf(CompilerInvariantError);
+  });
+
   it("updates no edge when one preimage moved", async () => {
     const { backend, profile, store } = await fixture();
     const [from, to] = await store.nodes.Person.bulkCreate([

--- a/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
+++ b/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@libsql/client";
+import { eq, sql as drizzleSql } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
@@ -6,12 +7,18 @@ import {
   markBundledRootAtomicMutationPrograms,
   resolveBundledRootAtomicMutationPrograms,
 } from "../src/backend/capabilities/atomic-mutation-program";
+import { tables as sqliteTables } from "../src/backend/drizzle/schema/sqlite";
 import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { rowPropsToObject } from "../src/backend/types";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
-import { CompilerInvariantError } from "../src/errors";
+import { CompilerInvariantError, DatabaseOperationError } from "../src/errors";
+import { buildKindRegistry } from "../src/registry";
 import { createStoreWithSchema, createVerifiedStore } from "../src/store";
+import {
+  resolveAtomicEdgeResolvedUpdateBatchExecutor,
+  resolveAtomicNodeResolvedUpdateBatchExecutor,
+} from "../src/store/operations/atomic-mutation-program";
 import { requireDefined } from "../src/utils/presence";
 
 const Person = defineNode("Person", {
@@ -20,11 +27,26 @@ const Person = defineNode("Person", {
 const relates = defineEdge("relates", {
   schema: z.object({ label: z.string() }),
 });
+const durableRelates = defineEdge("durableRelates", {
+  schema: z.object({ label: z.string() }),
+});
 const graph = defineGraph({
   id: "atomic-resolved-update-batch",
   nodes: { Person: { type: Person } },
   edges: {
     relates: { type: relates, from: [Person], to: [Person] },
+  },
+});
+const durableGraph = defineGraph({
+  id: "atomic-resolved-update-batch-durable",
+  nodes: { Person: { type: Person } },
+  edges: {
+    durableRelates: {
+      type: durableRelates,
+      from: [Person],
+      to: [Person],
+      matchIdentity: { name: "label", fields: ["label"] },
+    },
   },
 });
 
@@ -178,6 +200,121 @@ describe("atomic resolved update batches", () => {
     });
   });
 
+  it("asserts stored NULL edge validity bounds in the preimage guard", async () => {
+    const { backend, db, profile, store } = await fixture();
+    const [from, to] = await store.nodes.Person.bulkCreate([
+      { id: "from", props: { name: "From", score: 1 } },
+      { id: "to", props: { name: "To", score: 2 } },
+    ]);
+    const edges = await store.edges.relates.bulkCreate([
+      {
+        id: "a",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "A" },
+      },
+      {
+        id: "b",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "B" },
+      },
+    ]);
+    await db
+      .update(sqliteTables.edges)
+      .set({ validFrom: drizzleSql`NULL` })
+      .where(eq(sqliteTables.edges.id, "a"));
+    const beforeFrom = requireDefined(
+      await backend.getEdge(graph.id, requireDefined(edges[0]).id),
+    );
+    const beforeTo = requireDefined(
+      await backend.getEdge(graph.id, requireDefined(edges[1]).id),
+    );
+    await db
+      .update(sqliteTables.edges)
+      .set({ validFrom: "2026-08-27T00:00:00.000Z" })
+      .where(eq(sqliteTables.edges.id, "a"));
+
+    await expect(
+      requireDefined(profile.updateEdges)({
+        entries: [{ existing: beforeFrom, props: { label: "resolved" } }],
+        schemaFence: { graphId: graph.id, expectedVersion: 1 },
+      }),
+    ).resolves.toEqual([]);
+
+    await db
+      .update(sqliteTables.edges)
+      .set({ validTo: "2026-08-28T00:00:00.000Z" })
+      .where(eq(sqliteTables.edges.id, "b"));
+    await expect(
+      requireDefined(profile.updateEdges)({
+        entries: [{ existing: beforeTo, props: { label: "resolved" } }],
+        schemaFence: { graphId: graph.id, expectedVersion: 1 },
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("pins the D1 eligibility ceilings and refuses durable match identity", async () => {
+    const { db } = await fixture();
+    const budgetedBackend = createSqliteBackend(db, {
+      capabilities: { maxBindParameters: 100 },
+      executionProfile: { isSync: false, transactionMode: "none" },
+    });
+    const profile = requireDefined(
+      resolveBundledRootAtomicMutationPrograms(budgetedBackend),
+    );
+    expect(requireDefined(profile.updateNodes).maxEntries).toBe(17);
+    expect(requireDefined(profile.updateEdges).maxEntries).toBe(6);
+
+    const common = {
+      backend: budgetedBackend,
+      graph,
+      schemaVersion: 1,
+      historyEnabled: false,
+      revisionTrackingEnabled: false,
+    } as const;
+    const nodeInput = {
+      ...common,
+      kind: Person.kind,
+      identityEnabled: false,
+      registry: buildKindRegistry(graph),
+    } as const;
+    expect(
+      resolveAtomicNodeResolvedUpdateBatchExecutor({
+        ...nodeInput,
+        entryCount: 17,
+      }),
+    ).toBe(profile.updateNodes);
+    expect(
+      resolveAtomicNodeResolvedUpdateBatchExecutor({
+        ...nodeInput,
+        entryCount: 18,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveAtomicEdgeResolvedUpdateBatchExecutor({
+        ...common,
+        kind: relates.kind,
+        entryCount: 6,
+      }),
+    ).toBe(profile.updateEdges);
+    expect(
+      resolveAtomicEdgeResolvedUpdateBatchExecutor({
+        ...common,
+        kind: relates.kind,
+        entryCount: 7,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveAtomicEdgeResolvedUpdateBatchExecutor({
+        ...common,
+        graph: durableGraph,
+        kind: durableRelates.kind,
+        entryCount: 1,
+      }),
+    ).toBeUndefined();
+  });
+
   it("re-resolves the complete node set after a moved preimage", async () => {
     const { db, store } = await fixture();
     const nodes = await store.nodes.Person.bulkCreate([
@@ -218,5 +355,108 @@ describe("atomic resolved update batches", () => {
 
     expect(retrying).toHaveBeenCalledTimes(2);
     expect(updated.map((node) => node.score)).toEqual([10, 10]);
+  });
+
+  it("re-resolves the complete edge set after a moved preimage", async () => {
+    const { db, store } = await fixture();
+    const [from, to] = await store.nodes.Person.bulkCreate([
+      { id: "from", props: { name: "From", score: 1 } },
+      { id: "to", props: { name: "To", score: 2 } },
+    ]);
+    const edges = await store.edges.relates.bulkCreate([
+      {
+        id: "a",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "A" },
+      },
+      {
+        id: "b",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "B" },
+      },
+    ]);
+    const transactionlessBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: false, transactionMode: "none" },
+    });
+    const [transactionlessStore] = await createVerifiedStore(
+      graph,
+      transactionlessBackend,
+    );
+    const profile = requireDefined(
+      resolveBundledRootAtomicMutationPrograms(transactionlessBackend),
+    );
+    const original = requireDefined(profile.updateEdges);
+    let attempts = 0;
+    const run = vi.fn(async (input: Parameters<typeof original>[0]) => {
+      attempts += 1;
+      if (attempts === 1) return [];
+      return original(input);
+    });
+    const retrying = Object.assign(run, {
+      maxEntries: original.maxEntries,
+    }) satisfies typeof original;
+    markBundledRootAtomicMutationPrograms(transactionlessBackend, {
+      ...profile,
+      updateEdges: retrying,
+    });
+
+    const updated = await transactionlessStore.edges.relates.bulkUpsertById(
+      edges.map((edge) => ({
+        id: edge.id,
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: `${edge.label} updated` },
+      })),
+    );
+
+    expect(retrying).toHaveBeenCalledTimes(2);
+    expect(updated.map((edge) => edge.label)).toEqual([
+      "A updated",
+      "B updated",
+    ]);
+  });
+
+  it("fails closed when the resolved node set never stabilizes", async () => {
+    const { db, store } = await fixture();
+    const nodes = await store.nodes.Person.bulkCreate([
+      { id: "a", props: { name: "A", score: 1 } },
+      { id: "b", props: { name: "B", score: 2 } },
+    ]);
+    const transactionlessBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: false, transactionMode: "none" },
+    });
+    const [transactionlessStore] = await createVerifiedStore(
+      graph,
+      transactionlessBackend,
+    );
+    const profile = requireDefined(
+      resolveBundledRootAtomicMutationPrograms(transactionlessBackend),
+    );
+    const original = requireDefined(profile.updateNodes);
+    const refusing = Object.assign(
+      vi.fn(() => Promise.resolve([])),
+      {
+        maxEntries: original.maxEntries,
+      },
+    ) satisfies typeof original;
+    markBundledRootAtomicMutationPrograms(transactionlessBackend, {
+      ...profile,
+      updateNodes: refusing,
+    });
+
+    await expect(
+      transactionlessStore.nodes.Person.bulkUpsertById(
+        nodes.map((node) => ({
+          id: node.id,
+          props: { name: node.name, score: 10 },
+        })),
+      ),
+    ).rejects.toBeInstanceOf(DatabaseOperationError);
+    expect(refusing).toHaveBeenCalledTimes(2);
+    await expect(
+      transactionlessStore.nodes.Person.getByIds(nodes.map((node) => node.id)),
+    ).resolves.toEqual(nodes);
   });
 });

--- a/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
+++ b/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
@@ -1,0 +1,222 @@
+import { createClient } from "@libsql/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  markBundledRootAtomicMutationPrograms,
+  resolveBundledRootAtomicMutationPrograms,
+} from "../src/backend/capabilities/atomic-mutation-program";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
+import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
+import { rowPropsToObject } from "../src/backend/types";
+import { defineEdge, defineGraph, defineNode } from "../src/core";
+import { CompilerInvariantError } from "../src/errors";
+import { createStoreWithSchema, createVerifiedStore } from "../src/store";
+import { requireDefined } from "../src/utils/presence";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), score: z.number() }),
+});
+const relates = defineEdge("relates", {
+  schema: z.object({ label: z.string() }),
+});
+const graph = defineGraph({
+  id: "atomic-resolved-update-batch",
+  nodes: { Person: { type: Person } },
+  edges: {
+    relates: { type: relates, from: [Person], to: [Person] },
+  },
+});
+
+describe("atomic resolved update batches", () => {
+  const clients: ReturnType<typeof createClient>[] = [];
+
+  afterEach(() => {
+    for (const client of clients) client.close();
+    clients.length = 0;
+  });
+
+  async function fixture() {
+    const client = createClient({ url: "file::memory:" });
+    clients.push(client);
+    const { backend, db } = await createLibsqlBackend(client);
+    const [store] = await createStoreWithSchema(graph, backend);
+    const profile = requireDefined(
+      resolveBundledRootAtomicMutationPrograms(backend),
+    );
+    return { backend, db, profile, store };
+  }
+
+  it("updates distinct nodes as one guarded set", async () => {
+    const { backend, profile, store } = await fixture();
+    const nodes = await store.nodes.Person.bulkCreate([
+      { id: "a", props: { name: "A", score: 1 } },
+      { id: "b", props: { name: "B", score: 2 } },
+    ]);
+    const before = await requireDefined(backend.getNodes)(
+      graph.id,
+      Person.kind,
+      nodes.map((node) => node.id),
+    );
+    const executor = requireDefined(profile.updateNodes);
+    const rows = await executor({
+      entries: before.map((row) => ({
+        graphId: graph.id,
+        kind: row.kind,
+        id: row.id,
+        props: { ...rowPropsToObject(row.props), score: 10 },
+        expectedVersion: row.version,
+      })),
+      schemaFence: { graphId: graph.id, expectedVersion: 1 },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.version)).toEqual([2, 2]);
+    expect(rows.map((row) => rowPropsToObject(row.props)["score"])).toEqual([
+      10, 10,
+    ]);
+  });
+
+  it("updates no node when one preimage moved", async () => {
+    const { backend, profile, store } = await fixture();
+    await store.nodes.Person.bulkCreate([
+      { id: "a", props: { name: "A", score: 1 } },
+      { id: "b", props: { name: "B", score: 2 } },
+    ]);
+    const before = await requireDefined(backend.getNodes)(
+      graph.id,
+      Person.kind,
+      ["a", "b"],
+    );
+    await store.nodes.Person.update("a" as never, { score: 3 });
+
+    const rows = await requireDefined(profile.updateNodes)({
+      entries: before.map((row) => ({
+        graphId: graph.id,
+        kind: row.kind,
+        id: row.id,
+        props: { ...rowPropsToObject(row.props), score: 10 },
+        expectedVersion: row.version,
+      })),
+      schemaFence: { graphId: graph.id, expectedVersion: 1 },
+    });
+
+    expect(rows).toEqual([]);
+    expect(await store.nodes.Person.getById("a" as never)).toMatchObject({
+      score: 3,
+    });
+    expect(await store.nodes.Person.getById("b" as never)).toMatchObject({
+      score: 2,
+    });
+  });
+
+  it("refuses a resolved node set that is not bound to its fence", async () => {
+    const { backend, profile, store } = await fixture();
+    await store.nodes.Person.bulkCreate([
+      { id: "a", props: { name: "A", score: 1 } },
+    ]);
+    const row = requireDefined(
+      await backend.getNode(graph.id, Person.kind, "a"),
+    );
+
+    await expect(
+      requireDefined(profile.updateNodes)({
+        entries: [
+          {
+            graphId: "another-graph",
+            kind: row.kind,
+            id: row.id,
+            props: rowPropsToObject(row.props),
+            expectedVersion: row.version,
+          },
+        ],
+        schemaFence: { graphId: graph.id, expectedVersion: 1 },
+      }),
+    ).rejects.toBeInstanceOf(CompilerInvariantError);
+  });
+
+  it("updates no edge when one preimage moved", async () => {
+    const { backend, profile, store } = await fixture();
+    const [from, to] = await store.nodes.Person.bulkCreate([
+      { id: "from", props: { name: "From", score: 1 } },
+      { id: "to", props: { name: "To", score: 2 } },
+    ]);
+    const edges = await store.edges.relates.bulkCreate([
+      {
+        id: "a",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "A" },
+      },
+      {
+        id: "b",
+        from: requireDefined(from),
+        to: requireDefined(to),
+        props: { label: "B" },
+      },
+    ]);
+    const before = await requireDefined(backend.getEdges)(
+      graph.id,
+      edges.map((edge) => edge.id),
+    );
+    await store.edges.relates.update("a" as never, { label: "moved" });
+
+    const rows = await requireDefined(profile.updateEdges)({
+      entries: before.map((existing) => ({
+        existing,
+        props: { label: "resolved" },
+      })),
+      schemaFence: { graphId: graph.id, expectedVersion: 1 },
+    });
+
+    expect(rows).toEqual([]);
+    expect(await store.edges.relates.getById("a" as never)).toMatchObject({
+      label: "moved",
+    });
+    expect(await store.edges.relates.getById("b" as never)).toMatchObject({
+      label: "B",
+    });
+  });
+
+  it("re-resolves the complete node set after a moved preimage", async () => {
+    const { db, store } = await fixture();
+    const nodes = await store.nodes.Person.bulkCreate([
+      { id: "a", props: { name: "A", score: 1 } },
+      { id: "b", props: { name: "B", score: 2 } },
+    ]);
+    const transactionlessBackend = createSqliteBackend(db, {
+      executionProfile: { isSync: false, transactionMode: "none" },
+    });
+    const [transactionlessStore] = await createVerifiedStore(
+      graph,
+      transactionlessBackend,
+    );
+    const profile = requireDefined(
+      resolveBundledRootAtomicMutationPrograms(transactionlessBackend),
+    );
+    const original = requireDefined(profile.updateNodes);
+    let attempts = 0;
+    const run = vi.fn(async (input: Parameters<typeof original>[0]) => {
+      attempts += 1;
+      if (attempts === 1) return [];
+      return original(input);
+    });
+    const retrying = Object.assign(run, {
+      maxEntries: original.maxEntries,
+    }) satisfies typeof original;
+    markBundledRootAtomicMutationPrograms(transactionlessBackend, {
+      ...profile,
+      updateNodes: retrying,
+    });
+
+    const updated = await transactionlessStore.nodes.Person.bulkUpsertById(
+      nodes.map((node) => ({
+        id: node.id,
+        props: { name: node.name, score: 10 },
+      })),
+    );
+
+    expect(retrying).toHaveBeenCalledTimes(2);
+    expect(updated.map((node) => node.score)).toEqual([10, 10]);
+  });
+});

--- a/packages/typegraph/tests/drizzle-claim-sites.test.ts
+++ b/packages/typegraph/tests/drizzle-claim-sites.test.ts
@@ -37,13 +37,13 @@ const RECORDED_CLAIM_SITES: readonly RecordedClaimSite[] = [
   },
   {
     file: "apps/docs/src/content/docs/architecture.md",
-    line: 656,
+    line: 659,
     text:
       "graph DSL and its schema-derived types from the " + CLAIM_WORD + "-free",
   },
   {
     file: "apps/docs/src/content/docs/architecture.md",
-    line: 658,
+    line: 661,
     text:
       "import the full " +
       CLAIM_WORD +

--- a/packages/typegraph/tests/temporal-builder-inventory.test.ts
+++ b/packages/typegraph/tests/temporal-builder-inventory.test.ts
@@ -103,6 +103,9 @@ const LEAK_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
     "if (params.clearDeleted && params.validFrom !== undefined) {",
     // The fence's column argument, as for nodes.
     "edges.validFrom,",
+    // The resolved-set update compares the caller's already-read temporal
+    // preimage; the caller remains the owner of the new stamped bound.
+    "${expectedValidFromPredicate(edges.validFrom, existing.valid_from)}",
   ],
   "drizzle/trusted-import.ts": [
     // Column lists and projections in the two dialects' INSERT text. They name

--- a/packages/typegraph/tests/temporal-builder-inventory.test.ts
+++ b/packages/typegraph/tests/temporal-builder-inventory.test.ts
@@ -105,7 +105,7 @@ const LEAK_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
     "edges.validFrom,",
     // The resolved-set update compares the caller's already-read temporal
     // preimage; the caller remains the owner of the new stamped bound.
-    "${expectedValidFromPredicate(edges.validFrom, existing.valid_from)}",
+    "${expectedValidFromPredicate(edges.validFrom, existing.valid_from ?? EXPECTED_SQL_NULL)}",
   ],
   "drizzle/trusted-import.ts": [
     // Column lists and projections in the two dialects' INSERT text. They name

--- a/packages/typegraph/tests/write-exchange-inventory.test.ts
+++ b/packages/typegraph/tests/write-exchange-inventory.test.ts
@@ -6,9 +6,11 @@ import { createClient } from "@libsql/client";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
+import { resolveBundledRootAtomicMutationPrograms } from "../src/backend/capabilities/atomic-mutation-program";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
-import { createStoreWithSchema } from "../src/store";
+import { createStoreWithSchema, createVerifiedStore } from "../src/store";
 
 const Person = defineNode("Person", {
   schema: z.object({ name: z.string() }),
@@ -19,7 +21,13 @@ const Company = defineNode("Company", {
 const ClaimedPerson = defineNode("ClaimedPerson", {
   schema: z.object({ name: z.string() }),
 });
-const worksAt = defineEdge("worksAt", {
+const unconstrained = defineEdge("unconstrained", {
+  schema: z.object({ role: z.string() }),
+});
+const constrained = defineEdge("constrained", {
+  schema: z.object({ role: z.string() }),
+});
+const durable = defineEdge("durable", {
   schema: z.object({ role: z.string() }),
 });
 const graph = defineGraph({
@@ -41,18 +49,18 @@ const graph = defineGraph({
   },
   edges: {
     unconstrained: {
-      type: worksAt,
+      type: unconstrained,
       from: [Person],
       to: [Company],
     },
     constrained: {
-      type: worksAt,
+      type: constrained,
       from: [Person],
       to: [Company],
       cardinality: "one",
     },
     durable: {
-      type: worksAt,
+      type: durable,
       from: [Person],
       to: [Company],
       matchIdentity: { name: "role", fields: ["role"] },
@@ -68,9 +76,20 @@ describe("managed write exchange inventory", () => {
     const client = createClient({
       url: `file:${path.join(temporaryDirectory, "graph.db")}`,
     });
-    const { backend } = await createLibsqlBackend(client);
+    const { backend, db } = await createLibsqlBackend(client);
     try {
       const [store] = await createStoreWithSchema(graph, backend);
+      const transactionlessBackend = createSqliteBackend(db, {
+        executionProfile: { isSync: false, transactionMode: "none" },
+      });
+      const [transactionlessStore] = await createVerifiedStore(
+        graph,
+        transactionlessBackend,
+      );
+      expect(
+        resolveBundledRootAtomicMutationPrograms(transactionlessBackend)
+          ?.updateEdges,
+      ).toBeDefined();
       const from = await store.nodes.Person.create({ name: "Alice" });
       const to = await store.nodes.Company.create({ name: "Acme" });
       const deletableEdges = await store.edges.unconstrained.bulkCreate([
@@ -80,6 +99,14 @@ describe("managed write exchange inventory", () => {
       const deletableNodes = await store.nodes.Person.bulkCreate([
         { props: { name: "Delete Node A" } },
         { props: { name: "Delete Node B" } },
+      ]);
+      const upsertableNodes = await store.nodes.Person.bulkCreate([
+        { props: { name: "Upsert Node A" } },
+        { props: { name: "Upsert Node B" } },
+      ]);
+      const upsertableEdges = await store.edges.unconstrained.bulkCreate([
+        { from, to, props: { role: "Upsert Edge A" } },
+        { from, to, props: { role: "Upsert Edge B" } },
       ]);
       const execute = vi.spyOn(client, "execute");
       const batch = vi.spyOn(client, "batch");
@@ -172,6 +199,24 @@ describe("managed write exchange inventory", () => {
         await measure("node-delete-batch", () =>
           store.nodes.Person.bulkDelete(deletableNodes.map((node) => node.id)),
         ),
+        await measure("node-update-upsert-batch", () =>
+          transactionlessStore.nodes.Person.bulkUpsertById(
+            upsertableNodes.map((node, index) => ({
+              id: node.id,
+              props: { name: `Updated Node ${index}` },
+            })),
+          ),
+        ),
+        await measure("edge-update-upsert-batch", () =>
+          transactionlessStore.edges.unconstrained.bulkUpsertById(
+            upsertableEdges.map((edge, index) => ({
+              id: edge.id,
+              from,
+              to,
+              props: { role: `Updated Edge ${index}` },
+            })),
+          ),
+        ),
       ];
 
       expect(measurements).toMatchInlineSnapshot(`
@@ -240,6 +285,16 @@ describe("managed write exchange inventory", () => {
             "batch": 1,
             "execute": 0,
             "name": "node-delete-batch",
+          },
+          {
+            "batch": 1,
+            "execute": 1,
+            "name": "node-update-upsert-batch",
+          },
+          {
+            "batch": 1,
+            "execute": 1,
+            "name": "edge-update-upsert-batch",
           },
         ]
       `);

--- a/packages/typegraph/vitest.pglite-project.ts
+++ b/packages/typegraph/vitest.pglite-project.ts
@@ -8,6 +8,7 @@ export const PGLITE_TEST_FILES = [
   "tests/atomic-generated-edge-batch-pglite.test.ts",
   "tests/atomic-generated-node-batch-pglite.test.ts",
   "tests/atomic-node-batch-sql.test.ts",
+  "tests/atomic-resolved-update-batch-pglite.test.ts",
   "tests/base-schema-adoption.test.ts",
   "tests/capability-bundle-dialect-honesty.test.ts",
   "tests/capability-declaration-validation.test.ts",


### PR DESCRIPTION
Extend the unified exact-root mutation profile with resolved node and edge update executors so eligible update-only `bulkUpsertById()` batches pay one batched preimage read and one guarded set update instead of opening a managed write frame for every member.

Consolidate all fallback updates under one write plan and use batched authoritative reads inside transaction-capable sessions. Repeated IDs retain their running-state semantics, while creates, temporal changes, resurrections, sidecars, history/revision capture, constrained edge cardinalities, durable edge match identity, and caller-owned transactions remain on the complete interactive path.

## Architecture

Treat these operations as resolved mutation sets rather than closed SQL programs. Collection code remains the owner of input ordering and create/update partitioning; store operations resolve and validate after-images; the exact-root backend receives node versions or complete mutable edge preimages and applies every member or none. Eligibility has one owner and is bound to the exact bundled root through the existing capability profile.

A zero-row native result is not treated as success. The store first diagnoses the schema fence, refreshes the complete preimage set, and retries once. Partial results are compiler invariants, and repeated movement produces a typed database operation failure instead of falling through to an unsafe transactionless path. A refreshed missing or tombstoned row remains a typed not-found update target rather than being reinterpreted as a create.

The edge guard asserts kind, endpoints, props, update time, and both validity bounds. `EdgeRow` represents SQL `NULL` as `undefined`, so the builder explicitly translates that stored representation into the predicate helper's `IS NULL` assertion instead of silently omitting the bound.

## Performance

At the libSQL transport boundary, the measured two-row node and edge update-only upsert cases fall from 9 submissions to 2, a 78% reduction. The optimized shape is one batched preimage read plus one atomic set update, so the submission count remains 2 as the batch grows within the backend bind budget.

On D1's 100-parameter budget, the exact-root ceiling is 17 node updates or 6 edge updates. Larger batches return to the consolidated interactive path rather than splitting an all-or-nothing guard across autocommit statements. Other backends derive their ceiling from their declared parameter budget.

## Safety evidence

The all-member count gate has load-bearing mutation evidence: forcing an incorrect expected count makes the guarded happy-path test return zero rows. The nullable validity guard is independently mutation-checked: removing the SQL-null translation lets a drifted edge update and makes the regression fail. Boundary coverage pins the D1 ceiling and fallback at `maxEntries + 1`, edge retry re-resolution, terminal fail-closed behavior, and refusal of durable match identity.

## Compatibility and documentation

Unsupported shapes preserve the portable semantics through the consolidated write-plan path. The architecture, performance guide, limitations, temporal inventory, exchange inventory, and release changeset document the resolved-set boundary, eligibility exclusions, and bind-budget cliff.
