### PR TITLE
fix: refuse dishonest Store transactions on transactionless backends

### DIFF
--- a/.changeset/transaction-boundary-honesty.md
+++ b/.changeset/transaction-boundary-honesty.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Make `store.transaction()` and `store.transactionWithReceipt()` fail closed on backends without transaction support instead of invoking callbacks with non-atomic write semantics.

--- a/.changeset/transaction-boundary-honesty.md
+++ b/.changeset/transaction-boundary-honesty.md
@@ -1,5 +1,5 @@
 ---
-"@nicia-ai/typegraph": patch
+"@nicia-ai/typegraph": minor
 ---
 
-Make `store.transaction()` and `store.transactionWithReceipt()` fail closed on backends without transaction support instead of invoking callbacks with non-atomic write semantics.
+Make `store.transaction()` and `store.transactionWithReceipt()` fail closed on backends without transaction support instead of invoking callbacks with non-atomic write semantics. Applications that intentionally relied on the old D1 or Neon HTTP fallthrough must call ordinary Store write methods directly and own partial-failure recovery explicitly.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -256,9 +256,9 @@ Both Neon drivers work with TypeGraph. They have different tradeoffs:
 - **`drizzle-orm/neon-http`** uses HTTP per statement. Lowest cold-start cost; survives Workers'
   per-request isolation. **Cannot hold a session across statements**, so multi-statement transactions
   are unavailable — TypeGraph auto-detects this driver and sets `capabilities.transactions = false`,
-  so `store.transaction(...)` on a raw Store falls through to non-transactional sequential execution.
-  A schema-managed Store may attach for reads, but its first write fails closed because the driver
-  cannot hold the schema-version fence.
+  so `store.transaction(...)` refuses before invoking its callback. A schema-managed Store may
+  attach for reads, but its first unsupported write also fails closed because the driver cannot
+  hold the schema-version fence.
 - **`drizzle-orm/neon-serverless`** uses a WebSocket Pool. Holds a session, supports full transactional
   semantics, but the WebSocket connection lifecycle needs care in serverless / per-request contexts
   (you typically want a fresh Pool per request).
@@ -373,8 +373,8 @@ Edge runtimes expose `WebSocket` globally and need no extra setup.
 For stateless edge workloads where you don't need transactional writes. The HTTP
 driver issues one request per query — lowest cold-start cost, no session lifecycle
 to manage. TypeGraph auto-detects this driver and sets `capabilities.transactions`
-to `false`. On a raw Store, `store.transaction(...)` falls through to sequential
-execution rather than throwing. Eligible plain node batches and
+to `false`. `store.transaction(...)` refuses before invoking its callback rather
+than presenting sequential writes as atomic. Eligible plain node batches and
 `cardinality: "many"` edge creates use the authoritative one-statement command
 even on a schema-managed Store; other managed writes fail closed when they
 need an interactive schema or constraint fence.
@@ -1090,7 +1090,8 @@ transaction runner.
 
 **Important:** D1 has no interactive transaction primitive
 (`D1Database.batch(...)` is transactional, but batch-only — not an
-interactive runner), so `store.transaction()` is non-atomic on D1. See
+interactive runner), so `store.transaction()` refuses on D1 before invoking
+its callback. See
 [Limitations](/limitations) for details. For a transactional Cloudflare
 SQLite store, use **Durable Objects** (below) instead.
 
@@ -1596,9 +1597,10 @@ SQLite those run as `json_each()` scans — correct results, just not index-acce
 Both backends report `transactions: true` by default. The exception is symmetric and lives in specific drivers:
 Cloudflare D1 (SQLite) and `drizzle-orm/neon-http` (Postgres) are non-transactional, so they downgrade to
 `transactions: false`. Operations that require atomicity (`commitSchemaVersion`, `setActiveVersion`, Operational
-Identity) throw on those drivers regardless of backend. Schema-managed Store writes also fail closed because they
-cannot hold the transaction-scoped schema fence; only raw Store or direct-backend writes retain the sequential,
-non-atomic fallback.
+Identity) throw on those drivers regardless of backend. Schema-managed Store writes also fail closed when they
+cannot hold the transaction-scoped schema fence. Raw Store and direct-backend writes remain available when the
+application explicitly accepts their operation-level, non-atomic semantics, but public Store transaction methods
+refuse.
 :::
 
 :::note[Aggregate set operations are a builder limitation, not a parity gap]

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -34,22 +34,17 @@ Write behavior depends on how the Store was constructed. A schema-managed Store
 fails closed for writes that need the transaction-scoped schema or constraint
 fence, but eligible plain node batches and `cardinality: "many"` edges can use
 the authoritative one-statement command. A raw `createStore()` /
-`createAdapterStore()` without a reconciled snapshot still uses the sequential fallback:
-`store.transaction(fn)` invokes `fn` against the same backend, writes are applied
-as they happen, and a thrown error does not roll back earlier writes. Direct
-backend writes are raw as well.
+`createAdapterStore()` without a reconciled snapshot can still issue ordinary
+non-atomic writes, but `store.transaction(fn)` refuses before invoking `fn`.
+Direct backend writes are raw as well.
 
-These backends also ignore the `isolationLevel` option on
-`store.transaction(...)`, so the collection-read snapshot recipe documented
-elsewhere does nothing here.
+These backends cannot honor the `isolationLevel` option on
+`store.transaction(...)`; the method refuses before invoking its callback, so
+the collection-read snapshot recipe documented elsewhere does not apply here.
 
 ```typescript
-// On a raw D1 / neon-http Store: every successful create persists immediately.
-// If the throw fires after Alice is created, Alice stays in the database.
-await store.transaction(async (tx) => {
-  await tx.nodes.Person.create({ name: "Alice" });
-  throw new Error("boom"); // does NOT roll back the create above
-});
+// On a raw D1 / neon-http Store, use ordinary writes explicitly.
+await store.nodes.Person.create({ name: "Alice" });
 ```
 
 **If you require atomicity or schema-version fencing, branch on the capability:**
@@ -60,7 +55,7 @@ if (store.capabilities.transactions) {
     /* atomic */
   });
 } else {
-  // Raw Store only: sequential, non-atomic, and not schema-fenced.
+  // Use ordinary writes explicitly when non-atomic behavior is intentional.
   const person = await store.nodes.Person.create({ name: "Alice" });
   const company = await store.nodes.Company.create({ name: "Acme" });
   await store.edges.worksAt.create(person, company, { role: "Engineer" });

--- a/apps/docs/src/content/docs/materializing-event-logs.md
+++ b/apps/docs/src/content/docs/materializing-event-logs.md
@@ -214,11 +214,10 @@ transactional driver, or deliberately construct a raw Store and own schema/write
 coordination yourself.
 
 ```typescript
-await store.transaction(async (tx) => {
-  for (const change of batch.changes) {
-    await projectChange(tx, change);
-  }
-});
+for (const change of batch.changes) {
+  // Each successful projection may commit before a later projection or cursor write fails.
+  await projectChange(store, change);
+}
 
 await cursorStore.save({
   sourceId: batch.sourceId,

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -259,8 +259,8 @@ whole-call atomicity on bundled transactionless roots through one native
 atomic exchange, including durable-match and cardinality-constrained edge
 batches. Other
 bulk shapes on a transactionless root either refuse when their contract requires a fence or use
-sequential fallback, which can leave earlier chunks committed if a later one fails.
-`store.transaction()` cannot add atomicity to a backend that does not support transactions.
+their explicitly non-transactional operation semantics. `store.transaction()` refuses before
+invoking its callback on a transactionless root; it never presents sequential writes as atomic.
 
 To commit several bulk calls as one unit on a transaction-capable backend, wrap them in a
 transaction:

--- a/apps/docs/src/content/docs/queries/execute.md
+++ b/apps/docs/src/content/docs/queries/execute.md
@@ -263,7 +263,7 @@ observe a commit the earlier ones did not. There is no way to fix that for fluen
 `store.transaction()` accepts an `isolationLevel`, but its context exposes only `nodes` / `edges`,
 so a query builder cannot run inside it. Collection reads can get a snapshot via
 `store.transaction(fn, { isolationLevel: "repeatable_read" })` and `tx.nodes` / `tx.edges` — but
-only where the backend has transactions (others ignore the option), and a history-enabled store on
+only where the backend has transactions (other backends refuse before invoking `fn`), and a history-enabled store on
 PostgreSQL additionally requires `accessMode: "read_only"` or the call throws.
 
 ```typescript

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -2095,7 +2095,7 @@ isolation, so a later query in the batch can observe a commit the earlier ones d
 there is no public way to run a fluent query or a batch inside a transaction, so a snapshot across
 fluent queries is **not available today**. Collection reads can have one —
 `store.transaction(fn, { isolationLevel: "repeatable_read" })` reading through `tx.nodes` /
-`tx.edges` — but only where the backend has transactions (others ignore the option entirely), and a
+`tx.edges` — but only where the backend has transactions (other backends refuse before invoking the callback), and a
 history-enabled store on PostgreSQL additionally requires `accessMode: "read_only"` or the call
 throws.
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1957,11 +1957,10 @@ adopted-commit path for history stores — returns the same `TransactionOutcome`
 so the exactly-once cursor pattern gets a receipt too (see
 [Recorded time](/queries/temporal/#raw-sql-under-history-capture)); only
 `withTransaction`, whose commit belongs entirely to the caller with no flush
-point, produces no receipt. On a raw Store backed by a non-transactional driver,
-a receipt describes operations that individually committed; if the callback
-rejects there, no receipt is returned even though earlier operations committed.
-A schema-managed Store instead fails closed on its first write because it cannot
-hold the schema-version fence.
+point, produces no receipt. On a Store backed by a non-transactional driver,
+`transactionWithReceipt()` refuses before invoking the callback, so it cannot
+produce a receipt. Ordinary Store writes remain available when the application
+deliberately owns non-atomic coordination.
 
 ##### Scoped receipts: `tx.measure()`
 
@@ -2024,18 +2023,17 @@ context through your call chain.
 Not all backends support atomic transactions. Cloudflare D1 and
 `drizzle-orm/neon-http` cannot hold a multi-statement session and report
 `capabilities.transactions: false`. A schema-managed Store fails closed before
-writing on these backends because it cannot hold the schema fence. On a raw
-Store, `store.transaction(fn)` still runs — `fn` executes against the same
-backend used outside `transaction()`, sequentially — **but writes are applied
-as they happen and a thrown error does not roll back earlier writes inside the
-callback**. If you require atomicity or version fencing, branch on the
+writing on these backends because it cannot hold the schema fence. The public
+`store.transaction(fn)` and `store.transactionWithReceipt(fn)` methods also
+fail closed before invoking the callback, rather than silently degrading to
+sequential writes. If you require atomicity or version fencing, branch on the
 capability:
 
 ```typescript
 if (store.capabilities.transactions) {
   await store.transaction(async (tx) => { /* atomic */ });
 } else {
-  // Raw Store only: sequential, non-atomic, and not schema-fenced.
+  // Use ordinary Store writes explicitly when non-atomic work is intentional.
 }
 ```
 

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -2497,7 +2497,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * snapshot across fluent queries is not available today. Collection reads
    * can have one — `store.transaction(fn, { isolationLevel: "repeatable_read" })`
    * reading through `tx.nodes` / `tx.edges` — but only where the backend has
-   * transactions (others ignore the option entirely), and a history-enabled
+   * transactions (other backends refuse before invoking the callback), and a history-enabled
    * store on PostgreSQL additionally requires `accessMode: "read_only"` or the
    * call throws.
    *
@@ -3302,7 +3302,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         { capability: "adoptTransaction" },
         {
           suggestion:
-            "Use a Drizzle PostgreSQL/SQLite backend with transaction support, or run writes through store.transaction(...).",
+            "Use a Drizzle PostgreSQL/SQLite backend that can adopt this transaction, use store.transaction(...) on a backend with transaction support, or call ordinary Store writes when non-atomic work is intentional.",
         },
       );
     }

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -103,6 +103,7 @@ import {
   EagerMaterializationError,
   KindNotFoundError,
   MigrationError,
+  UnsupportedBackendCapabilityError,
   ValidationError,
 } from "../errors";
 import {
@@ -2840,19 +2841,16 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * cannot drain a raw statement still in flight when the transaction commits.
    *
    * **Backends without transactions.** When `backend.capabilities.transactions`
-   * is `false` (Cloudflare D1, `drizzle-orm/neon-http`), a raw Store runs the
-   * callback against the same backend used outside `transaction()` — writes
-   * are applied as they happen and a thrown error does **not** roll back
-   * earlier writes inside the callback. A schema-managed Store may run a
-   * read-only callback, but its first write fails closed because the backend
-   * cannot hold the schema-version fence. Branch on
-   * `backend.capabilities.transactions` if you require atomicity:
+   * is `false` (Cloudflare D1, `drizzle-orm/neon-http`), this method refuses
+   * before invoking the callback. A callback-shaped API that silently applies
+   * writes one by one is not a transaction and would make the atomicity
+   * contract depend on backend selection. Use the Store's ordinary write
+   * methods for deliberately non-atomic work, or provide a backend with real
+   * transaction support:
    *
    * ```typescript
    * if (backend.capabilities.transactions) {
    *   await store.transaction(async (tx) => { ... });
-   * } else {
-   *   // sequential, non-atomic — handle partial-failure recovery yourself
    * }
    * ```
    *
@@ -2860,9 +2858,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * @param options Optional {@link TransactionOptions} forwarded to the
    *   backend (e.g. `isolationLevel: "serializable"` on Postgres). Backends
    *   without isolation-level support ignore it. On non-transactional
-   *   backends, raw Stores use the sequential fallback while schema-managed
-   *   Stores fail closed at their first write because no transaction-scoped
-   *   schema fence is available. A concurrent schema commit can make a
+   *   backends, the method refuses before invoking `fn`. A concurrent schema commit can make a
    *   snapshot-isolated PostgreSQL write fail with the database's normal
    *   serialization error; retry the whole transaction. Graph-merge commits
    *   retry serialization failures automatically. Stores created with
@@ -2893,7 +2889,12 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     const invoke = fn as (
       tx: AdapterTransactionContext<G, TNativeTransaction>,
     ) => Promise<T>;
-    const { result } = await this.#runTransaction(invoke, options, undefined);
+    const { result } = await this.#runTransaction(
+      invoke,
+      options,
+      undefined,
+      "store.transaction()",
+    );
     return result;
   }
 
@@ -2913,11 +2914,9 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * {@link AdapterStore.withRecordedTransaction} also returns a
    * {@link TransactionOutcome}; only `withTransaction` (whose commit belongs
    * entirely to the caller with no flush point) produces no receipt. On
-   * non-transactional backends, a raw Store still returns a receipt, but it
-   * describes operations that individually committed rather than one atomic
-   * commit; if the callback rejects there, no receipt is returned even though
-   * earlier operations committed individually. A schema-managed Store fails
-   * closed on its first write instead.
+   * non-transactional backends, this method refuses before invoking the
+   * callback, so it cannot produce a receipt. Use ordinary Store writes when
+   * deliberately performing non-atomic work.
    *
    * For stores created with `{ history: true }`, `receipt.recorded` is the
    * recorded commit instant this transaction allocated for the store's
@@ -2972,6 +2971,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       invoke,
       options,
       receiptRecorder,
+      "store.transactionWithReceipt()",
     );
     return transactionOutcome(
       result,
@@ -2987,64 +2987,15 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     ) => Promise<T>,
     backendOptions: TransactionOptions | undefined,
     receiptRecorder: TransactionReceiptRecorder | undefined,
+    operation: "store.transaction()" | "store.transactionWithReceipt()",
   ): Promise<TransactionRunResult<T>> {
-    // Without a real transaction the tx-scoped collections would be
-    // bound to the same backend as this.nodes/this.edges and exposing
-    // the cached versions avoids rebuilding the proxies on every call.
-    // An isolation-level request in the options is equally meaningless here.
     if (!this.#backend.capabilities.transactions) {
-      let nodes = this.nodes;
-      let edges = this.edges;
-      if (receiptRecorder !== undefined) {
-        ({ nodes, edges } = wrapTransactionCollections(
-          nodes,
-          edges,
-          receiptRecorder,
-        ));
-      }
-      const identity =
-        this.#graph.identity === undefined ?
-          undefined
-        : createIdentityFacade(this.#identityContext(this.#backend));
-      const receiptIdentity =
-        identity === undefined || receiptRecorder === undefined ?
-          identity
-        : wrapTransactionIdentity(identity, receiptRecorder);
-      const fallbackContext: AdapterTransactionContext<G, TNativeTransaction> =
-        {
-          nodes,
-          edges,
-          ...(receiptIdentity === undefined ?
-            {}
-          : { identity: receiptIdentity }),
-          // No real transaction: `tx.sql` is absent and there is no atomicity.
-          sqlAvailability: "unavailable",
-          backend: createTransactionReadBackend(this.#backend),
-          [TRANSACTION_RUNTIME]: {
-            backend: this.#backend,
-            runNodeOperationHooks: (operation, kind, id, hookedFunction) =>
-              this.#withOperationHooks(
-                this.#createOperationContext(operation, "node", kind, id),
-                hookedFunction,
-              ),
-          },
-          getNodeCollection: <const K extends string>(kind: K) =>
-            this.#resolveDynamicNodeCollection(nodes, kind),
-        };
-      Object.defineProperty(fallbackContext, TRANSACTION_RUNTIME, {
-        configurable: false,
-        enumerable: false,
-        writable: false,
-      });
-      // `measure` on this non-transactional fallback scopes writes that
-      // individually committed rather than one atomic commit, mirroring the
-      // receipt caveat.
-      const result = await invoke(
-        receiptRecorder === undefined ? fallbackContext : (
-          this.#attachMeasure(fallbackContext)
-        ),
+      throw new UnsupportedBackendCapabilityError(
+        operation,
+        "transactions",
+        { graphId: this.graphId, dialect: this.#backend.dialect },
+        "Use a backend with transaction support, or call ordinary Store write methods when non-atomic work is intentional.",
       );
-      return { result, recordedByGraph: undefined };
     }
 
     // #134/#135: no gate here. The backend's transaction() wraps the

--- a/packages/typegraph/tests/no-transactions-fallthrough.test.ts
+++ b/packages/typegraph/tests/no-transactions-fallthrough.test.ts
@@ -3,12 +3,11 @@
  * (e.g. `drizzle-orm/neon-http`, Cloudflare D1).
  *
  * Wraps a real in-memory SQLite backend, flips `capabilities.transactions`
- * off, and makes `backend.transaction(...)` throw — then walks every
- * code path that historically wrapped its work in a transaction and
- * asserts it now completes via the sequential fall-through instead of
- * throwing. If a future change re-introduces an unconditional
- * `backend.transaction(...)` in any of these paths, the corresponding
- * test will fail with the synthetic transaction-disabled error.
+ * off, and makes `backend.transaction(...)` throw — then verifies that
+ * Store transaction callbacks fail closed before user code runs. Other
+ * APIs that intentionally use sequential execution remain covered by
+ * their own tests. If a future change accidentally invokes a callback on
+ * this backend, the assertions below will catch the contract regression.
  */
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -78,7 +77,7 @@ const identityGraph = defineGraph({
   identity: { sameIdAcrossKinds: "fold" },
 });
 
-describe("backends with transactions: false fall through to sequential execution", () => {
+describe("backends with transactions: false fail closed at Store transactions", () => {
   let backend: GraphBackend;
 
   beforeEach(() => {
@@ -94,7 +93,7 @@ describe("backends with transactions: false fall through to sequential execution
     expect(backend.capabilities.transactions).toBe(false);
   });
 
-  it("schema-managed Store writes fail closed before the sequential fallback", async () => {
+  it("schema-managed Store writes fail closed before any write", async () => {
     const store = await createInitializedStore(graph, backend);
 
     await expect(
@@ -112,65 +111,44 @@ describe("backends with transactions: false fall through to sequential execution
   // and can't reach into the backend's closure-scoped transaction
   // config.
 
-  it("store.transaction(fn) executes fn against the main backend", async () => {
+  it("store.transaction(fn) refuses before invoking the callback", async () => {
     const store = await createRawInitializedStore(graph, backend);
-
-    const result = await store.transaction(async (tx) => {
-      const person = await tx.nodes.Person.create({ name: "Alice" });
-      const company = await tx.nodes.Company.create({ name: "Acme" });
-      const edge = await tx.edges.worksAt.create(person, company, {
-        role: "Engineer",
-      });
-      return { personId: person.id, companyId: company.id, edgeId: edge.id };
-    });
-
-    // Writes are visible after the (non-atomic) callback returns.
-    const person = await store.nodes.Person.getById(result.personId);
-    expect(person?.name).toBe("Alice");
-    const company = await store.nodes.Company.getById(result.companyId);
-    expect(company?.name).toBe("Acme");
-  });
-
-  it("refuses convergent edge creation without a transaction fence", async () => {
-    const store = await createRawInitializedStore(graph, backend);
-    const person = await store.nodes.Person.create({ name: "Alice" });
-    const company = await store.nodes.Company.create({ name: "Acme" });
-
-    await expect(
-      store.edges.worksAt.getOrCreateByEndpoints(
-        person,
-        company,
-        { role: "Engineer" },
-        { matchOn: ["role"] },
-      ),
-    ).rejects.toMatchObject({
-      details: {
-        code: "CONSTRAINT_WRITE_FENCE_UNSUPPORTED",
-        graphId: graph.id,
-      },
-    });
-    await expect(store.edges.worksAt.find()).resolves.toEqual([]);
-  });
-
-  it("store.transaction errors propagate without rollback", async () => {
-    const store = await createRawInitializedStore(graph, backend);
-    const persisted = await store.nodes.Person.create({ name: "Persisted" });
+    let invoked = false;
 
     await expect(
       store.transaction(async (tx) => {
-        await tx.nodes.Person.create({ name: "AlsoPersisted" });
-        throw new Error("boom");
+        invoked = true;
+        await tx.nodes.Person.create({ name: "must-not-persist" });
+        throw new Error("callback must not run");
       }),
-    ).rejects.toThrow("boom");
+    ).rejects.toMatchObject({
+      name: "UnsupportedBackendCapabilityError",
+      details: {
+        graphId: graph.id,
+        capability: "transactions",
+      },
+    });
+    expect(invoked).toBe(false);
+    await expect(store.nodes.Person.find()).resolves.toEqual([]);
+  });
 
-    // Without transactions, prior writes inside the callback are NOT
-    // rolled back. This is the documented contract.
-    const allPeople = await store.nodes.Person.find();
-    expect(allPeople.map((person) => person.name).toSorted()).toEqual([
-      "AlsoPersisted",
-      "Persisted",
-    ]);
-    expect(persisted.id).toBeDefined();
+  it("transactionWithReceipt refuses before invoking the callback", async () => {
+    const store = await createRawInitializedStore(graph, backend);
+    let invoked = false;
+
+    await expect(
+      store.transactionWithReceipt(() => {
+        invoked = true;
+        return Promise.resolve();
+      }),
+    ).rejects.toMatchObject({
+      name: "UnsupportedBackendCapabilityError",
+      details: {
+        graphId: graph.id,
+        capability: "transactions",
+      },
+    });
+    expect(invoked).toBe(false);
   });
 
   it("store.batch returns per-query results without throwing", async () => {

--- a/packages/typegraph/tests/transaction-receipt.test.ts
+++ b/packages/typegraph/tests/transaction-receipt.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { defineEdge, defineGraph, defineNode, type GraphBackend } from "../src";
+import {
+  defineEdge,
+  defineGraph,
+  defineNode,
+  type GraphBackend,
+  UnsupportedBackendCapabilityError,
+} from "../src";
 import { deriveBackend } from "../src/backend/derive-backend";
 import {
   type TransactionBackend,
@@ -126,23 +132,18 @@ async function writeFixture(
 }
 
 describe("transaction receipts", () => {
-  it("returns counts on non-transactional backends", async () => {
+  it("refuses on non-transactional backends", async () => {
     const backend = disableTransactions(createTestBackend());
     const store = await createRawInitializedStore(receiptGraph, backend);
+    let invoked = false;
 
-    const outcome = await store.transactionWithReceipt(async (tx) => {
-      const person = await tx.nodes.Person.create({ name: "Alice" });
-      const company = await tx.nodes.Company.create({ name: "Acme" });
-      await tx.edges.worksAt.create(person, company, { role: "Engineer" });
-      return person.id;
-    });
-
-    expect(outcome.receipt.writes.nodes).toEqual({ Person: 1, Company: 1 });
-    expect(outcome.receipt.writes.edges).toEqual({ worksAt: 1 });
-    expect(outcome.receipt.writes.total).toBe(3);
     await expect(
-      store.nodes.Person.getById(outcome.result),
-    ).resolves.toMatchObject({ name: "Alice" });
+      store.transactionWithReceipt(() => {
+        invoked = true;
+        return Promise.resolve("unreachable");
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedBackendCapabilityError);
+    expect(invoked).toBe(false);
   });
 
   it("does not add backend write calls when receipt counting is requested", async () => {

--- a/packages/typegraph/tests/transaction-surface-honesty.test.ts
+++ b/packages/typegraph/tests/transaction-surface-honesty.test.ts
@@ -34,6 +34,7 @@ import {
   type TransactionBackend,
   type TransactionContext,
   type TransactionReadBackend,
+  UnsupportedBackendCapabilityError,
 } from "../src";
 import { projectGraphBackend } from "../src/backend/derive-backend";
 import {
@@ -44,7 +45,6 @@ import { STORE_RUNTIME } from "../src/store/runtime-port";
 import { TRANSACTION_RUNTIME } from "../src/store/types";
 import {
   createInitializedStore,
-  createRawInitializedStore,
   createTestBackend,
   disableTransactions,
 } from "./test-utils";
@@ -97,16 +97,17 @@ describe("#254 tx.sqlAvailability discriminant", () => {
     });
   });
 
-  it("reports 'unavailable' with tx.sql === undefined on a non-transactional backend", async () => {
-    const store = await createRawInitializedStore(
-      graph,
-      disableTransactions(createTestBackend()),
-    );
-    await store.transaction(async (tx) => {
-      await tx.nodes.Person.create({ name: "probe" });
-      expect(tx.sqlAvailability).toBe("unavailable");
-      expect(Reflect.get(tx, "sql")).toBeUndefined();
-    });
+  it("refuses before invoking a callback on a non-transactional backend", async () => {
+    const store = createStore(graph, disableTransactions(createTestBackend()));
+    let invoked = false;
+
+    await expect(
+      store.transaction(() => {
+        invoked = true;
+        return Promise.resolve();
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedBackendCapabilityError);
+    expect(invoked).toBe(false);
   });
 
   it("reports 'history' with a present-but-throwing tx.sql under history capture", async () => {


### PR DESCRIPTION
`Store.transaction()` and `Store.transactionWithReceipt()` now fail closed when a backend declares `capabilities.transactions: false`. Previously, both APIs executed their callbacks directly on the root backend, silently turning an atomic transaction contract into sequential, independently committed writes on transports such as Cloudflare D1 and Neon HTTP.

The refusal happens before callback invocation and uses `UnsupportedBackendCapabilityError`, so callers can make an explicit choice between a transaction-capable backend and deliberately non-atomic ordinary Store writes. The obsolete fallback implementation and its misleading transaction receipt behavior are removed.

Documentation now consistently describes transactionless Store behavior, updates serverless and event-log guidance, and includes migration guidance for callers that previously relied on the fallthrough.
