### PR TITLE
feat: certify atomic mutation program semantics

### DIFF
--- a/.changeset/semantic-mutation-conformance.md
+++ b/.changeset/semantic-mutation-conformance.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add a framework-agnostic semantic conformance runner for custom atomic mutation programs. The runner requires ordered Store results, independently observed committed state, stale-fence no-write behavior, typed semantic-refusal rollback, exact executor dispatch, and exact-root provenance for every registered family variant.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1416,6 +1416,7 @@ the earned declaration with the exact root transport in its factory:
 import {
   registerAtomicMutationPrograms,
   registerAtomicSqlProgram,
+  runAtomicMutationProgramConformance,
   runAtomicTransportConformance,
 } from "@nicia-ai/typegraph/backend";
 
@@ -1428,9 +1429,12 @@ const backend = createCustomBackend({
   },
 });
 registerAtomicSqlProgram(backend, { executeAtomicBatch });
-registerAtomicMutationPrograms(backend, {
-  createNodes: executeAtomicNodeBatch,
-  createEdges: executeAtomicEdgeBatch,
+registerAtomicMutationPrograms(backend, mutationPrograms);
+
+await runAtomicMutationProgramConformance({
+  backend,
+  equal: deepEqual,
+  cases: semanticCases,
 });
 ```
 
@@ -1451,9 +1455,38 @@ The semantic executors must preserve the same schema fence, validation,
 side-effect, refusal classification, rollback, postimage correlation, result
 ordering, and bind-ceiling contracts as the bundled implementation. Registering
 one family is not evidence for another. Derived, projected, and
-transaction-scoped backends inherit neither root registration. Run the shared
-cross-backend Store integration cases for every family the custom backend
-registers; the transport conformance runner alone cannot prove graph semantics.
+transaction-scoped backends inherit neither root registration.
+
+`runAtomicMutationProgramConformance()` is the executable semantic boundary.
+For every positive-limit variant in `mutationPrograms`, the fixture supplies
+three real Store-level cases:
+
+1. an ordered success whose return value and independently read committed state
+   both match their oracles;
+2. a stale-schema-fence refusal that leaves the database unchanged; and
+3. a family-specific typed refusal that rolls back every sibling write.
+
+The runner resolves the profile from `backend`; it does not accept a detached
+profile description or caller-supplied provenance verdict. Each case resolves
+the exact registered backend root it exercises and observes that root's
+semantic executor dispatch count. Before any operation runs, the runner proves
+that root registration does not leak through projections or transaction
+sessions. It then refuses a success that silently used the portable fallback,
+a case bound to a different family claim, a missing or duplicate family case,
+and a case that claims an unregistered family. A zero entry limit is an honest
+opt-out and does not require an unreachable case. `mutateEdges` has separate
+`resolvedSet` and `durableConvergence` variants because proving one does not
+prove the other.
+
+The fixture callbacks should invoke public Store methods and inspect committed
+rows through an independent database read. Each case's `resolveBackend()` must
+return the same exact root used by that Store. Instrument the registered
+executor, or a transport hook unique to that family program, only to count
+dispatches; do not use executor return rows as the state oracle. Match
+Store-level typed errors rather than raw driver sentinels. The runner is
+framework-agnostic, so the same fixture runs in the custom backend's own test
+suite. Pair it with the shared cross-backend Store integration suite; transport
+conformance alone cannot prove graph semantics.
 
 The profile is family-scoped:
 

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -43,6 +43,9 @@ export function assertVectorSearchLimit(limit: number): void;
 export function assumeRecursiveTraversalSupported(reason: string): RecursiveTraversalVerdict;
 
 // @public
+export const ATOMIC_MUTATION_PROGRAM_VARIANTS: readonly ["createNodes", "createEdges", "deleteNodes", "deleteEdges", "updateNodes", "updateEdges", "mutateNodes", "mutateEdges.resolvedSet", "mutateEdges.durableConvergence"];
+
+// @public
 export type AtomicDeleteBatchResult = Readonly<{
     affectedCount: number;
     schemaFenceMatched: boolean;
@@ -167,6 +170,56 @@ export type AtomicEdgeResolvedUpdateEntry = Readonly<{
 }>;
 
 // @public
+export type AtomicMutationProgramConformanceCase = Readonly<{
+    variant: AtomicMutationProgramVariant;
+    orderedSuccess: AtomicMutationProgramSuccessCase;
+    staleFenceNoWrite: AtomicMutationProgramRefusalCase;
+    semanticRefusalRollback: AtomicMutationProgramRefusalCase;
+}>;
+
+// @public
+export class AtomicMutationProgramConformanceError extends TypeGraphError {
+    constructor(message: string, details?: Readonly<Record<string, unknown>>);
+}
+
+// @public
+export type AtomicMutationProgramConformanceFixture = Readonly<{
+    backend: GraphBackend;
+    equal: (actual: unknown, expected: unknown) => boolean;
+    cases: readonly AtomicMutationProgramConformanceCase[];
+}>;
+
+// @public
+export type AtomicMutationProgramConformancePreparation = Readonly<{
+    expectedResult: unknown;
+    expectedState: unknown;
+}>;
+
+// @public
+export type AtomicMutationProgramConformanceReport = Readonly<{
+    variants: readonly Readonly<{
+        variant: AtomicMutationProgramVariant;
+        passed: readonly string[];
+    }>[];
+    provenance: readonly string[];
+}>;
+
+// @public
+export type AtomicMutationProgramRefusalCase = Readonly<{
+    prepare: () => AtomicMutationProgramRefusalPreparation | PromiseLike<AtomicMutationProgramRefusalPreparation>;
+    resolveBackend: () => GraphBackend;
+    execute: () => unknown;
+    observeState: () => unknown;
+    observeDispatchCount: () => number | PromiseLike<number>;
+    errorMatches: (error: unknown) => boolean;
+}>;
+
+// @public
+export type AtomicMutationProgramRefusalPreparation = Readonly<{
+    expectedState: unknown;
+}>;
+
+// @public
 export type AtomicMutationProgramRegistration = Readonly<{
     createNodes?: AtomicNodeBatchExecutor | undefined;
     createEdges?: AtomicEdgeBatchExecutor | undefined;
@@ -177,6 +230,18 @@ export type AtomicMutationProgramRegistration = Readonly<{
     mutateNodes?: AtomicNodeResolvedMutationSetExecutor | undefined;
     mutateEdges?: AtomicEdgeMutationProgramExecutor | undefined;
 }>;
+
+// @public
+export type AtomicMutationProgramSuccessCase = Readonly<{
+    prepare: () => AtomicMutationProgramConformancePreparation | PromiseLike<AtomicMutationProgramConformancePreparation>;
+    resolveBackend: () => GraphBackend;
+    execute: () => unknown;
+    observeState: () => unknown;
+    observeDispatchCount: () => number | PromiseLike<number>;
+}>;
+
+// @public
+export type AtomicMutationProgramVariant = (typeof ATOMIC_MUTATION_PROGRAM_VARIANTS)[number];
 
 // @public
 export type AtomicNodeBatchEntry = Readonly<{
@@ -3259,6 +3324,9 @@ export function rowPropsToJsonText(props: RowProps): string;
 
 // @public
 export function rowPropsToObject(props: RowProps): Record<string, unknown>;
+
+// @public
+export function runAtomicMutationProgramConformance(fixture: AtomicMutationProgramConformanceFixture): Promise<AtomicMutationProgramConformanceReport>;
 
 // @public
 export function runAtomicTransportConformance<TSnapshot = unknown>(fixture: AtomicTransportConformanceFixture<TSnapshot>): Promise<AtomicTransportConformanceReport>;

--- a/packages/typegraph/src/backend/conformance/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/conformance/atomic-mutation-program.ts
@@ -1,0 +1,423 @@
+/**
+ * Framework-agnostic conformance checks for semantic mutation programs.
+ *
+ * Transport conformance proves that a backend can dispatch a closed SQL
+ * program atomically. This runner proves the next boundary: each registered
+ * TypeGraph mutation family preserves its Store-visible result, schema fence,
+ * refusal, rollback, and exact-root contracts. Backend authors supply real
+ * Store operations and database observers; the runner owns the required case
+ * inventory and every verdict.
+ */
+import { TypeGraphError } from "../../errors";
+import {
+  type AtomicMutationProgramExecutor,
+  hasAtomicMutationProgramRegistration,
+  resolveAtomicMutationPrograms,
+} from "../capabilities/atomic-mutation-program";
+import { projectGraphBackend } from "../derive-backend";
+import type { GraphBackend } from "../types";
+import {
+  assertExactRootRegistrationProvenance,
+  type ExactRootRegistrationProvenanceChecks,
+} from "./exact-root-provenance";
+
+/** Every independently provable semantic variant in a mutation profile. */
+export const ATOMIC_MUTATION_PROGRAM_VARIANTS = [
+  "createNodes",
+  "createEdges",
+  "deleteNodes",
+  "deleteEdges",
+  "updateNodes",
+  "updateEdges",
+  "mutateNodes",
+  "mutateEdges.resolvedSet",
+  "mutateEdges.durableConvergence",
+] as const;
+
+/** One independently provable semantic variant in a mutation profile. */
+export type AtomicMutationProgramVariant =
+  (typeof ATOMIC_MUTATION_PROGRAM_VARIANTS)[number];
+
+/** Independently derived success oracles returned by fixture preparation. */
+export type AtomicMutationProgramConformancePreparation = Readonly<{
+  expectedResult: unknown;
+  expectedState: unknown;
+}>;
+
+/** Independently derived no-write oracle returned by fixture preparation. */
+export type AtomicMutationProgramRefusalPreparation = Readonly<{
+  expectedState: unknown;
+}>;
+
+/** One successful Store operation and its independent state observers. */
+export type AtomicMutationProgramSuccessCase = Readonly<{
+  /** Establishes isolated state and returns independently derived oracles. */
+  prepare: () =>
+    | AtomicMutationProgramConformancePreparation
+    | PromiseLike<AtomicMutationProgramConformancePreparation>;
+  /** Resolves the exact registered backend root used by this case. */
+  resolveBackend: () => GraphBackend;
+  /** Invokes the public Store operation whose registered family is claimed. */
+  execute: () => unknown;
+  /** Reads committed database state without trusting the returned postimages. */
+  observeState: () => unknown;
+  /** Counts invocations of the exact registered semantic executor. */
+  observeDispatchCount: () => number | PromiseLike<number>;
+}>;
+
+/** One refusing Store operation and its independent state observers. */
+export type AtomicMutationProgramRefusalCase = Readonly<{
+  /** Establishes isolated state and returns its no-write oracle. */
+  prepare: () =>
+    | AtomicMutationProgramRefusalPreparation
+    | PromiseLike<AtomicMutationProgramRefusalPreparation>;
+  /** Resolves the exact registered backend root used by this case. */
+  resolveBackend: () => GraphBackend;
+  /** Invokes the public Store operation that must refuse atomically. */
+  execute: () => unknown;
+  /** Reads committed database state after the refusal. */
+  observeState: () => unknown;
+  /** Counts invocations of the exact registered semantic executor. */
+  observeDispatchCount: () => number | PromiseLike<number>;
+  /** Matches the Store-level typed error, never a driver sentinel alone. */
+  errorMatches: (error: unknown) => boolean;
+}>;
+
+/** The three mandatory checks for one semantic mutation variant. */
+export type AtomicMutationProgramConformanceCase = Readonly<{
+  variant: AtomicMutationProgramVariant;
+  /** Proves ordered results and independently observed committed state. */
+  orderedSuccess: AtomicMutationProgramSuccessCase;
+  /** Proves a stale schema fence cannot leave any write behind. */
+  staleFenceNoWrite: AtomicMutationProgramRefusalCase;
+  /** Proves the family's semantic refusal rolls back every sibling write. */
+  semanticRefusalRollback: AtomicMutationProgramRefusalCase;
+}>;
+
+/** Complete caller-owned fixture for the framework-agnostic runner. */
+export type AtomicMutationProgramConformanceFixture = Readonly<{
+  /** A representative exact root registered by the backend factory. */
+  backend: GraphBackend;
+  equal: (actual: unknown, expected: unknown) => boolean;
+  cases: readonly AtomicMutationProgramConformanceCase[];
+}>;
+
+/** Passed checks grouped by semantic variant and exact-root provenance. */
+export type AtomicMutationProgramConformanceReport = Readonly<{
+  variants: readonly Readonly<{
+    variant: AtomicMutationProgramVariant;
+    passed: readonly string[];
+  }>[];
+  provenance: readonly string[];
+}>;
+
+/** A failed semantic mutation program conformance verdict. */
+export class AtomicMutationProgramConformanceError extends TypeGraphError {
+  constructor(
+    message: string,
+    details: Readonly<Record<string, unknown>> = {},
+  ) {
+    super(message, "ATOMIC_MUTATION_PROGRAM_CONFORMANCE_ERROR", {
+      category: "system",
+      details,
+    });
+    this.name = "AtomicMutationProgramConformanceError";
+  }
+}
+
+const VARIANTS_BY_FAMILY = {
+  createNodes: ["createNodes"],
+  createEdges: ["createEdges"],
+  deleteNodes: ["deleteNodes"],
+  deleteEdges: ["deleteEdges"],
+  updateNodes: ["updateNodes"],
+  updateEdges: ["updateEdges"],
+  mutateNodes: ["mutateNodes"],
+  mutateEdges: ["mutateEdges.resolvedSet", "mutateEdges.durableConvergence"],
+} as const satisfies Readonly<
+  Record<
+    keyof AtomicMutationProgramExecutor,
+    readonly AtomicMutationProgramVariant[]
+  >
+>;
+
+const ATOMIC_MUTATION_PROGRAM_FAMILIES = Object.keys(
+  VARIANTS_BY_FAMILY,
+) as readonly (keyof typeof VARIANTS_BY_FAMILY)[];
+
+function expectedVariants(
+  registration: AtomicMutationProgramExecutor,
+): readonly AtomicMutationProgramVariant[] {
+  const variants: AtomicMutationProgramVariant[] = [];
+  for (const family of ATOMIC_MUTATION_PROGRAM_FAMILIES) {
+    if (family === "updateNodes") {
+      if ((registration.updateNodes?.maxEntries ?? 0) > 0) {
+        variants.push("updateNodes");
+      }
+      continue;
+    }
+    if (family === "updateEdges") {
+      if ((registration.updateEdges?.maxEntries ?? 0) > 0) {
+        variants.push("updateEdges");
+      }
+      continue;
+    }
+    if (family === "mutateNodes") {
+      if ((registration.mutateNodes?.maxEntries ?? 0) > 0) {
+        variants.push("mutateNodes");
+      }
+      continue;
+    }
+    if (family === "mutateEdges") {
+      const executor = registration.mutateEdges;
+      if (executor === undefined) continue;
+      if (executor.maxEntries.resolvedSet > 0) {
+        variants.push("mutateEdges.resolvedSet");
+      }
+      if (executor.maxEntries.durableConvergence > 0) {
+        variants.push("mutateEdges.durableConvergence");
+      }
+      continue;
+    }
+    if (registration[family] === undefined) continue;
+    variants.push(...VARIANTS_BY_FAMILY[family]);
+  }
+  return variants;
+}
+
+function assertCaseBackendMatchesProfile(
+  fixtureBackend: GraphBackend,
+  profile: AtomicMutationProgramExecutor,
+  backend: GraphBackend,
+  variant: AtomicMutationProgramVariant,
+  check: string,
+): void {
+  const registered = resolveAtomicMutationPrograms(backend);
+  if (backend === fixtureBackend && registered === profile) {
+    return;
+  }
+  throw new AtomicMutationProgramConformanceError(
+    `Atomic mutation program conformance case is not bound to the exact registered ${variant} root during ${check}.`,
+    { variant, check },
+  );
+}
+
+function assertEqual(
+  fixture: AtomicMutationProgramConformanceFixture,
+  actual: unknown,
+  expected: unknown,
+  variant: AtomicMutationProgramVariant,
+  check: string,
+): void {
+  if (fixture.equal(actual, expected)) return;
+  throw new AtomicMutationProgramConformanceError(
+    `Atomic mutation program conformance check failed: ${variant} ${check}.`,
+    { variant, check, actual, expected },
+  );
+}
+
+function assertDispatched(
+  before: number,
+  after: number,
+  variant: AtomicMutationProgramVariant,
+  check: string,
+): void {
+  if (
+    Number.isSafeInteger(before) &&
+    Number.isSafeInteger(after) &&
+    after > before
+  ) {
+    return;
+  }
+  throw new AtomicMutationProgramConformanceError(
+    `Atomic mutation program conformance did not dispatch ${variant} during ${check}.`,
+    { variant, check, before, after },
+  );
+}
+
+async function runSuccessCase(
+  fixture: AtomicMutationProgramConformanceFixture,
+  variant: AtomicMutationProgramVariant,
+  conformanceCase: AtomicMutationProgramSuccessCase,
+): Promise<void> {
+  const expected = await conformanceCase.prepare();
+  assertCaseBackendMatchesProfile(
+    fixture.backend,
+    fixtureProfile(fixture),
+    conformanceCase.resolveBackend(),
+    variant,
+    "ordered success",
+  );
+  const before = await conformanceCase.observeDispatchCount();
+  const result = await conformanceCase.execute();
+  const after = await conformanceCase.observeDispatchCount();
+  assertDispatched(before, after, variant, "ordered success");
+  assertEqual(
+    fixture,
+    result,
+    expected.expectedResult,
+    variant,
+    "ordered result",
+  );
+  assertEqual(
+    fixture,
+    await conformanceCase.observeState(),
+    expected.expectedState,
+    variant,
+    "committed state",
+  );
+}
+
+async function runRefusalCase(
+  fixture: AtomicMutationProgramConformanceFixture,
+  variant: AtomicMutationProgramVariant,
+  check: string,
+  conformanceCase: AtomicMutationProgramRefusalCase,
+): Promise<void> {
+  const expected = await conformanceCase.prepare();
+  assertCaseBackendMatchesProfile(
+    fixture.backend,
+    fixtureProfile(fixture),
+    conformanceCase.resolveBackend(),
+    variant,
+    check,
+  );
+  const before = await conformanceCase.observeDispatchCount();
+  let refusal: unknown;
+  try {
+    await conformanceCase.execute();
+  } catch (error) {
+    refusal = error;
+  }
+  const after = await conformanceCase.observeDispatchCount();
+  assertDispatched(before, after, variant, check);
+  if (refusal === undefined || !conformanceCase.errorMatches(refusal)) {
+    throw new AtomicMutationProgramConformanceError(
+      `Atomic mutation program conformance returned an unexpected refusal for ${variant} ${check}.`,
+      { variant, check, refusal },
+    );
+  }
+  assertEqual(
+    fixture,
+    await conformanceCase.observeState(),
+    expected.expectedState,
+    variant,
+    `${check} rollback`,
+  );
+}
+
+function fixtureProfile(
+  fixture: AtomicMutationProgramConformanceFixture,
+): AtomicMutationProgramExecutor {
+  const profile = resolveAtomicMutationPrograms(fixture.backend);
+  if (profile !== undefined) return profile;
+  throw new AtomicMutationProgramConformanceError(
+    "Atomic mutation program conformance requires an exact registered backend root.",
+    { check: "exact root registration" },
+  );
+}
+
+function indexCases(
+  cases: readonly AtomicMutationProgramConformanceCase[],
+): ReadonlyMap<
+  AtomicMutationProgramVariant,
+  AtomicMutationProgramConformanceCase
+> {
+  const indexed = new Map<
+    AtomicMutationProgramVariant,
+    AtomicMutationProgramConformanceCase
+  >();
+  for (const conformanceCase of cases) {
+    if (indexed.has(conformanceCase.variant)) {
+      throw new AtomicMutationProgramConformanceError(
+        `Atomic mutation program conformance received duplicate ${conformanceCase.variant} cases.`,
+        { variant: conformanceCase.variant },
+      );
+    }
+    indexed.set(conformanceCase.variant, conformanceCase);
+  }
+  return indexed;
+}
+
+/**
+ * Runs every mandatory semantic check for the profile the backend registers.
+ *
+ * Zero entry limits are honest opt-outs and therefore do not require an
+ * unreachable case. Any positive registered variant requires exactly one
+ * case, while a case for an unregistered variant is refused as misleading.
+ */
+export async function runAtomicMutationProgramConformance(
+  fixture: AtomicMutationProgramConformanceFixture,
+): Promise<AtomicMutationProgramConformanceReport> {
+  const profile = fixtureProfile(fixture);
+  const required = expectedVariants(profile);
+  const indexedCases = indexCases(fixture.cases);
+  for (const variant of required) {
+    if (indexedCases.has(variant)) continue;
+    throw new AtomicMutationProgramConformanceError(
+      `Atomic mutation program conformance is missing the registered ${variant} case.`,
+      { variant },
+    );
+  }
+  for (const variant of indexedCases.keys()) {
+    if (required.includes(variant)) continue;
+    throw new AtomicMutationProgramConformanceError(
+      `Atomic mutation program conformance received a case for unregistered ${variant}.`,
+      { variant },
+    );
+  }
+
+  const provenance = await assertExactRootRegistrationProvenance(
+    {
+      exactRootRegistration: () =>
+        hasAtomicMutationProgramRegistration(fixture.backend),
+      derivedBackendIsolation: () =>
+        !hasAtomicMutationProgramRegistration(
+          projectGraphBackend(fixture.backend),
+        ),
+      transactionBackendIsolation: () => {
+        if (!fixture.backend.capabilities.execution.interactiveTransactions) {
+          return true;
+        }
+        return fixture.backend.transaction((transaction) =>
+          Promise.resolve(!hasAtomicMutationProgramRegistration(transaction)),
+        );
+      },
+    } satisfies ExactRootRegistrationProvenanceChecks,
+    (name) =>
+      new AtomicMutationProgramConformanceError(
+        `Atomic mutation program provenance check failed: ${name}.`,
+        { check: name },
+      ),
+  );
+
+  const variants: AtomicMutationProgramConformanceReport["variants"][number][] =
+    [];
+  for (const variant of required) {
+    const conformanceCase = indexedCases.get(variant);
+    if (conformanceCase === undefined) continue;
+    await runSuccessCase(fixture, variant, conformanceCase.orderedSuccess);
+    await runRefusalCase(
+      fixture,
+      variant,
+      "stale fence",
+      conformanceCase.staleFenceNoWrite,
+    );
+    await runRefusalCase(
+      fixture,
+      variant,
+      "semantic refusal",
+      conformanceCase.semanticRefusalRollback,
+    );
+    variants.push({
+      variant,
+      passed: [
+        "ordered result and committed state",
+        "stale fence no-write",
+        "semantic refusal rollback",
+      ],
+    });
+  }
+
+  return { variants, provenance };
+}

--- a/packages/typegraph/src/backend/conformance/atomic-transport.ts
+++ b/packages/typegraph/src/backend/conformance/atomic-transport.ts
@@ -15,6 +15,7 @@ import type {
   AtomicSqlRow,
   CompiledAtomicSqlStatement,
 } from "../capabilities/atomic-sql-program";
+import { assertExactRootRegistrationProvenance } from "./exact-root-provenance";
 
 export type AtomicTransportEquality = (
   actual: unknown,
@@ -192,24 +193,15 @@ export async function runAtomicTransportConformance<TSnapshot = unknown>(
   assertEqual(fixture.equal, emptyAfter, emptyBefore, "empty-batch no-op");
   passed.push("empty batch");
 
-  const provenanceChecks = [
-    ["exact root registration", fixture.provenance.exactRootRegistration],
-    ["derived backend isolation", fixture.provenance.derivedBackendIsolation],
-    [
-      "transaction backend isolation",
-      fixture.provenance.transactionBackendIsolation,
-    ],
-  ] as const;
-  for (const [name, check] of provenanceChecks) {
-    if (await check()) {
-      passed.push(`provenance: ${name}`);
-      continue;
-    }
-    throw new AtomicTransportConformanceError(
-      `Atomic transport provenance check failed: ${name}.`,
-      { check: `provenance: ${name}` },
-    );
-  }
+  const provenance = await assertExactRootRegistrationProvenance(
+    fixture.provenance,
+    (name) =>
+      new AtomicTransportConformanceError(
+        `Atomic transport provenance check failed: ${name}.`,
+        { check: `provenance: ${name}` },
+      ),
+  );
+  passed.push(...provenance.map((name) => `provenance: ${name}`));
 
   return { passed };
 }

--- a/packages/typegraph/src/backend/conformance/exact-root-provenance.ts
+++ b/packages/typegraph/src/backend/conformance/exact-root-provenance.ts
@@ -1,0 +1,35 @@
+/** Exact-root registration checks shared by transport and semantic conformance. */
+export type ExactRootRegistrationProvenanceChecks = Readonly<{
+  exactRootRegistration: () => boolean | PromiseLike<boolean>;
+  derivedBackendIsolation: () => boolean | PromiseLike<boolean>;
+  transactionBackendIsolation: () => boolean | PromiseLike<boolean>;
+}>;
+
+const EXACT_ROOT_PROVENANCE_CHECKS = [
+  ["exact root registration", "exactRootRegistration"],
+  ["derived backend isolation", "derivedBackendIsolation"],
+  ["transaction backend isolation", "transactionBackendIsolation"],
+] as const satisfies readonly Readonly<
+  [string, keyof ExactRootRegistrationProvenanceChecks]
+>[];
+
+/**
+ * Owns the shared exact-root provenance verdict for conformance runners.
+ *
+ * The caller supplies its boundary-specific error vocabulary while this seam
+ * owns which registrations must be present or isolated.
+ */
+export async function assertExactRootRegistrationProvenance(
+  checks: ExactRootRegistrationProvenanceChecks,
+  createError: (check: string) => Error,
+): Promise<readonly string[]> {
+  const passed: string[] = [];
+  for (const [name, member] of EXACT_ROOT_PROVENANCE_CHECKS) {
+    if (await checks[member]()) {
+      passed.push(name);
+      continue;
+    }
+    throw createError(name);
+  }
+  return passed;
+}

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -202,6 +202,21 @@ export {
   normalizeGraphCommandIsolation,
 } from "./command-contract";
 export type {
+  AtomicMutationProgramConformanceCase,
+  AtomicMutationProgramConformanceFixture,
+  AtomicMutationProgramConformancePreparation,
+  AtomicMutationProgramConformanceReport,
+  AtomicMutationProgramRefusalCase,
+  AtomicMutationProgramRefusalPreparation,
+  AtomicMutationProgramSuccessCase,
+  AtomicMutationProgramVariant,
+} from "./conformance/atomic-mutation-program";
+export {
+  ATOMIC_MUTATION_PROGRAM_VARIANTS,
+  AtomicMutationProgramConformanceError,
+  runAtomicMutationProgramConformance,
+} from "./conformance/atomic-mutation-program";
+export type {
   AtomicTransportConformanceFixture,
   AtomicTransportConformanceReport,
   AtomicTransportEquality,

--- a/packages/typegraph/tests/atomic-mutation-program-conformance-libsql.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-conformance-libsql.test.ts
@@ -1,0 +1,202 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createClient } from "@libsql/client";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  markBundledRootAtomicMutationPrograms,
+  resolveAtomicMutationPrograms,
+} from "../src/backend/capabilities/atomic-mutation-program";
+import { runAtomicMutationProgramConformance } from "../src/backend/conformance/atomic-mutation-program";
+import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
+import { defineGraph, defineNode } from "../src/core";
+import { StaleVersionError, ValidationError } from "../src/errors";
+import { migrateSchema } from "../src/schema";
+import { createStoreWithSchema } from "../src/store";
+import { requireDefined } from "../src/utils/presence";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+function definePersonGraph(id: string) {
+  return defineGraph({
+    id,
+    nodes: { Person: { type: Person } },
+    edges: {},
+  });
+}
+
+function defineEvolvedPersonGraph(id: string) {
+  return defineGraph({
+    id,
+    nodes: {
+      Person: {
+        type: defineNode("Person", {
+          schema: z.object({
+            name: z.string(),
+            nickname: z.string().optional(),
+          }),
+        }),
+      },
+    },
+    edges: {},
+  });
+}
+
+async function createFixture() {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "typegraph-semantic-conformance-"),
+  );
+  const client = createClient({
+    url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+  });
+  const { backend } = await createLibsqlBackend(client);
+  const successGraph = definePersonGraph("semantic-conformance-success");
+  const staleGraph = definePersonGraph("semantic-conformance-stale");
+  const refusalGraph = definePersonGraph("semantic-conformance-refusal");
+  const [[successStore], [staleStore], [refusalStore]] = await Promise.all([
+    createStoreWithSchema(successGraph, backend),
+    createStoreWithSchema(staleGraph, backend),
+    createStoreWithSchema(refusalGraph, backend),
+  ]);
+  const createNodes = requireDefined(
+    resolveAtomicMutationPrograms(backend)?.createNodes,
+  );
+  markBundledRootAtomicMutationPrograms(backend, { createNodes });
+
+  return {
+    backend,
+    client,
+    refusalGraph,
+    refusalStore,
+    staleGraph,
+    staleStore,
+    successGraph,
+    successStore,
+    close: async () => {
+      await backend.close();
+      client.close();
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    },
+  };
+}
+
+async function readLivePeople(
+  client: ReturnType<typeof createClient>,
+  graphId: string,
+): Promise<readonly (readonly [string, string])[]> {
+  const result = await client.execute({
+    sql: `
+      SELECT id, json_extract(props, '$.name') AS name
+      FROM typegraph_nodes
+      WHERE graph_id = ? AND kind = ? AND deleted_at IS NULL
+      ORDER BY id
+    `,
+    args: [graphId, "Person"],
+  });
+  return result.rows.map((row) => {
+    if (typeof row["id"] !== "string" || typeof row["name"] !== "string") {
+      throw new TypeError("Expected string node id and name columns.");
+    }
+    return [row["id"], row["name"]] as const;
+  });
+}
+
+describe("atomic mutation program semantic conformance: libSQL", () => {
+  it("proves the complete createNodes Store contract against a real engine", async () => {
+    const fixture = await createFixture();
+    const batch = vi.spyOn(fixture.client, "batch");
+
+    try {
+      const report = await runAtomicMutationProgramConformance({
+        backend: fixture.backend,
+        equal: (actual, expected) =>
+          JSON.stringify(actual) === JSON.stringify(expected),
+        cases: [
+          {
+            variant: "createNodes",
+            orderedSuccess: {
+              prepare: () => ({
+                expectedResult: [
+                  ["second", "Second"],
+                  ["first", "First"],
+                ],
+                expectedState: [
+                  ["first", "First"],
+                  ["second", "Second"],
+                ],
+              }),
+              resolveBackend: () => fixture.backend,
+              execute: async () => {
+                const nodes =
+                  await fixture.successStore.nodes.Person.bulkCreate([
+                    { id: "second", props: { name: "Second" } },
+                    { id: "first", props: { name: "First" } },
+                  ]);
+                return nodes.map((node) => [node.id, node.name]);
+              },
+              observeDispatchCount: () => batch.mock.calls.length,
+              observeState: () =>
+                readLivePeople(fixture.client, fixture.successGraph.id),
+            },
+            staleFenceNoWrite: {
+              prepare: async () => {
+                await migrateSchema(
+                  fixture.backend,
+                  defineEvolvedPersonGraph(fixture.staleGraph.id),
+                  1,
+                );
+                return { expectedState: [] };
+              },
+              resolveBackend: () => fixture.backend,
+              execute: () =>
+                fixture.staleStore.nodes.Person.bulkInsert([
+                  { id: "stale", props: { name: "Stale" } },
+                ]),
+              observeDispatchCount: () => batch.mock.calls.length,
+              observeState: () =>
+                readLivePeople(fixture.client, fixture.staleGraph.id),
+              errorMatches: (error) => error instanceof StaleVersionError,
+            },
+            semanticRefusalRollback: {
+              prepare: async () => {
+                await fixture.refusalStore.nodes.Person.create(
+                  { name: "Existing" },
+                  { id: "existing" },
+                );
+                return { expectedState: [["existing", "Existing"]] };
+              },
+              resolveBackend: () => fixture.backend,
+              execute: () =>
+                fixture.refusalStore.nodes.Person.bulkInsert([
+                  { id: "new", props: { name: "New" } },
+                  { id: "existing", props: { name: "Duplicate" } },
+                ]),
+              observeDispatchCount: () => batch.mock.calls.length,
+              observeState: () =>
+                readLivePeople(fixture.client, fixture.refusalGraph.id),
+              errorMatches: (error) => error instanceof ValidationError,
+            },
+          },
+        ],
+      });
+
+      expect(report.variants).toEqual([
+        {
+          variant: "createNodes",
+          passed: [
+            "ordered result and committed state",
+            "stale fence no-write",
+            "semantic refusal rollback",
+          ],
+        },
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  });
+});

--- a/packages/typegraph/tests/atomic-mutation-program-conformance.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-conformance.test.ts
@@ -1,0 +1,494 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type AtomicEdgeMutationProgramExecutor,
+  type AtomicMutationProgramRegistration,
+  type AtomicNodeBatchExecutor,
+  type AtomicNodeResolvedMutationSetExecutor,
+  type AtomicNodeResolvedUpdateBatchExecutor,
+  markBundledRootAtomicMutationPrograms,
+} from "../src/backend/capabilities/atomic-mutation-program";
+import {
+  type AtomicMutationProgramConformanceCase,
+  AtomicMutationProgramConformanceError,
+  type AtomicMutationProgramRefusalCase,
+  runAtomicMutationProgramConformance,
+} from "../src/backend/conformance/atomic-mutation-program";
+import { assertExactRootRegistrationProvenance } from "../src/backend/conformance/exact-root-provenance";
+import type { GraphBackend } from "../src/backend/types";
+import { requireDefined } from "../src/utils/presence";
+
+class ExpectedRefusal extends Error {}
+
+function callableWithLimit<T>(limit: number): T {
+  const executor = (() => Promise.resolve([])) as T;
+  Object.defineProperty(executor, "maxEntries", {
+    value: limit,
+  });
+  return executor;
+}
+
+function edgeMutationExecutor(
+  maxEntries?: AtomicEdgeMutationProgramExecutor["maxEntries"],
+): AtomicEdgeMutationProgramExecutor {
+  const executor = (() =>
+    Promise.resolve([])) as unknown as AtomicEdgeMutationProgramExecutor;
+  Object.defineProperty(executor, "maxEntries", {
+    value: maxEntries ?? { durableConvergence: 1, resolvedSet: 1 },
+  });
+  return executor;
+}
+
+function completeRegistration(): AtomicMutationProgramRegistration {
+  const noLimitExecutor = (() =>
+    Promise.resolve([])) as unknown as AtomicNodeBatchExecutor;
+  return {
+    createNodes: noLimitExecutor,
+    createEdges: (() => Promise.resolve([])) as never,
+    deleteNodes: () =>
+      Promise.resolve({
+        affectedCount: 0,
+        schemaFenceMatched: true,
+      }),
+    deleteEdges: () =>
+      Promise.resolve({
+        affectedCount: 0,
+        schemaFenceMatched: true,
+      }),
+    updateNodes: callableWithLimit<AtomicNodeResolvedUpdateBatchExecutor>(1),
+    updateEdges: callableWithLimit(1),
+    mutateNodes: callableWithLimit<AtomicNodeResolvedMutationSetExecutor>(1),
+    mutateEdges: edgeMutationExecutor(),
+  };
+}
+
+function successCase() {
+  let dispatchCount = 0;
+  let state: unknown = [];
+  return {
+    prepare: () => {
+      state = [];
+      return {
+        expectedResult: ["second", "first"],
+        expectedState: ["first", "second"],
+      };
+    },
+    resolveBackend: () => {
+      throw new Error("Conformance case was not bound to a backend.");
+    },
+    execute: () => {
+      dispatchCount += 1;
+      state = ["first", "second"];
+      return ["second", "first"];
+    },
+    observeState: () => state,
+    observeDispatchCount: () => dispatchCount,
+  };
+}
+
+function refusalCase(): AtomicMutationProgramRefusalCase {
+  let dispatchCount = 0;
+  let state: unknown = ["before"];
+  return {
+    prepare: () => {
+      state = ["before"];
+      return { expectedState: ["before"] };
+    },
+    resolveBackend: () => {
+      throw new Error("Conformance case was not bound to a backend.");
+    },
+    execute: () => {
+      dispatchCount += 1;
+      throw new ExpectedRefusal();
+    },
+    observeState: () => state,
+    observeDispatchCount: () => dispatchCount,
+    errorMatches: (error) => error instanceof ExpectedRefusal,
+  };
+}
+
+function conformanceCase(
+  variant: AtomicMutationProgramConformanceCase["variant"],
+): AtomicMutationProgramConformanceCase {
+  return {
+    variant,
+    orderedSuccess: successCase(),
+    staleFenceNoWrite: refusalCase(),
+    semanticRefusalRollback: refusalCase(),
+  };
+}
+
+function completeCases(): readonly AtomicMutationProgramConformanceCase[] {
+  return [
+    conformanceCase("createNodes"),
+    conformanceCase("createEdges"),
+    conformanceCase("deleteNodes"),
+    conformanceCase("deleteEdges"),
+    conformanceCase("updateNodes"),
+    conformanceCase("updateEdges"),
+    conformanceCase("mutateNodes"),
+    conformanceCase("mutateEdges.resolvedSet"),
+    conformanceCase("mutateEdges.durableConvergence"),
+  ];
+}
+
+function createProfileBackend(
+  registration: AtomicMutationProgramRegistration,
+): GraphBackend {
+  const backend = {
+    capabilities: {
+      execution: {
+        atomicBatch: "root",
+        interactiveTransactions: false,
+      },
+    },
+  } as unknown as GraphBackend;
+  return markBundledRootAtomicMutationPrograms(backend, registration);
+}
+
+function bindCaseToBackend(
+  conformanceCase: AtomicMutationProgramConformanceCase,
+  backend: GraphBackend,
+): AtomicMutationProgramConformanceCase {
+  return {
+    ...conformanceCase,
+    orderedSuccess: {
+      ...conformanceCase.orderedSuccess,
+      resolveBackend: () => backend,
+    },
+    staleFenceNoWrite: {
+      ...conformanceCase.staleFenceNoWrite,
+      resolveBackend: () => backend,
+    },
+    semanticRefusalRollback: {
+      ...conformanceCase.semanticRefusalRollback,
+      resolveBackend: () => backend,
+    },
+  };
+}
+
+function fixture(
+  registration: AtomicMutationProgramRegistration = completeRegistration(),
+  cases: readonly AtomicMutationProgramConformanceCase[] = completeCases(),
+) {
+  const backend = createProfileBackend(registration);
+  return {
+    backend,
+    cases: cases.map((conformanceCase) =>
+      bindCaseToBackend(conformanceCase, backend),
+    ),
+    equal: (actual: unknown, expected: unknown) =>
+      JSON.stringify(actual) === JSON.stringify(expected),
+  } as const;
+}
+
+describe("atomic mutation program conformance runner", () => {
+  it("runs every enabled family variant and exact-root provenance check", async () => {
+    const report = await runAtomicMutationProgramConformance(fixture());
+
+    expect(report.variants.map((entry) => entry.variant)).toEqual([
+      "createNodes",
+      "createEdges",
+      "deleteNodes",
+      "deleteEdges",
+      "updateNodes",
+      "updateEdges",
+      "mutateNodes",
+      "mutateEdges.resolvedSet",
+      "mutateEdges.durableConvergence",
+    ]);
+    expect(report.variants.every((entry) => entry.passed.length === 3)).toBe(
+      true,
+    );
+    expect(report.provenance).toEqual([
+      "exact root registration",
+      "derived backend isolation",
+      "transaction backend isolation",
+    ]);
+  });
+
+  it("requires a case for every positive registered variant", async () => {
+    const cases = completeCases().filter(
+      (entry) => entry.variant !== "deleteNodes",
+    );
+
+    await expect(
+      runAtomicMutationProgramConformance(fixture(undefined, cases)),
+    ).rejects.toMatchObject({
+      details: { variant: "deleteNodes" },
+    });
+  });
+
+  it("does not let an unregistered family borrow another family proof", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+
+    await expect(
+      runAtomicMutationProgramConformance(
+        fixture(registration, [
+          conformanceCase("createNodes"),
+          conformanceCase("createEdges"),
+        ]),
+      ),
+    ).rejects.toMatchObject({
+      details: { variant: "createEdges" },
+    });
+  });
+
+  it("treats zero limits as honest disabled variants", async () => {
+    const registrations = [
+      {
+        updateNodes:
+          callableWithLimit<AtomicNodeResolvedUpdateBatchExecutor>(0),
+      },
+      { updateEdges: callableWithLimit(0) },
+      {
+        mutateNodes:
+          callableWithLimit<AtomicNodeResolvedMutationSetExecutor>(0),
+      },
+      {
+        mutateEdges: edgeMutationExecutor({
+          durableConvergence: 0,
+          resolvedSet: 0,
+        }),
+      },
+    ] satisfies readonly AtomicMutationProgramRegistration[];
+
+    for (const registration of registrations) {
+      const report = await runAtomicMutationProgramConformance(
+        fixture(registration, []),
+      );
+      expect(report.variants).toEqual([]);
+    }
+  });
+
+  it("requires only the positive mutateEdges sub-limit", async () => {
+    const registration = {
+      mutateEdges: edgeMutationExecutor({
+        durableConvergence: 0,
+        resolvedSet: 1,
+      }),
+    };
+
+    const report = await runAtomicMutationProgramConformance(
+      fixture(registration, [conformanceCase("mutateEdges.resolvedSet")]),
+    );
+
+    expect(report.variants.map((entry) => entry.variant)).toEqual([
+      "mutateEdges.resolvedSet",
+    ]);
+  });
+
+  it("refuses duplicate cases instead of choosing one proof", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const duplicate = conformanceCase("createNodes");
+
+    await expect(
+      runAtomicMutationProgramConformance(
+        fixture(registration, [duplicate, duplicate]),
+      ),
+    ).rejects.toBeInstanceOf(AtomicMutationProgramConformanceError);
+  });
+
+  it("catches a success case that bypasses the registered executor", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const base = conformanceCase("createNodes");
+    const bypassed = {
+      ...base,
+      orderedSuccess: {
+        prepare: () => ({
+          expectedResult: ["second", "first"],
+          expectedState: ["first", "second"],
+        }),
+        resolveBackend: base.orderedSuccess.resolveBackend,
+        execute: vi.fn(() => ["second", "first"]),
+        observeState: () => ["first", "second"],
+        observeDispatchCount: () => 0,
+      },
+    };
+
+    await expect(
+      runAtomicMutationProgramConformance(fixture(registration, [bypassed])),
+    ).rejects.toMatchObject({
+      details: { check: "ordered success", variant: "createNodes" },
+    });
+  });
+
+  it("catches an ordered result that disagrees with committed state", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const base = conformanceCase("createNodes");
+    const misordered = {
+      ...base,
+      orderedSuccess: {
+        ...base.orderedSuccess,
+        execute: () => {
+          base.orderedSuccess.execute();
+          return ["first", "second"];
+        },
+      },
+    };
+
+    await expect(
+      runAtomicMutationProgramConformance(fixture(registration, [misordered])),
+    ).rejects.toMatchObject({
+      details: { check: "ordered result", variant: "createNodes" },
+    });
+  });
+
+  it("catches a refusal that bypasses the registered executor", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const base = conformanceCase("createNodes");
+    const bypassed = {
+      ...base,
+      staleFenceNoWrite: {
+        ...base.staleFenceNoWrite,
+        execute: () => {
+          throw new ExpectedRefusal();
+        },
+        observeDispatchCount: () => 0,
+      },
+    };
+
+    await expect(
+      runAtomicMutationProgramConformance(fixture(registration, [bypassed])),
+    ).rejects.toMatchObject({
+      details: { check: "stale fence", variant: "createNodes" },
+    });
+  });
+
+  it("catches a semantic refusal that leaks a sibling write", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const base = conformanceCase("createNodes");
+    let state: unknown = ["before"];
+    let dispatchCount = 0;
+    const leaking = {
+      ...base,
+      semanticRefusalRollback: {
+        ...base.semanticRefusalRollback,
+        prepare: () => {
+          state = ["before"];
+          return { expectedState: ["before"] };
+        },
+        execute: () => {
+          dispatchCount += 1;
+          state = ["leaked"];
+          throw new ExpectedRefusal();
+        },
+        observeDispatchCount: () => dispatchCount,
+        observeState: () => state,
+      },
+    };
+
+    await expect(
+      runAtomicMutationProgramConformance(fixture(registration, [leaking])),
+    ).rejects.toMatchObject({
+      details: {
+        check: "semantic refusal rollback",
+        variant: "createNodes",
+      },
+    });
+  });
+
+  it("refuses an unregistered profile before executing a case", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const base = conformanceCase("createNodes");
+    const bound = fixture(registration, [base]);
+    const execute = vi.fn(base.orderedSuccess.execute);
+    const backend = {
+      capabilities: {
+        execution: {
+          atomicBatch: "root",
+          interactiveTransactions: false,
+        },
+      },
+    } as unknown as GraphBackend;
+
+    await expect(
+      runAtomicMutationProgramConformance({
+        ...bound,
+        backend,
+        cases: bound.cases.map((entry) => ({
+          ...entry,
+          orderedSuccess: { ...entry.orderedSuccess, execute },
+        })),
+      }),
+    ).rejects.toMatchObject({
+      details: { check: "exact root registration" },
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("refuses transaction-scoped registration leakage before executing a case", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const base = conformanceCase("createNodes");
+    const execute = vi.fn(base.orderedSuccess.execute);
+    const backend = {
+      capabilities: {
+        execution: {
+          atomicBatch: "root",
+          interactiveTransactions: true,
+        },
+      },
+      transaction: (callback: (transaction: GraphBackend) => unknown) =>
+        Promise.resolve(callback(backend)),
+    } as unknown as GraphBackend;
+    markBundledRootAtomicMutationPrograms(backend, registration);
+    const bound = bindCaseToBackend(
+      {
+        ...base,
+        orderedSuccess: { ...base.orderedSuccess, execute },
+      },
+      backend,
+    );
+
+    await expect(
+      runAtomicMutationProgramConformance({
+        backend,
+        cases: [bound],
+        equal: (actual, expected) => actual === expected,
+      }),
+    ).rejects.toMatchObject({
+      details: { check: "transaction backend isolation" },
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("refuses an equivalent profile bound to a different root", async () => {
+    const registration = { createNodes: completeRegistration().createNodes };
+    const bound = fixture(registration, [conformanceCase("createNodes")]);
+    const boundCase = requireDefined(bound.cases[0]);
+    const differentBackend = createProfileBackend(registration);
+    const mismatched = {
+      ...boundCase,
+      orderedSuccess: {
+        ...boundCase.orderedSuccess,
+        resolveBackend: () => differentBackend,
+      },
+    };
+
+    await expect(
+      runAtomicMutationProgramConformance({ ...bound, cases: [mismatched] }),
+    ).rejects.toMatchObject({
+      details: { check: "ordered success", variant: "createNodes" },
+    });
+  });
+
+  it.each([
+    ["exactRootRegistration", "exact root registration"],
+    ["derivedBackendIsolation", "derived backend isolation"],
+    ["transactionBackendIsolation", "transaction backend isolation"],
+  ] as const)("owns the %s provenance verdict", async (member, name) => {
+    const checks = {
+      exactRootRegistration: () => true,
+      derivedBackendIsolation: () => true,
+      transactionBackendIsolation: () => true,
+      [member]: () => false,
+    };
+
+    await expect(
+      assertExactRootRegistrationProvenance(
+        checks,
+        (check) => new Error(check),
+      ),
+    ).rejects.toThrow(name);
+  });
+});

--- a/packages/typegraph/tests/backend-derivation-inventory.test.ts
+++ b/packages/typegraph/tests/backend-derivation-inventory.test.ts
@@ -93,6 +93,12 @@ const INVENTORY: readonly InventoryEntry[] = [
       "The seam composing itself: managed close is an overlay of one member, so the idempotent `close` decorates rather than copies.",
   },
   {
+    file: "backend/conformance/atomic-mutation-program.ts",
+    line: "projectGraphBackend(fixture.backend),",
+    reason:
+      "Semantic conformance deliberately probes a projected view of the registered root to prove exact-root mutation-program evidence does not leak through derivation.",
+  },
+  {
     file: "backend/drizzle/contribution-materializations.ts",
     line: "return deriveBackend<TransactionBackend>(",
     reason:


### PR DESCRIPTION
Custom backends can now certify the Store-level semantics behind each atomic mutation program family rather than relying on transport conformance as a proxy. The new framework-agnostic runner derives the registered profile from an exact backend root and requires ordered results, independently observed committed state, stale-fence no-write behavior, typed semantic-refusal rollback, and observed native dispatch for every positive-limit family variant.

Transport and semantic evidence remain separate. Exact-root provenance now has one shared owner used by both conformance layers, and semantic cases must execute against the same registered backend and profile object, preventing detached profile descriptions, counters, or equivalent-but-unrelated roots from serving as evidence.

The first real-engine fixture certifies `createNodes` against libSQL with direct storage reads and isolated success, stale-fence, and rollback graphs. Documentation now shows custom backend authors how to register transport and semantics, run both conformance layers, and pair them with the shared Store integration suite.

The runner's load-bearing guards were mutation-checked: disabling native-dispatch and rollback-state verdicts made their dedicated negative cases fail.
