### PR TITLE
perf: execute mixed mutation sets on PostgreSQL sessions

### DIFF
--- a/.changeset/atomic-operation-session-programs.md
+++ b/.changeset/atomic-operation-session-programs.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Execute eligible mixed node and edge `bulkUpsertById()` mutation sets through atomic programs bound to the exact collection-opened, caller-supplied, or adopted PostgreSQL transaction. The operation now returns an explicit `applied | unsupported` verdict, where `unsupported` is emitted before program SQL and safely re-enters the complete portable path. Transaction-session programs use a savepoint so typed refusal diagnosis remains available without committing or poisoning the caller's surrounding transaction.

--- a/apps/docs/src/content/docs/architecture.md
+++ b/apps/docs/src/content/docs/architecture.md
@@ -602,22 +602,26 @@ submitted:
 
 - A **closed mutation program** carries every input, fence, and refusal rule
   needed for the database to decide the write. Eligible node/edge creates and
-  soft deletes use one exact-root execution profile and can run as one native
+  soft deletes use one exact-resource execution profile and can run as one native
   atomic exchange on bundled serverless transports. The profile is attached to
-  the exact backend object; derived and transaction-scoped backends do not
-  inherit it accidentally.
+  the exact backend object. Derived backends do not inherit it accidentally;
+  an already-open PostgreSQL transaction earns a separate session-bound
+  registration.
 - A **resolved mutation set** requires an authoritative database preimage and
   application computation before its writes are known. `bulkUpsertById()` is
   the canonical example: stored props are merged and Zod-validated, temporal
   decisions are derived, and repeated IDs observe earlier batch items. An
-  eligible distinct-ID set can cross the exact-root boundary after resolution:
+  eligible distinct-ID set can cross the exact registered boundary after resolution:
   its guarded SQL carries the node versions or complete edge preimages that
   justified the after-images. Update-only sets use one guarded set statement;
   mixed create/update sets add a terminal database postimage assertion inside
   the same native exchange, so an incomplete update aborts and rolls back its
   creates before the transport commits. Complex sets resolve and execute inside
   one interactive transaction. Neither shape is mislabeled as a read-free
-  program.
+  program. On an interactive PostgreSQL root, the operation runs on the exact
+  collection-opened, caller-supplied, or adopted transaction and returns an
+  explicit `applied | unsupported` verdict. `unsupported` proves that no
+  program SQL ran before the complete portable path begins.
 
 This boundary keeps transport optimization subordinate to Store semantics. A
 new bulk optimization must either prove its mutation is closed or name the

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1197,7 +1197,7 @@ can inspect the same object as `backend.capabilities`. The shape is:
 
 | Field                                                                      | Meaning                                                                                             |
 | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `execution`                                                                | Execution boundaries: `interactiveTransactions` and exact-root `atomicBatch` support                |
+| `execution`                                                                | Execution boundaries: `interactiveTransactions` and exact-resource `atomicBatch` support            |
 | `windowFunctions`                                                          | SQL window functions such as `ROW_NUMBER()` are available                                           |
 | `constraintClaims?`                                                        | The backend carries the claim relations that fence declared constraints without a lock (see below)  |
 | `durableEdgeMatchIdentity?`                                                | Edge writes persist and atomically arbitrate a schema-declared endpoint/property identity            |
@@ -1211,10 +1211,13 @@ can inspect the same object as `backend.capabilities`. The shape is:
 The former top-level `capabilities.transactions` override is not interpreted
 as an alias. Bundled factories refuse it with `LEGACY_CAPABILITY_OVERRIDE`,
 including for JavaScript and already-compiled callers, because transaction
-availability and root atomic batching are now independent facts. Move the
-value to `capabilities.execution.interactiveTransactions`; root
-`atomicBatch` support is discovered from the bundled transport and cannot be
-claimed through factory overrides.
+availability and atomic batching are now independent facts. Move the value to
+`capabilities.execution.interactiveTransactions`; root `atomicBatch` support
+is discovered from the bundled transport and cannot be claimed through factory
+overrides. Bundled PostgreSQL transaction factories may expose
+`atomicBatch: "session"` on the exact already-open transaction object. That
+declaration is paired with fresh transport and semantic registrations and is
+never inherited by an ordinary derived backend.
 
 `graphAnalytics.supported` describes the backend shape, not mutable PostgreSQL
 session state. A hot standby or a role without the database `TEMP` privilege can
@@ -1451,9 +1454,11 @@ await runAtomicMutationProgramConformance({
 });
 ```
 
-Transport registration is exact-root evidence only: a derived or
-transaction-scoped backend does not inherit it, and a second registration on
-the same root is refused rather than replacing the function production uses.
+Transport registration is exact-resource evidence only: a derived backend does
+not inherit it, and a second registration on the same object is refused rather
+than replacing the function production uses. A bundled PostgreSQL transaction
+session earns a separate registration bound to its pinned client; it does not
+inherit the root's registration.
 Create wrappers with the exported `decorateBackend()` seam so the runner can
 verify their lineage back to the registered root instead of accepting an
 unrelated object as derivation evidence. The conformance fixture's mandatory
@@ -1467,15 +1472,16 @@ program.
 
 The separate `registerAtomicMutationPrograms()` call is the semantic boundary:
 each member declares one complete TypeGraph mutation family implemented by that
-exact root. Omitted families retain the portable path, and an empty profile or
+exact backend resource. Omitted families retain the portable path, and an empty profile or
 a profile registered before its atomic transport is refused with
 `ConfigurationError`.
 
 The semantic executors must preserve the same schema fence, validation,
 side-effect, refusal classification, rollback, postimage correlation, result
 ordering, and bind-ceiling contracts as the bundled implementation. Registering
-one family is not evidence for another. Derived, projected, and
-transaction-scoped backends inherit neither root registration.
+one family is not evidence for another. Derived and projected backends inherit
+neither registration. An exact transaction session must be registered
+independently before Store code can dispatch through it.
 
 `runAtomicMutationProgramConformance()` is the executable semantic boundary.
 For every reachable positive-limit variant in `mutationPrograms`, the fixture supplies
@@ -1537,9 +1543,11 @@ update-only and mixed mutation executors are independently reachable Store
 families even when their entry ceilings are equal, so each requires its own
 conformance evidence. On an interactive root, the collection-level
 read/partition/write unit moves into a transaction and exact-root registration
-does not follow; the conformance inventory therefore excludes those four root
-variants while continuing to require direct create, delete, and durable
-convergence evidence.
+does not follow; the root conformance inventory therefore excludes the mixed
+variants while continuing to require direct create, delete, update, and durable
+convergence evidence. Bundled PostgreSQL binds the same reviewed lowering to the
+exact transaction session and exercises the mixed node and edge variants against
+a real engine, including typed refusal rollback.
 Backend authors implementing edge
 refusal paths use the exported
 `AtomicEdgeBatchEndpointRefusalError`,
@@ -1696,8 +1704,8 @@ TypeGraph choosing separate query semantics per backend:
 | Managed node projection fusion                        | ✗ portable transactional fallback                    | ✓ PostgreSQL/PGlite                        | SQLite writes the node and fulltext/vector sidecars through the portable transaction path. PostgreSQL can compile them into one managed statement when every active strategy supplies an inserted-node builder |
 | Managed node claim fusion (`capabilities.atomicNodeInsertClaims`) | ✗ portable transactional fallback             | ✓ PostgreSQL/PGlite                        | SQLite keeps claim acquisition and insertion in the portable transaction. PostgreSQL transaction receivers fuse supported claim plans; a root non-transactional receiver is limited to exactly one generated-id, same-kind uniqueness claim with no other side effects |
 | Managed edge cardinality fusion                       | ✗ portable transactional fallback                    | ✓ PostgreSQL/PGlite transaction receivers | SQLite keeps its guarded claim and edge insert in the portable transaction. PostgreSQL can combine endpoint liveness, one cardinality claim, and the insert in one statement after any required graph lock |
-| Atomic SQL transport (`capabilities.execution.atomicBatch`) | ✓ on certified D1/libSQL roots; otherwise `none` | ✓ on bundled recognized PostgreSQL drivers, including neon-http | `root` is an exact-backend declaration paired with a registered executor. Neon HTTP uses its native transaction batch; session-capable `pg`, postgres-js, neon-serverless, and PGlite drivers execute the program on one pinned Drizzle transaction. Unrecognized drivers remain `none`. A custom backend must pass the framework-agnostic conformance runner before opting in; omitted support keeps the portable path |
-| Eligible exact-root managed writes                    | ✓ bundled SQLite roots, including D1 and libSQL     | ✓ bundled PostgreSQL roots, including neon-http | Eligible singleton generated-ID nodes and `cardinality: "many"` edges use one authoritative create statement. Eligible sidecar-free node updates, unconstrained non-durable-identity edge updates, direct edge deletes, and plain restricted node deletes use one authoritative read/gate plus one registered atomic mutation. Plain, projection-free generated-, caller-, or mixed-ID node `bulkInsert`/`bulkCreate` batches and direct edge batches without history/revision capture use one schema-fenced native atomic program; edge programs also maintain durable match identity and cardinality claims. Direct edge `bulkDelete` and plain restricted node `bulkDelete` use the same exact-root mutation profile. A custom backend may opt in per family only after registering its exact-root atomic transport and semantic executor. Derived wrappers, adopted caller transactions, unregistered or otherwise ineligible families, constrained/projected/identity-enabled node deletes, cascade/disconnect deletes, and other managed writes retain the existing path |
+| Atomic SQL transport (`capabilities.execution.atomicBatch`) | ✓ on certified D1/libSQL roots; otherwise `none` | ✓ on bundled recognized PostgreSQL drivers, including neon-http | `root` means the exact backend owns the atomic boundary; `session` means the exact object is already bound to an open transaction and the outer transaction owns commit/rollback. Both require identity-keyed executor registration. Neon HTTP uses its native transaction batch; session-capable `pg`, postgres-js, neon-serverless, and PGlite drivers can execute programs on one pinned Drizzle transaction. Unrecognized drivers remain `none`. A custom backend must pass the framework-agnostic conformance runner before opting in; omitted support keeps the portable path |
+| Eligible registered managed writes                    | ✓ bundled SQLite roots, including D1 and libSQL     | ✓ bundled PostgreSQL roots, including neon-http | Eligible singleton generated-ID nodes and `cardinality: "many"` edges use one authoritative create statement. Eligible sidecar-free node updates, unconstrained non-durable-identity edge updates, direct edge deletes, and plain restricted node deletes use one authoritative read/gate plus one registered atomic mutation. Plain, projection-free generated-, caller-, or mixed-ID node `bulkInsert`/`bulkCreate` batches and direct edge batches without history/revision capture use one schema-fenced native atomic program; edge programs also maintain durable match identity and cardinality claims. Direct edge `bulkDelete` and plain restricted node `bulkDelete` use the same mutation profile. Eligible mixed `bulkUpsertById` sets use the profile on serverless roots and on exact bundled PostgreSQL transaction sessions; a generic derived backend still loses the evidence. A custom backend may opt in per family only after registering its exact transport and semantic executor. Unregistered or otherwise ineligible families, constrained/projected/identity-enabled node deletes, cascade/disconnect deletes, and other managed writes retain the existing path |
 | Typed constraint error above READ COMMITTED            | n/a (no such isolation mode)                      | ✗ at `REPEATABLE READ` / `SERIALIZABLE`    | PostgreSQL raises `40001` from the claim's upsert instead of resolving the conflict, so the loser retries a serialization failure rather than reading `UniquenessError` |
 | Claim row lock released before end of transaction      | ✗                                                 | ✗                                          | Held to commit/rollback on both dialects, refusal included — a caller that catches a constraint error blocks other writers of that axis for the rest of its transaction |
 | Recursive traversal (`capabilities.recursiveTraversal`) | ✓                                                 | ✓                                          | Identical on both bundled backends. A third-party backend declaring `{ supported: false, reason }` refuses the five recursion-dependent operations with `ConfigurationError` code `RECURSIVE_TRAVERSAL_UNSUPPORTED`; `weightedShortestPath` degrades to a predecessor walk instead — see above. Unweighted `shortestPath` is unaffected — it never emits a recursive CTE |

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1548,6 +1548,13 @@ variants while continuing to require direct create, delete, update, and durable
 convergence evidence. Bundled PostgreSQL binds the same reviewed lowering to the
 exact transaction session and exercises the mixed node and edge variants against
 a real engine, including typed refusal rollback.
+An exact `atomicBatch: "session"` conformance fixture includes those mixed
+variants even though `interactiveTransactions` is true; nested-transaction
+isolation is reported as inapplicable because the fixture resource is already
+the open transaction. The transport runner accepts the same exact-session
+resource and certifies its ordered slots, parameter preservation, rollback,
+and empty-program behavior. Generic derived session objects still lose both
+the declaration and the identity-bound registrations.
 Backend authors implementing edge
 refusal paths use the exported
 `AtomicEdgeBatchEndpointRefusalError`,

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -359,14 +359,21 @@ SQL. Other delete shapes retain their transaction path. `bulkUpsertById()`
 remains a resolved mutation set because it must read and schema-validate a
 database preimage before its writes are known. Bundled serverless roots can
 submit an eligible distinct-ID, live-row resolved set as one native exchange
-after that read. Update-only sets use a guarded update; sets containing both
+after that read. Bundled session-capable PostgreSQL can bind the same program
+to the exact collection-opened, caller-supplied, or adopted transaction; this
+is a bounded statement sequence on the pinned session, not one network
+exchange. Update-only sets use a guarded update; sets containing both
 fresh creates and updates include a terminal database assertion that rolls the
 whole exchange back when any guarded postimage is absent. Repeated IDs,
 resurrections, temporal changes, sidecars (including durable edge match
-identity), history/revision capture, and caller transactions use the interactive
-path. On D1's 100-parameter budget the native ceiling is 17 total node mutations
+identity), history/revision capture, ordinary derived backends, and
+unregistered sessions use the interactive path. On D1's 100-parameter budget the native ceiling is 17 total node mutations
 or 6 total edge mutations; larger batches return to the interactive path rather
-than splitting the all-or-nothing guard across autocommit statements.
+than splitting the all-or-nothing guard across autocommit statements. The
+operation returns an explicit `unsupported` verdict before issuing program SQL;
+the Store never infers fallback safety from a missing result. Once a session
+program starts, a savepoint preserves the surrounding transaction for typed
+refusal diagnosis.
 
 Eligible singleton `update()` and `delete()` calls reuse those same registered
 families. Plain node updates, unconstrained non-durable-identity edge updates,

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -224,26 +224,36 @@ submits one guarded atomic update. Every direct edge delete, and a restricted
 node delete owing none of those sidecars, performs its existing live-row gate
 and then submits one guarded atomic delete. Missing or tombstoned deletes remain
 hook-free read-only no-ops. Temporal mutations, node cascade/disconnect,
-history/revision capture, derived backends, caller transactions, and
-unregistered custom families retain the complete portable transaction path.
+history/revision capture, ordinary derived backends, and unregistered custom
+families retain the complete portable transaction path.
 The guarded update converges optimistically rather than holding a transaction
 lock across its read and write. A one-row update gets four attempts; sustained
 same-row contention can still end in `DatabaseOperationError`, while larger
 resolved batches retain their two-attempt budget to bound retry cost.
 
-These operations are registered through one exact-root mutation execution
+These operations are registered through an exact-resource mutation execution
 profile. Create and delete are **closed programs**: validation and arbitration
 can be expressed by the submitted SQL itself. `bulkUpsertById()` is deliberately
 different. It first reads authoritative stored properties, then merges and
-validates them before its write set is known. On bundled serverless roots, an
+validates them before its write set is known. On bundled serverless roots, a
 distinct-ID batch with no claims, projections, Operational Identity, durable
 edge match identity, temporal mutation, history, or revision capture submits
-its resolved mutation set as one atomic exchange. Update-only sets use one
+its resolved mutation set as one atomic exchange. An eligible set on bundled
+session-capable PostgreSQL stays inside its exact open transaction and
+dispatches the same reviewed program through a separate registration bound to
+that pinned transaction. Its `applied | unsupported` result is explicit:
+`unsupported` is returned only before any program SQL runs, after which the
+collection enters the complete portable path. Update-only sets use one
 guarded set update. A set containing both fresh creates and live updates carries
 both legs plus a zero-write terminal postimage assertion in the same native
 batch; an incomplete preimage deliberately aborts the batch before any create
-can commit. Repeated IDs, resurrections, temporal changes, sidecars, and caller
-transactions retain the consolidated interactive path.
+can commit. Repeated IDs, resurrections, temporal changes, sidecars, and
+unregistered transaction sessions retain the consolidated interactive path.
+The exact session may be collection-opened, supplied by `store.transaction()`,
+or adopted from the caller. A
+session program uses a savepoint so a deliberate database refusal can be rolled
+back and diagnosed without poisoning the caller's surrounding PostgreSQL
+transaction.
 
 Measured at the libSQL transport boundary, eligible plain node
 `bulkInsert()` and `bulkCreate()` calls each submit one exchange for generated,
@@ -268,10 +278,18 @@ contains the SQL statements needed for inserts and sidecars; it submits them as
 one transaction so they do not each pay network latency. The exact previous
 count varies by driver and endpoint shape.
 
+On session-capable PostgreSQL, the preimage read and mutation program remain in
+one collection-owned transaction. The program has a bounded number of
+statements independent of row count within its bind ceiling; it is not described
+as a single network exchange because wire-protocol drivers execute those
+statements on the pinned session. The gain is removal of the portable
+per-family/per-member write-plan fan-out while retaining whole-call rollback.
+
 These are internal execution optimizations, not a public Store batch API.
-History/revision capture, caller-owned transactions, derived or custom
-backends, dynamic get-or-create convergence, and other unsupported shapes
-retain their transaction or fallback behavior.
+History/revision capture, ordinary derived or custom backends, dynamic
+get-or-create convergence, and other unsupported shapes retain their
+transaction or fallback behavior. Eligible mixed sets inside a bundled
+PostgreSQL transaction are the narrow session-bound exception.
 
 ### Single vs bulk operations
 

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -32,7 +32,7 @@ export type AnyPgTransaction = PgTransaction<PgQueryResultHKT, Record<string, un
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -29,7 +29,7 @@ export type AnyPgTransaction = PgTransaction<PgQueryResultHKT, Record<string, un
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -25,7 +25,7 @@ export type AnySqliteDatabase = BaseSQLiteDatabase<"sync" | "async", unknown>;
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -24,7 +24,7 @@ export type AnySqliteDatabase = BaseSQLiteDatabase<"sync" | "async", unknown>;
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -23,7 +23,7 @@ export type AnySqliteDatabase = BaseSQLiteDatabase<"sync" | "async", unknown>;
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -177,7 +177,7 @@ export type AtomicEdgeResolvedUpdateEntry = Readonly<{
 
 // @public (undocumented)
 export type AtomicMutationProgramConformanceCase = Readonly<{
-    backend: GraphBackend;
+    backend: GraphBackend | TransactionBackend;
     variant: AtomicMutationProgramVariant;
     orderedSuccess: AtomicMutationProgramSuccessCase;
     staleFenceNoWrite: AtomicMutationProgramRefusalCase & Readonly<{
@@ -193,7 +193,7 @@ export class AtomicMutationProgramConformanceError extends TypeGraphError {
 
 // @public (undocumented)
 export type AtomicMutationProgramConformanceFixture = Readonly<{
-    backend: GraphBackend;
+    backend: GraphBackend | TransactionBackend;
     equal: (actual: unknown, expected: unknown) => boolean;
     cases: readonly AtomicMutationProgramConformanceCase[];
 }> & ExactRootRegistrationProvenanceFixture;
@@ -359,7 +359,7 @@ export class AtomicTransportConformanceError extends TypeGraphError {
 
 // @public (undocumented)
 export type AtomicTransportConformanceFixture<TSnapshot = unknown, TParameterSnapshot = readonly CompiledAtomicSqlStatement[] | undefined> = Readonly<{
-    backend: GraphBackend;
+    backend: GraphBackend | TransactionBackend;
     executeAtomicBatch: AtomicSqlBatchExecutor;
     equal: AtomicTransportEquality;
     orderedResults: Readonly<{
@@ -1928,7 +1928,10 @@ export type ExactBackendOverlay<T extends object, O extends Partial<T>> = O & Re
 
 // @public
 export type ExactRootRegistrationProvenanceFixture = Readonly<{
-    derivedBackends: readonly [GraphBackend, ...GraphBackend[]];
+    derivedBackends: readonly [
+    GraphBackend | TransactionBackend,
+    ...(GraphBackend | TransactionBackend)[]
+    ];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -401,7 +401,7 @@ export type AtomicTransportRollbackCase<TSnapshot> = Readonly<{
 export type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;
@@ -3222,10 +3222,10 @@ export type RecursiveTraversalVerdict = Readonly<{
 })>;
 
 // @public
-export function registerAtomicMutationPrograms<T extends GraphBackend>(target: T, registration: AtomicMutationProgramRegistration): T;
+export function registerAtomicMutationPrograms<T extends GraphBackend | TransactionBackend>(target: T, registration: AtomicMutationProgramRegistration): T;
 
 // @public
-export function registerAtomicSqlProgram<T extends GraphBackend>(target: T, registration: AtomicSqlProgramRegistration): T;
+export function registerAtomicSqlProgram<T extends GraphBackend | TransactionBackend>(target: T, registration: AtomicSqlProgramRegistration): T;
 
 // @public
 export type RelationalIndexDeclaration = NodeIndexDeclaration | EdgeIndexDeclaration;

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -108,7 +108,7 @@ export function asBranchId(value: string): BranchId;
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -99,7 +99,7 @@ type ArrayPredicate = Readonly<{
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -99,7 +99,7 @@ type ArrayPredicate = Readonly<{
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -99,7 +99,7 @@ type ArrayPredicate = Readonly<{
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -99,7 +99,7 @@ type ArrayPredicate = Readonly<{
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -24,7 +24,7 @@ export function assertSchemaCurrent<G extends GraphDef>(backend: GraphBackend, g
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -99,7 +99,7 @@ type ArrayPredicate = Readonly<{
 type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -198,7 +198,7 @@ export function avg(alias: string, field: string): AggregateExpr;
 export type BackendCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     windowFunctions: boolean;
     clearValidTo?: boolean;

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -306,18 +306,20 @@ export const ATOMIC_EDGE_MUTATION_VARIANT_BY_KIND = {
  * A zero limit is an honest opt-out. Singleton updates reach the update-only
  * families directly on every exact root. Mixed resolved sets move their
  * collection-level read/partition/write unit into an interactive transaction;
- * the bundled PostgreSQL factory separately rebinds and tests those executors
- * on the exact session, but that does not make the root variants reachable.
- * Conformance consumes this owner instead of re-spelling either decision.
+ * an interactive root therefore cannot reach them, while an exact registered
+ * `atomicBatch: "session"` target can. Conformance consumes this owner instead
+ * of inferring session reachability from transaction availability.
  */
 export function reachableAtomicMutationProgramVariants(
   profile: AtomicMutationProgramExecutor,
   execution: Pick<
     GraphBackend["capabilities"]["execution"],
-    "interactiveTransactions"
+    "atomicBatch" | "interactiveTransactions"
   >,
 ): readonly AtomicMutationProgramVariant[] {
   const variants: AtomicMutationProgramVariant[] = [];
+  const resolvedMutationSetsReachable =
+    !execution.interactiveTransactions || execution.atomicBatch === "session";
   if (profile.createNodes !== undefined) variants.push("createNodes");
   if (profile.createEdges !== undefined) variants.push("createEdges");
   if (profile.deleteNodes !== undefined) variants.push("deleteNodes");
@@ -329,13 +331,13 @@ export function reachableAtomicMutationProgramVariants(
     variants.push("updateEdges");
   }
   if (
-    !execution.interactiveTransactions &&
+    resolvedMutationSetsReachable &&
     (profile.mutateNodes?.maxEntries ?? 0) > 0
   ) {
     variants.push("mutateNodes");
   }
   if (
-    !execution.interactiveTransactions &&
+    resolvedMutationSetsReachable &&
     (profile.mutateEdges?.maxEntries.resolvedSet ?? 0) > 0
   ) {
     variants.push("mutateEdges.resolvedSet");

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -1,10 +1,10 @@
 /**
- * Exact-root execution profile for closed semantic mutation programs.
+ * Exact-resource execution profile for closed semantic mutation programs.
  *
- * The transport-level atomic SQL executor answers only "can this exact root
+ * The transport-level atomic SQL executor answers only "can this exact resource
  * submit a closed statement sequence atomically?" This profile is the next
  * layer up: it names the TypeGraph mutations the backend can lower onto that
- * transport. Keeping every mutation family in one exact-root registration
+ * transport. Keeping every mutation family in one exact-resource registration
  * prevents each new operation from inventing another provenance WeakMap.
  */
 import { ConfigurationError } from "../../errors";
@@ -20,8 +20,12 @@ import type {
   SchemaWriteFenceParams,
   TransactionBackend,
 } from "../types";
-import { supportsRootAtomicBatch } from "../types";
-import { hasAtomicSqlProgramRegistration } from "./atomic-sql-program";
+import { supportsAtomicBatch } from "../types";
+import {
+  hasAtomicSqlProgramRegistration,
+  registerAtomicSqlProgram,
+  resolveRegisteredAtomicSqlBatchExecutor,
+} from "./atomic-sql-program";
 
 /** How a node batch member obtained the identifier stored by its program. */
 export type AtomicNodeBatchIdSource = "generated" | "caller";
@@ -300,10 +304,11 @@ export const ATOMIC_EDGE_MUTATION_VARIANT_BY_KIND = {
  * Owns which semantic variants a normalized profile can reach independently.
  *
  * A zero limit is an honest opt-out. Singleton updates reach the update-only
- * families directly on every exact root. Mixed resolved sets still move their
- * collection-level read/partition/write unit into an interactive transaction,
- * where exact-root registration deliberately does not follow. Conformance
- * consumes this owner instead of independently re-spelling either decision.
+ * families directly on every exact root. Mixed resolved sets move their
+ * collection-level read/partition/write unit into an interactive transaction;
+ * the bundled PostgreSQL factory separately rebinds and tests those executors
+ * on the exact session, but that does not make the root variants reachable.
+ * Conformance consumes this owner instead of re-spelling either decision.
  */
 export function reachableAtomicMutationProgramVariants(
   profile: AtomicMutationProgramExecutor,
@@ -359,7 +364,7 @@ export type AtomicMutationProgramRegistration = Readonly<{
   mutateEdges?: AtomicEdgeMutationProgramExecutor | undefined;
 }>;
 
-const ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS = new WeakMap<
+const ATOMIC_MUTATION_PROGRAM_EXECUTORS = new WeakMap<
   object,
   AtomicMutationProgramExecutor
 >();
@@ -368,7 +373,7 @@ type AtomicMutationProgramDispatchObserver = (
   variant: AtomicMutationProgramVariant,
 ) => void;
 
-const ROOT_ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS = new WeakMap<
+const ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS = new WeakMap<
   object,
   AtomicMutationProgramDispatchObserver
 >();
@@ -381,7 +386,7 @@ function reportAtomicMutationProgramDispatch(
   target: object,
   variant: AtomicMutationProgramVariant,
 ): void {
-  ROOT_ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.get(target)?.(variant);
+  ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.get(target)?.(variant);
 }
 
 function instrumentAtomicMutationProgramExecutors(
@@ -447,23 +452,23 @@ function instrumentAtomicMutationProgramExecutors(
   );
 }
 
-/** @internal Runs work while observing dispatches from this exact root. */
+/** @internal Runs work while observing dispatches from this exact resource. */
 export async function withAtomicMutationProgramDispatchObserver<TResult>(
   target: object,
   observer: AtomicMutationProgramDispatchObserver,
   run: () => TResult | PromiseLike<TResult>,
 ): Promise<TResult> {
-  if (ROOT_ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.has(target)) {
+  if (ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.has(target)) {
     throw new ConfigurationError(
-      "Atomic mutation program dispatch observation is already active for this exact root.",
+      "Atomic mutation program dispatch observation is already active for this exact resource.",
       { code: "ATOMIC_MUTATION_PROGRAM_OBSERVER_ALREADY_ACTIVE" },
     );
   }
-  ROOT_ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.set(target, observer);
+  ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.set(target, observer);
   try {
     return await run();
   } finally {
-    ROOT_ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.delete(target);
+    ATOMIC_MUTATION_PROGRAM_DISPATCH_OBSERVERS.delete(target);
   }
 }
 
@@ -600,10 +605,10 @@ function normalizeAtomicMutationProgramRegistration(
 }
 
 function throwAtomicMutationProgramRegistrationMismatch(
-  target: GraphBackend,
+  target: GraphBackend | TransactionBackend,
 ): never {
   throw new ConfigurationError(
-    "Atomic mutation programs require an exact root backend with a registered atomic SQL transport.",
+    "Atomic mutation programs require an exact backend session with a registered atomic SQL transport.",
     {
       code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
       atomicBatch: target.capabilities.execution.atomicBatch,
@@ -611,37 +616,36 @@ function throwAtomicMutationProgramRegistrationMismatch(
     },
     {
       suggestion:
-        "Register and validate the root atomic SQL transport before registering only the TypeGraph mutation families this backend implements.",
+        "Register and validate the exact-session atomic SQL transport before registering only the TypeGraph mutation families this backend implements.",
     },
   );
 }
 
 /**
- * Registers TypeGraph semantic mutation programs for one exact backend root.
+ * Registers TypeGraph semantic mutation programs for one exact backend resource.
  *
  * Transport registration proves atomic statement dispatch only. This second,
  * explicit profile declares which graph mutation families preserve their
  * complete schema-fence, validation, side-effect, refusal, and result-ordering
  * contracts. Object-identity registration prevents derived, projected, and
- * transaction-scoped backends from inheriting root execution evidence.
+ * other transaction sessions from inheriting execution evidence.
  */
-export function registerAtomicMutationPrograms<T extends GraphBackend>(
-  target: T,
-  registration: AtomicMutationProgramRegistration,
-): T {
+export function registerAtomicMutationPrograms<
+  T extends GraphBackend | TransactionBackend,
+>(target: T, registration: AtomicMutationProgramRegistration): T {
   if (
-    !supportsRootAtomicBatch(target) ||
+    !supportsAtomicBatch(target) ||
     !hasAtomicSqlProgramRegistration(target)
   ) {
     throwAtomicMutationProgramRegistrationMismatch(target);
   }
-  if (ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.has(target)) {
+  if (ATOMIC_MUTATION_PROGRAM_EXECUTORS.has(target)) {
     throw new ConfigurationError(
-      "Atomic mutation programs are already registered for this exact backend root.",
+      "Atomic mutation programs are already registered for this exact backend resource.",
       { code: "ATOMIC_MUTATION_PROGRAM_ALREADY_REGISTERED" },
     );
   }
-  ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.set(
+  ATOMIC_MUTATION_PROGRAM_EXECUTORS.set(
     target,
     instrumentAtomicMutationProgramExecutors(
       target,
@@ -651,18 +655,44 @@ export function registerAtomicMutationPrograms<T extends GraphBackend>(
   return target;
 }
 
-/** Returns whether this exact root owns a semantic program profile. */
+/** Returns whether this exact resource owns a semantic program profile. */
 export function hasAtomicMutationProgramRegistration(
   target: GraphBackend | TransactionBackend,
 ): boolean {
-  return ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.has(target);
+  return ATOMIC_MUTATION_PROGRAM_EXECUTORS.has(target);
 }
 
-/** Resolves semantic mutation programs only for their exact registered root. */
+/** Resolves semantic mutation programs only for their exact registered resource. */
 export function resolveAtomicMutationPrograms(
   target: GraphBackend | TransactionBackend,
 ): AtomicMutationProgramExecutor | undefined {
-  return ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.get(target);
+  return ATOMIC_MUTATION_PROGRAM_EXECUTORS.get(target);
+}
+
+/**
+ * Re-registers exact-session evidence on a transparent transaction wrapper.
+ *
+ * Session authority is never inherited implicitly: the wrapper seam calls
+ * this only after deriving a backend that forwards to the same pinned command
+ * session. Root registrations remain non-transferable.
+ *
+ * @internal
+ */
+export function carryAtomicMutationSessionRegistration<
+  T extends TransactionBackend,
+>(base: TransactionBackend, derived: T): T {
+  if (
+    base.capabilities.execution.atomicBatch !== "session" ||
+    derived.capabilities.execution.atomicBatch !== "session"
+  ) {
+    return derived;
+  }
+  const executeAtomicBatch = resolveRegisteredAtomicSqlBatchExecutor(base);
+  const profile = resolveAtomicMutationPrograms(base);
+  if (executeAtomicBatch === undefined || profile === undefined) return derived;
+  registerAtomicSqlProgram(derived, executeAtomicBatch);
+  registerAtomicMutationPrograms(derived, profile);
+  return derived;
 }
 
 /**
@@ -684,7 +714,7 @@ export function markBundledRootAtomicMutationPrograms<T extends object>(
     mutateEdges?: AtomicEdgeMutationProgramExecutor | undefined;
   }>,
 ): T {
-  ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.set(
+  ATOMIC_MUTATION_PROGRAM_EXECUTORS.set(
     target,
     instrumentAtomicMutationProgramExecutors(target, executor),
   );
@@ -703,7 +733,7 @@ export function markBundledRootAtomicNodeBatch<T extends object>(
   target: T,
   executor: AtomicNodeBatchExecutor,
 ): T {
-  const existing = ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.get(target);
+  const existing = ATOMIC_MUTATION_PROGRAM_EXECUTORS.get(target);
   return markBundledRootAtomicMutationPrograms(target, {
     ...existing,
     createNodes: executor,
@@ -715,7 +745,7 @@ export function markBundledRootAtomicEdgeBatch<T extends object>(
   target: T,
   executor: AtomicEdgeBatchExecutor,
 ): T {
-  const existing = ROOT_ATOMIC_MUTATION_PROGRAM_EXECUTORS.get(target);
+  const existing = ATOMIC_MUTATION_PROGRAM_EXECUTORS.get(target);
   return markBundledRootAtomicMutationPrograms(target, {
     ...existing,
     createEdges: executor,

--- a/packages/typegraph/src/backend/capabilities/atomic-sql-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-sql-program.ts
@@ -1,12 +1,12 @@
 /**
  * Internal execution boundary for a closed, precompiled SQL write program.
  *
- * This is deliberately an out-of-band root capability. An author registers
- * the exact root backend object after its transport has earned the root
- * execution declaration; derived backends and transaction backends do not
- * inherit the registration. A static batch is therefore never confused with
- * an interactive transaction or forwarded through a wrapper whose behavior
- * has not been audited for the program contract.
+ * This is deliberately an out-of-band exact-resource capability. An author
+ * registers either a root that owns the atomic boundary or an already-open
+ * transaction session. Derived backends and other transaction objects do not
+ * inherit the registration. A static batch is therefore never forwarded
+ * through a wrapper whose behavior has not been audited for the program
+ * contract.
  */
 import { CompilerInvariantError, ConfigurationError } from "../../errors";
 import type { GraphBackend, TransactionBackend } from "../types";
@@ -62,7 +62,7 @@ type RegisteredAtomicSqlProgram = Readonly<{
   executor: AtomicSqlProgramExecutor;
 }>;
 
-const ROOT_ATOMIC_SQL_PROGRAM_EXECUTORS = new WeakMap<
+const ATOMIC_SQL_PROGRAM_EXECUTORS = new WeakMap<
   object,
   RegisteredAtomicSqlProgram
 >();
@@ -176,11 +176,12 @@ function normalizeAtomicSqlProgramRegistration(
 }
 
 function throwAtomicSqlProgramRegistrationMismatch(
-  declaration: GraphBackend["capabilities"]["execution"]["atomicBatch"],
+  target: GraphBackend | TransactionBackend,
   registration: RegisteredAtomicSqlProgram | undefined,
 ): never {
+  const declaration = target.capabilities.execution.atomicBatch;
   throw new ConfigurationError(
-    'An atomic SQL program requires `capabilities.execution.atomicBatch: "root"` and a usable atomic batch executor.',
+    "An atomic SQL program requires exact-session atomic-batch authority and a usable batch executor.",
     {
       code: "ATOMIC_SQL_PROGRAM_REGISTRATION_MISMATCH",
       declared: declaration,
@@ -188,59 +189,68 @@ function throwAtomicSqlProgramRegistrationMismatch(
     },
     {
       suggestion:
-        'Declare `capabilities.execution.atomicBatch: "root"` only on an exact root backend whose executor submits the complete statement sequence atomically.',
+        'Declare `atomicBatch: "root"` on an exact root executor or `"session"` on an already-open transaction session, then register that exact object.',
     },
   );
 }
 
+function declaredCommandSession(target: object): unknown {
+  const commands = Reflect.get(target, "commands") as unknown;
+  if (typeof commands !== "object" || commands === null) return;
+  return Reflect.get(commands, "session") as unknown;
+}
+
 /**
- * Registers an atomic SQL program executor for one exact GraphBackend root.
+ * Registers an atomic SQL program executor for one exact backend resource.
  *
  * The declaration and executable transport are checked together so a backend
- * cannot claim root atomic execution while omitting the executor, nor expose
+ * cannot claim atomic execution while omitting the executor, nor expose
  * an executor without declaring the session on which it is valid. The
- * registration is keyed by object identity; derived and transaction-scoped
- * backends therefore do not resolve this root-only program.
+ * registration is keyed by object identity; derived backends and other
+ * transaction sessions therefore do not resolve this program.
  */
-export function registerAtomicSqlProgram<T extends GraphBackend>(
-  target: T,
-  registration: AtomicSqlProgramRegistration,
-): T {
-  if (ROOT_ATOMIC_SQL_PROGRAM_EXECUTORS.has(target)) {
+export function registerAtomicSqlProgram<
+  T extends GraphBackend | TransactionBackend,
+>(target: T, registration: AtomicSqlProgramRegistration): T {
+  if (ATOMIC_SQL_PROGRAM_EXECUTORS.has(target)) {
     throw new ConfigurationError(
-      "An atomic SQL program is already registered for this exact backend root.",
+      "An atomic SQL program is already registered for this exact backend resource.",
       { code: "ATOMIC_SQL_PROGRAM_ALREADY_REGISTERED" },
     );
   }
   const executor = normalizeAtomicSqlProgramRegistration(registration);
   const declaration = target.capabilities.execution.atomicBatch;
-  if (declaration !== "root" || executor === undefined) {
-    throwAtomicSqlProgramRegistrationMismatch(declaration, executor);
+  const declaredSession = declaredCommandSession(target);
+  const sessionMatches =
+    (declaration === "root" && declaredSession === "root") ||
+    (declaration === "session" && declaredSession === "transaction");
+  if (declaration === "none" || !sessionMatches || executor === undefined) {
+    throwAtomicSqlProgramRegistrationMismatch(target, executor);
   }
-  ROOT_ATOMIC_SQL_PROGRAM_EXECUTORS.set(target, executor);
+  ATOMIC_SQL_PROGRAM_EXECUTORS.set(target, executor);
   return target;
 }
 
 /**
- * Resolves the static program executor for an exact registered root.
- * Transaction-scoped and derived/projected backends return `undefined`.
+ * Resolves the static program executor for an exact registered resource.
+ * Other transaction sessions and derived/projected backends return `undefined`.
  */
 export function resolveAtomicSqlProgramExecutor(
   target: GraphBackend | TransactionBackend,
 ): AtomicSqlProgramExecutor | undefined {
-  return ROOT_ATOMIC_SQL_PROGRAM_EXECUTORS.get(target)?.executor;
+  return ATOMIC_SQL_PROGRAM_EXECUTORS.get(target)?.executor;
 }
 
-/** @internal Resolves the exact batch function registered on one root. */
+/** @internal Resolves the exact batch function registered on one resource. */
 export function resolveRegisteredAtomicSqlBatchExecutor(
   target: GraphBackend | TransactionBackend,
 ): AtomicSqlBatchExecutor | undefined {
-  return ROOT_ATOMIC_SQL_PROGRAM_EXECUTORS.get(target)?.executeAtomicBatch;
+  return ATOMIC_SQL_PROGRAM_EXECUTORS.get(target)?.executeAtomicBatch;
 }
 
 /** Returns whether this exact object owns a registered atomic SQL transport. */
 export function hasAtomicSqlProgramRegistration(
   target: GraphBackend | TransactionBackend,
 ): boolean {
-  return ROOT_ATOMIC_SQL_PROGRAM_EXECUTORS.has(target);
+  return ATOMIC_SQL_PROGRAM_EXECUTORS.has(target);
 }

--- a/packages/typegraph/src/backend/capabilities/execution.ts
+++ b/packages/typegraph/src/backend/capabilities/execution.ts
@@ -21,10 +21,13 @@ export function downgradeAtomicBatch(
 }
 
 /**
- * Rebinds root atomic authority to one already-open transaction session.
+ * Declares atomic authority for one already-open transaction session.
  *
- * The session must still register its own exact-resource transport and
- * semantic profile. This declaration alone never authorizes execution.
+ * Session authority is earned independently of the root verdict: a root may
+ * be unable to own a multi-statement atomic boundary while its transaction
+ * factory can still prove one pinned open session. The session must register
+ * its own exact-resource transport and semantic profile; this declaration
+ * alone never authorizes execution.
  */
 export function scopeAtomicBatchToSession(
   capabilities: BackendCapabilities,

--- a/packages/typegraph/src/backend/capabilities/execution.ts
+++ b/packages/typegraph/src/backend/capabilities/execution.ts
@@ -1,17 +1,40 @@
 import type { BackendCapabilities } from "../types";
 
 /**
- * Removes exact-root atomic execution evidence at a session boundary.
+ * Removes exact atomic execution evidence at a backend derivation or session
+ * boundary.
  *
  * Derived/projection constructors and transaction factories share this owner
- * so a new backend construction seam cannot accidentally retain root-only
- * execution authority.
+ * so a new backend construction seam cannot accidentally retain execution
+ * authority earned by another exact object.
  */
-export function downgradeRootAtomicBatch(
+export function downgradeAtomicBatch(
   capabilities: BackendCapabilities,
 ): BackendCapabilities {
   return {
     ...capabilities,
-    execution: { ...capabilities.execution, atomicBatch: "none" },
+    execution: {
+      ...capabilities.execution,
+      atomicBatch: "none",
+    },
+  };
+}
+
+/**
+ * Rebinds root atomic authority to one already-open transaction session.
+ *
+ * The session must still register its own exact-resource transport and
+ * semantic profile. This declaration alone never authorizes execution.
+ */
+export function scopeAtomicBatchToSession(
+  capabilities: BackendCapabilities,
+  available: boolean,
+): BackendCapabilities {
+  return {
+    ...capabilities,
+    execution: {
+      ...capabilities.execution,
+      atomicBatch: available ? "session" : "none",
+    },
   };
 }

--- a/packages/typegraph/src/backend/conformance/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/conformance/atomic-mutation-program.ts
@@ -8,7 +8,7 @@ import {
   resolveAtomicMutationPrograms,
   withAtomicMutationProgramDispatchObserver,
 } from "../capabilities/atomic-mutation-program";
-import type { GraphBackend } from "../types";
+import type { GraphBackend, TransactionBackend } from "../types";
 import {
   assertExactRootRegistrationProvenance,
   type ExactRootRegistrationProvenanceFixture,
@@ -46,8 +46,8 @@ export type AtomicMutationProgramRefusalCase = Readonly<{
   dispatch: AtomicMutationProgramRefusalDispatch;
 }>;
 export type AtomicMutationProgramConformanceCase = Readonly<{
-  /** Exact root used by every callback in this case. */
-  backend: GraphBackend;
+  /** Exact registered resource used by every callback in this case. */
+  backend: GraphBackend | TransactionBackend;
   variant: AtomicMutationProgramVariant;
   orderedSuccess: AtomicMutationProgramSuccessCase;
   staleFenceNoWrite: AtomicMutationProgramRefusalCase &
@@ -55,8 +55,8 @@ export type AtomicMutationProgramConformanceCase = Readonly<{
   semanticRefusalRollback: AtomicMutationProgramRefusalCase;
 }>;
 export type AtomicMutationProgramConformanceFixture = Readonly<{
-  /** Exact root reserved exclusively for this conformance run. */
-  backend: GraphBackend;
+  /** Exact root or open transaction session reserved for this run. */
+  backend: GraphBackend | TransactionBackend;
   equal: (actual: unknown, expected: unknown) => boolean;
   cases: readonly AtomicMutationProgramConformanceCase[];
 }> &

--- a/packages/typegraph/src/backend/conformance/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/conformance/atomic-mutation-program.ts
@@ -290,6 +290,7 @@ export async function runAtomicMutationProgramConformance(
         `Atomic mutation program provenance check failed: ${name}.`,
         { check: name },
       ),
+    (target) => resolveAtomicMutationPrograms(target) === profile,
   );
 
   const dispatchCounts = new Map<AtomicMutationProgramVariant, number>();

--- a/packages/typegraph/src/backend/conformance/atomic-transport.ts
+++ b/packages/typegraph/src/backend/conformance/atomic-transport.ts
@@ -17,7 +17,7 @@ import {
   hasAtomicSqlProgramRegistration,
   resolveRegisteredAtomicSqlBatchExecutor,
 } from "../capabilities/atomic-sql-program";
-import type { GraphBackend } from "../types";
+import type { GraphBackend, TransactionBackend } from "../types";
 import {
   assertExactRootRegistrationProvenance,
   type ExactRootRegistrationProvenanceFixture,
@@ -42,8 +42,8 @@ export type AtomicTransportConformanceFixture<
   TSnapshot = unknown,
   TParameterSnapshot = readonly CompiledAtomicSqlStatement[] | undefined,
 > = Readonly<{
-  /** Exact root that registered the batch function under test. */
-  backend: GraphBackend;
+  /** Exact root or open transaction session registered under test. */
+  backend: GraphBackend | TransactionBackend;
   executeAtomicBatch: AtomicSqlBatchExecutor;
   equal: AtomicTransportEquality;
   /** A multi-statement program whose result slots identify their positions. */

--- a/packages/typegraph/src/backend/conformance/atomic-transport.ts
+++ b/packages/typegraph/src/backend/conformance/atomic-transport.ts
@@ -145,6 +145,9 @@ export async function runAtomicTransportConformance<
         `Atomic transport provenance check failed: ${name}.`,
         { check: `provenance: ${name}` },
       ),
+    (target) =>
+      resolveRegisteredAtomicSqlBatchExecutor(target) ===
+      fixture.executeAtomicBatch,
   );
 
   const orderedRows = await invoke(

--- a/packages/typegraph/src/backend/conformance/exact-root-provenance.ts
+++ b/packages/typegraph/src/backend/conformance/exact-root-provenance.ts
@@ -3,7 +3,10 @@ import type { GraphBackend, TransactionBackend } from "../types";
 
 /** Actual author-created derived backends whose registrations must be probed. */
 export type ExactRootRegistrationProvenanceFixture = Readonly<{
-  derivedBackends: readonly [GraphBackend, ...GraphBackend[]];
+  derivedBackends: readonly [
+    GraphBackend | TransactionBackend,
+    ...(GraphBackend | TransactionBackend)[],
+  ];
 }>;
 
 /** Honest result of provenance checks that ran or were inapplicable. */
@@ -17,14 +20,15 @@ type ExactRootRegistrationPredicate = (
 ) => boolean;
 
 /**
- * Owns exact-root registration checks shared by transport and semantics.
+ * Owns exact-resource registration checks shared by transport and semantics.
  *
  * Derived targets come from the backend author rather than from a projection
- * this runner manufactures. Transaction isolation is checked on a real
- * session when the backend exposes one and reported as skipped otherwise.
+ * this runner manufactures. Root transaction isolation is checked on a real
+ * session when the backend exposes one. That check is inapplicable when the
+ * registered resource is already an open transaction session.
  */
 export async function assertExactRootRegistrationProvenance(
-  backend: GraphBackend,
+  backend: GraphBackend | TransactionBackend,
   fixture: ExactRootRegistrationProvenanceFixture,
   isRegistered: ExactRootRegistrationPredicate,
   createError: (check: string) => Error,
@@ -47,9 +51,19 @@ export async function assertExactRootRegistrationProvenance(
   }
   passed.push("derived backend isolation");
 
+  // A session registration is already scoped to one open transaction. It has
+  // no legitimate nested-transaction probe; exact registration plus derived
+  // isolation are the applicable provenance evidence for that resource.
+  if (backend.capabilities.execution.atomicBatch === "session") {
+    skipped.push("transaction backend isolation");
+    return { passed, skipped };
+  }
   if (!backend.capabilities.execution.interactiveTransactions) {
     skipped.push("transaction backend isolation");
     return { passed, skipped };
+  }
+  if (!("transaction" in backend)) {
+    throw createError("transaction backend isolation");
   }
   const isolated = await backend.transaction((transaction) =>
     Promise.resolve(!isRootRegistration(transaction)),

--- a/packages/typegraph/src/backend/conformance/exact-root-provenance.ts
+++ b/packages/typegraph/src/backend/conformance/exact-root-provenance.ts
@@ -28,6 +28,7 @@ export async function assertExactRootRegistrationProvenance(
   fixture: ExactRootRegistrationProvenanceFixture,
   isRegistered: ExactRootRegistrationPredicate,
   createError: (check: string) => Error,
+  isRootRegistration: ExactRootRegistrationPredicate = isRegistered,
 ): Promise<ExactRootRegistrationProvenanceReport> {
   const passed: string[] = [];
   const skipped: string[] = [];
@@ -51,7 +52,7 @@ export async function assertExactRootRegistrationProvenance(
     return { passed, skipped };
   }
   const isolated = await backend.transaction((transaction) =>
-    Promise.resolve(!isRegistered(transaction)),
+    Promise.resolve(!isRootRegistration(transaction)),
   );
   if (!isolated) throw createError("transaction backend isolation");
   passed.push("transaction backend isolation");

--- a/packages/typegraph/src/backend/derive-backend.ts
+++ b/packages/typegraph/src/backend/derive-backend.ts
@@ -23,7 +23,7 @@
  * `Backend` denotes a whole backend object; a members fragment is named
  * `*Members`.
  */
-import { downgradeRootAtomicBatch } from "./capabilities/execution";
+import { downgradeAtomicBatch } from "./capabilities/execution";
 import { carrySchemaFencedInsertEligibility } from "./capabilities/schema-fenced-insert";
 import { carryFirstPartyFactoryMark } from "./capabilities/write-fence";
 import { carryGraphCommandPortSessionMetadata } from "./command-contract";
@@ -37,6 +37,7 @@ import {
   type BackendCapabilities,
   type GraphBackend,
   type GraphCommandPort,
+  type TransactionBackend,
 } from "./types";
 
 const BACKEND_DERIVATION_SOURCES = new WeakMap<object, object>();
@@ -80,7 +81,10 @@ function isGraphCommandPort(value: unknown): value is GraphCommandPort {
   );
 }
 
-function downgradeDerivedAtomicBatch(capabilities: unknown): unknown {
+function resolveDerivedCapabilities(
+  capabilities: unknown,
+  preserveAtomicSession: boolean,
+): unknown {
   if (typeof capabilities !== "object" || capabilities === null) return;
   const capabilityMembers = capabilities as Readonly<
     Record<PropertyKey, unknown>
@@ -89,15 +93,26 @@ function downgradeDerivedAtomicBatch(capabilities: unknown): unknown {
   if (typeof execution !== "object" || execution === null) return;
   const executionMembers = execution as Readonly<Record<PropertyKey, unknown>>;
   if (!("atomicBatch" in executionMembers)) return;
-  return downgradeRootAtomicBatch(capabilityMembers as BackendCapabilities);
+  const typed = capabilityMembers as BackendCapabilities;
+  return preserveAtomicSession && typed.execution.atomicBatch === "session" ?
+      typed
+    : downgradeAtomicBatch(typed);
 }
 
-function deriveExecutionCapabilities(base: object, overrides: object): unknown {
+function deriveExecutionCapabilities(
+  base: object,
+  overrides: object,
+  preserveAtomicSession: boolean,
+): unknown {
+  const overridesCapabilities = Object.hasOwn(overrides, "capabilities");
   const capabilities =
-    Object.hasOwn(overrides, "capabilities") ?
+    overridesCapabilities ?
       (Reflect.get(overrides, "capabilities", overrides) as unknown)
     : (Reflect.get(base, "capabilities", base) as unknown);
-  return downgradeDerivedAtomicBatch(capabilities);
+  return resolveDerivedCapabilities(
+    capabilities,
+    preserveAtomicSession && !overridesCapabilities,
+  );
 }
 
 /**
@@ -141,11 +156,19 @@ function carryDerivedCommandPortMetadata(
  * declare, so the looser bound cannot smuggle a member onto a surface that
  * withholds it.
  */
-export function deriveBackend<
+function deriveBackendInternal<
   T extends object,
   const O extends Partial<T> = Partial<T>,
->(base: T, overrides: ExactBackendOverlay<T, O>): T {
-  const derivedCapabilities = deriveExecutionCapabilities(base, overrides);
+>(
+  base: T,
+  overrides: ExactBackendOverlay<T, O>,
+  preserveAtomicSession: boolean,
+): T {
+  const derivedCapabilities = deriveExecutionCapabilities(
+    base,
+    overrides,
+    preserveAtomicSession,
+  );
   // A Proxy may not report a different value for a non-writable,
   // non-configurable data property on its target. Bundled backends are often
   // frozen at public boundaries, so proxying `base` directly makes a valid
@@ -235,6 +258,29 @@ export function deriveBackend<
   return decoratedBackend;
 }
 
+export function deriveBackend<
+  T extends object,
+  const O extends Partial<T> = Partial<T>,
+>(base: T, overrides: ExactBackendOverlay<T, O>): T {
+  return deriveBackendInternal(base, overrides, false);
+}
+
+/**
+ * Decorates one already-open transaction without discarding its session
+ * declaration. The caller must separately bind exact transport and semantic
+ * registrations to the returned object before exposing it to Store code. A
+ * capabilities override still downgrades the declaration: this seam preserves
+ * evidence from the base session; it never accepts replacement evidence.
+ *
+ * @internal
+ */
+export function deriveTransactionSessionBackend<
+  T extends TransactionBackend,
+  const O extends Partial<T> = Partial<T>,
+>(base: T, overrides: ExactBackendOverlay<T, O>): T {
+  return deriveBackendInternal(base, overrides, true);
+}
+
 /** Public name for the audited, decoration-only backend derivation seam. */
 export function decorateBackend<
   T extends object,
@@ -261,7 +307,7 @@ export function projectBackend<
     const value = Reflect.get(base, key) as unknown;
     const projectedValue =
       key === "capabilities" ?
-        (downgradeDerivedAtomicBatch(value) ?? value)
+        (resolveDerivedCapabilities(value, false) ?? value)
       : value;
     return [[key, projectedValue] as const];
   });

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -46,7 +46,7 @@ import {
   resolveWriteFencePlan,
   type WriteFenceTarget,
 } from "../capabilities/write-fence";
-import { deriveBackend } from "../derive-backend";
+import { deriveTransactionSessionBackend } from "../derive-backend";
 import { formatPostgresTimestamp, nowIso } from "../row-mappers";
 import type { StrategyTableContribution } from "../table-contribution";
 import {
@@ -562,7 +562,7 @@ export function gateFulltext(
   assert: (graphId: string) => Promise<void>,
   refuseUnavailable: RefuseUnavailableFulltext,
 ): TransactionBackend {
-  return deriveBackend<TransactionBackend>(
+  return deriveTransactionSessionBackend<TransactionBackend>(
     tx,
     gateFulltextMethods(tx, assert, refuseUnavailable),
   );

--- a/packages/typegraph/src/backend/drizzle/execution/index.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/index.ts
@@ -4,6 +4,7 @@ export {
   createPostgresExecutionAdapter,
   type PostgresExecutionAdapter,
 } from "./postgres-execution";
+export { createSessionAtomicBatchAdapter } from "./session-atomic-batch";
 export {
   type AnySqliteDatabase,
   createSqliteExecutionAdapter,

--- a/packages/typegraph/src/backend/drizzle/execution/session-atomic-batch.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/session-atomic-batch.ts
@@ -5,6 +5,11 @@ import type {
 } from "../../capabilities/atomic-sql-program";
 import type { SqlExecutionAdapter } from "./types";
 
+type SessionAtomicBatchExecution = Readonly<{
+  executeCompiled: NonNullable<SqlExecutionAdapter["executeCompiled"]>;
+  runExclusive: NonNullable<SqlExecutionAdapter["runExclusive"]>;
+}>;
+
 const ATOMIC_PROGRAM_SAVEPOINT = "typegraph_atomic_program";
 const BEGIN_ATOMIC_PROGRAM = {
   sql: `SAVEPOINT ${ATOMIC_PROGRAM_SAVEPOINT}`,
@@ -31,24 +36,16 @@ const RELEASE_ATOMIC_PROGRAM = {
  * diagnostics can translate them to typed errors.
  */
 export function createSessionAtomicBatchAdapter(
-  adapter: SqlExecutionAdapter,
-): AtomicSqlProgramAdapter | undefined {
-  const runExclusive = adapter.runExclusive;
-  if (runExclusive === undefined || adapter.executeCompiled === undefined) {
-    return;
-  }
+  execution: SessionAtomicBatchExecution,
+): AtomicSqlProgramAdapter {
+  const { executeCompiled, runExclusive } = execution;
 
   return {
     async executeAtomicBatch<TRow>(
       statements: readonly CompiledAtomicSqlStatement[],
     ) {
-      return runExclusive(async (connection) => {
-        const executeCompiled = connection.executeCompiled;
-        if (executeCompiled === undefined) {
-          throw new CompilerInvariantError(
-            "An atomic transaction session lost compiled execution inside its exclusive boundary.",
-          );
-        }
+      if (statements.length === 0) return [];
+      return runExclusive(async () => {
         await executeCompiled(BEGIN_ATOMIC_PROGRAM);
         const results: (readonly TRow[])[] = [];
         try {
@@ -59,13 +56,21 @@ export function createSessionAtomicBatchAdapter(
           return results;
         } catch (error) {
           try {
+            // PostgreSQL protocol- and SQL-level prepared statements survive
+            // ROLLBACK TO SAVEPOINT (verified on PostgreSQL 18), so recovery
+            // restores data state without invalidating the session's cache.
             await executeCompiled(ROLLBACK_ATOMIC_PROGRAM);
             await executeCompiled(RELEASE_ATOMIC_PROGRAM);
           } catch (recoveryError) {
+            const failures = new AggregateError(
+              [error, recoveryError],
+              "The atomic program failed and its savepoint recovery also failed.",
+              { cause: error },
+            );
             throw new CompilerInvariantError(
               "An atomic transaction session could not restore its savepoint after a failed program.",
               {},
-              { cause: recoveryError },
+              { cause: failures },
             );
           }
           throw error;

--- a/packages/typegraph/src/backend/drizzle/execution/session-atomic-batch.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/session-atomic-batch.ts
@@ -1,6 +1,6 @@
 import { CompilerInvariantError } from "../../../errors";
 import type {
-  AtomicSqlProgramAdapter,
+  AtomicSqlBatchExecutor,
   CompiledAtomicSqlStatement,
 } from "../../capabilities/atomic-sql-program";
 import type { SqlExecutionAdapter } from "./types";
@@ -8,6 +8,10 @@ import type { SqlExecutionAdapter } from "./types";
 type SessionAtomicBatchExecution = Readonly<{
   executeCompiled: NonNullable<SqlExecutionAdapter["executeCompiled"]>;
   runExclusive: NonNullable<SqlExecutionAdapter["runExclusive"]>;
+}>;
+
+type SessionAtomicBatchAdapter = Readonly<{
+  executeAtomicBatch: AtomicSqlBatchExecutor;
 }>;
 
 const ATOMIC_PROGRAM_SAVEPOINT = "typegraph_atomic_program";
@@ -37,7 +41,7 @@ const RELEASE_ATOMIC_PROGRAM = {
  */
 export function createSessionAtomicBatchAdapter(
   execution: SessionAtomicBatchExecution,
-): AtomicSqlProgramAdapter {
+): SessionAtomicBatchAdapter {
   const { executeCompiled, runExclusive } = execution;
 
   return {

--- a/packages/typegraph/src/backend/drizzle/execution/session-atomic-batch.ts
+++ b/packages/typegraph/src/backend/drizzle/execution/session-atomic-batch.ts
@@ -1,0 +1,76 @@
+import { CompilerInvariantError } from "../../../errors";
+import type {
+  AtomicSqlProgramAdapter,
+  CompiledAtomicSqlStatement,
+} from "../../capabilities/atomic-sql-program";
+import type { SqlExecutionAdapter } from "./types";
+
+const ATOMIC_PROGRAM_SAVEPOINT = "typegraph_atomic_program";
+const BEGIN_ATOMIC_PROGRAM = {
+  sql: `SAVEPOINT ${ATOMIC_PROGRAM_SAVEPOINT}`,
+  params: [],
+} as const;
+const ROLLBACK_ATOMIC_PROGRAM = {
+  sql: `ROLLBACK TO SAVEPOINT ${ATOMIC_PROGRAM_SAVEPOINT}`,
+  params: [],
+} as const;
+const RELEASE_ATOMIC_PROGRAM = {
+  sql: `RELEASE SAVEPOINT ${ATOMIC_PROGRAM_SAVEPOINT}`,
+  params: [],
+} as const;
+
+/**
+ * Adapts one already-open, exclusively reservable transaction session to the
+ * closed atomic-program transport.
+ *
+ * `runExclusive` is load-bearing: queueing each statement independently would
+ * let unrelated work on the same transaction interleave with a program. The
+ * returned batch owns one queue slot for the whole sequence, while the outer
+ * transaction owns commit and rollback. A savepoint keeps deliberate
+ * constraint refusals from aborting that outer transaction before Store
+ * diagnostics can translate them to typed errors.
+ */
+export function createSessionAtomicBatchAdapter(
+  adapter: SqlExecutionAdapter,
+): AtomicSqlProgramAdapter | undefined {
+  const runExclusive = adapter.runExclusive;
+  if (runExclusive === undefined || adapter.executeCompiled === undefined) {
+    return;
+  }
+
+  return {
+    async executeAtomicBatch<TRow>(
+      statements: readonly CompiledAtomicSqlStatement[],
+    ) {
+      return runExclusive(async (connection) => {
+        const executeCompiled = connection.executeCompiled;
+        if (executeCompiled === undefined) {
+          throw new CompilerInvariantError(
+            "An atomic transaction session lost compiled execution inside its exclusive boundary.",
+          );
+        }
+        await executeCompiled(BEGIN_ATOMIC_PROGRAM);
+        const results: (readonly TRow[])[] = [];
+        try {
+          for (const statement of statements) {
+            results.push(await executeCompiled<TRow>(statement));
+          }
+          await executeCompiled(RELEASE_ATOMIC_PROGRAM);
+          return results;
+        } catch (error) {
+          try {
+            await executeCompiled(ROLLBACK_ATOMIC_PROGRAM);
+            await executeCompiled(RELEASE_ATOMIC_PROGRAM);
+          } catch (recoveryError) {
+            throw new CompilerInvariantError(
+              "An atomic transaction session could not restore its savepoint after a failed program.",
+              {},
+              { cause: recoveryError },
+            );
+          }
+          throw error;
+        }
+      });
+    },
+  };
+}

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -81,7 +81,15 @@ import {
   isPostgresConcurrentDdlRaceError,
 } from "../../utils/sql-errors";
 import { RECORDED_GRAPH_WRITE_ADVISORY_LOCK_NAMESPACE } from "../advisory-lock-namespaces";
-import { registerAtomicMutationPrograms } from "../capabilities/atomic-mutation-program";
+import {
+  type AtomicEdgeConvergenceInput,
+  type AtomicEdgeConvergenceResult,
+  type AtomicEdgeMutationProgramExecutor,
+  type AtomicEdgeResolvedMutationSetInput,
+  type AtomicEdgeResolvedMutationSetResult,
+  carryAtomicMutationSessionRegistration,
+  registerAtomicMutationPrograms,
+} from "../capabilities/atomic-mutation-program";
 import {
   type AtomicSqlProgramExecutor,
   createAtomicSqlProgramExecutor,
@@ -92,7 +100,7 @@ import {
   assertBundledCapabilityDeclarations,
   assertNoLegacyTransactionCapability,
 } from "../capabilities/declarations";
-import { downgradeRootAtomicBatch } from "../capabilities/execution";
+import { scopeAtomicBatchToSession } from "../capabilities/execution";
 import { markSchemaFencedInsertEligible } from "../capabilities/schema-fenced-insert";
 import { markFirstPartyFactory } from "../capabilities/write-fence";
 import { deriveBackend } from "../derive-backend";
@@ -204,6 +212,7 @@ import {
   type PostgresExecutionAdapter,
   type PostgresExecutionAdapterOptions,
 } from "./execution/postgres-execution";
+import { createSessionAtomicBatchAdapter } from "./execution/session-atomic-batch";
 import { createSerialExecutionAdapter } from "./execution/statement-queue";
 import { type ExecutableSql, toDrizzleSql } from "./execution/types";
 import { instantiateGraphTemplateSql } from "./graph-template-sql";
@@ -1286,10 +1295,13 @@ export function createPostgresBackend(
       iterativeScanProbe,
       schemaVersionsTable: tables.schemaVersions,
     });
-    const gatedBackend = gateFulltext(
+    const gatedBackend = carryAtomicMutationSessionRegistration(
       backend,
-      contributionMaterializer.assertInitialized,
-      contributionMaterializer.refuseUnavailableFulltext,
+      gateFulltext(
+        backend,
+        contributionMaterializer.assertInitialized,
+        contributionMaterializer.refuseUnavailableFulltext,
+      ),
     );
     return {
       backend: gatedBackend,
@@ -2645,7 +2657,7 @@ function createPostgresOperationBackend(
       execGet,
       execRun,
     },
-    ...(transactionScoped || atomicSqlProgramExecutor === undefined ?
+    ...(atomicSqlProgramExecutor === undefined ?
       {}
     : { atomicSqlProgramExecutor }),
     nowIso,
@@ -3255,6 +3267,36 @@ type BoundTransactionBackend = Readonly<{
   drainAndClose: () => Promise<void>;
 }>;
 
+function resolvedSetOnlyEdgeMutationProgram(
+  executor: AtomicEdgeMutationProgramExecutor,
+): AtomicEdgeMutationProgramExecutor {
+  function execute(
+    input: AtomicEdgeResolvedMutationSetInput,
+  ): Promise<AtomicEdgeResolvedMutationSetResult>;
+  function execute(
+    input: AtomicEdgeConvergenceInput,
+  ): Promise<readonly AtomicEdgeConvergenceResult[]>;
+  function execute(
+    input: AtomicEdgeResolvedMutationSetInput | AtomicEdgeConvergenceInput,
+  ):
+    | Promise<AtomicEdgeResolvedMutationSetResult>
+    | Promise<readonly AtomicEdgeConvergenceResult[]> {
+    if (input.kind === "resolved-set") return executor(input);
+    return Promise.reject<readonly AtomicEdgeConvergenceResult[]>(
+      new CompilerInvariantError(
+        "A transaction-session edge mutation profile received durable convergence outside its declared envelope.",
+      ),
+    );
+  }
+
+  return Object.assign(execute, {
+    maxEntries: Object.freeze({
+      resolvedSet: executor.maxEntries.resolvedSet,
+      durableConvergence: 0,
+    }),
+  });
+}
+
 function createTransactionBackend(
   options: CreatePostgresTransactionBackendOptions,
 ): BoundTransactionBackend {
@@ -3265,8 +3307,34 @@ function createTransactionBackend(
   // The wrap is unconditional because the overlap is created inside TypeGraph
   // (the node write pipeline syncs embeddings and fulltext concurrently), not
   // only by user code.
+  const operationExecutionAdapter = createPostgresExecutionAdapter(
+    options.db,
+    options.adapterOptions,
+  );
+  const compiledExecutionAdapter = createPostgresExecutionAdapter(options.db, {
+    ...options.adapterOptions,
+    useTransactionClient: true,
+  });
+  const executeCompiled = compiledExecutionAdapter.executeCompiled;
+  // Preserve the established Drizzle-routed execution surface for ordinary
+  // transaction work. Only a closed atomic program needs the pinned client's
+  // compiled-text seam; changing every statement to that seam would also
+  // bypass driver logging and other Drizzle session behavior merely because
+  // this transaction can execute programs.
   const txExecutionAdapter = createSerialExecutionAdapter(
-    createPostgresExecutionAdapter(options.db, options.adapterOptions),
+    executeCompiled === undefined ?
+      operationExecutionAdapter
+    : { ...operationExecutionAdapter, executeCompiled },
+  );
+  const sessionAtomicBatchAdapter =
+    createSessionAtomicBatchAdapter(txExecutionAdapter);
+  const sessionAtomicSqlProgramExecutor =
+    sessionAtomicBatchAdapter === undefined ? undefined : (
+      createAtomicSqlProgramExecutor(sessionAtomicBatchAdapter)
+    );
+  const sessionCapabilities = scopeAtomicBatchToSession(
+    options.capabilities,
+    sessionAtomicSqlProgramExecutor !== undefined,
   );
 
   // The transaction-scoped backend shares the outer backend's
@@ -3279,10 +3347,13 @@ function createTransactionBackend(
     createPostgresOperationBackend({
       db: options.db,
       executionAdapter: txExecutionAdapter,
+      ...(sessionAtomicSqlProgramExecutor === undefined ?
+        {}
+      : { atomicSqlProgramExecutor: sessionAtomicSqlProgramExecutor }),
       adapterOptions: options.adapterOptions,
       operationStrategy: options.operationStrategy,
       tableNames: options.tableNames,
-      capabilities: downgradeRootAtomicBatch(options.capabilities),
+      capabilities: sessionCapabilities,
       fulltextStrategy: options.fulltextStrategy,
       vectorStrategy: options.vectorStrategy,
       contributionMaterializer: options.contributionMaterializer,
@@ -3293,6 +3364,17 @@ function createTransactionBackend(
       transactionScoped: true,
     }),
   );
+
+  if (sessionAtomicBatchAdapter !== undefined) {
+    registerAtomicSqlProgram(backend, sessionAtomicBatchAdapter);
+    const mutateEdges = requireDefined(
+      backend.executeAtomicEdgeMutationProgram,
+    );
+    registerAtomicMutationPrograms(backend, {
+      mutateNodes: requireDefined(backend.executeAtomicNodeResolvedMutationSet),
+      mutateEdges: resolvedSetOnlyEdgeMutationProgram(mutateEdges),
+    });
+  }
 
   return { backend, drainAndClose: txExecutionAdapter.drainAndClose };
 }

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -3322,12 +3322,13 @@ function createTransactionBackend(
   // bypass driver logging and other Drizzle session behavior merely because
   // this transaction can execute programs.
   const txExecutionAdapter = createSerialExecutionAdapter(
-    executeCompiled === undefined ?
-      operationExecutionAdapter
-    : { ...operationExecutionAdapter, executeCompiled },
+    operationExecutionAdapter,
   );
+  const runExclusive = txExecutionAdapter.runExclusive;
   const sessionAtomicBatchAdapter =
-    createSessionAtomicBatchAdapter(txExecutionAdapter);
+    executeCompiled === undefined ? undefined : (
+      createSessionAtomicBatchAdapter({ executeCompiled, runExclusive })
+    );
   const sessionAtomicSqlProgramExecutor =
     sessionAtomicBatchAdapter === undefined ? undefined : (
       createAtomicSqlProgramExecutor(sessionAtomicBatchAdapter)

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -74,7 +74,7 @@ import {
   assertBundledCapabilityDeclarations,
   assertNoLegacyTransactionCapability,
 } from "../capabilities/declarations";
-import { downgradeRootAtomicBatch } from "../capabilities/execution";
+import { downgradeAtomicBatch } from "../capabilities/execution";
 import { markSchemaFencedInsertEligible } from "../capabilities/schema-fenced-insert";
 import { markFirstPartyFactory } from "../capabilities/write-fence";
 import { FIND_EDGES_ENDPOINT_FIXED_PARAM_COUNT } from "../edge-endpoint-sets";
@@ -2672,7 +2672,7 @@ function createTransactionBackend(
   // confirmed once stays a pure `Set.has` inside every later transaction.
   return markFirstPartyFactory(
     createSqliteOperationBackend({
-      capabilities: downgradeRootAtomicBatch(options.capabilities),
+      capabilities: downgradeAtomicBatch(options.capabilities),
       db: options.db,
       executionAdapter: txExecutionAdapter,
       operationStrategy: options.operationStrategy,

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -291,8 +291,12 @@ export type BackendCapabilities = Readonly<{
   execution: Readonly<{
     /** Whether the backend can hold an interactive callback/session transaction. */
     interactiveTransactions: boolean;
-    /** Whether the exact root backend exposes a conformance-earned atomic batch. */
-    atomicBatch: "none" | "root";
+    /**
+     * Where this exact backend object can execute a conformance-earned atomic
+     * batch. `root` owns the transaction boundary; `session` is already bound
+     * to the transaction that makes a closed statement sequence atomic.
+     */
+    atomicBatch: "none" | "root" | "session";
   }>;
   /** Whether the backend supports SQL window functions such as ROW_NUMBER() */
   windowFunctions: boolean;
@@ -467,6 +471,18 @@ export function supportsRootAtomicBatch(
       backendOrCapabilities.capabilities
     : backendOrCapabilities;
   return capabilities.execution.atomicBatch === "root";
+}
+
+/** Returns whether this exact object owns any certified atomic batch session. */
+export function supportsAtomicBatch(
+  backendOrCapabilities:
+    BackendCapabilities | Readonly<{ capabilities: BackendCapabilities }>,
+): boolean {
+  const capabilities =
+    "capabilities" in backendOrCapabilities ?
+      backendOrCapabilities.capabilities
+    : backendOrCapabilities;
+  return capabilities.execution.atomicBatch !== "none";
 }
 
 // ============================================================

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -20,6 +20,7 @@ import {
   type NodeUpsertUpdateBatchEntry,
   type UpsertUpdateNodeInput,
 } from "./collections/node-collection";
+import type { ResolvedMutationSetAttempt } from "./resolved-mutation-set";
 import { type EdgeRow, type NodeRow } from "./row-mappers";
 import {
   type CreateEdgeInput,
@@ -81,7 +82,9 @@ export type NodeOperations = Readonly<{
     updates: readonly NodeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
   ) => Promise<
-    Readonly<{ created: readonly Node[]; updated: readonly Node[] }> | undefined
+    ResolvedMutationSetAttempt<
+      Readonly<{ created: readonly Node[]; updated: readonly Node[] }>
+    >
   >;
   /**
    * Coalesce dirty-check for `upsertById` / `bulkUpsertById`. Present only when
@@ -190,7 +193,9 @@ export type EdgeOperations = Readonly<{
     updates: readonly EdgeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
   ) => Promise<
-    Readonly<{ created: readonly Edge[]; updated: readonly Edge[] }> | undefined
+    ResolvedMutationSetAttempt<
+      Readonly<{ created: readonly Edge[]; updated: readonly Edge[] }>
+    >
   >;
   /**
    * Coalesce dirty-check for `bulkUpsertById` (props only — endpoints are the

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -35,7 +35,10 @@ import {
   type EdgeIdentityExpectation,
   edgeIdentityFromRow,
 } from "../operations/edge-identity";
-import { runResolvedMutationSetConverging } from "../resolved-mutation-set";
+import {
+  type ResolvedMutationSetAttempt,
+  runResolvedMutationSetConverging,
+} from "../resolved-mutation-set";
 import { type EdgeRow } from "../row-mappers";
 import {
   type CreateEdgeInput,
@@ -129,7 +132,9 @@ export type EdgeCollectionConfig = Readonly<{
     updates: readonly EdgeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
   ) => Promise<
-    Readonly<{ created: readonly Edge[]; updated: readonly Edge[] }> | undefined
+    ResolvedMutationSetAttempt<
+      Readonly<{ created: readonly Edge[]; updated: readonly Edge[] }>
+    >
   >;
   /** See EdgeOperations.upsertDirtyCheck. */
   upsertDirtyCheck?: UpsertDirtyCheckFunction;
@@ -1047,12 +1052,12 @@ export function createEdgeCollection<
           clearDeleted: entry.clearDeleted,
           ...(entry.existing === undefined ? {} : { existing: entry.existing }),
         }));
-        const mutationSet = await executeEdgeResolvedMutationSet(
+        const mutationAttempt = await executeEdgeResolvedMutationSet(
           createInputs,
           updateEntries,
           target,
         );
-        if (mutationSet === undefined) {
+        if (mutationAttempt.outcome === "unsupported") {
           if (toCreate.length > 0) {
             const created = await executeEdgeCreateBatch(createInputs, target);
             for (const [index, entry] of toCreate.entries()) {
@@ -1073,6 +1078,7 @@ export function createEdgeCollection<
             }
           }
         } else {
+          const mutationSet = mutationAttempt.value;
           for (const [index, entry] of toCreate.entries()) {
             results[entry.index] = narrowEdge<E>(
               requireDefined(mutationSet.created[index]),

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -33,7 +33,10 @@ import {
 import { nowIso } from "../../utils/date";
 import { requireDefined } from "../../utils/presence";
 import { getNodeRowsByIds } from "../node-fetch";
-import { runResolvedMutationSetConverging } from "../resolved-mutation-set";
+import {
+  type ResolvedMutationSetAttempt,
+  runResolvedMutationSetConverging,
+} from "../resolved-mutation-set";
 import { type NodeRow } from "../row-mappers";
 import {
   type CreateNodeInput,
@@ -220,7 +223,9 @@ export type NodeCollectionConfig = Readonly<{
     updates: readonly NodeUpsertUpdateBatchEntry[],
     backend: GraphBackend | TransactionBackend,
   ) => Promise<
-    Readonly<{ created: readonly Node[]; updated: readonly Node[] }> | undefined
+    ResolvedMutationSetAttempt<
+      Readonly<{ created: readonly Node[]; updated: readonly Node[] }>
+    >
   >;
   /** See NodeOperations.upsertDirtyCheck. */
   upsertDirtyCheck?: UpsertDirtyCheckFunction;
@@ -970,12 +975,12 @@ export function createNodeCollection<
           clearDeleted: entry.clearDeleted,
           ...(entry.existing === undefined ? {} : { existing: entry.existing }),
         }));
-        const mutationSet = await executeNodeResolvedMutationSet(
+        const mutationAttempt = await executeNodeResolvedMutationSet(
           createInputs,
           updateEntries,
           target,
         );
-        if (mutationSet === undefined) {
+        if (mutationAttempt.outcome === "unsupported") {
           if (toCreate.length > 0) {
             const created = await executeNodeCreateBatch(createInputs, target);
             for (const [index, entry] of toCreate.entries()) {
@@ -996,6 +1001,7 @@ export function createNodeCollection<
             }
           }
         } else {
+          const mutationSet = mutationAttempt.value;
           for (const [index, entry] of toCreate.entries()) {
             results[entry.index] = narrowNode<N>(
               requireDefined(mutationSet.created[index]),

--- a/packages/typegraph/src/store/operations/atomic-mutation-program.ts
+++ b/packages/typegraph/src/store/operations/atomic-mutation-program.ts
@@ -18,7 +18,7 @@ import {
 } from "../../backend/capabilities/atomic-mutation-program";
 import {
   type GraphBackend,
-  supportsRootAtomicBatch,
+  supportsAtomicBatch,
   type TransactionBackend,
 } from "../../backend/types";
 import type { GraphDef } from "../../core/define-graph";
@@ -39,7 +39,7 @@ type CommonAtomicMutationEligibility = Readonly<{
 }>;
 
 function resolveAtomicMutationProfile(input: CommonAtomicMutationEligibility) {
-  if (!supportsRootAtomicBatch(input.backend)) return;
+  if (!supportsAtomicBatch(input.backend)) return;
   if (input.schemaVersion === undefined) return;
   if (input.historyEnabled || input.revisionTrackingEnabled) return;
   return resolveAtomicMutationPrograms(input.backend);

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -2405,6 +2405,10 @@ export async function executeEdgeResolvedMutationSet<G extends GraphDef>(
     return unsupportedResolvedMutationSet();
   }
 
+  // The eligibility owner above excludes every edge kind that can owe a
+  // cardinality claim. Preparation normalizes that proven shape; a claim here
+  // is contradictory evidence between the classifier and claim planner, not a
+  // late unsupported verdict that may silently enter another execution path.
   const preparation = await prepareAtomicEdgeBatchCreates(
     ctx,
     creates,

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -173,7 +173,12 @@ import {
   resolveEdgeMatchIdentityStorage,
 } from "../edge-match-key";
 import { type GraphWriteLock } from "../recorded-capture/clock";
-import { ResolvedMutationSetMoved } from "../resolved-mutation-set";
+import {
+  appliedResolvedMutationSet,
+  type ResolvedMutationSetAttempt,
+  ResolvedMutationSetMoved,
+  unsupportedResolvedMutationSet,
+} from "../resolved-mutation-set";
 import { type EdgeRow, rowToEdge } from "../row-mappers";
 import {
   type CreateEdgeInput,
@@ -2361,9 +2366,13 @@ export async function executeEdgeResolvedMutationSet<G extends GraphDef>(
   updates: readonly EdgeUpsertUpdateBatchEntry[],
   backend: GraphBackend | TransactionBackend,
 ): Promise<
-  Readonly<{ created: readonly Edge[]; updated: readonly Edge[] }> | undefined
+  ResolvedMutationSetAttempt<
+    Readonly<{ created: readonly Edge[]; updated: readonly Edge[] }>
+  >
 > {
-  if (creates.length === 0 || updates.length === 0) return;
+  if (creates.length === 0 || updates.length === 0) {
+    return unsupportedResolvedMutationSet();
+  }
   const firstUpdate = requireDefined(updates[0]);
   const executor = resolveAtomicEdgeResolvedMutationSetExecutor({
     backend,
@@ -2375,12 +2384,14 @@ export async function executeEdgeResolvedMutationSet<G extends GraphDef>(
     creates,
     updateCount: updates.length,
   });
-  if (executor === undefined) return;
+  if (executor === undefined) return unsupportedResolvedMutationSet();
   const ids = new Set([
     ...creates.map((input) => requireDefined(input.id)),
     ...updates.map((entry) => entry.input.id),
   ]);
-  if (ids.size !== creates.length + updates.length) return;
+  if (ids.size !== creates.length + updates.length) {
+    return unsupportedResolvedMutationSet();
+  }
   if (
     updates.some(
       (entry) =>
@@ -2391,7 +2402,7 @@ export async function executeEdgeResolvedMutationSet<G extends GraphDef>(
         entry.input.clearValidTo === true,
     )
   ) {
-    return;
+    return unsupportedResolvedMutationSet();
   }
 
   const preparation = await prepareAtomicEdgeBatchCreates(
@@ -2399,7 +2410,11 @@ export async function executeEdgeResolvedMutationSet<G extends GraphDef>(
     creates,
     backend,
   );
-  if (preparation.claims.length > 0) return;
+  if (preparation.claims.length > 0) {
+    throw new CompilerInvariantError(
+      "An eligible resolved edge mutation set produced unsupported cardinality claims.",
+    );
+  }
   const createParams = preparation.preparedCreates.map(
     (prepared) => prepared.insertParams,
   );
@@ -2456,14 +2471,14 @@ export async function executeEdgeResolvedMutationSet<G extends GraphDef>(
   memoizeLeasedSchemaFence(ctx, backend);
   const createdById = new Map(result.created.map((row) => [row.id, row]));
   const updatedById = new Map(result.updated.map((row) => [row.id, row]));
-  return {
+  return appliedResolvedMutationSet({
     created: creates.map((input) =>
       rowToEdge(requireDefined(createdById.get(requireDefined(input.id)))),
     ),
     updated: updates.map((entry) =>
       rowToEdge(requireDefined(updatedById.get(entry.input.id))),
     ),
-  };
+  });
 }
 
 export async function executeEdgeUpsertUpdateBatch<G extends GraphDef>(

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -2930,6 +2930,10 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
     return unsupportedResolvedMutationSet();
   }
 
+  // The eligibility owner above excludes every node kind whose create planner
+  // can emit claims. Preparation is allowed to normalize that proven shape,
+  // not to reopen eligibility after the operation has committed to this
+  // executor. A claim here therefore means those two owners drifted.
   const preparedCreates = await prepareAtomicBatchCreates(
     ctx,
     creates,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -167,7 +167,12 @@ import {
 } from "../fulltext-sync";
 import { getNodeRowsByIds } from "../node-fetch";
 import { type GraphWriteLock } from "../recorded-capture/clock";
-import { ResolvedMutationSetMoved } from "../resolved-mutation-set";
+import {
+  appliedResolvedMutationSet,
+  type ResolvedMutationSetAttempt,
+  ResolvedMutationSetMoved,
+  unsupportedResolvedMutationSet,
+} from "../resolved-mutation-set";
 import { type NodeRow, rowToNode } from "../row-mappers";
 import {
   type BulkOperationHookContext,
@@ -2884,9 +2889,13 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
   updates: readonly NodeUpsertUpdateBatchEntry[],
   backend: GraphBackend | TransactionBackend,
 ): Promise<
-  Readonly<{ created: readonly Node[]; updated: readonly Node[] }> | undefined
+  ResolvedMutationSetAttempt<
+    Readonly<{ created: readonly Node[]; updated: readonly Node[] }>
+  >
 > {
-  if (creates.length === 0 || updates.length === 0) return;
+  if (creates.length === 0 || updates.length === 0) {
+    return unsupportedResolvedMutationSet();
+  }
   const firstUpdate = requireDefined(updates[0]);
   const executor = resolveAtomicNodeResolvedMutationSetExecutor({
     backend,
@@ -2900,12 +2909,14 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
     identityEnabled: ctx.identity !== undefined,
     registry: ctx.registry,
   });
-  if (executor === undefined) return;
+  if (executor === undefined) return unsupportedResolvedMutationSet();
   const ids = new Set([
     ...creates.map((input) => requireDefined(input.id)),
     ...updates.map((entry) => entry.input.id),
   ]);
-  if (ids.size !== creates.length + updates.length) return;
+  if (ids.size !== creates.length + updates.length) {
+    return unsupportedResolvedMutationSet();
+  }
   if (
     updates.some(
       (entry) =>
@@ -2916,7 +2927,7 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
         entry.input.clearValidTo === true,
     )
   ) {
-    return;
+    return unsupportedResolvedMutationSet();
   }
 
   const preparedCreates = await prepareAtomicBatchCreates(
@@ -2925,7 +2936,11 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
     backend,
   );
   const createEntries = atomicNodeBatchEntries(preparedCreates, 0);
-  if (createEntries === undefined) return;
+  if (createEntries === undefined) {
+    throw new CompilerInvariantError(
+      "An eligible resolved node mutation set produced unsupported create claims.",
+    );
+  }
   const resolvedUpdates = updates.map((entry) => {
     const existing = requireDefined(entry.existing);
     const { validatedProps } = resolveNodeUpdateProps(
@@ -2970,12 +2985,12 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
     result.created,
   ).map((row) => rowToNode(row));
   const updatedById = new Map(result.updated.map((row) => [row.id, row]));
-  return {
+  return appliedResolvedMutationSet({
     created,
     updated: updates.map((entry) =>
       rowToNode(requireDefined(updatedById.get(entry.input.id))),
     ),
-  };
+  });
 }
 
 export async function executeNodeUpsertUpdateBatch<G extends GraphDef>(

--- a/packages/typegraph/src/store/resolved-mutation-set.ts
+++ b/packages/typegraph/src/store/resolved-mutation-set.ts
@@ -10,6 +10,29 @@ type ResolvedMutationSetExecutor =
   AtomicNodeResolvedMutationSetExecutor | AtomicEdgeMutationProgramExecutor;
 
 /**
+ * An operation-level atomic attempt. `unsupported` is emitted only before the
+ * operation executor is invoked, so it is affirmative evidence that the
+ * attempt executed no SQL and the caller may enter the complete portable path.
+ */
+export type ResolvedMutationSetAttempt<T> =
+  | Readonly<{ outcome: "applied"; value: T }>
+  | Readonly<{ outcome: "unsupported" }>;
+
+/** Constructs the only successful operation-level attempt verdict. */
+export function appliedResolvedMutationSet<T>(
+  value: T,
+): ResolvedMutationSetAttempt<T> {
+  return { outcome: "applied", value };
+}
+
+/** Constructs the no-SQL fallback verdict. */
+export function unsupportedResolvedMutationSet<
+  T,
+>(): ResolvedMutationSetAttempt<T> {
+  return { outcome: "unsupported" };
+}
+
+/**
  * Internal retry signal for a resolved mutation set whose authoritative
  * preconditions moved before its atomic program ran. The collection owns the
  * create/update partition, so only it can honestly re-read and rebuild the

--- a/packages/typegraph/tests/api-surface-compat.test.ts
+++ b/packages/typegraph/tests/api-surface-compat.test.ts
@@ -20,7 +20,7 @@ export function createFixtureBackend(capabilities: FixtureCapabilities): Fixture
 export type FixtureCapabilities = Readonly<{
     execution: Readonly<{
         interactiveTransactions: boolean;
-        atomicBatch: "none" | "root";
+        atomicBatch: "none" | "root" | "session";
     }>;
     internal?: FixtureInternalOptions;
     mandatory: FixtureMandatoryOptions;

--- a/packages/typegraph/tests/atomic-mutation-program-conformance.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-conformance.test.ts
@@ -86,7 +86,7 @@ function createProfileBackend(
 }
 
 async function dispatchVariant(
-  backend: GraphBackend,
+  backend: GraphBackend | TransactionBackend,
   variant: AtomicMutationProgramVariant,
 ): Promise<void> {
   const profile = resolveAtomicMutationPrograms(backend);
@@ -163,7 +163,7 @@ function completeCases(): readonly UnboundConformanceCase[] {
 
 function bindCase(
   conformanceCase: UnboundConformanceCase,
-  backend: GraphBackend,
+  backend: GraphBackend | TransactionBackend,
 ): AtomicMutationProgramConformanceCase {
   function bind<T extends { execute: () => unknown }>(value: T): T {
     return {
@@ -197,6 +197,37 @@ function fixture(
   interactiveTransactions = false,
 ) {
   const backend = createProfileBackend(registration, interactiveTransactions);
+  return {
+    backend,
+    derivedBackends: [deriveBackend(backend, {})] as const,
+    cases: cases.map((entry) => bindCase(entry, backend)),
+    equal: (actual: unknown, expected: unknown) =>
+      JSON.stringify(actual) === JSON.stringify(expected),
+  } as const;
+}
+
+function sessionFixture() {
+  const backend = markBundledRootAtomicMutationPrograms(
+    {
+      capabilities: {
+        execution: {
+          atomicBatch: "session",
+          interactiveTransactions: true,
+        },
+      },
+    } as TransactionBackend,
+    {
+      mutateNodes: callableWithLimit<AtomicNodeResolvedMutationSetExecutor>(1),
+      mutateEdges: edgeMutationExecutor({
+        durableConvergence: 0,
+        resolvedSet: 1,
+      }),
+    },
+  );
+  const cases = [
+    conformanceCase("mutateNodes"),
+    conformanceCase("mutateEdges.resolvedSet"),
+  ];
   return {
     backend,
     derivedBackends: [deriveBackend(backend, {})] as const,
@@ -295,6 +326,23 @@ describe("atomic mutation program conformance runner", () => {
     );
 
     expect(report.variants.map((entry) => entry.variant)).toEqual(reachable);
+  });
+
+  it("certifies mixed variants registered on an exact transaction session", async () => {
+    const report = await runAtomicMutationProgramConformance(sessionFixture());
+
+    expect(report.variants.map((entry) => entry.variant)).toEqual([
+      "mutateNodes",
+      "mutateEdges.resolvedSet",
+    ]);
+    expect(report.provenance).toEqual({
+      passed: [
+        "exact root registration",
+        "derived backend lineage",
+        "derived backend isolation",
+      ],
+      skipped: ["transaction backend isolation"],
+    });
   });
 
   it("refuses missing, unregistered, and duplicate cases", async () => {

--- a/packages/typegraph/tests/atomic-mutation-program-pglite-routing.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-pglite-routing.test.ts
@@ -176,6 +176,8 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
             expect(transactionBackend.capabilities.execution.atomicBatch).toBe(
               "session",
             );
+            expect("executeRaw" in transactionBackend).toBe(false);
+            expect(Object.hasOwn(transactionBackend, "executeRaw")).toBe(false);
             const sessionProfile = requireDefined(
               resolveAtomicMutationPrograms(transactionBackend),
             );
@@ -186,6 +188,12 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
             expect(
               sessionProfile.mutateEdges?.maxEntries.durableConvergence,
             ).toBe(0);
+            expect(
+              reachableAtomicMutationProgramVariants(
+                sessionProfile,
+                transactionBackend.capabilities.execution,
+              ),
+            ).toEqual(["mutateNodes", "mutateEdges.resolvedSet"]);
             const ordinaryWrapper = deriveBackend(transactionBackend, {});
             expect(ordinaryWrapper.capabilities.execution.atomicBatch).toBe(
               "none",

--- a/packages/typegraph/tests/atomic-mutation-program-pglite-routing.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-pglite-routing.test.ts
@@ -6,10 +6,12 @@ import {
   resolveAtomicMutationPrograms,
   withAtomicMutationProgramDispatchObserver,
 } from "../src/backend/capabilities/atomic-mutation-program";
+import { deriveBackend } from "../src/backend/derive-backend";
 import { createPostgresBackend } from "../src/backend/drizzle/postgres";
 import { createLocalPgliteBackend } from "../src/backend/postgres/pglite";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
-import { createStoreWithSchema } from "../src/store";
+import { EndpointNotFoundError } from "../src/errors";
+import { createStoreWithSchema, createVerifiedStore } from "../src/store";
 import { requireDefined } from "../src/utils/presence";
 
 const Person = defineNode("Person", {
@@ -144,6 +146,156 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
       ).resolves.toMatchObject({ label: "Updated" });
       await expect(
         store.nodes.Person.getById("delete-node" as never),
+      ).resolves.toBeUndefined();
+    } finally {
+      await local.backend.close();
+    }
+  });
+
+  it("rebinds mixed resolved sets to their exact collection transaction", async () => {
+    const local = await createLocalPgliteBackend({ vector: false });
+    const backend = createPostgresBackend(local.db, { vector: false });
+    try {
+      const [seedStore] = await createStoreWithSchema(graph, backend);
+      const [from, to, existingNode] = await seedStore.nodes.Person.bulkCreate([
+        { id: "session-from", props: { name: "From", score: 1 } },
+        { id: "session-to", props: { name: "To", score: 2 } },
+        { id: "session-node", props: { name: "Existing", score: 3 } },
+      ]);
+      const existingEdge = await seedStore.edges.relates.create(
+        requireDefined(from),
+        requireDefined(to),
+        { label: "Existing" },
+        { id: "session-edge" },
+      );
+
+      const dispatched: string[] = [];
+      const observedBackend = deriveBackend(backend, {
+        transaction: (fn, options) =>
+          backend.transaction(async (transactionBackend) => {
+            expect(transactionBackend.capabilities.execution.atomicBatch).toBe(
+              "session",
+            );
+            const sessionProfile = requireDefined(
+              resolveAtomicMutationPrograms(transactionBackend),
+            );
+            expect(Object.keys(sessionProfile)).toEqual([
+              "mutateNodes",
+              "mutateEdges",
+            ]);
+            expect(
+              sessionProfile.mutateEdges?.maxEntries.durableConvergence,
+            ).toBe(0);
+            const ordinaryWrapper = deriveBackend(transactionBackend, {});
+            expect(ordinaryWrapper.capabilities.execution.atomicBatch).toBe(
+              "none",
+            );
+            expect(
+              resolveAtomicMutationPrograms(ordinaryWrapper),
+            ).toBeUndefined();
+            return withAtomicMutationProgramDispatchObserver(
+              transactionBackend,
+              (variant) => {
+                dispatched.push(variant);
+              },
+              () => fn(transactionBackend),
+            );
+          }, options),
+      });
+      const [store] = await createVerifiedStore(graph, observedBackend);
+
+      await store.nodes.Person.bulkUpsertById([
+        { id: "session-new-node", props: { name: "New", score: 4 } },
+        {
+          id: requireDefined(existingNode).id,
+          props: { name: "Updated", score: 5 },
+        },
+      ]);
+      await store.edges.relates.bulkUpsertById([
+        {
+          id: existingEdge.id,
+          from: requireDefined(from),
+          to: requireDefined(to),
+          props: { label: "Updated" },
+        },
+        {
+          id: "session-new-edge" as never,
+          from: requireDefined(to),
+          to: requireDefined(from),
+          props: { label: "New" },
+        },
+      ]);
+      expect(dispatched).toEqual(["mutateNodes", "mutateEdges.resolvedSet"]);
+
+      dispatched.length = 0;
+      await store.transaction((tx) =>
+        tx.nodes.Person.bulkUpsertById([
+          {
+            id: "caller-session-new",
+            props: { name: "Caller new", score: 6 },
+          },
+          {
+            id: requireDefined(existingNode).id,
+            props: { name: "Caller updated", score: 7 },
+          },
+        ]),
+      );
+      expect(dispatched).toEqual(["mutateNodes"]);
+
+      dispatched.length = 0;
+      const repeated = await store.nodes.Person.bulkUpsertById([
+        { id: "session-repeated", props: { name: "First", score: 8 } },
+        { id: "session-repeated", props: { name: "Second", score: 9 } },
+      ]);
+      expect(dispatched).toEqual([]);
+      expect(dispatched).not.toContain("mutateNodes");
+      expect(repeated.map((node) => [node.name, node.score])).toEqual([
+        ["First", 8],
+        ["Second", 9],
+      ]);
+    } finally {
+      await local.backend.close();
+    }
+  });
+
+  it("restores the session after a program refusal so diagnosis stays typed", async () => {
+    const local = await createLocalPgliteBackend({ vector: false });
+    const backend = createPostgresBackend(local.db, { vector: false });
+    try {
+      const [store] = await createStoreWithSchema(graph, backend);
+      const [from, to] = await store.nodes.Person.bulkCreate([
+        { id: "refusal-from", props: { name: "From", score: 1 } },
+        { id: "refusal-to", props: { name: "To", score: 2 } },
+      ]);
+      const existing = await store.edges.relates.create(
+        requireDefined(from),
+        requireDefined(to),
+        { label: "Before" },
+        { id: "refusal-existing" },
+      );
+
+      await expect(
+        store.edges.relates.bulkUpsertById([
+          {
+            id: existing.id,
+            from: requireDefined(from),
+            to: requireDefined(to),
+            props: { label: "Must roll back" },
+          },
+          {
+            id: "refusal-new" as never,
+            from: requireDefined(from),
+            to: { kind: Person.kind, id: "missing-endpoint" },
+            props: { label: "Invalid" },
+          },
+        ]),
+      ).rejects.toBeInstanceOf(EndpointNotFoundError);
+
+      await expect(
+        store.edges.relates.getById(existing.id),
+      ).resolves.toMatchObject({ label: "Before" });
+      await expect(
+        store.edges.relates.getById("refusal-new" as never),
       ).resolves.toBeUndefined();
     } finally {
       await local.backend.close();

--- a/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
@@ -61,7 +61,11 @@ function createCustomAtomicRoot(): GraphBackend {
     capabilities: {
       execution: { interactiveTransactions: false, atomicBatch: "root" },
     },
-  } as GraphBackend;
+    commands: {
+      session: "root",
+      execute: () => Promise.reject(new Error("unused command port")),
+    },
+  } as unknown as GraphBackend;
 }
 
 const emptyAtomicBatch: AtomicSqlBatchExecutor = () => Promise.resolve([]);

--- a/packages/typegraph/tests/atomic-sql-program.test.ts
+++ b/packages/typegraph/tests/atomic-sql-program.test.ts
@@ -79,7 +79,11 @@ function createRoot(): GraphBackend {
     capabilities: {
       execution: { atomicBatch: "root" },
     },
-  } as GraphBackend;
+    commands: {
+      session: "root",
+      execute: () => Promise.reject(new Error("unused command port")),
+    },
+  } as unknown as GraphBackend;
 }
 
 function expectRegistrationMismatch(action: () => unknown): void {
@@ -219,6 +223,31 @@ describe("atomic SQL program executor", () => {
     expectRegistrationMismatch(() => registerAtomicSqlProgram(noBatch, {}));
   });
 
+  it("binds root and session declarations to their matching command resource", () => {
+    const transaction = {
+      capabilities: { execution: { atomicBatch: "session" } },
+      commands: {
+        session: "transaction",
+        execute: () => Promise.reject(new Error("unused command port")),
+      },
+    } as unknown as TransactionBackend;
+    expect(() =>
+      registerAtomicSqlProgram(transaction, oneRowBatch),
+    ).not.toThrow();
+    expect(resolveAtomicSqlProgramExecutor(transaction)).toBeDefined();
+
+    const mismatched = {
+      capabilities: { execution: { atomicBatch: "root" } },
+      commands: {
+        session: "transaction",
+        execute: () => Promise.reject(new Error("unused command port")),
+      },
+    } as unknown as GraphBackend;
+    expectRegistrationMismatch(() =>
+      registerAtomicSqlProgram(mismatched, oneRowBatch),
+    );
+  });
+
   it("refuses a malformed adapter instead of recording unusable evidence", () => {
     const malformed = {
       executeAtomicBatch: "not a function",
@@ -253,7 +282,7 @@ describe("atomic SQL program executor", () => {
       registerAtomicSqlProgram(undeclared, oneValueBatch),
     );
     expect(() => registerAtomicSqlProgram(undeclared, oneValueBatch)).toThrow(
-      /atomicBatch: "root"/,
+      /exact-session atomic-batch authority/,
     );
   });
 

--- a/packages/typegraph/tests/atomic-transport-conformance.test.ts
+++ b/packages/typegraph/tests/atomic-transport-conformance.test.ts
@@ -23,7 +23,7 @@ import { deriveBackend } from "../src/backend/derive-backend";
 import { createPostgresBackend } from "../src/backend/drizzle/postgres";
 import { createLocalPgliteBackend } from "../src/backend/postgres/pglite";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
-import type { GraphBackend } from "../src/backend/types";
+import type { GraphBackend, TransactionBackend } from "../src/backend/types";
 import { TypeGraphError } from "../src/errors";
 
 type FakeState = Readonly<{
@@ -62,6 +62,7 @@ function createFixture(
   wrapExecutor?: (
     executeAtomicBatch: AtomicSqlBatchExecutor,
   ) => AtomicSqlBatchExecutor,
+  scope: "root" | "session" = "root",
 ): AtomicTransportConformanceFixture<FakeState> {
   let state: MutableFakeState = { primary: [], sidecar: [] };
   let receivedStatements: readonly CompiledAtomicSqlStatement[] | undefined;
@@ -92,18 +93,23 @@ function createFixture(
     return statements.map(() => [] as readonly TRow[]);
   };
   const executeAtomicBatch = wrapExecutor?.(baseExecutor) ?? baseExecutor;
-  const root = {
-    capabilities: { execution: { atomicBatch: "root" } },
+  const backend = {
+    capabilities: {
+      execution: {
+        atomicBatch: scope,
+        interactiveTransactions: scope === "session",
+      },
+    },
     commands: {
-      session: "root",
+      session: scope === "root" ? "root" : "transaction",
       execute: () => Promise.reject(new Error("unused command port")),
     },
-  } as unknown as GraphBackend;
-  registerAtomicSqlProgram(root, executeAtomicBatch);
+  } as unknown as GraphBackend | TransactionBackend;
+  registerAtomicSqlProgram(backend, executeAtomicBatch);
 
   return {
-    backend: root,
-    derivedBackends: [deriveBackend(root, {})],
+    backend,
+    derivedBackends: [deriveBackend(backend, {})],
     executeAtomicBatch,
     equal,
     orderedResults: {
@@ -149,6 +155,17 @@ describe("atomic transport conformance runner", () => {
       "provenance: derived backend lineage",
       "provenance: derived backend isolation",
     ]);
+    expect(report.skipped).toEqual([
+      "provenance: transaction backend isolation",
+    ]);
+  });
+
+  it("certifies an exact transaction-session transport", async () => {
+    const report = await runAtomicTransportConformance(
+      createFixture(true, undefined, "session"),
+    );
+
+    expect(report.passed).toContain("provenance: exact root registration");
     expect(report.skipped).toEqual([
       "provenance: transaction backend isolation",
     ]);

--- a/packages/typegraph/tests/atomic-transport-conformance.test.ts
+++ b/packages/typegraph/tests/atomic-transport-conformance.test.ts
@@ -94,7 +94,11 @@ function createFixture(
   const executeAtomicBatch = wrapExecutor?.(baseExecutor) ?? baseExecutor;
   const root = {
     capabilities: { execution: { atomicBatch: "root" } },
-  } as GraphBackend;
+    commands: {
+      session: "root",
+      execute: () => Promise.reject(new Error("unused command port")),
+    },
+  } as unknown as GraphBackend;
   registerAtomicSqlProgram(root, executeAtomicBatch);
 
   return {

--- a/packages/typegraph/tests/backend-derivation-inventory.test.ts
+++ b/packages/typegraph/tests/backend-derivation-inventory.test.ts
@@ -56,6 +56,7 @@ const SOURCE_ROOT = path.resolve(
 const SEAM_CONSTRUCTORS = [
   "decorateBackend",
   "deriveBackend",
+  "deriveTransactionSessionBackend",
   "projectBackend",
   "projectBackendWithout",
   "projectGraphBackend",
@@ -103,9 +104,9 @@ const INVENTORY: readonly InventoryEntry[] = [
   },
   {
     file: "backend/drizzle/contribution-materializations.ts",
-    line: "return deriveBackend<TransactionBackend>(",
+    line: "return deriveTransactionSessionBackend<TransactionBackend>(",
     reason:
-      "Gates the fulltext members of a transaction-scoped backend until the graph's contributions are materialized, leaving every other member forwarding.",
+      "Gates the fulltext members of a transaction-scoped backend until the graph's contributions are materialized while preserving the already-open session declaration; the PostgreSQL factory immediately binds fresh exact transport and semantic registrations to the wrapper.",
   },
   {
     file: "backend/drizzle/postgres.ts",

--- a/packages/typegraph/tests/backend-derivation.test.ts
+++ b/packages/typegraph/tests/backend-derivation.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 import { resolveWriteFencePlan } from "../src/backend/capabilities/write-fence";
 import {
   deriveBackend,
+  deriveTransactionSessionBackend,
   projectBackend,
   projectBackendWithout,
   projectGraphBackend,
@@ -32,7 +33,11 @@ import {
   resolveBackendAudit,
   sharesSerializedTransactionResource,
 } from "../src/backend/transaction-resource";
-import { type GraphBackend, SQLITE_CAPABILITIES } from "../src/backend/types";
+import {
+  type GraphBackend,
+  SQLITE_CAPABILITIES,
+  type TransactionBackend,
+} from "../src/backend/types";
 import { createTestBackend, makeUnauditedBackend } from "./test-utils";
 
 type BaseVerdict = "serialized" | "independent" | "unaudited";
@@ -187,6 +192,32 @@ describe("deriveBackend over frozen inputs", () => {
     });
     expect(descriptor).not.toHaveProperty("get");
     expect(descriptor).not.toHaveProperty("set");
+  });
+});
+
+describe("transaction-session derivation", () => {
+  it("preserves only the base session declaration, never a replacement", () => {
+    const base = {
+      capabilities: {
+        ...SQLITE_CAPABILITIES,
+        execution: {
+          ...SQLITE_CAPABILITIES.execution,
+          atomicBatch: "session" as const,
+        },
+      },
+      commands: {
+        session: "transaction" as const,
+        execute: () => Promise.reject(new Error("unused command port")),
+      },
+    } as unknown as TransactionBackend;
+
+    const preserved = deriveTransactionSessionBackend(base, {});
+    const replaced = deriveTransactionSessionBackend(base, {
+      capabilities: base.capabilities,
+    });
+
+    expect(preserved.capabilities.execution.atomicBatch).toBe("session");
+    expect(replaced.capabilities.execution.atomicBatch).toBe("none");
   });
 });
 

--- a/packages/typegraph/tests/drizzle-claim-sites.test.ts
+++ b/packages/typegraph/tests/drizzle-claim-sites.test.ts
@@ -41,13 +41,13 @@ const RECORDED_CLAIM_SITES: readonly RecordedClaimSite[] = [
   },
   {
     file: "apps/docs/src/content/docs/architecture.md",
-    line: 669,
+    line: 673,
     text:
       "graph DSL and its schema-derived types from the " + CLAIM_WORD + "-free",
   },
   {
     file: "apps/docs/src/content/docs/architecture.md",
-    line: 671,
+    line: 675,
     text:
       "import the full " +
       CLAIM_WORD +

--- a/packages/typegraph/tests/session-atomic-batch.test.ts
+++ b/packages/typegraph/tests/session-atomic-batch.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import { createSessionAtomicBatchAdapter } from "../src/backend/drizzle/execution/session-atomic-batch";
 import type { SqlExecutionAdapter } from "../src/backend/drizzle/execution/types";
 import { CompilerInvariantError } from "../src/errors";
-import { requireDefined } from "../src/utils/presence";
 
 function createSessionAdapter(
   executeCompiled: NonNullable<SqlExecutionAdapter["executeCompiled"]>,
@@ -40,9 +39,7 @@ describe("transaction-session atomic batches", () => {
       ] as unknown as readonly TRow[]);
     };
     const { execution, exclusiveCalls } = createSessionAdapter(executeCompiled);
-    const batch = requireDefined(
-      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
-    );
+    const batch = createSessionAtomicBatchAdapter(execution).executeAtomicBatch;
 
     const result = await batch<{ sql: string }>([
       { sql: "SELECT first", params: [] },
@@ -73,9 +70,7 @@ describe("transaction-session atomic batches", () => {
       return Promise.resolve([] as readonly TRow[]);
     };
     const { execution } = createSessionAdapter(executeCompiled);
-    const batch = requireDefined(
-      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
-    );
+    const batch = createSessionAtomicBatchAdapter(execution).executeAtomicBatch;
 
     await expect(batch([{ sql: "BROKEN", params: [] }])).rejects.toBe(refusal);
     expect(statements).toEqual([
@@ -103,9 +98,7 @@ describe("transaction-session atomic batches", () => {
       return Promise.resolve([] as readonly TRow[]);
     };
     const { execution } = createSessionAdapter(executeCompiled);
-    const batch = requireDefined(
-      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
-    );
+    const batch = createSessionAtomicBatchAdapter(execution).executeAtomicBatch;
 
     const failure = await batch([{ sql: "BROKEN", params: [] }]).catch(
       (error: unknown) => error,
@@ -128,9 +121,7 @@ describe("transaction-session atomic batches", () => {
   it("returns an empty program without opening a savepoint or queue slot", async () => {
     const executeCompiled = vi.fn().mockResolvedValue([]);
     const { execution, exclusiveCalls } = createSessionAdapter(executeCompiled);
-    const batch = requireDefined(
-      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
-    );
+    const batch = createSessionAtomicBatchAdapter(execution).executeAtomicBatch;
 
     await expect(batch([])).resolves.toEqual([]);
     expect(exclusiveCalls()).toBe(0);

--- a/packages/typegraph/tests/session-atomic-batch.test.ts
+++ b/packages/typegraph/tests/session-atomic-batch.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createSessionAtomicBatchAdapter } from "../src/backend/drizzle/execution/session-atomic-batch";
+import type { SqlExecutionAdapter } from "../src/backend/drizzle/execution/types";
+import { CompilerInvariantError } from "../src/errors";
+import { requireDefined } from "../src/utils/presence";
+
+function createSessionAdapter(
+  executeCompiled: NonNullable<SqlExecutionAdapter["executeCompiled"]>,
+) {
+  const connection = {
+    compile: vi.fn(),
+    execute: vi.fn(),
+    executeCompiled,
+  } as unknown as SqlExecutionAdapter;
+  let exclusiveCalls = 0;
+  const runExclusive: NonNullable<SqlExecutionAdapter["runExclusive"]> = async <
+    T,
+  >(
+    critical: (adapter: SqlExecutionAdapter) => Promise<T>,
+  ) => {
+    exclusiveCalls += 1;
+    return critical(connection);
+  };
+  const adapter = {
+    ...connection,
+    runExclusive,
+  } satisfies SqlExecutionAdapter;
+  return { adapter, exclusiveCalls: () => exclusiveCalls };
+}
+
+describe("transaction-session atomic batches", () => {
+  it("holds one exclusive window around the savepoint and ordered program", async () => {
+    const statements: string[] = [];
+    const executeCompiled: NonNullable<
+      SqlExecutionAdapter["executeCompiled"]
+    > = <TRow>(statement: Readonly<{ sql: string }>) => {
+      statements.push(statement.sql);
+      return Promise.resolve([
+        { sql: statement.sql },
+      ] as unknown as readonly TRow[]);
+    };
+    const { adapter, exclusiveCalls } = createSessionAdapter(executeCompiled);
+    const batch = requireDefined(
+      createSessionAtomicBatchAdapter(adapter)?.executeAtomicBatch,
+    );
+
+    const result = await batch<{ sql: string }>([
+      { sql: "SELECT first", params: [] },
+      { sql: "SELECT second", params: [] },
+    ]);
+
+    expect(exclusiveCalls()).toBe(1);
+    expect(statements).toEqual([
+      "SAVEPOINT typegraph_atomic_program",
+      "SELECT first",
+      "SELECT second",
+      "RELEASE SAVEPOINT typegraph_atomic_program",
+    ]);
+    expect(result).toEqual([
+      [{ sql: "SELECT first" }],
+      [{ sql: "SELECT second" }],
+    ]);
+  });
+
+  it("restores a failed program before returning its original refusal", async () => {
+    const refusal = new Error("sentinel refusal");
+    const statements: string[] = [];
+    const executeCompiled: NonNullable<
+      SqlExecutionAdapter["executeCompiled"]
+    > = <TRow>(statement: Readonly<{ sql: string }>) => {
+      statements.push(statement.sql);
+      if (statement.sql === "BROKEN") return Promise.reject(refusal);
+      return Promise.resolve([] as readonly TRow[]);
+    };
+    const { adapter } = createSessionAdapter(executeCompiled);
+    const batch = requireDefined(
+      createSessionAtomicBatchAdapter(adapter)?.executeAtomicBatch,
+    );
+
+    await expect(batch([{ sql: "BROKEN", params: [] }])).rejects.toBe(refusal);
+    expect(statements).toEqual([
+      "SAVEPOINT typegraph_atomic_program",
+      "BROKEN",
+      "ROLLBACK TO SAVEPOINT typegraph_atomic_program",
+      "RELEASE SAVEPOINT typegraph_atomic_program",
+    ]);
+  });
+
+  it("reports failed savepoint recovery instead of returning a poisoned session", async () => {
+    const statements: string[] = [];
+    const executeCompiled: NonNullable<
+      SqlExecutionAdapter["executeCompiled"]
+    > = <TRow>(statement: Readonly<{ sql: string }>) => {
+      statements.push(statement.sql);
+      if (statement.sql === "BROKEN") {
+        return Promise.reject(new Error("sentinel refusal"));
+      }
+      if (statement.sql.startsWith("ROLLBACK TO")) {
+        return Promise.reject(new Error("savepoint recovery failed"));
+      }
+      return Promise.resolve([] as readonly TRow[]);
+    };
+    const { adapter } = createSessionAdapter(executeCompiled);
+    const batch = requireDefined(
+      createSessionAtomicBatchAdapter(adapter)?.executeAtomicBatch,
+    );
+
+    await expect(batch([{ sql: "BROKEN", params: [] }])).rejects.toBeInstanceOf(
+      CompilerInvariantError,
+    );
+    expect(statements).toEqual([
+      "SAVEPOINT typegraph_atomic_program",
+      "BROKEN",
+      "ROLLBACK TO SAVEPOINT typegraph_atomic_program",
+    ]);
+  });
+
+  it("refuses adapters that cannot reserve and execute one session", () => {
+    const execute = vi.fn();
+    const base = {
+      compile: vi.fn(),
+      execute,
+    } as unknown as SqlExecutionAdapter;
+
+    expect(createSessionAtomicBatchAdapter(base)).toBeUndefined();
+    expect(
+      createSessionAtomicBatchAdapter({
+        ...base,
+        runExclusive: (critical) => critical(base),
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/typegraph/tests/session-atomic-batch.test.ts
+++ b/packages/typegraph/tests/session-atomic-batch.test.ts
@@ -22,11 +22,10 @@ function createSessionAdapter(
     exclusiveCalls += 1;
     return critical(connection);
   };
-  const adapter = {
-    ...connection,
-    runExclusive,
-  } satisfies SqlExecutionAdapter;
-  return { adapter, exclusiveCalls: () => exclusiveCalls };
+  return {
+    execution: { executeCompiled, runExclusive },
+    exclusiveCalls: () => exclusiveCalls,
+  };
 }
 
 describe("transaction-session atomic batches", () => {
@@ -40,9 +39,9 @@ describe("transaction-session atomic batches", () => {
         { sql: statement.sql },
       ] as unknown as readonly TRow[]);
     };
-    const { adapter, exclusiveCalls } = createSessionAdapter(executeCompiled);
+    const { execution, exclusiveCalls } = createSessionAdapter(executeCompiled);
     const batch = requireDefined(
-      createSessionAtomicBatchAdapter(adapter)?.executeAtomicBatch,
+      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
     );
 
     const result = await batch<{ sql: string }>([
@@ -73,9 +72,9 @@ describe("transaction-session atomic batches", () => {
       if (statement.sql === "BROKEN") return Promise.reject(refusal);
       return Promise.resolve([] as readonly TRow[]);
     };
-    const { adapter } = createSessionAdapter(executeCompiled);
+    const { execution } = createSessionAdapter(executeCompiled);
     const batch = requireDefined(
-      createSessionAtomicBatchAdapter(adapter)?.executeAtomicBatch,
+      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
     );
 
     await expect(batch([{ sql: "BROKEN", params: [] }])).rejects.toBe(refusal);
@@ -88,27 +87,37 @@ describe("transaction-session atomic batches", () => {
   });
 
   it("reports failed savepoint recovery instead of returning a poisoned session", async () => {
+    const refusal = new Error("sentinel refusal");
+    const recoveryFailure = new Error("savepoint recovery failed");
     const statements: string[] = [];
     const executeCompiled: NonNullable<
       SqlExecutionAdapter["executeCompiled"]
     > = <TRow>(statement: Readonly<{ sql: string }>) => {
       statements.push(statement.sql);
       if (statement.sql === "BROKEN") {
-        return Promise.reject(new Error("sentinel refusal"));
+        return Promise.reject(refusal);
       }
       if (statement.sql.startsWith("ROLLBACK TO")) {
-        return Promise.reject(new Error("savepoint recovery failed"));
+        return Promise.reject(recoveryFailure);
       }
       return Promise.resolve([] as readonly TRow[]);
     };
-    const { adapter } = createSessionAdapter(executeCompiled);
+    const { execution } = createSessionAdapter(executeCompiled);
     const batch = requireDefined(
-      createSessionAtomicBatchAdapter(adapter)?.executeAtomicBatch,
+      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
     );
 
-    await expect(batch([{ sql: "BROKEN", params: [] }])).rejects.toBeInstanceOf(
-      CompilerInvariantError,
+    const failure = await batch([{ sql: "BROKEN", params: [] }]).catch(
+      (error: unknown) => error,
     );
+    expect(failure).toBeInstanceOf(CompilerInvariantError);
+    const failures = (failure as Error).cause;
+    expect(failures).toBeInstanceOf(AggregateError);
+    expect((failures as AggregateError).cause).toBe(refusal);
+    expect((failures as AggregateError).errors).toEqual([
+      refusal,
+      recoveryFailure,
+    ]);
     expect(statements).toEqual([
       "SAVEPOINT typegraph_atomic_program",
       "BROKEN",
@@ -116,19 +125,15 @@ describe("transaction-session atomic batches", () => {
     ]);
   });
 
-  it("refuses adapters that cannot reserve and execute one session", () => {
-    const execute = vi.fn();
-    const base = {
-      compile: vi.fn(),
-      execute,
-    } as unknown as SqlExecutionAdapter;
+  it("returns an empty program without opening a savepoint or queue slot", async () => {
+    const executeCompiled = vi.fn().mockResolvedValue([]);
+    const { execution, exclusiveCalls } = createSessionAdapter(executeCompiled);
+    const batch = requireDefined(
+      createSessionAtomicBatchAdapter(execution)?.executeAtomicBatch,
+    );
 
-    expect(createSessionAtomicBatchAdapter(base)).toBeUndefined();
-    expect(
-      createSessionAtomicBatchAdapter({
-        ...base,
-        runExclusive: (critical) => critical(base),
-      }),
-    ).toBeUndefined();
+    await expect(batch([])).resolves.toEqual([]);
+    expect(exclusiveCalls()).toBe(0);
+    expect(executeCompiled).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This extends the atomic mutation boundary from certified autocommit roots to exact PostgreSQL transaction sessions. Eligible mixed node and edge `bulkUpsertById()` sets now reuse the reviewed resolved-set programs inside the transaction that already owns their authoritative preimage, eliminating the portable per-family and per-member write-plan fan-out while preserving whole-call rollback.

## Architecture

`capabilities.execution.atomicBatch` now distinguishes `root` from `session`. Both declarations require identity-bound transport and semantic registrations; generic derivation and projection remove the evidence, while the one audited fulltext transaction wrapper re-registers the same pinned session explicitly. PostgreSQL session programs reserve one serialized execution window and use a savepoint so deliberate constraint refusals can be rolled back and translated without poisoning a caller-owned transaction. Ordinary transaction reads remain on the established Drizzle execution surface: the pinned client's compiled-text seam is private to the closed atomic-program adapter and does not synthesize `executeRaw` or transaction-scoped prepared-statement reuse. If savepoint recovery itself fails, the resulting invariant retains both the original database refusal and the recovery failure. PostgreSQL 18 verification also confirms that protocol-named and SQL-level prepared statements survive `ROLLBACK TO SAVEPOINT`.

The operation boundary now returns an explicit `applied | unsupported` verdict. `unsupported` can only be produced before executor dispatch and therefore proves that no program SQL ran; the collection then re-enters the complete portable path. Once preparation or execution begins, unsupported states are compiler invariants rather than silent fallback.

## Scope and performance

Session authority is intentionally limited to mixed node mutation and resolved edge mutation. Exact session resources and those two semantic variants now participate in the same executable transport and mutation-program conformance contracts as root programs; inapplicable nested-transaction provenance checks are reported as skipped rather than passed. Existing root routing, durable edge convergence, singleton and update-only families, statement ordering, ordinary Drizzle execution, and unsupported shapes retain their prior paths. Within the supported bind ceiling, the transaction-session program uses a bounded number of pinned-session statements independent of batch size; it is not described as a single network exchange. Empty programs return without opening a serialization or savepoint window.

## Compatibility

The public execution capability union adds `"session"` and the release is covered by a minor Changeset. Backend setup, architecture, limitations, and performance documentation describe the exact-resource contract, executable session conformance, and fallback behavior.
